### PR TITLE
docs(contributing): note beads CLI minimum version 1.0.0

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -42,6 +42,7 @@ export-state/
 
 # Dolt database (managed by Dolt remotes, not git)
 dolt/
+embeddeddolt/
 dolt-access.lock
 
 # NOTE: Do NOT add negation patterns (e.g., !issues.jsonl) here.

--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -183,3 +183,4 @@
 {"id":"int-62f8f94a","kind":"field_change","created_at":"2026-04-11T11:46:19.266179Z","actor":"Hellblazer","issue_id":"nexus-lets.8","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 {"id":"int-a53b2126","kind":"field_change","created_at":"2026-04-11T11:47:32.80178Z","actor":"Hellblazer","issue_id":"nexus-lets.9","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-e17257f9","kind":"field_change","created_at":"2026-04-11T12:02:47.778791Z","actor":"Hellblazer","issue_id":"nexus-lets.10","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-7c2d7d1a","kind":"field_change","created_at":"2026-04-11T12:13:36.574732Z","actor":"Hellblazer","issue_id":"nexus-ker","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -130,7 +130,7 @@ Do not bump these without testing the full chunking pipeline.
 
 - Branch naming: `feature/<bead-id>-<short-description>`
 - Never push directly to `main` — all changes via PR (exception: version-bump release commits, see Release Process below)
-- Use `bd` (beads) for task tracking
+- Use `bd` (beads, **≥ 1.0.0** — `brew install beads` or `brew upgrade beads`) for task tracking. Earlier 0.x versions reject the comma-separated `--status` flag the close-skill preamble uses; the bead advisory will silently report no open beads on stale installs.
 - **Code review**: Plans include review tasks after implementation phases. Use `/nx:review-code` or dispatch `code-review-expert` at the designated plan steps
 
 The `main` branch requires CI to pass before merging. Configure branch protection at


### PR DESCRIPTION
## Summary

- Add minimum-version note (`bd ≥ 1.0.0`) to `docs/contributing.md` next to the existing `bd` reference
- One-line change; no code touched

## Why

Surfaced during the RDR-065 close (PR #141): `bd 0.62.0` rejects the comma-separated `--status=open,in_progress` flag that `nx/commands/rdr-close.md`'s bead-advisory subprocess uses. The advisory silently reports "no open beads" on stale installs because the subprocess errors out and the preamble treats empty stdout as the empty case. `bd 1.0.0` accepts the syntax, so no code change to `rdr-close.md` is needed — just the tool upgrade.

This PR documents the requirement so a fresh contributor doesn't re-discover it.

## Test plan

- [x] `bd list --status=open,in_progress --limit=20` succeeds on bd 1.0.0 (verified on this machine)
- [x] No code changes — markdown only
- [x] bead nexus-ker created and closed against this branch