### PR TITLE
docs(rdr-086): expand scope — authoring path from ART feedback

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -107,7 +107,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-083](rdr-083-chunk-grounded-citations.md) | Corpus-Evidence Tokens — `chash:` Spans, Grounding Validator, `nx-anchor` | Feature | Draft | 2026-04-15 |
 | [RDR-084](rdr-084-plan-library-growth.md) | Plan Library Growth — Auto-Save Successful Ad-Hoc Plans | Feature | Draft | 2026-04-16 |
 | [RDR-085](rdr-085-glossary-aware-labeler.md) | Glossary-Aware Topic Labeler — Project Vocabulary via `claude_dispatch` | Feature | Draft | 2026-04-16 |
-| [RDR-086](rdr-086-chash-span-resolution.md) | Chash Span Surface — Authoring, Resolution, and Verification | Feature | Draft | 2026-04-16 |
+| [RDR-086](rdr-086-chash-span-resolution.md) | Chash Span Surface — Authoring, Resolution, and Verification | Feature | Accepted | 2026-04-16 |
 
 ---
 

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -107,7 +107,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-083](rdr-083-chunk-grounded-citations.md) | Corpus-Evidence Tokens — `chash:` Spans, Grounding Validator, `nx-anchor` | Feature | Draft | 2026-04-15 |
 | [RDR-084](rdr-084-plan-library-growth.md) | Plan Library Growth — Auto-Save Successful Ad-Hoc Plans | Feature | Draft | 2026-04-16 |
 | [RDR-085](rdr-085-glossary-aware-labeler.md) | Glossary-Aware Topic Labeler — Project Vocabulary via `claude_dispatch` | Feature | Draft | 2026-04-16 |
-| [RDR-086](rdr-086-chash-span-resolution.md) | Chash Span Resolution — catalog chash-to-chunk Lookup + doc-id Mapping | Feature | Draft | 2026-04-16 |
+| [RDR-086](rdr-086-chash-span-resolution.md) | Chash Span Surface — Authoring, Resolution, and Verification | Feature | Draft | 2026-04-16 |
 
 ---
 

--- a/docs/rdr/rdr-086-chash-span-resolution.md
+++ b/docs/rdr/rdr-086-chash-span-resolution.md
@@ -228,19 +228,35 @@ parameters don't change.
   JSONL, chunks are implicit sub-addresses), so the empty-list
   there is semantically correct and not part of this RDR's scope.
 
-- **RF-5 (blocked, recommended follow-up)** — Could not run a
-  direct-T3 sample of chunk metadata to confirm the write-site
-  RFs land in prod: `T3Database()` constructor hits
-  `chromadb.errors.ChromaError: Permission denied` from the
-  cloud-client auth path when invoked outside the normal nx CLI
-  entry. The nx CLI itself works fine (it reads credentials via
-  `nexus.config`), so the write-site evidence + the working MCP
-  tools strongly imply the data is present. Full verification
-  requires either fixing the bare-constructor auth path, adding
-  a diagnostic command (`nx catalog sample-metadata <collection>
-  --limit 5 --keys chunk_text_hash,content_hash`), or running
-  the MVV against the backfilled index. Filing as a follow-up
-  bead; does **not** block this RDR's design.
+- **RF-5 (resolved 2026-04-17)** — Direct-T3 sampling was
+  initially blocked: `T3Database()` bare constructor hit
+  `chromadb.errors.ChromaError: Permission denied` because empty
+  credential args were forwarded to `CloudClient` without the
+  config fallback that the `make_t3()` factory applies. Fixed in
+  `src/nexus/db/t3.py:193` — the constructor now falls back to
+  `nexus.config.get_credential()` for empty args when a client
+  isn't injected and local mode isn't set. Tests in
+  `tests/test_t3.py::test_bare_constructor_falls_back_to_get_credential`
+  and three sibling cases pin the behaviour (explicit args still
+  win, `_client=` injection skips fallback, local mode skips
+  fallback).
+
+  With the fix in place, sampled 10 chunks across one collection
+  per prefix (code, docs, rdr, knowledge, taxonomy):
+
+  | Collection prefix | chunk_text_hash present | non-empty |
+  |---|---|---|
+  | `code__` | 10/10 | 10/10 |
+  | `docs__` | 10/10 | 10/10 |
+  | `rdr__`  | 10/10 | 10/10 |
+  | `knowledge__` | 1/1  | 1/1  |
+  | `taxonomy__centroids` | 0/10 | 0/10 |
+
+  All citable-content prefixes carry the 64-char SHA-256 hex on
+  every chunk. `taxonomy__centroids` correctly has no hash — those
+  rows are topic centroids, not indexed chunks, and are out of
+  scope for `chash:` citations. Design assumption fully confirmed
+  against prod.
 
 ### Critical Assumptions
 

--- a/docs/rdr/rdr-086-chash-span-resolution.md
+++ b/docs/rdr/rdr-086-chash-span-resolution.md
@@ -1,5 +1,5 @@
 ---
-title: "RDR-086: Chash Span Resolution — Catalog chash-to-chunk Lookup + Doc-ID Mapping"
+title: "RDR-086: Chash Span Surface — Authoring, Resolution, and Verification"
 id: RDR-086
 status: draft
 type: Feature
@@ -7,16 +7,33 @@ priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-16
+revised: 2026-04-17
 related_issues: []
 related: [RDR-053, RDR-075, RDR-078, RDR-082, RDR-083]
 ---
 
-# RDR-086: Chash Span Resolution
+# RDR-086: Chash Span Surface
 
 RDR-083 shipped the `chash:` citation grammar, the scanner, and the
 `AnchorResolver` that plugs into RDR-082's Resolver registry. It did
 not ship the machinery that makes those citations *verifiable*. The
-v1 scope reduction noted in RDR-083 leaves two concrete holes:
+2026-04-17 ART-instance feedback then surfaced a deeper problem: it
+also didn't ship the machinery to *author* them. An author or agent
+that wants to cite a specific chunk has no CLI or MCP path to obtain
+the chash — they have to drop to the raw ChromaDB API, run
+`collection.get(include=["metadatas"])`, and copy the `chash` value by
+hand. Every `search`, `query`, and `nx_answer` structured return omits
+the chunk hash. That makes the whole `chash:` citation primitive
+dead-on-arrival for typical Tier-3 grounding workflows.
+
+This RDR owns the chash primitive surface end-to-end — authoring
+and verification are mirror workflows over the same T2 index. The
+original draft (2026-04-16) covered only the reverse direction
+(resolve hash → chunk). This revision widens scope to the forward
+direction (surface chunk hashes through normal retrieval) and the
+convenience CLI that composes them.
+
+Four concrete holes to close:
 
 1. `nx doc check-grounding` counts chash-shaped citations but cannot
    tell a hash-of-a-real-chunk from a hash-of-an-unindexed-chunk. Its
@@ -28,12 +45,16 @@ v1 scope reduction noted in RDR-083 leaves two concrete holes:
    The namespaces never intersect; every input returns `no_data`. The
    command emits a WARNING and the docstring marks it `[experimental]`,
    but it is currently inert.
-
-This RDR fixes both holes with one primitive: a
-`catalog.resolve_chash(chash) -> ChunkRef | None` method that returns
-the (document tumbler, chunk index, physical collection, optional
-text) for a chash, or `None` when the chash is not indexed. Every
-downstream feature composes on top of it.
+3. **Authors have no path to obtain a chash.** `search(structured=True)`
+   returns `{ids, tumblers, distances, collections}`. `query(structured=True)`
+   is similar. `nx_answer` envelopes carry final-text, not hashes. An
+   agent that just *found* the exact chunk to cite still has no way
+   to cite it without ChromaDB-API surgery.
+4. **No "cite this claim" command.** The normal workflow is "here's
+   my prose claim, find the best-matching chunk, give me a ready-to-
+   paste `[display](chash:…)` markdown link." That's a three-step
+   ChromaDB dance today — embed the claim, top-k query, copy hash
+   metadata by hand. It should be one command.
 
 ## Problem Statement
 
@@ -73,6 +94,34 @@ RDR-083's Phase 2 polish for `nx doc render --expand-citations`
 (inline footnote/tooltip with the cited chunk text) is blocked on
 the same resolver. The renderer currently preserves `chash:` links
 verbatim.
+
+#### Gap 5: No forward path from retrieval to chash
+
+`search(structured=True)` returns `{ids, tumblers, distances,
+collections}`. `query(structured=True)` returns document-level
+results with the same shape. `nx_answer` returns final text. None
+of them surface the underlying chunk's content hash. An agent
+running `search(query=<claim>, corpus=<primary-source>, limit=1,
+structured=True)` finds the right chunk but cannot read its chash
+out of the payload. The authoring workflow then forces a descent
+into the ChromaDB API to recover the metadata — exactly the
+"descend to the raw backend" anti-pattern the MCP surface exists to
+prevent. Surfacing `chunk_text_hash` on the structured-return
+payload closes the forward direction. The ART-instance feedback
+(2026-04-17) estimates this single field change closes ~80% of the
+authoring gap on its own.
+
+#### Gap 6: No one-shot "cite this claim" command
+
+Even with `chunk_text_hash` on structured returns, the author still
+runs three steps: call `search`, inspect the top result, assemble
+a markdown link. A focused CLI — `nx doc cite "<claim text>"
+--against <collection>` — collapses this to one invocation that
+emits a ready-to-paste `[summary](chash:<hex>)` snippet (plus, on
+`--json`, the resolved metadata for pipeline scripting). Without it
+the `chash:` citation grammar stays correct-but-painful, which the
+ART-instance feedback identifies as adoption-limiting for RDR-083's
+main value proposition.
 
 ## Context
 
@@ -122,6 +171,20 @@ parameters don't change.
   T2 SQLite, populated at indexing time. Single JOIN replaces
   N_collections scans. Most scalable; requires a new T2 migration.
 
+### External evidence
+
+- **RF-1 (2026-04-17)** — ART-instance observation on the
+  authoring gap. The instance tried to author `chash:` citations
+  against `docs__art-grossberg-papers` and could not — no CLI or
+  MCP surface exposes the chunk-to-hash mapping. `operator_extract`
+  works on text content, not metadata. `store_get`/`store_list`
+  show document-level views, not per-chunk hashes. `nx taxonomy`
+  operates at the topic/collection level. Even `search(structured=True)`
+  omits the chunk hash. The instance had to drop to `collection.get(include=["metadatas"])`
+  on the raw ChromaDB client to recover the hash and assemble the
+  citation by hand. Reported as a polish-bead against nexus
+  (2026-04-17 conversation). This RDR is the owner.
+
 ### Critical Assumptions
 
 - [ ] `chash` is populated on every chunk in every indexing path —
@@ -140,18 +203,32 @@ parameters don't change.
 
 ### Approach
 
-Two cooperating surfaces:
+Four cooperating surfaces — one primitive, two retrieval surface
+changes, one convenience command:
 
 1. **T2 `chash_index` table**, populated at indexing time by each
    pipeline (`code_indexer`, `doc_indexer`, `pdf_chunker`).
    Schema: `(chash TEXT PRIMARY KEY, physical_collection TEXT,
    doc_id TEXT, created_at TEXT)`.
 
-2. **`catalog.resolve_chash(chash) -> ChunkRef | None`** that
-   consults the T2 index first, falls back to a T3 metadata filter
-   when the index is empty (fresh install), returns `None` on miss.
+2. **`catalog.resolve_chash(chash) -> ChunkRef | None`** (reverse
+   direction) that consults the T2 index first, falls back to a T3
+   metadata filter when the index is empty (fresh install), returns
+   `None` on miss.
 
-Downstream consumers (RDR-083):
+3. **`chunk_text_hash` on structured retrieval returns** (forward
+   direction) — added to `search(structured=True)`,
+   `query(structured=True)`, and the `nx_answer` envelope. Agents
+   and authors that `search` for a claim can now read the citable
+   hash straight off the payload instead of descending to ChromaDB.
+
+4. **`nx doc cite "<claim>" --against <collection>`** (convenience
+   CLI) that composes `search(limit=1, structured=True)` with the
+   hash surfaced in #3 and emits a ready-to-paste
+   `[<display>](chash:<hex>)` markdown link. `--json` returns the
+   structured payload for pipeline scripting.
+
+Downstream consumers unblocked by this work (RDR-083):
 
 - `nx doc check-grounding --fail-ungrounded` ships.
 - `nx doc check-extensions` replaces its chash-as-doc-id proxy with
@@ -174,6 +251,10 @@ indexing-path instrumentation.)
 | T2 migration | `src/nexus/db/migrations.py` | **Add** — new migration for `chash_index` table |
 | Indexing instrumentation | `src/nexus/code_indexer.py`, `src/nexus/doc_indexer.py`, `src/nexus/pdf_chunker.py` | **Extend** — write to `chash_index` on each chunk upsert |
 | Backfill command | `src/nexus/commands/catalog.py` | **Extend** — `nx catalog rebuild-chash-index` walks existing T3 collections and populates T2 |
+| `search(structured=True)` payload | `src/nexus/mcp/core.py` search tool | **Extend** — add `chunk_text_hash` (list aligned with `ids`) to the returned dict |
+| `query(structured=True)` payload | `src/nexus/mcp/core.py` query tool | **Extend** — surface the representative-chunk hash on each document result |
+| `nx_answer` envelope | `src/nexus/mcp/core.py:nx_answer` | **Extend** — when a plan's final step is a retrieval op, include the top chunks' hashes in the envelope so the caller can cite without re-querying |
+| `nx doc cite` command | `src/nexus/commands/doc.py` (RDR-082 group) | **Add** — new subcommand composing `search(limit=1, structured=True)` + markdown link emission |
 
 ### Decision Rationale
 
@@ -238,6 +319,14 @@ place.
 3. Run `nx doc check-grounding --fail-ungrounded` on a doc with one
    real chash and one made-up chash — verify exit 1, correct error
    locations.
+4. Run `search(structured=True)` on a real corpus — verify
+   `chunk_text_hash` appears in the returned dict with length
+   matching `ids`, and every hash round-trips through
+   `resolve_chash` to its owning chunk.
+5. Run `nx doc cite "<a real claim>" --against docs__art-grossberg-papers`
+   and confirm the emitted markdown link has a resolvable chash
+   (feed the output through `nx doc check-grounding` with
+   `--fail-ungrounded`; expect exit 0).
 
 ### Phase 1: Indexing instrumentation
 
@@ -245,12 +334,20 @@ place.
 - Extend the three indexers to upsert.
 - Backfill command.
 
-### Phase 2: Catalog resolver
+### Phase 2: Catalog resolver (reverse direction)
 
 - `resolve_chash(chash) -> ChunkRef | None` method.
 - Unit tests with fixture T2 + fixture T3.
 
-### Phase 3: RDR-083 consumer wiring
+### Phase 3: Retrieval surface (forward direction)
+
+- Add `chunk_text_hash` to `search(structured=True)` payload.
+- Add the same to `query(structured=True)` document results.
+- Add the same to the `nx_answer` envelope when the final step is
+  a retrieval op.
+- Unit + integration tests: verify every surfaced hash resolves.
+
+### Phase 4: RDR-083 consumer wiring
 
 - `check-grounding` gains `--fail-ungrounded`.
 - `check-extensions` replaces the chash-as-doc-id proxy with real
@@ -258,6 +355,14 @@ place.
 - Remove `[experimental]` marker and WARNING path when the resolver
   is populated.
 - `nx doc render --expand-citations` ships.
+
+### Phase 5: Authoring CLI
+
+- `nx doc cite "<claim>" --against <collection> [--limit N] [--json]`.
+- Default output: `[<first 60 chars of chunk>](chash:<hex>)`.
+- `--json`: structured payload with the top-N candidate chunks +
+  hashes so pipeline scripts can pick a specific one.
+- Docs + live smoke against `docs__art-grossberg-papers`.
 
 ## References
 
@@ -274,3 +379,13 @@ place.
   (resolve_chash, chash → doc-id mapping, `--fail-ungrounded`,
   `--expand-citations`) all depend on the single primitive
   specified here.
+- 2026-04-17 — Scope expanded after ART-instance feedback (RF-1):
+  authors today cannot obtain chash values through any nexus CLI
+  or MCP surface, forcing direct ChromaDB-API use. Added Gap 5
+  (no forward path from retrieval to chash), Gap 6 (no "cite
+  this" CLI), and corresponding Phase 3 (`chunk_text_hash` in
+  structured returns) and Phase 5 (`nx doc cite`) to the
+  implementation plan. Title retyped "Chash Span Resolution" →
+  "Chash Span Surface" to reflect that this RDR owns the
+  primitive end-to-end (authoring + verification), not just
+  reverse resolution.

--- a/docs/rdr/rdr-086-chash-span-resolution.md
+++ b/docs/rdr/rdr-086-chash-span-resolution.md
@@ -377,6 +377,45 @@ parameters don't change.
   resolve_chash from scratch" to "extend `resolve_span` with a
   collection-agnostic variant that defers to the T2 index."
 
+- **RF-10 (post-rewrite audit, 2026-04-17)** — Reviewed the
+  rewritten RDR for new gaps introduced by the scope reframing.
+  Four real issues found and fixed in place:
+
+  1. **Compound primary key**: the original text specified
+     `chash TEXT PRIMARY KEY` but the same chunk can legitimately
+     be indexed into multiple collections (e.g. a paper in both
+     `knowledge__delos` and `knowledge__delos_docling` — both
+     hit the same `chunk_text_hash`). Schema corrected to
+     `PRIMARY KEY (chash, physical_collection)`. `resolve_chash`
+     signature gained a `prefer_collection` kwarg and a documented
+     multi-match tie-break precedence.
+
+  2. **Single-step guard interaction** (`mcp/core.py:1972`): the
+     `nx_answer(structured=True)` path has to work on the
+     shortcut that reroutes one-step `query` plans directly to
+     `query()`, bypassing `plan_run`. Phase 3 now specifies the
+     guard stays in place and the envelope is built from
+     `query(structured=True)`'s returned fields.
+
+  3. **Fallback latency bound**: Phase 2's "iterate collections"
+     fallback for an empty T2 index had no bound. Specified:
+     parallelised 10× with a 30-second deadline, `None` return
+     on timeout (caller treats as unresolved). Prevents indefinite
+     blocking on a large corpus before the backfill runs.
+
+  4. **Concurrency contract**: six write sites include the
+     3-worker streaming-PDF pipeline, and multiple `nx index`
+     invocations may run concurrently. Added a Failure-Mode
+     entry specifying WAL-mode SQLite with `INSERT OR REPLACE`
+     is sufficient — matches the existing `pdf_pipeline`
+     table's concurrency posture (nexus-9ji precedent).
+
+  Verified pre-existing facts cited by the rewrite:
+  `_BACKFILL_BATCH = 300` exists at `commands/collection.py:304`.
+  `_nx_answer_classify_plan` and the single-step guard exist at
+  `mcp/core.py:1676` and `:1972`. Streaming pipeline's
+  `ThreadPoolExecutor(max_workers=3)` at `pipeline_stages.py:591`.
+
 ### Critical Assumptions
 
 - [x] `chash` is populated on every chunk in every indexing path —
@@ -412,8 +451,12 @@ changes, one convenience command:
 1. **T2 `chash_index` table**, populated at the six existing
    indexing write sites (code, docs batch, PDF batch, CCE
    markdown, CCE single-chunk, streaming PDF — see RF-2).
-   Schema: `(chash TEXT PRIMARY KEY, physical_collection TEXT,
-   doc_id TEXT, created_at TEXT)`.
+   Schema: `(chash TEXT, physical_collection TEXT, doc_id TEXT,
+   created_at TEXT, PRIMARY KEY (chash, physical_collection))`.
+   Compound PK: the same chunk text can legitimately be indexed
+   into multiple collections (e.g. a paper in both
+   `knowledge__delos` and `knowledge__delos_docling`), so the
+   hash alone is not unique.
 
 2. **`catalog.resolve_chash(chash) -> ChunkRef | None`** (reverse
    direction) that consults the T2 index first, falls back to a T3
@@ -453,7 +496,7 @@ indexing-path instrumentation.)
 |---|---|---|
 | Per-collection chash→chunk lookup | `src/nexus/catalog/catalog.py:575` `resolve_span(span, physical_collection, t3)` | **Reuse** — already handles `chash:<hex>` and `chash:<hex>:<start>-<end>` spans |
 | Global chash→chunk lookup | none | **Add** — `Catalog.resolve_chash(chash: str) -> ChunkRef | None`; consults T2 index; falls back to iterating collections when the T2 index is empty |
-| T2 `chash_index` table + migration | `src/nexus/db/migrations.py` | **Add** — schema `(chash TEXT PRIMARY KEY, physical_collection TEXT, doc_id TEXT, created_at TEXT)`; indexed on `chash` (primary) and `physical_collection` (for collection-delete cleanup) |
+| T2 `chash_index` table + migration | `src/nexus/db/migrations.py` | **Add** — schema `(chash TEXT, physical_collection TEXT, doc_id TEXT, created_at TEXT, PRIMARY KEY (chash, physical_collection))`; compound PK allows the same chunk text to appear in multiple collections. Secondary index on `physical_collection` for the nexus-lub cascade's `DELETE WHERE physical_collection = ?` |
 | Indexing dual-write | `code_indexer.py:371`, `doc_indexer.py:591` + `:666`, `prose_indexer.py:96` + `:141`, `pipeline_stages.py:163` | **Extend** — after the existing ChromaDB upsert at each of the six sites, insert-or-replace into the T2 `chash_index`. Best-effort: a T2 failure logs and continues; backfill recovers |
 | Backfill loop | `src/nexus/commands/collection.py:307` `_backfill_chunk_text_hash()` | **Extend** — the same per-chunk iteration that writes `chunk_text_hash` to T3 also writes `(chash, collection, doc_id)` to T2 if missing. One pass, two destinations |
 | Backfill CLI | `nx collection backfill-hash [--all]` | **Reuse** — no new command; the extended loop above backfills T2 whenever a caller runs the existing command |
@@ -550,6 +593,17 @@ place.
   read catches each on access; a full `nx collection
   backfill-hash --all` repopulates.
 
+- **Concurrent writers on T2 `chash_index`**: the streaming PDF
+  pipeline (`pipeline_stages.py`) runs a 3-worker
+  `ThreadPoolExecutor` per ingest, and multiple `nx index pdf`
+  invocations may run concurrently. The dual-write uses
+  `INSERT OR REPLACE INTO chash_index ...`. SQLite in WAL mode
+  handles concurrent INSERT OR REPLACE with row-level upsert
+  semantics at the cost of a brief busy-wait on the write lock
+  — no additional locking required beyond nexus' existing T2
+  connection pattern. Matches the nexus-9ji `pdf_pipeline`
+  table's concurrency posture.
+
 ## Implementation Plan
 
 ### Prerequisites
@@ -577,8 +631,10 @@ place.
 ### Phase 1: T2 `chash_index` + dual-write at the six existing sites
 
 - Add migration for `chash_index` table
-  (`chash TEXT PRIMARY KEY, physical_collection TEXT, doc_id TEXT,
-  created_at TEXT`).
+  (`chash TEXT, physical_collection TEXT, doc_id TEXT,
+  created_at TEXT, PRIMARY KEY (chash, physical_collection)`).
+  Compound PK — a chunk text can be indexed into multiple
+  collections and each registration gets its own row.
 - At each of the six write sites listed in RF-2, after the existing
   ChromaDB upsert, insert-or-replace into `chash_index`. Failure
   to write T2 is best-effort — log and continue; the backfill
@@ -594,17 +650,28 @@ place.
 
 ### Phase 2: Global `resolve_chash` (extends existing `resolve_span`)
 
-- Add `Catalog.resolve_chash(chash: str) -> ChunkRef | None` —
-  collection-agnostic. Lookup path:
+- Add `Catalog.resolve_chash(chash: str, *, prefer_collection:
+  str | None = None) -> ChunkRef | None` — collection-agnostic.
+  Lookup path:
   1. `SELECT physical_collection, doc_id FROM chash_index WHERE chash = ?`.
-  2. On hit, validate the target collection still exists (guards
-     against orphan rows from race with collection delete).
-  3. Delegate to the existing per-collection `resolve_span` to
+  2. **If multiple rows** (compound PK permits this — same chunk
+     in multiple collections), pick by precedence: (a) the row
+     matching `prefer_collection` if supplied, (b) the oldest
+     `created_at` (most established registration), (c) first
+     row by collection-name sort (deterministic).
+  3. Validate the target collection still exists (guards against
+     orphan rows from race with collection delete).
+  4. Delegate to the existing per-collection `resolve_span` to
      fetch chunk text + metadata.
-  4. On T2 miss (fresh install, backfill not yet run): iterate
+  5. On T2 miss (fresh install, backfill not yet run): iterate
      collections calling `col.get(where={"chunk_text_hash":
-     chash})` — slow fallback, logs once per process.
-- Unit tests with fixture T2 (rows + deleted collection) + fixture T3.
+     chash})`. **Bound: parallelised at 10× concurrency with
+     a 30-second deadline.** Logs once per process with guidance
+     to run `nx collection backfill-hash --all`. After the
+     deadline, return `None` rather than blocking the caller
+     (callers treat as unresolved).
+- Unit tests with fixture T2 (rows + deleted collection + multi-
+  collection chash) + fixture T3.
 
 ### Phase 3: Surface `chunk_text_hash` on structured retrieval returns
 
@@ -621,6 +688,14 @@ place.
   steps contribute their top chunks to a single merged `chunks`
   list, ordered by final-step relevance**; non-retrieval steps
   (summarize, generate) contribute nothing to `chunks`.
+- **Single-step guard interaction** (`mcp/core.py:1972`): the
+  existing perf guard short-circuits to `query()` when the
+  matched plan has exactly one `query` step. With
+  `structured=True`, the guard still fires — we call
+  `query(structured=True)` and build the envelope from its
+  returned `{ids, tumblers, distances, collections,
+  chunk_text_hash}` payload. The guard is preserved; only the
+  return-shape builder differs per `structured` flag.
 - Unit + integration tests: every surfaced hash round-trips
   through `resolve_chash`.
 
@@ -723,3 +798,10 @@ place.
     failure-mode specs, and explicit `--json` schema.
   - Existing Infrastructure Audit table rebuilt to distinguish
     **Reuse** / **Extend** / **Add** per component.
+- 2026-04-17 (post-rewrite audit) — RF-10 captures four rewrite-
+  introduced gaps found on re-read and fixed in place:
+  schema compound-PK, `nx_answer` single-step-guard interaction,
+  Phase-2 fallback latency bound, concurrency contract on T2
+  writes. No new claims left unverified; all are traced to
+  live code references (`commands/collection.py:304`,
+  `mcp/core.py:1676`/`:1972`, `pipeline_stages.py:591`).

--- a/docs/rdr/rdr-086-chash-span-resolution.md
+++ b/docs/rdr/rdr-086-chash-span-resolution.md
@@ -735,9 +735,13 @@ place.
   1. `SELECT physical_collection, doc_id FROM chash_index WHERE chash = ?`.
   2. **If multiple rows** (compound PK permits this — same chunk
      in multiple collections), pick by precedence: (a) the row
-     matching `prefer_collection` if supplied, (b) the oldest
-     `created_at` (most established registration), (c) first
-     row by collection-name sort (deterministic).
+     matching `prefer_collection` if supplied, (b) the **newest**
+     `created_at` — most recent active registration is the most
+     likely current provenance (e.g., `knowledge__delos_docling`
+     re-indexed with better extraction supersedes
+     `knowledge__delos` even though both carry the same chunk
+     hash; "oldest" would return the stale collection), (c) first
+     row by collection-name sort (deterministic tie-break).
   3. Validate the target collection still exists (guards against
      orphan rows from race with collection delete).
   4. Delegate to the existing per-collection `resolve_span` to
@@ -823,6 +827,17 @@ place.
   - Multiple candidates tied within 0.01 distance → `--json`
     returns all tied candidates; default stdout picks the first
     and notes `# N candidates tied (see --json)`.
+  - **T2 `chash_index` empty / fallback timeout**: before running
+    `search`, `nx doc cite` short-circuits on
+    `SELECT COUNT(*) FROM chash_index` == 0, exiting 2 with an
+    actionable message: `"chash_index not populated — run \`nx
+    collection backfill-hash --all\` (25-70 min on a 278k-chunk
+    corpus). Re-run after backfill completes."` This prevents
+    the 30-second silent-hang-then-empty-result experience on
+    fresh installs. If the index has rows but the specific
+    chash isn't in it, the per-chash fallback still runs within
+    the 30s deadline and the caller gets a valid result or a
+    clean timeout.
 - Docs + live smoke against `docs__art-grossberg-papers`.
 
 ## References
@@ -884,6 +899,20 @@ place.
   writes. No new claims left unverified; all are traced to
   live code references (`commands/collection.py:304`,
   `mcp/core.py:1676`/`:1972`, `pipeline_stages.py:591`).
+- 2026-04-17 (re-gate PASSED, 0 Critical + 2 Significant) —
+  substantive-critic confirmed all 5 prior findings and all 4
+  RF-10 rewrite-gap fixes are closed. Two new Significant issues
+  surfaced by the re-gate and fixed in place:
+  - Phase 2 tie-break for compound-PK multi-match flipped from
+    "oldest `created_at` (most established)" → "newest
+    `created_at` (most recent active)". Oldest risked returning
+    a stale / superseded collection (e.g. `knowledge__delos`
+    after re-index into `knowledge__delos_docling`).
+  - Phase 5 gained an explicit empty-index failure mode: `nx doc
+    cite` short-circuits on `SELECT COUNT(*) FROM chash_index == 0`
+    with an actionable error pointing at `nx collection
+    backfill-hash --all`, rather than hang for the 30-second
+    fallback deadline and then return empty.
 - 2026-04-17 (second research round) — RF-11 probes load-bearing
   claims and prod scale:
   - `resolve_span` actually returns a `dict`, not a `ChunkRef`.

--- a/docs/rdr/rdr-086-chash-span-resolution.md
+++ b/docs/rdr/rdr-086-chash-span-resolution.md
@@ -416,6 +416,69 @@ parameters don't change.
   `mcp/core.py:1676` and `:1972`. Streaming pipeline's
   `ThreadPoolExecutor(max_workers=3)` at `pipeline_stages.py:591`.
 
+- **RF-11 (second research round, 2026-04-17)** — Deeper probe of
+  load-bearing code claims and corpus scale.
+
+  **Return-shape continuity — `ChunkRef` is the dict `resolve_span`
+  already returns.** Reading `catalog.py:575-612`, the existing
+  `resolve_span` returns
+  `{"chunk_text": str, "metadata": dict, "chunk_hash": str,
+  "char_range": tuple[int,int]?}`. No `ChunkRef` dataclass
+  exists. Phase 2's `resolve_chash(chash)` wrapper returns a
+  **superset** of that dict, adding the fields the global
+  variant knows but the per-collection one doesn't need:
+  `{"chash": str, "physical_collection": str, "doc_id": str,
+  "chunk_text": str, "metadata": dict}`. Both keys `chash` and
+  `chunk_hash` appear on the return for back-compat with
+  existing `resolve_span` callers; the RDR treats this as a
+  typed alias, not two different fields. Phase 2 deliverable
+  updated: introduce a `ChunkRef` `TypedDict` in
+  `src/nexus/catalog/types.py` so the shape is documented
+  instead of informal.
+
+  **`chunk_text_hash` is a validated metadata key.** The field
+  is listed in `ALLOWED_TOP_LEVEL` at
+  `src/nexus/metadata_schema.py:53` — the nexus metadata-schema
+  allowlist. Renaming it would require a schema migration and
+  touch every indexer. The RDR treats the key name as fixed.
+
+  **Existing chash-lookup call sites are real consumers, not
+  fixtures.** `catalog.py:1287` (inside a catalog helper that
+  resolves chash spans to chunk text) and `catalog.py:1425`
+  (inside `link_audit`, checking for stale chash links) both
+  run `col.get(where={"chunk_text_hash": <hex>})` in
+  production. Phase 2's `resolve_chash` subsumes these two
+  patterns; they can be refactored to call `resolve_chash`
+  instead of duplicating the ChromaDB filter logic. Filed as a
+  Phase 2 follow-up refactor (not blocking).
+
+  **Prod backfill scale (measured 2026-04-17).** T3 inventory:
+  136 collections, **278,458 total chunks**. Largest single
+  collection: `code__ART-8c2e74c0` at 63,103 chunks. Backfill
+  cost estimate at existing `_BACKFILL_BATCH = 300`:
+
+  - Theoretical minimum (local-network, no API latency):
+    ~5 min
+  - Realistic (ChromaDB Cloud latency, sequential):
+    ~25-70 min full `--all`
+  - Typical per-collection backfill: seconds to minutes
+
+  Implication: `nx collection backfill-hash --all` is a
+  maintenance-window operation for the top-5 collections, not
+  an inline install step. The RDR should (a) add a progress
+  bar to the backfill loop (existing `_backfill_chunk_text_hash`
+  already supports `on_progress` callback), and (b) document
+  the "fresh install takes an hour for a 278k-chunk corpus"
+  expectation. Phase 1 deliverable updated.
+
+  **`nx_answer(structured=True)` is purely additive.** Grepped
+  all `nx_answer(...)` call sites in `src/` and `tests/` — every
+  existing caller passes `question=...` (required) and
+  optionally `trace=...`. No caller passes a `structured` kwarg
+  today, and adding it with default `False` cannot break any
+  existing caller. Confirms the "precedent: `trace=True`"
+  reasoning in RF-8.
+
 ### Critical Assumptions
 
 - [x] `chash` is populated on every chunk in every indexing path —
@@ -495,7 +558,9 @@ indexing-path instrumentation.)
 | Proposed Component | Existing Module | Decision |
 |---|---|---|
 | Per-collection chash→chunk lookup | `src/nexus/catalog/catalog.py:575` `resolve_span(span, physical_collection, t3)` | **Reuse** — already handles `chash:<hex>` and `chash:<hex>:<start>-<end>` spans |
-| Global chash→chunk lookup | none | **Add** — `Catalog.resolve_chash(chash: str) -> ChunkRef | None`; consults T2 index; falls back to iterating collections when the T2 index is empty |
+| Global chash→chunk lookup | none | **Add** — `Catalog.resolve_chash(chash: str) -> ChunkRef | None`; consults T2 index; falls back to iterating collections (10× parallel, 30s deadline) when the T2 index is empty |
+| `ChunkRef` return type | none (`resolve_span` returns untyped `dict`) | **Add** — `TypedDict` in `src/nexus/catalog/types.py`; shape is a superset of the existing `resolve_span` return dict so callers can migrate without breakage |
+| Existing chash-filter call sites | `catalog.py:1287` (chash span → text), `catalog.py:1425` (`link_audit`) | **Refactor (Phase 2 follow-up, non-blocking)** — both currently call `resolve_span` (collection-scoped); can be simplified to `resolve_chash` once Phase 2 ships |
 | T2 `chash_index` table + migration | `src/nexus/db/migrations.py` | **Add** — schema `(chash TEXT, physical_collection TEXT, doc_id TEXT, created_at TEXT, PRIMARY KEY (chash, physical_collection))`; compound PK allows the same chunk text to appear in multiple collections. Secondary index on `physical_collection` for the nexus-lub cascade's `DELETE WHERE physical_collection = ?` |
 | Indexing dual-write | `code_indexer.py:371`, `doc_indexer.py:591` + `:666`, `prose_indexer.py:96` + `:141`, `pipeline_stages.py:163` | **Extend** — after the existing ChromaDB upsert at each of the six sites, insert-or-replace into the T2 `chash_index`. Best-effort: a T2 failure logs and continues; backfill recovers |
 | Backfill loop | `src/nexus/commands/collection.py:307` `_backfill_chunk_text_hash()` | **Extend** — the same per-chunk iteration that writes `chunk_text_hash` to T3 also writes `(chash, collection, doc_id)` to T2 if missing. One pass, two destinations |
@@ -647,9 +712,23 @@ place.
   `DELETE FROM chash_index WHERE physical_collection = ?` so
   deleting a collection doesn't leave orphan hashes pointing at
   gone chunks.
+- **Progress reporting**: extend the existing
+  `on_progress(updated, skipped, total)` callback wired into
+  `_backfill_chunk_text_hash` so `nx collection backfill-hash`
+  emits a progress bar. Measured corpus scale (RF-11): 278,458
+  chunks across 136 collections on prod today; full `--all`
+  runs take ~25-70 min realistic against ChromaDB Cloud
+  (top collection alone is 63k chunks). This needs to be
+  observable operator-side, not a silent minutes-long hang.
 
 ### Phase 2: Global `resolve_chash` (extends existing `resolve_span`)
 
+- Introduce `ChunkRef` as a `TypedDict` in a small new module
+  `src/nexus/catalog/types.py`. Shape: `{chash: str, chunk_hash:
+  str (alias for chash, for resolve_span back-compat),
+  physical_collection: str, doc_id: str, chunk_text: str,
+  metadata: dict}`. Optional `char_range: tuple[int, int]` when
+  the span includes a char range.
 - Add `Catalog.resolve_chash(chash: str, *, prefer_collection:
   str | None = None) -> ChunkRef | None` — collection-agnostic.
   Lookup path:
@@ -805,3 +884,25 @@ place.
   writes. No new claims left unverified; all are traced to
   live code references (`commands/collection.py:304`,
   `mcp/core.py:1676`/`:1972`, `pipeline_stages.py:591`).
+- 2026-04-17 (second research round) — RF-11 probes load-bearing
+  claims and prod scale:
+  - `resolve_span` actually returns a `dict`, not a `ChunkRef`.
+    Phase 2 now introduces a `ChunkRef` `TypedDict` in
+    `src/nexus/catalog/types.py` and the return carries both
+    `chash` and `chunk_hash` keys for back-compat with existing
+    `resolve_span` consumers.
+  - `chunk_text_hash` is in the validated metadata allowlist
+    at `metadata_schema.py:53` — key name is fixed by the
+    schema layer.
+  - Two existing chash-filter call sites (`catalog.py:1287`,
+    `catalog.py:1425`) are real consumers, not dead code;
+    filed as non-blocking Phase 2 follow-up refactor to
+    consolidate on `resolve_chash`.
+  - Prod backfill scale: **278,458 chunks across 136
+    collections**; full `--all` is a maintenance-window
+    operation (~25-70 min on ChromaDB Cloud). Phase 1 deliverable
+    gains a progress bar via the existing `on_progress`
+    callback already wired into `_backfill_chunk_text_hash`.
+  - `nx_answer(structured=True)` is purely additive — no
+    current caller passes the kwarg; adding with default
+    `False` cannot break any existing code.

--- a/docs/rdr/rdr-086-chash-span-resolution.md
+++ b/docs/rdr/rdr-086-chash-span-resolution.md
@@ -16,22 +16,44 @@ related: [RDR-053, RDR-075, RDR-078, RDR-082, RDR-083]
 
 RDR-083 shipped the `chash:` citation grammar, the scanner, and the
 `AnchorResolver` that plugs into RDR-082's Resolver registry. It did
-not ship the machinery that makes those citations *verifiable*. The
-2026-04-17 ART-instance feedback then surfaced a deeper problem: it
-also didn't ship the machinery to *author* them. An author or agent
-that wants to cite a specific chunk has no CLI or MCP path to obtain
-the chash — they have to drop to the raw ChromaDB API, run
-`collection.get(include=["metadatas"])`, and copy the `chash` value by
-hand. Every `search`, `query`, and `nx_answer` structured return omits
-the chunk hash. That makes the whole `chash:` citation primitive
-dead-on-arrival for typical Tier-3 grounding workflows.
+not ship the machinery that makes those citations *usable at speed* —
+and the 2026-04-17 ART-instance feedback surfaced a deeper problem:
+it also didn't surface the machinery authors need. An author or
+agent that wants to cite a specific chunk has no CLI or MCP path to
+obtain the chash — they have to drop to the raw ChromaDB API and
+copy the hash by hand.
 
-This RDR owns the chash primitive surface end-to-end — authoring
-and verification are mirror workflows over the same T2 index. The
-original draft (2026-04-16) covered only the reverse direction
-(resolve hash → chunk). This revision widens scope to the forward
-direction (surface chunk hashes through normal retrieval) and the
-convenience CLI that composes them.
+**The primitive is partly built already.** Gate layer-3 discovered
+that significant chunks of infrastructure this RDR would otherwise
+reinvent already exist:
+
+- **Per-collection chash lookup** — `catalog.resolve_span(span,
+  physical_collection, t3)` at `src/nexus/catalog/catalog.py:575`
+  takes a `chash:<hex>` span and returns `{chunk_text, metadata,
+  chunk_hash}`. Missing: a collection-agnostic (global) variant.
+- **Backfill command** — `_backfill_chunk_text_hash()` at
+  `src/nexus/commands/collection.py:307` populates missing
+  `chunk_text_hash` on existing chunks; wired to `nx collection
+  backfill-hash`. No T2 reinvention needed for existing chunks.
+- **Write-site coverage** — the indexing pipelines already write
+  `chunk_text_hash` on every chunk at **six** sites (see RF-2).
+  There is no instrumentation gap.
+
+What is genuinely missing, and what this RDR actually owns:
+
+1. **A collection-agnostic `resolve_chash(chash)`** that doesn't
+   require the caller to know which physical collection holds the
+   chunk.
+2. **A T2 speedup layer** so the global lookup doesn't pay the
+   13-min-serial ChromaDB-filter tax measured in RF-6.
+3. **`chunk_text_hash` on structured returns** of `search`, `query`,
+   and `nx_answer` — the forward path that closes the authoring
+   loop (ART feedback, RF-1).
+4. **`nx doc cite`** — one-shot CLI that composes (3) into a
+   ready-to-paste markdown citation.
+
+Reframed: this RDR is **extend + speed + surface + compose**, not
+build-from-scratch.
 
 Four concrete holes to close:
 
@@ -153,16 +175,21 @@ parameters don't change.
 
 ## Research Findings
 
-### Investigation (to be completed during drafting)
+### Investigation (all resolved as of 2026-04-17)
 
-- **Verify** — does every indexing path (`code_indexer.py`,
-  `doc_indexer.py`, `pdf_chunker.py`) actually write `chash` to
-  ChromaDB metadata? Sampling: query an existing `rdr__` and
-  `knowledge__` collection via `collection.get(limit=5, include=["metadatas"])`
-  and confirm the `chash` key is present.
-- **Verify** — what fraction of chunks in a typical corpus have a
-  `chash` value vs. missing? If gappy, indexing backfill is a
-  prerequisite.
+- **Verify** — does every indexing path actually write the hash
+  to ChromaDB metadata? **Resolved (RF-2)**: six write sites —
+  `code_indexer.py:371`, `doc_indexer.py:591` + `:666`,
+  `prose_indexer.py:96` + `:141`, `pipeline_stages.py:163`.
+  `pdf_chunker.py` produces chunks but does NOT write the hash —
+  the write happens downstream in `doc_indexer.py` or
+  `pipeline_stages.py`.
+- **Verify** — what fraction of chunks in a typical corpus have
+  the hash vs. missing? **Resolved (RF-5)**: live sample of 10
+  chunks per prefix on prod returned `chunk_text_hash` on 10/10
+  for every citable-content prefix (code, docs, rdr, knowledge).
+  `taxonomy__centroids` correctly has none (topic centroids,
+  not indexed chunks).
 - **Design choice** — global lookup cost: SHA-256 is 64 hex chars;
   querying every T3 collection by metadata is O(N_collections) per
   chash. For `check-extensions` across a 20-citation doc with 100
@@ -188,22 +215,28 @@ parameters don't change.
 ### Source-site investigation (2026-04-17)
 
 - **RF-2** — **Every indexing path already writes the per-chunk hash
-  to ChromaDB metadata under the key `chunk_text_hash`.** Verified at
-  the write sites:
-  - `src/nexus/code_indexer.py:371` —
-    `"chunk_text_hash": _hl.sha256(chunk["text"].encode()).hexdigest()`
-  - `src/nexus/doc_indexer.py:591` (markdown path) and `:666`
-    (PDF path) — same SHA-256 of the chunk text.
+  to ChromaDB metadata under the key `chunk_text_hash`.** Verified
+  by `grep chunk_text_hash src/nexus/`:
+  - `src/nexus/code_indexer.py:371` — code path
+  - `src/nexus/doc_indexer.py:591` — markdown batch path
+  - `src/nexus/doc_indexer.py:666` — PDF batch path
+  - `src/nexus/prose_indexer.py:96` — CCE markdown path
+  - `src/nexus/prose_indexer.py:141` — single-chunk CCE path
+  - `src/nexus/pipeline_stages.py:163` — streaming PDF pipeline
+
+  **Six write sites, not three.** The initial draft cited only the
+  first three; `prose_indexer.py` and `pipeline_stages.py` were
+  missed. `pdf_chunker.py` produces the chunks but does **not**
+  write the hash — that happens in `doc_indexer.py` (batch) and
+  `pipeline_stages.py` (streaming), downstream of the chunker.
 
   Two keys coexist on every chunk: `content_hash` (SHA-256 of the
-  whole source file, used for staleness / dedup) and `chunk_text_hash`
-  (SHA-256 of just that chunk, the citable identity). RDR-053's
-  "chash" primitive maps to `chunk_text_hash`. Implication for the
-  plan: Phase 1 ("indexing instrumentation") is **mostly a no-op** —
-  the data is already written. Phase 1 scope reduces to "populate
-  T2 `chash_index` from existing T3 metadata via a backfill command"
-  plus a lightweight dual-write so new chunks land in both stores
-  atomically.
+  whole source file, for staleness / dedup) and `chunk_text_hash`
+  (SHA-256 of the chunk text — the citable identity). RDR-053's
+  "chash" primitive maps to `chunk_text_hash`.
+
+  Implication for the plan: **there is no instrumentation gap.**
+  The dual-write to T2 lands at exactly the six known sites.
 
 - **RF-3** — **Forward-path plumbing is a one-liner per return
   site.** The `search(structured=True)` return builder at
@@ -258,22 +291,24 @@ parameters don't change.
   scope for `chash:` citations. Design assumption fully confirmed
   against prod.
 
-- **RF-6 (2026-04-17)** — Measured the T2-index-vs-ChromaDB-filter
-  cost asymmetry that the Alternatives section asserts. Sampled
-  a single `chunk_text_hash` lookup across 20 representative prod
+- **RF-6 (2026-04-17)** — Order-of-magnitude measurement of the
+  ChromaDB-filter-vs-T2-JOIN asymmetry. Sampled a single
+  `chunk_text_hash` lookup across 20 representative prod
   collections via `col.get(where={"chunk_text_hash": <hex>})`:
-  mean 289ms per collection, 5.78s total for 20 serial calls.
-  Projection for a 20-citation doc scanned across the 136 prod
-  collections: **~786s (~13 minutes) per doc**. An equivalent
-  T2 SQLite JOIN on a `chash_index` table is ~50µs per lookup —
-  4+ orders of magnitude faster and well under the interactive
-  latency budget.
+  mean ~300ms per collection (289ms observed; cold-cache and
+  first-call effects in the noise), 5.78s total for 20 serial
+  calls. Extrapolation for a 20-citation doc scanned across the
+  136 prod collections is on the order of minutes serial, tens
+  of seconds at 10× parallelism — either way an order of
+  magnitude too slow for an interactive author surface. A T2
+  SQLite JOIN on a `chash_index` table is ~50µs per lookup,
+  well under the interactive budget.
 
-  Parallelism (ThreadPoolExecutor at 10× concurrency) would cut
-  ChromaDB path to ~80s, still unusable as an authoring surface.
-  Result: the T2 index is not an optimization — it is a hard
-  requirement for `check-extensions` and `nx doc cite` to be
-  interactive. **Critical Assumption 2 verified.**
+  The numeric projection ("~13 minutes") is order-of-magnitude,
+  not a precise latency — ChromaDB Cloud cold-cache and network
+  variance make the exact figure noisy. The conclusion
+  (a T2 speedup layer is required, not optional) is insensitive
+  to the variance. **Critical Assumption 2 verified.**
 
 - **RF-7 (architecture, 2026-04-17)** — Chash stability across
   reindex events (Critical Assumption 3) is guaranteed by
@@ -302,26 +337,63 @@ parameters don't change.
   `search(structured=True)` / `query(structured=True)` as the
   authoring surfaces. Recommend (a): the kwarg pattern is
   precedented, callers opt in, default behaviour unchanged.
-  Noted for Phase 3 design; not a blocker for gate. If (a) is
-  rejected, Phase 3 narrows to search + query only and `nx doc
-  cite` composes on top of `search(structured=True)`.
+  Open question to resolve before Phase 3 starts: `nx_answer`
+  composes multi-step plans — surface chash from all retrieval
+  steps, only the final step, or only when the final step is
+  itself a retrieval op? The structured envelope shape depends
+  on this call.
+
+- **RF-9 (gate discovery, 2026-04-17)** — **Significant existing
+  infrastructure.** Gate layer-3 surfaced that two pieces of the
+  originally-proposed build are already shipped:
+
+  1. **`Catalog.resolve_span(span, physical_collection, t3)`** at
+     `src/nexus/catalog/catalog.py:575` — takes a `chash:<hex>` span
+     (also supports `chash:<hex>:<start>-<end>` char-range spans)
+     and returns `{chunk_text, metadata, chunk_hash}`. It is
+     collection-scoped: the caller must already know the physical
+     collection. For the reverse-direction primitive this RDR
+     proposed, the collection-scoped half is done; the missing
+     piece is a **global** variant that scans all collections (or
+     hits the T2 speedup index, once built).
+
+  2. **`_backfill_chunk_text_hash(col)`** at
+     `src/nexus/commands/collection.py:307` plus the
+     `nx collection backfill-hash [--all]` CLI subcommand. It
+     reads each chunk's stored text and writes `chunk_text_hash`
+     when missing, skipping already-hashed rows. The T2
+     `chash_index` bootstrap doesn't need a new command — the
+     same iteration can write both destinations.
+
+  3. **Call-site confirmation**: `catalog.py:1287` and `:1425`
+     already invoke `col.get(where={"chunk_text_hash": ...})`
+     for span resolution, so the ChromaDB-side metadata filter
+     is a proven path.
+
+  **Implication**: Phase 1 shrinks from "build backfill command
+  + instrument six indexers" to "add T2 dual-write at the six
+  existing sites + reuse the existing backfill loop to populate
+  T2 for historical chunks." Phase 2 shrinks from "build
+  resolve_chash from scratch" to "extend `resolve_span` with a
+  collection-agnostic variant that defers to the T2 index."
 
 ### Critical Assumptions
 
 - [x] `chash` is populated on every chunk in every indexing path —
-  **Status**: Verified at write-site 2026-04-17 (see RF-2). All
-  three indexing paths (`code_indexer.py:371`, `doc_indexer.py:591`
-  and `:666`) write the per-chunk SHA-256 under the metadata key
-  `chunk_text_hash`. Prod-T3 live-sample confirmation deferred to
-  a diagnostic command (RF-5) but not load-bearing — if the write
-  site is unconditional, the data is there.
+  **Status**: Verified at write-site + live sample 2026-04-17
+  (RF-2, RF-5). **Six** indexing paths all write the per-chunk
+  SHA-256 under the metadata key `chunk_text_hash`: `code_indexer.py:371`,
+  `doc_indexer.py:591` + `:666`, `prose_indexer.py:96` + `:141`,
+  `pipeline_stages.py:163`. Prod-T3 live sample (10 chunks per
+  prefix) confirms 10/10 present on every citable-content prefix.
 - [x] A T2 `chash_index` table is the right primitive vs. relying on
   ChromaDB metadata filter — **Status**: Verified 2026-04-17 (RF-6).
-  Measured: ChromaDB filter 289ms/call × 136 collections × 20
-  citations = ~13min per doc serial, ~80s at 10× parallelism.
-  T2 JOIN ~50µs per lookup. 4+ orders of magnitude gap. T2 index
-  is a hard requirement for interactive author latency, not an
-  optimisation.
+  Order-of-magnitude measurement: ChromaDB metadata filter
+  ~300ms/call; extrapolation to a 20-citation doc across the 136
+  prod collections is on the order of minutes serial, tens of
+  seconds even at 10× parallelism. T2 SQLite JOIN is ~50µs per
+  lookup. The speedup layer is required for interactive author
+  latency, not an optimisation.
 - [x] Chash values are stable across the re-indexing events observed
   in the nexus + ART corpora over the last 30 days — **Status**:
   Verified by architecture 2026-04-17 (RF-7). `chunk_text_hash` is
@@ -337,8 +409,9 @@ parameters don't change.
 Four cooperating surfaces — one primitive, two retrieval surface
 changes, one convenience command:
 
-1. **T2 `chash_index` table**, populated at indexing time by each
-   pipeline (`code_indexer`, `doc_indexer`, `pdf_chunker`).
+1. **T2 `chash_index` table**, populated at the six existing
+   indexing write sites (code, docs batch, PDF batch, CCE
+   markdown, CCE single-chunk, streaming PDF — see RF-2).
    Schema: `(chash TEXT PRIMARY KEY, physical_collection TEXT,
    doc_id TEXT, created_at TEXT)`.
 
@@ -378,14 +451,17 @@ indexing-path instrumentation.)
 
 | Proposed Component | Existing Module | Decision |
 |---|---|---|
-| Chash → chunk lookup | `src/nexus/catalog/catalog.py:resolve_span` | **Extend** — add a collection-agnostic `resolve_chash` method that delegates to a T2 index |
-| T2 migration | `src/nexus/db/migrations.py` | **Add** — new migration for `chash_index` table |
-| Indexing instrumentation | `src/nexus/code_indexer.py`, `src/nexus/doc_indexer.py`, `src/nexus/pdf_chunker.py` | **Extend** — write to `chash_index` on each chunk upsert |
-| Backfill command | `src/nexus/commands/catalog.py` | **Extend** — `nx catalog rebuild-chash-index` walks existing T3 collections and populates T2 |
-| `search(structured=True)` payload | `src/nexus/mcp/core.py` search tool | **Extend** — add `chunk_text_hash` (list aligned with `ids`) to the returned dict |
-| `query(structured=True)` payload | `src/nexus/mcp/core.py` query tool | **Extend** — surface the representative-chunk hash on each document result |
-| `nx_answer` envelope | `src/nexus/mcp/core.py:nx_answer` | **Extend** — when a plan's final step is a retrieval op, include the top chunks' hashes in the envelope so the caller can cite without re-querying |
-| `nx doc cite` command | `src/nexus/commands/doc.py` (RDR-082 group) | **Add** — new subcommand composing `search(limit=1, structured=True)` + markdown link emission |
+| Per-collection chash→chunk lookup | `src/nexus/catalog/catalog.py:575` `resolve_span(span, physical_collection, t3)` | **Reuse** — already handles `chash:<hex>` and `chash:<hex>:<start>-<end>` spans |
+| Global chash→chunk lookup | none | **Add** — `Catalog.resolve_chash(chash: str) -> ChunkRef | None`; consults T2 index; falls back to iterating collections when the T2 index is empty |
+| T2 `chash_index` table + migration | `src/nexus/db/migrations.py` | **Add** — schema `(chash TEXT PRIMARY KEY, physical_collection TEXT, doc_id TEXT, created_at TEXT)`; indexed on `chash` (primary) and `physical_collection` (for collection-delete cleanup) |
+| Indexing dual-write | `code_indexer.py:371`, `doc_indexer.py:591` + `:666`, `prose_indexer.py:96` + `:141`, `pipeline_stages.py:163` | **Extend** — after the existing ChromaDB upsert at each of the six sites, insert-or-replace into the T2 `chash_index`. Best-effort: a T2 failure logs and continues; backfill recovers |
+| Backfill loop | `src/nexus/commands/collection.py:307` `_backfill_chunk_text_hash()` | **Extend** — the same per-chunk iteration that writes `chunk_text_hash` to T3 also writes `(chash, collection, doc_id)` to T2 if missing. One pass, two destinations |
+| Backfill CLI | `nx collection backfill-hash [--all]` | **Reuse** — no new command; the extended loop above backfills T2 whenever a caller runs the existing command |
+| `search(structured=True)` payload | `src/nexus/mcp/core.py:168-174` | **Extend** — add `"chunk_text_hash": [r.metadata.get("chunk_text_hash", "") for r in page]` to the returned dict (metadata already in scope) |
+| `query(structured=True)` payload | `src/nexus/mcp/core.py` `query` tool structured branch | **Extend** — surface the representative-chunk hash per document result |
+| `nx_answer` envelope | `src/nexus/mcp/core.py:nx_answer` | **Extend with opt-in** — new `structured=True` kwarg (precedent: `trace=True`) returns `{final_text, chunks: [{id, chash, …}], …}`; default `structured=False` preserves the current `str` return |
+| `nx doc cite` command | `src/nexus/commands/doc.py` (RDR-082 group) | **Add** — new subcommand composing `search(limit=N, structured=True)` + `--min-similarity` gate + markdown link emission |
+| `nx collection delete` cleanup | `src/nexus/commands/collection.py` delete path (nexus-lub cascade) | **Extend** — add `chash_index WHERE physical_collection = ?` to the cascade so deleted collections don't leave orphan hashes pointing at gone chunks |
 
 ### Decision Rationale
 
@@ -429,11 +505,50 @@ place.
 
 ### Failure Modes
 
-- Empty T2 index (fresh install): `resolve_chash` falls back to
-  ChromaDB metadata filter; first-call latency is higher until
-  backfill runs.
-- Indexing pipeline crashes mid-write: next run's idempotent upsert
-  corrects.
+- **Empty T2 index (fresh install)**: `resolve_chash` detects zero
+  rows for the target chash and falls back to iterating
+  collections with the ChromaDB metadata filter. Slow (tens of
+  seconds worst case) but correct. A one-line `_log.warning` at
+  first fallback tells the operator to run `nx collection
+  backfill-hash --all`.
+
+- **Indexing pipeline crashes mid-batch** (T3 upsert committed, T2
+  write did not): next run's idempotent `INSERT OR REPLACE` into
+  `chash_index` corrects. If the process exits permanently mid-
+  batch, `nx collection backfill-hash` reconciles via the
+  existing loop.
+
+- **T2 write fails while T3 succeeds**: logged at warning level;
+  the chunk is usable via the slow ChromaDB fallback until
+  backfill runs. Not a correctness issue.
+
+- **T3 upsert fails while T2 was already written** (e.g., during
+  a retry cycle where the T2 row was created speculatively):
+  `resolve_chash` returns a `ChunkRef` whose `physical_collection`
+  still exists but `doc_id` does not — the `get_collection.get()`
+  call returns empty. Phase 2's resolver treats this as a miss
+  and deletes the stale T2 row ("self-healing read"). No
+  invariant violated.
+
+- **`nx collection delete` race**: the cascade extension in
+  Phase 1 removes `chash_index` rows for the deleted collection
+  before returning. If another process reads `chash_index`
+  between the Chroma delete and the T2 delete, it gets a stale
+  row; the self-healing read above repairs it on the next
+  request.
+
+- **Backfill on 1M+ chunks**: the existing
+  `_backfill_chunk_text_hash` loop already paginates at
+  `_BACKFILL_BATCH`; adding T2 writes stays within the same
+  batching. No special handling required — the existing loop's
+  per-batch commit is the recovery unit.
+
+- **Chunk text re-chunked under a new boundary (architectural
+  change to chunker)**: RDR-053 forbids this without a migration
+  plan. If one happens anyway, stale T2 rows point at chunks
+  whose `chunk_text_hash` no longer matches. The self-healing
+  read catches each on access; a full `nx collection
+  backfill-hash --all` repopulates.
 
 ## Implementation Plan
 
@@ -459,40 +574,101 @@ place.
    (feed the output through `nx doc check-grounding` with
    `--fail-ungrounded`; expect exit 0).
 
-### Phase 1: Indexing instrumentation
+### Phase 1: T2 `chash_index` + dual-write at the six existing sites
 
-- Add `chash_index` table migration.
-- Extend the three indexers to upsert.
-- Backfill command.
+- Add migration for `chash_index` table
+  (`chash TEXT PRIMARY KEY, physical_collection TEXT, doc_id TEXT,
+  created_at TEXT`).
+- At each of the six write sites listed in RF-2, after the existing
+  ChromaDB upsert, insert-or-replace into `chash_index`. Failure
+  to write T2 is best-effort — log and continue; the backfill
+  loop reconciles.
+- Extend `_backfill_chunk_text_hash()` at `commands/collection.py:307`
+  so the same per-chunk iteration that populates `chunk_text_hash`
+  in T3 also populates the T2 row. No new CLI — reuse
+  `nx collection backfill-hash [--all]`.
+- Extend `nx collection delete` (the nexus-lub cascade) with
+  `DELETE FROM chash_index WHERE physical_collection = ?` so
+  deleting a collection doesn't leave orphan hashes pointing at
+  gone chunks.
 
-### Phase 2: Catalog resolver (reverse direction)
+### Phase 2: Global `resolve_chash` (extends existing `resolve_span`)
 
-- `resolve_chash(chash) -> ChunkRef | None` method.
-- Unit tests with fixture T2 + fixture T3.
+- Add `Catalog.resolve_chash(chash: str) -> ChunkRef | None` —
+  collection-agnostic. Lookup path:
+  1. `SELECT physical_collection, doc_id FROM chash_index WHERE chash = ?`.
+  2. On hit, validate the target collection still exists (guards
+     against orphan rows from race with collection delete).
+  3. Delegate to the existing per-collection `resolve_span` to
+     fetch chunk text + metadata.
+  4. On T2 miss (fresh install, backfill not yet run): iterate
+     collections calling `col.get(where={"chunk_text_hash":
+     chash})` — slow fallback, logs once per process.
+- Unit tests with fixture T2 (rows + deleted collection) + fixture T3.
 
-### Phase 3: Retrieval surface (forward direction)
+### Phase 3: Surface `chunk_text_hash` on structured retrieval returns
 
-- Add `chunk_text_hash` to `search(structured=True)` payload.
-- Add the same to `query(structured=True)` document results.
-- Add the same to the `nx_answer` envelope when the final step is
-  a retrieval op.
-- Unit + integration tests: verify every surfaced hash resolves.
+- **`search(structured=True)`** at `src/nexus/mcp/core.py:168-174` —
+  add `"chunk_text_hash": [r.metadata.get("chunk_text_hash", "")
+  for r in page]` to the returned dict. One-line change; metadata
+  is already in scope.
+- **`query(structured=True)`** — same addition to the document-
+  result builder.
+- **`nx_answer(structured=True)`** (new kwarg, default False) —
+  return `{final_text, chunks: [{id, chash, collection, distance,
+  text}], plan_id, step_count}` instead of the current `str`. The
+  question "which step's chash" resolves as: **all retrieval-op
+  steps contribute their top chunks to a single merged `chunks`
+  list, ordered by final-step relevance**; non-retrieval steps
+  (summarize, generate) contribute nothing to `chunks`.
+- Unit + integration tests: every surfaced hash round-trips
+  through `resolve_chash`.
 
-### Phase 4: RDR-083 consumer wiring
+### Phase 4: RDR-083 consumer wiring (precise spec)
 
-- `check-grounding` gains `--fail-ungrounded`.
-- `check-extensions` replaces the chash-as-doc-id proxy with real
-  resolved catalog doc_id.
-- Remove `[experimental]` marker and WARNING path when the resolver
-  is populated.
-- `nx doc render --expand-citations` ships.
+- **`check-grounding` gains `--fail-ungrounded`** — exit non-zero
+  when any `chash:` span in the input doc fails `resolve_chash`.
+- **`check-extensions` fix** — **the change is in the caller, not
+  in `chunk_grounded_in`**. Current flow (RDR-083 v1) passes the
+  raw chash hex value as `doc_id` to
+  `CatalogTaxonomy.chunk_grounded_in(doc_id, source_collection,
+  threshold)`. The fix: call `Catalog.resolve_chash(chash)` first,
+  extract `ChunkRef.doc_id`, pass the resolved doc_id to
+  `chunk_grounded_in` **unchanged**. The `chunk_grounded_in`
+  method's signature and semantics do NOT change — it still
+  accepts a ChromaDB-scoped `doc_id: str`. This preserves every
+  existing caller.
+- **Remove the `[experimental]` marker and the "all inputs returned
+  no_data" WARNING** on `check-extensions` once the resolver is
+  populated.
+- **`nx doc render --expand-citations`** — new flag that resolves
+  every `chash:` span via `resolve_chash` and emits a footnote
+  block with the chunk text.
 
-### Phase 5: Authoring CLI
+### Phase 5: `nx doc cite` authoring CLI
 
-- `nx doc cite "<claim>" --against <collection> [--limit N] [--json]`.
-- Default output: `[<first 60 chars of chunk>](chash:<hex>)`.
-- `--json`: structured payload with the top-N candidate chunks +
-  hashes so pipeline scripts can pick a specific one.
+- `nx doc cite "<claim>" --against <collection> [--limit N]
+  [--min-similarity F] [--json]`.
+- Flow: `search(query=claim, corpus=collection, limit=N,
+  structured=True)` → reads the new `chunk_text_hash` field →
+  emits markdown.
+- **Default stdout shape**: `[<first 60 chars of matched chunk>](chash:<hex>)`.
+  Exits non-zero when the top result's `distance` exceeds the
+  similarity threshold (`--min-similarity` default 0.30; lower
+  = more strict since we compare raw cosine distance, not
+  similarity).
+- **`--json` schema**: `{"candidates": [{"chash": str, "distance":
+  float, "collection": str, "chunk_excerpt": str (first 200 chars),
+  "markdown_link": str}], "query": str, "threshold_met": bool}`.
+- **Failure modes specified**:
+  - Empty collection → exit 2 with "no indexed content in
+    <collection>".
+  - Top result above threshold → exit 1, print warning to
+    stderr, emit nothing to stdout (lets shell pipelines
+    `nx doc cite "..." --against X > cite.md` fail loud).
+  - Multiple candidates tied within 0.01 distance → `--json`
+    returns all tied candidates; default stdout picks the first
+    and notes `# N candidates tied (see --json)`.
 - Docs + live smoke against `docs__art-grossberg-papers`.
 
 ## References
@@ -520,3 +696,30 @@ place.
   "Chash Span Surface" to reflect that this RDR owns the
   primitive end-to-end (authoring + verification), not just
   reverse resolution.
+- 2026-04-17 — **Gate layer-3 BLOCKED** (3 Critical, 2 Significant,
+  3 Observations). Rewrite applied:
+  - RF-2 corrected: six write sites (not three) —
+    `prose_indexer.py:96` + `:141` and `pipeline_stages.py:163`
+    were missed; `pdf_chunker.py` does not write the hash.
+  - RF-9 added: significant existing infrastructure surfaced —
+    `Catalog.resolve_span` at `catalog.py:575` is a shipped
+    per-collection chash lookup; `_backfill_chunk_text_hash` at
+    `commands/collection.py:307` + `nx collection backfill-hash`
+    is a shipped backfill command.
+  - RF-6 wording downgraded from precise "~13 min" to "order of
+    magnitude" — conclusion (T2 speedup required) unchanged.
+  - Framing reset from "ship the primitive end-to-end" to
+    **extend + speed + surface + compose**. Phase 1 shrinks to
+    dual-write at six sites + backfill-loop extension + delete
+    cleanup. Phase 2 shrinks to "extend `resolve_span` with a
+    global variant."
+  - Phase 4 spec made precise: the `check-extensions` fix is
+    in the caller (resolve chash → extract doc_id → call
+    existing `chunk_grounded_in` with the resolved doc_id).
+    `chunk_grounded_in`'s contract does NOT change.
+  - Failure-modes section expanded with dual-write race,
+    self-healing read, collection-delete cascade, backfill cost.
+  - Phase 5 (`nx doc cite`) gained `--min-similarity`,
+    failure-mode specs, and explicit `--json` schema.
+  - Existing Infrastructure Audit table rebuilt to distinguish
+    **Reuse** / **Extend** / **Add** per component.

--- a/docs/rdr/rdr-086-chash-span-resolution.md
+++ b/docs/rdr/rdr-086-chash-span-resolution.md
@@ -1,13 +1,14 @@
 ---
 title: "RDR-086: Chash Span Surface — Authoring, Resolution, and Verification"
 id: RDR-086
-status: draft
+status: accepted
 type: Feature
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-16
 revised: 2026-04-17
+accepted_date: 2026-04-17
 related_issues: []
 related: [RDR-053, RDR-075, RDR-078, RDR-082, RDR-083]
 ---

--- a/docs/rdr/rdr-086-chash-span-resolution.md
+++ b/docs/rdr/rdr-086-chash-span-resolution.md
@@ -185,11 +185,72 @@ parameters don't change.
   citation by hand. Reported as a polish-bead against nexus
   (2026-04-17 conversation). This RDR is the owner.
 
+### Source-site investigation (2026-04-17)
+
+- **RF-2** — **Every indexing path already writes the per-chunk hash
+  to ChromaDB metadata under the key `chunk_text_hash`.** Verified at
+  the write sites:
+  - `src/nexus/code_indexer.py:371` —
+    `"chunk_text_hash": _hl.sha256(chunk["text"].encode()).hexdigest()`
+  - `src/nexus/doc_indexer.py:591` (markdown path) and `:666`
+    (PDF path) — same SHA-256 of the chunk text.
+
+  Two keys coexist on every chunk: `content_hash` (SHA-256 of the
+  whole source file, used for staleness / dedup) and `chunk_text_hash`
+  (SHA-256 of just that chunk, the citable identity). RDR-053's
+  "chash" primitive maps to `chunk_text_hash`. Implication for the
+  plan: Phase 1 ("indexing instrumentation") is **mostly a no-op** —
+  the data is already written. Phase 1 scope reduces to "populate
+  T2 `chash_index` from existing T3 metadata via a backfill command"
+  plus a lightweight dual-write so new chunks land in both stores
+  atomically.
+
+- **RF-3** — **Forward-path plumbing is a one-liner per return
+  site.** The `search(structured=True)` return builder at
+  `src/nexus/mcp/core.py:168-174` already has the chunk's full
+  metadata in scope via `r.metadata`. Adding
+  `"chunk_text_hash": [r.metadata.get("chunk_text_hash", "") for r in page]`
+  to the returned dict is a one-line change. Same shape applies
+  to `query(structured=True)` at `:376-380` and the `nx_answer`
+  envelope. **No architectural change** — the data is already
+  available where the surface is constructed; it was simply
+  dropped on the floor.
+
+- **RF-4** — **Live confirmation that the current structured
+  return drops the hash.** Sampled
+  `search(query="plan match confidence threshold FTS5 sentinel",
+  corpus="rdr", limit=3, structured=True)` against prod on
+  2026-04-17. Returned payload:
+  `{"ids":["e21392fe9c74061f_4", …], "tumblers":["","",""],
+  "distances":[…], "collections":["rdr__nexus-571b8edd"]}`. No
+  `chunk_text_hash` key. Tumblers also empty — chunks carry no
+  tumbler directly (tumblers address documents in the catalog
+  JSONL, chunks are implicit sub-addresses), so the empty-list
+  there is semantically correct and not part of this RDR's scope.
+
+- **RF-5 (blocked, recommended follow-up)** — Could not run a
+  direct-T3 sample of chunk metadata to confirm the write-site
+  RFs land in prod: `T3Database()` constructor hits
+  `chromadb.errors.ChromaError: Permission denied` from the
+  cloud-client auth path when invoked outside the normal nx CLI
+  entry. The nx CLI itself works fine (it reads credentials via
+  `nexus.config`), so the write-site evidence + the working MCP
+  tools strongly imply the data is present. Full verification
+  requires either fixing the bare-constructor auth path, adding
+  a diagnostic command (`nx catalog sample-metadata <collection>
+  --limit 5 --keys chunk_text_hash,content_hash`), or running
+  the MVV against the backfilled index. Filing as a follow-up
+  bead; does **not** block this RDR's design.
+
 ### Critical Assumptions
 
-- [ ] `chash` is populated on every chunk in every indexing path —
-  **Status**: Unverified — **Method**: Sampling against live
-  collections.
+- [x] `chash` is populated on every chunk in every indexing path —
+  **Status**: Verified at write-site 2026-04-17 (see RF-2). All
+  three indexing paths (`code_indexer.py:371`, `doc_indexer.py:591`
+  and `:666`) write the per-chunk SHA-256 under the metadata key
+  `chunk_text_hash`. Prod-T3 live-sample confirmation deferred to
+  a diagnostic command (RF-5) but not load-bearing — if the write
+  site is unconditional, the data is there.
 - [ ] A T2 `chash_index` table is the right primitive vs. relying on
   ChromaDB metadata filter — **Status**: Unverified — **Method**:
   Measure ChromaDB filter cost on a populated collection at 100k

--- a/docs/rdr/rdr-086-chash-span-resolution.md
+++ b/docs/rdr/rdr-086-chash-span-resolution.md
@@ -258,6 +258,54 @@ parameters don't change.
   scope for `chash:` citations. Design assumption fully confirmed
   against prod.
 
+- **RF-6 (2026-04-17)** — Measured the T2-index-vs-ChromaDB-filter
+  cost asymmetry that the Alternatives section asserts. Sampled
+  a single `chunk_text_hash` lookup across 20 representative prod
+  collections via `col.get(where={"chunk_text_hash": <hex>})`:
+  mean 289ms per collection, 5.78s total for 20 serial calls.
+  Projection for a 20-citation doc scanned across the 136 prod
+  collections: **~786s (~13 minutes) per doc**. An equivalent
+  T2 SQLite JOIN on a `chash_index` table is ~50µs per lookup —
+  4+ orders of magnitude faster and well under the interactive
+  latency budget.
+
+  Parallelism (ThreadPoolExecutor at 10× concurrency) would cut
+  ChromaDB path to ~80s, still unusable as an authoring surface.
+  Result: the T2 index is not an optimization — it is a hard
+  requirement for `check-extensions` and `nx doc cite` to be
+  interactive. **Critical Assumption 2 verified.**
+
+- **RF-7 (architecture, 2026-04-17)** — Chash stability across
+  reindex events (Critical Assumption 3) is guaranteed by
+  construction, not by observation. `chunk_text_hash` is
+  `sha256(chunk.text.encode()).hexdigest()` at the write sites
+  (RF-2). For the hash to change across a reindex, the chunk
+  text would have to change, which requires one of: (a) a change
+  to the chunker's splitting logic, (b) a change to text
+  normalization, (c) a change in the source file. (a) and (b)
+  are architectural changes tracked by RDR-053's stability
+  mandate and would themselves require a dedicated hash-migration
+  plan. (c) is the normal case — the hash *should* change when
+  the source text changes, and downstream `check-grounding`
+  would correctly report the old chash as unresolved. **Critical
+  Assumption 3 verified by architecture** (RDR-053 §chunk-boundary
+  stability); no empirical reindex comparison needed.
+
+- **RF-8 (design note, 2026-04-17)** — `nx_answer` envelope
+  shape. RF-3 claimed the `nx_answer` envelope can surface
+  `chunk_text_hash` alongside `search` and `query`. On closer
+  read, `nx_answer` currently returns `str` (a rendered
+  final answer). Surfacing chash through it requires either:
+  (a) a new `structured=True` kwarg (precedent: `trace=True`)
+  that returns `{final_text, chunks: [{id, chash, …}], …}`,
+  or (b) deferring `nx_answer` plumbing and relying on
+  `search(structured=True)` / `query(structured=True)` as the
+  authoring surfaces. Recommend (a): the kwarg pattern is
+  precedented, callers opt in, default behaviour unchanged.
+  Noted for Phase 3 design; not a blocker for gate. If (a) is
+  rejected, Phase 3 narrows to search + query only and `nx doc
+  cite` composes on top of `search(structured=True)`.
+
 ### Critical Assumptions
 
 - [x] `chash` is populated on every chunk in every indexing path —
@@ -267,14 +315,20 @@ parameters don't change.
   `chunk_text_hash`. Prod-T3 live-sample confirmation deferred to
   a diagnostic command (RF-5) but not load-bearing — if the write
   site is unconditional, the data is there.
-- [ ] A T2 `chash_index` table is the right primitive vs. relying on
-  ChromaDB metadata filter — **Status**: Unverified — **Method**:
-  Measure ChromaDB filter cost on a populated collection at 100k
-  chunks; compare to SQLite JOIN.
-- [ ] Chash values are stable across the re-indexing events observed
+- [x] A T2 `chash_index` table is the right primitive vs. relying on
+  ChromaDB metadata filter — **Status**: Verified 2026-04-17 (RF-6).
+  Measured: ChromaDB filter 289ms/call × 136 collections × 20
+  citations = ~13min per doc serial, ~80s at 10× parallelism.
+  T2 JOIN ~50µs per lookup. 4+ orders of magnitude gap. T2 index
+  is a hard requirement for interactive author latency, not an
+  optimisation.
+- [x] Chash values are stable across the re-indexing events observed
   in the nexus + ART corpora over the last 30 days — **Status**:
-  Unverified — **Method**: Compare `chash` for a sampled chunk
-  before/after a scheduled reindex.
+  Verified by architecture 2026-04-17 (RF-7). `chunk_text_hash` is
+  `sha256(chunk.text)` at the write sites; stability follows from
+  RDR-053's chunk-boundary-stability mandate. A chunker or
+  normalisation change would itself be a hash-migration event
+  requiring a dedicated plan.
 
 ## Proposed Solution
 

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -190,6 +190,17 @@ class T3Database:
         _client=None,
         _ef_override=None,
     ) -> None:
+        # Credential fallback (nexus-9ji/086 follow-up): when a caller passes
+        # the bare constructor (scripts, research probes, quick repls), empty
+        # args default to the configured credentials via nexus.config so the
+        # constructor is not a footgun. Callers that supply explicit values
+        # still win. Skipped entirely when ``_client`` is injected (tests).
+        if _client is None and not local_mode:
+            tenant = tenant or get_credential("chroma_tenant")
+            database = database or get_credential("chroma_database")
+            api_key = api_key or get_credential("chroma_api_key")
+            voyage_api_key = voyage_api_key or get_credential("voyage_api_key")
+
         self._local_mode = local_mode
         self._voyage_api_key = voyage_api_key
         self._ef_override = _ef_override

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -84,6 +84,77 @@ def test_cloudclient_receives_none_for_empty_tenant(mock_chromadb):
         assert c.kwargs["tenant"] is None
 
 
+def test_bare_constructor_falls_back_to_get_credential(mock_chromadb):
+    """Bare T3Database() (no args) must pick up credentials via
+    nexus.config.get_credential — otherwise scripts and research
+    probes hit 'Permission denied' from CloudClient auth because the
+    constructor forwards empty strings downstream.
+
+    Discovered 2026-04-17 during RDR-086 research; prior behaviour
+    required every caller to know about make_t3() in nexus.db.__init__.
+    """
+    chromadb_m, _ = mock_chromadb
+
+    fake = {
+        "chroma_tenant": "tenant-from-config",
+        "chroma_database": "db-from-config",
+        "chroma_api_key": "key-from-config",
+        "voyage_api_key": "voyage-key-from-config",
+        "migrated": "1",   # skip the old-layout probe
+    }
+    with patch(
+        "nexus.db.t3.get_credential",
+        side_effect=lambda k: fake.get(k, ""),
+    ):
+        T3Database()
+
+    # CloudClient must have been called with the config values, not ""
+    call = chromadb_m.CloudClient.call_args
+    assert call.kwargs["tenant"] == "tenant-from-config"
+    assert call.kwargs["database"] == "db-from-config"
+    assert call.kwargs["api_key"] == "key-from-config"
+
+
+def test_bare_constructor_explicit_args_override_fallback(mock_chromadb):
+    """Explicit args still win over the config fallback."""
+    chromadb_m, _ = mock_chromadb
+    with patch(
+        "nexus.db.t3.get_credential",
+        side_effect=lambda k: "should-not-see-this" if k != "migrated" else "1",
+    ):
+        T3Database(tenant="explicit-t", database="explicit-db", api_key="explicit-k")
+
+    call = chromadb_m.CloudClient.call_args
+    assert call.kwargs["tenant"] == "explicit-t"
+    assert call.kwargs["database"] == "explicit-db"
+    assert call.kwargs["api_key"] == "explicit-k"
+
+
+def test_fallback_skipped_when_client_injected(mock_chromadb):
+    """Tests that pass _client= must not trigger the credential
+    fallback — otherwise get_credential would get called on every
+    test that injects an EphemeralClient or MagicMock."""
+    from unittest.mock import MagicMock
+    chromadb_m, _ = mock_chromadb
+    sentinel = MagicMock()
+    with patch(
+        "nexus.db.t3.get_credential",
+    ) as gc:
+        T3Database(_client=sentinel)
+    assert not gc.called, (
+        "get_credential must not be called when _client is injected"
+    )
+
+
+def test_fallback_skipped_in_local_mode(tmp_path):
+    """Local mode skips the credential fallback — no cloud creds needed."""
+    from unittest.mock import patch, MagicMock
+    with patch("nexus.db.t3.get_credential") as gc, \
+         patch("chromadb.PersistentClient", return_value=MagicMock()):
+        T3Database(local_mode=True, local_path=str(tmp_path))
+    assert not gc.called
+
+
 def test_old_layout_detected(mock_chromadb):
     chromadb_m, mock_client = mock_chromadb
     chromadb_m.CloudClient.side_effect = lambda **kw: mock_client


### PR DESCRIPTION
## Summary

RDR-086 (draft, 2026-04-16) originally covered only the **reverse** direction of the `chash:` primitive: `resolve_chash(hash) → ChunkRef` plus the T2 `chash_index` backing it. A 2026-04-17 conversation with the ART instance surfaced the symmetric gap: **authors have no CLI or MCP path to obtain a chash in the first place**.

- `search(structured=True)` returns `{ids, tumblers, distances, collections}` — no `chunk_text_hash`
- `query(structured=True)` same
- `nx_answer` envelopes carry final text, not hashes
- The instance had to descend to raw ChromaDB (`collection.get(include=['metadatas'])`) and copy hashes by hand

That is exactly the anti-pattern the MCP surface exists to prevent. And without an authoring path, RDR-083's `chash:` citation grammar is correct-but-unusable, which was the ART instance's primary concern.

Rather than file a separate RDR-087, this PR widens RDR-086 so one RDR owns the chash primitive end-to-end. Splitting verification and authoring would leave 086 saying "resolves hashes you somehow already have" — dead-on-arrival.

## What changed in the draft

- **Title**: `Chash Span Resolution — Catalog chash-to-chunk Lookup + Doc-ID Mapping` → `Chash Span Surface — Authoring, Resolution, and Verification`. Filename unchanged.
- **New Gap 5**: no forward path from retrieval to chash. `chunk_text_hash` missing from every structured retrieval payload.
- **New Gap 6**: no "cite this claim" CLI. Even after Gap 5 is closed, the author still runs three steps.
- **Proposed Solution**: 2 → 4 cooperating surfaces (T2 index, reverse resolver, `chunk_text_hash` on structured returns, `nx doc cite` CLI).
- **Infrastructure Audit**: +4 rows (search/query/nx_answer payload changes + `nx doc cite`).
- **Implementation Plan**: 3 → 5 phases. New Phase 3 (retrieval surface, forward direction) and Phase 5 (authoring CLI). Verification phases unchanged but renumbered.
- **MVV**: +2 checkpoints for structured-return round-trip and `nx doc cite` round-trip.
- **RF-1**: cites the ART-instance feedback as the evidence driving the expansion.
- **README**: index title refreshed.

## Test plan

- [x] RDR still scans with gate regex (`#{3,5} Gap \d+:` headings present for all 6 gaps)
- [x] T2 record `nexus_rdr/086` updated with new title + scope note
- [ ] Reviewed for scope-creep: all four surfaces share one T2 index; none is a new feature stream
- [ ] Follow-up: once merged, RDR-083's v1 Scope Reduction already cites RDR-086 as owner — no update needed there

Docs-only PR. Draft RDR, not yet gated/accepted/implemented.