### PR TITLE
feat(collection): nx collection audit --live probe histogram (nexus-fx2d)

### DIFF
--- a/src/nexus/collection_audit.py
+++ b/src/nexus/collection_audit.py
@@ -94,11 +94,23 @@ class AuditReport:
     chash_coverage: ChashCoverage | None = None
 
 
-# ── Section 1: distance histogram (telemetry-only; live deferred) ───────────
+# ── Section 1: distance histogram (telemetry primary, live fallback) ────────
 
 
 _HIST_BIN_WIDTH = 0.2
 _HIST_BINS = 10  # covers [0.0, 2.0]
+_LIVE_PROBE_DEFAULT_N = 25
+
+
+def _bucketize(distances: list[float], source: str) -> DistanceHistogram:
+    """Pack *distances* into the 10-bin 0.0-2.0 histogram."""
+    buckets = [0] * _HIST_BINS
+    for d in distances:
+        idx = min(max(int(d / _HIST_BIN_WIDTH), 0), _HIST_BINS - 1)
+        buckets[idx] += 1
+    return DistanceHistogram(
+        buckets=buckets, source=source, sample_size=len(distances),
+    )
 
 
 def compute_distance_histogram(
@@ -107,8 +119,9 @@ def compute_distance_histogram(
     """Histogram of ``top_distance`` from search_telemetry for *collection*.
 
     10 fixed bins over [0.0, 2.0]. Empty table or <1 in-window rows →
-    ``DistanceHistogram(source="empty", sample_size=0)``. Live-probe
-    fallback is deferred to bead ``nexus-fx2d``.
+    ``DistanceHistogram(source="empty", sample_size=0)``. Use
+    :func:`sample_live_distances` + :func:`compute_live_distance_histogram`
+    for a live-probe fallback when telemetry is cold.
     """
     cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
     rows = taxonomy_conn.execute(
@@ -122,13 +135,72 @@ def compute_distance_histogram(
         return DistanceHistogram(
             buckets=[0] * _HIST_BINS, source="empty", sample_size=0,
         )
-    buckets = [0] * _HIST_BINS
-    for d in distances:
-        idx = min(int(d / _HIST_BIN_WIDTH), _HIST_BINS - 1)
-        buckets[idx] += 1
-    return DistanceHistogram(
-        buckets=buckets, source="telemetry", sample_size=len(distances),
-    )
+    return _bucketize(distances, "telemetry")
+
+
+def sample_live_distances(
+    collection: str, t3: Any, *, n: int = _LIVE_PROBE_DEFAULT_N,
+) -> list[float]:
+    """Run up to *n* self-queries against *collection* and return the
+    nearest-other distances (nexus-fx2d).
+
+    Samples N chunk embeddings directly from the collection via
+    ``col.get(include=["embeddings"])``, then for each runs
+    ``col.query(query_embeddings=[emb], n_results=2)`` and records the
+    distance at position ``[1]`` — position ``[0]`` is the chunk itself.
+    No re-embedding, no Voyage API roundtrips: we reuse the vectors
+    already in ChromaDB. Budget: ~10 s for N=25 against cloud under
+    light contention.
+
+    Returns a possibly-shorter list if the collection has fewer than
+    *n* chunks, or if individual probes return < 2 neighbours (solo
+    chunks). Caller decides what to do with a sparse sample.
+    """
+    col = t3.get_or_create_collection(collection)
+    try:
+        got = col.get(limit=n, include=["embeddings"])
+    except Exception:
+        return []
+    # ChromaDB returns embeddings as a numpy ndarray; guard the
+    # "truth-value ambiguous" trap with an explicit ``is None`` + length
+    # check, not a boolean collapse.
+    embeddings_raw = got.get("embeddings")
+    if embeddings_raw is None or len(embeddings_raw) == 0:
+        return []
+    embeddings = embeddings_raw
+
+    distances: list[float] = []
+    for emb in embeddings:
+        try:
+            res = col.query(
+                query_embeddings=[emb], n_results=2, include=["distances"],
+            )
+        except Exception:
+            continue
+        d_rows = res.get("distances") or [[]]
+        if not d_rows or not d_rows[0] or len(d_rows[0]) < 2:
+            continue
+        distances.append(float(d_rows[0][1]))
+    return distances
+
+
+def compute_live_distance_histogram(
+    collection: str, t3: Any, *, n: int = _LIVE_PROBE_DEFAULT_N,
+) -> DistanceHistogram:
+    """Build a histogram from :func:`sample_live_distances` (nexus-fx2d).
+
+    Distinct ``source="live"`` marker so downstream consumers can see
+    the audit hit ChromaDB, not search_telemetry. Cold collection (no
+    chunks, all probes failed) → ``source="empty"`` with sample_size=0
+    — identical to the telemetry-empty case so formatters only need
+    one branch.
+    """
+    distances = sample_live_distances(collection, t3, n=n)
+    if not distances:
+        return DistanceHistogram(
+            buckets=[0] * _HIST_BINS, source="empty", sample_size=0,
+        )
+    return _bucketize(distances, "live")
 
 
 # ── Section 2: top-N cross-projections ──────────────────────────────────────
@@ -372,11 +444,23 @@ def compute_chash_coverage(collection: str) -> ChashCoverage | None:
 # ── Orchestrator ────────────────────────────────────────────────────────────
 
 
-def run_collection_audit(collection: str) -> AuditReport:
+def run_collection_audit(
+    collection: str,
+    *,
+    live: bool = False,
+    t3: Any = None,
+    live_n: int = _LIVE_PROBE_DEFAULT_N,
+) -> AuditReport:
     """Assemble the full audit report for *collection*.
 
     Sections tolerate absent backing stores (empty-telemetry / uninit
     catalog) — each falls back to a neutral empty value.
+
+    nexus-fx2d: when *live* is True and the telemetry histogram is
+    ``source="empty"``, run :func:`compute_live_distance_histogram`
+    against *t3* (resolved via :func:`nexus.db.make_t3` when ``None``).
+    The telemetry path is always tried first so warm collections
+    stay cheap. Budget: ~10 s for N=25 probes against cloud T3.
     """
     t2 = _open_t2()
     cat_conn = _open_catalog_conn()
@@ -398,6 +482,18 @@ def run_collection_audit(collection: str) -> AuditReport:
             t2.close()
         if cat_conn is not None:
             cat_conn.close()
+
+    # Live-probe fallback — only when telemetry came back empty AND
+    # caller opted in. Same error boundary as chash coverage: a T3
+    # hiccup shouldn't blank the telemetry/projection/hub results.
+    if live and hist.source == "empty":
+        try:
+            if t3 is None:
+                from nexus.db import make_t3
+                t3 = make_t3()
+            hist = compute_live_distance_histogram(collection, t3, n=live_n)
+        except Exception:
+            pass
     # RDR-087 Phase 4.6 (nexus-c2op): chash coverage section. Own error
     # boundary — the rest of the audit is purely T2, chash coverage hits
     # T3, so failures (missing collection, network) shouldn't lose the
@@ -426,7 +522,7 @@ def format_audit_human(report: AuditReport) -> str:
     h = report.distance_histogram
     if h.sample_size == 0:
         lines.append(
-            f"  (no telemetry rows; live-probe fallback deferred — nexus-fx2d)"
+            "  (no telemetry rows; pass --live to sample from ChromaDB)"
         )
     else:
         lines.append(f"  source={h.source} samples={h.sample_size}")

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -585,13 +585,32 @@ def health_cmd(sort_by: str, fmt: str) -> None:
     show_default=True,
     help="Output format.",
 )
-def audit_cmd(name: str, fmt: str) -> None:
+@click.option(
+    "--live",
+    is_flag=True,
+    default=False,
+    help=(
+        "When the 30-day search_telemetry histogram is empty, sample N "
+        "chunks from ChromaDB and derive the distance histogram from "
+        "self-queries (budget ~10 s at N=25). Reuses stored embeddings "
+        "— no Voyage API roundtrips."
+    ),
+)
+@click.option(
+    "--live-n",
+    "live_n",
+    type=int,
+    default=25,
+    show_default=True,
+    help="Number of live-probe samples when --live fires.",
+)
+def audit_cmd(name: str, fmt: str, live: bool, live_n: int) -> None:
     """Deep-dive audit for a single collection (RDR-087 Phase 4.2).
 
-    Four sections: distance histogram (30d), top-5 cross-projections,
+    Five sections: distance histogram (30d telemetry, ``--live`` to
+    probe ChromaDB when telemetry is cold), top-5 cross-projections,
     orphan chunks (>30d, no incoming links), top-10 cross-collection
-    hub topic assignments. Live-probe distance fallback deferred to
-    follow-up bead nexus-fx2d — telemetry-only for now.
+    hub topic assignments, chash_index coverage.
     """
     from nexus.collection_audit import (
         format_audit_human,
@@ -599,7 +618,7 @@ def audit_cmd(name: str, fmt: str) -> None:
         run_collection_audit,
     )
 
-    report = run_collection_audit(name)
+    report = run_collection_audit(name, live=live, live_n=live_n)
     if fmt == "json":
         click.echo(format_audit_json(report))
     else:

--- a/tests/test_collection_audit.py
+++ b/tests/test_collection_audit.py
@@ -260,6 +260,132 @@ class TestDistanceHistogramTelemetryOnly:
         assert hist.source == "empty"
 
 
+# ── Section 1: live-probe fallback (nexus-fx2d) ─────────────────────────────
+
+
+class TestLiveDistanceProbe:
+    """Live probe reuses stored embeddings — no Voyage API, no network
+    when backed by an EphemeralClient."""
+
+    def _ephemeral_collection_with_embeddings(self, name: str):
+        """Seed a Chroma EphemeralClient collection with N deterministic
+        embeddings so ``col.query`` returns repeatable distances."""
+        import chromadb
+        from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+        client = chromadb.EphemeralClient()
+        ef = DefaultEmbeddingFunction()
+        col = client.create_collection(name=name, embedding_function=ef)
+        col.add(
+            ids=[f"d{i}" for i in range(6)],
+            documents=[
+                "authentication handler for OIDC flows",
+                "database migrations via Alembic",
+                "caching layer with Redis backing",
+                "async task queue over RabbitMQ",
+                "observability via OpenTelemetry spans",
+                "GraphQL schema with federation directives",
+            ],
+            metadatas=[{"idx": i} for i in range(6)],
+        )
+        return col
+
+    def test_sample_live_distances_returns_values_for_each_seed(self) -> None:
+        from nexus.collection_audit import sample_live_distances
+
+        col = self._ephemeral_collection_with_embeddings("code__live_probe")
+
+        class FakeT3:
+            def get_or_create_collection(self_, name):
+                assert name == "code__live_probe"
+                return col
+
+        distances = sample_live_distances("code__live_probe", FakeT3(), n=6)
+        # Each seed → one nearest-other distance. Self should have been
+        # excluded (position [0] is self; we take [1]).
+        assert len(distances) == 6
+        # MiniLM self → nearest-other distance must be >0 (else we
+        # accidentally returned self).
+        assert all(d > 0 for d in distances)
+
+    def test_compute_live_histogram_marks_source_live(self) -> None:
+        from nexus.collection_audit import compute_live_distance_histogram
+
+        col = self._ephemeral_collection_with_embeddings("code__live_mark")
+
+        class FakeT3:
+            def get_or_create_collection(self_, name):
+                return col
+
+        hist = compute_live_distance_histogram("code__live_mark", FakeT3(), n=6)
+        assert hist.source == "live"
+        assert hist.sample_size == 6
+        assert sum(hist.buckets) == 6
+        assert len(hist.buckets) == 10
+
+    def test_live_histogram_empty_when_collection_empty(self) -> None:
+        from nexus.collection_audit import compute_live_distance_histogram
+        import chromadb
+        from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+        client = chromadb.EphemeralClient()
+        ef = DefaultEmbeddingFunction()
+        empty = client.create_collection(name="code__empty", embedding_function=ef)
+
+        class FakeT3:
+            def get_or_create_collection(self_, name):
+                return empty
+
+        hist = compute_live_distance_histogram("code__empty", FakeT3(), n=5)
+        assert hist.source == "empty"
+        assert hist.sample_size == 0
+
+    def test_run_audit_uses_live_probe_only_when_telemetry_is_cold(
+        self, tmp_path: Path,
+    ) -> None:
+        """If warm telemetry already exists the live probe must not
+        fire — keeps the audit cheap and avoids rate-limit contention."""
+        from nexus.collection_audit import run_collection_audit
+        from unittest.mock import patch
+
+        _seed_t2(tmp_path / "memory.db")
+
+        # make_t3 must never be called because telemetry is warm.
+        sentinel_called = {"hit": False}
+
+        class ExplodingT3:
+            def get_or_create_collection(self_, name):
+                sentinel_called["hit"] = True
+                raise AssertionError("live probe fired despite warm telemetry")
+
+        with patch("nexus.commands._helpers.default_db_path", return_value=tmp_path / "memory.db"):
+            report = run_collection_audit(
+                "code__main", live=True, t3=ExplodingT3(),
+            )
+        assert sentinel_called["hit"] is False
+        assert report.distance_histogram.source == "telemetry"
+
+    def test_run_audit_falls_back_to_live_when_telemetry_empty(
+        self, tmp_path: Path,
+    ) -> None:
+        from nexus.collection_audit import run_collection_audit
+        from unittest.mock import patch
+
+        _seed_t2(tmp_path / "memory.db")
+        col = self._ephemeral_collection_with_embeddings("code__fallback_live")
+
+        class FakeT3:
+            def get_or_create_collection(self_, name):
+                return col
+
+        with patch("nexus.commands._helpers.default_db_path", return_value=tmp_path / "memory.db"):
+            report = run_collection_audit(
+                "code__fallback_live", live=True, t3=FakeT3(), live_n=6,
+            )
+        assert report.distance_histogram.source == "live"
+        assert report.distance_histogram.sample_size == 6
+
+
 # ── Section 5: chash_index coverage (RDR-087 Phase 4.6 / nexus-c2op) ────────
 
 
@@ -443,3 +569,52 @@ class TestCollectionAuditCli:
         assert "cross_projections" in payload
         assert "orphans" in payload
         assert "hub_assignments" in payload
+
+    def test_live_flag_populates_histogram_when_telemetry_cold(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """nexus-fx2d — ``--live`` promotes source="empty" → source="live"
+        by probing ChromaDB for chunks that have never been searched."""
+        import chromadb
+        import json
+        from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+        from unittest.mock import patch
+
+        from nexus.cli import main
+        from nexus.db.t2 import T2Database
+
+        # T2 with zero search_telemetry rows for code__live_cli.
+        db_path = tmp_path / "memory.db"
+        with T2Database(db_path):
+            pass
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+
+        # Seed an EphemeralClient collection the --live probe can sample.
+        client = chromadb.EphemeralClient()
+        ef = DefaultEmbeddingFunction()
+        col = client.create_collection(name="code__live_cli", embedding_function=ef)
+        col.add(
+            ids=[f"d{i}" for i in range(4)],
+            documents=["auth", "cache", "queue", "graphql"],
+            metadatas=[{"i": i} for i in range(4)],
+        )
+
+        class FakeT3:
+            def get_or_create_collection(self_, name):
+                assert name == "code__live_cli"
+                return col
+
+        with patch("nexus.db.make_t3", return_value=FakeT3()):
+            result = runner.invoke(
+                main,
+                [
+                    "collection", "audit", "code__live_cli",
+                    "--live", "--live-n", "4", "--format", "json",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["distance_histogram"]["source"] == "live"
+        assert payload["distance_histogram"]["sample_size"] == 4


### PR DESCRIPTION
## Summary

- Finishes RDR-087 Phase 4.2 section 1. Adds a live-probe fallback to the distance histogram for collections whose 30-day \`search_telemetry\` is empty — previously the audit just printed \`(no telemetry rows; live-probe fallback deferred — nexus-fx2d)\` and bailed.
- \`sample_live_distances(collection, t3, n=25)\` pulls stored embeddings via \`col.get(include=["embeddings"])\`, runs \`col.query(n_results=2)\` per seed, and records the position-[1] distance (nearest-other; [0] is self). Zero Voyage API roundtrips — vectors are reused from ChromaDB.
- \`compute_live_distance_histogram\` wraps the sampler into the existing \`DistanceHistogram\` shape and marks \`source="live"\` so formatters / downstream consumers can distinguish the two paths.
- \`run_collection_audit\` gains \`live=False\` + \`t3=None\` kwargs. Live probe fires only when telemetry came back empty AND the caller opted in — keeps warm audits cheap and avoids rate-limit contention during active indexing.
- New CLI flags: \`nx collection audit --live\` and \`--live-n N\` (default 25, ~10s budget per bead spec).

Closes nexus-fx2d.

## Test plan

- [x] \`uv run pytest tests/test_collection_audit.py\` — 19 tests (5 new in \`TestLiveDistanceProbe\` + 1 CLI smoke test covering the \`--live\` flag end-to-end)
- [x] New tests cover: sampler returns N values / excludes self / marks source="live" / empty collection still reports source="empty" / live probe skipped when telemetry warm / falls back when telemetry cold
- [x] \`uv run pytest tests/test_collection_audit.py tests/test_collection_cmd.py tests/test_collection_health.py\` — 61 tests pass, no regressions