### PR TITLE
nx plugin v0.4.0: CSO compliance, discipline skills, relay dedup

### DIFF
--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "0.3.2",
+  "version": "0.4.0-dev",
   "description": "Self-hosted semantic search, memory, and knowledge management for Claude Code agents. Indexes code repos, PDFs, and notes; searches across all of them semantically; manages persistent memory across sessions.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "0.4.0-dev",
+  "version": "0.4.0",
   "description": "Self-hosted semantic search, memory, and knowledge management for Claude Code agents. Indexes code repos, PDFs, and notes; searches across all of them semantically; manages persistent memory across sessions.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to the nx plugin are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] - 2026-02-24
+
+### Added
+- brainstorming-gate skill: design gate before implementation (S1)
+- verification-before-completion skill: evidence before claims (S2)
+- receiving-code-review skill: technical rigor for review feedback (S3)
+- using-nx-skills skill: skill invocation discipline (S4)
+- dispatching-parallel-agents skill: parallel agent coordination (O3)
+- writing-nx-skills meta-skill: plugin authorship guide (O5)
+- Graphviz flowcharts in decision-heavy skills (O2)
+- REQUIRED SUB-SKILL cross-reference markers (O4)
+- Companion reference.md for nexus skill (O6)
+- CHANGELOG.md
+- SessionStart hook for using-nx-skills injection
+
+### Changed
+- All skill descriptions rewritten to CSO "Use when [condition]" pattern (C1, C2)
+- Removed non-standard frontmatter fields from all skills (S6)
+- Removed YAML comments from description block scalars (S5)
+- Replaced inline relay templates with hybrid cross-reference to RELAY_TEMPLATE.md (O6)
+- Simplified agent-delegating commands with pre-filled relay parts (C3)
+- Added disable-model-invocation to pure-bash pm commands (O1)
+- PostToolUse hook now has matcher for bd create commands only (S7)
+- Nexus skill split into quick-ref SKILL.md + detailed reference.md
+
+### Fixed
+- PostToolUse hook performance (was firing Python on every tool use)
+
+## [0.3.2] - 2026-02-23
+
+### Added
+- RDR workflow skills (rdr-create, rdr-list, rdr-show, rdr-research, rdr-gate, rdr-close)
+- cli-controller skill with raw tmux commands

--- a/nx/README.md
+++ b/nx/README.md
@@ -35,13 +35,20 @@ nx/
 │       ├── setup.sh                  # One-time setup checks
 │       └── subagent-start.sh         # Context prep for spawned subagents
 ├── registry.yaml            # Single source of truth: agents, pipelines, aliases
+├── CHANGELOG.md            # Version history (Keep a Changelog format)
 └── skills/
+    ├── brainstorming-gate/  # Standalone: design gate before implementation
     ├── cli-controller/      # Standalone: tmux-based interactive CLI control
+    ├── dispatching-parallel-agents/ # Standalone: parallel agent coordination
     ├── nexus/               # Standalone: nx CLI reference (all tiers)
+    ├── receiving-code-review/ # Standalone: technical rigor for review feedback
+    ├── using-nx-skills/     # Standalone: skill invocation discipline
+    ├── verification-before-completion/ # Standalone: evidence before claims
+    ├── writing-nx-skills/   # Standalone: plugin authorship guide
     ├── code-review/         # → code-review-expert agent
     ├── codebase-analysis/   # → codebase-deep-analyzer agent
     ├── deep-analysis/       # → deep-analyst agent
-    ├── substantive-critique/       # → substantive-critic agent
+    ├── substantive-critique/# → substantive-critic agent
     ├── java-architecture/   # → java-architect-planner agent
     ├── java-debugging/      # → java-debugger agent
     ├── java-development/    # → java-developer agent
@@ -54,6 +61,21 @@ nx/
     ├── strategic-planning/  # → strategic-planner agent
     └── test-validation/     # → test-validator agent
 ```
+
+## Standalone Skills (8)
+
+Skills that provide guidance directly without delegating to an agent.
+
+| Skill | Purpose |
+|-------|---------|
+| brainstorming-gate | Design gate — requires exploration and user approval before implementation |
+| cli-controller | Expert guidance for controlling interactive CLI applications via tmux |
+| dispatching-parallel-agents | Parallel agent dispatch for independent problem domains |
+| nexus | Nexus CLI reference for all tiers (T1/T2/T3) |
+| receiving-code-review | Technical rigor for code review feedback — verify before implementing |
+| using-nx-skills | Skill invocation discipline — check skills before every response |
+| verification-before-completion | Evidence before claims — requires verification before completion |
+| writing-nx-skills | Guide for authoring nx plugin skills |
 
 ## Agents (14)
 
@@ -96,6 +118,7 @@ Defined in `registry.yaml`:
 | `SessionStart` | `mcp_health_hook.sh` | Verify nx and bd are healthy |
 | `SessionStart` | `session_start_hook.py` | Load PM context, prime bead state |
 | `SessionStart` | `bd prime` | Load beads context into session |
+| `SessionStart` | `using-nx-skills/SKILL.md` | Inject skill invocation discipline |
 | `SessionEnd` | `nx hook session-end` | Flush nx session state |
 | `PreCompact` | `bd prime` | Re-prime bead context after compact |
 | `SubagentStart` | `subagent-start.sh` | Inject context for spawned subagents |
@@ -126,7 +149,9 @@ Defined in `registry.yaml`:
 
 ### Agent Relay Format
 
-All agent handoffs use the relay template from `agents/_shared/RELAY_TEMPLATE.md`:
+All agent-delegating skills use a hybrid cross-reference pattern: each skill contains the agent name and deliverable inline, with optional fields deferred to `agents/_shared/RELAY_TEMPLATE.md`. This avoids duplication while keeping essential context in each skill.
+
+Full relay template from `agents/_shared/RELAY_TEMPLATE.md`:
 
 ```markdown
 ## Relay: {agent-name}

--- a/nx/commands/analyze-code.md
+++ b/nx/commands/analyze-code.md
@@ -72,31 +72,31 @@ description: Analyze codebase using codebase-deep-analyzer agent
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to codebase-deep-analyzer:
+Invoke the **codebase-analysis** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: codebase-deep-analyzer
 
-**Task**: Analyze codebase to understand architecture and patterns
-**Bead**: [Create analysis bead if multi-session or 'none']
+**Task**: Analyze codebase architecture, patterns, and dependencies
+**Bead**: [fill from active bead above or 'none']
 
 ### Input Artifacts
-- nx store: [Search for existing architecture docs]
-- nx memory: [project/title path or 'none']
-- Files: [Key entry points from structure above]
+- Files: [fill from key entry points in project structure above]
 
 ### Analysis Scope
 $ARGUMENTS
 
 ### Deliverable
-Comprehensive architecture analysis document
+Comprehensive architecture analysis: module structure map, identified design patterns, dependency graph, entry points, coding conventions, and technical debt assessment.
 
 ### Quality Criteria
-- [ ] Module structure mapped
-- [ ] Key patterns identified
-- [ ] Dependencies documented
-- [ ] Entry points identified
-- [ ] Conventions noted
+- [ ] Module structure mapped with responsibilities
+- [ ] Key design patterns identified and documented
+- [ ] Dependencies documented (internal and external)
+- [ ] Entry points identified for each module
+- [ ] Coding conventions and idioms noted
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/create-plan.md
+++ b/nx/commands/create-plan.md
@@ -64,33 +64,33 @@ description: Create implementation plan using strategic-planner agent
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to strategic-planner:
+Invoke the **strategic-planning** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: strategic-planner
 
 **Task**: Create comprehensive implementation plan for: $ARGUMENTS
-**Bead**: [Create epic bead for this work]
+**Bead**: [fill from active epic bead above or create new]
 
 ### Input Artifacts
-- nx store: [Search for prior architectural decisions]
-- nx memory: [project/title path or 'none']
-- Files: [Relevant existing code for context]
+- Files: [fill from relevant existing code for context]
 
 ### Requirements
 $ARGUMENTS
 
 ### Deliverable
-Phased execution plan with beads for tracking
+Phased execution plan with dependency graph, success criteria per phase, test strategy, and beads created for all trackable items.
 
 ### Quality Criteria
-- [ ] Work broken into logical phases
-- [ ] Dependencies clearly identified
-- [ ] Success criteria defined per phase
-- [ ] Test strategy included
+- [ ] Work broken into logical phases with clear boundaries
+- [ ] Dependencies identified and ordered correctly
+- [ ] Success criteria defined per phase (measurable)
+- [ ] Test strategy included for each phase
 - [ ] Beads created for all trackable items
 
 **IMPORTANT**: After planning completes, MUST delegate to plan-auditor for validation before implementation.
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/deep-analysis.md
+++ b/nx/commands/deep-analysis.md
@@ -60,33 +60,33 @@ description: Thorough analysis of complex problems using deep-analyst agent
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to deep-analyst:
+Invoke the **deep-analysis** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: deep-analyst
 
 **Task**: Investigate "$ARGUMENTS" using hypothesis-driven sequential analysis
-**Bead**: [Create investigation bead if significant or 'none']
+**Bead**: [fill from active bead above or 'none']
 
 ### Input Artifacts
-- nx store: [Search for prior analysis on this component/topic]
-- nx memory: [project/title path or 'none']
-- Files: [Key files related to the problem]
+- Files: [fill from key files related to the problem]
 
 ### Problem Statement
 $ARGUMENTS
 
 ### Deliverable
-Root cause analysis with evidence-backed conclusions and actionable recommendations
+Root cause analysis with hypothesis chain, evidence inventory, confidence-rated conclusions, and prioritized actionable recommendations.
 
 ### Quality Criteria
-- [ ] Multiple hypotheses explored before concluding
+- [ ] Multiple hypotheses explored and eliminated before concluding
 - [ ] Evidence gathered from code, logs, and metrics
-- [ ] Root cause identified with confidence rating
-- [ ] Conclusions supported by specific evidence
-- [ ] Recommendations are actionable and prioritized
+- [ ] Root cause identified with confidence rating (high/medium/low)
+- [ ] Each conclusion supported by specific cited evidence
+- [ ] Recommendations are actionable and prioritized by impact
 
 **IMPORTANT**: After analysis completes, persist findings to nx store using knowledge-tidier.
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/java-architecture.md
+++ b/nx/commands/java-architecture.md
@@ -81,35 +81,35 @@ description: Design Java architecture and create phased execution plans using ja
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to java-architect-planner:
+Invoke the **java-architecture** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: java-architect-planner
 
 **Task**: Design Java architecture for: $ARGUMENTS
-**Bead**: [From active epics/features above or create new]
+**Bead**: [fill from active epic/feature bead above or create new]
 
 ### Input Artifacts
-- nx store: [Search for prior architectural decisions on related components]
-- nx memory: [project/title path or 'none']
-- Files: [Key existing source files for context]
+- Files: [fill from key existing source files for context]
 
 ### Requirements
 $ARGUMENTS
 
 ### Deliverable
-Comprehensive Java architecture design with component boundaries, interfaces, phased execution plan, and risk assessment
+Comprehensive Java architecture design with component boundaries, interface contracts, dependency graph, phased execution plan with beads, and risk assessment with mitigations.
 
 ### Quality Criteria
 - [ ] All requirements addressed in design
-- [ ] Component boundaries clearly defined with interfaces specified
+- [ ] Component boundaries clearly defined with interface contracts
 - [ ] Integration points with existing code identified
-- [ ] Phased execution plan created with beads
+- [ ] Phased execution plan created with beads and dependencies
 - [ ] Risks identified with concrete mitigations
-- [ ] Design conforms to Java 24 patterns (var, modern concurrency)
+- [ ] Design conforms to Java 24 patterns (var, modern concurrency, no synchronized)
 - [ ] Ready for plan-auditor validation
 
 **IMPORTANT**: After architecture is designed, MUST delegate to plan-auditor for validation before implementation begins.
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/java-debug.md
+++ b/nx/commands/java-debug.md
@@ -79,32 +79,32 @@ description: Debug test failures using java-debugger agent
   fi
 }
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to java-debugger:
+Invoke the **java-debugging** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: java-debugger
 
 **Task**: Investigate failure using hypothesis-driven debugging
-**Bead**: [From active beads above or create bug bead]
+**Bead**: [fill from active bead above or create bug bead]
 
 ### Input Artifacts
-- nx store: [Search for prior debugging on similar issues]
-- nx memory: [project/title path or 'none']
-- Files: [Relevant source and test files]
+- Files: [fill from relevant source and test files]
 
 ### Context
-- Error message: [From test output above]
-- Stack trace: [Key frames]
-- Failed attempts: [What was already tried]
+- Error message: [fill from test output above]
+- Stack trace: [fill key frames from surefire reports]
+- Failed attempts: [fill what was already tried, or 'first attempt']
 
 ### Deliverable
-Root cause analysis with proposed fix
+Root cause analysis with hypothesis chain, supporting evidence, proposed fix, and regression test recommendation.
 
 ### Quality Criteria
-- [ ] Root cause definitively identified
-- [ ] Evidence supports conclusion
+- [ ] Root cause definitively identified with evidence
+- [ ] Hypothesis chain documented (explored and eliminated alternatives)
 - [ ] Fix addresses root cause (not symptoms)
-- [ ] Regression prevention addressed
+- [ ] Regression test recommended to prevent recurrence
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/java-implement.md
+++ b/nx/commands/java-implement.md
@@ -72,37 +72,37 @@ description: Implement feature using java-developer agent
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
 **PREREQUISITE**: Plan must be validated by plan-auditor before implementation.
 
-Use the **Task tool** to delegate to java-developer:
+Invoke the **java-development** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: java-developer
 
 **Task**: Implement "$ARGUMENTS" using TDD methodology
-**Bead**: [Task bead from active work - must be in_progress]
+**Bead**: [fill from active in_progress bead above]
 
 ### Input Artifacts
-- nx store: [Search for relevant patterns]
-- nx memory: [project/title path or 'none']
-- Files: [Existing files to modify or create location]
+- Files: [fill from existing files to modify or target package]
 
 ### Plan Context
-[Reference approved plan from plan-auditor]
+[fill from approved plan-auditor output]
 
 ### Requirements
 $ARGUMENTS
 
 ### Deliverable
-Working implementation with tests
+Working implementation with passing tests, following TDD red-green-refactor cycle. Code uses Java 24 patterns (var, modern concurrency, no synchronized).
 
 ### Quality Criteria
-- [ ] Tests written first (TDD)
-- [ ] All tests pass
-- [ ] Code follows project conventions
-- [ ] No regressions introduced
+- [ ] Tests written before implementation (TDD)
+- [ ] All tests pass (./mvnw test)
+- [ ] Code follows project conventions (Java 24, FP32-only for neural nets)
+- [ ] No regressions introduced in existing tests
 
 **IMPORTANT**: After implementation completes, MUST delegate to code-review-expert for quality review.
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/knowledge-tidy.md
+++ b/nx/commands/knowledge-tidy.md
@@ -64,31 +64,31 @@ description: Persist and organize knowledge into nx store using knowledge-tidier
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to knowledge-tidier:
+Invoke the **knowledge-tidying** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: knowledge-tidier
 
 **Task**: Organize and persist knowledge about "$ARGUMENTS" into nx store (T3)
-**Bead**: [From recently completed beads above or 'none']
+**Bead**: [fill from recently completed bead above or 'none']
 
 ### Input Artifacts
-- nx store: [Search for existing entries on this topic to avoid contradictions]
-- nx memory: [project/title path or 'none']
-- Files: [Source files or documents containing findings]
+- Files: [fill from source files or documents containing findings]
 
 ### Knowledge to Organize
 $ARGUMENTS
 
 ### Deliverable
-Knowledge persisted to nx store T3 with correct titles, tags, and verified searchability
+Knowledge persisted to nx store T3 with correct title convention, meaningful tags, contradiction check against existing entries, and verified searchability.
 
 ### Quality Criteria
 - [ ] Knowledge stored via `nx store put --collection knowledge`
 - [ ] No contradictions with existing entries (checked and resolved)
 - [ ] Title follows naming convention (research-*, decision-*, pattern-*, debug-*)
-- [ ] Tags are meaningful for future retrieval
-- [ ] Searchable — verified with `nx search "topic" --corpus knowledge`
+- [ ] Tags are meaningful and consistent with existing tag vocabulary
+- [ ] Searchable -- verified with `nx search "topic" --corpus knowledge`
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/orchestrate.md
+++ b/nx/commands/orchestrate.md
@@ -63,31 +63,30 @@ description: Route request to appropriate agent using orchestrator
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to orchestrator:
+Invoke the **orchestration** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: orchestrator
 
 **Task**: Analyze "$ARGUMENTS" and recommend the appropriate agent(s) and workflow
-**Bead**: [Create bead if this initiates trackable work or 'none']
+**Bead**: [fill from active bead above or 'none']
 
 ### Input Artifacts
-- nx store: [Search for prior work on related topic]
-- nx memory: [project/title path or 'none']
-- Files: [Relevant files if applicable]
+- Files: [fill from relevant files if applicable, or 'none']
 
 ### User Request
 $ARGUMENTS
 
 ### Deliverable
-Clear recommendation of which agent(s) to use, in what order, with rationale and a ready-to-use relay message
+Routing recommendation: identified agent(s), execution order (sequential/parallel), rationale for selection, and a ready-to-use relay message for the first agent in the workflow.
 
 ### Quality Criteria
-- [ ] User goal clearly understood
-- [ ] Most appropriate agent(s) identified
-- [ ] Workflow order justified (sequential vs parallel)
-- [ ] Clear rationale provided for routing decision
-- [ ] Ready-to-use relay message included for next agent
+- [ ] User goal clearly understood and restated
+- [ ] Most appropriate agent(s) identified from available roster
+- [ ] Workflow order justified (sequential vs parallel) with rationale
+- [ ] Ready-to-use relay message included for the recommended agent
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/pdf-process.md
+++ b/nx/commands/pdf-process.md
@@ -36,32 +36,32 @@ description: Index PDF files into nx store for semantic search using pdf-chromad
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to pdf-chromadb-processor:
+Invoke the **pdf-processing** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: pdf-chromadb-processor
 
 **Task**: Index "$ARGUMENTS" into nx store T3 for semantic search
-**Bead**: [Create bead if processing significant documentation set or 'none']
+**Bead**: [fill from active bead above or 'none']
 
 ### Input Artifacts
-- nx store: [Check for existing indexed versions of these PDFs]
-- nx memory: [project/title path or 'none']
-- Files: [PDF file paths from above]
+- Files: [fill from PDF file paths listed above]
 
 ### PDFs to Index
 $ARGUMENTS
 
 ### Deliverable
-All specified PDFs indexed in nx store with extracted text, metadata preserved, and verified searchability
+All specified PDFs extracted, chunked, and indexed in nx store T3 with metadata preserved (title, author, date) and searchability verified via `nx search` sample queries.
 
 ### Quality Criteria
 - [ ] All PDFs processed without errors
 - [ ] Text properly extracted with layout preserved
 - [ ] Content chunked appropriately for semantic search
-- [ ] Metadata (title, author, date) preserved
-- [ ] Documents searchable — verified with `nx search` sample queries
+- [ ] Metadata (title, author, date) preserved in document records
+- [ ] Documents searchable -- verified with `nx search` sample queries
 - [ ] Collection name follows convention (docs__corpus-name)
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/plan-audit.md
+++ b/nx/commands/plan-audit.md
@@ -48,33 +48,33 @@ description: Audit a plan using plan-auditor agent
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to plan-auditor:
+Invoke the **plan-validation** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: plan-auditor
 
 **Task**: Validate implementation plan before execution
-**Bead**: [Epic bead ID from context]
+**Bead**: [fill from epic bead above or 'none']
 
 ### Input Artifacts
-- nx store: [Search for architectural constraints]
-- nx memory: [project/title path or 'none']
-- Files: [Key files referenced in plan]
+- Files: [fill from key files referenced in plan]
 
 ### Plan to Validate
 $ARGUMENTS
 
-[Include full plan from strategic-planner or output of: nx pm status]
+[fill from strategic-planner output or nx pm status]
 
 ### Deliverable
-Validation report with go/no-go decision
+Validation report with go/no-go decision: assumption verification results, dependency confirmation, build/test command validation, risk assessment, and clear recommendation.
 
 ### Quality Criteria
-- [ ] All assumptions verified against codebase
-- [ ] Dependencies confirmed to exist
-- [ ] Build/test commands validated
-- [ ] Risks identified and acceptable
-- [ ] Clear go/no-go recommendation
+- [ ] All assumptions verified against actual codebase state
+- [ ] Dependencies confirmed to exist (classes, APIs, libraries)
+- [ ] Build/test commands validated (runnable as specified)
+- [ ] Risks identified with severity and mitigation status
+- [ ] Clear go/no-go recommendation with rationale
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/pm-archive.md
+++ b/nx/commands/pm-archive.md
@@ -1,5 +1,6 @@
 ---
 description: Archive active project (synthesize to T3, start T2 90-day decay) (project)
+disable-model-invocation: true
 ---
 
 !{

--- a/nx/commands/pm-close.md
+++ b/nx/commands/pm-close.md
@@ -1,5 +1,6 @@
 ---
 description: Mark project complete, archive, and close (project)
+disable-model-invocation: true
 ---
 
 !{

--- a/nx/commands/pm-list.md
+++ b/nx/commands/pm-list.md
@@ -1,5 +1,6 @@
 ---
 description: List current and archived PM projects (project)
+disable-model-invocation: true
 ---
 
 !{

--- a/nx/commands/pm-new.md
+++ b/nx/commands/pm-new.md
@@ -1,5 +1,6 @@
 ---
 description: Initialize project management for current repo via nx pm (project)
+disable-model-invocation: true
 ---
 
 !{

--- a/nx/commands/pm-restore.md
+++ b/nx/commands/pm-restore.md
@@ -1,5 +1,6 @@
 ---
 description: Restore an archived project within its 90-day decay window (project)
+disable-model-invocation: true
 ---
 
 !{

--- a/nx/commands/pm-status.md
+++ b/nx/commands/pm-status.md
@@ -1,5 +1,6 @@
 ---
 description: Show current project status via nx pm (project)
+disable-model-invocation: true
 ---
 
 !{

--- a/nx/commands/project-setup.md
+++ b/nx/commands/project-setup.md
@@ -49,29 +49,27 @@ description: Create PM infrastructure for multi-week projects using project-mana
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to project-management-setup:
+Invoke the **project-setup** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: project-management-setup
 
 **Task**: Create PM infrastructure for "$ARGUMENTS"
-**Bead**: [Create epic bead for this project]
+**Bead**: [fill from active epic bead above or create new]
 
 ### Input Artifacts
-- nx store: [Search for prior architectural decisions or related research]
-- nx memory: [project/title path or 'none']
-- Files: [Existing specs, READMEs, or planning docs]
+- Files: [fill from existing specs, READMEs, or planning docs]
 
 ### Project Description
 $ARGUMENTS
 
 ### Deliverable
-Complete PM infrastructure: nx pm initialized, T2 documents created (overview, continuation, phase docs), epic and phase beads created with dependencies
+Complete PM infrastructure: `nx pm init` run, T2 documents created (overview, continuation, at least one phase doc), epic and phase beads created with inter-phase dependencies, `nx pm status` verified working.
 
 ### Quality Criteria
-- [ ] `nx pm init` completed; `nx pm status` returns project info
+- [ ] `nx pm init` completed successfully
 - [ ] T2 documents created: overview, continuation, at least one phase doc
 - [ ] `nx pm status` returns actionable project context
 - [ ] Epic bead created for the overall project
@@ -80,3 +78,5 @@ Complete PM infrastructure: nx pm initialized, T2 documents created (overview, c
 
 **IMPORTANT**: After setup completes, run `nx pm status` to verify the infrastructure loads correctly.
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/research.md
+++ b/nx/commands/research.md
@@ -52,33 +52,33 @@ description: Research topic using deep-research-synthesizer agent
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to deep-research-synthesizer:
+Invoke the **research-synthesis** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: deep-research-synthesizer
 
 **Task**: Research "$ARGUMENTS" across all available sources
-**Bead**: [Create research bead if significant topic or 'none']
+**Bead**: [fill from active bead above or 'none']
 
 ### Input Artifacts
-- nx store: [Search for existing knowledge on topic]
-- nx memory: [project/title path or 'none']
-- Files: [Relevant code if applicable]
+- Files: [fill from relevant code if applicable, or 'none']
 
 ### Research Question
 $ARGUMENTS
 
 ### Deliverable
-Comprehensive research synthesis with actionable recommendations
+Comprehensive research synthesis that integrates findings from nx store, web, and codebase. Includes executive summary, detailed findings with source citations, contradiction resolution, and prioritized actionable recommendations.
 
 ### Quality Criteria
-- [ ] All sources consulted (nx store, web, code)
-- [ ] Findings synthesized (not just listed)
-- [ ] Contradictions resolved
-- [ ] Actionable recommendations provided
-- [ ] Sources cited
+- [ ] All available sources consulted (nx store, web, codebase)
+- [ ] Findings synthesized into coherent narrative (not just listed)
+- [ ] Contradictions between sources identified and resolved
+- [ ] Actionable recommendations provided with confidence levels
+- [ ] All claims cite their source
 
 **IMPORTANT**: After research completes, MUST delegate to knowledge-tidier to persist findings to nx store.
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/review-code.md
+++ b/nx/commands/review-code.md
@@ -74,30 +74,29 @@ description: Review code changes using code-review-expert agent
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to code-review-expert:
+Invoke the **code-review** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: code-review-expert
 
-**Task**: Review recent code changes for quality, security, and best practices
-**Bead**: [From active beads above or 'none']
+**Task**: Review the code changes for quality, security, and best practices
+**Bead**: [fill from active bead above or 'none']
 
 ### Input Artifacts
-- nx store: [Search for prior reviews on these files]
-- nx memory: [project/title path or 'none']
-- Files: [List from git diff above]
+- Files: [fill from modified files list above]
 
 ### Deliverable
-Structured code review with findings categorized by severity
+Structured code review with severity-rated findings, grouped by category (correctness, security, maintainability, performance).
 
 ### Quality Criteria
-- [ ] All changed files analyzed
-- [ ] Security vulnerabilities flagged
-- [ ] Best practices validated
-- [ ] Specific remediation guidance provided
+- [ ] All changed files reviewed
+- [ ] Findings categorized by severity (critical, important, suggestion)
+- [ ] Actionable fix recommendations for each finding
 
 ### Focus Areas
 $ARGUMENTS
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/substantive-critique.md
+++ b/nx/commands/substantive-critique.md
@@ -67,32 +67,32 @@ description: Constructive critique of code, plans, designs, or documentation usi
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to substantive-critic:
+Invoke the **substantive-critique** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: substantive-critic
 
 **Task**: Provide deep constructive critique of: $ARGUMENTS
-**Bead**: [From active beads above or 'none']
+**Bead**: [fill from active bead above or 'none']
 
 ### Input Artifacts
-- nx store: [Search for specifications or prior decisions this artifact should conform to]
-- nx memory: [project/title path or 'none']
-- Files: [Artifact files to critique]
+- Files: [fill from artifact files to critique]
 
 ### Artifact
 $ARGUMENTS
 
 ### Deliverable
-Structured critique with findings categorized by priority (Critical/Significant/Minor) and specific actionable recommendations
+Structured critique with findings categorized by priority (Critical/Significant/Minor), each with specific actionable recommendations. Covers structure, logical consistency, completeness, and spec conformance.
 
 ### Quality Criteria
 - [ ] Context and purpose of artifact established
-- [ ] Relevant specifications and criteria identified
+- [ ] Relevant specifications and conformance criteria identified
 - [ ] Structure, logic, and completeness all analyzed
-- [ ] Findings prioritized by impact (Critical first)
-- [ ] Recommendations are specific and actionable
-- [ ] Substantive issues surfaced (not just style/surface)
+- [ ] Findings prioritized by impact (Critical > Significant > Minor)
+- [ ] Each recommendation is specific and actionable
+- [ ] Substantive issues surfaced (not just style/surface-level)
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/test-validate.md
+++ b/nx/commands/test-validate.md
@@ -79,33 +79,33 @@ description: Validate tests using test-validator agent
 
 $ARGUMENTS
 
-## Relay Instructions
+## Action
 
-Use the **Task tool** to delegate to test-validator:
+Invoke the **test-validation** skill with the following relay. Fill in dynamic fields from the context above:
 
 ```markdown
 ## Relay: test-validator
 
 **Task**: Validate test coverage and quality for recent changes
-**Bead**: [From active beads above]
+**Bead**: [fill from active bead above or 'none']
 
 ### Input Artifacts
-- nx store: [Search for test patterns]
-- nx memory: [project/title path or 'none']
-- Files: [Changed source files and their test files]
+- Files: [fill from changed source files and their test files above]
 
 ### Changes to Validate
-[List from recently modified files above]
+[fill from recently modified files list above]
 
 ### Focus Area
 $ARGUMENTS
 
 ### Deliverable
-Test coverage report with gap analysis
+Test coverage report with gap analysis: mapping of source files to test files, identified coverage gaps, assessment of test quality (meaningful vs padding), and pass/fail status.
 
 ### Quality Criteria
-- [ ] All changed code has corresponding tests
-- [ ] Tests cover happy path and edge cases
-- [ ] Tests are meaningful (not just coverage padding)
-- [ ] All tests pass
+- [ ] All changed source files mapped to corresponding test files
+- [ ] Coverage gaps identified with specific missing scenarios
+- [ ] Tests validated as meaningful (not just coverage padding)
+- [ ] All tests pass (verified by running test suite)
 ```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -19,6 +19,10 @@
     {
       "type": "command",
       "command": "bd prime"
+    },
+    {
+      "type": "command",
+      "command": "cat $CLAUDE_PLUGIN_ROOT/skills/using-nx-skills/SKILL.md"
     }
   ],
   "SessionEnd": [

--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -54,7 +54,8 @@
   "PostToolUse": [
     {
       "type": "command",
-      "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/scripts/bead_context_hook.py"
+      "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/scripts/bead_context_hook.py",
+      "matcher": "bd create"
     }
   ]
 }

--- a/nx/registry.yaml
+++ b/nx/registry.yaml
@@ -394,6 +394,45 @@ standalone_skills:
       - "managing session memory"
     tools: [Bash, Read]
 
+  brainstorming-gate:
+    description: "Design gate — requires design exploration and user approval before implementation"
+    triggers:
+      - "about to implement a feature"
+      - "building something new"
+      - "adding functionality"
+    tools: [Read, Glob, Grep, Bash]
+
+  verification-before-completion:
+    description: "Evidence before claims — requires verification commands before completion claims"
+    triggers:
+      - "about to claim work is done"
+      - "before committing"
+      - "before marking bead complete"
+    tools: [Bash, Read]
+
+  receiving-code-review:
+    description: "Technical rigor for code review feedback — verify before implementing"
+    triggers:
+      - "receiving review feedback"
+      - "code review comments"
+      - "review suggestions"
+    tools: [Read, Grep, Bash]
+
+  using-nx-skills:
+    description: "Skill invocation discipline — check skills before every response"
+    triggers:
+      - "starting any conversation"
+      - "before any action"
+    tools: []
+
+  dispatching-parallel-agents:
+    description: "Parallel agent dispatch for independent problem domains"
+    triggers:
+      - "multiple independent failures"
+      - "parallel investigation needed"
+      - "independent subsystems broken"
+    tools: [Task]
+
 # =============================================================================
 # PIPELINES
 # =============================================================================

--- a/nx/registry.yaml
+++ b/nx/registry.yaml
@@ -433,6 +433,14 @@ standalone_skills:
       - "independent subsystems broken"
     tools: [Task]
 
+  writing-nx-skills:
+    description: "Guide for authoring nx plugin skills"
+    triggers:
+      - "creating new skill"
+      - "editing skill"
+      - "plugin authorship"
+    tools: [Read, Write, Edit, Bash]
+
 # =============================================================================
 # PIPELINES
 # =============================================================================

--- a/nx/skills/brainstorming-gate/SKILL.md
+++ b/nx/skills/brainstorming-gate/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: brainstorming-gate
+description: Use when about to implement any feature, build any component, or make any behavioral change — requires design exploration and user approval before implementation
+---
+
+# Brainstorming Gate
+
+## Overview
+
+Turn ideas into designs through collaborative dialogue before writing code.
+
+**Core principle:** No implementation without an approved design. Every project, regardless of perceived simplicity.
+
+<HARD-GATE>
+Do NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.
+</HARD-GATE>
+
+## Anti-Pattern: "This Is Too Simple To Need A Design"
+
+Every project goes through this process. A utility function, a config change, a single-file script — all of them. "Simple" projects are where unexamined assumptions cause the most wasted work. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval.
+
+## Process Flow
+
+```dot
+digraph brainstorming {
+    "Explore project context" [shape=box];
+    "Ask clarifying questions" [shape=box];
+    "Propose 2-3 approaches" [shape=box];
+    "Present design" [shape=box];
+    "User approves?" [shape=diamond];
+    "Save design doc" [shape=box];
+    "Invoke strategic-planning" [shape=doublecircle];
+
+    "Explore project context" -> "Ask clarifying questions";
+    "Ask clarifying questions" -> "Propose 2-3 approaches";
+    "Propose 2-3 approaches" -> "Present design";
+    "Present design" -> "User approves?";
+    "User approves?" -> "Present design" [label="no, revise"];
+    "User approves?" -> "Save design doc" [label="yes"];
+    "Save design doc" -> "Invoke strategic-planning";
+}
+```
+
+**Terminal state: invoke strategic-planning.** Do NOT invoke java-development, java-architecture, or any other implementation skill. The ONLY next step is strategic-planning (to create the implementation plan).
+
+## Checklist
+
+1. **Explore project context** — check files, docs, recent commits, nx search for prior art
+2. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
+3. **Propose 2-3 approaches** — with trade-offs and your recommendation
+4. **Present design** — scaled to complexity, get user approval after each section
+5. **Write design doc** — save to `docs/plans/YYYY-MM-DD-<topic>-design.md`
+6. **Transition** — invoke strategic-planning skill to create implementation plan
+
+## Key Principles
+
+- **One question at a time** — do not overwhelm with multiple questions
+- **YAGNI ruthlessly** — remove unnecessary features from all designs
+- **Explore alternatives** — always propose 2-3 approaches before settling
+- **Incremental validation** — present design sections, get approval before moving on
+
+## Red Flags — STOP and Restart
+
+- About to write code without a design
+- "This is too simple for a design"
+- "I already know what to build"
+- Skipping questions because the answer seems obvious
+- Jumping to implementation after one question
+
+**All of these mean: Stop. Follow the process.**
+
+**REQUIRED SUB-SKILL:** Use nx:strategic-planning after design approval to create the implementation plan.

--- a/nx/skills/cli-controller/SKILL.md
+++ b/nx/skills/cli-controller/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: cli-controller
-standalone: true
 description: >
   Expert guidance for controlling interactive CLI applications using tmux.
   Triggers: debugging Python/Java interactively, spawning Claude Code instances,
   long-running interactive processes, web application testing with browser automation.
-# See ../../registry.yaml for standalone skill metadata
-allowed-tools: Bash, Read, Write
 ---
 
 # CLI Controller Skill

--- a/nx/skills/cli-controller/SKILL.md
+++ b/nx/skills/cli-controller/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: cli-controller
-description: >
-  Expert guidance for controlling interactive CLI applications using tmux.
-  Triggers: debugging Python/Java interactively, spawning Claude Code instances,
-  long-running interactive processes, web application testing with browser automation.
+description: Use when controlling interactive CLI applications, debugging with pdb/gdb/jshell, spawning Claude Code instances, or working with REPLs and long-running processes
 ---
 
 # CLI Controller Skill

--- a/nx/skills/code-review/SKILL.md
+++ b/nx/skills/code-review/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: code-review
-description: >
-  Review code for quality, security, and best practices. Triggers when:
-  completing feature implementation, fixing bugs, refactoring code,
-  after git commit, before pull request, when code quality check is needed.
+description: Use when code changes are ready for quality, security, or best practices review, before committing or creating a pull request
 ---
 
 # Code Review Skill

--- a/nx/skills/code-review/SKILL.md
+++ b/nx/skills/code-review/SKILL.md
@@ -17,35 +17,27 @@ Delegates to the **code-review-expert** agent (model: sonnet).
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **code-review-expert**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: code-review-expert
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Structured code review with severity-rated findings
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] All changed files analyzed
+- [ ] Security vulnerabilities flagged
+- [ ] Specific remediation guidance provided
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Review Methodology
 

--- a/nx/skills/code-review/SKILL.md
+++ b/nx/skills/code-review/SKILL.md
@@ -4,9 +4,6 @@ description: >
   Review code for quality, security, and best practices. Triggers when:
   completing feature implementation, fixing bugs, refactoring code,
   after git commit, before pull request, when code quality check is needed.
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash
-memory: user
 ---
 
 # Code Review Skill

--- a/nx/skills/code-review/SKILL.md
+++ b/nx/skills/code-review/SKILL.md
@@ -15,6 +15,24 @@ Delegates to the **code-review-expert** agent (model: sonnet).
 - Before creating a pull request
 - When code quality, security, or best practices review is needed
 
+```dot
+digraph review_flow {
+    "Code changes ready?" [shape=diamond];
+    "Run tests first" [shape=box];
+    "Invoke code-review-expert" [shape=box];
+    "Critical findings?" [shape=diamond];
+    "Fix and re-review" [shape=box];
+    "Invoke test-validator" [shape=doublecircle];
+
+    "Code changes ready?" -> "Run tests first" [label="yes"];
+    "Run tests first" -> "Invoke code-review-expert";
+    "Invoke code-review-expert" -> "Critical findings?";
+    "Critical findings?" -> "Fix and re-review" [label="yes"];
+    "Critical findings?" -> "Invoke test-validator" [label="no"];
+    "Fix and re-review" -> "Invoke code-review-expert";
+}
+```
+
 ## Agent Invocation
 
 Use the Task tool to invoke **code-review-expert**:
@@ -46,6 +64,8 @@ The code-review-expert agent uses hypothesis-driven review:
 2. Gather evidence from code structure, naming, patterns
 3. Validate against best practices and security requirements
 4. Document findings with file:line references
+
+**REQUIRED BACKGROUND:** Understand nx:receiving-code-review for how to handle the review output.
 
 ## Agent-Specific PRODUCE
 

--- a/nx/skills/codebase-analysis/SKILL.md
+++ b/nx/skills/codebase-analysis/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: codebase-analysis
-description: >
-  Analyze codebase structure, patterns, and architecture. Triggers when:
-  exploring new codebase, onboarding to project, asking "how does X work",
-  "where is Y defined", before major refactoring, or understanding module structure.
+description: Use when exploring an unfamiliar codebase, onboarding to a project, or needing to understand module structure before making changes
 ---
 
 # Codebase Analysis Skill

--- a/nx/skills/codebase-analysis/SKILL.md
+++ b/nx/skills/codebase-analysis/SKILL.md
@@ -4,10 +4,6 @@ description: >
   Analyze codebase structure, patterns, and architecture. Triggers when:
   exploring new codebase, onboarding to project, asking "how does X work",
   "where is Y defined", before major refactoring, or understanding module structure.
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash
-memory: project
-context: fork
 ---
 
 # Codebase Analysis Skill

--- a/nx/skills/codebase-analysis/SKILL.md
+++ b/nx/skills/codebase-analysis/SKILL.md
@@ -18,35 +18,27 @@ Delegates to the **codebase-deep-analyzer** agent (model: sonnet).
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **codebase-deep-analyzer**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: codebase-deep-analyzer
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Architecture analysis with patterns and dependencies
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] Architecture overview documented
+- [ ] Key patterns identified and explained
+- [ ] Dependency relationships mapped
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Analysis Methodology
 

--- a/nx/skills/deep-analysis/SKILL.md
+++ b/nx/skills/deep-analysis/SKILL.md
@@ -4,10 +4,6 @@ description: >
   Thorough analysis of complex problems and intricate system relationships. Triggers when:
   investigating performance mysteries, debugging multi-component interactions,
   understanding complex system behavior, or when surface-level analysis is insufficient.
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash
-memory: local
-context: fork
 ---
 
 # Deep Analysis Skill

--- a/nx/skills/deep-analysis/SKILL.md
+++ b/nx/skills/deep-analysis/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: deep-analysis
-description: >
-  Thorough analysis of complex problems and intricate system relationships. Triggers when:
-  investigating performance mysteries, debugging multi-component interactions,
-  understanding complex system behavior, or when surface-level analysis is insufficient.
+description: Use when surface-level analysis is insufficient and problems require hypothesis-driven investigation across multiple system components
 ---
 
 # Deep Analysis Skill

--- a/nx/skills/deep-analysis/SKILL.md
+++ b/nx/skills/deep-analysis/SKILL.md
@@ -18,35 +18,27 @@ Delegates to the **deep-analyst** agent (model: opus).
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **deep-analyst**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: deep-analyst
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Analysis report with findings and recommendations
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] Multiple hypotheses explored
+- [ ] Root cause(s) identified with confidence
+- [ ] Recommendations are actionable
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Investigation Methodology
 

--- a/nx/skills/dispatching-parallel-agents/SKILL.md
+++ b/nx/skills/dispatching-parallel-agents/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: dispatching-parallel-agents
+description: Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies
+---
+
+# Dispatching Parallel Agents
+
+## Overview
+
+When you have multiple independent problems (different test files, different subsystems, different bugs), investigating them sequentially wastes time. Each investigation is independent and can happen in parallel.
+
+**Core principle:** Dispatch one agent per independent problem domain. Let them work concurrently.
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Multiple tasks?" [shape=diamond];
+    "Are they independent?" [shape=diamond];
+    "Single agent handles all" [shape=box];
+    "Can they run in parallel?" [shape=diamond];
+    "Sequential agents" [shape=box];
+    "Parallel dispatch" [shape=box];
+
+    "Multiple tasks?" -> "Are they independent?" [label="yes"];
+    "Multiple tasks?" -> "Single agent handles all" [label="no"];
+    "Are they independent?" -> "Can they run in parallel?" [label="yes"];
+    "Are they independent?" -> "Single agent handles all" [label="no - related"];
+    "Can they run in parallel?" -> "Parallel dispatch" [label="yes"];
+    "Can they run in parallel?" -> "Sequential agents" [label="no - shared state"];
+}
+```
+
+**Use when:**
+- 2+ independent tasks with different root causes
+- Multiple subsystems broken independently
+- Each problem can be understood without context from others
+- No shared state between investigations
+
+**Do not use when:**
+- Tasks are related (fix one might fix others)
+- Need to understand full system state first
+- Agents would edit the same files
+
+## The Pattern
+
+### 1. Identify Independent Domains
+
+Group work by what is independent:
+- Different test files with different failures
+- Different modules with separate concerns
+- Independent research questions
+
+### 2. Compose Focused Agent Tasks
+
+Each agent gets:
+- **Specific scope:** One problem domain
+- **Clear goal:** What success looks like
+- **Constraints:** What NOT to change
+- **Expected output:** Summary format
+
+Use the relay format from [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md) for each agent.
+
+### 3. Dispatch in Parallel
+
+```python
+# Use Task tool with multiple concurrent calls
+Task("Fix auth module tests — scope: tests/auth/")
+Task("Fix search module tests — scope: tests/search/")
+Task("Fix indexing module tests — scope: tests/indexing/")
+# All three run concurrently
+```
+
+### 4. Review and Integrate
+
+When agents return:
+1. Read each summary
+2. Verify fixes do not conflict
+3. Run full test suite
+4. Integrate all changes
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Scope too broad ("fix all tests") | One domain per agent |
+| No context in prompt | Include error messages, file paths |
+| No constraints | Specify what NOT to change |
+| Vague output expectations | Ask for summary of root cause and changes |
+| Trusting agent reports blindly | Always verify — see nx:verification-before-completion |
+
+## When NOT to Use
+
+- **Related failures:** Fix one might fix others — investigate together first
+- **Exploratory debugging:** You do not know what is broken yet
+- **Shared state:** Agents would interfere (editing same files, using same resources)

--- a/nx/skills/java-architecture/SKILL.md
+++ b/nx/skills/java-architecture/SKILL.md
@@ -4,9 +4,6 @@ description: >
   Design comprehensive Java architecture and create phased execution plans. Triggers when:
   starting complex features requiring architectural design, planning multi-phase implementations,
   before major refactoring, or when system design decisions are needed.
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash, LSP
-memory: project
 ---
 
 # Java Architecture Skill

--- a/nx/skills/java-architecture/SKILL.md
+++ b/nx/skills/java-architecture/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: java-architecture
-description: >
-  Design comprehensive Java architecture and create phased execution plans. Triggers when:
-  starting complex features requiring architectural design, planning multi-phase implementations,
-  before major refactoring, or when system design decisions are needed.
+description: Use when complex Java features need architectural design before implementation, or when system design decisions span multiple modules
 ---
 
 # Java Architecture Skill

--- a/nx/skills/java-architecture/SKILL.md
+++ b/nx/skills/java-architecture/SKILL.md
@@ -44,35 +44,27 @@ strategic-planner -> plan-auditor -> java-architect-planner -> java-developer
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **java-architect-planner**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: java-architect-planner
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Architecture design with phased execution plan
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] Component boundaries clearly defined
+- [ ] Interfaces specified
+- [ ] Execution plan with phases created
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Architecture Methodology
 

--- a/nx/skills/java-debugging/SKILL.md
+++ b/nx/skills/java-debugging/SKILL.md
@@ -39,35 +39,27 @@ Delegates to the **java-debugger** agent (model: opus).
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **java-debugger**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: java-debugger
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Root cause analysis with fix recommendation
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] Root cause definitively identified with evidence
+- [ ] Fix proposed and validated
+- [ ] Hypothesis chain preserved
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Debugging Methodology
 

--- a/nx/skills/java-debugging/SKILL.md
+++ b/nx/skills/java-debugging/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: java-debugging
-description: >
-  Debug Java failures using hypothesis-driven investigation. Triggers when:
-  test fails, NullPointerException, ClassCastException, ConcurrentModificationException,
-  after 2+ failed fix attempts, non-deterministic behavior, or stack trace analysis needed.
+description: Use when Java tests fail, exceptions occur, or behavior is non-deterministic, especially after 2+ failed manual fix attempts
 ---
 
 # Java Debugging Skill

--- a/nx/skills/java-debugging/SKILL.md
+++ b/nx/skills/java-debugging/SKILL.md
@@ -4,9 +4,6 @@ description: >
   Debug Java failures using hypothesis-driven investigation. Triggers when:
   test fails, NullPointerException, ClassCastException, ConcurrentModificationException,
   after 2+ failed fix attempts, non-deterministic behavior, or stack trace analysis needed.
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash, LSP
-memory: project
 ---
 
 # Java Debugging Skill

--- a/nx/skills/java-development/SKILL.md
+++ b/nx/skills/java-development/SKILL.md
@@ -69,6 +69,9 @@ The java-developer agent follows test-driven development:
 4. Repeat for each requirement
 5. Ensure all existing tests still pass
 
+**REQUIRED SUB-SKILL:** Use nx:verification-before-completion before claiming any task is done.
+**REQUIRED SUB-SKILL:** Use nx:code-review after implementation for quality review.
+
 ## Java 24 Standards
 
 - `var` for local variables where appropriate

--- a/nx/skills/java-development/SKILL.md
+++ b/nx/skills/java-development/SKILL.md
@@ -38,35 +38,27 @@ Delegates to the **java-developer** agent (sonnet). See [registry.yaml](../../re
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **java-developer**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: java-developer
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Working implementation with tests
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] All tests written and passing (TDD)
+- [ ] Code follows project conventions
+- [ ] No regressions in existing tests
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## TDD Methodology
 

--- a/nx/skills/java-development/SKILL.md
+++ b/nx/skills/java-development/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: java-development
-description: >
-  Implement Java features using TDD methodology. Triggers: plan approved,
-  user says "implement", bead in_progress for implementation, executing plan phase.
+description: Use when a plan has been approved and Java implementation work is ready to begin, before writing production code
 ---
 
 # Java Development Skill

--- a/nx/skills/java-development/SKILL.md
+++ b/nx/skills/java-development/SKILL.md
@@ -3,9 +3,6 @@ name: java-development
 description: >
   Implement Java features using TDD methodology. Triggers: plan approved,
   user says "implement", bead in_progress for implementation, executing plan phase.
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash, LSP
-memory: project
 ---
 
 # Java Development Skill

--- a/nx/skills/knowledge-tidying/SKILL.md
+++ b/nx/skills/knowledge-tidying/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: knowledge-tidying
-description: >
-  Persist and organize knowledge in Nexus T3. Triggers: research-synthesis completes,
-  major investigation concludes, user says "save this knowledge", valuable insights discovered.
+description: Use when validated findings, decisions, or patterns need to be persisted to nx T3 knowledge store for cross-session reuse
 ---
 
 # Knowledge Tidying Skill

--- a/nx/skills/knowledge-tidying/SKILL.md
+++ b/nx/skills/knowledge-tidying/SKILL.md
@@ -3,8 +3,6 @@ name: knowledge-tidying
 description: >
   Persist and organize knowledge in Nexus T3. Triggers: research-synthesis completes,
   major investigation concludes, user says "save this knowledge", valuable insights discovered.
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash
 ---
 
 # Knowledge Tidying Skill

--- a/nx/skills/knowledge-tidying/SKILL.md
+++ b/nx/skills/knowledge-tidying/SKILL.md
@@ -17,35 +17,27 @@ Delegates to the **knowledge-tidier** agent (haiku). See [registry.yaml](../../r
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **knowledge-tidier**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: knowledge-tidier
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Organized knowledge entries in T3
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] Knowledge stored in Nexus T3 via nx store put
+- [ ] No contradictions with existing knowledge
+- [ ] Tags are meaningful for future retrieval
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Nexus Storage Standards
 

--- a/nx/skills/nexus/SKILL.md
+++ b/nx/skills/nexus/SKILL.md
@@ -3,133 +3,52 @@ name: nexus
 description: Use when running nx commands for search, memory, knowledge storage, or project management — or when unsure which nx subcommand to use
 ---
 
-# Nexus — Agent Usage Guide
+# Nexus Quick Reference
 
-Nexus gives you a single CLI to index code, PDFs, and notes; search across all of them semantically; and manage persistent memory across sessions.
+## Storage Tiers
 
-**Three storage tiers:**
-- **T1 scratch** — in-memory, session-scoped (`nx scratch`)
-- **T2 memory** — local SQLite, survives restarts (`nx memory`)
-- **T3 knowledge** — ChromaDB cloud + Voyage AI, permanent (`nx search`, `nx store`, `nx index`)
+| Tier | Scope | CLI | Use For |
+|------|-------|-----|---------|
+| T1 | Session | `nx scratch` | Hypotheses, interim findings, checkpoints |
+| T2 | Persistent | `nx memory` | Cross-session state, agent relay notes |
+| T3 | Permanent | `nx search`, `nx store` | Validated findings, decisions, patterns |
 
-## Search
-
-```bash
-nx search "query"                          # semantic search across all T3 knowledge
-nx search "query" --corpus code            # code collections only
-nx search "query" --corpus docs            # docs collections only
-nx search "query" --corpus knowledge       # knowledge collections only
-nx search "query" --corpus code --corpus docs  # multi-corpus with reranker merge
-nx search "query" --hybrid                 # semantic + ripgrep + git frecency (code only)
-nx search "query" --answer                 # retrieval + Haiku answer synthesis
-nx search "query" --agentic               # Haiku-driven multi-step query refinement
-nx search "query" --mxbai                  # fan out to Mixedbread-indexed collections
-nx search "query" --vimgrep               # path:line:col:content output
-nx search "query" --json                   # JSON array output
-nx search "query" --files                  # unique file paths only
-nx search "query" --content               # show matched text inline
-nx search "query" -C 3                    # 3 context lines around each result
-nx search "query" --where store_type=pm-archive  # metadata filter
-```
-
-## Memory (T2 — persistent across sessions)
+## Common Commands
 
 ```bash
-nx memory put "content" --project {repo} --title title.md
-nx memory put - --project {repo} --title title.md   # from stdin
-nx memory get --project {repo} --title title.md
-nx memory search "query"
+# Search
+nx search "query"                    # semantic search across T3
+nx search "query" --corpus code      # code only
+nx search "query" --hybrid           # semantic + ripgrep + frecency
+nx search "query" --answer           # retrieval + synthesis
+
+# Memory (T2)
+nx memory put "content" --project {repo} --title file.md
+nx memory get --project {repo} --title file.md
 nx memory search "query" --project {repo}
-nx memory list --project {repo}
-nx memory expire                           # remove TTL-expired entries
-nx memory promote <id> --collection knowledge  # push to T3
+
+# Knowledge (T3)
+echo "content" | nx store put - --collection knowledge --title "title" --tags "tag"
+nx store list --collection knowledge
+
+# Scratch (T1)
+nx scratch put "working note"
+nx scratch flag <id>                 # auto-promote to T2 at session end
+
+# Project Management
+nx pm status                         # current phase, blockers
+nx pm resume                         # inject continuation context
+
+# Indexing
+nx index code <path>                 # index code repo
 ```
 
-**Project naming**: use bare `{repo}` for all project memory (e.g., `nexus`). No `_active` or `_pm` suffixes.
+## Collection Naming
 
-## Knowledge store (T3 — permanent, cloud)
+Always `__` as separator: `code__myrepo`, `docs__corpus`, `knowledge__topic`
 
-```bash
-nx store put analysis.md --collection knowledge --tags "arch"
-echo "# Finding..." | nx store put - --collection knowledge --title "My Finding" --tags "research"
-nx store put notes.md --collection knowledge --tags "notes" --ttl 30d
-nx store list
-nx store list --collection knowledge__notes
-nx store expire
-```
+## Title Conventions
 
-**TTL formats**: `30d` (30 days), `4w` (4 weeks), `permanent` or `never` (no expiry). Use `Nd`/`Nw` format — NOT bare integers. Omit `--ttl` entirely for permanent entries.
+Use hyphens: `research-{topic}`, `decision-{component}-{name}`, `pattern-{name}`
 
-## Scratch (T1 — session-scoped, cleared at session end)
-
-```bash
-nx scratch put "working hypothesis: the cache is stale"
-nx scratch search "cache"
-nx scratch list
-nx scratch get <id>
-nx scratch flag <id>                       # mark for auto-flush to T2 at session end
-nx scratch unflag <id>
-nx scratch promote <id> --project {repo} --title findings.md
-nx scratch clear
-```
-
-**Usage pattern**: Use T1 scratch for in-flight working notes (hypotheses, interim findings, checkpoints). Flag important items so they auto-promote to T2 at session end. Permanently validated findings go to T3 via `nx store put`.
-
-## Indexing
-
-```bash
-nx index code <path>                       # register and index a code repo
-nx index code <path> --frecency-only       # refresh git frecency scores only (fast)
-nx index pdf <path> --corpus my-papers
-nx index md  <path> --corpus notes
-```
-
-## Project management (PM)
-
-```bash
-nx pm init                                 # initialise for current git repo
-nx pm resume                               # inject continuation context (auto-called by hooks)
-nx pm status                               # phase, agent, blockers
-nx pm block "waiting on API approval"
-nx pm unblock 1
-nx pm phase next
-nx pm search "what did we decide about caching"
-nx pm promote phases/phase-2/context.md --collection knowledge --tags "decision"
-nx pm archive                              # synthesise → T3, start 90-day T2 decay
-nx pm close                                # archive + mark completed (alias for archive --status completed)
-nx pm restore <project>
-nx pm reference "how did we handle rate limiting"
-nx pm expire
-```
-
-## Health and server
-
-```bash
-nx doctor                                  # verify all credentials and tools
-nx serve start                             # start background HEAD-polling daemon
-nx serve stop
-nx serve status
-nx serve logs
-```
-
-## Workflow — when and why to use each tier
-
-**Session lifecycle:**
-1. Search T3 for prior art before starting work: `nx search "topic" --corpus knowledge`
-2. Index the codebase once per repo: `nx index code <path>`
-3. Use T1 scratch for working notes during the session
-4. Flag important scratch items for auto-promote to T2: `nx scratch flag <id>`
-5. Persist validated findings to T3 at session end: `nx store put`
-
-**Tier selection:**
-- **T1 scratch**: hypotheses, interim findings, checkpoints — anything ephemeral to this session
-- **T2 memory**: cross-session state, agent relay notes, active project context
-- **T3 knowledge**: validated findings, architectural decisions, reusable patterns — anything worth keeping permanently
-
-**Collection naming**: always `__` as separator — `code__myrepo`, `docs__corpus`, `knowledge__topic`. Colons are invalid in ChromaDB collection names.
-
-**Title conventions** (use hyphens, not colons):
-- `research-{topic}` — research findings
-- `decision-{component}-{name}` — architectural decisions
-- `pattern-{name}` — reusable patterns
-- `debug-{component}-{issue}` — debugging insights
+For full command reference with all flags and options, see [reference.md](./reference.md).

--- a/nx/skills/nexus/SKILL.md
+++ b/nx/skills/nexus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nexus
-description: Use Nexus (nx) for semantic search, memory, knowledge storage, and project management across sessions.
+description: Use when running nx commands for search, memory, knowledge storage, or project management — or when unsure which nx subcommand to use
 ---
 
 # Nexus — Agent Usage Guide

--- a/nx/skills/nexus/reference.md
+++ b/nx/skills/nexus/reference.md
@@ -1,0 +1,130 @@
+# Nexus — Agent Usage Guide
+
+Nexus gives you a single CLI to index code, PDFs, and notes; search across all of them semantically; and manage persistent memory across sessions.
+
+**Three storage tiers:**
+- **T1 scratch** — in-memory, session-scoped (`nx scratch`)
+- **T2 memory** — local SQLite, survives restarts (`nx memory`)
+- **T3 knowledge** — ChromaDB cloud + Voyage AI, permanent (`nx search`, `nx store`, `nx index`)
+
+## Search
+
+```bash
+nx search "query"                          # semantic search across all T3 knowledge
+nx search "query" --corpus code            # code collections only
+nx search "query" --corpus docs            # docs collections only
+nx search "query" --corpus knowledge       # knowledge collections only
+nx search "query" --corpus code --corpus docs  # multi-corpus with reranker merge
+nx search "query" --hybrid                 # semantic + ripgrep + git frecency (code only)
+nx search "query" --answer                 # retrieval + Haiku answer synthesis
+nx search "query" --agentic               # Haiku-driven multi-step query refinement
+nx search "query" --mxbai                  # fan out to Mixedbread-indexed collections
+nx search "query" --vimgrep               # path:line:col:content output
+nx search "query" --json                   # JSON array output
+nx search "query" --files                  # unique file paths only
+nx search "query" --content               # show matched text inline
+nx search "query" -C 3                    # 3 context lines around each result
+nx search "query" --where store_type=pm-archive  # metadata filter
+```
+
+## Memory (T2 — persistent across sessions)
+
+```bash
+nx memory put "content" --project {repo} --title title.md
+nx memory put - --project {repo} --title title.md   # from stdin
+nx memory get --project {repo} --title title.md
+nx memory search "query"
+nx memory search "query" --project {repo}
+nx memory list --project {repo}
+nx memory expire                           # remove TTL-expired entries
+nx memory promote <id> --collection knowledge  # push to T3
+```
+
+**Project naming**: use bare `{repo}` for all project memory (e.g., `nexus`). No `_active` or `_pm` suffixes.
+
+## Knowledge store (T3 — permanent, cloud)
+
+```bash
+nx store put analysis.md --collection knowledge --tags "arch"
+echo "# Finding..." | nx store put - --collection knowledge --title "My Finding" --tags "research"
+nx store put notes.md --collection knowledge --tags "notes" --ttl 30d
+nx store list
+nx store list --collection knowledge__notes
+nx store expire
+```
+
+**TTL formats**: `30d` (30 days), `4w` (4 weeks), `permanent` or `never` (no expiry). Use `Nd`/`Nw` format — NOT bare integers. Omit `--ttl` entirely for permanent entries.
+
+## Scratch (T1 — session-scoped, cleared at session end)
+
+```bash
+nx scratch put "working hypothesis: the cache is stale"
+nx scratch search "cache"
+nx scratch list
+nx scratch get <id>
+nx scratch flag <id>                       # mark for auto-flush to T2 at session end
+nx scratch unflag <id>
+nx scratch promote <id> --project {repo} --title findings.md
+nx scratch clear
+```
+
+**Usage pattern**: Use T1 scratch for in-flight working notes (hypotheses, interim findings, checkpoints). Flag important items so they auto-promote to T2 at session end. Permanently validated findings go to T3 via `nx store put`.
+
+## Indexing
+
+```bash
+nx index code <path>                       # register and index a code repo
+nx index code <path> --frecency-only       # refresh git frecency scores only (fast)
+nx index pdf <path> --corpus my-papers
+nx index md  <path> --corpus notes
+```
+
+## Project management (PM)
+
+```bash
+nx pm init                                 # initialise for current git repo
+nx pm resume                               # inject continuation context (auto-called by hooks)
+nx pm status                               # phase, agent, blockers
+nx pm block "waiting on API approval"
+nx pm unblock 1
+nx pm phase next
+nx pm search "what did we decide about caching"
+nx pm promote phases/phase-2/context.md --collection knowledge --tags "decision"
+nx pm archive                              # synthesise → T3, start 90-day T2 decay
+nx pm close                                # archive + mark completed (alias for archive --status completed)
+nx pm restore <project>
+nx pm reference "how did we handle rate limiting"
+nx pm expire
+```
+
+## Health and server
+
+```bash
+nx doctor                                  # verify all credentials and tools
+nx serve start                             # start background HEAD-polling daemon
+nx serve stop
+nx serve status
+nx serve logs
+```
+
+## Workflow — when and why to use each tier
+
+**Session lifecycle:**
+1. Search T3 for prior art before starting work: `nx search "topic" --corpus knowledge`
+2. Index the codebase once per repo: `nx index code <path>`
+3. Use T1 scratch for working notes during the session
+4. Flag important scratch items for auto-promote to T2: `nx scratch flag <id>`
+5. Persist validated findings to T3 at session end: `nx store put`
+
+**Tier selection:**
+- **T1 scratch**: hypotheses, interim findings, checkpoints — anything ephemeral to this session
+- **T2 memory**: cross-session state, agent relay notes, active project context
+- **T3 knowledge**: validated findings, architectural decisions, reusable patterns — anything worth keeping permanently
+
+**Collection naming**: always `__` as separator — `code__myrepo`, `docs__corpus`, `knowledge__topic`. Colons are invalid in ChromaDB collection names.
+
+**Title conventions** (use hyphens, not colons):
+- `research-{topic}` — research findings
+- `decision-{component}-{name}` — architectural decisions
+- `pattern-{name}` — reusable patterns
+- `debug-{component}-{issue}` — debugging insights

--- a/nx/skills/orchestration/SKILL.md
+++ b/nx/skills/orchestration/SKILL.md
@@ -3,8 +3,6 @@ name: orchestration
 description: >
   Route requests to appropriate specialized agents and manage multi-agent pipelines.
   Triggers: task ambiguous, coordinating multiple agents, user says "which agent".
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash
 ---
 
 # Orchestration Skill

--- a/nx/skills/orchestration/SKILL.md
+++ b/nx/skills/orchestration/SKILL.md
@@ -17,35 +17,27 @@ Delegates to the **orchestrator** agent (haiku). See [registry.yaml](../../regis
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **orchestrator**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: orchestrator
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Routing decision with recommended agent
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] User goal clearly understood
+- [ ] Appropriate agent(s) identified
+- [ ] Clear rationale provided
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Routing Quick Reference
 

--- a/nx/skills/orchestration/SKILL.md
+++ b/nx/skills/orchestration/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: orchestration
-description: >
-  Route requests to appropriate specialized agents and manage multi-agent pipelines.
-  Triggers: task ambiguous, coordinating multiple agents, user says "which agent".
+description: Use when unsure which agent to use for a task, or when coordinating work across multiple agents in a pipeline
 ---
 
 # Orchestration Skill

--- a/nx/skills/orchestration/SKILL.md
+++ b/nx/skills/orchestration/SKILL.md
@@ -15,6 +15,60 @@ Delegates to the **orchestrator** agent (haiku). See [registry.yaml](../../regis
 - When setting up multi-agent pipelines
 - When workflow routing decisions are needed
 
+```dot
+digraph routing {
+    rankdir=TB;
+    "Request type?" [shape=diamond];
+
+    "Plan a feature" [shape=box];
+    "Implement code" [shape=box];
+    "Debug issue" [shape=box];
+    "Review code" [shape=box];
+    "Research topic" [shape=box];
+    "Analyze system" [shape=box];
+
+    "strategic-planner" [shape=ellipse];
+    "plan-auditor" [shape=ellipse];
+    "java-architect-planner" [shape=ellipse];
+    "java-developer" [shape=ellipse];
+    "code-review-expert" [shape=ellipse];
+    "test-validator" [shape=ellipse];
+    "java-debugger" [shape=ellipse];
+    "deep-analyst" [shape=ellipse];
+    "substantive-critic" [shape=ellipse];
+    "deep-research-synthesizer" [shape=ellipse];
+    "knowledge-tidier" [shape=ellipse];
+    "codebase-deep-analyzer" [shape=ellipse];
+
+    "Request type?" -> "Plan a feature" [label="plan/design"];
+    "Request type?" -> "Implement code" [label="build/implement"];
+    "Request type?" -> "Debug issue" [label="test failure/bug"];
+    "Request type?" -> "Review code" [label="review/quality"];
+    "Request type?" -> "Research topic" [label="research/investigate"];
+    "Request type?" -> "Analyze system" [label="explore/understand"];
+
+    "Plan a feature" -> "strategic-planner";
+    "strategic-planner" -> "plan-auditor" [label="then"];
+    "plan-auditor" -> "java-architect-planner" [label="then"];
+
+    "Implement code" -> "java-developer";
+    "java-developer" -> "code-review-expert" [label="then"];
+    "code-review-expert" -> "test-validator" [label="then"];
+
+    "Debug issue" -> "java-debugger";
+    "java-debugger" -> "deep-analyst" [label="if cross-cutting"];
+
+    "Review code" -> "code-review-expert";
+    "code-review-expert" -> "substantive-critic" [label="if critical"];
+
+    "Research topic" -> "deep-research-synthesizer";
+    "deep-research-synthesizer" -> "knowledge-tidier" [label="then"];
+
+    "Analyze system" -> "codebase-deep-analyzer";
+    "codebase-deep-analyzer" -> "deep-analyst" [label="if deep"];
+}
+```
+
 ## Agent Invocation
 
 Use the Task tool to invoke **orchestrator**:

--- a/nx/skills/pdf-processing/SKILL.md
+++ b/nx/skills/pdf-processing/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: pdf-processing
-description: >
-  Process PDF files into nx store for semantic search. Triggers: user says "index PDF",
-  importing technical documentation, PDFs need semantic indexing.
+description: Use when PDF documents need to be indexed into nx store for semantic search
 ---
 
 # PDF Processing Skill

--- a/nx/skills/pdf-processing/SKILL.md
+++ b/nx/skills/pdf-processing/SKILL.md
@@ -3,8 +3,6 @@ name: pdf-processing
 description: >
   Process PDF files into nx store for semantic search. Triggers: user says "index PDF",
   importing technical documentation, PDFs need semantic indexing.
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash
 ---
 
 # PDF Processing Skill

--- a/nx/skills/pdf-processing/SKILL.md
+++ b/nx/skills/pdf-processing/SKILL.md
@@ -17,35 +17,27 @@ Delegates to the **pdf-chromadb-processor** agent (haiku). See [registry.yaml](.
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **pdf-chromadb-processor**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: pdf-chromadb-processor
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Indexed PDF chunks in nx store
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] All PDFs processed without errors
+- [ ] Content chunked appropriately
+- [ ] Documents searchable in nx store
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Processing Methodology
 

--- a/nx/skills/plan-validation/SKILL.md
+++ b/nx/skills/plan-validation/SKILL.md
@@ -3,8 +3,6 @@ name: plan-validation
 description: >
   Validate implementation plans before execution. Triggers: strategic-planner completes,
   before starting implementation, user says "validate plan" or "audit plan".
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash
 ---
 
 # Plan Validation Skill

--- a/nx/skills/plan-validation/SKILL.md
+++ b/nx/skills/plan-validation/SKILL.md
@@ -17,35 +17,27 @@ Delegates to the **plan-auditor** agent (sonnet). See [registry.yaml](../../regi
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **plan-auditor**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: plan-auditor
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Plan validation report with pass/fail/warn items
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] All plan assumptions verified
+- [ ] Dependencies confirmed present
+- [ ] Clear go/no-go decision provided
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Validation Methodology
 

--- a/nx/skills/plan-validation/SKILL.md
+++ b/nx/skills/plan-validation/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: plan-validation
-description: >
-  Validate implementation plans before execution. Triggers: strategic-planner completes,
-  before starting implementation, user says "validate plan" or "audit plan".
+description: Use when a plan has been created and needs validation before implementation begins, or when reviewing an existing plan for gaps
 ---
 
 # Plan Validation Skill

--- a/nx/skills/plan-validation/SKILL.md
+++ b/nx/skills/plan-validation/SKILL.md
@@ -50,6 +50,8 @@ The plan-auditor agent uses sequential thinking:
 6. Identify inconsistencies with current code
 7. Provide go/no-go recommendation
 
+**REQUIRED BACKGROUND:** Understand nx:strategic-planning for plan structure and conventions.
+
 ## Decision Outcomes
 
 **GO**: Proceed to java-developer with validated plan

--- a/nx/skills/project-setup/SKILL.md
+++ b/nx/skills/project-setup/SKILL.md
@@ -3,8 +3,6 @@ name: project-setup
 description: >
   Create project management infrastructure for multi-week projects. Triggers:
   starting projects over 3 weeks, requiring phase tracking, user says "set up project".
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash
 ---
 
 # Project Setup Skill

--- a/nx/skills/project-setup/SKILL.md
+++ b/nx/skills/project-setup/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: project-setup
-description: >
-  Create project management infrastructure for multi-week projects. Triggers:
-  starting projects over 3 weeks, requiring phase tracking, user says "set up project".
+description: Use when starting a project expected to span 3+ weeks that needs phase tracking and project management infrastructure
 ---
 
 # Project Setup Skill

--- a/nx/skills/project-setup/SKILL.md
+++ b/nx/skills/project-setup/SKILL.md
@@ -17,35 +17,27 @@ Delegates to the **project-management-setup** agent (haiku). See [registry.yaml]
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **project-management-setup**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: project-management-setup
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+PM infrastructure with phases and tracking
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] nx pm init completed
+- [ ] Core T2 documents created
+- [ ] Phase beads created with dependencies
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Infrastructure Created
 

--- a/nx/skills/rdr-close/SKILL.md
+++ b/nx/skills/rdr-close/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: rdr-close
-description: >
-  Close an RDR: capture divergence, create post-mortem, decompose into beads, archive to T3.
-  Triggers: user says "close this RDR", "RDR done", or /rdr-close
+description: Use when an RDR has passed its gate and needs to be closed with post-mortem, bead decomposition, and T3 archival
 ---
 
 # RDR Close Skill

--- a/nx/skills/rdr-close/SKILL.md
+++ b/nx/skills/rdr-close/SKILL.md
@@ -3,7 +3,6 @@ name: rdr-close
 description: >
   Close an RDR: capture divergence, create post-mortem, decompose into beads, archive to T3.
   Triggers: user says "close this RDR", "RDR done", or /rdr-close
-allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash
 ---
 
 # RDR Close Skill

--- a/nx/skills/rdr-create/SKILL.md
+++ b/nx/skills/rdr-create/SKILL.md
@@ -3,7 +3,6 @@ name: rdr-create
 description: >
   Scaffold a new RDR from template, assign sequential ID, register in T2, add to index.
   Triggers: user says "create an RDR", "new RDR", or /rdr-create
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash
 ---
 
 # RDR Create Skill

--- a/nx/skills/rdr-create/SKILL.md
+++ b/nx/skills/rdr-create/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: rdr-create
-description: >
-  Scaffold a new RDR from template, assign sequential ID, register in T2, add to index.
-  Triggers: user says "create an RDR", "new RDR", or /rdr-create
+description: Use when starting a new research-design-review document, before beginning structured investigation
 ---
 
 # RDR Create Skill

--- a/nx/skills/rdr-gate/SKILL.md
+++ b/nx/skills/rdr-gate/SKILL.md
@@ -3,7 +3,6 @@ name: rdr-gate
 description: >
   Run the RDR finalization gate: structural validation, assumption audit, and AI critique.
   Triggers: user says "gate this RDR", "finalization check", or /rdr-gate
-allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash
 ---
 
 # RDR Gate Skill

--- a/nx/skills/rdr-gate/SKILL.md
+++ b/nx/skills/rdr-gate/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: rdr-gate
-description: >
-  Run the RDR finalization gate: structural validation, assumption audit, and AI critique.
-  Triggers: user says "gate this RDR", "finalization check", or /rdr-gate
+description: Use when an RDR appears complete and needs finalization validation — structural, assumption, and AI critique checks
 ---
 
 # RDR Gate Skill

--- a/nx/skills/rdr-list/SKILL.md
+++ b/nx/skills/rdr-list/SKILL.md
@@ -3,7 +3,6 @@ name: rdr-list
 description: >
   List all RDRs in the current project with status, type, and priority.
   Triggers: user says "list RDRs", "show all RDRs", or /rdr-list
-allowed-tools: Read, Glob, Grep, Bash
 ---
 
 # RDR List Skill

--- a/nx/skills/rdr-list/SKILL.md
+++ b/nx/skills/rdr-list/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: rdr-list
-description: >
-  List all RDRs in the current project with status, type, and priority.
-  Triggers: user says "list RDRs", "show all RDRs", or /rdr-list
+description: Use when needing to see all RDRs in the project with their status, type, and priority
 ---
 
 # RDR List Skill

--- a/nx/skills/rdr-research/SKILL.md
+++ b/nx/skills/rdr-research/SKILL.md
@@ -3,7 +3,6 @@ name: rdr-research
 description: >
   Add, track, and verify structured research findings for an RDR.
   Triggers: user says "add research finding", "RDR research", or /rdr-research
-allowed-tools: Task, Read, Write, Edit, Glob, Grep, Bash
 ---
 
 # RDR Research Skill

--- a/nx/skills/rdr-research/SKILL.md
+++ b/nx/skills/rdr-research/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: rdr-research
-description: >
-  Add, track, and verify structured research findings for an RDR.
-  Triggers: user says "add research finding", "RDR research", or /rdr-research
+description: Use when adding, tracking, or verifying structured research findings for an active RDR
 ---
 
 # RDR Research Skill

--- a/nx/skills/rdr-show/SKILL.md
+++ b/nx/skills/rdr-show/SKILL.md
@@ -3,7 +3,6 @@ name: rdr-show
 description: >
   Display detailed RDR information including content, status, research findings,
   and linked beads. Triggers: user says "show RDR", "RDR details", or /rdr-show
-allowed-tools: Read, Glob, Grep, Bash
 ---
 
 # RDR Show Skill

--- a/nx/skills/rdr-show/SKILL.md
+++ b/nx/skills/rdr-show/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: rdr-show
-description: >
-  Display detailed RDR information including content, status, research findings,
-  and linked beads. Triggers: user says "show RDR", "RDR details", or /rdr-show
+description: Use when needing detailed information about a specific RDR including content, research findings, and linked beads
 ---
 
 # RDR Show Skill

--- a/nx/skills/receiving-code-review/SKILL.md
+++ b/nx/skills/receiving-code-review/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: receiving-code-review
+description: Use when receiving code review feedback — before implementing suggestions — especially if feedback seems unclear or technically questionable
+---
+
+# Receiving Code Review
+
+## Overview
+
+Code review requires technical evaluation, not emotional performance.
+
+**Core principle:** Verify before implementing. Ask before assuming. Technical correctness over social comfort.
+
+## The Response Pattern
+
+```
+WHEN receiving code review feedback:
+
+1. READ: Complete feedback without reacting
+2. UNDERSTAND: Restate requirement in own words (or ask)
+3. VERIFY: Check against codebase reality
+4. EVALUATE: Technically sound for THIS codebase?
+5. RESPOND: Technical acknowledgment or reasoned pushback
+6. IMPLEMENT: One item at a time, test each
+```
+
+## Forbidden Responses
+
+**NEVER:**
+- "You're absolutely right!"
+- "Great point!" / "Excellent feedback!"
+- "Let me implement that now" (before verification)
+
+**INSTEAD:**
+- Restate the technical requirement
+- Ask clarifying questions if anything is unclear
+- Push back with technical reasoning if wrong
+- Just start working (actions speak louder than words)
+
+## Handling Unclear Feedback
+
+```
+IF any item is unclear:
+  STOP — do not implement anything yet
+  ASK for clarification on unclear items
+
+WHY: Items may be related. Partial understanding = wrong implementation.
+```
+
+## When to Push Back
+
+Push back when:
+- Suggestion breaks existing functionality
+- Reviewer lacks full context
+- Violates YAGNI (unused feature)
+- Technically incorrect for this stack
+- Conflicts with prior architectural decisions
+
+**How to push back:**
+- Use technical reasoning, not defensiveness
+- Reference working tests/code
+- Ask specific questions
+
+## Implementation Order
+
+```
+FOR multi-item feedback:
+  1. Clarify anything unclear FIRST
+  2. Implement in this order:
+     - Blocking issues (breaks, security)
+     - Simple fixes (typos, imports)
+     - Complex fixes (refactoring, logic)
+  3. Test each fix individually
+  4. Verify no regressions
+```
+
+## Acknowledging Correct Feedback
+
+```
+Correct:  "Fixed. [Brief description]"
+Correct:  "Good catch — [specific issue]. Fixed in [location]."
+Correct:  [Just fix it and show in the code]
+
+Wrong:    "You're absolutely right!"
+Wrong:    "Thanks for catching that!"
+Wrong:    ANY gratitude expression
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Performative agreement | State requirement or just act |
+| Blind implementation | Verify against codebase first |
+| Batch without testing | One at a time, test each |
+| Avoiding pushback | Technical correctness over comfort |
+
+**REQUIRED BACKGROUND:** Understand nx:verification-before-completion — every fix must be verified before claiming it's done.

--- a/nx/skills/research-synthesis/SKILL.md
+++ b/nx/skills/research-synthesis/SKILL.md
@@ -4,10 +4,6 @@ description: >
   Research topics across multiple sources. Triggers: researching new topic/technology,
   investigating best practices, comparing approaches, learning unfamiliar concepts,
   user says "research", "find out about", "what are best practices for".
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, WebSearch, WebFetch
-memory: local
-context: fork
 ---
 
 # Research Synthesis Skill

--- a/nx/skills/research-synthesis/SKILL.md
+++ b/nx/skills/research-synthesis/SKILL.md
@@ -18,35 +18,27 @@ Delegates to the **deep-research-synthesizer** agent. See [registry.yaml](../../
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **deep-research-synthesizer**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: deep-research-synthesizer
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Research synthesis across multiple sources
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] All relevant sources consulted
+- [ ] Key findings synthesized (not just listed)
+- [ ] Recommendations provided with supporting evidence
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Research Methodology
 

--- a/nx/skills/research-synthesis/SKILL.md
+++ b/nx/skills/research-synthesis/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: research-synthesis
-description: >
-  Research topics across multiple sources. Triggers: researching new topic/technology,
-  investigating best practices, comparing approaches, learning unfamiliar concepts,
-  user says "research", "find out about", "what are best practices for".
+description: Use when researching unfamiliar topics, comparing technology approaches, or building comprehensive understanding from multiple sources
 ---
 
 # Research Synthesis Skill

--- a/nx/skills/strategic-planning/SKILL.md
+++ b/nx/skills/strategic-planning/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: strategic-planning
-description: >
-  Create implementation plans before development. Triggers: user says "implement feature",
-  "add functionality", "build component", starting new epic, before multi-step development,
-  user says "plan this", before architectural changes, breaking down complex work.
+description: Use when facing multi-step development work that needs decomposition into phases, before writing any implementation code
 ---
 
 # Strategic Planning Skill

--- a/nx/skills/strategic-planning/SKILL.md
+++ b/nx/skills/strategic-planning/SKILL.md
@@ -18,35 +18,27 @@ Delegates to the **strategic-planner** agent. See [registry.yaml](../../registry
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **strategic-planner**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: strategic-planner
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Implementation plan with phased tasks and dependencies
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] Phased execution plan created
+- [ ] Dependency graph established
+- [ ] Success criteria defined per phase
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Planning Methodology
 

--- a/nx/skills/strategic-planning/SKILL.md
+++ b/nx/skills/strategic-planning/SKILL.md
@@ -51,6 +51,8 @@ The agent uses sequential thinking:
 6. Create beads for trackable work items
 7. Define success criteria and test strategy
 
+**REQUIRED SUB-SKILL:** Use nx:plan-validation (plan-auditor) after creating any plan.
+
 ## Success Criteria
 
 - [ ] Epic/feature breakdown documented

--- a/nx/skills/strategic-planning/SKILL.md
+++ b/nx/skills/strategic-planning/SKILL.md
@@ -4,9 +4,6 @@ description: >
   Create implementation plans before development. Triggers: user says "implement feature",
   "add functionality", "build component", starting new epic, before multi-step development,
   user says "plan this", before architectural changes, breaking down complex work.
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash
-memory: project
 ---
 
 # Strategic Planning Skill

--- a/nx/skills/substantive-critique/SKILL.md
+++ b/nx/skills/substantive-critique/SKILL.md
@@ -5,9 +5,6 @@ description: >
   reviewing architectural decisions, validating implementations against specs,
   verifying claims against evidence, comprehensive system audits.
   (Workaround for substantive-critic framework bug)
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash
-memory: user
 ---
 
 # Deep Critique Skill

--- a/nx/skills/substantive-critique/SKILL.md
+++ b/nx/skills/substantive-critique/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: substantive-critique
-description: >
-  Deep constructive critique of code, documentation, plans, or designs. Triggers:
-  reviewing architectural decisions, validating implementations against specs,
-  verifying claims against evidence, comprehensive system audits.
-  (Workaround for substantive-critic framework bug)
+description: Use when architectural decisions, implementations, or documentation need deep constructive critique against specs or evidence
 ---
 
 # Deep Critique Skill

--- a/nx/skills/substantive-critique/SKILL.md
+++ b/nx/skills/substantive-critique/SKILL.md
@@ -21,35 +21,27 @@ Delegates to the **substantive-critic** agent. See [registry.yaml](../../registr
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **substantive-critic**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: substantive-critic
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Critique report with prioritized findings
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] All major dimensions analyzed (structure, logic, completeness)
+- [ ] Findings prioritized by impact
+- [ ] Recommendations are specific and actionable
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Critique Methodology
 

--- a/nx/skills/test-validation/SKILL.md
+++ b/nx/skills/test-validation/SKILL.md
@@ -4,8 +4,6 @@ description: >
   Validate test coverage and quality after implementation. Triggers: finishing feature,
   after fixing a bug, before merge/PR, user says "check tests" or "validate coverage",
   CI/CD check needed, verifying code has adequate tests.
-# See ../../registry.yaml for full agent metadata
-allowed-tools: Task, Read, Glob, Grep, Bash
 ---
 
 # Test Validation Skill

--- a/nx/skills/test-validation/SKILL.md
+++ b/nx/skills/test-validation/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: test-validation
-description: >
-  Validate test coverage and quality after implementation. Triggers: finishing feature,
-  after fixing a bug, before merge/PR, user says "check tests" or "validate coverage",
-  CI/CD check needed, verifying code has adequate tests.
+description: Use when implementation is complete and test coverage needs verification, before merge or pull request
 ---
 
 # Test Validation Skill

--- a/nx/skills/test-validation/SKILL.md
+++ b/nx/skills/test-validation/SKILL.md
@@ -19,35 +19,27 @@ Delegates to the **test-validator** agent. See [registry.yaml](../../registry.ya
 
 ## Agent Invocation
 
-## Relay Template (Use This Format)
-
-When invoking this agent via Task tool, use this exact structure:
+Use the Task tool to invoke **test-validator**:
 
 ```markdown
-## Relay: {agent-name}
+## Relay: test-validator
 
-**Task**: [1-2 sentence summary of what needs to be done]
-**Bead**: [ID] (status: [status]) or 'none'
+**Task**: [what needs to be done]
+**Bead**: [ID] or 'none'
 
 ### Input Artifacts
-- nx store: [document titles or "none"]
-- nx memory: [project/title path or "none"]
-- nx scratch: [scratch IDs or "none"]           # optional: ephemeral T1 items
-- nx pm context: [Phase N, active blockers or "none"]  # optional: from nx pm status
-- Files: [key files or "none"]
+- Files: [relevant files]
 
 ### Deliverable
-[What the receiving agent should produce]
+Test coverage report with gap analysis
 
 ### Quality Criteria
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
-- [ ] [Criterion 3]
+- [ ] All changed files have corresponding tests
+- [ ] Test coverage meets project standards
+- [ ] Edge cases covered
 ```
 
-**Required**: All fields must be present. Agent will validate relay before starting.
-
-For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
 ## Validation Methodology
 

--- a/nx/skills/test-validation/SKILL.md
+++ b/nx/skills/test-validation/SKILL.md
@@ -51,6 +51,8 @@ The agent will:
 5. Check test quality (assertions, edge cases, error paths)
 6. Recommend additional tests if needed
 
+**REQUIRED SUB-SKILL:** Use nx:verification-before-completion — run all tests before claiming coverage is adequate.
+
 ## Agent-Specific PRODUCE
 
 - **Session Scratch (T1)**: `nx scratch put "<snapshot>" --tags "test-run"` — test run snapshots and interim findings during session

--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: using-nx-skills
+description: Use when starting any conversation or task — establishes that nx skills must be checked before every response, including clarifying questions
+---
+
+<EXTREMELY-IMPORTANT>
+If you think there is even a 1% chance a skill might apply to what you are doing, you MUST invoke the skill.
+
+IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+This is not negotiable. This is not optional. You cannot rationalize your way out of this.
+</EXTREMELY-IMPORTANT>
+
+# Using nx Skills
+
+## The Rule
+
+**Invoke relevant skills BEFORE any response or action.** Even a 1% chance a skill might apply means you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you do not need to use it.
+
+## Process Flow
+
+```dot
+digraph skill_flow {
+    "User message received" [shape=doublecircle];
+    "About to implement?" [shape=diamond];
+    "Already brainstormed?" [shape=diamond];
+    "Invoke brainstorming-gate" [shape=box];
+    "Might any skill apply?" [shape=diamond];
+    "Invoke Skill tool" [shape=box];
+    "Follow skill exactly" [shape=box];
+    "Respond" [shape=doublecircle];
+
+    "User message received" -> "About to implement?";
+    "About to implement?" -> "Already brainstormed?" [label="yes"];
+    "About to implement?" -> "Might any skill apply?" [label="no"];
+    "Already brainstormed?" -> "Invoke brainstorming-gate" [label="no"];
+    "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
+    "Invoke brainstorming-gate" -> "Might any skill apply?";
+    "Might any skill apply?" -> "Invoke Skill tool" [label="yes, even 1%"];
+    "Might any skill apply?" -> "Respond" [label="definitely not"];
+    "Invoke Skill tool" -> "Follow skill exactly";
+    "Follow skill exactly" -> "Respond";
+}
+```
+
+## Red Flags
+
+These thoughts mean STOP — you are rationalizing:
+
+| Thought | Reality |
+|---------|---------|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE gathering context. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read current version. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+
+## Skill Priority
+
+When multiple skills could apply:
+
+1. **Discipline skills first** (brainstorming-gate, verification-before-completion) — these determine HOW to approach
+2. **Process skills second** (strategic-planning, code-review) — these guide workflow
+3. **Implementation skills third** (java-development, java-debugging) — these execute work
+
+## Skill Types
+
+**Rigid** (verification-before-completion, brainstorming-gate): Follow exactly. Do not adapt away discipline.
+
+**Flexible** (patterns, reference): Adapt principles to context.
+
+The skill itself tells you which type it is.
+
+## User Instructions
+
+Instructions say WHAT, not HOW. "Add X" or "Fix Y" does not mean skip workflows. Always check skills first.

--- a/nx/skills/verification-before-completion/SKILL.md
+++ b/nx/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: verification-before-completion
+description: Use when about to claim work is complete, fixed, or passing — before committing, creating PRs, or marking beads done — or when a delegated agent reports completion or success — requires running verification commands and confirming output independently before any success claims
+---
+
+# Verification Before Completion
+
+## Overview
+
+Claiming work is complete without verification is dishonesty, not efficiency.
+
+**Core principle:** Evidence before claims, always.
+
+**Violating the letter of this rule is violating the spirit of this rule.**
+
+## The Iron Law
+
+```
+NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE
+```
+
+If you have not run the verification command in this message, you cannot claim it passes.
+
+## The Gate Function
+
+```
+BEFORE claiming any status or expressing satisfaction:
+
+1. IDENTIFY: What command proves this claim?
+2. RUN: Execute the FULL command (fresh, complete)
+3. READ: Full output, check exit code, count failures
+4. VERIFY: Does output confirm the claim?
+   - If NO: State actual status with evidence
+   - If YES: State claim WITH evidence
+5. ONLY THEN: Make the claim
+
+Skip any step = lying, not verifying
+```
+
+## Common Failures
+
+| Claim | Requires | Not Sufficient |
+|-------|----------|----------------|
+| Tests pass | `pytest` output: 0 failures | Previous run, "should pass" |
+| Build succeeds | Build command: exit 0 | Linter passing |
+| Bug fixed | Symptom test: passes | Code changed, assumed fixed |
+| Bead done | All criteria verified | "I think it's done" |
+| Agent completed | VCS diff shows changes | Agent reports "success" |
+
+## Red Flags — STOP
+
+- Using "should", "probably", "seems to"
+- Expressing satisfaction before verification ("Done!", "Fixed!")
+- About to commit/push/PR without verification
+- Trusting agent success reports without checking
+- Relying on partial verification
+- Thinking "just this once"
+
+## Rationalization Prevention
+
+| Excuse | Reality |
+|--------|---------|
+| "Should work now" | RUN the verification |
+| "I'm confident" | Confidence is not evidence |
+| "Just this once" | No exceptions |
+| "Agent said success" | Verify independently |
+| "Partial check is enough" | Partial proves nothing |
+
+## Verification Commands Reference
+
+| Context | Command |
+|---------|---------|
+| Python tests | `pytest tests/ -v` |
+| Java tests | `./mvnw test` |
+| Plugin structure | `pytest tests/test_plugin_structure.py -v` |
+| Bead criteria | `bd show <id>` then check each criterion |
+| Git status | `git status && git diff --stat` |
+
+## The Bottom Line
+
+Run the command. Read the output. THEN claim the result.
+
+This is non-negotiable.

--- a/nx/skills/writing-nx-skills/SKILL.md
+++ b/nx/skills/writing-nx-skills/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: writing-nx-skills
+description: Use when creating new nx plugin skills, editing existing skills, or verifying skill quality before committing
+---
+
+# Writing nx Skills
+
+## Overview
+
+Guide for authoring skills in the nx Claude Code plugin. Skills are reference guides for proven techniques, patterns, or tools that help future Claude instances find and apply effective approaches.
+
+**REQUIRED BACKGROUND:** Understand superpowers:writing-skills for the foundational TDD-for-documentation methodology. This skill adds nx-specific conventions on top.
+
+## nx Skill Conventions
+
+### Frontmatter
+
+Only two fields. Max 1024 characters total:
+
+```yaml
+---
+name: skill-name-with-hyphens
+description: Use when [specific triggering conditions]
+---
+```
+
+- `name`: Letters, numbers, hyphens only
+- `description`: MUST start with "Use when". Describe triggering conditions, NEVER summarize workflow.
+
+### Skill Types in nx
+
+**Agent-delegating skills** (majority): Invoke a specific agent via Task tool relay.
+Required sections:
+- `## When This Skill Activates`
+- `## Agent Invocation` with cross-reference to RELAY_TEMPLATE.md
+- `## Success Criteria`
+- `## Agent-Specific PRODUCE` (T1/T2/T3 outputs)
+
+**Standalone skills** (nexus, cli-controller): Provide guidance directly without agent delegation.
+Required sections:
+- `## When This Skill Activates`
+- `## Success Criteria` (optional for pure reference)
+
+**Discipline skills** (brainstorming-gate, verification-before-completion): Enforce process rules.
+Required sections:
+- `<HARD-GATE>` or `<EXTREMELY-IMPORTANT>` blocks
+- Rationalization prevention table
+- Red flags list
+
+### Cross-References
+
+Use explicit markers, not file paths:
+- `**REQUIRED SUB-SKILL:** Use nx:skill-name for [purpose]`
+- `**REQUIRED BACKGROUND:** Understand nx:skill-name before using this skill`
+
+Never use `@` syntax (force-loads files, burns context).
+
+### Relay Cross-Reference
+
+Agent-delegating skills reference the canonical relay template:
+```markdown
+## Agent Invocation
+
+Use the Task tool with standardized relay format.
+See [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md) for required fields and examples.
+```
+
+Do NOT inline the relay template. One source of truth: `agents/_shared/RELAY_TEMPLATE.md`.
+
+### Storage Tier References
+
+Skills that produce outputs must document which tiers they use:
+- **T1 scratch**: `nx scratch put "..." --tags "..."` — session-scoped ephemeral notes
+- **T2 memory**: `nx memory put "..." --project {repo} --title file.md` — cross-session state
+- **T3 knowledge**: `nx store put ...` — permanent validated findings
+
+### Registry Integration
+
+After creating a skill, add it to `nx/registry.yaml`:
+- Agent-delegating: under `agents:` with model, skill, slash_command, triggers
+- Standalone: under `standalone_skills:` with tools and triggers
+- RDR: under `rdr_skills:` with slash_command and triggers
+
+## Quality Checklist
+
+- [ ] Frontmatter has only `name` and `description`
+- [ ] Description starts with "Use when"
+- [ ] Description has no workflow summary
+- [ ] Agent-delegating: has Agent Invocation cross-reference
+- [ ] Agent-delegating: has Agent-Specific PRODUCE section
+- [ ] Agent-delegating: mentions nx scratch (T1)
+- [ ] Has Success Criteria section
+- [ ] Added to registry.yaml
+- [ ] Tests pass: `pytest tests/test_plugin_structure.py -v`
+
+## Testing Skills
+
+Run structural validation:
+```bash
+pytest tests/test_plugin_structure.py -v -k "skill_name"
+```
+
+For behavioral testing, follow the TDD-for-documentation approach from superpowers:writing-skills — create pressure scenarios, test baseline without skill, verify compliance with skill.

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -299,29 +299,50 @@ class TestCliSyntax:
 class TestSkillStructure:
     """All SKILL.md files must have required content."""
 
+    # Standalone skills don't delegate to agents — exclude from agent-specific tests
+    STANDALONE_SKILLS = {
+        "cli-controller", "nexus",
+        "brainstorming-gate", "verification-before-completion",
+        "receiving-code-review", "using-nx-skills",
+        "dispatching-parallel-agents",
+    }
+
     REQUIRED_SKILL_SECTIONS = [
-        "## Relay Template",
+        ("## Relay Template", "## Agent Invocation"),
         "## Success Criteria",
     ]
 
     @pytest.mark.parametrize("skill_path", [
         pytest.param(p, id=p.parent.name)
         for p in skill_skill_mds()
-        # standalone skills (cli-controller, nexus) don't delegate to agents
-        if p.parent.name not in ("cli-controller", "nexus")
+        if p.parent.name not in {
+            "cli-controller", "nexus",
+            "brainstorming-gate", "verification-before-completion",
+            "receiving-code-review", "using-nx-skills",
+            "dispatching-parallel-agents",
+        }
     ])
     def test_skill_has_relay_template(self, skill_path: Path) -> None:
         text = skill_path.read_text()
         for section in self.REQUIRED_SKILL_SECTIONS:
-            assert section in text, (
-                f"{skill_path.parent.name}/SKILL.md: missing '{section}'"
-            )
+            if isinstance(section, tuple):
+                assert any(alt in text for alt in section), (
+                    f"{skill_path.parent.name}/SKILL.md: missing one of {section}"
+                )
+            else:
+                assert section in text, (
+                    f"{skill_path.parent.name}/SKILL.md: missing '{section}'"
+                )
 
     @pytest.mark.parametrize("skill_path", [
         pytest.param(p, id=p.parent.name)
         for p in skill_skill_mds()
-        # standalone skills (cli-controller, nexus) don't delegate to agents
-        if p.parent.name not in ("cli-controller", "nexus")
+        if p.parent.name not in {
+            "cli-controller", "nexus",
+            "brainstorming-gate", "verification-before-completion",
+            "receiving-code-review", "using-nx-skills",
+            "dispatching-parallel-agents",
+        }
     ])
     def test_agent_skill_has_produce_section(self, skill_path: Path) -> None:
         """Agent-delegating skills must have an Agent-Specific PRODUCE section."""
@@ -333,7 +354,12 @@ class TestSkillStructure:
     @pytest.mark.parametrize("skill_path", [
         pytest.param(p, id=p.parent.name)
         for p in skill_skill_mds()
-        if p.parent.name not in ("cli-controller", "nexus")
+        if p.parent.name not in {
+            "cli-controller", "nexus",
+            "brainstorming-gate", "verification-before-completion",
+            "receiving-code-review", "using-nx-skills",
+            "dispatching-parallel-agents",
+        }
     ])
     def test_skill_mentions_t1_scratch(self, skill_path: Path) -> None:
         """Agent-delegating skills should acknowledge T1 scratch usage."""
@@ -348,11 +374,10 @@ class TestSkillStructure:
     def test_relay_template_has_required_rows(self, skill_path: Path) -> None:
         """Relay templates must include nx store, nx memory, and Files rows."""
         text = skill_path.read_text()
-        # Only check if there's a relay template section
         if "## Relay Template" not in text:
+            if "RELAY_TEMPLATE.md" in text:
+                return  # Valid: uses hybrid cross-reference
             pytest.skip("No relay template in this skill")
-        # Note: don't split on "##" because the relay template code block starts with
-        # "## Relay: {agent-name}", which would truncate before the actual rows.
         relay_section = text.split("## Relay Template")[1]
         for row in ("nx store:", "nx memory:", "Files:"):
             assert row in relay_section, (

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -463,3 +463,142 @@ class TestCrossReferenceIntegrity:
         assert shared_file.exists(), (
             f"_shared/CONTEXT_PROTOCOL.md referenced by {agent_path.name} does not exist"
         )
+
+
+# ── CSO Description Validation ───────────────────────────────────────────────
+
+
+class TestSkillDescriptionCSO:
+    """Skill descriptions must follow CSO 'Use when' pattern."""
+
+    @pytest.mark.parametrize("skill_path", [
+        pytest.param(p, id=p.parent.name) for p in skill_skill_mds()
+    ])
+    def test_description_starts_with_use_when(self, skill_path: Path) -> None:
+        """All skill descriptions must start with 'Use when' per CSO methodology."""
+        text = skill_path.read_text()
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert match, f"{skill_path.parent.name}/SKILL.md: no YAML frontmatter"
+        fm = yaml.safe_load(match.group(1))
+        desc = fm.get("description", "")
+        assert desc.lower().startswith("use when"), (
+            f"{skill_path.parent.name}/SKILL.md: description must start with "
+            f"'Use when' (CSO pattern). Got: {desc[:80]!r}"
+        )
+
+    @pytest.mark.parametrize("skill_path", [
+        pytest.param(p, id=p.parent.name) for p in skill_skill_mds()
+    ])
+    def test_description_no_workflow_keywords(self, skill_path: Path) -> None:
+        """Descriptions must not summarize workflow — just triggering conditions."""
+        text = skill_path.read_text()
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        if not match:
+            pytest.skip("No frontmatter")
+        fm = yaml.safe_load(match.group(1))
+        desc = fm.get("description", "")
+        bad_keywords = ["Triggers:", "user says", "workflow", "process:"]
+        for kw in bad_keywords:
+            assert kw not in desc, (
+                f"{skill_path.parent.name}/SKILL.md: description contains "
+                f"workflow keyword {kw!r}. Descriptions should state WHEN to "
+                f"use the skill, not summarize what it does."
+            )
+
+    @pytest.mark.parametrize("skill_path", [
+        pytest.param(p, id=p.parent.name) for p in skill_skill_mds()
+    ])
+    def test_frontmatter_only_standard_fields(self, skill_path: Path) -> None:
+        """Skill frontmatter must contain only name and description."""
+        text = skill_path.read_text()
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert match, f"{skill_path.parent.name}/SKILL.md: no YAML frontmatter"
+        fm = yaml.safe_load(match.group(1))
+        allowed = {"name", "description"}
+        extra = set(fm.keys()) - allowed
+        assert not extra, (
+            f"{skill_path.parent.name}/SKILL.md: non-standard frontmatter fields "
+            f"{extra}. Claude Code only reads 'name' and 'description'."
+        )
+
+    @pytest.mark.parametrize("skill_path", [
+        pytest.param(p, id=p.parent.name) for p in skill_skill_mds()
+    ])
+    def test_no_yaml_comments_in_frontmatter(self, skill_path: Path) -> None:
+        """No YAML comments inside frontmatter block."""
+        text = skill_path.read_text()
+        match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        if not match:
+            pytest.skip("No frontmatter")
+        frontmatter_raw = match.group(1)
+        comment_lines = [
+            line for line in frontmatter_raw.splitlines()
+            if line.strip().startswith("#")
+        ]
+        assert not comment_lines, (
+            f"{skill_path.parent.name}/SKILL.md: YAML comments in frontmatter: "
+            f"{comment_lines}"
+        )
+
+
+# ── Hook Structure ───────────────────────────────────────────────────────────
+
+
+class TestHookStructure:
+    """Hook configuration must follow best practices."""
+
+    def test_post_tool_use_has_matcher(self) -> None:
+        """PostToolUse hooks should have a matcher to avoid firing on every tool use."""
+        import json
+        hooks_path = PLUGIN_DIR / "hooks" / "hooks.json"
+        assert hooks_path.exists(), "hooks.json not found"
+        hooks = json.loads(hooks_path.read_text())
+        for entry in hooks.get("PostToolUse", []):
+            has_matcher = "matcher" in entry
+            has_filter = "grep" in entry.get("command", "") or "bd create" in entry.get("command", "")
+            assert has_matcher or has_filter, (
+                f"PostToolUse hook fires on every tool use without matcher: "
+                f"{entry.get('command', '')[:80]}"
+            )
+
+
+# ── Standalone Skill Registry ────────────────────────────────────────────────
+
+
+class TestStandaloneSkillRegistry:
+    """standalone_skills entries must have matching directories."""
+
+    def test_standalone_skill_directory_exists(self) -> None:
+        """Every standalone_skills entry must have a matching skill directory."""
+        registry = yaml.safe_load(REGISTRY_PATH.read_text())
+        standalone = registry.get("standalone_skills", {})
+        for skill_name in standalone:
+            skill_dir = SKILLS_DIR / skill_name
+            assert skill_dir.is_dir(), (
+                f"standalone_skills entry '{skill_name}' has no matching "
+                f"directory at {skill_dir}"
+            )
+            skill_md = skill_dir / "SKILL.md"
+            assert skill_md.exists(), (
+                f"standalone_skills entry '{skill_name}' has directory but "
+                f"no SKILL.md at {skill_md}"
+            )
+
+
+# ── Shared Resources ────────────────────────────────────────────────────────
+
+
+class TestSharedResources:
+    """Shared resources referenced by skills must exist."""
+
+    def test_relay_template_exists(self) -> None:
+        """RELAY_TEMPLATE.md must exist — all hybrid relay cross-references point to it."""
+        relay_template = SHARED_DIR / "RELAY_TEMPLATE.md"
+        assert relay_template.exists(), (
+            f"RELAY_TEMPLATE.md not found at {relay_template}. "
+            f"All agent-delegating skills cross-reference this file."
+        )
+        content = relay_template.read_text()
+        assert len(content) > 100, (
+            "RELAY_TEMPLATE.md exists but appears empty or trivially short"
+        )

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -304,7 +304,7 @@ class TestSkillStructure:
         "cli-controller", "nexus",
         "brainstorming-gate", "verification-before-completion",
         "receiving-code-review", "using-nx-skills",
-        "dispatching-parallel-agents",
+        "dispatching-parallel-agents", "writing-nx-skills",
     }
 
     REQUIRED_SKILL_SECTIONS = [
@@ -319,7 +319,7 @@ class TestSkillStructure:
             "cli-controller", "nexus",
             "brainstorming-gate", "verification-before-completion",
             "receiving-code-review", "using-nx-skills",
-            "dispatching-parallel-agents",
+            "dispatching-parallel-agents", "writing-nx-skills",
         }
     ])
     def test_skill_has_relay_template(self, skill_path: Path) -> None:
@@ -341,7 +341,7 @@ class TestSkillStructure:
             "cli-controller", "nexus",
             "brainstorming-gate", "verification-before-completion",
             "receiving-code-review", "using-nx-skills",
-            "dispatching-parallel-agents",
+            "dispatching-parallel-agents", "writing-nx-skills",
         }
     ])
     def test_agent_skill_has_produce_section(self, skill_path: Path) -> None:
@@ -358,7 +358,7 @@ class TestSkillStructure:
             "cli-controller", "nexus",
             "brainstorming-gate", "verification-before-completion",
             "receiving-code-review", "using-nx-skills",
-            "dispatching-parallel-agents",
+            "dispatching-parallel-agents", "writing-nx-skills",
         }
     ])
     def test_skill_mentions_t1_scratch(self, skill_path: Path) -> None:


### PR DESCRIPTION
## Summary

Brings the nx Claude Code plugin to publication quality based on a deep-critic comparative review against the superpowers plugin. Addresses 3 critical, 7 significant, and 6 opportunity findings across 24 tasks in 6 phases.

### Key changes
- **CSO compliance (C1, C2)**: All 23 skill descriptions rewritten to "Use when [condition]" pattern for Claude search optimization
- **6 new standalone skills (S1-S4, O3, O5)**: brainstorming-gate, verification-before-completion, receiving-code-review, using-nx-skills, dispatching-parallel-agents, writing-nx-skills
- **Relay deduplication (C3, O6)**: Replaced inline relay templates with hybrid cross-reference to shared RELAY_TEMPLATE.md; pre-filled static relay parts in commands
- **Frontmatter cleanup (S5, S6)**: Removed non-standard fields and YAML comments from all skills
- **Hook optimization (S7)**: PostToolUse hook now has `matcher` for `bd create` only (was firing Python on every tool use)
- **SessionStart injection (S4)**: using-nx-skills loaded at session start for skill discipline
- **PM command hardening (O1)**: Added `disable-model-invocation` to 6 pure-bash pm commands
- **Nexus skill split (O6)**: Quick-reference SKILL.md + detailed companion reference.md

### Stats
- 57 files changed, +1417 / -697 lines
- 586 tests passing, 6 skipped
- 6 commits across 6 phases

## Test plan
- [x] All 586 structural tests pass (`uv run pytest tests/test_plugin_structure.py`)
- [x] CSO description validation (TestSkillDescriptionCSO: 4 tests × 23 skills)
- [x] Hook structure validation (TestHookStructure)
- [x] Standalone skill registry validation (TestStandaloneSkillRegistry)
- [x] Registry completeness verified (all 8 standalone skills present)
- [x] No stale patterns (inline relay, non-standard frontmatter, YAML comments)
- [ ] Manual: Invoke each new skill to verify activation
- [ ] Manual: Verify `disable-model-invocation` doesn't break pm command bash blocks