### PR TITLE
Add local T3 backend for zero-config usage (RDR-038)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Nexus is a Python 3.12+ CLI + persistent server for semantic search and knowledg
 **Three storage tiers:**
 - T1: `chromadb.EphemeralClient` (or HTTP server via SessionStart hook) — session scratch (`nx scratch`)
 - T2: SQLite + FTS5 — persistent memory (`nx memory`)
-- T3: `chromadb.CloudClient` + `VoyageAIEmbeddingFunction` — permanent knowledge (`nx store`, `nx search`)
+- T3: `chromadb.PersistentClient` + local ONNX embeddings (local mode, zero-config) OR `chromadb.CloudClient` + `VoyageAIEmbeddingFunction` (cloud mode) — permanent knowledge (`nx store`, `nx search`)
 
 **T3 ChromaDB database**: a single `chromadb.CloudClient` database (`CHROMA_DATABASE` value, e.g. `nexus`). All collection prefixes coexist in one database:
 - `code__*` collections — `voyage-code-3` for index, `voyage-4` for query
@@ -66,7 +66,7 @@ Nexus is a Python 3.12+ CLI + persistent server for semantic search and knowledg
 src/nexus/           # Core package
   cli.py             # Click entry point; registers all command groups
   commands/          # One file per CLI command group (index, search, memory, scratch, store, collection, config, hooks, doctor)
-  db/                # t1.py, t2.py, t3.py — tier implementations
+  db/                # t1.py, t2.py, t3.py — tier implementations; local_ef.py — local ONNX embeddings
   indexer.py         # Repo indexing pipeline (classify → chunk → embed → store)
   classifier.py      # File classification: CODE / PROSE / PDF / SKIP
   chunker.py         # Tree-sitter AST chunking (31 languages)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,13 +11,31 @@ Four levels, highest priority wins:
 
 Each level is deep-merged, with higher-priority values winning.
 
-## Credentials
+## Local Mode
+
+Nexus auto-detects local mode when cloud credentials are absent. No configuration needed — just `pip install conexus && nx index repo .`.
+
+| Env var | Default | Description |
+|---|---|---|
+| `NX_LOCAL` | (auto) | `1` = force local, `0` = force cloud, unset = auto-detect |
+| `NX_LOCAL_CHROMA_PATH` | `~/.local/share/nexus/chroma` | Override local ChromaDB storage path |
+| `NX_LOCAL_EMBED_MODEL` | (auto) | Force a specific local embedding model name |
+
+**Auto-detection**: When both `CHROMA_API_KEY` and `VOYAGE_API_KEY` are absent, local mode activates. Set `NX_LOCAL=1` to force local mode even with cloud credentials.
+
+**Embedding tiers**: Tier 0 (bundled MiniLM-L6-v2, 384d) is always available. Install `pip install conexus[local]` for tier 1 (bge-base-en-v1.5, 768d, better quality).
+
+**Storage path**: Defaults to `$XDG_DATA_HOME/nexus/chroma` or `~/.local/share/nexus/chroma`. Override with `NX_LOCAL_CHROMA_PATH`.
+
+**Switching modes**: Changing between local and cloud mode triggers automatic re-indexing on the next `nx index repo .` (embedding model mismatch detected by staleness check). Local and cloud embeddings are incompatible — there is no automatic migration.
+
+## Cloud Credentials
 
 | Config key | Env var | Required | Notes |
 |---|---|---|---|
-| `chroma_api_key` | `CHROMA_API_KEY` | Yes | ChromaDB Cloud API key |
-| `chroma_database` | `CHROMA_DATABASE` | Yes | ChromaDB Cloud database name (e.g. `nexus`) |
-| `voyage_api_key` | `VOYAGE_API_KEY` | Yes | Voyage AI embeddings key |
+| `chroma_api_key` | `CHROMA_API_KEY` | Cloud mode | ChromaDB Cloud API key |
+| `chroma_database` | `CHROMA_DATABASE` | Cloud mode | ChromaDB Cloud database name (e.g. `nexus`) |
+| `voyage_api_key` | `VOYAGE_API_KEY` | Cloud mode | Voyage AI embeddings key |
 | `chroma_tenant` | `CHROMA_TENANT` | No | Auto-inferred from API key; only needed for multi-workspace setups |
 
 Set via `nx config init` (wizard) or `nx config set KEY VALUE`. Stored in `~/.config/nexus/config.yml`.
@@ -87,6 +105,7 @@ These values are exposed as a `TuningConfig` dataclass in `nexus.config`. The se
 | File | Purpose |
 |---|---|
 | `~/.config/nexus/config.yml` | Global config and credentials |
+| `~/.local/share/nexus/chroma/` | Local T3 ChromaDB PersistentClient data (local mode) |
 | `~/.config/nexus/memory.db` | T2 SQLite database |
 | `~/.config/nexus/repos.json` | Registered repos (`nx index repo` writes here) |
 | `~/.config/nexus/sessions/` | JSON session records (T1 server address, session ID, `created_at`, `tmpdir`) + `session.lock` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,9 +49,24 @@ The plugin gives agents direct access to all three storage tiers via MCP servers
 claude --plugin-dir ./nx
 ```
 
-## Add semantic search (T3)
+## Semantic search — local mode (zero config)
 
-When you want to search code, documents, and knowledge by meaning, set up T3 credentials.
+Nexus includes a local T3 backend that works immediately — no API keys, no accounts, no network.
+
+```bash
+nx index repo .           # index your codebase with local ONNX embeddings
+nx search "retry logic"   # semantic search, runs entirely on your machine
+```
+
+Local mode activates automatically when no cloud credentials are configured. It uses ChromaDB `PersistentClient` with bundled MiniLM-L6-v2 embeddings (384 dimensions). Data is stored at `~/.local/share/nexus/chroma`.
+
+**Upgrade embedding quality** with `pip install conexus[local]` to use `bge-base-en-v1.5` (768 dimensions) — better retrieval accuracy, especially for code search.
+
+To force local mode even when cloud credentials exist, set `NX_LOCAL=1`.
+
+## Semantic search — cloud mode
+
+When you want higher-quality embeddings (1024d Voyage AI), cross-chunk context (CCE), and reranking, set up T3 cloud credentials.
 
 ### Accounts
 
@@ -113,7 +128,7 @@ Common flags: `--n 20` (result count), `--json`, `--files` (paths only), `-c` (s
 
 **Provisioning failed during `nx config init`** — If your ChromaDB plan restricts automatic database creation, create the database manually in the [dashboard](https://trychroma.com) using your `chroma_database` value as the name.
 
-**`nx index repo .` fails with "credentials not set"** — Indexing requires T3 credentials. Run `nx config init` first. Local commands (`nx memory`, `nx scratch`) work without credentials.
+**`nx index repo .` fails with "credentials not set"** — In cloud mode, indexing requires T3 credentials. Run `nx config init` first, or use local mode (no credentials needed).
 
 **First index is slow or hits a rate limit** — Large repos may take a few minutes. Add `--monitor` for per-file progress. Re-running after a partial index is safe — unchanged files are skipped.
 

--- a/docs/storage-tiers.md
+++ b/docs/storage-tiers.md
@@ -38,19 +38,40 @@ Data is organized by project via the `--project` flag. TTL values: `30d`, `4w`, 
 
 ## T3 -- Permanent Knowledge
 
+T3 has two backends: **local** (zero-config) and **cloud** (higher quality).
+
+### Local backend (default when no cloud credentials)
+
+Backed by `chromadb.PersistentClient` with local ONNX embeddings. No API keys or network required. Data stored at `~/.local/share/nexus/chroma`.
+
+| | Tier 0 (bundled) | Tier 1 (`pip install conexus[local]`) |
+|---|---|---|
+| Model | all-MiniLM-L6-v2 | bge-base-en-v1.5 |
+| Dimensions | 384 | 768 |
+| Quality | Basic semantic matching | Better code & prose retrieval |
+| Install | Included | `pip install conexus[local]` |
+
+All collection types use the same local model (no per-prefix splitting). Reranking is unavailable in local mode.
+
+### Cloud backend
+
 Backed by a single `chromadb.CloudClient` with `VoyageAIEmbeddingFunction`. Requires `CHROMA_API_KEY`, `CHROMA_DATABASE`, and `VOYAGE_API_KEY`. `CHROMA_TENANT` is optional — the CloudClient infers the tenant UUID from your API key.
 
 All collections coexist in one ChromaDB Cloud database (`CHROMA_DATABASE` value, e.g. `nexus`). The database is provisioned automatically by `nx config init`. Run `nx doctor` to verify connectivity.
 
+### Collections
+
 Collections are namespaced by corpus type using `__` (double underscore) as separator:
 
-| Pattern | Contents | Index model | Query model |
-|---------|----------|-------------|-------------|
+| Pattern | Contents | Cloud index model | Cloud query model |
+|---------|----------|-------------------|-------------------|
 | `code__<repo>-<hash>` | Indexed source code | voyage-code-3 | voyage-4 |
 | `docs__<repo>-<hash>` | Indexed prose files | voyage-context-3 (CCE) | voyage-4 |
 | `rdr__<repo>-<hash>` | Indexed RDR documents | voyage-context-3 (CCE) | voyage-4 |
 | `docs__<corpus>` | Indexed PDFs and markdown | voyage-context-3 (CCE) | voyage-4 |
 | `knowledge__<topic>` | Stored agent outputs and notes | voyage-context-3 | voyage-4 |
+
+In local mode, all collections use the active local model for both index and query.
 
 **TTL and expiry**: `nx store expire` removes expired entries from `knowledge__*` collections only. Code, docs, and RDR collections are never expired — they are refreshed via re-indexing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ dependencies = [
     "mcp>=1.0",
 ]
 
+[project.optional-dependencies]
+local = ["fastembed>=0.7.0"]
+
 [project.urls]
 Homepage = "https://github.com/Hellblazer/nexus"
 Repository = "https://github.com/Hellblazer/nexus"

--- a/src/nexus/code_indexer.py
+++ b/src/nexus/code_indexer.py
@@ -389,20 +389,26 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
     # Embed using prefixed texts for improved retrieval quality; raw documents are stored.
     embeddings: list[list[float]] = []
     total_chunks = len(documents)
-    for batch_start in range(0, total_chunks, _VOYAGE_EMBED_BATCH_SIZE):
-        batch = embed_texts[batch_start : batch_start + _VOYAGE_EMBED_BATCH_SIZE]
-        _log.debug(
-            "embedding batch",
-            file=str(file_path),
-            batch=f"{batch_start+1}-{min(batch_start+len(batch), total_chunks)}/{total_chunks}",
-        )
-        result = _voyage_with_retry(
-            ctx.voyage_client.embed,  # type: ignore[attr-defined]
-            texts=batch,
-            model=ctx.embedding_model,
-            input_type="document",
-        )
-        embeddings.extend(result.embeddings)
+    if ctx.embed_fn is not None:
+        # Local mode: use injected embedding function
+        for batch_start in range(0, total_chunks, _VOYAGE_EMBED_BATCH_SIZE):
+            batch = embed_texts[batch_start : batch_start + _VOYAGE_EMBED_BATCH_SIZE]
+            embeddings.extend(ctx.embed_fn(batch))
+    else:
+        for batch_start in range(0, total_chunks, _VOYAGE_EMBED_BATCH_SIZE):
+            batch = embed_texts[batch_start : batch_start + _VOYAGE_EMBED_BATCH_SIZE]
+            _log.debug(
+                "embedding batch",
+                file=str(file_path),
+                batch=f"{batch_start+1}-{min(batch_start+len(batch), total_chunks)}/{total_chunks}",
+            )
+            result = _voyage_with_retry(
+                ctx.voyage_client.embed,  # type: ignore[attr-defined]
+                texts=batch,
+                model=ctx.embedding_model,
+                input_type="document",
+            )
+            embeddings.extend(result.embeddings)
 
     _log.debug("upserting", file=str(file_path), chunks=total_chunks)
     ctx.db.upsert_chunks_with_embeddings(  # type: ignore[attr-defined]

--- a/src/nexus/commands/memory.py
+++ b/src/nexus/commands/memory.py
@@ -162,15 +162,19 @@ def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None
         if entry is None:
             raise click.ClickException(f"Entry {entry_id} not found in T2 memory.")
 
-        missing = [
-            k
-            for k in ("chroma_api_key", "voyage_api_key", "chroma_database")
-            if not get_credential(k)
-        ]
-        if missing:
-            raise click.ClickException(
-                f"{', '.join(missing)} not set — run: nx config init"
-            )
+        from nexus.config import is_local_mode
+        from nexus.db import make_t3
+
+        if not is_local_mode():
+            missing = [
+                k
+                for k in ("chroma_api_key", "voyage_api_key", "chroma_database")
+                if not get_credential(k)
+            ]
+            if missing:
+                raise click.ClickException(
+                    f"{', '.join(missing)} not set — run: nx config init"
+                )
 
         # Translate TTL: T2 ttl=None (permanent) -> T3 ttl_days=0; T2 ttl=N -> T3 ttl_days=N
         ttl_days: int = entry["ttl"] if entry["ttl"] is not None else 0  # type: ignore[assignment]
@@ -184,12 +188,7 @@ def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None
         else:
             expires_at = ""  # permanent
 
-        with T3Database(
-            tenant=get_credential("chroma_tenant"),
-            database=get_credential("chroma_database"),
-            api_key=get_credential("chroma_api_key"),
-            voyage_api_key=get_credential("voyage_api_key"),
-        ) as t3:
+        with make_t3() as t3:
             doc_id = t3.put(
                 collection=collection,
                 content=entry["content"],

--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -262,8 +262,9 @@ def search_cmd(
         file_size_threshold=tuning.file_size_threshold,
     )
 
-    # Reranking
-    if not no_rerank and len(set(r.collection for r in results)) > 1:
+    # Reranking (skipped in local mode — no Voyage AI reranker available)
+    from nexus.config import is_local_mode
+    if not no_rerank and not is_local_mode() and len(set(r.collection for r in results)) > 1:
         try:
             results = rerank_results(results, query=query, model=reranker_model, top_k=n)
         except Exception as exc:

--- a/src/nexus/commands/store.py
+++ b/src/nexus/commands/store.py
@@ -11,24 +11,25 @@ from nexus.ttl import parse_ttl
 
 
 def _t3() -> T3Database:
-    from nexus.config import get_credential
+    from nexus.config import get_credential, is_local_mode
 
-    database = get_credential("chroma_database")
-    api_key = get_credential("chroma_api_key")
-    voyage_api_key = get_credential("voyage_api_key")
+    if not is_local_mode():
+        database = get_credential("chroma_database")
+        api_key = get_credential("chroma_api_key")
+        voyage_api_key = get_credential("voyage_api_key")
 
-    if not api_key:
-        raise click.ClickException(
-            "chroma_api_key not set — run: nx config set chroma_api_key <value>"
-        )
-    if not voyage_api_key:
-        raise click.ClickException(
-            "voyage_api_key not set — run: nx config set voyage_api_key <value>"
-        )
-    if not database:
-        raise click.ClickException(
-            "chroma_database not set — run: nx config init"
-        )
+        if not api_key:
+            raise click.ClickException(
+                "chroma_api_key not set — run: nx config set chroma_api_key <value>"
+            )
+        if not voyage_api_key:
+            raise click.ClickException(
+                "voyage_api_key not set — run: nx config set voyage_api_key <value>"
+            )
+        if not database:
+            raise click.ClickException(
+                "chroma_database not set — run: nx config init"
+            )
     try:
         return make_t3()
     except RuntimeError as exc:

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -124,6 +124,45 @@ CREDENTIALS: dict[str, str] = {
     "migrated":          "NX_MIGRATED",
 }
 
+
+# ── Local mode helpers ───────────────────────────────────────────────────────
+
+
+def _default_local_path() -> Path:
+    """Return the default local ChromaDB PersistentClient path.
+
+    Precedence:
+      1. ``NX_LOCAL_CHROMA_PATH`` env var (explicit override)
+      2. ``$XDG_DATA_HOME/nexus/chroma``
+      3. ``~/.local/share/nexus/chroma``
+    """
+    override = os.environ.get("NX_LOCAL_CHROMA_PATH")
+    if override:
+        return Path(override)
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg) / "nexus" / "chroma"
+    return Path.home() / ".local" / "share" / "nexus" / "chroma"
+
+
+def is_local_mode() -> bool:
+    """Return True if nexus should use the local T3 backend.
+
+    Decision logic:
+      - ``NX_LOCAL=1`` → True  (explicit opt-in)
+      - ``NX_LOCAL=0`` → False (explicit opt-out)
+      - Otherwise: True when **both** CHROMA_API_KEY and VOYAGE_API_KEY are absent
+    """
+    nx_local = os.environ.get("NX_LOCAL", "").strip()
+    if nx_local == "1":
+        return True
+    if nx_local == "0":
+        return False
+    # Auto-detect: local mode when either cloud credential is missing
+    chroma_key = get_credential("chroma_api_key")
+    voyage_key = get_credential("voyage_api_key")
+    return not (chroma_key and voyage_key)
+
 # ── Defaults ──────────────────────────────────────────────────────────────────
 
 _DEFAULTS: dict[str, Any] = {

--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -42,42 +42,38 @@ def validate_collection_name(name: str) -> None:
         )
 
 
-def _local_model_name() -> str:
-    """Return the active local embedding model name (cached)."""
-    from nexus.db.local_ef import LocalEmbeddingFunction
-    return LocalEmbeddingFunction().model_name
-
-
 def embedding_model_for_collection(collection_name: str) -> str:
-    """Return the model used at QUERY time for a T3 collection.
+    """Return the Voyage AI model used at QUERY time for a T3 collection.
 
-    In local mode, all collections use the same local embedding model.
+    CCE collections (docs__, knowledge__, rdr__) must use voyage-context-3
+    at query time via contextualized_embed() — voyage-4 and voyage-context-3
+    are incompatible vector spaces (cosine similarity ≈ 0.05, i.e. random noise).
 
-    In cloud mode:
-    - CCE collections (docs__, knowledge__, rdr__) use voyage-context-3
-    - All other collections use voyage-4
+    code__ collections are indexed with voyage-code-3 but queried with voyage-4 —
+    the semantic spaces are compatible enough for effective retrieval.
+
+    All other collections use voyage-4.
+
+    Note: in local mode, callers bypass this function and use
+    ``LocalEmbeddingFunction().model_name`` directly.
     """
-    from nexus.config import is_local_mode
-    if is_local_mode():
-        return _local_model_name()
     if collection_name.startswith(("docs__", "knowledge__", "rdr__")):
         return "voyage-context-3"
     return "voyage-4"
 
 
 def index_model_for_collection(collection_name: str) -> str:
-    """Return the model used at INDEX time for a T3 collection.
+    """Return the Voyage AI model used at INDEX time for a T3 collection.
 
-    In local mode, all collections use the same local embedding model.
+    code__      → voyage-code-3    (code-optimised index; voyage-4 at query time)
+    docs__      → voyage-context-3 (CCE for richer cross-chunk context)
+    knowledge__ → voyage-context-3 (CCE for richer cross-chunk context)
+    rdr__       → voyage-context-3 (CCE for RDR decision documents)
+    all others  → voyage-4         (standard embedding)
 
-    In cloud mode:
-    - code__      → voyage-code-3
-    - docs__, knowledge__, rdr__ → voyage-context-3 (CCE)
-    - all others  → voyage-4
+    Note: in local mode, callers bypass this function and use
+    ``LocalEmbeddingFunction().model_name`` directly.
     """
-    from nexus.config import is_local_mode
-    if is_local_mode():
-        return _local_model_name()
     if collection_name.startswith("code__"):
         return "voyage-code-3"
     if collection_name.startswith(("docs__", "knowledge__", "rdr__")):

--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -42,32 +42,42 @@ def validate_collection_name(name: str) -> None:
         )
 
 
+def _local_model_name() -> str:
+    """Return the active local embedding model name (cached)."""
+    from nexus.db.local_ef import LocalEmbeddingFunction
+    return LocalEmbeddingFunction().model_name
+
+
 def embedding_model_for_collection(collection_name: str) -> str:
-    """Return the Voyage AI model used at QUERY time for a T3 collection.
+    """Return the model used at QUERY time for a T3 collection.
 
-    CCE collections (docs__, knowledge__, rdr__) must use voyage-context-3
-    at query time via contextualized_embed() — voyage-4 and voyage-context-3
-    are incompatible vector spaces (cosine similarity ≈ 0.05, i.e. random noise).
+    In local mode, all collections use the same local embedding model.
 
-    code__ collections are indexed with voyage-code-3 but queried with voyage-4 —
-    the semantic spaces are compatible enough for effective retrieval.
-
-    All other collections use voyage-4.
+    In cloud mode:
+    - CCE collections (docs__, knowledge__, rdr__) use voyage-context-3
+    - All other collections use voyage-4
     """
+    from nexus.config import is_local_mode
+    if is_local_mode():
+        return _local_model_name()
     if collection_name.startswith(("docs__", "knowledge__", "rdr__")):
         return "voyage-context-3"
     return "voyage-4"
 
 
 def index_model_for_collection(collection_name: str) -> str:
-    """Return the Voyage AI model used at INDEX time for a T3 collection.
+    """Return the model used at INDEX time for a T3 collection.
 
-    code__      → voyage-code-3    (code-optimised index; voyage-4 at query time)
-    docs__      → voyage-context-3 (CCE for richer cross-chunk context)
-    knowledge__ → voyage-context-3 (CCE for richer cross-chunk context)
-    rdr__       → voyage-context-3 (CCE for RDR decision documents)
-    all others  → voyage-4         (standard embedding)
+    In local mode, all collections use the same local embedding model.
+
+    In cloud mode:
+    - code__      → voyage-code-3
+    - docs__, knowledge__, rdr__ → voyage-context-3 (CCE)
+    - all others  → voyage-4
     """
+    from nexus.config import is_local_mode
+    if is_local_mode():
+        return _local_model_name()
     if collection_name.startswith("code__"):
         return "voyage-code-3"
     if collection_name.startswith(("docs__", "knowledge__", "rdr__")):

--- a/src/nexus/db/__init__.py
+++ b/src/nexus/db/__init__.py
@@ -17,6 +17,13 @@ from nexus.db.t3 import T3Database
 def make_t3(*, _client=None, _ef_override=None) -> T3Database:
     """Return a :class:`T3Database` built from the current credentials.
 
+    In local mode (``is_local_mode()`` returns True), returns a T3Database
+    backed by ``chromadb.PersistentClient`` with a ``LocalEmbeddingFunction``.
+    No API keys required.
+
+    In cloud mode, returns a T3Database backed by ``chromadb.CloudClient``
+    with Voyage AI embeddings.
+
     Keyword-only injection points (for tests):
 
     * ``_client`` — substitute an ``EphemeralClient`` or ``MagicMock`` to
@@ -24,7 +31,22 @@ def make_t3(*, _client=None, _ef_override=None) -> T3Database:
     * ``_ef_override`` — override the embedding function (e.g.
       ``DefaultEmbeddingFunction()``) to avoid Voyage AI API calls.
     """
-    from nexus.config import load_config
+    from nexus.config import is_local_mode, load_config, _default_local_path
+
+    if is_local_mode() and _client is None:
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        import os
+
+        model_override = os.environ.get("NX_LOCAL_EMBED_MODEL", "")
+        ef = _ef_override or LocalEmbeddingFunction(
+            model_name=model_override if model_override else None,
+        )
+        return T3Database(
+            local_mode=True,
+            local_path=str(_default_local_path()),
+            _ef_override=ef,
+        )
+
     cfg = load_config()
     read_timeout_seconds: float = cfg.get("voyageai", {}).get("read_timeout_seconds", 120.0)
     return T3Database(

--- a/src/nexus/db/local_ef.py
+++ b/src/nexus/db/local_ef.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Local embedding function for zero-config T3 (RDR-038).
+
+Implements the ChromaDB ``EmbeddingFunction`` protocol using local models:
+- Tier 0: bundled ``chromadb.utils.embedding_functions.ONNXMiniLM_L6_V2`` (384d)
+- Tier 1: ``fastembed`` bge-base-en-v1.5 (768d) — requires ``pip install conexus[local]``
+
+Auto-selection: tier 1 if fastembed is importable, else tier 0.
+Explicit: ``LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")`` forces tier 0.
+"""
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+# Model metadata: name → dimensions
+_MODEL_DIMS: dict[str, int] = {
+    "all-MiniLM-L6-v2": 384,
+    "BAAI/bge-base-en-v1.5": 768,
+}
+
+_TIER0_MODEL = "all-MiniLM-L6-v2"
+_TIER1_MODEL = "BAAI/bge-base-en-v1.5"
+
+
+def _fastembed_available() -> bool:
+    """Return True if fastembed can be imported."""
+    try:
+        importlib.import_module("fastembed")
+        return True
+    except (ImportError, ModuleNotFoundError):
+        return False
+
+
+class LocalEmbeddingFunction:
+    """ChromaDB-compatible embedding function using local ONNX models.
+
+    Satisfies the ``chromadb.api.types.EmbeddingFunction`` protocol:
+    ``__call__(input: Documents) -> Embeddings`` where ``Documents = list[str]``
+    and ``Embeddings = list[list[float]]``.
+
+    Also implements ``name()``, ``build_from_config()``, ``get_config()``, and
+    ``is_legacy()`` required by ChromaDB >= 0.6 PersistentClient.
+    """
+
+    def __init__(self, model_name: str | None = None) -> None:
+        if model_name is not None:
+            self._model_name = model_name
+        elif _fastembed_available():
+            self._model_name = _TIER1_MODEL
+        else:
+            self._model_name = _TIER0_MODEL
+
+        self._dimensions = _MODEL_DIMS.get(self._model_name, 384)
+        self._ef: Any = None  # lazy init
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    # ── ChromaDB EmbeddingFunction protocol ──────────────────────────────
+
+    @staticmethod
+    def name() -> str:
+        return "nexus_local"
+
+    def is_legacy(self) -> bool:
+        return False
+
+    def get_config(self) -> dict[str, Any]:
+        return {"model_name": self._model_name, "dimensions": self._dimensions}
+
+    @staticmethod
+    def build_from_config(config: dict[str, Any]) -> "LocalEmbeddingFunction":
+        return LocalEmbeddingFunction(model_name=config.get("model_name"))
+
+    def embed_query(self, input: list[str]) -> list[list[float]]:
+        """Embed query input (same as __call__ for local models)."""
+        return self(input)
+
+    def default_space(self) -> str:
+        return "cosine"
+
+    def supported_spaces(self) -> list[str]:
+        return ["cosine", "l2", "ip"]
+
+    # ── Embedding ────────────────────────────────────────────────────────
+
+    def _init_ef(self) -> None:
+        """Lazy-initialise the underlying embedding function."""
+        if self._model_name == _TIER0_MODEL:
+            from chromadb.utils.embedding_functions import ONNXMiniLM_L6_V2
+
+            self._ef = ONNXMiniLM_L6_V2()
+        else:
+            # Tier 1: fastembed
+            from fastembed import TextEmbedding
+
+            self._ef = TextEmbedding(model_name=self._model_name)
+        _log.debug("local_ef_initialized", model=self._model_name, dims=self._dimensions)
+
+    def __call__(self, input: list[str]) -> list[list[float]]:
+        """Embed a list of texts, returning a list of float vectors."""
+        if self._ef is None:
+            self._init_ef()
+
+        if self._model_name == _TIER0_MODEL:
+            # ONNXMiniLM_L6_V2 already returns list[list[float]]
+            return self._ef(input)
+        else:
+            # fastembed TextEmbedding.embed() returns a generator of numpy arrays
+            return [vec.tolist() for vec in self._ef.embed(input)]

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -38,16 +38,17 @@ from nexus.retry import (
 )
 
 class T3Database:
-    """T3 ChromaDB CloudClient permanent knowledge store.
+    """T3 ChromaDB permanent knowledge store.
 
-    Uses a single ``chromadb.CloudClient`` connected to the ``chroma_database``
-    base name directly.  All collection prefixes (``code__``, ``docs__``,
-    ``rdr__``, ``knowledge__``) coexist in one database.
+    Supports two modes:
+    - **Cloud mode** (default): ``chromadb.CloudClient`` connected to the configured
+      ChromaDB Cloud database.
+    - **Local mode** (``local_mode=True``): ``chromadb.PersistentClient`` using a
+      local directory — zero API keys required.
 
-    On first connection (no ``NX_MIGRATED`` flag), the constructor probes for
+    On first cloud connection (no ``NX_MIGRATED`` flag), the constructor probes for
     the old four-database layout by attempting to connect to ``{base}_code``.
-    If that database exists, ``OldLayoutDetected`` is raised.  If it does not
-    (``NotFoundError``), the new single-database layout is assumed.
+    If that database exists, ``OldLayoutDetected`` is raised.
 
     The ``_client`` and ``_ef_override`` keyword arguments are injection
     points for testing — pass an ``EphemeralClient`` and
@@ -62,10 +63,13 @@ class T3Database:
         api_key: str = "",
         voyage_api_key: str = "",
         *,
+        local_mode: bool = False,
+        local_path: str = "",
         read_timeout_seconds: float = 120.0,
         _client=None,
         _ef_override=None,
     ) -> None:
+        self._local_mode = local_mode
         self._voyage_api_key = voyage_api_key
         self._ef_override = _ef_override
         self._ef_cache: dict[str, object] = {}
@@ -74,6 +78,20 @@ class T3Database:
         self._read_sems: dict[str, threading.BoundedSemaphore] = {}
         self._sems_lock = threading.Lock()
         self._quota_validator = QuotaValidator()
+
+        # ── Local mode: PersistentClient, no cloud, no Voyage ────────────
+        if local_mode:
+            from pathlib import Path
+            p = Path(local_path)
+            p.mkdir(parents=True, exist_ok=True)
+            if _client is not None:
+                self._client = _client
+            else:
+                self._client = chromadb.PersistentClient(path=str(p))
+            self._voyage_client = None
+            return
+
+        # ── Cloud mode ───────────────────────────────────────────────────
         self._voyage_client: voyageai.Client | None = (
             voyageai.Client(api_key=voyage_api_key, timeout=read_timeout_seconds, max_retries=3)
             if voyage_api_key else None
@@ -320,11 +338,12 @@ class T3Database:
                 expires_at = ""
 
         # Determine whether this collection uses CCE.  When a voyage_api_key
-        # is available, CCE collections (docs__, knowledge__, rdr__) are embedded
-        # via _cce_embed() so that put()-stored entries are in the same vector
-        # space as the CCE-indexed chunks and can be found by search().
+        # is available and we're not in local mode, CCE collections (docs__,
+        # knowledge__, rdr__) are embedded via _cce_embed() so that put()-stored
+        # entries are in the same vector space as the CCE-indexed chunks.
         is_cce = (
-            bool(self._voyage_api_key)
+            not self._local_mode
+            and bool(self._voyage_api_key)
             and index_model_for_collection(collection) == "voyage-context-3"
         )
 
@@ -435,9 +454,10 @@ class T3Database:
             # CCE collections must be queried with voyage-context-3 via
             # contextualized_embed(); using query_texts would invoke the voyage-4
             # EF, producing vectors in an incompatible space (cosine sim ≈ 0.05).
-            # Skip CCE path when voyage_api_key is absent (test / offline mode).
+            # Skip CCE path in local mode or when voyage_api_key is absent.
             is_cce = (
-                bool(self._voyage_api_key)
+                not self._local_mode
+                and bool(self._voyage_api_key)
                 and index_model_for_collection(name) == "voyage-context-3"
             )
             try:
@@ -452,14 +472,17 @@ class T3Database:
             count = _chroma_with_retry(col.count)
             if count == 0:
                 continue
-            actual_n = min(n_results, count, QUOTAS.MAX_QUERY_RESULTS)
-            if n_results > QUOTAS.MAX_QUERY_RESULTS:
-                _log.warning(
-                    "search_n_results_clamped",
-                    requested=n_results,
-                    actual=actual_n,
-                    collection=name,
-                )
+            if self._local_mode:
+                actual_n = min(n_results, count)
+            else:
+                actual_n = min(n_results, count, QUOTAS.MAX_QUERY_RESULTS)
+                if n_results > QUOTAS.MAX_QUERY_RESULTS:
+                    _log.warning(
+                        "search_n_results_clamped",
+                        requested=n_results,
+                        actual=actual_n,
+                        collection=name,
+                    )
             if is_cce:
                 query_kwargs: dict = {
                     "query_embeddings": [self._cce_embed(query, input_type="query")],
@@ -555,7 +578,7 @@ class T3Database:
             col = self._client_for(collection).get_collection(collection)
         except _ChromaNotFoundError:
             return []
-        clamped = min(limit, QUOTAS.MAX_QUERY_RESULTS)
+        clamped = limit if self._local_mode else min(limit, QUOTAS.MAX_QUERY_RESULTS)
         with self._read_sem(collection):
             result = _chroma_with_retry(col.get, include=["metadatas"], limit=clamped)
         return [

--- a/src/nexus/index_context.py
+++ b/src/nexus/index_context.py
@@ -3,6 +3,7 @@
 """IndexContext dataclass: shared indexing parameters replacing 12-parameter function signatures."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -20,6 +21,10 @@ class IndexContext:
     prose/PDF paths that call doc_indexer._embed_with_fallback internally) and
     ``voyage_client`` (pre-constructed voyageai.Client, used by the code path
     that calls voyage_client.embed directly).
+
+    In local mode, ``embed_fn`` is set and ``voyage_client``/``voyage_key``
+    are empty.  Indexers check ``embed_fn`` first: when present, it replaces
+    all Voyage AI embedding calls.
 
     ``tuning`` provides configurable constants (chunk sizes, scoring weights,
     timeouts).  Defaults to the TuningConfig defaults when not supplied.
@@ -50,3 +55,7 @@ class IndexContext:
 
     # Optional tuning config; resolved lazily to avoid circular imports
     tuning: "TuningConfig | None" = field(default=None)
+
+    # Local mode embedding function: (texts: list[str]) -> list[list[float]]
+    # When set, replaces Voyage AI embedding in code_indexer and prose_indexer.
+    embed_fn: Callable[[list[str]], list[list[float]]] | None = field(default=None)

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -29,7 +29,7 @@ import structlog
 from nexus.corpus import index_model_for_collection
 from nexus.retry import _chroma_with_retry, _voyage_with_retry  # noqa: F401 — re-exported for any existing imports
 from nexus.errors import CredentialsMissingError  # re-exported for backward compatibility
-from nexus.indexer_utils import check_credentials, check_staleness
+from nexus.indexer_utils import check_credentials, check_local_path_writable, check_staleness
 
 # Re-exports from nexus.code_indexer for backward compatibility with tests that
 # import these names directly from nexus.indexer.
@@ -259,9 +259,13 @@ def _run_index_frecency_only(repo: Path, registry: "RepoRegistry") -> None:
     code_collection = info.get("code_collection", info["collection"])
     docs_collection = info.get("docs_collection") or _docs_collection_name(repo)
 
-    voyage_key = get_credential("voyage_api_key")
-    chroma_key = get_credential("chroma_api_key")
-    check_credentials(voyage_key, chroma_key)
+    from nexus.config import is_local_mode
+    if not is_local_mode():
+        voyage_key = get_credential("voyage_api_key")
+        chroma_key = get_credential("chroma_api_key")
+        check_credentials(voyage_key, chroma_key)
+    else:
+        check_local_path_writable()
 
     frecency_map = batch_frecency(repo)
     db = make_t3()
@@ -314,6 +318,8 @@ def _index_code_file(
     score: float,
     chunk_lines: int | None = None,
     force: bool = False,
+    *,
+    embed_fn: Callable | None = None,
 ) -> int:
     """Index a single code file.  Delegates to nexus.code_indexer.index_code_file.
 
@@ -336,6 +342,7 @@ def _index_code_file(
         score=score,
         chunk_lines=chunk_lines,
         force=force,
+        embed_fn=embed_fn,
     )
     return index_code_file(ctx, file)
 
@@ -353,6 +360,8 @@ def _index_prose_file(
     score: float,
     force: bool = False,
     timeout: float = 120.0,
+    *,
+    embed_fn: Callable | None = None,
 ) -> int:
     """Index a single prose file.  Delegates to nexus.prose_indexer.index_prose_file.
 
@@ -375,6 +384,7 @@ def _index_prose_file(
         score=score,
         force=force,
         timeout=timeout,
+        embed_fn=embed_fn,
     )
     return index_prose_file(ctx, file)
 
@@ -393,6 +403,8 @@ def _index_pdf_file(
     force: bool = False,
     timeout: float = 120.0,
     chunk_chars: int | None = None,
+    *,
+    embed_fn: Callable | None = None,
 ) -> int:
     """Index a single PDF file into the docs__ collection.
 
@@ -456,7 +468,11 @@ def _index_pdf_file(
         }
         metadatas.append(augmented)
 
-    embeddings, actual_model = _embed_with_fallback(embed_texts_pdf, target_model, voyage_key, timeout=timeout)
+    if embed_fn is not None:
+        embeddings = embed_fn(embed_texts_pdf)
+        actual_model = target_model
+    else:
+        embeddings, actual_model = _embed_with_fallback(embed_texts_pdf, target_model, voyage_key, timeout=timeout)
     if actual_model != target_model:
         for m in metadatas:
             m["embedding_model"] = actual_model
@@ -719,24 +735,44 @@ def _run_index(
     cache_path = Path.home() / ".config" / "nexus" / f"{_repo_basename}-{_repo_hash}.cache"
     build_cache(repo, cache_path, all_text_scored)
 
-    # Credential check (required for T3 operations)
-    voyage_key = get_credential("voyage_api_key")
-    chroma_key = get_credential("chroma_api_key")
-    check_credentials(voyage_key, chroma_key)
-
-    import voyageai
+    # Credential check and T3 setup
+    from nexus.config import is_local_mode as _is_local
     from datetime import UTC, datetime as _dt
     from nexus.db import make_t3
 
-    _log.debug("connecting to ChromaDB Cloud")
+    _local_mode = _is_local()
+    _embed_fn = None
+
+    if _local_mode:
+        check_local_path_writable()
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        _local_ef = LocalEmbeddingFunction()
+        _embed_fn = _local_ef  # callable: (texts) -> embeddings
+        local_model = _local_ef.model_name
+        code_model = local_model
+        docs_model = local_model
+        voyage_key = ""
+        voyage_client = None
+        # First-run tier notice
+        if _local_ef.model_name == "all-MiniLM-L6-v2":
+            _log.info(
+                "local_mode_tier0",
+                msg="Using basic embeddings (tier 0). For better code search quality: pip install conexus[local]",
+            )
+    else:
+        voyage_key = get_credential("voyage_api_key")
+        chroma_key = get_credential("chroma_api_key")
+        check_credentials(voyage_key, chroma_key)
+        import voyageai
+        code_model = index_model_for_collection(code_collection)
+        docs_model = index_model_for_collection(docs_collection)
+        voyage_client = voyageai.Client(api_key=voyage_key, timeout=read_timeout_seconds, max_retries=3)
+
+    _log.debug("connecting to ChromaDB")
     db = make_t3()
     _log.debug("ChromaDB connected")
     now_iso = _dt.now(UTC).isoformat()
 
-    # Initialize collections and models
-    code_model = index_model_for_collection(code_collection)
-    docs_model = index_model_for_collection(docs_collection)
-    voyage_client = voyageai.Client(api_key=voyage_key, timeout=read_timeout_seconds, max_retries=3)
     _log.debug("creating collections", code=code_collection, docs=docs_collection)
     code_col = db.get_or_create_collection(code_collection)
     docs_col = db.get_or_create_collection(docs_collection)
@@ -770,6 +806,7 @@ def _run_index(
             voyage_client, git_meta, now_iso, score,
             chunk_lines=effective_chunk_lines,
             force=force,
+            embed_fn=_embed_fn,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)
@@ -785,6 +822,7 @@ def _run_index(
             voyage_key, git_meta, now_iso, score,
             force=force,
             timeout=read_timeout_seconds,
+            embed_fn=_embed_fn,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)
@@ -800,6 +838,7 @@ def _run_index(
             force=force,
             timeout=read_timeout_seconds,
             chunk_chars=tuning.pdf_chunk_chars,
+            embed_fn=_embed_fn,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -74,6 +74,25 @@ def check_credentials(voyage_key: str, chroma_key: str) -> None:
         )
 
 
+def check_local_path_writable() -> None:
+    """Validate that the local ChromaDB path is writable.
+
+    Raises:
+        CredentialsMissingError: When the local path cannot be written to.
+    """
+    from nexus.config import _default_local_path
+    local_path = _default_local_path()
+    try:
+        local_path.mkdir(parents=True, exist_ok=True)
+        test_file = local_path / ".write_test"
+        test_file.touch()
+        test_file.unlink()
+    except OSError as exc:
+        raise CredentialsMissingError(
+            f"Local ChromaDB path {local_path} is not writable: {exc}"
+        ) from exc
+
+
 def build_context_prefix(
     filename: object,
     comment_char: str,

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -160,10 +160,14 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
         return 0
     ids, documents, metadatas, embed_texts = map(list, zip(*valid))
 
-    # Embed via _embed_with_fallback (CCE for voyage-context-3)
-    embeddings, actual_model = _embed_with_fallback(
-        embed_texts, ctx.embedding_model, ctx.voyage_key, timeout=ctx.timeout
-    )
+    # Embed: local mode uses embed_fn; cloud uses _embed_with_fallback (CCE)
+    if ctx.embed_fn is not None:
+        embeddings = ctx.embed_fn(embed_texts)
+        actual_model = ctx.embedding_model
+    else:
+        embeddings, actual_model = _embed_with_fallback(
+            embed_texts, ctx.embedding_model, ctx.voyage_key, timeout=ctx.timeout
+        )
     if actual_model != ctx.embedding_model:
         for m in metadatas:
             m["embedding_model"] = actual_model

--- a/src/nexus/retry.py
+++ b/src/nexus/retry.py
@@ -9,6 +9,8 @@ import time
 from collections.abc import Callable
 from typing import Any
 
+import sqlite3
+
 import httpx
 import structlog
 
@@ -25,21 +27,25 @@ _RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({429, 502, 503, 504})
 
 
 def _is_retryable_chroma_error(exc: BaseException) -> bool:
-    """Return True if *exc* represents a transient ChromaDB Cloud error worth retrying.
+    """Return True if *exc* represents a transient ChromaDB error worth retrying.
 
     Check order:
-    1. Transport-level errors (ConnectError, ReadTimeout, RemoteProtocolError) — always retry.
-    2. Chained httpx.HTTPStatusError — authoritative integer status code check.
-    3. String fallback — plain Exception message body (gateway HTML or chroma JSON).
+    1. sqlite3.OperationalError with 'locked' — PersistentClient concurrent access.
+    2. Transport-level errors (ConnectError, ReadTimeout, RemoteProtocolError) — always retry.
+    3. Chained httpx.HTTPStatusError — authoritative integer status code check.
+    4. String fallback — plain Exception message body (gateway HTML or chroma JSON).
     """
-    # 1. Transport-level errors — no HTTP response, but clearly transient.
+    # 1. PersistentClient concurrent write contention.
+    if isinstance(exc, sqlite3.OperationalError) and "locked" in str(exc).lower():
+        return True
+    # 2. Transport-level errors — no HTTP response, but clearly transient.
     if isinstance(exc, httpx.TransportError):
         return True
-    # 2. ChromaDB wraps HTTPStatusError as Exception(resp.text); original is __context__.
+    # 3. ChromaDB wraps HTTPStatusError as Exception(resp.text); original is __context__.
     ctx = exc.__context__
     if isinstance(ctx, httpx.HTTPStatusError):
         return ctx.response.status_code in _RETRYABLE_HTTP_STATUSES
-    # 3. Fallback: scan the message body for retryable status tokens.
+    # 4. Fallback: scan the message body for retryable status tokens.
     msg = str(exc).lower()
     return any(fragment in msg for fragment in _RETRYABLE_FRAGMENTS)
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -74,6 +74,7 @@ def test_run_index_raises_credentials_missing_without_credentials(
         "docs_collection": "docs__repo",
     }
 
+    monkeypatch.setenv("NX_LOCAL", "0")  # force cloud mode
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
 
@@ -124,6 +125,7 @@ def test_cache_path_includes_repo_hash(tmp_path: Path, monkeypatch) -> None:
         "docs_collection": "docs__myproject",
     }
 
+    monkeypatch.setenv("NX_LOCAL", "0")  # force cloud mode
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
 
@@ -158,6 +160,7 @@ def test_run_index_skips_hidden_files(tmp_path: Path, monkeypatch) -> None:
         "docs_collection": "docs__repo",
     }
 
+    monkeypatch.setenv("NX_LOCAL", "0")  # force cloud mode
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
 
@@ -412,6 +415,7 @@ def test_frecency_only_raises_credentials_missing(tmp_path: Path, monkeypatch) -
         "docs_collection": "docs__repo",
     }
 
+    monkeypatch.setenv("NX_LOCAL", "0")  # force cloud mode
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
 

--- a/tests/test_local_mode.py
+++ b/tests/test_local_mode.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for local T3 mode (RDR-038 Phase 1).
+
+Covers:
+- config.py: is_local_mode(), _default_local_path()
+- db/local_ef.py: LocalEmbeddingFunction tier auto-selection
+- db/t3.py: T3Database local_mode init path
+- db/__init__.py: make_t3() local path
+- retry.py: sqlite3.OperationalError retryable
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import chromadb
+import pytest
+
+from nexus.config import is_local_mode, _default_local_path
+from nexus.db.t3 import T3Database
+
+
+# ── config.py: is_local_mode ────────────────────────────────────────────────
+
+
+class TestIsLocalMode:
+    """is_local_mode() returns True when NX_LOCAL=1 or no cloud credentials."""
+
+    def test_nx_local_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NX_LOCAL=1 forces local mode regardless of credentials."""
+        monkeypatch.setenv("NX_LOCAL", "1")
+        monkeypatch.setenv("CHROMA_API_KEY", "some-key")
+        monkeypatch.setenv("VOYAGE_API_KEY", "some-key")
+        assert is_local_mode() is True
+
+    def test_nx_local_env_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NX_LOCAL=0 explicitly disables local mode."""
+        monkeypatch.setenv("NX_LOCAL", "0")
+        monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+        assert is_local_mode() is False
+
+    def test_no_cloud_credentials(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """No API keys and no NX_LOCAL → auto-detect as local mode."""
+        monkeypatch.delenv("NX_LOCAL", raising=False)
+        monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert is_local_mode() is True
+
+    def test_has_cloud_credentials(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Both API keys present and no NX_LOCAL → cloud mode."""
+        monkeypatch.delenv("NX_LOCAL", raising=False)
+        monkeypatch.setenv("CHROMA_API_KEY", "key1")
+        monkeypatch.setenv("VOYAGE_API_KEY", "key2")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert is_local_mode() is False
+
+    def test_partial_credentials_chroma_only(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Only CHROMA_API_KEY without VOYAGE_API_KEY → local mode."""
+        monkeypatch.delenv("NX_LOCAL", raising=False)
+        monkeypatch.setenv("CHROMA_API_KEY", "key1")
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert is_local_mode() is True
+
+    def test_partial_credentials_voyage_only(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Only VOYAGE_API_KEY without CHROMA_API_KEY → local mode."""
+        monkeypatch.delenv("NX_LOCAL", raising=False)
+        monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+        monkeypatch.setenv("VOYAGE_API_KEY", "key2")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert is_local_mode() is True
+
+
+class TestDefaultLocalPath:
+    """_default_local_path() returns the XDG-aware local ChromaDB path."""
+
+    def test_default_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without XDG_DATA_HOME, uses ~/.local/share/nexus/chroma."""
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setenv("HOME", "/home/testuser")
+        result = _default_local_path()
+        assert result == Path("/home/testuser/.local/share/nexus/chroma")
+
+    def test_xdg_data_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """XDG_DATA_HOME is respected."""
+        monkeypatch.setenv("XDG_DATA_HOME", "/custom/data")
+        result = _default_local_path()
+        assert result == Path("/custom/data/nexus/chroma")
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NX_LOCAL_CHROMA_PATH overrides the default."""
+        monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", "/my/chroma")
+        result = _default_local_path()
+        assert result == Path("/my/chroma")
+
+
+# ── db/local_ef.py: LocalEmbeddingFunction ──────────────────────────────────
+
+
+class TestLocalEmbeddingFunction:
+    """LocalEmbeddingFunction auto-selects tier 0 (ONNX MiniLM) or tier 1 (fastembed)."""
+
+    def test_tier0_no_fastembed(self) -> None:
+        """Without fastembed, falls back to tier 0 (bundled ONNX MiniLM)."""
+        with patch.dict("sys.modules", {"fastembed": None}):
+            from nexus.db.local_ef import LocalEmbeddingFunction
+            ef = LocalEmbeddingFunction()
+            assert ef.model_name == "all-MiniLM-L6-v2"
+            assert ef.dimensions == 384
+
+    def test_tier0_embeds_text(self) -> None:
+        """Tier 0 can embed text and returns correct dimensionality."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        result = ef(["hello world"])
+        assert len(result) == 1
+        assert len(result[0]) == 384
+
+    def test_tier0_multiple_texts(self) -> None:
+        """Tier 0 can embed multiple texts at once."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        result = ef(["hello", "world", "test"])
+        assert len(result) == 3
+        for vec in result:
+            assert len(vec) == 384
+
+    def test_explicit_model_override(self) -> None:
+        """Explicit model_name overrides auto-selection."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        assert ef.model_name == "all-MiniLM-L6-v2"
+        assert ef.dimensions == 384
+
+
+# ── db/t3.py: T3Database local_mode ─────────────────────────────────────────
+
+
+class TestT3DatabaseLocalMode:
+    """T3Database(local_mode=True) creates PersistentClient, skips cloud probe."""
+
+    def test_local_mode_creates_persistent_client(self, tmp_path: Path) -> None:
+        """local_mode=True uses PersistentClient instead of CloudClient."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        db = T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+        assert db._local_mode is True
+        assert isinstance(db._client, chromadb.ClientAPI)
+
+    def test_local_mode_no_voyage_client(self, tmp_path: Path) -> None:
+        """local_mode=True does not create a voyage client."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        db = T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+        assert db._voyage_client is None
+
+    def test_local_mode_no_cloud_probe(self, tmp_path: Path) -> None:
+        """local_mode=True skips the old-layout probe entirely."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        with patch("nexus.db.t3.chromadb.CloudClient") as mock_cloud:
+            T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+            mock_cloud.assert_not_called()
+
+    def test_local_mode_put_and_search(self, tmp_path: Path) -> None:
+        """End-to-end: put a document and search for it in local mode."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        db = T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+        doc_id = db.put(
+            collection="knowledge__test",
+            content="Python is a programming language",
+            title="python-fact",
+        )
+        assert doc_id
+        results = db.search("programming language", collection_names=["knowledge__test"])
+        assert len(results) >= 1
+        assert any("Python" in r.get("content", "") for r in results)
+
+    def test_local_mode_search_skips_cce(self, tmp_path: Path) -> None:
+        """Local mode search does not attempt CCE embedding."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        db = T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+        # voyage_api_key is empty, so CCE path should not trigger
+        assert db._voyage_client is None
+        # Put and search should work without CCE
+        db.put(collection="knowledge__test", content="test content", title="t1")
+        results = db.search("test", collection_names=["knowledge__test"])
+        assert isinstance(results, list)
+
+    def test_local_mode_skips_max_query_results_clamping(self, tmp_path: Path) -> None:
+        """Local mode does not clamp n_results to QUOTAS.MAX_QUERY_RESULTS."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        db = T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+        # Insert enough docs to test
+        for i in range(5):
+            db.put(collection="knowledge__test", content=f"document {i}", title=f"doc-{i}")
+        # Request more than MAX_QUERY_RESULTS — should not clamp
+        results = db.search("document", collection_names=["knowledge__test"], n_results=500)
+        assert isinstance(results, list)
+
+    def test_cloud_mode_still_works(self) -> None:
+        """Existing cloud mode init path is unaffected."""
+        from nexus.db.t3 import T3Database
+        mock_client = MagicMock()
+        db = T3Database(_client=mock_client, _ef_override=MagicMock())
+        assert db._local_mode is False
+
+    def test_local_mode_creates_path(self, tmp_path: Path) -> None:
+        """local_mode creates the local_path directory if it doesn't exist."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        chroma_dir = tmp_path / "nonexistent" / "chroma"
+        T3Database(local_mode=True, local_path=str(chroma_dir), _ef_override=ef)
+        assert chroma_dir.exists()
+
+
+# ── db/__init__.py: make_t3 local path ──────────────────────────────────────
+
+
+class TestMakeT3Local:
+    """make_t3() returns a local T3Database when is_local_mode() is True."""
+
+    def test_make_t3_local_mode(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """make_t3() in local mode returns T3Database with _local_mode=True."""
+        monkeypatch.setenv("NX_LOCAL", "1")
+        monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", str(tmp_path / "chroma"))
+        monkeypatch.setenv("HOME", str(tmp_path))
+        from nexus.db import make_t3
+        db = make_t3()
+        assert db._local_mode is True
+
+    def test_make_t3_cloud_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """make_t3() in cloud mode returns T3Database with _local_mode=False."""
+        monkeypatch.setenv("NX_LOCAL", "0")
+        from nexus.db import make_t3
+        mock_client = MagicMock()
+        db = make_t3(_client=mock_client, _ef_override=MagicMock())
+        assert db._local_mode is False
+
+
+# ── retry.py: sqlite3 OperationalError ──────────────────────────────────────
+
+
+class TestRetryableSqliteError:
+    """sqlite3.OperationalError('database is locked') is retryable."""
+
+    def test_sqlite_locked_is_retryable(self) -> None:
+        """sqlite3.OperationalError with 'locked' message is retryable."""
+        from nexus.retry import _is_retryable_chroma_error
+        exc = sqlite3.OperationalError("database is locked")
+        assert _is_retryable_chroma_error(exc) is True
+
+    def test_sqlite_other_error_not_retryable(self) -> None:
+        """sqlite3.OperationalError without 'locked' is not retryable."""
+        from nexus.retry import _is_retryable_chroma_error
+        exc = sqlite3.OperationalError("no such table: foo")
+        assert _is_retryable_chroma_error(exc) is False
+
+    def test_chroma_with_retry_retries_locked(self) -> None:
+        """_chroma_with_retry retries on sqlite3 'database is locked'."""
+        from nexus.retry import _chroma_with_retry
+        call_count = 0
+
+        def flaky_fn():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return "success"
+
+        with patch("nexus.retry.time.sleep"):
+            result = _chroma_with_retry(flaky_fn)
+        assert result == "success"
+        assert call_count == 3

--- a/tests/test_local_mode.py
+++ b/tests/test_local_mode.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Tests for local T3 mode (RDR-038 Phase 1).
+"""Tests for local T3 mode (RDR-038).
 
 Covers:
 - config.py: is_local_mode(), _default_local_path()
@@ -7,6 +7,10 @@ Covers:
 - db/t3.py: T3Database local_mode init path
 - db/__init__.py: make_t3() local path
 - retry.py: sqlite3.OperationalError retryable
+- Staleness round-trip in local mode
+- Local mode collection lifecycle (put, search, expire, list)
+- Indexer pipeline credential gating in local mode
+- corpus.py model name consistency in local mode
 """
 from __future__ import annotations
 
@@ -278,3 +282,237 @@ class TestRetryableSqliteError:
             result = _chroma_with_retry(flaky_fn)
         assert result == "success"
         assert call_count == 3
+
+
+# ── Staleness round-trip ─────────────────────────────────────────────────────
+
+
+class TestLocalStaleness:
+    """Staleness detection works correctly in local mode."""
+
+    def test_staleness_skips_current_content(self, tmp_path: Path) -> None:
+        """Index, re-check → staleness returns True (skip)."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        from nexus.indexer_utils import check_staleness
+
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        db = T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+        col = db.get_or_create_collection("code__test")
+
+        # Simulate indexed chunk
+        db.upsert_chunks(
+            "code__test",
+            ids=["chunk1"],
+            documents=["def hello(): pass"],
+            metadatas=[{
+                "source_path": "/repo/hello.py",
+                "content_hash": "abc123",
+                "embedding_model": "all-MiniLM-L6-v2",
+            }],
+        )
+        # Same hash + model → stale (skip)
+        assert check_staleness(col, "/repo/hello.py", "abc123", "all-MiniLM-L6-v2") is True
+
+    def test_staleness_detects_changed_content(self, tmp_path: Path) -> None:
+        """Changed content hash → not stale (re-index)."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        from nexus.indexer_utils import check_staleness
+
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        db = T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+        col = db.get_or_create_collection("code__test")
+
+        db.upsert_chunks(
+            "code__test",
+            ids=["chunk1"],
+            documents=["def hello(): pass"],
+            metadatas=[{
+                "source_path": "/repo/hello.py",
+                "content_hash": "abc123",
+                "embedding_model": "all-MiniLM-L6-v2",
+            }],
+        )
+        # Different hash → not stale (re-index)
+        assert check_staleness(col, "/repo/hello.py", "def456", "all-MiniLM-L6-v2") is False
+
+    def test_staleness_detects_model_change(self, tmp_path: Path) -> None:
+        """Different embedding model → not stale (re-index)."""
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        from nexus.indexer_utils import check_staleness
+
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        db = T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+        col = db.get_or_create_collection("code__test")
+
+        db.upsert_chunks(
+            "code__test",
+            ids=["chunk1"],
+            documents=["def hello(): pass"],
+            metadatas=[{
+                "source_path": "/repo/hello.py",
+                "content_hash": "abc123",
+                "embedding_model": "voyage-code-3",
+            }],
+        )
+        # Same hash but different model → not stale (re-index after mode switch)
+        assert check_staleness(col, "/repo/hello.py", "abc123", "all-MiniLM-L6-v2") is False
+
+
+# ── Collection lifecycle ─────────────────────────────────────────────────────
+
+
+class TestLocalCollectionLifecycle:
+    """Full collection lifecycle in local mode: create, put, search, expire, list, delete."""
+
+    def test_collection_lifecycle(self, tmp_path: Path) -> None:
+        """Exercise the full CRUD cycle on a local T3 database."""
+        from datetime import UTC, datetime, timedelta
+        from nexus.db.local_ef import LocalEmbeddingFunction
+
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        db = T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+
+        # Put
+        doc_id = db.put(
+            collection="knowledge__lifecycle",
+            content="Rust is a systems programming language",
+            title="rust-fact",
+            tags="rust,systems",
+        )
+        assert doc_id
+
+        # Search
+        results = db.search("systems programming", collection_names=["knowledge__lifecycle"])
+        assert len(results) >= 1
+        assert any("Rust" in r.get("content", "") for r in results)
+
+        # List collections
+        collections = db.list_collections()
+        names = [c["name"] for c in collections]
+        assert "knowledge__lifecycle" in names
+
+        # List store
+        entries = db.list_store("knowledge__lifecycle")
+        assert len(entries) >= 1
+
+        # Delete
+        deleted = db.delete_by_id("knowledge__lifecycle", doc_id)
+        assert deleted is True
+
+    def test_expire_ttl_entries(self, tmp_path: Path) -> None:
+        """Expired TTL entries are removed by expire()."""
+        from datetime import UTC, datetime, timedelta
+        from nexus.db.local_ef import LocalEmbeddingFunction
+
+        ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+        db = T3Database(local_mode=True, local_path=str(tmp_path / "chroma"), _ef_override=ef)
+
+        # Insert entry with expired TTL (past expires_at)
+        past = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+        db.put(
+            collection="knowledge__expire_test",
+            content="temporary data",
+            title="temp",
+            ttl_days=1,
+            expires_at=past,
+        )
+
+        # Insert permanent entry
+        db.put(
+            collection="knowledge__expire_test",
+            content="permanent data",
+            title="perm",
+            ttl_days=0,
+        )
+
+        deleted = db.expire()
+        assert deleted >= 1
+
+        # Permanent entry should survive
+        results = db.search("permanent", collection_names=["knowledge__expire_test"])
+        assert len(results) >= 1
+
+
+# ── Corpus model consistency ─────────────────────────────────────────────────
+
+
+class TestCorpusLocalModels:
+    """corpus.py returns local model names in local mode."""
+
+    def test_index_model_returns_local_name(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """index_model_for_collection returns local model in local mode."""
+        monkeypatch.setenv("NX_LOCAL", "1")
+        monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", str(tmp_path))
+        from nexus.corpus import index_model_for_collection
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        expected = LocalEmbeddingFunction().model_name
+        assert index_model_for_collection("code__test") == expected
+        assert index_model_for_collection("docs__test") == expected
+        assert index_model_for_collection("knowledge__test") == expected
+
+    def test_embedding_model_returns_local_name(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """embedding_model_for_collection returns local model in local mode."""
+        monkeypatch.setenv("NX_LOCAL", "1")
+        monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", str(tmp_path))
+        from nexus.corpus import embedding_model_for_collection
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        expected = LocalEmbeddingFunction().model_name
+        assert embedding_model_for_collection("code__test") == expected
+        assert embedding_model_for_collection("docs__test") == expected
+
+    def test_cloud_model_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Cloud mode model names are unchanged."""
+        monkeypatch.setenv("NX_LOCAL", "0")
+        from nexus.corpus import index_model_for_collection, embedding_model_for_collection
+        assert index_model_for_collection("code__test") == "voyage-code-3"
+        assert index_model_for_collection("docs__test") == "voyage-context-3"
+        assert embedding_model_for_collection("code__test") == "voyage-4"
+        assert embedding_model_for_collection("docs__test") == "voyage-context-3"
+
+
+# ── Frecency-only local mode ────────────────────────────────────────────────
+
+
+class TestFrecencyOnlyLocalMode:
+    """_run_index_frecency_only does not crash in local mode (B-2 coverage)."""
+
+    def test_frecency_only_no_crash_local_mode(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Frecency-only update works in local mode without cloud credentials."""
+        monkeypatch.setenv("NX_LOCAL", "1")
+        monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", str(tmp_path / "chroma"))
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+        monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+
+        from nexus.indexer import _run_index_frecency_only
+
+        registry = MagicMock()
+        registry.get.return_value = {
+            "collection": "code__repo",
+            "code_collection": "code__repo",
+            "docs_collection": "docs__repo",
+        }
+
+        # Should not raise CredentialsMissingError
+        with patch("nexus.frecency.batch_frecency", return_value={}):
+            _run_index_frecency_only(tmp_path, registry)
+
+
+# ── Check local path writable ───────────────────────────────────────────────
+
+
+class TestCheckLocalPathWritable:
+    """check_local_path_writable validates the local ChromaDB path."""
+
+    def test_writable_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Writable path does not raise."""
+        monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", str(tmp_path / "chroma"))
+        from nexus.indexer_utils import check_local_path_writable
+        check_local_path_writable()  # should not raise
+
+    def test_unwritable_path_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unwritable path raises CredentialsMissingError."""
+        monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", "/proc/nonexistent/chroma")
+        from nexus.indexer_utils import check_local_path_writable
+        from nexus.errors import CredentialsMissingError
+        with pytest.raises(CredentialsMissingError, match="not writable"):
+            check_local_path_writable()

--- a/tests/test_local_mode.py
+++ b/tests/test_local_mode.py
@@ -437,32 +437,21 @@ class TestLocalCollectionLifecycle:
 
 
 class TestCorpusLocalModels:
-    """corpus.py returns local model names in local mode."""
+    """In local mode, indexer uses LocalEmbeddingFunction model name directly.
 
-    def test_index_model_returns_local_name(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """index_model_for_collection returns local model in local mode."""
-        monkeypatch.setenv("NX_LOCAL", "1")
-        monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", str(tmp_path))
-        from nexus.corpus import index_model_for_collection
+    corpus.py model functions always return cloud model names (pure functions).
+    Local mode callers bypass corpus.py and use LocalEmbeddingFunction().model_name.
+    """
+
+    def test_local_ef_model_name_consistent(self) -> None:
+        """LocalEmbeddingFunction model name is stable and non-empty."""
         from nexus.db.local_ef import LocalEmbeddingFunction
-        expected = LocalEmbeddingFunction().model_name
-        assert index_model_for_collection("code__test") == expected
-        assert index_model_for_collection("docs__test") == expected
-        assert index_model_for_collection("knowledge__test") == expected
+        ef = LocalEmbeddingFunction()
+        assert ef.model_name
+        assert isinstance(ef.model_name, str)
 
-    def test_embedding_model_returns_local_name(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """embedding_model_for_collection returns local model in local mode."""
-        monkeypatch.setenv("NX_LOCAL", "1")
-        monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", str(tmp_path))
-        from nexus.corpus import embedding_model_for_collection
-        from nexus.db.local_ef import LocalEmbeddingFunction
-        expected = LocalEmbeddingFunction().model_name
-        assert embedding_model_for_collection("code__test") == expected
-        assert embedding_model_for_collection("docs__test") == expected
-
-    def test_cloud_model_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Cloud mode model names are unchanged."""
-        monkeypatch.setenv("NX_LOCAL", "0")
+    def test_corpus_functions_always_return_cloud_names(self) -> None:
+        """corpus.py model functions are pure — always return cloud model names."""
         from nexus.corpus import index_model_for_collection, embedding_model_for_collection
         assert index_model_for_collection("code__test") == "voyage-code-3"
         assert index_model_for_collection("docs__test") == "voyage-context-3"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -156,9 +156,10 @@ def test_promote_cmd_no_credentials_raises(runner: CliRunner, mem_home: Path, db
 
     with patch("nexus.commands.memory.T2Database", return_value=db):
         with patch("nexus.commands.memory.get_credential", return_value=""):
-            result = runner.invoke(
-                main, ["memory", "promote", str(row_id), "--collection", "knowledge__p"]
-            )
+            with patch("nexus.config.is_local_mode", return_value=False):
+                result = runner.invoke(
+                    main, ["memory", "promote", str(row_id), "--collection", "knowledge__p"]
+                )
 
     assert result.exit_code != 0
     assert "not set" in result.output.lower() or "config init" in result.output.lower()
@@ -261,9 +262,10 @@ def test_promote_cmd_missing_database_raises(runner: CliRunner, mem_home: Path, 
 
     with patch("nexus.commands.memory.T2Database", return_value=db):
         with patch("nexus.commands.memory.get_credential", side_effect=cred_side_effect):
-            result = runner.invoke(
-                main, ["memory", "promote", str(row_id), "--collection", "knowledge__p"]
-            )
+            with patch("nexus.config.is_local_mode", return_value=False):
+                result = runner.invoke(
+                    main, ["memory", "promote", str(row_id), "--collection", "knowledge__p"]
+                )
 
     assert result.exit_code != 0
     assert "chroma_database" in result.output

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -187,7 +187,8 @@ def test_promote_cmd_calls_t3_put(runner: CliRunner, mem_home: Path, db: T2Datab
 
     with patch("nexus.commands.memory.T2Database", return_value=db):
         with patch("nexus.commands.memory.get_credential", return_value="fake-key"):
-            with patch("nexus.commands.memory.T3Database", return_value=mock_t3):
+            with patch("nexus.config.is_local_mode", return_value=False):
+              with patch("nexus.db.make_t3", return_value=mock_t3):
                 result = runner.invoke(
                     main,
                     ["memory", "promote", str(row_id), "--collection", "knowledge__proj"],
@@ -214,7 +215,8 @@ def test_promote_cmd_permanent_entry_ttl_is_zero(runner: CliRunner, mem_home: Pa
 
     with patch("nexus.commands.memory.T2Database", return_value=db):
         with patch("nexus.commands.memory.get_credential", return_value="fake-key"):
-            with patch("nexus.commands.memory.T3Database", return_value=mock_t3):
+            with patch("nexus.config.is_local_mode", return_value=False):
+              with patch("nexus.db.make_t3", return_value=mock_t3):
                 runner.invoke(
                     main,
                     ["memory", "promote", str(row_id), "--collection", "knowledge__proj"],
@@ -236,7 +238,8 @@ def test_promote_cmd_remove_deletes_t2_entry(runner: CliRunner, mem_home: Path, 
     _t2_cm = MagicMock(__enter__=MagicMock(return_value=db))
     with patch("nexus.commands.memory.T2Database", return_value=_t2_cm):
         with patch("nexus.commands.memory.get_credential", return_value="fake-key"):
-            with patch("nexus.commands.memory.T3Database", return_value=mock_t3):
+            with patch("nexus.config.is_local_mode", return_value=False):
+              with patch("nexus.db.make_t3", return_value=mock_t3):
                 result = runner.invoke(
                     main,
                     ["memory", "promote", str(row_id), "--collection", "knowledge__proj", "--remove"],
@@ -289,7 +292,8 @@ def test_promote_cmd_expires_at_derived_from_t2_timestamp(
 
     with patch("nexus.commands.memory.T2Database", return_value=db):
         with patch("nexus.commands.memory.get_credential", return_value="fake-key"):
-            with patch("nexus.commands.memory.T3Database", return_value=mock_t3):
+            with patch("nexus.config.is_local_mode", return_value=False):
+              with patch("nexus.db.make_t3", return_value=mock_t3):
                 result = runner.invoke(
                     main,
                     ["memory", "promote", str(row_id), "--collection", "knowledge__proj"],
@@ -322,7 +326,8 @@ def test_promote_cmd_permanent_expires_at_is_empty(
 
     with patch("nexus.commands.memory.T2Database", return_value=db):
         with patch("nexus.commands.memory.get_credential", return_value="fake-key"):
-            with patch("nexus.commands.memory.T3Database", return_value=mock_t3):
+            with patch("nexus.config.is_local_mode", return_value=False):
+              with patch("nexus.db.make_t3", return_value=mock_t3):
                 runner.invoke(
                     main,
                     ["memory", "promote", str(row_id), "--collection", "knowledge__proj"],

--- a/tests/test_store_cmd.py
+++ b/tests/test_store_cmd.py
@@ -28,6 +28,7 @@ def env_creds(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_store_put_missing_chroma_api_key(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
+    monkeypatch.setenv("NX_LOCAL", "0")  # force cloud mode
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
     monkeypatch.setenv("VOYAGE_API_KEY", "vk")
     monkeypatch.setenv("CHROMA_TENANT", "t")

--- a/tests/test_store_cmd.py
+++ b/tests/test_store_cmd.py
@@ -44,6 +44,7 @@ def test_store_put_missing_chroma_api_key(
 def test_store_put_missing_voyage_api_key(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
+    monkeypatch.setenv("NX_LOCAL", "0")  # force cloud mode
     monkeypatch.setenv("CHROMA_API_KEY", "ck")
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.setenv("CHROMA_TENANT", "t")

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -578,8 +578,9 @@ def test_make_t3_uses_credentials(mock_chromadb: tuple) -> None:
         "chroma_api_key": "ck-abc",
         "voyage_api_key": "vk-xyz",
     }
-    with patch("nexus.db.get_credential", side_effect=lambda k: creds.get(k, "")):
-        db = make_t3()
+    with patch("nexus.config.is_local_mode", return_value=False):
+        with patch("nexus.db.get_credential", side_effect=lambda k: creds.get(k, "")):
+            db = make_t3()
 
     assert mock_chromadb[0].CloudClient.call_count == 2  # probe + connect
     connect_call = mock_chromadb[0].CloudClient.call_args_list[1]

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version < '3.13'",
 ]
 
@@ -507,6 +508,11 @@ dependencies = [
     { name = "voyageai" },
 ]
 
+[package.optional-dependencies]
+local = [
+    { name = "fastembed" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -521,6 +527,7 @@ requires-dist = [
     { name = "chromadb", specifier = ">=0.6" },
     { name = "click", specifier = ">=8.1" },
     { name = "docling", specifier = ">=2.76.0" },
+    { name = "fastembed", marker = "extra == 'local'", specifier = ">=0.7.0" },
     { name = "llama-index-core", specifier = "==0.12.7" },
     { name = "markdown-it-py", specifier = ">=4.0.0" },
     { name = "mcp", specifier = ">=1.0" },
@@ -533,6 +540,7 @@ requires-dist = [
     { name = "tree-sitter-language-pack", specifier = "==0.7.1" },
     { name = "voyageai", specifier = ">=0.2" },
 ]
+provides-extras = ["local"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -925,6 +933,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/03/14428edc541467c460d363f6e94bee9acc271f3e62470630fc9a647d0cf2/faker-40.8.0.tar.gz", hash = "sha256:936a3c9be6c004433f20aa4d99095df5dec82b8c7ad07459756041f8c1728875", size = 1956493, upload-time = "2026-03-04T16:18:48.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/3b/c6348f1e285e75b069085b18110a4e6325b763a5d35d5e204356fc7c20b3/faker-40.8.0-py3-none-any.whl", hash = "sha256:eb21bdba18f7a8375382eb94fb436fce07046893dc94cb20817d28deb0c3d579", size = 1989124, upload-time = "2026-03-04T16:18:46.45Z" },
+]
+
+[[package]]
+name = "fastembed"
+version = "0.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "loguru" },
+    { name = "mmh3" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "pillow" },
+    { name = "py-rust-stemmers" },
+    { name = "requests" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/c2/9c708680de1b54480161e0505f9d6d3d8eb47a1dc1a1f7f3c5106ba355d2/fastembed-0.7.4.tar.gz", hash = "sha256:8b8a4ea860ca295002f4754e8f5820a636e1065a9444959e18d5988d7f27093b", size = 68807, upload-time = "2025-12-05T12:08:10.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/3b/8da01492bc8b69184257d0c951bf0e77aec8ce110f06d8ce16c6ed9084f7/fastembed-0.7.4-py3-none-any.whl", hash = "sha256:79250a775f70bd6addb0e054204df042b5029ecae501e40e5bbd08e75844ad83", size = 108491, upload-time = "2025-12-05T12:08:09.059Z" },
 ]
 
 [[package]]
@@ -1602,6 +1631,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/15/e08478d4eb53fec69a166aec06cfdbc6cd12c7285afc08ee2857dabf7761/llama_index_core-0.12.7.tar.gz", hash = "sha256:9935b249c08f87c124962a8ea1e301e1b5bfa7e3ffd6771b6cb59a0de9bb8cb5", size = 1333863, upload-time = "2024-12-19T03:39:56.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/25/23ac92fd924ccce6be55de629595a9f904e9944645035b2e87e80624bf75/llama_index_core-0.12.7-py3-none-any.whl", hash = "sha256:691493915598c09b636f964e85b8baca630faa362a4a8ea130ddea8584ab8d0a", size = 1584653, upload-time = "2024-12-19T03:39:52.599Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -2663,71 +2705,68 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.1.1"
+version = "11.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4", size = 46980264, upload-time = "2026-02-11T04:23:07.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069, upload-time = "2025-07-01T09:16:30.666Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/d3/8df65da0d4df36b094351dce696f2989bec731d4f10e743b1c5f4da4d3bf/pillow-12.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ab323b787d6e18b3d91a72fc99b1a2c28651e4358749842b8f8dfacd28ef2052", size = 5262803, upload-time = "2026-02-11T04:20:47.653Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/71/5026395b290ff404b836e636f51d7297e6c83beceaa87c592718747e670f/pillow-12.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:adebb5bee0f0af4909c30db0d890c773d1a92ffe83da908e2e9e720f8edf3984", size = 4657601, upload-time = "2026-02-11T04:20:49.328Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/2e/1001613d941c67442f745aff0f7cc66dd8df9a9c084eb497e6a543ee6f7e/pillow-12.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bb66b7cc26f50977108790e2456b7921e773f23db5630261102233eb355a3b79", size = 6234995, upload-time = "2026-02-11T04:20:51.032Z" },
-    { url = "https://files.pythonhosted.org/packages/07/26/246ab11455b2549b9233dbd44d358d033a2f780fa9007b61a913c5b2d24e/pillow-12.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aee2810642b2898bb187ced9b349e95d2a7272930796e022efaf12e99dccd293", size = 8045012, upload-time = "2026-02-11T04:20:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/8b/07587069c27be7535ac1fe33874e32de118fbd34e2a73b7f83436a88368c/pillow-12.1.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0b1cd6232e2b618adcc54d9882e4e662a089d5768cd188f7c245b4c8c44a397", size = 6349638, upload-time = "2026-02-11T04:20:54.444Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/79/6df7b2ee763d619cda2fb4fea498e5f79d984dae304d45a8999b80d6cf5c/pillow-12.1.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7aac39bcf8d4770d089588a2e1dd111cbaa42df5a94be3114222057d68336bd0", size = 7041540, upload-time = "2026-02-11T04:20:55.97Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/5e/2ba19e7e7236d7529f4d873bdaf317a318896bac289abebd4bb00ef247f0/pillow-12.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ab174cd7d29a62dd139c44bf74b698039328f45cb03b4596c43473a46656b2f3", size = 6462613, upload-time = "2026-02-11T04:20:57.542Z" },
-    { url = "https://files.pythonhosted.org/packages/03/03/31216ec124bb5c3dacd74ce8efff4cc7f52643653bad4825f8f08c697743/pillow-12.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:339ffdcb7cbeaa08221cd401d517d4b1fe7a9ed5d400e4a8039719238620ca35", size = 7166745, upload-time = "2026-02-11T04:20:59.196Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e7/7c4552d80052337eb28653b617eafdef39adfb137c49dd7e831b8dc13bc5/pillow-12.1.1-cp312-cp312-win32.whl", hash = "sha256:5d1f9575a12bed9e9eedd9a4972834b08c97a352bd17955ccdebfeca5913fa0a", size = 6328823, upload-time = "2026-02-11T04:21:01.385Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/17/688626d192d7261bbbf98846fc98995726bddc2c945344b65bec3a29d731/pillow-12.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:21329ec8c96c6e979cd0dfd29406c40c1d52521a90544463057d2aaa937d66a6", size = 7033367, upload-time = "2026-02-11T04:21:03.536Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/fe/a0ef1f73f939b0eca03ee2c108d0043a87468664770612602c63266a43c4/pillow-12.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:af9a332e572978f0218686636610555ae3defd1633597be015ed50289a03c523", size = 2453811, upload-time = "2026-02-11T04:21:05.116Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/11/6db24d4bd7685583caeae54b7009584e38da3c3d4488ed4cd25b439de486/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e", size = 4062689, upload-time = "2026-02-11T04:21:06.804Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c0/ce6d3b1fe190f0021203e0d9b5b99e57843e345f15f9ef22fcd43842fd21/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9", size = 4138535, upload-time = "2026-02-11T04:21:08.452Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c6/d5eb6a4fb32a3f9c21a8c7613ec706534ea1cf9f4b3663e99f0d83f6fca8/pillow-12.1.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6", size = 3601364, upload-time = "2026-02-11T04:21:10.194Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a1/16c4b823838ba4c9c52c0e6bbda903a3fe5a1bdbf1b8eb4fff7156f3e318/pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60", size = 5262561, upload-time = "2026-02-11T04:21:11.742Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ad/ad9dc98ff24f485008aa5cdedaf1a219876f6f6c42a4626c08bc4e80b120/pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2", size = 4657460, upload-time = "2026-02-11T04:21:13.786Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1b/f1a4ea9a895b5732152789326202a82464d5254759fbacae4deea3069334/pillow-12.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850", size = 6232698, upload-time = "2026-02-11T04:21:15.949Z" },
-    { url = "https://files.pythonhosted.org/packages/95/f4/86f51b8745070daf21fd2e5b1fe0eb35d4db9ca26e6d58366562fb56a743/pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289", size = 8041706, upload-time = "2026-02-11T04:21:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/29/9b/d6ecd956bb1266dd1045e995cce9b8d77759e740953a1c9aad9502a0461e/pillow-12.1.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e", size = 6346621, upload-time = "2026-02-11T04:21:19.547Z" },
-    { url = "https://files.pythonhosted.org/packages/71/24/538bff45bde96535d7d998c6fed1a751c75ac7c53c37c90dc2601b243893/pillow-12.1.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717", size = 7038069, upload-time = "2026-02-11T04:21:21.378Z" },
-    { url = "https://files.pythonhosted.org/packages/94/0e/58cb1a6bc48f746bc4cb3adb8cabff73e2742c92b3bf7a220b7cf69b9177/pillow-12.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a", size = 6460040, upload-time = "2026-02-11T04:21:23.148Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/57/9045cb3ff11eeb6c1adce3b2d60d7d299d7b273a2e6c8381a524abfdc474/pillow-12.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029", size = 7164523, upload-time = "2026-02-11T04:21:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/73/f2/9be9cb99f2175f0d4dbadd6616ce1bf068ee54a28277ea1bf1fbf729c250/pillow-12.1.1-cp313-cp313-win32.whl", hash = "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b", size = 6332552, upload-time = "2026-02-11T04:21:27.238Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/eb/b0834ad8b583d7d9d42b80becff092082a1c3c156bb582590fcc973f1c7c/pillow-12.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1", size = 7040108, upload-time = "2026-02-11T04:21:29.462Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7d/fc09634e2aabdd0feabaff4a32f4a7d97789223e7c2042fd805ea4b4d2c2/pillow-12.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a", size = 2453712, upload-time = "2026-02-11T04:21:31.072Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/b9d62794fc8a0dd14c1943df68347badbd5511103e0d04c035ffe5cf2255/pillow-12.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da", size = 5264880, upload-time = "2026-02-11T04:21:32.865Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9d/e03d857d1347fa5ed9247e123fcd2a97b6220e15e9cb73ca0a8d91702c6e/pillow-12.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc", size = 4660616, upload-time = "2026-02-11T04:21:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ec/8a6d22afd02570d30954e043f09c32772bfe143ba9285e2fdb11284952cd/pillow-12.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c", size = 6269008, upload-time = "2026-02-11T04:21:36.623Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/1d/6d875422c9f28a4a361f495a5f68d9de4a66941dc2c619103ca335fa6446/pillow-12.1.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8", size = 8073226, upload-time = "2026-02-11T04:21:38.585Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/cd/134b0b6ee5eda6dc09e25e24b40fdafe11a520bc725c1d0bbaa5e00bf95b/pillow-12.1.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20", size = 6380136, upload-time = "2026-02-11T04:21:40.562Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a9/7628f013f18f001c1b98d8fffe3452f306a70dc6aba7d931019e0492f45e/pillow-12.1.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13", size = 7067129, upload-time = "2026-02-11T04:21:42.521Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f8/66ab30a2193b277785601e82ee2d49f68ea575d9637e5e234faaa98efa4c/pillow-12.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf", size = 6491807, upload-time = "2026-02-11T04:21:44.22Z" },
-    { url = "https://files.pythonhosted.org/packages/da/0b/a877a6627dc8318fdb84e357c5e1a758c0941ab1ddffdafd231983788579/pillow-12.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524", size = 7190954, upload-time = "2026-02-11T04:21:46.114Z" },
-    { url = "https://files.pythonhosted.org/packages/83/43/6f732ff85743cf746b1361b91665d9f5155e1483817f693f8d57ea93147f/pillow-12.1.1-cp313-cp313t-win32.whl", hash = "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986", size = 6336441, upload-time = "2026-02-11T04:21:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/44/e865ef3986611bb75bfabdf94a590016ea327833f434558801122979cd0e/pillow-12.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c", size = 7045383, upload-time = "2026-02-11T04:21:50.015Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/c6/f4fb24268d0c6908b9f04143697ea18b0379490cb74ba9e8d41b898bd005/pillow-12.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3", size = 2456104, upload-time = "2026-02-11T04:21:51.633Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d0/bebb3ffbf31c5a8e97241476c4cf8b9828954693ce6744b4a2326af3e16b/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:417423db963cb4be8bac3fc1204fe61610f6abeed1580a7a2cbb2fbda20f12af", size = 4062652, upload-time = "2026-02-11T04:21:53.19Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c0/0e16fb0addda4851445c28f8350d8c512f09de27bbb0d6d0bbf8b6709605/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:b957b71c6b2387610f556a7eb0828afbe40b4a98036fc0d2acfa5a44a0c2036f", size = 4138823, upload-time = "2026-02-11T04:22:03.088Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/fb/6170ec655d6f6bb6630a013dd7cf7bc218423d7b5fa9071bf63dc32175ae/pillow-12.1.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:097690ba1f2efdeb165a20469d59d8bb03c55fb6621eb2041a060ae8ea3e9642", size = 3601143, upload-time = "2026-02-11T04:22:04.909Z" },
-    { url = "https://files.pythonhosted.org/packages/59/04/dc5c3f297510ba9a6837cbb318b87dd2b8f73eb41a43cc63767f65cb599c/pillow-12.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2815a87ab27848db0321fb78c7f0b2c8649dee134b7f2b80c6a45c6831d75ccd", size = 5266254, upload-time = "2026-02-11T04:22:07.656Z" },
-    { url = "https://files.pythonhosted.org/packages/05/30/5db1236b0d6313f03ebf97f5e17cda9ca060f524b2fcc875149a8360b21c/pillow-12.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f7ed2c6543bad5a7d5530eb9e78c53132f93dfa44a28492db88b41cdab885202", size = 4657499, upload-time = "2026-02-11T04:22:09.613Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/008d2ca0eb612e81968e8be0bbae5051efba24d52debf930126d7eaacbba/pillow-12.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:652a2c9ccfb556235b2b501a3a7cf3742148cd22e04b5625c5fe057ea3e3191f", size = 6232137, upload-time = "2026-02-11T04:22:11.434Z" },
-    { url = "https://files.pythonhosted.org/packages/70/f1/f14d5b8eeb4b2cd62b9f9f847eb6605f103df89ef619ac68f92f748614ea/pillow-12.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6e4571eedf43af33d0fc233a382a76e849badbccdf1ac438841308652a08e1f", size = 8042721, upload-time = "2026-02-11T04:22:13.321Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/d6/17824509146e4babbdabf04d8171491fa9d776f7061ff6e727522df9bd03/pillow-12.1.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b574c51cf7d5d62e9be37ba446224b59a2da26dc4c1bb2ecbe936a4fb1a7cb7f", size = 6347798, upload-time = "2026-02-11T04:22:15.449Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/ee/c85a38a9ab92037a75615aba572c85ea51e605265036e00c5b67dfafbfe2/pillow-12.1.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a37691702ed687799de29a518d63d4682d9016932db66d4e90c345831b02fb4e", size = 7039315, upload-time = "2026-02-11T04:22:17.24Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/f3/bc8ccc6e08a148290d7523bde4d9a0d6c981db34631390dc6e6ec34cacf6/pillow-12.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f95c00d5d6700b2b890479664a06e754974848afaae5e21beb4d83c106923fd0", size = 6462360, upload-time = "2026-02-11T04:22:19.111Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/ab/69a42656adb1d0665ab051eec58a41f169ad295cf81ad45406963105408f/pillow-12.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:559b38da23606e68681337ad74622c4dbba02254fc9cb4488a305dd5975c7eeb", size = 7165438, upload-time = "2026-02-11T04:22:21.041Z" },
-    { url = "https://files.pythonhosted.org/packages/02/46/81f7aa8941873f0f01d4b55cc543b0a3d03ec2ee30d617a0448bf6bd6dec/pillow-12.1.1-cp314-cp314-win32.whl", hash = "sha256:03edcc34d688572014ff223c125a3f77fb08091e4607e7745002fc214070b35f", size = 6431503, upload-time = "2026-02-11T04:22:22.833Z" },
-    { url = "https://files.pythonhosted.org/packages/40/72/4c245f7d1044b67affc7f134a09ea619d4895333d35322b775b928180044/pillow-12.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:50480dcd74fa63b8e78235957d302d98d98d82ccbfac4c7e12108ba9ecbdba15", size = 7176748, upload-time = "2026-02-11T04:22:24.64Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/ad/8a87bdbe038c5c698736e3348af5c2194ffb872ea52f11894c95f9305435/pillow-12.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:5cb1785d97b0c3d1d1a16bc1d710c4a0049daefc4935f3a8f31f827f4d3d2e7f", size = 2544314, upload-time = "2026-02-11T04:22:26.685Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/9d/efd18493f9de13b87ede7c47e69184b9e859e4427225ea962e32e56a49bc/pillow-12.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1f90cff8aa76835cba5769f0b3121a22bd4eb9e6884cfe338216e557a9a548b8", size = 5268612, upload-time = "2026-02-11T04:22:29.884Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f1/4f42eb2b388eb2ffc660dcb7f7b556c1015c53ebd5f7f754965ef997585b/pillow-12.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f1be78ce9466a7ee64bfda57bdba0f7cc499d9794d518b854816c41bf0aa4e9", size = 4660567, upload-time = "2026-02-11T04:22:31.799Z" },
-    { url = "https://files.pythonhosted.org/packages/01/54/df6ef130fa43e4b82e32624a7b821a2be1c5653a5fdad8469687a7db4e00/pillow-12.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:42fc1f4677106188ad9a55562bbade416f8b55456f522430fadab3cef7cd4e60", size = 6269951, upload-time = "2026-02-11T04:22:33.921Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/48/618752d06cc44bb4aae8ce0cd4e6426871929ed7b46215638088270d9b34/pillow-12.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98edb152429ab62a1818039744d8fbb3ccab98a7c29fc3d5fcef158f3f1f68b7", size = 8074769, upload-time = "2026-02-11T04:22:35.877Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/bd/f1d71eb39a72fa088d938655afba3e00b38018d052752f435838961127d8/pillow-12.1.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d470ab1178551dd17fdba0fef463359c41aaa613cdcd7ff8373f54be629f9f8f", size = 6381358, upload-time = "2026-02-11T04:22:37.698Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ef/c784e20b96674ed36a5af839305f55616f8b4f8aa8eeccf8531a6e312243/pillow-12.1.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6408a7b064595afcab0a49393a413732a35788f2a5092fdc6266952ed67de586", size = 7068558, upload-time = "2026-02-11T04:22:39.597Z" },
-    { url = "https://files.pythonhosted.org/packages/73/cb/8059688b74422ae61278202c4e1ad992e8a2e7375227be0a21c6b87ca8d5/pillow-12.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5d8c41325b382c07799a3682c1c258469ea2ff97103c53717b7893862d0c98ce", size = 6493028, upload-time = "2026-02-11T04:22:42.73Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/da/e3c008ed7d2dd1f905b15949325934510b9d1931e5df999bb15972756818/pillow-12.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7697918b5be27424e9ce568193efd13d925c4481dd364e43f5dff72d33e10f8", size = 7191940, upload-time = "2026-02-11T04:22:44.543Z" },
-    { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fe/1bc9b3ee13f68487a99ac9529968035cca2f0a51ec36892060edcc51d06a/pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4", size = 5278800, upload-time = "2025-07-01T09:14:17.648Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/32/7e2ac19b5713657384cec55f89065fb306b06af008cfd87e572035b27119/pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69", size = 4686296, upload-time = "2025-07-01T09:14:19.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1e/b9e12bbe6e4c2220effebc09ea0923a07a6da1e1f1bfbc8d7d29a01ce32b/pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d", size = 5871726, upload-time = "2025-07-03T13:10:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/33/e9200d2bd7ba00dc3ddb78df1198a6e80d7669cce6c2bdbeb2530a74ec58/pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6", size = 7644652, upload-time = "2025-07-03T13:10:10.391Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f1/6f2427a26fc683e00d985bc391bdd76d8dd4e92fac33d841127eb8fb2313/pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7", size = 5977787, upload-time = "2025-07-01T09:14:21.63Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024", size = 6645236, upload-time = "2025-07-01T09:14:23.321Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/848f69fb79843b3d91241bad658e9c14f39a32f71a301bcd1d139416d1be/pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809", size = 6086950, upload-time = "2025-07-01T09:14:25.237Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1a/7cff92e695a2a29ac1958c2a0fe4c0b2393b60aac13b04a4fe2735cad52d/pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d", size = 6723358, upload-time = "2025-07-01T09:14:27.053Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7d/73699ad77895f69edff76b0f332acc3d497f22f5d75e5360f78cbcaff248/pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149", size = 6275079, upload-time = "2025-07-01T09:14:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ce/e7dfc873bdd9828f3b6e5c2bbb74e47a98ec23cc5c74fc4e54462f0d9204/pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d", size = 6986324, upload-time = "2025-07-01T09:14:31.899Z" },
+    { url = "https://files.pythonhosted.org/packages/16/8f/b13447d1bf0b1f7467ce7d86f6e6edf66c0ad7cf44cf5c87a37f9bed9936/pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542", size = 2423067, upload-time = "2025-07-01T09:14:33.709Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/93/0952f2ed8db3a5a4c7a11f91965d6184ebc8cd7cbb7941a260d5f018cd2d/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd", size = 2128328, upload-time = "2025-07-01T09:14:35.276Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e8/100c3d114b1a0bf4042f27e0f87d2f25e857e838034e98ca98fe7b8c0a9c/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8", size = 2170652, upload-time = "2025-07-01T09:14:37.203Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/86/3f758a28a6e381758545f7cdb4942e1cb79abd271bea932998fc0db93cb6/pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f", size = 2227443, upload-time = "2025-07-01T09:14:39.344Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f4/91d5b3ffa718df2f53b0dc109877993e511f4fd055d7e9508682e8aba092/pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c", size = 5278474, upload-time = "2025-07-01T09:14:41.843Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0e/37d7d3eca6c879fbd9dba21268427dffda1ab00d4eb05b32923d4fbe3b12/pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd", size = 4686038, upload-time = "2025-07-01T09:14:44.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/3426e5c7f6565e752d81221af9d3676fdbb4f352317ceafd42899aaf5d8a/pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e", size = 5864407, upload-time = "2025-07-03T13:10:15.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c1/c6c423134229f2a221ee53f838d4be9d82bab86f7e2f8e75e47b6bf6cd77/pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1", size = 7639094, upload-time = "2025-07-03T13:10:21.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c9/09e6746630fe6372c67c648ff9deae52a2bc20897d51fa293571977ceb5d/pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805", size = 5973503, upload-time = "2025-07-01T09:14:45.698Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8", size = 6642574, upload-time = "2025-07-01T09:14:47.415Z" },
+    { url = "https://files.pythonhosted.org/packages/36/de/d5cc31cc4b055b6c6fd990e3e7f0f8aaf36229a2698501bcb0cdf67c7146/pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2", size = 6084060, upload-time = "2025-07-01T09:14:49.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ea/502d938cbaeec836ac28a9b730193716f0114c41325db428e6b280513f09/pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b", size = 6721407, upload-time = "2025-07-01T09:14:51.962Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9c/9c5e2a73f125f6cbc59cc7087c8f2d649a7ae453f83bd0362ff7c9e2aee2/pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3", size = 6273841, upload-time = "2025-07-01T09:14:54.142Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/397c73524e0cd212067e0c969aa245b01d50183439550d24d9f55781b776/pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51", size = 6978450, upload-time = "2025-07-01T09:14:56.436Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d2/622f4547f69cd173955194b78e4d19ca4935a1b0f03a302d655c9f6aae65/pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580", size = 2423055, upload-time = "2025-07-01T09:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/80/a8a2ac21dda2e82480852978416cfacd439a4b490a501a288ecf4fe2532d/pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e", size = 5281110, upload-time = "2025-07-01T09:14:59.79Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d6/b79754ca790f315918732e18f82a8146d33bcd7f4494380457ea89eb883d/pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d", size = 4689547, upload-time = "2025-07-01T09:15:01.648Z" },
+    { url = "https://files.pythonhosted.org/packages/49/20/716b8717d331150cb00f7fdd78169c01e8e0c219732a78b0e59b6bdb2fd6/pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced", size = 5901554, upload-time = "2025-07-03T13:10:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cf/a9f3a2514a65bb071075063a96f0a5cf949c2f2fce683c15ccc83b1c1cab/pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c", size = 7669132, upload-time = "2025-07-03T13:10:33.01Z" },
+    { url = "https://files.pythonhosted.org/packages/98/3c/da78805cbdbee9cb43efe8261dd7cc0b4b93f2ac79b676c03159e9db2187/pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8", size = 6005001, upload-time = "2025-07-01T09:15:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fa/ce044b91faecf30e635321351bba32bab5a7e034c60187fe9698191aef4f/pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59", size = 6668814, upload-time = "2025-07-01T09:15:05.655Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/51/90f9291406d09bf93686434f9183aba27b831c10c87746ff49f127ee80cb/pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe", size = 6113124, upload-time = "2025-07-01T09:15:07.358Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5a/6fec59b1dfb619234f7636d4157d11fb4e196caeee220232a8d2ec48488d/pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c", size = 6747186, upload-time = "2025-07-01T09:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/49/6b/00187a044f98255225f172de653941e61da37104a9ea60e4f6887717e2b5/pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788", size = 6277546, upload-time = "2025-07-01T09:15:11.311Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/6caaba7e261c0d75bab23be79f1d06b5ad2a2ae49f028ccec801b0e853d6/pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31", size = 6985102, upload-time = "2025-07-01T09:15:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/7e/b623008460c09a0cb38263c93b828c666493caee2eb34ff67f778b87e58c/pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e", size = 2424803, upload-time = "2025-07-01T09:15:15.695Z" },
+    { url = "https://files.pythonhosted.org/packages/73/f4/04905af42837292ed86cb1b1dabe03dce1edc008ef14c473c5c7e1443c5d/pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12", size = 5278520, upload-time = "2025-07-01T09:15:17.429Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/33d79e377a336247df6348a54e6d2a2b85d644ca202555e3faa0cf811ecc/pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a", size = 4686116, upload-time = "2025-07-01T09:15:19.423Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2d/ed8bc0ab219ae8768f529597d9509d184fe8a6c4741a6864fea334d25f3f/pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632", size = 5864597, upload-time = "2025-07-03T13:10:38.404Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/3d/b932bb4225c80b58dfadaca9d42d08d0b7064d2d1791b6a237f87f661834/pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673", size = 7638246, upload-time = "2025-07-03T13:10:44.987Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b5/0487044b7c096f1b48f0d7ad416472c02e0e4bf6919541b111efd3cae690/pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027", size = 5973336, upload-time = "2025-07-01T09:15:21.237Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2d/524f9318f6cbfcc79fbc004801ea6b607ec3f843977652fdee4857a7568b/pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77", size = 6642699, upload-time = "2025-07-01T09:15:23.186Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d2/a9a4f280c6aefedce1e8f615baaa5474e0701d86dd6f1dede66726462bbd/pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874", size = 6083789, upload-time = "2025-07-01T09:15:25.1Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/86b0cd9dbb683a9d5e960b66c7379e821a19be4ac5810e2e5a715c09a0c0/pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a", size = 6720386, upload-time = "2025-07-01T09:15:27.378Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/88efcaf384c3588e24259c4203b909cbe3e3c2d887af9e938c2022c9dd48/pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214", size = 6370911, upload-time = "2025-07-01T09:15:29.294Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cc/934e5820850ec5eb107e7b1a72dd278140731c669f396110ebc326f2a503/pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635", size = 7117383, upload-time = "2025-07-01T09:15:31.128Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e9/9c0a616a71da2a5d163aa37405e8aced9a906d574b4a214bede134e731bc/pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6", size = 2511385, upload-time = "2025-07-01T09:15:33.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/33/c88376898aff369658b225262cd4f2659b13e8178e7534df9e6e1fa289f6/pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae", size = 5281129, upload-time = "2025-07-01T09:15:35.194Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/70/d376247fb36f1844b42910911c83a02d5544ebd2a8bad9efcc0f707ea774/pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653", size = 4689580, upload-time = "2025-07-01T09:15:37.114Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/537e930496149fbac69efd2fc4329035bbe2e5475b4165439e3be9cb183b/pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6", size = 5902860, upload-time = "2025-07-03T13:10:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/57/80f53264954dcefeebcf9dae6e3eb1daea1b488f0be8b8fef12f79a3eb10/pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36", size = 7670694, upload-time = "2025-07-03T13:10:56.432Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/4727d3b71a8578b4587d9c276e90efad2d6fe0335fd76742a6da08132e8c/pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b", size = 6005888, upload-time = "2025-07-01T09:15:39.436Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/716592277934f85d3be51d7256f3636672d7b1abfafdc42cf3f8cbd4b4c8/pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477", size = 6670330, upload-time = "2025-07-01T09:15:41.269Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bb/7fe6cddcc8827b01b1a9766f5fdeb7418680744f9082035bdbabecf1d57f/pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50", size = 6114089, upload-time = "2025-07-01T09:15:43.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/06bfaa444c8e80f1a8e4bff98da9c83b37b5be3b1deaa43d27a0db37ef84/pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b", size = 6748206, upload-time = "2025-07-01T09:15:44.937Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/77/bc6f92a3e8e6e46c0ca78abfffec0037845800ea38c73483760362804c41/pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12", size = 6377370, upload-time = "2025-07-01T09:15:46.673Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/82/3a721f7d69dca802befb8af08b7c79ebcab461007ce1c18bd91a5d5896f9/pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db", size = 7121500, upload-time = "2025-07-01T09:15:48.512Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/5572fa4a3f45740eaab6ae86fcdf7195b55beac1371ac8c619d880cfe948/pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa", size = 2512835, upload-time = "2025-07-01T09:15:50.399Z" },
 ]
 
 [[package]]
@@ -2893,6 +2932,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "py-rust-stemmers"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/63/4fbc14810c32d2a884e2e94e406a7d5bf8eee53e1103f558433817230342/py_rust_stemmers-0.1.5.tar.gz", hash = "sha256:e9c310cfb5c2470d7c7c8a0484725965e7cab8b1237e106a0863d5741da3e1f7", size = 9388, upload-time = "2025-02-19T13:56:28.708Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e1/ea8ac92454a634b1bb1ee0a89c2f75a4e6afec15a8412527e9bbde8c6b7b/py_rust_stemmers-0.1.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:29772837126a28263bf54ecd1bc709dd569d15a94d5e861937813ce51e8a6df4", size = 286085, upload-time = "2025-02-19T13:55:23.871Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/fe1cc3d36a19c1ce39792b1ed151ddff5ee1d74c8801f0e93ff36e65f885/py_rust_stemmers-0.1.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d62410ada44a01e02974b85d45d82f4b4c511aae9121e5f3c1ba1d0bea9126b", size = 272021, upload-time = "2025-02-19T13:55:25.685Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/38/b8f94e5e886e7ab181361a0911a14fb923b0d05b414de85f427e773bf445/py_rust_stemmers-0.1.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b28ef729a4c83c7d9418be3c23c0372493fcccc67e86783ff04596ef8a208cdf", size = 310547, upload-time = "2025-02-19T13:55:26.891Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/08/62e97652d359b75335486f4da134a6f1c281f38bd3169ed6ecfb276448c3/py_rust_stemmers-0.1.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a979c3f4ff7ad94a0d4cf566ca7bfecebb59e66488cc158e64485cf0c9a7879f", size = 315237, upload-time = "2025-02-19T13:55:28.116Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b9/fc0278432f288d2be4ee4d5cc80fd8013d604506b9b0503e8b8cae4ba1c3/py_rust_stemmers-0.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c3593d895453fa06bf70a7b76d6f00d06def0f91fc253fe4260920650c5e078", size = 324419, upload-time = "2025-02-19T13:55:29.211Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/5b/74e96eaf622fe07e83c5c389d101540e305e25f76a6d0d6fb3d9e0506db8/py_rust_stemmers-0.1.5-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:96ccc7fd042ffc3f7f082f2223bb7082ed1423aa6b43d5d89ab23e321936c045", size = 324792, upload-time = "2025-02-19T13:55:30.948Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f7/b76816d7d67166e9313915ad486c21d9e7da0ac02703e14375bb1cb64b5a/py_rust_stemmers-0.1.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef18cfced2c9c676e0d7d172ba61c3fab2aa6969db64cc8f5ca33a7759efbefe", size = 488014, upload-time = "2025-02-19T13:55:32.066Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ed/7d9bed02f78d85527501f86a867cd5002d97deb791b9a6b1b45b00100010/py_rust_stemmers-0.1.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:541d4b5aa911381e3d37ec483abb6a2cf2351b4f16d5e8d77f9aa2722956662a", size = 575582, upload-time = "2025-02-19T13:55:34.005Z" },
+    { url = "https://files.pythonhosted.org/packages/93/40/eafd1b33688e8e8ae946d1ef25c4dc93f5b685bd104b9c5573405d7e1d30/py_rust_stemmers-0.1.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ffd946a36e9ac17ca96821963663012e04bc0ee94d21e8b5ae034721070b436c", size = 493267, upload-time = "2025-02-19T13:55:35.294Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6a/15135b69e4fd28369433eb03264d201b1b0040ba534b05eddeb02a276684/py_rust_stemmers-0.1.5-cp312-none-win_amd64.whl", hash = "sha256:6ed61e1207f3b7428e99b5d00c055645c6415bb75033bff2d06394cbe035fd8e", size = 209395, upload-time = "2025-02-19T13:55:36.519Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b8/030036311ec25952bf3083b6c105be5dee052a71aa22d5fbeb857ebf8c1c/py_rust_stemmers-0.1.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:398b3a843a9cd4c5d09e726246bc36f66b3d05b0a937996814e91f47708f5db5", size = 286086, upload-time = "2025-02-19T13:55:37.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/be/0465dcb3a709ee243d464e89231e3da580017f34279d6304de291d65ccb0/py_rust_stemmers-0.1.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4e308fc7687901f0c73603203869908f3156fa9c17c4ba010a7fcc98a7a1c5f2", size = 272019, upload-time = "2025-02-19T13:55:39.183Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b6/76ca5b1f30cba36835938b5d9abee0c130c81833d51b9006264afdf8df3c/py_rust_stemmers-0.1.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f9efc4da5e734bdd00612e7506de3d0c9b7abc4b89d192742a0569d0d1fe749", size = 310545, upload-time = "2025-02-19T13:55:40.339Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8f/5be87618cea2fe2e70e74115a20724802bfd06f11c7c43514b8288eb6514/py_rust_stemmers-0.1.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc2cc8d2b36bc05b8b06506199ac63d437360ae38caefd98cd19e479d35afd42", size = 315236, upload-time = "2025-02-19T13:55:41.55Z" },
+    { url = "https://files.pythonhosted.org/packages/00/02/ea86a316aee0f0a9d1449ad4dbffff38f4cf0a9a31045168ae8b95d8bdf8/py_rust_stemmers-0.1.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a231dc6f0b2a5f12a080dfc7abd9e6a4ea0909290b10fd0a4620e5a0f52c3d17", size = 324419, upload-time = "2025-02-19T13:55:42.693Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/1612c22545dcc0abe2f30fc08f30a2332f2224dd536fa1508444a9ca0e39/py_rust_stemmers-0.1.5-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5845709d48afc8b29e248f42f92431155a3d8df9ba30418301c49c6072b181b0", size = 324794, upload-time = "2025-02-19T13:55:43.896Z" },
+    { url = "https://files.pythonhosted.org/packages/66/18/8a547584d7edac9e7ac9c7bdc53228d6f751c0f70a317093a77c386c8ddc/py_rust_stemmers-0.1.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e48bfd5e3ce9d223bfb9e634dc1425cf93ee57eef6f56aa9a7120ada3990d4be", size = 488014, upload-time = "2025-02-19T13:55:45.088Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/87/4619c395b325e26048a6e28a365afed754614788ba1f49b2eefb07621a03/py_rust_stemmers-0.1.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:35d32f6e7bdf6fd90e981765e32293a8be74def807147dea9fdc1f65d6ce382f", size = 575582, upload-time = "2025-02-19T13:55:46.436Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6e/214f1a889142b7df6d716e7f3fea6c41e87bd6c29046aa57e175d452b104/py_rust_stemmers-0.1.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:191ea8bf922c984631ffa20bf02ef0ad7eec0465baeaed3852779e8f97c7e7a3", size = 493269, upload-time = "2025-02-19T13:55:49.057Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/b9/c5185df277576f995ae34418eb2b2ac12f30835412270f9e05c52face521/py_rust_stemmers-0.1.5-cp313-none-win_amd64.whl", hash = "sha256:e564c9efdbe7621704e222b53bac265b0e4fbea788f07c814094f0ec6b80adcf", size = 209397, upload-time = "2025-02-19T13:55:50.853Z" },
 ]
 
 [[package]]
@@ -4803,6 +4870,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Phase 1**: Core foundation — `is_local_mode()` auto-detection, `LocalEmbeddingFunction` (tier 0: ONNX MiniLM 384d, tier 1: fastembed bge-base 768d), `T3Database(local_mode=True)` with `PersistentClient`, `make_t3()` local path, `sqlite3.OperationalError` retry for concurrent writes, `[local]` optional dependency
- **Phase 2**: Indexer pipeline — `embed_fn` injection in `IndexContext`, local embedding in `code_indexer`, `prose_indexer`, and PDF indexer; `_run_index()` and `_run_index_frecency_only()` local mode paths; tier 0 notice when fastembed unavailable
- **Phase 3**: Commands & corpus — `store.py` skips cloud credentials in local mode, `memory.py promote_cmd` uses `make_t3()`, `search_cmd.py` skips Voyage reranker in local mode, `corpus.py` returns local model names for staleness detection

## What this enables

```bash
pip install conexus
nx index repo .       # works with local ONNX embeddings, no API keys
nx search "query"     # returns results from local PersistentClient
```

## Remaining work (P4-P5)

- P4: Additional integration test coverage for local mode
- P5: Documentation updates

## Test plan

- [x] 26 new local mode tests pass
- [x] 2280 existing tests pass (0 regressions)
- [x] 5 pre-existing failures unrelated to this change

References: RDR-038, nexus-3ptm