### PR TITLE
fix: isolate T1 SESSIONS_DIR in test suite

### DIFF
--- a/docs/rdr/post-mortem/010-t1-http-server.md
+++ b/docs/rdr/post-mortem/010-t1-http-server.md
@@ -112,6 +112,34 @@ across separate Bash calls within the same Claude session.
 through a shell intermediary. An integration test that spans two separate
 subprocess invocations would have caught this before release.
 
+### Bug 3 — Test isolation held by accident; broken by Bug 1's fix (PR #41)
+
+Fixing Bug 1 (removing `--log-level`) caused 5 previously-passing tests to fail.
+
+**Root cause:** The test suite had an implicit dependency on `start_t1_server()` always
+failing. When `chroma run --log-level ERROR` was present, chroma exited immediately with
+code 2, `session_start()` caught the exception, and no session file was ever written to
+`SESSIONS_DIR`. All `T1Database()` calls fell back to `EphemeralClient`. Test isolation
+held — **by accident**.
+
+Once Bug 1 was fixed, `test_session_start_prints_ready_message` (which calls
+`session_start()` without patching `start_t1_server`) started actually launching a
+ChromaDB server and writing a real session file at `SESSIONS_DIR/{grandparent_pid}.session`.
+Every subsequent `T1Database()` call in the same pytest process walked the PPID chain,
+found that file, and used its UUID `session_id` — ignoring whatever `session_id` the test
+had passed explicitly. Five tests failed with cross-test session contamination.
+
+**Fix:** `autouse` fixture in `conftest.py` redirects both `nexus.db.t1.SESSIONS_DIR` and
+`nexus.hooks.SESSIONS_DIR` to a per-test empty `tmp_path`. `find_ancestor_session()` always
+returns `None`; `T1Database` falls back to the process-wide EphemeralClient singleton,
+isolated per test by unique `session_id`.
+
+**Lesson:** When a test implicitly relies on a downstream side-effect (server failing to
+start), fixing that side-effect breaks the test in a non-obvious way. The test for
+`session_start()` should have patched `start_t1_server` from the start. A broader lesson:
+any test that exercises a function which may write shared state (SESSIONS_DIR) needs
+explicit isolation, not reliance on a known failure in a dependency.
+
 ## PPID Topology: Empirically Confirmed (2026-03-01)
 
 Spawned a subagent via the Agent tool and traced its full PPID chain:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,29 @@ def pytest_configure(config):
     )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect T1 SESSIONS_DIR so tests never discover real live server records.
+
+    Before fixing chroma's --log-level flag, start_t1_server() always failed
+    in tests (chroma exited immediately), so no session file was ever written
+    and test isolation held by accident.  Now that the server starts cleanly,
+    test_session_start_prints_ready_message (and similar) actually write a
+    session file to the real SESSIONS_DIR.  Subsequent T1Database() calls in
+    the same pytest process find it via PPID chain walk, hijack the session_id,
+    and break isolation across unrelated tests.
+
+    Solution: redirect both consumers of SESSIONS_DIR to an empty per-test
+    tmp_path so find_ancestor_session() always returns None.  T1Database falls
+    back to the process-wide EphemeralClient singleton (isolated by session_id),
+    and any session files written by session_start() go to tmp_path, not ~/.
+    """
+    sessions = tmp_path / ".nexus" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("nexus.db.t1.SESSIONS_DIR", sessions)
+    monkeypatch.setattr("nexus.hooks.SESSIONS_DIR", sessions)
+
+
 @pytest.fixture
 def db(tmp_path: Path) -> T2Database:
     """Provide a T2Database backed by a temporary SQLite file."""


### PR DESCRIPTION
## Summary

Fixes 5 test failures introduced when the chroma `--log-level` bug was fixed in PR #40.

## Root Cause

Tests relied on `start_t1_server()` silently failing (chroma 1.x removed the `--log-level` flag → exit code 2). That failure meant no session file was ever written to `SESSIONS_DIR` during tests, so `find_ancestor_session()` always returned `None` and `T1Database()` always used the EphemeralClient. Test isolation held **by accident**.

Once PR #40 fixed the `--log-level` bug, `test_session_start_prints_ready_message` started actually launching a ChromaDB server and writing a session file to the real `~/.config/nexus/sessions/{ppid}.session`. Every subsequent `T1Database()` call in the same pytest run walked the PPID chain, found that file, used its `session_id` (a UUID), and ignored the test-supplied `session_id`. Cross-test session contamination.

## Fix

`autouse` fixture in `conftest.py` redirects both `nexus.db.t1.SESSIONS_DIR` and `nexus.hooks.SESSIONS_DIR` to an empty per-test `tmp_path`. `find_ancestor_session()` always returns `None`; `T1Database` falls back to the process-wide EphemeralClient singleton, isolated per test by unique `session_id`.

## Test Plan
- [ ] `tests/test_scratch.py` — all 5 previously failing tests pass
- [ ] `tests/test_scratch_cmd.py::test_scratch_search_no_results` — passes
- [ ] Full suite (1806 tests) passes locally