### PR TITLE
Address 6 technical debt items from architecture analysis

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,7 @@
 # Nexus Architecture
 
-> **Implementation Status**: Sections marked `[v1-actual]` reflect the current implementation.
-> Sections marked `[v2-planned]` describe aspirational design not yet implemented.
-> When in doubt, check `src/nexus/` — the code is the ground truth.
+> This document describes the current implementation. When in doubt,
+> check `src/nexus/` — the code is the ground truth.
 
 ## Executive Summary
 
@@ -24,10 +23,7 @@ persistent server), and Arcaneum (PDF/markdown extraction and chunking).
 
 ## Module/Package Structure
 
-### [v1-actual] Current Flat Layout
-
-The implementation uses a flat module layout, not the hierarchical subpackages described
-in the v2-planned section below. This is the ground truth as of the current codebase.
+### Flat Module Layout
 
 ```
 src/nexus/
@@ -52,7 +48,7 @@ src/nexus/
 |-- registry.py                    # repo registry (~/.config/nexus/repos.json)
 |-- ripgrep_cache.py               # mmap line cache (ported from SeaGOAT)
 |-- scoring.py                     # scoring primitives (min_max_normalize, etc.)
-|-- search_engine.py               # search orchestration (~175 lines, see [v1-actual] below)
+|-- search_engine.py               # search orchestration (~175 lines)
 |-- server.py                      # Flask app factory and routes
 |-- server_main.py                 # server entry point / daemonization
 |-- session.py                     # session ID management (PID-scoped file)
@@ -78,118 +74,7 @@ src/nexus/
     +-- t3.py                      # CloudClient + VoyageAIEmbeddingFunction
 ```
 
-### [v2-planned] Aspirational Hierarchical Layout
-
-The following hierarchical structure was the original design intent. It has NOT been
-implemented. The subpackages `protocols/`, `storage/`, `indexing/`, `search/`, `answer/`,
-`pm/`, `server/`, `cli/`, `formatting/`, and `integration/` do not exist.
-Note: `answer.py`, `formatters.py`, and `scoring.py` NOW EXIST as flat modules (partial
-progress toward the aspirational layout), but the full subpackage structure remains unimplemented.
-
-```
-src/nexus/
-|-- __init__.py                    # version, package metadata
-|-- __main__.py                    # entry point for `python -m nexus`
-|-- types.py                       # shared dataclasses (Chunk, SearchResult, etc.)
-|-- errors.py                      # custom exception hierarchy
-|-- config.py                      # config loading (YAML, env vars, merging)
-|-- session.py                     # session ID management (UUID4)
-|
-|-- protocols/                     # ABCs and Protocols (NO implementations)
-|   |-- __init__.py
-|   |-- storage.py                 # MemoryStore, VectorStore Protocols
-|   |-- embedding.py               # EmbeddingFunction Protocol
-|   |-- chunking.py                # ChunkStrategy Protocol
-|   |-- search.py                  # SearchPipeline Protocol
-|   |-- indexing.py                # IndexPipeline Protocol
-|   +-- formatting.py              # ResultFormatter Protocol
-|
-|-- storage/                       # Storage tier implementations
-|   |-- __init__.py                # tier factory functions
-|   |-- t1_ephemeral.py            # EphemeralClient + DefaultEmbeddingFunction
-|   |-- t2_sqlite.py               # SQLite + FTS5 + WAL
-|   +-- t3_cloud.py                # CloudClient + VoyageAIEmbeddingFunction
-|
-|-- indexing/                      # Indexing pipelines
-|   |-- __init__.py
-|   |-- code/                      # Code indexing pipeline
-|   |   |-- __init__.py
-|   |   |-- pipeline.py            # CodeIndexPipeline orchestrator
-|   |   |-- frecency.py            # git frecency scoring (ported from SeaGOAT)
-|   |   |-- chunker.py             # AST chunker via llama-index CodeSplitter
-|   |   +-- ripgrep_cache.py       # mmap line cache (ported from SeaGOAT)
-|   |-- pdf/                       # PDF indexing pipeline (ported from Arcaneum)
-|   |   |-- __init__.py
-|   |   |-- pipeline.py            # PDFIndexPipeline orchestrator
-|   |   |-- extractor.py           # PyMuPDF4LLM + pdfplumber + OCR
-|   |   |-- chunker.py             # PDF chunker
-|   |   +-- ocr.py                 # OCR engine (Tesseract/EasyOCR)
-|   +-- markdown/                  # Markdown indexing pipeline
-|       |-- __init__.py
-|       |-- pipeline.py            # MarkdownIndexPipeline orchestrator
-|       +-- chunker.py             # SemanticMarkdownChunker (ported from Arcaneum)
-|
-|-- search/                        # Search subsystem
-|   |-- __init__.py
-|   |-- semantic.py                # ChromaDB vector search (T1/T3)
-|   |-- fulltext.py                # ripgrep line cache search
-|   |-- hybrid.py                  # hybrid scoring (0.7*vector + 0.3*frecency)
-|   |-- cross_corpus.py            # cross-corpus retrieval + reranking
-|   |-- agentic.py                 # multi-step query refinement (Haiku)
-|   |-- mxbai.py                   # Mixedbread fan-out (read-only)
-|   +-- scoring.py                 # min_max_normalize, scoring utilities
-|
-|-- answer/                        # Q&A synthesis
-|   |-- __init__.py
-|   +-- synthesizer.py             # Haiku-based answer synthesis with citations
-|
-|-- pm/                            # Project management lifecycle
-|   |-- __init__.py
-|   |-- lifecycle.py               # init/archive/restore/close state machine
-|   |-- templates.py               # embedded PM document templates
-|   +-- synthesis.py               # Haiku archive synthesis
-|
-|-- server/                        # Persistent server
-|   |-- __init__.py
-|   |-- app.py                     # Flask app factory
-|   |-- daemon.py                  # daemonize, PID management
-|   |-- registry.py                # repo registry (~/.config/nexus/repos.json)
-|   +-- polling.py                 # HEAD hash polling, re-index triggers
-|
-|-- cli/                           # Click CLI commands
-|   |-- __init__.py
-|   |-- main.py                    # nx group + top-level commands
-|   |-- search_cmd.py              # nx search
-|   |-- memory_cmd.py              # nx memory put/get/search/list/expire/promote
-|   |-- store_cmd.py               # nx store, nx store expire
-|   |-- scratch_cmd.py             # nx scratch put/get/search/list/clear/flag/promote
-|   |-- index_cmd.py               # nx index code/pdf/md
-|   |-- serve_cmd.py               # nx serve start/stop/status/logs
-|   |-- pm_cmd.py                  # nx pm (all lifecycle subcommands)
-|   |-- collection_cmd.py          # nx collection list/info/delete/verify
-|   |-- config_cmd.py              # nx config show/set
-|   |-- doctor_cmd.py              # nx doctor
-|   +-- install_cmd.py             # nx install/uninstall claude-code
-|
-|-- formatting/                    # Output formatting
-|   |-- __init__.py
-|   |-- plain.py                   # plain text, pipe-friendly
-|   |-- highlighted.py             # bat/pygments syntax highlighting
-|   |-- vimgrep.py                 # path:line:col:content
-|   |-- json_fmt.py                # JSON output
-|   +-- citations.py               # <cite i="N"> formatting for answer mode
-|
-+-- integration/                   # External tool integration
-    |-- __init__.py
-    |-- claude_code/               # Claude Code plugin
-    |   |-- __init__.py
-    |   |-- installer.py           # SKILL.md + hooks installation
-    |   |-- hooks.py               # SessionStart/SessionEnd hook logic
-    |   +-- skill_template.py      # SKILL.md template content
-    +-- git_hooks.py               # post-commit hook for nx serve notification
-```
-
-### [v1-actual] Module Responsibility Summary
+### Module Responsibility Summary
 
 | Module | Responsibility |
 |--------|---------------|
@@ -219,349 +104,30 @@ src/nexus/
 | `errors.py` | Custom exception hierarchy |
 | `commands/` | Click CLI command definitions (one file per command group) |
 
-### [v2-planned] Module Responsibility Summary
-
-This table reflects the aspirational hierarchical layout. In the v1-actual flat layout,
-the responsibilities map to: `db/t1.py`, `db/t2.py`, `db/t3.py` (storage tiers),
-`scoring.py`, `answer.py`, `formatters.py` (search/formatting), `pm.py` (lifecycle),
-`server.py` / `server_main.py` (server), `commands/` (CLI), and flat modules for indexing.
-
-| Module | Responsibility | Dependencies |
-|--------|---------------|--------------|
-| `protocols/` | Abstract interfaces only | `types.py` only |
-| `storage/t1_ephemeral.py` | In-memory ChromaDB scratch | `protocols/`, `types.py`, `chromadb` |
-| `storage/t2_sqlite.py` | SQLite + FTS5 memory bank | `protocols/`, `types.py`, `sqlite3` (stdlib) |
-| `storage/t3_cloud.py` | ChromaDB cloud knowledge | `protocols/`, `types.py`, `chromadb`, `voyageai` |
-| `indexing/code/` | Code repo indexing | `protocols/storage.py (VectorStore)`, `protocols/`, git, llama-index |
-| `indexing/pdf/` | PDF extraction + chunking | `protocols/storage.py (VectorStore)`, `protocols/`, pymupdf4llm |
-| `indexing/markdown/` | Markdown chunking | `protocols/storage.py (VectorStore)`, `protocols/`, markdown-it-py |
-| `search/` | All search strategies | `storage/`, `scoring.py` |
-| `answer/` | Haiku synthesis | `search/`, `anthropic` SDK |
-| `pm/` | Project management lifecycle | `storage/t2_sqlite.py`, `storage/t3_cloud.py`, `answer/` |
-| `server/` | Flask/Waitress persistent process | `indexing/`, `search/`, `storage/` |
-| `cli/` | Click command definitions | Everything above (leaf layer) |
-| `formatting/` | Output rendering | `types.py` only |
-| `integration/` | External tool hooks | `config.py`, `session.py` |
-
-### [v2-planned] Dependency Rules (aspirational import structure)
-
-These rules describe the intended architecture for the hierarchical subpackage layout.
-In the v1-actual flat layout, these rules are approximated but not formally enforced via
-import-linter (the `.importlinter` configuration file does not yet exist).
-
-1. `protocols/` imports NOTHING from `storage/`, `indexing/`, `search/`, `cli/`
-2. `storage/` imports only from `protocols/` and `types.py`
-3. `indexing/` imports from `protocols/` only — **not** from `storage/t3_cloud.py` directly; receives a `VectorStore` protocol via constructor injection from `cli/index_cmd.py`
-4. `search/` imports from `storage/` and `protocols/` (never from `indexing/` or `cli/`)
-5. `cli/` imports from everything but NOTHING imports from `cli/`
-6. `formatting/` imports only from `types.py`
-7. No circular dependency paths exist
-
-These rules are intended to be enforced by `import-linter` (`dev` dependency). Configuration in `.importlinter`. Run `lint-imports` as part of the CI gate alongside pytest, mypy, and ruff.
-
----
-
-## Core Abstractions (Protocols) [v2-planned]
-
-The `protocols/` subpackage described in this section does not exist in the v1-actual
-flat layout. The protocol interfaces below document the intended contracts. In practice,
-the v1-actual implementation wires dependencies via direct imports within the flat module
-structure rather than formal Protocol injection. These definitions remain as the
-aspirational interface specification.
-
-### StorageTier Protocols
-
-T1/T3 both use ChromaDB but differ in client type and embedding function.
-T2 uses SQLite. Rather than forcing a single interface, we define tier-appropriate protocols.
-
-```python
-# protocols/storage.py
-
-from typing import Protocol, runtime_checkable
-from nexus.types import MemoryEntry, VectorResult, SearchResult
-
-@runtime_checkable
-class MemoryStore(Protocol):
-    """T2 SQLite memory bank operations."""
-
-    def put(self, project: str, title: str, content: str, *,
-            tags: str = "", ttl: int | None = 30,
-            session: str = "", agent: str = "") -> int:
-        """Insert or replace a memory entry. Returns row ID."""
-        ...
-
-    def get(self, project: str, title: str) -> MemoryEntry | None:
-        """Retrieve by (project, title) key. Primary access pattern."""
-        ...
-
-    def get_by_id(self, id: int) -> MemoryEntry | None:
-        """Retrieve by row ID. Secondary access pattern."""
-        ...
-
-    def search(self, query: str, *, project: str | None = None) -> list[MemoryEntry]:
-        """FTS5 keyword search. Optionally scoped to a project."""
-        ...
-
-    def list_entries(self, *, project: str | None = None,
-                     agent: str | None = None, limit: int = 100) -> list[MemoryEntry]:
-        """List entries with optional filters."""
-        ...
-
-    def expire(self) -> int:
-        """Delete TTL-expired entries. Returns count deleted."""
-        ...
-
-    def close(self) -> None:
-        """Close the database connection."""
-        ...
-
-
-@runtime_checkable
-class VectorStore(Protocol):
-    """ChromaDB vector store operations (used by both T1 and T3)."""
-
-    def upsert(self, collection: str, ids: list[str],
-               documents: list[str], metadatas: list[dict]) -> None:
-        """Upsert documents into a collection."""
-        ...
-
-    def query(self, collection: str, query_texts: list[str],
-              n_results: int = 10, *,
-              where: dict | None = None) -> list[VectorResult]:
-        """Semantic search within a collection."""
-        ...
-
-    def get(self, collection: str, *,
-            ids: list[str] | None = None,
-            where: dict | None = None) -> list[VectorResult]:
-        """Retrieve documents by ID or metadata filter."""
-        ...
-
-    def delete(self, collection: str, ids: list[str]) -> None:
-        """Delete documents by ID."""
-        ...
-
-    def list_collections(self) -> list[str]:
-        """List all collection names."""
-        ...
-
-    def collection_count(self, collection: str) -> int:
-        """Get document count for a collection."""
-        ...
-```
-
-### EmbeddingFunction Protocol
-
-```python
-# protocols/embedding.py
-
-from typing import Protocol, runtime_checkable
-
-@runtime_checkable
-class EmbeddingFunction(Protocol):
-    """Wraps ChromaDB embedding function interface."""
-
-    def __call__(self, input: list[str]) -> list[list[float]]:
-        """Generate embeddings for a list of texts."""
-        ...
-
-    @property
-    def model_name(self) -> str:
-        """Return the model identifier (e.g., 'voyage-code-3')."""
-        ...
-```
-
-**Implementations:**
-
-| Class | Tier | Model | Network |
-|-------|------|-------|---------|
-| `DefaultEmbedding` | T1 | all-MiniLM-L6-v2 (local ONNX) | No |
-| `VoyageCodeEmbedding` | T3 code | voyage-code-3 | Yes |
-| `VoyageDocsEmbedding` | T3 docs/knowledge | voyage-4 | Yes |
-
-### ChunkStrategy Protocol
-
-```python
-# protocols/chunking.py
-
-from typing import Protocol, runtime_checkable
-from nexus.types import Chunk
-
-@runtime_checkable
-class ChunkStrategy(Protocol):
-    """Strategy for splitting content into embeddable chunks."""
-
-    def chunk(self, content: str, source_path: Path | None, metadata: dict) -> list[Chunk]:
-        """Split content into chunks with metadata.
-
-        source_path: filesystem path to the source file (required by CodeChunker for
-        language detection via file extension and line attribution; ignored by
-        PDFChunker and SemanticMarkdownChunker, which use metadata instead).
-        """
-        ...
-```
-
-**Implementations:**
-
-| Class | Pipeline | Source |
-|-------|----------|--------|
-| `CodeChunker` | Code | llama-index CodeSplitter (AST) + line-based fallback |
-| `PDFChunker` | PDF | Ported from Arcaneum `PDFChunker` |
-| `SemanticMarkdownChunker` | Markdown | Ported from Arcaneum `SemanticMarkdownChunker` |
-
-### IndexPipeline Protocol
-
-```python
-# protocols/indexing.py
-
-from typing import Protocol, runtime_checkable
-from pathlib import Path
-from nexus.types import IndexResult
-
-@runtime_checkable
-class IndexPipeline(Protocol):
-    """Pipeline for indexing content into T3."""
-
-    def index(self, path: Path) -> IndexResult:
-        """Index content at the given path. Returns stats."""
-        ...
-
-    def needs_reindex(self, path: Path) -> bool:
-        """Check if content at path needs re-indexing."""
-        ...
-```
-
-**Implementations:**
-
-| Class | Chunker | Embedding | Collection Pattern |
-|-------|---------|-----------|-------------------|
-| `CodeIndexPipeline` | `CodeChunker` | `VoyageCodeEmbedding` | `code__{repo}` |
-| `PDFIndexPipeline` | `PDFChunker` | `VoyageDocsEmbedding` | `docs__{corpus}` |
-| `MarkdownIndexPipeline` | `SemanticMarkdownChunker` | `VoyageDocsEmbedding` | `docs__{corpus}` |
-
-### SearchPipeline Protocol
-
-```python
-# protocols/search.py
-
-from typing import Protocol, runtime_checkable
-from nexus.types import SearchResult, SearchOptions
-
-@runtime_checkable
-class SearchPipeline(Protocol):
-    """Strategy for searching across storage tiers."""
-
-    def search(self, query: str, options: SearchOptions) -> list[SearchResult]:
-        """Execute a search and return scored results."""
-        ...
-```
-
-**Implementations:**
-
-| Class | Scope | Dependencies |
-|-------|-------|-------------|
-| `SemanticSearch` | T1 or T3 | ChromaDB query |
-| `FulltextSearch` | Ripgrep cache | subprocess + mmap |
-| `HybridSearch` | T3 code + ripgrep | SemanticSearch + FulltextSearch + scoring |
-| `CrossCorpusSearch` | Multiple T3 | Per-corpus retrieval + Voyage rerank-2.5 |
-| `AgenticSearch` | T3 | Haiku refinement loop |
-| `MixedbreadFanout` | Mixedbread cloud | Mixedbread SDK (read-only) |
-
-### ResultFormatter Protocol
-
-```python
-# protocols/formatting.py
-
-from typing import Protocol, runtime_checkable
-from nexus.types import SearchResult, FormatOptions
-
-@runtime_checkable
-class ResultFormatter(Protocol):
-    """Strategy for formatting search results for display."""
-
-    def format(self, results: list[SearchResult], options: FormatOptions) -> str:
-        """Format results into a displayable string."""
-        ...
-```
-
-**Implementations:** `PlainFormatter`, `HighlightedFormatter`, `VimgrepFormatter`,
-`JsonFormatter`, `CitationFormatter`
 
 ---
 
 ## Component Architecture
 
-### CLI Dispatch Flow [v2-planned]
-
-The module paths in this diagram reflect the aspirational hierarchical layout.
-In the v1-actual layout, the equivalent modules are: `commands/search_cmd.py`,
-`commands/memory.py`, `commands/store.py`, `commands/scratch.py`, `commands/index.py`,
-`commands/serve.py`, `commands/pm.py`, `commands/collection.py`, `commands/config_cmd.py`,
-`commands/doctor.py`, `commands/install.py`; storage tiers are in `db/t1.py`, `db/t2.py`,
-`db/t3.py`; and search/answer/formatting live in flat modules `search_engine.py`,
-`answer.py`, `formatters.py`, `scoring.py`.
-
-```
-nx <command> [subcommand] [args] [flags]
-     |
-     v
-cli/main.py (Click group)
-     |
-     +-- search_cmd.py ----> search/ (SemanticSearch | HybridSearch | CrossCorpusSearch)
-     |                            \--> answer/synthesizer.py (if -a)
-     |                            \--> formatting/ (selected by flags)
-     |
-     +-- memory_cmd.py ----> storage/t2_sqlite.py
-     |
-     +-- store_cmd.py -----> storage/t3_cloud.py
-     |
-     +-- scratch_cmd.py ---> storage/t1_ephemeral.py
-     |                            \--> storage/t2_sqlite.py (on promote/flag-flush)
-     |
-     +-- index_cmd.py -----> indexing/{code,pdf,markdown}/pipeline.py
-     |                            \--> storage/t3_cloud.py (upsert)
-     |
-     +-- serve_cmd.py -----> server/daemon.py + server/app.py
-     |
-     +-- pm_cmd.py --------> pm/lifecycle.py
-     |                            \--> storage/t2_sqlite.py (T2 ops)
-     |                            \--> storage/t3_cloud.py (archive to T3)
-     |                            \--> pm/synthesis.py (Haiku synthesis)
-     |
-     +-- collection_cmd.py -> storage/t3_cloud.py
-     +-- config_cmd.py ----> config.py
-     +-- doctor_cmd.py ----> (validates all tiers + APIs)
-     +-- install_cmd.py ---> integration/claude_code/installer.py
-```
-
-### Server Architecture (`nx serve`) [v1-actual: server.py / server_main.py]
-
-The aspirational `server/` subpackage does not exist. The server is implemented in the
-flat modules `src/nexus/server.py` (Flask app factory + routes) and
-`src/nexus/server_main.py` (daemonization/entry point). Registry and polling live in
-`src/nexus/registry.py` and `src/nexus/polling.py` respectively.
+### Server Architecture (`server.py` / `server_main.py`)
 
 ```
 nx serve start
      |
      v
-server_main.py (daemonization)   [v1-actual: server_main.py]
-  |-- check_stale_pid()
+server_main.py (daemonization)     |-- check_stale_pid()
   |-- write PID to ~/.config/nexus/server.pid
   |-- Popen(start_new_session=True) for daemonization
      |
      v
-server.py (Flask app factory)    [v1-actual: server.py]
-  |-- /search          POST  -> search pipeline
+server.py (Flask app factory)      |-- /search          POST  -> search pipeline
   |-- /index/status    GET   -> indexing progress per repo
   |-- /status          GET   -> server health + repo accuracy %
      |
-     +-- registry.py             [v1-actual: registry.py]
-     |     |-- repos.json: [{path, collection, last_head, ...}]
+     +-- registry.py                  |     |-- repos.json: [{path, collection, last_head, ...}]
      |     |-- register(path) / unregister(path)
      |
-     +-- polling.py              [v1-actual: polling.py]
-           |-- per-repo thread: every N seconds (default 10)
+     +-- polling.py                         |-- per-repo thread: every N seconds (default 10)
            |   |-- git rev-parse HEAD
            |   |-- if changed: trigger indexer.py / doc_indexer.py
            |-- accuracy sigmoid (SeaGOAT pattern):
@@ -634,33 +200,31 @@ writes to T2 except `nx pm restore` which operates on T2 metadata only).
                             (after 90d: T2 entries expire, only T3 synthesis remains)
 ```
 
-### Component Ownership [v1-actual: pm.py]
+### Component Ownership
 
-In the v1-actual flat layout, all PM lifecycle logic lives in `src/nexus/pm.py` and the
-CLI commands in `src/nexus/commands/pm.py`. The aspirational `pm/lifecycle.py` and
-`pm/synthesis.py` submodules do not exist.
+All PM lifecycle logic lives in `src/nexus/pm.py` and the CLI commands in
+`src/nexus/commands/pm.py`.
 
 | Operation | Primary Module | Storage Touched |
 |-----------|---------------|-----------------|
-| `nx pm init` | `pm/lifecycle.py` | T2 write (4 standard docs) |
-| `nx pm resume` | `pm/lifecycle.py` | T2 computed resume from phase/blockers/activity |
-| `nx pm status` | `pm/lifecycle.py` | T2 read (phase tags, BLOCKERS.md) |
-| `nx pm phase next` | `pm/lifecycle.py` | T2 write (new phase doc) |
-| `nx pm search` | `pm/lifecycle.py` | T2 FTS5 query (tag-filtered for pm) |
-| `nx pm block/unblock` | `pm/lifecycle.py` | T2 write/update (BLOCKERS.md) |
-| `nx pm archive` | `pm/lifecycle.py` + `pm/synthesis.py` | T2 read (all docs) -> Haiku -> T3 write -> T2 update (decay) |
-| `nx pm close` | `pm/lifecycle.py` | Alias for archive --status=completed |
-| `nx pm restore` | `pm/lifecycle.py` | T2 update (reset ttl + tags) |
-| `nx pm reference` | `pm/lifecycle.py` | T3 query (knowledge__pm__* collections) |
-| `nx pm promote` | `pm/lifecycle.py` | T2 read -> T3 write (knowledge__pm__*) |
-| `nx pm expire` | `pm/lifecycle.py` | T2 delete (TTL-expired entries) |
+| `nx pm init` | `pm.py` | T2 write (4 standard docs) |
+| `nx pm resume` | `pm.py` | T2 computed resume from phase/blockers/activity |
+| `nx pm status` | `pm.py` | T2 read (phase tags, BLOCKERS.md) |
+| `nx pm phase next` | `pm.py` | T2 write (new phase doc) |
+| `nx pm search` | `pm.py` | T2 FTS5 query (tag-filtered for pm) |
+| `nx pm block/unblock` | `pm.py` | T2 write/update (BLOCKERS.md) |
+| `nx pm archive` | `pm.py` | T2 read (all docs) -> Haiku -> T3 write -> T2 update (decay) |
+| `nx pm close` | `pm.py` | Alias for archive --status=completed |
+| `nx pm restore` | `pm.py` | T2 update (reset ttl + tags) |
+| `nx pm reference` | `pm.py` | T3 query (knowledge__pm__* collections) |
+| `nx pm promote` | `pm.py` | T2 read -> T3 write (knowledge__pm__*) |
+| `nx pm expire` | `pm.py` | T2 delete (TTL-expired entries) |
 
 ---
 
 ## Cross-cutting Concerns
 
-### Session ID Management [v1-actual]
-
+### Session ID Management
 Implementation: `src/nexus/session.py`. Uses `os.getsid(0)` as the stable PID anchor
 (with `NX_SESSION_PID` env var override for testing). Session file path:
 `~/.config/nexus/sessions/{pid}.session`.
@@ -716,15 +280,11 @@ Global config: ~/.config/nexus/config.yml (lowest priority)
 
 Loaded by `config.py` with deepmerge (repo overrides global, env overrides both).
 
-### Error Hierarchy [v1-actual]
-
-Implementation: `src/nexus/errors.py`. The actual hierarchy is simpler than originally
-designed. The aspirational `StorageError`, `T2Error`, `T3Error`, `T3OfflineError`,
-`SearchError`, `ConfigError`, `SessionError`, and `SynthesisError` classes do NOT exist.
+### Error Hierarchy
+Implementation: `src/nexus/errors.py`.
 
 ```python
-# errors.py  [v1-actual]
-
+# errors.py 
 class NexusError(Exception):
     """Base exception for all Nexus errors."""
 
@@ -741,34 +301,15 @@ class CollectionNotFoundError(NexusError):
     """The requested ChromaDB collection does not exist."""
 ```
 
-The aspirational (v2-planned) hierarchy below was NOT implemented:
+### Search Engine Split
+Search responsibilities are split into focused flat modules:
 
-```python
-# errors.py  [v2-planned — NOT YET IMPLEMENTED]
-
-class StorageError(NexusError): ...      # not implemented
-class T2Error(StorageError): ...         # not implemented
-class T3Error(StorageError): ...         # not implemented
-class T3OfflineError(T3Error): ...       # not implemented
-class SearchError(NexusError): ...       # not implemented
-class ConfigError(NexusError): ...       # not implemented
-class SessionError(NexusError): ...      # not implemented
-class SynthesisError(NexusError): ...    # not implemented
-```
-
-### Search Engine Split [v1-actual]
-
-The original design described `search_engine.py` as a monolithic search module. As of
-nexus-895, the search responsibilities have been split into focused flat modules:
-
-- `src/nexus/scoring.py` — scoring primitives (min_max_normalize, frecency weighting, etc.)
+- `src/nexus/scoring.py` — scoring primitives (min_max_normalize, frecency weighting, reranking)
 - `src/nexus/answer.py` — answer synthesis (Haiku-based Q&A with `<cite>` formatting)
-- `src/nexus/formatters.py` — output formatters (plain, JSON, vimgrep, highlighted, citations)
-- `src/nexus/search_engine.py` — search orchestration only (~175 lines)
+- `src/nexus/formatters.py` — output formatters (plain, JSON, vimgrep, citations)
+- `src/nexus/search_engine.py` — search orchestration only (cross-corpus, Mixedbread fan-out, agentic search)
 
-The aspirational `search/` subpackage with separate `semantic.py`, `fulltext.py`,
-`hybrid.py`, `cross_corpus.py`, `agentic.py`, and `mxbai.py` modules [v2-planned] does
-not exist. All search orchestration remains in `search_engine.py`.
+Import from the canonical module directly (e.g., `from nexus.scoring import rerank_results`).
 
 > **Original Phased Implementation Plan**: Superseded. See [Appendix A](#appendix-a-original-phased-implementation-plan) for historical phase structure and bead IDs. Current authoritative plan: `.pm/PLAN.md`.
 

--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -8,16 +8,10 @@ from nexus.corpus import resolve_corpus
 from nexus.commands.store import _t3
 from nexus.ripgrep_cache import search_ripgrep
 from nexus.formatters import format_json, format_plain_with_context, format_vimgrep
-from nexus.search_engine import (
-    SearchResult,
-    answer_mode,
-    apply_hybrid_scoring,
-    agentic_search,
-    fetch_mxbai_results,
-    rerank_results,
-    round_robin_interleave,
-    search_cross_corpus,
-)
+from nexus.answer import answer_mode
+from nexus.scoring import apply_hybrid_scoring, rerank_results, round_robin_interleave
+from nexus.search_engine import agentic_search, fetch_mxbai_results, search_cross_corpus
+from nexus.types import SearchResult
 
 
 def _parse_where(where_pairs: tuple[str, ...]) -> dict | None:

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -65,10 +65,6 @@ class T3Database:
     def _embedding_fn(self, collection_name: str):
         if self._ef_override is not None:
             return self._ef_override
-        # Fast path: dict read without lock. Safe under CPython GIL but
-        # technically a data race in GIL-free Python (3.13+ free-threaded mode).
-        if collection_name in self._ef_cache:
-            return self._ef_cache[collection_name]
         with self._ef_lock:
             if collection_name not in self._ef_cache:
                 model = embedding_model_for_collection(collection_name)
@@ -309,15 +305,29 @@ class T3Database:
     def list_collections(self) -> list[dict]:
         """Return all T3 collections with their document counts.
 
-        Note: makes N+1 API calls (1 list + 1 count per collection).
-        Optimize if the ChromaDB CloudClient exposes batched counts.
+        Count queries are parallelized (up to 8 concurrent requests) to
+        reduce wall-clock time from O(N) sequential HTTP calls to roughly
+        O(N/8).
         """
-        result: list[dict] = []
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        names: list[str] = []
         for col_or_name in self._client.list_collections():
-            name = col_or_name if isinstance(col_or_name, str) else col_or_name.name
+            names.append(col_or_name if isinstance(col_or_name, str) else col_or_name.name)
+
+        if not names:
+            return []
+
+        def _count(name: str) -> dict:
             col = self._client.get_collection(name)
-            result.append({"name": name, "count": col.count()})
-        return result
+            return {"name": name, "count": col.count()}
+
+        result: list[dict] = []
+        with ThreadPoolExecutor(max_workers=min(8, len(names))) as pool:
+            futures = {pool.submit(_count, n): n for n in names}
+            for future in as_completed(futures):
+                result.append(future.result())
+        return sorted(result, key=lambda r: r["name"])
 
     def collection_exists(self, name: str) -> bool:
         """Return True if the collection already exists in T3 (no create side-effect)."""

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -18,9 +18,9 @@ from nexus.pdf_chunker import PDFChunker
 from nexus.pdf_extractor import PDFExtractor
 
 # Type alias for the chunking callback used by _index_document.
-# Receives (file_path, content_hash, target_model, now_iso) and returns a list
-# of (chunk_id, document_text, metadata_dict) tuples, or an empty list to skip.
-ChunkFn = Callable[[Path, str, str, str], list[tuple[str, str, dict]]]
+# Receives (file_path, content_hash, target_model, now_iso, corpus) and returns
+# a list of (chunk_id, document_text, metadata_dict) tuples, or an empty list.
+ChunkFn = Callable[[Path, str, str, str, str], list[tuple[str, str, dict]]]
 
 
 def _sha256(path: Path) -> str:
@@ -172,7 +172,7 @@ def _index_document(
             return 0
 
     now_iso = datetime.now(UTC).isoformat()
-    prepared = chunk_fn(file_path, content_hash, target_model, now_iso)
+    prepared = chunk_fn(file_path, content_hash, target_model, now_iso, corpus)
     if not prepared:
         return 0
 
@@ -205,6 +205,7 @@ def _pdf_chunks(
     content_hash: str,
     target_model: str,
     now_iso: str,
+    corpus: str,
 ) -> list[tuple[str, str, dict]]:
     """Chunk a PDF and return (id, text, metadata) tuples."""
     result = PDFExtractor().extract(pdf_path)
@@ -220,7 +221,7 @@ def _pdf_chunks(
             "source_title": "",
             "source_author": "",
             "source_date": "",
-            "corpus": "",  # filled by caller context via collection_name
+            "corpus": corpus,
             "store_type": "pdf",
             "page_count": result.metadata.get("page_count", 0),
             "page_number": chunk.metadata.get("page_number", 0),
@@ -244,6 +245,7 @@ def _markdown_chunks(
     content_hash: str,
     target_model: str,
     now_iso: str,
+    corpus: str,
 ) -> list[tuple[str, str, dict]]:
     """Chunk a Markdown file and return (id, text, metadata) tuples."""
     raw_text = md_path.read_text(encoding="utf-8")
@@ -252,7 +254,7 @@ def _markdown_chunks(
 
     base_meta: dict = {
         "source_path": str(md_path),
-        "corpus": "",  # filled by caller context via collection_name
+        "corpus": corpus,
     }
     chunks = SemanticMarkdownChunker().chunk(body, base_meta)
     if not chunks:
@@ -266,7 +268,7 @@ def _markdown_chunks(
             "source_title": str(frontmatter.get("title", "")),
             "source_author": str(frontmatter.get("author", "")),
             "source_date": str(frontmatter.get("date", "")),
-            "corpus": "",  # filled by caller context via collection_name
+            "corpus": corpus,
             "store_type": "markdown",
             "page_count": 0,
             "page_number": chunk.metadata.get("page_number", 0),
@@ -291,15 +293,7 @@ def index_pdf(pdf_path: Path, corpus: str, t3: Any = None) -> int:
     Returns the number of chunks indexed, or 0 if skipped (no credentials or
     content unchanged since last index with the same embedding model).
     """
-    def _chunk_fn(
-        path: Path, content_hash: str, target_model: str, now_iso: str
-    ) -> list[tuple[str, str, dict]]:
-        prepared = _pdf_chunks(path, content_hash, target_model, now_iso)
-        for _, _, meta in prepared:
-            meta["corpus"] = corpus
-        return prepared
-
-    return _index_document(pdf_path, corpus, _chunk_fn, t3=t3)
+    return _index_document(pdf_path, corpus, _pdf_chunks, t3=t3)
 
 
 def index_markdown(md_path: Path, corpus: str, t3: Any = None) -> int:
@@ -308,15 +302,7 @@ def index_markdown(md_path: Path, corpus: str, t3: Any = None) -> int:
     YAML frontmatter fields (title, author, date) are stored as metadata.
     Returns the number of chunks indexed, or 0 if skipped.
     """
-    def _chunk_fn(
-        path: Path, content_hash: str, target_model: str, now_iso: str
-    ) -> list[tuple[str, str, dict]]:
-        prepared = _markdown_chunks(path, content_hash, target_model, now_iso)
-        for _, _, meta in prepared:
-            meta["corpus"] = corpus
-        return prepared
-
-    return _index_document(md_path, corpus, _chunk_fn, t3=t3)
+    return _index_document(md_path, corpus, _markdown_chunks, t3=t3)
 
 
 def batch_index_pdfs(

--- a/src/nexus/ripgrep_cache.py
+++ b/src/nexus/ripgrep_cache.py
@@ -64,7 +64,7 @@ def search_ripgrep(
       - file_path (str)
       - line_number (int)
       - line_content (str)
-      - frecency_score (float, always 0.5 — cache ordering encodes frecency)
+      - frecency_score (float, position-based: 1.0 for first result, decaying toward 0)
 
     Returns [] if *cache_path* does not exist, ``rg`` is not installed, or the
     subprocess times out.
@@ -101,7 +101,7 @@ def search_ripgrep(
         _log.warning("rg exited with error", stderr=proc.stderr[:200] if proc.stderr else "")
         return []
 
-    results: list[dict] = []
+    parsed: list[dict] = []
     for raw_line in proc.stdout.splitlines():
         # Each matched line is a cache entry: /abs/path:lineno:content
         # Split on ":" with maxsplit=2 to get exactly three parts.
@@ -115,14 +115,17 @@ def search_ripgrep(
             line_number = int(lineno_str)
         except ValueError:
             continue
-        results.append({
+        parsed.append({
             "file_path": file_path_str,
             "line_number": line_number,
             "line_content": line_content,
-            # Hardcoded midpoint score. Ripgrep cache results rely on cache
-            # ordering (not this score) for relevance. If ever used for ranking
-            # against semantic search, consider computing a position-based score.
-            "frecency_score": 0.5,
         })
 
-    return results
+    # Position-based frecency: the cache file is ordered by descending
+    # frecency, so ripgrep (which scans sequentially) returns higher-frecency
+    # matches first.  Score decays from 1.0 (first hit) toward 0.0 (last).
+    n = len(parsed)
+    for i, hit in enumerate(parsed):
+        hit["frecency_score"] = 1.0 - (i / n) if n > 1 else 1.0
+
+    return parsed

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 Hal Hildebrand. All rights reserved.
-"""Search engine: cross-corpus orchestration, Mixedbread fan-out, agentic search.
-
-Scoring, answer synthesis, and output formatters have been split into focused
-sub-modules. All public names are re-exported here for backward compatibility.
-"""
+"""Search engine: cross-corpus orchestration, Mixedbread fan-out, agentic search."""
 from __future__ import annotations
 
 import hashlib
@@ -12,48 +8,12 @@ from typing import Any, Callable
 
 import structlog
 
-from nexus.types import SearchResult  # re-exported for backward compatibility
-
-# Re-exported for backward compatibility and test patching.
-# Prefer importing directly from nexus.scoring / nexus.answer.
-from nexus.scoring import (
-    min_max_normalize,
-    hybrid_score,
-    apply_hybrid_scoring,
-    rerank_results,
-    round_robin_interleave,
-    _voyage_client,
-)
-from nexus.answer import (
-    answer_mode,
-    _haiku_answer,
-    _haiku_refine,
-)
-from nexus.formatters import (
-    format_vimgrep,
-    format_json,
-    format_plain,
-    format_plain_with_context,
-)
+from nexus.answer import _haiku_refine
+from nexus.types import SearchResult
 
 _log = structlog.get_logger()
 
 __all__ = [
-    "SearchResult",
-    # scoring
-    "min_max_normalize",
-    "hybrid_score",
-    "apply_hybrid_scoring",
-    "rerank_results",
-    "round_robin_interleave",
-    # answer
-    "answer_mode",
-    # formatters
-    "format_vimgrep",
-    "format_json",
-    "format_plain",
-    "format_plain_with_context",
-    # orchestration
     "search_cross_corpus",
     "fetch_mxbai_results",
     "agentic_search",

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -143,7 +143,7 @@ def test_t3_cross_collection_search(local_t3: T3Database) -> None:
 
 def test_search_cross_corpus_end_to_end(local_t3: T3Database) -> None:
     """search_cross_corpus() retrieves and merges results from multiple corpora."""
-    from nexus.search_engine import search_cross_corpus
+    from nexus.search_engine import search_cross_corpus  # orchestration stays in search_engine
 
     uid = _uid()
     local_t3.put("knowledge__e2e", content=f"nexus architecture {uid}", title="arch.md")
@@ -162,7 +162,8 @@ def test_search_cross_corpus_end_to_end(local_t3: T3Database) -> None:
 
 def test_apply_hybrid_scoring_code_collection(local_t3: T3Database) -> None:
     """apply_hybrid_scoring applies 0.7*vector + 0.3*frecency for code__ collections."""
-    from nexus.search_engine import SearchResult, apply_hybrid_scoring
+    from nexus.scoring import apply_hybrid_scoring
+    from nexus.types import SearchResult
 
     results = [
         SearchResult(id="1", content="fn main()", distance=0.1,
@@ -177,7 +178,8 @@ def test_apply_hybrid_scoring_code_collection(local_t3: T3Database) -> None:
 
 def test_format_vimgrep(local_t3: T3Database) -> None:
     """format_vimgrep produces path:line:0:content lines."""
-    from nexus.search_engine import SearchResult, format_vimgrep
+    from nexus.formatters import format_vimgrep
+    from nexus.types import SearchResult
 
     results = [
         SearchResult(id="1", content="def foo():", distance=0.1,
@@ -193,7 +195,8 @@ def test_format_vimgrep(local_t3: T3Database) -> None:
 def test_format_json_is_valid_json(local_t3: T3Database) -> None:
     """format_json produces parseable JSON."""
     import json
-    from nexus.search_engine import SearchResult, format_json
+    from nexus.formatters import format_json
+    from nexus.types import SearchResult
 
     results = [
         SearchResult(id="a1", content="hello world", distance=0.2,
@@ -210,7 +213,8 @@ def test_format_json_is_valid_json(local_t3: T3Database) -> None:
 def test_answer_mode_returns_synthesis_with_citations() -> None:
     """answer_mode() calls Haiku and returns the synthesized text."""
     import nexus.answer as _answer_mod
-    from nexus.search_engine import SearchResult, answer_mode
+    from nexus.answer import answer_mode
+    from nexus.types import SearchResult
 
     results = [
         SearchResult(id="1", content="Nexus uses ChromaDB for storage.",

--- a/tests/test_ripgrep_cache.py
+++ b/tests/test_ripgrep_cache.py
@@ -125,7 +125,7 @@ def test_search_ripgrep_finds_matching_lines(tmp_path: Path) -> None:
     assert results[0]["file_path"] == "/repo/auth.py"
     assert results[0]["line_number"] == 42
     assert "authenticate" in results[0]["line_content"]
-    assert results[0]["frecency_score"] == pytest.approx(0.5)
+    assert results[0]["frecency_score"] == pytest.approx(1.0)
 
 
 def test_search_ripgrep_multiple_matches(tmp_path: Path) -> None:

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -7,7 +7,7 @@ import pytest
 from click.testing import CliRunner
 
 from nexus.cli import main
-from nexus.search_engine import SearchResult
+from nexus.types import SearchResult
 
 
 @pytest.fixture
@@ -340,7 +340,7 @@ def test_context_C_requires_integer(
 
 def test_format_plain_with_context_shows_correct_lines() -> None:
     """format_plain_with_context shows first line + lines_after additional lines."""
-    from nexus.search_engine import format_plain_with_context
+    from nexus.formatters import format_plain_with_context
 
     content = "\n".join(f"line{i}" for i in range(10))
     result = SearchResult(
@@ -355,7 +355,7 @@ def test_format_plain_with_context_shows_correct_lines() -> None:
 
 def test_format_plain_with_context_no_context_equals_format_plain() -> None:
     """format_plain_with_context(0) produces same output as format_plain."""
-    from nexus.search_engine import format_plain, format_plain_with_context
+    from nexus.formatters import format_plain, format_plain_with_context
 
     content = "alpha\nbeta\ngamma"
     result = SearchResult(

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -4,17 +4,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import nexus.search_engine as se_mod
-from nexus.search_engine import (
-    SearchResult,
-    answer_mode,
-    format_json,
-    format_vimgrep,
+from nexus.answer import answer_mode
+from nexus.formatters import format_json, format_vimgrep
+from nexus.scoring import (
+    apply_hybrid_scoring,
     hybrid_score,
     min_max_normalize,
     rerank_results,
     round_robin_interleave,
-    search_cross_corpus,
 )
+from nexus.search_engine import search_cross_corpus
+from nexus.types import SearchResult
 
 
 # ── AC1: Hybrid scoring ───────────────────────────────────────────────────────
@@ -61,7 +61,7 @@ def test_hybrid_no_code_corpus_warning(capsys):
         SearchResult(id="1", content="text", distance=0.1,
                      collection="docs__papers", metadata={}),
     ]
-    se_mod.apply_hybrid_scoring(results, hybrid=True)
+    apply_hybrid_scoring(results, hybrid=True)
     captured = capsys.readouterr()
     assert "no code corpus" in (captured.out + captured.err).lower()
 
@@ -74,7 +74,7 @@ def test_hybrid_mixed_corpus_no_warning(capsys):
         SearchResult(id="2", content="docs", distance=0.2,
                      collection="docs__papers", metadata={}),
     ]
-    se_mod.apply_hybrid_scoring(results, hybrid=True)
+    apply_hybrid_scoring(results, hybrid=True)
     out = capsys.readouterr()
     assert "no code corpus" not in (out.err + out.out).lower()
 
@@ -422,7 +422,7 @@ def test_haiku_answer_returns_empty_string_on_empty_content():
     _answer_mod._anthropic_instance = None
     with patch("nexus.config.get_credential", return_value="key"):
         with patch("anthropic.Anthropic", return_value=mock_client):
-            from nexus.search_engine import _haiku_answer
+            from nexus.answer import _haiku_answer
             result = _haiku_answer("what?", results)
     _answer_mod._anthropic_instance = None
 

--- a/tests/test_search_modules.py
+++ b/tests/test_search_modules.py
@@ -1,14 +1,13 @@
-"""Tests verifying the new module split: scoring.py, answer.py, formatters.py.
+"""Tests verifying the module split: scoring.py, answer.py, formatters.py, search_engine.py.
 
-These tests import directly from the new modules to confirm correct placement,
-and also verify backward-compat re-exports from nexus.search_engine.
+These tests import directly from the canonical modules to confirm correct placement.
 """
 import pytest
 
 from nexus.types import SearchResult
 
 
-# ── New module import paths ───────────────────────────────────────────────────
+# ── Canonical module import paths ────────────────────────────────────────────
 
 def test_scoring_imports():
     """All scoring functions importable from nexus.scoring."""
@@ -37,44 +36,20 @@ def test_formatters_imports():
 
 
 def test_search_engine_orchestration_imports():
-    """Orchestration functions still importable from nexus.search_engine."""
-    from nexus.search_engine import search_cross_corpus  # noqa: F401
-
-
-# ── Backward-compat re-exports from nexus.search_engine ──────────────────────
-
-def test_backward_compat_scoring_reexports():
-    """Scoring functions still importable from nexus.search_engine (backward compat)."""
+    """Orchestration functions importable from nexus.search_engine."""
     from nexus.search_engine import (  # noqa: F401
-        min_max_normalize,
-        hybrid_score,
-        apply_hybrid_scoring,
-        rerank_results,
-        round_robin_interleave,
+        search_cross_corpus,
+        fetch_mxbai_results,
+        agentic_search,
     )
 
 
-def test_backward_compat_answer_reexport():
-    """answer_mode still importable from nexus.search_engine (backward compat)."""
-    from nexus.search_engine import answer_mode  # noqa: F401
+def test_search_result_from_types():
+    """SearchResult importable from nexus.types (canonical path)."""
+    from nexus.types import SearchResult  # noqa: F401
 
 
-def test_backward_compat_formatter_reexports():
-    """Formatter functions still importable from nexus.search_engine (backward compat)."""
-    from nexus.search_engine import (  # noqa: F401
-        format_vimgrep,
-        format_json,
-        format_plain,
-        format_plain_with_context,
-    )
-
-
-def test_backward_compat_search_result_reexport():
-    """SearchResult still importable from nexus.search_engine (backward compat)."""
-    from nexus.search_engine import SearchResult  # noqa: F401
-
-
-# ── Functional spot-checks on new import paths ────────────────────────────────
+# ── Functional spot-checks on canonical import paths ─────────────────────────
 
 def test_scoring_min_max_normalize_works():
     """min_max_normalize from nexus.scoring returns correct values."""
@@ -171,7 +146,7 @@ def test_no_circular_imports():
         sys.modules.update(saved_modules)
 
 
-# ── New bug-fix tests ─────────────────────────────────────────────────────────
+# ── Bug-fix tests ────────────────────────────────────────────────────────────
 
 def test_format_json_metadata_does_not_shadow_canonical_fields():
     """Metadata keys must not overwrite canonical fields (id, content, distance, collection)."""

--- a/tests/test_types_and_errors.py
+++ b/tests/test_types_and_errors.py
@@ -17,14 +17,9 @@ class TestSearchResultInTypes:
         assert r.metadata == {}
         assert r.hybrid_score == 0.0
 
-    def test_searchresult_still_importable_from_search_engine(self):
-        """Backward-compat: search_engine re-exports SearchResult."""
-        from nexus.search_engine import SearchResult  # noqa: F401
-
-    def test_types_are_identical(self):
-        from nexus.types import SearchResult as T
-        from nexus.search_engine import SearchResult as SE
-        assert T is SE
+    def test_searchresult_importable_from_types(self):
+        """SearchResult importable from nexus.types (canonical path)."""
+        from nexus.types import SearchResult  # noqa: F401
 
 
 class TestErrorHierarchy:


### PR DESCRIPTION
## Summary
- **T3 list_collections N+1**: Parallelized with ThreadPoolExecutor (up to 8 workers)
- **Ripgrep frecency hardcoded 0.5**: Replaced with position-based score `1.0 - (i/n)`
- **Corpus metadata empty in chunkers**: Pass `corpus` directly through `ChunkFn` type alias
- **ARCHITECTURE.md v2-planned bloat**: Removed ~400 lines of aspirational/unimplemented content
- **Free-threaded Python 3.13+ data race**: Removed unguarded dict read in `_embedding_fn`
- **search_engine.py re-exports**: Removed all backward-compat re-exports; all 7 consumer files updated to canonical imports

## Test plan
- [x] Full test suite passes (1110 passed, 13 skipped)
- [x] Ripgrep frecency test updated for new position-based scoring
- [x] All import paths verified against canonical modules
- [x] No `v1-actual` / `v2-planned` / `aspirational` remnants in ARCHITECTURE.md