### PR TITLE
RDR-091 Phase 2d: scope_tags + scope-aware matching docs (nexus-jvma)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -279,3 +279,4 @@
 {"id":"int-59c9c2bf","kind":"field_change","created_at":"2026-04-21T12:56:05.232912Z","actor":"Hellblazer","issue_id":"nexus-obp2","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-a7e0de29","kind":"field_change","created_at":"2026-04-22T15:38:27.44043Z","actor":"Hellblazer","issue_id":"nexus-x6pr","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-86b113c9","kind":"field_change","created_at":"2026-04-22T15:59:28.688073Z","actor":"Hellblazer","issue_id":"nexus-bgs7","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-cb8decd6","kind":"field_change","created_at":"2026-04-22T16:03:54.309964Z","actor":"Hellblazer","issue_id":"nexus-svcg","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/docs/plan-authoring-guide.md
+++ b/docs/plan-authoring-guide.md
@@ -295,6 +295,72 @@ plan_match("author a new plan template", dimensions={verb: "plan-author"}, n=1)
 → plan_run(match, bindings={concept: "what the new plan does"})
 ```
 
+## `scope_tags` (matcher routing)
+
+`scope_tags` is a comma-separated string on the `plans` row that names
+the corpora or collections a plan actually touches. It is separate from
+the `scope` dimension, which names the plan's publication tier
+(`global`, `project`, `rdr-<slug>`, `personal`). The matcher uses
+`scope_tags` at match time to filter out plans whose retrieval space
+conflicts with the caller's `scope_preference`, and to boost plans whose
+space matches.
+
+### Inference vs explicit
+
+`plan_save` infers `scope_tags` from the plan JSON by walking retrieval
+steps and unioning the literal string values of each step's `corpus` and
+`collection` args. `$var` placeholders (e.g. `"corpus": "$corpus"`) are
+skipped, since the real routing is decided by the caller's bindings.
+`traverse`-only plans contribute nothing, so their `scope_tags` is `""`
+(agnostic).
+
+Pass an explicit `scope_tags="rdr__arcaneum,code__nexus"` kwarg to
+`plan_save` when inference would undershoot, the common case being a
+plan whose retrieval steps use `$var` placeholders but which you
+nonetheless know targets a specific corpus family. Explicit values
+override inference; they are normalized on the way in.
+
+### Normalization contract
+
+Both save-time and match-time normalization applies the same rules:
+
+- Trailing 8-char lowercase hex suffixes are stripped: `rdr__arcaneum-2ad2825c` → `rdr__arcaneum`. Shorter, longer, or non-hex tails are preserved verbatim (the collection hash convention is strict).
+- Trailing `*` or `-*` globs are stripped at match time only: caller scope `rdr__arcaneum-*` normalizes to `rdr__arcaneum`.
+- Bare family prefixes (`rdr__`) and tumbler addresses (`1.16`) pass through unchanged.
+
+### Matching semantics
+
+The matcher compares a plan's `scope_tags` to the caller's normalized
+`scope_preference` using `startswith` in either direction: tag
+`rdr__arcaneum` matches caller scope `rdr__` (bare family), and caller
+scope `rdr__arcaneum` matches tag `rdr__` (broader plan serving narrower
+query).
+
+- **Agnostic plan** (`scope_tags=""`) stays in the pool and competes on base cosine alone.
+- **Matching plan** gets a multiplicative boost `final_score = base_confidence * (1 + scope_fit_weight * 1.0)` with `scope_fit_weight = 0.15`.
+- **Conflicting plan** (non-empty `scope_tags`, no tag prefix-matches caller scope) is dropped from the candidate pool before scoring.
+
+### Multi-corpus bridging plans
+
+A plan tagged `scope_tags="knowledge__delos,knowledge__arcaneum"` passes
+when the caller scope prefix-matches *either* tag. Intersect semantics
+are the rule, so bridging plans that span a few corpora are not
+accidentally filtered out the moment the caller picks one of them.
+
+### Interaction with grown plans
+
+The `nx_answer` ad-hoc save path (RDR-084) infers `scope_tags` from the
+actual corpus used in that run. Running the same question against
+`knowledge__delos` and then against `knowledge__arcaneum` saves two
+grown plans with different `scope_tags`, which is the right answer:
+each plan is anchored to the retrieval space it actually explored.
+
+### Authoring guidance
+
+- Let inference do the work when your retrieval steps use literal corpus/collection names.
+- Pass explicit `scope_tags` when retrieval steps use `$var` placeholders but the plan targets a known corpus family.
+- For cross-corpus bridging plans, list every corpus the plan legitimately touches; inference already does this for you when the args are literals.
+
 ## Common mistakes
 
 - **Forgetting `scope`.** Every plan needs one; the validator

--- a/docs/plan-centric-retrieval.md
+++ b/docs/plan-centric-retrieval.md
@@ -137,6 +137,50 @@ links between documents first-class operators in a plan.  Before, link
 traversal was a post-hoc step after retrieval; now the plan itself can
 say "starting from the search hits, walk `implements` edges to depth 2".
 
+## Scope-aware matching
+
+The matcher honors a `scope_preference` argument passed by
+`nx_answer` (and any direct `plan_match` caller). It shapes which plans
+clear the candidate gate and how the surviving plans rank. The mechanism
+lives on a per-plan `scope_tags` column populated either by inference
+from retrieval-step args or by an explicit kwarg to `plan_save`; see
+[Plan Authoring Guide §`scope_tags`](plan-authoring-guide.md#scope_tags-matcher-routing)
+for authoring specifics.
+
+### Filter, boost, tie-break
+
+After the existing T1 cosine + dimension post-filter, the matcher:
+
+1. **Drops scope-conflicting plans.** A plan whose `scope_tags` is non-empty and none of whose tags prefix-match the caller scope is removed from the candidate pool before scoring.
+2. **Boosts scope-matching plans.** Each surviving plan's rank score is `final_score = base_confidence * (1 + scope_fit_weight * scope_fit)` where `scope_fit ∈ {0.0, 1.0}` and `scope_fit_weight = 0.15`. `Match.confidence` keeps the raw cosine so `min_confidence` and downstream thresholds are unaffected.
+3. **Tie-breaks on specificity.** When two plans land at the same `final_score`, the plan with fewer entries in `scope_tags` wins. Ties are uncommon in practice (cosine scores are near-continuous); the tie-break is mostly defensive.
+
+Agnostic plans (`scope_tags=""`) remain in the pool with `scope_fit=0.0`
+and compete on base cosine alone.
+
+### Zero-candidate fallback
+
+When every plan in the pool conflicts with the caller's scope, the
+matcher returns `[]`. Upstream `nx_answer` treats this exactly like
+"no plan matched at all" and falls through to `_nx_answer_plan_miss`,
+which invokes the inline planner with the caller's `scope` as a prompt
+hint. Saved plans that don't fit the caller's scope never degrade the
+answer; they are simply absent from the selection.
+
+### Prefix semantics
+
+Scope strings are normalized before comparison (hash suffixes stripped
+at save time, trailing globs stripped at match time), then matched with
+`startswith` in either direction. Bare-family tags serve narrower
+queries: tag `rdr__` matches caller scope `rdr__arcaneum`. Specific
+tags are also reached by bare-family callers: tag `rdr__arcaneum`
+matches caller scope `rdr__`.
+
+Multi-corpus plans use intersect semantics: a plan tagged
+`knowledge__delos,knowledge__arcaneum` passes when the caller scope
+prefix-matches either tag, so bridging plans survive when the caller
+picks one of them.
+
 ## When to author a new plan
 
 Three signals that a class of questions needs its own plan template:


### PR DESCRIPTION
## Summary

Documents the now-live scope-aware matching so plan authors can exploit it.

- **plan-authoring-guide.md**: new '`scope_tags` (matcher routing)' section covering inference vs explicit, normalization contract, matching semantics, multi-corpus bridging plans, interaction with grown plans, and authoring guidance. Clearly distinguishes `scope_tags` (matcher routing) from the `scope` dimension (publication tier).
- **plan-centric-retrieval.md**: new 'Scope-aware matching' section covering filter/boost/tie-break mechanics, zero-candidate fallback to the inline planner, and prefix semantics including intersect rules for multi-corpus plans. Quotes the final `scope_fit_weight=0.15` value picked in Phase 2c.

Docs lag code per the RDR bead constraint: the live behaviour is documented, not the originally-proposed behaviour.

## Test plan

- [x] Pure docs change; no code paths touched.
- [x] Values quoted in the docs match `src/nexus/plans/matcher.py` (`_SCOPE_FIT_WEIGHT = 0.15`).
- [x] No em dashes in new prose (pre-existing ones untouched).

## References

- RDR: `docs/rdr/rdr-091-scope-aware-plan-matching.md` §Phase 2d
- Bead: nexus-jvma (final bead under epic nexus-gr9n, parent nexus-zs1d)
- Prior: Phase 2a #231, Phase 2b #232, Phase 2c #233