### PR TITLE
fix(docs): correct factual errors in batch-created RDRs 026-033

### DIFF
--- a/docs/rdr/rdr-026-hybrid-search-fusion.md
+++ b/docs/rdr/rdr-026-hybrid-search-fusion.md
@@ -1,5 +1,5 @@
 ---
-title: "Hybrid Search — Vector + Ripgrep Query Fusion"
+title: "Hybrid Search — Exact-Match Score Boosting"
 id: RDR-026
 type: Feature
 status: draft
@@ -8,44 +8,46 @@ author: Hal Hildebrand
 reviewed-by: self
 created: 2026-03-08
 related_issues: ["RDR-006", "RDR-007", "RDR-014"]
-related_tests: []
+related_tests: ["tests/test_scoring.py", "tests/test_search_cmd.py"]
 implementation_notes: ""
 ---
 
-# RDR-026: Hybrid Search — Vector + Ripgrep Query Fusion
+# RDR-026: Hybrid Search — Exact-Match Score Boosting
 
 ## Problem Statement
 
-`nx search` queries ChromaDB vector collections only. The `ripgrep_cache.py` module exists but is wired only into the indexing pipeline — it is never used at query time. This means:
+`nx search --hybrid` fans out to both ChromaDB and ripgrep caches, appending ripgrep hits to the result set. However, `apply_hybrid_scoring()` does not apply any exact-match score boost. Ripgrep hits are scored purely by position-based frecency and vector distance normalization — there is no signal for whether the query text literally appears in a matched line. This means:
 
-1. **No exact-match boosting**: Searching for `def compute_frecency` returns semantically similar but non-literal matches ranked equally with exact matches
-2. **Recall gaps**: Canonical implementation files absent from ChromaDB's top-K candidate set (documented in RDR-006/007) could be found trivially by ripgrep
-3. **No keyword fallback**: When semantic search fails on domain-specific jargon, ripgrep would catch literal occurrences
+1. **No exact-match boosting**: Searching for `def compute_frecency` returns semantically similar but non-literal matches ranked equally with exact matches. Ripgrep hits that contain the literal query are not promoted.
+2. **Recall gaps**: Canonical implementation files absent from ChromaDB's top-K candidate set (documented in RDR-006/007) are found by ripgrep but not scored higher for containing the exact query.
+3. **`distance=0.0` bug**: `_rg_hit_to_result()` (search_cmd.py:53) hardcodes `distance=0.0` for all ripgrep hits. After min-max normalization this yields `v_norm=1.0`, making every ripgrep hit appear maximally similar — regardless of actual relevance.
 
-SeaGOAT (a sibling project at `/Users/hal.hildebrand/git/SeaGOAT/`) demonstrates that fusing ripgrep keyword hits with vector results produces strictly better results than either alone. Their implementation at `seagoat/engine.py:125-155` fans out to both sources asynchronously and merges with weighted scoring.
+SeaGOAT (a sibling project at `/Users/hal.hildebrand/git/SeaGOAT/`) demonstrates that fusing ripgrep keyword hits with vector results produces strictly better results than either alone. Their implementation at `engine.py:125-155` fans out to both sources asynchronously and merges with weighted scoring. Crucially, `result.py:59-62` applies a multiplicative exact-match boost: `score = vector_distance / (1 + exact_matches)`.
 
 ## Context
 
-- `ripgrep_cache.py` already provides `RipgrepCache.search(query, repo_path)` → list of file matches with line numbers
-- `search_engine.py` handles cross-corpus vector queries serially
-- `scoring.py` implements `apply_hybrid_scoring()` with weights `0.7 * vector + 0.3 * frecency`
-- SeaGOAT's scoring: `0.7 * vector + 0.3 * frecency`, plus exact-match boost (halves distance when regex matches found)
-- The `--hybrid` flag existed historically but was a no-op (bead nexus-4qu, since removed in RDR-009)
+- `ripgrep_cache.py` provides `search_ripgrep(query, cache_path)` — a standalone function (not a class) that runs `rg` against a line cache file and returns parsed hit dicts
+- `commands/search_cmd.py` already has the `--hybrid` flag (line 73) and calls `search_ripgrep()` at query time (line 169), appending hits to the vector result set
+- `scoring.py` has `apply_hybrid_scoring()` with the formula `0.7 * vector + 0.3 * frecency` — no `exact_match_boost` exists yet
+- `search_engine.py` provides `search_cross_corpus()` with no hybrid parameter — hybrid logic (ripgrep fan-out) lives in `search_cmd.py`
+- The `--hybrid` flag was a no-op until bead nexus-4qu was resolved. It is now functional: it fans out to ripgrep caches and appends hits to the result set. The missing piece is exact-match score boosting during `apply_hybrid_scoring()`.
 
 ## Research Findings
 
 ### F1: SeaGOAT Fusion Architecture (Verified — source search)
 
-SeaGOAT queries ChromaDB and ripgrep simultaneously via async (`engine.py:65-72`), then merges results. Each source produces `Result` objects with file paths, line numbers, and distances. The merge strategy:
+SeaGOAT queries ChromaDB and ripgrep simultaneously via async fan-out in `engine.py:125-151`. The `query()` method dispatches async fetchers (ripgrep) and sync fetchers (chroma), then merges results. Each source produces `Result` objects with file paths, line numbers, and distances. The merge strategy:
 - Vector results contribute semantic relevance scores
 - Ripgrep results contribute exact-match signals
 - `result.py:get_number_of_exact_matches()` boosts scores when query text literally appears in a result line
+- The boost is **multiplicative**: `score = vector_distance / (1 + exact_matches)` (result.py:59-62), effectively halving the distance when one exact match is found
 
-### F2: Nexus Infrastructure Already Exists (Verified — source search)
+### F2: Nexus Hybrid Infrastructure Is Wired (Verified — source search)
 
-- `ripgrep_cache.py:91` has `search()` with 10s timeout
-- `scoring.py` already has the hybrid scoring formula
-- The missing piece is the query-time fan-out: call ripgrep alongside ChromaDB, merge result sets, and boost exact matches
+- `ripgrep_cache.py:49` has `search_ripgrep()` with 10s timeout — accepts arbitrary query strings
+- `search_cmd.py:167-170` already calls `search_ripgrep()` when `--hybrid` is passed and appends hits to the vector result set
+- `scoring.py` has the two-term hybrid formula (`0.7 * vector + 0.3 * frecency`)
+- The missing piece is an exact-match boost term in the scoring formula: `apply_hybrid_scoring()` has no mechanism to reward results where the query literally appears in the chunk text
 
 ### F3: Ripgrep Availability (Verified — runtime check)
 
@@ -53,15 +55,20 @@ SeaGOAT queries ChromaDB and ripgrep simultaneously via async (`engine.py:65-72`
 
 ## Proposed Solution
 
-Add a `--hybrid` flag to `nx search` that:
+Add exact-match score boosting to the existing hybrid search path:
 
-1. Runs the vector query against ChromaDB (existing path)
-2. Simultaneously runs `rg --json "{query}" {repo_path}` via `ripgrep_cache.search()`
-3. Merges results: vector results are primary, ripgrep results boost scores for files/lines with exact matches
-4. Optionally: ripgrep-only results (files not in vector top-K) are appended with a configurable penalty
+1. Compute `exact_match_boost` in `apply_hybrid_scoring()` when the query text literally appears in the chunk content
+2. Link ripgrep hits to vector results by `file_path` during scoring so that vector results matching ripgrep files receive a boost
+3. Fix the `distance=0.0` bug in `_rg_hit_to_result()` (search_cmd.py:53) where all rg hits get `distance=0.0`, causing them to always receive `v_norm=1.0` after min-max normalization
 
 ### Scoring Formula
 
+The existing two-term formula:
+```
+score = 0.7 * vector_norm + 0.3 * frecency_norm
+```
+
+becomes a three-term additive formula:
 ```
 final_score = vector_weight * vector_norm + frecency_weight * frecency_norm + exact_match_boost
 ```
@@ -71,12 +78,13 @@ Where:
 - `frecency_weight = 0.3` (existing)
 - `exact_match_boost = 0.15` when ripgrep finds the query literally in the chunk (new)
 
+**Additive vs. multiplicative justification**: SeaGOAT uses a multiplicative boost (`score = vector_distance / (1 + exact_matches)`) which halves the raw distance. This works well in SeaGOAT because scoring happens on raw distances before normalization. In Nexus, scoring happens on *normalized* values in [0, 1]. Additive is preferred here because: (a) an additive constant is easier to reason about and tune — `+0.15` means "exact match is worth ~21% of the max possible score (0.7)"; (b) multiplicative boost on normalized scores would couple the boost magnitude to the vector score, giving semantically close results a disproportionately large absolute boost while semantically distant exact matches (the case we most want to fix) get minimal benefit. The additive term gives a fixed reward regardless of vector similarity, directly addressing the recall gap.
+
 ### Integration Points
 
-- `search_engine.py`: Add `hybrid: bool` parameter to `search()`, fan out to ripgrep
-- `scoring.py`: Add `exact_match_boost` to `apply_hybrid_scoring()`
-- `commands/search.py`: Add `--hybrid` CLI flag
-- `ripgrep_cache.py`: Ensure `search()` works for arbitrary queries (not just cached patterns)
+- `scoring.py`: Add `exact_match_boost` computation to `apply_hybrid_scoring()`, accepting the query string as a new parameter
+- `commands/search_cmd.py`: Pass the query string to `apply_hybrid_scoring()` so it can compute exact-match presence; fix `distance=0.0` in `_rg_hit_to_result()`
+- `ripgrep_cache.py`: No changes needed — `search_ripgrep()` already accepts arbitrary queries
 
 ## Alternatives Considered
 
@@ -86,35 +94,44 @@ Where:
 
 **C. BM25 via SQLite FTS5**: Build a full-text index in T2 alongside T3 vectors. Higher engineering cost than ripgrep integration and requires maintaining a parallel index. Deferred as a future enhancement.
 
+**D. Multiplicative boost (SeaGOAT-style)**: Use `score = score / (1 + exact_matches)` instead of additive `+0.15`. Rejected for Nexus because scoring operates on normalized [0,1] values, not raw distances (see justification above). Could be revisited if tuning shows additive is insufficient.
+
 ## Trade-offs
 
 **Benefits**:
 - Directly addresses the code search recall gap (RDR-006/007)
-- Leverages existing infrastructure (ripgrep_cache.py, scoring.py)
-- Opt-in via `--hybrid` flag — no regression risk for existing workflows
+- Leverages existing infrastructure (ripgrep_cache.py, scoring.py, search_cmd.py hybrid wiring)
+- Contained change — only modifies scoring logic, not the fan-out or retrieval path
 
 **Risks**:
-- Ripgrep adds ~100ms latency per query (mitigated: run in parallel with vector query)
+- Score calibration between vector distances and exact-match boosts needs tuning (0.15 is an initial estimate)
+- Multi-repo cache contamination: `_find_rg_cache_paths()` returns ALL caches regardless of `--corpus`, so ripgrep hits from unrelated repos may be injected
 - Ripgrep requires a local clone (not applicable for cloud-only collections)
-- Score calibration between vector distances and exact-match boosts needs tuning
 
 **Failure modes**:
-- Ripgrep not installed → degrade gracefully to vector-only (existing `nx doctor` check warns)
-- Ripgrep timeout → return vector-only results with warning
-- No local repo path available → skip ripgrep, log debug message
+- Ripgrep not installed: degrade gracefully to vector-only (existing `nx doctor` check warns)
+- Ripgrep timeout: return vector-only results with warning (existing 10s timeout in `search_ripgrep()`)
+- No local repo path available: skip ripgrep, log debug message
 
 ## Implementation Plan
 
-### Phase 1: Core Fusion
-1. Extend `RipgrepCache.search()` to accept arbitrary query strings
-2. Add `hybrid: bool` parameter to `SearchEngine.search()`
-3. Implement async fan-out: vector query + ripgrep query in parallel
-4. Merge results: boost vector results that have ripgrep matches
-5. Add `--hybrid` flag to `nx search` CLI
+### Phase 1: Bug Fixes and Core Boosting
+
+Already done:
+- `search_ripgrep()` accepts arbitrary query strings
+- `--hybrid` flag exists in CLI (search_cmd.py:73)
+- Fan-out to ripgrep in search_cmd.py:167-170
+
+TODO:
+1. Fix `distance=0.0` scoring bug in `_rg_hit_to_result()` — assign a synthetic distance (e.g., based on inverse frecency) instead of hardcoding 0.0, which distorts min-max normalization
+2. Add `exact_match_boost` to `apply_hybrid_scoring()` — accept `query: str` parameter, check whether `query` appears in `r.content`, add `+0.15` when found
+3. Link ripgrep hits to vector results by `file_path` for boosting — when a vector result's file_path matches a ripgrep hit, boost the vector result even though it was retrieved from ChromaDB
+4. Address multi-repo cache contamination: `_find_rg_cache_paths()` returns ALL caches regardless of `--corpus`. Scope cache selection to match the target corpus.
 
 ### Phase 2: Tuning & Testing
-6. Add integration tests with a fixture repo
-7. Tune exact_match_boost weight via A/B comparison on known queries
+5. Add unit tests for exact-match boost scoring math in `test_scoring.py`
+6. Add unit test: ripgrep-only results (no vector overlap) receive boost correctly
+7. Tune `exact_match_boost` weight via A/B comparison on known queries
 8. Add `search.hybrid_default` config option for per-project defaults
 
 ### Phase 3: Refinements
@@ -123,17 +140,41 @@ Where:
 
 ## Test Plan
 
-- Unit: mock ripgrep output, verify score boosting math
+- Unit: mock ripgrep output, verify `exact_match_boost` adds +0.15 when query text appears in chunk content
+- Unit: verify `distance=0.0` fix — rg hits should not all get `v_norm=1.0`
 - Unit: ripgrep timeout → graceful fallback to vector-only
 - Unit: ripgrep not installed → graceful fallback
+- Unit: file_path linkage — vector result boosted when matching rg hit exists
 - Integration: search a fixture repo with known exact matches, verify they rank higher with --hybrid
 - Regression: existing non-hybrid searches produce identical results
 
+## Finalization Gate
+
+### Contradiction Check
+No internal contradictions found. The RDR correctly identifies that hybrid infrastructure (flag, fan-out, result appending) is already wired, and scopes the work to the scoring gap. The additive boost approach is explicitly justified against the multiplicative alternative. The `distance=0.0` bug is identified as both a problem (Problem Statement point 3) and a fix target (Implementation Plan step 1).
+
+### Assumption Verification
+- **A1**: `search_ripgrep()` returns hits with `line_content` containing the raw source line — verified in `ripgrep_cache.py:113-122`. A simple `query in r.content` substring check is sufficient for exact-match detection.
+- **A2**: `apply_hybrid_scoring()` receives all results (vector + ripgrep) in a single list — verified in `search_cmd.py:191`. The function can match by `file_path` metadata to link rg hits to vector results.
+- **A3**: The `0.15` boost value is meaningful relative to the `[0, 1]` score range — `0.15` is ~21% of the vector weight (0.7). This is large enough to promote exact matches but not so large that irrelevant exact matches dominate semantic results. Tuning in Phase 2 may adjust this.
+
+### Scope Verification
+The change is contained to three files: `scoring.py` (add boost logic), `search_cmd.py` (pass query to scoring, fix distance bug), and tests. No changes to `search_engine.py`, `ripgrep_cache.py`, CLI flags, or the indexing pipeline. This is proportional to a P1 scoring enhancement.
+
+### Cross-Cutting Concerns
+- **Performance**: No additional subprocess calls or API requests. The exact-match check is a Python `in` operator on strings already in memory. Negligible overhead.
+- **Backward compatibility**: Non-hybrid searches are unaffected — `exact_match_boost` is only computed when `hybrid=True`. The `apply_hybrid_scoring()` signature gains a `query` parameter; callers must be updated (only `search_cmd.py:191`).
+- **Multi-repo contamination**: Identified as a known risk (Implementation Plan step 4). Not blocking for Phase 1 but must be addressed before the feature is considered complete.
+
+### Proportionality
+The implementation touches 2 production files and adds ~30 lines of scoring logic plus ~50 lines of tests. This is proportional to the problem: a well-scoped scoring enhancement that leverages existing infrastructure. No new dependencies, no architectural changes, no new CLI flags.
+
 ## References
 
-- SeaGOAT engine.py: `/Users/hal.hildebrand/git/SeaGOAT/seagoat/engine.py`
-- SeaGOAT result.py exact match: `/Users/hal.hildebrand/git/SeaGOAT/seagoat/result.py:14-28`
+- SeaGOAT engine.py (async fan-out): `/Users/hal.hildebrand/git/SeaGOAT/seagoat/engine.py:125-155`
+- SeaGOAT result.py (multiplicative exact-match boost): `/Users/hal.hildebrand/git/SeaGOAT/seagoat/result.py:59-62`
 - nexus ripgrep_cache.py: `src/nexus/ripgrep_cache.py`
 - nexus scoring.py: `src/nexus/scoring.py`
+- nexus search_cmd.py: `src/nexus/commands/search_cmd.py`
 - RDR-006: File-Size Scoring Penalty
 - RDR-007: Claude Adoption Search Guidance

--- a/docs/rdr/rdr-027-search-results-ux.md
+++ b/docs/rdr/rdr-027-search-results-ux.md
@@ -16,18 +16,25 @@ implementation_notes: ""
 
 ## Problem Statement
 
-`nx search` returns entire chunks (up to 150 lines of code or ~1500 chars of prose). This makes results hard to scan, especially when the relevant match is a few lines within a large chunk. Users must mentally grep within each result to find the salient portion.
+`nx search` already provides basic context windowing via `-A N` and `-C N` flags (search_cmd.py:92-95), which show the first 1+N lines of each chunk through `format_plain_with_context` (formatters.py:54-78). However, these flags lack several capabilities users expect from a grep-like experience:
 
-Two proven UX improvements from SeaGOAT and standard CLI tools:
+1. **No keyword-matching line identification**: The current `-A`/`-C` always window from the first line of the chunk, not from the most relevant line. If the matching term appears at line 80 of a 150-line chunk, `-A 3` still shows lines 1-4.
+2. **No `-B` (lines before match)**: There is no way to show context lines before a matching line.
+3. **No bridge merging**: When two nearby matches within a chunk are separated by 1-2 lines, there is no mechanism to merge them into a single contiguous block.
+4. **No syntax highlighting**: Results are plain text with no language-aware coloring.
 
-1. **Context lines** (`-A`, `-B`, `-C` flags like grep): Show only the most relevant lines within a chunk, with configurable context above/below
+Two proven UX improvements from SeaGOAT and standard CLI tools address these gaps:
+
+1. **Smarter context lines**: Identify the best-matching lines within a chunk, then apply `-A`, `-B`, `-C` windowing around those lines (not the chunk start)
 2. **Syntax highlighting** (via `bat`): When `bat` is installed, pipe results through it for language-aware syntax coloring with line ranges
 
 ## Context
 
-- Current formatters (`formatters.py`) display chunks as plain text blocks with file path, line range, and score
-- SeaGOAT (`seagoat/result.py:42-229`) implements `ResultLine` with types: RESULT, CONTEXT, BRIDGE — tracks per-line scores and merges nearby blocks
-- SeaGOAT (`seagoat/utils/cli_display.py:92-133`) detects `bat` and uses `bat --line-range {start}:{end} --file-name {path}` for syntax highlighting
+- Current formatters (`formatters.py`) display chunks in `path:line_no:content` format (one line per content line, no score displayed)
+- `-A N` and `-C N` exist but `-C` is implemented as an alias for `-A` (after-context only), which deviates from grep's `-C N` meaning (before AND after)
+- `format_plain_with_context` operates on `r.content` (chunk text from ChromaDB) and has no access to the original source file or the query string
+- SeaGOAT (`seagoat/result.py:51-73`) implements `ResultLine` dataclass with types: RESULT, CONTEXT, BRIDGE — tracks per-line scores and merges nearby blocks
+- SeaGOAT (`seagoat/utils/cli_display.py:71-132`) detects `bat` via `subprocess.run(["bat", "--version"])` with `FileNotFoundError` handling, and uses `bat {full_path} --file-name {file_name} --paging never --line-range {start}:{end}` for syntax highlighting
 - Chunks already carry `line_start`/`line_end` metadata (fixed in RDR-016)
 
 ## Research Findings
@@ -43,32 +50,49 @@ d. **Combined**: Use keyword matching when available (especially with RDR-026 hy
 
 Recommendation: Option (d) — keyword match when available, first-N-lines fallback.
 
-### F2: bat Integration (Verified — SeaGOAT source)
+### F2: bat Integration (SeaGOAT source review)
 
-SeaGOAT's implementation at `cli_display.py:92-133`:
-1. Check if `bat` is installed via `shutil.which("bat")`
-2. Call `bat --line-range {start}:{end} --file-name {path} --style=numbers,changes --color=always`
-3. Fall back to plain display if `bat` is not available
+SeaGOAT's implementation at `cli_display.py:101-132`:
+1. Check if `bat` is installed via `subprocess.run(["bat", "--version"])`, catching `FileNotFoundError` (lines 101-111)
+2. Call `bat {full_path} --file-name {file_name} --paging never --line-range {start}:{end}` (lines 114-132) — no `--style` or `--color` flags are passed; bat uses its own defaults
+3. Fall back to Pygments-based highlighting if `bat` is not available (lines 10-31)
 
 This is ~20 lines of code and provides immediate UX improvement.
 
-### F3: Bridge Line Merging (Verified — SeaGOAT source)
+### F3: Bridge Line Merging (SeaGOAT source review)
 
-When two result lines are separated by 2 or fewer non-matching lines, SeaGOAT bridges them into a single block (gap lines become BRIDGE type). This prevents fragmented output. The algorithm at `result.py:166-205` is straightforward.
+When two result lines are separated by 2 or fewer non-matching lines, SeaGOAT bridges them into a single block (gap lines become BRIDGE type). This prevents fragmented output. The algorithm at `result.py:148-177` (`_merge_almost_touching_blocks`) is straightforward.
+
+## Design Decisions
+
+### DD1: `-B` (lines before match) — within-chunk only
+
+`-B N` (lines before match) would ideally read N lines before the match from the original source file. However, the nexus display pipeline operates entirely on chunk text from ChromaDB — `format_plain_with_context` only has access to `r.content` (chunk text), not the source file. Reading from `r.metadata["source_path"]` would introduce file I/O, source-file-not-found failure modes, and content drift (file changed since indexing).
+
+**Decision**: Implement `-B` as within-chunk lines only. If the matching line is at position K within the chunk, `-B N` shows `max(0, K-N)` through `K-1`. If the match is on the first line of the chunk, `-B` produces no additional output. This is a pragmatic limitation that avoids source-file I/O while still being useful for the common case (matches in the middle of multi-line chunks).
+
+### DD2: `-C` semantic — change to before+after (breaking change)
+
+The current `-C N` implementation (search_cmd.py:94-95, 127-128) aliases `-C` to `-A` (after-context only). This deviates from the universal grep convention where `-C N` means N lines before AND after the match. The Test Plan specifies `-C 3` producing `3+1+3` lines (before+match+after), which contradicts the current after-only implementation.
+
+**Decision**: Change `-C N` to mean before+after (equivalent to `-B N -A N`), matching grep semantics. This is a breaking change for any user relying on the current `-C`-as-after-alias behavior, but: (a) the feature is new and unlikely to have dependents, (b) the current behavior is surprising and undocumented as a deviation, and (c) aligning with grep reduces cognitive load. The help text will be updated from "alias for -A N" to "Show N lines of context before and after each match (equivalent to -B N -A N)".
 
 ## Proposed Solution
 
-### Phase 1: Context Lines
-Add `-A` (after), `-B` (before), `-C` (context) flags to `nx search`:
-- Default: show entire chunk (backward compatible)
-- With flags: extract a focused window around the best-matching lines
-- Line identification: keyword match against query terms → highlight those lines
-- Bridge gaps of ≤2 lines between nearby matches
+### Phase 1: Extend Context Lines
+
+Extend the existing `-A`/`-C` implementation with keyword-matching line identification, `-B` support, and bridge merging:
+- `-A N`: Show N lines after each matching line (currently shows N lines after chunk start; change to match-relative)
+- `-B N`: Show N lines before each matching line (within-chunk only; see DD1)
+- `-C N`: Show N lines before and after each matching line (changed from after-alias to before+after; see DD2)
+- Default (no flags): show entire chunk (backward compatible)
+- Line identification: keyword match against query terms to highlight those lines; fall back to first line of chunk
+- Bridge gaps of <=2 lines between nearby matches
 
 ### Phase 2: Syntax Highlighting
 Add `--bat` flag to `nx search`:
-- Detect `bat` availability at startup
-- Pipe each result through `bat` with appropriate `--file-name` for language detection
+- Detect `bat` availability via `subprocess.run(["bat", "--version"])` with `FileNotFoundError` handling
+- Pipe each result through `bat` with appropriate `--file-name` for language detection and `--paging never`
 - Respect `--no-color` / `NO_COLOR` environment variable
 
 ### Phase 3: Compact Mode
@@ -78,43 +102,71 @@ Add `--compact` flag:
 
 ## Alternatives Considered
 
-**A. Always show full chunks**: Current behavior. Too verbose for scanning. Users read 150 lines to find 3 relevant ones.
+**A. Always show full chunks**: Current default behavior. Too verbose for scanning. Users read 150 lines to find 3 relevant ones.
 
 **B. Truncate chunks to N lines**: Loses context. If the match is at line 140 of a 150-line chunk, you'd never see it.
 
 **C. Integrate with `fzf`**: Interactive fuzzy filtering of results. Good for interactive use but doesn't help non-interactive workflows. Could be added as `--fzf` flag in a future phase.
 
+**D. Read source files for `-B`**: Would allow `-B` to show lines before the chunk boundary, but adds file I/O, staleness risk, and `FileNotFoundError` handling. Rejected in favor of within-chunk-only (DD1).
+
 ## Trade-offs
 
 **Benefits**:
 - Results become scannable (grep-like experience developers expect)
+- `-C` aligns with grep semantics, reducing cognitive load
 - Syntax highlighting is proven to improve code comprehension speed
-- All flags are additive — no existing behavior changes
+- All flags are additive — default behavior (no flags) is unchanged
 
 **Risks**:
+- `-C` semantic change is a breaking change (but feature is new, low impact)
 - Line identification heuristic may highlight wrong lines for semantic-only queries (no keyword overlap)
+- `-B` limited to within-chunk context (no pre-chunk lines)
 - `bat` adds subprocess overhead (~50ms per result)
 
 ## Implementation Plan
 
-1. Add `_find_matching_lines(chunk_text, query)` → list of line numbers
-2. Add `_extract_context(lines, matches, before, after)` → focused line blocks with bridge merging
-3. Add `-A`, `-B`, `-C` flags to `nx search` CLI
-4. Add `_format_with_bat(file_path, line_start, line_end)` → syntax-highlighted output
-5. Add `--bat` flag to `nx search` CLI
-6. Add `--compact` flag for single-line-per-result output
-7. Update `format_plain` and `format_vimgrep` formatters
+1. Extend `format_plain_with_context` signature to accept `query: str | None = None`; pass query from `search_cmd` to formatter
+2. Add `_find_matching_lines(chunk_text, query)` -> list of line numbers (keyword match with first-line fallback)
+3. Add `_extract_context(lines, matches, before, after)` -> focused line blocks with bridge merging (within-chunk only)
+4. Add `-B` flag to `nx search` CLI
+5. Change `-C N` from after-alias to before+after (`-B N -A N`), update help text
+6. Add `_format_with_bat(file_path, line_start, line_end)` -> syntax-highlighted output
+7. Add `--bat` flag to `nx search` CLI
+8. Add `--compact` flag for single-line-per-result output
+9. Update `format_plain` and `format_vimgrep` formatters
 
 ## Test Plan
 
 - Unit: `_find_matching_lines` with known query/chunk pairs
 - Unit: `_extract_context` with various before/after/bridge scenarios
-- Unit: bat detection when bat not installed → graceful fallback
-- Integration: search with `-C 3` produces exactly 3+1+3 lines per match
+- Unit: `-B` on match at chunk start produces no pre-context (within-chunk boundary)
+- Unit: bat detection when bat not installed -> graceful fallback
+- Integration: search with `-C 3` produces exactly 3+1+3 lines per match (before+match+after)
+- Integration: `-C N` is equivalent to `-B N -A N`
 - Integration: `--compact` produces grep-compatible output format
+- Regression: search with no flags produces identical output to current behavior
+
+## Finalization Gate
+
+### Contradiction Check
+The `-C` semantic contradiction between the current implementation (after-alias) and grep convention (before+after) is resolved in DD2: `-C` will be changed to before+after, matching grep and the Test Plan's `3+1+3` expectation. The Problem Statement no longer falsely claims `-A`/`-C` don't exist — it acknowledges them and identifies the specific gaps (no keyword-matching, no `-B`, no bridge merging). The format_plain output description is corrected to `path:line_no:content` (no score).
+
+### Assumption Verification
+Key assumption validated: `format_plain_with_context` operates solely on `r.content` (chunk text from ChromaDB) with no source-file access. This is confirmed by reading formatters.py:54-78. The `-B` design decision (DD1) explicitly addresses this constraint by limiting to within-chunk context. The query string is not currently available in the formatter — Implementation Plan step 1 adds this parameter threading.
+
+### Scope Verification
+Phase 1 is scoped to extending the existing `-A`/`-C` implementation, not building from scratch. The formatter signature change (adding `query` parameter) and `-C` semantic change are the two interface-level breaking changes, both documented. `-B` is new but constrained to within-chunk. Bridge merging is additive. Phase 2 (bat) and Phase 3 (compact) remain independent.
+
+### Cross-Cutting Concerns
+The `query` parameter must be threaded from `search_cmd.search_cmd()` through to `format_plain_with_context`. This touches the call site at search_cmd.py:225-227 and the formatter signature at formatters.py:54-56. No other callers of `format_plain_with_context` exist in the codebase. The `-C` semantic change requires updating the Click help text at search_cmd.py:94-95 and the alias logic at search_cmd.py:127-128.
+
+### Proportionality
+This is a P2 UX enhancement. Phase 1 (context lines with keyword matching) is the highest-value change and can land independently. The design decisions (DD1: within-chunk `-B`, DD2: `-C` as before+after) are pragmatic choices that avoid over-engineering while delivering grep-familiar behavior. Phase 2 (bat) is ~20 lines of subprocess plumbing. Phase 3 (compact) is a formatting variant. Total scope is proportionate to the improvement in daily search ergonomics.
 
 ## References
 
 - SeaGOAT result.py: `/Users/hal.hildebrand/git/SeaGOAT/seagoat/result.py`
 - SeaGOAT cli_display.py: `/Users/hal.hildebrand/git/SeaGOAT/seagoat/utils/cli_display.py`
 - nexus formatters.py: `src/nexus/formatters.py`
+- nexus search_cmd.py: `src/nexus/commands/search_cmd.py`

--- a/docs/rdr/rdr-030-reliability-hardening.md
+++ b/docs/rdr/rdr-030-reliability-hardening.md
@@ -16,7 +16,7 @@ implementation_notes: ""
 
 ## Problem Statement
 
-The nexus codebase has a **silent degradation** anti-pattern: at least 7 locations catch broad `Exception` and either return silently or pass without any logging. Historically, 8 of 22 P0 bugs were silent failures where the system appeared to work but produced wrong/incomplete results.
+The nexus codebase has a **silent degradation** anti-pattern: at least 11 locations catch exceptions — some broadly (`Exception`) and some specifically — without any logging, causing silent degradation. Historically, 8 known P0 bugs involved silent failures where the system appeared to work but produced wrong/incomplete results.
 
 This pattern makes debugging extremely difficult — the system silently falls back to degraded behavior with no indication to the user or in logs.
 
@@ -32,13 +32,17 @@ This pattern makes debugging extremely difficult — the system silently falls b
 
 | Location | What's swallowed | Impact |
 |----------|-----------------|--------|
-| `indexer.py:245-251` | tree-sitter parse failures | Context extraction silently degrades, no indication |
-| `session.py:199` | Corrupt session file JSON | Orphan T1 server processes leak |
-| `hooks.py:155` | Session record parse errors | Session cleanup fails silently |
+| `indexer.py:298-302` | `get_parser()` failure (lazy import / language-pack unavailability) — catches broad `Exception` | Language-pack breakage indistinguishable from unsupported language; silent. Warrants `warning` level. |
+| `indexer.py:304-307` | `parser.parse(source)` failure (malformed source bytes) — catches broad `Exception` | Parse failure on corrupt source silently skipped; appropriate for `debug` level. |
+| `indexer.py:264-267` | `child.text.decode("utf-8")` failure — catches `(UnicodeDecodeError, AttributeError)` | Tree-sitter text extraction silently continues on decode failure; name extraction returns empty string. |
+| `indexer.py:270-273` | `child.text.decode("utf-8")` failure — catches `(UnicodeDecodeError, AttributeError)` | Same as above, second extraction path for children with `identifier`/`name` type. |
+| `session.py:199` | Corrupt session file JSON during sweep — catches `(json.JSONDecodeError, OSError)` | Stale session files with corrupt JSON are never swept; if corresponding server is still running it is not stopped. This is the sweep/cleanup path, not the session-start path. |
+| `session.py:113-115` | `/proc/<pid>/status` read failure in `_ppid_of()` — catches `(OSError, ValueError)` | PPID chain walk silently stops, causing session adoption to fail without indication. |
+| `hooks.py:155` | Own session record parse errors — catches `(json.JSONDecodeError, OSError)` | If only the own session file is corrupt but an ancestor session exists, the corruption is silently ignored. Note: `_log.warning(...)` at line 162 fires when no session record is found at all, so the failure is not fully silent in that fallback case. |
 | `hooks.py:55` | git rev-parse failures | Repo name falls back to cwd name |
 | `commands/hook.py:24` | stdin JSON parse errors | session_id silently unavailable |
-| `commands/index.py:120` | Hook detection failures | Hooks silently not detected |
-| `commands/doctor.py:173` | Registry load failures | Corrupt config silently ignored |
+| `commands/index.py:138` | Hook detection failures | Hooks silently not detected |
+| `commands/doctor.py:211` | Registry load failures | Corrupt config silently ignored |
 
 ### F2: Historical P0 Silent Failures (Verified — beads)
 
@@ -60,7 +64,7 @@ ChromaDB Cloud's `get()` returns at most 300 entries per call. Code that calls `
 ## Proposed Solution
 
 ### Policy 1: Minimum Logging Standard
-Every `except` block MUST have at least `structlog.get_logger().debug()` with the exception and context. No bare `pass` or silent returns from exception handlers.
+Every `except` block MUST use the module-level `_log` logger with a descriptive event name and exception context, e.g., `_log.debug('event_name', error=str(exc), exc_info=True)`. The codebase pattern is `_log = structlog.get_logger()` at module level. No bare `pass` or silent returns from exception handlers.
 
 ### Policy 2: Warn on Degradation
 When a fallback path is taken (e.g., EphemeralClient instead of HTTP server), emit a `structlog.warning()` that the user can see with `--verbose`.
@@ -79,8 +83,8 @@ Any unimplemented code path must `raise NotImplementedError("...")` rather than 
 
 ## Implementation Plan
 
-### Phase 1: Silent Error Audit (7 locations)
-1. Add `structlog.debug` to all 7 identified catch-and-pass blocks
+### Phase 1: Silent Error Audit (11 locations)
+1. Add `_log.debug` (or `_log.warning` where degradation is user-visible) to all 11 identified catch-and-pass blocks
 2. Review each for appropriate recovery behavior
 3. Add warning-level logs for fallback paths (session.py EphemeralClient fallback)
 
@@ -90,10 +94,13 @@ Any unimplemented code path must `raise NotImplementedError("...")` rather than 
 6. Add T2 database integrity check
 7. Add ChromaDB pagination audit (spot-check record counts)
 
+### Phase 2.5: ChromaDB Pagination Audit
+8. Audit all `col.get()` call sites in `db/t3.py` and `doc_indexer.py` for missing `limit=` / pagination loop; fix any found.
+
 ### Phase 3: Codebase Sweep
-8. grep for `except.*pass` and `except.*return` patterns
-9. Verify each has appropriate logging
-10. Add `# noqa: silent-ok` comment for intentional silent catches (with justification)
+9. grep for `except.*pass` and `except.*return` patterns
+10. Verify each has appropriate logging
+11. Add a comment explaining why silence is correct for intentional silent catches, e.g., `# intentional: <reason>`. For linter enforcement, annotate with `B110` (flake8-bugbear blind `except: pass`) or ruff `PERF` rules as applicable.
 
 ## Test Plan
 
@@ -102,8 +109,30 @@ Any unimplemented code path must `raise NotImplementedError("...")` rather than 
 - Unit: stub code raises NotImplementedError
 - Integration: trigger each fallback path, verify warning emitted
 
+## Finalization Gate
+
+### Contradiction Check
+No contradictions found between the three proposed policies. Policy 1 (minimum logging) and Policy 2 (warn on degradation) are complementary: Policy 1 sets the floor (`debug`), Policy 2 raises it to `warning` for user-visible fallbacks. Policy 4 (stub code must raise) applies to unimplemented paths, not to the same catch blocks that Policies 1-2 cover — they target different code. The `nx doctor` expansion (Policy 3) is additive and does not conflict with logging changes.
+
+### Assumption Verification
+- **Assumption: structlog is universally available.** Verified: `structlog` is a hard dependency in `pyproject.toml` and `_log = structlog.get_logger()` exists in all affected modules (`indexer.py`, `session.py`, `hooks.py`).
+- **Assumption: All 11 silent catch sites are reachable.** Verified by source inspection. Each corresponds to a real try/except block in current `main`. The two `indexer.py:264-273` sites and `session.py:113-115` were initially missed but confirmed present.
+- **Assumption: P0 bug list is accurate.** Bead IDs are cited; the specific count "8 of 22" was softened to "8 known P0 bugs" since the total denominator is not independently verifiable from the current bead store.
+
+### Scope Verification
+This RDR is scoped to (a) cataloguing silent catches, (b) establishing logging policy, and (c) expanding `nx doctor`. It does not propose changes to retry logic (covered by RDR-019/020), error recovery strategies, or user-facing CLI error messages. The ChromaDB pagination audit (Phase 2.5) is tightly scoped to `col.get()` call sites only, not a general API audit.
+
+### Cross-Cutting Concerns
+- **Performance**: Adding `_log.debug()` calls has negligible overhead — structlog short-circuits when the level is not active. No hot-path concern.
+- **Testing**: Each new log emission is testable via `structlog.testing.capture_logs()`, already used in the test suite. No new test infrastructure needed.
+- **Backwards compatibility**: No CLI interface or API changes. Log output is additive. Users who do not set `--verbose` will see no difference for `debug`-level additions; `warning`-level additions (Policy 2) are intentionally user-visible.
+
+### Proportionality
+The effort is modest — each silent catch site needs 1-2 lines of logging added. The `nx doctor` expansion (Phase 2) is the largest component but builds on existing infrastructure. The historical cost of silent failures (8 P0 bugs requiring multi-hour debugging each) far exceeds the implementation cost. Risk is low: adding logging cannot break existing behavior, and `nx doctor` checks are purely diagnostic.
+
 ## References
 
 - Bead history: nexus-ng7, nexus-rln2, nexus-4qu, nexus-3rr, nexus-s5k, nexus-9ar, nexus-738, nexus-zmu
 - RDR-019: ChromaDB retry patterns
 - RDR-020: Voyage AI timeout patterns
+- RDR-029: Pipeline version tracking (referenced by Policy 3 / nx doctor expansion)

--- a/docs/rdr/rdr-031-collection-portability.md
+++ b/docs/rdr/rdr-031-collection-portability.md
@@ -30,13 +30,13 @@ Arcaneum designed a portable `.arcexp` format (RDR-017) with msgpack + numpy + g
 - ChromaDB Cloud has no built-in export/import
 - 26 collections across 4 databases, ~167K total chunks
 - Re-indexing cost: ~$25 for all collections at current Voyage AI rates
-- Arcaneum's design at `/Users/hal.hildebrand/git/arcaneum/docs/rdr/rdr-017-collection-portability.md`
+- Arcaneum's design at `/Users/hal.hildebrand/git/arcaneum/docs/rdr/RDR-017-collection-export-import.md`
 
 ## Research Findings
 
 ### F1: ChromaDB Collection Data Access (Verified — API)
 
-Collections expose `col.get(include=["documents", "metadatas", "embeddings"])` which returns all stored data. However, the 300-record pagination limit means large collections require batched retrieval.
+Collections expose `col.get(include=["documents", "metadatas", "embeddings"])` which returns all stored data. The `QUOTAS.MAX_RECORDS_PER_WRITE` limit (300 records, defined in `chroma_quotas.py`) applies to batched retrieval — large collections require paginated `col.get()` with offset/limit, same pattern used by `expire()` and `purge_deleted_files()` in `t3.py`.
 
 ### F2: Arcaneum Format Design (Verified — RDR-017)
 
@@ -46,9 +46,24 @@ Arcaneum's `.arcexp` format:
 - Compression: gzip (10x reduction)
 - Features: `--detach`/`--attach` for path remapping, `--include`/`--exclude` glob filters
 
-### F3: Embedding Portability (Verified — Voyage AI docs)
+### F3: Embedding Portability (Verified — stored vectors)
 
-Voyage AI embeddings are deterministic for the same input — exported embeddings can be imported without re-embedding. The embedding model name must be stored with the export to prevent model mismatch.
+Exported embeddings are the actual stored float arrays retrieved from ChromaDB via `col.get(include=["embeddings"])`. Importing preserves the original vector space without re-embedding cost. Since export captures pre-computed vectors (not re-computed ones), embedding determinism is not a concern — the exact vectors that produced the original search quality are preserved byte-for-byte.
+
+### F4: Embedding Space Incompatibility (CRITICAL — t3.py:164)
+
+Nexus uses **two incompatible embedding model families** across its T3 databases:
+
+| Collection prefix | Index model | Query model | Vector space |
+|---|---|---|---|
+| `code__` | `voyage-code-3` | `voyage-4` | voyage-4 space |
+| `docs__` | `voyage-context-3` (CCE) | `voyage-context-3` | CCE space |
+| `knowledge__` | `voyage-context-3` (CCE) | `voyage-context-3` | CCE space |
+| `rdr__` | `voyage-context-3` (CCE) | `voyage-context-3` | CCE space |
+
+As documented in `t3.py:164`: "voyage-4 is **not** compatible with CCE vector spaces (cross-model cosine similarity ≈ 0.05, i.e. random noise)."
+
+Importing a `code__` export (voyage-4 embeddings) into a `docs__` collection (CCE space) — or vice versa — would silently corrupt the target collection's search quality. This is not a "warning" scenario; it is a hard failure.
 
 ## Proposed Solution
 
@@ -56,7 +71,7 @@ Voyage AI embeddings are deterministic for the same input — exported embedding
 ```bash
 nx store export code__myrepo -o myrepo-backup.nxexp
 nx store export code__myrepo --include "*.py" -o python-only.nxexp
-nx store export --all -o full-backup.nxexp
+nx store export --all
 ```
 
 ### `nx store import`
@@ -71,6 +86,38 @@ nx store import myrepo-backup.nxexp --collection code__newname
 - Body: msgpack — list of {id, document, metadata, embedding (numpy bytes)}
 - Compression: gzip
 - Extension: `.nxexp`
+
+### Format Versioning Policy
+
+The `format_version` field in the export header enables forward compatibility. On import:
+- **Same version**: import proceeds normally.
+- **Older format version**: import proceeds — newer code must remain backward-compatible with older exports. Breaking changes require a major version bump.
+- **Newer format version than importer understands**: import MUST ABORT with an error instructing the user to upgrade Nexus. The importer maintains a `MAX_SUPPORTED_FORMAT_VERSION` constant.
+
+### Embedding Space Validation
+
+On import, the importer MUST validate embedding model compatibility:
+
+1. Read `embedding_model` from the `.nxexp` header.
+2. Determine the target collection's expected model via `corpus.index_model_for_collection(target_collection_name)`.
+3. If the models differ, import MUST ABORT with an `EmbeddingModelMismatch` error. This is not a warning — mixed embedding spaces produce random-noise cosine similarity (~0.05) and silently destroy search quality.
+
+Example abort message:
+```
+ERROR: Embedding model mismatch — export uses 'voyage-4' but target
+collection 'docs__corpus' requires 'voyage-context-3'. Import aborted.
+Re-index from source or export to a compatible collection prefix.
+```
+
+### `--include`/`--exclude` Filter Semantics
+
+`--include` and `--exclude` glob patterns match against the `source_path` metadata field (the field used by `indexer.py` for all indexed content — see lines 624, 731, 750, 798).
+
+Entries without a `source_path` metadata field (e.g., `knowledge__` entries created via `nx store put`) pass through filters unconditionally — they are always included in the export regardless of `--include`/`--exclude` patterns.
+
+### `--all` Semantics
+
+`--all` exports every collection across all 4 ChromaDB databases, producing **one `.nxexp` file per collection** with the naming convention `{collection_name}-{date}.nxexp` (e.g., `code__myrepo-2026-03-08.nxexp`). This keeps the format identical to single-collection exports — no combined-archive format needed. Output directory defaults to the current working directory and can be overridden with `-o <dir>/`.
 
 ## Alternatives Considered
 
@@ -89,31 +136,76 @@ nx store import myrepo-backup.nxexp --collection code__newname
 - Path remapping for cross-machine portability
 
 **Risks**:
-- 300-record pagination requires careful batching for export
-- Large exports consume significant disk (167K chunks × ~4KB avg = ~650MB uncompressed, ~65MB compressed)
-- Model version mismatch on import could produce mixed embedding spaces
+- `QUOTAS.MAX_RECORDS_PER_WRITE` pagination (300 records) requires careful batching for both export and import
+- Large exports consume significant disk (167K chunks x ~4KB avg = ~650MB uncompressed, ~65MB compressed)
+- Embedding model validation is mandatory to prevent silent corruption of mixed vector spaces
 
 ## Implementation Plan
 
 1. Create `src/nexus/exporter.py` with `export_collection()` and `import_collection()`
-2. Implement batched `col.get()` with 300-record pagination
+2. Implement batched `col.get()` with `QUOTAS.MAX_RECORDS_PER_WRITE` pagination
 3. Implement `.nxexp` format (JSON header + msgpack body + gzip)
 4. Add `nx store export` CLI command
 5. Add `nx store import` CLI command with `--remap` and `--collection` options
-6. Add `--all` flag for full backup
-7. Add model version validation on import
+6. Add `--all` flag producing one `.nxexp` per collection
+7. Implement embedding model validation on import — call `corpus.index_model_for_collection()` and compare against export header; abort on mismatch with `EmbeddingModelMismatch` error
+8. Implement format version check — abort if export `format_version` exceeds `MAX_SUPPORTED_FORMAT_VERSION`
+9. Import implementation should target `T3Database.upsert_chunks_with_embeddings()` (`t3.py:373`) — this method accepts pre-computed embeddings and bypasses ChromaDB's embedding function, which is exactly the import use case
 
 ## Test Plan
 
 - Unit: export/import round-trip preserves all data (documents, metadata, embeddings)
-- Unit: pagination correctly handles collections > 300 records
+- Unit: pagination correctly handles collections > 300 records using `QUOTAS.MAX_RECORDS_PER_WRITE`
 - Unit: gzip compression/decompression
-- Unit: path remapping transforms source_file metadata
-- Unit: model version mismatch warning on import
+- Unit: path remapping transforms `source_path` metadata
+- Unit: **embedding model mismatch — import `code__` export (voyage-4) into `docs__` target MUST fail with `EmbeddingModelMismatch`**
+- Unit: **embedding model match — import `code__` export into `code__` target succeeds**
+- Unit: **format version mismatch — import with future `format_version` MUST abort**
+- Unit: `--include`/`--exclude` filters match against `source_path` metadata
+- Unit: entries without `source_path` (e.g., `nx store put` entries) pass through filters unconditionally
+- Unit: `--all` produces one `.nxexp` per collection with correct naming convention
 - Integration: export from cloud, import to ephemeral, verify search results match
+
+## Finalization Gate
+
+### Contradiction Check
+No contradictions found. The design is consistent with existing Nexus conventions:
+- Uses `QUOTAS.MAX_RECORDS_PER_WRITE` for pagination (same as `expire()`, `purge_deleted_files()`)
+- Uses `upsert_chunks_with_embeddings()` for import (same pre-computed embedding path used by CCE indexing)
+- Embedding model validation aligns with the strict separation already enforced by `corpus.index_model_for_collection()`
+
+### Assumption Verification
+Three key assumptions validated:
+1. **CCE/voyage-4 split**: Confirmed at `t3.py:164` — cross-model cosine similarity is ~0.05 (random noise). Import MUST enforce model match, not warn. The `corpus.index_model_for_collection()` function (`corpus.py:62`) provides the authoritative model mapping.
+2. **300-record pagination**: Confirmed via `QUOTAS.MAX_RECORDS_PER_WRITE = 300` in `chroma_quotas.py:47`. Both `col.get()` for export and `upsert_chunks_with_embeddings()` for import use this limit. Export pagination follows the same offset/limit pattern as `expire()` in `t3.py`.
+3. **Embedding determinism**: Moot for this design — export captures stored vectors from ChromaDB, not re-computed ones. No Voyage AI API calls during export or import.
+
+### Scope Verification
+Scope is appropriate for a P3 feature:
+- Single new module (`exporter.py`) plus two CLI commands
+- No changes to existing indexing, search, or storage paths
+- Format is intentionally simple (JSON header + msgpack body + gzip) — no need for a database or complex archive format
+- `--all` uses per-collection files to avoid introducing a new combined-archive format
+
+### Cross-Cutting Concerns
+- **Error handling**: `EmbeddingModelMismatch` and `FormatVersionError` are new error types in `errors.py`
+- **Logging**: Export/import progress via `structlog` (chunk count, compression ratio, elapsed time)
+- **Config**: No new config — export/import are stateless CLI operations
+- **TTL**: Exported metadata includes `expires_at` and `ttl_days`; import preserves them as-is (expiry is evaluated at query time by `expire()`)
+
+### Proportionality
+Design complexity matches the problem:
+- Format is msgpack + gzip (proven by Arcaneum RDR-017, not novel)
+- Embedding validation adds ~10 lines but prevents catastrophic silent corruption
+- `--all` is one-file-per-collection (no new archive format)
+- Implementation targets an existing API (`upsert_chunks_with_embeddings`) rather than creating new storage paths
+- Estimated implementation: ~300 lines of code + ~200 lines of tests
 
 ## References
 
-- Arcaneum RDR-017: Collection portability design
+- Arcaneum RDR-017: Collection export/import design (`RDR-017-collection-export-import.md`)
 - ChromaDB `get()` API with pagination
+- `T3Database.upsert_chunks_with_embeddings()` at `t3.py:373`
+- `corpus.index_model_for_collection()` at `corpus.py:62`
+- `QUOTAS.MAX_RECORDS_PER_WRITE` at `chroma_quotas.py:47`
 - msgpack-python: efficient binary serialization

--- a/docs/rdr/rdr-032-indexer-decomposition.md
+++ b/docs/rdr/rdr-032-indexer-decomposition.md
@@ -7,7 +7,7 @@ priority: P3
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-03-08
-related_issues: ["RDR-015"]
+related_issues: ["RDR-014", "RDR-015", "RDR-016", "RDR-017", "RDR-025", "RDR-028"]
 related_tests: []
 implementation_notes: ""
 ---
@@ -18,7 +18,7 @@ implementation_notes: ""
 
 Two related technical debt issues are creating maintenance friction:
 
-### 1. indexer.py Monolith (1,236 lines)
+### 1. indexer.py Monolith (1,325 lines)
 
 `src/nexus/indexer.py` mixes:
 - File classification dispatch
@@ -31,18 +31,18 @@ Two related technical debt issues are creating maintenance friction:
 - Deleted file pruning
 - Context extraction (`_extract_context`)
 
-The `_index_code_file` and `_index_prose_file` functions each take 12 positional parameters including `col: object`, `db: object`, and `voyage_client: object` — the `object` type annotations hide the actual protocol expected.
+The `_index_code_file` and `_index_prose_file` functions each take 12 parameters including `col: object` and `db: object` — the `object` type annotations hide the actual protocol expected. Worse, the parameter types are asymmetric: `_index_code_file` (line 546) takes `voyage_client: object` (a pre-constructed `voyageai.Client` instance), while `_index_prose_file` (line 675) and `_index_pdf_file` (line 849) take `voyage_key: str` (a raw API key string). The prose and PDF paths delegate to `doc_indexer._embed_with_fallback`, which constructs its own client internally from the key. This means the caller must know which form to pass depending on the file type — a leaky abstraction that an `IndexContext` must resolve.
 
 ### 2. Hard-Coded Tuning Constants
 
-7+ constants are scattered across 5 files with no configuration override:
+8 constants are scattered across 6 files with no configuration override:
 
 | Constant | File | Value | Impact |
 |----------|------|-------|--------|
 | Vector/frecency weights | scoring.py:48 | 0.7/0.3 | Search ranking |
 | File-size threshold | scoring.py:16 | 30 chunks | Large file penalty |
 | Frecency decay rate | frecency.py:53 | 0.01 | Recency bias |
-| Chunk size | chunker.py:53 | 150 lines | Chunk granularity |
+| Chunk size | chunker.py:14 | 150 lines | Chunk granularity |
 | PDF chunk size | pdf_chunker.py:11 | 1500 chars | PDF chunk granularity |
 | Git log timeout | frecency.py:21 | 30s/60s | Frecency reliability |
 | Ripgrep timeout | ripgrep_cache.py:91 | 10s | Hybrid search speed |
@@ -50,7 +50,7 @@ The `_index_code_file` and `_index_prose_file` functions each take 12 positional
 
 ## Context
 
-- The indexer is the most-changed module (touched by RDR-014, 015, 016, 017, 028)
+- The indexer is the most-changed module (touched by RDR-014, 015, 016, 017, 025, 028)
 - `.nexus.yml` already exists as a per-project config mechanism but only controls `exclude_patterns`
 - Duplicated patterns: credential checking (3 locations), staleness check (3 locations)
 
@@ -58,32 +58,40 @@ The `_index_code_file` and `_index_prose_file` functions each take 12 positional
 
 ### Track A: Module Split
 
-Extract four focused modules from `indexer.py`:
+Extract three focused modules from `indexer.py`:
 
 ```
 src/nexus/
   indexer.py          # Orchestrator: classify, dispatch, coordinate (remains, ~300 lines)
   code_indexer.py     # _index_code_file + _extract_context (~250 lines)
   prose_indexer.py    # _index_prose_file (~200 lines)
-  pdf_indexer.py      # _index_pdf_file (moves from indexer.py, ~150 lines)
 ```
+
+**PDF indexing**: `pdf_chunker.py` and `pdf_extractor.py` already exist as separate modules, and `_index_pdf_file` already delegates to `doc_indexer._pdf_chunks` and `doc_indexer._embed_with_fallback`. Rather than creating a fourth PDF-named module (`pdf_indexer.py`) alongside these two, `_index_pdf_file` stays in the orchestrator (`indexer.py`) — it is thin glue (~60 lines of logic beyond delegation) and its extraction would fragment the PDF surface area across three modules without reducing complexity. If future growth warrants extraction, it should consolidate into `doc_indexer.py` rather than proliferate a new file.
 
 Shared utilities extracted to `indexer_utils.py`:
 - `check_staleness(col, source_file, content_hash, embedding_model)` → bool
 - `check_credentials(voyage_key, chroma_key)` → raises CredentialsMissingError
 - `build_context_prefix(filename, definition_name, line_start, line_end)` → str
 
-Replace 12-parameter functions with a `IndexContext` dataclass:
+**Implementation note on `check_staleness`**: The current inline staleness pattern performs a `col.get()` call wrapped in `_chroma_with_retry` (imported from `nexus.retry`). The extracted `check_staleness` utility must import and use `_chroma_with_retry` internally rather than expecting the caller to wrap the call — the retry logic is part of the staleness check's contract, not an optional decoration.
+
+Replace 12-parameter functions with an `IndexContext` dataclass:
 ```python
 @dataclass
 class IndexContext:
     col: Collection
     db: T3Database
-    voyage_client: voyageai.Client
+    voyage_key: str              # raw API key — single source of truth
+    voyage_client: voyageai.Client  # pre-constructed for code path
     repo_path: Path
     corpus: str
     # ... etc
 ```
+
+`IndexContext` carries **both** the key and a pre-constructed client. `code_indexer` uses `ctx.voyage_client` directly (as today); `prose_indexer` and `_index_pdf_file` pass `ctx.voyage_key` to `doc_indexer._embed_with_fallback` (which constructs its own client internally). This preserves existing behavior while making the asymmetry explicit and centralized.
+
+**Note on RDR-025 dependency**: `code_indexer.py` will carry a dependency on `nexus.languages.LANGUAGE_REGISTRY` (introduced by RDR-025, commit 32803fb). The import is used in `_index_code_file` to resolve file extensions to tree-sitter languages. This is a clean, stable dependency — `LANGUAGE_REGISTRY` is a module-level dict, not a runtime service.
 
 ### Track B: Configuration Externalization
 
@@ -109,7 +117,7 @@ Load via existing `config.py` with fallback to current hard-coded defaults.
 
 ## Alternatives Considered
 
-**A. Keep indexer.py as-is**: It works. But every RDR that touches indexing (RDR-014, 015, 016, 017, 028) requires understanding 1,236 lines. Maintenance cost is growing.
+**A. Keep indexer.py as-is**: It works. But every RDR that touches indexing (RDR-014, 015, 016, 017, 025, 028) requires understanding 1,325 lines. Maintenance cost is growing.
 
 **B. Full plugin architecture**: Over-engineered. The four file types (code, prose, PDF, RDR) are stable and unlikely to grow. Simple module extraction is sufficient.
 
@@ -129,12 +137,12 @@ Load via existing `config.py` with fallback to current hard-coded defaults.
 ## Implementation Plan
 
 ### Phase 1: Module Extraction
-1. Create `IndexContext` dataclass
-2. Extract `code_indexer.py` with `index_code_file(ctx, file_path)`
+1. Create `IndexContext` dataclass (carries both `voyage_key` and `voyage_client`)
+2. Extract `code_indexer.py` with `index_code_file(ctx, file_path)` (carries `LANGUAGE_REGISTRY` dependency)
 3. Extract `prose_indexer.py` with `index_prose_file(ctx, file_path)`
-4. Move PDF indexing to `pdf_indexer.py`
-5. Extract shared utilities to `indexer_utils.py`
-6. Reduce `indexer.py` to orchestrator role
+4. Extract shared utilities to `indexer_utils.py` (including `check_staleness` with internal `_chroma_with_retry`)
+5. Keep `_index_pdf_file` in `indexer.py` orchestrator (thin delegation to existing `doc_indexer`/`pdf_chunker`/`pdf_extractor`)
+6. Reduce `indexer.py` to orchestrator role (~300 lines)
 7. Verify all existing tests pass without modification
 
 ### Phase 2: Configuration
@@ -150,10 +158,50 @@ Load via existing `config.py` with fallback to current hard-coded defaults.
 - Unit: IndexContext creation and validation
 - Unit: TuningConfig loading with defaults, overrides, and invalid values
 - Regression: full test suite passes unchanged after extraction
-- Integration: `.nexus.yml` tuning overrides affect search/index behavior
+- Integration: `.nexus.yml` tuning overrides affect search/index behavior. Specific tests:
+  - Set `chunking.code_chunk_lines: 50` in `.nexus.yml`, index a file >50 lines, verify all chunks are ≤50 lines (vs. default 150)
+  - Set `scoring.vector_weight: 1.0, frecency_weight: 0.0`, verify frecency scores have zero effect on ranking
+  - Set `timeouts.ripgrep: 0.001`, verify hybrid search gracefully degrades (returns vector-only results)
+
+## Finalization Gate
+
+### Contradiction Check
+
+The original draft proposed a `pdf_indexer.py` module while `pdf_chunker.py` and `pdf_extractor.py` already exist. This has been resolved: `_index_pdf_file` remains in the orchestrator since it is thin glue over existing `doc_indexer` functions. No new PDF-named module is introduced.
+
+The `IndexContext` originally showed only `voyage_client` but `_index_prose_file` and `_index_pdf_file` take `voyage_key: str`. Resolved: `IndexContext` carries both `voyage_key` and `voyage_client`, preserving existing call semantics for each path.
+
+### Assumption Verification
+
+- **Assumption**: Extracted modules will not create circular imports.
+  **Verified**: The dependency graph is acyclic. `indexer.py` (orchestrator) imports `code_indexer` and `prose_indexer`. Both import from `indexer_utils`. `code_indexer` imports from `nexus.chunker` and `nexus.languages`. `prose_indexer` imports from `nexus.doc_indexer` and `nexus.md_chunker`. No reverse dependencies exist — `chunker`, `doc_indexer`, `md_chunker`, and `languages` do not import from `indexer`.
+
+- **Assumption**: The 12-parameter functions are the primary source of friction.
+  **Verified**: The parameter lists include 4 untyped `object` parameters (`col`, `db`, `voyage_client`/`voyage_key`) that hide protocols, plus 6 value parameters that are identical across all three file-type functions. `IndexContext` eliminates the positional coupling.
+
+- **Assumption**: `LANGUAGE_REGISTRY` (RDR-025) is a stable dependency for `code_indexer.py`.
+  **Verified**: It is a module-level dict defined in `nexus/languages.py` with no runtime state. It is used at one call site in `_index_code_file` (line 576) to map file extensions to tree-sitter language names.
+
+### Scope Verification
+
+The RDR is scoped to two tracks: module extraction (Track A) and configuration externalization (Track B). It does not attempt to change indexing semantics, modify the chunking pipeline, or alter embedding model selection. The `.nexus.yml` tuning section adds read-only config for existing constants — no new behavioral features.
+
+### Cross-Cutting Concerns
+
+- **Retry logic**: `check_staleness` extraction must internalize `_chroma_with_retry` (from `nexus.retry`) rather than leaving retry responsibility to callers. This is documented in the implementation notes above.
+
+- **PDF module surface area**: Three existing PDF-related modules (`pdf_chunker.py`, `pdf_extractor.py`, `doc_indexer.py`) already handle PDF processing. The decision to keep `_index_pdf_file` in the orchestrator avoids adding a fourth module and fragmenting the PDF code path further. If PDF indexing grows in complexity, consolidation into `doc_indexer.py` is the preferred path.
+
+- **Config migration**: Track B must ensure that repos without a `[tuning]` section in `.nexus.yml` behave identically to current behavior. The `TuningConfig` defaults are the current hard-coded values — no migration needed for existing users.
+
+### Proportionality
+
+Track A and Track B are **independently deliverable and parallelizable**. Track A (module extraction) is a pure refactor with no behavioral change — it can land as a single PR with no config changes. Track B (config externalization) can proceed independently by replacing hard-coded constants with config lookups in the existing monolithic `indexer.py` if needed. However, the cleanest sequencing is Track A first (to establish module boundaries), then Track B (to thread config through the new `IndexContext`). Neither track is blocked on the other.
+
+The scope is proportional to the problem: 6 RDRs have modified `indexer.py`, each requiring understanding of 1,325 lines. The extraction reduces the cognitive load per module to 200-300 lines while preserving all existing tests unchanged.
 
 ## References
 
-- Current indexer: `src/nexus/indexer.py` (1,236 lines)
+- Current indexer: `src/nexus/indexer.py` (1,325 lines)
 - Config system: `src/nexus/config.py`
 - `.nexus.yml` schema: `src/nexus/config.py`

--- a/docs/rdr/rdr-033-pdf-agent-nx-index-alignment.md
+++ b/docs/rdr/rdr-033-pdf-agent-nx-index-alignment.md
@@ -9,8 +9,9 @@ reviewed-by: self
 created: 2026-03-08
 related_issues:
   - "RDR-011 - PDF Ingest Test Coverage (closed)"
-  - "RDR-012 - pdfplumber Extraction Tier (closed)"
+  - "RDR-012 - pdfplumber Extraction Tier (closed, superseded by RDR-021)"
   - "RDR-015 - Indexing Pipeline Rethink"
+  - "RDR-021 - Docling PDF Extraction (accepted)"
   - "RDR-032 - Indexer Decomposition"
 ---
 
@@ -65,7 +66,7 @@ Options:
 ```
 
 Capabilities:
-- Automatic text extraction (pymupdf4llm primary, pdfplumber fallback per RDR-012)
+- Automatic text extraction (Docling primary with neural layout analysis, PyMuPDF normalized fallback — per RDR-021)
 - Context-safe chunking with page boundary awareness
 - Embedding generation (local ONNX or API)
 - Staleness detection (skip already-indexed PDFs)
@@ -126,6 +127,8 @@ Rewrite the agent to be a thin orchestration layer around `nx index pdf`:
 2. For batch jobs, track via beads
 ```
 
+The `--corpus` argument maps to `docs__{corpus}` — corpus names like `grossberg-1978` are correct; full collection names like `docs__grossberg-1978` should not be passed as `--corpus`.
+
 The agent system prompt shrinks from 234 lines to ~40 lines. The agent's job becomes:
 - Parse user intent (which PDFs, what corpus name)
 - Call `nx index pdf` for each
@@ -182,7 +185,7 @@ Update step 13 to be the primary path but keep all the fallback extraction logic
 ### Risks and Mitigations
 
 - **Risk**: `nx index pdf` has bugs or limitations not covered by the agent's fallbacks
-  **Mitigation**: Fix them in `nx index pdf` — that's where extraction logic belongs. RDR-012 already added pdfplumber as a fallback tier.
+  **Mitigation**: Fix them in `nx index pdf` — that's where extraction logic belongs. The extraction stack already has a two-tier fallback (Docling primary, PyMuPDF normalized fallback — per RDR-021), and any new extraction improvements belong in `pdf_extractor.py`, not in the agent prompt.
 
 - **Risk**: Removing agent breaks existing workflows that reference `pdf-chromadb-processor`
   **Mitigation**: Keep the agent name, just rewrite the prompt. Skill invocation path unchanged.
@@ -203,6 +206,7 @@ Update step 13 to be the primary path but keep all the fallback extraction logic
 1. Add inline single-PDF path that doesn't spawn an agent
 2. Reserve agent spawn for batch/complex scenarios
 3. Document `nx index pdf` as the primary command in skill content
+4. Update skill's PRODUCE section to reference `nx index pdf` output format (collection name, chunk count, searchability), not `nx store put` schema — the current PRODUCE describes "Indexed PDF content stored via `nx store put`" which becomes stale after Phase 1
 
 ### Phase 3: Test
 
@@ -220,12 +224,39 @@ Update step 13 to be the primary path but keep all the fallback extraction logic
 - **Scenario**: Already-indexed PDF → **Verify**: Staleness check prevents re-indexing (or `--force` re-indexes)
 - **Scenario**: Corrupt/encrypted PDF → **Verify**: Clear error message, no partial state
 
+## Finalization Gate
+
+### Contradiction Check
+
+No internal contradictions found. The problem statement (agent reimplements extraction, fails in sandbox) is consistent with the proposed solution (delegate to `nx index pdf`). The extraction stack description now correctly references Docling/PyMuPDF (RDR-021), consistent with the actual `pdf_extractor.py` implementation. Option A (thin wrapper) and Option B (skill-only) are presented as alternatives, not as conflicting requirements.
+
+### Assumption Verification
+
+1. **`nx index pdf` covers all agent extraction scenarios**: Verified. The command handles single-PDF ingestion with Docling primary extraction, PyMuPDF normalized fallback, staleness detection, and atomic operation. The only gap is URL download (curl to /tmp), which the thin wrapper agent retains.
+2. **Sandbox blocks the agent's CLI tools**: Confirmed by the 2026-03-08 Kramer project failure. `pdftotext`, `pdfinfo`, `ghostscript`, and `pdftk` are external binaries that Claude Code's sandbox restricts. `nx index pdf` runs as a Python subprocess via the `nx` CLI, which is already in the tool allowlist.
+3. **`--corpus` maps to `docs__` collections**: Verified in `doc_indexer.py`. The `--corpus` flag prepends `docs__` automatically; passing `docs__grossberg-1978` would produce the malformed collection name `docs__docs__grossberg-1978`.
+
+### Scope Verification
+
+This RDR is scoped to the agent prompt and skill file — no changes to `nx index pdf`, `pdf_extractor.py`, or any Python source. The implementation plan has three phases: (1) rewrite agent prompt, (2) update skill, (3) test. All phases are documentation/config changes except testing. The RDR does not propose changes to the extraction pipeline itself; extraction improvements belong in RDR-021 and its successors.
+
+### Cross-Cutting Concerns
+
+- **Naming conventions**: The agent currently generates corpus names like `author-year-short-title` which is correct for the `--corpus` argument. The updated agent prompt must document that `--corpus` auto-prepends `docs__`, so the agent should not include the prefix.
+- **Skill PRODUCE section**: Currently references `nx store put`, which Phase 2 updates to reflect `nx index pdf` output. This is a documentation-only change but affects downstream agents that read the skill's PRODUCE contract.
+- **Backward compatibility**: The agent name (`pdf-chromadb-processor`) and skill invocation path (`/pdf-process`) remain unchanged. Existing workflows that reference these names continue to work.
+
+### Proportionality
+
+The effort is proportional to the problem. The 234-line agent prompt is provably broken (zero successful indexing in the observed failure) and the fix is a prompt rewrite to ~40 lines plus a skill update. No new dependencies, no new code, no migration. The risk of the change is low — `nx index pdf` is already the working path that the human operator discovered manually. This RDR simply makes the agent use the same path.
+
 ## References
 
-- `nx index pdf` implementation: `src/nexus/indexer.py`
+- `nx index pdf` implementation: `src/nexus/doc_indexer.py` (CLI: `src/nexus/commands/index.py`)
 - Current agent: `nx/agents/pdf-chromadb-processor.md`
 - Current skill: `nx/skills/pdf-processing/SKILL.md`
 - RDR-011: PDF Ingest Test Coverage
-- RDR-012: pdfplumber Extraction Tier
+- RDR-012: pdfplumber Extraction Tier (superseded by RDR-021)
 - RDR-015: Indexing Pipeline Rethink
+- RDR-021: Docling PDF Extraction (current extraction stack)
 - RDR-032: Indexer Module Decomposition


### PR DESCRIPTION
## Summary

- Ran 6 parallel substantive-critic agents to audit all batch-created draft RDRs (026, 027, 030, 031, 032, 033) for fabricated code references, stale claims, and missing design decisions
- All 6 returned verdict **FIX** (not slop, but needs targeted corrections)
- Ran 6 parallel fix agents, one per RDR, with full critic findings as edit spec
- All Finalization Gate sections now contain substantive responses instead of placeholders

### Per-RDR changes

| RDR | Key Fixes |
|-----|-----------|
| 026 | Rewrite premise: `--hybrid` already exists, gap is exact-match boosting in `apply_hybrid_scoring()` |
| 027 | Acknowledge existing `-A`/`-C` flags, add `-B` design decision, fix fabricated bat command flags |
| 030 | Add 4 missed silent catches (7→11 total), correct overstated impact claims, add pagination audit task |
| 031 | Add embedding space abort-on-mismatch (CCE vs voyage-4), fix arcaneum file path, define `--all` semantics |
| 032 | Document `voyage_client` vs `voyage_key` parameter asymmetry, add RDR-025 dependency, resolve PDF module confusion |
| 033 | Fix extraction stack description (Docling/PyMuPDF, not pymupdf4llm/pdfplumber), add collection naming guidance |

## Test plan

- [x] No code changes — documentation only
- [x] Each fix agent verified corrections against actual codebase
- [x] All file/function references in corrected RDRs point to real code