### PR TITLE
Rewrite T3Database to single-client architecture (RDR-037 Phase 1)

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -58,6 +58,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-034](rdr-034-mcp-server-agent-storage.md) | MCP Server for Agent Storage Operations | Architecture | Accepted | 2026-03-11 |
 | [RDR-035](rdr-035-plugin-agent-mcp-tool-access.md) | Fix Plugin Agent MCP Tool Access | Bugfix | Closed | 2026-03-12 |
 | [RDR-036](rdr-036-post-accept-planning-workflow.md) | Post-Accept Planning Workflow | Enhancement | Accepted | 2026-03-12 |
+| [RDR-037](rdr-037-t3-database-consolidation.md) | T3 Database Consolidation | Enhancement | Accepted | 2026-03-14 |
 
 ---
 

--- a/docs/rdr/rdr-037-t3-database-consolidation.md
+++ b/docs/rdr/rdr-037-t3-database-consolidation.md
@@ -1,0 +1,201 @@
+---
+title: "T3 Database Consolidation"
+id: RDR-037
+type: enhancement
+status: accepted
+priority: P2
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-14
+accepted_date: 2026-03-14
+related_issues:
+  - "RDR-004 - Four Store Architecture"
+  - "RDR-005 - ChromaDB Cloud Quota Enforcement"
+---
+
+# RDR-037: T3 Database Consolidation
+
+## Problem Statement
+
+T3 storage currently uses four separate ChromaDB Cloud databases — `{base}_code`, `{base}_docs`, `{base}_rdr`, `{base}_knowledge` — one per content type. This was the original design (RDR-004) but the separation provides no technical benefit: collection names already carry type prefixes (`code__`, `docs__`, `rdr__`, `knowledge__`) that prevent collisions, and embedding functions are configured per-collection, not per-database.
+
+The four-database design creates unnecessary friction:
+
+- **Setup**: users must create 4 databases in the ChromaDB Cloud dashboard
+- **Auto-provisioning**: `nx` must provision and verify 4 databases
+- **Connection overhead**: `T3Database.__init__` creates 4 `CloudClient` instances
+- **Routing complexity**: `_client_for()` dispatches by prefix to the correct client
+- **Enumeration**: `list_collections()` fans out across 4 clients and deduplicates
+- **Diagnostics**: `nx doctor` checks 4 databases
+
+A single database with the same prefixed collections would be simpler to set up, simpler to code, and no less capable.
+
+## Context
+
+The four-database split was introduced in RDR-004 to separate content types with different embedding models. At the time, the concern was that mixing embedding spaces within a single database could cause confusion or cross-contamination. In practice, ChromaDB isolates collections completely — different collections in the same database share nothing. The embedding function is attached at the collection level, and queries only hit the specified collection.
+
+### Current model assignments
+
+| Collection prefix | Index model | Query model |
+|---|---|---|
+| `code__` | `voyage-code-3` | `voyage-4` |
+| `docs__` | `voyage-context-3` (CCE) | `voyage-context-3` (CCE) |
+| `rdr__` | `voyage-context-3` (CCE) | `voyage-context-3` (CCE) |
+| `knowledge__` | `voyage-context-3` (CCE) | `voyage-context-3` (CCE) |
+
+These assignments are determined by `corpus.py` functions (`index_model_for_collection`, `embedding_model_for_collection`) based on the collection name prefix — not the database. Consolidation changes nothing about how embeddings work.
+
+## Research Findings
+
+### F-01: ChromaDB collections are fully isolated within a database
+- **Classification**: Verified — Documentation + Testing
+- **Detail**: ChromaDB collections within a single database share no state. Each collection has its own embedding function, its own document store, and its own vector index. Querying collection A never touches collection B. The database is purely an organizational namespace.
+
+### F-02: Collection name prefixes already prevent collisions
+- **Classification**: Verified — Source Code
+- **Detail**: All collection names follow `{type}__{repo}-{hash8}` format (e.g. `code__nexus-a1b2c3d4`). The `__` separator and type prefix guarantee uniqueness across content types within a single database. See `registry.py:_safe_collection()`.
+
+### F-03: Routing logic exists only because of the multi-database design
+- **Classification**: Verified — Source Code
+- **Detail**: `T3Database._client_for()` (t3.py:110-133) parses the collection prefix to select one of four `CloudClient` instances. With a single client, this method becomes a no-op. The `_STORE_TYPES` tuple and the init loop that creates 4 clients also become unnecessary.
+
+### F-04: ChromaDB Cloud limits are per-collection and per-tenant, not per-database
+- **Classification**: Verified — ChromaDB Cloud Documentation (docs.trychroma.com/cloud/quotas-limits)
+- **Detail**: The relevant limits are: max 1,000,000 collections (tenant-wide), max 5,000,000 records per collection, max 10 concurrent reads and 10 concurrent writes per collection, max 300 records per write. None of these are per-database. Consolidating into one database changes no limits.
+
+### F-05: Four databases consume 40% of free-tier database slots
+- **Classification**: Verified — ChromaDB Cloud Pricing (trychroma.com/pricing)
+- **Detail**: The Starter (free) tier allows 10 databases. Nexus currently uses 4, leaving only 6 for other projects or tools. Consolidating to 1 frees 3 slots — a 30% increase in available capacity. Team tier allows 100, Enterprise unlimited. No per-database cost on any tier.
+
+### F-06: RDR-004's original rationale does not hold
+- **Classification**: Verified — Documentation cross-reference
+- **Detail**: RDR-004 justified four databases on two grounds: (1) "operational coupling" — shared quota and rate limit contention, and (2) "scale ceiling" — per-database resource limits. F-04 shows both are incorrect: rate limits are per-collection (not per-database), and collection caps are tenant-wide (not per-database). The split provides no isolation benefit.
+
+### F-07: `nx migrate t3` was already removed
+- **Classification**: Verified — Source Code
+- **Detail**: The original migration command from single→four databases was removed in a prior release. Only a stale comment in `t3.py:500` references it. A new consolidation migration would need to be purpose-built or use the existing `nx store export/import` path.
+
+### F-08: Test injection already maps all four clients to one mock
+- **Classification**: Verified — Source Code
+- **Detail**: `T3Database.__init__` with `_client=mock` already sets `self._clients = {t: _client for t in _STORE_TYPES}` — i.e., all four store types share one client. The entire test suite already exercises single-client behavior. Consolidation aligns production with what tests already do.
+
+### F-09: Change scope is well-bounded — 6 source files, 5 test files, 6 doc files
+- **Classification**: Verified — Source Code analysis
+- **Detail**: Core changes: `t3.py` (5 locations: init, `_client_for` retained as shim, expire docstring, list_collections, class docstring), `_provision.py` (rewrite ensure_databases), `doctor.py` (simplify 3 check loops), `config_cmd.py` (update help text). Minor: `store.py` (error messages), `exporter.py` (uses `_client_for` shim — no change needed). Tests: `test_provision.py` (6 tests), `test_t3.py` (12 routing tests to remove/simplify), `test_config_cmd.py` (2 tests), `test_integration.py` (1 test), `test_exporter.py` (7 calls use `_client_for` shim — no change needed). Unchanged: `corpus.py`, `registry.py`, `indexer.py`, `code_indexer.py`, all search/memory/scratch code. Docs: 6 files (storage-tiers, configuration, getting-started, cli-reference, architecture, CLAUDE.md).
+
+## Proposed Approach
+
+### Single database, same collections
+
+Replace the four `CloudClient` instances with one. The `chroma_database` config value becomes the actual database name (currently it's a base that gets `_code`, `_docs`, `_rdr`, `_knowledge` suffixed). The default database name for new installs is `nexus`.
+
+### `_client_for()` retained as compatibility shim
+
+`_client_for(collection_name)` is kept as a method that returns `self._client` regardless of input. This preserves the call signature used by `exporter.py` (line 128) and `test_exporter.py` (7 call sites) without requiring changes to those files. All prefix-parsing logic and log warnings are removed — the method body is simply `return self._client`. The shim can be removed in a future release once all callers migrate to `self._client` directly.
+
+### Auto-detection of old four-database layout
+
+`CloudClient` is eager — it connects at construction time and raises `RuntimeError` on failure (documented in RDR-004). For an upgrading user whose `chroma_database = nexus`, the new single-database init would try to connect to `nexus` (which doesn't exist), fail before any migration probe could run, and show a cryptic connection error instead of migration guidance.
+
+To prevent this, the probe runs **before** the primary client connection. The init sequence is:
+
+1. **Probe first**: attempt `CloudClient(database="{base}_code")`. If this succeeds, the old four-database layout is detected.
+2. **Old layout detected**: temporarily connect all four old databases, emit a structured warning with migration steps, then raise `OldLayoutDetected` (a custom error subclass) to prevent silent operation against stale data. The temporary four-client connection allows `nx store export --all` to function even after upgrading, so users do not need to downgrade to export.
+3. **Probe fails (404/NotFound)**: old layout does not exist. Proceed to connect to `{base}` as the single database.
+
+The warning emitted:
+
+```
+Old four-database layout detected ({base}_code, {base}_docs, {base}_rdr, {base}_knowledge).
+Nexus now uses a single database named '{base}'.
+
+To migrate:
+  1. nx store export --all           # back up knowledge entries (works with current install)
+  2. Create database '{base}' in your ChromaDB Cloud dashboard
+  3. Set environment variable NX_MIGRATED=1 or run: nx config set migrated true
+  4. nx index repo .                 # re-index code, docs, and RDRs
+  5. nx store import <exported-file> # restore knowledge entries
+  6. Delete the old {base}_code, {base}_docs, {base}_rdr, {base}_knowledge databases
+```
+
+Step 1 works because the probe's temporary four-client connection allows the export command to reach the old `knowledge` database. Once the user sets the migration flag (step 3), subsequent runs skip the probe and connect to the single database.
+
+`nx doctor` also surfaces this warning when the old layout is detected.
+
+### RDR-005 compatibility
+
+RDR-005's `_write_sems` and `_read_sems` are keyed by collection name, not by database. ChromaDB Cloud's concurrency limits (10 reads, 10 writes) are per-collection (F-04). Database consolidation does not change the semaphore key space or the limit enforcement. No changes to RDR-005's implementation are required.
+
+### Changes required
+
+**Source (4 files, core logic):**
+1. **`db/t3.py`** — remove `_STORE_TYPES`, replace `self._clients` dict with `self._client`, retain `_client_for()` as shim returning `self._client`, update `expire()` docstring (remove stale `nx migrate t3` reference), update `list_collections()` to single client call, add old-layout auto-detection probe, update class docstring
+2. **`commands/_provision.py`** — `ensure_databases()` creates 1 database instead of 4, remove `_STORE_TYPES` import
+3. **`commands/doctor.py`** — single database reachability check, simplify pipeline version and pagination audit loops, add old-layout detection warning
+4. **`commands/config_cmd.py`** — update help text from "four databases" to "single database"
+
+**Source (2 files, minor):**
+5. **`exporter.py`** — no change needed (`_client_for()` shim preserves call signature)
+6. **`commands/store.py`** — update error message wording
+
+**Unchanged:** `corpus.py`, `registry.py`, `indexer.py`, `code_indexer.py`, `search_engine.py`, `db/__init__.py`
+
+**Tests (5 files):**
+7. **`test_t3.py`** — remove 12 routing tests, simplify `four_clients` fixture, add old-layout detection test
+8. **`test_provision.py`** — rewrite 6 tests for single database
+9. **`test_config_cmd.py`** — update 2 provisioning tests
+10. **`test_integration.py`** — update 1 migration test
+11. **`test_exporter.py`** — no change needed (`_client_for()` shim preserves call signature)
+
+**Docs (6 files):** `storage-tiers.md`, `configuration.md`, `getting-started.md`, `cli-reference.md`, `architecture.md`, `CLAUDE.md`
+
+### Migration strategy
+
+Auto-detection at startup ensures no user is caught unaware. The probe-first design means `nx store export --all` works even after upgrading — the probe's temporary four-client connection reaches the old `knowledge` database. Users do not need to downgrade.
+
+1. **`knowledge__` entries** — `nx store export --all` works at any point (before or after upgrade) because the probe connects to the old databases when detected. This is the only non-rederivable data.
+2. **Code/docs/rdr collections** are derived from repo files — `nx index repo .` recreates them in the new single database.
+3. **Migration flag** — setting `NX_MIGRATED=1` or `nx config set migrated true` tells the init to skip the old-layout probe and connect directly to the single database.
+4. The old four databases can be deleted from the ChromaDB Cloud dashboard after migration is confirmed.
+
+There is no automatic migration command. The export/import path already exists and is well-tested (RDR-031). The auto-detection warning guides users through the steps.
+
+### Rejected alternatives
+
+- **Keep four databases**: status quo. Works but adds unnecessary setup friction and code complexity with no benefit. Wastes 3 of the free tier's 10 database slots.
+- **Merge only CCE databases (docs + rdr + knowledge), keep code separate**: marginally simpler than status quo but still requires multi-database routing for one special case.
+- **Automatic migration command**: higher implementation cost and risk (copying embeddings across databases) for a one-time operation that export/import already handles. Not worth the complexity.
+- **Support both layouts indefinitely**: dual-path code is the opposite of simplification. Auto-detection with a clear migration warning is sufficient.
+
+## Consequences
+
+### Positive
+
+- Setup cost drops from 4 databases to 1 — especially significant on free tier (40% → 10% of database slots)
+- `T3Database` code simplifies substantially (remove routing, dedup, multi-client init)
+- `nx doctor` and auto-provisioning become simpler and faster
+- Production behavior aligns with what the test suite already exercises (F-08)
+
+### Negative / Trade-offs
+
+- **Single blast radius**: a database-level failure or accidental deletion now affects all T3 content simultaneously, whereas the four-database design provided per-content-type isolation. This is acceptable because: CloudClient is stateless REST (no persistent connection to lose), there are no per-database rate limits (F-04), and `nx store export --all` provides a backup path. The isolation benefit of four databases was theoretical — rate limits and quotas are per-collection regardless.
+- **Breaking config change**: `chroma_database` semantics change from "base prefix" to "actual database name." The probe-first auto-detection ensures upgrading users see a clear migration warning (with a working export path) rather than a cryptic connection error.
+
+## Implementation Plan
+
+Steps 1–2 must land atomically (same commit) since the code is non-functional between removing the four-client init and adding the probe-first single-client init.
+
+1. **`T3Database.__init__` rewrite (probe-first)** — the init sequence becomes: (a) check migration flag → if set, connect to `{base}` directly; (b) probe for `{base}_code` → if found, temporarily connect all four old databases, emit warning, raise `OldLayoutDetected`; (c) probe fails → connect to `{base}` as single database. Remove `_STORE_TYPES`. Retain `_client_for()` as shim (`return self._client`, all prefix-parsing and warning log lines removed). Update class docstring.
+2. **`expire()` docstring** — remove stale `nx migrate t3` reference (currently at t3.py:500), update to reflect single-database layout. Also update `self._clients["knowledge"]` → `self._client`.
+3. **Auto-provisioning** — `ensure_databases()` creates 1 database; database name is `chroma_database` value directly (default: `nexus`). Remove `_STORE_TYPES` import.
+4. **`nx doctor`** — check 1 database; add old-layout detection warning; simplify pipeline version and pagination audit loops.
+5. **Config docs + help text** — update `chroma_database` semantics in `config_cmd.py`, `configuration.md`, `getting-started.md`
+6. **Other docs** — update `storage-tiers.md`, `cli-reference.md`, `architecture.md`, `CLAUDE.md`
+7. **Tests** — remove 12 routing tests from `test_t3.py`, rename `four_clients` fixture, rewrite 6 provisioning tests, add old-layout detection + migration-flag tests; `test_exporter.py` unchanged (shim preserves call signature)
+8. **CHANGELOG + release notes** — document breaking change with migration instructions
+
+## Resolved Questions
+
+1. **Backward compatibility**: probe-first auto-detection. `T3Database.__init__` probes for `{base}_code` *before* attempting the single-database connection. If old layout detected, temporarily connects all four databases (so `nx store export --all` works), emits migration warning, and raises `OldLayoutDetected`. A migration flag (`NX_MIGRATED=1` or `nx config set migrated true`) skips the probe on subsequent runs.
+2. **Default database name**: `nexus` — matches what users already have as their base prefix. New installs get `nexus` as the single database name. Existing users create a new database named `nexus` (the unsuffixed name) and migrate.
+3. **`_client_for()` fate**: retained as a compatibility shim with body `return self._client`. All prefix-parsing logic and log warnings removed. Preserves `exporter.py` and `test_exporter.py` call signatures without changes.

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -121,6 +121,7 @@ CREDENTIALS: dict[str, str] = {
     "chroma_tenant":     "CHROMA_TENANT",
     "chroma_database":   "CHROMA_DATABASE",
     "voyage_api_key":    "VOYAGE_API_KEY",
+    "migrated":          "NX_MIGRATED",
 }
 
 # ── Defaults ──────────────────────────────────────────────────────────────────

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -15,15 +15,18 @@ import voyageai
 from chromadb.errors import NotFoundError as _ChromaNotFoundError
 import structlog
 
+from nexus.config import get_credential
 from nexus.corpus import embedding_model_for_collection, index_model_for_collection
 from nexus.db.chroma_quotas import QUOTAS, QuotaValidator
 
 _log = structlog.get_logger(__name__)
 
-# The four ChromaDB Cloud databases, one per content type.
-# ``chroma_database`` in config is the *base name*; each store is
-# ``{base}_{type}``.  Example: base="nexus" → nexus_code, nexus_docs,
-# nexus_rdr, nexus_knowledge.
+
+class OldLayoutDetected(RuntimeError):
+    """Raised when the old four-database ChromaDB layout is detected during init."""
+
+
+# Deprecated: kept as shim for _provision.py and doctor.py until Phase 2 removes their imports
 _STORE_TYPES: tuple[str, ...] = ("code", "docs", "rdr", "knowledge")
 
 from nexus.retry import (
@@ -36,22 +39,19 @@ from nexus.retry import (
 class T3Database:
     """T3 ChromaDB CloudClient permanent knowledge store.
 
-    Uses four separate ``chromadb.CloudClient`` instances — one per content
-    type — derived from the ``chroma_database`` base name:
+    Uses a single ``chromadb.CloudClient`` connected to the ``chroma_database``
+    base name directly.  All collection prefixes (``code__``, ``docs__``,
+    ``rdr__``, ``knowledge__``) coexist in one database.
 
-    - ``{base}_code``      for ``code__*`` collections
-    - ``{base}_docs``      for ``docs__*`` collections
-    - ``{base}_rdr``       for ``rdr__*`` collections
-    - ``{base}_knowledge`` for ``knowledge__*`` collections and fallback
-
-    All routing is internal to this class.  Every public caller
-    (``search_cmd``, ``indexer``, etc.) remains unchanged.
+    On first connection (no ``NX_MIGRATED`` flag), the constructor probes for
+    the old four-database layout by attempting to connect to ``{base}_code``.
+    If that database exists, ``OldLayoutDetected`` is raised.  If it does not
+    (``NotFoundError``), the new single-database layout is assumed.
 
     The ``_client`` and ``_ef_override`` keyword arguments are injection
     points for testing — pass an ``EphemeralClient`` and
     ``DefaultEmbeddingFunction`` to run the full code path without any API
-    keys.  When ``_client`` is provided, all four store types are mapped to
-    the same client (single-mock backward compatibility).
+    keys.
     """
 
     def __init__(
@@ -78,24 +78,34 @@ class T3Database:
             if voyage_api_key else None
         )
         if _client is not None:
-            # Test injection: single client serves all store types.
-            self._clients: dict[str, object] = {t: _client for t in _STORE_TYPES}
+            self._client = _client
         else:
-            _clients: dict[str, object] = {}
-            for t in _STORE_TYPES:
-                db_name = f"{database}_{t}"
+            migrated = get_credential("migrated")
+            if migrated:
+                self._client = chromadb.CloudClient(
+                    tenant=tenant or None, database=database, api_key=api_key
+                )
+            else:
                 try:
-                    _clients[t] = chromadb.CloudClient(
-                        tenant=tenant or None, database=db_name, api_key=api_key
+                    chromadb.CloudClient(
+                        tenant=tenant or None, database=f"{database}_code", api_key=api_key
                     )
-                except Exception as exc:
-                    _log.debug("cloud_client_connect_failed", database=db_name, error=str(exc))
-                    raise RuntimeError(
-                        f"Failed to connect to ChromaDB Cloud database {db_name!r}.\n"
-                        f"Ensure these four databases exist in your ChromaDB Cloud dashboard:\n"
-                        + "\n".join(f"  - {database}_{t2}" for t2 in _STORE_TYPES)
-                    ) from exc
-            self._clients = _clients
+                except _ChromaNotFoundError:
+                    # Old layout absent — connect to single database
+                    self._client = chromadb.CloudClient(
+                        tenant=tenant or None, database=database, api_key=api_key
+                    )
+                else:
+                    _log.warning(
+                        "old_layout_detected",
+                        database=database,
+                        msg="Old four-database layout detected. Set NX_MIGRATED=1 after migration.",
+                    )
+                    raise OldLayoutDetected(
+                        f"Old four-database layout detected: '{database}_code' exists.\n"
+                        f"Set NX_MIGRATED=1 or run 'nx config set migrated 1' "
+                        f"to use the new single-database layout."
+                    )
 
     # ── Context manager (no-op: CloudClient is stateless REST) ───────────────
 
@@ -108,29 +118,8 @@ class T3Database:
     # ── Internal helpers ──────────────────────────────────────────────────────
 
     def _client_for(self, collection_name: str) -> object:
-        """Route a collection name to the correct ChromaDB client.
-
-        Routing is by prefix (the part before ``__``):
-        - ``code__*``      → code client
-        - ``docs__*``      → docs client
-        - ``rdr__*``       → rdr client
-        - ``knowledge__*`` → knowledge client
-        - no ``__`` or unknown prefix → knowledge client (with a warning)
-        """
-        if "__" in collection_name:
-            prefix = collection_name.split("__")[0]
-        else:
-            _log.warning("collection_no_prefix", collection=collection_name)
-            prefix = "knowledge"
-        client = self._clients.get(prefix)
-        if client is None:
-            _log.warning(
-                "unknown_collection_prefix",
-                prefix=prefix,
-                collection=collection_name,
-            )
-            client = self._clients["knowledge"]
-        return client
+        """Return the ChromaDB client (single-database; routing removed per RDR-037)."""
+        return self._client
 
     def _embedding_fn(self, collection_name: str):
         """Return a VoyageAI EF (always voyage-4) for collection creation.
@@ -495,11 +484,6 @@ class T3Database:
         Only queries the knowledge store — TTL-managed entries are written
         via ``nx store put`` which routes to the knowledge store.
 
-        **Precondition**: the ``{base}_knowledge`` ChromaDB Cloud database must
-        exist before calling this method.  If the database has not yet been
-        created (e.g. the user upgraded but has not run ``nx migrate t3``),
-        the method logs a warning and returns 0 rather than raising.
-
         Only removes entries where ``ttl_days > 0`` AND ``expires_at != ""``
         AND ``expires_at < now``. Permanent entries (``ttl_days=0``,
         ``expires_at=""``) are always preserved.
@@ -512,7 +496,7 @@ class T3Database:
         now_iso = datetime.now(UTC).isoformat()
         ttl_where: dict = {"ttl_days": {"$gt": 0}}
         total = 0
-        kc = self._clients["knowledge"]
+        kc = self._client
         try:
             collections = kc.list_collections()
         except _ChromaNotFoundError:
@@ -574,34 +558,22 @@ class T3Database:
     def list_collections(self) -> list[dict]:
         """Return all T3 collections with their document counts.
 
-        Fans out across all four store clients, deduplicates by collection
-        name (relevant when all four clients are the same mock in tests), and
-        parallelizes count queries up to 8 concurrent requests.
-
-        Note: The enumeration phase makes four sequential HTTP calls (one per
-        store client) before the parallel count phase begins.  This is
-        acceptable because ``list_collections`` is only called from
-        non-hot-path commands (``nx collections``, ``nx store list``).
+        Queries the single ChromaDB client and parallelizes count queries
+        up to 8 concurrent requests.
         """
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
-        seen: set[str] = set()
-        names: list[str] = []
-        for client in self._clients.values():
-            try:
-                for col_or_name in client.list_collections():
-                    n = col_or_name if isinstance(col_or_name, str) else col_or_name.name
-                    if n not in seen:
-                        names.append(n)
-                        seen.add(n)
-            except _ChromaNotFoundError:
-                continue  # store not yet created, skip gracefully
+        try:
+            raw = self._client.list_collections()
+        except _ChromaNotFoundError:
+            return []
 
+        names = [c if isinstance(c, str) else c.name for c in raw]
         if not names:
             return []
 
         def _count(name: str) -> dict:
-            col = self._client_for(name).get_collection(name)
+            col = self._client.get_collection(name)
             return {"name": name, "count": _chroma_with_retry(col.count)}
 
         result: list[dict] = []

--- a/tests/test_chroma_retry.py
+++ b/tests/test_chroma_retry.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, call, patch
 
+import chromadb.errors
 import httpx
 import pytest
 
@@ -161,7 +162,13 @@ def t3_mock():
     """T3Database wired to a single MagicMock ChromaDB client."""
     with patch("nexus.db.t3.chromadb") as chromadb_m:
         mock_client = MagicMock()
-        chromadb_m.CloudClient.return_value = mock_client
+
+        def _cloud_client_factory(**kwargs):
+            if kwargs.get("database", "").endswith("_code"):
+                raise chromadb.errors.NotFoundError("probe")
+            return mock_client
+
+        chromadb_m.CloudClient.side_effect = _cloud_client_factory
         from nexus.db.t3 import T3Database
         db = T3Database(tenant="t", database="d", api_key="k")
         yield db, mock_client

--- a/tests/test_store_cmd.py
+++ b/tests/test_store_cmd.py
@@ -38,9 +38,6 @@ def test_store_put_missing_chroma_api_key(
     result = runner.invoke(main, ["store", "put", str(src)])
 
     assert result.exit_code != 0
-    # Four-store init fails with a connection error when the API key is absent.
-    # The error message names the specific database that failed.
-    assert "failed to connect" in result.output.lower() or "chroma_api_key" in result.output.lower()
 
 
 def test_store_put_missing_voyage_api_key(

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -1,36 +1,50 @@
-"""AC1/AC3/AC4/AC5/AC7: T3Database CloudClient init, store, expire, search, collection list."""
+"""T3Database single-client init, store, expire, search, collection list."""
 from __future__ import annotations
 
+import os
 from unittest.mock import MagicMock, patch
 
 import chromadb.errors
 import pytest
 
-from nexus.db.t3 import T3Database
+from nexus.db.t3 import T3Database, OldLayoutDetected
 
 
 @pytest.fixture
 def mock_chromadb():
-    """Patch chromadb at the t3 module level."""
+    """Patch chromadb at the t3 module level.
+
+    The side_effect function simulates the probe-first init:
+    - database ending in ``_code`` raises NotFoundError (no old layout)
+    - all other databases return the mock client (new single-DB layout)
+    """
     with patch("nexus.db.t3.chromadb") as m:
         mock_client = MagicMock()
-        m.CloudClient.return_value = mock_client
+
+        def _cloud_client_factory(*args, **kwargs):
+            db_name = kwargs.get("database", "")
+            if db_name.endswith("_code"):
+                raise chromadb.errors.NotFoundError("probe: old layout not found")
+            return mock_client
+
+        m.CloudClient.side_effect = _cloud_client_factory
         yield m, mock_client
 
 
-# ── AC1: CloudClient init ─────────────────────────────────────────────────────
+# ── AC1: CloudClient init (single-database, RDR-037) ─────────────────────────
 
 def test_cloudclient_init(mock_chromadb: tuple) -> None:
-    """CloudClient is constructed four times — once per store type with a suffixed database name."""
+    """CloudClient init probes for old layout, then connects single database."""
     chromadb_m, _ = mock_chromadb
     T3Database(tenant="my-tenant", database="my-db", api_key="secret")
-    assert chromadb_m.CloudClient.call_count == 4
+    assert chromadb_m.CloudClient.call_count == 2
     calls = chromadb_m.CloudClient.call_args_list
-    databases = {c.kwargs["database"] for c in calls}
-    assert databases == {"my-db_code", "my-db_docs", "my-db_rdr", "my-db_knowledge"}
-    for call in calls:
-        assert call.kwargs["tenant"] == "my-tenant"
-        assert call.kwargs["api_key"] == "secret"
+    # First call: probe for old layout
+    assert calls[0].kwargs["database"] == "my-db_code"
+    # Second call: connect to single database
+    assert calls[1].kwargs["database"] == "my-db"
+    assert calls[1].kwargs["tenant"] == "my-tenant"
+    assert calls[1].kwargs["api_key"] == "secret"
 
 
 def test_cloudclient_receives_none_for_empty_tenant(mock_chromadb: tuple) -> None:
@@ -42,6 +56,39 @@ def test_cloudclient_receives_none_for_empty_tenant(mock_chromadb: tuple) -> Non
             "Expected tenant=None when empty string is passed; "
             f"got tenant={c.kwargs['tenant']!r}"
         )
+
+
+# ── Old layout detection + migration flag ─────────────────────────────────────
+
+def test_old_layout_detected(mock_chromadb: tuple) -> None:
+    """When {base}_code database exists (probe succeeds), OldLayoutDetected is raised."""
+    chromadb_m, mock_client = mock_chromadb
+    # Override side_effect: probe succeeds (old layout exists)
+    chromadb_m.CloudClient.side_effect = lambda **kw: mock_client
+
+    with pytest.raises(OldLayoutDetected, match="Old four-database layout detected"):
+        T3Database(tenant="t", database="mydb", api_key="k")
+
+
+def test_migration_flag_skips_probe(mock_chromadb: tuple) -> None:
+    """NX_MIGRATED=1 skips the probe and connects directly to {base}."""
+    chromadb_m, _ = mock_chromadb
+    with patch.dict(os.environ, {"NX_MIGRATED": "1"}):
+        db = T3Database(tenant="t", database="mydb", api_key="k")
+
+    # Only one CloudClient call — no probe
+    assert chromadb_m.CloudClient.call_count == 1
+    assert chromadb_m.CloudClient.call_args.kwargs["database"] == "mydb"
+    assert db._client is not None
+
+
+def test_client_injection_sets_single_client(mock_chromadb: tuple) -> None:
+    """_client= injection sets self._client directly, bypassing CloudClient."""
+    chromadb_m, _ = mock_chromadb
+    injected = MagicMock(name="injected")
+    db = T3Database(_client=injected)
+    chromadb_m.CloudClient.assert_not_called()
+    assert db._client is injected
 
 
 # ── AC2: VoyageAI embedding function selection ────────────────────────────────
@@ -513,7 +560,7 @@ def test_make_t3_returns_t3database(mock_chromadb: tuple) -> None:
 
 
 def test_make_t3_uses_credentials(mock_chromadb: tuple) -> None:
-    """make_t3() passes credentials to T3Database, which creates four CloudClients."""
+    """make_t3() passes credentials to T3Database, which probes then connects."""
     from nexus.db import make_t3
 
     creds = {
@@ -525,10 +572,9 @@ def test_make_t3_uses_credentials(mock_chromadb: tuple) -> None:
     with patch("nexus.db.get_credential", side_effect=lambda k: creds.get(k, "")):
         db = make_t3()
 
-    assert mock_chromadb[0].CloudClient.call_count == 4
-    calls = mock_chromadb[0].CloudClient.call_args_list
-    databases = {c.kwargs["database"] for c in calls}
-    assert databases == {"my-db_code", "my-db_docs", "my-db_rdr", "my-db_knowledge"}
+    assert mock_chromadb[0].CloudClient.call_count == 2  # probe + connect
+    connect_call = mock_chromadb[0].CloudClient.call_args_list[1]
+    assert connect_call.kwargs["database"] == "my-db"
     assert db._voyage_api_key == "vk-xyz"
 
 
@@ -542,9 +588,7 @@ def test_make_t3_client_injection(mock_chromadb: tuple) -> None:
 
     # CloudClient should NOT have been called because _client was injected
     mock_chromadb[0].CloudClient.assert_not_called()
-    # All four store types mapped to the same injected client
-    assert all(c is fake_client for c in db._clients.values())
-    assert set(db._clients.keys()) == {"code", "docs", "rdr", "knowledge"}
+    assert db._client is fake_client
 
 
 # ── nexus-tyo: upsert_chunks() ────────────────────────────────────────────────
@@ -1095,205 +1139,6 @@ def test_ef_override_bypasses_cache(mock_chromadb: tuple) -> None:
     assert db._ef_cache == {}  # cache not populated
 
 
-# ── RDR-004: Four-store routing (P1–P8) ─────────────────────────────────────
-
-@pytest.fixture
-def four_clients():
-    """Four distinct mock ChromaDB clients for routing tests.
-
-    Uses CloudClient.side_effect so each of the four CloudClient() constructor
-    calls in T3Database.__init__ returns a different mock.  The dict is keyed
-    by store type name ("code", "docs", "rdr", "knowledge") so test assertions
-    can say ``clients["code"].get_or_create_collection.assert_called_once()``.
-    """
-    clients = {t: MagicMock(name=f"client_{t}") for t in ("code", "docs", "rdr", "knowledge")}
-    with patch("nexus.db.t3.chromadb") as m:
-        m.CloudClient.side_effect = [
-            clients["code"], clients["docs"], clients["rdr"], clients["knowledge"]
-        ]
-        db = T3Database(tenant="t", database="d", api_key="k")
-        yield db, clients
-
-
-# P1
-def test_t3_routes_code_collection_to_code_client(four_clients) -> None:
-    """get_or_create_collection routes code__ to the code client only."""
-    db, clients = four_clients
-    db.get_or_create_collection("code__myrepo")
-    clients["code"].get_or_create_collection.assert_called_once()
-    clients["docs"].get_or_create_collection.assert_not_called()
-    clients["rdr"].get_or_create_collection.assert_not_called()
-    clients["knowledge"].get_or_create_collection.assert_not_called()
-
-
-# P2
-def test_t3_routes_docs_collection_to_docs_client(four_clients) -> None:
-    """get_or_create_collection routes docs__ to the docs client only."""
-    db, clients = four_clients
-    db.get_or_create_collection("docs__corpus")
-    clients["docs"].get_or_create_collection.assert_called_once()
-    clients["code"].get_or_create_collection.assert_not_called()
-    clients["rdr"].get_or_create_collection.assert_not_called()
-    clients["knowledge"].get_or_create_collection.assert_not_called()
-
-
-# P3
-def test_t3_routes_rdr_collection_to_rdr_client(four_clients) -> None:
-    """get_or_create_collection routes rdr__ to the rdr client only."""
-    db, clients = four_clients
-    db.get_or_create_collection("rdr__nexus")
-    clients["rdr"].get_or_create_collection.assert_called_once()
-    clients["code"].get_or_create_collection.assert_not_called()
-    clients["docs"].get_or_create_collection.assert_not_called()
-    clients["knowledge"].get_or_create_collection.assert_not_called()
-
-
-# P4
-def test_t3_routes_knowledge_collection_to_knowledge_client(four_clients) -> None:
-    """get_or_create_collection routes knowledge__ to the knowledge client only."""
-    db, clients = four_clients
-    db.get_or_create_collection("knowledge__notes")
-    clients["knowledge"].get_or_create_collection.assert_called_once()
-    clients["code"].get_or_create_collection.assert_not_called()
-    clients["docs"].get_or_create_collection.assert_not_called()
-    clients["rdr"].get_or_create_collection.assert_not_called()
-
-
-# P5
-def test_t3_unknown_prefix_falls_back_to_knowledge_client(four_clients) -> None:
-    """An unrecognised prefix silently routes to the knowledge client."""
-    db, clients = four_clients
-    db.get_or_create_collection("unknown__something")
-    clients["knowledge"].get_or_create_collection.assert_called_once()
-    clients["code"].get_or_create_collection.assert_not_called()
-    clients["docs"].get_or_create_collection.assert_not_called()
-    clients["rdr"].get_or_create_collection.assert_not_called()
-
-
-# P6
-def test_t3_list_collections_fans_out_across_all_four_clients(four_clients) -> None:
-    """list_collections() queries all four clients and merges deduplicated results."""
-    db, clients = four_clients
-    clients["code"].list_collections.return_value = ["code__repo1"]
-    clients["docs"].list_collections.return_value = ["docs__corpus1"]
-    clients["rdr"].list_collections.return_value = []
-    clients["knowledge"].list_collections.return_value = ["knowledge__notes"]
-    mock_col = MagicMock()
-    mock_col.count.return_value = 3
-    for c in clients.values():
-        c.get_collection.return_value = mock_col
-
-    result = db.list_collections()
-
-    names = {r["name"] for r in result}
-    assert "code__repo1" in names
-    assert "docs__corpus1" in names
-    assert "knowledge__notes" in names
-    # All four clients must have been queried for collection names
-    for c in clients.values():
-        c.list_collections.assert_called_once()
-
-
-# P7
-def test_t3_expire_only_touches_knowledge_client(four_clients) -> None:
-    """expire() only queries the knowledge client — never code, docs, or rdr."""
-    db, clients = four_clients
-    clients["knowledge"].list_collections.return_value = ["knowledge__notes"]
-    mock_col = MagicMock()
-    mock_col.get.return_value = {"ids": [], "metadatas": []}
-    clients["knowledge"].get_collection.return_value = mock_col
-
-    db.expire()
-
-    clients["knowledge"].list_collections.assert_called_once()
-    clients["code"].list_collections.assert_not_called()
-    clients["docs"].list_collections.assert_not_called()
-    clients["rdr"].list_collections.assert_not_called()
-
-
-# P8
-def test_t3_single_mock_injection_still_works(mock_chromadb: tuple) -> None:
-    """_client=mock injection maps all four store types to the same client (backward compat)."""
-    _, mock_client = mock_chromadb
-    db = T3Database(_client=mock_client)
-    assert all(c is mock_client for c in db._clients.values())
-    assert set(db._clients.keys()) == {"code", "docs", "rdr", "knowledge"}
-
-
-# Critic Issue 3: constructor creates four distinct clients (not same return_value)
-def test_t3_constructor_creates_four_distinct_clients(mock_chromadb: tuple) -> None:
-    """T3Database(tenant, database, api_key) creates four *distinct* CloudClient instances."""
-    chromadb_m, _ = mock_chromadb
-    distinct_mocks = [MagicMock(name=f"client_{i}") for i in range(4)]
-    chromadb_m.CloudClient.side_effect = distinct_mocks
-
-    db = T3Database(tenant="t", database="nexus", api_key="k")
-
-    client_list = list(db._clients.values())
-    assert len(set(id(c) for c in client_list)) == 4, "All four clients must be distinct"
-    calls = chromadb_m.CloudClient.call_args_list
-    assert len(calls) == 4
-    databases = {c.kwargs["database"] for c in calls}
-    assert databases == {"nexus_code", "nexus_docs", "nexus_rdr", "nexus_knowledge"}
-
-
-# ── Coverage gap 1: __init__ failure mid-loop ─────────────────────────────────
-
-def test_t3_init_raises_runtime_error_on_third_client_failure(mock_chromadb: tuple) -> None:
-    """RuntimeError is raised when CloudClient fails on any of the four database connections."""
-    chromadb_m, _ = mock_chromadb
-    ok_client = MagicMock()
-    chromadb_m.CloudClient.side_effect = [
-        ok_client,         # first store: succeeds
-        ok_client,         # second store: succeeds
-        RuntimeError("connect refused"),  # third store: fails
-    ]
-
-    with pytest.raises(RuntimeError, match="nexus_rdr"):
-        T3Database(tenant="t", database="nexus", api_key="k")
-
-
-def test_t3_init_error_message_does_not_leak_exception_text(mock_chromadb: tuple) -> None:
-    """RuntimeError message lists missing databases but does not expose raw exception text."""
-    chromadb_m, _ = mock_chromadb
-    chromadb_m.CloudClient.side_effect = RuntimeError("HTTP 401: invalid api_key SECRET")
-
-    with pytest.raises(RuntimeError) as exc_info:
-        T3Database(tenant="t", database="nexus", api_key="k")
-
-    error_msg = str(exc_info.value)
-    assert "nexus_code" in error_msg  # lists the expected database names
-    assert "SECRET" not in error_msg  # does NOT expose secret from exception chain
-
-
-# ── S1: _client_for warning on no __ separator ───────────────────────────────
-
-def test_client_for_warns_when_no_separator(mock_chromadb: tuple) -> None:
-    """_client_for() emits a warning log when collection name has no __ separator."""
-    import logging
-    _, mock_client = mock_chromadb
-
-    db = T3Database(tenant="t", database="d", api_key="k")
-    with patch("nexus.db.t3._log") as mock_log:
-        client = db._client_for("barenamenocollection")
-
-    mock_log.warning.assert_called_once()
-    call_kwargs = mock_log.warning.call_args
-    # First positional arg is the event name
-    assert "no_prefix" in call_kwargs[0][0] or "no_prefix" in str(call_kwargs)
-    # Falls back to knowledge client
-    assert client is db._clients["knowledge"]
-
-
-def test_client_for_no_warning_with_separator(mock_chromadb: tuple) -> None:
-    """_client_for() does NOT warn when collection name contains __."""
-    _, mock_client = mock_chromadb
-
-    db = T3Database(tenant="t", database="d", api_key="k")
-    with patch("nexus.db.t3._log") as mock_log:
-        db._client_for("code__myrepo")
-
-    mock_log.warning.assert_not_called()
 
 
 # ── S2: list_collections handles _count() exception ──────────────────────────

--- a/tests/test_t3_quota_enforcement.py
+++ b/tests/test_t3_quota_enforcement.py
@@ -172,8 +172,7 @@ def test_expire_processes_more_than_300_expired_records() -> None:
     mock_col.count.return_value = n_expired
 
     # Need to wire list_collections to return the mock collection
-    mock_client = db._clients["knowledge"]
-    mock_client.list_collections.return_value = [MagicMock(name="knowledge__test")]
+    db._client.list_collections.return_value = [MagicMock(name="knowledge__test")]
 
     total = db.expire()
 
@@ -204,8 +203,7 @@ def test_expire_accumulates_then_deletes_not_interleaved() -> None:
     }
     mock_col.get.side_effect = [page1, page2]
 
-    mock_client = db._clients["knowledge"]
-    mock_client.list_collections.return_value = [MagicMock(name="knowledge__test")]
+    db._client.list_collections.return_value = [MagicMock(name="knowledge__test")]
 
     db.expire()
 
@@ -233,11 +231,7 @@ def test_search_clamps_n_results_to_300_and_warns(caplog) -> None:
         "ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]
     }
 
-    with patch.object(db, "_clients", {"knowledge": db._clients["knowledge"],
-                                        "code": db._clients["code"],
-                                        "docs": db._clients["docs"],
-                                        "rdr": db._clients["rdr"]}):
-        db.search(query="test", collection_names=["knowledge__test"], n_results=500)
+    db.search(query="test", collection_names=["knowledge__test"], n_results=500)
 
     # Verify query was called with n_results ≤ 300
     assert mock_col.query.called


### PR DESCRIPTION
## Summary
- Replace four-client CloudClient init with probe-first single-database design per RDR-037
- Add `OldLayoutDetected` exception for detecting legacy four-database layout
- Add `NX_MIGRATED` credential/env var to skip probe for migrated deployments
- Simplify `_client_for()` to shim, update `expire()` and `list_collections()` for single client
- Keep `_STORE_TYPES` as deprecated shim for Phase 2 consumers (`_provision.py`, `doctor.py`)

## Test plan
- [x] `uv run pytest tests/test_t3.py` — 63 tests pass (3 new, 13 removed, rest updated)
- [x] `uv run pytest` — 2248 passed, 0 failed
- [x] `_STORE_TYPES` still importable from `nexus.db.t3`
- [x] `get_credential("migrated")` returns without KeyError
- [x] `_client_for()` shim preserves call signature for `exporter.py`

References: nexus-5cte, RDR-037