### PR TITLE
fix(mcp): clamp subagent timeouts to 300s floor (nexus-7sbf)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -41,6 +41,33 @@ mcp = FastMCP("nexus")
 
 _DEFAULT_PAGE_SIZE = 10
 
+# Minimum effective timeout for claude -p subagent tools. Planning and
+# enrichment agents have been observed passing 180s / 300s overrides
+# that re-trigger the class of false-positive timeouts v4.5.3 raised
+# the defaults to prevent (see bead nexus-7sbf). The floor clamps
+# caller-supplied values upward so agents can raise but not lower
+# the effective budget.
+_SUBAGENT_TIMEOUT_FLOOR = 300.0
+
+
+def _clamp_subagent_timeout(requested: float, tool_name: str) -> float:
+    """Clamp a caller-supplied subagent timeout to the floor.
+
+    Emits a structured warning when a caller's requested timeout is
+    below the floor so the override is visible in logs without
+    blocking the call.
+    """
+    if requested < _SUBAGENT_TIMEOUT_FLOOR:
+        import structlog
+        structlog.get_logger().warning(
+            "subagent_timeout_clamped",
+            tool=tool_name,
+            requested=requested,
+            floor=_SUBAGENT_TIMEOUT_FLOOR,
+        )
+        return _SUBAGENT_TIMEOUT_FLOOR
+    return requested
+
 # ── Post-store hooks (register once at import) ──────────────────────────────
 
 from nexus.mcp_infra import register_post_store_hook, taxonomy_assign_hook
@@ -2179,13 +2206,17 @@ async def nx_enrich_beads(
         timeout: Subprocess timeout in seconds. Default 300s (5 min) —
             codebase exploration with file:line verification is
             multi-step; 120s was a frequent false-timeout on beads
-            with broad scope. Caller can override lower for simple
-            single-file beads.
+            with broad scope. Requests below the 300s floor are
+            clamped upward (see nexus-7sbf) to prevent agent
+            overrides from re-introducing false-positive timeouts;
+            a structlog warning is emitted when clamping occurs.
 
     Returns:
         Enriched bead markdown as a human-readable string.
     """
     from nexus.operators.dispatch import claude_dispatch
+
+    timeout = _clamp_subagent_timeout(timeout, "nx_enrich_beads")
 
     schema = {
         "type": "object",
@@ -2234,13 +2265,18 @@ async def nx_plan_audit(
             a real plan audit verifies file:line pointers, cross-
             references research findings, walks dependency graphs;
             120s was hitting the timeout on RDR-086's real plan
-            (11 beads, 5 phases). Caller can override lower for
-            small spot-checks.
+            (11 beads, 5 phases). Requests below the 300s floor are
+            clamped upward (see nexus-7sbf) to prevent planning
+            agents from re-introducing false-positive timeouts via
+            low overrides; a structlog warning is emitted when
+            clamping occurs.
 
     Returns:
         Audit verdict as a human-readable string.
     """
     from nexus.operators.dispatch import claude_dispatch
+
+    timeout = _clamp_subagent_timeout(timeout, "nx_plan_audit")
 
     schema = {
         "type": "object",

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -933,3 +933,105 @@ class TestNxAnswerLatencyProxy:
             f"nx_answer with mocked I/O took {elapsed:.2f}s — "
             "possible blocking call reintroduced"
         )
+
+
+# ── Subagent timeout floor (nexus-7sbf) ──────────────────────────────────────
+
+
+class TestSubagentTimeoutFloor:
+    """Agents (e.g. strategic-planner) occasionally pass explicit low
+    timeouts to ``nx_plan_audit`` / ``nx_enrich_beads`` (seen: 180s,
+    300s), bypassing the v4.5.3 raised defaults and producing
+    false-positive timeouts on multi-phase plans. The tool body
+    clamps the requested timeout to a floor so agent overrides can
+    only raise, not lower, the effective timeout.
+    """
+
+    SUBAGENT_TIMEOUT_FLOOR = 300.0
+
+    @pytest.mark.asyncio
+    async def test_plan_audit_clamps_below_floor(self, monkeypatch):
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import nx_plan_audit
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"verdict": "pass", "findings": [], "summary": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_plan_audit(plan_json='{"steps": []}', timeout=60.0)
+        assert captured["timeout"] == self.SUBAGENT_TIMEOUT_FLOOR, (
+            f"nx_plan_audit with timeout=60 must clamp to "
+            f"{self.SUBAGENT_TIMEOUT_FLOOR}; got {captured['timeout']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_plan_audit_honours_above_floor(self, monkeypatch):
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import nx_plan_audit
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"verdict": "pass", "findings": [], "summary": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_plan_audit(plan_json='{"steps": []}', timeout=900.0)
+        assert captured["timeout"] == 900.0, (
+            "timeouts above the floor must be honoured verbatim"
+        )
+
+    @pytest.mark.asyncio
+    async def test_enrich_beads_clamps_below_floor(self, monkeypatch):
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import nx_enrich_beads
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"enriched_description": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_enrich_beads(bead_description="task", timeout=120.0)
+        assert captured["timeout"] == self.SUBAGENT_TIMEOUT_FLOOR, (
+            f"nx_enrich_beads with timeout=120 must clamp to "
+            f"{self.SUBAGENT_TIMEOUT_FLOOR}; got {captured['timeout']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_enrich_beads_honours_above_floor(self, monkeypatch):
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import nx_enrich_beads
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout=60.0):
+            captured["timeout"] = timeout
+            return {"enriched_description": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_enrich_beads(bead_description="task", timeout=450.0)
+        assert captured["timeout"] == 450.0
+
+    @pytest.mark.asyncio
+    async def test_plan_audit_logs_warning_on_clamp(self, monkeypatch, capsys):
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import nx_plan_audit
+
+        async def fake(prompt, schema, timeout=60.0):
+            return {"verdict": "pass", "findings": [], "summary": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await nx_plan_audit(plan_json='{"steps": []}', timeout=180.0)
+        out = capsys.readouterr()
+        emitted = out.out + out.err
+        assert "subagent_timeout_clamped" in emitted, (
+            "expected a structured warning when caller timeout is below floor"
+        )
+        assert "tool=nx_plan_audit" in emitted
+        assert "requested=180" in emitted
+        assert "floor=300" in emitted


### PR DESCRIPTION
## Summary
- Clamp caller-supplied timeouts upward to a 300s floor on `nx_plan_audit` and `nx_enrich_beads` so agent overrides (180s/300s seen in the wild) cannot re-introduce the false-positive timeout class v4.5.3 raised the defaults to prevent.
- Emit a `structlog.warning("subagent_timeout_clamped", tool=..., requested=..., floor=300.0)` when clamping fires so overrides remain visible in logs.
- Defaults unchanged: `nx_plan_audit` stays at 600s, `nx_enrich_beads` stays at 300s.

## Motivation
Observed twice: ART planning run earlier in the week, and RDR-087 accept 2026-04-17 where the strategic-planner called `nx_plan_audit(timeout=180)`, timed out at 180s, retried at `timeout=300`, and the retry succeeded in ~5 min (see bead nexus-7sbf). The agent's timeout choice is not hardcoded in `nx/agents/strategic-planner.md` — it is an LLM-time decision the floor neutralises.

## Test plan
- [x] `uv run pytest tests/test_nx_answer.py::TestSubagentTimeoutFloor` — 5 new cases green
- [x] `uv run pytest tests/test_nx_answer.py tests/test_mcp_package.py tests/test_mcp_server.py tests/test_mcp_concurrency.py` — 139 tests pass, no regressions
- [ ] Next multi-phase RDR accept completes `nx_plan_audit` on first attempt (no 180s retry) — in-the-wild validation

Closes nexus-7sbf.