### PR TITLE
fix(doctor): surface empty-collection count in Local collections line (nexus-obp2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **`nx doctor` `Local collections` line now reports the empty-collection count** (`src/nexus/health.py`). After deleting every doc from a collection, `nx collection list` continues to show the collection at `0 chunks` because the empty collection is intentionally retained — it preserves the embedding-model binding so the next `store_put` doesn't have to re-derive it. The absence of a doctor signal made this look like a leak. Output now reads `Local collections: N collections (including K empty), <size> on disk`; the `(including K empty)` clause is omitted when `K == 0`. Pure transparency — no behavior change. (nexus-obp2)
+
 ## [4.9.4] - 2026-04-20
 
 ### Fixed

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -201,20 +201,25 @@ def _check_t3_local() -> list[HealthResult]:
         r.fix_suggestions = ["Upgrade: pip install conexus[local]  (768d bge-base, better quality)"]
     results.append(r)
 
-    # Collection count and disk usage
+    # Collection count and disk usage. Empty collections are kept on purpose
+    # (they preserve embedding-model metadata so the next store_put doesn't
+    # need to re-derive it) — surface the count so users aren't surprised by
+    # a 0-chunk collection lingering after `nx store delete` of every entry.
     if path_exists:
         try:
             client = chromadb.PersistentClient(path=str(local_path))
             cols = client.list_collections()
             col_count = len(cols)
+            empty_count = sum(1 for c in cols if c.count() == 0)
             total_bytes = sum(f.stat().st_size for f in local_path.rglob("*") if f.is_file())
             if total_bytes < 1024 * 1024:
                 size_str = f"{total_bytes / 1024:.1f} KB"
             else:
                 size_str = f"{total_bytes / (1024 * 1024):.1f} MB"
+            empty_note = f" (including {empty_count} empty)" if empty_count else ""
             results.append(HealthResult(
                 label="Local collections", ok=True,
-                detail=f"{col_count} collections, {size_str} on disk",
+                detail=f"{col_count} collections{empty_note}, {size_str} on disk",
             ))
         except Exception as exc:
             _log.debug("doctor_local_collections_failed", error=str(exc))

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -92,3 +92,50 @@ def test_format_no_detail():
     output, _ = format_health_for_cli(results, local_mode=False)
     # No colon after label when detail is empty
     assert "  ✓ test\n" in output or output.endswith("  ✓ test")
+
+
+# ── Local collections empty-count surfacing (nexus-obp2) ──────────────────────
+
+
+def test_local_collections_reports_empty_count(tmp_path, monkeypatch) -> None:
+    """nx doctor surfaces the count of empty local collections so deletion of
+    every doc from a collection doesn't leave callers wondering why the
+    collection still appears in `nx collection list`. (Empty collections are
+    intentional — they preserve the embedding-model binding for fast next
+    store_put.)"""
+    import chromadb
+    from nexus.health import _check_t3_local
+
+    monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", str(tmp_path / "chroma"))
+    # Create one populated, two empty collections.
+    client = chromadb.PersistentClient(path=str(tmp_path / "chroma"))
+    populated = client.get_or_create_collection("knowledge__has_data")
+    populated.add(ids=["a"], documents=["hello"], embeddings=[[0.1] * 384])
+    client.get_or_create_collection("knowledge__empty1")
+    client.get_or_create_collection("knowledge__empty2")
+
+    results = _check_t3_local()
+    local_collections_line = next(
+        (r for r in results if r.label == "Local collections"), None
+    )
+    assert local_collections_line is not None
+    assert "3 collections" in local_collections_line.detail
+    assert "(including 2 empty)" in local_collections_line.detail
+
+
+def test_local_collections_omits_empty_note_when_none(tmp_path, monkeypatch) -> None:
+    """No `(including N empty)` note when every collection has data."""
+    import chromadb
+    from nexus.health import _check_t3_local
+
+    monkeypatch.setenv("NX_LOCAL_CHROMA_PATH", str(tmp_path / "chroma"))
+    client = chromadb.PersistentClient(path=str(tmp_path / "chroma"))
+    populated = client.get_or_create_collection("knowledge__has_data")
+    populated.add(ids=["a"], documents=["hello"], embeddings=[[0.1] * 384])
+
+    results = _check_t3_local()
+    local_collections_line = next(
+        (r for r in results if r.label == "Local collections"), None
+    )
+    assert local_collections_line is not None
+    assert "(including" not in local_collections_line.detail


### PR DESCRIPTION
## Summary

Shakeout 4.9.4 P5 follow-up. After deleting every doc from a collection, the collection itself remains on disk at `0 chunks`. This is intentional — the empty collection preserves the embedding-model binding so the next `store_put` doesn't have to re-derive it — but the absence of any doctor signal made it look like a leak.

`nx doctor` `Local collections` line now reads:
- `3 collections (including 2 empty), 448.0 KB on disk` when some are empty
- `3 collections, 448.0 KB on disk` when all populated (clause omitted)

Inline docstring on `_check_t3_local()` documents the intent so future readers don't try to "fix" it with an auto-reaper.

Pure transparency change. No behavior change.

## Test plan

- [x] `tests/test_health.py::test_local_collections_reports_empty_count` (3 collections, 2 empty → assertion on `(including 2 empty)`)
- [x] `tests/test_health.py::test_local_collections_omits_empty_note_when_none` (1 populated → no `(including` substring)
- [x] All 13 health unit tests pass

bead: nexus-obp2