### PR TITLE
Simplify T1 session: shared store + getsid(0) anchor

### DIFF
--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -10,14 +10,15 @@ _COLLECTION = "scratch"
 
 
 class T1Database:
-    """T1 in-memory ChromaDB session scratch.
+    """T1 ChromaDB session scratch.
 
-    Uses ``chromadb.EphemeralClient`` + ``DefaultEmbeddingFunction``
+    Uses a single shared ``chromadb.PersistentClient`` + ``DefaultEmbeddingFunction``
     (all-MiniLM-L6-v2, local ONNX — no API calls).
 
-    Each document stores ``session_id`` in its metadata so that, when T1 is
-    hosted in the long-running ``nx serve`` process and shared across sessions,
-    per-session filtering still works correctly.
+    All sessions share one PersistentClient directory. Per-session isolation is
+    provided by ``session_id`` metadata filtering in ``list_entries``, ``clear``,
+    and ``flagged_entries``. This avoids per-session directory proliferation and
+    allows ``SessionEnd`` to recover orphaned entries from crashed sessions.
     """
 
     def __init__(self, session_id: str) -> None:
@@ -25,11 +26,7 @@ class T1Database:
         from pathlib import Path
 
         self._session_id = session_id
-        # Use a PersistentClient keyed by session_id so data survives across
-        # separate CLI invocations within the same session (e.g., multiple
-        # `uv run nx scratch …` calls from the same terminal).  The directory
-        # is cleaned up by the SessionEnd hook or `nx scratch clear`.
-        scratch_dir = Path.home() / ".config" / "nexus" / "scratch" / session_id
+        scratch_dir = Path.home() / ".config" / "nexus" / "scratch"
         scratch_dir.mkdir(parents=True, exist_ok=True)
         self._client = chromadb.PersistentClient(path=str(scratch_dir))
         self._col = self._client.get_or_create_collection(_COLLECTION)

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -3,7 +3,6 @@
 """SessionStart and SessionEnd hook logic for Claude Code integration."""
 from __future__ import annotations
 
-import os
 import subprocess
 from pathlib import Path
 
@@ -43,16 +42,15 @@ def _infer_repo() -> str:
 def session_start() -> str:
     """Execute the SessionStart hook.
 
-    1. Generate UUID4 session ID and write to PID-scoped session file.
+    1. Generate UUID4 session ID and write to getsid(0)-scoped session file.
     2. Detect PM project via T2 query.
     3. If PM: inject CONTINUATION.md (≤2000 chars).
        Else: print recent memory summary (≤10 entries × 500 chars).
 
     Returns the output string to be printed.
     """
-    ppid = os.getppid()
     session_id = generate_session_id()
-    write_session_file(session_id, ppid=ppid)
+    write_session_file(session_id)
 
     lines: list[str] = [f"Nexus ready. T1 scratch initialized (session: {session_id})."]
 
@@ -85,12 +83,11 @@ def session_end() -> str:
     1. Flush flagged T1 entries to T2.
     2. Clear T1 session entries.
     3. Run T2 expire.
-    4. Remove the PID-scoped session file.
+    4. Remove the session file.
 
     Returns a summary string.
     """
-    ppid = os.getppid()
-    session_file = session_file_path(ppid)
+    session_file = session_file_path()
 
     # Read session ID so we can open T1
     try:
@@ -116,7 +113,7 @@ def session_end() -> str:
 
     expired = db.expire()
 
-    # Remove session file (clean up orphan)
+    # Remove session file
     try:
         session_file.unlink()
     except FileNotFoundError:

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -14,20 +14,12 @@ def _stable_pid() -> int:
 
     Lookup order:
     1. ``NX_SESSION_PID`` env var — allows callers to pin a specific PID.
-    2. PPID (``os.getppid()``) — used only when a ppid-scoped session file
-       already exists (i.e. a Claude Code SessionStart hook wrote it).
-    3. Process session leader (``os.getsid(0)``) — stable across all commands
-       in the same interactive terminal session; the correct anchor when
-       running ``nx`` directly from the CLI outside of Claude Code.
+    2. Process session leader (``os.getsid(0)``) — stable across all commands
+       in the same interactive terminal session, whether invoked from the
+       SessionStart hook or directly from the CLI.
     """
     if env_pid := os.environ.get("NX_SESSION_PID"):
         return int(env_pid)
-    ppid = os.getppid()
-    ppid_file = (
-        Path.home() / ".config" / "nexus" / "sessions" / f"{ppid}.session"
-    )
-    if ppid_file.exists():
-        return ppid
     return os.getsid(0)
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,5 @@
 """AC1–AC7: nx install/uninstall claude-code, hooks, doctor."""
 import json
-import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -84,15 +83,14 @@ def test_install_merges_existing_settings(runner: CliRunner, fake_home: Path) ->
 # ── AC2: SessionStart — UUID4 session ID ──────────────────────────────────────
 
 def test_session_start_writes_session_file(runner: CliRunner, fake_home: Path) -> None:
-    """nx hook session-start writes UUID4 session ID to the session file."""
-    with patch("nexus.hooks.os.getppid", return_value=12345):
+    """nx hook session-start writes UUID4 session ID to the getsid-scoped session file."""
+    with patch("nexus.session.os.getsid", return_value=12345):
         result = runner.invoke(main, ["hook", "session-start"])
     assert result.exit_code == 0, result.output
 
     session_file = fake_home / ".config" / "nexus" / "sessions" / "12345.session"
     assert session_file.exists()
     session_id = session_file.read_text().strip()
-    # UUID4 format: 8-4-4-4-12 hex digits
     import re
     assert re.match(
         r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
@@ -102,8 +100,7 @@ def test_session_start_writes_session_file(runner: CliRunner, fake_home: Path) -
 
 def test_session_start_prints_ready_message(runner: CliRunner, fake_home: Path) -> None:
     """nx hook session-start prints 'Nexus ready' with session ID."""
-    with patch("nexus.hooks.os.getppid", return_value=99):
-        result = runner.invoke(main, ["hook", "session-start"])
+    result = runner.invoke(main, ["hook", "session-start"])
     assert "Nexus ready" in result.output
     assert "session" in result.output.lower()
 
@@ -123,8 +120,7 @@ def test_session_start_pm_detection_injects_continuation(
     # Simulate repo name detection
     with patch("nexus.hooks._infer_repo", return_value="myrepo"):
         with patch("nexus.hooks._open_t2", return_value=mock_db):
-            with patch("nexus.hooks.os.getppid", return_value=1):
-                result = runner.invoke(main, ["hook", "session-start"])
+            result = runner.invoke(main, ["hook", "session-start"])
 
     assert "Phase: 3" in result.output or "implement auth" in result.output
 
@@ -143,8 +139,7 @@ def test_session_start_non_pm_outputs_memory_summary(
 
     with patch("nexus.hooks._infer_repo", return_value="myrepo"):
         with patch("nexus.hooks._open_t2", return_value=mock_db):
-            with patch("nexus.hooks.os.getppid", return_value=1):
-                result = runner.invoke(main, ["hook", "session-start"])
+            result = runner.invoke(main, ["hook", "session-start"])
 
     assert "memory" in result.output.lower() or "note.md" in result.output
 
@@ -156,25 +151,25 @@ def test_session_end_flushes_flagged_t1_entries(
 ) -> None:
     """SessionEnd flushes T1 flagged entries to T2."""
     # Create session file so session_end can find the session ID
-    session_file = fake_home / ".config" / "nexus" / "sessions" / "1.session"
-    session_file.parent.mkdir(parents=True, exist_ok=True)
-    session_file.write_text("test-session-id")
+    with patch("nexus.session.os.getsid", return_value=1):
+        session_file = fake_home / ".config" / "nexus" / "sessions" / "1.session"
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text("test-session-id")
 
-    mock_t1 = MagicMock()
-    mock_t1.flagged_entries.return_value = [
-        {
-            "id": "entry-1",
-            "content": "important finding",
-            "tags": "research",
-            "flush_project": "myproject",
-            "flush_title": "finding.md",
-        }
-    ]
-    mock_t2 = MagicMock()
+        mock_t1 = MagicMock()
+        mock_t1.flagged_entries.return_value = [
+            {
+                "id": "entry-1",
+                "content": "important finding",
+                "tags": "research",
+                "flush_project": "myproject",
+                "flush_title": "finding.md",
+            }
+        ]
+        mock_t2 = MagicMock()
 
-    with patch("nexus.hooks._open_t1", return_value=mock_t1):
-        with patch("nexus.hooks._open_t2", return_value=mock_t2):
-            with patch("nexus.hooks.os.getppid", return_value=1):
+        with patch("nexus.hooks._open_t1", return_value=mock_t1):
+            with patch("nexus.hooks._open_t2", return_value=mock_t2):
                 result = runner.invoke(main, ["hook", "session-end"])
 
     assert result.exit_code == 0, result.output
@@ -194,13 +189,13 @@ def test_session_end_clears_t1_and_removes_session_file(
     mock_t1 = MagicMock()
     mock_t1.flagged_entries.return_value = []
 
-    session_file = fake_home / ".config" / "nexus" / "sessions" / "42.session"
-    session_file.parent.mkdir(parents=True, exist_ok=True)
-    session_file.write_text("test-session-id")
+    with patch("nexus.session.os.getsid", return_value=42):
+        session_file = fake_home / ".config" / "nexus" / "sessions" / "42.session"
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text("test-session-id")
 
-    with patch("nexus.hooks._open_t1", return_value=mock_t1):
-        with patch("nexus.hooks._open_t2", return_value=MagicMock()):
-            with patch("nexus.hooks.os.getppid", return_value=42):
+        with patch("nexus.hooks._open_t1", return_value=mock_t1):
+            with patch("nexus.hooks._open_t2", return_value=MagicMock()):
                 result = runner.invoke(main, ["hook", "session-end"])
 
     assert result.exit_code == 0, result.output
@@ -215,8 +210,7 @@ def test_session_end_runs_expire(runner: CliRunner, fake_home: Path) -> None:
 
     with patch("nexus.hooks._open_t1", return_value=MagicMock(flagged_entries=lambda: [])):
         with patch("nexus.hooks._open_t2", return_value=mock_t2):
-            with patch("nexus.hooks.os.getppid", return_value=1):
-                result = runner.invoke(main, ["hook", "session-end"])
+            result = runner.invoke(main, ["hook", "session-end"])
 
     mock_t2.expire.assert_called_once()
 

--- a/tests/test_scratch.py
+++ b/tests/test_scratch.py
@@ -1,4 +1,6 @@
-"""AC2-AC6: T1 EphemeralClient scratch operations."""
+"""AC2-AC6: T1 scratch operations."""
+from pathlib import Path
+
 import pytest
 
 from nexus.db.t1 import T1Database
@@ -8,9 +10,9 @@ _SESSION = "test-session-0000-0000-0000-000000000000"
 
 
 @pytest.fixture
-def t1() -> T1Database:
-    # EphemeralClient shares in-process state; clear our session's docs before
-    # and after each test to ensure isolation.
+def t1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> T1Database:
+    # Redirect HOME so T1 uses a tmp directory, not ~/.config/nexus/scratch.
+    monkeypatch.setenv("HOME", str(tmp_path))
     db = T1Database(session_id=_SESSION)
     db.clear()          # defensive: remove stale docs from previous test
     yield db


### PR DESCRIPTION
## Summary

Two improvements to T1 scratch architecture, identified via deep-analyst + deep-critic analysis:

- **`session.py`**: Remove the fragile ppid-file-exists middle step from `_stable_pid()`. The hook and all CLI commands share the same `getsid(0)` (process session leader), making it the correct single anchor. Eliminates the risk of hook and CLI resolving to different PIDs and creating disconnected sessions. `hooks.py` no longer calls `os.getppid()`.

- **`t1.py`**: Switch from per-session PersistentClient directories (`scratch/{uuid}/`) to a single shared directory (`scratch/`). Per-session directories caused silent orphan accumulation on crash with no GC mechanism. The per-session directory was also redundant — `list_entries()`, `clear()`, and `flagged_entries()` already filter by `session_id` metadata. The shared directory preserves concurrent session safety via those existing filters while allowing `SessionEnd` to recover flagged entries from crashed sessions.

- **Tests**: redirect HOME to tmp_path in t1 fixture for proper isolation; update `test_plugin.py` to patch `nexus.session.os.getsid` instead of `nexus.hooks.os.getppid`.

## Test plan

- [x] 280 tests pass, 3 skipped
- [x] `test_session.py`, `test_scratch.py`, `test_plugin.py` all green