### PR TITLE
fix: sanitize FTS5 queries to prevent crash on hyphenated terms

### DIFF
--- a/src/nexus/db/t2.py
+++ b/src/nexus/db/t2.py
@@ -11,6 +11,36 @@ import structlog
 
 _log = structlog.get_logger()
 
+# ── FTS5 helpers ──────────────────────────────────────────────────────────────
+
+# FTS5 special characters that cause OperationalError when unquoted:
+#   -  (column filter: "col-name" → look in column "col" for "name")
+#   :  (explicit column filter: "col:term")
+#   (  )  ^  "  (grouping / phrase / boost — crash if unbalanced)
+# Note: trailing * is a valid FTS5 prefix wildcard (e.g. auth*) — NOT included here.
+_FTS5_SPECIAL = set('-:()"^~')
+
+
+def _sanitize_fts5(query: str) -> str:
+    """Escape a user-supplied query for FTS5 MATCH.
+
+    Splits on whitespace and wraps any token that contains FTS5 special
+    characters in double quotes, with internal double-quotes escaped as '""'.
+    Plain tokens (letters and digits only) are passed through unchanged so
+    that FTS5 AND-of-terms semantics and boolean operators (AND, OR, NOT)
+    still work for well-formed queries.
+    """
+    tokens = query.split()
+    parts: list[str] = []
+    for token in tokens:
+        if any(ch in _FTS5_SPECIAL for ch in token):
+            escaped = token.replace('"', '""')
+            parts.append(f'"{escaped}"')
+        else:
+            parts.append(token)
+    return " ".join(parts)
+
+
 # ── Schema SQL ────────────────────────────────────────────────────────────────
 
 _SCHEMA_SQL = """\
@@ -164,6 +194,7 @@ class T2Database:
 
     def search(self, query: str, project: str | None = None) -> list[dict[str, Any]]:
         """FTS5 keyword search. Returns rows ordered by relevance."""
+        safe = _sanitize_fts5(query)
         with self._lock:
             try:
                 if project:
@@ -176,7 +207,7 @@ class T2Database:
                           AND m.project = ?
                         ORDER BY rank
                     """
-                    rows = self.conn.execute(sql, (query, project)).fetchall()
+                    rows = self.conn.execute(sql, (safe, project)).fetchall()
                 else:
                     sql = """
                         SELECT m.id, m.project, m.title, m.session, m.agent,
@@ -186,7 +217,7 @@ class T2Database:
                         WHERE memory_fts MATCH ?
                         ORDER BY rank
                     """
-                    rows = self.conn.execute(sql, (query,)).fetchall()
+                    rows = self.conn.execute(sql, (safe,)).fetchall()
             except sqlite3.OperationalError as exc:
                 raise ValueError(f"Invalid search query {query!r}: {exc}") from exc
         return [dict(zip(_COLUMNS, row)) for row in rows]
@@ -249,9 +280,10 @@ class T2Database:
               AND m.project GLOB ?
             ORDER BY rank
         """
+        safe = _sanitize_fts5(query)
         with self._lock:
             try:
-                rows = self.conn.execute(sql, (query, project_glob)).fetchall()
+                rows = self.conn.execute(sql, (safe, project_glob)).fetchall()
             except sqlite3.OperationalError as exc:
                 raise ValueError(f"Invalid search query {query!r}: {exc}") from exc
         return [dict(zip(_COLUMNS, row)) for row in rows]
@@ -272,9 +304,10 @@ class T2Database:
             ORDER BY rank
         """
         like_pattern = f"%,{tag},%"
+        safe = _sanitize_fts5(query)
         with self._lock:
             try:
-                rows = self.conn.execute(sql, (query, like_pattern)).fetchall()
+                rows = self.conn.execute(sql, (safe, like_pattern)).fetchall()
             except sqlite3.OperationalError as exc:
                 raise ValueError(f"Invalid search query {query!r}: {exc}") from exc
         return [dict(zip(_COLUMNS, row)) for row in rows]

--- a/tests/test_t2.py
+++ b/tests/test_t2.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from nexus.db.t2 import T2Database
+from nexus.db.t2 import T2Database, _sanitize_fts5
 
 
 def test_t2database_context_manager_closes_on_exit(tmp_path: Path) -> None:
@@ -460,3 +460,60 @@ def test_t2_get_all_returns_full_content(db: T2Database) -> None:
     titles = {e["title"] for e in entries}
     assert titles == {"a.md", "b.md"}
     assert all("content" in e["content"] for e in entries)
+
+
+# ── _sanitize_fts5 ──────────────────────────────────────────────────────────
+
+def test_sanitize_fts5_plain_query_unchanged() -> None:
+    """Plain alphanumeric tokens pass through unquoted."""
+    assert _sanitize_fts5("hello world") == "hello world"
+
+
+def test_sanitize_fts5_hyphen_token_quoted() -> None:
+    """Tokens containing a hyphen are wrapped in double quotes."""
+    assert _sanitize_fts5("verification-probe") == '"verification-probe"'
+
+
+def test_sanitize_fts5_colon_token_quoted() -> None:
+    """Tokens containing a colon are wrapped in double quotes."""
+    assert _sanitize_fts5("phase:1") == '"phase:1"'
+
+
+def test_sanitize_fts5_mixed_tokens() -> None:
+    """Plain and special tokens are handled independently."""
+    assert _sanitize_fts5("foo bar-baz") == 'foo "bar-baz"'
+
+
+def test_sanitize_fts5_embedded_double_quote_escaped() -> None:
+    """Embedded double quotes within a token are escaped as ''."""
+    result = _sanitize_fts5('say"hello')
+    assert result == '"say""hello"'
+
+
+def test_sanitize_fts5_hyphenated_query_no_crash(db: T2Database) -> None:
+    """search() with a hyphenated query does not raise OperationalError."""
+    db.put(project="proj", title="notes.md", content="verification probe test")
+    results = db.search("verification-probe")
+    # May or may not match depending on FTS tokenisation, but must not crash.
+    assert isinstance(results, list)
+
+
+def test_sanitize_fts5_hyphenated_query_with_project_no_crash(db: T2Database) -> None:
+    """search() with project filter and hyphenated query does not raise."""
+    db.put(project="proj", title="notes.md", content="smoke test entry")
+    results = db.search("smoke-test", project="proj")
+    assert isinstance(results, list)
+
+
+def test_sanitize_fts5_search_glob_hyphen_no_crash(db: T2Database) -> None:
+    """search_glob() with a hyphenated query does not raise OperationalError."""
+    db.put(project="nexus_pm", title="notes.md", content="verification probe")
+    results = db.search_glob("verification-probe", "*_pm")
+    assert isinstance(results, list)
+
+
+def test_sanitize_fts5_search_by_tag_hyphen_no_crash(db: T2Database) -> None:
+    """search_by_tag() with a hyphenated query does not raise OperationalError."""
+    db.put(project="proj", title="notes.md", content="verification probe", tags="pm")
+    results = db.search_by_tag("verification-probe", "pm")
+    assert isinstance(results, list)


### PR DESCRIPTION
## Summary

- `nx memory search` crashed with `sqlite3.OperationalError: no such column: X` when the query contained a hyphen (e.g. `verification-probe`)
- FTS5 was interpreting hyphens as column filter separators in its query syntax
- Added `_sanitize_fts5()` helper that wraps special-character tokens in double quotes before passing to `MATCH`
- Applied to all three search methods: `search()`, `search_glob()`, `search_by_tag()`
- Trailing `*` (prefix wildcard, e.g. `auth*`) intentionally excluded from sanitization

## Test plan

- [ ] `test_sanitize_fts5_*` unit tests cover the sanitizer directly (plain pass-through, hyphen, colon, mixed, embedded quote)
- [ ] Integration tests verify all three search methods accept hyphenated queries without raising
- [ ] Existing `test_t2_search_prefix_wildcard` confirms `auth*` still works after the fix
- [ ] 52 T2 tests passing

Closes: nexus-aelb