### PR TITLE
feat: auto-enable per-file output when stdout is not a TTY (nexus-m7kc)

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -37,7 +37,7 @@ def index() -> None:
     help="Force re-indexing all files, bypassing staleness check (re-chunks and re-embeds in-place).",
 )
 @click.option("--monitor", is_flag=True, default=False,
-              help="Print per-file progress lines (verbose monitoring without debug spam).")
+              help="Print per-file progress lines. Auto-enabled when stdout is not a TTY.")
 def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool) -> None:
     """Register and immediately index a code repository at PATH.
 
@@ -74,7 +74,7 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool) 
         if bar is not None:
             bar.update(1)
             bar.set_postfix(now=fpath.name)
-        if monitor:
+        if monitor or not sys.stdout.isatty():
             lbl = f"{chunks} chunks" if chunks else "skipped"
             line = f"  [{n}/{total}] {fpath.name} \u2014 {lbl}  ({elapsed:.1f}s)"
             if bar is not None and sys.stdout.isatty():
@@ -128,7 +128,7 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool) 
     help="Force re-indexing, bypassing staleness check (re-chunks and re-embeds in-place).",
 )
 @click.option("--monitor", is_flag=True, default=False,
-              help="Print per-file progress lines (verbose monitoring without debug spam).")
+              help="Print chunking metadata after indexing. Auto-enabled when stdout is not a TTY.")
 def index_pdf_cmd(path: Path, corpus: str, collection: str | None, dry_run: bool, force: bool, monitor: bool) -> None:
     """Extract and index a PDF document into T3 docs__CORPUS (or --collection)."""
     from nexus.doc_indexer import index_pdf
@@ -189,7 +189,7 @@ def index_pdf_cmd(path: Path, corpus: str, collection: str | None, dry_run: bool
 
     label = "Force re-indexing" if force else "Indexing"
     click.echo(f"{label} {path}…")
-    if monitor:
+    if monitor or not sys.stdout.isatty():
         meta = index_pdf(path, corpus=corpus, collection_name=collection, force=force,
                          return_metadata=True)
         n = meta["chunks"]  # type: ignore[index]
@@ -219,7 +219,7 @@ def index_pdf_cmd(path: Path, corpus: str, collection: str | None, dry_run: bool
     help="Force re-indexing, bypassing staleness check.",
 )
 @click.option("--monitor", is_flag=True, default=False,
-              help="Print per-file progress lines (verbose monitoring without debug spam).")
+              help="Print chunking metadata after indexing. Auto-enabled when stdout is not a TTY.")
 def index_md_cmd(path: Path, corpus: str, force: bool, monitor: bool) -> None:
     """Extract and index a Markdown file into T3 docs__CORPUS."""
     from nexus.doc_indexer import index_markdown
@@ -227,7 +227,7 @@ def index_md_cmd(path: Path, corpus: str, force: bool, monitor: bool) -> None:
     path = path.resolve()
     label = "Force re-indexing" if force else "Indexing"
     click.echo(f"{label} {path}…")
-    if monitor:
+    if monitor or not sys.stdout.isatty():
         meta = index_markdown(path, corpus=corpus, force=force, return_metadata=True)
         n = meta["chunks"]  # type: ignore[index]
         sections = meta.get("sections", 0)  # type: ignore[union-attr]
@@ -250,7 +250,7 @@ _RDR_EXCLUDES = {"README.md", "TEMPLATE.md"}
     help="Force re-indexing all RDR documents, bypassing staleness check.",
 )
 @click.option("--monitor", is_flag=True, default=False,
-              help="Print per-file progress lines (verbose monitoring without debug spam).")
+              help="Print per-file progress lines. Auto-enabled when stdout is not a TTY.")
 def index_rdr_cmd(path: Path, force: bool, monitor: bool) -> None:
     """Discover and index RDR documents in docs/rdr/ into T3 rdr__REPO-HASH8."""
     from nexus.doc_indexer import batch_index_markdowns
@@ -286,7 +286,7 @@ def index_rdr_cmd(path: Path, force: bool, monitor: bool) -> None:
         n += 1
         bar.update(1)
         bar.set_postfix(now=fpath.name)
-        if monitor:
+        if monitor or not sys.stdout.isatty():
             lbl = f"{chunks} chunks" if chunks else "skipped"
             line = f"  [{n}/{len(rdr_files)}] {fpath.name} \u2014 {lbl}  ({elapsed:.1f}s)"
             if sys.stdout.isatty():

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -70,7 +70,7 @@ def test_index_pdf_command_indexes_file(runner: CliRunner, index_home: Path) -> 
     pdf = index_home / "doc.pdf"
     pdf.write_bytes(b"fake pdf")
 
-    with patch("nexus.doc_indexer.index_pdf", return_value=3) as mock_index:
+    with patch("nexus.doc_indexer.index_pdf", return_value={"chunks": 3, "pages": [], "title": "", "author": ""}) as mock_index:
         result = runner.invoke(main, ["index", "pdf", str(pdf)])
 
     assert result.exit_code == 0, result.output
@@ -91,7 +91,7 @@ def test_index_md_command_indexes_file(runner: CliRunner, index_home: Path) -> N
     md = index_home / "doc.md"
     md.write_text("# Hello\n\nWorld.\n")
 
-    with patch("nexus.doc_indexer.index_markdown", return_value=2) as mock_index:
+    with patch("nexus.doc_indexer.index_markdown", return_value={"chunks": 2, "sections": 0}) as mock_index:
         result = runner.invoke(main, ["index", "md", str(md)])
 
     assert result.exit_code == 0, result.output
@@ -201,7 +201,7 @@ def test_index_pdf_force_flag(runner: CliRunner, index_home: Path) -> None:
     pdf = index_home / "doc.pdf"
     pdf.write_bytes(b"fake pdf")
 
-    with patch("nexus.doc_indexer.index_pdf", return_value=5) as mock_index:
+    with patch("nexus.doc_indexer.index_pdf", return_value={"chunks": 5, "pages": [], "title": "", "author": ""}) as mock_index:
         result = runner.invoke(main, ["index", "pdf", str(pdf), "--force"])
 
     assert result.exit_code == 0, result.output
@@ -226,7 +226,7 @@ def test_index_md_force_flag(runner: CliRunner, index_home: Path) -> None:
     md = index_home / "doc.md"
     md.write_text("# Hello\n\nWorld.\n")
 
-    with patch("nexus.doc_indexer.index_markdown", return_value=2) as mock_index:
+    with patch("nexus.doc_indexer.index_markdown", return_value={"chunks": 2, "sections": 0}) as mock_index:
         result = runner.invoke(main, ["index", "md", str(md), "--force"])
 
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

- All four `nx index` subcommands (repo, pdf, md, rdr) now emit per-file progress lines automatically when stdout is not a TTY
- Previously, the `--monitor` flag was required to see any per-file detail; running backgrounded or piped produced only start/done lines
- Fix: `if monitor:` → `if monitor or not sys.stdout.isatty():` in all four command handlers
- Updated `--monitor` help text: _"Auto-enabled when stdout is not a TTY."_

## Test plan

- [ ] Updated 4 mock return values in `test_index_cmd.py` from plain ints to metadata dicts (required since the metadata path is always taken in non-TTY test runner)
- [ ] `pytest tests/test_index_cmd.py` — 28 passed
- [ ] Full suite — 1859 passed, 8 skipped

Closes nexus-m7kc