### PR TITLE
RDR-091 Phase 2c: scope_fit_weight=0.15 + multiplicative formula (nexus-svcg)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -278,3 +278,4 @@
 {"id":"int-6586e99b","kind":"field_change","created_at":"2026-04-21T01:02:55.960258Z","actor":"Hellblazer","issue_id":"nexus-43pq","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-59c9c2bf","kind":"field_change","created_at":"2026-04-21T12:56:05.232912Z","actor":"Hellblazer","issue_id":"nexus-obp2","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-a7e0de29","kind":"field_change","created_at":"2026-04-22T15:38:27.44043Z","actor":"Hellblazer","issue_id":"nexus-x6pr","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-86b113c9","kind":"field_change","created_at":"2026-04-22T15:59:28.688073Z","actor":"Hellblazer","issue_id":"nexus-bgs7","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/docs/rdr/rdr-091-scope-aware-plan-matching.md
+++ b/docs/rdr/rdr-091-scope-aware-plan-matching.md
@@ -12,7 +12,7 @@ related_issues:
   - "nexus-zs1d: Wire nx_answer scope through plan_match + plan_run"
 related_tests: [test_plan_match.py, test_plan_library.py, test_nx_answer.py]
 related: [RDR-078, RDR-079, RDR-080, RDR-084]
-implementation_notes: ""
+implementation_notes: "scope_fit_weight=0.15 picked Phase 2c (nexus-svcg): motivating case (generic agnostic 0.82 vs specialized matching 0.79) break-even at w~0.038; 0.15 leaves 0.09 margin (specialized 0.79*1.15=0.9085 beats generic 0.82) without drowning genuinely higher-cosine agnostic plans. Formula is multiplicative per RDR spec."
 ---
 
 # RDR-091: Scope-Aware Plan Matching (nexus-zs1d Phase 2)

--- a/src/nexus/plans/matcher.py
+++ b/src/nexus/plans/matcher.py
@@ -35,12 +35,19 @@ from nexus.plans.match import Match
 __all__ = ["PlanCache", "plan_match"]
 
 
-# ── Scope-aware re-ranking (RDR-091 Phase 2b) ──────────────────────────────
+# ── Scope-aware re-ranking (RDR-091 Phase 2b + 2c) ─────────────────────────
 #
-# Placeholder weight. Phase 2c (nexus-svcg) tunes this against 5 fixture
-# plan pairs; 0.10 is a small-but-nonzero starting guess that tips ties
-# toward scope-matched plans without overwhelming base cosine signal.
-_SCOPE_FIT_WEIGHT: float = 0.10
+# Score formula (RDR-091 §Proposed Solution → Score formula):
+#     final_score = base_confidence * (1 + _SCOPE_FIT_WEIGHT * scope_fit)
+# scope_fit is 0.0 (agnostic plan) or 1.0 (scope prefix match).
+#
+# 0.15 picked by inspection against 5 fixture pairs in test_plan_match.py
+# (Phase 2c, nexus-svcg). The motivating failure case (RDR §Problem
+# Statement, generic agnostic at 0.82 vs specialized matching at 0.79)
+# breaks even at weight ≈ 0.038; 0.15 leaves comfortable margin
+# (specialized 0.79 * 1.15 = 0.9085 beats generic 0.82) without so
+# much boost that a genuinely higher-cosine agnostic plan gets drowned.
+_SCOPE_FIT_WEIGHT: float = 0.15
 
 
 def _scope_fit(plan_scope_tags: str, normalized_scope_pref: str) -> float | None:
@@ -123,10 +130,11 @@ def plan_match(
         non-empty and none of whose tags prefix-match the caller scope
         (in either direction) is dropped from the candidate pool. Agnostic
         plans (``scope_tags == ''``) are kept with neutral weight.
-      * **Scope-fit boost**: matching plans receive a small additive
-        boost ``_SCOPE_FIT_WEIGHT * 1.0`` on top of their base cosine
-        score, used only for ranking. ``Match.confidence`` still carries
-        the raw cosine, so ``min_confidence`` and downstream thresholds
+      * **Scope-fit boost**: matching plans receive a small
+        multiplicative boost per the RDR-091 score formula
+        ``adjusted = confidence * (1 + _SCOPE_FIT_WEIGHT * scope_fit)``,
+        used only for ranking. ``Match.confidence`` still carries the
+        raw cosine, so ``min_confidence`` and downstream thresholds
         are unchanged.
       * **Specificity tie-break**: at equal adjusted score, the plan
         with fewer scope_tags (more specific scope) ranks first.
@@ -181,7 +189,7 @@ def plan_match(
             fit = _scope_fit(m.scope_tags, scope_pref)
             if fit is None:
                 continue  # scope conflict — drop from pool
-            adjusted = confidence + _SCOPE_FIT_WEIGHT * fit
+            adjusted = confidence * (1.0 + _SCOPE_FIT_WEIGHT * fit)
             scored.append((adjusted, _specificity(m.scope_tags), m))
 
         if scored:

--- a/tests/test_plan_match.py
+++ b/tests/test_plan_match.py
@@ -421,6 +421,115 @@ def test_fts5_fallback_keeps_matching_and_agnostic(library) -> None:
     assert agnostic in returned_ids
 
 
+# ── Phase 2c qualitative fixture pairs (RDR-091, nexus-svcg) ──────────────
+#
+# Five (scope, expected-plan) fixtures inspired by the RDR §Problem
+# Statement and §Phase 2c. Authored against realistic unequal cosines,
+# then the _SCOPE_FIT_WEIGHT constant was picked (0.15) so these pass
+# together with all pre-Phase-2b tests.
+
+
+def test_fixture_arcaneum_specialized_beats_generic_agnostic(library) -> None:
+    """RDR §Problem Statement: scope='rdr__arcaneum-*', specialized plan
+    at lower base cosine (0.79) should beat generic agnostic at higher
+    base cosine (0.82) after the multiplicative scope-fit boost."""
+    from nexus.plans.matcher import plan_match
+
+    specialized = _seed(library,
+                        query="arcaneum trade-off analysis",
+                        dimensions={"verb": "compare", "variant": "arcaneum"},
+                        scope_tags="rdr__arcaneum")
+    generic = _seed(library,
+                    query="decision lookup",
+                    dimensions={"verb": "research", "variant": "generic"},
+                    scope_tags="")
+    # Generic has HIGHER base cosine than specialized (problem statement).
+    cache = _FakeCache(hits=[(generic, 0.18), (specialized, 0.21)])
+    result = plan_match(
+        intent="arcaneum trade-offs", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="rdr__arcaneum-2ad2825c",
+    )
+    # After multiplicative boost: specialized = 0.79 * 1.15 = 0.9085;
+    # generic stays 0.82. Specialized wins.
+    assert [m.plan_id for m in result][0] == specialized
+
+
+def test_fixture_code_plan_beats_cross_corpus_on_tie_break(library) -> None:
+    """scope='code__nexus', at equal base cosine a code-only plan
+    (1 tag) beats a cross-corpus plan (2 tags) via specificity tie-break."""
+    from nexus.plans.matcher import plan_match
+
+    code_only = _seed(library, query="q",
+                      dimensions={"verb": "index", "variant": "code"},
+                      scope_tags="code__nexus")
+    cross_corpus = _seed(library, query="q",
+                         dimensions={"verb": "index", "variant": "both"},
+                         scope_tags="code__nexus,rdr__nexus")
+    cache = _FakeCache(hits=[(cross_corpus, 0.12), (code_only, 0.12)])
+    result = plan_match(
+        intent="indexing", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="code__nexus",
+    )
+    assert [m.plan_id for m in result] == [code_only, cross_corpus]
+
+
+def test_fixture_agnostic_fallback_unchanged_when_scope_empty(library) -> None:
+    """scope='' (empty) is a hard no-op. Ordering matches the pre-Phase-2b
+    behaviour (pure cosine rank). Regression guard for the empty path."""
+    from nexus.plans.matcher import plan_match
+
+    plan_a = _seed(library, query="q",
+                   dimensions={"verb": "research", "variant": "a"},
+                   scope_tags="rdr__arcaneum")
+    plan_b = _seed(library, query="q",
+                   dimensions={"verb": "research", "variant": "b"},
+                   scope_tags="knowledge__delos")
+    cache = _FakeCache(hits=[(plan_a, 0.10), (plan_b, 0.20)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="",
+    )
+    # Pure cosine: plan_a (confidence 0.9) before plan_b (confidence 0.8).
+    assert [m.plan_id for m in result] == [plan_a, plan_b]
+
+
+def test_fixture_bridging_plan_matches_via_intersect(library) -> None:
+    """scope='knowledge__delos', a bridging plan tagged
+    'knowledge__delos,knowledge__arcaneum' passes (intersect semantics):
+    caller scope prefix-matches at least one tag."""
+    from nexus.plans.matcher import plan_match
+
+    bridge = _seed(library, query="cross-paper synthesis",
+                   dimensions={"verb": "compare", "variant": "bridge"},
+                   scope_tags="knowledge__arcaneum,knowledge__delos")
+    cache = _FakeCache(hits=[(bridge, 0.15)])
+    result = plan_match(
+        intent="cross-paper", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="knowledge__delos",
+    )
+    assert [m.plan_id for m in result] == [bridge]
+
+
+def test_fixture_zero_candidate_scope_returns_empty(library) -> None:
+    """scope='rdr__nonexistent', no plan with matching scope_tags:
+    matcher returns []. nx_answer falls through to inline planner."""
+    from nexus.plans.matcher import plan_match
+
+    _seed(library, query="q1",
+          dimensions={"verb": "research", "variant": "k"},
+          scope_tags="knowledge__delos")
+    _seed(library, query="q2",
+          dimensions={"verb": "research", "variant": "c"},
+          scope_tags="code__nexus")
+    # Every seeded plan conflicts with 'rdr__nonexistent'.
+    cache = _FakeCache(hits=[])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="rdr__nonexistent",
+    )
+    assert result == []
+
+
 def test_context_parameter_is_a_no_op(library) -> None:
     """context dict is accepted but does not change results (Phase 2 stub)."""
     from nexus.plans.matcher import plan_match


### PR DESCRIPTION
## Summary

Two corrections on top of Phase 2b:

1. **Formula correction**. RDR-091 specifies `adjusted = base_confidence * (1 + scope_fit_weight * scope_fit)` (multiplicative). Phase 2b shipped additive (`base + weight * fit`). Phase 2b tests all used equal base cosines so the difference did not surface; Phase 2c's realistic unequal-cosine fixtures expose it. Corrected here.
2. **scope_fit_weight: 0.10 -> 0.15** (picked by inspection, not statistics, per RDR §Phase 2c constraints). The motivating case (generic agnostic at 0.82 vs specialized matching at 0.79) breaks even at `w ~ 0.038`; 0.15 leaves comfortable margin (`0.79 * 1.15 = 0.9085` beats `0.82`) without drowning genuinely higher-cosine agnostic plans.

## Test plan

- [x] 5 new fixture pairs in `test_plan_match.py` (§Phase 2c step 14): Arcaneum motivating case, code-only vs cross-corpus tie-break, agnostic no-op, bridging plan intersect semantics, zero-candidate empty return.
- [x] Fixtures authored against realistic unequal cosines BEFORE picking the weight (per bead's anti-backwards-fit rule).
- [x] Regression gate: 203/203 plan-subsystem tests pass (`test_plan_library`, `test_plan_run`, `test_plan_match`, `test_plan_cache_sentinel`, `test_plan_template_schema`, `test_nx_answer`, `test_rdr_084_plan_grow`, `test_traverse_step`).
- [x] RDR-091 `implementation_notes:` frontmatter recorded with weight + rationale per §Phase 2c step 17.

## References

- RDR: `docs/rdr/rdr-091-scope-aware-plan-matching.md` §Phase 2c
- Bead: nexus-svcg (under epic nexus-gr9n, parent nexus-zs1d)
- Prior: Phase 2a #231 (1dd1aa7), Phase 2b #232 (b2fa937)
- Follow-up: Phase 2d docs updates (nexus-jvma)