### PR TITLE
feat(plans): wire nx_answer scope through plan_run (nexus-zs1d phase 1)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -2186,8 +2186,15 @@ async def nx_answer(
         pass
 
     # ── Step 4: execute plan ─────────────────────────────────────────────
+    # nexus-zs1d Phase 1: propagate caller-supplied scope as the
+    # ``_nx_scope`` binding so retrieval steps in library-matched plans
+    # honour the caller's corpus intent. Plans that pin their own corpus
+    # still win; this only fills in the gap when a plan is agnostic.
+    run_bindings: dict[str, Any] = {"intent": question}
+    if scope:
+        run_bindings["_nx_scope"] = scope
     try:
-        result = await _plan_run(best, {"intent": question})
+        result = await _plan_run(best, run_bindings)
     except Exception as exc:
         elapsed_ms = int((time.monotonic() - start) * 1000)
         _log.error("nx_answer_plan_run_error", plan_id=best.plan_id, error=str(exc))

--- a/src/nexus/plans/runner.py
+++ b/src/nexus/plans/runner.py
@@ -259,6 +259,13 @@ _RETRIEVAL_TOOLS: frozenset[str] = frozenset(
 #: skips corpus injection when any of these are populated.
 _COLLECTION_ARG_KEYS: tuple[str, ...] = ("collection", "collections")
 
+#: Binding key used by ``nx_answer`` to propagate the caller-supplied
+#: ``scope`` parameter through ``plan_run``. Nexus-zs1d Phase 1: gives
+#: the runner a way to honour caller-supplied corpus intent without
+#: requiring plan-library schema changes. Plans that pin their own
+#: corpus still win; this binding only fills in the gap.
+_CALLER_SCOPE_BINDING: str = "_nx_scope"
+
 
 def _collections_in_args(args: dict[str, Any]) -> list[str]:
     """Pull every collection name out of the args dict for validation."""
@@ -458,6 +465,41 @@ def _apply_scope_to_args(
             topic, bindings=bindings, step_outputs=step_outputs,
         )
 
+    return out
+
+
+def _apply_caller_scope_to_args(
+    tool: str,
+    args: dict[str, Any],
+    *,
+    bindings: dict[str, Any],
+) -> dict[str, Any]:
+    """Return *args* with caller-supplied scope forwarded as ``corpus``
+    when the plan step is corpus-agnostic (nexus-zs1d Phase 1).
+
+    When ``nx_answer`` is invoked with a ``scope`` argument, it is
+    propagated as the ``_nx_scope`` binding. This helper reads that
+    binding and fills in ``args["corpus"]`` for retrieval tools that
+    haven't already pinned one. Behaviour:
+
+      * Only retrieval tools in :data:`_RETRIEVAL_TOOLS` are affected.
+      * Plan-declared ``corpus`` / ``collection`` / ``collections`` win
+        (``_collections_in_args`` covers the latter two); this helper
+        does not overwrite them.
+      * Plan-declared ``scope.taxonomy_domain`` still wins too, because
+        :func:`_apply_scope_to_args` runs first and populates ``corpus``
+        before this helper sees the args.
+      * Empty / missing binding → no-op, existing behaviour preserved.
+    """
+    if tool not in _RETRIEVAL_TOOLS:
+        return args
+    override = bindings.get(_CALLER_SCOPE_BINDING)
+    if not override:
+        return args
+    if "corpus" in args or _collections_in_args(args):
+        return args
+    out = dict(args)
+    out["corpus"] = override
     return out
 
 
@@ -749,6 +791,14 @@ async def plan_run(
         resolved = _apply_scope_to_args(
             tool, scope, resolved,
             bindings=merged, step_outputs=step_outputs,
+        )
+        # nexus-zs1d Phase 1: caller-supplied scope (from nx_answer's
+        # ``scope`` argument, propagated via the ``_nx_scope`` binding)
+        # fills in the corpus when the plan step is agnostic. Runs after
+        # _apply_scope_to_args so plan-declared corpus / taxonomy_domain
+        # always wins.
+        resolved = _apply_caller_scope_to_args(
+            tool, resolved, bindings=merged,
         )
 
         # Dispatcher may be async (default path, RDR-079 P4) or sync

--- a/tests/test_plan_run.py
+++ b/tests/test_plan_run.py
@@ -373,6 +373,169 @@ async def test_run_traverse_step_skips_embedding_check() -> None:
     await plan_run(_match(plan), {}, dispatcher=disp)
 
 
+# ── Caller-supplied scope override (nexus-zs1d Phase 1) ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_caller_scope_fills_unset_corpus_on_search() -> None:
+    """Caller's ``_nx_scope`` binding fills in ``corpus`` on a search step
+    that doesn't pin one. RDR-compatible with existing plans."""
+    from nexus.plans.runner import plan_run
+
+    plan = {"steps": [{"tool": "search", "args": {"query": "x"}}]}
+    disp = _FakeDispatcher([{"text": "ok", "ids": []}])
+    await plan_run(
+        _match(plan),
+        {"_nx_scope": "rdr__arcaneum-2ad2825c"},
+        dispatcher=disp,
+    )
+    _tool, args = disp.calls[0]
+    assert args["corpus"] == "rdr__arcaneum-2ad2825c"
+
+
+@pytest.mark.asyncio
+async def test_run_caller_scope_fills_unset_corpus_on_query() -> None:
+    """``query`` is a retrieval tool too — caller scope fills it in."""
+    from nexus.plans.runner import plan_run
+
+    plan = {"steps": [{"tool": "query", "args": {"question": "x"}}]}
+    disp = _FakeDispatcher([{"text": "ok"}])
+    await plan_run(
+        _match(plan),
+        {"_nx_scope": "rdr__nexus"},
+        dispatcher=disp,
+    )
+    _tool, args = disp.calls[0]
+    assert args["corpus"] == "rdr__nexus"
+
+
+@pytest.mark.asyncio
+async def test_run_caller_scope_does_not_override_plan_pinned_corpus() -> None:
+    """When the plan step already pins ``corpus``, caller scope does NOT
+    override. Plan authors win."""
+    from nexus.plans.runner import plan_run
+
+    plan = {
+        "steps": [
+            {"tool": "search", "args": {"query": "x", "corpus": "code__delos"}},
+        ],
+    }
+    disp = _FakeDispatcher([{"text": "ok", "ids": []}])
+    await plan_run(
+        _match(plan),
+        {"_nx_scope": "rdr__arcaneum"},
+        dispatcher=disp,
+    )
+    _tool, args = disp.calls[0]
+    assert args["corpus"] == "code__delos"
+
+
+@pytest.mark.asyncio
+async def test_run_caller_scope_does_not_override_plan_collection() -> None:
+    """When the plan step pins a specific ``collection``, caller scope does
+    NOT inject a corpus."""
+    from nexus.plans.runner import plan_run
+
+    plan = {
+        "steps": [
+            {
+                "tool": "search",
+                "args": {"query": "x", "collection": "rdr__delos"},
+            },
+        ],
+    }
+    disp = _FakeDispatcher([{"text": "ok", "ids": []}])
+    await plan_run(
+        _match(plan),
+        {"_nx_scope": "rdr__arcaneum"},
+        dispatcher=disp,
+    )
+    _tool, args = disp.calls[0]
+    assert "corpus" not in args
+    assert args["collection"] == "rdr__delos"
+
+
+@pytest.mark.asyncio
+async def test_run_caller_scope_does_not_override_plan_taxonomy_domain() -> None:
+    """When the plan step declares ``scope.taxonomy_domain``, that populates
+    corpus first; caller scope does not clobber it."""
+    from nexus.plans.runner import plan_run
+
+    plan = {
+        "steps": [
+            {
+                "tool": "search",
+                "args": {"query": "x"},
+                "scope": {"taxonomy_domain": "code"},
+            },
+        ],
+    }
+    disp = _FakeDispatcher([{"text": "ok", "ids": []}])
+    await plan_run(
+        _match(plan),
+        {"_nx_scope": "rdr__arcaneum"},
+        dispatcher=disp,
+    )
+    _tool, args = disp.calls[0]
+    # taxonomy_domain=code → "code" corpus prefix (from _DOMAIN_TO_CORPUS)
+    assert args["corpus"] == "code"
+
+
+@pytest.mark.asyncio
+async def test_run_caller_scope_skips_non_retrieval_tools() -> None:
+    """Non-retrieval tools (summarize, extract, rank, compare, generate,
+    traverse) do not get ``corpus`` injected from caller scope."""
+    from nexus.plans.runner import plan_run
+
+    plan = {
+        "steps": [
+            {"tool": "summarize", "args": {"text": "hello"}},
+            {"tool": "extract", "args": {"text": "hello", "schema": {}}},
+            {"tool": "traverse", "args": {"seeds": ["1.1"]}},
+        ],
+    }
+    disp = _FakeDispatcher([
+        {"text": "s"}, {"text": "e"}, {"tumblers": []},
+    ])
+    await plan_run(
+        _match(plan),
+        {"_nx_scope": "rdr__arcaneum"},
+        dispatcher=disp,
+    )
+    for _tool, args in disp.calls:
+        assert "corpus" not in args
+
+
+@pytest.mark.asyncio
+async def test_run_no_scope_binding_unchanged() -> None:
+    """When caller omits ``_nx_scope``, behavior is unchanged — the step
+    runs without any corpus injection."""
+    from nexus.plans.runner import plan_run
+
+    plan = {"steps": [{"tool": "search", "args": {"query": "x"}}]}
+    disp = _FakeDispatcher([{"text": "ok", "ids": []}])
+    await plan_run(_match(plan), {}, dispatcher=disp)
+    _tool, args = disp.calls[0]
+    assert "corpus" not in args
+
+
+@pytest.mark.asyncio
+async def test_run_caller_scope_binding_not_forwarded_to_tool() -> None:
+    """``_nx_scope`` is an internal binding; it must not leak into the
+    dispatched tool args."""
+    from nexus.plans.runner import plan_run
+
+    plan = {"steps": [{"tool": "search", "args": {"query": "x"}}]}
+    disp = _FakeDispatcher([{"text": "ok", "ids": []}])
+    await plan_run(
+        _match(plan),
+        {"_nx_scope": "rdr__arcaneum"},
+        dispatcher=disp,
+    )
+    _tool, args = disp.calls[0]
+    assert "_nx_scope" not in args
+
+
 # ── Result + step trace ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Phase 1 of the [nexus-zs1d](https://github.com/Hellblazer/nexus/issues) scope-routing fix. The ``scope`` parameter on ``nx_answer`` has been accepted and documented but silently dropped on the library-match path. Only the plan-miss path honours scope today (via a prompt hint to the inline planner).

This PR adds a narrow runtime override so retrieval step args pick up the caller's scope when the plan doesn't pin one. Plans with an explicit corpus, collection, or ``scope.taxonomy_domain`` still win. Behaviour is unchanged when scope is omitted.

Phase 2 (matcher scope-awareness + plan-corpus metadata schema) stays tracked in nexus-zs1d and is gated on its own RDR.

## Changes

- **``src/nexus/plans/runner.py``**: new ``_apply_caller_scope_to_args`` helper and ``_CALLER_SCOPE_BINDING = "_nx_scope"`` constant. Runs after ``_apply_scope_to_args`` so plan-declared corpus always wins.
- **``src/nexus/mcp/core.py``**: ``nx_answer`` propagates its ``scope`` parameter as the ``_nx_scope`` binding.
- **``tests/test_plan_run.py``**: eight new tests covering the override cases.

## Test plan

- [x] Eight new targeted tests for scope override
- [x] 190 existing plan-subsystem tests still pass (plan_run, plan_match, plan_library, nx_answer, builtin plans, cache sentinel, template schema, plan grow, scoped loader)

## How it was discovered

While validating post 5's worked-example probe against ``rdr__arcaneum-2ad2825c`` for the Nexus blog series. ``nx_answer(scope="rdr__arcaneum-2ad2825c", ...)`` returned chunks from ``code__nexus`` and ``code__claude-code`` because the matched library plan didn't pin a corpus and scope was being ignored. The same question forced into the plan-miss path returned rich, properly-cited Arcaneum content — confirming the operator composition works end-to-end, the gap was purely in scope propagation.

## Refs

- Bead: ``nexus-zs1d``
- Existing TODO: ``src/nexus/plans/matcher.py:77-80`` ("accepted for forward compatibility with Phase 2 scoping + specificity ranking (PQ-14 / PQ-20) — unused at this version")
- Existing miss-path precedent: ``src/nexus/mcp/core.py::_nx_answer_plan_miss`` (scope already injected as prompt hint)