### PR TITLE
fix(collection): nx collection health chunk_count comes from T3, not catalog (nexus-39zi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`nx collection health` chunk count now comes from T3, not the catalog** (nexus-39zi). The old report computed ``chunk_count`` as ``SELECT SUM(chunk_count) FROM catalog.documents WHERE physical_collection = ?``, which silently drifted to 0 on 129/143 production collections because the catalog's ``chunk_count`` column is only written by the paths that register through the catalog — direct ``store_put``, cloud-side operations, and tenants that predate the column leave it untouched. The 2026-04-18 live shakeout surfaced the drift: ``nx collection list`` showed ``code__ART-8c2e74c0`` with 63 077 chunks while ``nx collection health --format=json`` reported 0. Health now calls ``coll.count()`` on the live T3 collection (the same source ``nx collection list`` uses) so the two commands cannot disagree. A new `chunk_count_fn` parameter on `compute_collection_health` makes the source injectable for tests; the existing `catalog_stats_fn` still owns `last_indexed` and `orphan_count` (catalog-side properties). Four new tests pin the precedence rule, the exact drift case from the live shakeout, backward-compat for legacy callers, and the removal of ``chunk_count`` from ``_default_catalog_stats_fn``'s return. Same PR also folds the `_default_chash_coverage_fn` to use the public `ChashIndex.count_for_collection()` method instead of reaching into `_lock` (carryover from the review-remediation sweep that missed this site).
+
 ## [4.8.0] - 2026-04-18
 
 ### Added

--- a/src/nexus/collection_health.py
+++ b/src/nexus/collection_health.py
@@ -82,28 +82,36 @@ def _open_catalog():
 
 
 def _default_catalog_stats_fn(col: str) -> dict[str, Any]:
-    """Return ``{chunk_count, last_indexed, orphan_count}`` for *col*.
+    """Return ``{last_indexed, orphan_count}`` for *col* from the catalog.
 
-    Uses the catalog cache DB. ``chunk_count`` is the SUM across every
-    document in the collection; ``last_indexed`` is the MAX of
-    ``indexed_at``; ``orphan_count`` is the count of documents in this
-    collection that have zero incoming links.
+    ``last_indexed`` is the MAX of ``indexed_at`` across documents in
+    the collection; ``orphan_count`` is the count of documents that
+    have zero incoming links. Both properties are purely catalog-side
+    (the catalog is authoritative for its own rows and for the link
+    graph).
+
+    ``chunk_count`` is deliberately NOT returned here — the catalog's
+    ``chunk_count`` column drifts from T3 reality whenever a write
+    path skips the catalog registration step (direct ``store_put``,
+    cloud-side operations, tenants that predate the catalog column).
+    Ground-truth chunk counts come from T3 via :func:`_default_chunk_count_fn`
+    so ``nx collection health`` and ``nx collection list`` cannot
+    disagree (nexus-39zi).
     """
     cat = _open_catalog()
     if cat is None:
-        return {"chunk_count": 0, "last_indexed": None, "orphan_count": 0}
+        return {"last_indexed": None, "orphan_count": 0}
     try:
         # Catalog's SQL cache lives behind private attributes; an
         # explicit public accessor doesn't exist yet and isn't worth
         # adding just for this read-only path.
         conn = cat._db._conn  # noqa: SLF001
         row = conn.execute(
-            "SELECT COALESCE(SUM(chunk_count), 0), MAX(indexed_at) "
+            "SELECT MAX(indexed_at) "
             "FROM documents WHERE physical_collection = ?",
             (col,),
         ).fetchone()
-        chunk_count = int(row[0] or 0)
-        last_indexed = row[1] if row and row[1] else None
+        last_indexed = row[0] if row and row[0] else None
         orphan_row = conn.execute(
             "SELECT COUNT(*) FROM documents d "
             "LEFT JOIN links l ON d.tumbler = l.to_tumbler "
@@ -112,12 +120,38 @@ def _default_catalog_stats_fn(col: str) -> dict[str, Any]:
         ).fetchone()
         orphan_count = int(orphan_row[0] or 0)
         return {
-            "chunk_count": chunk_count,
             "last_indexed": last_indexed,
             "orphan_count": orphan_count,
         }
     except Exception:
-        return {"chunk_count": 0, "last_indexed": None, "orphan_count": 0}
+        return {"last_indexed": None, "orphan_count": 0}
+
+
+def _default_chunk_count_fn(col: str) -> int:
+    """Return the T3 chunk count for *col* — the ground-truth number.
+
+    Queries ``col.count()`` on the live T3 ChromaDB collection. This is
+    the same source ``nx collection list`` reads, so the health report
+    and the list command cannot disagree (nexus-39zi, 2026-04-18 live
+    shakeout finding: catalog-sourced count drifted to 0 for 129/143
+    collections on production).
+
+    Returns 0 on any failure — T3 unreachable, collection missing,
+    transient network error. The catalog-sourced ``last_indexed``
+    remains meaningful even when the T3 number is stale, so a 0 here
+    renders as an operator-visible "nothing to count" without
+    cascading errors elsewhere in the report.
+    """
+    try:
+        from nexus.db import make_t3
+        t3 = make_t3()
+        try:
+            coll = t3.get_or_create_collection(col)
+            return int(coll.count())
+        except Exception:
+            return 0
+    except Exception:
+        return 0
 
 
 def _open_t2():
@@ -239,13 +273,7 @@ def _default_chash_coverage_fn(col: str) -> float | None:
 
     idx = ChashIndex(db_path)
     try:
-        with idx._lock:
-            row = idx.conn.execute(
-                "SELECT COUNT(*) FROM chash_index "
-                "WHERE physical_collection = ?",
-                (col,),
-            ).fetchone()
-        chash_count = int(row[0] or 0)
+        chash_count = idx.count_for_collection(col)
     finally:
         idx.close()
 
@@ -267,6 +295,7 @@ def _default_chash_coverage_fn(col: str) -> float | None:
 # Module-level runner bindings — tests monkeypatch these directly.
 _enumerate_collections = _default_enumerate_collections
 _catalog_stats_fn = _default_catalog_stats_fn
+_chunk_count_fn = _default_chunk_count_fn
 _telemetry_stats_fn = _default_telemetry_stats_fn
 _projection_rank_fn = _default_projection_rank_fn
 _hub_score_fn = _default_hub_score_fn
@@ -283,11 +312,20 @@ def compute_collection_health(
     telemetry_stats_fn: Callable[[str], dict[str, Any]],
     projection_rank_fn: Callable[[list[str]], dict[str, int]],
     hub_score_fn: Callable[[str], float | None],
+    chunk_count_fn: Callable[[str], int] | None = None,
     chash_coverage_fn: Callable[[str], float | None] | None = None,
 ) -> list[CollectionHealthRow]:
     """Assemble per-collection health rows from the injected callables.
 
     Ordering follows *collections*; callers sort via ``format_health_table``.
+
+    ``chunk_count_fn`` (nexus-39zi) returns the ground-truth chunk count
+    from T3 for each collection. Optional only for backward-compat with
+    pre-39zi callers that still use ``catalog_stats_fn`` as the
+    chunk-count source. Production callers always pass it — the
+    catalog-sourced count drifts to 0 for most collections on tenants
+    that predate the catalog's ``chunk_count`` column. When both are
+    present, ``chunk_count_fn`` wins.
 
     ``chash_coverage_fn`` is optional only for backward-compat with the
     pre-nexus-c2op signature; production callers always pass it.
@@ -297,10 +335,18 @@ def compute_collection_health(
     for col in collections:
         catalog = catalog_stats_fn(col) or {}
         tel = telemetry_stats_fn(col) or {}
+        # T3 is the ground truth for chunk count. Fall back to the
+        # catalog's number only when no ``chunk_count_fn`` was injected
+        # (legacy callers) — NEVER mix the two sources inside a single
+        # row, as that would create asymmetric reporting.
+        if chunk_count_fn is not None:
+            chunk_count = int(chunk_count_fn(col))
+        else:
+            chunk_count = int(catalog.get("chunk_count", 0))
         rows.append(
             CollectionHealthRow(
                 name=col,
-                chunk_count=int(catalog.get("chunk_count", 0)),
+                chunk_count=chunk_count,
                 last_indexed=catalog.get("last_indexed"),
                 zero_hit_rate_30d=tel.get("zero_hit_rate"),
                 median_query_distance_30d=tel.get("median_top_distance"),
@@ -413,6 +459,7 @@ def run_collection_health(*, sort_by: str = "name", fmt: str = "table") -> str:
     rows = compute_collection_health(
         collections,
         catalog_stats_fn=_catalog_stats_fn,
+        chunk_count_fn=_chunk_count_fn,
         telemetry_stats_fn=_telemetry_stats_fn,
         projection_rank_fn=_projection_rank_fn,
         hub_score_fn=_hub_score_fn,

--- a/tests/test_collection_health.py
+++ b/tests/test_collection_health.py
@@ -150,6 +150,17 @@ def _fake_chash_coverage(col: str) -> float | None:
     }.get(col)
 
 
+def _fake_chunk_count(col: str) -> int:
+    """T3-sourced chunk counts (nexus-39zi). The real implementation
+    reads ``coll.count()`` on the live ChromaDB collection; tests
+    return deterministic fake values."""
+    return {
+        "code__alpha": 120,
+        "docs__beta": 30,
+        "docs__stale": 0,
+    }.get(col, 0)
+
+
 class TestComputeCollectionHealth:
     def test_rows_assemble_from_injected_fns(self) -> None:
         from nexus.collection_health import compute_collection_health
@@ -210,6 +221,97 @@ class TestComputeCollectionHealth:
             chash_coverage_fn=_fake_chash_coverage,
         )
         assert rows[0].hub_domination_score is None
+
+
+# ── chunk_count sourcing (nexus-39zi) ──────────────────────────────────────
+
+
+class TestChunkCountFromT3:
+    """Chunk count must come from T3's live ``coll.count()``, not the
+    catalog's ``SUM(chunk_count)`` column. The catalog drifts when a
+    write path skips catalog registration (direct ``store_put``,
+    cloud-side operations, pre-catalog tenants) — reporting catalog-
+    sourced counts puts ``nx collection health`` out of sync with
+    ``nx collection list``.
+    """
+
+    def test_chunk_count_fn_wins_over_catalog(self) -> None:
+        """When both sources are present, ``chunk_count_fn`` takes
+        precedence. Ground truth is T3, not the catalog cache."""
+        from nexus.collection_health import compute_collection_health
+
+        # Catalog reports 120; T3 reports 500. T3 must win.
+        def _t3_chunk_count(col: str) -> int:
+            return {"code__alpha": 500}.get(col, 0)
+
+        rows = compute_collection_health(
+            ["code__alpha"],
+            catalog_stats_fn=_fake_catalog_stats,  # returns chunk_count=120
+            telemetry_stats_fn=_fake_telemetry_stats,
+            projection_rank_fn=_fake_projection_ranks,
+            hub_score_fn=_fake_hub_score,
+            chunk_count_fn=_t3_chunk_count,
+            chash_coverage_fn=_fake_chash_coverage,
+        )
+        assert rows[0].chunk_count == 500, (
+            f"chunk_count_fn must override catalog-sourced count; "
+            f"got {rows[0].chunk_count}"
+        )
+
+    def test_drift_case_catalog_says_zero_t3_says_positive(self) -> None:
+        """The exact regression from 2026-04-18 live shakeout: catalog
+        reports 0 for most production collections while T3 has real
+        counts. Health must surface the real T3 count so the report
+        cannot silently disagree with ``nx collection list``."""
+        from nexus.collection_health import compute_collection_health
+
+        def _catalog_zero(col: str) -> dict:
+            return {"last_indexed": "2026-04-15", "orphan_count": 0}
+
+        def _t3_has_chunks(col: str) -> int:
+            return 63077  # like code__ART-8c2e74c0 on the live probe
+
+        rows = compute_collection_health(
+            ["code__ART-8c2e74c0"],
+            catalog_stats_fn=_catalog_zero,
+            telemetry_stats_fn=_fake_telemetry_stats,
+            projection_rank_fn=_fake_projection_ranks,
+            hub_score_fn=_fake_hub_score,
+            chunk_count_fn=_t3_has_chunks,
+            chash_coverage_fn=_fake_chash_coverage,
+        )
+        assert rows[0].chunk_count == 63077
+
+    def test_fallback_to_catalog_when_fn_not_injected(self) -> None:
+        """Backward-compat: callers without ``chunk_count_fn`` still
+        read from catalog stats. This preserves the pre-39zi signature
+        for legacy test fixtures while production paths plumb T3."""
+        from nexus.collection_health import compute_collection_health
+
+        rows = compute_collection_health(
+            ["code__alpha"],
+            catalog_stats_fn=_fake_catalog_stats,
+            telemetry_stats_fn=_fake_telemetry_stats,
+            projection_rank_fn=_fake_projection_ranks,
+            hub_score_fn=_fake_hub_score,
+            # no chunk_count_fn — fall through to catalog
+            chash_coverage_fn=_fake_chash_coverage,
+        )
+        # _fake_catalog_stats returns chunk_count=120 for code__alpha
+        assert rows[0].chunk_count == 120
+
+    def test_default_catalog_stats_no_longer_returns_chunk_count(self) -> None:
+        """The production ``_default_catalog_stats_fn`` dropped the
+        ``chunk_count`` key after 39zi. Production catalog paths now
+        return only ``last_indexed`` and ``orphan_count``; chunk count
+        comes from the T3-sourced ``_default_chunk_count_fn``."""
+        from nexus.collection_health import _default_catalog_stats_fn
+
+        stats = _default_catalog_stats_fn("does-not-matter")
+        assert "chunk_count" not in stats, (
+            "catalog stats must not surface chunk_count any more — T3 is "
+            "the source of truth, catalog drifted to 0 on prod (nexus-39zi)"
+        )
 
 
 # ── Chash coverage (RDR-087 Phase 4.6) ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Surfaced during the 2026-04-18 live 4.8.0 shakeout: \`nx collection health --format=json\` against production reported \`chunk_count: 0\` for **129 of 143** collections while \`nx collection list\` showed real numbers (e.g. \`code__ART-8c2e74c0\` = 63,077 chunks in list, 0 in health).

## Root cause

\`_default_catalog_stats_fn\` sourced \`chunk_count\` from \`SELECT SUM(chunk_count) FROM catalog.documents WHERE physical_collection = ?\`. The catalog's \`chunk_count\` column only gets written by the paths that register through the catalog — direct \`store_put\`, cloud-side operations, and tenants that predate the column leave it at 0 forever. The \`list\` command asks T3 directly via \`coll.count()\` so the two surfaces diverge in the field.

## Fix

- Split chunk_count out of \`_default_catalog_stats_fn\`; it now returns only \`{last_indexed, orphan_count}\` (pure catalog properties).
- New \`_default_chunk_count_fn(col) -> int\` calls \`coll.count()\` on the live T3 collection — same source as \`nx collection list\`.
- \`compute_collection_health\` gains a \`chunk_count_fn\` parameter; when provided it wins over any catalog-sourced number. Backward-compatible for callers that don't pass it (legacy test fixtures).
- \`run_collection_health\` wires \`_default_chunk_count_fn\` through.

## Bonus cleanup

\`_default_chash_coverage_fn\` was still reaching into \`ChashIndex._lock\` + \`.conn\` directly — a holdover the review-remediation sweep missed. Now uses the public \`ChashIndex.count_for_collection()\` method added in that same sweep.

## Not a 4.8.0 regression

\`nx collection health\` was introduced in PR #194 (nexus-yi4b.3.4) as part of v4.7.0. The catalog-sourced chunk_count has been the behaviour since then; v4.8.0 only added the chash_index_coverage column alongside.

## Test plan

- [x] \`uv run pytest tests/test_collection_health.py\` — 26 passed (4 new regression cases + 22 existing).
- [x] **Live verification on production cloud**: 144/144 collections now agree between \`health\` and \`list\` (was 14/143 before). code__ART correctly reports 63077 chunks.

Closes nexus-39zi.