### PR TITLE
feat(catalog): source_mtime column + index-time capture (nexus-8luh)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -227,6 +227,8 @@ class CatalogEntry:
     head_hash: str
     indexed_at: str
     meta: dict = field(default_factory=dict)
+    # nexus-8luh: POSIX mtime at index time; 0.0 → not captured.
+    source_mtime: float = 0.0
 
     def to_dict(self) -> dict:
         return {
@@ -242,6 +244,7 @@ class CatalogEntry:
             "head_hash": self.head_hash,
             "indexed_at": self.indexed_at,
             "meta": self.meta,
+            "source_mtime": self.source_mtime,
         }
 
 
@@ -545,6 +548,7 @@ class Catalog:
         author: str = "",
         year: int = 0,
         meta: dict | None = None,
+        source_mtime: float = 0.0,
     ) -> Tumbler:
         dir_fd = self._acquire_lock()
         try:
@@ -611,17 +615,19 @@ class Catalog:
                 head_hash=head_hash,
                 indexed_at=now,
                 meta=meta or {},
+                source_mtime=source_mtime,
             )
             self._append_jsonl(self._documents_path, rec.__dict__)
             self._db.execute(
                 "INSERT INTO documents "
                 "(tumbler, title, author, year, content_type, file_path, "
-                "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+                "metadata, source_mtime) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     str(tumbler), title, author, year, content_type, file_path,
                     corpus, physical_collection, chunk_count, head_hash, now,
-                    json.dumps(meta or {}),
+                    json.dumps(meta or {}), source_mtime,
                 ),
             )
             self._db.commit()
@@ -632,7 +638,7 @@ class Catalog:
     def resolve(self, tumbler: Tumbler) -> CatalogEntry | None:
         row = self._db.execute(
             "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime "
             "FROM documents WHERE tumbler = ?",
             (str(tumbler),),
         ).fetchone()
@@ -651,6 +657,7 @@ class Catalog:
             head_hash=row[9],
             indexed_at=row[10],
             meta=json.loads(row[11]) if row[11] else {},
+            source_mtime=row[12] or 0.0,
         )
 
     def resolve_path(self, tumbler: Tumbler) -> Path | None:
@@ -928,6 +935,7 @@ class Catalog:
                 "head_hash": entry.head_hash,
                 "indexed_at": entry.indexed_at,
                 "meta": entry.meta,
+                "source_mtime": entry.source_mtime,
             }
             # Merge meta dict rather than replace
             if "meta" in fields and isinstance(fields["meta"], dict):
@@ -940,14 +948,16 @@ class Catalog:
             self._db.execute(
                 "INSERT OR REPLACE INTO documents "
                 "(tumbler, title, author, year, content_type, file_path, "
-                "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+                "metadata, source_mtime) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     rec_dict["tumbler"], rec_dict["title"], rec_dict["author"],
                     rec_dict["year"], rec_dict["content_type"], rec_dict["file_path"],
                     rec_dict["corpus"], rec_dict["physical_collection"],
                     rec_dict["chunk_count"], rec_dict["head_hash"],
                     rec_dict["indexed_at"], json.dumps(rec_dict["meta"]),
+                    rec_dict.get("source_mtime", 0.0),
                 ),
             )
             self._db.commit()
@@ -978,6 +988,7 @@ class Catalog:
                 "head_hash": entry.head_hash,
                 "indexed_at": entry.indexed_at,
                 "meta": entry.meta,
+                "source_mtime": entry.source_mtime,
                 "_deleted": True,
             }
             self._append_jsonl(self._documents_path, tombstone)
@@ -1003,6 +1014,7 @@ class Catalog:
                 head_hash=r["head_hash"] or "",
                 indexed_at=r["indexed_at"] or "",
                 meta=json.loads(r["metadata"]) if r.get("metadata") else {},
+                source_mtime=r["source_mtime"] if "source_mtime" in r.keys() else 0.0,
             )
             for r in rows
         ]
@@ -1010,7 +1022,7 @@ class Catalog:
     def by_file_path(self, owner: Tumbler, file_path: str) -> CatalogEntry | None:
         row = self._db.execute(
             "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime "
             f"FROM documents WHERE {self._prefix_sql(str(owner))[0]} AND file_path = ?",
             (*self._prefix_sql(str(owner))[1], file_path),
         ).fetchone()
@@ -1029,12 +1041,13 @@ class Catalog:
             head_hash=row[9],
             indexed_at=row[10],
             meta=json.loads(row[11]) if row[11] else {},
+            source_mtime=row[12] or 0.0,
         )
 
     def by_owner(self, owner: Tumbler) -> list[CatalogEntry]:
         rows = self._db.execute(
             "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime "
             f"FROM documents WHERE {self._prefix_sql(str(owner))[0]}",
             self._prefix_sql(str(owner))[1],
         ).fetchall()
@@ -1052,6 +1065,7 @@ class Catalog:
                 head_hash=r[9],
                 indexed_at=r[10],
                 meta=json.loads(r[11]) if r[11] else {},
+                source_mtime=r[12] or 0.0,
             )
             for r in rows
         ]
@@ -1060,7 +1074,7 @@ class Catalog:
         """List all entries with the given content type (code, paper, rdr, knowledge)."""
         rows = self._db.execute(
             "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime "
             "FROM documents WHERE content_type = ?",
             (content_type,),
         ).fetchall()
@@ -1070,6 +1084,7 @@ class Catalog:
                 content_type=r[4], file_path=r[5], corpus=r[6],
                 physical_collection=r[7], chunk_count=r[8], head_hash=r[9],
                 indexed_at=r[10], meta=json.loads(r[11]) if r[11] else {},
+                source_mtime=r[12] or 0.0,
             )
             for r in rows
         ]
@@ -1078,7 +1093,7 @@ class Catalog:
         """List all entries with the given corpus tag."""
         rows = self._db.execute(
             "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime "
             "FROM documents WHERE corpus = ?",
             (corpus,),
         ).fetchall()
@@ -1088,6 +1103,7 @@ class Catalog:
                 content_type=r[4], file_path=r[5], corpus=r[6],
                 physical_collection=r[7], chunk_count=r[8], head_hash=r[9],
                 indexed_at=r[10], meta=json.loads(r[11]) if r[11] else {},
+                source_mtime=r[12] or 0.0,
             )
             for r in rows
         ]
@@ -1101,7 +1117,7 @@ class Catalog:
         """Return all catalog entries. limit=0 means unlimited."""
         sql = (
             "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime "
             "FROM documents"
         )
         if limit > 0:
@@ -1113,6 +1129,7 @@ class Catalog:
                 content_type=r[4], file_path=r[5], corpus=r[6],
                 physical_collection=r[7], chunk_count=r[8], head_hash=r[9],
                 indexed_at=r[10], meta=json.loads(r[11]) if r[11] else {},
+                source_mtime=r[12] or 0.0,
             )
             for r in rows
         ]
@@ -1121,7 +1138,7 @@ class Catalog:
         """Look up catalog entry by T3 doc_id stored in meta.doc_id."""
         row = self._db.execute(
             "SELECT tumbler, title, author, year, content_type, file_path, "
-            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime "
             "FROM documents WHERE json_extract(metadata, '$.doc_id') = ?",
             (doc_id,),
         ).fetchone()
@@ -1140,6 +1157,7 @@ class Catalog:
             head_hash=row[9],
             indexed_at=row[10],
             meta=json.loads(row[11]) if row[11] else {},
+            source_mtime=row[12] or 0.0,
         )
 
     # ── Links ──────────────────────────────────────────────────────────────

--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -39,7 +39,8 @@ CREATE TABLE IF NOT EXISTS documents (
     chunk_count INTEGER,
     head_hash TEXT,
     indexed_at TEXT,
-    metadata JSON
+    metadata JSON,
+    source_mtime REAL NOT NULL DEFAULT 0
 );
 
 CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
@@ -115,6 +116,17 @@ class CatalogDB:
             with self._conn:
                 self._conn.execute("ALTER TABLE owners ADD COLUMN repo_root TEXT DEFAULT ''")
 
+        # nexus-8luh: add source_mtime column to existing databases so
+        # RDR-087 Phase 3.4's stale_source_ratio has something to read
+        # from. Default 0 for pre-migration rows (meaning "unknown").
+        try:
+            self._conn.execute("SELECT source_mtime FROM documents LIMIT 0")
+        except sqlite3.OperationalError:
+            with self._conn:
+                self._conn.execute(
+                    "ALTER TABLE documents ADD COLUMN source_mtime REAL NOT NULL DEFAULT 0"
+                )
+
     def rebuild(
         self,
         owners: dict[str, OwnerRecord],
@@ -139,8 +151,9 @@ class CatalogDB:
                 self._conn.execute(
                     "INSERT INTO documents "
                     "(tumbler, title, author, year, content_type, file_path, "
-                    "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+                    "metadata, source_mtime) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         tumbler,
                         d.title,
@@ -154,6 +167,7 @@ class CatalogDB:
                         d.head_hash,
                         d.indexed_at,
                         json.dumps(d.meta),
+                        d.source_mtime,
                     ),
                 )
 
@@ -203,7 +217,7 @@ class CatalogDB:
             sql = (
                 "SELECT d.tumbler, d.title, d.author, d.year, d.content_type, "
                 "d.file_path, d.corpus, d.physical_collection, d.chunk_count, "
-                "d.head_hash, d.indexed_at, d.metadata "
+                "d.head_hash, d.indexed_at, d.metadata, d.source_mtime "
                 "FROM documents d "
                 "JOIN documents_fts f ON d.rowid = f.rowid "
                 "WHERE documents_fts MATCH ?"
@@ -217,7 +231,7 @@ class CatalogDB:
             rows = self._conn.execute(sql, params).fetchall()
             columns = ["tumbler", "title", "author", "year", "content_type",
                         "file_path", "corpus", "physical_collection", "chunk_count",
-                        "head_hash", "indexed_at", "metadata"]
+                        "head_hash", "indexed_at", "metadata", "source_mtime"]
             return [dict(zip(columns, row)) for row in rows]
 
     def descendants(self, prefix: str) -> list[dict]:
@@ -230,14 +244,14 @@ class CatalogDB:
             rows = self._conn.execute(
                 "SELECT tumbler, title, author, year, content_type, "
                 "file_path, corpus, physical_collection, chunk_count, "
-                "head_hash, indexed_at, metadata "
+                "head_hash, indexed_at, metadata, source_mtime "
                 "FROM documents WHERE tumbler LIKE ?",
                 (prefix + ".%",),
             ).fetchall()
         columns = [
             "tumbler", "title", "author", "year", "content_type",
             "file_path", "corpus", "physical_collection", "chunk_count",
-            "head_hash", "indexed_at", "metadata",
+            "head_hash", "indexed_at", "metadata", "source_mtime",
         ]
         return [dict(zip(columns, row)) for row in rows]
 

--- a/src/nexus/catalog/tumbler.py
+++ b/src/nexus/catalog/tumbler.py
@@ -156,6 +156,11 @@ class DocumentRecord:
     head_hash: str
     indexed_at: str
     meta: dict = field(default_factory=dict)
+    # nexus-8luh: POSIX mtime (seconds since epoch) of ``file_path`` at
+    # index time. 0.0 means "not captured" (pre-migration rows, manual
+    # registrations, synthesized docs). Used by stale-source detection
+    # to flag documents whose source file has changed since last index.
+    source_mtime: float = 0.0
     _deleted: bool = False
 
 

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -993,10 +993,15 @@ def _catalog_markdown_hook(
             owner = cat.register_owner(owner_name, "curator")
 
         fp = make_relative(md_path, base_path) if base_path else str(md_path)
+        try:
+            source_mtime = md_path.stat().st_mtime
+        except OSError:
+            source_mtime = 0.0
         cat.register(
             owner=owner, title=title, content_type=content_type,
             file_path=fp, physical_collection=collection_name,
             chunk_count=chunk_count, year=year,
+            source_mtime=source_mtime,
         )
     except Exception:
         _log.debug("catalog_markdown_hook_failed", exc_info=True)

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -286,6 +286,15 @@ def _catalog_hook(
             except OSError:
                 file_hash = ""
 
+            # nexus-8luh: capture mtime at index time so stale-source
+            # detection (RDR-087 Phase 3.4) can compare stored vs
+            # current. Missing file falls back to 0 (treated as
+            # "unknown" downstream).
+            try:
+                source_mtime = abs_path.stat().st_mtime
+            except OSError:
+                source_mtime = 0.0
+
             existing = cat.by_file_path(owner, rel_path)
             if existing is None:
                 tumbler = cat.register(
@@ -296,6 +305,7 @@ def _catalog_hook(
                     physical_collection=collection_name,
                     head_hash=head_hash,
                     meta={"content_hash": file_hash} if file_hash else None,
+                    source_mtime=source_mtime,
                 )
                 new_tumblers.append(tumbler)
             else:
@@ -304,6 +314,7 @@ def _catalog_hook(
                     head_hash=head_hash,
                     physical_collection=collection_name,
                     meta={"content_hash": file_hash} if file_hash else None,
+                    source_mtime=source_mtime,
                 )
         _progress(f"  Catalog: {len(new_tumblers)} new, {len(indexed_files) - len(new_tumblers)} updated\n")
 

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -494,12 +494,17 @@ def _catalog_pdf_hook(
         file_path_str = pdf_path.name  # Portable — not machine-specific absolute path
         existing = cat.by_file_path(owner, file_path_str)
 
+        try:
+            source_mtime = pdf_path.stat().st_mtime
+        except OSError:
+            source_mtime = 0.0
         if existing:
             cat.update(
                 existing.tumbler,
                 physical_collection=collection_name,
                 chunk_count=chunk_count,
                 indexed_at=datetime.now(UTC).isoformat(),
+                source_mtime=source_mtime,
             )
         else:
             cat.register(
@@ -508,6 +513,7 @@ def _catalog_pdf_hook(
                 physical_collection=collection_name,
                 chunk_count=chunk_count,
                 file_path=file_path_str,
+                source_mtime=source_mtime,
             )
     except Exception:
         _log.debug("catalog_pdf_hook_failed", exc_info=True)

--- a/tests/test_catalog_source_mtime.py
+++ b/tests/test_catalog_source_mtime.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-8luh — ``catalog.documents`` carries ``source_mtime`` at index time.
+
+Three surfaces are under test:
+
+  1. ``DocumentRecord`` + ``CatalogEntry`` dataclass round-trip.
+  2. ``CatalogDB`` schema — fresh install has the column; ALTER-on-open
+     migration adds it to pre-8luh databases without data loss.
+  3. ``Catalog.register`` / ``Catalog.update`` / ``Catalog.by_file_path`` /
+     ``Catalog.resolve`` / ``Catalog.by_doc_id`` / ``Catalog.delete_document``
+     round-trip source_mtime through JSONL + SQLite.
+
+Adds a column-exists smoke test so downstream consumers (RDR-087 Phase
+3.4 stale_source_ratio) can assume the schema is present.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.tumbler import DocumentRecord, read_documents
+
+
+# ── Dataclass round-trip ────────────────────────────────────────────────────
+
+
+class TestDocumentRecord:
+    def test_default_mtime_is_zero(self) -> None:
+        rec = DocumentRecord(
+            tumbler="1.1.1", title="t", author="", year=0,
+            content_type="paper", file_path="x.pdf",
+            corpus="", physical_collection="knowledge__x",
+            chunk_count=1, head_hash="", indexed_at="",
+        )
+        assert rec.source_mtime == 0.0
+
+    def test_accepts_explicit_mtime(self) -> None:
+        rec = DocumentRecord(
+            tumbler="1.1.1", title="t", author="", year=0,
+            content_type="paper", file_path="x.pdf",
+            corpus="", physical_collection="knowledge__x",
+            chunk_count=1, head_hash="", indexed_at="",
+            source_mtime=1_700_000_000.5,
+        )
+        assert rec.source_mtime == 1_700_000_000.5
+
+    def test_jsonl_roundtrip_preserves_mtime(self, tmp_path: Path) -> None:
+        path = tmp_path / "documents.jsonl"
+        rec = DocumentRecord(
+            tumbler="1.1.1", title="t", author="", year=0,
+            content_type="paper", file_path="x.pdf",
+            corpus="", physical_collection="knowledge__x",
+            chunk_count=1, head_hash="", indexed_at="",
+            source_mtime=1_700_000_000.5,
+        )
+        with path.open("w") as f:
+            f.write(json.dumps(rec.__dict__) + "\n")
+        loaded = read_documents(path)
+        assert loaded["1.1.1"].source_mtime == 1_700_000_000.5
+
+
+# ── Schema ──────────────────────────────────────────────────────────────────
+
+
+class TestCatalogDBSchema:
+    def test_fresh_install_has_column(self, tmp_path: Path) -> None:
+        db = CatalogDB(tmp_path / "cat.db")
+        cols = [r[1] for r in db._conn.execute("PRAGMA table_info(documents)").fetchall()]
+        assert "source_mtime" in cols
+
+    def test_migration_adds_column_to_pre_8luh_db(self, tmp_path: Path) -> None:
+        """ALTER-on-open must patch a pre-migration catalog.db that has
+        every column except source_mtime. Verifies the try/SELECT guard
+        actually runs the ALTER instead of silently skipping it."""
+        db_path = tmp_path / "cat.db"
+        conn = sqlite3.connect(str(db_path))
+        # Legacy schema — no source_mtime column.
+        conn.execute("""
+            CREATE TABLE documents (
+                tumbler TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                author TEXT,
+                year INTEGER,
+                content_type TEXT,
+                file_path TEXT,
+                corpus TEXT,
+                physical_collection TEXT,
+                chunk_count INTEGER,
+                head_hash TEXT,
+                indexed_at TEXT,
+                metadata JSON
+            )
+        """)
+        conn.execute(
+            "INSERT INTO documents (tumbler, title, author, year, content_type, "
+            "file_path, corpus, physical_collection, chunk_count, head_hash, "
+            "indexed_at, metadata) VALUES ('1.1.1', 'legacy', '', 0, 'paper', "
+            "'legacy.pdf', '', 'knowledge__legacy', 1, '', '', '{}')"
+        )
+        conn.commit()
+        conn.close()
+
+        # Re-open via CatalogDB — migration should kick in.
+        db = CatalogDB(db_path)
+        cols = [r[1] for r in db._conn.execute("PRAGMA table_info(documents)").fetchall()]
+        assert "source_mtime" in cols
+        # Legacy data survives, and pre-existing rows get the default 0.
+        row = db._conn.execute(
+            "SELECT title, source_mtime FROM documents WHERE tumbler = ?",
+            ("1.1.1",),
+        ).fetchone()
+        assert row == ("legacy", 0.0)
+
+
+# ── Catalog CRUD ────────────────────────────────────────────────────────────
+
+
+class TestCatalogRegisterStoresMtime:
+    def _seed(self, tmp_path: Path) -> tuple[Catalog, Path]:
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+        return cat, cat_dir
+
+    def test_register_without_mtime_defaults_to_zero(self, tmp_path: Path) -> None:
+        cat, _ = self._seed(tmp_path)
+        owner = cat.register_owner("repo", "corpus")
+        tumbler = cat.register(
+            owner, title="doc", content_type="paper",
+            file_path="a.pdf", physical_collection="knowledge__x",
+        )
+        entry = cat.resolve(tumbler)
+        assert entry is not None
+        assert entry.source_mtime == 0.0
+
+    def test_register_preserves_explicit_mtime(self, tmp_path: Path) -> None:
+        cat, _ = self._seed(tmp_path)
+        owner = cat.register_owner("repo", "corpus")
+        tumbler = cat.register(
+            owner, title="doc", content_type="paper",
+            file_path="a.pdf", physical_collection="knowledge__x",
+            source_mtime=1_700_000_000.25,
+        )
+        entry = cat.resolve(tumbler)
+        assert entry is not None
+        assert entry.source_mtime == 1_700_000_000.25
+
+    def test_by_file_path_returns_mtime(self, tmp_path: Path) -> None:
+        cat, _ = self._seed(tmp_path)
+        owner = cat.register_owner("repo", "corpus")
+        cat.register(
+            owner, title="doc", content_type="paper",
+            file_path="a.pdf", physical_collection="knowledge__x",
+            source_mtime=123.5,
+        )
+        entry = cat.by_file_path(owner, "a.pdf")
+        assert entry is not None
+        assert entry.source_mtime == 123.5
+
+    def test_update_can_bump_mtime(self, tmp_path: Path) -> None:
+        """Callers re-indexing a file must be able to bump stored mtime
+        to the latest file.stat().st_mtime without wiping the rest of
+        the record."""
+        cat, _ = self._seed(tmp_path)
+        owner = cat.register_owner("repo", "corpus")
+        tumbler = cat.register(
+            owner, title="doc", content_type="paper",
+            file_path="a.pdf", physical_collection="knowledge__x",
+            source_mtime=100.0,
+        )
+        cat.update(tumbler, source_mtime=200.5)
+        entry = cat.resolve(tumbler)
+        assert entry is not None
+        assert entry.source_mtime == 200.5
+        assert entry.title == "doc"  # other fields preserved
+
+    def test_by_doc_id_returns_mtime(self, tmp_path: Path) -> None:
+        cat, _ = self._seed(tmp_path)
+        owner = cat.register_owner("repo", "corpus")
+        cat.register(
+            owner, title="doc", content_type="paper",
+            file_path="a.pdf", physical_collection="knowledge__x",
+            meta={"doc_id": "doc-abc-42"},
+            source_mtime=55.5,
+        )
+        entry = cat.by_doc_id("doc-abc-42")
+        assert entry is not None
+        assert entry.source_mtime == 55.5
+
+
+# ── Indexing-side plumbing smoke test ───────────────────────────────────────
+
+
+class TestIndexSiteCapturesMtime:
+    def test_real_file_mtime_propagates_via_catalog_hook(self, tmp_path: Path) -> None:
+        """The indexer calls register() with file.stat().st_mtime; end-to-end
+        we verify the catalog stores the real mtime for a file we created."""
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+
+        # Mimic what indexer.py:291 now does: call cat.register with
+        # file.stat().st_mtime.
+        real_file = tmp_path / "sample.md"
+        real_file.write_text("hello")
+        # Set a known mtime so the round-trip is deterministic.
+        os_mtime = real_file.stat().st_mtime
+        owner = cat.register_owner("repo", "corpus")
+        tumbler = cat.register(
+            owner, title="sample", content_type="prose",
+            file_path=str(real_file), physical_collection="docs__x",
+            source_mtime=os_mtime,
+        )
+        entry = cat.resolve(tumbler)
+        assert entry is not None
+        assert entry.source_mtime == pytest.approx(os_mtime, abs=1e-3)


### PR DESCRIPTION
## Summary

- Adds \`source_mtime REAL NOT NULL DEFAULT 0\` to \`catalog.documents\` with a fresh-install schema entry + ALTER-on-open migration (mirrors the \`repo_root\` pattern from RDR-060).
- Threads \`source_mtime\` through the three active indexing paths — code repo (\`indexer.py\`), markdown/prose (\`doc_indexer._catalog_markdown_hook\`), and PDFs (\`pipeline_stages._catalog_pdf_hook\`, shared by batch + streaming). Each site reads \`file.stat().st_mtime\` at register time.
- All Catalog read paths now round-trip the column: \`resolve\`, \`by_file_path\`, \`by_owner\`, \`by_content_type\`, \`by_corpus\`, \`by_doc_id\`, \`all_documents\`, plus \`search\` / \`descendants\` in \`CatalogDB\`. \`update\` lets re-indexers bump the stored value; \`delete_document\` tombstones include it.

Unblocks RDR-087 Phase 3.4 \`stale_source_ratio\` — previously stuck on the \`"—"\` placeholder because the catalog had no mtime field. The downstream wiring (a real float instead of the placeholder) stays on a follow-up: it needs an O(N) fs walk per \`collection health\` run, out of scope for the column-add.

Closes nexus-8luh.

## Test plan

- [x] \`uv run pytest tests/test_catalog_source_mtime.py\` — 11 new tests (dataclass round-trip, fresh-install schema, pre-8luh migration preserving data, CRUD round-trip through register/update/resolve/by_file_path/by_doc_id, indexer-site mtime capture)
- [x] \`uv run pytest tests/test_catalog.py tests/test_indexer.py tests/test_doc_indexer.py tests/test_pipeline_stages.py tests/test_collection_health.py tests/test_collection_audit.py\` — 298 passing, no regressions in the catalog / indexer / pipeline / health surfaces that carry the new column