### PR TITLE
feat: indexer utilities refactor + incremental taxonomy assignment (RDR-070)

### DIFF
--- a/src/nexus/code_indexer.py
+++ b/src/nexus/code_indexer.py
@@ -419,4 +419,12 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
         embeddings=embeddings,
         metadatas=metadatas,
     )
+
+    # Incremental taxonomy: assign chunks to nearest existing topics.
+    try:
+        from nexus.mcp_infra import taxonomy_assign_batch
+        taxonomy_assign_batch(ids, ctx.corpus, embeddings)
+    except Exception:
+        _log.debug("taxonomy_incremental_assign_failed", exc_info=True)
+
     return len(ids)

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -310,13 +310,45 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
 
     # ── Batch mode (--dir) ──────────────────────────────────────────────
     if dir_path is not None:
-        pdfs = sorted(
-            p for p in dir_path.iterdir()
+        from nexus.indexer_utils import (
+            find_repo_root,
+            is_gitignored,
+            load_ignore_patterns,
+            should_ignore,
+        )
+
+        dir_path = dir_path.resolve()
+        repo_root = find_repo_root(dir_path)
+
+        # Collect PDFs and filter: resolve paths, respect git + .nexus.yml
+        ignore_patterns = load_ignore_patterns(repo_root)
+        raw_pdfs = sorted(
+            p.resolve() for p in dir_path.iterdir()
             if p.is_file() and p.suffix.lower() == ".pdf"
         )
+        pdfs: list[Path] = []
+        for p in raw_pdfs:
+            # Skip hidden files
+            if p.name.startswith("."):
+                continue
+            # Apply .nexus.yml ignore patterns (relative to repo or dir)
+            rel = p.relative_to(repo_root) if repo_root else p.relative_to(dir_path)
+            if should_ignore(rel, ignore_patterns):
+                _log.debug("skipping_ignored_pdf", path=str(p), pattern="ignore_patterns")
+                continue
+            # Respect .gitignore when inside a repository
+            if repo_root and is_gitignored(p, repo_root):
+                _log.debug("skipping_gitignored_pdf", path=str(p))
+                continue
+            pdfs.append(p)
+
         if not pdfs:
             click.echo(f"No PDF files found in {dir_path}")
             return
+
+        skipped = len(raw_pdfs) - len(pdfs)
+        if skipped:
+            click.echo(f"Filtered {skipped} PDF(s) via gitignore/.nexus.yml patterns")
 
         if collection is not None:
             collection = t3_collection_name(collection)

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -300,6 +300,9 @@ def _index_document(
     if embed_fn is None and not _has_credentials():
         return 0
 
+    # Normalize to absolute so staleness checks are path-form-independent.
+    file_path = file_path.resolve()
+
     sp = source_key if source_key is not None else str(file_path)
     content_hash = _sha256(file_path)
     if collection_name is None:
@@ -344,6 +347,13 @@ def _index_document(
         for m in metadatas:
             m["embedding_model"] = actual_model
     db.upsert_chunks_with_embeddings(collection_name, ids, documents, embeddings, metadatas)
+
+    # Incremental taxonomy: assign chunks to nearest existing topics.
+    try:
+        from nexus.mcp_infra import taxonomy_assign_batch
+        taxonomy_assign_batch(ids, collection_name, embeddings)
+    except Exception:
+        _log.debug("taxonomy_incremental_assign_failed", exc_info=True)
 
     # Prune stale chunks from a previous (larger) version of this file.
     # Paginate: ChromaDB Cloud returns at most 300 records per get() call.
@@ -437,6 +447,13 @@ def _index_pdf_incremental(
 
         # Upsert
         t3.upsert_chunks_with_embeddings(collection_name, batch_ids, batch_docs, embeddings, batch_metas)
+
+        # Incremental taxonomy: assign this batch to nearest existing topics.
+        try:
+            from nexus.mcp_infra import taxonomy_assign_batch
+            taxonomy_assign_batch(batch_ids, collection_name, embeddings)
+        except Exception:
+            _log.debug("taxonomy_incremental_assign_failed", exc_info=True)
 
         # Checkpoint
         write_checkpoint(CheckpointData(
@@ -663,6 +680,9 @@ def index_pdf(
     if embed_fn is None and not _has_credentials():
         return _empty_meta if return_metadata else 0
 
+    # Normalize to absolute so staleness checks are path-form-independent.
+    pdf_path = pdf_path.resolve()
+
     content_hash = _sha256(pdf_path)
     col_name = collection_name if collection_name is not None else f"docs__{corpus}"
     db = t3 if t3 is not None else make_t3()  # T3Database instance (not PipelineDB)
@@ -784,6 +804,13 @@ def index_pdf(
         for m in metadatas_list:
             m["embedding_model"] = actual_model
     db.upsert_chunks_with_embeddings(col_name, ids, documents, embeddings, metadatas_list)
+
+    # Incremental taxonomy: assign chunks to nearest existing topics.
+    try:
+        from nexus.mcp_infra import taxonomy_assign_batch
+        taxonomy_assign_batch(ids, col_name, embeddings)
+    except Exception:
+        _log.debug("taxonomy_incremental_assign_failed", exc_info=True)
 
     # Prune stale chunks
     current_ids_set = set(ids)
@@ -914,6 +941,9 @@ def index_markdown(
     from functools import partial
 
     from nexus.catalog.catalog import make_relative
+
+    # Normalize to absolute so staleness checks are path-form-independent.
+    md_path = md_path.resolve()
 
     col_name = collection_name if collection_name is not None else f"docs__{corpus}"
     chunk_fn = partial(_markdown_chunks, base_path=base_path) if base_path else _markdown_chunks

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -18,7 +18,6 @@ Per-file indexing logic lives in focused sub-modules (RDR-032):
 """
 import errno
 import fcntl
-import fnmatch
 import os
 import subprocess
 import time
@@ -31,7 +30,13 @@ import structlog
 from nexus.corpus import index_model_for_collection
 from nexus.retry import _chroma_with_retry, _voyage_with_retry  # noqa: F401 — re-exported for any existing imports
 from nexus.errors import CredentialsMissingError  # re-exported for backward compatibility
-from nexus.indexer_utils import check_credentials, check_local_path_writable, check_staleness
+from nexus.indexer_utils import (
+    check_credentials,
+    check_local_path_writable,
+    check_staleness,
+    should_ignore as _should_ignore,  # shared implementation
+    _DEFAULT_IGNORE,
+)
 
 # Re-exports from nexus.code_indexer for backward compatibility with tests that
 # import these names directly from nexus.indexer.
@@ -49,12 +54,8 @@ if TYPE_CHECKING:
     from nexus.catalog.tumbler import Tumbler
     from nexus.registry import RepoRegistry
 
-DEFAULT_IGNORE: list[str] = [
-    "node_modules", "vendor", ".venv", "__pycache__", "dist", "build", ".git",
-    # Dependency lock / checksum files: auto-generated, not semantically useful,
-    # and can produce chunks that exceed storage per-document size limits.
-    "*.lock", "go.sum",
-]
+# Re-export from indexer_utils for backward compatibility (tests import from here).
+DEFAULT_IGNORE: list[str] = _DEFAULT_IGNORE
 
 
 # Pipeline version: bump when indexing changes invalidate existing embeddings.
@@ -111,13 +112,8 @@ def _git_metadata(repo: Path) -> dict:
     }
 
 
-def _should_ignore(rel_path: Path, patterns: list[str]) -> bool:
-    """Return True if any component of *rel_path* matches any of *patterns*."""
-    for part in rel_path.parts:
-        for pattern in patterns:
-            if fnmatch.fnmatch(part, pattern):
-                return True
-    return False
+# _should_ignore is imported from indexer_utils (as `should_ignore`) above.
+# The local name `_should_ignore` is preserved for backward compatibility.
 
 
 def _git_ls_files(repo: Path, *, include_untracked: bool = False) -> list[Path]:
@@ -752,6 +748,14 @@ def _index_pdf_file(
         embeddings=embeddings,
         metadatas=metadatas,
     )
+
+    # Incremental taxonomy: assign chunks to nearest existing topics.
+    try:
+        from nexus.mcp_infra import taxonomy_assign_batch
+        taxonomy_assign_batch(ids, collection_name, embeddings)
+    except Exception:
+        _log.debug("taxonomy_incremental_assign_failed", exc_info=True)
+
     return len(prepared)
 
 

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -9,12 +9,76 @@ Leaf-ish module: imports from nexus.retry and nexus.errors only.
 """
 from __future__ import annotations
 
+import fnmatch
+import subprocess
+from pathlib import Path
+
 import structlog
 
 from nexus.errors import CredentialsMissingError
 from nexus.retry import _chroma_with_retry
 
 _log = structlog.get_logger(__name__)
+
+# Patterns always ignored (mirrors indexer.DEFAULT_IGNORE).
+_DEFAULT_IGNORE: list[str] = [
+    "node_modules", "vendor", ".venv", "__pycache__", "dist", "build", ".git",
+    "*.lock", "go.sum",
+]
+
+
+def find_repo_root(path: Path) -> Path | None:
+    """Return the git repository root containing *path*, or None.
+
+    Uses ``git rev-parse --show-toplevel`` so it works from any subdirectory.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=path if path.is_dir() else path.parent,
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return Path(result.stdout.strip())
+    except Exception:
+        pass
+    return None
+
+
+def should_ignore(rel_path: Path, patterns: list[str]) -> bool:
+    """Return True if any component of *rel_path* matches any of *patterns*."""
+    for part in rel_path.parts:
+        for pattern in patterns:
+            if fnmatch.fnmatch(part, pattern):
+                return True
+    return False
+
+
+def load_ignore_patterns(repo_root: Path | None = None) -> list[str]:
+    """Return merged ignore patterns from defaults + ``.nexus.yml``.
+
+    When *repo_root* is provided, picks up the per-repo config.
+    """
+    from nexus.config import load_config
+    cfg = load_config(repo_root=repo_root)
+    cfg_patterns: list[str] = cfg.get("server", {}).get("ignorePatterns", [])
+    return list(dict.fromkeys(_DEFAULT_IGNORE + cfg_patterns))
+
+
+def is_gitignored(path: Path, repo_root: Path) -> bool:
+    """Return True if *path* is ignored by git in *repo_root*.
+
+    Uses ``git check-ignore`` for an authoritative answer that respects
+    ``.gitignore``, ``.git/info/exclude``, and global gitignore config.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", str(path)],
+            cwd=repo_root, capture_output=True, timeout=10,
+        )
+        return result.returncode == 0  # 0 = ignored, 1 = not ignored
+    except Exception:
+        return False
 
 
 def check_staleness(

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -388,6 +388,13 @@ def uploader_loop(
 
                 t3.upsert_chunks_with_embeddings(collection, ids, documents, embeddings, metadatas)
 
+                # Incremental taxonomy: assign chunks to nearest existing topics.
+                try:
+                    from nexus.mcp_infra import taxonomy_assign_batch
+                    taxonomy_assign_batch(ids, collection, embeddings)
+                except Exception:
+                    pass  # non-fatal; logging handled inside
+
                 indices = [row["chunk_index"] for row in batch]
                 db.mark_uploaded(content_hash, indices)
                 total_uploaded += len(batch)
@@ -510,6 +517,9 @@ def pipeline_index_pdf(
 
     if db is None:
         db = PipelineDB(PIPELINE_DB_PATH)
+
+    # Normalize to absolute so staleness checks are path-form-independent.
+    pdf_path = pdf_path.resolve()
 
     # Pre-flight: check if pipeline should run before resolving credentials.
     result = db.create_pipeline(content_hash, str(pdf_path), collection)

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -183,4 +183,12 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
         embeddings=embeddings,
         metadatas=metadatas,
     )
+
+    # Incremental taxonomy: assign chunks to nearest existing topics.
+    try:
+        from nexus.mcp_infra import taxonomy_assign_batch
+        taxonomy_assign_batch(ids, ctx.corpus, embeddings)
+    except Exception:
+        _log.debug("taxonomy_incremental_assign_failed", exc_info=True)
+
     return len(ids)

--- a/tests/test_indexer_utils_repo.py
+++ b/tests/test_indexer_utils_repo.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for repo-aware helpers in indexer_utils (nexus-h74)."""
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nexus.indexer_utils import (
+    find_repo_root,
+    is_gitignored,
+    load_ignore_patterns,
+    should_ignore,
+)
+
+
+# ── should_ignore ───────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path,expected", [
+    ("node_modules/pkg/index.js", True),
+    ("src/main.py", False),
+    (".venv/lib/python3.12/site.py", True),
+    ("dist/bundle.js", True),
+    ("package-lock.lock", True),   # *.lock matches any file ending in .lock
+    ("yarn.lock", True),           # *.lock matches
+    ("src/vendor/lib.py", True),   # vendor in any component
+    ("build/output.js", True),
+])
+def test_should_ignore(path: str, expected: bool) -> None:
+    from nexus.indexer_utils import _DEFAULT_IGNORE
+    assert should_ignore(Path(path), _DEFAULT_IGNORE) == expected
+
+
+# ── find_repo_root ──────────────────────────────────────────────────────────
+
+def test_find_repo_root_in_git_repo(tmp_path: Path) -> None:
+    """find_repo_root returns repo root when inside a git repo."""
+    import subprocess
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True)
+    subdir = repo / "sub" / "deep"
+    subdir.mkdir(parents=True)
+
+    root = find_repo_root(subdir)
+    assert root is not None
+    assert root.resolve() == repo.resolve()
+
+
+def test_find_repo_root_not_git(tmp_path: Path) -> None:
+    """find_repo_root returns None for non-git directories."""
+    assert find_repo_root(tmp_path) is None
+
+
+def test_find_repo_root_from_file(tmp_path: Path) -> None:
+    """find_repo_root works when given a file path (uses parent dir)."""
+    import subprocess
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True)
+    f = repo / "test.txt"
+    f.write_text("hello")
+
+    root = find_repo_root(f)
+    assert root is not None
+    assert root.resolve() == repo.resolve()
+
+
+# ── is_gitignored ──────────────────────────────────────────────────────────
+
+def test_is_gitignored_respected(tmp_path: Path) -> None:
+    """is_gitignored returns True for .gitignore'd files."""
+    import subprocess
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True)
+    (repo / ".gitignore").write_text("*.pdf\n")
+    (repo / "paper.pdf").write_bytes(b"%PDF-1.4 test")
+    (repo / "code.py").write_text("x = 1\n")
+
+    assert is_gitignored(repo / "paper.pdf", repo) is True
+    assert is_gitignored(repo / "code.py", repo) is False
+
+
+def test_is_gitignored_non_repo(tmp_path: Path) -> None:
+    """is_gitignored returns False gracefully for non-repo dirs."""
+    (tmp_path / "file.txt").write_text("test")
+    assert is_gitignored(tmp_path / "file.txt", tmp_path) is False
+
+
+# ── load_ignore_patterns ────────────────────────────────────────────────────
+
+def test_load_ignore_patterns_defaults() -> None:
+    """Without repo config, returns at least the default patterns."""
+    patterns = load_ignore_patterns()
+    assert "node_modules" in patterns
+    assert ".git" in patterns
+    assert "*.lock" in patterns
+
+
+def test_load_ignore_patterns_merges_config(tmp_path: Path) -> None:
+    """load_ignore_patterns picks up .nexus.yml ignorePatterns."""
+    nexus_yml = tmp_path / ".nexus.yml"
+    nexus_yml.write_text("server:\n  ignorePatterns:\n    - '*.bak'\n    - tmp\n")
+    patterns = load_ignore_patterns(tmp_path)
+    assert "*.bak" in patterns
+    assert "tmp" in patterns
+    assert "node_modules" in patterns  # defaults still present
+
+
+# ── Path resolution in index_pdf ────────────────────────────────────────────
+
+def test_index_pdf_resolves_path(tmp_path: Path, monkeypatch) -> None:
+    """index_pdf normalizes pdf_path to absolute before staleness check."""
+    import hashlib
+    from nexus.doc_indexer import index_pdf
+
+    pdf = tmp_path / "test.pdf"
+    content = b"%PDF-1.4 test content"
+    pdf.write_bytes(content)
+    real_hash = hashlib.sha256(content).hexdigest()
+
+    # Mock credentials away
+    monkeypatch.setattr("nexus.doc_indexer._has_credentials", lambda: True)
+
+    captured_source_paths: list[str] = []
+
+    def fake_chroma_retry(fn, **kwargs):
+        if "where" in kwargs:
+            sp = kwargs["where"].get("source_path", "")
+            captured_source_paths.append(sp)
+        # Return matching hash+model so staleness check says "skip"
+        return {
+            "metadatas": [{"content_hash": real_hash, "embedding_model": "model"}],
+            "ids": ["x"],
+        }
+
+    # col.get is passed to _chroma_with_retry as the fn argument
+    mock_col = type("FakeCol", (), {"get": lambda self, **kw: None})()
+    mock_db = type("FakeDB", (), {
+        "get_or_create_collection": lambda self, name: mock_col,
+    })()
+
+    monkeypatch.setattr("nexus.doc_indexer.make_t3", lambda: mock_db)
+    monkeypatch.setattr("nexus.doc_indexer.index_model_for_collection", lambda n: "model")
+    monkeypatch.setattr("nexus.doc_indexer._chroma_with_retry", fake_chroma_retry)
+
+    result = index_pdf(pdf, "test")
+
+    # Staleness check skipped (returned 0) and used the resolved absolute path
+    assert result == 0
+    assert captured_source_paths
+    assert Path(captured_source_paths[0]).is_absolute()
+    assert captured_source_paths[0] == str(pdf.resolve())
+
+
+# ── backward compat: indexer._should_ignore ─────────────────────────────────
+
+def test_indexer_should_ignore_reexport() -> None:
+    """indexer._should_ignore is the same function as indexer_utils.should_ignore."""
+    from nexus.indexer import _should_ignore
+    assert _should_ignore is should_ignore
+
+
+def test_indexer_default_ignore_matches() -> None:
+    """indexer.DEFAULT_IGNORE matches indexer_utils._DEFAULT_IGNORE."""
+    from nexus.indexer import DEFAULT_IGNORE
+    from nexus.indexer_utils import _DEFAULT_IGNORE
+    assert DEFAULT_IGNORE is _DEFAULT_IGNORE


### PR DESCRIPTION
## Summary

Recovers uncommitted work from prior RDR-070 sessions that was riding the working tree.

- **Commit 1**: Extract `find_repo_root()`, `should_ignore()`, `load_ignore_patterns()`, `is_gitignored()` from `indexer.py` into `indexer_utils.py`. Wire PDF batch mode to use `.nexusignore` filtering. Normalize `doc_indexer` file paths to absolute.
- **Commit 2**: Wire `taxonomy_assign_batch()` into `code_indexer`, `prose_indexer`, and `pipeline_stages` uploader loop — incremental topic assignment during indexing. Non-fatal.

## Test plan

- [x] 18 tests in `test_indexer_utils_repo.py` (gitignore, repo root, path normalization)
- [x] taxonomy_assign_batch is non-fatal (try/except with debug logging)