### PR TITLE
fix(nexus-51j): RdrResolver matches RDR files case-insensitively

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.5.1"
+      "version": "4.5.2"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.5.1"
+      "version": "4.5.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.5.2] - 2026-04-17
+
+### Fixed
+
+- **nexus-51j** — `{{rdr:<id>.<field>}}` token resolution now works for projects using the uppercase `RDR-NNN-*.md` filename convention (common practice — makes RDR files visually distinct from other `docs/` content). The shipped `RdrResolver` (RDR-082) used `Path.glob("rdr-{key}-*.md")` which is case-sensitive on Linux/macOS filesystems and silently missed uppercase files. `_fetch` now iterates `*.md` files and matches case-insensitively via `re.IGNORECASE`. Zero-padding handling preserved; mixed-case cohabitation works (same directory with both `rdr-072-*.md` and `RDR-073-*.md` resolves both). Five regression tests in `tests/test_rdr_082_doc_tokens.py::TestRdrResolver` pin the behaviour. Observed on ART (70+ uppercase RDR files) during 2026-04-16 token pilot.
+
 ## [4.5.1] - 2026-04-17
 
 ### Fixed

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.5.2] - 2026-04-17
+
+Plugin version bump alongside conexus 4.5.2. See root CHANGELOG for
+the nexus-51j case-insensitive RDR-file-glob fix in `{{rdr:…}}`
+token resolution.
+
 ## [4.5.1] - 2026-04-17
 
 Follow-up bug fix bundled with conexus 4.5.1. See root `CHANGELOG.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.5.1"
+version = "4.5.2"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/doc/resolvers.py
+++ b/src/nexus/doc/resolvers.py
@@ -163,23 +163,27 @@ class RdrResolver:
         return str(value)
 
     def _fetch(self, key: str) -> dict[str, Any]:
-        # Match rdr-<id>-*.md or rdr-<zero-padded>-*.md
-        stem_prefix = f"rdr-{key.lstrip('0').zfill(len(key)) or key}-"
-        # Also match un-padded form
-        candidates = list(self._rdr_dir.glob(f"rdr-{key}-*.md"))
-        if not candidates:
-            candidates = list(self._rdr_dir.glob(f"{stem_prefix}*.md"))
-        if not candidates:
-            # Fallback: scan with regex for any rdr-<any leading zeros><key>-
-            pattern = re.compile(rf"^rdr-0*{int(key)}-.+\.md$") if key.isdigit() else None
-            if pattern:
-                for p in self._rdr_dir.glob("rdr-*.md"):
-                    if pattern.match(p.name):
-                        candidates = [p]
-                        break
+        # nexus-51j: case-insensitive match so projects that use the
+        # uppercase ``RDR-NNN-*.md`` convention (common, visually
+        # distinguishes RDRs from other docs/) work alongside the
+        # nexus-default lowercase ``rdr-NNN-*.md``. A numeric key
+        # matches any zero-padding of the same integer; a non-numeric
+        # key matches the literal text.
+        if key.isdigit():
+            pattern = re.compile(
+                rf"^rdr-0*{int(key)}-.+\.md$", re.IGNORECASE,
+            )
+        else:
+            pattern = re.compile(
+                rf"^rdr-{re.escape(key)}-.+\.md$", re.IGNORECASE,
+            )
+        candidates = [
+            p for p in self._rdr_dir.glob("*.md") if pattern.match(p.name)
+        ]
         if not candidates:
             raise ResolutionError(
-                f"no RDR file matching rdr-{key}-*.md under {self._rdr_dir}"
+                f"no RDR file matching rdr-{key}-*.md (case-insensitive) "
+                f"under {self._rdr_dir}"
             )
         text = candidates[0].read_text(errors="replace")
         m = _FRONTMATTER_RE.search(text)

--- a/tests/test_rdr_082_doc_tokens.py
+++ b/tests/test_rdr_082_doc_tokens.py
@@ -202,6 +202,67 @@ class TestRdrResolver:
         with pytest.raises(ResolutionError):
             r.resolve("999", field=None, filters={})
 
+    def test_resolves_uppercase_RDR_prefix(self, tmp_path: Path) -> None:
+        """nexus-51j: projects using the RDR-NNN-*.md (uppercase) convention
+        must resolve the same as lowercase."""
+        from nexus.doc.resolvers import RdrResolver
+
+        rdr_dir = tmp_path / "docs" / "rdr"
+        rdr_dir.mkdir(parents=True)
+        (rdr_dir / "RDR-068-masking-field-plan-learning.md").write_text(
+            "---\n"
+            "title: \"RDR-068: Masking Field Plan Learning\"\n"
+            "status: accepted\n"
+            "---\n"
+        )
+        r = RdrResolver(rdr_dir=rdr_dir)
+        assert r.resolve("068", field="status", filters={}) == "accepted"
+
+    def test_mixed_case_cohabitation(self, tmp_path: Path) -> None:
+        """Lowercase and uppercase RDRs in the same directory are both found."""
+        from nexus.doc.resolvers import RdrResolver
+
+        rdr_dir = tmp_path / "docs" / "rdr"
+        rdr_dir.mkdir(parents=True)
+        (rdr_dir / "rdr-072-lowercase.md").write_text(
+            "---\nstatus: draft\n---\n"
+        )
+        (rdr_dir / "RDR-073-uppercase.md").write_text(
+            "---\nstatus: accepted\n---\n"
+        )
+        r = RdrResolver(rdr_dir=rdr_dir)
+        assert r.resolve("072", field="status", filters={}) == "draft"
+        assert r.resolve("073", field="status", filters={}) == "accepted"
+
+    def test_zero_padding_still_works_case_insensitive(
+        self, tmp_path: Path,
+    ) -> None:
+        """Numeric key with or without zero-padding resolves against
+        either case of prefix. Regression: the original impl had a
+        zero-padding fallback; that behaviour is preserved."""
+        from nexus.doc.resolvers import RdrResolver
+
+        rdr_dir = tmp_path / "docs" / "rdr"
+        rdr_dir.mkdir(parents=True)
+        (rdr_dir / "RDR-9-foo.md").write_text("---\nstatus: x\n---\n")
+        r = RdrResolver(rdr_dir=rdr_dir)
+        # Padded key
+        assert r.resolve("009", field="status", filters={}) == "x"
+        # Unpadded key
+        assert r.resolve("9", field="status", filters={}) == "x"
+
+    def test_non_numeric_key_case_insensitive(self, tmp_path: Path) -> None:
+        """Non-numeric keys also honour case-insensitive matching."""
+        from nexus.doc.resolvers import RdrResolver
+
+        rdr_dir = tmp_path / "docs" / "rdr"
+        rdr_dir.mkdir(parents=True)
+        (rdr_dir / "RDR-proposal-alpha-notes.md").write_text(
+            "---\nstatus: draft\n---\n"
+        )
+        r = RdrResolver(rdr_dir=rdr_dir)
+        assert r.resolve("proposal", field="status", filters={}) == "draft"
+
 
 # ── Render engine ────────────────────────────────────────────────────────────
 

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.5.1"
+version = "4.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Projects using the `RDR-NNN-*.md` (uppercase) filename convention — common practice since it makes RDR files visually distinct from other `docs/` content — could not use `{{rdr:<id>.<field>}}` token resolution. `RdrResolver._fetch` used `Path.glob("rdr-{key}-*.md")` which is case-sensitive on Linux/macOS filesystems and silently missed uppercase matches.

Observed on ART (70+ uppercase RDR files) during the 2026-04-16 token pilot:

```
$ nx doc render /tmp/test.md
render error: line 1 col 16: no RDR file matching rdr-068-*.md under /path/to/project/docs/rdr
```

File `RDR-068-masking-field-plan-learning.md` was sitting right there on disk.

## Fix

`_fetch` now iterates `self._rdr_dir.glob("*.md")` and matches case-insensitively via `re.IGNORECASE`:

- Numeric keys match any zero-padding of the same integer (existing behaviour preserved)
- Non-numeric keys use `re.escape` for safe literal matching
- Mixed-case cohabitation works: `rdr-072-*.md` and `RDR-073-*.md` in the same directory both resolve

## Test plan

- [x] 4 new regression tests in `TestRdrResolver`:
  - `test_resolves_uppercase_RDR_prefix`
  - `test_mixed_case_cohabitation`
  - `test_zero_padding_still_works_case_insensitive`
  - `test_non_numeric_key_case_insensitive`
- [x] Full `tests/test_rdr_082_doc_tokens.py` suite — 28 pass (24 prior + 4 new)
- [x] Live repro: seeded tmp dir with `RDR-068-masking-field-plan-learning.md`, ran `nx doc render` with `{{rdr:068.status}}` + `{{rdr:068.title}}`, both resolved correctly

## Version

4.5.2 — plugin-only surface fix, same shape as 4.5.1's nexus-lub cascade follow-up.

Closes nexus-51j.