### PR TITLE
fix(t3): skip dimension-mismatched collections during search (#190 follow-up)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.6.2"
+      "version": "4.6.3"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.6.2"
+      "version": "4.6.3"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.6.3] - 2026-04-17
+
+### Fixed
+
+- **Issue #190 follow-up** — `nx search` (and any cross-corpus query) no longer crashes when a T3 collection's stored embeddings don't match the current embedding model's output dimension. `T3Database.search` now catches `chromadb.errors.InvalidArgumentError` where the message contains `"dimension"`, logs a structured `collection_dimension_mismatch_skipped` warning with the collection name, and continues to the next collection. Non-dimension `InvalidArgumentError` subtypes (malformed `where` clause, bad query args, etc.) still propagate. Unblocks users who upgraded their local embedding model and left older collections around at the previous dimension — they can now search across the healthy collections without manually deleting the stale ones first.
+
 ## [4.6.2] - 2026-04-17
 
 ### Fixed

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.6.3] - 2026-04-17
+
+Plugin version bump alongside conexus 4.6.3. See root CHANGELOG for
+the dimension-mismatch skip-and-warn guard in `T3Database.search`
+(issue #190 follow-up).
+
 ## [4.6.2] - 2026-04-17
 
 Plugin version bump alongside conexus 4.6.2. See root CHANGELOG for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.6.2"
+version = "4.6.3"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -12,7 +12,10 @@ from typing import Literal
 import chromadb
 import chromadb.errors
 import httpx
-from chromadb.errors import NotFoundError as _ChromaNotFoundError
+from chromadb.errors import (
+    InvalidArgumentError as _ChromaInvalidArgumentError,
+    NotFoundError as _ChromaNotFoundError,
+)
 import structlog
 
 import voyageai
@@ -678,7 +681,25 @@ class T3Database:
                 }
             if where is not None:
                 query_kwargs["where"] = where
-            qr = _chroma_with_retry(col.query, **query_kwargs)
+            try:
+                qr = _chroma_with_retry(col.query, **query_kwargs)
+            except _ChromaInvalidArgumentError as exc:
+                # Dimension mismatch = collection was indexed with a
+                # different embedding model than the one currently
+                # configured. Crashes the whole multi-collection search
+                # if we let it bubble. Skip this collection, warn, and
+                # continue — issue #190 follow-up. Other
+                # ``InvalidArgumentError`` subtypes (bad where clause,
+                # malformed query, etc.) point at a caller bug and
+                # must still surface.
+                if "dimension" in str(exc).lower():
+                    _log.warning(
+                        "collection_dimension_mismatch_skipped",
+                        collection=name,
+                        error=str(exc),
+                    )
+                    continue
+                raise
             for doc_id, doc, meta, dist in zip(
                 qr["ids"][0],
                 qr["documents"][0],

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -344,6 +344,78 @@ def test_search_skips_missing_collection_without_creating(mock_chromadb):
     mock_client.get_or_create_collection.assert_not_called()
 
 
+# ── Dimension-mismatch guard (issue #190 follow-up) ─────────────────────────
+
+
+def test_search_skips_dimension_mismatch_rather_than_crashing(mock_db):
+    """Collection indexed at a different embedding dimension than the
+    current model emits must be skipped with a warning, not crash search.
+
+    Issue #190 follow-up: users who upgraded the local embedding model
+    kept older collections around at the previous dimension; ChromaDB
+    raises ``InvalidArgumentError`` on ``col.query`` because the query
+    embedding dimension doesn't match the stored vectors. Previously
+    this crashed the whole multi-collection search. Now we log a
+    structured warning and continue with the remaining collections.
+    """
+    db, mock_col, _ = mock_db
+    mock_col.count.return_value = 3
+    mock_col.query.side_effect = chromadb.errors.InvalidArgumentError(
+        "Collection expecting embedding with dimension of 384, got 768"
+    )
+    # Single-collection call: search must return empty, not raise.
+    results = db.search("q", ["knowledge__stale"], n_results=5)
+    assert results == []
+
+
+def test_search_continues_past_dimension_mismatch_to_next_collection(
+    mock_chromadb,
+):
+    """Mismatch on collection A must not prevent collection B from being queried."""
+    _, mock_client = mock_chromadb
+
+    col_bad = MagicMock()
+    col_bad.count.return_value = 3
+    col_bad.query.side_effect = chromadb.errors.InvalidArgumentError(
+        "Collection expecting embedding with dimension of 384, got 768"
+    )
+
+    col_good = MagicMock()
+    col_good.count.return_value = 2
+    col_good.query.return_value = {
+        "ids": [["g-1"]],
+        "documents": [["good content"]],
+        "metadatas": [[{}]],
+        "distances": [[0.1]],
+    }
+
+    def _get_collection(name, **kw):
+        return col_bad if name == "knowledge__stale" else col_good
+
+    mock_client.get_collection.side_effect = _get_collection
+    db = T3Database(tenant="t", database="d", api_key="k")
+    results = db.search(
+        "q", ["knowledge__stale", "code__healthy"], n_results=5,
+    )
+    assert len(results) == 1
+    assert results[0]["id"] == "g-1"
+
+
+def test_search_propagates_non_dimension_invalid_argument_errors(mock_db):
+    """Only dimension-mismatch InvalidArgumentErrors are swallowed.
+
+    A different ``InvalidArgumentError`` (e.g. bad ``where`` clause)
+    must still surface — it points at a real caller bug.
+    """
+    db, mock_col, _ = mock_db
+    mock_col.count.return_value = 3
+    mock_col.query.side_effect = chromadb.errors.InvalidArgumentError(
+        "invalid where clause: unknown operator $weird"
+    )
+    with pytest.raises(chromadb.errors.InvalidArgumentError):
+        db.search("q", ["code__x"], n_results=5)
+
+
 def test_search_cce_collection_uses_query_embeddings(mock_chromadb):
     _, mock_client = mock_chromadb
     mock_col = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.6.2"
+version = "4.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Follow-up to **#190** — after 4.6.2 shipped, Steve hit a second crash on \`nx search\`:

\`\`\`
chromadb.errors.InvalidArgumentError:
  Collection expecting embedding with dimension of 384, got 768
\`\`\`

Root cause: older collections were indexed with a model whose output dimension differs from the one currently configured (local-mode embedding-model upgrade). Every cross-corpus search that touched a stale collection crashed.

## Fix

\`T3Database.search\` wraps the per-collection \`col.query()\` call in a targeted \`try/except\` for \`InvalidArgumentError\` where the message contains \`"dimension"\`. On catch:
- log a structured \`collection_dimension_mismatch_skipped\` warning with the collection name
- continue to the next collection in the same search call

Non-dimension \`InvalidArgumentError\` (bad \`where\`, malformed query arg, etc.) still surfaces — those are real caller bugs.

Uses a module-level \`_ChromaInvalidArgumentError\` alias so the existing \`mock_chromadb\` test fixture's patching of \`nexus.db.t3.chromadb\` doesn't replace the exception class at runtime (same pattern as \`_ChromaNotFoundError\`).

## Tests

3 new regressions in \`tests/test_t3.py\`:
- **single-collection mismatch** → empty list, no raise
- **mixed-collection** → mismatched collection A is skipped, healthy collection B still returns results
- **non-dimension InvalidArgumentError** → still propagates unchanged

## Test plan
- [x] \`uv run pytest tests/test_t3.py\` — 83 passed
- [x] Full suite — 4387 passed, 27 skipped
- [ ] CI green

## Version

4.6.2 → 4.6.3 (patch — pure behaviour restoration; no public surface change). Manifests: pyproject + marketplace + nx plugin + sn plugin; CHANGELOG backfilled.

## Follow-up (filed or proposed)

- **nx doctor dimension-mismatch probe** — Phase 3.3's probe 3b currently compares model *names* (cloud-mode). Extend to detect local-mode dimension drift. To be filed as a Phase 3 follow-up bead.
- **\`nx collection migrate-embeddings\` / \`reindex --all\`** — self-heal path so users don't have to manually \`delete\` + re-index. Steve's concrete suggestion #3. TBD whether it becomes its own RDR or an extension to collection management.