### PR TITLE
Release v1.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted semantic search, memory, and knowledge management for Claude Code agents.",
-      "version": "1.1.0"
+      "version": "1.1.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-03-02
+
+### Fixed
+- **`nx doctor` server check** — optional Nexus server now shows `✓` with status in
+  detail string instead of `✗` with a Fix: hint, preventing false failures in
+  preflight scripts that check exit code.
+
+### Changed
+- **Release process docs** — added explicit `uv sync` step and `uv.lock` to the
+  `git add` list so lock file is never missed in a release commit.
+
+### Docs
+- RDR skill docs: `rdr-close` pre-check aligned with actual command behaviour
+  (`"accepted"` not `"final"`); agent and skill counts corrected after PM removal.
+
 ## [1.1.0] - 2026-03-02
 
 ### Removed

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -104,9 +104,12 @@ Agent files, skill files, config files: no header needed — the LICENSE file co
    ```
 
 2. **Update version in `pyproject.toml`**
-   Change the `version` field (e.g. `"1.0.0rc4"` → `"1.0.0"`), then regenerate the lock file:
+   Change the `version` field (e.g. `"1.0.0rc4"` → `"1.0.0"`), then regenerate the lock file
+   and reinstall the local tool so `nx --version` reflects the new version immediately:
    ```bash
    uv sync
+   uv tool install --reinstall .
+   nx --version   # must show X.Y.Z before proceeding
    ```
 
 3. **Update `CHANGELOG.md`**

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the nx plugin are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-03-02
+
+### Fixed
+- **`rdr-close` pre-check** — status check now correctly accepts `"accepted"` (or
+  `"final"`) matching actual command behaviour; warning message shows `{current_status}`
+  instead of the hardcoded `"Draft"`.
+
+### Changed
+- **Agent and skill counts** corrected throughout plugin docs after PM removal
+  (14 agents, 27 skills).
+- **`nexus` skill description** — "project management" replaced with "indexing".
+
 ## [1.1.0] - 2026-03-02
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "1.1.0"
+version = "1.1.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -448,7 +448,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Patch release covering fixes and doc improvements since v1.1.0.

- **fix**: `nx doctor` server check no longer shows `✗` for optional server — was causing preflight scripts to exit non-zero
- **fix**: `rdr-close` skill pre-check aligned with actual command behaviour (`accepted` not `final`)
- **docs**: agent/skill counts corrected after PM removal (14 agents, 27 skills)
- **docs**: release process updated — `uv sync` step and `uv.lock` added to staged files

## Files changed
- `pyproject.toml` — version bump to 1.1.1
- `uv.lock` — regenerated
- `CHANGELOG.md` — 1.1.1 entry
- `nx/CHANGELOG.md` — 1.1.1 entry
- `.claude-plugin/marketplace.json` — version bump to 1.1.1