### PR TITLE
fix(tests): patch get_credential to prevent config.yml leak

### DIFF
--- a/tests/test_store_cmd.py
+++ b/tests/test_store_cmd.py
@@ -36,7 +36,10 @@ def test_store_put_missing_chroma_api_key(
     src = tmp_path / "f.txt"
     src.write_text("content")
 
-    result = runner.invoke(main, ["store", "put", str(src)])
+    # Patch get_credential so ~/.config/nexus/config.yml doesn't leak in
+    creds = {"chroma_database": "d", "voyage_api_key": "vk", "chroma_api_key": ""}
+    with patch("nexus.config.get_credential", side_effect=lambda k: creds.get(k, "")):
+        result = runner.invoke(main, ["store", "put", str(src)])
 
     assert result.exit_code != 0
     assert "chroma_api_key" in result.output.lower()

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -17,8 +17,12 @@ def mock_chromadb():
     The side_effect function simulates the probe-first init:
     - database ending in ``_code`` raises NotFoundError (no old layout)
     - all other databases return the mock client (new single-DB layout)
+
+    Also patches ``get_credential`` so the real ``~/.config/nexus/config.yml``
+    (which may contain ``migrated: '1'``) doesn't leak into cloud-mode tests.
     """
-    with patch("nexus.db.t3.chromadb") as m:
+    with patch("nexus.db.t3.chromadb") as m, \
+         patch("nexus.db.t3.get_credential", return_value=""):
         mock_client = MagicMock()
 
         def _cloud_client_factory(*args, **kwargs):
@@ -73,7 +77,7 @@ def test_old_layout_detected(mock_chromadb: tuple) -> None:
 def test_migration_flag_skips_probe(mock_chromadb: tuple) -> None:
     """NX_MIGRATED=1 skips the probe and connects directly to {base}."""
     chromadb_m, _ = mock_chromadb
-    with patch.dict(os.environ, {"NX_MIGRATED": "1"}):
+    with patch("nexus.db.t3.get_credential", side_effect=lambda k: "1" if k == "migrated" else ""):
         db = T3Database(tenant="t", database="mydb", api_key="k")
 
     # Only one CloudClient call — no probe


### PR DESCRIPTION
## Summary
- Patches `get_credential` in `mock_chromadb` fixture and store_cmd test so `~/.config/nexus/config.yml` doesn't leak `migrated: '1'` and `chroma_api_key` into cloud-mode tests
- Fixes 5 spurious test failures (`test_cloudclient_init`, `test_old_layout_detected`, `test_probe_auth_error_wraps_as_runtime_error`, `test_make_t3_uses_credentials`, `test_store_put_missing_chroma_api_key`)

## Test plan
- [x] Full suite: 2280 passed, 0 failed, 9 skipped