### PR TITLE
feat(taxonomy): backfill-source-collection CLI (nexus-yi4b.4.1)

### DIFF
--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -1633,3 +1633,61 @@ def validate_refs_cmd(paths, tolerance, strict, prefixes, fmt):
     if any_drift or (strict and any_missing):
         sys.exit(1)
     sys.exit(0)
+
+
+@taxonomy.command("backfill-source-collection")
+@click.option(
+    "--apply",
+    "apply_",
+    is_flag=True,
+    default=False,
+    help="Commit writes (default is dry-run). IRREVERSIBLE — review the "
+         "dry-run output first.",
+)
+def backfill_source_collection_cmd(apply_: bool) -> None:
+    """Backfill topic_assignments.source_collection for legacy hdbscan/
+    centroid rows.
+
+    RDR-087 Phase 4.1. Fills NULL source_collection by copying from
+    topics.collection where the clustering path (hdbscan/centroid)
+    guarantees correctness. Projection rows are untouched; auto-matched
+    rows stay NULL (ambiguous source).
+    """
+    from nexus.commands._helpers import default_db_path
+    from nexus.db.t2 import T2Database
+    from nexus.taxonomy_backfill import backfill_source_collection
+
+    db_path = default_db_path()
+    if not db_path.exists():
+        raise click.ClickException(f"T2 database not found: {db_path}")
+
+    t2 = T2Database(db_path)
+    try:
+        report = backfill_source_collection(t2.taxonomy.conn, apply=apply_)
+    finally:
+        t2.close()
+
+    mode = "DRY-RUN" if report.dry_run else "APPLIED"
+    click.echo(f"topic_assignments source_collection backfill ({mode})")
+    click.echo(f"  total rows:           {report.total_rows:>8}")
+    click.echo(
+        f"  non-null before:      {report.non_null_before:>8}  "
+        f"({report.coverage_before:.1%} coverage)"
+    )
+    click.echo(
+        f"  eligible (NULL):      {report.eligible_rows:>8}"
+    )
+    for cat, count in sorted(report.eligible_by_category.items()):
+        click.echo(f"    by assigned_by={cat:<10}  {count:>8}")
+    if report.dry_run:
+        click.echo(
+            f"  projected after apply: "
+            f"{report.non_null_before + report.eligible_rows:>8}  "
+            f"({report.coverage_projected:.1%} coverage)"
+        )
+        click.echo("Run with --apply to commit.")
+    else:
+        click.echo(
+            f"  updated:              {report.updated_rows:>8}  "
+            f"({report.coverage_after:.1%} coverage)"
+        )

--- a/src/nexus/taxonomy_backfill.py
+++ b/src/nexus/taxonomy_backfill.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""``topic_assignments.source_collection`` backfill — RDR-087 Phase 4.1.
+
+Legacy rows (pre-RDR-077 projection path) left ``source_collection``
+``NULL`` because clustering happens per-collection and the column was
+only introduced once cross-collection projection started caring about
+the source.
+
+Invariants that make a deterministic backfill safe:
+
+- **hdbscan / centroid** rows were produced by a single-collection
+  clustering pass. Every assignment is from a chunk in that
+  collection, and the topic it points at lives in the same
+  collection. Therefore ``source_collection == topics.collection``
+  holds by construction.
+- **projection** rows already have the field populated (and usually
+  disagree with ``topics.collection`` — that's the whole point of
+  cross-collection projection). Do not touch them.
+- **auto-matched** rows are the ambiguous case: a chunk from
+  collection X may have auto-matched to a topic in collection Y.
+  Leaving them NULL is the honest default; a later pass could do a
+  best-effort T3 walk but that's out of scope here.
+
+Writes are transaction-wrapped with explicit ``commit`` / ``rollback``
+and run only when ``apply=True``. Dry-run is the default both here
+and at the CLI layer.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+
+
+_ELIGIBLE_ASSIGNED_BY: tuple[str, ...] = ("hdbscan", "centroid")
+
+
+@dataclass(frozen=True)
+class BackfillReport:
+    dry_run: bool
+    total_rows: int
+    non_null_before: int
+    eligible_rows: int
+    updated_rows: int  # 0 on dry-run
+    eligible_by_category: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def coverage_before(self) -> float:
+        return self.non_null_before / self.total_rows if self.total_rows else 0.0
+
+    @property
+    def coverage_projected(self) -> float:
+        if not self.total_rows:
+            return 0.0
+        return (self.non_null_before + self.eligible_rows) / self.total_rows
+
+    @property
+    def coverage_after(self) -> float:
+        if not self.total_rows:
+            return 0.0
+        return (self.non_null_before + self.updated_rows) / self.total_rows
+
+
+def backfill_source_collection(
+    conn: sqlite3.Connection,
+    *,
+    apply: bool,
+) -> BackfillReport:
+    """Backfill ``topic_assignments.source_collection`` from ``topics.collection``.
+
+    Args:
+        conn: live sqlite3 connection for a ``T2Database`` that has both
+            ``topic_assignments`` and ``topics`` tables.
+        apply: when ``False`` (default at the CLI), only reports what
+            would be written. When ``True``, runs the UPDATE inside a
+            single transaction with rollback on error.
+
+    Returns a :class:`BackfillReport` with before / projected / after
+    coverage numbers and per-``assigned_by`` eligible counts.
+    """
+    total, non_null = conn.execute(
+        "SELECT COUNT(*), "
+        "SUM(CASE WHEN source_collection IS NULL THEN 0 ELSE 1 END) "
+        "FROM topic_assignments"
+    ).fetchone()
+    total = int(total or 0)
+    non_null = int(non_null or 0)
+
+    eligible_rows_by_category: dict[str, int] = {}
+    placeholders = ",".join("?" * len(_ELIGIBLE_ASSIGNED_BY))
+    for cat, count in conn.execute(
+        f"SELECT assigned_by, COUNT(*) FROM topic_assignments "
+        f"WHERE source_collection IS NULL "
+        f"AND assigned_by IN ({placeholders}) "
+        "GROUP BY assigned_by",
+        _ELIGIBLE_ASSIGNED_BY,
+    ).fetchall():
+        if count:
+            eligible_rows_by_category[cat] = int(count)
+    eligible_rows = sum(eligible_rows_by_category.values())
+
+    updated_rows = 0
+    if apply and eligible_rows:
+        try:
+            cur = conn.execute(
+                f"UPDATE topic_assignments "
+                f"SET source_collection = ("
+                f"    SELECT collection FROM topics "
+                f"    WHERE topics.id = topic_assignments.topic_id"
+                f") "
+                f"WHERE source_collection IS NULL "
+                f"AND assigned_by IN ({placeholders})",
+                _ELIGIBLE_ASSIGNED_BY,
+            )
+            updated_rows = cur.rowcount
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+    return BackfillReport(
+        dry_run=not apply,
+        total_rows=total,
+        non_null_before=non_null,
+        eligible_rows=eligible_rows,
+        updated_rows=updated_rows,
+        eligible_by_category=eligible_rows_by_category,
+    )

--- a/tests/test_taxonomy_backfill.py
+++ b/tests/test_taxonomy_backfill.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``nx taxonomy backfill-source-collection`` — RDR-087 Phase 4.1.
+
+Backfills ``topic_assignments.source_collection`` for legacy rows that
+predate the RDR-077 projection path. Strategy: for ``assigned_by`` in
+``{'hdbscan', 'centroid'}``, clustering is per-collection so
+``topics.collection`` is the source collection; for ``'auto-matched'``
+and ``'projection'`` rows, the source is genuinely ambiguous and we
+leave the field alone.
+
+**Irreversible DB write** — ``--apply`` required; default is dry-run.
+Sandbox verification happens at the end of CI via a run against a
+tmp copy of the real T2 DB.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _seed_t2_with_legacy_assignments(path: Path) -> None:
+    """Build a T2 DB with:
+
+    - 1 ``projection`` row (NON-null source_collection; distinct from topic)
+    - 1 ``hdbscan`` row (NULL source_collection; topic in 'code__X')
+    - 1 ``centroid`` row (NULL source_collection; topic in 'docs__Y')
+    - 1 ``auto-matched`` row (NULL source_collection; topic in 'knowledge__Z')
+    """
+    from nexus.db.t2 import T2Database
+
+    db = T2Database(path)
+    c = db.taxonomy.conn
+    # Insert topics. ``created_at`` is NOT NULL with no default so the
+    # seed must supply it; ``INSERT OR IGNORE`` would otherwise silently
+    # drop the row on constraint violation.
+    c.executemany(
+        "INSERT OR IGNORE INTO topics "
+        "(id, label, collection, created_at) VALUES (?, ?, ?, ?)",
+        [
+            (1, "alpha", "code__X", "2026-04-01T00:00:00Z"),
+            (2, "beta", "docs__Y", "2026-04-01T00:00:00Z"),
+            (3, "gamma", "knowledge__Z", "2026-04-01T00:00:00Z"),
+        ],
+    )
+    c.executemany(
+        "INSERT INTO topic_assignments "
+        "(doc_id, topic_id, assigned_by, similarity, assigned_at, source_collection) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            # Projection: already populated; MUST NOT be touched.
+            ("d1", 1, "projection", 0.85, "2026-04-01T00:00:00Z", "docs__external"),
+            # Legacy rows with NULL source_collection:
+            ("d2", 1, "hdbscan", None, None, None),
+            ("d3", 2, "centroid", None, None, None),
+            ("d4", 3, "auto-matched", None, None, None),
+        ],
+    )
+    c.commit()
+    db.close()
+
+
+class TestBackfillDryRun:
+    def test_report_counts_without_writing(self, tmp_path: Path) -> None:
+        from nexus.taxonomy_backfill import backfill_source_collection
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2_with_legacy_assignments(db_path)
+
+        db = T2Database(db_path)
+        try:
+            report = backfill_source_collection(db.taxonomy.conn, apply=False)
+        finally:
+            db.close()
+
+        assert report.dry_run is True
+        assert report.eligible_rows == 2  # hdbscan + centroid
+        assert report.updated_rows == 0
+        assert report.coverage_before == pytest.approx(0.25)  # 1/4
+        # Projected coverage after apply: 3/4 = 0.75
+        assert report.coverage_projected == pytest.approx(0.75)
+        # Per-category eligible counts:
+        assert report.eligible_by_category == {"hdbscan": 1, "centroid": 1}
+
+    def test_dry_run_leaves_data_unchanged(self, tmp_path: Path) -> None:
+        from nexus.taxonomy_backfill import backfill_source_collection
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2_with_legacy_assignments(db_path)
+
+        db = T2Database(db_path)
+        try:
+            backfill_source_collection(db.taxonomy.conn, apply=False)
+            nulls = db.taxonomy.conn.execute(
+                "SELECT COUNT(*) FROM topic_assignments "
+                "WHERE source_collection IS NULL"
+            ).fetchone()[0]
+            assert nulls == 3  # nothing written
+        finally:
+            db.close()
+
+
+class TestBackfillApply:
+    def test_apply_fills_hdbscan_and_centroid(self, tmp_path: Path) -> None:
+        from nexus.taxonomy_backfill import backfill_source_collection
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2_with_legacy_assignments(db_path)
+
+        db = T2Database(db_path)
+        try:
+            report = backfill_source_collection(db.taxonomy.conn, apply=True)
+            rows = db.taxonomy.conn.execute(
+                "SELECT doc_id, assigned_by, source_collection "
+                "FROM topic_assignments ORDER BY doc_id"
+            ).fetchall()
+        finally:
+            db.close()
+
+        by_id = {r[0]: r for r in rows}
+        # Projection row untouched — still 'docs__external'.
+        assert by_id["d1"][2] == "docs__external"
+        # hdbscan (topic 1 → code__X) backfilled to 'code__X'.
+        assert by_id["d2"][2] == "code__X"
+        # centroid (topic 2 → docs__Y) backfilled to 'docs__Y'.
+        assert by_id["d3"][2] == "docs__Y"
+        # auto-matched LEFT ALONE — still NULL.
+        assert by_id["d4"][2] is None
+        # Report.
+        assert report.dry_run is False
+        assert report.updated_rows == 2
+        assert report.coverage_after == pytest.approx(0.75)
+
+    def test_idempotent_second_apply_is_noop(self, tmp_path: Path) -> None:
+        from nexus.taxonomy_backfill import backfill_source_collection
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2_with_legacy_assignments(db_path)
+
+        db = T2Database(db_path)
+        try:
+            backfill_source_collection(db.taxonomy.conn, apply=True)
+            second = backfill_source_collection(db.taxonomy.conn, apply=True)
+            assert second.eligible_rows == 0
+            assert second.updated_rows == 0
+        finally:
+            db.close()
+
+    def test_projection_rows_never_modified(self, tmp_path: Path) -> None:
+        """Defence in depth — even if the SQL got sloppy, the WHERE
+        clause must prevent ``projection``-row writes."""
+        from nexus.taxonomy_backfill import backfill_source_collection
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2_with_legacy_assignments(db_path)
+
+        db = T2Database(db_path)
+        try:
+            before = db.taxonomy.conn.execute(
+                "SELECT source_collection FROM topic_assignments "
+                "WHERE doc_id = 'd1'"
+            ).fetchone()[0]
+            backfill_source_collection(db.taxonomy.conn, apply=True)
+            after = db.taxonomy.conn.execute(
+                "SELECT source_collection FROM topic_assignments "
+                "WHERE doc_id = 'd1'"
+            ).fetchone()[0]
+            assert before == after == "docs__external"
+        finally:
+            db.close()
+
+
+class TestBackfillCli:
+    def _stub_db_open(self, monkeypatch, db_path: Path) -> None:
+        """Point the CLI at the seeded tmp T2 DB."""
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path",
+            lambda: db_path,
+        )
+
+    def test_default_is_dry_run(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.cli import main
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2_with_legacy_assignments(db_path)
+        self._stub_db_open(monkeypatch, db_path)
+
+        result = runner.invoke(main, ["taxonomy", "backfill-source-collection"])
+        assert result.exit_code == 0, result.output
+        assert "dry-run" in result.output.lower()
+
+        # No data was modified.
+        conn = sqlite3.connect(str(db_path))
+        nulls = conn.execute(
+            "SELECT COUNT(*) FROM topic_assignments WHERE source_collection IS NULL"
+        ).fetchone()[0]
+        conn.close()
+        assert nulls == 3
+
+    def test_apply_flag_commits_writes(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.cli import main
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2_with_legacy_assignments(db_path)
+        self._stub_db_open(monkeypatch, db_path)
+
+        result = runner.invoke(
+            main, ["taxonomy", "backfill-source-collection", "--apply"],
+        )
+        assert result.exit_code == 0, result.output
+
+        conn = sqlite3.connect(str(db_path))
+        nulls = conn.execute(
+            "SELECT COUNT(*) FROM topic_assignments WHERE source_collection IS NULL"
+        ).fetchone()[0]
+        conn.close()
+        # Only auto-matched left NULL.
+        assert nulls == 1


### PR DESCRIPTION
## Summary

RDR-087 Phase 4.1 — new \`nx taxonomy backfill-source-collection\` subcommand fills \`topic_assignments.source_collection\` for legacy \`hdbscan\` / \`centroid\` rows produced before cross-collection projection existed. **Prereq** for Phase 4.2 audit + 4.3 merge-candidates accuracy.

## Invariant

- \`hdbscan\` and \`centroid\` assignments run per-collection, so \`topics.collection IS source_collection\` by construction.
- \`projection\` rows already populate \`source_collection\` (and deliberately differ from \`topics.collection\`). Untouched.
- \`auto-matched\` rows have ambiguous source when the match is cross-collection — intentionally left NULL.

## Safety

- **IRREVERSIBLE DB write** — dry-run is default; \`--apply\` required to commit.
- Single UPDATE wrapped in explicit transaction with rollback on error.
- Projection rows excluded by WHERE clause — defence-in-depth test pins this.

## Sandbox verification on live dev T2

Ran \`--apply\` against a \`cp\` of the live \`~/.config/nexus/memory.db\` (433,044 rows):

| | Before | After |
|---|---|---|
| non-null \`source_collection\` | 205,641 (47.5%) | 359,326 (**83.0%**) |
| hdbscan+centroid NULL | 153,685 | 0 |
| projection NULL | 0 | 0 (untouched) |
| auto-matched NULL | 73,718 | 73,718 (untouched) |

Runtime: **0.62 s**. Persistence reopened via plain sqlite3 — verified.

## Test plan
- [x] \`uv run pytest tests/test_taxonomy_backfill.py\` — 7 passed (dry-run counts, apply correctness, projection-row isolation, idempotent second-apply, CLI default-is-dry-run, \`--apply\` commits)
- [x] Sandbox apply on live dev T2 — numbers above
- [ ] CI green

## CLI

\`\`\`
nx taxonomy backfill-source-collection            # dry-run (safe)
nx taxonomy backfill-source-collection --apply    # commit
\`\`\`

## Follow-up

Phase 4.2 (\`nx collection audit <name>\`) and 4.3 (\`nx collection merge-candidates\`) can now rely on \`source_collection\` coverage ≥80% after users run \`--apply\`. Coverage checkable via the probe 3b / collection health surfaces already shipped.