### PR TITLE
feat(search): hybrid exact-match score boosting (RDR-026)

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -46,7 +46,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-030](rdr-030-reliability-hardening.md) | Reliability Hardening — Silent Error Audit and Logging Policy | Enhancement | Draft | 2026-03-08 |
 | [RDR-031](rdr-031-collection-portability.md) | Collection Portability — Export/Import for T3 Backup and Migration | Feature | Draft | 2026-03-08 |
 | [RDR-032](rdr-032-indexer-decomposition.md) | Indexer Module Decomposition and Configuration Externalization | Technical Debt | Draft | 2026-03-08 |
-| [RDR-033](rdr-033-pdf-agent-nx-index-alignment.md) | PDF Processing Agent Should Delegate to nx index pdf | Architecture | Accepted | 2026-03-08 |
+| [RDR-033](rdr-033-pdf-agent-nx-index-alignment.md) | PDF Processing Agent Should Delegate to nx index pdf | Architecture | Closed | 2026-03-08 |
 
 ## RDR Process Documentation
 

--- a/docs/rdr/rdr-033-pdf-agent-nx-index-alignment.md
+++ b/docs/rdr/rdr-033-pdf-agent-nx-index-alignment.md
@@ -2,8 +2,10 @@
 title: "PDF Processing Agent Should Delegate to nx index pdf"
 id: RDR-033
 type: Architecture
-status: accepted
+status: closed
 accepted_date: 2026-03-09
+close_date: 2026-03-09
+close_reason: implemented
 priority: P1
 author: Hal Hildebrand
 reviewed-by: self

--- a/nx/agents/pdf-chromadb-processor.md
+++ b/nx/agents/pdf-chromadb-processor.md
@@ -26,7 +26,13 @@ Before starting, validate the relay contains all required fields per [RELAY_TEMP
 4. [ ] **Deliverable** description
 5. [ ] At least one **Quality Criterion** in checkbox format
 
-**If validation fails**, use RECOVER protocol from [CONTEXT_PROTOCOL.md](./_shared/CONTEXT_PROTOCOL.md).
+**If validation fails**, use RECOVER protocol from [CONTEXT_PROTOCOL.md](./_shared/CONTEXT_PROTOCOL.md):
+1. Search nx T3 store for missing context: `nx search "[task topic]" --corpus knowledge --n 5`
+2. Check nx T2 memory for session state: `nx memory search "[topic]" --project {project}`
+3. Check T1 scratch for in-session notes: `nx scratch search "[topic]"`
+4. Query `bd list --status=in_progress`
+5. Flag incomplete relay to user
+6. Proceed with available context, documenting assumptions
 
 ### Project Context
 

--- a/nx/skills/pdf-processing/SKILL.md
+++ b/nx/skills/pdf-processing/SKILL.md
@@ -35,7 +35,7 @@ nx search "representative query" --corpus docs__{corpus-name} -m 3
 
 **Corpus naming**: Use `author-year-short-title` pattern. The `--corpus` flag auto-prepends `docs__` — do NOT include the prefix.
 
-## Agent Path (Batch/Complex Scenarios)
+## Agent Invocation (Batch/Complex Scenarios)
 
 Delegates to the **pdf-chromadb-processor** agent (haiku) for:
 - Multiple PDFs needing batch processing

--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -33,14 +33,29 @@ def _parse_where(where_pairs: tuple[str, ...]) -> dict | None:
     return result
 
 _CONTENT_MAX_CHARS: int = 200
+EXACT_MATCH_BOOST: float = 0.15
 
 # Directory where ripgrep cache files are stored (overridable in tests via monkeypatch)
 _CONFIG_DIR: Path = Path.home() / ".config" / "nexus"
 
+# Prefixes to strip when mapping collection names to cache file names
+_COLLECTION_PREFIXES = ("code__", "docs__", "rdr__", "knowledge__")
 
-def _find_rg_cache_paths() -> list[Path]:
-    """Return all ripgrep cache files in the nexus config directory."""
-    return list(_CONFIG_DIR.glob("*.cache"))
+
+def _find_rg_cache_paths(corpus: str | None = None) -> list[Path]:
+    """Return ripgrep cache files, optionally filtered by corpus.
+
+    When *corpus* is provided (e.g. ``"code__nexus-a1b2c3d4"``), strip the
+    collection prefix and glob for ``{slug}.cache`` instead of ``*.cache``.
+    """
+    if corpus is None:
+        return list(_CONFIG_DIR.glob("*.cache"))
+    slug = corpus
+    for prefix in _COLLECTION_PREFIXES:
+        if slug.startswith(prefix):
+            slug = slug[len(prefix):]
+            break
+    return list(_CONFIG_DIR.glob(f"{slug}.cache"))
 
 
 def _rg_hit_to_result(hit: dict) -> SearchResult:
@@ -165,7 +180,9 @@ def search_cmd(
     def _retrieve(q: str) -> list[SearchResult]:
         raw = search_cross_corpus(q, target_collections, n_results=n, t3=db, where=where_filter)
         if hybrid:
-            for cache_path in _find_rg_cache_paths():
+            # Scope ripgrep to matching caches when a single corpus is targeted
+            rg_corpus = target_collections[0] if len(target_collections) == 1 else None
+            for cache_path in _find_rg_cache_paths(corpus=rg_corpus):
                 rg_hits = search_ripgrep(q, cache_path, n_results=n * 2)
                 raw.extend(_rg_hit_to_result(h) for h in rg_hits)
         return raw
@@ -187,6 +204,17 @@ def search_cmd(
             click.echo("No results.")
             return
 
+    # Pre-reranker: capture rg file paths while all results are present.
+    # The reranker's top_k may drop rg hits, so we capture before reranking.
+    rg_file_paths: set[str] = set()
+    if hybrid:
+        rg_file_paths = {
+            r.metadata.get("file_path", "")
+            for r in results
+            if r.collection == "rg__cache"
+        }
+        rg_file_paths.discard("")
+
     # Hybrid scoring
     results = apply_hybrid_scoring(results, hybrid=hybrid)
 
@@ -202,6 +230,20 @@ def search_cmd(
         for r in results:
             groups.setdefault(r.collection, []).append(r)
         results = round_robin_interleave(list(groups.values()))[:n]
+
+    # Post-reranker: apply exact-match boost using pre-captured rg file paths.
+    # Fires unconditionally after both reranked and no-rerank paths.
+    if rg_file_paths:
+        for r in results:
+            src = r.metadata.get("source_path", r.metadata.get("file_path", ""))
+            if src in rg_file_paths:
+                r.hybrid_score = min(1.0, r.hybrid_score + EXACT_MATCH_BOOST)
+
+    # Filter rg__cache signals from output — they served as file_path linkage.
+    # Fallback guard: preserve rg results when no vector results survive.
+    if hybrid:
+        vector_results = [r for r in results if r.collection != "rg__cache"]
+        results = vector_results if vector_results else results
 
     # --reverse: invert final order
     if reverse:

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -14,6 +14,7 @@ _log = structlog.get_logger()
 _EPSILON = 1e-9
 _RERANK_MODEL = "rerank-2.5"
 _FILE_SIZE_THRESHOLD = 30
+RG_FLOOR_SCORE = 0.5
 
 
 def _file_size_factor(chunk_count: int) -> float:
@@ -76,7 +77,9 @@ def apply_hybrid_scoring(
     if hybrid and not has_code:
         _log.warning("--hybrid has no effect — no code corpus in scope")
 
-    distances = [r.distance for r in results]
+    # Exclude rg__cache from normalization window — distance=0.0 from ripgrep
+    # hits distorts the min-max range for real vector distances.
+    distances = [r.distance for r in results if r.collection != "rg__cache"]
     frecencies = [
         r.metadata.get("frecency_score", 0.0)
         for r in results
@@ -84,8 +87,11 @@ def apply_hybrid_scoring(
     ]
 
     for r in results:
+        if r.collection == "rg__cache":
+            r.hybrid_score = RG_FLOOR_SCORE
+            continue
         # Invert: distances are dissimilarity (smaller = better), so best match → v_norm=1.0
-        v_norm = 1.0 - min_max_normalize(r.distance, distances)
+        v_norm = 1.0 - min_max_normalize(r.distance, distances) if distances else 1.0
         if hybrid and r.collection.startswith("code__"):
             f_score = r.metadata.get("frecency_score", 0.0)
             f_norm = min_max_normalize(f_score, frecencies) if frecencies else 0.0

--- a/tests/test_hybrid_boost.py
+++ b/tests/test_hybrid_boost.py
@@ -1,0 +1,457 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for RDR-026: Hybrid Search — Exact-Match Score Boosting.
+
+Phase 1 covers:
+1. distance=0.0 fix (rg__cache excluded from normalization)
+2. Pre-reranker capture + post-reranker boost
+3. rg__cache filtered from output with fallback guard
+4. Boost fires on both reranked and --no-rerank paths
+5. Multi-repo cache corpus filtering
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.types import SearchResult
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _sr(
+    id: str = "r1",
+    content: str = "some content",
+    distance: float = 0.3,
+    collection: str = "code__repo",
+    file_path: str = "/repo/file.py",
+    **extra_meta: object,
+) -> SearchResult:
+    meta = {"source_path": file_path, "file_path": file_path, "frecency_score": 0.5}
+    meta.update(extra_meta)
+    return SearchResult(
+        id=id, content=content, distance=distance,
+        collection=collection, metadata=meta,
+    )
+
+
+def _rg_sr(file_path: str = "/repo/match.py", line: int = 10) -> SearchResult:
+    """Create a ripgrep-style SearchResult with distance=0.0."""
+    return SearchResult(
+        id=f"rg:{file_path}:{line}",
+        content="matched line content",
+        distance=0.0,
+        collection="rg__cache",
+        metadata={
+            "file_path": file_path,
+            "source_path": file_path,
+            "line_start": line,
+            "frecency_score": 0.5,
+            "source": "ripgrep",
+        },
+    )
+
+
+# ── 1. distance=0.0 fix — rg__cache excluded from normalization ─────────────
+
+
+def test_rg_cache_excluded_from_normalization_window() -> None:
+    """rg__cache results (distance=0.0) must NOT distort the normalization window."""
+    from nexus.scoring import apply_hybrid_scoring
+
+    vector_a = _sr(id="v1", distance=0.85, collection="code__repo")
+    vector_b = _sr(id="v2", distance=0.95, collection="code__repo")
+    rg_hit = _rg_sr()
+
+    results = apply_hybrid_scoring([vector_a, vector_b, rg_hit], hybrid=True)
+
+    # rg hit should get RG_FLOOR_SCORE, not v_norm=1.0 from distance=0.0
+    rg_result = next(r for r in results if r.collection == "rg__cache")
+    assert rg_result.hybrid_score == pytest.approx(0.5, abs=0.01), (
+        f"rg__cache should get RG_FLOOR_SCORE=0.5, got {rg_result.hybrid_score}"
+    )
+
+    # Vector results should be normalized only against each other
+    v_results = sorted(
+        [r for r in results if r.collection != "rg__cache"],
+        key=lambda r: r.distance,
+    )
+    # v1 (dist=0.85) should score higher than v2 (dist=0.95) — lower distance = better
+    assert v_results[0].hybrid_score > v_results[1].hybrid_score
+
+
+def test_rg_cache_gets_floor_score_not_v_norm() -> None:
+    """rg__cache hybrid_score is RG_FLOOR_SCORE (0.5), not computed from distance."""
+    from nexus.scoring import apply_hybrid_scoring, RG_FLOOR_SCORE
+
+    rg_hit = _rg_sr()
+    vector = _sr(id="v1", distance=0.9, collection="code__repo")
+
+    results = apply_hybrid_scoring([vector, rg_hit], hybrid=True)
+    rg_result = next(r for r in results if r.collection == "rg__cache")
+    assert rg_result.hybrid_score == pytest.approx(RG_FLOOR_SCORE)
+
+
+def test_rg_floor_score_constant_exists() -> None:
+    """RG_FLOOR_SCORE constant is exported from scoring module."""
+    from nexus.scoring import RG_FLOOR_SCORE
+    assert RG_FLOOR_SCORE == 0.5
+
+
+def test_scoring_without_rg_cache_unchanged() -> None:
+    """apply_hybrid_scoring without any rg__cache results behaves exactly as before."""
+    from nexus.scoring import apply_hybrid_scoring
+
+    v1 = _sr(id="v1", distance=0.0, collection="code__repo")
+    v2 = _sr(id="v2", distance=0.5, collection="code__repo")
+    v3 = _sr(id="v3", distance=1.0, collection="code__repo")
+
+    results = apply_hybrid_scoring([v1, v2, v3], hybrid=True)
+    scores = {r.id: r.hybrid_score for r in results}
+    # v1 (dist=0.0) → v_norm=1.0, v3 (dist=1.0) → v_norm=0.0
+    assert scores["v1"] > scores["v2"] > scores["v3"]
+
+
+# ── 2. Pre-reranker capture + post-reranker boost ───────────────────────────
+
+
+def test_exact_match_boost_constant_exists() -> None:
+    """EXACT_MATCH_BOOST constant is exported from search_cmd module."""
+    from nexus.commands.search_cmd import EXACT_MATCH_BOOST
+    assert EXACT_MATCH_BOOST == 0.15
+
+
+def test_boost_applied_to_vector_result_matching_rg_file_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Vector result whose source_path matches an rg hit gets +0.15 boost."""
+    monkeypatch.setenv("CHROMA_API_KEY", "k")
+    monkeypatch.setenv("VOYAGE_API_KEY", "v")
+    monkeypatch.setenv("CHROMA_TENANT", "t")
+    monkeypatch.setenv("CHROMA_DATABASE", "d")
+    monkeypatch.setattr("nexus.commands.search_cmd._CONFIG_DIR", tmp_path)
+
+    cache_file = tmp_path / "repo-abcd1234.cache"
+    cache_file.write_text("/repo/match.py:10:hello\n")
+
+    # Vector result for a file that rg also matched
+    vector_match = _sr(id="vm", distance=0.9, collection="code__repo-abcd1234",
+                       file_path="/repo/match.py")
+    # Vector result for a file rg did NOT match
+    vector_no_match = _sr(id="vnm", distance=0.9, collection="code__repo-abcd1234",
+                          file_path="/repo/other.py")
+
+    rg_hit = {"file_path": "/repo/match.py", "line_number": 10,
+              "line_content": "hello", "frecency_score": 0.5}
+
+    mock_t3 = MagicMock()
+    mock_t3.list_collections.return_value = [{"name": "code__repo-abcd1234"}]
+
+    runner = CliRunner()
+    with (
+        patch("nexus.commands.search_cmd._t3", return_value=mock_t3),
+        patch("nexus.commands.search_cmd.search_cross_corpus",
+              return_value=[vector_match, vector_no_match]),
+        patch("nexus.commands.search_cmd.search_ripgrep", return_value=[rg_hit]),
+        patch("nexus.commands.search_cmd.load_config",
+              return_value={"embeddings": {"rerankerModel": "rerank-2.5"}}),
+    ):
+        result = runner.invoke(
+            __import__("nexus.cli", fromlist=["main"]).main,
+            ["search", "query", "--hybrid", "--corpus", "code", "--no-rerank", "--json"],
+        )
+
+    assert result.exit_code == 0, result.output
+
+    import json
+    data = json.loads(result.output)
+
+    # format_json spreads metadata into top-level — source_path is a top-level key
+    match_result = next((r for r in data if r.get("source_path") == "/repo/match.py"), None)
+    no_match_result = next((r for r in data if r.get("source_path") == "/repo/other.py"), None)
+
+    assert match_result is not None, "Should have result for /repo/match.py"
+    assert no_match_result is not None, "Should have result for /repo/other.py"
+
+    # The boosted result should appear first (higher position = higher score)
+    match_idx = next(i for i, r in enumerate(data) if r.get("source_path") == "/repo/match.py")
+    nomatch_idx = next(i for i, r in enumerate(data) if r.get("source_path") == "/repo/other.py")
+    assert match_idx < nomatch_idx, (
+        "Boosted result should rank higher (appear first) than unboosted"
+    )
+
+
+# ── 3. rg__cache filtered from output with fallback guard ───────────────────
+
+
+def test_rg_cache_results_filtered_from_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """rg__cache results should not appear in final output."""
+    monkeypatch.setenv("CHROMA_API_KEY", "k")
+    monkeypatch.setenv("VOYAGE_API_KEY", "v")
+    monkeypatch.setenv("CHROMA_TENANT", "t")
+    monkeypatch.setenv("CHROMA_DATABASE", "d")
+    monkeypatch.setattr("nexus.commands.search_cmd._CONFIG_DIR", tmp_path)
+
+    cache_file = tmp_path / "repo-abcd1234.cache"
+    cache_file.write_text("/repo/main.py:1:hello\n")
+
+    vector = _sr(id="v1", distance=0.9, collection="code__repo-abcd1234",
+                 file_path="/repo/file.py")
+    rg_hit = {"file_path": "/repo/main.py", "line_number": 1,
+              "line_content": "hello", "frecency_score": 0.5}
+
+    mock_t3 = MagicMock()
+    mock_t3.list_collections.return_value = [{"name": "code__repo-abcd1234"}]
+
+    runner = CliRunner()
+    with (
+        patch("nexus.commands.search_cmd._t3", return_value=mock_t3),
+        patch("nexus.commands.search_cmd.search_cross_corpus", return_value=[vector]),
+        patch("nexus.commands.search_cmd.search_ripgrep", return_value=[rg_hit]),
+        patch("nexus.commands.search_cmd.load_config",
+              return_value={"embeddings": {"rerankerModel": "rerank-2.5"}}),
+    ):
+        result = runner.invoke(
+            __import__("nexus.cli", fromlist=["main"]).main,
+            ["search", "query", "--hybrid", "--corpus", "code", "--no-rerank", "--json"],
+        )
+
+    assert result.exit_code == 0, result.output
+    import json
+    data = json.loads(result.output)
+    collections = [r.get("collection") for r in data]
+    assert "rg__cache" not in collections, "rg__cache results should be filtered from output"
+
+
+def test_rg_only_results_preserved_by_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """When no vector results exist, rg__cache results are preserved (fallback guard)."""
+    monkeypatch.setenv("CHROMA_API_KEY", "k")
+    monkeypatch.setenv("VOYAGE_API_KEY", "v")
+    monkeypatch.setenv("CHROMA_TENANT", "t")
+    monkeypatch.setenv("CHROMA_DATABASE", "d")
+    monkeypatch.setattr("nexus.commands.search_cmd._CONFIG_DIR", tmp_path)
+
+    cache_file = tmp_path / "repo-abcd1234.cache"
+    cache_file.write_text("/repo/main.py:1:hello\n")
+
+    rg_hit = {"file_path": "/repo/main.py", "line_number": 1,
+              "line_content": "hello", "frecency_score": 0.5}
+
+    mock_t3 = MagicMock()
+    mock_t3.list_collections.return_value = [{"name": "code__repo-abcd1234"}]
+
+    runner = CliRunner()
+    with (
+        patch("nexus.commands.search_cmd._t3", return_value=mock_t3),
+        patch("nexus.commands.search_cmd.search_cross_corpus", return_value=[]),
+        patch("nexus.commands.search_cmd.search_ripgrep", return_value=[rg_hit]),
+        patch("nexus.commands.search_cmd.load_config",
+              return_value={"embeddings": {"rerankerModel": "rerank-2.5"}}),
+    ):
+        result = runner.invoke(
+            __import__("nexus.cli", fromlist=["main"]).main,
+            ["search", "query", "--hybrid", "--corpus", "code", "--no-rerank"],
+        )
+
+    assert result.exit_code == 0, result.output
+    # When no vector results exist, rg results should be preserved, not dropped
+    assert "No results" not in result.output, "Fallback guard should preserve rg-only results"
+
+
+# ── 4. Boost fires on --no-rerank path ──────────────────────────────────────
+
+
+def test_boost_fires_on_no_rerank_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Exact-match boost applies on --no-rerank path too, not just reranked."""
+    monkeypatch.setenv("CHROMA_API_KEY", "k")
+    monkeypatch.setenv("VOYAGE_API_KEY", "v")
+    monkeypatch.setenv("CHROMA_TENANT", "t")
+    monkeypatch.setenv("CHROMA_DATABASE", "d")
+    monkeypatch.setattr("nexus.commands.search_cmd._CONFIG_DIR", tmp_path)
+
+    cache_file = tmp_path / "repo-abcd1234.cache"
+    cache_file.write_text("/repo/match.py:10:hello\n")
+
+    # Both vector results have identical distance — only the boost differentiates
+    vector_match = _sr(id="vm", distance=0.9, collection="code__repo-abcd1234",
+                       file_path="/repo/match.py")
+    vector_no_match = _sr(id="vnm", distance=0.9, collection="code__repo-abcd1234",
+                          file_path="/repo/other.py")
+
+    rg_hit = {"file_path": "/repo/match.py", "line_number": 10,
+              "line_content": "hello", "frecency_score": 0.5}
+
+    mock_t3 = MagicMock()
+    mock_t3.list_collections.return_value = [{"name": "code__repo-abcd1234"}]
+
+    runner = CliRunner()
+    with (
+        patch("nexus.commands.search_cmd._t3", return_value=mock_t3),
+        patch("nexus.commands.search_cmd.search_cross_corpus",
+              return_value=[vector_match, vector_no_match]),
+        patch("nexus.commands.search_cmd.search_ripgrep", return_value=[rg_hit]),
+        patch("nexus.commands.search_cmd.load_config",
+              return_value={"embeddings": {"rerankerModel": "rerank-2.5"}}),
+    ):
+        result = runner.invoke(
+            __import__("nexus.cli", fromlist=["main"]).main,
+            ["search", "query", "--hybrid", "--corpus", "code",
+             "--no-rerank", "--json"],
+        )
+
+    assert result.exit_code == 0, result.output
+    import json
+    data = json.loads(result.output)
+
+    match_idx = next((i for i, r in enumerate(data) if r.get("source_path") == "/repo/match.py"), None)
+    nomatch_idx = next((i for i, r in enumerate(data) if r.get("source_path") == "/repo/other.py"), None)
+
+    assert match_idx is not None and nomatch_idx is not None
+    assert match_idx < nomatch_idx, (
+        "Boost should fire on --no-rerank path — boosted result should rank first"
+    )
+
+
+# ── 5. Multi-repo cache corpus filtering ────────────────────────────────────
+
+
+def test_find_rg_cache_paths_no_filter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without corpus filter, all .cache files are returned."""
+    monkeypatch.setattr("nexus.commands.search_cmd._CONFIG_DIR", tmp_path)
+
+    (tmp_path / "nexus-a1b2c3d4.cache").touch()
+    (tmp_path / "other-e5f6g7h8.cache").touch()
+
+    from nexus.commands.search_cmd import _find_rg_cache_paths
+    paths = _find_rg_cache_paths()
+    assert len(paths) == 2
+
+
+def test_find_rg_cache_paths_with_corpus_filter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With corpus filter, only matching cache files are returned."""
+    monkeypatch.setattr("nexus.commands.search_cmd._CONFIG_DIR", tmp_path)
+
+    (tmp_path / "nexus-a1b2c3d4.cache").touch()
+    (tmp_path / "other-e5f6g7h8.cache").touch()
+
+    from nexus.commands.search_cmd import _find_rg_cache_paths
+
+    # Filter by collection name — strips code__ prefix
+    paths = _find_rg_cache_paths(corpus="code__nexus-a1b2c3d4")
+    assert len(paths) == 1
+    assert paths[0].name == "nexus-a1b2c3d4.cache"
+
+
+def test_find_rg_cache_paths_strips_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Corpus filter strips code__/docs__/rdr__ prefixes correctly."""
+    monkeypatch.setattr("nexus.commands.search_cmd._CONFIG_DIR", tmp_path)
+
+    (tmp_path / "myrepo-abcd1234.cache").touch()
+
+    from nexus.commands.search_cmd import _find_rg_cache_paths
+
+    for prefix in ("code__", "docs__", "rdr__"):
+        paths = _find_rg_cache_paths(corpus=f"{prefix}myrepo-abcd1234")
+        assert len(paths) == 1, f"Should match after stripping {prefix}"
+        assert paths[0].name == "myrepo-abcd1234.cache"
+
+
+def test_find_rg_cache_paths_no_match_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Corpus filter with no matching cache returns empty list."""
+    monkeypatch.setattr("nexus.commands.search_cmd._CONFIG_DIR", tmp_path)
+
+    (tmp_path / "nexus-a1b2c3d4.cache").touch()
+
+    from nexus.commands.search_cmd import _find_rg_cache_paths
+    paths = _find_rg_cache_paths(corpus="code__nonexistent-00000000")
+    assert len(paths) == 0
+
+
+def test_hybrid_search_uses_corpus_filter(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """--hybrid with --corpus code__nexus only searches nexus caches, not others."""
+    monkeypatch.setenv("CHROMA_API_KEY", "k")
+    monkeypatch.setenv("VOYAGE_API_KEY", "v")
+    monkeypatch.setenv("CHROMA_TENANT", "t")
+    monkeypatch.setenv("CHROMA_DATABASE", "d")
+    monkeypatch.setattr("nexus.commands.search_cmd._CONFIG_DIR", tmp_path)
+
+    # Two cache files — only one should be searched
+    (tmp_path / "nexus-a1b2c3d4.cache").write_text("/repo/file.py:1:match\n")
+    (tmp_path / "other-e5f6g7h8.cache").write_text("/other/file.py:1:match\n")
+
+    rg_calls: list[Path] = []
+
+    def fake_search_ripgrep(query, cache_path, *, n_results=50, fixed_strings=True):
+        rg_calls.append(cache_path)
+        return []
+
+    mock_t3 = MagicMock()
+    mock_t3.list_collections.return_value = [{"name": "code__nexus-a1b2c3d4"}]
+
+    runner = CliRunner()
+    with (
+        patch("nexus.commands.search_cmd._t3", return_value=mock_t3),
+        patch("nexus.commands.search_cmd.search_cross_corpus", return_value=[]),
+        patch("nexus.commands.search_cmd.search_ripgrep", side_effect=fake_search_ripgrep),
+        patch("nexus.commands.search_cmd.load_config",
+              return_value={"embeddings": {"rerankerModel": "rerank-2.5"}}),
+    ):
+        result = runner.invoke(
+            __import__("nexus.cli", fromlist=["main"]).main,
+            ["search", "query", "--hybrid", "--corpus", "code__nexus-a1b2c3d4", "--no-rerank"],
+        )
+
+    assert result.exit_code == 0, result.output
+    cache_names = [p.name for p in rg_calls]
+    assert "nexus-a1b2c3d4.cache" in cache_names, "Should search nexus cache"
+    assert "other-e5f6g7h8.cache" not in cache_names, "Should NOT search other cache"
+
+
+# ── Edge cases ───────────────────────────────────────────────────────────────
+
+
+def test_hybrid_score_capped_at_one() -> None:
+    """Boost should never push hybrid_score above 1.0."""
+    from nexus.scoring import apply_hybrid_scoring
+    from nexus.commands.search_cmd import EXACT_MATCH_BOOST
+
+    # Create a result with max score that would exceed 1.0 with boost
+    v = _sr(id="v1", distance=0.0, collection="code__repo", file_path="/repo/match.py")
+    rg = _rg_sr(file_path="/repo/match.py")
+
+    results = apply_hybrid_scoring([v, rg], hybrid=True)
+
+    # The vector result has v_norm=1.0. After boost of 0.15, it should cap at 1.0
+    v_result = next(r for r in results if r.collection != "rg__cache")
+    # We can't directly test the cap here since boost happens in search_cmd,
+    # but we can verify that apply_hybrid_scoring scores are valid [0, 1]
+    assert 0.0 <= v_result.hybrid_score <= 1.0
+
+
+def test_non_hybrid_search_unaffected() -> None:
+    """Non-hybrid search produces same results as before (no rg__cache in play)."""
+    from nexus.scoring import apply_hybrid_scoring
+
+    v1 = _sr(id="v1", distance=0.2, collection="code__repo")
+    v2 = _sr(id="v2", distance=0.8, collection="code__repo")
+
+    results = apply_hybrid_scoring([v1, v2], hybrid=False)
+    assert results[0].id == "v1"  # lower distance = higher score
+    assert results[1].id == "v2"


### PR DESCRIPTION
## Summary
- Fix distance=0.0 bug: rg__cache excluded from normalization window, assigned RG_FLOOR_SCORE=0.5
- Add post-reranker exact-match boost (+0.15) using pre-captured rg file paths for file_path linkage
- Filter rg__cache signals from output with zero-result fallback guard
- Scope ripgrep cache search by corpus to prevent multi-repo contamination
- 16 new tests in `test_hybrid_boost.py` covering all Phase 1 items
- Also includes: RDR-033 close, PDF agent RECOVER protocol fix

## Test plan
- [x] 16 unit tests for all RDR-026 Phase 1 items pass
- [x] Full test suite: 1983 passed, 0 failed
- [ ] Integration: search a repo with `--hybrid` and verify exact-match files rank higher
- [ ] Regression: non-hybrid searches produce identical results

References: nexus-ir5i (RDR-026), nexus-nk3s (RDR-033)