### PR TITLE
feat(tests): add snapshot regression tests for search quality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,5 +71,6 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
     "pytest-cov>=7.0.0",
+    "syrupy>=4.0",
     "twine>=6.2.0",
 ]

--- a/tests/__snapshots__/test_search_snapshot.ambr
+++ b/tests/__snapshots__/test_search_snapshot.ambr
@@ -1,0 +1,127 @@
+# serializer version: 1
+# name: test_search_ranking_snapshot[caching strategy with TTL expiry]
+  '''
+  1.0000  knowledge__snapshot  /docs/arch_decision_002.md
+  0.4828  code__snapshot  /repo/cache_layer.py
+  0.3215  knowledge__snapshot  /docs/api_design.md
+  0.2327  code__snapshot  /repo/auth_logout.py
+  0.1254  code__snapshot  /repo/http_handler.py
+  0.1073  knowledge__snapshot  /docs/security_policy.md
+  0.0835  knowledge__snapshot  /docs/arch_decision_001.md
+  0.0433  code__snapshot  /repo/logging_setup.py
+  0.0235  code__snapshot  /repo/db_connection.py
+  0.0000  knowledge__snapshot  /docs/deployment_guide.md
+  '''
+# ---
+# name: test_search_ranking_snapshot[database connection pool management]
+  '''
+  0.7000  code__snapshot  /repo/db_connection.py
+  0.3270  knowledge__snapshot  /docs/security_policy.md
+  0.3166  knowledge__snapshot  /docs/arch_decision_001.md
+  0.1513  knowledge__snapshot  /docs/deployment_guide.md
+  0.1405  code__snapshot  /repo/auth_login.py
+  0.0979  code__snapshot  /repo/auth_register.py
+  0.0698  code__snapshot  /repo/db_migration.py
+  0.0465  knowledge__snapshot  /docs/api_design.md
+  0.0373  code__snapshot  /repo/config_loader.py
+  0.0000  knowledge__snapshot  /docs/arch_decision_002.md
+  '''
+# ---
+# name: test_search_ranking_snapshot[deployment docker configuration]
+  '''
+  1.0000  knowledge__snapshot  /docs/deployment_guide.md
+  0.4096  code__snapshot  /repo/config_loader.py
+  0.2495  code__snapshot  /repo/db_migration.py
+  0.2032  code__snapshot  /repo/db_connection.py
+  0.1070  code__snapshot  /repo/cache_layer.py
+  0.0912  code__snapshot  /repo/auth_login.py
+  0.0604  knowledge__snapshot  /docs/arch_decision_001.md
+  0.0479  knowledge__snapshot  /docs/api_design.md
+  0.0018  knowledge__snapshot  /docs/arch_decision_002.md
+  0.0000  knowledge__snapshot  /docs/security_policy.md
+  '''
+# ---
+# name: test_search_ranking_snapshot[search and indexing with embeddings]
+  '''
+  0.7000  code__snapshot  /repo/search_index.py
+  0.1960  knowledge__snapshot  /docs/arch_decision_002.md
+  0.1791  knowledge__snapshot  /docs/arch_decision_001.md
+  0.1240  code__snapshot  /repo/cache_layer.py
+  0.1048  code__snapshot  /repo/db_migration.py
+  0.0995  knowledge__snapshot  /docs/deployment_guide.md
+  0.0697  code__snapshot  /repo/auth_register.py
+  0.0631  knowledge__snapshot  /docs/security_policy.md
+  0.0165  code__snapshot  /repo/db_connection.py
+  0.0000  knowledge__snapshot  /docs/api_design.md
+  '''
+# ---
+# name: test_search_ranking_snapshot[security password hashing bcrypt]
+  '''
+  1.0000  knowledge__snapshot  /docs/security_policy.md
+  0.5161  code__snapshot  /repo/auth_login.py
+  0.4235  code__snapshot  /repo/auth_register.py
+  0.1947  knowledge__snapshot  /docs/arch_decision_002.md
+  0.1925  code__snapshot  /repo/auth_logout.py
+  0.1623  knowledge__snapshot  /docs/api_design.md
+  0.1522  code__snapshot  /repo/db_connection.py
+  0.1494  code__snapshot  /repo/cache_layer.py
+  0.1022  knowledge__snapshot  /docs/arch_decision_001.md
+  0.0000  knowledge__snapshot  /docs/deployment_guide.md
+  '''
+# ---
+# name: test_search_ranking_snapshot[user authentication login password]
+  '''
+  0.7000  code__snapshot  /repo/auth_login.py
+  0.6555  knowledge__snapshot  /docs/security_policy.md
+  0.4919  knowledge__snapshot  /docs/api_design.md
+  0.4608  code__snapshot  /repo/auth_register.py
+  0.2828  code__snapshot  /repo/auth_logout.py
+  0.0797  code__snapshot  /repo/logging_setup.py
+  0.0659  code__snapshot  /repo/cache_layer.py
+  0.0241  knowledge__snapshot  /docs/arch_decision_002.md
+  0.0143  knowledge__snapshot  /docs/arch_decision_001.md
+  0.0000  knowledge__snapshot  /docs/deployment_guide.md
+  '''
+# ---
+# name: test_search_single_corpus_snapshot[caching strategy with TTL expiry]
+  '''
+  1.0000  code__snapshot  /repo/cache_layer.py
+  0.5867  code__snapshot  /repo/auth_logout.py
+  0.4092  code__snapshot  /repo/http_handler.py
+  0.2736  code__snapshot  /repo/logging_setup.py
+  0.2408  code__snapshot  /repo/db_connection.py
+  0.2084  code__snapshot  /repo/config_loader.py
+  0.1624  code__snapshot  /repo/auth_login.py
+  0.1556  code__snapshot  /repo/auth_register.py
+  0.1037  code__snapshot  /repo/db_migration.py
+  0.0000  code__snapshot  /repo/search_index.py
+  '''
+# ---
+# name: test_search_single_corpus_snapshot[database connection pool management]
+  '''
+  1.0000  code__snapshot  /repo/db_connection.py
+  0.3926  code__snapshot  /repo/auth_login.py
+  0.3464  code__snapshot  /repo/auth_register.py
+  0.3159  code__snapshot  /repo/db_migration.py
+  0.2806  code__snapshot  /repo/config_loader.py
+  0.2684  code__snapshot  /repo/auth_logout.py
+  0.2311  code__snapshot  /repo/cache_layer.py
+  0.1992  code__snapshot  /repo/http_handler.py
+  0.0581  code__snapshot  /repo/logging_setup.py
+  0.0000  code__snapshot  /repo/search_index.py
+  '''
+# ---
+# name: test_search_single_corpus_snapshot[user authentication login password]
+  '''
+  1.0000  code__snapshot  /repo/auth_login.py
+  0.6964  code__snapshot  /repo/auth_register.py
+  0.4704  code__snapshot  /repo/auth_logout.py
+  0.2127  code__snapshot  /repo/logging_setup.py
+  0.1952  code__snapshot  /repo/cache_layer.py
+  0.1889  code__snapshot  /repo/db_connection.py
+  0.1777  code__snapshot  /repo/http_handler.py
+  0.1301  code__snapshot  /repo/config_loader.py
+  0.0216  code__snapshot  /repo/search_index.py
+  0.0000  code__snapshot  /repo/db_migration.py
+  '''
+# ---

--- a/tests/test_search_snapshot.py
+++ b/tests/test_search_snapshot.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Snapshot regression tests for search quality.
+
+Uses syrupy to capture search result ordering. When scoring weights,
+normalization logic, or context prefix format changes, these tests
+detect ranking regressions.
+
+No API keys required — uses EphemeralClient + ONNX MiniLM-L6-v2.
+"""
+from __future__ import annotations
+
+import chromadb
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+import pytest
+
+from nexus.db.t3 import T3Database
+from nexus.search_engine import search_cross_corpus
+from nexus.scoring import apply_hybrid_scoring
+
+
+# ── Corpus fixture ───────────────────────────────────────────────────────────
+
+# Deterministic documents covering different topics for ranking validation.
+_CODE_DOCS = [
+    ("auth_login", "def login(username, password):\n    user = db.find_user(username)\n    if not user or not verify_hash(password, user.password_hash):\n        raise AuthError('invalid credentials')\n    return create_session(user)"),
+    ("auth_logout", "def logout(session_id):\n    session = db.find_session(session_id)\n    if session:\n        db.delete_session(session_id)\n        return True\n    return False"),
+    ("auth_register", "def register(username, email, password):\n    if db.find_user(username):\n        raise ValueError('username taken')\n    hashed = hash_password(password)\n    user = User(username=username, email=email, password_hash=hashed)\n    db.save(user)\n    return user"),
+    ("db_connection", "class DatabasePool:\n    def __init__(self, dsn, min_conns=5, max_conns=20):\n        self.dsn = dsn\n        self.pool = create_pool(dsn, min_conns, max_conns)\n    def acquire(self):\n        return self.pool.get_connection()\n    def release(self, conn):\n        self.pool.return_connection(conn)"),
+    ("db_migration", "def run_migrations(db, migrations_dir):\n    applied = db.get_applied_migrations()\n    pending = discover_pending(migrations_dir, applied)\n    for migration in sorted(pending):\n        db.execute(migration.sql)\n        db.record_migration(migration.version)"),
+    ("http_handler", "class RequestHandler:\n    async def handle(self, request):\n        method = request.method\n        path = request.path\n        handler = self.router.match(method, path)\n        if not handler:\n            return Response(status=404)\n        return await handler(request)"),
+    ("cache_layer", "class CacheLayer:\n    def __init__(self, backend='redis', ttl=300):\n        self.backend = connect_cache(backend)\n        self.ttl = ttl\n    def get(self, key):\n        return self.backend.get(key)\n    def set(self, key, value):\n        self.backend.set(key, value, ex=self.ttl)"),
+    ("search_index", "def build_search_index(documents, embedding_model):\n    vectors = embedding_model.encode(documents)\n    index = create_faiss_index(vectors.shape[1])\n    index.add(vectors)\n    return index"),
+    ("config_loader", "def load_config(path='config.yml'):\n    with open(path) as f:\n        raw = yaml.safe_load(f)\n    defaults = get_defaults()\n    return deep_merge(defaults, raw)"),
+    ("logging_setup", "def setup_logging(level='INFO', json_output=False):\n    handler = logging.StreamHandler()\n    if json_output:\n        handler.setFormatter(JsonFormatter())\n    else:\n        handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))\n    logging.root.addHandler(handler)\n    logging.root.setLevel(level)"),
+]
+
+_KNOWLEDGE_DOCS = [
+    ("arch_decision_001", "We chose PostgreSQL over MySQL for the main database because it supports JSONB columns, better indexing, and has superior transaction isolation semantics."),
+    ("arch_decision_002", "Redis is used as the caching layer with a 5-minute TTL. Memcached was rejected because Redis supports data structures beyond simple key-value pairs."),
+    ("deployment_guide", "Deploy the application using Docker Compose. The stack includes nginx as reverse proxy, gunicorn for WSGI, and PostgreSQL for data storage."),
+    ("api_design", "All API endpoints follow REST conventions. Authentication uses JWT tokens with a 1-hour expiry. Rate limiting is applied at 100 requests per minute per user."),
+    ("security_policy", "All passwords are stored using bcrypt with a work factor of 12. SQL injection is prevented by parameterized queries. CSRF tokens are required for all state-changing operations."),
+]
+
+
+@pytest.fixture(scope="module")
+def search_corpus() -> T3Database:
+    """Session-scoped T3 with deterministic documents indexed.
+
+    Using module scope ensures the corpus is built once and shared across
+    all snapshot tests in this file, keeping tests fast.
+    """
+    client = chromadb.EphemeralClient()
+    ef = DefaultEmbeddingFunction()
+    db = T3Database(_client=client, _ef_override=ef)
+
+    # Index code documents
+    code_col = db.get_or_create_collection("code__snapshot")
+    ids = [f"code-{title}" for title, _ in _CODE_DOCS]
+    documents = [text for _, text in _CODE_DOCS]
+    metadatas = [
+        {
+            "title": title,
+            "source_path": f"/repo/{title}.py",
+            "file_path": f"/repo/{title}.py",
+            "line_start": 1,
+            "line_end": text.count("\n") + 1,
+            "frecency_score": 0.5,
+        }
+        for title, text in _CODE_DOCS
+    ]
+    code_col.add(ids=ids, documents=documents, metadatas=metadatas)
+
+    # Index knowledge documents
+    know_col = db.get_or_create_collection("knowledge__snapshot")
+    ids = [f"know-{title}" for title, _ in _KNOWLEDGE_DOCS]
+    documents = [text for _, text in _KNOWLEDGE_DOCS]
+    metadatas = [
+        {
+            "title": title,
+            "source_path": f"/docs/{title}.md",
+            "file_path": f"/docs/{title}.md",
+            "line_start": 1,
+            "line_end": 1,
+            "frecency_score": 0.5,
+        }
+        for title, text in _KNOWLEDGE_DOCS
+    ]
+    know_col.add(ids=ids, documents=documents, metadatas=metadatas)
+
+    return db
+
+
+# ── Snapshot queries ─────────────────────────────────────────────────────────
+
+_QUERIES = [
+    "user authentication login password",
+    "database connection pool management",
+    "caching strategy with TTL expiry",
+    "search and indexing with embeddings",
+    "deployment docker configuration",
+    "security password hashing bcrypt",
+]
+
+
+def _format_results(results: list) -> str:
+    """Format search results into a stable string for snapshot comparison."""
+    lines = []
+    for r in results:
+        path = r.metadata.get("source_path", "?")
+        score = f"{r.hybrid_score:.4f}" if r.hybrid_score else f"d={r.distance:.4f}"
+        lines.append(f"{score}  {r.collection}  {path}")
+    return "\n".join(lines)
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("query", _QUERIES)
+def test_search_ranking_snapshot(query: str, search_corpus: T3Database, snapshot) -> None:
+    """Search result ranking matches stored snapshot.
+
+    Catches regressions when scoring weights, normalization, or context
+    prefix logic changes. Update snapshots with: pytest --snapshot-update
+    """
+    raw = search_cross_corpus(
+        query,
+        ["code__snapshot", "knowledge__snapshot"],
+        n_results=5,
+        t3=search_corpus,
+    )
+    scored = apply_hybrid_scoring(raw, hybrid=True)
+    output = _format_results(scored)
+    assert output == snapshot
+
+
+@pytest.mark.parametrize("query", _QUERIES[:3])
+def test_search_single_corpus_snapshot(
+    query: str, search_corpus: T3Database, snapshot,
+) -> None:
+    """Single-corpus search ranking matches stored snapshot."""
+    raw = search_cross_corpus(
+        query,
+        ["code__snapshot"],
+        n_results=5,
+        t3=search_corpus,
+    )
+    scored = apply_hybrid_scoring(raw, hybrid=False)
+    output = _format_results(scored)
+    assert output == snapshot

--- a/uv.lock
+++ b/uv.lock
@@ -489,6 +489,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "syrupy" },
     { name = "twine" },
 ]
 
@@ -512,6 +513,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "syrupy", specifier = ">=4.0" },
     { name = "twine", specifier = ">=6.2.0" },
 ]
 
@@ -3933,6 +3935,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "syrupy"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/b0/24bca682d6a6337854be37f242d116cceeda9942571d5804c44bc1bdd427/syrupy-5.1.0.tar.gz", hash = "sha256:df543c7aa50d3cf1246e83d58fe490afe5f7dab7b41e74ecc0d8d23ae19bd4b8", size = 50495, upload-time = "2026-01-25T14:53:06.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/70/cf880c3b95a6034ef673e74b369941b42315c01f1554a5637a4f8b911009/syrupy-5.1.0-py3-none-any.whl", hash = "sha256:95162d2b05e61ed3e13f117b88dfab7c58bd6f90e66ebbf918e8a77114ad51c5", size = 51658, upload-time = "2026-01-25T14:53:05.105Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds syrupy snapshot tests that capture search result ordering
- 9 tests: 6 cross-corpus queries + 3 single-corpus queries
- Catches ranking regressions when scoring weights or normalization changes
- Uses EphemeralClient + ONNX MiniLM (no API keys needed)
- Adds `syrupy>=4.0` to dev dependencies

## Test plan
- [x] `uv run pytest tests/test_search_snapshot.py` — 9 passed
- [x] Snapshots stored in `tests/__snapshots__/test_search_snapshot.ambr`

References: nexus-dcnf