### PR TITLE
feat(store): add nx store get command

### DIFF
--- a/src/nexus/commands/store.py
+++ b/src/nexus/commands/store.py
@@ -137,6 +137,45 @@ def list_cmd(collection: str, limit: int) -> None:
 
 
 
+@store.command("get")
+@click.argument("doc_id")
+@click.option("--collection", "-c", default="knowledge", show_default=True,
+              help="Collection name or prefix (default: knowledge)")
+@click.option("--json", "json_out", is_flag=True, default=False,
+              help="Output as JSON")
+def get_cmd(doc_id: str, collection: str, json_out: bool) -> None:
+    """Retrieve a T3 knowledge entry by its document ID.
+
+    DOC_ID is the 16-char hex ID shown by 'nx store list'.
+
+    \b
+    Examples:
+      nx store get a1b2c3d4e5f6g7h8
+      nx store get a1b2c3d4e5f6g7h8 --collection code__myrepo --json
+    """
+    col_name = t3_collection_name(collection)
+    entry = _t3().get_by_id(col_name, doc_id)
+    if entry is None:
+        raise click.ClickException(f"Entry {doc_id!r} not found in {col_name}")
+
+    if json_out:
+        import json
+        click.echo(json.dumps(entry, indent=2))
+    else:
+        title = entry.get("title", "")
+        tags = entry.get("tags", "")
+        indexed_at = (entry.get("indexed_at") or "")[:10]
+        click.echo(f"ID:         {entry['id']}")
+        click.echo(f"Collection: {col_name}")
+        if title:
+            click.echo(f"Title:      {title}")
+        if tags:
+            click.echo(f"Tags:       {tags}")
+        if indexed_at:
+            click.echo(f"Indexed:    {indexed_at}")
+        click.echo(f"\n{entry.get('content', '')}")
+
+
 @store.command("delete")
 @click.option("--collection", "-c", required=True,
               help="Collection name (required)")

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -657,6 +657,28 @@ class T3Database:
             self._delete_batch(col, collection_name, ids)
         return len(ids)
 
+    def get_by_id(self, collection: str, doc_id: str) -> dict | None:
+        """Retrieve a single entry by its exact document ID.
+
+        Returns a dict with ``id``, ``content``, and all metadata fields,
+        or ``None`` if the entry does not exist.
+        """
+        try:
+            col = self._client_for(collection).get_collection(collection)
+        except _ChromaNotFoundError:
+            return None
+        with self._read_sem(collection):
+            result = _chroma_with_retry(
+                col.get, ids=[doc_id], include=["documents", "metadatas"]
+            )
+        if not result["ids"]:
+            return None
+        return {
+            "id": result["ids"][0],
+            "content": result["documents"][0],
+            **result["metadatas"][0],
+        }
+
     def delete_by_id(self, collection: str, doc_id: str) -> bool:
         """Delete a single entry by its exact document ID. Returns True if found and deleted."""
         try:

--- a/tests/test_store_cmd.py
+++ b/tests/test_store_cmd.py
@@ -691,3 +691,64 @@ def test_store_list_shows_16char_ids(runner: CliRunner, env_creds: None) -> None
         result = runner.invoke(main, ["store", "list"])
     assert result.exit_code == 0, result.output
     assert "abcdef1234567890" in result.output  # 16 chars present
+
+
+# ── nx store get ──────────────────────────────────────────────────────────────
+
+def test_store_get_happy(runner: CliRunner, env_creds: None) -> None:
+    """get retrieves entry and displays content."""
+    mock_db = MagicMock()
+    mock_db.get_by_id.return_value = {
+        "id": "abcdef1234567890",
+        "content": "Important knowledge content here",
+        "title": "finding.md",
+        "tags": "arch,review",
+        "indexed_at": "2026-03-09T10:00:00+00:00",
+    }
+    with patch("nexus.commands.store._t3", return_value=mock_db):
+        result = runner.invoke(main, ["store", "get", "abcdef1234567890"])
+    assert result.exit_code == 0, result.output
+    assert "abcdef1234567890" in result.output
+    assert "finding.md" in result.output
+    assert "arch,review" in result.output
+    assert "Important knowledge content here" in result.output
+
+
+def test_store_get_not_found(runner: CliRunner, env_creds: None) -> None:
+    """get exits non-zero when entry not found."""
+    mock_db = MagicMock()
+    mock_db.get_by_id.return_value = None
+    with patch("nexus.commands.store._t3", return_value=mock_db):
+        result = runner.invoke(main, ["store", "get", "nonexistent12345"])
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+def test_store_get_json_output(runner: CliRunner, env_creds: None) -> None:
+    """get --json outputs valid JSON with all fields."""
+    import json
+    mock_db = MagicMock()
+    mock_db.get_by_id.return_value = {
+        "id": "abcdef1234567890",
+        "content": "test content",
+        "title": "doc.md",
+        "tags": "test",
+        "indexed_at": "2026-03-09",
+    }
+    with patch("nexus.commands.store._t3", return_value=mock_db):
+        result = runner.invoke(main, ["store", "get", "abcdef1234567890", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["id"] == "abcdef1234567890"
+    assert data["content"] == "test content"
+
+
+def test_store_get_custom_collection(runner: CliRunner, env_creds: None) -> None:
+    """get --collection routes to the correct collection."""
+    mock_db = MagicMock()
+    mock_db.get_by_id.return_value = {
+        "id": "abc123", "content": "x", "title": "t",
+    }
+    with patch("nexus.commands.store._t3", return_value=mock_db):
+        runner.invoke(main, ["store", "get", "abc123", "-c", "code__myrepo"])
+    mock_db.get_by_id.assert_called_once_with("code__myrepo", "abc123")


### PR DESCRIPTION
## Summary
- Adds `nx store get <DOC_ID>` for retrieving T3 entries by document ID
- Supports `--json` flag for machine-readable output
- Supports `--collection` for non-default collections
- Adds `get_by_id()` method to `T3Database`
- 4 new tests, all 42 store tests passing

## Test plan
- [x] `uv run pytest tests/test_store_cmd.py` — 42 passed

References: nexus-h9nj