### PR TITLE
fix: clean up stale empty lock files from crashed background indexers

### DIFF
--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -187,29 +187,50 @@ def _repo_lock_path(repo: Path) -> Path:
     return Path.home() / ".config" / "nexus" / "locks" / f"{path_hash}.lock"
 
 
+_LOCK_STALE_SECONDS = 5  # lock files older than this with no live PID are stale
+
+
 def _clear_stale_lock(lock_path: Path) -> None:
-    """Delete *lock_path* if it contains a dead PID.
+    """Delete *lock_path* if it is stale (dead PID or old empty file).
 
-    Only removes a lock file when we can confirm the recorded PID is dead
-    (``ESRCH`` from ``os.kill(pid, 0)``).  Files with no parseable PID are
-    left alone — they may belong to an active process that hasn't written
-    its PID yet.
+    A lock file is stale when:
+    - It contains a PID that no longer exists (ESRCH), OR
+    - It has no parseable PID and is older than ``_LOCK_STALE_SECONDS``.
 
-    This is advisory only — ``fcntl.flock`` provides the real mutual exclusion.
+    The second case handles background processes (disown/&) that were killed
+    before writing their PID, leaving empty 0-byte lock files forever.
+
+    This is advisory cleanup — ``fcntl.flock`` provides the real mutual
+    exclusion.
     """
     if not lock_path.exists():
         return
     try:
         pid = int(lock_path.read_text().strip())
     except (ValueError, OSError):
-        # No readable PID — could be a just-opened lock. Leave it;
-        # flock will handle contention.
+        # No readable PID — check file age.  A just-opened lock will be
+        # younger than _LOCK_STALE_SECONDS; an orphan from a crashed
+        # process will be much older.
+        try:
+            age = time.time() - lock_path.stat().st_mtime
+        except OSError:
+            return
+        if age > _LOCK_STALE_SECONDS:
+            _remove_stale(lock_path)
         return
     try:
         os.kill(pid, 0)
     except OSError as exc:
         if exc.errno == errno.ESRCH:
             _remove_stale(lock_path)
+
+
+def _sweep_stale_locks(lock_dir: Path) -> None:
+    """Remove all stale lock files in *lock_dir*."""
+    if not lock_dir.is_dir():
+        return
+    for lock_file in lock_dir.glob("*.lock"):
+        _clear_stale_lock(lock_file)
 
 
 def _remove_stale(lock_path: Path) -> None:
@@ -434,6 +455,7 @@ def index_repository(
     if not frecency_only:
         lock_path = _repo_lock_path(repo)
         lock_path.parent.mkdir(parents=True, exist_ok=True)
+        _sweep_stale_locks(lock_path.parent)
         _clear_stale_lock(lock_path)
         lock_fd = open(lock_path, "w")  # noqa: SIM115  (must stay open while locked)
         try:

--- a/tests/test_index_lock.py
+++ b/tests/test_index_lock.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """T1: index_repository per-repo file lock, on_locked flag, and head_hash update."""
 import fcntl
+import os
 import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -37,6 +39,82 @@ def lock_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Redirect HOME so lock files land in tmp_path."""
     monkeypatch.setenv("HOME", str(tmp_path))
     return tmp_path
+
+
+# ── stale lock cleanup ────────────────────────────────────────────────────────
+
+
+def test_clear_stale_lock_removes_empty_old_file(tmp_path: Path) -> None:
+    """Empty lock files older than _LOCK_STALE_SECONDS are removed."""
+    from nexus.indexer import _clear_stale_lock, _LOCK_STALE_SECONDS
+
+    lock = tmp_path / "stale.lock"
+    lock.touch()
+    # Backdate the file so it's clearly stale
+    import os
+    old_time = time.time() - _LOCK_STALE_SECONDS - 1
+    os.utime(lock, (old_time, old_time))
+
+    _clear_stale_lock(lock)
+    assert not lock.exists()
+
+
+def test_clear_stale_lock_keeps_fresh_empty_file(tmp_path: Path) -> None:
+    """Empty lock files younger than _LOCK_STALE_SECONDS are left alone."""
+    from nexus.indexer import _clear_stale_lock
+
+    lock = tmp_path / "fresh.lock"
+    lock.touch()  # just created — mtime is now
+
+    _clear_stale_lock(lock)
+    assert lock.exists()
+
+
+def test_clear_stale_lock_removes_dead_pid(tmp_path: Path) -> None:
+    """Lock files containing a dead PID are removed."""
+    from nexus.indexer import _clear_stale_lock
+
+    lock = tmp_path / "dead.lock"
+    lock.write_text("999999999")  # PID that almost certainly doesn't exist
+
+    _clear_stale_lock(lock)
+    assert not lock.exists()
+
+
+def test_clear_stale_lock_keeps_live_pid(tmp_path: Path) -> None:
+    """Lock files containing the current (live) PID are kept."""
+    from nexus.indexer import _clear_stale_lock
+
+    lock = tmp_path / "live.lock"
+    lock.write_text(str(os.getpid()))
+
+    _clear_stale_lock(lock)
+    assert lock.exists()
+
+
+def test_sweep_stale_locks_cleans_directory(tmp_path: Path) -> None:
+    """_sweep_stale_locks removes all stale files from a directory."""
+    from nexus.indexer import _sweep_stale_locks, _LOCK_STALE_SECONDS
+
+    locks_dir = tmp_path / "locks"
+    locks_dir.mkdir()
+
+    # Create 3 stale empty lock files
+    old_time = time.time() - _LOCK_STALE_SECONDS - 1
+    for name in ["aaa.lock", "bbb.lock", "ccc.lock"]:
+        f = locks_dir / name
+        f.touch()
+        os.utime(f, (old_time, old_time))
+
+    # Create 1 fresh file that should survive
+    fresh = locks_dir / "fresh.lock"
+    fresh.touch()
+
+    _sweep_stale_locks(locks_dir)
+
+    remaining = list(locks_dir.glob("*.lock"))
+    assert len(remaining) == 1
+    assert remaining[0].name == "fresh.lock"
 
 
 # ── lock path helper ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `_clear_stale_lock()` now uses age-based detection for empty lock files (>5s with no PID = stale)
- New `_sweep_stale_locks()` cleans the entire locks directory on each index run
- Fixes accumulation of 0-byte orphan lock files from `disown`ed git hook indexers that crash before writing their PID

## Context
Git hooks run `nx index repo ... &; disown` in the background. When these processes are killed before writing their PID to the lock file, `_clear_stale_lock()` would skip the empty file ("could be a just-opened lock"). Over time, 59 stale lock files accumulated in `~/.config/nexus/locks/`. While `fcntl.flock` handles real mutual exclusion regardless, the stale files obscure diagnostics.

## Test plan
- [x] 5 new tests for age-based stale detection and directory sweep
- [x] All 20 lock tests pass (15 existing + 5 new)
- [x] Manually verified: cleared 59 stale locks from production