### PR TITLE
feat(chunker): add minified code handling

### DIFF
--- a/src/nexus/chunker.py
+++ b/src/nexus/chunker.py
@@ -15,6 +15,11 @@ _CHUNK_LINES = 150
 _OVERLAP = 0.15
 # Alias for backward-compat with existing tests that import _CHUNK_MAX_BYTES.
 _CHUNK_MAX_BYTES = SAFE_CHUNK_BYTES
+# Lines longer than this threshold (bytes) are split at natural break points
+# before line-based chunking. Prevents minified JS/CSS from producing a single
+# oversized chunk that gets truncated.
+_LONG_LINE_THRESHOLD = SAFE_CHUNK_BYTES
+_BREAK_CHARS = (";", ",", "}", ")", "]")
 
 
 def _make_code_splitter(language: str, content: str, chunk_lines: int = _CHUNK_LINES) -> list:
@@ -45,6 +50,58 @@ def _make_code_splitter(language: str, content: str, chunk_lines: int = _CHUNK_L
     return splitter.get_nodes_from_documents([doc])
 
 
+def _split_long_line(line: str, max_chars: int) -> list[str]:
+    """Split a very long line into smaller segments at natural break points.
+
+    Used for minified code where a single line can be the entire file.
+    Prefers splitting at semicolons, commas, and closing brackets within
+    the last 20% of each segment.  Falls back to a hard cut at *max_chars*
+    when no natural break point is found.
+    """
+    if len(line) <= max_chars:
+        return [line]
+
+    segments: list[str] = []
+    pos = 0
+    while pos < len(line):
+        end = min(pos + max_chars, len(line))
+        if end < len(line):
+            # Search for a natural break in the last 20% of the segment
+            search_start = pos + int(max_chars * 0.8)
+            best_break = -1
+            for ch in _BREAK_CHARS:
+                bp = line.rfind(ch, search_start, end)
+                if bp > best_break:
+                    best_break = bp
+            if best_break > search_start:
+                end = best_break + 1  # include the break character
+        segments.append(line[pos:end])
+        pos = end
+    return segments
+
+
+def _expand_long_lines(content: str, max_bytes: int = _LONG_LINE_THRESHOLD) -> str:
+    """Pre-process content by splitting lines that exceed *max_bytes*.
+
+    Returns the content with long lines broken into shorter segments,
+    each ending at a natural code delimiter when possible.  This ensures
+    the downstream line-based chunker has reasonable-length lines to work with.
+    """
+    lines = content.splitlines()
+    has_long = any(len(ln.encode()) > max_bytes for ln in lines)
+    if not has_long:
+        return content
+    # Conservative char estimate: UTF-8 chars are ≤4 bytes, but code is mostly ASCII.
+    max_chars = max_bytes  # 1:1 for ASCII; will overshoot for multi-byte but that's safe
+    expanded: list[str] = []
+    for ln in lines:
+        if len(ln.encode()) > max_bytes:
+            expanded.extend(_split_long_line(ln, max_chars))
+        else:
+            expanded.append(ln)
+    return "\n".join(expanded)
+
+
 def _line_chunk(
     content: str,
     chunk_lines: int = _CHUNK_LINES,
@@ -64,6 +121,9 @@ def _line_chunk(
 
     Returns list of (line_start, line_end, text) tuples (1-indexed).
     """
+    # Pre-split long lines (minified code) so the line-based chunker
+    # has reasonable-length lines to work with.
+    content = _expand_long_lines(content, max_bytes=max_bytes)
     lines = content.splitlines()
     n = len(lines)
     if n == 0:
@@ -117,7 +177,9 @@ def _enforce_byte_cap(
             result.append(chunk)
             continue
 
-        # Oversized node: re-split line-by-line with binary-search byte cap.
+        # Oversized node: expand long lines (minified code), then re-split
+        # line-by-line with binary-search byte cap.
+        text = _expand_long_lines(text, max_bytes=max_bytes)
         base_ls: int = chunk.get("line_start", 1)
         lines = text.splitlines()
         pos = 0

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -225,12 +225,13 @@ def test_line_chunk_respects_max_bytes() -> None:
         )
 
 
-def test_line_chunk_single_oversized_line_is_truncated_at_cap() -> None:
-    """A single line larger than max_bytes is truncated at the byte cap (not emitted as-is)."""
+def test_line_chunk_single_oversized_line_is_split_at_cap() -> None:
+    """A single line larger than max_bytes is split into multiple chunks (not truncated)."""
     big_line = "z" * 20_000  # 20 KB — exceeds SAFE_CHUNK_BYTES
     chunks = _line_chunk(big_line, chunk_lines=150, max_bytes=_CHUNK_MAX_BYTES)
-    assert len(chunks) == 1
-    assert len(chunks[0][2].encode()) <= _CHUNK_MAX_BYTES
+    assert len(chunks) >= 1
+    for _, _, text in chunks:
+        assert len(text.encode()) <= _CHUNK_MAX_BYTES
 
 
 def test_line_chunk_byte_cap_no_gaps() -> None:
@@ -383,16 +384,16 @@ def test_chunk_file_ast_none_start_char_idx(tmp_path: Path) -> None:
 
 # ── Phase 2a: single-line truncation (escape hatch fix) ───────────────────────
 
-def test_line_chunk_single_oversized_line_is_truncated() -> None:
-    """A single line exceeding max_bytes must be truncated, not emitted as-is."""
+def test_line_chunk_single_oversized_line_is_split() -> None:
+    """A single line exceeding max_bytes is split into multiple chunks."""
     max_bytes = 50
     big_line = "x" * 200  # 200 bytes > 50
     chunks = _line_chunk(big_line, chunk_lines=150, max_bytes=max_bytes)
-    assert len(chunks) == 1
-    _, _, text = chunks[0]
-    assert len(text.encode()) <= max_bytes, (
-        f"Single oversized line must be truncated: got {len(text.encode())} bytes (limit {max_bytes})"
-    )
+    assert len(chunks) >= 1
+    for _, _, text in chunks:
+        assert len(text.encode()) <= max_bytes, (
+            f"Each chunk must fit in max_bytes: got {len(text.encode())} bytes (limit {max_bytes})"
+        )
 
 
 def test_enforce_byte_cap_single_oversized_node_is_truncated() -> None:

--- a/tests/test_minified_chunking.py
+++ b/tests/test_minified_chunking.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for minified code handling in the AST chunker."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.chunker import (
+    _CHUNK_MAX_BYTES,
+    _expand_long_lines,
+    _split_long_line,
+    chunk_file,
+)
+
+
+# ── _split_long_line ─────────────────────────────────────────────────────────
+
+
+def test_split_long_line_short_passthrough() -> None:
+    """Lines shorter than max_chars are returned as-is."""
+    result = _split_long_line("short line", max_chars=100)
+    assert result == ["short line"]
+
+
+def test_split_long_line_splits_at_semicolon() -> None:
+    """Prefers splitting at semicolons in the last 20% of the segment."""
+    # Build a line with a semicolon near the end of the first segment
+    line = "a" * 85 + ";rest" + "b" * 20
+    result = _split_long_line(line, max_chars=100)
+    assert len(result) >= 2
+    assert result[0].endswith(";")
+
+
+def test_split_long_line_splits_at_brace() -> None:
+    """Splits at closing brace when no semicolon available."""
+    line = "a" * 85 + "}rest" + "b" * 20
+    result = _split_long_line(line, max_chars=100)
+    assert len(result) >= 2
+    assert result[0].endswith("}")
+
+
+def test_split_long_line_hard_cut_when_no_break() -> None:
+    """Falls back to hard cut when no break character in last 20%."""
+    line = "a" * 200  # no break characters at all
+    result = _split_long_line(line, max_chars=100)
+    assert len(result) == 2
+    assert len(result[0]) == 100
+    assert len(result[1]) == 100
+
+
+def test_split_long_line_produces_no_empty_segments() -> None:
+    """No empty strings in the output."""
+    line = ";" * 500
+    result = _split_long_line(line, max_chars=100)
+    assert all(len(s) > 0 for s in result)
+
+
+# ── _expand_long_lines ───────────────────────────────────────────────────────
+
+
+def test_expand_long_lines_passthrough_normal() -> None:
+    """Normal multi-line content passes through unchanged."""
+    content = "line 1\nline 2\nline 3"
+    assert _expand_long_lines(content) == content
+
+
+def test_expand_long_lines_splits_minified() -> None:
+    """A single very long line gets split into multiple lines."""
+    minified = "var x=1;" * 5000  # ~40KB
+    result = _expand_long_lines(minified, max_bytes=1000)
+    lines = result.splitlines()
+    assert len(lines) > 1
+    # Each line should be ≤ 1000 chars (ASCII)
+    for ln in lines:
+        assert len(ln) <= 1000
+
+
+# ── chunk_file with minified content ─────────────────────────────────────────
+
+
+def test_chunk_file_minified_js_produces_multiple_chunks(tmp_path: Path) -> None:
+    """Minified JS (single long line) produces multiple chunks, not just one truncated chunk."""
+    # Build ~50KB of minified JS
+    minified = "var a=1;" * 6000
+    assert len(minified) > _CHUNK_MAX_BYTES * 2  # definitely oversized
+
+    chunks = chunk_file(Path("bundle.min.js"), minified)
+
+    assert len(chunks) > 1, f"Expected multiple chunks, got {len(chunks)}"
+    # All chunks should be within the byte limit
+    for c in chunks:
+        assert len(c["text"].encode()) <= _CHUNK_MAX_BYTES, (
+            f"Chunk {c['chunk_index']} exceeds byte limit: {len(c['text'].encode())}"
+        )
+    # Combined text should cover most of the original content
+    total_text = "".join(c["text"] for c in chunks)
+    assert len(total_text) > len(minified) * 0.5, (
+        "Chunks should cover at least half the original content"
+    )
+
+
+def test_chunk_file_minified_css_produces_multiple_chunks(tmp_path: Path) -> None:
+    """Minified CSS (single long line) also produces multiple chunks."""
+    minified = ".a{color:red;}" * 4000
+    chunks = chunk_file(Path("styles.min.css"), minified)
+
+    assert len(chunks) > 1
+    for c in chunks:
+        assert len(c["text"].encode()) <= _CHUNK_MAX_BYTES
+
+
+def test_chunk_file_normal_js_unchanged(tmp_path: Path) -> None:
+    """Normal JS with many short lines is not affected by minified handling."""
+    normal = "\n".join(f"var x{i} = {i};" for i in range(100))
+    chunks = chunk_file(Path("normal.js"), normal)
+
+    assert len(chunks) >= 1
+    # Should use AST chunking for .js files
+    assert chunks[0]["ast_chunked"] is True or chunks[0]["ast_chunked"] is False
+
+
+def test_chunk_file_minified_preserves_metadata() -> None:
+    """Minified chunks have correct file_path, filename, extension metadata."""
+    minified = "function f(){" + "x();" * 5000 + "}"
+    chunks = chunk_file(Path("/repo/app.min.js"), minified)
+
+    for c in chunks:
+        assert c["file_path"] == "/repo/app.min.js"
+        assert c["filename"] == "app.min.js"
+        assert c["file_extension"] == ".js"
+        assert "chunk_index" in c
+        assert "chunk_count" in c
+        assert "line_start" in c
+        assert "line_end" in c


### PR DESCRIPTION
## Summary
- Splits long lines at natural break points (`;`, `,`, `}`, `)`, `]`) before chunking
- Prevents minified JS/CSS from producing single oversized chunks that get truncated
- Ported from arcaneum's `_split_long_line()` pattern
- 11 new tests, 94 total chunker/indexer tests passing

## Test plan
- [x] `uv run pytest tests/test_minified_chunking.py` — 11 passed
- [x] `uv run pytest tests/test_chunker.py tests/test_indexer.py` — 83 passed (no regressions)

References: nexus-x6nm