### PR TITLE
feat(pdf): activate pymupdf-layout for improved extraction quality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "llama-index-core==0.12.7",
     "markdown-it-py>=4.0.0",
     "pymupdf>=1.26.6",
+    "pymupdf-layout>=1.27.1",
     "pymupdf4llm>=0.2.2",
     "pyyaml>=6.0",
     "structlog>=24.0",

--- a/src/nexus/pdf_extractor.py
+++ b/src/nexus/pdf_extractor.py
@@ -39,12 +39,17 @@ class PDFExtractor:
         if self._has_type3_fonts(pdf_path):
             return self._extract_normalized(pdf_path)
         try:
-            return self._extract_markdown(pdf_path)
+            result = self._extract_markdown(pdf_path)
         except RuntimeError as exc:
             msg = str(exc).lower()
             if "font" in msg or "code=4" in msg:
                 return self._extract_normalized(pdf_path)
             raise
+        # Layout mode can produce empty output for minimal or atypical PDFs.
+        # Fall back to normalized extraction so callers always get some content.
+        if not result.text.strip():
+            return self._extract_normalized(pdf_path)
+        return result
 
     # ── internal extraction methods ───────────────────────────────────────────
 
@@ -66,6 +71,14 @@ class PDFExtractor:
     def _extract_markdown(self, pdf_path: Path) -> ExtractionResult:
         """Extract per-page markdown via pymupdf4llm."""
         import pymupdf        # lazy
+        # Activate layout analysis engine before importing pymupdf4llm so that
+        # pymupdf4llm selects layout mode (pymupdf._get_layout is checked at
+        # import time).  No-ops if layout was already activated or unavailable.
+        try:
+            from pymupdf import layout as _layout
+            _layout.activate()
+        except Exception:
+            pass
         import pymupdf4llm    # lazy
 
         page_texts: list[str] = []

--- a/uv.lock
+++ b/uv.lock
@@ -457,6 +457,7 @@ dependencies = [
     { name = "llama-index-core" },
     { name = "markdown-it-py" },
     { name = "pymupdf" },
+    { name = "pymupdf-layout" },
     { name = "pymupdf4llm" },
     { name = "pyyaml" },
     { name = "structlog" },
@@ -482,6 +483,7 @@ requires-dist = [
     { name = "llama-index-core", specifier = "==0.12.7" },
     { name = "markdown-it-py", specifier = ">=4.0.0" },
     { name = "pymupdf", specifier = ">=1.26.6" },
+    { name = "pymupdf-layout", specifier = ">=1.27.1" },
     { name = "pymupdf4llm", specifier = ">=0.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "structlog", specifier = ">=24.0" },
@@ -2483,6 +2485,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/29/690202b38b93cf77b73a29c25a63a2b6f3fcb36b1f75006e50b8dee7c108/pymupdf-1.27.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f1837554134fb45d390a44de8844b2ca9b6c901c82ccc90b340e3b7f3b126ca", size = 25167965, upload-time = "2026-02-11T22:36:35.478Z" },
     { url = "https://files.pythonhosted.org/packages/8a/81/f937e6aa606fd263c3a45d0ff0f0bbdbf3fb779933091fc0f6179513cc93/pymupdf-1.27.1-cp310-abi3-win32.whl", hash = "sha256:fa33b512d82c6c4852edadf57f22d5f27d16243bb33dac0fbe4eb0f281c5b17e", size = 18006253, upload-time = "2026-02-12T13:48:07.129Z" },
     { url = "https://files.pythonhosted.org/packages/3e/99/fe4a7752990bf65277718fffbead4478de9afd1c7288d7a6d643f79a6fa7/pymupdf-1.27.1-cp310-abi3-win_amd64.whl", hash = "sha256:4b6268dff3a9d713034eba5c2ffce0da37c62443578941ac5df433adcde57b2f", size = 19236703, upload-time = "2026-02-11T15:04:19.607Z" },
+]
+
+[[package]]
+name = "pymupdf-layout"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "pymupdf" },
+    { name = "pyyaml" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ac/574f537fa0199b31755eb0859d8e6ed8fcc669f7b460eba78611d1d78c8a/pymupdf_layout-1.27.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e60b7238f7652a825a884641fc1e9070e3b385905891ae194dfe91e5932b2342", size = 12323338, upload-time = "2026-02-11T16:23:52.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0b/b83178bb88cc8933f61dac113c89be9be426fd7c3b9deca3b628e96eb99a/pymupdf_layout-1.27.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:888923391e155cb6a4e0498709c8f4da750858dc273417a7386aeb8b81009b83", size = 12318712, upload-time = "2026-02-11T16:24:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e4/d11ebba2e950606713495620503d0e1b627c879c708fc488f7167cfb35a3/pymupdf_layout-1.27.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:05d88e0060b5875d21ee53c1dc50a2454aa32e59048b971847782318f47dca11", size = 12328732, upload-time = "2026-02-11T22:33:46.923Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/b6/0278408e2f6db993e3c9d4ee7be89f01b0022233298aa20fe54b95a0169c/pymupdf_layout-1.27.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e9e10d96f06ef5f511523a7caf5b707596a60c5c0a4735f4c5f84728cdb75ffd", size = 12329763, upload-time = "2026-02-11T16:24:09.825Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2c/f96920afb5a17226e7475f5db9eb7755a019623984caedcb47cb16660bd2/pymupdf_layout-1.27.1-cp310-abi3-win_amd64.whl", hash = "sha256:e456bcdc8760caadcaecb57e96277de11f9cdde785b04bf535448df4fb1e25fc", size = 12332980, upload-time = "2026-02-11T16:24:17.523Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `pymupdf-layout` dependency (CPU-only GNN layout analysis, ~15MB, no GPU required)
- Activates it in `PDFExtractor._extract_markdown` before importing `pymupdf4llm`, enabling layout mode which improves header/footer stripping, multi-column text ordering, table detection, and section heading recognition
- Adds empty-output fallback: if layout mode returns no text (can happen with minimal/atypical PDFs), falls back to normalized pymupdf extraction

## Observed improvement on `fireflies-tocs.pdf`

- 108 → 100 chunks (8 fewer noise chunks)
- Section headings properly detected: `## **6.1. Certificates and Bootstrapping**`
- Running footers partially stripped where detectable as footer regions
- No more `"Consider using the pymupdf_layout package..."` warning

## Test plan

- [x] 38/38 PDF tests pass (including AC-S2b bare-PDF test that exercises the empty-output fallback)
- [x] Live dry-run: `nx index pdf ~/Downloads/delos-papers/fireflies-tocs.pdf --dry-run` — cleaner output, no warning