### PR TITLE
feat(nx): post-implementation verification hooks (RDR-045)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 17 specialized agents, analytical query pipelines, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "2.9.2"
+      "version": "2.10.0"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "2.9.2"
+      "version": "2.10.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-04-01
+
+### Added
+- **Verification config** (RDR-045) — `_DEFAULTS["verification"]` section
+  in `.nexus.yml` with `on_stop`, `on_close`, `test_command`, `lint_command`,
+  `test_timeout` keys. New `get_verification_config()` and
+  `detect_test_command()` in `config.py` with auto-detection for 7 project
+  types (Maven, Gradle, Python, Node, Rust, Make, Go).
+
 ## [2.9.2] - 2026-03-31
 
 ### Changed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,7 @@ Data flows upward (T1 → T2 → T3).
 | **Export** | `exporter.py` | Collection export/import for T3 backup and migration (.nxexp format) |
 | **Search** | `search_engine.py`, `scoring.py`, `frecency.py`, `ripgrep_cache.py` | Query, rank, rerank |
 | **Hooks** | `commands/hooks.py` | Git hook install/uninstall/status, sentinel-bounded stanza management |
+| **Verification** | `config.py` (verification section), `nx/hooks/scripts/stop_verification_hook.sh`, `nx/hooks/scripts/pre_close_verification_hook.sh`, `nx/hooks/scripts/read_verification_config.py` | Opt-in mechanical enforcement: Stop hook (session-end checks), PreToolUse hook (bd-close gate), standalone config reader. See [Configuration — Verification](configuration.md#verification) |
 | **MCP Server** | `mcp_server.py` | FastMCP server exposing T1/T2/T3 storage APIs as 14 MCP tools: `search`, `store_put`, `store_list`, `memory_put`, `memory_get`, `memory_search`, `scratch`, `scratch_manage`, `collection_list`, `collection_info`, `collection_verify`, `plan_save`, `plan_search` |
 | **Enrichment** | `bib_enricher.py`, `commands/enrich.py` | Semantic Scholar bibliographic metadata lookup + `nx enrich` CLI backfill command |
 | **Support** | `config.py`, `registry.py`, `corpus.py`, `session.py`, `hooks.py`, `ttl.py`, `formatters.py`, `types.py`, `errors.py`, `retry.py` | Configuration, naming, formatting, session lifecycle, transient-error retry |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,54 @@ tuning:
 
 These values are exposed as a `TuningConfig` dataclass in `nexus.config`. The search command, indexer, and scoring modules all read from this config — changes take effect on the next invocation without restarting anything.
 
+## Verification
+
+Opt-in mechanical enforcement hooks that catch common agent failure modes: premature session closure and premature bead closure.
+
+```yaml
+# .nexus.yml
+verification:
+  on_stop: false          # Enable Stop hook — checks on session end (default: false)
+  on_close: false         # Enable bd-close gate — checks before closing a bead (default: false)
+  test_command: ""        # Auto-detected if omitted (see table below)
+  lint_command: ""        # Optional linter (currently advisory only)
+  test_timeout: 120       # Seconds; 0 = no timeout (default: 120)
+```
+
+### Activation
+
+**Both `on_stop` and `on_close` default to `false`.** A `verification:` section without either flag set does nothing. Projects opt in explicitly:
+
+```yaml
+verification:
+  on_stop: true    # Enable session-end checks
+  on_close: true   # Enable bead-close gate
+```
+
+### Auto-Detection
+
+If `test_command` is omitted but `on_stop` or `on_close` is `true`, the hook auto-detects from project marker files (first match wins):
+
+| Marker file | Test command |
+|---|---|
+| `pom.xml` | `mvn test` |
+| `build.gradle` / `build.gradle.kts` | `./gradlew test` |
+| `pyproject.toml` | `uv run pytest` |
+| `package.json` | `npm test` |
+| `Cargo.toml` | `cargo test` |
+| `Makefile` | `make test` |
+| `go.mod` | `go test ./...` |
+
+If no marker file is found and no command is configured, the test check is skipped with an advisory: "No test command configured or detected."
+
+### Behavior Reference
+
+**Stop hook** (`on_stop: true`): Fires when the agent ends a session. Checks: uncommitted git changes, open beads (`bd list --status=in_progress`), test suite result. If any check fails, blocks the session end and shows the reason. On retry, test failures are let through with a warning — mechanical issues (uncommitted changes, open beads) continue to block.
+
+**bd-close gate** (`on_close: true`): Fires before `bd close` or `bd done` commands. Test suite failure blocks the close. Absence of a review marker emits an advisory but does not block.
+
+**Command-not-found**: If the test command cannot be executed (exit 126/127), both hooks treat it as a skipped check with an advisory — not a blocking failure. Misconfigured environments do not permanently block all closures.
+
 ## File Locations
 
 | File | Purpose |

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -66,6 +66,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-042](rdr-042-agenticscholar-enhancements.md) | AgenticScholar-Inspired Enhancements | Architecture | Accepted | 2026-03-29 |
 | [RDR-043](rdr-043-plan-enricher-scope.md) | Widen Plan-Enricher Scope | Enhancement | Accepted | 2026-03-30 |
 | [RDR-044](rdr-044-math-aware-pdf-extraction.md) | Math-Aware PDF Extraction | Bug | Closed | 2026-03-31 |
+| [RDR-045](rdr-045-post-implementation-verification.md) | Post-Implementation Verification Gate | Architecture | Accepted | 2026-04-01 |
 
 ---
 

--- a/docs/rdr/rdr-045-post-implementation-verification.md
+++ b/docs/rdr/rdr-045-post-implementation-verification.md
@@ -1,0 +1,227 @@
+---
+id: RDR-045
+title: Post-Implementation Verification Gate
+type: Architecture
+status: accepted
+priority: P2
+created: 2026-04-01
+accepted_date: 2026-04-01
+reviewed-by: self
+---
+
+# RDR-045: Post-Implementation Verification Gate
+
+## Problem
+
+Agents routinely declare work "done" when it isn't — outputs unwired, return values discarded, components half-implemented. This is observable across projects and appears to be a fundamental LLM satisficing behavior, not a project-specific issue.
+
+The nx toolkit provides optional quality gates (critique agents, code review, test validation) but they're all manually invoked. The agent that cuts corners on implementation also cuts corners on invoking verification.
+
+## Design Principle
+
+nx is an opinionated plugin. Beads is the task tracker. RDRs are the design workflow. The verification gate should leverage all of these — the goal is not framework-agnostic generality but addressing universal failure classes (premature closure, untested code, abandoned state) within the nx workflow.
+
+The constraint is: don't encode project-specific domain knowledge (specific equations, specific architectures). Encode structural properties the workflow is supposed to ensure (tests pass, review happened, nothing dangling).
+
+## Research Findings
+
+### R1: PreToolUse limitations and the Stop hook alternative
+
+PreToolUse hooks fire on EVERY tool call with ~5s timeout. They have NO conversation context — only tool name + arguments via JSON stdin. They cannot make semantic judgments. The `readonly-agent-guard.sh` (a PreToolUse hook) was tried for enforcement and abandoned in v2.2.0.
+
+**However**, a PreToolUse hook that pattern-matches a specific command (`bd close`) and runs a purely mechanical check (test suite exit code) avoids both problems: it's a fast no-op on non-matching calls, and the check requires no conversation context. This is fundamentally different from `readonly-agent-guard.sh`, which tried to make permission decisions about arbitrary tool calls. The distinction: mechanical external checks (run tests, check exit code) are valid at PreToolUse; context-dependent reasoning (was the work actually done?) is not.
+
+**Stop hooks** fire when the agent declares "done", can block completion with a reason, and the agent retries with feedback. The `stop_hook_active` field indicates a retry pass (prevents infinite loops).
+
+### R2: Industry convergence on three generic patterns
+
+1. **Output guardrail function** (CrewAI): `f(output) -> (pass, feedback)` with bounded retry. Most portable — just a function signature.
+2. **Stop/completion hooks** (Claude Code, Agent SDK): Block at the "declare done" moment. Most directly applicable to nx.
+3. **Deterministic script postconditions** (OpenAI): `test + lint + typecheck` as non-negotiable gates. Most reliable.
+
+Key finding (arXiv:2512.12791): Agents achieve 100% tool sequencing but only 33% policy adherence. Prompt-level instructions ("always verify") compete with satisficing. Mechanical enforcement is the only reliable countermeasure.
+
+### R3: Failure mode classification (14 cases from ART project)
+
+| Category | Count | Detectable by | Example |
+|----------|-------|---------------|---------|
+| Static analysis | 3/14 | Linter/dead-code tool | Orphan classes, unused returns, no-op overrides |
+| Test execution | 4/14 | Purpose-built tests | Inert pathways, wrong signal source, scalar approximations |
+| Semantic understanding | 7/14 | **Nothing automated** | Correct equations but disconnected circuit, wrong formula, fabricated variables |
+
+**A PreToolUse hook catches 3/14.** A Stop hook running test+lint catches ~7/14. The remaining 7/14 require specification comparison — domain knowledge that cannot be mechanically enforced without being workflow-specific.
+
+### R4: What nx already has
+
+- `test-validator` agent with quality gates (test pass, coverage, no smells)
+- `java-developer` agent with a "Completion Protocol (MANDATORY)" — 6-step checklist
+- A half-built `verification-before-completion` skill in a worktree with the principle: "NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE"
+- The Gate Function pattern: IDENTIFY → RUN → READ → VERIFY
+
+These exist but are prompt-enforced, not mechanically enforced.
+
+### R5: Beads plugin architecture and extension model
+
+The beads plugin provides three interaction surfaces: `bd` CLI, `/beads:*` slash commands, and an optional MCP server (`beads-mcp`, separate PyPI package, not installed by default).
+
+**The `bd` CLI via Bash is the intended and actual interface for Claude Code.** The docs say "Prefer CLI + hooks when shell is available." The MCP server is for MCP-only environments (Claude Desktop). In practice, agents call `bd close`, `bd ready`, etc. directly via Bash — never through the skill commands or MCP.
+
+**Beads has no pre-close verification gate.** The plugin registers only two Claude Code hooks (SessionStart and PreCompact, both running `bd prime`). No PreToolUse, PostToolUse, or Stop hooks. The `bd gate` system is for formula-scoped async coordination (human approval, CI), not for validating work completeness before closure. "Don't close issues unless work is actually complete" is a behavioral instruction in the task-agent prompt.
+
+**Beads' extension model is primitives, not policy.** It provides storage and coordination (`bd close`, `bd gate`, `bd set-state`, labels, `bd preflight`). Domain-specific intelligence — including verification — is expected to come from external tools via the skill/command layer. This is exactly the layer nx operates at.
+
+**The `/beads:close` skill is a thin wrapper.** It tells the agent to call `bd close` (or the MCP tool) and suggests checking for unblocked dependents. No verification logic. Agents bypass it entirely and call `bd close` directly.
+
+**Relevant beads primitives for verification:**
+- `bd set-state <id> verification=passed` — label convention for auditability
+- `bd preflight` — PR readiness checks (manual invocation)
+- `bd lint` — structural validation of issue descriptions
+- `bd close --force` — override for pinned/gated issues (implies normal close respects gates)
+
+## Design
+
+Two mechanical enforcement points at the boundaries where agents cut corners:
+
+### Layer 1: Stop Hook — "Don't leave a mess"
+
+Fires when the agent ends the conversation. The hook reads `stop_hook_active` from stdin JSON to detect retry passes.
+
+**First pass** (`stop_hook_active: false`): runs all checks. Blocks on any failure.
+
+| Check | Type | What it catches |
+|-------|------|----------------|
+| `git status` — uncommitted changes to tracked files? | Mechanical | Agent walks away from half-committed work |
+| `bd list --status=in_progress` — beads still active? | Mechanical | Agent forgets to close or defer open work |
+| Run test command (from `.nexus.yml`) — failures? | Mechanical | Agent leaves broken code behind |
+
+**Retry pass** (`stop_hook_active: true`): runs the same checks again.
+- Mechanical issues now fixed (committed, beads closed) → pass silently.
+- Tests still failing → **let through with a prominent warning** to the user: "TESTS FAILING — agent could not resolve. Manual intervention needed."
+
+This differentiation matters: mechanical failures (forgot to commit, forgot to close bead) are trivially fixable in one pass. Test failures may not be — and giving the agent unlimited retries incentivizes test-commenting or assertion removal to game the gate. One honest attempt; after that, escalate to the human.
+
+**Timeout:** The test command has a configurable timeout (default 120s via `.nexus.yml`). If the test suite exceeds this, the hook warns but does not block — slow integration suites should not prevent session end.
+
+**Command-not-found handling:** If the configured (or auto-detected) test command fails to execute (command not found, permission denied — exit code 127 or 126), the hook treats this as a skipped check with an advisory, not a blocking failure. This prevents misconfigured environments from permanently blocking all closures and session ends.
+
+### Layer 2: PreToolUse Hook on `bd close` — "Don't close what isn't done"
+
+Agents call `bd close` directly via Bash — not through `/beads:close` skills or MCP tools. This is the intended beads interaction model for Claude Code ("prefer CLI when shell is available"). The enforcement must meet the agent where it is.
+
+PreToolUse hook on Bash, pattern-matching `bd close` and its alias `bd done`. Fast no-op on all other Bash calls.
+
+#### Layer 2a: Mechanical gate (blocking)
+
+| Check | What it catches |
+|-------|----------------|
+| Run test suite (from `.nexus.yml` verification config) | Agent closes bead with failing tests |
+
+This is a purely mechanical check: run command, check exit code. No conversation context needed. Fundamentally different from `readonly-agent-guard.sh` — that hook tried to make permission decisions about arbitrary tool calls; this one runs an external command at a narrow trigger point.
+
+If tests fail, the hook blocks the `bd close` call and returns the failure reason. The agent sees "tests failing, fix before closing" and can act on it.
+
+#### Layer 2b: Best-effort advisory (non-blocking)
+
+| Check | What it catches |
+|-------|----------------|
+| Check T1 scratch for review completion marker | Agent closes without review |
+
+This check attempts to infer session context via a scratch proxy. It is explicitly **best-effort**: if the marker is absent (review-code was not invoked, or scratch is unavailable), the check **fails open** with an advisory warning: "No review marker found — consider running /nx:review-code before closing." It does NOT block.
+
+**Why non-blocking:** The review marker is a context proxy, not a mechanical check. It has the same structural limitation R1 identified — no conversation context in hooks. Making it advisory rather than blocking prevents false confidence and avoids the `readonly-agent-guard.sh` mistake of enforcing a decision the hook cannot reliably make.
+
+#### Review-code scratch marker (deliverable)
+
+The `/nx:review-code` skill must be modified to write a T1 scratch marker on completion:
+
+**Producer** (review-code skill, on successful completion):
+```
+nx scratch put "review-completed bead={bead-id} at={ISO-timestamp}" --tags "review,{bead-id}"
+```
+
+**Consumer** (Layer 2b hook, before allowing `bd close {bead-id}`):
+```
+nx scratch search "review-completed" --n 20
+```
+Then grep output for the bead ID. If found, review was completed this session. If not found, emit advisory.
+
+- **Storage:** T1 scratch is session-ephemeral — no TTL needed, entries vanish when the session ends
+- **Lookup:** Semantic search + tag/bead-ID grep (T1 has no key-value lookup; search is the retrieval mechanism)
+- **Bead ID availability:** The review-code skill receives the bead ID when invoked with a bead context. When invoked without a bead (ad-hoc review), the marker is written with `bead=none` and the Layer 2b check skips it — fails open as designed
+
+If the marker is absent, the hook emits an advisory. If present, the hook notes "review completed" in its output.
+
+#### Auditability
+
+On successful verification (Layer 2a passes), set `bd set-state <id> verification=passed` before allowing the close through. This uses beads' native state dimension system to record that verification happened. This is also an extension point: `bd preflight` could check for `verification=passed` before PR creation.
+
+### Layer 3: Skill Enhancements (prompt-enforced, not mechanical)
+
+These address the gaps hooks can't reach:
+
+| Enhancement | What it catches |
+|-------------|----------------|
+| `/nx:review-code` writes scratch marker on completion (see Layer 2b) | Enables review-presence tracking |
+| `/nx:review-code` flags deferred items → prompts "create beads for these" | Deferred items vanishing into RDR prose |
+| `/nx:substantive-critique` compares implementation against RDR stated goals | Category 3 semantic gaps (correct code, wrong behavior) |
+| `finishing-branch` skill runs test-validate before allowing PR/merge | Final quality gate before integration |
+
+Layer 3 remains advisory — the agent can still skip invoking these skills. But Layers 1-2 provide the mechanical backstop that catches the structural failures.
+
+**Defense-in-depth:** `finishing-branch` also runs tests. If it was invoked, the Stop hook's test check is redundant but harmless. If it wasn't invoked, the Stop hook catches the gap. There is no signaling between them — this is intentional simplicity over coordination complexity.
+
+### What's out of scope
+
+Domain-specific semantic verification ("does this ODE match the paper?", "is this circuit wired correctly?"). These require specification knowledge that varies per project. The toolkit can surface the question (via critique agents) but can't mechanically enforce the answer.
+
+**Tests-as-oracle caveat:** The mechanical gates assume the test suite is an independent correctness oracle. When tests and implementation are co-generated by the same agent in the same session, this assumption degrades — the tests may verify the wrong behavior. `/nx:test-validate` addresses test quality concerns and should be invoked for critical work. The mechanical gate catches "tests don't pass," not "tests test the right thing."
+
+## Configuration
+
+```yaml
+# .nexus.yml
+verification:
+  test_command: "uv run pytest"     # auto-detected if omitted
+  lint_command: "ruff check src/"   # optional
+  test_timeout: 120                 # seconds (default 120; 0 = no timeout)
+  on_stop: true                     # REQUIRED to enable Stop hook — default false
+  on_close: true                    # REQUIRED to enable bd-close gate — default false
+```
+
+**Activation is explicit:** `on_stop` and `on_close` default to `false`. A `verification:` section without either flag set does nothing — no silent enforcement from a partially-written config. Projects opt in by setting the flags they want.
+
+**Auto-detection:** If `test_command` is omitted but `on_stop` or `on_close` is `true`, the hook auto-detects from project files:
+
+| Marker file | Test command |
+|-------------|-------------|
+| `pom.xml` | `mvn test` |
+| `build.gradle` / `build.gradle.kts` | `./gradlew test` |
+| `pyproject.toml` | `uv run pytest` (falls back to `pytest`) |
+| `package.json` | `npm test` |
+| `Cargo.toml` | `cargo test` |
+| `Makefile` | `make test` |
+| `go.mod` | `go test ./...` |
+
+Detection order is first-match. If nothing is detected, the test check is skipped with an advisory: "No test command configured or detected."
+
+## Interaction with Existing Workflow
+
+| Existing component | Interaction |
+|-------------------|-------------|
+| `finishing-branch` skill | Defense-in-depth — finishing-branch runs tests during integration; Stop hook is the backstop if finishing-branch wasn't invoked. No signaling between them. |
+| `test-validate` skill | Stop hook runs tests mechanically; test-validate adds coverage analysis and test quality review. Test-validate is the escalation when test quality (not just pass/fail) is in question. |
+| `review-code` skill | Modified to write T1 scratch marker on completion (Layer 2b deliverable). Layer 3 enhances review to flag deferred items. |
+| `brainstorming-gate` skill | Unchanged — protocol compliance remains prompt-enforced via SessionStart reminders |
+| `rdr_hook.py` (SessionStart) | Unchanged — RDR state awareness at session start; verification hooks enforce at session end and task close |
+
+## Deliverables
+
+1. **Stop hook script** (`nx/hooks/scripts/stop_verification_hook.sh`) — reads `.nexus.yml`, runs checks, handles `stop_hook_active` retry logic, differentiates mechanical vs test failures on retry, handles command-not-found (exit 126/127) as skip-with-advisory
+2. **PreToolUse hook script** (`nx/hooks/scripts/pre_close_verification_hook.sh`) — pattern-matches `bd close` and `bd done`, runs test suite (Layer 2a, blocking) + review scratch marker search (Layer 2b, advisory), sets `bd set-state <id> verification=passed` on success
+3. **hooks.json update** — register Stop and PreToolUse hooks
+4. **review-code skill modification** — write T1 scratch marker via `nx scratch put "review-completed bead={id} ..." --tags "review,{id}"` on completion; handle no-bead-context case (write `bead=none`)
+5. **`.nexus.yml` schema update** — document `verification` section with `on_stop`, `on_close`, `test_command`, `lint_command`, `test_timeout`
+
+## Decision
+
+**Accepted** on 2026-04-01 after two gate rounds (4 critical, 3 significant issues identified and resolved).

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-04-01
+
+### Added
+- **Post-implementation verification hooks** (RDR-045) — two opt-in
+  mechanical enforcement hooks that catch premature session closure and
+  premature bead closure.
+  - **Stop hook** (`on_stop: true`) — blocks session end on uncommitted
+    git changes, open beads, or test failures. On retry, test failures
+    are let through with a warning; mechanical issues continue to block.
+  - **PreToolUse close gate** (`on_close: true`) — intercepts `bd close`
+    and `bd done`, blocks on test failure, emits advisory when no
+    review marker found in T1 scratch.
+  - Standalone `read_verification_config.py` config reader for hooks
+    (no nexus package imports).
+  - hooks.json: `Stop` (timeout 180s) and `PreToolUse` (matcher `Bash`,
+    timeout 300s) entries registered.
+
+### Changed
+- **code-review skill** — writes T1 scratch marker
+  (`review-completed bead=<id>`) on successful completion, enabling the
+  PreToolUse hook to verify review happened before bead closure.
+
 ## [2.9.1] - 2026-03-31
 
 ### Added

--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -63,6 +63,30 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/stop_verification_hook.sh",
+            "timeout": 180
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/pre_close_verification_hook.sh",
+            "timeout": 300
+          }
+        ]
+      }
     ]
   }
 }

--- a/nx/hooks/scripts/pre_close_verification_hook.sh
+++ b/nx/hooks/scripts/pre_close_verification_hook.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# PreToolUse close verification hook — gates bd close/done on test pass.
+# Exit 0 with hookSpecificOutput JSON for structured decisions.
+# Exit 2 is the alternative blocking path (stderr fed to Claude as error).
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers — PreToolUse uses hookSpecificOutput, NOT decision/reason
+# ---------------------------------------------------------------------------
+
+allow() {
+    # permissionDecision: "allow" — tool call proceeds
+    if [[ -n "${1:-}" ]]; then
+        local escaped
+        escaped=$(printf '%s' "$1" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" 2>/dev/null || printf '"%s"' "$1")
+        printf '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow", "additionalContext": %s}}\n' "$escaped"
+    else
+        printf '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}\n'
+    fi
+    exit 0
+}
+
+deny() {
+    # permissionDecision: "deny" — tool call blocked, reason fed to Claude
+    local escaped
+    escaped=$(printf '%s' "$1" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" 2>/dev/null || printf '"%s"' "$1")
+    printf '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": %s}}\n' "$escaped"
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Read stdin
+# ---------------------------------------------------------------------------
+
+STDIN=$(cat 2>/dev/null || true)
+
+if [[ -z "$STDIN" ]]; then
+    allow
+fi
+
+# ---------------------------------------------------------------------------
+# Fast no-op: check tool_name
+# ---------------------------------------------------------------------------
+
+TOOL_NAME=$(printf '%s' "$STDIN" | python3 -c "
+import json, sys
+try:
+    print(json.load(sys.stdin).get('tool_name', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+    allow
+fi
+
+# ---------------------------------------------------------------------------
+# Fast no-op: check if command matches bd close/done
+# ---------------------------------------------------------------------------
+
+TOOL_INPUT=$(printf '%s' "$STDIN" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_input', {}).get('command', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+if ! printf '%s' "$TOOL_INPUT" | grep -qE '\bbd[[:space:]]+(close|done)\b'; then
+    allow
+fi
+
+# ---------------------------------------------------------------------------
+# Extract bead ID (first token after close/done)
+# ---------------------------------------------------------------------------
+
+BEAD_ID=$(printf '%s' "$TOOL_INPUT" | sed -E -n 's/.*bd[[:space:]]+(close|done)[[:space:]]+([^[:space:]]*).*/\2/p' 2>/dev/null || true)
+BEAD_ID="${BEAD_ID:-}"
+
+# ---------------------------------------------------------------------------
+# Read verification config
+# ---------------------------------------------------------------------------
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../../.." 2>/dev/null && pwd)}"
+CONFIG_SCRIPT="$PLUGIN_ROOT/hooks/scripts/read_verification_config.py"
+
+CONFIG=$(python3 "$CONFIG_SCRIPT" 2>/dev/null || true)
+
+if [[ -z "$CONFIG" ]]; then
+    # Config reader failed — fail open
+    allow
+fi
+
+ON_CLOSE=$(printf '%s' "$CONFIG" | python3 -c "
+import json, sys
+try:
+    print(json.load(sys.stdin).get('on_close', False))
+except Exception:
+    print('False')
+" 2>/dev/null || echo "False")
+
+if [[ "$ON_CLOSE" != "True" ]]; then
+    allow
+fi
+
+TEST_CMD=$(printf '%s' "$CONFIG" | python3 -c "
+import json, sys
+try:
+    print(json.load(sys.stdin).get('test_command', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+TEST_TIMEOUT=$(printf '%s' "$CONFIG" | python3 -c "
+import json, sys
+try:
+    print(json.load(sys.stdin).get('test_timeout', 120))
+except Exception:
+    print('120')
+" 2>/dev/null || echo "120")
+
+# ---------------------------------------------------------------------------
+# Layer 2a: Mechanical gate (blocking)
+# ---------------------------------------------------------------------------
+
+ADVISORY_MSGS=""
+
+if [[ -z "$TEST_CMD" ]]; then
+    ADVISORY_MSGS="ADVISORY: No test command configured or detected — skipping test check"
+else
+    TEST_EXIT=0
+    if command -v timeout &>/dev/null; then
+        timeout "$TEST_TIMEOUT" bash -c "$TEST_CMD" >/dev/null 2>&1 || TEST_EXIT=$?
+    else
+        bash -c "$TEST_CMD" >/dev/null 2>&1 || TEST_EXIT=$?
+    fi
+
+    if [[ $TEST_EXIT -eq 124 ]]; then
+        ADVISORY_MSGS="ADVISORY: Test command timed out after ${TEST_TIMEOUT}s — skipping test check"
+    elif [[ $TEST_EXIT -eq 126 || $TEST_EXIT -eq 127 ]]; then
+        ADVISORY_MSGS="ADVISORY: Test command not found or not executable (exit $TEST_EXIT) — skipping test check"
+    elif [[ $TEST_EXIT -ne 0 ]]; then
+        deny "Tests failing (exit code $TEST_EXIT) — fix before closing bead ${BEAD_ID:-unknown}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Layer 2b: Advisory check (non-blocking) — review scratch marker
+# ---------------------------------------------------------------------------
+
+REVIEW_MSG=""
+if command -v nx &>/dev/null; then
+    SCRATCH_RESULTS=$(nx scratch list 2>/dev/null || true)
+    if [[ -n "$BEAD_ID" ]]; then
+        if [[ -n "$SCRATCH_RESULTS" ]] && \
+           printf '%s' "$SCRATCH_RESULTS" | grep -q "review-completed" && \
+           printf '%s' "$SCRATCH_RESULTS" | grep -q "$BEAD_ID"; then
+            REVIEW_MSG="Review completed for $BEAD_ID."
+        else
+            REVIEW_MSG="ADVISORY: No review marker found for $BEAD_ID — consider running /nx:review-code before closing."
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Audit trail
+# ---------------------------------------------------------------------------
+
+if [[ -n "$BEAD_ID" ]] && command -v bd &>/dev/null; then
+    bd set-state "$BEAD_ID" verification=passed 2>/dev/null || true
+fi
+
+# ---------------------------------------------------------------------------
+# Compose allow message
+# ---------------------------------------------------------------------------
+
+CONTEXT=""
+if [[ -n "$ADVISORY_MSGS" ]]; then
+    CONTEXT="$ADVISORY_MSGS"
+fi
+if [[ -n "$REVIEW_MSG" ]]; then
+    if [[ -n "$CONTEXT" ]]; then
+        CONTEXT="$CONTEXT | $REVIEW_MSG"
+    else
+        CONTEXT="$REVIEW_MSG"
+    fi
+fi
+
+allow "$CONTEXT"

--- a/nx/hooks/scripts/read_verification_config.py
+++ b/nx/hooks/scripts/read_verification_config.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Read .nexus.yml verification config and output as JSON.
+
+Standalone script for hook consumption — no nexus package imports.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+DEBUG = os.environ.get("NX_HOOK_DEBUG", "0") == "1"
+
+DEFAULTS = {
+    "on_stop": False,
+    "on_close": False,
+    "test_command": "",
+    "lint_command": "",
+    "test_timeout": 120,
+}
+
+DETECT_TABLE = [
+    ("pom.xml",            "mvn test"),
+    ("build.gradle",       "./gradlew test"),
+    ("build.gradle.kts",   "./gradlew test"),
+    ("pyproject.toml",     "uv run pytest"),
+    ("package.json",       "npm test"),
+    ("Cargo.toml",         "cargo test"),
+    ("Makefile",           "make test"),
+    ("go.mod",             "go test ./..."),
+]
+
+
+def _debug(msg: str) -> None:
+    if DEBUG:
+        print(f"[read-verification-config] {msg}", file=sys.stderr)
+
+
+def _find_project_dir() -> Path:
+    """Determine project directory from env or cwd."""
+    env_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env_dir:
+        p = Path(env_dir)
+        if p.is_dir():
+            return p
+    return Path.cwd()
+
+
+def _detect_test_command(project_dir: Path) -> str:
+    """Auto-detect test command from marker files. First match wins."""
+    for marker, command in DETECT_TABLE:
+        if (project_dir / marker).exists():
+            _debug(f"detected {marker} → {command}")
+            return command
+    return ""
+
+
+def _read_config(project_dir: Path) -> dict:
+    """Read .nexus.yml and extract verification section, merging with defaults."""
+    result = dict(DEFAULTS)
+    nexus_yml = project_dir / ".nexus.yml"
+
+    if not nexus_yml.exists():
+        _debug(f"no .nexus.yml at {nexus_yml}")
+        return result
+
+    try:
+        import yaml
+        with nexus_yml.open() as f:
+            data = yaml.safe_load(f)
+    except Exception as exc:
+        _debug(f"failed to parse {nexus_yml}: {exc}")
+        return result
+
+    if not isinstance(data, dict):
+        _debug("YAML root is not a dict")
+        return result
+
+    verification = data.get("verification", {})
+    if not isinstance(verification, dict):
+        _debug("verification section is not a dict")
+        return result
+
+    # Merge only known keys
+    for key in DEFAULTS:
+        if key in verification:
+            result[key] = verification[key]
+
+    return result
+
+
+def main() -> None:
+    project_dir = _find_project_dir()
+    config = _read_config(project_dir)
+
+    # Auto-detect test command if not explicitly set and at least one gate is enabled
+    if not config["test_command"] and (config["on_stop"] or config["on_close"]):
+        config["test_command"] = _detect_test_command(project_dir)
+
+    print(json.dumps(config))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        if DEBUG:
+            print(f"[read-verification-config] unhandled: {exc}", file=sys.stderr)
+        # Always output valid JSON even on error
+        print(json.dumps(DEFAULTS))
+    sys.exit(0)

--- a/nx/hooks/scripts/stop_verification_hook.sh
+++ b/nx/hooks/scripts/stop_verification_hook.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Stop verification hook — checks for uncommitted changes, open beads, and test failures.
+# Exit 0 always. Communicate via JSON stdout.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+approve() {
+    if [[ -n "${1:-}" ]]; then
+        local escaped
+        escaped=$(printf '%s' "$1" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" 2>/dev/null || printf '"%s"' "$1")
+        printf '{"decision": "approve", "reason": %s}\n' "$escaped"
+    else
+        printf '{"decision": "approve"}\n'
+    fi
+    exit 0
+}
+
+block() {
+    local escaped
+    escaped=$(printf '%s' "$1" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" 2>/dev/null || printf '"%s"' "$1")
+    printf '{"decision": "block", "reason": %s}\n' "$escaped"
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Read stdin
+# ---------------------------------------------------------------------------
+
+STDIN=$(cat 2>/dev/null || true)
+
+# ---------------------------------------------------------------------------
+# Read config
+# ---------------------------------------------------------------------------
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../../.." 2>/dev/null && pwd)}"
+CONFIG=$(python3 "$PLUGIN_ROOT/hooks/scripts/read_verification_config.py" 2>/dev/null || echo '{}')
+
+ON_STOP=$(printf '%s' "$CONFIG" | python3 -c "import json,sys; print(json.load(sys.stdin).get('on_stop', False))" 2>/dev/null || echo "False")
+if [[ "$ON_STOP" != "True" ]]; then
+    approve
+fi
+
+TEST_CMD=$(printf '%s' "$CONFIG" | python3 -c "import json,sys; print(json.load(sys.stdin).get('test_command', ''))" 2>/dev/null || echo "")
+TEST_TIMEOUT=$(printf '%s' "$CONFIG" | python3 -c "import json,sys; print(json.load(sys.stdin).get('test_timeout', 120))" 2>/dev/null || echo "120")
+
+STOP_HOOK_ACTIVE=$(printf '%s' "$STDIN" | python3 -c "import json,sys; d=json.load(sys.stdin); print(str(d.get('stop_hook_active', False)).lower())" 2>/dev/null || echo "false")
+
+# ---------------------------------------------------------------------------
+# Run checks
+# ---------------------------------------------------------------------------
+
+FAILURES=""
+TEST_FAILED=""
+ADVISORY_ONLY="true"
+
+# Check 1: Uncommitted changes
+if command -v git &>/dev/null; then
+    GIT_STATUS=$(git status --porcelain 2>/dev/null || echo "")
+    if [[ -n "$GIT_STATUS" ]]; then
+        FAILURES="${FAILURES}Uncommitted changes detected:\n$(printf '%s' "$GIT_STATUS" | head -10)\n\n"
+        ADVISORY_ONLY="false"
+    fi
+fi
+
+# Check 2: Open beads
+if command -v bd &>/dev/null; then
+    BEADS_OUTPUT=$(bd list --status=in_progress 2>/dev/null || echo "")
+    if [[ -n "$BEADS_OUTPUT" ]] && printf '%s' "$BEADS_OUTPUT" | grep -q "in_progress"; then
+        FAILURES="${FAILURES}Beads still in progress:\n$(printf '%s' "$BEADS_OUTPUT" | head -5)\n\n"
+        ADVISORY_ONLY="false"
+    fi
+fi
+
+# Check 3: Test suite
+if [[ -n "$TEST_CMD" ]]; then
+    TEST_EXIT=0
+    if command -v timeout &>/dev/null; then
+        timeout "$TEST_TIMEOUT" bash -c "$TEST_CMD" >/dev/null 2>&1 || TEST_EXIT=$?
+    else
+        bash -c "$TEST_CMD" >/dev/null 2>&1 || TEST_EXIT=$?
+    fi
+
+    if [[ $TEST_EXIT -eq 124 ]]; then
+        FAILURES="${FAILURES}ADVISORY: Test command timed out after ${TEST_TIMEOUT}s — skipping test check\n\n"
+    elif [[ $TEST_EXIT -eq 126 || $TEST_EXIT -eq 127 ]]; then
+        FAILURES="${FAILURES}ADVISORY: Test command not found or not executable (exit $TEST_EXIT) — skipping test check\n\n"
+    elif [[ $TEST_EXIT -ne 0 ]]; then
+        TEST_FAILED="true"
+        FAILURES="${FAILURES}Tests failing (exit code $TEST_EXIT)\n\n"
+        ADVISORY_ONLY="false"
+    fi
+else
+    FAILURES="${FAILURES}ADVISORY: No test command configured or detected — skipping test check\n\n"
+fi
+
+# No failures → approve
+if [[ -z "$FAILURES" ]]; then
+    approve
+fi
+
+# Advisory-only failures → approve with advisory text
+if [[ "$ADVISORY_ONLY" == "true" ]]; then
+    approve "$(printf '%b' "$FAILURES")"
+fi
+
+# On retry pass, let test-only failures through
+if [[ "$STOP_HOOK_ACTIVE" == "true" ]]; then
+    # Re-check mechanical failures (git + beads)
+    MECHANICAL_FAILURES=""
+    if command -v git &>/dev/null; then
+        GIT_STATUS=$(git status --porcelain 2>/dev/null || echo "")
+        if [[ -n "$GIT_STATUS" ]]; then
+            MECHANICAL_FAILURES="${MECHANICAL_FAILURES}Uncommitted changes still present\n"
+        fi
+    fi
+    if command -v bd &>/dev/null; then
+        BEADS_OUTPUT=$(bd list --status=in_progress 2>/dev/null || echo "")
+        if [[ -n "$BEADS_OUTPUT" ]] && printf '%s' "$BEADS_OUTPUT" | grep -q "in_progress"; then
+            MECHANICAL_FAILURES="${MECHANICAL_FAILURES}Beads still in progress\n"
+        fi
+    fi
+
+    if [[ -n "$MECHANICAL_FAILURES" ]]; then
+        block "$(printf '%b' "$MECHANICAL_FAILURES")"
+    fi
+
+    # Test failures on retry → let through with warning
+    if [[ -n "$TEST_FAILED" ]]; then
+        approve "WARNING: TESTS FAILING — agent could not resolve. Manual intervention needed."
+    fi
+
+    # Any remaining (advisory) failures → approve
+    approve "$(printf '%b' "$FAILURES")"
+fi
+
+# First pass with non-advisory failures → block
+block "$(printf '%b' "$FAILURES")"

--- a/nx/skills/code-review/SKILL.md
+++ b/nx/skills/code-review/SKILL.md
@@ -85,3 +85,20 @@ The code-review-expert agent uses hypothesis-driven review:
 - [ ] T2 memory updated with session findings (if multi-session work)
 
 **Session Scratch (T1)**: Agent uses scratch tool for ephemeral working notes during the session. Flagged items auto-promote to T2 at session end.
+
+## On Completion (Mandatory)
+
+On successful review completion, write a T1 scratch marker so the PreToolUse verification hook can confirm review happened this session:
+
+```bash
+nx scratch put "review-completed bead={bead-id} at={ISO-timestamp}" --tags "review,{bead-id}"
+```
+
+Replace `{bead-id}` with the bead ID from the relay (e.g., `nexus-4yit`). Replace `{ISO-timestamp}` with the current UTC time in ISO 8601 format (e.g., `2026-04-01T16:00:00Z`).
+
+**No bead context**: If invoked without a bead ID (ad-hoc review), write the marker with `bead=none`:
+```bash
+nx scratch put "review-completed bead=none at={ISO-timestamp}" --tags "review"
+```
+
+The `--tags` flag format is a comma-separated string: `--tags "review,{bead-id}"` (not `--tags review --tags {bead-id}`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "2.9.2"
+version = "2.10.0"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -128,6 +128,54 @@ def get_tuning_config(repo_root: Path | None = None) -> TuningConfig:
     return _tuning_from_dict(cfg.get("tuning", {}))
 
 
+def get_verification_config(repo_root: Path | None = None) -> dict[str, Any]:
+    """Return the merged verification config section.
+
+    Does not perform auto-detection of ``test_command``; call
+    :func:`detect_test_command` separately when ``test_command`` is empty.
+    """
+    cfg = load_config(repo_root=repo_root)
+    defaults = _DEFAULTS["verification"]
+    section = cfg.get("verification", {})
+    return {**defaults, **section}
+
+
+# Detection table shared with nx/hooks/scripts/read_verification_config.py.
+# Keep both tables identical — a cross-validation test enforces this.
+_DETECT_TABLE: list[tuple[str, str]] = [
+    ("pom.xml",          "mvn test"),
+    ("build.gradle",     "./gradlew test"),
+    ("build.gradle.kts", "./gradlew test"),
+    ("pyproject.toml",   "uv run pytest"),
+    ("package.json",     "npm test"),
+    ("Cargo.toml",       "cargo test"),
+    ("Makefile",         "make test"),
+    ("go.mod",           "go test ./..."),
+]
+
+
+def detect_test_command(repo_root: Path | None = None) -> str:
+    """Auto-detect test command from project marker files.
+
+    Detection order (first match wins):
+      pom.xml            → "mvn test"
+      build.gradle /
+      build.gradle.kts   → "./gradlew test"
+      pyproject.toml     → "uv run pytest"
+      package.json       → "npm test"
+      Cargo.toml         → "cargo test"
+      Makefile           → "make test"
+      go.mod             → "go test ./..."
+
+    Returns "" if no marker file found.
+    """
+    base = Path(repo_root or Path.cwd())
+    for marker, command in _DETECT_TABLE:
+        if (base / marker).exists():
+            return command
+    return ""
+
+
 # ── Credential registry ───────────────────────────────────────────────────────
 # Maps config-file key → environment variable name
 CREDENTIALS: dict[str, str] = {
@@ -204,6 +252,13 @@ _DEFAULTS: dict[str, Any] = {
     },
     "voyageai": {
         "read_timeout_seconds": 120,
+    },
+    "verification": {
+        "on_stop": False,
+        "on_close": False,
+        "test_command": "",
+        "lint_command": "",
+        "test_timeout": 120,
     },
     # Derived from TuningConfig() at module load — single source of truth.
     # Do not edit values here; change TuningConfig field defaults instead.

--- a/tests/hooks/test_pre_close_verification_hook.py
+++ b/tests/hooks/test_pre_close_verification_hook.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the PreToolUse close verification hook script."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "nx"
+    / "hooks"
+    / "scripts"
+    / "pre_close_verification_hook.sh"
+)
+
+# Minimal PATH to avoid invoking real bd/nx in tests
+_SAFE_PATH = "/usr/bin:/bin"
+
+# Prepend python3 dir so the config reader script can run
+import shutil as _shutil
+
+_PYTHON3 = _shutil.which("python3") or ""
+if _PYTHON3:
+    _SAFE_PATH = str(Path(_PYTHON3).parent) + ":" + _SAFE_PATH
+
+
+def _make_payload(
+    tool_name: str = "Bash",
+    command: str = "bd close nexus-4yit",
+) -> str:
+    return json.dumps(
+        {
+            "session_id": "test-session",
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": {"command": command},
+        }
+    )
+
+
+@pytest.fixture
+def mock_config_env(tmp_path):
+    """Factory: create CLAUDE_PLUGIN_ROOT with a fake read_verification_config.py."""
+
+    def _make(config: dict) -> dict[str, str]:
+        scripts_dir = tmp_path / "hooks" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        script = scripts_dir / "read_verification_config.py"
+        config_json = json.dumps(config)
+        script.write_text(f"print({repr(config_json)})\n")
+        return {"CLAUDE_PLUGIN_ROOT": str(tmp_path)}
+
+    return _make
+
+
+def _run_hook(
+    stdin: str,
+    *,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "PATH": _SAFE_PATH,
+        **(env_overrides or {}),
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse(result: subprocess.CompletedProcess[str]) -> dict:
+    """Return parsed JSON from stdout."""
+    return json.loads(result.stdout.strip())
+
+
+def _get_decision(parsed: dict) -> str:
+    """Extract permissionDecision from PreToolUse hookSpecificOutput."""
+    return parsed.get("hookSpecificOutput", {}).get("permissionDecision", "")
+
+
+def _get_reason(parsed: dict) -> str:
+    """Extract the reason/context string from PreToolUse output."""
+    hso = parsed.get("hookSpecificOutput", {})
+    return hso.get("permissionDecisionReason", "") or hso.get("additionalContext", "")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPreCloseVerificationHook:
+    """PreToolUse close verification hook tests."""
+
+    # --- Basic invariants ---
+
+    def test_script_exists_and_is_executable(self) -> None:
+        assert SCRIPT.exists(), f"Script not found: {SCRIPT}"
+        assert os.access(SCRIPT, os.X_OK), f"Script not executable: {SCRIPT}"
+
+    def test_exits_zero_always(self) -> None:
+        result = _run_hook(_make_payload())
+        assert result.returncode == 0
+
+    def test_outputs_valid_json_with_hookspecificoutput(self) -> None:
+        result = _run_hook(_make_payload())
+        parsed = _parse(result)
+        assert "hookSpecificOutput" in parsed
+        decision = _get_decision(parsed)
+        assert decision in ("allow", "deny", "ask")
+
+    # --- Fast no-ops (tool_name check) ---
+
+    def test_fast_noop_non_bash_tool(self) -> None:
+        """Non-Bash tool → allow immediately without reading config."""
+        result = _run_hook(
+            _make_payload(tool_name="Write", command="bd close nexus-4yit"),
+        )
+        assert result.returncode == 0
+        assert _get_decision(_parse(result)) == "allow"
+
+    def test_fast_noop_non_matching_bash(self) -> None:
+        """Bash command that doesn't match bd close/done → allow."""
+        result = _run_hook(_make_payload(command="ls -la"))
+        assert result.returncode == 0
+        assert _get_decision(_parse(result)) == "allow"
+
+    def test_fast_noop_bd_list(self) -> None:
+        """bd list is NOT close/done → allow."""
+        result = _run_hook(_make_payload(command="bd list --status=in_progress"))
+        assert result.returncode == 0
+        assert _get_decision(_parse(result)) == "allow"
+
+    # --- Config guard ---
+
+    def test_allow_when_on_close_false(self, mock_config_env) -> None:
+        """on_close=False → allow without running tests."""
+        env = mock_config_env({"on_close": False, "test_command": "false"})
+        result = _run_hook(
+            _make_payload(),
+            env_overrides={"PATH": _SAFE_PATH, **env},
+        )
+        assert result.returncode == 0
+        assert _get_decision(_parse(result)) == "allow"
+
+    def test_allow_when_config_reader_fails(self) -> None:
+        """Missing CLAUDE_PLUGIN_ROOT → config reader fails → allow (safe default)."""
+        result = _run_hook(
+            _make_payload(),
+            env_overrides={"CLAUDE_PLUGIN_ROOT": "/nonexistent/path"},
+        )
+        assert result.returncode == 0
+        assert _get_decision(_parse(result)) == "allow"
+
+    # --- Layer 2a: mechanical gate ---
+
+    def test_denies_on_test_failure(self, mock_config_env) -> None:
+        """on_close=True, test_command='false' → deny."""
+        env = mock_config_env({"on_close": True, "test_command": "false", "test_timeout": 10})
+        result = _run_hook(
+            _make_payload(),
+            env_overrides={"PATH": _SAFE_PATH, **env},
+        )
+        assert result.returncode == 0
+        parsed = _parse(result)
+        assert _get_decision(parsed) == "deny"
+        assert "Tests failing" in _get_reason(parsed)
+
+    def test_allows_on_test_pass(self, mock_config_env) -> None:
+        """on_close=True, test_command='true' → allow."""
+        env = mock_config_env({"on_close": True, "test_command": "true", "test_timeout": 10})
+        result = _run_hook(
+            _make_payload(),
+            env_overrides={"PATH": _SAFE_PATH, **env},
+        )
+        assert result.returncode == 0
+        assert _get_decision(_parse(result)) == "allow"
+
+    def test_bd_done_pattern_matches(self, mock_config_env) -> None:
+        """'bd done <id>' should trigger the gate (not fast-noop)."""
+        env = mock_config_env({"on_close": True, "test_command": "true", "test_timeout": 10})
+        result = _run_hook(
+            _make_payload(command="bd done nexus-xyz"),
+            env_overrides={"PATH": _SAFE_PATH, **env},
+        )
+        assert result.returncode == 0
+        assert _get_decision(_parse(result)) == "allow"
+
+    def test_command_not_found_is_advisory(self, mock_config_env) -> None:
+        """test_command not found → allow with advisory, not deny."""
+        env = mock_config_env(
+            {
+                "on_close": True,
+                "test_command": "nonexistent_cmd_xyz_999",
+                "test_timeout": 10,
+            }
+        )
+        result = _run_hook(
+            _make_payload(),
+            env_overrides={"PATH": _SAFE_PATH, **env},
+        )
+        assert result.returncode == 0
+        parsed = _parse(result)
+        assert _get_decision(parsed) == "allow"
+        assert "ADVISORY" in _get_reason(parsed)
+
+    def test_empty_test_command_advisory(self, mock_config_env) -> None:
+        """on_close=True but test_command='' → allow with advisory."""
+        env = mock_config_env({"on_close": True, "test_command": "", "test_timeout": 10})
+        result = _run_hook(
+            _make_payload(),
+            env_overrides={"PATH": _SAFE_PATH, **env},
+        )
+        assert result.returncode == 0
+        parsed = _parse(result)
+        assert _get_decision(parsed) == "allow"
+        assert "ADVISORY" in _get_reason(parsed)
+
+    # --- Edge cases ---
+
+    def test_graceful_empty_stdin(self) -> None:
+        """Empty stdin → allow (no crash)."""
+        result = _run_hook("")
+        assert result.returncode == 0
+        assert _get_decision(_parse(result)) == "allow"
+
+    def test_bd_close_multiple_ids(self, mock_config_env) -> None:
+        """'bd close id1 id2' → extracts first bead ID (id1) and proceeds."""
+        env = mock_config_env({"on_close": True, "test_command": "true", "test_timeout": 10})
+        result = _run_hook(
+            _make_payload(command="bd close id1 id2"),
+            env_overrides={"PATH": _SAFE_PATH, **env},
+        )
+        assert result.returncode == 0
+        assert _get_decision(_parse(result)) == "allow"

--- a/tests/hooks/test_read_verification_config.py
+++ b/tests/hooks/test_read_verification_config.py
@@ -1,0 +1,157 @@
+"""Tests for the read_verification_config standalone script."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "nx" / "hooks" / "scripts" / "read_verification_config.py"
+
+DEFAULTS = {
+    "on_stop": False,
+    "on_close": False,
+    "test_command": "",
+    "lint_command": "",
+    "test_timeout": 120,
+}
+
+
+def _run_script(
+    *,
+    cwd: Path | None = None,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, **(env_overrides or {})}
+    return subprocess.run(
+        ["python3", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        cwd=str(cwd) if cwd else None,
+        env=env,
+    )
+
+
+class TestReadVerificationConfig:
+    """Tests for read_verification_config.py."""
+
+    def test_script_exists(self) -> None:
+        assert SCRIPT.exists(), f"Script not found: {SCRIPT}"
+
+    def test_outputs_valid_json_no_nexus_yml(self, tmp_path: Path) -> None:
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data == DEFAULTS
+
+    def test_outputs_defaults_when_no_verification_section(self, tmp_path: Path) -> None:
+        (tmp_path / ".nexus.yml").write_text("indexing:\n  code_extensions: [.sql]\n")
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data == DEFAULTS
+
+    def test_reads_on_stop_true(self, tmp_path: Path) -> None:
+        (tmp_path / ".nexus.yml").write_text("verification:\n  on_stop: true\n")
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["on_stop"] is True
+        assert data["on_close"] is False
+
+    def test_reads_on_close_true(self, tmp_path: Path) -> None:
+        (tmp_path / ".nexus.yml").write_text("verification:\n  on_close: true\n")
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["on_close"] is True
+        assert data["on_stop"] is False
+
+    def test_reads_test_command_override(self, tmp_path: Path) -> None:
+        (tmp_path / ".nexus.yml").write_text(
+            "verification:\n  on_stop: true\n  test_command: 'make check'\n"
+        )
+        # Also create a pyproject.toml to confirm explicit command wins over auto-detect
+        (tmp_path / "pyproject.toml").write_text("")
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["test_command"] == "make check"
+
+    def test_auto_detects_pyproject(self, tmp_path: Path) -> None:
+        (tmp_path / ".nexus.yml").write_text("verification:\n  on_stop: true\n")
+        (tmp_path / "pyproject.toml").write_text("")
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["test_command"] == "uv run pytest"
+
+    def test_auto_detect_skipped_when_test_command_set(self, tmp_path: Path) -> None:
+        (tmp_path / ".nexus.yml").write_text(
+            "verification:\n  on_stop: true\n  test_command: 'my custom test'\n"
+        )
+        (tmp_path / "pyproject.toml").write_text("")
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["test_command"] == "my custom test"
+
+    def test_auto_detect_skipped_when_both_flags_false(self, tmp_path: Path) -> None:
+        (tmp_path / ".nexus.yml").write_text(
+            "verification:\n  on_stop: false\n  on_close: false\n"
+        )
+        (tmp_path / "pyproject.toml").write_text("")
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["test_command"] == ""
+
+    def test_malformed_yaml_returns_defaults(self, tmp_path: Path) -> None:
+        (tmp_path / ".nexus.yml").write_text("verification:\n  on_stop: [unclosed\n  bad: yaml:\n")
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data == DEFAULTS
+
+    def test_respects_claude_project_dir_env(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / "project"
+        config_dir.mkdir()
+        other_dir = tmp_path / "other"
+        other_dir.mkdir()
+        (config_dir / ".nexus.yml").write_text(
+            "verification:\n  on_stop: true\n  test_command: 'special command'\n"
+        )
+        result = _run_script(
+            cwd=other_dir,
+            env_overrides={"CLAUDE_PROJECT_DIR": str(config_dir)},
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["on_stop"] is True
+        assert data["test_command"] == "special command"
+
+    def test_reads_lint_command(self, tmp_path: Path) -> None:
+        (tmp_path / ".nexus.yml").write_text(
+            "verification:\n  on_stop: true\n  lint_command: 'ruff check .'\n"
+        )
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["lint_command"] == "ruff check ."
+
+    def test_reads_test_timeout(self, tmp_path: Path) -> None:
+        (tmp_path / ".nexus.yml").write_text(
+            "verification:\n  on_stop: true\n  test_timeout: 300\n"
+        )
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["test_timeout"] == 300
+
+    def test_exits_zero_always(self, tmp_path: Path) -> None:
+        """Script must always exit 0 regardless of errors."""
+        result = _run_script(cwd=tmp_path)
+        assert result.returncode == 0

--- a/tests/hooks/test_stop_verification_hook.py
+++ b/tests/hooks/test_stop_verification_hook.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the Stop verification hook script."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "nx" / "hooks" / "scripts" / "stop_verification_hook.sh"
+
+
+def _make_payload(stop_hook_active: bool = False) -> str:
+    return json.dumps({
+        "session_id": "test-session",
+        "hook_event_name": "Stop",
+        "stop_hook_active": stop_hook_active,
+    })
+
+
+def _run_hook(
+    stdin: str = "",
+    *,
+    env_overrides: dict[str, str] | None = None,
+    cwd: str | Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "PATH": os.environ.get("PATH", ""),
+        **(env_overrides or {}),
+    }
+    if not stdin:
+        stdin = _make_payload()
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+        cwd=cwd,
+    )
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", str(path)], capture_output=True, check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@test.com"], capture_output=True, check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], capture_output=True, check=True)
+    (path / "README.md").write_text("init\n")
+    subprocess.run(["git", "-C", str(path), "add", "."], capture_output=True, check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-m", "init"], capture_output=True, check=True)
+
+
+@pytest.fixture
+def mock_config_env(tmp_path_factory):
+    """Create a mock CLAUDE_PLUGIN_ROOT with a fake read_verification_config.py.
+
+    Uses tmp_path_factory so the plugin root is always a separate directory from
+    any git repo fixtures (which also use tmp_path), preventing cross-contamination.
+    """
+    plugin_root = tmp_path_factory.mktemp("plugin_root")
+    scripts_dir = plugin_root / "hooks" / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    def _make(config: dict) -> dict[str, str]:
+        script = scripts_dir / "read_verification_config.py"
+        # Embed as a JSON string literal — avoids Python True/False mismatch
+        config_json = json.dumps(config)
+        script.write_text(
+            f"import json; print({repr(config_json)})\n"
+        )
+        return {"CLAUDE_PLUGIN_ROOT": str(plugin_root)}
+
+    return _make
+
+
+@pytest.fixture
+def clean_git_repo(tmp_path):
+    """A clean git repo with one commit and no uncommitted changes."""
+    _init_git_repo(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def dirty_git_repo(tmp_path):
+    """A git repo with an uncommitted modification."""
+    _init_git_repo(tmp_path)
+    (tmp_path / "README.md").write_text("modified\n")
+    return tmp_path
+
+
+# Path that has neither git nor bd nor any test tooling
+_MINIMAL_PATH = "/usr/bin:/bin"
+
+
+class TestStopVerificationHook:
+    """Stop verification hook script tests."""
+
+    def test_script_exists_and_is_executable(self) -> None:
+        assert SCRIPT.exists(), f"Script not found: {SCRIPT}"
+        assert os.access(SCRIPT, os.X_OK), f"Script not executable: {SCRIPT}"
+
+    def test_exits_zero_always(self) -> None:
+        result = _run_hook()
+        assert result.returncode == 0
+
+    def test_outputs_valid_json(self, mock_config_env) -> None:
+        env = mock_config_env({"on_stop": False})
+        result = _run_hook(env_overrides=env)
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert "decision" in parsed
+
+    def test_approve_when_on_stop_false(self, mock_config_env) -> None:
+        env = mock_config_env({"on_stop": False})
+        result = _run_hook(env_overrides=env)
+        parsed = json.loads(result.stdout)
+        assert parsed["decision"] == "approve"
+
+    def test_approve_when_config_reader_fails(self) -> None:
+        """When CLAUDE_PLUGIN_ROOT points nowhere, safe default is approve."""
+        result = _run_hook(env_overrides={"CLAUDE_PLUGIN_ROOT": "/nonexistent/path/xyz"})
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["decision"] == "approve"
+
+    def test_first_pass_blocks_on_uncommitted_changes(self, mock_config_env, dirty_git_repo) -> None:
+        """Uncommitted changes in git repo → block on first pass."""
+        env = {
+            **mock_config_env({
+                "on_stop": True,
+                "test_command": "",
+                "test_timeout": 10,
+            }),
+            # Remove bd from PATH to avoid false open-bead failures
+            "PATH": _MINIMAL_PATH,
+        }
+        result = _run_hook(
+            stdin=_make_payload(stop_hook_active=False),
+            env_overrides=env,
+            cwd=dirty_git_repo,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["decision"] == "block"
+        assert "uncommitted" in parsed["reason"].lower()
+
+    def test_first_pass_approve_when_clean(self, mock_config_env, clean_git_repo) -> None:
+        """Clean git repo + passing test command → approve."""
+        env = {
+            **mock_config_env({
+                "on_stop": True,
+                "test_command": "true",
+                "test_timeout": 10,
+            }),
+            "PATH": f"/usr/bin:/bin:{os.environ.get('PATH', '')}",
+        }
+        result = _run_hook(
+            stdin=_make_payload(stop_hook_active=False),
+            env_overrides=env,
+            cwd=clean_git_repo,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["decision"] == "approve"
+
+    def test_first_pass_blocks_on_test_failure(self, mock_config_env, clean_git_repo) -> None:
+        """test_command that always fails → block on first pass."""
+        env = {
+            **mock_config_env({
+                "on_stop": True,
+                "test_command": "false",
+                "test_timeout": 10,
+            }),
+            "PATH": _MINIMAL_PATH,
+        }
+        result = _run_hook(
+            stdin=_make_payload(stop_hook_active=False),
+            env_overrides=env,
+            cwd=clean_git_repo,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["decision"] == "block"
+        assert "test" in parsed["reason"].lower() or "exit" in parsed["reason"].lower()
+
+    def test_retry_lets_test_failures_through(self, mock_config_env, clean_git_repo) -> None:
+        """On retry (stop_hook_active=true), test failures → approve with warning."""
+        env = {
+            **mock_config_env({
+                "on_stop": True,
+                "test_command": "false",
+                "test_timeout": 10,
+            }),
+            "PATH": _MINIMAL_PATH,
+        }
+        result = _run_hook(
+            stdin=_make_payload(stop_hook_active=True),
+            env_overrides=env,
+            cwd=clean_git_repo,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["decision"] == "approve"
+        assert "warning" in parsed.get("reason", "").upper() or "TESTS FAILING" in parsed.get("reason", "")
+
+    def test_retry_blocks_mechanical_failures(self, mock_config_env, dirty_git_repo) -> None:
+        """On retry, git uncommitted changes still block."""
+        env = {
+            **mock_config_env({
+                "on_stop": True,
+                "test_command": "",
+                "test_timeout": 10,
+            }),
+            "PATH": _MINIMAL_PATH,
+        }
+        result = _run_hook(
+            stdin=_make_payload(stop_hook_active=True),
+            env_overrides=env,
+            cwd=dirty_git_repo,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["decision"] == "block"
+
+    def test_command_not_found_is_advisory(self, mock_config_env, clean_git_repo) -> None:
+        """Unknown test command (exit 127) → approve with advisory, never block."""
+        env = {
+            **mock_config_env({
+                "on_stop": True,
+                "test_command": "nonexistent_command_xyz_999",
+                "test_timeout": 10,
+            }),
+            "PATH": _MINIMAL_PATH,
+        }
+        result = _run_hook(
+            stdin=_make_payload(stop_hook_active=False),
+            env_overrides=env,
+            cwd=clean_git_repo,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["decision"] == "approve"
+
+    def test_timeout_is_advisory(self, mock_config_env, clean_git_repo) -> None:
+        """Test command that times out → approve with advisory, never block."""
+        env = {
+            **mock_config_env({
+                "on_stop": True,
+                "test_command": "sleep 999",
+                "test_timeout": 1,
+            }),
+            "PATH": f"/usr/bin:/bin:{os.environ.get('PATH', '')}",
+        }
+        result = _run_hook(
+            stdin=_make_payload(stop_hook_active=False),
+            env_overrides=env,
+            cwd=clean_git_repo,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["decision"] == "approve"
+
+    def test_empty_test_command_skips_test_check(self, mock_config_env, clean_git_repo) -> None:
+        """Empty test_command → skip test check entirely, approve with advisory."""
+        env = {
+            **mock_config_env({
+                "on_stop": True,
+                "test_command": "",
+                "test_timeout": 10,
+            }),
+            "PATH": _MINIMAL_PATH,
+        }
+        result = _run_hook(
+            stdin=_make_payload(stop_hook_active=False),
+            env_overrides=env,
+            cwd=clean_git_repo,
+        )
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        # Advisory-only failures → approve
+        assert parsed["decision"] == "approve"
+
+    def test_graceful_empty_stdin(self, mock_config_env) -> None:
+        """Empty stdin → safe default (approve)."""
+        env = mock_config_env({"on_stop": False})
+        result = _run_hook(stdin="", env_overrides=env)
+        assert result.returncode == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["decision"] == "approve"

--- a/tests/hooks/test_verification_integration.py
+++ b/tests/hooks/test_verification_integration.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Integration tests for the verification hook pipeline."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parents[2] / "nx" / "hooks" / "scripts"
+HOOKS_JSON = Path(__file__).resolve().parents[2] / "nx" / "hooks" / "hooks.json"
+STOP_HOOK = HOOKS_DIR / "stop_verification_hook.sh"
+CLOSE_HOOK = HOOKS_DIR / "pre_close_verification_hook.sh"
+CONFIG_READER = HOOKS_DIR / "read_verification_config.py"
+
+# Minimal PATH with python3 but without bd/nx
+_PYTHON3 = subprocess.run(
+    ["which", "python3"], capture_output=True, text=True
+).stdout.strip()
+_MINIMAL_PATH = f"{os.path.dirname(_PYTHON3)}:/usr/bin:/bin"
+
+
+def _run_hook(
+    script: Path,
+    stdin: str,
+    *,
+    env_overrides: dict[str, str] | None = None,
+    cwd: str | Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        "PATH": _MINIMAL_PATH,
+        "HOME": os.environ.get("HOME", "/tmp"),
+        **(env_overrides or {}),
+    }
+    return subprocess.run(
+        ["bash", str(script)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+        cwd=cwd,
+    )
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", str(path)], capture_output=True, check=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@test.com"],
+        capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.name", "Test"],
+        capture_output=True, check=True,
+    )
+    (path / "README.md").write_text("init\n")
+    subprocess.run(["git", "-C", str(path), "add", "."], capture_output=True, check=True)
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "init"],
+        capture_output=True, check=True,
+    )
+
+
+@pytest.fixture
+def mock_plugin_root(tmp_path_factory: pytest.TempPathFactory):
+    """Create a mock CLAUDE_PLUGIN_ROOT with a configurable read_verification_config.py."""
+    root = tmp_path_factory.mktemp("plugin")
+    scripts_dir = root / "hooks" / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    def _make(config: dict) -> dict[str, str]:
+        config_json = json.dumps(config)
+        script = scripts_dir / "read_verification_config.py"
+        script.write_text(
+            f"import json; print({repr(config_json)})"
+        )
+        return {"CLAUDE_PLUGIN_ROOT": str(root)}
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# hooks.json structure tests
+# ---------------------------------------------------------------------------
+
+
+class TestHooksJsonStructure:
+    """Verify hooks.json registration is correct."""
+
+    def test_hooks_json_is_valid_json(self) -> None:
+        data = json.loads(HOOKS_JSON.read_text())
+        assert "hooks" in data
+
+    def test_hooks_json_has_stop_event(self) -> None:
+        data = json.loads(HOOKS_JSON.read_text())
+        assert "Stop" in data["hooks"]
+
+    def test_hooks_json_has_pretooluse_event(self) -> None:
+        data = json.loads(HOOKS_JSON.read_text())
+        assert "PreToolUse" in data["hooks"]
+
+    def test_hooks_json_stop_timeout(self) -> None:
+        data = json.loads(HOOKS_JSON.read_text())
+        stop_hooks = data["hooks"]["Stop"]
+        hook = stop_hooks[0]["hooks"][0]
+        assert hook["timeout"] == 180
+
+    def test_hooks_json_pretooluse_timeout(self) -> None:
+        data = json.loads(HOOKS_JSON.read_text())
+        pre_hooks = data["hooks"]["PreToolUse"]
+        hook = pre_hooks[0]["hooks"][0]
+        assert hook["timeout"] == 300
+
+    def test_hooks_json_pretooluse_matcher_is_bash(self) -> None:
+        data = json.loads(HOOKS_JSON.read_text())
+        pre_hooks = data["hooks"]["PreToolUse"]
+        assert pre_hooks[0]["matcher"] == "Bash"
+
+    def test_hooks_json_existing_hooks_unchanged(self) -> None:
+        data = json.loads(HOOKS_JSON.read_text())
+        hooks = data["hooks"]
+        assert "SessionStart" in hooks
+        assert "PostCompact" in hooks
+        assert "StopFailure" in hooks
+        assert "SubagentStart" in hooks
+
+    def test_hooks_json_references_valid_scripts(self) -> None:
+        """All hook commands referencing hooks/scripts/ point to existing files."""
+        data = json.loads(HOOKS_JSON.read_text())
+        for event_name, event_hooks in data["hooks"].items():
+            for hook_group in event_hooks:
+                for hook in hook_group.get("hooks", []):
+                    cmd = hook.get("command", "")
+                    if "hooks/scripts/" in cmd:
+                        script_name = cmd.split("hooks/scripts/")[-1].split()[0]
+                        script_path = HOOKS_DIR / script_name
+                        assert script_path.exists(), (
+                            f"{event_name} references missing script: {script_path}"
+                        )
+
+
+# ---------------------------------------------------------------------------
+# Script existence and permissions
+# ---------------------------------------------------------------------------
+
+
+class TestScriptPermissions:
+    """Verify all hook scripts exist and are executable."""
+
+    def test_stop_hook_exists_and_executable(self) -> None:
+        assert STOP_HOOK.exists()
+        assert os.access(STOP_HOOK, os.X_OK)
+
+    def test_close_hook_exists_and_executable(self) -> None:
+        assert CLOSE_HOOK.exists()
+        assert os.access(CLOSE_HOOK, os.X_OK)
+
+    def test_config_reader_exists(self) -> None:
+        assert CONFIG_READER.exists()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end pipeline tests
+# ---------------------------------------------------------------------------
+
+
+class TestStopHookPipeline:
+    """End-to-end tests for the Stop verification hook."""
+
+    def test_on_stop_false_passes_through(self, mock_plugin_root) -> None:
+        env = mock_plugin_root({"on_stop": False})
+        payload = json.dumps({"hook_event_name": "Stop", "stop_hook_active": False})
+        result = _run_hook(STOP_HOOK, payload, env_overrides=env)
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "approve"
+
+    def test_on_stop_true_with_passing_tests(self, tmp_path, mock_plugin_root) -> None:
+        _init_git_repo(tmp_path)
+        env = mock_plugin_root({"on_stop": True, "test_command": "true", "test_timeout": 10})
+        payload = json.dumps({"hook_event_name": "Stop", "stop_hook_active": False})
+        result = _run_hook(STOP_HOOK, payload, env_overrides=env, cwd=tmp_path)
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "approve"
+
+    def test_blocks_uncommitted_changes(self, tmp_path, mock_plugin_root) -> None:
+        _init_git_repo(tmp_path)
+        (tmp_path / "README.md").write_text("modified\n")
+        env = mock_plugin_root({"on_stop": True, "test_command": "true", "test_timeout": 10})
+        payload = json.dumps({"hook_event_name": "Stop", "stop_hook_active": False})
+        result = _run_hook(STOP_HOOK, payload, env_overrides=env, cwd=tmp_path)
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "Uncommitted" in output.get("reason", "")
+
+    def test_blocks_test_failure_first_pass(self, tmp_path, mock_plugin_root) -> None:
+        _init_git_repo(tmp_path)
+        env = mock_plugin_root({"on_stop": True, "test_command": "false", "test_timeout": 10})
+        payload = json.dumps({"hook_event_name": "Stop", "stop_hook_active": False})
+        result = _run_hook(STOP_HOOK, payload, env_overrides=env, cwd=tmp_path)
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+
+    def test_retry_lets_test_failures_through(self, tmp_path, mock_plugin_root) -> None:
+        _init_git_repo(tmp_path)
+        env = mock_plugin_root({"on_stop": True, "test_command": "false", "test_timeout": 10})
+        payload = json.dumps({"hook_event_name": "Stop", "stop_hook_active": True})
+        result = _run_hook(STOP_HOOK, payload, env_overrides=env, cwd=tmp_path)
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "approve"
+        assert "WARNING" in output.get("reason", "")
+
+
+class TestCloseHookPipeline:
+    """End-to-end tests for the PreToolUse close verification hook."""
+
+    @staticmethod
+    def _get_decision(output: dict) -> str:
+        return output.get("hookSpecificOutput", {}).get("permissionDecision", "")
+
+    def test_non_bash_tool_fast_noop(self) -> None:
+        payload = json.dumps({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/tmp/x.txt", "content": "x"},
+        })
+        result = _run_hook(CLOSE_HOOK, payload)
+        assert result.returncode == 0
+        assert self._get_decision(json.loads(result.stdout)) == "allow"
+
+    def test_non_matching_bash_fast_noop(self) -> None:
+        payload = json.dumps({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls -la"},
+        })
+        result = _run_hook(CLOSE_HOOK, payload)
+        assert result.returncode == 0
+        assert self._get_decision(json.loads(result.stdout)) == "allow"
+
+    def test_on_close_true_denies_failing_tests(self, mock_plugin_root) -> None:
+        env = mock_plugin_root({"on_close": True, "test_command": "false", "test_timeout": 10})
+        payload = json.dumps({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "bd close nexus-test"},
+        })
+        result = _run_hook(CLOSE_HOOK, payload, env_overrides=env)
+        assert result.returncode == 0
+        assert self._get_decision(json.loads(result.stdout)) == "deny"
+
+    def test_on_close_true_allows_passing_tests(self, mock_plugin_root) -> None:
+        env = mock_plugin_root({"on_close": True, "test_command": "true", "test_timeout": 10})
+        payload = json.dumps({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "bd close nexus-test"},
+        })
+        result = _run_hook(CLOSE_HOOK, payload, env_overrides=env)
+        assert result.returncode == 0
+        assert self._get_decision(json.loads(result.stdout)) == "allow"
+
+    def test_bd_done_triggers_check(self, mock_plugin_root) -> None:
+        env = mock_plugin_root({"on_close": True, "test_command": "true", "test_timeout": 10})
+        payload = json.dumps({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "bd done nexus-test"},
+        })
+        result = _run_hook(CLOSE_HOOK, payload, env_overrides=env)
+        assert result.returncode == 0
+        assert self._get_decision(json.loads(result.stdout)) == "allow"
+
+    def test_on_close_false_passes_through(self, mock_plugin_root) -> None:
+        env = mock_plugin_root({"on_close": False, "test_command": "false"})
+        payload = json.dumps({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "bd close nexus-test"},
+        })
+        result = _run_hook(CLOSE_HOOK, payload, env_overrides=env)
+        assert result.returncode == 0
+        assert self._get_decision(json.loads(result.stdout)) == "allow"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from nexus.config import _DEFAULTS, load_config
+from nexus.config import _DEFAULTS, detect_test_command, get_verification_config, load_config
 
 
 def test_config_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -197,3 +197,135 @@ def test_nexus_yml_indexing_overrides(
     assert cfg["indexing"]["rdr_paths"] == ["docs/rdr", "design/decisions"]
     # prose_extensions not set in override → stays default
     assert cfg["indexing"]["prose_extensions"] == []
+
+
+# ── Verification config section ───────────────────────────────────────────────
+
+
+def test_defaults_include_verification_section() -> None:
+    """_DEFAULTS contains the verification section with all 5 keys and correct types."""
+    assert "verification" in _DEFAULTS
+    v = _DEFAULTS["verification"]
+    assert v["on_stop"] is False
+    assert v["on_close"] is False
+    assert v["test_command"] == ""
+    assert v["lint_command"] == ""
+    assert v["test_timeout"] == 120
+    assert isinstance(v["test_timeout"], int)
+
+
+def test_get_verification_config_returns_defaults_when_no_nexus_yml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """get_verification_config returns all defaults when no .nexus.yml exists."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = get_verification_config(repo_root=tmp_path)
+    assert cfg["on_stop"] is False
+    assert cfg["on_close"] is False
+    assert cfg["test_command"] == ""
+    assert cfg["lint_command"] == ""
+    assert cfg["test_timeout"] == 120
+
+
+def test_get_verification_config_merges_partial_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Partial verification section in .nexus.yml; rest comes from defaults."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".nexus.yml").write_text("verification:\n  on_stop: true\n")
+    cfg = get_verification_config(repo_root=tmp_path)
+    assert cfg["on_stop"] is True
+    # remaining keys stay at defaults
+    assert cfg["on_close"] is False
+    assert cfg["test_command"] == ""
+    assert cfg["lint_command"] == ""
+    assert cfg["test_timeout"] == 120
+
+
+def test_get_verification_config_all_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All verification fields in .nexus.yml override defaults."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".nexus.yml").write_text(
+        "verification:\n"
+        "  on_stop: true\n"
+        "  on_close: true\n"
+        "  test_command: uv run pytest\n"
+        "  lint_command: ruff check .\n"
+        "  test_timeout: 60\n"
+    )
+    cfg = get_verification_config(repo_root=tmp_path)
+    assert cfg["on_stop"] is True
+    assert cfg["on_close"] is True
+    assert cfg["test_command"] == "uv run pytest"
+    assert cfg["lint_command"] == "ruff check ."
+    assert cfg["test_timeout"] == 60
+
+
+# ── detect_test_command ───────────────────────────────────────────────────────
+
+
+def test_detect_test_command_pyproject(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[build-system]\n")
+    assert detect_test_command(repo_root=tmp_path) == "uv run pytest"
+
+
+def test_detect_test_command_pom(tmp_path: Path) -> None:
+    (tmp_path / "pom.xml").write_text("<project/>\n")
+    assert detect_test_command(repo_root=tmp_path) == "mvn test"
+
+
+def test_detect_test_command_gradle(tmp_path: Path) -> None:
+    (tmp_path / "build.gradle").write_text("// gradle\n")
+    assert detect_test_command(repo_root=tmp_path) == "./gradlew test"
+
+
+def test_detect_test_command_package_json(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text('{"scripts": {"test": "jest"}}\n')
+    assert detect_test_command(repo_root=tmp_path) == "npm test"
+
+
+def test_detect_test_command_cargo(tmp_path: Path) -> None:
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "foo"\n')
+    assert detect_test_command(repo_root=tmp_path) == "cargo test"
+
+
+def test_detect_test_command_makefile(tmp_path: Path) -> None:
+    (tmp_path / "Makefile").write_text("test:\n\tpython -m pytest\n")
+    assert detect_test_command(repo_root=tmp_path) == "make test"
+
+
+def test_detect_test_command_go_mod(tmp_path: Path) -> None:
+    (tmp_path / "go.mod").write_text("module example.com/foo\n")
+    assert detect_test_command(repo_root=tmp_path) == "go test ./..."
+
+
+def test_detect_test_command_none(tmp_path: Path) -> None:
+    assert detect_test_command(repo_root=tmp_path) == ""
+
+
+def test_detect_test_command_priority(tmp_path: Path) -> None:
+    """When both pyproject.toml and Makefile exist, pyproject.toml wins (first match)."""
+    (tmp_path / "pyproject.toml").write_text("[build-system]\n")
+    (tmp_path / "Makefile").write_text("test:\n\tpython -m pytest\n")
+    assert detect_test_command(repo_root=tmp_path) == "uv run pytest"
+
+
+def test_detect_test_command_gradle_kts(tmp_path: Path) -> None:
+    """build.gradle.kts (Kotlin DSL) is detected as Gradle."""
+    (tmp_path / "build.gradle.kts").write_text("// kotlin gradle\n")
+    assert detect_test_command(repo_root=tmp_path) == "./gradlew test"
+
+
+def test_detect_table_matches_reader_script() -> None:
+    """config.py _DETECT_TABLE and reader script DETECT_TABLE must be identical."""
+    import importlib.util
+
+    from nexus.config import _DETECT_TABLE
+
+    script = Path(__file__).parents[1] / "nx" / "hooks" / "scripts" / "read_verification_config.py"
+    spec = importlib.util.spec_from_file_location("reader", script)
+    reader = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(reader)
+    assert _DETECT_TABLE == reader.DETECT_TABLE

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "2.9.2"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

- **Stop hook** (`on_stop: true`) — blocks session end on uncommitted changes, open beads, or test failures. On retry, test failures let through with warning.
- **PreToolUse close gate** (`on_close: true`) — intercepts `bd close`/`bd done`, denies on test failure, advisory when no review marker in T1 scratch.
- Standalone `read_verification_config.py` config reader, `get_verification_config()` + `detect_test_command()` in config.py, hooks.json registration, review-code skill scratch marker, docs.

## Test plan

- [x] 116 unit + integration tests pass (`uv run pytest tests/test_config.py tests/hooks/`)
- [x] Live-tested: PreToolUse hook fires on `bd close`
- [x] Live-tested: allow path (tests pass → close proceeds)
- [x] Live-tested: deny path (tests fail → close blocked)
- [x] Live-tested: timeout advisory (tests exceed timeout → close proceeds with warning)
- [x] `stop_hook_active` field confirmed in Claude Code Stop hook stdin

Bead: nexus-0ohu