### PR TITLE
fix(session): nested subprocesses no longer stomp parent's current_session

### DIFF
--- a/scripts/sandbox-t1-uuid.sh
+++ b/scripts/sandbox-t1-uuid.sh
@@ -155,14 +155,41 @@ echo
 echo "── Test 3: NEXUS_SKIP_T1=1 skips server start (claude_dispatch path) ──"
 
 UUID_SKIP="33333333-cccc-cccc-cccc-cccccccccccc"
+CHROMA_COUNT_BEFORE_SKIP=$(pgrep -f 'chroma run --host 127.0.0.1.*nx_t1_' 2>/dev/null | wc -l | tr -d ' ')
 session_start_skip_t1 "$UUID_SKIP"
+CHROMA_COUNT_AFTER_SKIP=$(pgrep -f 'chroma run --host 127.0.0.1.*nx_t1_' 2>/dev/null | wc -l | tr -d ' ')
 
 check "no session file written for skip-T1 session" \
   bash -c "! test -f $SESSIONS_DIR/$UUID_SKIP.session"
-CHROMA_COUNT_BEFORE_SKIP=2
-ACTUAL_CHROMA_COUNT=$(pgrep -f 'chroma run --host 127.0.0.1.*nx_t1_' | wc -l | tr -d ' ')
 check "no extra chroma server spawned for skip-T1 session" \
-  test "$ACTUAL_CHROMA_COUNT" -eq "$CHROMA_COUNT_BEFORE_SKIP"
+  test "$CHROMA_COUNT_AFTER_SKIP" -eq "$CHROMA_COUNT_BEFORE_SKIP"
+
+# ── Test 3b: nested session_start does NOT stomp current_session ─────────────
+# Bug-fix coverage for the "operator subprocess overwrites parent's
+# current_session pointer" issue. With NX_SESSION_ID inherited (the way
+# claude_dispatch sets it), the nested SessionStart must preserve the
+# parent's pointer so shell-side `nx scratch` etc. still find the
+# parent's T1 record after the operator returns.
+
+echo
+echo "── Test 3b: nested SessionStart preserves parent's current_session ──"
+
+# Capture the parent's current_session before the nested call.
+PARENT_CURRENT=$(cat "$SANDBOX_DIR/current_session" 2>/dev/null)
+NESTED_UUID="55555555-eeee-eeee-eeee-eeeeeeeeeeee"
+
+echo "{\"session_id\": \"$NESTED_UUID\"}" \
+  | NEXUS_CONFIG_DIR="$SANDBOX_DIR" \
+    NX_SESSION_ID="$PARENT_CURRENT" \
+    NEXUS_SKIP_T1=1 \
+    uv run --quiet --project "$REPO_ROOT" -- nx hook session-start >/dev/null
+
+CURRENT_AFTER_NESTED=$(cat "$SANDBOX_DIR/current_session" 2>/dev/null)
+
+check "current_session unchanged after nested SessionStart" \
+  test "$PARENT_CURRENT" = "$CURRENT_AFTER_NESTED"
+check "current_session still points at parent UUID, not nested UUID" \
+  test "$CURRENT_AFTER_NESTED" != "$NESTED_UUID"
 
 # ── Test 4: Legacy numeric-stem files swept on next SessionStart ─────────────
 

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2026 Hal Hildebrand. All rights reserved.
 from __future__ import annotations
 
+import os
 import warnings
 from collections.abc import Callable
 from typing import TypeVar
@@ -137,13 +138,23 @@ class T1Database:
             self._client = client
             self._session_id = session_id or str(uuid4())
         else:
-            # UUID-keyed lookup (T1 scoped to Claude conversation, not
-            # terminal session). find_session_by_id resolves the UUID
-            # from NX_SESSION_ID env or current_session flat file.
-            # Falls back to find_ancestor_session for any legacy session
-            # files written by older nexus versions still living in
-            # ~/.config/nexus/sessions/{ppid}.session.
-            record = find_session_by_id(SESSIONS_DIR) or find_ancestor_session(SESSIONS_DIR)
+            # NEXUS_SKIP_T1=1 (set by claude_dispatch for stateless operator
+            # subprocesses) → go straight to EphemeralClient without searching
+            # for a server. Without this short-circuit, the subprocess inherits
+            # NX_SESSION_ID=<parent-uuid> from claude_dispatch and would
+            # inadvertently connect to the parent's T1 server, breaking the
+            # stateless-operator intent (operators reading/writing parent's
+            # scratch is precisely what we want to avoid).
+            skip_t1 = os.environ.get("NEXUS_SKIP_T1", "").strip().lower() in ("1", "true", "yes")
+            record = None
+            if not skip_t1:
+                # UUID-keyed lookup (T1 scoped to Claude conversation, not
+                # terminal session). find_session_by_id resolves the UUID
+                # from NX_SESSION_ID env or current_session flat file.
+                # Falls back to find_ancestor_session for any legacy session
+                # files written by older nexus versions still living in
+                # ~/.config/nexus/sessions/{ppid}.session.
+                record = find_session_by_id(SESSIONS_DIR) or find_ancestor_session(SESSIONS_DIR)
             if record is not None:
                 self._client = chromadb.HttpClient(
                     host=record["server_host"],
@@ -151,11 +162,15 @@ class T1Database:
                 )
                 self._session_id = record["session_id"]
             else:
-                warnings.warn(
-                    "No T1 server found; falling back to local EphemeralClient. "
-                    "Cross-agent scratch sharing is unavailable for this session.",
-                    stacklevel=2,
-                )
+                if not skip_t1:
+                    # Only warn when the absence of a T1 server is unexpected.
+                    # Skip-T1 is the stateless-operator path; the EphemeralClient
+                    # fallback is the documented intended behaviour there.
+                    warnings.warn(
+                        "No T1 server found; falling back to local EphemeralClient. "
+                        "Cross-agent scratch sharing is unavailable for this session.",
+                        stacklevel=2,
+                    )
                 from nexus.session import read_claude_session_id
                 self._client = chromadb.EphemeralClient()
                 self._session_id = session_id or read_claude_session_id() or str(uuid4())

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -78,18 +78,24 @@ def session_start(claude_session_id: str | None = None) -> str:
     # the old PID-keyed scheme are reaped unconditionally here.
     sweep_stale_sessions(SESSIONS_DIR)
 
-    # Initialize session_id before the lock block so it is always bound even
-    # if flock or find_session_by_id raises an unexpected exception. The
-    # claude_session_id arrives via stdin from the SessionStart hook payload
-    # (commands/hook.py) — that's the canonical Claude conversation UUID.
-    session_id = claude_session_id or generate_session_id()
+    # Resolve session_id with this precedence:
+    #   1. ``NX_SESSION_ID`` env  — we're a nested subprocess our parent
+    #      already populated. Inherit the parent's UUID so shell tools
+    #      that look up by ``current_session`` still find the parent's
+    #      record.
+    #   2. ``claude_session_id`` from stdin — top-level Claude session.
+    #      The hook payload (commands/hook.py) carries the canonical
+    #      conversation UUID Claude Code generated.
+    #   3. A fresh UUID — fallback for invocations outside Claude Code.
+    inherited = os.environ.get("NX_SESSION_ID", "").strip() or None
+    session_id = inherited or claude_session_id or generate_session_id()
 
     # Honor NEXUS_SKIP_T1 — set by ``claude_dispatch`` (and any caller of
     # ``claude -p`` where T1 inheritance is undesirable) so short-lived
     # operator subprocesses don't pay the chroma startup cost or pollute
     # session bookkeeping. The T1 client (``db/t1.py``) falls back to
-    # EphemeralClient when no server record is found, so skipping the
-    # server start here yields the right "no T1" semantics automatically.
+    # EphemeralClient when this env is set, so skipping the server start
+    # here yields the right "no T1" semantics automatically.
     skip_t1 = os.environ.get("NEXUS_SKIP_T1", "").strip().lower() in ("1", "true", "yes")
 
     if not skip_t1:
@@ -125,14 +131,17 @@ def session_start(claude_session_id: str | None = None) -> str:
         finally:
             os.close(lock_fd)  # closing the fd releases the flock automatically
 
-    # Persist the UUID for cross-tree inheritance via the ``current_session``
-    # flat file. This is the actual mechanism that propagates the session ID
-    # across Claude Code → Bash tool → nx command boundaries (subagent
-    # SessionStart hooks read the file, find the parent's UUID, and adopt
-    # the parent's T1 server). Always written, even when skip_t1 is set, so
-    # a subagent invoked from a skip-T1 parent can still cohere on its own
-    # session if it later writes a server record.
-    write_claude_session_id(session_id)
+    # Persist the UUID via ``current_session`` flat file — only when this is
+    # a TOP-LEVEL session. Nested subprocesses (operator ``claude -p`` calls,
+    # subagents) inherit ``NX_SESSION_ID`` from their parent's env and must
+    # leave the parent's pointer alone. Without this guard, a nested
+    # subprocess's SessionStart would stomp the flat file with its own
+    # transient UUID — typically pointing at no on-disk session record at
+    # all (because skip_t1 was set) — and the parent's shell-side
+    # ``nx scratch`` / ``nx memory`` would then fall back to EphemeralClient
+    # for the rest of the conversation.
+    if not inherited:
+        write_claude_session_id(session_id)
 
     # T2 memory context is surfaced by session_start_hook.py (via t2_prefix_scan.py)
     # which provides multi-namespace, snippet-enriched output. No duplication here.

--- a/src/nexus/operators/dispatch.py
+++ b/src/nexus/operators/dispatch.py
@@ -75,14 +75,28 @@ async def claude_dispatch(
     # claude leader and orphans the children.
     #
     # NEXUS_SKIP_T1=1 tells the subprocess's nx SessionStart hook to NOT
-    # spin up a chroma T1 server. Operator dispatch is stateless — each
+    # spin up a chroma T1 server, and tells the T1 client to go straight
+    # to EphemeralClient. Operator dispatch is stateless — each
     # `claude -p` invocation is a one-shot call that takes its input from
     # the prompt and produces structured JSON output. There's no cross-
     # invocation scratch to preserve, so paying the chroma startup cost
-    # for every call would be pure waste. The subprocess's T1 client
-    # falls back to EphemeralClient when no server is found, which is
-    # the correct semantics here: isolated, in-process, no cross talk.
+    # for every call would be pure waste.
+    #
+    # NX_SESSION_ID=<parent-uuid> tells the subprocess's SessionStart hook
+    # that it is a NESTED session — its own conversation UUID arrives via
+    # the stdin payload, but it should preserve the parent's
+    # ``current_session`` flat-file pointer instead of stomping it. Without
+    # this, the subprocess's hook would write its own UUID into
+    # ``current_session``, the file would point at no on-disk record (skip-
+    # T1 wrote none), and the parent's shell-side ``nx scratch`` would fall
+    # back to EphemeralClient for the rest of the parent conversation.
+    # ``read_claude_session_id`` reads the parent's UUID at dispatch time —
+    # the parent's SessionStart populated it before any operator runs.
+    from nexus.session import read_claude_session_id
     env = {**os.environ, "NEXUS_SKIP_T1": "1"}
+    parent_session_id = read_claude_session_id()
+    if parent_session_id:
+        env["NX_SESSION_ID"] = parent_session_id
     proc = await asyncio.create_subprocess_exec(
         "claude", "-p",
         "--output-format", "json",

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -83,6 +83,57 @@ def test_session_start_adopts_existing_session_for_same_uuid(tmp_path: Path) -> 
     mock_start.assert_not_called()  # should NOT start a new server
 
 
+def test_session_start_does_not_overwrite_current_session_when_inherited(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nested subprocess (NX_SESSION_ID set in env) must NOT stomp the
+    parent's ``current_session`` flat file. Without this guard, every
+    operator ``claude -p`` call would overwrite the parent's UUID with
+    its own transient one, and the parent's shell-side ``nx scratch``
+    would fall back to EphemeralClient for the rest of the conversation.
+    """
+    monkeypatch.setenv("NX_SESSION_ID", "parent-uuid-keep-me")
+    mock_write = MagicMock()
+
+    with (
+        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
+        patch("nexus.hooks.sweep_stale_sessions"),
+        patch("nexus.hooks.find_session_by_id", return_value=None),
+        patch("nexus.hooks.start_t1_server", side_effect=RuntimeError("no T1")),
+        patch("nexus.hooks.write_claude_session_id", mock_write),
+        patch("nexus.hooks._infer_repo", return_value="myrepo"),
+    ):
+        output = session_start(claude_session_id="my-own-transient-uuid")
+
+    # The hook should have used the inherited UUID (not the stdin one)
+    assert "parent-uuid-keep-me" in output
+    # And must NOT have written current_session — that would stomp the parent
+    mock_write.assert_not_called()
+
+
+def test_session_start_writes_current_session_when_top_level(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Top-level Claude session (no NX_SESSION_ID inherited) writes
+    ``current_session`` as today, populating the cross-tree pointer
+    that shell tools and subagents rely on.
+    """
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
+    mock_write = MagicMock()
+
+    with (
+        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
+        patch("nexus.hooks.sweep_stale_sessions"),
+        patch("nexus.hooks.find_session_by_id", return_value=None),
+        patch("nexus.hooks.start_t1_server", side_effect=RuntimeError("no T1")),
+        patch("nexus.hooks.write_claude_session_id", mock_write),
+        patch("nexus.hooks._infer_repo", return_value="myrepo"),
+    ):
+        session_start(claude_session_id="top-level-uuid")
+
+    mock_write.assert_called_once_with("top-level-uuid")
+
+
 def test_session_start_skips_t1_when_env_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """NEXUS_SKIP_T1 honoured: claude_dispatch (and similar one-shot
     `claude -p` callers) sets this so the subprocess does not pay the

--- a/tests/test_operator_dispatch.py
+++ b/tests/test_operator_dispatch.py
@@ -202,6 +202,60 @@ class TestSubprocessContract:
         )
 
     @pytest.mark.asyncio
+    async def test_sets_nx_session_id_env_from_current_session(self) -> None:
+        """claude_dispatch must read the parent's UUID from current_session
+        and export it as NX_SESSION_ID for the subprocess. Without this, the
+        subprocess's SessionStart hook can't tell it's a nested call and
+        will stomp the parent's current_session pointer.
+        """
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc()
+        captured: list = []
+
+        async def intercept(*args, **kwargs):
+            captured.append(kwargs)
+            return proc
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=intercept),
+            patch("nexus.session.read_claude_session_id", return_value="parent-uuid-from-flat-file"),
+        ):
+            await claude_dispatch("prompt", _SIMPLE_SCHEMA)
+
+        env = captured[0].get("env")
+        assert env is not None
+        assert env.get("NX_SESSION_ID") == "parent-uuid-from-flat-file", (
+            f"NX_SESSION_ID missing or wrong; got {env.get('NX_SESSION_ID')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_omits_nx_session_id_when_no_parent_session(self) -> None:
+        """When there's no parent session (e.g. CLI usage outside Claude Code),
+        claude_dispatch must not export an empty/None NX_SESSION_ID — the
+        subprocess's hook would treat that as 'top-level' anyway, but exporting
+        a junk value risks confusion.
+        """
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc()
+        captured: list = []
+
+        async def intercept(*args, **kwargs):
+            captured.append(kwargs)
+            return proc
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=intercept),
+            patch("nexus.session.read_claude_session_id", return_value=None),
+        ):
+            await claude_dispatch("prompt", _SIMPLE_SCHEMA)
+
+        env = captured[0].get("env")
+        assert env is not None
+        assert "NX_SESSION_ID" not in env or not env.get("NX_SESSION_ID")
+
+    @pytest.mark.asyncio
     async def test_sets_skip_t1_env(self) -> None:
         """claude_dispatch must export NEXUS_SKIP_T1=1 in the subprocess env so
         the spawned `claude -p`'s nx SessionStart hook does not spin up a chroma

--- a/tests/test_t1.py
+++ b/tests/test_t1.py
@@ -61,6 +61,46 @@ class TestT1DatabaseConstructor:
         t1 = T1Database(client=chromadb.EphemeralClient())
         assert t1._session_id
 
+    def test_skip_t1_env_short_circuits_to_ephemeral(self, monkeypatch) -> None:
+        """NEXUS_SKIP_T1=1 (set by claude_dispatch for stateless operator
+        subprocesses) must skip the server lookup entirely and use
+        EphemeralClient — even if NX_SESSION_ID is set in env (which would
+        otherwise resolve to the parent's record). Without this short-
+        circuit, the operator would inadvertently connect to the parent's
+        T1 server and could read/write the parent's scratch.
+
+        Also: the warning that normally fires when no T1 server is found
+        must be suppressed in the skip-T1 case, since EphemeralClient is
+        the documented intended behaviour, not a degraded fallback.
+        """
+        monkeypatch.setenv("NEXUS_SKIP_T1", "1")
+        # Set NX_SESSION_ID to simulate the operator-subprocess scenario; if
+        # the short-circuit failed, find_session_by_id would resolve this
+        # and HttpClient would get called.
+        monkeypatch.setenv("NX_SESSION_ID", "parent-uuid-not-mine")
+
+        find_calls: list[None] = []
+
+        def _should_not_be_called(*args, **kwargs):
+            find_calls.append(None)
+            return None
+
+        with (
+            patch("nexus.db.t1.find_session_by_id", side_effect=_should_not_be_called),
+            patch("nexus.db.t1.find_ancestor_session", side_effect=_should_not_be_called),
+            warnings.catch_warnings(record=True) as w,
+        ):
+            warnings.simplefilter("always")
+            t1 = T1Database()
+
+        assert not find_calls, "skip-T1 must not search for a session record"
+        assert not hasattr(t1._client, "_api_url"), "must use EphemeralClient"
+        # The "No T1 server found" warning is for the unexpected case;
+        # skip-T1 is the intended path and should be silent.
+        assert not any("EphemeralClient" in str(x.message) for x in w), (
+            f"skip-T1 should not warn about EphemeralClient fallback; got {[str(x.message) for x in w]}"
+        )
+
     def test_http_constructor_reads_real_session_file(self, tmp_path, monkeypatch) -> None:
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()


### PR DESCRIPTION
## Summary

After a parent Claude session runs any operator that spawns a `claude -p` subprocess (`operator_summarize`, `operator_generate`, etc.), the parent's shell-side `nx scratch` / `nx memory` started warning `"No T1 server found; falling back to local EphemeralClient"` and returning empty results for the rest of the parent conversation. MCP tool calls from the same session continued to work.

## Reproducer

```
1. Top-level Claude session: cat ~/.config/nexus/current_session → parent UUID
2. nx scratch list → succeeds, no warning
3. Invoke operator_summarize (or any tool that fires claude_dispatch)
4. cat ~/.config/nexus/current_session → now shows the SUBPROCESS UUID
5. ls ~/.config/nexus/sessions/ → no record for that UUID (skip-T1 wrote none)
6. nx scratch list → warns and falls back to ephemeral, persistent for the rest of the session
```

## Root cause

`session_start` called `write_claude_session_id(session_id)` unconditionally on every SessionStart. The flat file is single-slot, so subprocess-born Claude sessions (operator `claude -p` invocations) last-writer-win. The shell-side resolver in `db/t1.py` then read the ghost subprocess UUID, found no session record (skip-T1 wrote none), and silently fell back to EphemeralClient.

## Fix — three coordinated changes

The user's bug report proposed a one-line guard in `session_start`. That guard alone wouldn't have worked: `NX_SESSION_ID` was never populated for nested subprocesses, so the discriminator had nothing to discriminate on. The full fix needs three coordinated pieces:

| | Change | Why |
|---|---|---|
| **1** | `claude_dispatch` (`operators/dispatch.py`) reads parent's UUID from `current_session` and exports it as `NX_SESSION_ID` in the subprocess env | Populates the discriminator for nested subprocesses |
| **2** | `session_start` (`hooks.py`) honours `NX_SESSION_ID` env: prefers it over stdin's `claude_session_id`, AND skips the `write_claude_session_id()` call | Preserves the parent's flat-file pointer (the user's proposed guard) |
| **3** | `T1Database.__init__` (`db/t1.py`) respects `NEXUS_SKIP_T1`: short-circuits to EphemeralClient WITHOUT searching for a session record | Without this, change (1) accidentally connects operators to the parent's T1 server, defeating the stateless-operator intent |

## Tests

```
$ uv run pytest tests/test_hooks.py tests/test_t1.py tests/test_operator_dispatch.py tests/test_session.py tests/test_phase5_integration.py
109 passed in 1.27s
```

New test coverage:
- `test_hooks.py::test_session_start_does_not_overwrite_current_session_when_inherited` — the user's exact proposed test
- `test_hooks.py::test_session_start_writes_current_session_when_top_level` — ensures top-level path still works
- `test_t1.py::test_skip_t1_env_short_circuits_to_ephemeral` — ensures step (3) is honoured even with NX_SESSION_ID set
- `test_operator_dispatch.py::test_sets_nx_session_id_env_from_current_session` — ensures step (1) populates the env
- `test_operator_dispatch.py::test_omits_nx_session_id_when_no_parent_session` — handles CLI-only usage cleanly

## E2E sandbox

`scripts/sandbox-t1-uuid.sh` now has 22 checks (was 20). New **Test 3b** exercises the bug-fix scenario directly: invoke a nested SessionStart with both `NX_SESSION_ID` and `NEXUS_SKIP_T1` set; assert `current_session` is unchanged. Also fixed a pre-existing bug in Test 3's chroma-count assertion (was hardcoded to `2`; now captures count before/after the skip-T1 invocation and asserts no growth — robust to leftover system state).

```
── Test 3b: nested SessionStart preserves parent's current_session ──
  ✓ current_session unchanged after nested SessionStart
  ✓ current_session still points at parent UUID, not nested UUID
```

22/22 sandbox checks pass.

## Out-of-scope follow-up (per bug reporter's notes)

Claude Code's Bash tool doesn't export `NX_SESSION_ID` into shell subprocess env. Subagent SessionStart hooks (where we don't control the spawn) can't see `NX_SESSION_ID` and will still treat themselves as top-level. This PR fixes the operator subprocess case (where we *do* control the spawn via `claude_dispatch`); the subagent case stays a separate concern — acceptable since subagents don't currently pollute the same way (they tend to write their own session record, not skip-T1).

## Test plan

- [x] All affected unit tests pass (109/109 across the surface)
- [x] E2E sandbox passes 22/22 including new Test 3b
- [x] Pre-existing Test 3 bug fixed (hardcoded count → before/after diff)
- [ ] Verify on real install once merged: open Claude session, invoke `operator_summarize` from MCP, confirm `nx scratch list` afterward still finds the parent's T1 server