### PR TITLE
refactor(nexus-nwju): move retry helpers to nexus.retry leaf module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - **ChromaDB transient error retry** — all ChromaDB Cloud network calls in `db/t3.py`,
-  `indexer.py`, and `doc_indexer.py` are now wrapped with `_chroma_with_retry`: exponential
+  `indexer.py`, and `doc_indexer.py` are now wrapped with `_chroma_with_retry` (from
+  `retry.py`): exponential
   backoff (2 → 4 → 8 → 16 → 30 s, capped) retrying up to 5 times on HTTP 429/502/503/504
   and transport-level errors (`ConnectError`, `ReadTimeout`). Non-retryable errors raise
   immediately. Fixes multi-thousand-file indexing runs aborted by a single transient 504.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-03-05
+
+### Refactor
+- **`nexus.retry` leaf module** — moved `_chroma_with_retry`, `_is_retryable_chroma_error`,
+  `_voyage_with_retry`, and `_is_retryable_voyage_error` from `db/t3.py` into a new
+  `retry.py` with no `nexus.*` imports. Eliminates a local-import workaround in
+  `scoring.py` that was required to avoid a circular-import test-isolation bug.
+
 ## [1.5.1] - 2026-03-04
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ Data flows upward (T1 → T2 → T3).
 | **Indexing** | `indexer.py`, `classifier.py`, `chunker.py`, `md_chunker.py`, `doc_indexer.py`, `pdf_extractor.py`, `pdf_chunker.py` | Repo indexing pipeline |
 | **Search** | `search_engine.py`, `scoring.py`, `frecency.py`, `ripgrep_cache.py` | Query, rank, rerank |
 | **Hooks** | `commands/hooks.py` | Git hook install/uninstall/status, sentinel-bounded stanza management |
-| **Support** | `config.py`, `registry.py`, `corpus.py`, `session.py`, `hooks.py`, `ttl.py`, `formatters.py`, `types.py`, `errors.py` | Configuration, naming, formatting, session lifecycle |
+| **Support** | `config.py`, `registry.py`, `corpus.py`, `session.py`, `hooks.py`, `ttl.py`, `formatters.py`, `types.py`, `errors.py`, `retry.py` | Configuration, naming, formatting, session lifecycle, transient-error retry |
 
 ## Design Decisions
 

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -33,7 +33,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-017](rdr-017-indexing-progress-reporting.md) | Indexing Progress Reporting: tqdm-Based Progress Bar for nx index | Enhancement | Implemented | 2026-03-03 |
 | [RDR-018](rdr-018-replace-serve-with-git-hooks.md) | Replace nx serve Polling Server with Git Hooks | Refactor | Implemented | 2026-03-03 |
 | [RDR-019](rdr-019-chromadb-transient-retry.md) | ChromaDB Transient HTTP Error Retry | Bug Fix | Closed | 2026-03-04 |
-| [RDR-020](rdr-020-voyage-chromadb-read-timeout.md) | Voyage AI and ChromaDB Client Read Timeouts | Bug Fix | Accepted | 2026-03-04 |
+| [RDR-020](rdr-020-voyage-chromadb-read-timeout.md) | Voyage AI and ChromaDB Client Read Timeouts | Bug Fix | Closed | 2026-03-05 |
 
 ## RDR Process Documentation
 

--- a/docs/rdr/rdr-020-voyage-chromadb-read-timeout.md
+++ b/docs/rdr/rdr-020-voyage-chromadb-read-timeout.md
@@ -2,8 +2,10 @@
 id: RDR-020
 title: "Voyage AI and ChromaDB Client Read Timeouts"
 type: Bug Fix
-status: accepted
+status: closed
 accepted_date: 2026-03-04
+closed_date: 2026-03-05
+close_reason: implemented
 priority: P1
 created: 2026-03-04
 ---

--- a/docs/repo-indexing.md
+++ b/docs/repo-indexing.md
@@ -192,7 +192,7 @@ in the background after each qualifying git operation. Install them with `nx hoo
 ## Transient Error Resilience
 
 All ChromaDB Cloud network calls (staleness checks, upserts, deletes, queries) are wrapped
-with `_chroma_with_retry` — an exponential backoff helper in `db/t3.py`. If a call raises a
+with `_chroma_with_retry` — an exponential backoff helper in `retry.py`. If a call raises a
 transient error (HTTP 502/503/504/429, or a transport-level error such as `ConnectError` or
 `ReadTimeout`), it is retried up to 5 times with delays of 2 → 4 → 8 → 16 → 30 s (capped).
 Non-retryable errors (400, 401, 403, 404) raise immediately without retry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "1.5.1"
+version = "1.5.2"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12"

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -46,12 +46,16 @@ _DEFAULTS: dict[str, Any] = {
         "rdr_paths": ["docs/rdr"],
         "include_untracked": False,
     },
+    "voyageai": {
+        "read_timeout_seconds": 120,
+    },
 }
 
 # Env var → (section, key, type) mapping
 _ENV_OVERRIDES: dict[str, tuple[str, str, type]] = {
     "NX_EMBEDDINGS_RERANKER_MODEL": ("embeddings", "rerankerModel", str),
     "NX_CLIENT_HOST": ("client", "host", str),
+    "NX_VOYAGEAI_READ_TIMEOUT_SECONDS": ("voyageai", "read_timeout_seconds", int),
 }
 
 

--- a/src/nexus/db/__init__.py
+++ b/src/nexus/db/__init__.py
@@ -24,11 +24,15 @@ def make_t3(*, _client=None, _ef_override=None) -> T3Database:
     * ``_ef_override`` — override the embedding function (e.g.
       ``DefaultEmbeddingFunction()``) to avoid Voyage AI API calls.
     """
+    from nexus.config import load_config
+    cfg = load_config()
+    read_timeout_seconds: float = cfg.get("voyageai", {}).get("read_timeout_seconds", 120.0)
     return T3Database(
         tenant=get_credential("chroma_tenant"),
         database=get_credential("chroma_database"),
         api_key=get_credential("chroma_api_key"),
         voyage_api_key=get_credential("voyage_api_key"),
+        read_timeout_seconds=read_timeout_seconds,
         _client=_client,
         _ef_override=_ef_override,
     )

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -166,6 +166,7 @@ class T3Database:
         api_key: str = "",
         voyage_api_key: str = "",
         *,
+        read_timeout_seconds: float = 120.0,
         _client=None,
         _ef_override=None,
     ) -> None:
@@ -178,7 +179,8 @@ class T3Database:
         self._sems_lock = threading.Lock()
         self._quota_validator = QuotaValidator()
         self._voyage_client: voyageai.Client | None = (
-            voyageai.Client(api_key=voyage_api_key) if voyage_api_key else None
+            voyageai.Client(api_key=voyage_api_key, timeout=read_timeout_seconds, max_retries=3)
+            if voyage_api_key else None
         )
         if _client is not None:
             # Test injection: single client serves all store types.

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import hashlib
 import os
 import threading
-import time
-from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal
+from typing import Literal
 
 import chromadb
 import chromadb.errors
@@ -28,115 +26,12 @@ _log = structlog.get_logger(__name__)
 # nexus_rdr, nexus_knowledge.
 _STORE_TYPES: tuple[str, ...] = ("code", "docs", "rdr", "knowledge")
 
-
-# ── ChromaDB transient-error retry ───────────────────────────────────────────
-
-_RETRYABLE_FRAGMENTS: frozenset[str] = frozenset({
-    "502", "503", "504", "429",
-    "bad gateway", "service unavailable", "gateway time-out", "too many requests",
-})
-_RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({429, 502, 503, 504})
-
-
-def _is_retryable_chroma_error(exc: BaseException) -> bool:
-    """Return True if *exc* represents a transient ChromaDB Cloud error worth retrying.
-
-    Check order:
-    1. Transport-level errors (ConnectError, ReadTimeout, RemoteProtocolError) — always retry.
-    2. Chained httpx.HTTPStatusError — authoritative integer status code check.
-    3. String fallback — plain Exception message body (gateway HTML or chroma JSON).
-    """
-    # 1. Transport-level errors — no HTTP response, but clearly transient.
-    if isinstance(exc, httpx.TransportError):
-        return True
-    # 2. ChromaDB wraps HTTPStatusError as Exception(resp.text); original is __context__.
-    ctx = exc.__context__
-    if isinstance(ctx, httpx.HTTPStatusError):
-        return ctx.response.status_code in _RETRYABLE_HTTP_STATUSES
-    # 3. Fallback: scan the message body for retryable status tokens.
-    msg = str(exc).lower()
-    return any(fragment in msg for fragment in _RETRYABLE_FRAGMENTS)
-
-
-def _chroma_with_retry(
-    fn: Callable[..., Any],
-    *args: Any,
-    max_attempts: int = 5,
-    **kwargs: Any,
-) -> Any:
-    """Call *fn* with exponential backoff on transient ChromaDB Cloud errors.
-
-    Retries up to *max_attempts* times (default 5).  Backoff starts at 2 s,
-    doubles each attempt, capped at 30 s.  Non-retryable errors raise immediately.
-    """
-    delay = 2.0
-    for attempt in range(1, max_attempts + 1):
-        try:
-            return fn(*args, **kwargs)
-        except Exception as exc:
-            if attempt == max_attempts or not _is_retryable_chroma_error(exc):
-                raise
-            _log.warning(
-                "chroma_transient_error_retry",
-                attempt=attempt,
-                delay=delay,
-                error=str(exc)[:120],
-            )
-            time.sleep(delay)
-            delay = min(delay * 2, 30.0)
-
-
-
-# ── Voyage AI transient-error retry ──────────────────────────────────────────
-
-try:
-    import voyageai.error as _voyageai_error
-    _VOYAGE_ERROR_TYPES: tuple[type, ...] | None = (
-        _voyageai_error.APIConnectionError,
-        _voyageai_error.TryAgain,
-    )
-except ImportError:  # pragma: no cover
-    _VOYAGE_ERROR_TYPES = None
-
-
-def _is_retryable_voyage_error(exc: BaseException) -> bool:
-    """Return True if *exc* is a transient Voyage AI error worth retrying.
-
-    Only APIConnectionError and TryAgain are retried here.  Timeout,
-    RateLimitError, and ServiceUnavailableError are handled by the built-in
-    ``max_retries`` on ``voyageai.Client`` (tenacity-based).  The two error
-    spaces are disjoint; do not add Voyage AI types to _is_retryable_chroma_error.
-    """
-    return bool(_VOYAGE_ERROR_TYPES and isinstance(exc, _VOYAGE_ERROR_TYPES))
-
-
-def _voyage_with_retry(
-    fn: Callable[..., Any],
-    *args: Any,
-    max_attempts: int = 3,
-    **kwargs: Any,
-) -> Any:
-    """Call *fn* with backoff on transient Voyage AI errors (APIConnectionError, TryAgain).
-
-    Retries up to *max_attempts* times (default 3).  Backoff starts at 1 s,
-    doubles each attempt, capped at 10 s.  Non-retryable errors raise immediately.
-    """
-    delay = 1.0
-    for attempt in range(1, max_attempts + 1):
-        try:
-            return fn(*args, **kwargs)
-        except Exception as exc:
-            if attempt == max_attempts or not _is_retryable_voyage_error(exc):
-                raise
-            _log.warning(
-                "voyage_transient_error_retry",
-                attempt=attempt,
-                delay=delay,
-                error=str(exc)[:120],
-            )
-            time.sleep(delay)
-            delay = min(delay * 2, 10.0)
-
+from nexus.retry import (
+    _chroma_with_retry,
+    _is_retryable_chroma_error,
+    _is_retryable_voyage_error,
+    _voyage_with_retry,
+)
 
 class T3Database:
     """T3 ChromaDB CloudClient permanent knowledge store.

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -276,7 +276,8 @@ class T3Database:
         the original CCE/voyage-4 mismatch.
         """
         assert self._voyage_client is not None, "_cce_embed called without voyage_api_key"
-        result = self._voyage_client.contextualized_embed(
+        result = _voyage_with_retry(
+            self._voyage_client.contextualized_embed,
             inputs=[[text]],
             model="voyage-context-3",
             input_type=input_type,

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -86,6 +86,58 @@ def _chroma_with_retry(
             delay = min(delay * 2, 30.0)
 
 
+
+# ── Voyage AI transient-error retry ──────────────────────────────────────────
+
+try:
+    import voyageai.error as _voyageai_error
+    _VOYAGE_ERROR_TYPES: tuple[type, ...] | None = (
+        _voyageai_error.APIConnectionError,
+        _voyageai_error.TryAgain,
+    )
+except ImportError:  # pragma: no cover
+    _VOYAGE_ERROR_TYPES = None
+
+
+def _is_retryable_voyage_error(exc: BaseException) -> bool:
+    """Return True if *exc* is a transient Voyage AI error worth retrying.
+
+    Only APIConnectionError and TryAgain are retried here.  Timeout,
+    RateLimitError, and ServiceUnavailableError are handled by the built-in
+    ``max_retries`` on ``voyageai.Client`` (tenacity-based).  The two error
+    spaces are disjoint; do not add Voyage AI types to _is_retryable_chroma_error.
+    """
+    return bool(_VOYAGE_ERROR_TYPES and isinstance(exc, _VOYAGE_ERROR_TYPES))
+
+
+def _voyage_with_retry(
+    fn: Callable[..., Any],
+    *args: Any,
+    max_attempts: int = 3,
+    **kwargs: Any,
+) -> Any:
+    """Call *fn* with backoff on transient Voyage AI errors (APIConnectionError, TryAgain).
+
+    Retries up to *max_attempts* times (default 3).  Backoff starts at 1 s,
+    doubles each attempt, capped at 10 s.  Non-retryable errors raise immediately.
+    """
+    delay = 1.0
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:
+            if attempt == max_attempts or not _is_retryable_voyage_error(exc):
+                raise
+            _log.warning(
+                "voyage_transient_error_retry",
+                attempt=attempt,
+                delay=delay,
+                error=str(exc)[:120],
+            )
+            time.sleep(delay)
+            delay = min(delay * 2, 10.0)
+
+
 class T3Database:
     """T3 ChromaDB CloudClient permanent knowledge store.
 

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -87,6 +87,7 @@ def _embed_with_fallback(
     model: str,
     api_key: str,
     input_type: str = "document",
+    timeout: float = 120.0,
 ) -> tuple[list[list[float]], str]:
     """Embed chunks using CCE when possible, falling back to voyage-4 on failure.
 
@@ -112,7 +113,7 @@ def _embed_with_fallback(
             limit=_CCE_MAX_TOTAL_CHUNKS,
         )
     import voyageai
-    client = voyageai.Client(api_key=api_key)
+    client = voyageai.Client(api_key=api_key, timeout=timeout, max_retries=3)
     if model == "voyage-context-3":
         if len(chunks) < 2:
             # CCE requires 2+ chunks; fall back to voyage-4 (the query-time model)
@@ -215,11 +216,12 @@ def _index_document(
     if embed_fn is not None:
         embeddings, actual_model = embed_fn(documents, target_model)
     else:
-        from nexus.config import get_credential
+        from nexus.config import get_credential, load_config
         voyage_key = get_credential("voyage_api_key")
         if not voyage_key:
             raise RuntimeError("voyage_api_key must be set — unreachable if _has_credentials() passed")
-        embeddings, actual_model = _embed_with_fallback(documents, target_model, voyage_key)
+        timeout = load_config().get("voyageai", {}).get("read_timeout_seconds", 120.0)
+        embeddings, actual_model = _embed_with_fallback(documents, target_model, voyage_key, timeout=timeout)
     if actual_model != target_model:
         for m in metadatas:
             m["embedding_model"] = actual_model

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -18,7 +18,7 @@ _log = structlog.get_logger(__name__)
 
 from nexus.corpus import index_model_for_collection
 from nexus.db import make_t3
-from nexus.db.t3 import _chroma_with_retry
+from nexus.db.t3 import _chroma_with_retry, _voyage_with_retry
 from nexus.md_chunker import SemanticMarkdownChunker, parse_frontmatter
 from nexus.pdf_chunker import PDFChunker
 from nexus.pdf_extractor import PDFExtractor
@@ -125,8 +125,9 @@ def _embed_with_fallback(
             any_fallback = False
             for batch in batches:
                 try:
-                    result = client.contextualized_embed(
-                        inputs=[batch], model=model, input_type=input_type
+                    result = _voyage_with_retry(
+                        client.contextualized_embed,
+                        inputs=[batch], model=model, input_type=input_type,
                     )
                     all_embeddings.extend(result.results[0].embeddings)
                 except Exception as exc:
@@ -135,7 +136,7 @@ def _embed_with_fallback(
                                  error=str(exc), batch_size=len(batch))
                     for j in range(0, len(batch), _EMBED_BATCH_SIZE):
                         sub = batch[j:j + _EMBED_BATCH_SIZE]
-                        fb = client.embed(texts=sub, model="voyage-4", input_type=input_type)
+                        fb = _voyage_with_retry(client.embed, texts=sub, model="voyage-4", input_type=input_type)
                         all_embeddings.extend(fb.embeddings)
             if all_embeddings:
                 # Report voyage-4 if any batch fell back — forces re-index on next run
@@ -145,7 +146,7 @@ def _embed_with_fallback(
     all_emb: list[list[float]] = []
     for i in range(0, len(chunks), _EMBED_BATCH_SIZE):
         batch = chunks[i:i + _EMBED_BATCH_SIZE]
-        result = client.embed(texts=batch, model=model, input_type=input_type)
+        result = _voyage_with_retry(client.embed, texts=batch, model=model, input_type=input_type)
         all_emb.extend(result.embeddings)
     return all_emb, model
 

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -18,7 +18,7 @@ _log = structlog.get_logger(__name__)
 
 from nexus.corpus import index_model_for_collection
 from nexus.db import make_t3
-from nexus.db.t3 import _chroma_with_retry, _voyage_with_retry
+from nexus.retry import _chroma_with_retry, _voyage_with_retry
 from nexus.md_chunker import SemanticMarkdownChunker, parse_frontmatter
 from nexus.pdf_chunker import PDFChunker
 from nexus.pdf_extractor import PDFExtractor

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -627,6 +627,7 @@ def _index_prose_file(
     now_iso: str,
     score: float,
     force: bool = False,
+    timeout: float = 120.0,
 ) -> int:
     """Index a single prose file into the docs__ collection.
 
@@ -773,7 +774,7 @@ def _index_prose_file(
     texts_to_embed = embed_texts
 
     # Embed via _embed_with_fallback (CCE for voyage-context-3)
-    embeddings, actual_model = _embed_with_fallback(texts_to_embed, target_model, voyage_key)
+    embeddings, actual_model = _embed_with_fallback(texts_to_embed, target_model, voyage_key, timeout=timeout)
     if actual_model != target_model:
         for m in metadatas:
             m["embedding_model"] = actual_model
@@ -800,6 +801,7 @@ def _index_pdf_file(
     now_iso: str,
     score: float,
     force: bool = False,
+    timeout: float = 120.0,
 ) -> int:
     """Index a single PDF file into the docs__ collection.
 
@@ -868,7 +870,7 @@ def _index_pdf_file(
         }
         metadatas.append(augmented)
 
-    embeddings, actual_model = _embed_with_fallback(embed_texts_pdf, target_model, voyage_key)
+    embeddings, actual_model = _embed_with_fallback(embed_texts_pdf, target_model, voyage_key, timeout=timeout)
     if actual_model != target_model:
         for m in metadatas:
             m["embedding_model"] = actual_model
@@ -1045,6 +1047,7 @@ def _run_index(
     ignore_patterns: list[str] = list(dict.fromkeys(DEFAULT_IGNORE + cfg_patterns))
     indexing_config: dict = cfg.get("indexing", {})
     rdr_paths: list[str] = indexing_config.get("rdr_paths", ["docs/rdr"])
+    read_timeout_seconds: float = cfg.get("voyageai", {}).get("read_timeout_seconds", 120.0)
 
     # Collect git metadata once for all chunks
     git_meta = _git_metadata(repo)
@@ -1150,7 +1153,7 @@ def _run_index(
     # Initialize collections and models
     code_model = index_model_for_collection(code_collection)
     docs_model = index_model_for_collection(docs_collection)
-    voyage_client = voyageai.Client(api_key=voyage_key)
+    voyage_client = voyageai.Client(api_key=voyage_key, timeout=read_timeout_seconds, max_retries=3)
     _log.debug("creating collections", code=code_collection, docs=docs_collection)
     code_col = db.get_or_create_collection(code_collection)
     docs_col = db.get_or_create_collection(docs_collection)
@@ -1179,6 +1182,7 @@ def _run_index(
             file, repo, docs_collection, docs_model, docs_col, db,
             voyage_key, git_meta, now_iso, score,
             force=force,
+            timeout=read_timeout_seconds,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)
@@ -1192,6 +1196,7 @@ def _run_index(
             file, repo, docs_collection, docs_model, docs_col, db,
             voyage_key, git_meta, now_iso, score,
             force=force,
+            timeout=read_timeout_seconds,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import structlog
 
 from nexus.corpus import index_model_for_collection
-from nexus.db.t3 import _chroma_with_retry
+from nexus.db.t3 import _chroma_with_retry, _voyage_with_retry
 from nexus.errors import CredentialsMissingError  # re-exported for backward compatibility
 
 _log = structlog.get_logger(__name__)
@@ -601,7 +601,7 @@ def _index_code_file(
     for batch_start in range(0, total_chunks, _VOYAGE_EMBED_BATCH_SIZE):
         batch = embed_texts[batch_start : batch_start + _VOYAGE_EMBED_BATCH_SIZE]
         _log.debug("embedding batch", file=str(file), batch=f"{batch_start+1}-{min(batch_start+len(batch), total_chunks)}/{total_chunks}")
-        result = voyage_client.embed(texts=batch, model=target_model, input_type="document")
+        result = _voyage_with_retry(voyage_client.embed, texts=batch, model=target_model, input_type="document")
         embeddings.extend(result.embeddings)
 
     _log.debug("upserting", file=str(file), chunks=total_chunks)

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import structlog
 
 from nexus.corpus import index_model_for_collection
-from nexus.db.t3 import _chroma_with_retry, _voyage_with_retry
+from nexus.retry import _chroma_with_retry, _voyage_with_retry
 from nexus.errors import CredentialsMissingError  # re-exported for backward compatibility
 
 _log = structlog.get_logger(__name__)

--- a/src/nexus/retry.py
+++ b/src/nexus/retry.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Transient-error retry helpers for ChromaDB Cloud and Voyage AI.
+
+Leaf module — no nexus.* imports.  Only stdlib + httpx + structlog + soft voyageai.error.
+"""
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+
+# ── ChromaDB transient-error retry ───────────────────────────────────────────
+
+_RETRYABLE_FRAGMENTS: frozenset[str] = frozenset({
+    "502", "503", "504", "429",
+    "bad gateway", "service unavailable", "gateway time-out", "too many requests",
+})
+_RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({429, 502, 503, 504})
+
+
+def _is_retryable_chroma_error(exc: BaseException) -> bool:
+    """Return True if *exc* represents a transient ChromaDB Cloud error worth retrying.
+
+    Check order:
+    1. Transport-level errors (ConnectError, ReadTimeout, RemoteProtocolError) — always retry.
+    2. Chained httpx.HTTPStatusError — authoritative integer status code check.
+    3. String fallback — plain Exception message body (gateway HTML or chroma JSON).
+    """
+    # 1. Transport-level errors — no HTTP response, but clearly transient.
+    if isinstance(exc, httpx.TransportError):
+        return True
+    # 2. ChromaDB wraps HTTPStatusError as Exception(resp.text); original is __context__.
+    ctx = exc.__context__
+    if isinstance(ctx, httpx.HTTPStatusError):
+        return ctx.response.status_code in _RETRYABLE_HTTP_STATUSES
+    # 3. Fallback: scan the message body for retryable status tokens.
+    msg = str(exc).lower()
+    return any(fragment in msg for fragment in _RETRYABLE_FRAGMENTS)
+
+
+def _chroma_with_retry(
+    fn: Callable[..., Any],
+    *args: Any,
+    max_attempts: int = 5,
+    **kwargs: Any,
+) -> Any:
+    """Call *fn* with exponential backoff on transient ChromaDB Cloud errors.
+
+    Retries up to *max_attempts* times (default 5).  Backoff starts at 2 s,
+    doubles each attempt, capped at 30 s.  Non-retryable errors raise immediately.
+    """
+    delay = 2.0
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:
+            if attempt == max_attempts or not _is_retryable_chroma_error(exc):
+                raise
+            _log.warning(
+                "chroma_transient_error_retry",
+                attempt=attempt,
+                delay=delay,
+                error=str(exc)[:120],
+            )
+            time.sleep(delay)
+            delay = min(delay * 2, 30.0)
+
+
+# ── Voyage AI transient-error retry ──────────────────────────────────────────
+
+try:
+    import voyageai.error as _voyageai_error
+    _VOYAGE_ERROR_TYPES: tuple[type, ...] | None = (
+        _voyageai_error.APIConnectionError,
+        _voyageai_error.TryAgain,
+    )
+except ImportError:  # pragma: no cover
+    _VOYAGE_ERROR_TYPES = None
+
+
+def _is_retryable_voyage_error(exc: BaseException) -> bool:
+    """Return True if *exc* is a transient Voyage AI error worth retrying.
+
+    Only APIConnectionError and TryAgain are retried here.  Timeout,
+    RateLimitError, and ServiceUnavailableError are handled by the built-in
+    ``max_retries`` on ``voyageai.Client`` (tenacity-based).  The two error
+    spaces are disjoint; do not add Voyage AI types to _is_retryable_chroma_error.
+    """
+    return bool(_VOYAGE_ERROR_TYPES and isinstance(exc, _VOYAGE_ERROR_TYPES))
+
+
+def _voyage_with_retry(
+    fn: Callable[..., Any],
+    *args: Any,
+    max_attempts: int = 3,
+    **kwargs: Any,
+) -> Any:
+    """Call *fn* with backoff on transient Voyage AI errors (APIConnectionError, TryAgain).
+
+    Retries up to *max_attempts* times (default 3).  Backoff starts at 1 s,
+    doubles each attempt, capped at 10 s.  Non-retryable errors raise immediately.
+    """
+    delay = 1.0
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:
+            if attempt == max_attempts or not _is_retryable_voyage_error(exc):
+                raise
+            _log.warning(
+                "voyage_transient_error_retry",
+                attempt=attempt,
+                delay=delay,
+                error=str(exc)[:120],
+            )
+            time.sleep(delay)
+            delay = min(delay * 2, 10.0)

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -145,9 +145,11 @@ def rerank_results(
 
     n = top_k or len(results)
     documents = [r.content for r in results]
+    from nexus.db.t3 import _voyage_with_retry
     client = _voyage_client()
     try:
-        rerank_response = client.rerank(
+        rerank_response = _voyage_with_retry(
+            client.rerank,
             query=query,
             documents=documents,
             model=model,

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -115,6 +115,13 @@ def _voyage_client():
     return _voyage_instance
 
 
+def _reset_voyage_client() -> None:
+    """Reset the cached Voyage AI client singleton (for test isolation only)."""
+    global _voyage_instance
+    with _voyage_lock:
+        _voyage_instance = None
+
+
 def rerank_results(
     results: list[SearchResult],
     query: str,

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -145,6 +145,10 @@ def rerank_results(
 
     n = top_k or len(results)
     documents = [r.content for r in results]
+    # Local import: top-level import of nexus.db.t3 mutates nexus.db's attribute on the
+    # nexus package during test_no_circular_imports' module-reload phase, leaving
+    # nexus.db.t1 inaccessible for subsequent tests.  Keep this import local until
+    # _voyage_with_retry is moved to a leaf module (e.g. nexus.retry) with no upward deps.
     from nexus.db.t3 import _voyage_with_retry
     client = _voyage_client()
     try:

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -6,6 +6,7 @@ import threading
 
 import structlog
 
+from nexus.retry import _voyage_with_retry
 from nexus.types import SearchResult
 
 _log = structlog.get_logger()
@@ -145,11 +146,6 @@ def rerank_results(
 
     n = top_k or len(results)
     documents = [r.content for r in results]
-    # Local import: top-level import of nexus.db.t3 mutates nexus.db's attribute on the
-    # nexus package during test_no_circular_imports' module-reload phase, leaving
-    # nexus.db.t1 inaccessible for subsequent tests.  Keep this import local until
-    # _voyage_with_retry is moved to a leaf module (e.g. nexus.retry) with no upward deps.
-    from nexus.db.t3 import _voyage_with_retry
     client = _voyage_client()
     try:
         rerank_response = _voyage_with_retry(

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -110,8 +110,13 @@ def _voyage_client():
     with _voyage_lock:
         if _voyage_instance is None:
             import voyageai
-            from nexus.config import get_credential
-            _voyage_instance = voyageai.Client(api_key=get_credential("voyage_api_key"))
+            from nexus.config import get_credential, load_config
+            timeout = load_config().get("voyageai", {}).get("read_timeout_seconds", 120.0)
+            _voyage_instance = voyageai.Client(
+                api_key=get_credential("voyage_api_key"),
+                timeout=timeout,
+                max_retries=3,
+            )
     return _voyage_instance
 
 

--- a/tests/test_chroma_retry.py
+++ b/tests/test_chroma_retry.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, call, patch
 import httpx
 import pytest
 
-from nexus.db.t3 import _chroma_with_retry, _is_retryable_chroma_error
+from nexus.retry import _chroma_with_retry, _is_retryable_chroma_error
 
 
 # ── _is_retryable_chroma_error ────────────────────────────────────────────────
@@ -95,7 +95,7 @@ def test_retry_connect_error_twice_then_success() -> None:
             raise httpx.ConnectError("transient connect failure")
         return "ok"
 
-    with patch("nexus.db.t3.time") as mock_time:
+    with patch("nexus.retry.time") as mock_time:
         result = _chroma_with_retry(flaky_fn)
 
     assert result == "ok"
@@ -107,7 +107,7 @@ def test_all_attempts_exhausted_on_persistent_504() -> None:
     """fn raises 504 on every attempt; _chroma_with_retry raises after 5 attempts."""
     fn = MagicMock(side_effect=Exception("504 Gateway Time-out"))
 
-    with patch("nexus.db.t3.time"):
+    with patch("nexus.retry.time"):
         with pytest.raises(Exception, match="504"):
             _chroma_with_retry(fn, max_attempts=5)
 
@@ -118,7 +118,7 @@ def test_non_retryable_400_raises_immediately() -> None:
     """fn raises 400 on first attempt; _chroma_with_retry re-raises immediately without sleeping."""
     fn = MagicMock(side_effect=Exception("400 Bad Request: invalid collection name"))
 
-    with patch("nexus.db.t3.time") as mock_time:
+    with patch("nexus.retry.time") as mock_time:
         with pytest.raises(Exception, match="400"):
             _chroma_with_retry(fn)
 
@@ -137,7 +137,7 @@ def test_backoff_curve_2_4_8_16() -> None:
             raise Exception("503 Service Unavailable")
         return "done"
 
-    with patch("nexus.db.t3.time") as mock_time:
+    with patch("nexus.retry.time") as mock_time:
         result = _chroma_with_retry(fn_succeeds_on_5th, max_attempts=5)
 
     assert result == "done"
@@ -186,7 +186,7 @@ def test_search_retries_on_503(t3_mock) -> None:
     }
     mock_col.query.side_effect = [exc, valid_result]
 
-    with patch("nexus.db.t3.time"):
+    with patch("nexus.retry.time"):
         results = db.search("query text", ["code__myrepo"])
 
     assert len(results) == 1
@@ -201,7 +201,7 @@ def test_write_batch_retries_on_504(t3_mock) -> None:
     mock_col = MagicMock()
     mock_col.upsert.side_effect = [Exception("504 Gateway Time-out"), None]
 
-    with patch("nexus.db.t3.time"):
+    with patch("nexus.retry.time"):
         db._write_batch(
             mock_col,
             "code__myrepo",
@@ -232,7 +232,7 @@ def test_list_store_retries_on_read_timeout(t3_mock) -> None:
         },
     ]
 
-    with patch("nexus.db.t3.time"):
+    with patch("nexus.retry.time"):
         results = db.list_store("knowledge__mystore")
 
     assert len(results) == 1
@@ -257,7 +257,7 @@ def test_index_code_file_retries_on_connect_error(tmp_path) -> None:
     mock_voyage = MagicMock()
     mock_voyage.embed.return_value = MagicMock(embeddings=[[0.1, 0.2]])
 
-    with patch("nexus.db.t3.time"):
+    with patch("nexus.retry.time"):
         result = _index_code_file(
             file=src,
             repo=tmp_path,

--- a/tests/test_chroma_retry.py
+++ b/tests/test_chroma_retry.py
@@ -273,3 +273,31 @@ def test_index_code_file_retries_on_connect_error(tmp_path) -> None:
 
     assert result >= 0  # completed without raising
     assert mock_col.get.call_count == 2
+
+
+# ── RDR-020 regression: _is_retryable_chroma_error disjoint from Voyage AI ───
+
+def test_chroma_error_unchanged_transport() -> None:
+    """_is_retryable_chroma_error still True for httpx.TransportError subclasses."""
+    assert _is_retryable_chroma_error(httpx.ConnectError("refused")) is True
+    assert _is_retryable_chroma_error(httpx.ReadTimeout("timeout")) is True
+
+
+def test_chroma_error_unchanged_503() -> None:
+    """_is_retryable_chroma_error still True for chained 503."""
+    assert _is_retryable_chroma_error(_make_chained_exc(503)) is True
+
+
+def test_chroma_error_unchanged_429() -> None:
+    """_is_retryable_chroma_error still True for chained 429."""
+    assert _is_retryable_chroma_error(_make_chained_exc(429)) is True
+
+
+def test_chroma_error_false_for_voyage_api_connection_error() -> None:
+    """_is_retryable_chroma_error returns False for voyageai.error.APIConnectionError.
+
+    The two error oracles must be disjoint: a Voyage AI error must not be
+    treated as a ChromaDB retryable error.
+    """
+    import voyageai.error as _ve
+    assert _is_retryable_chroma_error(_ve.APIConnectionError("down")) is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,6 +47,22 @@ def test_config_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
 
 
 
+def test_config_voyageai_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """load_config() returns voyageai.read_timeout_seconds == 120 by default."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config = load_config(repo_root=tmp_path)
+    assert config["voyageai"]["read_timeout_seconds"] == 120
+
+
+def test_config_voyageai_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """NX_VOYAGEAI_READ_TIMEOUT_SECONDS overrides the default."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("NX_VOYAGEAI_READ_TIMEOUT_SECONDS", "60")
+    config = load_config(repo_root=tmp_path)
+    assert config["voyageai"]["read_timeout_seconds"] == 60
+    assert isinstance(config["voyageai"]["read_timeout_seconds"], int)
+
+
 def test_config_missing_files_returns_defaults(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -218,7 +218,7 @@ def test_pdf_metadata_schema_complete(simple_pdf: Path, monkeypatch):
     mock_t3.get_or_create_collection.return_value = mock_col
     mock_t3.upsert_chunks_with_embeddings.side_effect = capture_upsert
 
-    def fake_embed(chunks, model, api_key, input_type="document"):
+    def fake_embed(chunks, model, api_key, input_type="document", timeout=120.0):
         return [[0.1] * 5] * len(chunks), "test-local"
 
     with patch("nexus.doc_indexer._embed_with_fallback", side_effect=fake_embed):

--- a/tests/test_pdf_e2e.py
+++ b/tests/test_pdf_e2e.py
@@ -22,7 +22,7 @@ from nexus.indexer import _git_metadata, _index_pdf_file
 _local_ef = DefaultEmbeddingFunction()
 
 
-def _local_embed(chunks, model, api_key, input_type="document"):
+def _local_embed(chunks, model, api_key, input_type="document", timeout=120.0):
     """Local embed stub: wraps ONNX MiniLM-L6-v2 — no API keys needed.
 
     Returns (embeddings, model) to match _embed_with_fallback's

--- a/tests/test_pdf_subsystem.py
+++ b/tests/test_pdf_subsystem.py
@@ -71,7 +71,7 @@ def ruled_table_pdf(pdf_fixtures_dir: Path) -> Path:
     return path
 
 
-def _fake_embed(chunks, model, api_key, input_type="document"):
+def _fake_embed(chunks, model, api_key, input_type="document", timeout=120.0):
     """Embedding stub: returns unit vectors without calling Voyage AI."""
     return [[0.1] * 5] * len(chunks), "test-local"
 

--- a/tests/test_search_modules.py
+++ b/tests/test_search_modules.py
@@ -129,6 +129,11 @@ def test_no_circular_imports():
         # Verify search_engine is not in their __dict__ as an imported sub-module
         assert not hasattr(scoring, "search_engine"), "scoring must not import search_engine"
         assert not hasattr(formatters, "search_engine"), "formatters must not import search_engine"
+
+        # nexus.retry must be a true leaf module — no nexus.db or search_engine
+        retry_mod = importlib.import_module("nexus.retry")
+        assert not hasattr(retry_mod, "search_engine"), "nexus.retry must not import search_engine"
+        assert not hasattr(retry_mod, "db"), "nexus.retry must not import nexus.db"
     finally:
         # Restore original sys.modules to avoid contaminating subsequent tests
         sys.modules.clear()

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -308,7 +308,7 @@ def test_search_cce_collection_uses_query_embeddings(mock_chromadb: tuple) -> No
         results = db.search("four store t3 architecture", ["rdr__nexus-abc123"], n_results=5)
 
     # voyageai.Client instantiated with the voyage_api_key
-    mock_vo_mod.Client.assert_called_once_with(api_key="vkey")
+    mock_vo_mod.Client.assert_called_once_with(api_key="vkey", timeout=120.0, max_retries=3)
     # contextualized_embed called with the query wrapped in a list-of-list
     mock_vo_inst.contextualized_embed.assert_called_once_with(
         inputs=[["four store t3 architecture"]],

--- a/tests/test_voyage_retry.py
+++ b/tests/test_voyage_retry.py
@@ -72,7 +72,7 @@ def test_voyage_with_retry_success_after_transient() -> None:
 def test_voyage_with_retry_fires_3_times_then_raises() -> None:
     """Retries max_attempts=3 times on APIConnectionError then re-raises."""
     fn = MagicMock(side_effect=_ve.APIConnectionError("persistent"))
-    with pytest.raises(_ve.APIConnectionError):
+    with patch("nexus.db.t3.time.sleep"), pytest.raises(_ve.APIConnectionError):
         _voyage_with_retry(fn, max_attempts=3)
     assert fn.call_count == 3
 
@@ -113,10 +113,13 @@ def test_embed_with_fallback_voyage_client_has_timeout() -> None:
     from nexus.doc_indexer import _embed_with_fallback
 
     mock_client = MagicMock()
-    mock_client.contextualized_embed.return_value = MagicMock(
-        embeddings=[[0.1] * 1024, [0.2] * 1024]
-    )
-    with patch("voyageai.Client", return_value=mock_client) as mock_ctor:
+    # CCE result structure: result.results[0].embeddings (not result.embeddings)
+    cce_result = MagicMock()
+    cce_result.results = [MagicMock()]
+    cce_result.results[0].embeddings = [[0.1] * 1024, [0.2] * 1024]
+    mock_client.contextualized_embed.return_value = cce_result
+    with patch("voyageai.Client", return_value=mock_client) as mock_ctor, \
+         patch("nexus.db.t3.time.sleep"):
         _embed_with_fallback(["chunk one", "chunk two"], "voyage-context-3", "test-key", timeout=75.0)
         mock_ctor.assert_called_once_with(api_key="test-key", timeout=75.0, max_retries=3)
 

--- a/tests/test_voyage_retry.py
+++ b/tests/test_voyage_retry.py
@@ -4,6 +4,7 @@ Covers:
   - _is_retryable_voyage_error oracle (nexus-k8dv)
   - _voyage_with_retry wrapper (nexus-k8dv)
   - _reset_voyage_client singleton reset (nexus-b1m0)
+  - voyageai.Client timeout + max_retries wired at all 4 sites (nexus-oh22)
 """
 
 from unittest.mock import MagicMock, patch
@@ -89,6 +90,52 @@ def test_voyage_with_retry_try_again_retries() -> None:
     result = _voyage_with_retry(fn)
     assert result == "result"
     assert fn.call_count == 2
+
+
+# ── _reset_voyage_client singleton reset ──────────────────────────────────────
+
+# ── nexus-oh22: voyageai.Client timeout + max_retries at all 4 sites ──────────
+
+def test_t3_database_voyage_client_has_timeout() -> None:
+    """T3Database.__init__ passes timeout=read_timeout_seconds and max_retries=3."""
+    from nexus.db.t3 import T3Database
+
+    with patch("nexus.db.t3.voyageai.Client") as mock_ctor:
+        mock_ctor.return_value = MagicMock()
+        T3Database(voyage_api_key="test-key", read_timeout_seconds=60.0, _client=MagicMock())
+        mock_ctor.assert_called_once_with(
+            api_key="test-key",
+            timeout=60.0,
+            max_retries=3,
+        )
+
+
+def test_embed_with_fallback_voyage_client_has_timeout() -> None:
+    """_embed_with_fallback passes timeout and max_retries=3 to voyageai.Client."""
+    from nexus.doc_indexer import _embed_with_fallback
+
+    mock_client = MagicMock()
+    mock_client.contextualized_embed.return_value = MagicMock(
+        embeddings=[[0.1] * 1024, [0.2] * 1024]
+    )
+    with patch("voyageai.Client", return_value=mock_client) as mock_ctor:
+        _embed_with_fallback(["chunk one", "chunk two"], "voyage-context-3", "test-key", timeout=75.0)
+        mock_ctor.assert_called_once_with(api_key="test-key", timeout=75.0, max_retries=3)
+
+
+def test_scoring_voyage_client_has_timeout() -> None:
+    """_voyage_client() reads timeout from config and passes it to voyageai.Client."""
+    import nexus.scoring as scoring
+    scoring._reset_voyage_client()
+
+    with patch("voyageai.Client") as mock_ctor, \
+         patch("nexus.config.get_credential", return_value="test-key"), \
+         patch("nexus.config.load_config", return_value={"voyageai": {"read_timeout_seconds": 55}}):
+        mock_ctor.return_value = MagicMock()
+        scoring._voyage_client()
+        mock_ctor.assert_called_once_with(api_key="test-key", timeout=55, max_retries=3)
+
+    scoring._reset_voyage_client()
 
 
 # ── _reset_voyage_client singleton reset ──────────────────────────────────────

--- a/tests/test_voyage_retry.py
+++ b/tests/test_voyage_retry.py
@@ -1,0 +1,115 @@
+"""Tests for Voyage AI retry helpers and scoring.py singleton reset.
+
+Covers:
+  - _is_retryable_voyage_error oracle (nexus-k8dv)
+  - _voyage_with_retry wrapper (nexus-k8dv)
+  - _reset_voyage_client singleton reset (nexus-b1m0)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import voyageai.error as _ve
+
+from nexus.db.t3 import _is_retryable_voyage_error, _voyage_with_retry
+
+
+# ── _is_retryable_voyage_error oracle ─────────────────────────────────────────
+
+def test_retryable_voyage_api_connection_error() -> None:
+    assert _is_retryable_voyage_error(_ve.APIConnectionError("connection reset")) is True
+
+
+def test_retryable_voyage_try_again() -> None:
+    assert _is_retryable_voyage_error(_ve.TryAgain("try again")) is True
+
+
+def test_not_retryable_voyage_timeout() -> None:
+    """Timeout handled by voyageai.Client built-in max_retries — not by outer wrapper."""
+    assert _is_retryable_voyage_error(_ve.Timeout("timed out")) is False
+
+
+def test_not_retryable_voyage_rate_limit() -> None:
+    """RateLimitError handled by built-in max_retries."""
+    assert _is_retryable_voyage_error(_ve.RateLimitError("rate limited")) is False
+
+
+def test_not_retryable_voyage_service_unavailable() -> None:
+    """ServiceUnavailableError handled by built-in max_retries."""
+    assert _is_retryable_voyage_error(_ve.ServiceUnavailableError("unavailable")) is False
+
+
+def test_not_retryable_voyage_auth_error() -> None:
+    assert _is_retryable_voyage_error(_ve.AuthenticationError("bad key")) is False
+
+
+def test_not_retryable_voyage_invalid_request() -> None:
+    assert _is_retryable_voyage_error(_ve.InvalidRequestError("bad input")) is False
+
+
+def test_not_retryable_plain_exception() -> None:
+    assert _is_retryable_voyage_error(ValueError("random")) is False
+
+
+# ── _voyage_with_retry wrapper ─────────────────────────────────────────────────
+
+def test_voyage_with_retry_success_no_retry() -> None:
+    fn = MagicMock(return_value="ok")
+    result = _voyage_with_retry(fn, "arg")
+    assert result == "ok"
+    fn.assert_called_once_with("arg")
+
+
+def test_voyage_with_retry_success_after_transient() -> None:
+    """Succeeds on second attempt after one APIConnectionError."""
+    fn = MagicMock(side_effect=[_ve.APIConnectionError("down"), "ok"])
+    result = _voyage_with_retry(fn)
+    assert result == "ok"
+    assert fn.call_count == 2
+
+
+def test_voyage_with_retry_fires_3_times_then_raises() -> None:
+    """Retries max_attempts=3 times on APIConnectionError then re-raises."""
+    fn = MagicMock(side_effect=_ve.APIConnectionError("persistent"))
+    with pytest.raises(_ve.APIConnectionError):
+        _voyage_with_retry(fn, max_attempts=3)
+    assert fn.call_count == 3
+
+
+def test_voyage_with_retry_non_retryable_raises_immediately() -> None:
+    """AuthenticationError (non-retryable) raises on first attempt."""
+    fn = MagicMock(side_effect=_ve.AuthenticationError("bad key"))
+    with pytest.raises(_ve.AuthenticationError):
+        _voyage_with_retry(fn)
+    fn.assert_called_once()
+
+
+def test_voyage_with_retry_try_again_retries() -> None:
+    fn = MagicMock(side_effect=[_ve.TryAgain("wait"), "result"])
+    result = _voyage_with_retry(fn)
+    assert result == "result"
+    assert fn.call_count == 2
+
+
+# ── _reset_voyage_client singleton reset ──────────────────────────────────────
+
+def test_reset_voyage_client_clears_singleton() -> None:
+    """_reset_voyage_client() sets _voyage_instance = None; next call re-creates."""
+    import nexus.scoring as scoring
+    # Always get _reset_voyage_client from the CURRENT module object (not cached via 'from')
+    # test_no_circular_imports reloads nexus.scoring, detaching cached imports.
+    _reset_voyage_client = scoring._reset_voyage_client
+
+    # Ensure clean slate (idempotent)
+    _reset_voyage_client()
+    assert scoring._voyage_instance is None
+
+    # Inject a fake singleton
+    sentinel = MagicMock()
+    scoring._voyage_instance = sentinel
+    assert scoring._voyage_instance is sentinel
+
+    # Reset clears it
+    _reset_voyage_client()
+    assert scoring._voyage_instance is None
+

--- a/tests/test_voyage_retry.py
+++ b/tests/test_voyage_retry.py
@@ -92,8 +92,6 @@ def test_voyage_with_retry_try_again_retries() -> None:
     assert fn.call_count == 2
 
 
-# ── _reset_voyage_client singleton reset ──────────────────────────────────────
-
 # ── nexus-oh22: voyageai.Client timeout + max_retries at all 4 sites ──────────
 
 def test_t3_database_voyage_client_has_timeout() -> None:
@@ -134,6 +132,115 @@ def test_scoring_voyage_client_has_timeout() -> None:
         mock_ctor.return_value = MagicMock()
         scoring._voyage_client()
         mock_ctor.assert_called_once_with(api_key="test-key", timeout=55, max_retries=3)
+
+    scoring._reset_voyage_client()
+
+
+# ── nexus-vdly: _voyage_with_retry wraps all Voyage AI call sites ─────────────
+
+def test_cce_embed_retries_api_connection_error() -> None:
+    """_cce_embed retries once on APIConnectionError then returns the result."""
+    from nexus.db.t3 import T3Database
+
+    success_result = MagicMock()
+    success_result.results = [MagicMock()]
+    success_result.results[0].embeddings = [[0.1] * 1024]
+    mock_voyage = MagicMock()
+    mock_voyage.contextualized_embed.side_effect = [_ve.APIConnectionError("down"), success_result]
+
+    with patch("nexus.db.t3.voyageai.Client", return_value=mock_voyage), \
+         patch("nexus.db.t3.time.sleep"):
+        db = T3Database(voyage_api_key="test-key", _client=MagicMock())
+        result = db._cce_embed("hello world")
+
+    assert mock_voyage.contextualized_embed.call_count == 2
+    assert result == [0.1] * 1024
+
+
+def test_embed_with_fallback_cce_path_retries_api_connection_error() -> None:
+    """CCE path in _embed_with_fallback retries before returning the result."""
+    from nexus.doc_indexer import _embed_with_fallback
+
+    success_result = MagicMock()
+    success_result.results = [MagicMock()]
+    success_result.results[0].embeddings = [[0.1] * 1024, [0.2] * 1024]
+    mock_client = MagicMock()
+    mock_client.contextualized_embed.side_effect = [_ve.APIConnectionError("down"), success_result]
+
+    with patch("voyageai.Client", return_value=mock_client), \
+         patch("nexus.db.t3.time.sleep"):
+        embeddings, model = _embed_with_fallback(["chunk one", "chunk two"], "voyage-context-3", "test-key")
+
+    assert mock_client.contextualized_embed.call_count == 2
+    assert model == "voyage-context-3"
+
+
+def test_embed_with_fallback_standard_path_retries_api_connection_error() -> None:
+    """Standard embed path in _embed_with_fallback retries on APIConnectionError."""
+    from nexus.doc_indexer import _embed_with_fallback
+
+    success_result = MagicMock()
+    success_result.embeddings = [[0.1] * 1024]
+    mock_client = MagicMock()
+    mock_client.embed.side_effect = [_ve.APIConnectionError("down"), success_result]
+
+    with patch("voyageai.Client", return_value=mock_client), \
+         patch("nexus.db.t3.time.sleep"):
+        embeddings, model = _embed_with_fallback(["one chunk"], "voyage-4", "test-key")
+
+    assert mock_client.embed.call_count == 2
+    assert model == "voyage-4"
+
+
+def test_index_code_file_embed_retries_api_connection_error(tmp_path) -> None:
+    """_index_code_file batch embed retries on APIConnectionError."""
+    from nexus.indexer import _index_code_file
+
+    py_file = tmp_path / "hello.py"
+    py_file.write_text("def hello():\n    return 'world'\n")
+
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"ids": [], "metadatas": []}
+    mock_db = MagicMock()
+
+    success_result = MagicMock()
+    success_result.embeddings = [[0.1] * 1024]
+    mock_voyage = MagicMock()
+    mock_voyage.embed.side_effect = [
+        _ve.APIConnectionError("down"),
+        success_result, success_result, success_result,
+    ]
+
+    with patch("nexus.db.t3.time.sleep"):
+        _index_code_file(
+            py_file, tmp_path, "code__test", "voyage-code-3",
+            mock_col, mock_db, mock_voyage, {}, "2026-03-05T00:00:00",
+            score=0.5,
+        )
+
+    assert mock_voyage.embed.call_count >= 2
+
+
+def test_rerank_results_retries_then_degrades() -> None:
+    """rerank_results retries on APIConnectionError then degrades to unranked results."""
+    import nexus.scoring as scoring
+    scoring._reset_voyage_client()
+
+    from nexus.types import SearchResult
+    results = [
+        SearchResult(id="1", content="text", collection="code__repo", distance=0.1, metadata={})
+    ]
+    mock_client = MagicMock()
+    mock_client.rerank.side_effect = _ve.APIConnectionError("persistent")
+
+    with patch("voyageai.Client", return_value=mock_client), \
+         patch("nexus.config.get_credential", return_value="test-key"), \
+         patch("nexus.config.load_config", return_value={"voyageai": {"read_timeout_seconds": 120}}), \
+         patch("nexus.db.t3.time.sleep"):
+        returned = scoring.rerank_results(results, "query", top_k=1)
+
+    assert mock_client.rerank.call_count == 3  # 3 attempts then re-raises → caught by outer except
+    assert returned == results  # graceful degradation
 
     scoring._reset_voyage_client()
 

--- a/tests/test_voyage_retry.py
+++ b/tests/test_voyage_retry.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import voyageai.error as _ve
 
-from nexus.db.t3 import _is_retryable_voyage_error, _voyage_with_retry
+from nexus.retry import _is_retryable_voyage_error, _voyage_with_retry
 
 
 # ── _is_retryable_voyage_error oracle ─────────────────────────────────────────
@@ -72,7 +72,7 @@ def test_voyage_with_retry_success_after_transient() -> None:
 def test_voyage_with_retry_fires_3_times_then_raises() -> None:
     """Retries max_attempts=3 times on APIConnectionError then re-raises."""
     fn = MagicMock(side_effect=_ve.APIConnectionError("persistent"))
-    with patch("nexus.db.t3.time.sleep"), pytest.raises(_ve.APIConnectionError):
+    with patch("nexus.retry.time.sleep"), pytest.raises(_ve.APIConnectionError):
         _voyage_with_retry(fn, max_attempts=3)
     assert fn.call_count == 3
 
@@ -119,7 +119,7 @@ def test_embed_with_fallback_voyage_client_has_timeout() -> None:
     cce_result.results[0].embeddings = [[0.1] * 1024, [0.2] * 1024]
     mock_client.contextualized_embed.return_value = cce_result
     with patch("voyageai.Client", return_value=mock_client) as mock_ctor, \
-         patch("nexus.db.t3.time.sleep"):
+         patch("nexus.retry.time.sleep"):
         _embed_with_fallback(["chunk one", "chunk two"], "voyage-context-3", "test-key", timeout=75.0)
         mock_ctor.assert_called_once_with(api_key="test-key", timeout=75.0, max_retries=3)
 
@@ -152,7 +152,7 @@ def test_cce_embed_retries_api_connection_error() -> None:
     mock_voyage.contextualized_embed.side_effect = [_ve.APIConnectionError("down"), success_result]
 
     with patch("nexus.db.t3.voyageai.Client", return_value=mock_voyage), \
-         patch("nexus.db.t3.time.sleep"):
+         patch("nexus.retry.time.sleep"):
         db = T3Database(voyage_api_key="test-key", _client=MagicMock())
         result = db._cce_embed("hello world")
 
@@ -171,7 +171,7 @@ def test_embed_with_fallback_cce_path_retries_api_connection_error() -> None:
     mock_client.contextualized_embed.side_effect = [_ve.APIConnectionError("down"), success_result]
 
     with patch("voyageai.Client", return_value=mock_client), \
-         patch("nexus.db.t3.time.sleep"):
+         patch("nexus.retry.time.sleep"):
         embeddings, model = _embed_with_fallback(["chunk one", "chunk two"], "voyage-context-3", "test-key")
 
     assert mock_client.contextualized_embed.call_count == 2
@@ -188,7 +188,7 @@ def test_embed_with_fallback_standard_path_retries_api_connection_error() -> Non
     mock_client.embed.side_effect = [_ve.APIConnectionError("down"), success_result]
 
     with patch("voyageai.Client", return_value=mock_client), \
-         patch("nexus.db.t3.time.sleep"):
+         patch("nexus.retry.time.sleep"):
         embeddings, model = _embed_with_fallback(["one chunk"], "voyage-4", "test-key")
 
     assert mock_client.embed.call_count == 2
@@ -214,7 +214,7 @@ def test_index_code_file_embed_retries_api_connection_error(tmp_path) -> None:
         success_result, success_result, success_result,
     ]
 
-    with patch("nexus.db.t3.time.sleep"):
+    with patch("nexus.retry.time.sleep"):
         _index_code_file(
             py_file, tmp_path, "code__test", "voyage-code-3",
             mock_col, mock_db, mock_voyage, {}, "2026-03-05T00:00:00",
@@ -239,7 +239,7 @@ def test_rerank_results_retries_then_degrades() -> None:
     with patch("voyageai.Client", return_value=mock_client), \
          patch("nexus.config.get_credential", return_value="test-key"), \
          patch("nexus.config.load_config", return_value={"voyageai": {"read_timeout_seconds": 120}}), \
-         patch("nexus.db.t3.time.sleep"):
+         patch("nexus.retry.time.sleep"):
         returned = scoring.rerank_results(results, "query", top_k=1)
 
     assert mock_client.rerank.call_count == 3  # 3 attempts then re-raises → caught by outer except
@@ -290,7 +290,7 @@ def test_embed_with_fallback_cce_retry_then_degrade_e2e() -> None:
     mock_client.embed.return_value = voyage4_result
 
     with patch("voyageai.Client", return_value=mock_client), \
-         patch("nexus.db.t3.time.sleep"):
+         patch("nexus.retry.time.sleep"):
         # CCE requires >= 2 chunks; use two chunks to trigger the CCE path
         embeddings, model = _embed_with_fallback(
             ["chunk one", "chunk two"], "voyage-context-3", "test-key"
@@ -309,7 +309,7 @@ def test_embed_with_fallback_standard_path_propagates_after_retry_exhaustion() -
     mock_client.embed.side_effect = _ve.APIConnectionError("persistent")
 
     with patch("voyageai.Client", return_value=mock_client), \
-         patch("nexus.db.t3.time.sleep"), \
+         patch("nexus.retry.time.sleep"), \
          pytest.raises(_ve.APIConnectionError):
         _embed_with_fallback(["one chunk"], "voyage-4", "test-key")
 
@@ -324,6 +324,6 @@ def test_client_constructed_with_config_timeout() -> None:
     mock_client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024])
 
     with patch("voyageai.Client", return_value=mock_client) as mock_ctor, \
-         patch("nexus.db.t3.time.sleep"):
+         patch("nexus.retry.time.sleep"):
         _embed_with_fallback(["chunk"], "voyage-4", "test-key", timeout=60.0)
         mock_ctor.assert_called_once_with(api_key="test-key", timeout=60.0, max_retries=3)

--- a/tests/test_voyage_retry.py
+++ b/tests/test_voyage_retry.py
@@ -267,3 +267,60 @@ def test_reset_voyage_client_clears_singleton() -> None:
     _reset_voyage_client()
     assert scoring._voyage_instance is None
 
+
+
+# ── nexus-n4v9: integration tests ─────────────────────────────────────────────
+
+def test_embed_with_fallback_cce_retry_then_degrade_e2e() -> None:
+    """Full flow: CCE raises APIConnectionError 3 times (exhausting _voyage_with_retry),
+    except block catches and falls back to voyage-4 embed.
+    Verify: CCE called 3 times, fallback embed called once, returned model is 'voyage-4'.
+    """
+    from nexus.doc_indexer import _embed_with_fallback
+
+    cce_failure = _ve.APIConnectionError("persistent down")
+    voyage4_result = MagicMock()
+    voyage4_result.embeddings = [[0.1] * 1024]
+
+    mock_client = MagicMock()
+    mock_client.contextualized_embed.side_effect = cce_failure
+    mock_client.embed.return_value = voyage4_result
+
+    with patch("voyageai.Client", return_value=mock_client), \
+         patch("nexus.db.t3.time.sleep"):
+        # CCE requires >= 2 chunks; use two chunks to trigger the CCE path
+        embeddings, model = _embed_with_fallback(
+            ["chunk one", "chunk two"], "voyage-context-3", "test-key"
+        )
+
+    assert mock_client.contextualized_embed.call_count == 3  # 3 retry attempts
+    assert mock_client.embed.call_count == 1                  # fallback fired once
+    assert model == "voyage-4"
+
+
+def test_embed_with_fallback_standard_path_propagates_after_retry_exhaustion() -> None:
+    """Standard embed() raises APIConnectionError 3 times; exception propagates to caller."""
+    from nexus.doc_indexer import _embed_with_fallback
+
+    mock_client = MagicMock()
+    mock_client.embed.side_effect = _ve.APIConnectionError("persistent")
+
+    with patch("voyageai.Client", return_value=mock_client), \
+         patch("nexus.db.t3.time.sleep"), \
+         pytest.raises(_ve.APIConnectionError):
+        _embed_with_fallback(["one chunk"], "voyage-4", "test-key")
+
+    assert mock_client.embed.call_count == 3
+
+
+def test_client_constructed_with_config_timeout() -> None:
+    """When config has voyageai.read_timeout_seconds=60, Client is built with timeout=60."""
+    from nexus.doc_indexer import _embed_with_fallback
+
+    mock_client = MagicMock()
+    mock_client.embed.return_value = MagicMock(embeddings=[[0.1] * 1024])
+
+    with patch("voyageai.Client", return_value=mock_client) as mock_ctor, \
+         patch("nexus.db.t3.time.sleep"):
+        _embed_with_fallback(["chunk"], "voyage-4", "test-key", timeout=60.0)
+        mock_ctor.assert_called_once_with(api_key="test-key", timeout=60.0, max_retries=3)


### PR DESCRIPTION
## Summary

- Creates `src/nexus/retry.py` as a true leaf module (no `nexus.*` imports — only stdlib + httpx + structlog + soft voyageai.error)
- Moves all four retry helpers from `nexus.db.t3`: `_is_retryable_chroma_error`, `_chroma_with_retry`, `_is_retryable_voyage_error`, `_voyage_with_retry`
- Removes the local-import workaround in `scoring.py::rerank_results` — top-level `from nexus.retry import _voyage_with_retry` is now safe
- Updates all callers (`doc_indexer.py`, `indexer.py`, `scoring.py`) and test imports
- Updates `time.sleep` mock patches from `nexus.db.t3.time` → `nexus.retry.time`
- Extends `test_no_circular_imports` to assert `nexus.retry` has no `nexus.db` attribute

## Test plan

- [x] `tests/test_chroma_retry.py` — 60 tests pass
- [x] `tests/test_voyage_retry.py` — included in above count
- [x] `tests/test_search_modules.py` — `test_no_circular_imports` passes with new retry assertion
- [x] Full suite: 1884 passed, 8 skipped, 0 errors

References: nexus-nwju