### PR TITLE
feat(cli): add --dry-run flag to nx index pdf

### DIFF
--- a/docs/plans/2026-03-01-dry-run-pdf-design.md
+++ b/docs/plans/2026-03-01-dry-run-pdf-design.md
@@ -1,0 +1,66 @@
+# Design: `--dry-run` flag for `nx index pdf`
+
+**Date:** 2026-03-01
+**Status:** Approved
+
+## Problem
+
+`nx index pdf` always writes to ChromaDB Cloud (T3) and requires Voyage AI + Chroma credentials.
+There is no way to smoke-test PDF extraction locally without API keys.
+
+## Approved Approach: Option B — `embed_fn` parameter on `_index_document`
+
+Add an `embed_fn` keyword argument to the shared `_index_document` pipeline.
+When provided, it replaces `_embed_with_fallback` and bypasses the credential guard.
+The CLI `--dry-run` flag builds a local T3 (EphemeralClient + DefaultEmbeddingFunction)
+and a matching `embed_fn`, then queries the ephemeral collection to display a chunk preview.
+
+No patching. No new functions. Three files changed.
+
+## Changes
+
+### `src/nexus/doc_indexer.py`
+
+1. `_index_document(... embed_fn=None)` — new keyword-only parameter
+   - Skip `_has_credentials()` when `embed_fn is not None`
+   - Branch: if `embed_fn` → call it; else → credential check + `_embed_with_fallback`
+
+2. `index_pdf(... embed_fn=None)` — thread `embed_fn` through to `_index_document`
+
+### `src/nexus/commands/index.py`
+
+3. `index_pdf_cmd` — add `--dry-run` flag
+   - Build `ef = DefaultEmbeddingFunction()`
+   - Build `local_t3 = make_t3(_client=EphemeralClient(), _ef_override=ef)`
+   - Build `embed_fn = lambda texts, model: ([v.tolist() for v in ef(texts)], model)`
+   - Call `index_pdf(path, corpus=corpus, t3=local_t3, embed_fn=embed_fn)`
+   - After indexing, query local collection and print chunk preview
+
+## Output Format (approved)
+
+```
+Dry-run mode — local ONNX, no cloud writes.
+Indexing /path/to/paper.pdf…
+
+  Chunks : 7  Pages: 1–3  Title: "My Document"
+
+  [1] p.1  Hello World. This is a test document…
+  [2] p.2  Database transactions ensure ACID…
+  …
+
+(no cloud write)
+```
+
+## Embed Fn Signature
+
+```python
+EmbedFn = Callable[[list[str], str], tuple[list[list[float]], str]]
+# (texts, model) -> (embeddings, actual_model)
+```
+
+## What Is NOT Changed
+
+- `index_markdown` — no `--dry-run` flag (not requested)
+- `_index_pdf_file` (in indexer.py) — not involved
+- `make_t3`, `T3Database` — no changes
+- No new test files — E2E suite already validates the same code path

--- a/docs/plans/2026-03-01-dry-run-pdf-impl-plan.md
+++ b/docs/plans/2026-03-01-dry-run-pdf-impl-plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: `nx index pdf --dry-run`
+
+**Date:** 2026-03-01
+**Design:** docs/plans/2026-03-01-dry-run-pdf-design.md
+
+## Phase 1 — `_index_document` embed_fn parameter
+
+**Files:** `src/nexus/doc_indexer.py`
+
+1. Add `embed_fn: Callable[[list[str], str], tuple[list[list[float]], str]] | None = None`
+   as a keyword-only parameter to `_index_document`.
+2. Change the credential guard from:
+   ```python
+   if not _has_credentials():
+       return 0
+   ```
+   to:
+   ```python
+   if embed_fn is None and not _has_credentials():
+       return 0
+   ```
+3. Replace the Voyage embed block:
+   ```python
+   from nexus.config import get_credential
+   voyage_key = get_credential("voyage_api_key")
+   if not voyage_key:
+       raise RuntimeError(...)
+   embeddings, actual_model = _embed_with_fallback(documents, target_model, voyage_key)
+   ```
+   with:
+   ```python
+   if embed_fn is not None:
+       embeddings, actual_model = embed_fn(documents, target_model)
+   else:
+       from nexus.config import get_credential
+       voyage_key = get_credential("voyage_api_key")
+       if not voyage_key:
+           raise RuntimeError("voyage_api_key must be set — unreachable if _has_credentials() passed")
+       embeddings, actual_model = _embed_with_fallback(documents, target_model, voyage_key)
+   ```
+
+**Success criteria:** existing tests still pass (embed_fn=None path unchanged).
+
+## Phase 2 — Thread embed_fn through index_pdf
+
+**Files:** `src/nexus/doc_indexer.py`
+
+Add `embed_fn=None` to `index_pdf` signature and thread to `_index_document`.
+
+**Success criteria:** `index_pdf(..., embed_fn=local_fn)` calls `_index_document` with it.
+
+## Phase 3 — CLI `--dry-run` flag and chunk preview output
+
+**Files:** `src/nexus/commands/index.py`
+
+Add `--dry-run` flag to `index_pdf_cmd`:
+- Print dry-run banner
+- Build `ef = DefaultEmbeddingFunction()`
+- Build `local_t3 = make_t3(_client=chromadb.EphemeralClient(), _ef_override=ef)`
+- Build `embed_fn = lambda texts, model: ([v.tolist() for v in ef(texts)], model)`
+- Call `index_pdf(path, corpus=corpus, t3=local_t3, embed_fn=embed_fn)`
+- Query local collection for metadatas + documents
+- Print summary line: `Chunks: N  Pages: X–Y  Title: "..."`
+- Print per-chunk preview: `[N] p.{page}  {text[:80]}…`
+- Print `(no cloud write)` footer
+
+**Success criteria:** `nx index pdf some.pdf --dry-run` runs without credentials,
+prints chunk preview, exits 0.

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -135,11 +135,69 @@ def index_repo_cmd(
 @index.command("pdf")
 @click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option("--corpus", default="default", show_default=True, help="Corpus name for docs__ collection.")
-def index_pdf_cmd(path: Path, corpus: str) -> None:
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help=(
+        "Extract and embed locally using ONNX (no API keys, no cloud writes). "
+        "Prints a chunk preview so you can verify extraction before indexing for real."
+    ),
+)
+def index_pdf_cmd(path: Path, corpus: str, dry_run: bool) -> None:
     """Extract and index a PDF document into T3 docs__CORPUS."""
     from nexus.doc_indexer import index_pdf
 
     path = path.resolve()
+
+    if dry_run:
+        import chromadb
+        from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+        from nexus.db import make_t3
+
+        click.echo("Dry-run mode — local ONNX embeddings, no cloud writes.")
+        ef = DefaultEmbeddingFunction()
+        local_t3 = make_t3(_client=chromadb.EphemeralClient(), _ef_override=ef)
+
+        def _local_embed(texts: list[str], model: str) -> tuple[list[list[float]], str]:
+            return [v.tolist() for v in ef(texts)], model
+
+        click.echo(f"Indexing {path}…")
+        n = index_pdf(path, corpus=corpus, t3=local_t3, embed_fn=_local_embed)
+
+        if n == 0:
+            click.echo("No chunks produced (file may already be indexed or extraction failed).")
+            return
+
+        # Retrieve indexed chunks from the ephemeral collection for preview
+        col = local_t3.get_or_create_collection(f"docs__{corpus}")
+        result = col.get(include=["documents", "metadatas"])
+        docs: list[str] = result.get("documents") or []
+        metas: list[dict] = result.get("metadatas") or []
+
+        # Summary line
+        pages = sorted({int(m.get("page_number", 0)) for m in metas if m})
+        page_range = f"{pages[0]}–{pages[-1]}" if len(pages) > 1 else str(pages[0]) if pages else "?"
+        title = metas[0].get("source_title", "") if metas else ""
+        author = metas[0].get("source_author", "") if metas else ""
+        summary_parts = [f"Chunks: {n}", f"Pages: {page_range}"]
+        if title:
+            summary_parts.append(f'Title: "{title}"')
+        if author:
+            summary_parts.append(f'Author: "{author}"')
+        click.echo(f"\n  {'  '.join(summary_parts)}\n")
+
+        # Per-chunk preview
+        for i, (doc, meta) in enumerate(zip(docs, metas), start=1):
+            page = meta.get("page_number", "?") if meta else "?"
+            preview = doc[:80].replace("\n", " ") if doc else ""
+            ellipsis = "…" if doc and len(doc) > 80 else ""
+            click.echo(f"  [{i}] p.{page}  {preview}{ellipsis}")
+
+        click.echo("\n(no cloud write)")
+        return
+
     click.echo(f"Indexing {path}…")
     n = index_pdf(path, corpus=corpus)
     click.echo(f"Indexed {n} chunk(s).")

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -26,6 +26,10 @@ from nexus.pdf_extractor import PDFExtractor
 # a list of (chunk_id, document_text, metadata_dict) tuples, or an empty list.
 ChunkFn = Callable[[Path, str, str, str, str], list[tuple[str, str, dict]]]
 
+# Type alias for a local embedding function (replaces _embed_with_fallback).
+# Receives (texts, model) and returns (embeddings, actual_model).
+EmbedFn = Callable[[list[str], str], tuple[list[list[float]], str]]
+
 
 def _sha256(path: Path) -> str:
     h = hashlib.sha256()
@@ -150,6 +154,7 @@ def _index_document(
     t3: Any = None,
     *,
     collection_name: str | None = None,
+    embed_fn: EmbedFn | None = None,
 ) -> int:
     """Shared indexing pipeline: credential check, staleness, embed, upsert, prune.
 
@@ -160,8 +165,12 @@ def _index_document(
     When *collection_name* is provided it is used as the T3 collection name
     directly, bypassing the default ``docs__{corpus}`` derivation.  This is
     used for RDR collections (``rdr__<repo>-<hash8>``).
+
+    When *embed_fn* is provided it replaces ``_embed_with_fallback`` and the
+    Voyage AI credential check is skipped.  This supports local dry-run mode
+    (ONNX / DefaultEmbeddingFunction) without requiring any API keys.
     """
-    if not _has_credentials():
+    if embed_fn is None and not _has_credentials():
         return 0
 
     content_hash = _sha256(file_path)
@@ -193,11 +202,14 @@ def _index_document(
     documents = [p[1] for p in prepared]
     metadatas = [p[2] for p in prepared]
 
-    from nexus.config import get_credential
-    voyage_key = get_credential("voyage_api_key")
-    if not voyage_key:
-        raise RuntimeError("voyage_api_key must be set — unreachable if _has_credentials() passed")
-    embeddings, actual_model = _embed_with_fallback(documents, target_model, voyage_key)
+    if embed_fn is not None:
+        embeddings, actual_model = embed_fn(documents, target_model)
+    else:
+        from nexus.config import get_credential
+        voyage_key = get_credential("voyage_api_key")
+        if not voyage_key:
+            raise RuntimeError("voyage_api_key must be set — unreachable if _has_credentials() passed")
+        embeddings, actual_model = _embed_with_fallback(documents, target_model, voyage_key)
     if actual_model != target_model:
         for m in metadatas:
             m["embedding_model"] = actual_model
@@ -308,13 +320,17 @@ def _markdown_chunks(
     return prepared
 
 
-def index_pdf(pdf_path: Path, corpus: str, t3: Any = None) -> int:
+def index_pdf(pdf_path: Path, corpus: str, t3: Any = None, *, embed_fn: EmbedFn | None = None) -> int:
     """Index *pdf_path* into the T3 ``docs__{corpus}`` collection.
 
     Returns the number of chunks indexed, or 0 if skipped (no credentials or
     content unchanged since last index with the same embedding model).
+
+    Pass *embed_fn* to override the default Voyage AI embedding (e.g. a local
+    ONNX function for dry-run mode).  When *embed_fn* is provided the Voyage
+    credential check is bypassed.
     """
-    return _index_document(pdf_path, corpus, _pdf_chunks, t3=t3)
+    return _index_document(pdf_path, corpus, _pdf_chunks, t3=t3, embed_fn=embed_fn)
 
 
 def index_markdown(


### PR DESCRIPTION
## Summary

- Adds `embed_fn: EmbedFn | None = None` to `_index_document` and `index_pdf` — when provided, replaces `_embed_with_fallback` and bypasses the Voyage AI credential gate
- Adds `--dry-run` flag to `nx index pdf` that uses `EphemeralClient` + `DefaultEmbeddingFunction` (ONNX MiniLM-L6-v2), requires no API keys, and makes no cloud writes
- Prints a chunk preview showing page numbers, source title/author, and the first 80 chars of each chunk

## Example output

```
Dry-run mode — local ONNX embeddings, no cloud writes.
Indexing /path/to/paper.pdf…

  Chunks: 7  Pages: 1–3  Title: "My Document"  Author: "A. Person"

  [1] p.1  Hello World. This is a test document…
  [2] p.2  Database transactions ensure ACID consistency…
  …

(no cloud write)
```

## Test plan

- [x] 86 existing PDF + doc-indexer tests pass unchanged (embed_fn=None path untouched)
- [x] Live smoke test: `nx index pdf /tmp/dryrun_test.pdf --dry-run` — correct output, no credentials needed
- [x] `nx index pdf --help` shows `--dry-run` with description

References: nexus-1fnt