### PR TITLE
RDR-060: Catalog path rationalization + link graph usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Catalog path rationalization (RDR-060)** — catalog `file_path` and T3 `source_path` now store relative paths. `resolve_path()` reconstructs absolute paths via `owner.repo_root` or registry fallback.
+- **Link-aware search boost** — `query` MCP tool boosts results from documents with `implements` links. `implements-heuristic` links get zero boost (too noisy). Configurable per-type weights.
+- **Discovery tools** — `nx catalog orphans`, `coverage`, `suggest-links` for link graph observability.
+- **Incremental link generation** — link generators accept `new_tumblers` for O(new_n × m) incremental mode during `nx index repo`. `nx catalog link-generate` for full batch scans.
+- **Agent integration** — `nx catalog links-for-file` and `session-summary` surface linked RDRs for code files.
+- **Catalog housekeeping** — `_run_housekeeping()` tracks `miss_count`, evicts orphans after 2 missed index runs, detects renames via content hash. `nx catalog gc` CLI.
+- **`nx doctor --fix-paths [--dry-run]`** — one-time migration of absolute paths to relative (catalog + T3 metadata).
+
+### Fixed
+- **Test catalog isolation** — autouse `conftest.py` fixture prevents integration tests from polluting the user's live catalog.
+
 ## [3.5.2] - 2026-04-08
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,22 @@ Nexus is a Python 3.12+ CLI + persistent server for semantic search and knowledg
 
 **Pagination**: All list-returning tools include footers when truncated — `offset=N` for next page.
 
+## Catalog Link Graph
+
+When researching a file's design intent, use the link graph:
+
+```bash
+nx catalog links-for-file src/nexus/catalog/catalog.py   # linked RDRs/code
+nx catalog session-summary                                 # recently modified files + links
+nx catalog coverage                                        # link coverage by content type
+nx catalog orphans --no-links                              # unlinked entries
+```
+
+In the `query` MCP tool, use `follow_links=True` to traverse the link graph:
+```
+query("how does path resolution work", follow_links=True, subtree="1.1")
+```
+
 **T3 expire guard**: always filter `ttl_days > 0 AND expires_at != "" AND expires_at < now` — the `expires_at != ""` guard is mandatory: permanent entries use `expires_at=""` which sorts before ISO timestamps and would be incorrectly deleted by a 2-condition guard.
 
 ## Source Layout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,9 @@ nx catalog coverage                                        # link coverage by co
 nx catalog orphans --no-links                              # unlinked entries
 ```
 
-In the `query` MCP tool, use `follow_links=True` to traverse the link graph:
+In the `query` MCP tool, use `follow_links` with a link type to traverse the graph:
 ```
-query("how does path resolution work", follow_links=True, subtree="1.1")
+query("how does path resolution work", follow_links="implements", subtree="1.1")
 ```
 
 **T3 expire guard**: always filter `ttl_days > 0 AND expires_at != "" AND expires_at < now` — the `expires_at != ""` guard is mandatory: permanent entries use `expires_at=""` which sorts before ISO timestamps and would be incorrectly deleted by a 2-condition guard.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -260,6 +260,47 @@ nx catalog link-bulk-delete --type implements-heuristic --created-by indexer --d
 
 Preview and bulk-delete links by type and/or creator. Always use `--dry-run` first.
 
+### Discovery and observability
+
+```bash
+nx catalog orphans --no-links           # entries with zero links
+nx catalog coverage                     # % of entries with links, by content type
+nx catalog coverage --owner 1.1         # scoped to a specific repo
+nx catalog suggest-links --limit 20     # unlinked code-RDR pairs by name overlap
+nx catalog links-for-file src/foo.py    # all docs linked to a file
+nx catalog session-summary              # recently modified files + linked RDRs
+```
+
+Use `coverage` to track link graph completeness. Use `orphans` to find documents that need linking. `links-for-file` shows the design context for any source file.
+
+### Link generation
+
+```bash
+nx catalog link-generate                # full batch scan — all linkers
+nx catalog link-generate --dry-run      # preview without creating
+```
+
+Normal `nx index repo` runs generate links incrementally (only for newly indexed files). Use `link-generate` for the full O(n×m) batch scan after bulk imports or initial setup.
+
+### Housekeeping
+
+```bash
+nx catalog gc                           # delete entries missed in 2+ index runs
+nx catalog gc --dry-run                 # preview
+nx catalog compact                      # remove tombstones from JSONL
+```
+
+The indexer automatically tracks `miss_count` for each catalog entry. Files deleted or renamed are detected: renames (same content hash at a new path) transfer links to the new entry; true deletions are evicted after 2 consecutive missed index runs. `gc` provides the manual escape hatch.
+
+### Path migration
+
+```bash
+nx doctor --fix-paths --dry-run         # preview absolute→relative migration
+nx doctor --fix-paths                   # apply migration (catalog + T3 source_path)
+```
+
+After upgrading to RDR-060, run `--fix-paths` once to migrate existing absolute `file_path` entries to relative paths. Curator-owned entries (PDFs, standalone docs) are skipped — they keep absolute paths by design.
+
 ### Troubleshooting
 
 **SQLite cache disappeared:** Delete `.catalog.db` (or let it be deleted). The system rebuilds it from JSONL on next access — no data lost.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -221,6 +221,62 @@ nx catalog pull                  # pull from remote + rebuild SQLite
 
 `sync` is called automatically at session close (via the Stop hook) when JSONL files have changed. Manual use is rarely needed.
 
+### nx catalog orphans
+
+```
+nx catalog orphans --no-links
+```
+
+Find catalog entries with zero incoming and outgoing links. Useful for identifying documents that need linking or cleanup.
+
+### nx catalog coverage
+
+```
+nx catalog coverage [--owner OWNER_PREFIX]
+```
+
+Per content-type report showing what percentage of catalog entries have at least one link. Use `--owner 1.1` to scope to a specific repo.
+
+### nx catalog suggest-links
+
+```
+nx catalog suggest-links [--limit N]
+```
+
+Find unlinked code-RDR pairs by module name overlap. Read-only — shows potential links without creating them.
+
+### nx catalog links-for-file
+
+```
+nx catalog links-for-file FILE_PATH
+```
+
+Show all linked documents for a specific file (by relative path). Displays link type and direction.
+
+### nx catalog session-summary
+
+```
+nx catalog session-summary [--since HOURS]
+```
+
+Show linked RDRs for recently git-modified files. Default: last 24 hours. Useful for understanding design context of files you're working on.
+
+### nx catalog link-generate
+
+```
+nx catalog link-generate [--dry-run]
+```
+
+Run all link generators over the full catalog (batch O(n×m) scan). Use for initial setup or after bulk imports. Normal index runs are incremental.
+
+### nx catalog gc
+
+```
+nx catalog gc [--dry-run]
+```
+
+Remove orphan catalog entries (entries with `miss_count >= 2` — missed in 2 consecutive index runs). Use `--dry-run` to preview.
+
 ### nx catalog list / stats / owners / delete
 
 Standard catalog management. Run `nx catalog COMMAND --help` for details.
@@ -469,6 +525,8 @@ Checks: ChromaDB API key, ChromaDB tenant, T3 database (`CHROMA_DATABASE`), Voya
 nx doctor --clean-checkpoints   # Delete orphaned PDF checkpoint files
 nx doctor --clean-pipelines     # Delete orphaned pipeline buffer entries
 nx doctor --fix                 # Apply HNSW search_ef=256 to local collections
+nx doctor --fix-paths           # Migrate absolute file_path entries to relative (catalog + T3)
+nx doctor --fix-paths --dry-run # Preview migration without applying
 ```
 
 The `--fix` flag retroactively applies HNSW `search_ef` tuning to all existing local-mode collections. New collections get this automatically. In cloud mode (SPANN), prints a skip message — SPANN defaults are adequate.

--- a/docs/querying-guide.md
+++ b/docs/querying-guide.md
@@ -113,6 +113,19 @@ query(question="database design", follow_links="cites", depth=1)
 
 This means `query(question="X", author="Fagin")` is faster and more precise than `query(question="X")` because it searches fewer collections.
 
+### Link-aware scoring
+
+The `query()` tool automatically boosts results from documents that have outgoing `implements` links in the catalog. This means code files linked to RDRs rank higher than unlinked code at similar semantic distance. The boost is additive (+0.15 × link signal) and uses per-type weights:
+
+| Link type | Weight | Rationale |
+|-----------|--------|-----------|
+| `implements` | 1.0 | Precise — manually created or filepath-extracted |
+| `relates` / `cites` | 0.5 | Moderate signal |
+| `implements-heuristic` | 0.0 | Too noisy (87% of links, substring-matched) |
+| `supersedes` | 0.0 | Historical, not relevance signal |
+
+The `search()` tool does **not** apply link boost — it returns raw distance-ranked results. Use `query()` when you want the link graph to influence ranking.
+
 ---
 
 ## /nx:query skill (analytical queries)

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -81,7 +81,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-057](rdr-057-progressive-formalization-memory-tiers.md) | Progressive Formalization Across Memory Tiers | Feature | Draft | 2026-04-07 |
 | [RDR-058](rdr-058-pipeline-orchestration-plan-reuse.md) | Pipeline Orchestration and Plan Reuse | Feature | Accepted | 2026-04-07 |
 | [RDR-059](rdr-059-code-search-embedding-mismatch.md) | Code Search Embedding Model Mismatch | Bug | Closed | 2026-04-07 |
-| [RDR-060](rdr-060-catalog-path-rationalization-link-usability.md) | Catalog Path Rationalization and Link Graph Usability | Feature | Draft | 2026-04-08 |
+| [RDR-060](rdr-060-catalog-path-rationalization-link-usability.md) | Catalog Path Rationalization and Link Graph Usability | Feature | Accepted | 2026-04-08 |
 
 ---
 

--- a/docs/rdr/rdr-060-catalog-path-rationalization-link-usability.md
+++ b/docs/rdr/rdr-060-catalog-path-rationalization-link-usability.md
@@ -2,11 +2,19 @@
 title: "Catalog Path Rationalization and Link Graph Usability"
 id: RDR-060
 type: Feature
-status: draft
+status: accepted
+accepted_date: 2026-04-08
+reviewed-by: self
 priority: high
 author: Hal Hildebrand
 created: 2026-04-08
 related_issues: [RDR-049, RDR-050, RDR-051, RDR-052, RDR-053]
+related_notes: >
+  RDR-049 (closed): Introduced OwnerRecord and tumbler model — E1 adds repo_root to this structure.
+  RDR-050 (closed): Deferred computed similarity — E3 justifies why link boost is distinct.
+  RDR-051 (closed): Implemented link CRUD — E5 builds on link_if_absent() idempotency.
+  RDR-052 (closed): Implemented follow_links in query MCP — E3/E6 extend its reach.
+  RDR-053 (closed): Tumbler arithmetic — E1 path resolution completes the Xanadu location-independence pattern.
 ---
 
 # RDR-060: Catalog Path Rationalization and Link Graph Usability
@@ -37,15 +45,16 @@ Code entries store relative paths (`src/nexus/indexer.py`), but RDR/prose entrie
 
 ### 3. Link Quality Is Low
 
-- **Chunk-level duplication**: Each code chunk gets its own catalog entry, so `session.py` (35 chunks) × 3 RDRs = 105 links for what should be 3 file→RDR relationships
-- **Heuristic noise**: `implements-heuristic` links match substrings ("session" in title) — false positives for unrelated RDRs that mention common words
+- **Heuristic noise**: `implements-heuristic` links (87% of all links) match substrings ("session" in title) — false positives for unrelated RDRs that mention common words. These dominate the graph and drown out precise `implements` links
 - **No link validation**: Stale links to deleted/renamed files persist silently
 - **No coverage metrics**: No way to know which RDRs have zero code links, or which code files reference no design docs
+
+*Note: An earlier draft cited "chunk-level duplication" as a problem. RF-7 disproved this — catalog entries are already per-file. The original observation was measuring links across multiple owners, not chunk-level duplicates.*
 
 ## Design Principles
 
 1. **Relative paths, always** — `file_path` in catalog entries is relative to repo root. Owner tumbler → repo root mapping provides the absolute path when needed.
-2. **File-level links, not chunk-level** — Links connect documents (files), not chunks. A link from RDR-053 to `catalog.py` means "this RDR discusses this module."
+2. **File-level links** — Links already connect documents (files), not chunks (confirmed RF-7). A link from RDR-053 to `catalog.py` means "this RDR discusses this module." No deduplication needed.
 3. **Links are first-class in search** — When searching for "tumbler arithmetic," results from files linked to RDR-053 rank higher than unlinked results.
 4. **Discovery over manual curation** — Auto-linkers should find 80% of relationships. Agents and humans add the remaining 20%.
 
@@ -60,21 +69,51 @@ Code entries store relative paths (`src/nexus/indexer.py`), but RDR/prose entrie
 - `Catalog.resolve_path(tumbler) -> Path` computes absolute path: `owner.repo_root / entry.file_path`
 - Migration: `nx doctor --fix-paths` rewrites absolute paths to relative for all entries under known owners
 
-### E2: File-Level Link Deduplication
+**Backwards compatibility** (OwnerRecord is already in production since RDR-049):
+- `repo_root` defaults to `""` in JSONL deserialization so existing owner entries load without error
+- `resolve_path()` falls back to registry lookup (`registry.py` repo_hash → Path) when `repo_root == ""`
+- New `repo_root` field populated lazily on next `catalog.register()` call for each owner
 
-**Scope**: Link generator, catalog
+**Migration sequence** (order matters — idempotency uses exact string match on `file_path`):
+1. Patch all call sites that store absolute paths (`doc_indexer.py:831`, `pipeline_stages.py:476`, `mcp_server.py:1174`, `commands/catalog.py:395,825,901`) to store relative paths
+2. Run `nx doctor --fix-paths` to rewrite existing absolute entries via `cat.update()` on the existing tumbler (not delete-and-reinsert) — the FTS5 `documents_fts` update trigger propagates the change
+3. Verify: `nx catalog search --where "file_path LIKE '/%'"` returns zero results
 
-- Links connect file-level document tumblers, not chunk tumblers
-- `generate_code_rdr_links` operates on deduplicated file entries (one tumbler per source file, not per chunk)
-- Existing chunk-level link duplicates cleaned up via `nx catalog link-audit --dedup`
+**T3 metadata consistency** (critical coordination): `_prefilter_from_catalog()` (`search_engine.py:97-143`) pulls `file_path` from the catalog and uses it as a `source_path` filter against ChromaDB chunk metadata (`{"source_path": {"$in": [paths]}}`). If catalog stores relative paths but T3 chunks retain absolute `source_path` metadata, the `$in` filter silently returns zero results. Therefore:
+- E1 must also patch all indexer paths to store relative `source_path` in T3 chunk metadata (same call sites as catalog: `doc_indexer.py`, `pipeline_stages.py`, `mcp_server.py`)
+- Migration must update existing T3 `source_path` metadata alongside the catalog `--fix-paths` rewrite
+- Verification step 3 should also check: `nx search --where "source_path LIKE '/%%'"` returns zero results across all collections
+
+**T3 migration procedure**: `nx doctor --fix-paths` drives both catalog and T3 migration atomically per entry:
+1. For each catalog entry with absolute `file_path`, derive the old absolute path and the new relative path
+2. For the entry's `physical_collection`, paginate `col.get(where={"source_path": old_absolute}, limit=300)` to collect all chunk IDs and metadata (respecting Cloud's 300-record batch limit)
+3. Rewrite `source_path` in each chunk's metadata dict to the new relative value
+4. Call `col.update(ids=chunk_ids, metadatas=new_metadatas)` in batches of 300
+5. Then update the catalog entry's `file_path` via `cat.update()`
+
+Add a `T3Database.update_source_path(collection, old_path, new_path) -> int` helper that encapsulates steps 2-4, following the existing pagination pattern in `delete_by_source()` (`t3.py:688-716`). Returns count of chunks updated.
+
+**Migration safety**: Run in dry-run mode first (`--fix-paths --dry-run`) to report affected entries and chunk counts without writing. The migration is idempotent — re-running on already-relative paths is a no-op (the `col.get(where={"source_path": old_absolute})` returns empty).
+
+**Downstream callers of `file_path`**: Any code that reads `file_path` and treats it as a filesystem path must switch to `resolve_path()` after E1. Known caller: `generate_rdr_filepath_links()` (`link_generator.py:82-83`) uses `Path(rdr.file_path).is_file()` — after E1, relative paths resolve against cwd (not repo root), so this always returns False and the linker silently stops generating all `implements` links. Fix: replace with `resolved = cat.resolve_path(rdr.tumbler); if resolved is None or not resolved.is_file(): continue`. This is a direct consequence of E1 and must ship in the same PR.
+
+**PDF exception**: Curator-owner entries (PDFs indexed via `pipeline_stages.py`) store filename-only `file_path` (e.g., `paper.pdf`). These are not resolvable to a filesystem location from catalog metadata alone. `resolve_path()` returns `None` for curator owners. `--fix-paths` skips curator-owner entries entirely.
+
+### ~~E2: File-Level Link Deduplication~~ — REMOVED
+
+**Rationale**: RF-7 confirms catalog entries are already per-file (ONE entry per source file with `chunk_count` metadata). All 5 indexer paths follow this pattern. The earlier observation of "chunk-level duplication" was measuring links across all owners, not duplicated chunks within one owner. The `link-audit --dedup` command would have undefined semantics against a non-existent problem and could destroy valid links. See OQ1 resolution below.
 
 ### E3: Link-Aware Search Boost
 
 **Scope**: search_engine.py, scoring.py
 
-- When search returns chunks from file X, check if X has catalog links to any RDR matching the query context
-- Linked results get a configurable boost (similar to quality_score — additive to hybrid_score)
+**Mechanism** (concrete, testable):
+- When the `query` MCP tool receives a `subtree` or tumbler context, follow links from that tumbler and include linked documents' chunks in the candidate pool — extending the existing `follow_links` parameter (RDR-052)
+- When no explicit tumbler context is given: for each result chunk from file X, look up X's catalog entry and count outgoing `implements` links (NOT `implements-heuristic` — see link-type weighting below). Results with ≥1 precise link get a configurable additive boost to `hybrid_score`
+- **Link-type weighting**: `implements` links get full boost; `implements-heuristic` links get zero boost (they dominate the graph at 5,145 of 5,913 links and are too noisy for scoring). `relates` and `cites` get half boost. Weights configurable via `.nexus.yml`
 - Opt-in via `link_boost` config key (default: enabled for `query` MCP, disabled for `nx search`)
+
+**Justification vs RDR-050 deferral**: RDR-050 deferred *computed pairwise similarity* (O(n²) embedding comparison to generate `similar` links). E3 uses the existing link graph — no new link generation, no embedding computation. The deferred approach asks "what's similar to X?" which semantic search already answers. E3 asks "what's *intentionally connected* to X?" which semantic search cannot answer. The signal is structural (human/auto-linker declared a relationship), not statistical.
 
 ### E4: Discovery Tools
 
@@ -82,15 +121,20 @@ Code entries store relative paths (`src/nexus/indexer.py`), but RDR/prose entrie
 
 - `nx catalog orphans` — files in T3 with no catalog entry or no links
 - `nx catalog coverage` — per-repo report: files with links vs without, RDRs with code links vs without
-- `nx catalog suggest-links` — semantic similarity between RDR content and code files that aren't yet linked (uses T3 embeddings, no new API calls)
+- `nx catalog suggest-links` — semantic similarity between RDR content and code files that aren't yet linked
+
+**`suggest-links` feasibility**: Uses `collection.get(include=["embeddings"])` on local `PersistentClient` to fetch per-document embeddings without API calls. **CloudClient limitation**: ChromaDB Cloud does not support batch embedding retrieval in the same way — `suggest-links` is local-mode only. Cloud users can run `suggest-links` after `nx pull` syncs to local storage. This constraint should be documented in CLI help text.
 
 ### E5: Incremental Linker Improvements
 
 **Scope**: link_generator.py, auto_linker.py
 
-- Filepath linker runs incrementally on every `nx index repo` (not just `nx catalog setup`)
+**Current state (RF-6)**: Both `generate_code_rdr_links()` and `generate_rdr_filepath_links()` already run after every `index_repository` call (`indexer.py:273-282`). However, they perform O(n×m) full scans via `_all_entries(cat)` on every run, relying on `link_if_absent()` idempotency to skip existing links.
+
+**Proposed change**: Make linkers incremental — `_register_indexed_files()` passes the set of newly registered tumblers to each linker, so each run evaluates only new entries against the full corpus. Complexity drops from O(n×m) per index to O(new_n × m), which matters as the catalog grows (currently 526 entries, heading toward thousands).
+
 - Auto-linker seeds from RDR `related_issues` frontmatter field (currently ignored)
-- New `nx catalog link-generate` CLI command to run all linkers on demand
+- New `nx catalog link-generate` CLI command to run all linkers on demand (full O(n×m) scan, for batch/setup use)
 
 ### E6: Agent Integration
 
@@ -99,6 +143,22 @@ Code entries store relative paths (`src/nexus/indexer.py`), but RDR/prose entrie
 - Session hook shows link summary: "N RDRs linked to files you're touching"
 - When an agent modifies a file, check for linked RDRs and surface them as context
 - `query` MCP tool's `follow_links` parameter documented in agent instructions with worked examples
+
+### E7: Catalog Housekeeping in Index Pipeline
+
+**Scope**: indexer.py (`_catalog_hook`), catalog.py
+
+**Current state (RF-8)**: `_catalog_hook()` only processes files that were just indexed. Deleted/renamed files leave orphan catalog entries and stale links. `delete_document()`, `defrag()`, `compact()` exist but are never called automatically.
+
+**Proposed change**: Add a housekeeping phase to `_catalog_hook()` that runs after registration and link generation:
+
+1. **Orphan detection**: Compare all catalog entries for the current owner against the set of just-indexed files. Entries whose `file_path` no longer exists in the indexed set are orphan candidates.
+2. **Grace period**: Track misses via `miss_count` integer in the entry's `metadata` JSON dict (no schema migration needed — `metadata` is already a JSON column). Increment on each full index run where the entry's file is absent. Reset to 0 when the file is seen. Delete the entry (via `delete_document()`) when `miss_count >= N` (default: 2). **Partial runs** (`--on-locked=skip`) do not increment the counter — only full successful `_catalog_hook()` completions for the owner count as a run. The `metadata` dict is not indexed, but the scan is already O(entries_for_owner) so the JSON parse adds negligible cost.
+3. **Rename detection** (best-effort): When a new file is indexed and an orphan candidate has the same `content_hash`, treat as a rename — update the orphan's `file_path` rather than creating a new entry. This preserves existing links.
+4. **Stale link cleanup**: After orphan removal, enumerate links where `from_tumbler` or `to_tumbler` references a deleted document and call `unlink()` for each. The existing `link_audit()` method (`catalog.py:1242`, actual name `link_audit`) identifies orphaned links but has no deletion logic — E7 extends it with a `fix: bool = False` parameter that calls `unlink()` on each orphaned link when `fix=True`.
+5. **CLI escape hatch**: `nx catalog gc` for manual full housekeeping outside the index pipeline.
+
+**Design constraint**: Housekeeping must be fast enough to run in a post-commit hook (~1-2s). The orphan scan is O(entries_for_owner) with a single pass — acceptable at current scale (526 entries).
 
 ## Research Findings
 
@@ -155,17 +215,50 @@ DB schema change: add `repo_root TEXT` to owners table in `catalog_db.py:25`.
 
 Catalog registers ONE entry per source file with `chunk_count` metadata. All 5 indexer paths (code, prose, PDF, doc-markdown, streaming PDF) follow this pattern. The link graph is already file-level. The earlier observation of "133 links for session.py" was measuring links across all owners, not duplicated chunks.
 
+### RF-8: Git Hooks Do Not Maintain Catalog Consistency
+
+**Source**: `hooks.py`, `indexer.py:1035-1081`, `catalog.py:585,1243-1508`
+
+Nexus installs three git hooks (`post-commit`, `post-merge`, `post-rewrite`) via `nx hooks install` (`commands/hooks.py:13-20`). All three run `nx index repo` in the background, which calls `_catalog_hook()` (`indexer.py:222-284`).
+
+**What works**: `_catalog_hook()` registers/updates catalog entries for currently-indexed files and runs both link generators post-index.
+
+**What's missing**:
+- **Deleted files orphan catalog entries**: `_prune_deleted_files()` (line 1035-1043) removes T3 chunks for deleted files, but catalog entries are never touched. `delete_document()` (`catalog.py:585`) exists but is never called by the indexer.
+- **File renames create duplicates**: A moved file gets a new entry under its new `file_path`; the old entry persists as an orphan. No rename detection (fuzzy match on content hash or similar).
+- **No automatic cleanup**: `defrag()` and `compact()` (`catalog.py:1463-1508`) exist but are manual-only CLI commands.
+- **Audit detects but doesn't fix**: `audit_links()` (`catalog.py:1243-1361`) identifies orphaned/stale links but takes no corrective action.
+
+**Impact on E1**: After path migration, any existing orphan entries with absolute paths will persist in the catalog permanently unless cleanup runs. The 7 entries pointing to renamed/missing files (Problem Statement §1) are symptoms of this gap.
+
+### RF-9: Claude Code Plugin Hooks Do Not Touch Catalog
+
+**Source**: `nx/hooks/hooks.json`
+
+The Claude Code plugin hooks (`SessionStart`, `PostCompact`, `StopFailure`, `SubagentStart`) manage T1 scratch, T2 memory, and session lifecycle. None invoke catalog operations. This is appropriate — catalog maintenance belongs in git hooks, not agent session hooks.
+
+### RF-10: Query Planner Is Path-Agnostic, But Pre-Filter Is Not
+
+**Source**: `mcp_server.py:215-343`, `search_engine.py:97-143`
+
+The query planning infrastructure (`query` MCP tool) routes on tumblers and collection names — `cat.descendants(subtree)`, `cat.graph(tumbler, depth)` — and never uses `file_path` for routing decisions. `follow_links` traversal is purely graph-based. **E1's path change does not affect query planning.**
+
+However, `_prefilter_from_catalog()` bridges catalog and search by pulling `file_path` values and using them as ChromaDB `source_path` filters (`{"source_path": {"$in": paths}}`). This creates a consistency requirement: catalog `file_path` and T3 `source_path` metadata must use the same format. After E1, both must be relative. See E1's "T3 metadata consistency" section.
+
 ## Open Questions
 
-1. **Chunk-to-file mapping**: Should the catalog store one entry per file (collapsing chunks) or keep chunk-level entries with a `file_tumbler` parent? The file-level approach is simpler but loses chunk-level span resolution.
-2. **Cross-repo links**: When RDR-053 in nexus references `arcaneum/ast_extractor.py`, should the link cross repo boundaries? Current tumblers support this but no linker generates cross-repo links.
-3. **Link confidence scores**: Should heuristic links carry a confidence score so search boost can weight precise `implements` links higher than fuzzy `implements-heuristic`?
-4. **Incremental vs batch**: Should the filepath linker run on every index (adding ~2s) or only on demand?
+1. ~~**Chunk-to-file mapping**~~ — **RESOLVED by RF-7**: Catalog already stores one entry per file with `chunk_count` metadata. All 5 indexer paths follow this pattern. No change needed.
+2. ~~**Cross-repo links**~~ — **RESOLVED**: Tumblers already encode owner identity — a link from `1.5` (nexus RDR) to `2.3` (arcaneum file) is just a link between two tumblers in different owner spaces. The link graph is owner-agnostic by design. `resolve_path()` naturally follows the *target entry's* owner to get the correct `repo_root`, so cross-repo resolution works without special-casing. No linker currently generates cross-repo links, but the infrastructure supports them — agents or humans can create them via `catalog_link` MCP tool today. Auto-generation can be added later when there's demand.
+3. ~~**Link confidence scores**~~ — **RESOLVED in E3**: Link-type weighting is baked into the search boost design. `implements` gets full boost, `implements-heuristic` gets zero (too noisy at 87% of all links), `relates`/`cites` get half. Weights are configurable via `.nexus.yml`. No separate confidence score needed — `link_type` already carries the signal.
+4. ~~**Incremental vs batch**~~ — **RESOLVED in E5**: Both. Linkers already run post-index (RF-6). E5 makes them incremental (O(new_n × m) per index run). `nx catalog link-generate` provides the full O(n×m) batch scan for setup and catch-up.
 
 ## Success Criteria
 
-- [ ] Zero absolute file_path values in catalog after migration
-- [ ] `nx catalog coverage` shows >80% of nexus code files linked to at least one RDR
-- [ ] `nx search` with link boost returns relevant RDR context in top-5 for code queries
-- [ ] `nx catalog orphans` reports <10% unlinked files for indexed repos
-- [ ] Agent workflows surface linked RDRs when modifying linked code files
+- [ ] Zero absolute file_path values in catalog after migration (E1)
+- [ ] `resolve_path()` returns correct absolute path for repo-owner entries, `None` for curator-owner entries (E1)
+- [ ] `nx catalog coverage` shows >80% of nexus code files linked to at least one RDR (E4)
+- [ ] `query` MCP tool with link boost returns relevant RDR context in top-5 for code queries (E3)
+- [ ] `nx catalog orphans` reports <10% unlinked files for indexed repos (E4)
+- [ ] Agent workflows surface linked RDRs when modifying linked code files (E6)
+- [ ] Deleted files are removed from catalog within 2 index runs (E7)
+- [ ] Renamed files preserve their catalog links (E7)

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Link-boosted query results** — `query` MCP tool now automatically boosts results from documents with `implements` links. No agent changes needed.
+- **CONTEXT_PROTOCOL** — added catalog link graph as search source #4 for proactive agents.
+
 ## [3.5.2] - 2026-04-08
 
 Plugin version aligned with Nexus CLI 3.5.2. No plugin-level changes.

--- a/nx/agents/_shared/CONTEXT_PROTOCOL.md
+++ b/nx/agents/_shared/CONTEXT_PROTOCOL.md
@@ -20,7 +20,8 @@ These agents **MUST proactively search** for context before starting:
 1. **Bead**: `/beads:show <id>` for task context, design field, dependencies
 2. **Project Infrastructure**: T2 memory and beads context is auto-injected by SessionStart and SubagentStart hooks
 3. **nx T3 store**: mcp__plugin_nx_nexus__search( `query="[topic]", corpus="knowledge", limit=5`
-4. **nx T2 memory**: mcp__plugin_nx_nexus__memory_get( `project="{project}", title="ACTIVE_INDEX.md"`
+4. **Catalog link graph**: `mcp__plugin_nx_nexus__query( question="[topic]", follow_links="implements" )` — the `query` tool automatically boosts results from documents with precise `implements` links
+5. **nx T2 memory**: mcp__plugin_nx_nexus__memory_get( `project="{project}", title="ACTIVE_INDEX.md"`
 5. **T1 scratch** (current session): mcp__plugin_nx_nexus__scratch( `action="search", query="[topic]"`
 
 ### Relay-Reliant Agents (Execution & Validation)

--- a/nx/agents/_shared/CONTEXT_PROTOCOL.md
+++ b/nx/agents/_shared/CONTEXT_PROTOCOL.md
@@ -22,7 +22,7 @@ These agents **MUST proactively search** for context before starting:
 3. **nx T3 store**: mcp__plugin_nx_nexus__search( `query="[topic]", corpus="knowledge", limit=5`
 4. **Catalog link graph**: `mcp__plugin_nx_nexus__query( question="[topic]", follow_links="implements" )` — the `query` tool automatically boosts results from documents with precise `implements` links
 5. **nx T2 memory**: mcp__plugin_nx_nexus__memory_get( `project="{project}", title="ACTIVE_INDEX.md"`
-5. **T1 scratch** (current session): mcp__plugin_nx_nexus__scratch( `action="search", query="[topic]"`
+6. **T1 scratch** (current session): mcp__plugin_nx_nexus__scratch( `action="search", query="[topic]"`
 
 ### Relay-Reliant Agents (Execution & Validation)
 

--- a/nx/hooks/scripts/subagent-start.sh
+++ b/nx/hooks/scripts/subagent-start.sh
@@ -54,6 +54,34 @@ if command -v bd &> /dev/null; then
   fi
 fi
 
+# Catalog link context for files mentioned in the task
+if command -v nx &> /dev/null && [[ $SKIP_STORAGE_DOCS -eq 0 ]]; then
+  # Extract file paths from the task text and show linked RDRs
+  FILE_PATHS=$(python3 -c "
+import re, sys
+text = sys.argv[1] if len(sys.argv) > 1 else ''
+# Match patterns like src/nexus/foo.py or docs/rdr/bar.md
+paths = re.findall(r'(?:src|tests|docs|nx)/[\w/.-]+\.\w+', text)
+for p in set(paths[:5]):  # cap at 5 to keep it fast
+    print(p)
+" "$TASK_TEXT" 2>/dev/null)
+
+  if [[ -n "$FILE_PATHS" ]]; then
+    LINK_OUT=""
+    while IFS= read -r fp; do
+      LINKS=$(nx catalog links-for-file "$fp" 2>/dev/null | grep -E '^\s+[←→]')
+      if [[ -n "$LINKS" ]]; then
+        LINK_OUT+="  $fp:"$'\n'"$LINKS"$'\n'
+      fi
+    done <<< "$FILE_PATHS"
+    if [[ -n "$LINK_OUT" ]]; then
+      echo ""
+      echo "## Linked RDRs (files in task)"
+      echo "$LINK_OUT"
+    fi
+  fi
+fi
+
 # Relay template (required fields only)
 RELAY_TEMPLATE="$CLAUDE_PLUGIN_ROOT/agents/_shared/RELAY_TEMPLATE.md"
 if [[ -f "$RELAY_TEMPLATE" ]]; then

--- a/nx/registry.yaml
+++ b/nx/registry.yaml
@@ -434,6 +434,16 @@ standalone_skills:
       - "REPL sessions"
     tools: [Bash, Read, Write]
 
+  catalog:
+    description: "Catalog manipulation — resolve tumblers, create links, seed auto-linker context, file link context"
+    triggers:
+      - "working with catalog entries"
+      - "creating or viewing links"
+      - "resolving tumblers"
+      - "seeding link context before store_put"
+      - "understanding what RDRs relate to a file"
+    tools: [Bash, Read]
+
   nexus:
     description: "Nexus CLI reference for nx search, nx store, nx memory"
     triggers:

--- a/nx/skills/catalog/SKILL.md
+++ b/nx/skills/catalog/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: catalog
+description: Use when working with catalog entries, resolving tumblers, creating links, understanding what's linked to a file, or seeding link context for the auto-linker. Covers resolve, link, context, and seed operations.
+effort: low
+---
+
+# Catalog Manipulation
+
+Agent-friendly operations for the document catalog and link graph. Use these instead of raw MCP calls when you need to find, link, or understand documents.
+
+## Resolve: Find a Document
+
+Given a file path, title, or RDR name, find its catalog tumbler.
+
+```
+# By file path (relative — post-RDR-060)
+mcp__plugin_nx_nexus__catalog_search(query="src/nexus/scoring.py")
+# → Extract tumbler from first result
+
+# By title or RDR name
+mcp__plugin_nx_nexus__catalog_search(query="RDR-060")
+# → Extract tumbler from first result
+
+# By content type
+mcp__plugin_nx_nexus__catalog_search(query="catalog", content_type="code")
+```
+
+The result includes `tumbler`, `title`, `content_type`, `file_path`. Use the `tumbler` for all subsequent operations.
+
+**Quick resolve pattern** (copy-paste):
+```
+result = mcp__plugin_nx_nexus__catalog_search(query="<file-or-title>", limit=1)
+# Parse tumbler from result
+```
+
+## Context: What's Linked to This File?
+
+Before modifying a file, understand its design context:
+
+```bash
+# CLI (fast, human-readable)
+nx catalog links-for-file src/nexus/scoring.py
+```
+
+```
+# MCP (for agents)
+mcp__plugin_nx_nexus__catalog_search(query="src/nexus/scoring.py", limit=1)
+# → get tumbler
+mcp__plugin_nx_nexus__catalog_links(tumbler="<tumbler>", direction="both")
+# → {"nodes": [...], "edges": [...]}
+```
+
+This shows which RDRs discuss the file, what other code it's linked to, and through what link types.
+
+## Link: Connect Two Documents
+
+Create a typed link between documents. Accepts tumblers or titles.
+
+```
+# By tumbler
+mcp__plugin_nx_nexus__catalog_link(
+    from_tumbler="1.1.115",
+    to_tumbler="1.1.440",
+    link_type="implements",
+    created_by="<your-agent-name>"
+)
+
+# By title (resolve first)
+# 1. Search for source: catalog_search(query="scoring.py") → tumbler "1.1.115"
+# 2. Search for target: catalog_search(query="RDR-060") → tumbler "1.1.440"
+# 3. Link: catalog_link(from_tumbler="1.1.115", to_tumbler="1.1.440", ...)
+```
+
+**Link types** (use the right one):
+| Type | Meaning | When to use |
+|------|---------|-------------|
+| `implements` | Code implements design | Code file ← RDR that specifies it |
+| `cites` | Document references another | Paper citing another paper or RDR |
+| `relates` | General relationship | Two related docs without directional meaning |
+| `supersedes` | Replaces an older version | New RDR superseding old one |
+
+Do NOT use `implements-heuristic` — that's for the automated linker only.
+
+## Seed: Set Up Auto-Linker Context
+
+Before storing findings via `store_put`, seed T1 scratch so the auto-linker creates links automatically:
+
+```
+# 1. Resolve the target document
+mcp__plugin_nx_nexus__catalog_search(query="RDR-060", limit=1)
+# → tumbler "1.1.440"
+
+# 2. Seed link-context in T1 scratch
+mcp__plugin_nx_nexus__scratch(
+    action="put",
+    content='{"targets": [{"tumbler": "1.1.440", "link_type": "relates"}], "source_agent": "<agent-name>"}',
+    tags="link-context"
+)
+
+# 3. Now store_put — auto-linker fires automatically
+mcp__plugin_nx_nexus__store_put(content="...", collection="knowledge", title="...")
+# → auto-linker reads link-context and creates: new_doc → 1.1.440 (relates)
+```
+
+**Multiple targets**: add more items to the `targets` array:
+```json
+{"targets": [
+    {"tumbler": "1.1.440", "link_type": "implements"},
+    {"tumbler": "1.1.383", "link_type": "cites"}
+], "source_agent": "my-agent"}
+```
+
+**Skip seeding when**: no relevant RDR/document exists for what you're storing. The auto-linker handles empty context gracefully (zero links created, no error).
+
+## Discovery: Find What Needs Linking
+
+```bash
+nx catalog orphans --no-links     # entries with zero links
+nx catalog coverage               # % linked by content type
+nx catalog suggest-links           # unlinked code-RDR pairs
+nx catalog session-summary         # recently modified files + linked RDRs
+```
+
+## When to Create Links
+
+- **Implementing an RDR**: link code files → RDR with `implements`
+- **Storing research findings**: seed link-context before `store_put` with `cites` or `relates`
+- **Architectural decisions**: link decision doc → related RDRs with `relates`
+- **Consolidating knowledge**: link new → old with `supersedes`
+
+Links are permanent and idempotent — creating the same link twice is a no-op.

--- a/nx/skills/catalog/SKILL.md
+++ b/nx/skills/catalog/SKILL.md
@@ -52,6 +52,12 @@ mcp__plugin_nx_nexus__catalog_links(tumbler="<tumbler>", direction="both")
 
 This shows which RDRs discuss the file, what other code it's linked to, and through what link types.
 
+**To retrieve linked RDR *content*** (not just the graph structure), use query with link traversal:
+```
+mcp__plugin_nx_nexus__query(question="<topic>", follow_links="implements", subtree="<owner>")
+```
+This returns document content from linked RDRs ranked by relevance — typically more useful than raw graph metadata.
+
 ## Link: Connect Two Documents
 
 Create a typed link between documents. Accepts tumblers or titles.

--- a/nx/skills/code-review/SKILL.md
+++ b/nx/skills/code-review/SKILL.md
@@ -34,6 +34,10 @@ digraph review_flow {
 }
 ```
 
+## Pre-Dispatch: Seed Link Context (optional)
+
+If the review references an RDR or bead, seed link-context so any patterns the agent stores to T3 auto-link. See `/nx:catalog` for details. Skip if the review is purely ad-hoc.
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **code-review-expert**:

--- a/nx/skills/codebase-analysis/SKILL.md
+++ b/nx/skills/codebase-analysis/SKILL.md
@@ -16,6 +16,10 @@ Delegates to the **codebase-deep-analyzer** agent (model: sonnet).
 - Before undertaking major refactoring
 - Mapping dependencies between components or modules
 
+## Pre-Dispatch: Seed Link Context (optional)
+
+If the analysis is for a specific RDR or architectural decision, seed link-context so findings stored to T3 auto-link. See `/nx:catalog` for details. Skip for general exploration.
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **codebase-deep-analyzer**:

--- a/nx/skills/development/SKILL.md
+++ b/nx/skills/development/SKILL.md
@@ -37,15 +37,12 @@ Delegates to the **developer** agent (sonnet). See [registry.yaml](../../registr
 
 ## Pre-Dispatch: Seed Link Context
 
-Before dispatching the developer agent, seed T1 scratch with link targets so the auto-linker can create catalog links when the agent stores findings:
+Before dispatching the developer agent, seed T1 scratch with link targets so the auto-linker can create catalog links when the agent stores findings. See `/nx:catalog` skill for full reference.
 
 1. If the task references an RDR (pattern `RDR-\d+`), resolve it: `mcp__plugin_nx_nexus__catalog_search(query="RDR-NNN")`
 2. Check T1 scratch for `rdr-planning-context` (set by strategic-planner for RDR-driven beads)
-3. Write link context to scratch — use `"implements"` when working on an RDR-driven bead, `"relates"` otherwise:
-   ```
-   mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<resolved-tumbler>", "link_type": "implements"}], "source_agent": "developer"}', tags="link-context")
-   ```
-4. If no RDR/document reference found, skip seeding (the auto-linker handles empty context gracefully)
+3. Seed: `mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<tumbler>", "link_type": "implements"}], "source_agent": "developer"}', tags="link-context")`
+4. If no RDR/document reference found, skip seeding (auto-linker handles empty context gracefully)
 
 ## Agent Invocation
 

--- a/nx/skills/knowledge-tidying/SKILL.md
+++ b/nx/skills/knowledge-tidying/SKILL.md
@@ -16,6 +16,15 @@ Delegates to the **knowledge-tidier** agent (haiku). See [registry.yaml](../../r
 - When valuable insights should be preserved for future sessions
 - Consolidating or organizing existing Nexus knowledge (T3)
 
+## Pre-Dispatch: Seed Link Context
+
+Before dispatching the knowledge-tidier agent, seed T1 scratch with link targets so the auto-linker creates catalog links when the agent calls `store_put`. See `/nx:catalog` skill for full reference.
+
+1. If the task references an RDR or source document, resolve it: `mcp__plugin_nx_nexus__catalog_search(query="<reference>")`
+2. Check T1 scratch for existing `link-context` (may already be seeded by a predecessor skill like research-synthesis)
+3. If no link-context exists, seed: `mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<tumbler>", "link_type": "relates"}], "source_agent": "knowledge-tidier"}', tags="link-context")`
+4. If no document reference found, skip seeding (auto-linker handles empty context gracefully)
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **knowledge-tidier**:
@@ -61,9 +70,13 @@ For full relay structure and optional fields, see [RELAY_TEMPLATE.md](../../agen
 ## Contradiction Handling
 
 If contradictions found with existing knowledge:
-1. Search: mcp__plugin_nx_nexus__search(query="topic", corpus="knowledge" to find related entries
+1. Search: mcp__plugin_nx_nexus__search(query="topic", corpus="knowledge") to find related entries
 2. Identify which is more current/accurate
-3. Replace the stale entry by re-storing with the corrected content
+3. Re-store with corrected content, then create a `supersedes` link from the new entry to the old:
+   ```
+   mcp__plugin_nx_nexus__catalog_link(from_tumbler="<new-entry-tumbler>", to_tumbler="<old-entry-tumbler>", link_type="supersedes", created_by="knowledge-tidier")
+   ```
+   This preserves the history chain and prevents the old entry from appearing in link-boosted results.
 
 ## Agent-Specific PRODUCE
 

--- a/nx/skills/plan-validation/SKILL.md
+++ b/nx/skills/plan-validation/SKILL.md
@@ -16,6 +16,10 @@ Delegates to the **plan-auditor** agent (sonnet). See [registry.yaml](../../regi
 - When validating that a plan aligns with the codebase
 - Before committing significant effort to a plan
 
+## Pre-Dispatch: Seed Link Context (optional)
+
+If the plan is RDR-driven, seed link-context so audit findings stored to T3 auto-link. See `/nx:catalog` for details.
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **plan-auditor**:

--- a/nx/skills/query/SKILL.md
+++ b/nx/skills/query/SKILL.md
@@ -46,7 +46,7 @@ The hybrid path avoids unnecessary planner dispatch for questions like "compare 
 
 ### Path 1: Single-Tool (most questions)
 
-The enhanced `query` MCP tool handles catalog-aware routing internally. Use this when the question maps to a single scoped retrieval.
+The enhanced `query` MCP tool handles catalog-aware routing internally. Use this when the question maps to a single scoped retrieval. The `query` tool automatically applies link-aware scoring — results from documents with `implements` links rank higher than unlinked documents at similar distance. See [querying-guide.md](../../docs/querying-guide.md#link-aware-scoring) for weight details.
 
 **Detection**: The question has explicit catalog handles (author, content type, subtree, citation/link signals) without analytical signals. Or: no catalog handles but a catalog probe returns a match.
 

--- a/nx/skills/rdr-close/SKILL.md
+++ b/nx/skills/rdr-close/SKILL.md
@@ -90,7 +90,7 @@ If T2 record has no `epic_bead` field (user skipped planning at accept time):
 
 After `nx index rdr` in Step 4, the RDR has a catalog entry. Create links to capture implementation provenance:
 
-1. **Code→RDR links**: The indexer hook auto-generates `implements-heuristic` links via title substring matching. These are created automatically — no action needed here.
+1. **Code→RDR links**: The indexer hook auto-generates `implements-heuristic` links via title substring matching. These are created automatically. Review with `nx catalog links <rdr-tumbler> --type implements-heuristic` — promote high-confidence ones to `implements` via `catalog_link` for link-boost scoring benefit (heuristic links have zero search boost weight).
 
 2. **RDR→prior-RDR links**: If the RDR's T2 record has a `supersedes` field, create the catalog link:
    ```

--- a/nx/skills/rdr-close/SKILL.md
+++ b/nx/skills/rdr-close/SKILL.md
@@ -100,7 +100,7 @@ After `nx index rdr` in Step 4, the RDR has a catalog entry. Create links to cap
 3. **RDR→research links**: If research findings reference indexed papers, create `cites` links:
    - Read T2 research findings for this RDR
    - For each finding with a URL or paper title as source, search catalog: `mcp__plugin_nx_nexus__catalog_search(query="<source>")`
-   - If found, create: `mcp__plugin_nx_nexus__catalog_link(from_tumbler="<rdr-title>", to_tumbler="<paper-tumbler>", link_type="cites", created_by="rdr-close")`
+   - If found, resolve the RDR tumbler (`catalog_search(query="RDR-NNN")`), then: `mcp__plugin_nx_nexus__catalog_link(from_tumbler="<rdr-tumbler>", to_tumbler="<paper-tumbler>", link_type="cites", created_by="rdr-close")`
 
 Skip all catalog steps silently if catalog is not initialized. The T2 record and markdown are the authorities — catalog links are supplementary graph enrichment.
 

--- a/nx/skills/rdr-close/SKILL.md
+++ b/nx/skills/rdr-close/SKILL.md
@@ -110,6 +110,11 @@ The main RDR is already semantically indexed by Step 4's `nx index rdr` (CCE emb
 
 If a post-mortem exists, archive it to a separate collection (using the exact file path from Step 2, not a glob): mcp__plugin_nx_nexus__store_put(content=(contents of $RDR_DIR/post-mortem/NNN-kebab-title.md), collection="knowledge__rdr_postmortem__{repo}", title="PREFIX-NNN Title (post-mortem)", tags="rdr,post-mortem,{drift-categories}"
 
+Before dispatching the knowledge-tidier, seed link-context so the post-mortem auto-links to the RDR:
+```
+mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<rdr-tumbler>", "link_type": "relates"}], "source_agent": "rdr-close"}', tags="link-context")
+```
+
 Dispatch `knowledge-tidier` agent for post-mortem archival if the post-mortem contains substantial divergence analysis that benefits from knowledge organization.
 
 ## Flow: Reverted or Abandoned

--- a/nx/skills/rdr-gate/SKILL.md
+++ b/nx/skills/rdr-gate/SKILL.md
@@ -71,6 +71,11 @@ If assumed findings remain:
 
 ### Layer 3 — AI Critique (substantive-critic agent)
 
+Before dispatch, seed link-context so the gate critique auto-links to the RDR:
+```
+mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<rdr-tumbler>", "link_type": "relates"}], "source_agent": "rdr-gate"}', tags="link-context")
+```
+
 Dispatch the `substantive-critic` agent via Agent tool with this relay:
 
 ```markdown

--- a/nx/skills/rdr-research/SKILL.md
+++ b/nx/skills/rdr-research/SKILL.md
@@ -46,9 +46,9 @@ Resolve RDR directory from `.nexus.yml` `indexing.rdr_paths[0]`; default `docs/r
    ```
    mcp__plugin_nx_nexus__catalog_search(query="<source title or keywords>")
    ```
-   If a matching catalog entry is found, and the current RDR has a catalog entry:
+   If a matching catalog entry is found, resolve the RDR's tumbler too (`catalog_search(query="RDR-NNN")`), then link:
    ```
-   mcp__plugin_nx_nexus__catalog_link(from_tumbler="<rdr-title>", to_tumbler="<paper-tumbler>", link_type="cites", created_by="rdr-research")
+   mcp__plugin_nx_nexus__catalog_link(from_tumbler="<rdr-tumbler>", to_tumbler="<paper-tumbler>", link_type="cites", created_by="rdr-research")
    ```
    Skip silently if catalog not initialized, RDR not indexed, or no match found. This enriches the citation graph incrementally as research findings are added.
 

--- a/nx/skills/rdr-research/SKILL.md
+++ b/nx/skills/rdr-research/SKILL.md
@@ -87,7 +87,7 @@ Before dispatching an agent, seed T1 scratch with link targets so the auto-linke
 1. Resolve the RDR's tumbler: `mcp__plugin_nx_nexus__catalog_search(query="RDR-NNN", content_type="rdr")`
 2. Write link context to scratch:
    ```
-   mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<resolved-tumbler>", "link_type": "cites"}], "source_agent": "rdr-research"}', tag="link-context")
+   mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<resolved-tumbler>", "link_type": "cites"}], "source_agent": "rdr-research"}', tags="link-context")
    ```
 3. If catalog search returns no result, skip seeding (the auto-linker handles empty context gracefully)
 

--- a/nx/skills/strategic-planning/SKILL.md
+++ b/nx/skills/strategic-planning/SKILL.md
@@ -16,6 +16,15 @@ Delegates to the **strategic-planner** agent. See [registry.yaml](../../registry
 - When breaking vague requirements into concrete, sequenced steps
 - Before architectural changes affecting multiple files or modules
 
+## Pre-Dispatch: Seed Link Context
+
+Before dispatching the strategic-planner agent, seed T1 scratch with link targets so the auto-linker can create catalog links when the agent stores planning artifacts. See `/nx:catalog` skill for full reference.
+
+1. If the task references an RDR (pattern `RDR-\d+`), resolve it: `mcp__plugin_nx_nexus__catalog_search(query="RDR-NNN")`
+2. Check T1 scratch for `rdr-planning-context` (set by rdr-accept for RDR-driven plans)
+3. Seed: `mcp__plugin_nx_nexus__scratch(action="put", content='{"targets": [{"tumbler": "<tumbler>", "link_type": "relates"}], "source_agent": "strategic-planner"}', tags="link-context")`
+4. If no RDR/document reference found, skip seeding (auto-linker handles empty context gracefully)
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **strategic-planner**:

--- a/nx/skills/substantive-critique/SKILL.md
+++ b/nx/skills/substantive-critique/SKILL.md
@@ -18,6 +18,10 @@ Delegates to the **substantive-critic** agent. See [registry.yaml](../../registr
 - When verifying claims against evidence
 - Before major milestones or releases
 
+## Pre-Dispatch: Seed Link Context (optional)
+
+If the critique targets an RDR or architectural artifact, seed link-context so critique findings stored to T3 auto-link. See `/nx:catalog` for details.
+
 ## Agent Invocation
 
 Use the Agent tool to invoke **substantive-critic**:

--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -101,6 +101,7 @@ Plan reuse is opportunistic — the skill functions normally when the plan libra
 - Tests written? → `/nx:test-validate`
 
 **Research and knowledge:**
+- Analytical question over nx knowledge (compare, extract, synthesize) → `/nx:query`
 - Unfamiliar topic or technology comparison → `/nx:research`
 - 3+ validated findings worth keeping → `/nx:knowledge-tidy`
 - PDF to index → `/nx:pdf-process`
@@ -150,6 +151,7 @@ Use this table to match tasks to skills. When in doubt, check the skill.
 |-------|---------|----------------|
 | codebase-analysis | `/nx:analyze-code` | Exploring unfamiliar codebase or understanding module structure before changes |
 | deep-analysis | `/nx:deep-analysis` | Surface-level analysis is insufficient; hypothesis-driven investigation needed |
+| query | `/nx:query` | Analytical questions over nx knowledge — compare, extract, synthesize across corpora with link-aware boosting |
 | research-synthesis | `/nx:research` | Researching unfamiliar topics or comparing technology approaches |
 | architecture | `/nx:architecture` | Complex features need architectural design before implementation |
 | development | `/nx:implement` | Plan approved; implementation work ready to begin |

--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -113,6 +113,10 @@ Plan reuse is opportunistic — the skill functions normally when the plan libra
 - Implementation done, ready to merge/PR? → `/nx:finishing-branch`
 - Receiving review feedback? → `/nx:receiving-review` (verify before implementing)
 
+**Catalog and linking:**
+- Working with catalog entries, links, or tumblers → `/nx:catalog`
+- Seeding link context before `store_put` → `/nx:catalog` (Seed section)
+
 **Reference skills (invoke when relevant, no agent dispatch):**
 - Symbol navigation (definitions, callers, renames) → `/nx:serena-code-nav`
 - nx CLI usage → `/nx:nexus`
@@ -178,6 +182,7 @@ Use this table to match tasks to skills. When in doubt, check the skill.
 | knowledge-tidying | `/nx:knowledge-tidy` | 3+ validated findings or decisions need persisting to T3 for cross-session reuse |
 | orchestration | `/nx:orchestrate` | Unsure which agent fits — consult [routing reference](../orchestration/reference.md) |
 | pdf-processing | `/nx:pdf-process` | PDF documents need indexing into nx store for semantic search |
+| catalog | `/nx:catalog` | Working with catalog entries, resolving tumblers, creating links, seeding auto-linker context |
 | nexus | `/nx:nexus` | Running nx commands or unsure which nx subcommand to use |
 | serena-code-nav | `/nx:serena-code-nav` | Navigating code by symbol — finding definitions, callers, type hierarchies, or safe renames |
 | cli-controller | `/nx:cli-controller` | Controlling interactive CLI apps, REPLs, pdb, gdb, or spawning Claude Code instances |

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -302,7 +302,7 @@ class Catalog:
     # ── Owners ─────────────────────────────────────────────────────────────
 
     def register_owner(
-        self, name: str, owner_type: str, *, repo_hash: str = "", description: str = ""
+        self, name: str, owner_type: str, *, repo_hash: str = "", description: str = "", repo_root: str = ""
     ) -> Tumbler:
         dir_fd = self._acquire_lock()
         try:
@@ -318,13 +318,14 @@ class Catalog:
                 owner_type=owner_type,
                 repo_hash=repo_hash,
                 description=description,
+                repo_root=repo_root,
             )
             self._append_jsonl(self._owners_path, rec.__dict__)
             # Upsert SQLite
             self._db.execute(
-                "INSERT OR REPLACE INTO owners (tumbler_prefix, name, owner_type, repo_hash, description) "
-                "VALUES (?, ?, ?, ?, ?)",
-                (prefix, name, owner_type, repo_hash, description),
+                "INSERT OR REPLACE INTO owners (tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (prefix, name, owner_type, repo_hash, description, repo_root),
             )
             self._db.commit()
             return Tumbler.parse(prefix)

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -317,6 +317,8 @@ class Catalog:
     def register_owner(
         self, name: str, owner_type: str, *, repo_hash: str = "", description: str = "", repo_root: str = ""
     ) -> Tumbler:
+        if repo_root and not Path(repo_root).is_absolute():
+            raise ValueError(f"repo_root must be an absolute path: {repo_root!r}")
         dir_fd = self._acquire_lock()
         try:
             # Read existing owners to find next number
@@ -497,15 +499,18 @@ class Catalog:
         if not entry:
             return None
 
-        # Find owner
+        # Find owner via SQLite (avoids re-reading JSONL on every call)
         owner_prefix = str(tumbler.owner_address())
-        owners = read_owners(self._owners_path) if self._owners_path.exists() else {}
-        owner_rec = owners.get(owner_prefix)
-        if not owner_rec:
+        row = self._db.execute(
+            "SELECT owner_type, repo_root, repo_hash FROM owners WHERE tumbler_prefix = ?",
+            (owner_prefix,),
+        ).fetchone()
+        if not row:
             return None
+        owner_type, repo_root, repo_hash = row[0], row[1], row[2]
 
         # Curators (PDFs, standalone docs) are not resolvable
-        if owner_rec.owner_type == "curator":
+        if owner_type == "curator":
             return None
 
         # If file_path is already absolute, return it directly
@@ -514,17 +519,17 @@ class Catalog:
             return fp
 
         # Primary: use repo_root from owner
-        if owner_rec.repo_root:
-            return Path(owner_rec.repo_root) / entry.file_path
+        if repo_root:
+            return Path(repo_root) / entry.file_path
 
         # Fallback: find repo_root from registry by matching repo_hash
-        if owner_rec.repo_hash:
+        if repo_hash:
             registry_path = _default_registry_path()
             if registry_path.exists():
                 reg = RepoRegistry(registry_path)
                 for path_str in reg.all_info():
                     path_hash = hashlib.sha256(path_str.encode()).hexdigest()[:8]
-                    if path_hash == owner_rec.repo_hash:
+                    if path_hash == repo_hash:
                         return Path(path_str) / entry.file_path
 
         return None

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -43,6 +43,19 @@ from nexus.catalog.tumbler import (
 _log = structlog.get_logger()
 
 
+def _default_registry_path() -> Path:
+    """Return the default path to the repo registry JSON file."""
+    return Path.home() / ".config" / "nexus" / "repos.json"
+
+
+def make_relative(abs_path: str | Path, repo_root: Path) -> str:
+    """Return path relative to repo_root, or original if not under repo_root."""
+    try:
+        return str(Path(abs_path).relative_to(repo_root))
+    except ValueError:
+        return str(abs_path)
+
+
 @dataclass
 class CatalogEntry:
     tumbler: Tumbler
@@ -461,6 +474,60 @@ class Catalog:
             indexed_at=row[10],
             meta=json.loads(row[11]) if row[11] else {},
         )
+
+    def resolve_path(self, tumbler: Tumbler) -> Path | None:
+        """Return absolute path for the document's file_path.
+
+        Resolution order:
+        1. Look up entry via self.resolve(tumbler)
+        2. If entry not found: return None
+        3. Find owner: tumbler.owner_address() -> str, look up in JSONL
+        4. If owner not found or owner.owner_type == "curator": return None
+        5. If entry.file_path is already absolute: return Path(entry.file_path)
+        6. If owner.repo_root is non-empty: return Path(owner.repo_root) / entry.file_path
+        7. Fallback: iterate registry to find path matching owner.repo_hash
+        8. If fallback found: return Path(repo_path) / entry.file_path
+        9. Otherwise: return None
+        """
+        import hashlib
+
+        from nexus.registry import RepoRegistry
+
+        entry = self.resolve(tumbler)
+        if not entry:
+            return None
+
+        # Find owner
+        owner_prefix = str(tumbler.owner_address())
+        owners = read_owners(self._owners_path) if self._owners_path.exists() else {}
+        owner_rec = owners.get(owner_prefix)
+        if not owner_rec:
+            return None
+
+        # Curators (PDFs, standalone docs) are not resolvable
+        if owner_rec.owner_type == "curator":
+            return None
+
+        # If file_path is already absolute, return it directly
+        fp = Path(entry.file_path)
+        if fp.is_absolute():
+            return fp
+
+        # Primary: use repo_root from owner
+        if owner_rec.repo_root:
+            return Path(owner_rec.repo_root) / entry.file_path
+
+        # Fallback: find repo_root from registry by matching repo_hash
+        if owner_rec.repo_hash:
+            registry_path = _default_registry_path()
+            if registry_path.exists():
+                reg = RepoRegistry(registry_path)
+                for path_str in reg.all_info():
+                    path_hash = hashlib.sha256(path_str.encode()).hexdigest()[:8]
+                    if path_hash == owner_rec.repo_hash:
+                        return Path(path_str) / entry.file_path
+
+        return None
 
     def descendants(self, prefix: str) -> list[dict]:
         """All documents whose tumbler starts with *prefix* (any depth).

--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -106,7 +106,8 @@ class CatalogDB:
         try:
             self._conn.execute("SELECT repo_root FROM owners LIMIT 0")
         except sqlite3.OperationalError:
-            self._conn.execute("ALTER TABLE owners ADD COLUMN repo_root TEXT DEFAULT ''")
+            with self._conn:
+                self._conn.execute("ALTER TABLE owners ADD COLUMN repo_root TEXT DEFAULT ''")
 
     def rebuild(
         self,

--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -23,7 +23,8 @@ CREATE TABLE IF NOT EXISTS owners (
     name TEXT NOT NULL UNIQUE,
     owner_type TEXT NOT NULL,
     repo_hash TEXT,
-    description TEXT
+    description TEXT,
+    repo_root TEXT DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS documents (
@@ -101,6 +102,11 @@ class CatalogDB:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._lock = threading.Lock()
         self._conn.executescript(_SCHEMA_SQL)
+        # Migration: add repo_root column if missing (pre-RDR-060 databases)
+        try:
+            self._conn.execute("SELECT repo_root FROM owners LIMIT 0")
+        except sqlite3.OperationalError:
+            self._conn.execute("ALTER TABLE owners ADD COLUMN repo_root TEXT DEFAULT ''")
 
     def rebuild(
         self,
@@ -117,9 +123,9 @@ class CatalogDB:
 
             for prefix, o in owners.items():
                 self._conn.execute(
-                    "INSERT OR REPLACE INTO owners (tumbler_prefix, name, owner_type, repo_hash, description) "
-                    "VALUES (?, ?, ?, ?, ?)",
-                    (prefix, o.name, o.owner_type, o.repo_hash, o.description),
+                    "INSERT OR REPLACE INTO owners (tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (prefix, o.name, o.owner_type, o.repo_hash, o.description, o.repo_root),
                 )
 
             for tumbler, d in documents.items():

--- a/src/nexus/catalog/link_generator.py
+++ b/src/nexus/catalog/link_generator.py
@@ -60,17 +60,27 @@ _FILE_PATH_RE = re.compile(
 )
 
 
-def generate_rdr_filepath_links(cat: Catalog) -> int:
+def generate_rdr_filepath_links(cat: Catalog, *, new_tumblers: list[Tumbler] | None = None) -> int:
     """Extract file paths from RDR content and link to matching code entries.
 
     Scans each RDR's file on disk for source file paths (e.g.,
     ``src/nexus/catalog/catalog.py``). Matches against catalog code entries
     by file_path. Creates ``implements`` links (RDR → code).
     created_by='filepath_extractor'.
+
+    When *new_tumblers* is provided, only those entries are scanned (incremental
+    mode). Pass ``None`` (default) for the full-scan behavior.
     """
+    if new_tumblers is not None and len(new_tumblers) == 0:
+        return 0
+
     entries = _all_entries(cat)
     rdr_entries = [e for e in entries if e.content_type == "rdr" and e.file_path]
     code_entries = [e for e in entries if e.content_type == "code" and e.file_path]
+
+    if new_tumblers is not None:
+        new_set = {str(t) for t in new_tumblers}
+        rdr_entries = [e for e in rdr_entries if str(e.tumbler) in new_set]
 
     # Index: file_path → tumbler (code entries)
     path_to_code: dict[str, Tumbler] = {}
@@ -118,14 +128,23 @@ def generate_rdr_filepath_links(cat: Catalog) -> int:
 _MAX_RDR_MATCHES_PER_CODE = 5
 
 
-def generate_code_rdr_links(cat: Catalog) -> int:
+def generate_code_rdr_links(cat: Catalog, *, new_tumblers: list[Tumbler] | None = None) -> int:
     """Heuristic: match RDR entries to code files by module name in title.
 
     Uses link_type='implements-heuristic' (not 'implements') to distinguish
     these substring-matched links from manually created or API-backed links.
     created_by='index_hook' per RF-8. Only matches module names > 3 chars.
     Capped at _MAX_RDR_MATCHES_PER_CODE matches per code file to prevent saturation.
+
+    When *new_tumblers* is provided (incremental mode), only newly added entries
+    are evaluated:
+    - New code entries × all RDRs
+    - All code entries × new RDR entries
+    Pass ``None`` (default) for the full-scan behavior.
     """
+    if new_tumblers is not None and len(new_tumblers) == 0:
+        return 0
+
     entries = _all_entries(cat)
     rdr_entries = [e for e in entries if e.content_type == "rdr"]
     code_entries = [e for e in entries if e.content_type == "code"]
@@ -136,13 +155,33 @@ def generate_code_rdr_links(cat: Catalog) -> int:
         for rdr in rdr_entries
     ]
 
+    if new_tumblers is not None:
+        new_set = {str(t) for t in new_tumblers}
+        new_code = [e for e in code_entries if str(e.tumbler) in new_set]
+        new_rdrs_normalized = [(rdr, norm) for rdr, norm in rdr_normalized if str(rdr.tumbler) in new_set]
+
+        # Determine which (code, rdr) pairs to evaluate:
+        # 1. new code × all RDRs
+        # 2. all code × new RDRs  (minus pairs already covered by #1 to avoid double-count)
+        pairs: list[tuple[CatalogEntry, list[tuple[CatalogEntry, str]]]] = []
+        if new_code:
+            pairs.extend((c, rdr_normalized) for c in new_code)
+        if new_rdrs_normalized:
+            new_rdr_set = {str(rdr.tumbler) for rdr, _ in new_rdrs_normalized}
+            for code in code_entries:
+                if str(code.tumbler) in new_set:
+                    continue  # already covered in #1
+                pairs.append((code, new_rdrs_normalized))
+    else:
+        pairs = [(code, rdr_normalized) for code in code_entries]
+
     count = 0
-    for code in code_entries:
+    for code, rdrs_to_check in pairs:
         module_name = Path(code.file_path).stem.replace("_", "").lower()
         if len(module_name) <= 3:
             continue
         matches_for_code = 0
-        for rdr, rdr_title_norm in rdr_normalized:
+        for rdr, rdr_title_norm in rdrs_to_check:
             if module_name in rdr_title_norm:
                 created = cat.link_if_absent(code.tumbler, rdr.tumbler, "implements-heuristic", created_by="index_hook")
                 if created:

--- a/src/nexus/catalog/link_generator.py
+++ b/src/nexus/catalog/link_generator.py
@@ -79,11 +79,11 @@ def generate_rdr_filepath_links(cat: Catalog) -> int:
 
     count = 0
     for rdr in rdr_entries:
-        rdr_path = Path(rdr.file_path)
-        if not rdr_path.is_file():
+        resolved = cat.resolve_path(rdr.tumbler)
+        if resolved is None or not resolved.is_file():
             continue
         try:
-            text = rdr_path.read_text(errors="replace")
+            text = resolved.read_text(errors="replace")
         except OSError:
             continue
 

--- a/src/nexus/catalog/tumbler.py
+++ b/src/nexus/catalog/tumbler.py
@@ -138,6 +138,7 @@ class OwnerRecord:
     owner_type: str  # "repo" | "curator"
     repo_hash: str
     description: str
+    repo_root: str = ""  # absolute path to repo working tree (RDR-060)
     next_seq: int = 1  # high-water mark — next document number to assign (never decreases)
 
 

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -753,6 +753,171 @@ def compact_cmd() -> None:
         click.echo("Run 'nx catalog sync' to commit the compacted files.")
 
 
+@catalog.command("orphans")
+@click.option("--no-links", "no_links", is_flag=True, help="Show entries with zero incoming and outgoing links")
+def orphans_cmd(no_links: bool) -> None:
+    """Find catalog entries that are not connected to anything.
+
+    \b
+    Examples:
+      nx catalog orphans --no-links    # entries with no links at all
+    """
+    if not no_links:
+        raise click.UsageError("Specify a mode: --no-links")
+
+    cat = _get_catalog()
+    db = cat._db
+    rows = db.execute(
+        """
+        SELECT tumbler, title, content_type, file_path
+        FROM documents
+        WHERE tumbler NOT IN (SELECT from_tumbler FROM links)
+          AND tumbler NOT IN (SELECT to_tumbler FROM links)
+        ORDER BY content_type, tumbler
+        """
+    ).fetchall()
+
+    if not rows:
+        click.echo("No orphan entries (all documents have at least one link).")
+        return
+
+    click.echo(f"Orphan entries ({len(rows)} with no links):")
+    for tumbler, title, content_type, file_path in rows:
+        loc = f"  [{file_path}]" if file_path else ""
+        click.echo(f"  {tumbler:<12} {content_type:<10} {title}{loc}")
+
+
+@catalog.command("coverage")
+@click.option("--owner", "owner_prefix", default="", help="Filter by tumbler prefix (e.g. '1.1')")
+def coverage_cmd(owner_prefix: str) -> None:
+    """Show what percentage of catalog entries have at least one link, by content type.
+
+    \b
+    Examples:
+      nx catalog coverage                # all types
+      nx catalog coverage --owner 1.1   # only entries under owner 1.1
+    """
+    cat = _get_catalog()
+    db = cat._db
+
+    # Fetch all distinct content types under filter
+    if owner_prefix:
+        like_pat = owner_prefix.rstrip(".") + ".%"
+        type_rows = db.execute(
+            "SELECT DISTINCT content_type FROM documents WHERE tumbler LIKE ? OR tumbler = ?",
+            (like_pat, owner_prefix),
+        ).fetchall()
+    else:
+        type_rows = db.execute("SELECT DISTINCT content_type FROM documents").fetchall()
+
+    content_types = [r[0] for r in type_rows]
+    if not content_types:
+        click.echo("No documents in catalog.")
+        return
+
+    click.echo("Link coverage by content type:")
+    for ct in sorted(content_types):
+        if owner_prefix:
+            like_pat = owner_prefix.rstrip(".") + ".%"
+            total = db.execute(
+                "SELECT COUNT(*) FROM documents WHERE content_type = ? AND (tumbler LIKE ? OR tumbler = ?)",
+                (ct, like_pat, owner_prefix),
+            ).fetchone()[0]
+            linked = db.execute(
+                """
+                SELECT COUNT(DISTINCT d.tumbler)
+                FROM documents d
+                JOIN links l ON d.tumbler = l.from_tumbler OR d.tumbler = l.to_tumbler
+                WHERE d.content_type = ?
+                  AND (d.tumbler LIKE ? OR d.tumbler = ?)
+                """,
+                (ct, like_pat, owner_prefix),
+            ).fetchone()[0]
+        else:
+            total = db.execute(
+                "SELECT COUNT(*) FROM documents WHERE content_type = ?",
+                (ct,),
+            ).fetchone()[0]
+            linked = db.execute(
+                """
+                SELECT COUNT(DISTINCT d.tumbler)
+                FROM documents d
+                JOIN links l ON d.tumbler = l.from_tumbler OR d.tumbler = l.to_tumbler
+                WHERE d.content_type = ?
+                """,
+                (ct,),
+            ).fetchone()[0]
+
+        pct = (linked / total * 100) if total else 0.0
+        click.echo(f"  {ct:<12} {linked:>4}/{total:<4} = {pct:5.1f}%")
+
+
+@catalog.command("suggest-links")
+@click.option("--limit", "-n", default=50, type=int, help="Max suggestions to show")
+@click.option("--threshold", default=0.0, type=float, help="Reserved for future similarity threshold (unused)")
+def suggest_links_cmd(limit: int, threshold: float) -> None:
+    """Suggest unlinked code-RDR pairs by module-name overlap.
+
+    Finds code entries whose filename stem appears in an RDR title, where no
+    link yet exists between the pair. Same heuristic as 'generate-links' but
+    read-only — shows what would be created.
+
+    \b
+    Examples:
+      nx catalog suggest-links
+      nx catalog suggest-links --limit 20
+    """
+    from pathlib import Path as _Path
+
+    cat = _get_catalog()
+    entries = cat.all_documents(limit=10_000)
+    rdr_entries = [e for e in entries if e.content_type == "rdr"]
+    code_entries = [e for e in entries if e.content_type == "code" and e.file_path]
+
+    if not rdr_entries or not code_entries:
+        click.echo("0 suggestions (no code or RDR entries to match).")
+        return
+
+    # Pre-normalize RDR titles
+    rdr_normalized = [
+        (rdr, rdr.title.lower().replace("-", "").replace(" ", "").replace("_", ""))
+        for rdr in rdr_entries
+    ]
+
+    suggestions: list[tuple[str, str, str, str]] = []  # (code_t, rdr_t, module, rdr_title)
+    for code in code_entries:
+        module_name = _Path(code.file_path).stem.replace("_", "").lower()
+        if len(module_name) <= 3:
+            continue
+        for rdr, rdr_title_norm in rdr_normalized:
+            if module_name not in rdr_title_norm:
+                continue
+            # Check if link already exists in either direction
+            existing = cat.link_query(
+                from_t=str(code.tumbler), to_t=str(rdr.tumbler),
+                link_type="", limit=1,
+            ) or cat.link_query(
+                from_t=str(rdr.tumbler), to_t=str(code.tumbler),
+                link_type="", limit=1,
+            )
+            if not existing:
+                suggestions.append((
+                    str(code.tumbler), str(rdr.tumbler),
+                    module_name, rdr.title,
+                ))
+        if len(suggestions) >= limit:
+            break
+
+    suggestions = suggestions[:limit]
+    if not suggestions:
+        click.echo("0 suggestions (all matching pairs are already linked).")
+        return
+
+    click.echo(f"{len(suggestions)} suggestion(s):")
+    for code_t, rdr_t, module, rdr_title in suggestions:
+        click.echo(f"  {code_t} → {rdr_t}  [{module}] {rdr_title}")
+
+
 # ── Backfill helpers ──────────────────────────────────────────────────────────
 
 

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -397,10 +397,10 @@ def register_cmd(
     # Relativize absolute file_path if under a known repo (RDR-060)
     fp = file_path
     if fp and Path(fp).is_absolute():
-        from nexus.config import default_db_path
+        from nexus.catalog.catalog import _default_registry_path
         from nexus.registry import RepoRegistry
 
-        reg_path = default_db_path() / "repos.json"
+        reg_path = _default_registry_path()
         if reg_path.exists():
             for repo_path_str in RepoRegistry(reg_path).all_info():
                 rel = make_relative(fp, Path(repo_path_str))
@@ -910,14 +910,14 @@ def _backfill_rdrs(cat: Catalog, t3: object, dry_run: bool) -> int:
             # Derive repo root from registry for relativization (RDR-060)
             repo_root: Path | None = None
             try:
-                from nexus.catalog.catalog import make_relative
-                from nexus.config import default_db_path
+                import hashlib
+
+                from nexus.catalog.catalog import _default_registry_path, make_relative
                 from nexus.registry import RepoRegistry
 
-                reg_path = default_db_path() / "repos.json"
+                reg_path = _default_registry_path()
                 if reg_path.exists():
                     for repo_path_str in RepoRegistry(reg_path).all_info():
-                        import hashlib
                         h = hashlib.sha256(repo_path_str.encode()).hexdigest()[:8]
                         if col_name.endswith(h):
                             repo_root = Path(repo_path_str)

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -787,6 +787,114 @@ def orphans_cmd(no_links: bool) -> None:
         click.echo(f"  {tumbler:<12} {content_type:<10} {title}{loc}")
 
 
+@catalog.command("links-for-file")
+@click.argument("file_path")
+def links_for_file_cmd(file_path: str) -> None:
+    """Show catalog entries linked to a specific file.
+
+    \b
+    Examples:
+      nx catalog links-for-file src/nexus/catalog/catalog.py
+      nx catalog links-for-file docs/rdr/rdr-060.md
+    """
+    cat = _get_catalog()
+    db = cat._db
+
+    row = db.execute(
+        "SELECT tumbler, title, content_type FROM documents WHERE file_path = ?",
+        (file_path,),
+    ).fetchone()
+    if not row:
+        click.echo(f"No catalog entry for: {file_path}")
+        return
+
+    tumbler_str, title, content_type = row
+    click.echo(f"{tumbler_str} {content_type}: {title}")
+
+    link_rows = db.execute(
+        """SELECT d.tumbler, d.title, d.content_type, l.link_type,
+                  CASE WHEN l.from_tumbler = ? THEN 'outgoing' ELSE 'incoming' END as direction
+           FROM links l
+           JOIN documents d ON (d.tumbler = l.to_tumbler AND l.from_tumbler = ?)
+                            OR (d.tumbler = l.from_tumbler AND l.to_tumbler = ?)
+           ORDER BY l.link_type, d.content_type""",
+        (tumbler_str, tumbler_str, tumbler_str),
+    ).fetchall()
+
+    if not link_rows:
+        click.echo("  No links.")
+        return
+
+    for t, t_title, t_type, l_type, direction in link_rows:
+        arrow = "→" if direction == "outgoing" else "←"
+        click.echo(f"  {arrow} [{l_type}] {t} {t_type}: {t_title}")
+
+
+@catalog.command("session-summary")
+@click.option("--since", default=24, type=int, help="Hours to look back for git changes")
+def session_summary_cmd(since: int) -> None:
+    """Show link graph summary for recently modified files.
+
+    \b
+    Examples:
+      nx catalog session-summary            # files modified in last 24 hours
+      nx catalog session-summary --since 48 # last 48 hours
+    """
+    import subprocess
+
+    try:
+        cat = _get_catalog()
+    except click.ClickException:
+        click.echo("Catalog not initialized — skipping session summary.")
+        return
+
+    try:
+        result = subprocess.run(
+            [
+                "git", "log",
+                f"--since={since} hours ago",
+                "--name-only",
+                "--pretty=format:",
+                "--diff-filter=ACMR",
+            ],
+            capture_output=True, text=True, timeout=5,
+        )
+        files = {f.strip() for f in result.stdout.splitlines() if f.strip()}
+    except Exception:
+        click.echo("Could not determine recent file changes.")
+        return
+
+    if not files:
+        click.echo(f"No files modified in the last {since} hours.")
+    else:
+        db = cat._db
+        found_any = False
+        for fp in sorted(files):
+            row = db.execute(
+                "SELECT tumbler FROM documents WHERE file_path = ?", (fp,)
+            ).fetchone()
+            if not row:
+                continue
+            tumbler_str = row[0]
+            link_rows = db.execute(
+                """SELECT DISTINCT d.title FROM links l
+                   JOIN documents d ON (d.tumbler = l.to_tumbler AND l.from_tumbler = ?)
+                                    OR (d.tumbler = l.from_tumbler AND l.to_tumbler = ?)
+                   WHERE d.content_type = 'rdr'""",
+                (tumbler_str, tumbler_str),
+            ).fetchall()
+            if link_rows:
+                rdrs = ", ".join(r[0] for r in link_rows)
+                click.echo(f"  {fp} — {len(link_rows)} RDR(s): {rdrs}")
+                found_any = True
+
+        if not found_any:
+            click.echo("No linked RDRs found for recently modified files.")
+
+    total = cat._db.execute("SELECT COUNT(*) FROM links").fetchone()[0]
+    click.echo(f"\nLink graph: {total} links active.")
+
+
 @catalog.command("gc")
 @click.option("--dry-run", is_flag=True, default=False, help="Show what would be deleted without deleting.")
 def gc_cmd(dry_run: bool) -> None:

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -1195,11 +1195,16 @@ def consolidate_cmd(corpus: str, dry_run: bool) -> None:
 @catalog.command("generate-links")
 @click.option("--citations/--no-citations", default=True, help="Generate citation links from bib metadata")
 @click.option("--code-rdr/--no-code-rdr", default=True, help="Generate code-RDR links by heuristic")
+@click.option("--filepath/--no-filepath", default=True, help="Generate RDR filepath links")
 @click.option("--dry-run", is_flag=True, help="Show what would be created without writing")
-def generate_links_cmd(citations: bool, code_rdr: bool, dry_run: bool) -> None:
+def generate_links_cmd(citations: bool, code_rdr: bool, filepath: bool, dry_run: bool) -> None:
     """Auto-generate typed links from metadata cross-matching."""
     cat = _get_catalog()
-    from nexus.catalog.link_generator import generate_citation_links, generate_code_rdr_links
+    from nexus.catalog.link_generator import (
+        generate_citation_links,
+        generate_code_rdr_links,
+        generate_rdr_filepath_links,
+    )
 
     total = 0
     if citations:
@@ -1218,8 +1223,30 @@ def generate_links_cmd(citations: bool, code_rdr: bool, dry_run: bool) -> None:
             click.echo(f"Code-RDR links created: {count}")
             total += count
 
+    if filepath:
+        if dry_run:
+            click.echo("Would generate RDR filepath links (dry-run mode not yet supported for link preview)")
+        else:
+            count = generate_rdr_filepath_links(cat)
+            click.echo(f"RDR filepath links created: {count}")
+            total += count
+
     if not dry_run:
         click.echo(f"Total links generated: {total}")
+
+
+@catalog.command("link-generate")
+@click.option("--dry-run", is_flag=True, default=False, help="Show what would be done without writing")
+def link_generate_cmd(dry_run: bool) -> None:
+    """Run all link generators over the full catalog (batch scan)."""
+    cat = _get_catalog()
+    if dry_run:
+        click.echo("[dry-run] Would run full link generation scan")
+        return
+    from nexus.catalog.link_generator import generate_code_rdr_links, generate_rdr_filepath_links
+    count1 = generate_code_rdr_links(cat)
+    count2 = generate_rdr_filepath_links(cat)
+    click.echo(f"Generated {count1} heuristic + {count2} filepath links.")
 
 
 def _make_t3():

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -391,10 +391,26 @@ def register_cmd(
     content_type: str, file_path: str, corpus: str,
 ) -> None:
     """Register a document in the catalog."""
+    from nexus.catalog.catalog import make_relative
+
     cat = _get_catalog()
+    # Relativize absolute file_path if under a known repo (RDR-060)
+    fp = file_path
+    if fp and Path(fp).is_absolute():
+        from nexus.config import default_db_path
+        from nexus.registry import RepoRegistry
+
+        reg_path = default_db_path() / "repos.json"
+        if reg_path.exists():
+            for repo_path_str in RepoRegistry(reg_path).all_info():
+                rel = make_relative(fp, Path(repo_path_str))
+                if rel != fp:
+                    fp = rel
+                    break
+
     tumbler = cat.register(
         Tumbler.parse(owner), title,
-        content_type=content_type, file_path=file_path,
+        content_type=content_type, file_path=fp,
         corpus=corpus, author=author, year=year,
     )
     click.echo(f"Registered: {tumbler}")
@@ -891,16 +907,35 @@ def _backfill_rdrs(cat: Catalog, t3: object, dry_run: bool) -> int:
                     break
                 offset += 200
 
+            # Derive repo root from registry for relativization (RDR-060)
+            repo_root: Path | None = None
+            try:
+                from nexus.catalog.catalog import make_relative
+                from nexus.config import default_db_path
+                from nexus.registry import RepoRegistry
+
+                reg_path = default_db_path() / "repos.json"
+                if reg_path.exists():
+                    for repo_path_str in RepoRegistry(reg_path).all_info():
+                        import hashlib
+                        h = hashlib.sha256(repo_path_str.encode()).hexdigest()[:8]
+                        if col_name.endswith(h):
+                            repo_root = Path(repo_path_str)
+                            break
+            except Exception:
+                pass  # non-fatal — store as-is
+
             for path, title in seen_paths.items():
                 if dry_run:
                     click.echo(f"  [dry-run] {title} → {col_name}")
                     count += 1
                     continue
-                existing = [e for e in cat.by_owner(curator) if e.file_path == path]
+                fp = make_relative(path, repo_root) if repo_root else path
+                existing = [e for e in cat.by_owner(curator) if e.file_path in (path, fp)]
                 if not existing:
                     cat.register(
                         owner=curator, title=title, content_type="rdr",
-                        file_path=path, physical_collection=col_name,
+                        file_path=fp, physical_collection=col_name,
                     )
                     count += 1
         except Exception as exc:

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -1145,6 +1145,7 @@ def _backfill_repos(
         if owner is None:
             owner = cat.register_owner(
                 repo_name, "repo", repo_hash=path_hash,
+                repo_root=str(repo_path),
                 description=f"Git repository: {repo_name}",
             )
 

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -787,6 +787,51 @@ def orphans_cmd(no_links: bool) -> None:
         click.echo(f"  {tumbler:<12} {content_type:<10} {title}{loc}")
 
 
+@catalog.command("gc")
+@click.option("--dry-run", is_flag=True, default=False, help="Show what would be deleted without deleting.")
+def gc_cmd(dry_run: bool) -> None:
+    """Remove orphan catalog entries that have miss_count >= 2.
+
+    \b
+    Orphans are entries that were absent in two or more consecutive index runs.
+    Use --dry-run to preview deletions without applying them.
+
+    \b
+    Examples:
+      nx catalog gc              # delete orphan entries
+      nx catalog gc --dry-run   # preview without deleting
+    """
+    cat = _get_catalog()
+
+    rows = cat._db.execute(
+        "SELECT tumbler, title, file_path, metadata FROM documents"
+    ).fetchall()
+
+    orphans: list[tuple[str, str, str]] = []
+    for tumbler_str, title, file_path, meta_json in rows:
+        meta = json.loads(meta_json) if meta_json else {}
+        if int(meta.get("miss_count", 0)) >= 2:
+            orphans.append((tumbler_str, title or "", file_path or ""))
+
+    if not orphans:
+        click.echo("No orphan entries found.")
+        return
+
+    click.echo(f"Found {len(orphans)} orphan {'entry' if len(orphans) == 1 else 'entries'} (miss_count >= 2):")
+    for tumbler_str, title, file_path in orphans:
+        loc = f" ({file_path})" if file_path else ""
+        if dry_run:
+            click.echo(f"  [dry-run] would delete {tumbler_str}: {title}{loc}")
+        else:
+            cat.delete_document(Tumbler.parse(tumbler_str))
+            click.echo(f"  deleted {tumbler_str}: {title}{loc}")
+
+    if dry_run:
+        click.echo(f"\n{len(orphans)} {'entry' if len(orphans) == 1 else 'entries'} would be deleted. Run without --dry-run to apply.")
+    else:
+        click.echo(f"\nDeleted {len(orphans)} orphan {'entry' if len(orphans) == 1 else 'entries'}.")
+
+
 @catalog.command("coverage")
 @click.option("--owner", "owner_prefix", default="", help="Filter by tumbler prefix (e.g. '1.1')")
 def coverage_cmd(owner_prefix: str) -> None:

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -264,7 +264,20 @@ def _check_chroma_pagination(lines: list[str], client: object, db_name: str) -> 
     default=False,
     help="Apply HNSW ef tuning to all local collections (local mode only).",
 )
-def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool) -> None:
+@click.option(
+    "--fix-paths",
+    is_flag=True,
+    default=False,
+    help="Migrate absolute file_path entries to relative paths (catalog + T3).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Report affected entries without writing changes (use with --fix-paths).",
+)
+def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
+               fix_paths: bool, dry_run: bool) -> None:
     """Verify that all required services and credentials are available."""
     if fix:
         from nexus.config import is_local_mode, _default_local_path
@@ -298,6 +311,99 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool) -> Non
             click.echo(f"Deleted {len(deleted)} orphaned pipeline entry/entries.")
         else:
             click.echo("No orphaned pipeline entries found.")
+        return
+
+    if fix_paths:
+        from nexus.catalog import Catalog
+        from nexus.catalog.catalog import make_relative
+        from nexus.catalog.tumbler import Tumbler, read_owners
+        from nexus.config import catalog_path
+        from nexus.db import make_t3
+
+        import hashlib
+
+        cat_p = catalog_path()
+        if not Catalog.is_initialized(cat_p):
+            click.echo("Catalog not initialized — run: nx catalog setup")
+            return
+
+        cat = Catalog(cat_p, cat_p / ".catalog.db")
+
+        # Find all entries with absolute file_path
+        rows = cat._db.execute(
+            "SELECT tumbler, file_path, physical_collection FROM documents WHERE file_path LIKE '/%'"
+        ).fetchall()
+
+        if not rows:
+            click.echo("No absolute file_path entries found.")
+            return
+
+        click.echo(f"Found {len(rows)} entries with absolute paths.")
+
+        # Load owners for repo_root lookup
+        owners_path = cat._owners_path
+        owners = read_owners(owners_path) if owners_path.exists() else {}
+
+        # Get registry for fallback
+        registry_path = Path.home() / ".config" / "nexus" / "repos.json"
+        registry = RepoRegistry(registry_path) if registry_path.exists() else None
+
+        t3_db = None
+        if not dry_run:
+            t3_db = make_t3()
+
+        fixed = 0
+        chunks_updated = 0
+        for tumbler_str, file_path, physical_collection in rows:
+            tumbler = Tumbler.parse(tumbler_str)
+            owner_prefix = str(tumbler.owner_address())
+            owner_rec = owners.get(owner_prefix)
+
+            if not owner_rec:
+                continue
+            if owner_rec.owner_type == "curator":
+                continue
+
+            # Determine repo_root
+            repo_root = None
+            if owner_rec.repo_root:
+                repo_root = Path(owner_rec.repo_root)
+            elif owner_rec.repo_hash and registry:
+                for rp in registry.all_info():
+                    h = hashlib.sha256(rp.encode()).hexdigest()[:8]
+                    if h == owner_rec.repo_hash:
+                        repo_root = Path(rp)
+                        break
+
+            if repo_root is None:
+                _log.warning("fix_paths_no_root", tumbler=tumbler_str, file_path=file_path)
+                continue
+
+            new_rel = make_relative(file_path, repo_root)
+            if new_rel == file_path:
+                # Not under repo_root — skip
+                _log.warning("fix_paths_not_under_root", tumbler=tumbler_str,
+                             file_path=file_path, repo_root=str(repo_root))
+                continue
+
+            if dry_run:
+                click.echo(f"  [dry-run] {tumbler_str}: {file_path} -> {new_rel}")
+            else:
+                # Update T3 source_path
+                n = 0
+                if physical_collection:
+                    n = t3_db.update_source_path(physical_collection, file_path, new_rel)
+                chunks_updated += n
+                # Update catalog entry
+                cat.update(tumbler, file_path=new_rel)
+                click.echo(f"  fixed: {tumbler_str}: {file_path} -> {new_rel} ({n} chunks)")
+
+            fixed += 1
+
+        if dry_run:
+            click.echo(f"\n{fixed} entries would be fixed. Use --fix-paths without --dry-run to apply.")
+        else:
+            click.echo(f"\nFixed {fixed} entries ({chunks_updated} T3 chunks updated).")
         return
 
     lines: list[str] = ["Nexus health check:\n"]

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -471,7 +471,8 @@ def index_rdr_cmd(path: Path, force: bool, monitor: bool) -> None:
                 click.echo(line)
 
     results = batch_index_markdowns(rdr_files, corpus=basename, collection_name=collection,
-                                    content_type="rdr", force=force, on_file=on_file)
+                                    content_type="rdr", force=force, on_file=on_file,
+                                    base_path=path)
     bar.close()
     indexed = sum(1 for s in results.values() if s == "indexed")
     result_label = "Force re-indexed" if force else "Indexed"

--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -207,7 +207,7 @@ def search_cmd(
         hybrid = config.get("search", {}).get("hybrid_default", False)
 
     def _retrieve(q: str) -> list[SearchResult]:
-        raw = search_cross_corpus(q, target_collections, n_results=n, t3=db, where=where_filter)
+        raw = search_cross_corpus(q, target_collections, n_results=n, t3=db, where=where_filter, link_boost=False)
         if hybrid:
             # Scope ripgrep to matching caches when a single corpus is targeted
             rg_corpus = target_collections[0] if len(target_collections) == 1 else None

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -715,6 +715,52 @@ class T3Database:
             self._delete_batch(col, collection_name, ids)
         return len(ids)
 
+    def update_source_path(
+        self, collection_name: str, old_path: str, new_path: str
+    ) -> int:
+        """Rewrite source_path metadata for all chunks matching old_path.
+
+        Paginates via col.get() to respect Cloud's 300-record batch limit.
+        Returns count of chunks updated. Idempotent.
+        """
+        try:
+            col = self._client_for(collection_name).get_collection(collection_name)
+        except _ChromaNotFoundError:
+            return 0
+        ids: list[str] = []
+        metadatas: list[dict] = []
+        offset = 0
+        page_limit = QUOTAS.MAX_RECORDS_PER_WRITE
+        while True:
+            result = _chroma_with_retry(
+                col.get,
+                where={"source_path": old_path},
+                include=["metadatas"],
+                limit=page_limit,
+                offset=offset,
+            )
+            page_ids = result["ids"]
+            page_metas = result["metadatas"]
+            for i, mid in enumerate(page_ids):
+                ids.append(mid)
+                updated = dict(page_metas[i])
+                updated["source_path"] = new_path
+                metadatas.append(updated)
+            offset += len(page_ids)
+            if len(page_ids) < page_limit:
+                break
+        if not ids:
+            return 0
+        size = QUOTAS.MAX_RECORDS_PER_WRITE
+        with self._write_sem(collection_name):
+            for start in range(0, len(ids), size):
+                _chroma_with_retry(
+                    col.update,
+                    ids=ids[start:start + size],
+                    metadatas=metadatas[start:start + size],
+                )
+        return len(ids)
+
     def get_by_id(self, collection: str, doc_id: str) -> dict | None:
         """Retrieve a single entry by its exact document ID.
 

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -249,6 +249,7 @@ def _index_document(
     force: bool = False,
     return_metadata: bool = False,
     on_progress: Callable[[int, int], None] | None = None,
+    source_key: str | None = None,
 ) -> int | list[dict]:
     """Shared indexing pipeline: credential check, staleness, embed, upsert, prune.
 
@@ -268,10 +269,16 @@ def _index_document(
     instead of a bare int.  Callers (index_pdf, index_markdown) use it to
     build format-specific summary dicts.  Default False preserves the existing
     int return type with zero overhead.
+
+    When *source_key* is provided it overrides ``str(file_path)`` as the
+    ``source_path`` value used in the staleness check and stale-chunk pruning.
+    Callers pass a relative path here so that T3 metadata lookups match the
+    relative ``source_path`` stored in chunk metadata (RDR-060).
     """
     if embed_fn is None and not _has_credentials():
         return 0
 
+    sp = source_key if source_key is not None else str(file_path)
     content_hash = _sha256(file_path)
     if collection_name is None:
         collection_name = f"docs__{corpus}"
@@ -283,7 +290,7 @@ def _index_document(
     # Incremental sync: skip if file is already indexed with the same hash AND model
     existing = _chroma_with_retry(
         col.get,
-        where={"source_path": str(file_path)},
+        where={"source_path": sp},
         include=["metadatas"],
         limit=1,
     )
@@ -324,7 +331,7 @@ def _index_document(
     while True:
         batch = _chroma_with_retry(
             col.get,
-            where={"source_path": str(file_path)},
+            where={"source_path": sp},
             include=[],
             limit=300,
             offset=offset,
@@ -540,14 +547,19 @@ def _markdown_chunks(
     target_model: str,
     now_iso: str,
     corpus: str,
+    *,
+    base_path: Path | None = None,
 ) -> list[tuple[str, str, dict]]:
     """Chunk a Markdown file and return (id, text, metadata) tuples."""
+    from nexus.catalog.catalog import make_relative
+
     raw_text = md_path.read_text(encoding="utf-8")
     frontmatter, body = parse_frontmatter(raw_text)
     frontmatter_len = len(raw_text) - len(body)
 
+    sp = make_relative(md_path, base_path) if base_path else str(md_path)
     base_meta: dict = {
-        "source_path": str(md_path),
+        "source_path": sp,
         "corpus": corpus,
     }
     chunks = SemanticMarkdownChunker().chunk(body, base_meta)
@@ -558,7 +570,7 @@ def _markdown_chunks(
     for chunk in chunks:
         chunk_id = f"{content_hash[:16]}_{chunk.chunk_index}"
         meta: dict = {
-            "source_path": str(md_path),
+            "source_path": sp,
             "source_title": str(frontmatter.get("title", "")),
             "source_author": str(frontmatter.get("author", "")),
             "source_date": str(frontmatter.get("date", "")),
@@ -785,10 +797,12 @@ def index_pdf(
 
 def _catalog_markdown_hook(
     md_path: Path, collection_name: str, content_type: str, corpus: str, chunk_count: int,
+    *, base_path: Path | None = None,
 ) -> None:
     """Register markdown document in catalog after indexing. Silently skipped if absent."""
     try:
         from nexus.catalog import Catalog
+        from nexus.catalog.catalog import make_relative
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
@@ -828,9 +842,10 @@ def _catalog_markdown_hook(
         else:
             owner = cat.register_owner(owner_name, "curator")
 
+        fp = make_relative(md_path, base_path) if base_path else str(md_path)
         cat.register(
             owner=owner, title=title, content_type=content_type,
-            file_path=str(md_path), physical_collection=collection_name,
+            file_path=fp, physical_collection=collection_name,
             chunk_count=chunk_count, year=year,
         )
     except Exception:
@@ -848,6 +863,7 @@ def index_markdown(
     return_metadata: bool = False,
     on_progress: Callable[[int, int], None] | None = None,
     content_type: str = "prose",
+    base_path: Path | None = None,
 ) -> int | dict:
     """Index *md_path* into a T3 collection.
 
@@ -869,25 +885,35 @@ def index_markdown(
 
     *sections* is the count of chunks with a non-empty ``section_title``
     (i.e. produced under a heading).  Default False preserves existing int behavior.
+
+    When *base_path* is provided, ``source_path`` in T3 chunk metadata is
+    stored relative to *base_path* instead of absolute (RDR-060).
     """
+    from functools import partial
+
+    from nexus.catalog.catalog import make_relative
+
     col_name = collection_name if collection_name is not None else f"docs__{corpus}"
+    chunk_fn = partial(_markdown_chunks, base_path=base_path) if base_path else _markdown_chunks
+    source_key = make_relative(md_path, base_path) if base_path else None
     raw = _index_document(
-        md_path, corpus, _markdown_chunks, t3=t3,
+        md_path, corpus, chunk_fn, t3=t3,
         collection_name=collection_name, embed_fn=embed_fn,
         force=force, return_metadata=return_metadata, on_progress=on_progress,
+        source_key=source_key,
     )
     if not return_metadata:
         assert isinstance(raw, int)
         count = raw
         if count > 0:
-            _catalog_markdown_hook(md_path, col_name, content_type, corpus, count)
+            _catalog_markdown_hook(md_path, col_name, content_type, corpus, count, base_path=base_path)
         return count
     if not isinstance(raw, list):
         return {"chunks": 0, "sections": 0}
     metadatas: list[dict] = raw
     sections = sum(1 for m in metadatas if m.get("section_title", ""))
     if metadatas:
-        _catalog_markdown_hook(md_path, col_name, content_type, corpus, len(metadatas))
+        _catalog_markdown_hook(md_path, col_name, content_type, corpus, len(metadatas), base_path=base_path)
     return {"chunks": len(metadatas), "sections": sections}
 
 
@@ -936,6 +962,7 @@ def batch_index_markdowns(
     content_type: str = "prose",
     force: bool = False,
     on_file: Callable[[Path, int, float], None] | None = None,
+    base_path: Path | None = None,
 ) -> dict[str, str]:
     """Index multiple Markdown files sequentially, returning per-file status.
 
@@ -953,6 +980,9 @@ def batch_index_markdowns(
     *on_file*, if provided, is called after each file as
     ``on_file(path, chunks, elapsed_s)`` where *chunks* is the number of
     chunks upserted (0 for skipped/failed) and *elapsed_s* is wall time.
+
+    When *base_path* is provided, ``source_path`` in T3 chunk metadata and
+    catalog ``file_path`` are stored relative to *base_path* (RDR-060).
     """
     results: dict[str, str] = {}
     for path in paths:
@@ -960,7 +990,7 @@ def batch_index_markdowns(
         t0 = time.monotonic()
         try:
             raw = index_markdown(path, corpus, t3=t3, collection_name=collection_name,
-                                 content_type=content_type, force=force)
+                                 content_type=content_type, force=force, base_path=base_path)
             count = raw if isinstance(raw, int) else 0
             results[str(path)] = "indexed" if count else "skipped"
         except Exception as e:

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -246,6 +246,7 @@ def _catalog_hook(
                 name=repo_name,
                 owner_type="repo",
                 repo_hash=repo_hash,
+                repo_root=str(repo),
                 description=f"Git repository: {repo_name}",
             )
             _log.info("catalog_owner_created", owner=str(owner), repo=repo_name)
@@ -286,8 +287,8 @@ def _catalog_hook(
         # Auto-generate links after registration (incremental: only new entries)
         try:
             from nexus.catalog.link_generator import generate_code_rdr_links, generate_rdr_filepath_links
-            link_count = generate_code_rdr_links(cat, new_tumblers=new_tumblers if new_tumblers else None)
-            fp_count = generate_rdr_filepath_links(cat, new_tumblers=new_tumblers if new_tumblers else None)
+            link_count = generate_code_rdr_links(cat, new_tumblers=new_tumblers)
+            fp_count = generate_rdr_filepath_links(cat, new_tumblers=new_tumblers)
             total = link_count + fp_count
             if total:
                 _log.info("catalog_links_generated", heuristic=link_count, filepath=fp_count, repo=repo_name)

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -257,6 +257,13 @@ def _catalog_hook(
             except ValueError:
                 rel_path = abs_path.name
 
+            # Per-file content hash for rename detection (RDR-060 E7)
+            import hashlib as _hl
+            try:
+                file_hash = _hl.sha256(abs_path.read_bytes()).hexdigest()
+            except OSError:
+                file_hash = ""
+
             existing = cat.by_file_path(owner, rel_path)
             if existing is None:
                 tumbler = cat.register(
@@ -266,6 +273,7 @@ def _catalog_hook(
                     file_path=rel_path,
                     physical_collection=collection_name,
                     head_hash=head_hash,
+                    meta={"content_hash": file_hash} if file_hash else None,
                 )
                 new_tumblers.append(tumbler)
             else:
@@ -273,6 +281,7 @@ def _catalog_hook(
                     existing.tumbler,
                     head_hash=head_hash,
                     physical_collection=collection_name,
+                    meta={"content_hash": file_hash} if file_hash else None,
                 )
         # Auto-generate links after registration (incremental: only new entries)
         try:
@@ -297,13 +306,23 @@ def _run_housekeeping(
     owner: "Tumbler",
     indexed_set: set[str],
 ) -> None:
-    """Orphan detection with miss_count tracking.
+    """Orphan detection with miss_count tracking and rename detection.
 
     For each catalog entry owned by *owner*:
     - If the file is present in *indexed_set*, reset miss_count to 0.
-    - If absent, increment miss_count. Delete at threshold >= 2.
+    - If absent and a content_hash match exists at a new path, treat as rename:
+      transfer links to the new entry and delete the old one.
+    - If absent with no rename match, increment miss_count. Delete at threshold >= 2.
     """
     owner_entries = cat.by_owner(owner)
+
+    # Build content_hash → entry map for rename detection
+    hash_to_entry: dict[str, object] = {}
+    for e in owner_entries:
+        ch = (e.meta or {}).get("content_hash", "")
+        if ch and e.file_path in indexed_set:
+            hash_to_entry[ch] = e
+
     for entry in owner_entries:
         if entry.file_path in indexed_set:
             meta = entry.meta or {}
@@ -311,6 +330,34 @@ def _run_housekeeping(
                 meta = dict(meta)
                 meta["miss_count"] = 0
                 cat.update(entry.tumbler, meta=meta)
+            continue
+
+        # Check for rename: orphan's content_hash matches a newly-indexed entry
+        orphan_hash = (entry.meta or {}).get("content_hash", "")
+        if orphan_hash and orphan_hash in hash_to_entry:
+            new_entry = hash_to_entry[orphan_hash]
+            # Transfer links from old entry to new entry
+            old_links = cat.links_from(entry.tumbler)
+            for lnk in old_links:
+                cat.link_if_absent(
+                    new_entry.tumbler, lnk.to_tumbler, lnk.link_type,
+                    created_by=lnk.created_by,
+                )
+            # Also transfer incoming links
+            incoming = cat.links_to(entry.tumbler)
+            for lnk in incoming:
+                cat.link_if_absent(
+                    lnk.from_tumbler, new_entry.tumbler, lnk.link_type,
+                    created_by=lnk.created_by,
+                )
+            cat.delete_document(entry.tumbler)
+            _log.info(
+                "housekeeping_rename_detected",
+                old_path=entry.file_path,
+                new_path=new_entry.file_path,
+                old_tumbler=str(entry.tumbler),
+                new_tumbler=str(new_entry.tumbler),
+            )
             continue
 
         # File not in this index run — increment miss_count

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -248,6 +248,7 @@ def _catalog_hook(
             )
             _log.info("catalog_owner_created", owner=str(owner), repo=repo_name)
 
+        new_tumblers = []
         for abs_path, content_type, collection_name in indexed_files:
             try:
                 rel_path = str(abs_path.relative_to(repo))
@@ -256,7 +257,7 @@ def _catalog_hook(
 
             existing = cat.by_file_path(owner, rel_path)
             if existing is None:
-                cat.register(
+                tumbler = cat.register(
                     owner=owner,
                     title=abs_path.name,
                     content_type=content_type,
@@ -264,17 +265,18 @@ def _catalog_hook(
                     physical_collection=collection_name,
                     head_hash=head_hash,
                 )
+                new_tumblers.append(tumbler)
             else:
                 cat.update(
                     existing.tumbler,
                     head_hash=head_hash,
                     physical_collection=collection_name,
                 )
-        # Auto-generate links after registration
+        # Auto-generate links after registration (incremental: only new entries)
         try:
             from nexus.catalog.link_generator import generate_code_rdr_links, generate_rdr_filepath_links
-            link_count = generate_code_rdr_links(cat)
-            fp_count = generate_rdr_filepath_links(cat)
+            link_count = generate_code_rdr_links(cat, new_tumblers=new_tumblers if new_tumblers else None)
+            fp_count = generate_rdr_filepath_links(cat, new_tumblers=new_tumblers if new_tumblers else None)
             total = link_count + fp_count
             if total:
                 _log.info("catalog_links_generated", heuristic=link_count, filepath=fp_count, repo=repo_name)

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -45,6 +45,8 @@ from nexus.code_indexer import (  # noqa: F401
 _log = structlog.get_logger(__name__)
 
 if TYPE_CHECKING:
+    from nexus.catalog.catalog import Catalog
+    from nexus.catalog.tumbler import Tumbler
     from nexus.registry import RepoRegistry
 
 DEFAULT_IGNORE: list[str] = [
@@ -282,8 +284,54 @@ def _catalog_hook(
                 _log.info("catalog_links_generated", heuristic=link_count, filepath=fp_count, repo=repo_name)
         except Exception:
             _log.debug("catalog_link_generation_failed", exc_info=True)
+
+        # Housekeeping: detect and evict orphaned catalog entries
+        indexed_set = {str(abs_path.relative_to(repo)) for abs_path, _, _ in indexed_files}
+        _run_housekeeping(cat, owner, indexed_set)
     except Exception:
         _log.debug("catalog_hook_failed", exc_info=True)
+
+
+def _run_housekeeping(
+    cat: "Catalog",
+    owner: "Tumbler",
+    indexed_set: set[str],
+) -> None:
+    """Orphan detection with miss_count tracking.
+
+    For each catalog entry owned by *owner*:
+    - If the file is present in *indexed_set*, reset miss_count to 0.
+    - If absent, increment miss_count. Delete at threshold >= 2.
+    """
+    owner_entries = cat.by_owner(owner)
+    for entry in owner_entries:
+        if entry.file_path in indexed_set:
+            meta = entry.meta or {}
+            if int(meta.get("miss_count", 0)) > 0:
+                meta = dict(meta)
+                meta["miss_count"] = 0
+                cat.update(entry.tumbler, meta=meta)
+            continue
+
+        # File not in this index run — increment miss_count
+        meta = dict(entry.meta or {})
+        miss_count = int(meta.get("miss_count", 0)) + 1
+
+        if miss_count >= 2:
+            cat.delete_document(entry.tumbler)
+            _log.info(
+                "housekeeping_orphan_deleted",
+                tumbler=str(entry.tumbler),
+                file_path=entry.file_path,
+            )
+        else:
+            meta["miss_count"] = miss_count
+            cat.update(entry.tumbler, meta=meta)
+            _log.debug(
+                "housekeeping_miss_count_incremented",
+                tumbler=str(entry.tumbler),
+                miss_count=miss_count,
+            )
 
 
 def index_repository(

--- a/src/nexus/mcp_server.py
+++ b/src/nexus/mcp_server.py
@@ -1168,12 +1168,28 @@ def catalog_register(
         return {"error": err}
     try:
         import json as _json
+        from pathlib import Path as _Path
 
+        from nexus.catalog.catalog import make_relative
         from nexus.catalog.tumbler import Tumbler
+
+        # Relativize absolute file_path if it falls under a known repo (RDR-060)
+        fp = file_path
+        if fp and _Path(fp).is_absolute():
+            from nexus.config import default_db_path
+            from nexus.registry import RepoRegistry
+
+            reg_path = default_db_path() / "repos.json"
+            if reg_path.exists():
+                for repo_path_str in RepoRegistry(reg_path).all_info():
+                    rel = make_relative(fp, _Path(repo_path_str))
+                    if rel != fp:
+                        fp = rel
+                        break
 
         tumbler = cat.register(
             Tumbler.parse(owner), title,
-            content_type=content_type, file_path=file_path,
+            content_type=content_type, file_path=fp,
             corpus=corpus, author=author, year=year,
             physical_collection=physical_collection,
             meta=_json.loads(meta) if meta else None,

--- a/src/nexus/mcp_server.py
+++ b/src/nexus/mcp_server.py
@@ -1176,10 +1176,10 @@ def catalog_register(
         # Relativize absolute file_path if it falls under a known repo (RDR-060)
         fp = file_path
         if fp and _Path(fp).is_absolute():
-            from nexus.config import default_db_path
+            from nexus.catalog.catalog import _default_registry_path
             from nexus.registry import RepoRegistry
 
-            reg_path = default_db_path() / "repos.json"
+            reg_path = _default_registry_path()
             if reg_path.exists():
                 for repo_path_str in RepoRegistry(reg_path).all_info():
                     rel = make_relative(fp, _Path(repo_path_str))

--- a/src/nexus/mcp_server.py
+++ b/src/nexus/mcp_server.py
@@ -87,6 +87,7 @@ def search(
             query, target, n_results=fetch_n, t3=t3, where=where_dict,
             cluster_by=cluster_by or None,
             catalog=_get_catalog(),
+            link_boost=False,
         )
         # Only sort by distance for flat (non-clustered) results.
         # Clustered results arrive in cluster-grouped order from search_engine.
@@ -279,6 +280,8 @@ def query(
         fetch_n = limit * 10
         results = search_cross_corpus(
             question, target, n_results=fetch_n, t3=t3, where=where_dict,
+            catalog=_get_catalog(),
+            link_boost=True,
         )
         results.sort(key=lambda r: r.distance)
         if not results:

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from typing import Any
 
 import structlog
 
@@ -183,6 +184,85 @@ def apply_quality_boost(
             except (ValueError, TypeError):
                 pass
         r.hybrid_score += boost_weight * quality_score(count, age_days=age_days)
+    return results
+
+
+# ── Link-aware boost (RDR-060 E3) ───────────────────────────────────────────
+
+_LINK_BOOST_WEIGHTS: dict[str, float] = {
+    "implements": 1.0,
+    "implements-heuristic": 0.0,
+    "relates": 0.5,
+    "cites": 0.5,
+    "supersedes": 0.0,
+}
+_DEFAULT_LINK_BOOST_WEIGHT: float = 0.15
+
+
+def apply_link_boost(
+    results: list[SearchResult],
+    catalog: Any,
+    boost_weight: float = _DEFAULT_LINK_BOOST_WEIGHT,
+    type_weights: dict[str, float] | None = None,
+) -> list[SearchResult]:
+    """Boost hybrid_score for results whose source documents have outgoing links.
+
+    Looks up each result's source_path in the catalog, finds outgoing links,
+    and computes a link signal from type weights. Additive:
+    ``score += boost_weight * min(signal, 1.0)``.
+
+    Only processes results that have ``source_path`` metadata and a matching
+    catalog entry. Results without catalog matches are untouched.
+    """
+    if not catalog:
+        return results
+    tw = type_weights if type_weights is not None else _LINK_BOOST_WEIGHTS
+
+    # Collect unique source_paths from results
+    source_paths: set[str] = set()
+    for r in results:
+        sp = r.metadata.get("source_path", "")
+        if sp:
+            source_paths.add(sp)
+
+    if not source_paths:
+        return results
+
+    # Batch query: find all tumblers for these source_paths
+    placeholders = ",".join("?" for _ in source_paths)
+    rows = catalog._db.execute(
+        f"SELECT file_path, tumbler FROM documents WHERE file_path IN ({placeholders})",
+        list(source_paths),
+    ).fetchall()
+    path_to_tumbler: dict[str, str] = {row[0]: row[1] for row in rows}
+
+    if not path_to_tumbler:
+        return results
+
+    # Batch query: get all outgoing links for these tumblers
+    tumbler_strs = list(path_to_tumbler.values())
+    placeholders2 = ",".join("?" for _ in tumbler_strs)
+    link_rows = catalog._db.execute(
+        f"SELECT from_tumbler, link_type FROM links WHERE from_tumbler IN ({placeholders2})",
+        tumbler_strs,
+    ).fetchall()
+
+    # Aggregate: tumbler -> total weighted signal
+    tumbler_signal: dict[str, float] = {}
+    for from_t, link_type in link_rows:
+        w = tw.get(link_type, 0.0)
+        tumbler_signal[from_t] = tumbler_signal.get(from_t, 0.0) + w
+
+    # Apply boost
+    for r in results:
+        sp = r.metadata.get("source_path", "")
+        t_str = path_to_tumbler.get(sp)
+        if not t_str:
+            continue
+        signal = min(tumbler_signal.get(t_str, 0.0), 1.0)
+        if signal > 0:
+            r.hybrid_score += boost_weight * signal
+
     return results
 
 

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -62,7 +62,7 @@ def _overfetch_multiplier(collection_name: str) -> int:
 _OP_MAP = {"$eq": "=", "$gte": ">=", "$lte": "<=", "$gt": ">", "$lt": "<", "$ne": "!="}
 
 # Predicates we can route to catalog SQLite for pre-filtering.
-_PREDICATE_TO_COLUMN = {"bib_year": "year", "bib_citation_count": "year"}  # citation_count not in catalog
+_PREDICATE_TO_COLUMN = {"bib_year": "year"}
 
 
 def _catalog_ids_for_predicates(db: sqlite3.Connection, predicates: dict) -> list[str]:

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -153,6 +153,7 @@ def search_cross_corpus(
     where: dict | None = None,
     cluster_by: str | None = None,
     catalog: Any | None = None,
+    link_boost: bool = False,
 ) -> list[SearchResult]:
     """Query each collection independently, returning combined raw results.
 
@@ -217,6 +218,11 @@ def search_cross_corpus(
                 dropped=dropped,
                 threshold=threshold,
             )
+
+    # Link-aware boost (RDR-060 E3)
+    if link_boost and catalog and all_results:
+        from nexus.scoring import apply_link_boost
+        all_results = apply_link_boost(all_results, catalog)
 
     if cluster_by == "semantic" and all_results:
         all_results = _apply_clustering(all_results, t3)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,18 @@ def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr("nexus.hooks.SESSIONS_DIR", sessions)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_catalog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect NEXUS_CATALOG_PATH so tests never pollute the real user catalog.
+
+    Without this, integration tests that trigger _catalog_hook() (via index_repo
+    or similar) register documents in the user's live catalog at ~/.config/nexus/.
+    This creates thousands of junk entries from pytest temp dirs that accumulate
+    across test runs.
+    """
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "test-catalog"))
+
+
 def set_credentials(monkeypatch) -> None:
     """Set required T3/Voyage credential env vars for tests that call _has_credentials().
 

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -290,3 +290,94 @@ class TestStatsCommand:
         result = runner.invoke(main, ["catalog", "stats"])
         assert result.exit_code == 0
         assert "1" in result.output  # at least 1 document
+
+
+class TestDiscoveryTools:
+    def test_orphans_no_links(self, initialized_catalog, catalog_env):
+        """Entries with no links are reported as orphans."""
+        runner = CliRunner()
+        runner.invoke(main, ["catalog", "register", "--title", "Orphan Doc", "--owner", "1.1", "--type", "code"])
+        result = runner.invoke(main, ["catalog", "orphans", "--no-links"])
+        assert result.exit_code == 0
+        assert "Orphan Doc" in result.output
+
+    def test_orphans_all_linked(self, initialized_catalog, catalog_env):
+        """When all entries have links, report zero orphans."""
+        runner = CliRunner()
+        runner.invoke(main, ["catalog", "register", "--title", "A", "--owner", "1.1"])
+        runner.invoke(main, ["catalog", "register", "--title", "B", "--owner", "1.1"])
+        runner.invoke(main, ["catalog", "link", "1.1.1", "1.1.2", "--type", "cites"])
+        result = runner.invoke(main, ["catalog", "orphans", "--no-links"])
+        assert result.exit_code == 0
+        assert "No orphan" in result.output
+
+    def test_orphans_empty_catalog(self, initialized_catalog, catalog_env):
+        """Empty catalog handles gracefully."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "orphans", "--no-links"])
+        assert result.exit_code == 0
+        assert "No orphan" in result.output
+
+    def test_coverage_report(self, initialized_catalog, catalog_env):
+        """Coverage shows linked vs total count per content type."""
+        runner = CliRunner()
+        runner.invoke(main, ["catalog", "register", "--title", "A", "--owner", "1.1", "--type", "code"])
+        runner.invoke(main, ["catalog", "register", "--title", "B", "--owner", "1.1", "--type", "code"])
+        runner.invoke(main, ["catalog", "register", "--title", "C", "--owner", "1.1", "--type", "paper"])
+        runner.invoke(main, ["catalog", "link", "1.1.1", "1.1.2", "--type", "cites"])
+        result = runner.invoke(main, ["catalog", "coverage"])
+        assert result.exit_code == 0
+        assert "code" in result.output
+        assert "%" in result.output
+
+    def test_coverage_empty_catalog(self, initialized_catalog, catalog_env):
+        """Empty catalog shows a graceful message."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "coverage"])
+        assert result.exit_code == 0
+        assert "No documents" in result.output
+
+    def test_coverage_with_owner_filter(self, initialized_catalog, catalog_env):
+        """--owner filters by tumbler prefix."""
+        runner = CliRunner()
+        runner.invoke(main, ["catalog", "register", "--title", "A", "--owner", "1.1", "--type", "code"])
+        runner.invoke(main, ["catalog", "register", "--title", "B", "--owner", "1.1", "--type", "paper"])
+        result = runner.invoke(main, ["catalog", "coverage", "--owner", "1.1"])
+        assert result.exit_code == 0
+        assert "%" in result.output
+
+    def test_suggest_links_no_candidates(self, initialized_catalog, catalog_env):
+        """When no code-RDR pairs match, report zero suggestions."""
+        runner = CliRunner()
+        runner.invoke(main, ["catalog", "register", "--title", "something", "--owner", "1.1", "--type", "code"])
+        result = runner.invoke(main, ["catalog", "suggest-links"])
+        assert result.exit_code == 0
+        assert "0" in result.output or "No suggestions" in result.output
+
+    def test_suggest_links_finds_unlinked_pair(self, initialized_catalog, catalog_env):
+        """Finds a code-RDR pair by module name overlap that has no existing link."""
+        runner = CliRunner()
+        # Register code entry with a file path so stem extraction works
+        cat = initialized_catalog
+        from nexus.catalog.tumbler import Tumbler
+        owner = Tumbler.parse("1.1")
+        cat.register(owner, "chunker module", content_type="code", file_path="src/nexus/chunker.py")
+        cat.register(owner, "RDR-027 chunker improvements", content_type="rdr", file_path="docs/rdr/rdr-027.md")
+        result = runner.invoke(main, ["catalog", "suggest-links"])
+        assert result.exit_code == 0
+        # Should find the chunker → RDR pair
+        assert "chunker" in result.output.lower()
+
+    def test_suggest_links_skips_already_linked(self, initialized_catalog, catalog_env):
+        """Already-linked pairs are not suggested again."""
+        runner = CliRunner()
+        cat = initialized_catalog
+        from nexus.catalog.tumbler import Tumbler
+        owner = Tumbler.parse("1.1")
+        code_t = cat.register(owner, "chunker module", content_type="code", file_path="src/nexus/chunker.py")
+        rdr_t = cat.register(owner, "RDR-027 chunker improvements", content_type="rdr", file_path="docs/rdr/rdr-027.md")
+        cat.link(code_t, rdr_t, "implements-heuristic", created_by="index_hook")
+        result = runner.invoke(main, ["catalog", "suggest-links"])
+        assert result.exit_code == 0
+        # The pair is already linked — should not appear
+        assert "chunker" not in result.output.lower() or "0" in result.output

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -381,3 +381,48 @@ class TestDiscoveryTools:
         assert result.exit_code == 0
         # The pair is already linked — should not appear
         assert "chunker" not in result.output.lower() or "0" in result.output
+
+
+class TestLinkGenerate:
+    """Tests for `nx catalog link-generate` command."""
+
+    def test_link_generate_dry_run(self, initialized_catalog, catalog_env):
+        """--dry-run outputs a message and exits cleanly without writing."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "link-generate", "--dry-run"])
+        assert result.exit_code == 0
+        assert "dry-run" in result.output.lower()
+
+    def test_link_generate_empty_catalog(self, initialized_catalog, catalog_env):
+        """Running on a catalog with no entries produces 0 links."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "link-generate"])
+        assert result.exit_code == 0
+        assert "0" in result.output
+
+    def test_link_generate_creates_heuristic_links(self, initialized_catalog, catalog_env):
+        """Command creates heuristic links for matching code-RDR pairs."""
+        runner = CliRunner()
+        cat = initialized_catalog
+        from nexus.catalog.tumbler import Tumbler
+        owner = Tumbler.parse("1.1")
+        cat.register(owner, "catalog module", content_type="code", file_path="src/nexus/catalog.py")
+        cat.register(owner, "RDR-001 catalog improvements", content_type="rdr", file_path="docs/rdr/rdr-001.md")
+        result = runner.invoke(main, ["catalog", "link-generate"])
+        assert result.exit_code == 0
+        # Output should show non-zero heuristic links
+        assert "1" in result.output
+
+    def test_link_generate_idempotent(self, initialized_catalog, catalog_env):
+        """Running twice produces 0 new links the second time."""
+        runner = CliRunner()
+        cat = initialized_catalog
+        from nexus.catalog.tumbler import Tumbler
+        owner = Tumbler.parse("1.1")
+        cat.register(owner, "catalog module", content_type="code", file_path="src/nexus/catalog.py")
+        cat.register(owner, "RDR-001 catalog improvements", content_type="rdr", file_path="docs/rdr/rdr-001.md")
+        runner.invoke(main, ["catalog", "link-generate"])
+        result = runner.invoke(main, ["catalog", "link-generate"])
+        assert result.exit_code == 0
+        # Second run should generate 0 new links
+        assert "0 heuristic + 0 filepath" in result.output

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -428,6 +428,73 @@ class TestLinkGenerate:
         assert "0 heuristic + 0 filepath" in result.output
 
 
+class TestAgentIntegration:
+    """Tests for agent-facing discovery commands: links-for-file, session-summary."""
+
+    def _make_catalog_with_links(self, catalog_env: object) -> "Catalog":
+        from nexus.catalog.catalog import Catalog
+        from nexus.catalog.tumbler import Tumbler
+
+        cat = Catalog.init(catalog_env)  # type: ignore[arg-type]
+        owner = cat.register_owner("test", "repo", repo_hash="abc")
+        t1 = cat.register(owner, "catalog.py", content_type="code", file_path="src/nexus/catalog.py")
+        t2 = cat.register(owner, "RDR-060", content_type="rdr", file_path="docs/rdr/rdr-060.md")
+        cat.link(t1, t2, "implements", created_by="test")
+        return cat
+
+    def test_links_for_file_found(self, catalog_env):
+        runner = CliRunner()
+        self._make_catalog_with_links(catalog_env)
+        result = runner.invoke(main, ["catalog", "links-for-file", "src/nexus/catalog.py"])
+        assert result.exit_code == 0
+        assert "RDR-060" in result.output
+        assert "implements" in result.output
+
+    def test_links_for_file_not_found(self, catalog_env):
+        runner = CliRunner()
+        self._make_catalog_with_links(catalog_env)
+        result = runner.invoke(main, ["catalog", "links-for-file", "nonexistent.py"])
+        assert result.exit_code == 0
+        assert "No catalog entry" in result.output
+
+    def test_links_for_file_shows_direction(self, catalog_env):
+        """Incoming and outgoing links are shown with arrow direction."""
+        runner = CliRunner()
+        cat = self._make_catalog_with_links(catalog_env)
+        # Also check from the RDR side (incoming link)
+        result = runner.invoke(main, ["catalog", "links-for-file", "docs/rdr/rdr-060.md"])
+        assert result.exit_code == 0
+        assert "implements" in result.output
+        # Arrow direction — incoming or outgoing arrow
+        assert ("→" in result.output or "←" in result.output)
+
+    def test_links_for_file_not_initialized(self, tmp_path, monkeypatch):
+        """Graceful failure when catalog not initialized."""
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "nocat"))
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "links-for-file", "some.py"])
+        # Should fail with catalog-not-initialized error, not crash
+        assert result.exit_code != 0 or "not initialized" in result.output.lower()
+
+    def test_session_summary_no_catalog(self, tmp_path, monkeypatch):
+        """Should not crash when catalog not initialized."""
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "nocat"))
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "session-summary"])
+        # Either exits cleanly (0) or with a non-zero code — must not raise
+        assert result.exit_code in (0, 1)
+
+    def test_session_summary_shows_link_count(self, catalog_env):
+        """session-summary should print link graph total at the end."""
+        runner = CliRunner()
+        self._make_catalog_with_links(catalog_env)
+        # Pass --since=99999 so we don't need git to have recent activity
+        result = runner.invoke(main, ["catalog", "session-summary", "--since", "99999"])
+        assert result.exit_code == 0
+        # Should show link graph total
+        assert "link" in result.output.lower()
+
+
 class TestGcCommand:
     """Tests for `nx catalog gc` — remove orphan entries with miss_count >= 2."""
 

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -426,3 +426,72 @@ class TestLinkGenerate:
         assert result.exit_code == 0
         # Second run should generate 0 new links
         assert "0 heuristic + 0 filepath" in result.output
+
+
+class TestGcCommand:
+    """Tests for `nx catalog gc` — remove orphan entries with miss_count >= 2."""
+
+    def _make_cat(self, catalog_env: object) -> "Catalog":
+        from nexus.catalog.catalog import Catalog
+        cat = Catalog.init(catalog_env)  # type: ignore[arg-type]
+        return cat
+
+    def test_gc_no_orphans(self, catalog_env):
+        runner = CliRunner()
+        cat = self._make_cat(catalog_env)
+        owner = cat.register_owner("repo", "repo", repo_hash="abc")
+        cat.register(owner, "current.py", content_type="code", file_path="src/current.py")
+        # miss_count is 0 by default — not an orphan
+        result = runner.invoke(main, ["catalog", "gc"])
+        assert result.exit_code == 0
+        assert "No orphan" in result.output
+
+    def test_gc_dry_run_does_not_delete(self, catalog_env):
+        runner = CliRunner()
+        cat = self._make_cat(catalog_env)
+        owner = cat.register_owner("repo", "repo", repo_hash="abc")
+        t = cat.register(owner, "old.py", content_type="code", file_path="src/old.py")
+        cat.update(t, meta={"miss_count": 2})
+        result = runner.invoke(main, ["catalog", "gc", "--dry-run"])
+        assert result.exit_code == 0
+        assert "[dry-run]" in result.output
+        # Entry still exists after dry run
+        assert cat.resolve(t) is not None
+
+    def test_gc_deletes_orphans(self, catalog_env):
+        runner = CliRunner()
+        cat = self._make_cat(catalog_env)
+        owner = cat.register_owner("repo", "repo", repo_hash="abc")
+        t = cat.register(owner, "old.py", content_type="code", file_path="src/old.py")
+        cat.update(t, meta={"miss_count": 2})
+        result = runner.invoke(main, ["catalog", "gc"])
+        assert result.exit_code == 0
+        assert "Deleted 1" in result.output
+        # Entry gone from catalog
+        assert cat.resolve(t) is None
+
+    def test_gc_skips_low_miss_count(self, catalog_env):
+        """Entries with miss_count < 2 must NOT be deleted."""
+        runner = CliRunner()
+        cat = self._make_cat(catalog_env)
+        owner = cat.register_owner("repo", "repo", repo_hash="abc")
+        t = cat.register(owner, "maybe.py", content_type="code", file_path="src/maybe.py")
+        cat.update(t, meta={"miss_count": 1})
+        result = runner.invoke(main, ["catalog", "gc"])
+        assert result.exit_code == 0
+        assert "No orphan" in result.output
+        assert cat.resolve(t) is not None
+
+    def test_gc_mixed_entries(self, catalog_env):
+        """Only entries with miss_count >= 2 are deleted; others survive."""
+        runner = CliRunner()
+        cat = self._make_cat(catalog_env)
+        owner = cat.register_owner("repo", "repo", repo_hash="abc")
+        t_keep = cat.register(owner, "keep.py", content_type="code", file_path="src/keep.py")
+        t_del = cat.register(owner, "del.py", content_type="code", file_path="src/del.py")
+        cat.update(t_del, meta={"miss_count": 3})
+        result = runner.invoke(main, ["catalog", "gc"])
+        assert result.exit_code == 0
+        assert "Deleted 1" in result.output
+        assert cat.resolve(t_keep) is not None
+        assert cat.resolve(t_del) is None

--- a/tests/test_catalog_db.py
+++ b/tests/test_catalog_db.py
@@ -17,6 +17,7 @@ def _make_owner(*, owner: str = "1.1", name: str = "test-repo", **kw) -> OwnerRe
         "owner_type": "repo",
         "repo_hash": "abcd1234",
         "description": "test repo",
+        "repo_root": "",
     }
     defaults.update(kw)
     return OwnerRecord(**defaults)

--- a/tests/test_catalog_indexer_hook.py
+++ b/tests/test_catalog_indexer_hook.py
@@ -257,3 +257,50 @@ class TestRunHousekeeping:
         entry = cat.resolve(t)
         assert entry is not None
         assert entry.meta.get("miss_count", 0) == 0
+
+    def test_rename_detected_by_content_hash(self, tmp_path, monkeypatch):
+        """File renamed: orphan with matching content_hash gets file_path updated, links preserved."""
+        from nexus.indexer import _run_housekeeping
+
+        catalog_dir, cat = self._make_cat(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("nexus", "repo", repo_hash="fff666")
+        owner_t = cat.owner_for_repo("fff666")
+        # Old entry at old path with a content hash
+        old_t = cat.register(owner_t, "old_name.py", content_type="code", file_path="src/old_name.py",
+                             meta={"content_hash": "deadbeef1234"})
+        # Create a link from old entry to another doc
+        other_t = cat.register(owner_t, "rdr-1", content_type="rdr", file_path="docs/rdr/rdr-1.md")
+        cat.link(old_t, other_t, "implements", created_by="test")
+
+        # New entry already registered at new path with same content hash
+        new_t = cat.register(owner_t, "new_name.py", content_type="code", file_path="src/new_name.py",
+                             meta={"content_hash": "deadbeef1234"})
+
+        # indexed_set has new path but not old
+        _run_housekeeping(cat, owner_t, indexed_set={"src/new_name.py", "docs/rdr/rdr-1.md"})
+
+        # Old entry should be deleted (rename transfers links, then deletes)
+        assert cat.resolve(old_t) is None
+        # Links should be transferred to the new entry
+        links = cat.links_from(new_t)
+        assert any(str(l.to_tumbler) == str(other_t) for l in links)
+
+    def test_rename_not_triggered_without_content_hash(self, tmp_path, monkeypatch):
+        """Orphan without content_hash follows normal miss_count path, not rename."""
+        from nexus.indexer import _run_housekeeping
+
+        catalog_dir, cat = self._make_cat(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("nexus", "repo", repo_hash="ggg777")
+        owner_t = cat.owner_for_repo("ggg777")
+        # No content_hash in meta
+        t = cat.register(owner_t, "no_hash.py", content_type="code", file_path="src/no_hash.py")
+
+        _run_housekeeping(cat, owner_t, indexed_set=set())
+
+        entry = cat.resolve(t)
+        assert entry is not None  # not renamed, just incremented
+        assert entry.meta.get("miss_count") == 1

--- a/tests/test_catalog_indexer_hook.py
+++ b/tests/test_catalog_indexer_hook.py
@@ -162,3 +162,98 @@ class TestCatalogHookErrorSafe:
             indexed_files=[(Path("/nonexistent/repo/file.py"), "code", "code__test")],
         )
         # Should not raise — errors are caught internally
+
+
+class TestRunHousekeeping:
+    """Tests for _run_housekeeping() — orphan detection with miss_count tracking."""
+
+    def _make_cat(self, tmp_path: Path) -> tuple[Path, "Catalog"]:
+        return _make_catalog(tmp_path)
+
+    def test_miss_count_incremented_for_missing_file(self, tmp_path, monkeypatch):
+        """Entry not in indexed_set → miss_count goes from 0 to 1, not deleted."""
+        from nexus.indexer import _run_housekeeping
+        from nexus.catalog.tumbler import Tumbler
+
+        catalog_dir, cat = self._make_cat(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("nexus", "repo", repo_hash="aaa111")
+        owner_t = cat.owner_for_repo("aaa111")
+        t = cat.register(owner_t, "missing.py", content_type="code", file_path="src/missing.py")
+
+        _run_housekeeping(cat, owner_t, indexed_set=set())
+
+        entry = cat.resolve(t)
+        assert entry is not None  # not deleted yet
+        assert entry.meta.get("miss_count") == 1
+
+    def test_miss_count_reset_when_file_seen(self, tmp_path, monkeypatch):
+        """Entry in indexed_set with miss_count=1 → reset to 0."""
+        from nexus.indexer import _run_housekeeping
+        from nexus.catalog.tumbler import Tumbler
+
+        catalog_dir, cat = self._make_cat(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("nexus", "repo", repo_hash="bbb222")
+        owner_t = cat.owner_for_repo("bbb222")
+        t = cat.register(owner_t, "present.py", content_type="code", file_path="src/present.py")
+        # Simulate a prior miss
+        cat.update(t, meta={"miss_count": 1})
+
+        _run_housekeeping(cat, owner_t, indexed_set={"src/present.py"})
+
+        entry = cat.resolve(t)
+        assert entry is not None
+        assert entry.meta.get("miss_count", 0) == 0
+
+    def test_orphan_deleted_at_threshold(self, tmp_path, monkeypatch):
+        """Entry with miss_count=1, not in indexed_set → increments to 2 → deleted."""
+        from nexus.indexer import _run_housekeeping
+
+        catalog_dir, cat = self._make_cat(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("nexus", "repo", repo_hash="ccc333")
+        owner_t = cat.owner_for_repo("ccc333")
+        t = cat.register(owner_t, "stale.py", content_type="code", file_path="src/stale.py")
+        cat.update(t, meta={"miss_count": 1})
+
+        _run_housekeeping(cat, owner_t, indexed_set=set())
+
+        # Should be deleted after reaching threshold of 2
+        assert cat.resolve(t) is None
+
+    def test_already_at_threshold_gets_deleted(self, tmp_path, monkeypatch):
+        """Entry with miss_count already >= 2 and not in indexed_set is deleted."""
+        from nexus.indexer import _run_housekeeping
+
+        catalog_dir, cat = self._make_cat(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("nexus", "repo", repo_hash="ddd444")
+        owner_t = cat.owner_for_repo("ddd444")
+        t = cat.register(owner_t, "dead.py", content_type="code", file_path="src/dead.py")
+        cat.update(t, meta={"miss_count": 2})
+
+        _run_housekeeping(cat, owner_t, indexed_set=set())
+
+        assert cat.resolve(t) is None
+
+    def test_present_files_not_affected(self, tmp_path, monkeypatch):
+        """Files in indexed_set are never modified (miss_count stays at 0 if already 0)."""
+        from nexus.indexer import _run_housekeeping
+
+        catalog_dir, cat = self._make_cat(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner("nexus", "repo", repo_hash="eee555")
+        owner_t = cat.owner_for_repo("eee555")
+        t = cat.register(owner_t, "ok.py", content_type="code", file_path="src/ok.py")
+
+        _run_housekeeping(cat, owner_t, indexed_set={"src/ok.py"})
+
+        entry = cat.resolve(t)
+        assert entry is not None
+        assert entry.meta.get("miss_count", 0) == 0

--- a/tests/test_catalog_path.py
+++ b/tests/test_catalog_path.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Tests for RDR-060 path rationalization: OwnerRecord.repo_root + DDL migration."""
+"""Tests for RDR-060 path rationalization: OwnerRecord.repo_root + DDL + resolve_path + relative paths."""
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from nexus.catalog.catalog import Catalog, make_relative
 from nexus.catalog.catalog_db import CatalogDB
-from nexus.catalog.tumbler import OwnerRecord, _filter_fields
+from nexus.catalog.tumbler import OwnerRecord, Tumbler, _filter_fields
 
 
 class TestOwnerRecordRepoRoot:
@@ -96,3 +100,180 @@ class TestCatalogDBMigration:
         row = db.execute("SELECT repo_root FROM owners WHERE tumbler_prefix = '1.1'").fetchone()
         assert row[0] == ""
         db.close()
+
+
+# ── resolve_path (nexus-1p4g.2) ──────────────────────────────────────────────
+
+
+class TestResolvePath:
+    """Catalog.resolve_path() resolution tests."""
+
+    def _make_catalog(self, tmp_path: Path) -> Catalog:
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        (cat_dir / "owners.jsonl").touch()
+        (cat_dir / "documents.jsonl").touch()
+        (cat_dir / "links.jsonl").touch()
+        return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+    def test_resolve_path_with_repo_root(self, tmp_path: Path) -> None:
+        cat = self._make_catalog(tmp_path)
+        repo_dir = tmp_path / "myrepo"
+        repo_dir.mkdir()
+        owner = cat.register_owner(
+            "test-repo", "repo", repo_hash="abc12345", repo_root=str(repo_dir),
+        )
+        tumbler = cat.register(
+            owner, "test.py", content_type="code", file_path="src/test.py",
+        )
+        result = cat.resolve_path(tumbler)
+        assert result == repo_dir / "src" / "test.py"
+
+    def test_resolve_path_curator_returns_none(self, tmp_path: Path) -> None:
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        tumbler = cat.register(
+            owner, "paper.pdf", content_type="paper", file_path="paper.pdf",
+        )
+        assert cat.resolve_path(tumbler) is None
+
+    def test_resolve_path_unknown_tumbler(self, tmp_path: Path) -> None:
+        cat = self._make_catalog(tmp_path)
+        assert cat.resolve_path(Tumbler.parse("1.99.99")) is None
+
+    def test_resolve_path_absolute_file_path(self, tmp_path: Path) -> None:
+        """Existing absolute file_path returned as-is."""
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test-repo", "repo", repo_hash="abc12345")
+        tumbler = cat.register(
+            owner, "test.py", content_type="code", file_path="/absolute/path/test.py",
+        )
+        assert cat.resolve_path(tumbler) == Path("/absolute/path/test.py")
+
+    def test_resolve_path_empty_repo_root_no_registry(self, tmp_path: Path) -> None:
+        """repo_root empty and no registry -> None."""
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test-repo", "repo", repo_hash="abc12345")
+        tumbler = cat.register(
+            owner, "test.py", content_type="code", file_path="src/test.py",
+        )
+        with patch(
+            "nexus.catalog.catalog._default_registry_path",
+            return_value=tmp_path / "nonexistent" / "repos.json",
+        ):
+            assert cat.resolve_path(tumbler) is None
+
+    def test_resolve_path_fallback_to_registry(self, tmp_path: Path) -> None:
+        """repo_root empty but registry has matching hash -> resolve via registry."""
+        repo_dir = tmp_path / "myrepo"
+        repo_dir.mkdir()
+        repo_hash = hashlib.sha256(str(repo_dir).encode()).hexdigest()[:8]
+
+        db_path = tmp_path / "db"
+        db_path.mkdir()
+        registry_data = {
+            "repos": {str(repo_dir): {"name": "myrepo", "collection": "code__myrepo"}},
+        }
+        (db_path / "repos.json").write_text(json.dumps(registry_data))
+
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test-repo", "repo", repo_hash=repo_hash)
+        tumbler = cat.register(
+            owner, "test.py", content_type="code", file_path="src/test.py",
+        )
+        with patch(
+            "nexus.catalog.catalog._default_registry_path",
+            return_value=db_path / "repos.json",
+        ):
+            assert cat.resolve_path(tumbler) == repo_dir / "src" / "test.py"
+
+
+# ── make_relative (nexus-1p4g.3) ─────────────────────────────────────────────
+
+
+class TestMakeRelative:
+    """make_relative() helper for path normalization."""
+
+    def test_relativizes_path_under_root(self, tmp_path: Path) -> None:
+        root = tmp_path / "repo"
+        assert make_relative(root / "src" / "foo.py", root) == "src/foo.py"
+
+    def test_returns_original_if_not_under_root(self, tmp_path: Path) -> None:
+        root = tmp_path / "repo"
+        other = tmp_path / "other" / "bar.py"
+        assert make_relative(other, root) == str(other)
+
+    def test_returns_original_string_for_relative_input(self) -> None:
+        assert make_relative("src/foo.py", Path("/repo")) == "src/foo.py"
+
+    def test_accepts_string_input(self, tmp_path: Path) -> None:
+        root = tmp_path / "repo"
+        assert make_relative(str(root / "src" / "foo.py"), root) == "src/foo.py"
+
+
+# ── _markdown_chunks relative source_path (nexus-1p4g.3) ─────────────────────
+
+
+class TestMarkdownChunksRelativePath:
+    """_markdown_chunks stores relative source_path when base_path given."""
+
+    def test_markdown_chunks_absolute_source_path_by_default(self, tmp_path: Path) -> None:
+        from nexus.doc_indexer import _markdown_chunks
+
+        md = tmp_path / "doc.md"
+        md.write_text("# Hello\n\nSome content here for chunking.")
+        result = _markdown_chunks(md, "abc123", "voyage-context-3", "2026-01-01", "corp")
+        assert result  # non-empty
+        assert result[0][2]["source_path"] == str(md)  # absolute
+
+    def test_markdown_chunks_relative_source_path_with_base(self, tmp_path: Path) -> None:
+        from nexus.doc_indexer import _markdown_chunks
+
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        md = repo / "docs" / "rdr" / "rdr-001.md"
+        md.parent.mkdir(parents=True)
+        md.write_text("# RDR-001\n\nSome research content for chunking.")
+        result = _markdown_chunks(md, "abc123", "voyage-context-3", "2026-01-01", "corp", base_path=repo)
+        assert result
+        assert result[0][2]["source_path"] == "docs/rdr/rdr-001.md"
+
+
+# ── _index_document source_key (nexus-1p4g.3) ───────────────────────────────
+
+
+class TestIndexDocumentSourceKey:
+    """_index_document uses source_key for staleness check and pruning."""
+
+    def test_staleness_check_uses_source_key(self, tmp_path: Path, monkeypatch) -> None:
+        """When source_key is provided, staleness check uses it instead of abs path."""
+        from unittest.mock import MagicMock, call
+
+        from tests.conftest import set_credentials
+        from nexus.doc_indexer import _index_document
+
+        set_credentials(monkeypatch)
+
+        md = tmp_path / "doc.md"
+        md.write_text("# Test\n\nContent for staleness check.")
+
+        mock_col = MagicMock()
+        # Simulate staleness hit — same hash and model
+        mock_col.get.return_value = {
+            "ids": ["existing"],
+            "metadatas": [{"content_hash": hashlib.sha256(md.read_bytes()).hexdigest(), "embedding_model": "voyage-context-3"}],
+        }
+        mock_t3 = MagicMock()
+        mock_t3.get_or_create_collection.return_value = mock_col
+
+        def dummy_chunk_fn(file_path, content_hash, target_model, now_iso, corpus):
+            return [("id1", "text", {"source_path": "relative/doc.md"})]
+
+        with patch("nexus.doc_indexer.make_t3", return_value=mock_t3):
+            result = _index_document(md, "corp", dummy_chunk_fn, t3=mock_t3, source_key="relative/doc.md")
+
+        # Staleness check should use source_key, not str(md)
+        staleness_call = mock_col.get.call_args
+        assert staleness_call.kwargs["where"] == {"source_path": "relative/doc.md"}
+        # Skipped (same hash) — returns 0
+        assert result == 0

--- a/tests/test_catalog_path.py
+++ b/tests/test_catalog_path.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for RDR-060 path rationalization: OwnerRecord.repo_root + DDL migration."""
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.tumbler import OwnerRecord, _filter_fields
+
+
+class TestOwnerRecordRepoRoot:
+    """OwnerRecord repo_root field basics."""
+
+    def test_default_repo_root_is_empty_string(self):
+        rec = OwnerRecord(owner="1.1", name="r", owner_type="repo", repo_hash="h", description="d")
+        assert rec.repo_root == ""
+
+    def test_explicit_repo_root(self):
+        rec = OwnerRecord(
+            owner="1.1", name="r", owner_type="repo", repo_hash="h",
+            description="d", repo_root="/home/user/repo",
+        )
+        assert rec.repo_root == "/home/user/repo"
+
+    def test_jsonl_roundtrip_with_repo_root(self):
+        rec = OwnerRecord(
+            owner="1.1", name="r", owner_type="repo", repo_hash="h",
+            description="d", repo_root="/tmp/repo",
+        )
+        serialized = json.dumps(rec.__dict__)
+        deserialized = json.loads(serialized)
+        rec2 = OwnerRecord(**_filter_fields(OwnerRecord, deserialized))
+        assert rec2.repo_root == "/tmp/repo"
+
+    def test_jsonl_backwards_compat_without_repo_root(self):
+        """Old JSONL entries without repo_root should deserialize with default ''."""
+        old_data = {"owner": "1.1", "name": "r", "owner_type": "repo", "repo_hash": "h", "description": "d"}
+        rec = OwnerRecord(**_filter_fields(OwnerRecord, old_data))
+        assert rec.repo_root == ""
+
+
+class TestCatalogDBMigration:
+    """DDL migration: existing DBs get repo_root column added."""
+
+    def test_new_db_has_repo_root_column(self, tmp_path):
+        db = CatalogDB(tmp_path / "catalog.db")
+        # Should be able to query repo_root without error
+        db.execute("SELECT repo_root FROM owners LIMIT 0")
+        db.close()
+
+    def test_migration_adds_repo_root_to_existing_db(self, tmp_path):
+        """Simulate an existing DB without repo_root, then open with new CatalogDB."""
+        db_path = tmp_path / "catalog.db"
+        # Create old-schema DB manually
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("""
+            CREATE TABLE owners (
+                tumbler_prefix TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                owner_type TEXT NOT NULL,
+                repo_hash TEXT,
+                description TEXT
+            )
+        """)
+        conn.execute("INSERT INTO owners VALUES ('1.1', 'old-repo', 'repo', 'hash1', 'desc')")
+        conn.commit()
+        conn.close()
+
+        # Open with new CatalogDB — should migrate
+        db = CatalogDB(db_path)
+        row = db.execute("SELECT repo_root FROM owners WHERE tumbler_prefix = '1.1'").fetchone()
+        assert row[0] == ""  # default empty string
+        db.close()
+
+    def test_rebuild_stores_repo_root(self, tmp_path):
+        db = CatalogDB(tmp_path / "catalog.db")
+        owner = OwnerRecord(
+            owner="1.1", name="test-repo", owner_type="repo",
+            repo_hash="abc", description="test", repo_root="/home/user/repo",
+        )
+        db.rebuild(owners={"1.1": owner}, documents={}, links=[])
+        row = db.execute("SELECT repo_root FROM owners WHERE tumbler_prefix = '1.1'").fetchone()
+        assert row[0] == "/home/user/repo"
+        db.close()
+
+    def test_rebuild_stores_empty_repo_root(self, tmp_path):
+        db = CatalogDB(tmp_path / "catalog.db")
+        owner = OwnerRecord(
+            owner="1.1", name="test-repo", owner_type="repo",
+            repo_hash="abc", description="test",
+        )
+        db.rebuild(owners={"1.1": owner}, documents={}, links=[])
+        row = db.execute("SELECT repo_root FROM owners WHERE tumbler_prefix = '1.1'").fetchone()
+        assert row[0] == ""
+        db.close()

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -314,3 +314,100 @@ def test_doctor_local_mode_shows_collection_count(runner, mock_reg, tmp_path):
     assert result.exit_code == 0
     assert "1 collections" in result.output
     assert "on disk" in result.output
+
+
+# ── doctor --fix-paths ─────────────────────────────────────────────────────
+
+
+class TestFixPaths:
+    """doctor --fix-paths migration tests."""
+
+    def _make_catalog_with_entries(self, tmp_path, entries):
+        """Create catalog with specified entries.
+
+        entries: list of (owner_type, repo_hash, repo_root, file_path, collection).
+        """
+        from nexus.catalog.catalog import Catalog
+
+        cat_dir = tmp_path / "catalog"
+        cat = Catalog.init(cat_dir)
+        for owner_type, repo_hash, repo_root, file_path, collection in entries:
+            owner = cat.register_owner(
+                f"test-{repo_hash or 'curator'}",
+                owner_type,
+                repo_hash=repo_hash,
+                repo_root=repo_root,
+            )
+            cat.register(
+                owner,
+                "test-doc",
+                content_type="code",
+                file_path=file_path,
+                physical_collection=collection,
+            )
+        return cat, cat_dir
+
+    def test_fix_paths_dry_run(self, tmp_path, runner):
+        cat, cat_dir = self._make_catalog_with_entries(tmp_path, [
+            ("repo", "abc12345", str(tmp_path / "repo"),
+             str(tmp_path / "repo" / "src" / "foo.py"), "code__test"),
+        ])
+        mock_t3 = MagicMock()
+        with (
+            patch("nexus.config.catalog_path", return_value=cat_dir),
+            patch("nexus.db.make_t3", return_value=mock_t3),
+        ):
+            result = runner.invoke(main, ["doctor", "--fix-paths", "--dry-run"])
+        assert result.exit_code == 0
+        assert "[dry-run]" in result.output
+        assert "src/foo.py" in result.output
+        # Verify nothing was actually changed
+        row = cat._db.execute("SELECT file_path FROM documents").fetchone()
+        assert row[0].startswith("/")  # still absolute
+
+    def test_fix_paths_writes_relative(self, tmp_path, runner):
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        cat, cat_dir = self._make_catalog_with_entries(tmp_path, [
+            ("repo", "abc12345", str(repo_dir),
+             str(repo_dir / "src" / "foo.py"), "code__test"),
+        ])
+        mock_t3 = MagicMock()
+        mock_t3.update_source_path.return_value = 5
+        with (
+            patch("nexus.config.catalog_path", return_value=cat_dir),
+            patch("nexus.db.make_t3", return_value=mock_t3),
+        ):
+            result = runner.invoke(main, ["doctor", "--fix-paths"])
+        assert result.exit_code == 0
+        assert "Fixed 1" in result.output
+        row = cat._db.execute("SELECT file_path FROM documents").fetchone()
+        assert row[0] == "src/foo.py"
+        mock_t3.update_source_path.assert_called_once()
+
+    def test_fix_paths_skips_curator(self, tmp_path, runner):
+        cat, cat_dir = self._make_catalog_with_entries(tmp_path, [
+            ("curator", "", "", "/abs/path/paper.pdf", "docs__papers"),
+        ])
+        mock_t3 = MagicMock()
+        with (
+            patch("nexus.config.catalog_path", return_value=cat_dir),
+            patch("nexus.db.make_t3", return_value=mock_t3),
+        ):
+            result = runner.invoke(main, ["doctor", "--fix-paths"])
+        assert result.exit_code == 0
+        mock_t3.update_source_path.assert_not_called()
+
+    def test_fix_paths_idempotent(self, tmp_path, runner):
+        cat, cat_dir = self._make_catalog_with_entries(tmp_path, [
+            ("repo", "abc12345", str(tmp_path / "repo"),
+             "src/foo.py", "code__test"),  # already relative
+        ])
+        mock_t3 = MagicMock()
+        with (
+            patch("nexus.config.catalog_path", return_value=cat_dir),
+            patch("nexus.db.make_t3", return_value=mock_t3),
+        ):
+            result = runner.invoke(main, ["doctor", "--fix-paths"])
+        assert result.exit_code == 0
+        assert "No absolute" in result.output

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -322,6 +322,13 @@ def test_doctor_local_mode_shows_collection_count(runner, mock_reg, tmp_path):
 class TestFixPaths:
     """doctor --fix-paths migration tests."""
 
+    @pytest.fixture(autouse=True)
+    def _git_identity(self, monkeypatch):
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
     def _make_catalog_with_entries(self, tmp_path, entries):
         """Create catalog with specified entries.
 

--- a/tests/test_link_generator.py
+++ b/tests/test_link_generator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from nexus.catalog.catalog import Catalog
-from nexus.catalog.link_generator import generate_rdr_filepath_links
+from nexus.catalog.link_generator import generate_code_rdr_links, generate_rdr_filepath_links
 
 
 class TestRdrFilepathLinks:
@@ -96,3 +96,152 @@ class TestRdrFilepathLinks:
         assert count1 == 1
         assert count2 == 0  # idempotent — no new links
         assert len(cat.links_from(rdr_tumbler)) == 1
+
+
+class TestIncrementalCodeRdrLinking:
+    """Incremental mode for generate_code_rdr_links via new_tumblers parameter."""
+
+    def _make_catalog(self, tmp_path: Path) -> Catalog:
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        (cat_dir / "owners.jsonl").touch()
+        (cat_dir / "documents.jsonl").touch()
+        (cat_dir / "links.jsonl").touch()
+        return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+    def test_empty_new_tumblers_returns_zero(self, tmp_path: Path) -> None:
+        """Passing new_tumblers=[] skips all work and returns 0."""
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc", repo_root=str(tmp_path))
+        cat.register(owner, "catalog.py", content_type="code", file_path="src/catalog.py")
+        cat.register(owner, "rdr-1", content_type="rdr", file_path="docs/rdr/rdr-1.md")
+        count = generate_code_rdr_links(cat, new_tumblers=[])
+        assert count == 0
+
+    def test_full_scan_when_new_tumblers_is_none(self, tmp_path: Path) -> None:
+        """new_tumblers=None uses existing full-scan behavior."""
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc", repo_root=str(tmp_path))
+        cat.register(owner, "catalog.py", content_type="code", file_path="src/catalog.py")
+        cat.register(owner, "rdr-catalog-001", content_type="rdr", file_path="docs/rdr/rdr-catalog-001.md")
+        # None = full scan (backward-compatible)
+        count = generate_code_rdr_links(cat, new_tumblers=None)
+        # "catalog" > 3 chars, matches "rdrcatalog001" normalized title
+        assert count == 1
+
+    def test_incremental_new_code_entry(self, tmp_path: Path) -> None:
+        """Only the new code tumbler is evaluated against existing RDRs."""
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc", repo_root=str(tmp_path))
+
+        # Pre-existing entries
+        old_code = cat.register(owner, "indexer.py", content_type="code", file_path="src/indexer.py")
+        rdr_t = cat.register(owner, "rdr-indexer-001", content_type="rdr", file_path="docs/rdr/rdr-indexer-001.md")
+
+        # Full scan to establish baseline links
+        count_full = generate_code_rdr_links(cat)
+        assert count_full >= 1  # indexer matches rdr-indexer-001
+
+        # Add a new code entry that matches the existing RDR
+        new_t = cat.register(owner, "chunker.py", content_type="code", file_path="src/chunker.py")
+
+        # Incremental — should only check new_t against all RDRs, not redo old_code
+        count_inc = generate_code_rdr_links(cat, new_tumblers=[new_t])
+        # "chunker" does not match "rdrindexer001" so count_inc == 0
+        assert count_inc == 0
+
+    def test_incremental_new_rdr_matches_existing_code(self, tmp_path: Path) -> None:
+        """A new RDR tumbler is checked against all existing code entries."""
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc", repo_root=str(tmp_path))
+
+        # Pre-existing code
+        code_t = cat.register(owner, "catalog.py", content_type="code", file_path="src/catalog.py")
+
+        # Add a new RDR that matches "catalog"
+        new_rdr = cat.register(owner, "rdr-catalog-001", content_type="rdr", file_path="docs/rdr/rdr-catalog-001.md")
+
+        count_inc = generate_code_rdr_links(cat, new_tumblers=[new_rdr])
+        assert count_inc == 1
+
+        # Verify the link points correctly
+        links = cat.links_from(code_t)
+        assert len(links) == 1
+        assert str(links[0].to_tumbler) == str(new_rdr)
+        assert links[0].link_type == "implements-heuristic"
+
+    def test_incremental_idempotent(self, tmp_path: Path) -> None:
+        """Running incremental twice with the same tumbler produces no duplicates."""
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc", repo_root=str(tmp_path))
+        code_t = cat.register(owner, "catalog.py", content_type="code", file_path="src/catalog.py")
+        new_rdr = cat.register(owner, "rdr-catalog-002", content_type="rdr", file_path="docs/rdr/rdr-catalog-002.md")
+
+        count1 = generate_code_rdr_links(cat, new_tumblers=[new_rdr])
+        count2 = generate_code_rdr_links(cat, new_tumblers=[new_rdr])
+        assert count1 == 1
+        assert count2 == 0  # idempotent
+
+
+class TestIncrementalRdrFilepathLinking:
+    """Incremental mode for generate_rdr_filepath_links via new_tumblers parameter."""
+
+    def _make_catalog(self, tmp_path: Path) -> Catalog:
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        (cat_dir / "owners.jsonl").touch()
+        (cat_dir / "documents.jsonl").touch()
+        (cat_dir / "links.jsonl").touch()
+        return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+    def _make_rdr_file(self, repo: Path, name: str, content: str) -> Path:
+        rdr_dir = repo / "docs" / "rdr"
+        rdr_dir.mkdir(parents=True, exist_ok=True)
+        f = rdr_dir / name
+        f.write_text(content)
+        return f
+
+    def test_empty_new_tumblers_returns_zero(self, tmp_path: Path) -> None:
+        """Passing new_tumblers=[] skips all work and returns 0."""
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        self._make_rdr_file(repo, "rdr-001.md", "# RDR\n\nSee src/catalog.py.\n")
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("myrepo", "repo", repo_hash="abc", repo_root=str(repo))
+        cat.register(owner, "RDR-001", content_type="rdr", file_path="docs/rdr/rdr-001.md")
+        cat.register(owner, "catalog.py", content_type="code", file_path="src/catalog.py")
+        count = generate_rdr_filepath_links(cat, new_tumblers=[])
+        assert count == 0
+
+    def test_full_scan_when_new_tumblers_is_none(self, tmp_path: Path) -> None:
+        """new_tumblers=None uses existing full-scan behavior."""
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        self._make_rdr_file(repo, "rdr-001.md", "# RDR\n\nSee src/catalog.py.\n")
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("myrepo", "repo", repo_hash="abc", repo_root=str(repo))
+        cat.register(owner, "RDR-001", content_type="rdr", file_path="docs/rdr/rdr-001.md")
+        cat.register(owner, "catalog.py", content_type="code", file_path="src/catalog.py")
+        count = generate_rdr_filepath_links(cat, new_tumblers=None)
+        assert count == 1
+
+    def test_incremental_only_scans_new_rdrs(self, tmp_path: Path) -> None:
+        """With new_tumblers, only listed RDR tumblers are scanned."""
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        self._make_rdr_file(repo, "rdr-001.md", "# RDR-001\n\nSee src/catalog.py.\n")
+        self._make_rdr_file(repo, "rdr-002.md", "# RDR-002\n\nNo file paths here.\n")
+
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("myrepo", "repo", repo_hash="abc", repo_root=str(repo))
+        rdr1 = cat.register(owner, "RDR-001", content_type="rdr", file_path="docs/rdr/rdr-001.md")
+        rdr2 = cat.register(owner, "RDR-002", content_type="rdr", file_path="docs/rdr/rdr-002.md")
+        cat.register(owner, "catalog.py", content_type="code", file_path="src/catalog.py")
+
+        # Only process rdr2 (which has no paths) — should not pick up rdr1's path
+        count = generate_rdr_filepath_links(cat, new_tumblers=[rdr2])
+        assert count == 0
+
+        # Process rdr1 explicitly — should create 1 link
+        count2 = generate_rdr_filepath_links(cat, new_tumblers=[rdr1])
+        assert count2 == 1

--- a/tests/test_link_generator.py
+++ b/tests/test_link_generator.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for link_generator.py — RDR filepath linking with resolve_path (RDR-060)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.link_generator import generate_rdr_filepath_links
+
+
+class TestRdrFilepathLinks:
+    """generate_rdr_filepath_links uses resolve_path for relative file_path."""
+
+    def _make_catalog(self, tmp_path: Path) -> Catalog:
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        (cat_dir / "owners.jsonl").touch()
+        (cat_dir / "documents.jsonl").touch()
+        (cat_dir / "links.jsonl").touch()
+        return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+    def test_filepath_linker_with_relative_paths(self, tmp_path: Path) -> None:
+        """RDR with relative file_path resolves via resolve_path and generates links."""
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+
+        # Create actual RDR file on disk (resolve_path must return an existing file)
+        rdr_dir = repo / "docs" / "rdr"
+        rdr_dir.mkdir(parents=True)
+        rdr_file = rdr_dir / "rdr-001.md"
+        rdr_file.write_text("# RDR-001\n\nThis affects `src/nexus/catalog.py` directly.\n")
+
+        cat = self._make_catalog(tmp_path)
+        # Register repo owner with repo_root
+        owner = cat.register_owner("myrepo", "repo", repo_hash="abc12345", repo_root=str(repo))
+
+        # Register RDR entry with RELATIVE file_path
+        rdr_tumbler = cat.register(
+            owner, "RDR-001", content_type="rdr",
+            file_path="docs/rdr/rdr-001.md",
+        )
+
+        # Register code entry with matching relative file_path
+        code_tumbler = cat.register(
+            owner, "catalog.py", content_type="code",
+            file_path="src/nexus/catalog.py",
+        )
+
+        count = generate_rdr_filepath_links(cat)
+        assert count == 1
+
+        # Verify the link was created
+        links = cat.links_from(rdr_tumbler)
+        assert len(links) == 1
+        assert str(links[0].to_tumbler) == str(code_tumbler)
+        assert links[0].link_type == "implements"
+
+    def test_filepath_linker_curator_skipped(self, tmp_path: Path) -> None:
+        """Curator RDR entries (resolve_path returns None) are skipped."""
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        cat.register(owner, "paper.pdf", content_type="rdr", file_path="paper.pdf")
+        count = generate_rdr_filepath_links(cat)
+        assert count == 0
+
+    def test_filepath_linker_file_not_on_disk(self, tmp_path: Path) -> None:
+        """resolve_path returns path but file doesn't exist on disk -- entry skipped."""
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("myrepo", "repo", repo_hash="abc12345", repo_root=str(repo))
+        # Register RDR with file_path that doesn't exist on disk
+        cat.register(owner, "RDR-999", content_type="rdr", file_path="docs/rdr/nonexistent.md")
+        count = generate_rdr_filepath_links(cat)
+        assert count == 0
+
+    def test_filepath_linker_idempotent(self, tmp_path: Path) -> None:
+        """Running the linker twice produces no duplicate links."""
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+
+        rdr_dir = repo / "docs" / "rdr"
+        rdr_dir.mkdir(parents=True)
+        rdr_file = rdr_dir / "rdr-001.md"
+        rdr_file.write_text("# RDR-001\n\nThis affects `src/nexus/catalog.py` directly.\n")
+
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("myrepo", "repo", repo_hash="abc12345", repo_root=str(repo))
+        rdr_tumbler = cat.register(owner, "RDR-001", content_type="rdr", file_path="docs/rdr/rdr-001.md")
+        cat.register(owner, "catalog.py", content_type="code", file_path="src/nexus/catalog.py")
+
+        count1 = generate_rdr_filepath_links(cat)
+        count2 = generate_rdr_filepath_links(cat)
+        assert count1 == 1
+        assert count2 == 0  # idempotent — no new links
+        assert len(cat.links_from(rdr_tumbler)) == 1

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -31,7 +31,7 @@ _STANDALONE_SKILLS = {
     "using-nx-skills", "writing-nx-skills",
     "rdr-list", "rdr-show", "rdr-create",
     "sequential-thinking",
-    "serena-code-nav",
+    "serena-code-nav", "catalog",
     "receiving-review", "git-worktrees", "finishing-branch",
 }
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -9,6 +9,7 @@ import pytest
 from nexus.scoring import (
     _file_size_factor,
     apply_hybrid_scoring,
+    apply_link_boost,
     apply_quality_boost,
     min_max_normalize,
     quality_score,
@@ -218,3 +219,95 @@ def test_format_json_no_metadata_shadow():
                      metadata={"id": "EVIL", "content": "EVIL"})
     parsed = _json.loads(format_json([r]))
     assert parsed[0]["id"] == "real" and parsed[0]["content"] == "real"
+
+
+# ── link boost (RDR-060 E3) ─────────────────────────────────────────────────
+
+class TestLinkBoost:
+    """apply_link_boost() scoring tests."""
+
+    def _make_catalog(self, tmp_path):
+        from nexus.catalog.catalog import Catalog
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        (cat_dir / "owners.jsonl").touch()
+        (cat_dir / "documents.jsonl").touch()
+        (cat_dir / "links.jsonl").touch()
+        return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+    def _make_result(self, source_path="src/foo.py", score=0.5, collection="code__test"):
+        return SearchResult(
+            id="r1", content="text", distance=0.3, collection=collection,
+            metadata={"source_path": source_path}, hybrid_score=score,
+        )
+
+    def test_implements_link_boosts_score(self, tmp_path):
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc12345", repo_root=str(tmp_path))
+        t1 = cat.register(owner, "foo.py", content_type="code", file_path="src/foo.py")
+        t2 = cat.register(owner, "bar.py", content_type="code", file_path="src/bar.py")
+        cat.link(t1, t2, "implements", created_by="test")
+
+        r = self._make_result(source_path="src/foo.py", score=0.5)
+        apply_link_boost([r], cat)
+        assert r.hybrid_score > 0.5  # boosted
+
+    def test_heuristic_link_no_boost(self, tmp_path):
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc12345", repo_root=str(tmp_path))
+        t1 = cat.register(owner, "foo.py", content_type="code", file_path="src/foo.py")
+        t2 = cat.register(owner, "bar.py", content_type="code", file_path="src/bar.py")
+        cat.link(t1, t2, "implements-heuristic", created_by="test")
+
+        r = self._make_result(source_path="src/foo.py", score=0.5)
+        apply_link_boost([r], cat)
+        assert r.hybrid_score == 0.5  # unchanged
+
+    def test_no_catalog_returns_unchanged(self):
+        r = self._make_result(score=0.5)
+        apply_link_boost([r], None)
+        assert r.hybrid_score == 0.5
+
+    def test_no_matching_entry_unchanged(self, tmp_path):
+        cat = self._make_catalog(tmp_path)
+        r = self._make_result(source_path="nonexistent.py", score=0.5)
+        apply_link_boost([r], cat)
+        assert r.hybrid_score == 0.5
+
+    def test_signal_capped_at_one(self, tmp_path):
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc12345", repo_root=str(tmp_path))
+        t1 = cat.register(owner, "foo.py", content_type="code", file_path="src/foo.py")
+        # Create 10 implements links
+        for i in range(10):
+            t_target = cat.register(owner, f"bar{i}.py", content_type="code", file_path=f"src/bar{i}.py")
+            cat.link(t1, t_target, "implements", created_by="test")
+
+        r = self._make_result(source_path="src/foo.py", score=0.5)
+        apply_link_boost([r], cat, boost_weight=0.15)
+        # signal capped at 1.0, so max boost is 0.15
+        assert r.hybrid_score == pytest.approx(0.65, abs=0.01)
+
+    def test_relates_link_half_boost(self, tmp_path):
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc12345", repo_root=str(tmp_path))
+        t1 = cat.register(owner, "foo.py", content_type="code", file_path="src/foo.py")
+        t2 = cat.register(owner, "bar.py", content_type="code", file_path="src/bar.py")
+        cat.link(t1, t2, "relates", created_by="test")
+
+        r = self._make_result(source_path="src/foo.py", score=0.5)
+        apply_link_boost([r], cat, boost_weight=0.15)
+        # relates = 0.5 weight, so boost = 0.15 * 0.5 = 0.075
+        assert r.hybrid_score == pytest.approx(0.575, abs=0.01)
+
+    def test_custom_type_weights(self, tmp_path):
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc12345", repo_root=str(tmp_path))
+        t1 = cat.register(owner, "foo.py", content_type="code", file_path="src/foo.py")
+        t2 = cat.register(owner, "bar.py", content_type="code", file_path="src/bar.py")
+        cat.link(t1, t2, "implements", created_by="test")
+
+        r = self._make_result(source_path="src/foo.py", score=0.5)
+        apply_link_boost([r], cat, boost_weight=0.2, type_weights={"implements": 0.5})
+        # 0.2 * 0.5 = 0.1
+        assert r.hybrid_score == pytest.approx(0.6, abs=0.01)

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -61,7 +61,7 @@ def _capture_ctx(collections: list[str] | None = None):
     mock = _mock_t3(collections)
     captured: list[dict | None] = []
 
-    def fake(query, cols, n_results, t3, where=None):
+    def fake(query, cols, n_results, t3, where=None, **kwargs):
         captured.append(where)
         return []
 

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -541,6 +541,86 @@ def test_delete_by_source_nonexistent_collection_returns_zero(mock_chromadb):
     assert db.delete_by_source("code__nonexistent", "src/file.py") == 0
 
 
+# ── update_source_path ─────────────────────────────────────────────────────
+
+
+def test_update_source_path_basic(mock_db):
+    db, mock_col, _ = mock_db
+    mock_col.get.return_value = {
+        "ids": ["c1", "c2"],
+        "metadatas": [
+            {"source_path": "/abs/path/f.py", "title": "f.py:1-5"},
+            {"source_path": "/abs/path/f.py", "title": "f.py:6-10"},
+        ],
+    }
+    result = db.update_source_path("code__myrepo", "/abs/path/f.py", "src/f.py")
+    assert result == 2
+    mock_col.update.assert_called_once()
+    call_kwargs = mock_col.update.call_args.kwargs
+    assert call_kwargs["ids"] == ["c1", "c2"]
+    assert call_kwargs["metadatas"][0]["source_path"] == "src/f.py"
+    assert call_kwargs["metadatas"][0]["title"] == "f.py:1-5"  # preserved
+    assert call_kwargs["metadatas"][1]["source_path"] == "src/f.py"
+
+
+def test_update_source_path_empty_result(mock_db):
+    db, mock_col, _ = mock_db
+    mock_col.get.return_value = {"ids": [], "metadatas": []}
+    result = db.update_source_path("code__myrepo", "/nonexistent", "relative/f.py")
+    assert result == 0
+    mock_col.update.assert_not_called()
+
+
+def test_update_source_path_missing_collection(mock_chromadb):
+    _, mock_client = mock_chromadb
+    mock_client.get_collection.side_effect = chromadb.errors.NotFoundError("not found")
+    db = T3Database(tenant="t", database="d", api_key="k")
+    assert db.update_source_path("code__nonexistent", "/old", "new") == 0
+
+
+def test_update_source_path_preserves_other_metadata(mock_db):
+    db, mock_col, _ = mock_db
+    mock_col.get.return_value = {
+        "ids": ["c1"],
+        "metadatas": [{
+            "source_path": "/abs/file.py",
+            "title": "file.py:1-10",
+            "tags": "python",
+            "category": "code",
+            "frecency_score": 0.5,
+            "start_line": 1,
+            "end_line": 10,
+        }],
+    }
+    db.update_source_path("code__myrepo", "/abs/file.py", "src/file.py")
+    meta = mock_col.update.call_args.kwargs["metadatas"][0]
+    assert meta["source_path"] == "src/file.py"
+    assert meta["title"] == "file.py:1-10"
+    assert meta["tags"] == "python"
+    assert meta["frecency_score"] == 0.5
+    assert meta["start_line"] == 1
+
+
+def test_update_source_path_pagination(mock_db):
+    """Verify pagination works for >300 chunks."""
+    db, mock_col, _ = mock_db
+    # First page: 300 results (full page)
+    page1_ids = [f"c{i}" for i in range(300)]
+    page1_metas = [{"source_path": "/old/f.py"} for _ in range(300)]
+    # Second page: 5 results (short page = last)
+    page2_ids = [f"c{i}" for i in range(300, 305)]
+    page2_metas = [{"source_path": "/old/f.py"} for _ in range(5)]
+
+    mock_col.get.side_effect = [
+        {"ids": page1_ids, "metadatas": page1_metas},
+        {"ids": page2_ids, "metadatas": page2_metas},
+    ]
+    result = db.update_source_path("code__myrepo", "/old/f.py", "src/f.py")
+    assert result == 305
+    # Should be called twice (two batches of ≤300)
+    assert mock_col.update.call_count == 2
+
+
 # ── collection_metadata ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- **E1 Path rationalization**: Store relative paths in catalog `file_path` and T3 `source_path`. `resolve_path()` reconstructs absolute paths via `owner.repo_root` or registry fallback. `doctor --fix-paths` migrates existing data. Filepath linker uses `resolve_path()`.
- **E3 Link-aware search boost**: `apply_link_boost()` in scoring.py — `implements` links boost search results, heuristic links get zero boost. On by default for `query` MCP, off for CLI.
- **E4 Discovery tools**: `nx catalog orphans`, `coverage`, `suggest-links` commands for link graph observability.
- **E5 Incremental linkers**: `generate_code_rdr_links` and `generate_rdr_filepath_links` accept `new_tumblers` for O(new_n × m) incremental mode. `nx catalog link-generate` for batch scans.
- **E7 Catalog housekeeping**: `_run_housekeeping()` tracks `miss_count` in entry metadata, deletes orphans after 2 missed index runs. `nx catalog gc` CLI.

## Beads closed

nexus-1p4g.1 through nexus-1p4g.15 (14 of 17 epic beads). E6 (agent integration) deferred — depends on E3+E4.

## Test plan

- [ ] `uv run pytest tests/test_catalog_path.py tests/test_scoring.py tests/test_link_generator.py tests/test_catalog_cli.py tests/test_catalog_indexer_hook.py tests/test_t3.py tests/test_doctor_cmd.py -x -q` — all RDR-060 tests
- [ ] `uv run pytest tests/ --ignore=tests/test_integration.py --ignore=tests/e2e -x -q` — full unit suite
- [ ] `nx doctor --fix-paths --dry-run` on real catalog
- [ ] `nx catalog coverage` on real catalog
- [ ] `nx catalog orphans --no-links` on real catalog