### PR TITLE
fix(t2): remove plans(verb) index from base schema — unblocks pre-4.4.0 upgraders (#190)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.6.1"
+      "version": "4.6.2"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.6.1"
+      "version": "4.6.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.6.2] - 2026-04-17
+
+### Fixed
+
+- **Issue #190** — `nx search` (and any `T2Database` construction) crashed with `sqlite3.OperationalError: no such column: verb` for anyone whose DB was created before 4.4.0 (RDR-078 dimensional-identity columns). `_PLANS_SCHEMA_SQL` in `db/t2/plan_library.py` created four `CREATE INDEX` statements referencing the `verb` / `scope` / `dimensions` columns inline, so `_create_base_tables` crashed before the 4.4.0 `_add_plan_dimensional_identity` migration had a chance to add those columns. Indexes removed from `_PLANS_SCHEMA_SQL`; the migration already creates all four idempotently (`CREATE INDEX IF NOT EXISTS`), so fresh installs still get them via the migration and upgrading installs get both the columns and the indexes added together. Two regression tests seed a pre-4.4.0 plans table and pin `bootstrap_version` + `apply_pending` behaviour.
+
 ## [4.6.1] - 2026-04-17
 
 ### Fixed

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.6.2] - 2026-04-17
+
+Plugin version bump alongside conexus 4.6.2. See root CHANGELOG for
+the issue #190 `plans(verb)` index crash fix on pre-4.4.0 DBs.
+
 ## [4.6.1] - 2026-04-17
 
 Plugin version bump alongside conexus 4.6.1. See root CHANGELOG for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.6.1"
+version = "4.6.2"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/db/t2/plan_library.py
+++ b/src/nexus/db/t2/plan_library.py
@@ -77,11 +77,13 @@ CREATE TABLE IF NOT EXISTS plans (
     failure_count   INTEGER NOT NULL DEFAULT 0
 );
 
-CREATE INDEX IF NOT EXISTS idx_plans_verb ON plans(verb);
-CREATE INDEX IF NOT EXISTS idx_plans_scope ON plans(scope);
-CREATE INDEX IF NOT EXISTS idx_plans_verb_scope ON plans(verb, scope);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_plans_project_dimensions
-    ON plans(project, dimensions) WHERE dimensions IS NOT NULL;
+-- Indexes on the RDR-078 columns (verb/scope/dimensions) live in the
+-- 4.4.0 ``_add_plan_dimensional_identity`` migration, not here. On a
+-- pre-4.4.0 DB the plans table exists without those columns (the
+-- ``CREATE TABLE IF NOT EXISTS`` above is a no-op against an existing
+-- table) and creating the indexes inline crashes with
+-- ``sqlite3.OperationalError: no such column: verb`` before the
+-- migration that would add them has a chance to run. Issue #190.
 
 CREATE VIRTUAL TABLE IF NOT EXISTS plans_fts USING fts5(
     query,

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -883,6 +883,81 @@ class TestT2DatabaseIntegration:
             db.close()
 
 
+# ── Issue #190 regression: _create_base_tables on pre-4.4.0 DB ──────────────
+
+
+class TestBootstrapOnPreRdr078Plans:
+    """``bootstrap_version`` must not crash when the existing ``plans``
+    table lacks the RDR-078 columns (``verb``, ``scope``, ``dimensions``,
+    …). Seeded the crash Steve reported in issue #190 on conexus 4.5.3.
+
+    Root cause: ``_PLANS_SCHEMA_SQL`` previously created four indexes
+    referencing RDR-078 columns inline. On a pre-4.4.0 DB the plans
+    table existed without those columns; the ``CREATE TABLE IF NOT
+    EXISTS`` was a no-op, but the ``CREATE INDEX IF NOT EXISTS
+    idx_plans_verb ON plans(verb)`` statement crashed before the 4.4.0
+    ``_add_plan_dimensional_identity`` migration could add the columns.
+    """
+
+    def _seed_pre_rdr078_plans(self, conn: sqlite3.Connection) -> None:
+        """Seed a ``plans`` table shaped like pre-4.4.0 installs."""
+        conn.executescript(
+            """\
+            CREATE TABLE plans (
+                id         INTEGER PRIMARY KEY,
+                project    TEXT NOT NULL DEFAULT '',
+                query      TEXT NOT NULL,
+                plan_json  TEXT NOT NULL,
+                outcome    TEXT DEFAULT 'success',
+                tags       TEXT DEFAULT '',
+                created_at TEXT NOT NULL,
+                ttl        INTEGER
+            );
+            """
+        )
+        conn.commit()
+
+    def test_bootstrap_does_not_crash_on_pre_rdr078_plans(self) -> None:
+        """Regression: bootstrap_version + _create_base_tables must no-op
+        cleanly against an old plans shape."""
+        from nexus.db.migrations import bootstrap_version
+
+        conn = sqlite3.connect(":memory:")
+        self._seed_pre_rdr078_plans(conn)
+
+        # Must not raise ``sqlite3.OperationalError: no such column: verb``.
+        last_seen = bootstrap_version(conn)
+        assert isinstance(last_seen, str) and last_seen
+
+    def test_apply_pending_adds_columns_then_indexes(self) -> None:
+        """After ``apply_pending`` walks past 4.4.0, the plans table has
+        both the RDR-078 columns and the four indexes.
+        """
+        from nexus.db.migrations import apply_pending
+
+        conn = sqlite3.connect(":memory:")
+        self._seed_pre_rdr078_plans(conn)
+
+        apply_pending(conn, "4.6.2")
+
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(plans)").fetchall()}
+        assert {"verb", "scope", "dimensions"} <= cols
+
+        # PRAGMA index_list rows: (seq, name, unique, origin, partial).
+        index_info = {
+            r[1]: {"unique": bool(r[2]), "partial": bool(r[4])}
+            for r in conn.execute("PRAGMA index_list(plans)").fetchall()
+        }
+        assert "idx_plans_verb" in index_info
+        assert "idx_plans_scope" in index_info
+        assert "idx_plans_verb_scope" in index_info
+        assert "idx_plans_project_dimensions" in index_info
+        # Guard against silent degradation: this one MUST be unique AND
+        # partial (``WHERE dimensions IS NOT NULL``) per the migration.
+        assert index_info["idx_plans_project_dimensions"]["unique"]
+        assert index_info["idx_plans_project_dimensions"]["partial"]
+
+
 # ── RDR-087 Phase 2.1: search_telemetry migration ───────────────────────────
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.6.1"
+version = "4.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Fixes **#190** — \`nx search\` (and every other \`nx\` command) crashed with \`sqlite3.OperationalError: no such column: verb\` for anyone whose DB was created before 4.4.0.

## Root cause

\`_PLANS_SCHEMA_SQL\` in \`src/nexus/db/t2/plan_library.py\` had four \`CREATE INDEX\` statements referencing RDR-078 columns (\`verb\`, \`scope\`, \`dimensions\`) inline. On a pre-4.4.0 DB:

1. \`T2Database(__init__)\` → \`apply_pending\` → \`bootstrap_version\`
2. \`_create_base_tables\` runs \`conn.executescript(_PLANS_SCHEMA_SQL)\`
3. \`CREATE TABLE IF NOT EXISTS plans (...)\` is a no-op (existing old table)
4. \`CREATE INDEX IF NOT EXISTS idx_plans_verb ON plans(verb)\` **crashes** — \`verb\` doesn't exist yet
5. The 4.4.0 \`_add_plan_dimensional_identity\` migration that would have added \`verb\` never gets to run

## Fix

Delete the four \`CREATE INDEX\` statements from \`_PLANS_SCHEMA_SQL\`. The 4.4.0 migration already creates them idempotently with \`CREATE INDEX IF NOT EXISTS\` — nothing is lost:

- **Fresh install** (\`last_seen=0.0.0\`): migration creates columns + indexes.
- **Pre-registry upgrade** (\`last_seen=PRE_REGISTRY_VERSION=4.1.2\`, Steve's case): migration adds columns and indexes together.
- **Already migrated** (\`last_seen≥4.4.0\`): indexes exist; fast path no-op.

Confirmed live — seeded a pre-4.4.0 plans table, ran \`T2Database(path)\`, watched all 12 migrations complete cleanly, \`verb\` column added, indexes present.

## Scope audit

Checked every other \`_*_SCHEMA_SQL\` constant under \`src/nexus/db/t2/\` for the same pattern (inline \`CREATE INDEX\` on a column that only exists after a migration):

- \`memory_store.py\`: \`agent\` / \`access_count\` / \`last_accessed\` all declared in the base \`CREATE TABLE\` block — safe.
- \`telemetry.py\`: both tables are self-contained; no migration-added column is indexed inline.
- \`catalog_taxonomy.py\`: no inline \`CREATE INDEX\` at all.

No analogous bombs.

## Tests

New \`TestBootstrapOnPreRdr078Plans\` in \`tests/test_migrations.py\`:
- \`test_bootstrap_does_not_crash_on_pre_rdr078_plans\` — seeds a pre-4.4.0 plans shape, calls \`bootstrap_version\`, asserts no raise.
- \`test_apply_pending_adds_columns_then_indexes\` — same seed, calls \`apply_pending("4.6.2")\`, asserts all 12 RDR-078 columns present AND all four indexes created. Guards against silent degradation of \`idx_plans_project_dimensions\` to a plain (non-unique, non-partial) index.

## Test plan
- [x] \`uv run pytest tests/test_migrations.py tests/test_plan_library.py\` — 87 passed
- [x] Full suite — 4378 passed, 27 skipped
- [x] Live repro: pre-4.4.0 plans table seeded, \`T2Database\` constructs cleanly, all migrations run
- [ ] CI green

## Version

4.6.1 → 4.6.2 (patch — pure behaviour restoration). Manifests: \`pyproject.toml\`, \`.claude-plugin/marketplace.json\` (2 entries), \`nx/.claude-plugin/plugin.json\`, \`sn/.claude-plugin/plugin.json\`; \`CHANGELOG\` + \`nx/CHANGELOG\` backfilled.