### PR TITLE
fix(shakeout): six findings from 2026-04-20 fresh-instance shakeout (nexus-43pq)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`nx store delete` left the catalog entry visible until the next `nx catalog gc`** (`src/nexus/commands/store.py`). The MCP `catalog_links` tool already filtered deleted-endpoint links immediately, so the eventual-consistency gap surprised users who expected delete to be atomic. After the T3 delete succeeds, look up each doc by `meta.doc_id`, tombstone the catalog row, and remove it from SQLite. Best-effort: silently skips when the catalog is uninitialised. (nexus-43pq)
+- **`nx scratch get` rejected the 8-char prefix that `nx scratch list` printed** (`src/nexus/commands/scratch.py`). `delete` already accepted the prefix; `get` required the full UUID, breaking the natural `list → get <prefix>` copy-paste flow. Extracted `_resolve_entry_id()` from `delete_cmd` and reused it in `get`. Ambiguous prefixes still error with the candidate count. (nexus-43pq)
+- **`nx collection info` reported the cloud Voyage model name in local mode** (`src/nexus/commands/collection.py`). `embedding_model_for_collection()` always returns the Voyage tag (its docstring even says "callers in local mode bypass this"); collection info forgot to. Now branches on `is_local_mode()` and reports `<minilm-or-bge> (local)` when local. Prevents callers from trusting the collection's self-reported model and reindexing with an incompatible embedder. (nexus-43pq)
+- **`nx search` printed `:0:<content>` for results without a `source_path`** (`src/nexus/formatters.py`). The `path:line:content` format gracefully degrades to empty path + line 0 for `knowledge__*` / `docs__*` entries that aren't file-backed. `format_plain` now falls back to the MCP-style `[distance] title\n  snippet` format when no source path is present. (nexus-43pq)
+- **`nx doctor` printed `Fix:` under passing (`✓`) checks** (`src/nexus/health.py`). The `Embedding model: all-MiniLM-L6-v2 (384d)` line carried `Fix: Upgrade: pip install conexus[local]…` even though nothing was broken. Renamed the prefix to `Suggest:` for `r.ok=True` results; `Fix:` is reserved for actual failures. (nexus-43pq)
+- **`nx doctor` reported `T1 sessions: N session file(s), no orphans detected` even when sessions belonged to dead Claude Code instances** (`src/nexus/health.py`). The orphan check only inspects whether the chroma server PID is alive; long-lived chroma servers from prior conversations are technically "live" by that definition. Output now lists each session file with `(pid <N> alive, age <H>m/h)` so the state is transparent — and the failure message clarifies that "orphan" means the chroma pid is dead. (nexus-43pq)
+
+### Changed
+
+- **`nx store --help` tagline** updated from `(ChromaDB Cloud + Voyage AI)` to `(local ChromaDB or Cloud + Voyage AI)`. Local mode is the zero-config default; the prior tagline misled fresh installs. (nexus-43pq)
+- **MCP `scratch` list / search** display now uses the same 8-character UUID prefix as the `nx scratch list` CLI (`src/nexus/mcp/core.py`). Previously the MCP surface showed 12 chars while the CLI showed 8, complicating copy-paste between the two. (nexus-43pq)
+
 ## [4.9.3] - 2026-04-20
 
 ### Fixed

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -36,8 +36,14 @@ def info_cmd(name: str) -> None:
     if match is None:
         raise click.ClickException(f"collection not found: {name!r} — use: nx collection list")
 
-    query_model = embedding_model_for_collection(name)
-    idx_model   = index_model_for_collection(name)
+    from nexus.config import is_local_mode
+    if is_local_mode():
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        ef = LocalEmbeddingFunction()
+        query_model = idx_model = f"{ef.model_name} (local)"
+    else:
+        query_model = embedding_model_for_collection(name)
+        idx_model   = index_model_for_collection(name)
 
     info = db.collection_info(name)
 

--- a/src/nexus/commands/scratch.py
+++ b/src/nexus/commands/scratch.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import sys
+from typing import Any
 
 import click
 
@@ -41,11 +42,30 @@ def put_cmd(content: str, tags: str, persist: bool, project: str, title: str) ->
     click.echo(f"Stored: {doc_id}")
 
 
+def _resolve_entry_id(t1: Any, entry_id: str) -> str:
+    """Resolve an exact UUID or unique prefix (as printed by ``scratch list``)
+    to a full entry id. Raises ClickException on miss / ambiguity."""
+    entries = t1.list_entries()
+    matches = [e["id"] for e in entries if e["id"].startswith(entry_id)]
+    exact = [m for m in matches if m == entry_id]
+    if exact:
+        return exact[0]
+    if not matches:
+        raise click.ClickException(f"scratch entry {entry_id!r} not found — use: nx scratch list")
+    if len(matches) > 1:
+        raise click.ClickException(
+            f"ambiguous ID prefix {entry_id!r} — {len(matches)} entries match; be more specific"
+        )
+    return matches[0]
+
+
 @scratch.command("get")
 @click.argument("entry_id", metavar="ID")
 def get_cmd(entry_id: str) -> None:
-    """Retrieve a scratch entry by ID."""
-    result = _t1().get(entry_id)
+    """Retrieve a scratch entry by ID prefix (as shown by 'nx scratch list')."""
+    t1 = _t1()
+    full_id = _resolve_entry_id(t1, entry_id)
+    result = t1.get(full_id)
     if result is None:
         raise click.ClickException(f"scratch entry {entry_id!r} not found — use: nx scratch list")
     click.echo(result["content"])

--- a/src/nexus/commands/store.py
+++ b/src/nexus/commands/store.py
@@ -41,7 +41,7 @@ def _t3() -> T3Database:
 
 @click.group()
 def store() -> None:
-    """Permanent semantic knowledge store (ChromaDB Cloud + Voyage AI)."""
+    """Permanent semantic knowledge store (local ChromaDB or Cloud + Voyage AI)."""
 
 
 @store.command("put")
@@ -275,6 +275,30 @@ def get_cmd(doc_id: str, collection: str, json_out: bool) -> None:
         click.echo(f"\n{entry.get('content', '')}")
 
 
+def _reap_catalog_for_doc_ids(doc_ids: list[str]) -> None:
+    """Best-effort: tombstone catalog entries for deleted T3 docs.
+
+    Why: ``nx store delete`` removed only the T3 doc, leaving the catalog
+    entry visible to ``nx catalog list`` until the next ``nx catalog gc``.
+    Eventual consistency surprised users who expected delete to be atomic.
+    Skipped silently when the catalog is uninitialised.
+    """
+    from nexus.catalog import Catalog
+    from nexus.config import catalog_path
+
+    cat_path = catalog_path()
+    if not Catalog.is_initialized(cat_path):
+        return
+    try:
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
+        for doc_id in doc_ids:
+            entry = cat.by_doc_id(doc_id)
+            if entry is not None:
+                cat.delete_document(entry.tumbler)
+    except Exception:
+        _log.debug("catalog_reap_failed", exc_info=True, doc_ids=doc_ids)
+
+
 @store.command("delete")
 @click.option("--collection", "-c", required=True,
               help="Collection name (required)")
@@ -301,6 +325,7 @@ def delete_cmd(collection: str, doc_id: str | None, title: str | None, yes: bool
     if doc_id:
         if not db.delete_by_id(col_name, doc_id):
             raise click.ClickException(f"Entry {doc_id!r} not found in {col_name}")
+        _reap_catalog_for_doc_ids([doc_id])
         click.echo(f"Deleted: {doc_id}  from  {col_name}")
     else:
         ids = db.find_ids_by_title(col_name, title)
@@ -311,6 +336,7 @@ def delete_cmd(collection: str, doc_id: str | None, title: str | None, yes: bool
             click.echo(f"Found {len(ids)} {n} with title {title!r} in {col_name}.")
             click.confirm("Delete?", abort=True)
         db.batch_delete(col_name, ids)
+        _reap_catalog_for_doc_ids(ids)
         click.echo(f"Deleted {len(ids)} {'entry' if len(ids) == 1 else 'entries'} with title {title!r} from {col_name}.")
 
 @store.command("expire")

--- a/src/nexus/formatters.py
+++ b/src/nexus/formatters.py
@@ -323,10 +323,22 @@ def format_json(results: list[SearchResult]) -> str:
 
 
 def format_plain(results: list[SearchResult]) -> list[str]:
-    """Default plain-text format: ./path/to/file.py:42:    content."""
+    """Default plain-text format: ./path/to/file.py:42:    content.
+
+    For results without a ``source_path`` (knowledge/docs entries from
+    ``store put``), falls back to the doc-style ``[distance] title\\n  snippet``
+    format that the MCP surface uses.
+    """
     lines: list[str] = []
     for r in results:
         source_path = r.metadata.get("source_path", "")
+        if not source_path:
+            title = r.metadata.get("title") or r.id
+            snippet = r.content.splitlines()[0] if r.content else ""
+            lines.append(f"[{r.distance:.4f}] {title}")
+            if snippet:
+                lines.append(f"  {snippet}")
+            continue
         line_start = r.metadata.get("line_start", 0)
         for i, content_line in enumerate(r.content.splitlines()):
             line_no = int(line_start) + i

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -55,11 +55,13 @@ def format_health_for_cli(
         lines.append(msg)
 
         if r.fix_suggestions:
+            prefix = "Fix: " if not r.ok else "Suggest: "
+            cont_indent = " " * (4 + len(prefix))
             for i, fix_line in enumerate(r.fix_suggestions):
                 if i == 0:
-                    lines.append(f"    Fix: {fix_line}")
+                    lines.append(f"    {prefix}{fix_line}")
                 else:
-                    lines.append(f"         {fix_line}")
+                    lines.append(f"{cont_indent}{fix_line}")
 
         if r.fatal and not r.ok:
             failed = True
@@ -514,6 +516,11 @@ def _check_index_log() -> list[HealthResult]:
 
 
 def _check_orphan_t1() -> list[HealthResult]:
+    """Report on session files. An "orphan" here means the chroma server PID
+    in the file is no longer alive — that is the only state that warrants
+    cleanup. Live-but-unowned sessions (e.g. server still running after the
+    spawning Claude Code instance exited) are listed but not flagged.
+    """
     from nexus.session import SESSIONS_DIR
 
     if not SESSIONS_DIR.exists():
@@ -523,7 +530,9 @@ def _check_orphan_t1() -> list[HealthResult]:
     if not session_files:
         return [HealthResult(label="T1 sessions", ok=True, detail="no session files")]
 
+    now = time.time()
     orphans: list[str] = []
+    live_descriptors: list[str] = []
     for sf in session_files:
         try:
             record = json.loads(sf.read_text())
@@ -531,10 +540,14 @@ def _check_orphan_t1() -> list[HealthResult]:
             _log.debug("orphan_t1_session_corrupt", path=str(sf), error=str(exc))
             continue
         pid = record.get("server_pid")
+        age_s = max(0, int(now - sf.stat().st_mtime))
+        age_str = f"{age_s // 60}m" if age_s < 3600 else f"{age_s // 3600}h"
         if pid is None:
+            live_descriptors.append(f"{sf.name} (no pid, age {age_str})")
             continue
         try:
             os.kill(int(pid), 0)
+            live_descriptors.append(f"{sf.name} (pid {pid} alive, age {age_str})")
         except OSError:
             orphans.append(sf.name)
         except (ValueError, TypeError):
@@ -545,7 +558,7 @@ def _check_orphan_t1() -> list[HealthResult]:
         return [HealthResult(
             label="T1 sessions",
             ok=False,
-            detail=f"{len(orphans)} orphaned session file(s): {', '.join(orphans)}",
+            detail=f"{len(orphans)} orphaned session file(s) (chroma pid dead): {', '.join(orphans)}",
             fix_suggestions=[
                 "Remove stale files: rm ~/.config/nexus/sessions/*.session",
                 "Or run: nx doctor (sweep runs automatically on session start)",
@@ -554,7 +567,7 @@ def _check_orphan_t1() -> list[HealthResult]:
 
     return [HealthResult(
         label="T1 sessions", ok=True,
-        detail=f"{len(session_files)} session file(s), no orphans detected",
+        detail=f"{len(session_files)} session file(s), all chroma servers alive: {', '.join(live_descriptors)}",
     )]
 
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1082,7 +1082,7 @@ def scratch(
             lines: list[str] = []
             for r in results:
                 snippet = r["content"][:200].replace("\n", " ")
-                lines.append(f"{prefix}[{r['id'][:12]}] {snippet}")
+                lines.append(f"{prefix}[{r['id'][:8]}] {snippet}")
             if len(results) >= limit:
                 lines.append(f"\n--- showing {len(results)} results (limit={limit}). Increase limit to see more.")
             return "\n".join(lines)
@@ -1097,7 +1097,7 @@ def scratch(
             for e in entries:
                 snippet = e["content"][:80].replace("\n", " ")
                 tags_str = f"  [{e.get('tags', '')}]" if e.get("tags") else ""
-                lines.append(f"{prefix}[{e['id'][:12]}] {snippet}{tags_str}")
+                lines.append(f"{prefix}[{e['id'][:8]}] {snippet}{tags_str}")
             if total > limit:
                 lines.append(f"\n--- showing {limit} of {total} entries. Increase limit to see all.")
             return "\n".join(lines)

--- a/tests/test_doctor_integrity.py
+++ b/tests/test_doctor_integrity.py
@@ -64,7 +64,9 @@ class TestCheckOrphanT1:
         d.mkdir()
         _make_session_file(d, "99999.session", os.getpid())
         ok, results = _run_orphan_t1(d)
-        assert ok is True and "no orphans detected" in results[0].detail
+        assert ok is True
+        assert "all chroma servers alive" in results[0].detail
+        assert f"pid {os.getpid()} alive" in results[0].detail
 
     def test_dead_pid_detected_as_orphan(self, tmp_path):
         d = tmp_path / "sessions"

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -88,8 +88,21 @@ def test_plain_variants(content, expected) -> None:
 
 
 def test_plain_missing_metadata() -> None:
+    """Without source_path, fall back to MCP-style [distance] title\\n  snippet."""
     r = SearchResult(id="r1", content="hello", distance=0.1, collection="c", metadata={})
-    assert format_plain([r]) == [":0:hello"]
+    assert format_plain([r]) == ["[0.1000] r1", "  hello"]
+
+
+def test_plain_uses_title_when_present() -> None:
+    """Source-path-less results prefer metadata title over the bare id."""
+    r = SearchResult(
+        id="abc123",
+        content="line one\nline two",
+        distance=0.5,
+        collection="knowledge__demo",
+        metadata={"title": "Demo Note"},
+    )
+    assert format_plain([r]) == ["[0.5000] Demo Note", "  line one"]
 
 
 # ── format_plain_with_context ───────────────────────────────────────────────

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -119,8 +119,10 @@ def test_m_flag_limits_results(runner: CliRunner, cloud_env) -> None:
             main, ["search", "query", "--no-rerank", "-m", "3", "--corpus", "knowledge"],
         )
     assert result.exit_code == 0, result.output
-    output_lines = [ln for ln in result.output.splitlines() if ln.strip()]
-    assert len(output_lines) <= 3
+    # Count results (each renders as "[dist] title" header + indented snippet
+    # for source_path-less hits) — -m caps the result count, not line count.
+    result_headers = [ln for ln in result.output.splitlines() if ln.startswith("[")]
+    assert len(result_headers) <= 3
 
 
 def test_reverse_flag_reverses_output_order(runner: CliRunner, cloud_env) -> None:


### PR DESCRIPTION
## Summary

Six independent fixes surfaced by the 2026-04-20 fresh-instance shakeout report (`nexus-shakeout-2026-04-20.md`), grouped because they all flowed from a single round of CLI / MCP round-trip exercise.

| # | Pri | What |
|---|-----|------|
| 1 | P2  | `nx collection info` reports the cloud Voyage model in **local** mode → branch on `is_local_mode()` and report `<minilm-or-bge> (local)`. |
| 2 | P3  | `nx store delete` leaves catalog entry visible until next `nx catalog gc` → reap catalog row by `meta.doc_id` immediately (best-effort). |
| 3 | P3  | `nx scratch get` rejects 8-char prefix that `nx scratch list` printed → reuse `delete`'s prefix resolver. |
| 4 | P4  | `nx search` printed `:0:<content>` for results without `source_path` → fall back to MCP-style `[distance] title\n  snippet`. |
| 5 | P4  | `nx doctor` printed `Fix:` under passing (✓) checks → `Suggest:` for `r.ok=True`, `Fix:` for failures only. |
| 6 | P5  | `nx doctor` `T1 sessions: N file(s), no orphans detected` was opaque → list each session with `(pid <N> alive, age <Hm/h>)`; clarify that orphan = chroma pid dead. |

Plus two cosmetic alignments:
- `nx store --help` tagline updated to `(local ChromaDB or Cloud + Voyage AI)` (local mode is the default).
- MCP `scratch` list/search use 8-char prefix to match CLI (was 12; broke copy-paste).

## Test plan

- [x] `uv run pytest -q --ignore=tests/e2e` — **4722 passed, 27 skipped**
- [x] Three test updates reflect the changed observable behaviour (`test_plain_missing_metadata`, `test_live_process_reports_ok`, `test_m_flag_limits_results`)
- [x] CHANGELOG entry under `[Unreleased]`

bead: nexus-43pq