### PR TITLE
fix(nexus-lub): cascade runs even when T3 collection already absent

### DIFF
--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -69,11 +69,25 @@ def delete_cmd(name: str, yes: bool) -> None:
     """Delete a T3 collection + cascade-purge taxonomy state (irreversible)."""
     if not yes:
         click.confirm(f"Delete collection '{name}'? This cannot be undone.", abort=True)
-    _t3().delete_collection(name)
 
-    # nexus-lub: cascade-purge taxonomy state (topics, assignments,
-    # links, meta) so `nx taxonomy status` / hub detection don't drag
-    # ghost rows across deletions.
+    # nexus-lub: T3 delete may fail with NotFoundError when the caller
+    # is recovering from an orphan-taxonomy state where the collection
+    # was deleted previously but the cascade didn't run (pre-4.5.0). We
+    # still run the cascade in that case so the orphan rows are cleaned.
+    # Any other T3 error aborts before cascade.
+    from chromadb.errors import NotFoundError as _ChromaNotFoundError
+    t3_absent = False
+    try:
+        _t3().delete_collection(name)
+    except _ChromaNotFoundError:
+        t3_absent = True
+        click.echo(
+            f"note: T3 collection '{name}' already absent — running cascade anyway",
+            err=True,
+        )
+
+    # Cascade-purge taxonomy state (topics, assignments, links, meta)
+    # so `nx taxonomy status` / hub detection don't drag ghost rows.
     taxonomy_counts: dict[str, int] | None = None
     try:
         from nexus.commands._helpers import default_db_path
@@ -82,8 +96,9 @@ def delete_cmd(name: str, yes: bool) -> None:
         with T2Database(default_db_path()) as db:
             taxonomy_counts = db.taxonomy.purge_collection(name)
     except Exception as exc:
+        prefix = "absent" if t3_absent else "succeeded"
         click.echo(
-            f"warn: T3 delete succeeded but taxonomy cascade failed: {exc}",
+            f"warn: T3 delete {prefix} but taxonomy cascade failed: {exc}",
             err=True,
         )
 

--- a/tests/test_nexus_lub_collection_delete_cascade.py
+++ b/tests/test_nexus_lub_collection_delete_cascade.py
@@ -228,6 +228,60 @@ class TestPurgeCollection:
 class TestCollectionDeleteCommandCascades:
     """Integration: `nx collection delete` cascades via Click entry point."""
 
+    def test_cli_delete_cascades_when_t3_collection_absent(self, tmp_path):
+        """Discovered during 4.5.0 shakeout: if the Chroma collection is
+        already gone (previous delete left orphan taxonomy rows), the T3
+        delete raises NotFoundError. The cascade MUST still run so the
+        orphans can be cleaned up — otherwise the recovery case never
+        terminates and users are stuck with manual sqlite surgery per
+        the pre-fix workaround."""
+        from click.testing import CliRunner
+        from chromadb.errors import NotFoundError
+        from unittest.mock import MagicMock, patch
+
+        from nexus.db.t2 import T2Database
+        from nexus.commands.collection import delete_cmd
+
+        db_path = tmp_path / "memory.db"
+        db = T2Database(db_path)
+        db.taxonomy.conn.execute(
+            "INSERT INTO topics (label, collection, centroid_hash, "
+            "doc_count, terms, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            ("Orphan", "docs__gone", "h", 1, "[]", "2026-04-17T00:00:00Z"),
+        )
+        db.taxonomy.conn.commit()
+        db.close()
+
+        fake_t3 = MagicMock()
+        fake_t3.delete_collection = MagicMock(
+            side_effect=NotFoundError("Collection [docs__gone] does not exist")
+        )
+
+        runner = CliRunner()
+        with patch("nexus.commands.collection._t3", return_value=fake_t3), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
+             patch(
+                 "nexus.commands._helpers.default_db_path",
+                 return_value=db_path,
+             ):
+            result = runner.invoke(delete_cmd, ["docs__gone", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        assert "already absent" in result.output, (
+            f"Expected informational note that T3 collection was absent. "
+            f"Got: {result.output!r}"
+        )
+
+        # Cascade DID run despite the NotFoundError
+        with T2Database(db_path) as verify_db:
+            remaining = verify_db.taxonomy.conn.execute(
+                "SELECT COUNT(*) FROM topics WHERE collection = ?",
+                ("docs__gone",),
+            ).fetchone()[0]
+        assert remaining == 0, (
+            "Cascade must run even when T3 collection is absent"
+        )
+
     def test_cli_delete_calls_purge_collection(self, tmp_path, monkeypatch):
         """The CLI path must invoke purge_collection after the Chroma
         delete — not skip it, not run before (order matters for the


### PR DESCRIPTION
## Summary

Discovered during the v4.5.0 live shakeout. The nexus-lub cascade fix shipped in v4.5.0 (commit e1defdb) had a hidden gap: it assumed the T3 delete succeeds before the cascade runs. When a user invokes `nx collection delete <name>` to clean up orphan taxonomy rows left by a PRE-4.5.0 deletion (the exact recovery case the fix was supposed to enable), the T3 collection is already gone → `delete_collection` raises `chromadb.errors.NotFoundError` → cascade never runs → orphans remain forever.

## Fix

Wrap the T3 delete in `try/except NotFoundError`. When the collection is absent:
- Print an informational `note:` to stderr so the caller knows why the T3 side was a no-op
- Proceed with the taxonomy cascade anyway

Any other T3 error still aborts before cascade (preserves the "don't cascade on unexpected T3 failure" invariant).

## Test plan

- [x] New regression test `test_cli_delete_cascades_when_t3_collection_absent` — seeds an orphan topic + patches `_t3.delete_collection` to raise `NotFoundError`, asserts the "already absent" note + cascade cleanup
- [x] Full `tests/test_nexus_lub_collection_delete_cascade.py` suite — 8 pass (7 prior + 1 new)
- [x] Live-smoked: seeded 2 topics + 1 meta row for `docs__4-5-0-smoke`, ran `nx collection delete docs__4-5-0-smoke --yes`, got `note: T3 collection 'docs__4-5-0-smoke' already absent — running cascade anyway` followed by `Deleted: docs__4-5-0-smoke (taxonomy: 2 topics, 0 assignments, 0 links, 1 meta)`, confirmed T2 rows are gone