### PR TITLE
feat(telemetry): RDR-087 review follow-ups + 4.6.1 (nexus-yi4b.2.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.6.0"
+      "version": "4.6.1"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.6.0"
+      "version": "4.6.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.6.1] - 2026-04-17
+
+### Fixed
+
+- **RDR-087 review follow-up** (nexus-yi4b.2.5) — two post-merge nits from the Phase 2 code review:
+  - **Typed telemetry accessor on hot path** — `search_engine.search_cross_corpus` and `commands/search_cmd._emit_silent_zero_note` now read the `telemetry.search_enabled` / `telemetry.stderr_silent_zero` opt-outs via `config.get_telemetry_config(cfg=cfg)` instead of raw `cfg.get("telemetry", {}).get(...)`. Malformed `.nexus.yml` values (e.g. `search_enabled: "yes"`) now surface the structured `telemetry_config_malformed` warning on every call, matching the design intent of Phase 2.3's typed accessor. `get_telemetry_config` accepts an optional pre-loaded `cfg` kwarg so the hot path skips the disk re-read.
+  - **Schema column rename** (migration 4.6.1) — `search_telemetry.dropped_count` → `kept_count` with value flip (`kept = raw − dropped`). RDR-087 §Proposed Solution specifies `kept_count`; 4.6.0 shipped with `dropped_count`. Idempotent ALTER + UPDATE migration; no-op on already-renamed or missing tables. Fresh installs get `kept_count` directly via `_TELEMETRY_SCHEMA_SQL`. Phase 3 consumers can now rely on spec-aligned column semantics.
+
+## [4.6.0] - 2026-04-17
+
+### Added
+
+- **RDR-087 Phase 2: Telemetry Persistence** (nexus-yi4b.2) — four stacked beads that turn the Phase 1 silent-zero stderr diagnostic into queryable T2 state:
+  - **2.1** — `search_telemetry` T2 table + registered migration; `nx doctor --check-schema` recognises it.
+  - **2.2** — hot-path `INSERT OR IGNORE` from `search_cross_corpus` writing one row per (query, collection). Failure is swallowed at DEBUG so a telemetry fault never breaks search. Composite PK `(ts, query_hash, collection)` dedupes same-second writers.
+  - **2.3** — `telemetry.search_enabled` / `telemetry.stderr_silent_zero` opt-out section in `.nexus.yml`; `TelemetryConfig` dataclass + `get_telemetry_config()` accessor with malformed-value structured warning.
+  - **2.4** — `nx doctor --trim-telemetry [--days N]` (default 30d, `click.IntRange(min=1)`); safe on empty tables, missing-DB handled gracefully.
+
 ## [4.5.3] - 2026-04-17
 
 ### Fixed

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.6.1] - 2026-04-17
+
+Plugin version bump alongside conexus 4.6.1. See root CHANGELOG for
+the RDR-087 review follow-ups: typed telemetry accessor on the hot
+path and the `search_telemetry.dropped_count` → `kept_count` schema
+rename migration.
+
+## [4.6.0] - 2026-04-17
+
+Plugin version bump alongside conexus 4.6.0. See root CHANGELOG for
+RDR-087 Phase 2: `search_telemetry` table + migration, hot-path
+writes from `search_cross_corpus`, `telemetry.*` opt-out config, and
+`nx doctor --trim-telemetry` retention command.
+
 ## [4.5.3] - 2026-04-17
 
 Plugin version bump alongside conexus 4.5.3. See root CHANGELOG for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.6.0"
+version = "4.6.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import click
 import structlog
 
-from nexus.config import get_tuning_config, load_config
+from nexus.config import get_telemetry_config, get_tuning_config, load_config
 from nexus.corpus import resolve_corpus
 from nexus.commands.store import _t3
 from nexus.ripgrep_cache import search_ripgrep
@@ -61,7 +61,7 @@ def _maybe_emit_silent_zero_note(
     """
     if quiet:
         return
-    if not config.get("telemetry", {}).get("stderr_silent_zero", True):
+    if not get_telemetry_config(cfg=config).stderr_silent_zero:
         return
     if not diagnostics_out:
         return

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -160,14 +160,21 @@ def _coerce_bool(value: Any, *, key: str, default: bool) -> bool:
     return default
 
 
-def get_telemetry_config(repo_root: Path | None = None) -> TelemetryConfig:
+def get_telemetry_config(
+    repo_root: Path | None = None,
+    *,
+    cfg: dict | None = None,
+) -> TelemetryConfig:
     """Load the ``telemetry`` config section into a typed struct.
 
     Malformed boolean values coerce to the default with a structured
     warning so a stray string in ``.nexus.yml`` never silently disables
     the feature (or silently enables it).
+
+    Pass *cfg* to reuse an already-loaded config dict and skip the disk
+    read — required on the search hot path.
     """
-    tel = load_config(repo_root=repo_root).get("telemetry", {})
+    tel = (cfg if cfg is not None else load_config(repo_root=repo_root)).get("telemetry", {})
     return TelemetryConfig(
         search_enabled=_coerce_bool(
             tel.get("search_enabled", True),

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -373,6 +373,32 @@ def migrate_search_telemetry(conn: sqlite3.Connection) -> None:
     _log.info("Migrated: created search_telemetry table (RDR-087)")
 
 
+def migrate_rename_dropped_to_kept(conn: sqlite3.Connection) -> None:
+    """Rename ``search_telemetry.dropped_count`` → ``kept_count`` and flip values.
+
+    RDR-087 review follow-up (nexus-yi4b.2.5). The RDR spec calls for
+    ``kept_count``; 4.6.0 shipped with ``dropped_count``. Rename the
+    column and flip stored values via ``kept_count = raw_count - kept_count``
+    so downstream Phase 3 consumers see spec-aligned column semantics.
+
+    Idempotent — no-op when ``dropped_count`` is already absent (either
+    because the column was renamed previously, or the table doesn't
+    exist yet).
+    """
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='search_telemetry'"
+    ).fetchone()
+    if row is None:
+        return
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(search_telemetry)").fetchall()}
+    if "dropped_count" not in cols:
+        return
+    conn.execute("ALTER TABLE search_telemetry RENAME COLUMN dropped_count TO kept_count")
+    conn.execute("UPDATE search_telemetry SET kept_count = raw_count - kept_count")
+    conn.commit()
+    _log.info("Migrated: search_telemetry.dropped_count → kept_count (RDR-087 errata)")
+
+
 def _add_plan_dimensional_identity(conn: sqlite3.Connection) -> None:
     """Add RDR-078 dimensional identity + currying + metrics columns to plans.
 
@@ -494,6 +520,11 @@ MIGRATIONS: list[Migration] = [
         "4.6.0",
         "Add search_telemetry table (RDR-087)",
         migrate_search_telemetry,
+    ),
+    Migration(
+        "4.6.1",
+        "Rename search_telemetry.dropped_count to kept_count (RDR-087 errata)",
+        migrate_rename_dropped_to_kept,
     ),
 ]
 

--- a/src/nexus/db/t2/telemetry.py
+++ b/src/nexus/db/t2/telemetry.py
@@ -82,12 +82,14 @@ CREATE INDEX IF NOT EXISTS idx_relevance_log_session
 -- Schema duplicated from migrations.migrate_search_telemetry so that
 -- fresh T2Database constructions get the table even before apply_pending
 -- runs. IF NOT EXISTS makes construction idempotent with the migration.
+-- ``kept_count`` matches the RDR-087 spec; 4.6.0 shipped this column as
+-- ``dropped_count`` — the 4.6.1 rename migration upgrades existing DBs.
 CREATE TABLE IF NOT EXISTS search_telemetry (
     ts             TEXT    NOT NULL,
     query_hash     TEXT    NOT NULL,
     collection     TEXT    NOT NULL,
     raw_count      INTEGER NOT NULL,
-    dropped_count  INTEGER NOT NULL,
+    kept_count     INTEGER NOT NULL,
     top_distance   REAL,
     threshold      REAL,
     PRIMARY KEY (ts, query_hash, collection)
@@ -253,7 +255,7 @@ class Telemetry:
         """Insert per-call threshold-filter telemetry in a single transaction.
 
         Row tuple layout: ``(ts, query_hash, collection, raw_count,
-        dropped_count, top_distance, threshold)``.
+        kept_count, top_distance, threshold)``.
 
         Uses ``INSERT OR IGNORE`` on the composite PK so two writers
         racing within the same ISO-second emit exactly one row. Duplicate
@@ -265,7 +267,7 @@ class Telemetry:
         with self._lock:
             self.conn.executemany(
                 "INSERT OR IGNORE INTO search_telemetry "
-                "(ts, query_hash, collection, raw_count, dropped_count, "
+                "(ts, query_hash, collection, raw_count, kept_count, "
                 "top_distance, threshold) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?)",
                 rows,

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import structlog
 
-from nexus.config import load_config
+from nexus.config import get_telemetry_config, load_config
 from nexus.types import SearchResult
 
 _log = structlog.get_logger(__name__)
@@ -243,7 +243,7 @@ def search_cross_corpus(
     engine never emits stderr itself.
 
     *telemetry* (RDR-087 Phase 2.2 / nexus-yi4b.2.2), when provided,
-    receives one ``(ts, query_hash, collection, raw_count, dropped_count,
+    receives one ``(ts, query_hash, collection, raw_count, kept_count,
     top_distance, threshold)`` row per collection via
     ``log_search_batch``. Opt-out via ``telemetry.search_enabled = false``
     in ``.nexus.yml`` — the engine reads the flag and silently skips the
@@ -359,9 +359,10 @@ def search_cross_corpus(
         ))
 
     # RDR-087 Phase 2.2: persist per-call threshold-filter telemetry.
-    # Opt-out gate read from the same ``cfg`` used above to avoid a second
-    # config load on the hot path.
-    if telemetry is not None and cfg.get("telemetry", {}).get("search_enabled", True):
+    # Opt-out gate reads from the typed accessor so malformed
+    # ``.nexus.yml`` values surface a structured warning instead of
+    # silently coercing to a truthy string.
+    if telemetry is not None and get_telemetry_config(cfg=cfg).search_enabled:
         import hashlib
         from datetime import UTC, datetime
 
@@ -370,7 +371,7 @@ def search_cross_corpus(
         rows = [
             (
                 ts, query_hash, col,
-                raw_count, dropped_count, min_raw_per_collection[col], thr,
+                raw_count, raw_count - dropped_count, min_raw_per_collection[col], thr,
             )
             for col, (raw_count, dropped_count, thr, _dropped_min)
             in diag_per_collection.items()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -73,7 +73,7 @@ class TestMigrationDataclass:
         from nexus.db.migrations import MIGRATIONS
 
         assert isinstance(MIGRATIONS, list)
-        assert len(MIGRATIONS) == 11  # + RDR-087 search_telemetry
+        assert len(MIGRATIONS) == 12  # + RDR-087 4.6.1 rename-to-kept_count
 
     def test_migrations_ordered_by_version(self) -> None:
         from nexus.db.migrations import MIGRATIONS, _parse_version
@@ -1014,3 +1014,78 @@ class TestMigrateSearchTelemetry:
             "SELECT COUNT(*) FROM search_telemetry"
         ).fetchone()[0]
         assert count == 1
+
+
+# ── RDR-087 errata: rename dropped_count → kept_count (4.6.1) ───────────────
+
+
+class TestMigrateRenameDroppedToKept:
+    """``migrate_rename_dropped_to_kept`` upgrades a 4.6.0-era DB whose
+    ``search_telemetry`` table has ``dropped_count`` to the spec-aligned
+    ``kept_count``. Stored values are flipped via
+    ``kept_count = raw_count - dropped_count``.
+    """
+
+    def _seed_4_6_0(self, conn: sqlite3.Connection) -> None:
+        from nexus.db.migrations import migrate_search_telemetry
+
+        migrate_search_telemetry(conn)
+
+    def test_renames_column_and_flips_values(self) -> None:
+        from nexus.db.migrations import migrate_rename_dropped_to_kept
+
+        conn = sqlite3.connect(":memory:")
+        self._seed_4_6_0(conn)
+        conn.execute(
+            "INSERT INTO search_telemetry "
+            "(ts, query_hash, collection, raw_count, dropped_count, top_distance, threshold) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("2026-04-17T18:00:00Z", "h" * 64, "code__a", 5, 2, 0.30, 0.45),
+        )
+        conn.commit()
+
+        migrate_rename_dropped_to_kept(conn)
+
+        cols = {
+            r[1]
+            for r in conn.execute("PRAGMA table_info(search_telemetry)").fetchall()
+        }
+        assert "dropped_count" not in cols
+        assert "kept_count" in cols
+
+        row = conn.execute(
+            "SELECT raw_count, kept_count FROM search_telemetry"
+        ).fetchone()
+        assert row == (5, 3)  # kept = raw − dropped = 5 − 2
+
+    def test_idempotent_on_reapply(self) -> None:
+        """Second call is a no-op — column already renamed."""
+        from nexus.db.migrations import migrate_rename_dropped_to_kept
+
+        conn = sqlite3.connect(":memory:")
+        self._seed_4_6_0(conn)
+        migrate_rename_dropped_to_kept(conn)
+        migrate_rename_dropped_to_kept(conn)  # must not raise
+
+        row = conn.execute(
+            "SELECT kept_count FROM search_telemetry"
+        ).fetchone()
+        assert row is None  # empty table, column still exists
+
+    def test_noop_when_table_absent(self) -> None:
+        """No ``search_telemetry`` table — migration must be a silent no-op."""
+        from nexus.db.migrations import migrate_rename_dropped_to_kept
+
+        conn = sqlite3.connect(":memory:")
+        migrate_rename_dropped_to_kept(conn)  # must not raise
+
+    def test_in_migrations_list(self) -> None:
+        from nexus.db.migrations import MIGRATIONS
+
+        matches = [
+            (m.introduced, m.name)
+            for m in MIGRATIONS
+            if "kept_count" in m.name
+        ]
+        assert matches, "rename-to-kept_count migration must be registered"
+        assert matches[0][0] == "4.6.1"

--- a/tests/test_phase5_integration.py
+++ b/tests/test_phase5_integration.py
@@ -223,10 +223,10 @@ class TestDoctorTrimTelemetry:
             ts = (now - timedelta(days=age)).isoformat()
             conn.execute(
                 "INSERT INTO search_telemetry "
-                "(ts, query_hash, collection, raw_count, dropped_count, "
+                "(ts, query_hash, collection, raw_count, kept_count, "
                 "top_distance, threshold) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?)",
-                (ts, f"hash{i:02d}", f"coll__{i}", 3, 1, 0.30, 0.45),
+                (ts, f"hash{i:02d}", f"coll__{i}", 3, 2, 0.30, 0.45),
             )
         conn.commit()
         conn.close()

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -458,7 +458,7 @@ class _StubTelemetry:
 class TestSearchTelemetryHotPath:
     """``search_cross_corpus`` writes one row per collection to
     ``Telemetry.log_search_batch`` when a telemetry store is injected.
-    Row shape: ``(ts, query_hash, collection, raw_count, dropped_count,
+    Row shape: ``(ts, query_hash, collection, raw_count, kept_count,
     top_distance, threshold)``. ``top_distance`` here is the min distance
     across ALL raw candidates (not just the dropped subset).
     """
@@ -485,7 +485,7 @@ class TestSearchTelemetryHotPath:
         assert names == {"code__a", "knowledge__b"}
 
     def test_row_shape_matches_spec(self):
-        """Row layout: (ts, query_hash, collection, raw, dropped, top_distance, threshold)."""
+        """Row layout: (ts, query_hash, collection, raw, kept, top_distance, threshold)."""
         import hashlib
 
         telemetry = _StubTelemetry()
@@ -500,12 +500,12 @@ class TestSearchTelemetryHotPath:
         )
         rows = telemetry.batches[0]
         assert len(rows) == 1
-        ts, query_hash, collection, raw_count, dropped_count, top_distance, threshold = rows[0]
+        ts, query_hash, collection, raw_count, kept_count, top_distance, threshold = rows[0]
         expected_hash = hashlib.sha256("my query".encode()).hexdigest()[:64]
         assert query_hash == expected_hash
         assert collection == "code__a"
         assert raw_count == 2
-        assert dropped_count == 1  # 0.50 > 0.45
+        assert kept_count == 1  # 2 raw − 1 dropped (0.50 > 0.45)
         assert top_distance == pytest.approx(0.30)  # min over RAW (kept or dropped)
         assert threshold == pytest.approx(0.45)
         assert isinstance(ts, str) and "T" in ts
@@ -519,9 +519,9 @@ class TestSearchTelemetryHotPath:
         )
         rows = telemetry.batches[0]
         assert len(rows) == 1
-        _, _, _, raw_count, dropped_count, top_distance, _ = rows[0]
+        _, _, _, raw_count, kept_count, top_distance, _ = rows[0]
         assert raw_count == 0
-        assert dropped_count == 0
+        assert kept_count == 0
         assert top_distance is None
 
     def test_no_write_when_telemetry_absent(self):
@@ -560,9 +560,9 @@ class TestSearchTelemetryHotPath:
             "q", ["code__a"], 10, t3, telemetry=telemetry,
         )
         rows = telemetry.batches[0]
-        _, _, _, raw, dropped, _, threshold = rows[0]
+        _, _, _, raw, kept, _, threshold = rows[0]
         assert raw == 1
-        assert dropped == 0
+        assert kept == 1  # no filtering → all raw are kept
         assert threshold is None
 
     def test_duplicate_insert_is_ignored_not_raised(self, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.6.0"
+version = "4.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Closes the two non-blocking nits surfaced by the Phase 2.5 code review:

1. **Typed telemetry accessor on hot path** — `search_engine.search_cross_corpus` and `commands/search_cmd._emit_silent_zero_note` now use `config.get_telemetry_config(cfg=cfg)` instead of raw dict access. Malformed \`.nexus.yml\` values surface the structured `telemetry_config_malformed` warning on every call. `get_telemetry_config` accepts an optional pre-loaded `cfg` kwarg so the hot path skips the disk re-read.
2. **Schema column rename to `kept_count`** — RDR-087 §Proposed Solution specifies \`kept_count\`; 4.6.0 shipped with \`dropped_count\`. New 4.6.1 migration renames + flips values (\`kept = raw - dropped\`). Idempotent, safe on absent tables. Fresh installs get \`kept_count\` directly via \`_TELEMETRY_SCHEMA_SQL\`.

Version bump 4.6.0 → 4.6.1 across all four manifests (pyproject / marketplace / nx / sn), plus CHANGELOG + nx/CHANGELOG entries that also backfill the 4.6.0 Phase 2 umbrella.

## Test plan
- [x] `uv run pytest` — 4358 passed, 27 skipped, 0 failed
- [x] New `TestMigrateRenameDroppedToKept`: rename + value flip, idempotent reapply, no-op on absent table, registry entry
- [x] `test_phase5_integration` + `test_search_engine` updated for new column name
- [x] `test_config` unchanged (typed accessor still exercised via cfg kwarg path)
- [ ] CI green