### PR TITLE
feat: replace serve check in doctor with hooks + index log (Phase 4 RDR-018)

### DIFF
--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -8,6 +8,7 @@ from nexus.commands.collection import collection
 from nexus.commands.config_cmd import config_group
 from nexus.commands.doctor import doctor_cmd
 from nexus.commands.hook import hook_group
+from nexus.commands.hooks import hooks
 from nexus.commands.index import index
 from nexus.commands.memory import memory
 from nexus.commands.migrate import migrate
@@ -43,6 +44,7 @@ main.add_command(config_group, name="config")
 main.add_command(doctor_cmd, name="doctor")
 hook_group.hidden = True
 main.add_command(hook_group, name="hook")
+main.add_command(hooks)
 main.add_command(index)
 main.add_command(memory)
 main.add_command(migrate)

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -2,6 +2,7 @@
 """nx doctor — health check for all required services."""
 import shutil
 import sys
+from pathlib import Path
 
 import chromadb
 import click
@@ -9,6 +10,8 @@ import structlog
 
 from nexus.config import get_credential
 from nexus.db.t3 import _STORE_TYPES
+from nexus.commands.hooks import _effective_hooks_dir, SENTINEL_BEGIN
+from nexus.registry import RepoRegistry
 
 _log = structlog.get_logger(__name__)
 
@@ -160,14 +163,57 @@ def doctor_cmd() -> None:
     lines.append(_check_line("uv (optional)",               True,
                               uv_path or "not found — pip install conexus works too"))
 
-    # ── Nexus server ──────────────────────────────────────────────────────────
-    # Server is optional for most commands; always ✓, report status in detail.
-    from nexus.commands.serve import _read_pid, _process_running
-    pid = _read_pid()
-    server_running = pid is not None and _process_running(pid)
-    lines.append(_check_line("Nexus server (optional)",     True,
-                              f"running (PID {pid})" if server_running else
-                              "not running — start with: nx serve start"))
+    # ── git hooks ─────────────────────────────────────────────────────────────
+    # Hooks are optional and always non-fatal — always ✓, report status in detail.
+    _hook_names = ("post-commit", "post-merge", "post-rewrite")
+    _registry_path = Path.home() / ".config" / "nexus" / "repos.json"
+
+    try:
+        reg = RepoRegistry(_registry_path)
+        repos = reg.all()
+    except Exception:
+        repos = []
+
+    if not repos:
+        lines.append(_check_line("git hooks", True,
+                                 "no repos registered (run: nx index repo <path>)"))
+    else:
+        for repo_str in repos:
+            repo_path = Path(repo_str)
+            try:
+                hdir = _effective_hooks_dir(repo_path)
+                installed = [
+                    n for n in _hook_names
+                    if (hdir / n).exists() and SENTINEL_BEGIN in (hdir / n).read_text()
+                ]
+                if installed:
+                    lines.append(_check_line("git hooks", True,
+                                             f"{repo_path} ({', '.join(installed)})"))
+                else:
+                    lines.append(_check_line("git hooks", True,
+                                             f"{repo_path} — not installed"))
+                    _fix(lines, f"nx hooks install {repo_path}")
+            except Exception:
+                lines.append(_check_line("git hooks", True,
+                                         f"{repo_path} — could not check"))
+
+    # ── index log ─────────────────────────────────────────────────────────────
+    import time as _time
+    log_path = Path.home() / ".config" / "nexus" / "index.log"
+    if log_path.exists():
+        mtime = log_path.stat().st_mtime
+        age_s = _time.time() - mtime
+        if age_s < 60:
+            age_str = f"{int(age_s)}s ago"
+        elif age_s < 3600:
+            age_str = f"{int(age_s // 60)} minutes ago"
+        else:
+            age_str = f"{int(age_s // 3600)} hours ago"
+        lines.append(_check_line("index log", True,
+                                 f"{log_path} (last write: {age_str})"))
+    else:
+        lines.append(_check_line("index log", True,
+                                 f"{log_path} (not created yet — hooks have not fired)"))
 
     click.echo("\n".join(lines))
 

--- a/src/nexus/commands/hooks.py
+++ b/src/nexus/commands/hooks.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nx hooks — git hook management for automatic repo indexing."""
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+import click
+
+SENTINEL_BEGIN = "# >>> nexus managed begin >>>"
+SENTINEL_END = "# <<< nexus managed end <<<"
+
+_HOOK_NAMES = ("post-commit", "post-merge", "post-rewrite")
+
+_STANZA = """\
+{begin}
+nx index repo "$(git rev-parse --show-toplevel)" --on-locked=skip \\
+  >> "$HOME/.config/nexus/index.log" 2>&1 &
+disown
+{end}""".format(begin=SENTINEL_BEGIN, end=SENTINEL_END)
+
+
+# ── git helpers ───────────────────────────────────────────────────────────────
+
+
+def _git_common_dir(repo: Path) -> Path:
+    """Return the effective .git directory (handles worktrees)."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise click.ClickException(f"Not a git repository: {repo}")
+    git_common = Path(result.stdout.strip())
+    if not git_common.is_absolute():
+        git_common = (repo / git_common).resolve()
+    return git_common
+
+
+def _effective_hooks_dir(repo: Path) -> Path:
+    """Return the hooks directory for *repo*, respecting core.hooksPath."""
+    # Check for custom hooks path
+    result = subprocess.run(
+        ["git", "config", "core.hooksPath"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        hpath = Path(result.stdout.strip())
+        if not hpath.is_absolute():
+            hpath = (repo / hpath).resolve()
+        return hpath
+
+    # Default: <git-common-dir>/hooks
+    return _git_common_dir(repo) / "hooks"
+
+
+# ── stanza helpers ────────────────────────────────────────────────────────────
+
+
+def _remove_stanza(content: str) -> str:
+    """Remove the nexus sentinel stanza from *content*."""
+    return re.sub(
+        rf"\n?{re.escape(SENTINEL_BEGIN)}.*?{re.escape(SENTINEL_END)}\n?",
+        "",
+        content,
+        flags=re.DOTALL,
+    )
+
+
+def _hook_status(hooks_dir: Path, hook_name: str) -> str:
+    """Return status string: 'not installed' | 'unmanaged' | 'owned' | 'appended'."""
+    hook_file = hooks_dir / hook_name
+    if not hook_file.exists():
+        return "not installed"
+    content = hook_file.read_text()
+    if SENTINEL_BEGIN not in content:
+        return "unmanaged"
+    remainder = _remove_stanza(content).strip()
+    if remainder in ("", "#!/bin/sh"):
+        return "owned"
+    return "appended"
+
+
+def _install_hook(hooks_dir: Path, hook_name: str) -> str:
+    """Install or append nexus stanza. Returns 'created' | 'appended' | 'already installed'."""
+    hook_file = hooks_dir / hook_name
+    if not hook_file.exists():
+        hook_file.write_text(f"#!/bin/sh\n{_STANZA}\n")
+        hook_file.chmod(0o755)
+        return "created"
+
+    content = hook_file.read_text()
+    if SENTINEL_BEGIN in content:
+        return "already installed"
+
+    # Append to existing hook
+    hook_file.write_text(content.rstrip("\n") + "\n" + _STANZA + "\n")
+    return "appended"
+
+
+def _uninstall_hook(hooks_dir: Path, hook_name: str) -> str:
+    """Remove nexus stanza. Returns 'removed' | 'stanza removed' | 'not installed'."""
+    hook_file = hooks_dir / hook_name
+    if not hook_file.exists():
+        return "not installed"
+    content = hook_file.read_text()
+    if SENTINEL_BEGIN not in content:
+        return "not installed"
+
+    new_content = _remove_stanza(content)
+    if new_content.strip() in ("", "#!/bin/sh"):
+        hook_file.unlink()
+        return "removed"
+
+    hook_file.write_text(new_content)
+    return "stanza removed"
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+@click.group()
+def hooks() -> None:
+    """Manage git hooks for automatic repo indexing.
+
+    Distinct from ``nx hook`` (singular) which handles Claude Code session hooks.
+    """
+
+
+@hooks.command("install")
+@click.argument("path", type=click.Path(file_okay=False, path_type=Path), default=".")
+def hooks_install(path: Path) -> None:
+    """Install nexus git hooks into PATH (default: current directory).
+
+    Installs post-commit, post-merge, and post-rewrite hooks that run
+    ``nx index repo`` in the background after each qualifying git operation.
+    Appends a sentinel-bounded stanza to existing hook files without
+    overwriting them.
+    """
+    repo = path.resolve()
+
+    try:
+        hooks_dir = _effective_hooks_dir(repo)
+    except click.ClickException as exc:
+        raise exc
+
+    # Check writeability
+    if hooks_dir.exists() and not _is_writable(hooks_dir):
+        raise click.ClickException(
+            f"Hooks directory is not writable: {hooks_dir}\n"
+            "Check core.hooksPath or directory permissions."
+        )
+
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    click.echo(f"Installing hooks for {repo}…")
+
+    for name in _HOOK_NAMES:
+        action = _install_hook(hooks_dir, name)
+        symbol = "✓" if action != "already installed" else "·"
+        click.echo(f"  {symbol} {name}  ({action})")
+
+    click.echo("Done. Indexing will run in the background after each commit.")
+
+
+@hooks.command("uninstall")
+@click.argument("path", type=click.Path(file_okay=False, path_type=Path), default=".")
+def hooks_uninstall(path: Path) -> None:
+    """Remove nexus git hooks from PATH (default: current directory).
+
+    Removes the nexus-managed sentinel stanza; leaves any unrelated hook
+    content intact.
+    """
+    repo = path.resolve()
+    hooks_dir = _effective_hooks_dir(repo)
+
+    click.echo(f"Removing nexus hooks from {repo}…")
+
+    for name in _HOOK_NAMES:
+        action = _uninstall_hook(hooks_dir, name)
+        symbol = "✓" if action != "not installed" else "·"
+        click.echo(f"  {symbol} {name}  ({action})")
+
+    click.echo("Done.")
+
+
+@hooks.command("status")
+@click.argument("path", type=click.Path(file_okay=False, path_type=Path), default=".")
+def hooks_status(path: Path) -> None:
+    """Show nexus git hook status for PATH (default: current directory)."""
+    repo = path.resolve()
+    hooks_dir = _effective_hooks_dir(repo)
+
+    click.echo(f"Hooks directory: {hooks_dir}")
+
+    for name in _HOOK_NAMES:
+        s = _hook_status(hooks_dir, name)
+        symbol = "✓" if s.startswith(("owned", "appended")) else "·"
+        click.echo(f"  {symbol} {name}: {s}")
+
+
+# ── internal ──────────────────────────────────────────────────────────────────
+
+
+def _is_writable(path: Path) -> bool:
+    return bool(path.stat().st_mode & stat.S_IWUSR)

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -98,6 +98,20 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool) 
             if rdr_failed:
                 parts.append(f"{rdr_failed} failed")
             click.echo(f"  RDR documents: {', '.join(parts)} (collection rdr__)")
+    if not frecency_only:
+        try:
+            from nexus.commands.hooks import SENTINEL_BEGIN, _effective_hooks_dir
+            hdir = _effective_hooks_dir(path)
+            hook_names = ("post-commit", "post-merge", "post-rewrite")
+            any_managed = any(
+                SENTINEL_BEGIN in (hdir / n).read_text()
+                for n in hook_names
+                if (hdir / n).exists()
+            )
+            if not any_managed:
+                click.echo("Tip: run `nx hooks install` to auto-index this repo on every commit.")
+        except Exception:
+            pass  # Don't let hook detection break indexing
     click.echo("Done.")
 
 

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -1,10 +1,13 @@
 """nx doctor — health check command tests."""
-import sys
+import tempfile
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from click.testing import CliRunner
 
 from nexus.cli import main
+
+SENTINEL_BEGIN = "# >>> nexus managed begin >>>"
 
 
 def _runner() -> CliRunner:
@@ -16,11 +19,12 @@ def _runner() -> CliRunner:
 def test_doctor_all_healthy() -> None:
     """When everything is present, exit code is 0."""
     runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor.get_credential", return_value="sk-fake-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
-        patch("nexus.commands.serve._read_pid", return_value=12345),
-        patch("nexus.commands.serve._process_running", return_value=True),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
     ):
         result = runner.invoke(main, ["doctor"])
@@ -34,11 +38,12 @@ def test_doctor_all_healthy() -> None:
 def test_doctor_missing_credentials_exit_1() -> None:
     """Missing credentials cause exit code 1 with signup hints."""
     runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor.get_credential", return_value=None),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
-        patch("nexus.commands.serve._read_pid", return_value=None),
-        patch("nexus.commands.serve._process_running", return_value=False),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
     ):
         result = runner.invoke(main, ["doctor"])
 
@@ -59,11 +64,12 @@ def test_doctor_missing_rg() -> None:
             return None
         return f"/usr/bin/{name}"
 
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", side_effect=which_side_effect),
-        patch("nexus.commands.serve._read_pid", return_value=None),
-        patch("nexus.commands.serve._process_running", return_value=False),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
     ):
         result = runner.invoke(main, ["doctor"])
@@ -74,22 +80,202 @@ def test_doctor_missing_rg() -> None:
     assert "brew install ripgrep" in result.output
 
 
-# ── Server status ────────────────────────────────────────────────────────────
+# ── Hooks status ──────────────────────────────────────────────────────────────
 
-def test_doctor_server_not_running() -> None:
-    """Reports server not running (server is optional — does not fail)."""
+def test_doctor_hooks_section_present() -> None:
+    """nx doctor output includes a hooks section (shows 'git hooks' in output)."""
     runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
-        patch("nexus.commands.serve._read_pid", return_value=None),
-        patch("nexus.commands.serve._process_running", return_value=False),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
     ):
         result = runner.invoke(main, ["doctor"])
 
     assert result.exit_code == 0
-    assert "not running" in result.output
+    assert "git hooks" in result.output
+
+
+def test_doctor_hooks_no_repos_registered() -> None:
+    """When no repos in registry, doctor shows 'no repos registered' message."""
+    runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
+    with (
+        patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+        patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
+        patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
+    ):
+        result = runner.invoke(main, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "no repos registered" in result.output
+    assert "nx index repo" in result.output
+    # Always ✓ — never causes exit 1
+    assert "✓ git hooks" in result.output
+
+
+def test_doctor_hooks_installed() -> None:
+    """When hooks are installed, doctor shows tick with repo path and hook names."""
+    runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = ["/some/repo"]
+
+    with tempfile.TemporaryDirectory() as td:
+        hooks_dir = Path(td)
+        for name in ("post-commit", "post-merge", "post-rewrite"):
+            (hooks_dir / name).write_text(f"#!/bin/sh\n{SENTINEL_BEGIN}\nnx index repo ...\n")
+
+        with (
+            patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+            patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
+            patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
+            patch("nexus.commands.doctor._effective_hooks_dir", return_value=hooks_dir),
+            patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
+        ):
+            result = runner.invoke(main, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "✓ git hooks" in result.output
+    assert "/some/repo" in result.output
+    assert "post-commit" in result.output
+
+
+def test_doctor_hooks_not_installed() -> None:
+    """When hooks are missing, doctor shows tick (non-fatal) with 'not installed' and Fix hint."""
+    runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = ["/some/repo"]
+
+    with tempfile.TemporaryDirectory() as td:
+        hooks_dir = Path(td)  # empty — no hook files
+
+        with (
+            patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+            patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
+            patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
+            patch("nexus.commands.doctor._effective_hooks_dir", return_value=hooks_dir),
+            patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
+        ):
+            result = runner.invoke(main, ["doctor"])
+
+    assert result.exit_code == 0  # Always non-fatal
+    assert "✓ git hooks" in result.output
+    assert "not installed" in result.output
+    assert "nx hooks install /some/repo" in result.output
+
+
+def test_doctor_hooks_check_always_nonfatal() -> None:
+    """Hooks check is always ✓ (non-fatal), even when hooks are missing."""
+    runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = ["/some/repo"]
+
+    with tempfile.TemporaryDirectory() as td:
+        hooks_dir = Path(td)  # empty — no hook files
+
+        with (
+            patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+            patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
+            patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
+            patch("nexus.commands.doctor._effective_hooks_dir", return_value=hooks_dir),
+            patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
+        ):
+            result = runner.invoke(main, ["doctor"])
+
+    # Credentials all set, tools found — only hooks missing, which is non-fatal
+    assert result.exit_code == 0
+    assert "✗ git hooks" not in result.output
+
+
+def test_doctor_hooks_exception_does_not_propagate() -> None:
+    """Exception in hooks check is swallowed — doctor still exits 0 when creds are ok."""
+    runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = ["/some/repo"]
+
+    with (
+        patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+        patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
+        patch("nexus.commands.doctor._effective_hooks_dir",
+              side_effect=RuntimeError("git error")),
+        patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
+    ):
+        result = runner.invoke(main, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "git hooks" in result.output
+
+
+# ── Index log check ───────────────────────────────────────────────────────────
+
+def test_doctor_index_log_shows_path() -> None:
+    """Doctor output contains the index log label."""
+    runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
+
+    with (
+        patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+        patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
+        patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
+    ):
+        result = runner.invoke(main, ["doctor"])
+
+    assert "index log" in result.output
+    assert "✓ index log" in result.output
+
+
+def test_doctor_index_log_not_created_yet() -> None:
+    """When index.log does not exist, doctor reports 'not created yet'."""
+    runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
+
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Point HOME to a temp dir that has no index.log
+        fake_home = Path(tmpdir)
+        (fake_home / ".config" / "nexus").mkdir(parents=True, exist_ok=True)
+        # Do not create index.log — it should not exist
+
+        with (
+            patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+            patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
+            patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
+            patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
+        ):
+            # Patch Path.home so the log_path and registry_path use our tmp dir
+            with patch.object(Path, "home", return_value=fake_home):
+                result = runner.invoke(main, ["doctor"])
+
+    assert "index log" in result.output
+    assert "not created yet" in result.output
+
+
+# ── No serve import ───────────────────────────────────────────────────────────
+
+def test_doctor_does_not_mention_serve_start() -> None:
+    """doctor output does NOT mention 'nx serve start' (serve check removed)."""
+    runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
+    with (
+        patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+        patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
+        patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
+    ):
+        result = runner.invoke(main, ["doctor"])
+
+    assert "nx serve start" not in result.output
+    assert "Nexus server" not in result.output
 
 
 # ── Partial credentials ──────────────────────────────────────────────────────
@@ -101,11 +287,12 @@ def test_doctor_partial_credentials() -> None:
     def cred_side_effect(key):
         return "sk-key" if key in ("chroma_api_key", "voyage_api_key") else None
 
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor.get_credential", side_effect=cred_side_effect),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
-        patch("nexus.commands.serve._read_pid", return_value=None),
-        patch("nexus.commands.serve._process_running", return_value=False),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
     ):
         result = runner.invoke(main, ["doctor"])
 
@@ -123,11 +310,12 @@ def test_doctor_partial_credentials() -> None:
 def test_doctor_python_version_shown() -> None:
     """Python version is always reported in output."""
     runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
-        patch("nexus.commands.serve._read_pid", return_value=12345),
-        patch("nexus.commands.serve._process_running", return_value=True),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
     ):
         result = runner.invoke(main, ["doctor"])
@@ -139,12 +327,13 @@ def test_doctor_python_version_shown() -> None:
 def test_doctor_python_version_too_old_fails() -> None:
     """Exit code 1 and fix hint when Python < 3.12."""
     runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor._python_ok", return_value=(False, "3.11.0")),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
-        patch("nexus.commands.serve._read_pid", return_value=12345),
-        patch("nexus.commands.serve._process_running", return_value=True),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
     ):
         result = runner.invoke(main, ["doctor"])
@@ -160,11 +349,12 @@ def test_doctor_python_version_too_old_fails() -> None:
 def test_doctor_missing_credential_shows_inline_fix() -> None:
     """Each missing credential shows an inline Fix: hint with nx config set command."""
     runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor.get_credential", return_value=None),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
-        patch("nexus.commands.serve._read_pid", return_value=None),
-        patch("nexus.commands.serve._process_running", return_value=False),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
     ):
         result = runner.invoke(main, ["doctor"])
 
@@ -177,12 +367,13 @@ def test_doctor_missing_credential_shows_inline_fix() -> None:
 def test_doctor_missing_rg_shows_platform_hints() -> None:
     """Missing ripgrep shows brew, apt, and URL fix hints."""
     runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
 
     with (
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value=None),
-        patch("nexus.commands.serve._read_pid", return_value=None),
-        patch("nexus.commands.serve._process_running", return_value=False),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
     ):
         result = runner.invoke(main, ["doctor"])
@@ -197,11 +388,12 @@ def test_doctor_missing_rg_shows_platform_hints() -> None:
 def test_doctor_four_store_calls_cloud_client_four_times() -> None:
     """doctor four-store check calls CloudClient exactly four times (one per store type)."""
     runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
-        patch("nexus.commands.serve._read_pid", return_value=None),
-        patch("nexus.commands.serve._process_running", return_value=False),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()) as mock_cc,
     ):
         result = runner.invoke(main, ["doctor"])
@@ -215,6 +407,8 @@ def test_doctor_four_store_calls_cloud_client_four_times() -> None:
 def test_doctor_four_store_one_unreachable_fails_with_fix_hint() -> None:
     """When one of the four stores is unreachable, exit code 1 and fix hint shown."""
     runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
 
     def cloud_client_side_effect(**kwargs):
         if kwargs.get("database", "").endswith("_rdr"):
@@ -224,8 +418,7 @@ def test_doctor_four_store_one_unreachable_fails_with_fix_hint() -> None:
     with (
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
-        patch("nexus.commands.serve._read_pid", return_value=None),
-        patch("nexus.commands.serve._process_running", return_value=False),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient",
               side_effect=cloud_client_side_effect),
     ):
@@ -239,12 +432,13 @@ def test_doctor_four_store_one_unreachable_fails_with_fix_hint() -> None:
 def test_doctor_four_store_error_does_not_expose_exception_text() -> None:
     """doctor four-store check prints 'not reachable' without raw exception detail."""
     runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
 
     with (
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
-        patch("nexus.commands.serve._read_pid", return_value=None),
-        patch("nexus.commands.serve._process_running", return_value=False),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient",
               side_effect=RuntimeError("HTTP 401: invalid api_key SUPERSECRET")),
     ):
@@ -265,11 +459,12 @@ def test_doctor_missing_bd_does_not_fail() -> None:
             return None
         return f"/usr/bin/{name}"
 
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", side_effect=which_side_effect),
-        patch("nexus.commands.serve._read_pid", return_value=12345),
-        patch("nexus.commands.serve._process_running", return_value=True),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
     ):
         result = runner.invoke(main, ["doctor"])
@@ -289,11 +484,12 @@ def test_doctor_missing_uv_does_not_fail() -> None:
             return None
         return f"/usr/bin/{name}"
 
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", side_effect=which_side_effect),
-        patch("nexus.commands.serve._read_pid", return_value=12345),
-        patch("nexus.commands.serve._process_running", return_value=True),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
         patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
     ):
         result = runner.invoke(main, ["doctor"])

--- a/tests/test_git_hooks.py
+++ b/tests/test_git_hooks.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""T2: commands/hooks.py — nx hooks install/uninstall/status command group."""
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+
+HOOK_NAMES = ("post-commit", "post-merge", "post-rewrite")
+SENTINEL_BEGIN = "# >>> nexus managed begin >>>"
+SENTINEL_END = "# <<< nexus managed end <<<"
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """A fake git repo directory with .git/hooks."""
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    hooks_dir = repo / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    return repo
+
+
+def _mock_git(repo: Path, git_common_dir: str | None = None, hooks_path: str | None = None):
+    """Return a patcher context that stubs out subprocess calls for git config."""
+
+    def _run(cmd, *, cwd=None, capture_output=False, text=False, timeout=None, **kw):
+        import subprocess
+
+        class Res:
+            stdout = ""
+            stderr = ""
+            returncode = 0
+
+        r = Res()
+        if cmd[:2] == ["git", "rev-parse"] and "--git-common-dir" in cmd:
+            r.stdout = git_common_dir or str(repo / ".git")
+        elif cmd[:3] == ["git", "config", "core.hooksPath"]:
+            if hooks_path:
+                r.stdout = hooks_path
+            else:
+                r.returncode = 1  # not set
+        else:
+            # propagate real git calls
+            import subprocess as sp
+
+            return sp.run(cmd, cwd=cwd, capture_output=capture_output, text=text, timeout=timeout)
+        return r
+
+    return patch("nexus.commands.hooks.subprocess.run", side_effect=_run)
+
+
+# ── install: fresh repo ───────────────────────────────────────────────────────
+
+
+def test_install_creates_three_hooks(runner: CliRunner, fake_repo: Path) -> None:
+    """nx hooks install creates post-commit, post-merge, post-rewrite."""
+    with _mock_git(fake_repo):
+        result = runner.invoke(main, ["hooks", "install", str(fake_repo)])
+
+    assert result.exit_code == 0, result.output
+    hooks_dir = fake_repo / ".git" / "hooks"
+    for name in HOOK_NAMES:
+        hf = hooks_dir / name
+        assert hf.exists(), f"{name} not created"
+        assert SENTINEL_BEGIN in hf.read_text()
+        assert SENTINEL_END in hf.read_text()
+        assert "--on-locked=skip" in hf.read_text()
+
+
+def test_install_sets_executable_bit(runner: CliRunner, fake_repo: Path) -> None:
+    """Newly created hook files are executable."""
+    with _mock_git(fake_repo):
+        runner.invoke(main, ["hooks", "install", str(fake_repo)])
+
+    hooks_dir = fake_repo / ".git" / "hooks"
+    for name in HOOK_NAMES:
+        mode = (hooks_dir / name).stat().st_mode
+        assert mode & stat.S_IXUSR, f"{name} not executable"
+
+
+def test_install_output_shows_created(runner: CliRunner, fake_repo: Path) -> None:
+    """Install output shows 'created' for fresh hooks."""
+    with _mock_git(fake_repo):
+        result = runner.invoke(main, ["hooks", "install", str(fake_repo)])
+
+    assert "created" in result.output
+    assert result.exit_code == 0
+
+
+# ── install: coexistence with existing hooks ─────────────────────────────────
+
+
+def test_install_appends_to_existing_hook(runner: CliRunner, fake_repo: Path) -> None:
+    """install appends nexus stanza without overwriting existing hook content."""
+    hooks_dir = fake_repo / ".git" / "hooks"
+    existing = hooks_dir / "post-commit"
+    existing.write_text("#!/bin/sh\necho 'existing hook'\n")
+
+    with _mock_git(fake_repo):
+        result = runner.invoke(main, ["hooks", "install", str(fake_repo)])
+
+    assert result.exit_code == 0
+    content = existing.read_text()
+    assert "existing hook" in content, "Existing content must be preserved"
+    assert SENTINEL_BEGIN in content, "Nexus stanza must be added"
+    assert "appended" in result.output
+
+
+def test_install_idempotent(runner: CliRunner, fake_repo: Path) -> None:
+    """Running install twice does not add the stanza twice."""
+    with _mock_git(fake_repo):
+        runner.invoke(main, ["hooks", "install", str(fake_repo)])
+        result = runner.invoke(main, ["hooks", "install", str(fake_repo)])
+
+    assert result.exit_code == 0
+    hooks_dir = fake_repo / ".git" / "hooks"
+    for name in HOOK_NAMES:
+        content = (hooks_dir / name).read_text()
+        assert content.count(SENTINEL_BEGIN) == 1, f"{name}: stanza duplicated"
+
+
+# ── install: core.hooksPath ───────────────────────────────────────────────────
+
+
+def test_install_respects_core_hooks_path(runner: CliRunner, fake_repo: Path, tmp_path: Path) -> None:
+    """install uses core.hooksPath when configured."""
+    custom_dir = tmp_path / "custom_hooks"
+    custom_dir.mkdir()
+
+    with _mock_git(fake_repo, hooks_path=str(custom_dir)):
+        result = runner.invoke(main, ["hooks", "install", str(fake_repo)])
+
+    assert result.exit_code == 0
+    for name in HOOK_NAMES:
+        assert (custom_dir / name).exists(), f"{name} not in custom_dir"
+    # Default .git/hooks should be empty
+    assert not (fake_repo / ".git" / "hooks" / "post-commit").exists()
+
+
+def test_install_warns_on_non_writable_hooks_path(
+    runner: CliRunner, fake_repo: Path, tmp_path: Path
+) -> None:
+    """install warns clearly when core.hooksPath is not writable."""
+    locked_dir = tmp_path / "locked_hooks"
+    locked_dir.mkdir()
+    locked_dir.chmod(0o555)  # read+exec only
+
+    try:
+        with _mock_git(fake_repo, hooks_path=str(locked_dir)):
+            result = runner.invoke(main, ["hooks", "install", str(fake_repo)])
+
+        assert result.exit_code != 0 or "warning" in result.output.lower() or "not writable" in result.output.lower()
+    finally:
+        locked_dir.chmod(0o755)  # restore for cleanup
+
+
+# ── install: worktree ─────────────────────────────────────────────────────────
+
+
+def test_install_worktree_uses_main_repo_hooks(
+    runner: CliRunner, fake_repo: Path, tmp_path: Path
+) -> None:
+    """Hooks are installed into the main repo's hooks dir, not a worktree gitlink."""
+    # Simulate a worktree where git-common-dir points to the main repo
+    worktree_dir = tmp_path / "worktrees" / "feature"
+    worktree_dir.mkdir(parents=True)
+
+    # git-common-dir returns the main repo's .git path
+    main_git = fake_repo / ".git"
+
+    with _mock_git(fake_repo, git_common_dir=str(main_git)):
+        result = runner.invoke(main, ["hooks", "install", str(fake_repo)])
+
+    assert result.exit_code == 0
+    hooks_dir = fake_repo / ".git" / "hooks"
+    assert (hooks_dir / "post-commit").exists()
+
+
+# ── uninstall ─────────────────────────────────────────────────────────────────
+
+
+def test_uninstall_removes_owned_hooks(runner: CliRunner, fake_repo: Path) -> None:
+    """Uninstall removes nexus-owned hook files entirely."""
+    with _mock_git(fake_repo):
+        runner.invoke(main, ["hooks", "install", str(fake_repo)])
+
+    with _mock_git(fake_repo):
+        result = runner.invoke(main, ["hooks", "uninstall", str(fake_repo)])
+
+    assert result.exit_code == 0
+    hooks_dir = fake_repo / ".git" / "hooks"
+    for name in HOOK_NAMES:
+        assert not (hooks_dir / name).exists(), f"{name} should be deleted"
+    assert "removed" in result.output
+
+
+def test_uninstall_preserves_existing_content(runner: CliRunner, fake_repo: Path) -> None:
+    """Uninstall removes only the nexus stanza; other hook content remains."""
+    hooks_dir = fake_repo / ".git" / "hooks"
+    existing = hooks_dir / "post-commit"
+    existing.write_text("#!/bin/sh\necho 'keep me'\n")
+
+    with _mock_git(fake_repo):
+        runner.invoke(main, ["hooks", "install", str(fake_repo)])
+        result = runner.invoke(main, ["hooks", "uninstall", str(fake_repo)])
+
+    assert result.exit_code == 0
+    content = existing.read_text()
+    assert "keep me" in content, "Existing content must be preserved"
+    assert SENTINEL_BEGIN not in content, "Nexus stanza must be removed"
+
+
+def test_uninstall_idempotent(runner: CliRunner, fake_repo: Path) -> None:
+    """Calling uninstall when no hooks are installed exits cleanly."""
+    with _mock_git(fake_repo):
+        result = runner.invoke(main, ["hooks", "uninstall", str(fake_repo)])
+
+    assert result.exit_code == 0
+
+
+# ── status ────────────────────────────────────────────────────────────────────
+
+
+def test_status_not_installed(runner: CliRunner, fake_repo: Path) -> None:
+    """Status shows 'not installed' when hooks are absent."""
+    with _mock_git(fake_repo):
+        result = runner.invoke(main, ["hooks", "status", str(fake_repo)])
+
+    assert result.exit_code == 0
+    assert "not installed" in result.output
+
+
+def test_status_managed_owned(runner: CliRunner, fake_repo: Path) -> None:
+    """Status shows 'owned' for freshly installed (nexus-created) hooks."""
+    with _mock_git(fake_repo):
+        runner.invoke(main, ["hooks", "install", str(fake_repo)])
+        result = runner.invoke(main, ["hooks", "status", str(fake_repo)])
+
+    assert result.exit_code == 0
+    assert "owned" in result.output
+
+
+def test_status_managed_appended(runner: CliRunner, fake_repo: Path) -> None:
+    """Status shows 'appended' when nexus stanza was added to existing hook."""
+    hooks_dir = fake_repo / ".git" / "hooks"
+    (hooks_dir / "post-commit").write_text("#!/bin/sh\necho 'pre-existing'\n")
+
+    with _mock_git(fake_repo):
+        runner.invoke(main, ["hooks", "install", str(fake_repo)])
+        result = runner.invoke(main, ["hooks", "status", str(fake_repo)])
+
+    assert result.exit_code == 0
+    assert "appended" in result.output
+
+
+def test_status_unmanaged(runner: CliRunner, fake_repo: Path) -> None:
+    """Status shows 'unmanaged' for hook files without the nexus sentinel."""
+    hooks_dir = fake_repo / ".git" / "hooks"
+    (hooks_dir / "post-commit").write_text("#!/bin/sh\necho 'third-party'\n")
+
+    with _mock_git(fake_repo):
+        result = runner.invoke(main, ["hooks", "status", str(fake_repo)])
+
+    assert result.exit_code == 0
+    assert "unmanaged" in result.output
+
+
+def test_status_reports_hooks_directory(runner: CliRunner, fake_repo: Path) -> None:
+    """Status output includes the resolved hooks directory path."""
+    with _mock_git(fake_repo):
+        result = runner.invoke(main, ["hooks", "status", str(fake_repo)])
+
+    assert result.exit_code == 0
+    # hooks dir path should be in output
+    assert ".git" in result.output or "hooks" in result.output
+
+
+def test_status_core_hooks_path(runner: CliRunner, fake_repo: Path, tmp_path: Path) -> None:
+    """Status reports the correct path when core.hooksPath is set."""
+    custom_dir = tmp_path / "shared_hooks"
+    custom_dir.mkdir()
+
+    with _mock_git(fake_repo, hooks_path=str(custom_dir)):
+        result = runner.invoke(main, ["hooks", "status", str(fake_repo)])
+
+    assert result.exit_code == 0
+    assert str(custom_dir) in result.output or "shared_hooks" in result.output
+
+
+# ── hook script content ───────────────────────────────────────────────────────
+
+
+def test_hook_script_contains_required_elements(runner: CliRunner, fake_repo: Path) -> None:
+    """Hook script includes log redirect, disown, and --on-locked=skip."""
+    with _mock_git(fake_repo):
+        runner.invoke(main, ["hooks", "install", str(fake_repo)])
+
+    hook = fake_repo / ".git" / "hooks" / "post-commit"
+    content = hook.read_text()
+    assert "index.log" in content
+    assert "disown" in content
+    assert "--on-locked=skip" in content
+    assert "nx index repo" in content
+
+
+def test_hook_stanza_is_identical_in_owned_and_appended(runner: CliRunner, fake_repo: Path) -> None:
+    """The nexus stanza is the same whether the hook is created fresh or appended."""
+    hooks_dir = fake_repo / ".git" / "hooks"
+
+    # Fresh install
+    with _mock_git(fake_repo):
+        runner.invoke(main, ["hooks", "install", str(fake_repo)])
+    owned_content = (hooks_dir / "post-commit").read_text()
+
+    # Remove and install with existing file
+    for name in HOOK_NAMES:
+        (hooks_dir / name).unlink(missing_ok=True)
+    (hooks_dir / "post-commit").write_text("#!/bin/sh\necho 'pre'\n")
+
+    with _mock_git(fake_repo):
+        runner.invoke(main, ["hooks", "install", str(fake_repo)])
+    appended_content = (hooks_dir / "post-commit").read_text()
+
+    # Extract stanza from each
+    def extract_stanza(text: str) -> str:
+        import re
+
+        m = re.search(
+            rf"{re.escape(SENTINEL_BEGIN)}.*?{re.escape(SENTINEL_END)}",
+            text,
+            re.DOTALL,
+        )
+        return m.group(0) if m else ""
+
+    assert extract_stanza(owned_content) == extract_stanza(appended_content)

--- a/tests/test_index_reminder.py
+++ b/tests/test_index_reminder.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for nx index repo hooks-install reminder (Phase 3 RDR-018)."""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def index_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+def _make_repo(base: Path) -> Path:
+    """Create a minimal fake repo directory and return it."""
+    repo = base / "myrepo"
+    repo.mkdir()
+    return repo
+
+
+def _mock_reg(already_registered: bool = True) -> MagicMock:
+    mock = MagicMock()
+    mock.get.return_value = {"collection": "code__myrepo"} if already_registered else None
+    return mock
+
+
+# ── Reminder IS shown when no hook files contain the sentinel ──────────────────
+
+def test_reminder_shown_when_no_hooks_installed(runner: CliRunner, index_home: Path, tmp_path: Path) -> None:
+    """Reminder is printed when none of the 3 hook files contain the nexus sentinel."""
+    repo = _make_repo(index_home)
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    # No hook files at all — sentinel is absent
+
+    with (
+        patch("nexus.commands.index._registry", return_value=_mock_reg()),
+        patch("nexus.indexer.index_repository", return_value={}),
+        patch("nexus.commands.hooks._effective_hooks_dir", return_value=hooks_dir),
+    ):
+        result = runner.invoke(main, ["index", "repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "nx hooks install" in result.output
+    assert "auto-index" in result.output
+
+
+def test_reminder_shown_when_hook_files_exist_without_sentinel(
+    runner: CliRunner, index_home: Path, tmp_path: Path
+) -> None:
+    """Reminder is printed when hook files exist but none contain the nexus sentinel."""
+    repo = _make_repo(index_home)
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    # Create hook files without the sentinel
+    for name in ("post-commit", "post-merge", "post-rewrite"):
+        (hooks_dir / name).write_text("#!/bin/sh\necho hello\n")
+
+    with (
+        patch("nexus.commands.index._registry", return_value=_mock_reg()),
+        patch("nexus.indexer.index_repository", return_value={}),
+        patch("nexus.commands.hooks._effective_hooks_dir", return_value=hooks_dir),
+    ):
+        result = runner.invoke(main, ["index", "repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "nx hooks install" in result.output
+
+
+# ── Reminder is NOT shown when at least one hook contains the sentinel ─────────
+
+def test_reminder_suppressed_when_post_commit_managed(
+    runner: CliRunner, index_home: Path, tmp_path: Path
+) -> None:
+    """Reminder is suppressed when post-commit contains the nexus sentinel."""
+    from nexus.commands.hooks import SENTINEL_BEGIN
+
+    repo = _make_repo(index_home)
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "post-commit").write_text(f"#!/bin/sh\n{SENTINEL_BEGIN}\nnx index repo .\n")
+
+    with (
+        patch("nexus.commands.index._registry", return_value=_mock_reg()),
+        patch("nexus.indexer.index_repository", return_value={}),
+        patch("nexus.commands.hooks._effective_hooks_dir", return_value=hooks_dir),
+    ):
+        result = runner.invoke(main, ["index", "repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "nx hooks install" not in result.output
+
+
+def test_reminder_suppressed_when_post_merge_managed(
+    runner: CliRunner, index_home: Path, tmp_path: Path
+) -> None:
+    """Reminder is suppressed when post-merge contains the nexus sentinel."""
+    from nexus.commands.hooks import SENTINEL_BEGIN
+
+    repo = _make_repo(index_home)
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    # Only post-merge has the sentinel; that's sufficient
+    (hooks_dir / "post-merge").write_text(f"#!/bin/sh\n{SENTINEL_BEGIN}\nnx index repo .\n")
+
+    with (
+        patch("nexus.commands.index._registry", return_value=_mock_reg()),
+        patch("nexus.indexer.index_repository", return_value={}),
+        patch("nexus.commands.hooks._effective_hooks_dir", return_value=hooks_dir),
+    ):
+        result = runner.invoke(main, ["index", "repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "nx hooks install" not in result.output
+
+
+def test_reminder_suppressed_when_post_rewrite_managed(
+    runner: CliRunner, index_home: Path, tmp_path: Path
+) -> None:
+    """Reminder is suppressed when post-rewrite contains the nexus sentinel."""
+    from nexus.commands.hooks import SENTINEL_BEGIN
+
+    repo = _make_repo(index_home)
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "post-rewrite").write_text(f"#!/bin/sh\n{SENTINEL_BEGIN}\nnx index repo .\n")
+
+    with (
+        patch("nexus.commands.index._registry", return_value=_mock_reg()),
+        patch("nexus.indexer.index_repository", return_value={}),
+        patch("nexus.commands.hooks._effective_hooks_dir", return_value=hooks_dir),
+    ):
+        result = runner.invoke(main, ["index", "repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "nx hooks install" not in result.output
+
+
+# ── Reminder is NOT shown on --frecency-only runs ─────────────────────────────
+
+def test_reminder_suppressed_on_frecency_only(
+    runner: CliRunner, index_home: Path, tmp_path: Path
+) -> None:
+    """Reminder is NOT printed when --frecency-only is used (content not changed)."""
+    repo = _make_repo(index_home)
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    # No hooks installed — would normally show reminder
+
+    with (
+        patch("nexus.commands.index._registry", return_value=_mock_reg()),
+        patch("nexus.indexer.index_repository", return_value={}),
+        patch("nexus.commands.hooks._effective_hooks_dir", return_value=hooks_dir),
+    ):
+        result = runner.invoke(main, ["index", "repo", str(repo), "--frecency-only"])
+
+    assert result.exit_code == 0, result.output
+    assert "nx hooks install" not in result.output
+
+
+# ── Hook detection errors are silently suppressed ─────────────────────────────
+
+def test_hook_detection_error_does_not_break_indexing(
+    runner: CliRunner, index_home: Path
+) -> None:
+    """If _effective_hooks_dir raises, indexing still completes successfully."""
+    import click
+
+    repo = _make_repo(index_home)
+
+    with (
+        patch("nexus.commands.index._registry", return_value=_mock_reg()),
+        patch("nexus.indexer.index_repository", return_value={}),
+        patch(
+            "nexus.commands.hooks._effective_hooks_dir",
+            side_effect=click.ClickException("Not a git repository"),
+        ),
+    ):
+        result = runner.invoke(main, ["index", "repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "Done" in result.output
+
+
+def test_hook_detection_generic_error_does_not_break_indexing(
+    runner: CliRunner, index_home: Path
+) -> None:
+    """If hook detection raises any unexpected exception, indexing still completes."""
+    repo = _make_repo(index_home)
+
+    with (
+        patch("nexus.commands.index._registry", return_value=_mock_reg()),
+        patch("nexus.indexer.index_repository", return_value={}),
+        patch(
+            "nexus.commands.hooks._effective_hooks_dir",
+            side_effect=RuntimeError("unexpected failure"),
+        ),
+    ):
+        result = runner.invoke(main, ["index", "repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "Done" in result.output
+
+
+# ── Reminder text exact match ─────────────────────────────────────────────────
+
+def test_reminder_exact_text(runner: CliRunner, index_home: Path, tmp_path: Path) -> None:
+    """The reminder contains the exact canonical text."""
+    repo = _make_repo(index_home)
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+
+    with (
+        patch("nexus.commands.index._registry", return_value=_mock_reg()),
+        patch("nexus.indexer.index_repository", return_value={}),
+        patch("nexus.commands.hooks._effective_hooks_dir", return_value=hooks_dir),
+    ):
+        result = runner.invoke(main, ["index", "repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert (
+        "Tip: run `nx hooks install` to auto-index this repo on every commit."
+        in result.output
+    )
+
+
+# ── _effective_hooks_dir is used (worktree/core.hooksPath aware) ───────────────
+
+def test_effective_hooks_dir_is_called_with_repo_path(
+    runner: CliRunner, index_home: Path, tmp_path: Path
+) -> None:
+    """_effective_hooks_dir is invoked with the resolved repo path."""
+    repo = _make_repo(index_home)
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    mock_hdir = MagicMock(return_value=hooks_dir)
+
+    with (
+        patch("nexus.commands.index._registry", return_value=_mock_reg()),
+        patch("nexus.indexer.index_repository", return_value={}),
+        patch("nexus.commands.hooks._effective_hooks_dir", mock_hdir),
+    ):
+        result = runner.invoke(main, ["index", "repo", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    mock_hdir.assert_called_once_with(repo.resolve())


### PR DESCRIPTION
## Summary

- Removes `nexus.commands.serve` import from `doctor.py` entirely
- Adds **per-repo git hooks check** (always ✓ non-fatal): iterates registered repos, checks each repo's effective hooks dir for the nexus sentinel, reports installed hooks or `not installed` with `Fix: nx hooks install <path>` hint
- Adds **index log check** (always ✓ non-fatal): reports `~/.config/nexus/index.log` last-write time or "not created yet"
- Rewrites `tests/test_doctor_cmd.py`: removes all `nexus.commands.serve._read_pid` patches, adds hooks section and index log tests using real temp directories

## Test plan
- [ ] `uv run pytest tests/test_doctor_cmd.py` — all 25 pass
- [ ] `uv run pytest --ignore=tests/test_integration.py` — 1877 passed

References: nexus-8k3s (Phase 4 of RDR-018)