### PR TITLE
chore: bump version to 1.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 14 specialized agents, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "1.4.0"
+      "version": "1.5.0"
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "1.4.0"
+version = "1.5.0"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"


### PR DESCRIPTION
Version bump for v1.5.0 release.

## Changes since v1.4.0

### Added
- **Auto-provision T3 databases in `nx config init`** — drops `nx migrate`; init now creates the tenant/database on first run.

### Fixed
- `chroma_tenant` is now optional — removed from required-credential checks.
- Real tenant UUID resolved before admin calls; `get_database` used for existence check.

### Improved
- **UX polish** — help text, wizard flow, and troubleshooting messages across all commands.
- **Test coverage** — closed gaps identified by test-validator audit.

### Docs
- White-glove polish pass on all plugin agents (14), skills (27), and marketplace metadata.
- White-glove polish pass on all RDR documentation.
- `getting-started.md` agent/skill counts corrected.
- RDR-001, 002, 017, 018 closed as implemented with post-mortems.