### PR TITLE
fix(nx): prevent planning chain bypass and bd update content corruption

### DIFF
--- a/nx/agents/plan-enricher.md
+++ b/nx/agents/plan-enricher.md
@@ -114,10 +114,13 @@ For each child bead, update its description with:
 
 ### Step 4: Update Beads
 
-For each enriched bead:
-```bash
-bd update <id> --description "enriched content"
-```
+For each enriched bead, two actions in sequence:
+
+**Step 4a** — Write enriched content to a temp file using the **Write tool** (file_path: `/tmp/bead-<id>.md`, content: the enriched markdown). Do NOT use echo, cat, or heredoc — use the Write tool.
+
+**Step 4b** — Update the bead from the file: `bd update <id> --body-file /tmp/bead-<id>.md`
+
+**IMPORTANT**: Do NOT use `--description "..."` for multi-line or markdown content — shell escaping silently corrupts backticks, `$variables`, and nested quotes without raising an error. Always use `--body-file`.
 
 ## T2 Persistence
 
@@ -154,7 +157,7 @@ This agent follows the [Shared Context Protocol](./_shared/CONTEXT_PROTOCOL.md).
 See [ERROR_HANDLING.md](./_shared/ERROR_HANDLING.md) for common error patterns and recovery.
 
 ### Agent-Specific PRODUCE
-- **Enriched Beads**: Updated via `bd update <id> --description "..."` with execution-ready context
+- **Enriched Beads**: Updated via Write tool → `bd update <id> --body-file /tmp/bead-<id>.md` with execution-ready context
 - **T2 memory**: Epic bead ID written via memory_put tool: project="{repo}_rdr", title="NNN"
 - **T1 scratch**: Enrichment summary via scratch tool: action="put", tags="enrichment-complete"
 - **Console output**: Enriched plan summary table
@@ -168,7 +171,7 @@ Store using these naming conventions:
 **CRITICAL**: Complete all data persistence BEFORE generating final response.
 
 **Sequence** (follow strictly):
-1. **Update All Beads**: Run `bd update` for every enriched bead
+1. **Update All Beads**: For each bead — Write content to `/tmp/bead-<id>.md` via Write tool, then `bd update <id> --body-file /tmp/bead-<id>.md` (never `--description`)
 2. **Write T2 Record**: Store epic bead ID and enrichment metadata via memory_put tool
 3. **Write T1 Summary**: Store enrichment summary to scratch
 4. **Verify Persistence**: Confirm beads updated (bd show <id> for sample), T2 written (memory_get)

--- a/nx/commands/rdr-accept.md
+++ b/nx/commands/rdr-accept.md
@@ -133,50 +133,26 @@ if not rdr_file:
 fm, text = parse_frontmatter(rdr_file)
 title = fm.get('title', fm.get('name', rdr_file.stem))
 current_status = fm.get('status', '?')
+rdr_type = fm.get('type', '?')
 rdr_num = re.search(r'\d+', rdr_file.stem)
 t2_key = rdr_num.group(0) if rdr_num else rdr_file.stem
 
 print(f"### RDR: {rdr_file.name}")
-print(f"**Title:** {title}  **Current Status:** {current_status}")
+print(f"**RDR ID:** {t2_key}  **Title:** {title}  **Type:** {rdr_type}  **File Status:** {current_status}")
 print()
 
-# Check current status — only Draft can be accepted (but check T2 for two-way idempotency)
+# Accepted status is allowed — agent handles idempotency in Step 1
 if current_status.lower() not in ('draft', 'accepted'):
     print(f"> **BLOCKED**: RDR status is `{current_status}`. Only Draft RDRs can be accepted.")
     sys.exit(0)
 
-# Check T2 status for idempotency / self-healing
-# Use memory_get tool: project="{repo_name}_rdr", title="{t2_key}" to retrieve T2 status
-t2_status = None
-print(f"**T2 lookup needed**: Use memory_get tool: project=\"{repo_name}_rdr\", title=\"{t2_key}\"")
+# T2 lookups — agent must call these MCP tools and use the results in the Action section
+print("### T2 Lookups (call these before executing Action steps)")
 print()
-
-# Two-way idempotency: both agree on accepted → true no-op
-if current_status.lower() == 'accepted' and t2_status == 'accepted':
-    print(f"> RDR is already accepted (file and T2 agree). Nothing to do.")
-    sys.exit(0)
-# Self-healing: file=accepted but T2 behind → flag for Action to repair T2
-elif current_status.lower() == 'accepted' and t2_status != 'accepted':
-    print(f"> **Self-healing needed**: file shows `accepted` but T2 shows `{t2_status}`.")
-    print(f"> Action will update T2 to match file.")
-    print()
-# Self-healing: T2=accepted but file behind → flag for Action to repair file
-elif t2_status == 'accepted' and current_status.lower() != 'accepted':
-    print(f"> **Self-healing needed**: T2 shows `accepted` but file shows `{current_status}`.")
-    print(f"> Action will update file to match T2.")
-    print()
-
-# Check T2 gate result
-print("### T2 Gate Result")
-print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}-gate-latest\" to retrieve gate result.")
-print(f"If no gate record exists, run `/nx:rdr-gate {t2_key}` first.")
+print(f"1. **T2 metadata**: Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}\"")
+print(f"2. **T2 gate result**: Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}-gate-latest\"")
+print(f"   If no gate record exists, run `/nx:rdr-gate {t2_key}` first.")
 print()
-
-# T2 metadata (for context)
-print("### T2 Metadata")
-print(f"Use **memory_get** tool: project=\"{repo_name}_rdr\", title=\"{t2_key}\" to retrieve T2 metadata.")
-print()
-
 print(f"**RDR file path:** `{rdr_file}`")
 print()
 
@@ -185,16 +161,22 @@ ip_match = re.search(
     r'^## Implementation Plan\s*\n(.*?)(?=^## |\Z)',
     text, re.MULTILINE | re.DOTALL)
 phase_count = 0
-if ip_match:
+has_impl_plan = ip_match is not None
+if has_impl_plan:
     phase_count = len(re.findall(r'^### Phase', ip_match.group(1), re.MULTILINE))
 
 print("### Planning Handoff")
 print(f"**Phase count detected:** {phase_count}")
+print(f"**Has Implementation Plan section:** {'yes' if has_impl_plan else 'no'}")
 if phase_count >= 2:
     print("**Recommendation:** Invoke strategic planner (multi-phase RDR)")
     print("**Default:** yes")
+elif not has_impl_plan:
+    print("**Warning:** No Implementation Plan section detected — this RDR may not be ready for planning.")
+    print("**Recommendation:** Skip planning")
+    print("**Default:** no")
 else:
-    print("**Recommendation:** Skip planning (single-phase or no implementation plan)")
+    print("**Recommendation:** Skip planning (single-phase)")
     print("**Default:** no")
 print()
 PYEOF
@@ -206,39 +188,75 @@ $ARGUMENTS
 
 ## Action
 
-All data is pre-loaded above — no additional tool calls needed.
+> **PROHIBITION — PLANNING CHAIN INTEGRITY**
+> You MUST NOT create beads, write plans, enrich beads, or perform any planning/enrichment work yourself.
+> You are the **orchestrator only**. Running `bd create`, `bd dep add`, `bd update --description`,
+> or writing plan content in the Planning Chain is a HARD STOP — halt and report the error.
+> Only the dispatched subagents (strategic-planner, plan-auditor, plan-enricher) do this work.
+> Doing it yourself bypasses the audit and enrichment chain, producing unvalidated plans.
+>
+> **SUBAGENT FAILURE**: If any subagent in the chain fails or returns partial results,
+> you MUST NOT compensate by doing the subagent's work yourself. Report the failure,
+> state which step broke, and provide the retry command. "Let me finish this directly"
+> is the exact behavior this prohibition exists to prevent.
+>
+> If the Agent tool is not available (e.g., you are a subagent), report:
+> "Cannot dispatch planning chain — Agent tool unavailable. Run /nx:rdr-accept from the main conversation."
 
-- **Verify gate**: Check that the T2 Gate Result above shows `outcome: "PASSED"`. If it shows `BLOCKED` or is missing, report **BLOCKED** and stop.
-- **Self-healing check**: If T2 metadata already shows `status: "accepted"` but the file shows `draft`, update the file to match T2 (repair the file). Report the repair and stop.
-- **Update T2 first** (T2 is the process authority):
-  Use **memory_put** tool: content="... (same fields from T2 Metadata above, with status: \"accepted\", accepted_date: \"YYYY-MM-DD\")", project="{repo_name}_rdr", title="{id}", ttl="permanent", tags="rdr,{type}"
-- **Update the RDR file**: Change `status: draft` to `status: accepted` in the YAML frontmatter. Add `accepted_date: YYYY-MM-DD` if not present.
-- **Update `reviewed-by`**: If `reviewed-by` is empty or placeholder, set to `self` (solo review).
-- **Regenerate README**: Update `{rdr_dir}/README.md` index to reflect the new status.
-- **Stage files**: `git add` the modified RDR file and README.
-- **Step 7 (Planning handoff)**: Use the phase count and recommendation above.
-  - Ask: "Invoke strategic planner to build execution beads? (y/n) [default from above]"
-  - **If no:** Skip — accept is complete. Print: `> RDR {id} accepted. Ready for implementation.`
-  - **If yes — execute the full chain (3 sequential dispatches):**
+All RDR metadata is pre-loaded above. Step 8 requires additional tool calls for planning dispatch.
 
-    **Step 7a — Write T1 context:**
-    Write T1 scratch entry: Use scratch tool: action="put", content="RDR {id}: planning context for {title}. RDR file: {rdr_file}", tags="rdr-planning-context,rdr-{id}"
+**Notation**: All references to `<ID>` below mean the **RDR ID** value from the script output (e.g. `027`). All references to `<type>` mean the **Type** value (e.g. `design`). Substitute with the actual values.
 
-    **Step 7b — Dispatch strategic-planner:**
-    Dispatch `nx:strategic-planner` agent (via Agent tool, subagent_type="nx:strategic-planner") with prompt:
-    > Create phased execution plan for RDR-{id}: {title}. RDR file: {rdr_file}. Read the RDR content for implementation phases. Create epic and task beads with dependencies.
-    **Wait for the planner to complete before proceeding.**
-    Note the plan file path and bead IDs from the planner's output.
+**Before executing steps below**, call both T2 lookups listed above (memory_get for metadata and gate result). You need these results for Steps 1–2.
 
-    **Step 7c — Dispatch plan-auditor:**
-    After the planner completes, dispatch `nx:plan-auditor` agent (via Agent tool, subagent_type="nx:plan-auditor") with prompt:
-    > Audit the execution plan just created for RDR-{id}: {title}. Check T1 scratch for rdr-planning-context. Validate the plan against the codebase. Check beads created by the planner.
-    **Wait for the auditor to complete before proceeding.**
+- **Step 1 — T2 idempotency and self-healing**: Compare the **File Status** (from script output above) against the **T2 metadata status** (from your memory_get call):
+  - **Both show `accepted`**: True no-op. Print `> RDR is already accepted (file and T2 agree). Nothing to do.` and stop.
+  - **File shows `accepted`, T2 does not**: Self-healing — update T2 to match file. Print `> Self-healing: file shows accepted but T2 shows <actual-T2-status>. Updating T2.` Use memory_put to set T2 status to `accepted`. Then stop (no further steps needed).
+  - **T2 shows `accepted`, file shows `draft`**: Self-healing — update file to match T2. Print `> Self-healing: T2 shows accepted but file shows draft. Updating file.` Change file frontmatter to `status: accepted` and `git add` the updated file. Then stop.
+  - **File shows `draft` and T2 shows `draft` (or T2 record not found)**: Normal flow — proceed to Step 2.
+- **Step 2 — Verify gate**: Check that the T2 gate result (from your memory_get call) shows `outcome: "PASSED"`. If the record exists but `outcome` is absent or is not `"PASSED"`, treat as BLOCKED. If no gate record exists at all, also BLOCKED. Report **BLOCKED** and stop. Print: `> Run /nx:rdr-gate <ID> first.`
+- **Step 3 — Update T2** (T2 is the process authority):
+  Use **memory_put** tool: content="status: accepted\naccepted_date: <today YYYY-MM-DD>\ntitle: <title>\ntype: <type>\n(preserve other fields from T2 Metadata lookup)", project="<repo-name>_rdr" (same project as in the T2 Lookups above), title="<ID>", ttl="permanent", tags="rdr,<type>"
+- **Step 4 — Update the RDR file**: Change `status: draft` to `status: accepted` in the YAML frontmatter. Add `accepted_date: YYYY-MM-DD` if not present.
+- **Step 5 — Update `reviewed-by`**: If `reviewed-by` is empty or placeholder, set to `self` (solo review).
+- **Step 6 — Regenerate README**: Update `<rdr-dir>/README.md` (the RDR directory from the script output header) index to reflect the new status.
+- **Step 7 — Stage files**: `git add` the modified RDR file and README.
+- **Step 8 — Planning handoff**: Use the phase count and recommendation from the script output above.
+  - **If phase_count >= 2**: The planning chain is **MANDATORY**. Do not ask — print `> Multi-phase RDR — dispatching planning chain (mandatory).` and proceed to the Planning Chain below.
+  - **If phase_count < 2**: Ask: "Invoke strategic planner to build execution beads? (y/n) [default: no]"
+    - **If no:** Accept is complete. Print: `> RDR <ID> accepted. Ready for implementation.`
+    - **If yes:** Proceed to the Planning Chain below.
 
-    **Step 7d — Dispatch plan-enricher:**
-    After the auditor completes, dispatch `nx:plan-enricher` agent (via Agent tool, subagent_type="nx:plan-enricher") with prompt:
-    > Enrich all beads for RDR-{id}: {title} with audit findings from T1 scratch. Write epic bead ID to T2.
-    **Wait for the enricher to complete.**
+---
 
-    **Step 7e — Report chain completion:**
-    Print: `> RDR {id} accepted. Planning chain complete: planner → auditor → enricher. Use 'bd ready' to see executable tasks.`
+### Planning Chain (triggered from Step 8 above)
+
+Execute these steps sequentially when the planning handoff triggers (mandatory multi-phase or user opted in). **Reminder: you are the orchestrator. Do NOT create beads or plans yourself.**
+
+**Step 8a — Write T1 context:**
+Write T1 scratch entry: Use scratch tool: action="put", content="RDR-<ID>: planning context for <title>. RDR file: <RDR-file-path>", tags="rdr-planning-context,rdr-<ID>"
+
+**Step 8b — Dispatch strategic-planner (MANDATORY — do NOT do this yourself):**
+Dispatch `nx:strategic-planner` agent (via Agent tool, subagent_type="nx:strategic-planner") with prompt:
+> Create phased execution plan for RDR-<ID>: <title>. RDR file: <RDR-file-path>. Read the RDR content for implementation phases. Create epic and task beads with dependencies.
+
+**Wait for the planner to complete before proceeding.**
+Note the plan file path and bead IDs from the planner's output.
+**If the planner did not create beads, this is a failure — report it and stop. The RDR acceptance is still valid. To retry the planning chain only, run `/nx:create-plan` manually with the RDR file path.**
+
+**Step 8c — Dispatch plan-auditor (MANDATORY — do NOT skip):**
+After the planner completes, dispatch `nx:plan-auditor` agent (via Agent tool, subagent_type="nx:plan-auditor") with prompt:
+> Audit the execution plan just created for RDR-<ID>: <title>. Check T1 scratch for rdr-planning-context. Validate the plan against the codebase. Check beads created by the planner.
+
+**Wait for the auditor to complete before proceeding. Do NOT skip this step.**
+
+**Step 8d — Dispatch plan-enricher (MANDATORY — do NOT skip):**
+After the auditor completes, dispatch `nx:plan-enricher` agent (via Agent tool, subagent_type="nx:plan-enricher") with prompt:
+> Enrich all beads for RDR-<ID>: <title> with audit findings from T1 scratch. Write epic bead ID to T2.
+
+**Wait for the enricher to complete. Do NOT skip this step.**
+
+**Step 8e — Verify chain completion:**
+Confirm all three agents ran: planner created beads, auditor validated, enricher enriched.
+Print: `> RDR-<ID> accepted. Planning chain complete: planner → auditor → enricher. Use 'bd ready' to see executable tasks.`
+**If any step was skipped or failed, report which step broke the chain and provide the retry command.**

--- a/nx/skills/enrich-plan/SKILL.md
+++ b/nx/skills/enrich-plan/SKILL.md
@@ -46,7 +46,7 @@ T1 scratch is session-scoped. Standalone invocation only works within the same s
 
 ## Agent-Specific PRODUCE
 
-- **Enriched Beads**: Updated via `bd update <id> --description "..."` with execution-ready context
+- **Enriched Beads**: Updated via Write tool → `bd update <id> --body-file /tmp/bead-<id>.md` with execution-ready context
 - **T2 memory**: Epic bead ID written via memory_put tool: project="{repo}_rdr", title="NNN"
 - **T1 scratch**: Enrichment summary via scratch tool: action="put", tags="enrichment-complete"
 - **Console output**: Enriched plan summary table

--- a/nx/skills/writing-nx-skills/SKILL.md
+++ b/nx/skills/writing-nx-skills/SKILL.md
@@ -89,6 +89,23 @@ After creating a skill, update `nx/registry.yaml`:
 
 When adding a new skill, also add it to `nx/skills/using-nx-skills/SKILL.md` routing tree. This file is injected every session — if your skill isn't listed there, it won't be discovered.
 
+## Known Pitfalls
+
+### bd update --description silently corrupts multi-line content
+
+**Never** instruct agents to use `bd update <id> --description "..."` for multi-line or markdown content. Shell escaping silently destroys backticks (executed as command substitution), `$variables` (expanded to empty), and nested quotes (break argument boundaries). No error is raised — the command reports success with mangled data.
+
+**Correct pattern**: Write content to a temp file via the Write tool, then use `--body-file`:
+
+```
+Step 1 — Write enriched content using the Write tool (file_path: /tmp/bead-<id>.md)
+Step 2 — bd update <id> --body-file /tmp/bead-<id>.md
+```
+
+Short single-phrase values (e.g. `--design "revised scope"`) are safe. The bug only affects multi-line content with markdown formatting.
+
+This applies to `--description`, `--notes`, `--design`, and any flag that accepts free-text content longer than a simple phrase. Use `--body-file` or `--design-file` respectively.
+
 ## Quality Checklist
 
 - [ ] Frontmatter has `name`, `description`, and `effort`


### PR DESCRIPTION
## Summary

- **Planning chain bypass prevention**: Agents executing `/nx:rdr-accept` were skipping the strategic-planner → plan-auditor → plan-enricher chain by creating beads directly or compensating when subagents failed ("Let me finish the enrichment directly"). Added PROHIBITION block, made chain mandatory for multi-phase RDRs, added subagent failure clause.
- **Silent content corruption fix**: `bd update --description "..."` silently destroys multi-line markdown — backticks execute as command substitution, `$variables` expand to empty, nested quotes break. Replaced with Write tool → `--body-file` pattern across enricher agent, skill, and completion protocol.
- **Dead code removal**: Removed Python T2 idempotency comparisons against always-None `t2_status`. Moved self-healing logic to Action section where agent has live `memory_get` results.
- **Authoring guardrail**: Added Known Pitfalls section to `writing-nx-skills` skill so future agent authors avoid `--description` for multi-line content.

## Test plan

- [x] Verified `bd update --body-file` preserves backticks, `$variables`, code blocks, nested quotes
- [x] Verified `bd update --description` silently corrupts same content (no error, mangled data)
- [x] Grep confirmed no remaining `--description` instruction patterns in nx plugin (only warnings/prohibitions)
- [ ] End-to-end: accept a multi-phase RDR and verify the full chain dispatches without bypass