### PR TITLE
feat(collection): nx collection merge-candidates (nexus-yi4b.4.3)

### DIFF
--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -539,3 +539,70 @@ def audit_cmd(name: str, fmt: str) -> None:
         click.echo(format_audit_json(report))
     else:
         click.echo(format_audit_human(report))
+
+
+@collection.command("merge-candidates")
+@click.option(
+    "--min-shared", "min_shared", type=int, default=3, show_default=True,
+    help="Minimum distinct shared topics between two collections "
+         "to qualify as a candidate.",
+)
+@click.option(
+    "--min-similarity", "min_similarity", type=float, default=0.5,
+    show_default=True,
+    help="Minimum mean ``similarity`` across shared topics.",
+)
+@click.option(
+    "--exclude-hubs", "exclude_hubs", is_flag=True, default=False,
+    help="Drop top-N cross-collection hub topics from the shared-topic "
+         "count before thresholding (reduces false positives from "
+         "generic hubs).",
+)
+@click.option(
+    "--hub-top-n", "hub_top_n", type=int, default=10, show_default=True,
+    help="Hub depth used by --exclude-hubs.",
+)
+@click.option(
+    "--limit", "limit", type=int, default=50, show_default=True,
+    help="Max number of candidate pairs returned.",
+)
+@click.option(
+    "--format", "fmt",
+    type=click.Choice(["table", "json"]), default="table", show_default=True,
+    help="Output format.",
+)
+@click.option(
+    "--create-link", "create_link", is_flag=True, default=False,
+    help="(deferred) Write catalog `relates`/`bridges` edges for each "
+         "surfaced pair. Currently reports a deferred-workflow advisory "
+         "per RDR §bridge-link — use nx catalog link manually.",
+)
+def merge_candidates_cmd(
+    min_shared: int, min_similarity: float,
+    exclude_hubs: bool, hub_top_n: int,
+    limit: int, fmt: str, create_link: bool,
+) -> None:
+    """Pair-wise cross-collection overlap ranking (RDR-087 Phase 4.3).
+
+    Surfaces (a, b) pairs where collection *a* projects into topics in
+    collection *b* with high similarity — hints at merge or bridge-
+    link opportunities for a human / agent to decide on. NEVER writes
+    catalog edges automatically; --create-link is advisory and deferred.
+    """
+    if create_link:
+        raise click.ClickException(
+            "--create-link is deferred per RDR-087 §bridge-link workflow. "
+            "Use `nx catalog link` manually after reviewing the candidates."
+        )
+    from nexus.merge_candidates import run_merge_candidates
+
+    click.echo(
+        run_merge_candidates(
+            min_shared=min_shared,
+            min_similarity=min_similarity,
+            exclude_hubs=exclude_hubs,
+            hub_top_n=hub_top_n,
+            limit=limit,
+            fmt=fmt,
+        )
+    )

--- a/src/nexus/merge_candidates.py
+++ b/src/nexus/merge_candidates.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""``nx collection merge-candidates`` — RDR-087 Phase 4.3.
+
+Pair-wise cross-collection overlap via ``topic_assignments``. Ranks
+(source_collection, topics.collection) pairs by
+``shared_topics * mean_similarity``.
+
+Null ``source_collection`` rows are excluded (legacy pre-RDR-077
+rows). Self-pairs (``source_collection == topics.collection``) are
+excluded — those are same-collection assignments, not cross-collection
+merge candidates. ``--exclude-hubs`` subtracts the top-N hub topics
+(widest ``source_collection`` spread) from the shared-topic count to
+mitigate false positives from generic hubs like "API rate limiting"
+or "schema evolution".
+
+Catalog link creation (``--create-link``) is explicitly deferred per
+RDR §bridge-link workflow. This bead surfaces the candidates; the
+human / agent decides.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass(frozen=True)
+class MergeCandidate:
+    a: str                       # source_collection
+    b: str                       # topic's collection
+    shared_topics: int
+    mean_sim: float
+    sample_chunks: list[str] = field(default_factory=list)
+
+    @property
+    def score(self) -> float:
+        return self.shared_topics * self.mean_sim
+
+
+# ── Core query ──────────────────────────────────────────────────────────────
+
+
+_DEFAULT_HUB_TOP_N = 10
+
+
+def _top_hub_topic_ids(
+    conn: sqlite3.Connection, hub_top_n: int,
+) -> tuple[int, ...]:
+    rows = conn.execute(
+        "SELECT ta.topic_id "
+        "FROM topic_assignments ta "
+        "GROUP BY ta.topic_id "
+        "ORDER BY COUNT(DISTINCT ta.source_collection) DESC, ta.topic_id ASC "
+        "LIMIT ?",
+        (hub_top_n,),
+    ).fetchall()
+    return tuple(int(r[0]) for r in rows)
+
+
+def compute_merge_candidates(
+    conn: sqlite3.Connection,
+    *,
+    min_shared: int = 3,
+    min_similarity: float = 0.5,
+    exclude_hubs: bool = False,
+    hub_top_n: int = _DEFAULT_HUB_TOP_N,
+    limit: int = 50,
+    sample_k: int = 3,
+) -> list[MergeCandidate]:
+    """Return ranked (a, b) cross-collection merge candidates."""
+    hub_filter = ""
+    hub_params: tuple[int, ...] = ()
+    if exclude_hubs:
+        hub_ids = _top_hub_topic_ids(conn, hub_top_n)
+        if hub_ids:
+            placeholders = ",".join("?" * len(hub_ids))
+            hub_filter = f" AND ta.topic_id NOT IN ({placeholders})"
+            hub_params = hub_ids
+
+    sql = f"""
+        SELECT ta.source_collection AS a,
+               t.collection AS b,
+               COUNT(DISTINCT ta.topic_id) AS shared,
+               AVG(ta.similarity) AS mean_sim
+        FROM topic_assignments ta
+        JOIN topics t ON ta.topic_id = t.id
+        WHERE ta.source_collection IS NOT NULL
+          AND ta.source_collection <> t.collection
+          AND ta.similarity IS NOT NULL
+          {hub_filter}
+        GROUP BY ta.source_collection, t.collection
+        HAVING shared >= ? AND mean_sim >= ?
+        ORDER BY shared * mean_sim DESC
+        LIMIT ?
+    """
+    rows = conn.execute(sql, (*hub_params, min_shared, min_similarity, limit)).fetchall()
+    out: list[MergeCandidate] = []
+    for a, b, shared, mean_sim in rows:
+        samples = [
+            r[0] for r in conn.execute(
+                "SELECT ta.doc_id "
+                "FROM topic_assignments ta "
+                "JOIN topics t ON ta.topic_id = t.id "
+                "WHERE ta.source_collection = ? AND t.collection = ? "
+                "  AND ta.similarity IS NOT NULL "
+                f"  {hub_filter} "
+                "ORDER BY ta.similarity DESC "
+                "LIMIT ?",
+                (a, b, *hub_params, sample_k),
+            ).fetchall()
+        ]
+        out.append(
+            MergeCandidate(
+                a=a, b=b,
+                shared_topics=int(shared),
+                mean_sim=float(mean_sim),
+                sample_chunks=samples,
+            )
+        )
+    return out
+
+
+# ── Default production runners ──────────────────────────────────────────────
+
+
+def _open_t2():
+    from nexus.commands._helpers import default_db_path
+    from nexus.db.t2 import T2Database
+
+    db_path = default_db_path()
+    if not db_path.exists():
+        return None
+    return T2Database(db_path)
+
+
+# ── CLI entry point ─────────────────────────────────────────────────────────
+
+
+def run_merge_candidates(
+    *,
+    min_shared: int,
+    min_similarity: float,
+    exclude_hubs: bool,
+    hub_top_n: int,
+    limit: int,
+    fmt: str,
+) -> str:
+    t2 = _open_t2()
+    if t2 is None:
+        return "T2 database not initialised."
+    try:
+        pairs = compute_merge_candidates(
+            t2.taxonomy.conn,
+            min_shared=min_shared,
+            min_similarity=min_similarity,
+            exclude_hubs=exclude_hubs,
+            hub_top_n=hub_top_n,
+            limit=limit,
+        )
+    finally:
+        t2.close()
+    if fmt == "json":
+        return json.dumps(
+            {
+                "candidates": [asdict(p) for p in pairs],
+                "filters": {
+                    "min_shared": min_shared,
+                    "min_similarity": min_similarity,
+                    "exclude_hubs": exclude_hubs,
+                    "hub_top_n": hub_top_n if exclude_hubs else None,
+                    "limit": limit,
+                },
+            },
+            indent=2,
+        )
+    return _format_human(pairs, exclude_hubs=exclude_hubs)
+
+
+def _format_human(
+    pairs: list[MergeCandidate], *, exclude_hubs: bool,
+) -> str:
+    if not pairs:
+        return "No merge candidates above the configured thresholds."
+    lines = ["Merge candidates — pair-wise cross-collection overlap"]
+    if exclude_hubs:
+        lines.append("  (top-N hub topics excluded)")
+    lines.append("")
+    lines.append(
+        f"  {'a':<35}  {'b':<35}  {'shared':>7}  "
+        f"{'mean_sim':>9}  {'score':>7}  samples"
+    )
+    for p in pairs:
+        samples_str = (",".join(p.sample_chunks[:3]))[:45]
+        lines.append(
+            f"  {p.a:<35}  {p.b:<35}  {p.shared_topics:>7}  "
+            f"{p.mean_sim:>9.3f}  {p.score:>7.2f}  {samples_str}"
+        )
+    return "\n".join(lines)

--- a/tests/test_merge_candidates.py
+++ b/tests/test_merge_candidates.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``nx collection merge-candidates`` — RDR-087 Phase 4.3.
+
+Pair-wise cross-collection overlap ranking. Candidates where two
+collections share topics with high similarity hint at merge/bridge
+opportunities — surfaced for a human or agent to decide on.
+
+``--create-link`` is **opt-in**; the command never writes catalog
+edges without explicit confirmation. RDR §bridge-link workflow
+explicitly defers auto-bridge to a later cycle.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _seed_t2(path: Path) -> None:
+    """Build a T2 DB with a mix of legitimate merge signals and
+    hub-dominated noise.
+
+    - 5 topics: 2 cross-collection hubs (topic_ids 4, 5), 3 normal.
+    - Pair (code__a, docs__b): shared across 3 normal topics, high sim.
+    - Pair (code__a, code__c): shared only via hub topics → suppressible.
+    - One NULL source_collection row — must be excluded per RDR Failure
+      Modes.
+    """
+    from nexus.db.t2 import T2Database
+
+    db = T2Database(path)
+    c = db.taxonomy.conn
+    c.executemany(
+        "INSERT OR IGNORE INTO topics "
+        "(id, label, collection, created_at) VALUES (?, ?, ?, ?)",
+        [
+            (1, "auth",   "docs__b", "2026-04-01"),
+            (2, "search", "docs__b", "2026-04-01"),
+            (3, "db",     "docs__b", "2026-04-01"),
+            (4, "hub-A",  "code__c", "2026-04-01"),  # hub: wide source_collection spread
+            (5, "hub-B",  "code__c", "2026-04-01"),  # hub
+        ],
+    )
+    c.executemany(
+        "INSERT INTO topic_assignments "
+        "(doc_id, topic_id, assigned_by, similarity, "
+        " assigned_at, source_collection) VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            # (code__a, docs__b) pair — 3 distinct topics, mean sim 0.8.
+            ("a1", 1, "projection", 0.9, "2026-04-01", "code__a"),
+            ("a2", 2, "projection", 0.8, "2026-04-01", "code__a"),
+            ("a3", 3, "projection", 0.7, "2026-04-01", "code__a"),
+            # (code__a, code__c) pair — only via hubs (topics 4, 5).
+            ("a4", 4, "projection", 0.6, "2026-04-01", "code__a"),
+            ("a5", 5, "projection", 0.6, "2026-04-01", "code__a"),
+            # Hub topics also get chunks from other collections — makes
+            # them actual cross-collection hubs.
+            ("b1", 4, "projection", 0.7, "2026-04-01", "docs__b"),
+            ("c1", 4, "projection", 0.7, "2026-04-01", "docs__d"),
+            ("e1", 4, "projection", 0.7, "2026-04-01", "docs__e"),
+            ("b2", 5, "projection", 0.7, "2026-04-01", "docs__b"),
+            ("c2", 5, "projection", 0.7, "2026-04-01", "docs__d"),
+            ("e2", 5, "projection", 0.7, "2026-04-01", "docs__e"),
+            # NULL source_collection — must be ignored.
+            ("x1", 1, "hdbscan",    None, None,           None),
+        ],
+    )
+    c.commit()
+    db.close()
+
+
+# ── Core query ──────────────────────────────────────────────────────────────
+
+
+class TestComputeMergeCandidates:
+    def test_orders_by_score_desc(self, tmp_path: Path) -> None:
+        from nexus.merge_candidates import compute_merge_candidates
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            pairs = compute_merge_candidates(
+                db.taxonomy.conn,
+                min_shared=1,
+                min_similarity=0.0,
+            )
+        finally:
+            db.close()
+        # Best pair by (shared × mean_sim) must be first.
+        assert pairs[0].a == "code__a"
+        assert pairs[0].b == "docs__b"
+        assert pairs[0].shared_topics == 3
+        assert pairs[0].mean_sim == pytest.approx((0.9 + 0.8 + 0.7) / 3)
+
+    def test_excludes_null_source_collection(self, tmp_path: Path) -> None:
+        from nexus.merge_candidates import compute_merge_candidates
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            pairs = compute_merge_candidates(
+                db.taxonomy.conn, min_shared=1, min_similarity=0.0,
+            )
+        finally:
+            db.close()
+        # NULL-source row pointed at topic 1 (docs__b) — if included,
+        # it would add a NULL→docs__b row. Must not appear.
+        assert not any(p.a is None or p.a == "" for p in pairs)
+
+    def test_excludes_self_pairs(self, tmp_path: Path) -> None:
+        """source_collection == topics.collection is a same-collection
+        assignment, not a cross-collection candidate."""
+        from nexus.merge_candidates import compute_merge_candidates
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            pairs = compute_merge_candidates(
+                db.taxonomy.conn, min_shared=1, min_similarity=0.0,
+            )
+        finally:
+            db.close()
+        for p in pairs:
+            assert p.a != p.b
+
+    def test_min_shared_threshold_filters(self, tmp_path: Path) -> None:
+        from nexus.merge_candidates import compute_merge_candidates
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            pairs = compute_merge_candidates(
+                db.taxonomy.conn, min_shared=3, min_similarity=0.0,
+            )
+        finally:
+            db.close()
+        # Only (code__a, docs__b) hits 3 shared topics.
+        assert len(pairs) == 1
+        assert (pairs[0].a, pairs[0].b) == ("code__a", "docs__b")
+
+    def test_min_similarity_threshold_filters(self, tmp_path: Path) -> None:
+        from nexus.merge_candidates import compute_merge_candidates
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            pairs = compute_merge_candidates(
+                db.taxonomy.conn, min_shared=1, min_similarity=0.65,
+            )
+        finally:
+            db.close()
+        # (code__a, code__c) pair has mean_sim 0.6 → filtered out.
+        by_pair = {(p.a, p.b) for p in pairs}
+        assert ("code__a", "code__c") not in by_pair
+
+    def test_exclude_hubs_subtracts_top_n_hub_topics(
+        self, tmp_path: Path,
+    ) -> None:
+        """Hub-dominated pair drops below threshold when hubs are
+        excluded from the shared-topic count."""
+        from nexus.merge_candidates import compute_merge_candidates
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        db = T2Database(db_path)
+        try:
+            # Top-2 hubs is enough to drop both hub topics (ids 4, 5).
+            pairs = compute_merge_candidates(
+                db.taxonomy.conn,
+                min_shared=1,
+                min_similarity=0.0,
+                exclude_hubs=True,
+                hub_top_n=2,
+            )
+        finally:
+            db.close()
+        by_pair = {(p.a, p.b): p.shared_topics for p in pairs}
+        # (code__a, docs__b): unchanged — zero hub topics in the pair.
+        assert by_pair[("code__a", "docs__b")] == 3
+        # (code__a, code__c): dropped — its 2 shared topics are the hubs.
+        assert ("code__a", "code__c") not in by_pair
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+class TestMergeCandidatesCli:
+    def test_default_output(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.cli import main
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+
+        result = runner.invoke(
+            main,
+            ["collection", "merge-candidates", "--min-shared", "1"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "code__a" in result.output
+        assert "docs__b" in result.output
+
+    def test_json_output(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.cli import main
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+
+        result = runner.invoke(
+            main,
+            ["collection", "merge-candidates",
+             "--min-shared", "1", "--format", "json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert "candidates" in payload
+        assert len(payload["candidates"]) >= 1
+
+    def test_exclude_hubs_flag_wires_through(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.cli import main
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+
+        result = runner.invoke(
+            main,
+            ["collection", "merge-candidates",
+             "--min-shared", "1", "--exclude-hubs", "--hub-top-n", "2",
+             "--format", "json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        pairs = {(c["a"], c["b"]) for c in payload["candidates"]}
+        # Hub-only pair suppressed.
+        assert ("code__a", "code__c") not in pairs
+        # Legitimate pair survives.
+        assert ("code__a", "docs__b") in pairs
+
+    def test_create_link_is_opt_in_default_does_nothing(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """Default invocation must NOT write catalog edges. RDR §bridge-
+        link workflow explicitly defers auto-bridge. The ``--create-
+        link`` flag is opt-in and currently surfaces a 'not yet
+        implemented' advisory rather than writing silently."""
+        from nexus.cli import main
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+
+        result = runner.invoke(
+            main, ["collection", "merge-candidates", "--min-shared", "1"],
+        )
+        assert result.exit_code == 0, result.output
+        # No mention of link creation happened.
+        assert "creating" not in result.output.lower()
+        assert "wrote" not in result.output.lower()
+
+    def test_create_link_flag_emits_advisory(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from nexus.cli import main
+
+        db_path = tmp_path / "memory.db"
+        _seed_t2(db_path)
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+
+        result = runner.invoke(
+            main,
+            ["collection", "merge-candidates",
+             "--min-shared", "1", "--create-link"],
+        )
+        # Surface a deferred-workflow advisory (non-zero exit is fine —
+        # pins that the flag is recognised but takes no destructive
+        # action in this bead).
+        assert result.exit_code != 0
+        assert "deferred" in result.output.lower()


### PR DESCRIPTION
## Summary

RDR-087 Phase 4.3 — new \`nx collection merge-candidates\` subcommand ranks cross-collection merge candidates by \`shared_topics × mean_similarity\` over \`topic_assignments\`.

## CLI

\`\`\`
nx collection merge-candidates
  [--min-shared N=3]          # distinct shared topics threshold
  [--min-similarity S=0.5]    # mean similarity floor
  [--exclude-hubs]            # drop top-N cross-collection hubs
  [--hub-top-n N=10]          # hub depth
  [--limit N=50]
  [--format table|json]
  [--create-link]             # DEFERRED — raises advisory, no write
\`\`\`

## Query safety

- **Excludes NULL source_collection** (legacy pre-RDR-077 rows per Failure Modes)
- **Excludes self-pairs** (\`source == topics.collection\` is same-collection assignment, not cross-collection)
- **\`--exclude-hubs\`** subtracts top-N hubs (same ranking as probe 3b and \`collection health\`) to suppress false positives from generic hubs like "API rate limiting" / "schema evolution"

## Bridge-link deferral

RDR §bridge-link workflow explicitly defers auto-bridge. This bead surfaces candidates only; users run \`nx catalog link\` manually after reviewing. The \`--create-link\` flag is wired but raises a deferred-workflow advisory rather than writing silently — avoids accidental catalog noise during the calibration phase.

## Live smoke on dev repo

Real candidates surfaced with \`--min-shared 20 --min-similarity 0.6 --exclude-hubs\`:

| a | b | shared | mean_sim | score |
|---|---|---|---|---|
| \`code__nexus-571b8edd\` | \`code__arcaneum-2ad2825c\` | 88 | 0.745 | 65.52 |
| \`docs__nexus-571b8edd\` | \`rdr__nexus-571b8edd\` | 88 | 0.630 | 55.42 |
| \`knowledge__knowledge\` | \`rdr__nexus-571b8edd\` | 68 | 0.649 | 44.14 |

Top pair is the nexus+arcaneum codebases — consistent with these being related projects. Docs/RDR same-project pair also expected. Signal is legit.

## Test plan
- [x] \`uv run pytest tests/test_merge_candidates.py\` — 11 passed
  - Score ordering, NULL-source exclusion, self-pair exclusion
  - \`--min-shared\` / \`--min-similarity\` thresholds
  - \`--exclude-hubs\` drops hub-dominated pairs
  - CLI default/json/exclude-hubs paths
  - \`--create-link\` advisory (non-destructive)
- [x] Live smoke — real pairs surfaced
- [ ] CI green

## Follow-up
- Phase 4.4 code review + 4.5 test validation + Phase 4 epic close
- Phase 5 (MCP tool promotion) remains deferred per RDR