### PR TITLE
fix(nx): fully-qualify all skill slash command references

### DIFF
--- a/nx/README.md
+++ b/nx/README.md
@@ -45,14 +45,14 @@ Run `/nx-preflight` after installing to verify all dependencies are present.
 
 | Goal | Start here |
 |------|-----------|
-| Explore an unfamiliar codebase | `/analyze-code` |
-| Plan a feature or component | `/brainstorming-gate` → `/create-plan` |
-| Debug a failure | `/debug` (after 2–3 failed attempts) |
-| Review code before committing | `/review-code` |
-| Research an unfamiliar topic | `/research` |
-| Document a technical decision | `/rdr-create` → `/rdr-research` → `/rdr-accept` |
-| Index PDFs into semantic search | `/pdf-process` |
-| Not sure which agent to use | `/orchestrate` |
+| Explore an unfamiliar codebase | `/nx:analyze-code` |
+| Plan a feature or component | `/nx:brainstorming-gate` → `/nx:create-plan` |
+| Debug a failure | `/nx:debug` (after 2–3 failed attempts) |
+| Review code before committing | `/nx:review-code` |
+| Research an unfamiliar topic | `/nx:research` |
+| Document a technical decision | `/nx:rdr-create` → `/nx:rdr-research` → `/nx:rdr-accept` |
+| Index PDFs into semantic search | `/nx:pdf-process` |
+| Not sure which agent to use | `/nx:orchestrate` |
 
 ## Directory Structure
 
@@ -67,7 +67,7 @@ nx/
 │   │   └── RELAY_TEMPLATE.md    # Canonical relay message format
 │   └── *.md                 # 15 specialized agent definitions
 ├── commands/
-│   └── *.md                 # Slash commands (/research, /create-plan, /review-code, etc.)
+│   └── *.md                 # Slash commands (/nx:research, /nx:create-plan, /nx:review-code, etc.)
 ├── hooks/
 │   ├── hooks.json           # Hook event → script wiring
 │   └── scripts/
@@ -145,21 +145,21 @@ See [`registry.yaml`](./registry.yaml) for full metadata (model, triggers, prede
 
 | Agent | Skill | Command | Model | Purpose |
 |-------|-------|---------|-------|---------|
-| code-review-expert | code-review | `/review-code` | sonnet | Code quality, security, best practices |
-| codebase-deep-analyzer | codebase-analysis | `/analyze-code` | sonnet | Architecture, patterns, dependency mapping |
-| deep-analyst | deep-analysis | `/deep-analysis` | opus | Complex problem investigation, root cause |
-| substantive-critic | substantive-critique | `/substantive-critique` | sonnet | Constructive critique of plans/designs/code |
-| deep-research-synthesizer | research-synthesis | `/research` | sonnet | Multi-source research with synthesis |
-| architect-planner | architecture | `/architecture` | opus | Software architecture design, execution plans |
-| debugger | debugging | `/debug` | opus | Hypothesis-driven debugging |
-| developer | development | `/implement` | sonnet | TDD implementation, test-first methodology |
-| knowledge-tidier | knowledge-tidying | `/knowledge-tidy` | haiku | Persist and organize knowledge in nx store |
-| orchestrator | orchestration | `/orchestrate` | haiku | Route requests to appropriate agents |
-| pdf-chromadb-processor | pdf-processing | `/pdf-process` | haiku | Index PDFs into nx store for semantic search |
-| plan-auditor | plan-validation | `/plan-audit` | sonnet | Validate plans before execution |
-| plan-enricher | enrich-plan | `/enrich-plan` | sonnet | Enrich beads with audit findings and execution context |
-| strategic-planner | strategic-planning | `/create-plan` | opus | Implementation planning, task decomposition |
-| test-validator | test-validation | `/test-validate` | sonnet | Test coverage and quality validation |
+| code-review-expert | code-review | `/nx:review-code` | sonnet | Code quality, security, best practices |
+| codebase-deep-analyzer | codebase-analysis | `/nx:analyze-code` | sonnet | Architecture, patterns, dependency mapping |
+| deep-analyst | deep-analysis | `/nx:deep-analysis` | opus | Complex problem investigation, root cause |
+| substantive-critic | substantive-critique | `/nx:substantive-critique` | sonnet | Constructive critique of plans/designs/code |
+| deep-research-synthesizer | research-synthesis | `/nx:research` | sonnet | Multi-source research with synthesis |
+| architect-planner | architecture | `/nx:architecture` | opus | Software architecture design, execution plans |
+| debugger | debugging | `/nx:debug` | opus | Hypothesis-driven debugging |
+| developer | development | `/nx:implement` | sonnet | TDD implementation, test-first methodology |
+| knowledge-tidier | knowledge-tidying | `/nx:knowledge-tidy` | haiku | Persist and organize knowledge in nx store |
+| orchestrator | orchestration | `/nx:orchestrate` | haiku | Route requests to appropriate agents |
+| pdf-chromadb-processor | pdf-processing | `/nx:pdf-process` | haiku | Index PDFs into nx store for semantic search |
+| plan-auditor | plan-validation | `/nx:plan-audit` | sonnet | Validate plans before execution |
+| plan-enricher | enrich-plan | `/nx:enrich-plan` | sonnet | Enrich beads with audit findings and execution context |
+| strategic-planner | strategic-planning | `/nx:create-plan` | opus | Implementation planning, task decomposition |
+| test-validator | test-validation | `/nx:test-validate` | sonnet | Test coverage and quality validation |
 
 ## Standard Pipelines
 
@@ -191,23 +191,23 @@ Defined in `registry.yaml`:
 ## Slash Commands
 
 **Agent commands** (`/command → agent`):
-- `/research` → deep-research-synthesizer
-- `/create-plan` → strategic-planner
-- `/plan-audit` → plan-auditor
-- `/analyze-code` → codebase-deep-analyzer
-- `/review-code` → code-review-expert
-- `/test-validate` → test-validator
-- `/implement` → developer
-- `/debug` → debugger
-- `/architecture` → architect-planner
-- `/orchestrate` → orchestrator
-- `/knowledge-tidy` → knowledge-tidier
-- `/pdf-process` → pdf-chromadb-processor
-- `/deep-analysis` → deep-analyst
-- `/substantive-critique` → substantive-critic
-- `/enrich-plan` → plan-enricher
+- `/nx:research` → deep-research-synthesizer
+- `/nx:create-plan` → strategic-planner
+- `/nx:plan-audit` → plan-auditor
+- `/nx:analyze-code` → codebase-deep-analyzer
+- `/nx:review-code` → code-review-expert
+- `/nx:test-validate` → test-validator
+- `/nx:implement` → developer
+- `/nx:debug` → debugger
+- `/nx:architecture` → architect-planner
+- `/nx:orchestrate` → orchestrator
+- `/nx:knowledge-tidy` → knowledge-tidier
+- `/nx:pdf-process` → pdf-chromadb-processor
+- `/nx:deep-analysis` → deep-analyst
+- `/nx:substantive-critique` → substantive-critic
+- `/nx:enrich-plan` → plan-enricher
 
-**RDR commands**: `/rdr-create`, `/rdr-list`, `/rdr-show`, `/rdr-research`, `/rdr-gate`, `/rdr-accept`, `/rdr-close`
+**RDR commands**: `/nx:rdr-create`, `/nx:rdr-list`, `/nx:rdr-show`, `/nx:rdr-research`, `/nx:rdr-gate`, `/nx:rdr-accept`, `/nx:rdr-close`
 
 
 ## MCP Servers

--- a/nx/agents/plan-enricher.md
+++ b/nx/agents/plan-enricher.md
@@ -8,8 +8,8 @@ color: emerald
 
 ## Usage Examples
 
-- **RDR Planning Chain**: Receives relay from plan-auditor after `/rdr-accept` dispatches planning → enriches every bead with audit findings, file paths, and execution context
-- **Standalone Same-Session**: User runs `/plan-audit` then `/enrich-plan` manually → reads T1 scratch for audit context and enriches beads
+- **RDR Planning Chain**: Receives relay from plan-auditor after `/nx:rdr-accept` dispatches planning → enriches every bead with audit findings, file paths, and execution context
+- **Standalone Same-Session**: User runs `/nx:plan-audit` then `/nx:enrich-plan` manually → reads T1 scratch for audit context and enriches beads
 - **Degraded Mode**: T1 has no audit findings → warns user and proceeds with context-only enrichment (codebase search, file paths, line numbers)
 
 ---

--- a/nx/agents/strategic-planner.md
+++ b/nx/agents/strategic-planner.md
@@ -29,7 +29,7 @@ Before starting, validate the relay contains all required fields per [RELAY_TEMP
    the pattern `RDR-\d+`. For each match, run:
    Use memory_get tool: project="{repo}_rdr", title="NNN"
    If status is not `accepted` or `closed`, warn the user:
-   "RDR-NNN is {status}. Consider running `/rdr-gate NNN` and `/rdr-accept NNN` first."
+   "RDR-NNN is {status}. Consider running `/nx:rdr-gate NNN` and `/nx:rdr-accept NNN` first."
    If the lookup fails or returns no result, warn and proceed (fail-open).
    If no RDR pattern is found, proceed normally.
 

--- a/nx/commands/enrich-plan.md
+++ b/nx/commands/enrich-plan.md
@@ -36,7 +36,7 @@ Invoke the **enrich-plan** skill with the following relay. Fill in dynamic field
 **Bead**: [fill from epic bead above or 'none']
 
 ### Input Artifacts
-- nx scratch: audit findings, plan structure, bead IDs (from same-session /plan-audit)
+- nx scratch: audit findings, plan structure, bead IDs (from same-session /nx:plan-audit)
 - Files: [fill from key files referenced in plan]
 
 ### Deliverable

--- a/nx/commands/rdr-accept.md
+++ b/nx/commands/rdr-accept.md
@@ -110,7 +110,7 @@ if not rdr_path.exists():
 id_match = re.search(r'\d+', args)
 
 if not id_match:
-    print("> **Usage**: `/rdr-accept <id>` — e.g. `/rdr-accept 003` or `/rdr-accept RDR-003`")
+    print("> **Usage**: `/nx:rdr-accept <id>` — e.g. `/nx:rdr-accept 003` or `/nx:rdr-accept RDR-003`")
     print()
     rdrs = get_all_rdrs(rdr_path)
     draft_rdrs = [r for r in rdrs if r['status'].lower() == 'draft']
@@ -169,7 +169,7 @@ elif t2_status == 'accepted' and current_status.lower() != 'accepted':
 # Check T2 gate result
 print("### T2 Gate Result")
 print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}-gate-latest\" to retrieve gate result.")
-print(f"If no gate record exists, run `/rdr-gate {t2_key}` first.")
+print(f"If no gate record exists, run `/nx:rdr-gate {t2_key}` first.")
 print()
 
 # T2 metadata (for context)

--- a/nx/commands/rdr-close.md
+++ b/nx/commands/rdr-close.md
@@ -118,7 +118,7 @@ args_clean = re.sub(r'--force', '', args_clean).strip()
 id_match = re.search(r'\d+', args_clean)
 
 if not id_match:
-    print("> **Usage**: `/rdr-close <id> [--reason implemented|reverted|abandoned|superseded]`")
+    print("> **Usage**: `/nx:rdr-close <id> [--reason implemented|reverted|abandoned|superseded]`")
     print()
     rdrs = get_all_rdrs(rdr_path)
     print("### Open/Draft RDRs")
@@ -156,7 +156,7 @@ if current_status.lower() not in ('accepted', 'final'):
         print()
     else:
         print(f"> **BLOCKED**: RDR status is `{current_status}`. Close requires status `accepted` or `final`.")
-        print(f"> Run `/rdr-gate` to validate, or use `--force` to override.")
+        print(f"> Run `/nx:rdr-gate` to validate, or use `--force` to override.")
         print()
         sys.exit(0)
 

--- a/nx/commands/rdr-gate.md
+++ b/nx/commands/rdr-gate.md
@@ -111,7 +111,7 @@ if not rdr_path.exists():
 id_match = re.search(r'\d+', args)
 
 if not id_match:
-    print("> **Usage**: `/rdr-gate <id>` — e.g. `/rdr-gate 003` or `/rdr-gate RDR-003`")
+    print("> **Usage**: `/nx:rdr-gate <id>` — e.g. `/nx:rdr-gate 003` or `/nx:rdr-gate RDR-003`")
     print()
     rdrs = get_all_rdrs(rdr_path)
     print("### Available RDRs")
@@ -174,7 +174,7 @@ print()
 # T2 research findings
 print("### T2 Research Findings")
 print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"\" to list all entries, then filter for {t2_key}-research* titles.")
-print(f"If no research findings exist, run `/rdr-research add {t2_key}` to record findings before gating.")
+print(f"If no research findings exist, run `/nx:rdr-research add {t2_key}` to record findings before gating.")
 print(f"Use `--skip-research` in your gate command to override.")
 PYEOF
 }
@@ -204,5 +204,5 @@ All data is pre-loaded above — no additional tool calls needed.
   summary: "One-sentence summary of gate result"
   ```
   This overwrites any previous gate result for this RDR, so only the latest gate run is stored.
-- **If PASSED**, print: `> Run '/rdr-accept <id>' to accept this RDR.`
+- **If PASSED**, print: `> Run '/nx:rdr-accept <id>' to accept this RDR.`
 - If no ID given, show the available RDR table above and prompt for an ID.

--- a/nx/commands/rdr-research.md
+++ b/nx/commands/rdr-research.md
@@ -181,7 +181,7 @@ else:
     else:
         print(f"No RDRs found in `{rdr_dir}`")
     print()
-    print("> **Usage**: `/rdr-research <id>` or `/rdr-research add <id>` or `/rdr-research verify <id> <seq>`")
+    print("> **Usage**: `/nx:rdr-research <id>` or `/nx:rdr-research add <id>` or `/nx:rdr-research verify <id> <seq>`")
 PYEOF
 }
 

--- a/nx/hooks/scripts/bead_context_hook.py
+++ b/nx/hooks/scripts/bead_context_hook.py
@@ -37,7 +37,7 @@ def main():
         messages.append(
             f"Bead references {rdr_list}. "
             f"Verify RDR status before implementation: "
-            f"/rdr-show {rdr_refs[0]}"
+            f"/nx:rdr-show {rdr_refs[0]}"
         )
 
     if messages:

--- a/nx/skills/brainstorming-gate/SKILL.md
+++ b/nx/skills/brainstorming-gate/SKILL.md
@@ -59,7 +59,7 @@ digraph brainstorming {
    pattern `RDR-\d+`. For each match:
    - Use memory_get tool: project="{repo}_rdr", title="NNN"
    - If status is not `accepted` or `closed`, **warn the user**:
-     "RDR-NNN is still {status}. Run `/rdr-gate NNN` and `/rdr-accept NNN`
+     "RDR-NNN is still {status}. Run `/nx:rdr-gate NNN` and `/nx:rdr-accept NNN`
      before planning implementation."
    - If the lookup fails or returns no result, warn and proceed (fail-open).
    - If no `RDR-\d+` pattern is found, proceed normally.

--- a/nx/skills/enrich-plan/SKILL.md
+++ b/nx/skills/enrich-plan/SKILL.md
@@ -11,8 +11,8 @@ Delegates to the **plan-enricher** agent (sonnet). See [registry.yaml](../../reg
 
 - After plan-auditor completes in RDR planning chain (automatic relay)
 - User says "enrich beads", "groom plan", "enrich plan"
-- User invokes `/enrich-plan`
-- After `/plan-audit` when beads need audit findings folded in
+- User invokes `/nx:enrich-plan`
+- After `/nx:plan-audit` when beads need audit findings folded in
 
 ## Agent Invocation
 
@@ -25,7 +25,7 @@ Use the Task tool to invoke **plan-enricher**:
 **Bead**: [epic bead ID] or 'none'
 
 ### Input Artifacts
-- nx scratch: audit findings, plan structure, bead IDs (from same-session /plan-audit)
+- nx scratch: audit findings, plan structure, bead IDs (from same-session /nx:plan-audit)
 - Files: [RDR file path if known]
 
 ### Deliverable
@@ -41,7 +41,7 @@ For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agen
 
 ## Session Scope Note
 
-T1 scratch is session-scoped. Standalone invocation only works within the same session where `/plan-audit` ran. Cross-session use requires re-running `/plan-audit` first to populate T1 with audit findings.
+T1 scratch is session-scoped. Standalone invocation only works within the same session where `/nx:plan-audit` ran. Cross-session use requires re-running `/nx:plan-audit` first to populate T1 with audit findings.
 
 ## Agent-Specific PRODUCE
 

--- a/nx/skills/rdr-accept/SKILL.md
+++ b/nx/skills/rdr-accept/SKILL.md
@@ -10,7 +10,7 @@ Accepts an RDR after it passes the gate. This is the author/reviewer decision po
 ## When This Skill Activates
 
 - User says "accept this RDR", "mark as accepted", "approve the RDR"
-- User invokes `/rdr-accept`
+- User invokes `/nx:rdr-accept`
 - Gate returns PASSED and user confirms acceptance
 
 ## Input

--- a/nx/skills/rdr-close/SKILL.md
+++ b/nx/skills/rdr-close/SKILL.md
@@ -10,7 +10,7 @@ Reports bead status as advisory. Optionally delegates post-mortem archival to th
 ## When This Skill Activates
 
 - User says "close this RDR", "RDR done", "finish RDR"
-- User invokes `/rdr-close`
+- User invokes `/nx:rdr-close`
 - Implementation is complete and the RDR should be finalized
 
 ## Inputs
@@ -73,7 +73,7 @@ If T2 record has no `epic_bead` field (user skipped planning at accept time):
 ### Step 4: Update State
 
 1. Update T2 record: Use memory_put tool: content="... (same fields, status: Implemented, closed: YYYY-MM-DD, close_reason: Implemented, archived: true)", project="{repo}_rdr", title="NNN", ttl="permanent", tags="rdr,{type},closed"
-   If T3 archive fails, set `archived: false` — retryable by re-running `/rdr-close`
+   If T3 archive fails, set `archived: false` — retryable by re-running `/nx:rdr-close`
 
 2. Update status in RDR markdown metadata
 3. Regenerate `docs/rdr/README.md` index
@@ -111,7 +111,7 @@ Dispatch `knowledge-tidier` agent for post-mortem archival if the post-mortem co
 The close operation performs multiple state mutations. If any step fails:
 - Each step emits clear status (e.g., "T2 updated ✓", "Bead advisory ✓", "T3 archive ✗ FAILED")
 - T2 `archived` flag tracks whether T3 archival succeeded
-- Re-running `/rdr-close` is idempotent: checks T2 state and skips completed steps
+- Re-running `/nx:rdr-close` is idempotent: checks T2 state and skips completed steps
 
 ## Relay Template (Use This Format)
 

--- a/nx/skills/rdr-create/SKILL.md
+++ b/nx/skills/rdr-create/SKILL.md
@@ -8,7 +8,7 @@ description: Use when starting a new research-design-review document to think th
 ## When This Skill Activates
 
 - User says "create an RDR", "new RDR", "start an RDR"
-- User invokes `/rdr-create`
+- User invokes `/nx:rdr-create`
 - User wants to think through a technical decision — before, during, or after building
 
 ## Inputs
@@ -97,7 +97,7 @@ Created RDR PREFIX-NNN: "Title"
 File: docs/rdr/NNN-kebab-title.md
 Status: Draft
 
-Next: Fill in Problem Statement and Context, then use /rdr-research to add findings.
+Next: Fill in Problem Statement and Context, then use /nx:rdr-research to add findings.
 ```
 
 ## Success Criteria
@@ -114,7 +114,7 @@ Next: Fill in Problem Statement and Context, then use /rdr-research to add findi
 
 This skill produces outputs directly (no agent delegation):
 
-- **T3 knowledge**: Not produced at create time (archival happens at `/rdr-close`)
+- **T3 knowledge**: Not produced at create time (archival happens at `/nx:rdr-close`)
 - **T2 memory**: RDR metadata record via memory_put tool: project="{repo}_rdr", title="{NNN}", ttl="permanent", tags="rdr,{type}"
 - **T1 scratch**: Working notes during creation via scratch tool: action="put", content="RDR NNN: scaffolding", tags="rdr,create" (optional, for tracking multi-step creation)
 - **Filesystem**: `docs/rdr/NNN-kebab-title.md`, updated `docs/rdr/README.md`
@@ -123,7 +123,7 @@ This skill produces outputs directly (no agent delegation):
 
 ## Does NOT
 
-- Create beads (that happens at `/rdr-close`)
-- Run validation (that happens at `/rdr-gate`)
+- Create beads (that happens at `/nx:rdr-close`)
+- Run validation (that happens at `/nx:rdr-gate`)
 - Commit (user decides when to commit)
 - Run `nx index rdr` (user can do this manually or it happens at gate/close)

--- a/nx/skills/rdr-gate/SKILL.md
+++ b/nx/skills/rdr-gate/SKILL.md
@@ -12,7 +12,7 @@ Delegates Layer 3 to the **substantive-critic** agent (sonnet). See [registry.ya
 ## When This Skill Activates
 
 - User says "gate this RDR", "finalization check", "is this RDR ready?"
-- User invokes `/rdr-gate`
+- User invokes `/nx:rdr-gate`
 - User wants to validate an RDR before locking it as Final
 
 ## Input
@@ -114,9 +114,9 @@ If no collections found: "No prior RDRs indexed. Cross-project prior-art search 
 
 1. Write gate result to T2: Use memory_put tool: content="outcome: PASSED\ndate: YYYY-MM-DD\ncritical_count: 0\nsignificant_count: N\nobservation_count: N\nsummary: One-sentence summary", project="{repo}_rdr", title="{id}-gate-latest", ttl="permanent", tags="rdr,gate"
 2. Append gate findings to the RDR's Revision History section
-3. Print: `> Run '/rdr-accept <id>' to accept this RDR.`
+3. Print: `> Run '/nx:rdr-accept <id>' to accept this RDR.`
 
-Status remains **Draft** until the author explicitly accepts via `/rdr-accept`.
+Status remains **Draft** until the author explicitly accepts via `/nx:rdr-accept`.
 
 ### On Fail
 

--- a/nx/skills/rdr-list/SKILL.md
+++ b/nx/skills/rdr-list/SKILL.md
@@ -8,12 +8,12 @@ description: Use when needing to see all RDRs in the project with their status, 
 ## When This Skill Activates
 
 - User says "list RDRs", "show RDRs", "what RDRs exist"
-- User invokes `/rdr-list`
+- User invokes `/nx:rdr-list`
 - User asks about the state of planning documents
 
 ## Behavior
 
-**All data is pre-loaded in the command context.** Do NOT make additional Bash, Read, or tool calls — the `/rdr-list` command already gathered:
+**All data is pre-loaded in the command context.** Do NOT make additional Bash, Read, or tool calls — the `/nx:rdr-list` command already gathered:
 
 - Repo name and RDR directory (from `.nexus.yml` or default `docs/rdr`)
 - All RDR files with parsed metadata (title, status, type, priority)

--- a/nx/skills/rdr-research/SKILL.md
+++ b/nx/skills/rdr-research/SKILL.md
@@ -10,7 +10,7 @@ Optionally delegates to **deep-research-synthesizer** (sonnet) for evidence gath
 ## When This Skill Activates
 
 - User says "add research finding", "update RDR research", "verify assumption"
-- User invokes `/rdr-research`
+- User invokes `/nx:rdr-research`
 - User wants to record or classify a discovery during RDR planning
 
 ## Path Detection
@@ -19,7 +19,7 @@ Resolve RDR directory from `.nexus.yml` `indexing.rdr_paths[0]`; default `docs/r
 
 ## Subcommands
 
-### `/rdr-research add <id>`
+### `/nx:rdr-research add <id>`
 
 **Inputs** (prompt the user):
 1. **Finding text**: What was discovered
@@ -40,7 +40,7 @@ Resolve RDR directory from `.nexus.yml` `indexing.rdr_paths[0]`; default `docs/r
      *Source: source description*
    ```
 
-### `/rdr-research status <id>`
+### `/nx:rdr-research status <id>`
 
 1. List T2 entries: Use memory_get tool: project="{repo}_rdr", title=""
 2. Filter titles matching `NNN-research-*`
@@ -54,7 +54,7 @@ Resolve RDR directory from `.nexus.yml` `indexing.rdr_paths[0]`; default `docs/r
      - [seq 6] "Latency under 100ms" (docs only)
    ```
 
-### `/rdr-research verify <id> <finding-seq>`
+### `/nx:rdr-research verify <id> <finding-seq>`
 
 1. Read T2 record: Use memory_get tool: project="{repo}_rdr", title="NNN-research-{seq}"
 2. Prompt for new classification (verified or documented) and updated verification method

--- a/nx/skills/rdr-show/SKILL.md
+++ b/nx/skills/rdr-show/SKILL.md
@@ -8,7 +8,7 @@ description: Use when needing detailed information about a specific RDR includin
 ## When This Skill Activates
 
 - User says "show RDR 003", "RDR details", "what's in RDR 5"
-- User invokes `/rdr-show`
+- User invokes `/nx:rdr-show`
 - User asks about a specific RDR's content or status
 
 ## Behavior
@@ -45,7 +45,7 @@ description: Use when needing detailed information about a specific RDR includin
 (not closed yet)
 ```
 
-7. If the RDR ID is not found, list available RDRs (delegate to `/rdr-list` behavior).
+7. If the RDR ID is not found, list available RDRs (delegate to `/nx:rdr-list` behavior).
 
 ## Success Criteria
 
@@ -53,7 +53,7 @@ description: Use when needing detailed information about a specific RDR includin
 - [ ] Research findings summarized by classification (Verified, Documented, Assumed)
 - [ ] Linked beads shown with status (if `epic_bead` is set in T2)
 - [ ] Supersedes/Superseded-by relationships displayed
-- [ ] Fallback to `/rdr-list` behavior if RDR ID not found
+- [ ] Fallback to `/nx:rdr-list` behavior if RDR ID not found
 
 ## Agent-Specific PRODUCE
 

--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -53,53 +53,53 @@ Use this table to match tasks to skills. When in doubt, check the skill.
 
 | Skill | Command | Invoke when... |
 |-------|---------|----------------|
-| brainstorming-gate | `/brainstorming-gate` | About to implement any feature, build any component, or change any behavior |
+| brainstorming-gate | `/nx:brainstorming-gate` | About to implement any feature, build any component, or change any behavior |
 
 ### Process (guide workflow and quality)
 
 | Skill | Command | Invoke when... |
 |-------|---------|----------------|
-| code-review | `/review-code` | Code changes ready for quality, security, or best practices review |
-| strategic-planning | `/create-plan` | Multi-step work needs decomposition into tasks before any code |
-| plan-validation | `/plan-audit` | A plan exists and needs validation before implementation begins |
-| enrich-plan | `/enrich-plan` | Beads need enrichment with audit findings and execution context after plan-audit |
-| test-validation | `/test-validate` | Implementation complete; test coverage needs verification |
-| substantive-critique | `/substantive-critique` | Architectural decisions, multi-phase plans, or major docs need deep constructive critique |
+| code-review | `/nx:review-code` | Code changes ready for quality, security, or best practices review |
+| strategic-planning | `/nx:create-plan` | Multi-step work needs decomposition into tasks before any code |
+| plan-validation | `/nx:plan-audit` | A plan exists and needs validation before implementation begins |
+| enrich-plan | `/nx:enrich-plan` | Beads need enrichment with audit findings and execution context after plan-audit |
+| test-validation | `/nx:test-validate` | Implementation complete; test coverage needs verification |
+| substantive-critique | `/nx:substantive-critique` | Architectural decisions, multi-phase plans, or major docs need deep constructive critique |
 
 ### Implementation (execute domain-specific work)
 
 | Skill | Command | Invoke when... |
 |-------|---------|----------------|
-| codebase-analysis | `/analyze-code` | Exploring unfamiliar codebase or understanding module structure before changes |
-| deep-analysis | `/deep-analysis` | Surface-level analysis is insufficient; hypothesis-driven investigation needed |
-| research-synthesis | `/research` | Researching unfamiliar topics or comparing technology approaches |
-| architecture | `/architecture` | Complex features need architectural design before implementation |
-| development | `/implement` | Plan approved; implementation work ready to begin |
-| debugging | `/debug` | Tests fail or behavior is non-deterministic, especially after 2+ failed attempts |
+| codebase-analysis | `/nx:analyze-code` | Exploring unfamiliar codebase or understanding module structure before changes |
+| deep-analysis | `/nx:deep-analysis` | Surface-level analysis is insufficient; hypothesis-driven investigation needed |
+| research-synthesis | `/nx:research` | Researching unfamiliar topics or comparing technology approaches |
+| architecture | `/nx:architecture` | Complex features need architectural design before implementation |
+| development | `/nx:implement` | Plan approved; implementation work ready to begin |
+| debugging | `/nx:debug` | Tests fail or behavior is non-deterministic, especially after 2+ failed attempts |
 
 ### RDR Lifecycle (research-design-review documents)
 
 | Skill | Command | Invoke when... |
 |-------|---------|----------------|
-| rdr-create | `/rdr-create` | Starting a new technical decision document |
-| rdr-research | `/rdr-research` | Adding or tracking structured research findings for an active RDR |
-| rdr-list | `/rdr-list` | Listing all RDRs with status, type, and priority |
-| rdr-show | `/rdr-show` | Viewing full details and research findings for a specific RDR |
-| rdr-gate | `/rdr-gate` | RDR appears complete; needs structural + assumption + AI critique check |
-| rdr-accept | `/rdr-accept` | Gate returned PASSED; ready to officially accept the RDR |
-| rdr-close | `/rdr-close` | RDR implemented; close with optional post-mortem and bead status advisory |
+| rdr-create | `/nx:rdr-create` | Starting a new technical decision document |
+| rdr-research | `/nx:rdr-research` | Adding or tracking structured research findings for an active RDR |
+| rdr-list | `/nx:rdr-list` | Listing all RDRs with status, type, and priority |
+| rdr-show | `/nx:rdr-show` | Viewing full details and research findings for a specific RDR |
+| rdr-gate | `/nx:rdr-gate` | RDR appears complete; needs structural + assumption + AI critique check |
+| rdr-accept | `/nx:rdr-accept` | Gate returned PASSED; ready to officially accept the RDR |
+| rdr-close | `/nx:rdr-close` | RDR implemented; close with optional post-mortem and bead status advisory |
 
 ### Standalone Reference
 
 | Skill | Command | Invoke when... |
 |-------|---------|----------------|
-| knowledge-tidying | `/knowledge-tidy` | 3+ validated findings or decisions need persisting to T3 for cross-session reuse |
-| orchestration | `/orchestrate` | After reading this directory, still unsure which agent fits the task |
-| pdf-processing | `/pdf-process` | PDF documents need indexing into nx store for semantic search |
-| nexus | `/nexus` | Running nx commands or unsure which nx subcommand to use |
-| serena-code-nav | `/serena-code-nav` | Navigating code by symbol — finding definitions, callers, type hierarchies, or safe renames |
-| cli-controller | `/cli-controller` | Controlling interactive CLI apps, REPLs, pdb, gdb, or spawning Claude Code instances |
-| writing-nx-skills | `/writing-nx-skills` | Creating new nx plugin skills or editing existing ones |
+| knowledge-tidying | `/nx:knowledge-tidy` | 3+ validated findings or decisions need persisting to T3 for cross-session reuse |
+| orchestration | `/nx:orchestrate` | After reading this directory, still unsure which agent fits the task |
+| pdf-processing | `/nx:pdf-process` | PDF documents need indexing into nx store for semantic search |
+| nexus | `/nx:nexus` | Running nx commands or unsure which nx subcommand to use |
+| serena-code-nav | `/nx:serena-code-nav` | Navigating code by symbol — finding definitions, callers, type hierarchies, or safe renames |
+| cli-controller | `/nx:cli-controller` | Controlling interactive CLI apps, REPLs, pdb, gdb, or spawning Claude Code instances |
+| writing-nx-skills | `/nx:writing-nx-skills` | Creating new nx plugin skills or editing existing ones |
 
 ## Storage Tier Protocol
 
@@ -111,7 +111,7 @@ Use this table to match tasks to skills. When in doubt, check the skill.
 | T2 | Use memory_search tool: query="..." | Project decisions, findings, session context | Before project work — past context and past decisions live here |
 | T1 | Use scratch tool: action="search", query="..." | This session's discoveries, shared across all agents | Before doing work a sibling or parent agent may have already done |
 
-**Write path:** T1 (immediate, shared) → `--persist` flag to T2 (survives session end) → `/knowledge-tidy` to T3 (permanent, cross-project).
+**Write path:** T1 (immediate, shared) → `--persist` flag to T2 (survives session end) → `/nx:knowledge-tidy` to T3 (permanent, cross-project).
 
 ## Red Flags
 


### PR DESCRIPTION
## Summary
- All 19 files in the nx plugin that referenced skills by short name (`/rdr-accept`, `/create-plan`, etc.) now use the fully-qualified form (`/nx:rdr-accept`, `/nx:create-plan`)
- Short-form references don't work because Claude Code requires the `/<plugin>:<skill>` format for plugin-namespaced skills
- Users were seeing suggestions like "Run `/rdr-accept 009`" which failed silently

## Files changed
- 2 agent definitions
- 5 command files  
- 1 hook script (Python)
- 10 skill files
- 1 README

## Not changed (correctly)
- `registry.yaml` — canonical registrations; plugin system auto-prefixes
- `CHANGELOG.md` — historical record
- `TEMPLATE.md` — metadata comment

## Test plan
- [ ] Verify no remaining short-form references: `grep -rn '`/rdr-' nx/ --include='*.md' | grep -v nx: | grep -v CHANGELOG`
- [ ] Verify skills still invoke correctly via `/nx:rdr-list`, `/nx:rdr-show`, etc.