### PR TITLE
Add local mode health checks to nx doctor

### DIFF
--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -201,105 +201,157 @@ def doctor_cmd() -> None:
              "brew install python@3.12         (macOS)",
              "apt install python3.12           (Ubuntu/Debian)")
 
-    # ── CHROMA_API_KEY ────────────────────────────────────────────────────────
-    chroma_key = get_credential("chroma_api_key")
-    lines.append(_check_line("ChromaDB  (CHROMA_API_KEY)",  bool(chroma_key),
-                              "set" if chroma_key else "not set"))
-    if not chroma_key:
-        failed = True
-        _fix(lines,
-             "nx config init                           (interactive wizard)",
-             "nx config set chroma_api_key <your-key>  (set individually)",
-             "Get key: https://trychroma.com  →  Cloud  →  API Keys")
+    # ── T3 mode detection ────────────────────────────────────────────────────
+    from nexus.config import is_local_mode, _default_local_path
+    _local = is_local_mode()
 
-    # ── CHROMA_TENANT (optional — inferred from API key if not set) ──────────
-    chroma_tenant = get_credential("chroma_tenant")
-    lines.append(_check_line("ChromaDB  (CHROMA_TENANT)",
-                              True,
-                              chroma_tenant if chroma_tenant
-                              else "not set (auto-inferred from API key — set explicitly only for multi-workspace)"))
+    if _local:
+        # ── Local mode checks ────────────────────────────────────────────
+        lines.append(_check_line("T3 mode", True, "local (no API keys needed)"))
 
-    # ── CHROMA_DATABASE ───────────────────────────────────────────────────────
-    chroma_database = get_credential("chroma_database")
-    lines.append(_check_line("ChromaDB  (CHROMA_DATABASE)", bool(chroma_database),
-                              chroma_database if chroma_database else "not set"))
-    if not chroma_database:
-        failed = True
-        _fix(lines,
-             "nx config init                           (interactive wizard, also provisions database)",
-             "nx config set chroma_database <name>",
-             "e.g. nx config set chroma_database nexus")
+        # Local ChromaDB path
+        local_path = _default_local_path()
+        path_exists = local_path.exists()
+        if path_exists:
+            # Check writable
+            try:
+                test_file = local_path / ".doctor_test"
+                test_file.touch()
+                test_file.unlink()
+                lines.append(_check_line("Local ChromaDB path", True, str(local_path)))
+            except OSError:
+                failed = True
+                lines.append(_check_line("Local ChromaDB path", False, f"{local_path} — not writable"))
+                _fix(lines, f"Check permissions on {local_path}")
+        else:
+            lines.append(_check_line("Local ChromaDB path", True, f"{local_path} (will be created on first index)"))
 
-    # ── ChromaDB database reachability ────────────────────────────────────────
-    if chroma_key and chroma_database:
-        try:
-            chromadb.CloudClient(
-                tenant=chroma_tenant or None, database=chroma_database, api_key=chroma_key
-            )
-            lines.append(_check_line(f"ChromaDB  ({chroma_database})", True, "reachable"))
-        except Exception as exc:
-            failed = True
-            _log.debug("db_not_reachable", db_name=chroma_database, error=str(exc))
-            lines.append(_check_line(f"ChromaDB  ({chroma_database})", False, "not reachable"))
-            _fix(lines,
-                 "Run 'nx config init' to provision the database automatically.",
-                 f"Or create '{chroma_database}' manually in the ChromaDB Cloud dashboard.")
-        # Warn if old four-database layout is still present
-        try:
-            chromadb.CloudClient(
-                tenant=chroma_tenant or None, database=f"{chroma_database}_code", api_key=chroma_key
-            )
-            lines.append(_check_line(f"ChromaDB  ({chroma_database}_code)", False,
-                                     "old layout detected — migrate and set NX_MIGRATED=1"))
-        except Exception:
-            pass  # Old layout absent — expected
+        # Embedding model
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction()
+        lines.append(_check_line("Embedding model", True, f"{ef.model_name} ({ef.dimensions}d)"))
+        if ef.model_name == "all-MiniLM-L6-v2":
+            _fix(lines, "Upgrade: pip install conexus[local]  (768d bge-base, better quality)")
 
-    # ── VOYAGE_API_KEY ────────────────────────────────────────────────────────
-    voyage_key = get_credential("voyage_api_key")
-    lines.append(_check_line("Voyage AI (VOYAGE_API_KEY)",  bool(voyage_key),
-                              "set" if voyage_key else "not set"))
-    if not voyage_key:
-        failed = True
-        _fix(lines,
-             "nx config init                           (interactive wizard)",
-             "nx config set voyage_api_key <your-key>  (set individually)",
-             "Get key: https://voyageai.com  →  Dashboard  →  API Keys")
-
-    # ── Pipeline version check ───────────────────────────────────────────────
-    if chroma_key and chroma_database and voyage_key:
-        from nexus.indexer import PIPELINE_VERSION, get_collection_pipeline_version
-
-        stale_count = 0
-        try:
-            client = chromadb.CloudClient(
-                tenant=chroma_tenant or None, database=chroma_database, api_key=chroma_key
-            )
-            cols = client.list_collections()
-            for col in cols:
-                stored = get_collection_pipeline_version(col)
-                if stored is None:
-                    lines.append(_check_line(
-                        f"pipeline ({col.name})", True,
-                        "no version stamp (index with --force to stamp)",
-                    ))
-                elif stored != PIPELINE_VERSION:
-                    stale_count += 1
-                    lines.append(_check_line(
-                        f"pipeline ({col.name})", False,
-                        f"v{stored} (current: v{PIPELINE_VERSION})",
-                    ))
+        # Collection count and disk usage
+        if path_exists:
+            try:
+                client = chromadb.PersistentClient(path=str(local_path))
+                cols = client.list_collections()
+                col_count = len(cols)
+                # Disk usage
+                total_bytes = sum(f.stat().st_size for f in local_path.rglob("*") if f.is_file())
+                if total_bytes < 1024 * 1024:
+                    size_str = f"{total_bytes / 1024:.1f} KB"
                 else:
-                    lines.append(_check_line(
-                        f"pipeline ({col.name})", True, f"v{stored}",
-                    ))
-        except Exception as exc:
-            _log.debug("doctor_pipeline_check_failed", db=chroma_database, error=str(exc))
-            lines.append(_check_line(f"pipeline ({chroma_database})", False, "check failed"))
-        if stale_count:
+                    size_str = f"{total_bytes / (1024 * 1024):.1f} MB"
+                lines.append(_check_line("Local collections", True, f"{col_count} collections, {size_str} on disk"))
+            except Exception as exc:
+                _log.debug("doctor_local_collections_failed", error=str(exc))
+                lines.append(_check_line("Local collections", True, "could not query"))
+    else:
+        # ── Cloud mode checks ────────────────────────────────────────────
+        lines.append(_check_line("T3 mode", True, "cloud"))
+
+        # CHROMA_API_KEY
+        chroma_key = get_credential("chroma_api_key")
+        lines.append(_check_line("ChromaDB  (CHROMA_API_KEY)",  bool(chroma_key),
+                                  "set" if chroma_key else "not set"))
+        if not chroma_key:
             failed = True
             _fix(lines,
-                 "nx index repo <path> --force-stale  (re-index outdated collections)",
-                 "nx index repo <path> --force        (re-index all collections)")
+                 "nx config init                           (interactive wizard)",
+                 "nx config set chroma_api_key <your-key>  (set individually)",
+                 "Get key: https://trychroma.com  →  Cloud  →  API Keys")
+
+        # CHROMA_TENANT (optional)
+        chroma_tenant = get_credential("chroma_tenant")
+        lines.append(_check_line("ChromaDB  (CHROMA_TENANT)",
+                                  True,
+                                  chroma_tenant if chroma_tenant
+                                  else "not set (auto-inferred from API key — set explicitly only for multi-workspace)"))
+
+        # CHROMA_DATABASE
+        chroma_database = get_credential("chroma_database")
+        lines.append(_check_line("ChromaDB  (CHROMA_DATABASE)", bool(chroma_database),
+                                  chroma_database if chroma_database else "not set"))
+        if not chroma_database:
+            failed = True
+            _fix(lines,
+                 "nx config init                           (interactive wizard, also provisions database)",
+                 "nx config set chroma_database <name>",
+                 "e.g. nx config set chroma_database nexus")
+
+        # ChromaDB reachability
+        if chroma_key and chroma_database:
+            try:
+                chromadb.CloudClient(
+                    tenant=chroma_tenant or None, database=chroma_database, api_key=chroma_key
+                )
+                lines.append(_check_line(f"ChromaDB  ({chroma_database})", True, "reachable"))
+            except Exception as exc:
+                failed = True
+                _log.debug("db_not_reachable", db_name=chroma_database, error=str(exc))
+                lines.append(_check_line(f"ChromaDB  ({chroma_database})", False, "not reachable"))
+                _fix(lines,
+                     "Run 'nx config init' to provision the database automatically.",
+                     f"Or create '{chroma_database}' manually in the ChromaDB Cloud dashboard.")
+            # Old layout warning
+            try:
+                chromadb.CloudClient(
+                    tenant=chroma_tenant or None, database=f"{chroma_database}_code", api_key=chroma_key
+                )
+                lines.append(_check_line(f"ChromaDB  ({chroma_database}_code)", False,
+                                         "old layout detected — migrate and set NX_MIGRATED=1"))
+            except Exception:
+                pass
+
+        # VOYAGE_API_KEY
+        voyage_key = get_credential("voyage_api_key")
+        lines.append(_check_line("Voyage AI (VOYAGE_API_KEY)",  bool(voyage_key),
+                                  "set" if voyage_key else "not set"))
+        if not voyage_key:
+            failed = True
+            _fix(lines,
+                 "nx config init                           (interactive wizard)",
+                 "nx config set voyage_api_key <your-key>  (set individually)",
+                 "Get key: https://voyageai.com  →  Dashboard  →  API Keys")
+
+        # Pipeline version check
+        if chroma_key and chroma_database and voyage_key:
+            from nexus.indexer import PIPELINE_VERSION, get_collection_pipeline_version
+
+            stale_count = 0
+            try:
+                client = chromadb.CloudClient(
+                    tenant=chroma_tenant or None, database=chroma_database, api_key=chroma_key
+                )
+                cols = client.list_collections()
+                for col in cols:
+                    stored = get_collection_pipeline_version(col)
+                    if stored is None:
+                        lines.append(_check_line(
+                            f"pipeline ({col.name})", True,
+                            "no version stamp (index with --force to stamp)",
+                        ))
+                    elif stored != PIPELINE_VERSION:
+                        stale_count += 1
+                        lines.append(_check_line(
+                            f"pipeline ({col.name})", False,
+                            f"v{stored} (current: v{PIPELINE_VERSION})",
+                        ))
+                    else:
+                        lines.append(_check_line(
+                            f"pipeline ({col.name})", True, f"v{stored}",
+                        ))
+            except Exception as exc:
+                _log.debug("doctor_pipeline_check_failed", db=chroma_database, error=str(exc))
+                lines.append(_check_line(f"pipeline ({chroma_database})", False, "check failed"))
+            if stale_count:
+                failed = True
+                _fix(lines,
+                     "nx index repo <path> --force-stale  (re-index outdated collections)",
+                     "nx index repo <path> --force        (re-index all collections)")
 
     # ── ripgrep ───────────────────────────────────────────────────────────────
     rg_path = shutil.which("rg")
@@ -393,21 +445,28 @@ def doctor_cmd() -> None:
     # Non-fatal: integrity failure is logged but does not set failed=True.
     _check_t2_integrity(lines)
 
-    # ── ChromaDB pagination audit ─────────────────────────────────────────────
+    # ── ChromaDB pagination audit (cloud only) ──────────────────────────────
     # Spot-check one non-empty collection in the configured database (non-fatal).
-    if chroma_key and chroma_database:
-        try:
-            client = chromadb.CloudClient(
-                tenant=chroma_tenant or None, database=chroma_database, api_key=chroma_key
-            )
-            _check_chroma_pagination(lines, client, chroma_database)
-        except Exception as exc:
-            _log.debug("doctor_pagination_check_client_failed", db=chroma_database, error=str(exc))
-            lines.append(_check_line(f"ChromaDB pagination ({chroma_database})", True,
-                                     "skipped (client unavailable)"))
+    if not _local:
+        chroma_key = get_credential("chroma_api_key")
+        chroma_database = get_credential("chroma_database")
+        chroma_tenant = get_credential("chroma_tenant")
+        if chroma_key and chroma_database:
+            try:
+                client = chromadb.CloudClient(
+                    tenant=chroma_tenant or None, database=chroma_database, api_key=chroma_key
+                )
+                _check_chroma_pagination(lines, client, chroma_database)
+            except Exception as exc:
+                _log.debug("doctor_pagination_check_client_failed", db=chroma_database, error=str(exc))
+                lines.append(_check_line(f"ChromaDB pagination ({chroma_database})", True,
+                                         "skipped (client unavailable)"))
 
     click.echo("\n".join(lines))
 
     if failed:
-        click.echo("\nRun 'nx config init' to set up credentials and provision the database automatically.")
+        if _local:
+            click.echo("\nSome checks failed. Run 'nx doctor' again after fixing the issues above.")
+        else:
+            click.echo("\nRun 'nx config init' to set up credentials and provision the database automatically.")
         raise click.exceptions.Exit(1)

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -22,6 +22,7 @@ def test_doctor_all_healthy() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-fake-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -41,6 +42,7 @@ def test_doctor_missing_credentials_exit_1() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value=None),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -67,6 +69,7 @@ def test_doctor_missing_rg() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", side_effect=which_side_effect),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -88,6 +91,7 @@ def test_doctor_hooks_section_present() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -105,6 +109,7 @@ def test_doctor_hooks_no_repos_registered() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -131,7 +136,8 @@ def test_doctor_hooks_installed() -> None:
             (hooks_dir / name).write_text(f"#!/bin/sh\n{SENTINEL_BEGIN}\nnx index repo ...\n")
 
         with (
-            patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+            patch("nexus.config.is_local_mode", return_value=False),
+        patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
             patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
             patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
             patch("nexus.commands.doctor._effective_hooks_dir", return_value=hooks_dir),
@@ -155,7 +161,8 @@ def test_doctor_hooks_not_installed() -> None:
         hooks_dir = Path(td)  # empty — no hook files
 
         with (
-            patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+            patch("nexus.config.is_local_mode", return_value=False),
+        patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
             patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
             patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
             patch("nexus.commands.doctor._effective_hooks_dir", return_value=hooks_dir),
@@ -179,7 +186,8 @@ def test_doctor_hooks_check_always_nonfatal() -> None:
         hooks_dir = Path(td)  # empty — no hook files
 
         with (
-            patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+            patch("nexus.config.is_local_mode", return_value=False),
+        patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
             patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
             patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
             patch("nexus.commands.doctor._effective_hooks_dir", return_value=hooks_dir),
@@ -199,6 +207,7 @@ def test_doctor_hooks_exception_does_not_propagate() -> None:
     mock_reg.all.return_value = ["/some/repo"]
 
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -221,6 +230,7 @@ def test_doctor_index_log_shows_path() -> None:
     mock_reg.all.return_value = []
 
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -246,7 +256,8 @@ def test_doctor_index_log_not_created_yet() -> None:
         # Do not create index.log — it should not exist
 
         with (
-            patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
+            patch("nexus.config.is_local_mode", return_value=False),
+        patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
             patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
             patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
             patch("nexus.commands.doctor.chromadb.CloudClient", return_value=MagicMock()),
@@ -267,6 +278,7 @@ def test_doctor_does_not_mention_serve_start() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -290,6 +302,7 @@ def test_doctor_partial_credentials() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", side_effect=cred_side_effect),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -315,6 +328,7 @@ def test_doctor_python_version_shown() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -333,6 +347,7 @@ def test_doctor_python_version_too_old_fails() -> None:
     mock_reg.all.return_value = []
     with (
         patch("nexus.commands.doctor._python_ok", return_value=(False, "3.11.0")),
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -354,6 +369,7 @@ def test_doctor_missing_credential_shows_inline_fix() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value=None),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/tool"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -373,6 +389,7 @@ def test_doctor_missing_rg_shows_platform_hints() -> None:
     mock_reg.all.return_value = []
 
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value=None),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -404,6 +421,7 @@ def test_doctor_single_db_calls_cloud_client() -> None:
         return mock_client
 
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -422,6 +440,7 @@ def test_doctor_single_db_unreachable_fails_with_fix_hint() -> None:
     mock_reg.all.return_value = []
 
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -442,6 +461,7 @@ def test_doctor_single_db_error_does_not_expose_exception_text() -> None:
     mock_reg.all.return_value = []
 
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -468,6 +488,7 @@ def test_doctor_missing_bd_does_not_fail() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", side_effect=which_side_effect),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -493,6 +514,7 @@ def test_doctor_missing_uv_does_not_fail() -> None:
     mock_reg = MagicMock()
     mock_reg.all.return_value = []
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", side_effect=which_side_effect),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -511,3 +533,54 @@ def test_check_helper_format() -> None:
     assert "✓" in _check("Test", True)
     assert "✗" in _check("Test", False)
     assert "some detail" in _check("Test", True, "some detail")
+
+
+# ── Local mode ───────────────────────────────────────────────────────────────
+
+def test_doctor_local_mode_shows_local_checks(tmp_path: Path) -> None:
+    """In local mode, doctor shows local path, embedding model, and skips cloud checks."""
+    runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
+
+    with (
+        patch("nexus.config.is_local_mode", return_value=True),
+        patch("nexus.config._default_local_path", return_value=tmp_path / "chroma"),
+        patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
+    ):
+        result = runner.invoke(main, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "local" in result.output.lower()
+    assert "Embedding model" in result.output
+    assert "CHROMA_API_KEY" not in result.output
+    assert "VOYAGE_API_KEY" not in result.output
+
+
+def test_doctor_local_mode_shows_collection_count(tmp_path: Path) -> None:
+    """In local mode with existing data, doctor shows collection count and disk usage."""
+    runner = _runner()
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
+
+    # Create a local chroma dir with some data
+    chroma_path = tmp_path / "chroma"
+    import chromadb
+    from nexus.db.local_ef import LocalEmbeddingFunction
+    ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
+    client = chromadb.PersistentClient(path=str(chroma_path))
+    col = client.get_or_create_collection("knowledge__test", embedding_function=ef)
+    col.add(ids=["doc1"], documents=["test content"])
+
+    with (
+        patch("nexus.config.is_local_mode", return_value=True),
+        patch("nexus.config._default_local_path", return_value=chroma_path),
+        patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
+        patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
+    ):
+        result = runner.invoke(main, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "1 collections" in result.output
+    assert "on disk" in result.output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -186,16 +186,17 @@ def test_t1_scratch_search(runner: CliRunner, tmp_path, monkeypatch) -> None:
 
 @pytest.mark.integration
 def test_doctor_runs_and_reports(runner: CliRunner) -> None:
-    """nx doctor completes without crashing and reports all five checks.
+    """nx doctor completes without crashing and reports key checks.
 
-    Exit code 0 = all credentials present; 1 = some missing. Both are valid
+    Exit code 0 = all checks pass; 1 = some failed. Both are valid
     in this test — we only care that the output covers each component.
+    In local mode (no API keys), checks local path and embedding model
+    instead of cloud credentials.
     """
     result = runner.invoke(main, ["doctor"])
     assert result.exit_code in (0, 1), result.output
     output = result.output.lower()
-    assert "chroma" in output
-    assert "voyage" in output
+    assert "t3 mode" in output
     assert "ripgrep" in output or "rg" in output
     assert "git" in output
 

--- a/tests/test_pipeline_version.py
+++ b/tests/test_pipeline_version.py
@@ -158,6 +158,7 @@ def test_doctor_reports_stale_collections():
 
     from nexus.cli import main
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),
@@ -190,6 +191,7 @@ def test_doctor_handles_no_version_stamp():
 
     from nexus.cli import main
     with (
+        patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.commands.doctor.get_credential", return_value="sk-key"),
         patch("nexus.commands.doctor.shutil.which", return_value="/usr/bin/rg"),
         patch("nexus.commands.doctor.RepoRegistry", return_value=mock_reg),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -220,6 +220,7 @@ def test_doctor_missing_chroma_key_reports_warning(
     runner: CliRunner, fake_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """nx doctor reports warning and exits 1 when CHROMA_API_KEY is unset."""
+    monkeypatch.setenv("NX_LOCAL", "0")  # force cloud mode
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
     result = runner.invoke(main, ["doctor"])
     assert result.exit_code == 1

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -200,8 +200,7 @@ def test_doctor_shows_all_checks(runner: CliRunner, fake_home: Path) -> None:
     result = runner.invoke(main, ["doctor"])
     assert result.exit_code in (0, 1), result.output
     output_lower = result.output.lower()
-    assert "chroma" in output_lower or "chromadb" in output_lower
-    assert "voyage" in output_lower
+    assert "t3 mode" in output_lower
     assert "ripgrep" in output_lower or "rg" in output_lower
     assert "git" in output_lower
 
@@ -210,6 +209,7 @@ def test_doctor_missing_voyage_key_reports_warning(
     runner: CliRunner, fake_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """nx doctor reports warning and exits 1 when VOYAGE_API_KEY is unset."""
+    monkeypatch.setenv("NX_LOCAL", "0")  # force cloud mode
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     result = runner.invoke(main, ["doctor"])
     assert result.exit_code == 1


### PR DESCRIPTION
## Summary

- `nx doctor` now detects local vs cloud mode and shows appropriate checks
- **Local mode**: path exists/writable, embedding model + tier, collection count, disk usage
- **Cloud mode**: all existing checks preserved unchanged
- Cloud credential checks (API keys, reachability, pagination) skipped entirely in local mode

## Test plan

- [x] 25 doctor tests pass (2 new local mode tests)
- [x] Existing cloud-mode tests patched with `is_local_mode=False` for CI compatibility
- [x] `test_plugin.py` cloud-mode test fixed with `NX_LOCAL=0`

References: nexus-wgw7, RDR-038