### PR TITLE
fix(catalog): guard NoneType meta + SS null fields (nexus-8d6e)

### DIFF
--- a/src/nexus/bib_enricher.py
+++ b/src/nexus/bib_enricher.py
@@ -59,14 +59,14 @@ def enrich(title: str) -> dict[str, Any]:
                 return {}
             paper = data[0]
             refs = [
-                r.get("paperId", "") for r in paper.get("references", [])
+                r.get("paperId", "") for r in (paper.get("references") or [])
                 if r and r.get("paperId")
             ]
             return {
                 "year": paper.get("year", 0) or 0,
                 "venue": paper.get("venue", "") or "",
                 "authors": ", ".join(
-                    a.get("name", "") for a in paper.get("authors", [])[:5]
+                    a.get("name", "") for a in (paper.get("authors") or [])[:5]
                 ),
                 "citation_count": paper.get("citationCount", 0) or 0,
                 "semantic_scholar_id": paper.get("paperId", "") or "",

--- a/src/nexus/catalog/link_generator.py
+++ b/src/nexus/catalog/link_generator.py
@@ -34,10 +34,11 @@ def generate_citation_links(cat: Catalog) -> int:
     entries_with_refs: list[tuple[Tumbler, list[str]]] = []
 
     for entry in entries:
-        ss_id = entry.meta.get("bib_semantic_scholar_id", "")
+        meta = entry.meta or {}
+        ss_id = meta.get("bib_semantic_scholar_id", "")
         if ss_id:
             id_to_tumbler[ss_id] = entry.tumbler
-        refs = entry.meta.get("references", [])
+        refs = meta.get("references", [])
         if refs:
             entries_with_refs.append((entry.tumbler, refs))
 

--- a/tests/test_bib_enricher.py
+++ b/tests/test_bib_enricher.py
@@ -165,3 +165,18 @@ def test_enrich_malformed_json():
         result = enrich("Some Paper Title")
 
     assert result == {}
+
+
+def test_enrich_null_references_and_authors():
+    """SS returns explicit null for references/authors — must not crash (nexus-8d6e)."""
+    from nexus.bib_enricher import enrich
+
+    paper = dict(_VALID_PAPER, references=None, authors=None)
+    mock_resp = _make_response(200, {"data": [paper]})
+
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich("Paper With Null Fields")
+
+    assert result["references"] == []
+    assert result["authors"] == ""
+    assert result["semantic_scholar_id"] == "abc123"

--- a/tests/test_link_generator.py
+++ b/tests/test_link_generator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from nexus.catalog.catalog import Catalog
-from nexus.catalog.link_generator import generate_rdr_filepath_links
+from nexus.catalog.link_generator import generate_citation_links, generate_rdr_filepath_links
 
 
 class TestRdrFilepathLinks:
@@ -160,3 +160,43 @@ class TestIncrementalRdrFilepathLinking:
         # Process rdr1 explicitly — should create 1 link
         count2 = generate_rdr_filepath_links(cat, new_tumblers=[rdr1])
         assert count2 == 1
+
+
+class TestCitationLinksNoneMeta:
+    """generate_citation_links must tolerate entries with meta=None (nexus-8d6e)."""
+
+    def _make_catalog(self, tmp_path: Path) -> Catalog:
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        (cat_dir / "owners.jsonl").touch()
+        (cat_dir / "documents.jsonl").touch()
+        (cat_dir / "links.jsonl").touch()
+        return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+    def test_meta_none_does_not_crash(self, tmp_path: Path) -> None:
+        """Entries with meta=None (legacy rows) are skipped without crashing."""
+        from unittest.mock import patch
+
+        from nexus.catalog.catalog import CatalogEntry
+        from nexus.catalog.tumbler import Tumbler
+
+        cat = self._make_catalog(tmp_path)
+        # Construct a CatalogEntry with meta=None — the shape seen on legacy
+        # JSONL rows where the "meta" key was absent when parsed.
+        legacy = CatalogEntry(
+            tumbler=Tumbler.parse("1.1.1"),
+            title="legacy",
+            author="",
+            year=0,
+            content_type="code",
+            file_path="src/x.py",
+            corpus="default",
+            physical_collection="code__x",
+            chunk_count=1,
+            head_hash="",
+            indexed_at="",
+            meta=None,  # type: ignore[arg-type]
+        )
+        with patch.object(cat, "all_documents", return_value=[legacy]):
+            count = generate_citation_links(cat)
+        assert count == 0


### PR DESCRIPTION
## Summary

Two related crashes surfaced during knowledge__delos hygiene for the blog-post-1 demo:

- `link_generator.generate_citation_links` crashed with `AttributeError: 'NoneType' object has no attribute 'get'` on six legacy catalog entries whose `meta` field is `None` (absent in older JSONL rows).
- `bib_enricher.enrich` crashed with `TypeError: 'NoneType' object is not iterable` when Semantic Scholar returns explicit `null` (not omitted) for `references` or `authors`.

Both paths blocked `nx catalog generate-links --citations` and the auto-citation pass at the end of `nx enrich`.

## Changes

- `src/nexus/catalog/link_generator.py`: guard `entry.meta` via `(entry.meta or {}).get(...)`
- `src/nexus/bib_enricher.py`: guard `paper.get("references")` and `paper.get("authors")` via `(x or [])`
- Regression tests in both `tests/test_bib_enricher.py` and `tests/test_link_generator.py`

## Test plan
- [x] `uv run pytest tests/test_bib_enricher.py tests/test_link_generator.py` — 18 passed, incl. 2 new
- [x] Reproduced original crashes on `main` with a legacy catalog entry and an SS `references: null` response
- [x] Confirmed `nx catalog generate-links --citations` now completes cleanly against production catalog
- [x] Confirmed `nx enrich knowledge__delos` no longer crashes on null references

Closes nexus-8d6e.