### PR TITLE
fix(pdf): use pdfplumber for table counting to avoid layout.activate() suppression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ htmlcov/
 /coverage.json
 tests/e2e/.claude-auth/
 .worktrees/
+tests/fixtures/*.pdf
+.beads/ephemeral.sqlite3
+.serena/

--- a/src/nexus/pdf_extractor.py
+++ b/src/nexus/pdf_extractor.py
@@ -71,6 +71,10 @@ class PDFExtractor:
 
     def extract(self, pdf_path: Path) -> ExtractionResult:
         """Extract text from *pdf_path*. Returns ExtractionResult."""
+        # Count ruled tables BEFORE layout activation. pymupdf.layout.activate()
+        # (called inside _extract_markdown) suppresses find_tables() on some PDFs,
+        # making post-activation counts unreliable. Pre-activation count is safe.
+        pre_table_count = self._count_ruled_tables(pdf_path)
         if self._has_type3_fonts(pdf_path):
             return self._extract_normalized(pdf_path)
         try:
@@ -87,7 +91,7 @@ class PDFExtractor:
         # Quality-rescue: fall back to pdfplumber if ruled tables are present
         # but missing from the markdown output (e.g. GNN mis-classified cells
         # as body text). pdfplumber is opened only when actually needed.
-        if self._markdown_misses_tables(pdf_path, result.text):
+        if self._markdown_misses_tables(pre_table_count, result.text):
             try:
                 rescue = self._extract_with_pdfplumber(pdf_path)
                 if rescue.text.strip():
@@ -98,39 +102,49 @@ class PDFExtractor:
 
     # ── internal extraction methods ───────────────────────────────────────────
 
-    def _markdown_misses_tables(self, pdf_path: Path, markdown_text: str) -> bool:
-        """Return True if the PDF has ruled tables that are absent from the markdown.
+    def _count_ruled_tables(self, pdf_path: Path, max_pages: int = 5) -> int:
+        """Count ruled tables in the first *max_pages* pages using pdfplumber.find_tables().
 
-        Uses PyMuPDF's native find_tables() (same algorithm as pdfplumber) to count
-        ruled tables on the first five pages, then checks whether the markdown output
-        contains a proportional number of pipe characters. Returns False (no fallback)
-        when pdfplumber is not installed.
+        Uses pdfplumber (pdfminer-based) rather than pymupdf so that the count is
+        immune to pymupdf.layout.activate() global state: layout activation suppresses
+        pymupdf's find_tables() on some PDFs, making pymupdf-based counts unreliable
+        once any call to _extract_markdown() has occurred in the process.
+
+        Returns 0 if pdfplumber is not installed (table rescue is disabled anyway),
+        or on any error.
 
         Note: borderless tables (spacing-only alignment, common in IEEE/ACM papers)
         produce no edges from find_tables() and will not be detected. This is a known
         scope limitation — see RDR-012 Risks.
         """
         try:
-            import pdfplumber  # noqa: F401 — availability check only
+            import pdfplumber
         except ImportError:
             _log.debug("pdfplumber not installed; table rescue disabled")
-            return False
-        import pymupdf
+            return 0
         try:
-            ruled_tables = 0
-            with pymupdf.open(pdf_path) as doc:
-                for page in list(doc)[:5]:
-                    # TableFinder is always truthy; len() is the correct test.
-                    ruled_tables += len(page.find_tables().tables)
-            if ruled_tables == 0:
-                return False
-            pipe_count = markdown_text.count("|")
-            # A well-formatted Markdown table produces roughly 2*(N+1) pipes per row
-            # plus a separator row. With 3 pipes per table as floor, we allow small
-            # single-column pseudo-tables while still catching absent multi-column tables.
-            return pipe_count < ruled_tables * 3
+            count = 0
+            with pdfplumber.open(pdf_path) as pdf:
+                for page in pdf.pages[:max_pages]:
+                    count += len(page.find_tables())
+            return count
         except Exception:
+            return 0
+
+    def _markdown_misses_tables(self, ruled_table_count: int, markdown_text: str) -> bool:
+        """Return True if *markdown_text* lacks pipe chars proportional to *ruled_table_count*.
+
+        Pure predicate — no file I/O. Call _count_ruled_tables() first (before layout
+        activation) to obtain the count.
+
+        A well-formatted Markdown table produces roughly 2*(N+1) pipes per row plus a
+        separator row. With 3 pipes per table as floor, small single-column pseudo-tables
+        are tolerated while absent multi-column tables are caught.
+        """
+        if ruled_table_count == 0:
             return False
+        pipe_count = markdown_text.count("|")
+        return pipe_count < ruled_table_count * 3
 
     def _extract_with_pdfplumber(self, pdf_path: Path) -> ExtractionResult:
         """Extract text and tables via pdfplumber with Markdown table formatting.

--- a/tests/test_pdf_extractor.py
+++ b/tests/test_pdf_extractor.py
@@ -182,80 +182,85 @@ def test_format_table_empty():
     assert _format_table([]) == ""
 
 
-# ── _markdown_misses_tables ───────────────────────────────────────────────────
+# ── _count_ruled_tables ───────────────────────────────────────────────────────
 
-def _mock_pymupdf_with_tables(n_tables: int):
-    """Return a mock pymupdf module with n_tables ruled tables on page 0."""
-    mock_finder = MagicMock()
-    mock_finder.tables = [MagicMock()] * n_tables
+def _mock_pdfplumber_with_tables(n_tables: int):
+    """Return a mock pdfplumber module with n_tables ruled tables on page 0."""
     mock_page = MagicMock()
-    mock_page.find_tables.return_value = mock_finder
+    mock_page.find_tables.return_value = [MagicMock()] * n_tables
 
-    mock_doc = MagicMock()
-    mock_doc.__enter__ = MagicMock(return_value=mock_doc)
-    mock_doc.__exit__ = MagicMock(return_value=False)
-    mock_doc.__iter__ = MagicMock(side_effect=lambda: iter([mock_page]))
+    mock_pdf = MagicMock()
+    mock_pdf.__enter__ = MagicMock(return_value=mock_pdf)
+    mock_pdf.__exit__ = MagicMock(return_value=False)
+    mock_pdf.pages = [mock_page]
 
-    mock_pymupdf = MagicMock()
-    mock_pymupdf.open.return_value = mock_doc
-    return mock_pymupdf
-
-
-def test_markdown_misses_tables_detects_gap(extractor, dummy_pdf):
-    """PDF has ruled tables; markdown has no pipes → returns True (rescue needed)."""
-    mock_pymupdf = _mock_pymupdf_with_tables(n_tables=2)
-    with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
-        result = extractor._markdown_misses_tables(dummy_pdf, "prose only, no pipes here")
-    assert result is True
+    mock_pdfplumber = MagicMock()
+    mock_pdfplumber.open.return_value = mock_pdf
+    return mock_pdfplumber
 
 
-def test_markdown_misses_tables_no_tables(extractor, dummy_pdf):
-    """PDF has no ruled tables → returns False."""
-    mock_pymupdf = _mock_pymupdf_with_tables(n_tables=0)
-    with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
-        result = extractor._markdown_misses_tables(dummy_pdf, "prose only")
-    assert result is False
+def test_count_ruled_tables_counts_pages(extractor, dummy_pdf):
+    """_count_ruled_tables returns the total across the first 5 pages."""
+    mock_pdfplumber = _mock_pdfplumber_with_tables(n_tables=3)
+    with patch.dict("sys.modules", {"pdfplumber": mock_pdfplumber}):
+        assert extractor._count_ruled_tables(dummy_pdf) == 3
 
 
-def test_markdown_misses_tables_pipes_present(extractor, dummy_pdf):
-    """PDF has ruled tables; markdown already has sufficient pipes → returns False."""
-    mock_pymupdf = _mock_pymupdf_with_tables(n_tables=1)
-    # 1 table × 3 = threshold of 3 pipes; supply 5 to ensure False
-    markdown_with_pipes = "| col1 | col2 | col3 | col4 | col5 |"
-    with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
-        result = extractor._markdown_misses_tables(dummy_pdf, markdown_with_pipes)
-    assert result is False
+def test_count_ruled_tables_zero_when_none(extractor, dummy_pdf):
+    """Returns 0 when no ruled tables are found."""
+    mock_pdfplumber = _mock_pdfplumber_with_tables(n_tables=0)
+    with patch.dict("sys.modules", {"pdfplumber": mock_pdfplumber}):
+        assert extractor._count_ruled_tables(dummy_pdf) == 0
 
 
-def test_markdown_misses_tables_at_threshold_boundary(extractor, dummy_pdf):
-    """Exactly at threshold (3 pipes, 1 table) → False (not missing)."""
-    mock_pymupdf = _mock_pymupdf_with_tables(n_tables=1)
-    with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
-        result = extractor._markdown_misses_tables(dummy_pdf, "| a | b | c |")
-    assert result is False
-
-
-def test_markdown_misses_tables_one_below_threshold(extractor, dummy_pdf):
-    """One below threshold (2 pipes, 1 table → threshold 3) → True (rescue needed)."""
-    mock_pymupdf = _mock_pymupdf_with_tables(n_tables=1)
-    with patch.dict("sys.modules", {"pymupdf": mock_pymupdf}):
-        # "| a |" has exactly 2 pipes; threshold is 1*3=3, so 2<3 → True
-        result = extractor._markdown_misses_tables(dummy_pdf, "| a |")
-    assert result is True
-
-
-def test_markdown_misses_tables_no_pdfplumber(extractor, dummy_pdf):
-    """pdfplumber not installed → returns False (graceful degradation)."""
+def test_count_ruled_tables_no_pdfplumber(extractor, dummy_pdf):
+    """pdfplumber not installed → returns 0 (table rescue disabled)."""
     import sys
-    # Temporarily remove pdfplumber from sys.modules to simulate ImportError
     saved = sys.modules.pop("pdfplumber", None)
     try:
         with patch.dict("sys.modules", {"pdfplumber": None}):
-            result = extractor._markdown_misses_tables(dummy_pdf, "prose")
-        assert result is False
+            result = extractor._count_ruled_tables(dummy_pdf)
+        assert result == 0
     finally:
         if saved is not None:
             sys.modules["pdfplumber"] = saved
+
+
+def test_count_ruled_tables_returns_zero_on_error(extractor, dummy_pdf):
+    """Any exception during counting returns 0 (graceful degradation)."""
+    mock_pdfplumber = MagicMock()
+    mock_pdfplumber.open.side_effect = Exception("bad PDF")
+    with patch.dict("sys.modules", {"pdfplumber": mock_pdfplumber}):
+        assert extractor._count_ruled_tables(dummy_pdf) == 0
+
+
+# ── _markdown_misses_tables ───────────────────────────────────────────────────
+
+def test_markdown_misses_tables_detects_gap(extractor):
+    """Ruled tables present; markdown has no pipes → returns True (rescue needed)."""
+    assert extractor._markdown_misses_tables(2, "prose only, no pipes here") is True
+
+
+def test_markdown_misses_tables_no_tables(extractor):
+    """Zero ruled tables → always returns False."""
+    assert extractor._markdown_misses_tables(0, "prose only") is False
+
+
+def test_markdown_misses_tables_pipes_present(extractor):
+    """Ruled tables present; markdown has sufficient pipes → returns False."""
+    # 1 table × 3 = threshold of 3 pipes; supply 5 to ensure False
+    assert extractor._markdown_misses_tables(1, "| col1 | col2 | col3 | col4 | col5 |") is False
+
+
+def test_markdown_misses_tables_at_threshold_boundary(extractor):
+    """Exactly at threshold (3 pipes, 1 table) → False (not missing)."""
+    assert extractor._markdown_misses_tables(1, "| a | b | c |") is False
+
+
+def test_markdown_misses_tables_one_below_threshold(extractor):
+    """One below threshold (2 pipes, 1 table → threshold 3) → True (rescue needed)."""
+    # "| a |" has exactly 2 pipes; threshold is 1*3=3, so 2<3 → True
+    assert extractor._markdown_misses_tables(1, "| a |") is True
 
 
 # ── _extract_with_pdfplumber ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `pymupdf.layout.activate()` is called inside `_extract_markdown()` and is process-global. It suppresses `find_tables()` on some PDFs for the remainder of the process — confirmed with `distributed-bloom-filter.pdf` (5 ruled tables on pages 2 and 4 become 0 after layout activation).
- The previous fix (calling `_count_ruled_tables` before `_extract_markdown` within `extract()`) only worked for the first PDF in a process. Subsequent PDFs still ran with layout already active.
- **Root fix**: switch `_count_ruled_tables` to use `pdfplumber.find_tables()` (pdfminer-based engine), which is immune to pymupdf layout state.

## Changes

- **`_count_ruled_tables(pdf_path, max_pages=5) -> int`** (new): uses `pdfplumber.open().pages[:max_pages][i].find_tables()` — immune to `layout.activate()` global state
- **`_markdown_misses_tables(ruled_table_count: int, markdown_text: str) -> bool`** (refactored): pure predicate, no file I/O, no pymupdf dependency
- **`extract()`**: calls `_count_ruled_tables()` first, passes count to `_markdown_misses_tables()`
- **Tests**: updated `_markdown_misses_tables` tests (simpler, no mocking), new `_count_ruled_tables` tests with pdfplumber mocks

## Test plan

- [x] `uv run pytest tests/test_pdf_extractor.py tests/test_pdf_subsystem.py` — 38 passed
- [x] Full suite — 1898 passed, 8 skipped
- [x] Manual verification: `distributed-bloom-filter.pdf` now correctly routes to `pdfplumber` (183 pipes) in a multi-PDF session where layout was already activated by a prior PDF