### PR TITLE
feat(collection): nx collection rename via ChromaDB modify(name=) (nexus-1ccq)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -954,6 +954,50 @@ class Catalog:
         finally:
             self._release_lock(dir_fd)
 
+    def rename_collection(self, old: str, new: str) -> int:
+        """Re-point every document from ``physical_collection=old`` → ``new``.
+
+        nexus-1ccq: `nx collection rename` cascade. JSONL is the source
+        of truth, so for every matching row we append a new record with
+        the updated ``physical_collection`` and also update the SQLite
+        cache (one UPDATE, no per-row upsert). Rebuild-from-JSONL sees
+        the later record and wins — append-only semantics preserved.
+        Returns count renamed.
+        """
+        dir_fd = self._acquire_lock()
+        try:
+            rows = self._db.execute(
+                "SELECT tumbler, title, author, year, content_type, file_path, "
+                "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata "
+                "FROM documents WHERE physical_collection = ?",
+                (old,),
+            ).fetchall()
+            for row in rows:
+                rec = {
+                    "tumbler": row[0],
+                    "title": row[1],
+                    "author": row[2],
+                    "year": row[3],
+                    "content_type": row[4],
+                    "file_path": row[5],
+                    "corpus": row[6],
+                    "physical_collection": new,
+                    "chunk_count": row[8],
+                    "head_hash": row[9] or "",
+                    "indexed_at": row[10] or "",
+                    "meta": json.loads(row[11]) if row[11] else {},
+                }
+                self._append_jsonl(self._documents_path, rec)
+            self._db.execute(
+                "UPDATE documents SET physical_collection = ? "
+                "WHERE physical_collection = ?",
+                (new, old),
+            )
+            self._db.commit()
+            return len(rows)
+        finally:
+            self._release_lock(dir_fd)
+
     def delete_document(self, tumbler: Tumbler) -> bool:
         """Soft-delete a document: tombstone in JSONL, DELETE from SQLite.
 

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -123,6 +123,95 @@ def delete_cmd(name: str, yes: bool) -> None:
         click.echo(f"Deleted: {name}")
 
 
+@collection.command("rename")
+@click.argument("old")
+@click.argument("new")
+@click.option(
+    "--force-prefix-change",
+    is_flag=True,
+    help=(
+        "Allow a cross-prefix rename (e.g. code__foo → docs__foo). "
+        "Embedding-model spaces differ across prefixes, so the renamed "
+        "collection is query-incompatible with its old clients. Use only "
+        "when you've deleted every downstream reader of the old name."
+    ),
+)
+def rename_cmd(old: str, new: str, force_prefix_change: bool) -> None:
+    """Rename a collection in-place via ChromaDB's native modify(name=).
+
+    O(1) metadata update — no embedding re-upload, no Voyage cost,
+    no ChromaDB egress. Cascades the new name through T2 taxonomy,
+    chash_index, and catalog (JSONL + SQLite).
+
+    Cross-prefix renames (e.g. ``code__`` ↔ ``docs__``) change the
+    embedding-model space and are rejected unless ``--force-prefix-change``
+    is set; otherwise search hits would be garbage.
+    """
+    old_prefix = old.split("__", 1)[0] if "__" in old else ""
+    new_prefix = new.split("__", 1)[0] if "__" in new else ""
+    if old_prefix != new_prefix and not force_prefix_change:
+        raise click.ClickException(
+            f"prefix mismatch: {old_prefix!r} → {new_prefix!r} would change "
+            f"the embedding-model space. Pass --force-prefix-change if this "
+            f"is intentional (rare — usually means the caller is resurrecting "
+            f"an orphaned collection with the wrong prefix)."
+        )
+
+    db = _t3()
+    if not db.collection_exists(old):
+        raise click.ClickException(f"collection not found: {old!r}")
+    if db.collection_exists(new):
+        raise click.ClickException(f"collection already exists: {new!r}")
+
+    db.rename_collection(old, new)
+
+    # Cascade T2 + catalog. Fail-open: log and continue — T3 is already
+    # renamed, and rolling back a rename is nontrivial (would need a
+    # second modify(name=old)).
+    tax_counts: dict[str, int] | None = None
+    chash_updated = 0
+    cat_updated = 0
+    try:
+        from nexus.commands._helpers import default_db_path
+        from nexus.db.t2 import T2Database
+
+        with T2Database(default_db_path()) as t2db:
+            tax_counts = t2db.taxonomy.rename_collection(old, new)
+            chash_updated = t2db.chash_index.rename_collection(old=old, new=new)
+    except Exception as exc:
+        click.echo(
+            f"warn: T3 rename succeeded but T2 cascade failed: {exc}",
+            err=True,
+        )
+
+    try:
+        from nexus.catalog.catalog import Catalog
+        from nexus.config import catalog_path
+        cat_path = catalog_path()
+        cat_updated = Catalog(cat_path, cat_path / ".catalog.db").rename_collection(old, new)
+    except Exception as exc:
+        click.echo(
+            f"warn: T3 rename succeeded but catalog cascade failed: {exc}",
+            err=True,
+        )
+
+    parts: list[str] = []
+    if tax_counts and any(tax_counts.values()):
+        parts.append(
+            f"{tax_counts['topics']} topics, "
+            f"{tax_counts['assignments']} assignments, "
+            f"{tax_counts['meta']} meta"
+        )
+    if chash_updated:
+        parts.append(f"{chash_updated} chash rows")
+    if cat_updated:
+        parts.append(f"{cat_updated} catalog docs")
+    if parts:
+        click.echo(f"Renamed: {old} → {new} ({'; '.join(parts)})")
+    else:
+        click.echo(f"Renamed: {old} → {new}")
+
+
 @collection.command("reindex")
 @click.argument("name")
 @click.option("--force", is_flag=True, help="Force reindex even if sourceless entries exist")

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -2276,6 +2276,46 @@ class CatalogTaxonomy:
                 raise
         return out
 
+    def rename_collection(self, old: str, new: str) -> dict[str, int]:
+        """Re-point every taxonomy row from ``old`` → ``new``.
+
+        nexus-1ccq: `nx collection rename` cascade. Updates three
+        tables in one transaction:
+
+          * ``topics.collection`` — where the cluster lives
+          * ``topic_assignments.source_collection`` — projection origin
+          * ``taxonomy_meta.collection`` — discovery bookkeeping
+
+        ``topic_links`` is keyed by topic_id (FK), not by collection
+        name, so links survive unchanged. Returns count dict mirroring
+        ``purge_collection`` so the CLI can surface the row counts.
+        Transactional — partial failure rolls back.
+        """
+        out = {"topics": 0, "assignments": 0, "meta": 0}
+        with self._lock:
+            try:
+                cur = self.conn.execute(
+                    "UPDATE topics SET collection = ? WHERE collection = ?",
+                    (new, old),
+                )
+                out["topics"] = cur.rowcount or 0
+                cur = self.conn.execute(
+                    "UPDATE topic_assignments SET source_collection = ? "
+                    "WHERE source_collection = ?",
+                    (new, old),
+                )
+                out["assignments"] = cur.rowcount or 0
+                cur = self.conn.execute(
+                    "UPDATE taxonomy_meta SET collection = ? WHERE collection = ?",
+                    (new, old),
+                )
+                out["meta"] = cur.rowcount or 0
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+        return out
+
     def purge_assignments_for_doc(self, project: str, title: str) -> int:
         """Remove topic_assignments for a deleted memory entry, empty topics.
 

--- a/src/nexus/db/t2/chash_index.py
+++ b/src/nexus/db/t2/chash_index.py
@@ -154,6 +154,37 @@ class ChashIndex:
             self.conn.commit()
             return cur.rowcount
 
+    def rename_collection(self, *, old: str, new: str) -> int:
+        """Re-point every row from ``old`` → ``new``. Returns row count updated.
+
+        nexus-1ccq: `nx collection rename` cascade. Safe because
+        ``(chash, physical_collection)`` is the PK: when a chash existed
+        in both ``old`` and ``new`` simultaneously (should be rare,
+        but possible from interleaved indexes), the UPDATE would
+        collide on the new PK. We defend by deleting any
+        ``(chash, new)`` row that already exists before the UPDATE —
+        rename is an atomic re-home so preserving the ``new``-side row
+        would drop our updated ``doc_id`` silently.
+        """
+        with self._lock:
+            # Drop any pre-existing new-collection rows that would collide
+            # with the rename. This is conservative — most real renames
+            # have an empty destination — but guarantees the UPDATE below
+            # can never raise UNIQUE.
+            self.conn.execute(
+                "DELETE FROM chash_index "
+                "WHERE physical_collection = ? "
+                "  AND chash IN (SELECT chash FROM chash_index WHERE physical_collection = ?)",
+                (new, old),
+            )
+            cur = self.conn.execute(
+                "UPDATE chash_index SET physical_collection = ? "
+                "WHERE physical_collection = ?",
+                (new, old),
+            )
+            self.conn.commit()
+            return cur.rowcount
+
     def delete_stale(self, *, chash: str, collection: str) -> int:
         """Drop the single row identified by the compound PK ``(chash, collection)``.
 

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -838,6 +838,28 @@ class T3Database:
         """Delete a T3 collection entirely."""
         self._client_for(name).delete_collection(name)
 
+    def rename_collection(self, old: str, new: str) -> None:
+        """Rename a T3 collection via ``collection.modify(name=new)``.
+
+        ChromaDB exposes ``modify(name=...)`` as an O(1) metadata-only
+        rename — no embedding re-upload, no data movement. nexus-1ccq
+        exposes this primitive as ``nx collection rename``. Caller
+        guarantees ``new`` does not collide (we raise here if it does).
+        """
+        from nexus.corpus import validate_collection_name
+        validate_collection_name(new)
+        client = self._client_for(old)
+        if self.collection_exists(new):
+            raise ValueError(
+                f"cannot rename to {new!r}: a collection with that name already exists",
+            )
+        col = client.get_collection(old)
+        col.modify(name=new)
+        # Bust the embedding-function cache under the old key so the next
+        # caller fetching ``new`` does not reuse an unrelated EF.
+        with self._ef_lock:
+            self._ef_cache.pop(old, None)
+
     def ids_for_source(self, collection_name: str, source_path: str) -> list[str]:
         """Return all chunk IDs for a given source path. Does not fetch content.
 

--- a/tests/test_collection_rename.py
+++ b/tests/test_collection_rename.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-1ccq — `nx collection rename` + domain-store cascade coverage.
+
+ChromaDB Cloud's ``collection.modify(name=...)`` is an O(1) metadata-only
+rename. The CLI wraps it and cascades the new name through the three T2
+surfaces that store a collection string:
+
+  * ``chash_index.physical_collection``
+  * ``topics.collection`` / ``topic_assignments.source_collection`` /
+    ``taxonomy_meta.collection``
+  * Catalog documents' ``physical_collection`` (JSONL + SQLite cache).
+
+The cascade is fail-open after the T3 rename lands — T2/catalog errors
+log but do not abort, mirroring the delete-cascade contract.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def env_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHROMA_API_KEY", "test")
+    monkeypatch.setenv("VOYAGE_API_KEY", "test")
+    monkeypatch.setenv("CHROMA_TENANT", "test")
+    monkeypatch.setenv("CHROMA_DATABASE", "test")
+
+
+# ── ChashIndex.rename_collection ────────────────────────────────────────────
+
+
+class TestChashIndexRename:
+    def test_updates_matching_rows(self, tmp_path: Path) -> None:
+        from nexus.db.t2.chash_index import ChashIndex
+
+        idx = ChashIndex(tmp_path / "chash.db")
+        idx.upsert(chash="aa", collection="code__old", doc_id="d1")
+        idx.upsert(chash="bb", collection="code__old", doc_id="d2")
+        idx.upsert(chash="cc", collection="code__stays", doc_id="d3")
+
+        count = idx.rename_collection(old="code__old", new="code__new")
+        assert count == 2
+
+        old_rows = idx.conn.execute(
+            "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+            ("code__old",),
+        ).fetchone()[0]
+        new_rows = idx.conn.execute(
+            "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+            ("code__new",),
+        ).fetchone()[0]
+        stays_rows = idx.conn.execute(
+            "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+            ("code__stays",),
+        ).fetchone()[0]
+        assert (old_rows, new_rows, stays_rows) == (0, 2, 1)
+
+    def test_pk_collision_new_side_wins(self, tmp_path: Path) -> None:
+        """When `(chash, new)` already exists, the rename's updated doc_id
+        must win — pre-existing new-side row is cleared first."""
+        from nexus.db.t2.chash_index import ChashIndex
+
+        idx = ChashIndex(tmp_path / "chash.db")
+        idx.upsert(chash="aa", collection="code__old", doc_id="from_old")
+        idx.upsert(chash="aa", collection="code__new", doc_id="stale_new")
+
+        count = idx.rename_collection(old="code__old", new="code__new")
+        assert count == 1
+
+        doc_id = idx.conn.execute(
+            "SELECT doc_id FROM chash_index WHERE chash = ? AND physical_collection = ?",
+            ("aa", "code__new"),
+        ).fetchone()[0]
+        assert doc_id == "from_old"
+
+    def test_no_rows_returns_zero(self, tmp_path: Path) -> None:
+        from nexus.db.t2.chash_index import ChashIndex
+
+        idx = ChashIndex(tmp_path / "chash.db")
+        assert idx.rename_collection(old="docs__ghost", new="docs__phantom") == 0
+
+
+# ── CatalogTaxonomy.rename_collection ───────────────────────────────────────
+
+
+class TestTaxonomyRename:
+    def _seed(self, tmp_path: Path):
+        from nexus.db.t2 import T2Database
+
+        db = T2Database(tmp_path / "memory.db")
+        tax = db.taxonomy
+        t_old = tax.conn.execute(
+            "INSERT INTO topics (label, collection, centroid_hash, doc_count, terms, created_at) "
+            "VALUES (?, ?, ?, ?, ?, '2026-04-18T00:00:00Z')",
+            ("T", "docs__old", "h1", 1, "[]"),
+        ).lastrowid
+        t_stays = tax.conn.execute(
+            "INSERT INTO topics (label, collection, centroid_hash, doc_count, terms, created_at) "
+            "VALUES (?, ?, ?, ?, ?, '2026-04-18T00:00:00Z')",
+            ("K", "docs__stays", "h2", 1, "[]"),
+        ).lastrowid
+        tax.conn.execute(
+            "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by, source_collection) "
+            "VALUES (?, ?, ?, ?)",
+            ("d1", t_old, "hdbscan", "docs__old"),
+        )
+        tax.conn.execute(
+            "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by, source_collection) "
+            "VALUES (?, ?, ?, ?)",
+            ("d2", t_stays, "projection", "docs__old"),
+        )
+        tax.conn.execute(
+            "INSERT INTO topic_links (from_topic_id, to_topic_id, link_count, link_types) "
+            "VALUES (?, ?, ?, ?)",
+            (t_old, t_stays, 1, "[]"),
+        )
+        tax.conn.execute(
+            "INSERT INTO taxonomy_meta (collection, last_discover_at) VALUES (?, ?)",
+            ("docs__old", "2026-04-18T00:00:00Z"),
+        )
+        tax.conn.commit()
+        return db, tax, t_old
+
+    def test_updates_topics_assignments_and_meta(self, tmp_path: Path) -> None:
+        db, tax, _ = self._seed(tmp_path)
+        try:
+            counts = tax.rename_collection("docs__old", "docs__new")
+            assert counts == {"topics": 1, "assignments": 2, "meta": 1}
+
+            assert tax.conn.execute(
+                "SELECT COUNT(*) FROM topics WHERE collection = ?",
+                ("docs__new",),
+            ).fetchone()[0] == 1
+            assert tax.conn.execute(
+                "SELECT COUNT(*) FROM topic_assignments WHERE source_collection = ?",
+                ("docs__new",),
+            ).fetchone()[0] == 2
+            # Survivor untouched.
+            assert tax.conn.execute(
+                "SELECT COUNT(*) FROM topics WHERE collection = ?",
+                ("docs__stays",),
+            ).fetchone()[0] == 1
+        finally:
+            db.close()
+
+    def test_topic_links_survive_rename(self, tmp_path: Path) -> None:
+        """topic_links use topic_id FK, not collection name — rename is
+        a no-op for links and must not drop or mutate them."""
+        db, tax, _ = self._seed(tmp_path)
+        try:
+            before = tax.conn.execute("SELECT COUNT(*) FROM topic_links").fetchone()[0]
+            tax.rename_collection("docs__old", "docs__new")
+            after = tax.conn.execute("SELECT COUNT(*) FROM topic_links").fetchone()[0]
+            assert before == after == 1
+        finally:
+            db.close()
+
+
+# ── Catalog.rename_collection ───────────────────────────────────────────────
+
+
+class TestCatalogRename:
+    def _seed(self, tmp_path: Path):
+        from nexus.catalog.catalog import Catalog
+
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+        owner = cat.register_owner("knowledge-corpus", "corpus")
+        tumbler_a = cat.register(
+            owner, title="doc-a", content_type="paper", file_path="a.pdf",
+            physical_collection="knowledge__old", chunk_count=3,
+        )
+        tumbler_b = cat.register(
+            owner, title="doc-b", content_type="paper", file_path="b.pdf",
+            physical_collection="knowledge__stays", chunk_count=2,
+        )
+        return cat, cat_dir, tumbler_a, tumbler_b
+
+    def test_updates_matching_docs(self, tmp_path: Path) -> None:
+        cat, cat_dir, tumbler_a, tumbler_b = self._seed(tmp_path)
+        count = cat.rename_collection("knowledge__old", "knowledge__new")
+        assert count == 1
+
+        # SQLite cache reflects the rename.
+        rows = cat._db.execute(
+            "SELECT physical_collection FROM documents ORDER BY tumbler",
+        ).fetchall()
+        assert [r[0] for r in rows] == ["knowledge__new", "knowledge__stays"]
+
+    def test_jsonl_appended_so_rebuild_preserves_rename(self, tmp_path: Path) -> None:
+        cat, cat_dir, tumbler_a, tumbler_b = self._seed(tmp_path)
+        cat.rename_collection("knowledge__old", "knowledge__new")
+
+        # Last record for tumbler 1.1 in JSONL must have the new collection.
+        records = [
+            json.loads(line)
+            for line in (cat_dir / "documents.jsonl").read_text().splitlines()
+            if line.strip()
+        ]
+        by_tumbler: dict[str, dict] = {}
+        for r in records:
+            by_tumbler[r["tumbler"]] = r
+        assert by_tumbler[str(tumbler_a)]["physical_collection"] == "knowledge__new"
+        assert by_tumbler[str(tumbler_b)]["physical_collection"] == "knowledge__stays"
+
+    def test_no_matches_returns_zero(self, tmp_path: Path) -> None:
+        cat, *_ = self._seed(tmp_path)
+        assert cat.rename_collection("knowledge__ghost", "knowledge__phantom") == 0
+
+
+# ── CLI `nx collection rename` ──────────────────────────────────────────────
+
+
+class TestRenameCLI:
+    def _fake_t3(self, *, old_exists: bool = True, new_exists: bool = False) -> MagicMock:
+        fake = MagicMock()
+        fake.collection_exists = MagicMock(
+            side_effect=lambda name: (
+                old_exists if name == "code__old" else
+                new_exists if name == "code__new" else
+                False
+            ),
+        )
+        fake.rename_collection = MagicMock()
+        return fake
+
+    def test_rename_happy_path(self, tmp_path: Path, env_creds) -> None:
+        from nexus.commands.collection import rename_cmd
+
+        db_path = tmp_path / "memory.db"
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        from nexus.db.t2 import T2Database
+        with T2Database(db_path) as db:
+            db.chash_index.upsert(
+                chash="aa", collection="code__old", doc_id="d1",
+            )
+
+        fake = self._fake_t3(old_exists=True, new_exists=False)
+        runner = CliRunner()
+        with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
+             patch("nexus.commands._helpers.default_db_path", return_value=db_path), \
+             patch("nexus.config.catalog_path", return_value=cat_dir):
+            result = runner.invoke(rename_cmd, ["code__old", "code__new"])
+
+        assert result.exit_code == 0, result.output
+        fake.rename_collection.assert_called_once_with("code__old", "code__new")
+
+        # Cascade actually happened.
+        with T2Database(db_path) as verify_db:
+            new_rows = verify_db.chash_index.conn.execute(
+                "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+                ("code__new",),
+            ).fetchone()[0]
+            old_rows = verify_db.chash_index.conn.execute(
+                "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+                ("code__old",),
+            ).fetchone()[0]
+        assert new_rows == 1 and old_rows == 0
+
+    def test_rename_rejects_unknown_old(self, tmp_path: Path, env_creds) -> None:
+        from nexus.commands.collection import rename_cmd
+
+        fake = self._fake_t3(old_exists=False, new_exists=False)
+        runner = CliRunner()
+        with patch("nexus.commands.collection._t3", return_value=fake):
+            result = runner.invoke(rename_cmd, ["code__old", "code__new"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+        fake.rename_collection.assert_not_called()
+
+    def test_rename_rejects_collision(self, tmp_path: Path, env_creds) -> None:
+        from nexus.commands.collection import rename_cmd
+
+        fake = self._fake_t3(old_exists=True, new_exists=True)
+        runner = CliRunner()
+        with patch("nexus.commands.collection._t3", return_value=fake):
+            result = runner.invoke(rename_cmd, ["code__old", "code__new"])
+        assert result.exit_code != 0
+        assert "already exists" in result.output.lower()
+        fake.rename_collection.assert_not_called()
+
+    def test_rename_rejects_prefix_mismatch(self, env_creds) -> None:
+        from nexus.commands.collection import rename_cmd
+
+        runner = CliRunner()
+        # No _t3 patch — the prefix gate runs before we touch T3.
+        result = runner.invoke(rename_cmd, ["code__foo", "docs__foo"])
+        assert result.exit_code != 0
+        assert "prefix mismatch" in result.output.lower()
+
+    def test_force_prefix_change_bypasses_gate(self, tmp_path: Path, env_creds) -> None:
+        from nexus.commands.collection import rename_cmd
+
+        db_path = tmp_path / "memory.db"
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        from nexus.db.t2 import T2Database
+        with T2Database(db_path):
+            pass
+
+        fake = MagicMock()
+        fake.collection_exists = MagicMock(
+            side_effect=lambda n: n == "code__foo",
+        )
+        fake.rename_collection = MagicMock()
+
+        runner = CliRunner()
+        with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.commands._helpers.default_db_path", return_value=db_path), \
+             patch("nexus.config.catalog_path", return_value=cat_dir):
+            result = runner.invoke(
+                rename_cmd,
+                ["code__foo", "docs__foo", "--force-prefix-change"],
+            )
+        assert result.exit_code == 0, result.output
+        fake.rename_collection.assert_called_once_with("code__foo", "docs__foo")


### PR DESCRIPTION
## Summary

- Adds \`nx collection rename <old> <new>\` — wraps ChromaDB's native O(1) \`collection.modify(name=)\` primitive (no embedding re-upload, no Voyage cost, no ChromaDB egress).
- Cascades the new name through T2 \`chash_index\`, T2 taxonomy (topics / assignments / meta), and Catalog (JSONL append + SQLite UPDATE) so downstream queries, hub detection, and citation lookups keep working after the rename.
- Guards: unknown source → error; destination collision → error; cross-prefix rename (e.g. \`code__\` ↔ \`docs__\`) → error unless \`--force-prefix-change\` (embedding-model spaces differ).
- \`copy\` (the convenience export/import wrapper) is deferred — scope-creep for a P2 and the export/import fallback still works.

Closes nexus-1ccq.

## Test plan

- [x] \`uv run pytest tests/test_collection_rename.py\` — 13 new tests (ChashIndex rename / collision, taxonomy cascade / link-survival, Catalog rename + JSONL rebuild preservation, CLI happy path / not-found / collision / prefix mismatch / force bypass)
- [x] \`uv run pytest tests/test_collection_cmd.py tests/test_nexus_lub_collection_delete_cascade.py tests/test_pipeline_buffer.py tests/test_chash_index_store.py tests/test_catalog.py\` — 167 passing, no neighbor regressions