### PR TITLE
feat(collection): nx collection health composite report (nexus-yi4b.3.4)

### DIFF
--- a/src/nexus/collection_health.py
+++ b/src/nexus/collection_health.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""``nx collection health`` composite report — RDR-087 Phase 3.4.
+
+One row per collection with 9 columns folding catalog, T2 telemetry,
+and topic-assignment signals into a single per-collection view:
+
+    name, chunk_count, last_indexed, zero_hit_rate_30d,
+    median_query_distance_30d, cross_projection_rank,
+    orphan_catalog_rows, stale_source_ratio, hub_domination_score
+
+``stale_source_ratio`` is currently a placeholder (``"—"``) because
+the catalog doesn't store ``source_mtime`` yet (tracked in bead
+``nexus-8luh``).
+
+Every data source is dependency-injected via module-level callables
+so tests can monkeypatch without standing up live T2/T3/catalog.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Callable
+
+
+_STALE_PLACEHOLDER = "—"
+_SORT_COLUMNS = (
+    "name",
+    "chunk_count",
+    "last_indexed",
+    "zero_hit_rate_30d",
+    "median_query_distance_30d",
+    "cross_projection_rank",
+    "orphan_catalog_rows",
+    "hub_domination_score",
+)
+
+
+@dataclass(frozen=True)
+class CollectionHealthRow:
+    name: str
+    chunk_count: int
+    last_indexed: str | None
+    zero_hit_rate_30d: float | None
+    median_query_distance_30d: float | None
+    cross_projection_rank: int | None
+    orphan_catalog_rows: int | None
+    hub_domination_score: float | None = None
+    stale_source_ratio: str = _STALE_PLACEHOLDER  # deferred: nexus-8luh
+
+
+# ── Default production runners (dep-injected) ───────────────────────────────
+
+
+def _default_enumerate_collections() -> list[str]:
+    from nexus.db import make_t3
+
+    return [c["name"] for c in make_t3().list_collections()]
+
+
+def _open_catalog():
+    """Return an initialised :class:`Catalog` or ``None`` when absent.
+
+    The catalog lives outside the T2 DB; an uninitialised catalog just
+    means the collection has no documents on record yet — health rows
+    for such collections show zero chunks / no links / no orphans.
+    """
+    from nexus.catalog.catalog import Catalog
+    from nexus.config import catalog_path
+
+    path = catalog_path()
+    if not Catalog.is_initialized(path):
+        return None
+    return Catalog(path, path / ".catalog.db")
+
+
+def _default_catalog_stats_fn(col: str) -> dict[str, Any]:
+    """Return ``{chunk_count, last_indexed, orphan_count}`` for *col*.
+
+    Uses the catalog cache DB. ``chunk_count`` is the SUM across every
+    document in the collection; ``last_indexed`` is the MAX of
+    ``indexed_at``; ``orphan_count`` is the count of documents in this
+    collection that have zero incoming links.
+    """
+    cat = _open_catalog()
+    if cat is None:
+        return {"chunk_count": 0, "last_indexed": None, "orphan_count": 0}
+    try:
+        # Catalog's SQL cache lives behind private attributes; an
+        # explicit public accessor doesn't exist yet and isn't worth
+        # adding just for this read-only path.
+        conn = cat._db._conn  # noqa: SLF001
+        row = conn.execute(
+            "SELECT COALESCE(SUM(chunk_count), 0), MAX(indexed_at) "
+            "FROM documents WHERE physical_collection = ?",
+            (col,),
+        ).fetchone()
+        chunk_count = int(row[0] or 0)
+        last_indexed = row[1] if row and row[1] else None
+        orphan_row = conn.execute(
+            "SELECT COUNT(*) FROM documents d "
+            "LEFT JOIN links l ON d.tumbler = l.to_tumbler "
+            "WHERE d.physical_collection = ? AND l.id IS NULL",
+            (col,),
+        ).fetchone()
+        orphan_count = int(orphan_row[0] or 0)
+        return {
+            "chunk_count": chunk_count,
+            "last_indexed": last_indexed,
+            "orphan_count": orphan_count,
+        }
+    except Exception:
+        return {"chunk_count": 0, "last_indexed": None, "orphan_count": 0}
+
+
+def _open_t2():
+    """Open a ``T2Database`` rooted at the default path, or ``None``
+    when the DB file doesn't exist yet."""
+    from nexus.commands._helpers import default_db_path
+    from nexus.db.t2 import T2Database
+
+    db_path = default_db_path()
+    if not db_path.exists():
+        return None
+    return T2Database(db_path)
+
+
+def _default_telemetry_stats_fn(col: str) -> dict[str, Any]:
+    t2 = _open_t2()
+    if t2 is None:
+        return {"row_count": 0, "zero_hit_rate": None, "median_top_distance": None}
+    try:
+        return t2.telemetry.query_collection_stats(col)
+    finally:
+        t2.close()
+
+
+def _default_projection_rank_fn(cols: list[str]) -> dict[str, int]:
+    """Rank collections by their incoming cross-projection count.
+
+    Rank 1 = receives from the most distinct source collections.
+    Collections with no incoming projections are absent from the map;
+    the orchestrator treats that as ``None``.
+    """
+    t2 = _open_t2()
+    if t2 is None:
+        return {}
+    try:
+        conn = t2.taxonomy.conn
+        rows = conn.execute(
+            "SELECT t.collection AS col, "
+            "COUNT(DISTINCT ta.source_collection) AS src_count "
+            "FROM topic_assignments ta "
+            "JOIN topics t ON ta.topic_id = t.id "
+            "WHERE t.collection IN ({}) "
+            "GROUP BY t.collection "
+            "ORDER BY src_count DESC".format(
+                ",".join("?" * len(cols)) or "''"
+            ),
+            cols,
+        ).fetchall()
+        return {row[0]: idx + 1 for idx, row in enumerate(rows)}
+    except Exception:
+        return {}
+    finally:
+        t2.close()
+
+
+def _default_hub_score_fn(col: str) -> float | None:
+    """Ratio of *col*'s chunks assigned to top-10 cross-collection hubs.
+
+    ``None`` when the taxonomy tables don't exist yet or the collection
+    has zero chunks.
+    """
+    t2 = _open_t2()
+    if t2 is None:
+        return None
+    try:
+        conn = t2.taxonomy.conn
+        # Top-10 hubs: topics whose assignments span the most distinct
+        # source collections. Ranks deterministically by
+        # ``(src_count DESC, topic_id ASC)``.
+        hub_rows = conn.execute(
+            "SELECT ta.topic_id "
+            "FROM topic_assignments ta "
+            "GROUP BY ta.topic_id "
+            "ORDER BY COUNT(DISTINCT ta.source_collection) DESC, ta.topic_id ASC "
+            "LIMIT 10"
+        ).fetchall()
+        if not hub_rows:
+            return None
+        hub_ids = tuple(r[0] for r in hub_rows)
+        total = conn.execute(
+            "SELECT COUNT(*) FROM topic_assignments "
+            "WHERE source_collection = ?",
+            (col,),
+        ).fetchone()[0] or 0
+        if total == 0:
+            return None
+        in_hubs = conn.execute(
+            "SELECT COUNT(*) FROM topic_assignments "
+            "WHERE source_collection = ? AND topic_id IN ({})".format(
+                ",".join("?" * len(hub_ids))
+            ),
+            (col, *hub_ids),
+        ).fetchone()[0] or 0
+        return in_hubs / total
+    except Exception:
+        return None
+    finally:
+        t2.close()
+
+
+# Module-level runner bindings — tests monkeypatch these directly.
+_enumerate_collections = _default_enumerate_collections
+_catalog_stats_fn = _default_catalog_stats_fn
+_telemetry_stats_fn = _default_telemetry_stats_fn
+_projection_rank_fn = _default_projection_rank_fn
+_hub_score_fn = _default_hub_score_fn
+
+
+# ── Orchestrator ────────────────────────────────────────────────────────────
+
+
+def compute_collection_health(
+    collections: list[str],
+    *,
+    catalog_stats_fn: Callable[[str], dict[str, Any]],
+    telemetry_stats_fn: Callable[[str], dict[str, Any]],
+    projection_rank_fn: Callable[[list[str]], dict[str, int]],
+    hub_score_fn: Callable[[str], float | None],
+) -> list[CollectionHealthRow]:
+    """Assemble per-collection health rows from the injected callables.
+
+    Ordering follows *collections*; callers sort via ``format_health_table``.
+    """
+    ranks = projection_rank_fn(collections)
+    rows: list[CollectionHealthRow] = []
+    for col in collections:
+        catalog = catalog_stats_fn(col) or {}
+        tel = telemetry_stats_fn(col) or {}
+        rows.append(
+            CollectionHealthRow(
+                name=col,
+                chunk_count=int(catalog.get("chunk_count", 0)),
+                last_indexed=catalog.get("last_indexed"),
+                zero_hit_rate_30d=tel.get("zero_hit_rate"),
+                median_query_distance_30d=tel.get("median_top_distance"),
+                cross_projection_rank=ranks.get(col),
+                orphan_catalog_rows=int(catalog.get("orphan_count", 0))
+                    if catalog.get("orphan_count") is not None else None,
+                hub_domination_score=hub_score_fn(col),
+            )
+        )
+    return rows
+
+
+# ── Formatters ──────────────────────────────────────────────────────────────
+
+
+def _fmt_cell(value: Any) -> str:
+    if value is None:
+        return _STALE_PLACEHOLDER
+    if isinstance(value, float):
+        return f"{value:.3f}"
+    return str(value)
+
+
+def _sort_key(col: str):
+    """Return a per-row sort-key lambda for *col*."""
+    if col not in _SORT_COLUMNS:
+        raise ValueError(
+            f"unknown sort column {col!r}; valid: {sorted(_SORT_COLUMNS)}"
+        )
+    # Numeric columns — descending; text columns — ascending.
+    descending = col not in {"name", "last_indexed"}
+    def _key(row: CollectionHealthRow):
+        v = getattr(row, col)
+        # None sorts last regardless of direction.
+        if v is None:
+            return (1, 0)
+        return (0, -v if descending and isinstance(v, (int, float)) else v)
+    return _key
+
+
+def format_health_table(
+    rows: list[CollectionHealthRow], *, sort_by: str = "name",
+) -> str:
+    """Render rows as a column-aligned text table."""
+    ordered = sorted(rows, key=_sort_key(sort_by))
+    headers = [
+        "name", "chunk_count", "last_indexed", "zero_hit_rate_30d",
+        "median_query_distance_30d", "cross_projection_rank",
+        "orphan_catalog_rows", "stale_source_ratio", "hub_domination_score",
+    ]
+    data = [
+        [
+            r.name,
+            str(r.chunk_count),
+            _fmt_cell(r.last_indexed),
+            _fmt_cell(r.zero_hit_rate_30d),
+            _fmt_cell(r.median_query_distance_30d),
+            _fmt_cell(r.cross_projection_rank),
+            _fmt_cell(r.orphan_catalog_rows),
+            r.stale_source_ratio,
+            _fmt_cell(r.hub_domination_score),
+        ]
+        for r in ordered
+    ]
+    widths = [
+        max(len(h), *(len(row[i]) for row in data)) if data else len(h)
+        for i, h in enumerate(headers)
+    ]
+    def _row(cells):
+        return "  ".join(c.ljust(w) for c, w in zip(cells, widths))
+    lines = [_row(headers), _row(["─" * w for w in widths])]
+    lines.extend(_row(r) for r in data)
+    return "\n".join(lines)
+
+
+def format_health_json(rows: list[CollectionHealthRow]) -> str:
+    payload = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "collections": [asdict(r) for r in rows],
+    }
+    return json.dumps(payload, indent=2)
+
+
+# ── CLI entry point ─────────────────────────────────────────────────────────
+
+
+def run_collection_health(*, sort_by: str = "name", fmt: str = "table") -> str:
+    """Render the composite report. Invoked by ``commands/collection.py``."""
+    collections = _enumerate_collections()
+    rows = compute_collection_health(
+        collections,
+        catalog_stats_fn=_catalog_stats_fn,
+        telemetry_stats_fn=_telemetry_stats_fn,
+        projection_rank_fn=_projection_rank_fn,
+        hub_score_fn=_hub_score_fn,
+    )
+    if fmt == "json":
+        return format_health_json(rows)
+    return format_health_table(rows, sort_by=sort_by)

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -475,3 +475,36 @@ def rewrite_metadata_cmd(
         f"({grand_skipped} already canonical, {grand_total} scanned) "
         f"across {len(targets)} collection(s)."
     )
+
+
+@collection.command("health")
+@click.option(
+    "--sort",
+    "sort_by",
+    type=click.Choice([
+        "name", "chunk_count", "last_indexed",
+        "zero_hit_rate_30d", "median_query_distance_30d",
+        "cross_projection_rank", "orphan_catalog_rows",
+        "hub_domination_score",
+    ]),
+    default="name",
+    show_default=True,
+    help="Sort the health table by the named column.",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    show_default=True,
+    help="Output format.",
+)
+def health_cmd(sort_by: str, fmt: str) -> None:
+    """Composite per-collection health report (RDR-087 Phase 3.4).
+
+    Folds catalog, T2 telemetry, and topic-assignment signals into one
+    row per collection. Use ``--format=json`` for agents and dashboards.
+    """
+    from nexus.collection_health import run_collection_health
+
+    click.echo(run_collection_health(sort_by=sort_by, fmt=fmt))

--- a/src/nexus/db/t2/telemetry.py
+++ b/src/nexus/db/t2/telemetry.py
@@ -275,6 +275,58 @@ class Telemetry:
             self.conn.commit()
         return len(rows)
 
+    def query_collection_stats(
+        self, collection: str, *, days: int = 30,
+    ) -> dict[str, Any]:
+        """Return retrieval-health stats for *collection* over the last *days*.
+
+        Used by ``nx collection health`` (RDR-087 Phase 3.4). Returns a
+        dict with keys:
+
+        - ``row_count``            : rows in-window for this collection.
+        - ``zero_hit_rate``        : ``kept_count == 0`` fraction, or
+          ``None`` when ``row_count == 0``.
+        - ``median_top_distance``  : median ``top_distance`` over rows
+          with ``raw_count > 0``, or ``None`` when no such rows.
+
+        Does not write. Uses the same 30-day window the CLI flag uses
+        by default; *days* is overridable for testing / audits.
+        """
+        if days < 1:
+            raise ValueError(f"days must be >= 1; got {days}")
+        cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+        with self._lock:
+            row_count, zero_count = self.conn.execute(
+                "SELECT COUNT(*), "
+                "SUM(CASE WHEN kept_count = 0 THEN 1 ELSE 0 END) "
+                "FROM search_telemetry WHERE collection = ? AND ts >= ?",
+                (collection, cutoff),
+            ).fetchone()
+            distances = [
+                r[0] for r in self.conn.execute(
+                    "SELECT top_distance FROM search_telemetry "
+                    "WHERE collection = ? AND ts >= ? "
+                    "AND raw_count > 0 AND top_distance IS NOT NULL "
+                    "ORDER BY top_distance",
+                    (collection, cutoff),
+                ).fetchall()
+            ]
+        zero_rate: float | None = None
+        if row_count:
+            zero_rate = (zero_count or 0) / row_count
+        median: float | None = None
+        n = len(distances)
+        if n:
+            if n % 2 == 1:
+                median = distances[n // 2]
+            else:
+                median = (distances[n // 2 - 1] + distances[n // 2]) / 2
+        return {
+            "row_count": row_count or 0,
+            "zero_hit_rate": zero_rate,
+            "median_top_distance": median,
+        }
+
     def trim_search_telemetry(self, days: int = 30) -> int:
         """Delete ``search_telemetry`` rows older than *days* days (Phase 2.4).
 

--- a/tests/test_collection_health.py
+++ b/tests/test_collection_health.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``nx collection health`` composite report — RDR-087 Phase 3.4.
+
+Tests decompose into three layers:
+
+1. ``Telemetry.query_collection_stats`` — new T2 aggregate API pinned in
+   isolation with seeded rows.
+2. ``compute_collection_health`` orchestrator — every per-column
+   computation is dependency-injected so the test can drive each
+   outcome class deterministically without live T2/T3/catalog.
+3. Formatters (human + JSON) and the ``nx collection health`` CLI
+   wiring, asserting ``--sort`` and ``--format=json`` behaviour.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+# ── Telemetry.query_collection_stats ────────────────────────────────────────
+
+
+class TestTelemetryQueryCollectionStats:
+    def _fresh_telemetry(self, tmp_path: Path):
+        from nexus.db.t2.telemetry import Telemetry
+
+        db_path = tmp_path / "memory.db"
+        return Telemetry(db_path)
+
+    def _seed(self, tm, collection: str, rows):
+        """Rows: iterable of (age_days, raw, kept, top_distance)."""
+        now = datetime.now(UTC)
+        payload = []
+        for i, (age, raw, kept, dist) in enumerate(rows):
+            ts = (now - timedelta(days=age)).isoformat()
+            payload.append(
+                (ts, f"hash{i:04d}", collection, raw, kept, dist, 0.45),
+            )
+        tm.log_search_batch(payload)
+
+    def test_empty_table_returns_none_placeholders(self, tmp_path) -> None:
+        tm = self._fresh_telemetry(tmp_path)
+        stats = tm.query_collection_stats("code__x")
+        assert stats["row_count"] == 0
+        assert stats["zero_hit_rate"] is None
+        assert stats["median_top_distance"] is None
+        tm.close()
+
+    def test_zero_hit_rate_computed_over_window(self, tmp_path) -> None:
+        tm = self._fresh_telemetry(tmp_path)
+        # 4 in-window rows: 2 kept>0, 2 kept==0 → rate=0.5.
+        # 1 out-of-window row: 45d old, should be ignored.
+        self._seed(tm, "docs__a", [
+            (1, 5, 3, 0.30),
+            (2, 4, 2, 0.40),
+            (3, 3, 3, 0.50),  # kept_count = 3 - 3 = 0? no: kept=3, dropped=0.
+            (5, 5, 0, 0.20),  # kept=0
+            (45, 2, 0, 0.10),  # out of window
+        ])
+        # Re-seed row #3 as genuinely kept==0 (my list had kept=3 above —
+        # reorder so test matches the 0.5 rate assertion cleanly):
+        tm.conn.execute("DELETE FROM search_telemetry")
+        tm.conn.commit()
+        self._seed(tm, "docs__a", [
+            (1, 5, 3, 0.30),   # kept>0
+            (2, 4, 0, 0.40),   # kept==0
+            (3, 3, 2, 0.50),   # kept>0
+            (5, 5, 0, 0.20),   # kept==0
+            (45, 2, 0, 0.10),  # out of window
+        ])
+        stats = tm.query_collection_stats("docs__a", days=30)
+        assert stats["row_count"] == 4
+        assert stats["zero_hit_rate"] == pytest.approx(0.5)
+        tm.close()
+
+    def test_median_top_distance_ignores_raw_zero(self, tmp_path) -> None:
+        """Median is computed only over rows with raw_count > 0."""
+        tm = self._fresh_telemetry(tmp_path)
+        self._seed(tm, "code__x", [
+            (1, 5, 2, 0.20),
+            (1, 3, 0, 0.40),
+            (1, 4, 1, 0.60),
+            (1, 0, 0, None),  # raw_count==0 — excluded
+        ])
+        stats = tm.query_collection_stats("code__x")
+        # distances in raw>0 rows: 0.20, 0.40, 0.60 — median = 0.40.
+        assert stats["median_top_distance"] == pytest.approx(0.40)
+        tm.close()
+
+    def test_other_collections_do_not_leak(self, tmp_path) -> None:
+        tm = self._fresh_telemetry(tmp_path)
+        self._seed(tm, "code__a", [(1, 5, 3, 0.30)])
+        self._seed(tm, "code__b", [(1, 3, 0, 0.70)])
+        stats_a = tm.query_collection_stats("code__a")
+        stats_b = tm.query_collection_stats("code__b")
+        assert stats_a["row_count"] == 1
+        assert stats_a["zero_hit_rate"] == pytest.approx(0.0)
+        assert stats_b["row_count"] == 1
+        assert stats_b["zero_hit_rate"] == pytest.approx(1.0)
+        tm.close()
+
+    def test_rejects_zero_days(self, tmp_path) -> None:
+        tm = self._fresh_telemetry(tmp_path)
+        with pytest.raises(ValueError):
+            tm.query_collection_stats("any", days=0)
+        tm.close()
+
+
+# ── compute_collection_health orchestrator ─────────────────────────────────
+
+
+def _fake_catalog_stats(col: str) -> dict:
+    data = {
+        "code__alpha":  {"chunk_count": 120, "last_indexed": "2026-04-15", "orphan_count": 2},
+        "docs__beta":   {"chunk_count": 30,  "last_indexed": "2026-04-10", "orphan_count": 0},
+        "docs__stale":  {"chunk_count": 0,   "last_indexed": None,          "orphan_count": 0},
+    }
+    return data.get(col, {"chunk_count": 0, "last_indexed": None, "orphan_count": 0})
+
+
+def _fake_telemetry_stats(col: str) -> dict:
+    data = {
+        "code__alpha": {"row_count": 50, "zero_hit_rate": 0.10, "median_top_distance": 0.35},
+        "docs__beta":  {"row_count": 0,  "zero_hit_rate": None, "median_top_distance": None},
+        "docs__stale": {"row_count": 8,  "zero_hit_rate": 1.00, "median_top_distance": 0.80},
+    }
+    return data.get(col, {"row_count": 0, "zero_hit_rate": None, "median_top_distance": None})
+
+
+def _fake_projection_ranks(cols: list[str]) -> dict[str, int]:
+    # code__alpha receives from 5 source collections, docs__beta from 2.
+    return {"code__alpha": 1, "docs__beta": 2}
+
+
+def _fake_hub_score(col: str) -> float | None:
+    return {"code__alpha": 0.05, "docs__beta": 0.20}.get(col)
+
+
+class TestComputeCollectionHealth:
+    def test_rows_assemble_from_injected_fns(self) -> None:
+        from nexus.collection_health import compute_collection_health
+
+        rows = compute_collection_health(
+            ["code__alpha", "docs__beta", "docs__stale"],
+            catalog_stats_fn=_fake_catalog_stats,
+            telemetry_stats_fn=_fake_telemetry_stats,
+            projection_rank_fn=_fake_projection_ranks,
+            hub_score_fn=_fake_hub_score,
+        )
+        by_name = {r.name: r for r in rows}
+        assert by_name["code__alpha"].chunk_count == 120
+        assert by_name["code__alpha"].zero_hit_rate_30d == pytest.approx(0.10)
+        assert by_name["code__alpha"].cross_projection_rank == 1
+        assert by_name["code__alpha"].orphan_catalog_rows == 2
+        assert by_name["code__alpha"].hub_domination_score == pytest.approx(0.05)
+        # stale_source_ratio is the deferred column (nexus-8luh); placeholder.
+        assert by_name["code__alpha"].stale_source_ratio == "—"
+
+    def test_empty_telemetry_sets_placeholders(self) -> None:
+        from nexus.collection_health import compute_collection_health
+
+        rows = compute_collection_health(
+            ["docs__beta"],
+            catalog_stats_fn=_fake_catalog_stats,
+            telemetry_stats_fn=_fake_telemetry_stats,
+            projection_rank_fn=_fake_projection_ranks,
+            hub_score_fn=_fake_hub_score,
+        )
+        assert rows[0].zero_hit_rate_30d is None
+        assert rows[0].median_query_distance_30d is None
+
+    def test_missing_projection_rank_is_none(self) -> None:
+        from nexus.collection_health import compute_collection_health
+
+        rows = compute_collection_health(
+            ["docs__stale"],  # not in projection map
+            catalog_stats_fn=_fake_catalog_stats,
+            telemetry_stats_fn=_fake_telemetry_stats,
+            projection_rank_fn=_fake_projection_ranks,
+            hub_score_fn=_fake_hub_score,
+        )
+        assert rows[0].cross_projection_rank is None
+
+    def test_missing_hub_score_is_none(self) -> None:
+        from nexus.collection_health import compute_collection_health
+
+        rows = compute_collection_health(
+            ["docs__stale"],
+            catalog_stats_fn=_fake_catalog_stats,
+            telemetry_stats_fn=_fake_telemetry_stats,
+            projection_rank_fn=_fake_projection_ranks,
+            hub_score_fn=_fake_hub_score,
+        )
+        assert rows[0].hub_domination_score is None
+
+
+# ── Formatters ─────────────────────────────────────────────────────────────
+
+
+class TestFormatters:
+    @pytest.fixture
+    def rows(self):
+        from nexus.collection_health import compute_collection_health
+
+        return compute_collection_health(
+            ["code__alpha", "docs__beta", "docs__stale"],
+            catalog_stats_fn=_fake_catalog_stats,
+            telemetry_stats_fn=_fake_telemetry_stats,
+            projection_rank_fn=_fake_projection_ranks,
+            hub_score_fn=_fake_hub_score,
+        )
+
+    def test_human_format_contains_all_columns(self, rows) -> None:
+        from nexus.collection_health import format_health_table
+
+        out = format_health_table(rows, sort_by="name")
+        for col in [
+            "name", "chunk_count", "last_indexed", "zero_hit_rate",
+            "median", "cross_projection", "orphan", "stale", "hub_domination",
+        ]:
+            assert col in out.lower()
+
+    def test_human_format_renders_none_as_placeholder(self, rows) -> None:
+        from nexus.collection_health import format_health_table
+
+        out = format_health_table(rows, sort_by="name")
+        # docs__beta has empty telemetry → two '—' cells in its row.
+        lines = [l for l in out.split("\n") if "docs__beta" in l]
+        assert lines, "docs__beta row missing from output"
+        assert "—" in lines[0]
+
+    def test_json_format_is_parseable(self, rows) -> None:
+        from nexus.collection_health import format_health_json
+
+        payload = json.loads(format_health_json(rows))
+        assert isinstance(payload, dict)
+        assert "collections" in payload
+        assert "generated_at" in payload
+        assert len(payload["collections"]) == 3
+        names = {c["name"] for c in payload["collections"]}
+        assert names == {"code__alpha", "docs__beta", "docs__stale"}
+
+    def test_sort_by_chunk_count_desc(self, rows) -> None:
+        from nexus.collection_health import format_health_table
+
+        out = format_health_table(rows, sort_by="chunk_count")
+        # code__alpha (120) first, docs__beta (30) second, docs__stale (0) last.
+        idx_alpha = out.find("code__alpha")
+        idx_beta = out.find("docs__beta")
+        idx_stale = out.find("docs__stale")
+        assert 0 <= idx_alpha < idx_beta < idx_stale
+
+    def test_sort_rejects_unknown_column(self, rows) -> None:
+        from nexus.collection_health import format_health_table
+
+        with pytest.raises(ValueError):
+            format_health_table(rows, sort_by="nonsense")
+
+
+# ── CLI: `nx collection health` ────────────────────────────────────────────
+
+
+class TestCollectionHealthCli:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def _stub(self, monkeypatch):
+        monkeypatch.setattr(
+            "nexus.collection_health._enumerate_collections",
+            lambda: ["code__alpha", "docs__beta", "docs__stale"],
+        )
+        monkeypatch.setattr(
+            "nexus.collection_health._catalog_stats_fn",
+            _fake_catalog_stats,
+        )
+        monkeypatch.setattr(
+            "nexus.collection_health._telemetry_stats_fn",
+            _fake_telemetry_stats,
+        )
+        monkeypatch.setattr(
+            "nexus.collection_health._projection_rank_fn",
+            _fake_projection_ranks,
+        )
+        monkeypatch.setattr(
+            "nexus.collection_health._hub_score_fn",
+            _fake_hub_score,
+        )
+
+    def test_default_human_output(self, runner, monkeypatch) -> None:
+        from nexus.cli import main
+
+        self._stub(monkeypatch)
+        result = runner.invoke(main, ["collection", "health"])
+        assert result.exit_code == 0, result.output
+        assert "code__alpha" in result.output
+
+    def test_json_output(self, runner, monkeypatch) -> None:
+        from nexus.cli import main
+
+        self._stub(monkeypatch)
+        result = runner.invoke(main, ["collection", "health", "--format", "json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert "collections" in payload
+
+    def test_sort_flag(self, runner, monkeypatch) -> None:
+        from nexus.cli import main
+
+        self._stub(monkeypatch)
+        result = runner.invoke(
+            main, ["collection", "health", "--sort", "chunk_count"],
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_sort_rejects_unknown_value(self, runner, monkeypatch) -> None:
+        from nexus.cli import main
+
+        self._stub(monkeypatch)
+        result = runner.invoke(
+            main, ["collection", "health", "--sort", "nonsense"],
+        )
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

RDR-087 Phase 3.4 — new \`nx collection health\` subcommand renders a 9-column per-collection health table folding catalog / T2 telemetry / topic-assignment signals into one view.

**Columns**
\`name\` · \`chunk_count\` · \`last_indexed\` · \`zero_hit_rate_30d\` · \`median_query_distance_30d\` · \`cross_projection_rank\` · \`orphan_catalog_rows\` · \`stale_source_ratio\` · \`hub_domination_score\`

\`stale_source_ratio\` is a \`—\` placeholder — catalog doesn't store \`source_mtime\` yet (tracked in bead \`nexus-8luh\`).

**Two commits**
1. **\`wip(collection)\` → \`Telemetry.query_collection_stats\` + test skeleton** (19 tests red). Adds a new aggregate method returning \`{row_count, zero_hit_rate, median_top_distance}\` for a given collection over the last N days.
2. **\`feat(collection)\` → module + CLI wiring**. New \`src/nexus/collection_health.py\` with:
   - \`CollectionHealthRow\` frozen dataclass (9 fields)
   - \`compute_collection_health(...)\` orchestrator taking four dep-injected callables so tests drive deterministic outcomes without live T2/T3/catalog
   - \`format_health_table\` / \`format_health_json\` (no tabulate dep; matches doctor probe formatting style)
   - Default production runners wired to \`make_t3\`, \`T2Database\`, \`Catalog\` — each guards cleanly when the underlying store isn't initialised yet

**CLI**
\`\`\`
nx collection health                            # default: sort by name, table format
nx collection health --sort chunk_count         # numeric columns sort desc
nx collection health --format json              # parseable payload for agents
\`\`\`

\`--sort\` uses \`click.Choice\` over 8 sortable columns.

**Live smoke on this repo**: 137 collections enumerated, table renders in ~1s after the catalog cache is warm. Telemetry signals confirm the RDR-087 §259-268 silent-threshold-drop class at aggregate — many collections show \`zero_hit_rate_30d = 1.000\` (every search in the last 30 days returned zero after threshold filtering).

## Test plan
- [x] \`uv run pytest tests/test_collection_health.py\` — 18 passed
- [x] Cross-surface sanity — test_t3 + test_migrations + test_collection_health = 167 passed post-rebase onto \`a560629\` (4.6.3 hotfix)
- [x] Live smoke — real 137-collection report renders and sorts correctly
- [ ] CI green

## Follow-up
- **\`nexus-8luh\`** (P3) — add \`source_mtime\` column to catalog documents, unblocks \`stale_source_ratio\`.
- Phase 3.5: code review on the full Phase 3 diff.
- Phase 3.6: test validation.