### PR TITLE
docs(rdr): close RDR-001, 002, 017, 018 as implemented

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -15,8 +15,8 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 
 | ID | Title | Type | Status | Created |
 | -- | ----- | ---- | ------ | ------- |
-| [RDR-001](rdr-001-rdr-process-validation.md) | RDR Process Validation | Architecture | Accepted | 2026-02-27 |
-| [RDR-002](rdr-002-t2-status-synchronization.md) | T2 Status Synchronization | Technical Debt | Accepted | 2026-02-27 |
+| [RDR-001](rdr-001-rdr-process-validation.md) | RDR Process Validation | Architecture | Implemented | 2026-02-27 |
+| [RDR-002](rdr-002-t2-status-synchronization.md) | T2 Status Synchronization | Technical Debt | Implemented | 2026-02-27 |
 | [RDR-004](rdr-004-four-store-architecture.md) | Four-Store T3 Architecture | Architecture | Closed | 2026-02-28 |
 | [RDR-005](rdr-005-chromadb-cloud-quota-enforcement.md) | ChromaDB Cloud Quota Enforcement | Architecture | Closed | 2026-02-28 |
 | [RDR-006](rdr-006-chunk-size-configuration.md) | File-Size Scoring Penalty for Code Search | Feature | Closed | 2026-02-28 |
@@ -30,8 +30,8 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-014](rdr-014-knowledge-base-retrieval-quality.md) | Knowledge Base Retrieval Quality: Code Context and Docs Deduplication | Bug | Closed | 2026-03-02 |
 | [RDR-015](rdr-015-indexing-pipeline-rethink.md) | Indexing Pipeline Rethink: Align Nexus with Arcaneum's Battle-Tested Implementation | Enhancement | Closed | 2026-03-02 |
 | [RDR-016](rdr-016-ast-chunk-line-range-bug.md) | AST Chunk Line Range Bug: CodeSplitter Returns Empty Metadata, Breaking Context Prefix | Bug | Closed | 2026-03-03 |
-| [RDR-017](rdr-017-indexing-progress-reporting.md) | Indexing Progress Reporting: tqdm-Based Progress Bar for nx index | Enhancement | Accepted | 2026-03-03 |
-| [RDR-018](rdr-018-replace-serve-with-git-hooks.md) | Replace nx serve Polling Server with Git Hooks | Refactor | Accepted | 2026-03-03 |
+| [RDR-017](rdr-017-indexing-progress-reporting.md) | Indexing Progress Reporting: tqdm-Based Progress Bar for nx index | Enhancement | Implemented | 2026-03-03 |
+| [RDR-018](rdr-018-replace-serve-with-git-hooks.md) | Replace nx serve Polling Server with Git Hooks | Refactor | Implemented | 2026-03-03 |
 
 ## RDR Process Documentation
 

--- a/docs/rdr/post-mortem/001-rdr-process-validation.md
+++ b/docs/rdr/post-mortem/001-rdr-process-validation.md
@@ -1,0 +1,44 @@
+---
+rdr: RDR-001
+title: "RDR Process Validation"
+closed_date: 2026-03-04
+close_reason: implemented
+---
+
+# Post-Mortem: RDR-001 — RDR Process Validation
+
+## RDR Summary
+
+Evaluated the RDR process across three pilot RDRs, identified seven improvements (P1–P7), and proposed specific fixes for enforcement gaps, template gaps, and status model ambiguity.
+
+## Implementation Status
+
+All seven improvements (P1–P7) implemented across the plugin and documentation layers.
+
+## Implementation vs. Plan
+
+| Item | Planned | Delivered | Drift |
+|------|---------|-----------|-------|
+| P1: Hard-block close without accepted/final | `rdr-close` checks status, blocks non-accepted | ✓ Implemented with `--force` override | None |
+| P2: Research findings discoverability | `rdr-gate` prints prompt if no T2 research findings | ✓ Layer 1 check added to gate output | None |
+| P3: Test Plan section in template | Add `## Test Plan` to `TEMPLATE.md` | ✓ Added to `resources/rdr/TEMPLATE.md` | None |
+| P4: `reviewed-by` field + YAML frontmatter | Standardize on YAML frontmatter | ✓ `reviewed-by` in all new RDRs | None |
+| P5: Define status model | BLOCKED/PASSED outcomes; Draft/Accepted/Implemented terminal states | ✓ Documented in `rdr-workflow.md` | None |
+| P6: Gate findings to Revision History | Move findings to `## Revision History` appendix | ✓ Convention established | None |
+| P7: Cross-RDR consistency check | Layer 3 checks `related_issues` for contradictions | ✓ Implemented in `rdr-gate` prompt | None |
+
+## Drift Classification
+
+No significant drift. All items implemented as designed.
+
+## RDR Quality Assessment
+
+- Gate caught: multiple critical issues including layer attribution errors, plan/design contradictions, inaccurate evidence tables
+- All critical issues resolved before acceptance
+- The process worked exactly as the RDR itself hypothesized it would
+
+## Key Takeaways
+
+- The RDR process is self-validating: writing an RDR about the RDR process and running it through the gate caught real issues
+- P2 (research discoverability) was the highest-leverage fix: the gate now surfaces a reminder when no research findings exist
+- The T2-primary architecture (gate results in T2, file as secondary) proved valuable during implementation

--- a/docs/rdr/post-mortem/002-t2-status-synchronization.md
+++ b/docs/rdr/post-mortem/002-t2-status-synchronization.md
@@ -1,0 +1,41 @@
+---
+rdr: RDR-002
+title: "T2 Status Synchronization"
+closed_date: 2026-03-04
+close_reason: implemented
+---
+
+# Post-Mortem: RDR-002 — T2 Status Synchronization
+
+## RDR Summary
+
+Identified that the RDR lifecycle had no authoritative process store — file frontmatter and T2 memory could silently diverge. Introduced T2-primary architecture: T2 is updated first on every state transition; file frontmatter follows T2.
+
+## Implementation Status
+
+All components implemented: `/rdr-accept` command, gate result storage in T2, `/rdr-list` T2-primary read, and `SessionStart` reconciliation.
+
+## Implementation vs. Plan
+
+| Item | Planned | Delivered | Drift |
+|------|---------|-----------|-------|
+| `/rdr-accept` command | New skill that verifies T2 gate result before accepting | ✓ Implemented with idempotency and self-healing checks | None |
+| Gate result in T2 | `nx memory put ... --title {id}-gate-latest` after every gate | ✓ Stored on every gate run | None |
+| `/rdr-list` T2-primary | Read from T2 first, file fallback | ✓ T2 batch API used; file fallback retained | None |
+| SessionStart reconciliation | Compare T2 status vs file status; surface mismatches | ✓ Self-healing detection in `rdr-accept` | Reconciliation is opportunistic on accept, not a full scan |
+
+## Drift Classification
+
+Minor: Full SessionStart scan across all RDRs was scoped down to opportunistic self-healing on `/rdr-accept`. Acceptable trade-off — full scans are expensive and the divergence window is narrow.
+
+## RDR Quality Assessment
+
+- Gate caught issues with idempotency edge cases and self-healing direction ambiguity
+- T2-primary architecture proved solid in practice — gate results are queryable and auditable
+- The "file as secondary" principle means the file can always be regenerated from T2
+
+## Key Takeaways
+
+- T2-primary is the right call: process state (accepted, blocked, gate results) belongs in a queryable store, not free-form YAML
+- Idempotency checks (both agree → no-op; file ahead → repair T2; T2 ahead → repair file) cover the real failure modes
+- Self-healing on use is more practical than a background reconciliation loop

--- a/docs/rdr/post-mortem/017-indexing-progress-reporting.md
+++ b/docs/rdr/post-mortem/017-indexing-progress-reporting.md
@@ -1,0 +1,44 @@
+---
+rdr: RDR-017
+title: "Indexing Progress Reporting: tqdm-Based Progress Bar for nx index"
+closed_date: 2026-03-04
+close_reason: implemented
+---
+
+# Post-Mortem: RDR-017 — Indexing Progress Reporting
+
+## RDR Summary
+
+`nx index repo` ran silently for 45–90 minutes with no user feedback. Added tqdm progress bars to all four `nx index` subcommands via a two-hook callback interface (`on_start`/`on_file`), plus a `--monitor` flag for per-file detail lines.
+
+## Implementation Status
+
+Phase 1 (callback interface + helper refactor) and Phase 2 (CLI integration) fully implemented. Phase 3 (chunk-level PDF/MD callbacks) was explicitly dropped in the RDR as not worth the architectural cost.
+
+## Implementation vs. Plan
+
+| Item | Planned | Delivered | Drift |
+|------|---------|-----------|-------|
+| Helper `-> bool` → `-> int` refactor | `_index_code_file`, `_index_prose_file`, `_index_pdf_file` | ✓ Implemented; returned chunk count | None |
+| `on_start` / `on_file` callbacks | Added to `index_repository`, `_run_index`, `batch_index_markdowns` | ✓ Threaded through all call paths | None |
+| tqdm bar for `repo`/`rdr` | `total=`, `disable=None`, rate + ETA + filename postfix | ✓ Implemented | None |
+| `--monitor` flag | Per-file detail lines via `tqdm.write()` or `click.echo()` | ✓ TTY and non-TTY branches | None |
+| `return_metadata` for `pdf`/`md` | `--monitor` prints page/title/author metadata | ✓ `index_pdf(return_metadata=True)` and `index_markdown` | None |
+| Non-TTY counter for `--monitor` | Separate `n` counter (not `bar.n`) | ✓ Implemented per RF-2 finding | None |
+| `tqdm>=4.65` in `pyproject.toml` | Add explicit dep | ✓ Added | None |
+
+## Drift Classification
+
+None. All planned work delivered. Phase 3 drop was pre-approved in the RDR.
+
+## RDR Quality Assessment
+
+- Research findings (RF-1 through RF-7) were accurate and complete — implementation matched all empirical discoveries
+- RF-6 (helper return type refactor) was the right call to surface up front rather than discover mid-implementation
+- The non-TTY counter note (RF-2 / Phase 2 implementation note) prevented a subtle bug: `bar.n` is unreliable when `disable=True`
+
+## Key Takeaways
+
+- The two-hook interface (`on_start`, `on_file`) is a clean separation: the indexer knows nothing about tqdm, the CLI knows nothing about indexer internals
+- `disable=None` is the right default for tqdm in CLI tools: silent in CI/tests, visible in TTY
+- Documenting the empirical research findings in the RDR before implementation saved real debugging time

--- a/docs/rdr/post-mortem/018-replace-serve-with-git-hooks.md
+++ b/docs/rdr/post-mortem/018-replace-serve-with-git-hooks.md
@@ -1,0 +1,48 @@
+---
+rdr: RDR-018
+title: "Replace nx serve Polling Server with Git Hooks"
+closed_date: 2026-03-04
+close_reason: implemented
+---
+
+# Post-Mortem: RDR-018 — Replace nx serve with Git Hooks
+
+## RDR Summary
+
+Deleted the Flask + Waitress polling server (`nx serve`) and replaced it with git hooks (`nx hooks install/uninstall/status`). Removed ~411 lines of daemon/REST/polling code; added ~250 lines of event-driven hook management.
+
+## Implementation Status
+
+Fully implemented. All success criteria met.
+
+## Implementation vs. Plan
+
+| Item | Planned | Delivered | Drift |
+|------|---------|-----------|-------|
+| Delete `server.py`, `polling.py`, `commands/serve.py` | Remove ~411 lines | ✓ Deleted | None |
+| `nx hooks install/uninstall/status` | New `commands/hooks.py` | ✓ Implemented | None |
+| Worktree-aware hooks dir (`git rev-parse --git-common-dir`) | Resolve effective hooks directory | ✓ Implemented | None |
+| `core.hooksPath` support | Install into configured path with warning if non-writable | ✓ Implemented | None |
+| Sentinel-based coexistence | Append/remove nexus stanza in existing hooks | ✓ `# >>> nexus managed begin >>>` sentinel | None |
+| `--on-locked={skip,wait}` flag | Per-repo file lock with configurable behaviour | ✓ Lock guard in `index_repository`; hooks use `skip` | None |
+| `head_hash` update in `index_repository` | Moved from caller to callee after successful run | ✓ Implemented | None |
+| `nx index repo` reminder | Print reminder if nexus sentinel absent from effective hooks dir | ✓ Implemented | None |
+| `nx doctor` hooks + log check | Per-repo hook status and index log last-modified | ✓ Implemented | None |
+| `chmod +x` on new hook files | Set executable bit | ✓ Implemented | None |
+
+## Drift Classification
+
+None. Every success criterion in the RDR was delivered.
+
+## RDR Quality Assessment
+
+- The decision to delete `nx serve` entirely (vs. keeping it alongside hooks) proved correct: no backward-compatibility surface to maintain
+- The acknowledged regression (credential failure silently drops hooks, requires manual `nx index repo`) is acceptable and documented
+- Gate review caught no issues requiring rework — the design was clean before implementation
+
+## Key Takeaways
+
+- Sentinel-based coexistence (`# >>> nexus managed begin >>>`) is robust: enables install, uninstall, and status checks with a single string match
+- The `--on-locked=skip` default for hooks prevents cascading lock contention during `git rebase -i` without user intervention
+- Event-driven hooks + auditable log (`~/.config/nexus/index.log`) are strictly better than polling: zero idle CPU, exact semantics, no daemon lifecycle
+- `nx doctor` integration turns a previously invisible process into a visible, diagnosable one

--- a/docs/rdr/rdr-001-rdr-process-validation.md
+++ b/docs/rdr/rdr-001-rdr-process-validation.md
@@ -2,10 +2,13 @@
 title: "RDR Process Validation"
 id: RDR-001
 type: architecture
-status: accepted
+status: implemented
 priority: high
 author: Hal Hildebrand
+reviewed-by: self
 created: 2026-02-27
+closed_date: 2026-03-04
+close_reason: implemented
 related_issues: []
 ---
 

--- a/docs/rdr/rdr-002-t2-status-synchronization.md
+++ b/docs/rdr/rdr-002-t2-status-synchronization.md
@@ -2,11 +2,13 @@
 title: "T2 Status Synchronization"
 id: RDR-002
 type: Technical Debt
-status: accepted
+status: implemented
 priority: high
 author: Hal Hildebrand
-reviewed-by:
+reviewed-by: self
 created: 2026-02-27
+closed_date: 2026-03-04
+close_reason: implemented
 related_issues:
   - RDR-001
 ---

--- a/docs/rdr/rdr-017-indexing-progress-reporting.md
+++ b/docs/rdr/rdr-017-indexing-progress-reporting.md
@@ -1,12 +1,14 @@
 ---
 title: "Indexing Progress Reporting: tqdm-Based Progress Bar for nx index"
 type: enhancement
-status: accepted
+status: implemented
 priority: P2
 author: Hal Hildebrand
 date: 2026-03-03
 accepted_date: 2026-03-03
 reviewed_by: "self"
+closed_date: 2026-03-04
+close_reason: implemented
 related_issues:
   - nexus-4iti
 ---

--- a/docs/rdr/rdr-018-replace-serve-with-git-hooks.md
+++ b/docs/rdr/rdr-018-replace-serve-with-git-hooks.md
@@ -1,12 +1,14 @@
 ---
 title: "Replace nx serve Polling Server with Git Hooks"
 type: refactor
-status: accepted
+status: implemented
 priority: P2
 author: Hal Hildebrand
 date: 2026-03-03
 accepted_date: 2026-03-03
 reviewed_by: "self"
+closed_date: 2026-03-04
+close_reason: implemented
 related_issues: []
 ---
 


### PR DESCRIPTION
## Summary

- Closes RDR-001 (RDR Process Validation), RDR-002 (T2 Status Synchronization), RDR-017 (Indexing Progress Reporting), RDR-018 (Replace nx serve with Git Hooks) — all fully implemented
- Updates frontmatter `status: implemented` + `closed_date`/`close_reason` on all four
- Regenerates `docs/rdr/README.md` index (Accepted → Implemented for all four)
- Creates post-mortem files in `docs/rdr/post-mortem/` (001, 002, 017, 018)
- T2 updated for all four RDRs

## Test plan

- [ ] README index shows `Implemented` for RDR-001, 002, 017, 018
- [ ] Post-mortem files exist in `docs/rdr/post-mortem/`
- [ ] No code changes — documentation only