### PR TITLE
Address all remaining deferred review findings

### DIFF
--- a/src/nexus/commands/serve.py
+++ b/src/nexus/commands/serve.py
@@ -4,6 +4,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import click
@@ -81,6 +82,12 @@ def stop_cmd() -> None:
         click.echo(f"Process {pid} not found (stale PID file). Cleaning up.")
         _pid_path().unlink(missing_ok=True)
         return
+    # Wait up to 5 seconds for the process to exit before reporting success.
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if not _process_running(pid):
+            break
+        time.sleep(0.1)
     _pid_path().unlink(missing_ok=True)
     click.echo(f"Server stopped (PID {pid}).")
 

--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -1,6 +1,27 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 from __future__ import annotations
 
+import re
+
+# ChromaDB collection name constraints:
+# - 3–63 characters
+# - Must start and end with an alphanumeric character
+# - May contain alphanumeric characters, hyphens, or underscores in the middle
+_COLLECTION_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{1,61}[a-zA-Z0-9]$")
+
+
+def validate_collection_name(name: str) -> None:
+    """Raise ValueError if *name* violates ChromaDB collection name constraints."""
+    if not (3 <= len(name) <= 63):
+        raise ValueError(
+            f"Collection name {name!r} must be 3–63 characters (got {len(name)})"
+        )
+    if not _COLLECTION_NAME_RE.match(name):
+        raise ValueError(
+            f"Collection name {name!r} must start and end with an alphanumeric character "
+            "and contain only alphanumeric characters, hyphens, or underscores"
+        )
+
 
 def embedding_model_for_collection(collection_name: str) -> str:
     """Return the Voyage AI model name appropriate for a T3 collection."""

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -58,6 +58,8 @@ class T3Database:
 
     def get_or_create_collection(self, name: str) -> chromadb.Collection:
         """Get or create a T3 collection with the appropriate embedding function."""
+        from nexus.corpus import validate_collection_name
+        validate_collection_name(name)
         return self._client.get_or_create_collection(
             name, embedding_function=self._embedding_fn(name)
         )

--- a/src/nexus/frecency.py
+++ b/src/nexus/frecency.py
@@ -16,7 +16,7 @@ def _git_commit_timestamps(repo: Path, file: Path) -> list[float]:
         cwd=repo,
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=30,
     )
     if result.returncode != 0 or not result.stdout.strip():
         return []

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -48,8 +48,11 @@ def _run_index(repo: Path, registry: "RepoRegistry") -> None:
     # Sort descending by frecency
     scored.sort(key=lambda x: x[0], reverse=True)
 
-    # Update ripgrep cache
-    cache_path = Path.home() / ".config" / "nexus" / f"{repo.name}.cache"
+    # Update ripgrep cache — include path hash to avoid collisions between
+    # repos with the same basename (e.g. two different "myproject/" dirs).
+    import hashlib as _hl
+    _repo_hash = _hl.sha256(str(repo).encode()).hexdigest()[:8]
+    cache_path = Path.home() / ".config" / "nexus" / f"{repo.name}-{_repo_hash}.cache"
     build_cache(repo, cache_path, scored)
 
     # Chunk and index (requires T3 credentials)

--- a/src/nexus/md_chunker.py
+++ b/src/nexus/md_chunker.py
@@ -114,7 +114,12 @@ class SemanticMarkdownChunker:
                     "header_path": [h["text"] for h in header_stack],
                     "content_parts": [],
                 }
-                i += 3  # heading_open, inline, heading_close
+                # Advance past heading_close, searching forward in case
+                # the token stream has unexpected structure (e.g. empty heading).
+                i += 1
+                while i < len(tokens) and tokens[i].type != "heading_close":
+                    i += 1
+                i += 1  # step past heading_close
                 continue
             if current_section is not None:
                 content = self._token_content(token, source_text)

--- a/src/nexus/pdf_extractor.py
+++ b/src/nexus/pdf_extractor.py
@@ -64,8 +64,10 @@ class PDFExtractor:
         with pymupdf.open(pdf_path) as doc:
             page_count = len(doc)
             for page_num in range(page_count):
+                # Pass the open doc object (not the path) to avoid re-opening
+                # the file for every page — O(1) opens instead of O(N_pages).
                 page_md: str = pymupdf4llm.to_markdown(
-                    str(pdf_path),
+                    doc,
                     pages=[page_num],
                     ignore_images=True,
                     force_text=True,
@@ -102,8 +104,14 @@ class PDFExtractor:
         with pymupdf.open(pdf_path) as doc:
             page_count = len(doc)
             for page_num, page in enumerate(doc):
-                page_text: str = page.get_text(sort=True)
-                if page_text.strip():
+                raw: str = page.get_text(sort=True)
+                # Normalize per-page so page_boundaries match character positions
+                # in the final joined text (global normalization after the fact
+                # would shift boundaries unpredictably).
+                page_text = re.sub(r" +", " ", raw)
+                page_text = re.sub(r"\n{3,}", "\n\n", page_text)
+                page_text = "\n".join(line.rstrip() for line in page_text.split("\n")).strip()
+                if page_text:
                     page_boundaries.append(
                         {
                             "page_number": page_num + 1,
@@ -115,9 +123,6 @@ class PDFExtractor:
                     current_pos += len(page_text) + 1
 
         text = "\n".join(text_parts)
-        text = re.sub(r" +", " ", text)
-        text = re.sub(r"\n{3,}", "\n\n", text)
-        text = "\n".join(line.rstrip() for line in text.split("\n"))
 
         return ExtractionResult(
             text=text,

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
-import sys
 from dataclasses import dataclass, field
 from typing import Any, Callable
+
+_log = logging.getLogger(__name__)
 
 _HAIKU_MODEL = "claude-haiku-4-5-20251001"
 _RERANK_MODEL = "rerank-2.5"
@@ -64,10 +66,7 @@ def apply_hybrid_scoring(
     has_code = any(r.collection.startswith("code__") for r in results)
 
     if hybrid and not has_code:
-        print(
-            "Warning: --hybrid has no effect — no code corpus in scope.",
-            file=sys.stderr,
-        )
+        _log.warning("--hybrid has no effect — no code corpus in scope")
 
     distances = [r.distance for r in results]
     frecencies = [
@@ -204,7 +203,7 @@ def fetch_mxbai_results(
     from nexus.config import get_credential
     api_key = get_credential("mxbai_api_key")
     if not api_key:
-        print("Warning: MXBAI_API_KEY not set — skipping Mixedbread fan-out")
+        _log.warning("MXBAI_API_KEY not set — skipping Mixedbread fan-out")
         return []
 
     client = _mxbai_client(api_key)

--- a/src/nexus/server.py
+++ b/src/nexus/server.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Flask server for the Nexus persistent background service."""
 import logging
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -59,6 +60,15 @@ def add_repo():
     path = Path(path_str)
     if not path.exists():
         return jsonify({"error": "path not found"}), 404
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        return jsonify({"error": "path is not a git repository"}), 400
     _get_registry().add(path)
     return jsonify({"added": str(path)}), 201
 

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,5 +1,12 @@
 """AC2/AC6: Embedding model selection and --corpus prefix resolution."""
-from nexus.corpus import embedding_model_for_collection, resolve_corpus, t3_collection_name
+import pytest
+
+from nexus.corpus import (
+    embedding_model_for_collection,
+    resolve_corpus,
+    t3_collection_name,
+    validate_collection_name,
+)
 
 
 # ── Embedding model selection ─────────────────────────────────────────────────
@@ -60,3 +67,36 @@ def test_resolve_corpus_no_match_returns_empty() -> None:
 def test_resolve_corpus_docs_prefix() -> None:
     all_cols = ["docs__papers", "docs__books", "code__myrepo"]
     assert resolve_corpus("docs", all_cols) == ["docs__papers", "docs__books"]
+
+
+# ── validate_collection_name ──────────────────────────────────────────────────
+
+def test_validate_collection_name_valid() -> None:
+    validate_collection_name("code__myrepo")
+    validate_collection_name("knowledge__security")
+    validate_collection_name("abc")
+
+
+def test_validate_collection_name_too_short() -> None:
+    with pytest.raises(ValueError, match="3"):
+        validate_collection_name("ab")
+
+
+def test_validate_collection_name_too_long() -> None:
+    with pytest.raises(ValueError, match="63"):
+        validate_collection_name("a" * 64)
+
+
+def test_validate_collection_name_invalid_chars() -> None:
+    with pytest.raises(ValueError, match="alphanumeric"):
+        validate_collection_name("bad:name")
+
+
+def test_validate_collection_name_starts_with_hyphen() -> None:
+    with pytest.raises(ValueError, match="alphanumeric"):
+        validate_collection_name("-badstart")
+
+
+def test_validate_collection_name_ends_with_hyphen() -> None:
+    with pytest.raises(ValueError, match="alphanumeric"):
+        validate_collection_name("badend-")

--- a/tests/test_head_polling.py
+++ b/tests/test_head_polling.py
@@ -63,6 +63,23 @@ def test_indexing_status_skips_reindex(registry) -> None:
     registry.update.assert_not_called()
 
 
+def test_index_failure_still_updates_head_hash(registry) -> None:
+    """When index_repo raises, head_hash is still updated to prevent infinite retry loops."""
+    repo = Path("/repo")
+    registry.get.return_value = {
+        "head_hash": "old_hash",
+        "status": "ready",
+        "collection": "code__repo",
+    }
+
+    with patch("nexus.polling._current_head", return_value="new_hash"):
+        with patch("nexus.polling.index_repo", side_effect=RuntimeError("index failed")):
+            with pytest.raises(RuntimeError, match="index failed"):
+                check_and_reindex(repo, registry)
+
+    registry.update.assert_called_once_with(repo, head_hash="new_hash")
+
+
 def test_missing_repo_in_registry_skips(registry) -> None:
     """If registry.get returns None, skip gracefully."""
     repo = Path("/repo")

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -65,6 +65,36 @@ def test_run_index_skips_embedding_without_credentials(tmp_path: Path, monkeypat
     mock_t3.assert_not_called()
 
 
+def test_cache_path_includes_repo_hash(tmp_path: Path, monkeypatch) -> None:
+    """Cache filenames include a path hash so two repos named 'myproject' don't collide."""
+    from nexus.indexer import _run_index
+
+    repo_a = tmp_path / "myproject"
+    repo_b = tmp_path / "other" / "myproject"
+    repo_a.mkdir()
+    repo_b.mkdir(parents=True)
+
+    seen_paths: list[Path] = []
+
+    def fake_build_cache(repo: Path, cache_path: Path, scored: list) -> None:
+        seen_paths.append(cache_path)
+
+    registry = MagicMock()
+    registry.get.return_value = {"collection": "code__myproject"}
+
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+    monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+
+    with patch("nexus.frecency.compute_frecency", return_value=0.0):
+        with patch("nexus.ripgrep_cache.build_cache", side_effect=fake_build_cache):
+            _run_index(repo_a, registry)
+            _run_index(repo_b, registry)
+
+    assert len(seen_paths) == 2
+    assert seen_paths[0] != seen_paths[1], "Cache paths for same-name repos must differ"
+    assert seen_paths[0].name != seen_paths[1].name
+
+
 def test_run_index_skips_hidden_files(tmp_path: Path, monkeypatch) -> None:
     """Files inside hidden directories (e.g. .git/) are excluded."""
     from nexus.indexer import _run_index

--- a/tests/test_md_chunker.py
+++ b/tests/test_md_chunker.py
@@ -76,3 +76,17 @@ def test_chunk_preserves_base_metadata():
     for c in chunks:
         assert c.metadata["source_path"] == "/my/doc.md"
         assert c.metadata["corpus"] == "notes"
+
+
+def test_chunk_multiple_headings_no_index_error():
+    """Multiple headings in sequence do not crash the token advance loop.
+
+    Exercises the forward-search for heading_close (guards against the old
+    hardcoded i += 3 assumption).
+    """
+    chunker = SemanticMarkdownChunker(chunk_size=512)
+    text = "# Alpha\n\nContent A.\n\n# Beta\n\nContent B.\n\n# Gamma\n\nContent C."
+    chunks = chunker.chunk(text, {})
+    titles = [c.metadata.get("header_path", "") for c in chunks]
+    assert any("Alpha" in t for t in titles)
+    assert any("Gamma" in t for t in titles)

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -55,16 +55,16 @@ def test_hybrid_score_ripgrep_exact_vector_norm_one():
 
 # ── AC2: --hybrid warns when no code corpus ───────────────────────────────────
 
-def test_hybrid_no_code_corpus_warning(capsys):
-    """hybrid_score_results warns when no code__ collections in scope."""
+def test_hybrid_no_code_corpus_warning(caplog):
+    """hybrid_score_results logs a warning when no code__ collections in scope."""
+    import logging
     results = [
         SearchResult(id="1", content="text", distance=0.1,
                      collection="docs__papers", metadata={}),
     ]
-    scored = se_mod.apply_hybrid_scoring(results, hybrid=True)
-    out = capsys.readouterr()
-    assert "Warning" in out.err or "Warning" in out.out
-    assert "no code corpus" in (out.err + out.out).lower()
+    with caplog.at_level(logging.WARNING, logger="nexus.search_engine"):
+        se_mod.apply_hybrid_scoring(results, hybrid=True)
+    assert any("no code corpus" in r.message.lower() for r in caplog.records)
 
 
 def test_hybrid_mixed_corpus_no_warning(capsys):
@@ -137,12 +137,13 @@ def test_cross_corpus_overfetch():
 
 # ── AC4: Mixedbread graceful degradation ──────────────────────────────────────
 
-def test_mxbai_missing_key_warns_and_returns_empty(capsys, monkeypatch):
-    """When MXBAI_API_KEY is unset, warn and return empty results."""
+def test_mxbai_missing_key_warns_and_returns_empty(caplog, monkeypatch):
+    """When MXBAI_API_KEY is unset, logs a warning and returns empty results."""
+    import logging
     monkeypatch.delenv("MXBAI_API_KEY", raising=False)
-    results = se_mod.fetch_mxbai_results(query="test", stores=["art"], per_k=5)
-    out = capsys.readouterr()
-    assert "MXBAI_API_KEY" in (out.err + out.out)
+    with caplog.at_level(logging.WARNING, logger="nexus.search_engine"):
+        results = se_mod.fetch_mxbai_results(query="test", stores=["art"], per_k=5)
+    assert any("MXBAI_API_KEY" in r.message for r in caplog.records)
     assert results == []
 
 

--- a/tests/test_serve_cmd.py
+++ b/tests/test_serve_cmd.py
@@ -94,7 +94,8 @@ def test_serve_stop_sends_sigterm(runner: CliRunner, serve_home: Path) -> None:
     pid_path.write_text("12345")
 
     with patch("nexus.commands.serve.os.kill") as mock_kill:
-        result = runner.invoke(main, ["serve", "stop"])
+        with patch("nexus.commands.serve._process_running", return_value=False):
+            result = runner.invoke(main, ["serve", "stop"])
 
     assert result.exit_code == 0
     mock_kill.assert_called_once_with(12345, signal.SIGTERM)
@@ -107,6 +108,24 @@ def test_serve_stop_no_server_running(runner: CliRunner, serve_home: Path) -> No
     assert result.exit_code != 0
     output = result.output.lower()
     assert "not running" in output or "no server" in output or "pid" in output
+
+
+def test_serve_stop_waits_for_process_exit(runner: CliRunner, serve_home: Path) -> None:
+    """stop_cmd polls until the process exits before reporting success."""
+    pid_path = _pid_path(serve_home)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text("12345")
+
+    # Simulate process still running on first check, gone on second
+    running_sequence = [True, False]
+
+    with patch("nexus.commands.serve.os.kill"):
+        with patch("nexus.commands.serve._process_running", side_effect=running_sequence):
+            result = runner.invoke(main, ["serve", "stop"])
+
+    assert result.exit_code == 0
+    assert "stopped" in result.output.lower()
+    assert not pid_path.exists()
 
 
 def test_serve_stop_stale_pid_cleans_up(runner: CliRunner, serve_home: Path) -> None:

--- a/tests/test_server_api.py
+++ b/tests/test_server_api.py
@@ -56,8 +56,10 @@ def test_add_repo_success(client, tmp_path: Path) -> None:
     repo = tmp_path / "myrepo"
     repo.mkdir()
     mock_reg = MagicMock()
+    mock_git = MagicMock(returncode=0)
     with patch.object(server_module, "_get_registry", return_value=mock_reg):
-        resp = client.post("/repos", json={"path": str(repo)})
+        with patch("nexus.server.subprocess.run", return_value=mock_git):
+            resp = client.post("/repos", json={"path": str(repo)})
     assert resp.status_code == 201
     mock_reg.add.assert_called_once_with(repo)
 
@@ -65,6 +67,28 @@ def test_add_repo_success(client, tmp_path: Path) -> None:
 def test_add_repo_path_not_found(client, tmp_path: Path) -> None:
     resp = client.post("/repos", json={"path": str(tmp_path / "nonexistent")})
     assert resp.status_code == 404
+
+
+def test_add_repo_rejects_non_git_directory(client, tmp_path: Path) -> None:
+    """POST /repos returns 400 when the path exists but is not a git repository."""
+    repo = tmp_path / "notgit"
+    repo.mkdir()
+    resp = client.post("/repos", json={"path": str(repo)})
+    assert resp.status_code == 400
+    assert "git" in resp.get_json()["error"].lower()
+
+
+def test_add_repo_accepts_git_repository(client, tmp_path: Path) -> None:
+    """POST /repos accepts a directory that contains a .git repo."""
+    import subprocess as _sp
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _sp.run(["git", "init", str(repo)], capture_output=True)
+    mock_reg = MagicMock()
+    with patch.object(server_module, "_get_registry", return_value=mock_reg):
+        resp = client.post("/repos", json={"path": str(repo)})
+    assert resp.status_code == 201
+    mock_reg.add.assert_called_once_with(repo)
 
 
 def test_add_repo_malformed_json(client) -> None:


### PR DESCRIPTION
## Summary

Addresses all issues deferred from PR #16 (5-stream global code review):

**S2-SEARCH** — Cache file collision: `indexer.py` now suffixes cache filename with an 8-char path hash, preventing collisions between repos with identical basenames (e.g. two `myproject/` directories)

**S3-SEARCH** — PDF boundary off-by-one: `pdf_extractor._extract_normalized` now normalizes text per-page before computing `start_char` boundaries, so boundary positions match character positions in the final joined text

**S1-SEARCH** — O(N_pages) PDF re-opens: `pdf_extractor._extract_markdown` passes the already-open `pymupdf.Document` object to `to_markdown` instead of the file path, reducing file opens from N to 1

**S5-SEARCH** — Fragile `i += 3` in `md_chunker._build_sections`: replaced hardcoded advance with a forward search for `heading_close`, robust to empty or unusual heading token sequences

**C2-PM** — Unvalidated git repo path: `server.POST /repos` now runs `git rev-parse --show-toplevel` before registering; returns 400 if path is not a git repository

**S4-PM** — `nx serve stop` race: `stop_cmd` now polls `_process_running` for up to 5 seconds before printing "Server stopped" and deleting the PID file

**O2** — `print()` in search_engine: both `print()` calls replaced with `_log.warning()`; `sys` import removed

**O4** — ChromaDB name validation: `corpus.validate_collection_name()` added (3–63 chars, alphanumeric start/end, `[a-zA-Z0-9_-]` middle); called from `T3Database.get_or_create_collection`

**O5** — `frecency.py` subprocess timeout: 120 s → 30 s

Plus missing test from review O5:
- `test_index_failure_still_updates_head_hash` — verifies `check_and_reindex` always records the new HEAD hash even when `index_repo` raises (preventing infinite retry loops)

## Test plan

- [ ] 316 tests pass, 3 skipped (up from 304 in PR #16)
- [ ] `test_cache_path_includes_repo_hash` — S2 regression guard
- [ ] `test_add_repo_rejects_non_git_directory` / `test_add_repo_accepts_git_repository` — C2 regression guard
- [ ] `test_serve_stop_waits_for_process_exit` — S4 regression guard
- [ ] `test_validate_collection_name_*` (6 cases) — O4 regression guard
- [ ] `test_chunk_multiple_headings_no_index_error` — S5 regression guard
- [ ] `test_hybrid_no_code_corpus_warning` / `test_mxbai_missing_key_warns_and_returns_empty` updated to use `caplog` — O2 regression guard
- [ ] `test_index_failure_still_updates_head_hash` — polling invariant