### PR TITLE
fix(subprocess): process-group cleanup for T1 chroma + MinerU (nexus-ze2a + nexus-dc57)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.6.3"
+      "version": "4.6.4"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.6.3"
+      "version": "4.6.4"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.6.4] - 2026-04-18
+
+### Fixed
+
+- **nexus-ze2a (P0) + nexus-dc57 (P1) — POSIX semaphore-leak root cause** — cross-corpus `_multiprocessing.SemLock()` was failing with `[Errno 28] No space left on device` whenever MinerU or orphaned T1 chroma children had accumulated. Both bugs shared a single root: we used `os.kill(pid, SIGTERM/SIGKILL)` on the long-running subprocess head, which did not propagate to its multiprocessing workers or their `resource_tracker`. Workers got orphaned and their POSIX named semaphores were never `sem_unlink()`-ed, eventually exhausting the kernel namespace (`kern.posix.sem.max = 10000`). **Fix**: (1) T1 chroma spawn in `session.py` now uses `start_new_session=True` so chroma plus its workers share one killable process group; (2) `stop_t1_server` uses `os.killpg(os.getpgid(pid), SIGTERM)` → `os.killpg(..., SIGKILL)` so the whole subtree receives the signal; (3) `nx mineru stop` uses the same `killpg` pattern so MinerU workers' `resource_tracker` runs before the group exits. No periodic-restart band-aid — the process-group contract itself was broken. New `nx doctor --check-resources` probes the POSIX semaphore namespace and exits 2 with actionable guidance on `[Errno 28]` pressure (pointing at both sources by name).
+
 ## [4.6.3] - 2026-04-17
 
 ### Fixed

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.6.4] - 2026-04-18
+
+Plugin version bump alongside conexus 4.6.4. See root CHANGELOG for
+the POSIX-semaphore leak root-cause fix (nexus-ze2a + nexus-dc57)
+and the new `nx doctor --check-resources` probe.
+
 ## [4.6.3] - 2026-04-17
 
 Plugin version bump alongside conexus 4.6.3. See root CHANGELOG for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.6.3"
+version = "4.6.4"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -187,6 +187,16 @@ def _run_trim_telemetry(days: int) -> None:
          "raises an unexpected exception. RDR-087 Phase 3.2.",
 )
 @click.option(
+    "--check-resources",
+    "check_resources",
+    is_flag=True,
+    default=False,
+    help="Probe POSIX semaphore headroom. Exits 2 with 'Errno 28' when "
+         "the namespace is exhausted (known sources: MinerU workers / "
+         "orphan chroma children leaking via multiprocessing). Beads "
+         "nexus-dc57 + nexus-ze2a.",
+)
+@click.option(
     "--json",
     "json_out",
     is_flag=True,
@@ -211,7 +221,7 @@ def _run_trim_telemetry(days: int) -> None:
 )
 def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                fix_paths: bool, dry_run: bool, check_schema: bool,
-               check_search: bool, json_out: bool,
+               check_search: bool, check_resources: bool, json_out: bool,
                trim_telemetry: bool, days: int) -> None:
     """Verify that all required services and credentials are available."""
     if check_schema:
@@ -221,6 +231,10 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
     if check_search:
         from nexus.doctor_search import run_check_search
         run_check_search(json_out=json_out)
+        return
+
+    if check_resources:
+        _run_check_resources()
         return
 
     if trim_telemetry:
@@ -361,3 +375,50 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if failed:
         raise click.exceptions.Exit(1)
+
+
+def _probe_semaphore_namespace() -> tuple[bool, str]:
+    """Probe POSIX named-semaphore availability.
+
+    Attempts to allocate and immediately unlink one throwaway named
+    semaphore. Returns ``(True, info_msg)`` when the kernel namespace
+    has headroom; ``(False, error_repr)`` when allocation fails —
+    typically ``[Errno 28] No such space left on device`` under
+    exhaustion (beads nexus-dc57 + nexus-ze2a).
+
+    Separated from the CLI handler so tests can monkeypatch it.
+    """
+    import os as _os
+    try:
+        from _multiprocessing import SemLock  # type: ignore[attr-defined]
+    except ImportError:
+        return True, "SemLock probe unavailable on this platform"
+    probe_name = f"/nx-doctor-probe-{_os.getpid()}"
+    try:
+        lock = SemLock(0, 0, 1, name=probe_name, unlink=True)
+        # SemLock ctor created and owns the semaphore; unlink happens
+        # via the ``unlink=True`` flag on close.
+        del lock
+        return True, "POSIX named-semaphore namespace has headroom"
+    except OSError as exc:
+        return False, f"{exc!r}"
+
+
+def _run_check_resources() -> None:
+    """Emit a resource-pressure report to stdout; exit 2 on failure."""
+    ok, msg = _probe_semaphore_namespace()
+    if ok:
+        click.echo(f"[\u2713] resources: {msg}")
+        return
+    click.echo(f"[\u2717] resources: SemLock probe FAILED — {msg}", err=True)
+    click.echo(
+        "Known sources of POSIX semaphore exhaustion on this project:\n"
+        "  - nexus-ze2a: MinerU workers leak semaphores.\n"
+        "    Workaround: `nx mineru stop` (kills the whole process group).\n"
+        "  - nexus-dc57: orphan chroma children from earlier nexus sessions.\n"
+        "    Workaround: kill orphan chromas (`ps aux | grep 'chroma run'`).\n"
+        "If the count does not recover, reboot — macOS does not unlink\n"
+        "leaked named semaphores until the next boot.",
+        err=True,
+    )
+    raise click.exceptions.Exit(2)

--- a/src/nexus/commands/mineru.py
+++ b/src/nexus/commands/mineru.py
@@ -180,20 +180,41 @@ def stop() -> None:
         pid_path.unlink(missing_ok=True)
         return
 
-    # Send SIGTERM for graceful shutdown
-    os.kill(pid, signal.SIGTERM)
+    # SIGTERM the entire process group owned by *pid*. MinerU's
+    # multiprocessing workers and their ``resource_tracker`` children
+    # must receive the signal too — otherwise the tracker never gets
+    # to ``sem_unlink`` and POSIX named semaphores leak into the
+    # global namespace (bead nexus-ze2a root cause). ``start_new_session
+    # =True`` at spawn (mineru.py start) guarantees they share one
+    # killable pgid.
+    try:
+        pgid = os.getpgid(pid)
+    except OSError:
+        pgid = pid  # fallback: treat head pid as its own group
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except OSError:
+        # Process group already gone — nothing to do.
+        pid_path.unlink(missing_ok=True)
+        click.echo(f"MinerU server stopped (PID {pid})")
+        return
 
     # Poll until process exits (os.waitpid only works on child processes;
-    # the server was started by a different nx invocation)
+    # the server was started by a different nx invocation).
     deadline = time.monotonic() + _STOP_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         if not _is_process_alive(pid):
             break
         time.sleep(0.2)
     else:
+        # Escalate to SIGKILL on the group — same reason (reach workers).
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except OSError:
+            pass  # already gone
         click.echo(
             f"Warning: MinerU server (PID {pid}) did not exit within "
-            f"{_STOP_TIMEOUT_SECONDS}s",
+            f"{_STOP_TIMEOUT_SECONDS}s; escalated SIGKILL to process group",
             err=True,
         )
 

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -245,6 +245,12 @@ def start_t1_server() -> tuple[str, int, int, str]:
     sock.close()
 
     tmpdir = tempfile.mkdtemp(prefix="nx_t1_")
+    # start_new_session=True isolates chroma + its multiprocessing workers
+    # into their own process group so `os.killpg(getpgid(pid), …)` at
+    # shutdown reaches the whole subtree. Without this, SIGTERM only hits
+    # the chroma head; workers get orphaned and their POSIX named
+    # semaphores are never ``sem_unlink()``-ed → Errno 28 namespace
+    # exhaustion (bead nexus-dc57 / nexus-ze2a root cause).
     proc = subprocess.Popen(
         [
             chroma, "run",
@@ -254,6 +260,7 @@ def start_t1_server() -> tuple[str, int, int, str]:
         ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        start_new_session=True,
     )
 
     # Poll until the server accepts TCP connections or the process exits.
@@ -278,24 +285,43 @@ def start_t1_server() -> tuple[str, int, int, str]:
 
 
 def stop_t1_server(server_pid: int) -> None:
-    """Send SIGTERM to *server_pid*; escalate to SIGKILL after 3 seconds."""
+    """Send SIGTERM → SIGKILL to the *entire process group* owned by
+    *server_pid*.
+
+    Uses ``os.killpg(os.getpgid(pid), …)`` rather than ``os.kill(pid, …)``
+    so chroma's multiprocessing workers and their ``resource_tracker``
+    children receive the signal too. The tracker unlinks POSIX named
+    semaphores during its own shutdown; without it, workers' semaphores
+    stay registered with the kernel until reboot and eventually exhaust
+    ``kern.posix.sem.max`` (beads nexus-dc57 + nexus-ze2a).
+
+    Graceful SIGTERM first; escalates to SIGKILL after 3 s.
+    """
     try:
-        os.kill(server_pid, signal.SIGTERM)
+        pgid = os.getpgid(server_pid)
     except OSError:
-        return  # intentional: process already gone before SIGTERM
-    # Wait up to 3 seconds for graceful exit
+        return  # intentional: process already gone before any signal
+
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except OSError:
+        return  # intentional: process group vanished between getpgid and signal
+
+    # Wait up to 3 seconds for graceful exit.
     deadline = time.time() + 3.0
     while time.time() < deadline:
         try:
-            os.kill(server_pid, 0)  # check if alive
+            os.kill(server_pid, 0)  # readiness probe — NOT a signal delivery
         except OSError:
-            return  # intentional: process exited after SIGTERM — success
+            return  # process exited after SIGTERM — success
         time.sleep(0.1)
-    # Escalate
+
+    # Escalate.
     try:
-        os.kill(server_pid, signal.SIGKILL)
+        os.killpg(pgid, signal.SIGKILL)
     except OSError:
-        return  # intentional: process exited between poll and SIGKILL
+        return  # intentional: process group exited between poll and SIGKILL
+
     # Reap the zombie so it does not linger in the process table.
     try:
         os.waitpid(server_pid, os.WNOHANG)

--- a/tests/test_mineru_cmd.py
+++ b/tests/test_mineru_cmd.py
@@ -130,15 +130,32 @@ class TestMineruStop:
                     raise OSError("No such process")
         return side_effect, signals
 
-    def test_stop_sends_sigterm_and_cleans_pid(self, runner, pid_file):
+    def test_stop_sends_sigterm_to_process_group(self, runner, pid_file):
+        """``nx mineru stop`` must SIGTERM the whole process group so
+        MinerU's multiprocessing workers' resource_tracker gets a
+        chance to ``sem_unlink`` POSIX named semaphores before exit.
+        Regression for bead nexus-ze2a.
+        """
         _write_pid(pid_file, pid=12345)
-        effect, signals = self._kill_tracking()
-        with patch("nexus.commands.mineru.os.kill", side_effect=effect) as mock_kill, \
+        killpg_calls: list[tuple[int, int]] = []
+
+        def _fake_killpg(pgid: int, sig: int) -> None:
+            killpg_calls.append((pgid, sig))
+
+        # Initial liveness probe True, then dead after SIGTERM delivery.
+        alive_states = [True, False, False, False]
+
+        def _alive(pid: int) -> bool:
+            return alive_states.pop(0) if alive_states else False
+
+        with patch("nexus.commands.mineru.os.killpg", side_effect=_fake_killpg), \
+             patch("nexus.commands.mineru.os.getpgid", lambda pid: pid), \
+             patch("nexus.commands.mineru._is_process_alive", side_effect=_alive), \
              patch("nexus.commands.mineru.time.sleep"):
             result = runner.invoke(main, ["mineru", "stop"])
         assert result.exit_code == 0 and not pid_file.exists()
-        mock_kill.assert_any_call(12345, signal.SIGTERM)
-        assert signal.SIGTERM in signals and signal.SIGKILL not in signals
+        assert (12345, signal.SIGTERM) in killpg_calls
+        assert (12345, signal.SIGKILL) not in killpg_calls
 
     def test_stop_no_pid_file(self, runner, pid_file):
         result = runner.invoke(main, ["mineru", "stop"])
@@ -146,7 +163,9 @@ class TestMineruStop:
 
     def test_stop_stale_pid(self, runner, pid_file):
         _write_pid(pid_file, pid=99999)
-        with patch("nexus.commands.mineru.os.kill", side_effect=OSError("No such process")):
+        with patch(
+            "nexus.commands.mineru._is_process_alive", return_value=False,
+        ):
             result = runner.invoke(main, ["mineru", "stop"])
         assert result.exit_code == 0 and not pid_file.exists()
 

--- a/tests/test_semaphore_leak_rootcause.py
+++ b/tests/test_semaphore_leak_rootcause.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Process-group cleanup regressions for ``nexus-ze2a`` + ``nexus-dc57``.
+
+Both bugs surface as ``[Errno 28] No space left on device`` on
+``_multiprocessing.SemLock()`` and share a single root cause:
+
+When a long-running Python subprocess (T1 ChromaDB / MinerU) dies
+uncleanly, its **worker children** get orphaned. Workers hold POSIX
+named semaphores allocated by ``multiprocessing``. Without a process-
+group kill that also reaches ``resource_tracker``, those semaphores
+are never ``sem_unlink()``-ed until reboot.
+
+The fix: spawn with ``start_new_session=True`` (own process group) +
+cleanup via ``os.killpg(pgid, …)`` so SIGTERM / SIGKILL reaches the
+whole subtree.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── session.start_t1_server: must isolate into a new process group ──────────
+
+
+def test_start_t1_server_uses_start_new_session(monkeypatch) -> None:
+    """Regression for nexus-dc57 — the T1 chroma spawn MUST use
+    ``start_new_session=True`` so its workers share a killable pgid."""
+    from nexus import session
+
+    captured: dict[str, object] = {}
+
+    class _FakeProc:
+        pid = 12345
+        returncode = None
+        def poll(self):
+            return None
+        def kill(self):
+            pass
+
+    def _fake_popen(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        # Short-circuit the poll loop by returning a proc that immediately
+        # appears ready at the socket layer via the next monkeypatch.
+        return _FakeProc()
+
+    def _fake_create_connection(*args, **kwargs):
+        class _FakeConn:
+            def close(self): pass
+        return _FakeConn()
+
+    monkeypatch.setattr(session, "_find_chroma", lambda: "/fake/chroma")
+    monkeypatch.setattr(session.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(session.socket, "create_connection", _fake_create_connection)
+
+    host, port, pid, tmpdir = session.start_t1_server()
+    assert pid == 12345
+    # The critical assertion: Popen must have isolated the child.
+    assert captured["kwargs"].get("start_new_session") is True
+
+
+# ── stop_t1_server: must kill the whole process group ───────────────────────
+
+
+def test_stop_t1_server_uses_killpg(monkeypatch) -> None:
+    """Regression for nexus-dc57 — SIGTERM/SIGKILL must reach the entire
+    subtree so chroma's workers' semaphores get unlinked before exit."""
+    from nexus import session
+
+    calls: list[tuple] = []
+
+    def _fake_killpg(pgid, sig):
+        calls.append(("killpg", pgid, sig))
+        # Fake the liveness check: after first SIGTERM call, pretend dead.
+        if sig == signal.SIGTERM:
+            return
+        if sig == 0:
+            raise ProcessLookupError("gone")
+
+    def _fake_kill(pid, sig):
+        # Permitted ONLY for readiness probes (sig==0), never SIGTERM/SIGKILL
+        # on the head PID — those must go via killpg.
+        if sig in (signal.SIGTERM, signal.SIGKILL):
+            raise AssertionError(
+                f"stop_t1_server used os.kill({pid}, {sig}) — "
+                f"must use os.killpg to reach worker subtree"
+            )
+
+    def _fake_getpgid(pid):
+        return pid
+
+    monkeypatch.setattr(session.os, "killpg", _fake_killpg)
+    monkeypatch.setattr(session.os, "kill", _fake_kill)
+    monkeypatch.setattr(session.os, "getpgid", _fake_getpgid)
+    # Fast-fail alive-check to let the cleanup short-circuit.
+    def _fake_is_alive(pid):
+        return False
+    monkeypatch.setattr(session, "_process_alive", _fake_is_alive, raising=False)
+
+    session.stop_t1_server(99999)
+    kpg = [c for c in calls if c[0] == "killpg"]
+    assert any(c[2] == signal.SIGTERM for c in kpg), (
+        f"expected at least one killpg(SIGTERM) call, got {calls!r}"
+    )
+
+
+# ── mineru.stop: same killpg discipline ─────────────────────────────────────
+
+
+def test_mineru_stop_uses_killpg(monkeypatch, tmp_path) -> None:
+    """Regression for nexus-ze2a — MinerU stop must reach worker subtree."""
+    from nexus.commands import mineru
+    from click.testing import CliRunner
+
+    calls: list[tuple] = []
+
+    def _fake_killpg(pgid, sig):
+        calls.append(("killpg", pgid, sig))
+
+    def _fake_kill(pid, sig):
+        if sig in (signal.SIGTERM, signal.SIGKILL):
+            raise AssertionError(
+                f"mineru.stop used os.kill({pid}, {sig}) on head — "
+                f"must use killpg to reach worker subtree"
+            )
+
+    pid_path = tmp_path / "mineru.pid.json"
+    import json as _json
+    from datetime import datetime, timezone
+    pid_path.write_text(_json.dumps({
+        "pid": 77777, "port": 12345,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }))
+
+    # Initial liveness probe must say "alive" so the stop logic enters
+    # the kill path; later probes return "dead" so the poll loop exits.
+    alive_states = [True, False, False, False]
+    def _alive(pid: int) -> bool:
+        return alive_states.pop(0) if alive_states else False
+
+    monkeypatch.setattr(mineru, "_pid_file_path", lambda: pid_path)
+    monkeypatch.setattr(mineru, "_is_process_alive", _alive)
+    monkeypatch.setattr(mineru.os, "killpg", _fake_killpg)
+    monkeypatch.setattr(mineru.os, "kill", _fake_kill)
+    monkeypatch.setattr(mineru.os, "getpgid", lambda pid: pid)
+
+    runner = CliRunner()
+    result = runner.invoke(mineru.mineru_group, ["stop"])
+    assert any(c[0] == "killpg" for c in calls), (
+        f"expected killpg call on stop, got {calls!r}"
+    )
+
+
+# ── End-to-end process-group spawn + kill + semaphore audit ─────────────────
+
+
+@pytest.mark.skipif(
+    sys.platform not in ("darwin", "linux"),
+    reason="POSIX-only: Windows has no sem_unlink.",
+)
+def test_process_group_spawn_and_killpg_contract() -> None:
+    """Concrete POSIX test: spawn a Python child that uses multiprocessing,
+    kill its process group, and confirm the child + its workers all exit.
+
+    Does NOT assert zero semaphore leak (that depends on Python internals
+    we cannot observe directly). Instead it pins the contract we rely on:
+    ``start_new_session=True`` → ``os.killpg(getpgid(pid), SIGKILL)``
+    terminates the whole subtree.
+    """
+    # Minimal child: fork a plain subprocess (no multiprocessing complexity)
+    # that prints its own pid and sleeps. That's all we need to validate
+    # the contract: killpg reaches a grandchild that's in the same group.
+    child_script = (
+        "import os, sys, time\n"
+        "p = os.fork()\n"
+        "if p == 0:\n"
+        "    sys.stdout.write(str(os.getpid()) + '\\n'); sys.stdout.flush()\n"
+        "    time.sleep(60)\n"
+        "else:\n"
+        "    sys.stdout.write('parent\\n'); sys.stdout.flush()\n"
+        "    time.sleep(60)\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", child_script],
+        start_new_session=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        # Loop until we read the child's pid line (fork output order is
+        # non-deterministic — parent's "parent\n" may race).
+        worker_pid = None
+        deadline = time.time() + 5.0
+        while time.time() < deadline and worker_pid is None:
+            line = proc.stdout.readline().strip()
+            if line.isdigit():
+                worker_pid = int(line)
+                break
+        assert worker_pid is not None, "never saw a child pid line"
+        # Both parent and worker should be alive.
+        os.kill(proc.pid, 0)
+        os.kill(worker_pid, 0)
+        # The fix under test: killpg reaches both.
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        time.sleep(0.3)
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        # Confirm both are gone.
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            try:
+                os.kill(worker_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail(f"worker pid={worker_pid} survived killpg")
+    finally:
+        try:
+            proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
+# ── nx doctor --check=resources: detect semaphore pressure ──────────────────
+
+
+def test_doctor_check_resources_reports_available(
+    tmp_path, monkeypatch,
+) -> None:
+    """``nx doctor --check=resources`` probes POSIX semaphores and reports
+    the current state. Healthy machine → exit 0 + 'ok'/'available' in output."""
+    from click.testing import CliRunner
+    from nexus.cli import main
+
+    result = CliRunner().invoke(main, ["doctor", "--check-resources"])
+    # On a healthy CI machine, probe succeeds.
+    assert result.exit_code == 0, result.output
+    lowered = result.output.lower()
+    assert "semaphore" in lowered or "ok" in lowered
+
+
+def test_doctor_check_resources_surfaces_errno28(monkeypatch) -> None:
+    """When the SemLock probe fails with Errno 28, the doctor exits 2
+    and prints an actionable message pointing at the known sources."""
+    from click.testing import CliRunner
+    from nexus.cli import main
+    from nexus.commands import doctor as doctor_cmd
+
+    def _fake_probe() -> tuple[bool, str]:
+        return False, "[Errno 28] No space left on device"
+
+    monkeypatch.setattr(
+        doctor_cmd, "_probe_semaphore_namespace", _fake_probe, raising=False,
+    )
+    result = CliRunner().invoke(main, ["doctor", "--check-resources"])
+    assert result.exit_code == 2, result.output
+    out = result.output.lower()
+    assert "errno 28" in out or "semaphore" in out

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.6.3"
+version = "4.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Combines **nexus-ze2a (P0)** + **nexus-dc57 (P1)** — two bugs, one root cause.

## Root cause

Both surfaced as \`[Errno 28] No space left on device\` from \`_multiprocessing.SemLock()\`. Python multiprocessing allocates POSIX named semaphores per worker and relies on its \`resource_tracker\` process to \`sem_unlink()\` them on shutdown. Our cleanup code used \`os.kill(pid, SIGTERM/SIGKILL)\` — which reaches **only the head process**. Workers plus their resource_tracker got orphaned, their semaphores were never unlinked, and the kernel namespace (\`kern.posix.sem.max = 10000\`) eventually filled. Every Python multiprocessing workload on the machine then failed.

Confirmed via Context7 / upstream CPython docs:
> "Leaked semaphores and shared memory segments are NOT automatically unlinked until next system reboot."

The orphan-chroma leak (dc57, 333 accumulated) and the MinerU leak (ze2a, P0) are **the same bug** manifesting through different spawn sites.

## Fix (not a band-aid)

| Change | File | Why |
|---|---|---|
| Add \`start_new_session=True\` to T1 chroma Popen | \`session.py:248\` | Put chroma + its workers in their own killable process group |
| \`stop_t1_server\` uses \`os.killpg(os.getpgid(pid), …)\` | \`session.py:280\` | SIGTERM / SIGKILL reaches workers + \`resource_tracker\`, so \`sem_unlink\` runs before exit |
| \`nx mineru stop\` uses \`killpg\` | \`commands/mineru.py:183\` | Same asymmetry — start already isolated the session; stop didn't use it |
| New \`nx doctor --check-resources\` | \`commands/doctor.py\` | Probes semaphore headroom; exits 2 with Errno-28 guidance pointing at both sources |

No periodic-restart band-aid. User was explicit: **find the root and fix this, don't paper over with periodic restart**.

## Tests

- **6 new** in \`tests/test_semaphore_leak_rootcause.py\` — spawn contract, kill-style contract (T1 + MinerU), E2E fork+killpg POSIX contract, doctor probe on ok + Errno-28 paths.
- **\`test_mineru_cmd.py::TestMineruStop\`** refreshed — new \`test_stop_sends_sigterm_to_process_group\` + stale-pid path updated.

## Test plan
- [x] \`uv run pytest\` full suite — **4434 passed, 27 skipped, 0 failed**
- [x] Live smoke: \`uv run nx doctor --check-resources\` → exit 0, "POSIX named-semaphore namespace has headroom"
- [ ] CI green

## Version

4.6.3 → **4.6.4** across pyproject / marketplace / nx plugin / sn plugin. CHANGELOG + nx/CHANGELOG backfilled.

## Follow-up

- Upstream: MinerU still leaks at the workers-in-MinerU level if *its* head dies uncleanly. Our \`killpg\` gives resource_tracker a chance; a full upstream fix (MinerU auditing its own multiprocessing hygiene) is out of scope for this bead but worth filing at opendatalab/MinerU.
- Local installations still on <4.6.4 should upgrade after release lands: \`uv tool upgrade conexus\`.