### PR TITLE
Smart repository indexing: per-file classification and dual collections

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,7 +59,7 @@ src/nexus/
 |   |-- __init__.py
 |   |-- collection.py              # nx collection list/info/delete/verify
 |   |-- config_cmd.py              # nx config show/set
-|   |-- index.py                   # nx index code/pdf/md
+|   |-- index.py                   # nx index repo/pdf/md
 |   |-- memory.py                  # nx memory put/get/search/list/expire/promote
 |   |-- pm.py                      # nx pm (all lifecycle subcommands)
 |   |-- scratch.py                 # nx scratch put/get/search/list/clear/flag/promote
@@ -427,7 +427,7 @@ Phase 2    Phase 3 (T3)
 
 **Deliverables:** `server/app.py`, `server/daemon.py`, `server/registry.py`, `server/polling.py`, `indexing/code/frecency.py`, `indexing/code/chunker.py`, `indexing/code/ripgrep_cache.py`, `indexing/code/pipeline.py`, `cli/serve_cmd.py`, `cli/index_cmd.py` (code), `integration/git_hooks.py`, tests.
 
-**Exit criteria:** Full `nx serve` lifecycle; `nx index code` registers repo + triggers indexing + builds ripgrep cache; HEAD polling detects changes; frecency matches SeaGOAT formula.
+**Exit criteria:** Full `nx serve` lifecycle; `nx index repo` registers repo + triggers indexing + builds ripgrep cache; HEAD polling detects changes; frecency matches SeaGOAT formula.
 
 ### Phase 5: PDF/Markdown Indexing Pipelines
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Self-hosted semantic search and knowledge management for Claude Code agents.
 
-Nexus gives you and your AI agents a single CLI to index code, PDFs, and notes; search across all of them semantically; and manage persistent memory across sessions. Only chunk text and embeddings leave your machine — raw source files stay local.
+Nexus gives you and your AI agents a single CLI to index repositories, PDFs, and notes; search across all of them semantically; and manage persistent memory across sessions. Only chunk text and embeddings leave your machine — raw source files stay local.
 
 ## How it works
 
@@ -20,7 +20,7 @@ Within T3, collections fall into three corpus categories:
 
 | Corpus | Created by | Collection name |
 |--------|-----------|-----------------|
-| `code` | `nx index code` | `code__<repo>` |
+| `code` | `nx index repo` | `code__<repo>`, `docs__<repo>` |
 | `docs` | `nx index pdf` / `nx index md` | `docs__<corpus>` |
 | `knowledge` | `nx store put` | `knowledge__<topic>` |
 
@@ -133,15 +133,15 @@ This writes `~/.claude/skills/nexus/SKILL.md` and registers SessionStart/Session
 
 ```bash
 nx serve start              # start the background server (optional but recommended)
-nx index code .             # index the current repo
-nx index code /path/to/other-repo
+nx index repo .             # index the current repo
+nx index repo /path/to/other-repo
 ```
 
 The server watches registered repos and re-indexes automatically when the git HEAD changes. You don't need it running to search — it just keeps the index fresh.
 
 ```bash
 # Already indexed? Refresh git recency scores without re-embedding (fast)
-nx index code . --frecency-only
+nx index repo . --frecency-only
 ```
 
 > **Frecency** = a blend of recency and frequency derived from git history. Recently-touched files rank higher in hybrid search results.
@@ -381,7 +381,8 @@ T2  sqlite3 + FTS5, WAL mode — ~/.config/nexus/memory.db
 T3  chromadb.CloudClient + VoyageAIEmbeddingFunction — ChromaDB cloud
 
 Indexing pipelines:
-  code   git frecency → tree-sitter AST chunking → voyage-code-3 → T3 code__<repo>
+  repo   git frecency → classify by extension → code files: tree-sitter AST → voyage-code-3 → T3 code__<repo>
+                                               docs files: semantic markdown → voyage-context-3 → T3 docs__<repo>
   PDF    PyMuPDF4LLM extraction → voyage-4 (CCE) → T3 docs__<corpus>
   MD     SemanticMarkdownChunker + SHA256 sync → voyage-4 (CCE) → T3 docs__<corpus>
 

--- a/docs/plans/2026-02-24-smart-repo-indexing-design.md
+++ b/docs/plans/2026-02-24-smart-repo-indexing-design.md
@@ -1,0 +1,223 @@
+# Smart Repository Indexing Design
+
+## Problem Statement
+
+`nx index code` treats every file in a git repo as code, embedding all content with voyage-code-3. This produces poor retrieval quality for non-code content — markdown docs, RDRs, config prose, READMEs, PDFs. Repos also contain RDR documents that require a separate manual `nx index rdr` invocation that's easy to forget.
+
+## Scope
+
+The repository indexing pipeline. Specifically:
+
+- Extension-based file classification (code vs prose vs PDF)
+- Per-class embedding model selection (voyage-code-3 vs voyage-context-3)
+- Two general collections per repo (`code__` and `docs__`), plus optional `docs__rdr__`
+- RDR directory discovery and T3 indexing (report-only for T2 concerns)
+- `.nexus.yml` per-repo config for extension and RDR path overrides
+- HEAD polling triggers the unified pipeline
+
+**Out of scope**:
+
+- T2 RDR lifecycle (rdr-* skills, `nx memory`) — entirely untouched
+- Explicit document indexing (`nx index docs`, `nx index pdf`) — unchanged
+- Search engine changes — collection routing already works via prefix
+- Any automatic T2 operations
+
+## File Classification
+
+A canonical set of code extensions defines the boundary. Files with these extensions get voyage-code-3 and AST chunking. PDFs get extracted and chunked via the existing pipeline. Everything else that reads as UTF-8 text gets voyage-context-3 (CCE with voyage-4 fallback) and line/semantic chunking.
+
+### Default Code Extensions
+
+The small, greppable list (union of current `_EXT_TO_LANGUAGE` and `_AST_EXTENSIONS`):
+
+```
+.py .js .jsx .ts .tsx .java .go .rs .cpp .cc .c .h .hpp
+.rb .cs .sh .bash .kt .swift .scala .r .m .php
+```
+
+Everything not on this list is prose.
+
+### Classification Decisions
+
+- `.toml`, `.yaml`, `.yml`, `.json`, `.xml` — **prose**. They contain meaningful natural language (descriptions, comments, keys) that benefits from general-purpose embeddings. Removed from the code set even though tree-sitter can parse them.
+- `.sql`, `.proto`, `.graphql` — **prose** by default. Overridable via `.nexus.yml`.
+- `.pdf` — **PDF pipeline**. Routed through `PDFExtractor` + `PDFChunker`.
+- Binary files — skipped (existing UnicodeDecodeError catch). No change.
+
+### Three Content Classes
+
+| Class | Extensions | Embedding Model | Chunking | Target Collection |
+|-------|-----------|----------------|----------|-------------------|
+| Code | `_CODE_EXTENSIONS` set | voyage-code-3 | AST (tree-sitter) with line fallback | `code__repo-hash` |
+| PDF | `.pdf` | voyage-context-3 (CCE, voyage-4 fallback) | PyMuPDF4LLM + PDFChunker | `docs__repo-hash` |
+| Prose | everything else (UTF-8) | voyage-context-3 (CCE, voyage-4 fallback) | SemanticMarkdownChunker for `.md`, line-based otherwise | `docs__repo-hash` |
+
+## Collection Scheme
+
+Three collections per repo (up from one today):
+
+| Collection | Contents | Embedding Model | Notes |
+|-----------|----------|----------------|-------|
+| `code__repo-hash` | Code files | voyage-code-3 | Same naming as today |
+| `docs__repo-hash` | Prose + PDFs (minus RDR paths) | voyage-context-3 / voyage-4 fallback | New, same hash scheme |
+| `docs__rdr__repo` | RDR documents only | voyage-context-3 / voyage-4 fallback | Same as today's `nx index rdr` |
+
+### Naming
+
+- `code__repo-hash` — unchanged from today (`code__{basename}-{sha256[:8]}`)
+- `docs__repo-hash` — new, same hash derivation
+- `docs__rdr__repo` — unchanged (uses repo name, not hash)
+
+### Search Routing (no changes needed)
+
+- `nx search --corpus code` → all `code__*` collections
+- `nx search --corpus docs` → all `docs__*` collections (repo prose, RDRs, and explicitly indexed PDFs/markdown)
+- `nx search "query"` (no corpus filter) → searches everything
+
+### Embedding Models
+
+`corpus.py` `index_model_for_collection()` already returns correct models by collection prefix:
+
+- `code__*` → `voyage-code-3` (index time)
+- `docs__*` → `voyage-context-3` (index time, CCE)
+- All collections → `voyage-4` (query time, universal)
+
+The existing `_embed_with_fallback()` in `doc_indexer.py` handles CCE's 2+ chunk requirement by falling back to voyage-4 for single-chunk files. No changes needed.
+
+### Metadata
+
+Every chunk carries: `source_path`, `line_start`, `line_end`, `git_commit_hash`, `git_branch`, `git_remote_url`, `content_hash`, `embedding_model`, `store_type`, `frecency_score`. This enables search to work after a repo is no longer locally available. GitHub/GitLab permalinks can be derived from `git_remote_url` + `source_path` + `git_commit_hash`.
+
+## Unified Indexer Pipeline
+
+`nx index code` is renamed to `nx index repo`. One file walk, three output streams:
+
+```
+nx index repo <path>
+  │
+  ├─ Walk repo (respecting .gitignore, ignore patterns)
+  ├─ Load .nexus.yml (extension overrides, rdr_paths)
+  ├─ Collect git metadata once
+  ├─ Compute frecency scores once (single git log pass)
+  │
+  ├─ For each file:
+  │   ├─ Under an rdr_path? → skip (handled separately below)
+  │   ├─ .pdf? → PDF extraction + chunking → docs__repo-hash
+  │   ├─ Extension in code set? → AST chunking → code__repo-hash
+  │   ├─ Reads as UTF-8? → prose chunking → docs__repo-hash
+  │   └─ Otherwise → skip (binary)
+  │
+  ├─ RDR discovery:
+  │   ├─ Check each rdr_path (default: docs/rdr)
+  │   ├─ Report count to user
+  │   ├─ Index .md files → docs__rdr__repo (T3 only)
+  │   └─ Report new/unindexed RDRs (does NOT touch T2)
+  │
+  ├─ Prune stale chunks:
+  │   ├─ Files that changed classification (code→prose or vice versa)
+  │   └─ Files deleted from repo
+  │
+  └─ Build ripgrep cache (all text files, sorted by frecency — unchanged)
+```
+
+### Design Decisions
+
+- **One file walk**: frecency, classification, and ripgrep cache all come from the same traversal.
+- **Ripgrep cache includes all text files** regardless of classification. Full-text search is model-agnostic.
+- **RDR files excluded from `docs__repo-hash`** to avoid double-indexing.
+- **RDR discovery is report-only for T2**. Prints findings, does not create memory entries or trigger rdr-* skills.
+- **Staleness check per-file**: existing `content_hash` + `embedding_model` comparison. Handles both content changes and model reclassification.
+- **HEAD polling**: `check_and_reindex()` calls the unified `index_repository()`. No changes to `polling.py`.
+
+## `.nexus.yml` Configuration
+
+Extends the existing per-repo config mechanism (`load_config(repo_root=repo)`):
+
+```yaml
+# .nexus.yml (in repo root)
+indexing:
+  # Additional extensions to treat as code (added to defaults)
+  code_extensions: [.sql, .proto]
+
+  # Force these extensions to prose (overrides defaults and code_extensions)
+  prose_extensions: [.sh]
+
+  # RDR document directories (default: ["docs/rdr"])
+  rdr_paths:
+    - docs/rdr
+    - design/decisions
+```
+
+### Rules
+
+- All fields optional. Absent `indexing` section = pure defaults.
+- `prose_extensions` wins over `code_extensions` wins over defaults.
+- `rdr_paths` defaults to `["docs/rdr"]`. Set to `[]` to disable RDR discovery.
+- Extensions include the dot (`.sql` not `sql`).
+- No path-pattern overrides in v1. Schema accommodates them later.
+
+## Migration & Existing Collections
+
+Existing `code__repo-hash` collections contain prose files embedded with voyage-code-3. On first `nx index repo` run:
+
+1. Indexer classifies each file by extension
+2. Prose/PDF files get embedded into `docs__repo-hash` (created automatically)
+3. Stale prose chunks are pruned from `code__repo-hash`
+
+**Pruning**: After indexing both collections, compare `source_path` values in each collection against the current classification. Chunks in the wrong collection get deleted. Handles reclassification in both directions.
+
+One-time cost on first re-index. Subsequent runs use normal staleness checks.
+
+No explicit migration command. `nx index repo <path>` converges to correct state.
+
+## What Changes, What Doesn't
+
+### Changes
+
+- `indexer.py`: `_run_index()` partitions files by classification, embeds to two collections, handles PDFs, discovers RDRs
+- `commands/index.py`: `nx index code` renamed to `nx index repo`; `nx index rdr` stays as standalone convenience
+- `config.py`: `_DEFAULTS` gets `indexing` section with `code_extensions`, `prose_extensions`, `rdr_paths`
+- `registry.py`: registry entries track docs collection name alongside code collection name
+- `spec.md`, `ARCHITECTURE.md`, `README.md`, `CLAUDE.md`: update references to `nx index repo`, document new collection scheme
+
+### Unchanged
+
+- `corpus.py`: `index_model_for_collection()` already correct by prefix
+- `doc_indexer.py`: PDF and markdown chunking pipelines reused as-is
+- `search_engine.py`: cross-corpus search works by collection prefix
+- `ripgrep_cache.py`: builds from all text files regardless of classification
+- `polling.py`: calls `index_repository()` which now does the right thing
+- `db/t3.py`: no changes
+- T2: completely untouched
+- `nx index docs`, `nx index pdf`: unchanged
+
+## Testing Strategy
+
+### Unit Tests
+
+- File classification: given extension + config overrides, assert correct class
+- Config merge: `code_extensions` and `prose_extensions` precedence rules
+- RDR path detection: given `.nexus.yml` rdr_paths, assert discovery and exclusion from `docs__`
+- PDF routing: `.pdf` files go through `PDFExtractor`, land in `docs__`
+- Pruning: files that change classification get removed from old collection
+- Collection naming: `docs__repo-hash` uses same hash as `code__repo-hash`
+
+### End-to-End Tests (real embeddings, real ChromaDB)
+
+These tests use real Voyage AI embeddings and real ChromaDB (ephemeral client) to verify the full pipeline including embedding quality and retrieval correctness.
+
+- **Code retrieval**: index a repo with `.py` and `.md` files, search with a code-specific query, verify code chunks rank higher from `code__` than prose chunks
+- **Prose retrieval**: same repo, search with a natural language query, verify prose chunks from `docs__` rank appropriately
+- **PDF retrieval**: repo containing a `.pdf`, verify extraction + chunking + embedding + retrieval works end-to-end
+- **Cross-repo search**: index two repos, verify `--corpus code` searches code across both, `--corpus docs` searches prose across both
+- **RDR discovery**: repo with `docs/rdr/*.md`, verify indexed into `docs__rdr__`, not `docs__repo-hash`
+- **Classification override**: repo with `.nexus.yml` overriding an extension, verify chunks land in correct collection
+- **Migration**: pre-populate `code__` with prose chunks (simulating old behavior), run unified indexer, verify prose moved to `docs__` and pruned from `code__`
+- **Historical repo**: index a repo, delete the local clone, verify semantic search still returns results with correct metadata (source_path, git_remote_url, git_commit_hash)
+- **Staleness**: index, modify a file, re-index, verify only changed file re-embedded (content_hash check)
+- **Model recorded**: verify `embedding_model` metadata matches expected model per collection type
+
+### Existing Tests
+
+- `test_index_rdr_cmd.py`: unchanged
+- Existing indexer tests: updated to expect new collection split

--- a/docs/plans/2026-02-24-smart-repo-indexing-impl-plan.md
+++ b/docs/plans/2026-02-24-smart-repo-indexing-impl-plan.md
@@ -1,0 +1,1718 @@
+# Smart Repository Indexing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the single-model code indexer with a unified pipeline that classifies files by extension, embeds code with voyage-code-3 and prose/PDFs with voyage-context-3, and stores results in separate `code__` and `docs__` collections per repo.
+
+**Architecture:** Extension-based file classification drives a three-stream pipeline (code, prose, PDF) within a single file walk. The existing `doc_indexer.py` embedding helpers (`_embed_with_fallback`, `_pdf_chunks`, `_markdown_chunks`) are reused for prose/PDF streams. Registry tracks both collection names. `.nexus.yml` overrides classification defaults. RDR directories are auto-discovered and indexed into `docs__rdr__` (T3 only).
+
+**Tech Stack:** Python 3.12+, ChromaDB, Voyage AI (voyage-code-3, voyage-context-3, voyage-4), tree-sitter, PyMuPDF4LLM, pytest, click
+
+**Design doc:** `docs/plans/2026-02-24-smart-repo-indexing-design.md`
+
+---
+
+### Task 1: File Classification — Tests
+
+**Files:**
+- Create: `tests/test_classifier.py`
+
+**Step 1: Write the failing tests**
+
+```python
+# tests/test_classifier.py
+"""Unit tests for file classification logic."""
+from pathlib import Path
+
+import pytest
+
+
+def test_python_file_classified_as_code():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("main.py")) == ContentClass.CODE
+
+
+def test_markdown_file_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("README.md")) == ContentClass.PROSE
+
+
+def test_yaml_file_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("config.yaml")) == ContentClass.PROSE
+
+
+def test_toml_file_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("pyproject.toml")) == ContentClass.PROSE
+
+
+def test_json_file_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("package.json")) == ContentClass.PROSE
+
+
+def test_pdf_file_classified_as_pdf():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("paper.pdf")) == ContentClass.PDF
+
+
+def test_unknown_extension_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("notes.txt")) == ContentClass.PROSE
+
+
+def test_no_extension_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("Makefile")) == ContentClass.PROSE
+
+
+def test_code_extensions_set_matches_design():
+    """The canonical set must match the design doc exactly."""
+    from nexus.classifier import _CODE_EXTENSIONS
+    expected = {
+        ".py", ".js", ".jsx", ".ts", ".tsx", ".java", ".go", ".rs",
+        ".cpp", ".cc", ".c", ".h", ".hpp", ".rb", ".cs", ".sh", ".bash",
+        ".kt", ".swift", ".scala", ".r", ".m", ".php",
+    }
+    assert _CODE_EXTENSIONS == expected
+
+
+def test_config_code_extensions_override():
+    """code_extensions in config adds to the default set."""
+    from nexus.classifier import classify_file, ContentClass
+    cfg = {"code_extensions": [".sql", ".proto"]}
+    assert classify_file(Path("schema.sql"), indexing_config=cfg) == ContentClass.CODE
+    assert classify_file(Path("api.proto"), indexing_config=cfg) == ContentClass.CODE
+
+
+def test_config_prose_extensions_override():
+    """prose_extensions wins over both defaults and code_extensions."""
+    from nexus.classifier import classify_file, ContentClass
+    cfg = {"prose_extensions": [".sh"], "code_extensions": [".sql"]}
+    # .sh is in defaults as code, but prose_extensions overrides
+    assert classify_file(Path("deploy.sh"), indexing_config=cfg) == ContentClass.PROSE
+    # .sql added by code_extensions still works
+    assert classify_file(Path("query.sql"), indexing_config=cfg) == ContentClass.CODE
+
+
+def test_case_insensitive_extension():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("Main.PY")) == ContentClass.CODE
+    assert classify_file(Path("Doc.PDF")) == ContentClass.PDF
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_classifier.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'nexus.classifier'`
+
+**Step 3: Commit test file**
+
+```bash
+git add tests/test_classifier.py
+git commit -m "test: add file classification unit tests for smart repo indexing"
+```
+
+---
+
+### Task 2: File Classification — Implementation
+
+**Files:**
+- Create: `src/nexus/classifier.py`
+
+**Step 1: Implement the classifier module**
+
+```python
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""File classification for repository indexing.
+
+Extension-based classification determines which embedding model and chunking
+strategy each file receives during repository indexing.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class ContentClass(Enum):
+    """Content classification for a repository file."""
+    CODE = "code"
+    PROSE = "prose"
+    PDF = "pdf"
+
+
+# Canonical code extensions — the greppable, authoritative list.
+# Everything NOT in this set (and not .pdf) is treated as prose.
+_CODE_EXTENSIONS: frozenset[str] = frozenset({
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".java", ".go", ".rs",
+    ".cpp", ".cc", ".c", ".h", ".hpp", ".rb", ".cs", ".sh", ".bash",
+    ".kt", ".swift", ".scala", ".r", ".m", ".php",
+})
+
+
+def classify_file(
+    path: Path,
+    *,
+    indexing_config: dict[str, Any] | None = None,
+) -> ContentClass:
+    """Classify *path* as code, prose, or PDF based on its extension.
+
+    *indexing_config* is the ``indexing`` section from ``.nexus.yml``:
+    - ``code_extensions``: list of extensions to add to the code set
+    - ``prose_extensions``: list of extensions forced to prose (wins over all)
+    """
+    ext = path.suffix.lower()
+
+    if ext == ".pdf":
+        return ContentClass.PDF
+
+    cfg = indexing_config or {}
+    prose_overrides = set(cfg.get("prose_extensions", []))
+    code_additions = set(cfg.get("code_extensions", []))
+
+    # prose_extensions wins over everything
+    if ext in prose_overrides:
+        return ContentClass.PROSE
+
+    # code_extensions adds to defaults
+    effective_code = _CODE_EXTENSIONS | code_additions
+    if ext in effective_code:
+        return ContentClass.CODE
+
+    return ContentClass.PROSE
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_classifier.py -v`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/nexus/classifier.py
+git commit -m "feat: add file classification module for smart repo indexing"
+```
+
+---
+
+### Task 3: Config — Indexing Section Tests and Implementation
+
+**Files:**
+- Modify: `src/nexus/config.py:36-58` (add indexing to _DEFAULTS)
+- Modify: `tests/test_config.py` (add tests for indexing section)
+
+**Step 1: Write the failing tests**
+
+Add to existing test file or create new section. Check if `tests/test_config.py` exists first; if not, create it.
+
+```python
+# Add to tests/test_config.py (or create)
+"""Tests for indexing config section."""
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def test_defaults_include_indexing_section():
+    from nexus.config import _DEFAULTS
+    assert "indexing" in _DEFAULTS
+    assert _DEFAULTS["indexing"]["code_extensions"] == []
+    assert _DEFAULTS["indexing"]["prose_extensions"] == []
+    assert _DEFAULTS["indexing"]["rdr_paths"] == ["docs/rdr"]
+
+
+def test_load_config_returns_indexing_defaults():
+    from nexus.config import load_config
+    with patch("nexus.config._global_config_path") as mock_path:
+        mock_path.return_value = Path("/nonexistent/config.yml")
+        cfg = load_config(repo_root=Path("/nonexistent/repo"))
+    assert cfg["indexing"]["rdr_paths"] == ["docs/rdr"]
+
+
+def test_nexus_yml_indexing_overrides(tmp_path: Path):
+    from nexus.config import load_config
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".nexus.yml").write_text(
+        "indexing:\n"
+        "  code_extensions: [.sql, .proto]\n"
+        "  rdr_paths:\n"
+        "    - docs/rdr\n"
+        "    - design/decisions\n"
+    )
+    with patch("nexus.config._global_config_path") as mock_path:
+        mock_path.return_value = Path("/nonexistent/config.yml")
+        cfg = load_config(repo_root=repo)
+    assert cfg["indexing"]["code_extensions"] == [".sql", ".proto"]
+    assert cfg["indexing"]["rdr_paths"] == ["docs/rdr", "design/decisions"]
+    # prose_extensions not set → stays default
+    assert cfg["indexing"]["prose_extensions"] == []
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py -v -k "indexing"`
+Expected: FAIL — `KeyError: 'indexing'`
+
+**Step 3: Add indexing section to _DEFAULTS**
+
+Modify `src/nexus/config.py:36-58`:
+
+```python
+_DEFAULTS: dict[str, Any] = {
+    "server": {
+        "port": 7890,
+        "headPollInterval": 10,
+        "ignorePatterns": [],
+    },
+    "embeddings": {
+        "rerankerModel": "rerank-2.5",
+    },
+    "pm": {
+        "archiveTtl": 90,
+    },
+    "mxbai": {
+        "stores": [],
+    },
+    "chromadb": {
+        "tenant": "",
+        "database": "",
+    },
+    "client": {
+        "host": "localhost",
+    },
+    "indexing": {
+        "code_extensions": [],
+        "prose_extensions": [],
+        "rdr_paths": ["docs/rdr"],
+    },
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py -v -k "indexing"`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/nexus/config.py tests/test_config.py
+git commit -m "feat: add indexing config section with code_extensions, prose_extensions, rdr_paths"
+```
+
+---
+
+### Task 4: Chunker Cleanup — Remove Config Extensions from AST
+
+**Files:**
+- Modify: `src/nexus/chunker.py:11-31`
+- Modify: `tests/test_chunker.py` (add test for YAML fallback)
+
+**Step 1: Write failing test**
+
+```python
+# Add to tests/test_chunker.py
+def test_yaml_uses_line_chunking_not_ast():
+    """YAML files should use line-based chunking, not AST (they're prose now)."""
+    from nexus.chunker import chunk_file
+    content = "key: value\nlist:\n  - item1\n  - item2\n"
+    chunks = chunk_file(Path("config.yaml"), content)
+    assert chunks
+    assert not chunks[0].get("ast_chunked", False)
+
+
+def test_toml_uses_line_chunking_not_ast():
+    """TOML files should use line-based chunking, not AST (they're prose now)."""
+    from nexus.chunker import chunk_file
+    content = "[section]\nkey = \"value\"\n"
+    chunks = chunk_file(Path("pyproject.toml"), content)
+    assert chunks
+    assert not chunks[0].get("ast_chunked", False)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_chunker.py -v -k "yaml_uses_line or toml_uses_line"`
+Expected: FAIL — YAML gets AST-chunked
+
+**Step 3: Remove .toml, .yaml, .yml from _AST_EXTENSIONS**
+
+Modify `src/nexus/chunker.py:11-31`:
+
+```python
+_AST_EXTENSIONS: dict[str, str] = {
+    ".py": "python",
+    ".js": "javascript",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".jsx": "javascript",
+    ".rs": "rust",
+    ".go": "go",
+    ".java": "java",
+    ".c": "c",
+    ".cpp": "cpp",
+    ".h": "c",
+    ".hpp": "cpp",
+    ".rb": "ruby",
+    ".cs": "c_sharp",
+    ".sh": "bash",
+    ".bash": "bash",
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_chunker.py -v`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/nexus/chunker.py tests/test_chunker.py
+git commit -m "fix: remove .toml/.yaml/.yml from AST extensions (they are prose)"
+```
+
+---
+
+### Task 5: Registry — Dual Collection Names
+
+**Files:**
+- Modify: `src/nexus/registry.py:16-26,47-58`
+- Create or modify: `tests/test_registry.py`
+
+**Step 1: Write failing tests**
+
+```python
+# tests/test_registry.py (add to existing or create)
+"""Tests for dual-collection registry."""
+from pathlib import Path
+
+import pytest
+
+from nexus.registry import RepoRegistry
+
+
+def test_add_stores_both_collection_names(tmp_path: Path):
+    reg = RepoRegistry(tmp_path / "repos.json")
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    reg.add(repo)
+    info = reg.get(repo)
+    assert "code_collection" in info
+    assert "docs_collection" in info
+    assert info["code_collection"].startswith("code__")
+    assert info["docs_collection"].startswith("docs__")
+    # Same hash suffix
+    code_suffix = info["code_collection"].split("code__")[1]
+    docs_suffix = info["docs_collection"].split("docs__")[1]
+    assert code_suffix == docs_suffix
+
+
+def test_backward_compat_collection_key(tmp_path: Path):
+    """The 'collection' key still works as alias for code_collection."""
+    reg = RepoRegistry(tmp_path / "repos.json")
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    reg.add(repo)
+    info = reg.get(repo)
+    assert info["collection"] == info["code_collection"]
+
+
+def test_docs_collection_name_function():
+    from nexus.registry import _docs_collection_name
+    repo = Path("/some/path/myrepo")
+    name = _docs_collection_name(repo)
+    assert name.startswith("docs__myrepo-")
+    assert len(name.split("-")[-1]) == 8  # 8-char hash
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_registry.py -v -k "both_collection or backward_compat or docs_collection_name"`
+Expected: FAIL
+
+**Step 3: Add _docs_collection_name and update add()**
+
+Modify `src/nexus/registry.py`:
+
+Add after `_collection_name()` (line 26):
+
+```python
+def _docs_collection_name(repo: Path) -> str:
+    """Return the docs__ ChromaDB collection name for *repo*.
+
+    Uses the same hash scheme as _collection_name() for consistency.
+    """
+    path_hash = hashlib.sha256(str(repo).encode()).hexdigest()[:8]
+    return f"docs__{repo.name}-{path_hash}"
+```
+
+Update `add()` method (line 47-58):
+
+```python
+    def add(self, repo: Path) -> None:
+        """Register *repo*, initialising collection names and head_hash."""
+        key = str(repo)
+        name = repo.name
+        code_col = _collection_name(repo)
+        docs_col = _docs_collection_name(repo)
+        with self._lock:
+            self._data["repos"][key] = {
+                "name": name,
+                "collection": code_col,  # backward compat alias
+                "code_collection": code_col,
+                "docs_collection": docs_col,
+                "head_hash": "",
+                "status": "registered",
+            }
+            self._save()
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_registry.py -v`
+Expected: All PASS
+
+**Step 5: Run full test suite to check for regressions**
+
+Run: `uv run pytest tests/ -x -q`
+Expected: All pass (existing tests use `info["collection"]` which still works)
+
+**Step 6: Commit**
+
+```bash
+git add src/nexus/registry.py tests/test_registry.py
+git commit -m "feat: registry stores both code_collection and docs_collection per repo"
+```
+
+---
+
+### Task 6: Unified Indexer — Core Rewrite
+
+This is the largest task. The indexer's `_run_index()` is rewritten to:
+1. Classify each file
+2. Route code files to `code__` via voyage-code-3 (existing path)
+3. Route prose files to `docs__` via `_embed_with_fallback` (CCE)
+4. Route PDF files to `docs__` via `_pdf_chunks` + `_embed_with_fallback`
+5. Exclude RDR paths from `docs__`
+
+**Files:**
+- Modify: `src/nexus/indexer.py` (major rewrite of `_run_index`)
+
+**Step 1: Write failing unit tests**
+
+Add to `tests/test_indexer.py`:
+
+```python
+# ── Smart repo indexing: classification routing ──────────────────────────────
+
+def test_run_index_routes_prose_to_docs_collection(tmp_path: Path) -> None:
+    """Markdown files should be indexed into the docs__ collection, not code__."""
+    from nexus.indexer import _run_index
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("# Hello World\n\nThis is a readme.\n")
+
+    registry = MagicMock()
+    registry.get.return_value = {
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+        "collection": "code__repo",
+    }
+
+    upserted_collections: dict[str, list] = {}
+
+    mock_db = MagicMock()
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"metadatas": []}
+    mock_db.get_or_create_collection.return_value = mock_col
+
+    def capture_upsert(collection_name, ids, documents, embeddings, metadatas):
+        upserted_collections.setdefault(collection_name, []).extend(metadatas)
+
+    mock_db.upsert_chunks_with_embeddings.side_effect = capture_upsert
+
+    mock_voyage_result = MagicMock(spec=EmbeddingsObject)
+    mock_voyage_result.embeddings = [[0.1] * 1024]
+
+    mock_voyage_client = MagicMock()
+    mock_voyage_client.embed.return_value = mock_voyage_result
+
+    with patch("nexus.frecency.batch_frecency", return_value={}):
+        with patch("nexus.ripgrep_cache.build_cache"):
+            with patch("nexus.indexer._git_metadata", return_value={}):
+                with patch("nexus.config.load_config", return_value={
+                    "server": {"ignorePatterns": []},
+                    "indexing": {"code_extensions": [], "prose_extensions": [], "rdr_paths": ["docs/rdr"]},
+                }):
+                    with patch("nexus.config.get_credential", return_value="fake-key"):
+                        with patch("nexus.db.make_t3", return_value=mock_db):
+                            with patch("voyageai.Client", return_value=mock_voyage_client):
+                                _run_index(repo, registry)
+
+    # README.md should go to docs__ not code__
+    assert "docs__repo" in upserted_collections, f"Expected docs__repo, got: {list(upserted_collections.keys())}"
+    assert "code__repo" not in upserted_collections
+
+
+def test_run_index_routes_code_to_code_collection(tmp_path: Path) -> None:
+    """Python files should be indexed into the code__ collection."""
+    from nexus.indexer import _run_index
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "main.py").write_text("def hello():\n    pass\n")
+
+    registry = MagicMock()
+    registry.get.return_value = {
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+        "collection": "code__repo",
+    }
+
+    upserted_collections: dict[str, list] = {}
+
+    mock_db = MagicMock()
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"metadatas": []}
+    mock_db.get_or_create_collection.return_value = mock_col
+
+    def capture_upsert(collection_name, ids, documents, embeddings, metadatas):
+        upserted_collections.setdefault(collection_name, []).extend(metadatas)
+
+    mock_db.upsert_chunks_with_embeddings.side_effect = capture_upsert
+
+    mock_voyage_result = MagicMock(spec=EmbeddingsObject)
+    mock_voyage_result.embeddings = [[0.1] * 1024]
+
+    mock_voyage_client = MagicMock()
+    mock_voyage_client.embed.return_value = mock_voyage_result
+
+    fake_chunk = {
+        "line_start": 1, "line_end": 2, "text": "def hello():\n    pass",
+        "chunk_index": 0, "chunk_count": 1,
+        "ast_chunked": True, "filename": "main.py", "file_extension": ".py",
+    }
+
+    with patch("nexus.frecency.batch_frecency", return_value={}):
+        with patch("nexus.ripgrep_cache.build_cache"):
+            with patch("nexus.indexer._git_metadata", return_value={}):
+                with patch("nexus.config.load_config", return_value={
+                    "server": {"ignorePatterns": []},
+                    "indexing": {"code_extensions": [], "prose_extensions": [], "rdr_paths": ["docs/rdr"]},
+                }):
+                    with patch("nexus.config.get_credential", return_value="fake-key"):
+                        with patch("nexus.db.make_t3", return_value=mock_db):
+                            with patch("nexus.chunker.chunk_file", return_value=[fake_chunk]):
+                                with patch("voyageai.Client", return_value=mock_voyage_client):
+                                    _run_index(repo, registry)
+
+    assert "code__repo" in upserted_collections
+    assert "docs__repo" not in upserted_collections
+
+
+def test_run_index_excludes_rdr_paths_from_docs(tmp_path: Path) -> None:
+    """Files under rdr_paths should not be indexed into docs__ (they go to docs__rdr__)."""
+    from nexus.indexer import _run_index
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    rdr_dir = repo / "docs" / "rdr"
+    rdr_dir.mkdir(parents=True)
+    (rdr_dir / "ADR-001.md").write_text("# ADR 001\n\nDecision.\n")
+    (repo / "README.md").write_text("# Project\n\nReadme text.\n")
+
+    registry = MagicMock()
+    registry.get.return_value = {
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+        "collection": "code__repo",
+    }
+
+    upserted_collections: dict[str, list] = {}
+
+    mock_db = MagicMock()
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"metadatas": []}
+    mock_db.get_or_create_collection.return_value = mock_col
+
+    def capture_upsert(collection_name, ids, documents, embeddings, metadatas):
+        upserted_collections.setdefault(collection_name, []).extend(metadatas)
+
+    mock_db.upsert_chunks_with_embeddings.side_effect = capture_upsert
+
+    mock_voyage_result = MagicMock(spec=EmbeddingsObject)
+    mock_voyage_result.embeddings = [[0.1] * 1024]
+
+    mock_voyage_client = MagicMock()
+    mock_voyage_client.embed.return_value = mock_voyage_result
+
+    with patch("nexus.frecency.batch_frecency", return_value={}):
+        with patch("nexus.ripgrep_cache.build_cache"):
+            with patch("nexus.indexer._git_metadata", return_value={}):
+                with patch("nexus.config.load_config", return_value={
+                    "server": {"ignorePatterns": []},
+                    "indexing": {"code_extensions": [], "prose_extensions": [], "rdr_paths": ["docs/rdr"]},
+                }):
+                    with patch("nexus.config.get_credential", return_value="fake-key"):
+                        with patch("nexus.db.make_t3", return_value=mock_db):
+                            with patch("voyageai.Client", return_value=mock_voyage_client):
+                                _run_index(repo, registry)
+
+    # README.md → docs__repo; ADR-001.md → docs__rdr__repo; neither in code__repo
+    if "docs__repo" in upserted_collections:
+        paths = [m.get("source_path", "") for m in upserted_collections["docs__repo"]]
+        assert not any("docs/rdr" in p for p in paths), "RDR files must not be in docs__repo"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_indexer.py -v -k "routes_prose or routes_code or excludes_rdr"`
+Expected: FAIL — `_run_index` doesn't know about `docs_collection`
+
+**Step 3: Rewrite `_run_index` in `src/nexus/indexer.py`**
+
+Replace the entire `_run_index` function (lines 139-293) and update imports:
+
+```python
+def _run_index(repo: Path, registry: "RepoRegistry") -> None:
+    """Full indexing pipeline: classify → chunk → embed → upsert to code__/docs__ collections."""
+    import hashlib as _hl
+
+    from nexus.chunker import chunk_file
+    from nexus.classifier import ContentClass, classify_file
+    from nexus.config import load_config
+    from nexus.doc_indexer import _embed_with_fallback, _markdown_chunks, _pdf_chunks
+    from nexus.frecency import batch_frecency
+    from nexus.md_chunker import SemanticMarkdownChunker
+    from nexus.ripgrep_cache import build_cache
+
+    info = registry.get(repo)
+    if info is None:
+        return
+
+    code_collection = info.get("code_collection", info["collection"])
+    docs_collection = info.get("docs_collection", f"docs__{repo.name}")
+
+    # Load config (picks up per-repo .nexus.yml if present)
+    cfg = load_config(repo_root=repo)
+    cfg_patterns: list[str] = cfg.get("server", {}).get("ignorePatterns", [])
+    ignore_patterns: list[str] = list(dict.fromkeys(DEFAULT_IGNORE + cfg_patterns))
+    indexing_cfg: dict = cfg.get("indexing", {})
+    rdr_paths: list[str] = indexing_cfg.get("rdr_paths", ["docs/rdr"])
+
+    # Collect git metadata once for all chunks
+    git_meta = _git_metadata(repo)
+
+    # Compute frecency scores in a single git log pass
+    frecency_map = batch_frecency(repo)
+
+    # Build the set of absolute RDR directories for exclusion
+    rdr_abs_paths: list[Path] = []
+    for rdr_rel in rdr_paths:
+        rdr_abs = repo / rdr_rel
+        if rdr_abs.is_dir():
+            rdr_abs_paths.append(rdr_abs.resolve())
+
+    # Gather all files with frecency scores, classified
+    code_files: list[tuple[float, Path]] = []
+    prose_files: list[tuple[float, Path]] = []
+    pdf_files: list[tuple[float, Path]] = []
+    all_text_scored: list[tuple[float, Path]] = []
+
+    for path in sorted(repo.rglob("*")):
+        if not path.is_file() or path.is_symlink():
+            continue
+        rel = path.relative_to(repo)
+        if any(part.startswith(".") for part in rel.parts):
+            continue
+        if _should_ignore(rel, ignore_patterns):
+            continue
+
+        # Skip files under RDR paths (handled separately)
+        resolved = path.resolve()
+        if any(resolved == rdr_dir or rdr_dir in resolved.parents for rdr_dir in rdr_abs_paths):
+            continue
+
+        score = frecency_map.get(path, 0.0)
+        content_class = classify_file(path, indexing_config=indexing_cfg)
+
+        match content_class:
+            case ContentClass.CODE:
+                code_files.append((score, path))
+                all_text_scored.append((score, path))
+            case ContentClass.PDF:
+                pdf_files.append((score, path))
+            case ContentClass.PROSE:
+                all_text_scored.append((score, path))
+                prose_files.append((score, path))
+
+    # Sort descending by frecency
+    code_files.sort(key=lambda x: x[0], reverse=True)
+    prose_files.sort(key=lambda x: x[0], reverse=True)
+    all_text_scored.sort(key=lambda x: x[0], reverse=True)
+
+    # Update ripgrep cache (all text files, classification-agnostic)
+    _repo_hash = _hl.sha256(str(repo).encode()).hexdigest()[:8]
+    cache_path = Path.home() / ".config" / "nexus" / f"{repo.name}-{_repo_hash}.cache"
+    build_cache(repo, cache_path, all_text_scored)
+
+    # ── Credentials check ────────────────────────────────────────────────────
+    from nexus.config import get_credential
+    voyage_key = get_credential("voyage_api_key")
+    chroma_key = get_credential("chroma_api_key")
+    if not voyage_key or not chroma_key:
+        raise CredentialsMissingError(
+            f"T3 credentials missing for repo '{repo.name}' "
+            f"(voyage_api_key={'set' if voyage_key else 'missing'}, "
+            f"chroma_api_key={'set' if chroma_key else 'missing'})"
+        )
+
+    import voyageai
+    from datetime import UTC, datetime as _dt
+    from nexus.db import make_t3
+
+    db = make_t3()
+    now_iso = _dt.now(UTC).isoformat()
+    voyage_client = voyageai.Client(api_key=voyage_key)
+
+    # ── Index code files → code__ ────────────────────────────────────────────
+    code_model = index_model_for_collection(code_collection)
+    code_col = db.get_or_create_collection(code_collection)
+
+    for score, file in code_files:
+        _index_code_file(
+            file, repo, code_collection, code_model, code_col,
+            db, voyage_client, git_meta, now_iso, score,
+        )
+
+    # ── Index prose files → docs__ ───────────────────────────────────────────
+    docs_model = index_model_for_collection(docs_collection)
+    docs_col = db.get_or_create_collection(docs_collection)
+
+    for score, file in prose_files:
+        _index_prose_file(
+            file, repo, docs_collection, docs_model, docs_col,
+            db, voyage_key, git_meta, now_iso, score,
+        )
+
+    # ── Index PDF files → docs__ ─────────────────────────────────────────────
+    for score, file in pdf_files:
+        _index_pdf_file(
+            file, repo, docs_collection, docs_model, docs_col,
+            db, voyage_key, git_meta, now_iso, score,
+        )
+
+    # ── RDR discovery → docs__rdr__ ──────────────────────────────────────────
+    _discover_and_index_rdrs(repo, rdr_abs_paths, db, voyage_key, now_iso)
+
+    # ── Cross-collection pruning ─────────────────────────────────────────────
+    _prune_misclassified(repo, code_collection, docs_collection, code_files, prose_files, pdf_files, db)
+
+    _log.info(
+        "index_repository complete",
+        repo=str(repo),
+        code_files=len(code_files),
+        prose_files=len(prose_files),
+        pdf_files=len(pdf_files),
+    )
+```
+
+**Step 4: Add the helper functions (same file, after `_run_index`)**
+
+```python
+def _index_code_file(
+    file: Path, repo: Path, collection_name: str, target_model: str,
+    col, db, voyage_client, git_meta: dict, now_iso: str, score: float,
+) -> None:
+    """Index a single code file into the code__ collection."""
+    import hashlib as _hl
+    from nexus.chunker import chunk_file
+
+    try:
+        content = file.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError) as exc:
+        _log.debug("skipped non-text file", path=str(file), error=type(exc).__name__)
+        return
+
+    content_hash = _hl.sha256(content.encode()).hexdigest()
+
+    # Staleness check
+    existing = col.get(where={"source_path": str(file)}, include=["metadatas"], limit=1)
+    if existing["metadatas"]:
+        stored = existing["metadatas"][0]
+        if stored.get("content_hash") == content_hash and stored.get("embedding_model") == target_model:
+            return
+
+    chunks = chunk_file(file, content)
+    if not chunks:
+        _log.debug("skipped file with no chunks", path=str(file))
+        return
+    total_chunks = len(chunks)
+
+    ids: list[str] = []
+    documents: list[str] = []
+    metadatas: list[dict] = []
+
+    for i, chunk in enumerate(chunks):
+        title = f"{file.relative_to(repo)}:{chunk['line_start']}-{chunk['line_end']}"
+        doc_id = _hl.sha256(f"{collection_name}:{title}".encode()).hexdigest()[:32]
+        ext = file.suffix.lower()
+        metadata: dict = {
+            "title": title,
+            "tags": ext.lstrip("."),
+            "category": "code",
+            "session_id": "",
+            "source_agent": "nexus-indexer",
+            "store_type": "code",
+            "indexed_at": now_iso,
+            "expires_at": "",
+            "ttl_days": 0,
+            "source_path": str(file),
+            "line_start": chunk["line_start"],
+            "line_end": chunk["line_end"],
+            "frecency_score": float(score),
+            "chunk_index": chunk.get("chunk_index", i),
+            "chunk_count": chunk.get("chunk_count", total_chunks),
+            "ast_chunked": chunk.get("ast_chunked", False),
+            "filename": chunk.get("filename", str(file.name)),
+            "file_extension": chunk.get("file_extension", ext),
+            "programming_language": _EXT_TO_LANGUAGE.get(ext, ""),
+            "corpus": collection_name,
+            "embedding_model": target_model,
+            "content_hash": content_hash,
+            **git_meta,
+        }
+        ids.append(doc_id)
+        documents.append(chunk["text"])
+        metadatas.append(metadata)
+
+    embeddings: list[list[float]] = []
+    for batch_start in range(0, len(documents), _VOYAGE_EMBED_BATCH_SIZE):
+        batch = documents[batch_start : batch_start + _VOYAGE_EMBED_BATCH_SIZE]
+        result = voyage_client.embed(texts=batch, model=target_model, input_type="document")
+        embeddings.extend(result.embeddings)
+
+    db.upsert_chunks_with_embeddings(
+        collection_name=collection_name,
+        ids=ids, documents=documents, embeddings=embeddings, metadatas=metadatas,
+    )
+
+
+def _index_prose_file(
+    file: Path, repo: Path, collection_name: str, target_model: str,
+    col, db, voyage_key: str, git_meta: dict, now_iso: str, score: float,
+) -> None:
+    """Index a single prose file into the docs__ collection using CCE."""
+    import hashlib as _hl
+    from nexus.doc_indexer import _embed_with_fallback
+    from nexus.md_chunker import SemanticMarkdownChunker, parse_frontmatter
+
+    try:
+        content = file.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError) as exc:
+        _log.debug("skipped non-text file", path=str(file), error=type(exc).__name__)
+        return
+
+    content_hash = _hl.sha256(content.encode()).hexdigest()
+
+    # Staleness check
+    existing = col.get(where={"source_path": str(file)}, include=["metadatas"], limit=1)
+    if existing["metadatas"]:
+        stored = existing["metadatas"][0]
+        if stored.get("content_hash") == content_hash and stored.get("embedding_model") == target_model:
+            return
+
+    ext = file.suffix.lower()
+
+    # Chunk based on format
+    if ext == ".md":
+        raw_text = content
+        frontmatter, body = parse_frontmatter(raw_text)
+        base_meta = {"source_path": str(file), "corpus": collection_name}
+        sm_chunks = SemanticMarkdownChunker().chunk(body, base_meta)
+        if not sm_chunks:
+            return
+        chunk_texts = [c.text for c in sm_chunks]
+        chunk_metas = []
+        for i, c in enumerate(sm_chunks):
+            chunk_metas.append({
+                "title": f"{file.relative_to(repo)}:chunk-{i}",
+                "tags": "markdown",
+                "category": "prose",
+                "session_id": "",
+                "source_agent": "nexus-indexer",
+                "store_type": "prose",
+                "indexed_at": now_iso,
+                "expires_at": "",
+                "ttl_days": 0,
+                "source_path": str(file),
+                "line_start": c.metadata.get("line_start", 0),
+                "line_end": c.metadata.get("line_end", 0),
+                "frecency_score": float(score),
+                "chunk_index": i,
+                "chunk_count": len(sm_chunks),
+                "ast_chunked": False,
+                "filename": file.name,
+                "file_extension": ext,
+                "section_title": c.metadata.get("header_path", ""),
+                "corpus": collection_name,
+                "embedding_model": target_model,
+                "content_hash": content_hash,
+                **git_meta,
+            })
+    else:
+        # Line-based chunking for non-markdown prose
+        from nexus.chunker import _line_chunk
+        raw_chunks = _line_chunk(content)
+        if not raw_chunks:
+            if not content.strip():
+                return
+            raw_chunks = [(1, 1, content)]
+        chunk_texts = [text for _, _, text in raw_chunks]
+        chunk_metas = []
+        for i, (ls, le, _) in enumerate(raw_chunks):
+            chunk_metas.append({
+                "title": f"{file.relative_to(repo)}:{ls}-{le}",
+                "tags": ext.lstrip(".") if ext else "text",
+                "category": "prose",
+                "session_id": "",
+                "source_agent": "nexus-indexer",
+                "store_type": "prose",
+                "indexed_at": now_iso,
+                "expires_at": "",
+                "ttl_days": 0,
+                "source_path": str(file),
+                "line_start": ls,
+                "line_end": le,
+                "frecency_score": float(score),
+                "chunk_index": i,
+                "chunk_count": len(raw_chunks),
+                "ast_chunked": False,
+                "filename": file.name,
+                "file_extension": ext,
+                "corpus": collection_name,
+                "embedding_model": target_model,
+                "content_hash": content_hash,
+                **git_meta,
+            })
+
+    if not chunk_texts:
+        return
+
+    # Generate IDs
+    ids = [
+        _hl.sha256(f"{collection_name}:{m['title']}".encode()).hexdigest()[:32]
+        for m in chunk_metas
+    ]
+
+    # Embed with CCE fallback
+    embeddings, actual_model = _embed_with_fallback(
+        chunk_texts, target_model, voyage_key, input_type="document",
+    )
+    if actual_model != target_model:
+        for m in chunk_metas:
+            m["embedding_model"] = actual_model
+
+    db.upsert_chunks_with_embeddings(
+        collection_name=collection_name,
+        ids=ids, documents=chunk_texts, embeddings=embeddings, metadatas=chunk_metas,
+    )
+
+
+def _index_pdf_file(
+    file: Path, repo: Path, collection_name: str, target_model: str,
+    col, db, voyage_key: str, git_meta: dict, now_iso: str, score: float,
+) -> None:
+    """Index a single PDF file into the docs__ collection."""
+    import hashlib as _hl
+    from nexus.doc_indexer import _embed_with_fallback
+    from nexus.pdf_chunker import PDFChunker
+    from nexus.pdf_extractor import PDFExtractor
+
+    content_hash = _hl.sha256(file.read_bytes()).hexdigest()
+
+    # Staleness check
+    existing = col.get(where={"source_path": str(file)}, include=["metadatas"], limit=1)
+    if existing["metadatas"]:
+        stored = existing["metadatas"][0]
+        if stored.get("content_hash") == content_hash and stored.get("embedding_model") == target_model:
+            return
+
+    try:
+        result = PDFExtractor().extract(file)
+        chunks = PDFChunker().chunk(result.text, result.metadata)
+    except Exception as exc:
+        _log.warning("PDF extraction failed", path=str(file), error=str(exc))
+        return
+
+    if not chunks:
+        return
+
+    chunk_texts = [c.text for c in chunks]
+    ids = [f"{content_hash[:16]}_{c.chunk_index}" for c in chunks]
+    chunk_metas = []
+    for c in chunks:
+        chunk_metas.append({
+            "title": f"{file.relative_to(repo)}:page-{c.metadata.get('page_number', 0)}",
+            "tags": "pdf",
+            "category": "prose",
+            "session_id": "",
+            "source_agent": "nexus-indexer",
+            "store_type": "pdf",
+            "indexed_at": now_iso,
+            "expires_at": "",
+            "ttl_days": 0,
+            "source_path": str(file),
+            "line_start": 0,
+            "line_end": 0,
+            "frecency_score": float(score),
+            "chunk_index": c.chunk_index,
+            "chunk_count": len(chunks),
+            "ast_chunked": False,
+            "filename": file.name,
+            "file_extension": ".pdf",
+            "page_number": c.metadata.get("page_number", 0),
+            "corpus": collection_name,
+            "embedding_model": target_model,
+            "content_hash": content_hash,
+            **git_meta,
+        })
+
+    embeddings, actual_model = _embed_with_fallback(
+        chunk_texts, target_model, voyage_key, input_type="document",
+    )
+    if actual_model != target_model:
+        for m in chunk_metas:
+            m["embedding_model"] = actual_model
+
+    db.upsert_chunks_with_embeddings(
+        collection_name=collection_name,
+        ids=ids, documents=chunk_texts, embeddings=embeddings, metadatas=chunk_metas,
+    )
+
+
+def _discover_and_index_rdrs(
+    repo: Path, rdr_abs_paths: list[Path], db, voyage_key: str, now_iso: str,
+) -> None:
+    """Discover and index RDR documents into docs__rdr__<repo-name>."""
+    from nexus.doc_indexer import batch_index_markdowns
+
+    _RDR_EXCLUDES = {"README.md", "TEMPLATE.md"}
+    rdr_files: list[Path] = []
+
+    for rdr_dir in rdr_abs_paths:
+        if not rdr_dir.is_dir():
+            continue
+        rdr_files.extend(
+            p for p in sorted(rdr_dir.glob("*.md"))
+            if p.is_file() and p.name not in _RDR_EXCLUDES
+        )
+
+    if not rdr_files:
+        return
+
+    corpus = f"rdr__{repo.name}"
+    _log.info("RDR discovery", repo=str(repo), rdr_count=len(rdr_files), corpus=f"docs__{corpus}")
+
+    batch_index_markdowns(rdr_files, corpus)
+
+
+def _prune_misclassified(
+    repo: Path,
+    code_collection: str,
+    docs_collection: str,
+    code_files: list[tuple[float, Path]],
+    prose_files: list[tuple[float, Path]],
+    pdf_files: list[tuple[float, Path]],
+    db,
+) -> None:
+    """Remove chunks from the wrong collection after reclassification.
+
+    E.g., if a .md file was previously in code__ (old indexer), delete those chunks.
+    """
+    code_paths = {str(f) for _, f in code_files}
+    docs_paths = {str(f) for _, f in prose_files} | {str(f) for _, f in pdf_files}
+
+    # Check code__ for prose/PDF files that don't belong
+    code_col = db.get_or_create_collection(code_collection)
+    _prune_collection(code_col, docs_paths)
+
+    # Check docs__ for code files that don't belong
+    docs_col = db.get_or_create_collection(docs_collection)
+    _prune_collection(docs_col, code_paths)
+
+
+def _prune_collection(col, wrong_paths: set[str]) -> None:
+    """Delete chunks from *col* whose source_path is in *wrong_paths*."""
+    for source_path in wrong_paths:
+        existing = col.get(where={"source_path": source_path}, include=[])
+        if existing["ids"]:
+            col.delete(ids=existing["ids"])
+            _log.debug("pruned misclassified chunks", source_path=source_path, count=len(existing["ids"]))
+```
+
+**Step 5: Update `_run_index_frecency_only` to handle both collections**
+
+Replace `_run_index_frecency_only` (lines 101-137):
+
+```python
+def _run_index_frecency_only(repo: Path, registry: "RepoRegistry") -> None:
+    """Update frecency_score metadata on all indexed chunks without re-embedding."""
+    from nexus.config import get_credential
+    from nexus.frecency import batch_frecency
+    from nexus.db import make_t3
+
+    info = registry.get(repo)
+    if info is None:
+        return
+
+    voyage_key = get_credential("voyage_api_key")
+    chroma_key = get_credential("chroma_api_key")
+    if not voyage_key or not chroma_key:
+        raise CredentialsMissingError(
+            f"T3 credentials missing for frecency reindex of '{repo.name}'"
+        )
+
+    frecency_map = batch_frecency(repo)
+    db = make_t3()
+
+    # Update frecency in both code__ and docs__ collections
+    collection_names = [
+        info.get("code_collection", info["collection"]),
+    ]
+    docs_col = info.get("docs_collection")
+    if docs_col:
+        collection_names.append(docs_col)
+
+    for collection_name in collection_names:
+        col = db.get_or_create_collection(collection_name)
+        for file, score in frecency_map.items():
+            existing = col.get(
+                where={"source_path": str(file)},
+                include=["metadatas"],
+            )
+            if not existing["ids"]:
+                continue
+            updated_metadatas = [
+                {**m, "frecency_score": float(score)}
+                for m in existing["metadatas"]
+            ]
+            db.update_chunks(collection=collection_name, ids=existing["ids"], metadatas=updated_metadatas)
+```
+
+**Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_indexer.py -v`
+Expected: All PASS (including new routing tests)
+
+**Step 7: Run full suite**
+
+Run: `uv run pytest tests/ -x -q`
+Expected: All pass
+
+**Step 8: Commit**
+
+```bash
+git add src/nexus/indexer.py tests/test_indexer.py
+git commit -m "feat: unified indexer pipeline with code/prose/PDF classification and dual collections"
+```
+
+---
+
+### Task 7: CLI Rename — `nx index code` → `nx index repo`
+
+**Files:**
+- Modify: `src/nexus/commands/index.py:23-43`
+- Modify: `tests/test_index_cmd.py`
+
+**Step 1: Update the command**
+
+In `src/nexus/commands/index.py`, change:
+
+```python
+@index.command("repo")
+@click.argument("path", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option(
+    "--frecency-only",
+    is_flag=True,
+    default=False,
+    help="Update frecency scores only; skip re-embedding (faster, for re-ranking refresh).",
+)
+def index_repo_cmd(path: Path, frecency_only: bool) -> None:
+    """Register and immediately index a code repository at PATH.
+
+    Classifies files by extension: code files get voyage-code-3 embeddings (code__),
+    prose and PDFs get voyage-context-3 embeddings (docs__), RDR documents are
+    auto-discovered and indexed into docs__rdr__.
+    """
+    from nexus.indexer import index_repository
+
+    reg = _registry()
+    path = path.resolve()
+    if reg.get(path) is None:
+        reg.add(path)
+        click.echo(f"Registered {path}.")
+
+    click.echo(f"{'Updating frecency scores' if frecency_only else 'Indexing'} {path}…")
+    index_repository(path, reg, frecency_only=frecency_only)
+    click.echo("Done.")
+```
+
+**Step 2: Update tests — change "code" to "repo"**
+
+In `tests/test_index_cmd.py`, replace all occurrences of `"code"` in CLI invocations with `"repo"`:
+
+- `["index", "code", str(repo)]` → `["index", "repo", str(repo)]`
+- `["index", "code", str(repo), "--frecency-only"]` → `["index", "repo", str(repo), "--frecency-only"]`
+- `["index", "code", str(index_home / "nonexistent")]` → `["index", "repo", str(index_home / "nonexistent")]`
+
+Update test names and docstrings similarly.
+
+**Step 3: Update E2E tests — change "code" to "repo"**
+
+In `tests/test_indexer_e2e.py`:
+
+- `["index", "code", str(mini_repo)]` → `["index", "repo", str(mini_repo)]`
+- `["index", "code", str(mini_repo), "--frecency-only"]` → `["index", "repo", str(mini_repo), "--frecency-only"]`
+
+**Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_index_cmd.py tests/test_indexer_e2e.py -v`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/nexus/commands/index.py tests/test_index_cmd.py tests/test_indexer_e2e.py
+git commit -m "feat: rename 'nx index code' to 'nx index repo' (clean break, no aliases)"
+```
+
+---
+
+### Task 8: E2E Tests — Dual Collection Pipeline
+
+**Files:**
+- Modify: `tests/test_indexer_e2e.py` (add new E2E tests)
+
+**Step 1: Create a richer mini_repo fixture**
+
+Add to `tests/test_indexer_e2e.py`:
+
+```python
+# Additional corpus files for smart indexing tests
+_PROSE_FILES = {
+    "README.md": "# Nexus\n\nNexus is a semantic search and knowledge management system.\n\n"
+                 "## Features\n\n- Semantic search across code repositories\n"
+                 "- Persistent memory across sessions\n- Three storage tiers\n",
+    "docs/architecture.md": "# Architecture\n\n## Overview\n\nNexus uses a three-tier storage model.\n\n"
+                            "### T1 — Session Scratch\n\nEphemeral ChromaDB with DefaultEmbeddingFunction.\n\n"
+                            "### T3 — Permanent Knowledge\n\nChromaDB Cloud with Voyage AI embeddings.\n",
+    "config.yaml": "server:\n  port: 7890\n  headPollInterval: 10\nembeddings:\n  rerankerModel: rerank-2.5\n",
+}
+
+_RDR_FILES = {
+    "docs/rdr/ADR-001-storage-tiers.md": "---\ntitle: Storage Tier Architecture\nstatus: accepted\n---\n\n"
+                                          "# ADR-001: Storage Tier Architecture\n\n"
+                                          "## Decision\n\nWe use three storage tiers.\n",
+}
+
+
+@pytest.fixture(scope="module")
+def rich_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A git repo with code, prose, and RDR files for smart indexing tests."""
+    repo = tmp_path_factory.mktemp("nexus-rich")
+
+    # Code files
+    for rel in _CORPUS_FILES:
+        src = _NEXUS_ROOT / rel
+        dest = repo / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+
+    # Prose files
+    for rel, content in _PROSE_FILES.items():
+        dest = repo / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
+
+    # RDR files
+    for rel, content in _RDR_FILES.items():
+        dest = repo / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@nexus"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Nexus Test"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial rich corpus"], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+@pytest.fixture
+def rich_registry(tmp_path: Path, rich_repo: Path) -> RepoRegistry:
+    reg = RepoRegistry(tmp_path / "repos.json")
+    reg.add(rich_repo)
+    return reg
+```
+
+**Step 2: Write E2E tests for dual-collection indexing**
+
+```python
+# ── Smart repo indexing E2E tests ────────────────────────────────────────────
+
+def test_smart_index_creates_both_collections(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """index_repository creates chunks in both code__ and docs__ collections."""
+    from nexus.indexer import index_repository
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, rich_registry)
+
+    info = rich_registry.get(rich_repo)
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+
+    assert code_col.count() > 0, "Expected code chunks in code__ collection"
+    assert docs_col.count() > 0, "Expected prose chunks in docs__ collection"
+
+
+def test_smart_index_code_files_in_code_collection(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Python source files end up in the code__ collection."""
+    from nexus.indexer import index_repository
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, rich_registry)
+
+    info = rich_registry.get(rich_repo)
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    result = code_col.get(include=["metadatas"])
+    source_paths = {m.get("source_path", "") for m in result["metadatas"]}
+
+    assert any("ttl.py" in p for p in source_paths), f"Expected ttl.py in code__; got: {source_paths}"
+    assert any("corpus.py" in p for p in source_paths)
+    # Prose files must NOT be in code__
+    assert not any("README.md" in p for p in source_paths), "README.md should not be in code__"
+
+
+def test_smart_index_prose_files_in_docs_collection(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Markdown and YAML files end up in the docs__ collection."""
+    from nexus.indexer import index_repository
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, rich_registry)
+
+    info = rich_registry.get(rich_repo)
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+    result = docs_col.get(include=["metadatas"])
+    source_paths = {m.get("source_path", "") for m in result["metadatas"]}
+
+    assert any("README.md" in p for p in source_paths), f"Expected README.md in docs__; got: {source_paths}"
+    assert any("architecture.md" in p for p in source_paths)
+    assert any("config.yaml" in p for p in source_paths)
+    # Code files must NOT be in docs__
+    assert not any("ttl.py" in p for p in source_paths), "ttl.py should not be in docs__"
+
+
+def test_smart_index_rdr_excluded_from_docs(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """RDR files are NOT in the docs__repo collection (they go to docs__rdr__)."""
+    from nexus.indexer import index_repository
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, rich_registry)
+
+    info = rich_registry.get(rich_repo)
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+    result = docs_col.get(include=["metadatas"])
+    source_paths = {m.get("source_path", "") for m in result["metadatas"]}
+
+    assert not any("ADR-001" in p for p in source_paths), (
+        f"RDR files should not be in docs__ collection; got: {source_paths}"
+    )
+
+
+def test_smart_index_search_code_query(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Code-specific query returns results from code__ collection."""
+    from nexus.indexer import index_repository
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, rich_registry)
+
+    info = rich_registry.get(rich_repo)
+    results = local_t3.search("parse TTL days weeks permanent", [info["code_collection"]], n_results=5)
+    assert len(results) > 0
+    source_paths = [r.get("source_path", "") for r in results]
+    assert any("ttl.py" in p for p in source_paths)
+
+
+def test_smart_index_search_prose_query(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Natural language query returns results from docs__ collection."""
+    from nexus.indexer import index_repository
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, rich_registry)
+
+    info = rich_registry.get(rich_repo)
+    results = local_t3.search(
+        "semantic search knowledge management system features",
+        [info["docs_collection"]],
+        n_results=5,
+    )
+    assert len(results) > 0
+    source_paths = [r.get("source_path", "") for r in results]
+    assert any("README.md" in p for p in source_paths), (
+        f"Expected README.md in prose search results; got: {source_paths}"
+    )
+
+
+def test_smart_index_embedding_model_metadata(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Chunks record the correct embedding_model in metadata."""
+    from nexus.indexer import index_repository
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, rich_registry)
+
+    info = rich_registry.get(rich_repo)
+
+    # Code chunks should record voyage-code-3
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    code_result = code_col.get(include=["metadatas"], limit=1)
+    if code_result["metadatas"]:
+        assert code_result["metadatas"][0].get("embedding_model") == "voyage-code-3"
+
+    # Docs chunks should record voyage-context-3 (or voyage-4 fallback for single-chunk)
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+    docs_result = docs_col.get(include=["metadatas"], limit=1)
+    if docs_result["metadatas"]:
+        model = docs_result["metadatas"][0].get("embedding_model", "")
+        assert model in ("voyage-context-3", "voyage-4"), f"Unexpected docs model: {model}"
+
+
+def test_smart_index_staleness_check(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Second index run skips unchanged files in both collections."""
+    from nexus.indexer import index_repository
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, rich_registry)
+
+        info = rich_registry.get(rich_repo)
+        code_count = local_t3.get_or_create_collection(info["code_collection"]).count()
+        docs_count = local_t3.get_or_create_collection(info["docs_collection"]).count()
+
+        # Re-index unchanged repo
+        index_repository(rich_repo, rich_registry)
+
+        assert local_t3.get_or_create_collection(info["code_collection"]).count() == code_count
+        assert local_t3.get_or_create_collection(info["docs_collection"]).count() == docs_count
+
+
+def test_smart_index_git_metadata_present(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """All chunks carry git metadata for historical repo access."""
+    from nexus.indexer import index_repository
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, rich_registry)
+
+    info = rich_registry.get(rich_repo)
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    result = code_col.get(include=["metadatas"], limit=1)
+    meta = result["metadatas"][0]
+
+    assert meta.get("git_commit_hash"), "git_commit_hash must be set"
+    assert meta.get("git_branch") == "main"
+    assert meta.get("source_path"), "source_path must be set"
+```
+
+**Step 2: Run E2E tests**
+
+Run: `uv run pytest tests/test_indexer_e2e.py -v -k "smart"`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_indexer_e2e.py
+git commit -m "test: add E2E tests for smart repo indexing with dual collections"
+```
+
+---
+
+### Task 9: E2E Test — Migration from Old Single-Collection
+
+**Files:**
+- Modify: `tests/test_indexer_e2e.py`
+
+**Step 1: Write migration E2E test**
+
+```python
+def test_migration_moves_prose_from_code_to_docs(
+    rich_repo: Path, tmp_path: Path, local_t3: T3Database,
+) -> None:
+    """Simulates old indexer (all in code__), then runs new indexer to verify migration."""
+    from nexus.indexer import index_repository
+
+    # Create a registry that only has the old-style 'collection' key
+    reg = RepoRegistry(tmp_path / "repos.json")
+    reg.add(rich_repo)
+    info = reg.get(rich_repo)
+    code_col_name = info["code_collection"]
+    docs_col_name = info["docs_collection"]
+
+    # Manually insert a prose file's chunk into code__ (simulating old behavior)
+    code_col = local_t3.get_or_create_collection(code_col_name)
+    readme_path = str(rich_repo / "README.md")
+    code_col.add(
+        ids=["fake-prose-in-code"],
+        documents=["Nexus is a semantic search system"],
+        metadatas=[{
+            "source_path": readme_path,
+            "content_hash": "old-hash",
+            "embedding_model": "voyage-code-3",
+            "store_type": "code",
+        }],
+    )
+    assert code_col.count() == 1
+
+    # Run the new unified indexer
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, reg)
+
+    # The fake prose chunk should have been pruned from code__
+    code_result = code_col.get(include=["metadatas"])
+    code_sources = {m.get("source_path", "") for m in code_result["metadatas"]}
+    assert readme_path not in code_sources, "README.md should be pruned from code__ after migration"
+
+    # README.md should now be in docs__
+    docs_col = local_t3.get_or_create_collection(docs_col_name)
+    docs_result = docs_col.get(include=["metadatas"])
+    docs_sources = {m.get("source_path", "") for m in docs_result["metadatas"]}
+    assert any("README.md" in p for p in docs_sources), "README.md should be in docs__ after migration"
+```
+
+**Step 2: Run test**
+
+Run: `uv run pytest tests/test_indexer_e2e.py::test_migration_moves_prose_from_code_to_docs -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_indexer_e2e.py
+git commit -m "test: add migration E2E test for prose chunks moving from code__ to docs__"
+```
+
+---
+
+### Task 10: Documentation Updates
+
+**Files:**
+- Modify: `spec.md` — update `nx index code` references to `nx index repo`, document new collection scheme
+- Modify: `ARCHITECTURE.md` — if it exists, update indexing pipeline description
+- Modify: `CLAUDE.md` — update `nx index code` → `nx index repo` reference
+- Modify: `nx/skills/nexus/SKILL.md` — update quick reference command
+- Modify: `nx/README.md` — update command reference if `nx index code` is mentioned
+
+**Step 1: Find and update all references**
+
+Search for `"nx index code"` and `"index code"` across the codebase:
+
+Run: `uv run grep -rn "index code" --include="*.md" --include="*.py" .` to find all references
+
+Then update each one to `nx index repo` / `index repo`.
+
+Key files to update:
+
+In `nx/skills/nexus/SKILL.md` (line 43):
+```
+nx index code <path>                 # index code repo
+```
+→
+```
+nx index repo <path>                 # index repository (code + prose + PDFs)
+```
+
+In `CLAUDE.md`, the Knowledge Architecture section:
+```
+2. Index current codebase: `nx index code <path>` (do this once per repo)
+```
+→
+```
+2. Index current codebase: `nx index repo <path>` (do this once per repo)
+```
+
+In `nx/hooks/scripts/permission-request-stdin.sh` if it auto-approves `nx index`:
+Check if pattern-matched — likely already works since `nx index` is the prefix.
+
+**Step 2: Run full test suite**
+
+Run: `uv run pytest tests/ -x -q`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "docs: update all references from 'nx index code' to 'nx index repo'"
+```
+
+---
+
+### Task 11: Final Integration Test Run
+
+**Step 1: Run the full test suite**
+
+Run: `uv run pytest tests/ -v --tb=short`
+Expected: All tests pass
+
+**Step 2: Run E2E tests specifically**
+
+Run: `uv run pytest tests/test_indexer_e2e.py -v`
+Expected: All pass, including:
+- Original tests (adapted for `nx index repo`)
+- Smart indexing: dual collections, search routing, metadata, staleness
+- Migration: prose chunks move from code__ to docs__
+
+**Step 3: Run classifier + config tests**
+
+Run: `uv run pytest tests/test_classifier.py tests/test_config.py -v`
+Expected: All pass
+
+**Step 4: Verify no regressions in existing functionality**
+
+Run: `uv run pytest tests/test_index_rdr_cmd.py tests/test_search.py -v`
+Expected: All pass (RDR command and search are unchanged)

--- a/nx/agents/_shared/MAINTENANCE.md
+++ b/nx/agents/_shared/MAINTENANCE.md
@@ -102,7 +102,7 @@ Update version in frontmatter when making significant changes to an agent.
 - Content comes from original agent's PRODUCE section
 
 **nx search not returning results**:
-- Run `nx index code <path>` first to index the repo
+- Run `nx index repo <path>` first to index the repo
 - Use `--hybrid` flag for best results with code
 - Try broader queries if results are sparse
 - Use `nx doctor` to verify Nexus server is running

--- a/nx/agents/codebase-deep-analyzer.md
+++ b/nx/agents/codebase-deep-analyzer.md
@@ -44,7 +44,7 @@ You are an elite codebase architect and analysis specialist with deep expertise 
 ### Phase 0 — Index Repository with Nexus
 
 Before analysis, ensure the codebase is indexed:
-1. Run `nx index code <path>` to index the repository (if not already done)
+1. Run `nx index repo <path>` to index the repository (if not already done)
 2. Use `nx search "query" --corpus code__<repo> --hybrid --n 20` for semantic code search throughout analysis
 3. Use `nx search "query" --corpus code --hybrid` for cross-repo searches
 

--- a/nx/skills/nexus/SKILL.md
+++ b/nx/skills/nexus/SKILL.md
@@ -40,7 +40,7 @@ nx pm status                         # current phase, blockers
 nx pm resume                         # inject continuation context
 
 # Indexing
-nx index code <path>                 # index code repo
+nx index repo <path>                 # index repo (classifies into code + docs collections)
 ```
 
 ## Collection Naming

--- a/nx/skills/nexus/reference.md
+++ b/nx/skills/nexus/reference.md
@@ -1,6 +1,6 @@
 # Nexus — Agent Usage Guide
 
-Nexus gives you a single CLI to index code, PDFs, and notes; search across all of them semantically; and manage persistent memory across sessions.
+Nexus gives you a single CLI to index repositories, PDFs, and notes; search across all of them semantically; and manage persistent memory across sessions.
 
 **Three storage tiers:**
 - **T1 scratch** — in-memory, session-scoped (`nx scratch`)
@@ -73,8 +73,8 @@ nx scratch clear
 ## Indexing
 
 ```bash
-nx index code <path>                       # register and index a code repo
-nx index code <path> --frecency-only       # refresh git frecency scores only (fast)
+nx index repo <path>                       # register and index a repo (classifies into code + docs collections)
+nx index repo <path> --frecency-only       # refresh git frecency scores only (fast)
 nx index pdf <path> --corpus my-papers
 nx index md  <path> --corpus notes
 ```
@@ -111,7 +111,7 @@ nx serve logs
 
 **Session lifecycle:**
 1. Search T3 for prior art before starting work: `nx search "topic" --corpus knowledge`
-2. Index the codebase once per repo: `nx index code <path>`
+2. Index the codebase once per repo: `nx index repo <path>`
 3. Use T1 scratch for working notes during the session
 4. Flag important scratch items for auto-promote to T2: `nx scratch flag <id>`
 5. Persist validated findings to T3 at session end: `nx store put`

--- a/spec.md
+++ b/spec.md
@@ -165,8 +165,8 @@ WHERE ttl IS NOT NULL
 `nx serve` is a single persistent Flask/Waitress process managing multiple repositories:
 
 - **Repo registry**: `~/.config/nexus/repos.json` — list of registered repo paths with per-repo state
-- `nx index code <path>` adds the path to the registry and triggers initial indexing
-- Each repo has its own T3 collection (`code__{repo-name}`) and ripgrep line cache file
+- `nx index repo <path>` adds the path to the registry and triggers initial indexing
+- Each repo has its own T3 collections (`code__{repo-name}` for source code, `docs__{repo-name}` for documentation) and ripgrep line cache file
 - HEAD polling runs per-repo every 10 seconds (configurable via `server.headPollInterval`); stale repos are re-indexed automatically
 - **Concurrent access**: polling threads and Flask handlers share three resources requiring explicit locking: (1) `repos.json` — use `threading.RLock` + atomic write (`repos.json.tmp` → `os.replace()`); (2) ripgrep cache file — use per-repo `threading.RLock`; exclusive lock during rebuild, shared lock during hybrid search reads; (3) indexing progress counters — update atomically or hold the per-repo lock. Waitress runs with `threads=1` (eliminates Flask-level concurrency) but does not protect against concurrent polling threads
 - Optional: `nx install claude-code` sets a post-commit hook as an additional trigger alongside polling
@@ -174,7 +174,7 @@ WHERE ttl IS NOT NULL
 
 ### Code Repositories
 
-1. `nx index code <path>` registers the repo with the persistent `nx serve` process
+1. `nx index repo <path>` registers the repo with the persistent `nx serve` process
 2. `git log` to compute frecency scores per file: `sum(exp(-0.01 * days_passed))`
 3. Files chunked: AST-first via `llama_index.core.node_parser.CodeSplitter` (which wraps `tree-sitter-language-pack` internally) for 30+ languages including Python, JS/TS, Java, Go, Rust, C, C++, C#, PHP, Ruby, Kotlin, Scala, Swift, and more — line-based fallback for unsupported extensions. Target ~150 lines per chunk; no overlap at function/class boundaries; 15% overlap for line-based fallback. Install: `pip install llama-index-core tree-sitter-language-pack`. **Version pinning required**: known breaking incompatibilities exist between these packages at certain version combinations (see llama_index issues #13521, #17567); pin to a verified-good pair in `pyproject.toml` and test before upgrading.
 4. Chunks embedded via `voyageai.Client().embed(model="voyage-code-3", input_type="document")` (direct SDK call; bypasses ChromaDB's `VoyageAIEmbeddingFunction`). Batched at 128 texts per API call. Stored via `upsert_chunks_with_embeddings()` so ChromaDB's collection EF is not invoked at write time.
@@ -874,7 +874,7 @@ Recent memory ({project}, last 10 entries):
 /nx:search <query> -a           — search + Haiku answer synthesis
 /nx:store <content>             — persist to T3 knowledge
 /nx:memory <content>            — write to T2 SQLite
-/nx:index code <path>           — index a code repo (registers with nx serve)
+/nx:index repo <path>           — index a repo (classifies into code + docs collections)
 /nx:index pdf <path>            — index PDFs
 /nx:scratch <content>           — write to T1 (session only)
 /nx:doctor                      — health check

--- a/src/nexus/chunker.py
+++ b/src/nexus/chunker.py
@@ -35,12 +35,17 @@ def _make_code_splitter(language: str, content: str) -> list:
     """Chunk *content* via CodeSplitter for *language*; returns list of nodes.
 
     All llama-index imports live here so tests can patch this single function.
+    Uses tree-sitter-language-pack to obtain the parser, passing it explicitly
+    to CodeSplitter (which otherwise tries the deprecated tree_sitter_languages).
     """
     from llama_index.core import Document  # type: ignore[import]
     from llama_index.core.node_parser import CodeSplitter  # type: ignore[import]
+    from tree_sitter_language_pack import get_parser  # type: ignore[import]
 
+    parser = get_parser(language)
     splitter = CodeSplitter(
         language=language,
+        parser=parser,
         chunk_lines=_CHUNK_LINES,
         chunk_lines_overlap=int(_CHUNK_LINES * _OVERLAP),
     )

--- a/src/nexus/chunker.py
+++ b/src/nexus/chunker.py
@@ -25,9 +25,6 @@ _AST_EXTENSIONS: dict[str, str] = {
     ".cs": "c_sharp",
     ".sh": "bash",
     ".bash": "bash",
-    ".toml": "toml",
-    ".yaml": "yaml",
-    ".yml": "yaml",
 }
 
 _CHUNK_LINES = 150

--- a/src/nexus/classifier.py
+++ b/src/nexus/classifier.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""File classification for repository indexing.
+
+Extension-based classification determines which embedding model and chunking
+strategy each file receives during repository indexing.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class ContentClass(Enum):
+    """Content classification for a repository file."""
+    CODE = "code"
+    PROSE = "prose"
+    PDF = "pdf"
+
+
+# Canonical code extensions — the greppable, authoritative list.
+# Everything NOT in this set (and not .pdf) is treated as prose.
+_CODE_EXTENSIONS: frozenset[str] = frozenset({
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".java", ".go", ".rs",
+    ".cpp", ".cc", ".c", ".h", ".hpp", ".rb", ".cs", ".sh", ".bash",
+    ".kt", ".swift", ".scala", ".r", ".m", ".php",
+})
+
+
+def classify_file(
+    path: Path,
+    *,
+    indexing_config: dict[str, Any] | None = None,
+) -> ContentClass:
+    """Classify *path* as code, prose, or PDF based on its extension.
+
+    *indexing_config* is the ``indexing`` section from ``.nexus.yml``:
+    - ``code_extensions``: list of extensions to add to the code set
+    - ``prose_extensions``: list of extensions forced to prose (wins over all)
+    """
+    ext = path.suffix.lower()
+
+    if ext == ".pdf":
+        return ContentClass.PDF
+
+    cfg = indexing_config or {}
+    prose_overrides = set(cfg.get("prose_extensions", []))
+    code_additions = set(cfg.get("code_extensions", []))
+
+    # prose_extensions wins over everything
+    if ext in prose_overrides:
+        return ContentClass.PROSE
+
+    # code_extensions adds to defaults
+    effective_code = _CODE_EXTENSIONS | code_additions
+    if ext in effective_code:
+        return ContentClass.CODE
+
+    return ContentClass.PROSE

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -20,7 +20,7 @@ def index() -> None:
     """Index code repositories for semantic search."""
 
 
-@index.command("code")
+@index.command("repo")
 @click.argument("path", type=click.Path(exists=True, file_okay=False, path_type=Path))
 @click.option(
     "--frecency-only",
@@ -28,8 +28,13 @@ def index() -> None:
     default=False,
     help="Update frecency scores only; skip re-embedding (faster, for re-ranking refresh).",
 )
-def index_code_cmd(path: Path, frecency_only: bool) -> None:
-    """Register and immediately index a code repository at PATH."""
+def index_repo_cmd(path: Path, frecency_only: bool) -> None:
+    """Register and immediately index a code repository at PATH.
+
+    Classifies files by extension: code files get voyage-code-3 embeddings (code__),
+    prose and PDFs get voyage-context-3 embeddings (docs__), RDR documents are
+    auto-discovered and indexed into docs__rdr__.
+    """
     from nexus.indexer import index_repository
 
     reg = _registry()

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -59,6 +59,7 @@ _DEFAULTS: dict[str, Any] = {
         "code_extensions": [],
         "prose_extensions": [],
         "rdr_paths": ["docs/rdr"],
+        "include_untracked": False,
     },
 }
 

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -55,6 +55,11 @@ _DEFAULTS: dict[str, Any] = {
     "client": {
         "host": "localhost",
     },
+    "indexing": {
+        "code_extensions": [],
+        "prose_extensions": [],
+        "rdr_paths": ["docs/rdr"],
+    },
 }
 
 # Env var → (section, key, type) mapping

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -145,7 +145,7 @@ def _run_index_frecency_only(repo: Path, registry: "RepoRegistry") -> None:
                 include=["metadatas"],
             )
             if not existing["ids"]:
-                continue  # not yet indexed — needs full nx index code
+                continue  # not yet indexed — needs full nx index repo
 
             updated_metadatas = [
                 {**m, "frecency_score": float(score)}

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -73,7 +73,13 @@ def _should_ignore(rel_path: Path, patterns: list[str]) -> bool:
 
 
 def index_repository(repo: Path, registry: "RepoRegistry", *, frecency_only: bool = False) -> None:
-    """Index all files in *repo* into the T3 code__ collection.
+    """Index all files in *repo* into T3 code__ and docs__ collections.
+
+    Files are classified and routed:
+    - Code → code__ collection (voyage-code-3, AST chunking)
+    - Prose → docs__ collection (voyage-context-3, semantic chunking)
+    - PDF → docs__ collection (PDF extraction + voyage-context-3)
+    - RDR markdown → docs__rdr__ collection
 
     Marks status as 'indexing' while running, 'ready' on success,
     'pending_credentials' when T3 credentials are absent.
@@ -99,16 +105,22 @@ def index_repository(repo: Path, registry: "RepoRegistry", *, frecency_only: boo
 
 
 def _run_index_frecency_only(repo: Path, registry: "RepoRegistry") -> None:
-    """Update frecency_score metadata on all indexed chunks without re-embedding."""
+    """Update frecency_score metadata on all indexed chunks without re-embedding.
+
+    Handles both code__ and docs__ collections.
+    """
     from nexus.config import get_credential
     from nexus.frecency import batch_frecency
     from nexus.db import make_t3
+    from nexus.registry import _docs_collection_name
 
     info = registry.get(repo)
     if info is None:
         return
 
-    collection_name = info["collection"]
+    # C2: use deterministic naming function as fallback
+    code_collection = info.get("code_collection", info["collection"])
+    docs_collection = info.get("docs_collection") or _docs_collection_name(repo)
 
     voyage_key = get_credential("voyage_api_key")
     chroma_key = get_credential("chroma_api_key")
@@ -119,42 +131,489 @@ def _run_index_frecency_only(repo: Path, registry: "RepoRegistry") -> None:
 
     frecency_map = batch_frecency(repo)
     db = make_t3()
-    col = db.get_or_create_collection(collection_name)
 
-    for file, score in frecency_map.items():
-        existing = col.get(
-            where={"source_path": str(file)},
-            include=["metadatas"],
-        )
-        if not existing["ids"]:
-            continue  # not yet indexed — needs full nx index code
+    # Update frecency in both collections
+    collection_names = [code_collection]
+    if docs_collection:
+        collection_names.append(docs_collection)
 
-        updated_metadatas = [
-            {**m, "frecency_score": float(score)}
-            for m in existing["metadatas"]
-        ]
-        db.update_chunks(collection=collection_name, ids=existing["ids"], metadatas=updated_metadatas)
+    for collection_name in collection_names:
+        col = db.get_or_create_collection(collection_name)
+        for file, score in frecency_map.items():
+            existing = col.get(
+                where={"source_path": str(file)},
+                include=["metadatas"],
+            )
+            if not existing["ids"]:
+                continue  # not yet indexed — needs full nx index code
+
+            updated_metadatas = [
+                {**m, "frecency_score": float(score)}
+                for m in existing["metadatas"]
+            ]
+            db.update_chunks(collection=collection_name, ids=existing["ids"], metadatas=updated_metadatas)
+
+
+# ── Per-file indexing helpers ────────────────────────────────────────────────
+
+
+def _index_code_file(
+    file: Path,
+    repo: Path,
+    collection_name: str,
+    target_model: str,
+    col: object,
+    db: object,
+    voyage_client: object,
+    git_meta: dict,
+    now_iso: str,
+    score: float,
+) -> bool:
+    """Index a single code file into the code__ collection.
+
+    Returns True if the file was indexed (upserted), False if skipped.
+    """
+    import hashlib as _hl
+    from nexus.chunker import chunk_file
+
+    try:
+        content = file.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError) as exc:
+        _log.debug("skipped non-text file", path=str(file), error=type(exc).__name__)
+        return False
+
+    content_hash = _hl.sha256(content.encode()).hexdigest()
+
+    # Staleness check
+    existing = col.get(
+        where={"source_path": str(file)},
+        include=["metadatas"],
+        limit=1,
+    )
+    if existing["metadatas"]:
+        stored = existing["metadatas"][0]
+        if stored.get("content_hash") == content_hash and stored.get("embedding_model") == target_model:
+            return False
+
+    chunks = chunk_file(file, content)
+    if not chunks:
+        _log.debug("skipped file with no chunks", path=str(file))
+        return False
+    total_chunks = len(chunks)
+
+    ids: list[str] = []
+    documents: list[str] = []
+    metadatas: list[dict] = []
+
+    for i, chunk in enumerate(chunks):
+        title = f"{file.relative_to(repo)}:{chunk['line_start']}-{chunk['line_end']}"
+        doc_id = _hl.sha256(f"{collection_name}:{title}".encode()).hexdigest()[:32]
+        ext = file.suffix.lower()
+        metadata: dict = {
+            "title": title,
+            "tags": ext.lstrip("."),
+            "category": "code",
+            "session_id": "",
+            "source_agent": "nexus-indexer",
+            "store_type": "code",
+            "indexed_at": now_iso,
+            "expires_at": "",
+            "ttl_days": 0,
+            "source_path": str(file),
+            "line_start": chunk["line_start"],
+            "line_end": chunk["line_end"],
+            "frecency_score": float(score),
+            "chunk_index": chunk.get("chunk_index", i),
+            "chunk_count": chunk.get("chunk_count", total_chunks),
+            "ast_chunked": chunk.get("ast_chunked", False),
+            "filename": chunk.get("filename", str(file.name)),
+            "file_extension": chunk.get("file_extension", ext),
+            "programming_language": _EXT_TO_LANGUAGE.get(ext, ""),
+            "corpus": collection_name,
+            "embedding_model": target_model,
+            "content_hash": content_hash,
+            **git_meta,
+        }
+        ids.append(doc_id)
+        documents.append(chunk["text"])
+        metadatas.append(metadata)
+
+    # Embed with voyage-code-3 direct call; batch per API limit
+    embeddings: list[list[float]] = []
+    for batch_start in range(0, len(documents), _VOYAGE_EMBED_BATCH_SIZE):
+        batch = documents[batch_start : batch_start + _VOYAGE_EMBED_BATCH_SIZE]
+        result = voyage_client.embed(texts=batch, model=target_model, input_type="document")
+        embeddings.extend(result.embeddings)
+
+    db.upsert_chunks_with_embeddings(
+        collection_name=collection_name,
+        ids=ids,
+        documents=documents,
+        embeddings=embeddings,
+        metadatas=metadatas,
+    )
+    return True
+
+
+def _index_prose_file(
+    file: Path,
+    repo: Path,
+    collection_name: str,
+    target_model: str,
+    col: object,
+    db: object,
+    voyage_key: str,
+    git_meta: dict,
+    now_iso: str,
+    score: float,
+) -> bool:
+    """Index a single prose file into the docs__ collection.
+
+    Uses SemanticMarkdownChunker for .md files, _line_chunk for all others.
+    Embeds via _embed_with_fallback (CCE for voyage-context-3).
+
+    Returns True if the file was indexed (upserted), False if skipped.
+    """
+    import hashlib as _hl
+    from nexus.chunker import _line_chunk
+    from nexus.doc_indexer import _embed_with_fallback
+    from nexus.md_chunker import SemanticMarkdownChunker, parse_frontmatter
+
+    try:
+        content = file.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError) as exc:
+        _log.debug("skipped non-text file", path=str(file), error=type(exc).__name__)
+        return False
+
+    content_hash = _hl.sha256(content.encode()).hexdigest()
+
+    # Staleness check
+    existing = col.get(
+        where={"source_path": str(file)},
+        include=["metadatas"],
+        limit=1,
+    )
+    if existing["metadatas"]:
+        stored = existing["metadatas"][0]
+        if stored.get("content_hash") == content_hash and stored.get("embedding_model") == target_model:
+            return False
+
+    ext = file.suffix.lower()
+    ids: list[str] = []
+    documents: list[str] = []
+    metadatas: list[dict] = []
+
+    if ext in (".md", ".markdown"):
+        # Markdown: use SemanticMarkdownChunker (M1: uses char offsets, not line numbers)
+        frontmatter, body = parse_frontmatter(content)
+        frontmatter_len = len(content) - len(body)
+        base_meta: dict = {"source_path": str(file), "corpus": collection_name}
+        chunks = SemanticMarkdownChunker().chunk(body, base_meta)
+        if not chunks:
+            _log.debug("skipped file with no chunks", path=str(file))
+            return False
+
+        for chunk in chunks:
+            title = f"{file.relative_to(repo)}:chunk-{chunk.chunk_index}"
+            doc_id = _hl.sha256(f"{collection_name}:{title}".encode()).hexdigest()[:32]
+            metadata: dict = {
+                "title": title,
+                "tags": "markdown",
+                "category": "prose",
+                "session_id": "",
+                "source_agent": "nexus-indexer",
+                "store_type": "prose",
+                "indexed_at": now_iso,
+                "expires_at": "",
+                "ttl_days": 0,
+                "source_path": str(file),
+                # M1: SemanticMarkdownChunker uses char offsets, not line numbers
+                "line_start": 0,
+                "line_end": 0,
+                "chunk_start_char": chunk.metadata.get("chunk_start_char", 0) + frontmatter_len,
+                "chunk_end_char": chunk.metadata.get("chunk_end_char", 0) + frontmatter_len,
+                "section_title": chunk.metadata.get("header_path", ""),
+                "frecency_score": float(score),
+                "chunk_index": chunk.chunk_index,
+                "chunk_count": len(chunks),
+                "corpus": collection_name,
+                "embedding_model": target_model,
+                "content_hash": content_hash,
+                **git_meta,
+            }
+            ids.append(doc_id)
+            documents.append(chunk.text)
+            metadatas.append(metadata)
+    else:
+        # Non-markdown prose: use line-based chunking
+        raw_chunks = _line_chunk(content)
+        if not raw_chunks:
+            if not content.strip():
+                return False
+            raw_chunks = [(1, 1, content)]
+        total_chunks = len(raw_chunks)
+
+        for i, (ls, le, text) in enumerate(raw_chunks):
+            title = f"{file.relative_to(repo)}:{ls}-{le}"
+            doc_id = _hl.sha256(f"{collection_name}:{title}".encode()).hexdigest()[:32]
+            metadata = {
+                "title": title,
+                "tags": ext.lstrip("."),
+                "category": "prose",
+                "session_id": "",
+                "source_agent": "nexus-indexer",
+                "store_type": "prose",
+                "indexed_at": now_iso,
+                "expires_at": "",
+                "ttl_days": 0,
+                "source_path": str(file),
+                "line_start": ls,
+                "line_end": le,
+                "frecency_score": float(score),
+                "chunk_index": i,
+                "chunk_count": total_chunks,
+                "corpus": collection_name,
+                "embedding_model": target_model,
+                "content_hash": content_hash,
+                **git_meta,
+            }
+            ids.append(doc_id)
+            documents.append(text)
+            metadatas.append(metadata)
+
+    if not documents:
+        return False
+
+    # Embed via _embed_with_fallback (CCE for voyage-context-3)
+    embeddings, actual_model = _embed_with_fallback(documents, target_model, voyage_key)
+    if actual_model != target_model:
+        for m in metadatas:
+            m["embedding_model"] = actual_model
+
+    db.upsert_chunks_with_embeddings(
+        collection_name=collection_name,
+        ids=ids,
+        documents=documents,
+        embeddings=embeddings,
+        metadatas=metadatas,
+    )
+    return True
+
+
+def _index_pdf_file(
+    file: Path,
+    repo: Path,
+    collection_name: str,
+    target_model: str,
+    col: object,
+    db: object,
+    voyage_key: str,
+    git_meta: dict,
+    now_iso: str,
+    score: float,
+) -> bool:
+    """Index a single PDF file into the docs__ collection.
+
+    Uses PDF extraction + chunking from doc_indexer, embeds via _embed_with_fallback.
+    Returns True if the file was indexed, False if skipped.
+    """
+    import hashlib as _hl
+    from nexus.doc_indexer import _embed_with_fallback, _pdf_chunks
+
+    content_hash = _hl.sha256()
+    with file.open("rb") as f:
+        for block in iter(lambda: f.read(65536), b""):
+            content_hash.update(block)
+    content_hash_hex = content_hash.hexdigest()
+
+    # Staleness check
+    existing = col.get(
+        where={"source_path": str(file)},
+        include=["metadatas"],
+        limit=1,
+    )
+    if existing["metadatas"]:
+        stored = existing["metadatas"][0]
+        if stored.get("content_hash") == content_hash_hex and stored.get("embedding_model") == target_model:
+            return False
+
+    prepared = _pdf_chunks(file, content_hash_hex, target_model, now_iso, collection_name)
+    if not prepared:
+        _log.debug("skipped PDF with no chunks", path=str(file))
+        return False
+
+    ids = [p[0] for p in prepared]
+    documents = [p[1] for p in prepared]
+    metadatas_raw = [p[2] for p in prepared]
+
+    # Augment metadata with repo-indexer fields
+    metadatas: list[dict] = []
+    for m in metadatas_raw:
+        augmented = {
+            **m,
+            "title": f"{file.relative_to(repo)}:page-{m.get('page_number', 0)}",
+            "tags": "pdf",
+            "category": "prose",
+            "session_id": "",
+            "source_agent": "nexus-indexer",
+            "expires_at": "",
+            "ttl_days": 0,
+            "frecency_score": float(score),
+            **git_meta,
+        }
+        metadatas.append(augmented)
+
+    embeddings, actual_model = _embed_with_fallback(documents, target_model, voyage_key)
+    if actual_model != target_model:
+        for m in metadatas:
+            m["embedding_model"] = actual_model
+
+    db.upsert_chunks_with_embeddings(
+        collection_name=collection_name,
+        ids=ids,
+        documents=documents,
+        embeddings=embeddings,
+        metadatas=metadatas,
+    )
+    return True
+
+
+def _discover_and_index_rdrs(
+    repo: Path,
+    rdr_abs_paths: set[Path],
+    db: object,
+    voyage_key: str,
+    now_iso: str,
+) -> None:
+    """Find .md files under RDR paths and index them via batch_index_markdowns.
+
+    M2: passes t3=db to avoid creating a redundant T3 client.
+    """
+    import hashlib as _hl
+    from nexus.doc_indexer import batch_index_markdowns
+
+    if not rdr_abs_paths:
+        return
+
+    md_paths: list[Path] = []
+    for rdr_dir in rdr_abs_paths:
+        if not rdr_dir.is_dir():
+            continue
+        for path in sorted(rdr_dir.rglob("*.md")):
+            if path.is_file() and not path.is_symlink():
+                md_paths.append(path)
+
+    if not md_paths:
+        return
+
+    # Corpus: rdr__{repo_name}-{hash8} → collection docs__rdr__{repo_name}-{hash8}
+    path_hash = _hl.sha256(str(repo).encode()).hexdigest()[:8]
+    corpus = f"rdr__{repo.name}-{path_hash}"
+
+    batch_index_markdowns(md_paths, corpus, t3=db)
+
+
+def _prune_misclassified(
+    repo: Path,
+    code_collection: str,
+    docs_collection: str,
+    code_files: list[Path],
+    prose_files: list[Path],
+    pdf_files: list[Path],
+    db: object,
+) -> None:
+    """Remove chunks from the wrong collection after reclassification.
+
+    If a file was previously classified as code but is now prose (or vice versa),
+    its chunks in the old collection must be removed.
+    """
+    code_col = db.get_or_create_collection(code_collection)
+    docs_col = db.get_or_create_collection(docs_collection)
+
+    # Prose + PDF files should NOT have chunks in the code__ collection
+    docs_paths = {str(f) for f in prose_files} | {str(f) for f in pdf_files}
+    for source_path in docs_paths:
+        existing = code_col.get(where={"source_path": source_path}, include=[])
+        if existing["ids"]:
+            code_col.delete(ids=existing["ids"])
+            _log.debug("pruned misclassified chunks from code collection",
+                       source_path=source_path, count=len(existing["ids"]))
+
+    # Code files should NOT have chunks in the docs__ collection
+    code_paths = {str(f) for f in code_files}
+    for source_path in code_paths:
+        existing = docs_col.get(where={"source_path": source_path}, include=[])
+        if existing["ids"]:
+            docs_col.delete(ids=existing["ids"])
+            _log.debug("pruned misclassified chunks from docs collection",
+                       source_path=source_path, count=len(existing["ids"]))
+
+
+def _prune_deleted_files(
+    code_collection: str,
+    docs_collection: str,
+    all_current_paths: set[str],
+    db: object,
+) -> None:
+    """Remove chunks for files that no longer exist in the repo (C3 fix).
+
+    Queries each collection for all distinct source_paths and deletes chunks
+    for any path not in *all_current_paths*.
+    """
+    for collection_name in (code_collection, docs_collection):
+        col = db.get_or_create_collection(collection_name)
+        # Get all chunks to find unique source_paths
+        all_chunks = col.get(include=["metadatas"])
+        if not all_chunks["ids"]:
+            continue
+
+        # Group chunk IDs by source_path
+        stale_ids: list[str] = []
+        for chunk_id, meta in zip(all_chunks["ids"], all_chunks["metadatas"]):
+            source_path = meta.get("source_path", "")
+            if source_path and source_path not in all_current_paths:
+                stale_ids.append(chunk_id)
+
+        if stale_ids:
+            col.delete(ids=stale_ids)
+            _log.info("pruned deleted-file chunks",
+                       collection=collection_name, count=len(stale_ids))
+
+
+# ── Main indexing pipeline ───────────────────────────────────────────────────
 
 
 def _run_index(repo: Path, registry: "RepoRegistry") -> None:
-    """Full indexing pipeline: frecency → chunking → embedding → T3 upsert."""
+    """Full indexing pipeline: classify → route → embed → upsert → prune.
+
+    Routes files to the appropriate collection based on content classification:
+    - Code files → code__ collection (voyage-code-3, AST chunking)
+    - Prose files → docs__ collection (voyage-context-3 via CCE)
+    - PDF files → docs__ collection (PDF extraction + voyage-context-3)
+    - RDR markdown → docs__rdr__ collection (via batch_index_markdowns)
+    """
     import hashlib as _hl
 
-    from nexus.chunker import chunk_file
+    from nexus.classifier import ContentClass, classify_file
     from nexus.config import load_config
     from nexus.frecency import batch_frecency
+    from nexus.registry import _docs_collection_name
     from nexus.ripgrep_cache import build_cache
 
     info = registry.get(repo)
     if info is None:
         return
 
-    collection_name = info["collection"]
+    # C2: use deterministic naming function as fallback
+    code_collection = info.get("code_collection", info["collection"])
+    docs_collection = info.get("docs_collection") or _docs_collection_name(repo)
 
     # Load config (picks up per-repo .nexus.yml if present)
     cfg = load_config(repo_root=repo)
     cfg_patterns: list[str] = cfg.get("server", {}).get("ignorePatterns", [])
     ignore_patterns: list[str] = list(dict.fromkeys(DEFAULT_IGNORE + cfg_patterns))
+    indexing_config: dict = cfg.get("indexing", {})
+    rdr_paths: list[str] = indexing_config.get("rdr_paths", ["docs/rdr"])
 
     # Collect git metadata once for all chunks
     git_meta = _git_metadata(repo)
@@ -162,8 +621,18 @@ def _run_index(repo: Path, registry: "RepoRegistry") -> None:
     # Compute frecency scores in a single git log pass
     frecency_map = batch_frecency(repo)
 
-    # Gather all text files with frecency scores
-    scored: list[tuple[float, Path]] = []
+    # Build absolute RDR path set for exclusion
+    rdr_abs_paths: set[Path] = set()
+    for rdr_rel in rdr_paths:
+        rdr_abs = (repo / rdr_rel).resolve()
+        rdr_abs_paths.add(rdr_abs)
+
+    # Walk repo and classify files into code, prose, and PDF lists
+    code_files: list[tuple[float, Path]] = []
+    prose_files: list[tuple[float, Path]] = []
+    pdf_files: list[tuple[float, Path]] = []
+    all_text_scored: list[tuple[float, Path]] = []  # code + prose for ripgrep cache
+
     for path in sorted(repo.rglob("*")):
         if not path.is_file() or path.is_symlink():
             continue
@@ -171,20 +640,39 @@ def _run_index(repo: Path, registry: "RepoRegistry") -> None:
         if any(part.startswith(".") for part in rel.parts):
             continue  # Skip hidden dirs/files
         if _should_ignore(rel, ignore_patterns):
-            continue  # Skip ignored patterns (node_modules, __pycache__, etc.)
+            continue  # Skip ignored patterns
+
+        # Skip files under RDR paths — they go to docs__rdr__ separately
+        resolved = path.resolve()
+        if any(resolved == rdr or _is_under(resolved, rdr) for rdr in rdr_abs_paths):
+            continue
+
         score = frecency_map.get(path, 0.0)
-        scored.append((score, path))
+        classification = classify_file(path, indexing_config=indexing_config)
 
-    # Sort descending by frecency
-    scored.sort(key=lambda x: x[0], reverse=True)
+        match classification:
+            case ContentClass.CODE:
+                code_files.append((score, path))
+                all_text_scored.append((score, path))
+            case ContentClass.PROSE:
+                prose_files.append((score, path))
+                all_text_scored.append((score, path))
+            case ContentClass.PDF:
+                pdf_files.append((score, path))
+                # PDF files not included in ripgrep text cache
 
-    # Update ripgrep cache — include path hash to avoid collisions between
-    # repos with the same basename (e.g. two different "myproject/" dirs).
+    # Sort all lists descending by frecency
+    code_files.sort(key=lambda x: x[0], reverse=True)
+    prose_files.sort(key=lambda x: x[0], reverse=True)
+    pdf_files.sort(key=lambda x: x[0], reverse=True)
+    all_text_scored.sort(key=lambda x: x[0], reverse=True)
+
+    # Update ripgrep cache (code + prose text files, not PDFs)
     _repo_hash = _hl.sha256(str(repo).encode()).hexdigest()[:8]
     cache_path = Path.home() / ".config" / "nexus" / f"{repo.name}-{_repo_hash}.cache"
-    build_cache(repo, cache_path, scored)
+    build_cache(repo, cache_path, all_text_scored)
 
-    # Chunk and index (requires T3 credentials)
+    # Credential check (required for T3 operations)
     from nexus.config import get_credential
     voyage_key = get_credential("voyage_api_key")
     chroma_key = get_credential("chroma_api_key")
@@ -201,92 +689,62 @@ def _run_index(repo: Path, registry: "RepoRegistry") -> None:
 
     db = make_t3()
     now_iso = _dt.now(UTC).isoformat()
-    target_model = index_model_for_collection(collection_name)
+
+    # Initialize collections and models
+    code_model = index_model_for_collection(code_collection)
+    docs_model = index_model_for_collection(docs_collection)
     voyage_client = voyageai.Client(api_key=voyage_key)
-    col = db.get_or_create_collection(collection_name)
+    code_col = db.get_or_create_collection(code_collection)
+    docs_col = db.get_or_create_collection(docs_collection)
 
-    for score, file in scored:
-        try:
-            content = file.read_text(encoding="utf-8")
-        except (UnicodeDecodeError, OSError) as exc:
-            _log.debug("skipped non-text file", path=str(file), error=type(exc).__name__)
-            continue
-
-        # Compute content hash once per file (reused across all chunks of the file)
-        content_hash = _hl.sha256(content.encode()).hexdigest()
-
-        # Staleness check: skip if content_hash AND embedding_model both match.
-        # Reading one chunk per file is sufficient — all chunks share the same
-        # content_hash and embedding_model (set once per file in this loop).
-        existing = col.get(
-            where={"source_path": str(file)},
-            include=["metadatas"],
-            limit=1,
+    # Index code files → code__ (voyage-code-3, AST chunking)
+    for score, file in code_files:
+        _index_code_file(
+            file, repo, code_collection, code_model, code_col, db,
+            voyage_client, git_meta, now_iso, score,
         )
-        if existing["metadatas"]:
-            stored = existing["metadatas"][0]
-            if stored.get("content_hash") == content_hash and stored.get("embedding_model") == target_model:
-                continue
 
-        chunks = chunk_file(file, content)
-        if not chunks:
-            _log.debug("skipped file with no chunks", path=str(file))
-            continue
-        total_chunks = len(chunks)
-
-        ids: list[str] = []
-        documents: list[str] = []
-        metadatas: list[dict] = []
-
-        for i, chunk in enumerate(chunks):
-            title = f"{file.relative_to(repo)}:{chunk['line_start']}-{chunk['line_end']}"
-            doc_id = _hl.sha256(f"{collection_name}:{title}".encode()).hexdigest()[:32]
-            ext = file.suffix.lower()
-            metadata: dict = {
-                # Core fields
-                "title": title,
-                "tags": ext.lstrip("."),
-                "category": "code",
-                "session_id": "",
-                "source_agent": "nexus-indexer",
-                "store_type": "code",
-                "indexed_at": now_iso,
-                "expires_at": "",
-                "ttl_days": 0,
-                "source_path": str(file),
-                # Line range — spec names
-                "line_start": chunk["line_start"],
-                "line_end": chunk["line_end"],
-                "frecency_score": float(score),
-                # Chunk fields from chunker
-                "chunk_index": chunk.get("chunk_index", i),
-                "chunk_count": chunk.get("chunk_count", total_chunks),
-                "ast_chunked": chunk.get("ast_chunked", False),
-                "filename": chunk.get("filename", str(file.name)),
-                "file_extension": chunk.get("file_extension", ext),
-                # Computed fields
-                "programming_language": _EXT_TO_LANGUAGE.get(ext, ""),
-                "corpus": collection_name,
-                "embedding_model": target_model,
-                "content_hash": content_hash,
-                # Git fields (computed once per index run)
-                **git_meta,
-            }
-            ids.append(doc_id)
-            documents.append(chunk["text"])
-            metadatas.append(metadata)
-
-        # Pre-compute voyage-code-3 embeddings; batch per API limit
-        embeddings: list[list[float]] = []
-        for batch_start in range(0, len(documents), _VOYAGE_EMBED_BATCH_SIZE):
-            batch = documents[batch_start : batch_start + _VOYAGE_EMBED_BATCH_SIZE]
-            result = voyage_client.embed(texts=batch, model=target_model, input_type="document")
-            embeddings.extend(result.embeddings)
-
-        db.upsert_chunks_with_embeddings(
-            collection_name=collection_name,
-            ids=ids,
-            documents=documents,
-            embeddings=embeddings,
-            metadatas=metadatas,
+    # Index prose files → docs__ (voyage-context-3 via CCE)
+    for score, file in prose_files:
+        _index_prose_file(
+            file, repo, docs_collection, docs_model, docs_col, db,
+            voyage_key, git_meta, now_iso, score,
         )
+
+    # Index PDF files → docs__ (PDF extraction + voyage-context-3)
+    for score, file in pdf_files:
+        _index_pdf_file(
+            file, repo, docs_collection, docs_model, docs_col, db,
+            voyage_key, git_meta, now_iso, score,
+        )
+
+    # Discover and index RDR markdown files → docs__rdr__
+    _discover_and_index_rdrs(repo, rdr_abs_paths, db, voyage_key, now_iso)
+
+    # Prune misclassified chunks (reclassification cleanup)
+    _prune_misclassified(
+        repo, code_collection, docs_collection,
+        [f for _, f in code_files],
+        [f for _, f in prose_files],
+        [f for _, f in pdf_files],
+        db,
+    )
+
+    # C3: Prune deleted files — remove chunks for files no longer in the repo
+    all_current_paths: set[str] = set()
+    for _, f in code_files:
+        all_current_paths.add(str(f))
+    for _, f in prose_files:
+        all_current_paths.add(str(f))
+    for _, f in pdf_files:
+        all_current_paths.add(str(f))
+    _prune_deleted_files(code_collection, docs_collection, all_current_paths, db)
+
+
+def _is_under(child: Path, parent: Path) -> bool:
+    """Return True if *child* is a descendant of *parent*."""
+    try:
+        child.relative_to(parent)
+        return True
+    except ValueError:
+        return False

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -231,7 +231,7 @@ def _index_code_file(
 
     for i, chunk in enumerate(chunks):
         title = f"{file.relative_to(repo)}:{chunk['line_start']}-{chunk['line_end']}"
-        doc_id = _hl.sha256(f"{collection_name}:{title}".encode()).hexdigest()[:32]
+        doc_id = _hl.sha256(f"{collection_name}:{title}:chunk{i}".encode()).hexdigest()[:32]
         ext = file.suffix.lower()
         metadata: dict = {
             "title": title,

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -72,6 +72,30 @@ def _should_ignore(rel_path: Path, patterns: list[str]) -> bool:
     return False
 
 
+def _git_ls_files(repo: Path, *, include_untracked: bool = False) -> list[Path]:
+    """Return repository files using git ls-files, respecting .gitignore.
+
+    By default returns only tracked (committed/staged) files.
+    With *include_untracked*, also includes untracked files that are not
+    ignored by .gitignore / .git/info/exclude / global gitignore.
+    """
+    args = ["git", "ls-files", "--cached", "-z"]
+    if include_untracked:
+        args.extend(["--others", "--exclude-standard"])
+    result = subprocess.run(
+        args, cwd=repo, capture_output=True, text=True, timeout=60,
+    )
+    if result.returncode != 0:
+        _log.warning("git ls-files failed, falling back to rglob", error=result.stderr.strip())
+        return []  # caller should fall back
+    # -z uses NUL separators (handles filenames with spaces/newlines)
+    paths = []
+    for rel_str in result.stdout.split("\0"):
+        if rel_str:  # filter empty strings from trailing NUL
+            paths.append(repo / rel_str)
+    return paths
+
+
 def index_repository(repo: Path, registry: "RepoRegistry", *, frecency_only: bool = False) -> None:
     """Index all files in *repo* into T3 code__ and docs__ collections.
 
@@ -633,10 +657,22 @@ def _run_index(repo: Path, registry: "RepoRegistry") -> None:
     pdf_files: list[tuple[float, Path]] = []
     all_text_scored: list[tuple[float, Path]] = []  # code + prose for ripgrep cache
 
-    for path in sorted(repo.rglob("*")):
-        if not path.is_file() or path.is_symlink():
-            continue
+    # Use git ls-files to respect .gitignore (security + efficiency)
+    include_untracked = indexing_config.get("include_untracked", False)
+    git_files = _git_ls_files(repo, include_untracked=include_untracked)
+
+    if git_files:
+        candidate_files = git_files
+    else:
+        # Fallback to rglob if git ls-files fails (not a git repo, etc.)
+        _log.warning("falling back to rglob file walk", repo=str(repo))
+        candidate_files = sorted(p for p in repo.rglob("*") if p.is_file() and not p.is_symlink())
+
+    for path in candidate_files:
+        if not path.is_file():
+            continue  # git ls-files may list deleted files not yet committed
         rel = path.relative_to(repo)
+        # Defense-in-depth: still filter hidden dirs and ignore patterns
         if any(part.startswith(".") for part in rel.parts):
             continue  # Skip hidden dirs/files
         if _should_ignore(rel, ignore_patterns):

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -530,9 +530,10 @@ def _discover_and_index_rdrs(
     if not md_paths:
         return
 
-    # Corpus: rdr__{repo_name}-{hash8} → collection docs__rdr__{repo_name}-{hash8}
-    path_hash = _hl.sha256(str(repo).encode()).hexdigest()[:8]
-    corpus = f"rdr__{repo.name}-{path_hash}"
+    # Corpus: rdr__{basename}-{hash8} — uses worktree-stable identity
+    from nexus.registry import _repo_identity
+    basename, path_hash = _repo_identity(repo)
+    corpus = f"rdr__{basename}-{path_hash}"
 
     batch_index_markdowns(md_paths, corpus, t3=db)
 
@@ -616,8 +617,6 @@ def _run_index(repo: Path, registry: "RepoRegistry") -> None:
     - PDF files → docs__ collection (PDF extraction + voyage-context-3)
     - RDR markdown → docs__rdr__ collection (via batch_index_markdowns)
     """
-    import hashlib as _hl
-
     from nexus.classifier import ContentClass, classify_file
     from nexus.config import load_config
     from nexus.frecency import batch_frecency
@@ -704,8 +703,9 @@ def _run_index(repo: Path, registry: "RepoRegistry") -> None:
     all_text_scored.sort(key=lambda x: x[0], reverse=True)
 
     # Update ripgrep cache (code + prose text files, not PDFs)
-    _repo_hash = _hl.sha256(str(repo).encode()).hexdigest()[:8]
-    cache_path = Path.home() / ".config" / "nexus" / f"{repo.name}-{_repo_hash}.cache"
+    from nexus.registry import _repo_identity
+    _repo_basename, _repo_hash = _repo_identity(repo)
+    cache_path = Path.home() / ".config" / "nexus" / f"{_repo_basename}-{_repo_hash}.cache"
     build_cache(repo, cache_path, all_text_scored)
 
     # Credential check (required for T3 operations)

--- a/src/nexus/registry.py
+++ b/src/nexus/registry.py
@@ -25,6 +25,15 @@ def _collection_name(repo: Path) -> str:
     return f"code__{repo.name}-{path_hash}"
 
 
+def _docs_collection_name(repo: Path) -> str:
+    """Return the docs__ ChromaDB collection name for *repo*.
+
+    Uses the same hash scheme as _collection_name() for consistency.
+    """
+    path_hash = hashlib.sha256(str(repo).encode()).hexdigest()[:8]
+    return f"docs__{repo.name}-{path_hash}"
+
+
 class RepoRegistry:
     """Thread-safe registry of indexed repositories stored as JSON."""
 
@@ -45,13 +54,17 @@ class RepoRegistry:
     # ── public API ────────────────────────────────────────────────────────────
 
     def add(self, repo: Path) -> None:
-        """Register *repo*, initialising collection name and head_hash."""
+        """Register *repo*, initialising collection names and head_hash."""
         key = str(repo)
         name = repo.name
+        code_col = _collection_name(repo)
+        docs_col = _docs_collection_name(repo)
         with self._lock:
             self._data["repos"][key] = {
                 "name": name,
-                "collection": _collection_name(repo),
+                "collection": code_col,  # backward compat alias
+                "code_collection": code_col,
+                "docs_collection": docs_col,
                 "head_hash": "",
                 "status": "registered",
             }

--- a/src/nexus/registry.py
+++ b/src/nexus/registry.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import os
+import subprocess
 import tempfile
 import threading
 from pathlib import Path
@@ -13,25 +14,58 @@ import structlog
 _log = structlog.get_logger()
 
 
+def _repo_identity(repo: Path) -> tuple[str, str]:
+    """Return ``(basename, hash8)`` for collection naming, stable across worktrees.
+
+    Uses ``git rev-parse --git-common-dir`` to resolve the main repository root
+    even when called from a worktree.  Falls back to the given *repo* path when
+    git is unavailable (not installed, not a git repo, etc.).
+
+    The hash is the first 8 hex characters of the SHA-256 digest of the
+    resolved main repo path.  Two worktrees of the same repo produce identical
+    collection names.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            git_common = Path(result.stdout.strip())
+            if not git_common.is_absolute():
+                git_common = (repo / git_common).resolve()
+            main_repo = git_common.parent
+        else:
+            main_repo = repo
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _log.debug("git rev-parse failed, using repo path directly", error=str(exc))
+        main_repo = repo
+
+    path_hash = hashlib.sha256(str(main_repo).encode()).hexdigest()[:8]
+    return main_repo.name, path_hash
+
+
 def _collection_name(repo: Path) -> str:
     """Return a unique ChromaDB collection name for *repo*.
 
     The collection name is ``code__{basename}-{hash8}`` where *hash8* is the
-    first 8 hex characters of the SHA-256 digest of the full absolute path.
-    This guarantees uniqueness even when two repos share the same leaf name
-    (e.g. ``/work/a/repo`` and ``/work/b/repo`` both named ``repo``).
+    first 8 hex characters of the SHA-256 digest of the main repository path
+    (resolved via git, stable across worktrees).
     """
-    path_hash = hashlib.sha256(str(repo).encode()).hexdigest()[:8]
-    return f"code__{repo.name}-{path_hash}"
+    name, path_hash = _repo_identity(repo)
+    return f"code__{name}-{path_hash}"
 
 
 def _docs_collection_name(repo: Path) -> str:
     """Return the docs__ ChromaDB collection name for *repo*.
 
-    Uses the same hash scheme as _collection_name() for consistency.
+    Uses the same identity scheme as _collection_name() for consistency.
     """
-    path_hash = hashlib.sha256(str(repo).encode()).hexdigest()[:8]
-    return f"docs__{repo.name}-{path_hash}"
+    name, path_hash = _repo_identity(repo)
+    return f"docs__{name}-{path_hash}"
 
 
 class RepoRegistry:

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -116,3 +116,30 @@ def test_chunk_file_ast_failure_falls_back_to_lines(tmp_path: Path) -> None:
 
     assert len(chunks) >= 1
     assert all(c["ast_chunked"] is False for c in chunks)
+
+
+# ── Config extensions use line chunking, not AST ────────────────────────────
+
+
+def test_yaml_uses_line_chunking_not_ast() -> None:
+    """YAML files should use line-based chunking, not AST (they're prose now)."""
+    content = "key: value\nlist:\n  - item1\n  - item2\n"
+    chunks = chunk_file(Path("config.yaml"), content)
+    assert chunks
+    assert not chunks[0].get("ast_chunked", False)
+
+
+def test_yml_uses_line_chunking_not_ast() -> None:
+    """YML files should use line-based chunking, not AST (they're prose now)."""
+    content = "key: value\nlist:\n  - item1\n  - item2\n"
+    chunks = chunk_file(Path("config.yml"), content)
+    assert chunks
+    assert not chunks[0].get("ast_chunked", False)
+
+
+def test_toml_uses_line_chunking_not_ast() -> None:
+    """TOML files should use line-based chunking, not AST (they're prose now)."""
+    content = '[section]\nkey = "value"\n'
+    chunks = chunk_file(Path("pyproject.toml"), content)
+    assert chunks
+    assert not chunks[0].get("ast_chunked", False)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,77 @@
+"""Unit tests for file classification logic."""
+from pathlib import Path
+
+import pytest
+
+
+def test_python_file_classified_as_code():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("main.py")) == ContentClass.CODE
+
+
+def test_markdown_file_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("README.md")) == ContentClass.PROSE
+
+
+def test_yaml_file_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("config.yaml")) == ContentClass.PROSE
+
+
+def test_toml_file_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("pyproject.toml")) == ContentClass.PROSE
+
+
+def test_json_file_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("package.json")) == ContentClass.PROSE
+
+
+def test_pdf_file_classified_as_pdf():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("paper.pdf")) == ContentClass.PDF
+
+
+def test_unknown_extension_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("notes.txt")) == ContentClass.PROSE
+
+
+def test_no_extension_classified_as_prose():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("Makefile")) == ContentClass.PROSE
+
+
+def test_code_extensions_set_matches_design():
+    """The canonical set must match the design doc exactly."""
+    from nexus.classifier import _CODE_EXTENSIONS
+    expected = {
+        ".py", ".js", ".jsx", ".ts", ".tsx", ".java", ".go", ".rs",
+        ".cpp", ".cc", ".c", ".h", ".hpp", ".rb", ".cs", ".sh", ".bash",
+        ".kt", ".swift", ".scala", ".r", ".m", ".php",
+    }
+    assert _CODE_EXTENSIONS == expected
+
+
+def test_config_code_extensions_override():
+    """code_extensions in config adds to the default set."""
+    from nexus.classifier import classify_file, ContentClass
+    cfg = {"code_extensions": [".sql", ".proto"]}
+    assert classify_file(Path("schema.sql"), indexing_config=cfg) == ContentClass.CODE
+    assert classify_file(Path("api.proto"), indexing_config=cfg) == ContentClass.CODE
+
+
+def test_config_prose_extensions_override():
+    """prose_extensions wins over both defaults and code_extensions."""
+    from nexus.classifier import classify_file, ContentClass
+    cfg = {"prose_extensions": [".sh"], "code_extensions": [".sql"]}
+    assert classify_file(Path("deploy.sh"), indexing_config=cfg) == ContentClass.PROSE
+    assert classify_file(Path("query.sql"), indexing_config=cfg) == ContentClass.CODE
+
+
+def test_case_insensitive_extension():
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path("Main.PY")) == ContentClass.CODE
+    assert classify_file(Path("Doc.PDF")) == ContentClass.PDF

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,11 @@
 """AC6: Config merges global + per-repo YAML with env var overrides."""
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
 
-from nexus.config import load_config
+from nexus.config import _DEFAULTS, load_config
 
 
 def test_config_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -90,7 +91,6 @@ def test_set_credential_cleans_up_temp_on_write_failure(
     """When the temp file write fails, os.unlink is called on the temp file."""
     import os
     import tempfile
-    from unittest.mock import patch
 
     from nexus.config import set_credential
 
@@ -165,3 +165,44 @@ def test_set_credential_unknown_name_raises(
 
     with pytest.raises(ValueError, match="Unknown credential"):
         set_credential("totally_unknown_credential", "some-value")
+
+
+# ── Indexing config section ────────────────────────────────────────────────
+
+
+def test_defaults_include_indexing_section() -> None:
+    """_DEFAULTS contains the indexing section with expected keys."""
+    assert "indexing" in _DEFAULTS
+    assert _DEFAULTS["indexing"]["code_extensions"] == []
+    assert _DEFAULTS["indexing"]["prose_extensions"] == []
+    assert _DEFAULTS["indexing"]["rdr_paths"] == ["docs/rdr"]
+
+
+def test_load_config_returns_indexing_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """load_config returns indexing defaults when no config files exist."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = load_config(repo_root=tmp_path)
+    assert cfg["indexing"]["code_extensions"] == []
+    assert cfg["indexing"]["prose_extensions"] == []
+    assert cfg["indexing"]["rdr_paths"] == ["docs/rdr"]
+
+
+def test_nexus_yml_indexing_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Per-repo .nexus.yml can override indexing defaults via deep merge."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".nexus.yml").write_text(
+        "indexing:\n"
+        "  code_extensions: [.sql, .proto]\n"
+        "  rdr_paths:\n"
+        "    - docs/rdr\n"
+        "    - design/decisions\n"
+    )
+    cfg = load_config(repo_root=tmp_path)
+    assert cfg["indexing"]["code_extensions"] == [".sql", ".proto"]
+    assert cfg["indexing"]["rdr_paths"] == ["docs/rdr", "design/decisions"]
+    # prose_extensions not set in override → stays default
+    assert cfg["indexing"]["prose_extensions"] == []

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -1,4 +1,4 @@
-"""T3: commands/index.py — nx index code registration and indexing."""
+"""T3: commands/index.py — nx index repo registration and indexing."""
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -19,8 +19,8 @@ def index_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
-def test_index_code_registers_and_indexes(runner: CliRunner, index_home: Path) -> None:
-    """nx index code <path> registers the repo and calls index_repository."""
+def test_index_repo_registers_and_indexes(runner: CliRunner, index_home: Path) -> None:
+    """nx index repo <path> registers the repo and calls index_repository."""
     repo = index_home / "myrepo"
     repo.mkdir()
 
@@ -29,7 +29,7 @@ def test_index_code_registers_and_indexes(runner: CliRunner, index_home: Path) -
 
     with patch("nexus.commands.index._registry", return_value=mock_reg):
         with patch("nexus.indexer.index_repository") as mock_index:
-            result = runner.invoke(main, ["index", "code", str(repo)])
+            result = runner.invoke(main, ["index", "repo", str(repo)])
 
     assert result.exit_code == 0
     mock_reg.add.assert_called_once()
@@ -38,7 +38,7 @@ def test_index_code_registers_and_indexes(runner: CliRunner, index_home: Path) -
     assert "Done" in result.output
 
 
-def test_index_code_idempotent_when_already_registered(runner: CliRunner, index_home: Path) -> None:
+def test_index_repo_idempotent_when_already_registered(runner: CliRunner, index_home: Path) -> None:
     """If repo is already registered, skip add() and just re-index."""
     repo = index_home / "myrepo"
     repo.mkdir()
@@ -48,7 +48,7 @@ def test_index_code_idempotent_when_already_registered(runner: CliRunner, index_
 
     with patch("nexus.commands.index._registry", return_value=mock_reg):
         with patch("nexus.indexer.index_repository") as mock_index:
-            result = runner.invoke(main, ["index", "code", str(repo)])
+            result = runner.invoke(main, ["index", "repo", str(repo)])
 
     assert result.exit_code == 0
     mock_reg.add.assert_not_called()
@@ -56,9 +56,9 @@ def test_index_code_idempotent_when_already_registered(runner: CliRunner, index_
     assert "Registered" not in result.output
 
 
-def test_index_code_invalid_path(runner: CliRunner, index_home: Path) -> None:
+def test_index_repo_invalid_path(runner: CliRunner, index_home: Path) -> None:
     """Non-existent path produces a non-zero exit code."""
-    result = runner.invoke(main, ["index", "code", str(index_home / "nonexistent")])
+    result = runner.invoke(main, ["index", "repo", str(index_home / "nonexistent")])
     assert result.exit_code != 0
 
 
@@ -106,8 +106,8 @@ def test_index_md_nonexistent_path_fails(runner: CliRunner, index_home: Path) ->
 
 # ── --frecency-only flag ──────────────────────────────────────────────────────
 
-def test_index_code_frecency_only_flag_passed_through(runner: CliRunner, index_home: Path) -> None:
-    """nx index code <path> --frecency-only passes frecency_only=True to index_repository."""
+def test_index_repo_frecency_only_flag_passed_through(runner: CliRunner, index_home: Path) -> None:
+    """nx index repo <path> --frecency-only passes frecency_only=True to index_repository."""
     repo = index_home / "myrepo"
     repo.mkdir()
 
@@ -116,7 +116,7 @@ def test_index_code_frecency_only_flag_passed_through(runner: CliRunner, index_h
 
     with patch("nexus.commands.index._registry", return_value=mock_reg):
         with patch("nexus.indexer.index_repository") as mock_index:
-            result = runner.invoke(main, ["index", "code", str(repo), "--frecency-only"])
+            result = runner.invoke(main, ["index", "repo", str(repo), "--frecency-only"])
 
     assert result.exit_code == 0, result.output
     mock_index.assert_called_once()
@@ -125,8 +125,8 @@ def test_index_code_frecency_only_flag_passed_through(runner: CliRunner, index_h
     assert "frecency" in result.output.lower()
 
 
-def test_index_code_default_is_full_index(runner: CliRunner, index_home: Path) -> None:
-    """nx index code <path> without --frecency-only passes frecency_only=False."""
+def test_index_repo_default_is_full_index(runner: CliRunner, index_home: Path) -> None:
+    """nx index repo <path> without --frecency-only passes frecency_only=False."""
     repo = index_home / "myrepo"
     repo.mkdir()
 
@@ -135,7 +135,7 @@ def test_index_code_default_is_full_index(runner: CliRunner, index_home: Path) -
 
     with patch("nexus.commands.index._registry", return_value=mock_reg):
         with patch("nexus.indexer.index_repository") as mock_index:
-            result = runner.invoke(main, ["index", "code", str(repo)])
+            result = runner.invoke(main, ["index", "repo", str(repo)])
 
     assert result.exit_code == 0, result.output
     mock_index.assert_called_once()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -11,8 +11,20 @@ from nexus.indexer import CredentialsMissingError, index_repository
 @pytest.fixture
 def registry():
     mock = MagicMock()
-    mock.get.return_value = {"collection": "code__repo", "status": "registered"}
+    mock.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+        "status": "registered",
+    }
     return mock
+
+
+# Default config mock that includes the indexing section
+_DEFAULT_CONFIG = {
+    "server": {"ignorePatterns": []},
+    "indexing": {"code_extensions": [], "prose_extensions": [], "rdr_paths": ["docs/rdr"]},
+}
 
 
 def test_index_sets_indexing_then_ready(tmp_path: Path, registry) -> None:
@@ -55,16 +67,21 @@ def test_run_index_raises_credentials_missing_without_credentials(
     (repo / "hello.py").write_text("print('hi')\n")
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__repo"}
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
 
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
 
     with patch("nexus.frecency.batch_frecency", return_value={}):
         with patch("nexus.ripgrep_cache.build_cache"):
-            with patch("nexus.db.make_t3") as mock_make_t3:
-                with pytest.raises(CredentialsMissingError):
-                    _run_index(repo, registry)
+            with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
+                with patch("nexus.db.make_t3") as mock_make_t3:
+                    with pytest.raises(CredentialsMissingError):
+                        _run_index(repo, registry)
 
     mock_make_t3.assert_not_called()
 
@@ -100,17 +117,22 @@ def test_cache_path_includes_repo_hash(tmp_path: Path, monkeypatch) -> None:
         seen_paths.append(cache_path)
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__myproject"}
+    registry.get.return_value = {
+        "collection": "code__myproject",
+        "code_collection": "code__myproject",
+        "docs_collection": "docs__myproject",
+    }
 
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
 
     with patch("nexus.frecency.batch_frecency", return_value={}):
         with patch("nexus.ripgrep_cache.build_cache", side_effect=fake_build_cache):
-            with pytest.raises(CredentialsMissingError):
-                _run_index(repo_a, registry)
-            with pytest.raises(CredentialsMissingError):
-                _run_index(repo_b, registry)
+            with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
+                with pytest.raises(CredentialsMissingError):
+                    _run_index(repo_a, registry)
+                with pytest.raises(CredentialsMissingError):
+                    _run_index(repo_b, registry)
 
     assert len(seen_paths) == 2
     assert seen_paths[0] != seen_paths[1], "Cache paths for same-name repos must differ"
@@ -129,7 +151,11 @@ def test_run_index_skips_hidden_files(tmp_path: Path, monkeypatch) -> None:
     (repo / "main.py").write_text("x = 1\n")
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__repo"}
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
 
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
@@ -142,8 +168,9 @@ def test_run_index_skips_hidden_files(tmp_path: Path, monkeypatch) -> None:
 
     with patch("nexus.frecency.batch_frecency", return_value={}):
         with patch("nexus.ripgrep_cache.build_cache", side_effect=fake_build_cache):
-            with pytest.raises(CredentialsMissingError):
-                _run_index(repo, registry)
+            with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
+                with pytest.raises(CredentialsMissingError):
+                    _run_index(repo, registry)
 
     assert all(".git" not in str(p) for p in seen_paths), f"Hidden files were not filtered: {seen_paths}"
     assert any("main.py" in str(p) for p in seen_paths)
@@ -158,12 +185,16 @@ def test_run_index_source_path_is_absolute(tmp_path: Path) -> None:
     (repo / "main.py").write_text("x = 1\n")
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__repo"}
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
 
     captured_metadatas: list = []
 
     mock_col = MagicMock()
-    mock_col.get.return_value = {"metadatas": []}  # no existing data → proceed to upsert
+    mock_col.get.return_value = {"metadatas": [], "ids": []}
 
     mock_db = MagicMock()
     mock_db.get_or_create_collection.return_value = mock_col
@@ -188,7 +219,7 @@ def test_run_index_source_path_is_absolute(tmp_path: Path) -> None:
     with patch("nexus.frecency.batch_frecency", return_value={}):
         with patch("nexus.ripgrep_cache.build_cache"):
             with patch("nexus.indexer._git_metadata", return_value={}):
-                with patch("nexus.config.load_config", return_value={"server": {"ignorePatterns": []}}):
+                with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
                     with patch("nexus.config.get_credential", return_value="fake-key"):
                         with patch("nexus.db.make_t3", return_value=mock_db):
                             with patch("nexus.chunker.chunk_file", return_value=[fake_chunk]):
@@ -213,11 +244,18 @@ def test_run_index_skips_unchanged_content_hash(tmp_path: Path) -> None:
     content_hash = hashlib.sha256(content.encode()).hexdigest()
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__repo"}
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
 
     mock_col = MagicMock()
     # Simulate file already indexed with the same content_hash AND same embedding model
-    mock_col.get.return_value = {"metadatas": [{"content_hash": content_hash, "embedding_model": "voyage-code-3"}]}
+    mock_col.get.return_value = {
+        "metadatas": [{"content_hash": content_hash, "embedding_model": "voyage-code-3"}],
+        "ids": [],
+    }
 
     mock_db = MagicMock()
     mock_db.get_or_create_collection.return_value = mock_col
@@ -225,10 +263,11 @@ def test_run_index_skips_unchanged_content_hash(tmp_path: Path) -> None:
     with patch("nexus.frecency.batch_frecency", return_value={}):
         with patch("nexus.ripgrep_cache.build_cache"):
             with patch("nexus.indexer._git_metadata", return_value={}):
-                with patch("nexus.config.load_config", return_value={"server": {"ignorePatterns": []}}):
+                with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
                     with patch("nexus.config.get_credential", return_value="fake-key"):
                         with patch("nexus.db.make_t3", return_value=mock_db):
-                            _run_index(repo, registry)
+                            with patch("voyageai.Client"):
+                                _run_index(repo, registry)
 
     mock_db.upsert_chunks_with_embeddings.assert_not_called()
 
@@ -245,11 +284,18 @@ def test_run_index_reindexes_when_embedding_model_changed(tmp_path: Path) -> Non
     content_hash = hashlib.sha256(content.encode()).hexdigest()
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__repo"}
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
 
     mock_col = MagicMock()
     # Same content_hash but stale embedding model (voyage-4 from old collection-EF path)
-    mock_col.get.return_value = {"metadatas": [{"content_hash": content_hash, "embedding_model": "voyage-4"}]}
+    mock_col.get.return_value = {
+        "metadatas": [{"content_hash": content_hash, "embedding_model": "voyage-4"}],
+        "ids": [],
+    }
 
     mock_db = MagicMock()
     mock_db.get_or_create_collection.return_value = mock_col
@@ -269,7 +315,7 @@ def test_run_index_reindexes_when_embedding_model_changed(tmp_path: Path) -> Non
     with patch("nexus.frecency.batch_frecency", return_value={}):
         with patch("nexus.ripgrep_cache.build_cache"):
             with patch("nexus.indexer._git_metadata", return_value={}):
-                with patch("nexus.config.load_config", return_value={"server": {"ignorePatterns": []}}):
+                with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
                     with patch("nexus.config.get_credential", return_value="fake-key"):
                         with patch("nexus.db.make_t3", return_value=mock_db):
                             with patch("nexus.chunker.chunk_file", return_value=[fake_chunk]):
@@ -292,7 +338,11 @@ def test_frecency_only_updates_frecency_score(tmp_path: Path) -> None:
     src_file.write_text("x = 1\n")
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__repo"}
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
 
     old_meta = {"frecency_score": 0.1, "source_path": str(src_file), "title": "main.py:1-1"}
     mock_col = MagicMock()
@@ -306,8 +356,10 @@ def test_frecency_only_updates_frecency_score(tmp_path: Path) -> None:
             with patch("nexus.db.make_t3", return_value=mock_db):
                 _run_index_frecency_only(repo, registry)
 
-    mock_db.update_chunks.assert_called_once()
-    call_kwargs = mock_db.update_chunks.call_args.kwargs
+    # Called at least once (may be called for both code__ and docs__ collections)
+    assert mock_db.update_chunks.call_count >= 1
+    # Verify the first call has correct data
+    call_kwargs = mock_db.update_chunks.call_args_list[0].kwargs
     assert call_kwargs["ids"] == ["chunk-1"]
     assert call_kwargs["metadatas"][0]["frecency_score"] == 0.75
     # Other metadata fields must be preserved
@@ -324,7 +376,11 @@ def test_frecency_only_skips_unindexed_files(tmp_path: Path) -> None:
     src_file.write_text("y = 2\n")
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__repo"}
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
 
     mock_col = MagicMock()
     # No existing chunks for this file
@@ -349,7 +405,11 @@ def test_frecency_only_raises_credentials_missing(tmp_path: Path, monkeypatch) -
     repo.mkdir()
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__repo"}
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
 
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
@@ -372,10 +432,14 @@ def test_run_index_logs_skipped_binary_files(tmp_path: Path) -> None:
     (repo / "image.bin").write_bytes(b"\x80\x81\x82\x83\xff\xfe")
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__repo"}
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
 
     mock_col = MagicMock()
-    mock_col.get.return_value = {"metadatas": []}
+    mock_col.get.return_value = {"metadatas": [], "ids": []}
 
     mock_db = MagicMock()
     mock_db.get_or_create_collection.return_value = mock_col
@@ -394,7 +458,7 @@ def test_run_index_logs_skipped_binary_files(tmp_path: Path) -> None:
     with patch("nexus.frecency.batch_frecency", return_value={}):
         with patch("nexus.ripgrep_cache.build_cache"):
             with patch("nexus.indexer._git_metadata", return_value={}):
-                with patch("nexus.config.load_config", return_value={"server": {"ignorePatterns": []}}):
+                with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
                     with patch("nexus.config.get_credential", return_value="fake-key"):
                         with patch("nexus.db.make_t3", return_value=mock_db):
                             with patch("nexus.chunker.chunk_file", return_value=[fake_chunk]):
@@ -422,10 +486,14 @@ def test_run_index_logs_empty_chunks(tmp_path: Path) -> None:
     (repo / "empty.py").write_text("   \n\n   \n")
 
     registry = MagicMock()
-    registry.get.return_value = {"collection": "code__repo"}
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
 
     mock_col = MagicMock()
-    mock_col.get.return_value = {"metadatas": []}
+    mock_col.get.return_value = {"metadatas": [], "ids": []}
 
     mock_db = MagicMock()
     mock_db.get_or_create_collection.return_value = mock_col
@@ -433,7 +501,7 @@ def test_run_index_logs_empty_chunks(tmp_path: Path) -> None:
     with patch("nexus.frecency.batch_frecency", return_value={}):
         with patch("nexus.ripgrep_cache.build_cache"):
             with patch("nexus.indexer._git_metadata", return_value={}):
-                with patch("nexus.config.load_config", return_value={"server": {"ignorePatterns": []}}):
+                with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
                     with patch("nexus.config.get_credential", return_value="fake-key"):
                         with patch("nexus.db.make_t3", return_value=mock_db):
                             with patch("nexus.chunker.chunk_file", return_value=[]):
@@ -446,4 +514,314 @@ def test_run_index_logs_empty_chunks(tmp_path: Path) -> None:
     empty_calls = [c for c in debug_calls if "skipped file with no chunks" in str(c)]
     assert empty_calls, (
         f"Expected debug log for empty chunks file, got calls: {debug_calls}"
+    )
+
+
+# ── Content-class routing tests ──────────────────────────────────────────────
+
+
+def _make_collection_tracking_db():
+    """Create a mock DB that tracks upsert calls by collection name."""
+    upserts_by_collection: dict[str, list] = {}
+    cols_by_name: dict[str, MagicMock] = {}
+
+    def get_or_create(name):
+        if name not in cols_by_name:
+            col = MagicMock()
+            col.get.return_value = {"metadatas": [], "ids": []}
+            cols_by_name[name] = col
+        return cols_by_name[name]
+
+    def capture_upsert(collection_name, ids, documents, embeddings, metadatas):
+        upserts_by_collection.setdefault(collection_name, []).extend(metadatas)
+
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.side_effect = get_or_create
+    mock_db.upsert_chunks_with_embeddings.side_effect = capture_upsert
+    return mock_db, upserts_by_collection, cols_by_name
+
+
+def _registry_with_dual_collections():
+    """Create a registry mock with both code_collection and docs_collection."""
+    registry = MagicMock()
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        "docs_collection": "docs__repo",
+    }
+    return registry
+
+
+def test_run_index_routes_prose_to_docs_collection(tmp_path: Path) -> None:
+    """Markdown files should be indexed into the docs__ collection, not code__."""
+    from nexus.indexer import _run_index
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("# Hello\n\nThis is a README with enough content to chunk.\n")
+
+    registry = _registry_with_dual_collections()
+    mock_db, upserts, cols = _make_collection_tracking_db()
+
+    mock_embed_result = (
+        [[0.1] * 10],  # embeddings
+        "voyage-context-3",  # actual model
+    )
+
+    with patch("nexus.frecency.batch_frecency", return_value={}):
+        with patch("nexus.ripgrep_cache.build_cache"):
+            with patch("nexus.indexer._git_metadata", return_value={}):
+                with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
+                    with patch("nexus.config.get_credential", return_value="fake-key"):
+                        with patch("nexus.db.make_t3", return_value=mock_db):
+                            with patch("voyageai.Client"):
+                                with patch("nexus.doc_indexer._embed_with_fallback", return_value=mock_embed_result):
+                                    _run_index(repo, registry)
+
+    # docs__repo should have received chunks
+    assert "docs__repo" in upserts, f"Expected docs__repo to receive chunks, got: {list(upserts.keys())}"
+    assert all(m["category"] == "prose" for m in upserts["docs__repo"])
+    # code__repo should NOT have received any chunks
+    assert "code__repo" not in upserts, f"code__repo should not have chunks for .md files"
+
+
+def test_run_index_routes_code_to_code_collection(tmp_path: Path) -> None:
+    """Python files should be indexed into the code__ collection, not docs__."""
+    from nexus.indexer import _run_index
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "main.py").write_text("x = 1\n")
+
+    registry = _registry_with_dual_collections()
+    mock_db, upserts, cols = _make_collection_tracking_db()
+
+    fake_chunk = {
+        "line_start": 1, "line_end": 1, "text": "x = 1",
+        "chunk_index": 0, "chunk_count": 1,
+        "ast_chunked": False, "filename": "main.py", "file_extension": ".py",
+    }
+
+    mock_voyage_result = MagicMock(spec=EmbeddingsObject)
+    mock_voyage_result.embeddings = [[0.1, 0.2, 0.3]]
+    mock_voyage_client = MagicMock()
+    mock_voyage_client.embed.return_value = mock_voyage_result
+
+    with patch("nexus.frecency.batch_frecency", return_value={}):
+        with patch("nexus.ripgrep_cache.build_cache"):
+            with patch("nexus.indexer._git_metadata", return_value={}):
+                with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
+                    with patch("nexus.config.get_credential", return_value="fake-key"):
+                        with patch("nexus.db.make_t3", return_value=mock_db):
+                            with patch("nexus.chunker.chunk_file", return_value=[fake_chunk]):
+                                with patch("voyageai.Client", return_value=mock_voyage_client):
+                                    _run_index(repo, registry)
+
+    # code__repo should have received chunks
+    assert "code__repo" in upserts, f"Expected code__repo to receive chunks, got: {list(upserts.keys())}"
+    assert all(m["category"] == "code" for m in upserts["code__repo"])
+    # docs__repo should NOT have received any chunks
+    assert "docs__repo" not in upserts, f"docs__repo should not have chunks for .py files"
+
+
+def test_run_index_excludes_rdr_paths_from_docs(tmp_path: Path) -> None:
+    """Files under rdr_paths should not be indexed into docs__."""
+    from nexus.indexer import _run_index
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Create a regular markdown file (should be indexed in docs__)
+    (repo / "README.md").write_text("# README\n\nProject description here.\n")
+    # Create an RDR file (should NOT be indexed in docs__)
+    rdr_dir = repo / "docs" / "rdr"
+    rdr_dir.mkdir(parents=True)
+    (rdr_dir / "ADR-001.md").write_text("# ADR-001\n\nArchitecture decision.\n")
+
+    registry = _registry_with_dual_collections()
+    mock_db, upserts, cols = _make_collection_tracking_db()
+
+    mock_embed_result = (
+        [[0.1] * 10],
+        "voyage-context-3",
+    )
+
+    # Config with rdr_paths pointing to docs/rdr
+    config_with_rdr = {
+        "server": {"ignorePatterns": []},
+        "indexing": {"code_extensions": [], "prose_extensions": [], "rdr_paths": ["docs/rdr"]},
+    }
+
+    with patch("nexus.frecency.batch_frecency", return_value={}):
+        with patch("nexus.ripgrep_cache.build_cache"):
+            with patch("nexus.indexer._git_metadata", return_value={}):
+                with patch("nexus.config.load_config", return_value=config_with_rdr):
+                    with patch("nexus.config.get_credential", return_value="fake-key"):
+                        with patch("nexus.db.make_t3", return_value=mock_db):
+                            with patch("voyageai.Client"):
+                                with patch("nexus.doc_indexer._embed_with_fallback", return_value=mock_embed_result):
+                                    with patch("nexus.doc_indexer.batch_index_markdowns") as mock_batch:
+                                        _run_index(repo, registry)
+
+    # docs__repo should have README but NOT ADR-001
+    if "docs__repo" in upserts:
+        source_paths = [m["source_path"] for m in upserts["docs__repo"]]
+        assert any("README.md" in p for p in source_paths), "README.md should be in docs__repo"
+        assert not any("ADR-001" in p for p in source_paths), "ADR-001 should NOT be in docs__repo"
+    # batch_index_markdowns should have been called for the RDR files
+    mock_batch.assert_called_once()
+    rdr_call_paths = [str(p) for p in mock_batch.call_args[0][0]]
+    assert any("ADR-001.md" in p for p in rdr_call_paths), "ADR-001.md should be in batch_index_markdowns call"
+
+
+def test_run_index_mixed_repo(tmp_path: Path) -> None:
+    """A repo with both code and prose files routes each to the correct collection."""
+    from nexus.indexer import _run_index
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "main.py").write_text("print('hello')\n")
+    (repo / "README.md").write_text("# Project\n\nA simple project.\n")
+    (repo / "notes.txt").write_text("Some notes about the project.\n")
+
+    registry = _registry_with_dual_collections()
+    mock_db, upserts, cols = _make_collection_tracking_db()
+
+    fake_chunk = {
+        "line_start": 1, "line_end": 1, "text": "print('hello')",
+        "chunk_index": 0, "chunk_count": 1,
+        "ast_chunked": False, "filename": "main.py", "file_extension": ".py",
+    }
+
+    mock_voyage_result = MagicMock(spec=EmbeddingsObject)
+    mock_voyage_result.embeddings = [[0.1, 0.2, 0.3]]
+    mock_voyage_client = MagicMock()
+    mock_voyage_client.embed.return_value = mock_voyage_result
+
+    mock_embed_result = ([[0.1] * 10], "voyage-context-3")
+
+    with patch("nexus.frecency.batch_frecency", return_value={}):
+        with patch("nexus.ripgrep_cache.build_cache"):
+            with patch("nexus.indexer._git_metadata", return_value={}):
+                with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
+                    with patch("nexus.config.get_credential", return_value="fake-key"):
+                        with patch("nexus.db.make_t3", return_value=mock_db):
+                            with patch("nexus.chunker.chunk_file", return_value=[fake_chunk]):
+                                with patch("voyageai.Client", return_value=mock_voyage_client):
+                                    with patch("nexus.doc_indexer._embed_with_fallback", return_value=mock_embed_result):
+                                        _run_index(repo, registry)
+
+    # code__repo should have main.py
+    assert "code__repo" in upserts
+    code_paths = {m["source_path"] for m in upserts["code__repo"]}
+    assert any("main.py" in p for p in code_paths)
+
+    # docs__repo should have README.md and notes.txt
+    assert "docs__repo" in upserts
+    docs_paths = {m["source_path"] for m in upserts["docs__repo"]}
+    assert any("README.md" in p for p in docs_paths)
+    assert any("notes.txt" in p for p in docs_paths)
+
+
+def test_run_index_prune_deleted_files(tmp_path: Path) -> None:
+    """Chunks for files no longer in the repo should be pruned from both collections."""
+    from nexus.indexer import _prune_deleted_files
+
+    # Simulate: only file_a.py is current; file_b.py was deleted
+    all_current = {"/repo/file_a.py"}
+
+    mock_col = MagicMock()
+    mock_col.get.return_value = {
+        "ids": ["chunk-a1", "chunk-b1", "chunk-b2"],
+        "metadatas": [
+            {"source_path": "/repo/file_a.py"},
+            {"source_path": "/repo/file_b.py"},
+            {"source_path": "/repo/file_b.py"},
+        ],
+    }
+
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.return_value = mock_col
+
+    _prune_deleted_files("code__repo", "docs__repo", all_current, mock_db)
+
+    # Should delete chunks for file_b.py from both collections
+    delete_calls = mock_col.delete.call_args_list
+    assert len(delete_calls) == 2  # once for code__repo, once for docs__repo
+    for dc in delete_calls:
+        deleted_ids = dc.kwargs.get("ids") or dc[1].get("ids") if dc[1] else dc[0][0]
+        # chunk-b1 and chunk-b2 should be in the deleted set
+        if isinstance(deleted_ids, list):
+            assert "chunk-a1" not in deleted_ids
+            assert "chunk-b1" in deleted_ids or "chunk-b2" in deleted_ids
+
+
+def test_run_index_prune_misclassified(tmp_path: Path) -> None:
+    """Chunks in the wrong collection should be removed after reclassification."""
+    from nexus.indexer import _prune_misclassified
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    code_files = [repo / "main.py"]
+    prose_files = [repo / "README.md"]  # was previously in code__
+    pdf_files: list[Path] = []
+
+    # Mock: docs collection has a chunk for main.py (misclassified)
+    mock_code_col = MagicMock()
+    mock_code_col.get.return_value = {"ids": []}  # README.md not in code__ (clean)
+
+    mock_docs_col = MagicMock()
+    mock_docs_col.get.return_value = {"ids": ["stale-chunk-1"]}  # main.py in docs__ (wrong)
+
+    cols = {"code__repo": mock_code_col, "docs__repo": mock_docs_col}
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.side_effect = lambda name: cols[name]
+
+    _prune_misclassified(repo, "code__repo", "docs__repo", code_files, prose_files, pdf_files, mock_db)
+
+    # main.py chunk should be deleted from docs__repo
+    mock_docs_col.delete.assert_called_once_with(ids=["stale-chunk-1"])
+
+
+def test_registry_c2_fallback(tmp_path: Path) -> None:
+    """When registry lacks docs_collection, the deterministic naming function is used."""
+    from nexus.indexer import _run_index
+    from nexus.registry import _docs_collection_name
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # Registry without docs_collection key
+    registry = MagicMock()
+    registry.get.return_value = {
+        "collection": "code__repo",
+        "code_collection": "code__repo",
+        # No docs_collection key
+    }
+
+    expected_docs = _docs_collection_name(repo)
+    collection_names_used: list[str] = []
+
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"metadatas": [], "ids": []}
+    mock_db = MagicMock()
+
+    def track_get_or_create(name):
+        collection_names_used.append(name)
+        return mock_col
+
+    mock_db.get_or_create_collection.side_effect = track_get_or_create
+
+    with patch("nexus.frecency.batch_frecency", return_value={}):
+        with patch("nexus.ripgrep_cache.build_cache"):
+            with patch("nexus.indexer._git_metadata", return_value={}):
+                with patch("nexus.config.load_config", return_value=_DEFAULT_CONFIG):
+                    with patch("nexus.config.get_credential", return_value="fake-key"):
+                        with patch("nexus.db.make_t3", return_value=mock_db):
+                            with patch("voyageai.Client"):
+                                _run_index(repo, registry)
+
+    # The deterministic docs collection name should be used
+    assert expected_docs in collection_names_used, (
+        f"Expected {expected_docs} in {collection_names_used}"
     )

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,4 +1,5 @@
 """T1: indexer.py — status transitions, error path, credential skip, hidden file filter."""
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -23,7 +24,7 @@ def registry():
 # Default config mock that includes the indexing section
 _DEFAULT_CONFIG = {
     "server": {"ignorePatterns": []},
-    "indexing": {"code_extensions": [], "prose_extensions": [], "rdr_paths": ["docs/rdr"]},
+    "indexing": {"code_extensions": [], "prose_extensions": [], "rdr_paths": ["docs/rdr"], "include_untracked": False},
 }
 
 
@@ -825,3 +826,73 @@ def test_registry_c2_fallback(tmp_path: Path) -> None:
     assert expected_docs in collection_names_used, (
         f"Expected {expected_docs} in {collection_names_used}"
     )
+
+
+# ── _git_ls_files tests ──────────────────────────────────────────────────────
+
+
+def test_git_ls_files_returns_tracked_files(tmp_path: Path) -> None:
+    """_git_ls_files returns only tracked files, not .gitignored ones."""
+    from nexus.indexer import _git_ls_files
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "tracked.py").write_text("x = 1\n")
+    (repo / ".env").write_text("SECRET=abc\n")
+    (repo / ".gitignore").write_text(".env\n")
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+
+    files = _git_ls_files(repo)
+    file_names = {f.name for f in files}
+    assert "tracked.py" in file_names
+    assert ".gitignore" in file_names
+    assert ".env" not in file_names, ".env should be gitignored"
+
+
+def test_git_ls_files_with_untracked(tmp_path: Path) -> None:
+    """include_untracked=True also returns untracked-but-not-ignored files."""
+    from nexus.indexer import _git_ls_files
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "tracked.py").write_text("x = 1\n")
+    (repo / ".gitignore").write_text(".env\n")
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "tracked.py", ".gitignore"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+
+    # Create untracked (not ignored) file
+    (repo / "new_file.py").write_text("y = 2\n")
+    # Create ignored file
+    (repo / ".env").write_text("SECRET=abc\n")
+
+    # Without include_untracked
+    files = _git_ls_files(repo, include_untracked=False)
+    file_names = {f.name for f in files}
+    assert "new_file.py" not in file_names
+
+    # With include_untracked
+    files = _git_ls_files(repo, include_untracked=True)
+    file_names = {f.name for f in files}
+    assert "new_file.py" in file_names
+    assert ".env" not in file_names, ".env should still be gitignored"
+
+
+def test_git_ls_files_fallback_on_non_git_dir(tmp_path: Path) -> None:
+    """_git_ls_files returns empty list for non-git directories (triggers fallback)."""
+    from nexus.indexer import _git_ls_files
+
+    non_git = tmp_path / "not-a-repo"
+    non_git.mkdir()
+    (non_git / "file.py").write_text("x = 1\n")
+
+    files = _git_ls_files(non_git)
+    assert files == [], "Non-git directory should return empty list for fallback"

--- a/tests/test_indexer_e2e.py
+++ b/tests/test_indexer_e2e.py
@@ -35,6 +35,34 @@ _CORPUS_FILES = [
 
 _NEXUS_ROOT = Path(__file__).parent.parent
 
+# Prose files for the rich_repo fixture — markdown + config content
+_PROSE_FILES = {
+    "README.md": (
+        "# Nexus\n\nNexus is a semantic search and knowledge management system.\n\n"
+        "## Features\n\n- Semantic search across code repositories\n"
+        "- Persistent memory across sessions\n- Three storage tiers\n"
+    ),
+    "docs/architecture.md": (
+        "# Architecture\n\n## Overview\n\nNexus uses a three-tier storage model.\n\n"
+        "### T1 — Session Scratch\n\nEphemeral ChromaDB with DefaultEmbeddingFunction.\n\n"
+        "### T3 — Permanent Knowledge\n\nChromaDB Cloud with Voyage AI embeddings.\n"
+    ),
+    "config.yaml": (
+        "server:\n  port: 7890\n  headPollInterval: 10\n"
+        "embeddings:\n  rerankerModel: rerank-2.5\n"
+    ),
+}
+
+# RDR (Record of Design Rationale) files — under docs/rdr/
+_RDR_FILES = {
+    "docs/rdr/ADR-001-storage-tiers.md": (
+        "---\ntitle: Storage Tier Architecture\nstatus: accepted\n---\n\n"
+        "# ADR-001: Storage Tier Architecture\n\n"
+        "## Decision\n\nWe use three storage tiers for different persistence needs.\n"
+        "## Consequences\n\nMore complexity but better separation of concerns.\n"
+    ),
+}
+
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -79,6 +107,10 @@ def registry(tmp_path: Path, mini_repo: Path) -> RepoRegistry:
 def mock_voyage_client():
     """Patch voyageai.Client so E2E tests run without API keys.
 
+    Mocks both embed() and contextualized_embed() so that:
+    - Code indexing (direct embed via voyage-code-3) works
+    - Prose/PDF indexing (CCE via _embed_with_fallback / voyage-context-3) works
+
     Uses DefaultEmbeddingFunction (ONNX MiniLM-L6) to produce embeddings so
     that index vectors and query vectors are in the same space as the local_t3
     fixture's _ef_override — keeping semantic search meaningful in unit tests.
@@ -92,10 +124,67 @@ def mock_voyage_client():
         result.embeddings = ef(texts)
         return result
 
+    def fake_contextualized_embed(inputs, model, input_type="document"):
+        # inputs is a list of lists: [[chunk1, chunk2, ...]]
+        # contextualized_embed returns result.results[i].embeddings
+        result = MagicMock()
+        batch_result = MagicMock()
+        batch_result.embeddings = ef(inputs[0])
+        result.results = [batch_result]
+        return result
+
     mock_client.embed.side_effect = fake_embed
+    mock_client.contextualized_embed.side_effect = fake_contextualized_embed
 
     with patch("voyageai.Client", return_value=mock_client):
         yield mock_client
+
+
+@pytest.fixture(scope="module")
+def rich_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A real git repo with code, prose, and RDR files.
+
+    Module-scoped: git init + commit runs once per test session.
+    Contains:
+      - Code files (from _CORPUS_FILES): .py source files
+      - Prose files (from _PROSE_FILES): .md and .yaml files
+      - RDR files (from _RDR_FILES): ADR markdown under docs/rdr/
+    """
+    repo = tmp_path_factory.mktemp("nexus-rich")
+
+    # Code files — copied from the real Nexus source
+    for rel in _CORPUS_FILES:
+        src = _NEXUS_ROOT / rel
+        dest = repo / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+
+    # Prose files — synthetic content
+    for rel, content in _PROSE_FILES.items():
+        dest = repo / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+
+    # RDR files — synthetic ADR content
+    for rel, content in _RDR_FILES.items():
+        dest = repo / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@nexus"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Nexus Test"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial rich corpus commit"], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+@pytest.fixture
+def rich_registry(tmp_path: Path, rich_repo: Path) -> RepoRegistry:
+    """RepoRegistry in a temp file with rich_repo pre-registered."""
+    reg = RepoRegistry(tmp_path / "repos.json")
+    reg.add(rich_repo)
+    return reg
 
 
 # ── Indexer pipeline tests ─────────────────────────────────────────────────────
@@ -187,6 +276,293 @@ def test_index_frecency_only_preserves_chunk_count(
         index_repository(mini_repo, registry, frecency_only=True)
 
     assert col.count() == count_before
+
+
+# ── Smart indexing: dual collection tests ────────────────────────────────────
+
+def _run_smart_index(repo: Path, registry: RepoRegistry, local_t3: T3Database) -> None:
+    """Helper: run index_repository with standard test patches."""
+    from nexus.indexer import index_repository
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(repo, registry)
+
+
+def test_smart_index_creates_both_collections(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """index_repository creates both code__ and docs__ collections with chunks."""
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    info = rich_registry.get(rich_repo)
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+
+    assert code_col.count() > 0, "Expected chunks in code__ collection"
+    assert docs_col.count() > 0, "Expected chunks in docs__ collection"
+
+
+def test_smart_index_code_files_in_code_collection(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """.py files should be in code__, NOT in docs__."""
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    info = rich_registry.get(rich_repo)
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+
+    code_result = code_col.get(include=["metadatas"])
+    code_sources = {m.get("source_path", "") for m in code_result["metadatas"]}
+    assert any("ttl.py" in p for p in code_sources), (
+        f"ttl.py should be in code__ collection; got: {code_sources}"
+    )
+
+    docs_result = docs_col.get(include=["metadatas"])
+    docs_sources = {m.get("source_path", "") for m in docs_result["metadatas"]}
+    assert not any(".py" in p for p in docs_sources), (
+        f".py files should NOT be in docs__ collection; found: "
+        f"{[p for p in docs_sources if '.py' in p]}"
+    )
+
+
+def test_smart_index_prose_files_in_docs_collection(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """.md and .yaml files should be in docs__, NOT in code__."""
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    info = rich_registry.get(rich_repo)
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+
+    docs_result = docs_col.get(include=["metadatas"])
+    docs_sources = {m.get("source_path", "") for m in docs_result["metadatas"]}
+    assert any("README.md" in p for p in docs_sources), (
+        f"README.md should be in docs__ collection; got: {docs_sources}"
+    )
+    assert any("architecture.md" in p for p in docs_sources), (
+        f"architecture.md should be in docs__ collection; got: {docs_sources}"
+    )
+    assert any("config.yaml" in p for p in docs_sources), (
+        f"config.yaml should be in docs__ collection; got: {docs_sources}"
+    )
+
+    code_result = code_col.get(include=["metadatas"])
+    code_sources = {m.get("source_path", "") for m in code_result["metadatas"]}
+    assert not any("README.md" in p for p in code_sources), (
+        "README.md should NOT be in code__ collection"
+    )
+
+
+def test_smart_index_rdr_excluded_from_docs(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """RDR files should NOT be in the main docs__<repo> collection."""
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    info = rich_registry.get(rich_repo)
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+
+    docs_result = docs_col.get(include=["metadatas"])
+    docs_sources = {m.get("source_path", "") for m in docs_result["metadatas"]}
+    assert not any("ADR-001" in p for p in docs_sources), (
+        f"RDR files should NOT be in docs__<repo> collection; "
+        f"found: {[p for p in docs_sources if 'ADR-001' in p]}"
+    )
+
+
+def test_smart_index_rdr_in_rdr_collection(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """RDR files should be indexed into docs__rdr__<repo-name> (M4 fix)."""
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    path_hash = hashlib.sha256(str(rich_repo).encode()).hexdigest()[:8]
+    rdr_col_name = f"docs__rdr__{rich_repo.name}-{path_hash}"
+    rdr_col = local_t3.get_or_create_collection(rdr_col_name)
+    assert rdr_col.count() > 0, "Expected RDR chunks in docs__rdr__ collection"
+
+    result = rdr_col.get(include=["metadatas"])
+    source_paths = {m.get("source_path", "") for m in result["metadatas"]}
+    assert any("ADR-001" in p for p in source_paths), (
+        f"ADR-001 should be in docs__rdr__ collection; got: {source_paths}"
+    )
+
+
+def test_smart_index_search_code_query(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Searching code__ returns code files for a code-related query."""
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    info = rich_registry.get(rich_repo)
+    results = local_t3.search(
+        "parse TTL days weeks permanent", [info["code_collection"]], n_results=5,
+    )
+    assert len(results) > 0, "Expected code search results"
+    source_paths = [r.get("source_path", "") for r in results]
+    assert any("ttl.py" in p for p in source_paths), (
+        f"Expected ttl.py in code search results; got: {source_paths}"
+    )
+
+
+def test_smart_index_search_prose_query(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Searching docs__ returns prose files for a prose-related query."""
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    info = rich_registry.get(rich_repo)
+    results = local_t3.search(
+        "semantic search knowledge management features", [info["docs_collection"]], n_results=5,
+    )
+    assert len(results) > 0, "Expected prose search results"
+    source_paths = [r.get("source_path", "") for r in results]
+    assert any("README.md" in p for p in source_paths), (
+        f"Expected README.md in prose search results; got: {source_paths}"
+    )
+
+
+def test_smart_index_embedding_model_metadata(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Code chunks record voyage-code-3; docs chunks record voyage-context-3 or voyage-4."""
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    info = rich_registry.get(rich_repo)
+
+    # Check code collection
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    code_result = code_col.get(include=["metadatas"])
+    code_models = {m.get("embedding_model", "") for m in code_result["metadatas"]}
+    assert "voyage-code-3" in code_models, (
+        f"Code chunks should use voyage-code-3; got: {code_models}"
+    )
+
+    # Check docs collection — CCE uses voyage-context-3, fallback uses voyage-4
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+    docs_result = docs_col.get(include=["metadatas"])
+    docs_models = {m.get("embedding_model", "") for m in docs_result["metadatas"]}
+    allowed = {"voyage-context-3", "voyage-4"}
+    assert docs_models <= allowed, (
+        f"Docs chunks should use voyage-context-3 or voyage-4; got: {docs_models}"
+    )
+    assert len(docs_models) > 0, "Expected at least one embedding model in docs chunks"
+
+
+def test_smart_index_staleness_check(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Second index skips unchanged files in both code__ and docs__ collections."""
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    info = rich_registry.get(rich_repo)
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+    code_count_1 = code_col.count()
+    docs_count_1 = docs_col.count()
+
+    # Re-run indexing — should be a no-op
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    assert code_col.count() == code_count_1, (
+        f"Code chunk count changed on re-index: {code_count_1} -> {code_col.count()}"
+    )
+    assert docs_col.count() == docs_count_1, (
+        f"Docs chunk count changed on re-index: {docs_count_1} -> {docs_col.count()}"
+    )
+
+
+def test_smart_index_git_metadata_present(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database,
+) -> None:
+    """Chunks in both collections carry git_commit_hash, git_branch, source_path."""
+    _run_smart_index(rich_repo, rich_registry, local_t3)
+
+    info = rich_registry.get(rich_repo)
+
+    for col_name in (info["code_collection"], info["docs_collection"]):
+        col = local_t3.get_or_create_collection(col_name)
+        result = col.get(include=["metadatas"])
+        assert len(result["metadatas"]) > 0, f"No chunks in {col_name}"
+
+        sample = result["metadatas"][0]
+        assert sample.get("git_commit_hash"), (
+            f"git_commit_hash missing in {col_name}: {sample}"
+        )
+        assert sample.get("git_branch"), (
+            f"git_branch missing in {col_name}: {sample}"
+        )
+        assert sample.get("source_path"), (
+            f"source_path missing in {col_name}: {sample}"
+        )
+
+
+# ── Migration test ──────────────────────────────────────────────────────────
+
+def test_migration_moves_prose_from_code_to_docs(
+    rich_repo: Path, tmp_path: Path, local_t3: T3Database,
+) -> None:
+    """Simulates old indexer (all in code__), then runs new indexer to verify migration.
+
+    The _prune_misclassified step should remove prose chunks from code__ and
+    the new indexer should place prose into docs__.
+
+    Note: chromadb.EphemeralClient is a singleton — all instances share state.
+    The test verifies by ID that the specific fake chunk is pruned.
+    """
+    from nexus.indexer import index_repository
+
+    reg = RepoRegistry(tmp_path / "repos.json")
+    reg.add(rich_repo)
+    info = reg.get(rich_repo)
+    code_col_name = info["code_collection"]
+    docs_col_name = info["docs_collection"]
+
+    # Manually insert a prose file's chunk into code__ (simulating old behavior)
+    code_col = local_t3.get_or_create_collection(code_col_name)
+    readme_path = str(rich_repo / "README.md")
+    code_col.add(
+        ids=["fake-prose-in-code"],
+        documents=["Nexus is a semantic search system"],
+        metadatas=[{
+            "source_path": readme_path,
+            "content_hash": "old-hash",
+            "embedding_model": "voyage-code-3",
+            "store_type": "code",
+        }],
+    )
+    # Verify the fake chunk was inserted (by specific ID, not total count)
+    pre_result = code_col.get(ids=["fake-prose-in-code"], include=["metadatas"])
+    assert len(pre_result["ids"]) == 1, "Fake prose chunk must exist before migration"
+
+    # Run the new unified indexer
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(rich_repo, reg)
+
+    # The fake prose chunk should have been pruned from code__
+    code_result = code_col.get(include=["metadatas"])
+    code_sources = {m.get("source_path", "") for m in code_result["metadatas"]}
+    assert readme_path not in code_sources, (
+        "README.md should be pruned from code__ after reclassification"
+    )
+
+    # Specifically, the fake ID should be gone
+    post_fake = code_col.get(ids=["fake-prose-in-code"], include=[])
+    assert len(post_fake["ids"]) == 0, (
+        "The fake-prose-in-code chunk should have been pruned from code__"
+    )
+
+    # README.md should now be in docs__
+    docs_col = local_t3.get_or_create_collection(docs_col_name)
+    docs_result = docs_col.get(include=["metadatas"])
+    docs_sources = {m.get("source_path", "") for m in docs_result["metadatas"]}
+    assert any("README.md" in p for p in docs_sources), (
+        f"README.md should be in docs__ after migration; got: {docs_sources}"
+    )
 
 
 # ── Index → search pipeline ───────────────────────────────────────────────────

--- a/tests/test_indexer_e2e.py
+++ b/tests/test_indexer_e2e.py
@@ -333,13 +333,13 @@ def test_polling_does_not_record_head_hash_on_credentials_missing(
     )
 
 
-# ── CLI: nx index code ─────────────────────────────────────────────────────────
+# ── CLI: nx index repo ─────────────────────────────────────────────────────────
 
-def test_cli_index_code_registers_and_indexes(
+def test_cli_index_repo_registers_and_indexes(
     mini_repo: Path, tmp_path: Path, local_t3: T3Database,
     monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """nx index code <path> registers the repo and indexes it end-to-end."""
+    """nx index repo <path> registers the repo and indexes it end-to-end."""
     from click.testing import CliRunner
     from nexus.cli import main
 
@@ -348,7 +348,7 @@ def test_cli_index_code_registers_and_indexes(
 
     with patch("nexus.db.make_t3", return_value=local_t3), \
          patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
-        result = runner.invoke(main, ["index", "code", str(mini_repo)])
+        result = runner.invoke(main, ["index", "repo", str(mini_repo)])
 
     assert result.exit_code == 0, result.output
     assert "Done" in result.output
@@ -358,7 +358,7 @@ def test_cli_index_then_search_pipeline(
     mini_repo: Path, tmp_path: Path, local_t3: T3Database,
     monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """nx index code → nx search: full CLI pipeline returns results."""
+    """nx index repo → nx search: full CLI pipeline returns results."""
     from click.testing import CliRunner
     from nexus.cli import main
 
@@ -376,7 +376,7 @@ def test_cli_index_then_search_pipeline(
          patch("nexus.config.get_credential", side_effect=lambda k: "test-key"), \
          patch("nexus.commands.search_cmd._t3", return_value=local_t3):
 
-        index_result = runner.invoke(main, ["index", "code", str(mini_repo)])
+        index_result = runner.invoke(main, ["index", "repo", str(mini_repo)])
         assert index_result.exit_code == 0, index_result.output
 
         search_result = runner.invoke(main, [
@@ -393,7 +393,7 @@ def test_cli_index_frecency_only_flag(
     mini_repo: Path, tmp_path: Path, local_t3: T3Database,
     monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """nx index code --frecency-only completes without error after a full index."""
+    """nx index repo --frecency-only completes without error after a full index."""
     from click.testing import CliRunner
     from nexus.cli import main
 
@@ -402,8 +402,8 @@ def test_cli_index_frecency_only_flag(
 
     with patch("nexus.db.make_t3", return_value=local_t3), \
          patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
-        runner.invoke(main, ["index", "code", str(mini_repo)])
-        result = runner.invoke(main, ["index", "code", str(mini_repo), "--frecency-only"])
+        runner.invoke(main, ["index", "repo", str(mini_repo)])
+        result = runner.invoke(main, ["index", "repo", str(mini_repo), "--frecency-only"])
 
     assert result.exit_code == 0, result.output
     assert "Done" in result.output

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -209,3 +209,95 @@ def test_docs_collection_name_function() -> None:
     name = _docs_collection_name(repo)
     assert name.startswith("docs__myrepo-")
     assert len(name.split("-")[-1]) == 8  # 8-char hash
+
+
+# ── worktree-stable hashing ──────────────────────────────────────────────────
+
+
+def test_repo_identity_fallback_without_git(tmp_path: Path) -> None:
+    """_repo_identity falls back to repo path when not a git repo."""
+    from nexus.registry import _repo_identity
+
+    repo = tmp_path / "not-a-git-repo"
+    repo.mkdir()
+    name, hash8 = _repo_identity(repo)
+    assert name == "not-a-git-repo"
+    expected = hashlib.sha256(str(repo).encode()).hexdigest()[:8]
+    assert hash8 == expected
+
+
+def test_repo_identity_stable_in_git_repo(tmp_path: Path) -> None:
+    """_repo_identity uses the git common dir for a real git repo."""
+    import subprocess
+
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+
+    from nexus.registry import _repo_identity
+
+    name, hash8 = _repo_identity(repo)
+    assert name == "myrepo"
+    expected = hashlib.sha256(str(repo).encode()).hexdigest()[:8]
+    assert hash8 == expected
+
+
+def test_repo_identity_worktree_matches_main(tmp_path: Path) -> None:
+    """A worktree produces the same identity as the main repo."""
+    import subprocess
+
+    # Create a main repo with an initial commit (required for worktree)
+    main_repo = tmp_path / "main-repo"
+    main_repo.mkdir()
+    subprocess.run(["git", "init"], cwd=main_repo, capture_output=True, check=True)
+    (main_repo / "f.txt").write_text("hello")
+    subprocess.run(["git", "add", "."], cwd=main_repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=main_repo, capture_output=True, check=True,
+        env={**__import__("os").environ, "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
+    # Create a worktree
+    wt = tmp_path / "my-worktree"
+    subprocess.run(
+        ["git", "worktree", "add", str(wt), "-b", "wt-branch"],
+        cwd=main_repo, capture_output=True, check=True,
+    )
+
+    from nexus.registry import _repo_identity
+
+    main_name, main_hash = _repo_identity(main_repo)
+    wt_name, wt_hash = _repo_identity(wt)
+
+    assert main_name == wt_name, f"names differ: {main_name} vs {wt_name}"
+    assert main_hash == wt_hash, f"hashes differ: {main_hash} vs {wt_hash}"
+
+
+def test_collection_names_stable_across_worktrees(tmp_path: Path) -> None:
+    """_collection_name and _docs_collection_name are identical for main and worktree."""
+    import subprocess
+
+    from nexus.registry import _collection_name, _docs_collection_name
+
+    main_repo = tmp_path / "repo"
+    main_repo.mkdir()
+    subprocess.run(["git", "init"], cwd=main_repo, capture_output=True, check=True)
+    (main_repo / "f.txt").write_text("hello")
+    subprocess.run(["git", "add", "."], cwd=main_repo, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=main_repo, capture_output=True, check=True,
+        env={**__import__("os").environ, "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+
+    wt = tmp_path / "wt"
+    subprocess.run(
+        ["git", "worktree", "add", str(wt), "-b", "wt-branch"],
+        cwd=main_repo, capture_output=True, check=True,
+    )
+
+    assert _collection_name(main_repo) == _collection_name(wt)
+    assert _docs_collection_name(main_repo) == _docs_collection_name(wt)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -171,3 +171,41 @@ def test_registry_get_returns_copy_not_reference(tmp_path: Path) -> None:
     expected_hash = hashlib.sha256(str(repo).encode()).hexdigest()[:8]
     assert fresh["collection"] == f"code__myrepo-{expected_hash}"
     assert "injected" not in fresh
+
+
+# ── dual-collection names ─────────────────────────────────────────────────────
+
+
+def test_add_stores_both_collection_names(tmp_path: Path) -> None:
+    reg = RepoRegistry(tmp_path / "repos.json")
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    reg.add(repo)
+    info = reg.get(repo)
+    assert "code_collection" in info
+    assert "docs_collection" in info
+    assert info["code_collection"].startswith("code__")
+    assert info["docs_collection"].startswith("docs__")
+    # Same hash suffix
+    code_suffix = info["code_collection"].split("code__")[1]
+    docs_suffix = info["docs_collection"].split("docs__")[1]
+    assert code_suffix == docs_suffix
+
+
+def test_backward_compat_collection_key(tmp_path: Path) -> None:
+    """The 'collection' key still works as alias for code_collection."""
+    reg = RepoRegistry(tmp_path / "repos.json")
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    reg.add(repo)
+    info = reg.get(repo)
+    assert info["collection"] == info["code_collection"]
+
+
+def test_docs_collection_name_function() -> None:
+    from nexus.registry import _docs_collection_name
+
+    repo = Path("/some/path/myrepo")
+    name = _docs_collection_name(repo)
+    assert name.startswith("docs__myrepo-")
+    assert len(name.split("-")[-1]) == 8  # 8-char hash


### PR DESCRIPTION
## Summary

- **File classification**: New `classifier.py` module routes files by extension — code (voyage-code-3, AST chunking) vs prose (voyage-context-3/CCE, semantic chunking) vs PDF (extraction + voyage-context-3)
- **Dual collections per repo**: `code__repo-hash` for code, `docs__repo-hash` for prose/PDFs, `docs__rdr__repo-hash` for auto-discovered RDR documents
- **`nx index code` renamed to `nx index repo`**: Single command, one file walk, three output streams
- **`.gitignore`-aware file walk**: Uses `git ls-files` instead of `rglob("*")` — prevents indexing secrets, large training files, and build artifacts
- **Worktree-stable collection names**: `git rev-parse --git-common-dir` ensures main repo and all worktrees share the same collections; graceful fallback when git unavailable
- **`.nexus.yml` config**: Per-repo `code_extensions`, `prose_extensions`, `rdr_paths`, `include_untracked` overrides
- **AST chunking fix**: Pass `tree-sitter-language-pack` parser directly to CodeSplitter (replaces deprecated `tree_sitter_languages`)
- **Cross-collection pruning**: Files that change classification get cleaned up from the old collection; deleted files are pruned

## Test plan

- [x] 1289 tests pass (17 skipped), 0 failures
- [x] 12 new classifier tests, 10 new indexer unit tests, 11 new E2E tests, 4 new registry worktree tests
- [x] Live test with real Voyage AI + ChromaDB Cloud credentials — code/prose/RDR routed correctly, search works across all corpora
- [x] Plan audited before implementation (3 critical + 4 medium issues, all addressed)