### PR TITLE
feat: cross-collection topic projection — Phases 3-5 (RDR-075)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,12 +105,13 @@ src/nexus/           # Core package
     config_cmd.py    # nx config
     hooks.py         # nx hooks (user-facing hook management)
     hook.py          # nx hook (hidden; git hook stanza management)
-    doctor.py        # nx doctor
+    doctor.py        # nx doctor (includes --check-schema for T2 validation, RDR-076)
+    upgrade.py       # nx upgrade (--dry-run, --force, --auto; T2 migrations + T3 upgrade steps, RDR-076)
     enrich.py        # nx enrich
     catalog.py       # nx catalog
     mineru.py        # nx mineru
     console.py       # nx console (embedded web UI server)
-    taxonomy_cmd.py  # nx taxonomy (topic browsing and discovery)
+    taxonomy_cmd.py  # nx taxonomy (topic browsing, discovery, cross-collection projection via project subcommand)
     _helpers.py      # Shared CLI helpers (default_db_path)
     _provision.py    # ChromaDB Cloud provisioning helpers
   catalog/           # Xanadu-inspired document catalog (JSONL truth + SQLite cache)
@@ -126,6 +127,7 @@ src/nexus/           # Core package
     watchers.py      # File/event watchers for live UI updates
     routes/          # FastAPI routers (activity, campaigns, health, partials)
   db/                # Storage tier implementations
+    migrations.py    # Centralised T2 migration registry: Migration dataclass, apply_pending(), T3UpgradeStep, version tracking (RDR-076)
     t1.py            # T1 ChromaDB client (ephemeral or HTTP)
     t2/              # T2 SQLite package: MemoryStore, PlanLibrary, CatalogTaxonomy, Telemetry domain stores + T2Database facade
     t3.py            # T3 ChromaDB client (persistent local or cloud)
@@ -138,7 +140,7 @@ src/nexus/           # Core package
   code_indexer.py    # Code file indexing: AST chunking, context extraction, Voyage AI embedding (extracted from indexer.py, RDR-032)
   prose_indexer.py   # Prose file indexing: semantic markdown chunking, CCE embedding (extracted from indexer.py, RDR-032)
   index_context.py   # IndexContext dataclass: shared indexing parameters replacing 12-parameter signatures
-  indexer_utils.py   # Shared indexing utilities: staleness checks, context-prefix building
+  indexer_utils.py   # Shared indexing utilities: staleness checks, context-prefix building, gitignore/repo-root helpers
   classifier.py      # File classification: CODE / PROSE / PDF / SKIP
   chunker.py         # Tree-sitter AST chunking (31 languages)
   languages.py       # LANGUAGE_REGISTRY: unified extension→language map (single source of truth)
@@ -160,7 +162,7 @@ src/nexus/           # Core package
   ripgrep_cache.py   # ripgrep integration for hybrid search
   session.py         # Session lifecycle (T1 server start/connect)
   config.py          # Config hierarchy + .nexus.yml
-  registry.py        # Collection → database routing
+  registry.py        # Collection → database routing + list_sibling_collections() for cross-collection scoping (RDR-075)
   corpus.py          # Corpus naming utilities
   formatters.py      # Result display formatting
   types.py           # Shared type definitions
@@ -171,7 +173,7 @@ src/nexus/           # Core package
   logging_setup.py   # Structured logging configuration (cli/console/mcp/hook modes, rotating file handler)
   taxonomy.py        # Deprecation shim — imports forwarded to db.t2.catalog_taxonomy (RDR-070)
   mcp_server.py      # Backward-compat shim — re-exports all MCP tools from nexus.mcp package
-  mcp_infra.py       # MCP server infrastructure: singletons, caching, test injection, taxonomy_assign_hook (post-store topic assignment)
+  mcp_infra.py       # MCP server infrastructure: singletons, caching, test injection, taxonomy_assign_hook (post-store topic assignment + cross-collection projection), check_version_compatibility (RDR-076)
 nx/                  # Claude Code plugin (skills, agents, hooks, slash commands)
 tests/               # pytest suite (unit + integration + e2e/)
 docs/                # Documentation (architecture.md is the module map)

--- a/README.md
+++ b/README.md
@@ -135,10 +135,11 @@ The `nx` command provides direct access to all storage tiers, indexing, and sear
 | `nx scratch` | Inter-agent session context (in-memory, no API keys) |
 | `nx collection` | Inspect and manage cloud collections |
 | `nx config` | Credentials and settings |
-| `nx doctor` | Health check — verifies dependencies, credentials, connectivity |
+| `nx upgrade` | Run pending database migrations and T3 upgrade steps |
+| `nx doctor` | Health check — verifies dependencies, credentials, connectivity, schema |
 | `nx hooks` | Install git hooks for automatic re-indexing on commit |
 | `nx catalog` | Document registry — search, link, audit the catalog metadata layer |
-| `nx taxonomy` | Topic taxonomy — review, rename, merge, and split auto-discovered topic clusters |
+| `nx taxonomy` | Topic taxonomy — discover, project across collections, review, merge, split |
 | `nx context` | Project context cache — topic map for agent cold-start acceleration |
 | `nx mineru` | MinerU server lifecycle (start/stop/status) for PDF extraction |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,14 +242,25 @@ Phase 2 consequences:
   own `threading.Lock` plus the SQLite file-level write lock -- callers
   never see `OperationalError: database is locked`.
 
-**Migrations**: Each store owns its schema-migration guards and runs
-them the first time it opens a given database path. The guards are
-per-domain, so concurrent `T2Database` constructors on the same path
-can each reach their own `_init_schema` without coordinating through a
-single global migration lock. (`T2Database.__init__` itself constructs
-the four stores sequentially in dependency order -- the per-domain
-guard matters for multi-process / multi-constructor races, not for the
-sequential initialization inside a single `T2Database`.)
+**Migration Registry** (RDR-076): All T2 schema migrations are centralised in
+`src/nexus/db/migrations.py`. The `MIGRATIONS` list contains version-tagged
+`Migration(introduced, name, fn)` entries. `apply_pending(conn, current_version)`
+runs migrations between the last-seen version (stored in `_nexus_version` table)
+and the current CLI version. Each migration function is idempotent via
+`PRAGMA table_info()` or `sqlite_master` guards.
+
+`T2Database.__init__()` opens a transient connection, calls `apply_pending()`,
+closes it, then constructs the four domain stores. The `_upgrade_done` set
+(guarded by `_upgrade_lock`) provides a process-level fast path — subsequent
+constructions skip all DB access. Domain stores retain their own
+`_migrated_paths` guards for standalone construction outside `T2Database`.
+
+**T3 Upgrade Steps**: `T3UpgradeStep(introduced, name, fn)` entries in the
+`T3_UPGRADES` list handle ChromaDB operations (backfills, re-indexing) that
+require a `T3Database` client. These run via `nx upgrade` (not `--auto` mode).
+
+**Auto-upgrade**: `nx upgrade --auto` runs as the first SessionStart hook,
+applying T2 migrations silently. T3 steps are skipped in auto mode.
 
 **In-memory SQLite**: Tests that want an ephemeral database should use
 a temp file path, not `":memory:"` -- `:memory:` databases are

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -325,6 +325,9 @@ nx taxonomy merge "source" "target"             # merge topics
 nx taxonomy split "label" --k 3                 # split into sub-topics
 nx taxonomy links                               # show inter-topic relationships
 nx taxonomy rebuild -c docs__nexus              # full rebuild
+nx taxonomy project code__nexus                 # project against sibling collections
+nx taxonomy project code__nexus --against knowledge__art  # explicit targets
+nx taxonomy project --backfill --persist        # project all collections
 ```
 
 | Subcommand | Description |
@@ -341,6 +344,7 @@ nx taxonomy rebuild -c docs__nexus              # full rebuild
 | `split LABEL --k N` | Split into N sub-topics via KMeans. `-c NAME` scopes label lookup |
 | `links` | Inter-topic link counts from catalog graph. `-c NAME` filters by collection |
 | `rebuild` | Full re-cluster (alias for `discover --force`). `-c NAME` required |
+| `project SOURCE` | Cross-collection projection: match chunks against other collections' centroids. `--against TARGETS` for explicit targets (default: sibling collections). `--threshold N` (default 0.85). `--persist` to write assignments. `--backfill` to project all collections against each other |
 
 **Configuration** (in `.nexus.yml`):
 
@@ -350,7 +354,7 @@ taxonomy:
   local_exclude_collections: []       # default: ["code__*"] — MiniLM clusters poorly on code
 ```
 
-**Upgrade path**: Run `nx taxonomy discover --all` once after upgrading to populate topics for existing collections.
+**Upgrade path**: Run `nx upgrade` after upgrading to apply pending migrations and T3 upgrade steps (including cross-collection projection backfill). Run `nx taxonomy discover --all` to populate topics for new collections.
 
 ---
 
@@ -620,6 +624,35 @@ nx doctor --fix-paths --dry-run # Preview migration without applying
 ```
 
 The `--fix` flag retroactively applies HNSW `search_ef` tuning to all existing local-mode collections. New collections get this automatically. In cloud mode (SPANN), prints a skip message — SPANN defaults are adequate.
+
+```
+nx doctor --check-schema          # Validate T2 database schema and report pending migrations
+```
+
+---
+
+## nx upgrade
+
+Run pending database migrations and T3 upgrade steps.
+
+```
+nx upgrade                        # Apply all pending T2 + T3 migrations
+nx upgrade --dry-run              # List pending migrations without executing
+nx upgrade --force                # Reset version gate and re-run all migrations
+nx upgrade --auto                 # Quiet mode for hook invocation (T2 only, exit 0 always)
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | List pending migrations without executing (creates base tables if absent) |
+| `--force` | Reset version gate to 0.0.0 and re-run all migrations. Per-migration idempotency guards still apply |
+| `--auto` | Quiet mode for SessionStart hook. T2 migrations only (T3 skipped — may exceed hook timeout). Exit 0 always |
+
+**How it works**: The CLI version (`importlib.metadata.version("conexus")`) is compared against the last-seen version stored in T2 (`_nexus_version` table). Migrations tagged with versions between last-seen and current are executed. Each migration is idempotent via `PRAGMA table_info()` / `sqlite_master` guards.
+
+**Auto-upgrade**: `nx upgrade --auto` runs as the first SessionStart hook in the Claude Code plugin. T2 migrations apply silently on every session start. T3 upgrade steps (e.g., cross-collection projection backfill) run only via explicit `nx upgrade`.
+
+**Adding new migrations**: Append a `Migration("x.y.z", "description", fn)` entry to the `MIGRATIONS` list in `src/nexus/db/migrations.py`. For T3 operations, use `T3UpgradeStep`.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -254,6 +254,7 @@ Every step below is **required**. Missing any one of them has caused problems in
 | `docs/configuration.md` | new config keys or tuning parameters |
 | `docs/storage-tiers.md` | new storage capabilities |
 | `README.md` | high-level feature descriptions |
+| `src/nexus/db/migrations.py` | verify `PRE_REGISTRY_VERSION` matches previous release; new T2 migrations in `MIGRATIONS` list; new T3 steps in `T3_UPGRADES` |
 
 ### Pre-push release checklist
 

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -96,7 +96,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-072](rdr-072-progressive-context-loading.md) | Progressive Context Loading | Feature | Closed | 2026-04-13 |
 | [RDR-073](rdr-073-temporal-entity-knowledge-graph.md) | Temporal Entity Knowledge Graph | Feature | Deferred | 2026-04-13 |
 | [RDR-074](rdr-074-permanence-mode.md) | Permanence Mode | Feature | Deferred | 2026-04-13 |
-| [RDR-075](rdr-075-cross-collection-topic-projection.md) | Cross-Collection Topic Projection | Feature | Accepted | 2026-04-13 |
+| [RDR-075](rdr-075-cross-collection-topic-projection.md) | Cross-Collection Topic Projection | Feature | Closed (implemented) | 2026-04-13 |
 | [RDR-076](rdr-076-idempotent-upgrade-mechanism.md) | Idempotent Upgrade Mechanism | Architecture | Closed (implemented) | 2026-04-13 |
 
 ---

--- a/docs/rdr/rdr-075-cross-collection-topic-projection.md
+++ b/docs/rdr/rdr-075-cross-collection-topic-projection.md
@@ -1,10 +1,12 @@
 ---
 title: "RDR-075: Cross-Collection Topic Projection"
-status: accepted
+status: closed
+close_reason: implemented
 type: feature
 priority: P2
 created: 2026-04-13
 accepted_date: 2026-04-14
+closed_date: 2026-04-14
 github_issue: 154
 reviewed-by: self
 ---

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -209,6 +209,14 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
                 except Exception:
                     _log.debug("taxonomy_projection_failed", exc_info=True)
 
+                # Co-occurrence topic links from projections (RDR-075 SC-5)
+                try:
+                    cooc = db.taxonomy.generate_cooccurrence_links()
+                    if cooc:
+                        _log.info("cooccurrence_links_generated", count=cooc)
+                except Exception:
+                    _log.debug("cooccurrence_links_failed", exc_info=True)
+
                 # Auto-populate topic links if catalog available
                 try:
                     from nexus.commands.taxonomy_cmd import _try_load_catalog, compute_topic_links

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -195,6 +195,20 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
                         f"  Review:   {unreviewed} topics pending. "
                         f"Run `nx taxonomy review` to curate."
                     )
+                # Cross-collection projection pass (RDR-075 SC-7)
+                try:
+                    for col_name in collections:
+                        others = [c for c in collections if c != col_name]
+                        if others:
+                            result = db.taxonomy.project_against(
+                                col_name, others, t3._client, threshold=0.85,
+                            )
+                            if result.get("chunk_assignments"):
+                                from nexus.commands.taxonomy_cmd import _persist_assignments
+                                _persist_assignments(db.taxonomy, result["chunk_assignments"])
+                except Exception:
+                    _log.debug("taxonomy_projection_failed", exc_info=True)
+
                 # Auto-populate topic links if catalog available
                 try:
                     from nexus.commands.taxonomy_cmd import _try_load_catalog, compute_topic_links

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -205,7 +205,7 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
                             )
                             if result.get("chunk_assignments"):
                                 from nexus.commands.taxonomy_cmd import _persist_assignments
-                                _persist_assignments(db.taxonomy, result["chunk_assignments"])
+                                _persist_assignments(db.taxonomy, result["chunk_assignments"], quiet=True)
                 except Exception:
                     _log.debug("taxonomy_projection_failed", exc_info=True)
 

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -197,15 +197,20 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
                     )
                 # Cross-collection projection pass (RDR-075 SC-7)
                 try:
+                    proj_total = 0
                     for col_name in collections:
                         others = [c for c in collections if c != col_name]
                         if others:
                             result = db.taxonomy.project_against(
                                 col_name, others, t3._client, threshold=0.85,
                             )
-                            if result.get("chunk_assignments"):
+                            assignments = result.get("chunk_assignments", [])
+                            if assignments:
                                 from nexus.commands.taxonomy_cmd import _persist_assignments
-                                _persist_assignments(db.taxonomy, result["chunk_assignments"], quiet=True)
+                                _persist_assignments(db.taxonomy, assignments, quiet=True)
+                                proj_total += len(assignments)
+                    if proj_total:
+                        click.echo(f"  Project:  {proj_total} cross-collection assignments.")
                 except Exception:
                     _log.debug("taxonomy_projection_failed", exc_info=True)
 

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -956,139 +956,73 @@ def project_cmd(
     db = _T2Database(_default_db_path())
     t3 = make_t3()
 
-    if backfill:
-        _run_backfill(db.taxonomy, t3._client, threshold=threshold, top_k=top_k, persist=persist)
-        db.close()
-        return
-
-    if not source_collection:
-        click.echo("Specify a source collection or use --backfill.")
-        db.close()
-        return
-
-    # Determine target collections
-    if against:
-        targets = [c.strip() for c in against.split(",") if c.strip()]
-    else:
-        # All other collections with existing topics
-        rows = db.taxonomy.conn.execute(
-            "SELECT DISTINCT collection FROM topics WHERE collection != ?",
-            (source_collection,),
-        ).fetchall()
-        targets = [r[0] for r in rows]
-        if not targets:
-            click.echo("No other collections have topics. Run 'nx taxonomy discover' first.")
-            db.close()
+    try:
+        if backfill:
+            _run_backfill(db.taxonomy, t3._client, threshold=threshold, top_k=top_k, persist=persist)
             return
 
-    _progress(f"Projecting {source_collection} against {len(targets)} collection(s)...")
+        if not source_collection:
+            click.echo("Specify a source collection or use --backfill.")
+            return
 
-    try:
+        # Determine target collections
+        if against:
+            targets = [c.strip() for c in against.split(",") if c.strip()]
+        else:
+            rows = db.taxonomy.conn.execute(
+                "SELECT DISTINCT collection FROM topics WHERE collection != ?",
+                (source_collection,),
+            ).fetchall()
+            targets = [r[0] for r in rows]
+            if not targets:
+                click.echo("No other collections have topics. Run 'nx taxonomy discover' first.")
+                return
+
+        _progress(f"Projecting {source_collection} against {len(targets)} collection(s)...")
+
         result = db.taxonomy.project_against(
             source_collection, targets, t3._client,
             threshold=threshold, top_k=top_k,
         )
+
+        # Display results
+        matched = result["matched_topics"]
+        novel = result["novel_chunks"]
+        total = result["total_chunks"]
+
+        if matched:
+            click.echo(f"\nMatched topics (threshold {threshold}):")
+            for m in matched:
+                click.echo(
+                    f"  [{m['topic_id']}] {m['label']} ({m['collection']}) "
+                    f"— {m['chunk_count']} chunks, avg sim {m['avg_similarity']:.2f}"
+                )
+        else:
+            click.echo("\nNo matched topics above threshold.")
+
+        click.echo(f"\nNovel chunks: {len(novel)} (no centroid match >= {threshold})")
+        covered = total - len(novel)
+        click.echo(f"Total: {len(matched)} matched topics, {covered}/{total} chunks covered")
+
+        if persist and result.get("chunk_assignments"):
+            _persist_assignments(db.taxonomy, result["chunk_assignments"])
+        elif matched and not persist:
+            click.echo("\nRun with --persist to write assignments to topic_assignments.")
+
     except ValueError as e:
         click.echo(f"Error: {e}")
+    finally:
         db.close()
-        return
-
-    # Display results
-    matched = result["matched_topics"]
-    novel = result["novel_chunks"]
-    total = result["total_chunks"]
-
-    if matched:
-        click.echo(f"\nMatched topics (threshold {threshold}):")
-        for m in matched:
-            click.echo(
-                f"  [{m['topic_id']}] {m['label']} ({m['collection']}) "
-                f"— {m['chunk_count']} chunks, avg sim {m['avg_similarity']:.2f}"
-            )
-    else:
-        click.echo("\nNo matched topics above threshold.")
-
-    click.echo(f"\nNovel chunks: {len(novel)} (no centroid match >= {threshold})")
-    covered = total - len(novel)
-    click.echo(f"Total: {len(matched)} matched topics, {covered}/{total} chunks covered")
-
-    if persist and matched:
-        count = 0
-        for m in matched:
-            # Re-project to get per-chunk assignments (project_against aggregates)
-            # Use assign_topic directly for each match
-            pass
-        # For persist, re-run with per-chunk granularity
-        _persist_projections(
-            db.taxonomy, source_collection, targets, t3._client,
-            threshold=threshold, top_k=top_k,
-        )
-    elif matched and not persist:
-        click.echo("\nRun with --persist to write assignments to topic_assignments.")
-
-    db.close()
 
 
-def _persist_projections(
+def _persist_assignments(
     taxonomy: "CatalogTaxonomy",
-    source_collection: str,
-    target_collections: list[str],
-    chroma_client: Any,
-    *,
-    threshold: float = 0.85,
-    top_k: int = 3,
+    chunk_assignments: list[tuple[str, int]],
 ) -> None:
-    """Write projection assignments to topic_assignments."""
-    # Re-fetch and compute to get per-chunk → topic mappings
-    try:
-        src_coll = chroma_client.get_collection(source_collection, embedding_function=None)
-    except Exception:
-        return
-
-    src_data = src_coll.get(include=["embeddings"])
-    src_ids = src_data.get("ids", [])
-    src_raw = src_data.get("embeddings")
-    if not src_ids or src_raw is None:
-        return
-
-    src_embs = np.array(src_raw, dtype=np.float32)
-
-    try:
-        centroid_coll = chroma_client.get_collection("taxonomy__centroids", embedding_function=None)
-    except Exception:
-        return
-
-    ctr_data = centroid_coll.get(
-        where={"collection": {"$in": target_collections}},
-        include=["embeddings", "metadatas"],
-    )
-    ctr_raw = ctr_data.get("embeddings")
-    ctr_metas = ctr_data.get("metadatas", [])
-    if ctr_raw is None or len(ctr_raw) == 0:
-        return
-
-    ctr_embs = np.array(ctr_raw, dtype=np.float32)
-    if src_embs.shape[1] != ctr_embs.shape[1]:
-        return
-
-    # Normalize
-    src_norms = np.linalg.norm(src_embs, axis=1, keepdims=True)
-    src_norms[src_norms == 0] = 1.0
-    ctr_norms = np.linalg.norm(ctr_embs, axis=1, keepdims=True)
-    ctr_norms[ctr_norms == 0] = 1.0
-    sim = (src_embs / src_norms) @ (ctr_embs / ctr_norms).T
-
-    count = 0
-    for i, doc_id in enumerate(src_ids):
-        top_indices = np.argsort(-sim[i])[:top_k]
-        for idx in top_indices:
-            if float(sim[i, idx]) < threshold:
-                break
-            topic_id = int(ctr_metas[idx]["topic_id"])
-            taxonomy.assign_topic(doc_id, topic_id, assigned_by="projection")
-            count += 1
-
-    click.echo(f"Persisted {count} projection assignment(s).")
+    """Write per-chunk projection assignments from project_against results."""
+    for doc_id, topic_id in chunk_assignments:
+        taxonomy.assign_topic(doc_id, topic_id, assigned_by="projection")
+    click.echo(f"Persisted {len(chunk_assignments)} projection assignment(s).")
 
 
 def _run_backfill(
@@ -1125,12 +1059,9 @@ def _run_backfill(
             novel = len(result["novel_chunks"])
             click.echo(f"    {matched} matched topics, {novel} novel chunks")
 
-            if persist and result["matched_topics"]:
-                _persist_projections(
-                    taxonomy, src, targets, chroma_client,
-                    threshold=threshold, top_k=top_k,
-                )
-        except ValueError as e:
+            if persist and result.get("chunk_assignments"):
+                _persist_assignments(taxonomy, result["chunk_assignments"])
+        except (ValueError, Exception) as e:
             click.echo(f"    Skipped: {e}")
 
     click.echo("Backfill complete.")

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -1077,11 +1077,13 @@ def _run_backfill(
 
     click.echo(f"Backfilling {len(collections)} collection(s)...")
 
-    for src in collections:
+    total_assigned = 0
+    total_novel = 0
+    for i, src in enumerate(collections, 1):
         targets = [c for c in collections if c != src]
         if not targets:
             continue
-        _progress(f"  {src} → {len(targets)} target(s)...")
+        _progress(f"  [{i}/{len(collections)}] {src} → {len(targets)} target(s)...")
         try:
             result = taxonomy.project_against(
                 src, targets, chroma_client,
@@ -1089,11 +1091,20 @@ def _run_backfill(
             )
             matched = len(result["matched_topics"])
             novel = len(result["novel_chunks"])
-            click.echo(f"    {matched} matched topics, {novel} novel chunks")
+            chunks = result["total_chunks"]
+            click.echo(
+                f"    {matched} matched topics, {novel} novel, "
+                f"{chunks} chunks, {len(result.get('chunk_assignments', []))} assignments"
+            )
+            total_novel += novel
 
             if persist and result.get("chunk_assignments"):
                 _persist_assignments(taxonomy, result["chunk_assignments"])
+                total_assigned += len(result["chunk_assignments"])
         except Exception as e:
             click.echo(f"    Skipped: {e}")
 
-    click.echo("Backfill complete.")
+    click.echo(
+        f"Backfill complete: {total_assigned} assignments, {total_novel} novel chunks "
+        f"across {len(collections)} collections."
+    )

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -354,6 +354,25 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
             else:
                 click.echo(f"  {col_name}: skipped")
 
+        # Cross-collection projection pass (RDR-075 SC-7)
+        if total_topics and len(targets) > 1:
+            try:
+                proj_count = 0
+                for col_name in targets:
+                    others = [c for c in targets if c != col_name]
+                    if others:
+                        result = db.taxonomy.project_against(
+                            col_name, others, t3._client, threshold=0.85,
+                        )
+                        assignments = result.get("chunk_assignments", [])
+                        if assignments:
+                            _persist_assignments(db.taxonomy, assignments)
+                            proj_count += len(assignments)
+                if proj_count:
+                    click.echo(f"  Projection: {proj_count} cross-collection assignments")
+            except Exception:
+                _log.debug("discover_projection_failed", exc_info=True)
+
         # Refresh L1 context cache after discovery
         if total_topics:
             try:

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -366,7 +366,7 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
                         )
                         assignments = result.get("chunk_assignments", [])
                         if assignments:
-                            _persist_assignments(db.taxonomy, assignments)
+                            _persist_assignments(db.taxonomy, assignments, quiet=True)
                             proj_count += len(assignments)
                 if proj_count:
                     click.echo(f"  Projection: {proj_count} cross-collection assignments")
@@ -1037,11 +1037,19 @@ def project_cmd(
 def _persist_assignments(
     taxonomy: "CatalogTaxonomy",
     chunk_assignments: list[tuple[str, int]],
-) -> None:
-    """Write per-chunk projection assignments from project_against results."""
+    *,
+    quiet: bool = False,
+) -> int:
+    """Write per-chunk projection assignments from project_against results.
+
+    Returns the number of assignments written.  Set *quiet* to suppress
+    CLI output (used when called from pipeline context).
+    """
     for doc_id, topic_id in chunk_assignments:
         taxonomy.assign_topic(doc_id, topic_id, assigned_by="projection")
-    click.echo(f"Persisted {len(chunk_assignments)} projection assignment(s).")
+    if not quiet:
+        click.echo(f"Persisted {len(chunk_assignments)} projection assignment(s).")
+    return len(chunk_assignments)
 
 
 def _run_backfill(
@@ -1080,7 +1088,7 @@ def _run_backfill(
 
             if persist and result.get("chunk_assignments"):
                 _persist_assignments(taxonomy, result["chunk_assignments"])
-        except (ValueError, Exception) as e:
+        except Exception as e:
             click.echo(f"    Skipped: {e}")
 
     click.echo("Backfill complete.")

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -370,6 +370,10 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
                             proj_count += len(assignments)
                 if proj_count:
                     click.echo(f"  Projection: {proj_count} cross-collection assignments")
+                    # Co-occurrence topic links (SC-5, SC-7)
+                    cooc = db.taxonomy.generate_cooccurrence_links()
+                    if cooc:
+                        click.echo(f"  Links:      {cooc} co-occurrence topic links")
             except Exception:
                 _log.debug("discover_projection_failed", exc_info=True)
 

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -997,11 +997,10 @@ def project_cmd(
             targets = list_sibling_collections(source_collection, t3._client)
             if not targets:
                 # Fall back to all collections with topics
-                rows = db.taxonomy.conn.execute(
-                    "SELECT DISTINCT collection FROM topics WHERE collection != ?",
-                    (source_collection,),
-                ).fetchall()
-                targets = [r[0] for r in rows]
+                targets = [
+                    c for c in db.taxonomy.get_distinct_collections()
+                    if c != source_collection
+                ]
             if not targets:
                 click.echo("No other collections have topics. Run 'nx taxonomy discover' first.")
                 return
@@ -1070,10 +1069,7 @@ def _run_backfill(
     persist: bool = False,
 ) -> None:
     """Project all collections against each other."""
-    rows = taxonomy.conn.execute(
-        "SELECT DISTINCT collection FROM topics"
-    ).fetchall()
-    collections = [r[0] for r in rows]
+    collections = taxonomy.get_distinct_collections()
 
     if not collections:
         click.echo("No collections with topics found. Run 'nx taxonomy discover' first.")

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -375,7 +375,7 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
                     if cooc:
                         click.echo(f"  Links:      {cooc} co-occurrence topic links")
             except Exception:
-                _log.debug("discover_projection_failed", exc_info=True)
+                _log.warning("discover_projection_failed", exc_info=True)
 
         # Refresh L1 context cache after discovery
         if total_topics:

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -988,11 +988,16 @@ def project_cmd(
         if against:
             targets = [c.strip() for c in against.split(",") if c.strip()]
         else:
-            rows = db.taxonomy.conn.execute(
-                "SELECT DISTINCT collection FROM topics WHERE collection != ?",
-                (source_collection,),
-            ).fetchall()
-            targets = [r[0] for r in rows]
+            # Try sibling collections first (same repo, different prefix)
+            from nexus.registry import list_sibling_collections
+            targets = list_sibling_collections(source_collection, t3._client)
+            if not targets:
+                # Fall back to all collections with topics
+                rows = db.taxonomy.conn.execute(
+                    "SELECT DISTINCT collection FROM topics WHERE collection != ?",
+                    (source_collection,),
+                ).fetchall()
+                targets = [r[0] for r in rows]
             if not targets:
                 click.echo("No other collections have topics. Run 'nx taxonomy discover' first.")
                 return

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -134,8 +134,25 @@ def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool) -> None:
             else:
                 click.echo(f"Up to date (v{current}).")
 
-        # T3 steps (skipped in auto mode)
-        # TODO: implement T3 step execution when T3_UPGRADES is populated
+        # T3 steps (skipped in auto mode — require ChromaDB, may exceed hook timeout)
+        if not auto_mode and pending_t3:
+            from nexus.commands._helpers import default_db_path
+            from nexus.db import make_t3
+            from nexus.db.t2 import T2Database
+
+            try:
+                t3_db = make_t3()
+                t2_db = T2Database(default_db_path())
+                try:
+                    for step in pending_t3:
+                        click.echo(f"  T3: [{step.introduced}] {step.name}")
+                        step.fn(t3_db, t2_db.taxonomy)
+                    click.echo(f"Applied {len(pending_t3)} T3 upgrade step(s).")
+                finally:
+                    t2_db.close()
+            except Exception:
+                _log.warning("t3_upgrade_failed", exc_info=True)
+                click.echo("T3 upgrade step failed (see log for details).")
 
     finally:
         conn.close()

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -318,10 +318,7 @@ def backfill_projection(t3_db: Any, taxonomy: Any) -> None:
     log = structlog.get_logger()
 
     # Find all collections with existing topics
-    rows = taxonomy.conn.execute(
-        "SELECT DISTINCT collection FROM topics"
-    ).fetchall()
-    collections = [r[0] for r in rows]
+    collections = taxonomy.get_distinct_collections()
 
     if not collections:
         log.info("backfill_projection_skip", reason="no topics discovered yet")

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -304,9 +304,58 @@ class T3UpgradeStep:
     fn: Callable  # Callable[[T3Database, CatalogTaxonomy], None]
 
 
+def backfill_projection(t3_db: Any, taxonomy: Any) -> None:
+    """Backfill cross-collection projection for all existing collections.
+
+    For each collection with existing topics, projects against all other
+    collections' centroids and stores assignments with ``assigned_by='projection'``.
+    Then generates co-occurrence topic links.
+
+    RDR-075 RF-11.  Idempotent via ``INSERT OR IGNORE`` in ``assign_topic``.
+    """
+    import structlog
+
+    log = structlog.get_logger()
+
+    # Find all collections with existing topics
+    rows = taxonomy.conn.execute(
+        "SELECT DISTINCT collection FROM topics"
+    ).fetchall()
+    collections = [r[0] for r in rows]
+
+    if not collections:
+        log.info("backfill_projection_skip", reason="no topics discovered yet")
+        return
+
+    log.info("backfill_projection_start", collections=len(collections))
+    total_assigned = 0
+
+    for src in collections:
+        targets = [c for c in collections if c != src]
+        if not targets:
+            continue
+        try:
+            result = taxonomy.project_against(
+                src, targets, t3_db._client, threshold=0.85,
+            )
+            assignments = result.get("chunk_assignments", [])
+            for doc_id, topic_id in assignments:
+                taxonomy.assign_topic(doc_id, topic_id, assigned_by="projection")
+            total_assigned += len(assignments)
+        except Exception:
+            log.debug("backfill_projection_collection_failed", collection=src, exc_info=True)
+
+    # Generate co-occurrence links from the new projection assignments
+    try:
+        taxonomy.generate_cooccurrence_links()
+    except Exception:
+        log.debug("backfill_cooccurrence_failed", exc_info=True)
+
+    log.info("backfill_projection_complete", total_assigned=total_assigned)
+
+
 T3_UPGRADES: list[T3UpgradeStep] = [
-    # Future T3 upgrades append here
-    # T3UpgradeStep("4.2.0", "Backfill cross-collection projection", backfill_projection),
+    T3UpgradeStep("4.2.0", "Backfill cross-collection projection", backfill_projection),
 ]
 
 

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -1089,6 +1089,10 @@ class CatalogTaxonomy:
         if not pairs:
             return 0
 
+        # Two-lock split is intentional: the SQL fetch and the write are
+        # separated to avoid holding the lock during the full self-join read.
+        # Stale counts between the two windows are acceptable for this batch
+        # analytics use case — co-occurrence links are regenerated on each run.
         with self._lock:
             self.conn.executemany(
                 "INSERT OR REPLACE INTO topic_links "

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -1052,6 +1052,63 @@ class CatalogTaxonomy:
 
         return count
 
+    # ── Cross-collection co-occurrence links (RDR-075 Phase 4, SC-5) ─
+
+    def generate_cooccurrence_links(self) -> int:
+        """Generate topic_links from cross-collection projection co-occurrence.
+
+        For each doc_id assigned to topics in multiple collections,
+        creates a ``topic_links`` entry between each cross-collection
+        topic pair, weighted by co-occurrence count.
+
+        Uses ``INSERT OR REPLACE`` to merge with existing projection
+        links from ``_discover_cross_links``.
+
+        Returns count of links generated.
+        """
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT ta.doc_id, ta.topic_id, t.collection "
+                "FROM topic_assignments ta "
+                "JOIN topics t ON ta.topic_id = t.id"
+            ).fetchall()
+
+        # Group by doc_id
+        doc_topics: dict[str, list[tuple[int, str]]] = {}
+        for doc_id, topic_id, collection in rows:
+            doc_topics.setdefault(doc_id, []).append((topic_id, collection))
+
+        # For each doc with topics in multiple collections, generate pairs
+        link_counts: dict[tuple[int, int], int] = {}
+        for assignments in doc_topics.values():
+            collections = {coll for _, coll in assignments}
+            if len(collections) < 2:
+                continue
+            for i, (tid_a, coll_a) in enumerate(assignments):
+                for tid_b, coll_b in assignments[i + 1:]:
+                    if coll_a == coll_b:
+                        continue
+                    pair = (min(tid_a, tid_b), max(tid_a, tid_b))
+                    link_counts[pair] = link_counts.get(pair, 0) + 1
+
+        if not link_counts:
+            return 0
+
+        with self._lock:
+            self.conn.executemany(
+                "INSERT OR REPLACE INTO topic_links "
+                "(from_topic_id, to_topic_id, link_count, link_types) "
+                "VALUES (?, ?, ?, ?)",
+                [
+                    (a, b, count, '["cooccurrence"]')
+                    for (a, b), count in link_counts.items()
+                ],
+            )
+            self.conn.commit()
+
+        _log.info("cooccurrence_links", count=len(link_counts))
+        return len(link_counts)
+
     # ── Cross-collection centroid linking (RDR-075 Phase 3) ─────────
 
     _PROJECTION_THRESHOLD = 0.85

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -1036,10 +1036,87 @@ class CatalogTaxonomy:
         if c_ids_out:
             centroid_coll.upsert(ids=c_ids_out, embeddings=c_embs, metadatas=c_metas)
 
+        # Cross-collection post-pass: find topic links to other collections'
+        # centroids (RDR-075 SC-6, Phase 3).  Lightweight: only new centroids
+        # × existing centroids from other collections.
+        if c_embs:
+            try:
+                self._discover_cross_links(
+                    collection_name, c_embs, c_metas, centroid_coll,
+                )
+            except Exception:
+                _log.debug("discover_cross_links_failed", exc_info=True)
+
         # Record doc count for rebalance tracking
         self.record_discover_count(collection_name, n)
 
         return count
+
+    # ── Cross-collection centroid linking (RDR-075 Phase 3) ─────────
+
+    _PROJECTION_THRESHOLD = 0.85
+
+    def _discover_cross_links(
+        self,
+        collection_name: str,
+        new_centroids: list[list[float]],
+        new_metas: list[dict[str, Any]],
+        centroid_coll: Any,
+    ) -> None:
+        """Find topic links between new centroids and other collections'.
+
+        After discover creates centroids for *collection_name*, query
+        existing centroids from all OTHER collections. Store matches
+        above ``_PROJECTION_THRESHOLD`` as ``topic_links`` entries.
+        """
+        # Fetch all centroids NOT in this collection
+        try:
+            other = centroid_coll.get(
+                where={"collection": {"$ne": collection_name}},
+                include=["embeddings", "metadatas"],
+            )
+        except Exception:
+            return
+
+        other_embs_raw = other.get("embeddings")
+        other_metas = other.get("metadatas", [])
+        if other_embs_raw is None or len(other_embs_raw) == 0:
+            return
+
+        other_embs = np.array(other_embs_raw, dtype=np.float32)
+        new_embs = np.array(new_centroids, dtype=np.float32)
+
+        if new_embs.shape[1] != other_embs.shape[1]:
+            return
+
+        # Cosine similarity: new centroids × other centroids
+        n_norms = np.linalg.norm(new_embs, axis=1, keepdims=True)
+        n_norms[n_norms == 0] = 1.0
+        o_norms = np.linalg.norm(other_embs, axis=1, keepdims=True)
+        o_norms[o_norms == 0] = 1.0
+        sim = (new_embs / n_norms) @ (other_embs / o_norms).T
+
+        links_added = 0
+        with self._lock:
+            for i, meta in enumerate(new_metas):
+                new_tid = int(meta["topic_id"])
+                for j in range(sim.shape[1]):
+                    if float(sim[i, j]) >= self._PROJECTION_THRESHOLD:
+                        other_tid = int(other_metas[j]["topic_id"])
+                        self.conn.execute(
+                            "INSERT OR REPLACE INTO topic_links "
+                            "(from_topic_id, to_topic_id, link_count, link_types) "
+                            "VALUES (?, ?, ?, ?)",
+                            (new_tid, other_tid, 1, '["projection"]'),
+                        )
+                        links_added += 1
+            if links_added:
+                self.conn.commit()
+                _log.info(
+                    "discover_cross_links",
+                    collection=collection_name,
+                    links=links_added,
+                )
 
     # ── Centroid dimension guard (RDR-075 SC-10) ─────────────────────
 

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -590,13 +590,13 @@ class CatalogTaxonomy:
         """Persist inter-topic link pairs from ``compute_topic_links``.
 
         Each dict has from_topic_id, to_topic_id, link_count, link_types.
+        Uses INSERT OR REPLACE — preserves projection links written by
+        ``_discover_cross_links`` (only overwrites matching PK pairs).
         Returns number of rows upserted.
         """
         if not links:
             return 0
         with self._lock:
-            # Clear existing links
-            self.conn.execute("DELETE FROM topic_links")
             for link in links:
                 self.conn.execute(
                     "INSERT OR REPLACE INTO topic_links "
@@ -1096,27 +1096,29 @@ class CatalogTaxonomy:
         o_norms[o_norms == 0] = 1.0
         sim = (new_embs / n_norms) @ (other_embs / o_norms).T
 
-        links_added = 0
-        with self._lock:
-            for i, meta in enumerate(new_metas):
-                new_tid = int(meta["topic_id"])
-                for j in range(sim.shape[1]):
-                    if float(sim[i, j]) >= self._PROJECTION_THRESHOLD:
-                        other_tid = int(other_metas[j]["topic_id"])
-                        self.conn.execute(
-                            "INSERT OR REPLACE INTO topic_links "
-                            "(from_topic_id, to_topic_id, link_count, link_types) "
-                            "VALUES (?, ?, ?, ?)",
-                            (new_tid, other_tid, 1, '["projection"]'),
-                        )
-                        links_added += 1
-            if links_added:
-                self.conn.commit()
-                _log.info(
-                    "discover_cross_links",
-                    collection=collection_name,
-                    links=links_added,
+        # Collect pairs outside the lock (numpy work, no DB access)
+        pairs: list[tuple[int, int]] = []
+        for i, meta in enumerate(new_metas):
+            new_tid = int(meta["topic_id"])
+            for j in range(sim.shape[1]):
+                if float(sim[i, j]) >= self._PROJECTION_THRESHOLD:
+                    other_tid = int(other_metas[j]["topic_id"])
+                    pairs.append((new_tid, other_tid))
+
+        if pairs:
+            with self._lock:
+                self.conn.executemany(
+                    "INSERT OR REPLACE INTO topic_links "
+                    "(from_topic_id, to_topic_id, link_count, link_types) "
+                    "VALUES (?, ?, 1, ?)",
+                    [(a, b, '["projection"]') for a, b in pairs],
                 )
+                self.conn.commit()
+            _log.info(
+                "discover_cross_links",
+                collection=collection_name,
+                links=len(pairs),
+            )
 
     # ── Centroid dimension guard (RDR-075 SC-10) ─────────────────────
 
@@ -1131,8 +1133,9 @@ class CatalogTaxonomy:
         """Return the nearest topic_id for a single embedding.
 
         When *cross_collection* is False (default), queries only centroids
-        for *collection_name*.  When True, queries all centroids regardless
-        of collection — used for cross-collection projection (RDR-075 SC-6).
+        for *collection_name*.  When True, queries only FOREIGN centroids
+        (``$ne collection_name``) — used for cross-collection projection
+        (RDR-075 SC-6).
 
         Returns ``None`` when the centroid collection does not exist, is
         empty, or dimensions mismatch (SC-10).
@@ -1155,7 +1158,9 @@ class CatalogTaxonomy:
             "query_embeddings": [embedding.tolist()],
             "n_results": 1,
         }
-        if not cross_collection:
+        if cross_collection:
+            query_kwargs["where"] = {"collection": {"$ne": collection_name}}
+        else:
             query_kwargs["where"] = {"collection": collection_name}
 
         try:
@@ -1180,8 +1185,9 @@ class CatalogTaxonomy:
         """Assign multiple docs to their nearest topics via centroid ANN.
 
         When *cross_collection* is False (default), queries only centroids
-        for *collection_name*.  When True, queries all centroids — used for
-        cross-collection projection (RDR-075 SC-6).
+        for *collection_name*.  When True, queries only FOREIGN centroids
+        (``$ne collection_name``) — used for cross-collection projection
+        (RDR-075 SC-6).
 
         Returns the number of docs successfully assigned.  No-op (returns 0)
         when centroids don't exist or dimensions mismatch.
@@ -1205,7 +1211,9 @@ class CatalogTaxonomy:
                 return 0
 
         base_kwargs: dict[str, Any] = {"n_results": 1}
-        if not cross_collection:
+        if cross_collection:
+            base_kwargs["where"] = {"collection": {"$ne": collection_name}}
+        else:
             base_kwargs["where"] = {"collection": collection_name}
 
         assigned = 0

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -539,6 +539,14 @@ class CatalogTaxonomy:
             ).fetchall()
         return {r[0]: r[1] for r in rows}
 
+    def get_distinct_collections(self) -> list[str]:
+        """Return sorted list of collections that have at least one topic."""
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT DISTINCT collection FROM topics ORDER BY collection"
+            ).fetchall()
+        return [r[0] for r in rows]
+
     def get_topics_for_collection(
         self,
         collection: str,
@@ -1057,9 +1065,9 @@ class CatalogTaxonomy:
     def generate_cooccurrence_links(self) -> int:
         """Generate topic_links from cross-collection projection co-occurrence.
 
-        For each doc_id assigned to topics in multiple collections,
-        creates a ``topic_links`` entry between each cross-collection
-        topic pair, weighted by co-occurrence count.
+        Uses a SQL self-join to find topic pairs sharing docs across
+        different collections, avoiding loading the full assignment
+        table into Python memory.
 
         Uses ``INSERT OR REPLACE`` to merge with existing projection
         links from ``_discover_cross_links``.
@@ -1067,31 +1075,18 @@ class CatalogTaxonomy:
         Returns count of links generated.
         """
         with self._lock:
-            rows = self.conn.execute(
-                "SELECT ta.doc_id, ta.topic_id, t.collection "
-                "FROM topic_assignments ta "
-                "JOIN topics t ON ta.topic_id = t.id"
+            pairs = self.conn.execute(
+                "SELECT MIN(a.topic_id, b.topic_id), MAX(a.topic_id, b.topic_id), "
+                "       COUNT(*) "
+                "FROM topic_assignments a "
+                "JOIN topic_assignments b ON a.doc_id = b.doc_id "
+                "JOIN topics ta ON a.topic_id = ta.id "
+                "JOIN topics tb ON b.topic_id = tb.id "
+                "WHERE a.topic_id < b.topic_id AND ta.collection != tb.collection "
+                "GROUP BY MIN(a.topic_id, b.topic_id), MAX(a.topic_id, b.topic_id)"
             ).fetchall()
 
-        # Group by doc_id
-        doc_topics: dict[str, list[tuple[int, str]]] = {}
-        for doc_id, topic_id, collection in rows:
-            doc_topics.setdefault(doc_id, []).append((topic_id, collection))
-
-        # For each doc with topics in multiple collections, generate pairs
-        link_counts: dict[tuple[int, int], int] = {}
-        for assignments in doc_topics.values():
-            collections = {coll for _, coll in assignments}
-            if len(collections) < 2:
-                continue
-            for i, (tid_a, coll_a) in enumerate(assignments):
-                for tid_b, coll_b in assignments[i + 1:]:
-                    if coll_a == coll_b:
-                        continue
-                    pair = (min(tid_a, tid_b), max(tid_a, tid_b))
-                    link_counts[pair] = link_counts.get(pair, 0) + 1
-
-        if not link_counts:
+        if not pairs:
             return 0
 
         with self._lock:
@@ -1099,15 +1094,12 @@ class CatalogTaxonomy:
                 "INSERT OR REPLACE INTO topic_links "
                 "(from_topic_id, to_topic_id, link_count, link_types) "
                 "VALUES (?, ?, ?, ?)",
-                [
-                    (a, b, count, '["cooccurrence"]')
-                    for (a, b), count in link_counts.items()
-                ],
+                [(a, b, count, '["cooccurrence"]') for a, b, count in pairs],
             )
             self.conn.commit()
 
-        _log.info("cooccurrence_links", count=len(link_counts))
-        return len(link_counts)
+        _log.info("cooccurrence_links", count=len(pairs))
+        return len(pairs)
 
     # ── Cross-collection centroid linking (RDR-075 Phase 3) ─────────
 
@@ -1273,21 +1265,25 @@ class CatalogTaxonomy:
         else:
             base_kwargs["where"] = {"collection": collection_name}
 
+        # Batch query — single ChromaDB round-trip for all embeddings
+        emb_list = [
+            emb if isinstance(emb, list) else emb.tolist()
+            for emb in embeddings
+        ]
+        try:
+            results = centroid_coll.query(
+                query_embeddings=emb_list,
+                **base_kwargs,
+            )
+        except Exception:
+            return 0
+
+        by = "projection" if cross_collection else "centroid"
         assigned = 0
-        for doc_id, emb in zip(doc_ids, embeddings):
-            try:
-                results = centroid_coll.query(
-                    query_embeddings=[emb if isinstance(emb, list) else emb.tolist()],
-                    **base_kwargs,
-                )
-            except Exception:
+        for i, doc_id in enumerate(doc_ids):
+            if not results["ids"][i]:
                 continue
-
-            if not results["ids"] or not results["ids"][0]:
-                continue
-
-            topic_id = int(results["metadatas"][0][0]["topic_id"])
-            by = "projection" if cross_collection else "centroid"
+            topic_id = int(results["metadatas"][i][0]["topic_id"])
             self.assign_topic(doc_id, topic_id, assigned_by=by)
             assigned += 1
 
@@ -1327,17 +1323,31 @@ class CatalogTaxonomy:
                 "total_centroids": 0,
             }
 
-        src_data = src_coll.get(include=["embeddings"])
-        src_ids = src_data.get("ids", [])
-        src_raw = src_data.get("embeddings")
-        if not src_ids or src_raw is None:
+        # Paginated fetch to avoid OOM on large collections
+        _PAGE = 2000
+        src_ids: list[str] = []
+        src_emb_pages: list[np.ndarray] = []
+        offset = 0
+        while True:
+            page = src_coll.get(include=["embeddings"], limit=_PAGE, offset=offset)
+            page_ids = page.get("ids", [])
+            page_embs = page.get("embeddings")
+            if not page_ids or page_embs is None:
+                break
+            src_ids.extend(page_ids)
+            src_emb_pages.append(np.array(page_embs, dtype=np.float32))
+            if len(page_ids) < _PAGE:
+                break
+            offset += _PAGE
+
+        if not src_ids:
             return {
                 "matched_topics": [],
                 "novel_chunks": [],
                 "total_chunks": 0,
                 "total_centroids": 0,
             }
-        src_embs = np.array(src_raw, dtype=np.float32)
+        src_embs = np.concatenate(src_emb_pages)
 
         # 2. Fetch target centroids
         try:

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -1448,6 +1448,18 @@ class CatalogTaxonomy:
             for s in sorted(topic_stats.values(), key=lambda x: x["chunk_count"], reverse=True)
         ]
 
+        _log.info(
+            "project_against",
+            source=source_collection,
+            targets=len(target_collections),
+            chunks=len(src_ids),
+            centroids=len(ctr_metas),
+            matched_topics=len(matched_topics),
+            novel=len(novel_chunks),
+            assignments=len(chunk_assignments),
+            threshold=threshold,
+        )
+
         return {
             "matched_topics": matched_topics,
             "novel_chunks": novel_chunks,

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -1236,9 +1236,10 @@ class CatalogTaxonomy:
         # 5. Similarity matrix: (N, M) — values in [-1, 1]
         sim = src_norm @ ctr_norm.T
 
-        # 6. Aggregate matched topics
+        # 6. Aggregate matched topics and collect per-chunk assignments
         topic_stats: dict[int, dict[str, Any]] = {}
         novel_chunks: list[str] = []
+        chunk_assignments: list[tuple[str, int]] = []
 
         for i, doc_id in enumerate(src_ids):
             row_max = float(sim[i].max())
@@ -1253,6 +1254,7 @@ class CatalogTaxonomy:
                     break
                 meta = ctr_metas[idx]
                 tid = int(meta["topic_id"])
+                chunk_assignments.append((doc_id, tid))
                 if tid not in topic_stats:
                     topic_stats[tid] = {
                         "topic_id": tid,
@@ -1278,6 +1280,7 @@ class CatalogTaxonomy:
         return {
             "matched_topics": matched_topics,
             "novel_chunks": novel_chunks,
+            "chunk_assignments": chunk_assignments,
             "total_chunks": len(src_ids),
             "total_centroids": len(ctr_metas),
         }

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -1287,7 +1287,8 @@ class CatalogTaxonomy:
                 continue
 
             topic_id = int(results["metadatas"][0][0]["topic_id"])
-            self.assign_topic(doc_id, topic_id, assigned_by="centroid")
+            by = "projection" if cross_collection else "centroid"
+            self.assign_topic(doc_id, topic_id, assigned_by=by)
             assigned += 1
 
         return assigned

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -1048,12 +1048,17 @@ class CatalogTaxonomy:
         collection_name: str,
         embedding: np.ndarray,
         chroma_client: Any,
+        *,
+        cross_collection: bool = False,
     ) -> int | None:
         """Return the nearest topic_id for a single embedding.
 
-        Queries ``taxonomy__centroids`` with collection-scoped nearest-centroid
-        assignment (RF-070-7). Returns ``None`` when the centroid collection
-        does not exist, is empty, or dimensions mismatch (SC-10).
+        When *cross_collection* is False (default), queries only centroids
+        for *collection_name*.  When True, queries all centroids regardless
+        of collection — used for cross-collection projection (RDR-075 SC-6).
+
+        Returns ``None`` when the centroid collection does not exist, is
+        empty, or dimensions mismatch (SC-10).
         """
         try:
             centroid_coll = chroma_client.get_collection(
@@ -1069,14 +1074,17 @@ class CatalogTaxonomy:
         if not _check_centroid_dimension(embedding, centroid_coll):
             return None
 
+        query_kwargs: dict[str, Any] = {
+            "query_embeddings": [embedding.tolist()],
+            "n_results": 1,
+        }
+        if not cross_collection:
+            query_kwargs["where"] = {"collection": collection_name}
+
         try:
-            results = centroid_coll.query(
-                query_embeddings=[embedding.tolist()],
-                n_results=1,
-                where={"collection": collection_name},
-            )
+            results = centroid_coll.query(**query_kwargs)
         except Exception:
-            return None  # No centroids match the collection filter
+            return None  # No centroids match the filter
 
         if not results["ids"] or not results["ids"][0]:
             return None
@@ -1089,14 +1097,17 @@ class CatalogTaxonomy:
         doc_ids: list[str],
         embeddings: list[list[float]],
         chroma_client: Any,
+        *,
+        cross_collection: bool = False,
     ) -> int:
         """Assign multiple docs to their nearest topics via centroid ANN.
 
-        Queries ``taxonomy__centroids`` once for each embedding and bulk-inserts
-        assignments.  Returns the number of docs successfully assigned.
+        When *cross_collection* is False (default), queries only centroids
+        for *collection_name*.  When True, queries all centroids — used for
+        cross-collection projection (RDR-075 SC-6).
 
-        No-op (returns 0) when centroids don't exist or the collection has no
-        centroid entries — callers need not guard.
+        Returns the number of docs successfully assigned.  No-op (returns 0)
+        when centroids don't exist or dimensions mismatch.
         """
         try:
             centroid_coll = chroma_client.get_collection(
@@ -1116,13 +1127,16 @@ class CatalogTaxonomy:
             if not _check_centroid_dimension(sample, centroid_coll):
                 return 0
 
+        base_kwargs: dict[str, Any] = {"n_results": 1}
+        if not cross_collection:
+            base_kwargs["where"] = {"collection": collection_name}
+
         assigned = 0
         for doc_id, emb in zip(doc_ids, embeddings):
             try:
                 results = centroid_coll.query(
                     query_embeddings=[emb if isinstance(emb, list) else emb.tolist()],
-                    n_results=1,
-                    where={"collection": collection_name},
+                    **base_kwargs,
                 )
             except Exception:
                 continue

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -358,10 +358,17 @@ def taxonomy_assign_batch(
                 collection, doc_ids, embeddings, chroma_client,
             )
             # Cross-collection projection (RDR-075 SC-6)
-            db.taxonomy.assign_batch(
+            cross_assigned = db.taxonomy.assign_batch(
                 collection, doc_ids, embeddings, chroma_client,
                 cross_collection=True,
             )
+            if cross_assigned:
+                import structlog
+                structlog.get_logger().debug(
+                    "taxonomy_cross_collection_batch",
+                    collection=collection,
+                    cross_assigned=cross_assigned,
+                )
             return assigned
     except Exception:
         import structlog

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -303,7 +303,8 @@ def _run_taxonomy_assign(doc_id, collection, content, taxonomy, chroma_client):
             if emb is not None and len(emb) > 0:
                 embedding = np.array(emb, dtype=np.float32)
     except Exception:
-        pass  # Fall through to MiniLM
+        import structlog
+        structlog.get_logger().debug("taxonomy_t3_embedding_fetch_failed", doc_id=doc_id, exc_info=True)
 
     if embedding is None:
         from nexus.db.local_ef import LocalEmbeddingFunction
@@ -352,9 +353,16 @@ def taxonomy_assign_batch(
     try:
         with t2_ctx() as db:
             chroma_client = get_t3()._client
-            return db.taxonomy.assign_batch(
+            # Same-collection assignment
+            assigned = db.taxonomy.assign_batch(
                 collection, doc_ids, embeddings, chroma_client,
             )
+            # Cross-collection projection (RDR-075 SC-6)
+            db.taxonomy.assign_batch(
+                collection, doc_ids, embeddings, chroma_client,
+                cross_collection=True,
+            )
+            return assigned
     except Exception:
         import structlog
         structlog.get_logger().debug("taxonomy_assign_batch_failed", exc_info=True)

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -311,9 +311,17 @@ def _run_taxonomy_assign(doc_id, collection, content, taxonomy, chroma_client):
         ef = LocalEmbeddingFunction(model_name="all-MiniLM-L6-v2")
         embedding = np.array(ef([content])[0], dtype=np.float32)
 
+    # Same-collection assignment (existing behavior)
     topic_id = taxonomy.assign_single(collection, embedding, chroma_client)
     if topic_id is not None:
         taxonomy.assign_topic(doc_id, topic_id, assigned_by="centroid")
+
+    # Cross-collection projection (RDR-075 SC-4, SC-6)
+    cross_topic_id = taxonomy.assign_single(
+        collection, embedding, chroma_client, cross_collection=True,
+    )
+    if cross_topic_id is not None and cross_topic_id != topic_id:
+        taxonomy.assign_topic(doc_id, cross_topic_id, assigned_by="projection")
 
 
 def taxonomy_assign_batch(

--- a/src/nexus/registry.py
+++ b/src/nexus/registry.py
@@ -91,6 +91,42 @@ def _rdr_collection_name(repo: Path) -> str:
     return _safe_collection("rdr__", name, path_hash)
 
 
+def list_sibling_collections(
+    collection_name: str,
+    t3_client: Any,
+) -> list[str]:
+    """Return all T3 collections sharing the same repo identity suffix.
+
+    For ``docs__art-architecture-8c2e74c0``, returns all collections whose
+    name ends with ``-8c2e74c0``, excluding the input and ``taxonomy__*``.
+
+    Limitation: ``knowledge__*`` collections without a ``{hash8}`` suffix
+    are not detected — use explicit ``--against`` for those.
+    """
+    # Extract hash8 suffix: last 8 chars after the final hyphen
+    parts = collection_name.rsplit("-", 1)
+    if len(parts) != 2 or len(parts[1]) != 8:
+        return []
+    hash8 = parts[1]
+
+    try:
+        all_colls = t3_client.list_collections()
+    except Exception:
+        return []
+
+    siblings = []
+    for coll in all_colls:
+        name = coll.name if hasattr(coll, "name") else str(coll)
+        if name == collection_name:
+            continue
+        if name.startswith("taxonomy__"):
+            continue
+        if name.endswith(f"-{hash8}"):
+            siblings.append(name)
+
+    return sorted(siblings)
+
+
 class RepoRegistry:
     """Thread-safe registry of indexed repositories stored as JSON."""
 

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -311,6 +311,69 @@ def test_assign_single_cross_collection_isolation(
     assert result is None, "assign_single must not cross collection boundaries"
 
 
+def test_assign_single_cross_collection_finds_foreign_topic(
+    db: T2Database, chroma_client: chromadb.ClientAPI,
+) -> None:
+    """assign_single with cross_collection=True returns topics from other collections."""
+    rng = np.random.default_rng(42)
+    # Create topics in collection A
+    embeddings = rng.standard_normal((60, 384)).astype(np.float32) * 0.1
+    embeddings[:30, 0] += 3.0
+    embeddings[30:, 1] += 3.0
+    doc_ids = [f"doc-{i}" for i in range(60)]
+    texts = [f"text {i}" for i in range(60)]
+    db.taxonomy.discover_topics("coll_A_xc", doc_ids, embeddings, texts, chroma_client)
+
+    # Query from collection B with cross_collection=True — should find A's topics
+    new_emb = rng.standard_normal(384).astype(np.float32) * 0.1
+    new_emb[0] += 3.0
+    result = db.taxonomy.assign_single(
+        "coll_B_xc", new_emb, chroma_client, cross_collection=True,
+    )
+    assert result is not None, "cross_collection=True should find topics from other collections"
+
+    # Confirm default (False) still isolates
+    result_isolated = db.taxonomy.assign_single(
+        "coll_B_xc", new_emb, chroma_client, cross_collection=False,
+    )
+    assert result_isolated is None, "cross_collection=False must not cross boundaries"
+
+
+def test_assign_batch_cross_collection(
+    db: T2Database, chroma_client: chromadb.ClientAPI,
+) -> None:
+    """assign_batch with cross_collection=True assigns from foreign centroids."""
+    rng = np.random.default_rng(42)
+    embeddings = rng.standard_normal((60, 384)).astype(np.float32) * 0.1
+    embeddings[:30, 0] += 3.0
+    embeddings[30:, 1] += 3.0
+    db.taxonomy.discover_topics(
+        "batch_A_xc",
+        [f"doc-{i}" for i in range(60)],
+        embeddings,
+        [f"text {i}" for i in range(60)],
+        chroma_client,
+    )
+
+    # New batch from collection B
+    new_embs = rng.standard_normal((3, 384)).astype(np.float32) * 0.1
+    new_embs[:, 0] += 3.0
+    new_ids = ["xc-0", "xc-1", "xc-2"]
+
+    assigned = db.taxonomy.assign_batch(
+        "batch_B_xc", new_ids, new_embs.tolist(), chroma_client,
+        cross_collection=True,
+    )
+    assert assigned == 3
+
+    # Default should assign 0 (no centroids for batch_B_xc)
+    assigned_isolated = db.taxonomy.assign_batch(
+        "batch_B_xc", ["iso-0"], new_embs[:1].tolist(), chroma_client,
+        cross_collection=False,
+    )
+    assert assigned_isolated == 0
+
+
 def test_assign_batch_assigns_multiple_docs(
     db: T2Database, chroma_client: chromadb.ClientAPI,
 ) -> None:

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -2461,6 +2461,73 @@ class TestComputeTopicLinks:
         assert set(result[0]["link_types"]) == {"cites", "implements"}
 
 
+class TestCooccurrenceLinks:
+    """Tests for generate_cooccurrence_links (RDR-075 SC-5)."""
+
+    def test_cross_collection_cooccurrence(self, db: T2Database) -> None:
+        """Docs assigned to topics in different collections generate links."""
+        # Create topics in two collections
+        db.taxonomy.conn.executemany(
+            "INSERT INTO topics (label, collection, doc_count, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            [
+                ("neural-nets", "coll_A", 5, "2026-01-01T00:00:00Z"),
+                ("databases", "coll_B", 5, "2026-01-01T00:00:00Z"),
+            ],
+        )
+        t1 = db.taxonomy.conn.execute(
+            "SELECT id FROM topics WHERE label = 'neural-nets'"
+        ).fetchone()[0]
+        t2 = db.taxonomy.conn.execute(
+            "SELECT id FROM topics WHERE label = 'databases'"
+        ).fetchone()[0]
+
+        # Assign one doc to topics in both collections
+        db.taxonomy.conn.executemany(
+            "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by) "
+            "VALUES (?, ?, ?)",
+            [
+                ("doc-shared", t1, "centroid"),
+                ("doc-shared", t2, "projection"),
+            ],
+        )
+        db.taxonomy.conn.commit()
+
+        count = db.taxonomy.generate_cooccurrence_links()
+        assert count == 1
+
+        rows = db.taxonomy.conn.execute(
+            "SELECT from_topic_id, to_topic_id, link_count FROM topic_links"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][2] == 1  # link_count
+
+    def test_same_collection_no_links(self, db: T2Database) -> None:
+        """Docs assigned to topics in the SAME collection don't generate links."""
+        db.taxonomy.conn.executemany(
+            "INSERT INTO topics (label, collection, doc_count, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            [
+                ("topic-x", "same_coll", 5, "2026-01-01T00:00:00Z"),
+                ("topic-y", "same_coll", 5, "2026-01-01T00:00:00Z"),
+            ],
+        )
+        t1 = db.taxonomy.conn.execute(
+            "SELECT id FROM topics WHERE label = 'topic-x'"
+        ).fetchone()[0]
+        t2 = db.taxonomy.conn.execute(
+            "SELECT id FROM topics WHERE label = 'topic-y'"
+        ).fetchone()[0]
+        db.taxonomy.conn.executemany(
+            "INSERT INTO topic_assignments (doc_id, topic_id) VALUES (?, ?)",
+            [("doc-same", t1), ("doc-same", t2)],
+        )
+        db.taxonomy.conn.commit()
+
+        count = db.taxonomy.generate_cooccurrence_links()
+        assert count == 0
+
+
 class TestTopicLinksCLI:
     """CLI tests for nx taxonomy links."""
 

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -3049,3 +3049,37 @@ class TestProjectCmd:
 
         assert result.exit_code == 0
         assert "persisted" in result.output.lower()
+
+
+class TestListSiblingCollections:
+    """Tests for list_sibling_collections (RDR-075 SC-8)."""
+
+    def test_finds_siblings_by_hash8(self, chroma_client: chromadb.ClientAPI) -> None:
+        from nexus.registry import list_sibling_collections
+
+        # Create collections with shared hash suffix
+        chroma_client.get_or_create_collection("code__myrepo-abc12345")
+        chroma_client.get_or_create_collection("docs__myrepo-abc12345")
+        chroma_client.get_or_create_collection("rdr__myrepo-abc12345")
+        chroma_client.get_or_create_collection("code__other-def67890")
+
+        siblings = list_sibling_collections("code__myrepo-abc12345", chroma_client)
+        assert "docs__myrepo-abc12345" in siblings
+        assert "rdr__myrepo-abc12345" in siblings
+        assert "code__myrepo-abc12345" not in siblings  # excludes self
+        assert "code__other-def67890" not in siblings  # different hash
+
+    def test_excludes_taxonomy_collections(self, chroma_client: chromadb.ClientAPI) -> None:
+        from nexus.registry import list_sibling_collections
+
+        chroma_client.get_or_create_collection("code__repo-aaa11111")
+        chroma_client.get_or_create_collection("taxonomy__centroids-aaa11111")
+
+        siblings = list_sibling_collections("code__repo-aaa11111", chroma_client)
+        assert not any(s.startswith("taxonomy__") for s in siblings)
+
+    def test_no_hash_suffix_returns_empty(self, chroma_client: chromadb.ClientAPI) -> None:
+        from nexus.registry import list_sibling_collections
+
+        siblings = list_sibling_collections("knowledge__art", chroma_client)
+        assert siblings == []

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -428,10 +428,16 @@ def test_project_against_basic(
 
     assert "matched_topics" in result
     assert "novel_chunks" in result
+    assert "chunk_assignments" in result
     assert "total_chunks" in result
     assert result["total_chunks"] == 20
     # With threshold=0.5 and clearly separated clusters, most chunks should match
     assert len(result["matched_topics"]) > 0
+    # Invariant: novel + covered == total
+    covered = result["total_chunks"] - len(result["novel_chunks"])
+    assert covered + len(result["novel_chunks"]) == result["total_chunks"]
+    # chunk_assignments has entries for covered chunks
+    assert len(result["chunk_assignments"]) > 0
 
 
 def test_project_against_empty_target(


### PR DESCRIPTION
## Summary

Completes RDR-075 implementation (Phases 3-5, building on Phase 2 merged in PR #156).

- **Phase 3**: `cross_collection` parameter on `assign_single`/`assign_batch` with `$ne` filter for foreign centroids. Hook wiring in `_run_taxonomy_assign` for automatic cross-collection projection on every `store_put`. Discover post-pass (`_discover_cross_links`) for centroid-to-centroid similarity. Pipeline wiring in `index repo` and `discover --all`.
- **Phase 4**: `generate_cooccurrence_links()` — creates topic_links from docs assigned to topics in multiple collections. Wired into `index repo` pipeline.
- **Phase 5**: `list_sibling_collections()` in registry.py. Default `--against` to sibling collections. `backfill_projection()` T3UpgradeStep + T3 execution loop in `upgrade.py` (closes the TODO).

## Review fixes applied

- Removed `_persist_projections` duplication (double fetch+matmul)
- `upsert_topic_links` no longer DELETEs all rows before inserting
- `cross_collection=True` uses `$ne` (foreign only), not unscoped
- `_discover_cross_links` uses `executemany` outside lock
- `_persist_assignments` has `quiet` parameter for pipeline context
- `project_cmd` uses `try/finally` for `db.close()`

## Test plan

- [x] 111 taxonomy tests pass (zero regressions)
- [x] 174 related tests pass (taxonomy + migrations + upgrade)
- [x] New tests: cross_collection assign (2), cooccurrence links (2), sibling collections (3), project CLI (2), dimension mismatch (2)

## Beads closed

nexus-20w, nexus-d1q, nexus-bo4, nexus-1sb, nexus-88e, nexus-70u, nexus-jq7, nexus-rw6, nexus-cjf, nexus-ek8, nexus-13u, nexus-78i + epic nexus-7zy (auto-closed)