### PR TITLE
feat: implement post-accept planning workflow (RDR-036)

### DIFF
--- a/docs/rdr-workflow.md
+++ b/docs/rdr-workflow.md
@@ -15,6 +15,8 @@
      │
   [Accepted]
      │
+     │ optional: strategic-planner → plan-auditor → plan-enricher
+     │
      │ /rdr-close --reason implemented
      ▼
 [Implemented]
@@ -57,12 +59,14 @@ formal validation and archival — use them when the decision is load-bearing.
 ```
 /rdr-accept 016
 # Verifies gate result, updates status → accepted
+# Auto-detects multi-phase RDR → offers planning handoff
+# If yes: planner → auditor → enricher → beads ready
 ```
 
 ```
 /rdr-close 016 --reason implemented
 # Creates post-mortem template
-# Decomposes Implementation Plan → beads
+# Displays bead status advisory (if beads exist from accept-time planning)
 # Indexes RDR into rdr__ collection
 ```
 
@@ -178,6 +182,12 @@ Author/reviewer decision point. The gate validates; acceptance is deliberate.
 3. Updates the **RDR file** frontmatter to match.
 4. Regenerates `docs/rdr/README.md`.
 5. Stages modified files via `git add`.
+6. **Planning handoff** (optional): counts `### Phase` headings in the
+   Implementation Plan. If 2+ phases, defaults to yes; otherwise defaults to no.
+   - If accepted: writes T1 `rdr-planning-context` tag, dispatches
+     `strategic-planner` → `plan-auditor` → `plan-enricher` chain.
+   - Plan-enricher enriches beads with audit findings and writes epic bead ID to T2.
+   - If declined: no beads created — accept is complete.
 
 **Self-healing**: if T2 shows `accepted` but the file still shows `draft`,
 `/rdr-accept` repairs the file to match T2.
@@ -186,7 +196,7 @@ Author/reviewer decision point. The gate validates; acceptance is deliberate.
 
 ## Close (`/rdr-close`)
 
-Finalizes an Accepted RDR and sets up implementation tracking.
+Finalizes an Accepted RDR.
 
 Requires status: **Accepted**. Blocked otherwise — use `--force` to override.
 
@@ -194,7 +204,8 @@ Close reasons: `implemented` · `reverted` · `abandoned` · `superseded`
 
 Steps:
 1. Creates `docs/rdr/post-mortem/NNN-kebab-title.md` for drift analysis.
-2. Decomposes the Implementation Plan into beads: one epic, one task per step.
+2. **Bead status advisory**: if T2 has an `epic_bead` field (set during accept-time
+   planning), displays bead statuses. Advisory only — the human decides which to close.
 3. Indexes RDR content via `nx index rdr` into the `rdr__` collection.
 4. Updates T2 with close date, close reason, and final status.
 5. Regenerates `docs/rdr/README.md`.

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -49,6 +49,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-033](rdr-033-pdf-agent-nx-index-alignment.md) | PDF Processing Agent Should Delegate to nx index pdf | Architecture | Closed | 2026-03-08 |
 | [RDR-034](rdr-034-mcp-server-agent-storage.md) | MCP Server for Agent Storage Operations | Architecture | Accepted | 2026-03-11 |
 | [RDR-035](rdr-035-plugin-agent-mcp-tool-access.md) | Fix Plugin Agent MCP Tool Access | Bugfix | Closed | 2026-03-12 |
+| [RDR-036](rdr-036-post-accept-planning-workflow.md) | Post-Accept Planning Workflow | Enhancement | Accepted | 2026-03-12 |
 
 ## RDR Process Documentation
 

--- a/docs/rdr/rdr-036-post-accept-planning-workflow.md
+++ b/docs/rdr/rdr-036-post-accept-planning-workflow.md
@@ -1,0 +1,293 @@
+---
+title: "Post-Accept Planning Workflow"
+id: RDR-036
+type: enhancement
+status: accepted
+priority: P2
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-12
+accepted_date: 2026-03-12
+related_issues:
+  - "RDR-024 - RDR Process Guardrails"
+---
+
+# RDR-036: Post-Accept Planning Workflow
+
+## Problem Statement
+
+The current RDR workflow places bead decomposition at close time (`/rdr-close` Step 3), after implementation is already complete. This is backwards — by then the beads serve only as retroactive bookkeeping rather than actionable work items. In practice, planning happens after accept, not after close.
+
+The actual workflow that has emerged through 35+ RDRs:
+
+1. Accept the RDR (`/rdr-accept`)
+2. Manually invoke `/create-plan` to build out implementation beads
+3. Manually invoke `/plan-audit` to validate
+4. Execute the plan
+5. Close the RDR (`/rdr-close`)
+
+Steps 2-3 should be an optional, integrated handoff from `/rdr-accept` rather than manual separate invocations. And the bead decomposition currently in `/rdr-close` should be removed since beads are already created during planning.
+
+## Context
+
+The RDR lifecycle is: draft → gate → accept → implement → close. The accept-to-implement transition is where planning naturally fits — you've validated the design, now you need to decompose it into executable work. The close transition is where you record what happened, not where you plan what to do.
+
+Additionally, the current close skill creates beads from the Implementation Plan section text, which produces shallow task descriptions. The strategic-planner agent creates richer beads with proper dependency graphs, success criteria, and test strategies.
+
+### Complexity Threshold
+
+Not every RDR warrants full planning ceremony. RDR-035 (delete one frontmatter line from 14 files) needed zero planning. RDR-034 (MCP server with 8 tools, test strategy, documentation) absolutely benefited from it. The trigger should be:
+
+- **Skip planning**: single-phase fix, implementation obvious from the RDR
+- **Invoke planning**: multi-phase, cross-cutting, or ambiguous implementation path
+
+## Research Findings
+
+### F-01: Close-time bead decomposition is never used as intended
+- **Classification**: Verified — Project History
+- **Method**: Review of 35 closed RDRs
+- **Detail**: Bead decomposition at close time produces beads that are immediately closed. The Implementation Plan section is parsed into tasks, but the work is already done. These beads have no lifecycle value.
+
+### F-02: Strategic planner produces richer work items than text extraction
+- **Classification**: Verified — Usage
+- **Method**: Comparison of planner output vs close-time decomposition
+- **Detail**: The strategic-planner agent creates beads with dependency graphs, success criteria per phase, test strategies, and proper descriptions. Close-time decomposition does shallow text extraction from markdown headings.
+
+### F-03: Plan-auditor catches issues before implementation starts
+- **Classification**: Verified — Usage
+- **Method**: Project experience with RDR-034
+- **Detail**: Running plan-auditor after strategic-planner but before implementation catches gaps, ordering issues, and missing dependencies. This is the right time for the audit — after planning, before coding.
+
+### F-04: Strategic planner already mandates plan-auditor as successor
+- **Classification**: Verified — Source Search
+- **Method**: Read `nx/agents/strategic-planner.md` lines 165-170
+- **Detail**: The strategic-planner agent has a "Successor Enforcement (MANDATORY)" section that always relays to plan-auditor after creating a plan. This means the accept skill only needs to dispatch strategic-planner — the auditor handoff is already built into the agent chain. No separate dispatch logic needed.
+
+### F-05: Accept skill currently has no agent delegation
+- **Classification**: Verified — Source Search
+- **Method**: Read `nx/skills/rdr-accept/SKILL.md` line 31
+- **Detail**: The accept skill states "This skill executes directly — no agent delegation." Adding the planning handoff would be the first agent dispatch from the accept skill. The skill needs to be updated to support optional agent delegation.
+
+### F-06: RDR content provides complete input for strategic planner relay
+- **Classification**: Verified — Source Search
+- **Method**: Read strategic-planner relay reception requirements
+- **Detail**: The strategic-planner relay requires: Task (from RDR title + problem statement), Bead (create new epic), Input Artifacts (RDR file path + T2 metadata), Deliverable (phased plan with beads), Quality Criteria (from RDR success criteria). All fields can be auto-populated from the accepted RDR without additional user input.
+
+### F-07: Auto-detection heuristic can use Implementation Plan section structure
+- **Classification**: Verified — Source Search
+- **Method**: Analysis of RDR template and closed RDRs
+- **Detail**: The Implementation Plan section uses `### Phase N:` headings. Counting these headings gives a reliable complexity signal: 1 phase = simple (skip planning), 2+ phases = complex (suggest planning). (Note: F-10 supersedes the RDR-type component originally considered here; phase count alone is used.)
+
+### F-08: Strategic planner lacks an explicit enrichment phase after audit
+- **Classification**: Verified — Source Search
+- **Method**: Read `nx/agents/strategic-planner.md` Phase 3 (lines 107-114) and Bead Content Requirements (lines 118-150)
+- **Detail**: Phase 3 says "Iterate based on audit feedback until the plan passes review" but this is aspirational — the planner dispatches the auditor as a successor and is done. There is no mechanism for the audit findings to flow back into the beads. The Bead Content Requirements template describes what beads should contain (context, prerequisites, execution instructions, parallelization guidance, continuation state, validation) but the audit-identified gaps, refined dependency ordering, missing test strategies, and codebase alignment issues are never folded back in.
+
+### F-09: Feedback loop to strategic planner is architecturally impossible
+- **Classification**: Verified — Source Search (Gate C-1)
+- **Method**: Read plan-auditor Successor Enforcement (lines 174-177)
+- **Detail**: Plan-auditor's successor enforcement relays to `architect-planner` or `developer` — not back to strategic-planner. Adding a Phase 4 to the strategic planner cannot work because the planner dispatches the auditor as a relay successor and is done by the time audit findings exist. The relay chain is one-directional: planner → auditor → developer. Solving this requires a new agent in the chain that receives audit findings and enriches beads as a forward step, not a feedback loop.
+
+### F-10: Auto-detection heuristic should use phase count only
+- **Classification**: Verified — Analysis (Gate C-2)
+- **Method**: Review of heuristic edge cases
+- **Detail**: The original heuristic conflated phase count and RDR type, producing inconsistent defaults for non-bugfix single-phase RDRs (e.g., an architecture RDR with 1 phase hits "otherwise → ask" instead of "default no"). Simplify to: phases ≥ 2 → default yes; phases ≤ 1 or no Implementation Plan section → default no. Drop RDR type from the decision entirely.
+
+### F-11: Accept-to-planner path must satisfy RDR-024 guardrails
+- **Classification**: Verified — Cross-reference (Gate S-3)
+- **Method**: Cross-check RDR-024 Guardrail 2 against proposed accept flow
+- **Detail**: RDR-024's Guardrail 2 (strategic-planner pre-check) warns if a referenced RDR is not yet "accepted." The accept skill must complete the T2 `status: accepted` write (Step 2) before dispatching the planner (Step 6) to avoid a false warning. This ordering is natural (Step 2 precedes Step 6) but must be explicitly stated. Additionally, the accept-to-planner path intentionally bypasses RDR-024's Guardrail 1 (brainstorming-gate) — this is correct since the RDR has already passed the gate.
+
+### F-12: Close skill needs bead discovery mechanism
+- **Classification**: Verified — Analysis (Gate S-5)
+- **Method**: Analysis of close skill bead advisory requirements
+- **Detail**: For the close skill to report bead status as an advisory, it needs to discover which beads belong to the RDR. The accept skill should store the epic bead ID in T2 at the end of the planning flow. Close reads that field and walks `bd show <epic-id>` to get child statuses. If no epic bead ID exists in T2 (user skipped planning), close skips the advisory.
+
+### F-13: T1 scratch enables lightweight relay with rich shared context
+- **Classification**: Verified — Architecture
+- **Method**: Analysis of T1 session sharing (RDR-010) and agent chain context needs
+- **Detail**: The accept-to-enricher chain involves 3 agents that each produce context the next one needs. Passing all of this through relay text makes relays bloated and fragile. T1 scratch is purpose-built for this scenario: session-scoped, shared across the agent tree via PPID chain, and semantically searchable. Each agent writes its outputs to T1 (plan structure, bead IDs, audit findings, gap analysis) and the next agent discovers them via `scratch search`. This keeps relays lightweight (task description + pointers) while T1 carries the heavy context.
+
+### F-14: Plan-auditor needs explicit routing discriminant for conditional successor
+- **Classification**: Verified — Architecture
+- **Method**: Analysis of plan-auditor successor enforcement and relay context
+- **Detail**: Plan-auditor's Successor Enforcement currently always relays to `architect-planner` or `developer`. Adding plan-enricher as a conditional successor requires a discriminant the auditor can check. The accept skill writes a T1 scratch entry tagged `rdr-planning-context` with the RDR ID and planning metadata. Plan-auditor searches T1 for this tag and checks that the RDR ID in the tag matches the RDR ID in the current relay context: if both match, relay to `plan-enricher`; if tag absent or RDR ID mismatch (standalone audit, or unrelated plan-audit in same session), relay to existing successors. The RDR ID correlation prevents false positives when a session runs `/rdr-accept` for one RDR followed by an unrelated `/plan-audit`.
+
+## Proposed Solution
+
+### New agent: plan-enricher
+
+A new agent (`nx/agents/plan-enricher.md`) that sits at the end of the planning chain. It receives audit findings from plan-auditor and enriches every bead to be fully self-contained and ready for autonomous execution.
+
+**Agent chain (forward-only, no feedback loops):**
+```
+strategic-planner → plan-auditor → plan-enricher → done
+```
+
+**What plan-enricher does:**
+- Searches T1 scratch for audit findings, plan structure, bead IDs, and gap analysis written by predecessors in the chain
+- Reads every bead created by the strategic planner (discovers epic bead ID from T1)
+- For each bead, enriches with:
+  - Audit-identified gaps and mitigations (from T1 audit findings)
+  - Refined dependency ordering per audit recommendations
+  - Test strategy specifics the auditor flagged as missing
+  - Codebase alignment issues the auditor discovered
+  - Full execution context (search keywords, memory pointers, prerequisite state)
+- Updates each bead via `bd update <id> --description` with enriched content
+- Writes epic bead ID directly to T2 (`memory_put` to `{repo}_rdr/NNN` with `epic_bead: <id>`) — the accept skill's execution context is gone by this point, so plan-enricher owns the T2 persistence (Gate S-2)
+- **Degraded mode (T1 miss):** If T1 scratch yields no audit findings (standalone invocation without prior `/plan-audit` in session, or semantic search miss): warn the user that audit findings are unavailable, proceed to enrich beads with execution context only (codebase alignment, search keywords, prerequisite state), and skip audit-finding injection. Do not abort.
+- Reports the final enriched plan to the user
+
+**T1 scratch as the shared context bus (F-13):**
+
+Each agent in the chain writes its outputs to T1 and reads predecessors' context from T1. Relays stay lightweight (task + RDR reference), T1 carries the heavy context:
+
+| Agent | Writes to T1 | Reads from T1 |
+|-------|-------------|---------------|
+| Accept skill | RDR content, T2 metadata, planning context (tagged `rdr-planning-context`) | — |
+| Strategic planner | Plan structure, bead IDs, dependency graph, design rationale | RDR context from accept |
+| Plan-auditor | Audit findings, gap analysis, severity classifications | Plan structure, bead IDs, `rdr-planning-context` tag (for successor routing) |
+| Plan-enricher | Epic bead ID, enrichment summary | All of the above |
+
+Within the same session, `/enrich-plan` can be invoked standalone — if T1 has audit findings from a same-session `/plan-audit`, the enricher finds them via T1 scratch search without being part of a relay chain.
+
+**Wiring (F-14):**
+- Accept skill writes a T1 scratch entry tagged `rdr-planning-context` with the RDR ID and planning metadata before dispatching strategic-planner
+- Update plan-auditor's Successor Enforcement: search T1 for `rdr-planning-context` tag and verify the RDR ID in the tag matches the RDR ID in the current relay — if both match, relay to `plan-enricher`; if tag absent or ID mismatch (standalone audit), relay to `developer`/`architect-planner` (existing behavior)
+- plan-enricher has no mandatory successor — it reports to the user
+
+**Skill and command:** `/enrich-plan` — can also be invoked standalone within the same session where `/plan-audit` was run (T1 scratch is session-scoped, so audit findings from the current session are available; cross-session standalone use requires the user to re-run `/plan-audit` first).
+
+### Modified `/rdr-accept` flow
+
+After the existing accept steps (verify gate, update T2, update file, regenerate README), add:
+
+**Step 6 (new): Planning handoff prompt**
+
+Note: Step 2 (T2 `status: accepted` write) must complete before Step 6 to satisfy RDR-024 Guardrail 2 (strategic-planner pre-check). This ordering is natural since Step 2 precedes Step 6 in the accept sequence. The accept-to-planner path intentionally bypasses RDR-024 Guardrail 1 (brainstorming-gate) since the RDR has already passed the gate.
+
+Ask: "Invoke strategic planner to build execution beads? (y/n)"
+
+Auto-detection heuristic for the prompt default (phase count only — F-10):
+- If the RDR has an Implementation Plan with 2+ phases → default yes
+- If the RDR has 0-1 phases or no Implementation Plan section → default no
+
+**If yes:**
+1. Dispatch `strategic-planner` agent with the full RDR content as input
+2. Strategic planner creates epic + phase beads with dependencies
+3. Strategic planner relays to `plan-auditor` (existing successor enforcement)
+4. Plan-auditor validates and relays to `plan-enricher` (new successor)
+5. Plan-enricher enriches every bead with audit findings → beads are execution-ready
+6. Plan-enricher writes epic bead ID to T2 for close-time advisory (F-12, Gate S-2)
+
+**If no:**
+Continue as before — no beads created at accept time.
+
+### Modified `/rdr-close` flow
+
+Remove Step 3 (bead decomposition) from the close skill. Close becomes purely a state transition + archival:
+
+1. Divergence notes (if any)
+2. Post-mortem (if diverged)
+3. ~~Decompose into beads~~ → removed
+4. Update state (T2, file, README)
+5. T3 archive (post-mortem only)
+
+**Bead status advisory:** If T2 has an `epic_bead` field (set at accept time), close reads it and runs `bd show <epic-id>` to report child bead statuses. The human decides what to close; `/rdr-close` does not automatically mark beads complete. If no `epic_bead` exists (user skipped planning), close skips the advisory.
+
+Update the close skill's frontmatter description to remove "bead decomposition" and its Success Criteria to remove the bead-creation checkbox and add the bead-status advisory checkbox.
+
+## Alternatives Considered
+
+### A1: Move planning to a separate `/rdr-plan` command
+- **Pro**: Clean separation of concerns
+- **Con**: Adds yet another command to the lifecycle; users already struggle to remember the sequence
+- **Rejected**: The natural moment is right after accept — making it a sub-step is more ergonomic
+
+### A2: Always invoke planning on accept (no prompt)
+- **Pro**: Simpler logic
+- **Con**: Wastes time on trivial RDRs (single-line fixes, doc-only changes)
+- **Rejected**: The complexity threshold matters; ceremony should scale with risk
+
+### A3: Keep bead decomposition in close, add planning to accept
+- **Pro**: Belt and suspenders
+- **Con**: Creates duplicate beads — planner beads at accept time, decomposition beads at close time
+- **Rejected**: Confusing and redundant
+
+### A4: Add Phase 4 (enrichment) to strategic planner instead of new agent
+- **Pro**: No new agent to maintain
+- **Con**: Architecturally impossible — plan-auditor relays to developer/architect-planner, not back to planner. The relay chain is one-directional (F-09). Making auditor a blocking sub-agent call breaks the existing relay pattern for all non-RDR uses of strategic-planner.
+- **Rejected**: Cannot solve the feedback loop without breaking existing agent contracts
+
+## Trade-offs
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| When beads are created | Close (retroactive) | Accept (actionable) |
+| Bead quality | Shallow text extraction | Strategic planner + auditor + plan-enricher |
+| Planning ceremony | Manual, separate invocations | Integrated prompt on accept |
+| Simple RDRs | Same ceremony as complex | Skip planning with one keystroke |
+| Close complexity | 5 steps | 4 steps (simpler) |
+
+## Implementation Plan
+
+### Phase 1: Create plan-enricher agent
+- Create `nx/agents/plan-enricher.md` with:
+  - Relay reception: lightweight relay with RDR reference; discovers context via T1 scratch search
+  - T1 read pattern: search for audit findings, plan structure, bead IDs from predecessors
+  - Bead enrichment logic: read each bead, update with audit findings, ensure self-contained
+  - T1 write: epic bead ID and enrichment summary (for accept skill to persist to T2)
+  - No mandatory successor — reports to user
+  - Model: sonnet (structured enrichment, not deep reasoning)
+- Create `/enrich-plan` skill (`nx/skills/enrich-plan/SKILL.md`)
+- Register agent and skill in `nx/registry.yaml`
+
+### Phase 2: Wire plan-auditor successor
+- Update `nx/agents/plan-auditor.md` Successor Enforcement:
+  - Search T1 for `rdr-planning-context` tag (written by accept skill) and verify RDR ID matches current relay — if both match, relay to `plan-enricher`
+  - If tag absent or RDR ID mismatch (standalone audit) → relay to `developer`/`architect-planner` (existing behavior)
+- Remove aspirational "iterate based on audit feedback" from strategic planner Phase 3
+
+### Phase 3: Update `/rdr-accept` skill
+- Add planning handoff prompt after existing Step 5
+- Implement auto-detection heuristic (phase count only: ≥ 2 → yes, ≤ 1 → no)
+- Write T1 scratch entry tagged `rdr-planning-context` with RDR ID and planning metadata before dispatching strategic-planner (F-14)
+- Add strategic-planner relay template (auto-populated from RDR content)
+- Ensure T2 `status: accepted` write (Step 2) precedes planner dispatch (Step 6) for RDR-024 compatibility
+- Epic bead ID written to T2 by plan-enricher at chain end (Gate S-2)
+
+### Phase 4: Update `/rdr-close` skill
+- Remove Step 3 (bead decomposition)
+- Add bead status advisory: read `epic_bead` from T2, walk dependencies via `bd show`, report statuses
+- Update frontmatter description to remove "bead decomposition"
+- Update Success Criteria to remove bead-creation checkbox, add bead-status advisory checkbox
+- Skip advisory if no `epic_bead` in T2 (user skipped planning)
+- Update `nx/registry.yaml` rdr-close entry to remove "bead decomposition" from description
+
+### Phase 5: Update workflow documentation
+- Update `docs/rdr-workflow.md` state machine and Accept/Close sections
+- Update accept skill description to reflect agent delegation
+- Update close skill to reflect simplified flow
+- Add plan-enricher to agent documentation
+
+## Success Criteria
+
+- [ ] Plan-enricher agent created with relay reception and bead enrichment logic
+- [ ] `/enrich-plan` skill and command registered
+- [ ] Plan-auditor relays to plan-enricher when T1 `rdr-planning-context` tag present
+- [ ] Strategic planner Phase 3 "iterate based on audit feedback" instruction removed
+- [ ] `/rdr-accept` prompts for planning after acceptance
+- [ ] Auto-detection heuristic defaults based on phase count (≥ 2 yes, ≤ 1 no)
+- [ ] T2 `status: accepted` precedes planner dispatch (RDR-024 compatibility)
+- [ ] Epic bead ID stored in T2 for close-time advisory
+- [ ] Plan-enricher enriches every bead with audit findings → execution-ready
+- [ ] `/rdr-close` reports bead status as advisory, does not auto-close beads
+- [ ] `/rdr-close` frontmatter and success criteria updated
+- [ ] Simple RDRs can skip planning with one keystroke
+- [ ] Workflow documentation reflects the new flow
+
+## Finalization Gate
+
+- [ ] Structural: all sections filled
+- [ ] Assumption audit: no unverified assumptions in load-bearing positions
+- [ ] AI critique: substantive-critic review

--- a/nx/README.md
+++ b/nx/README.md
@@ -1,6 +1,6 @@
 # Nexus Claude Code Plugin
 
-14 agents, 27 skills, session hooks, slash commands, and two bundled MCP servers for software engineering workflows — backed by the [Nexus CLI](../README.md) for semantic search and knowledge management.
+15 agents, 28 skills, session hooks, slash commands, and two bundled MCP servers for software engineering workflows — backed by the [Nexus CLI](../README.md) for semantic search and knowledge management.
 
 ## Installation
 
@@ -34,8 +34,8 @@ Run `/nx-preflight` after installing to verify all dependencies are present.
 
 ## What You Get
 
-- **14 agents** matched to task complexity: opus for reasoning, sonnet for implementation, haiku for utility
-- **27 skills** — 6 standalone + 14 agent-delegating + 7 RDR workflow
+- **15 agents** matched to task complexity: opus for reasoning, sonnet for implementation, haiku for utility
+- **28 skills** — 6 standalone + 15 agent-delegating + 7 RDR workflow
 - **5 standard pipelines** — feature, bug, research, onboarding, architecture
 - **Session hooks** — surface T2 memory context, prime beads, health-check dependencies
 - **Permission auto-approval** — safe commands and all nexus MCP tools skip the confirmation prompt
@@ -65,7 +65,7 @@ nx/
 │   │   ├── MAINTENANCE.md       # How to maintain/update agents
 │   │   ├── README.md            # _shared directory guide (this section)
 │   │   └── RELAY_TEMPLATE.md    # Canonical relay message format
-│   └── *.md                 # 14 specialized agent definitions
+│   └── *.md                 # 15 specialized agent definitions
 ├── commands/
 │   └── *.md                 # Slash commands (/research, /create-plan, /review-code, etc.)
 ├── hooks/
@@ -104,7 +104,8 @@ nx/
     ├── strategic-planning/  # → strategic-planner agent
     ├── test-validation/     # → test-validator agent
     ├── rdr-accept/          # RDR workflow: accept a gated RDR
-    ├── rdr-close/           # RDR workflow: close RDR, create beads
+    ├── enrich-plan/         # → plan-enricher agent
+    ├── rdr-close/           # RDR workflow: close RDR, bead advisory
     ├── rdr-create/          # RDR workflow: create new RDR from template
     ├── rdr-gate/            # RDR workflow: quality gate before finalizing
     ├── rdr-list/            # RDR workflow: list RDRs with status
@@ -138,7 +139,7 @@ Skills that provide guidance directly without delegating to an agent.
 | using-nx-skills | Skill invocation discipline — check skills before every response |
 | writing-nx-skills | Guide for authoring nx plugin skills |
 
-## Agents (14)
+## Agents (15)
 
 See [`registry.yaml`](./registry.yaml) for full metadata (model, triggers, predecessors/successors).
 
@@ -156,6 +157,7 @@ See [`registry.yaml`](./registry.yaml) for full metadata (model, triggers, prede
 | orchestrator | orchestration | `/orchestrate` | haiku | Route requests to appropriate agents |
 | pdf-chromadb-processor | pdf-processing | `/pdf-process` | haiku | Index PDFs into nx store for semantic search |
 | plan-auditor | plan-validation | `/plan-audit` | sonnet | Validate plans before execution |
+| plan-enricher | enrich-plan | `/enrich-plan` | sonnet | Enrich beads with audit findings and execution context |
 | strategic-planner | strategic-planning | `/create-plan` | opus | Implementation planning, task decomposition |
 | test-validator | test-validation | `/test-validate` | sonnet | Test coverage and quality validation |
 
@@ -163,7 +165,7 @@ See [`registry.yaml`](./registry.yaml) for full metadata (model, triggers, prede
 
 Defined in `registry.yaml`:
 
-- **feature**: strategic-planner → plan-auditor → architect-planner → developer → code-review-expert → test-validator
+- **feature**: strategic-planner → plan-auditor → plan-enricher *(conditional)* → architect-planner → developer → code-review-expert → test-validator
 - **bug**: debugger → developer → code-review-expert → test-validator
 - **research**: deep-research-synthesizer → knowledge-tidier
 - **onboarding**: codebase-deep-analyzer → strategic-planner
@@ -203,6 +205,7 @@ Defined in `registry.yaml`:
 - `/pdf-process` → pdf-chromadb-processor
 - `/deep-analysis` → deep-analyst
 - `/substantive-critique` → substantive-critic
+- `/enrich-plan` → plan-enricher
 
 **RDR commands**: `/rdr-create`, `/rdr-list`, `/rdr-show`, `/rdr-research`, `/rdr-gate`, `/rdr-accept`, `/rdr-close`
 

--- a/nx/agents/_shared/README.md
+++ b/nx/agents/_shared/README.md
@@ -11,7 +11,7 @@ This directory contains shared resources used across multiple agents.
 
 ## Usage Pattern
 
-All 14 agents reference this shared Context Protocol using:
+All 15 agents reference this shared Context Protocol using:
 
 ```markdown
 ## Context Protocol

--- a/nx/agents/plan-auditor.md
+++ b/nx/agents/plan-auditor.md
@@ -173,10 +173,20 @@ You will leverage Nexus to:
 
 ## Successor Enforcement (MANDATORY)
 
-After completing work, relay to `architect-planner` and `developer`.
+After completing work, determine successor based on context:
 
-**Condition**: Architectural design needed → architect-planner; otherwise → developer
-**Rationale**: Validated plans proceed to architecture or implementation
+**RDR Planning Chain Detection:**
+1. Search T1 scratch for `rdr-planning-context` tag: Use scratch tool: action="search", query="rdr-planning-context"
+2. If found, extract the RDR ID from the tag content
+3. Compare the RDR ID with any RDR reference in the current relay context (Task field, Input Artifacts)
+4. If both match → relay to `plan-enricher`
+5. If tag absent or RDR ID mismatch → use standard routing below
+
+**Standard Routing (standalone audit or non-RDR context):**
+- Architectural design needed → relay to `architect-planner`
+- Otherwise → relay to `developer`
+
+**Rationale**: When invoked as part of the RDR accept → plan → audit → enrich chain, the plan-enricher receives audit findings and enriches beads for autonomous execution (RDR-036 F-14). The RDR ID correlation prevents false positives when a session runs /rdr-accept for one RDR followed by an unrelated /plan-audit.
 
 Use the standard relay format from [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md) with:
 - Task: Clear description of what successor should do

--- a/nx/agents/plan-enricher.md
+++ b/nx/agents/plan-enricher.md
@@ -1,0 +1,199 @@
+---
+name: plan-enricher
+version: "1.0"
+description: Enriches beads with audit findings, execution context, and codebase alignment after plan-auditor validates. Use after plan-audit in RDR planning chain, or standalone for bead enrichment within the same session.
+model: sonnet
+color: emerald
+---
+
+## Usage Examples
+
+- **RDR Planning Chain**: Receives relay from plan-auditor after `/rdr-accept` dispatches planning → enriches every bead with audit findings, file paths, and execution context
+- **Standalone Same-Session**: User runs `/plan-audit` then `/enrich-plan` manually → reads T1 scratch for audit context and enriches beads
+- **Degraded Mode**: T1 has no audit findings → warns user and proceeds with context-only enrichment (codebase search, file paths, line numbers)
+
+---
+
+
+## Relay Reception (MANDATORY)
+
+Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):
+
+1. [ ] Non-empty **Task** field (1-2 sentences)
+2. [ ] **Bead** field present (ID with status, or 'none')
+3. [ ] **Input Artifacts** section with at least one artifact
+4. [ ] **Deliverable** description
+5. [ ] At least one **Quality Criterion** in checkbox format
+
+**If validation fails**, use RECOVER protocol from [CONTEXT_PROTOCOL.md](./_shared/CONTEXT_PROTOCOL.md):
+1. Search nx T3 store for missing context: Use search tool: query="[task topic]", corpus="knowledge", n=5
+2. Check nx T2 memory for session state: Use memory_search tool: query="[topic]", project="{project}"
+3. Check T1 scratch for in-session notes: Use scratch tool: action="search", query="[topic]"
+4. Query `bd list --status=in_progress`
+5. Flag incomplete relay to user
+6. Proceed with available context, documenting assumptions
+
+### Project Context
+
+T2 memory context is auto-injected by SessionStart and SubagentStart hooks.
+
+You are an expert at enriching task beads with execution-ready context derived from audit findings, codebase analysis, and dependency ordering.
+
+## T1 Context Discovery
+
+Search T1 scratch for context written by upstream agents in the current session.
+
+### Required Searches
+
+1. **RDR Planning Context**: Use scratch tool: action="search", query="rdr-planning-context"
+   - Expect: RDR ID, title, acceptance metadata
+   - If empty: warn user "No RDR planning context found in T1 scratch — proceeding with available context"
+
+2. **Plan Structure**: Use scratch tool: action="search", query="plan-structure"
+   - Expect: Epic bead ID, child bead IDs, dependency graph from strategic-planner
+   - If empty: warn user "No plan structure found in T1 scratch — will discover from beads directly"
+
+3. **Audit Findings**: Use scratch tool: action="search", query="audit-findings"
+   - Expect: Gap analysis, severity classifications, recommendations from plan-auditor
+   - If empty: warn user "No audit findings found in T1 scratch — proceeding with context-only enrichment (degraded mode)"
+
+### Degraded Mode
+
+If any T1 search returns empty:
+- Log which searches returned empty
+- Warn user with specific missing context
+- Proceed with available context — enrichment is still valuable without audit findings
+- Skip audit-specific enrichment (gap mitigations, severity classifications) when audit findings are missing
+
+## Bead Enrichment Workflow
+
+Use `mcp__sequential-thinking__sequentialthinking` for design decisions during enrichment.
+
+**When to Use**: Deciding how to map audit findings to specific beads, resolving ambiguous file paths, choosing between enrichment approaches for complex beads.
+
+### Step 1: Discover Beads
+
+1. Get epic bead ID from T1 plan structure (or from relay Input Artifacts)
+2. If no epic ID available, ask user: "Which epic bead should I enrich?"
+3. Run `bd show <epic-id>` to get all child beads
+4. Build a working list of all beads to enrich
+
+### Step 2: Read Current State
+
+For each child bead:
+1. Run `bd show <id>` to read current description
+2. Note existing context, dependencies, and gaps
+
+### Step 3: Enrich Each Bead
+
+For each child bead, update its description with:
+
+- **Audit-identified gaps and mitigations** (from T1 audit findings, if available):
+  - Map each audit gap to the specific bead(s) it affects
+  - Add mitigation instructions inline
+
+- **Refined dependency ordering** per audit recommendations:
+  - Adjust any dependency sequencing the auditor flagged
+  - Document why ordering changed (if it did)
+
+- **Test strategy specifics** the auditor flagged as missing:
+  - Add concrete test file paths, test names, assertion types
+  - Reference existing test patterns in the codebase
+
+- **Codebase alignment issues** the auditor discovered:
+  - Note any pattern mismatches or convention violations
+  - Include correct patterns from existing code
+
+- **Full execution context**:
+  - Specific file paths and line numbers to modify
+  - Search keywords for nx T3 store and T2 memory lookups
+  - Memory pointers to relevant prior decisions
+  - Prerequisite state (what must be true before starting)
+  - Validation checklists (what to verify after completing)
+
+### Step 4: Update Beads
+
+For each enriched bead:
+```bash
+bd update <id> --description "enriched content"
+```
+
+## T2 Persistence
+
+Plan-enricher owns the T2 write for epic bead ID — the accept skill's execution context is gone by this point.
+
+1. **Write epic bead ID to T2**: First read the existing T2 record via memory_get tool: project="{repo}_rdr", title="NNN" (where NNN is the RDR ID extracted from the T1 `rdr-planning-context` scratch entry). Then write back the **full merged content** — all original fields (status, type, priority, file_path, etc.) plus the new fields `epic_bead: <epic-id>`, `enriched: YYYY-MM-DD`, `bead_count: N`. Use memory_put tool with the merged content.
+   - **Critical**: Do not write only the new fields — memory_put overwrites by key, so omitting existing fields will lose them
+
+2. **Write enrichment summary to T1**: Use scratch tool: action="put", content="Plan enrichment complete for RDR-NNN: {N} beads enriched, epic={epic-id}", tags="enrichment-complete,rdr-NNN"
+
+## Beads Integration
+
+- Verify all beads referenced in T1 exist via `bd show`
+- Check bead dependencies match plan dependencies
+- Flag any orphan beads (referenced but not found) or missing references
+- Report discrepancies to user before proceeding
+
+## NO Successor Enforcement
+
+Plan-enricher is the terminal node in the planning chain. It does NOT relay to any downstream agent.
+
+After completing enrichment:
+1. Display enriched plan summary table to user:
+   - Bead ID | Title | Status | Enrichment Summary
+2. Report any beads that could not be enriched (with reason)
+3. Report any audit findings that could not be mapped to beads
+4. Print total beads enriched and ready for implementation
+
+
+## Context Protocol
+
+This agent follows the [Shared Context Protocol](./_shared/CONTEXT_PROTOCOL.md).
+
+See [ERROR_HANDLING.md](./_shared/ERROR_HANDLING.md) for common error patterns and recovery.
+
+### Agent-Specific PRODUCE
+- **Enriched Beads**: Updated via `bd update <id> --description "..."` with execution-ready context
+- **T2 memory**: Epic bead ID written via memory_put tool: project="{repo}_rdr", title="NNN"
+- **T1 scratch**: Enrichment summary via scratch tool: action="put", tags="enrichment-complete"
+- **Console output**: Enriched plan summary table
+
+Store using these naming conventions:
+- **nx memory**: Use memory_put tool: project="{repo}_rdr", title="NNN" (updates existing RDR record)
+- **Bead Description**: Include `Context: nx` line
+
+### Completion Protocol
+
+**CRITICAL**: Complete all data persistence BEFORE generating final response to mitigate framework relay bug.
+
+**Sequence** (follow strictly):
+1. **Update All Beads**: Run `bd update` for every enriched bead
+2. **Write T2 Record**: Store epic bead ID and enrichment metadata via memory_put tool
+3. **Write T1 Summary**: Store enrichment summary to scratch
+4. **Verify Persistence**: Confirm beads updated (bd show <id> for sample), T2 written (memory_get)
+5. **Generate Response**: Only after all above steps complete, generate final enrichment report
+
+**Verification Checklist**:
+- [ ] All beads updated with enriched descriptions (spot-check via bd show)
+- [ ] T2 RDR record includes epic_bead field (verify via memory_get)
+- [ ] T1 enrichment summary written
+- [ ] All data persisted before composing final response
+
+**If Verification Fails** (partial persistence):
+1. **Retry once**: Attempt failed bd update or memory_put again
+2. **Document partial state**: Note which beads succeeded/failed in response
+3. **Persist recovery notes**: Use memory_put tool: content="failure details", project="{project}", title="enrichment-failure-{date}.md"
+4. **Continue with response**: Include count of succeeded enrichments and list of failed bead IDs
+
+**Rationale**: The framework error occurs during task completion AFTER the agent finishes. By persisting all data first, we ensure no work is lost even if the framework error occurs.
+
+## Known Issues
+
+**Framework Error (Claude Code 2.1.27)**: This agent may fail with `classifyHandoffIfNeeded is not defined` during the completion phase. This is a **cosmetic error** in the Claude Code framework:
+
+- All bead updates and T2 writes complete successfully before the error
+- Data is persisted — enriched beads, T2 records, T1 scratch all written
+- The error occurs during cleanup, not during enrichment
+- Error notification can be safely ignored
+
+**Workaround**: Verify bead enrichment via `bd show <id>` and T2 record via memory_get tool — data will be present despite the error.

--- a/nx/agents/strategic-planner.md
+++ b/nx/agents/strategic-planner.md
@@ -104,14 +104,12 @@ Set `needsMoreThoughts: true` to continue, use `isRevision: true, revisesThought
    - Reminder to use `mcp__sequential-thinking__sequentialthinking` for complex work
    - Context pointers to nx memory, nx store, or documentation
 
-### Phase 3: Audit and Iteration
+### Phase 3: Audit Handoff
 **MANDATORY**: Always use the plan-auditor agent to review plans before finalization:
 - Check for completeness and gaps
 - Identify redundancy and consolidation opportunities
 - Validate dependency ordering
 - Verify TDD compliance in task structure
-
-Iterate based on audit feedback until the plan passes review.
 
 
 

--- a/nx/commands/enrich-plan.md
+++ b/nx/commands/enrich-plan.md
@@ -1,0 +1,51 @@
+---
+description: Enrich beads with audit findings using plan-enricher agent
+---
+
+# Enrich Plan
+
+!{
+  echo "## Context"
+  echo ""
+  echo "**Working directory:** $(pwd)"
+  echo ""
+
+  # Bead context
+  echo "### Related Beads"
+  echo '```'
+  if command -v bd &> /dev/null; then
+    bd list --type=epic --status=open --limit=5 2>/dev/null || echo "No open epics"
+  else
+    echo "Beads not available"
+  fi
+  echo '```'
+}
+
+## Plan to Enrich
+
+$ARGUMENTS
+
+## Action
+
+Invoke the **enrich-plan** skill with the following relay. Fill in dynamic fields from the context above:
+
+```markdown
+## Relay: plan-enricher
+
+**Task**: Enrich all beads with audit findings, execution context, and codebase alignment
+**Bead**: [fill from epic bead above or 'none']
+
+### Input Artifacts
+- nx scratch: audit findings, plan structure, bead IDs (from same-session /plan-audit)
+- Files: [fill from key files referenced in plan]
+
+### Deliverable
+All beads enriched with audit-identified gaps, test strategies, dependency refinements, and full execution context. Epic bead ID persisted to T2.
+
+### Quality Criteria
+- [ ] Every bead enriched with audit findings (or context-only if T1 miss)
+- [ ] Epic bead ID written to T2 for close-time advisory
+- [ ] Enrichment summary reported to user
+```
+
+For full relay structure, see [RELAY_TEMPLATE.md](../agents/_shared/RELAY_TEMPLATE.md).

--- a/nx/commands/rdr-accept.md
+++ b/nx/commands/rdr-accept.md
@@ -178,6 +178,25 @@ print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}\"
 print()
 
 print(f"**RDR file path:** `{rdr_file}`")
+print()
+
+# Phase count auto-detection for planning handoff
+ip_match = re.search(
+    r'^## Implementation Plan\s*\n(.*?)(?=^## |\Z)',
+    text, re.MULTILINE | re.DOTALL)
+phase_count = 0
+if ip_match:
+    phase_count = len(re.findall(r'^### Phase', ip_match.group(1), re.MULTILINE))
+
+print("### Planning Handoff")
+print(f"**Phase count detected:** {phase_count}")
+if phase_count >= 2:
+    print("**Recommendation:** Invoke strategic planner (multi-phase RDR)")
+    print("**Default:** yes")
+else:
+    print("**Recommendation:** Skip planning (single-phase or no implementation plan)")
+    print("**Default:** no")
+print()
 PYEOF
 }
 
@@ -197,4 +216,11 @@ All data is pre-loaded above — no additional tool calls needed.
 - **Update `reviewed-by`**: If `reviewed-by` is empty or placeholder, set to `self` (solo review).
 - **Regenerate README**: Update `{rdr_dir}/README.md` index to reflect the new status.
 - **Stage files**: `git add` the modified RDR file and README.
+- **Step 7 (Planning handoff)**: Use the phase count and recommendation above.
+  - Ask: "Invoke strategic planner to build execution beads? (y/n) [default from above]"
+  - If yes:
+    1. Write T1 scratch entry: Use scratch tool: action="put", content="RDR {id}: planning context for {title}", tags="rdr-planning-context,rdr-{id}"
+    2. Dispatch strategic-planner agent with full RDR content
+    3. Chain proceeds automatically: planner → auditor → enricher
+  - If no: Skip — accept is complete
 - Print confirmation: `> RDR {id} accepted. Ready for implementation or '/rdr-close {id} --reason implemented'.`

--- a/nx/commands/rdr-close.md
+++ b/nx/commands/rdr-close.md
@@ -1,5 +1,5 @@
 ---
-description: Close an RDR with optional post-mortem, bead decomposition, and T3 archival
+description: Close an RDR with optional post-mortem, bead status advisory, and T3 archival
 ---
 
 # RDR Close
@@ -165,20 +165,11 @@ print("### T2 Metadata (current status)")
 print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}\" to retrieve T2 metadata.")
 print()
 
-# Implementation Plan section (for bead decomposition)
-print("### Implementation Plan (for bead decomposition)")
-ip_match = re.search(
-    r'^## Implementation Plan\s*\n(.*?)(?=^## |\Z)',
-    text, re.MULTILINE | re.DOTALL)
-if ip_match:
-    section = ip_match.group(1).strip()
-    # Limit to first 60 lines to avoid overwhelming output
-    lines = section.splitlines()[:60]
-    print('\n'.join(lines))
-    if len(section.splitlines()) > 60:
-        print(f"... ({len(section.splitlines()) - 60} more lines)")
-else:
-    print("_No `## Implementation Plan` section found in this RDR._")
+# Bead status advisory
+print("### Bead Status Advisory")
+print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}\" to check for `epic_bead` field.")
+print(f"If `epic_bead` exists, run `bd show <epic-id>` to display child bead statuses.")
+print(f"If no `epic_bead`, skip advisory (user skipped planning at accept time).")
 print()
 
 # Active beads
@@ -205,8 +196,8 @@ All data is pre-loaded above — no additional tool calls needed.
 - RDR directory is shown above (from `.nexus.yml` `indexing.rdr_paths[0]`).
 - Parse RDR ID and close reason from `$ARGUMENTS` (e.g. `003 --reason implemented`).
 - Pre-check warning is shown above if status is not Final when reason is Implemented.
-- **Implemented**: review Implementation Plan above for divergences, optionally create post-mortem, decompose into beads.
-- **Reverted / Abandoned**: offer post-mortem, no bead decomposition.
+- **Implemented**: review for divergences, optionally create post-mortem, display bead status advisory.
+- **Reverted / Abandoned**: offer post-mortem.
 - **Superseded**: prompt for superseding RDR ID, cross-link both files.
 - Post-mortem archive location: `{rdr_dir}/post-mortem/NNN-kebab-title.md`.
 - Update RDR file status field and register close in T2: use **memory_put** tool: project="{repo}_rdr", title="{id}" with updated status fields.

--- a/nx/registry.yaml
+++ b/nx/registry.yaml
@@ -232,8 +232,26 @@ agents:
       - "Codebase alignment"
     typical_runtime: "30-60 seconds"
     predecessors: [strategic-planner]
-    successors: [architect-planner, developer]
+    successors: [architect-planner, developer, plan-enricher]
 
+  plan-enricher:
+    model: sonnet
+    version: "1.0"
+    color: emerald
+    skill: enrich-plan
+    slash_command: /enrich-plan
+    description: "Enriches beads with audit findings and execution context"
+    triggers:
+      - "plan-auditor completes in RDR planning chain"
+      - "user says enrich beads or groom plan"
+      - "beads need audit findings folded in"
+    strengths:
+      - "Bead enrichment"
+      - "Audit finding integration"
+      - "Execution context assembly"
+    typical_runtime: "30-60 seconds"
+    predecessors: [plan-auditor]
+    successors: []
 
   strategic-planner:
     model: opus
@@ -336,7 +354,8 @@ rdr_skills:
   rdr-accept:
     slash_command: /rdr-accept
     command_file: commands/rdr-accept.md
-    description: "Accept a gated RDR — verify gate PASSED, update T2 and file status"
+    description: "Accept a gated RDR — verify gate PASSED, update status, optional planning dispatch"
+    dispatches_to: [strategic-planner]
     triggers:
       - "accept this RDR"
       - "mark RDR as accepted"
@@ -345,7 +364,7 @@ rdr_skills:
   rdr-close:
     slash_command: /rdr-close
     command_file: commands/rdr-close.md
-    description: "Close RDR with post-mortem, bead decomposition, T3 archive"
+    description: "Close RDR with post-mortem, bead status advisory, T3 archive"
     triggers:
       - "close this RDR"
       - "RDR done"
@@ -440,6 +459,7 @@ pipelines:
     sequence:
       - strategic-planner
       - plan-auditor
+      - plan-enricher  # conditional: only when rdr-planning-context T1 tag present
       - architect-planner
       - developer
       - code-review-expert
@@ -511,6 +531,7 @@ model_summary:
     - deep-research-synthesizer
     - developer
     - plan-auditor
+    - plan-enricher
     - test-validator
   haiku: # Fast, cheap - utility agents
     - knowledge-tidier

--- a/nx/skills/enrich-plan/SKILL.md
+++ b/nx/skills/enrich-plan/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: enrich-plan
+description: Use after plan-audit to enrich beads with audit findings, execution context, and codebase alignment for autonomous execution
+---
+
+# Enrich Plan Skill
+
+Delegates to the **plan-enricher** agent (sonnet). See [registry.yaml](../../registry.yaml).
+
+## When This Skill Activates
+
+- After plan-auditor completes in RDR planning chain (automatic relay)
+- User says "enrich beads", "groom plan", "enrich plan"
+- User invokes `/enrich-plan`
+- After `/plan-audit` when beads need audit findings folded in
+
+## Agent Invocation
+
+Use the Task tool to invoke **plan-enricher**:
+
+```markdown
+## Relay: plan-enricher
+
+**Task**: Enrich all beads with audit findings, execution context, and codebase alignment
+**Bead**: [epic bead ID] or 'none'
+
+### Input Artifacts
+- nx scratch: audit findings, plan structure, bead IDs (from same-session /plan-audit)
+- Files: [RDR file path if known]
+
+### Deliverable
+All beads enriched with audit-identified gaps, test strategies, dependency refinements, and full execution context. Epic bead ID persisted to T2.
+
+### Quality Criteria
+- [ ] Every bead enriched with audit findings (or context-only if T1 miss)
+- [ ] Epic bead ID written to T2 for close-time advisory
+- [ ] Enrichment summary reported to user
+```
+
+For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
+
+## Session Scope Note
+
+T1 scratch is session-scoped. Standalone invocation only works within the same session where `/plan-audit` ran. Cross-session use requires re-running `/plan-audit` first to populate T1 with audit findings.
+
+## Success Criteria
+
+- [ ] Plan-enricher agent dispatched with relay template
+- [ ] All beads enriched with available context
+- [ ] Epic bead ID persisted to T2
+- [ ] Enrichment summary displayed

--- a/nx/skills/rdr-accept/SKILL.md
+++ b/nx/skills/rdr-accept/SKILL.md
@@ -25,10 +25,26 @@ Accepts an RDR after it passes the gate. This is the author/reviewer decision po
 4. **Update reviewed-by** — set to `self` if empty.
 5. **Regenerate README** — update `{rdr_dir}/README.md` index.
 6. **Stage files** — `git add` modified files.
+7. **Planning handoff** (optional) — Auto-detect complexity:
+   - Count `### Phase` headings in the RDR's Implementation Plan section
+   - If 2+ phases → default yes; if 0-1 phases or no Implementation Plan → default no
+   - Ask: "Invoke strategic planner to build execution beads? (y/n) [default]"
+   - **If yes:**
+     1. Write T1 scratch entry tagged `rdr-planning-context` with RDR ID and planning metadata: Use scratch tool: action="put", content="RDR {id}: planning context for {title}", tags="rdr-planning-context,rdr-{id}"
+     2. Dispatch `strategic-planner` agent via Task tool with relay:
+        - Task: Create phased execution plan for RDR-{id}: {title}
+        - Bead: Create new epic
+        - Input Artifacts: RDR file path, T2 metadata
+        - T1 scratch has RDR content and planning context tagged `rdr-planning-context`
+     3. Chain proceeds: strategic-planner → plan-auditor → plan-enricher (automatic via successor enforcement)
+     4. Plan-enricher writes epic bead ID to T2 at chain end
+   - **If no:** Continue — no beads created
 
 ## Agent Invocation
 
-This skill executes directly — no agent delegation. All state mutations are performed by the skill itself using `nx memory`, filesystem writes, and `git add`.
+Steps 1-6 execute directly — no agent delegation. Step 7 (planning handoff) optionally dispatches the `strategic-planner` agent, which chains to `plan-auditor` then `plan-enricher` via successor enforcement. The accept skill writes a T1 scratch entry tagged `rdr-planning-context` before dispatch to enable the plan-auditor → plan-enricher routing (RDR-036 F-14).
+
+**Important**: Step 2 (T2 `status: accepted` write) must complete before Step 7 (planner dispatch) to satisfy RDR-024 Guardrail 2 (strategic-planner pre-check warns if RDR not accepted).
 
 ## Success Criteria
 
@@ -37,11 +53,16 @@ This skill executes directly — no agent delegation. All state mutations are pe
 - [ ] File frontmatter updated to match T2
 - [ ] README index regenerated
 - [ ] Files staged via git add
+- [ ] Planning handoff prompt shown with correct default (phase count heuristic)
+- [ ] T1 scratch entry written with rdr-planning-context tag before planner dispatch
+- [ ] Strategic-planner dispatched with relay template (if user accepts)
 
 ## Agent-Specific PRODUCE
 
-Outputs produced directly by this skill (no agent delegation):
+Outputs produced directly by this skill (Steps 1-6):
 
 - **T2 memory**: Updated status record via memory_put tool: project="{repo}_rdr", title="NNN", ttl="permanent", tags="rdr,accepted"
 - **Filesystem**: Updated RDR markdown (frontmatter `status: accepted`, `accepted_date`), regenerated `{rdr_dir}/README.md`
 - **T1 scratch**: Use scratch tool: action="put", content="RDR NNN: accepted YYYY-MM-DD" for ephemeral tracking during multi-step acceptance flow
+- **T1 scratch**: rdr-planning-context tag entry via scratch tool (for plan-auditor successor routing)
+- **Agent dispatch**: strategic-planner via Task tool (optional, user-confirmed)

--- a/nx/skills/rdr-close/SKILL.md
+++ b/nx/skills/rdr-close/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: rdr-close
-description: Use when an RDR is done — close it with optional post-mortem, bead decomposition, and T3 archival
+description: Use when an RDR is done — close it with optional post-mortem, bead status advisory, and T3 archival
 ---
 
 # RDR Close Skill
 
-Creates beads directly. Optionally delegates post-mortem archival to the **knowledge-tidier** agent (haiku). See [registry.yaml](../../registry.yaml).
+Reports bead status as advisory. Optionally delegates post-mortem archival to the **knowledge-tidier** agent (haiku). See [registry.yaml](../../registry.yaml).
 
 ## When This Skill Activates
 
@@ -57,30 +57,22 @@ Create `$RDR_DIR/post-mortem/NNN-kebab-title.md` from the post-mortem template. 
   - Internal contradiction
   - Missing cross-cutting concern
 
-### Step 3: Decompose into Beads
+### Step 3: Bead Status Advisory
 
-Parse the Implementation Plan section directly (the skill has Bash access):
+If T2 record has an `epic_bead` field (set during accept-time planning):
+1. Read epic bead ID from T2: Use memory_get tool: project="{repo}_rdr", title="NNN"
+2. Run `bd show <epic-id>` to get child bead statuses
+3. Display bead status table to user:
+   - Bead ID, title, status (open/in_progress/closed)
+   - Highlight any unclosed beads
+4. **Advisory only** — the human decides which beads to close. Do NOT automatically mark beads complete.
 
-1. Read the RDR markdown file's Implementation Plan section
-2. Create epic bead:
-   ```bash
-   bd create --title "PREFIX-NNN: Title" --type epic --priority {priority}
-   ```
-3. For each phase/step in the Implementation Plan, create a child bead:
-   ```bash
-   bd create --title "PREFIX-NNN Phase N: Description" --type task --priority {priority}
-   ```
-4. Wire dependencies:
-   ```bash
-   bd dep add <child-id> <epic-id>
-   ```
-5. Display the bead tree for user confirmation before proceeding
-
-**Note:** Bead creation is done directly by the skill (not delegated to an agent) because it is structured text extraction from a known schema, and the skill already has `Bash` in `allowed-tools`.
+If T2 record has no `epic_bead` field (user skipped planning at accept time):
+- Skip this step entirely. Print: "No planning beads found for this RDR."
 
 ### Step 4: Update State
 
-1. Update T2 record: Use memory_put tool: content="... (same fields, status: Implemented, closed: YYYY-MM-DD, close_reason: Implemented, epic_bead: {bead_id}, archived: true)", project="{repo}_rdr", title="NNN", ttl="permanent", tags="rdr,{type},closed"
+1. Update T2 record: Use memory_put tool: content="... (same fields, status: Implemented, closed: YYYY-MM-DD, close_reason: Implemented, archived: true)", project="{repo}_rdr", title="NNN", ttl="permanent", tags="rdr,{type},closed"
    If T3 archive fails, set `archived: false` — retryable by re-running `/rdr-close`
 
 2. Update status in RDR markdown metadata
@@ -103,8 +95,7 @@ Dispatch `knowledge-tidier` agent for post-mortem archival if the post-mortem co
 4. Update markdown metadata
 5. Run `nx index rdr` to update T3 semantic index (research findings are valuable even for failed RDRs)
 6. Archive post-mortem to `knowledge__rdr_postmortem__{repo}` (if created)
-7. Do NOT create beads
-8. Regenerate index
+7. Regenerate index
 
 ## Flow: Superseded
 
@@ -118,10 +109,9 @@ Dispatch `knowledge-tidier` agent for post-mortem archival if the post-mortem co
 ## Failure Handling
 
 The close operation performs multiple state mutations. If any step fails:
-- Each step emits clear status (e.g., "T2 updated ✓", "Beads created ✓", "T3 archive ✗ FAILED")
+- Each step emits clear status (e.g., "T2 updated ✓", "Bead advisory ✓", "T3 archive ✗ FAILED")
 - T2 `archived` flag tracks whether T3 archival succeeded
 - Re-running `/rdr-close` is idempotent: checks T2 state and skips completed steps
-- If bead creation partially fails, report which beads were created and which failed
 
 ## Relay Template (Use This Format)
 
@@ -152,15 +142,14 @@ Post-mortem archived to `knowledge__rdr_postmortem__{repo}` with drift categorie
 
 For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/RELAY_TEMPLATE.md).
 
-**Note:** Bead decomposition is handled directly by this skill (Step 3), not delegated to an agent.
-
 ## Success Criteria
 
 - [ ] RDR directory resolved from `.nexus.yml` `indexing.rdr_paths[0]` (default `docs/rdr`)
 - [ ] Pre-check completed (status verified, warnings issued for non-Final RDRs)
 - [ ] Divergence notes captured from user (if implementation diverged)
 - [ ] Post-mortem created with drift classification (if diverged or reverted/abandoned)
-- [ ] Beads created directly: epic + child beads matching Implementation Plan phases (Implemented flow only)
+- [ ] Bead status advisory displayed (if epic_bead exists in T2)
+- [ ] Beads NOT auto-closed — human decides
 - [ ] T2 record updated with close reason, date, epic bead ID, and archived flag
 - [ ] T3 semantic index updated via `nx index rdr`
 - [ ] Post-mortem archived to `knowledge__rdr_postmortem__{repo}` (if exists)
@@ -171,7 +160,7 @@ For additional optional fields, see [RELAY_TEMPLATE.md](../../agents/_shared/REL
 
 Outputs produced by this skill directly:
 
-- **Beads**: Epic + child beads via `bd create` and `bd dep add` (direct, not delegated)
+- **Console output**: Bead status advisory table (if epic_bead in T2)
 - **T2 memory**: Close metadata via memory_put tool: project="{repo}_rdr", title="NNN", ttl="permanent", tags="rdr,{type},closed"
 - **T3 semantic index**: Updated via `nx index rdr` (CCE embeddings, section-level chunks)
 - **Filesystem**: Post-mortem at `$RDR_DIR/post-mortem/NNN-kebab-title.md`, updated README

--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -86,7 +86,7 @@ Use this table to match tasks to skills. When in doubt, check the skill.
 | rdr-show | `/rdr-show` | Viewing full details and research findings for a specific RDR |
 | rdr-gate | `/rdr-gate` | RDR appears complete; needs structural + assumption + AI critique check |
 | rdr-accept | `/rdr-accept` | Gate returned PASSED; ready to officially accept the RDR |
-| rdr-close | `/rdr-close` | RDR implemented; close with optional post-mortem and bead decomposition |
+| rdr-close | `/rdr-close` | RDR implemented; close with optional post-mortem and bead status advisory |
 
 ### Standalone Reference
 


### PR DESCRIPTION
## Summary

- Moves bead creation from close-time to accept-time via an optional planning chain: `strategic-planner → plan-auditor → plan-enricher`
- New `plan-enricher` agent enriches beads with audit findings, execution context, and codebase alignment
- `rdr-accept` gains Step 7: planning handoff with phase-count auto-detection (2+ phases defaults yes)
- `rdr-close` bead decomposition replaced with read-only bead status advisory
- `plan-auditor` gains conditional successor routing via T1 `rdr-planning-context` tag

## Changed Files (16)

**New**: `plan-enricher.md` agent, `enrich-plan/SKILL.md` skill, `enrich-plan.md` command

**Modified**: `rdr-accept` skill + command, `rdr-close` skill + command, `plan-auditor.md`, `strategic-planner.md`, `registry.yaml`, `README.md`, `_shared/README.md`, `using-nx-skills/SKILL.md`, `rdr-workflow.md`, `docs/rdr/README.md`, RDR-036 spec

## Test plan

- [ ] `/enrich-plan` command loads and shows bash context injection
- [ ] `/rdr-accept` on a multi-phase RDR shows planning handoff prompt with "default: yes"
- [ ] `/rdr-accept` on a single-phase RDR shows "default: no"
- [ ] `/rdr-close` on an RDR with `epic_bead` in T2 displays bead status advisory
- [ ] `/rdr-close` on an RDR without `epic_bead` prints "No planning beads found"
- [ ] `python3 -c "import yaml; yaml.safe_load(open('nx/registry.yaml'))"` passes
- [ ] No "bead decomposition" references remain in `nx/` tree

References: nexus-f2fg (RDR-036 epic)