### PR TITLE
fix(nexus-2my): rewrite-metadata CLI + drop empty bib_* + git_meta in PDF/markdown ingest

### DIFF
--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -358,3 +358,79 @@ def backfill_hash_cmd(name: str | None, all_collections: bool) -> None:
             click.echo(f"  [{i}/{len(targets)}] {col_name}: all {total_count} chunks already have hash")
 
     click.echo(f"Done: {grand_updated} chunks updated across {len(targets)} collection(s)")
+
+
+@collection.command("rewrite-metadata")
+@click.argument("name", required=False, default=None)
+@click.option("--all", "all_collections", is_flag=True,
+              help="Rewrite metadata in every T3 collection.")
+@click.option("--source-path", default=None,
+              help="Only rewrite chunks whose source_path equals this value.")
+@click.option("--dry-run", is_flag=True,
+              help="Report counts without issuing any writes.")
+def rewrite_metadata_cmd(
+    name: str | None,
+    all_collections: bool,
+    source_path: str | None,
+    dry_run: bool,
+) -> None:
+    """Rewrite each chunk's metadata to the canonical schema (nexus-2my).
+
+    Operationalises the nexus-40t metadata schema rationalisation on
+    already-indexed corpora. Chunks ingested before 4.3.1 keep their
+    pre-canonical metadata (cargo keys, flat git_*, oversized records)
+    until this command is run; ``nx index --force`` is a silent no-op
+    when the pipeline-state DB still has the content_hash on file.
+
+    \\b
+    Examples:
+      nx collection rewrite-metadata knowledge__delos
+      nx collection rewrite-metadata knowledge__delos --source-path paper.pdf
+      nx collection rewrite-metadata --all --dry-run
+    """
+    from nexus.db.t3 import _rewrite_collection_metadata
+
+    if not name and not all_collections:
+        raise click.ClickException("specify a collection name or use --all")
+    if name and all_collections:
+        raise click.ClickException("--all is mutually exclusive with NAME")
+
+    db = _t3()
+    targets = (
+        sorted(c["name"] for c in db.list_collections())
+        if all_collections else [name]
+    )
+
+    grand_updated = 0
+    grand_skipped = 0
+    grand_total = 0
+    for i, col_name in enumerate(targets, 1):
+        try:
+            updated, skipped, total = _rewrite_collection_metadata(
+                db, col_name,
+                source_path=source_path,
+                dry_run=dry_run,
+            )
+        except Exception as exc:
+            click.echo(
+                f"  [{i}/{len(targets)}] {col_name}: "
+                f"{type(exc).__name__}: {exc}",
+                err=True,
+            )
+            continue
+
+        grand_updated += updated
+        grand_skipped += skipped
+        grand_total += total
+        verb = "would rewrite" if dry_run else "rewrote"
+        click.echo(
+            f"  [{i}/{len(targets)}] {col_name}: {verb} {updated}, "
+            f"skipped {skipped} (already canonical), {total} scanned"
+        )
+
+    verb = "Would rewrite" if dry_run else "Rewrote"
+    click.echo(
+        f"Done: {verb} {grand_updated} chunks "
+        f"({grand_skipped} already canonical, {grand_total} scanned) "
+        f"across {len(targets)} collection(s)."
+    )

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -71,6 +71,82 @@ def _normalize_for_write(metadata: dict, collection_name: str) -> dict:
     return normalize(metadata, content_type=content_type)
 
 
+def _rewrite_collection_metadata(
+    t3_db: T3Database,
+    collection_name: str,
+    *,
+    source_path: str | None = None,
+    dry_run: bool = False,
+) -> tuple[int, int, int]:
+    """Rewrite every chunk's metadata to the canonical schema (nexus-2my).
+
+    Paginates ``col.get(limit=300)`` over the collection, normalises each
+    record's metadata via :func:`_normalize_for_write`, and writes back via
+    :meth:`T3Database.update_chunks` (which validates the canonical
+    output a second time as defense-in-depth).
+
+    Returns ``(updated, skipped, total)``:
+
+      * ``updated`` — chunks whose canonicalised metadata differs from
+        the stored value (``dry_run`` reports what *would* be written).
+      * ``skipped`` — chunks already in canonical shape; no write issued.
+      * ``total`` — chunks scanned.
+
+    Required follow-up to nexus-40t (PR #164): the original fix only
+    constrains *new* writes. Already-indexed corpora keep their pre-4.3.1
+    metadata until this command is run. Unblocks ART by sidestepping the
+    pipeline-state staleness short-circuit on ``--force``.
+    """
+    page = QUOTAS.MAX_RECORDS_PER_WRITE  # 300, dual-purpose: read page + write batch
+
+    # ChromaDB's ``where=`` is the cleanest filter — falls back to a
+    # post-loop equality check when no source_path is requested.
+    where_clause: dict | None = (
+        {"source_path": source_path} if source_path else None
+    )
+
+    col = t3_db.get_or_create_collection(collection_name)
+    updated = skipped = total = 0
+    offset = 0
+
+    while True:
+        if where_clause is not None:
+            batch = _chroma_with_retry(
+                col.get, where=where_clause, include=["metadatas"],
+                limit=page, offset=offset,
+            )
+        else:
+            batch = _chroma_with_retry(
+                col.get, include=["metadatas"], limit=page, offset=offset,
+            )
+        ids = batch.get("ids") or []
+        metas = batch.get("metadatas") or []
+        if not ids:
+            break
+
+        rewrite_ids: list[str] = []
+        rewrite_metas: list[dict] = []
+        for chunk_id, meta in zip(ids, metas):
+            total += 1
+            current = dict(meta or {})
+            canonical = _normalize_for_write(current, collection_name)
+            if canonical == current:
+                skipped += 1
+                continue
+            updated += 1
+            rewrite_ids.append(chunk_id)
+            rewrite_metas.append(canonical)
+
+        if rewrite_ids and not dry_run:
+            t3_db.update_chunks(collection_name, rewrite_ids, rewrite_metas)
+
+        if len(ids) < page:
+            break
+        offset += len(ids)
+
+    return updated, skipped, total
+
+
 # Deprecated: no internal callers remain after RDR-037. Kept for one release
 # cycle in case external scripts import it. Will be removed in next major version.
 _STORE_TYPES: tuple[str, ...] = ("code", "docs", "rdr", "knowledge")

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -504,6 +504,7 @@ def _pdf_chunks(
     chunk_chars: int | None = None,
     bib_enrich_enabled: bool = False,
     extractor: str = "auto",
+    git_meta: dict | None = None,
 ) -> list[tuple[str, str, dict]]:
     """Chunk a PDF and return (id, text, metadata) tuples.
 
@@ -517,7 +518,17 @@ def _pdf_chunks(
 
     *extractor* selects the PDF extraction backend (``"auto"``, ``"docling"``,
     or ``"mineru"``).
+
+    *git_meta* — flat ``git_*`` provenance dict. When ``None`` the function
+    auto-detects via :func:`nexus.indexer_utils.detect_git_metadata` from
+    ``pdf_path``. Pass an explicit value when the caller has already
+    resolved it (the repo-walk path does this once per repo). Empty dict
+    when *pdf_path* is not in a git repository — :func:`normalize` then
+    omits ``git_meta`` per the empty-set rule (nexus-2my fix #3).
     """
+    if git_meta is None:
+        from nexus.indexer_utils import detect_git_metadata
+        git_meta = detect_git_metadata(pdf_path)
     result = PDFExtractor().extract(pdf_path, extractor=extractor)
     chunker = PDFChunker(chunk_chars=chunk_chars) if chunk_chars is not None else PDFChunker()
     chunks = chunker.chunk(result.text, result.metadata)
@@ -575,6 +586,7 @@ def _pdf_chunks(
             "bib_citation_count": bib.get("citation_count", 0),
             "bib_semantic_scholar_id": bib.get("semantic_scholar_id", ""),
             "chunk_text_hash": hashlib.sha256(chunk.text.encode()).hexdigest(),
+            **{k: v for k, v in git_meta.items() if v},
         }
         prepared.append((chunk_id, chunk.text, meta))
     return prepared
@@ -588,9 +600,20 @@ def _markdown_chunks(
     corpus: str,
     *,
     base_path: Path | None = None,
+    git_meta: dict | None = None,
 ) -> list[tuple[str, str, dict]]:
-    """Chunk a Markdown file and return (id, text, metadata) tuples."""
+    """Chunk a Markdown file and return (id, text, metadata) tuples.
+
+    *git_meta* — flat ``git_*`` provenance dict. ``None`` triggers
+    auto-detection from *md_path* via
+    :func:`nexus.indexer_utils.detect_git_metadata`. Empty dict outside
+    a git repo (nexus-2my fix #3).
+    """
     from nexus.catalog.catalog import make_relative
+
+    if git_meta is None:
+        from nexus.indexer_utils import detect_git_metadata
+        git_meta = detect_git_metadata(md_path)
 
     raw_text = md_path.read_text(encoding="utf-8")
     frontmatter, body = parse_frontmatter(raw_text)
@@ -629,6 +652,7 @@ def _markdown_chunks(
             "indexed_at": now_iso,
             "content_hash": content_hash,
             "chunk_text_hash": hashlib.sha256(chunk.text.encode()).hexdigest(),
+            **{k: v for k, v in git_meta.items() if v},
         }
         prepared.append((chunk_id, chunk.text, meta))
     return prepared

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -45,6 +45,43 @@ def find_repo_root(path: Path) -> Path | None:
     return None
 
 
+def detect_git_metadata(path: Path) -> dict[str, str]:
+    """Return git provenance metadata for the repo containing *path*.
+
+    Walks up via :func:`find_repo_root`, then collects:
+
+      * ``git_project_name`` — basename of the repo root
+      * ``git_branch`` — current branch name
+      * ``git_commit_hash`` — full SHA of HEAD
+      * ``git_remote_url`` — ``origin`` URL (empty when no remote)
+
+    Returns an empty dict when *path* is not inside a git repository
+    so callers can ``**``-merge the result without conditional logic.
+    Indexer-side code (PDF / markdown / pipeline) needs this so chunks
+    carry the same provenance the repo-walk path gets via
+    ``indexer._git_metadata`` (nexus-2my fix #3).
+    """
+    repo = find_repo_root(path)
+    if repo is None:
+        return {}
+
+    def _run(args: list[str]) -> str:
+        try:
+            r = subprocess.run(
+                args, cwd=repo, capture_output=True, text=True, timeout=10,
+            )
+        except Exception:
+            return ""
+        return r.stdout.strip() if r.returncode == 0 else ""
+
+    return {
+        "git_project_name": repo.name,
+        "git_branch": _run(["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+        "git_commit_hash": _run(["git", "rev-parse", "HEAD"]),
+        "git_remote_url": _run(["git", "remote", "get-url", "origin"]),
+    }
+
+
 def should_ignore(rel_path: Path, patterns: list[str]) -> bool:
     """Return True if any component of *rel_path* matches any of *patterns*."""
     for part in rel_path.parts:

--- a/src/nexus/metadata_schema.py
+++ b/src/nexus/metadata_schema.py
@@ -106,6 +106,15 @@ _GIT_FIELD_MAP: dict[str, str] = {
     "git_remote_url": "remote",
 }
 
+#: Bibliographic slots. All four are dropped together when every value
+#: is the placeholder (``0`` or ``""``) — without ``--enrich`` they are
+#: pure cargo eating metadata budget (nexus-2my fix #2). When at least
+#: one slot is populated the full set rides along so the search/display
+#: contract stays uniform.
+_BIB_FIELDS: tuple[str, ...] = (
+    "bib_year", "bib_authors", "bib_venue", "bib_citation_count",
+)
+
 #: Primitive value types accepted by ChromaDB metadata.
 _PRIMITIVE_TYPES: tuple[type, ...] = (str, int, float, bool, type(None))
 
@@ -132,6 +141,9 @@ def normalize(raw: dict[str, Any], *, content_type: str) -> dict[str, Any]:
     3. Pack every populated ``git_*`` field into a single ``git_meta``
        JSON string (omit entirely when all four are empty, saving a slot).
     4. Drop cargo keys — anything outside :data:`ALLOWED_TOP_LEVEL`.
+       Then drop the four ``bib_*`` slots together when every value is
+       the placeholder (``0`` / ``""``) — consistent with the
+       git_meta-omitted-when-empty pattern.
     5. Inject ``content_type`` so routing code has a single canonical
        field to read.
 
@@ -168,6 +180,15 @@ def normalize(raw: dict[str, Any], *, content_type: str) -> dict[str, Any]:
 
     # Step 4: drop cargo.
     normalised = {k: v for k, v in working.items() if k in ALLOWED_TOP_LEVEL}
+
+    # Step 4b: drop the bib_* placeholder set when every slot is empty.
+    # When ``--enrich`` is off the indexer writes the four bib_* keys
+    # with ``0`` / ``""`` defaults; without this filter they consume four
+    # metadata slots for no payload (nexus-2my fix #2). Mirrors the
+    # git_meta-omitted-when-empty pattern.
+    if not any(normalised.get(field) for field in _BIB_FIELDS):
+        for field in _BIB_FIELDS:
+            normalised.pop(field, None)
 
     # Step 3 (cont.): write git_meta only when at least one field has
     # a truthy value.

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -125,14 +125,21 @@ def _build_chunk_metadata(
     embedding_model: str,
     chunk_count: int,
     now_iso: str,
+    git_meta: dict | None = None,
 ) -> dict:
     """Build chunk metadata with fields known at chunk time.
 
     Extraction-dependent fields (source_title, source_author, extraction_method,
     format, page_count, is_image_pdf, has_formulas) are set to defaults here
     and corrected by the metadata post-pass after extraction completes.
+
+    *git_meta* — flat ``git_*`` provenance dict (nexus-2my fix #3). Caller
+    resolves once via :func:`nexus.indexer_utils.detect_git_metadata` and
+    passes through to keep per-chunk overhead at zero. Empty dict when
+    *pdf_path* is not in a git repo.
     """
-    return {
+    base_git = {k: v for k, v in (git_meta or {}).items() if v}
+    return {**base_git,
         "source_path": pdf_path,
         "source_title": "",       # post-pass: from ExtractionResult
         "source_author": "",      # post-pass: from ExtractionResult
@@ -179,6 +186,7 @@ def _embed_and_write_batch(
     target_model: str,
     chunk_count: int,
     now_iso: str,
+    git_meta: dict | None = None,
 ) -> tuple[int, str]:
     """Embed and write a batch of chunks. Returns (count_written, actual_model)."""
     if not chunks_to_embed:
@@ -213,6 +221,7 @@ def _embed_and_write_batch(
             embedding_model=actual_model,
             chunk_count=chunk_count,
             now_iso=now_iso,
+            git_meta=git_meta,
         )
         db.write_chunk(content_hash, chunk.chunk_index, chunk.text, chunk_id,
                         metadata=meta, embedding=emb_bytes)
@@ -232,6 +241,7 @@ def chunker_loop(
     pdf_path: str = "",
     corpus: str = "",
     target_model: str = "voyage-context-3",
+    git_meta: dict | None = None,
 ) -> None:
     """Incrementally chunk pages as they arrive, overlapping with extraction.
 
@@ -320,7 +330,7 @@ def chunker_loop(
 
         batch_kwargs = dict(
             pdf_path=pdf_path, corpus=corpus, target_model=current_model,
-            now_iso=now_iso,
+            now_iso=now_iso, git_meta=git_meta,
         )
 
         if is_final:
@@ -502,6 +512,7 @@ def pipeline_index_pdf(
     extractor: str = "auto",
     corpus: str = "",
     target_model: str = "voyage-context-3",
+    git_meta: dict | None = None,
 ) -> int:
     """Three-stage streaming pipeline for PDFs.
 
@@ -520,6 +531,13 @@ def pipeline_index_pdf(
 
     # Normalize to absolute so staleness checks are path-form-independent.
     pdf_path = pdf_path.resolve()
+
+    # Resolve git provenance once at the entrypoint so chunker_loop and
+    # _build_chunk_metadata can stamp every chunk without re-detecting
+    # (nexus-2my fix #3).
+    if git_meta is None:
+        from nexus.indexer_utils import detect_git_metadata
+        git_meta = detect_git_metadata(pdf_path)
 
     # Pre-flight: check if pipeline should run before resolving credentials.
     result = db.create_pipeline(content_hash, str(pdf_path), collection)
@@ -553,6 +571,7 @@ def pipeline_index_pdf(
             chunker_loop, content_hash, db, cancel, embed_fn,
             extraction_done=extraction_done, chunking_done=chunking_done,
             pdf_path=str(pdf_path), corpus=corpus, target_model=target_model,
+            git_meta=git_meta,
         )
         upload_future = pool.submit(
             uploader_loop, content_hash, db, t3, collection, cancel,

--- a/tests/test_collection_rewrite_metadata.py
+++ b/tests/test_collection_rewrite_metadata.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""TDD tests for ``nx collection rewrite-metadata`` (nexus-2my fix #1).
+
+Operationalises the nexus-40t metadata schema rationalisation on
+already-indexed corpora. Without this, chunks ingested before the
+4.3.1 release keep their pre-canonical metadata until they are
+deleted and re-ingested — and `--force` is a silent no-op when the
+pipeline-state DB still has the content_hash on file.
+
+Covers:
+  * Legacy chunks with cargo keys (``store_type``, ``indexed_at``,
+    flat ``git_*``) get normalised in place via ``t3.update_chunks``
+    so the metadata-schema validator runs and the canonical key set
+    lands.
+  * Chunks already in canonical shape are skipped (no spurious
+    update). ``--dry-run`` reports counts without touching writes.
+  * ``--source-path PATH`` filter narrows the rewrite scope to one
+    document.
+  * Pagination handles collections that exceed the 300-row Chroma
+    Cloud cap.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ── _rewrite_collection_metadata helper ─────────────────────────────────────
+
+
+def _legacy_meta(**overrides):
+    """Mock chunk metadata in the pre-4.3.1 shape."""
+    base = {
+        "source_path": "p.pdf",
+        "content_hash": "abc",
+        "chunk_text_hash": "def",
+        "chunk_index": 0,
+        "chunk_count": 1,
+        "store_type": "pdf",
+        "indexed_at": "2026-01-01T00:00:00+00:00",  # cargo
+        "format": "pdf",                             # cargo
+        "extraction_method": "docling",              # cargo
+        "page_count": 5,                             # cargo
+        "git_project_name": "myproj",                # → git_meta
+        "git_branch": "main",                        # → git_meta
+        "git_commit_hash": "deadbeef",               # → git_meta
+        "git_remote_url": "https://example.com",     # → git_meta
+        "bib_year": 0,                               # cargo (after fix #2 — keep here for fix #1 baseline)
+        "bib_authors": "",
+        "bib_venue": "",
+        "bib_citation_count": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_t3_mock(collection_name: str, chunks: list[dict]) -> tuple:
+    """Build a mock ``T3Database`` whose ``get_or_create_collection`` returns
+    a collection backed by *chunks*.
+
+    Returns ``(t3, mock_col)`` so tests can assert against the col's
+    captured ``update`` calls.
+    """
+    from nexus.db.t3 import T3Database
+
+    db = T3Database.__new__(T3Database)  # bypass __init__ network calls
+    db._local_mode = True
+    db._write_sems = {}
+    db._read_sems = {}
+    db._sems_lock = MagicMock()
+    db._sems_lock.__enter__ = lambda self_: None
+    db._sems_lock.__exit__ = lambda *args: None
+
+    mock_col = MagicMock()
+    ids = [f"id-{i}" for i in range(len(chunks))]
+
+    def _get(limit=300, offset=0, include=None, where=None):
+        # Filter by where if provided (only equality on source_path supported here).
+        filt_chunks = chunks
+        filt_ids = ids
+        if where:
+            keep = [
+                (i, m) for i, m in zip(ids, chunks)
+                if all(m.get(k) == v for k, v in where.items())
+            ]
+            filt_ids = [i for i, _ in keep]
+            filt_chunks = [m for _, m in keep]
+        page_ids = filt_ids[offset:offset + limit]
+        page_metas = filt_chunks[offset:offset + limit]
+        return {"ids": page_ids, "metadatas": page_metas}
+
+    mock_col.get.side_effect = _get
+    db.get_or_create_collection = MagicMock(return_value=mock_col)
+    db._client_for = MagicMock(return_value=MagicMock(
+        get_or_create_collection=MagicMock(return_value=mock_col),
+    ))
+
+    # update_chunks needs a write semaphore; stub the lock context.
+    sem = MagicMock()
+    sem.__enter__ = lambda self_: None
+    sem.__exit__ = lambda *args: None
+    db._write_sem = MagicMock(return_value=sem)
+    return db, mock_col
+
+
+# ── Behaviour ───────────────────────────────────────────────────────────────
+
+
+def test_rewrite_drops_cargo_and_packs_git_meta() -> None:
+    """A legacy chunk with flat git_* + cargo keys becomes canonical
+    (git_meta JSON; no store_type/indexed_at/format/etc. dropped)."""
+    from nexus.db.t3 import _rewrite_collection_metadata
+
+    chunks = [_legacy_meta()]
+    db, mock_col = _make_t3_mock("knowledge__delos", chunks)
+
+    updated, skipped, total = _rewrite_collection_metadata(
+        db, "knowledge__delos",
+    )
+
+    assert total == 1
+    assert updated == 1
+    assert skipped == 0
+
+    # The col.update call carries the canonicalised metadata.
+    written = mock_col.update.call_args.kwargs["metadatas"][0]
+    assert "git_meta" in written
+    import json as _j
+    assert _j.loads(written["git_meta"])["project"] == "myproj"
+    assert "git_project_name" not in written
+    assert "indexed_at" not in written
+    assert "format" not in written
+    assert "extraction_method" not in written
+    assert written["content_type"]  # injected
+
+
+def test_rewrite_skips_already_canonical_chunks() -> None:
+    """A chunk that's already canonical produces no col.update call."""
+    from nexus.db.t3 import _rewrite_collection_metadata
+    from nexus.metadata_schema import normalize
+
+    canonical = normalize({
+        "source_path": "p.pdf",
+        "content_hash": "abc",
+        "chunk_text_hash": "def",
+        "chunk_index": 0,
+        "chunk_count": 1,
+    }, content_type="prose")
+
+    db, mock_col = _make_t3_mock("docs__corpus", [canonical])
+
+    updated, skipped, total = _rewrite_collection_metadata(
+        db, "docs__corpus",
+    )
+
+    assert total == 1
+    assert updated == 0
+    assert skipped == 1
+    mock_col.update.assert_not_called()
+
+
+def test_rewrite_idempotent() -> None:
+    """Two passes: first writes, second is a no-op."""
+    from nexus.db.t3 import _rewrite_collection_metadata
+    from nexus.metadata_schema import normalize
+
+    chunks = [_legacy_meta()]
+    db, mock_col = _make_t3_mock("knowledge__delos", chunks)
+
+    _rewrite_collection_metadata(db, "knowledge__delos")
+    # Mutate the in-memory chunks list to reflect the rewrite, simulating
+    # what would be true on a real second pass.
+    chunks[0] = normalize(chunks[0], content_type="prose")
+    mock_col.update.reset_mock()
+
+    updated, skipped, total = _rewrite_collection_metadata(
+        db, "knowledge__delos",
+    )
+    assert updated == 0
+    assert skipped == 1
+    mock_col.update.assert_not_called()
+
+
+def test_rewrite_dry_run_skips_writes() -> None:
+    from nexus.db.t3 import _rewrite_collection_metadata
+
+    chunks = [_legacy_meta(), _legacy_meta(content_hash="hh2")]
+    db, mock_col = _make_t3_mock("knowledge__delos", chunks)
+
+    updated, skipped, total = _rewrite_collection_metadata(
+        db, "knowledge__delos", dry_run=True,
+    )
+    assert total == 2
+    # dry_run reports what *would* be updated.
+    assert updated == 2
+    assert skipped == 0
+    mock_col.update.assert_not_called()
+
+
+def test_rewrite_filter_by_source_path() -> None:
+    from nexus.db.t3 import _rewrite_collection_metadata
+
+    chunks = [
+        _legacy_meta(source_path="paper-a.pdf"),
+        _legacy_meta(source_path="paper-b.pdf"),
+    ]
+    db, mock_col = _make_t3_mock("knowledge__delos", chunks)
+
+    updated, skipped, total = _rewrite_collection_metadata(
+        db, "knowledge__delos", source_path="paper-a.pdf",
+    )
+    assert total == 1
+    assert updated == 1
+    written_ids = mock_col.update.call_args.kwargs["ids"]
+    assert written_ids == ["id-0"]
+
+
+def test_rewrite_paginates_above_300() -> None:
+    """Collections >300 chunks use multiple ``coll.get(limit=300)`` calls."""
+    from nexus.db.t3 import _rewrite_collection_metadata
+
+    chunks = [_legacy_meta(content_hash=f"h{i}") for i in range(750)]
+    db, mock_col = _make_t3_mock("knowledge__delos", chunks)
+
+    updated, _, total = _rewrite_collection_metadata(
+        db, "knowledge__delos",
+    )
+    assert total == 750
+    assert updated == 750
+    # 750 / 300 = 3 pages.
+    assert mock_col.get.call_count == 3
+
+
+def test_rewrite_respects_300_record_write_cap() -> None:
+    """update_chunks splits internally — verify update calls stay ≤300."""
+    from nexus.db.t3 import _rewrite_collection_metadata
+
+    chunks = [_legacy_meta(content_hash=f"h{i}") for i in range(450)]
+    db, mock_col = _make_t3_mock("knowledge__delos", chunks)
+
+    _rewrite_collection_metadata(db, "knowledge__delos")
+
+    for call in mock_col.update.call_args_list:
+        assert len(call.kwargs["ids"]) <= 300

--- a/tests/test_metadata_schema.py
+++ b/tests/test_metadata_schema.py
@@ -263,6 +263,75 @@ def test_normalize_drops_empty_ttl_defaults() -> None:
     assert out["expires_at"] == ""
 
 
+def test_normalize_drops_empty_bib_placeholders() -> None:
+    """Bib_* slots with placeholder values (``0`` / ``""``) eat metadata
+    budget for no payload when ``--enrich`` is off (nexus-2my fix #2).
+
+    Mirrors the git_meta-omitted-when-empty behaviour: drop bib_* whose
+    values are zero/empty; keep them when populated.
+    """
+    from nexus.metadata_schema import normalize
+
+    raw = {
+        "source_path": "p.pdf",
+        "content_hash": "x",
+        "chunk_text_hash": "y",
+        "chunk_index": 0,
+        "chunk_count": 1,
+        "bib_year": 0,
+        "bib_authors": "",
+        "bib_venue": "",
+        "bib_citation_count": 0,
+    }
+    out = normalize(raw, content_type="pdf")
+    for key in ("bib_year", "bib_authors", "bib_venue", "bib_citation_count"):
+        assert key not in out, f"empty {key} should be dropped"
+
+
+def test_normalize_keeps_partial_bib_when_year_populated() -> None:
+    """If even one bib_* slot has a real value, keep all four for a
+    consistent search/display contract."""
+    from nexus.metadata_schema import normalize
+
+    raw = {
+        "source_path": "p.pdf",
+        "content_hash": "x",
+        "chunk_text_hash": "y",
+        "chunk_index": 0,
+        "chunk_count": 1,
+        "bib_year": 2024,
+        "bib_authors": "",
+        "bib_venue": "",
+        "bib_citation_count": 0,
+    }
+    out = normalize(raw, content_type="pdf")
+    assert out["bib_year"] == 2024
+    assert out["bib_authors"] == ""
+    assert out["bib_venue"] == ""
+    assert out["bib_citation_count"] == 0
+
+
+def test_normalize_keeps_fully_populated_bib() -> None:
+    from nexus.metadata_schema import normalize
+
+    raw = {
+        "source_path": "p.pdf",
+        "content_hash": "x",
+        "chunk_text_hash": "y",
+        "chunk_index": 0,
+        "chunk_count": 1,
+        "bib_year": 2024,
+        "bib_authors": "Smith",
+        "bib_venue": "ICML",
+        "bib_citation_count": 42,
+    }
+    out = normalize(raw, content_type="pdf")
+    assert out["bib_year"] == 2024
+    assert out["bib_authors"] == "Smith"
+    assert out["bib_venue"] == "ICML"
+    assert out["bib_citation_count"] == 42
+
+
 # ── validate() ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_pdf_git_meta_propagation.py
+++ b/tests/test_pdf_git_meta_propagation.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Integration tests: git provenance flows into PDF + markdown ingest paths.
+
+Pre-PR-#164: the single-file CLI (``nx index pdf <file>``) never wrote
+git_* metadata because the augment-with-git step lived only in the
+repo-walk path (``indexer.py:_pdf_augment``).
+
+This test pins the fix: ``_pdf_chunks`` and ``_markdown_chunks``
+auto-detect git metadata via :func:`nexus.indexer_utils.detect_git_metadata`
+and emit flat ``git_*`` keys, which ``normalize()`` then packs into a
+``git_meta`` JSON string.
+
+nexus-2my fix #3.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True,
+                   capture_output=True, text=True)
+
+
+@pytest.fixture()
+def repo_with_pdf(tmp_path: Path) -> tuple[Path, Path]:
+    """A tmpdir initialised as a git repo with one PDF + one commit."""
+    pymupdf = pytest.importorskip("pymupdf")
+
+    _git("init", "-b", "main", cwd=tmp_path)
+    _git("config", "user.email", "test@example.com", cwd=tmp_path)
+    _git("config", "user.name", "Test", cwd=tmp_path)
+    _git("remote", "add", "origin",
+         "https://example.com/test-repo.git", cwd=tmp_path)
+
+    pdf_path = tmp_path / "sample.pdf"
+    doc = pymupdf.open()
+    page = doc.new_page()
+    page.insert_text((50, 50), "Hello world. " * 50)
+    doc.save(str(pdf_path))
+    doc.close()
+
+    _git("add", "sample.pdf", cwd=tmp_path)
+    _git("commit", "-m", "initial", cwd=tmp_path)
+    return tmp_path, pdf_path
+
+
+@pytest.fixture()
+def repo_with_markdown(tmp_path: Path) -> tuple[Path, Path]:
+    _git("init", "-b", "main", cwd=tmp_path)
+    _git("config", "user.email", "test@example.com", cwd=tmp_path)
+    _git("config", "user.name", "Test", cwd=tmp_path)
+    _git("remote", "add", "origin",
+         "https://example.com/test-repo.git", cwd=tmp_path)
+
+    md_path = tmp_path / "doc.md"
+    md_path.write_text(
+        "# Title\n\nFirst section text.\n\n"
+        "## Section\n\nMore content here.\n",
+    )
+    _git("add", "doc.md", cwd=tmp_path)
+    _git("commit", "-m", "initial", cwd=tmp_path)
+    return tmp_path, md_path
+
+
+# ── detect_git_metadata helper ──────────────────────────────────────────────
+
+
+def test_detect_git_metadata_returns_full_set(repo_with_pdf) -> None:
+    from nexus.indexer_utils import detect_git_metadata
+
+    repo, pdf = repo_with_pdf
+    meta = detect_git_metadata(pdf)
+    assert meta["git_project_name"] == repo.name
+    assert meta["git_branch"] == "main"
+    assert len(meta["git_commit_hash"]) == 40  # full SHA
+    assert meta["git_remote_url"] == "https://example.com/test-repo.git"
+
+
+def test_detect_git_metadata_returns_empty_outside_repo(tmp_path: Path) -> None:
+    """Path not in a git repo → empty dict (caller can ``**``-merge safely)."""
+    from nexus.indexer_utils import detect_git_metadata
+
+    assert detect_git_metadata(tmp_path) == {}
+
+
+# ── _pdf_chunks propagation ─────────────────────────────────────────────────
+
+
+def test_pdf_chunks_emits_flat_git_keys(repo_with_pdf) -> None:
+    """``_pdf_chunks`` writes git_* keys auto-detected from the PDF path."""
+    from nexus.doc_indexer import _pdf_chunks
+
+    repo, pdf = repo_with_pdf
+    chunks = _pdf_chunks(
+        pdf, "test-hash", "voyage-context-3", "2026-04-15Z", "test_corpus",
+    )
+    assert chunks
+    meta = chunks[0][2]
+    assert meta.get("git_project_name") == repo.name
+    assert meta.get("git_branch") == "main"
+    assert meta.get("git_remote_url") == "https://example.com/test-repo.git"
+    assert len(meta.get("git_commit_hash", "")) == 40
+
+
+def test_pdf_chunks_normalize_packs_git_meta(repo_with_pdf) -> None:
+    """End-to-end: _pdf_chunks → normalize → git_meta JSON populated."""
+    from nexus.doc_indexer import _pdf_chunks
+    from nexus.metadata_schema import normalize
+
+    repo, pdf = repo_with_pdf
+    chunks = _pdf_chunks(
+        pdf, "test-hash", "voyage-context-3", "2026-04-15Z", "test_corpus",
+    )
+    meta = chunks[0][2]
+    canonical = normalize(meta, content_type="pdf")
+    assert "git_meta" in canonical
+    decoded = json.loads(canonical["git_meta"])
+    assert decoded["project"] == repo.name
+    assert decoded["branch"] == "main"
+    assert decoded["remote"] == "https://example.com/test-repo.git"
+
+
+def test_pdf_chunks_outside_git_repo_no_git_keys(tmp_path: Path) -> None:
+    """A PDF outside any git repo gets no git_* keys (and no git_meta
+    after normalize, mirroring the omitted-when-empty pattern)."""
+    pymupdf = pytest.importorskip("pymupdf")
+    from nexus.doc_indexer import _pdf_chunks
+    from nexus.metadata_schema import normalize
+
+    pdf_path = tmp_path / "loose.pdf"
+    doc = pymupdf.open()
+    page = doc.new_page()
+    page.insert_text((50, 50), "x" * 200)
+    doc.save(str(pdf_path))
+    doc.close()
+
+    chunks = _pdf_chunks(
+        pdf_path, "h", "voyage-context-3", "Z", "test",
+    )
+    meta = chunks[0][2]
+    assert "git_project_name" not in meta
+    assert normalize(meta, content_type="pdf").get("git_meta") in (None,)
+
+
+def test_pdf_chunks_explicit_git_meta_override(repo_with_pdf) -> None:
+    """Caller may pass ``git_meta=`` to override auto-detection
+    (useful for repo-walk paths that compute it once)."""
+    from nexus.doc_indexer import _pdf_chunks
+
+    _, pdf = repo_with_pdf
+    chunks = _pdf_chunks(
+        pdf, "h", "voyage-context-3", "Z", "test",
+        git_meta={
+            "git_project_name": "override-name",
+            "git_branch": "feature",
+            "git_commit_hash": "z" * 40,
+            "git_remote_url": "https://override.example/r.git",
+        },
+    )
+    meta = chunks[0][2]
+    assert meta["git_project_name"] == "override-name"
+    assert meta["git_branch"] == "feature"
+
+
+# ── _markdown_chunks propagation ────────────────────────────────────────────
+
+
+def test_markdown_chunks_emits_flat_git_keys(repo_with_markdown) -> None:
+    from nexus.doc_indexer import _markdown_chunks
+
+    repo, md = repo_with_markdown
+    chunks = _markdown_chunks(
+        md, "h", "voyage-context-3", "Z", "test_corpus",
+    )
+    assert chunks
+    meta = chunks[0][2]
+    assert meta.get("git_project_name") == repo.name
+    assert meta.get("git_branch") == "main"
+    assert meta.get("git_remote_url") == "https://example.com/test-repo.git"
+
+
+def test_markdown_chunks_normalize_packs_git_meta(repo_with_markdown) -> None:
+    from nexus.doc_indexer import _markdown_chunks
+    from nexus.metadata_schema import normalize
+
+    repo, md = repo_with_markdown
+    chunks = _markdown_chunks(md, "h", "voyage-context-3", "Z", "test")
+    canonical = normalize(chunks[0][2], content_type="markdown")
+    assert "git_meta" in canonical
+    decoded = json.loads(canonical["git_meta"])
+    assert decoded["project"] == repo.name


### PR DESCRIPTION
## Summary

Three follow-ups to PR #164 (nexus-40t metadata schema rationalisation), surfaced by the ART instance during a real-world re-ingest:

### 1. ``nx collection rewrite-metadata`` (load-bearing)
PR #164 only constrained *new* T3 writes. Already-indexed corpora kept their pre-canonical metadata, and ``nx index --force`` is a silent no-op when the pipeline-state DB still has the content_hash on file (blocks any direct re-ingest path). New CLI command paginates ``coll.get(limit=300)`` over the target collection, normalises each chunk's metadata via the same ``_normalize_for_write`` that fronts every live write, and writes back via ``T3Database.update_chunks`` so ``validate()`` runs again as defense-in-depth. Idempotent, ``--source-path`` filter, ``--dry-run``, ``--all``. **Unblocks ART (gnadt-2008 + grossberg-* corpora) without delete + re-ingest. Embeddings stay put.**

### 2. Drop empty bib_* placeholder set in normalize()
Without ``--enrich``, the indexer wrote ``bib_year=0``, ``bib_authors=\"\"``, ``bib_venue=\"\"``, ``bib_citation_count=0`` as placeholders. After PR #164 these survived normalize() and consumed four metadata slots for zero payload. ``normalize()`` now drops the four bib_* slots together when every value is the placeholder; populated values pass through unchanged. Mirrors the git_meta-omitted-when-empty pattern.

### 3. Wire git_metadata into PDF + markdown ingest paths
Pre-fix: ``nx index pdf <file>`` and ``nx index md <file>`` (single-file CLI) never wrote git provenance because the augment-with-git step lived only in the repo-walk path (``indexer.py:_pdf_augment``). New ``nexus.indexer_utils.detect_git_metadata(path)`` helper walks up via ``find_repo_root`` and collects project_name / branch / commit / remote_url. ``_pdf_chunks``, ``_markdown_chunks``, ``pipeline_stages._build_chunk_metadata`` accept an optional ``git_meta`` kwarg with auto-detection fallback. Resolved once at the entrypoint for the streaming pipeline so per-chunk overhead stays zero.

## Memory housekeeping

- ``feedback_git_meta_dual_read.md`` was flagged UNVERIFIED by the ART instance — confirmed: dual-read would ``KeyError`` on 4.4.0+ chunks because git_meta is the only carrier and flat git_* are dropped by normalize(). **Do not implement dual-read.** After this PR ships, the memory becomes \"git_meta is the sole carrier; legacy chunks must be rewritten via ``nx collection rewrite-metadata``.\"

## Tests

- 7 new TDD tests for ``rewrite-metadata`` (cargo drop, git_meta packing, idempotency, dry-run, source_path filter, >300-row pagination, 300-record write cap).
- 3 new tests for empty-bib drop (all-empty drop, partial-population preservation, full-population preservation).
- 8 integration tests for git_meta propagation (real ``git init`` + commit + PyMuPDF-built PDF / written markdown; covers both auto-detect and explicit override paths, both PDF and markdown).
- **Full non-e2e suite: 4001 passed / 14 skipped / 0 failed.**

## Out of scope (deferred)

- Pipeline-state staleness investigation — ``nx index --force`` should also clear pipeline_buffer state, not just leave it. File as ``nexus-40t.2``; not blocking this PR since ``nx collection rewrite-metadata`` is the operator-facing answer.

## Test plan

- [x] ``uv run pytest tests/test_collection_rewrite_metadata.py`` (7/7)
- [x] ``uv run pytest tests/test_metadata_schema.py`` (covers empty-bib drop)
- [x] ``uv run pytest tests/test_pdf_git_meta_propagation.py`` (8/8)
- [x] Full non-e2e suite (4001 passed)
- [ ] Manual on ART: ``nx collection rewrite-metadata knowledge__delos --dry-run`` then live; ``nx index pdf gnadt-2008.pdf --collection knowledge__delos`` should now persist git_meta.

Refs nexus-40t.