### PR TITLE
docs(rdr): reframe iteration policy and sweep em dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
 <a href="https://i0.wp.com/tensegrity.blog/wp-content/uploads/2026/04/tensegrity-69e5247d907e5.png?w=1024&ssl=1">
-  <img src="https://i0.wp.com/tensegrity.blog/wp-content/uploads/2026/04/tensegrity-69e5247d907e5.png?w=480&ssl=1" alt="The steam-driven semantic engine — illustration from the Nexus by Example blog post" align="right" width="320" />
+  <img src="https://i0.wp.com/tensegrity.blog/wp-content/uploads/2026/04/tensegrity-69e5247d907e5.png?w=480&ssl=1" alt="The steam-driven semantic engine, illustration from the Nexus by Example blog post" align="right" width="320" />
 </a>
 
 Nexus is a lightweight knowledge management system for AI coding agents. It provides persistent memory and semantic search through tiered storage that preserves decisions, findings, and project knowledge across agent sessions. That knowledge compounds over time, becoming more valuable as the corpus grows.
 
-Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system. RDRs capture the reasoning behind technical decisions — problem, research, chosen approach, rejected alternatives — as structured, searchable documents that live in the repository alongside the code. Nexus indexes the RDR corpus so team members and their agents can quickly get up to speed on a project's design history and stay aligned as the codebase evolves.
+Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system. RDRs capture the reasoning behind technical decisions (problem, research, chosen approach, rejected alternatives) as structured, searchable documents that live in the repository alongside the code. Nexus indexes the RDR corpus so team members and their agents can quickly get up to speed on a project's design history and stay aligned as the codebase evolves.
 
-> **New to Nexus?** Read [**Nexus by Example**](https://tensegrity.blog/2026/04/19/nexus-by-example/) on the Tensegrity blog — a guided walkthrough of how the pieces fit together in practice.
+> **New to Nexus?** Read [**Nexus by Example**](https://tensegrity.blog/2026/04/19/nexus-by-example/) on the Tensegrity blog: a guided walkthrough of how the pieces fit together in practice.
 
 ## What it does
 
-**Semantic search.** Standard text search matches exact strings. Nexus matches by meaning: querying "how does authentication work" returns the auth middleware, the login handler, and the JWT validation — even when none contain the word "authentication."
+**Semantic search.** Standard text search matches exact strings. Nexus matches by meaning: querying "how does authentication work" returns the auth middleware, the login handler, and the JWT validation, even when none contain the word "authentication."
 
 ```bash
 nx index repo .                  # index current repo
@@ -33,7 +33,7 @@ nx memory put --project myapp --title "DB choice"  "Chose Postgres over SQLite f
 nx store put --collection knowledge__myapp "API rate limit is 10k/min per the vendor docs"
 ```
 
-**Analytical queries.** The `query` MCP tool handles catalog-aware scoped search in a single call — `query(question="...", author="Fagin")` searches only that author's collections. For complex multi-step analysis (compare, extract, generate), the `/nx:query` skill routes through three paths: direct query, template match, or planner dispatch.
+**Analytical queries.** The `query` MCP tool handles catalog-aware scoped search in a single call: `query(question="...", author="Fagin")` searches only that author's collections. For complex multi-step analysis (compare, extract, generate), the `/nx:query` skill routes through three paths: direct query, template match, or planner dispatch.
 
 ```bash
 # Filter indexed PDFs by bibliographic metadata
@@ -43,7 +43,7 @@ nx search "consensus protocols" --where bib_year>=2024 --where chunk_type=table_
 nx enrich knowledge__papers --delay 0.5
 ```
 
-**Topic taxonomy.** After indexing, Nexus automatically discovers topics across your corpus using HDBSCAN clustering, then labels each cluster with a human-readable name via Claude Haiku. Search results are grouped by topic and boosted for relevance. Works with both local and cloud embeddings — no configuration needed.
+**Topic taxonomy.** After indexing, Nexus automatically discovers topics across your corpus using HDBSCAN clustering, then labels each cluster with a human-readable name via Claude Haiku. Search results are grouped by topic and boosted for relevance. Works with both local and cloud embeddings; no configuration needed.
 
 ```bash
 nx index repo .                  # indexing triggers topic discovery automatically
@@ -67,7 +67,7 @@ nx taxonomy status               # see discovered topics
 
 Update: `uv tool update conexus`
 
-Works immediately with local ONNX embeddings — no accounts, no API keys. For higher-quality cloud embeddings (Voyage AI), see the [cloud setup instructions](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md#cloud-mode-optional).
+Works immediately with local ONNX embeddings: no accounts, no API keys. For higher-quality cloud embeddings (Voyage AI), see the [cloud setup instructions](https://github.com/Hellblazer/nexus/blob/main/docs/getting-started.md#cloud-mode-optional).
 
 For Claude Code, install the plugin:
 
@@ -84,15 +84,15 @@ Different information has different lifetimes. Together the three tiers form an 
 
 | Tier | Purpose | Storage | API keys? |
 |------|---------|---------|-----------|
-| **Scratch** (T1) | Inter-agent session context — coordination and knowledge sharing across agent invocations | In-memory ChromaDB | No |
+| **Scratch** (T1) | Inter-agent session context: coordination and knowledge sharing across agent invocations | In-memory ChromaDB | No |
 | **Memory** (T2) | Project-level persistence with full-text search | Local SQLite + FTS5 | No |
-| **Knowledge** (T3) | Permanent semantic knowledge — code, papers, docs, decisions searchable by meaning | Local ChromaDB (default) or ChromaDB Cloud + Voyage AI | No (local) / Yes (cloud) |
+| **Knowledge** (T3) | Permanent semantic knowledge: code, papers, docs, decisions searchable by meaning | Local ChromaDB (default) or ChromaDB Cloud + Voyage AI | No (local) / Yes (cloud) |
 
-Agents use all three tiers cooperatively. T1 enables inter-agent communication — sharing findings and preventing duplicate work within a session. T2 provides project decisions that constrain solutions. T3 surfaces how similar problems were resolved in other contexts. As the T3 knowledge base grows, it becomes the project's institutional memory — managing the information overload that accompanies complex designs and long-lived codebases.
+Agents use all three tiers cooperatively. T1 enables inter-agent communication: sharing findings and preventing duplicate work within a session. T2 provides project decisions that constrain solutions. T3 surfaces how similar problems were resolved in other contexts. As the T3 knowledge base grows, it becomes the project's institutional memory, managing the information overload that accompanies complex designs and long-lived codebases.
 
 ## What you can index
 
-Code, documents, PDFs, and manual knowledge entries — anything that benefits from semantic search:
+Code, documents, PDFs, and manual knowledge entries: anything that benefits from semantic search:
 
 ```bash
 nx index repo .                          # code + docs + RDRs from a git repo
@@ -108,9 +108,9 @@ See [Repo Indexing](https://github.com/Hellblazer/nexus/blob/main/docs/repo-inde
 
 ## RDR: Research-Design-Review
 
-Complex features are bigger than what fits in working memory — yours or an LLM's. Without a locked specification, purpose drift sets in during implementation. An RDR is a specification document written *before* coding: it captures the problem, the research journey, competing options, and the chosen approach. Once accepted, the RDR is the stable target that implementation builds against. If the design proves wrong, abandon the code and iterate the RDR.
+Complex features are bigger than what fits in working memory, whether yours or an LLM's. Without a specification to track against, purpose drift sets in during implementation. An RDR is a specification document written *before* coding: it captures the problem, the research journey, competing options, and the chosen approach. Once accepted, the RDR is the stable target that implementation builds against. If the design proves wrong, abandon the RDR and draft a new one with what you learned; iteration lives in the chain of RDRs, not in any single document.
 
-Each research finding is tagged with its evidence quality — verified against source code, supported by documentation only, or assumed — so readers know which conclusions are load-bearing and which need validation. The growing corpus is searchable, so prior decisions surface automatically when starting new design work.
+Each research finding is tagged with its evidence quality (verified against source code, supported by documentation only, or assumed) so readers know which conclusions are load-bearing and which need validation. The growing corpus is searchable, so prior decisions surface automatically when starting new design work.
 
 RDR is fully optional. See [RDR Overview](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-overview.md) for the full process.
 
@@ -123,7 +123,7 @@ The `nx/` directory is a Claude Code plugin that gives agents access to everythi
 /plugin install nx@nexus-plugins
 ```
 
-The plugin provides 13 specialized agents, 43 skills covering the RDR lifecycle, plan-centric retrieval, and development workflows, session hooks for automatic context initialization, and 36 MCP tools split across two focused servers — `nexus` (26 tools: search, store, memory, scratch, plans, 5 operator tools for structured extract/rank/compare/summarize/generate, plus 4 orchestration tools including `nx_answer` for plan-matched multi-step retrieval) and `nexus-catalog` (10 catalog tools: search, show, link, resolve, stats, etc.). The plan-centric retrieval layer (`nx_answer`) matches questions against a library of scenario templates, executes the matched plan, and records every run — so the library compounds with use. Agents search indexed code before proposing changes, check prior RDR decisions before designing new features, and coordinate through standard pipelines (plan → implement → review → test) with built-in quality gates.
+The plugin provides 13 specialized agents, 43 skills covering the RDR lifecycle, plan-centric retrieval, and development workflows, session hooks for automatic context initialization, and 36 MCP tools split across two focused servers: `nexus` (26 tools: search, store, memory, scratch, plans, 5 operator tools for structured extract/rank/compare/summarize/generate, plus 4 orchestration tools including `nx_answer` for plan-matched multi-step retrieval) and `nexus-catalog` (10 catalog tools: search, show, link, resolve, stats, etc.). The plan-centric retrieval layer (`nx_answer`) matches questions against a library of scenario templates, executes the matched plan, and records every run, so the library compounds with use. Agents search indexed code before proposing changes, check prior RDR decisions before designing new features, and coordinate through standard pipelines (plan → implement → review → test) with built-in quality gates.
 
 The plugin integrates with [Beads](https://github.com/BeadsProject/beads) for task tracking. See [nx/README.md](https://github.com/Hellblazer/nexus/blob/main/nx/README.md) for the full plugin documentation.
 
@@ -142,11 +142,11 @@ The `nx` command provides direct access to all storage tiers, indexing, and sear
 | `nx collection` | Inspect and manage cloud collections |
 | `nx config` | Credentials and settings |
 | `nx upgrade` | Run pending database migrations and T3 upgrade steps |
-| `nx doctor` | Health check — verifies dependencies, credentials, connectivity, schema |
+| `nx doctor` | Health check: verifies dependencies, credentials, connectivity, schema |
 | `nx hooks` | Install git hooks for automatic re-indexing on commit |
-| `nx catalog` | Document registry — search, link, audit the catalog metadata layer |
-| `nx taxonomy` | Topic taxonomy — discover, project across collections, review, merge, split |
-| `nx context` | Project context cache — topic map for agent cold-start acceleration |
+| `nx catalog` | Document registry: search, link, audit the catalog metadata layer |
+| `nx taxonomy` | Topic taxonomy: discover, project across collections, review, merge, split |
+| `nx context` | Project context cache: topic map for agent cold-start acceleration |
 | `nx mineru` | MinerU server lifecycle (start/stop/status) for PDF extraction |
 
 Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs/cli-reference.md).
@@ -163,19 +163,19 @@ Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs
 | [Configuration](https://github.com/Hellblazer/nexus/blob/main/docs/configuration.md) | Config hierarchy, .nexus.yml, tuning parameters |
 | [Architecture](https://github.com/Hellblazer/nexus/blob/main/docs/architecture.md) | Module map, design decisions |
 | [Contributing](https://github.com/Hellblazer/nexus/blob/main/docs/contributing.md) | Dev setup, testing, code style |
-| [Nexus by Example](https://tensegrity.blog/2026/04/19/nexus-by-example/) | Blog walkthrough — the steam-driven semantic engine in practice |
+| [Nexus by Example](https://tensegrity.blog/2026/04/19/nexus-by-example/) | Blog walkthrough of the steam-driven semantic engine in practice |
 
 **RDR (Research-Design-Review):**
-1. [Overview](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-overview.md) — What RDRs are, when to write one, evidence classification
-2. [Workflow](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-workflow.md) — Create → Research → Gate → Accept → Close
-3. [Nexus Integration](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-nexus-integration.md) — How storage tiers and agents amplify RDRs
-4. [Templates](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-templates.md) — Minimal and full examples, post-mortem template
-5. [Project RDR Index](https://github.com/Hellblazer/nexus/blob/main/docs/rdr/README.md) — All project RDRs with status
+1. [Overview](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-overview.md): What RDRs are, when to write one, evidence classification
+2. [Workflow](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-workflow.md): Create → Research → Gate → Accept → Close
+3. [Nexus Integration](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-nexus-integration.md): How storage tiers and agents amplify RDRs
+4. [Templates](https://github.com/Hellblazer/nexus/blob/main/docs/rdr-templates.md): Minimal and full examples, post-mortem template
+5. [Project RDR Index](https://github.com/Hellblazer/nexus/blob/main/docs/rdr/README.md): All project RDRs with status
 
 ## Prerequisites
 
 - Python 3.12–3.13, [`uv`](https://docs.astral.sh/uv/), `git`
-- For the Claude Code plugin: [Node.js](https://nodejs.org/) (provides `npx`) — the bundled `sequential-thinking` and `context7` MCP servers are spawned via `npx`. The `nx` CLI alone does not need it.
+- For the Claude Code plugin: [Node.js](https://nodejs.org/) (provides `npx`) for the bundled `sequential-thinking` and `context7` MCP servers, which are spawned via `npx`. The `nx` CLI alone does not need it.
 - For cloud embeddings (optional): [ChromaDB Cloud](https://www.trychroma.com/) + [Voyage AI](https://www.voyageai.com/) accounts (free tiers available)
 - For hybrid search: [`ripgrep`](https://github.com/BurntSushi/ripgrep)
 

--- a/docs/rdr-nexus-integration.md
+++ b/docs/rdr-nexus-integration.md
@@ -4,21 +4,21 @@
 
 # RDR: Nexus Integration
 
-RDR documents live in the repository as markdown, but Nexus makes them queryable through both structured metadata (T2) and semantic search (T3). This means agents and team members don't need to parse files or remember which RDR covered a topic — they search by meaning and get relevant decisions back.
+RDR documents live in the repository as markdown, but Nexus makes them queryable through both structured metadata (T2) and semantic search (T3). This means agents and team members don't need to parse files or remember which RDR covered a topic; they search by meaning and get relevant decisions back.
 
 ## How agents use RDRs
 
 The typical agent workflow touches the storage tiers at each stage:
 
-1. **Before new work** — search T3 for prior RDRs: `nx search "topic" --corpus rdr`. New designs often build on or refine earlier decisions; the search surfaces that chain automatically.
-2. **During research** — `/nx:rdr-research` can delegate to `deep-research-synthesizer` or `codebase-deep-analyzer` for investigation that goes beyond what a single agent session can cover.
-3. **At gate time** — `substantive-critic` provides independent review of the RDR's logic, evidence, and completeness.
-4. **At accept time** — `/nx:rdr-accept` updates T2 metadata, then optionally dispatches the planning chain: `strategic-planner` agent → `nx_plan_audit` MCP tool → `nx_enrich_beads` MCP tool. The last two were agents before RDR-080; they're now direct MCP-tool calls that the strategic-planner can invoke without a sub-agent spawn.
-5. **After close** — `/nx:rdr-close` archives the full RDR to T3 for permanent semantic retrieval.
+1. **Before new work**: search T3 for prior RDRs with `nx search "topic" --corpus rdr`. New designs often build on or refine earlier decisions; the search surfaces that chain automatically.
+2. **During research**: `/nx:rdr-research` can delegate to `deep-research-synthesizer` or `codebase-deep-analyzer` for investigation that goes beyond what a single agent session can cover.
+3. **At gate time**: `substantive-critic` provides independent review of the RDR's logic, evidence, and completeness.
+4. **At accept time**: `/nx:rdr-accept` updates T2 metadata, then optionally dispatches the planning chain: `strategic-planner` agent → `nx_plan_audit` MCP tool → `nx_enrich_beads` MCP tool. The last two were agents before RDR-080; they're now direct MCP-tool calls that the strategic-planner can invoke without a sub-agent spawn.
+5. **After close**: `/nx:rdr-close` archives the full RDR to T3 for permanent semantic retrieval.
 
 Agents access all storage tiers via structured MCP tools rather than CLI commands, which works reliably in background agents and restricted permission contexts. Team members use the `nx` CLI directly. See [nx/README.md](../nx/README.md#mcp-servers) for MCP tool details.
 
-## T2 — structured metadata
+## T2: structured metadata
 
 Each RDR has a T2 record in the `{repo}_rdr` project, providing structured access to status, type, priority, timestamps, and linked beads without parsing markdown.
 
@@ -27,15 +27,15 @@ nx memory search "caching" --project myrepo_rdr
 nx memory search "status:draft" --project nexus_rdr
 ```
 
-Key fields include `id`, `status` (Draft → Accepted → Implemented/Reverted/Abandoned/Superseded), `type`, `priority`, `accepted_date`, `epic_bead` (links to implementation tracking), and `file_path`. T2 is the authoritative source for RDR state — the markdown file is the human-readable persistence layer.
+Key fields include `id`, `status` (Draft → Accepted → Implemented/Reverted/Abandoned/Superseded), `type`, `priority`, `accepted_date`, `epic_bead` (links to implementation tracking), and `file_path`. T2 is the authoritative source for RDR state; the markdown file is the human-readable persistence layer.
 
 Timestamps (`created`, `gated`, `accepted_date`, `closed`) let you reconstruct which decisions were active at any point in time.
 
-## T3 — semantic search
+## T3: semantic search
 
 RDRs are indexed into `rdr__<repo>` collections using `voyage-context-3` embeddings. This happens two ways:
 
-- **`nx index repo`** auto-discovers `docs/rdr/*.md` and indexes them during normal repo indexing. Draft RDRs are findable immediately — no need to wait for `/nx:rdr-close`.
+- **`nx index repo`** auto-discovers `docs/rdr/*.md` and indexes them during normal repo indexing. Draft RDRs are findable immediately; no need to wait for `/nx:rdr-close`.
 - **`/nx:rdr-close`** indexes the RDR explicitly at close time as part of permanent archival.
 
 ```bash
@@ -43,7 +43,7 @@ nx search "caching strategy" --corpus rdr
 nx search "chromadb quota" --corpus rdr --n 5
 ```
 
-Cross-project search works automatically — decisions from one project surface when researching similar problems in another.
+Cross-project search works automatically: decisions from one project surface when researching similar problems in another.
 
 ### What search returns
 
@@ -53,7 +53,7 @@ The highest-signal chunks are typically the **Problem Statement** (best for dete
 
 `/nx:rdr-accept` optionally decomposes the Implementation Plan into beads (epic + tasks) via the planning chain. The `epic_bead` T2 field links each accepted decision to its implementation work items. Session hooks inject T2 context and the active bead into spawned agents, so they pick up where the previous session left off.
 
-## Catalog — document registry and link graph
+## Catalog: document registry and link graph
 
 When the [catalog](catalog.md) is initialized, RDR lifecycle skills create typed links that connect RDRs to each other and to the broader knowledge base:
 
@@ -68,7 +68,7 @@ When the [catalog](catalog.md) is initialized, RDR lifecycle skills create typed
 | `/nx:rdr-close` (Implemented) | `cites` links from RDR to referenced research papers |
 | Indexer hook | `implements-heuristic` links from code files to RDRs (title substring match) |
 
-This means `nx catalog links "RDR-051"` shows which code implements it, what research it cites, and what it supersedes — without parsing markdown.
+This means `nx catalog links "RDR-051"` shows which code implements it, what research it cites, and what it supersedes, without parsing markdown.
 
 All catalog steps are skipped silently if the catalog isn't initialized. T2 and the markdown file remain the authorities.
 

--- a/docs/rdr-overview.md
+++ b/docs/rdr-overview.md
@@ -4,19 +4,19 @@
 
 # RDR: Research-Design-Review
 
-An RDR is a specification document written *before* implementation. It captures the problem, the research journey, competing options, and the chosen approach — then locks that decision so implementation has a stable target.
+An RDR is a specification document written *before* implementation. It captures the problem, the research journey, competing options, and the chosen approach, then locks that decision so implementation has a stable target.
 
-The core insight: complex features are bigger than what fits in working memory — yours or an LLM's. Without a locked specification, purpose drift sets in as new problems emerge during coding, side-quests derail the original vision, and you end up coding your way out of corners instead of designing your way around them. An RDR front-loads the thinking so implementation can focus on execution.
+The core insight: complex features are bigger than what fits in working memory, whether yours or an LLM's. Without a locked specification, purpose drift sets in as new problems emerge during coding, side-quests derail the original vision, and you end up coding your way out of corners instead of designing your way around them. An RDR front-loads the thinking so implementation can focus on execution.
 
-**The rule:** revise the RDR during planning; lock it at acceptance. If implementation proves the design wrong, abandon the code and iterate the RDR — not the other way around.
+**The rule is mostly about timing.** Iterate on the RDR freely during drafting; at acceptance it becomes the reference for what was decided. If implementation proves the design wrong, don't rewrite the accepted RDR to match what shipped; abandon it and draft a new one with what you learned. Iteration on a decision lives in the chain of RDRs, not in any single accepted document.
 
 ## Quick start
 
-1. `/nx:rdr-create` — creates a new file with metadata prefilled, status set to Draft
-2. `/nx:rdr-research add <id>` — appends a finding with an evidence classification tag
-3. `/nx:rdr-gate <id>` — runs 3-layer validation: structure check, assumption audit, AI critique (optional, recommended for irreversible decisions)
-4. `/nx:rdr-accept <id>` — locks the decision, sets status to Accepted
-5. `/nx:rdr-close <id> --reason implemented` — archives the RDR, creates a post-mortem template, indexes to T3
+1. `/nx:rdr-create`: creates a new file with metadata prefilled, status set to Draft
+2. `/nx:rdr-research add <id>`: appends a finding with an evidence classification tag
+3. `/nx:rdr-gate <id>`: runs 3-layer validation: structure check, assumption audit, AI critique (optional, recommended for irreversible decisions)
+4. `/nx:rdr-accept <id>`: locks the decision, sets status to Accepted
+5. `/nx:rdr-close <id> --reason implemented`: archives the RDR, creates a post-mortem template, indexes to T3
 
 Steps 3–5 add rigor for high-stakes decisions. For a straightforward bug fix, steps 1–2 plus writing the solution may be all you need.
 
@@ -31,7 +31,7 @@ Write an RDR *before implementing* when any of these apply:
 - A previous decision turned out to be wrong and you're correcting course
 - The feature is complex enough that you'd lose track of why you're making specific choices mid-implementation
 
-Not every decision needs an RDR. If the rationale is self-evident from the code, skip it. But if you find yourself three hours into implementation wondering "why did I go this way?" — that's the RDR you should have written first.
+Not every decision needs an RDR. If the rationale is self-evident from the code, skip it. But if you find yourself three hours into implementation wondering "why did I go this way?", that's the RDR you should have written first.
 
 ## Right-sizing
 
@@ -46,7 +46,7 @@ If you can state the problem, root cause, and fix in one paragraph, that IS the 
 
 ## Evidence classification
 
-Each research finding is tagged so readers — both human and agent — know what is solid and what needs further validation.
+Each research finding is tagged so readers (both human and agent) know what is solid and what needs further validation.
 
 | Classification | Meaning |
 |---|---|
@@ -58,11 +58,11 @@ Flag assumptions that your design depends on. Low-stakes assumptions need no ver
 
 ## The iterative pattern
 
-RDRs are iterative across a project, not within a single document. Write one, lock it, build against it, learn from what you find. If the design was wrong, don't patch the code — abandon it and write a new RDR with what you learned. Each RDR builds on what earlier ones established, and the corpus grows into institutional memory.
+RDRs are iterative across a project, not within a single document. Write one, lock it, build against it, learn from what you find. If the design turns out to be wrong, abandon the RDR and write a new one capturing what you learned. Each RDR builds on what earlier ones established, and the corpus grows into institutional memory.
 
-Research may reveal that one RDR needs to split into several — that's normal. Cross-reference related RDRs to maintain conceptual integrity. Stack them by dependency so implementation order is clear.
+Research may reveal that one RDR needs to split into several; that's normal. Cross-reference related RDRs to maintain conceptual integrity. Stack them by dependency so implementation order is clear.
 
-The Nexus project has produced over 35 RDRs across its development. The corpus is searchable, so when starting a new design, prior decisions surface automatically — preventing contradictions and avoiding redundant investigation.
+The Nexus project has produced over 35 RDRs across its development. The corpus is searchable, so when starting a new design, prior decisions surface automatically, preventing contradictions and avoiding redundant investigation.
 
 ## Statuses and types
 
@@ -85,13 +85,13 @@ Draft --> Accepted --> Implemented
 
 ## Using RDR in your project
 
-RDR works in any repository — it doesn't require the Nexus CLI or plugin. The tooling amplifies RDRs with search, validation, and agent context, but the core value is the document itself.
+RDR works in any repository; it doesn't require the Nexus CLI or plugin. The tooling amplifies RDRs with search, validation, and agent context, but the core value is the document itself.
 
 **Minimal setup (no tooling):**
 
 1. Create `docs/rdr/` in your repo
 2. Copy the [template](rdr-templates.md) into `docs/rdr/TEMPLATE.md`
-3. Write your first RDR — Problem Statement + Research Findings + Proposed Solution is enough
+3. Write your first RDR: Problem Statement + Research Findings + Proposed Solution is enough
 
 **With Nexus CLI + plugin:**
 

--- a/docs/rdr-templates.md
+++ b/docs/rdr-templates.md
@@ -31,15 +31,15 @@ related_tests: [test_indexer_chunk_flow.py]
 
 Every code chunk shows `Lines: 1-780` regardless of actual position.
 `CodeSplitter` returns empty metadata; the fallback assigns full-file extent.
-Result: context prefixes are useless — all chunks from a file look identical.
+Result: context prefixes are useless; all chunks from a file look identical.
 
 ## Research Findings
 
-**Root cause** (Verified — source search `chunker.py:210`):
+**Root cause** (Verified, source search `chunker.py:210`):
 `setdefault("line_start", 1)` / `setdefault("line_end", len(lines))` fires
 for every node. `CodeSplitter` never populates `line_start`/`line_end`.
 
-**Fix available** (Verified — llama-index source):
+**Fix available** (Verified, llama-index source):
 `TextNode.start_char_idx` / `end_char_idx` are populated.
 Convert: `content[:start_char_idx].count('\n') + 1` → exact 1-indexed line.
 
@@ -84,7 +84,7 @@ require at least one reviewer other than the author.
 `related_tests` lists test files or test names that validate this RDR's
 implementation. Populated at close time.
 
-`implementation_notes` captures deviations from the plan — filled in at close
+`implementation_notes` captures deviations from the plan, filled in at close
 time. Empty string if the implementation matched the RDR exactly.
 
 ### Sections
@@ -102,22 +102,23 @@ time. Empty string if the implementation matched the RDR exactly.
 | **Validation** | Testing strategy and performance expectations |
 | **Finalization Gate** | Contradiction check, assumption verification, scope check, cross-cutting concerns, proportionality |
 | **References** | Requirements, dependency docs, related issues |
-| **Revision History** | Gate findings appendix — keeps design sections clean |
+| **Revision History** | Gate findings appendix; keeps design sections clean |
 
 ### Critical Assumptions
 
 Each load-bearing assumption is a checkbox with verification status:
 
 ```markdown
-- [ ] [Assumption 1] — **Status**: Verified | Unverified
-  — **Method**: Source Search | Spike | Docs Only
+- [ ] [Assumption 1]
+  - **Status**: Verified | Unverified
+  - **Method**: Source Search | Spike | Docs Only
 ```
 
 | Method | Description |
 |--------|-------------|
 | **Source Search** | API verified against dependency source code |
 | **Spike** | Behavior verified by running code against a live service |
-| **Docs Only** | Documentation reading only — insufficient for load-bearing assumptions |
+| **Docs Only** | Documentation reading only; insufficient for load-bearing assumptions |
 
 ## Post-Mortem Template
 
@@ -159,9 +160,9 @@ Each category has a **Count**, **Examples**, and **Preventable?** column
 ### RDR Quality Assessment
 
 Three dimensions:
-- **What the RDR got right** — research and decisions worth repeating
-- **What the RDR missed** — wrong assumptions, overlooked constraints
-- **What the RDR over-specified** — code rewritten, features deferred, config never used
+- **What the RDR got right**: research and decisions worth repeating
+- **What the RDR missed**: wrong assumptions, overlooked constraints
+- **What the RDR over-specified**: code rewritten, features deferred, config never used
 
 ---
 

--- a/docs/rdr-workflow.md
+++ b/docs/rdr-workflow.md
@@ -30,7 +30,7 @@ This document covers the operational details of each lifecycle step. For backgro
 Terminal states: Reverted · Abandoned · Superseded
 ```
 
-Only **Create** and **Research** are required. Gate, Accept, and Close add formal validation and archival — use them when the decision is load-bearing.
+Only **Create** and **Research** are required. Gate, Accept, and Close add formal validation and archival; use them when the decision is load-bearing.
 
 ## Worked example
 
@@ -44,7 +44,7 @@ A bug fix RDR from create to close:
 
 /nx:rdr-research add 016
   Finding: CodeSplitter never populates line_start/line_end
-  Classification: Verified — Source Search (chunker.py:210)
+  Classification: Verified (Source Search, chunker.py:210)
 
 /nx:rdr-gate 016
   Structure ✓ · Assumptions ✓ · AI critique ✓ → PASSED
@@ -70,9 +70,9 @@ Adds structured findings to a Draft RDR. Each finding records a summary, evidenc
 
 Verification methods:
 
-- **Source Search** — API or behavior verified against dependency source code
-- **Spike** — behavior verified by running code against a live service
-- **Docs Only** — documentation reading only; insufficient for load-bearing assumptions
+- **Source Search**: API or behavior verified against dependency source code
+- **Spike**: behavior verified by running code against a live service
+- **Docs Only**: documentation reading only; insufficient for load-bearing assumptions
 
 For complex investigations, `/nx:rdr-research` can delegate to specialized agents (`deep-research-synthesizer` for web/document research, `codebase-deep-analyzer` for codebase exploration). Findings are written to both the markdown file and T2. The RDR stays Draft throughout.
 
@@ -80,13 +80,13 @@ For complex investigations, `/nx:rdr-research` can delegate to specialized agent
 
 Three-layer validation. Optional but recommended before committing to irreversible decisions.
 
-**Layer 1 — Structural**: Required sections filled, metadata complete, at least one research finding present.
+**Layer 1, Structural**: Required sections filled, metadata complete, at least one research finding present.
 
-**Layer 2 — Assumption audit**: Every Assumed finding must have a risk assessment. Each critical assumption must acknowledge what happens if it's wrong.
+**Layer 2, Assumption audit**: Every Assumed finding must have a risk assessment. Each critical assumption must acknowledge what happens if it's wrong.
 
-**Layer 3 — AI critique**: Delegates to the `substantive-critic` agent, which evaluates logical coherence, missing alternatives, unstated assumptions, and evidence gaps. Findings are appended to the RDR.
+**Layer 3, AI critique**: Delegates to the `substantive-critic` agent, which evaluates logical coherence, missing alternatives, unstated assumptions, and evidence gaps. Findings are appended to the RDR.
 
-The gate either **BLOCKS** (critical issues — fix and re-gate) or **PASSES** (no critical issues, may have observations). No conditional outcomes. The result is stored in T2 for `/nx:rdr-accept` to verify.
+The gate either **BLOCKS** (critical issues; fix and re-gate) or **PASSES** (no critical issues, may have observations). No conditional outcomes. The result is stored in T2 for `/nx:rdr-accept` to verify.
 
 ## Accept (`/nx:rdr-accept`)
 
@@ -102,7 +102,7 @@ Finalizes an Accepted RDR. Requires status Accepted (use `--force` to override).
 
 Close reasons: `implemented` · `reverted` · `abandoned` · `superseded`
 
-Closing creates a post-mortem template for drift analysis, indexes the RDR into the `rdr__` collection for permanent semantic retrieval, and updates T2 with the close date and reason. If beads were created during accept, their status is displayed as an advisory. If the [catalog](catalog.md) is initialized, closing also creates typed links — `supersedes` for superseded RDRs, `cites` for referenced research papers.
+Closing creates a post-mortem template for drift analysis, indexes the RDR into the `rdr__` collection for permanent semantic retrieval, and updates T2 with the close date and reason. If beads were created during accept, their status is displayed as an advisory. If the [catalog](catalog.md) is initialized, closing also creates typed links: `supersedes` for superseded RDRs, `cites` for referenced research papers.
 
 ## Querying RDRs
 
@@ -114,7 +114,7 @@ Closing creates a post-mortem template for drift analysis, indexes the RDR into 
 /nx:rdr-show 007                  # full detail: metadata, findings, gate status, linked beads
 ```
 
-Both commands read from T2 — no markdown parsing required.
+Both commands read from T2; no markdown parsing required.
 
 ## T2 synchronization
 


### PR DESCRIPTION
## Summary

- **RDR iteration policy reframe.** Iterate freely on the RDR during drafting; at acceptance it becomes the reference for what was decided. If implementation proves the design wrong, abandon the RDR and draft a new one with what you learned. Iteration on a decision lives in the chain of RDRs, not in any single accepted document. Updates three places that state the rule (rdr-overview.md x2, README.md).
- **Em-dash sweep** across the four RDR docs and README (60 em dashes removed total). Replacements chosen contextually: commas for parentheticals, semicolons for clause breaks, colons for definitional intros, parens for nested asides.

## Files

- README.md
- docs/rdr-overview.md
- docs/rdr-workflow.md
- docs/rdr-templates.md
- docs/rdr-nexus-integration.md

## Test plan

- [x] No code changes; docs and README only
- [x] Verified zero remaining em dashes in all five files
- [x] Policy wording matches updated language in published blog post 3 (https://tensegrity.blog/?p=1330)