### PR TITLE
feat(observability): nx index post-processing phase markers (nexus-vatx Gap 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`nx index` post-processing phase markers** (nexus-vatx Gap 2). After the per-file `[N/N]` progress bar finishes, the pipeline keeps running for several seconds to minutes — RDR discovery, misclassified-chunk pruning, deleted-file pruning, pipeline-version stamping, and catalog registration. Previously the operator saw silence and could not tell hung from busy. A new `on_phase` callback threaded through `index_repository` → `_run_index` emits `[post] <phase>…` / `[post] <phase> done (Xs)` lines to stderr for each phase, bookended by `[post] Post-processing complete (Xs)`. The `nx index` CLI wires the callback to `click.echo(..., err=True)` so markers are visible even when stdout is redirected to a file. Four new tests in `tests/test_indexer.py` pin the phase surface.
+
 ### Fixed
 
 - **`nx taxonomy validate-refs` proximity false-positives on bullet lists and multi-count paragraphs** (nexus-7ay). Each markdown list item (`-`, `*`, `+`, ordered) is now its own count-binding scope — a count claim in one bullet no longer leaks into every sibling, which previously produced a single OK line followed by a cascade of spurious Drift lines. Within a prose paragraph that names more than one collection, each reference now binds to the textually nearest chunk-count claim instead of always the first one encountered. Seven new tests in `tests/test_ref_scanner.py` pin the expected proximity semantics.

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -122,9 +122,16 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
             else:
                 click.echo(line)
 
+    def on_phase(msg: str) -> None:
+        # nexus-vatx Gap 2: surface post-processing phases so the operator
+        # knows the indexer is still busy after the per-file bar finishes.
+        # Stderr so the line is visible even when stdout is redirected.
+        click.echo(f"  [post] {msg}", err=True)
+
     stats = index_repository(path, reg, frecency_only=frecency_only, force=force,
                              force_stale=force_stale,
-                             on_locked=on_locked, on_start=on_start, on_file=on_file)
+                             on_locked=on_locked, on_start=on_start, on_file=on_file,
+                             on_phase=on_phase)
     if bar:
         bar.close()
     if not frecency_only and stats:

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -431,6 +431,7 @@ def index_repository(
     on_locked: str = "wait",
     on_start: Callable[[int], None] | None = None,
     on_file: Callable[[Path, int, float], None] | None = None,
+    on_phase: Callable[[str], None] | None = None,
 ) -> dict[str, int]:
     """Index all files in *repo* into T3 code__ and docs__ collections.
 
@@ -485,7 +486,7 @@ def index_repository(
                 _run_index_frecency_only(repo, registry)
                 stats: dict[str, int] = {}
             else:
-                stats = _run_index(repo, registry, chunk_lines=chunk_lines, force=force, force_stale=force_stale, on_start=on_start, on_file=on_file)
+                stats = _run_index(repo, registry, chunk_lines=chunk_lines, force=force, force_stale=force_stale, on_start=on_start, on_file=on_file, on_phase=on_phase)
                 registry.update(repo, head_hash=_current_head(repo))
             registry.update(repo, status="ready")
             return stats
@@ -960,6 +961,7 @@ def _run_index(
     force_stale: bool = False,
     on_start: Callable[[int], None] | None = None,
     on_file: Callable[[Path, int, float], None] | None = None,
+    on_phase: Callable[[str], None] | None = None,
 ) -> dict[str, int]:
     """Full indexing pipeline: classify → route → embed → upsert → prune.
 
@@ -1206,6 +1208,16 @@ def _run_index(
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)
 
+    # Post-processing phase markers (nexus-vatx Gap 2): the per-file
+    # progress bar ends at "[N/N]" but the pipeline keeps running for
+    # pruning, stamping, and catalog registration. Without markers the
+    # operator sees silence and cannot tell hung from busy.
+    post_t0 = time.monotonic()
+
+    def _phase(msg: str) -> None:
+        if on_phase is not None:
+            on_phase(msg)
+
     # Discover and index RDR markdown files → rdr__
     # Pass the local embed_fn so RDR indexing respects NX_LOCAL mode
     # (without it, the RDR branch defaulted to Voyage 1024-dim; query
@@ -1215,12 +1227,20 @@ def _run_index(
     # ``(texts, model) -> (embeddings, actual_model)``. In local mode
     # hand over the tuple-returning adapter; in cloud mode pass None so
     # doc_indexer falls back to _embed_with_fallback on its own.
+    _phase("Discovering and indexing RDR markdown files…")
+    _t = time.monotonic()
     rdr_indexed, rdr_current, rdr_failed = _discover_and_index_rdrs(
         repo, rdr_abs_paths, db, voyage_key, now_iso, force=force,
         embed_fn=_embed_fn_doc,
     )
+    _phase(
+        f"RDR indexing done — {rdr_indexed} indexed, {rdr_current} current, "
+        f"{rdr_failed} failed ({time.monotonic() - _t:.1f}s)"
+    )
 
     # Prune misclassified chunks (reclassification cleanup)
+    _phase("Pruning misclassified chunks…")
+    _t = time.monotonic()
     _prune_misclassified(
         repo, code_collection, docs_collection,
         [f for _, f in code_files],
@@ -1228,8 +1248,11 @@ def _run_index(
         [f for _, f in pdf_files],
         db,
     )
+    _phase(f"Pruning misclassified done ({time.monotonic() - _t:.1f}s)")
 
     # C3: Prune deleted files — remove chunks for files no longer in the repo
+    _phase("Pruning deleted files…")
+    _t = time.monotonic()
     all_current_paths: set[str] = set()
     for _, f in code_files:
         all_current_paths.add(str(f))
@@ -1238,9 +1261,12 @@ def _run_index(
     for _, f in pdf_files:
         all_current_paths.add(str(f))
     _prune_deleted_files(code_collection, docs_collection, all_current_paths, db)
+    _phase(f"Pruning deleted files done ({time.monotonic() - _t:.1f}s)")
 
     # Stamp pipeline version on force indexing (after all work completes)
     if force:
+        _phase("Stamping pipeline version on forced collections…")
+        _t = time.monotonic()
         stamp_collection_version(code_col)
         stamp_collection_version(docs_col)
         # Stamp RDR collection if it was indexed
@@ -1252,6 +1278,7 @@ def _run_index(
                 stamp_collection_version(rdr_col)
             except Exception:
                 _log.debug("rdr_stamp_skipped", collection=rdr_col_name)
+        _phase(f"Pipeline version stamped ({time.monotonic() - _t:.1f}s)")
 
     # Catalog hook: register indexed files (opt-in, graceful absence)
     indexed_for_catalog: list[tuple[Path, str, str]] = []
@@ -1269,6 +1296,8 @@ def _run_index(
                 for md_file in sorted(rdr_dir.rglob("*.md")):
                     if md_file.is_file():
                         indexed_for_catalog.append((md_file, "rdr", rdr_col))
+    _phase(f"Registering {len(indexed_for_catalog)} catalog entries…")
+    _t = time.monotonic()
     _catalog_hook(
         repo=repo,
         repo_name=_repo_basename,
@@ -1276,6 +1305,9 @@ def _run_index(
         head_hash=_current_head(repo),
         indexed_files=indexed_for_catalog,
     )
+    _phase(f"Catalog registration done ({time.monotonic() - _t:.1f}s)")
+
+    _phase(f"Post-processing complete ({time.monotonic() - post_t0:.1f}s)")
 
     return {"rdr_indexed": rdr_indexed, "rdr_current": rdr_current, "rdr_failed": rdr_failed}
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -577,6 +577,73 @@ def test_rdr_files_do_not_trigger_on_file(tmp_path):
     assert len(calls) == 1 and calls[0][0].name == "code.py"
 
 
+# ── on_phase post-processing callbacks (nexus-vatx Gap 2) ───────────────────
+
+
+def test_on_phase_fires_on_post_processing_phases(tmp_path):
+    """`_run_index` emits phase markers for every post-per-file-loop stage
+    so the operator can tell hung from busy after "[N/N]" finishes."""
+    run, repo = _cb_repo(tmp_path)
+    db, _ = _mock_db()
+    phases: list[str] = []
+    with _cb_patches(db, rdr=(1, 0, 0)):
+        run(repo, _reg(), on_phase=phases.append)
+
+    # The key beats: RDR start/done, prune misclassified, prune deleted,
+    # catalog registration, and the closing "complete" line.
+    joined = "\n".join(phases)
+    assert "Discovering and indexing RDR markdown files" in joined
+    assert "RDR indexing done" in joined
+    assert "Pruning misclassified chunks" in joined
+    assert "Pruning misclassified done" in joined
+    assert "Pruning deleted files" in joined
+    assert "Pruning deleted files done" in joined
+    assert "Registering" in joined and "catalog entries" in joined
+    assert "Catalog registration done" in joined
+    assert "Post-processing complete" in joined
+
+
+def test_on_phase_reports_rdr_counts(tmp_path):
+    """The RDR "done" line carries the indexed/current/failed triple so
+    operators see the same summary the final stats would show."""
+    run, repo = _cb_repo(tmp_path)
+    db, _ = _mock_db()
+    phases: list[str] = []
+    with _cb_patches(db, rdr=(4, 2, 1)):
+        run(repo, _reg(), on_phase=phases.append)
+    done = next(p for p in phases if p.startswith("RDR indexing done"))
+    assert "4 indexed" in done
+    assert "2 current" in done
+    assert "1 failed" in done
+
+
+def test_on_phase_none_is_safe(tmp_path):
+    """on_phase=None must not raise — matches on_start/on_file idiom."""
+    run, repo = _cb_repo(tmp_path)
+    db, _ = _mock_db()
+    with _cb_patches(db):
+        run(repo, _reg())  # on_phase omitted → None default
+
+
+def test_on_phase_includes_stamp_phase_on_force(tmp_path):
+    """The pipeline-version stamp phase only fires when ``force=True``."""
+    run, repo = _cb_repo(tmp_path)
+    db, _ = _mock_db()
+
+    # Without force → no stamp phase
+    phases_no_force: list[str] = []
+    with _cb_patches(db):
+        run(repo, _reg(), on_phase=phases_no_force.append)
+    assert not any("Stamping pipeline version" in p for p in phases_no_force)
+
+    # With force → stamp phase present
+    phases_force: list[str] = []
+    with _cb_patches(db):
+        run(repo, _reg(), force=True, on_phase=phases_force.append)
+    assert any("Stamping pipeline version" in p for p in phases_force)
+    assert any("Pipeline version stamped" in p for p in phases_force)
+
+
 # ── Pagination tests ────────────────────────────────────────────────────────
 
 def test_prune_deleted_files_paginates(tmp_path):


### PR DESCRIPTION
## Summary

- After the per-file `[N/N]` progress bar ends, `_run_index` keeps running for RDR discovery, misclassified-chunk pruning, deleted-file pruning, pipeline-version stamping, and catalog registration — operator saw silence and could not tell hung from busy. The 2026-04-17 Delos re-index was reported as "indeterminate — still running after 1801/1801 files."
- Adds an `on_phase: Callable[[str], None] | None` callback threaded through `index_repository` → `_run_index`. Each phase emits a `[post] <msg>` line carrying start + done + elapsed timing. The `nx index` CLI wires the callback to `click.echo(..., err=True)` so markers are visible even when stdout is redirected.

Example operator-visible sequence:

```
  [post] Discovering and indexing RDR markdown files…
  [post] RDR indexing done — 4 indexed, 2 current, 1 failed (3.1s)
  [post] Pruning misclassified chunks…
  [post] Pruning misclassified done (0.4s)
  [post] Pruning deleted files…
  [post] Pruning deleted files done (0.2s)
  [post] Registering 1801 catalog entries…
  [post] Catalog registration done (2.3s)
  [post] Post-processing complete (6.1s)
```

Closes **Gap 2** of `nexus-vatx`. Gaps 3–5 (ETA line, per-stage timers, `doctor --check=quotas`) remain for follow-up PRs.

## Test plan

- [x] `uv run pytest tests/test_indexer.py -k on_phase` — 4 new cases pass (per-phase firing, RDR count summary, None default safe, force-only stamp phase)
- [x] `uv run pytest tests/test_indexer.py tests/test_index_cmd.py tests/test_index_rdr_cmd.py` — 113 passed

Part of nexus-vatx (bead remains open for Gaps 3–5).