### PR TITLE
feat(mcp): detect plugin↔CLI version drift at MCP server startup

### DIFF
--- a/nx/.mcp.json
+++ b/nx/.mcp.json
@@ -5,10 +5,16 @@
   },
   "nexus": {
     "command": "nx-mcp",
-    "args": []
+    "args": [],
+    "env": {
+      "CLAUDE_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
+    }
   },
   "nexus-catalog": {
     "command": "nx-mcp-catalog",
-    "args": []
+    "args": [],
+    "env": {
+      "CLAUDE_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
+    }
   }
 }

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -6,6 +6,7 @@ Separated from tool definitions (mcp_server.py) to isolate concerns.
 """
 from __future__ import annotations
 
+import os
 import threading
 import time
 import warnings
@@ -480,51 +481,99 @@ def chash_dual_write_batch(
 
 
 def check_version_compatibility() -> None:
-    """Synchronous check: warn if CLI version diverges from stored version.
+    """Synchronous startup check for two version-drift cases.
 
-    Called from MCP ``main()`` before ``mcp.run()``.  Never blocks startup.
+    Called from each MCP server's ``main()`` before ``mcp.run()`` — the
+    natural single binding point between plugin and CLI (the MCP server
+    binaries ``nx-mcp`` / ``nx-mcp-catalog`` are conexus entry points;
+    plugin/CLI coupling runs entirely through this surface).
+
+    Two warnings, both non-fatal:
+
+    1. **CLI ↔ T2 schema drift** — current ``conexus`` package version
+       differs (minor or major) from ``_nexus_version.cli_version``
+       stored in T2. Suggests ``nx upgrade``. Catches the case where
+       the user upgraded conexus but hasn't run any migration-applying
+       command yet.
+
+    2. **Plugin ↔ CLI version drift** — installed Claude Code plugin's
+       declared version (read from ``${CLAUDE_PLUGIN_ROOT}/.claude-plugin/
+       plugin.json``) differs (minor or major) from the running CLI.
+       Suggests ``/plugin update nx@nexus-plugins`` or
+       ``uv tool upgrade conexus`` depending on which side is older.
+       The plugin and CLI ship from the same repo at the same version
+       (CI enforces marketplace.json parity); drift means one update
+       command was run without the other.
+
+    Never blocks startup — both checks log warnings only.
     """
+    import json
     import sqlite3
+    from pathlib import Path
 
     import structlog
 
     log = structlog.get_logger()
     try:
         from importlib.metadata import version as _pkg_version
-
-        cli_ver = _pkg_version("conexus")
-        db_path = default_db_path()
-        if not db_path.exists():
-            return
-        conn = sqlite3.connect(str(db_path))
-        try:
-            row = conn.execute(
-                "SELECT value FROM _nexus_version WHERE key='cli_version'"
-            ).fetchone()
-        except sqlite3.OperationalError:
-            return  # table doesn't exist yet
-        finally:
-            conn.close()
-        if row is None:
-            return
-        stored_ver = row[0]
         from nexus.db.migrations import _parse_version
 
-        cli_t = _parse_version(cli_ver)
-        stored_t = _parse_version(stored_ver)
-        # Warn on minor or major divergence, not patch.
-        # Tuple slicing is safe for short tuples — (4,)[:2] == (4,).
-        if cli_t[:2] != stored_t[:2]:
-            if cli_t > stored_t:
-                hint = "run 'nx upgrade' to apply pending migrations"
-            else:
-                hint = "DB was upgraded by a newer CLI version"
-            log.warning(
-                "version_mismatch",
-                cli_version=cli_ver,
-                stored_version=stored_ver,
-                hint=hint,
-            )
+        cli_ver = _pkg_version("conexus")
+
+        # ── (1) CLI ↔ T2 schema drift ────────────────────────────────────
+        db_path = default_db_path()
+        if db_path.exists():
+            conn = sqlite3.connect(str(db_path))
+            try:
+                row = conn.execute(
+                    "SELECT value FROM _nexus_version WHERE key='cli_version'"
+                ).fetchone()
+            except sqlite3.OperationalError:
+                row = None  # table doesn't exist yet — fresh install
+            finally:
+                conn.close()
+            if row is not None:
+                stored_ver = row[0]
+                cli_t = _parse_version(cli_ver)
+                stored_t = _parse_version(stored_ver)
+                # Warn on minor or major divergence, not patch.
+                # Tuple slicing is safe for short tuples — (4,)[:2] == (4,).
+                if cli_t[:2] != stored_t[:2]:
+                    if cli_t > stored_t:
+                        hint = "run 'nx upgrade' to apply pending migrations"
+                    else:
+                        hint = "DB was upgraded by a newer CLI version"
+                    log.warning(
+                        "version_mismatch",
+                        cli_version=cli_ver,
+                        stored_version=stored_ver,
+                        hint=hint,
+                    )
+
+        # ── (2) Plugin ↔ CLI version drift ──────────────────────────────
+        plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+        if plugin_root:
+            manifest_path = Path(plugin_root) / ".claude-plugin" / "plugin.json"
+            try:
+                manifest = json.loads(manifest_path.read_text())
+                plugin_ver = manifest.get("version")
+            except (OSError, json.JSONDecodeError):
+                plugin_ver = None
+            if plugin_ver:
+                cli_t = _parse_version(cli_ver)
+                plugin_t = _parse_version(plugin_ver)
+                if cli_t[:2] != plugin_t[:2]:
+                    # Choose the actionable update for the lagging side.
+                    if cli_t > plugin_t:
+                        hint = "plugin is older — run '/plugin update nx@nexus-plugins' in Claude Code"
+                    else:
+                        hint = "CLI is older — run 'uv tool upgrade conexus'"
+                    log.warning(
+                        "plugin_cli_version_mismatch",
+                        cli_version=cli_ver,
+                        plugin_version=plugin_ver,
+                        hint=hint,
+                    )
     except Exception:
         pass  # never block MCP startup
 

--- a/tests/test_phase5_integration.py
+++ b/tests/test_phase5_integration.py
@@ -142,6 +142,127 @@ class TestMcpVersionCheck:
             check_version_compatibility()  # should not raise
 
 
+class TestPluginCliVersionCheck:
+    """Plugin↔CLI drift detection at MCP server startup.
+
+    The MCP server is the single binding point between the Claude Code
+    plugin and the conexus CLI (``nx-mcp`` / ``nx-mcp-catalog`` are
+    conexus entry points). On startup, ``check_version_compatibility``
+    reads the plugin manifest at ``${CLAUDE_PLUGIN_ROOT}/.claude-plugin/
+    plugin.json`` and warns on minor or major divergence from the
+    installed CLI.
+    """
+
+    def _write_plugin_manifest(self, root: Path, version: str) -> None:
+        manifest_dir = root / ".claude-plugin"
+        manifest_dir.mkdir(parents=True, exist_ok=True)
+        (manifest_dir / "plugin.json").write_text(
+            json.dumps({"name": "nx", "version": version})
+        )
+
+    def test_no_plugin_root_silent(self, tmp_path: Path, monkeypatch) -> None:
+        """No CLAUDE_PLUGIN_ROOT env → plugin check is silent (CLI usage)."""
+        from nexus.mcp_infra import check_version_compatibility
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+
+        with (
+            patch("nexus.mcp_infra.default_db_path", return_value=tmp_path / "no.db"),
+            patch("importlib.metadata.version", return_value="4.9.2"),
+            patch("structlog.get_logger") as mock_get_logger,
+        ):
+            check_version_compatibility()
+            mock_get_logger.return_value.warning.assert_not_called()
+
+    def test_plugin_version_matches_cli_no_warning(self, tmp_path: Path, monkeypatch) -> None:
+        from nexus.mcp_infra import check_version_compatibility
+
+        plugin_root = tmp_path / "plugin"
+        self._write_plugin_manifest(plugin_root, "4.9.2")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        with (
+            patch("nexus.mcp_infra.default_db_path", return_value=tmp_path / "no.db"),
+            patch("importlib.metadata.version", return_value="4.9.2"),
+            patch("structlog.get_logger") as mock_get_logger,
+        ):
+            check_version_compatibility()
+            mock_get_logger.return_value.warning.assert_not_called()
+
+    def test_patch_divergence_no_warning(self, tmp_path: Path, monkeypatch) -> None:
+        from nexus.mcp_infra import check_version_compatibility
+
+        plugin_root = tmp_path / "plugin"
+        self._write_plugin_manifest(plugin_root, "4.9.1")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        with (
+            patch("nexus.mcp_infra.default_db_path", return_value=tmp_path / "no.db"),
+            patch("importlib.metadata.version", return_value="4.9.2"),
+            patch("structlog.get_logger") as mock_get_logger,
+        ):
+            check_version_compatibility()
+            mock_get_logger.return_value.warning.assert_not_called()
+
+    def test_cli_newer_warns_with_plugin_update_hint(self, tmp_path: Path, monkeypatch) -> None:
+        """CLI is at a newer minor version → user should run /plugin update."""
+        from nexus.mcp_infra import check_version_compatibility
+
+        plugin_root = tmp_path / "plugin"
+        self._write_plugin_manifest(plugin_root, "4.9.0")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        with (
+            patch("nexus.mcp_infra.default_db_path", return_value=tmp_path / "no.db"),
+            patch("importlib.metadata.version", return_value="4.10.0"),
+            patch("structlog.get_logger") as mock_get_logger,
+        ):
+            check_version_compatibility()
+            mock_log = mock_get_logger.return_value
+            mock_log.warning.assert_called_once()
+            event, kwargs = mock_log.warning.call_args.args[0], mock_log.warning.call_args.kwargs
+            assert event == "plugin_cli_version_mismatch"
+            assert kwargs["cli_version"] == "4.10.0"
+            assert kwargs["plugin_version"] == "4.9.0"
+            assert "/plugin update" in kwargs["hint"]
+
+    def test_plugin_newer_warns_with_uv_upgrade_hint(self, tmp_path: Path, monkeypatch) -> None:
+        """Plugin is at a newer minor version → user should run uv tool upgrade conexus."""
+        from nexus.mcp_infra import check_version_compatibility
+
+        plugin_root = tmp_path / "plugin"
+        self._write_plugin_manifest(plugin_root, "4.10.0")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        with (
+            patch("nexus.mcp_infra.default_db_path", return_value=tmp_path / "no.db"),
+            patch("importlib.metadata.version", return_value="4.9.2"),
+            patch("structlog.get_logger") as mock_get_logger,
+        ):
+            check_version_compatibility()
+            mock_log = mock_get_logger.return_value
+            mock_log.warning.assert_called_once()
+            kwargs = mock_log.warning.call_args.kwargs
+            assert "uv tool upgrade conexus" in kwargs["hint"]
+
+    def test_corrupt_manifest_silent(self, tmp_path: Path, monkeypatch) -> None:
+        """Corrupt plugin.json must not crash MCP startup."""
+        from nexus.mcp_infra import check_version_compatibility
+
+        plugin_root = tmp_path / "plugin"
+        manifest_dir = plugin_root / ".claude-plugin"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "plugin.json").write_text("{not-json{{{")
+        monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+
+        with (
+            patch("nexus.mcp_infra.default_db_path", return_value=tmp_path / "no.db"),
+            patch("importlib.metadata.version", return_value="4.9.2"),
+            patch("structlog.get_logger") as mock_get_logger,
+        ):
+            check_version_compatibility()  # must not raise
+            mock_get_logger.return_value.warning.assert_not_called()
+
+
 # ── doctor --check-schema tests ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes the version-drift gap discussed during the 4.9.2 cut. The Claude Code plugin and conexus CLI are versioned in lockstep from one `pyproject.toml` (CI enforces marketplace.json parity), but the user runs two separate update commands:

- `uv tool upgrade conexus`
- `/plugin update nx@nexus-plugins`

Either can be run without the other. After drift, the plugin's hooks may invoke flags the CLI no longer recognises, or vice versa — silent breakage mid-session.

## The right place to detect this

The plugin and CLI are functionally coupled **through the MCP servers** (`nx-mcp`, `nx-mcp-catalog`) — both are conexus entry points; the plugin's MCP tool definitions resolve to CLI code paths. Hook scripts are a side channel for context injection. The MCP server boot is therefore the single binding point where drift can be both detected and surfaced visibly.

`check_version_compatibility()` (`src/nexus/mcp_infra.py:482`) already runs at every MCP server `main()` for one drift case — CLI vs T2 schema. This PR extends it with a second case.

## Changes

- **`nx/.mcp.json`** — explicit `env: {"CLAUDE_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"}` on the `nexus` and `nexus-catalog` servers. Without this, `${CLAUDE_PLUGIN_ROOT}` is only available for *path substitution* in `.mcp.json` (per Claude Code's plugin reference) — the spawned MCP server itself wouldn't see it as an env var. With it, the server can `os.environ.get("CLAUDE_PLUGIN_ROOT")` reliably.

- **`src/nexus/mcp_infra.py:check_version_compatibility()`** — adds a second check after the existing T2-schema drift logic:
  - Read `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`
  - Compare its `version` field against `importlib.metadata.version(\"conexus\")`
  - Log `plugin_cli_version_mismatch` warning on minor or major divergence, with the actionable update hint for the lagging side
  - Patch-level drift ignored (within-minor releases are wire-compatible)
  - Never blocks startup — warning only, same policy as the existing check

- **`tests/test_phase5_integration.py:TestPluginCliVersionCheck`** — six new tests covering: no `CLAUDE_PLUGIN_ROOT` (CLI usage), version match, patch-only drift, CLI-newer (warns with `/plugin update`), plugin-newer (warns with `uv tool upgrade conexus`), corrupt manifest (silent).

## Best-practice grounding

Surveyed plugin/host version-coupling patterns across npm/Node, VSCode, Cargo, pip, Homebrew, OSGi, JupyterLab, Chrome. Three archetypes:

| Archetype | Where it works | Why it doesn't fit us |
|---|---|---|
| Lockstep release (Cargo+rustup) | Single update channel | We have two user-facing update commands |
| Manifest declaration + install enforcement (npm engines, pip requires-python) | Registry that enforces | Claude Code doesn't enforce `engines` |
| **Manifest declaration + runtime drift check** (VSCode, OSGi, JupyterLab, Chrome) | Plugin host that rechecks on every load | **Best fit — and our MCP server boot IS the plugin host load event** |

This PR implements the third archetype, scoped to our single-binding-point: one function extension, no new infrastructure.

## Tests

```
$ uv run pytest tests/test_phase5_integration.py::TestPluginCliVersionCheck tests/test_phase5_integration.py::TestMcpVersionCheck
11 passed in 0.08s

$ uv run pytest tests/test_phase5_integration.py tests/test_mcp_server.py tests/test_upgrade_e2e.py
109 passed in 11.68s
```

## Test plan

- [x] All 6 new test cases pass (match, patch drift, both directions of minor drift, corrupt manifest, no env)
- [x] Existing `TestMcpVersionCheck` (CLI ↔ T2 schema drift) unchanged + still passes
- [x] Wider phase5 + mcp_server + upgrade_e2e modules still pass
- [ ] Verify on real install once merged: drop a stale `plugin.json` (e.g. version=4.8.0) under a fake `CLAUDE_PLUGIN_ROOT` and start `nx-mcp`, confirm warning appears in MCP server logs