### PR TITLE
feat: storage tier awareness for agents — T1 injection, tier protocol

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted semantic search, memory, and knowledge management for Claude Code agents.",
-      "version": "1.0.0rc8"
+      "version": "1.0.0rc9"
     }
   ]
 }

--- a/nx/hooks/scripts/subagent-start.sh
+++ b/nx/hooks/scripts/subagent-start.sh
@@ -49,5 +49,15 @@ if [[ -f "$RELAY_TEMPLATE" ]]; then
   awk '/^## Optional Fields/{exit} {print}' "$RELAY_TEMPLATE"
 fi
 
-# T1 scratch: session-scoped, each subagent has its own T1 scope
-# Use nx memory for cross-agent relay within the same project session
+# T1 scratch: SHARED across all agents in this session via PPID chain (RDR-010).
+# All agents spawned from the same root Claude Code process see the same entries.
+# Inject current entries so this agent knows what siblings/parent already found.
+if command -v nx &> /dev/null; then
+  T1_ENTRIES=$(nx scratch list 2>/dev/null)
+  if [[ -n "$T1_ENTRIES" && "$T1_ENTRIES" != "No scratch entries." ]]; then
+    echo ""
+    echo "## Session Scratch (T1 — shared across all agents this session)"
+    echo "$T1_ENTRIES"
+    echo ""
+  fi
+fi

--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -101,6 +101,18 @@ Use this table to match tasks to skills. When in doubt, check the skill.
 | cli-controller | `/cli-controller` | Controlling interactive CLI apps, REPLs, pdb, gdb, or spawning Claude Code instances |
 | writing-nx-skills | `/writing-nx-skills` | Creating new nx plugin skills or editing existing ones |
 
+## Storage Tier Protocol
+
+**Read widest → narrowest before starting any research or implementation.**
+
+| Tier | Command | What's there | Read when... |
+|------|---------|--------------|--------------|
+| T3 | `nx search <query>` | Permanent knowledge across all sessions and projects | Before any research — if it's been learned, it's here |
+| T2 | `nx memory search <query>` | Project decisions, findings, PM context | Before project work — past context and past decisions live here |
+| T1 | `nx scratch search <query>` | This session's discoveries, shared across all agents | Before doing work a sibling or parent agent may have already done |
+
+**Write path:** T1 (immediate, shared) → `--persist` flag to T2 (survives session end) → `/knowledge-tidy` to T3 (permanent, cross-project).
+
 ## Red Flags
 
 These thoughts mean STOP — you are rationalizing:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "1.0.0rc8"
+version = "1.0.0rc9"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- **`subagent-start.sh`**: Fixes stale comment that said \"each subagent has its own T1 scope\" (wrong since RDR-010 shipped shared T1 via PPID chain). Adds live T1 entry injection at SubagentStart — if the session has entries, the new agent sees them immediately and knows what siblings/parent already discovered.

- **`using-nx-skills/SKILL.md`**: Adds a **Storage Tier Protocol** section with a read-first table (T3 → T2 → T1) and write path (T1 → `--persist` → `/knowledge-tidy`). Agents now have a mental model for when to search each tier before doing work, not just when to write.

- **Version:** 1.0.0rc8 → 1.0.0rc9

## Rationale

The T1 server has been shared across agents since RDR-010, but nothing told agents this or injected the shared state. Two agents working on the same session could do redundant research because neither checked what the other found. The tier protocol teaches the read-before-work pattern for all three tiers.

## Test plan
- [ ] Spawn a subagent after putting a T1 entry — verify the entry appears in the subagent's context
- [ ] Confirm tier protocol table appears in `using-nx-skills` session context
- [ ] CI green