### PR TITLE
release: 1.0.0rc7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted semantic search, memory, and knowledge management for Claude Code agents.",
-      "version": "1.0.0rc6"
+      "version": "1.0.0rc7"
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "1.0.0rc6"
+version = "1.0.0rc7"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` and `.claude-plugin/marketplace.json` to `1.0.0rc7`

## Changes since rc6 (RDR-007: Claude Adoption — Session Context & Search Guidance)

- **T2 prefix scan**: `subagent-start.sh` now runs `t2_prefix_scan.py` to surface all `{repo}*` namespaces with content snippets (5 with snippet, 3 title-only, remainder as count, 15-entry hard cap)
- **`nx index repo --chunk-size N`**: configurable lines-per-chunk for code files (default 150, min 1)
- **`nx index repo --no-chunk-warning`**: suppress large-file pre-scan warning
- **Large-file warning**: pre-scan detects code files exceeding 30× chunk size before indexing
- **`reference.md`**: T2 FTS5 search constraints, code search (nx vs Grep) guidance, RDR-006 precision tip
- **`AST_EXTENSIONS`**: renamed from `_AST_EXTENSIONS` to public constant
- **Docs**: `cli-reference.md`, `repo-indexing.md`, `nx/CHANGELOG.md`, `nx/README.md` all updated

## Test plan

- [ ] CI passes (1784 tests)
- [ ] `pyproject.toml` version = `1.0.0rc7`
- [ ] `.claude-plugin/marketplace.json` version = `1.0.0rc7`