### PR TITLE
docs: audit docs, close stale RDRs, accept RDR-030

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Hybrid search score boosting** (RDR-026) — ripgrep exact-match results boost
+  vector search scores by `EXACT_MATCH_BOOST=0.15`. Pre-reranker capture of
+  `rg_file_paths` and `rg_matched_lines` metadata for downstream context windowing.
+  Ripgrep-only results (files not in vector top-K) kept with `RG_FLOOR_SCORE * 0.8`
+  penalty. Snapshot regression tests for search quality via syrupy.
+- **Context line windowing** (RDR-027 Phase 1) — `-A`/`-B`/`-C` flags now center
+  on matching lines within chunks (keyword match or rg_matched_lines) rather than
+  always showing from chunk start. `-C N` changed from after-only alias to
+  before+after (matching grep semantics). Bridge merging joins nearby matches
+  separated by ≤2 lines.
+- **Syntax highlighting** (RDR-027 Phase 2) — `--bat` flag pipes results through
+  `bat` with per-file batching, merged line ranges, and graceful fallback. Skipped
+  when `--no-color` or `NO_COLOR` is set.
+- **Compact mode** (RDR-027 Phase 3) — `--compact` flag outputs one line per result
+  in `path:line:text` format (grep-compatible).
+- **Query-aware vimgrep** — `--vimgrep` now reports the best-matching line within
+  the chunk when a query is provided, not always the first line.
+
 ## [1.8.0] - 2026-03-08
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ src/nexus/           # Core package
   db/                # t1.py, t2.py, t3.py — tier implementations
   indexer.py         # Repo indexing pipeline (classify → chunk → embed → store)
   classifier.py      # File classification: CODE / PROSE / PDF / SKIP
-  chunker.py         # Tree-sitter AST chunking (19 languages)
+  chunker.py         # Tree-sitter AST chunking (31 languages)
   md_chunker.py      # Semantic markdown splitter for prose
   pdf_extractor.py   # Docling-based PDF extraction
   pdf_chunker.py     # PDF → chunks

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Scratch and memory commands work with zero API keys. Cloud search requires [Chro
 
 1. Walks tracked files via `git ls-files` (respects `.gitignore`)
 2. Classifies each file by extension — code, prose, or PDF
-3. Chunks code with tree-sitter AST parsing (19 languages, 27 file types) and prose with semantic markdown splitting
+3. Chunks code with tree-sitter AST parsing (31 languages, 52 file types) and prose with semantic markdown splitting
 4. Embeds each chunk with a purpose-built Voyage AI model
 5. Routes results to separate collections: `code__<repo>`, `docs__<repo>`, and `rdr__<repo>` for RDR documents
 6. Computes git frecency scores so recently-touched files rank higher in hybrid search

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ CLI (cli.py + commands/)
     │     code: classify(SKIP|CODE|PROSE|PDF) → tree-sitter AST → context prefix → voyage-code-3 → code__<repo>
     │     prose: SemanticMarkdownChunker (md) or line-split → voyage-context-3 → docs__<repo>
     │     rdr:   SemanticMarkdownChunker → voyage-context-3 → rdr__<repo>
-    │     pdf:   PyMuPDF4LLM → voyage-context-3 → docs__<corpus>
+    │     pdf:   Docling (PyMuPDF fallback) → voyage-context-3 → docs__<corpus>
     │     skip:  .xml/.json/.yml/.html/.css/.lock/etc → silently ignored
     │
     ├── Search: query → retrieve → rerank → format

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,14 +22,17 @@ nx search "authentication middleware" --corpus code --hybrid --n 20
 | `--where KEY=VALUE` | Metadata filter (repeatable; multiple flags are ANDed) |
 | `--max-file-chunks N` | Exclude chunks from files larger than N chunks (code corpora only; ANDs with `--where`) |
 | `-m` / `--n` / `--max-results NUM` | Max results (default 10) |
-| `-A N` | Show N lines of context after each result chunk |
-| `-C N` | Show N lines of context after each result chunk (alias for `-A`) |
+| `-A N` | Show N lines of context after each matching line (within chunk) |
+| `-B N` | Show N lines of context before each matching line (within chunk) |
+| `-C N` | Show N lines before and after each match (equivalent to `-B N -A N`) |
 | `-c` / `--content` | Show matched text inline under each result (truncated at 200 chars) |
 | `-r` / `--reverse` | Reverse result order (highest-scoring last) |
-| `--vimgrep` | Output as `path:line:col:content` |
+| `--vimgrep` | Output as `path:line:col:content` (query-aware: reports best-matching line) |
 | `--json` | JSON array output |
 | `--files` | Unique file paths only |
-| `--no-color` | Disable colored output |
+| `--compact` | One line per result: `path:line:text` (grep-compatible) |
+| `--bat` | Syntax highlight with `bat` (ignored with `--json`/`--vimgrep`/`--files`) |
+| `--no-color` | Disable colored output (also skips `--bat`) |
 
 ---
 

--- a/docs/plans/2026-03-09-rdr-030-reliability-hardening-impl-plan.md
+++ b/docs/plans/2026-03-09-rdr-030-reliability-hardening-impl-plan.md
@@ -1,0 +1,406 @@
+# RDR-030 Reliability Hardening Implementation Plan
+
+**Epic**: nexus-56u1 (Implement RDR-030: Reliability Hardening)
+**RDR**: docs/rdr/rdr-030-reliability-hardening.md (status: accepted)
+**Branch**: feature/nexus-56u1-reliability-hardening
+**Created**: 2026-03-09
+
+## Executive Summary
+
+Implement the four-phase reliability hardening programme from RDR-030:
+1. Add structured logging to 14 silent catch-and-pass blocks across 8 modules
+2. Expand `nx doctor` with orphan T1 detection, T2 FTS5 integrity, and ChromaDB pagination audit
+3. Fix a confirmed correctness bug in `doc_indexer.py` stale-chunk pruning (unpaginated `col.get()`)
+4. Sweep the codebase to annotate all intentional silent catches with rationale comments
+
+Total scope: ~14 logging additions (1-2 lines each), 3 new `nx doctor` checks, 1 pagination bug fix, ~10-15 annotation comments. Low risk: all changes are additive (logging, diagnostics, comments) except the pagination fix which is a correctness improvement.
+
+## Dependency Graph
+
+```
+nexus-56u1 (Epic — tracker)
+  |
+  +-- nexus-4our  Phase 1 impl   -----> nexus-op38  Phase 1 tests
+  |
+  +-- nexus-n1bv  Phase 2 impl   -----> nexus-btid  Phase 2 tests
+  |
+  +-- nexus-eld3  Phase 2.5 tests -----> nexus-klxc  Phase 2.5 impl
+  |
+  +-- nexus-1hv5  Phase 3 sweep   (no test task — comments only)
+```
+
+**Parallelization**: Phases 1, 2, 2.5, and 3 are fully independent. Each can be assigned to a parallel agent. Within each phase, implementation blocks testing.
+
+**Critical path**: Phase 2.5 (pagination bug fix) is the highest priority (P1) and should be addressed first since it is a correctness defect with data-loss risk.
+
+## Phase 1: Silent Error Audit (14 locations)
+
+**Bead**: nexus-4our (impl) + nexus-op38 (tests)
+**Files modified**: indexer.py, session.py, hooks.py, commands/hook.py, commands/index.py, commands/doctor.py, md_chunker.py, classifier.py
+
+### Prerequisites
+
+Three modules lack a module-level `_log` binding and need one added before logging calls:
+
+| Module | Addition |
+|--------|----------|
+| `commands/hook.py` | `import structlog` + `_log = structlog.get_logger()` |
+| `commands/index.py` | `import structlog` + `_log = structlog.get_logger()` |
+| `classifier.py` | `import structlog` + `_log = structlog.get_logger()` |
+
+### Site-by-Site Changes
+
+| # | File:Line | Exception caught | Current behavior | Change | Log level |
+|---|-----------|-----------------|------------------|--------|-----------|
+| 1 | `indexer.py:264-267` | `(UnicodeDecodeError, AttributeError)` | `pass` | Add `_log.debug("extract_name_decode_failed", error=str(exc), exc_info=True)` | debug |
+| 2 | `indexer.py:270-273` | `(UnicodeDecodeError, AttributeError)` | `pass` | Add `_log.debug("extract_name_child_decode_failed", error=str(exc), exc_info=True)` | debug |
+| 3 | `indexer.py:298-302` | `Exception` | `return ("", "")` | Add `_log.warning("get_parser_failed", language=language, error=str(exc), exc_info=True)` before return | warning |
+| 4 | `indexer.py:304-307` | `Exception` | `return ("", "")` | Add `_log.debug("tree_parse_failed", language=language, error=str(exc))` before return | debug |
+| 5 | `indexer.py:398` | `(OSError, subprocess.TimeoutExpired)` | `return ""` | Add `_log.debug("current_head_failed", repo=str(repo), error=str(exc))` before return | debug |
+| 6 | `session.py:113-115` | `(OSError, ValueError)` | `pass` | Add `_log.debug("ppid_proc_read_failed", pid=pid, error=str(exc))` | debug |
+| 7 | `session.py:199` | `(json.JSONDecodeError, OSError)` | `pass` | Add `_log.debug("sweep_corrupt_session_file", path=str(f), error=str(exc))` | debug |
+| 8 | `hooks.py:55` | `Exception` | `return Path.cwd().name` | Add `_log.debug("infer_repo_git_failed", error=str(exc))` before return | debug |
+| 9 | `hooks.py:155` | `(json.JSONDecodeError, OSError)` | `pass` | Add `_log.debug("session_end_own_record_corrupt", path=str(own_file), error=str(exc))` | debug |
+| 10 | `commands/hook.py:24` | `Exception` | `pass` | Add `_log.debug("session_start_stdin_parse_failed", error=str(exc))` | debug |
+| 11 | `commands/index.py:138` | `Exception` | `pass` | Add `_log.debug("hook_detection_failed", error=str(exc))` | debug |
+| 12 | `commands/doctor.py:211` | `Exception` | `repos = []` | Add `_log.warning("doctor_registry_load_failed", error=str(exc))` | warning |
+| 13 | `md_chunker.py:73` | `yaml.YAMLError` | `data = {}` | Add `_log.warning("frontmatter_parse_failed", error=str(exc))` before `data = {}` | warning |
+| 14 | `classifier.py:46` | `OSError` | `return False` | Add `_log.debug("has_shebang_read_failed", path=str(path), error=str(exc))` before return | debug |
+
+### Implementation Pattern
+
+Each change follows the same pattern. Capture the exception into a variable and add one log line:
+
+```python
+# Before:
+except (UnicodeDecodeError, AttributeError):
+    pass
+
+# After:
+except (UnicodeDecodeError, AttributeError) as exc:
+    _log.debug("extract_name_decode_failed", error=str(exc), exc_info=True)
+```
+
+For sites that already have `as exc`, only the log line is added.
+
+### Success Criteria
+
+- [ ] All 14 sites emit a log at the documented level when the exception path is triggered
+- [ ] 3 modules have `_log = structlog.get_logger()` added
+- [ ] `grep -r 'except.*:\s*pass$' src/nexus/{indexer,session,hooks,commands/hook,commands/index,commands/doctor,md_chunker,classifier}.py` returns 0 matches (all bare passes replaced with logging)
+- [ ] All existing tests pass (`uv run pytest`)
+- [ ] Code compiles cleanly
+
+### Test Strategy (nexus-op38)
+
+**Test file**: `tests/test_silent_error_logging.py`
+
+Use `structlog.testing.capture_logs()` context manager for each site:
+
+```python
+import structlog
+from structlog.testing import capture_logs
+
+def test_indexer_get_parser_failure_logs_warning(monkeypatch):
+    """Site 3: indexer.py get_parser() failure emits warning."""
+    import nexus.indexer as mod
+    monkeypatch.setattr("nexus.indexer.get_parser", lambda lang: (_ for _ in ()).throw(RuntimeError("no parser")))
+    with capture_logs() as cap:
+        result = mod._extract_context(b"x = 1", "python", 0, 0)
+    assert result == ("", "")
+    assert any(e["event"] == "get_parser_failed" and e["log_level"] == "warning" for e in cap)
+```
+
+Each of the 14 sites gets a test following this pattern:
+1. Mock the failing dependency to trigger the exception path
+2. Call the function under test
+3. Assert the log event name and level appear in `capture_logs()` output
+4. Assert the function returns the expected fallback value
+
+## Phase 2: nx doctor Expansion
+
+**Bead**: nexus-n1bv (impl) + nexus-btid (tests)
+**File modified**: `src/nexus/commands/doctor.py`
+
+### Step 5: Orphan T1 Process Detection
+
+Scan `~/.config/nexus/sessions/` for `*.session` files whose `server_pid` does not correspond to a running process.
+
+```python
+# Pseudocode for doctor check
+from nexus.session import SESSIONS_DIR
+
+def _check_orphan_t1(lines: list[str]) -> bool:
+    """Check for orphaned T1 session files. Returns True if all clean."""
+    if not SESSIONS_DIR.exists():
+        lines.append(_check_line("T1 sessions", True, "no sessions directory"))
+        return True
+    orphans = []
+    for f in SESSIONS_DIR.glob("*.session"):
+        try:
+            record = json.loads(f.read_text())
+            if not isinstance(record, dict):
+                continue
+            pid = record.get("server_pid")
+            if pid:
+                try:
+                    os.kill(pid, 0)  # Check if alive
+                except OSError:
+                    orphans.append((f.name, pid))
+        except (json.JSONDecodeError, OSError):
+            orphans.append((f.name, None))
+    if orphans:
+        lines.append(_check_line("T1 sessions", False,
+                     f"{len(orphans)} orphaned session file(s)"))
+        return False
+    lines.append(_check_line("T1 sessions", True, "no orphans"))
+    return True
+```
+
+### Step 6: T2 Database Integrity Check
+
+Run SQLite `PRAGMA integrity_check` and FTS5 `integrity-check` on the T2 memory database.
+
+```python
+def _check_t2_integrity(lines: list[str]) -> bool:
+    """Verify T2 SQLite + FTS5 index integrity. Returns True if healthy."""
+    db_path = Path.home() / ".config" / "nexus" / "memory.db"
+    if not db_path.exists():
+        lines.append(_check_line("T2 database", True, "not created yet"))
+        return True
+    try:
+        conn = sqlite3.connect(str(db_path))
+        # SQLite integrity
+        result = conn.execute("PRAGMA integrity_check").fetchone()
+        sqlite_ok = result and result[0] == "ok"
+        # FTS5 integrity
+        try:
+            conn.execute("INSERT INTO memory_fts(memory_fts) VALUES('integrity-check')")
+            fts_ok = True
+        except sqlite3.OperationalError:
+            fts_ok = False
+        conn.close()
+        ok = sqlite_ok and fts_ok
+        detail = "ok" if ok else []
+        if not sqlite_ok:
+            detail.append("SQLite integrity check failed")
+        if not fts_ok:
+            detail.append("FTS5 index corrupt")
+        lines.append(_check_line("T2 database", ok,
+                     detail if isinstance(detail, str) else "; ".join(detail)))
+        return ok
+    except (sqlite3.Error, OSError) as exc:
+        lines.append(_check_line("T2 database", False, f"check failed: {exc}"))
+        return False
+```
+
+### Step 7: ChromaDB Pagination Audit
+
+Spot-check that `col.count()` matches the number of records retrievable via paginated `col.get()`. This catches any `col.get()` call site that silently truncates at 300.
+
+```python
+def _check_chroma_pagination(lines: list[str], client, db_name: str) -> bool:
+    """Spot-check one collection's count vs paginated get. Returns True if consistent."""
+    cols = client.list_collections()
+    if not cols:
+        return True
+    # Spot-check the first non-empty collection
+    for col in cols:
+        count = col.count()
+        if count == 0:
+            continue
+        # Paginated retrieval
+        retrieved = 0
+        offset = 0
+        while True:
+            batch = col.get(include=[], limit=300, offset=offset)
+            batch_ids = batch.get("ids", [])
+            retrieved += len(batch_ids)
+            if len(batch_ids) < 300:
+                break
+            offset += 300
+        if retrieved != count:
+            lines.append(_check_line(
+                f"pagination ({col.name})", False,
+                f"count={count} but get returned {retrieved}"))
+            return False
+        lines.append(_check_line(
+            f"pagination ({col.name})", True,
+            f"{count} records consistent"))
+        return True  # Spot-check one collection only
+    return True
+```
+
+### Success Criteria
+
+- [ ] `nx doctor` includes T1 orphan check, T2 integrity check, and ChromaDB pagination spot-check
+- [ ] Each check reports pass/fail status in the existing output format
+- [ ] Checks are gated behind credential/path availability (no crashes if unconfigured)
+- [ ] Fix suggestions provided for failures
+
+### Test Strategy (nexus-btid)
+
+**Test file**: `tests/test_doctor_integrity.py`
+
+- **Step 5**: Create tmp sessions dir with fake session files. Set `server_pid` to a non-existent PID. Verify doctor detects orphan.
+- **Step 6**: Create a T2 database, verify integrity check passes. Then corrupt the database (truncate file), verify check fails.
+- **Step 7**: Use `chromadb.EphemeralClient` with a test collection. Add records, verify pagination audit passes. (Cannot test truncation without a real Cloud client, but can verify the audit runs without error.)
+
+## Phase 2.5: ChromaDB Pagination Fix
+
+**Bead**: nexus-klxc (impl, P1 bug) + nexus-eld3 (tests)
+**File modified**: `src/nexus/doc_indexer.py`
+
+### Problem
+
+Line 233 of `doc_indexer.py`:
+```python
+all_existing = _chroma_with_retry(col.get, where={"source_path": str(file_path)}, include=[])
+```
+
+This call has no `limit=` parameter. ChromaDB Cloud returns at most 300 records per `get()` call. For documents that produce >300 chunks, stale chunks beyond the 300-record limit survive re-indexing and pollute search results.
+
+### Fix
+
+Replace the single `col.get()` call with a pagination loop matching the pattern already used in `db/t3.py` (e.g., `delete_by_source()`, `find_ids_by_title()`):
+
+```python
+# Paginated retrieval of all existing IDs for this source_path
+current_ids_set = set(ids)
+stale_ids: list[str] = []
+offset = 0
+while True:
+    batch = _chroma_with_retry(
+        col.get,
+        where={"source_path": str(file_path)},
+        include=[],
+        limit=300,
+        offset=offset,
+    )
+    batch_ids = batch.get("ids", [])
+    stale_ids.extend(eid for eid in batch_ids if eid not in current_ids_set)
+    if len(batch_ids) < 300:
+        break
+    offset += 300
+if stale_ids:
+    _chroma_with_retry(col.delete, ids=stale_ids)
+```
+
+### Success Criteria
+
+- [ ] `doc_indexer.py:_index_document()` stale-chunk pruning uses `limit=300` + offset pagination
+- [ ] Documents with >300 chunks have all stale chunks correctly pruned on re-index
+- [ ] Existing tests pass (no regression)
+
+### Test Strategy (nexus-eld3)
+
+**Test file**: `tests/test_doc_indexer_pagination.py`
+
+Use `chromadb.EphemeralClient` to simulate a collection with >300 chunks for a single source_path:
+
+1. Pre-populate collection with 350 fake chunks (IDs: `hash_0` through `hash_349`)
+2. Call `_index_document()` with a file that produces only 10 new chunks
+3. Verify that all 340 stale chunks (350 - 10) are deleted
+4. Verify that the 10 new chunks are present
+
+This requires mocking the embed function to avoid Voyage API calls.
+
+## Phase 3: Codebase Sweep
+
+**Bead**: nexus-1hv5 (chore, P3)
+**Files modified**: Multiple (annotation-only changes)
+
+### Process
+
+1. Run `grep -rn 'except.*:\s*$' src/nexus/ --include='*.py' -A2` to find all except blocks
+2. For each block without logging: add `# intentional: <reason>` comment
+3. Skip blocks that already have logging, re-raise, or were addressed in Phase 1
+
+### Known Intentional Silent Catches to Annotate
+
+| File:Line | Exception | Reason |
+|-----------|-----------|--------|
+| `session.py:60` | `ValueError` in `_stable_pid()` | Invalid NX_SESSION_PID env var — fall through to os.getsid(0) |
+| `session.py:302-303` | `ChildProcessError` in `stop_t1_server()` | Already commented: "not our child" |
+| `session.py:304-305` | `OSError` in `stop_t1_server()` | Process already gone after SIGKILL — expected |
+| `session.py:342-343` | `OSError` in `_try_remove_path()` | Best-effort file cleanup |
+| `hooks.py:196-197` | `OSError` in `session_end()` | Best-effort session file deletion |
+| `config.py:140-141` | `OSError` in atomic write cleanup | Cleanup after re-raise |
+| `registry.py:179-180` | `OSError` in atomic write cleanup | Cleanup after re-raise |
+| `scoring.py:187-188` | `StopIteration` in round-robin merge | Iterator exhaustion is normal |
+| `frecency.py:96-97` | `ValueError` in timestamp parse | Corrupt git log line — skip it |
+
+### Success Criteria
+
+- [ ] Every `except` block without logging has either: (a) logging added (Phase 1), or (b) `# intentional: <reason>` comment
+- [ ] No bare `pass` in exception handlers without explanation
+- [ ] All existing tests pass
+
+### Test Strategy
+
+No tests needed. This phase is purely annotation/documentation.
+
+## Execution Order
+
+### Recommended Sequence
+
+1. **Phase 2.5** (nexus-eld3 tests first, then nexus-klxc impl) — P1 bug fix, TDD, highest priority
+2. **Phase 1** (nexus-4our + nexus-op38) — Core reliability improvement
+3. **Phase 2** (nexus-n1bv + nexus-btid) — Diagnostic expansion
+4. **Phase 3** (nexus-1hv5) — Cleanup sweep
+
+### Parallelization Opportunities
+
+All four phases touch different code with minimal overlap:
+- **Phase 1**: indexer.py, session.py, hooks.py, commands/hook.py, commands/index.py, commands/doctor.py, md_chunker.py, classifier.py (logging additions only)
+- **Phase 2**: commands/doctor.py (new check functions)
+- **Phase 2.5**: doc_indexer.py (pagination fix)
+- **Phase 3**: Multiple files (comment annotations only)
+
+Phase 1 and Phase 2 both touch `commands/doctor.py`, but Phase 1 modifies line 211 (one log line) while Phase 2 adds new functions. Merge conflict risk is minimal.
+
+**Recommendation**: Spawn up to 3 parallel agents — one for Phases 1+3 (logging + annotations, same concern), one for Phase 2 (doctor expansion), one for Phase 2.5 (pagination fix).
+
+## Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| Adding logging to hot path degrades performance | Very low | Low | structlog short-circuits inactive levels; RDR confirms negligible overhead |
+| nx doctor ChromaDB pagination audit slow for large collections | Low | Low | Spot-check only one collection; gate behind credential availability |
+| Pagination fix changes stale-chunk pruning behavior | Low | Medium | Well-tested via EphemeralClient; fix is strictly more correct than current behavior |
+| Phase 3 annotations create noisy diff | Very low | Very low | Comments are non-functional; can be merged independently |
+
+## Bead Summary
+
+| ID | Title | Type | Priority | Depends on |
+|----|-------|------|----------|-----------|
+| nexus-56u1 | Implement RDR-030: Reliability Hardening | feature | P2 | (tracker) |
+| nexus-4our | Phase 1: Add structlog to 14 silent catch-and-pass blocks | task | P2 | none |
+| nexus-op38 | Phase 1 Tests: capture_logs verification | task | P2 | nexus-4our |
+| nexus-n1bv | Phase 2: nx doctor Steps 5-7 | task | P2 | none |
+| nexus-btid | Phase 2 Tests: nx doctor expansion | task | P2 | nexus-n1bv |
+| nexus-eld3 | Phase 2.5 Tests: pagination fix verification (TDD) | task | P1 | none |
+| nexus-klxc | Phase 2.5: Fix doc_indexer.py pagination bug | bug | P1 | nexus-eld3 |
+| nexus-1hv5 | Phase 3: Codebase sweep annotations | chore | P3 | none |
+
+## Context for Executing Agents
+
+### Knowledge Base Search Terms
+- `structlog capture_logs testing` — for test patterns
+- `chromadb pagination limit offset` — for pagination fix
+- `nx doctor health check` — for existing doctor patterns
+- `silent error logging policy` — for RDR-030 context
+
+### Key References
+- RDR: `docs/rdr/rdr-030-reliability-hardening.md`
+- Existing pagination patterns: `src/nexus/db/t3.py` (search for `limit=300`)
+- Existing doctor checks: `src/nexus/commands/doctor.py`
+- Session management: `src/nexus/session.py`
+- T2 schema: `src/nexus/db/t2.py` (FTS5 triggers and schema)
+
+### Reminders for Executing Agents
+- Use `mcp__sequential-thinking__sequentialthinking` for complex analysis
+- Write tests FIRST (TDD) — Phase 2.5 and Phase 2 require tests before impl; Phase 1 logging additions are trivial enough for impl-first
+- Ensure code compiles including all tests before marking complete
+- Update continuation state after each significant milestone
+- Sub-agents may spawn children for intensive work

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -15,8 +15,8 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 
 | ID | Title | Type | Status | Created |
 | -- | ----- | ---- | ------ | ------- |
-| [RDR-001](rdr-001-rdr-process-validation.md) | RDR Process Validation | Architecture | Implemented | 2026-02-27 |
-| [RDR-002](rdr-002-t2-status-synchronization.md) | T2 Status Synchronization | Technical Debt | Implemented | 2026-02-27 |
+| [RDR-001](rdr-001-rdr-process-validation.md) | RDR Process Validation | Architecture | Closed | 2026-02-27 |
+| [RDR-002](rdr-002-t2-status-synchronization.md) | T2 Status Synchronization | Technical Debt | Closed | 2026-02-27 |
 | [RDR-004](rdr-004-four-store-architecture.md) | Four-Store T3 Architecture | Architecture | Closed | 2026-02-28 |
 | [RDR-005](rdr-005-chromadb-cloud-quota-enforcement.md) | ChromaDB Cloud Quota Enforcement | Architecture | Closed | 2026-02-28 |
 | [RDR-006](rdr-006-chunk-size-configuration.md) | File-Size Scoring Penalty for Code Search | Feature | Closed | 2026-02-28 |
@@ -30,11 +30,11 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-014](rdr-014-knowledge-base-retrieval-quality.md) | Knowledge Base Retrieval Quality: Code Context and Docs Deduplication | Bug | Closed | 2026-03-02 |
 | [RDR-015](rdr-015-indexing-pipeline-rethink.md) | Indexing Pipeline Rethink: Align Nexus with Arcaneum's Battle-Tested Implementation | Enhancement | Closed | 2026-03-02 |
 | [RDR-016](rdr-016-ast-chunk-line-range-bug.md) | AST Chunk Line Range Bug: CodeSplitter Returns Empty Metadata, Breaking Context Prefix | Bug | Closed | 2026-03-03 |
-| [RDR-017](rdr-017-indexing-progress-reporting.md) | Indexing Progress Reporting: tqdm-Based Progress Bar for nx index | Enhancement | Implemented | 2026-03-03 |
-| [RDR-018](rdr-018-replace-serve-with-git-hooks.md) | Replace nx serve Polling Server with Git Hooks | Refactor | Implemented | 2026-03-03 |
+| [RDR-017](rdr-017-indexing-progress-reporting.md) | Indexing Progress Reporting: tqdm-Based Progress Bar for nx index | Enhancement | Closed | 2026-03-03 |
+| [RDR-018](rdr-018-replace-serve-with-git-hooks.md) | Replace nx serve Polling Server with Git Hooks | Refactor | Closed | 2026-03-03 |
 | [RDR-019](rdr-019-chromadb-transient-retry.md) | ChromaDB Transient HTTP Error Retry | Bug Fix | Closed | 2026-03-04 |
 | [RDR-020](rdr-020-voyage-chromadb-read-timeout.md) | Voyage AI and ChromaDB Client Read Timeouts | Bug Fix | Closed | 2026-03-05 |
-| [RDR-021](rdr-021-docling-pdf-extraction.md) | Replace 3-Tier PDF Extraction Stack with Docling | Enhancement | Accepted | 2026-03-05 |
+| [RDR-021](rdr-021-docling-pdf-extraction.md) | Replace 3-Tier PDF Extraction Stack with Docling | Enhancement | Closed | 2026-03-05 |
 | [RDR-022](rdr-022-memory-delete-command.md) | Add delete subcommand to nx memory, nx store, nx scratch | Enhancement | Closed | 2026-03-05 |
 | [RDR-023](rdr-023-agent-tool-permissions-audit.md) | Agent Tool Permissions Audit and Remediation | Enhancement | Closed | 2026-03-07 |
 | [RDR-024](rdr-024-rdr-process-guardrails.md) | RDR Process Guardrails: Prevent Implementation Before Gate/Accept | Enhancement | Closed | 2026-03-07 |
@@ -43,7 +43,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-027](rdr-027-search-results-ux.md) | Search Results UX — Context Lines and Syntax Highlighting | Feature | Closed | 2026-03-08 |
 | [RDR-028](rdr-028-code-search-recall.md) | Code Search Recall — Language Registry Unification | Enhancement | Closed | 2026-03-08 |
 | [RDR-029](rdr-029-pipeline-versioning.md) | Pipeline Versioning — Force Reindex and Collection Version Stamping | Enhancement | Closed | 2026-03-08 |
-| [RDR-030](rdr-030-reliability-hardening.md) | Reliability Hardening — Silent Error Audit and Logging Policy | Enhancement | Draft | 2026-03-08 |
+| [RDR-030](rdr-030-reliability-hardening.md) | Reliability Hardening — Silent Error Audit and Logging Policy | Enhancement | Accepted | 2026-03-08 |
 | [RDR-031](rdr-031-collection-portability.md) | Collection Portability — Export/Import for T3 Backup and Migration | Feature | Draft | 2026-03-08 |
 | [RDR-032](rdr-032-indexer-decomposition.md) | Indexer Module Decomposition and Configuration Externalization | Technical Debt | Draft | 2026-03-08 |
 | [RDR-033](rdr-033-pdf-agent-nx-index-alignment.md) | PDF Processing Agent Should Delegate to nx index pdf | Architecture | Closed | 2026-03-08 |

--- a/docs/rdr/rdr-001-rdr-process-validation.md
+++ b/docs/rdr/rdr-001-rdr-process-validation.md
@@ -2,7 +2,7 @@
 title: "RDR Process Validation"
 id: RDR-001
 type: architecture
-status: implemented
+status: closed
 priority: high
 author: Hal Hildebrand
 reviewed-by: self

--- a/docs/rdr/rdr-002-t2-status-synchronization.md
+++ b/docs/rdr/rdr-002-t2-status-synchronization.md
@@ -2,7 +2,7 @@
 title: "T2 Status Synchronization"
 id: RDR-002
 type: Technical Debt
-status: implemented
+status: closed
 priority: high
 author: Hal Hildebrand
 reviewed-by: self

--- a/docs/rdr/rdr-017-indexing-progress-reporting.md
+++ b/docs/rdr/rdr-017-indexing-progress-reporting.md
@@ -1,7 +1,7 @@
 ---
 title: "Indexing Progress Reporting: tqdm-Based Progress Bar for nx index"
 type: enhancement
-status: implemented
+status: closed
 priority: P2
 author: Hal Hildebrand
 date: 2026-03-03

--- a/docs/rdr/rdr-018-replace-serve-with-git-hooks.md
+++ b/docs/rdr/rdr-018-replace-serve-with-git-hooks.md
@@ -1,7 +1,7 @@
 ---
 title: "Replace nx serve Polling Server with Git Hooks"
 type: refactor
-status: implemented
+status: closed
 priority: P2
 author: Hal Hildebrand
 date: 2026-03-03

--- a/docs/rdr/rdr-021-docling-pdf-extraction.md
+++ b/docs/rdr/rdr-021-docling-pdf-extraction.md
@@ -2,8 +2,10 @@
 id: RDR-021
 title: "Replace 3-Tier PDF Extraction Stack with Docling"
 type: enhancement
-status: accepted
+status: closed
 accepted_date: 2026-03-05
+close_date: 2026-03-09
+close_reason: implemented
 reviewed-by: self
 priority: P2
 created: 2026-03-05

--- a/docs/rdr/rdr-030-reliability-hardening.md
+++ b/docs/rdr/rdr-030-reliability-hardening.md
@@ -2,7 +2,8 @@
 title: "Reliability Hardening — Silent Error Audit and Logging Policy"
 id: RDR-030
 type: Enhancement
-status: draft
+status: accepted
+accepted_date: 2026-03-09
 priority: P2
 author: Hal Hildebrand
 reviewed-by: self
@@ -22,8 +23,8 @@ This pattern makes debugging extremely difficult — the system silently falls b
 
 ## Context
 
-- `structlog` is already the logging framework (used throughout the codebase)
-- `nx doctor` exists but only checks configuration and connectivity, not data integrity
+- `structlog` is already the logging framework (used throughout the codebase); three modules (`commands/hook.py`, `commands/index.py`, `classifier.py`) lack a module-level `_log` binding and will need one added
+- `nx doctor` checks configuration, connectivity, and pipeline versioning (RDR-029), but not T1 process orphans, T2 FTS5 integrity, or ChromaDB pagination counts
 - RDR-019 and RDR-020 established retry patterns for external APIs, but internal error handling remains inconsistent
 
 ## Research Findings
@@ -57,9 +58,25 @@ This pattern makes debugging extremely difficult — the system silently falls b
 | nexus-738 | Formatters always emitted `:0:` line numbers — wrong output |
 | nexus-zmu | Pre-heading markdown content silently dropped |
 
-### F3: ChromaDB 300-Record Pagination (Verified — production discovery)
+### F3: ChromaDB 300-Record Pagination (Verified — production discovery + 2026-03-09 audit)
 
-ChromaDB Cloud's `get()` returns at most 300 entries per call. Code that calls `col.get()` without pagination silently misses data. Known fixed locations: `delete_by_source()`, `nx store delete --title`. Other call sites may still be vulnerable.
+ChromaDB Cloud's `get()` returns at most 300 entries per call. Code that calls `col.get()` without pagination silently misses data. Known fixed locations: `delete_by_source()`, `nx store delete --title`. Full audit (2026-03-09):
+- **Correctly paginated**: `expire()`, `delete_by_source()`, `find_ids_by_title()` — all use `limit=300` + offset loop
+- **Safe (exact/capped)**: `get_by_id()`, `delete_by_id()` (exact ID), staleness check (`limit=1`)
+- **Display truncation**: `list_store()` caps at `min(limit, 300)`, default 200 — UX, not correctness
+- **BUG: `doc_indexer.py:233`** — stale-chunk pruning `col.get(where={"source_path": ...})` has no `limit=`/pagination. For documents >300 chunks, orphan stale chunks survive re-indexing and pollute search results.
+
+### F4: New Silent Catch Sites (Verified — 2026-03-09 source scan)
+
+Three additional sites not in the original F1 audit:
+
+| Location | What's swallowed | Impact | Recommended level |
+|----------|-----------------|--------|--------------------|
+| `indexer.py:398` | `(OSError, subprocess.TimeoutExpired)` in `_current_head()` | Returns `""`, causing unnecessary full re-index next run | `debug` |
+| `md_chunker.py:73` | `yaml.YAMLError` in frontmatter parse | Metadata (title, author, date) silently lost — indexed without attribution | `warning` |
+| `classifier.py:46` | `OSError` in `_has_shebang()` | File classified as no-shebang when it can't be read | `debug` |
+
+**Total actionable silent-error sites: 14** (11 F1 + 3 F4).
 
 ## Proposed Solution
 
@@ -83,19 +100,19 @@ Any unimplemented code path must `raise NotImplementedError("...")` rather than 
 
 ## Implementation Plan
 
-### Phase 1: Silent Error Audit (11 locations)
-1. Add `_log.debug` (or `_log.warning` where degradation is user-visible) to all 11 identified catch-and-pass blocks
+### Phase 1: Silent Error Audit (14 locations)
+1. Add `_log.debug` (or `_log.warning` where degradation is user-visible) to all 14 identified catch-and-pass blocks (11 F1 + 3 F4)
 2. Review each for appropriate recovery behavior
-3. Add warning-level logs for fallback paths (session.py EphemeralClient fallback)
+3. Add warning-level logs for fallback paths (session.py EphemeralClient fallback, md_chunker frontmatter loss)
 
 ### Phase 2: nx doctor Expansion
-4. Add collection pipeline_version check
-5. Add orphan T1 process detection
+4. ~~Add collection pipeline_version check~~ — already implemented (RDR-029, `doctor.py:134-170`)
+5. Add orphan T1 process detection — scan `~/.config/nexus/sessions/` for records whose `server_pid` is not a live process; report count of orphaned records
 6. Add T2 database integrity check
 7. Add ChromaDB pagination audit (spot-check record counts)
 
-### Phase 2.5: ChromaDB Pagination Audit
-8. Audit all `col.get()` call sites in `db/t3.py` and `doc_indexer.py` for missing `limit=` / pagination loop; fix any found.
+### Phase 2.5: ChromaDB Pagination Fix (scope extension — discovered during audit)
+8. Fix `doc_indexer.py:233` stale-chunk pruning — add `limit=300` + offset pagination loop (only confirmed unpaginated site with real data-loss risk). Audit verified all other `col.get()` call sites in `db/t3.py` are already paginated or use exact-ID lookups. This is a correctness fix, not a logging change, but is included here because the audit that discovered it is integral to this RDR's research phase.
 
 ### Phase 3: Codebase Sweep
 9. grep for `except.*pass` and `except.*return` patterns
@@ -115,7 +132,7 @@ Any unimplemented code path must `raise NotImplementedError("...")` rather than 
 No contradictions found between the three proposed policies. Policy 1 (minimum logging) and Policy 2 (warn on degradation) are complementary: Policy 1 sets the floor (`debug`), Policy 2 raises it to `warning` for user-visible fallbacks. Policy 4 (stub code must raise) applies to unimplemented paths, not to the same catch blocks that Policies 1-2 cover — they target different code. The `nx doctor` expansion (Policy 3) is additive and does not conflict with logging changes.
 
 ### Assumption Verification
-- **Assumption: structlog is universally available.** Verified: `structlog` is a hard dependency in `pyproject.toml` and `_log = structlog.get_logger()` exists in all affected modules (`indexer.py`, `session.py`, `hooks.py`).
+- **Assumption: structlog is universally available.** Verified: `structlog` is a hard dependency in `pyproject.toml` and `_log = structlog.get_logger()` exists in most affected modules (`indexer.py`, `session.py`, `hooks.py`, `doctor.py`, `md_chunker.py`). Three modules (`commands/hook.py`, `commands/index.py`, `classifier.py`) lack a module-level `_log` binding — these need 2 lines per site (binding + log call) instead of 1.
 - **Assumption: All 11 silent catch sites are reachable.** Verified by source inspection. Each corresponds to a real try/except block in current `main`. The two `indexer.py:264-273` sites and `session.py:113-115` were initially missed but confirmed present.
 - **Assumption: P0 bug list is accurate.** Bead IDs are cited; the specific count "8 of 22" was softened to "8 known P0 bugs" since the total denominator is not independently verifiable from the current bead store.
 
@@ -129,6 +146,11 @@ This RDR is scoped to (a) cataloguing silent catches, (b) establishing logging p
 
 ### Proportionality
 The effort is modest — each silent catch site needs 1-2 lines of logging added. The `nx doctor` expansion (Phase 2) is the largest component but builds on existing infrastructure. The historical cost of silent failures (8 P0 bugs requiring multi-hour debugging each) far exceeds the implementation cost. Risk is low: adding logging cannot break existing behavior, and `nx doctor` checks are purely diagnostic.
+
+## Revision History
+
+- **2026-03-09 (Research)**: Codebase audit verified all 11 F1 sites still-silent, found 3 new sites (F4), confirmed 1 pagination bug (`doc_indexer.py:233`). Total actionable: 14 silent-error sites + 1 pagination fix.
+- **2026-03-09 (Gate — PASSED)**: 0 critical, 3 significant (all addressed): (1) Context falsely claimed nx doctor has no integrity checks — corrected (pipeline_version check exists from RDR-029, Step 4 struck), (2) 3 modules lack `_log` binding — documented in assumptions, (3) Phase 2.5 pagination fix is a correctness change, not logging — justified as audit discovery. 3 observations noted.
 
 ## References
 

--- a/docs/repo-indexing.md
+++ b/docs/repo-indexing.md
@@ -58,7 +58,7 @@ separate `rdr__<name>-<hash8>` collection via the batch markdown indexer.
 Code files are chunked via tree-sitter AST parsing using `llama-index` `CodeSplitter` and
 `tree-sitter-language-pack`.
 
-**AST-supported languages** (28 extension mappings, 19 parsers after Fix B):
+**AST-supported languages** (44 extension mappings, 31 parsers):
 
 | Extensions | Parser |
 |---|---|
@@ -81,6 +81,20 @@ Code files are chunked via tree-sitter AST parsing using `llama-index` `CodeSpli
 | `.php` | php |
 | `.r` | r |
 | `.lua` | lua |
+| `.proto` | proto |
+| `.ex`, `.exs` | elixir |
+| `.erl`, `.hrl` | erlang |
+| `.hs` | haskell |
+| `.clj`, `.cljs`, `.cljc` | clojure |
+| `.ml` | ocaml |
+| `.mli` | ocaml\_interface |
+| `.el` | elisp |
+| `.dart` | dart |
+| `.zig` | zig |
+| `.jl` | julia |
+| `.pl`, `.pm` | perl |
+
+Additionally, 8 GPU shader extensions (`.cl`, `.comp`, `.frag`, `.vert`, `.metal`, `.glsl`, `.wgsl`, `.hlsl`) are classified as CODE with line-based chunking (no AST parser).
 
 When AST parsing fails or no parser exists for the extension, the chunker falls back to
 line-based splitting: 150-line chunks with 15% overlap.
@@ -96,8 +110,9 @@ the file, class, method, and line range. The raw chunk text is stored in ChromaD
 <original chunk text>
 ```
 
-Class and method names are extracted by tree-sitter using `DEFINITION_TYPES` covering 14
-languages (Python, Java, Go, TypeScript, Rust, C, C++, C#, Ruby, PHP, Swift, Kotlin, Scala).
+Class and method names are extracted by tree-sitter using `DEFINITION_TYPES` covering 23
+languages (Python, JavaScript, TypeScript, TSX, Java, Go, Rust, C, C++, C#, Ruby, PHP,
+Swift, Kotlin, Scala, R, Lua, Dart, Haskell, Julia, OCaml, Perl, Erlang).
 For a chunk spanning multiple methods, the method field is empty. For unsupported languages
 or when parsing fails, the prefix falls back to `File + Lines` only.
 


### PR DESCRIPTION
## Summary

- Documentation audit across 8 files to reflect RDR-026/027/028/029 changes (language counts, CLI flags, PDF extractor, CHANGELOG)
- Close 5 stale RDRs (001, 002, 017, 018, 021) that were implemented but never formally closed
- Accept RDR-030 (Reliability Hardening) after research, gate (PASSED), and acceptance
- Create RDR-030 implementation plan with 7 beads across 4 phases, with plan audit fixes applied

## Test plan

- [ ] All docs render correctly on GitHub
- [ ] RDR README index reflects correct statuses
- [ ] Implementation plan bead dependencies match `bd show` output
- [ ] No broken links in documentation