### PR TITLE
Fix code review findings: batch overflow, boundary check, dead code

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -200,8 +200,9 @@ ChromaDB natively supports `VoyageAIEmbeddingFunction` (`pip install voyageai`; 
 2. Text extracted and chunked in-process using **ported Arcaneum extraction logic**: PyMuPDF4LLM → markdown (primary), PyMuPDF → normalized text (fallback), Tesseract/EasyOCR (scanned fallback)
 3. **Only the extracted text chunks + embeddings + metadata are stored in T3 ChromaDB** — raw PDF bytes never leave the machine
 4. Chunks embedded via `voyage-context-3` (Contextualized Chunk Embedding — captures cross-chunk context
-   at index time for richer retrieval). Falls back to `voyage-4` if fewer than 2 chunks or estimated
-   tokens exceed 100K. Query-time embedding always uses `voyage-4` (standard; CCE is index-only).
+   at index time for richer retrieval). Large documents are automatically batched into groups fitting
+   the 32K token context window. Falls back to `voyage-4` if fewer than 2 chunks or on CCE API error.
+   Query-time embedding always uses `voyage-4` (standard; CCE is index-only).
 5. Upserted into T3 collection `docs__{corpus-name}`
 
 Arcaneum's extraction and chunking logic (PDFExtractor, PDFChunker, OCREngine) is **ported** — not imported as a library. The storage layer calls (Qdrant `PointStruct`, `upload_points`, scroll-based sync) must be rewritten as ChromaDB `collection.upsert()` calls. The embedding layer (`fastembed` local ONNX) is replaced with `VoyageAIEmbeddingFunction`. The extraction and chunking logic itself (PyMuPDF4LLM calls, OCR orchestration) ports with minimal changes.

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -36,11 +36,6 @@ def _has_credentials() -> bool:
     return bool(get_credential("voyage_api_key") and get_credential("chroma_api_key"))
 
 
-def _estimate_tokens(chunks: list[str]) -> int:
-    """Rough token estimate: 3 characters per token (conservative; code skews short)."""
-    return sum(len(c) for c in chunks) // 3
-
-
 _CCE_TOKEN_LIMIT = 32_000
 _CCE_TOTAL_TOKEN_LIMIT = 120_000  # Voyage API total token limit across all inputs
 # Note: per-batch limit of 32K means we never hit 120K in a single call
@@ -69,7 +64,8 @@ def _batch_chunks_for_cce(chunks: list[str]) -> list[list[str]]:
             current_tokens += chunk_tokens
     if current:
         # CCE requires >= 2 chunks per batch; merge singletons into previous batch
-        if len(current) < 2 and batches:
+        # but only if that won't exceed the per-batch chunk limit
+        if len(current) < 2 and batches and len(batches[-1]) < _CCE_MAX_BATCH_CHUNKS:
             batches[-1].extend(current)
         else:
             batches.append(current)
@@ -97,7 +93,7 @@ def _embed_with_fallback(
     """
     if not chunks:
         return [], model
-    if len(chunks) > _CCE_MAX_TOTAL_CHUNKS:
+    if len(chunks) >= _CCE_MAX_TOTAL_CHUNKS:
         _log.warning(
             "chunk count exceeds Voyage API limit",
             chunk_count=len(chunks),

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -406,23 +406,6 @@ def test_index_markdown_no_frontmatter_offsets_unchanged(tmp_path: Path, monkeyp
 
 # ── nexus-370: CCE helpers ────────────────────────────────────────────────────
 
-def test_estimate_tokens_returns_reasonable_value():
-    """300 chars of text should estimate to ~100 tokens (3 chars/token)."""
-    from nexus.doc_indexer import _estimate_tokens
-
-    chunks = ["a" * 300]
-    result = _estimate_tokens(chunks)
-    assert result == 100
-
-
-def test_estimate_tokens_multi_chunk():
-    """Estimate sums all chunk lengths then divides by 3."""
-    from nexus.doc_indexer import _estimate_tokens
-
-    chunks = ["a" * 150, "b" * 150]
-    assert _estimate_tokens(chunks) == 100
-
-
 def test_embed_with_fallback_calls_cce_for_docs_collection(monkeypatch):
     """When model=voyage-context-3 and len(chunks) >= 2, contextualized_embed is called."""
     from unittest.mock import MagicMock, patch
@@ -1023,10 +1006,49 @@ def test_batch_chunks_for_cce_no_batch_exceeds_1000():
     batches = _batch_chunks_for_cce(chunks)
 
     for i, batch in enumerate(batches):
-        # Allow the singleton-merge case: last batch can exceed by 1 if merged
-        assert len(batch) <= _CCE_MAX_BATCH_CHUNKS + 1, (
-            f"Batch {i} has {len(batch)} chunks, exceeds limit"
+        assert len(batch) <= _CCE_MAX_BATCH_CHUNKS, (
+            f"Batch {i} has {len(batch)} chunks, max allowed is {_CCE_MAX_BATCH_CHUNKS}"
         )
+
+
+def test_batch_chunks_for_cce_singleton_not_merged_when_target_at_limit():
+    """Singleton is NOT merged into previous batch if that batch is already at the limit."""
+    from nexus.doc_indexer import _batch_chunks_for_cce, _CCE_MAX_BATCH_CHUNKS
+
+    # Exactly _CCE_MAX_BATCH_CHUNKS chunks → fills one batch to the limit
+    # Then one more → singleton that must NOT be merged (would overflow)
+    chunks = ["tiny"] * (_CCE_MAX_BATCH_CHUNKS + 1)
+    batches = _batch_chunks_for_cce(chunks)
+
+    for i, batch in enumerate(batches):
+        assert len(batch) <= _CCE_MAX_BATCH_CHUNKS, (
+            f"Batch {i} has {len(batch)} chunks, max is {_CCE_MAX_BATCH_CHUNKS}"
+        )
+    # All chunks preserved
+    assert sum(len(b) for b in batches) == _CCE_MAX_BATCH_CHUNKS + 1
+
+
+def test_embed_with_fallback_warns_at_exactly_limit(monkeypatch):
+    """Warning fires when chunk count equals the limit (>= boundary)."""
+    from unittest.mock import MagicMock, patch
+    from nexus.doc_indexer import _embed_with_fallback
+
+    mock_client = MagicMock()
+    mock_result = MagicMock()
+    mock_result.embeddings = [[0.1]]
+    mock_client.embed.return_value = mock_result
+
+    with patch("voyageai.Client", return_value=mock_client):
+        with patch("nexus.doc_indexer._log") as mock_log:
+            # Patch limit to 2 and pass exactly 2 chunks → should warn with >=
+            with patch("nexus.doc_indexer._CCE_MAX_TOTAL_CHUNKS", 2):
+                _embed_with_fallback(
+                    chunks=["a", "b"],
+                    model="voyage-4",
+                    api_key="vk_test",
+                )
+            mock_log.warning.assert_called_once()
+            assert "chunk count exceeds" in mock_log.warning.call_args[0][0]
 
 
 # ── C3: Fallback embed() in CCE error handler also batches ──────────────────


### PR DESCRIPTION
## Summary
- **I1**: Prevent `_batch_chunks_for_cce` singleton merge from overflowing `_CCE_MAX_BATCH_CHUNKS` (guard added before merge)
- **I2**: Warning fires at `>=` 16K chunks (boundary-inclusive), not just `>` 16K
- **I3**: Update `spec.md` from stale "100K" threshold to actual 32K batching behavior
- **S1**: Remove dead `_estimate_tokens` function (unused after batching rewrite)
- Two new boundary tests for I1 and I2, strict batch limit assertion (no `+1` accommodation)

## Test plan
- [x] All 45 doc_indexer tests pass (including 2 new boundary tests)
- [x] Full suite: 1114 passed, 0 failed
- [x] Verify no batch can exceed `_CCE_MAX_BATCH_CHUNKS` (strict assertion, no `+1`)
- [x] Verify warning at exactly-at-limit boundary (>= not >)