### PR TITLE
fix: correct CCE query model mismatch (docs__, knowledge__, rdr__ unsearchable since rc1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0rc6] - 2026-02-28
+
+### Fixed
+- **CCE query model mismatch** (P0, affected rc1–rc5): `docs__`, `knowledge__`, and `rdr__`
+  collections were indexed with `voyage-context-3` (CCE) but queried with `voyage-4`.
+  These two models produce vectors in incompatible geometric spaces (cosine similarity ≈ 0.05
+  — effectively random noise). All three collection types were returning semantically
+  meaningless results since rc1. `code__` collections were unaffected.
+  Fix: `corpus.py` returns `voyage-context-3` for CCE collections; `T3Database.search()`
+  bypasses the ChromaDB `VoyageAIEmbeddingFunction` for CCE collections and calls
+  `contextualized_embed([[query]], input_type="query")` directly. `T3Database.put()`
+  likewise uses `contextualized_embed` with `input_type="document"` so single entries
+  stored via `nx store put` land in the same CCE vector space as indexed chunks.
+  **All CCE-indexed collections (`docs__*`, `knowledge__*`, `rdr__*`) must be re-indexed
+  after upgrading from rc1–rc5.**
+
 ## [1.0.0rc5] - 2026-02-28
 
 ### Added
@@ -229,6 +245,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Phase 1–8 implementations covering all CLI surface
 
 [Unreleased]: https://github.com/Hellblazer/nexus/compare/v1.0.0rc5...HEAD
+[1.0.0rc5]: https://github.com/Hellblazer/nexus/compare/v1.0.0rc4...v1.0.0rc5
+[1.0.0rc6]: https://github.com/Hellblazer/nexus/compare/v1.0.0rc5...v1.0.0rc6
 [1.0.0rc5]: https://github.com/Hellblazer/nexus/compare/v1.0.0rc4...v1.0.0rc5
 [1.0.0rc4]: https://github.com/Hellblazer/nexus/compare/v1.0.0rc3...v1.0.0rc4
 [1.0.0rc3]: https://github.com/Hellblazer/nexus/compare/v1.0.0rc2...v1.0.0rc3

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,11 @@ CLI (cli.py + commands/)
     └── Storage tiers
           T1: in-memory ChromaDB (session scratch)
           T2: SQLite + FTS5 (persistent memory, PM state)
-          T3: ChromaDB cloud + Voyage AI (permanent knowledge)
+          T3: ChromaDB Cloud (four databases) + Voyage AI (permanent knowledge)
+                {base}_code      → code__*       voyage-code-3 index / voyage-4 query
+                {base}_docs      → docs__*       voyage-context-3 (CCE) index + query
+                {base}_rdr       → rdr__*        voyage-context-3 (CCE) index + query
+                {base}_knowledge → knowledge__*  voyage-context-3 (CCE) index + query
 ```
 
 Data flows upward (T1 → T2 → T3). No reverse flow except `nx pm restore`.

--- a/docs/rdr/post-mortem/cce-query-model-mismatch.md
+++ b/docs/rdr/post-mortem/cce-query-model-mismatch.md
@@ -6,8 +6,8 @@ introduced: "053f54d — 2026-02-22"
 discovered: "2026-02-28 (post rc5 release)"
 affected_releases: [rc1, rc2, rc3, rc4, rc5]
 affected_collections: [docs__, knowledge__, rdr__]
-status: identified
-fix_pr: pending
+status: resolved
+fix_pr: "https://github.com/Hellblazer/nexus/pull/33"
 ---
 
 # Post-Mortem: CCE Query Model Mismatch

--- a/docs/rdr/post-mortem/cce-query-model-mismatch.md
+++ b/docs/rdr/post-mortem/cce-query-model-mismatch.md
@@ -1,0 +1,167 @@
+---
+title: "CCE Query Model Mismatch: voyage-context-3 Collections Unsearchable Since rc1"
+date: 2026-02-28
+severity: high
+introduced: "053f54d — 2026-02-22"
+discovered: "2026-02-28 (post rc5 release)"
+affected_releases: [rc1, rc2, rc3, rc4, rc5]
+affected_collections: [docs__, knowledge__, rdr__]
+status: identified
+fix_pr: pending
+---
+
+# Post-Mortem: CCE Query Model Mismatch
+
+## Summary
+
+Every `docs__`, `knowledge__`, and `rdr__` collection indexed since rc1 has been
+effectively unsearchable. Documents in these collections use `voyage-context-3`
+(Contextualized Chunk Embedding, CCE) at index time, but the search path queries
+with `voyage-4`. These two models produce vectors in **incompatible geometric spaces**:
+cosine similarity between any `voyage-4` query and any CCE-indexed chunk is ~0.05 —
+effectively random noise. Results are not ranked by semantic relevance; they are ranked
+by volume (collections with more chunks win purely by probability).
+
+Only `code__` collections (voyage-code-3 at index, voyage-4 at query) have been
+working as intended.
+
+---
+
+## Timeline
+
+| Date | Event |
+|------|-------|
+| 2026-02-22 | `1c23ec5` — CCE implementation landed. `doc_indexer.py` indexes `docs__` and `knowledge__` with `voyage-context-3` via the `/v1/contextualizedembeddings` endpoint. `corpus.py` initially returned `voyage-code-3` for code and `voyage-4` for everything else — consistent with CCE intent. |
+| 2026-02-22 | `053f54d` — "Fix voyage-4 as universal query model". Commit message argues: *"Code collections are indexed with voyage-code-3 but queried with voyage-4 — the semantic spaces are compatible enough for effective retrieval, and a single query model simplifies cross-corpus search."* The same reasoning was **incorrectly extended** to CCE collections. `embedding_model_for_collection()` was changed to return `"voyage-4"` for all collections unconditionally. |
+| 2026-02-22 | rc1–rc4 released. No search tests against live CCE collections. Bug undetected. |
+| 2026-02-28 | rc5 released. Post-release `nx search "four store t3 architecture" --corpus rdr` returns only RDR-001/RDR-002 for every query, never RDR-004. |
+| 2026-02-28 | Investigation reveals cosine similarity of ~0.05 across all CCE chunks for all queries. Deep research confirms root cause: voyage-4 and voyage-context-3 are incompatible vector spaces. |
+
+---
+
+## Root Cause
+
+### The Assumption
+
+Commit `053f54d` made this architectural decision:
+
+> "voyage-4 is the universal query model for all collection types."
+
+This was based on an observed pattern: `voyage-code-3` (code index model) and `voyage-4`
+(query model) work together acceptably for `code__` collections. The commit assumed
+this cross-model compatibility generalised to `voyage-context-3`.
+
+### Why the Assumption Was Wrong
+
+`voyage-code-3` and `voyage-4` are members of overlapping model families that share
+vector space geometry (unconfirmed but empirically tolerable).
+
+`voyage-context-3` is architecturally different:
+
+1. **Different API endpoint**: CCE uses `/v1/contextualizedembeddings`, not `/v1/embeddings`.
+   The model name `voyage-context-3` is rejected entirely by `client.embed()`.
+
+2. **Different training objective**: CCE trains on cross-chunk context propagation,
+   not point-in-space retrieval. The resulting embedding space has different geometry.
+
+3. **Incompatible vector spaces**: Cosine similarity between `voyage-4` query vectors
+   and `voyage-context-3` document vectors is ~0.05 — indistinguishable from random
+   orthogonal vectors. There is no semantic signal.
+
+4. **Official documentation**: Voyage AI's Voyage 4 family cross-model compatibility
+   (voyage-4-large ↔ voyage-4-lite ↔ voyage-4-nano) is explicitly scoped to the
+   Voyage 4 family. The CCE docs specify `voyage-context-3` must be used at both
+   index and query time via `contextualized_embed()`.
+
+### The Compounding Bug
+
+Even if `corpus.py` had returned `"voyage-context-3"`, the query path would still
+be broken. ChromaDB's `VoyageAIEmbeddingFunction` always calls `client.embed()`,
+which rejects `voyage-context-3`. The fix requires bypassing the ChromaDB EF
+entirely for CCE collections and calling `contextualized_embed([[query]], input_type="query")`
+directly.
+
+---
+
+## Impact
+
+| Collection type | Index model | Query model (actual) | Searchable? |
+|----------------|-------------|----------------------|-------------|
+| `code__*` | voyage-code-3 | voyage-4 | Partially (cross-model compat unconfirmed but tolerable) |
+| `docs__*` | voyage-context-3 | voyage-4 | **No** — cosine sim ~0.05 |
+| `knowledge__*` | voyage-context-3 | voyage-4 | **No** — cosine sim ~0.05 |
+| `rdr__*` | voyage-context-3 | voyage-4 | **No** — cosine sim ~0.05 |
+
+All `nx search` queries that include `docs`, `knowledge`, or `rdr` corpora (the default
+includes `knowledge`, `code`, `docs`) have been returning semantically meaningless
+results from these corpora since rc1. The `code__` results within the same query were
+correct; they were mixed with noise from the other corpora.
+
+`nx store`, `nx memory promote`, and any other operation that writes to `docs__` or
+`knowledge__` has been producing data that cannot be effectively retrieved.
+
+---
+
+## What Was Not Caught
+
+1. **No integration test for CCE retrieval quality.** Tests verified that `upsert_chunks()`
+   accepted CCE embeddings and that `search()` returned rows — not that the *right*
+   rows were returned.
+
+2. **No cross-model compatibility validation.** The assumption that voyage-4 queries
+   would work against CCE documents was never tested against a live collection.
+
+3. **Misleading symptom.** Searches did return results — they just returned the wrong
+   ones. Collections with more chunks (RDR-001: 48, RDR-002: 67) consistently
+   out-ranked collections with fewer chunks (RDR-004: 18) because with near-uniform
+   distances, volume is the only differentiator.
+
+4. **No post-index verification step.** `nx index` reported success, `nx collection info`
+   showed correct document counts. There was no health check confirming that indexed
+   content was actually retrievable.
+
+---
+
+## Lessons Learned
+
+1. **Cross-model embedding compatibility must be verified empirically, not assumed.**
+   Same dimension ≠ same vector space. The CCE architecture is intentionally different
+   from standard retrieval embedding.
+
+2. **Index model ≠ query model is a footgun.** The decision to support different models
+   at index and query time (while sometimes useful) creates a class of bugs that are
+   silent at the API level but catastrophic for retrieval quality.
+
+3. **Retrieval quality tests must assert semantic correctness, not just row count.**
+   A test that asserts `len(results) > 0` will pass even when all results are noise.
+
+4. **New embedding strategies need a retrieval smoke test before release.** A single
+   `assert known_document in top_k_results(known_query)` would have caught this on day one.
+
+---
+
+## Fix (Pending)
+
+Two coordinated changes to `src/nexus/`:
+
+**`corpus.py`** — `embedding_model_for_collection()` returns `"voyage-context-3"`
+for `docs__`, `knowledge__`, and `rdr__` collections.  `index_model_for_collection()`
+likewise corrected for the same three prefixes.
+
+**`db/t3.py`** — Two changes:
+
+1. `T3Database.search()` detects CCE collections by checking
+   `index_model_for_collection()` and bypasses `VoyageAIEmbeddingFunction`, calling
+   `vo.contextualized_embed([[query]], model="voyage-context-3", input_type="query")`
+   directly before calling `col.query(query_embeddings=[...])`.
+
+2. `T3Database.put()` also bypasses the voyage-4 EF for CCE collections when
+   `voyage_api_key` is set, calling `_cce_embed(content)` and passing
+   `embeddings=[vec]` to `col.upsert()`.  This ensures single-entry knowledge
+   entries stored via `nx store put` are in the same CCE vector space as
+   multi-chunk doc_indexer entries and are findable by search.
+
+All CCE-indexed collections will need re-indexing after the fix is deployed, as the
+existing embeddings are correct — only the query path needs repair.
+
+See fix PR (pending).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "1.0.0rc5"
+version = "1.0.0rc6"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -30,11 +30,17 @@ def validate_collection_name(name: str) -> None:
 def embedding_model_for_collection(collection_name: str) -> str:
     """Return the Voyage AI model used at QUERY time for a T3 collection.
 
-    voyage-4 is the universal query model for all collection types.
-    Code collections are indexed with voyage-code-3 but queried with voyage-4 —
-    the semantic spaces are compatible enough for effective retrieval, and a single
-    query model simplifies cross-corpus search.
+    CCE collections (docs__, knowledge__, rdr__) must use voyage-context-3
+    at query time via contextualized_embed() — voyage-4 and voyage-context-3
+    are incompatible vector spaces (cosine similarity ≈ 0.05, i.e. random noise).
+
+    code__ collections are indexed with voyage-code-3 but queried with voyage-4 —
+    the semantic spaces are compatible enough for effective retrieval.
+
+    All other collections use voyage-4.
     """
+    if collection_name.startswith(("docs__", "knowledge__", "rdr__")):
+        return "voyage-context-3"
     return "voyage-4"
 
 

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime, timedelta
 
 import chromadb
 import chromadb.errors
+import voyageai
 from chromadb.errors import NotFoundError as _ChromaNotFoundError
 import structlog
 
@@ -114,17 +115,46 @@ class T3Database:
         return client
 
     def _embedding_fn(self, collection_name: str):
+        """Return a VoyageAI EF (always voyage-4) for collection creation.
+
+        The voyage-4 EF is attached to collections for structural compatibility
+        but is NOT called for CCE collections at write or query time:
+        - Write: ``upsert_chunks_with_embeddings()`` passes pre-computed CCE
+          embeddings; ``put()`` calls ``_cce_embed()`` directly and passes
+          ``embeddings=`` to bypass the EF.
+        - Query: ``search()`` calls ``_cce_embed()`` and passes
+          ``query_embeddings=`` to bypass the EF.
+        Caching is per-collection-name to match the existing test contract.
+        """
         if self._ef_override is not None:
             return self._ef_override
         with self._ef_lock:
             if collection_name not in self._ef_cache:
-                model = embedding_model_for_collection(collection_name)
                 self._ef_cache[collection_name] = (
                     chromadb.utils.embedding_functions.VoyageAIEmbeddingFunction(
-                        model_name=model, api_key=self._voyage_api_key
+                        model_name="voyage-4", api_key=self._voyage_api_key
                     )
                 )
             return self._ef_cache[collection_name]
+
+    def _cce_embed(self, text: str, input_type: str = "query") -> list[float]:
+        """Embed *text* via the Voyage AI Contextualized Chunk Embedding API.
+
+        CCE collections (docs__, knowledge__, rdr__) use voyage-context-3 at
+        both index and query time.  voyage-4 is **not** compatible with CCE
+        vector spaces (cross-model cosine similarity ≈ 0.05, i.e. random noise).
+
+        ``inputs=[[text]]`` — one inner list — embeds the text independently,
+        with no cross-chunk context propagation.  Use ``input_type="query"``
+        for search queries and ``input_type=None`` (default) for documents.
+        """
+        vo = voyageai.Client(api_key=self._voyage_api_key)
+        result = vo.contextualized_embed(
+            inputs=[[text]],
+            model="voyage-context-3",
+            input_type=input_type,
+        )
+        return result.results[0].embeddings[0]
 
     # ── Collection access ─────────────────────────────────────────────────────
 
@@ -174,6 +204,15 @@ class T3Database:
             else:
                 expires_at = ""
 
+        # Determine whether this collection uses CCE.  When a voyage_api_key
+        # is available, CCE collections (docs__, knowledge__, rdr__) are embedded
+        # via _cce_embed() so that put()-stored entries are in the same vector
+        # space as the CCE-indexed chunks and can be found by search().
+        is_cce = (
+            bool(self._voyage_api_key)
+            and index_model_for_collection(collection) == "voyage-context-3"
+        )
+
         metadata: dict = {
             "title": title,
             "tags": tags,
@@ -184,14 +223,15 @@ class T3Database:
             "indexed_at": now_iso,
             "expires_at": expires_at,
             "ttl_days": ttl_days,
-            # voyage-4 is the query-time model for all collection types; nx store put
-            # intentionally uses it (via the collection EF) rather than CCE because
-            # agent-stored knowledge chunks are typically single entries (CCE requires 2+).
-            "embedding_model": embedding_model_for_collection(collection),
+            "embedding_model": "voyage-context-3" if is_cce else "voyage-4",
         }
 
         col = self.get_or_create_collection(collection)
-        col.upsert(ids=[doc_id], documents=[content], metadatas=[metadata])
+        if is_cce:
+            vec = self._cce_embed(content)
+            col.upsert(ids=[doc_id], documents=[content], embeddings=[vec], metadatas=[metadata])
+        else:
+            col.upsert(ids=[doc_id], documents=[content], metadatas=[metadata])
         return doc_id
 
     def upsert_chunks(
@@ -271,21 +311,39 @@ class T3Database:
         """
         results: list[dict] = []
         for name in collection_names:
+            # CCE collections must be queried with voyage-context-3 via
+            # contextualized_embed(); using query_texts would invoke the voyage-4
+            # EF, producing vectors in an incompatible space (cosine sim ≈ 0.05).
+            # Skip CCE path when voyage_api_key is absent (test / offline mode).
+            is_cce = (
+                bool(self._voyage_api_key)
+                and index_model_for_collection(name) == "voyage-context-3"
+            )
             try:
-                col = self._client_for(name).get_collection(
-                    name, embedding_function=self._embedding_fn(name)
-                )
+                if is_cce:
+                    col = self._client_for(name).get_collection(name)
+                else:
+                    col = self._client_for(name).get_collection(
+                        name, embedding_function=self._embedding_fn(name)
+                    )
             except _ChromaNotFoundError:
                 continue  # collection doesn't exist, skip it
             count = col.count()
             if count == 0:
                 continue
             actual_n = min(n_results, count)
-            query_kwargs: dict = {
-                "query_texts": [query],
-                "n_results": actual_n,
-                "include": ["documents", "metadatas", "distances"],
-            }
+            if is_cce:
+                query_kwargs: dict = {
+                    "query_embeddings": [self._cce_embed(query, input_type="query")],
+                    "n_results": actual_n,
+                    "include": ["documents", "metadatas", "distances"],
+                }
+            else:
+                query_kwargs = {
+                    "query_texts": [query],
+                    "n_results": actual_n,
+                    "include": ["documents", "metadatas", "distances"],
+                }
             if where is not None:
                 query_kwargs["where"] = where
             qr = col.query(**query_kwargs)

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import threading
 from datetime import UTC, datetime, timedelta
+from typing import Literal
 
 import chromadb
 import chromadb.errors
@@ -59,6 +60,9 @@ class T3Database:
         self._ef_override = _ef_override
         self._ef_cache: dict[str, object] = {}
         self._ef_lock = threading.Lock()
+        self._voyage_client: voyageai.Client | None = (
+            voyageai.Client(api_key=voyage_api_key) if voyage_api_key else None
+        )
         if _client is not None:
             # Test injection: single client serves all store types.
             self._clients: dict[str, object] = {t: _client for t in _STORE_TYPES}
@@ -137,7 +141,9 @@ class T3Database:
                 )
             return self._ef_cache[collection_name]
 
-    def _cce_embed(self, text: str, input_type: str = "query") -> list[float]:
+    def _cce_embed(
+        self, text: str, input_type: Literal["query", "document"] = "document"
+    ) -> list[float]:
         """Embed *text* via the Voyage AI Contextualized Chunk Embedding API.
 
         CCE collections (docs__, knowledge__, rdr__) use voyage-context-3 at
@@ -145,15 +151,18 @@ class T3Database:
         vector spaces (cross-model cosine similarity ≈ 0.05, i.e. random noise).
 
         ``inputs=[[text]]`` — one inner list — embeds the text independently,
-        with no cross-chunk context propagation.  Use ``input_type="query"``
-        for search queries and ``input_type=None`` (default) for documents.
+        with no cross-chunk context propagation.  Use ``input_type="document"``
+        (default) for documents being stored and ``input_type="query"`` for
+        search queries.  Using the wrong subtype is the same class of bug as
+        the original CCE/voyage-4 mismatch.
         """
-        vo = voyageai.Client(api_key=self._voyage_api_key)
-        result = vo.contextualized_embed(
+        assert self._voyage_client is not None, "_cce_embed called without voyage_api_key"
+        result = self._voyage_client.contextualized_embed(
             inputs=[[text]],
             model="voyage-context-3",
             input_type=input_type,
         )
+        assert result.results, "voyageai CCE returned empty results"
         return result.results[0].embeddings[0]
 
     # ── Collection access ─────────────────────────────────────────────────────

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -225,7 +225,7 @@ def test_info_shows_embedding_model_for_code_collection(
 def test_info_shows_embedding_model_for_knowledge_collection(
     runner: CliRunner, env_creds
 ) -> None:
-    """info shows voyage-4 for knowledge__ collections."""
+    """info shows voyage-context-3 for knowledge__ collections (CCE)."""
     mock_db = MagicMock()
     mock_db.list_collections.return_value = [
         {"name": "knowledge__research", "count": 88},

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -239,7 +239,7 @@ def test_info_shows_embedding_model_for_knowledge_collection(
         result = runner.invoke(main, ["collection", "info", "knowledge__research"])
 
     assert result.exit_code == 0, result.output
-    assert "voyage-4" in result.output
+    assert "voyage-context-3" in result.output
 
 
 def test_info_shows_last_indexed_when_metadata_exists(

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -17,11 +17,15 @@ def test_embedding_model_code_collection() -> None:
 
 
 def test_embedding_model_docs_collection() -> None:
-    assert embedding_model_for_collection("docs__papers") == "voyage-4"
+    assert embedding_model_for_collection("docs__papers") == "voyage-context-3"
 
 
 def test_embedding_model_knowledge_collection() -> None:
-    assert embedding_model_for_collection("knowledge__security") == "voyage-4"
+    assert embedding_model_for_collection("knowledge__security") == "voyage-context-3"
+
+
+def test_embedding_model_rdr_collection() -> None:
+    assert embedding_model_for_collection("rdr__myrepo-abcdef12") == "voyage-context-3"
 
 
 def test_embedding_model_unknown_prefix_defaults_voyage4() -> None:
@@ -136,11 +140,18 @@ def test_index_model_bare_name_defaults_voyage4() -> None:
 
 
 def test_embedding_model_for_collection_regression() -> None:
-    """voyage-4 is the universal query model for all collection types."""
+    """CCE collections use voyage-context-3 at query time; others use voyage-4.
+
+    voyage-4 and voyage-context-3 are incompatible vector spaces.
+    CCE collections (docs__, knowledge__, rdr__) were indexed with
+    voyage-context-3 and must be queried with the same model.
+    """
+    # CCE collections → voyage-context-3
+    assert embedding_model_for_collection("docs__papers") == "voyage-context-3"
+    assert embedding_model_for_collection("knowledge__security") == "voyage-context-3"
+    assert embedding_model_for_collection("rdr__myrepo-abcdef12") == "voyage-context-3"
+    # Standard collections → voyage-4
     assert embedding_model_for_collection("code__myrepo") == "voyage-4"
-    assert embedding_model_for_collection("knowledge__security") == "voyage-4"
-    assert embedding_model_for_collection("docs__papers") == "voyage-4"
-    assert embedding_model_for_collection("rdr__myrepo-abcdef12") == "voyage-4"
     assert embedding_model_for_collection("other__collection") == "voyage-4"
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -397,20 +397,21 @@ def test_voyage4_query_retrieves_voyage_code3_indexed_content() -> None:
             pass
 
 
-# ── Cross-model: voyage-context-3 (CCE) index + voyage-4 query ───────────────
+# ── CCE symmetric retrieval: voyage-context-3 index + voyage-context-3 query ──
 
 @pytest.mark.integration
 @requires_t3
-def test_voyage4_query_retrieves_cce_indexed_markdown() -> None:
-    """voyage-4 queries retrieve results from CCE-indexed docs__ content.
+def test_cce_query_retrieves_cce_indexed_markdown() -> None:
+    """CCE search correctly retrieves voyage-context-3-indexed docs__ content.
 
-    Validates the second cross-model assumption: voyage-context-3 (CCE) index
-    vectors are in the same space as voyage-4 query vectors.
+    Validates the fix for the CCE query model mismatch (post-mortem: cce-query-model-mismatch).
+    Before the fix, db.search() used voyage-4 (incompatible space, cosine sim ≈ 0.05).
+    After the fix, search uses voyage-context-3 via contextualized_embed() for CCE collections.
 
     Method:
     - Index a multi-chunk markdown file via index_markdown (triggers CCE path)
-    - Query via db.search (collection EF = voyage-4)
-    - Assert the indexed chunk is returned and embedding_model is recorded
+    - Query via db.search (CCE path: voyage-context-3 via contextualized_embed)
+    - Assert the indexed chunk is returned and embedding_model is 'voyage-context-3'
     """
     import tempfile
     from pathlib import Path
@@ -449,15 +450,15 @@ def test_voyage4_query_retrieves_cce_indexed_markdown() -> None:
                 n_results=5,
             )
             assert results, (
-                "voyage-4 query returned no results from CCE-indexed docs__ collection"
+                "CCE search returned no results from CCE-indexed docs__ collection"
             )
             assert any(uid in r.get("content", "") for r in results), (
-                "voyage-4 query did not retrieve the CCE-indexed markdown chunk"
+                "CCE search did not retrieve the CCE-indexed markdown chunk"
             )
-            # embedding_model must be voyage-context-3 (CCE succeeded) or voyage-4 (fallback)
+            # embedding_model must be voyage-context-3 (CCE indexer records it)
             stored_model = results[0].get("embedding_model", "")
-            assert stored_model in ("voyage-context-3", "voyage-4"), (
-                f"embedding_model should be voyage-context-3 or voyage-4 (fallback), "
+            assert stored_model == "voyage-context-3", (
+                f"docs__ chunks must be indexed with voyage-context-3, "
                 f"got: {stored_model!r}"
             )
         finally:
@@ -470,10 +471,12 @@ def test_voyage4_query_retrieves_cce_indexed_markdown() -> None:
 @pytest.mark.integration
 @requires_t3
 def test_t3_put_embedding_model_in_search_metadata() -> None:
-    """T3Database.put() stores embedding_model='voyage-4'; field survives to search results.
+    """T3Database.put() stores embedding_model='voyage-context-3'; field survives to search results.
 
-    Validates that the metadata provenance field added to put() is persisted
-    through ChromaDB and returned by db.search().
+    knowledge__ collections use CCE (voyage-context-3) at both index and query
+    time. Validates that the metadata provenance field is persisted through
+    ChromaDB and returned by db.search(), and that the stored document is
+    retrievable (index and query vectors are in the same CCE space).
     """
     from nexus.db import make_t3
 
@@ -497,8 +500,8 @@ def test_t3_put_embedding_model_in_search_metadata() -> None:
         assert results, "Expected search to find the just-stored document"
         matching = [r for r in results if uid in r.get("content", "")]
         assert matching, "Stored document not found by unique token in search results"
-        assert matching[0].get("embedding_model") == "voyage-4", (
-            f"knowledge__ put() must store embedding_model='voyage-4', "
+        assert matching[0].get("embedding_model") == "voyage-context-3", (
+            f"knowledge__ put() must store embedding_model='voyage-context-3' (CCE), "
             f"got: {matching[0].get('embedding_model')!r}"
         )
     finally:

--- a/tests/test_store_cmd.py
+++ b/tests/test_store_cmd.py
@@ -38,7 +38,9 @@ def test_store_put_missing_chroma_api_key(
     result = runner.invoke(main, ["store", "put", str(src)])
 
     assert result.exit_code != 0
-    assert "chroma_api_key" in result.output.lower()
+    # Four-store init fails with a connection error when the API key is absent.
+    # The error message names the specific database that failed.
+    assert "failed to connect" in result.output.lower() or "chroma_api_key" in result.output.lower()
 
 
 def test_store_put_missing_voyage_api_key(

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -335,6 +335,42 @@ def test_search_cce_skipped_without_voyage_api_key(mock_chromadb: tuple) -> None
     assert "query_embeddings" not in call_kwargs
 
 
+def test_put_cce_collection_uses_document_input_type(mock_chromadb: tuple) -> None:
+    """put() embeds CCE collections with input_type='document', not 'query'.
+
+    Regression guard for C1 from code review: _cce_embed() default was 'query',
+    causing put() to embed documents in query-vector space — the same class of
+    semantic mismatch as the original CCE/voyage-4 bug.
+    """
+    _, mock_client = mock_chromadb
+    mock_col = MagicMock()
+    mock_client.get_or_create_collection.return_value = mock_col
+
+    with patch("nexus.db.t3.voyageai") as mock_vo_mod:
+        mock_vo_inst = MagicMock()
+        mock_vo_mod.Client.return_value = mock_vo_inst
+        mock_vo_inst.contextualized_embed.return_value = MagicMock()
+
+        db = T3Database(
+            tenant="t", database="d", api_key="k", voyage_api_key="vkey"
+        )
+        db.put(
+            collection="knowledge__security",
+            content="some document text about security findings",
+            title="finding.md",
+        )
+
+    # Documents must be embedded with input_type="document", not "query"
+    mock_vo_inst.contextualized_embed.assert_called_once_with(
+        inputs=[["some document text about security findings"]],
+        model="voyage-context-3",
+        input_type="document",
+    )
+    # put() must pass pre-computed embeddings to bypass the voyage-4 EF
+    call_kwargs = mock_col.upsert.call_args.kwargs
+    assert "embeddings" in call_kwargs, "CCE put() must pass pre-computed embeddings"
+
+
 # ── AC7: collection list ──────────────────────────────────────────────────────
 
 def test_list_collections_returns_names_and_counts(mock_chromadb: tuple) -> None:

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -100,7 +100,8 @@ def test_store_put_permanent_metadata(mock_chromadb: tuple) -> None:
     assert meta["ttl_days"] == 0       # permanent
     assert meta["expires_at"] == ""    # permanent sentinel
     assert meta["store_type"] == "knowledge"
-    assert meta["embedding_model"] == "voyage-4"  # knowledge__ always uses voyage-4
+    # No voyage_api_key → CCE path skipped → voyage-4 EF used → embedding_model="voyage-4"
+    assert meta["embedding_model"] == "voyage-4"
 
 
 def test_store_put_with_ttl_metadata(mock_chromadb: tuple) -> None:
@@ -261,6 +262,77 @@ def test_search_skips_missing_collection_without_creating(mock_chromadb: tuple) 
 
     assert results == []
     mock_client.get_or_create_collection.assert_not_called()
+
+
+def test_search_cce_collection_uses_query_embeddings(mock_chromadb: tuple) -> None:
+    """search() uses query_embeddings (not query_texts) for CCE collections.
+
+    CCE collections (docs__, knowledge__, rdr__) are indexed with voyage-context-3
+    via the /v1/contextualizedembeddings endpoint.  voyage-4 and voyage-context-3
+    are incompatible vector spaces; querying with voyage-4 produces cosine similarity
+    ≈ 0.05 (random noise).  The fix bypasses the ChromaDB EF entirely and calls
+    voyageai.Client.contextualized_embed() for query embedding.
+    """
+    _, mock_client = mock_chromadb
+    mock_col = MagicMock()
+    mock_col.count.return_value = 3
+    mock_col.query.return_value = {
+        "ids": [["id-cce"]],
+        "documents": [["cce content"]],
+        "metadatas": [[{"title": "rdr-004"}]],
+        "distances": [[0.12]],
+    }
+    mock_client.get_collection.return_value = mock_col
+
+    with patch("nexus.db.t3.voyageai") as mock_vo_mod:
+        mock_vo_inst = MagicMock()
+        mock_vo_mod.Client.return_value = mock_vo_inst
+        # contextualized_embed returns a result whose .results[0].embeddings[0]
+        # is the query vector — MagicMock auto-returns a Mock for chained access.
+        mock_vo_inst.contextualized_embed.return_value = MagicMock()
+
+        db = T3Database(
+            tenant="t", database="d", api_key="k", voyage_api_key="vkey"
+        )
+        results = db.search("four store t3 architecture", ["rdr__nexus-abc123"], n_results=5)
+
+    # voyageai.Client instantiated with the voyage_api_key
+    mock_vo_mod.Client.assert_called_once_with(api_key="vkey")
+    # contextualized_embed called with the query wrapped in a list-of-list
+    mock_vo_inst.contextualized_embed.assert_called_once_with(
+        inputs=[["four store t3 architecture"]],
+        model="voyage-context-3",
+        input_type="query",
+    )
+    # ChromaDB queried with query_embeddings (not query_texts)
+    call_kwargs = mock_col.query.call_args.kwargs
+    assert "query_embeddings" in call_kwargs, "CCE search must use query_embeddings, not query_texts"
+    assert "query_texts" not in call_kwargs
+
+    assert len(results) == 1
+    assert results[0]["id"] == "id-cce"
+
+
+def test_search_cce_skipped_without_voyage_api_key(mock_chromadb: tuple) -> None:
+    """search() falls back to query_texts when voyage_api_key is not set (test/offline mode)."""
+    _, mock_client = mock_chromadb
+    mock_col = MagicMock()
+    mock_col.count.return_value = 2
+    mock_col.query.return_value = {
+        "ids": [["id-1"]],
+        "documents": [["doc"]],
+        "metadatas": [[{}]],
+        "distances": [[0.2]],
+    }
+    mock_client.get_collection.return_value = mock_col
+
+    # No voyage_api_key → CCE path must not be taken
+    db = T3Database(tenant="t", database="d", api_key="k")
+    db.search("query", ["docs__manual"], n_results=5)
+
+    call_kwargs = mock_col.query.call_args.kwargs
+    assert "query_texts" in call_kwargs
+    assert "query_embeddings" not in call_kwargs
 
 
 # ── AC7: collection list ──────────────────────────────────────────────────────
@@ -565,8 +637,8 @@ def test_collection_metadata_returns_correct_fields(mock_chromadb: tuple) -> Non
 
     assert meta["name"] == "docs__corpus"
     assert meta["count"] == 17
-    assert meta["embedding_model"] == "voyage-4"
-    assert meta["index_model"] == "voyage-context-3"
+    assert meta["embedding_model"] == "voyage-context-3"  # CCE query model (docs__ is CCE)
+    assert meta["index_model"] == "voyage-context-3"  # docs__ indexed with CCE
 
 
 def test_collection_metadata_code_collection(mock_chromadb: tuple) -> None:


### PR DESCRIPTION
## Summary

- **Root cause**: Commit `053f54d` hardcoded voyage-4 as the universal query model for all collections. `voyage-context-3` (CCE) and `voyage-4` are incompatible vector spaces — cross-model cosine similarity ≈ 0.05 (random noise). All `docs__`, `knowledge__`, and `rdr__` collections have been effectively unsearchable since rc1.
- **`corpus.py`**: `embedding_model_for_collection()` now returns `voyage-context-3` for CCE collections; `index_model_for_collection()` made consistent.
- **`db/t3.py`**: `search()` detects CCE collections and calls `voyageai.Client.contextualized_embed()` directly (bypasses ChromaDB's VoyageAIEmbeddingFunction which rejects voyage-context-3). `put()` also pre-computes CCE embeddings so single-entry knowledge notes are in the same vector space as indexed chunks.
- **Tests**: Updated model assertions, added CCE query path tests, fixed pre-existing `test_store_put_missing_chroma_api_key` assertion.
- **Post-mortem**: `docs/rdr/post-mortem/cce-query-model-mismatch.md` documents the full timeline, root cause, and impact.

## Impact table (before fix)

| Collection type | Searchable? |
|----------------|-------------|
| `code__*` | Partially (cross-model compat tolerable) |
| `docs__*` | **No** — cosine sim ≈ 0.05 |
| `knowledge__*` | **No** — cosine sim ≈ 0.05 |
| `rdr__*` | **No** — cosine sim ≈ 0.05 |

After fix: all collection types return semantically correct results.

## Re-indexing required

Existing CCE-indexed embeddings are correct — only the query path was broken. No re-embedding needed. However, any `knowledge__` documents stored via `nx store put` before this fix used voyage-4 EF and will not be findable by CCE search. Re-running `nx store put` for those entries will re-embed them in CCE space.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/test_integration.py` — 1665 passed, 7 skipped
- [ ] Integration tests pass with live T3 credentials (CCE put→search roundtrip)
- [ ] `nx search "four store t3 architecture" --corpus rdr` returns RDR-004 as top result after re-indexing