### PR TITLE
feat: surface Node.js dependency for the Claude Code plugin (docs + doctor + preflight)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs
 ## Prerequisites
 
 - Python 3.12–3.13, [`uv`](https://docs.astral.sh/uv/), `git`
+- For the Claude Code plugin: [Node.js](https://nodejs.org/) (provides `npx`) — the bundled `sequential-thinking` and `context7` MCP servers are spawned via `npx`. The `nx` CLI alone does not need it.
 - For cloud embeddings (optional): [ChromaDB Cloud](https://www.trychroma.com/) + [Voyage AI](https://www.voyageai.com/) accounts (free tiers available)
 - For hybrid search: [`ripgrep`](https://github.com/BurntSushi/ripgrep)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,6 +5,7 @@
 - **Python 3.12 or 3.13** (3.14 is not yet supported — [upstream dependency issue](https://github.com/pydantic/pydantic/issues))
 - **[uv](https://docs.astral.sh/uv/)** — Python package manager
 - **git**
+- **[Node.js](https://nodejs.org/)** — required *only* if you install the Claude Code plugin. The plugin bundles the `sequential-thinking` and `context7` MCP servers, both spawned via `npx -y …`, which requires `node` and `npm` on PATH. The `nx` CLI alone does not need it. Install with `brew install node` (macOS) or follow the [Node.js installer](https://nodejs.org/) for your platform.
 
 Check your Python version:
 
@@ -94,6 +95,8 @@ See [Document Catalog](catalog.md) for details.
 ## Claude Code plugin (optional)
 
 The `nx` plugin gives Claude Code agents access to all three storage tiers, 13 specialized agents, and 43 skills covering the RDR lifecycle, plan-centric retrieval, and development workflows.
+
+**Plugin-only prerequisite: [Node.js](https://nodejs.org/).** The plugin's `sequential-thinking` and `context7` MCP servers are spawned via `npx -y …` and silently fail to start without `node`/`npm` on PATH. Install with `brew install node` (macOS) or your platform's installer before running the plugin commands below.
 
 ```bash
 /plugin marketplace add Hellblazer/nexus

--- a/nx/commands/nx-preflight.md
+++ b/nx/commands/nx-preflight.md
@@ -68,7 +68,27 @@ disable-model-invocation: false
   fi
   echo ""
 
-  # ── 5. CLAUDE.md Agent Readiness ────────────────────────────────────────────
+  # ── 5. Node.js / npx (plugin MCP servers) ───────────────────────────────────
+  echo "### 5. Node.js / npx (required by plugin MCP servers)"
+  echo ""
+  if command -v npx &>/dev/null; then
+    NODE_VERSION=$(node --version 2>&1)
+    NPX_PATH=$(command -v npx)
+    echo "Status: PASS"
+    echo "Node: $NODE_VERSION"
+    echo "npx:  $NPX_PATH"
+  else
+    echo "Status: FAIL"
+    echo "npx not found in PATH — the plugin's sequential-thinking and context7 MCP"
+    echo "servers are spawned via 'npx -y …' and will silently fail to start."
+    echo "Install:"
+    echo "  brew install node                         (macOS)"
+    echo "  apt install nodejs npm                    (Ubuntu/Debian)"
+    echo "  https://nodejs.org/                       (other platforms)"
+  fi
+  echo ""
+
+  # ── 6. CLAUDE.md Agent Readiness ────────────────────────────────────────────
   echo "### 6. CLAUDE.md Agent Readiness"
   echo ""
   if [ -f "CLAUDE.md" ]; then
@@ -116,6 +136,7 @@ Based on the preflight output above, produce a summary table:
 | nx doctor | — | — |
 | bd (beads) | — | — |
 | uv | — | — |
+| Node.js / npx | — | — |
 | CLAUDE.md | — | — |
 
 Fill in each row from the check results above. Use "PASS", "FAIL", or "WARN" for Status. Leave Action needed blank for passing checks; for failures/warnings, provide the install command or link.

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -414,6 +414,28 @@ def _check_tools() -> list[HealthResult]:
             fix_suggestions=["https://github.com/BeadsProject/beads"],
         ))
 
+    # npx (Node.js, plugin-only)
+    # Required by the nx Claude Code plugin, which spawns the
+    # ``sequential-thinking`` and ``context7`` MCP servers via ``npx -y …``.
+    # The CLI alone does not need it, so this is non-fatal — but a missing
+    # ``npx`` causes silent MCP-server failures the moment a plugin tool is
+    # invoked. Reported as informational so plugin users see the gap before
+    # they hit it at runtime.
+    npx_path = shutil.which("npx")
+    if npx_path:
+        results.append(HealthResult(label="npx (Node.js, plugin-only)", ok=True, detail=npx_path))
+    else:
+        results.append(HealthResult(
+            label="npx (Node.js, plugin-only)",
+            ok=True,
+            detail="not found — plugin MCP servers (sequential-thinking, context7) will fail",
+            fix_suggestions=[
+                "brew install node                         (macOS)",
+                "apt install nodejs npm                    (Ubuntu/Debian)",
+                "https://nodejs.org/                       (other platforms)",
+            ],
+        ))
+
     return results
 
 

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -150,6 +150,19 @@ def test_doctor_missing_bd_output(runner, mock_reg):
     assert "BeadsProject/beads" in result.output
 
 
+def test_doctor_missing_npx_is_non_fatal_with_plugin_hint(runner, mock_reg):
+    """Missing npx is plugin-only — non-fatal for the CLI but reported with
+    a clear hint that the plugin's MCP servers will fail without it."""
+    def which_side(name):
+        return None if name == "npx" else f"/usr/bin/{name}"
+    result = _invoke(runner, mock_reg, which=which_side)
+    assert result.exit_code == 0, "missing npx must not fail nx doctor (plugin-only)"
+    assert "npx (Node.js, plugin-only)" in result.output
+    assert "not found" in result.output
+    assert "sequential-thinking" in result.output or "context7" in result.output
+    assert "nodejs.org" in result.output
+
+
 # ── Python version ──────────────────────────────────────────────────────────
 
 def test_doctor_python_version_too_old_fails(runner, mock_reg):


### PR DESCRIPTION
## Summary

Two MCP servers in the `nx` plugin set are spawned via `npx -y …` and silently fail to start without `node`/`npm` on PATH:

- `sequential-thinking` — declared in `nx/.mcp.json` (`@modelcontextprotocol/server-sequential-thinking`)
- `context7` — declared in `sn/.mcp.json` (`@upstash/context7-mcp`)

Neither `nx doctor` nor `/nx:nx-preflight` caught this, so users with a fresh machine missing Node.js had **no signal** until they tried to use a plugin tool inside Claude Code, at which point the failure mode was a quiet "tool didn't respond" with no obvious diagnosis path.

This PR closes that gap on three surfaces: docs, `nx doctor`, and `/nx:nx-preflight`.

## Changes

### Docs (commit 1)

- **`README.md`** — added a Node.js bullet to the Prerequisites section, scoped *"For the Claude Code plugin"*, with the explanation of which servers need it and a note that the CLI alone is unaffected.
- **`docs/getting-started.md`** — same prerequisite added to the top-level Prerequisites list, plus a more direct in-place reminder right before the `/plugin install` command in the *Claude Code plugin (optional)* section.

### `nx doctor` + `/nx:nx-preflight` (commit 2)

- **`src/nexus/health.py`** — `_check_tools()` now reports an `npx (Node.js, plugin-only)` line. **Non-fatal** because the CLI alone doesn't need it; the detail message and `fix_suggestions` explain the plugin coupling so plugin users understand why the line is there. Verified live: `✓ npx (Node.js, plugin-only): /opt/homebrew/bin/npx`.
- **`nx/commands/nx-preflight.md`** — new section 5 between `uv` and CLAUDE.md that bash-checks for `npx` and **FAILs** if missing (preflight is explicitly checking plugin readiness, so the stricter outcome is right). Summary table gains a `Node.js / npx` row.
- **`tests/test_doctor_cmd.py`** — new test `test_doctor_missing_npx_is_non_fatal_with_plugin_hint` asserts the missing-npx case reports the right label, the not-found message, the named MCP servers it affects, and a `nodejs.org` install hint, while keeping `exit_code == 0` (CLI users without the plugin shouldn't get a failure here).

## Test plan

- [x] `uv run pytest tests/test_doctor_cmd.py` — 41 passed (incl. new test) in 27.4s
- [x] `nx doctor` smoke-tested locally; new line renders correctly with both present and absent npx
- [x] Markdown renders correctly in both READMEs
- [x] Docs claim the preflight checks for Node — and now it actually does