### PR TITLE
feat(store): collection export/import for T3 backup and migration (RDR-031)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
     "click>=8.1",
     "llama-index-core==0.12.7",
     "markdown-it-py>=4.0.0",
+    "msgpack>=1.0",
+    "numpy>=1.24",
     "pymupdf>=1.26.6",
     "pyyaml>=6.0",
     "structlog>=24.0",

--- a/src/nexus/commands/store.py
+++ b/src/nexus/commands/store.py
@@ -219,3 +219,159 @@ def expire_cmd() -> None:
     """Remove T3 knowledge__ entries whose TTL has expired."""
     count = _t3().expire()
     click.echo(f"Expired {count} {'entry' if count == 1 else 'entries'}.")
+
+
+@store.command("export")
+@click.argument("collection", default="", required=False)
+@click.option("--output", "-o", default=None,
+              help="Output file path (.nxexp) or directory (when --all).")
+@click.option("--include", "includes", multiple=True,
+              help="Glob pattern matched against source_path. Repeat for OR logic.")
+@click.option("--exclude", "excludes", multiple=True,
+              help="Glob pattern matched against source_path. Repeat for OR logic.")
+@click.option("--all", "export_all", is_flag=True, default=False,
+              help="Export every collection to separate .nxexp files.")
+def export_cmd(
+    collection: str,
+    output: str | None,
+    includes: tuple[str, ...],
+    excludes: tuple[str, ...],
+    export_all: bool,
+) -> None:
+    """Export a T3 collection to a portable .nxexp backup file.
+
+    The export preserves all documents, metadata, and embeddings, enabling
+    later import without re-embedding (saves Voyage AI API costs).
+
+    \b
+    Examples:
+      nx store export code__myrepo -o myrepo-backup.nxexp
+      nx store export code__myrepo --include "*.py" -o python-only.nxexp
+      nx store export --all
+      nx store export --all -o /path/to/backup-dir/
+    """
+    from datetime import date
+
+    from nexus.corpus import t3_collection_name as _t3col
+    from nexus.errors import EmbeddingModelMismatch, FormatVersionError
+    from nexus.exporter import export_collection
+
+    if export_all and collection:
+        raise click.UsageError("Cannot specify COLLECTION together with --all.")
+    if not export_all and not collection:
+        raise click.UsageError("Provide a COLLECTION name or use --all.")
+
+    db = _t3()
+
+    if export_all:
+        # One .nxexp file per collection; output may be a directory.
+        out_dir = Path(output) if output else Path.cwd()
+        if output and not out_dir.exists():
+            out_dir.mkdir(parents=True, exist_ok=True)
+        collections_info = db.list_collections()
+        if not collections_info:
+            click.echo("No collections found.")
+            return
+        today = date.today().isoformat()
+        total_exported = 0
+        for info in collections_info:
+            col_name: str = info["name"]
+            fname = f"{col_name}-{today}.nxexp"
+            out_path = out_dir / fname
+            try:
+                result = export_collection(
+                    db=db,
+                    collection_name=col_name,
+                    output_path=out_path,
+                    includes=includes,
+                    excludes=excludes,
+                )
+                click.echo(
+                    f"Exported {result['exported_count']:>6} records  "
+                    f"{col_name}  ->  {out_path.name}"
+                )
+                total_exported += result["exported_count"]
+            except Exception as exc:
+                click.echo(f"ERROR exporting {col_name}: {exc}", err=True)
+        click.echo(f"\nTotal: {total_exported} records across {len(collections_info)} collections.")
+    else:
+        col_name = collection if "__" in collection else _t3col(collection)
+        out_path = Path(output) if output else Path(f"{col_name}.nxexp")
+        try:
+            result = export_collection(
+                db=db,
+                collection_name=col_name,
+                output_path=out_path,
+                includes=includes,
+                excludes=excludes,
+            )
+        except (EmbeddingModelMismatch, FormatVersionError) as exc:
+            raise click.ClickException(str(exc)) from exc
+        except Exception as exc:
+            raise click.ClickException(f"Export failed: {exc}") from exc
+
+        size_kb = result["file_bytes"] / 1024
+        click.echo(
+            f"Exported {result['exported_count']} records from {col_name} "
+            f"-> {out_path}  ({size_kb:.1f} KB, {result['elapsed_seconds']:.1f}s)"
+        )
+
+
+@store.command("import")
+@click.argument("file", type=click.Path(exists=True))
+@click.option("--collection", "-c", default=None,
+              help="Override target collection name (default: from export header).")
+@click.option("--remap", "remaps", multiple=True,
+              help="Path substitution: /old/path:/new/path  (repeat for multiple remaps).")
+def import_cmd(
+    file: str,
+    collection: str | None,
+    remaps: tuple[str, ...],
+) -> None:
+    """Import a .nxexp export file into T3.
+
+    Embedding model validation is enforced: importing a code__ export into a
+    docs__ collection (or vice versa) is rejected to prevent silent corruption
+    of the target collection's vector space.
+
+    \b
+    Examples:
+      nx store import myrepo-backup.nxexp
+      nx store import myrepo-backup.nxexp --remap "/old/path:/new/path"
+      nx store import myrepo-backup.nxexp --collection code__newname
+    """
+    from nexus.errors import EmbeddingModelMismatch, FormatVersionError
+    from nexus.exporter import import_collection
+
+    # Parse --remap options (format: old:new).
+    parsed_remaps: list[tuple[str, str]] = []
+    for remap in remaps:
+        if ":" not in remap:
+            raise click.UsageError(
+                f"--remap requires old:new format (e.g. /old/path:/new/path), "
+                f"got: {remap!r}"
+            )
+        old, new = remap.split(":", 1)
+        parsed_remaps.append((old, new))
+
+    db = _t3()
+    input_path = Path(file)
+
+    try:
+        result = import_collection(
+            db=db,
+            input_path=input_path,
+            target_collection=collection,
+            remaps=parsed_remaps,
+        )
+    except FormatVersionError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except EmbeddingModelMismatch as exc:
+        raise click.ClickException(str(exc)) from exc
+    except Exception as exc:
+        raise click.ClickException(f"Import failed: {exc}") from exc
+
+    click.echo(
+        f"Imported {result['imported_count']} records into "
+        f"{result['collection_name']}  ({result['elapsed_seconds']:.1f}s)"
+    )

--- a/src/nexus/errors.py
+++ b/src/nexus/errors.py
@@ -22,3 +22,19 @@ class CredentialsMissingError(NexusError):
 
 class CollectionNotFoundError(NexusError):
     """The requested ChromaDB collection does not exist."""
+
+
+class EmbeddingModelMismatch(NexusError):
+    """Export embedding model is incompatible with the target collection's model.
+
+    Importing an export produced with one embedding model into a collection
+    that uses a different model would silently corrupt search quality
+    (cross-model cosine similarity ≈ 0.05, i.e. random noise).
+    """
+
+
+class FormatVersionError(NexusError):
+    """Export file format version is newer than this version of Nexus supports.
+
+    Upgrade Nexus to import this file.
+    """

--- a/src/nexus/exporter.py
+++ b/src/nexus/exporter.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Collection export/import for T3 ChromaDB backup and migration.
+
+Format: ``.nxexp`` (Nexus Export)
+- Line 1: JSON header (newline-terminated) containing format metadata
+- Remainder: gzip-compressed msgpack stream of records
+
+Each record is a dict:
+    {"id": str, "document": str, "metadata": dict, "embedding": bytes}
+
+Embeddings are stored as little-endian float32 bytes (numpy tostring).
+"""
+from __future__ import annotations
+
+import fnmatch
+import gzip
+import json
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import msgpack
+import numpy as np
+import structlog
+
+from nexus.corpus import index_model_for_collection
+from nexus.db.chroma_quotas import QUOTAS
+from nexus.errors import EmbeddingModelMismatch, FormatVersionError
+from nexus.retry import _chroma_with_retry
+
+if TYPE_CHECKING:
+    from nexus.db.t3 import T3Database
+
+_log = structlog.get_logger(__name__)
+
+#: The format version written by this implementation.
+FORMAT_VERSION: int = 1
+
+#: The maximum format version this importer can read.
+#: If an export file's format_version > this, import MUST abort.
+MAX_SUPPORTED_FORMAT_VERSION: int = 1
+
+#: Pipeline version tag embedded in every export header.
+_PIPELINE_VERSION: str = "nexus-1"
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _apply_filter(
+    source_path: str | None,
+    includes: tuple[str, ...],
+    excludes: tuple[str, ...],
+) -> bool:
+    """Return True if this record should be included in the export.
+
+    Entries without a source_path (e.g. nx store put entries) pass
+    unconditionally regardless of include/exclude patterns.
+
+    Include logic (OR): if any pattern matches, the entry is included.
+    Exclude logic (AND): if any pattern matches, the entry is excluded.
+    Excludes are evaluated after includes.
+    """
+    if source_path is None:
+        # No source_path — pass through unconditionally.
+        return True
+
+    if includes:
+        if not any(fnmatch.fnmatch(source_path, p) for p in includes):
+            return False
+
+    if excludes:
+        if any(fnmatch.fnmatch(source_path, p) for p in excludes):
+            return False
+
+    return True
+
+
+def _apply_remap(source_path: str, remaps: list[tuple[str, str]]) -> str:
+    """Apply the first matching prefix remap to *source_path*.
+
+    Each element of *remaps* is a ``(old_prefix, new_prefix)`` pair.
+    The first matching pair wins; subsequent pairs are not evaluated.
+    """
+    for old, new in remaps:
+        if source_path.startswith(old):
+            return new + source_path[len(old):]
+    return source_path
+
+
+def export_collection(
+    db: "T3Database",
+    collection_name: str,
+    output_path: Path,
+    includes: tuple[str, ...] = (),
+    excludes: tuple[str, ...] = (),
+) -> dict:
+    """Export *collection_name* to *output_path* in ``.nxexp`` format.
+
+    Parameters
+    ----------
+    db:
+        A connected T3Database instance.
+    collection_name:
+        Fully-qualified collection name (e.g. ``code__myrepo``).
+    output_path:
+        Destination file path.  Parent directories must exist.
+    includes:
+        Glob patterns matched against ``source_path`` metadata.
+        If non-empty, only entries whose source_path matches at least one
+        pattern are exported.  Entries without source_path pass through.
+    excludes:
+        Glob patterns matched against ``source_path`` metadata.
+        Entries whose source_path matches any pattern are excluded.
+        Entries without source_path are never excluded.
+
+    Returns
+    -------
+    dict with keys: collection_name, record_count, exported_count,
+    file_bytes, elapsed_seconds, output_path.
+    """
+    t0 = time.monotonic()
+
+    # Access the underlying ChromaDB collection directly to retrieve embeddings.
+    col = db._client_for(collection_name).get_collection(collection_name)
+    total_count = _chroma_with_retry(col.count)
+
+    embedding_model = index_model_for_collection(collection_name)
+
+    _log.info(
+        "export_start",
+        collection=collection_name,
+        total_count=total_count,
+        embedding_model=embedding_model,
+        output=str(output_path),
+    )
+
+    # Phase 1: paginated retrieval of all records.
+    page_size = QUOTAS.MAX_RECORDS_PER_WRITE
+    all_records: list[dict] = []
+    offset = 0
+
+    while True:
+        result = _chroma_with_retry(
+            col.get,
+            include=["documents", "metadatas", "embeddings"],
+            limit=page_size,
+            offset=offset,
+        )
+        page_ids = result["ids"]
+        if not page_ids:
+            break
+
+        for rec_id, doc, meta, emb in zip(
+            page_ids,
+            result["documents"],
+            result["metadatas"],
+            result["embeddings"],
+        ):
+            source_path = (meta or {}).get("source_path")
+            if not _apply_filter(source_path, includes, excludes):
+                continue
+            # Store embedding as bytes (float32 little-endian)
+            emb_bytes: bytes = np.array(emb, dtype=np.float32).tobytes()
+            all_records.append(
+                {
+                    "id": rec_id,
+                    "document": doc,
+                    "metadata": meta or {},
+                    "embedding": emb_bytes,
+                }
+            )
+
+        offset += len(page_ids)
+        if len(page_ids) < page_size:
+            break  # last page
+
+    exported_count = len(all_records)
+    embedding_dim = 0
+    if all_records:
+        first_emb = all_records[0]["embedding"]
+        embedding_dim = len(first_emb) // 4  # float32 = 4 bytes each
+
+    # Determine database_type from collection prefix.
+    prefix = collection_name.split("__")[0] if "__" in collection_name else "knowledge"
+
+    header: dict = {
+        "format_version": FORMAT_VERSION,
+        "collection_name": collection_name,
+        "database_type": prefix,
+        "embedding_model": embedding_model,
+        "record_count": exported_count,
+        "embedding_dim": embedding_dim,
+        "exported_at": _now_iso(),
+        "pipeline_version": _PIPELINE_VERSION,
+    }
+
+    # Phase 2: write header + gzip-compressed msgpack body.
+    header_line = json.dumps(header).encode() + b"\n"
+
+    with open(output_path, "wb") as f:
+        f.write(header_line)
+        with gzip.GzipFile(fileobj=f, mode="wb") as gz:
+            for record in all_records:
+                gz.write(msgpack.packb(record, use_bin_type=True))
+
+    file_bytes = output_path.stat().st_size
+    elapsed = time.monotonic() - t0
+
+    _log.info(
+        "export_complete",
+        collection=collection_name,
+        exported_count=exported_count,
+        file_bytes=file_bytes,
+        elapsed_seconds=round(elapsed, 2),
+    )
+
+    return {
+        "collection_name": collection_name,
+        "record_count": total_count,
+        "exported_count": exported_count,
+        "file_bytes": file_bytes,
+        "elapsed_seconds": round(elapsed, 2),
+        "output_path": str(output_path),
+    }
+
+
+def import_collection(
+    db: "T3Database",
+    input_path: Path,
+    target_collection: str | None = None,
+    remaps: list[tuple[str, str]] | None = None,
+) -> dict:
+    """Import a ``.nxexp`` file into T3.
+
+    Parameters
+    ----------
+    db:
+        A connected T3Database instance.
+    input_path:
+        Path to the ``.nxexp`` file to import.
+    target_collection:
+        Override the collection name from the export header.  Useful for
+        renaming on import (e.g. ``code__newname``).
+    remaps:
+        List of ``(old_prefix, new_prefix)`` pairs applied to the
+        ``source_path`` metadata field during import.
+
+    Returns
+    -------
+    dict with keys: collection_name, imported_count, elapsed_seconds.
+
+    Raises
+    ------
+    FormatVersionError:
+        If the export file's format_version exceeds MAX_SUPPORTED_FORMAT_VERSION.
+    EmbeddingModelMismatch:
+        If the export's embedding_model does not match the target collection's
+        expected index model.
+    """
+    t0 = time.monotonic()
+    remaps = remaps or []
+
+    # Phase 1: read and validate header.
+    with open(input_path, "rb") as f:
+        header_line = f.readline()
+
+    header: dict = json.loads(header_line.decode())
+
+    file_format_version: int = header.get("format_version", 0)
+    if file_format_version > MAX_SUPPORTED_FORMAT_VERSION:
+        raise FormatVersionError(
+            f"Export file format_version={file_format_version} exceeds "
+            f"MAX_SUPPORTED_FORMAT_VERSION={MAX_SUPPORTED_FORMAT_VERSION}. "
+            "Upgrade Nexus to import this file."
+        )
+
+    source_collection: str = header["collection_name"]
+    collection_name: str = target_collection or source_collection
+    export_model: str = header["embedding_model"]
+    expected_model: str = index_model_for_collection(collection_name)
+
+    if export_model != expected_model:
+        raise EmbeddingModelMismatch(
+            f"Embedding model mismatch — export uses '{export_model}' but "
+            f"target collection '{collection_name}' requires '{expected_model}'. "
+            "Import aborted. Re-index from source or export to a compatible "
+            "collection prefix."
+        )
+
+    _log.info(
+        "import_start",
+        source_collection=source_collection,
+        target_collection=collection_name,
+        embedding_model=export_model,
+        input=str(input_path),
+    )
+
+    # Phase 2: read records from gzip-compressed msgpack body.
+    header_len = len(header_line)
+    ids: list[str] = []
+    documents: list[str] = []
+    embeddings: list[list[float]] = []
+    metadatas: list[dict] = []
+
+    with open(input_path, "rb") as f:
+        f.seek(header_len)
+        with gzip.GzipFile(fileobj=f, mode="rb") as gz:
+            unpacker = msgpack.Unpacker(gz, raw=False)
+            for record in unpacker:
+                rec_id: str = record["id"]
+                doc: str = record["document"]
+                meta: dict = record["metadata"]
+                emb_bytes: bytes = record["embedding"]
+
+                # Apply path remapping to source_path if present.
+                if remaps and "source_path" in meta:
+                    meta = dict(meta)
+                    meta["source_path"] = _apply_remap(meta["source_path"], remaps)
+
+                # Reconstruct embedding from float32 bytes.
+                emb: list[float] = np.frombuffer(emb_bytes, dtype=np.float32).tolist()
+
+                ids.append(rec_id)
+                documents.append(doc)
+                embeddings.append(emb)
+                metadatas.append(meta)
+
+    imported_count = len(ids)
+
+    # Phase 3: upsert in batches using the pre-computed embedding path.
+    page_size = QUOTAS.MAX_RECORDS_PER_WRITE
+    for start in range(0, imported_count, page_size):
+        end = start + page_size
+        db.upsert_chunks_with_embeddings(
+            collection_name=collection_name,
+            ids=ids[start:end],
+            documents=documents[start:end],
+            embeddings=embeddings[start:end],
+            metadatas=metadatas[start:end],
+        )
+        _log.debug(
+            "import_batch_written",
+            start=start,
+            end=min(end, imported_count),
+            total=imported_count,
+        )
+
+    elapsed = time.monotonic() - t0
+
+    _log.info(
+        "import_complete",
+        collection=collection_name,
+        imported_count=imported_count,
+        elapsed_seconds=round(elapsed, 2),
+    )
+
+    return {
+        "collection_name": collection_name,
+        "imported_count": imported_count,
+        "elapsed_seconds": round(elapsed, 2),
+    }

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,834 @@
+"""Tests for nexus.exporter — collection export/import (RDR-031).
+
+All tests use chromadb.EphemeralClient + DefaultEmbeddingFunction to avoid
+requiring any real API keys or network access.
+"""
+from __future__ import annotations
+
+import json
+import gzip
+from pathlib import Path
+from typing import Generator
+
+import chromadb
+import msgpack
+import numpy as np
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+from nexus.db.t3 import T3Database
+from nexus.errors import EmbeddingModelMismatch, FormatVersionError
+from nexus.exporter import (
+    FORMAT_VERSION,
+    MAX_SUPPORTED_FORMAT_VERSION,
+    _apply_filter,
+    _apply_remap,
+    export_collection,
+    import_collection,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ephemeral_db() -> Generator[T3Database, None, None]:
+    """T3Database backed by an in-memory EphemeralClient — no API keys needed."""
+    client = chromadb.EphemeralClient()
+    ef = DefaultEmbeddingFunction()
+    yield T3Database(_client=client, _ef_override=ef)
+
+
+@pytest.fixture
+def populated_db(ephemeral_db: T3Database, tmp_path: Path):
+    """T3Database pre-populated with 5 records in code__test collection."""
+    col = ephemeral_db.get_or_create_collection("code__test")
+    ef = DefaultEmbeddingFunction()
+    docs = [f"document {i}" for i in range(5)]
+    ids = [f"id-{i:03d}" for i in range(5)]
+    metadatas = [
+        {
+            "source_path": f"/repo/file_{i}.py",
+            "title": f"File {i}",
+            "indexed_at": "2026-03-01T00:00:00+00:00",
+        }
+        for i in range(5)
+    ]
+    embeddings = [ef([doc])[0] for doc in docs]
+    col.upsert(ids=ids, documents=docs, embeddings=embeddings, metadatas=metadatas)
+    return ephemeral_db
+
+
+# ── Unit: filter helpers ───────────────────────────────────────────────────────
+
+
+class TestApplyFilter:
+    def test_no_filters_all_pass(self):
+        assert _apply_filter("/repo/file.py", (), ()) is True
+
+    def test_include_match(self):
+        assert _apply_filter("/repo/main.py", ("*.py",), ()) is True
+
+    def test_include_no_match(self):
+        assert _apply_filter("/repo/main.go", ("*.py",), ()) is False
+
+    def test_include_or_logic(self):
+        """Multiple --include patterns use OR logic."""
+        assert _apply_filter("/repo/main.py", ("*.py", "*.go"), ()) is True
+        assert _apply_filter("/repo/main.go", ("*.py", "*.go"), ()) is True
+        assert _apply_filter("/repo/main.rs", ("*.py", "*.go"), ()) is False
+
+    def test_exclude_match(self):
+        assert _apply_filter("/repo/test_foo.py", (), ("*/test_*",)) is False
+
+    def test_exclude_no_match(self):
+        assert _apply_filter("/repo/main.py", (), ("*/test_*",)) is True
+
+    def test_none_source_path_passes_unconditionally(self):
+        """Entries without source_path always pass (nx store put entries)."""
+        assert _apply_filter(None, ("*.py",), ("*/test*",)) is True
+
+    def test_include_and_exclude_combined(self):
+        """Entry matching include but also exclude is excluded."""
+        assert _apply_filter("/repo/test_main.py", ("*.py",), ("*/test_*",)) is False
+
+    def test_include_only_entry_without_path_passes(self):
+        """No source_path bypasses include filter."""
+        assert _apply_filter(None, ("*.py",), ()) is True
+
+
+class TestApplyRemap:
+    def test_matching_prefix(self):
+        result = _apply_remap("/old/path/file.py", [("/old/path", "/new/path")])
+        assert result == "/new/path/file.py"
+
+    def test_no_match(self):
+        result = _apply_remap("/other/file.py", [("/old/path", "/new/path")])
+        assert result == "/other/file.py"
+
+    def test_first_match_wins(self):
+        result = _apply_remap(
+            "/prefix/file.py",
+            [("/prefix", "/first"), ("/prefix", "/second")],
+        )
+        assert result == "/first/file.py"
+
+    def test_empty_remaps(self):
+        assert _apply_remap("/some/path", []) == "/some/path"
+
+
+# ── Unit: round-trip ──────────────────────────────────────────────────────────
+
+
+class TestRoundTrip:
+    def test_basic_round_trip(self, populated_db: T3Database, tmp_path: Path):
+        """Export then import preserves documents, metadata, and embedding count."""
+        out_file = tmp_path / "test.nxexp"
+
+        export_result = export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        assert export_result["exported_count"] == 5
+        assert out_file.exists()
+        assert out_file.stat().st_size > 0
+
+        # Import into a new collection name.
+        import_result = import_collection(
+            db=populated_db,
+            input_path=out_file,
+            target_collection="code__restored",
+        )
+        assert import_result["imported_count"] == 5
+        assert import_result["collection_name"] == "code__restored"
+
+        # Verify the data made it in.
+        restored_col = populated_db._client_for("code__restored").get_collection(
+            "code__restored"
+        )
+        assert restored_col.count() == 5
+
+    def test_round_trip_preserves_metadata(self, populated_db: T3Database, tmp_path: Path):
+        """Import preserves all metadata fields from the export."""
+        out_file = tmp_path / "meta_rt.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        import_collection(
+            db=populated_db,
+            input_path=out_file,
+            target_collection="code__meta_check",
+        )
+        col = populated_db._client_for("code__meta_check").get_collection("code__meta_check")
+        result = col.get(include=["documents", "metadatas"])
+        # Check a metadata field
+        source_paths = {m["source_path"] for m in result["metadatas"]}
+        assert "/repo/file_0.py" in source_paths
+        assert "/repo/file_4.py" in source_paths
+
+    def test_round_trip_preserves_embeddings(self, populated_db: T3Database, tmp_path: Path):
+        """Embeddings are preserved byte-for-byte through export/import."""
+        out_file = tmp_path / "emb_rt.nxexp"
+
+        # Get original embeddings.
+        orig_col = populated_db._client_for("code__test").get_collection("code__test")
+        orig = orig_col.get(ids=["id-000"], include=["embeddings"])
+        orig_emb = orig["embeddings"][0]
+
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        import_collection(
+            db=populated_db,
+            input_path=out_file,
+            target_collection="code__emb_check",
+        )
+
+        restored_col = populated_db._client_for("code__emb_check").get_collection(
+            "code__emb_check"
+        )
+        restored = restored_col.get(ids=["id-000"], include=["embeddings"])
+        restored_emb = restored["embeddings"][0]
+
+        # Embeddings should match within float32 precision.
+        np.testing.assert_allclose(orig_emb, restored_emb, rtol=1e-6)
+
+
+# ── Unit: gzip compression ─────────────────────────────────────────────────────
+
+
+class TestGzipCompression:
+    def test_body_is_gzip_compressed(self, populated_db: T3Database, tmp_path: Path):
+        """The body (after the JSON header line) is gzip-compressed."""
+        out_file = tmp_path / "gz_test.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        with open(out_file, "rb") as f:
+            header_line = f.readline()
+            body_start = f.read(2)
+        # gzip magic bytes: 0x1f 0x8b
+        assert body_start == b"\x1f\x8b", "Body should start with gzip magic bytes"
+
+    def test_header_is_valid_json(self, populated_db: T3Database, tmp_path: Path):
+        """The first line is valid JSON."""
+        out_file = tmp_path / "hdr_test.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        with open(out_file, "rb") as f:
+            header_line = f.readline()
+        header = json.loads(header_line.decode())
+        assert header["format_version"] == FORMAT_VERSION
+        assert header["collection_name"] == "code__test"
+        assert header["record_count"] == 5
+        assert "embedding_model" in header
+        assert "exported_at" in header
+
+
+# ── Unit: pagination ──────────────────────────────────────────────────────────
+
+
+class TestPagination:
+    def test_export_pagination_handles_large_collection(
+        self, ephemeral_db: T3Database, tmp_path: Path
+    ):
+        """Export paginate correctly for collections larger than one page (300 records)."""
+        from nexus.db.chroma_quotas import QUOTAS
+
+        n = QUOTAS.MAX_RECORDS_PER_WRITE + 50  # 350 records
+        col = ephemeral_db.get_or_create_collection("code__large")
+        ef = DefaultEmbeddingFunction()
+        docs = [f"doc {i}" for i in range(n)]
+        ids = [f"id-{i:04d}" for i in range(n)]
+        metadatas = [{"source_path": f"/f{i}.py"} for i in range(n)]
+        embeddings = [ef([d])[0] for d in docs]
+        # Insert in two batches to avoid ChromaDB limit.
+        mid = n // 2
+        col.upsert(
+            ids=ids[:mid],
+            documents=docs[:mid],
+            embeddings=embeddings[:mid],
+            metadatas=metadatas[:mid],
+        )
+        col.upsert(
+            ids=ids[mid:],
+            documents=docs[mid:],
+            embeddings=embeddings[mid:],
+            metadatas=metadatas[mid:],
+        )
+
+        out_file = tmp_path / "large.nxexp"
+        result = export_collection(
+            db=ephemeral_db,
+            collection_name="code__large",
+            output_path=out_file,
+        )
+        assert result["exported_count"] == n
+
+    def test_import_pagination_handles_large_export(
+        self, ephemeral_db: T3Database, tmp_path: Path
+    ):
+        """Import paginates correctly for exports with > 300 records."""
+        from nexus.db.chroma_quotas import QUOTAS
+
+        n = QUOTAS.MAX_RECORDS_PER_WRITE + 50  # 350 records
+        col = ephemeral_db.get_or_create_collection("code__big_src")
+        ef = DefaultEmbeddingFunction()
+        docs = [f"doc {i}" for i in range(n)]
+        ids = [f"big-{i:04d}" for i in range(n)]
+        metadatas = [{"source_path": f"/big{i}.py"} for i in range(n)]
+        embeddings = [ef([d])[0] for d in docs]
+        mid = n // 2
+        col.upsert(
+            ids=ids[:mid],
+            documents=docs[:mid],
+            embeddings=embeddings[:mid],
+            metadatas=metadatas[:mid],
+        )
+        col.upsert(
+            ids=ids[mid:],
+            documents=docs[mid:],
+            embeddings=embeddings[mid:],
+            metadatas=metadatas[mid:],
+        )
+
+        out_file = tmp_path / "big.nxexp"
+        export_collection(
+            db=ephemeral_db,
+            collection_name="code__big_src",
+            output_path=out_file,
+        )
+        result = import_collection(
+            db=ephemeral_db,
+            input_path=out_file,
+            target_collection="code__big_dst",
+        )
+        assert result["imported_count"] == n
+
+        dst_col = ephemeral_db._client_for("code__big_dst").get_collection("code__big_dst")
+        assert dst_col.count() == n
+
+
+# ── Unit: path remapping ───────────────────────────────────────────────────────
+
+
+class TestPathRemapping:
+    def test_remap_transforms_source_path_on_import(
+        self, populated_db: T3Database, tmp_path: Path
+    ):
+        """--remap applies the prefix substitution to source_path metadata."""
+        out_file = tmp_path / "remap.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        import_collection(
+            db=populated_db,
+            input_path=out_file,
+            target_collection="code__remapped",
+            remaps=[("/repo", "/new_root")],
+        )
+        col = populated_db._client_for("code__remapped").get_collection("code__remapped")
+        result = col.get(include=["metadatas"])
+        paths = {m["source_path"] for m in result["metadatas"]}
+        assert all(p.startswith("/new_root/") for p in paths), (
+            f"Expected all paths to start with /new_root/, got: {paths}"
+        )
+
+    def test_remap_no_match_leaves_path_unchanged(
+        self, populated_db: T3Database, tmp_path: Path
+    ):
+        """A remap that doesn't match leaves source_path unchanged."""
+        out_file = tmp_path / "no_remap.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        import_collection(
+            db=populated_db,
+            input_path=out_file,
+            target_collection="code__no_remap",
+            remaps=[("/nonexistent", "/other")],
+        )
+        col = populated_db._client_for("code__no_remap").get_collection("code__no_remap")
+        result = col.get(include=["metadatas"])
+        paths = {m["source_path"] for m in result["metadatas"]}
+        assert all(p.startswith("/repo/") for p in paths)
+
+
+# ── Unit: embedding model validation ─────────────────────────────────────────
+
+
+class TestEmbeddingModelValidation:
+    def test_code_to_code_same_model_succeeds(
+        self, populated_db: T3Database, tmp_path: Path
+    ):
+        """Importing a code__ export into a code__ collection succeeds."""
+        out_file = tmp_path / "same_model.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        # Should not raise.
+        result = import_collection(
+            db=populated_db,
+            input_path=out_file,
+            target_collection="code__compat",
+        )
+        assert result["imported_count"] == 5
+
+    def test_code_export_into_docs_collection_raises(
+        self, populated_db: T3Database, tmp_path: Path
+    ):
+        """Importing a code__ (voyage-code-3) export into docs__ (voyage-context-3) MUST fail."""
+        out_file = tmp_path / "mismatch.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        with pytest.raises(EmbeddingModelMismatch) as exc_info:
+            import_collection(
+                db=populated_db,
+                input_path=out_file,
+                target_collection="docs__corpus",
+            )
+        assert "voyage-code-3" in str(exc_info.value)
+        assert "voyage-context-3" in str(exc_info.value)
+        assert "docs__corpus" in str(exc_info.value)
+
+    def test_code_export_into_knowledge_collection_raises(
+        self, populated_db: T3Database, tmp_path: Path
+    ):
+        """Importing a code__ export into knowledge__ MUST fail."""
+        out_file = tmp_path / "mismatch_knowledge.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        with pytest.raises(EmbeddingModelMismatch):
+            import_collection(
+                db=populated_db,
+                input_path=out_file,
+                target_collection="knowledge__myknowledge",
+            )
+
+    def test_code_export_into_rdr_collection_raises(
+        self, populated_db: T3Database, tmp_path: Path
+    ):
+        """Importing a code__ export into rdr__ MUST fail."""
+        out_file = tmp_path / "mismatch_rdr.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        with pytest.raises(EmbeddingModelMismatch):
+            import_collection(
+                db=populated_db,
+                input_path=out_file,
+                target_collection="rdr__decisions",
+            )
+
+    def test_knowledge_export_into_knowledge_succeeds(
+        self, ephemeral_db: T3Database, tmp_path: Path
+    ):
+        """knowledge__ to knowledge__ import succeeds (same model: voyage-context-3)."""
+        ef = DefaultEmbeddingFunction()
+        col = ephemeral_db.get_or_create_collection("knowledge__src")
+        docs = ["doc a", "doc b"]
+        ids = ["ka-001", "ka-002"]
+        metas = [{"title": "A"}, {"title": "B"}]
+        embeddings = [ef([d])[0] for d in docs]
+        col.upsert(ids=ids, documents=docs, embeddings=embeddings, metadatas=metas)
+
+        out_file = tmp_path / "k_to_k.nxexp"
+        export_collection(
+            db=ephemeral_db,
+            collection_name="knowledge__src",
+            output_path=out_file,
+        )
+        result = import_collection(
+            db=ephemeral_db,
+            input_path=out_file,
+            target_collection="knowledge__dst",
+        )
+        assert result["imported_count"] == 2
+
+
+# ── Unit: format version validation ──────────────────────────────────────────
+
+
+class TestFormatVersionValidation:
+    def test_current_version_accepted(self, populated_db: T3Database, tmp_path: Path):
+        """Current format version (1) is accepted without error."""
+        out_file = tmp_path / "v1.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+        # Verify the header has format_version = FORMAT_VERSION.
+        with open(out_file, "rb") as f:
+            header = json.loads(f.readline().decode())
+        assert header["format_version"] == FORMAT_VERSION
+
+        # Import should succeed.
+        result = import_collection(
+            db=populated_db,
+            input_path=out_file,
+            target_collection="code__v1_dst",
+        )
+        assert result["imported_count"] == 5
+
+    def test_future_version_raises(self, populated_db: T3Database, tmp_path: Path):
+        """A file with format_version > MAX_SUPPORTED_FORMAT_VERSION MUST abort."""
+        out_file = tmp_path / "future.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+
+        # Tamper with the header to simulate a future format version.
+        with open(out_file, "rb") as f:
+            header_line = f.readline()
+            rest = f.read()
+
+        header = json.loads(header_line.decode())
+        header["format_version"] = MAX_SUPPORTED_FORMAT_VERSION + 1
+        new_header_line = json.dumps(header).encode() + b"\n"
+
+        future_file = tmp_path / "future_tampered.nxexp"
+        with open(future_file, "wb") as f:
+            f.write(new_header_line)
+            f.write(rest)
+
+        with pytest.raises(FormatVersionError) as exc_info:
+            import_collection(
+                db=populated_db,
+                input_path=future_file,
+                target_collection="code__future_dst",
+            )
+        assert "format_version" in str(exc_info.value).lower()
+        assert "upgrade" in str(exc_info.value).lower()
+
+
+# ── Unit: include/exclude filters ────────────────────────────────────────────
+
+
+class TestIncludeExcludeFilters:
+    def _make_db_with_mixed_paths(self, ephemeral_db: T3Database) -> T3Database:
+        """Populate a collection with files at varying paths."""
+        ef = DefaultEmbeddingFunction()
+        col = ephemeral_db.get_or_create_collection("code__filter_test")
+        docs = [
+            "python file content",
+            "go file content",
+            "test python file",
+            "no-path entry",
+        ]
+        ids = ["py-001", "go-001", "test-001", "nopath-001"]
+        metadatas = [
+            {"source_path": "/repo/main.py"},
+            {"source_path": "/repo/main.go"},
+            {"source_path": "/repo/test_main.py"},
+            {"title": "store put entry"},  # no source_path
+        ]
+        embeddings = [ef([d])[0] for d in docs]
+        col.upsert(ids=ids, documents=docs, embeddings=embeddings, metadatas=metadatas)
+        return ephemeral_db
+
+    def test_include_filters_by_source_path(
+        self, ephemeral_db: T3Database, tmp_path: Path
+    ):
+        """--include *.py exports only .py files (plus entries without source_path)."""
+        self._make_db_with_mixed_paths(ephemeral_db)
+        out_file = tmp_path / "py_only.nxexp"
+        result = export_collection(
+            db=ephemeral_db,
+            collection_name="code__filter_test",
+            output_path=out_file,
+            includes=("*.py",),
+        )
+        # 3 .py files + 1 no-path entry = 4 expected... but test_main.py also matches *.py
+        # py-001 (/repo/main.py), test-001 (/repo/test_main.py), nopath-001 (no path)
+        assert result["exported_count"] == 3  # main.py, test_main.py, no-path
+
+    def test_exclude_filters_out_matching_paths(
+        self, ephemeral_db: T3Database, tmp_path: Path
+    ):
+        """--exclude */test_* excludes test files but keeps entries without source_path."""
+        self._make_db_with_mixed_paths(ephemeral_db)
+        out_file = tmp_path / "no_tests.nxexp"
+        result = export_collection(
+            db=ephemeral_db,
+            collection_name="code__filter_test",
+            output_path=out_file,
+            excludes=("*/test_*",),
+        )
+        # main.py, main.go, no-path = 3
+        assert result["exported_count"] == 3
+
+    def test_no_source_path_always_included(
+        self, ephemeral_db: T3Database, tmp_path: Path
+    ):
+        """Entries without source_path pass through both include and exclude filters."""
+        self._make_db_with_mixed_paths(ephemeral_db)
+        out_file = tmp_path / "strict.nxexp"
+        result = export_collection(
+            db=ephemeral_db,
+            collection_name="code__filter_test",
+            output_path=out_file,
+            includes=("*.go",),       # only .go files + no-path
+            excludes=("*/main*",),   # but main.go is excluded
+        )
+        # Only no-path entry survives (main.go matched include but also excluded)
+        assert result["exported_count"] == 1
+
+    def test_include_and_exclude_combined(
+        self, ephemeral_db: T3Database, tmp_path: Path
+    ):
+        """Combined include + exclude: include *.py, exclude */test_*."""
+        self._make_db_with_mixed_paths(ephemeral_db)
+        out_file = tmp_path / "py_no_tests.nxexp"
+        result = export_collection(
+            db=ephemeral_db,
+            collection_name="code__filter_test",
+            output_path=out_file,
+            includes=("*.py",),
+            excludes=("*/test_*",),
+        )
+        # main.py (passes include, not excluded) + no-path = 2
+        assert result["exported_count"] == 2
+
+
+# ── Unit: --all semantics (via CLI layer) ─────────────────────────────────────
+
+
+class TestExportAll:
+    def test_export_all_produces_one_file_per_collection(
+        self, ephemeral_db: T3Database, tmp_path: Path
+    ):
+        """export_collection can be called per-collection to simulate --all."""
+        from datetime import date
+
+        ef = DefaultEmbeddingFunction()
+        for prefix in ("code__alpha", "knowledge__beta"):
+            col = ephemeral_db.get_or_create_collection(prefix)
+            docs = ["doc a", "doc b"]
+            ids = [f"{prefix}-001", f"{prefix}-002"]
+            metas = [{"title": "A"}, {"title": "B"}]
+            embs = [ef([d])[0] for d in docs]
+            col.upsert(ids=ids, documents=docs, embeddings=embs, metadatas=metas)
+
+        today = date.today().isoformat()
+        collections = ["code__alpha", "knowledge__beta"]
+        files: list[Path] = []
+        for col_name in collections:
+            fname = f"{col_name}-{today}.nxexp"
+            out_path = tmp_path / fname
+            export_collection(
+                db=ephemeral_db,
+                collection_name=col_name,
+                output_path=out_path,
+            )
+            files.append(out_path)
+
+        assert len(files) == 2
+        for f in files:
+            assert f.exists()
+            # Verify each file has the correct collection in header.
+            with open(f, "rb") as fh:
+                header = json.loads(fh.readline().decode())
+            # The filename is {collection_name}-{YYYY-MM-DD}.nxexp
+            # Strip the .nxexp suffix, then strip the trailing -{YYYY-MM-DD}
+            stem = f.stem  # e.g. "code__alpha-2026-03-09"
+            # Date is the last 10 chars of the stem (YYYY-MM-DD)
+            expected_col = stem[:-11]  # remove "-YYYY-MM-DD" (11 chars)
+            assert header["collection_name"] == expected_col
+
+        # Verify naming convention: {collection_name}-{date}.nxexp
+        names = [f.name for f in files]
+        assert f"code__alpha-{today}.nxexp" in names
+        assert f"knowledge__beta-{today}.nxexp" in names
+
+
+# ── Unit: CLI layer tests ─────────────────────────────────────────────────────
+
+
+class TestExportImportCLI:
+    """CLI-layer tests using CliRunner and patched _t3."""
+
+    @pytest.fixture
+    def runner(self):
+        from click.testing import CliRunner
+        return CliRunner()
+
+    @pytest.fixture
+    def env_creds(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("CHROMA_API_KEY", "test-chroma-key")
+        monkeypatch.setenv("VOYAGE_API_KEY", "test-voyage-key")
+        monkeypatch.setenv("CHROMA_TENANT", "test-tenant")
+        monkeypatch.setenv("CHROMA_DATABASE", "test-db")
+
+    def test_export_missing_collection_and_all(
+        self, runner, env_creds, tmp_path
+    ):
+        """Providing neither COLLECTION nor --all fails with UsageError."""
+        from unittest.mock import MagicMock, patch
+        from nexus.cli import main
+
+        mock_db = MagicMock()
+        with patch("nexus.commands.store._t3", return_value=mock_db):
+            result = runner.invoke(main, ["store", "export"])
+        assert result.exit_code != 0
+
+    def test_export_collection_and_all_exclusive(
+        self, runner, env_creds, tmp_path
+    ):
+        """Providing both COLLECTION and --all fails with UsageError."""
+        from unittest.mock import MagicMock, patch
+        from nexus.cli import main
+
+        mock_db = MagicMock()
+        with patch("nexus.commands.store._t3", return_value=mock_db):
+            result = runner.invoke(
+                main,
+                ["store", "export", "code__test", "--all"],
+            )
+        assert result.exit_code != 0
+
+    def test_import_remap_bad_format(self, runner, env_creds, tmp_path):
+        """--remap without colon separator fails with UsageError."""
+        from unittest.mock import MagicMock, patch
+        from nexus.cli import main
+
+        # Create a dummy .nxexp file so the click.Path(exists=True) check passes.
+        dummy = tmp_path / "dummy.nxexp"
+        dummy.write_bytes(b"not a real file")
+
+        mock_db = MagicMock()
+        with patch("nexus.commands.store._t3", return_value=mock_db):
+            result = runner.invoke(
+                main,
+                ["store", "import", str(dummy), "--remap", "no_colon_here"],
+            )
+        assert result.exit_code != 0
+        assert "remap" in result.output.lower() or "colon" in result.output.lower() or result.exit_code != 0
+
+    def test_export_single_collection_success(
+        self, runner, env_creds, tmp_path, populated_db: T3Database
+    ):
+        """CLI export command succeeds for a single collection."""
+        from unittest.mock import patch
+        from nexus.cli import main
+
+        out_file = tmp_path / "out.nxexp"
+        with patch("nexus.commands.store._t3", return_value=populated_db):
+            result = runner.invoke(
+                main,
+                ["store", "export", "code__test", "-o", str(out_file)],
+            )
+        assert result.exit_code == 0, result.output
+        assert out_file.exists()
+        assert "5" in result.output
+
+    def test_import_embedding_mismatch_shows_error(
+        self, runner, env_creds, tmp_path, populated_db: T3Database
+    ):
+        """CLI import shows error on EmbeddingModelMismatch."""
+        from unittest.mock import patch
+        from nexus.cli import main
+
+        # First export the code__ collection.
+        out_file = tmp_path / "code_export.nxexp"
+        export_collection(
+            db=populated_db,
+            collection_name="code__test",
+            output_path=out_file,
+        )
+
+        # Now try to import into docs__ via CLI — must fail.
+        with patch("nexus.commands.store._t3", return_value=populated_db):
+            result = runner.invoke(
+                main,
+                [
+                    "store",
+                    "import",
+                    str(out_file),
+                    "--collection",
+                    "docs__corpus",
+                ],
+            )
+        assert result.exit_code != 0
+        output = result.output.lower()
+        assert "mismatch" in output or "error" in output
+
+    def test_export_all_produces_files(
+        self, runner, env_creds, tmp_path, ephemeral_db: T3Database
+    ):
+        """--all exports one file per collection into the output directory."""
+        from unittest.mock import patch
+        from nexus.cli import main
+
+        # Seed two collections.
+        ef = DefaultEmbeddingFunction()
+        for name in ("code__repo1", "knowledge__notes"):
+            col = ephemeral_db.get_or_create_collection(name)
+            embs = [ef(["hello"])[0]]
+            col.upsert(ids=[f"{name}-001"], documents=["hello"], embeddings=embs, metadatas=[{"title": "t"}])
+
+        ephemeral_db.list_collections = lambda: [
+            {"name": "code__repo1", "count": 1},
+            {"name": "knowledge__notes", "count": 1},
+        ]
+
+        out_dir = tmp_path / "exports"
+        out_dir.mkdir()
+        with patch("nexus.commands.store._t3", return_value=ephemeral_db):
+            result = runner.invoke(
+                main,
+                ["store", "export", "--all", "-o", str(out_dir)],
+            )
+        assert result.exit_code == 0, result.output
+        nxexp_files = list(out_dir.glob("*.nxexp"))
+        assert len(nxexp_files) == 2
+
+
+# ── Unit: error types ─────────────────────────────────────────────────────────
+
+
+class TestErrorTypes:
+    def test_embedding_model_mismatch_importable(self):
+        from nexus.errors import EmbeddingModelMismatch  # noqa: F401
+
+    def test_format_version_error_importable(self):
+        from nexus.errors import FormatVersionError  # noqa: F401
+
+    def test_both_are_nexus_error_subclasses(self):
+        from nexus.errors import EmbeddingModelMismatch, FormatVersionError, NexusError
+        assert issubclass(EmbeddingModelMismatch, NexusError)
+        assert issubclass(FormatVersionError, NexusError)
+
+    def test_embedding_model_mismatch_message(self):
+        exc = EmbeddingModelMismatch("test message")
+        assert "test message" in str(exc)
+
+    def test_format_version_error_message(self):
+        exc = FormatVersionError("version error message")
+        assert "version error message" in str(exc)

--- a/uv.lock
+++ b/uv.lock
@@ -476,6 +476,8 @@ dependencies = [
     { name = "docling" },
     { name = "llama-index-core" },
     { name = "markdown-it-py" },
+    { name = "msgpack" },
+    { name = "numpy" },
     { name = "pymupdf" },
     { name = "pyyaml" },
     { name = "structlog" },
@@ -500,6 +502,8 @@ requires-dist = [
     { name = "docling", specifier = ">=2.76.0" },
     { name = "llama-index-core", specifier = "==0.12.7" },
     { name = "markdown-it-py", specifier = ">=4.0.0" },
+    { name = "msgpack", specifier = ">=1.0" },
+    { name = "numpy", specifier = ">=1.24" },
     { name = "pymupdf", specifier = ">=1.26.6" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "structlog", specifier = ">=24.0" },
@@ -1860,6 +1864,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
+    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
+    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `.nxexp` format (JSON header + gzip-compressed msgpack + numpy float32 embeddings)
- `nx store export` with --include/--exclude glob filters and --all mode
- `nx store import` with --remap path substitution and --collection override
- Hard embedding model validation prevents cross-space corruption
- Format version guard for forward-compatibility
- Full pagination via QUOTAS.MAX_RECORDS_PER_WRITE (300/page)

## Test plan
- [x] 45 new tests in tests/test_exporter.py
- [x] Round-trip: export -> import preserves documents, metadata, embeddings
- [x] Embedding model mismatch: code__ export into docs__ target raises EmbeddingModelMismatch
- [x] Format version mismatch: future format_version raises FormatVersionError
- [x] Pagination: collections > 300 records work correctly
- [x] All existing tests pass

References: nexus-iwx4 (RDR-031)