### PR TITLE
refactor: remove anthropic SDK dependency

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,6 @@ For T3 (permanent cloud storage), you also need accounts at:
 |---------|---------|-----------|--------|
 | ChromaDB Cloud | Vector storage | Generous storage + requests for individual use | [trychroma.com](https://trychroma.com) |
 | Voyage AI | Embeddings | 200M tokens/month — indexing a large codebase uses 1–5M | [voyageai.com](https://voyageai.com) |
-| Anthropic | PM archival (optional) | — | [console.anthropic.com](https://console.anthropic.com) |
 
 > **Cost**: Both ChromaDB Cloud and Voyage AI free tiers cover all typical Nexus usage at no cost.
 > Voyage AI requires a credit card on file to unlock higher rate limits — but **usage remains
@@ -63,7 +62,6 @@ nx config set chroma_api_key sk-...
 nx config set chroma_tenant YOUR_TENANT_UUID
 nx config set chroma_database default_database
 nx config set voyage_api_key pa-...
-nx config set anthropic_api_key sk-ant-...
 ```
 
 Credentials are stored in `~/.config/nexus/config.yml`. Environment variables always take precedence:
@@ -74,7 +72,6 @@ Credentials are stored in `~/.config/nexus/config.yml`. Environment variables al
 | `chroma_tenant` | `CHROMA_TENANT` |
 | `chroma_database` | `CHROMA_DATABASE` |
 | `voyage_api_key` | `VOYAGE_API_KEY` |
-| `anthropic_api_key` | `ANTHROPIC_API_KEY` |
 
 **ChromaDB tenant** is the UUID shown on your Cloud settings page, not the URL slug.
 **ChromaDB database** is the base name for your four T3 databases. If you set `chroma_database = nexus`, Nexus will use `nexus_code`, `nexus_docs`, `nexus_rdr`, and `nexus_knowledge`. You must create all four in your ChromaDB Cloud dashboard before running `nx index` or `nx store`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "anthropic>=0.39",
     "chromadb>=0.6",
     "click>=8.1",
     "flask>=3.0",

--- a/src/nexus/commands/config_cmd.py
+++ b/src/nexus/commands/config_cmd.py
@@ -20,7 +20,6 @@ _SIGNUP = {
     "chroma_tenant":     "https://trychroma.com  (Cloud → Settings → Tenant ID)",
     "chroma_database":   "https://trychroma.com  (Cloud → Settings → Database)",
     "voyage_api_key":    "https://voyageai.com   (Dashboard → API Keys)",
-    "anthropic_api_key": "https://console.anthropic.com  (API Keys)",
     "mxbai_api_key":     "https://mixedbread.ai  (Dashboard → API Keys)  [optional]",
 }
 
@@ -142,7 +141,6 @@ def config_init() -> None:
         ("chroma_tenant",     "ChromaDB tenant ID"),
         ("chroma_database",   "ChromaDB database name"),
         ("voyage_api_key",    "Voyage AI API key"),
-        ("anthropic_api_key", "Anthropic API key"),
         ("mxbai_api_key",     "Mixedbread API key (optional — press Enter to skip)"),
     ]
 

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -128,16 +128,6 @@ def doctor_cmd() -> None:
              "nx config set voyage_api_key <your-key>",
              "Get key: https://www.voyageai.com")
 
-    # ── ANTHROPIC_API_KEY ─────────────────────────────────────────────────────
-    anthropic_key = get_credential("anthropic_api_key")
-    lines.append(_check_line("Anthropic (ANTHROPIC_API_KEY)", bool(anthropic_key),
-                              "set" if anthropic_key else "not set"))
-    if not anthropic_key:
-        failed = True
-        _fix(lines,
-             "nx config set anthropic_api_key <your-key>",
-             "Get key: https://console.anthropic.com")
-
     # ── ripgrep ───────────────────────────────────────────────────────────────
     rg_path = shutil.which("rg")
     lines.append(_check_line("ripgrep   (rg)",              bool(rg_path),

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -18,8 +18,6 @@ _config_lock = threading.Lock()
 
 # ── Model constants ───────────────────────────────────────────────────────────
 
-HAIKU_MODEL: str = "claude-haiku-4-5-20251001"
-
 # ── Credential registry ───────────────────────────────────────────────────────
 # Maps config-file key → environment variable name
 CREDENTIALS: dict[str, str] = {
@@ -27,7 +25,6 @@ CREDENTIALS: dict[str, str] = {
     "chroma_tenant":     "CHROMA_TENANT",
     "chroma_database":   "CHROMA_DATABASE",
     "voyage_api_key":    "VOYAGE_API_KEY",
-    "anthropic_api_key": "ANTHROPIC_API_KEY",
     "mxbai_api_key":     "MXBAI_API_KEY",
 }
 

--- a/src/nexus/pm.py
+++ b/src/nexus/pm.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from nexus.config import HAIKU_MODEL, get_credential
 from nexus.db import make_t3
 
 if TYPE_CHECKING:
@@ -41,15 +40,17 @@ _STANDARD_DOCS: dict[str, str] = {
 
 _log = structlog.get_logger()
 
-# ~1200 tokens x 3.3 chars/token ~ 3960 chars. Keeps each chunk
-# within Claude Haiku's comfortable synthesis window.
+_ARCHIVE_MODEL = "claude-haiku-4-5-20251001"
+
+# ~1200 tokens x 3.3 chars/token ~ 3960 chars. Keeps each archive chunk
+# within a comfortable context window for downstream embedding / retrieval.
 _SYNTHESIS_CHAR_LIMIT = 3960
 
-def _synthesize_haiku(docs: list[dict[str, Any]], project: str, status: str) -> str:
-    """Call Haiku to synthesize PM docs into a structured archive chunk."""
-    import anthropic
 
-    # Build doc selection: standard docs first, then others by most-recently-written
+def _build_archive_context(
+    docs: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], str, str]:
+    """Select and trim docs for archival; return (selected, started_at, archived_at)."""
     standard_titles = set(_STANDARD_DOCS.keys())
     standard = [d for d in docs if d["title"] in standard_titles]
     others = sorted(
@@ -61,7 +62,6 @@ def _synthesize_haiku(docs: list[dict[str, Any]], project: str, status: str) -> 
 
     total_chars = sum(len(d.get("content", "")) for d in selected)
     if total_chars > 100_000:
-        # Trim others to fit
         budget = 100_000 - sum(len(d.get("content", "")) for d in standard)
         trimmed: list[dict] = list(standard)
         for doc in others:
@@ -71,12 +71,44 @@ def _synthesize_haiku(docs: list[dict[str, Any]], project: str, status: str) -> 
                 budget -= len(c)
         selected = trimmed
 
-    # Compute started_at from oldest doc
     timestamps = [d.get("timestamp", "") for d in docs if d.get("timestamp")]
     started_at = min(timestamps) if timestamps else "unknown"
     archived_at = datetime.now(UTC).isoformat()
+    return selected, started_at, archived_at
 
-    # Build context string
+
+def _format_archive(docs: list[dict[str, Any]], project: str, status: str) -> str:
+    """Format PM docs as a structured archive (no AI — plain concatenation fallback)."""
+    selected, started_at, archived_at = _build_archive_context(docs)
+    parts: list[str] = [
+        f"# Project Archive: {project}",
+        f"Status: {status}",
+        f"Date Range: {started_at} → {archived_at}",
+        "",
+    ]
+    for doc in selected:
+        parts.append(f"## {doc['title']}")
+        parts.append(doc.get("content", ""))
+        parts.append("")
+    return "\n".join(parts).strip()
+
+
+def _synthesize_archive(docs: list[dict[str, Any]], project: str, status: str) -> str:
+    """Synthesize PM docs via ``claude --print`` subprocess.
+
+    Builds a structured synthesis prompt and pipes it to the ``claude`` CLI.
+    Falls back to ``_format_archive`` (plain concatenation) if ``claude`` is
+    not on PATH or the subprocess fails — so ``nx pm archive`` works outside
+    of a Claude Code session without any API key.
+    """
+    import shutil
+    import subprocess
+
+    if not shutil.which("claude"):
+        _log.debug("claude CLI not found; using plain archive format")
+        return _format_archive(docs, project, status)
+
+    selected, started_at, archived_at = _build_archive_context(docs)
     context_parts: list[str] = []
     for doc in selected:
         context_parts.append(f"## {doc['title']}\n{doc.get('content', '')}")
@@ -97,22 +129,25 @@ def _synthesize_haiku(docs: list[dict[str, Any]], project: str, status: str) -> 
         f"Use brief bullets (one line per item). Target 400-800 tokens, hard cap 1200 tokens."
     )
 
-    api_key = get_credential("anthropic_api_key")
-    if not api_key:
-        raise RuntimeError(
-            "anthropic_api_key is required for PM archive synthesis. "
-            "Set ANTHROPIC_API_KEY or run `nx config set anthropic_api_key <key>`."
+    _log.info("Synthesizing archive via claude CLI", project=project)
+    try:
+        result = subprocess.run(
+            ["claude", "--print", "--model", _ARCHIVE_MODEL],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
-    _log.info("Synthesizing archive via Haiku", project=project)
-    client = anthropic.Anthropic(api_key=api_key, timeout=60.0)
-    message = client.messages.create(
-        model=HAIKU_MODEL,
-        max_tokens=1200,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    if not message.content:
-        raise RuntimeError("Haiku returned empty response during archive synthesis")
-    return message.content[0].text
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+        _log.warning(
+            "claude CLI returned empty or non-zero; using plain archive format",
+            returncode=result.returncode,
+            stderr=result.stderr[:200] if result.stderr else "",
+        )
+    except Exception as exc:
+        _log.warning("claude CLI synthesis failed; using plain archive format", error=str(exc))
+    return _format_archive(docs, project, status)
 
 
 def _split_synthesis(text: str) -> list[str]:
@@ -336,7 +371,7 @@ def pm_archive(
             return
 
     # Phase 1: Synthesize → T3
-    synthesis_text = _synthesize_haiku(all_docs, project, status)
+    synthesis_text = _synthesize_archive(all_docs, project, status)
 
     # Compute metadata
     archived_at = datetime.now(UTC).isoformat()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,7 +115,7 @@ def test_set_credential_cleans_up_temp_on_write_failure(
     with patch("nexus.config.os.fdopen", side_effect=failing_fdopen):
         with patch("nexus.config.os.unlink", side_effect=tracking_unlink):
             with pytest.raises(IOError, match="simulated write failure"):
-                set_credential("anthropic_api_key", "test-key")
+                set_credential("voyage_api_key", "test-key")
 
     # Verify unlink was called on a temp file
     assert len(unlinked_paths) >= 1, "os.unlink should have been called on the temp file"

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -133,7 +133,7 @@ def test_config_list_shows_credential_names(runner: CliRunner, fake_home: Path) 
     assert result.exit_code == 0, result.output
     assert "chroma_api_key" in result.output
     assert "voyage_api_key" in result.output
-    assert "anthropic_api_key" in result.output
+    assert "mxbai_api_key" in result.output
 
 
 def test_config_list_shows_non_secret_settings(runner: CliRunner, fake_home: Path) -> None:
@@ -149,7 +149,7 @@ def test_config_list_shows_non_secret_settings(runner: CliRunner, fake_home: Pat
 def test_config_init_writes_provided_values(runner: CliRunner, fake_home: Path) -> None:
     """nx config init with all inputs writes all credentials to config.yml."""
     # Simulate interactive input: provide values for each prompt, then empty to skip mxbai
-    inputs = "chroma-key\nmy-tenant\nmy-db\nvoyage-key\nanthropickey\n\n"
+    inputs = "chroma-key\nmy-tenant\nmy-db\nvoyage-key\n\n"
     result = runner.invoke(main, ["config", "init"], input=inputs)
     assert result.exit_code == 0, result.output
 
@@ -159,7 +159,7 @@ def test_config_init_writes_provided_values(runner: CliRunner, fake_home: Path) 
     creds = data.get("credentials", {})
     assert creds.get("chroma_api_key") == "chroma-key"
     assert creds.get("voyage_api_key") == "voyage-key"
-    assert creds.get("anthropic_api_key") == "anthropickey"
+    assert "anthropic_api_key" not in creds
 
 
 def test_config_init_shows_signup_urls(runner: CliRunner, fake_home: Path) -> None:

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -112,9 +112,7 @@ def test_doctor_partial_credentials() -> None:
     assert result.exit_code == 1
     # Missing ones should be listed with fix hints
     assert "CHROMA_TENANT" in result.output
-    assert "ANTHROPIC_API_KEY" in result.output
     assert "nx config set chroma_tenant" in result.output
-    assert "nx config set anthropic_api_key" in result.output
     # Present keys should show as set, not have fix hints
     assert "nx config set chroma_api_key" not in result.output
     assert "nx config set voyage_api_key" not in result.output
@@ -172,10 +170,8 @@ def test_doctor_missing_credential_shows_inline_fix() -> None:
 
     assert "nx config set chroma_api_key" in result.output
     assert "nx config set voyage_api_key" in result.output
-    assert "nx config set anthropic_api_key" in result.output
     assert "trychroma.com" in result.output
     assert "voyageai.com" in result.output
-    assert "console.anthropic.com" in result.output
 
 
 def test_doctor_missing_rg_shows_platform_hints() -> None:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -312,10 +312,10 @@ def test_pm_init_status_block_unblock(
         assert unblock.exit_code == 0, unblock.output
 
 
-def test_pm_archive_with_mocked_haiku(
+def test_pm_archive_with_mocked_synthesis(
     runner: CliRunner, fake_home: Path, db, local_t3: T3Database
 ) -> None:
-    """nx pm archive synthesizes docs via Haiku (mocked) and writes to T3."""
+    """nx pm archive synthesizes docs via claude CLI (mocked) and writes to T3."""
     canned_synthesis = "# Archive\n\n## Summary\nProject completed.\n\n## Key Decisions\n- Used ChromaDB"
 
     _t2_cm = MagicMock(__enter__=MagicMock(return_value=db))
@@ -323,17 +323,11 @@ def test_pm_archive_with_mocked_haiku(
         runner.invoke(main, ["pm", "init", "--project", "archive-proj"])
 
     with patch("nexus.pm.make_t3", return_value=local_t3):
-        with patch("nexus.pm.get_credential", return_value="mock-key"):
-            with patch("anthropic.Anthropic") as mock_cls:
-                mock_client = MagicMock()
-                mock_cls.return_value = mock_client
-                mock_client.messages.create.return_value = MagicMock(
-                    content=[MagicMock(text=canned_synthesis)]
-                )
-                with patch("nexus.commands.pm.T2Database", return_value=_t2_cm):
-                    result = runner.invoke(main, [
-                        "pm", "archive", "--project", "archive-proj"
-                    ])
+        with patch("nexus.pm._synthesize_archive", return_value=canned_synthesis):
+            with patch("nexus.commands.pm.T2Database", return_value=_t2_cm):
+                result = runner.invoke(main, [
+                    "pm", "archive", "--project", "archive-proj"
+                ])
 
     assert result.exit_code == 0, result.output
     # Verify synthesis was written to T3

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -224,7 +224,6 @@ def test_doctor_shows_all_checks(runner: CliRunner, fake_home: Path) -> None:
     output_lower = result.output.lower()
     assert "chroma" in output_lower or "chromadb" in output_lower
     assert "voyage" in output_lower
-    assert "anthropic" in output_lower
     assert "ripgrep" in output_lower or "rg" in output_lower
     assert "git" in output_lower
 

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -167,8 +167,8 @@ def test_pm_phase_next_increments_correctly(db) -> None:
 
 # ── AC5: pm_archive — two-phase, idempotency ──────────────────────────────────
 
-def test_pm_archive_calls_haiku_then_t3(db) -> None:
-    """pm_archive synthesizes via Haiku then upserts to T3 collection."""
+def test_pm_archive_synthesizes_then_upserts_t3(db) -> None:
+    """pm_archive synthesizes via claude CLI then upserts to T3 collection."""
     pm_init(db, project="myrepo")
 
     mock_col = MagicMock()
@@ -177,11 +177,11 @@ def test_pm_archive_calls_haiku_then_t3(db) -> None:
     mock_t3.search.return_value = []  # no prior archive
     mock_t3.get_or_create_collection.return_value = mock_col
 
-    with patch("nexus.pm._synthesize_haiku", return_value="# Archive summary") as mock_h:
+    with patch("nexus.pm._synthesize_archive", return_value="# Archive summary") as mock_s:
         with patch("nexus.pm.make_t3", return_value=mock_t3):
             pm_archive(db, project="myrepo", status="completed", archive_ttl=90)
 
-    mock_h.assert_called_once()
+    mock_s.assert_called_once()
     mock_t3.upsert_chunks.assert_called_once()
 
 
@@ -195,7 +195,7 @@ def test_pm_archive_decays_t2_after_t3(db) -> None:
     mock_t3.search.return_value = []
     mock_t3.get_or_create_collection.return_value = mock_col
 
-    with patch("nexus.pm._synthesize_haiku", return_value="# summary"):
+    with patch("nexus.pm._synthesize_archive", return_value="# summary"):
         with patch("nexus.pm.make_t3", return_value=mock_t3):
             pm_archive(db, project="myrepo", status="completed", archive_ttl=90)
 
@@ -230,11 +230,11 @@ def test_pm_archive_idempotent_skips_synthesis(db) -> None:
     mock_t3 = MagicMock()
     mock_t3.get_or_create_collection.return_value = mock_col
 
-    with patch("nexus.pm._synthesize_haiku") as mock_h:
+    with patch("nexus.pm._synthesize_archive") as mock_s:
         with patch("nexus.pm.make_t3", return_value=mock_t3):
             pm_archive(db, project="myrepo", status="completed", archive_ttl=90)
 
-    mock_h.assert_not_called()
+    mock_s.assert_not_called()
 
 
 def test_pm_archive_aborts_on_haiku_failure(db) -> None:
@@ -247,7 +247,7 @@ def test_pm_archive_aborts_on_haiku_failure(db) -> None:
     mock_t3.search.return_value = []
     mock_t3.get_or_create_collection.return_value = mock_col
 
-    with patch("nexus.pm._synthesize_haiku", side_effect=RuntimeError("API error")):
+    with patch("nexus.pm._synthesize_archive", side_effect=RuntimeError("API error")):
         with patch("nexus.pm.make_t3", return_value=mock_t3):
             with pytest.raises(RuntimeError, match="API error"):
                 pm_archive(db, project="myrepo", status="completed", archive_ttl=90)
@@ -425,7 +425,7 @@ def test_pm_archive_upsert_includes_required_metadata(db) -> None:
     mock_t3.search.return_value = []
     mock_t3.get_or_create_collection.return_value = mock_col
 
-    with patch("nexus.pm._synthesize_haiku", return_value="# summary"):
+    with patch("nexus.pm._synthesize_archive", return_value="# summary"):
         with patch("nexus.pm.make_t3", return_value=mock_t3):
             pm_archive(db, project="myrepo", status="completed", archive_ttl=90)
 
@@ -482,7 +482,7 @@ def test_pm_archive_writes_chunk_total_in_metadata(db) -> None:
     mock_t3.upsert_chunks.side_effect = capture_upsert_chunks
 
     synthesis = "# Archive\n\n## Key Decisions\n- Used SQLite"
-    with patch("nexus.pm._synthesize_haiku", return_value=synthesis):
+    with patch("nexus.pm._synthesize_archive", return_value=synthesis):
         with patch("nexus.pm.make_t3", return_value=mock_t3):
             pm_archive(db, project="myrepo", status="completed", archive_ttl=90)
 
@@ -627,30 +627,11 @@ def test_split_synthesis_short_text_single_chunk() -> None:
     assert chunks == [short_text]
 
 
-# ── Edge cases: _synthesize_haiku ─────────────────────────────────────────────
+# ── Edge cases: _synthesize_archive ──────────────────────────────────────────
 
-def test_synthesize_haiku_empty_response_raises() -> None:
-    """_synthesize_haiku raises RuntimeError when Anthropic returns empty message.content."""
-    from nexus.pm import _synthesize_haiku
-
-    mock_message = MagicMock()
-    mock_message.content = []  # empty content list
-
-    with patch("anthropic.Anthropic") as mock_anthropic_cls:
-        mock_client = mock_anthropic_cls.return_value
-        mock_client.messages.create.return_value = mock_message
-        with patch("nexus.pm.get_credential", return_value="fake-api-key"):
-            with pytest.raises(RuntimeError, match="empty response"):
-                _synthesize_haiku(
-                    docs=[{"title": "METHODOLOGY.md", "content": "hello", "timestamp": "2026-01-01T00:00:00"}],
-                    project="test",
-                    status="completed",
-                )
-
-
-def test_synthesize_haiku_trims_long_content() -> None:
-    """_synthesize_haiku trims input when total doc chars exceed 100K before calling Anthropic."""
-    from nexus.pm import _STANDARD_DOCS, _synthesize_haiku
+def test_synthesize_archive_trims_long_content() -> None:
+    """_synthesize_archive trims input when total doc chars exceed 100K."""
+    from nexus.pm import _STANDARD_DOCS, _synthesize_archive
 
     # Build docs: 5 standard (small) + 50 "other" docs (each 3000 chars) = ~150K total
     standard_docs = [
@@ -665,31 +646,36 @@ def test_synthesize_haiku_trims_long_content() -> None:
     total_chars = sum(len(d["content"]) for d in all_docs)
     assert total_chars > 100_000, f"Test setup: need >100K chars, got {total_chars}"
 
-    mock_message = MagicMock()
-    mock_message.content = [MagicMock(text="# Archive synthesis")]
+    captured: dict = {}
 
-    captured_prompt = {}
+    def fake_run(cmd, *, input, **kwargs):
+        captured["input"] = input
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "# Archive synthesis"
+        return result
 
-    def capture_create(**kwargs):
-        captured_prompt["messages"] = kwargs["messages"]
-        return mock_message
+    import shutil
+    with patch("shutil.which", return_value="/usr/bin/claude"):
+        with patch("subprocess.run", side_effect=fake_run):
+            result = _synthesize_archive(all_docs, project="test", status="completed")
 
-    with patch("anthropic.Anthropic") as mock_anthropic_cls:
-        mock_client = mock_anthropic_cls.return_value
-        mock_client.messages.create.side_effect = capture_create
-        with patch("nexus.pm.get_credential", return_value="fake-api-key"):
-            result = _synthesize_haiku(all_docs, project="test", status="completed")
-
-    # Verify Anthropic was called
-    assert "messages" in captured_prompt
-    # The prompt content sent to Anthropic should be shorter than the raw total
-    prompt_text = captured_prompt["messages"][0]["content"]
-    # The prompt should contain fewer chars than the raw 150K input
-    # (standard ~65 chars + budget ~100K max for others + prompt boilerplate)
-    assert len(prompt_text) < total_chars, (
-        f"Expected trimmed prompt ({len(prompt_text)} chars) < raw total ({total_chars} chars)"
-    )
+    # Verify the prompt was trimmed before being sent to claude
+    assert "input" in captured
+    assert len(captured["input"]) < total_chars
     assert result == "# Archive synthesis"
+
+
+def test_synthesize_archive_falls_back_when_claude_missing() -> None:
+    """_synthesize_archive falls back to plain format when claude CLI is not found."""
+    from nexus.pm import _synthesize_archive
+
+    docs = [{"title": "METHODOLOGY.md", "content": "hello", "timestamp": "2026-01-01T00:00:00"}]
+    with patch("shutil.which", return_value=None):
+        result = _synthesize_archive(docs, project="test", status="completed")
+
+    assert "# Project Archive: test" in result
+    assert "METHODOLOGY.md" in result
 
 
 # ── Edge cases: pm_block / pm_unblock ─────────────────────────────────────────
@@ -771,19 +757,22 @@ def test_pm_status_empty_blockers_list(db) -> None:
     assert status["blockers"] == []
 
 
-# ── Gap 1: _synthesize_haiku raises RuntimeError when API key is empty ──────
+# ── Gap 1: _synthesize_archive falls back on claude CLI failure ──────────────
 
-def test_synthesize_haiku_raises_when_api_key_empty() -> None:
-    """_synthesize_haiku raises RuntimeError when get_credential returns empty string."""
-    from nexus.pm import _synthesize_haiku
+def test_synthesize_archive_falls_back_on_subprocess_error() -> None:
+    """_synthesize_archive returns plain format when claude CLI subprocess fails."""
+    from nexus.pm import _synthesize_archive
 
-    with patch("nexus.pm.get_credential", return_value=""):
-        with pytest.raises(RuntimeError, match="anthropic_api_key is required"):
-            _synthesize_haiku(
+    with patch("shutil.which", return_value="/usr/bin/claude"):
+        with patch("subprocess.run", side_effect=OSError("exec failed")):
+            result = _synthesize_archive(
                 docs=[{"title": "METHODOLOGY.md", "content": "hello", "timestamp": "2026-01-01T00:00:00"}],
                 project="test",
                 status="completed",
             )
+
+    assert "# Project Archive: test" in result
+    assert "METHODOLOGY.md" in result
 
 
 # ── Gap 2: _split_synthesis no-headers fallback ────────────────────────────
@@ -828,7 +817,7 @@ def test_pm_archive_handles_non_integer_phase_tag(db) -> None:
     mock_t3 = MagicMock()
     mock_t3.get_or_create_collection.return_value = mock_col
 
-    with patch("nexus.pm._synthesize_haiku", return_value="# Archive summary"):
+    with patch("nexus.pm._synthesize_archive", return_value="# Archive summary"):
         with patch("nexus.pm.make_t3", return_value=mock_t3):
             # Should not raise — gracefully ignores the bad phase tag
             pm_archive(db, project="myrepo", status="completed", archive_ttl=90)
@@ -866,7 +855,7 @@ def test_pm_archive_stores_multiple_chunks_for_long_synthesis(db) -> None:
     mock_t3.get_or_create_collection.return_value = mock_col
     mock_t3.upsert_chunks.side_effect = capture_upsert
 
-    with patch("nexus.pm._synthesize_haiku", return_value=long_synthesis):
+    with patch("nexus.pm._synthesize_archive", return_value=long_synthesis):
         with patch("nexus.pm.make_t3", return_value=mock_t3):
             pm_archive(db, project="myrepo", status="completed", archive_ttl=90)
 

--- a/uv.lock
+++ b/uv.lock
@@ -141,25 +141,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.83.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/e5/02cd2919ec327b24234abb73082e6ab84c451182cc3cc60681af700f4c63/anthropic-0.83.0.tar.gz", hash = "sha256:a8732c68b41869266c3034541a31a29d8be0f8cd0a714f9edce3128b351eceb4", size = 534058, upload-time = "2026-02-19T19:26:38.904Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/75/b9d58e4e2a4b1fc3e75ffbab978f999baf8b7c4ba9f96e60edb918ba386b/anthropic-0.83.0-py3-none-any.whl", hash = "sha256:f069ef508c73b8f9152e8850830d92bd5ef185645dbacf234bb213344a274810", size = 456991, upload-time = "2026-02-19T19:26:40.114Z" },
-]
-
-[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -470,7 +451,6 @@ name = "conexus"
 version = "1.0.0"
 source = { editable = "." }
 dependencies = [
-    { name = "anthropic" },
     { name = "chromadb" },
     { name = "click" },
     { name = "flask" },
@@ -497,7 +477,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.39" },
     { name = "chromadb", specifier = ">=0.6" },
     { name = "click", specifier = ">=8.1" },
     { name = "flask", specifier = ">=3.0" },
@@ -700,15 +679,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]
@@ -1215,74 +1185,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "jiter"
-version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
-    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
-    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
-    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
-    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
-    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
-    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
-    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
-    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
-    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
-    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
-    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
-    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
-    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
-    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
-    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
-    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
-    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
-    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
-    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
-    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
-    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
-    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
-    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
-    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
-    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
-    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
-    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
-    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
 ]
 
 [[package]]
@@ -3031,15 +2933,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Removes leftover `anthropic>=0.39` Python dependency from RDR-009 cleanup (`answer.py` was already deleted but `pm.py` still used the SDK)
- Replaces `_synthesize_haiku()` in `pm.py` with `_synthesize_archive()` that calls `claude --print --model claude-haiku-4-5-20251001` as a subprocess
- Adds graceful fallback to `_format_archive()` (plain concatenation) when `claude` CLI is absent or fails — works outside Claude Code
- Removes `anthropic_api_key` from doctor checks, config prompts, credentials registry, and getting-started docs

## Test plan

- [ ] 1880 tests pass (`uv run pytest -x -q -m "not integration"`)
- [ ] `pm_archive` synthesis path mocked via `nexus.pm._synthesize_archive` in `test_e2e.py`
- [ ] New `test_synthesize_archive_*` tests cover subprocess path, fallback-on-missing-CLI, and fallback-on-error
- [ ] No `anthropic` imports remain in source tree