### PR TITLE
docs: close RDR-026 — all 3 phases implemented

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -39,7 +39,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-023](rdr-023-agent-tool-permissions-audit.md) | Agent Tool Permissions Audit and Remediation | Enhancement | Closed | 2026-03-07 |
 | [RDR-024](rdr-024-rdr-process-guardrails.md) | RDR Process Guardrails: Prevent Implementation Before Gate/Accept | Enhancement | Closed | 2026-03-07 |
 | [RDR-025](rdr-025-language-agnostic-agents.md) | Generalize Java Agents to Language-Agnostic Developer/Debugger/Architect-Planner | Enhancement | Closed | 2026-03-08 |
-| [RDR-026](rdr-026-hybrid-search-fusion.md) | Hybrid Search — Exact-Match Score Boosting | Feature | Accepted | 2026-03-08 |
+| [RDR-026](rdr-026-hybrid-search-fusion.md) | Hybrid Search — Exact-Match Score Boosting | Feature | Closed | 2026-03-08 |
 | [RDR-027](rdr-027-search-results-ux.md) | Search Results UX — Context Lines and Syntax Highlighting | Feature | Draft | 2026-03-08 |
 | [RDR-028](rdr-028-code-search-recall.md) | Code Search Recall — Language Registry Unification | Enhancement | Closed | 2026-03-08 |
 | [RDR-029](rdr-029-pipeline-versioning.md) | Pipeline Versioning — Force Reindex and Collection Version Stamping | Enhancement | Closed | 2026-03-08 |

--- a/docs/rdr/rdr-026-hybrid-search-fusion.md
+++ b/docs/rdr/rdr-026-hybrid-search-fusion.md
@@ -2,15 +2,17 @@
 title: "Hybrid Search — Exact-Match Score Boosting"
 id: RDR-026
 type: Feature
-status: accepted
+status: closed
 accepted_date: 2026-03-09
+close_date: 2026-03-09
+close_reason: implemented
 priority: P1
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-03-08
 related_issues: ["RDR-006", "RDR-007"]
 related_tests: ["tests/test_scoring.py", "tests/test_search_cmd.py", "tests/test_hybrid_boost.py"]
-implementation_notes: "PR #84 — Phase 1 complete"
+implementation_notes: "Phase 1: PR #84, Phase 2-3: PR #86 — all 11 items complete"
 ---
 
 # RDR-026: Hybrid Search — Exact-Match Score Boosting


### PR DESCRIPTION
## Summary
- Closes RDR-026 (Hybrid Search — Exact-Match Score Boosting)
- All 11 implementation plan items across 3 phases are complete
- Phase 1: PR #84, Phase 2-3: PR #86
- Updates frontmatter status to `closed` and README index

## Test plan
- [x] No code changes — docs only