### PR TITLE
fix: raise MCP analytical-tool timeout defaults (120s → 300/600s)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1277,13 +1277,13 @@ def collection_verify(name: str) -> str:
 
 
 @mcp.tool()
-async def operator_extract(inputs: str, fields: str, timeout: float = 120.0) -> dict:
+async def operator_extract(inputs: str, fields: str, timeout: float = 300.0) -> dict:
     """Extract structured fields from each input item using claude -p.
 
     Args:
         inputs: Items to extract from (plain text or JSON array string).
         fields: Comma-separated field names to extract.
-        timeout: Seconds before the subprocess is killed.
+        timeout: Seconds before the subprocess is killed. Default 300s (5 min) — the claude -p substrate handles multi-step analytical workloads; 120s was hitting false timeouts on real input.
     """
     from nexus.operators.dispatch import claude_dispatch
 
@@ -1305,13 +1305,13 @@ async def operator_extract(inputs: str, fields: str, timeout: float = 120.0) -> 
 
 
 @mcp.tool()
-async def operator_rank(items: str, criterion: str, timeout: float = 120.0) -> dict:
+async def operator_rank(items: str, criterion: str, timeout: float = 300.0) -> dict:
     """Rank items by a criterion using claude -p.
 
     Args:
         items: Items to rank (plain text or JSON array string).
         criterion: Natural-language ranking criterion.
-        timeout: Seconds before the subprocess is killed.
+        timeout: Seconds before the subprocess is killed. Default 300s (5 min) — the claude -p substrate handles multi-step analytical workloads; 120s was hitting false timeouts on real input.
     """
     from nexus.operators.dispatch import claude_dispatch
 
@@ -1331,13 +1331,13 @@ async def operator_rank(items: str, criterion: str, timeout: float = 120.0) -> d
 
 
 @mcp.tool()
-async def operator_compare(items: str, focus: str = "", timeout: float = 120.0) -> dict:
+async def operator_compare(items: str, focus: str = "", timeout: float = 300.0) -> dict:
     """Compare items and return a structured comparison using claude -p.
 
     Args:
         items: Items to compare (plain text or JSON array string).
         focus: Optional aspect to focus the comparison on.
-        timeout: Seconds before the subprocess is killed.
+        timeout: Seconds before the subprocess is killed. Default 300s (5 min) — the claude -p substrate handles multi-step analytical workloads; 120s was hitting false timeouts on real input.
     """
     from nexus.operators.dispatch import claude_dispatch
 
@@ -1360,14 +1360,14 @@ async def operator_compare(items: str, focus: str = "", timeout: float = 120.0) 
 async def operator_summarize(
     content: str,
     cited: bool = False,
-    timeout: float = 120.0,
+    timeout: float = 300.0,
 ) -> dict:
     """Summarize content using claude -p, optionally with citations.
 
     Args:
         content: Text to summarize.
         cited: If True, include a citations list in the output.
-        timeout: Seconds before the subprocess is killed.
+        timeout: Seconds before the subprocess is killed. Default 300s (5 min) — the claude -p substrate handles multi-step analytical workloads; 120s was hitting false timeouts on real input.
     """
     from nexus.operators.dispatch import claude_dispatch
 
@@ -1389,7 +1389,7 @@ async def operator_generate(
     template: str,
     context: str,
     cited: bool = False,
-    timeout: float = 120.0,
+    timeout: float = 300.0,
 ) -> dict:
     """Generate output from a template and context using claude -p.
 
@@ -1397,7 +1397,7 @@ async def operator_generate(
         template: Named template or description of desired output form.
         context: Source material or context to generate from.
         cited: If True, include a citations list in the output.
-        timeout: Seconds before the subprocess is killed.
+        timeout: Seconds before the subprocess is killed. Default 300s (5 min) — the claude -p substrate handles multi-step analytical workloads; 120s was hitting false timeouts on real input.
     """
     from nexus.operators.dispatch import claude_dispatch
 
@@ -1767,7 +1767,12 @@ async def _nx_answer_plan_miss(
         f"{{\"tool\": \"<bare name>\", \"args\": {{...}}}}."
     )
 
-    payload = await claude_dispatch(prompt, _PLANNER_SCHEMA, timeout=120.0)
+    # Inline planner timeout: 300s — decomposing a question into a
+    # plan is heavier than a single operator call (multi-step reasoning,
+    # tool-choice enumeration). 120s was hitting the timeout on
+    # non-trivial questions. Callers of nx_answer see the miss path
+    # as a hang when this trips.
+    payload = await claude_dispatch(prompt, _PLANNER_SCHEMA, timeout=300.0)
     steps = payload.get("steps", []) if isinstance(payload, dict) else []
     if not steps:
         raise ValueError("planner returned empty plan")
@@ -2106,7 +2111,7 @@ async def nx_answer(
 async def nx_tidy(
     topic: str,
     collection: str = "knowledge",
-    timeout: float = 120.0,
+    timeout: float = 600.0,
 ) -> str:
     """Consolidate knowledge entries on *topic* via claude -p. RDR-080 P3.
 
@@ -2117,7 +2122,10 @@ async def nx_tidy(
     Args:
         topic: The knowledge topic to consolidate (e.g. "chromadb quotas").
         collection: T3 collection to search (default: knowledge).
-        timeout: Subprocess timeout in seconds.
+        timeout: Subprocess timeout in seconds. Default 600s (10 min) —
+            consolidation on a large corpus does multi-step search +
+            cross-reference; 120s was hitting the timeout routinely on
+            real workloads. Caller can override lower for small topics.
 
     Returns:
         Consolidated summary as a human-readable string.
@@ -2156,7 +2164,7 @@ async def nx_tidy(
 async def nx_enrich_beads(
     bead_description: str,
     context: str = "",
-    timeout: float = 120.0,
+    timeout: float = 300.0,
 ) -> str:
     """Enrich a bead with execution context via claude -p. RDR-080 P3.
 
@@ -2168,7 +2176,11 @@ async def nx_enrich_beads(
     Args:
         bead_description: The bead's title and description to enrich.
         context: Optional additional context (e.g. audit findings).
-        timeout: Subprocess timeout in seconds.
+        timeout: Subprocess timeout in seconds. Default 300s (5 min) —
+            codebase exploration with file:line verification is
+            multi-step; 120s was a frequent false-timeout on beads
+            with broad scope. Caller can override lower for simple
+            single-file beads.
 
     Returns:
         Enriched bead markdown as a human-readable string.
@@ -2207,7 +2219,7 @@ async def nx_enrich_beads(
 async def nx_plan_audit(
     plan_json: str,
     context: str = "",
-    timeout: float = 120.0,
+    timeout: float = 600.0,
 ) -> str:
     """Audit a plan for correctness and codebase alignment via claude -p. RDR-080 P3.
 
@@ -2218,7 +2230,12 @@ async def nx_plan_audit(
     Args:
         plan_json: The plan to audit (JSON string or free-text description).
         context: Optional additional context (e.g. RDR reference).
-        timeout: Subprocess timeout in seconds.
+        timeout: Subprocess timeout in seconds. Default 600s (10 min) —
+            a real plan audit verifies file:line pointers, cross-
+            references research findings, walks dependency graphs;
+            120s was hitting the timeout on RDR-086's real plan
+            (11 beads, 5 phases). Caller can override lower for
+            small spot-checks.
 
     Returns:
         Audit verdict as a human-readable string.

--- a/src/nexus/operators/dispatch.py
+++ b/src/nexus/operators/dispatch.py
@@ -41,7 +41,7 @@ class OperatorOutputError(OperatorError):
 async def claude_dispatch(
     prompt: str,
     json_schema: dict[str, Any],
-    timeout: float = 60.0,
+    timeout: float = 300.0,
 ) -> dict[str, Any]:
     """Dispatch a single operator call to claude -p, fully async.
 
@@ -49,7 +49,14 @@ async def claude_dispatch(
         prompt: The full prompt text, delivered via stdin.
         json_schema: JSON Schema the model output must conform to.
             Passed via --output-format json and --json-schema flag.
-        timeout: Seconds before the subprocess is killed.
+        timeout: Seconds before the subprocess is killed. Default 300s
+            (5 min) — the analytical workloads these tools run
+            (audit, enrich, summarise, extract) can legitimately
+            take minutes. Callers that know their input is short
+            should override lower; callers running heavy audits
+            override up (``nx_plan_audit`` / ``nx_tidy`` use 600s).
+            The prior 60s default produced a lot of false timeouts
+            on real workloads.
 
     Returns:
         Parsed JSON dict from stdout.

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -410,6 +410,28 @@ class TestNxTidy:
         await nx_tidy(topic="test")
         assert dispatch_calls, "claude_dispatch must be called"
 
+    @pytest.mark.asyncio
+    async def test_default_timeout_is_600s(self, monkeypatch):
+        """nx_tidy default timeout is 600s (10 min).
+
+        Consolidation on a large corpus hits the old 120s ceiling
+        routinely. Default raised 2026-04-17; caller can override.
+        """
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import nx_tidy
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"summary": "ok", "actions": []}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_tidy(topic="test")
+        assert captured["timeout"] == 600.0, (
+            f"nx_tidy default timeout must be 600s; got {captured['timeout']}"
+        )
+
 
 # ── nx_enrich_beads ───────────────────────────────────────────────────────────
 
@@ -457,6 +479,29 @@ class TestNxEnrichBeads:
         monkeypatch.setattr(_mod, "claude_dispatch", fake)
         await nx_enrich_beads(bead_description="task", context="extra ctx sentinel")
         assert "extra ctx sentinel" in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_is_300s(self, monkeypatch):
+        """nx_enrich_beads default timeout is 300s (5 min).
+
+        Codebase enrichment with file:line verification is
+        multi-step; 120s was a frequent false-timeout.
+        """
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import nx_enrich_beads
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"enriched_description": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_enrich_beads(bead_description="task")
+        assert captured["timeout"] == 300.0, (
+            f"nx_enrich_beads default timeout must be 300s; "
+            f"got {captured['timeout']}"
+        )
 
 
 # ── nx_plan_audit ─────────────────────────────────────────────────────────────
@@ -509,6 +554,125 @@ class TestNxPlanAudit:
         sentinel_plan = '{"steps": [{"tool": "search_sentinel_xyz"}]}'
         await nx_plan_audit(plan_json=sentinel_plan)
         assert "search_sentinel_xyz" in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_is_600s(self, monkeypatch):
+        """nx_plan_audit default timeout is 600s (10 min).
+
+        A real plan audit verifies file:line pointers across the
+        codebase and cross-references research findings; 120s was
+        routinely hitting the timeout on non-trivial plans
+        (observed on RDR-086's 11-bead plan, 2026-04-17).
+        """
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import nx_plan_audit
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"verdict": "pass", "findings": [], "summary": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_plan_audit(plan_json='{"steps": []}')
+        assert captured["timeout"] == 600.0, (
+            f"nx_plan_audit default timeout must be 600s; "
+            f"got {captured['timeout']}"
+        )
+
+
+# ── Operator timeout defaults (all raised to 300s 2026-04-17) ────────────────
+
+
+class TestOperatorTimeoutDefaults:
+    """The 5 operator_* MCP tools default to 300s. 120s was too tight
+    on real input (long documents, large item lists, complex criteria).
+    Callers can still override lower when they know the scope is small.
+    """
+
+    @pytest.mark.asyncio
+    async def test_operator_summarize_default_is_300s(self, monkeypatch):
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import operator_summarize
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"summary": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await operator_summarize(content="text")
+        assert captured["timeout"] == 300.0
+
+    @pytest.mark.asyncio
+    async def test_operator_extract_default_is_300s(self, monkeypatch):
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import operator_extract
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"extractions": []}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await operator_extract(inputs="x", fields="a,b")
+        assert captured["timeout"] == 300.0
+
+    @pytest.mark.asyncio
+    async def test_operator_rank_default_is_300s(self, monkeypatch):
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import operator_rank
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"ranked": []}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await operator_rank(items="a", criterion="x")
+        assert captured["timeout"] == 300.0
+
+    @pytest.mark.asyncio
+    async def test_operator_compare_default_is_300s(self, monkeypatch):
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import operator_compare
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"comparison": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await operator_compare(items="a")
+        assert captured["timeout"] == 300.0
+
+    @pytest.mark.asyncio
+    async def test_operator_generate_default_is_300s(self, monkeypatch):
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import operator_generate
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"output": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await operator_generate(template="x", context="y")
+        assert captured["timeout"] == 300.0
+
+    def test_claude_dispatch_default_is_300s(self):
+        """The dispatch substrate default should not regress below 300s —
+        it's the floor every direct caller inherits."""
+        import inspect
+        from nexus.operators.dispatch import claude_dispatch
+
+        sig = inspect.signature(claude_dispatch)
+        assert sig.parameters["timeout"].default == 300.0
 
 
 # ── nx_answer end-to-end orchestration (trunk tests, no API keys) ─────────────


### PR DESCRIPTION
## Summary

The 120s default on `claude_dispatch`-backed MCP tools was producing routine false timeouts on real analytical workloads. User flagged during RDR-086 acceptance (2026-04-17) after `nx_plan_audit` hit the ceiling on an 11-bead plan: *"This is what I feared when we went to a timeout based mechanism. Audits can take a LONG time."*

Raised defaults to match observed workload sizes. Callers can still override lower when they know the scope is small.

## Default changes

| Tool | Before | After | Rationale |
|---|---|---|---|
| `claude_dispatch` substrate | 60s | 300s | The floor every direct caller inherits |
| `operator_extract` / `_rank` / `_compare` / `_summarize` / `_generate` | 120s | 300s | Content transforms on real input |
| `nx_enrich_beads` | 120s | 300s | Codebase exploration with file:line verification |
| `nx_tidy` | 120s | 600s | Whole-corpus consolidation sweep |
| `nx_plan_audit` | 120s | 600s | Plan verification walks full codebase |
| `_nx_answer_plan_miss` planner | 120s (hardcoded) | 300s | Inline question decomposition |

## Tiering rationale

- **300s (5 min)** — content transforms and the dispatch floor. Covers the p95 case for real input; p50 completes well under. The operator tools are still meant for short-form work; this raise is about not false-timing-out on edge-case input size, not encouraging 5-min ops as the norm.
- **600s (10 min)** — whole-corpus analytical sweeps. Audit of a plan with 10+ beads walks the codebase verifying file:line pointers; tidy does multi-step search + cross-reference.

## Test plan

- [x] 9 new regression tests in `tests/test_nx_answer.py`:
  - `TestNxTidy::test_default_timeout_is_600s`
  - `TestNxEnrichBeads::test_default_timeout_is_300s`
  - `TestNxPlanAudit::test_default_timeout_is_600s`
  - `TestOperatorTimeoutDefaults` — 5 operator defaults + `claude_dispatch` floor
- [x] Full `tests/test_nx_answer.py` suite — 49 pass (40 prior + 9 new)
- [x] Docstrings updated to document the raised defaults + the "caller can override lower" pattern

## Follow-up

If an operator routinely runs >60s, that's a signal to split the input, not tune the timeout. This PR is about **not failing on p95**, not about shifting the p50 expectation.