### PR TITLE
docs: replace nx serve with nx hooks across all docs (Phase 6 RDR-018)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ Data flows upward (T1 → T2 → T3).
 | **Storage** | `db/t1.py`, `db/t2.py`, `db/t3.py` | Tier implementations |
 | **Indexing** | `indexer.py`, `classifier.py`, `chunker.py`, `md_chunker.py`, `doc_indexer.py`, `pdf_extractor.py`, `pdf_chunker.py` | Repo indexing pipeline |
 | **Search** | `search_engine.py`, `scoring.py`, `frecency.py`, `ripgrep_cache.py` | Query, rank, rerank |
-| **Server** | `server.py`, `server_main.py`, `polling.py` | Daemon, HEAD polling, auto-reindex |
+| **Hooks** | `commands/hooks.py` | Git hook install/uninstall/status, sentinel-bounded stanza management |
 | **Support** | `config.py`, `registry.py`, `corpus.py`, `session.py`, `hooks.py`, `ttl.py`, `formatters.py`, `types.py`, `errors.py` | Configuration, naming, formatting, session lifecycle |
 
 ## Design Decisions

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -191,26 +191,23 @@ nx collection list
 
 ---
 
-## nx serve
+## nx hooks
 
-Background daemon for indexing and search.
+Git hook management for automatic repo indexing.
 
 ```
-nx serve start
+nx hooks install [PATH]
 ```
 
 | Subcommand | Description |
 |------------|-------------|
-| `start` | Start background daemon |
-| `stop` | Stop daemon |
-| `status` | Uptime and per-repo indexing state |
-| `logs` | Recent server log output (last 20 lines by default) |
+| `install [PATH]` | Install `post-commit`, `post-merge`, `post-rewrite` hooks (default: `.`) |
+| `uninstall [PATH]` | Remove nexus hook stanza; leaves other hook content intact |
+| `status [PATH]` | Show hook status for each hook file |
 
-**`logs` flags:**
+Hooks run `nx index repo` in the background after each qualifying git operation, appending output to `~/.config/nexus/index.log`. If a hook file already exists, the nexus stanza is appended (sentinel-bounded) without overwriting existing content.
 
-| Flag | Description |
-|------|-------------|
-| `-n` / `--lines NUM` | Number of log lines to show (default: 20) |
+**Hook status values:** `not installed` · `owned` (nexus-created) · `appended` (added to existing hook) · `unmanaged` (no nexus sentinel)
 
 ---
 
@@ -278,4 +275,4 @@ Health check for all dependencies.
 nx doctor
 ```
 
-Checks: ChromaDB API key, ChromaDB tenant, all four T3 databases (`{base}_code`, `{base}_docs`, `{base}_rdr`, `{base}_knowledge`), Voyage AI key, ripgrep binary, git binary, Nexus server.
+Checks: ChromaDB API key, ChromaDB tenant, all four T3 databases (`{base}_code`, `{base}_docs`, `{base}_rdr`, `{base}_knowledge`), Voyage AI key, ripgrep binary, git binary, git hooks status for registered repos, index log last-write time.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,8 +28,6 @@ Set via `nx config init` (wizard) or `nx config set KEY VALUE`. Stored in `~/.co
 
 | YAML path | Env var | Default | Description |
 |---|---|---|---|
-| `server.port` | `NX_SERVER_PORT` | `7890` | HTTP port for `nx serve` |
-| `server.headPollInterval` | `NX_SERVER_HEAD_POLL_INTERVAL` | `10` | Seconds between HEAD checks per repo |
 | `embeddings.rerankerModel` | `NX_EMBEDDINGS_RERANKER_MODEL` | `rerank-2.5` | Voyage reranker for multi-corpus merge |
 | `client.host` | `NX_CLIENT_HOST` | `localhost` | Override ChromaDB host URL |
 
@@ -55,8 +53,7 @@ Merge behavior: nested dict keys are **additive** (both global and per-repo keys
 |---|---|
 | `~/.config/nexus/config.yml` | Global config and credentials |
 | `~/.config/nexus/memory.db` | T2 SQLite database |
-| `~/.config/nexus/repos.json` | Registered repos for `nx serve` |
+| `~/.config/nexus/repos.json` | Registered repos (`nx index repo` writes here) |
 | `~/.config/nexus/sessions/` | JSON session records (T1 server address, session ID, `created_at`, `tmpdir`) + `session.lock` |
-| `~/.config/nexus/server.pid` | Server PID file |
-| `~/.config/nexus/serve.log` | Server log output |
+| `~/.config/nexus/index.log` | Background indexing log (written by git hooks) |
 | `.nexus.yml` | Per-repo config overrides |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,6 +6,8 @@
 git clone https://github.com/Hellblazer/nexus.git
 cd nexus
 uv sync
+uv tool install .
+nx hooks install    # auto-index this repo on every commit
 ```
 
 ## Running Tests

--- a/docs/repo-indexing.md
+++ b/docs/repo-indexing.md
@@ -186,8 +186,8 @@ moves it from code to prose, or a previously-PROSE extension is now SKIP), the
 misclassification pruner deletes chunks from the old collection. Previously-indexed
 SKIP files are cleaned automatically on the next `nx index repo` run.
 
-HEAD polling via `nx serve` monitors registered repositories and triggers automatic
-re-indexing when `git rev-parse HEAD` changes.
+Git hooks (`post-commit`, `post-merge`, `post-rewrite`) trigger automatic re-indexing
+in the background after each qualifying git operation. Install them with `nx hooks install`.
 
 ## Searching Indexed Repos
 


### PR DESCRIPTION
## Summary

- `cli-reference.md`: replace `## nx serve` section with `## nx hooks` section (install/uninstall/status)
- `cli-reference.md`: update `nx doctor` description to mention hooks + index log checks
- `repo-indexing.md`: replace HEAD polling sentence with git hooks explanation
- `architecture.md`: replace `Server` module row with `Hooks` row
- `configuration.md`: remove `server.port` and `server.headPollInterval` from settings table; update File Locations
- `contributing.md`: add `nx hooks install` to development setup steps

## Test plan

- [x] `uv run pytest --ignore=tests/test_integration.py -q` → 1805 passed, 8 skipped
- [x] No stale `nx serve`/`server.port`/`polling` refs in user-facing docs

Closes nexus-4y7u (Phase 6 RDR-018)