### PR TITLE
fix: wire chunk overlap into semantic markdown splitter and bump PDF overlap to 20%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Chunk boundary overlap** (RDR-054) — wired dead `overlap_chars` into `SemanticMarkdownChunker._split_large_section`, which previously had zero overlap between sub-chunks. Bumped `PDFChunker` default overlap from 15% to 20% (225 → 300 chars). Fixed header duplication bug when overlap exceeds emitted content length. Guarded Python `[-0:]` edge case.
+
 ## [3.2.3] - 2026-04-07
 
 ### Fixed

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -75,7 +75,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-051](rdr-051-link-lifecycle.md) | Link Lifecycle: Full CRUD, Queryable Links, Bulk Operations | Architecture | Closed | 2026-04-05 |
 | [RDR-052](rdr-052-catalog-first-query-routing.md) | Catalog-First Query Routing — Push Planning into MCP | Architecture | Closed | 2026-04-05 |
 | [RDR-053](rdr-053-xanadu-fidelity.md) | Xanadu Fidelity — Tumbler Arithmetic and Content-Addressed Spans | Architecture | Closed | 2026-04-05 |
-| [RDR-054](rdr-054-chunk-boundary-equation-splitting.md) | Chunk Boundary Equation Splitting — Information Loss at Chunk Boundaries | Bug | Accepted | 2026-04-07 |
+| [RDR-054](rdr-054-chunk-boundary-equation-splitting.md) | Chunk Boundary Equation Splitting — Information Loss at Chunk Boundaries | Bug | Closed | 2026-04-07 |
 
 ---
 

--- a/docs/rdr/rdr-006-chunk-size-configuration.md
+++ b/docs/rdr/rdr-006-chunk-size-configuration.md
@@ -239,7 +239,7 @@ nx index repo PATH
 ```
 
 Markdown prose uses `SemanticMarkdownChunker(chunk_size=512, chunk_overlap=50)` (tokens).
-PDFs use `PDFChunker(chunk_chars=1500, overlap_percent=0.15)`.
+PDFs use `PDFChunker(chunk_chars=1500, overlap_percent=0.20)`.
 Both are out of scope — this RDR addresses code files only.
 
 ### R3: Scope of change (Confirmed)

--- a/docs/rdr/rdr-048-streaming-pdf-pipeline.md
+++ b/docs/rdr/rdr-048-streaming-pdf-pipeline.md
@@ -311,7 +311,7 @@ Three concurrent threads need coordinated shutdown when any stage fails. Standar
 **Current pipeline memory for 771-page CMRB book**:
 - Extraction: `md_parts` list — 771 page strings, ~2-5 MB total
 - `"\n".join(md_parts)` — creates a second copy, ~2-5 MB
-- `PDFChunker.chunk()` — returns ~2000 `TextChunk` objects, each holding a copy of its text. Total: ~3-5 MB (overlapping chunks mean ~15% extra text)
+- `PDFChunker.chunk()` — returns ~2000 `TextChunk` objects, each holding a copy of its text. Total: ~3-5 MB (overlapping chunks mean ~20% extra text)
 - `_embed_with_fallback` — embedding vectors: 2000 × 1024 floats × 4 bytes = ~8 MB
 - `_index_document` / `_index_pdf_incremental` — IDs, documents, metadatas lists: ~5-10 MB
 - **Peak concurrent**: ~20-30 MB for the 771-page book (extraction + chunks + embeddings all in memory simultaneously before the first upsert)

--- a/docs/rdr/rdr-054-chunk-boundary-equation-splitting.md
+++ b/docs/rdr/rdr-054-chunk-boundary-equation-splitting.md
@@ -2,7 +2,9 @@
 title: "Chunk Boundary Equation Splitting — Information Loss at Chunk Boundaries"
 id: RDR-054
 type: Bug
-status: accepted
+status: closed
+close_reason: implemented
+closed_date: 2026-04-07
 priority: high
 author: Hal Hildebrand
 reviewed-by: self

--- a/src/nexus/md_chunker.py
+++ b/src/nexus/md_chunker.py
@@ -284,10 +284,18 @@ class SemanticMarkdownChunker:
                 current_tokens += part_tokens
                 current_end_char = part_end_char
             else:
+                is_code = part.get("is_code_block", False)
+                if self.preserve_code_blocks and is_code:
+                    # Emit code blocks atomically — never truncate, even if oversized.
+                    pass
+                elif len(part_text) > self.max_chars:
+                    # Truncate oversized non-code parts to prevent unbounded chunk sizes.
+                    part_text = part_text[: self.max_chars]
                 if current_parts:
+                    emitted_text = "\n\n".join(current_parts)
                     chunks.append(
                         self._make_chunk(
-                            "\n\n".join(current_parts),
+                            emitted_text,
                             chunk_index,
                             base_metadata,
                             section["header_path"],
@@ -297,16 +305,17 @@ class SemanticMarkdownChunker:
                     )
                     chunk_index += 1
                     section_start_char = current_end_char
-                is_code = part.get("is_code_block", False)
-                if self.preserve_code_blocks and is_code:
-                    # Emit code blocks atomically — never truncate, even if oversized.
-                    pass
-                elif len(part_text) > self.max_chars:
-                    # Truncate oversized non-code parts to prevent unbounded chunk sizes.
-                    part_text = part_text[: self.max_chars]
-                header_tokens = len(header_text) / _CHARS_PER_TOKEN if header_text else 0.0
-                current_parts = [header_text, part_text] if header_text else [part_text]
-                current_tokens = header_tokens + len(part_text) / _CHARS_PER_TOKEN
+                    if self.overlap_chars > 0:
+                        overlap_tail = emitted_text[-self.overlap_chars:]
+                        if header_text:
+                            current_parts = [header_text, overlap_tail, part_text]
+                        else:
+                            current_parts = [overlap_tail, part_text]
+                    else:
+                        current_parts = [header_text, part_text] if header_text else [part_text]
+                else:
+                    current_parts = [header_text, part_text] if header_text else [part_text]
+                current_tokens = sum(len(p) for p in current_parts) / _CHARS_PER_TOKEN
                 current_end_char = part_end_char
 
         if current_parts:

--- a/src/nexus/md_chunker.py
+++ b/src/nexus/md_chunker.py
@@ -306,7 +306,11 @@ class SemanticMarkdownChunker:
                     chunk_index += 1
                     section_start_char = current_end_char
                     if self.overlap_chars > 0:
-                        overlap_tail = emitted_text[-self.overlap_chars:]
+                        # Compute overlap from content only (skip header) to
+                        # avoid duplicating the header when emitted_text is
+                        # shorter than overlap_chars.
+                        content_text = "\n\n".join(current_parts[1:]) if header_text else emitted_text
+                        overlap_tail = content_text[-self.overlap_chars:] if content_text else ""
                         if header_text:
                             current_parts = [header_text, overlap_tail, part_text]
                         else:

--- a/src/nexus/pdf_chunker.py
+++ b/src/nexus/pdf_chunker.py
@@ -9,7 +9,7 @@ from nexus.db.chroma_quotas import SAFE_CHUNK_BYTES
 _log = structlog.get_logger()
 
 _DEFAULT_CHUNK_CHARS = 1500   # ~450 tokens at 3.3 chars/token
-_DEFAULT_OVERLAP = 0.15
+_DEFAULT_OVERLAP = 0.20
 
 
 @dataclass

--- a/tests/test_md_chunker.py
+++ b/tests/test_md_chunker.py
@@ -284,17 +284,31 @@ def test_md_chunker_byte_cap_no_code_fence() -> None:
 # ── nexus-je5o: _split_large_section must carry overlap into next chunk ──────
 
 
+def _assert_overlap_at_start(chunks, overlap_chars):
+    """Verify overlap tail of chunk[i] appears at START of chunk[i+1] body."""
+    for i in range(len(chunks) - 1):
+        tail = chunks[i].text[-overlap_chars:]
+        next_text = chunks[i + 1].text
+        # Strip the repeated header line (e.g. "## Test\n\n") to find the overlap body
+        body_start = next_text.find("\n\n")
+        next_body = next_text[body_start + 2:] if body_start != -1 else next_text
+        assert next_body.startswith(tail), (
+            f"Chunk {i} tail not at START of chunk {i+1} body.\n"
+            f"  tail ({overlap_chars} chars): {tail!r}\n"
+            f"  next body: {next_body!r}"
+        )
+
+
 def test_split_large_section_overlap():
     """Tail of chunk[i] text must appear verbatim at start of chunk[i+1] text.
 
     Uses small chunk_size=50 / chunk_overlap=10 so the fixture stays compact.
     max_chars = int(50 * 3.3) = 165, overlap_chars = int(10 * 3.3) = 33.
+    Five paragraphs force ≥3 chunks, exercising the overlap carry-forward chain.
     """
     chunker = SemanticMarkdownChunker(chunk_size=50, chunk_overlap=10)
     overlap_chars = chunker.overlap_chars  # 33
 
-    # Each paragraph is ~60 chars — 3 paragraphs total ~180 chars > max_chars (165),
-    # so _split_large_section must split at least once.
     para = "Alpha bravo charlie delta echo foxtrot golf hotel. "  # 52 chars
     section = {
         "level": 2,
@@ -304,23 +318,58 @@ def test_split_large_section_overlap():
             {"type": "text", "content": para + "One.", "is_code_block": False},
             {"type": "text", "content": para + "Two.", "is_code_block": False},
             {"type": "text", "content": para + "Three.", "is_code_block": False},
+            {"type": "text", "content": para + "Four.", "is_code_block": False},
+            {"type": "text", "content": para + "Five.", "is_code_block": False},
         ],
     }
     chunks = chunker._split_large_section(section, {}, start_index=0)
 
-    assert len(chunks) >= 2, (
-        f"Expected ≥2 chunks from section exceeding max_chars, got {len(chunks)}"
+    assert len(chunks) >= 3, (
+        f"Expected ≥3 chunks from 5-part section, got {len(chunks)}"
     )
+    _assert_overlap_at_start(chunks, overlap_chars)
 
-    # The overlap_chars tail of chunk[i] must appear in chunk[i+1]
-    for i in range(len(chunks) - 1):
-        tail = chunks[i].text[-overlap_chars:]
-        next_text = chunks[i + 1].text
-        # Strip the repeated header line (e.g. "## Test\n\n") to find the overlap body
-        body_start = next_text.find("\n\n")
-        next_body = next_text[body_start + 2:] if body_start != -1 else next_text
-        assert tail in next_body, (
-            f"Chunk {i} tail not found in chunk {i+1} body.\n"
-            f"  tail ({overlap_chars} chars): {tail!r}\n"
-            f"  next body: {next_body!r}"
+
+def test_split_large_section_overlap_no_header_duplication():
+    """Overlap from a short emitted chunk must not duplicate the section header."""
+    chunker = SemanticMarkdownChunker(chunk_size=20, chunk_overlap=15)
+    # max_chars=66, overlap_chars=49 — overlap > likely content length
+
+    section = {
+        "level": 2,
+        "header": "Hdr",
+        "header_path": ["Hdr"],
+        "content_parts": [
+            {"type": "text", "content": "Short.", "is_code_block": False},
+            {"type": "text", "content": "Second part is here.", "is_code_block": False},
+            {"type": "text", "content": "Third part follows.", "is_code_block": False},
+        ],
+    }
+    chunks = chunker._split_large_section(section, {}, start_index=0)
+    for chunk in chunks:
+        header_count = chunk.text.count("## Hdr")
+        assert header_count <= 1, (
+            f"Header duplicated {header_count} times in chunk: {chunk.text!r}"
+        )
+
+
+def test_split_large_section_truncation_with_overlap():
+    """Oversized part is truncated even when overlap is non-zero."""
+    chunker = SemanticMarkdownChunker(chunk_size=10, chunk_overlap=3)
+    # max_chars=33, overlap_chars=9
+
+    oversized = "x" * 10000
+    section = {
+        "level": 1,
+        "header": "Big",
+        "header_path": ["Big"],
+        "content_parts": [{"type": "text", "content": oversized, "is_code_block": False}],
+    }
+    chunks = chunker._split_large_section(section, {}, start_index=0)
+    assert len(chunks) >= 1
+    for chunk in chunks:
+        # Budget: max_chars + header + overlap + separators
+        budget = chunker.max_chars + len("# Big") + chunker.overlap_chars + 8
+        assert len(chunk.text) <= budget, (
+            f"Chunk exceeds budget: {len(chunk.text)} > {budget}"
         )

--- a/tests/test_md_chunker.py
+++ b/tests/test_md_chunker.py
@@ -279,3 +279,48 @@ def test_md_chunker_byte_cap_no_code_fence() -> None:
         assert len(c.text.encode()) <= SAFE_CHUNK_BYTES, (
             f"Chunk exceeds SAFE_CHUNK_BYTES: {len(c.text.encode())} bytes (limit {SAFE_CHUNK_BYTES})"
         )
+
+
+# ── nexus-je5o: _split_large_section must carry overlap into next chunk ──────
+
+
+def test_split_large_section_overlap():
+    """Tail of chunk[i] text must appear verbatim at start of chunk[i+1] text.
+
+    Uses small chunk_size=50 / chunk_overlap=10 so the fixture stays compact.
+    max_chars = int(50 * 3.3) = 165, overlap_chars = int(10 * 3.3) = 33.
+    """
+    chunker = SemanticMarkdownChunker(chunk_size=50, chunk_overlap=10)
+    overlap_chars = chunker.overlap_chars  # 33
+
+    # Each paragraph is ~60 chars — 3 paragraphs total ~180 chars > max_chars (165),
+    # so _split_large_section must split at least once.
+    para = "Alpha bravo charlie delta echo foxtrot golf hotel. "  # 52 chars
+    section = {
+        "level": 2,
+        "header": "Test",
+        "header_path": ["Test"],
+        "content_parts": [
+            {"type": "text", "content": para + "One.", "is_code_block": False},
+            {"type": "text", "content": para + "Two.", "is_code_block": False},
+            {"type": "text", "content": para + "Three.", "is_code_block": False},
+        ],
+    }
+    chunks = chunker._split_large_section(section, {}, start_index=0)
+
+    assert len(chunks) >= 2, (
+        f"Expected ≥2 chunks from section exceeding max_chars, got {len(chunks)}"
+    )
+
+    # The overlap_chars tail of chunk[i] must appear in chunk[i+1]
+    for i in range(len(chunks) - 1):
+        tail = chunks[i].text[-overlap_chars:]
+        next_text = chunks[i + 1].text
+        # Strip the repeated header line (e.g. "## Test\n\n") to find the overlap body
+        body_start = next_text.find("\n\n")
+        next_body = next_text[body_start + 2:] if body_start != -1 else next_text
+        assert tail in next_body, (
+            f"Chunk {i} tail not found in chunk {i+1} body.\n"
+            f"  tail ({overlap_chars} chars): {tail!r}\n"
+            f"  next body: {next_body!r}"
+        )

--- a/tests/test_md_chunker.py
+++ b/tests/test_md_chunker.py
@@ -151,7 +151,7 @@ def test_semantic_chunk_end_char_greater_than_start():
 
 def test_split_large_section_truncates_oversized_part():
     """A content part larger than max_chars is truncated to max_chars."""
-    chunker = SemanticMarkdownChunker(chunk_size=10)  # max_chars ≈ 33 chars
+    chunker = SemanticMarkdownChunker(chunk_size=10, chunk_overlap=0)  # max_chars ≈ 33 chars
 
     # Build a section with one part that vastly exceeds max_chars
     oversized = "x" * 10000  # 10000 chars >> max_chars (≈33)

--- a/tests/test_pdf_chunker.py
+++ b/tests/test_pdf_chunker.py
@@ -72,3 +72,14 @@ def test_pdf_chunker_byte_cap_enforced() -> None:
         assert len(c.text.encode()) <= SAFE_CHUNK_BYTES, (
             f"PDF chunk exceeds SAFE_CHUNK_BYTES: {len(c.text.encode())} bytes (limit {SAFE_CHUNK_BYTES})"
         )
+
+
+# ── nexus-nd3e: default overlap must be 300 chars (20% of 1500) ─────────────
+
+
+def test_pdf_chunker_default_overlap_is_300_chars():
+    """Default PDFChunker overlap must be 300 chars (20% of 1500-char default)."""
+    chunker = PDFChunker()
+    assert chunker.overlap_chars == 300, (
+        f"Expected overlap_chars=300 (0.20 * 1500), got {chunker.overlap_chars}"
+    )


### PR DESCRIPTION
## Summary

- Wire dead `self.overlap_chars` into `SemanticMarkdownChunker._split_large_section` so chunk boundaries carry forward context (fixes RDR-054 CRITICAL finding)
- Bump `PDFChunker._DEFAULT_OVERLAP` from 0.15 to 0.20, giving 300 overlap chars at the default 1500-char chunk size (RDR-054 RF-3)
- Fix header duplication bug when overlap_chars exceeds emitted content length
- Guard Python `[-0:]` edge case when overlap_chars is zero

## Commits

1. `9e48dd6` — RED test for md_chunker overlap [nexus-je5o]
2. `173f1d0` — Wire overlap_chars into flush path [nexus-v0ap]
3. `0627856` — Review fixes: header dedup, startswith assertion, edge-case tests [nexus-r0rr]
4. `3d4d8eb` — RED test for PDFChunker 300-char default [nexus-nd3e]
5. `eb7c919` — Bump _DEFAULT_OVERLAP 0.15 → 0.20 [nexus-mw49]

## Test plan

- [x] `test_split_large_section_overlap` — 5-part fixture, 3 chunks, positional startswith assertion
- [x] `test_split_large_section_overlap_no_header_duplication` — overlap > content length
- [x] `test_split_large_section_truncation_with_overlap` — oversized part + non-zero overlap
- [x] `test_pdf_chunker_default_overlap_is_300_chars` — constructor default assertion
- [x] Full suite: 3303 passed, 13 skipped, 0 failed

Epic: nexus-ykz6 | RDR: docs/rdr/rdr-054-chunk-boundary-equation-splitting.md