### PR TITLE
v3.8.1: fix 4 shakeout findings from v3.8.0 live exercise

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -169,3 +169,4 @@
 {"id":"int-657bb391","kind":"field_change","created_at":"2026-04-10T19:02:29.725219Z","actor":"Hellblazer","issue_id":"nexus-s8o5","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-c86217ee","kind":"field_change","created_at":"2026-04-10T19:31:07.518563Z","actor":"Hellblazer","issue_id":"nexus-s8o5","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Phase 2 review complete; all recommendations remediated"}}
 {"id":"int-a8639365","kind":"field_change","created_at":"2026-04-10T19:45:09.264889Z","actor":"Hellblazer","issue_id":"nexus-4y8d","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"RDR-063 implemented and closed; all 13 children complete, post-mortem written"}}
+{"id":"int-b4c6fd47","kind":"field_change","created_at":"2026-04-10T21:43:31.166781Z","actor":"Hellblazer","issue_id":"nexus-6kzp","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -112,7 +112,7 @@ than agent convenience.
 | `nx collection verify` | Full-collection scan; expensive and rarely needed by agents |
 | `nx catalog unlink` | Destructive edge removal |
 | `nx catalog link-audit` | Full-graph scan; expensive and human-oriented |
-| `nx catalog link-bulk` | Bulk link creation; high blast radius if misused |
+| `nx catalog link-bulk-delete` (hidden) | Bulk link deletion by filter; high blast radius if misused |
 
 The underlying Python functions still exist under the same names inside
 `src/nexus/mcp/core.py` and `src/nexus/mcp/catalog.py` — they're just no

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -512,7 +512,8 @@ def link_cmd(
 
     Both FROM and TO accept tumblers (1.1.5) or titles. Built-in link types:
     cites, implements, implements-heuristic, supersedes, relates, quotes,
-    comments. Custom types are also accepted. Duplicate links are merged.
+    comments, formalizes. Custom types are also accepted. Duplicate links
+    are merged.
 
     \b
     Spans (optional) identify the specific passage being referenced:

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -24,6 +24,87 @@ _T = TypeVar("_T")
 
 _COLLECTION = "scratch"
 
+# Common English stopwords — shared with MemoryStore._STOPWORDS for
+# consistency across the two overlap-detection helpers.
+_PROMOTE_STOPWORDS = frozenset(
+    {
+        "the", "a", "an", "in", "of", "for", "to", "and", "or", "is", "are", "was",
+        "it", "that", "this", "with", "on", "at", "by", "from", "as", "be", "not",
+    }
+)
+
+# Jaccard threshold for promote() overlap confirmation. Matches the
+# default used by MemoryStore.find_overlapping_memories (RDR-061 E6) but
+# is slightly more permissive (0.5 vs 0.7) because the promote path
+# flags advisorily — the row is still written — while consolidation
+# uses the higher bar for destructive merges.
+_PROMOTE_OVERLAP_JACCARD = 0.5
+
+
+def _promote_content_words(text: str) -> set[str]:
+    """Return the set of non-stopword content tokens (length > 2) in *text*.
+
+    Lowercased for case-insensitive comparison. Shared between the FTS5
+    candidate query builder and the Jaccard confirmation step.
+    """
+    return {
+        w.lower() for w in text.split()
+        if len(w) > 2 and w.lower() not in _PROMOTE_STOPWORDS
+    }
+
+
+def _find_promote_overlap_candidates(
+    content: str,
+    project: str,
+    t2: T2Database,
+) -> list[dict]:
+    """Return existing T2 entries under *project* that overlap with *content*.
+
+    Two-phase match mirroring ``MemoryStore.find_overlapping_memories``:
+
+    1. Pull the first 3 content tokens (non-stopword, length > 2) and use
+       them as the FTS5 MATCH query for candidate retrieval. Keeping the
+       query small is critical: FTS5 defaults to implicit AND, so using
+       the full content would require every token to appear in the
+       candidate (making detection impossible for similar-but-not-identical
+       content).
+    2. Compute Jaccard similarity on the full non-stopword word sets and
+       keep only candidates at or above ``_PROMOTE_OVERLAP_JACCARD``.
+
+    Returns an empty list when no candidates exceed the threshold, or
+    when the content has fewer than 3 usable tokens.
+    """
+    words = [
+        w for w in content.split()
+        if len(w) > 2 and w.lower() not in _PROMOTE_STOPWORDS
+    ]
+    if len(words) < 3:
+        # Not enough content to compute a meaningful similarity — trust
+        # the caller's intent and report no overlap. Very short scratch
+        # entries (< 3 non-stopword tokens) don't benefit from overlap
+        # detection anyway.
+        return []
+    snippet = " ".join(words[:3])
+    try:
+        candidates = t2.memory.search(snippet, project=project, access="silent")
+    except ValueError:
+        return []
+    if not candidates:
+        return []
+    w_new = _promote_content_words(content)
+    if not w_new:
+        return []
+    hits: list[tuple[float, dict]] = []
+    for cand in candidates:
+        w_cand = _promote_content_words(cand.get("content", ""))
+        if not w_cand:
+            continue
+        jaccard = len(w_new & w_cand) / len(w_new | w_cand)
+        if jaccard >= _PROMOTE_OVERLAP_JACCARD:
+            hits.append((jaccard, cand))
+    hits.sort(key=lambda x: -x[0])
+    return [cand for _, cand in hits]
+
 
 class T1Database:
     """T1 ChromaDB session scratch — shared across all agents in a session tree.
@@ -318,7 +399,23 @@ class T1Database:
     # ── Promote ───────────────────────────────────────────────────────────────
 
     def promote(self, id: str, project: str, title: str, t2: T2Database) -> "PromotionReport":
-        """Copy T1 entry *id* to T2 immediately. Returns a PromotionReport."""
+        """Copy T1 entry *id* to T2 immediately. Returns a PromotionReport.
+
+        Overlap detection (RDR-057): pulls the first few non-stopword content
+        tokens from the scratch entry and FTS5-searches T2 for any existing
+        entry under the same project that matches them. If candidates come
+        back, confirms with Jaccard similarity (≥ 0.5) on the non-stopword
+        word sets before reporting ``overlap_detected``.
+
+        Why not MATCH the full snippet: FTS5 MATCH uses implicit AND, so a
+        full-content query requires every token in the new entry to also
+        appear in the existing entry. By construction, similar-but-not-
+        identical content always has at least one new token, making the
+        full-snippet approach unable to detect the common case (v3.8.0
+        shakeout finding). Using a small token prefix for candidate
+        retrieval plus Jaccard for precision matches the pattern already
+        used by ``find_overlapping_memories`` (memory_store.py).
+        """
         from nexus.types import PromotionReport
 
         # Fetch without incrementing access_count (promote is a write-path, not a read)
@@ -326,12 +423,8 @@ class T1Database:
         if not result["ids"]:
             raise KeyError(f"No scratch entry: {id!r}")
         entry = self._to_row(result["ids"][0], result["documents"][0], result["metadatas"][0])
-        # FTS5 overlap detection: first ~100 chars as search query
-        snippet = entry["content"][:100]
-        try:
-            matches = t2.search(snippet, project=project)
-        except ValueError:
-            matches = []
+
+        matches = _find_promote_overlap_candidates(entry["content"], project, t2)
         if matches:
             best = matches[0]
             # merged=False: T2.put() writes the new entry as a separate row.

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -199,7 +199,36 @@ class T2Database:
         title: str | None = None,
         id: int | None = None,
     ) -> bool:
-        return self.memory.delete(project=project, title=title, id=id)
+        """Delete a memory entry and cascade cleanup taxonomy assignments.
+
+        v3.8.1: cross-domain cascade (memory → taxonomy). When a memory
+        row is deleted, any ``topic_assignments`` rows referencing it
+        by (project, title) are also removed and any topics left empty
+        by the deletion are dropped. See
+        ``CatalogTaxonomy.purge_assignments_for_doc`` for the
+        scoped-by-collection semantics.
+
+        The cascade is the facade's job because it crosses a domain
+        boundary — ``MemoryStore`` does not know about taxonomy tables
+        and should not. When the delete is by numeric id, we resolve
+        the row's project and title first so the cascade can scope
+        correctly.
+        """
+        # Resolve (project, title) for cascade scoping. Cheap indexed
+        # lookup via the memory connection directly to avoid the
+        # access_count side-effect of ``memory.get(id=...)`` on a row
+        # we're about to delete. Only executes when the caller used --id.
+        if id is not None and (project is None or title is None):
+            with self.memory._lock:
+                row = self.memory.conn.execute(
+                    "SELECT project, title FROM memory WHERE id = ?", (id,)
+                ).fetchone()
+            if row is not None:
+                project, title = row[0], row[1]
+        deleted = self.memory.delete(project=project, title=title, id=id)
+        if deleted and project and title:
+            self.taxonomy.purge_assignments_for_doc(project=project, title=title)
+        return deleted
 
     def find_overlapping_memories(
         self,

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -438,6 +438,63 @@ class CatalogTaxonomy:
 
         return count
 
+    def purge_assignments_for_doc(self, project: str, title: str) -> int:
+        """Remove topic_assignments for a deleted memory entry, empty topics.
+
+        Called by ``T2Database.delete()`` after a successful memory row
+        deletion to prevent orphan ``topic_assignments`` rows (v3.8.0
+        shakeout finding). The ``topic_assignments.doc_id`` column
+        references ``memory.title`` by value, not by SQL foreign key, so
+        deleting a memory row by itself leaves dangling assignments that
+        show up in ``nx taxonomy list`` and ``nx taxonomy show`` as
+        ghost entries.
+
+        This method is idempotent and scoped: it only affects topics in
+        the given ``project`` (taxonomy's ``collection`` column) to
+        avoid accidentally touching unrelated taxonomies that might
+        reference the same title under a different project.
+
+        Two-step operation under ``self._lock``:
+
+        1. DELETE matching ``topic_assignments`` rows (``doc_id = title``
+           AND parent topic's ``collection = project``).
+        2. DELETE any topics in that collection whose ``doc_count``
+           implicit count has dropped to zero — i.e. topics that now
+           have no remaining assignments.
+
+        Returns the number of ``topic_assignments`` rows removed. The
+        count of cleaned-up topics is not returned because it is
+        derivable by the caller if needed and the common case is
+        "either 0 or exactly 1 assignment removed".
+        """
+        with self._lock:
+            cursor = self.conn.execute(
+                """
+                DELETE FROM topic_assignments
+                WHERE doc_id = ?
+                  AND topic_id IN (
+                      SELECT id FROM topics WHERE collection = ?
+                  )
+                """,
+                (title, project),
+            )
+            removed = cursor.rowcount
+            # Drop topics in this collection that no longer have any
+            # assignments. Scoped by collection so we don't disturb
+            # siblings from other projects.
+            self.conn.execute(
+                """
+                DELETE FROM topics
+                WHERE collection = ?
+                  AND id NOT IN (
+                      SELECT DISTINCT topic_id FROM topic_assignments
+                  )
+                """,
+                (project,),
+            )
+            self.conn.commit()
+        return removed
+
     def rebuild_taxonomy(
         self,
         project: str,

--- a/tests/test_scratch.py
+++ b/tests/test_scratch.py
@@ -142,6 +142,88 @@ def test_promote_writes_to_t2_regardless_of_action(t1: T1Database, db: T2Databas
     assert r["content"] == "overlap content here"
 
 
+def test_promote_overlap_detected_on_superset_content(t1: T1Database, db: T2Database) -> None:
+    """Regression (v3.8.0 shakeout): superset content triggers overlap_detected.
+
+    Pre-v3.8.1, ``T1.promote()`` used the scratch entry's full first-100-char
+    snippet as an FTS5 MATCH query. FTS5 MATCH is implicit-AND, so any
+    scratch content with even one token not present in the existing T2
+    entry would return zero matches and falsely report ``action=new``.
+
+    The fix uses only the first 3 non-stopword tokens for candidate
+    retrieval and then confirms with Jaccard similarity on the full
+    word sets. This test pins the superset case that was the v3.8.0
+    shakeout failure: scratch content contains all of the existing T2
+    entry's words plus one extra.
+    """
+    db.put(
+        project="proj",
+        title="base.md",
+        content="alpha beta gamma delta epsilon zeta eta theta iota kappa lambda",
+    )
+    doc_id = t1.put(
+        "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda EXTRA"
+    )
+    report = t1.promote(doc_id, project="proj", title="superset.md", t2=db)
+    assert report.action == "overlap_detected", (
+        f"superset content should fire overlap_detected, got {report.action}"
+    )
+    assert report.existing_title == "base.md"
+    assert report.merged is False
+
+
+def test_promote_returns_new_when_jaccard_below_threshold(
+    t1: T1Database, db: T2Database,
+) -> None:
+    """Short subset content reports new, not overlap_detected.
+
+    Three non-stopword tokens against an 11-token base entry gives a
+    Jaccard of 3/11 ≈ 0.27 which is below the 0.5 promote threshold.
+    The content is "similar" by containment but semantically distinct
+    — a 3-word summary vs an 11-word paragraph — so ``new`` is the
+    honest answer.
+    """
+    db.put(
+        project="proj",
+        title="paragraph.md",
+        content="alpha beta gamma delta epsilon zeta eta theta iota kappa lambda",
+    )
+    doc_id = t1.put("alpha beta gamma")
+    report = t1.promote(doc_id, project="proj", title="short.md", t2=db)
+    assert report.action == "new", (
+        f"3-of-11 subset is below Jaccard 0.5 threshold, should be new, got {report.action}"
+    )
+
+
+def test_promote_returns_new_when_content_too_short(
+    t1: T1Database, db: T2Database,
+) -> None:
+    """Scratch content with fewer than 3 non-stopword tokens always returns new.
+
+    Very short entries (one or two words) don't benefit from overlap
+    detection — there's not enough signal to compute a meaningful
+    Jaccard or a sensible FTS5 query. Return ``new`` without a search.
+    """
+    db.put(project="proj", title="existing.md", content="some existing content")
+    doc_id = t1.put("hi")  # 1 token, below the 3-token minimum
+    report = t1.promote(doc_id, project="proj", title="tiny.md", t2=db)
+    assert report.action == "new"
+
+
+def test_promote_overlap_ignores_unrelated_content(
+    t1: T1Database, db: T2Database,
+) -> None:
+    """Completely unrelated content under the same project reports new."""
+    db.put(
+        project="proj",
+        title="auth.md",
+        content="authentication design patterns using JWT with refresh rotation",
+    )
+    doc_id = t1.put("completely unrelated kubernetes scheduling topology constraints")
+    report = t1.promote(doc_id, project="proj", title="k8s.md", t2=db)
+    assert report.action == "new"
+
+
 # ── AC6: clear ────────────────────────────────────────────────────────────────
 
 def test_scratch_clear_removes_all(t1: T1Database) -> None:

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -264,6 +264,149 @@ def test_get_topic_docs_known_defect_project_collection_mismatch(db: T2Database)
     )
 
 
+# ── Cascade on memory delete (v3.8.1) ─────────────────────────────────────
+
+
+def test_memory_delete_cascades_topic_assignments(db: T2Database) -> None:
+    """Deleting a memory entry removes its topic_assignments (v3.8.1 fix).
+
+    Regression pin: pre-v3.8.1, ``nx memory delete`` left dangling
+    ``topic_assignments`` rows whose ``doc_id`` referenced the deleted
+    entry. Those orphans surfaced in ``nx taxonomy list`` / ``nx
+    taxonomy show`` as ghost entries. The fix adds a cascade in the
+    facade ``T2Database.delete()`` that calls
+    ``CatalogTaxonomy.purge_assignments_for_doc()``.
+    """
+    # Seed memory entries for a project
+    db.put(project="proj", title="doc-a", content="alpha content here")
+    db.put(project="proj", title="doc-b", content="beta content here")
+
+    # Seed a topic with both entries assigned
+    db.taxonomy.conn.execute(
+        "INSERT INTO topics (label, collection, doc_count, created_at) VALUES (?, ?, ?, ?)",
+        ("test-topic", "proj", 2, "2026-01-01T00:00:00Z"),
+    )
+    topic_id = db.taxonomy.conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    db.taxonomy.conn.executemany(
+        "INSERT INTO topic_assignments (doc_id, topic_id) VALUES (?, ?)",
+        [("doc-a", topic_id), ("doc-b", topic_id)],
+    )
+    db.taxonomy.conn.commit()
+
+    # Sanity: both assignments present
+    pre = db.taxonomy.conn.execute(
+        "SELECT COUNT(*) FROM topic_assignments WHERE topic_id = ?", (topic_id,)
+    ).fetchone()[0]
+    assert pre == 2
+
+    # Delete doc-a via the facade — should cascade-purge its assignment
+    assert db.delete(project="proj", title="doc-a") is True
+
+    post = db.taxonomy.conn.execute(
+        "SELECT doc_id FROM topic_assignments WHERE topic_id = ? ORDER BY doc_id",
+        (topic_id,),
+    ).fetchall()
+    assert [r[0] for r in post] == ["doc-b"], (
+        "cascade should have removed doc-a's assignment but kept doc-b's"
+    )
+
+    # Topic still exists because doc-b still references it
+    topics_remaining = db.taxonomy.conn.execute(
+        "SELECT COUNT(*) FROM topics WHERE collection = 'proj'"
+    ).fetchone()[0]
+    assert topics_remaining == 1
+
+
+def test_memory_delete_drops_empty_topics(db: T2Database) -> None:
+    """Deleting the last memory entry in a topic also drops the topic."""
+    db.put(project="proj", title="solo-doc", content="lonely content")
+    db.taxonomy.conn.execute(
+        "INSERT INTO topics (label, collection, doc_count, created_at) VALUES (?, ?, ?, ?)",
+        ("solo-topic", "proj", 1, "2026-01-01T00:00:00Z"),
+    )
+    topic_id = db.taxonomy.conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    db.taxonomy.conn.execute(
+        "INSERT INTO topic_assignments (doc_id, topic_id) VALUES (?, ?)",
+        ("solo-doc", topic_id),
+    )
+    db.taxonomy.conn.commit()
+
+    assert db.delete(project="proj", title="solo-doc") is True
+
+    # Assignment gone
+    ta_count = db.taxonomy.conn.execute(
+        "SELECT COUNT(*) FROM topic_assignments WHERE topic_id = ?", (topic_id,)
+    ).fetchone()[0]
+    assert ta_count == 0
+
+    # Topic also gone (empty after the cascade)
+    topic_count = db.taxonomy.conn.execute(
+        "SELECT COUNT(*) FROM topics WHERE id = ?", (topic_id,)
+    ).fetchone()[0]
+    assert topic_count == 0
+
+
+def test_memory_delete_cascade_scoped_to_project(db: T2Database) -> None:
+    """Cascade only touches topics in the deleted entry's project.
+
+    If two projects happen to have a memory entry with the same title,
+    deleting one must not cascade-remove the other's topic assignment.
+    """
+    # Same title under two projects
+    db.put(project="proj-a", title="shared-title", content="content under proj-a")
+    db.put(project="proj-b", title="shared-title", content="content under proj-b")
+
+    # Two topics, one per project, both assigning the shared title
+    db.taxonomy.conn.executemany(
+        "INSERT INTO topics (label, collection, doc_count, created_at) VALUES (?, ?, ?, ?)",
+        [
+            ("topic-a", "proj-a", 1, "2026-01-01T00:00:00Z"),
+            ("topic-b", "proj-b", 1, "2026-01-01T00:00:00Z"),
+        ],
+    )
+    topic_a_id, topic_b_id = [
+        r[0] for r in db.taxonomy.conn.execute(
+            "SELECT id FROM topics ORDER BY id DESC LIMIT 2"
+        ).fetchall()
+    ][::-1]
+    db.taxonomy.conn.executemany(
+        "INSERT INTO topic_assignments (doc_id, topic_id) VALUES (?, ?)",
+        [("shared-title", topic_a_id), ("shared-title", topic_b_id)],
+    )
+    db.taxonomy.conn.commit()
+
+    # Delete only the proj-a entry
+    assert db.delete(project="proj-a", title="shared-title") is True
+
+    # topic-a's assignment removed, topic-b's assignment untouched
+    remaining = db.taxonomy.conn.execute(
+        "SELECT topic_id FROM topic_assignments WHERE doc_id = 'shared-title'"
+    ).fetchall()
+    assert [r[0] for r in remaining] == [topic_b_id]
+
+
+def test_memory_delete_by_id_cascades(db: T2Database) -> None:
+    """Facade resolves project/title from --id before cascading."""
+    row_id = db.put(project="proj", title="by-id", content="delete via numeric id")
+    db.taxonomy.conn.execute(
+        "INSERT INTO topics (label, collection, doc_count, created_at) VALUES (?, ?, ?, ?)",
+        ("id-topic", "proj", 1, "2026-01-01T00:00:00Z"),
+    )
+    topic_id = db.taxonomy.conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    db.taxonomy.conn.execute(
+        "INSERT INTO topic_assignments (doc_id, topic_id) VALUES (?, ?)",
+        ("by-id", topic_id),
+    )
+    db.taxonomy.conn.commit()
+
+    assert db.delete(id=row_id) is True
+
+    ta_count = db.taxonomy.conn.execute(
+        "SELECT COUNT(*) FROM topic_assignments"
+    ).fetchone()[0]
+    assert ta_count == 0
+
+
 def test_cli_taxonomy_list(db: T2Database) -> None:
     """CLI taxonomy list outputs topic labels."""
     from click.testing import CliRunner


### PR DESCRIPTION
## Summary

Live shakeout of v3.8.0 on darwin arm64 exercised each user-visible feature from RDRs 057/061/062/063 and found four real bugs. All fixed for 3.8.1 as a bug-fix-only patch release.

## Fixes

### 1. RDR-057 `overlap_detected` logic bug (the big one)

`T1.promote()` used the scratch entry's full first-100-char snippet as an FTS5 MATCH query. FTS5 MATCH is implicit-AND, so any scratch entry with even one new token against the candidate returned zero matches — and by construction a similar-but-not-identical entry always has at least one new token. Result: `action=overlap_detected` was effectively unreachable for the intended use case.

**Fix**: rewrote the overlap detection in `src/nexus/db/t1.py` using the same two-phase pattern as `MemoryStore.find_overlapping_memories`:
1. Pull the first 3 non-stopword tokens from the scratch content and use them as the FTS5 MATCH query (small query → AND tolerable, good recall)
2. Compute Jaccard similarity on the full non-stopword word sets and keep candidates ≥ 0.5 (advisory threshold, more permissive than consolidation's 0.7 because promote is non-destructive)

Four regression tests in `tests/test_scratch.py` pin the v3.8.0 shakeout case plus related edges.

### 2. `nx catalog link-bulk` doc drift

`docs/mcp-servers.md` listed `nx catalog link-bulk` as a demoted CLI-only tool. The actual command is `nx catalog link-bulk-delete` (hidden, bulk DELETE by filter). Updated the docs.

### 3. `formalizes` missing from link help text

`nx catalog link --help` didn't list `formalizes` among the built-in link types, though the creation path accepts it. One-line docstring fix.

### 4. `nx memory delete` taxonomy cascade

`nx memory delete` left dangling `topic_assignments` rows pointing to deleted memory entries. Orphan topics showed up as ghost entries in `nx taxonomy list`.

**Fix**: cross-domain coordination in the `T2Database` facade. Added `CatalogTaxonomy.purge_assignments_for_doc(project, title)` that deletes matching assignments (scoped by collection) and drops any topics that become empty. The facade's `delete()` calls it after a successful memory row delete; when `--id` is used, the facade resolves `(project, title)` via a direct SELECT on `memory.conn` before the delete so the cascade can scope correctly (avoids the access-count side effect of `memory.get(id=...)` on a dying row).

Four regression tests in `tests/test_taxonomy.py` cover the cascade, empty-topic cleanup, cross-project scoping, and delete-by-id.

## Test plan

- [x] tests/test_scratch.py: 51 passing (+4 new)
- [x] tests/test_taxonomy.py: 18 passing (+4 new)
- [x] Focused T2 suite (8 files): 238 passing
- [x] Full non-integration suite: **3466 passed (+8 from baseline)**, 14 skipped
- [x] Integration suite: 20 passing (one flake on first run cleared on retry — ChromaDB Cloud eventual-consistency on sequential put-then-search; not a regression, same test passed in v3.8.0 release earlier today)
- [ ] CI (pytest 3.12 + 3.13) — pending PR checks