### PR TITLE
Documentation overhaul: README, Getting Started, RDR docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ nx index repo .                  # index your repo
 nx search "what does X do"       # search it
 ```
 
+For Claude Code, install the plugin:
+
+```bash
+/plugin marketplace add Hellblazer/nexus
+/plugin install nx@nexus-plugins
+```
+
 Scratch (`nx scratch`) and memory (`nx memory`) work with **zero API keys** — fully local. Semantic search requires [ChromaDB](https://www.trychroma.com/) and [Voyage AI](https://www.voyageai.com/) accounts (free tiers available). See [Getting Started](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md) for the full walkthrough.
 
 ## Three tiers, one lifecycle

--- a/README.md
+++ b/README.md
@@ -5,15 +5,13 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-Nexus helps you find things in your codebase by semantic meaning, not just by name.
+AI coding agents are powerful, but they forget everything between sessions. They can't recall what you decided last week, what your teammate learned about the API, or that you already tried the approach they're about to suggest. Every session starts from zero.
 
-`grep` and IDE search find exact strings. Nexus finds *concepts*: "how does authentication work here?" returns the auth middleware, the login handler, the session management code, and the JWT validation — even if none of them contain the word "authentication." It understands what your code does, not just what it says.
-
-That matters most when you're working with AI coding agents. An agent that can search your codebase semantically before proposing changes makes fewer mistakes, avoids reinventing things that already exist, and builds on your actual architecture instead of guessing.
+Nexus gives agents — and you — persistent memory and semantic search across your code, your projects, and your accumulated knowledge. Not just "better grep." A lightweight knowledge management system where agents and humans share context that survives beyond a single conversation.
 
 ## What it does
 
-**Search by meaning.** Index any git repo. Code is parsed into logical chunks (functions, classes, methods) using tree-sitter across 31 languages. Prose and PDFs are split semantically. Everything is embedded with Voyage AI models so you search by concept, not keywords.
+**Search by meaning, not just keywords.** `grep` finds exact strings. Nexus finds *concepts*: "how does authentication work?" returns the auth middleware, the login handler, and the JWT validation — even if none contain the word "authentication."
 
 ```bash
 nx index repo .                  # index current repo
@@ -21,10 +19,10 @@ nx search "error handling"       # finds try/catch, Result types, error middlewa
 nx search "auth" --hybrid        # combine semantic + keyword matching
 ```
 
-**Remember things across sessions.** Scratch notes that disappear when you're done, project memory that persists locally, and permanent knowledge in the cloud — use whichever fits.
+**Remember things at every scale.** Quick notes for this session, project decisions that persist across months, reference material searchable across all your work — each at the right level of permanence.
 
 ```bash
-nx scratch put "the bug is in the retry logic"    # gone after this session
+nx scratch put "the bug is in the retry logic"    # session-scoped, shared across agents
 nx memory put --project myapp --title "DB choice"  "Chose Postgres over SQLite for concurrency"
 nx store put --collection knowledge__myapp "API rate limit is 10k/min per the vendor docs"
 ```
@@ -44,17 +42,19 @@ nx search "what does X do"       # search it
 
 Scratch (`nx scratch`) and memory (`nx memory`) work with **zero API keys** — no accounts needed, fully local. Semantic search (`nx search`, `nx index`) requires [ChromaDB](https://www.trychroma.com/) and [Voyage AI](https://www.voyageai.com/) accounts — both offer free tiers that cover typical usage. See [Getting Started](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md) for the full setup walkthrough.
 
-## Storage: start local, add cloud when ready
+## Three tiers, one lifecycle
 
-Nexus has three storage tiers so you can start with zero setup and add capabilities as you need them:
+Each tier exists because different information has different lifetimes and different access patterns. Together they form an integrated memory system that agents use synergistically — extending Claude's context across sessions, across projects, and across knowledge islands that would otherwise stay siloed.
 
-| What you need | Tier | Storage | API keys? |
-|--------------|------|---------|-----------|
-| Quick notes for this session | **Scratch** (T1) | In-memory | No |
-| Project notes that survive restarts | **Memory** (T2) | Local SQLite | No |
-| Search across all your code and knowledge | **Knowledge** (T3) | ChromaDB cloud + Voyage AI | Yes (free tier) |
+| Tier | Purpose | Storage | API keys? |
+|------|---------|---------|-----------|
+| **Scratch** (T1) | Ephemeral session context — shared across all agents in a session, gone when you're done | In-memory ChromaDB | No |
+| **Memory** (T2) | Project-level persistence — decisions, context, findings with full-text search | Local SQLite + FTS5 | No |
+| **Knowledge** (T3) | Permanent semantic knowledge — code, papers, docs, decisions searchable by meaning across all projects | ChromaDB cloud + Voyage AI | Yes (free tier) |
 
-You don't need to understand tiers to use Nexus. `nx scratch` just works. `nx memory` just works. When you want semantic search, run `nx config init` to add API keys and you're in T3 territory.
+T1 and T2 work with zero setup — no API keys, no accounts, fully local. T3 adds semantic search when you're ready: `nx config init` to connect, then index what matters to you.
+
+An agent debugging a problem writes its hypotheses to T1 scratch so sibling agents don't repeat work. It checks T2 for project decisions that constrain the fix. It searches T3 for how similar problems were solved elsewhere. Each tier contributes context that no single conversation could hold.
 
 ## The CLI
 
@@ -72,18 +72,19 @@ You don't need to understand tiers to use Nexus. `nx scratch` just works. `nx me
 
 Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs/cli-reference.md).
 
-## Repository indexing
+## What you can index
 
-`nx index repo` walks your git-tracked files and:
+T3 isn't limited to code. Anything you want searchable by meaning can go in:
 
-1. **Classifies** each file — code (52 extensions), prose (markdown), PDF, or skip (config, lock files)
-2. **Chunks** code into logical pieces using tree-sitter AST parsing (functions, classes, methods — not arbitrary line splits)
-3. **Chunks** prose at section boundaries, PDFs at layout boundaries
-4. **Embeds** each chunk with a purpose-matched Voyage AI model (`voyage-code-3` for code, `voyage-context-3` for prose)
-5. **Routes** to separate collections: `code__<repo>`, `docs__<repo>`, `rdr__<repo>`
-6. **Scores** with git frecency so recently-touched files rank higher
+```bash
+nx index repo .                          # code + docs + RDRs from a git repo
+nx index pdf paper.pdf --collection knowledge__ml  # reference papers
+nx store put --collection knowledge__ops "Redis maxmemory-policy: allkeys-lru for cache, noeviction for queues"
+```
 
-Configurable per-repo via `.nexus.yml`. Stable across git worktrees. See [Repo Indexing](https://github.com/Hellblazer/nexus/blob/main/docs/repo-indexing.md).
+**Repository indexing** (`nx index repo`) is the most automated path: it walks git-tracked files, classifies them (code, prose, PDF), chunks code into logical pieces via tree-sitter AST parsing across 31 languages, and embeds each chunk with purpose-matched Voyage AI models. Recently-touched files rank higher via git frecency scoring.
+
+See [Repo Indexing](https://github.com/Hellblazer/nexus/blob/main/docs/repo-indexing.md) for details and `.nexus.yml` configuration.
 
 ## RDR: Research-Design-Review
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-AI coding agents lose all context between sessions. Prior decisions, research findings, and accumulated project knowledge vanish with each new conversation.
-
-Nexus is a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and humans share the same tiered storage, so context built in one session is available in every session that follows.
+AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus is a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and humans share the same tiered storage, so context built in one session is available in every session that follows.
 
 Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents. The result is a persistent decision history that agents consult before proposing new work and humans review to understand why the codebase evolved as it did.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-Nexus helps you find things in your codebase by meaning, not just by name.
+Nexus helps you find things in your codebase by semantic meaning, not just by name.
 
 `grep` and IDE search find exact strings. Nexus finds *concepts*: "how does authentication work here?" returns the auth middleware, the login handler, the session management code, and the JWT validation — even if none of them contain the word "authentication." It understands what your code does, not just what it says.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and humans share the same tiered storage, so context built in one session is available in every session that follows.
+AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and teams share the same tiered storage, so context built in one session is available in every session that follows.
 
-Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents. The result is a persistent decision history that agents consult before proposing new work and humans review to understand why the codebase evolved as it did.
+Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents. The result is a persistent decision history that agents consult before proposing new work and teams review to understand why the codebase evolved as it did.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context is shared across agent invocations and sessions.
+AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus addresses this with a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context is shared across agent invocations and sessions.
 
-Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus enhances this with T2 metadata tracking and T3 semantic indexing of the RDR corpus, so team members and their agents can quickly get up to speed on a project's design history and stay aligned as the codebase evolves.
+Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus indexes the RDR corpus so team members and their agents can quickly get up to speed on a project's design history and stay aligned as the codebase evolves.
 
 ## What it does
 
@@ -19,7 +19,7 @@ nx search "error handling"       # finds try/catch, Result types, error middlewa
 nx search "auth" --hybrid        # combine semantic + keyword matching
 ```
 
-**Tiered persistent memory.** Session scratch, project-level decisions, and cross-project knowledge — each stored at the appropriate level of permanence and searchability.
+**Persistent memory.** Session scratch, project-level decisions, and cross-project knowledge — each at the appropriate level of permanence.
 
 ```bash
 nx scratch put "the bug is in the retry logic"    # session-scoped, shared across agents
@@ -27,7 +27,7 @@ nx memory put --project myapp --title "DB choice"  "Chose Postgres over SQLite f
 nx store put --collection knowledge__myapp "API rate limit is 10k/min per the vendor docs"
 ```
 
-**Decision tracking.** RDR (Research-Design-Review) documents record the reasoning behind technical choices — the problem, what was investigated, what was chosen, and what was rejected. RDRs are indexed and searchable alongside code, so prior decisions surface automatically during new design work.
+**Decision tracking.** RDR documents record the reasoning behind technical choices and are searchable alongside code, so prior decisions surface automatically during new design work.
 
 ## Quick Start
 
@@ -40,21 +40,19 @@ nx index repo .                  # index your repo
 nx search "what does X do"       # search it
 ```
 
-Scratch (`nx scratch`) and memory (`nx memory`) work with **zero API keys** — no accounts needed, fully local. Semantic search (`nx search`, `nx index`) requires [ChromaDB](https://www.trychroma.com/) and [Voyage AI](https://www.voyageai.com/) accounts — both offer free tiers that cover typical usage. See [Getting Started](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md) for the full setup walkthrough.
+Scratch (`nx scratch`) and memory (`nx memory`) work with **zero API keys** — fully local. Semantic search requires [ChromaDB](https://www.trychroma.com/) and [Voyage AI](https://www.voyageai.com/) accounts (free tiers available). See [Getting Started](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md) for the full walkthrough.
 
 ## Three tiers, one lifecycle
 
-Each tier serves a distinct purpose defined by information lifetime and access pattern. Together they form an integrated memory system that extends agent context across sessions, projects, and otherwise-siloed knowledge.
+Different information has different lifetimes. Together the three tiers form an integrated memory system that extends agent context across sessions and projects.
 
 | Tier | Purpose | Storage | API keys? |
 |------|---------|---------|-----------|
 | **Scratch** (T1) | Ephemeral session context shared across all agents in a session | In-memory ChromaDB | No |
-| **Memory** (T2) | Project-level persistence with full-text search — decisions, findings, context | Local SQLite + FTS5 | No |
-| **Knowledge** (T3) | Permanent semantic knowledge — code, papers, docs, decisions searchable by meaning across all projects | ChromaDB cloud + Voyage AI | Yes (free tier) |
+| **Memory** (T2) | Project-level persistence with full-text search | Local SQLite + FTS5 | No |
+| **Knowledge** (T3) | Permanent semantic knowledge — code, papers, docs, decisions searchable by meaning | ChromaDB cloud + Voyage AI | Yes (free tier) |
 
-T1 and T2 require no API keys or external accounts. T3 adds semantic search via `nx config init`.
-
-Agents use all three tiers cooperatively: T1 scratch prevents duplicate work across sibling agents within a session, T2 provides project decisions that constrain solutions, and T3 surfaces how similar problems were resolved in other contexts. Each tier contributes information that no single conversation context could hold.
+Agents use all three tiers cooperatively. T1 scratch prevents duplicate work across sibling agents within a session. T2 provides project decisions that constrain solutions. T3 surfaces how similar problems were resolved in other contexts.
 
 ## The CLI
 
@@ -74,7 +72,7 @@ Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs
 
 ## What you can index
 
-T3 accepts any content that benefits from semantic retrieval:
+Code, documents, PDFs, and manual knowledge entries — anything that benefits from semantic search:
 
 ```bash
 nx index repo .                          # code + docs + RDRs from a git repo
@@ -82,13 +80,13 @@ nx index pdf paper.pdf --collection knowledge__ml  # reference papers
 nx store put --collection knowledge__ops "Redis maxmemory-policy: allkeys-lru for cache, noeviction for queues"
 ```
 
-**Repository indexing** (`nx index repo`) is the most automated path: it walks git-tracked files, classifies them (code, prose, PDF), chunks code into logical pieces via tree-sitter AST parsing across 31 languages, and embeds each chunk with purpose-matched Voyage AI models. Recently-touched files rank higher via git frecency scoring.
+Repository indexing (`nx index repo`) is the most automated path. It classifies git-tracked files, chunks code into logical pieces via tree-sitter AST parsing across 31 languages, and embeds each chunk with purpose-matched Voyage AI models. Recently-touched files rank higher via git frecency scoring.
 
 See [Repo Indexing](https://github.com/Hellblazer/nexus/blob/main/docs/repo-indexing.md) for details and `.nexus.yml` configuration.
 
 ## RDR: Research-Design-Review
 
-Technical decisions made during rapid development — especially with AI agents — lose their reasoning quickly. An RDR captures the problem, investigation, chosen approach, and rejected alternatives in a structured, searchable format. Each finding is classified by evidence quality:
+Technical decisions made during rapid development lose their reasoning quickly. An RDR captures the problem, investigation, chosen approach, and rejected alternatives. Each finding is classified by evidence quality:
 
 | Tag | Meaning |
 |-----|---------|
@@ -96,7 +94,7 @@ Technical decisions made during rapid development — especially with AI agents 
 | **Documented** | Supported by external docs only |
 | **Assumed** | Unverified — flag it if your design depends on it |
 
-RDRs are iterative: write, build, learn, revise. Nexus has produced 36 across its own development. The growing corpus remains searchable — prior decisions surface automatically when starting new design work, preventing contradictions and redundant investigation.
+RDRs are iterative: write, build, learn, revise. The growing corpus remains searchable, so prior decisions surface automatically when starting new design work.
 
 RDR is fully optional. See [RDR Overview](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-overview.md) for the full process.
 
@@ -109,15 +107,7 @@ The `nx/` directory is a Claude Code plugin that gives agents access to everythi
 /plugin install nx@nexus-plugins
 ```
 
-What the plugin adds:
-
-- **15 agents** — code review, debugging, architecture, research, strategic planning, and more — each on a model matched to its task (opus for reasoning, sonnet for implementation)
-- **28 skills** — RDR lifecycle, TDD discipline, brainstorming gates, CLI reference
-- **Session hooks** — auto-initialize scratch, surface project context, health-check dependencies
-- **Slash commands** — `/research`, `/create-plan`, `/review-code`, `/rdr-create`, `/rdr-accept`, etc.
-- **Two MCP servers** — 8 structured storage tools (agents access T1/T2/T3 without Bash) and sequential-thinking for hypothesis-driven reasoning
-
-Agents search your indexed code before proposing changes. They check prior RDR decisions before designing new features. They coordinate through standard pipelines (plan → implement → review → test) with built-in quality gates.
+The plugin provides 15 specialized agents, 28 skills covering the RDR lifecycle and development workflows, session hooks for automatic context initialization, and MCP servers for structured storage access. Agents search indexed code before proposing changes, check prior RDR decisions before designing new features, and coordinate through standard pipelines (plan → implement → review → test) with built-in quality gates.
 
 The plugin integrates with [Beads](https://github.com/BeadsProject/beads) for task tracking. See [nx/README.md](https://github.com/Hellblazer/nexus/blob/main/nx/README.md) for the full plugin documentation.
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ nx search "error handling"       # finds try/catch, Result types, error middlewa
 nx search "auth" --hybrid        # combine semantic + keyword matching
 ```
 
-**Persistent memory.** Session scratch, project-level decisions, and cross-project knowledge — each at the appropriate level of permanence.
+**Persistent memory.** Agents share ephemeral session context for inter-agent coordination, project-level decisions persist locally with full-text search, and cross-project knowledge is stored permanently with semantic retrieval.
 
 ```bash
-nx scratch put "the bug is in the retry logic"    # session-scoped, shared across agents
+nx scratch put "the bug is in the retry logic"    # T1: inter-agent session context
 nx memory put --project myapp --title "DB choice"  "Chose Postgres over SQLite for concurrency"
 nx store put --collection knowledge__myapp "API rate limit is 10k/min per the vendor docs"
 ```
@@ -48,11 +48,11 @@ Different information has different lifetimes. Together the three tiers form an 
 
 | Tier | Purpose | Storage | API keys? |
 |------|---------|---------|-----------|
-| **Scratch** (T1) | Ephemeral session context shared across all agents in a session | In-memory ChromaDB | No |
+| **Scratch** (T1) | Inter-agent session context — coordination and knowledge sharing across agent invocations | In-memory ChromaDB | No |
 | **Memory** (T2) | Project-level persistence with full-text search | Local SQLite + FTS5 | No |
 | **Knowledge** (T3) | Permanent semantic knowledge — code, papers, docs, decisions searchable by meaning | ChromaDB cloud + Voyage AI | Yes (free tier) |
 
-Agents use all three tiers cooperatively. T1 scratch prevents duplicate work across sibling agents within a session. T2 provides project decisions that constrain solutions. T3 surfaces how similar problems were resolved in other contexts.
+Agents use all three tiers cooperatively. T1 enables inter-agent communication — sharing findings and preventing duplicate work within a session. T2 provides project decisions that constrain solutions. T3 surfaces how similar problems were resolved in other contexts.
 
 ## The CLI
 
@@ -62,7 +62,7 @@ Agents use all three tiers cooperatively. T1 scratch prevents duplicate work acr
 | `nx index` | Index git repos, PDFs, and markdown into searchable collections |
 | `nx store` | Store, retrieve, export, and import knowledge entries |
 | `nx memory` | Per-project persistent notes (local, no API keys) |
-| `nx scratch` | Ephemeral session scratch pad (in-memory, no API keys) |
+| `nx scratch` | Inter-agent session context (in-memory, no API keys) |
 | `nx collection` | Inspect and manage cloud collections |
 | `nx config` | Credentials and settings |
 | `nx doctor` | Health check — verifies dependencies, credentials, connectivity |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context is shared across agent invocations and sessions.
 
-Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus enhances this with T2 metadata tracking and T3 semantic indexing of the RDR corpus, so team members and their agents can quickly get up to speed on a project's design history and maintain traction control as the codebase evolves.
+Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus enhances this with T2 metadata tracking and T3 semantic indexing of the RDR corpus, so team members and their agents can quickly get up to speed on a project's design history and stay aligned as the codebase evolves.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-AI coding agents are powerful, but they forget everything between sessions. They can't recall what you decided last week, what your teammate learned about the API, or that you already tried the approach they're about to suggest. Every session starts from zero.
+AI coding agents lose all context between sessions. Prior decisions, research findings, and accumulated project knowledge vanish with each new conversation.
 
-Nexus gives agents — and you — persistent memory and semantic search across your code, your projects, and your accumulated knowledge. Not just "better grep." A lightweight knowledge management system where agents and humans share context that survives beyond a single conversation.
+Nexus is a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and humans share the same tiered storage, so context built in one session is available in every session that follows.
 
 ## What it does
 
-**Search by meaning, not just keywords.** `grep` finds exact strings. Nexus finds *concepts*: "how does authentication work?" returns the auth middleware, the login handler, and the JWT validation — even if none contain the word "authentication."
+**Semantic search.** Standard text search matches exact strings. Nexus matches by meaning: querying "how does authentication work" returns the auth middleware, the login handler, and the JWT validation — even when none contain the word "authentication."
 
 ```bash
 nx index repo .                  # index current repo
@@ -19,7 +19,7 @@ nx search "error handling"       # finds try/catch, Result types, error middlewa
 nx search "auth" --hybrid        # combine semantic + keyword matching
 ```
 
-**Remember things at every scale.** Quick notes for this session, project decisions that persist across months, reference material searchable across all your work — each at the right level of permanence.
+**Tiered persistent memory.** Session scratch, project-level decisions, and cross-project knowledge — each stored at the appropriate level of permanence and searchability.
 
 ```bash
 nx scratch put "the bug is in the retry logic"    # session-scoped, shared across agents
@@ -27,7 +27,7 @@ nx memory put --project myapp --title "DB choice"  "Chose Postgres over SQLite f
 nx store put --collection knowledge__myapp "API rate limit is 10k/min per the vendor docs"
 ```
 
-**Track decisions, not just code.** RDR (Research-Design-Review) documents record *why* you made a choice — the problem, what you found, what you picked, what you rejected. They're searchable alongside your code so "didn't we already decide about caching?" has a real answer instead of a Slack archaeology expedition.
+**Decision tracking.** RDR (Research-Design-Review) documents record the reasoning behind technical choices — the problem, what was investigated, what was chosen, and what was rejected. RDRs are indexed and searchable alongside code, so prior decisions surface automatically during new design work.
 
 ## Quick Start
 
@@ -44,17 +44,17 @@ Scratch (`nx scratch`) and memory (`nx memory`) work with **zero API keys** — 
 
 ## Three tiers, one lifecycle
 
-Each tier exists because different information has different lifetimes and different access patterns. Together they form an integrated memory system that agents use synergistically — extending Claude's context across sessions, across projects, and across knowledge islands that would otherwise stay siloed.
+Each tier serves a distinct purpose defined by information lifetime and access pattern. Together they form an integrated memory system that extends agent context across sessions, projects, and otherwise-siloed knowledge.
 
 | Tier | Purpose | Storage | API keys? |
 |------|---------|---------|-----------|
-| **Scratch** (T1) | Ephemeral session context — shared across all agents in a session, gone when you're done | In-memory ChromaDB | No |
-| **Memory** (T2) | Project-level persistence — decisions, context, findings with full-text search | Local SQLite + FTS5 | No |
+| **Scratch** (T1) | Ephemeral session context shared across all agents in a session | In-memory ChromaDB | No |
+| **Memory** (T2) | Project-level persistence with full-text search — decisions, findings, context | Local SQLite + FTS5 | No |
 | **Knowledge** (T3) | Permanent semantic knowledge — code, papers, docs, decisions searchable by meaning across all projects | ChromaDB cloud + Voyage AI | Yes (free tier) |
 
-T1 and T2 work with zero setup — no API keys, no accounts, fully local. T3 adds semantic search when you're ready: `nx config init` to connect, then index what matters to you.
+T1 and T2 require no API keys or external accounts. T3 adds semantic search via `nx config init`.
 
-An agent debugging a problem writes its hypotheses to T1 scratch so sibling agents don't repeat work. It checks T2 for project decisions that constrain the fix. It searches T3 for how similar problems were solved elsewhere. Each tier contributes context that no single conversation could hold.
+Agents use all three tiers cooperatively: T1 scratch prevents duplicate work across sibling agents within a session, T2 provides project decisions that constrain solutions, and T3 surfaces how similar problems were resolved in other contexts. Each tier contributes information that no single conversation context could hold.
 
 ## The CLI
 
@@ -74,7 +74,7 @@ Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs
 
 ## What you can index
 
-T3 isn't limited to code. Anything you want searchable by meaning can go in:
+T3 accepts any content that benefits from semantic retrieval:
 
 ```bash
 nx index repo .                          # code + docs + RDRs from a git repo
@@ -88,9 +88,7 @@ See [Repo Indexing](https://github.com/Hellblazer/nexus/blob/main/docs/repo-inde
 
 ## RDR: Research-Design-Review
 
-When you're coding fast — especially with AI agents — decisions happen quickly and the reasoning evaporates. A week later, nobody remembers *why* you picked Postgres over SQLite, or what the tradeoff was with the caching strategy.
-
-An RDR is a short document: the problem, what you found, what you chose, what you rejected. Nothing more. Each finding is tagged so readers know what's solid and what's a guess:
+Technical decisions made during rapid development — especially with AI agents — lose their reasoning quickly. An RDR captures the problem, investigation, chosen approach, and rejected alternatives in a structured, searchable format. Each finding is classified by evidence quality:
 
 | Tag | Meaning |
 |-----|---------|
@@ -98,9 +96,9 @@ An RDR is a short document: the problem, what you found, what you chose, what yo
 | **Documented** | Supported by external docs only |
 | **Assumed** | Unverified — flag it if your design depends on it |
 
-RDRs are iterative, not waterfall. Write one, build it, learn something, write another. Nexus has produced 35+ across its own development. The growing corpus stays searchable — when you start a new design, prior decisions surface automatically so you don't contradict yourself or redo settled work.
+RDRs are iterative: write, build, learn, revise. Nexus has produced 36 across its own development. The growing corpus remains searchable — prior decisions surface automatically when starting new design work, preventing contradictions and redundant investigation.
 
-RDR is fully optional. Use it when decisions matter; skip it when they don't. Start here: [RDR Overview](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-overview.md).
+RDR is fully optional. See [RDR Overview](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-overview.md) for the full process.
 
 ## Claude Code plugin
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and teams share the same tiered storage, so context built in one session is available in every session that follows.
 
-Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents. Because RDRs live in the shared knowledge base, every team member and every agent session sees the same decision history. Teams use this to understand how the project reached its current state, coordinate across independent workstreams, and maintain traction control over AI-assisted development as the codebase evolves.
+Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus enhances this with T2 metadata tracking and T3 semantic indexing of the RDR corpus, so team members and their agents can quickly get up to speed on a project's design history and maintain traction control as the codebase evolves.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus addresses this with a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context is shared across agent invocations and sessions.
+AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus addresses this with a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context is shared across agent invocations and sessions — and that knowledge compounds over time, becoming more valuable as the corpus grows.
 
 Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus indexes the RDR corpus so team members and their agents can quickly get up to speed on a project's design history and stay aligned as the codebase evolves.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ AI coding agents lose all context between sessions. Prior decisions, research fi
 
 Nexus is a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and humans share the same tiered storage, so context built in one session is available in every session that follows.
 
+Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents. The result is a persistent decision history that agents consult before proposing new work and humans review to understand why the codebase evolved as it did.
+
 ## What it does
 
 **Semantic search.** Standard text search matches exact strings. Nexus matches by meaning: querying "how does authentication work" returns the auth middleware, the login handler, and the JWT validation — even when none contain the word "authentication."

--- a/README.md
+++ b/README.md
@@ -54,22 +54,6 @@ Different information has different lifetimes. Together the three tiers form an 
 
 Agents use all three tiers cooperatively. T1 enables inter-agent communication — sharing findings and preventing duplicate work within a session. T2 provides project decisions that constrain solutions. T3 surfaces how similar problems were resolved in other contexts.
 
-## The CLI
-
-| Command | What it does |
-|---------|-------------|
-| `nx search` | Semantic and hybrid search across indexed code, docs, and knowledge |
-| `nx index` | Index git repos, PDFs, and markdown into searchable collections |
-| `nx store` | Store, retrieve, export, and import knowledge entries |
-| `nx memory` | Per-project persistent notes (local, no API keys) |
-| `nx scratch` | Inter-agent session context (in-memory, no API keys) |
-| `nx collection` | Inspect and manage cloud collections |
-| `nx config` | Credentials and settings |
-| `nx doctor` | Health check — verifies dependencies, credentials, connectivity |
-| `nx hooks` | Install git hooks for automatic re-indexing on commit |
-
-Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs/cli-reference.md).
-
 ## What you can index
 
 Code, documents, PDFs, and manual knowledge entries — anything that benefits from semantic search:
@@ -110,6 +94,24 @@ The `nx/` directory is a Claude Code plugin that gives agents access to everythi
 The plugin provides 15 specialized agents, 28 skills covering the RDR lifecycle and development workflows, session hooks for automatic context initialization, and MCP servers for structured storage access. Agents search indexed code before proposing changes, check prior RDR decisions before designing new features, and coordinate through standard pipelines (plan → implement → review → test) with built-in quality gates.
 
 The plugin integrates with [Beads](https://github.com/BeadsProject/beads) for task tracking. See [nx/README.md](https://github.com/Hellblazer/nexus/blob/main/nx/README.md) for the full plugin documentation.
+
+## CLI Reference
+
+The `nx` command provides direct access to all storage tiers, indexing, and search.
+
+| Command | What it does |
+|---------|-------------|
+| `nx search` | Semantic and hybrid search across indexed code, docs, and knowledge |
+| `nx index` | Index git repos, PDFs, and markdown into searchable collections |
+| `nx store` | Store, retrieve, export, and import knowledge entries |
+| `nx memory` | Per-project persistent notes (local, no API keys) |
+| `nx scratch` | Inter-agent session context (in-memory, no API keys) |
+| `nx collection` | Inspect and manage cloud collections |
+| `nx config` | Credentials and settings |
+| `nx doctor` | Health check — verifies dependencies, credentials, connectivity |
+| `nx hooks` | Install git hooks for automatic re-indexing on commit |
+
+Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs/cli-reference.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and teams share the same tiered storage, so context built in one session is available in every session that follows.
+AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context built in one session is available in every session that follows.
 
 Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus enhances this with T2 metadata tracking and T3 semantic indexing of the RDR corpus, so team members and their agents can quickly get up to speed on a project's design history and maintain traction control as the codebase evolves.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and teams share the same tiered storage, so context built in one session is available in every session that follows.
 
-Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents. The result is a persistent decision history that agents consult before proposing new work and teams review to understand why the codebase evolved as it did.
+Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents. Because RDRs live in the shared knowledge base, every team member and every agent session sees the same decision history. Teams use this to understand how the project reached its current state, coordinate across independent workstreams, and maintain traction control over AI-assisted development as the codebase evolves.
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ nx index repo .                  # index your repo
 nx search "what does X do"       # search it
 ```
 
-For Claude Code, install the plugin:
+For Claude Code, also install the plugin:
 
 ```bash
 /plugin marketplace add Hellblazer/nexus

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus addresses this with a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context is shared across agent invocations and sessions — and that knowledge compounds over time, becoming more valuable as the corpus grows.
+As projects grow in complexity — more code, more decisions, more team members, more agent sessions — the volume of relevant context quickly exceeds what any single conversation or person can hold. AI coding agents lose all context between sessions, and the reasoning behind past decisions scatters across conversations, commits, and tribal knowledge. Nexus addresses this with a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context is shared across agent invocations and sessions — and that knowledge compounds over time, becoming more valuable as the corpus grows.
 
 Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus indexes the RDR corpus so team members and their agents can quickly get up to speed on a project's design history and stay aligned as the codebase evolves.
 
@@ -59,7 +59,7 @@ Different information has different lifetimes. Together the three tiers form an 
 | **Memory** (T2) | Project-level persistence with full-text search | Local SQLite + FTS5 | No |
 | **Knowledge** (T3) | Permanent semantic knowledge — code, papers, docs, decisions searchable by meaning | ChromaDB cloud + Voyage AI | Yes (free tier) |
 
-Agents use all three tiers cooperatively. T1 enables inter-agent communication — sharing findings and preventing duplicate work within a session. T2 provides project decisions that constrain solutions. T3 surfaces how similar problems were resolved in other contexts.
+Agents use all three tiers cooperatively. T1 enables inter-agent communication — sharing findings and preventing duplicate work within a session. T2 provides project decisions that constrain solutions. T3 surfaces how similar problems were resolved in other contexts. As the T3 knowledge base grows, it becomes the project's institutional memory — managing the information overload that accompanies complex designs and long-lived codebases.
 
 ## What you can index
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context built in one session is available in every session that follows.
+AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context is shared across agent invocations and sessions.
 
 Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus enhances this with T2 metadata tracking and T3 semantic indexing of the RDR corpus, so team members and their agents can quickly get up to speed on a project's design history and maintain traction control as the codebase evolves.
 

--- a/README.md
+++ b/README.md
@@ -77,15 +77,9 @@ See [Repo Indexing](https://github.com/Hellblazer/nexus/blob/main/docs/repo-inde
 
 ## RDR: Research-Design-Review
 
-Technical decisions made during rapid development lose their reasoning quickly. An RDR captures the problem, investigation, chosen approach, and rejected alternatives. Each finding is classified by evidence quality:
+Technical decisions made during rapid development lose their reasoning quickly. An RDR captures the problem, investigation, chosen approach, and rejected alternatives in a structured document. Each research finding is tagged with its evidence quality — verified against source code, supported by documentation only, or assumed — so readers know which conclusions are load-bearing and which need further validation.
 
-| Tag | Meaning |
-|-----|---------|
-| **Verified** | Confirmed via source code search or working spike |
-| **Documented** | Supported by external docs only |
-| **Assumed** | Unverified — flag it if your design depends on it |
-
-RDRs are iterative: write, build, learn, revise. The growing corpus remains searchable, so prior decisions surface automatically when starting new design work.
+RDRs are iterative: write, build, learn, revise. The growing corpus remains searchable, so prior decisions surface automatically when starting new design work — preventing contradictions and avoiding redundant investigation across the team.
 
 RDR is fully optional. See [RDR Overview](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-overview.md) for the full process.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-As projects grow in complexity — more code, more decisions, more team members, more agent sessions — the volume of relevant context quickly exceeds what any single conversation or person can hold. AI coding agents lose all context between sessions, and the reasoning behind past decisions scatters across conversations, commits, and tribal knowledge. Nexus addresses this with a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context is shared across agent invocations and sessions — and that knowledge compounds over time, becoming more valuable as the corpus grows.
+As projects grow in complexity — more code, more decisions, more team members, more agent sessions — the volume of relevant context quickly exceeds what any single conversation or person can hold. AI coding agents lose all context between sessions, and the reasoning behind past decisions scatters across conversations, commits, and tribal knowledge.
+
+Nexus addresses this with a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents share the same tiered storage, so context is shared across agent invocations and sessions — and that knowledge compounds over time, becoming more valuable as the corpus grows.
 
 Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus indexes the RDR corpus so team members and their agents can quickly get up to speed on a project's design history and stay aligned as the codebase evolves.
 
@@ -118,7 +120,7 @@ Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs
 
 | Document | What it covers |
 |----------|---------------|
-| [Getting Started](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md) | Install, configure, first index and search |
+| [Getting Started](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md) | Install, local usage, Claude Code plugin, semantic search setup |
 | [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs/cli-reference.md) | Every command, every flag |
 | [Storage Tiers](https://github.com/Hellblazer/nexus/blob/main/docs/storage-tiers.md) | T1/T2/T3 architecture and data flow |
 | [Memory and Tasks](https://github.com/Hellblazer/nexus/blob/main/docs/memory-and-tasks.md) | T2 memory, beads integration, session context |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ nx index repo .                  # index your repo
 nx search "what does X do"       # search it
 ```
 
-For Claude Code, also install the plugin:
+For Claude Code, also install the plugin (see [plugin documentation](https://github.com/Hellblazer/nexus/blob/main/nx/README.md)):
 
 ```bash
 /plugin marketplace add Hellblazer/nexus

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus is a lightweight knowledge management system that provides persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and humans share the same tiered storage, so context built in one session is available in every session that follows.
+AI coding agents lose all context between sessions — prior decisions, research findings, and accumulated project knowledge vanish with each new conversation. Nexus provides a solution to this by providing a lightweight knowledge management system with persistent memory and semantic search across code, projects, and accumulated knowledge. Agents and humans share the same tiered storage, so context built in one session is available in every session that follows.
 
 Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system built on top of the storage tiers. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents. The result is a persistent decision history that agents consult before proposing new work and humans review to understand why the codebase evolved as it did.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Nexus Documentation
 
-Nexus provides persistent memory and semantic search for AI coding agents. Start with Getting Started, then explore by topic.
+Nexus provides persistent memory and semantic search for AI coding agents. Begin with the getting started guide, then explore by topic.
 
 ## Getting Started
 
@@ -8,7 +8,7 @@ Nexus provides persistent memory and semantic search for AI coding agents. Start
 
 ## Core Concepts
 
-- [Storage Tiers](storage-tiers.md) — T1 (session scratch), T2 (project memory), T3 (semantic knowledge) — architecture and data flow
+- [Storage Tiers](storage-tiers.md) — T1 (inter-agent session context), T2 (project memory), T3 (semantic knowledge) — architecture and data flow
 - [Memory and Tasks](memory-and-tasks.md) — T2 memory, beads integration, session context
 - [Repo Indexing](repo-indexing.md) — File classification, tree-sitter chunking, frecency scoring
 - [Configuration](configuration.md) — Config hierarchy, `.nexus.yml`, settings

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,36 +1,38 @@
 # Nexus Documentation
 
+Nexus provides persistent memory and semantic search for AI coding agents. Start with Getting Started, then explore by topic.
+
 ## Getting Started
 
-- [Getting Started](getting-started.md) — Install, configure, first index and search
+- [Getting Started](getting-started.md) — Install, local usage (no API keys), Claude Code plugin, semantic search setup
 
-## User Guide
+## Core Concepts
 
-- [CLI Reference](cli-reference.md) — Every command, every flag
-- [Storage Tiers](storage-tiers.md) — T1/T2/T3 architecture and data flow
+- [Storage Tiers](storage-tiers.md) — T1 (session scratch), T2 (project memory), T3 (semantic knowledge) — architecture and data flow
 - [Memory and Tasks](memory-and-tasks.md) — T2 memory, beads integration, session context
-- [Repo Indexing](repo-indexing.md) — Smart file classification, chunking, frecency
-- [Configuration](configuration.md) — Config hierarchy, .nexus.yml, settings
+- [Repo Indexing](repo-indexing.md) — File classification, tree-sitter chunking, frecency scoring
+- [Configuration](configuration.md) — Config hierarchy, `.nexus.yml`, settings
 
 ## RDR (Research-Design-Review)
 
-Start here, read in order:
+Structured decision tracking for human-AI collaboration. Read in order:
 
 1. [Overview](rdr-overview.md) — What RDRs are, when to write one, evidence classification
-2. [Workflow](rdr-workflow.md) — Create → Research → Gate → Accept → Close, with worked example
-3. [Nexus Integration](rdr-nexus-integration.md) — How storage tiers and agents amplify RDRs
+2. [Workflow](rdr-workflow.md) — Create → Research → Gate → Accept → Close
+3. [Nexus Integration](rdr-nexus-integration.md) — How agents and storage tiers work with RDRs
 4. [Templates](rdr-templates.md) — Minimal and full examples, post-mortem template
 5. [RDR Index](rdr/README.md) — All project RDRs with status
 
-## Development
+## Claude Code Plugin
 
+- [nx Plugin](../nx/README.md) — Agents, skills, session hooks, MCP servers, slash commands
+
+## Reference
+
+- [CLI Reference](cli-reference.md) — Every command, every flag
 - [Architecture](architecture.md) — Module map, design decisions
 - [Contributing](contributing.md) — Dev setup, testing, code style
 
-## Plugin
-
-- [nx Plugin](../nx/README.md) — Claude Code plugin: agents, skills, hooks, commands
-
 ## Historical
 
-- [Historical Documents](historical/README.md) — Original spec, architecture, and implementation plans
+- [Historical Documents](historical/README.md) — Original spec and implementation plans

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -105,7 +105,7 @@ nx search "API changelog" --corpus docs
 nx search "database pool" --hybrid          # blend semantic + keyword matching
 ```
 
-Common flags: `--n 20` (result count), `--json`, `--files` (paths only), `-c` (show matched text).
+Common flags: `--n 20` (result count), `--json`, `--files` (paths only), `-c` (show matched text). The `--hybrid` flag requires [ripgrep](https://github.com/BurntSushi/ripgrep) (`brew install ripgrep` or your system package manager).
 
 ## Troubleshooting
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,52 +1,53 @@
 # Getting Started with Nexus
 
-Nexus is a self-hosted semantic search and knowledge management CLI.
-It indexes code repositories, documents, and notes into three storage tiers,
-then lets you search across all of them with a single command.
-
-## Prerequisites
-
-- **Python 3.12+**
-- **uv** (package manager) — `curl -LsSf https://astral.sh/uv/install.sh | sh`
-- **git**
-- **ripgrep** (`rg`) — required for `--hybrid` search. Install via `brew install ripgrep` or your system package manager.
-
-For T3 (permanent cloud storage), you also need accounts at:
-
-| Service | Purpose | Free tier | Signup |
-|---------|---------|-----------|--------|
-| ChromaDB Cloud | Vector storage | Generous storage + requests for individual use | [trychroma.com](https://trychroma.com) |
-| Voyage AI | Embeddings | 200M tokens/month — indexing a large codebase uses 1–5M | [voyageai.com](https://voyageai.com) |
-
-> **Cost**: Both ChromaDB Cloud and Voyage AI free tiers cover all typical Nexus usage at no cost.
-> Voyage AI requires a credit card on file to unlock higher rate limits — but **usage remains
-> free**. You will not be charged for normal indexing and search workloads.
-
-Scratch and memory commands work with zero API keys (see [Local-only quick start](#local-only-quick-start)).
+Nexus provides persistent memory and semantic search for AI coding agents and the teams that work with them. This guide walks through installation, immediate local usage, and optional cloud setup for semantic search.
 
 ## Install
 
-**From PyPI** (recommended):
-
 ```bash
 uv tool install conexus
-```
-
-**From source**:
-
-```bash
-git clone https://github.com/Hellblazer/nexus.git
-cd nexus
-uv sync
-```
-
-Verify the CLI is available:
-
-```bash
 nx --help
 ```
 
-## Configure credentials
+Requires Python 3.12+, [uv](https://docs.astral.sh/uv/), and git. For source installation, see [Contributing](https://github.com/Hellblazer/nexus/blob/main/docs/contributing.md).
+
+## Start using it (no API keys needed)
+
+Scratch and memory work immediately with zero configuration.
+
+**Scratch** — inter-agent session context (ephemeral):
+
+```bash
+nx scratch put "working hypothesis: the cache TTL is too short"
+nx scratch list
+nx scratch search "cache"
+```
+
+**Memory** — project-level persistence with full-text search:
+
+```bash
+nx memory put "auth uses JWT with 24h expiry" -p myproject -t auth-notes
+nx memory search "JWT" -p myproject
+nx memory list -p myproject
+nx memory get -p myproject -t auth-notes
+```
+
+These are T1 and T2 — fully local, no accounts, no network. Many workflows start and end here.
+
+## Add semantic search (T3)
+
+When you want to search code, documents, and knowledge by meaning, set up T3 credentials.
+
+### Accounts
+
+| Service | Purpose | Free tier |
+|---------|---------|-----------|
+| [ChromaDB Cloud](https://trychroma.com) | Vector storage | Generous for individual use |
+| [Voyage AI](https://voyageai.com) | Embeddings | 200M tokens/month |
+
+Both free tiers cover typical Nexus usage at no cost. Voyage AI may require a credit card on file for higher rate limits, but usage remains free for normal workloads.
+
+### Configure
 
 Run the interactive wizard:
 
@@ -54,149 +55,74 @@ Run the interactive wizard:
 nx config init
 ```
 
-It walks through each credential, shows where to sign up, and **automatically provisions the four required ChromaDB databases** — no dashboard visit needed. Alternatively, set credentials individually:
+This walks through each credential and automatically provisions the required ChromaDB databases. Alternatively, set credentials individually:
 
 ```bash
 nx config set chroma_api_key sk-...
-nx config set chroma_database nexus          # your chosen base name
+nx config set chroma_database nexus
 nx config set voyage_api_key pa-...
 ```
 
-Credentials are stored in `~/.config/nexus/config.yml`. Environment variables always take precedence:
+Credentials are stored in `~/.config/nexus/config.yml`. Environment variables (`CHROMA_API_KEY`, `CHROMA_DATABASE`, `VOYAGE_API_KEY`) always take precedence. See [Configuration](https://github.com/Hellblazer/nexus/blob/main/docs/configuration.md) for the full reference.
 
-| Config key | Env var | Notes |
-|---|---|---|
-| `chroma_api_key` | `CHROMA_API_KEY` | Required |
-| `chroma_database` | `CHROMA_DATABASE` | Required — short base name you choose (e.g. `nexus`) |
-| `voyage_api_key` | `VOYAGE_API_KEY` | Required |
-| `chroma_tenant` | `CHROMA_TENANT` | Optional — inferred from your API key; only set for multi-workspace |
-
-**`chroma_database` is a base name.** Nexus derives four database names from it: `{base}_code`, `{base}_docs`, `{base}_rdr`, `{base}_knowledge`. These are provisioned automatically during `nx config init`.
-
-## Verify
+### Verify
 
 ```bash
 nx doctor
 ```
 
-This checks all credentials, required tools (`rg`, `git`), and connectivity to each T3 database. Fix anything marked with `✗` before proceeding. If a database is unreachable, run `nx config init` to provision it automatically.
+Checks credentials, required tools, and connectivity to each T3 database. Fix anything marked with `✗` before proceeding.
 
-## Index your first repo
+### Index a repo
 
 ```bash
 nx index repo .
 ```
 
-This registers the repository and indexes it into T3 ChromaDB:
+Code files are chunked via tree-sitter AST parsing and embedded with `voyage-code-3`. Prose and PDFs are embedded with `voyage-context-3`. RDR documents in `docs/rdr/` are auto-discovered and indexed separately. The indexer respects `.gitignore` and skips binary and generated files.
 
-- **Code files** (`.py`, `.java`, `.ts`, `.go`, etc.) are embedded with `voyage-code-3` into `code__<repo-name>` collections.
-- **Prose files** (`.md`, `.txt`, `.rst`) and PDFs are embedded with `voyage-context-3` into `docs__<repo-name>` collections.
-- **RDR documents** in `docs/rdr/` are auto-discovered and indexed into `rdr__<repo-name>`.
-
-Files are classified by extension. The indexer respects `.gitignore` and skips binary/generated files.
-
-## Search
-
-Basic semantic search across all corpora:
+### Search
 
 ```bash
 nx search "how does authentication work"
-```
-
-Scope to code or docs:
-
-```bash
 nx search "retry logic" --corpus code
 nx search "API changelog" --corpus docs
+nx search "database pool" --hybrid          # blend semantic + keyword matching
 ```
 
-Blend semantic search with git frecency for hybrid ranking:
+Common flags: `--n 20` (result count), `--json`, `--files` (paths only), `-c` (show matched text).
 
-```bash
-nx search "database connection pool" --hybrid
-```
+## Claude Code plugin
 
-Other useful flags:
-
-```bash
-nx search "query" --n 20              # return 20 results (default: 10)
-nx search "query" --json              # JSON output
-nx search "query" --files             # file paths only
-nx search "query" --vimgrep           # path:line:col:content format
-nx search "query" -c                  # show matched text inline
-nx search "query" path/to/dir         # scope to a directory
-```
-
-## Local-only quick start
-
-Scratch and memory require no API keys or cloud accounts.
-
-**Scratch** — ephemeral per-session notes:
-
-```bash
-nx scratch put "working hypothesis: the cache TTL is too short"
-nx scratch list
-nx scratch search "cache"
-nx scratch flag <ID>          # auto-promote to T2 on session end
-```
-
-**Memory** — persistent per-project notes (survives restarts):
-
-```bash
-nx memory put "auth uses JWT with 24h expiry" -p myproject -t auth-notes
-nx memory get -p myproject -t auth-notes       # by project + title
-nx memory get 42                                # or by numeric ID
-nx memory search "JWT" -p myproject
-nx memory list -p myproject
-```
-
-## Claude Code integration
-
-The `nx/` directory in this repo is a Claude Code plugin. Install via the marketplace:
+For Claude Code, also install the plugin (see [plugin documentation](https://github.com/Hellblazer/nexus/blob/main/nx/README.md)):
 
 ```bash
 /plugin marketplace add Hellblazer/nexus
 /plugin install nx@nexus-plugins
 ```
 
-For local development, load the plugin directly from the repo checkout:
+The plugin gives agents direct access to all three storage tiers via MCP servers, plus specialized agents, skills, session hooks, and development workflows. For local development, load from a repo checkout:
 
 ```bash
 claude --plugin-dir ./nx
 ```
 
-The plugin provides 14 agents, 27 skills, session hooks, slash commands, two bundled MCP servers (nexus storage tools + sequential-thinking), and standard pipelines. Agents access all three storage tiers via structured MCP tools — no Bash dependency required. See [nx/README.md](../nx/README.md) for details.
+## Troubleshooting
 
-## Troubleshooting first-run issues
+**`nx doctor` reports credentials not set** — Run `nx config init` to walk through setup interactively.
 
-**`nx doctor` reports credentials not set**
-Run `nx config init` — the interactive wizard prompts for each key and saves to `~/.config/nexus/config.yml`.
+**Provisioning failed during `nx config init`** — If your ChromaDB plan restricts automatic database creation, create them manually in the [dashboard](https://trychroma.com): `{base}_code`, `{base}_docs`, `{base}_rdr`, `{base}_knowledge` (where `{base}` is your `chroma_database` value).
 
-**Provisioning failed during `nx config init`**
-If your ChromaDB plan restricts automatic database creation, create the four databases manually in the [ChromaDB Cloud dashboard](https://trychroma.com):
-```
-{base}_code    {base}_docs    {base}_rdr    {base}_knowledge
-```
-where `{base}` is the value you set for `chroma_database`.
+**`nx index repo .` fails with "credentials not set"** — Indexing requires T3 credentials. Run `nx config init` first. Local commands (`nx memory`, `nx scratch`) work without credentials.
 
-**`nx index repo .` fails with "credentials not set"**
-`nx index repo` requires T3 credentials (ChromaDB + Voyage AI). Run `nx config init` first.
-Local commands (`nx memory`, `nx scratch`) work with no credentials at all.
+**First index is slow or hits a rate limit** — Large repos may take a few minutes. Add `--monitor` for per-file progress. Re-running after a partial index is safe — unchanged files are skipped.
 
-**First index is slow or hits a rate limit**
-Large repos can take a few minutes and may briefly hit Voyage AI rate limits. Add `--monitor` to watch per-file progress:
-```bash
-nx index repo . --monitor
-```
-Re-running after a partial index is safe — files are skipped when their content hash is unchanged.
-
-**`nx search` returns no results after indexing**
-Verify the index completed: run `nx doctor` and check that all four ChromaDB databases are reachable.
-If the index was interrupted, re-run `nx index repo .` — it resumes from where it left off.
+**`nx search` returns no results** — Run `nx doctor` to verify all databases are reachable. If indexing was interrupted, re-run `nx index repo .` to resume.
 
 ## Next steps
 
-- [CLI Reference](cli-reference.md) — full command documentation
-- [Storage Tiers](storage-tiers.md) — T1, T2, T3 architecture and trade-offs
-- [Repo Indexing](repo-indexing.md) — file classification, incremental updates, frecency
-- [Configuration](configuration.md) — all config keys, environment variables, `config.yml` format
+- [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs/cli-reference.md) — full command documentation
+- [Storage Tiers](https://github.com/Hellblazer/nexus/blob/main/docs/storage-tiers.md) — T1, T2, T3 architecture and trade-offs
+- [Repo Indexing](https://github.com/Hellblazer/nexus/blob/main/docs/repo-indexing.md) — file classification, incremental updates, frecency
+- [Configuration](https://github.com/Hellblazer/nexus/blob/main/docs/configuration.md) — all config keys, environment variables, `config.yml` format
+- [RDR Overview](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-overview.md) — decision tracking with Research-Design-Review

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,6 +34,21 @@ nx memory get -p myproject -t auth-notes
 
 These are T1 and T2 — fully local, no accounts, no network. Many workflows start and end here.
 
+## Claude Code plugin
+
+For Claude Code, also install the plugin (see [plugin documentation](https://github.com/Hellblazer/nexus/blob/main/nx/README.md)):
+
+```bash
+/plugin marketplace add Hellblazer/nexus
+/plugin install nx@nexus-plugins
+```
+
+The plugin gives agents direct access to all three storage tiers via MCP servers, plus specialized agents, skills, session hooks, and development workflows. For local development, load from a repo checkout:
+
+```bash
+claude --plugin-dir ./nx
+```
+
 ## Add semantic search (T3)
 
 When you want to search code, documents, and knowledge by meaning, set up T3 credentials.
@@ -91,21 +106,6 @@ nx search "database pool" --hybrid          # blend semantic + keyword matching
 ```
 
 Common flags: `--n 20` (result count), `--json`, `--files` (paths only), `-c` (show matched text).
-
-## Claude Code plugin
-
-For Claude Code, also install the plugin (see [plugin documentation](https://github.com/Hellblazer/nexus/blob/main/nx/README.md)):
-
-```bash
-/plugin marketplace add Hellblazer/nexus
-/plugin install nx@nexus-plugins
-```
-
-The plugin gives agents direct access to all three storage tiers via MCP servers, plus specialized agents, skills, session hooks, and development workflows. For local development, load from a repo checkout:
-
-```bash
-claude --plugin-dir ./nx
-```
 
 ## Troubleshooting
 

--- a/docs/rdr-nexus-integration.md
+++ b/docs/rdr-nexus-integration.md
@@ -4,125 +4,64 @@
 
 # RDR: Nexus Integration
 
-Nexus indexes every RDR the moment it is committed. Search, filter, and retrieve
-past decisions without parsing markdown.
+RDR documents live in the repository as markdown, but Nexus makes them queryable through both structured metadata (T2) and semantic search (T3). This means agents and team members don't need to parse files or remember which RDR covered a topic — they search by meaning and get relevant decisions back.
 
----
+## How agents use RDRs
 
-## T2 — RDR Metadata
+The typical agent workflow touches the storage tiers at each stage:
 
-Each RDR has a T2 record in the `{repo}_rdr` project. Query with:
+1. **Before new work** — search T3 for prior RDRs: `nx search "topic" --corpus rdr`. New designs often build on or refine earlier decisions; the search surfaces that chain automatically.
+2. **During research** — `/rdr-research` can delegate to `deep-research-synthesizer` or `codebase-deep-analyzer` for investigation that goes beyond what a single agent session can cover.
+3. **At gate time** — `substantive-critic` provides independent review of the RDR's logic, evidence, and completeness.
+4. **At accept time** — `/rdr-accept` updates T2 metadata, then optionally dispatches the planning chain (strategic-planner → plan-auditor → plan-enricher) to decompose the implementation into trackable beads.
+5. **After close** — `/rdr-close` archives the full RDR to T3 for permanent semantic retrieval.
+
+Agents access all storage tiers via structured MCP tools rather than CLI commands, which works reliably in background agents and restricted permission contexts. Team members use the `nx` CLI directly. See [nx/README.md](../nx/README.md#mcp-servers) for MCP tool details.
+
+## T2 — structured metadata
+
+Each RDR has a T2 record in the `{repo}_rdr` project, providing structured access to status, type, priority, timestamps, and linked beads without parsing markdown.
 
 ```bash
 nx memory search "caching" --project myrepo_rdr
 nx memory search "status:draft" --project nexus_rdr
 ```
 
-| Field | Description |
-|---|---|
-| `id` | Sequential number (e.g., `007`) |
-| `prefix` | Project prefix derived from repo name |
-| `title` | Human-readable title |
-| `status` | Draft, Accepted, Implemented, Reverted, Abandoned, Superseded |
-| `type` | Feature, Bug Fix, Technical Debt, Framework Workaround, Architecture |
-| `priority` | High, Medium, Low |
-| `created` | ISO timestamp |
-| `gated` | ISO timestamp of gate pass (empty if not gated) |
-| `accepted_date` | ISO date set by `/rdr-accept` (empty if not accepted) |
-| `closed` | ISO timestamp of close (empty if open) |
-| `close_reason` | Why the RDR was closed |
-| `superseded_by` | ID of the replacing RDR (if superseded) |
-| `supersedes` | ID of the RDR this one replaces |
-| `epic_bead` | Bead ID of the implementation epic (set at accept, if planning chain runs) |
-| `archived` | Whether content has been archived to T3 |
-| `file_path` | Relative path to the markdown file |
+Key fields include `id`, `status` (Draft → Accepted → Implemented/Reverted/Abandoned/Superseded), `type`, `priority`, `accepted_date`, `epic_bead` (links to implementation tracking), and `file_path`. T2 is the authoritative source for RDR state — the markdown file is the human-readable persistence layer.
 
-T2 is the authoritative source. The markdown file is the human-readable
-persistence layer. Timestamps let you reconstruct which decisions were active
-at any point in time.
+Timestamps (`created`, `gated`, `accepted_date`, `closed`) let you reconstruct which decisions were active at any point in time.
 
----
+## T3 — semantic search
 
-## T3 — Permanent Archival
+RDRs are indexed into `rdr__<repo>` collections using `voyage-context-3` embeddings. This happens two ways:
 
-`/rdr-close` indexes the RDR into the `rdr__` collection via VoyageAI embeddings.
-RDRs committed to the repo are also indexed immediately by `nx index repo`.
-
-**Search commands:**
+- **`nx index repo`** auto-discovers `docs/rdr/*.md` and indexes them during normal repo indexing. Draft RDRs are findable immediately — no need to wait for `/rdr-close`.
+- **`/rdr-close`** indexes the RDR explicitly at close time as part of permanent archival.
 
 ```bash
 nx search "caching strategy" --corpus rdr
 nx search "chromadb quota" --corpus rdr --n 5
-nx search "authentication" --corpus rdr --n 3
 ```
 
-Cross-project search works automatically. Decisions from one project surface
-when researching similar problems in another.
+Cross-project search works automatically — decisions from one project surface when researching similar problems in another.
 
-### What an agent sees
+### What search returns
 
-When an agent queries `--corpus rdr`, the highest-signal chunks returned are:
+The highest-signal chunks are typically the **Problem Statement** (best for determining relevance) and the **Proposed Solution** (surfaces implementation approach and trade-offs). Evidence classification (Verified, Documented, Assumed) is visible in result metadata, so agents can distinguish validated constraints from working assumptions without loading the full document. The `file_path` metadata allows loading the complete RDR when more depth is needed.
 
-- **Problem Statement** — the most semantically dense chunk; best for
-  determining relevance. A well-written Problem Statement is the single most
-  valuable thing for agent context.
-- **Proposed Solution** — surfaces implementation approach and trade-offs.
+## Beads integration
 
-Evidence classification (`Verified`, `Documented`, `Assumed`) is visible in
-search result metadata. Agents can distinguish validated constraints from
-working assumptions without reading the full file.
+`/rdr-accept` optionally decomposes the Implementation Plan into beads (epic + tasks) via the planning chain. The `epic_bead` T2 field links each accepted decision to its implementation work items. Session hooks inject T2 context and the active bead into spawned agents, so they pick up where the previous session left off.
 
-The result metadata includes `file_path`, so an agent can load the full RDR
-when it needs depth beyond the top chunks.
+## Learning from post-mortems
 
----
+`/rdr-close` creates a post-mortem template for drift analysis. Findings from post-mortems feed directly into the next RDR:
 
-## Smart Repo Indexing
-
-`nx index repo` auto-discovers `docs/rdr/*.md` files and routes them to
-`rdr__<repo>` using the `voyage-context-3` model. Draft RDRs are indexed and
-findable immediately — no need to wait for `/rdr-close`.
-
-Index a single RDR or directory independently:
-
-```bash
-nx index rdr docs/rdr/rdr-015-indexing-pipeline-rethink.md
-nx index rdr docs/rdr/
-```
-
----
-
-## Beads Integration
-
-`/rdr-accept` optionally decomposes the Implementation Plan into beads
-(epic + tasks) via the planning chain (strategic-planner → plan-auditor →
-plan-enricher). The `epic_bead` T2 field links each decision to its work
-items. The `SubagentStart` hook injects T2 memory context and the active
-bead, so spawned agents pick up where the last session left off.
-
----
-
-## Agent Workflow
-
-1. **Before new work**: search T3 for prior RDRs — `nx search "topic" --corpus rdr`. A new RDR often refines an earlier one; the search surfaces that chain.
-2. **During research**: `/rdr-research` can delegate to `deep-research-synthesizer` or `codebase-deep-analyzer` for heavy investigation.
-3. **At gate time**: `substantive-critic` provides independent review.
-4. **At accept time**: `/rdr-accept` updates T2 first, then repairs the file to match. Optionally dispatches the planning chain to create implementation beads.
-5. **After close**: `/rdr-close` archives to T3 and displays bead status advisory.
-
-**MCP access**: Agents access all storage tiers via structured MCP tools (`mcp__plugin_nx_nexus__search`, `mcp__plugin_nx_nexus__memory_search`, etc.) rather than CLI commands. This eliminates Bash dependency and works reliably in background agents and restricted permission contexts. Human users continue using the `nx` CLI. See [nx/README.md](../nx/README.md#mcp-servers) for tool details.
-
----
-
-## From Post-Mortem to Next RDR
-
-Post-mortem findings map directly to improvements in the next design:
-
-- **Unvalidated assumption** → add a Spike task to the next RDR's research phase before writing the Proposed Solution.
-- **Missing failure mode** → add an explicit failure mode entry to the next RDR's risk section.
-- **Framework API detail wrong** → standard fix: run `nx search "<api>" --corpus rdr` and grep the source before writing the Proposed Solution.
-- **Scope creep** → narrow the next RDR's Problem Statement; if the problem has two parts, write two RDRs.
-- **Implementation diverged from design** → flag the delta in the post-mortem and open a follow-up RDR to record the actual solution.
+- **Unvalidated assumption** → add a Spike task to the next RDR's research phase.
+- **Missing failure mode** → add explicit failure mode entries to the risk section.
+- **Framework API detail wrong** → search T3 and verify against source before writing the Proposed Solution.
+- **Scope creep** → narrow the Problem Statement; if the problem has two parts, write two RDRs.
+- **Implementation diverged from design** → flag the delta in the post-mortem and open a follow-up RDR.
 
 ---
 

--- a/docs/rdr-overview.md
+++ b/docs/rdr-overview.md
@@ -6,68 +6,59 @@
 
 An RDR records a technical decision: problem, evidence, chosen solution, rejected alternatives. It exists so decisions can be reproduced, searched, and fed directly to agents as context.
 
-## Quick Start
+## Quick start
 
 1. `/rdr-create` — creates a new file with metadata prefilled, status set to Draft
 2. `/rdr-research add <id>` — appends a finding with an evidence classification tag
-3. `/rdr-gate <id>` — runs 3-layer validation: structure check, assumption audit, AI critique (optional but recommended for irreversible decisions)
+3. `/rdr-gate <id>` — runs 3-layer validation: structure check, assumption audit, AI critique (optional, recommended for irreversible decisions)
 4. `/rdr-accept <id>` — locks the decision, sets status to Accepted
 5. `/rdr-close <id> --reason implemented` — archives the RDR, creates a post-mortem template, indexes to T3
 
-## When to Write One
+Steps 3–5 add rigor for high-stakes decisions. For a straightforward bug fix, steps 1–2 plus writing the solution may be all you need.
 
-- A design choice has non-obvious trade-offs
-- You investigated two or more options before deciding
+## When to write one
+
+Write an RDR when the "why" behind a decision won't be obvious from the code or commit history alone:
+
+- A design choice has non-obvious trade-offs or you evaluated multiple options
 - A bug required root-cause analysis, not just a patch
-- A decision will be hard to reverse or expensive if wrong
-- External constraints (API limits, vendor behavior, third-party behavior) shaped the solution
+- External constraints (API limits, vendor behavior) shaped the solution
 - A previous decision turned out to be wrong and you're correcting it
-- You're about to refactor something others depend on
-- The "why" won't be obvious from the code or commit history alone
-- You discovered something during implementation that changes the original plan
+- You're refactoring something others depend on
+- Something discovered during implementation changes the original plan
 
-## Right-Sizing an RDR
+Not every decision needs an RDR. If the rationale is self-evident from the code, skip it.
 
-Not every RDR needs every section. Match depth to complexity.
+## Right-sizing
+
+Match depth to the decision's complexity.
 
 | Scenario | Sections needed | Example |
 |---|---|---|
-| **Minimal** (bug, 1 option) | Problem + Root Cause + Fix | AST line-range bug: splitter returns empty metadata |
+| **Minimal** (bug, single option) | Problem + Root Cause + Fix | AST line-range bug: splitter returns empty metadata |
 | **Full** (architecture, multiple options) | All sections | Four-store T3 architecture with quota enforcement |
 
-**The rule**: if you can state the problem, root cause, and fix in one paragraph, that IS the RDR. Don't add sections to look thorough.
+If you can state the problem, root cause, and fix in one paragraph, that IS the RDR. Don't add sections to look thorough.
 
-## Evidence Classification
+## Evidence classification
 
-Each research finding is tagged so readers know what is solid and what is a guess.
+Each research finding is tagged so readers — both human and agent — know what is solid and what needs further validation.
 
-| Classification | Meaning | Example |
-|---|---|---|
-| **Verified** | Confirmed via source code search or working spike | "grep confirms the API accepts batch writes" |
-| **Documented** | Supported by external documentation only | "Vendor docs state 10k RPS limit" |
-| **Assumed** | Unverified belief based on experience or inference | "Serialization overhead assumed negligible" |
-
-Flag assumptions that your design depends on. Low-stakes assumptions need no verification; load-bearing ones should be visible.
-
-## The Iterative Pattern
-
-The Nexus project produced 18 RDRs over two weeks. Here's what that looks like in practice:
-
-| RDRs | Theme |
+| Classification | Meaning |
 |---|---|
-| 001–002 | Foundation: process validation, T2 status synchronization |
-| 004–007 | Architecture: four-store layout, quota enforcement, scoring, agent session context |
-| 008–013 | Workflow integration, API cleanup, T1 cross-process sessions, PDF ingest tiers, memory simplification |
-| 014–016 | Retrieval quality: code context prefixes, pipeline rethink (cross-repo learning from Arcaneum), AST line-range bug |
-| 017–018 | Operational: progress bars, replace polling server with git hooks |
+| **Verified** | Confirmed via source code search or working spike |
+| **Documented** | Supported by external documentation only |
+| **Assumed** | Unverified belief based on experience or inference |
 
-RDR-015 exists because implementing RDR-014 exposed that Arcaneum had already solved the same indexing problems. RDR-016 exists because fixing RDR-014 uncovered a latent bug in the AST chunker. Each RDR is a step, not a plan.
+Flag assumptions that your design depends on. Low-stakes assumptions need no verification; load-bearing ones should be explicitly visible so they can be challenged or validated later.
 
-## What an Agent Sees
+## The iterative pattern
 
-When you run `nx search "topic" --corpus rdr`, the agent retrieves the Problem Statement, Proposed Solution, and evidence classifications for matching RDRs. A well-written Problem Statement and Proposed Solution are the most valuable parts — they give the agent enough context to implement or extend without reading the full document. The evidence classification tells the agent which parts of the design are verified facts versus assumptions it should check before relying on them.
+RDRs are not waterfall documents written once before implementation. They're iterative — write one, build, learn from what you find, write the next one. Each RDR builds on what earlier ones established, and sometimes an implementation reveals that a prior decision needs revisiting.
 
-## Statuses
+The Nexus project has produced 36 RDRs across its development. The corpus is searchable, so when starting a new design, prior decisions surface automatically — preventing contradictions and avoiding redundant investigation.
+
+## Statuses and types
 
 ```
 Draft --> Accepted --> Implemented
@@ -75,42 +66,34 @@ Draft --> Accepted --> Implemented
                        Reverted / Abandoned / Superseded
 ```
 
-- **Draft**: skeleton created, research in progress
-- **Accepted**: gate passed; decision formally accepted
-- **Implemented**: implementation complete, archived to T3
-- **Reverted**: implementation was rolled back
-- **Abandoned**: decision dropped before implementation
-- **Superseded**: replaced by a newer RDR (linked via `superseded_by` field)
+| Status | Meaning |
+|---|---|
+| **Draft** | Created, research in progress |
+| **Accepted** | Gate passed, decision formally accepted |
+| **Implemented** | Implementation complete, archived to T3 |
+| **Reverted** | Implementation rolled back |
+| **Abandoned** | Dropped before implementation |
+| **Superseded** | Replaced by a newer RDR (linked via `superseded_by`) |
 
-## Types
+**Types**: Feature, Bug Fix, Technical Debt, Framework Workaround, Architecture.
 
-- **Feature**: new capability or user-facing behavior
-- **Bug Fix**: root-cause analysis and fix strategy for a defect
-- **Technical Debt**: refactoring or cleanup of existing code
-- **Framework Workaround**: mitigation for a known framework limitation
-- **Architecture**: cross-cutting structural decision
+## Using RDR in your project
 
-## Optional Rigor
-
-[`/rdr-gate`](rdr-workflow.md#gate-rdr-gate) runs a structural check, assumption audit, and AI critique before you commit. Use it when the decision is expensive to reverse. [`/rdr-close`](rdr-workflow.md#close-rdr-close) optionally generates a post-mortem comparing what was decided to what was built — useful for improving future RDRs. Neither is required for routine work.
-
-## Using RDR in Your Project
-
-RDR works in any repository — it doesn't require the Nexus CLI or plugin. The tooling amplifies RDRs (search, gate, agent context), but the core value is the document itself.
+RDR works in any repository — it doesn't require the Nexus CLI or plugin. The tooling amplifies RDRs with search, validation, and agent context, but the core value is the document itself.
 
 **Minimal setup (no tooling):**
 
 1. Create `docs/rdr/` in your repo
 2. Copy the [template](rdr-templates.md) into `docs/rdr/TEMPLATE.md`
-3. Write your first RDR by hand — Problem Statement + Research Findings + Proposed Solution is enough
+3. Write your first RDR — Problem Statement + Research Findings + Proposed Solution is enough
 
 **With Nexus CLI + plugin:**
 
-1. Run `/rdr-create` — it bootstraps the directory, templates, and README automatically on first use
-2. Use `/rdr-research`, `/rdr-gate`, `/rdr-accept`, `/rdr-close` for the full lifecycle
+1. `/rdr-create` bootstraps the directory, templates, and README automatically on first use
+2. `/rdr-research`, `/rdr-gate`, `/rdr-accept`, `/rdr-close` manage the full lifecycle
 3. RDRs are auto-indexed by `nx index repo` and searchable via `nx search --corpus rdr`
 
-See [Nexus Integration](rdr-nexus-integration.md) for how storage tiers and agents work with RDRs.
+See [Nexus Integration](rdr-nexus-integration.md) for how agents and storage tiers work with RDRs.
 
 ---
 

--- a/docs/rdr-templates.md
+++ b/docs/rdr-templates.md
@@ -8,8 +8,6 @@
 bug-fix RDR may need only Problem Statement, Research Findings, and Proposed
 Solution. A high-stakes architecture decision warrants everything.
 
----
-
 ## Minimal RDR Example
 
 A complete bug-fix RDR at its leanest:
@@ -56,8 +54,6 @@ conversion using `start_char_idx`/`end_char_idx`. No dependency changes needed.
 2. Add `test_ast_chunk_line_range_populated` in `test_chunker.py`
 3. Re-index affected collections (`code__*`)
 ````
-
----
 
 ## RDR Template
 
@@ -122,8 +118,6 @@ Each load-bearing assumption is a checkbox with verification status:
 | **Source Search** | API verified against dependency source code |
 | **Spike** | Behavior verified by running code against a live service |
 | **Docs Only** | Documentation reading only — insufficient for load-bearing assumptions |
-
----
 
 ## Post-Mortem Template
 

--- a/docs/rdr-workflow.md
+++ b/docs/rdr-workflow.md
@@ -4,7 +4,9 @@
 
 # RDR Workflow
 
-## State Machine
+This document covers the operational details of each lifecycle step. For background on what RDRs are and when to write them, see the [Overview](rdr-overview.md).
+
+## Lifecycle
 
 ```
 /rdr-create
@@ -19,7 +21,7 @@
      │
   [Accepted]
      │
-     │ optional: strategic-planner → plan-auditor → plan-enricher
+     │ optional: planning chain → implementation beads
      │
      │ /rdr-close --reason implemented
      ▼
@@ -28,238 +30,95 @@
 Terminal states: Reverted · Abandoned · Superseded
 ```
 
-Only **Create** and **Research** are required. Gate, Accept, and Close add
-formal validation and archival — use them when the decision is load-bearing.
+Only **Create** and **Research** are required. Gate, Accept, and Close add formal validation and archival — use them when the decision is load-bearing.
 
----
+## Worked example
 
-## Full Journey in 5 Minutes
-
-**Scenario**: fix a bug where AST chunks show wrong line ranges.
+A bug fix RDR from create to close:
 
 ```
 /rdr-create
-# Title: "Fix: chunker emits full-file line range for every AST chunk"
-# Type: Bug Fix  Priority: High
-# → Creates docs/rdr/016-fix-chunker-line-range.md  (status: draft)
-```
+  Title: "Fix: chunker emits full-file line range for every AST chunk"
+  Type: Bug Fix   Priority: High
+  → Creates docs/rdr/rdr-016-fix-chunker-line-range.md (status: draft)
 
-```
 /rdr-research add 016
-# Finding: CodeSplitter never populates line_start/line_end
-# Classification: Verified — Source Search (chunker.py:210)
-# Finding: start_char_idx/end_char_idx are populated; char→line conversion works
-# Classification: Verified — Source Search (llama-index TextNode)
-```
+  Finding: CodeSplitter never populates line_start/line_end
+  Classification: Verified — Source Search (chunker.py:210)
 
-```
 /rdr-gate 016
-# Layer 1: all sections present ✓
-# Layer 2: no Assumed findings ✓
-# Layer 3: substantive-critic → no blockers ✓
-# Outcome: PASSED
-```
+  Structure ✓ · Assumptions ✓ · AI critique ✓ → PASSED
 
-```
 /rdr-accept 016
-# Verifies gate result, updates status → accepted
-# Auto-detects multi-phase RDR → offers planning handoff
-# If yes: planner → auditor → enricher → beads ready
-```
+  Verifies gate, updates status → accepted
 
-```
 /rdr-close 016 --reason implemented
-# Creates post-mortem template
-# Displays bead status advisory (if beads exist from accept-time planning)
-# Indexes RDR into rdr__ collection
+  Creates post-mortem template, indexes to T3
 ```
 
-Total elapsed: ~10 minutes of tool calls. The RDR is now discoverable via
-`nx search --corpus rdr` and its decisions are tracked in T2.
-
----
-
-## Status Model
-
-| Status | Meaning |
-|--------|---------|
-| **Draft** | In progress, not yet gated |
-| **Accepted** | Gate passed; author/reviewer approved |
-| **Implemented** | Code matches accepted design |
-| **Reverted** | Implemented then rolled back |
-| **Abandoned** | Stopped before implementation |
-| **Superseded** | Replaced by a later RDR |
-
----
+The RDR is now searchable via `nx search --corpus rdr` and tracked in T2.
 
 ## Create (`/rdr-create`)
 
-1. Prompts for **title**, **type** (Feature, Bug Fix, Technical Debt, Framework
-   Workaround, Architecture), and **priority** (High, Medium, Low).
-2. Assigns a **sequential ID** by scanning `docs/rdr/` for the highest existing
-   number and incrementing. Zero-padded to three digits (e.g., `007`).
-3. Derives the **project prefix** from the repository name.
-4. Creates `docs/rdr/NNN-kebab-title.md` from the standard template with
-   `## Metadata` pre-filled.
-5. Writes a **T2 metadata record** to `{repo}_rdr`: id, prefix, title, status,
-   type, priority, created, file_path.
-6. Regenerates `docs/rdr/README.md`.
-7. Stages new files via `git add`.
+Prompts for title, type, and priority. Creates `docs/rdr/NNN-kebab-title.md` from the standard template with metadata prefilled, writes a T2 record, and regenerates the RDR index. Status: **Draft**.
 
-Status after creation: **Draft**. Sections exist but contain no research yet.
-
----
+On first use in a repository, `/rdr-create` bootstraps the `docs/rdr/` directory and copies the template automatically.
 
 ## Research (`/rdr-research`)
 
-Adds structured findings to a Draft RDR.
+Adds structured findings to a Draft RDR. Each finding records a summary, evidence classification (Verified, Documented, or Assumed), verification method, and source reference.
 
-Each finding records:
-- **Summary** — one sentence describing what was learned
-- **Classification** — Verified, Documented, or Assumed
-- **Method** — how the finding was obtained
-- **Source** — where the evidence came from
+Verification methods:
 
-### Verification Methods
+- **Source Search** — API or behavior verified against dependency source code
+- **Spike** — behavior verified by running code against a live service
+- **Docs Only** — documentation reading only; insufficient for load-bearing assumptions
 
-| Method | Description |
-|--------|-------------|
-| `Source Search` | API verified against dependency source code |
-| `Spike` | Behavior verified by running code against a live service |
-| `Docs Only` | Documentation reading only — insufficient for load-bearing assumptions |
-
-### Agent Delegation
-
-For complex research, `/rdr-research` can delegate to:
-- **deep-research-synthesizer** — multi-source web and document research
-- **codebase-deep-analyzer** — deep codebase exploration and pattern analysis
-
-Findings are written to the markdown file and to T2 (machine-queryable for agents).
-The RDR stays **Draft** throughout the research phase.
-
----
+For complex investigations, `/rdr-research` can delegate to specialized agents (`deep-research-synthesizer` for web/document research, `codebase-deep-analyzer` for codebase exploration). Findings are written to both the markdown file and T2. The RDR stays Draft throughout.
 
 ## Gate (`/rdr-gate`)
 
-Three-layer validation before implementation.
+Three-layer validation. Optional but recommended before committing to irreversible decisions.
 
-### Layer 1: Structural
+**Layer 1 — Structural**: Required sections filled, metadata complete, at least one research finding present.
 
-- All required sections filled (Problem Statement, Context, Research Findings,
-  Proposed Solution, Alternatives Considered, Trade-offs, Implementation Plan,
-  Finalization Gate)
-- Metadata complete
-- At least one research finding present
+**Layer 2 — Assumption audit**: Every Assumed finding must have a risk assessment. Each critical assumption must acknowledge what happens if it's wrong.
 
-### Layer 2: Assumption Audit
+**Layer 3 — AI critique**: Delegates to the `substantive-critic` agent, which evaluates logical coherence, missing alternatives, unstated assumptions, and evidence gaps. Findings are appended to the RDR.
 
-- Every **Assumed** finding must have an explicit risk assessment
-- Each Critical Assumption must acknowledge: what happens if it is wrong?
-- Unacknowledged assumptions prompt the user before proceeding
-
-### Layer 3: AI Critique
-
-- Delegates to the **substantive-critic** agent
-- Evaluates: logical coherence, missing alternatives, unstated assumptions, evidence gaps
-- Critique findings are appended to the RDR
-
-### Outcomes
-
-| Outcome | Meaning |
-|---------|---------|
-| **BLOCKED** | Critical issues found — fix and re-gate |
-| **PASSED** | No critical issues (may have observations) |
-
-No "Conditional Accept" or other ad-hoc outcomes. The gate either blocks or
-passes. Acceptance is a separate human decision after the gate passes.
-
-Gate result is written to T2 as `{id}-gate-latest` for `/rdr-accept` to verify.
-
----
+The gate either **BLOCKS** (critical issues — fix and re-gate) or **PASSES** (no critical issues, may have observations). No conditional outcomes. The result is stored in T2 for `/rdr-accept` to verify.
 
 ## Accept (`/rdr-accept`)
 
-Author/reviewer decision point. The gate validates; acceptance is deliberate.
+The decision point. The gate validates; acceptance is a deliberate human choice.
 
-1. Verifies T2 gate result shows `outcome: "PASSED"`. Blocks if no gate result.
-2. Updates **T2 first** (process authority): sets `status: "accepted"` and `accepted_date`.
-3. Updates the **RDR file** frontmatter to match.
-4. Regenerates `docs/rdr/README.md`.
-5. Stages modified files via `git add`.
-6. **Planning handoff** (optional): counts `### Phase` headings in the
-   Implementation Plan. If 2+ phases, defaults to yes; otherwise defaults to no.
-   - If accepted: writes T1 `rdr-planning-context` tag, dispatches
-     `strategic-planner` → `plan-auditor` → `plan-enricher` chain.
-   - Plan-enricher enriches beads with audit findings and writes epic bead ID to T2.
-   - If declined: no beads created — accept is complete.
+Verifies that the gate passed, updates T2 status to Accepted, updates the file frontmatter to match, and regenerates the index. For multi-phase implementation plans, `/rdr-accept` optionally dispatches the planning chain (strategic-planner → plan-auditor → plan-enricher) to decompose the work into trackable beads.
 
-**Self-healing**: if T2 shows `accepted` but the file still shows `draft`,
-`/rdr-accept` repairs the file to match T2.
-
----
+If T2 and the file disagree on status, `/rdr-accept` self-heals by repairing the file to match T2.
 
 ## Close (`/rdr-close`)
 
-Finalizes an Accepted RDR.
-
-Requires status: **Accepted**. Blocked otherwise — use `--force` to override.
+Finalizes an Accepted RDR. Requires status Accepted (use `--force` to override).
 
 Close reasons: `implemented` · `reverted` · `abandoned` · `superseded`
 
-Steps:
-1. Creates `docs/rdr/post-mortem/NNN-kebab-title.md` for drift analysis.
-2. **Bead status advisory**: if T2 has an `epic_bead` field (set during accept-time
-   planning), displays bead statuses. Advisory only — the human decides which to close.
-3. Indexes RDR content via `nx index rdr` into the `rdr__` collection.
-4. Updates T2 with close date, close reason, and final status.
-5. Regenerates `docs/rdr/README.md`.
+Closing creates a post-mortem template for drift analysis, indexes the RDR into the `rdr__` collection for permanent semantic retrieval, and updates T2 with the close date and reason. If beads were created during accept, their status is displayed as an advisory.
 
-After closing, use `nx search --corpus rdr` to find decisions across all projects.
+## Querying RDRs
 
----
-
-## List (`/rdr-list`)
-
-```
+```bash
 /rdr-list                      # all RDRs
 /rdr-list --status Draft       # active research only
 /rdr-list --type "Bug Fix"     # bug fixes only
-/rdr-list --has-assumptions    # RDRs with unverified findings
+
+/rdr-show 007                  # full detail: metadata, findings, gate status, linked beads
 ```
 
-Reads from T2 — no markdown parsing required.
+Both commands read from T2 — no markdown parsing required.
 
----
+## T2 synchronization
 
-## Show (`/rdr-show`)
-
-```
-/rdr-show 007
-```
-
-Displays: metadata summary, research findings with classifications, gate status,
-linked beads (if closed), post-mortem status (if exists). Combines markdown and
-T2 data into a single view.
-
----
-
-## T2 Synchronization
-
-T2 is the **process authority** for RDR status. Files are git-versioned,
-human-editable persistence. Agents read and write T2.
-
-### SessionStart Reconciliation
-
-`rdr_hook.py` runs on every session start using the **monotonic-advance rule**:
-status always advances, never regresses.
-
-| Condition | Action |
-|-----------|--------|
-| File more advanced than T2 (e.g., human edited draft → accepted) | T2 updated to match file |
-| T2 more advanced than file (e.g., file write failed) | File repaired to match T2 |
-| Both sides have different terminal states | File wins, warning logged |
-
-No file watchers or git hooks required.
+T2 is the process authority for RDR status; the markdown file is the human-readable persistence layer. On session start, a reconciliation hook ensures they agree using a monotonic-advance rule: status only moves forward, never regresses. If a human edits the file ahead of T2, T2 catches up. If T2 is ahead (e.g., a file write failed), the file is repaired.
 
 ---
 

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -61,4 +61,4 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 
 ---
 
-**Reading order:** [Overview](../rdr-overview.md) | [Workflow](../rdr-workflow.md) | [Nexus Integration](../rdr-nexus-integration.md) | [Templates](../rdr-templates.md)
+**Reading order:** [Overview](../rdr-overview.md) | [Workflow](../rdr-workflow.md) | [Nexus Integration](../rdr-nexus-integration.md) | [Templates](../rdr-templates.md) | RDR Index (this page)


### PR DESCRIPTION
## Summary

- **README rewrite**: Problem-first framing, three-tier lifecycle explanation, RDR as human-AI design system, inter-agent T1 framing, compounding knowledge insight
- **Getting Started reorganization**: Local-first flow (Install → T1/T2 → Plugin → T3), ripgrep requirement restored
- **RDR docs edited**: Overview, Workflow, Nexus Integration, Templates all tightened for readability and reduced density
- **docs/README reorganized**: Core Concepts / RDR / Plugin / Reference grouping

## Test plan

- [ ] All links render correctly on GitHub
- [ ] README renders correctly (will verify on PyPI after release)
- [ ] No code changes — test suite unaffected