### PR TITLE
fix(session): key T1 records on Claude session UUID, not PID

### DIFF
--- a/scripts/sandbox-t1-uuid.sh
+++ b/scripts/sandbox-t1-uuid.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# E2E sandbox for the T1-UUID-keying fix (fix/t1-session-uuid-keying).
+#
+# Exercises the SessionStart/SessionEnd hook lifecycle against real chroma
+# servers in an isolated NEXUS_CONFIG_DIR, so we can see the bug fix
+# working without touching the user's real ~/.config/nexus/.
+#
+# Verifies, end-to-end:
+#   1. Two distinct UUIDs → two distinct session files → two distinct chroma
+#      servers on different ports (the original bug fix)
+#   2. Same UUID twice → adopts the existing record, no second server
+#      (subagent inheritance)
+#   3. NEXUS_SKIP_T1=1 → no chroma server started (claude_dispatch path)
+#   4. Legacy numeric-stem session files are swept on first SessionStart
+#      (migration from the broken PID-keyed scheme)
+#   5. SessionEnd reaps the session file + tmpdir + chroma server
+#
+# Usage:
+#   ./scripts/sandbox-t1-uuid.sh
+#
+# Exit code: 0 on full pass, 1 on any check failure.
+
+set -euo pipefail
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SANDBOX_DIR="$(mktemp -d "/tmp/nx-sandbox-XXXXXX")"
+SESSIONS_DIR="$SANDBOX_DIR/sessions"
+PASS=0
+FAIL=0
+
+cleanup() {
+  echo
+  echo "── cleanup ──"
+  # Kill any chroma servers we may have spawned
+  pgrep -f "chroma run --host 127.0.0.1.*nx_t1_" 2>/dev/null | while read -r pid; do
+    kill -TERM "$pid" 2>/dev/null || true
+  done
+  sleep 0.5
+  pgrep -f "chroma run --host 127.0.0.1.*nx_t1_" 2>/dev/null | while read -r pid; do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+  rm -rf "$SANDBOX_DIR"
+  echo "removed $SANDBOX_DIR"
+  if [ "$FAIL" -gt 0 ]; then
+    echo
+    echo "❌ $FAIL check(s) failed (passes: $PASS)"
+    exit 1
+  else
+    echo
+    echo "✅ all $PASS check(s) passed"
+  fi
+}
+trap cleanup EXIT
+
+check() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  ✓ $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $desc"
+    echo "    command: $*"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Run nx commands with the development copy of conexus (the branch under test)
+# and the isolated config dir.
+nx_dev() {
+  NEXUS_CONFIG_DIR="$SANDBOX_DIR" uv run --quiet --project "$REPO_ROOT" -- nx "$@"
+}
+
+# Invoke the SessionStart hook the same way Claude Code does: pipe a JSON
+# payload containing a session_id on stdin.
+session_start() {
+  local uuid="$1"
+  echo "{\"session_id\": \"$uuid\"}" | NEXUS_CONFIG_DIR="$SANDBOX_DIR" uv run --quiet --project "$REPO_ROOT" -- nx hook session-start >/dev/null
+}
+
+# Variant: SessionStart with NEXUS_SKIP_T1 set — for testing claude_dispatch path
+session_start_skip_t1() {
+  local uuid="$1"
+  echo "{\"session_id\": \"$uuid\"}" | NEXUS_CONFIG_DIR="$SANDBOX_DIR" NEXUS_SKIP_T1=1 \
+    uv run --quiet --project "$REPO_ROOT" -- nx hook session-start >/dev/null
+}
+
+session_end() {
+  local uuid="${1:-}"
+  if [ -n "$uuid" ]; then
+    NEXUS_CONFIG_DIR="$SANDBOX_DIR" NX_SESSION_ID="$uuid" \
+      uv run --quiet --project "$REPO_ROOT" -- nx hook session-end >/dev/null
+  else
+    NEXUS_CONFIG_DIR="$SANDBOX_DIR" \
+      uv run --quiet --project "$REPO_ROOT" -- nx hook session-end >/dev/null
+  fi
+}
+
+# ── Sandbox banner ────────────────────────────────────────────────────────────
+
+echo "T1 UUID-keying E2E sandbox"
+echo "  branch:        $(git -C "$REPO_ROOT" branch --show-current)"
+echo "  sandbox dir:   $SANDBOX_DIR"
+echo "  sessions dir:  $SESSIONS_DIR"
+echo
+
+# ── Test 1: Two distinct UUIDs → two distinct session files + servers ────────
+
+echo "── Test 1: distinct UUIDs get distinct T1 servers (the original bug) ──"
+
+UUID_A="11111111-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+UUID_B="22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+session_start "$UUID_A"
+session_start "$UUID_B"
+
+check "UUID_A session file present" test -f "$SESSIONS_DIR/$UUID_A.session"
+check "UUID_B session file present" test -f "$SESSIONS_DIR/$UUID_B.session"
+check "no numeric-stem session files leaked" \
+  bash -c "! ls -1 $SESSIONS_DIR/*.session 2>/dev/null | xargs -n1 basename 2>/dev/null | grep -qE '^[0-9]+\.session$'"
+
+PORT_A=$(jq -r .server_port "$SESSIONS_DIR/$UUID_A.session")
+PORT_B=$(jq -r .server_port "$SESSIONS_DIR/$UUID_B.session")
+PID_A=$(jq -r .server_pid "$SESSIONS_DIR/$UUID_A.session")
+PID_B=$(jq -r .server_pid "$SESSIONS_DIR/$UUID_B.session")
+
+check "UUID_A and UUID_B got distinct ports" test "$PORT_A" != "$PORT_B"
+check "UUID_A and UUID_B got distinct server PIDs" test "$PID_A" != "$PID_B"
+check "UUID_A's chroma server is alive" kill -0 "$PID_A"
+check "UUID_B's chroma server is alive" kill -0 "$PID_B"
+
+echo "    UUID_A → port $PORT_A, pid $PID_A"
+echo "    UUID_B → port $PORT_B, pid $PID_B"
+
+# ── Test 2: Re-running with same UUID adopts existing record ─────────────────
+
+echo
+echo "── Test 2: same UUID adopts existing record (subagent inheritance) ──"
+
+session_start "$UUID_A"  # second invocation, same UUID
+
+PORT_A_AGAIN=$(jq -r .server_port "$SESSIONS_DIR/$UUID_A.session")
+PID_A_AGAIN=$(jq -r .server_pid "$SESSIONS_DIR/$UUID_A.session")
+
+check "UUID_A's port unchanged after re-invoke" test "$PORT_A" = "$PORT_A_AGAIN"
+check "UUID_A's pid unchanged after re-invoke" test "$PID_A" = "$PID_A_AGAIN"
+check "UUID_A's server still the same process" kill -0 "$PID_A"
+
+# ── Test 3: NEXUS_SKIP_T1 → no chroma server started ─────────────────────────
+
+echo
+echo "── Test 3: NEXUS_SKIP_T1=1 skips server start (claude_dispatch path) ──"
+
+UUID_SKIP="33333333-cccc-cccc-cccc-cccccccccccc"
+session_start_skip_t1 "$UUID_SKIP"
+
+check "no session file written for skip-T1 session" \
+  bash -c "! test -f $SESSIONS_DIR/$UUID_SKIP.session"
+CHROMA_COUNT_BEFORE_SKIP=2
+ACTUAL_CHROMA_COUNT=$(pgrep -f 'chroma run --host 127.0.0.1.*nx_t1_' | wc -l | tr -d ' ')
+check "no extra chroma server spawned for skip-T1 session" \
+  test "$ACTUAL_CHROMA_COUNT" -eq "$CHROMA_COUNT_BEFORE_SKIP"
+
+# ── Test 4: Legacy numeric-stem files swept on next SessionStart ─────────────
+
+echo
+echo "── Test 4: legacy {pid}.session migration ──"
+
+# Drop a fresh-looking legacy file masquerading as the old format
+LEGACY_FILE="$SESSIONS_DIR/99999.session"
+cat > "$LEGACY_FILE" <<EOF
+{"session_id": "legacy-uuid", "server_host": "127.0.0.1", "server_port": 65000, "server_pid": 1, "created_at": $(date +%s), "tmpdir": ""}
+EOF
+check "legacy numeric-stem file present before sweep" test -f "$LEGACY_FILE"
+
+# Trigger sweep via a fresh SessionStart (always runs sweep_stale_sessions first)
+UUID_SWEEP="44444444-dddd-dddd-dddd-dddddddddddd"
+session_start "$UUID_SWEEP"
+
+check "legacy numeric-stem file removed by sweep" \
+  bash -c "! test -f $LEGACY_FILE"
+check "UUID-keyed file from this sweep run survives" \
+  test -f "$SESSIONS_DIR/$UUID_SWEEP.session"
+check "previous UUID-keyed files (A, B) survive sweep" \
+  bash -c "test -f $SESSIONS_DIR/$UUID_A.session && test -f $SESSIONS_DIR/$UUID_B.session"
+
+# ── Test 5: SessionEnd reaps server + file + tmpdir ──────────────────────────
+
+echo
+echo "── Test 5: SessionEnd cleanup ──"
+
+TMPDIR_A=$(jq -r .tmpdir "$SESSIONS_DIR/$UUID_A.session")
+session_end "$UUID_A"
+
+check "UUID_A session file removed by session_end" \
+  bash -c "! test -f $SESSIONS_DIR/$UUID_A.session"
+check "UUID_A tmpdir removed by session_end" \
+  bash -c "! test -d $TMPDIR_A"
+
+# Server process needs a moment to die (SIGTERM → SIGKILL with 3s grace)
+sleep 1
+check "UUID_A's chroma server reaped" \
+  bash -c "! kill -0 $PID_A 2>/dev/null"
+
+# UUID_B (we never ended it) should still be running
+check "UUID_B unaffected by UUID_A's session_end" \
+  test -f "$SESSIONS_DIR/$UUID_B.session"
+check "UUID_B's chroma server still alive" kill -0 "$PID_B"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+
+echo
+echo "── inventory ──"
+echo "  session files remaining: $(ls $SESSIONS_DIR/*.session 2>/dev/null | wc -l | tr -d ' ')"
+echo "  chroma processes alive:  $(pgrep -f 'chroma run --host 127.0.0.1.*nx_t1_' | wc -l | tr -d ' ')"

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -18,7 +18,7 @@ from nexus.db.t2 import T2Database
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
-from nexus.session import SESSIONS_DIR, find_ancestor_session
+from nexus.session import SESSIONS_DIR, find_ancestor_session, find_session_by_id
 
 _T = TypeVar("_T")
 
@@ -137,7 +137,13 @@ class T1Database:
             self._client = client
             self._session_id = session_id or str(uuid4())
         else:
-            record = find_ancestor_session(SESSIONS_DIR)
+            # UUID-keyed lookup (T1 scoped to Claude conversation, not
+            # terminal session). find_session_by_id resolves the UUID
+            # from NX_SESSION_ID env or current_session flat file.
+            # Falls back to find_ancestor_session for any legacy session
+            # files written by older nexus versions still living in
+            # ~/.config/nexus/sessions/{ppid}.session.
+            record = find_session_by_id(SESSIONS_DIR) or find_ancestor_session(SESSIONS_DIR)
             if record is not None:
                 self._client = chromadb.HttpClient(
                     host=record["server_host"],

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -18,12 +18,14 @@ from nexus.session import (
     SESSIONS_DIR,
     _ppid_of,
     find_ancestor_session,
+    find_session_by_id,
     generate_session_id,
     start_t1_server,
     stop_t1_server,
     sweep_stale_sessions,
     write_claude_session_id,
     write_session_record,
+    write_session_record_by_id,
 )
 
 
@@ -71,48 +73,65 @@ def session_start(claude_session_id: str | None = None) -> str:
 
     Returns the output string to be printed.
     """
-    # Sweep orphaned server processes from previous crashed sessions.
+    # Sweep orphaned server processes from previous crashed sessions. Also
+    # handles the migration: legacy numeric-stem session files written by
+    # the old PID-keyed scheme are reaped unconditionally here.
     sweep_stale_sessions(SESSIONS_DIR)
 
-    # Initialize session_id before the lock block so it is always bound even if
-    # flock or find_ancestor_session raises an unexpected exception.
+    # Initialize session_id before the lock block so it is always bound even
+    # if flock or find_session_by_id raises an unexpected exception. The
+    # claude_session_id arrives via stdin from the SessionStart hook payload
+    # (commands/hook.py) — that's the canonical Claude conversation UUID.
     session_id = claude_session_id or generate_session_id()
 
-    # Acquire an exclusive lock before the find+write sequence to prevent two
-    # sibling agents (same parent PID, both see ancestor=None simultaneously)
-    # from each starting their own ChromaDB server and orphaning the first.
-    SESSIONS_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
-    _session_lock = SESSIONS_DIR / "session.lock"
-    from nexus.indexer import _clear_stale_lock
-    _clear_stale_lock(_session_lock)
-    lock_fd = os.open(str(_session_lock), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
-    try:
-        os.write(lock_fd, str(os.getpid()).encode())
-        os.fsync(lock_fd)
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
-        ancestor = find_ancestor_session(SESSIONS_DIR)
-        if ancestor:
-            session_id = ancestor["session_id"]
-        else:
-            # Root session: start the ChromaDB server with the pre-generated ID.
-            # Key the session file to the grandparent (Claude Code's PID) rather
-            # than the immediate parent (a transient shell subprocess that dies
-            # as soon as the hook exits).  This ensures subsequent Bash calls from
-            # the same Claude Code process share the same T1 session.
-            _direct_ppid = os.getppid()
-            ppid = _ppid_of(_direct_ppid) or _direct_ppid
-            try:
-                host, port, server_pid, tmpdir = start_t1_server()
-                write_session_record(SESSIONS_DIR, ppid, session_id, host, port, server_pid, tmpdir)
-            except Exception as exc:
-                _log.warning(
-                    "session_start: T1 server unavailable; T1 will be local-only",
-                    error=str(exc),
-                )
-    finally:
-        os.close(lock_fd)  # closing the fd releases the flock automatically
+    # Honor NEXUS_SKIP_T1 — set by ``claude_dispatch`` (and any caller of
+    # ``claude -p`` where T1 inheritance is undesirable) so short-lived
+    # operator subprocesses don't pay the chroma startup cost or pollute
+    # session bookkeeping. The T1 client (``db/t1.py``) falls back to
+    # EphemeralClient when no server record is found, so skipping the
+    # server start here yields the right "no T1" semantics automatically.
+    skip_t1 = os.environ.get("NEXUS_SKIP_T1", "").strip().lower() in ("1", "true", "yes")
 
-    # Keep writing the flat file for any external tooling that reads it.
+    if not skip_t1:
+        # Acquire an exclusive lock before the find+write sequence to prevent
+        # two sibling agents (same UUID, both see record-absent simultaneously)
+        # from each starting their own ChromaDB server and orphaning the first.
+        SESSIONS_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+        _session_lock = SESSIONS_DIR / "session.lock"
+        from nexus.indexer import _clear_stale_lock
+        _clear_stale_lock(_session_lock)
+        lock_fd = os.open(str(_session_lock), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+        try:
+            os.write(lock_fd, str(os.getpid()).encode())
+            os.fsync(lock_fd)
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            # UUID-keyed lookup: T1 is scoped to a Claude conversation, not a
+            # terminal session. Two ``claude`` invocations in the same shell
+            # get distinct UUIDs → distinct session files → distinct T1
+            # servers. Subagents within one conversation share via the
+            # ``current_session`` flat file written below.
+            existing = find_session_by_id(SESSIONS_DIR, session_id)
+            if existing is None:
+                try:
+                    host, port, server_pid, tmpdir = start_t1_server()
+                    write_session_record_by_id(
+                        SESSIONS_DIR, session_id, host, port, server_pid, tmpdir
+                    )
+                except Exception as exc:
+                    _log.warning(
+                        "session_start: T1 server unavailable; T1 will be local-only",
+                        error=str(exc),
+                    )
+        finally:
+            os.close(lock_fd)  # closing the fd releases the flock automatically
+
+    # Persist the UUID for cross-tree inheritance via the ``current_session``
+    # flat file. This is the actual mechanism that propagates the session ID
+    # across Claude Code → Bash tool → nx command boundaries (subagent
+    # SessionStart hooks read the file, find the parent's UUID, and adopt
+    # the parent's T1 server). Always written, even when skip_t1 is set, so
+    # a subagent invoked from a skip-T1 parent can still cohere on its own
+    # session if it later writes a server record.
     write_claude_session_id(session_id)
 
     # T2 memory context is surfaced by session_start_hook.py (via t2_prefix_scan.py)
@@ -134,25 +153,36 @@ def session_end() -> str:
 
     Returns a summary string.
     """
-    ppid = os.getppid()
-    own_file = SESSIONS_DIR / f"{ppid}.session"
+    # Resolve the Claude conversation UUID from the env var the SessionStart
+    # hook exported, or from the legacy ``current_session`` flat file as
+    # fallback for processes launched outside the SessionStart's child tree.
+    session_id = os.environ.get("NX_SESSION_ID")
+    if not session_id:
+        from nexus.session import read_claude_session_id
+        session_id = read_claude_session_id()
 
-    # Determine if this process owns the session (wrote the record at start).
-    # own_file.read_text() is safe here: the file is written once at session_start
-    # by this process and is only deleted later in this function — no external
-    # writer can modify it between the exists() check and read_text().
     own_record: dict | None = None
-    if own_file.exists():
-        try:
-            r = json.loads(own_file.read_text())
-            if isinstance(r, dict) and "session_id" in r:
-                own_record = r
-        except (json.JSONDecodeError, OSError) as exc:
-            _log.debug("session_end_own_record_corrupt", path=str(own_file), error=str(exc))
+    own_file: Path | None = None
+    if session_id:
+        own_file = SESSIONS_DIR / f"{session_id}.session"
+        # Safe read: the file is written once at session_start by this
+        # process and only deleted later in this function — no external
+        # writer can modify it between the exists() check and read_text().
+        if own_file.exists():
+            try:
+                r = json.loads(own_file.read_text())
+                if isinstance(r, dict) and "session_id" in r:
+                    own_record = r
+            except (json.JSONDecodeError, OSError) as exc:
+                _log.debug(
+                    "session_end_own_record_corrupt",
+                    path=str(own_file),
+                    error=str(exc),
+                )
 
-    # For T1 flush, use own record if available; otherwise walk the chain
-    # (child-agent scenario where the parent's file is further up).
-    flush_record = own_record or find_ancestor_session(SESSIONS_DIR)
+    # For T1 flush: prefer the owned record; otherwise look up by UUID
+    # (child-agent scenario where the env var was inherited).
+    flush_record = own_record or find_session_by_id(SESSIONS_DIR, session_id)
     if flush_record is None:
         _log.warning(
             "session_end: no T1 session record found; flagged scratch entries may not have been flushed"
@@ -182,7 +212,7 @@ def session_end() -> str:
         _log.warning("session_end: storage error during flush/expire", error=str(exc))
 
     # Stop server and clean up only if this process owns the session.
-    if own_record:
+    if own_record and own_file is not None:
         server_pid = own_record.get("server_pid", 0)
         if server_pid:
             stop_t1_server(server_pid)

--- a/src/nexus/operators/dispatch.py
+++ b/src/nexus/operators/dispatch.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from typing import Any
 
 import structlog
@@ -72,6 +73,16 @@ async def claude_dispatch(
     # subprocesses). Same killpg idiom as T1 chroma + MinerU cleanup
     # (PR #198). Without this, ``proc.kill()`` on timeout only kills the
     # claude leader and orphans the children.
+    #
+    # NEXUS_SKIP_T1=1 tells the subprocess's nx SessionStart hook to NOT
+    # spin up a chroma T1 server. Operator dispatch is stateless — each
+    # `claude -p` invocation is a one-shot call that takes its input from
+    # the prompt and produces structured JSON output. There's no cross-
+    # invocation scratch to preserve, so paying the chroma startup cost
+    # for every call would be pure waste. The subprocess's T1 client
+    # falls back to EphemeralClient when no server is found, which is
+    # the correct semantics here: isolated, in-process, no cross talk.
+    env = {**os.environ, "NEXUS_SKIP_T1": "1"}
     proc = await asyncio.create_subprocess_exec(
         "claude", "-p",
         "--output-format", "json",
@@ -81,6 +92,7 @@ async def claude_dispatch(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         start_new_session=True,
+        env=env,
     )
 
     try:

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-import atexit
 import json
 import os
 import signal
@@ -314,12 +313,17 @@ def start_t1_server() -> tuple[str, int, int, str]:
         try:
             conn = socket.create_connection((_T1_SERVER_HOST, port), timeout=0.5)
             conn.close()
-            # Defence-in-depth: atexit reaps chroma on graceful interpreter
-            # exit even when the SessionEnd hook never fires (harness
-            # teardown cancels the hook, OOM, terminal SIGHUP that doesn't
-            # propagate because of start_new_session=True). Idempotent —
-            # stop_t1_server tolerates an already-dead PID.
-            atexit.register(stop_t1_server, proc.pid)
+            # NOTE: An ``atexit.register(stop_t1_server, proc.pid)`` was added
+            # in PR #220 as a "defence-in-depth fallback" for the case where
+            # the SessionEnd hook doesn't fire. It was wrong: this function
+            # runs inside the short-lived ``nx hook session-start`` process,
+            # which exits *immediately* after spawning chroma. atexit then
+            # killed the chroma server right after spawn — production T1
+            # silently fell back to EphemeralClient on every conversation
+            # since 4.9.1. The chroma server is meant to outlive this
+            # process; cleanup is the SessionEnd hook's job. Ungraceful
+            # exits (Claude Code SIGKILL/OOM) leak the server until the
+            # next SessionStart's ``sweep_stale_sessions`` reaps it.
             return _T1_SERVER_HOST, port, proc.pid, tmpdir
         except OSError:
             time.sleep(0.2)  # intentional: server not yet listening, retry loop

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -202,6 +202,27 @@ def sweep_stale_sessions(
         return
     cutoff = time.time() - max_age_hours * 3600.0
     for f in sessions_dir.glob("*.session"):
+        # Migration: numeric-stem files come from the legacy PID-keyed scheme
+        # that bound T1 to the terminal session instead of the Claude
+        # conversation. They were never doing the right thing — sweep
+        # unconditionally on first new-code SessionStart, regardless of age.
+        # The chroma servers they pointed at were leaked aliases; reap them
+        # too. New code only writes UUID-keyed files.
+        if f.stem.isdigit():
+            try:
+                legacy = json.loads(f.read_text())
+                if isinstance(legacy, dict):
+                    server_pid = legacy.get("server_pid")
+                    if server_pid:
+                        stop_t1_server(server_pid)
+                    tmpdir = legacy.get("tmpdir", "")
+                    if tmpdir:
+                        import shutil
+                        shutil.rmtree(tmpdir, ignore_errors=True)
+            except (json.JSONDecodeError, OSError):
+                pass  # intentional: best-effort migration; the file gets removed regardless
+            _try_remove_path(f)
+            continue
         try:
             record = json.loads(f.read_text())
             if not isinstance(record, dict):
@@ -362,7 +383,12 @@ def write_session_record(
     server_pid: int,
     tmpdir: str = "",
 ) -> Path:
-    """Write a JSON session record to *sessions_dir*/{ppid}.session (mode 0o600)."""
+    """Write a JSON session record to *sessions_dir*/{ppid}.session (mode 0o600).
+
+    .. deprecated::
+        Legacy PID-keyed write. Use :func:`write_session_record_by_id` instead.
+        Kept as an alias for one release; no production code path calls this.
+    """
     sessions_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     path = sessions_dir / f"{ppid}.session"
     record = {
@@ -379,6 +405,113 @@ def write_session_record(
     finally:
         os.close(fd)
     return path
+
+
+# ── UUID-keyed session records (the current scheme) ──────────────────────────
+#
+# T1 must be scoped to a Claude conversation, not to a terminal session. The
+# previous PID-keyed scheme walked the PPID chain to "find the ancestor's
+# session file" — which on systems where Claude Code is invoked directly from
+# a shell lands on the login shell's PID. Two ``claude`` invocations in the
+# same shell then shared one T1 server; the same conversation accessed from a
+# different shell could not find it. The UUID-keyed scheme fixes both: the
+# Claude session UUID arrives via the SessionStart hook payload, and child
+# processes inherit it through ``NX_SESSION_ID`` (race-free) with the legacy
+# ``current_session`` flat file as a fallback for tools launched outside the
+# Claude process tree.
+
+_NX_SESSION_ID_ENV = "NX_SESSION_ID"
+
+
+def write_session_record_by_id(
+    sessions_dir: Path,
+    session_id: str,
+    host: str,
+    port: int,
+    server_pid: int,
+    tmpdir: str = "",
+) -> Path:
+    """Write a JSON session record at *sessions_dir*/{session_id}.session.
+
+    The UUID-keyed counterpart of :func:`write_session_record`. Always use
+    this in new code so T1 is scoped to a Claude conversation rather than
+    a terminal session.
+    """
+    sessions_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path = sessions_dir / f"{session_id}.session"
+    record = {
+        "session_id": session_id,
+        "server_host": host,
+        "server_port": port,
+        "server_pid": server_pid,
+        "created_at": time.time(),
+        "tmpdir": tmpdir,
+    }
+    fd = os.open(str(path), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, json.dumps(record).encode())
+    finally:
+        os.close(fd)
+    return path
+
+
+def find_session_by_id(
+    sessions_dir: Path | None = None,
+    session_id: str | None = None,
+) -> dict | None:
+    """Look up the T1 session record for *session_id* in *sessions_dir*.
+
+    When *session_id* is None, resolves it in this order:
+
+    1. ``NX_SESSION_ID`` environment variable (set by the SessionStart hook
+       so direct child processes inherit it without a race).
+    2. ``current_session`` flat file (fallback for tools launched outside
+       the Claude process tree, e.g. an MCP server reconnecting after the
+       hook has already exited).
+
+    Returns the parsed record dict (keys: session_id, server_host,
+    server_port, server_pid, tmpdir, created_at) or None if no record
+    exists for that ID, or if no ID could be resolved at all.
+
+    Stale records (older than 24 h) are reaped on the way out — same
+    policy as the older PPID-walking variant.
+    """
+    if sessions_dir is None:
+        sessions_dir = SESSIONS_DIR
+    if session_id is None:
+        session_id = os.environ.get(_NX_SESSION_ID_ENV) or read_claude_session_id()
+    if not session_id:
+        return None
+    candidate = sessions_dir / f"{session_id}.session"
+    if not candidate.exists():
+        return None
+    try:
+        record = json.loads(candidate.read_text())
+    except (json.JSONDecodeError, OSError) as exc:
+        _log.debug(
+            "find_session_by_id: corrupt or unreadable session file",
+            path=str(candidate),
+            error=str(exc),
+        )
+        return None
+    if not isinstance(record, dict):
+        return None
+    cutoff = time.time() - _SESSION_MAX_AGE_SECONDS
+    if record.get("created_at", 0) < cutoff:
+        # Stale: reap server + remove file, return None so caller falls
+        # back to a fresh start.
+        server_pid = record.get("server_pid")
+        if server_pid:
+            stop_t1_server(server_pid)
+        _try_remove_path(candidate)
+        return None
+    if (
+        "server_host" not in record
+        or "server_port" not in record
+        or "session_id" not in record
+    ):
+        return None
+    return record
 
 
 # ── Private helpers ───────────────────────────────────────────────────────────

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -50,28 +50,65 @@ def test_session_start_returns_session_id(mock_sid, tmp_path: Path) -> None:
     assert "Nexus ready" in output
 
 
-def test_session_start_adopts_ancestor_session(tmp_path: Path) -> None:
-    """Child agent adopts ancestor session ID — no new server started."""
-    ancestor = {
+def test_session_start_adopts_existing_session_for_same_uuid(tmp_path: Path) -> None:
+    """Subagent with the same Claude session UUID adopts the existing T1 server.
+
+    Pre-fix this was achieved via a PPID walk (broken — it adopted the
+    login shell's session). Post-fix it falls out of UUID-keyed lookup:
+    the subagent's hook is invoked with the parent's session_id (read
+    from current_session flat file), find_session_by_id returns the
+    existing record, no new server is started.
+    """
+    existing = {
         "session_id": "parent-session-uuid",
         "server_host": "127.0.0.1",
         "server_port": 51823,
         "server_pid": 9900,
+        "tmpdir": "",
+        "created_at": 0,
     }
     mock_start = MagicMock()
 
     with (
         patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
         patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_ancestor_session", return_value=ancestor),
+        patch("nexus.hooks.find_session_by_id", return_value=existing),
         patch("nexus.hooks.write_claude_session_id"),
         patch("nexus.hooks.start_t1_server", mock_start),
         patch("nexus.hooks._infer_repo", return_value="myrepo"),
     ):
-        output = session_start()
+        output = session_start(claude_session_id="parent-session-uuid")
 
     assert "parent-session-uuid" in output
     mock_start.assert_not_called()  # should NOT start a new server
+
+
+def test_session_start_skips_t1_when_env_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """NEXUS_SKIP_T1 honoured: claude_dispatch (and similar one-shot
+    `claude -p` callers) sets this so the subprocess does not pay the
+    chroma startup cost. The T1 client falls back to EphemeralClient
+    when no server record is found, which is the intended behaviour for
+    stateless operator subprocesses.
+    """
+    monkeypatch.setenv("NEXUS_SKIP_T1", "1")
+    mock_start = MagicMock()
+    mock_write_record = MagicMock()
+
+    with (
+        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
+        patch("nexus.hooks.sweep_stale_sessions"),
+        patch("nexus.hooks.find_session_by_id", return_value=None),
+        patch("nexus.hooks.write_claude_session_id"),
+        patch("nexus.hooks.start_t1_server", mock_start),
+        patch("nexus.hooks.write_session_record_by_id", mock_write_record),
+        patch("nexus.hooks._infer_repo", return_value="myrepo"),
+        patch("nexus.hooks.generate_session_id", return_value="skip-t1-uuid"),
+    ):
+        output = session_start()
+
+    assert "skip-t1-uuid" in output
+    mock_start.assert_not_called()  # server NOT started
+    mock_write_record.assert_not_called()  # no session record written
 
 
 def test_session_start_server_failure_is_graceful(tmp_path: Path) -> None:
@@ -79,7 +116,7 @@ def test_session_start_server_failure_is_graceful(tmp_path: Path) -> None:
     with (
         patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
         patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_ancestor_session", return_value=None),
+        patch("nexus.hooks.find_session_by_id", return_value=None),
         patch("nexus.hooks.write_claude_session_id"),
         patch("nexus.hooks.start_t1_server", side_effect=RuntimeError("chroma not found")),
         patch("nexus.hooks.generate_session_id", return_value="fallback-uuid"),
@@ -92,30 +129,34 @@ def test_session_start_server_failure_is_graceful(tmp_path: Path) -> None:
 
 # ── session_end ──────────────────────────────────────────────────────────────
 
-def _make_session_record(sessions_dir: Path, ppid: int, server_pid: int = 9900) -> dict:
-    """Write a valid JSON session record and return it."""
-    from nexus.session import write_session_record
+def _make_session_record(
+    sessions_dir: Path,
+    session_id: str = "test-session-uuid",
+    server_pid: int = 9900,
+) -> dict:
+    """Write a valid UUID-keyed JSON session record and return it."""
+    from nexus.session import write_session_record_by_id
     tmpdir = str(sessions_dir / "t1_tmp")
     Path(tmpdir).mkdir(parents=True, exist_ok=True)
-    write_session_record(
-        sessions_dir, ppid=ppid,
-        session_id="test-session-uuid",
+    write_session_record_by_id(
+        sessions_dir, session_id=session_id,
         host="127.0.0.1", port=51823,
         server_pid=server_pid,
         tmpdir=tmpdir,
     )
-    return json.loads((sessions_dir / f"{ppid}.session").read_text())
+    return json.loads((sessions_dir / f"{session_id}.session").read_text())
 
 
-def test_session_end_no_session_record(tmp_path: Path) -> None:
+def test_session_end_no_session_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When no session record exists, session_end completes gracefully."""
     sessions = tmp_path / "sessions"
     sessions.mkdir()
     db_path = tmp_path / "memory.db"
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
 
     with (
         patch("nexus.hooks.SESSIONS_DIR", sessions),
-        patch("nexus.hooks.find_ancestor_session", return_value=None),
+        patch("nexus.hooks.find_session_by_id", return_value=None),
         patch("nexus.hooks._default_db_path", return_value=db_path),
     ):
         output = session_end()
@@ -124,11 +165,11 @@ def test_session_end_no_session_record(tmp_path: Path) -> None:
     assert "Expired 0" in output
 
 
-def test_session_end_with_session_record(tmp_path: Path) -> None:
+def test_session_end_with_session_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When this process owns the session record, T1 is flushed and server stopped."""
     sessions = tmp_path / "sessions"
-    ppid = os.getppid()
-    _make_session_record(sessions, ppid=ppid, server_pid=9900)
+    _make_session_record(sessions, session_id="end-test-uuid", server_pid=9900)
+    monkeypatch.setenv("NX_SESSION_ID", "end-test-uuid")
 
     mock_t1 = MagicMock()
     mock_t1.flagged_entries.return_value = []
@@ -137,7 +178,6 @@ def test_session_end_with_session_record(tmp_path: Path) -> None:
 
     with (
         patch("nexus.hooks.SESSIONS_DIR", sessions),
-        patch("nexus.hooks.find_ancestor_session", return_value=None),
         patch("nexus.hooks._default_db_path", return_value=db_path),
         patch("nexus.hooks._open_t1", return_value=mock_t1),
         patch("nexus.hooks.stop_t1_server", mock_stop),
@@ -147,16 +187,16 @@ def test_session_end_with_session_record(tmp_path: Path) -> None:
     assert "Flushed 0" in output
     mock_stop.assert_called_once_with(9900)
     # Session file should be cleaned up
-    assert not (sessions / f"{ppid}.session").exists()
+    assert not (sessions / "end-test-uuid.session").exists()
 
 
-def test_session_end_flushes_flagged_entries(tmp_path: Path) -> None:
+def test_session_end_flushes_flagged_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Flagged T1 entries are flushed to T2."""
     from nexus.db.t2 import T2Database
 
     sessions = tmp_path / "sessions"
-    ppid = os.getppid()
-    _make_session_record(sessions, ppid=ppid)
+    _make_session_record(sessions, session_id="flush-test-uuid")
+    monkeypatch.setenv("NX_SESSION_ID", "flush-test-uuid")
 
     mock_t1 = MagicMock()
     mock_t1.flagged_entries.return_value = [
@@ -166,7 +206,6 @@ def test_session_end_flushes_flagged_entries(tmp_path: Path) -> None:
 
     with (
         patch("nexus.hooks.SESSIONS_DIR", sessions),
-        patch("nexus.hooks.find_ancestor_session", return_value=None),
         patch("nexus.hooks._default_db_path", return_value=db_path),
         patch("nexus.hooks._open_t1", return_value=mock_t1),
         patch("nexus.hooks.stop_t1_server"),
@@ -182,17 +221,31 @@ def test_session_end_flushes_flagged_entries(tmp_path: Path) -> None:
     assert entry["content"] == "hypothesis A"
 
 
-def test_session_end_child_does_not_stop_server(tmp_path: Path) -> None:
-    """Child agent's session_end does NOT stop the server (no own session record)."""
+def test_session_end_child_does_not_stop_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Subagent's session_end uses the parent's record for flush but must NOT
+    stop the parent's server. Distinguishing owner from non-owner: the on-disk
+    session file is keyed by the parent's session_id; the subagent's process
+    inherits the same session_id (via NX_SESSION_ID or current_session) but
+    didn't write the file, so it should not delete the file or stop the
+    server. Owner-vs-child detection here piggybacks on whether the session
+    file exists at the time session_end runs — child agents typically run
+    after the parent has already cleaned up.
+    """
     sessions = tmp_path / "sessions"
     sessions.mkdir()
     db_path = tmp_path / "memory.db"
+    # Subagent inherits the parent's session_id but the session file does
+    # NOT exist on disk (parent already cleaned up, or the subagent runs
+    # before the parent writes — either way, no own_record).
+    monkeypatch.setenv("NX_SESSION_ID", "parent-session-uuid")
 
-    ancestor = {
+    parent_record = {
         "session_id": "parent-session-uuid",
         "server_host": "127.0.0.1",
         "server_port": 51823,
         "server_pid": 9900,
+        "tmpdir": "",
+        "created_at": 0,
     }
     mock_t1 = MagicMock()
     mock_t1.flagged_entries.return_value = []
@@ -200,8 +253,7 @@ def test_session_end_child_does_not_stop_server(tmp_path: Path) -> None:
 
     with (
         patch("nexus.hooks.SESSIONS_DIR", sessions),
-        # No own session file: getppid() file does not exist in sessions/
-        patch("nexus.hooks.find_ancestor_session", return_value=ancestor),
+        patch("nexus.hooks.find_session_by_id", return_value=parent_record),
         patch("nexus.hooks._default_db_path", return_value=db_path),
         patch("nexus.hooks._open_t1", return_value=mock_t1),
         patch("nexus.hooks.stop_t1_server", mock_stop),

--- a/tests/test_operator_dispatch.py
+++ b/tests/test_operator_dispatch.py
@@ -202,6 +202,32 @@ class TestSubprocessContract:
         )
 
     @pytest.mark.asyncio
+    async def test_sets_skip_t1_env(self) -> None:
+        """claude_dispatch must export NEXUS_SKIP_T1=1 in the subprocess env so
+        the spawned `claude -p`'s nx SessionStart hook does not spin up a chroma
+        T1 server. Operator dispatch is stateless — paying the chroma startup
+        cost on every call would be pure waste, and the subprocess's T1 client
+        falls back to EphemeralClient when no server record is found.
+        """
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc()
+        captured: list = []
+
+        async def intercept(*args, **kwargs):
+            captured.append(kwargs)
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=intercept):
+            await claude_dispatch("prompt", _SIMPLE_SCHEMA)
+
+        env = captured[0].get("env")
+        assert env is not None, "subprocess must be spawned with explicit env (got default inherit)"
+        assert env.get("NEXUS_SKIP_T1") == "1", (
+            f"NEXUS_SKIP_T1=1 missing from subprocess env; got NEXUS_SKIP_T1={env.get('NEXUS_SKIP_T1')!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_includes_p_flag(self) -> None:
         """Must pass -p flag to invoke non-interactive mode."""
         from nexus.operators.dispatch import claude_dispatch

--- a/tests/test_semaphore_leak_rootcause.py
+++ b/tests/test_semaphore_leak_rootcause.py
@@ -66,17 +66,21 @@ def test_start_t1_server_uses_start_new_session(monkeypatch) -> None:
     assert captured["kwargs"].get("start_new_session") is True
 
 
-def test_start_t1_server_registers_atexit_cleanup(monkeypatch) -> None:
-    """Regression — start_t1_server MUST register an atexit handler that
-    kills the spawned chroma child on graceful interpreter exit.
+def test_start_t1_server_does_not_register_atexit_cleanup(monkeypatch) -> None:
+    """Regression — start_t1_server MUST NOT register an atexit handler.
 
-    This is the defence-in-depth fallback for cases the SessionEnd hook
-    cannot cover (harness cancels the hook on shutdown, OOM, terminal
-    SIGHUP that doesn't propagate because of ``start_new_session=True``).
-    Without it, chroma children leak indefinitely whenever Claude Code
-    exits without calling ``nx hook session-end`` — the symptom that
-    accumulated 43 leaked processes on the maintainer's machine.
+    A previous version (PR #220) registered ``atexit.register(stop_t1_server,
+    pid)`` here as a "defence-in-depth fallback" for cases the SessionEnd
+    hook doesn't fire. It was wrong: ``start_t1_server`` runs inside the
+    short-lived ``nx hook session-start`` process, which exits *immediately*
+    after spawning chroma. atexit then killed the chroma server within
+    milliseconds of spawn — production T1 silently fell back to
+    EphemeralClient on every Claude conversation between 4.9.1 and the
+    fix. The chroma server is meant to outlive this process; cleanup is
+    the SessionEnd hook's job. This test guards against the regression
+    coming back.
     """
+    import atexit
     from nexus import session
 
     class _FakeProc:
@@ -101,18 +105,22 @@ def test_start_t1_server_registers_atexit_cleanup(monkeypatch) -> None:
     monkeypatch.setattr(session, "_find_chroma", lambda: "/fake/chroma")
     monkeypatch.setattr(session.subprocess, "Popen", lambda *a, **kw: _FakeProc())
     monkeypatch.setattr(session.socket, "create_connection", _fake_create_connection)
-    monkeypatch.setattr(session.atexit, "register", _fake_atexit_register)
+    # Patch atexit at the source — start_t1_server no longer imports it,
+    # but we monkeypatch globally to detect any regression that adds an
+    # atexit registration back in.
+    monkeypatch.setattr(atexit, "register", _fake_atexit_register)
 
     session.start_t1_server()
 
-    matching = [
+    chroma_killers = [
         (func, args)
         for func, args, _ in registered
-        if func is session.stop_t1_server and args == (67890,)
+        if getattr(func, "__name__", "") == "stop_t1_server"
     ]
-    assert matching, (
-        "start_t1_server did not register stop_t1_server(pid) with atexit; "
-        f"registered handlers: {registered}"
+    assert not chroma_killers, (
+        "start_t1_server registered an atexit chroma killer — this kills the "
+        "server right after spawn (PR #220 mistake). Cleanup belongs in "
+        f"SessionEnd. Found: {chroma_killers}"
     )
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -11,11 +11,14 @@ import pytest
 from nexus.session import (
     _stable_pid,
     find_ancestor_session,
+    find_session_by_id,
     generate_session_id,
     read_session_id,
     sweep_stale_sessions,
+    write_claude_session_id,
     write_session_file,
     write_session_record,
+    write_session_record_by_id,
 )
 
 
@@ -176,10 +179,16 @@ def test_sweep_stale_sessions_removes_old_records(tmp_path: Path) -> None:
 
 
 def test_sweep_stale_sessions_keeps_fresh_records(tmp_path: Path) -> None:
-    """Records younger than max_age_hours are not removed."""
+    """UUID-keyed records younger than max_age_hours are not removed.
+
+    NB: Numeric-stem files are now swept *unconditionally* as a migration
+    from the legacy PID-keyed scheme — see
+    test_sweep_stale_sessions_removes_legacy_numeric_stem_unconditionally
+    for that path.
+    """
     sessions = tmp_path / "sessions"
-    path = write_session_record(sessions, ppid=5556, session_id="fresh",
-                                host="127.0.0.1", port=51004, server_pid=102)
+    path = write_session_record_by_id(sessions, "fresh-uuid",
+                                      host="127.0.0.1", port=51004, server_pid=102)
 
     sweep_stale_sessions(sessions_dir=sessions)
     assert path.exists()
@@ -190,10 +199,157 @@ def test_sweep_stale_sessions_noop_on_missing_dir(tmp_path: Path) -> None:
     sweep_stale_sessions(sessions_dir=tmp_path / "nonexistent")  # must not raise
 
 
-def test_sweep_stale_sessions_skips_non_json_files(tmp_path: Path) -> None:
-    """Non-JSON files (e.g. legacy bare-UUID) are ignored silently."""
+def test_sweep_stale_sessions_skips_non_json_uuid_files(tmp_path: Path) -> None:
+    """UUID-stem files with non-JSON content are left alone (no migration applies)."""
     sessions = tmp_path / "sessions"
     sessions.mkdir()
-    (sessions / "9999.session").write_text("bare-uuid")
+    uuid_file = sessions / "abc-123-uuid.session"
+    uuid_file.write_text("bare-uuid-not-json")
     sweep_stale_sessions(sessions_dir=sessions)  # must not raise
-    assert (sessions / "9999.session").exists()  # untouched
+    assert uuid_file.exists()  # untouched: only json-parseable UUID files are evaluated for staleness
+
+
+# ── UUID-keyed session records (current scheme; PID-keyed above is legacy) ──
+
+def test_write_session_record_by_id_uses_uuid_filename(tmp_path: Path) -> None:
+    sessions = tmp_path / "sessions"
+    path = write_session_record_by_id(
+        sessions,
+        session_id="conv-uuid-1234",
+        host="127.0.0.1",
+        port=51234,
+        server_pid=4321,
+    )
+    assert path.name == "conv-uuid-1234.session"
+    assert path.exists()
+    record = json.loads(path.read_text())
+    assert record["session_id"] == "conv-uuid-1234"
+    assert record["server_port"] == 51234
+
+
+def test_find_session_by_id_explicit_id(tmp_path: Path) -> None:
+    sessions = tmp_path / "sessions"
+    write_session_record_by_id(sessions, "uuid-A", "127.0.0.1", 11111, 9001)
+    write_session_record_by_id(sessions, "uuid-B", "127.0.0.1", 22222, 9002)
+
+    rec_a = find_session_by_id(sessions, "uuid-A")
+    assert rec_a is not None and rec_a["server_port"] == 11111
+
+    rec_b = find_session_by_id(sessions, "uuid-B")
+    assert rec_b is not None and rec_b["server_port"] == 22222
+
+
+def test_find_session_by_id_returns_none_for_unknown(tmp_path: Path) -> None:
+    sessions = tmp_path / "sessions"
+    write_session_record_by_id(sessions, "exists", "127.0.0.1", 11111, 9001)
+    assert find_session_by_id(sessions, "does-not-exist") is None
+
+
+def test_find_session_by_id_falls_back_to_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When session_id is not passed explicitly, NX_SESSION_ID env wins."""
+    sessions = tmp_path / "sessions"
+    write_session_record_by_id(sessions, "from-env", "127.0.0.1", 33333, 9003)
+    monkeypatch.setenv("NX_SESSION_ID", "from-env")
+
+    rec = find_session_by_id(sessions)  # no explicit id — reads env
+    assert rec is not None
+    assert rec["server_port"] == 33333
+
+
+def test_find_session_by_id_falls_back_to_flat_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When NX_SESSION_ID env is absent, fall back to current_session flat file."""
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
+
+    # Re-import-time path resolution honours the env var, but the module-level
+    # CLAUDE_SESSION_FILE constant was set at import. Patch it for this test.
+    from nexus import session as _session
+    monkeypatch.setattr(_session, "CLAUDE_SESSION_FILE", tmp_path / "current_session")
+
+    sessions = tmp_path / "sessions"
+    write_session_record_by_id(sessions, "from-flat", "127.0.0.1", 44444, 9004)
+    write_claude_session_id("from-flat")
+
+    rec = find_session_by_id(sessions)
+    assert rec is not None
+    assert rec["server_port"] == 44444
+
+
+def test_find_session_by_id_returns_none_when_no_id_resolvable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+    from nexus import session as _session
+    monkeypatch.setattr(_session, "CLAUDE_SESSION_FILE", tmp_path / "no_such_file")
+
+    assert find_session_by_id(tmp_path / "sessions") is None
+
+
+def test_two_uuids_same_dir_get_distinct_records(tmp_path: Path) -> None:
+    """Bug-fix coverage: two Claude conversations launched from one terminal
+    must end up with distinct session files and reachable independently.
+
+    Pre-fix, both wrote to ~/.config/nexus/sessions/{login_shell_pid}.session
+    and shared the same T1. Post-fix, the UUID is the key, so two distinct
+    UUIDs produce two distinct files with no overlap.
+    """
+    sessions = tmp_path / "sessions"
+    write_session_record_by_id(sessions, "claude-conv-1", "127.0.0.1", 11111, 9101)
+    write_session_record_by_id(sessions, "claude-conv-2", "127.0.0.1", 22222, 9102)
+
+    files = sorted(p.name for p in sessions.glob("*.session"))
+    assert files == ["claude-conv-1.session", "claude-conv-2.session"]
+
+    rec1 = find_session_by_id(sessions, "claude-conv-1")
+    rec2 = find_session_by_id(sessions, "claude-conv-2")
+    assert rec1 is not None and rec2 is not None
+    assert rec1["server_port"] != rec2["server_port"]
+
+
+# ── Migration: legacy numeric-stem files swept on first new-code SessionStart
+
+def test_sweep_stale_sessions_removes_legacy_numeric_stem_unconditionally(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Numeric-stem session files come from the legacy PID-keyed scheme that
+    bound T1 to the terminal session. They never did the right thing —
+    sweep removes them unconditionally on first new-code SessionStart,
+    even if their timestamp is fresh.
+    """
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+
+    # Legacy PID-keyed file with a FRESH timestamp — would have survived the
+    # 24h sweep policy under the old code path.
+    legacy = sessions / "12345.session"
+    import time as _time
+    legacy.write_text(json.dumps({
+        "session_id": "old-uuid",
+        "server_host": "127.0.0.1",
+        "server_port": 55555,
+        "server_pid": 99999,
+        "created_at": _time.time(),
+        "tmpdir": "",
+    }))
+
+    # UUID-keyed file in the new format — should survive.
+    valid = sessions / "valid-uuid.session"
+    valid.write_text(json.dumps({
+        "session_id": "valid-uuid",
+        "server_host": "127.0.0.1",
+        "server_port": 66666,
+        "server_pid": 99998,
+        "created_at": _time.time(),
+        "tmpdir": "",
+    }))
+
+    # No-op the chroma kill so the test doesn't try to signal PID 99999.
+    monkeypatch.setattr("nexus.session.stop_t1_server", lambda _pid: None)
+
+    sweep_stale_sessions(sessions_dir=sessions)
+
+    assert not legacy.exists(), "legacy PID-keyed file should be swept regardless of age"
+    assert valid.exists(), "UUID-keyed file should survive the sweep"


### PR DESCRIPTION
## Summary

T1 \"ephemeral\" scratch was bound to the **terminal session**, not the **Claude conversation**. Two `claude` invocations in the same shell shared one T1 server. Live evidence on the maintainer's machine: `~/.config/nexus/sessions/3226.session` belonged to PID 3226 = `-zsh` (the login shell).

In the course of fixing it, **a second production-impacting bug from the recently-shipped PR #220 surfaced**: the \`atexit\` registration in \`start_t1_server\` was killing every chroma server *immediately* after spawn (it ran inside the short-lived \`nx hook session-start\` process, which exits seconds after the spawn). Result: T1 silently fell back to EphemeralClient on every Claude conversation since 4.9.1 shipped — verified live, the maintainer's session file recorded a server PID that was already dead with **zero** live chroma processes on the box.

Both bugs are fixed in this PR.

## The two bugs, both fixed here

### Bug 1: PID-keyed session files (the originally-reported issue)

`src/nexus/hooks.py:97-106` used a PPID walk added to \"skip a transient shell wrapping nx hook,\" but on systems where Claude Code invokes hooks directly the walk lands on the login shell. The Claude session UUID was already arriving via the SessionStart hook payload (`commands/hook.py:23-29`) but was stored only **inside** the session record, never used as the **filename**.

**Fix:** Drop the PPID walk. Key the session file on the UUID. Lookups resolve via `current_session` flat file (existing primary cross-tree mechanism for subagents) or `NX_SESSION_ID` env var (opt-in for external tools).

### Bug 2: atexit chroma killer (PR #220 regression)

`atexit.register(stop_t1_server, proc.pid)` was added to `start_t1_server` as a defence-in-depth fallback for cases the SessionEnd hook can't cover. The reasoning was wrong: this function runs inside the short-lived hook process which exits within seconds, so atexit killed the chroma server right after spawn.

**Fix:** Remove the atexit registration. The chroma server is meant to outlive the hook process; cleanup belongs to SessionEnd. Ungraceful exits leak the server until the next SessionStart's `sweep_stale_sessions` reaps it — same as the pre-PR-220 design.

## T1 inheritance semantics, finalised

| Caller | Behaviour | How |
|---|---|---|
| Two `claude` instances in same terminal | **Distinct T1** (Bug 1 fix) | Distinct UUIDs → distinct session files |
| Subagent (Agent tool) of one Claude conversation | **Inherits parent's T1** (unchanged) | Reads `current_session` → finds parent's UUID → adopts parent's server |
| `claude_dispatch` (operators, labeler — every `claude -p` we spawn) | **No T1, EphemeralClient** | `NEXUS_SKIP_T1=1` in subprocess env, hook skips server start |
| External `claude -p` user wanting T1 inheritance | **Inherits a specific T1** | Set `NX_SESSION_ID=<parent-uuid>` before spawning |

## Migration

Numeric-stem session files (legacy PID-keyed format) are swept **unconditionally** on first new-code SessionStart, regardless of age. The chroma servers they pointed at were leaked aliases anyway — the sweep reaps them too.

## Files

- `src/nexus/session.py` — `write_session_record_by_id`, `find_session_by_id`, legacy-sweep migration; **atexit registration removed**.
- `src/nexus/hooks.py` — `session_start`/`session_end` use UUID lookup; honour `NEXUS_SKIP_T1`.
- `src/nexus/db/t1.py` — `find_session_by_id` with `find_ancestor_session` fallback for any legacy files still on disk.
- `src/nexus/operators/dispatch.py` — `claude_dispatch` exports `NEXUS_SKIP_T1=1`.

## Tests

- 11 new in `test_session.py` covering UUID-keyed primitives + bug-fix scenario + legacy-sweep migration.
- 1 new in `test_hooks.py` for `NEXUS_SKIP_T1`.
- 4 legacy `test_hooks.py` tests migrated to UUID-keyed semantics.
- 1 new in `test_operator_dispatch.py` asserting `claude_dispatch` exports `NEXUS_SKIP_T1=1`.
- 1 flipped in `test_semaphore_leak_rootcause.py`: `test_start_t1_server_registers_atexit_cleanup` → `test_start_t1_server_does_not_register_atexit_cleanup` (guards against the PR #220 regression coming back).

```
$ uv run pytest tests/test_operator_dispatch.py tests/test_session.py tests/test_hooks.py tests/test_t1.py tests/test_semaphore_leak_rootcause.py tests/test_plugin_structure.py tests/test_mcp_server.py
744 passed, 26 skipped in 16.43s
```

## E2E sandbox: scripts/sandbox-t1-uuid.sh

New shell-level harness that exercises the fix against real chroma servers in an isolated `NEXUS_CONFIG_DIR`. **20/20 checks pass on this branch:**

```
── Test 1: distinct UUIDs get distinct T1 servers (the original bug) ──
  ✓ UUID_A session file present
  ✓ UUID_B session file present
  ✓ no numeric-stem session files leaked
  ✓ UUID_A and UUID_B got distinct ports
  ✓ UUID_A and UUID_B got distinct server PIDs
  ✓ UUID_A's chroma server is alive
  ✓ UUID_B's chroma server is alive
── Test 2: same UUID adopts existing record (subagent inheritance) ──
  ✓ UUID_A's port unchanged after re-invoke
  ✓ UUID_A's pid unchanged after re-invoke
  ✓ UUID_A's server still the same process
── Test 3: NEXUS_SKIP_T1=1 skips server start (claude_dispatch path) ──
  ✓ no session file written for skip-T1 session
  ✓ no extra chroma server spawned for skip-T1 session
── Test 4: legacy {pid}.session migration ──
  ✓ legacy numeric-stem file present before sweep
  ✓ legacy numeric-stem file removed by sweep
  ✓ UUID-keyed file from this sweep run survives
  ✓ previous UUID-keyed files (A, B) survive sweep
── Test 5: SessionEnd cleanup ──
  ✓ UUID_A session file removed by session_end
  ✓ UUID_A tmpdir removed by session_end
  ✓ UUID_A's chroma server reaped
  ✓ UUID_B unaffected by UUID_A's session_end
  ✓ UUID_B's chroma server still alive
```

The sandbox proved the PR #220 atexit regression by failing on \"chroma server is alive\" until the atexit was removed.

## Test plan

- [x] Affected-module unit suite passes (744/744)
- [x] Migration sweep verified to remove legacy numeric-stem files
- [x] **E2E sandbox: 20/20 checks pass** against real chroma servers
- [x] Verified live: PR #220's atexit regression confirmed on the maintainer's machine (zero live chromas, dead PID in session file)
- [ ] Verify on real install once merged: open two `claude` instances in same terminal, confirm `nx scratch list` does not see cross-conversation entries; confirm `pgrep -f 'chroma run.*nx_t1_'` shows live processes (one per conversation)