### PR TITLE
fix(hooks): guard StopFailure side effects behind CLAUDECODE env

### DIFF
--- a/nx/hooks/scripts/stop_failure_hook.py
+++ b/nx/hooks/scripts/stop_failure_hook.py
@@ -66,6 +66,12 @@ def main() -> None:
         _debug(f"unknown error type: {error_type}, treating as 'unknown'")
         error_type = "unknown"
 
+    # Only run side effects inside a real Claude Code session.
+    # Tests invoke us via subprocess but don't set CLAUDECODE=1.
+    if not os.environ.get("CLAUDECODE"):
+        _debug("not in Claude Code session (CLAUDECODE not set), skipping side effects")
+        return
+
     if not shutil.which("bd"):
         _debug("bd not on PATH, skipping")
         return

--- a/tests/hooks/test_stop_failure_hook.py
+++ b/tests/hooks/test_stop_failure_hook.py
@@ -107,3 +107,13 @@ class TestStopFailureHook:
         })
         result = _run_hook(payload)
         assert result.returncode == 0
+
+    def test_skips_side_effects_without_claudecode_env(self) -> None:
+        """Without CLAUDECODE=1, script must not call bd (no junk beads)."""
+        # Ensure CLAUDECODE is NOT set
+        result = _run_hook(
+            _make_payload("rate_limit"),
+            env_overrides={"CLAUDECODE": "", "NX_HOOK_DEBUG": "1"},
+        )
+        assert result.returncode == 0
+        assert "skipping side effects" in result.stderr.lower()


### PR DESCRIPTION
## Summary
- StopFailure hook creates junk beads/memories when tests invoke it via subprocess, because `bd` is on PATH
- Added `CLAUDECODE` env var guard — Claude Code sets this in all hook processes, so side effects only fire in real sessions
- Tests don't set `CLAUDECODE=1`, so they verify exit behavior without polluting beads

## Test plan
- [x] All 23 hook tests pass
- [x] New `test_skips_side_effects_without_claudecode_env` verifies guard with debug output
- [x] No more junk `stop-failure-*` beads or `Rate limit hit` bugs after test runs