### PR TITLE
chore: close implemented RDRs 034, 036, 037

### DIFF
--- a/docs/rdr/rdr-034-mcp-server-agent-storage.md
+++ b/docs/rdr/rdr-034-mcp-server-agent-storage.md
@@ -2,8 +2,10 @@
 title: "MCP Server for Agent Storage Operations"
 id: RDR-034
 type: Architecture
-status: accepted
+status: closed
 accepted_date: 2026-03-11
+closed_date: 2026-03-19
+close_reason: implemented
 priority: P0
 author: Hal Hildebrand
 reviewed-by: self

--- a/docs/rdr/rdr-036-post-accept-planning-workflow.md
+++ b/docs/rdr/rdr-036-post-accept-planning-workflow.md
@@ -2,7 +2,9 @@
 title: "Post-Accept Planning Workflow"
 id: RDR-036
 type: enhancement
-status: accepted
+status: closed
+closed_date: 2026-03-19
+close_reason: implemented
 priority: P2
 author: Hal Hildebrand
 reviewed-by: self

--- a/docs/rdr/rdr-037-t3-database-consolidation.md
+++ b/docs/rdr/rdr-037-t3-database-consolidation.md
@@ -2,7 +2,9 @@
 title: "T3 Database Consolidation"
 id: RDR-037
 type: enhancement
-status: accepted
+status: closed
+closed_date: 2026-03-19
+close_reason: implemented
 priority: P2
 author: Hal Hildebrand
 reviewed-by: self


### PR DESCRIPTION
## Summary
- Close RDR-034 (MCP Server for Agent Storage Operations) — implemented via PR #103
- Close RDR-036 (Post-Accept Planning Workflow) — implemented via PR #105
- Close RDR-037 (T3 Database Consolidation) — implemented in multi-phase commits

Frontmatter-only changes: `status: closed`, `closed_date: 2026-03-19`, `close_reason: implemented`.