### PR TITLE
feat: unify language registry and expand to 44 extensions (RDR-028)

### DIFF
--- a/docs/plans/2026-03-09-rdr-028-language-registry-impl-plan.md
+++ b/docs/plans/2026-03-09-rdr-028-language-registry-impl-plan.md
@@ -1,0 +1,504 @@
+# RDR-028: Language Registry Unification -- Implementation Plan
+
+**RDR**: docs/rdr/rdr-028-code-search-recall.md (status: accepted)
+**Parent bead**: nexus-bqjj (in_progress)
+**Estimated LOC**: ~185 (new + changed)
+**Risk**: Low -- dict unification, no architectural changes
+
+## Executive Summary
+
+Unify three drifted language-to-extension maps (`AST_EXTENSIONS`, `_EXT_TO_LANGUAGE`, `_CODE_EXTENSIONS`) into a single `LANGUAGE_REGISTRY` in a new `src/nexus/languages.py` module. Fix the `.tsx` inconsistency, close the 4-extension classifier gap, and add ~14 new languages from arcaneum's coverage set. All changes are backward-compatible via import aliases.
+
+## Phase Breakdown
+
+### Phase 1: Registry Foundation + Migration (~70 LOC)
+**Bead**: nexus-luhd (P1)
+**Rationale**: Establish the single source of truth before expanding. Fix existing bugs (.tsx inconsistency, 4 missing classifier extensions) immediately.
+
+### Phase 2: Language Expansion (~80 LOC)
+**Bead**: nexus-kyah (P2, blocked by nexus-luhd)
+**Rationale**: With the registry in place, adding languages is a pure data addition -- no structural changes.
+
+### Phase 4 (deferred): Alias Removal
+**Bead**: nexus-mnzi (P3, blocked by nexus-kyah)
+**Rationale**: After one release cycle, remove `AST_EXTENSIONS` and `_EXT_TO_LANGUAGE` aliases if no external imports exist.
+
+## Dependency Graph
+
+```
+nexus-bqjj (parent epic, in_progress)
+  |
+  +-- nexus-luhd (Phase 1: Registry Foundation + Migration)
+        |
+        +-- nexus-kyah (Phase 2: Language Expansion)
+              |
+              +-- nexus-mnzi (Phase 4: Alias Removal, deferred)
+```
+
+Critical path: Phase 1 -> Phase 2 (sequential, no parallelization -- TDD requires test-then-implement ordering).
+
+## Detailed Task Specifications
+
+---
+
+### Task 1.1: Write Failing Consistency Tests (TDD Red)
+
+**Bead**: nexus-luhd
+**File**: `tests/test_languages.py` (NEW)
+**Command**: `uv run pytest tests/test_languages.py -v` (expect failures)
+
+Write the following tests before any implementation exists:
+
+```python
+# tests/test_languages.py -- ~40 LOC
+
+# Test A: LANGUAGE_REGISTRY importable, >= 27 entries
+def test_registry_exists_and_has_minimum_entries():
+    from nexus.languages import LANGUAGE_REGISTRY
+    assert len(LANGUAGE_REGISTRY) >= 27
+
+# Test B: Every entry has valid tree-sitter parser
+@pytest.mark.parametrize("ext,lang", LANGUAGE_REGISTRY.items())
+def test_registry_entry_has_valid_parser(ext, lang):
+    from tree_sitter_language_pack import get_parser
+    parser = get_parser(lang)
+    assert parser is not None
+
+# Test C: .tsx maps to "tsx" (not "typescript")
+def test_tsx_maps_to_tsx():
+    from nexus.languages import LANGUAGE_REGISTRY
+    assert LANGUAGE_REGISTRY[".tsx"] == "tsx"
+
+# Test D: Every DEFINITION_TYPES key is a LANGUAGE_REGISTRY value
+def test_definition_types_subset_of_registry():
+    from nexus.languages import LANGUAGE_REGISTRY
+    from nexus.indexer import DEFINITION_TYPES
+    registry_values = set(LANGUAGE_REGISTRY.values())
+    for lang in DEFINITION_TYPES:
+        assert lang in registry_values, f"{lang} in DEFINITION_TYPES but not in LANGUAGE_REGISTRY values"
+
+# Test E: Every _COMMENT_CHARS key is a LANGUAGE_REGISTRY value
+def test_comment_chars_subset_of_registry():
+    from nexus.languages import LANGUAGE_REGISTRY
+    from nexus.indexer import _COMMENT_CHARS
+    registry_values = set(LANGUAGE_REGISTRY.values())
+    for lang in _COMMENT_CHARS:
+        assert lang in registry_values, f"{lang} in _COMMENT_CHARS but not in LANGUAGE_REGISTRY values"
+
+# Test F: Every LANGUAGE_REGISTRY key is in _CODE_EXTENSIONS
+def test_all_registry_keys_in_code_extensions():
+    from nexus.languages import LANGUAGE_REGISTRY
+    from nexus.classifier import _CODE_EXTENSIONS
+    for ext in LANGUAGE_REGISTRY:
+        assert ext in _CODE_EXTENSIONS, f"{ext} in LANGUAGE_REGISTRY but not in _CODE_EXTENSIONS"
+
+# Test G: .tsx has DEFINITION_TYPES entry
+def test_tsx_has_definition_types():
+    from nexus.indexer import DEFINITION_TYPES
+    assert "tsx" in DEFINITION_TYPES
+
+# Test H: .tsx has _COMMENT_CHARS entry
+def test_tsx_has_comment_chars():
+    from nexus.indexer import _COMMENT_CHARS
+    assert "tsx" in _COMMENT_CHARS
+    assert _COMMENT_CHARS["tsx"] == "//"
+```
+
+**Acceptance criteria**:
+- [ ] File exists at `tests/test_languages.py`
+- [ ] All tests fail with ImportError or AssertionError (red phase)
+- [ ] No other tests broken
+
+---
+
+### Task 1.2: Create Registry + Migrate Consumers (TDD Green)
+
+**Bead**: nexus-luhd
+**Files**:
+- `src/nexus/languages.py` (NEW, ~30 LOC)
+- `src/nexus/chunker.py` (MODIFY lines 12-51)
+- `src/nexus/indexer.py` (MODIFY lines 32-60, 63-82, 87-179)
+- `src/nexus/classifier.py` (MODIFY lines 22-29)
+
+**Command**: `uv run pytest tests/test_languages.py -v` (expect pass)
+
+#### Step A: Create `src/nexus/languages.py`
+
+```python
+# src/nexus/languages.py
+
+"""Unified language registry for code indexing.
+
+Single source of truth for extension-to-language mapping, consumed by
+chunker.py (AST splitting), indexer.py (context extraction), and
+classifier.py (CODE vs PROSE classification).
+"""
+
+LANGUAGE_REGISTRY: dict[str, str] = {
+    # Core web/scripting
+    ".py": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".ts": "typescript",
+    ".tsx": "tsx",           # tree-sitter has separate tsx grammar
+    # Systems languages
+    ".c": "c",
+    ".h": "c",
+    ".cpp": "cpp",
+    ".cc": "cpp",
+    ".cxx": "cpp",
+    ".hpp": "cpp",
+    ".rs": "rust",
+    ".go": "go",
+    # JVM family
+    ".java": "java",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".scala": "scala",
+    ".sc": "scala",
+    # .NET
+    ".cs": "c_sharp",
+    # Shell / scripting
+    ".sh": "bash",
+    ".bash": "bash",
+    # Mobile / cross-platform
+    ".swift": "swift",
+    ".m": "objc",
+    # Interpreted
+    ".rb": "ruby",
+    ".php": "php",
+    ".r": "r",
+    ".lua": "lua",
+}
+
+# Extensions classified as CODE but not in LANGUAGE_REGISTRY
+# (no tree-sitter grammar or AST chunking needed).
+GPU_SHADER_EXTENSIONS: frozenset[str] = frozenset({
+    ".cl", ".comp", ".frag", ".vert", ".metal", ".glsl", ".wgsl", ".hlsl",
+})
+```
+
+#### Step B: Migrate `src/nexus/chunker.py`
+
+Replace the `AST_EXTENSIONS` dict literal (lines 12-51) with:
+
+```python
+from nexus.languages import LANGUAGE_REGISTRY
+
+# Backward-compat alias; will be removed after one release cycle.
+AST_EXTENSIONS = LANGUAGE_REGISTRY
+```
+
+Remove the comment block at lines 12-15 that explains the old dict.
+
+#### Step C: Migrate `src/nexus/indexer.py`
+
+Replace the `_EXT_TO_LANGUAGE` dict literal (lines 32-60) with:
+
+```python
+from nexus.languages import LANGUAGE_REGISTRY
+
+# Backward-compat alias; will be removed after one release cycle.
+_EXT_TO_LANGUAGE = LANGUAGE_REGISTRY
+```
+
+Add `"tsx"` to `_COMMENT_CHARS` (after line 66, alongside "typescript"):
+
+```python
+"tsx": "//",
+```
+
+Add `"tsx"` to `DEFINITION_TYPES` (after the "typescript" entry, line 107):
+
+```python
+"tsx": {
+    "function_declaration": "function",
+    "class_declaration": "class",
+    "method_definition": "method",
+    "interface_declaration": "interface",
+    "type_alias_declaration": "type",
+    "arrow_function": "function",
+},
+```
+
+#### Step D: Derive `_CODE_EXTENSIONS` in `src/nexus/classifier.py`
+
+Replace the hardcoded `_CODE_EXTENSIONS` frozenset (lines 22-29) with:
+
+```python
+from nexus.languages import LANGUAGE_REGISTRY, GPU_SHADER_EXTENSIONS
+
+# Derived from LANGUAGE_REGISTRY to prevent drift.
+_CODE_EXTENSIONS: frozenset[str] = frozenset(LANGUAGE_REGISTRY.keys()) | GPU_SHADER_EXTENSIONS
+```
+
+This automatically adds the 4 previously missing extensions: `.lua`, `.cxx`, `.kts`, `.sc`.
+
+**Acceptance criteria**:
+- [ ] `src/nexus/languages.py` exists with LANGUAGE_REGISTRY (27 entries)
+- [ ] `chunker.py` imports from `languages.py`, AST_EXTENSIONS is alias
+- [ ] `indexer.py` imports from `languages.py`, _EXT_TO_LANGUAGE is alias
+- [ ] `indexer.py` has "tsx" in both DEFINITION_TYPES and _COMMENT_CHARS
+- [ ] `classifier.py` derives _CODE_EXTENSIONS from LANGUAGE_REGISTRY
+- [ ] `uv run pytest tests/test_languages.py -v` all pass
+
+---
+
+### Task 1.3: Update Existing Tests (TDD Maintain Green)
+
+**Bead**: nexus-luhd
+**File**: `tests/test_classifier.py` (MODIFY, line 67-77)
+**Command**: `uv run pytest` (full suite, all green)
+
+Rewrite `test_code_extensions_set_matches_design` to verify the derivation property rather than hardcoding the exact set:
+
+```python
+def test_code_extensions_derived_from_registry():
+    """_CODE_EXTENSIONS contains all LANGUAGE_REGISTRY keys plus GPU shader extensions."""
+    from nexus.languages import LANGUAGE_REGISTRY, GPU_SHADER_EXTENSIONS
+    from nexus.classifier import _CODE_EXTENSIONS
+    expected = frozenset(LANGUAGE_REGISTRY.keys()) | GPU_SHADER_EXTENSIONS
+    assert _CODE_EXTENSIONS == expected
+```
+
+Also verify the 4 previously missing extensions now classify correctly:
+
+```python
+@pytest.mark.parametrize("filename", [
+    "script.lua", "main.cxx", "build.kts", "app.sc",
+])
+def test_previously_missing_code_extensions(filename: str):
+    """Extensions that were in LANGUAGE_REGISTRY but missing from _CODE_EXTENSIONS."""
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path(filename)) == ContentClass.CODE, f"{filename} should be CODE"
+```
+
+**Acceptance criteria**:
+- [ ] `test_code_extensions_set_matches_design` replaced with derivation test
+- [ ] 4 previously missing extensions verified as CODE
+- [ ] `uv run pytest` full suite passes (zero failures)
+- [ ] Phase 1 ready to commit
+
+---
+
+### Task 2.1: Write Failing Expansion Tests (TDD Red)
+
+**Bead**: nexus-kyah
+**File**: `tests/test_languages.py` (MODIFY, append)
+**Command**: `uv run pytest tests/test_languages.py -v` (expect new failures)
+
+Add tests for language expansion:
+
+```python
+# New language extensions to verify
+_NEW_EXTENSIONS = {
+    ".proto": "proto",
+    ".ex": "elixir", ".exs": "elixir",
+    ".hs": "haskell",
+    ".clj": "clojure", ".cljs": "clojure", ".cljc": "clojure",
+    ".dart": "dart",
+    ".zig": "zig",
+    ".jl": "julia",
+    ".el": "elisp",
+    ".erl": "erlang", ".hrl": "erlang",
+    ".ml": "ocaml", ".mli": "ocaml_interface",
+    ".pl": "perl", ".pm": "perl",
+}
+
+def test_registry_expanded():
+    from nexus.languages import LANGUAGE_REGISTRY
+    assert len(LANGUAGE_REGISTRY) >= 44  # 27 + 17
+
+@pytest.mark.parametrize("ext,lang", _NEW_EXTENSIONS.items())
+def test_new_extension_in_registry(ext, lang):
+    from nexus.languages import LANGUAGE_REGISTRY
+    assert ext in LANGUAGE_REGISTRY, f"{ext} not in LANGUAGE_REGISTRY"
+    assert LANGUAGE_REGISTRY[ext] == lang
+
+@pytest.mark.parametrize("ext", _NEW_EXTENSIONS.keys())
+def test_new_extension_classified_as_code(ext):
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path(f"file{ext}")) == ContentClass.CODE
+
+_NEW_COMMENT_CHARS = {
+    "proto": "//", "elixir": "#", "haskell": "--",
+    "clojure": ";", "dart": "//", "zig": "//",
+    "julia": "#", "elisp": ";", "erlang": "%",
+    "ocaml": "(*", "ocaml_interface": "(*", "perl": "#",
+}
+
+@pytest.mark.parametrize("lang,char", _NEW_COMMENT_CHARS.items())
+def test_new_language_has_comment_char(lang, char):
+    from nexus.indexer import _COMMENT_CHARS
+    assert lang in _COMMENT_CHARS, f"{lang} missing from _COMMENT_CHARS"
+    assert _COMMENT_CHARS[lang] == char
+
+_NEW_DEFINITION_TYPES_LANGS = ["dart", "haskell", "julia", "ocaml", "perl", "erlang"]
+
+@pytest.mark.parametrize("lang", _NEW_DEFINITION_TYPES_LANGS)
+def test_new_language_has_definition_types(lang):
+    from nexus.indexer import DEFINITION_TYPES
+    assert lang in DEFINITION_TYPES, f"{lang} missing from DEFINITION_TYPES"
+    assert len(DEFINITION_TYPES[lang]) >= 1
+```
+
+**Acceptance criteria**:
+- [ ] New tests added to `tests/test_languages.py`
+- [ ] New tests fail (red phase)
+- [ ] Existing tests still pass
+
+---
+
+### Task 2.2: Add New Languages (TDD Green)
+
+**Bead**: nexus-kyah
+**Files**:
+- `src/nexus/languages.py` (MODIFY, add entries)
+- `src/nexus/indexer.py` (MODIFY, add _COMMENT_CHARS + DEFINITION_TYPES)
+
+**Command**: `uv run pytest` (full suite, all green)
+
+#### Step A: Expand LANGUAGE_REGISTRY in `src/nexus/languages.py`
+
+Add after the existing entries:
+
+```python
+    # ── New languages (RDR-028 Phase 2) ──
+    # Protocol / schema
+    ".proto": "proto",
+    # BEAM ecosystem
+    ".ex": "elixir",
+    ".exs": "elixir",
+    ".erl": "erlang",
+    ".hrl": "erlang",
+    # Functional languages
+    ".hs": "haskell",
+    ".clj": "clojure",
+    ".cljs": "clojure",
+    ".cljc": "clojure",
+    ".ml": "ocaml",
+    ".mli": "ocaml_interface",
+    ".el": "elisp",
+    # Modern systems / app languages
+    ".dart": "dart",
+    ".zig": "zig",
+    ".jl": "julia",
+    # Scripting
+    ".pl": "perl",
+    ".pm": "perl",
+```
+
+#### Step B: Expand `_COMMENT_CHARS` in `src/nexus/indexer.py`
+
+Add after existing entries:
+
+```python
+    "proto": "//",
+    "elixir": "#",
+    "haskell": "--",
+    "clojure": ";",
+    "dart": "//",
+    "zig": "//",
+    "julia": "#",
+    "elisp": ";",
+    "erlang": "%",
+    "ocaml": "(*",
+    "ocaml_interface": "(*",
+    "perl": "#",
+```
+
+#### Step C: Expand `DEFINITION_TYPES` in `src/nexus/indexer.py`
+
+Add after existing entries:
+
+```python
+    "dart": {
+        "class_definition": "class",
+        "method_signature": "method",
+        "function_signature": "function",
+    },
+    "haskell": {
+        "function": "function",
+        "data_type": "class",
+    },
+    "julia": {
+        "function_definition": "function",
+        "struct_definition": "class",
+    },
+    "ocaml": {
+        "value_definition": "function",
+        "type_definition": "class",
+        "module_definition": "module",
+    },
+    "perl": {
+        "subroutine_declaration_statement": "function",
+    },
+    "erlang": {
+        "function_clause": "function",
+    },
+```
+
+**Note**: Languages without DEFINITION_TYPES (proto, elixir, clojure, zig, elisp, ocaml_interface) still get AST chunking and comment-char prefixes but no class/method context extraction. This is acceptable degradation per the RDR.
+
+**Acceptance criteria**:
+- [ ] LANGUAGE_REGISTRY has 44 entries (27 + 17)
+- [ ] _COMMENT_CHARS covers all 30 LANGUAGE_REGISTRY language values
+- [ ] DEFINITION_TYPES has entries for dart, haskell, julia, ocaml, perl, erlang
+- [ ] `uv run pytest` full suite passes (zero failures)
+- [ ] Phase 2 ready to commit
+
+---
+
+### Phase 4 (deferred): Alias Removal
+
+**Bead**: nexus-mnzi (blocked by nexus-kyah)
+**When**: After one release cycle following Phase 2 merge.
+
+Steps:
+1. Grep for imports of `AST_EXTENSIONS` and `_EXT_TO_LANGUAGE` outside the nexus package
+2. If no external consumers, remove aliases:
+   - `chunker.py`: Change `AST_EXTENSIONS = LANGUAGE_REGISTRY` to direct `LANGUAGE_REGISTRY` usage at line 200
+   - `indexer.py`: Change `_EXT_TO_LANGUAGE = LANGUAGE_REGISTRY` to direct `LANGUAGE_REGISTRY` usage at line 519
+3. Update tests that import `AST_EXTENSIONS` (currently `test_chunker.py` does NOT import it directly)
+4. Run full test suite
+
+---
+
+## Risk Factors and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| `.tsx` metadata value change breaks search results | Existing chunks have `programming_language: "typescript"`, new chunks get `"tsx"` | Document in CHANGELOG: `--force` reindex needed for TSX repos |
+| tree-sitter parser quirks for new languages | AST chunking may produce suboptimal chunks | Existing `try/except` in chunker falls back to line-based |
+| OCaml `(*` comment char looks odd in prefix | Embedding sees `(* File: path` without closing `*)` | Embedding model treats it as metadata context; not a correctness issue |
+| `ocaml_interface` as language name may confuse users | `.mli` files show `ocaml_interface` in metadata | Correct: `.mli` has different AST structure; tree-sitter requires separate parser |
+| `nim` dropped (no tree-sitter binding) | nim files not indexed | Can add when tree-sitter-language-pack ships nim binding |
+
+## Verification Checklist
+
+After each phase, verify:
+- [ ] `uv run pytest` -- full suite passes
+- [ ] `uv run pytest tests/test_languages.py -v` -- all consistency tests pass
+- [ ] `uv run pytest tests/test_classifier.py -v` -- classifier tests pass
+- [ ] `uv run pytest tests/test_chunker_ast_languages.py -v` -- AST chunking tests pass
+
+## Files Changed Summary
+
+| File | Phase | Change |
+|------|-------|--------|
+| `src/nexus/languages.py` | 1+2 | NEW: LANGUAGE_REGISTRY, GPU_SHADER_EXTENSIONS |
+| `src/nexus/chunker.py` | 1 | Replace dict with import alias |
+| `src/nexus/indexer.py` | 1+2 | Replace dict with import alias, expand DEFINITION_TYPES + _COMMENT_CHARS |
+| `src/nexus/classifier.py` | 1 | Derive _CODE_EXTENSIONS from registry |
+| `tests/test_languages.py` | 1+2 | NEW: consistency + expansion tests |
+| `tests/test_classifier.py` | 1 | Update hardcoded test to derivation test |
+
+## References
+
+- RDR: `docs/rdr/rdr-028-code-search-recall.md`
+- Parent bead: nexus-bqjj
+- Phase 1 bead: nexus-luhd
+- Phase 2 bead: nexus-kyah
+- Phase 4 bead: nexus-mnzi (deferred)
+- Arcaneum LANGUAGE_MAP: `/Users/hal.hildebrand/git/arcaneum/src/arcaneum/indexing/ast_chunker.py:40-95`
+- tree-sitter-language-pack bindings: 158 languages available (v0.7.1)

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -41,7 +41,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-025](rdr-025-language-agnostic-agents.md) | Generalize Java Agents to Language-Agnostic Developer/Debugger/Architect-Planner | Enhancement | Closed | 2026-03-08 |
 | [RDR-026](rdr-026-hybrid-search-fusion.md) | Hybrid Search — Vector + Ripgrep Query Fusion | Feature | Draft | 2026-03-08 |
 | [RDR-027](rdr-027-search-results-ux.md) | Search Results UX — Context Lines and Syntax Highlighting | Feature | Draft | 2026-03-08 |
-| [RDR-028](rdr-028-code-search-recall.md) | Code Search Recall — Language Registry Unification | Enhancement | Accepted | 2026-03-08 |
+| [RDR-028](rdr-028-code-search-recall.md) | Code Search Recall — Language Registry Unification | Enhancement | Closed | 2026-03-08 |
 | [RDR-029](rdr-029-pipeline-versioning.md) | Pipeline Versioning — Force Reindex and Collection Version Stamping | Enhancement | Draft | 2026-03-08 |
 | [RDR-030](rdr-030-reliability-hardening.md) | Reliability Hardening — Silent Error Audit and Logging Policy | Enhancement | Draft | 2026-03-08 |
 | [RDR-031](rdr-031-collection-portability.md) | Collection Portability — Export/Import for T3 Backup and Migration | Feature | Draft | 2026-03-08 |

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -39,6 +39,13 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-023](rdr-023-agent-tool-permissions-audit.md) | Agent Tool Permissions Audit and Remediation | Enhancement | Closed | 2026-03-07 |
 | [RDR-024](rdr-024-rdr-process-guardrails.md) | RDR Process Guardrails: Prevent Implementation Before Gate/Accept | Enhancement | Closed | 2026-03-07 |
 | [RDR-025](rdr-025-language-agnostic-agents.md) | Generalize Java Agents to Language-Agnostic Developer/Debugger/Architect-Planner | Enhancement | Closed | 2026-03-08 |
+| [RDR-026](rdr-026-hybrid-search-fusion.md) | Hybrid Search — Vector + Ripgrep Query Fusion | Feature | Draft | 2026-03-08 |
+| [RDR-027](rdr-027-search-results-ux.md) | Search Results UX — Context Lines and Syntax Highlighting | Feature | Draft | 2026-03-08 |
+| [RDR-028](rdr-028-code-search-recall.md) | Code Search Recall — Language Registry Unification | Enhancement | Accepted | 2026-03-08 |
+| [RDR-029](rdr-029-pipeline-versioning.md) | Pipeline Versioning — Force Reindex and Collection Version Stamping | Enhancement | Draft | 2026-03-08 |
+| [RDR-030](rdr-030-reliability-hardening.md) | Reliability Hardening — Silent Error Audit and Logging Policy | Enhancement | Draft | 2026-03-08 |
+| [RDR-031](rdr-031-collection-portability.md) | Collection Portability — Export/Import for T3 Backup and Migration | Feature | Draft | 2026-03-08 |
+| [RDR-032](rdr-032-indexer-decomposition.md) | Indexer Module Decomposition and Configuration Externalization | Technical Debt | Draft | 2026-03-08 |
 
 ## RDR Process Documentation
 

--- a/docs/rdr/post-mortem/028-language-registry-unification.md
+++ b/docs/rdr/post-mortem/028-language-registry-unification.md
@@ -1,0 +1,55 @@
+# Post-Mortem: RDR-028 — Language Registry Unification
+
+**Closed**: 2026-03-09
+**Reason**: Implemented
+**PR**: #76
+**Bead**: nexus-bqjj
+
+## What Was Done
+
+Unified three drifted language-to-extension maps into a single `LANGUAGE_REGISTRY`
+in `src/nexus/languages.py`:
+
+1. Created `LANGUAGE_REGISTRY` (44 extensions → 30 languages) and `GPU_SHADER_EXTENSIONS`
+2. Migrated `chunker.py`, `indexer.py`, `classifier.py` to import from the registry
+3. Fixed `.tsx` inconsistency: consistently `"tsx"` with matching DEFINITION_TYPES and _COMMENT_CHARS
+4. Fixed `c_sharp` parser lookup: chunker now maps to `"csharp"` for tree-sitter-language-pack
+5. Fixed 4 extensions (`.lua`, `.cxx`, `.kts`, `.sc`) missing from classifier
+6. Added 16 new extensions across 11 languages: elixir, erlang, haskell, clojure, ocaml, elisp, dart, zig, julia, perl, proto
+7. Added DEFINITION_TYPES for 6 new languages (dart, haskell, julia, ocaml, perl, erlang)
+8. Added _COMMENT_CHARS for all 12 new language values
+9. Derived `_CODE_EXTENSIONS` from `LANGUAGE_REGISTRY.keys() | GPU_SHADER_EXTENSIONS` to prevent future drift
+
+## Plan vs. Actual Divergences
+
+| Planned | Actual | Impact |
+|---------|--------|--------|
+| Backward-compat aliases for AST_EXTENSIONS and _EXT_TO_LANGUAGE | User chose to skip — aliases removed directly | Simpler code, Phase 4 (deferred removal) completed immediately |
+| `.proto` in Phase 2 expansion | Moved to Phase 1 — was already in `_CODE_EXTENSIONS`, removing it would regress | No impact, just reordered |
+| nim language included | Dropped — tree-sitter-language-pack 0.7.1 has no nim binding | Can add when binding ships |
+| 28 base entries | Actually 28 (27 + proto from old _CODE_EXTENSIONS) | Corrected in implementation |
+| c_sharp parser bug not in scope | Discovered during implementation — get_parser("c_sharp") throws LookupError | Bonus fix: C# files now get AST chunking instead of silent fallback to line-based |
+
+## Discoveries
+
+- **c_sharp parser was broken**: `get_parser("c_sharp")` fails because tree-sitter-language-pack
+  uses `"csharp"`. The chunker's `try/except` silently caught the LookupError and fell back to
+  line-based chunking. C# files have never had AST chunking in nexus. Fixed with a parser name
+  mapping in `_make_code_splitter`.
+
+- **ocaml_interface is a separate parser**: `.mli` files need `ocaml_interface`, not `ocaml`.
+  tree-sitter treats OCaml interface files as a distinct grammar.
+
+## Test Coverage
+
+- 59 tests in `tests/test_languages.py` covering registry consistency, parser availability,
+  DEFINITION_TYPES/COMMENT_CHARS subset relationships, and classifier derivation
+- Updated `test_classifier.py` to verify derivation property instead of hardcoded set
+- Full suite: 1954 passed, 0 failed
+
+## Process Notes
+
+This RDR went through the full lifecycle: draft → gate (2 rounds — first found factual
+errors about Tracks A/B being unimplemented, second found classifier gap) → accept → implement → close.
+The gate process caught a real bug (classifier not updating for new languages) that would have
+been a silent regression.

--- a/docs/rdr/rdr-026-hybrid-search-fusion.md
+++ b/docs/rdr/rdr-026-hybrid-search-fusion.md
@@ -1,0 +1,139 @@
+---
+title: "Hybrid Search — Vector + Ripgrep Query Fusion"
+id: RDR-026
+type: Feature
+status: draft
+priority: P1
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues: ["RDR-006", "RDR-007", "RDR-014"]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-026: Hybrid Search — Vector + Ripgrep Query Fusion
+
+## Problem Statement
+
+`nx search` queries ChromaDB vector collections only. The `ripgrep_cache.py` module exists but is wired only into the indexing pipeline — it is never used at query time. This means:
+
+1. **No exact-match boosting**: Searching for `def compute_frecency` returns semantically similar but non-literal matches ranked equally with exact matches
+2. **Recall gaps**: Canonical implementation files absent from ChromaDB's top-K candidate set (documented in RDR-006/007) could be found trivially by ripgrep
+3. **No keyword fallback**: When semantic search fails on domain-specific jargon, ripgrep would catch literal occurrences
+
+SeaGOAT (a sibling project at `/Users/hal.hildebrand/git/SeaGOAT/`) demonstrates that fusing ripgrep keyword hits with vector results produces strictly better results than either alone. Their implementation at `seagoat/engine.py:125-155` fans out to both sources asynchronously and merges with weighted scoring.
+
+## Context
+
+- `ripgrep_cache.py` already provides `RipgrepCache.search(query, repo_path)` → list of file matches with line numbers
+- `search_engine.py` handles cross-corpus vector queries serially
+- `scoring.py` implements `apply_hybrid_scoring()` with weights `0.7 * vector + 0.3 * frecency`
+- SeaGOAT's scoring: `0.7 * vector + 0.3 * frecency`, plus exact-match boost (halves distance when regex matches found)
+- The `--hybrid` flag existed historically but was a no-op (bead nexus-4qu, since removed in RDR-009)
+
+## Research Findings
+
+### F1: SeaGOAT Fusion Architecture (Verified — source search)
+
+SeaGOAT queries ChromaDB and ripgrep simultaneously via async (`engine.py:65-72`), then merges results. Each source produces `Result` objects with file paths, line numbers, and distances. The merge strategy:
+- Vector results contribute semantic relevance scores
+- Ripgrep results contribute exact-match signals
+- `result.py:get_number_of_exact_matches()` boosts scores when query text literally appears in a result line
+
+### F2: Nexus Infrastructure Already Exists (Verified — source search)
+
+- `ripgrep_cache.py:91` has `search()` with 10s timeout
+- `scoring.py` already has the hybrid scoring formula
+- The missing piece is the query-time fan-out: call ripgrep alongside ChromaDB, merge result sets, and boost exact matches
+
+### F3: Ripgrep Availability (Verified — runtime check)
+
+`rg` is a required dependency for nexus (installed by `brew install ripgrep` on macOS, `apt install ripgrep` on Linux). The `nx doctor` command already checks for its presence.
+
+## Proposed Solution
+
+Add a `--hybrid` flag to `nx search` that:
+
+1. Runs the vector query against ChromaDB (existing path)
+2. Simultaneously runs `rg --json "{query}" {repo_path}` via `ripgrep_cache.search()`
+3. Merges results: vector results are primary, ripgrep results boost scores for files/lines with exact matches
+4. Optionally: ripgrep-only results (files not in vector top-K) are appended with a configurable penalty
+
+### Scoring Formula
+
+```
+final_score = vector_weight * vector_norm + frecency_weight * frecency_norm + exact_match_boost
+```
+
+Where:
+- `vector_weight = 0.7` (existing)
+- `frecency_weight = 0.3` (existing)
+- `exact_match_boost = 0.15` when ripgrep finds the query literally in the chunk (new)
+
+### Integration Points
+
+- `search_engine.py`: Add `hybrid: bool` parameter to `search()`, fan out to ripgrep
+- `scoring.py`: Add `exact_match_boost` to `apply_hybrid_scoring()`
+- `commands/search.py`: Add `--hybrid` CLI flag
+- `ripgrep_cache.py`: Ensure `search()` works for arbitrary queries (not just cached patterns)
+
+## Alternatives Considered
+
+**A. Keyword search via ChromaDB's where_document filter**: ChromaDB supports `$contains` filters, but these are post-filter on the vector results, not a separate search source. This doesn't expand the candidate set.
+
+**B. Full ripgrep-first, vector-rerank**: Run ripgrep first, then use Voyage AI to rerank. Inverts the architecture and loses semantic discovery. Rejected.
+
+**C. BM25 via SQLite FTS5**: Build a full-text index in T2 alongside T3 vectors. Higher engineering cost than ripgrep integration and requires maintaining a parallel index. Deferred as a future enhancement.
+
+## Trade-offs
+
+**Benefits**:
+- Directly addresses the code search recall gap (RDR-006/007)
+- Leverages existing infrastructure (ripgrep_cache.py, scoring.py)
+- Opt-in via `--hybrid` flag — no regression risk for existing workflows
+
+**Risks**:
+- Ripgrep adds ~100ms latency per query (mitigated: run in parallel with vector query)
+- Ripgrep requires a local clone (not applicable for cloud-only collections)
+- Score calibration between vector distances and exact-match boosts needs tuning
+
+**Failure modes**:
+- Ripgrep not installed → degrade gracefully to vector-only (existing `nx doctor` check warns)
+- Ripgrep timeout → return vector-only results with warning
+- No local repo path available → skip ripgrep, log debug message
+
+## Implementation Plan
+
+### Phase 1: Core Fusion
+1. Extend `RipgrepCache.search()` to accept arbitrary query strings
+2. Add `hybrid: bool` parameter to `SearchEngine.search()`
+3. Implement async fan-out: vector query + ripgrep query in parallel
+4. Merge results: boost vector results that have ripgrep matches
+5. Add `--hybrid` flag to `nx search` CLI
+
+### Phase 2: Tuning & Testing
+6. Add integration tests with a fixture repo
+7. Tune exact_match_boost weight via A/B comparison on known queries
+8. Add `search.hybrid_default` config option for per-project defaults
+
+### Phase 3: Refinements
+9. Handle ripgrep-only results (files not in vector top-K) — append with penalty
+10. Line-level match tracking for future context-line display (see RDR-027)
+
+## Test Plan
+
+- Unit: mock ripgrep output, verify score boosting math
+- Unit: ripgrep timeout → graceful fallback to vector-only
+- Unit: ripgrep not installed → graceful fallback
+- Integration: search a fixture repo with known exact matches, verify they rank higher with --hybrid
+- Regression: existing non-hybrid searches produce identical results
+
+## References
+
+- SeaGOAT engine.py: `/Users/hal.hildebrand/git/SeaGOAT/seagoat/engine.py`
+- SeaGOAT result.py exact match: `/Users/hal.hildebrand/git/SeaGOAT/seagoat/result.py:14-28`
+- nexus ripgrep_cache.py: `src/nexus/ripgrep_cache.py`
+- nexus scoring.py: `src/nexus/scoring.py`
+- RDR-006: File-Size Scoring Penalty
+- RDR-007: Claude Adoption Search Guidance

--- a/docs/rdr/rdr-027-search-results-ux.md
+++ b/docs/rdr/rdr-027-search-results-ux.md
@@ -1,0 +1,120 @@
+---
+title: "Search Results UX — Context Lines and Syntax Highlighting"
+id: RDR-027
+type: Feature
+status: draft
+priority: P2
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues: ["RDR-026"]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-027: Search Results UX — Context Lines and Syntax Highlighting
+
+## Problem Statement
+
+`nx search` returns entire chunks (up to 150 lines of code or ~1500 chars of prose). This makes results hard to scan, especially when the relevant match is a few lines within a large chunk. Users must mentally grep within each result to find the salient portion.
+
+Two proven UX improvements from SeaGOAT and standard CLI tools:
+
+1. **Context lines** (`-A`, `-B`, `-C` flags like grep): Show only the most relevant lines within a chunk, with configurable context above/below
+2. **Syntax highlighting** (via `bat`): When `bat` is installed, pipe results through it for language-aware syntax coloring with line ranges
+
+## Context
+
+- Current formatters (`formatters.py`) display chunks as plain text blocks with file path, line range, and score
+- SeaGOAT (`seagoat/result.py:42-229`) implements `ResultLine` with types: RESULT, CONTEXT, BRIDGE — tracks per-line scores and merges nearby blocks
+- SeaGOAT (`seagoat/utils/cli_display.py:92-133`) detects `bat` and uses `bat --line-range {start}:{end} --file-name {path}` for syntax highlighting
+- Chunks already carry `line_start`/`line_end` metadata (fixed in RDR-016)
+
+## Research Findings
+
+### F1: Line-Level Scoring Within Chunks (Design needed)
+
+Unlike SeaGOAT which stores line-level embeddings, nexus stores chunk-level embeddings. To identify the most relevant lines within a chunk, options:
+
+a. **Keyword highlighting**: Use the query terms to find matching lines within the chunk (cheap, works for literal matches)
+b. **Embedding sub-scoring**: Embed individual lines and compare to query (expensive, defeats the purpose of chunking)
+c. **Heuristic center**: Show the middle N lines of the chunk (simple, often wrong)
+d. **Combined**: Use keyword matching when available (especially with RDR-026 hybrid search), fall back to showing the first N lines
+
+Recommendation: Option (d) — keyword match when available, first-N-lines fallback.
+
+### F2: bat Integration (Verified — SeaGOAT source)
+
+SeaGOAT's implementation at `cli_display.py:92-133`:
+1. Check if `bat` is installed via `shutil.which("bat")`
+2. Call `bat --line-range {start}:{end} --file-name {path} --style=numbers,changes --color=always`
+3. Fall back to plain display if `bat` is not available
+
+This is ~20 lines of code and provides immediate UX improvement.
+
+### F3: Bridge Line Merging (Verified — SeaGOAT source)
+
+When two result lines are separated by 2 or fewer non-matching lines, SeaGOAT bridges them into a single block (gap lines become BRIDGE type). This prevents fragmented output. The algorithm at `result.py:166-205` is straightforward.
+
+## Proposed Solution
+
+### Phase 1: Context Lines
+Add `-A` (after), `-B` (before), `-C` (context) flags to `nx search`:
+- Default: show entire chunk (backward compatible)
+- With flags: extract a focused window around the best-matching lines
+- Line identification: keyword match against query terms → highlight those lines
+- Bridge gaps of ≤2 lines between nearby matches
+
+### Phase 2: Syntax Highlighting
+Add `--bat` flag to `nx search`:
+- Detect `bat` availability at startup
+- Pipe each result through `bat` with appropriate `--file-name` for language detection
+- Respect `--no-color` / `NO_COLOR` environment variable
+
+### Phase 3: Compact Mode
+Add `--compact` flag:
+- Show only file path, line number, and the single best-matching line (like grep output)
+- Useful for piping into other tools
+
+## Alternatives Considered
+
+**A. Always show full chunks**: Current behavior. Too verbose for scanning. Users read 150 lines to find 3 relevant ones.
+
+**B. Truncate chunks to N lines**: Loses context. If the match is at line 140 of a 150-line chunk, you'd never see it.
+
+**C. Integrate with `fzf`**: Interactive fuzzy filtering of results. Good for interactive use but doesn't help non-interactive workflows. Could be added as `--fzf` flag in a future phase.
+
+## Trade-offs
+
+**Benefits**:
+- Results become scannable (grep-like experience developers expect)
+- Syntax highlighting is proven to improve code comprehension speed
+- All flags are additive — no existing behavior changes
+
+**Risks**:
+- Line identification heuristic may highlight wrong lines for semantic-only queries (no keyword overlap)
+- `bat` adds subprocess overhead (~50ms per result)
+
+## Implementation Plan
+
+1. Add `_find_matching_lines(chunk_text, query)` → list of line numbers
+2. Add `_extract_context(lines, matches, before, after)` → focused line blocks with bridge merging
+3. Add `-A`, `-B`, `-C` flags to `nx search` CLI
+4. Add `_format_with_bat(file_path, line_start, line_end)` → syntax-highlighted output
+5. Add `--bat` flag to `nx search` CLI
+6. Add `--compact` flag for single-line-per-result output
+7. Update `format_plain` and `format_vimgrep` formatters
+
+## Test Plan
+
+- Unit: `_find_matching_lines` with known query/chunk pairs
+- Unit: `_extract_context` with various before/after/bridge scenarios
+- Unit: bat detection when bat not installed → graceful fallback
+- Integration: search with `-C 3` produces exactly 3+1+3 lines per match
+- Integration: `--compact` produces grep-compatible output format
+
+## References
+
+- SeaGOAT result.py: `/Users/hal.hildebrand/git/SeaGOAT/seagoat/result.py`
+- SeaGOAT cli_display.py: `/Users/hal.hildebrand/git/SeaGOAT/seagoat/utils/cli_display.py`
+- nexus formatters.py: `src/nexus/formatters.py`

--- a/docs/rdr/rdr-028-code-search-recall.md
+++ b/docs/rdr/rdr-028-code-search-recall.md
@@ -2,7 +2,7 @@
 title: "Code Search Recall — Language Registry Unification"
 id: RDR-028
 type: Enhancement
-status: accepted
+status: closed
 priority: P2
 author: Hal Hildebrand
 reviewed-by: self

--- a/docs/rdr/rdr-028-code-search-recall.md
+++ b/docs/rdr/rdr-028-code-search-recall.md
@@ -1,0 +1,221 @@
+---
+title: "Code Search Recall — Language Registry Unification"
+id: RDR-028
+type: Enhancement
+status: accepted
+priority: P2
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues: ["RDR-006", "RDR-014", "RDR-015", "RDR-016"]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-028: Code Search Recall — Language Registry Unification
+
+## Problem Statement
+
+Nexus maintains two separate language-to-extension maps that have drifted:
+
+1. **`chunker.py:AST_EXTENSIONS`** (27 entries) — controls which files get AST-based chunking
+2. **`indexer.py:_EXT_TO_LANGUAGE`** (27 entries) — controls which files get context prefix metadata
+3. **`classifier.py:_CODE_EXTENSIONS`** (29 entries) — controls which files are classified as CODE vs PROSE
+
+These maps are nearly identical but have subtle inconsistencies:
+- `.tsx` maps to `"tsx"` in `AST_EXTENSIONS` but `"typescript"` in `_EXT_TO_LANGUAGE`
+- Neither map covers languages available in arcaneum's 53-entry `LANGUAGE_MAP`: `.el` (elisp), `.clj` (clojure), `.ex/.exs` (elixir), `.erl` (erlang), `.hs` (haskell), `.ml` (ocaml), `.proto`, `.dart`, `.zig`, `.jl` (julia), and more
+
+Having three maps invites future drift — a new language added to one but not the others would silently degrade classification, chunking, or context extraction. Currently, `_CODE_EXTENSIONS` is missing `.lua`, `.cxx`, `.kts`, `.sc` (present in both other maps), meaning those files are classified as PROSE and routed to the wrong indexing path. New languages added to `LANGUAGE_REGISTRY` must also be added to `_CODE_EXTENSIONS` or they will be silently indexed as prose.
+
+### Previously Proposed Tracks (Now Implemented)
+
+This RDR originally proposed three tracks. During gate review, Tracks A and B were found to be already implemented:
+
+- **Track A (DONE)**: `DEFINITION_TYPES` (16 languages) ported to `indexer.py:84-179`. `_extract_name_from_node()` at `indexer.py:185-218`. `_extract_context()` at `indexer.py:221-281`. Embed-only prefix uses `Class: {class_ctx}  Method: {method_ctx}` at `indexer.py:552-556`.
+- **Track B (DONE)**: Prose embed-only prefix `## Section: {header_path}` at `indexer.py:714-718`. PDF embed-only prefix `## Document: {source_title}  Page: {page_number}` at `indexer.py:845-854`.
+
+**Only Track C (Language Registry Unification) remains.**
+
+## Context
+
+- Both maps exist because they were created independently — `AST_EXTENSIONS` for the chunker, `_EXT_TO_LANGUAGE` for the indexer's context extraction
+- `_COMMENT_CHARS` (indexer.py:63-82) currently covers all 18 languages in `_EXT_TO_LANGUAGE` (including bash and objc which DEFINITION_TYPES lacks). When new languages are added to LANGUAGE_REGISTRY, `_COMMENT_CHARS` must be updated simultaneously or new languages will silently use `#` as comment char
+- Arcaneum's `LANGUAGE_MAP` at `ast_chunker.py` has 53 entries covering tree-sitter-language-pack's full set
+- `tree-sitter-language-pack==0.7.1` (pinned in pyproject.toml) provides parsers for 30+ languages
+
+## Research Findings
+
+### F1: Current Map Comparison (Verified — source search)
+
+Both maps contain the same 27 extensions. The single value mismatch is `.tsx`:
+
+| Extension | AST_EXTENSIONS | _EXT_TO_LANGUAGE | Mismatch? |
+|-----------|---------------|-----------------|-----------|
+| `.tsx` | `"tsx"` | `"typescript"` | **Yes** — chunker uses `tsx` grammar, indexer treats as typescript |
+| All others | Identical | Identical | No |
+
+The `.tsx` discrepancy is intentional for the chunker (tree-sitter has a separate `tsx` grammar) but the indexer should also use `"tsx"` for DEFINITION_TYPES lookup — except `DEFINITION_TYPES` has no `"tsx"` entry (it has `"typescript"`). This means `.tsx` files get AST chunking via the `tsx` parser but context extraction falls through to `DEFINITION_TYPES["typescript"]` via `_EXT_TO_LANGUAGE["tsx"] = "typescript"`. This happens to work because TypeScript definition types match TSX, but the coupling is fragile.
+
+### F2: Arcaneum Language Coverage (Verified — source search)
+
+Languages in arcaneum's `LANGUAGE_MAP` that nexus could support (tree-sitter parsers available):
+- `.proto` (protobuf) — common in microservice codebases
+- `.ex/.exs` (elixir) — growing ecosystem
+- `.hs` (haskell), `.ml/.mli` (ocaml) — functional languages
+- `.clj/.cljs/.cljc` (clojure) — JVM ecosystem
+- `.dart` (dart) — Flutter ecosystem
+- `.zig` (zig) — systems language
+- `.jl` (julia) — scientific computing
+- `.el` (elisp) — Emacs ecosystem
+- `.erl/.hrl` (erlang) — BEAM ecosystem
+- `.nim` (nim) — systems language
+
+### F3: tree-sitter-language-pack Compatibility (Verified — docs)
+
+`tree-sitter-language-pack==0.7.1` bundles parsers for all the above languages. Adding entries to the registry requires no new dependencies — only extending the dict.
+
+## Proposed Solution
+
+Create a single `LANGUAGE_REGISTRY` in a new `src/nexus/languages.py` module:
+
+```python
+LANGUAGE_REGISTRY: dict[str, str] = {
+    # Current 28 entries from AST_EXTENSIONS...
+    # Plus new languages from arcaneum
+    ".proto": "protobuf",
+    ".ex": "elixir",
+    ".exs": "elixir",
+    ".hs": "haskell",
+    ".clj": "clojure",
+    ".dart": "dart",
+    ".zig": "zig",
+    ".jl": "julia",
+    ".el": "elisp",
+    ".erl": "erlang",
+    ".hrl": "erlang",
+    ".ml": "ocaml",
+    ".mli": "ocaml",
+    ".nim": "nim",
+    # ...
+}
+```
+
+- `chunker.py`, `indexer.py`, and `classifier.py` all import from `languages.py`
+- Replace direct usage of `_EXT_TO_LANGUAGE` and `AST_EXTENSIONS` with `LANGUAGE_REGISTRY` imports; the `.tsx` value intentionally changes from `"typescript"` to `"tsx"` (guarded by simultaneous DEFINITION_TYPES and _COMMENT_CHARS updates)
+- `_CODE_EXTENSIONS` in `classifier.py` derived from `LANGUAGE_REGISTRY.keys()` plus GPU shader extensions
+- `_COMMENT_CHARS` expanded to cover all new languages (including `"tsx": "//"`)
+- `DEFINITION_TYPES` expanded where tree-sitter grammar supports it
+
+## Alternatives Considered
+
+**A. Keep two maps, add a CI test for consistency**: Lower effort but doesn't solve the coverage gap. The test prevents drift but doesn't consolidate. Rejected — the root cause is duplication.
+
+**B. Import arcaneum's full 53-entry map**: Too aggressive. Many entries are for obscure formats (`.pde` Processing, `.v` Verilog) that most users won't index. Better to add the top ~15 languages and expand on demand.
+
+## Trade-offs
+
+**Benefits**:
+- Single source of truth for language support — no more drift
+- 15+ new languages supported with zero new dependencies
+- `_COMMENT_CHARS` and `DEFINITION_TYPES` gaps become obvious when adding a language
+
+**Risks**:
+- Some tree-sitter parsers may have quirks for less-tested languages (mitigated: add one test per new language)
+- Backward-compatibility: if any code imports `AST_EXTENSIONS` or `_EXT_TO_LANGUAGE` directly, the alias must be maintained temporarily
+
+**Failure modes**:
+- A new language's parser crashes on malformed input → existing `try/except` in `_extract_context` handles this
+- `.tsx` fix changes chunk behavior → only affects re-indexed TSX files, existing chunks unchanged until `--force`
+- If `.tsx` metadata changes from `"typescript"` to `"tsx"`, collections must be force-reindexed (`--force`) for consistent `programming_language` metadata filtering. Partial reindex leaves mixed values.
+
+## Implementation Plan
+
+### Phase 1: Create Unified Registry (~40 LOC) — commit atomically
+1. Create `src/nexus/languages.py` with `LANGUAGE_REGISTRY`
+2. Migrate all entries from `AST_EXTENSIONS`, `_EXT_TO_LANGUAGE`, and `_CODE_EXTENSIONS`
+3. Fix `.tsx` to use consistent value `"tsx"` everywhere; add `"tsx"` to `DEFINITION_TYPES` and `_COMMENT_CHARS`
+4. Replace `AST_EXTENSIONS` and `_EXT_TO_LANGUAGE` with imports from `languages.py`
+5. Derive `_CODE_EXTENSIONS` in `classifier.py` from `LANGUAGE_REGISTRY.keys()` plus GPU shader extensions
+6. Fix existing gap: add `.lua`, `.cxx`, `.kts`, `.sc` to `_CODE_EXTENSIONS`
+
+### Phase 2: Expand Coverage (~80 LOC)
+7. Add ~15 new languages to `LANGUAGE_REGISTRY` from arcaneum
+8. Add `_COMMENT_CHARS` entries for all new languages
+9. Add `DEFINITION_TYPES` entries where applicable (elixir, haskell, clojure, dart, etc.)
+10. Add all new extensions to classifier (via LANGUAGE_REGISTRY derivation in Phase 1)
+
+### Phase 3: Tests (~60 LOC)
+11. Test: every `LANGUAGE_REGISTRY` entry has a valid tree-sitter parser
+12. Test: every `DEFINITION_TYPES` language is in `LANGUAGE_REGISTRY` values
+13. Test: every `_COMMENT_CHARS` language is in `LANGUAGE_REGISTRY` values
+14. Test: every `LANGUAGE_REGISTRY` key is in `_CODE_EXTENSIONS`
+15. Test: `.tsx` gets correct AST chunking AND context extraction AND comment char
+
+### Phase 4 (deferred): Alias Removal
+16. After one release cycle, remove `AST_EXTENSIONS` and `_EXT_TO_LANGUAGE` aliases if no external imports exist
+
+## Test Plan
+
+- Unit: `LANGUAGE_REGISTRY` consistency — every entry has a working tree-sitter parser
+- Unit: `DEFINITION_TYPES` is a subset of `LANGUAGE_REGISTRY` values
+- Unit: `_COMMENT_CHARS` covers all `LANGUAGE_REGISTRY` values
+- Unit: every `LANGUAGE_REGISTRY` key is in `_CODE_EXTENSIONS` (classifier consistency)
+- Unit: `.tsx` gets correct AST chunking AND context extraction AND `//` comment char
+- Integration: index a fixture file for each new language, verify classified as CODE (not PROSE)
+
+## Finalization Gate
+
+### Contradiction Check
+No contradictions identified. The RDR proposes consolidating two maps into one — the implementation is straightforward dict unification.
+
+### Assumption Verification
+- [x] tree-sitter-language-pack 0.7.1 supports all proposed languages — **Status**: Verified by test (Phase 3 Step 11 runs `get_parser()` for every entry)
+- [x] Both maps are nearly identical — **Verified**: source comparison shows 27 entries match
+- [x] `.tsx` value is the only mismatch between AST_EXTENSIONS and _EXT_TO_LANGUAGE — **Verified**: exhaustive comparison
+- [x] `_CODE_EXTENSIONS` is missing `.lua`, `.cxx`, `.kts`, `.sc` — **Verified**: source search of classifier.py
+
+### Scope Verification
+Scope: one new module (`languages.py`), three import-site changes (`chunker.py`, `indexer.py`, `classifier.py`), dict expansion. No architectural changes. Phase 4 (alias removal) explicitly deferred.
+
+### Cross-Cutting Concerns
+- **Classifier**: `classifier.py:_CODE_EXTENSIONS` MUST be updated for all new languages. Without this, new languages are classified as PROSE and routed to the wrong indexer. Phase 1 Step 5 derives `_CODE_EXTENSIONS` from `LANGUAGE_REGISTRY` to prevent this class of drift permanently.
+- **_COMMENT_CHARS**: Must add `"tsx": "//"` in Phase 1 to prevent `.tsx` files getting `#` as comment char after the value change.
+- DEFINITION_TYPES: Not all new languages need definition types — those without will get AST chunking but no class/method context. This is acceptable degradation.
+
+### Proportionality
+~180 LOC for 15+ new languages, elimination of a three-way maintenance hazard, and fix of 4 existing misclassified extensions. Proportionate to the problem.
+
+## References
+
+- nexus `chunker.py:AST_EXTENSIONS`: `src/nexus/chunker.py:16-51`
+- nexus `indexer.py:_EXT_TO_LANGUAGE`: `src/nexus/indexer.py:32-60`
+- nexus `indexer.py:DEFINITION_TYPES`: `src/nexus/indexer.py:84-179`
+- nexus `indexer.py:_COMMENT_CHARS`: `src/nexus/indexer.py:63-82`
+- arcaneum `LANGUAGE_MAP`: `/Users/hal.hildebrand/git/arcaneum/src/arcaneum/indexing/code/ast_chunker.py`
+- RDR-014: Context prefix implementation (Track A/B already done)
+
+## Revision History
+
+### Gate Review 1 (2026-03-09)
+
+**Layer 1 — Structural Validation**: BLOCKED. RDR contained factually incorrect claims:
+- Track A (DEFINITION_TYPES + _extract_name) claimed unimplemented but found at indexer.py:84-281
+- Track B (prose/PDF context prefixes) claimed unimplemented but found at indexer.py:714-718 and 845-854
+- Problem Statement, Proposed Solution, and Implementation Plan rewritten to scope down to Track C only
+- Title updated from "Definition Extraction, Context Prefixes, and Language Coverage" to "Language Registry Unification"
+- Priority downgraded from P1 to P2 (reduced scope)
+- Finalization Gate section added
+
+### Gate Review 2 (2026-03-09)
+
+**Layer 3 — AI Critique (substantive-critic)**: 1 FAIL, 3 WARNs.
+
+Corrections applied:
+- **FAIL (Scope)**: `classifier.py:_CODE_EXTENSIONS` was absent from Implementation Plan. Phase 2 language expansion would be silently ineffective without classifier updates. Fixed: added Phase 1 Step 5 (derive _CODE_EXTENSIONS from LANGUAGE_REGISTRY) and Step 6 (fix 4 existing missing extensions).
+- **WARN (Contradiction)**: Entry count corrected from 28 to 27. `_COMMENT_CHARS` "covers fewer" claim corrected — it actually covers all 18 languages.
+- **WARN (Assumption)**: Parser availability verification method clarified as confirmed-by-test (Phase 3 Step 11).
+- **WARN (Cross-cutting)**: Added `"tsx": "//"` to `_COMMENT_CHARS` plan. Added `.tsx` metadata inconsistency to failure modes. Reframed backward-compat alias as intentional value change.
+- LOC estimate corrected from ~120 to ~180.
+- Phase 4 (alias removal) added as explicit deferred step.
+- Related RDR-006 kept (chunk-size penalty interacts with language coverage via file classification).

--- a/docs/rdr/rdr-029-pipeline-versioning.md
+++ b/docs/rdr/rdr-029-pipeline-versioning.md
@@ -1,0 +1,115 @@
+---
+title: "Pipeline Versioning — Force Reindex and Collection Version Stamping"
+id: RDR-029
+type: Enhancement
+status: draft
+priority: P2
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues: ["RDR-014", "RDR-028"]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-029: Pipeline Versioning — Force Reindex and Collection Version Stamping
+
+## Problem Statement
+
+When the indexing pipeline changes (new context prefixes, new chunking logic, new embedding model), `nx index repo` without `--force` silently skips unchanged files because `content_hash` and `embedding_model` match. There is no way to:
+
+1. **Force re-indexing**: Override the hash-based dedup to re-process all files with the new pipeline
+2. **Detect staleness**: Know that a collection was indexed with an older pipeline version and needs updating
+
+This creates a silent quality degradation window after every pipeline improvement. Users must manually delete entire collections and re-index from scratch.
+
+## Context
+
+- A plan exists at `docs/plans/2026-03-03-force-reindex-impl-plan.md` for the `--force` flag
+- RDR-014 R5 identified the version stamping need: "Adding a version stamp to collection metadata (and checking it on open) would surface this mismatch"
+- The staleness check at `indexer.py:524-533` compares `content_hash` + `embedding_model` — pipeline version is not checked
+- Each pipeline change (RDR-014 context prefix, RDR-028 definition extraction) requires manual collection deletion
+
+## Research Findings
+
+### F1: Force Reindex Plan (Verified — existing plan)
+
+The plan at `docs/plans/2026-03-03-force-reindex-impl-plan.md` proposes adding `--force` to all four `nx index` subcommands (`repo`, `pdf`, `md`, `rdr`). Implementation: skip the `content_hash` check when `--force` is set, re-process all files regardless.
+
+### F2: Collection Metadata API (Verified — ChromaDB docs)
+
+ChromaDB collections support arbitrary metadata via `collection.modify(metadata={...})`. This can store a pipeline version:
+```python
+col.modify(metadata={"pipeline_version": "3", "last_indexed": "2026-03-08T12:00:00"})
+```
+
+On collection open, compare stored `pipeline_version` against current `PIPELINE_VERSION` constant. If mismatched, warn user.
+
+### F3: What Constitutes a Pipeline Version Change
+
+Changes that invalidate existing embeddings:
+- Context prefix format changes (RDR-014, RDR-028)
+- Chunk size changes (Track B)
+- Embedding model changes
+- Definition extraction additions (RDR-028)
+- Classifier changes (new SKIP extensions)
+
+Changes that do NOT invalidate embeddings:
+- Scoring weight changes
+- CLI flag additions
+- Formatter changes
+
+## Proposed Solution
+
+### Component 1: `--force` Flag
+Add `--force` to all `nx index` subcommands. When set, skip the content_hash/embedding_model staleness check and re-process all files.
+
+### Component 2: Pipeline Version Stamp
+1. Define `PIPELINE_VERSION = "4"` constant in `indexer.py` (bump on each embedding-affecting change)
+2. On `nx index repo`: write `pipeline_version` to collection metadata after indexing
+3. On `nx index repo` (without --force): check `pipeline_version` against current. If mismatched, emit warning: "Collection was indexed with pipeline v{old}, current is v{new}. Run with --force to re-index."
+4. On `nx doctor`: check all collections for version mismatches
+
+### Component 3: Selective Force
+Add `--force-stale` flag that only re-indexes collections with outdated `pipeline_version`, skipping collections that are current. This is the "smart force" — re-index what needs it without touching everything.
+
+## Alternatives Considered
+
+**A. Auto-reindex on version mismatch**: Dangerous for large collections (e.g., `code__ART` at 94K chunks). User should opt in.
+
+**B. Per-file pipeline version in metadata**: More granular but much more complex. Collection-level is sufficient because pipeline changes affect all files equally.
+
+## Trade-offs
+
+**Benefits**:
+- Eliminates the manual "delete collection, re-index" workflow
+- Version mismatch warnings prevent silent quality degradation
+- `--force-stale` provides a one-command upgrade path
+
+**Risks**:
+- Bumping `PIPELINE_VERSION` requires developer discipline (forgettable)
+- `--force` on large collections is expensive (e.g., `code__ART`: 94K chunks, ~$15 Voyage AI)
+
+## Implementation Plan
+
+1. Add `PIPELINE_VERSION` constant to `indexer.py`
+2. Add `--force` flag to all `nx index` subcommands
+3. Write `pipeline_version` to collection metadata after indexing
+4. Check `pipeline_version` on index start, warn if stale
+5. Add `--force-stale` flag for selective re-indexing
+6. Add version check to `nx doctor`
+7. Add tests for force reindex and version mismatch detection
+
+## Test Plan
+
+- Unit: `--force` bypasses content_hash check
+- Unit: pipeline version written to collection metadata
+- Unit: version mismatch warning emitted
+- Unit: `--force-stale` only re-indexes outdated collections
+- Integration: index, bump version, verify warning on next index
+
+## References
+
+- Existing plan: `docs/plans/2026-03-03-force-reindex-impl-plan.md`
+- RDR-014 R5: version stamping need identified
+- ChromaDB collection metadata API: `collection.modify(metadata={...})`

--- a/docs/rdr/rdr-030-reliability-hardening.md
+++ b/docs/rdr/rdr-030-reliability-hardening.md
@@ -1,0 +1,109 @@
+---
+title: "Reliability Hardening — Silent Error Audit and Logging Policy"
+id: RDR-030
+type: Enhancement
+status: draft
+priority: P2
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues: ["RDR-019", "RDR-020"]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-030: Reliability Hardening — Silent Error Audit and Logging Policy
+
+## Problem Statement
+
+The nexus codebase has a **silent degradation** anti-pattern: at least 7 locations catch broad `Exception` and either return silently or pass without any logging. Historically, 8 of 22 P0 bugs were silent failures where the system appeared to work but produced wrong/incomplete results.
+
+This pattern makes debugging extremely difficult — the system silently falls back to degraded behavior with no indication to the user or in logs.
+
+## Context
+
+- `structlog` is already the logging framework (used throughout the codebase)
+- `nx doctor` exists but only checks configuration and connectivity, not data integrity
+- RDR-019 and RDR-020 established retry patterns for external APIs, but internal error handling remains inconsistent
+
+## Research Findings
+
+### F1: Current Silent Error Locations (Verified — source scan)
+
+| Location | What's swallowed | Impact |
+|----------|-----------------|--------|
+| `indexer.py:245-251` | tree-sitter parse failures | Context extraction silently degrades, no indication |
+| `session.py:199` | Corrupt session file JSON | Orphan T1 server processes leak |
+| `hooks.py:155` | Session record parse errors | Session cleanup fails silently |
+| `hooks.py:55` | git rev-parse failures | Repo name falls back to cwd name |
+| `commands/hook.py:24` | stdin JSON parse errors | session_id silently unavailable |
+| `commands/index.py:120` | Hook detection failures | Hooks silently not detected |
+| `commands/doctor.py:173` | Registry load failures | Corrupt config silently ignored |
+
+### F2: Historical P0 Silent Failures (Verified — beads)
+
+| Bug | Silent behavior |
+|-----|----------------|
+| nexus-ng7 | `apply_hybrid_scoring` inverted ranking — wrong results, no error |
+| nexus-rln2 | CCE query model wrong — collections unsearchable, no error |
+| nexus-4qu | `--hybrid` search was a no-op — silently delivered semantic-only results |
+| nexus-3rr | Missing credentials silently marked repo ready — prevented retry |
+| nexus-s5k | `doc_indexer` partial failure silently emptied collection |
+| nexus-9ar | Semantic chunker never wrote chunk positions — metadata silently missing |
+| nexus-738 | Formatters always emitted `:0:` line numbers — wrong output |
+| nexus-zmu | Pre-heading markdown content silently dropped |
+
+### F3: ChromaDB 300-Record Pagination (Verified — production discovery)
+
+ChromaDB Cloud's `get()` returns at most 300 entries per call. Code that calls `col.get()` without pagination silently misses data. Known fixed locations: `delete_by_source()`, `nx store delete --title`. Other call sites may still be vulnerable.
+
+## Proposed Solution
+
+### Policy 1: Minimum Logging Standard
+Every `except` block MUST have at least `structlog.get_logger().debug()` with the exception and context. No bare `pass` or silent returns from exception handlers.
+
+### Policy 2: Warn on Degradation
+When a fallback path is taken (e.g., EphemeralClient instead of HTTP server), emit a `structlog.warning()` that the user can see with `--verbose`.
+
+### Policy 3: nx doctor Data Integrity Checks
+Expand `nx doctor` to validate:
+- All collections have current `pipeline_version` (ties to RDR-029)
+- No orphan T1 server processes
+- T2 database integrity (FTS5 index consistency)
+- ChromaDB collection record counts match expected pagination
+- Registry repos.json parseable
+- Config files valid YAML/JSON
+
+### Policy 4: Stub Code Must Raise
+Any unimplemented code path must `raise NotImplementedError("...")` rather than silently returning empty results. The `pm_reference` stub and `--hybrid` no-op bugs would have been caught immediately.
+
+## Implementation Plan
+
+### Phase 1: Silent Error Audit (7 locations)
+1. Add `structlog.debug` to all 7 identified catch-and-pass blocks
+2. Review each for appropriate recovery behavior
+3. Add warning-level logs for fallback paths (session.py EphemeralClient fallback)
+
+### Phase 2: nx doctor Expansion
+4. Add collection pipeline_version check
+5. Add orphan T1 process detection
+6. Add T2 database integrity check
+7. Add ChromaDB pagination audit (spot-check record counts)
+
+### Phase 3: Codebase Sweep
+8. grep for `except.*pass` and `except.*return` patterns
+9. Verify each has appropriate logging
+10. Add `# noqa: silent-ok` comment for intentional silent catches (with justification)
+
+## Test Plan
+
+- Unit: each formerly-silent location now emits log at appropriate level
+- Unit: nx doctor detects known integrity issues (inject corrupt config, stale pipeline version)
+- Unit: stub code raises NotImplementedError
+- Integration: trigger each fallback path, verify warning emitted
+
+## References
+
+- Bead history: nexus-ng7, nexus-rln2, nexus-4qu, nexus-3rr, nexus-s5k, nexus-9ar, nexus-738, nexus-zmu
+- RDR-019: ChromaDB retry patterns
+- RDR-020: Voyage AI timeout patterns

--- a/docs/rdr/rdr-031-collection-portability.md
+++ b/docs/rdr/rdr-031-collection-portability.md
@@ -1,0 +1,119 @@
+---
+title: "Collection Portability — Export/Import for T3 Backup and Migration"
+id: RDR-031
+type: Feature
+status: draft
+priority: P3
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues: []
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-031: Collection Portability — Export/Import for T3 Backup and Migration
+
+## Problem Statement
+
+Nexus has no way to:
+1. **Export** a T3 collection for backup or sharing
+2. **Import** a collection onto a different machine or ChromaDB instance
+3. **Migrate** data when changing ChromaDB providers or plans
+
+Rebuilding collections from source requires re-indexing (expensive: Voyage AI API costs ~$0.15 per 1000 chunks) and re-embedding (slow: minutes to hours for large repos). `code__ART` alone has 94,059 chunks.
+
+Arcaneum designed a portable `.arcexp` format (RDR-017) with msgpack + numpy + gzip compression achieving 10x reduction vs JSON, plus path remapping for cross-machine migration. This validates the need and provides a reference implementation.
+
+## Context
+
+- ChromaDB Cloud has no built-in export/import
+- 26 collections across 4 databases, ~167K total chunks
+- Re-indexing cost: ~$25 for all collections at current Voyage AI rates
+- Arcaneum's design at `/Users/hal.hildebrand/git/arcaneum/docs/rdr/rdr-017-collection-portability.md`
+
+## Research Findings
+
+### F1: ChromaDB Collection Data Access (Verified — API)
+
+Collections expose `col.get(include=["documents", "metadatas", "embeddings"])` which returns all stored data. However, the 300-record pagination limit means large collections require batched retrieval.
+
+### F2: Arcaneum Format Design (Verified — RDR-017)
+
+Arcaneum's `.arcexp` format:
+- Header: format version, collection name, record count, embedding dimension
+- Body: msgpack-serialized records with numpy arrays for embeddings
+- Compression: gzip (10x reduction)
+- Features: `--detach`/`--attach` for path remapping, `--include`/`--exclude` glob filters
+
+### F3: Embedding Portability (Verified — Voyage AI docs)
+
+Voyage AI embeddings are deterministic for the same input — exported embeddings can be imported without re-embedding. The embedding model name must be stored with the export to prevent model mismatch.
+
+## Proposed Solution
+
+### `nx store export`
+```bash
+nx store export code__myrepo -o myrepo-backup.nxexp
+nx store export code__myrepo --include "*.py" -o python-only.nxexp
+nx store export --all -o full-backup.nxexp
+```
+
+### `nx store import`
+```bash
+nx store import myrepo-backup.nxexp
+nx store import myrepo-backup.nxexp --remap "/old/path:/new/path"
+nx store import myrepo-backup.nxexp --collection code__newname
+```
+
+### Format: `.nxexp` (Nexus Export)
+- Header: JSON — format_version, collection_name, database_type, embedding_model, record_count, embedding_dim, exported_at, pipeline_version
+- Body: msgpack — list of {id, document, metadata, embedding (numpy bytes)}
+- Compression: gzip
+- Extension: `.nxexp`
+
+## Alternatives Considered
+
+**A. JSON export**: Simple but 10x larger and slow for large collections. No binary embedding support.
+
+**B. SQLite export**: Portable and queryable, but heavier than needed for a transfer format.
+
+**C. ChromaDB persist directory copy**: Only works for local ChromaDB, not cloud. No path remapping.
+
+## Trade-offs
+
+**Benefits**:
+- Backup/restore for cloud ChromaDB collections
+- Machine migration without re-embedding ($25+ saved per full export)
+- Selective export with glob filters
+- Path remapping for cross-machine portability
+
+**Risks**:
+- 300-record pagination requires careful batching for export
+- Large exports consume significant disk (167K chunks × ~4KB avg = ~650MB uncompressed, ~65MB compressed)
+- Model version mismatch on import could produce mixed embedding spaces
+
+## Implementation Plan
+
+1. Create `src/nexus/exporter.py` with `export_collection()` and `import_collection()`
+2. Implement batched `col.get()` with 300-record pagination
+3. Implement `.nxexp` format (JSON header + msgpack body + gzip)
+4. Add `nx store export` CLI command
+5. Add `nx store import` CLI command with `--remap` and `--collection` options
+6. Add `--all` flag for full backup
+7. Add model version validation on import
+
+## Test Plan
+
+- Unit: export/import round-trip preserves all data (documents, metadata, embeddings)
+- Unit: pagination correctly handles collections > 300 records
+- Unit: gzip compression/decompression
+- Unit: path remapping transforms source_file metadata
+- Unit: model version mismatch warning on import
+- Integration: export from cloud, import to ephemeral, verify search results match
+
+## References
+
+- Arcaneum RDR-017: Collection portability design
+- ChromaDB `get()` API with pagination
+- msgpack-python: efficient binary serialization

--- a/docs/rdr/rdr-032-indexer-decomposition.md
+++ b/docs/rdr/rdr-032-indexer-decomposition.md
@@ -1,0 +1,159 @@
+---
+title: "Indexer Module Decomposition and Configuration Externalization"
+id: RDR-032
+type: Technical Debt
+status: draft
+priority: P3
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues: ["RDR-015"]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-032: Indexer Module Decomposition and Configuration Externalization
+
+## Problem Statement
+
+Two related technical debt issues are creating maintenance friction:
+
+### 1. indexer.py Monolith (1,236 lines)
+
+`src/nexus/indexer.py` mixes:
+- File classification dispatch
+- Code file indexing (`_index_code_file`, 12 parameters)
+- Prose file indexing (`_index_prose_file`, 12 parameters)
+- PDF file indexing (`_index_pdf_file`)
+- RDR file indexing
+- Frecency score computation
+- Misclassification pruning
+- Deleted file pruning
+- Context extraction (`_extract_context`)
+
+The `_index_code_file` and `_index_prose_file` functions each take 12 positional parameters including `col: object`, `db: object`, and `voyage_client: object` — the `object` type annotations hide the actual protocol expected.
+
+### 2. Hard-Coded Tuning Constants
+
+7+ constants are scattered across 5 files with no configuration override:
+
+| Constant | File | Value | Impact |
+|----------|------|-------|--------|
+| Vector/frecency weights | scoring.py:48 | 0.7/0.3 | Search ranking |
+| File-size threshold | scoring.py:16 | 30 chunks | Large file penalty |
+| Frecency decay rate | frecency.py:53 | 0.01 | Recency bias |
+| Chunk size | chunker.py:53 | 150 lines | Chunk granularity |
+| PDF chunk size | pdf_chunker.py:11 | 1500 chars | PDF chunk granularity |
+| Git log timeout | frecency.py:21 | 30s/60s | Frecency reliability |
+| Ripgrep timeout | ripgrep_cache.py:91 | 10s | Hybrid search speed |
+| CCE token estimate | doc_indexer.py:67 | len/3 | Batch boundary accuracy |
+
+## Context
+
+- The indexer is the most-changed module (touched by RDR-014, 015, 016, 017, 028)
+- `.nexus.yml` already exists as a per-project config mechanism but only controls `exclude_patterns`
+- Duplicated patterns: credential checking (3 locations), staleness check (3 locations)
+
+## Proposed Solution
+
+### Track A: Module Split
+
+Extract four focused modules from `indexer.py`:
+
+```
+src/nexus/
+  indexer.py          # Orchestrator: classify, dispatch, coordinate (remains, ~300 lines)
+  code_indexer.py     # _index_code_file + _extract_context (~250 lines)
+  prose_indexer.py    # _index_prose_file (~200 lines)
+  pdf_indexer.py      # _index_pdf_file (moves from indexer.py, ~150 lines)
+```
+
+Shared utilities extracted to `indexer_utils.py`:
+- `check_staleness(col, source_file, content_hash, embedding_model)` → bool
+- `check_credentials(voyage_key, chroma_key)` → raises CredentialsMissingError
+- `build_context_prefix(filename, definition_name, line_start, line_end)` → str
+
+Replace 12-parameter functions with a `IndexContext` dataclass:
+```python
+@dataclass
+class IndexContext:
+    col: Collection
+    db: T3Database
+    voyage_client: voyageai.Client
+    repo_path: Path
+    corpus: str
+    # ... etc
+```
+
+### Track B: Configuration Externalization
+
+Add a `[tuning]` section to `.nexus.yml`:
+
+```yaml
+tuning:
+  scoring:
+    vector_weight: 0.7
+    frecency_weight: 0.3
+    file_size_threshold: 30
+  frecency:
+    decay_rate: 0.01
+  chunking:
+    code_chunk_lines: 150
+    pdf_chunk_chars: 1500
+  timeouts:
+    git_log: 30
+    ripgrep: 10
+```
+
+Load via existing `config.py` with fallback to current hard-coded defaults.
+
+## Alternatives Considered
+
+**A. Keep indexer.py as-is**: It works. But every RDR that touches indexing (RDR-014, 015, 016, 017, 028) requires understanding 1,236 lines. Maintenance cost is growing.
+
+**B. Full plugin architecture**: Over-engineered. The four file types (code, prose, PDF, RDR) are stable and unlikely to grow. Simple module extraction is sufficient.
+
+## Trade-offs
+
+**Benefits**:
+- Each module is independently testable and understandable
+- Type-safe `IndexContext` replaces 12 untyped parameters
+- Users can tune scoring for their repos without code changes
+- Reduced merge conflicts when multiple RDRs touch the indexer
+
+**Risks**:
+- Module extraction is a large diff (high merge conflict risk if done alongside other work)
+- Config externalization adds validation and migration burden
+- Defaults must remain backward-compatible
+
+## Implementation Plan
+
+### Phase 1: Module Extraction
+1. Create `IndexContext` dataclass
+2. Extract `code_indexer.py` with `index_code_file(ctx, file_path)`
+3. Extract `prose_indexer.py` with `index_prose_file(ctx, file_path)`
+4. Move PDF indexing to `pdf_indexer.py`
+5. Extract shared utilities to `indexer_utils.py`
+6. Reduce `indexer.py` to orchestrator role
+7. Verify all existing tests pass without modification
+
+### Phase 2: Configuration
+8. Add `TuningConfig` to `config.py`
+9. Add `[tuning]` section to `.nexus.yml` schema
+10. Replace hard-coded constants with config lookups
+11. Add defaults matching current values
+12. Add `nx config show tuning` command
+
+## Test Plan
+
+- Unit: each extracted module independently testable
+- Unit: IndexContext creation and validation
+- Unit: TuningConfig loading with defaults, overrides, and invalid values
+- Regression: full test suite passes unchanged after extraction
+- Integration: `.nexus.yml` tuning overrides affect search/index behavior
+
+## References
+
+- Current indexer: `src/nexus/indexer.py` (1,236 lines)
+- Config system: `src/nexus/config.py`
+- `.nexus.yml` schema: `src/nexus/config.py`

--- a/docs/rdr/rdr-033-pdf-agent-nx-index-alignment.md
+++ b/docs/rdr/rdr-033-pdf-agent-nx-index-alignment.md
@@ -1,0 +1,231 @@
+---
+title: "PDF Processing Agent Should Delegate to nx index pdf"
+id: RDR-033
+type: Architecture
+status: draft
+priority: P1
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues:
+  - "RDR-011 - PDF Ingest Test Coverage (closed)"
+  - "RDR-012 - pdfplumber Extraction Tier (closed)"
+  - "RDR-015 - Indexing Pipeline Rethink"
+  - "RDR-032 - Indexer Decomposition"
+---
+
+# RDR-033: PDF Processing Agent Should Delegate to nx index pdf
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+The `pdf-chromadb-processor` agent and `pdf-processing` skill contain a 234-line system prompt that reinvents PDF processing from first principles — calling `pdftotext`, `pdfinfo`, `ghostscript`, and `pdftk` directly, manually chunking text, and storing chunks one-by-one via `nx store put`. Meanwhile, the `nx index pdf` CLI command already handles the entire pipeline in a single invocation:
+
+```bash
+nx index pdf /path/to/paper.pdf --corpus my-corpus --monitor
+# → Indexed 83 chunk(s) in seconds
+```
+
+In practice, the agent fails completely: it hits sandbox restrictions on CLI tools, falls back to asking for permissions, and produces zero indexed content. The human operator then has to discover `nx index pdf` themselves and run it manually — defeating the purpose of the agent entirely.
+
+## Context
+
+### Observed Failure (2026-03-08, Kramer project)
+
+1. User asked to ingest a research PDF into T3
+2. `/pdf-process` skill activated, which spawned `pdf-chromadb-processor` agent
+3. Agent attempted to run `pdfinfo`, `pdftotext` — all denied by sandbox
+4. Agent produced zero output, asked for permission escalation
+5. Human operator fell back to manual `nx store put` chunking (wrong approach)
+6. Eventually discovered `nx index pdf` — completed in one command, 83 chunks
+
+### Root Cause Analysis
+
+The agent's system prompt was written before `nx index pdf` existed (or before it was mature). It describes a manual 4-phase process:
+- Phase 0: Discovery/validation (pdfinfo, extraction method testing)
+- Phase 1: Setup (working directories, progress tracking, chunk calculation)
+- Phase 2: Parallel extraction (pdftotext per page range, manual nx store put)
+- Phase 3: Verification (store list, search testing)
+
+This is exactly what `nx index pdf` does internally — but the agent reimplements it badly in bash, hitting sandbox restrictions and context limits that `nx index pdf` avoids by running as a native Python pipeline.
+
+### The nx index pdf Command
+
+```
+nx index pdf [OPTIONS] PATH
+
+Options:
+  --corpus TEXT      Corpus name for docs__ collection
+  --collection TEXT  Fully-qualified T3 collection name
+  --dry-run          Extract and embed locally (preview before indexing)
+  --force            Force re-indexing, bypassing staleness check
+  --monitor          Print chunking metadata after indexing
+```
+
+Capabilities:
+- Automatic text extraction (pymupdf4llm primary, pdfplumber fallback per RDR-012)
+- Context-safe chunking with page boundary awareness
+- Embedding generation (local ONNX or API)
+- Staleness detection (skip already-indexed PDFs)
+- Metadata extraction (title, author, page count)
+- Single atomic operation — no partial state
+
+## Research Findings
+
+### What the Agent Should Do vs What It Does
+
+| Responsibility | Current Agent | Should Be |
+|---|---|---|
+| Text extraction | Calls pdftotext/ghostscript/pdftk | Delegate to `nx index pdf` |
+| Chunking | Manual page-range splitting | Delegate to `nx index pdf` |
+| Storage | Individual `nx store put` per chunk | Delegate to `nx index pdf` |
+| Progress tracking | Manual T2 memory updates | `--monitor` flag |
+| Verification | Manual `nx store list` + `nx search` | `nx search` post-indexing |
+| Quality assessment | Manual character ratio checks | Built into nx extraction pipeline |
+| Resume/checkpoint | Manual T2 progress file | `--force` flag for re-index |
+| Collection naming | Manual pattern generation | `--corpus` argument |
+
+### What the Agent Should Actually Do
+
+The agent's value-add should be at a higher level than raw extraction:
+
+1. **URL handling**: Download PDFs from URLs to temp files before indexing
+2. **Corpus naming**: Suggest appropriate corpus names from context
+3. **Batch processing**: Index multiple PDFs with appropriate corpus organization
+4. **Post-indexing verification**: Run `nx search` with representative queries
+5. **Error reporting**: If `nx index pdf` fails, provide actionable diagnostics
+6. **Dry-run guidance**: Use `--dry-run` first for large/unknown PDFs
+7. **Integration with beads**: Track batch processing jobs
+
+### Skill Chain Issues
+
+The current skill → agent chain has multiple problems:
+
+1. **Skill invocation overhead**: `/pdf-process` skill spawns a haiku agent, which then tries to run bash commands that get sandboxed
+2. **No awareness of nx index pdf**: Neither the skill nor the agent mention `nx index pdf` as the primary tool (it's buried as an afterthought in step 13)
+3. **Redundant with CLI**: For single-PDF ingestion, the user could just run `nx index pdf` directly — the agent adds negative value by failing
+4. **Wrong model tier**: PDF indexing is a deterministic pipeline operation, not a reasoning task — haiku is appropriate but the task doesn't need an LLM at all for the common case
+
+## Proposed Solution
+
+### Option A: Thin Wrapper (Recommended)
+
+Rewrite the agent to be a thin orchestration layer around `nx index pdf`:
+
+```markdown
+## Core Loop
+
+1. For each PDF in the input:
+   a. If URL, download to /tmp
+   b. Run: nx index pdf {path} --corpus {corpus} --monitor
+   c. Verify: nx search "representative query" --corpus {corpus} -m 3
+   d. Report results
+
+2. For batch jobs, track via beads
+```
+
+The agent system prompt shrinks from 234 lines to ~40 lines. The agent's job becomes:
+- Parse user intent (which PDFs, what corpus name)
+- Call `nx index pdf` for each
+- Verify and report
+
+### Option B: Skill-Only (No Agent)
+
+Replace the agent entirely with an expanded skill that provides inline instructions:
+
+```markdown
+## PDF Processing
+
+To index a PDF into T3:
+  nx index pdf /path/to/file.pdf --corpus {corpus-name} --monitor
+
+To verify:
+  nx search "query" --corpus docs__{corpus-name} -m 3
+
+For dry-run preview:
+  nx index pdf /path/to/file.pdf --corpus {corpus-name} --dry-run
+```
+
+This eliminates the agent spawn overhead entirely. The parent agent (or user) runs the commands directly.
+
+### Option C: Hybrid
+
+Keep the agent for batch/complex scenarios (multiple PDFs, URL downloads, corpus organization), but have the skill handle single-PDF cases inline without spawning an agent.
+
+## Alternatives Considered
+
+### Keep Current Agent, Fix Sandbox
+
+Grant the agent bypass permissions for pdftotext/pdfinfo. This fixes the immediate failure but doesn't address the fundamental problem: the agent reimplements what `nx index pdf` already does, adding complexity and failure modes.
+
+**Rejected**: Treats symptom, not cause.
+
+### Migrate Agent to Use nx index pdf But Keep Full Prompt
+
+Update step 13 to be the primary path but keep all the fallback extraction logic.
+
+**Rejected**: Unnecessary complexity. The fallback extraction tiers are already in `nx index pdf`'s Python implementation.
+
+## Trade-offs
+
+### Consequences
+
+- **Positive**: PDF processing actually works reliably
+- **Positive**: 234-line agent prompt → ~40 lines (Option A) or eliminated (Option B)
+- **Positive**: No sandbox permission issues — `nx index pdf` runs as a native CLI tool
+- **Positive**: Consistent behavior — same chunking/extraction whether invoked via agent or CLI
+- **Negative**: Agent loses ability to use alternative extraction tools not in nx pipeline
+- **Negative**: Option B removes the ability to do complex multi-PDF orchestration without a parent agent
+
+### Risks and Mitigations
+
+- **Risk**: `nx index pdf` has bugs or limitations not covered by the agent's fallbacks
+  **Mitigation**: Fix them in `nx index pdf` — that's where extraction logic belongs. RDR-012 already added pdfplumber as a fallback tier.
+
+- **Risk**: Removing agent breaks existing workflows that reference `pdf-chromadb-processor`
+  **Mitigation**: Keep the agent name, just rewrite the prompt. Skill invocation path unchanged.
+
+## Implementation Plan
+
+### Phase 1: Rewrite Agent Prompt
+
+1. Replace the 4-phase manual extraction system prompt with a thin `nx index pdf` wrapper
+2. Keep URL download capability (curl/wget to /tmp, then `nx index pdf`)
+3. Keep batch processing and beads integration
+4. Keep verification step (`nx search` after indexing)
+5. Remove all references to pdftotext, pdfinfo, ghostscript, pdftk as direct tools
+6. Update tools list: remove dependency on Bash for extraction, keep for `nx` CLI
+
+### Phase 2: Update Skill
+
+1. Add inline single-PDF path that doesn't spawn an agent
+2. Reserve agent spawn for batch/complex scenarios
+3. Document `nx index pdf` as the primary command in skill content
+
+### Phase 3: Test
+
+1. Index a PDF via the updated skill/agent flow
+2. Verify sandbox compatibility (no pdftotext/pdfinfo calls)
+3. Verify searchability of indexed content
+4. Test URL download path
+5. Test batch processing path
+
+## Test Plan
+
+- **Scenario**: Single PDF via skill → **Verify**: `nx index pdf` called, chunks indexed, searchable
+- **Scenario**: PDF from URL → **Verify**: Downloaded to /tmp, indexed, searchable
+- **Scenario**: Batch of 3 PDFs → **Verify**: All indexed with appropriate corpus names
+- **Scenario**: Already-indexed PDF → **Verify**: Staleness check prevents re-indexing (or `--force` re-indexes)
+- **Scenario**: Corrupt/encrypted PDF → **Verify**: Clear error message, no partial state
+
+## References
+
+- `nx index pdf` implementation: `src/nexus/indexer.py`
+- Current agent: `nx/agents/pdf-chromadb-processor.md`
+- Current skill: `nx/skills/pdf-processing/SKILL.md`
+- RDR-011: PDF Ingest Test Coverage
+- RDR-012: pdfplumber Extraction Tier
+- RDR-015: Indexing Pipeline Rethink
+- RDR-032: Indexer Module Decomposition

--- a/src/nexus/chunker.py
+++ b/src/nexus/chunker.py
@@ -9,46 +9,7 @@ from nexus.db.chroma_quotas import SAFE_CHUNK_BYTES
 
 _log = structlog.get_logger()
 
-# Extensions supported by llama-index CodeSplitter / tree-sitter-language-pack.
-# Values are tree-sitter-language-pack language names (may differ from the logical
-# language names in indexer._EXT_TO_LANGUAGE, e.g. .tsx → "tsx" here vs "typescript"
-# for comment/context purposes; .cs → "c_sharp" in both dicts).
-AST_EXTENSIONS: dict[str, str] = {
-    # Core web/scripting
-    ".py": "python",
-    ".js": "javascript",
-    ".jsx": "javascript",
-    ".ts": "typescript",
-    ".tsx": "tsx",
-    # Systems languages
-    ".c": "c",
-    ".h": "c",
-    ".cpp": "cpp",
-    ".cc": "cpp",
-    ".cxx": "cpp",
-    ".hpp": "cpp",
-    ".rs": "rust",
-    ".go": "go",
-    # JVM family
-    ".java": "java",
-    ".kt": "kotlin",
-    ".kts": "kotlin",
-    ".scala": "scala",
-    ".sc": "scala",
-    # .NET
-    ".cs": "c_sharp",
-    # Shell / scripting
-    ".sh": "bash",
-    ".bash": "bash",
-    # Mobile / cross-platform
-    ".swift": "swift",
-    ".m": "objc",
-    # Interpreted
-    ".rb": "ruby",
-    ".php": "php",
-    ".r": "r",
-    ".lua": "lua",
-}
+from nexus.languages import LANGUAGE_REGISTRY
 
 _CHUNK_LINES = 150
 _OVERLAP = 0.15
@@ -71,7 +32,9 @@ def _make_code_splitter(language: str, content: str, chunk_lines: int = _CHUNK_L
         from llama_index.core.node_parser import CodeSplitter  # type: ignore[import]
     from tree_sitter_language_pack import get_parser  # type: ignore[import]
 
-    parser = get_parser(language)
+    # tree-sitter-language-pack uses "csharp" not "c_sharp".
+    parser_name = "csharp" if language == "c_sharp" else language
+    parser = get_parser(parser_name)
     splitter = CodeSplitter(
         language=language,
         parser=parser,
@@ -197,7 +160,7 @@ def chunk_file(file: Path, content: str, chunk_lines: int | None = None) -> list
     """
     effective_chunk_lines = chunk_lines if chunk_lines is not None else _CHUNK_LINES
     ext = file.suffix.lower()
-    language = AST_EXTENSIONS.get(ext)
+    language = LANGUAGE_REGISTRY.get(ext)
 
     base_meta = {
         "file_path": str(file),

--- a/src/nexus/classifier.py
+++ b/src/nexus/classifier.py
@@ -19,14 +19,10 @@ class ContentClass(Enum):
     SKIP = "skip"
 
 
-# Canonical code extensions — the greppable, authoritative list.
-_CODE_EXTENSIONS: frozenset[str] = frozenset({
-    ".py", ".js", ".jsx", ".ts", ".tsx", ".java", ".go", ".rs",
-    ".cpp", ".cc", ".c", ".h", ".hpp", ".rb", ".cs", ".sh", ".bash",
-    ".kt", ".swift", ".scala", ".r", ".m", ".php",
-    # GPU shaders and Protobuf schemas
-    ".proto", ".cl", ".comp", ".frag", ".vert", ".metal", ".glsl", ".wgsl", ".hlsl",
-})
+# Derived from LANGUAGE_REGISTRY to prevent drift (RDR-028).
+from nexus.languages import LANGUAGE_REGISTRY, GPU_SHADER_EXTENSIONS
+
+_CODE_EXTENSIONS: frozenset[str] = frozenset(LANGUAGE_REGISTRY.keys()) | GPU_SHADER_EXTENSIONS
 
 # Extensions for known-noise files that should never be indexed.
 _SKIP_EXTENSIONS: frozenset[str] = frozenset({

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -29,41 +29,14 @@ DEFAULT_IGNORE: list[str] = [
 # Voyage AI embed() API limit: https://docs.voyageai.com/reference/embeddings-api
 _VOYAGE_EMBED_BATCH_SIZE = 128
 
-_EXT_TO_LANGUAGE: dict[str, str] = {
-    ".py": "python",
-    ".js": "javascript",
-    ".jsx": "javascript",
-    ".ts": "typescript",
-    ".tsx": "typescript",
-    ".java": "java",
-    ".go": "go",
-    ".rs": "rust",
-    ".cpp": "cpp",
-    ".cc": "cpp",
-    ".c": "c",
-    ".h": "c",
-    ".hpp": "cpp",
-    ".rb": "ruby",
-    ".cs": "c_sharp",
-    ".sh": "bash",
-    ".bash": "bash",
-    ".kt": "kotlin",
-    ".swift": "swift",
-    ".scala": "scala",
-    ".r": "r",
-    ".m": "objc",
-    ".php": "php",
-    ".lua": "lua",
-    ".cxx": "cpp",
-    ".kts": "kotlin",
-    ".sc": "scala",
-}
+from nexus.languages import LANGUAGE_REGISTRY
 
 # Comment character for each language used to build the embed-only context prefix.
 _COMMENT_CHARS: dict[str, str] = {
     "python": "#",
     "javascript": "//",
     "typescript": "//",
+    "tsx": "//",
     "java": "//",
     "go": "//",
     "rust": "//",
@@ -79,6 +52,18 @@ _COMMENT_CHARS: dict[str, str] = {
     "r": "#",
     "objc": "//",
     "lua": "--",
+    "proto": "//",
+    "elixir": "#",
+    "haskell": "--",
+    "clojure": ";",
+    "dart": "//",
+    "zig": "//",
+    "julia": "#",
+    "elisp": ";",
+    "erlang": "%",
+    "ocaml": "(*",
+    "ocaml_interface": "(*",
+    "perl": "#",
 }
 
 # Tree-sitter node types → semantic code_type, per language.
@@ -98,6 +83,14 @@ DEFINITION_TYPES: dict[str, dict[str, str]] = {
         "generator_function_declaration": "function",
     },
     "typescript": {
+        "function_declaration": "function",
+        "class_declaration": "class",
+        "method_definition": "method",
+        "interface_declaration": "interface",
+        "type_alias_declaration": "type",
+        "arrow_function": "function",
+    },
+    "tsx": {
         "function_declaration": "function",
         "class_declaration": "class",
         "method_definition": "method",
@@ -175,6 +168,30 @@ DEFINITION_TYPES: dict[str, dict[str, str]] = {
     "lua": {
         "function_declaration": "function",
         "local_function": "function",
+    },
+    "dart": {
+        "class_definition": "class",
+        "method_signature": "method",
+        "function_signature": "function",
+    },
+    "haskell": {
+        "function": "function",
+        "data_type": "class",
+    },
+    "julia": {
+        "function_definition": "function",
+        "struct_definition": "class",
+    },
+    "ocaml": {
+        "value_definition": "function",
+        "type_definition": "class",
+        "module_definition": "module",
+    },
+    "perl": {
+        "subroutine_declaration_statement": "function",
+    },
+    "erlang": {
+        "function_clause": "function",
     },
 }
 
@@ -516,7 +533,7 @@ def _index_code_file(
     content_hash = _hl.sha256(content.encode()).hexdigest()
     source_bytes = content.encode("utf-8")
     ext = file.suffix.lower()
-    language = _EXT_TO_LANGUAGE.get(ext, "")
+    language = LANGUAGE_REGISTRY.get(ext, "")
     comment_char = _COMMENT_CHARS.get(language, "#")
     rel_path = file.relative_to(repo)
 

--- a/src/nexus/languages.py
+++ b/src/nexus/languages.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unified language registry for code indexing.
+
+Single source of truth for extension-to-language mapping, consumed by
+chunker.py (AST splitting), indexer.py (context extraction), and
+classifier.py (CODE vs PROSE classification).
+"""
+
+LANGUAGE_REGISTRY: dict[str, str] = {
+    # Core web/scripting
+    ".py": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".ts": "typescript",
+    ".tsx": "tsx",  # tree-sitter has separate tsx grammar
+    # Systems languages
+    ".c": "c",
+    ".h": "c",
+    ".cpp": "cpp",
+    ".cc": "cpp",
+    ".cxx": "cpp",
+    ".hpp": "cpp",
+    ".rs": "rust",
+    ".go": "go",
+    # JVM family
+    ".java": "java",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".scala": "scala",
+    ".sc": "scala",
+    # .NET
+    ".cs": "c_sharp",
+    # Shell / scripting
+    ".sh": "bash",
+    ".bash": "bash",
+    # Mobile / cross-platform
+    ".swift": "swift",
+    ".m": "objc",
+    # Interpreted
+    ".rb": "ruby",
+    ".php": "php",
+    ".r": "r",
+    ".lua": "lua",
+    # Protocol / schema
+    ".proto": "proto",
+    # BEAM ecosystem
+    ".ex": "elixir",
+    ".exs": "elixir",
+    ".erl": "erlang",
+    ".hrl": "erlang",
+    # Functional languages
+    ".hs": "haskell",
+    ".clj": "clojure",
+    ".cljs": "clojure",
+    ".cljc": "clojure",
+    ".ml": "ocaml",
+    ".mli": "ocaml_interface",
+    ".el": "elisp",
+    # Modern systems / app languages
+    ".dart": "dart",
+    ".zig": "zig",
+    ".jl": "julia",
+    # Scripting
+    ".pl": "perl",
+    ".pm": "perl",
+}
+
+# Extensions classified as CODE but not in LANGUAGE_REGISTRY
+# (no tree-sitter grammar or AST chunking needed).
+GPU_SHADER_EXTENSIONS: frozenset[str] = frozenset({
+    ".cl", ".comp", ".frag", ".vert", ".metal", ".glsl", ".wgsl", ".hlsl",
+})

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -64,17 +64,21 @@ def test_extensionless_shebang_bash(tmp_path: Path):
     assert classify_file(f) == ContentClass.CODE
 
 
-def test_code_extensions_set_matches_design():
-    """The canonical set must match the design doc exactly (including shader/proto additions)."""
+def test_code_extensions_derived_from_registry():
+    """_CODE_EXTENSIONS contains all LANGUAGE_REGISTRY keys plus GPU shader extensions."""
+    from nexus.languages import LANGUAGE_REGISTRY, GPU_SHADER_EXTENSIONS
     from nexus.classifier import _CODE_EXTENSIONS
-    expected = {
-        ".py", ".js", ".jsx", ".ts", ".tsx", ".java", ".go", ".rs",
-        ".cpp", ".cc", ".c", ".h", ".hpp", ".rb", ".cs", ".sh", ".bash",
-        ".kt", ".swift", ".scala", ".r", ".m", ".php",
-        # shader + protobuf extensions
-        ".proto", ".cl", ".comp", ".frag", ".vert", ".metal", ".glsl", ".wgsl", ".hlsl",
-    }
+    expected = frozenset(LANGUAGE_REGISTRY.keys()) | GPU_SHADER_EXTENSIONS
     assert _CODE_EXTENSIONS == expected
+
+
+@pytest.mark.parametrize("filename", [
+    "script.lua", "main.cxx", "build.kts", "app.sc",
+])
+def test_previously_missing_code_extensions(filename: str):
+    """Extensions that were missing from _CODE_EXTENSIONS now classify as CODE."""
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path(filename)) == ContentClass.CODE, f"{filename} should be CODE"
 
 
 # ── SKIP extension coverage ────────────────────────────────────────────────────

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the unified language registry (RDR-028)."""
+from pathlib import Path
+
+import pytest
+
+
+# ── Phase 1: Registry consistency tests ──────────────────────────────────────
+
+
+def test_registry_exists_and_has_minimum_entries():
+    from nexus.languages import LANGUAGE_REGISTRY
+    assert len(LANGUAGE_REGISTRY) >= 27
+
+
+@pytest.fixture()
+def registry():
+    from nexus.languages import LANGUAGE_REGISTRY
+    return LANGUAGE_REGISTRY
+
+
+def test_tsx_maps_to_tsx(registry):
+    assert registry[".tsx"] == "tsx"
+
+
+def test_every_entry_has_valid_parser(registry):
+    from tree_sitter_language_pack import get_parser
+    # tree-sitter-language-pack uses "csharp" not "c_sharp"
+    _PARSER_ALIASES = {"c_sharp": "csharp"}
+    for ext, lang in registry.items():
+        parser_name = _PARSER_ALIASES.get(lang, lang)
+        parser = get_parser(parser_name)
+        assert parser is not None, f"No parser for {ext} -> {lang}"
+
+
+def test_definition_types_subset_of_registry(registry):
+    from nexus.indexer import DEFINITION_TYPES
+    registry_values = set(registry.values())
+    for lang in DEFINITION_TYPES:
+        assert lang in registry_values, (
+            f"{lang} in DEFINITION_TYPES but not in LANGUAGE_REGISTRY values"
+        )
+
+
+def test_comment_chars_subset_of_registry(registry):
+    from nexus.indexer import _COMMENT_CHARS
+    registry_values = set(registry.values())
+    for lang in _COMMENT_CHARS:
+        assert lang in registry_values, (
+            f"{lang} in _COMMENT_CHARS but not in LANGUAGE_REGISTRY values"
+        )
+
+
+def test_all_registry_keys_in_code_extensions(registry):
+    from nexus.classifier import _CODE_EXTENSIONS
+    for ext in registry:
+        assert ext in _CODE_EXTENSIONS, (
+            f"{ext} in LANGUAGE_REGISTRY but not in _CODE_EXTENSIONS"
+        )
+
+
+def test_tsx_has_definition_types():
+    from nexus.indexer import DEFINITION_TYPES
+    assert "tsx" in DEFINITION_TYPES
+
+
+def test_tsx_has_comment_chars():
+    from nexus.indexer import _COMMENT_CHARS
+    assert "tsx" in _COMMENT_CHARS
+    assert _COMMENT_CHARS["tsx"] == "//"
+
+
+# ── Phase 2: Language expansion tests ────────────────────────────────────────
+
+_NEW_EXTENSIONS = {
+    ".ex": "elixir", ".exs": "elixir",
+    ".hs": "haskell",
+    ".clj": "clojure", ".cljs": "clojure", ".cljc": "clojure",
+    ".dart": "dart",
+    ".zig": "zig",
+    ".jl": "julia",
+    ".el": "elisp",
+    ".erl": "erlang", ".hrl": "erlang",
+    ".ml": "ocaml", ".mli": "ocaml_interface",
+    ".pl": "perl", ".pm": "perl",
+}
+
+
+def test_registry_expanded(registry):
+    assert len(registry) >= 44  # 28 base + 16 new
+
+
+@pytest.mark.parametrize("ext,lang", _NEW_EXTENSIONS.items())
+def test_new_extension_in_registry(ext, lang, registry):
+    assert ext in registry, f"{ext} not in LANGUAGE_REGISTRY"
+    assert registry[ext] == lang
+
+
+@pytest.mark.parametrize("ext", _NEW_EXTENSIONS.keys())
+def test_new_extension_classified_as_code(ext):
+    from nexus.classifier import classify_file, ContentClass
+    assert classify_file(Path(f"file{ext}")) == ContentClass.CODE
+
+
+_NEW_COMMENT_CHARS = {
+    "proto": "//", "elixir": "#", "haskell": "--",
+    "clojure": ";", "dart": "//", "zig": "//",
+    "julia": "#", "elisp": ";", "erlang": "%",
+    "ocaml": "(*", "ocaml_interface": "(*", "perl": "#",
+}
+
+
+@pytest.mark.parametrize("lang,char", _NEW_COMMENT_CHARS.items())
+def test_new_language_has_comment_char(lang, char):
+    from nexus.indexer import _COMMENT_CHARS
+    assert lang in _COMMENT_CHARS, f"{lang} missing from _COMMENT_CHARS"
+    assert _COMMENT_CHARS[lang] == char
+
+
+_NEW_DEFINITION_TYPES_LANGS = ["dart", "haskell", "julia", "ocaml", "perl", "erlang"]
+
+
+@pytest.mark.parametrize("lang", _NEW_DEFINITION_TYPES_LANGS)
+def test_new_language_has_definition_types(lang):
+    from nexus.indexer import DEFINITION_TYPES
+    assert lang in DEFINITION_TYPES, f"{lang} missing from DEFINITION_TYPES"
+    assert len(DEFINITION_TYPES[lang]) >= 1


### PR DESCRIPTION
## Summary

- Create single `LANGUAGE_REGISTRY` in `src/nexus/languages.py` replacing three drifted maps (`AST_EXTENSIONS`, `_EXT_TO_LANGUAGE`, `_CODE_EXTENSIONS`)
- Fix `.tsx` inconsistency, `c_sharp` parser lookup bug, and 4 missing classifier extensions
- Add 16 new extensions across 11 languages (elixir, erlang, haskell, clojure, ocaml, elisp, dart, zig, julia, perl, proto)
- Add 7 new RDRs (026-033) from cross-repo data mining analysis
- 59 new/updated tests, full suite passes (1954 passed, 0 failed)

## Test plan

- [x] `uv run pytest tests/test_languages.py -v` — 59 registry consistency tests pass
- [x] `uv run pytest tests/test_classifier.py -v` — classifier derivation + 4 previously missing extensions verified
- [x] `uv run pytest` — full suite 1954 passed, 0 failed
- [ ] Verify `.tsx` files get correct AST chunking AND context extraction on re-index

References: nexus-bqjj (RDR-028)