### PR TITLE
feat(catalog): auto-link at storage boundaries

### DIFF
--- a/nx/skills/architecture/SKILL.md
+++ b/nx/skills/architecture/SKILL.md
@@ -42,6 +42,18 @@ Delegates to the **architect-planner** agent (model: opus).
 strategic-planner -> plan-auditor -> architect-planner -> developer
 ```
 
+## Pre-Dispatch: Seed Link Context
+
+Before dispatching the architect-planner agent, seed T1 scratch with link targets so the auto-linker can create catalog links when the agent stores findings:
+
+1. If the task references an RDR (pattern `RDR-\d+`) or a known document, resolve it: `mcp__plugin_nx_nexus__catalog_search(query="RDR-NNN or document title")`
+2. Check T1 scratch for `rdr-planning-context`
+3. Write link context to scratch:
+   ```
+   mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<resolved-tumbler>", "link_type": "relates"}], "source_agent": "architect-planner"}', tags="link-context")
+   ```
+4. If no RDR/document reference found, skip seeding (the auto-linker handles empty context gracefully)
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **architect-planner**:

--- a/nx/skills/debugging/SKILL.md
+++ b/nx/skills/debugging/SKILL.md
@@ -35,6 +35,18 @@ Delegates to the **debugger** agent (model: opus).
 - Performance issues requiring systematic investigation
 - Any bug where the root cause is not immediately obvious
 
+## Pre-Dispatch: Seed Link Context
+
+Before dispatching the debugger agent, seed T1 scratch with link targets so the auto-linker can create catalog links when the agent stores findings:
+
+1. If the task references an RDR (pattern `RDR-\d+`), resolve it: `mcp__plugin_nx_nexus__catalog_search(query="RDR-NNN")`
+2. Check T1 scratch for `rdr-planning-context`
+3. Write link context to scratch:
+   ```
+   mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<resolved-tumbler>", "link_type": "relates"}], "source_agent": "debugger"}', tags="link-context")
+   ```
+4. If no RDR/document reference found, skip seeding (the auto-linker handles empty context gracefully)
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **debugger**:

--- a/nx/skills/deep-analysis/SKILL.md
+++ b/nx/skills/deep-analysis/SKILL.md
@@ -17,6 +17,18 @@ Delegates to the **deep-analyst** agent (model: opus).
 - When root cause analysis requires deep investigation
 - After debugger if issue is cross-cutting
 
+## Pre-Dispatch: Seed Link Context
+
+Before dispatching the deep-analyst agent, seed T1 scratch with link targets so the auto-linker can create catalog links when the agent stores findings:
+
+1. If the task references an RDR (pattern `RDR-\d+`) or a known document, resolve it: `mcp__plugin_nx_nexus__catalog_search(query="RDR-NNN or document title")`
+2. Check T1 scratch for `rdr-planning-context`
+3. Write link context to scratch:
+   ```
+   mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<resolved-tumbler>", "link_type": "relates"}], "source_agent": "deep-analyst"}', tags="link-context")
+   ```
+4. If no RDR/document reference found, skip seeding (the auto-linker handles empty context gracefully)
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **deep-analyst**:

--- a/nx/skills/development/SKILL.md
+++ b/nx/skills/development/SKILL.md
@@ -35,6 +35,18 @@ Delegates to the **developer** agent (sonnet). See [registry.yaml](../../registr
 - Executing tasks from an approved implementation plan
 - Writing or modifying production code
 
+## Pre-Dispatch: Seed Link Context
+
+Before dispatching the developer agent, seed T1 scratch with link targets so the auto-linker can create catalog links when the agent stores findings:
+
+1. If the task references an RDR (pattern `RDR-\d+`), resolve it: `mcp__plugin_nx_nexus__catalog_search(query="RDR-NNN")`
+2. Check T1 scratch for `rdr-planning-context` (set by strategic-planner for RDR-driven beads)
+3. Write link context to scratch — use `"implements"` when working on an RDR-driven bead, `"relates"` otherwise:
+   ```
+   mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<resolved-tumbler>", "link_type": "implements"}], "source_agent": "developer"}', tags="link-context")
+   ```
+4. If no RDR/document reference found, skip seeding (the auto-linker handles empty context gracefully)
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **developer**:

--- a/nx/skills/research-synthesis/SKILL.md
+++ b/nx/skills/research-synthesis/SKILL.md
@@ -16,6 +16,18 @@ Delegates to the **deep-research-synthesizer** agent. See [registry.yaml](../../
 - Questions requiring synthesis from multiple sources
 - When nx T3 search returns insufficient context for a decision
 
+## Pre-Dispatch: Seed Link Context
+
+Before dispatching the deep-research-synthesizer agent, seed T1 scratch with link targets so the auto-linker can create catalog links when the agent stores findings:
+
+1. If the task references an RDR (pattern `RDR-\d+`) or a known document, resolve it: `mcp__plugin_nx_nexus__catalog_search(query="RDR-NNN or document title")`
+2. Check T1 scratch for `rdr-planning-context`
+3. Write link context to scratch:
+   ```
+   mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<resolved-tumbler>", "link_type": "cites"}], "source_agent": "deep-research-synthesizer"}', tags="link-context")
+   ```
+4. If no RDR/document reference found, skip seeding (the auto-linker handles empty context gracefully)
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **deep-research-synthesizer**:

--- a/src/nexus/catalog/auto_linker.py
+++ b/src/nexus/catalog/auto_linker.py
@@ -30,6 +30,10 @@ def read_link_contexts(entries: list[dict[str, Any]]) -> list[LinkContext]:
 
     Each entry may contain a ``targets`` array with multiple items.
     Flattens: one entry with N targets → N LinkContext objects.
+
+    Accepts both ``"target_tumbler"`` (canonical) and ``"tumbler"``
+    (shorthand used by skill SKILL.md templates). ``link_type`` defaults
+    to ``"relates"`` when omitted.
     """
     contexts: list[LinkContext] = []
     for entry in entries:
@@ -43,6 +47,7 @@ def read_link_contexts(entries: list[dict[str, Any]]) -> list[LinkContext]:
 
         targets = raw.get("targets", [])
         for item in targets:
+            # "tumbler" is the skill-authored shorthand; "target_tumbler" is canonical
             tumbler = item.get("target_tumbler") or item.get("tumbler", "")
             link_type = item.get("link_type", "relates")
             if tumbler:
@@ -78,12 +83,14 @@ def auto_link(
                 ctx.link_type,
                 created_by="auto-linker",
             )
-        except ValueError:
-            # Endpoint not found in catalog — skip gracefully
+        except ValueError as exc:
+            # link_if_absent raises ValueError for missing endpoints;
+            # log the message to distinguish from unexpected ValueErrors
             _log.debug(
                 "auto_link_skip_missing_endpoint",
                 source=str(source_tumbler),
                 target=str(target),
+                reason=str(exc),
             )
             continue
 

--- a/src/nexus/catalog/auto_linker.py
+++ b/src/nexus/catalog/auto_linker.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+
+"""Auto-create catalog links from T1 scratch link-context entries."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.tumbler import Tumbler
+
+_log = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class LinkContext:
+    """A single link target parsed from a T1 scratch link-context entry."""
+
+    target_tumbler: str
+    link_type: str
+
+
+def read_link_contexts(entries: list[dict[str, Any]]) -> list[LinkContext]:
+    """Parse T1 scratch entries into LinkContext objects.
+
+    Each entry may contain a ``targets`` array with multiple items.
+    Flattens: one entry with N targets → N LinkContext objects.
+    """
+    contexts: list[LinkContext] = []
+    for entry in entries:
+        raw = entry
+        # If the entry has a "content" key (raw T1 scratch format), parse it
+        if isinstance(raw.get("content"), str):
+            try:
+                raw = json.loads(raw["content"])
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+        targets = raw.get("targets", [])
+        for item in targets:
+            tumbler = item.get("target_tumbler") or item.get("tumbler", "")
+            link_type = item.get("link_type", "relates")
+            if tumbler:
+                contexts.append(LinkContext(target_tumbler=tumbler, link_type=link_type))
+    return contexts
+
+
+def auto_link(
+    cat: Catalog,
+    source_tumbler: Tumbler,
+    contexts: list[LinkContext],
+) -> int:
+    """Create catalog links from source to each target in contexts.
+
+    Uses ``link_if_absent`` for idempotency. Skips targets whose tumblers
+    don't resolve. Returns the number of links actually created.
+    """
+    if not contexts:
+        return 0
+
+    count = 0
+    for ctx in contexts:
+        try:
+            target = Tumbler.parse(ctx.target_tumbler)
+        except ValueError:
+            _log.debug("auto_link_skip_invalid_tumbler", tumbler=ctx.target_tumbler)
+            continue
+
+        try:
+            created = cat.link_if_absent(
+                source_tumbler,
+                target,
+                ctx.link_type,
+                created_by="auto-linker",
+            )
+        except ValueError:
+            # Endpoint not found in catalog — skip gracefully
+            _log.debug(
+                "auto_link_skip_missing_endpoint",
+                source=str(source_tumbler),
+                target=str(target),
+            )
+            continue
+
+        if created:
+            count += 1
+            _log.debug(
+                "auto_link_created",
+                source=str(source_tumbler),
+                target=str(target),
+                link_type=ctx.link_type,
+            )
+
+    return count

--- a/src/nexus/mcp_server.py
+++ b/src/nexus/mcp_server.py
@@ -162,6 +162,28 @@ def _max_jsonl_mtime(cat) -> float:
     return mtime
 
 
+def _catalog_auto_link(doc_id: str) -> int:
+    """Create catalog links from T1 link-context to the just-stored document.
+
+    Reads link-context entries from T1 scratch, resolves the stored doc's
+    tumbler via doc_id, and creates links. Returns count of links created.
+    """
+    cat = _get_catalog()
+    if cat is None:
+        return 0
+    t1, _ = _get_t1()
+    entries = t1.list_entries()
+    link_entries = [e for e in entries if "link-context" in (e.get("tags") or "")]
+    if not link_entries:
+        return 0
+    entry = cat.by_doc_id(doc_id)
+    if entry is None:
+        return 0
+    from nexus.catalog.auto_linker import auto_link, read_link_contexts
+    contexts = read_link_contexts(link_entries)
+    return auto_link(cat, entry.tumbler, contexts)
+
+
 def _get_catalog():
     """Return Catalog singleton or None if not initialized.
 
@@ -608,6 +630,11 @@ def store_put(
             _catalog_store_hook(title=title, doc_id=doc_id, collection_name=col_name)
         except Exception:
             pass  # catalog registration is non-fatal
+        # Auto-link from T1 scratch link-context
+        try:
+            _catalog_auto_link(doc_id)
+        except Exception:
+            pass  # auto-linking is non-fatal
         return f"Stored: {doc_id} -> {col_name}"
     except Exception as e:
         return f"Error: {e}"

--- a/src/nexus/mcp_server.py
+++ b/src/nexus/mcp_server.py
@@ -166,18 +166,28 @@ def _catalog_auto_link(doc_id: str) -> int:
     """Create catalog links from T1 link-context to the just-stored document.
 
     Reads link-context entries from T1 scratch, resolves the stored doc's
-    tumbler via doc_id, and creates links. Returns count of links created.
+    tumbler via doc_id, and creates links. Link-context entries persist for
+    the session — every store_put in the session links to the seeded targets.
+    Returns count of links created.
     """
+    import structlog
+    _al_log = structlog.get_logger()
+
     cat = _get_catalog()
     if cat is None:
         return 0
     t1, _ = _get_t1()
     entries = t1.list_entries()
-    link_entries = [e for e in entries if "link-context" in (e.get("tags") or "")]
+    # Exact tag match — avoid substring hits on e.g. "pre-link-context"
+    link_entries = [
+        e for e in entries
+        if "link-context" in {t.strip() for t in (e.get("tags") or "").split(",")}
+    ]
     if not link_entries:
         return 0
     entry = cat.by_doc_id(doc_id)
     if entry is None:
+        _al_log.debug("auto_link_skip_doc_not_in_catalog", doc_id=doc_id)
         return 0
     from nexus.catalog.auto_linker import auto_link, read_link_contexts
     contexts = read_link_contexts(link_entries)
@@ -632,7 +642,10 @@ def store_put(
             pass  # catalog registration is non-fatal
         # Auto-link from T1 scratch link-context
         try:
-            _catalog_auto_link(doc_id)
+            n = _catalog_auto_link(doc_id)
+            if n:
+                import structlog
+                structlog.get_logger().debug("store_put_auto_linked", doc_id=doc_id, link_count=n)
         except Exception:
             pass  # auto-linking is non-fatal
         return f"Stored: {doc_id} -> {col_name}"

--- a/tests/test_auto_linker.py
+++ b/tests/test_auto_linker.py
@@ -133,3 +133,90 @@ class TestAutoLink:
         assert len(links) == 2
         for link in links:
             assert link.created_by == "auto-linker"
+
+
+class TestCatalogAutoLinkIntegration:
+    """Integration test: _catalog_auto_link wired through store_put path."""
+
+    def test_store_put_creates_link_from_scratch_context(self, tmp_path):
+        """Full pipeline: T1 scratch link-context + store_put → catalog link."""
+        import json
+        from nexus.db.t1 import T1Database
+        from nexus.mcp_server import (
+            _catalog_auto_link,
+            _inject_catalog,
+            _inject_t1,
+            _reset_singletons,
+        )
+
+        _reset_singletons()
+
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("knowledge", "curator")
+        target_t = cat.register(owner, "Target RDR", content_type="rdr")
+
+        # Register a source doc (simulating what _catalog_store_hook does)
+        source_t = cat.register(
+            owner, "Agent Finding", content_type="knowledge",
+            meta={"doc_id": "test-doc-001"},
+        )
+
+        _inject_catalog(cat)
+
+        t1 = T1Database(session_id="test-auto-link-session")
+        _inject_t1(t1)
+
+        # Seed link-context in T1 scratch
+        t1.put(
+            content=json.dumps({
+                "targets": [{"target_tumbler": str(target_t), "link_type": "relates"}],
+                "source_agent": "developer",
+            }),
+            tags="link-context",
+        )
+
+        count = _catalog_auto_link("test-doc-001")
+
+        assert count == 1
+        links = cat.links_from(source_t, link_type="relates")
+        assert len(links) == 1
+        assert links[0].created_by == "auto-linker"
+
+        _reset_singletons()
+
+    def test_store_put_no_crash_without_context(self, tmp_path):
+        """_catalog_auto_link with no link-context in scratch → 0, no crash."""
+        from nexus.db.t1 import T1Database
+        from nexus.mcp_server import (
+            _catalog_auto_link,
+            _inject_catalog,
+            _inject_t1,
+            _reset_singletons,
+        )
+
+        _reset_singletons()
+
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("knowledge", "curator")
+        cat.register(
+            owner, "Some Doc", content_type="knowledge",
+            meta={"doc_id": "test-doc-002"},
+        )
+
+        _inject_catalog(cat)
+        t1 = T1Database(session_id="test-no-context-session")
+        _inject_t1(t1)
+
+        count = _catalog_auto_link("test-doc-002")
+        assert count == 0
+
+        _reset_singletons()
+
+    def test_store_put_no_catalog_returns_zero(self):
+        """_catalog_auto_link with no catalog → 0."""
+        from nexus.mcp_server import _catalog_auto_link, _reset_singletons
+
+        _reset_singletons()
+        count = _catalog_auto_link("nonexistent-doc")
+        assert count == 0
+        _reset_singletons()

--- a/tests/test_auto_linker.py
+++ b/tests/test_auto_linker.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.auto_linker import LinkContext, auto_link, read_link_contexts
+
+
+@pytest.fixture(autouse=True)
+def git_identity(monkeypatch):
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
+
+def _make_catalog(tmp_path: Path) -> Catalog:
+    catalog_dir = tmp_path / "catalog"
+    cat = Catalog.init(catalog_dir)
+    return cat
+
+
+class TestAutoLink:
+    def test_link_context_creates_relates_link(self, tmp_path):
+        """Seeding one LinkContext with a valid tumbler creates a relates link."""
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("test", "curator")
+        source_t = cat.register(owner, "Source Doc", content_type="knowledge")
+        target_t = cat.register(owner, "Target Doc", content_type="knowledge")
+
+        ctx = LinkContext(target_tumbler=str(target_t), link_type="relates")
+        count = auto_link(cat, source_t, [ctx])
+
+        assert count == 1
+        links = cat.links_from(source_t, link_type="relates")
+        assert len(links) == 1
+        assert links[0].created_by == "auto-linker"
+
+    def test_no_link_context_no_crash(self, tmp_path):
+        """Empty context list produces no links and no exception."""
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("test", "curator")
+        source_t = cat.register(owner, "Source Doc", content_type="knowledge")
+
+        count = auto_link(cat, source_t, [])
+
+        assert count == 0
+        links = cat.links_from(source_t)
+        assert links == []
+
+    def test_nonexistent_tumbler_graceful_skip(self, tmp_path):
+        """A LinkContext referencing a non-existent tumbler is silently skipped."""
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("test", "curator")
+        source_t = cat.register(owner, "Source Doc", content_type="knowledge")
+
+        ctx = LinkContext(target_tumbler="99.99.99", link_type="relates")
+        count = auto_link(cat, source_t, [ctx])
+
+        assert count == 0
+        links = cat.links_from(source_t)
+        assert links == []
+
+    def test_multiple_contexts_create_multiple_links(self, tmp_path):
+        """Two LinkContext objects each create one link — two total."""
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("test", "curator")
+        source_t = cat.register(owner, "Source Doc", content_type="knowledge")
+        target1_t = cat.register(owner, "Target One", content_type="knowledge")
+        target2_t = cat.register(owner, "Target Two", content_type="knowledge")
+
+        contexts = [
+            LinkContext(target_tumbler=str(target1_t), link_type="relates"),
+            LinkContext(target_tumbler=str(target2_t), link_type="relates"),
+        ]
+        count = auto_link(cat, source_t, contexts)
+
+        assert count == 2
+        links = cat.links_from(source_t, link_type="relates")
+        assert len(links) == 2
+
+    def test_single_entry_multiple_targets(self):
+        """read_link_contexts() flattens a targets array into multiple LinkContext objects."""
+        entries = [
+            {
+                "targets": [
+                    {"target_tumbler": "1.1.1", "link_type": "relates"},
+                    {"target_tumbler": "1.1.2", "link_type": "implements"},
+                ]
+            }
+        ]
+        contexts = read_link_contexts(entries)
+        assert len(contexts) == 2
+        assert contexts[0].target_tumbler == "1.1.1"
+        assert contexts[0].link_type == "relates"
+        assert contexts[1].target_tumbler == "1.1.2"
+        assert contexts[1].link_type == "implements"
+
+    def test_idempotent_no_duplicate(self, tmp_path):
+        """Calling auto_link twice with the same inputs creates only one link."""
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("test", "curator")
+        source_t = cat.register(owner, "Source Doc", content_type="knowledge")
+        target_t = cat.register(owner, "Target Doc", content_type="knowledge")
+
+        ctx = LinkContext(target_tumbler=str(target_t), link_type="relates")
+        auto_link(cat, source_t, [ctx])
+        count2 = auto_link(cat, source_t, [ctx])
+
+        assert count2 == 0
+        links = cat.links_from(source_t, link_type="relates")
+        assert len(links) == 1
+
+    def test_created_by_auto_linker(self, tmp_path):
+        """Every link created by auto_link has created_by='auto-linker'."""
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("test", "curator")
+        source_t = cat.register(owner, "Source Doc", content_type="knowledge")
+        target1_t = cat.register(owner, "Target One", content_type="knowledge")
+        target2_t = cat.register(owner, "Target Two", content_type="knowledge")
+
+        contexts = [
+            LinkContext(target_tumbler=str(target1_t), link_type="relates"),
+            LinkContext(target_tumbler=str(target2_t), link_type="implements"),
+        ]
+        auto_link(cat, source_t, contexts)
+
+        links = cat.links_from(source_t)
+        assert len(links) == 2
+        for link in links:
+            assert link.created_by == "auto-linker"

--- a/tests/test_auto_linker.py
+++ b/tests/test_auto_linker.py
@@ -100,6 +100,30 @@ class TestAutoLink:
         assert contexts[1].target_tumbler == "1.1.2"
         assert contexts[1].link_type == "implements"
 
+    def test_content_wrapper_parsing(self):
+        """read_link_contexts() unwraps T1 scratch 'content' string format."""
+        import json
+        entries = [
+            {
+                "content": json.dumps({
+                    "targets": [{"tumbler": "1.3.1", "link_type": "cites"}],
+                    "source_agent": "researcher",
+                }),
+                "tags": "link-context",
+            }
+        ]
+        contexts = read_link_contexts(entries)
+        assert len(contexts) == 1
+        assert contexts[0].target_tumbler == "1.3.1"
+        assert contexts[0].link_type == "cites"
+
+    def test_default_link_type_is_relates(self):
+        """Omitting link_type defaults to 'relates'."""
+        entries = [{"targets": [{"tumbler": "1.1.1"}]}]
+        contexts = read_link_contexts(entries)
+        assert len(contexts) == 1
+        assert contexts[0].link_type == "relates"
+
     def test_idempotent_no_duplicate(self, tmp_path):
         """Calling auto_link twice with the same inputs creates only one link."""
         cat = _make_catalog(tmp_path)
@@ -219,4 +243,53 @@ class TestCatalogAutoLinkIntegration:
         _reset_singletons()
         count = _catalog_auto_link("nonexistent-doc")
         assert count == 0
+        _reset_singletons()
+
+    def test_link_context_persists_across_stores(self, tmp_path):
+        """Link-context entries apply to every store_put in the session (by design)."""
+        import json
+        from nexus.db.t1 import T1Database
+        from nexus.mcp_server import (
+            _catalog_auto_link,
+            _inject_catalog,
+            _inject_t1,
+            _reset_singletons,
+        )
+
+        _reset_singletons()
+
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("knowledge", "curator")
+        target_t = cat.register(owner, "Target RDR", content_type="rdr")
+        doc1_t = cat.register(
+            owner, "Finding One", content_type="knowledge",
+            meta={"doc_id": "multi-doc-001"},
+        )
+        doc2_t = cat.register(
+            owner, "Finding Two", content_type="knowledge",
+            meta={"doc_id": "multi-doc-002"},
+        )
+
+        _inject_catalog(cat)
+        t1 = T1Database(session_id="test-multi-store-session")
+        _inject_t1(t1)
+
+        # Seed once
+        t1.put(
+            content=json.dumps({
+                "targets": [{"target_tumbler": str(target_t), "link_type": "relates"}],
+                "source_agent": "developer",
+            }),
+            tags="link-context",
+        )
+
+        # Two stores in the same session both get linked
+        count1 = _catalog_auto_link("multi-doc-001")
+        count2 = _catalog_auto_link("multi-doc-002")
+
+        assert count1 == 1
+        assert count2 == 1
+        assert len(cat.links_from(doc1_t, link_type="relates")) == 1
+        assert len(cat.links_from(doc2_t, link_type="relates")) == 1
+
         _reset_singletons()


### PR DESCRIPTION
## Summary

- **New module** `src/nexus/catalog/auto_linker.py` — pure-function auto-linker that creates catalog links from T1 scratch `link-context` entries via `link_if_absent` (idempotent, non-fatal)
- **Wired into `store_put`** MCP handler — after `_catalog_store_hook` registers the doc, `_catalog_auto_link` reads link-context from T1 scratch and creates links to the stored document
- **5 skill updates** — development, debugging, research-synthesis, deep-analysis, architecture skills now seed T1 scratch with `link-context` before dispatching agents
- **10 tests** — 7 unit tests for core module + 3 integration tests for the MCP wiring

### Problem
All 50 existing catalog links were post-hoc (created by `index_hook` or `bib_enricher`). Agent definitions had link-creation instructions but agents never actually created links during workflows.

### Solution: Seed + Intercept
1. Dispatching skills seed T1 scratch with link targets before agent dispatch
2. `store_put` intercepts after catalog registration and auto-creates links
3. `created_by="auto-linker"` distinguishes mechanical links from agent-created and heuristic links

Epic: nexus-zuij

## Test plan
- [x] 7 unit tests for `auto_link()`, `read_link_contexts()`, `LinkContext`
- [x] 3 integration tests for `_catalog_auto_link` MCP wiring
- [x] Full suite regression: 3271 passed, 0 failures