### PR TITLE
fix(plugin): declare + enforce Python >=3.12 across all plugin hooks

### DIFF
--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -7,5 +7,8 @@
     "url": "https://github.com/Hellblazer"
   },
   "repository": "https://github.com/Hellblazer/nexus",
-  "license": "AGPL-3.0-or-later"
+  "license": "AGPL-3.0-or-later",
+  "engines": {
+    "python": ">=3.12"
+  }
 }

--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -16,12 +16,12 @@
           },
           {
             "type": "command",
-            "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/scripts/session_start_hook.py",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/session_start_hook.py",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/scripts/rdr_hook.py",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/rdr_hook.py",
             "timeout": 10
           },
           {
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/scripts/stop_failure_hook.py",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/stop_failure_hook.py",
             "timeout": 5
           }
         ]

--- a/nx/hooks/scripts/_run_python_hook.sh
+++ b/nx/hooks/scripts/_run_python_hook.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Wrapper that picks a Python interpreter satisfying the plugin's >=3.12
+# requirement and execs the given hook script under it.
+#
+# Probes higher versions first so a system that has python3.13 on PATH
+# uses it even when unqualified `python3` resolves to something older
+# (the common macOS case where /Library/Frameworks/Python.framework
+# wins PATH precedence over /opt/homebrew/bin). Falls back to plain
+# `python3` last — if that happens to be too old, the hook script's own
+# `sys.version_info < (3, 12)` guard surfaces a clean actionable error
+# rather than the worse parser-failure modes we'd see otherwise.
+#
+# Usage:
+#   bash _run_python_hook.sh /abs/path/to/hook_script.py [args...]
+
+set -u
+
+# Order matches conexus's supported Python range (>=3.12,<3.14 in
+# pyproject.toml). If conexus widens that range, add new versions here.
+for py in python3.13 python3.12; do
+  if command -v "$py" >/dev/null 2>&1; then
+    exec "$py" "$@"
+  fi
+done
+
+# Last resort: plain python3. Hook script's own version guard handles
+# the too-old case loudly. If python3 happens to be 3.14+, the hook
+# itself runs fine (hooks are stdlib-only) but downstream `nx ...`
+# subprocess calls will fail since conexus isn't installable there.
+exec python3 "$@"

--- a/nx/hooks/scripts/rdr_hook.py
+++ b/nx/hooks/scripts/rdr_hook.py
@@ -1,9 +1,19 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """SessionStart hook: detect RDR dir, reconcile file↔T2 status, report."""
+from __future__ import annotations
+
+import sys
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx plugin hook requires Python 3.12+, got {sys.version.split()[0]}\n"
+        f"  Resolved: {sys.executable}\n"
+        f"  Install: brew install python@3.13 (macOS) | apt install python3.12 (Ubuntu) | uv python install 3.12\n"
+    )
+    sys.exit(1)
+
 import re
 import subprocess
-import sys
 from collections import Counter
 from pathlib import Path
 

--- a/nx/hooks/scripts/read_verification_config.py
+++ b/nx/hooks/scripts/read_verification_config.py
@@ -5,9 +5,17 @@ Standalone script for hook consumption — no nexus package imports.
 """
 from __future__ import annotations
 
+import sys
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx plugin hook requires Python 3.12+, got {sys.version.split()[0]}\n"
+        f"  Resolved: {sys.executable}\n"
+        f"  Install: brew install python@3.13 (macOS) | apt install python3.12 (Ubuntu) | uv python install 3.12\n"
+    )
+    sys.exit(1)
+
 import json
 import os
-import sys
 from pathlib import Path
 
 DEBUG = os.environ.get("NX_HOOK_DEBUG", "0") == "1"

--- a/nx/hooks/scripts/session_start_hook.py
+++ b/nx/hooks/scripts/session_start_hook.py
@@ -5,11 +5,20 @@ SessionStart hook: Load project context via nx CLI.
 Surfaces T2 memory, beads, and scratch into Claude's session context.
 Output goes to stdout and is injected into Claude's session context.
 """
+from __future__ import annotations
+
+import sys
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx plugin hook requires Python 3.12+, got {sys.version.split()[0]}\n"
+        f"  Resolved: {sys.executable}\n"
+        f"  Install: brew install python@3.13 (macOS) | apt install python3.12 (Ubuntu) | uv python install 3.12\n"
+    )
+    sys.exit(1)
 
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 # Configuration via environment variables

--- a/nx/hooks/scripts/stop_failure_hook.py
+++ b/nx/hooks/scripts/stop_failure_hook.py
@@ -6,11 +6,19 @@ for side effects: bd remember (all failures) and bd create (rate_limit only).
 """
 from __future__ import annotations
 
+import sys
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx plugin hook requires Python 3.12+, got {sys.version.split()[0]}\n"
+        f"  Resolved: {sys.executable}\n"
+        f"  Install: brew install python@3.13 (macOS) | apt install python3.12 (Ubuntu) | uv python install 3.12\n"
+    )
+    sys.exit(1)
+
 import json
 import os
 import shutil
 import subprocess
-import sys
 from datetime import datetime, timezone
 
 DEBUG = os.environ.get("NX_HOOK_DEBUG", "0") == "1"

--- a/nx/hooks/scripts/t2_prefix_scan.py
+++ b/nx/hooks/scripts/t2_prefix_scan.py
@@ -16,7 +16,16 @@ Cap algorithm:
   Cross-namespace hard cap: 15 rendered entries total (snippet or title).
   Namespaces are processed in recency order (most-recently-updated first).
 """
+from __future__ import annotations
+
 import sys
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx plugin hook requires Python 3.12+, got {sys.version.split()[0]}\n"
+        f"  Resolved: {sys.executable}\n"
+        f"  Install: brew install python@3.13 (macOS) | apt install python3.12 (Ubuntu) | uv python install 3.12\n"
+    )
+    sys.exit(1)
 
 _HARD_CAP = 15       # max rendered entries across all namespaces combined
 _SNIPPET_LIMIT = 5   # per-namespace: entries up to this rank get a snippet

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -424,6 +425,60 @@ class TestHooks:
         )
         assert "Python 3.12+" in head, (
             f"{script_name}: version guard does not include the 'Python 3.12+' user-facing message"
+        )
+
+    def test_python_hook_runner_helper_present_and_executable(self) -> None:
+        """The hooks.json command lines route Python hook invocations through
+        ``_run_python_hook.sh`` so a system whose default ``python3`` is older
+        than 3.12 still picks up a usable Python (probing python3.13 then
+        python3.12 explicitly, falling back to plain ``python3``).
+
+        Without this layer, hook invocations resolved ``python3`` directly
+        and broke under macOS framework Python installs (3.10) that win
+        PATH precedence over Homebrew's 3.13. The hook script's runtime
+        version guard fires as a defence-in-depth backstop.
+        """
+        helper = PLUGIN_DIR / "hooks" / "scripts" / "_run_python_hook.sh"
+        assert helper.exists(), f"missing Python hook runner: {helper}"
+        # Executable bit must be set; the json command invokes it directly.
+        assert os.access(helper, os.X_OK), f"helper is not executable: {helper}"
+        text = helper.read_text()
+        # Assert the version preference is encoded — anyone removing the
+        # python3.13/python3.12 lookups falls back to the broken behaviour
+        # we just fixed.
+        assert "python3.13" in text and "python3.12" in text, (
+            f"helper should probe explicit python3.13 / python3.12; got:\n{text}"
+        )
+        # Final fallback to plain python3 must remain so the hook script's
+        # own version guard still gets a chance to surface a friendly error.
+        assert 'exec python3 "$@"' in text, (
+            f"helper missing python3 fallback (needed for the runtime guard's clean error path):\n{text}"
+        )
+
+    def test_python_hooks_use_runner_helper(self) -> None:
+        """Every Python hook script registered in hooks.json must be invoked
+        via ``_run_python_hook.sh`` rather than a bare ``python3``. Catches
+        the regression where someone adds a new Python hook and reaches for
+        the old ``python3 path/to/hook.py`` pattern out of habit.
+        """
+        data = json.loads(HOOKS_PATH.read_text())
+        events = data.get("hooks", data)
+        offenders: list[tuple[str, str]] = []
+        for event, entries in events.items():
+            for entry in entries:
+                for sub in entry.get("hooks", []):
+                    cmd = sub.get("command", "")
+                    if cmd.endswith(".py") or " .py " in cmd or cmd.rstrip().endswith(".py"):
+                        # Cheap heuristic: command ends in a .py invocation
+                        if "_run_python_hook.sh" not in cmd:
+                            offenders.append((event, cmd))
+                    # Stricter check: any 'python3 …/hook.py' literal is wrong
+                    if re.search(r"\bpython3 \S+\.py\b", cmd):
+                        offenders.append((event, cmd))
+        assert not offenders, (
+            "hooks.json invokes Python hooks directly via 'python3'; route through "
+            f"_run_python_hook.sh instead. Offenders:\n" +
+            "\n".join(f"  [{e}] {c}" for e, c in offenders)
         )
 
     def test_plugin_json_declares_python_engine(self) -> None:

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -393,6 +393,50 @@ class TestHooks:
     def test_hook_script_exists(self, event: str, rel_path: str) -> None:
         assert (PLUGIN_DIR / rel_path).exists(), f"hooks.json [{event}] references missing: {rel_path}"
 
+    @pytest.mark.parametrize("script_name", [
+        "session_start_hook.py",
+        "rdr_hook.py",
+        "stop_failure_hook.py",
+        "read_verification_config.py",
+        "t2_prefix_scan.py",
+    ])
+    def test_python_hook_has_future_annotations_and_version_guard(self, script_name: str) -> None:
+        """Every Python hook script must (a) defer annotation evaluation via
+        ``from __future__ import annotations`` so PEP 604 unions parse on
+        Python ≥3.7, and (b) fail fast with a clear error if running under
+        Python <3.12 (the floor conexus targets).
+
+        Without (a), `int | None` annotations crash the parser on Python
+        3.9 (still default on macOS Sonoma without homebrew Python). Without
+        (b), the script may run partially under an unsupported interpreter
+        and produce confusing failures further down. Both are required so
+        a missing-system-Python case surfaces as a single actionable error
+        rather than a SyntaxError or AttributeError chain.
+        """
+        path = PLUGIN_DIR / "hooks" / "scripts" / script_name
+        assert path.exists(), f"missing hook script: {path}"
+        head = "\n".join(path.read_text().splitlines()[:30])
+        assert "from __future__ import annotations" in head, (
+            f"{script_name}: missing 'from __future__ import annotations' in first 30 lines"
+        )
+        assert "sys.version_info < (3, 12)" in head, (
+            f"{script_name}: missing 'if sys.version_info < (3, 12)' guard in first 30 lines"
+        )
+        assert "Python 3.12+" in head, (
+            f"{script_name}: version guard does not include the 'Python 3.12+' user-facing message"
+        )
+
+    def test_plugin_json_declares_python_engine(self) -> None:
+        """nx/.claude-plugin/plugin.json must declare engines.python so the
+        Python ≥3.12 requirement is discoverable from the plugin manifest,
+        not just from the runtime guards in each hook script.
+        """
+        plugin_json = json.loads((PLUGIN_DIR / ".claude-plugin" / "plugin.json").read_text())
+        engines = plugin_json.get("engines") or {}
+        py_req = engines.get("python", "")
+        assert py_req, "plugin.json missing 'engines.python' field"
+        assert "3.12" in py_req, f"engines.python should require >=3.12, got {py_req!r}"
+
     def test_session_end_hook_registered(self) -> None:
         """Regression guard: SessionEnd must invoke ``nx hook session-end``.
 


### PR DESCRIPTION
## Summary

Three of the five Python hook scripts in `nx/hooks/scripts/` used PEP 604 union annotations (`str | None`, `dict[str, str] | None`) without a matching `from __future__ import annotations`, so they **refused to parse on system Python <3.10**. Even on 3.10+ where the syntax parses, the plugin was silently relying on whatever `python3` resolved to, not the Python 3.12+ that conexus itself targets.

This PR fixes the gap on three layers, each providing a backstop for the next:

1. **Hook commands auto-find Python 3.12+** via a small bash helper, so a user with `python3.13` on PATH (typical Homebrew install) never hits the issue regardless of what unqualified `python3` resolves to.
2. **Hook scripts themselves declare and enforce the requirement** — `from __future__ import annotations` for parse compatibility, plus a `sys.version_info < (3, 12)` guard with a clear actionable error message.
3. **Plugin manifest declares the requirement** — `engines.python: ">=3.12"` in `nx/.claude-plugin/plugin.json` so the constraint is discoverable from metadata alone.

## Why all three layers

The author's machine surfaced the failure mode plainly: default `python3` is **3.10.9** (framework install, wins PATH precedence), but `/opt/homebrew/bin/python3.13` is also installed. Three different fixes solve different cases:

| Failure mode | Layer that catches it |
|--------------|------------------------|
| User has python3.13 but `python3` resolves to old framework Python | **Helper auto-find** picks `python3.13` directly |
| User has only old Python; no 3.12+ at all | **Runtime guard** prints clean install instructions |
| User reads the plugin manifest before installing | **`engines.python`** field declares the requirement |

## Changes

### Hook scripts (`nx/hooks/scripts/`)

All 5 Python hooks now have:
- `from __future__ import annotations` (added to the 3 missing it: `session_start_hook.py`, `rdr_hook.py`, `t2_prefix_scan.py`)
- `sys.version_info < (3, 12)` guard at the top of the module body, before any non-stdlib imports

Plus a new helper:
- **`nx/hooks/scripts/_run_python_hook.sh`** — probes `python3.13` then `python3.12` via `command -v` and execs the first match, falling back to plain `python3` (where the runtime guard still produces the friendly error if too old). Probe order matches conexus's supported range (`>=3.12,<3.14`); 3.14 intentionally excluded since downstream `nx …` subprocess calls would fail there.

### Hook command lines (`nx/hooks/hooks.json`)

All 3 Python-hook invocations route through `_run_python_hook.sh` instead of bare `python3`:

```diff
- "command": "python3 $CLAUDE_PLUGIN_ROOT/hooks/scripts/session_start_hook.py"
+ "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/session_start_hook.py"
```

### Plugin manifest (`nx/.claude-plugin/plugin.json`)

Adds `engines.python: ">=3.12"`.

## Tests (`tests/test_plugin_structure.py`)

Four new structural guards in `TestHooks`:

- **`test_python_hook_has_future_annotations_and_version_guard`** — parametrized across all 5 hook scripts; asserts both declarations are present in the first 30 lines.
- **`test_python_hook_runner_helper_present_and_executable`** — helper exists, is executable, has the expected probe order, retains the `python3` fallback.
- **`test_python_hooks_use_runner_helper`** — every Python hook in `hooks.json` is invoked via the helper, not bare `python3`. Catches the regression where someone adds a new hook with the old pattern.
- **`test_plugin_json_declares_python_engine`** — verifies `engines.python` declares `>=3.12`.

```
$ uv run pytest tests/test_plugin_structure.py
577 passed, 26 skipped in 0.82s
```

## Live verification on author's machine

- `python3 --version` → 3.10.9 (framework install)
- `_run_python_hook.sh` probe → resolves to 3.13.12 at `/opt/homebrew/opt/python@3.13/bin/python3.13`
- Direct invocation under 3.10.9 (the worst case) → prints the friendly guard error and exits 1, instead of the previous SyntaxError on `dict[str, str] | None`

Both layers verified working independently.

## Test plan

- [x] All 5 hook scripts have both required declarations
- [x] Helper exists, is executable, picks the right Python on this machine (3.13.12 from Homebrew)
- [x] hooks.json invokes Python hooks through the helper, not bare `python3`
- [x] Manual smoke-test: hook script invoked under 3.10.9 prints the friendly error
- [x] 577 plugin-structure tests pass
- [ ] Live test under the plugin: SessionStart fires after merge, hooks complete cleanly without PATH adjustments on machines with mixed Python installs