### PR TITLE
feat(doctor): --check-search probe 3b (nexus-yi4b.3.3)

### DIFF
--- a/src/nexus/doctor_search.py
+++ b/src/nexus/doctor_search.py
@@ -1,46 +1,68 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 Hal Hildebrand. All rights reserved.
-"""Probe 3a — name-resolution canary for ``nx doctor --check-search``.
+"""Probes 3a + 3b — ``nx doctor --check-search``.
 
-RDR-087 Phase 3.2 (nexus-yi4b.3.2). Walks the ``NAME_CANARIES``
-fixture through three name-resolution surfaces (``resolve_corpus``,
-``rdr_resolve``, ``resolve_span``) and reports one of three outcomes
-per dispatch:
+RDR-087 Phase 3. Two probes running back-to-back under one CLI flag:
+
+**Probe 3a — name resolution** (Phase 3.2, nexus-yi4b.3.2). Walks the
+``NAME_CANARIES`` fixture through three name-resolution surfaces
+(``resolve_corpus``, ``rdr_resolve``, ``resolve_span``). Outcomes per
+dispatch:
 
 - ``matched`` — surface returned a positive result.
-- ``empty``   — surface completed cleanly but found nothing
-  (``resolve_corpus`` returns empty list, ``rdr_resolve`` raises
-  ``ResolutionError``). Informational, NOT a regression.
+- ``empty``   — surface completed cleanly but found nothing.
 - ``error``   — surface raised an unexpected exception. Regression.
-  This is what nexus-51j (case-sensitive glob pre-PR #173),
-  nexus-7ay, and nexus-rc45 looked like in production.
 
-The CLI exits ``2`` when any dispatch produced ``error``, ``0``
-otherwise. ``--json`` emits a parseable payload for automation.
+**Probe 3b — retrieval quality** (Phase 3.3, nexus-yi4b.3.3). One
+``search_cross_corpus`` call per registered collection with a canned
+query; classifies each as:
+
+- ``matched``        — raw>0 AND kept>0. Healthy.
+- ``empty``          — raw==0. Empty or corrupt.
+- ``threshold_drop`` — raw>0 AND kept==0. nexus-rc45 class (silent
+  threshold-drop). Regression-level signal.
+- ``model_drift``    — registered ``embedding_model`` metadata
+  disagrees with :func:`corpus.voyage_model_for_collection`.
+  Regression.
+- ``error``          — unexpected exception during search or
+  metadata lookup.
+
+The CLI exits ``2`` when either probe produced any ``error`` /
+``threshold_drop`` / ``model_drift`` outcome, ``0`` otherwise.
+``--json`` emits a parseable payload covering both probes.
 """
 from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 import click
 
 _CHASH_SHAPE = re.compile(r"chash:[0-9a-f]{64}(:\d+-\d+)?")
 
 
+# Retrieval-quality outcomes that signal a regression (exit 2).
+_FAIL_OUTCOMES = {"error", "threshold_drop", "model_drift"}
+
+
 @dataclass(frozen=True)
 class ProbeResult:
     name: str
     surface: str
-    outcome: str  # "matched" | "empty" | "error"
+    outcome: str  # matched | empty | error | threshold_drop | model_drift
     error: str | None = None
     shape_note: str = ""
+    # Probe 3b-specific context (None on probe 3a rows).
+    raw_count: int | None = None
+    kept_count: int | None = None
+    expected_model: str | None = None
+    actual_model: str | None = None
 
 
-# ── Surface runners (real, production-wired) ────────────────────────────────
+# ── Surface runners (probe 3a, production-wired) ────────────────────────────
 
 
 def _default_rdr_dir() -> Path:
@@ -75,7 +97,27 @@ def _load_canaries():
     return NAME_CANARIES
 
 
-# ── Core probe ──────────────────────────────────────────────────────────────
+# ── Collection + metadata enumerators (probe 3b, production-wired) ──────────
+
+
+def _make_t3():
+    from nexus.db import make_t3
+
+    return make_t3()
+
+
+def _list_collections() -> list[str]:
+    """Return every registered T3 collection name."""
+    t3 = _make_t3()
+    return [c["name"] for c in t3.list_collections()]
+
+
+def _collection_metadata(t3, col: str) -> dict[str, Any]:
+    """Return the ChromaDB metadata dict for *col* (or empty dict)."""
+    return t3.collection_metadata(col)
+
+
+# ── Probe 3a: name resolution ───────────────────────────────────────────────
 
 
 def run_name_resolution_probe(
@@ -129,36 +171,225 @@ def run_name_resolution_probe(
     return out
 
 
+# ── Probe 3b: retrieval quality ─────────────────────────────────────────────
+
+
+def _default_search_fn(*args, **kwargs):
+    from nexus.search_engine import search_cross_corpus
+
+    return search_cross_corpus(*args, **kwargs)
+
+
+def _default_model_for(col: str) -> str:
+    from nexus.corpus import voyage_model_for_collection
+
+    return voyage_model_for_collection(col)
+
+
+def run_retrieval_quality_probe(
+    *,
+    t3,
+    collections: list[str],
+    search_fn: Callable[..., Any] = _default_search_fn,
+    model_for: Callable[[str], str] = _default_model_for,
+    metadata_fn: Callable[[str], dict[str, Any]] | None = None,
+    query: str = "example test probe",
+    n_results: int = 5,
+) -> list[ProbeResult]:
+    """Query each registered collection and classify retrieval health.
+
+    Model-drift detection runs *before* the search so a drifted collection
+    is flagged even if the query happened to return data (wrong embedding
+    model → systematically wrong distances, even when non-empty).
+
+    Args:
+        t3: T3Database client. Passed through to ``search_fn``.
+        collections: collection names to probe (caller enumerates).
+        search_fn: injectable ``search_cross_corpus`` stand-in for tests.
+        model_for: maps collection name → expected embedding_model.
+        metadata_fn: ``col_name -> metadata dict``. Defaults to
+            ``t3.collection_metadata`` when *None*.
+        query: canned probe query. Short so we stay inside the budget
+            (≤400 ms per A-2 measurement).
+        n_results: small probe depth.
+    """
+    from nexus.search_engine import SearchDiagnostics  # noqa: F401
+
+    if metadata_fn is None:
+        def metadata_fn(col: str) -> dict[str, Any]:
+            return _collection_metadata(t3, col)
+
+    out: list[ProbeResult] = []
+    for col in collections:
+        expected = ""
+        actual = ""
+        try:
+            expected = model_for(col)
+            meta = metadata_fn(col) or {}
+            actual = str(meta.get("embedding_model") or "")
+        except Exception as exc:
+            out.append(
+                ProbeResult(
+                    name=col,
+                    surface="retrieval_quality",
+                    outcome="error",
+                    error=f"{type(exc).__name__}: {exc}",
+                    expected_model=expected or None,
+                    actual_model=actual or None,
+                )
+            )
+            continue
+
+        if actual and actual != expected:
+            out.append(
+                ProbeResult(
+                    name=col,
+                    surface="retrieval_quality",
+                    outcome="model_drift",
+                    expected_model=expected,
+                    actual_model=actual,
+                )
+            )
+            continue
+
+        try:
+            diag_list: list[Any] = []
+            search_fn(
+                query, [col], n_results, t3,
+                diagnostics_out=diag_list,
+            )
+        except Exception as exc:
+            out.append(
+                ProbeResult(
+                    name=col,
+                    surface="retrieval_quality",
+                    outcome="error",
+                    error=f"{type(exc).__name__}: {exc}",
+                    expected_model=expected,
+                    actual_model=actual,
+                )
+            )
+            continue
+
+        if not diag_list:
+            out.append(
+                ProbeResult(
+                    name=col,
+                    surface="retrieval_quality",
+                    outcome="error",
+                    error="search_fn did not populate diagnostics_out",
+                    expected_model=expected,
+                    actual_model=actual,
+                )
+            )
+            continue
+
+        diag = diag_list[0]
+        per_col = diag.per_collection.get(col, (0, 0, None, None))
+        raw, dropped = per_col[0], per_col[1]
+        kept = raw - dropped
+        if raw == 0:
+            outcome = "empty"
+        elif kept == 0:
+            outcome = "threshold_drop"
+        else:
+            outcome = "matched"
+        out.append(
+            ProbeResult(
+                name=col,
+                surface="retrieval_quality",
+                outcome=outcome,
+                raw_count=raw,
+                kept_count=kept,
+                expected_model=expected,
+                actual_model=actual,
+            )
+        )
+    return out
+
+
 # ── Output formatters ───────────────────────────────────────────────────────
 
 
-_GLYPH = {"matched": "[\u2713]", "empty": "[-]", "error": "[\u2717]"}
+_GLYPH = {
+    "matched": "[\u2713]",
+    "empty": "[-]",
+    "error": "[\u2717]",
+    "threshold_drop": "[\u2717]",
+    "model_drift": "[\u2717]",
+}
 
 
-def format_probe_human(results: list[ProbeResult]) -> str:
-    lines = ["name_resolution probe:"]
+def _format_probe_section(title: str, results: list[ProbeResult]) -> list[str]:
+    lines = [f"{title}:"]
     for r in results:
         glyph = _GLYPH.get(r.outcome, "[?]")
-        suffix = f"  {r.error}" if r.error else ""
+        detail_parts: list[str] = []
+        if r.raw_count is not None:
+            detail_parts.append(f"raw={r.raw_count} kept={r.kept_count}")
+        if r.outcome == "model_drift":
+            detail_parts.append(
+                f"expected={r.expected_model} actual={r.actual_model}"
+            )
+        if r.error:
+            detail_parts.append(r.error)
+        detail = ("  " + " ".join(detail_parts)) if detail_parts else ""
         lines.append(
-            f"  {glyph} {r.outcome:<7} {r.name} ({r.surface}){suffix}"
+            f"  {glyph} {r.outcome:<15} {r.name} ({r.surface}){detail}"
         )
-    m = sum(1 for r in results if r.outcome == "matched")
-    e = sum(1 for r in results if r.outcome == "empty")
-    x = sum(1 for r in results if r.outcome == "error")
-    lines.append(f"Summary: {m} matched, {e} empty, {x} error.")
+    return lines
+
+
+def _summary_counts(results: list[ProbeResult]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.outcome] = counts.get(r.outcome, 0) + 1
+    return counts
+
+
+def format_combined_human(
+    name_results: list[ProbeResult],
+    retrieval_results: list[ProbeResult],
+) -> str:
+    lines: list[str] = []
+    lines.extend(_format_probe_section("name_resolution probe", name_results))
+    nr = _summary_counts(name_results)
+    lines.append(
+        f"Summary: {nr.get('matched', 0)} matched, "
+        f"{nr.get('empty', 0)} empty, {nr.get('error', 0)} error."
+    )
+    lines.append("")
+    lines.extend(
+        _format_probe_section("retrieval_quality probe", retrieval_results)
+    )
+    rq = _summary_counts(retrieval_results)
+    lines.append(
+        f"Summary: {rq.get('matched', 0)} matched, "
+        f"{rq.get('empty', 0)} empty, "
+        f"{rq.get('threshold_drop', 0)} threshold_drop, "
+        f"{rq.get('model_drift', 0)} model_drift, "
+        f"{rq.get('error', 0)} error."
+    )
     return "\n".join(lines)
 
 
-def format_probe_json(results: list[ProbeResult]) -> str:
+def format_combined_json(
+    name_results: list[ProbeResult],
+    retrieval_results: list[ProbeResult],
+) -> str:
     payload = {
-        "probe": "name_resolution",
-        "results": [asdict(r) for r in results],
-        "summary": {
-            "matched": sum(1 for r in results if r.outcome == "matched"),
-            "empty": sum(1 for r in results if r.outcome == "empty"),
-            "error": sum(1 for r in results if r.outcome == "error"),
-        },
+        "probes": [
+            {
+                "probe": "name_resolution",
+                "results": [asdict(r) for r in name_results],
+                "summary": _summary_counts(name_results),
+            },
+            {
+                "probe": "retrieval_quality",
+                "results": [asdict(r) for r in retrieval_results],
+                "summary": _summary_counts(retrieval_results),
+            },
+        ],
     }
     return json.dumps(payload, indent=2)
 
@@ -167,19 +398,57 @@ def format_probe_json(results: list[ProbeResult]) -> str:
 
 
 def run_check_search(*, json_out: bool) -> None:
-    """Execute probe 3a and exit with status 2 when any regression is seen."""
+    """Execute both probes and exit 2 when any regression signal is seen."""
+    # Probe 3a.
     canaries = _load_canaries()
-    # Look up runners at call time (not via defaults) so tests can
-    # monkeypatch the module-level names without patching every caller.
-    results = run_name_resolution_probe(
+    name_results = run_name_resolution_probe(
         canaries,
         resolve_corpus_fn=_corpus_runner,
         rdr_resolve_fn=_rdr_runner,
         resolve_span_fn=_span_runner,
     )
-    if json_out:
-        click.echo(format_probe_json(results))
+
+    # Probe 3b — enumerate collections via a live T3 client.  Any failure
+    # in the enumeration itself is reported as a single error row so the
+    # probe stays informative even when T3 is unreachable.
+    retrieval_results: list[ProbeResult] = []
+    try:
+        collections = _list_collections()
+    except Exception as exc:
+        retrieval_results.append(
+            ProbeResult(
+                name="<enumerate>",
+                surface="retrieval_quality",
+                outcome="error",
+                error=f"{type(exc).__name__}: {exc}",
+            )
+        )
     else:
-        click.echo(format_probe_human(results))
-    if any(r.outcome == "error" for r in results):
+        if collections:
+            try:
+                t3 = _make_t3()
+            except Exception as exc:
+                retrieval_results.append(
+                    ProbeResult(
+                        name="<t3_client>",
+                        surface="retrieval_quality",
+                        outcome="error",
+                        error=f"{type(exc).__name__}: {exc}",
+                    )
+                )
+            else:
+                retrieval_results.extend(
+                    run_retrieval_quality_probe(
+                        t3=t3,
+                        collections=collections,
+                    )
+                )
+
+    if json_out:
+        click.echo(format_combined_json(name_results, retrieval_results))
+    else:
+        click.echo(format_combined_human(name_results, retrieval_results))
+
+    combined = name_results + retrieval_results
+    if any(r.outcome in _FAIL_OUTCOMES for r in combined):
         raise SystemExit(2)

--- a/tests/test_doctor_search.py
+++ b/tests/test_doctor_search.py
@@ -178,7 +178,8 @@ class TestDoctorCheckSearchCli:
     def test_json_flag_emits_parseable_output(
         self, runner: CliRunner, tmp_path, monkeypatch,
     ) -> None:
-        """``--check-search --json`` emits a parseable JSON array."""
+        """``--check-search --json`` emits a parseable JSON payload that
+        wraps both probes."""
         from nexus.cli import main
 
         monkeypatch.setattr(
@@ -197,16 +198,24 @@ class TestDoctorCheckSearchCli:
             "nexus.doctor_search._rdr_runner",
             _faked_rdr_runner,
         )
+        # Isolate from live T3 for probe 3b.
+        monkeypatch.setattr(
+            "nexus.doctor_search._list_collections",
+            lambda: [],
+        )
 
         result = runner.invoke(main, ["doctor", "--check-search", "--json"])
         # exit_code == 2 because the seeded set includes 'raises-name';
         # JSON payload is still emitted on regression.
         payload = json.loads(result.output)
         assert isinstance(payload, dict)
-        assert payload["probe"] == "name_resolution"
-        assert isinstance(payload["results"], list)
-        assert len(payload["results"]) == 3
-        outcomes = {r["name"]: r["outcome"] for r in payload["results"]}
+        assert "probes" in payload and len(payload["probes"]) == 2
+        probe_names = [p["probe"] for p in payload["probes"]]
+        assert probe_names == ["name_resolution", "retrieval_quality"]
+        name_res = payload["probes"][0]
+        assert isinstance(name_res["results"], list)
+        assert len(name_res["results"]) == 3
+        outcomes = {r["name"]: r["outcome"] for r in name_res["results"]}
         assert outcomes == {
             "healthy-name": "matched",
             "raises-name": "error",
@@ -235,7 +244,202 @@ class TestDoctorCheckSearchCli:
             "nexus.doctor_search._rdr_runner",
             _faked_rdr_runner,
         )
+        # Stub retrieval probe so CLI test doesn't exercise live T3.
+        monkeypatch.setattr(
+            "nexus.doctor_search.run_retrieval_quality_probe",
+            lambda **kwargs: [],
+        )
+        # Short-circuit the enumerator so we don't try to list T3.
+        monkeypatch.setattr(
+            "nexus.doctor_search._list_collections",
+            lambda: [],
+        )
 
         result = runner.invoke(main, ["doctor", "--check-search"])
         # At least one canary raises → regression → exit 2.
         assert result.exit_code == 2
+
+
+# ── Probe 3b: retrieval quality ─────────────────────────────────────────────
+
+
+def _stub_search_fn(dist_table):
+    """Return a search_fn that populates diag_per_collection from *dist_table*.
+
+    dist_table maps collection_name → (raw, dropped) tuples.
+    """
+    def _fn(query, collections, n_results, t3, *, diagnostics_out=None, **_):
+        from nexus.search_engine import SearchDiagnostics
+
+        per_col = {}
+        total_raw = 0
+        total_dropped = 0
+        for col in collections:
+            raw, dropped = dist_table.get(col, (0, 0))
+            per_col[col] = (raw, dropped, 0.45, None)
+            total_raw += raw
+            total_dropped += dropped
+        if diagnostics_out is not None:
+            diagnostics_out.append(
+                SearchDiagnostics(
+                    per_collection=per_col,
+                    total_dropped=total_dropped,
+                    total_raw=total_raw,
+                )
+            )
+        return []
+    return _fn
+
+
+def _stub_model_for(col: str) -> str:
+    if col.startswith(("docs__", "knowledge__", "rdr__")):
+        return "voyage-context-3"
+    return "voyage-code-3"
+
+
+class TestRetrievalQualityProbe:
+    """Probe 3b — one search per registered collection, classify outcomes."""
+
+    def test_matched_when_raw_positive_and_kept_positive(self) -> None:
+        from nexus.doctor_search import run_retrieval_quality_probe
+
+        results = run_retrieval_quality_probe(
+            t3=None,
+            collections=["code__clean"],
+            search_fn=_stub_search_fn({"code__clean": (5, 2)}),
+            model_for=_stub_model_for,
+            metadata_fn=lambda col: {"embedding_model": "voyage-code-3"},
+        )
+        assert len(results) == 1
+        assert results[0].outcome == "matched"
+        assert results[0].raw_count == 5
+        assert results[0].kept_count == 3
+
+    def test_empty_when_raw_is_zero(self) -> None:
+        from nexus.doctor_search import run_retrieval_quality_probe
+
+        results = run_retrieval_quality_probe(
+            t3=None,
+            collections=["knowledge__empty"],
+            search_fn=_stub_search_fn({"knowledge__empty": (0, 0)}),
+            model_for=_stub_model_for,
+            metadata_fn=lambda col: {"embedding_model": "voyage-context-3"},
+        )
+        assert results[0].outcome == "empty"
+        assert results[0].raw_count == 0
+
+    def test_threshold_drop_when_raw_positive_kept_zero(self) -> None:
+        """nexus-rc45 class — raw>0 but threshold filtered everything."""
+        from nexus.doctor_search import run_retrieval_quality_probe
+
+        results = run_retrieval_quality_probe(
+            t3=None,
+            collections=["docs__dropped"],
+            search_fn=_stub_search_fn({"docs__dropped": (4, 4)}),
+            model_for=_stub_model_for,
+            metadata_fn=lambda col: {"embedding_model": "voyage-context-3"},
+        )
+        assert results[0].outcome == "threshold_drop"
+        assert results[0].raw_count == 4
+        assert results[0].kept_count == 0
+
+    def test_model_drift_when_metadata_disagrees(self) -> None:
+        """Registered embedding_model doesn't match expected for prefix."""
+        from nexus.doctor_search import run_retrieval_quality_probe
+
+        results = run_retrieval_quality_probe(
+            t3=None,
+            collections=["knowledge__drifted"],
+            search_fn=_stub_search_fn({"knowledge__drifted": (3, 1)}),
+            model_for=_stub_model_for,
+            # Expected voyage-context-3 for knowledge__, but metadata says voyage-code-3.
+            metadata_fn=lambda col: {"embedding_model": "voyage-code-3"},
+        )
+        # Model drift overrides the match-class — it's a regression-level signal
+        # even when the query happened to return results.
+        assert results[0].outcome == "model_drift"
+        assert results[0].expected_model == "voyage-context-3"
+        assert results[0].actual_model == "voyage-code-3"
+
+    def test_error_when_search_raises(self) -> None:
+        from nexus.doctor_search import run_retrieval_quality_probe
+
+        def _raise(*a, **kw):
+            raise RuntimeError("t3 connection crashed")
+
+        results = run_retrieval_quality_probe(
+            t3=None,
+            collections=["code__boom"],
+            search_fn=_raise,
+            model_for=_stub_model_for,
+            metadata_fn=lambda col: {"embedding_model": "voyage-code-3"},
+        )
+        assert results[0].outcome == "error"
+        assert results[0].error is not None
+        assert "t3 connection crashed" in results[0].error
+
+    def test_all_five_outcome_classes_together(self) -> None:
+        """One call over a mixed collection list covers every bucket."""
+        from nexus.doctor_search import run_retrieval_quality_probe
+
+        metas = {
+            "code__healthy":    {"embedding_model": "voyage-code-3"},
+            "docs__empty":      {"embedding_model": "voyage-context-3"},
+            "knowledge__drop":  {"embedding_model": "voyage-context-3"},
+            "docs__drifted":    {"embedding_model": "voyage-code-3"},  # wrong
+        }
+
+        def _search(query, collections, n_results, t3, *, diagnostics_out=None, **_):
+            from nexus.search_engine import SearchDiagnostics
+
+            if "code__boom" in collections:
+                raise RuntimeError("simulated")
+            per_col = {}
+            for col in collections:
+                if col == "code__healthy":
+                    per_col[col] = (5, 2, 0.45, None)
+                elif col == "docs__empty":
+                    per_col[col] = (0, 0, 0.45, None)
+                elif col == "knowledge__drop":
+                    per_col[col] = (4, 4, 0.45, None)
+                elif col == "docs__drifted":
+                    per_col[col] = (3, 1, 0.45, None)
+                else:
+                    per_col[col] = (0, 0, 0.45, None)
+            if diagnostics_out is not None:
+                diagnostics_out.append(
+                    SearchDiagnostics(
+                        per_collection=per_col,
+                        total_dropped=0,
+                        total_raw=0,
+                    )
+                )
+            return []
+
+        def _outer_search(query, collections, n_results, t3, *, diagnostics_out=None, **kw):
+            if "code__boom" in collections:
+                raise RuntimeError("simulated")
+            return _search(
+                query, collections, n_results, t3,
+                diagnostics_out=diagnostics_out, **kw,
+            )
+
+        results = run_retrieval_quality_probe(
+            t3=None,
+            collections=[
+                "code__healthy",
+                "docs__empty",
+                "knowledge__drop",
+                "docs__drifted",
+                "code__boom",
+            ],
+            search_fn=_outer_search,
+            model_for=_stub_model_for,
+            metadata_fn=lambda col: metas.get(col, {}),
+        )
+        by_name = {r.name: r.outcome for r in results}
+        assert by_name["code__healthy"] == "matched"
+        assert by_name["docs__empty"] == "empty"
+        assert by_name["knowledge__drop"] == "threshold_drop"
+        assert by_name["docs__drifted"] == "model_drift"
+        assert by_name["code__boom"] == "error"


### PR DESCRIPTION
## Summary

RDR-087 Phase 3.3 — probe 3b (retrieval quality) wired into the existing \`nx doctor --check-search\` CLI. Runs one canned-query search per registered T3 collection and classifies each as \`matched\` / \`empty\` / \`threshold_drop\` / \`model_drift\` / \`error\`.

**Outcome semantics**
| outcome | meaning | fail-the-probe? |
|---|---|---|
| \`matched\`        | raw>0 AND kept>0. Healthy. | no |
| \`empty\`          | raw==0. Empty / corrupt. | no (informational) |
| \`threshold_drop\` | raw>0 AND kept==0. nexus-rc45 class. | **yes** |
| \`model_drift\`    | registered \`embedding_model\` ≠ \`voyage_model_for_collection()\` | **yes** |
| \`error\`          | unexpected exception in search or metadata | **yes** |

Model-drift detection runs *before* the search so drifted collections flag even when a query happens to return data.

**Architecture**

- \`run_retrieval_quality_probe(...)\` in \`src/nexus/doctor_search.py\` — dependency-injected (search_fn, model_for, metadata_fn) so tests don't need live T3.
- \`ProbeResult\` gains 4 optional fields (\`raw_count\`, \`kept_count\`, \`expected_model\`, \`actual_model\`) — None on probe 3a rows.
- CLI unchanged: \`--check-search\` runs both probes back-to-back. \`--json\` output wraps both under \`{"probes": [...]}\`.
- Live T3 enumeration (\`make_t3() → list_collections\`) wrapped in \`try/except\` so T3 failures produce a single error row rather than crashing the whole probe.

**Live smoke on this repo** (post-rebase against \`e0fac24\`):

\`\`\`
name_resolution probe:  2 matched, 9 empty, 0 error
retrieval_quality probe: 13 matched, 2 empty, 122 threshold_drop, 0 model_drift, 0 error
\`\`\`

The 122 \`threshold_drop\` results are exactly the nexus-rc45 bug class the RDR calls out (lines 259-268): default per-prefix thresholds are too strict for dense-prose collections; the generic \`"example test probe"\` query lands far enough from canonical documents that thresholds zero everything out. Probe 3b is **working as designed** — this is the surfacing the RDR wants. Tuning the thresholds (or deciding this is acceptable noise) is downstream work, not a probe-3b bug.

## Test plan
- [x] \`uv run pytest tests/test_doctor_search.py tests/test_name_canaries.py tests/test_migrations.py\` — 90 passed
- [x] Full suite locally (pre-rebase) — 4378 passed, 27 skipped
- [x] Live smoke on this repo — probe completes in ~20s across 137 collections
- [ ] CI green

## Follow-up

- Phase 3.4 (\`nexus-yi4b.3.4\`): \`nx collection health\` composite report that folds both probes + telemetry aggregates into a single per-collection view.
- Consider making the probe query configurable via \`.nexus.yml\` so users can run it against collection-specific canned queries that they expect to match (tuning knob for threshold-drop noise).