### PR TITLE
Add frecency-only reindex flag to nx index code

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -22,7 +22,13 @@ def index() -> None:
 
 @index.command("code")
 @click.argument("path", type=click.Path(exists=True, file_okay=False, path_type=Path))
-def index_code_cmd(path: Path) -> None:
+@click.option(
+    "--frecency-only",
+    is_flag=True,
+    default=False,
+    help="Update frecency scores only; skip re-embedding (faster, for re-ranking refresh).",
+)
+def index_code_cmd(path: Path, frecency_only: bool) -> None:
     """Register and immediately index a code repository at PATH."""
     from nexus.indexer import index_repository
 
@@ -32,8 +38,8 @@ def index_code_cmd(path: Path) -> None:
         reg.add(path)
         click.echo(f"Registered {path}.")
 
-    click.echo(f"Indexing {path}…")
-    index_repository(path, reg)
+    click.echo(f"{'Updating frecency scores' if frecency_only else 'Indexing'} {path}…")
+    index_repository(path, reg, frecency_only=frecency_only)
     click.echo("Done.")
 
 

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -171,6 +171,21 @@ class T3Database:
             metadatas=metadatas,
         )
 
+    def update_chunks(
+        self,
+        collection: str,
+        ids: list[str],
+        metadatas: list[dict],
+    ) -> None:
+        """Update chunk metadata without re-embedding.
+
+        Preserves original document text and embedding vectors.
+        Use for frecency-only reindex: update frecency_score without
+        triggering expensive re-embedding.
+        """
+        col = self.get_or_create_collection(collection)
+        col.update(ids=ids, metadatas=metadatas)
+
     # ── Read ──────────────────────────────────────────────────────────────────
 
     def search(

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -65,15 +65,21 @@ def _should_ignore(rel_path: Path, patterns: list[str]) -> bool:
     return False
 
 
-def index_repository(repo: Path, registry: "RepoRegistry") -> None:
+def index_repository(repo: Path, registry: "RepoRegistry", *, frecency_only: bool = False) -> None:
     """Index all files in *repo* into the T3 code__ collection.
 
     Marks status as 'indexing' while running, 'ready' on success,
     'pending_credentials' when T3 credentials are absent.
+
+    *frecency_only* skips re-chunking and re-embedding; only updates the
+    ``frecency_score`` metadata field on existing T3 chunks.
     """
     registry.update(repo, status="indexing")
     try:
-        _run_index(repo, registry)
+        if frecency_only:
+            _run_index_frecency_only(repo, registry)
+        else:
+            _run_index(repo, registry)
         registry.update(repo, status="ready")
     except CredentialsMissingError:
         registry.update(repo, status="pending_credentials")
@@ -83,6 +89,44 @@ def index_repository(repo: Path, registry: "RepoRegistry") -> None:
     except Exception:
         registry.update(repo, status="error")
         raise
+
+
+def _run_index_frecency_only(repo: Path, registry: "RepoRegistry") -> None:
+    """Update frecency_score metadata on all indexed chunks without re-embedding."""
+    from nexus.config import get_credential
+    from nexus.frecency import batch_frecency
+    from nexus.db import make_t3
+
+    info = registry.get(repo)
+    if info is None:
+        return
+
+    collection_name = info["collection"]
+
+    voyage_key = get_credential("voyage_api_key")
+    chroma_key = get_credential("chroma_api_key")
+    if not voyage_key or not chroma_key:
+        raise CredentialsMissingError(
+            f"T3 credentials missing for frecency reindex of '{repo.name}'"
+        )
+
+    frecency_map = batch_frecency(repo)
+    db = make_t3()
+    col = db.get_or_create_collection(collection_name)
+
+    for file, score in frecency_map.items():
+        existing = col.get(
+            where={"source_path": str(file)},
+            include=["metadatas"],
+        )
+        if not existing["ids"]:
+            continue  # not yet indexed — needs full nx index code
+
+        updated_metadatas = [
+            {**m, "frecency_score": float(score)}
+            for m in existing["metadatas"]
+        ]
+        db.update_chunks(collection_name, ids=existing["ids"], metadatas=updated_metadatas)
 
 
 def _run_index(repo: Path, registry: "RepoRegistry") -> None:

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -102,3 +102,42 @@ def test_index_md_nonexistent_path_fails(runner: CliRunner, index_home: Path) ->
     """Non-existent markdown path produces a non-zero exit code."""
     result = runner.invoke(main, ["index", "md", str(index_home / "missing.md")])
     assert result.exit_code != 0
+
+
+# ── --frecency-only flag ──────────────────────────────────────────────────────
+
+def test_index_code_frecency_only_flag_passed_through(runner: CliRunner, index_home: Path) -> None:
+    """nx index code <path> --frecency-only passes frecency_only=True to index_repository."""
+    repo = index_home / "myrepo"
+    repo.mkdir()
+
+    mock_reg = MagicMock()
+    mock_reg.get.return_value = {"collection": "code__myrepo"}  # already registered
+
+    with patch("nexus.commands.index._registry", return_value=mock_reg):
+        with patch("nexus.indexer.index_repository") as mock_index:
+            result = runner.invoke(main, ["index", "code", str(repo), "--frecency-only"])
+
+    assert result.exit_code == 0, result.output
+    mock_index.assert_called_once()
+    _, call_kwargs = mock_index.call_args
+    assert call_kwargs.get("frecency_only") is True
+    assert "frecency" in result.output.lower()
+
+
+def test_index_code_default_is_full_index(runner: CliRunner, index_home: Path) -> None:
+    """nx index code <path> without --frecency-only passes frecency_only=False."""
+    repo = index_home / "myrepo"
+    repo.mkdir()
+
+    mock_reg = MagicMock()
+    mock_reg.get.return_value = {"collection": "code__myrepo"}
+
+    with patch("nexus.commands.index._registry", return_value=mock_reg):
+        with patch("nexus.indexer.index_repository") as mock_index:
+            result = runner.invoke(main, ["index", "code", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    mock_index.assert_called_once()
+    _, call_kwargs = mock_index.call_args
+    assert call_kwargs.get("frecency_only") is False

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -223,3 +223,81 @@ def test_run_index_skips_unchanged_content_hash(tmp_path: Path) -> None:
                             _run_index(repo, registry)
 
     mock_db.upsert_chunks.assert_not_called()
+
+
+# ── _run_index_frecency_only ──────────────────────────────────────────────────
+
+def test_frecency_only_updates_frecency_score(tmp_path: Path) -> None:
+    """_run_index_frecency_only updates frecency_score on existing chunks."""
+    from nexus.indexer import _run_index_frecency_only
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    src_file = repo / "main.py"
+    src_file.write_text("x = 1\n")
+
+    registry = MagicMock()
+    registry.get.return_value = {"collection": "code__repo"}
+
+    old_meta = {"frecency_score": 0.1, "source_path": str(src_file), "title": "main.py:1-1"}
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"ids": ["chunk-1"], "metadatas": [old_meta]}
+
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.return_value = mock_col
+
+    with patch("nexus.frecency.batch_frecency", return_value={src_file: 0.75}):
+        with patch("nexus.config.get_credential", return_value="fake-key"):
+            with patch("nexus.db.make_t3", return_value=mock_db):
+                _run_index_frecency_only(repo, registry)
+
+    mock_db.update_chunks.assert_called_once()
+    call_kwargs = mock_db.update_chunks.call_args.kwargs
+    assert call_kwargs["ids"] == ["chunk-1"]
+    assert call_kwargs["metadatas"][0]["frecency_score"] == 0.75
+    # Other metadata fields must be preserved
+    assert call_kwargs["metadatas"][0]["title"] == "main.py:1-1"
+
+
+def test_frecency_only_skips_unindexed_files(tmp_path: Path) -> None:
+    """_run_index_frecency_only skips files with no existing indexed chunks."""
+    from nexus.indexer import _run_index_frecency_only
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    src_file = repo / "new_file.py"
+    src_file.write_text("y = 2\n")
+
+    registry = MagicMock()
+    registry.get.return_value = {"collection": "code__repo"}
+
+    mock_col = MagicMock()
+    # No existing chunks for this file
+    mock_col.get.return_value = {"ids": [], "metadatas": []}
+
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.return_value = mock_col
+
+    with patch("nexus.frecency.batch_frecency", return_value={src_file: 0.5}):
+        with patch("nexus.config.get_credential", return_value="fake-key"):
+            with patch("nexus.db.make_t3", return_value=mock_db):
+                _run_index_frecency_only(repo, registry)
+
+    mock_db.update_chunks.assert_not_called()
+
+
+def test_frecency_only_raises_credentials_missing(tmp_path: Path, monkeypatch) -> None:
+    """_run_index_frecency_only raises CredentialsMissingError when T3 keys are absent."""
+    from nexus.indexer import _run_index_frecency_only
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    registry = MagicMock()
+    registry.get.return_value = {"collection": "code__repo"}
+
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+    monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+
+    with pytest.raises(CredentialsMissingError):
+        _run_index_frecency_only(repo, registry)

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -623,3 +623,33 @@ def test_upsert_chunks_with_embeddings_uses_get_or_create(mock_chromadb: tuple) 
 
     mock_client.get_or_create_collection.assert_called_once()
     assert mock_client.get_or_create_collection.call_args.args[0] == "knowledge__wiki"
+
+
+# ── update_chunks ─────────────────────────────────────────────────────────────
+
+def test_update_chunks_calls_col_update_without_documents(mock_chromadb: tuple) -> None:
+    """update_chunks() calls col.update with ids+metadatas only — no documents — preserving embeddings."""
+    _, mock_client = mock_chromadb
+    mock_col = MagicMock()
+    mock_client.get_or_create_collection.return_value = mock_col
+
+    db = T3Database(tenant="t", database="d", api_key="k")
+    db.update_chunks(
+        collection="code__myrepo",
+        ids=["id-1", "id-2"],
+        metadatas=[
+            {"frecency_score": 0.9, "source_path": "src/foo.py"},
+            {"frecency_score": 0.9, "source_path": "src/foo.py"},
+        ],
+    )
+
+    mock_col.update.assert_called_once_with(
+        ids=["id-1", "id-2"],
+        metadatas=[
+            {"frecency_score": 0.9, "source_path": "src/foo.py"},
+            {"frecency_score": 0.9, "source_path": "src/foo.py"},
+        ],
+    )
+    # documents must NOT be passed — that would trigger re-embedding
+    call_kwargs = mock_col.update.call_args.kwargs
+    assert "documents" not in call_kwargs


### PR DESCRIPTION
## Summary

- Add `T3Database.update_chunks()` to update chunk metadata without re-embedding (preserves document text and embedding vectors)
- Add `_run_index_frecency_only()` to refresh `frecency_score` on existing T3 chunks without re-chunking or re-embedding
- Add `--frecency-only` flag to `nx index code`; dispatches to the fast path and adjusts progress output accordingly

Addresses the known v1 limitation noted in spec.md line 187: stable files' relative frecency scores become stale as other files receive commits, without requiring a full reindex.

## Test plan

- [ ] `test_update_chunks_calls_col_update_without_documents` — verifies `col.update` called with ids+metadatas only, no documents
- [ ] `test_frecency_only_updates_frecency_score` — mock existing chunks; verify `update_chunks` called with updated score and other fields preserved
- [ ] `test_frecency_only_skips_unindexed_files` — `col.get` returns empty ids; verify `update_chunks` not called
- [ ] `test_frecency_only_raises_credentials_missing` — no voyage/chroma keys; verify `CredentialsMissingError`
- [ ] `test_index_code_frecency_only_flag_passed_through` — CLI `--frecency-only` passes `frecency_only=True` to `index_repository`
- [ ] `test_index_code_default_is_full_index` — omitting flag passes `frecency_only=False`
- [ ] Full suite: 505 passed, 3 skipped