### PR TITLE
feat(reliability): implement RDR-030 silent error audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Hybrid search score boosting** (RDR-026) — ripgrep exact-match results boost
+  vector search scores by `EXACT_MATCH_BOOST=0.15`. Pre-reranker capture of
+  `rg_file_paths` and `rg_matched_lines` metadata for downstream context windowing.
+  Ripgrep-only results (files not in vector top-K) kept with `RG_FLOOR_SCORE * 0.8`
+  penalty. Snapshot regression tests for search quality via syrupy.
+- **Context line windowing** (RDR-027 Phase 1) — `-A`/`-B`/`-C` flags now center
+  on matching lines within chunks (keyword match or rg_matched_lines) rather than
+  always showing from chunk start. `-C N` changed from after-only alias to
+  before+after (matching grep semantics). Bridge merging joins nearby matches
+  separated by ≤2 lines.
+- **Syntax highlighting** (RDR-027 Phase 2) — `--bat` flag pipes results through
+  `bat` with per-file batching, merged line ranges, and graceful fallback. Skipped
+  when `--no-color` or `NO_COLOR` is set.
+- **Compact mode** (RDR-027 Phase 3) — `--compact` flag outputs one line per result
+  in `path:line:text` format (grep-compatible).
+- **Query-aware vimgrep** — `--vimgrep` now reports the best-matching line within
+  the chunk when a query is provided, not always the first line.
+
 ## [1.8.0] - 2026-03-08
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ src/nexus/           # Core package
   db/                # t1.py, t2.py, t3.py — tier implementations
   indexer.py         # Repo indexing pipeline (classify → chunk → embed → store)
   classifier.py      # File classification: CODE / PROSE / PDF / SKIP
-  chunker.py         # Tree-sitter AST chunking (19 languages)
+  chunker.py         # Tree-sitter AST chunking (31 languages)
   md_chunker.py      # Semantic markdown splitter for prose
   pdf_extractor.py   # Docling-based PDF extraction
   pdf_chunker.py     # PDF → chunks

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Scratch and memory commands work with zero API keys. Cloud search requires [Chro
 
 1. Walks tracked files via `git ls-files` (respects `.gitignore`)
 2. Classifies each file by extension — code, prose, or PDF
-3. Chunks code with tree-sitter AST parsing (19 languages, 27 file types) and prose with semantic markdown splitting
+3. Chunks code with tree-sitter AST parsing (31 languages, 52 file types) and prose with semantic markdown splitting
 4. Embeds each chunk with a purpose-built Voyage AI model
 5. Routes results to separate collections: `code__<repo>`, `docs__<repo>`, and `rdr__<repo>` for RDR documents
 6. Computes git frecency scores so recently-touched files rank higher in hybrid search

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ CLI (cli.py + commands/)
     │     code: classify(SKIP|CODE|PROSE|PDF) → tree-sitter AST → context prefix → voyage-code-3 → code__<repo>
     │     prose: SemanticMarkdownChunker (md) or line-split → voyage-context-3 → docs__<repo>
     │     rdr:   SemanticMarkdownChunker → voyage-context-3 → rdr__<repo>
-    │     pdf:   PyMuPDF4LLM → voyage-context-3 → docs__<corpus>
+    │     pdf:   Docling (PyMuPDF fallback) → voyage-context-3 → docs__<corpus>
     │     skip:  .xml/.json/.yml/.html/.css/.lock/etc → silently ignored
     │
     ├── Search: query → retrieve → rerank → format

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -22,14 +22,17 @@ nx search "authentication middleware" --corpus code --hybrid --n 20
 | `--where KEY=VALUE` | Metadata filter (repeatable; multiple flags are ANDed) |
 | `--max-file-chunks N` | Exclude chunks from files larger than N chunks (code corpora only; ANDs with `--where`) |
 | `-m` / `--n` / `--max-results NUM` | Max results (default 10) |
-| `-A N` | Show N lines of context after each result chunk |
-| `-C N` | Show N lines of context after each result chunk (alias for `-A`) |
+| `-A N` | Show N lines of context after each matching line (within chunk) |
+| `-B N` | Show N lines of context before each matching line (within chunk) |
+| `-C N` | Show N lines before and after each match (equivalent to `-B N -A N`) |
 | `-c` / `--content` | Show matched text inline under each result (truncated at 200 chars) |
 | `-r` / `--reverse` | Reverse result order (highest-scoring last) |
-| `--vimgrep` | Output as `path:line:col:content` |
+| `--vimgrep` | Output as `path:line:col:content` (query-aware: reports best-matching line) |
 | `--json` | JSON array output |
 | `--files` | Unique file paths only |
-| `--no-color` | Disable colored output |
+| `--compact` | One line per result: `path:line:text` (grep-compatible) |
+| `--bat` | Syntax highlight with `bat` (ignored with `--json`/`--vimgrep`/`--files`) |
+| `--no-color` | Disable colored output (also skips `--bat`) |
 
 ---
 

--- a/docs/plans/2026-03-09-rdr-030-reliability-hardening-impl-plan.md
+++ b/docs/plans/2026-03-09-rdr-030-reliability-hardening-impl-plan.md
@@ -1,0 +1,406 @@
+# RDR-030 Reliability Hardening Implementation Plan
+
+**Epic**: nexus-56u1 (Implement RDR-030: Reliability Hardening)
+**RDR**: docs/rdr/rdr-030-reliability-hardening.md (status: accepted)
+**Branch**: feature/nexus-56u1-reliability-hardening
+**Created**: 2026-03-09
+
+## Executive Summary
+
+Implement the four-phase reliability hardening programme from RDR-030:
+1. Add structured logging to 14 silent catch-and-pass blocks across 8 modules
+2. Expand `nx doctor` with orphan T1 detection, T2 FTS5 integrity, and ChromaDB pagination audit
+3. Fix a confirmed correctness bug in `doc_indexer.py` stale-chunk pruning (unpaginated `col.get()`)
+4. Sweep the codebase to annotate all intentional silent catches with rationale comments
+
+Total scope: ~14 logging additions (1-2 lines each), 3 new `nx doctor` checks, 1 pagination bug fix, ~10-15 annotation comments. Low risk: all changes are additive (logging, diagnostics, comments) except the pagination fix which is a correctness improvement.
+
+## Dependency Graph
+
+```
+nexus-56u1 (Epic — tracker)
+  |
+  +-- nexus-4our  Phase 1 impl   -----> nexus-op38  Phase 1 tests
+  |
+  +-- nexus-n1bv  Phase 2 impl   -----> nexus-btid  Phase 2 tests
+  |
+  +-- nexus-eld3  Phase 2.5 tests -----> nexus-klxc  Phase 2.5 impl
+  |
+  +-- nexus-1hv5  Phase 3 sweep   (no test task — comments only)
+```
+
+**Parallelization**: Phases 1, 2, 2.5, and 3 are fully independent. Each can be assigned to a parallel agent. Within each phase, implementation blocks testing.
+
+**Critical path**: Phase 2.5 (pagination bug fix) is the highest priority (P1) and should be addressed first since it is a correctness defect with data-loss risk.
+
+## Phase 1: Silent Error Audit (14 locations)
+
+**Bead**: nexus-4our (impl) + nexus-op38 (tests)
+**Files modified**: indexer.py, session.py, hooks.py, commands/hook.py, commands/index.py, commands/doctor.py, md_chunker.py, classifier.py
+
+### Prerequisites
+
+Three modules lack a module-level `_log` binding and need one added before logging calls:
+
+| Module | Addition |
+|--------|----------|
+| `commands/hook.py` | `import structlog` + `_log = structlog.get_logger()` |
+| `commands/index.py` | `import structlog` + `_log = structlog.get_logger()` |
+| `classifier.py` | `import structlog` + `_log = structlog.get_logger()` |
+
+### Site-by-Site Changes
+
+| # | File:Line | Exception caught | Current behavior | Change | Log level |
+|---|-----------|-----------------|------------------|--------|-----------|
+| 1 | `indexer.py:264-267` | `(UnicodeDecodeError, AttributeError)` | `pass` | Add `_log.debug("extract_name_decode_failed", error=str(exc), exc_info=True)` | debug |
+| 2 | `indexer.py:270-273` | `(UnicodeDecodeError, AttributeError)` | `pass` | Add `_log.debug("extract_name_child_decode_failed", error=str(exc), exc_info=True)` | debug |
+| 3 | `indexer.py:298-302` | `Exception` | `return ("", "")` | Add `_log.warning("get_parser_failed", language=language, error=str(exc), exc_info=True)` before return | warning |
+| 4 | `indexer.py:304-307` | `Exception` | `return ("", "")` | Add `_log.debug("tree_parse_failed", language=language, error=str(exc))` before return | debug |
+| 5 | `indexer.py:398` | `(OSError, subprocess.TimeoutExpired)` | `return ""` | Add `_log.debug("current_head_failed", repo=str(repo), error=str(exc))` before return | debug |
+| 6 | `session.py:113-115` | `(OSError, ValueError)` | `pass` | Add `_log.debug("ppid_proc_read_failed", pid=pid, error=str(exc))` | debug |
+| 7 | `session.py:199` | `(json.JSONDecodeError, OSError)` | `pass` | Add `_log.debug("sweep_corrupt_session_file", path=str(f), error=str(exc))` | debug |
+| 8 | `hooks.py:55` | `Exception` | `return Path.cwd().name` | Add `_log.debug("infer_repo_git_failed", error=str(exc))` before return | debug |
+| 9 | `hooks.py:155` | `(json.JSONDecodeError, OSError)` | `pass` | Add `_log.debug("session_end_own_record_corrupt", path=str(own_file), error=str(exc))` | debug |
+| 10 | `commands/hook.py:24` | `Exception` | `pass` | Add `_log.debug("session_start_stdin_parse_failed", error=str(exc))` | debug |
+| 11 | `commands/index.py:138` | `Exception` | `pass` | Add `_log.debug("hook_detection_failed", error=str(exc))` | debug |
+| 12 | `commands/doctor.py:211` | `Exception` | `repos = []` | Add `_log.warning("doctor_registry_load_failed", error=str(exc))` | warning |
+| 13 | `md_chunker.py:73` | `yaml.YAMLError` | `data = {}` | Add `_log.warning("frontmatter_parse_failed", error=str(exc))` before `data = {}` | warning |
+| 14 | `classifier.py:46` | `OSError` | `return False` | Add `_log.debug("has_shebang_read_failed", path=str(path), error=str(exc))` before return | debug |
+
+### Implementation Pattern
+
+Each change follows the same pattern. Capture the exception into a variable and add one log line:
+
+```python
+# Before:
+except (UnicodeDecodeError, AttributeError):
+    pass
+
+# After:
+except (UnicodeDecodeError, AttributeError) as exc:
+    _log.debug("extract_name_decode_failed", error=str(exc), exc_info=True)
+```
+
+For sites that already have `as exc`, only the log line is added.
+
+### Success Criteria
+
+- [ ] All 14 sites emit a log at the documented level when the exception path is triggered
+- [ ] 3 modules have `_log = structlog.get_logger()` added
+- [ ] `grep -r 'except.*:\s*pass$' src/nexus/{indexer,session,hooks,commands/hook,commands/index,commands/doctor,md_chunker,classifier}.py` returns 0 matches (all bare passes replaced with logging)
+- [ ] All existing tests pass (`uv run pytest`)
+- [ ] Code compiles cleanly
+
+### Test Strategy (nexus-op38)
+
+**Test file**: `tests/test_silent_error_logging.py`
+
+Use `structlog.testing.capture_logs()` context manager for each site:
+
+```python
+import structlog
+from structlog.testing import capture_logs
+
+def test_indexer_get_parser_failure_logs_warning(monkeypatch):
+    """Site 3: indexer.py get_parser() failure emits warning."""
+    import nexus.indexer as mod
+    monkeypatch.setattr("nexus.indexer.get_parser", lambda lang: (_ for _ in ()).throw(RuntimeError("no parser")))
+    with capture_logs() as cap:
+        result = mod._extract_context(b"x = 1", "python", 0, 0)
+    assert result == ("", "")
+    assert any(e["event"] == "get_parser_failed" and e["log_level"] == "warning" for e in cap)
+```
+
+Each of the 14 sites gets a test following this pattern:
+1. Mock the failing dependency to trigger the exception path
+2. Call the function under test
+3. Assert the log event name and level appear in `capture_logs()` output
+4. Assert the function returns the expected fallback value
+
+## Phase 2: nx doctor Expansion
+
+**Bead**: nexus-n1bv (impl) + nexus-btid (tests)
+**File modified**: `src/nexus/commands/doctor.py`
+
+### Step 5: Orphan T1 Process Detection
+
+Scan `~/.config/nexus/sessions/` for `*.session` files whose `server_pid` does not correspond to a running process.
+
+```python
+# Pseudocode for doctor check
+from nexus.session import SESSIONS_DIR
+
+def _check_orphan_t1(lines: list[str]) -> bool:
+    """Check for orphaned T1 session files. Returns True if all clean."""
+    if not SESSIONS_DIR.exists():
+        lines.append(_check_line("T1 sessions", True, "no sessions directory"))
+        return True
+    orphans = []
+    for f in SESSIONS_DIR.glob("*.session"):
+        try:
+            record = json.loads(f.read_text())
+            if not isinstance(record, dict):
+                continue
+            pid = record.get("server_pid")
+            if pid:
+                try:
+                    os.kill(pid, 0)  # Check if alive
+                except OSError:
+                    orphans.append((f.name, pid))
+        except (json.JSONDecodeError, OSError):
+            orphans.append((f.name, None))
+    if orphans:
+        lines.append(_check_line("T1 sessions", False,
+                     f"{len(orphans)} orphaned session file(s)"))
+        return False
+    lines.append(_check_line("T1 sessions", True, "no orphans"))
+    return True
+```
+
+### Step 6: T2 Database Integrity Check
+
+Run SQLite `PRAGMA integrity_check` and FTS5 `integrity-check` on the T2 memory database.
+
+```python
+def _check_t2_integrity(lines: list[str]) -> bool:
+    """Verify T2 SQLite + FTS5 index integrity. Returns True if healthy."""
+    db_path = Path.home() / ".config" / "nexus" / "memory.db"
+    if not db_path.exists():
+        lines.append(_check_line("T2 database", True, "not created yet"))
+        return True
+    try:
+        conn = sqlite3.connect(str(db_path))
+        # SQLite integrity
+        result = conn.execute("PRAGMA integrity_check").fetchone()
+        sqlite_ok = result and result[0] == "ok"
+        # FTS5 integrity
+        try:
+            conn.execute("INSERT INTO memory_fts(memory_fts) VALUES('integrity-check')")
+            fts_ok = True
+        except sqlite3.OperationalError:
+            fts_ok = False
+        conn.close()
+        ok = sqlite_ok and fts_ok
+        detail = "ok" if ok else []
+        if not sqlite_ok:
+            detail.append("SQLite integrity check failed")
+        if not fts_ok:
+            detail.append("FTS5 index corrupt")
+        lines.append(_check_line("T2 database", ok,
+                     detail if isinstance(detail, str) else "; ".join(detail)))
+        return ok
+    except (sqlite3.Error, OSError) as exc:
+        lines.append(_check_line("T2 database", False, f"check failed: {exc}"))
+        return False
+```
+
+### Step 7: ChromaDB Pagination Audit
+
+Spot-check that `col.count()` matches the number of records retrievable via paginated `col.get()`. This catches any `col.get()` call site that silently truncates at 300.
+
+```python
+def _check_chroma_pagination(lines: list[str], client, db_name: str) -> bool:
+    """Spot-check one collection's count vs paginated get. Returns True if consistent."""
+    cols = client.list_collections()
+    if not cols:
+        return True
+    # Spot-check the first non-empty collection
+    for col in cols:
+        count = col.count()
+        if count == 0:
+            continue
+        # Paginated retrieval
+        retrieved = 0
+        offset = 0
+        while True:
+            batch = col.get(include=[], limit=300, offset=offset)
+            batch_ids = batch.get("ids", [])
+            retrieved += len(batch_ids)
+            if len(batch_ids) < 300:
+                break
+            offset += 300
+        if retrieved != count:
+            lines.append(_check_line(
+                f"pagination ({col.name})", False,
+                f"count={count} but get returned {retrieved}"))
+            return False
+        lines.append(_check_line(
+            f"pagination ({col.name})", True,
+            f"{count} records consistent"))
+        return True  # Spot-check one collection only
+    return True
+```
+
+### Success Criteria
+
+- [ ] `nx doctor` includes T1 orphan check, T2 integrity check, and ChromaDB pagination spot-check
+- [ ] Each check reports pass/fail status in the existing output format
+- [ ] Checks are gated behind credential/path availability (no crashes if unconfigured)
+- [ ] Fix suggestions provided for failures
+
+### Test Strategy (nexus-btid)
+
+**Test file**: `tests/test_doctor_integrity.py`
+
+- **Step 5**: Create tmp sessions dir with fake session files. Set `server_pid` to a non-existent PID. Verify doctor detects orphan.
+- **Step 6**: Create a T2 database, verify integrity check passes. Then corrupt the database (truncate file), verify check fails.
+- **Step 7**: Use `chromadb.EphemeralClient` with a test collection. Add records, verify pagination audit passes. (Cannot test truncation without a real Cloud client, but can verify the audit runs without error.)
+
+## Phase 2.5: ChromaDB Pagination Fix
+
+**Bead**: nexus-klxc (impl, P1 bug) + nexus-eld3 (tests)
+**File modified**: `src/nexus/doc_indexer.py`
+
+### Problem
+
+Line 233 of `doc_indexer.py`:
+```python
+all_existing = _chroma_with_retry(col.get, where={"source_path": str(file_path)}, include=[])
+```
+
+This call has no `limit=` parameter. ChromaDB Cloud returns at most 300 records per `get()` call. For documents that produce >300 chunks, stale chunks beyond the 300-record limit survive re-indexing and pollute search results.
+
+### Fix
+
+Replace the single `col.get()` call with a pagination loop matching the pattern already used in `db/t3.py` (e.g., `delete_by_source()`, `find_ids_by_title()`):
+
+```python
+# Paginated retrieval of all existing IDs for this source_path
+current_ids_set = set(ids)
+stale_ids: list[str] = []
+offset = 0
+while True:
+    batch = _chroma_with_retry(
+        col.get,
+        where={"source_path": str(file_path)},
+        include=[],
+        limit=300,
+        offset=offset,
+    )
+    batch_ids = batch.get("ids", [])
+    stale_ids.extend(eid for eid in batch_ids if eid not in current_ids_set)
+    if len(batch_ids) < 300:
+        break
+    offset += 300
+if stale_ids:
+    _chroma_with_retry(col.delete, ids=stale_ids)
+```
+
+### Success Criteria
+
+- [ ] `doc_indexer.py:_index_document()` stale-chunk pruning uses `limit=300` + offset pagination
+- [ ] Documents with >300 chunks have all stale chunks correctly pruned on re-index
+- [ ] Existing tests pass (no regression)
+
+### Test Strategy (nexus-eld3)
+
+**Test file**: `tests/test_doc_indexer_pagination.py`
+
+Use `chromadb.EphemeralClient` to simulate a collection with >300 chunks for a single source_path:
+
+1. Pre-populate collection with 350 fake chunks (IDs: `hash_0` through `hash_349`)
+2. Call `_index_document()` with a file that produces only 10 new chunks
+3. Verify that all 340 stale chunks (350 - 10) are deleted
+4. Verify that the 10 new chunks are present
+
+This requires mocking the embed function to avoid Voyage API calls.
+
+## Phase 3: Codebase Sweep
+
+**Bead**: nexus-1hv5 (chore, P3)
+**Files modified**: Multiple (annotation-only changes)
+
+### Process
+
+1. Run `grep -rn 'except.*:\s*$' src/nexus/ --include='*.py' -A2` to find all except blocks
+2. For each block without logging: add `# intentional: <reason>` comment
+3. Skip blocks that already have logging, re-raise, or were addressed in Phase 1
+
+### Known Intentional Silent Catches to Annotate
+
+| File:Line | Exception | Reason |
+|-----------|-----------|--------|
+| `session.py:60` | `ValueError` in `_stable_pid()` | Invalid NX_SESSION_PID env var — fall through to os.getsid(0) |
+| `session.py:302-303` | `ChildProcessError` in `stop_t1_server()` | Already commented: "not our child" |
+| `session.py:304-305` | `OSError` in `stop_t1_server()` | Process already gone after SIGKILL — expected |
+| `session.py:342-343` | `OSError` in `_try_remove_path()` | Best-effort file cleanup |
+| `hooks.py:196-197` | `OSError` in `session_end()` | Best-effort session file deletion |
+| `config.py:140-141` | `OSError` in atomic write cleanup | Cleanup after re-raise |
+| `registry.py:179-180` | `OSError` in atomic write cleanup | Cleanup after re-raise |
+| `scoring.py:187-188` | `StopIteration` in round-robin merge | Iterator exhaustion is normal |
+| `frecency.py:96-97` | `ValueError` in timestamp parse | Corrupt git log line — skip it |
+
+### Success Criteria
+
+- [ ] Every `except` block without logging has either: (a) logging added (Phase 1), or (b) `# intentional: <reason>` comment
+- [ ] No bare `pass` in exception handlers without explanation
+- [ ] All existing tests pass
+
+### Test Strategy
+
+No tests needed. This phase is purely annotation/documentation.
+
+## Execution Order
+
+### Recommended Sequence
+
+1. **Phase 2.5** (nexus-eld3 tests first, then nexus-klxc impl) — P1 bug fix, TDD, highest priority
+2. **Phase 1** (nexus-4our + nexus-op38) — Core reliability improvement
+3. **Phase 2** (nexus-n1bv + nexus-btid) — Diagnostic expansion
+4. **Phase 3** (nexus-1hv5) — Cleanup sweep
+
+### Parallelization Opportunities
+
+All four phases touch different code with minimal overlap:
+- **Phase 1**: indexer.py, session.py, hooks.py, commands/hook.py, commands/index.py, commands/doctor.py, md_chunker.py, classifier.py (logging additions only)
+- **Phase 2**: commands/doctor.py (new check functions)
+- **Phase 2.5**: doc_indexer.py (pagination fix)
+- **Phase 3**: Multiple files (comment annotations only)
+
+Phase 1 and Phase 2 both touch `commands/doctor.py`, but Phase 1 modifies line 211 (one log line) while Phase 2 adds new functions. Merge conflict risk is minimal.
+
+**Recommendation**: Spawn up to 3 parallel agents — one for Phases 1+3 (logging + annotations, same concern), one for Phase 2 (doctor expansion), one for Phase 2.5 (pagination fix).
+
+## Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| Adding logging to hot path degrades performance | Very low | Low | structlog short-circuits inactive levels; RDR confirms negligible overhead |
+| nx doctor ChromaDB pagination audit slow for large collections | Low | Low | Spot-check only one collection; gate behind credential availability |
+| Pagination fix changes stale-chunk pruning behavior | Low | Medium | Well-tested via EphemeralClient; fix is strictly more correct than current behavior |
+| Phase 3 annotations create noisy diff | Very low | Very low | Comments are non-functional; can be merged independently |
+
+## Bead Summary
+
+| ID | Title | Type | Priority | Depends on |
+|----|-------|------|----------|-----------|
+| nexus-56u1 | Implement RDR-030: Reliability Hardening | feature | P2 | (tracker) |
+| nexus-4our | Phase 1: Add structlog to 14 silent catch-and-pass blocks | task | P2 | none |
+| nexus-op38 | Phase 1 Tests: capture_logs verification | task | P2 | nexus-4our |
+| nexus-n1bv | Phase 2: nx doctor Steps 5-7 | task | P2 | none |
+| nexus-btid | Phase 2 Tests: nx doctor expansion | task | P2 | nexus-n1bv |
+| nexus-eld3 | Phase 2.5 Tests: pagination fix verification (TDD) | task | P1 | none |
+| nexus-klxc | Phase 2.5: Fix doc_indexer.py pagination bug | bug | P1 | nexus-eld3 |
+| nexus-1hv5 | Phase 3: Codebase sweep annotations | chore | P3 | none |
+
+## Context for Executing Agents
+
+### Knowledge Base Search Terms
+- `structlog capture_logs testing` — for test patterns
+- `chromadb pagination limit offset` — for pagination fix
+- `nx doctor health check` — for existing doctor patterns
+- `silent error logging policy` — for RDR-030 context
+
+### Key References
+- RDR: `docs/rdr/rdr-030-reliability-hardening.md`
+- Existing pagination patterns: `src/nexus/db/t3.py` (search for `limit=300`)
+- Existing doctor checks: `src/nexus/commands/doctor.py`
+- Session management: `src/nexus/session.py`
+- T2 schema: `src/nexus/db/t2.py` (FTS5 triggers and schema)
+
+### Reminders for Executing Agents
+- Use `mcp__sequential-thinking__sequentialthinking` for complex analysis
+- Write tests FIRST (TDD) — Phase 2.5 and Phase 2 require tests before impl; Phase 1 logging additions are trivial enough for impl-first
+- Ensure code compiles including all tests before marking complete
+- Update continuation state after each significant milestone
+- Sub-agents may spawn children for intensive work

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -15,8 +15,8 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 
 | ID | Title | Type | Status | Created |
 | -- | ----- | ---- | ------ | ------- |
-| [RDR-001](rdr-001-rdr-process-validation.md) | RDR Process Validation | Architecture | Implemented | 2026-02-27 |
-| [RDR-002](rdr-002-t2-status-synchronization.md) | T2 Status Synchronization | Technical Debt | Implemented | 2026-02-27 |
+| [RDR-001](rdr-001-rdr-process-validation.md) | RDR Process Validation | Architecture | Closed | 2026-02-27 |
+| [RDR-002](rdr-002-t2-status-synchronization.md) | T2 Status Synchronization | Technical Debt | Closed | 2026-02-27 |
 | [RDR-004](rdr-004-four-store-architecture.md) | Four-Store T3 Architecture | Architecture | Closed | 2026-02-28 |
 | [RDR-005](rdr-005-chromadb-cloud-quota-enforcement.md) | ChromaDB Cloud Quota Enforcement | Architecture | Closed | 2026-02-28 |
 | [RDR-006](rdr-006-chunk-size-configuration.md) | File-Size Scoring Penalty for Code Search | Feature | Closed | 2026-02-28 |
@@ -30,11 +30,11 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-014](rdr-014-knowledge-base-retrieval-quality.md) | Knowledge Base Retrieval Quality: Code Context and Docs Deduplication | Bug | Closed | 2026-03-02 |
 | [RDR-015](rdr-015-indexing-pipeline-rethink.md) | Indexing Pipeline Rethink: Align Nexus with Arcaneum's Battle-Tested Implementation | Enhancement | Closed | 2026-03-02 |
 | [RDR-016](rdr-016-ast-chunk-line-range-bug.md) | AST Chunk Line Range Bug: CodeSplitter Returns Empty Metadata, Breaking Context Prefix | Bug | Closed | 2026-03-03 |
-| [RDR-017](rdr-017-indexing-progress-reporting.md) | Indexing Progress Reporting: tqdm-Based Progress Bar for nx index | Enhancement | Implemented | 2026-03-03 |
-| [RDR-018](rdr-018-replace-serve-with-git-hooks.md) | Replace nx serve Polling Server with Git Hooks | Refactor | Implemented | 2026-03-03 |
+| [RDR-017](rdr-017-indexing-progress-reporting.md) | Indexing Progress Reporting: tqdm-Based Progress Bar for nx index | Enhancement | Closed | 2026-03-03 |
+| [RDR-018](rdr-018-replace-serve-with-git-hooks.md) | Replace nx serve Polling Server with Git Hooks | Refactor | Closed | 2026-03-03 |
 | [RDR-019](rdr-019-chromadb-transient-retry.md) | ChromaDB Transient HTTP Error Retry | Bug Fix | Closed | 2026-03-04 |
 | [RDR-020](rdr-020-voyage-chromadb-read-timeout.md) | Voyage AI and ChromaDB Client Read Timeouts | Bug Fix | Closed | 2026-03-05 |
-| [RDR-021](rdr-021-docling-pdf-extraction.md) | Replace 3-Tier PDF Extraction Stack with Docling | Enhancement | Accepted | 2026-03-05 |
+| [RDR-021](rdr-021-docling-pdf-extraction.md) | Replace 3-Tier PDF Extraction Stack with Docling | Enhancement | Closed | 2026-03-05 |
 | [RDR-022](rdr-022-memory-delete-command.md) | Add delete subcommand to nx memory, nx store, nx scratch | Enhancement | Closed | 2026-03-05 |
 | [RDR-023](rdr-023-agent-tool-permissions-audit.md) | Agent Tool Permissions Audit and Remediation | Enhancement | Closed | 2026-03-07 |
 | [RDR-024](rdr-024-rdr-process-guardrails.md) | RDR Process Guardrails: Prevent Implementation Before Gate/Accept | Enhancement | Closed | 2026-03-07 |
@@ -43,7 +43,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-027](rdr-027-search-results-ux.md) | Search Results UX — Context Lines and Syntax Highlighting | Feature | Closed | 2026-03-08 |
 | [RDR-028](rdr-028-code-search-recall.md) | Code Search Recall — Language Registry Unification | Enhancement | Closed | 2026-03-08 |
 | [RDR-029](rdr-029-pipeline-versioning.md) | Pipeline Versioning — Force Reindex and Collection Version Stamping | Enhancement | Closed | 2026-03-08 |
-| [RDR-030](rdr-030-reliability-hardening.md) | Reliability Hardening — Silent Error Audit and Logging Policy | Enhancement | Draft | 2026-03-08 |
+| [RDR-030](rdr-030-reliability-hardening.md) | Reliability Hardening — Silent Error Audit and Logging Policy | Enhancement | Accepted | 2026-03-08 |
 | [RDR-031](rdr-031-collection-portability.md) | Collection Portability — Export/Import for T3 Backup and Migration | Feature | Draft | 2026-03-08 |
 | [RDR-032](rdr-032-indexer-decomposition.md) | Indexer Module Decomposition and Configuration Externalization | Technical Debt | Draft | 2026-03-08 |
 | [RDR-033](rdr-033-pdf-agent-nx-index-alignment.md) | PDF Processing Agent Should Delegate to nx index pdf | Architecture | Closed | 2026-03-08 |

--- a/docs/rdr/rdr-001-rdr-process-validation.md
+++ b/docs/rdr/rdr-001-rdr-process-validation.md
@@ -2,7 +2,7 @@
 title: "RDR Process Validation"
 id: RDR-001
 type: architecture
-status: implemented
+status: closed
 priority: high
 author: Hal Hildebrand
 reviewed-by: self

--- a/docs/rdr/rdr-002-t2-status-synchronization.md
+++ b/docs/rdr/rdr-002-t2-status-synchronization.md
@@ -2,7 +2,7 @@
 title: "T2 Status Synchronization"
 id: RDR-002
 type: Technical Debt
-status: implemented
+status: closed
 priority: high
 author: Hal Hildebrand
 reviewed-by: self

--- a/docs/rdr/rdr-017-indexing-progress-reporting.md
+++ b/docs/rdr/rdr-017-indexing-progress-reporting.md
@@ -1,7 +1,7 @@
 ---
 title: "Indexing Progress Reporting: tqdm-Based Progress Bar for nx index"
 type: enhancement
-status: implemented
+status: closed
 priority: P2
 author: Hal Hildebrand
 date: 2026-03-03

--- a/docs/rdr/rdr-018-replace-serve-with-git-hooks.md
+++ b/docs/rdr/rdr-018-replace-serve-with-git-hooks.md
@@ -1,7 +1,7 @@
 ---
 title: "Replace nx serve Polling Server with Git Hooks"
 type: refactor
-status: implemented
+status: closed
 priority: P2
 author: Hal Hildebrand
 date: 2026-03-03

--- a/docs/rdr/rdr-021-docling-pdf-extraction.md
+++ b/docs/rdr/rdr-021-docling-pdf-extraction.md
@@ -2,8 +2,10 @@
 id: RDR-021
 title: "Replace 3-Tier PDF Extraction Stack with Docling"
 type: enhancement
-status: accepted
+status: closed
 accepted_date: 2026-03-05
+close_date: 2026-03-09
+close_reason: implemented
 reviewed-by: self
 priority: P2
 created: 2026-03-05

--- a/docs/rdr/rdr-030-reliability-hardening.md
+++ b/docs/rdr/rdr-030-reliability-hardening.md
@@ -2,7 +2,8 @@
 title: "Reliability Hardening — Silent Error Audit and Logging Policy"
 id: RDR-030
 type: Enhancement
-status: draft
+status: accepted
+accepted_date: 2026-03-09
 priority: P2
 author: Hal Hildebrand
 reviewed-by: self
@@ -22,8 +23,8 @@ This pattern makes debugging extremely difficult — the system silently falls b
 
 ## Context
 
-- `structlog` is already the logging framework (used throughout the codebase)
-- `nx doctor` exists but only checks configuration and connectivity, not data integrity
+- `structlog` is already the logging framework (used throughout the codebase); three modules (`commands/hook.py`, `commands/index.py`, `classifier.py`) lack a module-level `_log` binding and will need one added
+- `nx doctor` checks configuration, connectivity, and pipeline versioning (RDR-029), but not T1 process orphans, T2 FTS5 integrity, or ChromaDB pagination counts
 - RDR-019 and RDR-020 established retry patterns for external APIs, but internal error handling remains inconsistent
 
 ## Research Findings
@@ -57,9 +58,25 @@ This pattern makes debugging extremely difficult — the system silently falls b
 | nexus-738 | Formatters always emitted `:0:` line numbers — wrong output |
 | nexus-zmu | Pre-heading markdown content silently dropped |
 
-### F3: ChromaDB 300-Record Pagination (Verified — production discovery)
+### F3: ChromaDB 300-Record Pagination (Verified — production discovery + 2026-03-09 audit)
 
-ChromaDB Cloud's `get()` returns at most 300 entries per call. Code that calls `col.get()` without pagination silently misses data. Known fixed locations: `delete_by_source()`, `nx store delete --title`. Other call sites may still be vulnerable.
+ChromaDB Cloud's `get()` returns at most 300 entries per call. Code that calls `col.get()` without pagination silently misses data. Known fixed locations: `delete_by_source()`, `nx store delete --title`. Full audit (2026-03-09):
+- **Correctly paginated**: `expire()`, `delete_by_source()`, `find_ids_by_title()` — all use `limit=300` + offset loop
+- **Safe (exact/capped)**: `get_by_id()`, `delete_by_id()` (exact ID), staleness check (`limit=1`)
+- **Display truncation**: `list_store()` caps at `min(limit, 300)`, default 200 — UX, not correctness
+- **BUG: `doc_indexer.py:233`** — stale-chunk pruning `col.get(where={"source_path": ...})` has no `limit=`/pagination. For documents >300 chunks, orphan stale chunks survive re-indexing and pollute search results.
+
+### F4: New Silent Catch Sites (Verified — 2026-03-09 source scan)
+
+Three additional sites not in the original F1 audit:
+
+| Location | What's swallowed | Impact | Recommended level |
+|----------|-----------------|--------|--------------------|
+| `indexer.py:398` | `(OSError, subprocess.TimeoutExpired)` in `_current_head()` | Returns `""`, causing unnecessary full re-index next run | `debug` |
+| `md_chunker.py:73` | `yaml.YAMLError` in frontmatter parse | Metadata (title, author, date) silently lost — indexed without attribution | `warning` |
+| `classifier.py:46` | `OSError` in `_has_shebang()` | File classified as no-shebang when it can't be read | `debug` |
+
+**Total actionable silent-error sites: 14** (11 F1 + 3 F4).
 
 ## Proposed Solution
 
@@ -83,19 +100,19 @@ Any unimplemented code path must `raise NotImplementedError("...")` rather than 
 
 ## Implementation Plan
 
-### Phase 1: Silent Error Audit (11 locations)
-1. Add `_log.debug` (or `_log.warning` where degradation is user-visible) to all 11 identified catch-and-pass blocks
+### Phase 1: Silent Error Audit (14 locations)
+1. Add `_log.debug` (or `_log.warning` where degradation is user-visible) to all 14 identified catch-and-pass blocks (11 F1 + 3 F4)
 2. Review each for appropriate recovery behavior
-3. Add warning-level logs for fallback paths (session.py EphemeralClient fallback)
+3. Add warning-level logs for fallback paths (session.py EphemeralClient fallback, md_chunker frontmatter loss)
 
 ### Phase 2: nx doctor Expansion
-4. Add collection pipeline_version check
-5. Add orphan T1 process detection
+4. ~~Add collection pipeline_version check~~ — already implemented (RDR-029, `doctor.py:134-170`)
+5. Add orphan T1 process detection — scan `~/.config/nexus/sessions/` for records whose `server_pid` is not a live process; report count of orphaned records
 6. Add T2 database integrity check
 7. Add ChromaDB pagination audit (spot-check record counts)
 
-### Phase 2.5: ChromaDB Pagination Audit
-8. Audit all `col.get()` call sites in `db/t3.py` and `doc_indexer.py` for missing `limit=` / pagination loop; fix any found.
+### Phase 2.5: ChromaDB Pagination Fix (scope extension — discovered during audit)
+8. Fix `doc_indexer.py:233` stale-chunk pruning — add `limit=300` + offset pagination loop (only confirmed unpaginated site with real data-loss risk). Audit verified all other `col.get()` call sites in `db/t3.py` are already paginated or use exact-ID lookups. This is a correctness fix, not a logging change, but is included here because the audit that discovered it is integral to this RDR's research phase.
 
 ### Phase 3: Codebase Sweep
 9. grep for `except.*pass` and `except.*return` patterns
@@ -115,7 +132,7 @@ Any unimplemented code path must `raise NotImplementedError("...")` rather than 
 No contradictions found between the three proposed policies. Policy 1 (minimum logging) and Policy 2 (warn on degradation) are complementary: Policy 1 sets the floor (`debug`), Policy 2 raises it to `warning` for user-visible fallbacks. Policy 4 (stub code must raise) applies to unimplemented paths, not to the same catch blocks that Policies 1-2 cover — they target different code. The `nx doctor` expansion (Policy 3) is additive and does not conflict with logging changes.
 
 ### Assumption Verification
-- **Assumption: structlog is universally available.** Verified: `structlog` is a hard dependency in `pyproject.toml` and `_log = structlog.get_logger()` exists in all affected modules (`indexer.py`, `session.py`, `hooks.py`).
+- **Assumption: structlog is universally available.** Verified: `structlog` is a hard dependency in `pyproject.toml` and `_log = structlog.get_logger()` exists in most affected modules (`indexer.py`, `session.py`, `hooks.py`, `doctor.py`, `md_chunker.py`). Three modules (`commands/hook.py`, `commands/index.py`, `classifier.py`) lack a module-level `_log` binding — these need 2 lines per site (binding + log call) instead of 1.
 - **Assumption: All 11 silent catch sites are reachable.** Verified by source inspection. Each corresponds to a real try/except block in current `main`. The two `indexer.py:264-273` sites and `session.py:113-115` were initially missed but confirmed present.
 - **Assumption: P0 bug list is accurate.** Bead IDs are cited; the specific count "8 of 22" was softened to "8 known P0 bugs" since the total denominator is not independently verifiable from the current bead store.
 
@@ -129,6 +146,11 @@ This RDR is scoped to (a) cataloguing silent catches, (b) establishing logging p
 
 ### Proportionality
 The effort is modest — each silent catch site needs 1-2 lines of logging added. The `nx doctor` expansion (Phase 2) is the largest component but builds on existing infrastructure. The historical cost of silent failures (8 P0 bugs requiring multi-hour debugging each) far exceeds the implementation cost. Risk is low: adding logging cannot break existing behavior, and `nx doctor` checks are purely diagnostic.
+
+## Revision History
+
+- **2026-03-09 (Research)**: Codebase audit verified all 11 F1 sites still-silent, found 3 new sites (F4), confirmed 1 pagination bug (`doc_indexer.py:233`). Total actionable: 14 silent-error sites + 1 pagination fix.
+- **2026-03-09 (Gate — PASSED)**: 0 critical, 3 significant (all addressed): (1) Context falsely claimed nx doctor has no integrity checks — corrected (pipeline_version check exists from RDR-029, Step 4 struck), (2) 3 modules lack `_log` binding — documented in assumptions, (3) Phase 2.5 pagination fix is a correctness change, not logging — justified as audit discovery. 3 observations noted.
 
 ## References
 

--- a/docs/repo-indexing.md
+++ b/docs/repo-indexing.md
@@ -58,7 +58,7 @@ separate `rdr__<name>-<hash8>` collection via the batch markdown indexer.
 Code files are chunked via tree-sitter AST parsing using `llama-index` `CodeSplitter` and
 `tree-sitter-language-pack`.
 
-**AST-supported languages** (28 extension mappings, 19 parsers after Fix B):
+**AST-supported languages** (44 extension mappings, 31 parsers):
 
 | Extensions | Parser |
 |---|---|
@@ -81,6 +81,20 @@ Code files are chunked via tree-sitter AST parsing using `llama-index` `CodeSpli
 | `.php` | php |
 | `.r` | r |
 | `.lua` | lua |
+| `.proto` | proto |
+| `.ex`, `.exs` | elixir |
+| `.erl`, `.hrl` | erlang |
+| `.hs` | haskell |
+| `.clj`, `.cljs`, `.cljc` | clojure |
+| `.ml` | ocaml |
+| `.mli` | ocaml\_interface |
+| `.el` | elisp |
+| `.dart` | dart |
+| `.zig` | zig |
+| `.jl` | julia |
+| `.pl`, `.pm` | perl |
+
+Additionally, 8 GPU shader extensions (`.cl`, `.comp`, `.frag`, `.vert`, `.metal`, `.glsl`, `.wgsl`, `.hlsl`) are classified as CODE with line-based chunking (no AST parser).
 
 When AST parsing fails or no parser exists for the extension, the chunker falls back to
 line-based splitting: 150-line chunks with 15% overlap.
@@ -96,8 +110,9 @@ the file, class, method, and line range. The raw chunk text is stored in ChromaD
 <original chunk text>
 ```
 
-Class and method names are extracted by tree-sitter using `DEFINITION_TYPES` covering 14
-languages (Python, Java, Go, TypeScript, Rust, C, C++, C#, Ruby, PHP, Swift, Kotlin, Scala).
+Class and method names are extracted by tree-sitter using `DEFINITION_TYPES` covering 23
+languages (Python, JavaScript, TypeScript, TSX, Java, Go, Rust, C, C++, C#, Ruby, PHP,
+Swift, Kotlin, Scala, R, Lua, Dart, Haskell, Julia, OCaml, Perl, Erlang).
 For a chunk spanning multiple methods, the method field is empty. For unsupported languages
 or when parsing fails, the prefix falls back to `File + Lines` only.
 

--- a/src/nexus/classifier.py
+++ b/src/nexus/classifier.py
@@ -10,6 +10,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+import structlog
+
+_log = structlog.get_logger()
+
 
 class ContentClass(Enum):
     """Content classification for a repository file."""
@@ -43,7 +47,8 @@ def _has_shebang(path: Path) -> bool:
     try:
         with path.open("rb") as f:
             return f.read(2) == b"#!"
-    except OSError:
+    except OSError as exc:
+        _log.debug("has_shebang_read_failed", path=str(path), error=str(exc))
         return False
 
 

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """nx doctor — health check for all required services."""
+import json
+import os
 import shutil
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -11,7 +14,9 @@ import structlog
 from nexus.config import get_credential
 from nexus.db.t3 import _STORE_TYPES
 from nexus.commands.hooks import _effective_hooks_dir, SENTINEL_BEGIN
+from nexus.commands._helpers import default_db_path
 from nexus.registry import RepoRegistry
+from nexus.session import SESSIONS_DIR
 
 _log = structlog.get_logger(__name__)
 
@@ -48,6 +53,129 @@ def _python_ok() -> tuple[bool, str]:
 # Keep old name so existing tests importing `_check` still work.
 def _check(label: str, ok: bool, detail: str = "") -> str:
     return _check_line(label, ok, detail)
+
+
+def _check_orphan_t1(lines: list[str]) -> bool:
+    """Check for orphaned T1 session files. Returns True if all clean."""
+    if not SESSIONS_DIR.exists():
+        lines.append(_check_line("T1 sessions", True, "no sessions directory"))
+        return True
+
+    session_files = list(SESSIONS_DIR.glob("*.session"))
+    if not session_files:
+        lines.append(_check_line("T1 sessions", True, "no session files"))
+        return True
+
+    orphans: list[str] = []
+    for sf in session_files:
+        try:
+            record = json.loads(sf.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue  # corrupt/unreadable — skip
+        pid = record.get("server_pid")
+        if pid is None:
+            continue
+        try:
+            os.kill(int(pid), 0)  # raises OSError if process is dead
+        except OSError:
+            orphans.append(sf.name)
+
+    if orphans:
+        lines.append(_check_line(
+            "T1 sessions", False,
+            f"{len(orphans)} orphaned session file(s): {', '.join(orphans)}",
+        ))
+        _fix(lines,
+             "Remove stale files: rm ~/.config/nexus/sessions/*.session",
+             "Or run: nx doctor (sweep runs automatically on session start)")
+        return False
+
+    lines.append(_check_line(
+        "T1 sessions", True,
+        f"{len(session_files)} session file(s), all processes live",
+    ))
+    return True
+
+
+def _check_t2_integrity(lines: list[str]) -> bool:
+    """Verify T2 SQLite + FTS5 index integrity. Returns True if all ok."""
+    db_path = default_db_path()
+    if not db_path.exists():
+        lines.append(_check_line("T2 integrity", True, "not created yet"))
+        return True
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            # PRAGMA integrity_check returns one row per problem; "ok" means clean.
+            rows = conn.execute("PRAGMA integrity_check").fetchall()
+            pragma_ok = len(rows) == 1 and rows[0][0] == "ok"
+            if not pragma_ok:
+                issues = "; ".join(r[0] for r in rows[:3])
+                lines.append(_check_line("T2 integrity", False, f"PRAGMA: {issues}"))
+                return False
+
+            # FTS5 integrity-check: raises OperationalError if index is corrupt.
+            conn.execute("INSERT INTO memory_fts(memory_fts) VALUES('integrity-check')")
+            fts_ok = True
+        except sqlite3.OperationalError as exc:
+            lines.append(_check_line("T2 integrity", False, f"FTS5: {exc}"))
+            return False
+        finally:
+            conn.close()
+    except Exception as exc:
+        lines.append(_check_line("T2 integrity", False, f"could not open: {exc}"))
+        return False
+
+    if pragma_ok and fts_ok:
+        lines.append(_check_line("T2 integrity", True, "PRAGMA ok, FTS5 ok"))
+    return pragma_ok and fts_ok
+
+
+def _check_chroma_pagination(lines: list[str], client: object, db_name: str) -> bool:
+    """Spot-check one non-empty collection's count() vs paginated get(). Returns True if ok."""
+    try:
+        cols = client.list_collections()  # type: ignore[union-attr]
+    except Exception as exc:
+        lines.append(_check_line(f"ChromaDB pagination ({db_name})", False, f"list failed: {exc}"))
+        return False
+
+    # Find the first non-empty collection to audit.
+    target_col = None
+    for col in cols:
+        try:
+            if col.count() > 0:
+                target_col = col
+                break
+        except Exception:
+            continue
+
+    if target_col is None:
+        lines.append(_check_line(f"ChromaDB pagination ({db_name})", True, "no non-empty collections to audit"))
+        return True
+
+    try:
+        expected = target_col.count()
+        retrieved = 0
+        offset = 0
+        page_size = 300
+        while True:
+            batch = target_col.get(limit=page_size, offset=offset)
+            ids = batch.get("ids", [])
+            retrieved += len(ids)
+            if len(ids) < page_size:
+                break
+            offset += page_size
+
+        ok = retrieved == expected
+        detail = (
+            f"{target_col.name}: count={expected}, paginated={retrieved}"
+        )
+        lines.append(_check_line(f"ChromaDB pagination ({db_name})", ok, detail))
+        return ok
+    except Exception as exc:
+        lines.append(_check_line(f"ChromaDB pagination ({db_name})", False, f"audit failed: {exc}"))
+        return False
 
 
 @click.command("doctor")
@@ -208,7 +336,8 @@ def doctor_cmd() -> None:
     try:
         reg = RepoRegistry(_registry_path)
         repos = reg.all()
-    except Exception:
+    except Exception as exc:
+        _log.warning("doctor_registry_load_failed", error=str(exc))
         repos = []
 
     if not repos:
@@ -251,6 +380,29 @@ def doctor_cmd() -> None:
     else:
         lines.append(_check_line("index log", True,
                                  f"{log_path} (not created yet — git hooks have not fired)"))
+
+    # ── Orphan T1 process detection ───────────────────────────────────────────
+    # Non-fatal: stale session files are annoying but do not block operation.
+    _check_orphan_t1(lines)
+
+    # ── T2 database integrity ─────────────────────────────────────────────────
+    # Non-fatal: integrity failure is logged but does not set failed=True.
+    _check_t2_integrity(lines)
+
+    # ── ChromaDB pagination audit ─────────────────────────────────────────────
+    # Spot-check one non-empty collection per configured store (non-fatal).
+    if chroma_key and chroma_database:
+        for t in _STORE_TYPES:
+            db_name = f"{chroma_database}_{t}"
+            try:
+                client = chromadb.CloudClient(
+                    tenant=chroma_tenant or None, database=db_name, api_key=chroma_key
+                )
+                _check_chroma_pagination(lines, client, db_name)
+            except Exception as exc:
+                _log.debug("doctor_pagination_check_client_failed", db=db_name, error=str(exc))
+                lines.append(_check_line(f"ChromaDB pagination ({db_name})", True,
+                                         "skipped (client unavailable)"))
 
     click.echo("\n".join(lines))
 

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -80,6 +80,9 @@ def _check_orphan_t1(lines: list[str]) -> bool:
             os.kill(int(pid), 0)  # raises OSError if process is dead
         except OSError:
             orphans.append(sf.name)
+        except (ValueError, TypeError):
+            _log.debug("orphan_t1_invalid_pid", path=str(sf), pid=repr(pid))
+            continue
 
     if orphans:
         lines.append(_check_line(
@@ -93,7 +96,7 @@ def _check_orphan_t1(lines: list[str]) -> bool:
 
     lines.append(_check_line(
         "T1 sessions", True,
-        f"{len(session_files)} session file(s), all processes live",
+        f"{len(session_files)} session file(s), no orphans detected",
     ))
     return True
 

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -70,8 +70,9 @@ def _check_orphan_t1(lines: list[str]) -> bool:
     for sf in session_files:
         try:
             record = json.loads(sf.read_text())
-        except (json.JSONDecodeError, OSError):
-            continue  # corrupt/unreadable — skip
+        except (json.JSONDecodeError, OSError) as exc:
+            _log.debug("orphan_t1_session_corrupt", path=str(sf), error=str(exc))
+            continue
         pid = record.get("server_pid")
         if pid is None:
             continue
@@ -148,7 +149,7 @@ def _check_chroma_pagination(lines: list[str], client: object, db_name: str) -> 
                 target_col = col
                 break
         except Exception:
-            continue
+            continue  # intentional: skip collections that error on count()
 
     if target_col is None:
         lines.append(_check_line(f"ChromaDB pagination ({db_name})", True, "no non-empty collections to audit"))
@@ -160,7 +161,7 @@ def _check_chroma_pagination(lines: list[str], client: object, db_name: str) -> 
         offset = 0
         page_size = 300
         while True:
-            batch = target_col.get(limit=page_size, offset=offset)
+            batch = target_col.get(limit=page_size, offset=offset, include=[])
             ids = batch.get("ids", [])
             retrieved += len(ids)
             if len(ids) < page_size:

--- a/src/nexus/commands/hook.py
+++ b/src/nexus/commands/hook.py
@@ -4,8 +4,11 @@ import json
 import sys
 
 import click
+import structlog
 
 from nexus import hooks
+
+_log = structlog.get_logger()
 
 
 @click.group("hook")
@@ -21,8 +24,8 @@ def session_start_cmd() -> None:
     try:
         data = json.loads(sys.stdin.read())
         claude_session_id = data.get("session_id")
-    except Exception:
-        pass
+    except Exception as exc:
+        _log.debug("session_start_stdin_parse_failed", error=str(exc))
     output = hooks.session_start(claude_session_id=claude_session_id)
     click.echo(output)
 

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -4,9 +4,12 @@ import sys
 from pathlib import Path
 
 import click
+import structlog
 from tqdm import tqdm
 
 from nexus.registry import RepoRegistry
+
+_log = structlog.get_logger()
 
 
 def _registry_path() -> Path:
@@ -135,8 +138,8 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
             )
             if not any_managed:
                 click.echo("Tip: run `nx hooks install` to auto-index this repo on every commit.")
-        except Exception:
-            pass  # Don't let hook detection break indexing
+        except Exception as exc:
+            _log.debug("hook_detection_failed", error=str(exc))  # Don't let hook detection break indexing
     click.echo("Done.")
 
 

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -138,7 +138,7 @@ def set_credential(name: str, value: str) -> None:
             try:
                 os.unlink(tmp_path)
             except OSError:
-                pass
+                pass  # intentional: cleanup after re-raise
             raise
 
 

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -228,10 +228,24 @@ def _index_document(
             m["embedding_model"] = actual_model
     db.upsert_chunks_with_embeddings(collection_name, ids, documents, embeddings, metadatas)
 
-    # Prune stale chunks from a previous (larger) version of this file
+    # Prune stale chunks from a previous (larger) version of this file.
+    # Paginate: ChromaDB Cloud returns at most 300 records per get() call.
     current_ids_set = set(ids)
-    all_existing = _chroma_with_retry(col.get, where={"source_path": str(file_path)}, include=[])
-    stale_ids = [eid for eid in all_existing["ids"] if eid not in current_ids_set]
+    stale_ids: list[str] = []
+    offset = 0
+    while True:
+        batch = _chroma_with_retry(
+            col.get,
+            where={"source_path": str(file_path)},
+            include=[],
+            limit=300,
+            offset=offset,
+        )
+        batch_ids = batch.get("ids", [])
+        stale_ids.extend(eid for eid in batch_ids if eid not in current_ids_set)
+        if len(batch_ids) < 300:
+            break
+        offset += 300
     if stale_ids:
         _chroma_with_retry(col.delete, ids=stale_ids)
 

--- a/src/nexus/frecency.py
+++ b/src/nexus/frecency.py
@@ -94,7 +94,7 @@ def batch_frecency(repo: Path) -> dict[Path, float]:
             try:
                 current_ts = float(line[7:])
             except ValueError:
-                current_ts = None
+                current_ts = None  # intentional: corrupt git log line, skip
         elif current_ts is not None:
             file_path = repo / line
             days = max(0.0, (now - current_ts) / 86400.0)

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -52,7 +52,8 @@ def _infer_repo() -> str:
             capture_output=True, text=True, check=True, timeout=10,
         )
         return Path(result.stdout.strip()).name
-    except Exception:
+    except Exception as exc:
+        _log.debug("infer_repo_git_failed", error=str(exc))
         return Path.cwd().name
 
 
@@ -152,8 +153,8 @@ def session_end() -> str:
             r = json.loads(own_file.read_text())
             if isinstance(r, dict) and "session_id" in r:
                 own_record = r
-        except (json.JSONDecodeError, OSError):
-            pass
+        except (json.JSONDecodeError, OSError) as exc:
+            _log.debug("session_end_own_record_corrupt", path=str(own_file), error=str(exc))
 
     # For T1 flush, use own record if available; otherwise walk the chain
     # (child-agent scenario where the parent's file is further up).
@@ -194,7 +195,7 @@ def session_end() -> str:
         try:
             own_file.unlink(missing_ok=True)
         except OSError:
-            pass
+            pass  # intentional: best-effort session file deletion
         tmpdir = own_record.get("tmpdir", "")
         if tmpdir:
             shutil.rmtree(tmpdir, ignore_errors=True)

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -263,14 +263,14 @@ def _extract_name_from_node(node) -> str:  # type: ignore[no-untyped-def]
         if child:
             try:
                 return child.text.decode("utf-8")
-            except (UnicodeDecodeError, AttributeError):
-                pass
+            except (UnicodeDecodeError, AttributeError) as exc:
+                _log.debug("extract_name_decode_failed", error=str(exc), exc_info=True)
     for child in node.children:
         if child.type in ("identifier", "name"):
             try:
                 return child.text.decode("utf-8")
-            except (UnicodeDecodeError, AttributeError):
-                pass
+            except (UnicodeDecodeError, AttributeError) as exc:
+                _log.debug("extract_name_child_decode_failed", error=str(exc), exc_info=True)
     return ""
 
 
@@ -298,12 +298,14 @@ def _extract_context(
     try:
         from tree_sitter_language_pack import get_parser  # lazy import
         parser = get_parser(language)
-    except Exception:
+    except Exception as exc:
+        _log.warning("get_parser_failed", language=language, error=str(exc), exc_info=True)
         return ("", "")
 
     try:
         tree = parser.parse(source)
-    except Exception:
+    except Exception as exc:
+        _log.debug("tree_parse_failed", language=language, error=str(exc))
         return ("", "")
 
     class_name = ""
@@ -395,7 +397,8 @@ def _current_head(repo: Path) -> str:
             timeout=30,
         )
         return result.stdout.strip() if result.returncode == 0 else ""
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _log.debug("current_head_failed", repo=str(repo), error=str(exc))
         return ""
 
 

--- a/src/nexus/md_chunker.py
+++ b/src/nexus/md_chunker.py
@@ -70,7 +70,8 @@ def parse_frontmatter(text: str) -> tuple[dict, str]:
         data = yaml.safe_load(fm_content) or {}
         if not isinstance(data, dict):
             data = {}
-    except yaml.YAMLError:
+    except yaml.YAMLError as exc:
+        _log.warning("frontmatter_parse_failed", error=str(exc))
         data = {}
     return data, rest
 

--- a/src/nexus/registry.py
+++ b/src/nexus/registry.py
@@ -177,5 +177,5 @@ class RepoRegistry:
             try:
                 os.unlink(tmp_path_str)
             except OSError:
-                pass
+                pass  # intentional: cleanup after re-raise
             raise

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -185,6 +185,6 @@ def round_robin_interleave(
                 merged.append(next(it))
                 next_iters.append(it)
             except StopIteration:
-                pass
+                pass  # intentional: iterator exhaustion is normal control flow
         iterators = next_iters
     return merged

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -40,7 +40,7 @@ def read_claude_session_id() -> str | None:
         text = CLAUDE_SESSION_FILE.read_text().strip()
         return text or None
     except OSError:
-        return None
+        return None  # intentional: file not created yet, normal on first run
 
 
 def _stable_pid() -> int:
@@ -86,7 +86,7 @@ def read_session_id(ppid: int | None = None) -> str | None:
         text = session_file_path(ppid).read_text().strip()
         return text or None
     except OSError:
-        return None
+        return None  # intentional: session file not created yet, normal on first run
 
 
 # ── T1 server session management (RDR-010) ────────────────────────────────────
@@ -124,7 +124,7 @@ def _ppid_of(pid: int) -> int | None:
         val = int(out)
         return val if val > 1 else None
     except (subprocess.CalledProcessError, ValueError, FileNotFoundError, OSError):
-        return None
+        return None  # intentional: process gone or ps unavailable — expected during PPID walk
 
 
 def find_ancestor_session(
@@ -268,7 +268,7 @@ def start_t1_server() -> tuple[str, int, int, str]:
             conn.close()
             return _T1_SERVER_HOST, port, proc.pid, tmpdir
         except OSError:
-            time.sleep(0.2)
+            time.sleep(0.2)  # intentional: server not yet listening, retry loop
 
     proc.kill()
     raise RuntimeError(
@@ -282,20 +282,20 @@ def stop_t1_server(server_pid: int) -> None:
     try:
         os.kill(server_pid, signal.SIGTERM)
     except OSError:
-        return
+        return  # intentional: process already gone before SIGTERM
     # Wait up to 3 seconds for graceful exit
     deadline = time.time() + 3.0
     while time.time() < deadline:
         try:
             os.kill(server_pid, 0)  # check if alive
         except OSError:
-            return  # process gone
+            return  # intentional: process exited after SIGTERM — success
         time.sleep(0.1)
     # Escalate
     try:
         os.kill(server_pid, signal.SIGKILL)
     except OSError:
-        return
+        return  # intentional: process exited between poll and SIGKILL
     # Reap the zombie so it does not linger in the process table.
     try:
         os.waitpid(server_pid, os.WNOHANG)

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -58,7 +58,7 @@ def _stable_pid() -> int:
         try:
             return int(raw)
         except ValueError:
-            pass
+            pass  # intentional: invalid NX_SESSION_PID env var, fall through to os.getsid(0)
     return os.getsid(0)
 
 
@@ -111,8 +111,8 @@ def _ppid_of(pid: int) -> int | None:
                 if line.startswith("PPid:"):
                     val = int(line.split()[1])
                     return val if val > 1 else None
-        except (OSError, ValueError):
-            pass
+        except (OSError, ValueError) as exc:
+            _log.debug("ppid_proc_read_failed", pid=pid, error=str(exc))
 
     # Fallback: ps (macOS + Linux with procps)
     try:
@@ -196,8 +196,8 @@ def sweep_stale_sessions(
                     import shutil
                     shutil.rmtree(tmpdir, ignore_errors=True)
                 _try_remove_path(f)
-        except (json.JSONDecodeError, OSError):
-            pass
+        except (json.JSONDecodeError, OSError) as exc:
+            _log.debug("sweep_corrupt_session_file", path=str(f), error=str(exc))
 
 
 def _find_chroma() -> str | None:
@@ -302,7 +302,7 @@ def stop_t1_server(server_pid: int) -> None:
     except ChildProcessError:
         pass  # not our child (different parent process — acceptable)
     except OSError:
-        pass
+        pass  # intentional: process already gone after SIGKILL
 
 
 def write_session_record(
@@ -340,4 +340,4 @@ def _try_remove_path(path: Path) -> None:
     try:
         path.unlink(missing_ok=True)
     except OSError:
-        pass
+        pass  # intentional: best-effort file cleanup

--- a/tests/test_doc_indexer_pagination.py
+++ b/tests/test_doc_indexer_pagination.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Phase 2.5 — verify stale-chunk pruning paginates beyond 300-record ChromaDB limit.
+
+Bug: doc_indexer.py _index_document() calls col.get(where={"source_path": ...})
+without limit=/offset pagination.  ChromaDB Cloud returns at most 300 records
+per get() call, so documents producing >300 chunks leave orphan stale chunks
+after re-indexing.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.doc_indexer import _index_document
+from tests.conftest import set_credentials
+
+
+@pytest.fixture
+def sample_file(tmp_path: Path) -> Path:
+    p = tmp_path / "big_doc.md"
+    p.write_text("content for testing pagination")
+    return p
+
+
+def _make_embed_fn(dim: int = 3):
+    """Return an embed_fn that produces deterministic embeddings (no Voyage API)."""
+    def embed_fn(texts: list[str], model: str) -> tuple[list[list[float]], str]:
+        return [[0.1] * dim for _ in texts], model
+    return embed_fn
+
+
+def _make_chunk_fn(num_chunks: int):
+    """Return a chunk_fn that produces *num_chunks* fake chunks."""
+    def chunk_fn(file_path, content_hash, target_model, now_iso, corpus):
+        return [
+            (
+                f"{content_hash[:16]}_{i}",
+                f"chunk text {i}",
+                {
+                    "source_path": str(file_path),
+                    "corpus": corpus,
+                    "store_type": "markdown",
+                    "embedding_model": target_model,
+                    "content_hash": content_hash,
+                    "indexed_at": now_iso,
+                    "chunk_index": i,
+                    "chunk_count": num_chunks,
+                },
+            )
+            for i in range(num_chunks)
+        ]
+    return chunk_fn
+
+
+class TestStaleChunkPaginatedPruning:
+    """Verify that stale-chunk pruning handles >300 existing chunks."""
+
+    def test_prune_stale_beyond_300(self, sample_file: Path, monkeypatch):
+        """Documents with >300 existing chunks must have ALL stale chunks pruned.
+
+        Simulates a re-index where 350 old chunks exist but only 10 new chunks
+        are produced.  All 340 stale chunks must be deleted.
+        """
+        set_credentials(monkeypatch)
+        content_hash = hashlib.sha256(sample_file.read_bytes()).hexdigest()
+
+        # -- Mock T3 collection --
+        mock_col = MagicMock()
+
+        # First col.get() is the staleness check (limit=1) — return empty to force indexing
+        # Subsequent col.get() calls are the pagination loop for stale-chunk pruning
+        old_ids = [f"old_hash_________{i}" for i in range(350)]
+        new_chunk_count = 10
+
+        def mock_get(**kwargs):
+            # First call: staleness check (has limit=1)
+            if kwargs.get("limit") == 1:
+                return {"ids": [], "metadatas": []}
+
+            # Pagination calls for stale-chunk pruning
+            offset = kwargs.get("offset", 0)
+            limit = kwargs.get("limit", 300)
+            page = old_ids[offset:offset + limit]
+            return {"ids": page}
+
+        mock_col.get = mock_get
+        mock_col.delete = MagicMock()
+
+        mock_t3 = MagicMock()
+        mock_t3.get_or_create_collection.return_value = mock_col
+
+        chunk_fn = _make_chunk_fn(new_chunk_count)
+        embed_fn = _make_embed_fn()
+
+        result = _index_document(
+            sample_file,
+            "test_corpus",
+            chunk_fn,
+            t3=mock_t3,
+            embed_fn=embed_fn,
+            force=True,  # bypass staleness check
+        )
+
+        assert result == new_chunk_count
+
+        # Verify delete was called with the stale IDs
+        mock_col.delete.assert_called_once()
+        deleted_ids = mock_col.delete.call_args[1].get("ids") or mock_col.delete.call_args[0][0]
+
+        # All 350 old IDs that are NOT in the new set should be deleted
+        new_ids = {f"{content_hash[:16]}_{i}" for i in range(new_chunk_count)}
+        expected_stale = [eid for eid in old_ids if eid not in new_ids]
+        assert set(deleted_ids) == set(expected_stale)
+        assert len(deleted_ids) == 350  # none of the old IDs match the new hash prefix
+
+    def test_prune_stale_under_300_still_works(self, sample_file: Path, monkeypatch):
+        """Documents with <300 existing chunks still have stale chunks pruned (no regression)."""
+        set_credentials(monkeypatch)
+
+        old_ids = [f"old_hash_________{i}" for i in range(50)]
+        new_chunk_count = 5
+
+        def mock_get(**kwargs):
+            if kwargs.get("limit") == 1:
+                return {"ids": [], "metadatas": []}
+            offset = kwargs.get("offset", 0)
+            limit = kwargs.get("limit", 300)
+            page = old_ids[offset:offset + limit]
+            return {"ids": page}
+
+        mock_col = MagicMock()
+        mock_col.get = mock_get
+        mock_col.delete = MagicMock()
+
+        mock_t3 = MagicMock()
+        mock_t3.get_or_create_collection.return_value = mock_col
+
+        result = _index_document(
+            sample_file,
+            "test_corpus",
+            _make_chunk_fn(new_chunk_count),
+            t3=mock_t3,
+            embed_fn=_make_embed_fn(),
+            force=True,
+        )
+
+        assert result == new_chunk_count
+        mock_col.delete.assert_called_once()
+        deleted_ids = mock_col.delete.call_args[1].get("ids") or mock_col.delete.call_args[0][0]
+        assert len(deleted_ids) == 50  # all old chunks are stale
+
+    def test_no_stale_chunks_no_delete(self, sample_file: Path, monkeypatch):
+        """When all existing chunks match new chunks, delete is not called."""
+        set_credentials(monkeypatch)
+        content_hash = hashlib.sha256(sample_file.read_bytes()).hexdigest()
+        new_chunk_count = 5
+        new_ids = [f"{content_hash[:16]}_{i}" for i in range(new_chunk_count)]
+
+        def mock_get(**kwargs):
+            if kwargs.get("limit") == 1:
+                return {"ids": [], "metadatas": []}
+            offset = kwargs.get("offset", 0)
+            limit = kwargs.get("limit", 300)
+            page = new_ids[offset:offset + limit]
+            return {"ids": page}
+
+        mock_col = MagicMock()
+        mock_col.get = mock_get
+        mock_col.delete = MagicMock()
+
+        mock_t3 = MagicMock()
+        mock_t3.get_or_create_collection.return_value = mock_col
+
+        result = _index_document(
+            sample_file,
+            "test_corpus",
+            _make_chunk_fn(new_chunk_count),
+            t3=mock_t3,
+            embed_fn=_make_embed_fn(),
+            force=True,
+        )
+
+        assert result == new_chunk_count
+        mock_col.delete.assert_not_called()

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -388,7 +388,7 @@ def test_doctor_missing_rg_shows_platform_hints() -> None:
 # ── Four-store database check ─────────────────────────────────────────────────
 
 def test_doctor_four_store_calls_cloud_client_four_times() -> None:
-    """doctor four-store check calls CloudClient exactly four times (one per store type)."""
+    """doctor four-store check calls CloudClient for each store type."""
     runner = _runner()
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
@@ -400,8 +400,8 @@ def test_doctor_four_store_calls_cloud_client_four_times() -> None:
     ):
         result = runner.invoke(main, ["doctor"])
 
-    # 4 for reachability check + 4 for pipeline version check = 8
-    assert mock_cc.call_count == 8
+    # 4 for reachability + 4 for pipeline version + 4 for pagination audit = 12
+    assert mock_cc.call_count == 12
     # All four suffixed database names appear in output
     for suffix in ("_code", "_docs", "_rdr", "_knowledge"):
         assert suffix in result.output

--- a/tests/test_doctor_integrity.py
+++ b/tests/test_doctor_integrity.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for doctor.py Steps 5–7: orphan T1 detection, T2 integrity, ChromaDB pagination."""
+import json
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import chromadb
+import pytest
+
+from nexus.commands.doctor import (
+    _check_orphan_t1,
+    _check_t2_integrity,
+    _check_chroma_pagination,
+)
+from nexus.db.t2 import T2Database
+
+
+# ── Step 5: Orphan T1 process detection ──────────────────────────────────────
+
+class TestCheckOrphanT1:
+    """Tests for _check_orphan_t1."""
+
+    def _make_session_file(self, sessions_dir: Path, name: str, pid: int) -> Path:
+        """Write a minimal JSON session record with the given pid."""
+        record = {
+            "session_id": "test-session",
+            "server_host": "127.0.0.1",
+            "server_port": 12345,
+            "server_pid": pid,
+            "created_at": 9999999999.0,
+        }
+        path = sessions_dir / name
+        path.write_text(json.dumps(record))
+        return path
+
+    def test_no_sessions_dir_reports_ok(self, tmp_path: Path) -> None:
+        """When sessions dir does not exist, check reports ok and returns True."""
+        missing_dir = tmp_path / "sessions"
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.SESSIONS_DIR", missing_dir):
+            result = _check_orphan_t1(lines)
+        assert result is True
+        assert len(lines) == 1
+        assert "✓" in lines[0]
+        assert "no sessions directory" in lines[0]
+
+    def test_empty_sessions_dir_reports_ok(self, tmp_path: Path) -> None:
+        """When sessions dir exists but has no *.session files, check reports ok."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.SESSIONS_DIR", sessions_dir):
+            result = _check_orphan_t1(lines)
+        assert result is True
+        assert "no session files" in lines[0]
+
+    def test_live_process_session_reports_ok(self, tmp_path: Path) -> None:
+        """A session file with our own PID (definitely live) reports ✓."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        self._make_session_file(sessions_dir, "99999.session", os.getpid())
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.SESSIONS_DIR", sessions_dir):
+            result = _check_orphan_t1(lines)
+        assert result is True
+        assert "✓" in lines[0]
+        assert "all processes live" in lines[0]
+
+    def test_dead_pid_session_detected_as_orphan(self, tmp_path: Path) -> None:
+        """A session file with a dead PID is detected as an orphan."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        # PID 2 is init/systemd's child and PID 1 belongs to init — neither
+        # can be killed by a non-root user; use a clearly dead PID instead.
+        # We use a PID that is very unlikely to be alive: 2**22 - 1 (max on Linux).
+        dead_pid = (2 ** 22) - 1
+        self._make_session_file(sessions_dir, f"{dead_pid}.session", dead_pid)
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.SESSIONS_DIR", sessions_dir):
+            result = _check_orphan_t1(lines)
+        # If the PID happens to be live (extremely unlikely), we cannot assert orphan.
+        # But if dead (expected), check the output.
+        try:
+            os.kill(dead_pid, 0)
+            pid_alive = True
+        except OSError:
+            pid_alive = False
+
+        if not pid_alive:
+            assert result is False
+            assert "✗" in lines[0]
+            assert "orphaned" in lines[0]
+            assert "1 orphaned" in lines[0]
+            # Fix hint should be appended
+            assert any("rm" in line for line in lines)
+
+    def test_corrupt_session_file_skipped(self, tmp_path: Path) -> None:
+        """Corrupt (non-JSON) session files are skipped, not counted as orphans."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        (sessions_dir / "corrupt.session").write_text("not-json{{{")
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.SESSIONS_DIR", sessions_dir):
+            result = _check_orphan_t1(lines)
+        # Corrupt files are skipped; no valid sessions remain → "no session files"
+        # is not quite right here — the glob finds the file, so we get "all live"
+        # because the corrupt file has no valid pid entry.
+        assert result is True
+
+    def test_session_without_server_pid_skipped(self, tmp_path: Path) -> None:
+        """Session files missing server_pid field are skipped silently."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        record = {"session_id": "abc", "server_host": "127.0.0.1", "server_port": 1234}
+        (sessions_dir / "nopid.session").write_text(json.dumps(record))
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.SESSIONS_DIR", sessions_dir):
+            result = _check_orphan_t1(lines)
+        assert result is True
+
+    def test_multiple_orphans_count_reported(self, tmp_path: Path) -> None:
+        """When multiple session files have dead PIDs, the count is reported."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        # Two definitely-dead PIDs
+        dead_pids = [(2 ** 22) - 1, (2 ** 22) - 2]
+        alive_check = []
+        for pid in dead_pids:
+            try:
+                os.kill(pid, 0)
+                alive_check.append(True)
+            except OSError:
+                alive_check.append(False)
+            self._make_session_file(sessions_dir, f"{pid}.session", pid)
+
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.SESSIONS_DIR", sessions_dir):
+            result = _check_orphan_t1(lines)
+
+        if all(not a for a in alive_check):
+            # Both dead — expect 2 orphans reported
+            assert result is False
+            assert "2 orphaned" in lines[0]
+
+
+# ── Step 6: T2 database integrity ────────────────────────────────────────────
+
+class TestCheckT2Integrity:
+    """Tests for _check_t2_integrity."""
+
+    def test_db_not_exists_reports_ok(self, tmp_path: Path) -> None:
+        """When memory.db does not exist, check reports 'not created yet' and returns True."""
+        missing_db = tmp_path / "nonexistent.db"
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.default_db_path", return_value=missing_db):
+            result = _check_t2_integrity(lines)
+        assert result is True
+        assert "not created yet" in lines[0]
+        assert "✓" in lines[0]
+
+    def test_valid_t2_database_passes(self, tmp_path: Path) -> None:
+        """A properly created T2 database passes both PRAGMA and FTS5 checks."""
+        db_path = tmp_path / "memory.db"
+        # Create a valid T2 database using the real T2Database class.
+        with T2Database(db_path) as db:
+            db.put(project="test", title="item1", content="hello world", ttl=30)
+
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.default_db_path", return_value=db_path):
+            result = _check_t2_integrity(lines)
+
+        assert result is True
+        assert "✓" in lines[0]
+        assert "PRAGMA ok" in lines[0]
+        assert "FTS5 ok" in lines[0]
+
+    def test_empty_t2_database_passes(self, tmp_path: Path) -> None:
+        """A freshly created but empty T2 database also passes integrity checks."""
+        db_path = tmp_path / "memory.db"
+        with T2Database(db_path):
+            pass  # create schema only
+
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.default_db_path", return_value=db_path):
+            result = _check_t2_integrity(lines)
+
+        assert result is True
+        assert "PRAGMA ok" in lines[0]
+
+    def test_truncated_database_fails_pragma(self, tmp_path: Path) -> None:
+        """A truncated (corrupt) database file fails PRAGMA integrity_check."""
+        db_path = tmp_path / "memory.db"
+        # Create valid DB first.
+        with T2Database(db_path) as db:
+            db.put(project="p", title="t", content="data", ttl=1)
+        # Truncate to 512 bytes — corrupts the SQLite file format.
+        with open(str(db_path), "r+b") as f:
+            f.truncate(512)
+
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.default_db_path", return_value=db_path):
+            result = _check_t2_integrity(lines)
+
+        # A truncated file may raise on connect or on PRAGMA — either way, check fails.
+        assert result is False
+        assert "✗" in lines[0]
+
+    def test_unparseable_database_fails_gracefully(self, tmp_path: Path) -> None:
+        """A file that is not a SQLite database at all fails gracefully (no exception raised)."""
+        db_path = tmp_path / "memory.db"
+        db_path.write_bytes(b"this is not sqlite" * 100)
+
+        lines: list[str] = []
+        with patch("nexus.commands.doctor.default_db_path", return_value=db_path):
+            result = _check_t2_integrity(lines)
+
+        assert result is False
+        assert "✗" in lines[0]
+
+
+# ── Step 7: ChromaDB pagination audit ────────────────────────────────────────
+
+class TestCheckChromaPagination:
+    """Tests for _check_chroma_pagination using EphemeralClient."""
+
+    @pytest.fixture()
+    def ephemeral_client(self):
+        """Return a ChromaDB client with all pre-existing collections removed."""
+        client = chromadb.EphemeralClient()
+        # Clean up any collections leaked from previous tests (singleton client)
+        for col in client.list_collections():
+            client.delete_collection(col.name)
+        return client
+
+    def test_no_collections_reports_ok(self, ephemeral_client) -> None:
+        """When there are no non-empty collections, check reports ok."""
+        lines: list[str] = []
+        result = _check_chroma_pagination(lines, ephemeral_client, "test_db")
+        assert result is True
+        assert "✓" in lines[0]
+        assert "no non-empty" in lines[0]
+
+    def test_empty_collection_reports_ok(self, ephemeral_client) -> None:
+        """An empty collection is skipped; check reports ok (nothing to audit)."""
+        ephemeral_client.create_collection("empty_col")
+        lines: list[str] = []
+        result = _check_chroma_pagination(lines, ephemeral_client, "test_db")
+        assert result is True
+        assert "no non-empty" in lines[0]
+
+    def test_single_page_collection_passes(self, ephemeral_client) -> None:
+        """A collection with fewer than 300 records: count() == paginated result."""
+        col = ephemeral_client.create_collection("small_col")
+        n = 10
+        col.add(
+            ids=[f"id{i}" for i in range(n)],
+            documents=[f"doc {i}" for i in range(n)],
+        )
+        lines: list[str] = []
+        result = _check_chroma_pagination(lines, ephemeral_client, "test_db")
+        assert result is True
+        assert "✓" in lines[0]
+        assert f"count={n}" in lines[0]
+        assert f"paginated={n}" in lines[0]
+
+    def test_multi_page_collection_passes(self, ephemeral_client) -> None:
+        """A collection with >300 records paginates correctly and passes."""
+        col = ephemeral_client.create_collection("large_col")
+        n = 350
+        col.add(
+            ids=[f"id{i}" for i in range(n)],
+            documents=[f"document number {i}" for i in range(n)],
+        )
+        lines: list[str] = []
+        result = _check_chroma_pagination(lines, ephemeral_client, "test_db")
+        assert result is True
+        assert f"count={n}" in lines[0]
+        assert f"paginated={n}" in lines[0]
+
+    def test_count_mismatch_fails(self, ephemeral_client) -> None:
+        """When mocked count() disagrees with paginated get(), check returns False."""
+        col = ephemeral_client.create_collection("mismatch_col")
+        n = 5
+        col.add(
+            ids=[f"id{i}" for i in range(n)],
+            documents=[f"doc {i}" for i in range(n)],
+        )
+        # Wrap the real collection in a mock that inflates count()
+        mock_col = MagicMock(wraps=col)
+        mock_col.name = col.name
+        mock_col.count.return_value = n + 100  # inflated — pagination will return only n
+
+        mock_client = MagicMock()
+        mock_client.list_collections.return_value = [mock_col]
+
+        lines: list[str] = []
+        result = _check_chroma_pagination(lines, mock_client, "test_db")
+        assert result is False
+        assert "✗" in lines[0]
+
+    def test_list_collections_exception_fails_gracefully(self) -> None:
+        """If list_collections() raises, check returns False without propagating."""
+        bad_client = MagicMock()
+        bad_client.list_collections.side_effect = RuntimeError("network error")
+        lines: list[str] = []
+        result = _check_chroma_pagination(lines, bad_client, "bad_db")
+        assert result is False
+        assert "✗" in lines[0]
+        assert "list failed" in lines[0]
+
+    def test_only_one_collection_audited(self, ephemeral_client) -> None:
+        """Only the first non-empty collection is spot-checked — not all of them."""
+        for i in range(3):
+            col = ephemeral_client.create_collection(f"col_{i}")
+            col.add(ids=[f"id{i}"], documents=[f"doc {i}"])
+        lines: list[str] = []
+        _check_chroma_pagination(lines, ephemeral_client, "test_db")
+        # Only one line added (one audit, not three).
+        assert len(lines) == 1

--- a/tests/test_doctor_integrity.py
+++ b/tests/test_doctor_integrity.py
@@ -71,31 +71,23 @@ class TestCheckOrphanT1:
 
     def test_dead_pid_session_detected_as_orphan(self, tmp_path: Path) -> None:
         """A session file with a dead PID is detected as an orphan."""
+        import subprocess
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()
-        # PID 2 is init/systemd's child and PID 1 belongs to init — neither
-        # can be killed by a non-root user; use a clearly dead PID instead.
-        # We use a PID that is very unlikely to be alive: 2**22 - 1 (max on Linux).
-        dead_pid = (2 ** 22) - 1
+        # Spawn a short-lived process and wait for it to exit — guarantees a dead PID.
+        proc = subprocess.Popen(["true"])
+        proc.wait()
+        dead_pid = proc.pid
         self._make_session_file(sessions_dir, f"{dead_pid}.session", dead_pid)
         lines: list[str] = []
         with patch("nexus.commands.doctor.SESSIONS_DIR", sessions_dir):
             result = _check_orphan_t1(lines)
-        # If the PID happens to be live (extremely unlikely), we cannot assert orphan.
-        # But if dead (expected), check the output.
-        try:
-            os.kill(dead_pid, 0)
-            pid_alive = True
-        except OSError:
-            pid_alive = False
-
-        if not pid_alive:
-            assert result is False
-            assert "✗" in lines[0]
-            assert "orphaned" in lines[0]
-            assert "1 orphaned" in lines[0]
-            # Fix hint should be appended
-            assert any("rm" in line for line in lines)
+        assert result is False
+        assert "✗" in lines[0]
+        assert "orphaned" in lines[0]
+        assert "1 orphaned" in lines[0]
+        # Fix hint should be appended
+        assert any("rm" in line for line in lines)
 
     def test_corrupt_session_file_skipped(self, tmp_path: Path) -> None:
         """Corrupt (non-JSON) session files are skipped, not counted as orphans."""
@@ -123,27 +115,24 @@ class TestCheckOrphanT1:
 
     def test_multiple_orphans_count_reported(self, tmp_path: Path) -> None:
         """When multiple session files have dead PIDs, the count is reported."""
+        import subprocess
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()
-        # Two definitely-dead PIDs
-        dead_pids = [(2 ** 22) - 1, (2 ** 22) - 2]
-        alive_check = []
+        # Spawn two short-lived processes to get guaranteed-dead PIDs
+        dead_pids = []
+        for _ in range(2):
+            proc = subprocess.Popen(["true"])
+            proc.wait()
+            dead_pids.append(proc.pid)
         for pid in dead_pids:
-            try:
-                os.kill(pid, 0)
-                alive_check.append(True)
-            except OSError:
-                alive_check.append(False)
             self._make_session_file(sessions_dir, f"{pid}.session", pid)
 
         lines: list[str] = []
         with patch("nexus.commands.doctor.SESSIONS_DIR", sessions_dir):
             result = _check_orphan_t1(lines)
 
-        if all(not a for a in alive_check):
-            # Both dead — expect 2 orphans reported
-            assert result is False
-            assert "2 orphaned" in lines[0]
+        assert result is False
+        assert "2 orphaned" in lines[0]
 
 
 # ── Step 6: T2 database integrity ────────────────────────────────────────────

--- a/tests/test_doctor_integrity.py
+++ b/tests/test_doctor_integrity.py
@@ -67,7 +67,7 @@ class TestCheckOrphanT1:
             result = _check_orphan_t1(lines)
         assert result is True
         assert "✓" in lines[0]
-        assert "all processes live" in lines[0]
+        assert "no orphans detected" in lines[0]
 
     def test_dead_pid_session_detected_as_orphan(self, tmp_path: Path) -> None:
         """A session file with a dead PID is detected as an orphan."""

--- a/tests/test_silent_error_logging.py
+++ b/tests/test_silent_error_logging.py
@@ -126,13 +126,22 @@ def test_ppid_proc_read_failed_logs_debug():
     if sys.platform != "linux":
         pytest.skip("_ppid_of reads /proc, only testable on Linux")
 
+    import os
     from nexus.session import _ppid_of
 
-    with patch("builtins.open", side_effect=OSError("no such file")):
-        with capture_logs() as cap:
-            result = _ppid_of(99999)
+    # Use our own PID so /proc/{pid}/status exists on Linux.
+    pid = os.getpid()
+    original_read_text = Path.read_text
 
-    assert result is None
+    def failing_read_text(self, *args, **kwargs):
+        if str(self).startswith("/proc/"):
+            raise OSError("simulated permission denied")
+        return original_read_text(self, *args, **kwargs)
+
+    with patch.object(Path, "read_text", failing_read_text):
+        with capture_logs() as cap:
+            _ppid_of(pid)
+
     assert any(e["event"] == "ppid_proc_read_failed" for e in cap)
 
 
@@ -215,7 +224,10 @@ def test_hook_detection_failed_logs_debug(tmp_path):
     subprocess.run(["git", "init", str(tmp_path)], capture_output=True)
     (tmp_path / "test.txt").write_text("hello")
 
-    with patch("nexus.commands.hooks._effective_hooks_dir", side_effect=RuntimeError("broken")):
+    # Mock index_repository to skip the actual indexing (needs API keys on CI),
+    # and _effective_hooks_dir to trigger the hook detection failure path.
+    with patch("nexus.indexer.index_repository", return_value={}), \
+         patch("nexus.commands.hooks._effective_hooks_dir", side_effect=RuntimeError("broken")):
         with capture_logs() as cap:
             runner = CliRunner()
             runner.invoke(index_repo_cmd, [str(tmp_path)])

--- a/tests/test_silent_error_logging.py
+++ b/tests/test_silent_error_logging.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Phase 1 — verify formerly-silent catch blocks now emit structlog events."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+
+@pytest.fixture(autouse=True)
+def _enable_debug_logging():
+    """Temporarily allow DEBUG-level structlog events so capture_logs() can see them."""
+    structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG))
+    yield
+    structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(logging.WARNING))
+
+
+# ── Site 1: indexer.py _extract_name_from_node decode (field-name path) ───────
+
+def test_extract_name_decode_failed_logs_debug():
+    """Site 1: UnicodeDecodeError in child_by_field_name('name').text.decode."""
+    from nexus.indexer import _extract_name_from_node
+
+    node = MagicMock()
+    node.type = "function_definition"
+    # child_by_field_name("name") returns a child whose .text.decode raises
+    bad_child = MagicMock()
+    bad_child.text = MagicMock()
+    bad_child.text.decode = MagicMock(side_effect=UnicodeDecodeError("utf-8", b"", 0, 1, "bad"))
+
+    def field_lookup(name):
+        if name == "name":
+            return bad_child
+        return None
+
+    node.child_by_field_name = field_lookup
+    node.children = []
+
+    with capture_logs() as cap:
+        result = _extract_name_from_node(node)
+
+    assert result == ""
+    assert any(e["event"] == "extract_name_decode_failed" for e in cap)
+
+
+# ── Site 2: indexer.py _extract_name_from_node decode (children path) ─────────
+
+def test_extract_name_child_decode_failed_logs_debug():
+    """Site 2: UnicodeDecodeError in children scan path."""
+    from nexus.indexer import _extract_name_from_node
+
+    node = MagicMock()
+    node.type = "function_definition"
+    node.child_by_field_name = MagicMock(return_value=None)
+
+    bad_child = MagicMock()
+    bad_child.type = "identifier"
+    bad_child.text = MagicMock()
+    bad_child.text.decode = MagicMock(side_effect=AttributeError("no text"))
+    node.children = [bad_child]
+
+    with capture_logs() as cap:
+        result = _extract_name_from_node(node)
+
+    assert result == ""
+    assert any(e["event"] == "extract_name_child_decode_failed" for e in cap)
+
+
+# ── Site 3: indexer.py get_parser failure ─────────────────────────────────────
+
+def test_get_parser_failed_logs_warning():
+    """Site 3: get_parser() failure emits warning-level log."""
+    from nexus.indexer import _extract_context
+
+    with patch("tree_sitter_language_pack.get_parser", side_effect=RuntimeError("no parser")):
+        with capture_logs() as cap:
+            result = _extract_context(b"x = 1", "python", 0, 0)
+
+    assert result == ("", "")
+    assert any(
+        e["event"] == "get_parser_failed" and e["log_level"] == "warning"
+        for e in cap
+    )
+
+
+# ── Site 4: indexer.py tree parse failure ─────────────────────────────────────
+
+def test_tree_parse_failed_logs_debug():
+    """Site 4: parser.parse() failure emits debug-level log."""
+    from nexus.indexer import _extract_context
+
+    mock_parser = MagicMock()
+    mock_parser.parse.side_effect = RuntimeError("bad source")
+
+    with patch("tree_sitter_language_pack.get_parser", return_value=mock_parser):
+        with capture_logs() as cap:
+            result = _extract_context(b"x = 1", "python", 0, 0)
+
+    assert result == ("", "")
+    assert any(e["event"] == "tree_parse_failed" for e in cap)
+
+
+# ── Site 5: indexer.py _current_head failure ──────────────────────────────────
+
+def test_current_head_failed_logs_debug():
+    """Site 5: _current_head() OSError emits debug-level log."""
+    from nexus.indexer import _current_head
+
+    with patch("nexus.indexer.subprocess.run", side_effect=OSError("git not found")):
+        with capture_logs() as cap:
+            result = _current_head(Path("/fake/repo"))
+
+    assert result == ""
+    assert any(e["event"] == "current_head_failed" for e in cap)
+
+
+# ── Site 6: session.py _ppid_of failure ───────────────────────────────────────
+
+def test_ppid_proc_read_failed_logs_debug():
+    """Site 6: _ppid_of() /proc read failure emits debug-level log."""
+    import sys
+    if sys.platform != "linux":
+        pytest.skip("_ppid_of reads /proc, only testable on Linux")
+
+    from nexus.session import _ppid_of
+
+    with patch("builtins.open", side_effect=OSError("no such file")):
+        with capture_logs() as cap:
+            result = _ppid_of(99999)
+
+    assert result is None
+    assert any(e["event"] == "ppid_proc_read_failed" for e in cap)
+
+
+# ── Site 8: hooks.py _infer_repo failure ──────────────────────────────────────
+
+def test_infer_repo_git_failed_logs_debug():
+    """Site 8: _infer_repo() git failure emits debug-level log."""
+    from nexus.hooks import _infer_repo
+
+    with patch("nexus.hooks.subprocess.run", side_effect=RuntimeError("git broken")):
+        with capture_logs() as cap:
+            result = _infer_repo()
+
+    # Falls back to cwd name
+    assert isinstance(result, str) and len(result) > 0
+    assert any(e["event"] == "infer_repo_git_failed" for e in cap)
+
+
+# ── Site 10: commands/hook.py stdin parse failure ─────────────────────────────
+
+def test_session_start_stdin_parse_failed_logs_debug():
+    """Site 10: stdin JSON parse failure in session_start_cmd emits debug log."""
+    from nexus.commands.hook import session_start_cmd
+    from click.testing import CliRunner
+
+    runner = CliRunner()
+    with capture_logs() as cap:
+        runner.invoke(session_start_cmd, input="not json\n")
+
+    assert any(e["event"] == "session_start_stdin_parse_failed" for e in cap)
+
+
+# ── Site 12: commands/doctor.py registry load failure ─────────────────────────
+
+def test_doctor_registry_load_failed_logs_warning():
+    """Site 12: corrupt registry emits warning-level log in doctor."""
+    from nexus.commands.doctor import RepoRegistry, doctor_cmd
+    from click.testing import CliRunner
+
+    with patch.object(RepoRegistry, "__init__", side_effect=RuntimeError("corrupt")):
+        with capture_logs() as cap:
+            runner = CliRunner()
+            runner.invoke(doctor_cmd)
+
+    assert any(
+        e["event"] == "doctor_registry_load_failed" and e["log_level"] == "warning"
+        for e in cap
+    )
+
+
+# ── Site 13: md_chunker.py frontmatter parse failure ─────────────────────────
+
+def test_frontmatter_parse_failed_logs_warning():
+    """Site 13: invalid YAML frontmatter emits warning-level log."""
+    from nexus.md_chunker import parse_frontmatter
+
+    bad_md = "---\ninvalid: yaml: [unclosed\n---\n\n# Body\n\nText here."
+
+    with capture_logs() as cap:
+        fm, body = parse_frontmatter(bad_md)
+
+    assert fm == {}
+    assert any(
+        e["event"] == "frontmatter_parse_failed" and e["log_level"] == "warning"
+        for e in cap
+    )
+
+
+# ── Site 14: classifier.py _has_shebang failure ──────────────────────────────
+
+def test_has_shebang_read_failed_logs_debug():
+    """Site 14: OSError in _has_shebang emits debug-level log."""
+    from nexus.classifier import _has_shebang
+
+    fake_path = Path("/nonexistent/file.py")
+
+    with capture_logs() as cap:
+        result = _has_shebang(fake_path)
+
+    assert result is False
+    assert any(e["event"] == "has_shebang_read_failed" for e in cap)

--- a/tests/test_silent_error_logging.py
+++ b/tests/test_silent_error_logging.py
@@ -136,6 +136,22 @@ def test_ppid_proc_read_failed_logs_debug():
     assert any(e["event"] == "ppid_proc_read_failed" for e in cap)
 
 
+# ── Site 7: session.py sweep_stale_sessions corrupt file ──────────────────────
+
+def test_sweep_corrupt_session_file_logs_debug(tmp_path):
+    """Site 7: corrupt session file in sweep_stale_sessions emits debug-level log."""
+    from nexus.session import sweep_stale_sessions
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    (sessions_dir / "999.session").write_text("not-json{{{")
+
+    with capture_logs() as cap:
+        sweep_stale_sessions(sessions_dir=sessions_dir)
+
+    assert any(e["event"] == "sweep_corrupt_session_file" for e in cap)
+
+
 # ── Site 8: hooks.py _infer_repo failure ──────────────────────────────────────
 
 def test_infer_repo_git_failed_logs_debug():
@@ -149,6 +165,28 @@ def test_infer_repo_git_failed_logs_debug():
     # Falls back to cwd name
     assert isinstance(result, str) and len(result) > 0
     assert any(e["event"] == "infer_repo_git_failed" for e in cap)
+
+
+# ── Site 9: hooks.py session_end own record corrupt ───────────────────────────
+
+def test_session_end_own_record_corrupt_logs_debug(tmp_path):
+    """Site 9: corrupt own session file in session_end emits debug-level log."""
+    import os
+    from nexus.hooks import session_end
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    # Write a corrupt file named after this process's parent PID
+    ppid = os.getppid()
+    corrupt_file = sessions_dir / f"{ppid}.session"
+    corrupt_file.write_text("not-valid-json{{{")
+
+    with patch("nexus.hooks.SESSIONS_DIR", sessions_dir), \
+         patch("nexus.hooks.find_ancestor_session", return_value=None):
+        with capture_logs() as cap:
+            session_end()
+
+    assert any(e["event"] == "session_end_own_record_corrupt" for e in cap)
 
 
 # ── Site 10: commands/hook.py stdin parse failure ─────────────────────────────

--- a/tests/test_silent_error_logging.py
+++ b/tests/test_silent_error_logging.py
@@ -203,6 +203,26 @@ def test_session_start_stdin_parse_failed_logs_debug():
     assert any(e["event"] == "session_start_stdin_parse_failed" for e in cap)
 
 
+# ── Site 11: commands/index.py hook detection failure ─────────────────────────
+
+def test_hook_detection_failed_logs_debug(tmp_path):
+    """Site 11: hook detection exception in index_repo_cmd emits debug log."""
+    from nexus.commands.index import index_repo_cmd
+    from click.testing import CliRunner
+
+    # Create a minimal git repo so the command doesn't fail before reaching hook detection
+    import subprocess
+    subprocess.run(["git", "init", str(tmp_path)], capture_output=True)
+    (tmp_path / "test.txt").write_text("hello")
+
+    with patch("nexus.commands.hooks._effective_hooks_dir", side_effect=RuntimeError("broken")):
+        with capture_logs() as cap:
+            runner = CliRunner()
+            runner.invoke(index_repo_cmd, [str(tmp_path)])
+
+    assert any(e["event"] == "hook_detection_failed" for e in cap)
+
+
 # ── Site 12: commands/doctor.py registry load failure ─────────────────────────
 
 def test_doctor_registry_load_failed_logs_warning():


### PR DESCRIPTION
## Summary

- **Phase 1**: Add structlog logging to 14 silent catch-and-pass blocks across 8 modules (3 warning-level, 11 debug-level)
- **Phase 2**: Expand `nx doctor` with orphan T1 detection, T2 FTS5 integrity check, and ChromaDB pagination audit
- **Phase 2.5**: Fix P1 bug in `doc_indexer.py` — stale-chunk pruning now paginates beyond 300-record ChromaDB limit
- **Phase 3**: Annotate 9 intentional silent catches with `# intentional: <reason>` rationale comments

## Test plan

- [ ] 10 new tests verify all 14 logging additions emit correct structlog events at correct levels
- [ ] 19 new tests cover 3 nx doctor integrity checks (orphan T1, T2 SQLite/FTS5, ChromaDB pagination)
- [ ] 3 new tests verify paginated stale-chunk pruning handles >300 chunks
- [ ] 2067 total unit tests pass, 0 failures
- [ ] No API keys required — all tests use EphemeralClient + mocks

References: nexus-56u1, RDR-030