### PR TITLE
docs(rdr-026): accept RDR — hybrid search exact-match boost

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -39,7 +39,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-023](rdr-023-agent-tool-permissions-audit.md) | Agent Tool Permissions Audit and Remediation | Enhancement | Closed | 2026-03-07 |
 | [RDR-024](rdr-024-rdr-process-guardrails.md) | RDR Process Guardrails: Prevent Implementation Before Gate/Accept | Enhancement | Closed | 2026-03-07 |
 | [RDR-025](rdr-025-language-agnostic-agents.md) | Generalize Java Agents to Language-Agnostic Developer/Debugger/Architect-Planner | Enhancement | Closed | 2026-03-08 |
-| [RDR-026](rdr-026-hybrid-search-fusion.md) | Hybrid Search — Exact-Match Score Boosting | Feature | Draft | 2026-03-08 |
+| [RDR-026](rdr-026-hybrid-search-fusion.md) | Hybrid Search — Exact-Match Score Boosting | Feature | Accepted | 2026-03-08 |
 | [RDR-027](rdr-027-search-results-ux.md) | Search Results UX — Context Lines and Syntax Highlighting | Feature | Draft | 2026-03-08 |
 | [RDR-028](rdr-028-code-search-recall.md) | Code Search Recall — Language Registry Unification | Enhancement | Closed | 2026-03-08 |
 | [RDR-029](rdr-029-pipeline-versioning.md) | Pipeline Versioning — Force Reindex and Collection Version Stamping | Enhancement | Closed | 2026-03-08 |

--- a/docs/rdr/rdr-026-hybrid-search-fusion.md
+++ b/docs/rdr/rdr-026-hybrid-search-fusion.md
@@ -2,7 +2,8 @@
 title: "Hybrid Search — Exact-Match Score Boosting"
 id: RDR-026
 type: Feature
-status: draft
+status: accepted
+accepted_date: 2026-03-09
 priority: P1
 author: Hal Hildebrand
 reviewed-by: self


### PR DESCRIPTION
## Summary
- Accept RDR-026 after three rounds of gate validation (PASSED)
- Updates frontmatter `status: draft` → `status: accepted`, adds `accepted_date: 2026-03-09`
- Updates README index to reflect Accepted status

## Test plan
- [ ] Verify frontmatter change is correct (`status: accepted`, `accepted_date: 2026-03-09`)
- [ ] Verify README table shows Accepted for RDR-026