### PR TITLE
fix(taxonomy): per-bullet scope + nearest-count binding in validate-refs (nexus-7ay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`nx taxonomy validate-refs` proximity false-positives on bullet lists and multi-count paragraphs** (nexus-7ay). Each markdown list item (`-`, `*`, `+`, ordered) is now its own count-binding scope — a count claim in one bullet no longer leaks into every sibling, which previously produced a single OK line followed by a cascade of spurious Drift lines. Within a prose paragraph that names more than one collection, each reference now binds to the textually nearest chunk-count claim instead of always the first one encountered. Seven new tests in `tests/test_ref_scanner.py` pin the expected proximity semantics.
+
 ## [4.7.0] - 2026-04-18
 
 ### Added

--- a/src/nexus/doc/ref_scanner.py
+++ b/src/nexus/doc/ref_scanner.py
@@ -114,55 +114,82 @@ def _collection_regex(prefixes: list[str]) -> re.Pattern:
 from nexus.doc._common import iter_plain_lines as _iter_plain_lines
 
 
-def _paragraph_for_line(lines: list[tuple[int, str]], target_lineno: int) -> list[str]:
-    """Return the block of consecutive non-empty plain lines containing
-    *target_lineno*. A paragraph is delimited by a blank line on either side.
+# Markdown list-item markers: -, *, +, or N. / N) — leading whitespace allowed.
+_LIST_ITEM_RE = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+")
+
+
+def _is_list_item(line: str) -> bool:
+    """True if *line* starts a markdown bullet or ordered-list item."""
+    return bool(_LIST_ITEM_RE.match(line))
+
+
+def _scope_for_line(
+    lines: list[tuple[int, str]],
+    target_idx: int,
+) -> tuple[list[str], int]:
+    """Return ``(scope_lines, target_within_scope)`` for count-proximity binding.
+
+    Each list-item line is its own scope — count claims from sibling
+    bullets do not leak (nexus-7ay). Non-list lines expand to the
+    surrounding consecutive prose paragraph, with list-item boundaries
+    treated as paragraph breaks.
     """
-    idx = next((i for i, (ln, _) in enumerate(lines) if ln == target_lineno), -1)
-    if idx < 0:
-        return []
-    # Scan upward for paragraph start
-    start = idx
-    while start > 0 and lines[start - 1][1].strip() and lines[start - 1][0] == lines[start][0] - 1:
+    target_line = lines[target_idx][1]
+    if _is_list_item(target_line):
+        return [target_line], 0
+
+    start = target_idx
+    while (
+        start > 0
+        and lines[start - 1][1].strip()
+        and lines[start - 1][0] == lines[start][0] - 1
+        and not _is_list_item(lines[start - 1][1])
+    ):
         start -= 1
-    # Scan downward for paragraph end
-    end = idx
-    while end + 1 < len(lines) and lines[end + 1][1].strip() and lines[end + 1][0] == lines[end][0] + 1:
+    end = target_idx
+    while (
+        end + 1 < len(lines)
+        and lines[end + 1][1].strip()
+        and lines[end + 1][0] == lines[end][0] + 1
+        and not _is_list_item(lines[end + 1][1])
+    ):
         end += 1
-    return [ln[1] for ln in lines[start : end + 1]]
+    return [ln[1] for ln in lines[start : end + 1]], target_idx - start
 
 
-def _extract_count(paragraph_text: str) -> int | None:
-    """Find the first chunk-count claim in *paragraph_text* and return
-    the integer value. ``~13k`` → ``13000``; ``12,900`` → ``12900``.
-    Returns ``None`` if no claim is present.
+def _iter_count_matches(scope_text: str):
+    """Yield ``(start_position, value)`` for every chunk-count claim
+    in *scope_text*. Both plain-integer and k-shorthand patterns are
+    scanned; positions are character offsets into *scope_text*.
     """
-    # First pattern (plain integer) wins when both match — it's more precise.
-    m = _COUNT_RES[0].search(paragraph_text)
-    if m:
+    for m in _COUNT_RES[0].finditer(scope_text):
         try:
-            return int(m.group("n").replace(",", ""))
+            yield m.start(), int(m.group("n").replace(",", ""))
         except ValueError:
-            pass
-    m = _COUNT_RES[1].search(paragraph_text)
-    if m:
+            continue
+    for m in _COUNT_RES[1].finditer(scope_text):
         try:
-            # "~13k" → 13000; "13.5k" → 13500
-            raw = float(m.group("n"))
-            return int(raw * 1000)
+            yield m.start(), int(float(m.group("n")) * 1000)
         except ValueError:
-            pass
-    return None
+            continue
+
+
+def _extract_count_near(scope_text: str, ref_pos: int) -> int | None:
+    """Return the value of the count claim nearest *ref_pos* in
+    *scope_text*, or ``None`` when no claim is present.
+    """
+    candidates = list(_iter_count_matches(scope_text))
+    if not candidates:
+        return None
+    return min(candidates, key=lambda c: abs(c[0] - ref_pos))[1]
 
 
 def scan_markdown(path: Path, prefixes: list[str]) -> list[Reference]:
     """Return every ``<prefix>__<name>`` reference in *path*.
 
-    References inside fenced code blocks are ignored. When a reference
-    line is part of a paragraph containing a chunk-count claim, the
-    claim is associated with every reference in that paragraph
-    (same-paragraph nearest-match heuristic — cheap, and good enough
-    for the advisory scope).
+    References inside fenced code blocks are ignored. Each bullet-list
+    item is its own count-binding scope; within a prose paragraph each
+    reference binds to the textually nearest chunk-count claim.
     """
     # Validate prefixes up-front so a bad config fails fast, even on
     # empty documents (where scan would otherwise short-circuit).
@@ -175,13 +202,19 @@ def scan_markdown(path: Path, prefixes: list[str]) -> list[Reference]:
         return []
     refs: list[Reference] = []
 
-    for lineno, line in plain_lines:
+    for idx, (lineno, line) in enumerate(plain_lines):
         for m in coll_re.finditer(line):
             prefix = m.group("prefix")
             name = m.group("name")
             collection = f"{prefix}__{name}"
-            paragraph = _paragraph_for_line(plain_lines, lineno)
-            claimed = _extract_count(" ".join(paragraph)) if paragraph else None
+
+            scope_lines, target_within = _scope_for_line(plain_lines, idx)
+            scope_text = " ".join(scope_lines)
+            # Offset of the target line within the joined scope. `" "` join
+            # means a single-char separator between lines.
+            offset = sum(len(s) + 1 for s in scope_lines[:target_within])
+            claimed = _extract_count_near(scope_text, offset + m.start())
+
             refs.append(
                 Reference(
                     path=path,

--- a/tests/test_ref_scanner.py
+++ b/tests/test_ref_scanner.py
@@ -160,6 +160,116 @@ def test_embedded_reference_boundary(tmp_path):
     assert refs[0].line == 2
 
 
+# ── proximity binding (nexus-7ay) ────────────────────────────────────────────
+
+
+def test_bullet_list_each_item_is_own_scope(tmp_path):
+    """Each bullet binds to its own count, not the first count in the list.
+
+    Before nexus-7ay the first count in a bullet list leaked into every
+    sibling bullet as a false-positive Drift.
+    """
+    p = _write(
+        tmp_path,
+        "## Key Stores\n"
+        "\n"
+        "- `docs__art-grossberg-papers`: 19,417 chunks (80 papers)\n"
+        "- `knowledge__art`: 5,724 chunks (textbook)\n"
+        "- `docs__art-architecture`: 101 chunks (this set)\n",
+    )
+    refs = scan_markdown(p, DEFAULT_PREFIXES)
+    by_coll = {r.collection: r.claimed_count for r in refs}
+    assert by_coll["docs__art-grossberg-papers"] == 19417
+    assert by_coll["knowledge__art"] == 5724
+    assert by_coll["docs__art-architecture"] == 101
+
+
+def test_ordered_list_each_item_is_own_scope(tmp_path):
+    p = _write(
+        tmp_path,
+        "1. `docs__alpha`: 100 chunks\n"
+        "2. `docs__beta`: 200 chunks\n"
+        "3. `docs__gamma`: 300 chunks\n",
+    )
+    refs = scan_markdown(p, DEFAULT_PREFIXES)
+    by_coll = {r.collection: r.claimed_count for r in refs}
+    assert by_coll["docs__alpha"] == 100
+    assert by_coll["docs__beta"] == 200
+    assert by_coll["docs__gamma"] == 300
+
+
+def test_asterisk_and_plus_bullets_are_own_scope(tmp_path):
+    p = _write(
+        tmp_path,
+        "* `docs__one`: 10 chunks\n"
+        "* `docs__two`: 20 chunks\n"
+        "+ `docs__three`: 30 chunks\n",
+    )
+    refs = scan_markdown(p, DEFAULT_PREFIXES)
+    by_coll = {r.collection: r.claimed_count for r in refs}
+    assert by_coll["docs__one"] == 10
+    assert by_coll["docs__two"] == 20
+    assert by_coll["docs__three"] == 30
+
+
+def test_paragraph_multiple_counts_bind_nearest(tmp_path):
+    """Prose with multiple collections + multiple counts binds each ref
+    to its textually nearest count, not always the first."""
+    p = _write(
+        tmp_path,
+        "The source contains over 19,400 chunks in `docs__grossberg-papers`. "
+        "The textbook material (5,724 chunks) is in `knowledge__textbook`.\n",
+    )
+    refs = scan_markdown(p, DEFAULT_PREFIXES)
+    by_coll = {r.collection: r.claimed_count for r in refs}
+    assert by_coll["docs__grossberg-papers"] == 19400
+    assert by_coll["knowledge__textbook"] == 5724
+
+
+def test_paragraph_single_count_applies_to_all_refs(tmp_path):
+    """Exactly one count in a paragraph still applies to every ref in it."""
+    p = _write(
+        tmp_path,
+        "The 1,000 chunks span `docs__alpha` and `docs__beta` collections.\n",
+    )
+    refs = scan_markdown(p, DEFAULT_PREFIXES)
+    by_coll = {r.collection: r.claimed_count for r in refs}
+    assert by_coll["docs__alpha"] == 1000
+    assert by_coll["docs__beta"] == 1000
+
+
+def test_bullet_without_count_does_not_leak_sibling_count(tmp_path):
+    """A bullet with no count in its own line stays None — no leak from
+    a sibling bullet's count."""
+    p = _write(
+        tmp_path,
+        "- `docs__with-count`: 100 chunks\n"
+        "- `docs__no-count` is a sibling collection\n",
+    )
+    refs = scan_markdown(p, DEFAULT_PREFIXES)
+    by_coll = {r.collection: r.claimed_count for r in refs}
+    assert by_coll["docs__with-count"] == 100
+    assert by_coll["docs__no-count"] is None
+
+
+def test_bullet_list_inside_multiline_paragraph(tmp_path):
+    """A list sandwiched between prose paragraphs still scopes per-bullet."""
+    p = _write(
+        tmp_path,
+        "Context preamble paragraph.\n"
+        "\n"
+        "- `docs__A`: 10 chunks\n"
+        "- `docs__B`: 20 chunks\n"
+        "\n"
+        "Trailing paragraph with 999 chunks in `docs__C`.\n",
+    )
+    refs = scan_markdown(p, DEFAULT_PREFIXES)
+    by_coll = {r.collection: r.claimed_count for r in refs}
+    assert by_coll["docs__A"] == 10
+    assert by_coll["docs__B"] == 20
+    assert by_coll["docs__C"] == 999
+
+
 # ── validate ─────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- `nx taxonomy validate-refs` false-positived on markdown bullet lists and multi-count prose paragraphs. The scanner joined every consecutive non-blank line into a single paragraph, then assigned the first count claim in that paragraph to every subsequent collection reference — a five-bullet list of per-collection chunk claims produced one OK line and four spurious Drift lines, drowning real drift in noise (nexus-7ay repro: ART `docs/architecture/primary-sources.md`).
- Each markdown list item (`-`, `*`, `+`, or ordered `N.`/`N)`) is now its own count-binding scope — sibling bullets no longer leak.
- Within a prose paragraph, each reference now binds to the textually nearest chunk-count claim instead of always the first match.
- A bullet without its own count stays `None`, preventing sibling-leak.

## Test plan

- [x] `uv run pytest tests/test_ref_scanner.py` — 28 passed (7 new, 21 existing)
- [x] `uv run pytest -k "taxonomy or validate_ref or ref_scanner or canary"` — 175 passed

Closes nexus-7ay.