### PR TITLE
docs(rdr-066): research cycle — CA-3 verified, CA-2 spiked (easy case)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -184,3 +184,4 @@
 {"id":"int-a53b2126","kind":"field_change","created_at":"2026-04-11T11:47:32.80178Z","actor":"Hellblazer","issue_id":"nexus-lets.9","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-e17257f9","kind":"field_change","created_at":"2026-04-11T12:02:47.778791Z","actor":"Hellblazer","issue_id":"nexus-lets.10","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-7c2d7d1a","kind":"field_change","created_at":"2026-04-11T12:13:36.574732Z","actor":"Hellblazer","issue_id":"nexus-ker","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-126869a0","kind":"field_change","created_at":"2026-04-11T12:29:55.004881Z","actor":"Hellblazer","issue_id":"nexus-kxt","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/docs/rdr/rdr-066-enrichment-time-contract-preflight.md
+++ b/docs/rdr/rdr-066-enrichment-time-contract-preflight.md
@@ -13,9 +13,17 @@ related_issues: ["RDR-065"]
 
 # RDR-066: Enrichment-Time Contract Pre-Flight
 
-> Stub. Do not start until RDR-065 has shipped and produced at least one
-> close-time funnel measurement. This RDR has explicit dependencies on
-> RDR-065's findings about which failures actually slip through.
+> **Draft, awaiting trigger event.** RDR-065 shipped 2026-04-11. This RDR
+> is now gated on CA-1's **trigger** rather than a time-based wait: it
+> moves from `draft` to `in-progress` on the first observed composition
+> failure where close-time gates caught the problem but at ≥2 beads of
+> sunk-cost penalty. See CA-1 below for the exact condition.
+>
+> **CA-3** (can "coordinator bead" be expressed without modifying bd
+> schema) and **CA-2** (can plan-enricher produce dimensional contracts
+> without runtime symbol resolution) are already verified — see
+> Research Findings. Phase 1 design work can start immediately once
+> the CA-1 trigger fires.
 
 ## Problem Statement
 
@@ -90,37 +98,63 @@ documented failure mode. The three siblings split by lifecycle stage:
   workaround gating, beginning as a research RDR mining ART incidents
   for a regex bank. Stub.
 
-### Why deferred
+### Why deferred (revised 2026-04-11)
 
-Two reasons. First, RDR-065 must ship and produce a baseline measurement
-of which failures actually pass through the close-time funnel. Without
-that measurement, RDR-066's interventions are speculative — we don't
-know whether enrichment-time fixes will catch failures the close-time
-funnel already caught for free. Second, the "coordinator bead" concept
-is a structural change to how plans relate to beads, and that change
-deserves its own design pass once we understand what RDR-065 has and
-hasn't fixed.
+**Original rationale** (from stub): wait for RDR-065 baseline data
+before building enrichment-time interventions. This framing was broken
+in two ways:
 
-### Drift condition
+1. **The baseline doesn't exist.** Nothing in RDR-065 accumulates "N
+   close-time catches that would have been cheaper at enrichment time"
+   metrics. That instrumentation is RDR-067's job — which is also a
+   stub. Waiting for baseline data was waiting for a signal no code
+   generates.
+2. **Detection ≠ prevention.** Even if RDR-065's close-time gates
+   catch composition failures 100% of the time, they catch them
+   AFTER ≥2 beads of wasted work. Enrichment-time gates catch the
+   same failures BEFORE any work is done. These are sequential
+   filters, not substitutes. A close-time catch doesn't make an
+   enrichment-time catch redundant — it just means the failure was
+   expensive to detect.
 
-**If RDR-066 has not moved from `draft` to a state where Phase 1
-investigation has started within 120 days of RDR-065 closing as
-`implemented`, reopen RDR-065 and re-evaluate whether the enrichment-
-time scope should be folded back into RDR-065 or explicitly
-abandoned.** 120 days gives RDR-065 time to produce meaningful
-baseline data. If the data shows the close-time funnel is catching
-the failure mode effectively, RDR-066 may become lower priority or
-be abandoned — which is fine, as long as the decision is made
-explicitly and not by drift.
+**Revised rationale**: this RDR's value is gated on encountering the
+failure mode in real work with meaningful sunk-cost penalty. See CA-1
+below for the exact trigger. If no qualifying event occurs within
+120 days, the RDR is explicitly ABANDONED or reclassified as
+research-only — not left drifting as an open draft.
+
+### Drift condition (revised 2026-04-11)
+
+**Trigger-based, not time-based.** This RDR moves from `draft` to
+`in-progress` on the first CA-1 trigger event (see Critical
+Assumptions). If 120 days from RDR-065 closing (i.e., by 2026-08-09)
+pass without a CA-1 trigger, take one of these explicit actions —
+don't let the RDR sit:
+
+1. **Abandon**: close as `reverted` with reason "failure mode did not
+   manifest with expected frequency".
+2. **Reclassify**: convert `type: process` → `type: research`; leave
+   open as a permanent document about the enrichment-time failure
+   mode without building the interventions.
+3. **Fold**: merge surviving scope (e.g., the contracts template
+   from CA-2's spike) into a broader RDR and close this one as
+   `superseded`.
+
+The decision must be made explicitly with a one-paragraph rationale
+in the Revision History. Passive drift is disallowed.
 
 ### Technical Environment
 
 - **`nx:enrich-plan`** (`nx/skills/enrich-plan/SKILL.md`): the skill
   that produces enriched plans from sketches
 - **plan-enricher agent**: the agent the skill dispatches
-- **bead metadata**: managed by external `bd` tool; we cannot add fields
-  directly. May need a wrapper convention or a "coordinator" tag in the
-  description text that the probe skill greps for
+- **bead metadata**: bd 1.0.0 has first-class `--metadata` JSON
+  (verified via CA-3 — see Research Finding 1). We can set
+  `metadata.coordinator=true` and query via `bd show --json` or
+  `bd list --json | jq '.[] | select(.metadata.coordinator == true)'`.
+  **No wrapper convention needed.** bd also natively has
+  `--waits-for-gate all-children` (default) which is literally the
+  coordinator "wait until all children complete" semantic.
 - **No existing composition-probe machinery**: would need to design from
   scratch, drawing on RDR-068's regex bank for failure detection
 
@@ -214,10 +248,21 @@ contracts stored in metadata. Address in Phase 1 design review.
 
 ### Critical Assumptions
 
-- [ ] **CA-1**: RDR-065's close-time funnel does NOT catch the
-  enrichment-stage failures that ART RC-1 and RC-2 describe. If it does,
-  this RDR may be unnecessary.
-  — **Status**: Unverified — **Method**: Wait for RDR-065 baseline data
+- [ ] **CA-1** (reframed 2026-04-11): At least one composition failure
+  matching ART RC-1 or RC-2 pattern is observed during real nexus
+  development **where close-time gates caught it but at ≥2 beads of
+  sunk-cost penalty**. Such an observation confirms the prevention vs.
+  detection gap that justifies enrichment-time interventions.
+  — **Status**: Unverified — no qualifying event observed yet
+  — **Method**: **Trigger-based.** The RDR moves from `draft` to
+  `in-progress` on the first qualifying observation. If no trigger
+  fires within 120 days (by 2026-08-09), apply the drift condition —
+  abandon, reclassify as research, or fold into another RDR.
+  — **Why the old framing was wrong**: the original CA-1 said "wait
+  for RDR-065 baseline data." No code generates such a baseline (that
+  would be RDR-067's job, also a stub). And even a 100% close-time
+  catch rate doesn't make this RDR unnecessary — it just makes the
+  failures expensive to detect. Detection ≠ prevention.
 - [x] **CA-2**: The plan-enricher agent can produce dimensional contracts
   given a structured template prompt without requiring runtime symbol
   resolution. If contracts must be verified by Serena/JetBrains lookup
@@ -286,3 +331,19 @@ contracts stored in metadata. Address in Phase 1 design review.
 ## Revision History
 
 - 2026-04-10 — Stub created as deferred sibling to RDR-065.
+- 2026-04-11 — CA-3 verified (bd 1.0.0 first-class `--metadata`).
+  T2: `nexus_rdr/066-research-1-ca3-verified`.
+- 2026-04-11 — CA-2 spike verified for the easy case (plan-enricher
+  can produce grounded contracts from `Read` alone for self-contained
+  functions with plain types). Phase 1 must retry on a hard case.
+  T2: `nexus_rdr/066-research-2-ca2-spike-verified`.
+- 2026-04-11 — **CA-1 reframed from wait-based to trigger-based.**
+  The old "wait for RDR-065 baseline data" condition was broken: no
+  code in RDR-065 or elsewhere accumulates the baseline it waited
+  for, and the detection-vs-prevention logic was a category error
+  (RDR-065 catches failures AFTER ≥2 beads of sunk work; RDR-066
+  would prevent them BEFORE any work — these are sequential filters,
+  not substitutes). New CA-1 trips on the first observed composition
+  failure with ≥2 beads of sunk-cost penalty. Drift condition
+  rewritten: 120-day window → explicit abandon/reclassify/fold
+  decision. Passive drift disallowed.

--- a/docs/rdr/rdr-066-enrichment-time-contract-preflight.md
+++ b/docs/rdr/rdr-066-enrichment-time-contract-preflight.md
@@ -126,11 +126,45 @@ explicitly and not by drift.
 
 ## Research Findings
 
-[Pending — do not start research until RDR-065 has shipped.]
-
 ### Investigation
 
-[Pending.]
+#### Finding 1 (2026-04-11): bd 1.0.0 has native first-class custom metadata
+
+**Source Search** against `bd create --help` and live JSON roundtrip
+verification on bd 1.0.0 (Homebrew). T2: `nexus_rdr/066-research-1-ca3-verified`.
+
+The stub assumed "we cannot modify beads internals" and scoped Gap 2
+around a tag/naming convention. That assumption is wrong in a good way:
+
+- **`--metadata string`** — bd accepts arbitrary JSON (`--metadata
+  '{"coordinator":true,...}'` or `@file.json`). Stored at top-level
+  `metadata` in `bd show --json` output, no key collisions with bd's
+  own fields. Roundtrips losslessly.
+- **`--waits-for-gate all-children`** — bd natively has a "wait until
+  all child beads complete" gate (the default). This is literally the
+  coordinator-bead semantic Gap 2 sketches.
+- **`--design`, `--context`, `--acceptance`, `--notes`, `--spec-id`,
+  `--external-ref`** — structured fields that can host per-bead
+  contracts without abusing `--description`.
+
+**Design implications** for when Phase 1 of this RDR begins:
+
+- **Gap 2** (coordinator bead concept) — no hack needed. Set
+  `metadata.coordinator=true` on coordinator beads; keep
+  `--waits-for-gate all-children` (default); probe trigger is
+  `bd list --json | jq '.[] | select(.metadata.coordinator == true)'`.
+- **Gap 1** (dimensional contracts) — contracts can live in
+  `--design` / `--context` / `metadata.contracts` rather than jammed
+  into free-form `--description`. This preserves description as
+  narrative and contracts as structured data.
+- **Gap 3** (`nx:composition-probe` skill) — still build from scratch,
+  but its trigger mechanism is now trivial (single `bd list --json`
+  query against the metadata key).
+
+**Risk noted**: bd's `metadata` is freeform JSON with no schema
+enforcement. A downstream tool relying on `metadata.coordinator`
+has no guarantee the key exists or is a bool. Same risk applies to
+contracts stored in metadata. Address in Phase 1 design review.
 
 ### Critical Assumptions
 
@@ -143,10 +177,14 @@ explicitly and not by drift.
   resolution. If contracts must be verified by Serena/JetBrains lookup
   at enrichment time, the cost may be prohibitive.
   — **Status**: Unverified — **Method**: Spike
-- [ ] **CA-3**: A "coordinator bead" concept can be expressed as a tag
+- [x] **CA-3**: A "coordinator bead" concept can be expressed as a tag
   or naming convention without modifying the `bd` schema. (We cannot
   modify beads internals.)
-  — **Status**: Unverified — **Method**: Source Search
+  — **Status**: **VERIFIED (2026-04-11)** — stronger than assumed: bd 1.0.0
+  has first-class `--metadata` JSON support plus native `--waits-for-gate
+  all-children` coordinator semantic. No tag/convention hack needed.
+  — **Method**: Source Search (bd CLI help + live JSON roundtrip) —
+  see Finding 1 above. T2: `nexus_rdr/066-research-1-ca3-verified`
 
 ## Proposed Solution
 

--- a/docs/rdr/rdr-066-enrichment-time-contract-preflight.md
+++ b/docs/rdr/rdr-066-enrichment-time-contract-preflight.md
@@ -128,6 +128,52 @@ explicitly and not by drift.
 
 ### Investigation
 
+#### Finding 2 (2026-04-11): plan-enricher can produce grounded contracts from Read alone (easy case)
+
+**Spike** against a Sonnet-class subagent simulating plan-enricher.
+T2: `nexus_rdr/066-research-2-ca2-spike-verified`.
+
+Target: `src/nexus/frecency.py:compute_frecency` (132-line self-
+contained module). Contracts template: 11 fields including signature,
+inputs, output, preconditions, postconditions, side effects, error
+modes, calls-out-to, tools-used-to-ground, hallucination-self-check.
+
+**Result**: the agent produced a fully grounded contract in ONE
+`Read()` call on the full file. Every field carried `file:line`
+citations. No Serena / JetBrains symbol lookup was needed — the LLM
+parsed the Python signature and docstring directly. HIGH self-
+confidence on all fields except "propagating exceptions" (inferred
+from absence-of-handler, correctly self-flagged).
+
+**Hardest field**: distinguishing caught from propagating exceptions.
+Inference-from-absence is weaker than assertion-from-handler.
+
+**Template refinements surfaced by the spike**:
+
+1. Split "Error modes" into sub-bullets **caught** / **propagates**.
+2. Add a "Default values resolved" line to inline constants rather
+   than leaving them symbolic (`_DEFAULT_DECAY_RATE` → `0.01`).
+3. Keep the "Tools used" + "Hallucination self-check" fields — they
+   made the result auditable.
+
+**Scope of the verification (honest)**:
+
+- **Verified**: single self-contained function, plain types, same-
+  file helpers only, no generics, no third-party types.
+- **NOT verified** (Phase 1 concerns):
+  - Functions with cross-file symbol chains (Read alone may need many
+    reads)
+  - Generic / Protocol / TypeVar types where the declaration lives
+    elsewhere
+  - Third-party library types (may need docs lookup)
+  - Coherence scaling: can the agent hold state for ~20 contracts in
+    one enrichment pass?
+
+**Phase 1 design note**: retry the spike on a **hard case** (cross-
+file generic or protocol consumer) before committing to "no Serena
+ever". The Read-to-Serena boundary is the real question, and this
+spike only proves Read suffices on the easy side of it.
+
 #### Finding 1 (2026-04-11): bd 1.0.0 has native first-class custom metadata
 
 **Source Search** against `bd create --help` and live JSON roundtrip
@@ -172,11 +218,16 @@ contracts stored in metadata. Address in Phase 1 design review.
   enrichment-stage failures that ART RC-1 and RC-2 describe. If it does,
   this RDR may be unnecessary.
   — **Status**: Unverified — **Method**: Wait for RDR-065 baseline data
-- [ ] **CA-2**: The plan-enricher agent can produce dimensional contracts
+- [x] **CA-2**: The plan-enricher agent can produce dimensional contracts
   given a structured template prompt without requiring runtime symbol
   resolution. If contracts must be verified by Serena/JetBrains lookup
   at enrichment time, the cost may be prohibitive.
-  — **Status**: Unverified — **Method**: Spike
+  — **Status**: **VERIFIED for the easy case (2026-04-11)** — Sonnet-
+  class subagent produced a fully line-grounded contract for
+  `compute_frecency` from a single `Read()` call with no Serena lookup.
+  Phase 1 must retry on a hard case (cross-file generic or protocol
+  consumer) to find the Read-to-Serena boundary.
+  — **Method**: Spike — see Finding 2. T2: `nexus_rdr/066-research-2-ca2-spike-verified`
 - [x] **CA-3**: A "coordinator bead" concept can be expressed as a tag
   or naming convention without modifying the `bd` schema. (We cannot
   modify beads internals.)


### PR DESCRIPTION
## Summary

Three RDR-066 changes in one cycle. The RDR stays `draft` overall, but it is now **actionable**: its blocking CA is a concrete trigger event, not a wait for a signal that nothing generates.

### 1. CA-1 reframed from wait-based to trigger-based

The original CA-1 was broken:

- It said *"wait for RDR-065 baseline data"* — but no code in RDR-065 or elsewhere produces such a baseline. (That instrumentation would be RDR-067's job, which is also a stub.) CA-1 was waiting forever for a signal nothing generates.
- Its *"if RDR-065 catches these, RDR-066 is unnecessary"* framing was a category error. RDR-065 catches composition failures at **close time** — AFTER ≥2 beads of sunk work. RDR-066 would catch them at **enrichment time** — BEFORE any work. Detection ≠ prevention.

**New CA-1**: the RDR moves from `draft` to `in-progress` on the first observed composition failure matching ART RC-1 / RC-2 where close-time gates caught it but at ≥2 beads of sunk-cost penalty. If 120 days pass (by 2026-08-09) without a qualifying event, the drift condition forces one of three explicit decisions — abandon, reclassify as research-only, or fold into another RDR. Passive drift is disallowed.

### 2. CA-3 (Source Search) verified — bd 1.0.0 has first-class metadata

Stub assumed "we cannot modify beads internals" and scoped Gap 2 around a tag/convention hack. That assumption is wrong in a good way:

- `bd create --metadata '{...}'` accepts arbitrary JSON, roundtrips via `bd show --json`
- `--waits-for-gate all-children` (default) is literally the coordinator "wait until children complete" semantic
- `--design`, `--context`, `--notes`, `--spec-id`, `--external-ref` host structured per-bead fields

Verified with a live JSON roundtrip test (create throwaway bead → read JSON → delete).

### 3. CA-2 (Spike) verified for the easy case

Sonnet-class subagent simulating plan-enricher produced a fully line-grounded 11-field contract for `src/nexus/frecency.py:compute_frecency` from a single `Read()` call. No Serena / symbol lookup needed for self-contained functions with plain types.

Hardest field: distinguishing caught vs. propagating exceptions (inference from absence-of-handler, correctly self-flagged as lowest confidence).

Template refinements surfaced:
1. Split "Error modes" into caught / propagates sub-bullets
2. Add "Default values resolved" to inline constants (`_DEFAULT_DECAY_RATE` → `0.01`)
3. Keep "Tools used to ground" + "Hallucination self-check" fields for auditability

**Honest scope bound**: only the easy case is verified. Cross-file generics, protocols, third-party library types are Phase 1 concerns. The spike only proves Read suffices on the easy side of the Read-to-Serena boundary.

## What this PR does NOT do

- Does not promote RDR-066 out of `draft`. The status change is trigger-gated.
- Does not start Gap 1/2/3 design work.
- Does not commit to "no Serena ever" for contracts.
- Does not produce any code changes — three Markdown edits total.

## Commits

1. `08b9071` — docs(rdr-066): CA-3 verified — bd 1.0.0 has first-class metadata
2. `d767a98` — docs(rdr-066): CA-2 verified (easy case) — contracts from Read alone
3. `0afdec8` — docs(rdr-066): reframe CA-1 from wait-based to trigger-based

## T2 artifacts (permanent)

- `nexus_rdr/066-research-1-ca3-verified` (id 714)
- `nexus_rdr/066-research-2-ca2-spike-verified` (id 715)

## Test plan

- [x] RDR-066 parses cleanly; all anchors (`## Research Findings`, `### Critical Assumptions`, `## Revision History`) present
- [x] bd metadata roundtrip verified (test bead created + deleted)
- [x] Subagent spike completed HIGH confidence on all fields except self-flagged "propagating exceptions"
- [x] Both T2 entries permanent TTL
- [x] CA-1 reframe includes explicit abandon/reclassify/fold drift decisions

## Closes

- `nexus-kxt` — RDR-066 research cycle