### PR TITLE
fix: direct log output to stderr; suppress warnings in structured search output

### DIFF
--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import logging
+import sys
 
 import click
 import structlog
@@ -17,7 +18,7 @@ from nexus.commands.store import store
 
 def _configure_logging(verbose: bool) -> None:
     level = logging.DEBUG if verbose else logging.WARNING
-    logging.basicConfig(level=level, format="%(message)s")
+    logging.basicConfig(level=level, format="%(message)s", stream=sys.stderr, force=True)
     structlog.configure(
         wrapper_class=structlog.make_filtering_bound_logger(level),
     )

--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+import logging
 import os
 from pathlib import Path
 
 import click
+import structlog
 
 from nexus.config import load_config
 from nexus.corpus import resolve_corpus
@@ -156,6 +158,15 @@ def search_cmd(
     --corpus may be a prefix (code, docs, knowledge) or a fully-qualified
     collection name (code__myrepo).  Repeat --corpus to search multiple corpora.
     """
+    # Structured output modes (--json, --vimgrep, --files, --compact) must
+    # produce clean machine-parseable output.  Suppress log messages below
+    # ERROR so warnings don't pollute stdout.
+    if json_out or vimgrep or files_only or compact:
+        logging.getLogger().setLevel(logging.ERROR)
+        structlog.configure(
+            wrapper_class=structlog.make_filtering_bound_logger(logging.ERROR),
+        )
+
     # -C N = -B N -A N (grep semantics: before + after)
     if lines_context:
         lines_before = lines_context


### PR DESCRIPTION
## Summary
- Log messages now go to stderr via `logging.basicConfig(stream=sys.stderr, force=True)` — they should never pollute stdout
- Structured output modes (`--json`, `--vimgrep`, `--files`, `--compact`) suppress log warnings below ERROR so machine-parseable output is clean
- Root cause: RDR-030 added structlog warnings that leaked into `CliRunner`'s captured stdout, breaking `test_cli_search_json_output`

## Test plan
- [x] `test_cli_search_json_output` passes
- [x] Full test suite: 2085 passed, 9 skipped
- [ ] CI green