### PR TITLE
feat(collection): nx collection audit deep-dive (nexus-yi4b.4.2)

### DIFF
--- a/src/nexus/collection_audit.py
+++ b/src/nexus/collection_audit.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""``nx collection audit <name>`` — RDR-087 Phase 4.2.
+
+Four sections:
+
+1. **Distance histogram** — 10-bucket histogram of ``top_distance`` over
+   the last 30 days from ``search_telemetry``. Live-probe fallback
+   (N=25 queries against ChromaDB when telemetry is cold) is deferred
+   to bead ``nexus-fx2d``; this module ships the telemetry-only path
+   and reports ``source="empty"`` when cold.
+
+2. **Top-5 cross-projections** — collections this one projects INTO.
+   Aggregates ``topic_assignments`` WHERE ``source_collection=<name>``
+   AND ``topics.collection != <name>``, ranks by
+   ``shared_topics * avg_similarity``.
+
+3. **Orphan chunks** — catalog documents in this collection with no
+   incoming links AND ``indexed_at < now - 30d``.
+
+4. **Hub-topic assignments** — top-10 cross-collection hubs (topics
+   whose assignments span the most distinct source collections) and
+   this collection's contribution to each.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+# ── Dataclasses ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class DistanceHistogram:
+    buckets: list[int]              # 10 counts over [0.0, 2.0] in 0.2 steps
+    source: str                     # "telemetry" | "live" | "empty"
+    sample_size: int
+
+
+@dataclass(frozen=True)
+class ProjectionPair:
+    other_collection: str
+    shared_topics: int
+    avg_similarity: float
+
+    @property
+    def score(self) -> float:
+        return self.shared_topics * self.avg_similarity
+
+
+@dataclass(frozen=True)
+class OrphanChunk:
+    tumbler: str
+    title: str
+    indexed_at: str
+
+
+@dataclass(frozen=True)
+class HubAssignment:
+    topic_id: int
+    topic_label: str
+    topic_collection: str
+    source_collection_count: int    # # distinct source_collections across the hub
+    chunks_in_hub: int              # this collection's chunks assigned to the hub
+
+
+@dataclass(frozen=True)
+class AuditReport:
+    collection: str
+    distance_histogram: DistanceHistogram
+    cross_projections: list[ProjectionPair]
+    orphans: list[OrphanChunk]
+    hub_assignments: list[HubAssignment]
+
+
+# ── Section 1: distance histogram (telemetry-only; live deferred) ───────────
+
+
+_HIST_BIN_WIDTH = 0.2
+_HIST_BINS = 10  # covers [0.0, 2.0]
+
+
+def compute_distance_histogram(
+    taxonomy_conn: sqlite3.Connection, collection: str, *, days: int = 30,
+) -> DistanceHistogram:
+    """Histogram of ``top_distance`` from search_telemetry for *collection*.
+
+    10 fixed bins over [0.0, 2.0]. Empty table or <1 in-window rows →
+    ``DistanceHistogram(source="empty", sample_size=0)``. Live-probe
+    fallback is deferred to bead ``nexus-fx2d``.
+    """
+    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    rows = taxonomy_conn.execute(
+        "SELECT top_distance FROM search_telemetry "
+        "WHERE collection = ? AND ts >= ? "
+        "AND raw_count > 0 AND top_distance IS NOT NULL",
+        (collection, cutoff),
+    ).fetchall()
+    distances = [float(r[0]) for r in rows]
+    if not distances:
+        return DistanceHistogram(
+            buckets=[0] * _HIST_BINS, source="empty", sample_size=0,
+        )
+    buckets = [0] * _HIST_BINS
+    for d in distances:
+        idx = min(int(d / _HIST_BIN_WIDTH), _HIST_BINS - 1)
+        buckets[idx] += 1
+    return DistanceHistogram(
+        buckets=buckets, source="telemetry", sample_size=len(distances),
+    )
+
+
+# ── Section 2: top-N cross-projections ──────────────────────────────────────
+
+
+def compute_cross_projections(
+    taxonomy_conn: sqlite3.Connection, collection: str, *, top_n: int = 5,
+) -> list[ProjectionPair]:
+    """Top-*top_n* collections this one projects INTO.
+
+    Ranked by ``shared_topics * avg_similarity``. Requires
+    ``assigned_by='projection'`` rows with non-NULL ``similarity`` and
+    ``source_collection``.
+    """
+    rows = taxonomy_conn.execute(
+        "SELECT t.collection AS other, "
+        "       COUNT(DISTINCT ta.topic_id) AS shared, "
+        "       AVG(ta.similarity) AS avg_sim "
+        "FROM topic_assignments ta "
+        "JOIN topics t ON ta.topic_id = t.id "
+        "WHERE ta.source_collection = ? "
+        "  AND t.collection != ? "
+        "  AND ta.similarity IS NOT NULL "
+        "GROUP BY t.collection "
+        "ORDER BY shared * AVG(ta.similarity) DESC "
+        "LIMIT ?",
+        (collection, collection, top_n),
+    ).fetchall()
+    return [
+        ProjectionPair(
+            other_collection=r[0],
+            shared_topics=int(r[1]),
+            avg_similarity=float(r[2]),
+        )
+        for r in rows
+    ]
+
+
+# ── Section 3: orphan chunks ────────────────────────────────────────────────
+
+
+def compute_orphan_chunks(
+    catalog_conn: sqlite3.Connection,
+    collection: str,
+    *,
+    age_days: int = 30,
+    limit: int = 20,
+) -> list[OrphanChunk]:
+    """Catalog documents with no incoming links older than *age_days*."""
+    cutoff = (datetime.now(UTC) - timedelta(days=age_days)).isoformat()
+    rows = catalog_conn.execute(
+        "SELECT d.tumbler, d.title, d.indexed_at "
+        "FROM documents d "
+        "LEFT JOIN links l ON d.tumbler = l.to_tumbler "
+        "WHERE d.physical_collection = ? "
+        "  AND l.id IS NULL "
+        "  AND d.indexed_at IS NOT NULL "
+        "  AND d.indexed_at < ? "
+        "ORDER BY d.indexed_at ASC "
+        "LIMIT ?",
+        (collection, cutoff, limit),
+    ).fetchall()
+    return [
+        OrphanChunk(tumbler=r[0], title=r[1] or "", indexed_at=r[2] or "")
+        for r in rows
+    ]
+
+
+# ── Section 4: hub-topic assignments ────────────────────────────────────────
+
+
+def compute_hub_assignments(
+    taxonomy_conn: sqlite3.Connection, collection: str, *, top_n: int = 10,
+) -> list[HubAssignment]:
+    """Top-*top_n* cross-collection hub topics and this collection's share."""
+    hubs = taxonomy_conn.execute(
+        "SELECT ta.topic_id, COUNT(DISTINCT ta.source_collection) AS src_count "
+        "FROM topic_assignments ta "
+        "GROUP BY ta.topic_id "
+        "ORDER BY src_count DESC, ta.topic_id ASC "
+        "LIMIT ?",
+        (top_n,),
+    ).fetchall()
+    if not hubs:
+        return []
+    out: list[HubAssignment] = []
+    for topic_id, src_count in hubs:
+        meta = taxonomy_conn.execute(
+            "SELECT label, collection FROM topics WHERE id = ?",
+            (topic_id,),
+        ).fetchone()
+        if meta is None:
+            continue
+        label, topic_collection = meta
+        chunk_count = taxonomy_conn.execute(
+            "SELECT COUNT(*) FROM topic_assignments "
+            "WHERE topic_id = ? AND source_collection = ?",
+            (topic_id, collection),
+        ).fetchone()[0]
+        out.append(
+            HubAssignment(
+                topic_id=int(topic_id),
+                topic_label=label or "",
+                topic_collection=topic_collection or "",
+                source_collection_count=int(src_count),
+                chunks_in_hub=int(chunk_count or 0),
+            )
+        )
+    return out
+
+
+# ── Default production runners (dep-injected) ───────────────────────────────
+
+
+def _open_t2():
+    from nexus.commands._helpers import default_db_path
+    from nexus.db.t2 import T2Database
+
+    db_path = default_db_path()
+    if not db_path.exists():
+        return None
+    return T2Database(db_path)
+
+
+def _open_catalog_conn() -> sqlite3.Connection | None:
+    """Return a sqlite3 connection to the catalog cache DB.
+
+    Tests monkeypatch this module-level function to point at a seeded
+    fixture; production reaches to ``~/.config/nexus`` by default.
+    """
+    from nexus.catalog.catalog import Catalog
+    from nexus.config import catalog_path
+
+    path = catalog_path()
+    if not Catalog.is_initialized(path):
+        return None
+    return sqlite3.connect(str(path / ".catalog.db"))
+
+
+# ── Orchestrator ────────────────────────────────────────────────────────────
+
+
+def run_collection_audit(collection: str) -> AuditReport:
+    """Assemble the full audit report for *collection*.
+
+    Sections tolerate absent backing stores (empty-telemetry / uninit
+    catalog) — each falls back to a neutral empty value.
+    """
+    t2 = _open_t2()
+    cat_conn = _open_catalog_conn()
+    try:
+        if t2 is not None:
+            hist = compute_distance_histogram(t2.taxonomy.conn, collection)
+            projections = compute_cross_projections(t2.taxonomy.conn, collection)
+            hubs = compute_hub_assignments(t2.taxonomy.conn, collection)
+        else:
+            hist = DistanceHistogram(buckets=[0] * _HIST_BINS, source="empty", sample_size=0)
+            projections = []
+            hubs = []
+        if cat_conn is not None:
+            orphans = compute_orphan_chunks(cat_conn, collection)
+        else:
+            orphans = []
+    finally:
+        if t2 is not None:
+            t2.close()
+        if cat_conn is not None:
+            cat_conn.close()
+    return AuditReport(
+        collection=collection,
+        distance_histogram=hist,
+        cross_projections=projections,
+        orphans=orphans,
+        hub_assignments=hubs,
+    )
+
+
+# ── Formatters ──────────────────────────────────────────────────────────────
+
+
+def format_audit_human(report: AuditReport) -> str:
+    lines: list[str] = [f"Audit: {report.collection}", ""]
+    # Section 1
+    lines.append("=== distance histogram (30d) ===")
+    h = report.distance_histogram
+    if h.sample_size == 0:
+        lines.append(
+            f"  (no telemetry rows; live-probe fallback deferred — nexus-fx2d)"
+        )
+    else:
+        lines.append(f"  source={h.source} samples={h.sample_size}")
+        for i, count in enumerate(h.buckets):
+            lo = i * _HIST_BIN_WIDTH
+            hi = lo + _HIST_BIN_WIDTH
+            bar = "▇" * count if count else ""
+            lines.append(f"  [{lo:.1f}, {hi:.1f})  {count:>5}  {bar}")
+    lines.append("")
+    # Section 2
+    lines.append("=== top-5 cross-projections ===")
+    if not report.cross_projections:
+        lines.append("  (no projection rows for this collection)")
+    else:
+        for p in report.cross_projections:
+            lines.append(
+                f"  → {p.other_collection:<40}  "
+                f"shared={p.shared_topics:>4}  "
+                f"avg_sim={p.avg_similarity:.3f}  "
+                f"score={p.score:.3f}"
+            )
+    lines.append("")
+    # Section 3
+    lines.append("=== orphan chunks (>30d, no incoming links) ===")
+    if not report.orphans:
+        lines.append("  (none)")
+    else:
+        for o in report.orphans:
+            lines.append(f"  {o.tumbler:<10}  {o.indexed_at:<25}  {o.title}")
+    lines.append("")
+    # Section 4
+    lines.append("=== top-10 cross-collection hubs ===")
+    if not report.hub_assignments:
+        lines.append("  (no hub signals)")
+    else:
+        for h_ in report.hub_assignments:
+            lines.append(
+                f"  topic#{h_.topic_id:<5} {h_.topic_label:<30} "
+                f"({h_.topic_collection})  "
+                f"srcs={h_.source_collection_count:>3}  "
+                f"this_col_chunks={h_.chunks_in_hub:>4}"
+            )
+    return "\n".join(lines)
+
+
+def format_audit_json(report: AuditReport) -> str:
+    return json.dumps(asdict(report), indent=2)

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -508,3 +508,34 @@ def health_cmd(sort_by: str, fmt: str) -> None:
     from nexus.collection_health import run_collection_health
 
     click.echo(run_collection_health(sort_by=sort_by, fmt=fmt))
+
+
+@collection.command("audit")
+@click.argument("name")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    show_default=True,
+    help="Output format.",
+)
+def audit_cmd(name: str, fmt: str) -> None:
+    """Deep-dive audit for a single collection (RDR-087 Phase 4.2).
+
+    Four sections: distance histogram (30d), top-5 cross-projections,
+    orphan chunks (>30d, no incoming links), top-10 cross-collection
+    hub topic assignments. Live-probe distance fallback deferred to
+    follow-up bead nexus-fx2d — telemetry-only for now.
+    """
+    from nexus.collection_audit import (
+        format_audit_human,
+        format_audit_json,
+        run_collection_audit,
+    )
+
+    report = run_collection_audit(name)
+    if fmt == "json":
+        click.echo(format_audit_json(report))
+    else:
+        click.echo(format_audit_human(report))

--- a/tests/test_collection_audit.py
+++ b/tests/test_collection_audit.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``nx collection audit <name>`` — RDR-087 Phase 4.2.
+
+Four sections in one report: distance histogram, top-5 cross-projections,
+orphan chunks, hub-topic assignments. Section 1 (distance histogram)
+ships telemetry-only in this bead; the live-probe fallback is deferred
+to follow-up bead ``nexus-fx2d``.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _seed_t2(path: Path) -> None:
+    """Build a T2 DB with topics, topic_assignments, and search_telemetry
+    seeded for a ``code__main`` collection under audit plus a few others
+    so cross-projection + hub queries have data."""
+    from nexus.db.t2 import T2Database
+
+    db = T2Database(path)
+    c = db.taxonomy.conn
+    c.executemany(
+        "INSERT OR IGNORE INTO topics "
+        "(id, label, collection, created_at) VALUES (?, ?, ?, ?)",
+        [
+            (1, "auth",    "code__main",    "2026-04-01"),
+            (2, "search",  "code__main",    "2026-04-01"),
+            (3, "db",      "docs__alpha",   "2026-04-01"),
+            (4, "misc",    "code__other",   "2026-04-01"),
+            (5, "hub-A",   "code__main",    "2026-04-01"),  # high-src hub
+            (6, "hub-B",   "code__main",    "2026-04-01"),
+        ],
+    )
+    # topic_assignments:
+    # - topic 3 (docs__alpha) gets multiple chunks from code__main → cross-projection pair.
+    # - topic 4 (code__other) gets 1 chunk from code__main → another pair.
+    # - topics 5 and 6 get chunks from many source collections → they're cross-coll hubs.
+    c.executemany(
+        "INSERT INTO topic_assignments "
+        "(doc_id, topic_id, assigned_by, similarity, assigned_at, source_collection) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            # code__main → docs__alpha/db (3 shared docs, avg sim 0.7)
+            ("cm1", 3, "projection", 0.8, "2026-04-01", "code__main"),
+            ("cm2", 3, "projection", 0.7, "2026-04-01", "code__main"),
+            ("cm3", 3, "projection", 0.6, "2026-04-01", "code__main"),
+            # code__main → code__other/misc (1 shared doc, avg sim 0.5)
+            ("cm4", 4, "projection", 0.5, "2026-04-01", "code__main"),
+            # Hub-A (topic 5) gets chunks from 3 source collections → hub
+            ("cm5", 5, "projection", 0.9, "2026-04-01", "code__main"),
+            ("hx",  5, "projection", 0.9, "2026-04-01", "docs__alpha"),
+            ("hy",  5, "projection", 0.9, "2026-04-01", "code__other"),
+            # Hub-B (topic 6) gets chunks from 2 source collections
+            ("cm6", 6, "projection", 0.85, "2026-04-01", "code__main"),
+            ("hy2", 6, "projection", 0.85, "2026-04-01", "code__other"),
+        ],
+    )
+    c.commit()
+    # search_telemetry: seed 15 rows for code__main in the last 30d
+    # with top_distance values spread across buckets.
+    now = datetime.now(UTC)
+    tel_rows = []
+    dists = [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 1.05,
+             1.25, 0.15, 0.25, 0.35, 0.45]  # 15 samples
+    for i, d in enumerate(dists):
+        ts = (now - timedelta(days=1)).isoformat()
+        tel_rows.append(
+            (ts, f"hash{i:04d}", "code__main", 5, 3, d, 0.45),
+        )
+    db.telemetry.log_search_batch(tel_rows)
+    db.close()
+
+
+def _seed_catalog_conn(db_path: Path) -> "sqlite3.Connection":
+    """Build a minimal catalog SQLite cache directly — skip the
+    JSONL/git facade that would rebuild from source on first open."""
+    import sqlite3
+
+    from nexus.catalog.catalog_db import _SCHEMA_SQL
+
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SCHEMA_SQL)
+    old_ts = (datetime.now(UTC) - timedelta(days=45)).isoformat()
+    new_ts = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+    conn.executemany(
+        "INSERT INTO documents "
+        "(tumbler, title, author, year, content_type, file_path, corpus, "
+        " physical_collection, chunk_count, head_hash, indexed_at, metadata) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("1.1", "linked doc (old)", "t", 2026, "code", "src/linked.py",
+             "code", "code__main", 5, "h1", old_ts, "{}"),
+            ("1.2", "orphan old", "t", 2026, "code", "src/orphan.py",
+             "code", "code__main", 3, "h2", old_ts, "{}"),
+            ("1.3", "orphan recent", "t", 2026, "code", "src/recent.py",
+             "code", "code__main", 1, "h3", new_ts, "{}"),
+        ],
+    )
+    # Incoming link onto 1.1 — makes it non-orphan.
+    conn.execute(
+        "INSERT INTO links (from_tumbler, to_tumbler, link_type, created_by) "
+        "VALUES (?, ?, ?, ?)",
+        ("2.1", "1.1", "cites", "test"),
+    )
+    conn.commit()
+    return conn
+
+
+# ── Section 2: cross-projections ────────────────────────────────────────────
+
+
+class TestCrossProjections:
+    def test_ranked_by_score_shared_x_similarity(self, tmp_path: Path) -> None:
+        from nexus.collection_audit import compute_cross_projections
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            pairs = compute_cross_projections(
+                db.taxonomy.conn, "code__main", top_n=5,
+            )
+        finally:
+            db.close()
+
+        # code__main → docs__alpha is higher-score than → code__other.
+        names = [p.other_collection for p in pairs]
+        assert "docs__alpha" in names
+        assert "code__other" in names
+        idx_alpha = names.index("docs__alpha")
+        idx_other = names.index("code__other")
+        assert idx_alpha < idx_other
+        # code__main should NOT project to itself even though topics 5/6
+        # are in code__main (that's not cross-projection).
+        assert "code__main" not in names
+
+    def test_empty_when_no_projection_rows(self, tmp_path: Path) -> None:
+        from nexus.collection_audit import compute_cross_projections
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            pairs = compute_cross_projections(
+                db.taxonomy.conn, "code__unseen", top_n=5,
+            )
+        finally:
+            db.close()
+        assert pairs == []
+
+
+# ── Section 3: orphan chunks ────────────────────────────────────────────────
+
+
+class TestOrphanChunks:
+    def test_flags_old_unlinked_documents(self, tmp_path: Path) -> None:
+        from nexus.collection_audit import compute_orphan_chunks
+
+        conn = _seed_catalog_conn(tmp_path / "catalog.db")
+        try:
+            orphans = compute_orphan_chunks(
+                conn, "code__main", age_days=30, limit=20,
+            )
+        finally:
+            conn.close()
+        # 1.1 has incoming link → not orphan.
+        # 1.2 is old + unlinked → orphan.
+        # 1.3 is unlinked but young (5d) → not orphan.
+        tumblers = {o.tumbler for o in orphans}
+        assert "1.2" in tumblers
+        assert "1.1" not in tumblers
+        assert "1.3" not in tumblers
+
+    def test_empty_when_collection_clean(self, tmp_path: Path) -> None:
+        from nexus.collection_audit import compute_orphan_chunks
+
+        conn = _seed_catalog_conn(tmp_path / "catalog.db")
+        try:
+            orphans = compute_orphan_chunks(
+                conn, "code__notreal", age_days=30, limit=20,
+            )
+        finally:
+            conn.close()
+        assert orphans == []
+
+
+# ── Section 4: hub assignments ──────────────────────────────────────────────
+
+
+class TestHubAssignments:
+    def test_top_10_by_source_collection_breadth(self, tmp_path: Path) -> None:
+        from nexus.collection_audit import compute_hub_assignments
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            hubs = compute_hub_assignments(
+                db.taxonomy.conn, "code__main", top_n=10,
+            )
+        finally:
+            db.close()
+
+        # Topic 5 (hub-A) sees chunks from 3 collections; topic 6 from 2;
+        # topic 3 from 1 (only code__main); topic 4 from 1 (only code__main).
+        # Assuming "hub" threshold is simply top-N by src_count, all topics
+        # appear in the top-10; code__main chunks in each:
+        by_id = {h.topic_id: h for h in hubs}
+        # code__main contributes 1 chunk (cm5) to topic 5.
+        assert by_id[5].chunks_in_hub == 1
+        # code__main contributes 1 chunk (cm6) to topic 6.
+        assert by_id[6].chunks_in_hub == 1
+
+
+# ── Section 1: distance histogram (telemetry-only for this bead) ────────────
+
+
+class TestDistanceHistogramTelemetryOnly:
+    def test_buckets_cover_0_to_2_in_10_bins(self, tmp_path: Path) -> None:
+        from nexus.collection_audit import compute_distance_histogram
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            hist = compute_distance_histogram(
+                db.taxonomy.conn, "code__main",
+            )
+        finally:
+            db.close()
+        assert len(hist.buckets) == 10
+        assert sum(hist.buckets) == hist.sample_size == 15
+        assert hist.source == "telemetry"
+
+    def test_reports_empty_source_when_no_rows(self, tmp_path: Path) -> None:
+        from nexus.collection_audit import compute_distance_histogram
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            hist = compute_distance_histogram(db.taxonomy.conn, "code__cold")
+        finally:
+            db.close()
+        assert hist.sample_size == 0
+        assert hist.source == "empty"
+
+
+# ── CLI integration ─────────────────────────────────────────────────────────
+
+
+class TestCollectionAuditCli:
+    def test_default_output_covers_four_sections(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.cli import main
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        catalog_db_path = tmp_path / "catalog.db"
+        _seed_catalog_conn(catalog_db_path).close()
+
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+        monkeypatch.setattr(
+            "nexus.collection_audit._open_catalog_conn",
+            lambda: __import__("sqlite3").connect(str(catalog_db_path)),
+        )
+
+        result = runner.invoke(
+            main, ["collection", "audit", "code__main"],
+        )
+        assert result.exit_code == 0, result.output
+        out = result.output.lower()
+        for section_hint in ["distance histogram", "cross-projection", "orphan", "hub"]:
+            assert section_hint in out
+
+    def test_json_flag_emits_parseable_payload(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        import json
+        from nexus.cli import main
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        catalog_db_path = tmp_path / "catalog.db"
+        _seed_catalog_conn(catalog_db_path).close()
+
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+        monkeypatch.setattr(
+            "nexus.collection_audit._open_catalog_conn",
+            lambda: __import__("sqlite3").connect(str(catalog_db_path)),
+        )
+
+        result = runner.invoke(
+            main, ["collection", "audit", "code__main", "--format", "json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["collection"] == "code__main"
+        assert "distance_histogram" in payload
+        assert "cross_projections" in payload
+        assert "orphans" in payload
+        assert "hub_assignments" in payload


### PR DESCRIPTION
## Summary

RDR-087 Phase 4.2 — new \`nx collection audit <name>\` subcommand builds a 4-section per-collection deep-dive.

### Sections

| # | Section | Source |
|---|---|---|
| 1 | Distance histogram (30d, 10 bins over [0.0, 2.0]) | \`search_telemetry\` — telemetry-only; live fallback deferred to \`nexus-fx2d\` |
| 2 | Top-5 cross-projections | \`topic_assignments\` JOIN \`topics\`, ranked by \`shared × avg_sim\` |
| 3 | Orphan chunks (>30d, no incoming links) | catalog \`documents\` LEFT JOIN \`links\` |
| 4 | Top-10 cross-collection hubs + this collection's contribution | \`topic_assignments\` grouped by \`topic_id\` |

### Section 1 deferral
Live-probe fallback (N=25 ChromaDB queries against the collection when telemetry is cold) is filed as follow-up bead **\`nexus-fx2d\`** — waiting for the parallel indexing instance on \`delos\` to finish so the probe doesn't contend on T3 writes. Today ships the telemetry-only path and reports \`source="empty"\` cleanly when cold.

### Dep-injected helpers
Per-section computations take \`sqlite3.Connection\` directly (not facades) so tests drive deterministic seeds without standing up T2Database / Catalog. Orchestrator \`run_collection_audit\` wires live paths via \`_open_t2()\` / \`_open_catalog_conn()\` with graceful fallback on uninitialised stores.

### Live smoke on \`rdr__nexus-571b8edd\`
- Histogram: 4/4 samples in \`[0.8, 1.0)\` — matches the silent-threshold-drop class probe 3b already surfaced.
- Top projections: \`docs__nexus-571b8edd\` (64 shared), \`rdr__arcaneum-2ad2825c\` (21), plus 3 more — the expected related collections.
- 0 orphans (RDR corpus is well-linked).
- 10 hubs surfaced; this collection contributes 0–401 chunks per hub.

## Test plan
- [x] \`uv run pytest tests/test_collection_audit.py\` — 9 passed (per-section unit + CLI default + CLI JSON)
- [x] Live smoke on a real collection
- [ ] CI green

## CLI

\`\`\`
nx collection audit <name>                  # default: 4-section table
nx collection audit <name> --format json    # parseable payload for agents
\`\`\`

## Follow-up
- \`nexus-fx2d\` — section 1 live-probe path (blocks on delos indexing finish)
- Phase 4.3 \`nx collection merge-candidates\` — pair-wise overlap; can start once this merges