### PR TITLE
chore: 4.4.1 — wire up 11 new MCP tools in plugin hooks + docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.4.0"
+      "version": "4.4.1"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.4.0"
+      "version": "4.4.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.4.1] - 2026-04-16
+
+### Fixed
+
+- **Plugin auto-approval allow list** — added the 11 MCP tools shipped in 4.4.0 that were missing from `nx/hooks/scripts/auto-approve-nx-mcp.sh`: `nx_answer`, `nx_tidy`, `nx_enrich_beads`, `nx_plan_audit`, `traverse`, `store_get_many`, and the 5 operators (`operator_summarize`, `operator_extract`, `operator_rank`, `operator_compare`, `operator_generate`). Without this, every call to any of these tools surfaced a permission prompt instead of running silently. Plugin-only fix — no Python code changed.
+- **Subagent-start operators block** — the analytical-operators guidance in `nx/hooks/scripts/subagent-start.sh` still told subagents to dispatch the removed `analytical-operator` agent. Replaced with direct invocations of the 5 `operator_*` MCP tools plus a pointer to `nx_answer` for plan-matched retrieval.
+- **`nexus` skill reference** — `SKILL.md` common-operations block and `reference.md` tool catalog were frozen at the 15-tool v4.3.x surface. Added full entries for `nx_answer`, `traverse`, `store_get_many`, the 5 operators, and the 3 hygiene tools (`nx_tidy` / `nx_enrich_beads` / `nx_plan_audit`); corrected core-tool count to 26.
+- **Stale "15 agents" reference** in `nx/agents/_shared/README.md` updated to "13 agents (10 active + 3 RDR-080 MCP-tool redirect stubs)".
+- **`catalog.py` docstring** — removed lingering `query-planner` reference from `link_query`.
+
 ## [4.4.0] - 2026-04-16
 
 ### Added

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.4.1] - 2026-04-16
+
+### Fixed
+
+- **Auto-approval allow list** — `nx/hooks/scripts/auto-approve-nx-mcp.sh` was shipped with the 4.3.x tool surface. Added the 11 MCP tools introduced in 4.4.0 (`nx_answer`, `nx_tidy`, `nx_enrich_beads`, `nx_plan_audit`, `traverse`, `store_get_many`, 5 `operator_*`). Anyone running 4.4.0 from the marketplace saw a permission prompt on every call; 4.4.1 silences them.
+- **SubagentStart operators guidance** — the "Analytical Operators" block was still telling subagents to `Agent` tool dispatch to the removed `analytical-operator` agent. Replaced with the 5 `operator_*` MCP tool signatures and a pointer to `nx_answer` for plan-matched multi-step retrieval.
+- **`nexus` skill** — `SKILL.md` common-operations block was missing every tool added in 4.4.0. Rewrote to include `nx_answer`, `traverse`, `store_get_many`, the 5 operators, and the 3 hygiene tools, plus a "When to reach for each" guide. `reference.md` gained full entries for the same 11 tools; tool count corrected (15 → 26).
+- **`_shared/README.md`** — "All 15 agents" updated to reflect the post-RDR-080 shape (13 agents = 10 active + 3 MCP-tool redirect stubs).
+
 ## [4.4.0] - 2026-04-16
 
 ### Added

--- a/nx/agents/_shared/README.md
+++ b/nx/agents/_shared/README.md
@@ -11,7 +11,7 @@ This directory contains shared resources used across multiple agents.
 
 ## Usage Pattern
 
-All 15 agents reference this shared Context Protocol using:
+All 13 agents (10 active + 3 RDR-080 MCP-tool redirect stubs) reference this shared Context Protocol using:
 
 ```markdown
 ## Context Protocol

--- a/nx/hooks/scripts/auto-approve-nx-mcp.sh
+++ b/nx/hooks/scripts/auto-approve-nx-mcp.sh
@@ -11,6 +11,7 @@ case "$TOOL_NAME" in
   mcp__plugin_nx_nexus__query|\
   mcp__plugin_nx_nexus__store_put|\
   mcp__plugin_nx_nexus__store_get|\
+  mcp__plugin_nx_nexus__store_get_many|\
   mcp__plugin_nx_nexus__store_list|\
   mcp__plugin_nx_nexus__memory_put|\
   mcp__plugin_nx_nexus__memory_get|\
@@ -22,6 +23,16 @@ case "$TOOL_NAME" in
   mcp__plugin_nx_nexus__collection_list|\
   mcp__plugin_nx_nexus__plan_save|\
   mcp__plugin_nx_nexus__plan_search|\
+  mcp__plugin_nx_nexus__traverse|\
+  mcp__plugin_nx_nexus__nx_answer|\
+  mcp__plugin_nx_nexus__nx_tidy|\
+  mcp__plugin_nx_nexus__nx_enrich_beads|\
+  mcp__plugin_nx_nexus__nx_plan_audit|\
+  mcp__plugin_nx_nexus__operator_summarize|\
+  mcp__plugin_nx_nexus__operator_extract|\
+  mcp__plugin_nx_nexus__operator_rank|\
+  mcp__plugin_nx_nexus__operator_compare|\
+  mcp__plugin_nx_nexus__operator_generate|\
   mcp__plugin_nx_nexus-catalog__search|\
   mcp__plugin_nx_nexus-catalog__show|\
   mcp__plugin_nx_nexus-catalog__list|\

--- a/nx/hooks/scripts/subagent-start.sh
+++ b/nx/hooks/scripts/subagent-start.sh
@@ -178,11 +178,17 @@ SEQTHINK
 if [[ $SKIP_OPERATORS -eq 0 ]]; then
 cat <<'OPERATORS'
 
-## Analytical Operators
+## Analytical Operators (RDR-080)
 
-Agent `analytical-operator` — dispatch via Agent tool with relay containing operation + inputs + params.
-Operations: extract (JSON template), summarize (short|detailed|evidence), rank (criterion), compare (criterion), generate (cited text).
-Step outputs: T1 scratch tag `query-step,step-N`.
+Five MCP tools wrap the five operations — each spawns `claude -p` (default timeout 120s). Call them directly; no Agent dispatch.
+
+  mcp__plugin_nx_nexus__operator_summarize(content="<text>", cited=True)
+  mcp__plugin_nx_nexus__operator_extract(inputs=["doc1","doc2"], fields="title,year,author")
+  mcp__plugin_nx_nexus__operator_rank(items=["a","b","c"], criterion="<criterion>")
+  mcp__plugin_nx_nexus__operator_compare(items=["x","y"], focus="<aspect>")
+  mcp__plugin_nx_nexus__operator_generate(template="<template>", context="<source material>")
+
+For plan-matched multi-step retrieval use `mcp__plugin_nx_nexus__nx_answer` — it composes search/query/operators under a plan-match-first gate.
 OPERATORS
 fi
 

--- a/nx/skills/nexus/SKILL.md
+++ b/nx/skills/nexus/SKILL.md
@@ -17,10 +17,36 @@ effort: low
 ## Common Operations
 
 ```
-# Search
+# Analytical answer (RDR-080) — plan-match-first, falls through to inline planner on miss
+mcp__plugin_nx_nexus__nx_answer(question="how does plan matching work"                  # primary front door
+mcp__plugin_nx_nexus__nx_answer(question="...", dimensions={"verb":"research"}          # pin a verb for the matcher
+mcp__plugin_nx_nexus__nx_answer(question="...", scope="1.2"                             # catalog subtree filter
+
+# Search (chunk-level) / query (document-level)
 mcp__plugin_nx_nexus__search(query="query"                          # semantic search across T3
 mcp__plugin_nx_nexus__search(query="query", corpus="code"           # code only
-mcp__plugin_nx_nexus__search(query="query", corpus="knowledge", limit=5 # knowledge with limit
+mcp__plugin_nx_nexus__search(query="query", structured=True         # returns {ids, tumblers, distances, collections}
+mcp__plugin_nx_nexus__query(question="...", corpus="knowledge", follow_links="cites"    # catalog-aware, document-level
+
+# Batch hydrate chunks past the ChromaDB 300-record quota
+mcp__plugin_nx_nexus__store_get_many(ids=["id1","id2","id3"], collections="knowledge__art"
+mcp__plugin_nx_nexus__store_get_many(ids="id1,id2", collections="rdr__nexus", structured=True
+
+# Walk the catalog link graph (depth capped at 3 — SC-4)
+mcp__plugin_nx_nexus__traverse(seeds=["1.1.635"], link_types=["implements","cites"], depth=2
+mcp__plugin_nx_nexus__traverse(seeds="1.1.635", purpose="find-implementations"          # link_types XOR purpose
+
+# Analytical operators — each spawns `claude -p` (default timeout 120s)
+mcp__plugin_nx_nexus__operator_summarize(content="...", cited=True
+mcp__plugin_nx_nexus__operator_extract(inputs=["doc1","doc2"], fields="title,year,author"
+mcp__plugin_nx_nexus__operator_rank(items=["a","b","c"], criterion="relevance to X"
+mcp__plugin_nx_nexus__operator_compare(items=["x","y"], focus="scalability"
+mcp__plugin_nx_nexus__operator_generate(template="release note", context="..."
+
+# Background hygiene — call and let run (long-lived claude -p subprocesses)
+mcp__plugin_nx_nexus__nx_tidy()                                     # T2 memory consolidation
+mcp__plugin_nx_nexus__nx_enrich_beads()                             # design-notes auto-fill
+mcp__plugin_nx_nexus__nx_plan_audit()                               # plan library quality sweep
 
 # Memory (T2)
 mcp__plugin_nx_nexus__memory_put(content="content", project="{repo}", title="file.md"
@@ -34,7 +60,20 @@ mcp__plugin_nx_nexus__store_list(collection="knowledge"
 # Scratch (T1)
 mcp__plugin_nx_nexus__scratch(action="put", content="working note"
 mcp__plugin_nx_nexus__scratch_manage(action="flag", entry_id="<id>"       # auto-promote to T2 at session end
+
+# Plan library (T2)
+mcp__plugin_nx_nexus__plan_search(query="retrieval"                       # find reusable plans
+mcp__plugin_nx_nexus__plan_save(query="...", plan_json="{...}"            # persist a successful plan
 ```
+
+## When to reach for each
+
+- **`nx_answer`** — analytical questions, cross-corpus synthesis. Primary front door for research / review / analyze / debug verb skills. Plan-match-first; falls through to inline planner on miss.
+- **`search` vs `query`** — `search` returns chunks (finest grain), `query` returns documents grouped by source. Use `search` for fragment hunting, `query` for literature scoping + catalog traversal.
+- **`traverse`** — walk the typed link graph from known tumblers. `link_types` XOR `purpose`; depth ≤ 3.
+- **`store_get_many`** — batch-hydrate chunk IDs from `search(structured=True)` or `traverse`. Safe past the 300-record write cap.
+- **Operators** — content transforms; take raw text, return structured JSON. Use after retrieval to summarize/extract/rank/compare/generate.
+- **`nx_tidy` / `nx_enrich_beads` / `nx_plan_audit`** — background hygiene; slow (claude -p). Call and move on.
 
 ## Catalog (T3 metadata — document registry + typed link graph)
 

--- a/nx/skills/nexus/reference.md
+++ b/nx/skills/nexus/reference.md
@@ -11,7 +11,7 @@ Nexus provides MCP tools for semantic search, persistent memory, and knowledge m
 
 Core tools are prefixed `mcp__plugin_nx_nexus__`; catalog tools are prefixed `mcp__plugin_nx_nexus-catalog__`.
 
-There are 15 core tools: `search`, `query`, `store_put`, `store_get`, `store_list`, `memory_put`, `memory_get`, `memory_delete`, `memory_search`, `memory_consolidate`, `scratch`, `scratch_manage`, `collection_list`, `plan_save`, `plan_search`.
+There are 26 core tools: `search`, `query`, `store_put`, `store_get`, `store_get_many`, `store_list`, `memory_put`, `memory_get`, `memory_delete`, `memory_search`, `memory_consolidate`, `scratch`, `scratch_manage`, `collection_list`, `plan_save`, `plan_search`, `traverse`, `nx_answer`, `nx_tidy`, `nx_enrich_beads`, `nx_plan_audit`, `operator_summarize`, `operator_extract`, `operator_rank`, `operator_compare`, `operator_generate`.
 There are 10 catalog tools (nexus-catalog server): `search`, `show`, `list`, `register`, `update`, `link`, `links`, `link_query`, `resolve`, `stats`.
 
 ### search
@@ -59,6 +59,126 @@ mcp__plugin_nx_nexus__query(question="error handling patterns", corpus="code", l
 Returns per-document: title, relevance score, bibliographic metadata (year, authors, venue, citations), technical metadata (pages, chunks, extraction method, formulas), collection, and best matching snippet.
 
 Use `search` for chunk-level retrieval. Use `query` when you need to know **which documents** match.
+
+### nx_answer
+
+Plan-match-first analytical retrieval (RDR-080). Primary front door for research / review / analyze / debug verb skills. Internally: `plan_match` → (on hit) run matched plan via `plan_run`; (on miss) dispatch inline `claude -p` planner. Every run logged to T2 `nx_answer_runs`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `question` | str | required | Natural-language question |
+| `scope` | str | `""` | Catalog subtree (e.g. `"1.2"`) or corpus filter (e.g. `"knowledge"`) |
+| `context` | str | `""` | Supplementary caller-supplied context for the plan matcher |
+| `max_steps` | int | `6` | Cap on plan DAG size (applied to inline planner on miss) |
+| `budget_usd` | float | `0.25` | Per-invocation cost cap (reserved for future enforcement) |
+| `trace` | bool | `True` | When False, redacts question + final_text in the run log |
+| `dimensions` | dict/null | `null` | Dimensional filter for the matcher. Verb skills pin `{"verb": "research"}` etc. |
+
+```
+mcp__plugin_nx_nexus__nx_answer(question="how does plan matching work"
+mcp__plugin_nx_nexus__nx_answer(question="...", dimensions={"verb":"research"}
+mcp__plugin_nx_nexus__nx_answer(question="...", scope="1.2"
+mcp__plugin_nx_nexus__nx_answer(question="...", trace=False            # redact in run log
+```
+
+### traverse
+
+Walk the catalog link graph from seed tumblers (RDR-078 P3). Accepts `link_types` **XOR** `purpose` — never both. Returns the standard retrieval step-output contract so downstream plan steps can reference `$stepN.tumblers` / `$stepN.collections` / `$stepN.ids`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `seeds` | list/str | required | Tumbler(s) to start from (e.g. `["1.1.635"]` or `"1.1.635"`) |
+| `link_types` | list/null | `null` | Catalog link types to follow (`implements`, `cites`, ...). Mutually exclusive with `purpose` |
+| `purpose` | str | `""` | Named alias for a link-type set (e.g. `"find-implementations"`). Mutually exclusive with `link_types` |
+| `depth` | int | `1` | BFS depth. Capped at 3 (SC-4) |
+| `direction` | str | `"both"` | `"out"`, `"in"`, or `"both"` |
+
+```
+mcp__plugin_nx_nexus__traverse(seeds=["1.1.635"], link_types=["implements","cites"], depth=2
+mcp__plugin_nx_nexus__traverse(seeds="1.1.635", purpose="find-implementations"
+```
+
+Returns `{"tumblers": [...], "ids": [...], "collections": [...]}`.
+
+### store_get_many
+
+Batch-hydrate document content by ID past the ChromaDB 300-record read cap (RDR-079 hydration primitive). Use after `search(structured=True)` or `traverse` to fetch the actual text.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ids` | list/str | required | Document IDs. Accepts comma-separated string or list |
+| `collections` | list/str | `"knowledge"` | Target collection(s). Single name, comma-separated, or list aligned 1:1 with `ids` |
+| `max_chars_per_doc` | int | `4000` | Per-document truncation cap |
+| `structured` | bool | `false` | Return `{contents, missing}` dict when True; human-readable string when False |
+
+```
+mcp__plugin_nx_nexus__store_get_many(ids=["id1","id2"], collections="knowledge__art"
+mcp__plugin_nx_nexus__store_get_many(ids="id1,id2", collections="rdr__nexus", structured=True
+```
+
+### operator_summarize
+
+Summarize content via `claude -p` (default timeout 120s). Set `cited=True` for a citations list in the output.
+
+```
+mcp__plugin_nx_nexus__operator_summarize(content="<text>"
+mcp__plugin_nx_nexus__operator_summarize(content="<text>", cited=True
+```
+
+### operator_extract
+
+Extract named fields from each input item. `inputs` accepts a list or a JSON-array string. `fields` is a comma-separated list of field names.
+
+```
+mcp__plugin_nx_nexus__operator_extract(inputs=["doc1","doc2"], fields="title,year,author"
+```
+
+Returns `{"extractions": [{...}, {...}]}`.
+
+### operator_rank
+
+Rank items by a natural-language criterion.
+
+```
+mcp__plugin_nx_nexus__operator_rank(items=["a","b","c"], criterion="relevance to X"
+```
+
+Returns `{"ranked": [...]}`.
+
+### operator_compare
+
+Compare items; optional `focus` narrows the comparison dimension.
+
+```
+mcp__plugin_nx_nexus__operator_compare(items=["x","y"], focus="scalability"
+```
+
+Returns `{"comparison": "<markdown>"}`.
+
+### operator_generate
+
+Generate output from a template + context. Template is a natural-language description or named template; `context` is source material. `cited=True` to include a citations list.
+
+```
+mcp__plugin_nx_nexus__operator_generate(template="release note", context="v4.4.0 adds ..."
+mcp__plugin_nx_nexus__operator_generate(template="..", context="..", cited=True
+```
+
+Returns `{"output": "<generated>"}`.
+
+### nx_tidy / nx_enrich_beads / nx_plan_audit
+
+Background hygiene tools — each spawns a long-lived `claude -p` subprocess. Call and move on; these are slow (minutes, not seconds).
+
+- **`nx_tidy`** — T2 memory consolidation sweep (overlaps, stale entries).
+- **`nx_enrich_beads`** — auto-fills missing `design` / `notes` sections on open beads.
+- **`nx_plan_audit`** — plan library quality audit (missing required fields, low match confidence, stale entries).
+
+```
+mcp__plugin_nx_nexus__nx_tidy()
+mcp__plugin_nx_nexus__nx_enrich_beads()
+mcp__plugin_nx_nexus__nx_plan_audit()
+```
 
 ### store_put
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.4.0"
+version = "4.4.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -394,7 +394,7 @@ def catalog_link_query(
     Results are paged. When truncated, a ``_pagination`` entry appears at the end
     with ``next_offset``. Pass that as ``offset`` to get the next page.
 
-    NOT a query-planner step — use catalog_links for graph traversal.
+    NOT a retrieval step — use catalog_links (or the `traverse` MCP tool) for graph traversal.
     Use for: audit by creator, find all links of a type, count generator output.
     created_at_before: ISO timestamp — only links created before this time.
     Note: returns ALL matching links including orphans (links to deleted documents).

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.4.0"
+version = "4.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

v4.4.0 shipped 11 new MCP tools (`nx_answer`, `traverse`, `store_get_many`, 5 `operator_*`, 3 hygiene redirects) but left the plugin's **auto-approval allow list frozen at the 4.3.x surface**. Every call to one of those tools surfaced a permission prompt instead of running silently. A handful of related docs and the subagent-start operators block were also stale.

This is a plugin-only patch. No Python behaviour changes.

## What changed

- `nx/hooks/scripts/auto-approve-nx-mcp.sh` — add 11 missing full tool names to the allow list. Verified all 11 auto-approve and an unknown tool is still rejected.
- `nx/hooks/scripts/subagent-start.sh` — the "Analytical Operators" block still told subagents to dispatch the removed `analytical-operator` agent. Replaced with the 5 `operator_*` MCP tool signatures + pointer to `nx_answer` for plan-matched retrieval.
- `nx/skills/nexus/SKILL.md` — common-operations block rewritten to include the 11 new tools, plus a "When to reach for each" guide.
- `nx/skills/nexus/reference.md` — full entries added for `nx_answer`, `traverse`, `store_get_many`, the 5 operators, and the 3 hygiene tools. Core-tool count 15 → 26.
- `nx/agents/_shared/README.md` — "All 15 agents" corrected to "13 agents (10 active + 3 RDR-080 MCP-tool redirect stubs)".
- `src/nexus/mcp/catalog.py` — `link_query` docstring no longer references the removed `query-planner` agent.
- Version bump: `pyproject.toml`, both `plugin.json` files, both marketplace entries, `uv.lock` → 4.4.1. `sn` bumped alongside `nx` to satisfy `tests/test_plugin_structure.py::TestMarketplaceVersion`.
- CHANGELOG entries in root and `nx/`.

## Test plan

- [x] `uv run pytest tests/test_plugin_structure.py` — 562 passed, 26 skipped (including the marketplace ⇄ pyproject parity check)
- [x] `uv run python scripts/validate/06-agent-wiring.py` — 87 pass, 0 fail
- [x] `uv run pytest tests/ --ignore=tests/integration --ignore=tests/e2e` — 4184 passed, 27 skipped
- [x] Manual smoke — each of the 11 new tool names auto-approves via the updated hook; bogus tool name correctly NOT approved
- [ ] After merge: tag `v4.4.1`, let the release workflow publish to PyPI and push the plugin manifest to the marketplace