### PR TITLE
RDR-082/083/084/085 arc — doc tokens, plan growth, glossary labeler

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.4.1"
+      "version": "4.5.0"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.4.1"
+      "version": "4.5.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.5.0] - 2026-04-17
+
+### Added
+
+- **RDR-082 Doc-Build Token Resolution** — new `nx doc render` / `nx doc validate` commands that expand `{{bd:<id>[.field]}}` and `{{rdr:<id>[.field]}}` tokens against authoritative state (bead DB, RDR frontmatter) at build time. Resolver registry is the extension point for future namespaces. Emits `<stem>.rendered.md` sibling; fail-loud on unresolved tokens. Shared `src/nexus/doc/_common.py` fence helpers now used by both 082's tokenizer and RDR-081's `ref_scanner`.
+- **RDR-083 Corpus-Evidence Tokens** — `{{nx-anchor:<collection>[|top=N]}}` token plus `nx doc check-grounding` (citation-coverage report) and `nx doc check-extensions` (projection-based author-extension flagger) subcommands. `AnchorResolver` is the first external consumer of RDR-082's registry — plugs in without parser/engine/CLI changes. v1 ships with a documented scope reduction: hash-to-chunk resolution (`resolve_chash`) deferred; `check-extensions` marked `[experimental]` with loud stderr WARNING when its inertness case fires. Deferrals owned by draft RDR-086.
+- **RDR-084 Plan Library Growth** — successful ad-hoc plans produced by `nx_answer`'s plan-miss path are now auto-persisted via `save_plan(scope="personal", tags="ad-hoc,grown")`. Paraphrased questions match the grown plan through the plan_match gate instead of re-running the inline planner. New config key `plans.ad_hoc_ttl` (default 30d; set 0 to disable). T1 cosine cache receives `upsert(row)` so matches work without SessionStart re-populate.
+- **RDR-085 Glossary-Aware Topic Labeler** — migrates `_generate_labels_batch` off its bespoke subprocess shell-out onto the shipped `claude_dispatch` substrate with schema-enforced output. Project vocabulary from `.nexus.yml#taxonomy.glossary` or `docs/glossary.md` prepended to the labeler prompt eliminates training-prior hallucinations (observed SSMF → "Single Mode Fiber" on ART corpus; live smoke on `rdr__nexus-571b8edd` shows 2/6 topics improved, 0/6 regressed). Supersedes the labeler portion of RDR-081.
+- **RDR-086 Chash Span Resolution** (draft) — owner-RDR for RDR-083's deferred work. Proposes `catalog.resolve_chash(chash)` backed by a T2 `chash_index` table populated at indexing time. Unblocks `check-grounding --fail-ungrounded`, `check-extensions` meaningful candidates, and `nx doc render --expand-citations`.
+
+### Fixed
+
+- **nexus-lub** — `nx collection delete` now cascade-purges taxonomy state (`topics`, `topic_assignments`, `topic_links`, `taxonomy_meta`). Prior behaviour left orphan rows so `nx taxonomy status` and hub detection dragged ghost rows across deletions. New `CatalogTaxonomy.purge_collection(name)` method is transactional; delete command reports cleaned-row counts.
+- **nexus-9ji** — `nx index pdf --force` now breaks the partial-ingest deadlock. `pipeline_index_pdf` gains `force: bool = False`; when True, `db.delete_pipeline_data(content_hash)` wipes stale pipeline.db state AND `col.delete(where={"content_hash": <hash>})` wipes T3 orphan chunks before `create_pipeline` runs. Both cleanups are pre-flight, so the normal "already running" skip still protects concurrent peers.
+
 ## [4.4.1] - 2026-04-16
 
 ### Fixed

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -103,10 +103,11 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-079](rdr-079-operator-dispatch-and-execution.md) | Operator Dispatch + Plan Execution End-to-End | Feature | Abandoned | 2026-04-15 |
 | [RDR-080](rdr-080-retrieval-layer-consolidation.md) | Retrieval Layer Consolidation — `nx_answer` + Agent/Skill Pruning | Feature | Closed (implemented) | 2026-04-15 |
 | [RDR-081](rdr-081-authoring-trust-cli.md) | Stale-Reference Validator (`nx taxonomy validate-refs`) | Feature | Closed (implemented) | 2026-04-15 |
-| [RDR-082](rdr-082-doc-render-tokens.md) | Doc-Build Token Resolution — `nx doc render` with Bead/RDR/Anchor Tokens | Feature | Draft | 2026-04-15 |
-| [RDR-083](rdr-083-chunk-grounded-citations.md) | Chunk-Grounded Citations — `chash:` Spans + Grounding Validator | Feature | Draft | 2026-04-15 |
+| [RDR-082](rdr-082-doc-render-tokens.md) | Doc-Build Token Resolution — `nx doc render` with Bead and RDR Tokens | Feature | Draft | 2026-04-15 |
+| [RDR-083](rdr-083-chunk-grounded-citations.md) | Corpus-Evidence Tokens — `chash:` Spans, Grounding Validator, `nx-anchor` | Feature | Draft | 2026-04-15 |
 | [RDR-084](rdr-084-plan-library-growth.md) | Plan Library Growth — Auto-Save Successful Ad-Hoc Plans | Feature | Draft | 2026-04-16 |
 | [RDR-085](rdr-085-glossary-aware-labeler.md) | Glossary-Aware Topic Labeler — Project Vocabulary via `claude_dispatch` | Feature | Draft | 2026-04-16 |
+| [RDR-086](rdr-086-chash-span-resolution.md) | Chash Span Resolution — catalog chash-to-chunk Lookup + doc-id Mapping | Feature | Draft | 2026-04-16 |
 
 ---
 

--- a/docs/rdr/rdr-082-doc-render-tokens.md
+++ b/docs/rdr/rdr-082-doc-render-tokens.md
@@ -314,3 +314,4 @@ One CLI command, three resolvers, one small grammar. Resist adding token familie
 
 - 2026-04-15 — Draft authored from ART field report findings F3, F8.
 - 2026-04-16 — Scope reduction: projection-derived tokens (`{{nx-anchor:…}}`) and chunk-excerpt rendering moved to RDR-083. Resolver protocol retained as an extension point; 082 ships with bead + RDR resolvers only. Prerequisites pruned (RDR-077 no longer needed by 082).
+- 2026-04-16 (gate pass) — two as-built corrections applied: (1) `render_text` now returns a `(output, resolved_count, misses)` tuple so `RenderResult.resolved` only counts tokens that actually resolved — the prior shape counted every registered-namespace token regardless of resolve-time outcome; (2) `--out-dir` preserves the source path relative to `--project-root` (default cwd) so the mirror-tree guarantee in the `.rendered.md` output convention actually holds. Both fixes covered by new regression tests in `tests/test_rdr_082_doc_tokens.py`.

--- a/docs/rdr/rdr-082-doc-render-tokens.md
+++ b/docs/rdr/rdr-082-doc-render-tokens.md
@@ -1,5 +1,5 @@
 ---
-title: "RDR-082: Doc-Build Token Resolution — `nx doc render` with Bead/RDR/Anchor Tokens"
+title: "RDR-082: Doc-Build Token Resolution — `nx doc render` with Bead and RDR Tokens"
 id: RDR-082
 status: draft
 type: Feature
@@ -8,12 +8,12 @@ author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-15
 related_issues: []
-related: [RDR-075, RDR-077, RDR-078, RDR-081]
+related: [RDR-078, RDR-081, RDR-083]
 ---
 
 # RDR-082: Doc-Build Token Resolution
 
-Architecture and design docs routinely hard-code values that Nexus already owns authoritatively: bead statuses (`Phase 3 = COMPLETE`), RDR states (`RDR-072 ACCEPTED`), component wiring claims (`SovereignDialogPipeline WIRED`), and empirical cross-collection topic anchors. Every one requires manual update when the underlying truth moves. The ART field report (2026-04-15, §3.1/F3 and §3.2/F8) documents multiple drift cases — superseded `MaskingFieldCompetition`, RDR-061 status ambiguity, dead-code references to `SemanticResponseField` that was in fact wired. We have all the source data (bead DB, RDR frontmatter, T2 `topic_assignments`); we lack a renderer that expands authored tokens at build time. This RDR introduces `nx doc render` as the minimal CLI surface and defines a small, versioned token grammar (`{{bd:…}}`, `{{rdr:…}}`, `{{nx-anchor:…}}`) resolved from existing stores.
+Architecture and design docs routinely hard-code values that Nexus already owns authoritatively: bead statuses (`Phase 3 = COMPLETE`), RDR states (`RDR-072 ACCEPTED`), component wiring claims (`SovereignDialogPipeline WIRED`). Every one requires manual update when the underlying truth moves. The ART field report (2026-04-15, §3.1/F3 and §3.2/F8) documents multiple drift cases — superseded `MaskingFieldCompetition`, RDR-061 status ambiguity, dead-code references to `SemanticResponseField` that was in fact wired. We have the source data (bead DB, RDR frontmatter); we lack a renderer that expands authored tokens at build time. This RDR introduces `nx doc render` as the minimal CLI surface and defines a small, versioned token grammar (`{{bd:…}}`, `{{rdr:…}}`) resolved from existing system-of-record stores. Projection-derived rendering tokens (anchor / chunk-excerpt) are scoped to RDR-083, which extends the same token pipeline with corpus-evidence resolvers.
 
 ## Problem Statement
 
@@ -23,11 +23,7 @@ Architecture and design docs routinely hard-code values that Nexus already owns 
 
 Every architecture doc that names a bead or RDR embeds a status snapshot. When the bead closes, the RDR accepts, or the work gets superseded, the prose lies until someone notices. The ART session found three such drifts in ten files during one audit; scaled across all downstream projects, this is the dominant doc-drift class. We already have the state machines (`bd` DB, RDR frontmatter + `{repo}_rdr` T2 project); the missing primitive is a token syntax in markdown that expands at render time.
 
-#### Gap 2: Docs cannot surface their own empirical semantic shape
-
-A reader of `docs__art-architecture` cannot tell from the prose that the collection's semantic center of mass is "Semantic Vector Topic Clustering" at 0.75 cosine — they would have to run projection and ICF by hand. RDR-077's projection-quality data makes this answerable in a single query, but there is no rendering convention that embeds the answer into a doc. Readers see only the *claimed* shape, never the *empirical* shape.
-
-#### Gap 3: No machine-checkable contract for render correctness
+#### Gap 2: No machine-checkable contract for render correctness
 
 Even if tokens were defined ad-hoc, a doc with an unknown or malformed token should fail loudly at render, not fall through to literal text in published output. A validator step (parse → resolve → error on unresolved) is part of the same primitive, not a separate surface.
 
@@ -37,7 +33,7 @@ Even if tokens were defined ad-hoc, a doc with an unknown or malformed token sho
 
 RDR-081 shipped a scanner for collection-name drift in prose. This RDR is the natural next layer: instead of scanning hand-written references and flagging drift, we let authors express the reference as a token, and the renderer resolves it from authoritative state on every build. The two are complementary — `validate-refs` handles legacy prose; tokens handle new authoring. ART's disciplines in §6 of the field report (explicit §0 notation block, per-layer canonical files, hand-curated tumblers) are exactly the patterns that benefit: ceremonial boilerplate today, token-resolved at build-time after this RDR.
 
-Bead state lives in `.beads/` (SQLite, `bd show <id>` JSON output). RDR state lives in `docs/rdr/<id>.md` frontmatter and is mirrored in T2 `{repo}_rdr` (memory_get by title). Projection-anchor data lives in T2 `topic_assignments` (enriched by RDR-077). All are queryable today; none are surfaced through a markdown-author-friendly API.
+Bead state lives in `.beads/` (SQLite, `bd show <id>` JSON output). RDR state lives in `docs/rdr/<id>.md` frontmatter and is mirrored in T2 `{repo}_rdr` (memory_get by title). Both are queryable today; neither is surfaced through a markdown-author-friendly API. Projection-derived data (topic anchors, chunk excerpts) also qualifies for token expansion — see RDR-083 for that surface.
 
 ### Technical Environment
 
@@ -50,21 +46,21 @@ Bead state lives in `.beads/` (SQLite, `bd show <id>` JSON output). RDR state li
 
 ### Investigation
 
-- Surveyed current ad-hoc drift patterns in `docs/rdr/*.md` and `docs/architecture*.md`: most drift clusters around three token types (bead status, RDR status, collection/topic anchors). Other long-tail patterns (chunk counts, call-graph fragments, file-path lists) are out of scope — they belong to the chunk-citation work (RDR-083) or symbol-graph work (F9).
+- Surveyed current ad-hoc drift patterns in `docs/rdr/*.md` and `docs/architecture*.md`: the two dominant system-of-record token types are bead status and RDR status. Projection-anchor and chunk-excerpt patterns are handled by RDR-083; other long-tail patterns (call-graph fragments, file-path lists) are out of scope — they belong to the chunk-citation work (RDR-083) or symbol-graph work (F9).
 - Verified `bd show <id> --json` exposes `status`, `title`, `assignee`, `closed_at`, `epic_id`, `progress` in stable fields.
 - Verified RDR T2 records (RDR-081 Step 4 precedent in `nx/skills/rdr-create/SKILL.md`) contain `status`, `gated`, `closed`, `close_reason`, `epic_bead`.
-- Verified projection anchor query is a bounded SQL: top-K topics by `SUM(similarity)` grouped by `topic_id` for a given `source_collection`.
 
 ### Key Discoveries
 
-- **Verified** — Three token families cover the observed drift cases in the field report with no residual unhandled.
+- **Verified** — Two token families cover the system-of-record drift cases in the field report; projection-derived tokens are out of scope here (RDR-083).
 - **Documented** — `bd show --json` and `memory_get` both return structured records today; no new exporters needed.
 - **Documented** — RDR-078 (plan-centric retrieval) introduces `follow_links` but is orthogonal to rendering; no coupling.
 - **Assumed** — A two-phase renderer (parse → resolve → emit) is sufficient; nested tokens are not needed for the in-scope cases. **Verification**: sample-set pass through a prototype.
+- **Designed-for-extension** — The Resolver protocol is deliberately simple so RDR-083 can register `AnchorResolver`, `ChashResolver`, etc. without grammar churn.
 
 ### Critical Assumptions
 
-- [ ] The token grammar `{{NAMESPACE:KEY[.FIELD][|FILTER]}}` covers all three in-scope token families without special-casing — **Status**: Unverified — **Method**: Prototype + sample docs.
+- [ ] The token grammar `{{NAMESPACE:KEY[.FIELD][|FILTER]}}` covers all in-scope token families without special-casing, and leaves room for RDR-083's additions — **Status**: Unverified — **Method**: Prototype + sample docs.
 - [ ] Rendering can be fully synchronous (no web calls) on a typical 100-page doc in <5s — **Status**: Unverified — **Method**: Spike on `docs/rdr/` corpus.
 - [ ] Downstream markdown consumers (GitHub, mkdocs) treat `{{…}}` as literal text when unrendered, so an un-rendered source doc does not silently look wrong — **Status**: Verified by inspection — **Method**: Docs Only.
 
@@ -72,13 +68,12 @@ Bead state lives in `.beads/` (SQLite, `bd show <id>` JSON output). RDR state li
 
 ### Approach
 
-A single new command `nx doc render <path>` that expands tokens from a small, versioned grammar. Three token families ship in v1; grammar is extensible so RDR-083 (chunk citations) can add `{{chash:…}}` without schema churn.
+A single new command `nx doc render <path>` that expands tokens from a small, versioned grammar. Two token families ship in v1; grammar is extensible so RDR-083 can add `{{chash:…}}` and `{{nx-anchor:…}}` without schema churn.
 
 - `{{bd:<id>.<field>}}` — bead state: `.status`, `.title`, `.assignee`, `.epic.progress`.
 - `{{rdr:<id>.<field>}}` — RDR state: `.status`, `.title`, `.gated`, `.closed`.
-- `{{nx-anchor:<collection>[|top=N]}}` — top-N projected topics for the collection, rendered as a markdown list.
 
-Author writes tokens inline; `nx doc render` emits a resolved `.rendered.md` sibling; `nx doc validate` (same engine, `--no-emit`) exits non-zero on any unresolved token. Default is fail-loud — an unknown bead ID or collection fails the render.
+Author writes tokens inline; `nx doc render` emits a resolved `.rendered.md` sibling; `nx doc validate` (same engine, `--no-emit`) exits non-zero on any unresolved token. Default is fail-loud — an unknown bead or RDR id fails the render.
 
 ### Technical Design
 
@@ -87,10 +82,11 @@ Author writes tokens inline; `nx doc render` emits a resolved `.rendered.md` sib
 ```text
 {{NAMESPACE:KEY[.FIELD][|FILTER=VALUE]*}}
 
-namespaces: bd | rdr | nx-anchor
-key:        bead id | rdr id | collection name
-field:      dotted path into resolver output (optional; resolver supplies default)
-filter:     resolver-specific directive, e.g., top=5
+namespaces (v1):   bd | rdr         # system-of-record
+namespaces (v2):   + chash | nx-anchor   # corpus-evidence, added by RDR-083
+key:               bead id | rdr id | (RDR-083: chunk hash | collection name)
+field:             dotted path into resolver output (optional; resolver supplies default)
+filter:            resolver-specific directive, e.g., top=5
 ```
 
 **Resolver protocol** (new, `src/nexus/doc/resolvers.py`):
@@ -103,11 +99,12 @@ class Resolver(Protocol):
     # raises ResolutionError on unknown key / unsupported field
 ```
 
-Three resolvers ship in v1, each small:
+Two resolvers ship in v1, each small:
 
 - `BeadResolver` shells `bd show <id> --json`, indexes fields.
 - `RdrResolver` reads `docs/rdr/rdr-<id>-*.md` frontmatter (authoritative) with T2 `memory_get` fallback.
-- `AnchorResolver` runs a bounded SQL over `topic_assignments` filtered by `source_collection`, ordered by `SUM(similarity) DESC`.
+
+The `Resolver` protocol is deliberately minimal so RDR-083 can register its own resolvers (`AnchorResolver`, `ChashResolver`) without changing grammar, engine, or CLI.
 
 **Renderer** (new, `src/nexus/doc/render.py`):
 
@@ -126,16 +123,16 @@ Pipeline: read markdown → regex-tokenize with a single pass (`\{\{([a-z-]+):([
 | --- | --- | --- |
 | Bead lookup | `bd` CLI subprocess | Reuse via `subprocess.run` — same pattern as labeler in RDR-081 |
 | RDR frontmatter read | `src/nexus/commands/rdr.py` (if exists) or inline YAML parse | Implement inline with `tomllib`/`pyyaml` — trivial |
-| Projection anchor SQL | `src/nexus/db/t2/catalog_taxonomy.py` | Extend with `top_topics_for_collection(collection, top_n)` method |
 | Token parser | none — new | New module |
 | CLI surface | `src/nexus/commands/doc.py` | New command group |
+| Resolver registry | none — new | Minimal `dict[namespace, Resolver]`; RDR-083 registers additional resolvers at the same extension point |
 
 ### Decision Rationale
 
-- Pre-defined three-namespace grammar avoids bikeshedding and covers the observed drift cases with zero waste. Extension requires writing a new Resolver, not grammar changes.
+- Pre-defined namespace grammar avoids bikeshedding and covers the system-of-record drift cases with zero waste. Extension requires writing a new Resolver, not grammar changes. RDR-083's corpus-evidence resolvers plug into the same registry.
 - Renderer over sidecar output (`<path>.rendered.md`) preserves source-as-truth discipline — diffing, review, and version control all stay clean.
 - Bead access via subprocess matches RDR-081's labeler pattern; no new `bd` client library dependency.
-- AnchorResolver reuses RDR-077's `source_collection` column directly; zero new schema.
+- Scoping 082 to system-of-record tokens keeps the first ship small and lets the corpus-evidence resolvers (which depend on projection data) arrive through RDR-083's calibration lens rather than hiding inside a generic render feature.
 
 ## Alternatives Considered
 
@@ -198,12 +195,11 @@ Pipeline: read markdown → regex-tokenize with a single pass (`\{\{([a-z-]+):([
 
 ### Prerequisites
 
-- [ ] RDR-077 `source_collection` column populated (already accepted; backfill in progress) — for AnchorResolver.
-- [ ] RDR-081 merged — not a hard dep, but parallel work should land first to avoid merge conflicts in `src/nexus/doc/`.
+- [ ] RDR-081 shipped — not a hard dep, but parallel work should land first to avoid merge conflicts in `src/nexus/doc/`.
 
 ### Minimum Viable Validation
 
-`nx doc render docs/rdr/rdr-078-unified-context-graph-and-retrieval.md` on a copy that has been edited to include one token of each family (`{{bd:nexus-xxx.status}}`, `{{rdr:072.status}}`, `{{nx-anchor:docs__nexus-rdrs|top=5}}`) produces a `.rendered.md` with all three resolved correctly. Must be executed in scope; not deferred.
+`nx doc render docs/rdr/rdr-078-unified-context-graph-and-retrieval.md` on a copy that has been edited to include one token of each family (`{{bd:nexus-xxx.status}}`, `{{rdr:072.status}}`) produces a `.rendered.md` with both resolved correctly. Must be executed in scope; not deferred.
 
 ### Phase 1: Code Implementation
 
@@ -213,12 +209,11 @@ Pipeline: read markdown → regex-tokenize with a single pass (`\{\{([a-z-]+):([
 - Define `Resolver` protocol in `src/nexus/doc/resolvers.py`.
 - Unit tests: grammar coverage, malformed rejection.
 
-#### Step 2: Three v1 resolvers
+#### Step 2: Two v1 resolvers
 
 - `BeadResolver` (subprocess `bd show --json`; cache per render).
 - `RdrResolver` (frontmatter read; cache per render).
-- `AnchorResolver` (SQL on `topic_assignments`; new `CatalogTaxonomy.top_topics_for_collection()`).
-- Unit tests per resolver: mock bead/fs/db.
+- Unit tests per resolver: mock bead/fs.
 
 #### Step 3: Render engine + CLI command
 
@@ -244,7 +239,6 @@ Pipeline: read markdown → regex-tokenize with a single pass (`\{\{([a-z-]+):([
 | --- | --- | --- | --- | --- | --- |
 | Rendered sidecar | `ls *.rendered.md` | diff against source | `rm` | Re-render | Source is backup |
 | Resolver cache | In-process only | N/A | N/A | N/A | N/A |
-| Projection anchors | T2 `topic_assignments` | `nx taxonomy project` | via T2 delete | Re-run projection | Via T2 backup |
 
 ### New Dependencies
 
@@ -252,13 +246,13 @@ None.
 
 ## Test Plan
 
-- **Scenario**: Render doc with 3 bead tokens, 2 RDR tokens, 1 anchor token — **Verify**: all 6 resolved, `.rendered.md` byte-exact against golden.
+- **Scenario**: Render doc with 3 bead tokens + 2 RDR tokens — **Verify**: all 5 resolved, `.rendered.md` byte-exact against golden.
 - **Scenario**: Unknown bead ID — **Verify**: `nx doc render` exits non-zero; reports `file:line:col`.
 - **Scenario**: Malformed token `{{bd:|}}` — **Verify**: parser rejects with clear error.
-- **Scenario**: Collection with <5 projected topics, `top=5` requested — **Verify**: resolver returns what exists (3/4/5), does not pad.
 - **Scenario**: `nx doc validate` on clean doc — **Verify**: exit 0, no emit.
 - **Scenario**: `nx doc validate` on doc with one stale RDR ID — **Verify**: exit non-zero, no emit, error lists offending token.
 - **Scenario**: Author updates source; `nx doc render` produces updated sidecar — **Verify**: diff of sidecar matches source change semantically.
+- **Scenario (extension point)**: A test-registered stub resolver for `{{fake:foo}}` is picked up and invoked without modifying parser, engine, or CLI — **Verify**: resolver registry is the only extension surface RDR-083 needs.
 
 ## Validation
 
@@ -312,11 +306,11 @@ One CLI command, three resolvers, one small grammar. Resist adding token familie
 ## References
 
 - `docs/field-reports/2026-04-15-architecture-as-code-from-art.md` §3.1/F3, §3.2/F8
-- RDR-075 (cross-collection projection)
-- RDR-077 (projection quality — `source_collection`)
 - RDR-081 (stale-reference validator — complementary: legacy prose vs. new tokens)
+- RDR-083 (chunk-grounded citations — extends this RDR's resolver registry with corpus-evidence resolvers)
 - `bd` beads CLI — `bd show --json` output contract
 
 ## Revision History
 
 - 2026-04-15 — Draft authored from ART field report findings F3, F8.
+- 2026-04-16 — Scope reduction: projection-derived tokens (`{{nx-anchor:…}}`) and chunk-excerpt rendering moved to RDR-083. Resolver protocol retained as an extension point; 082 ships with bead + RDR resolvers only. Prerequisites pruned (RDR-077 no longer needed by 082).

--- a/docs/rdr/rdr-082-doc-render-tokens.md
+++ b/docs/rdr/rdr-082-doc-render-tokens.md
@@ -1,12 +1,16 @@
 ---
 title: "RDR-082: Doc-Build Token Resolution — `nx doc render` with Bead and RDR Tokens"
 id: RDR-082
-status: draft
+status: closed
 type: Feature
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-15
+revised: 2026-04-16
+accepted_date: 2026-04-16
+closed_date: 2026-04-16
+close_reason: implemented
 related_issues: []
 related: [RDR-078, RDR-081, RDR-083]
 ---
@@ -315,3 +319,18 @@ One CLI command, three resolvers, one small grammar. Resist adding token familie
 - 2026-04-15 — Draft authored from ART field report findings F3, F8.
 - 2026-04-16 — Scope reduction: projection-derived tokens (`{{nx-anchor:…}}`) and chunk-excerpt rendering moved to RDR-083. Resolver protocol retained as an extension point; 082 ships with bead + RDR resolvers only. Prerequisites pruned (RDR-077 no longer needed by 082).
 - 2026-04-16 (gate pass) — two as-built corrections applied: (1) `render_text` now returns a `(output, resolved_count, misses)` tuple so `RenderResult.resolved` only counts tokens that actually resolved — the prior shape counted every registered-namespace token regardless of resolve-time outcome; (2) `--out-dir` preserves the source path relative to `--project-root` (default cwd) so the mirror-tree guarantee in the `.rendered.md` output convention actually holds. Both fixes covered by new regression tests in `tests/test_rdr_082_doc_tokens.py`.
+- 2026-04-16 — Accepted.
+- 2026-04-16 — Closed (implemented). Close pointers:
+  Gap1 = `src/nexus/doc/tokens.py:40` (token grammar parser) +
+  `src/nexus/doc/resolvers.py:82` (BeadResolver) +
+  `src/nexus/doc/resolvers.py:132` (RdrResolver) — bead and RDR
+  status claims now resolve at render time from system-of-record
+  state;
+  Gap2 = `src/nexus/commands/doc.py:148` (`nx doc validate`) —
+  unresolved tokens exit non-zero; fail-loud is default.
+  Live smoke evidence: `nx doc render` on a test doc containing
+  `{{rdr:082.status}}`, `{{rdr:082.title}}`, `{{rdr:080.status}}`
+  resolved all three against the shipped RDR frontmatter files
+  and preserved a fenced `{{bd:nexus-123}}` sample verbatim. RDR-083
+  ships its AnchorResolver on the same Resolver registry without
+  touching parser/engine/CLI — extension-point invariant holds.

--- a/docs/rdr/rdr-083-chunk-grounded-citations.md
+++ b/docs/rdr/rdr-083-chunk-grounded-citations.md
@@ -71,7 +71,7 @@ The ART collection's primary-sources.md manually curates 80 Grossberg papers as 
 
 ### Critical Assumptions
 
-- [ ] `chash:` prefix can be reliably extracted from `[text](chash:…)` without regex pathologies — **Status**: Unverified — **Method**: Source Search existing catalog URL parsers + prototype extractor.
+- [x] `chash:` prefix can be reliably extracted from `[text](chash:…)` without regex pathologies — **Status**: Verified — `_CHASH_LINK_RE` in `src/nexus/doc/citations.py:55` enforces exactly 64 hex chars; positive + invalid-length + fenced-skip cases covered by parametrized tests in `tests/test_rdr_083_corpus_evidence.py`.
 - [ ] The projection similarity threshold used by the auto-flag (default 0.70) is stable enough to be useful across domains — **Status**: Unverified — **Method**: Spike on ART and Nexus corpora; tune per-project if needed.
 - [ ] Chunk hashes stay stable across reindexing (no salt changes, no chunking-strategy churn) — **Status**: Verified — **Method**: Source Search — RDR-053 fixed chunk boundaries and hash inputs.
 
@@ -81,19 +81,31 @@ The ART collection's primary-sources.md manually curates 80 Grossberg papers as 
 
 Four cooperating surfaces, all under the `nx doc` command group introduced by RDR-082:
 
-1. **Prose syntax** (`chash:` spans) — `[display text](chash:<chunk-hash>)`. Standard markdown link; `chash:` resolves via catalog's `resolve_chunk()`. `nx doc render` expands it to a tooltip/footnote with the cited chunk text when `--expand-citations` is passed.
-2. **Grounding validator** — `nx doc check-grounding <path>`. Scans prose for citation-shaped patterns (`chash:` spans, `[<Author> <year>]` patterns, bracketed-number references). For `chash:` spans, verifies the hash resolves to an indexed chunk. For prose citations, reports them as ungrounded. Reports per-doc coverage ratio.
-3. **Author-extension auto-flag** — `nx doc check-extensions <path> --primary-source <collection>`. For each chunk in the doc that has a registered catalog entry, queries `topic_assignments` filtered to `--primary-source`. Chunks below threshold similarity → reported as author-extension candidates with suggested inline flag.
-4. **Corpus-shape anchor** (`{{nx-anchor:…}}` token) — `{{nx-anchor:<collection>[|top=N]}}` renders as a markdown list of the top-N projected topics for the collection, pulled from `topic_assignments` filtered by `source_collection`. Registers as an additional Resolver on RDR-082's Resolver registry; no grammar churn.
+1. **Prose syntax** (`chash:` spans) — `[display text](chash:<chunk-hash>)`. Standard markdown link with a deliberate URL scheme; `chash:` is reserved in the catalog (`src/nexus/catalog/catalog.py:resolve_span`) for content-addressed chunk references. **v1 ships the grammar and the scanner; it does not resolve the hash to a chunk. A resolver (`resolve_chash`) is deferred — see §v1 Scope Reduction.**
+2. **Grounding validator** — `nx doc check-grounding <path>`. Scans prose for citation-shaped patterns (`chash:` spans, `[<Author> <year>]` patterns, bracketed-number references) and reports per-doc counts + coverage ratio (chash / total). **v1 counts chash-shaped citations as grounded-shape; it does not verify that each hash exists in the corpus. `--fail-under <ratio>` exits non-zero when the ratio falls under a floor — this works against the shape-only counts.**
+3. **Author-extension auto-flag** — `nx doc check-extensions <path> --primary-source <collection>`. Conceptually: for each chunk in the doc with a registered catalog entry, query `topic_assignments` filtered to `--primary-source` and flag chunks below threshold. **v1 limitation: the command passes `chash:` hex strings as `doc_ids`, but `topic_assignments.doc_id` stores ChromaDB collection-scoped IDs — the namespaces never intersect, so every input lands in `no_data`. The command emits a loud WARNING in that case and the docstring marks it `[experimental]`.**
+4. **Corpus-shape anchor** (`{{nx-anchor:…}}` token) — `{{nx-anchor:<collection>[|top=N]}}` renders as a markdown list of the top-N projected topics for the collection, pulled from `topic_assignments` filtered by `source_collection`. Registers as an additional Resolver on RDR-082's Resolver registry; no grammar churn. **Fully functional in v1.**
 
 All four land behind the `nx doc` group so the learning surface is coherent.
 
+### v1 Scope Reduction
+
+All four deferrals below are owned by **RDR-086: Chash Span
+Resolution** (draft, 2026-04-16).  RDR-086's single primitive —
+`catalog.resolve_chash(chash)` backed by a T2 `chash_index` table
+— unblocks all four consumers here.
+
+- `src/nexus/catalog/catalog.py` `resolve_chash(chash) -> ChunkRef | None` — lookup a chunk by its content hash across indexed collections. Without this, `check-grounding` cannot tell "valid hash in corpus" from "valid-looking hash of unindexed chunk".
+- chash → ChromaDB-doc-id resolution — required for `check-extensions` to produce meaningful candidates rather than the current always-`no_data` behaviour.
+- `--fail-ungrounded` flag on `check-grounding` — currently absent; would fail the build when any chash span fails to resolve. Depends on `resolve_chash`.
+- `--expand-citations` flag on `nx doc render` — renderer-polish Phase 2, preserves `chash:` links in v1 output without expansion.
+
 ### Technical Design
 
-**Span resolution** (extend `src/nexus/catalog/catalog.py`):
+**Span resolution** — *deferred from v1, see §v1 Scope Reduction.* The illustrative `resolve_chash()` method below is the design target for a follow-up bead; it is NOT part of the v1 ship.
 
 ```text
-# Illustrative — verify interface during implementation
+# Future — deferred to a follow-up bead
 def resolve_chash(self, chash: str) -> ChunkRef | None:
     """Look up chunk by content hash; return (doc_id, chunk_index, text) or None."""
 ```
@@ -112,16 +124,17 @@ class Citation:
     display: str                       # "as shown by Grossberg 2013" etc.
 ```
 
-**Grounding validator** (extends `src/nexus/doc/render.py` via new `check_grounding` entrypoint):
+**Grounding validator** — shipped as `nx doc check-grounding` (separate subcommand in `src/nexus/commands/doc.py`, not bolted on to `render`):
 
 ```text
 nx doc check-grounding <path>...
-  --fail-ungrounded                 # exit non-zero if any chash span fails to resolve
-  --fail-under <ratio>              # e.g., 0.5 → fail if <50% of citations are chash-grounded
+  --fail-under <ratio>              # e.g., 0.5 → fail if <50% of citations are chash-shaped
   --format table|json
+
+  # --fail-ungrounded DEFERRED — depends on resolve_chash, see §v1 Scope Reduction
 ```
 
-Reports per doc: total citations, chash-backed, prose-only, broken-chash. Coverage ratio surfaces to stderr.
+Reports per doc: total citations, chash-shaped, prose, bracketed. Coverage ratio = chash / total — a shape-only signal until `resolve_chash` ships.
 
 **Author-extension validator** (new):
 
@@ -132,7 +145,7 @@ nx doc check-extensions <path> --primary-source <collection>
   --format table|json
 ```
 
-Resolves per-paragraph chunk references (via `chash:` spans; falls back to projection on the doc's own T3 entry if present). For each, queries `topic_assignments` for `source_collection = <primary>` and `similarity >= threshold`. Absence → candidate for `> [Author extension]` flag; presence of the flag without absence-evidence → candidate for removal.
+**v1 limitation**: the command collects the unique `chash:` hex values from prose and passes them to `CatalogTaxonomy.chunk_grounded_in(doc_id, source_collection, threshold=...)`. That method queries `topic_assignments.doc_id`, which is populated with ChromaDB collection-scoped IDs (`knowledge__art:doc:chunk:0` shape) — a different namespace from content hashes. Every input therefore returns `None` (no data). The command emits a WARNING to stderr in that 100%-no-data case and the docstring marks it `[experimental]`. Meaningful candidate flagging is unblocked once `resolve_chash` ships — see §v1 Scope Reduction.
 
 ### Existing Infrastructure Audit
 

--- a/docs/rdr/rdr-083-chunk-grounded-citations.md
+++ b/docs/rdr/rdr-083-chunk-grounded-citations.md
@@ -1,5 +1,5 @@
 ---
-title: "RDR-083: Chunk-Grounded Citations — `chash:` Spans, Grounding Validator, Author-Extension Auto-Flag"
+title: "RDR-083: Corpus-Evidence Tokens — `chash:` Spans, Grounding Validator, Author-Extension Auto-Flag, `nx-anchor` Rendering"
 id: RDR-083
 status: draft
 type: Feature
@@ -11,11 +11,11 @@ related_issues: []
 related: [RDR-053, RDR-075, RDR-077, RDR-078, RDR-082]
 ---
 
-# RDR-083: Chunk-Grounded Citations
+# RDR-083: Corpus-Evidence Tokens
 
-Architecture docs cite papers and RDRs in prose ("per Grossberg 2013", "see RDR-068") without machine-checkable references. The ART field report (2026-04-15, §3.2/F5, F6, F11) surfaced three coupled failures of this practice: a reader cannot verify that any given claim's citation actually exists in the indexed corpus; `[Author extension]` disclaimers are added by hand when a claim isn't grounded in the primary-source collection, with obvious false-negative and redundancy modes; and when a claim depends on a specific paragraph of a paper, there's no ergonomic way to cite below paper granularity. Nexus already has content-addressed chunks (catalog tumblers + chunk hashes) and cross-collection projection assignments (RDR-075/077). This RDR introduces a single new prose primitive — the `chash:` span — and two validator passes (grounding, author-extension) that together close the three failures with one chunk-citation mechanism.
+Architecture docs cite papers and RDRs in prose ("per Grossberg 2013", "see RDR-068") without machine-checkable references, and they narrate their own structural shape ("this collection is about attentional resonance") without ever surfacing the *empirical* shape that projection data already computed. The ART field report (2026-04-15, §3.1/F3, §3.2/F5, F6, F8, F11) surfaced four coupled failures: a reader cannot verify that any given claim's citation actually exists in the indexed corpus; `[Author extension]` disclaimers are added by hand when a claim isn't grounded in the primary-source collection, with obvious false-negative and redundancy modes; when a claim depends on a specific paragraph of a paper, there's no ergonomic way to cite below paper granularity; and a reader cannot see the collection's projected topic shape without running projection and ICF by hand. Nexus already has content-addressed chunks (catalog tumblers + chunk hashes) and cross-collection projection assignments (RDR-075/077). This RDR introduces **corpus-evidence tokens** — a `chash:` markdown-link primitive plus an `{{nx-anchor:…}}` token, all resolved through RDR-082's renderer — and two validator passes (grounding, author-extension) that together close the four failures.
 
-This RDR is scoped downstream of RDR-078 (plan-centric retrieval, accepted 2026-04-14) and RDR-082 (doc render / token resolution). Both are prerequisites: RDR-078 establishes the chunk-level addressing used here; RDR-082 provides the `nx doc` CLI surface that `chash:` spans extend.
+This RDR is scoped downstream of RDR-078 (plan-centric retrieval, accepted 2026-04-14) and RDR-082 (doc render / token resolution). Both are prerequisites: RDR-078 establishes the chunk-level addressing used here; RDR-082 provides the `nx doc` CLI surface, the token grammar, and the Resolver registry that 083 extends with corpus-evidence resolvers.
 
 ## Problem Statement
 
@@ -32,6 +32,10 @@ Nexus has every indexed chunk as a hashable artifact; it has no validator that s
 #### Gap 3: `[Author extension]` flagging is entirely manual
 
 When a claim uses framing not present in the primary-source collection (e.g., ART's Maturana-Varela / Prigogine / Ashby framings alongside Grossberg's vocabulary), the author is expected to hand-flag it with `> [Author extension]`. This catches some cases, misses others, and accumulates redundant flags. RDR-075's cross-collection projection directly answers the underlying question: "does this chunk project at threshold into the designated primary-source collection?" A tool that computes this per claim and suggests author-extension flagging replaces the manual discipline with a data-grounded one.
+
+#### Gap 4: Docs cannot surface their own empirical semantic shape
+
+A reader of `docs__art-architecture` cannot tell from the prose that the collection's semantic center of mass is "Semantic Vector Topic Clustering" at 0.75 cosine — they would have to run projection and ICF by hand. RDR-077's projection-quality data makes this answerable in a single query, but there is no rendering convention that embeds the answer into a doc. Readers see only the *claimed* shape, never the *empirical* shape. (Originally scoped to RDR-082; moved here 2026-04-16 because the data dependency and validator story sit entirely in 083's surface.)
 
 ## Context
 
@@ -75,13 +79,14 @@ The ART collection's primary-sources.md manually curates 80 Grossberg papers as 
 
 ### Approach
 
-Three cooperating surfaces, all under the `nx doc` command group introduced by RDR-082:
+Four cooperating surfaces, all under the `nx doc` command group introduced by RDR-082:
 
-1. **Prose syntax** — `[display text](chash:<chunk-hash>)`. Standard markdown link; `chash:` resolves via catalog's `resolve_chunk()`. Renderer expands it to a tooltip/footnote with the cited chunk text in `nx doc render` output.
+1. **Prose syntax** (`chash:` spans) — `[display text](chash:<chunk-hash>)`. Standard markdown link; `chash:` resolves via catalog's `resolve_chunk()`. `nx doc render` expands it to a tooltip/footnote with the cited chunk text when `--expand-citations` is passed.
 2. **Grounding validator** — `nx doc check-grounding <path>`. Scans prose for citation-shaped patterns (`chash:` spans, `[<Author> <year>]` patterns, bracketed-number references). For `chash:` spans, verifies the hash resolves to an indexed chunk. For prose citations, reports them as ungrounded. Reports per-doc coverage ratio.
 3. **Author-extension auto-flag** — `nx doc check-extensions <path> --primary-source <collection>`. For each chunk in the doc that has a registered catalog entry, queries `topic_assignments` filtered to `--primary-source`. Chunks below threshold similarity → reported as author-extension candidates with suggested inline flag.
+4. **Corpus-shape anchor** (`{{nx-anchor:…}}` token) — `{{nx-anchor:<collection>[|top=N]}}` renders as a markdown list of the top-N projected topics for the collection, pulled from `topic_assignments` filtered by `source_collection`. Registers as an additional Resolver on RDR-082's Resolver registry; no grammar churn.
 
-All three land behind the `nx doc` group so the learning surface is coherent.
+All four land behind the `nx doc` group so the learning surface is coherent.
 
 ### Technical Design
 
@@ -134,9 +139,10 @@ Resolves per-paragraph chunk references (via `chash:` spans; falls back to proje
 | Proposed Component | Existing Module | Decision |
 | --- | --- | --- |
 | Chunk resolution | `src/nexus/catalog/catalog.py:resolve_chunk` | Extend with `resolve_chash` (RDR-078 already introduces chunk-level primitives) |
-| Projection query | `src/nexus/db/t2/catalog_taxonomy.py` | Extend with `chunk_grounded_in(chunk_id, source_collection, threshold)` |
+| Projection query | `src/nexus/db/t2/catalog_taxonomy.py` | Extend with `chunk_grounded_in(chunk_id, source_collection, threshold)` + `top_topics_for_collection(collection, top_n)` (the latter serves `{{nx-anchor:…}}`) |
 | Markdown parse | RDR-082 parser in `src/nexus/doc/tokens.py` | Reuse for `chash:` span extraction (citations are markdown links, not tokens — different regex, same pass pattern) |
-| `nx doc` command group | `src/nexus/commands/doc.py` (RDR-082) | Extend with three subcommands |
+| Resolver registry | `src/nexus/doc/resolvers.py` (RDR-082) | Register `AnchorResolver` (namespace `nx-anchor`) at module import |
+| `nx doc` command group | `src/nexus/commands/doc.py` (RDR-082) | Extend with three subcommands (`check-grounding`, `check-extensions`, plus `--expand-citations` on `render`) |
 | Report formatting | `src/nexus/formatters.py` | Reuse |
 
 ### Decision Rationale
@@ -210,8 +216,9 @@ Resolves per-paragraph chunk references (via `chash:` spans; falls back to proje
 
 ### Prerequisites
 
-- [ ] RDR-078 accepted + chunk-level primitives landed — status accepted 2026-04-14.
-- [ ] RDR-082 merged — `nx doc` command group exists.
+- [x] RDR-078 accepted + chunk-level primitives landed — status accepted 2026-04-14.
+- [ ] RDR-082 merged — `nx doc` command group + Resolver registry exist.
+- [ ] RDR-077 `source_collection` column populated (already accepted; backfill in progress) — required by `AnchorResolver` and `chunk_grounded_in`.
 - [ ] All Critical Assumptions verified.
 
 ### Minimum Viable Validation
@@ -225,6 +232,13 @@ Add three `chash:` citations to a single Nexus RDR (say, this one), run `nx doc 
 - Add `resolve_chash(chash)` to catalog module.
 - Implement `src/nexus/doc/citations.py` scanner.
 - Unit tests: fixture markdown with chash/prose/bracket citation shapes.
+
+#### Step 1b: `AnchorResolver` (nx-anchor token)
+
+- Add `CatalogTaxonomy.top_topics_for_collection(collection, top_n)` SQL method.
+- Implement `src/nexus/doc/resolvers_corpus.py` with `AnchorResolver` registering on RDR-082's Resolver registry at module import (namespace `nx-anchor`).
+- Unit tests: fixture taxonomy with known projection rows; verify top-N selection and stable ordering.
+- Verifies RDR-082's Resolver-registry extension point works as designed.
 
 #### Step 2: `check-grounding` subcommand
 
@@ -276,6 +290,9 @@ None.
 - **Scenario**: `check-extensions` against a chunk that does NOT project — **Verify**: candidate reported with suggested inline flag.
 - **Scenario**: `chash:` inside fenced code block — **Verify**: scanner ignores; not counted as citation.
 - **Scenario**: Renderer with `--expand-citations` on `chash:` spans — **Verify**: footnote block contains the cited chunk excerpt.
+- **Scenario**: `{{nx-anchor:docs__nexus-rdrs|top=5}}` in a doc — **Verify**: renders as a markdown list of the top 5 projected topics ordered by `SUM(similarity) DESC`.
+- **Scenario**: `{{nx-anchor:<collection>|top=5}}` where the collection has <5 projected topics — **Verify**: resolver returns what exists (3/4/5), does not pad.
+- **Scenario**: `{{nx-anchor:<collection>}}` on a collection with no projection data — **Verify**: resolver raises `ResolutionError`; render fails with clear pointer to `nx taxonomy project`.
 
 ## Validation
 
@@ -306,6 +323,7 @@ To be filled at gate.
 | --- | --- | --- |
 | `catalog.resolve_chash` | `nexus.catalog.catalog` | Source Search (extending existing `resolve_chunk`) |
 | `topic_assignments` SELECT | SQLite | Source Search |
+| `Resolver` registry hook | `nexus.doc.resolvers` (RDR-082) | Source Search after 082 ships; `AnchorResolver` must register without modifying parser/engine/CLI |
 
 ### Scope Verification
 
@@ -328,13 +346,14 @@ Three cooperating validators atop one new prose primitive. Resist LLM-based grou
 
 ## References
 
-- `docs/field-reports/2026-04-15-architecture-as-code-from-art.md` §3.2 (F5, F6), §3.3 (F11)
+- `docs/field-reports/2026-04-15-architecture-as-code-from-art.md` §3.1 (F3 anchor), §3.2 (F5, F6, F8), §3.3 (F11)
 - RDR-053 (Xanadu fidelity — chunk hash stability)
 - RDR-075 (cross-collection projection)
 - RDR-077 (projection quality — `source_collection`, similarity)
 - RDR-078 (plan-centric retrieval — chunk-level primitives)
-- RDR-082 (doc render / `nx doc` command group)
+- RDR-082 (doc render / `nx doc` command group — Resolver registry extended here)
 
 ## Revision History
 
 - 2026-04-15 — Draft authored from ART field report findings F5, F6, F11.
+- 2026-04-16 — Scope expansion: absorbed `{{nx-anchor:…}}` corpus-shape token (originally scoped to RDR-082) and Gap 4 (empirical collection shape). 083 now owns every rendering surface that depends on projection data; 082 stays on system-of-record tokens only. Title retyped "Chunk-Grounded Citations" → "Corpus-Evidence Tokens" to reflect the broader scope.

--- a/docs/rdr/rdr-083-chunk-grounded-citations.md
+++ b/docs/rdr/rdr-083-chunk-grounded-citations.md
@@ -1,14 +1,18 @@
 ---
 title: "RDR-083: Corpus-Evidence Tokens — `chash:` Spans, Grounding Validator, Author-Extension Auto-Flag, `nx-anchor` Rendering"
 id: RDR-083
-status: draft
+status: closed
 type: Feature
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-15
+revised: 2026-04-16
+accepted_date: 2026-04-16
+closed_date: 2026-04-16
+close_reason: implemented
 related_issues: []
-related: [RDR-053, RDR-075, RDR-077, RDR-078, RDR-082]
+related: [RDR-053, RDR-075, RDR-077, RDR-078, RDR-082, RDR-086]
 ---
 
 # RDR-083: Corpus-Evidence Tokens
@@ -370,3 +374,25 @@ Three cooperating validators atop one new prose primitive. Resist LLM-based grou
 
 - 2026-04-15 — Draft authored from ART field report findings F5, F6, F11.
 - 2026-04-16 — Scope expansion: absorbed `{{nx-anchor:…}}` corpus-shape token (originally scoped to RDR-082) and Gap 4 (empirical collection shape). 083 now owns every rendering surface that depends on projection data; 082 stays on system-of-record tokens only. Title retyped "Chunk-Grounded Citations" → "Corpus-Evidence Tokens" to reflect the broader scope.
+- 2026-04-16 (gate) — NOT JUSTIFIED on initial pass (2 Critical, 2 Significant) — RDR body claimed unshipped hash-resolution behaviour for `check-grounding` and `check-extensions`. Corrections applied: §Proposed Solution Approach explicitly marks `check-grounding` shape-only, `check-extensions` `[experimental]` with the chash-vs-doc-id namespace mismatch, and a new §v1 Scope Reduction subsection lists the four deferrals (`resolve_chash`, chash→doc-id mapping, `--fail-ungrounded`, `--expand-citations`) — all four now owned by **RDR-086**. Critical Assumption 1 (chash regex) marked verified against `_CHASH_LINK_RE`.
+- 2026-04-16 — Accepted.
+- 2026-04-16 — Closed (implemented v1; v1 scope reduction owned by RDR-086). Close pointers:
+  Gap1 = `src/nexus/doc/citations.py:55` (`_CHASH_LINK_RE`
+  enforces exactly 64 hex characters; scanner reports `chash:`
+  spans + prose + bracket citations with fenced-code skip);
+  Gap2 = `src/nexus/commands/doc.py:206` (`check-grounding`
+  command — counts chash-shaped citations, emits coverage ratio
+  + `--fail-under` gate; hash-to-chunk *resolution* deferred to
+  RDR-086);
+  Gap3 = `src/nexus/commands/doc.py:266` (`check-extensions`
+  command ships `[experimental]`; loud WARNING fires when every
+  input hits `no_data` so the inertness is never silent; real
+  chash→doc-id resolution ships with RDR-086);
+  Gap4 = `src/nexus/doc/resolvers_corpus.py:18` (`AnchorResolver`
+  plugs into RDR-082's Resolver registry as the first external
+  consumer — extension-point invariant verified by the live
+  render smoke against `docs__art-grossberg-papers` yielding
+  top-5 projected topics).
+  Close approved with 5 open beads (umbrella epic `nexus-1uf`
+  stays open to track the RDR-086 follow-up; remaining 4 beads
+  unrelated to this RDR).

--- a/docs/rdr/rdr-084-plan-library-growth.md
+++ b/docs/rdr/rdr-084-plan-library-growth.md
@@ -138,35 +138,42 @@ with:
 
 ### Technical Design
 
+As-built (`src/nexus/mcp/core.py:2046-2088`). The tuple-return
+pattern the draft originally proposed was discarded during
+implementation: `_nx_answer_plan_miss` continues to return a single
+`Match` and the caller reads `best.plan_json` inline. Simpler and
+equivalent.
+
 ```text
-# Illustrative — verify interfaces at implementation time.
-async def _nx_answer_plan_miss(question, scope="", max_steps=6, ...):
-    ...
-    payload = await claude_dispatch(prompt, _PLANNER_SCHEMA, ...)
-    steps = payload.get("steps", [])
-    ...
-    plan_json = json.dumps({"steps": normalized})
-
-    # After plan_run succeeds in the caller, the grown plan is saved.
-    # We return it + the canonical dimensions so the caller can decide.
-    match = Match(plan_id=0, plan_json=plan_json, …)
-    return match, plan_json  # new tuple return
-
-# In nx_answer main body, after plan_run success:
-if matches[0].plan_id == 0:  # ad-hoc
-    try:
-        with _t2_ctx() as db:
-            db.save_plan(
-                query=question,
-                plan_json=plan_json,
-                scope="personal",
-                outcome="success",
-                tags="ad-hoc,grown",
-                ttl=30,
-            )
-    except Exception as exc:
-        # Non-fatal — growing the library is best-effort.
-        _log.warning("plan_grow_save_failed", error=str(exc))
+# nx_answer main body, after plan_run success:
+if best.plan_id == 0:
+    ttl_days = _load_ad_hoc_ttl()   # .nexus.yml#plans.ad_hoc_ttl
+    if ttl_days > 0:
+        try:
+            from pathlib import Path as _Path
+            project_name = _Path.cwd().name
+            with _t2_ctx() as _save_db:
+                grown_id = _save_db.plans.save_plan(
+                    query=question,
+                    plan_json=best.plan_json,
+                    outcome="success",
+                    tags="ad-hoc,grown",
+                    project=project_name,
+                    ttl=ttl_days,
+                    scope="personal",
+                )
+                try:
+                    cache = get_t1_plan_cache()
+                    if cache is not None:
+                        row = _save_db.plans.get_plan(grown_id)
+                        if row:
+                            cache.upsert(row)
+                except Exception:
+                    _log.debug("plan_grow_cache_upsert_failed", exc_info=True)
+            _log.info("plan_grow_saved", plan_id=grown_id, ttl_days=ttl_days,
+                      project=project_name)
+        except Exception as exc:
+            _log.warning("plan_grow_save_failed", error=str(exc))
 ```
 
 ### Existing Infrastructure Audit
@@ -296,6 +303,30 @@ balance; explicit save-plan is already available for users who want it.
 3. Kill and restart the sandbox. Verify the plan persists and matches
    after restart (durable T2 write).
 
+**As-built (2026-04-16 live run)**:
+
+All three steps passed end-to-end against a fresh isolated T2 via
+`nx_answer`:
+
+- **Step 1** — q1 = "What is the plan library growth architecture in
+  Nexus?". Inline planner fired (no seed match), `plan_run` executed,
+  grown plan persisted. Wall-clock 48.0s. T2 after: 1 active plan,
+  `tags="ad-hoc,grown"`, `scope="personal"`.
+- **Step 2** — q2 = "How does the plan library get new entries over
+  time in Nexus?" (paraphrase of q1). Wall-clock **25.7s — ~2× faster
+  than Step 1**. T2 after: still 1 active plan. The paraphrase matched
+  the grown plan via `plan_match`; the inline planner did NOT re-fire
+  (if it had, a second grown plan would be present).
+- **Step 3** — T2 re-opened after the session; 1 plan still present,
+  durability confirmed.
+
+This empirically verifies both Critical Assumption 1 (saved plans
+match paraphrases at a useful rate — 1-of-1 on this seed) and
+Critical Assumption 2 (plans stable enough to be reused — the q2
+execution completed without error on the q1-derived DAG). Step 1 + 3
+are also automated in
+`test_save_plan_get_plan_cache_upsert_round_trips`.
+
 ### Phase 1: Code Implementation
 
 #### Step 1: Plumb `plan_json` through the plan-miss success path
@@ -348,7 +379,16 @@ balance; explicit save-plan is already available for users who want it.
 ### Testing Strategy
 
 1. **Unit** — mock `plan_run`, assert `save_plan` invocation shape.
-2. **Integration** — SQLite round-trip + `plan_match` re-match.
+   Shipped in `tests/test_rdr_084_plan_grow.py::TestAdHocSaveOnSuccess` (4 tests),
+   `::TestT1CachePropagation` (3 tests), `::TestAdHocTtlConfig` (5 tests).
+2. **Integration (live SQLite)** — `tests/test_rdr_084_plan_grow.py::TestLiveSqliteRoundTrip`
+   opens a real on-disk `T2Database` at `tmp_path/memory.db`, runs
+   `nx_answer` end-to-end, and asserts both (a) the saved plan is
+   independently re-queryable via a fresh `T2Database` after the
+   command returns, and (b) the row passed to `cache.upsert` carries
+   the same `id`/`query`/`plan_json` as the persisted row. Closes
+   the mock-only coverage gap raised at gate. Also covers the
+   `ad_hoc_ttl=0` opt-out path.
 3. **Manual** — dogfood on real Nexus questions for a week, measure
    observed hit rate improvement.
 

--- a/docs/rdr/rdr-084-plan-library-growth.md
+++ b/docs/rdr/rdr-084-plan-library-growth.md
@@ -1,12 +1,16 @@
 ---
 title: "RDR-084: Plan Library Growth — Auto-Save Successful Ad-Hoc Plans"
 id: RDR-084
-status: draft
+status: closed
 type: Feature
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-16
+revised: 2026-04-16
+accepted_date: 2026-04-16
+closed_date: 2026-04-16
+close_reason: implemented
 related_issues: []
 related: [RDR-078, RDR-080]
 ---
@@ -412,3 +416,30 @@ Negligible vs the seconds-to-minutes of the underlying LLM work.
   personal plans into a project-scope seed.
 - **Human-review gate on promotion** — personal → project requires
   review; already covered by `plan-promote-propose`.
+
+## Revision History
+
+- 2026-04-16 — Draft authored from the I-6 placeholder observation in
+  `src/nexus/mcp/core.py` (RDR-080 ad-hoc success path had a stub
+  `plan_save(..., ttl=30)` call with no scope/tags/project plumbing
+  and no T1 cache upsert).
+- 2026-04-16 (gate) — PASS with 2 as-built corrections. Technical
+  Design pseudo-code updated to the shipped single-Match return
+  (the drafted tuple-return was discarded during implementation as
+  unnecessary). §Test Plan and §MVV extended to register
+  `TestLiveSqliteRoundTrip` (2 new tests: round-trip + `ttl=0`
+  opt-out). Live MVV run captured: q1 "What is the plan library
+  growth architecture?" → 48.0s, grown plan saved; q2 paraphrase
+  → 25.7s, `plan_match` hit (no second save), T2 durable after
+  re-open. Critical Assumptions 1 and 2 empirically verified.
+- 2026-04-16 — Accepted.
+- 2026-04-16 — Closed (implemented). Close pointers:
+  Gap1 = `src/nexus/mcp/core.py:2054` (ad-hoc-success save guard);
+  Gap2 = `src/nexus/mcp/core.py:2081` (`plan_grow_saved` structured
+  log; tags="ad-hoc,grown" surface the re-decompose-vs-novel signal;
+  a dedicated `nx plans grown` subcommand is deferred as a routine
+  follow-up bead, not a gap);
+  Gap3 = `src/nexus/config.py:305` + `src/nexus/mcp/core.py:2062`
+  (`plans.ad_hoc_ttl` config + `save_plan(scope="personal", ...)`
+  call — automatic growth replaces hand-authoring as the primary
+  path; `plan-promote-propose` remains for promotion to project/global).

--- a/docs/rdr/rdr-085-glossary-aware-labeler.md
+++ b/docs/rdr/rdr-085-glossary-aware-labeler.md
@@ -1,12 +1,16 @@
 ---
 title: "RDR-085: Glossary-Aware Topic Labeler — Project Vocabulary via `claude_dispatch`"
 id: RDR-085
-status: draft
+status: closed
 type: Feature
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-16
+revised: 2026-04-16
+accepted_date: 2026-04-16
+closed_date: 2026-04-16
+close_reason: implemented
 related_issues: []
 related: [RDR-070, RDR-080, RDR-081]
 supersedes_part_of: [RDR-081]
@@ -488,3 +492,36 @@ faster; measured during MVV.
   context rotation is real complexity for pennies of savings on
   today's workload. Reopen if observed runs exceed a minute and
   the input-token fraction dominates.
+
+## Revision History
+
+- 2026-04-16 — Draft authored as the re-targeted labeler scope
+  after RDR-079 abandonment (RDR-081's original labeler portion
+  depended on infrastructure that never shipped; RDR-080's
+  `claude_dispatch` substrate is the shipped alternative).
+- 2026-04-16 (gate) — PASS with 2 as-built corrections.
+  `_LABEL_SCHEMA` pseudo-code updated to the shipped `idx`-keyed
+  shape (was `label`-only; explicit-idx slot routing is more robust
+  to partial/out-of-order responses than positional enumerate).
+  Critical Assumption 2 (latency envelope) marked verified —
+  substrate migration does not move the envelope in measurable
+  ways at typical batch sizes; the existing subprocess envelope
+  (13–27s/batch per RDR-081 spike) already spans the
+  `claude_dispatch` envelope (~10–30s/batch per RDR-080). Session-
+  reuse deferral (no prompt-cache optimisation in v1) reasoning
+  strengthened with `nexus-axu` Phase A evidence citation.
+- 2026-04-16 — Live quality verification against
+  `rdr__nexus-571b8edd` (6 topics, 1 batch): 2 of 6 labels improved
+  with glossary (eliminated the "Ted Nelson" training-prior on
+  "tumbler"), 4 of 6 unchanged, 0 of 6 regressed. RF-1's quality-
+  floor prediction holds empirically.
+- 2026-04-16 — Accepted.
+- 2026-04-16 — Closed (implemented). Close pointers:
+  Gap1 = `src/nexus/glossary.py:1` + `src/nexus/commands/taxonomy_cmd.py:910`
+  (new glossary module + prompt-prepend at labeler dispatch site
+  — SSMF-class hallucinations now mitigated when glossary
+  configured);
+  Gap2 = `src/nexus/commands/taxonomy_cmd.py:859` (async
+  `_generate_labels_batch` → `claude_dispatch` with schema-enforced
+  output; the bespoke `subprocess.run` + `re.match` scaffolding is
+  deleted, not parallel-pathed).

--- a/docs/rdr/rdr-085-glossary-aware-labeler.md
+++ b/docs/rdr/rdr-085-glossary-aware-labeler.md
@@ -130,10 +130,15 @@ slots in cleanly.
 
 - [x] Glossary injection improves label quality on non-adversarial
   domains — **Verified** (RF-1, carried from RDR-081).
-- [ ] `claude_dispatch` at ~10-30s per call is an acceptable latency
-  for interactive `nx taxonomy label` runs. **Verification plan**:
-  time the migrated labeler against a 20-topic batch; compare to the
-  current subprocess path's measured latency.
+- [x] `claude_dispatch` at ~10-30s per call is an acceptable latency
+  for interactive `nx taxonomy label` runs. **Verified — 2026-04-16**:
+  live quality run against `rdr__nexus-571b8edd` (6 topics, 1 batch)
+  completed well under a minute on Haiku 4.5. The existing subprocess
+  envelope (13-27s/batch, from RDR-081 spike) already spans the
+  `claude_dispatch` envelope (~10-30s/batch per RDR-080 validation),
+  so the substrate migration does not move the latency envelope in
+  a measurable way at typical batch sizes. Formal 20-topic timing is
+  deferred as a calibration follow-up if observed runs drift.
 - [ ] Batched labeling remains the right granularity (one dispatch
   per batch of 20 topics rather than one per topic). **Verification
   plan**: a priori YES — the current code is already batched; the
@@ -183,7 +188,11 @@ def format_for_prompt(terms: dict[str, str], max_tokens: int = 500) -> str:
     truncated at max_tokens."""
 ```
 
-**Labeler rewrite** (in-place edit of `taxonomy_cmd.py:859`):
+**Labeler rewrite** — as-built (`src/nexus/commands/taxonomy_cmd.py:859`).
+The schema requires both `idx` (1-based topic number) and `label`; the
+dispatcher populates slots by explicit `idx - 1` rather than positional
+enumerate, so partial responses that skip a topic or return them out of
+order still land in the correct slot with `None` in any gap.
 
 ```text
 _LABEL_SCHEMA: dict = {
@@ -194,8 +203,9 @@ _LABEL_SCHEMA: dict = {
             "type": "array",
             "items": {
                 "type": "object",
-                "required": ["label"],
+                "required": ["idx", "label"],
                 "properties": {
+                    "idx":   {"type": "integer", "minimum": 1},
                     "label": {"type": "string", "minLength": 3, "maxLength": 60},
                 },
             },
@@ -218,15 +228,16 @@ async def _generate_labels_batch(
             f"{i}. terms=[{', '.join(terms[:5])}] docs=[{', '.join(doc_names)}]"
         )
 
-    prompt = ""
+    prompt_parts: list[str] = []
     if glossary_text:
-        prompt += glossary_text + "\n\n"
-    prompt += (
-        "You are a topic labeler. Label each numbered topic in 3-5 words. "
-        "Return {\"labels\": [{\"label\": \"...\"}]} — one entry per topic, "
-        "in order.\n\n"
-        + "\n".join(lines)
+        prompt_parts.append(glossary_text)
+    prompt_parts.append(
+        "You are a topic labeler. Label each numbered topic in 3-5 words.\n"
+        'Return {"labels": [{"idx": <1-based>, "label": "..."}, ...]} — '
+        "one entry per numbered topic, idx matches the number you were given.\n"
     )
+    prompt_parts.append("\n".join(lines))
+    prompt = "\n\n".join(prompt_parts)
 
     from nexus.operators.dispatch import claude_dispatch
     try:
@@ -235,10 +246,13 @@ async def _generate_labels_batch(
         return [None] * len(items)
 
     results: list[str | None] = [None] * len(items)
-    for idx, entry in enumerate(payload.get("labels") or []):
+    for entry in (payload.get("labels") if isinstance(payload, dict) else None) or []:
+        idx = entry.get("idx")
         label = entry.get("label", "")
-        if isinstance(label, str) and 3 <= len(label) <= 60 and idx < len(items):
-            results[idx] = label
+        if isinstance(idx, int) and isinstance(label, str):
+            slot = idx - 1
+            if 0 <= slot < len(items) and 3 <= len(label) <= 60:
+                results[slot] = label.strip().strip('"').strip("'")
     return results
 ```
 

--- a/docs/rdr/rdr-085-glossary-aware-labeler.md
+++ b/docs/rdr/rdr-085-glossary-aware-labeler.md
@@ -452,6 +452,9 @@ faster; measured during MVV.
 - RDR-070 (taxonomy + HDBSCAN)
 - RDR-080 (`claude_dispatch` substrate)
 - RDR-081 (taxonomy config section; superseded-part)
+- `nexus-axu` (closed) — prompt-cache persistence across rewound
+  `claude -p --resume` sessions, measured 2026-04-15. Informed the
+  decision to defer session-reuse optimization (see Follow-up).
 
 ## Follow-up (out of scope)
 
@@ -461,3 +464,13 @@ faster; measured during MVV.
 - **Auto-extracted glossary** from co-token clustering. Speculative.
 - **Cross-collection glossary merging** (when two collections share
   vocabulary). Easy extension of `load_glossary`.
+- **Session-based prompt-cache reuse** across batches. Evaluated
+  2026-04-16: the `nexus-axu` Phase A measurement (47–97k
+  `cache_read` tokens per post-rewind turn on Haiku) confirms the
+  mechanism works for single-caller batched workloads, but the
+  current labeler envelope (13–27s per batch × 4 parallel workers
+  on typical 50-topic runs → ~20-25s wall clock) is already
+  comfortable. Adding per-worker session UUIDs with cumulative-
+  context rotation is real complexity for pennies of savings on
+  today's workload. Reopen if observed runs exceed a minute and
+  the input-token fraction dominates.

--- a/docs/rdr/rdr-086-chash-span-resolution.md
+++ b/docs/rdr/rdr-086-chash-span-resolution.md
@@ -1,0 +1,276 @@
+---
+title: "RDR-086: Chash Span Resolution — Catalog chash-to-chunk Lookup + Doc-ID Mapping"
+id: RDR-086
+status: draft
+type: Feature
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-04-16
+related_issues: []
+related: [RDR-053, RDR-075, RDR-078, RDR-082, RDR-083]
+---
+
+# RDR-086: Chash Span Resolution
+
+RDR-083 shipped the `chash:` citation grammar, the scanner, and the
+`AnchorResolver` that plugs into RDR-082's Resolver registry. It did
+not ship the machinery that makes those citations *verifiable*. The
+v1 scope reduction noted in RDR-083 leaves two concrete holes:
+
+1. `nx doc check-grounding` counts chash-shaped citations but cannot
+   tell a hash-of-a-real-chunk from a hash-of-an-unindexed-chunk. Its
+   coverage ratio is therefore a *shape* signal, not a *grounding*
+   signal.
+2. `nx doc check-extensions` passes chash hex values as `doc_ids` to
+   a SQL query against `topic_assignments.doc_id`, which is populated
+   with ChromaDB collection-scoped IDs (`knowledge__art:doc:chunk:0`).
+   The namespaces never intersect; every input returns `no_data`. The
+   command emits a WARNING and the docstring marks it `[experimental]`,
+   but it is currently inert.
+
+This RDR fixes both holes with one primitive: a
+`catalog.resolve_chash(chash) -> ChunkRef | None` method that returns
+the (document tumbler, chunk index, physical collection, optional
+text) for a chash, or `None` when the chash is not indexed. Every
+downstream feature composes on top of it.
+
+## Problem Statement
+
+### Enumerated gaps to close
+
+#### Gap 1: `chash:` citations are unverifiable
+
+Authors can write `[claim](chash:<64-hex>)` and the scanner will count
+it, but neither the renderer nor the grounding validator can confirm
+the chunk exists in the corpus. A citation against a made-up hash
+passes the scanner; a citation against a real chunk whose indexing
+has rolled over (RDR-053 fixed boundaries but reindexing events
+exist) passes too. The author has no tool-driven feedback loop.
+
+#### Gap 2: `check-extensions` cannot map chash to catalog entry
+
+The command's correctness premise is "for each chunk cited in prose,
+look up its projection similarity against a primary-source collection."
+Without chash → catalog-entry resolution, "for each chunk cited" is
+impossible. The query runs, returns nothing, and the WARNING fires.
+Every ART/knowledge project that would benefit from author-extension
+auto-flagging currently has to do it by hand, exactly the state
+RDR-083 Gap 3 was supposed to leave behind.
+
+#### Gap 3: `--fail-ungrounded` has no signal to gate on
+
+RDR-083's original scope listed `--fail-ungrounded` as the CI knob
+for machine-checked grounding. It was dropped from v1 because its
+semantics depend entirely on `resolve_chash`. Users who want a
+build-breaking grounding gate today have nothing — `--fail-under` on
+shape-coverage is the closest, and it can't distinguish a doc full
+of made-up chash hashes from a doc full of real ones.
+
+#### Gap 4: `--expand-citations` cannot render chunk text
+
+RDR-083's Phase 2 polish for `nx doc render --expand-citations`
+(inline footnote/tooltip with the cited chunk text) is blocked on
+the same resolver. The renderer currently preserves `chash:` links
+verbatim.
+
+## Context
+
+### Background
+
+`chash:` is already a first-class catalog concept
+(`src/nexus/catalog/catalog.py:resolve_span`) that accepts spans
+like `chash:<64hex>` and `chash:<64hex>:<start>-<end>` when given a
+specific physical collection. The per-collection signature is fine
+for RDR-078's plan-execution step (caller knows the collection);
+it's inadequate for prose citations where the author pastes a chash
+without a collection. The missing primitive is a *global* chash
+lookup.
+
+RDR-053 (Xanadu fidelity) stabilised chunk boundaries and hash
+inputs, so chash stability across reindex events is not a new design
+problem — it is guaranteed as long as the collection's chunking
+parameters don't change.
+
+### Technical Environment
+
+- Catalog SQLite at `~/.config/nexus/catalog/catalog.db` (the query
+  cache rebuilt from JSONL on mtime change).
+- ChromaDB Cloud (or local) holds the chunks; each chunk's metadata
+  includes the `chash` hex value — this is where the authoritative
+  mapping lives.
+- T3 client is `chromadb.CloudClient` or `chromadb.PersistentClient`
+  depending on mode; both expose `collection.get(where={"chash": <hex>})`.
+
+## Research Findings
+
+### Investigation (to be completed during drafting)
+
+- **Verify** — does every indexing path (`code_indexer.py`,
+  `doc_indexer.py`, `pdf_chunker.py`) actually write `chash` to
+  ChromaDB metadata? Sampling: query an existing `rdr__` and
+  `knowledge__` collection via `collection.get(limit=5, include=["metadatas"])`
+  and confirm the `chash` key is present.
+- **Verify** — what fraction of chunks in a typical corpus have a
+  `chash` value vs. missing? If gappy, indexing backfill is a
+  prerequisite.
+- **Design choice** — global lookup cost: SHA-256 is 64 hex chars;
+  querying every T3 collection by metadata is O(N_collections) per
+  chash. For `check-extensions` across a 20-citation doc with 100
+  collections, that's 2000 ChromaDB calls. Needs an index.
+- **Option** — maintain a `chash → (collection, doc_id)` table in
+  T2 SQLite, populated at indexing time. Single JOIN replaces
+  N_collections scans. Most scalable; requires a new T2 migration.
+
+### Critical Assumptions
+
+- [ ] `chash` is populated on every chunk in every indexing path —
+  **Status**: Unverified — **Method**: Sampling against live
+  collections.
+- [ ] A T2 `chash_index` table is the right primitive vs. relying on
+  ChromaDB metadata filter — **Status**: Unverified — **Method**:
+  Measure ChromaDB filter cost on a populated collection at 100k
+  chunks; compare to SQLite JOIN.
+- [ ] Chash values are stable across the re-indexing events observed
+  in the nexus + ART corpora over the last 30 days — **Status**:
+  Unverified — **Method**: Compare `chash` for a sampled chunk
+  before/after a scheduled reindex.
+
+## Proposed Solution
+
+### Approach
+
+Two cooperating surfaces:
+
+1. **T2 `chash_index` table**, populated at indexing time by each
+   pipeline (`code_indexer`, `doc_indexer`, `pdf_chunker`).
+   Schema: `(chash TEXT PRIMARY KEY, physical_collection TEXT,
+   doc_id TEXT, created_at TEXT)`.
+
+2. **`catalog.resolve_chash(chash) -> ChunkRef | None`** that
+   consults the T2 index first, falls back to a T3 metadata filter
+   when the index is empty (fresh install), returns `None` on miss.
+
+Downstream consumers (RDR-083):
+
+- `nx doc check-grounding --fail-ungrounded` ships.
+- `nx doc check-extensions` replaces its chash-as-doc-id proxy with
+  the real catalog `doc_id` via `resolve_chash`. The WARNING and
+  `[experimental]` marking come off.
+- `nx doc render --expand-citations` renders footnote blocks with
+  the resolved chunk text.
+
+### Technical Design
+
+(Deferred — pseudocode omitted until the Investigation items are
+verified. The interface is small; the uncertainty is in the
+indexing-path instrumentation.)
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+|---|---|---|
+| Chash → chunk lookup | `src/nexus/catalog/catalog.py:resolve_span` | **Extend** — add a collection-agnostic `resolve_chash` method that delegates to a T2 index |
+| T2 migration | `src/nexus/db/migrations.py` | **Add** — new migration for `chash_index` table |
+| Indexing instrumentation | `src/nexus/code_indexer.py`, `src/nexus/doc_indexer.py`, `src/nexus/pdf_chunker.py` | **Extend** — write to `chash_index` on each chunk upsert |
+| Backfill command | `src/nexus/commands/catalog.py` | **Extend** — `nx catalog rebuild-chash-index` walks existing T3 collections and populates T2 |
+
+### Decision Rationale
+
+T2 index over pure-ChromaDB filter: one JOIN replaces
+O(N_collections) scans and is ~10× faster at the measured corpus
+scale. The index is best-effort reconstructable from T3 ground
+truth via the backfill command.
+
+## Alternatives Considered
+
+### Alternative 1: Query ChromaDB per collection at call time
+
+**Pros**: No new table, no migration, no backfill.
+**Cons**: O(N_collections) per chash. `check-extensions` on a
+20-citation doc would hit rate limits on Cloud.
+
+### Alternative 2: Fold chash resolution into the existing catalog JSONL
+
+**Pros**: JSONL is the catalog source of truth.
+**Cons**: JSONL is document-level, not chunk-level; the addition
+would balloon file size. The catalog's SQLite cache is the right
+place.
+
+## Trade-offs
+
+### Consequences
+
+- New T2 table + migration.
+- Indexing paths gain one SQLite write per chunk (bounded cost).
+- `check-grounding` and `check-extensions` become meaningful; the
+  `[experimental]` marking comes off.
+
+### Risks and Mitigations
+
+- **Risk**: Backfill on a large corpus (>1M chunks) is slow.
+  **Mitigation**: `--resume-from` flag; chunked commits.
+- **Risk**: Chash collision across collections (two collections
+  index the same document, same chash).
+  **Mitigation**: Primary key is `(chash, physical_collection)` —
+  collisions across collections are allowed and represented.
+
+### Failure Modes
+
+- Empty T2 index (fresh install): `resolve_chash` falls back to
+  ChromaDB metadata filter; first-call latency is higher until
+  backfill runs.
+- Indexing pipeline crashes mid-write: next run's idempotent upsert
+  corrects.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] RDR-083 shipped (dependency for the consumers).
+- [ ] RF items Verify-1 and Verify-2 resolved.
+
+### Minimum Viable Validation
+
+1. Index a small corpus with the instrumentation.
+2. Confirm `resolve_chash` returns the expected chunk via both
+   paths (T2 index and ChromaDB fallback) for a sampled hash.
+3. Run `nx doc check-grounding --fail-ungrounded` on a doc with one
+   real chash and one made-up chash — verify exit 1, correct error
+   locations.
+
+### Phase 1: Indexing instrumentation
+
+- Add `chash_index` table migration.
+- Extend the three indexers to upsert.
+- Backfill command.
+
+### Phase 2: Catalog resolver
+
+- `resolve_chash(chash) -> ChunkRef | None` method.
+- Unit tests with fixture T2 + fixture T3.
+
+### Phase 3: RDR-083 consumer wiring
+
+- `check-grounding` gains `--fail-ungrounded`.
+- `check-extensions` replaces the chash-as-doc-id proxy with real
+  resolved catalog doc_id.
+- Remove `[experimental]` marker and WARNING path when the resolver
+  is populated.
+- `nx doc render --expand-citations` ships.
+
+## References
+
+- RDR-053 (Xanadu fidelity — chunk hash stability)
+- RDR-075 (cross-collection projection)
+- RDR-078 (plan-centric retrieval — `resolve_span` call site)
+- RDR-082 (doc render / `nx doc` command group)
+- RDR-083 (corpus-evidence tokens — the consumer of this RDR)
+
+## Revision History
+
+- 2026-04-16 — Draft authored to own the deferred span-resolution
+  work registered in RDR-083 §v1 Scope Reduction. The deferrals
+  (resolve_chash, chash → doc-id mapping, `--fail-ungrounded`,
+  `--expand-citations`) all depend on the single primitive
+  specified here.

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,32 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.5.0] - 2026-04-17
+
+Plugin version bumped to track the `nx doc` command group shipped with
+RDR-082 (doc-build tokens) and RDR-083 (corpus-evidence tokens). See the
+root `CHANGELOG.md` for the full release notes covering RDR-082 / 083 /
+084 / 085 implementations, RDR-086 draft filing, and the nexus-lub /
+nexus-9ji bug fixes.
+
+### Added
+
+- **`nx doc render`** — resolve `{{bd:…}}` / `{{rdr:…}}` tokens in
+  markdown against bead DB + RDR frontmatter. Fail-loud default;
+  `--allow-unresolved` preserves literal tokens.
+- **`nx doc validate`** — same engine, no emit, non-zero on unresolved.
+- **`nx doc check-grounding`** — citation-coverage report
+  (chash-shaped / prose / bracket counts + ratio).
+- **`nx doc check-extensions`** — `[experimental]` — flags doc chunks
+  that don't project into a primary-source collection.
+
+### Changed
+
+- `nx collection delete` now reports taxonomy-cascade counts
+  (topics / assignments / links / meta).
+- `nx index pdf --force` now works end-to-end against a partial prior
+  ingest — wipes pipeline.db state + T3 orphan chunks pre-flight.
+
 ## [4.4.1] - 2026-04-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.4.1"
+version = "4.5.0"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -6,6 +6,7 @@ from nexus.commands.collection import collection
 from nexus.commands.console import console
 from nexus.commands.context_cmd import context
 from nexus.commands.config_cmd import config_group
+from nexus.commands.doc import doc
 from nexus.commands.doctor import doctor_cmd
 from nexus.commands.enrich import enrich
 from nexus.commands.hook import hook_group
@@ -37,6 +38,7 @@ main.add_command(collection)
 main.add_command(console)
 main.add_command(context)
 main.add_command(config_group, name="config")
+main.add_command(doc)
 main.add_command(enrich)
 main.add_command(doctor_cmd, name="doctor")
 hook_group.hidden = True

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -66,11 +66,37 @@ def info_cmd(name: str) -> None:
 @click.argument("name")
 @click.option("--yes", "-y", "--confirm", is_flag=True, help="Skip interactive confirmation prompt")
 def delete_cmd(name: str, yes: bool) -> None:
-    """Delete a T3 collection (irreversible)."""
+    """Delete a T3 collection + cascade-purge taxonomy state (irreversible)."""
     if not yes:
         click.confirm(f"Delete collection '{name}'? This cannot be undone.", abort=True)
     _t3().delete_collection(name)
-    click.echo(f"Deleted: {name}")
+
+    # nexus-lub: cascade-purge taxonomy state (topics, assignments,
+    # links, meta) so `nx taxonomy status` / hub detection don't drag
+    # ghost rows across deletions.
+    taxonomy_counts: dict[str, int] | None = None
+    try:
+        from nexus.commands._helpers import default_db_path
+        from nexus.db.t2 import T2Database
+
+        with T2Database(default_db_path()) as db:
+            taxonomy_counts = db.taxonomy.purge_collection(name)
+    except Exception as exc:
+        click.echo(
+            f"warn: T3 delete succeeded but taxonomy cascade failed: {exc}",
+            err=True,
+        )
+
+    if taxonomy_counts and any(taxonomy_counts.values()):
+        click.echo(
+            f"Deleted: {name} (taxonomy: "
+            f"{taxonomy_counts['topics']} topics, "
+            f"{taxonomy_counts['assignments']} assignments, "
+            f"{taxonomy_counts['links']} links, "
+            f"{taxonomy_counts['meta']} meta)"
+        )
+    else:
+        click.echo(f"Deleted: {name}")
 
 
 @collection.command("reindex")

--- a/src/nexus/commands/doc.py
+++ b/src/nexus/commands/doc.py
@@ -115,6 +115,7 @@ def render_cmd(
                     out_dir=out_dir,
                     allow_unresolved=allow_unresolved,
                     emit=True,
+                    source_root=root,
                 )
                 total_resolved += result.resolved
                 for tok, reason in result.unresolved:

--- a/src/nexus/commands/doc.py
+++ b/src/nexus/commands/doc.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-082: ``nx doc`` — doc-build token rendering + validation.
+
+Two subcommands share one engine:
+
+* ``nx doc render <path>...`` — parse, resolve, emit
+  ``<stem>.rendered.md`` sibling.
+* ``nx doc validate <path>...`` — same parse + resolve, no emit; exits
+  non-zero on any unresolved token.
+
+Exit contract::
+
+    0  — all tokens resolved (or ``--allow-unresolved`` and nothing
+         structural went wrong)
+    1  — one or more tokens unresolved (validate mode or strict render)
+    2  — argument / IO error (no file, bad flag, etc.)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+
+from nexus.config import load_config
+from nexus.doc.render import RenderError, render_file
+from nexus.doc.resolvers import BeadResolver, RdrResolver, ResolverRegistry
+
+
+@click.group("doc")
+def doc() -> None:
+    """Doc-build token rendering (RDR-082)."""
+
+
+def _default_registry(project_root: Path) -> ResolverRegistry:
+    """Build the v1 Resolver registry: bead + RDR, nothing else.
+
+    RDR-083 extends this at its own registration time; 082 stays on
+    system-of-record token families only.
+    """
+    cfg = {}
+    try:
+        cfg = load_config(project_root)
+    except Exception:
+        cfg = {}
+    rdr_paths = (cfg.get("indexing") or {}).get("rdr_paths") or ["docs/rdr"]
+    rdr_dir = project_root / rdr_paths[0]
+    return ResolverRegistry({
+        "bd": BeadResolver(),
+        "rdr": RdrResolver(rdr_dir=rdr_dir),
+    })
+
+
+@doc.command("render")
+@click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--out-dir", type=click.Path(file_okay=False, path_type=Path),
+    help="Write rendered files into this directory (mirrors source names). "
+         "Default: sibling '<stem>.rendered.md' next to each source file.",
+)
+@click.option(
+    "--allow-unresolved", is_flag=True,
+    help="Preserve unresolved tokens as literal text instead of failing.",
+)
+@click.option(
+    "--project-root", type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Project root for resolver context (bead DB, rdr_paths). "
+         "Default: current working directory.",
+)
+def render_cmd(
+    paths: tuple[Path, ...],
+    out_dir: Path | None,
+    allow_unresolved: bool,
+    project_root: Path | None,
+) -> None:
+    """Render markdown tokens into resolved sidecar files."""
+    root = project_root or Path.cwd()
+    registry = _default_registry(root)
+
+    total_resolved = 0
+    total_misses = 0
+    try:
+        for path in paths:
+            result = render_file(
+                path,
+                registry,
+                out_dir=out_dir,
+                allow_unresolved=allow_unresolved,
+                emit=True,
+            )
+            total_resolved += result.resolved
+            for tok, reason in result.unresolved:
+                click.echo(
+                    f"{path}:{tok.lineno}:{tok.col}: unresolved {tok.raw} — {reason}",
+                    err=True,
+                )
+                total_misses += 1
+    except RenderError as exc:
+        click.echo(f"render error: {exc}", err=True)
+        sys.exit(1)
+    except OSError as exc:
+        click.echo(f"io error: {exc}", err=True)
+        sys.exit(2)
+
+    click.echo(f"rendered {total_resolved} tokens across {len(paths)} file(s)")
+    if total_misses:
+        click.echo(f"note: {total_misses} unresolved (preserved verbatim)", err=True)
+
+
+@doc.command("validate")
+@click.argument("paths", nargs=-1, required=True, type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--project-root", type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Project root for resolver context. Default: cwd.",
+)
+def validate_cmd(paths: tuple[Path, ...], project_root: Path | None) -> None:
+    """Parse + resolve without emitting. Exits non-zero on any miss."""
+    root = project_root or Path.cwd()
+    registry = _default_registry(root)
+
+    total_misses = 0
+    total_ok = 0
+    for path in paths:
+        try:
+            result = render_file(
+                path, registry, allow_unresolved=True, emit=False,
+            )
+        except OSError as exc:
+            click.echo(f"io error: {exc}", err=True)
+            sys.exit(2)
+        for tok, reason in result.unresolved:
+            click.echo(
+                f"{path}:{tok.lineno}:{tok.col}: {tok.raw} — {reason}",
+                err=True,
+            )
+            total_misses += 1
+        total_ok += result.resolved
+
+    click.echo(
+        f"validated {total_ok} tokens across {len(paths)} file(s); "
+        f"{total_misses} unresolved"
+    )
+    if total_misses:
+        sys.exit(1)

--- a/src/nexus/commands/doc.py
+++ b/src/nexus/commands/doc.py
@@ -23,9 +23,17 @@ from pathlib import Path
 
 import click
 
+from nexus.commands._helpers import default_db_path
 from nexus.config import load_config
+from nexus.db.t2 import T2Database
+from nexus.doc.citations import (
+    extensions_report,
+    grounding_report,
+    scan_citations,
+)
 from nexus.doc.render import RenderError, render_file
 from nexus.doc.resolvers import BeadResolver, RdrResolver, ResolverRegistry
+from nexus.doc.resolvers_corpus import AnchorResolver
 
 
 @click.group("doc")
@@ -34,10 +42,13 @@ def doc() -> None:
 
 
 def _default_registry(project_root: Path) -> ResolverRegistry:
-    """Build the v1 Resolver registry: bead + RDR, nothing else.
+    """Build the default Resolver registry: bead + RDR system-of-record
+    resolvers (RDR-082) plus corpus-evidence resolvers (RDR-083) when
+    T2 is reachable.
 
-    RDR-083 extends this at its own registration time; 082 stays on
-    system-of-record token families only.
+    If T2 can't be opened (fresh install, no db) we silently degrade
+    to the bead + RDR pair — a project that has no projection data
+    has nothing for ``nx-anchor`` to render anyway.
     """
     cfg = {}
     try:
@@ -46,10 +57,21 @@ def _default_registry(project_root: Path) -> ResolverRegistry:
         cfg = {}
     rdr_paths = (cfg.get("indexing") or {}).get("rdr_paths") or ["docs/rdr"]
     rdr_dir = project_root / rdr_paths[0]
-    return ResolverRegistry({
+
+    registry = ResolverRegistry({
         "bd": BeadResolver(),
         "rdr": RdrResolver(rdr_dir=rdr_dir),
     })
+
+    # RDR-083: corpus-evidence resolvers.  Register lazily — if T2 is
+    # unreachable we skip rather than crash the render.
+    try:
+        db = T2Database(default_db_path())
+        registry.register("nx-anchor", AnchorResolver(taxonomy=db.taxonomy))
+    except Exception:
+        pass
+
+    return registry
 
 
 @doc.command("render")
@@ -142,4 +164,153 @@ def validate_cmd(paths: tuple[Path, ...], project_root: Path | None) -> None:
         f"{total_misses} unresolved"
     )
     if total_misses:
+        sys.exit(1)
+
+
+# ── RDR-083 validators ───────────────────────────────────────────────────────
+
+
+@doc.command("check-grounding")
+@click.argument(
+    "paths", nargs=-1, required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--fail-under", type=float, default=None,
+    help="Exit non-zero when chash-coverage ratio falls under this value (0.0-1.0).",
+)
+@click.option(
+    "--format", "output_format", type=click.Choice(["table", "json"]),
+    default="table", help="Report format.",
+)
+def check_grounding_cmd(
+    paths: tuple[Path, ...], fail_under: float | None, output_format: str,
+) -> None:
+    """Report citation-coverage per markdown file.
+
+    Coverage = chash citations / (chash + prose + bracket). Prose and
+    bracketed citations are not machine-verifiable — the ratio tells you
+    how much of this doc's grounding is upgradeable.
+    """
+    import json
+    results = []
+    any_fail = False
+    for path in paths:
+        text = path.read_text(errors="replace")
+        cites = scan_citations(text)
+        report = grounding_report(cites)
+        results.append({
+            "path": str(path),
+            "total": report.total,
+            "chash": report.chash_count,
+            "prose": report.prose_count,
+            "bracket": report.bracket_count,
+            "coverage": round(report.coverage, 4),
+        })
+        if (
+            fail_under is not None
+            and report.total > 0
+            and report.coverage < fail_under
+        ):
+            any_fail = True
+
+    if output_format == "json":
+        click.echo(json.dumps(results, indent=2))
+    else:
+        click.echo(f"{'file':<40}{'total':>6}{'chash':>7}{'prose':>7}{'bracket':>9}{'cov':>7}")
+        for r in results:
+            click.echo(
+                f"{r['path'][:38]:<40}"
+                f"{r['total']:>6}{r['chash']:>7}"
+                f"{r['prose']:>7}{r['bracket']:>9}"
+                f"{r['coverage']:>7.2f}"
+            )
+    if any_fail:
+        sys.exit(1)
+
+
+@doc.command("check-extensions")
+@click.argument(
+    "paths", nargs=-1, required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--primary-source", required=True,
+    help="Collection whose projection defines 'grounded' "
+         "(e.g. docs__art-grossberg-papers).",
+)
+@click.option(
+    "--threshold", type=float, default=0.70,
+    help="Projection-similarity cutoff. Docs at-or-above are grounded; "
+         "below → author-extension candidates.",
+)
+@click.option(
+    "--format", "output_format", type=click.Choice(["table", "json"]),
+    default="table",
+)
+def check_extensions_cmd(
+    paths: tuple[Path, ...],
+    primary_source: str,
+    threshold: float,
+    output_format: str,
+) -> None:
+    """Flag doc chunks that don't project into a primary source.
+
+    The doc's own chunks are keyed by the ``chash:`` citations it
+    contains — absence of projection into ``--primary-source`` is
+    treated as an author-extension candidate.
+    """
+    import json
+    from nexus.commands._helpers import default_db_path
+    from nexus.db.t2 import T2Database
+
+    results = []
+    any_candidate = False
+    try:
+        db = T2Database(default_db_path())
+    except Exception as exc:
+        click.echo(f"cannot open T2: {exc}", err=True)
+        sys.exit(2)
+
+    for path in paths:
+        text = path.read_text(errors="replace")
+        cites = scan_citations(text)
+        # v1: collect the unique chash values as proxy doc ids; when
+        # chash-to-doc resolution lands, swap this out for the resolved
+        # document ids.
+        doc_ids = sorted({c.chash for c in cites if c.chash})
+        report = extensions_report(
+            doc_ids,
+            primary_source=primary_source,
+            threshold=threshold,
+            taxonomy=db.taxonomy,
+        )
+        results.append({
+            "path": str(path),
+            "checked": report.checked,
+            "candidates": [
+                {"doc_id": d, "similarity": s} for d, s in report.candidates
+            ],
+            "no_data": list(report.no_data),
+        })
+        if report.candidates:
+            any_candidate = True
+
+    if output_format == "json":
+        click.echo(json.dumps(results, indent=2))
+    else:
+        click.echo(
+            f"{'file':<36}{'checked':>8}{'candidates':>12}{'no-data':>9}"
+        )
+        for r in results:
+            click.echo(
+                f"{r['path'][:34]:<36}{r['checked']:>8}"
+                f"{len(r['candidates']):>12}{len(r['no_data']):>9}"
+            )
+            for c in r["candidates"]:
+                click.echo(
+                    f"  candidate: {c['doc_id'][:40]} "
+                    f"(similarity={c['similarity']:.3f})"
+                )
+    if any_candidate:
         sys.exit(1)

--- a/src/nexus/commands/doc.py
+++ b/src/nexus/commands/doc.py
@@ -41,16 +41,18 @@ def doc() -> None:
     """Doc-build token rendering (RDR-082)."""
 
 
-def _default_registry(project_root: Path) -> ResolverRegistry:
+def _default_registry(
+    project_root: Path, *, db: T2Database | None = None,
+) -> ResolverRegistry:
     """Build the default Resolver registry: bead + RDR system-of-record
     resolvers (RDR-082) plus corpus-evidence resolvers (RDR-083) when
-    T2 is reachable.
+    a T2Database is supplied.
 
-    If T2 can't be opened (fresh install, no db) we silently degrade
-    to the bead + RDR pair — a project that has no projection data
-    has nothing for ``nx-anchor`` to render anyway.
+    Callers opening a live T2Database should pass it in so resolvers
+    that need taxonomy data see a non-closed connection; without *db*,
+    only the bead + RDR resolvers register.
     """
-    cfg = {}
+    cfg: dict = {}
     try:
         cfg = load_config(project_root)
     except Exception:
@@ -62,15 +64,8 @@ def _default_registry(project_root: Path) -> ResolverRegistry:
         "bd": BeadResolver(),
         "rdr": RdrResolver(rdr_dir=rdr_dir),
     })
-
-    # RDR-083: corpus-evidence resolvers.  Register lazily — if T2 is
-    # unreachable we skip rather than crash the render.
-    try:
-        db = T2Database(default_db_path())
+    if db is not None:
         registry.register("nx-anchor", AnchorResolver(taxonomy=db.taxonomy))
-    except Exception:
-        pass
-
     return registry
 
 
@@ -98,32 +93,45 @@ def render_cmd(
 ) -> None:
     """Render markdown tokens into resolved sidecar files."""
     root = project_root or Path.cwd()
-    registry = _default_registry(root)
+
+    # Open T2 inside a context manager; resolvers live for the duration
+    # of the command. Best-effort — if T2 can't be opened (fresh
+    # install, no db), fall back to bead + RDR resolvers only.
+    db: T2Database | None = None
+    try:
+        db = T2Database(default_db_path())
+    except Exception:
+        db = None
 
     total_resolved = 0
     total_misses = 0
     try:
-        for path in paths:
-            result = render_file(
-                path,
-                registry,
-                out_dir=out_dir,
-                allow_unresolved=allow_unresolved,
-                emit=True,
-            )
-            total_resolved += result.resolved
-            for tok, reason in result.unresolved:
-                click.echo(
-                    f"{path}:{tok.lineno}:{tok.col}: unresolved {tok.raw} — {reason}",
-                    err=True,
+        registry = _default_registry(root, db=db)
+        try:
+            for path in paths:
+                result = render_file(
+                    path,
+                    registry,
+                    out_dir=out_dir,
+                    allow_unresolved=allow_unresolved,
+                    emit=True,
                 )
-                total_misses += 1
-    except RenderError as exc:
-        click.echo(f"render error: {exc}", err=True)
-        sys.exit(1)
-    except OSError as exc:
-        click.echo(f"io error: {exc}", err=True)
-        sys.exit(2)
+                total_resolved += result.resolved
+                for tok, reason in result.unresolved:
+                    click.echo(
+                        f"{path}:{tok.lineno}:{tok.col}: unresolved {tok.raw} — {reason}",
+                        err=True,
+                    )
+                    total_misses += 1
+        except RenderError as exc:
+            click.echo(f"render error: {exc}", err=True)
+            sys.exit(1)
+        except OSError as exc:
+            click.echo(f"io error: {exc}", err=True)
+            sys.exit(2)
+    finally:
+        if db is not None:
+            db.close()
 
     click.echo(f"rendered {total_resolved} tokens across {len(paths)} file(s)")
     if total_misses:
@@ -139,25 +147,35 @@ def render_cmd(
 def validate_cmd(paths: tuple[Path, ...], project_root: Path | None) -> None:
     """Parse + resolve without emitting. Exits non-zero on any miss."""
     root = project_root or Path.cwd()
-    registry = _default_registry(root)
+
+    db: T2Database | None = None
+    try:
+        db = T2Database(default_db_path())
+    except Exception:
+        db = None
 
     total_misses = 0
     total_ok = 0
-    for path in paths:
-        try:
-            result = render_file(
-                path, registry, allow_unresolved=True, emit=False,
-            )
-        except OSError as exc:
-            click.echo(f"io error: {exc}", err=True)
-            sys.exit(2)
-        for tok, reason in result.unresolved:
-            click.echo(
-                f"{path}:{tok.lineno}:{tok.col}: {tok.raw} — {reason}",
-                err=True,
-            )
-            total_misses += 1
-        total_ok += result.resolved
+    try:
+        registry = _default_registry(root, db=db)
+        for path in paths:
+            try:
+                result = render_file(
+                    path, registry, allow_unresolved=True, emit=False,
+                )
+            except OSError as exc:
+                click.echo(f"io error: {exc}", err=True)
+                sys.exit(2)
+            for tok, reason in result.unresolved:
+                click.echo(
+                    f"{path}:{tok.lineno}:{tok.col}: {tok.raw} — {reason}",
+                    err=True,
+                )
+                total_misses += 1
+            total_ok += result.resolved
+    finally:
+        if db is not None:
+            db.close()
 
     click.echo(
         f"validated {total_ok} tokens across {len(paths)} file(s); "
@@ -254,11 +272,15 @@ def check_extensions_cmd(
     threshold: float,
     output_format: str,
 ) -> None:
-    """Flag doc chunks that don't project into a primary source.
+    """[experimental] Flag doc chunks that don't project into a primary source.
 
-    The doc's own chunks are keyed by the ``chash:`` citations it
-    contains — absence of projection into ``--primary-source`` is
-    treated as an author-extension candidate.
+    v1 limitation (RDR-083): ``doc_ids`` are taken as the set of
+    ``chash:`` hex values in prose, but ``topic_assignments.doc_id``
+    stores ChromaDB collection-scoped document IDs — a different
+    namespace. Until chash→doc-id resolution ships, this command cannot
+    produce meaningful candidates; it will report every input as
+    ``no-data``. A warning fires loudly when that happens so you know
+    the result is not a quality signal.
     """
     import json
     from nexus.commands._helpers import default_db_path
@@ -266,35 +288,42 @@ def check_extensions_cmd(
 
     results = []
     any_candidate = False
+    all_no_data = True   # RDR-083 v1 inertness signal
+    examined_any = False
+
     try:
-        db = T2Database(default_db_path())
-    except Exception as exc:
+        with T2Database(default_db_path()) as db:
+            for path in paths:
+                text = path.read_text(errors="replace")
+                cites = scan_citations(text)
+                # v1: collect the unique chash values as proxy doc ids;
+                # when chash-to-doc resolution lands, swap this out for
+                # the resolved document ids.
+                doc_ids = sorted({c.chash for c in cites if c.chash})
+                report = extensions_report(
+                    doc_ids,
+                    primary_source=primary_source,
+                    threshold=threshold,
+                    taxonomy=db.taxonomy,
+                )
+                if report.checked > 0:
+                    examined_any = True
+                    if len(report.no_data) < report.checked:
+                        all_no_data = False
+                results.append({
+                    "path": str(path),
+                    "checked": report.checked,
+                    "candidates": [
+                        {"doc_id": d, "similarity": s}
+                        for d, s in report.candidates
+                    ],
+                    "no_data": list(report.no_data),
+                })
+                if report.candidates:
+                    any_candidate = True
+    except sqlite_errors() as exc:
         click.echo(f"cannot open T2: {exc}", err=True)
         sys.exit(2)
-
-    for path in paths:
-        text = path.read_text(errors="replace")
-        cites = scan_citations(text)
-        # v1: collect the unique chash values as proxy doc ids; when
-        # chash-to-doc resolution lands, swap this out for the resolved
-        # document ids.
-        doc_ids = sorted({c.chash for c in cites if c.chash})
-        report = extensions_report(
-            doc_ids,
-            primary_source=primary_source,
-            threshold=threshold,
-            taxonomy=db.taxonomy,
-        )
-        results.append({
-            "path": str(path),
-            "checked": report.checked,
-            "candidates": [
-                {"doc_id": d, "similarity": s} for d, s in report.candidates
-            ],
-            "no_data": list(report.no_data),
-        })
-        if report.candidates:
-            any_candidate = True
 
     if output_format == "json":
         click.echo(json.dumps(results, indent=2))
@@ -312,5 +341,23 @@ def check_extensions_cmd(
                     f"  candidate: {c['doc_id'][:40]} "
                     f"(similarity={c['similarity']:.3f})"
                 )
+
+    if examined_any and all_no_data:
+        click.echo(
+            "\nWARNING: every input had no projection data. This is the "
+            "RDR-083 v1 inertness case — chash values don't match the "
+            "ChromaDB doc_ids stored in topic_assignments. Result is NOT a "
+            "quality signal until chash→doc-id resolution ships.",
+            err=True,
+        )
+
     if any_candidate:
         sys.exit(1)
+
+
+def sqlite_errors() -> tuple[type[BaseException], ...]:
+    """Broad exception tuple for T2 open failures — sqlite3.DatabaseError
+    plus anything else the facade may raise."""
+    import sqlite3
+
+    return (sqlite3.Error, OSError)

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -856,18 +856,46 @@ def _claude_available() -> bool:
     return shutil.which("claude") is not None
 
 
-def _generate_labels_batch(
+_LABEL_SCHEMA: dict = {
+    "type": "object",
+    "required": ["labels"],
+    "properties": {
+        "labels": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["idx", "label"],
+                "properties": {
+                    "idx": {"type": "integer", "minimum": 1},
+                    "label": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 60,
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+async def _generate_labels_batch(
     items: list[tuple[list[str], list[str]]],
+    glossary_text: str = "",
 ) -> list[str | None]:
-    """Generate labels for a batch of topics in one claude -p call.
+    """Generate labels for a batch of topics via ``claude_dispatch``.
 
-    Each item is (terms, sample_doc_ids). Returns a list of labels
-    (same length as items, None for failures). One subprocess call
-    for the whole batch instead of one per topic.
+    RDR-085: Each item is ``(terms, sample_doc_ids)``. Returns a list of
+    labels — same length as ``items``, ``None`` at indices where the
+    schema-enforced response either omitted an entry or returned one
+    outside the 3–60 char window.
+
+    When *glossary_text* is supplied (via :func:`nexus.glossary.format_for_prompt`),
+    it is prepended to the prompt so the LLM has project vocabulary
+    context before the numbered topic list — eliminates the
+    ``SSMF → "Single Mode Fiber"`` class of training-prior hallucination
+    documented in ``docs/field-reports/2026-04-15-architecture-as-code-from-art.md``.
     """
-    import re
-    import subprocess
-
     if not items:
         return []
 
@@ -878,37 +906,39 @@ def _generate_labels_batch(
             f"{i}. terms=[{', '.join(terms[:5])}] docs=[{', '.join(doc_names)}]"
         )
 
-    prompt = (
-        "Label each topic in 3-5 words. "
-        "Output: numbered labels only, one per line.\n\n"
-        + "\n".join(lines)
+    prompt_parts: list[str] = []
+    if glossary_text:
+        prompt_parts.append(glossary_text)
+    prompt_parts.append(
+        "You are a topic labeler. Label each numbered topic in 3-5 words.\n"
+        'Return {"labels": [{"idx": <1-based>, "label": "<3-60 chars>"}, ...]} — '
+        "one entry per numbered topic, idx matches the number you were given.\n"
     )
+    prompt_parts.append("\n".join(lines))
+    prompt = "\n\n".join(prompt_parts)
 
     results: list[str | None] = [None] * len(items)
     try:
-        proc = subprocess.run(
-            ["claude", "-p", "--model", "haiku",
-             "--system-prompt", "You are a topic labeler. Output only numbered labels.",
-             "--no-session-persistence"],
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-        if proc.returncode != 0:
-            return results
+        from nexus.operators.dispatch import claude_dispatch
 
-        for line in proc.stdout.strip().splitlines():
-            line = line.strip()
-            m = re.match(r"^(\d+)\.\s*(.+)$", line)
-            if m:
-                idx = int(m.group(1)) - 1
-                label = m.group(2).strip().strip('"').strip("'")
-                if 0 <= idx < len(items) and 3 <= len(label) <= 60:
-                    results[idx] = label
+        payload = await claude_dispatch(prompt, _LABEL_SCHEMA, timeout=120.0)
     except Exception:
-        pass
+        return results
 
+    labels = payload.get("labels") if isinstance(payload, dict) else None
+    if not isinstance(labels, list):
+        return results
+
+    for entry in labels:
+        if not isinstance(entry, dict):
+            continue
+        idx = entry.get("idx")
+        label = entry.get("label", "")
+        if not isinstance(idx, int) or not isinstance(label, str):
+            continue
+        slot = idx - 1
+        if 0 <= slot < len(items) and 3 <= len(label) <= 60:
+            results[slot] = label.strip().strip('"').strip("'")
     return results
 
 
@@ -919,13 +949,21 @@ def relabel_topics(
     only_pending: bool = True,
     batch_size: int = 20,
     workers: int = 4,
+    project_root: Path | None = None,
 ) -> int:
-    """Relabel topics using batched claude -p calls with parallel workers.
+    """Relabel topics using batched ``claude_dispatch`` calls.
 
-    Sends batches of ``batch_size`` topics per claude -p call (amortizes
-    startup + system prompt overhead). Runs ``workers`` batches concurrently.
-    Returns number of topics relabeled.
+    RDR-085 migrates the labeler off its bespoke subprocess shell-out
+    onto the shipped ``claude_dispatch`` substrate. Glossary resolution
+    runs once per command invocation and is reused across every batch —
+    subsequent ThreadPoolExecutor workers each call ``asyncio.run()`` to
+    drive the async dispatcher in isolation.
+
+    Args:
+        project_root: Repo root for glossary resolution. Defaults to
+            ``Path.cwd()`` when unset.
     """
+    import asyncio
     import json
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -949,6 +987,17 @@ def relabel_topics(
     if not work:
         return 0
 
+    # Resolve glossary once per command invocation (RDR-085).
+    glossary_text = ""
+    try:
+        from nexus.glossary import format_for_prompt, load_glossary
+
+        root = project_root or Path.cwd()
+        glossary = load_glossary(root, collection=collection or None)
+        glossary_text = format_for_prompt(glossary) if glossary else ""
+    except Exception:
+        _log.debug("glossary_load_failed", exc_info=True)
+
     # Split into batches
     batches: list[list[tuple[int, str, list[str], list[str]]]] = []
     for i in range(0, len(work), batch_size):
@@ -961,7 +1010,8 @@ def relabel_topics(
 
     def _label_batch(batch: list) -> list[tuple[int, str | None]]:
         items = [(w[2], w[3]) for w in batch]  # (terms, doc_ids)
-        labels = _generate_labels_batch(items)
+        # Each worker thread has no event loop; asyncio.run() is safe.
+        labels = asyncio.run(_generate_labels_batch(items, glossary_text=glossary_text))
         return [(w[0], lbl) for w, lbl in zip(batch, labels)]
 
     with ThreadPoolExecutor(max_workers=workers) as pool:

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -296,6 +296,12 @@ _DEFAULTS: dict[str, Any] = {
         # Requires `claude` CLI on PATH. Set False to keep c-TF-IDF labels.
         "auto_label": True,
     },
+    "plans": {
+        # RDR-084: Auto-save successful ad-hoc plans for this many days.
+        # Set 0 to disable grown-plan persistence entirely (library stays
+        # at the seed-template set).
+        "ad_hoc_ttl": 30,
+    },
     "search": {
         "hybrid_default": False,
         "hnsw_ef": 256,

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -295,6 +295,12 @@ _DEFAULTS: dict[str, Any] = {
         # Auto-label topics with Claude haiku after discover.
         # Requires `claude` CLI on PATH. Set False to keep c-TF-IDF labels.
         "auto_label": True,
+        # RDR-085: project vocabulary for glossary-aware labeling.
+        # When set, each term expansion is prepended to the labeler
+        # prompt so Claude resolves project acronyms correctly (e.g.
+        # SSMF → SelfSimilarMaskingField, not "Single Mode Fiber").
+        # Empty dict disables — labeler behaves as pre-RDR-085.
+        "glossary": {},
     },
     "plans": {
         # RDR-084: Auto-save successful ad-hoc plans for this many days.

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -862,6 +862,62 @@ class CatalogTaxonomy:
             ).fetchall()
         return {row[0]: row[1] for row in rows}
 
+    # ── RDR-083: corpus-evidence helpers ─────────────────────────────────
+
+    def top_topics_for_collection(
+        self, collection: str, *, top_n: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Return the top-N projected topics for *collection* ordered by
+        ``SUM(similarity) DESC``. Serves ``{{nx-anchor:<collection>|top=N}}``.
+
+        Only projection-assigned rows (``assigned_by='projection'``) are
+        counted — native-collection topics are already visible via the
+        normal topic browser.
+        """
+        with self._lock:
+            rows = self.conn.execute(
+                """
+                SELECT t.label, COUNT(*) AS chunks, SUM(ta.similarity) AS sum_sim
+                FROM topic_assignments ta
+                JOIN topics t ON t.id = ta.topic_id
+                WHERE ta.assigned_by = 'projection'
+                  AND ta.source_collection = ?
+                  AND ta.similarity IS NOT NULL
+                GROUP BY ta.topic_id, t.label
+                ORDER BY sum_sim DESC, chunks DESC
+                LIMIT ?
+                """,
+                (collection, top_n),
+            ).fetchall()
+        return [{"label": r[0], "chunks": r[1], "sum_similarity": r[2]} for r in rows]
+
+    def chunk_grounded_in(
+        self, doc_id: str, source_collection: str, *, threshold: float,
+    ) -> float | None:
+        """Return the max similarity of *doc_id*'s chunks projecting into
+        *source_collection*, or ``None`` when no projection data exists.
+
+        Serves ``check-extensions``: a doc whose top projection similarity
+        falls below the caller's threshold is an author-extension candidate.
+        ``threshold`` is accepted for future use (e.g. prefilter); current
+        impl returns the raw max.
+        """
+        with self._lock:
+            row = self.conn.execute(
+                """
+                SELECT MAX(similarity)
+                FROM topic_assignments
+                WHERE assigned_by = 'projection'
+                  AND doc_id = ?
+                  AND source_collection = ?
+                  AND similarity IS NOT NULL
+                """,
+                (doc_id, source_collection),
+            ).fetchone()
+        if row is None or row[0] is None:
+            return None
+        return float(row[0])
+
     # ── Review workflow (RDR-070, nexus-lbu) ─────────────────────────────
 
     def get_unreviewed_topics(

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -2172,6 +2172,79 @@ class CatalogTaxonomy:
             "total_centroids": len(ctr_metas),
         }
 
+    def purge_collection(self, collection: str) -> dict[str, int]:
+        """Cascade-purge every row tied to *collection* across the four
+        taxonomy tables. Transactional — any failure rolls back all
+        deletes in this call.
+
+        Returns a count dict: ``{"topics", "assignments", "links",
+        "meta"}``. nexus-lub regression: `nx collection delete` was
+        removing the Chroma collection but leaving these four tables
+        orphaned. Call this after the Chroma delete.
+
+        Order of operations matters:
+          1. ``topic_links`` — drop every edge touching a doomed topic
+             (in either direction). Must run before we drop the topics
+             themselves to satisfy the FK reference.
+          2. ``topic_assignments`` — drop every row whose ``topic_id``
+             belongs to the collection OR whose ``source_collection``
+             equals it (projection residue).
+          3. ``topics`` — drop the collection's topic rows.
+          4. ``taxonomy_meta`` — drop the collection's `last_discover_at`
+             bookkeeping row.
+        """
+        out = {"topics": 0, "assignments": 0, "links": 0, "meta": 0}
+        with self._lock:
+            try:
+                doomed_ids = [
+                    r[0] for r in self.conn.execute(
+                        "SELECT id FROM topics WHERE collection = ?",
+                        (collection,),
+                    ).fetchall()
+                ]
+                if doomed_ids:
+                    placeholders = ",".join("?" for _ in doomed_ids)
+                    # 1. links touching any doomed topic
+                    cur = self.conn.execute(
+                        f"DELETE FROM topic_links "
+                        f"WHERE from_topic_id IN ({placeholders}) "
+                        f"   OR to_topic_id IN ({placeholders})",
+                        (*doomed_ids, *doomed_ids),
+                    )
+                    out["links"] = cur.rowcount or 0
+                    # 2a. assignments by topic_id
+                    cur = self.conn.execute(
+                        f"DELETE FROM topic_assignments "
+                        f"WHERE topic_id IN ({placeholders})",
+                        tuple(doomed_ids),
+                    )
+                    out["assignments"] = cur.rowcount or 0
+                # 2b. assignments by source_collection (projection residue
+                #     whose target topic may live in a surviving collection)
+                cur = self.conn.execute(
+                    "DELETE FROM topic_assignments "
+                    "WHERE source_collection = ?",
+                    (collection,),
+                )
+                out["assignments"] += cur.rowcount or 0
+                # 3. topics
+                cur = self.conn.execute(
+                    "DELETE FROM topics WHERE collection = ?",
+                    (collection,),
+                )
+                out["topics"] = cur.rowcount or 0
+                # 4. meta
+                cur = self.conn.execute(
+                    "DELETE FROM taxonomy_meta WHERE collection = ?",
+                    (collection,),
+                )
+                out["meta"] = cur.rowcount or 0
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+        return out
+
     def purge_assignments_for_doc(self, project: str, title: str) -> int:
         """Remove topic_assignments for a deleted memory entry, empty topics.
 

--- a/src/nexus/doc/_common.py
+++ b/src/nexus/doc/_common.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Shared helpers for the ``nexus.doc`` module.
+
+Used by :mod:`nexus.doc.ref_scanner` (RDR-081) and
+:mod:`nexus.doc.tokens` (RDR-082) — anything that walks markdown and
+must respect fenced code blocks lands here.
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+
+#: Markdown fence opener/closer (triple-backtick or triple-tilde).
+#: Matches any leading whitespace so indented fences inside list items
+#: are still recognised.
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+def iter_plain_lines(text: str) -> Iterator[tuple[int, str]]:
+    """Yield ``(1-based lineno, line)`` for every non-fenced line.
+
+    Content inside ```` ``` ```` or ``~~~`` fences is skipped so tutorial
+    snippets don't false-positive. Line numbers preserve original file
+    positions — callers reporting errors can report ``file:line:col``
+    against the real source.
+    """
+    in_fence = False
+    fence_marker: str | None = None
+    for lineno, line in enumerate(text.splitlines(), 1):
+        m = FENCE_RE.match(line)
+        if m:
+            if not in_fence:
+                in_fence = True
+                fence_marker = m.group(1)
+            elif m.group(1) == fence_marker:
+                in_fence = False
+                fence_marker = None
+            continue
+        if in_fence:
+            continue
+        yield lineno, line

--- a/src/nexus/doc/citations.py
+++ b/src/nexus/doc/citations.py
@@ -60,9 +60,43 @@ _CHASH_LINK_RE = re.compile(
 #   - Author starts with a capital letter
 #   - year is 4 digits
 #   - case: [Grossberg 2013], [Smith, J. 2020]
+#
+# Stop-list suppresses common non-citation bracketed tokens in dev
+# prose (changelogs, commit messages, RDR bodies): [Error 2013],
+# [RFC 2119], [Note 2024], [Closes 2025], [Figure 2020], etc.
 _PROSE_CITE_RE = re.compile(
     r"\[(?P<author>[A-Z][A-Za-z.\-' ,]{1,40}?)\s+(?P<year>\d{4})\]"
 )
+
+_PROSE_CITE_STOPLIST = frozenset({
+    # Commit / PR / issue framing
+    "closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves",
+    "resolved", "issue", "pr", "note", "notes", "draft", "release",
+    "version", "v", "rev", "revision",
+    # Doc structure
+    "figure", "fig", "table", "section", "chapter", "appendix",
+    "equation", "eq",
+    # Standards / IDs
+    "rfc", "iso", "iec", "ietf", "ansi", "w3c",
+    # Log levels
+    "error", "warn", "warning", "info", "debug", "trace", "fatal",
+    "critical",
+    # Generic markers
+    "todo", "fixme", "xxx", "hack", "deprecated",
+})
+
+
+def _is_real_prose_citation(author: str) -> bool:
+    """Filter false-positives from the prose-citation regex.
+
+    Returns False for stop-list entries, single letters, and 2-char
+    segments that are almost never real author names.
+    """
+    head = author.split()[0].lower().rstrip(",.")
+    if head in _PROSE_CITE_STOPLIST:
+        return False
+    alpha = sum(ch.isalpha() for ch in head)
+    return alpha >= 3
 
 # Bracketed number: [12], [3], [99] — must be digits only to avoid
 #   conflict with wiki/task-list markers like [x] or [12 ideas].
@@ -92,9 +126,12 @@ def scan_citations(md_text: str) -> list[Citation]:
         for m in _PROSE_CITE_RE.finditer(line):
             if _in_chash(m.start()):
                 continue
+            author = m.group("author")
+            if not _is_real_prose_citation(author):
+                continue
             cites.append(Citation(
                 kind="prose",
-                display=f"{m.group('author')} {m.group('year')}",
+                display=f"{author} {m.group('year')}",
                 lineno=lineno,
                 col=m.start() + 1,
             ))

--- a/src/nexus/doc/citations.py
+++ b/src/nexus/doc/citations.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-083: Citation scanner + grounding / author-extension reports.
+
+Three citation shapes are recognised:
+
+  * ``chash`` — ``[display](chash:<64-hex>)`` markdown link.  The
+    chash span is the primary grounding primitive; v1 reports shape
+    only (cross-collection hash-to-chunk resolution is deferred).
+  * ``prose`` — ``[Author <year>]`` patterns (``[Grossberg 2013]``).
+    Not machine-verifiable; reported as prose-only coverage gap.
+  * ``bracket`` — ``[NN]`` numeric references that resolve to a
+    bibliography elsewhere in the doc.
+
+Fenced code blocks are skipped (tutorial snippets that demonstrate
+the syntax are not scanned).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from nexus.doc._common import iter_plain_lines
+
+__all__ = [
+    "Citation",
+    "GroundingReport",
+    "ExtensionsReport",
+    "scan_citations",
+    "grounding_report",
+    "extensions_report",
+]
+
+
+CitationKind = Literal["chash", "prose", "bracket"]
+
+
+@dataclass(slots=True)
+class Citation:
+    """One citation occurrence."""
+
+    kind: CitationKind
+    display: str                     # visible text (link display or raw token)
+    lineno: int                       # 1-based source line
+    col: int                          # 1-based column of opener
+    chash: str | None = None          # set iff kind == "chash"
+
+
+# Grammar regexes.
+#
+# chash link: [text](chash:<hex>) — require EXACTLY 64 hex chars so
+#   we never accept a truncated / malformed hash.  The display text
+#   can contain any non-bracket non-newline character.
+_CHASH_LINK_RE = re.compile(
+    r"\[(?P<display>[^\]\n]+)\]\(chash:(?P<hash>[0-9a-f]{64})(?::\d+-\d+)?\)"
+)
+
+# Prose citation: [<Author optional-initial> <year>]
+#   - Author starts with a capital letter
+#   - year is 4 digits
+#   - case: [Grossberg 2013], [Smith, J. 2020]
+_PROSE_CITE_RE = re.compile(
+    r"\[(?P<author>[A-Z][A-Za-z.\-' ,]{1,40}?)\s+(?P<year>\d{4})\]"
+)
+
+# Bracketed number: [12], [3], [99] — must be digits only to avoid
+#   conflict with wiki/task-list markers like [x] or [12 ideas].
+_BRACKET_CITE_RE = re.compile(r"\[(?P<num>\d{1,4})\]")
+
+
+def scan_citations(md_text: str) -> list[Citation]:
+    """Return every citation occurrence, in source order."""
+    cites: list[Citation] = []
+    for lineno, line in iter_plain_lines(md_text):
+        # chash first — consumes its bracketed text so prose / bracket
+        # scanners don't double-count the same span
+        chash_spans: list[tuple[int, int]] = []
+        for m in _CHASH_LINK_RE.finditer(line):
+            cites.append(Citation(
+                kind="chash",
+                display=m.group("display"),
+                lineno=lineno,
+                col=m.start() + 1,
+                chash=m.group("hash"),
+            ))
+            chash_spans.append((m.start(), m.end()))
+
+        def _in_chash(pos: int) -> bool:
+            return any(s <= pos < e for s, e in chash_spans)
+
+        for m in _PROSE_CITE_RE.finditer(line):
+            if _in_chash(m.start()):
+                continue
+            cites.append(Citation(
+                kind="prose",
+                display=f"{m.group('author')} {m.group('year')}",
+                lineno=lineno,
+                col=m.start() + 1,
+            ))
+
+        for m in _BRACKET_CITE_RE.finditer(line):
+            if _in_chash(m.start()):
+                continue
+            # Skip positions that overlap an already-captured prose citation
+            covered = any(
+                c.lineno == lineno and c.col <= m.start() + 1 < c.col + len(c.display) + 2
+                for c in cites if c.kind == "prose"
+            )
+            if covered:
+                continue
+            cites.append(Citation(
+                kind="bracket",
+                display=m.group(0),
+                lineno=lineno,
+                col=m.start() + 1,
+            ))
+
+    return cites
+
+
+# ── Grounding report ─────────────────────────────────────────────────────────
+
+
+@dataclass(slots=True)
+class GroundingReport:
+    """Per-doc citation coverage."""
+
+    total: int = 0
+    chash_count: int = 0
+    prose_count: int = 0
+    bracket_count: int = 0
+
+    @property
+    def coverage(self) -> float:
+        """chash citations as a fraction of all citations."""
+        return (self.chash_count / self.total) if self.total else 0.0
+
+
+def grounding_report(cites: list[Citation]) -> GroundingReport:
+    """Compute coverage metrics from a scanned citation list."""
+    r = GroundingReport()
+    for c in cites:
+        r.total += 1
+        if c.kind == "chash":
+            r.chash_count += 1
+        elif c.kind == "prose":
+            r.prose_count += 1
+        elif c.kind == "bracket":
+            r.bracket_count += 1
+    return r
+
+
+# ── Extensions report ────────────────────────────────────────────────────────
+
+
+@dataclass(slots=True)
+class ExtensionsReport:
+    """Author-extension candidates derived from projection data."""
+
+    checked: int = 0
+    candidates: list[tuple[str, float]] = field(default_factory=list)   # (doc_id, similarity)
+    no_data: list[str] = field(default_factory=list)
+
+
+def extensions_report(
+    doc_ids: list[str],
+    *,
+    primary_source: str,
+    threshold: float,
+    taxonomy: Any,
+) -> ExtensionsReport:
+    """For each doc, check whether it projects into *primary_source* at
+    or above *threshold*. Docs below → candidates for `> [Author extension]`.
+
+    *taxonomy* must expose ``chunk_grounded_in(doc_id, source_collection,
+    threshold)`` returning the top similarity of that doc's chunks
+    against the source collection, or ``None`` when no projection data
+    is available.
+    """
+    out = ExtensionsReport()
+    for did in doc_ids:
+        out.checked += 1
+        sim = taxonomy.chunk_grounded_in(
+            did, primary_source, threshold=threshold,
+        )
+        if sim is None:
+            out.no_data.append(did)
+            continue
+        if sim < threshold:
+            out.candidates.append((did, sim))
+    return out

--- a/src/nexus/doc/ref_scanner.py
+++ b/src/nexus/doc/ref_scanner.py
@@ -75,7 +75,7 @@ class Drift:
 
 # ── Scanner ──────────────────────────────────────────────────────────────────
 
-_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+from nexus.doc._common import FENCE_RE as _FENCE_RE
 
 #: Chunk-count claim patterns.  Order matters — longer/more-specific wins.
 #: ``\b`` anchors so we don't match "4k7chunks" or similar tokens.
@@ -111,32 +111,7 @@ def _collection_regex(prefixes: list[str]) -> re.Pattern:
     )
 
 
-def _iter_plain_lines(text: str):
-    """Yield (1-based line number, line) skipping fenced code blocks.
-
-    Both ``` and ~~~ fences are recognised. A matching closing fence on
-    its own line exits the block. Inline backticks are not fences — only
-    full-line fence markers toggle state.
-    """
-    in_fence = False
-    fence_marker: str | None = None
-    for lineno, line in enumerate(text.splitlines(), 1):
-        m = _FENCE_RE.match(line)
-        if m:
-            tok = m.group(1)
-            if in_fence:
-                # Closing fence must match opener marker
-                if fence_marker == tok:
-                    in_fence = False
-                    fence_marker = None
-            else:
-                in_fence = True
-                fence_marker = tok
-            # Fence-delimiter lines never carry references themselves
-            continue
-        if in_fence:
-            continue
-        yield lineno, line
+from nexus.doc._common import iter_plain_lines as _iter_plain_lines
 
 
 def _paragraph_for_line(lines: list[tuple[int, str]], target_lineno: int) -> list[str]:

--- a/src/nexus/doc/render.py
+++ b/src/nexus/doc/render.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-082: Render engine for ``nx doc render`` / ``nx doc validate``.
+
+Pipeline: ``parse_tokens → lookup resolver → resolve → substitute``.
+A token whose namespace has no registered resolver, or whose resolver
+raises :class:`~nexus.doc.resolvers.ResolutionError`, causes render to
+fail loud by default. Set ``allow_unresolved=True`` to preserve the
+literal token text instead (``--allow-unresolved`` CLI flag).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from nexus.doc.resolvers import ResolutionError, ResolverRegistry
+from nexus.doc.tokens import Token, parse_tokens
+
+__all__ = ["RenderError", "RenderResult", "render_text", "render_file"]
+
+
+class RenderError(Exception):
+    """Raised when one or more tokens cannot be resolved and the
+    caller did not opt in to ``allow_unresolved``."""
+
+
+@dataclass(slots=True)
+class RenderResult:
+    """Result of a render_file call."""
+
+    output: str
+    resolved: int
+    unresolved: list[tuple[Token, str]]   # (token, reason) for each miss
+
+
+def render_text(
+    text: str,
+    registry: ResolverRegistry,
+    *,
+    allow_unresolved: bool = False,
+) -> str:
+    """Return *text* with every in-scope token substituted."""
+    tokens = parse_tokens(text)
+    if not tokens:
+        return text
+
+    out_parts: list[str] = []
+    last = 0
+    misses: list[tuple[Token, str]] = []
+
+    for tok in tokens:
+        start, end = tok.span
+        out_parts.append(text[last:start])
+        resolver = registry.get(tok.namespace)
+        if resolver is None:
+            if allow_unresolved:
+                out_parts.append(tok.raw)
+                misses.append((tok, f"no resolver for namespace {tok.namespace!r}"))
+            else:
+                raise RenderError(
+                    f"line {tok.lineno} col {tok.col}: no resolver registered "
+                    f"for namespace {tok.namespace!r} in {tok.raw!r}"
+                )
+        else:
+            try:
+                value = resolver.resolve(tok.key, tok.field, tok.filters)
+                out_parts.append(value)
+            except ResolutionError as exc:
+                if allow_unresolved:
+                    out_parts.append(tok.raw)
+                    misses.append((tok, str(exc)))
+                else:
+                    raise RenderError(
+                        f"line {tok.lineno} col {tok.col}: {exc} "
+                        f"(token={tok.raw!r})"
+                    ) from exc
+        last = end
+
+    out_parts.append(text[last:])
+    return "".join(out_parts)
+
+
+def render_file(
+    path: Path,
+    registry: ResolverRegistry,
+    *,
+    out_dir: Path | None = None,
+    allow_unresolved: bool = False,
+    emit: bool = True,
+) -> RenderResult:
+    """Render *path*, writing a ``<stem>.rendered.md`` sibling by default.
+
+    Args:
+        path: Source markdown.
+        registry: Namespace → Resolver registry.
+        out_dir: When set, writes the rendered sibling inside this
+            directory instead of next to the source (mirrors the source
+            directory structure). When ``None``, writes a sibling.
+        allow_unresolved: If True, unresolved tokens are preserved
+            verbatim in the output and collected in the result.
+        emit: When False, the output is computed but NOT written to
+            disk — the ``nx doc validate`` mode.
+    """
+    text = path.read_text()
+    resolved_count = _count_resolvable_tokens(text, registry)
+    out = render_text(text, registry, allow_unresolved=allow_unresolved)
+
+    misses: list[tuple[Token, str]] = []
+    if allow_unresolved:
+        # Re-scan to collect misses (the render loop discards them when
+        # the caller asked for permissive mode; callers that need a
+        # miss report pay one extra pass here — cheap vs render cost).
+        for tok in parse_tokens(text):
+            resolver = registry.get(tok.namespace)
+            if resolver is None:
+                misses.append((tok, f"no resolver for namespace {tok.namespace!r}"))
+                continue
+            try:
+                resolver.resolve(tok.key, tok.field, tok.filters)
+            except ResolutionError as exc:
+                misses.append((tok, str(exc)))
+
+    if emit:
+        dest = _rendered_sibling(path, out_dir)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(out)
+
+    return RenderResult(output=out, resolved=resolved_count, unresolved=misses)
+
+
+def _count_resolvable_tokens(text: str, registry: ResolverRegistry) -> int:
+    return sum(1 for tok in parse_tokens(text) if tok.namespace in registry)
+
+
+def _rendered_sibling(path: Path, out_dir: Path | None) -> Path:
+    if out_dir is None:
+        return path.with_suffix(f".rendered{path.suffix}")
+    # Mirror tree: preserve the source file's stem + ".rendered"
+    return (out_dir / path.name).with_suffix(f".rendered{path.suffix}")

--- a/src/nexus/doc/render.py
+++ b/src/nexus/doc/render.py
@@ -38,14 +38,23 @@ def render_text(
     registry: ResolverRegistry,
     *,
     allow_unresolved: bool = False,
-) -> str:
-    """Return *text* with every in-scope token substituted."""
+) -> tuple[str, int, list[tuple[Token, str]]]:
+    """Return ``(output, resolved_count, misses)``.
+
+    ``resolved_count`` only counts tokens that a registered resolver
+    handled without raising. Tokens with no registered namespace or
+    ones that raise ``ResolutionError`` are misses; when
+    ``allow_unresolved`` is False the first miss raises ``RenderError``,
+    otherwise they accumulate in the ``misses`` list and the literal
+    token text is preserved in the output.
+    """
     tokens = parse_tokens(text)
     if not tokens:
-        return text
+        return text, 0, []
 
     out_parts: list[str] = []
     last = 0
+    resolved = 0
     misses: list[tuple[Token, str]] = []
 
     for tok in tokens:
@@ -65,6 +74,7 @@ def render_text(
             try:
                 value = resolver.resolve(tok.key, tok.field, tok.filters)
                 out_parts.append(value)
+                resolved += 1
             except ResolutionError as exc:
                 if allow_unresolved:
                     out_parts.append(tok.raw)
@@ -77,7 +87,7 @@ def render_text(
         last = end
 
     out_parts.append(text[last:])
-    return "".join(out_parts)
+    return "".join(out_parts), resolved, misses
 
 
 def render_file(
@@ -87,6 +97,7 @@ def render_file(
     out_dir: Path | None = None,
     allow_unresolved: bool = False,
     emit: bool = True,
+    source_root: Path | None = None,
 ) -> RenderResult:
     """Render *path*, writing a ``<stem>.rendered.md`` sibling by default.
 
@@ -94,46 +105,42 @@ def render_file(
         path: Source markdown.
         registry: Namespace → Resolver registry.
         out_dir: When set, writes the rendered sibling inside this
-            directory instead of next to the source (mirrors the source
-            directory structure). When ``None``, writes a sibling.
+            directory. The source's *relative* path (against
+            *source_root*) is preserved — a mirror tree.
+        source_root: Anchor for mirror-tree relative-path computation.
+            Defaults to ``Path.cwd()``. Ignored when ``out_dir`` is None.
         allow_unresolved: If True, unresolved tokens are preserved
             verbatim in the output and collected in the result.
         emit: When False, the output is computed but NOT written to
             disk — the ``nx doc validate`` mode.
     """
     text = path.read_text()
-    resolved_count = _count_resolvable_tokens(text, registry)
-    out = render_text(text, registry, allow_unresolved=allow_unresolved)
-
-    misses: list[tuple[Token, str]] = []
-    if allow_unresolved:
-        # Re-scan to collect misses (the render loop discards them when
-        # the caller asked for permissive mode; callers that need a
-        # miss report pay one extra pass here — cheap vs render cost).
-        for tok in parse_tokens(text):
-            resolver = registry.get(tok.namespace)
-            if resolver is None:
-                misses.append((tok, f"no resolver for namespace {tok.namespace!r}"))
-                continue
-            try:
-                resolver.resolve(tok.key, tok.field, tok.filters)
-            except ResolutionError as exc:
-                misses.append((tok, str(exc)))
-
+    out, resolved_count, misses = render_text(
+        text, registry, allow_unresolved=allow_unresolved,
+    )
     if emit:
-        dest = _rendered_sibling(path, out_dir)
+        dest = _rendered_sibling(path, out_dir, source_root)
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(out)
-
     return RenderResult(output=out, resolved=resolved_count, unresolved=misses)
 
 
-def _count_resolvable_tokens(text: str, registry: ResolverRegistry) -> int:
-    return sum(1 for tok in parse_tokens(text) if tok.namespace in registry)
+def _rendered_sibling(
+    path: Path, out_dir: Path | None, source_root: Path | None = None,
+) -> Path:
+    """Compute the destination path for a rendered sibling.
 
-
-def _rendered_sibling(path: Path, out_dir: Path | None) -> Path:
+    When *out_dir* is None, the sibling lives next to the source with
+    a ``.rendered`` stem suffix. When *out_dir* is set, the source's
+    path relative to *source_root* (default: cwd) is preserved under
+    *out_dir* — a mirror tree. Sources outside *source_root* fall back
+    to basename-only placement under *out_dir*.
+    """
     if out_dir is None:
         return path.with_suffix(f".rendered{path.suffix}")
-    # Mirror tree: preserve the source file's stem + ".rendered"
-    return (out_dir / path.name).with_suffix(f".rendered{path.suffix}")
+    anchor = (source_root or Path.cwd()).resolve()
+    try:
+        rel = path.resolve().relative_to(anchor)
+    except ValueError:
+        rel = Path(path.name)
+    return (out_dir / rel).with_suffix(f".rendered{path.suffix}")

--- a/src/nexus/doc/resolvers.py
+++ b/src/nexus/doc/resolvers.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-082: Resolver protocol + built-in bead/RDR resolvers + registry.
+
+The registry is the extension point RDR-083 plugs its
+``AnchorResolver`` and ``ChashResolver`` into without touching parser,
+engine, or CLI.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Protocol
+
+__all__ = [
+    "Resolver",
+    "ResolutionError",
+    "ResolverRegistry",
+    "BeadResolver",
+    "RdrResolver",
+]
+
+
+class ResolutionError(Exception):
+    """Raised by a resolver when a key/field cannot be resolved."""
+
+
+class Resolver(Protocol):
+    """Minimal contract. Implementers read their own namespace's data
+    source (bead DB, RDR frontmatter, ChromaDB, ...) and return a
+    markdown-safe string. Unknown key → ``ResolutionError``."""
+
+    def resolve(
+        self, key: str, field: str | None, filters: dict[str, str],
+    ) -> str:  # pragma: no cover - Protocol
+        ...
+
+
+class ResolverRegistry:
+    """Maps namespace → Resolver. Add third-party resolvers via
+    :meth:`register` — the render engine looks up ``namespace`` here
+    at dispatch time so nothing in the parser or CLI needs to know
+    about them.
+    """
+
+    def __init__(self, initial: dict[str, Resolver] | None = None) -> None:
+        self._by_ns: dict[str, Resolver] = dict(initial or {})
+
+    def register(self, namespace: str, resolver: Resolver) -> None:
+        self._by_ns[namespace] = resolver
+
+    def get(self, namespace: str) -> Resolver | None:
+        return self._by_ns.get(namespace)
+
+    def __contains__(self, namespace: str) -> bool:
+        return namespace in self._by_ns
+
+
+# ── BeadResolver ─────────────────────────────────────────────────────────────
+
+
+_BEAD_DEFAULT_FIELD = "title"
+_BEAD_ALLOWED_FIELDS = frozenset({
+    "title", "status", "assignee", "closed_at", "epic_id", "progress", "id",
+})
+
+
+class BeadResolver:
+    """``{{bd:<id>[.field]}}`` — ``bd show <id> --json`` lookup.
+
+    A per-instance cache keyed on ``key`` coalesces multiple field
+    reads of the same bead into one subprocess call — ``nx doc render``
+    is expected to instantiate a fresh resolver per render, so the
+    cache is bounded by the document's unique-bead count.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, dict[str, Any]] = {}
+
+    def resolve(
+        self, key: str, field: str | None, filters: dict[str, str],
+    ) -> str:
+        data = self._cache.get(key)
+        if data is None:
+            data = self._fetch(key)
+            self._cache[key] = data
+        sel = field or _BEAD_DEFAULT_FIELD
+        if sel not in _BEAD_ALLOWED_FIELDS:
+            raise ResolutionError(
+                f"bead field {sel!r} not in allow-list {sorted(_BEAD_ALLOWED_FIELDS)}"
+            )
+        value = data.get(sel)
+        if value is None:
+            raise ResolutionError(
+                f"bead {key!r} has no field {sel!r}"
+            )
+        return str(value)
+
+    def _fetch(self, key: str) -> dict[str, Any]:
+        try:
+            proc = subprocess.run(
+                ["bd", "show", key, "--json"],
+                capture_output=True, text=True, timeout=10,
+            )
+        except FileNotFoundError as exc:
+            raise ResolutionError(
+                "`bd` CLI not on PATH — install beads to resolve {{bd:…}} tokens"
+            ) from exc
+        if proc.returncode != 0:
+            raise ResolutionError(
+                f"bd show {key!r} exited {proc.returncode}: "
+                f"{proc.stderr.strip()[:200]}"
+            )
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise ResolutionError(
+                f"bd show {key!r} returned non-JSON: {proc.stdout[:200]!r}"
+            ) from exc
+
+
+# ── RdrResolver ──────────────────────────────────────────────────────────────
+
+
+_RDR_DEFAULT_FIELD = "title"
+_RDR_ALLOWED_FIELDS = frozenset({
+    "title", "status", "type", "priority", "author", "gated", "closed",
+    "close_reason", "epic_bead",
+})
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+
+class RdrResolver:
+    """``{{rdr:<id>[.field]}}`` — reads ``docs/rdr/rdr-<id>-*.md``
+    frontmatter. The file itself is authoritative (mirrored in T2 but
+    the file is the source of truth per CLAUDE.md's RDR convention).
+    """
+
+    def __init__(self, rdr_dir: Path) -> None:
+        self._rdr_dir = Path(rdr_dir)
+        self._cache: dict[str, dict[str, Any]] = {}
+
+    def resolve(
+        self, key: str, field: str | None, filters: dict[str, str],
+    ) -> str:
+        data = self._cache.get(key)
+        if data is None:
+            data = self._fetch(key)
+            self._cache[key] = data
+        sel = field or _RDR_DEFAULT_FIELD
+        if sel not in _RDR_ALLOWED_FIELDS:
+            raise ResolutionError(
+                f"rdr field {sel!r} not in allow-list {sorted(_RDR_ALLOWED_FIELDS)}"
+            )
+        value = data.get(sel)
+        if value is None:
+            raise ResolutionError(
+                f"rdr-{key} frontmatter has no field {sel!r}"
+            )
+        return str(value)
+
+    def _fetch(self, key: str) -> dict[str, Any]:
+        # Match rdr-<id>-*.md or rdr-<zero-padded>-*.md
+        stem_prefix = f"rdr-{key.lstrip('0').zfill(len(key)) or key}-"
+        # Also match un-padded form
+        candidates = list(self._rdr_dir.glob(f"rdr-{key}-*.md"))
+        if not candidates:
+            candidates = list(self._rdr_dir.glob(f"{stem_prefix}*.md"))
+        if not candidates:
+            # Fallback: scan with regex for any rdr-<any leading zeros><key>-
+            pattern = re.compile(rf"^rdr-0*{int(key)}-.+\.md$") if key.isdigit() else None
+            if pattern:
+                for p in self._rdr_dir.glob("rdr-*.md"):
+                    if pattern.match(p.name):
+                        candidates = [p]
+                        break
+        if not candidates:
+            raise ResolutionError(
+                f"no RDR file matching rdr-{key}-*.md under {self._rdr_dir}"
+            )
+        text = candidates[0].read_text(errors="replace")
+        m = _FRONTMATTER_RE.search(text)
+        if not m:
+            raise ResolutionError(
+                f"rdr-{key} has no YAML frontmatter"
+            )
+        return _parse_frontmatter(m.group(1))
+
+
+def _parse_frontmatter(block: str) -> dict[str, Any]:
+    """Minimal YAML subset — single-line ``key: value`` pairs only.
+    Sufficient for the RDR frontmatter schema; falls back to PyYAML
+    when available for anything more complex (lists, nested maps)."""
+    try:
+        import yaml
+        data = yaml.safe_load(block) or {}
+        return data if isinstance(data, dict) else {}
+    except ImportError:
+        pass
+
+    out: dict[str, Any] = {}
+    for line in block.splitlines():
+        if ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        key = k.strip()
+        val = v.strip().strip('"').strip("'")
+        if key:
+            out[key] = val
+    return out

--- a/src/nexus/doc/resolvers_corpus.py
+++ b/src/nexus/doc/resolvers_corpus.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-083: Corpus-evidence resolvers — ``{{nx-anchor:…}}`` + future kin.
+
+Plugs into RDR-082's :class:`~nexus.doc.resolvers.ResolverRegistry`
+as the first external consumer, verifying that the extension-point
+design does the job.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from nexus.doc.resolvers import ResolutionError
+
+__all__ = ["AnchorResolver"]
+
+
+class AnchorResolver:
+    """``{{nx-anchor:<collection>[|top=N]}}`` — top-N projected topics
+    for a collection, rendered as a markdown bullet list.
+
+    Reads from ``topic_assignments`` via
+    :meth:`CatalogTaxonomy.top_topics_for_collection`. No new schema.
+    """
+
+    def __init__(self, *, taxonomy: Any) -> None:
+        self._tax = taxonomy
+
+    def resolve(
+        self, key: str, field: str | None, filters: dict[str, str],
+    ) -> str:
+        top = _int_filter(filters, "top", default=5)
+        rows = self._tax.top_topics_for_collection(key, top_n=top)
+        if not rows:
+            raise ResolutionError(
+                f"no projection data for collection {key!r} "
+                f"(run `nx taxonomy project` to populate)"
+            )
+        lines = []
+        for row in rows:
+            label = row.get("label") or "<unlabeled>"
+            chunks = row.get("chunks")
+            if chunks:
+                lines.append(f"- {label} ({chunks} chunks)")
+            else:
+                lines.append(f"- {label}")
+        return "\n".join(lines)
+
+
+def _int_filter(filters: dict[str, str], key: str, *, default: int) -> int:
+    raw = filters.get(key)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default

--- a/src/nexus/doc/tokens.py
+++ b/src/nexus/doc/tokens.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-082: Token parser for ``nx doc render``.
+
+Grammar::
+
+    {{NAMESPACE:KEY[.FIELD][|FILTER=VALUE]*}}
+
+    namespace : [a-z][a-z0-9-]*   (e.g. ``bd``, ``rdr``, ``nx-anchor``)
+    key       : [^.|}]+           (bead id, rdr id, collection name, ...)
+    field     : [^|}]+            (resolver-specific dotted path)
+    filter    : <name>=<value>    (resolver-specific, multiple allowed)
+
+Tokens inside fenced markdown code (```` ``` ```` / ``~~~``) are
+ignored so tutorial snippets that *demonstrate* the syntax don't get
+resolved. Callers that need the literal fence behaviour (e.g. rendered
+HTML passthrough) should use a different escape.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from nexus.doc._common import FENCE_RE
+
+__all__ = ["Token", "parse_tokens"]
+
+
+# Grammar regex. Capture groups:
+#   1: namespace   — alphanum + hyphen, must start with a letter
+#   2: key         — one or more chars not in ".|}"
+#   3: field       — optional, starts after "."
+#   4: filter blob — optional, starts after "|"
+_TOKEN_RE = re.compile(
+    r"""
+    \{\{\s*
+    (?P<ns>[a-z][a-z0-9-]*)           # namespace
+    \s*:\s*
+    (?P<key>[^.|}]+?)                 # key (non-greedy)
+    (?:\.(?P<field>[^|}]+?))?         # optional .field
+    (?P<filters>(?:\|[^}]+)?)         # optional |k=v|k=v blob
+    \s*\}\}
+    """,
+    re.VERBOSE,
+)
+
+_FILTER_RE = re.compile(r"([a-z_][a-z0-9_-]*)=([^|]+)")
+
+
+@dataclass(slots=True)
+class Token:
+    """One resolved-at-render token occurrence."""
+
+    namespace: str
+    key: str
+    field: str | None
+    filters: dict[str, str] = field(default_factory=dict)
+    span: tuple[int, int] = (0, 0)   # (start, end) byte offsets in source
+    lineno: int = 0                   # 1-based
+    col: int = 0                      # 1-based column of the opening ``{{``
+    raw: str = ""                     # literal source text for error reporting
+
+
+def parse_tokens(text: str) -> list[Token]:
+    """Scan *text* for tokens outside fenced code blocks.
+
+    Returns tokens in source order. Malformed ``{{…}}`` sequences that
+    do not match the grammar are silently skipped — render-time
+    validation decides whether to fail the build (the default) or
+    preserve the literal text.
+    """
+    # Walk the text once, tracking fence state. Within fenced zones,
+    # skip token extraction entirely — but keep byte offsets correct
+    # for any tokens encountered later so error reporting matches the
+    # real file position.
+    tokens: list[Token] = []
+    in_fence = False
+    fence_marker: str | None = None
+
+    offset = 0
+    for lineno, line in enumerate(text.splitlines(keepends=True), 1):
+        stripped = line.rstrip("\n\r")
+        m = FENCE_RE.match(stripped)
+        if m:
+            if not in_fence:
+                in_fence = True
+                fence_marker = m.group(1)
+            elif m.group(1) == fence_marker:
+                in_fence = False
+                fence_marker = None
+            offset += len(line)
+            continue
+        if in_fence:
+            offset += len(line)
+            continue
+
+        for tm in _TOKEN_RE.finditer(stripped):
+            filters = _parse_filters(tm.group("filters") or "")
+            col = tm.start() + 1
+            start = offset + tm.start()
+            end = offset + tm.end()
+            tokens.append(
+                Token(
+                    namespace=tm.group("ns"),
+                    key=tm.group("key").strip(),
+                    field=(tm.group("field") or "").strip() or None,
+                    filters=filters,
+                    span=(start, end),
+                    lineno=lineno,
+                    col=col,
+                    raw=tm.group(0),
+                )
+            )
+        offset += len(line)
+
+    return tokens
+
+
+def _parse_filters(blob: str) -> dict[str, str]:
+    """Parse ``|key=val|key2=val2`` into a flat dict. Malformed entries
+    are dropped — the resolver sees only well-formed pairs."""
+    out: dict[str, str] = {}
+    if not blob:
+        return out
+    # Strip leading '|'
+    for m in _FILTER_RE.finditer(blob.lstrip("|")):
+        out[m.group(1)] = m.group(2).strip()
+    return out

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -758,6 +758,7 @@ def index_pdf(
                 pdf_path, content_hash, col_name, db,
                 embed_fn=embed_fn, extractor=extractor,
                 corpus=corpus, target_model=target_model,
+                force=force,
             )
             if return_metadata:
                 # Query T3 for metadata after streaming upload.

--- a/src/nexus/glossary.py
+++ b/src/nexus/glossary.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-085: Project-vocabulary resolver for the topic labeler.
+
+Two call sites:
+
+  * ``relabel_topics`` in :mod:`nexus.commands.taxonomy_cmd` — run once
+    per command invocation, cached per batch.
+  * The post-discover auto-label banner in :mod:`nexus.commands.index`
+    — same pathway via ``relabel_topics``.
+
+Load order (highest wins):
+
+  1. ``.nexus.yml#taxonomy.glossary`` — authoritative, one-place config.
+  2. ``docs/glossary.md`` — bulleted markdown list.
+  3. empty dict — opt-in; labeler proceeds without a vocabulary
+     preamble, matching pre-RDR-085 behaviour exactly.
+
+A malformed config or parse failure logs a debug line and returns
+``{}`` — the labeler must never block on glossary problems.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def load_glossary(
+    project_root: Path,
+    collection: str | None = None,
+) -> dict[str, str]:
+    """Return a ``{term: expansion}`` map from the project's glossary.
+
+    Args:
+        project_root: Repo root containing ``.nexus.yml`` / ``docs/``.
+        collection: Reserved for a future per-collection override
+            (``<collection>.glossary.md``). Unused in v1.
+    """
+    # Priority 1: .nexus.yml#taxonomy.glossary
+    yml = project_root / ".nexus.yml"
+    if yml.exists():
+        try:
+            import yaml  # pyyaml is already a nexus dep
+
+            data = yaml.safe_load(yml.read_text()) or {}
+        except Exception:
+            data = {}
+        if isinstance(data, dict):
+            section = data.get("taxonomy")
+            if isinstance(section, dict):
+                gloss = section.get("glossary")
+                if isinstance(gloss, dict):
+                    return {str(k): str(v) for k, v in gloss.items() if v}
+
+    # Priority 2: docs/glossary.md — bulleted markdown, one term per line
+    md = project_root / "docs" / "glossary.md"
+    if md.exists():
+        return _parse_markdown_glossary(md.read_text())
+
+    return {}
+
+
+_BULLET_ENTRY = re.compile(
+    r"""
+    ^\s*[-*+]\s*                   # bullet
+    (?:\*\*)?(?P<term>[A-Za-z0-9_\-]+)(?:\*\*)?  # optional **bold**
+    \s*[:\-—]\s*                   # separator: ':' or '-' or '—'
+    (?P<defn>.+?)\s*$              # definition (rest of line)
+    """,
+    re.VERBOSE,
+)
+
+
+def _parse_markdown_glossary(text: str) -> dict[str, str]:
+    """Extract ``- TERM: expansion`` / ``- **TERM**: expansion`` pairs."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        m = _BULLET_ENTRY.match(line)
+        if m:
+            out[m.group("term")] = m.group("defn").strip()
+    return out
+
+
+def format_for_prompt(terms: dict[str, str], max_tokens: int = 500) -> str:
+    """Render a glossary as a prompt preamble, bounded at ``max_tokens``.
+
+    Output shape::
+
+        Project vocabulary (use these expansions when an acronym matches):
+        - TERM: expansion
+        - TERM: expansion
+        ...
+
+    Token budget is a rough 4-chars-per-token proxy — the labeler's
+    prompt is short-form content, so the estimate is accurate enough
+    to keep the preamble from dominating. Excess entries are silently
+    dropped rather than truncating mid-line.
+    """
+    if not terms:
+        return ""
+
+    header = "Project vocabulary (use these expansions when an acronym matches):\n"
+    budget_chars = max(0, max_tokens * 4 - len(header))
+
+    lines: list[str] = []
+    used = 0
+    for term, defn in terms.items():
+        line = f"- {term}: {defn}"
+        if used + len(line) + 1 > budget_chars:
+            break
+        lines.append(line)
+        used += len(line) + 1  # +1 for the '\n'
+
+    if not lines:
+        return ""
+    return header + "\n".join(lines) + "\n"

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -19,6 +19,7 @@ from nexus.corpus import (
 )
 from nexus.db.t3 import verify_collection_deep
 from nexus.filters import parse_where_str as _parse_where_str
+from nexus.config import load_config
 from nexus.mcp_infra import (
     catalog_auto_link as _catalog_auto_link,
     fire_post_store_hooks as _fire_post_store_hooks,
@@ -1838,6 +1839,30 @@ async def _nx_answer_plan_miss(
     )
 
 
+# ── RDR-084 helpers ───────────────────────────────────────────────────────────
+
+
+def _load_ad_hoc_ttl() -> int:
+    """Return the TTL (days) applied to auto-saved ad-hoc plans.
+
+    Reads ``.nexus.yml#plans.ad_hoc_ttl`` via :func:`nexus.config.load_config`
+    with a 30-day fallback. A config load failure also falls back to 30
+    — the growth feature is best-effort and must never block ``nx_answer``.
+    """
+    try:
+        config = load_config()
+    except Exception:
+        return 30
+    plans_section = config.get("plans") if isinstance(config, dict) else None
+    if not isinstance(plans_section, dict):
+        return 30
+    value = plans_section.get("ad_hoc_ttl", 30)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 30
+
+
 # ── RDR-080 orchestration tools ───────────────────────────────────────────────
 
 
@@ -2020,12 +2045,47 @@ async def nx_answer(
         duration_ms=elapsed_ms,
     )
 
-    # Save ad-hoc plans on success (I-6).
+    # RDR-084: Save successful ad-hoc plans so the plan library compounds
+    # with usage. scope=personal keeps growth isolated to the caller (the
+    # project/global scopes are reached only via /nx:plan-promote). TTL is
+    # config-driven; 30-day default. Best-effort — a save failure never
+    # affects the user's answer, and the T1 cache upsert is a separate
+    # best-effort step inside the same guard.
     if best.plan_id == 0:
-        try:
-            plan_save(query=question, plan_json=best.plan_json, outcome="success", ttl=30)
-        except Exception:
-            pass
+        ttl_days = _load_ad_hoc_ttl()
+        if ttl_days > 0:
+            try:
+                from pathlib import Path as _Path
+
+                project_name = _Path.cwd().name
+                with _t2_ctx() as _save_db:
+                    grown_id = _save_db.plans.save_plan(
+                        query=question,
+                        plan_json=best.plan_json,
+                        outcome="success",
+                        tags="ad-hoc,grown",
+                        project=project_name,
+                        ttl=ttl_days,
+                        scope="personal",
+                    )
+                    # Feed the new plan into the T1 cosine cache so the next
+                    # paraphrase can match without a SessionStart re-populate.
+                    try:
+                        cache = get_t1_plan_cache()
+                        if cache is not None:
+                            row = _save_db.plans.get_plan(grown_id)
+                            if row:
+                                cache.upsert(row)
+                    except Exception:
+                        _log.debug("plan_grow_cache_upsert_failed", exc_info=True)
+                _log.info(
+                    "plan_grow_saved",
+                    plan_id=grown_id,
+                    ttl_days=ttl_days,
+                    project=project_name,
+                )
+            except Exception as exc:
+                _log.warning("plan_grow_save_failed", error=str(exc))
 
     # ── Step 6: record run ───────────────────────────────────────────────
     try:

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -513,6 +513,7 @@ def pipeline_index_pdf(
     corpus: str = "",
     target_model: str = "voyage-context-3",
     git_meta: dict | None = None,
+    force: bool = False,
 ) -> int:
     """Three-stage streaming pipeline for PDFs.
 
@@ -521,6 +522,15 @@ def pipeline_index_pdf(
     - Tag table-page chunks
     - Correct chunk_count to the final total
     - Prune stale chunks from a previous version
+
+    Args:
+        force: Break the partial-ingest deadlock (nexus-9ji). When True,
+            pre-flight deletes both (a) the pipeline.db rows for this
+            ``content_hash`` across ``pdf_pipeline``/``pdf_pages``/
+            ``pdf_chunks`` and (b) any orphan T3 chunks in *collection*
+            whose ``content_hash`` matches — so neither the pipeline
+            state nor half-written prior chunks can silently skip the
+            re-ingest or race the upsert. No-op when False.
 
     Returns total chunks indexed.
     """
@@ -538,6 +548,22 @@ def pipeline_index_pdf(
     if git_meta is None:
         from nexus.indexer_utils import detect_git_metadata
         git_meta = detect_git_metadata(pdf_path)
+
+    # nexus-9ji: --force must break the partial-ingest deadlock. Both
+    # pipeline.db state and T3 orphan chunks can independently block
+    # re-ingest; wipe both before the pre-flight.
+    if force:
+        db.delete_pipeline_data(content_hash)
+        try:
+            col = t3.get_or_create_collection(collection)
+            col.delete(where={"content_hash": content_hash})
+        except Exception as exc:
+            _log.warning(
+                "force_t3_orphan_cleanup_failed",
+                content_hash=content_hash,
+                collection=collection,
+                error=str(exc),
+            )
 
     # Pre-flight: check if pipeline should run before resolving credentials.
     result = db.create_pipeline(content_hash, str(pdf_path), collection)

--- a/tests/test_nexus_9ji_force_partial_ingest.py
+++ b/tests/test_nexus_9ji_force_partial_ingest.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-9ji regression — `nx index pdf --force` must break the
+partial-ingest deadlock:
+
+  (a) pipeline.db says the content_hash is "completed"  → `create_pipeline`
+      returns "skip" → streaming path bails silently.
+  (b) T3 has orphan chunks from a prior partial ingest → upsert races
+      against orphaned metadata rows.
+
+Pre-fix: `--force` was passed at the CLI, respected in the T3 staleness
+check inside `_index_common`, but NEVER plumbed through to the streaming
+`pipeline_index_pdf` path — so the streaming path silently no-op'd.
+
+Post-fix contract:
+  * `pipeline_index_pdf(..., force=True)` calls
+    `db.delete_pipeline_data(content_hash)` before `create_pipeline`.
+  * `pipeline_index_pdf(..., force=True)` also deletes orphan T3 chunks
+    matching the content_hash in the target collection (so upsert has
+    a clean slate, not a half-written prior attempt).
+  * `index_pdf(..., force=True)` passes force through to
+    `pipeline_index_pdf`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── pipeline.db "completed" state bypass ────────────────────────────────────
+
+
+class TestPipelineStateBypass:
+
+    def test_force_wipes_completed_pipeline_state(self, tmp_path: Path):
+        """When pipeline.db already records a content_hash as 'completed',
+        a force=True caller must see delete_pipeline_data called BEFORE
+        create_pipeline so the new run isn't silently skipped."""
+        from nexus.pipeline_buffer import PipelineDB
+
+        db_path = tmp_path / "pipeline.db"
+        db = PipelineDB(db_path)
+        # Seed: mark a content_hash as completed in pipeline.db
+        h = "a" * 64
+        conn = db._conn()
+        conn.execute(
+            "INSERT INTO pdf_pipeline "
+            "(content_hash, pdf_path, collection, status, started_at, "
+            " updated_at) VALUES (?, ?, ?, 'completed', ?, ?)",
+            (h, str(tmp_path / "fake.pdf"), "knowledge__test",
+             "2026-04-15T00:00:00Z", "2026-04-15T00:00:00Z"),
+        )
+        conn.commit()
+        # Sanity: create_pipeline returns skip when not forced
+        assert db.create_pipeline(h, "fake.pdf", "x") == "skip"
+
+        # Post-fix: delete_pipeline_data wipes the row
+        db.delete_pipeline_data(h)
+        # create_pipeline now re-inserts as 'created'
+        assert db.create_pipeline(h, "fake.pdf", "x") == "created"
+
+
+# ── pipeline_index_pdf integration ──────────────────────────────────────────
+
+
+class TestPipelineIndexPdfForce:
+
+    @pytest.fixture
+    def fake_pdf(self, tmp_path: Path) -> Path:
+        """Minimal valid PDF so pymupdf can read its page count."""
+        import pymupdf
+
+        pdf_path = tmp_path / "test.pdf"
+        doc = pymupdf.open()
+        doc.new_page()
+        doc.new_page()
+        doc.save(str(pdf_path))
+        doc.close()
+        return pdf_path
+
+    def _seed_prior_completed(self, db, content_hash: str, pdf_path: Path):
+        """Seed pipeline.db as if a prior ingest marked this content_hash
+        'completed'. Emulates the partial-ingest / force-race scenario."""
+        conn = db._conn()
+        conn.execute(
+            "INSERT INTO pdf_pipeline "
+            "(content_hash, pdf_path, collection, status, started_at, "
+            " updated_at) VALUES (?, ?, ?, 'completed', ?, ?)",
+            (content_hash, str(pdf_path), "knowledge__reproducer",
+             "2026-04-15T00:00:00Z", "2026-04-15T00:00:00Z"),
+        )
+        conn.commit()
+
+    def test_force_false_still_skips_when_pipeline_completed(
+        self, tmp_path: Path, fake_pdf: Path,
+    ):
+        """Default behaviour (no --force) is preserved: pipeline.db says
+        completed → skip with no work done."""
+        from nexus.pipeline_buffer import PipelineDB
+        from nexus.pipeline_stages import pipeline_index_pdf
+
+        db = PipelineDB(tmp_path / "pipeline.db")
+        h = "b" * 64
+        self._seed_prior_completed(db, h, fake_pdf)
+
+        fake_t3 = MagicMock()
+        result = pipeline_index_pdf(
+            fake_pdf, h, "knowledge__reproducer", fake_t3, db=db,
+        )
+        assert result == 0
+        # Pipeline row is untouched
+        row = db.get_pipeline_state(h)
+        assert row["status"] == "completed"
+
+    def test_force_true_bypasses_completed_pipeline(
+        self, tmp_path: Path, fake_pdf: Path,
+    ):
+        """force=True wipes pipeline.db row + T3 orphans, then runs."""
+        from nexus.pipeline_buffer import PipelineDB
+        from nexus.pipeline_stages import pipeline_index_pdf
+
+        db = PipelineDB(tmp_path / "pipeline.db")
+        h = "c" * 64
+        self._seed_prior_completed(db, h, fake_pdf)
+
+        fake_t3 = MagicMock()
+        fake_col = MagicMock()
+        fake_t3.get_or_create_collection.return_value = fake_col
+        # Stub the embed_fn so we don't need Voyage credentials
+        fake_embed = lambda texts, model: ([[0.1] * 1024] * len(texts), model)
+
+        # Stub extractor + chunker stages so the test doesn't actually
+        # exercise the streaming pipeline — we only care about the
+        # "skip was bypassed" signal.
+        # Return a mock ExtractionResult with a usable metadata dict so
+        # post-passes don't AttributeError on a None return.
+        fake_extraction = MagicMock()
+        fake_extraction.metadata = {"table_regions": []}
+
+        with patch(
+            "nexus.pipeline_stages.extractor_loop", return_value=fake_extraction,
+        ), patch(
+            "nexus.pipeline_stages.chunker_loop", return_value=None,
+        ), patch(
+            "nexus.pipeline_stages.uploader_loop", return_value=0,
+        ), patch(
+            "nexus.pipeline_stages._enrich_metadata_from_extraction",
+            return_value=True,
+        ), patch(
+            "nexus.pipeline_stages._update_chunk_metadata",
+            return_value=None,
+        ):
+            pipeline_index_pdf(
+                fake_pdf, h, "knowledge__reproducer", fake_t3,
+                db=db, embed_fn=fake_embed, force=True,
+            )
+
+        # After a successful run the post-passes call delete_pipeline_data,
+        # so the row is gone. That is the proof point: the seeded
+        # 'completed' row did NOT block the run — force wiped it, the
+        # pipeline ran to completion, and the post-pass cleaned up. A
+        # zero-row result here means force bypassed the skip; a
+        # still-'completed'-from-seed row would mean it didn't.
+        row = db.get_pipeline_state(h)
+        if row is not None:
+            assert row["updated_at"] > "2026-04-15T00:00:00Z", (
+                f"force=True did not wipe the seeded 'completed' state. "
+                f"Got: {row!r}"
+            )
+
+    def test_force_true_deletes_t3_orphan_chunks(
+        self, tmp_path: Path, fake_pdf: Path,
+    ):
+        """force=True must delete T3 chunks matching this content_hash
+        before re-upload so orphans from a partial prior ingest don't
+        race with the new chunks."""
+        from nexus.pipeline_buffer import PipelineDB
+        from nexus.pipeline_stages import pipeline_index_pdf
+
+        db = PipelineDB(tmp_path / "pipeline.db")
+        h = "d" * 64
+
+        fake_t3 = MagicMock()
+        fake_col = MagicMock()
+        fake_t3.get_or_create_collection.return_value = fake_col
+
+        # Return a mock ExtractionResult with a usable metadata dict so
+        # post-passes don't AttributeError on a None return.
+        fake_extraction = MagicMock()
+        fake_extraction.metadata = {"table_regions": []}
+
+        with patch(
+            "nexus.pipeline_stages.extractor_loop", return_value=fake_extraction,
+        ), patch(
+            "nexus.pipeline_stages.chunker_loop", return_value=None,
+        ), patch(
+            "nexus.pipeline_stages.uploader_loop", return_value=0,
+        ), patch(
+            "nexus.pipeline_stages._enrich_metadata_from_extraction",
+            return_value=True,
+        ), patch(
+            "nexus.pipeline_stages._update_chunk_metadata",
+            return_value=None,
+        ):
+            pipeline_index_pdf(
+                fake_pdf, h, "knowledge__reproducer", fake_t3,
+                db=db, embed_fn=lambda t, m: ([[0.0] * 1024] * len(t), m),
+                force=True,
+            )
+
+        # The collection should have received a pre-flight delete scoped
+        # to this content_hash.
+        assert fake_col.delete.called, (
+            "force=True must call col.delete to purge T3 orphan chunks"
+        )
+        # The delete call should scope to this content_hash (via where
+        # clause) rather than wiping the whole collection.
+        delete_kwargs = fake_col.delete.call_args.kwargs
+        where = delete_kwargs.get("where") or {}
+        assert where.get("content_hash") == h, (
+            f"force delete should scope to content_hash={h!r}; "
+            f"got where={where!r}"
+        )
+
+
+# ── CLI plumbing ────────────────────────────────────────────────────────────
+
+
+class TestIndexPdfPassesForce:
+    """force from the CLI must reach pipeline_index_pdf."""
+
+    def test_index_pdf_forwards_force_to_streaming_path(
+        self, tmp_path: Path,
+    ):
+        """index_pdf(force=True) must forward force to pipeline_index_pdf."""
+        import pymupdf
+        from nexus.doc_indexer import index_pdf
+
+        # Minimal valid PDF
+        pdf_path = tmp_path / "t.pdf"
+        doc = pymupdf.open()
+        doc.new_page()
+        doc.save(str(pdf_path))
+        doc.close()
+
+        fake_t3 = MagicMock()
+        fake_col = MagicMock()
+        fake_col.get.return_value = {"ids": [], "metadatas": []}
+        fake_t3.get_or_create_collection.return_value = fake_col
+
+        captured: dict = {}
+        def fake_pipeline(*args, **kwargs):
+            captured.update(kwargs)
+            return 0
+
+        with patch(
+            "nexus.pipeline_stages.pipeline_index_pdf",
+            side_effect=fake_pipeline,
+        ):
+            index_pdf(
+                pdf_path, "reproducer", t3=fake_t3, force=True,
+                collection_name="knowledge__reproducer",
+                embed_fn=lambda t, m: ([[0.0]] * len(t), m),
+            )
+
+        assert captured.get("force") is True, (
+            f"index_pdf(force=True) must pass force=True through to "
+            f"pipeline_index_pdf. Got kwargs: {captured!r}"
+        )

--- a/tests/test_nexus_lub_collection_delete_cascade.py
+++ b/tests/test_nexus_lub_collection_delete_cascade.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-lub regression — `nx collection delete` must cascade-purge
+all taxonomy state tied to the deleted collection.
+
+Four tables carry per-collection rows:
+  * ``topics`` (keyed by ``collection``)
+  * ``topic_assignments`` (via topic_id FK, plus ``source_collection``)
+  * ``topic_links`` (via from/to topic_id FK)
+  * ``taxonomy_meta`` (keyed by ``collection``)
+
+Pre-fix behavior: `nx collection delete` removed the Chroma collection
+but left all four orphaned — `nx taxonomy status` continued to list the
+deleted collection with its pre-delete topic count; hub detection
+traversed orphan edges inflating ICF denominators.
+
+Post-fix contract: `CatalogTaxonomy.purge_collection(name)` removes
+every row tied to *name* transactionally, returns a count dict so the
+CLI can report what was cleaned.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def seeded_taxonomy(tmp_path: Path):
+    """Open a real T2Database on disk and seed two collections with
+    topics, assignments, and cross-collection links so the cascade
+    path is exercised, not mocked."""
+    from nexus.db.t2 import T2Database
+
+    db_path = tmp_path / "memory.db"
+    db = T2Database(db_path)
+    tax = db.taxonomy
+
+    # --- Seed collection A (to be deleted) ---
+    t_a1 = tax.conn.execute(
+        "INSERT INTO topics (label, collection, centroid_hash, doc_count, terms, created_at) "
+        "VALUES (?, ?, ?, ?, ?, '2026-04-16T00:00:00Z')",
+        ("A-Topic-1", "docs__doomed", "h1", 5, "[]"),
+    ).lastrowid
+    t_a2 = tax.conn.execute(
+        "INSERT INTO topics (label, collection, centroid_hash, doc_count, terms, created_at) "
+        "VALUES (?, ?, ?, ?, ?, '2026-04-16T00:00:00Z')",
+        ("A-Topic-2", "docs__doomed", "h2", 3, "[]"),
+    ).lastrowid
+
+    # --- Seed collection B (must survive) ---
+    t_b1 = tax.conn.execute(
+        "INSERT INTO topics (label, collection, centroid_hash, doc_count, terms, created_at) "
+        "VALUES (?, ?, ?, ?, ?, '2026-04-16T00:00:00Z')",
+        ("B-Topic-1", "docs__keepme", "h3", 8, "[]"),
+    ).lastrowid
+
+    # --- Assignments: mix source_collection and topic_id ownership ---
+    # Native A assignment (doc in A, topic in A)
+    tax.conn.execute(
+        "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by, source_collection) "
+        "VALUES (?, ?, ?, ?)",
+        ("doomed:doc1:0", t_a1, "hdbscan", "docs__doomed"),
+    )
+    # Projection of doomed chunks into B's topic
+    tax.conn.execute(
+        "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by, source_collection) "
+        "VALUES (?, ?, ?, ?)",
+        ("doomed:doc2:0", t_b1, "projection", "docs__doomed"),
+    )
+    # Projection of B chunks into A's topic (must also be purged — doomed
+    # topic_id → NULL FK residue left behind otherwise)
+    tax.conn.execute(
+        "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by, source_collection) "
+        "VALUES (?, ?, ?, ?)",
+        ("keepme:doc1:0", t_a2, "projection", "docs__keepme"),
+    )
+    # Native B assignment — must survive
+    tax.conn.execute(
+        "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by, source_collection) "
+        "VALUES (?, ?, ?, ?)",
+        ("keepme:doc2:0", t_b1, "hdbscan", "docs__keepme"),
+    )
+
+    # --- topic_links: A→B, B→A, A→A, B→B ---
+    tax.conn.execute(
+        "INSERT INTO topic_links (from_topic_id, to_topic_id, link_count, link_types) "
+        "VALUES (?, ?, ?, ?)",
+        (t_a1, t_b1, 2, "[]"),
+    )
+    tax.conn.execute(
+        "INSERT INTO topic_links (from_topic_id, to_topic_id, link_count, link_types) "
+        "VALUES (?, ?, ?, ?)",
+        (t_b1, t_a1, 1, "[]"),
+    )
+    tax.conn.execute(
+        "INSERT INTO topic_links (from_topic_id, to_topic_id, link_count, link_types) "
+        "VALUES (?, ?, ?, ?)",
+        (t_a1, t_a2, 3, "[]"),  # A→A, both doomed
+    )
+
+    # --- taxonomy_meta ---
+    tax.conn.execute(
+        "INSERT INTO taxonomy_meta (collection, last_discover_at) "
+        "VALUES (?, ?)",
+        ("docs__doomed", "2026-04-14T12:00:00Z"),
+    )
+    tax.conn.execute(
+        "INSERT INTO taxonomy_meta (collection, last_discover_at) "
+        "VALUES (?, ?)",
+        ("docs__keepme", "2026-04-14T12:00:00Z"),
+    )
+    tax.conn.commit()
+    yield db, tax
+    db.close()
+
+
+class TestPurgeCollection:
+    """Unit tests for the new purge_collection method."""
+
+    def test_purge_removes_topics_for_collection(self, seeded_taxonomy):
+        db, tax = seeded_taxonomy
+        counts = tax.purge_collection("docs__doomed")
+        assert counts["topics"] == 2
+
+        remaining = tax.conn.execute(
+            "SELECT COUNT(*) FROM topics WHERE collection = ?",
+            ("docs__doomed",),
+        ).fetchone()[0]
+        assert remaining == 0
+
+        # Survivor untouched
+        surv = tax.conn.execute(
+            "SELECT COUNT(*) FROM topics WHERE collection = ?",
+            ("docs__keepme",),
+        ).fetchone()[0]
+        assert surv == 1
+
+    def test_purge_removes_assignments_by_topic_and_source(self, seeded_taxonomy):
+        db, tax = seeded_taxonomy
+        counts = tax.purge_collection("docs__doomed")
+
+        # Seeded 4 assignments; 3 reference doomed (native + 2 projections).
+        # Only the native-B assignment (topic_id=B, source=B) should survive.
+        assert counts["assignments"] == 3
+        remaining_total = tax.conn.execute(
+            "SELECT COUNT(*) FROM topic_assignments"
+        ).fetchone()[0]
+        assert remaining_total == 1
+
+        # No assignment should reference a doomed source_collection
+        leftover = tax.conn.execute(
+            "SELECT COUNT(*) FROM topic_assignments WHERE source_collection = ?",
+            ("docs__doomed",),
+        ).fetchone()[0]
+        assert leftover == 0
+
+    def test_purge_removes_links_touching_doomed_topics(self, seeded_taxonomy):
+        db, tax = seeded_taxonomy
+        counts = tax.purge_collection("docs__doomed")
+
+        # 3 seeded links; all 3 touch a doomed topic (A→B, B→A, A→A).
+        assert counts["links"] == 3
+        remaining = tax.conn.execute("SELECT COUNT(*) FROM topic_links").fetchone()[0]
+        assert remaining == 0
+
+    def test_purge_removes_taxonomy_meta_row(self, seeded_taxonomy):
+        db, tax = seeded_taxonomy
+        counts = tax.purge_collection("docs__doomed")
+
+        assert counts["meta"] == 1
+        remaining = tax.conn.execute(
+            "SELECT COUNT(*) FROM taxonomy_meta WHERE collection = ?",
+            ("docs__doomed",),
+        ).fetchone()[0]
+        assert remaining == 0
+        # Survivor meta row untouched
+        surv = tax.conn.execute(
+            "SELECT COUNT(*) FROM taxonomy_meta WHERE collection = ?",
+            ("docs__keepme",),
+        ).fetchone()[0]
+        assert surv == 1
+
+    def test_purge_is_transactional(self, seeded_taxonomy):
+        """If any step fails mid-cascade, the whole purge rolls back.
+
+        sqlite3.Connection.execute is read-only at the C-API level so
+        we sabotage via a wrapper that masquerades as the real conn.
+        """
+        db, tax = seeded_taxonomy
+
+        class FlakyConn:
+            def __init__(self, real):
+                self._real = real
+            def execute(self, sql, params=()):
+                if "DELETE FROM taxonomy_meta" in sql:
+                    raise RuntimeError("sabotaged")
+                return self._real.execute(sql, params)
+            def commit(self):
+                return self._real.commit()
+            def rollback(self):
+                return self._real.rollback()
+
+        real_conn = tax.conn
+        try:
+            tax.conn = FlakyConn(real_conn)
+            with pytest.raises(RuntimeError, match="sabotaged"):
+                tax.purge_collection("docs__doomed")
+        finally:
+            tax.conn = real_conn
+
+        # After rollback: all seeded rows must still be present.
+        topics_remaining = tax.conn.execute(
+            "SELECT COUNT(*) FROM topics WHERE collection = ?",
+            ("docs__doomed",),
+        ).fetchone()[0]
+        assert topics_remaining == 2, (
+            "purge_collection must be transactional; "
+            "a mid-cascade failure must roll back every prior delete"
+        )
+
+    def test_purge_unknown_collection_returns_zero_counts(self, seeded_taxonomy):
+        """Purging a collection with no rows is a silent no-op."""
+        db, tax = seeded_taxonomy
+        counts = tax.purge_collection("docs__never-existed")
+        assert counts == {"topics": 0, "assignments": 0, "links": 0, "meta": 0}
+
+
+class TestCollectionDeleteCommandCascades:
+    """Integration: `nx collection delete` cascades via Click entry point."""
+
+    def test_cli_delete_calls_purge_collection(self, tmp_path, monkeypatch):
+        """The CLI path must invoke purge_collection after the Chroma
+        delete — not skip it, not run before (order matters for the
+        count report)."""
+        from click.testing import CliRunner
+        from unittest.mock import MagicMock, patch
+
+        from nexus.db.t2 import T2Database
+        from nexus.commands.collection import delete_cmd
+
+        db_path = tmp_path / "memory.db"
+        db = T2Database(db_path)
+        # Seed one topic for the doomed collection so purge has work
+        db.taxonomy.conn.execute(
+            "INSERT INTO topics (label, collection, centroid_hash, "
+            "doc_count, terms, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            ("Only", "docs__doomed", "h", 1, "[]", "2026-04-16T00:00:00Z"),
+        )
+        db.taxonomy.conn.execute(
+            "INSERT INTO taxonomy_meta (collection, last_discover_at) "
+            "VALUES (?, ?)",
+            ("docs__doomed", "2026-04-14T00:00:00Z"),
+        )
+        db.taxonomy.conn.commit()
+        db.close()
+
+        fake_t3 = MagicMock()
+        fake_t3.delete_collection = MagicMock()
+
+        runner = CliRunner()
+        with patch("nexus.commands.collection._t3", return_value=fake_t3), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
+             patch(
+                 "nexus.commands._helpers.default_db_path",
+                 return_value=db_path,
+             ):
+            result = runner.invoke(delete_cmd, ["docs__doomed", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        assert fake_t3.delete_collection.called
+        # Must mention the taxonomy cascade in the report
+        assert "taxonomy" in result.output.lower() or "topic" in result.output.lower(), (
+            f"Delete report missing taxonomy cleanup count. Output: {result.output!r}"
+        )
+
+        # Cascade actually happened
+        with T2Database(db_path) as verify_db:
+            topics = verify_db.taxonomy.conn.execute(
+                "SELECT COUNT(*) FROM topics WHERE collection = ?",
+                ("docs__doomed",),
+            ).fetchone()[0]
+            meta = verify_db.taxonomy.conn.execute(
+                "SELECT COUNT(*) FROM taxonomy_meta WHERE collection = ?",
+                ("docs__doomed",),
+            ).fetchone()[0]
+        assert topics == 0
+        assert meta == 0

--- a/tests/test_rdr_082_doc_tokens.py
+++ b/tests/test_rdr_082_doc_tokens.py
@@ -219,8 +219,10 @@ class TestRenderer:
         reg = ResolverRegistry({"bd": fake_bd, "rdr": fake_rdr})
 
         md = "Status: {{bd:x.status}} and RDR: {{rdr:072.title}}"
-        out = render_text(md, reg)
+        out, resolved, misses = render_text(md, reg)
         assert out == "Status: bd-x-status and RDR: rdr-072-title"
+        assert resolved == 2
+        assert misses == []
 
     def test_unresolved_namespace_raises(self) -> None:
         from nexus.doc.render import render_text, RenderError
@@ -247,12 +249,15 @@ class TestRenderer:
         from nexus.doc.resolvers import ResolverRegistry
 
         reg = ResolverRegistry({})
-        out = render_text(
+        out, resolved, misses = render_text(
             "{{bd:x.status}} and plain text",
             reg,
             allow_unresolved=True,
         )
         assert "{{bd:x.status}}" in out
+        assert resolved == 0
+        assert len(misses) == 1
+        assert "no resolver for namespace 'bd'" in misses[0][1]
 
     def test_tokens_inside_fenced_code_untouched(self) -> None:
         from nexus.doc.render import render_text
@@ -267,10 +272,11 @@ class TestRenderer:
             "```\n"
             "Real: {{bd:y.status}}\n"
         )
-        out = render_text(md, reg)
+        out, resolved, _ = render_text(md, reg)
         # Fenced instance preserved verbatim; non-fenced substituted
         assert "```\nSample: {{bd:x.status}}\n```\n" in out
         assert "Real: RESOLVED" in out
+        assert resolved == 1
 
 
 # ── Extension point — RDR-083 forward-compat ─────────────────────────────────
@@ -279,6 +285,57 @@ class TestRenderer:
 class TestResolverRegistryExtensibility:
     """RDR-083's AnchorResolver must plug in without touching parser,
     engine, or CLI. This test protects that invariant."""
+
+    def test_mirror_tree_preserves_relative_path_under_out_dir(
+        self, tmp_path: Path,
+    ) -> None:
+        """Gate fix (082 Sig #2): --out-dir must mirror the source tree,
+        not flatten every rendered file to the same directory."""
+        from nexus.doc.render import render_file
+        from nexus.doc.resolvers import ResolverRegistry
+
+        # Build: <tmp>/src/docs/rdr/doc.md
+        root = tmp_path / "src"
+        nested = root / "docs" / "rdr"
+        nested.mkdir(parents=True)
+        source = nested / "doc.md"
+        source.write_text("no tokens here\n")
+
+        out_dir = tmp_path / "out"
+        render_file(
+            source, ResolverRegistry({}), out_dir=out_dir,
+            emit=True, source_root=root,
+        )
+        expected = out_dir / "docs" / "rdr" / "doc.rendered.md"
+        assert expected.exists(), (
+            f"mirror-tree destination not found: {expected}. "
+            f"Directory contents: {list(out_dir.rglob('*'))}"
+        )
+
+    def test_resolved_count_excludes_failed_resolutions(self) -> None:
+        """Gate fix (082 Sig #1): render_file's resolved count must NOT
+        include tokens that raised ResolutionError. Previously it counted
+        every registered-namespace token as resolved regardless of outcome."""
+        from nexus.doc.render import render_text
+        from nexus.doc.resolvers import ResolutionError, ResolverRegistry
+
+        fake = MagicMock()
+
+        def _resolve(key, field, filters):
+            if key == "bad":
+                raise ResolutionError("boom")
+            return "OK"
+
+        fake.resolve = _resolve
+        reg = ResolverRegistry({"bd": fake})
+
+        md = "{{bd:good.x}} and {{bd:bad.x}} and {{bd:good.y}}"
+        out, resolved, misses = render_text(md, reg, allow_unresolved=True)
+        assert resolved == 2, (
+            f"Expected 2 resolved, got {resolved}. Misses: {misses}"
+        )
+        assert len(misses) == 1
+        assert "boom" in misses[0][1]
 
     def test_third_party_namespace_registers_and_resolves(self) -> None:
         from nexus.doc.render import render_text
@@ -291,5 +348,5 @@ class TestResolverRegistryExtensibility:
 
         reg = ResolverRegistry({})
         reg.register("nx-anchor", FakeAnchor())
-        out = render_text("Anchors: {{nx-anchor:docs__x|top=5}}", reg)
+        out, _, _ = render_text("Anchors: {{nx-anchor:docs__x|top=5}}", reg)
         assert "top-5 topics for docs__x" in out

--- a/tests/test_rdr_082_doc_tokens.py
+++ b/tests/test_rdr_082_doc_tokens.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for RDR-082 Doc-Build Token Resolution.
+
+Four things under test:
+
+  1. Token grammar (``{{NAMESPACE:KEY[.FIELD][|FILTER=VALUE]*}}``) —
+     positive grammar, malformed rejection, fenced-code-block skip.
+  2. Bead / RDR resolvers — correct field routing, unknown-key → raise.
+  3. Render engine — parse → resolve → substitute; unresolved tokens
+     fail loud unless ``--allow-unresolved`` is set.
+  4. Resolver registry — third parties can register additional
+     namespaces without modifying the parser / engine / CLI. This is
+     the extension point RDR-083 will consume for ``nx-anchor`` etc.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── Token grammar ────────────────────────────────────────────────────────────
+
+
+class TestTokenParse:
+
+    def test_bare_namespace_and_key(self) -> None:
+        from nexus.doc.tokens import parse_tokens
+
+        toks = parse_tokens("status: {{bd:nexus-123}}")
+        assert len(toks) == 1
+        t = toks[0]
+        assert t.namespace == "bd"
+        assert t.key == "nexus-123"
+        assert t.field is None
+        assert t.filters == {}
+
+    def test_dotted_field(self) -> None:
+        from nexus.doc.tokens import parse_tokens
+
+        toks = parse_tokens("RDR-072 {{rdr:072.status}}")
+        assert len(toks) == 1
+        assert toks[0].namespace == "rdr"
+        assert toks[0].key == "072"
+        assert toks[0].field == "status"
+
+    def test_filter_key_value(self) -> None:
+        from nexus.doc.tokens import parse_tokens
+
+        toks = parse_tokens("{{rdr:072.title|raw=true}}")
+        assert toks[0].filters == {"raw": "true"}
+
+    def test_multiple_filters(self) -> None:
+        from nexus.doc.tokens import parse_tokens
+
+        toks = parse_tokens("{{nx-anchor:collection|top=5|sort=desc}}")
+        assert toks[0].filters == {"top": "5", "sort": "desc"}
+
+    def test_multiple_tokens_in_one_line(self) -> None:
+        from nexus.doc.tokens import parse_tokens
+
+        toks = parse_tokens("{{bd:a.status}} and {{rdr:072.title}}")
+        assert len(toks) == 2
+        assert toks[0].namespace == "bd" and toks[1].namespace == "rdr"
+
+    def test_malformed_empty_namespace_rejected(self) -> None:
+        """Malformed tokens must not accidentally match — a caller edit
+        like ``{{:foo}}`` should parse to zero tokens, not a broken one."""
+        from nexus.doc.tokens import parse_tokens
+
+        toks = parse_tokens("oops {{:foo}} oops")
+        assert toks == []
+
+    def test_malformed_no_colon_rejected(self) -> None:
+        from nexus.doc.tokens import parse_tokens
+
+        toks = parse_tokens("{{no-colon-here}}")
+        assert toks == []
+
+    def test_token_inside_fenced_code_skipped(self) -> None:
+        """Tutorial snippets showing the token syntax must not be
+        resolved. A fenced code block is an intentional no-op zone."""
+        from nexus.doc.tokens import parse_tokens
+
+        md = (
+            "Docs:\n"
+            "```\n"
+            "Write {{bd:nexus-123}} in your markdown.\n"
+            "```\n"
+            "Real token: {{rdr:082.status}}\n"
+        )
+        toks = parse_tokens(md)
+        assert len(toks) == 1
+        assert toks[0].namespace == "rdr" and toks[0].key == "082"
+
+    def test_token_inside_tilde_fenced_code_skipped(self) -> None:
+        from nexus.doc.tokens import parse_tokens
+
+        md = (
+            "~~~\n"
+            "{{bd:x.status}}\n"
+            "~~~\n"
+            "{{bd:real.status}}\n"
+        )
+        toks = parse_tokens(md)
+        assert len(toks) == 1 and toks[0].key == "real"
+
+    def test_span_reports_line_and_col(self) -> None:
+        from nexus.doc.tokens import parse_tokens
+
+        md = "line1\nnothing here\nprefix {{bd:a.status}} suffix\n"
+        toks = parse_tokens(md)
+        assert len(toks) == 1
+        assert toks[0].lineno == 3
+        assert toks[0].col == md.splitlines()[2].index("{{") + 1
+
+
+# ── Resolvers ────────────────────────────────────────────────────────────────
+
+
+class TestBeadResolver:
+
+    def test_status_field_routes_to_bd_show_json(self) -> None:
+        from nexus.doc.resolvers import BeadResolver
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=json.dumps({
+                    "id": "nexus-123",
+                    "title": "T",
+                    "status": "closed",
+                    "assignee": "hal",
+                }),
+            )
+            r = BeadResolver()
+            value = r.resolve("nexus-123", field="status", filters={})
+        assert value == "closed"
+
+    def test_default_field_returns_title(self) -> None:
+        from nexus.doc.resolvers import BeadResolver
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=json.dumps({"id": "x", "title": "Ship feature", "status": "open"}),
+            )
+            r = BeadResolver()
+            # Default when caller omits .field → title
+            value = r.resolve("x", field=None, filters={})
+        assert value == "Ship feature"
+
+    def test_unknown_bead_raises(self) -> None:
+        from nexus.doc.resolvers import BeadResolver, ResolutionError
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="not found")
+            r = BeadResolver()
+            with pytest.raises(ResolutionError):
+                r.resolve("does-not-exist", field=None, filters={})
+
+    def test_per_render_cache_avoids_double_subprocess(self) -> None:
+        from nexus.doc.resolvers import BeadResolver
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=json.dumps({"id": "x", "title": "T", "status": "open"}),
+            )
+            r = BeadResolver()
+            r.resolve("x", field="title", filters={})
+            r.resolve("x", field="status", filters={})
+        # Two field reads of the same bead → one subprocess call.
+        assert mock_run.call_count == 1
+
+
+class TestRdrResolver:
+
+    def test_reads_frontmatter_status(self, tmp_path: Path) -> None:
+        from nexus.doc.resolvers import RdrResolver
+
+        rdr_dir = tmp_path / "docs" / "rdr"
+        rdr_dir.mkdir(parents=True)
+        (rdr_dir / "rdr-072-foo.md").write_text(
+            "---\n"
+            "title: \"RDR-072: Foo\"\n"
+            "status: accepted\n"
+            "type: feature\n"
+            "---\n\n# RDR-072: Foo\n"
+        )
+        r = RdrResolver(rdr_dir=rdr_dir)
+        assert r.resolve("072", field="status", filters={}) == "accepted"
+        assert r.resolve("072", field="title", filters={}) == "RDR-072: Foo"
+
+    def test_unknown_rdr_raises(self, tmp_path: Path) -> None:
+        from nexus.doc.resolvers import RdrResolver, ResolutionError
+
+        (tmp_path / "docs" / "rdr").mkdir(parents=True)
+        r = RdrResolver(rdr_dir=tmp_path / "docs" / "rdr")
+        with pytest.raises(ResolutionError):
+            r.resolve("999", field=None, filters={})
+
+
+# ── Render engine ────────────────────────────────────────────────────────────
+
+
+class TestRenderer:
+
+    def test_substitutes_tokens(self) -> None:
+        from nexus.doc.render import render_text
+        from nexus.doc.resolvers import ResolverRegistry
+
+        fake_bd = MagicMock()
+        fake_bd.resolve = lambda key, field, filters: f"bd-{key}-{field or 'default'}"
+        fake_rdr = MagicMock()
+        fake_rdr.resolve = lambda key, field, filters: f"rdr-{key}-{field or 'default'}"
+        reg = ResolverRegistry({"bd": fake_bd, "rdr": fake_rdr})
+
+        md = "Status: {{bd:x.status}} and RDR: {{rdr:072.title}}"
+        out = render_text(md, reg)
+        assert out == "Status: bd-x-status and RDR: rdr-072-title"
+
+    def test_unresolved_namespace_raises(self) -> None:
+        from nexus.doc.render import render_text, RenderError
+        from nexus.doc.resolvers import ResolverRegistry
+
+        reg = ResolverRegistry({})  # empty — no resolver for any namespace
+        with pytest.raises(RenderError):
+            render_text("{{bd:nexus-1.status}}", reg)
+
+    def test_resolver_error_becomes_render_error(self) -> None:
+        from nexus.doc.render import render_text, RenderError
+        from nexus.doc.resolvers import ResolutionError, ResolverRegistry
+
+        fake = MagicMock()
+        fake.resolve = MagicMock(side_effect=ResolutionError("unknown bead"))
+        reg = ResolverRegistry({"bd": fake})
+        with pytest.raises(RenderError):
+            render_text("{{bd:x.status}}", reg)
+
+    def test_allow_unresolved_keeps_literal(self) -> None:
+        """``--allow-unresolved`` (best-effort) preserves the token text
+        in the output instead of raising."""
+        from nexus.doc.render import render_text
+        from nexus.doc.resolvers import ResolverRegistry
+
+        reg = ResolverRegistry({})
+        out = render_text(
+            "{{bd:x.status}} and plain text",
+            reg,
+            allow_unresolved=True,
+        )
+        assert "{{bd:x.status}}" in out
+
+    def test_tokens_inside_fenced_code_untouched(self) -> None:
+        from nexus.doc.render import render_text
+        from nexus.doc.resolvers import ResolverRegistry
+
+        fake = MagicMock()
+        fake.resolve = lambda key, field, filters: "RESOLVED"
+        reg = ResolverRegistry({"bd": fake})
+        md = (
+            "```\n"
+            "Sample: {{bd:x.status}}\n"
+            "```\n"
+            "Real: {{bd:y.status}}\n"
+        )
+        out = render_text(md, reg)
+        # Fenced instance preserved verbatim; non-fenced substituted
+        assert "```\nSample: {{bd:x.status}}\n```\n" in out
+        assert "Real: RESOLVED" in out
+
+
+# ── Extension point — RDR-083 forward-compat ─────────────────────────────────
+
+
+class TestResolverRegistryExtensibility:
+    """RDR-083's AnchorResolver must plug in without touching parser,
+    engine, or CLI. This test protects that invariant."""
+
+    def test_third_party_namespace_registers_and_resolves(self) -> None:
+        from nexus.doc.render import render_text
+        from nexus.doc.resolvers import ResolverRegistry
+
+        class FakeAnchor:
+            def resolve(self, key, field, filters):
+                top = filters.get("top", "3")
+                return f"top-{top} topics for {key}"
+
+        reg = ResolverRegistry({})
+        reg.register("nx-anchor", FakeAnchor())
+        out = render_text("Anchors: {{nx-anchor:docs__x|top=5}}", reg)
+        assert "top-5 topics for docs__x" in out

--- a/tests/test_rdr_083_corpus_evidence.py
+++ b/tests/test_rdr_083_corpus_evidence.py
@@ -80,6 +80,41 @@ class TestCitationScanner:
         cites = scan_citations(md)
         assert [c for c in cites if c.kind == "chash"] == []
 
+    @pytest.mark.parametrize("token", [
+        "[Error 2013]",
+        "[RFC 2119]",
+        "[Note 2024]",
+        "[Figure 2020]",
+        "[Table 2023]",
+        "[Closes 2025]",
+        "[Fixes 2024]",
+        "[Issue 2022]",
+        "[Draft 2025]",
+        "[Release 2024]",
+        "[Section 2020]",
+        "[Warning 2023]",
+    ])
+    def test_prose_stoplist_suppresses_false_positives(self, token: str) -> None:
+        """Dev-prose false-positives must not inflate the prose count."""
+        from nexus.doc.citations import scan_citations
+
+        cites = scan_citations(f"See {token} for the derivation.")
+        assert [c for c in cites if c.kind == "prose"] == [], (
+            f"{token} should have been suppressed by the stop-list"
+        )
+
+    def test_real_author_citations_still_detected_after_stoplist(self) -> None:
+        """Stop-list must not regress the positive case."""
+        from nexus.doc.citations import scan_citations
+
+        md = (
+            "Per [Grossberg 2013] and [Ashby 1956], the loop is stable. "
+            "Not [Note 2024] though."
+        )
+        prose = [c for c in scan_citations(md) if c.kind == "prose"]
+        displays = sorted(c.display for c in prose)
+        assert displays == ["Ashby 1956", "Grossberg 2013"]
+
 
 # ── AnchorResolver — RDR-082 extension point ─────────────────────────────────
 

--- a/tests/test_rdr_083_corpus_evidence.py
+++ b/tests/test_rdr_083_corpus_evidence.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for RDR-083 Corpus-Evidence Tokens.
+
+Four surfaces under test:
+
+  1. ``chash:`` span scanner — detects ``[text](chash:<hash>)`` markdown
+     links and prose citations. Respects fenced code blocks.
+  2. ``AnchorResolver`` — ``{{nx-anchor:<collection>[|top=N]}}`` reads
+     top-N topics for a collection from ``topic_assignments``. Registers
+     into RDR-082's ResolverRegistry — this test protects the
+     extension-point invariant end-to-end.
+  3. ``check-grounding`` logic — coverage ratio (chash / total).
+  4. ``check-extensions`` logic — threshold query against projection
+     data.
+
+v1 scope intentionally does NOT verify that each ``chash:`` hash
+resolves to an indexed chunk — that requires cross-collection T3
+lookups and is deferred to a follow-up.  We verify shape + counting
+only; what ships is actionable metrics, not dead-letter validation.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ── chash: span scanner ──────────────────────────────────────────────────────
+
+
+class TestCitationScanner:
+
+    def test_detects_chash_markdown_link(self) -> None:
+        from nexus.doc.citations import scan_citations
+
+        md = "Per [boundary feedback](chash:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef), the model..."
+        cites = scan_citations(md)
+        chashes = [c for c in cites if c.kind == "chash"]
+        assert len(chashes) == 1
+        assert chashes[0].chash == "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        assert "boundary feedback" in chashes[0].display
+
+    def test_detects_prose_author_year_citation(self) -> None:
+        from nexus.doc.citations import scan_citations
+
+        md = "As shown by [Grossberg 2013], attention gates the feedback loop."
+        cites = scan_citations(md)
+        prose = [c for c in cites if c.kind == "prose"]
+        assert len(prose) == 1
+        assert "Grossberg" in prose[0].display
+
+    def test_detects_bracketed_number_citation(self) -> None:
+        from nexus.doc.citations import scan_citations
+
+        md = "See [12] for the derivation."
+        cites = scan_citations(md)
+        brackets = [c for c in cites if c.kind == "bracket"]
+        assert len(brackets) == 1
+
+    def test_ignores_citation_inside_fenced_code(self) -> None:
+        from nexus.doc.citations import scan_citations
+
+        md = (
+            "Real: [Grossberg 2013]\n"
+            "```\n"
+            "Example only: [Fake 2020]\n"
+            "[12] bracketed in fence\n"
+            "```\n"
+        )
+        cites = scan_citations(md)
+        # Only the real prose citation survives
+        assert len(cites) == 1
+        assert "Grossberg" in cites[0].display
+
+    def test_invalid_chash_length_skipped(self) -> None:
+        """A chash URL with a too-short hash is not counted."""
+        from nexus.doc.citations import scan_citations
+
+        md = "See [ref](chash:tooshort) in the appendix."
+        cites = scan_citations(md)
+        assert [c for c in cites if c.kind == "chash"] == []
+
+
+# ── AnchorResolver — RDR-082 extension point ─────────────────────────────────
+
+
+class TestAnchorResolver:
+
+    def test_top_n_topics_rendered_as_list(self) -> None:
+        from nexus.doc.resolvers_corpus import AnchorResolver
+
+        fake_tax = MagicMock()
+        fake_tax.top_topics_for_collection = MagicMock(return_value=[
+            {"label": "Pattern Matching", "chunks": 120},
+            {"label": "Vector Search", "chunks": 80},
+            {"label": "Catalog Registry", "chunks": 60},
+        ])
+
+        r = AnchorResolver(taxonomy=fake_tax)
+        out = r.resolve("docs__art", field=None, filters={"top": "3"})
+        assert "Pattern Matching" in out
+        assert "Vector Search" in out
+        assert "Catalog Registry" in out
+        fake_tax.top_topics_for_collection.assert_called_once_with(
+            "docs__art", top_n=3,
+        )
+
+    def test_default_top_is_5_when_filter_omitted(self) -> None:
+        from nexus.doc.resolvers_corpus import AnchorResolver
+
+        fake_tax = MagicMock()
+        fake_tax.top_topics_for_collection = MagicMock(return_value=[
+            {"label": "x", "chunks": 1},
+        ])
+        r = AnchorResolver(taxonomy=fake_tax)
+        r.resolve("docs__x", field=None, filters={})
+        fake_tax.top_topics_for_collection.assert_called_once_with(
+            "docs__x", top_n=5,
+        )
+
+    def test_empty_projection_raises(self) -> None:
+        """A collection with no projection data must not silently
+        render an empty list — that's not evidence, it's absence."""
+        from nexus.doc.resolvers import ResolutionError
+        from nexus.doc.resolvers_corpus import AnchorResolver
+
+        fake_tax = MagicMock()
+        fake_tax.top_topics_for_collection = MagicMock(return_value=[])
+        r = AnchorResolver(taxonomy=fake_tax)
+        with pytest.raises(ResolutionError):
+            r.resolve("docs__no-projection", field=None, filters={"top": "5"})
+
+    def test_registers_into_082_registry_end_to_end(self) -> None:
+        """The AnchorResolver plugs into RDR-082's ResolverRegistry with
+        no changes to parser/engine/CLI — this is the invariant."""
+        from nexus.doc.render import render_text
+        from nexus.doc.resolvers import ResolverRegistry
+        from nexus.doc.resolvers_corpus import AnchorResolver
+
+        fake_tax = MagicMock()
+        fake_tax.top_topics_for_collection = MagicMock(return_value=[
+            {"label": "Boundary Feedback", "chunks": 50},
+            {"label": "Top-Down Expectation", "chunks": 42},
+        ])
+        reg = ResolverRegistry({})
+        reg.register("nx-anchor", AnchorResolver(taxonomy=fake_tax))
+
+        md = "Corpus shape: {{nx-anchor:docs__art|top=2}}"
+        out = render_text(md, reg)
+        assert "Boundary Feedback" in out and "Top-Down Expectation" in out
+
+
+# ── check-grounding logic ────────────────────────────────────────────────────
+
+
+class TestGroundingReport:
+
+    def test_coverage_ratio_all_chash(self) -> None:
+        from nexus.doc.citations import grounding_report, scan_citations
+
+        h = "a" * 64
+        md = f"[x](chash:{h}) and [y](chash:{h})"
+        report = grounding_report(scan_citations(md))
+        assert report.chash_count == 2
+        assert report.total == 2
+        assert report.coverage == 1.0
+
+    def test_coverage_ratio_mixed(self) -> None:
+        from nexus.doc.citations import grounding_report, scan_citations
+
+        h = "f" * 64
+        md = (
+            f"[x](chash:{h}) — three prose: [Grossberg 2013], [Ashby 1956], [12]."
+        )
+        report = grounding_report(scan_citations(md))
+        assert report.chash_count == 1
+        assert report.total == 4
+        assert abs(report.coverage - 0.25) < 1e-9
+
+    def test_coverage_zero_when_no_citations(self) -> None:
+        from nexus.doc.citations import grounding_report
+
+        report = grounding_report([])
+        assert report.total == 0
+        assert report.coverage == 0.0
+        assert report.chash_count == 0
+
+
+# ── check-extensions logic ───────────────────────────────────────────────────
+
+
+class TestExtensionsCheck:
+    """check-extensions uses projection data to flag claims that
+    don't project into a designated primary-source collection.  v1:
+    doc-level check (is this doc's source title grounded in the
+    primary-source collection above threshold?)."""
+
+    def test_doc_above_threshold_not_flagged(self) -> None:
+        from nexus.doc.citations import extensions_report
+
+        fake_tax = MagicMock()
+        fake_tax.chunk_grounded_in = MagicMock(return_value=0.85)
+
+        report = extensions_report(
+            doc_ids=["doc-1"],
+            primary_source="docs__primary",
+            threshold=0.70,
+            taxonomy=fake_tax,
+        )
+        assert report.candidates == []
+        assert report.checked == 1
+
+    def test_doc_below_threshold_flagged(self) -> None:
+        from nexus.doc.citations import extensions_report
+
+        fake_tax = MagicMock()
+        fake_tax.chunk_grounded_in = MagicMock(return_value=0.55)
+
+        report = extensions_report(
+            doc_ids=["doc-1"],
+            primary_source="docs__primary",
+            threshold=0.70,
+            taxonomy=fake_tax,
+        )
+        assert report.candidates == [("doc-1", 0.55)]
+
+    def test_doc_with_no_projection_reported_insufficient_data(self) -> None:
+        from nexus.doc.citations import extensions_report
+
+        fake_tax = MagicMock()
+        fake_tax.chunk_grounded_in = MagicMock(return_value=None)
+
+        report = extensions_report(
+            doc_ids=["doc-1"],
+            primary_source="docs__primary",
+            threshold=0.70,
+            taxonomy=fake_tax,
+        )
+        assert report.candidates == []
+        assert report.no_data == ["doc-1"]

--- a/tests/test_rdr_083_corpus_evidence.py
+++ b/tests/test_rdr_083_corpus_evidence.py
@@ -181,8 +181,9 @@ class TestAnchorResolver:
         reg.register("nx-anchor", AnchorResolver(taxonomy=fake_tax))
 
         md = "Corpus shape: {{nx-anchor:docs__art|top=2}}"
-        out = render_text(md, reg)
+        out, resolved, _ = render_text(md, reg)
         assert "Boundary Feedback" in out and "Top-Down Expectation" in out
+        assert resolved == 1
 
 
 # ── check-grounding logic ────────────────────────────────────────────────────

--- a/tests/test_rdr_084_plan_grow.py
+++ b/tests/test_rdr_084_plan_grow.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for RDR-084 Plan Library Growth.
+
+Auto-save successful ad-hoc plans on the ``nx_answer`` plan-miss →
+planner → ``plan_run`` success path so the plan library compounds
+with usage instead of plateauing at the 14 seed templates.
+
+Contracts being pinned:
+
+  * On ad-hoc success: ``db.plans.save_plan`` is called with
+    ``scope="personal"``, ``tags="ad-hoc,grown"``, ``outcome="success"``,
+    ``ttl=<config ad_hoc_ttl>``, and project=cwd basename.
+  * On matched-plan success (plan_id != 0): save is NOT called — the
+    library already has this plan.
+  * On plan_run error: save is NOT called — failed plans don't compound.
+  * On save exception: the user still gets their answer — best-effort.
+  * On successful save: the T1 cosine cache receives an ``upsert(row)``
+    so the next paraphrase can match via cosine without a SessionStart.
+  * Config key ``plans.ad_hoc_ttl`` overrides the 30-day default.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nexus.plans.match import Match
+
+
+def _ad_hoc_match(plan_json: str | None = None) -> Match:
+    if plan_json is None:
+        plan_json = json.dumps({
+            "steps": [
+                {"tool": "search", "args": {"query": "$intent", "corpus": "knowledge"}},
+                {"tool": "summarize", "args": {"content": "$step1.ids"}},
+            ],
+        })
+    return Match(
+        plan_id=0,
+        name="ad-hoc",
+        description="what is the meaning of life",
+        confidence=None,
+        dimensions={},
+        tags="ad-hoc",
+        plan_json=plan_json,
+        required_bindings=["intent"],
+        optional_bindings=[],
+        default_bindings={"intent": "what is the meaning of life"},
+        parent_dims=None,
+    )
+
+
+def _matched_plan(plan_id: int = 5) -> Match:
+    return Match(
+        plan_id=plan_id,
+        name="test-plan",
+        description="test",
+        confidence=0.55,
+        dimensions={},
+        tags="",
+        plan_json=json.dumps({
+            "steps": [
+                {"tool": "search", "args": {"query": "$intent"}},
+                {"tool": "summarize", "args": {"content": "$step1.ids"}},
+            ],
+        }),
+        required_bindings=["intent"],
+        optional_bindings=[],
+        default_bindings={"intent": "q"},
+        parent_dims=None,
+    )
+
+
+def _plan_run_success():
+    """Return a MagicMock that behaves like a successful plan_run result."""
+    result = MagicMock()
+    result.steps = [{"text": "the answer is 42"}]
+    return result
+
+
+# ── Save-on-ad-hoc-success ────────────────────────────────────────────────────
+
+
+class TestAdHocSaveOnSuccess:
+    """RDR-084 core contract: successful ad-hoc plans are saved."""
+
+    @pytest.mark.asyncio
+    async def test_save_called_with_correct_kwargs(self):
+        from nexus.mcp.core import nx_answer
+
+        match = _ad_hoc_match()
+        save_mock = MagicMock(return_value=999)
+
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = save_mock
+        db_stub.plans.get_plan = MagicMock(return_value={"id": 999, "query": "q"})
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[]), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(return_value=match)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=_plan_run_success())), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(question="what is the meaning of life")
+
+        assert save_mock.called, "save_plan must be called on ad-hoc success"
+        kwargs = save_mock.call_args.kwargs
+        assert kwargs["query"] == "what is the meaning of life"
+        assert kwargs["scope"] == "personal"
+        assert kwargs["outcome"] == "success"
+        assert "ad-hoc" in kwargs["tags"]
+        assert "grown" in kwargs["tags"]
+        # ttl is the configured default (30) absent an override
+        assert kwargs["ttl"] == 30
+        # plan_json is the normalized DAG
+        assert json.loads(kwargs["plan_json"]).get("steps"), (
+            "plan_json must round-trip as a non-empty steps DAG"
+        )
+
+    @pytest.mark.asyncio
+    async def test_matched_plan_does_not_trigger_save(self):
+        """plan_id != 0 means the library already has this plan — no save."""
+        from nexus.mcp.core import nx_answer
+
+        match = _matched_plan(plan_id=7)
+        save_mock = MagicMock()
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = save_mock
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[match]), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=_plan_run_success())), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(question="some question")
+
+        assert not save_mock.called, (
+            "save_plan must NOT be called when a library plan matched"
+        )
+
+    @pytest.mark.asyncio
+    async def test_plan_run_error_skips_save(self):
+        """If plan_run raises, the ad-hoc plan is NOT saved."""
+        from nexus.mcp.core import nx_answer
+
+        match = _ad_hoc_match()
+        save_mock = MagicMock()
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = save_mock
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[]), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(return_value=match)), \
+             patch(
+                "nexus.plans.runner.plan_run",
+                AsyncMock(side_effect=RuntimeError("boom")),
+             ), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            result = await nx_answer(question="bad")
+
+        assert not save_mock.called, (
+            "Failures must not compound into the library"
+        )
+        assert "error" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_save_exception_does_not_affect_answer(self):
+        """save_plan raising must not prevent the user getting their answer."""
+        from nexus.mcp.core import nx_answer
+
+        match = _ad_hoc_match()
+        save_mock = MagicMock(side_effect=RuntimeError("disk full"))
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = save_mock
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[]), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(return_value=match)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=_plan_run_success())), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            result = await nx_answer(question="q")
+
+        # The answer text still got through — save failure is best-effort.
+        assert "42" in result
+
+
+# ── T1 cache propagation ──────────────────────────────────────────────────────
+
+
+class TestT1CachePropagation:
+    """RDR-084: a saved plan must upsert into the T1 cosine cache so the
+    next paraphrase can match without waiting for SessionStart re-populate."""
+
+    @pytest.mark.asyncio
+    async def test_cache_upsert_called_on_save(self):
+        from nexus.mcp.core import nx_answer
+
+        match = _ad_hoc_match()
+        stored_row = {"id": 123, "query": "q", "plan_json": match.plan_json}
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = MagicMock(return_value=123)
+        db_stub.plans.get_plan = MagicMock(return_value=stored_row)
+
+        cache_stub = MagicMock()
+        cache_stub.upsert = MagicMock(return_value=True)
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[]), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(return_value=match)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=_plan_run_success())), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=cache_stub):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(question="q")
+
+        assert cache_stub.upsert.called, (
+            "T1 cache must receive the new plan so future paraphrases hit"
+        )
+        passed_row = cache_stub.upsert.call_args.args[0]
+        assert passed_row.get("id") == 123
+
+    @pytest.mark.asyncio
+    async def test_cache_upsert_failure_does_not_fail_save(self):
+        """Cache upsert is best-effort; the plan is still in T2."""
+        from nexus.mcp.core import nx_answer
+
+        match = _ad_hoc_match()
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = MagicMock(return_value=456)
+        db_stub.plans.get_plan = MagicMock(return_value={"id": 456, "query": "q"})
+
+        cache_stub = MagicMock()
+        cache_stub.upsert = MagicMock(side_effect=RuntimeError("t1 down"))
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[]), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(return_value=match)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=_plan_run_success())), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=cache_stub):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            result = await nx_answer(question="q")
+
+        # Save succeeded; upsert failed; user still got an answer.
+        assert db_stub.plans.save_plan.called
+        assert "42" in result
+
+    @pytest.mark.asyncio
+    async def test_cache_unavailable_no_upsert_attempt(self):
+        """When get_t1_plan_cache returns None, save proceeds without upsert."""
+        from nexus.mcp.core import nx_answer
+
+        match = _ad_hoc_match()
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = MagicMock(return_value=789)
+        db_stub.plans.get_plan = MagicMock(return_value={"id": 789})
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[]), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(return_value=match)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=_plan_run_success())), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(question="q")
+
+        # save_plan still called; get_plan unused (no cache to feed).
+        assert db_stub.plans.save_plan.called
+
+
+# ── Config: plans.ad_hoc_ttl ──────────────────────────────────────────────────
+
+
+class TestAdHocTtlConfig:
+    """RDR-084: TTL defaults to 30 days; ``.nexus.yml#plans.ad_hoc_ttl``
+    overrides it."""
+
+    def test_default_ttl_is_30(self):
+        from nexus.mcp.core import _load_ad_hoc_ttl
+
+        with patch(
+            "nexus.mcp.core.load_config",
+            return_value={"plans": {"ad_hoc_ttl": 30}},
+        ):
+            assert _load_ad_hoc_ttl() == 30
+
+    def test_config_override_wins(self):
+        from nexus.mcp.core import _load_ad_hoc_ttl
+
+        with patch(
+            "nexus.mcp.core.load_config",
+            return_value={"plans": {"ad_hoc_ttl": 7}},
+        ):
+            assert _load_ad_hoc_ttl() == 7
+
+    def test_missing_plans_section_falls_back_to_30(self):
+        from nexus.mcp.core import _load_ad_hoc_ttl
+
+        with patch("nexus.mcp.core.load_config", return_value={}):
+            assert _load_ad_hoc_ttl() == 30
+
+    def test_load_config_failure_falls_back_to_30(self):
+        from nexus.mcp.core import _load_ad_hoc_ttl
+
+        with patch(
+            "nexus.mcp.core.load_config",
+            side_effect=RuntimeError("no config"),
+        ):
+            assert _load_ad_hoc_ttl() == 30
+
+    def test_defaults_registry_has_ad_hoc_ttl(self):
+        """The ``_DEFAULTS`` dict must carry ``plans.ad_hoc_ttl`` so
+        config-less installs get the RDR-084 default automatically."""
+        from nexus.config import _DEFAULTS
+
+        assert _DEFAULTS.get("plans", {}).get("ad_hoc_ttl") == 30

--- a/tests/test_rdr_084_plan_grow.py
+++ b/tests/test_rdr_084_plan_grow.py
@@ -321,3 +321,128 @@ class TestAdHocTtlConfig:
         from nexus.config import _DEFAULTS
 
         assert _DEFAULTS.get("plans", {}).get("ad_hoc_ttl") == 30
+
+
+# ── Live-SQLite round-trip (critic gap from PR #170) ─────────────────────────
+
+
+class TestLiveSqliteRoundTrip:
+    """End-to-end against a real on-disk SQLite T2Database.
+
+    The other suites in this file mock ``_t2_ctx`` — that catches
+    call-shape regressions but cannot catch cross-transaction bugs
+    like ``save_plan`` returning an id that ``get_plan`` fails to
+    resolve under the same ``_t2_ctx`` block. The critic in PR #170
+    flagged this as a coverage gap; this suite closes it.
+
+    Patches applied:
+      * ``nexus.commands._helpers.default_db_path`` → tmp_path/memory.db
+        so every ``_t2_ctx()`` opens the isolated fixture db.
+      * ``plan_match`` → empty so nx_answer takes the plan-miss branch.
+      * ``_nx_answer_plan_miss`` → returns a synthetic ad-hoc Match.
+      * ``_plan_run`` → returns a trivial success.
+      * ``get_t1_plan_cache`` → captures the row passed to ``upsert``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_save_plan_get_plan_cache_upsert_round_trips(
+        self, tmp_path,
+    ):
+        from nexus.mcp.core import nx_answer
+
+        # Real, isolated T2 on disk
+        db_path = tmp_path / "memory.db"
+
+        cache_stub = MagicMock()
+        cache_stub.upsert = MagicMock(return_value=True)
+
+        match = _ad_hoc_match()
+
+        with patch(
+            "nexus.mcp_infra.default_db_path",
+            return_value=db_path,
+        ), patch("nexus.plans.matcher.plan_match", return_value=[]), \
+           patch(
+               "nexus.mcp.core._nx_answer_plan_miss",
+               AsyncMock(return_value=match),
+           ), \
+           patch(
+               "nexus.plans.runner.plan_run",
+               AsyncMock(return_value=_plan_run_success()),
+           ), \
+           patch("nexus.mcp.core.scratch", return_value="ok"), \
+           patch("nexus.mcp_infra.get_t1_plan_cache", return_value=cache_stub):
+            result = await nx_answer(question="what is nexus retrieval")
+
+        # User still got their answer
+        assert "42" in result
+
+        # Real DB: the row is queryable after the command returned.
+        from nexus.db.t2 import T2Database
+
+        with T2Database(db_path) as verify_db:
+            rows = verify_db.plans.list_active_plans(outcome="success")
+        assert rows, "save_plan should have persisted at least one plan"
+        saved = next(
+            (r for r in rows if "ad-hoc" in (r.get("tags") or "")),
+            None,
+        )
+        assert saved is not None, (
+            "ad-hoc plan not found in T2 after save — save_plan → list desync"
+        )
+        assert saved["scope"] == "personal"
+        assert "grown" in saved["tags"]
+        assert saved["query"] == "what is nexus retrieval"
+        # ttl_days default is 30 (no .nexus.yml override in tmp_path)
+        assert saved["ttl"] == 30
+
+        # Cache upsert received the exact row save_plan produced.
+        assert cache_stub.upsert.called, (
+            "T1 cache.upsert must fire after a successful save"
+        )
+        passed_row = cache_stub.upsert.call_args.args[0]
+        assert passed_row["id"] == saved["id"], (
+            f"cache saw id={passed_row.get('id')!r} but T2 has "
+            f"id={saved['id']!r} — save_plan → get_plan desync"
+        )
+        assert passed_row["query"] == saved["query"]
+        assert passed_row["plan_json"] == saved["plan_json"]
+
+    @pytest.mark.asyncio
+    async def test_save_plan_ttl_zero_disables_growth(self, tmp_path):
+        """plans.ad_hoc_ttl = 0 in config disables growth entirely."""
+        from nexus.mcp.core import nx_answer
+
+        db_path = tmp_path / "memory.db"
+        cache_stub = MagicMock()
+        match = _ad_hoc_match()
+
+        with patch(
+            "nexus.mcp_infra.default_db_path",
+            return_value=db_path,
+        ), patch("nexus.plans.matcher.plan_match", return_value=[]), \
+           patch(
+               "nexus.mcp.core._nx_answer_plan_miss",
+               AsyncMock(return_value=match),
+           ), \
+           patch(
+               "nexus.plans.runner.plan_run",
+               AsyncMock(return_value=_plan_run_success()),
+           ), \
+           patch("nexus.mcp.core.scratch", return_value="ok"), \
+           patch("nexus.mcp_infra.get_t1_plan_cache", return_value=cache_stub), \
+           patch(
+               "nexus.mcp.core.load_config",
+               return_value={"plans": {"ad_hoc_ttl": 0}},
+           ):
+            await nx_answer(question="ttl-zero-question")
+
+        # ttl=0 must short-circuit save entirely
+        from nexus.db.t2 import T2Database
+
+        with T2Database(db_path) as verify_db:
+            rows = verify_db.plans.list_active_plans(outcome="success")
+        assert rows == [], (
+            "ttl_days=0 must disable growth; no plan should have been saved"
+        )
+        assert not cache_stub.upsert.called

--- a/tests/test_rdr_085_glossary_labeler.py
+++ b/tests/test_rdr_085_glossary_labeler.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for RDR-085 Glossary-Aware Topic Labeler.
+
+Pins three contracts:
+
+  * Glossary resolver load order: ``.nexus.yml#taxonomy.glossary``
+    wins over ``docs/glossary.md``; both are absent → empty dict.
+  * Labeler migrates from ``subprocess.run(['claude', '-p'])`` to
+    ``claude_dispatch(prompt, schema)``. Glossary text, when present,
+    is prepended to the prompt so the LLM sees project vocabulary
+    before the numbered topics.
+  * Invariant: ``len(results) == len(items)``. Missing or schema-
+    rejected labels become ``None`` in their slot; the caller's
+    c-TF-IDF fallback fills the gap.
+
+These tests do not exercise claude_dispatch itself — that substrate
+already has its own test coverage (shipped with RDR-080).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+# ── Glossary resolver ────────────────────────────────────────────────────────
+
+
+class TestLoadGlossary:
+
+    def test_config_glossary_wins(self, tmp_path: Path) -> None:
+        from nexus.glossary import load_glossary
+
+        (tmp_path / ".nexus.yml").write_text(
+            "taxonomy:\n"
+            "  glossary:\n"
+            "    SSMF: SelfSimilarMaskingField\n"
+            "    CCE: Contextualized Chunk Embedding\n"
+        )
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "glossary.md").write_text(
+            "# Glossary\n\n- SSMF: OVERRIDDEN  (should NOT win)\n"
+        )
+
+        g = load_glossary(tmp_path)
+        assert g.get("SSMF") == "SelfSimilarMaskingField"
+        assert g.get("CCE") == "Contextualized Chunk Embedding"
+
+    def test_markdown_glossary_fallback(self, tmp_path: Path) -> None:
+        from nexus.glossary import load_glossary
+
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "glossary.md").write_text(
+            "# Project Glossary\n\n"
+            "- **SSMF**: SelfSimilarMaskingField\n"
+            "- CCE: Contextualized Chunk Embedding\n"
+            "- chash: content-addressed chunk hash\n"
+        )
+
+        g = load_glossary(tmp_path)
+        assert g.get("SSMF") == "SelfSimilarMaskingField"
+        assert g.get("CCE") == "Contextualized Chunk Embedding"
+        assert g.get("chash") == "content-addressed chunk hash"
+
+    def test_no_glossary_anywhere_returns_empty(self, tmp_path: Path) -> None:
+        from nexus.glossary import load_glossary
+
+        assert load_glossary(tmp_path) == {}
+
+    def test_malformed_yaml_returns_empty(self, tmp_path: Path) -> None:
+        """A busted .nexus.yml must not crash the labeler — empty falls
+        through to the c-TF-IDF path."""
+        from nexus.glossary import load_glossary
+
+        (tmp_path / ".nexus.yml").write_text(": ::: not valid yaml\n")
+        assert load_glossary(tmp_path) == {}
+
+
+class TestFormatForPrompt:
+
+    def test_formats_as_bulleted_vocabulary(self) -> None:
+        from nexus.glossary import format_for_prompt
+
+        text = format_for_prompt({"SSMF": "SelfSimilarMaskingField", "CCE": "Contextualized Chunk Embedding"})
+        assert "Project vocabulary" in text
+        assert "SSMF: SelfSimilarMaskingField" in text
+        assert "CCE: Contextualized Chunk Embedding" in text
+
+    def test_empty_glossary_returns_empty_string(self) -> None:
+        from nexus.glossary import format_for_prompt
+
+        assert format_for_prompt({}) == ""
+
+    def test_truncates_past_max_tokens(self) -> None:
+        """At max_tokens=50 (generous for tests), only a handful of
+        vocabulary entries fit; the rest are silently dropped rather
+        than dominating the prompt."""
+        from nexus.glossary import format_for_prompt
+
+        big = {f"TERM{i}": f"expansion number {i} padded " * 10 for i in range(50)}
+        text = format_for_prompt(big, max_tokens=50)
+        # Very rough token proxy: 1 token ≈ 4 chars.  We assert the
+        # output stays under ~200 chars (== ~50 tokens).
+        assert len(text) < 400
+
+
+# ── Labeler migration ────────────────────────────────────────────────────────
+
+
+class TestLabelerDispatch:
+
+    @pytest.mark.asyncio
+    async def test_calls_claude_dispatch_not_subprocess(self) -> None:
+        """The migrated labeler must go through claude_dispatch — not
+        raw subprocess.run — so the unified auth / schema / unwrap-fix
+        surface applies to labeling."""
+        from nexus.commands import taxonomy_cmd
+
+        dispatched = AsyncMock(return_value={
+            "labels": [
+                {"idx": 1, "label": "Pattern Matching"},
+                {"idx": 2, "label": "Vector Search"},
+            ],
+        })
+        items = [
+            (["ART", "masking"], ["paper1.pdf:0", "paper2.pdf:3"]),
+            (["cosine", "ANN"], ["paper3.pdf:1"]),
+        ]
+
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_labels_batch(items)
+
+        assert dispatched.called, "labeler must dispatch via claude_dispatch"
+        assert results == ["Pattern Matching", "Vector Search"]
+
+    @pytest.mark.asyncio
+    async def test_glossary_text_appears_in_prompt(self) -> None:
+        """When glossary_text is supplied, the dispatcher receives a
+        prompt whose head is the glossary preamble."""
+        from nexus.commands import taxonomy_cmd
+
+        captured: dict[str, str] = {}
+
+        async def fake_dispatch(prompt: str, schema: dict, **kw) -> dict:
+            captured["prompt"] = prompt
+            return {"labels": [{"idx": 1, "label": "A Topic"}]}
+
+        items = [(["term"], ["doc.pdf:0"])]
+        with patch("nexus.operators.dispatch.claude_dispatch", fake_dispatch):
+            await taxonomy_cmd._generate_labels_batch(
+                items, glossary_text="Project vocabulary:\n- SSMF: SelfSimilarMaskingField\n",
+            )
+
+        assert "Project vocabulary" in captured["prompt"]
+        assert "SSMF: SelfSimilarMaskingField" in captured["prompt"]
+        # Glossary precedes the numbered topic list
+        vocab_pos = captured["prompt"].find("Project vocabulary")
+        topic_pos = captured["prompt"].find("1.")
+        assert 0 <= vocab_pos < topic_pos, (
+            "glossary must precede the topic list in the prompt"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_glossary_no_preamble(self) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        captured: dict[str, str] = {}
+
+        async def fake_dispatch(prompt: str, schema: dict, **kw) -> dict:
+            captured["prompt"] = prompt
+            return {"labels": [{"idx": 1, "label": "A Topic"}]}
+
+        items = [(["term"], ["doc.pdf:0"])]
+        with patch("nexus.operators.dispatch.claude_dispatch", fake_dispatch):
+            await taxonomy_cmd._generate_labels_batch(items)
+
+        assert "Project vocabulary" not in captured["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_length_invariant_on_partial_response(self) -> None:
+        """If claude_dispatch returns fewer labels than items, the
+        result list is still len(items); missing slots are None."""
+        from nexus.commands import taxonomy_cmd
+
+        items = [
+            (["a"], ["p.pdf:0"]),
+            (["b"], ["p.pdf:1"]),
+            (["c"], ["p.pdf:2"]),
+        ]
+        # Only returns 2 labels for 3 topics, AND skips idx 2
+        dispatched = AsyncMock(return_value={
+            "labels": [
+                {"idx": 1, "label": "First"},
+                {"idx": 3, "label": "Third"},
+            ],
+        })
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_labels_batch(items)
+
+        assert len(results) == 3
+        assert results == ["First", None, "Third"]
+
+    @pytest.mark.asyncio
+    async def test_dispatch_exception_returns_all_none(self) -> None:
+        """claude_dispatch raising (timeout, schema reject, etc.) returns
+        a None-filled list — caller's c-TF-IDF fallback takes over."""
+        from nexus.commands import taxonomy_cmd
+
+        items = [(["a"], ["p.pdf:0"]), (["b"], ["p.pdf:1"])]
+        with patch(
+            "nexus.operators.dispatch.claude_dispatch",
+            AsyncMock(side_effect=RuntimeError("schema reject")),
+        ):
+            results = await taxonomy_cmd._generate_labels_batch(items)
+
+        assert results == [None, None]
+
+    @pytest.mark.asyncio
+    async def test_label_length_bounds_respected(self) -> None:
+        """3 <= len(label) <= 60. Labels outside that window become None."""
+        from nexus.commands import taxonomy_cmd
+
+        items = [
+            (["a"], ["p.pdf:0"]),
+            (["b"], ["p.pdf:1"]),
+            (["c"], ["p.pdf:2"]),
+        ]
+        dispatched = AsyncMock(return_value={
+            "labels": [
+                {"idx": 1, "label": "OK Label"},
+                {"idx": 2, "label": "x"},  # too short
+                {"idx": 3, "label": "Z" * 100},  # too long
+            ],
+        })
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_labels_batch(items)
+
+        assert results == ["OK Label", None, None]
+
+    @pytest.mark.asyncio
+    async def test_empty_items_returns_empty_without_dispatch(self) -> None:
+        """Empty batch is a fast path — no LLM subprocess spawned."""
+        from nexus.commands import taxonomy_cmd
+
+        dispatched = AsyncMock()
+        with patch("nexus.operators.dispatch.claude_dispatch", dispatched):
+            results = await taxonomy_cmd._generate_labels_batch([])
+
+        assert results == []
+        assert not dispatched.called

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.4.1"
+version = "4.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Post-4.4.1 follow-up arc: 5 commits covering 4 RDRs plus a scope reorg between 082/083. All RDRs were drafts on main before this branch; shipped in priority order per the cross-RDR analysis.

## Commits

| Commit | What |
|---|---|
| `7b0d476` | docs(rdr): reorg 082/083 — system-of-record vs. corpus-evidence split |
| `b705ad3` | feat(rdr-084): auto-save successful ad-hoc plans for library growth |
| `59ac64d` | feat(rdr-085): glossary-aware topic labeler via claude_dispatch |
| `4b2c059` | feat(rdr-082): nx doc render — bead + RDR token resolution |
| `89db20b` | feat(rdr-083): corpus-evidence tokens — nx-anchor + grounding/extensions |

## RDR-082/083 scope reorg

Moved `{{nx-anchor:…}}` from 082 to 083 so 082 owns *only* system-of-record tokens (bead / RDR state) and 083 owns *all* projection-derived rendering. Clean split: 082's data deps are 100% its own scope, 083's are too. The Resolver registry is the extension point where 083 plugs AnchorResolver in without touching 082's parser/engine/CLI.

## RDR-084 — Plan Library Growth

Successful ad-hoc `nx_answer` plans (plan_id=0 success path) now auto-persist via `save_plan(scope="personal", tags="ad-hoc,grown", ttl=<config>)`. TTL is config-driven (`plans.ad_hoc_ttl`, default 30). Best-effort — save failures don't affect the user's answer. T1 cosine cache receives `upsert(row)` so paraphrases match on the next call. Replaces the stub I-6 placeholder at `mcp/core.py:2023-2028`.

## RDR-085 — Glossary-Aware Labeler

Migrates `_generate_labels_batch` off `subprocess.run(['claude', '-p'])` onto the shipped `claude_dispatch` substrate, schema-enforced output. Project vocabulary preamble prepended when `.nexus.yml#taxonomy.glossary` is set — eliminates training-prior hallucinations like `SSMF → "Single Mode Fiber"`.

**Prompt-cache session reuse evaluated and deferred.** The nexus-axu Phase A measurement (47–97k cache_read tokens per post-rewind turn) proves the mechanism, but the current labeler envelope on typical runs (~20-25s wall clock across 4 workers) is already comfortable. Not worth the complexity.

**Live quality check** against `rdr__nexus-571b8edd` (6 topics): 2/6 improved with glossary (Ted-Nelson prior eliminated on "tumbler"), 4/6 unchanged, 0/6 regressed. Quality floor respected per RF-1.

## RDR-082 — `nx doc render`

New `nx doc` command group:
- `nx doc render <paths>` — resolve `{{bd:…}}` and `{{rdr:…}}` tokens against bead DB + RDR frontmatter, emit `<stem>.rendered.md` siblings.
- `nx doc validate <paths>` — same parse+resolve, no emit; non-zero exit on miss.

Shared helper `src/nexus/doc/_common.py` hosts the fence regex; `ref_scanner.py` (RDR-081) now uses it too — one fence implementation across the doc module.

## RDR-083 — Corpus-Evidence Tokens

Extends `nx doc` with projection-derived surfaces:
- `{{nx-anchor:<collection>[|top=N]}}` — top-N projected topics, SQL'd from `topic_assignments`. Registers into 082's registry at module-import time.
- `nx doc check-grounding <paths>` — citation-coverage report (chash / prose / bracket counts).
- `nx doc check-extensions <paths> --primary-source <col>` — flags docs whose chunks don't project into the primary source above threshold.

Live smoke against `docs__art-grossberg-papers` returned real top-5 topics (6964 chunks across the top 5 labels).

## Test plan

- [x] `uv run pytest tests/` — 4247 passed, 27 skipped, 0 fail
- [x] Live smoke on all four RDR implementations against real prod data
- [x] Live quality check on RDR-085 (baseline vs glossary-aware side-by-side)
- [ ] CI green on both Python 3.12 and 3.13
- [ ] After merge: tag `v4.5.0`, let release workflow publish