### PR TITLE
Add thorough test coverage for T1 session architecture

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -105,6 +105,35 @@ def test_session_start_prints_ready_message(runner: CliRunner, fake_home: Path) 
     assert "session" in result.output.lower()
 
 
+# ── Behavior 4: hook and CLI use the same getsid(0) anchor ───────────────────
+
+def test_hook_and_cli_use_same_getsid_anchor(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """session_start() and read_session_id() both resolve to the same session file.
+
+    If the SessionStart hook writes the session file using getsid(0)=X as the
+    filename anchor, a CLI command that calls read_session_id() with the same
+    getsid(0)=X must find the same file and recover the same session ID.
+    """
+    from nexus.hooks import session_start
+    from nexus.session import read_session_id
+
+    monkeypatch.delenv("NX_SESSION_PID", raising=False)
+
+    with patch("nexus.session.os.getsid", return_value=98765):
+        with patch("nexus.hooks._open_t2", return_value=MagicMock(get=lambda **kw: None, list_entries=lambda **kw: [])):
+            session_start()
+        recovered = read_session_id()
+
+    assert recovered is not None
+    import re
+    assert re.match(
+        r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+        recovered,
+    ), f"Recovered session ID is not a UUID4: {recovered!r}"
+
+
 # ── AC3: SessionStart PM detection ────────────────────────────────────────────
 
 def test_session_start_pm_detection_injects_continuation(

--- a/tests/test_scratch.py
+++ b/tests/test_scratch.py
@@ -1,5 +1,6 @@
 """AC2-AC6: T1 scratch operations."""
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -165,3 +166,138 @@ def test_scratch_put_persist_explicit_destination(t1: T1Database) -> None:
     assert entry["flagged"] is True
     assert entry["flush_project"] == "p"
     assert entry["flush_title"] == "f.md"
+
+
+# ── Behavior 5: cross-session isolation via metadata ─────────────────────────
+
+_SESSION_B = "test-session-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+@pytest.fixture
+def two_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Two T1Database instances sharing the same scratch directory."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    db_a = T1Database(session_id=_SESSION)
+    db_b = T1Database(session_id=_SESSION_B)
+    db_a.clear()
+    db_b.clear()
+    yield db_a, db_b
+    db_a.clear()
+    db_b.clear()
+
+
+def test_list_entries_scoped_to_session(two_sessions) -> None:
+    """list_entries() returns only entries belonging to its own session."""
+    db_a, db_b = two_sessions
+    db_a.put("session A entry one")
+    db_a.put("session A entry two")
+    db_b.put("session B entry only")
+
+    a_entries = db_a.list_entries()
+    b_entries = db_b.list_entries()
+
+    assert len(a_entries) == 2
+    assert all(e["session_id"] == _SESSION for e in a_entries)
+    assert len(b_entries) == 1
+    assert b_entries[0]["session_id"] == _SESSION_B
+
+
+def test_clear_does_not_delete_other_session_entries(two_sessions) -> None:
+    """clear() removes only this session's entries; another session's entries survive."""
+    db_a, db_b = two_sessions
+    db_a.put("session A entry")
+    db_b.put("session B survives")
+    db_b.put("session B survives too")
+
+    deleted = db_a.clear()
+
+    assert deleted == 1
+    assert db_a.list_entries() == []
+    b_entries = db_b.list_entries()
+    assert len(b_entries) == 2
+
+
+# ── Behavior 6: search is unscoped across sessions ────────────────────────────
+
+def test_search_is_unscoped_across_sessions(two_sessions) -> None:
+    """search() returns entries from ALL sessions, not just the calling session.
+
+    This is intentional design: scratch search is a broad similarity lookup
+    across the shared collection, regardless of which session stored the entry.
+    """
+    db_a, db_b = two_sessions
+    db_a.put("neural network gradient descent training")
+    db_b.put("convolutional neural network image classification")
+
+    # Search from db_a — should surface db_b's entry too
+    results = db_a.search("neural network machine learning", n_results=10)
+    session_ids_in_results = {r["session_id"] for r in results}
+    assert _SESSION in session_ids_in_results
+    assert _SESSION_B in session_ids_in_results
+
+
+# ── Behavior 7: flagged_entries scoped to this session ────────────────────────
+
+def test_flagged_entries_scoped_to_session(two_sessions) -> None:
+    """flagged_entries() only returns flagged entries belonging to this session."""
+    db_a, db_b = two_sessions
+    id_a1 = db_a.put("session A flagged entry")
+    db_a.put("session A unflagged entry")
+    id_b1 = db_b.put("session B flagged entry")
+    db_a.flag(id_a1)
+    db_b.flag(id_b1)
+
+    flagged_a = db_a.flagged_entries()
+    flagged_b = db_b.flagged_entries()
+
+    assert len(flagged_a) == 1
+    assert flagged_a[0]["id"] == id_a1
+    assert len(flagged_b) == 1
+    assert flagged_b[0]["id"] == id_b1
+
+
+# ── Behavior 8: SessionEnd orphan recovery ────────────────────────────────────
+
+def test_session_end_orphan_recovery(two_sessions) -> None:
+    """When session A ends (clear), session B's entries in the shared store survive."""
+    db_a, db_b = two_sessions
+    db_a.put("session A will be cleared")
+    db_b.put("session B orphan survives one")
+    db_b.put("session B orphan survives two")
+
+    # Simulate session A ending: clear its entries
+    db_a.clear()
+
+    # Session B's entries are unaffected
+    b_entries = db_b.list_entries()
+    assert len(b_entries) == 2
+    assert all(e["session_id"] == _SESSION_B for e in b_entries)
+    # Session A has nothing left
+    assert db_a.list_entries() == []
+
+
+# ── Behavior 9: _t1() auto-create session ────────────────────────────────────
+
+def test_t1_auto_create_session_when_no_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_t1() generates a new session ID and writes it when no session file exists.
+
+    A second call within the same process (same getsid anchor) reads the same
+    file and returns a T1Database with the same session_id.
+    """
+    from nexus.commands.scratch import _t1
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("NX_SESSION_PID", raising=False)
+
+    with patch("nexus.session.os.getsid", return_value=12300):
+        first = _t1()
+        second = _t1()
+
+    assert first._session_id == second._session_id
+
+    # The session file must now exist on disk
+    session_file = tmp_path / ".config" / "nexus" / "sessions" / "12300.session"
+    assert session_file.exists()
+    assert session_file.read_text().strip() == first._session_id

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,10 +1,11 @@
 """AC1: Session ID is a valid UUID4, written to and readable from a PID-scoped file."""
 import re
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from nexus.session import generate_session_id, read_session_id, write_session_file
+from nexus.session import _stable_pid, generate_session_id, read_session_id, write_session_file
 
 
 def test_generate_session_id_is_uuid4() -> None:
@@ -40,3 +41,24 @@ def test_session_file_is_pid_scoped(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
     assert read_session_id(ppid=1001) == "session-a"
     assert read_session_id(ppid=1002) == "session-b"
+
+
+# ── Behavior 1: _stable_pid() env var path ────────────────────────────────────
+
+def test_stable_pid_env_var_takes_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When NX_SESSION_PID is set, _stable_pid() returns that value and ignores getsid(0)."""
+    monkeypatch.setenv("NX_SESSION_PID", "77777")
+    with patch("nexus.session.os.getsid", return_value=99999):
+        result = _stable_pid()
+    assert result == 77777
+
+
+# ── Behavior 2: _stable_pid() getsid fallback ────────────────────────────────
+
+def test_stable_pid_falls_back_to_getsid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When NX_SESSION_PID is unset, _stable_pid() returns os.getsid(0)."""
+    monkeypatch.delenv("NX_SESSION_PID", raising=False)
+    with patch("nexus.session.os.getsid", return_value=55555) as mock_getsid:
+        result = _stable_pid()
+    assert result == 55555
+    mock_getsid.assert_called_once_with(0)


### PR DESCRIPTION
## Summary

9 new tests covering all behaviors that were missing or only partially covered after the T1 simplification in #14.

| Behavior | Status |
|----------|--------|
| `_stable_pid()` env var takes precedence | was missing |
| `_stable_pid()` getsid(0) fallback | was partial |
| Hook and CLI use same getsid(0) anchor | was missing |
| `list_entries()` scoped to session (shared store) | was missing |
| `clear()` does not delete other sessions' entries | was missing |
| `search()` intentionally unscoped (documented) | was missing |
| `flagged_entries()` scoped to session | was missing |
| SessionEnd orphan recovery | was missing |
| `_t1()` auto-create session when no file exists | was missing |

All tests use `tmp_path` + `monkeypatch` for full isolation. No real filesystem side effects.

## Test plan

- [x] 289 tests pass, 3 skipped