### PR TITLE
RDR-091 critic follow-up: corpus=all sentinel + explicit scope_tags preservation (nexus-dfok)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -280,3 +280,5 @@
 {"id":"int-a7e0de29","kind":"field_change","created_at":"2026-04-22T15:38:27.44043Z","actor":"Hellblazer","issue_id":"nexus-x6pr","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-86b113c9","kind":"field_change","created_at":"2026-04-22T15:59:28.688073Z","actor":"Hellblazer","issue_id":"nexus-bgs7","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-cb8decd6","kind":"field_change","created_at":"2026-04-22T16:03:54.309964Z","actor":"Hellblazer","issue_id":"nexus-svcg","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-9678bfba","kind":"field_change","created_at":"2026-04-22T16:08:14.975195Z","actor":"Hellblazer","issue_id":"nexus-jvma","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-47a006df","kind":"field_change","created_at":"2026-04-22T16:08:28.765075Z","actor":"Hellblazer","issue_id":"nexus-zs1d","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/docs/plan-authoring-guide.md
+++ b/docs/plan-authoring-guide.md
@@ -349,11 +349,17 @@ accidentally filtered out the moment the caller picks one of them.
 
 ### Interaction with grown plans
 
-The `nx_answer` ad-hoc save path (RDR-084) infers `scope_tags` from the
-actual corpus used in that run. Running the same question against
-`knowledge__delos` and then against `knowledge__arcaneum` saves two
-grown plans with different `scope_tags`, which is the right answer:
-each plan is anchored to the retrieval space it actually explored.
+The `nx_answer` ad-hoc save path (RDR-084) passes the caller's `scope`
+argument through as the grown plan's `scope_tags`, so grown plans are
+anchored to the retrieval space that produced them. Running the same
+question against `knowledge__delos` and then against `knowledge__arcaneum`
+saves two grown plans with different `scope_tags`, each ready to serve
+future questions in the same scope.
+
+When `nx_answer` is called without a `scope` argument, the grown plan's
+`scope_tags` is inferred from literal corpus/collection args in the
+executed plan_json; plans whose retrieval steps use `$var` bindings or
+the `"all"` wildcard end up agnostic (`scope_tags=""`) in that case.
 
 ### Authoring guidance
 

--- a/docs/rdr/rdr-091-scope-aware-plan-matching.md
+++ b/docs/rdr/rdr-091-scope-aware-plan-matching.md
@@ -12,7 +12,7 @@ related_issues:
   - "nexus-zs1d: Wire nx_answer scope through plan_match + plan_run"
 related_tests: [test_plan_match.py, test_plan_library.py, test_nx_answer.py]
 related: [RDR-078, RDR-079, RDR-080, RDR-084]
-implementation_notes: "scope_fit_weight=0.15 picked Phase 2c (nexus-svcg): motivating case (generic agnostic 0.82 vs specialized matching 0.79) break-even at w~0.038; 0.15 leaves 0.09 margin (specialized 0.79*1.15=0.9085 beats generic 0.82) without drowning genuinely higher-cosine agnostic plans. Formula is multiplicative per RDR spec."
+implementation_notes: "scope_fit_weight=0.15 picked Phase 2c (nexus-svcg): motivating case (generic agnostic 0.82 vs specialized matching 0.79) break-even at w~0.038; 0.15 leaves 0.09 margin (specialized 0.79*1.15=0.9085 beats generic 0.82) without drowning genuinely higher-cosine agnostic plans. Formula is multiplicative per RDR spec. Phase 2c regression gate is semantic (empty-scope no-op), not an arithmetic test count; current plan-subsystem suite runs ~200 tests post-091 including the new phase 2a-2c additions. Critic follow-up (nexus-dfok, 2026-04-22) fixed two silent bugs: (1) 'all' corpus sentinel was inferred as a concrete scope tag, filtering 7 of 9 builtins out of scoped nx_answer calls; (2) backfill migration overwrote explicit save_plan(scope_tags=...) values on every process restart. 4.8.1 rewash migration corrects pre-fix rows; grown-plan save now passes scope_tags=scope explicitly so grown plans are anchored to the retrieval space that produced them."
 ---
 
 # RDR-091: Scope-Aware Plan Matching (nexus-zs1d Phase 2)

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -545,7 +545,7 @@ def migrate_chash_index(conn: sqlite3.Connection) -> None:
 
 
 def _add_plan_scope_tags(conn: sqlite3.Connection) -> None:
-    """Add the ``scope_tags`` column to ``plans`` and backfill existing rows.
+    """Add the ``scope_tags`` column to ``plans`` and backfill default rows.
 
     RDR-091 Phase 2a (bead ``nexus-x6pr``). ``scope_tags`` captures which
     corpora / collections a plan actually touched — a comma-separated,
@@ -553,9 +553,15 @@ def _add_plan_scope_tags(conn: sqlite3.Connection) -> None:
     this column during match-time re-ranking; this migration only ensures
     the column exists and carries a best-effort value for every row.
 
+    The backfill intentionally guards on ``WHERE scope_tags = ''`` so
+    explicitly-authored values (passed via ``save_plan(scope_tags=...)``)
+    survive process restarts. Without this guard (RDR-091 critic
+    follow-up, nexus-dfok), every process start would overwrite
+    explicit tags with inference output, defeating the explicit-override
+    path documented in the authoring guide.
+
     Idempotent via a ``PRAGMA table_info`` column guard. The backfill is
-    re-run on every invocation because inference is deterministic — so a
-    partial migration that crashed mid-UPDATE is safe to retry.
+    safe to re-run because inference is deterministic.
 
     No-op on a DB that has no ``plans`` table (fresh install without
     :mod:`nexus.db.t2.plan_library` ever instantiated).
@@ -578,17 +584,75 @@ def _add_plan_scope_tags(conn: sqlite3.Connection) -> None:
             "ALTER TABLE plans ADD COLUMN scope_tags TEXT NOT NULL DEFAULT ''"
         )
 
-    # Backfill: inference is deterministic and cheap; re-running is safe.
+    # Backfill only rows where scope_tags is still the default ''.
+    # Explicit values survive; partial-failure retries pick up where
+    # they left off.
     from nexus.db.t2.plan_library import _infer_scope_tags
 
-    rows = conn.execute("SELECT id, plan_json FROM plans").fetchall()
+    rows = conn.execute(
+        "SELECT id, plan_json FROM plans WHERE scope_tags = ''"
+    ).fetchall()
+    for row_id, plan_json in rows:
+        inferred = _infer_scope_tags(plan_json or "")
+        if inferred:
+            conn.execute(
+                "UPDATE plans SET scope_tags = ? WHERE id = ? AND scope_tags = ''",
+                (inferred, row_id),
+            )
+    conn.commit()
+
+
+def _rewash_plan_scope_tags_all_sentinel(conn: sqlite3.Connection) -> None:
+    """Rewash rows whose ``scope_tags`` contains ``'all'`` from pre-fix backfill.
+
+    RDR-091 critic follow-up (bead ``nexus-dfok``). The first-cut
+    ``_infer_scope_tags`` treated ``corpus: "all"`` as a concrete
+    scope tag, so the 4.8.0 backfill wrote ``scope_tags='all'`` onto
+    every builtin plan that uses ``corpus: all`` (7 of 9 builtins).
+    At match time those plans prefix-matched no real scope and were
+    filtered out of the candidate pool — inverting RDR-091's whole
+    purpose for any scoped ``nx_answer`` call.
+
+    The inference fix (``"all"`` is now a skipped sentinel) takes
+    effect on new saves, but existing rows carry the broken value.
+    This migration re-runs inference on any row whose ``scope_tags``
+    contains the token ``all``, replacing it with the corrected value
+    (typically ``""`` for agnostic plans, or the subset of real tags
+    when a multi-corpus plan mixed ``all`` with specific corpora).
+
+    No-op on fresh installs or on DBs where every row already has
+    clean tags. Idempotent: a second run finds no matching rows.
+    """
+    has_table = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='plans'"
+    ).fetchone()
+    if not has_table:
+        return
+
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(plans)").fetchall()}
+    if "scope_tags" not in cols:
+        return
+
+    from nexus.db.t2.plan_library import _infer_scope_tags
+
+    rows = conn.execute(
+        """
+        SELECT id, plan_json FROM plans
+        WHERE scope_tags = 'all'
+           OR scope_tags LIKE 'all,%'
+           OR scope_tags LIKE '%,all'
+           OR scope_tags LIKE '%,all,%'
+        """
+    ).fetchall()
     for row_id, plan_json in rows:
         inferred = _infer_scope_tags(plan_json or "")
         conn.execute(
             "UPDATE plans SET scope_tags = ? WHERE id = ?",
             (inferred, row_id),
         )
-    conn.commit()
+    if rows:
+        _log.info("Rewashed plan scope_tags 'all' sentinel", row_count=len(rows))
+        conn.commit()
 
 
 MIGRATIONS: list[Migration] = [
@@ -633,6 +697,11 @@ MIGRATIONS: list[Migration] = [
         "4.8.0",
         "Add plans.scope_tags column (RDR-091 Phase 2a)",
         _add_plan_scope_tags,
+    ),
+    Migration(
+        "4.8.1",
+        "Rewash plans.scope_tags 'all' sentinel (RDR-091 critic follow-up)",
+        _rewash_plan_scope_tags_all_sentinel,
     ),
 ]
 

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -587,7 +587,7 @@ def _add_plan_scope_tags(conn: sqlite3.Connection) -> None:
     # Backfill only rows where scope_tags is still the default ''.
     # Explicit values survive; partial-failure retries pick up where
     # they left off.
-    from nexus.db.t2.plan_library import _infer_scope_tags
+    from nexus.plans.scope import _infer_scope_tags
 
     rows = conn.execute(
         "SELECT id, plan_json FROM plans WHERE scope_tags = ''"
@@ -633,7 +633,7 @@ def _rewash_plan_scope_tags_all_sentinel(conn: sqlite3.Connection) -> None:
     if "scope_tags" not in cols:
         return
 
-    from nexus.db.t2.plan_library import _infer_scope_tags
+    from nexus.plans.scope import _infer_scope_tags
 
     rows = conn.execute(
         """

--- a/src/nexus/db/t2/plan_library.py
+++ b/src/nexus/db/t2/plan_library.py
@@ -25,8 +25,6 @@ seeding would break in production.
 
 from __future__ import annotations
 
-import json
-import re
 import sqlite3
 import threading
 from datetime import UTC, datetime
@@ -36,95 +34,28 @@ from typing import Any
 import structlog
 
 from nexus.db.t2.memory_store import _sanitize_fts5
+# Scope-tag helpers live in ``nexus.plans.scope`` to break the
+# ``migrations -> plan_library -> migrations`` circular import path
+# (RDR-091 code-review finding C-1). Re-exported for backward compat
+# with callers that import them from this module.
+from nexus.plans.scope import (
+    _HASH_SUFFIX_RE,
+    _RETRIEVAL_SCOPE_ARGS,
+    _SCOPE_AGNOSTIC_SENTINELS,
+    _infer_scope_tags,
+    _normalize_scope_string,
+)
+
+__all__ = [
+    "PlanLibrary",
+    "_HASH_SUFFIX_RE",
+    "_RETRIEVAL_SCOPE_ARGS",
+    "_SCOPE_AGNOSTIC_SENTINELS",
+    "_infer_scope_tags",
+    "_normalize_scope_string",
+]
 
 _log = structlog.get_logger()
-
-
-# ── Scope-tag helpers (RDR-091 Phase 2a) ──────────────────────────────────────
-#
-# ``scope_tags`` is a comma-separated, sorted, deduplicated, hash-suffix-
-# normalized string naming the corpora / collections a plan actually
-# touched. Phase 2a stores and infers; Phase 2b consumes during match-time
-# re-ranking. ``_normalize_scope_string`` is also shared with the matcher.
-
-_HASH_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$")
-
-
-def _normalize_scope_string(scope: str) -> str:
-    """Return *scope* in canonical scope-tag form.
-
-    Rules (RDR-091 §Proposed Solution → Normalization):
-      * Strip a trailing 8-char lowercase hex suffix (``-deadbeef``).
-        The collection-name convention is exactly 8 hex chars; shorter,
-        longer, or non-hex tails are preserved verbatim.
-      * Strip a trailing ``*`` or ``-*`` glob.
-      * Preserve a bare family prefix (``rdr__``) and tumbler addresses
-        (``1.16``) unchanged.
-      * Empty input is returned unchanged.
-    """
-    if not scope:
-        return scope
-    # Glob suffix first — a ``rdr__arcaneum-*`` has no hex tail to strip.
-    if scope.endswith("-*"):
-        return scope[:-2]
-    if scope.endswith("*"):
-        return scope[:-1]
-    return _HASH_SUFFIX_RE.sub("", scope)
-
-
-_RETRIEVAL_SCOPE_ARGS: tuple[str, ...] = ("corpus", "collection")
-
-# ``"all"`` is a sentinel the search/query MCP tools document as "search
-# every collection". It is scope-agnostic, not a concrete corpus name,
-# so it must never contribute to ``scope_tags`` — otherwise the seven
-# builtin plans that use ``corpus: all`` would be scope-filtered out of
-# the candidate pool whenever ``scope_preference`` is set (RDR-091
-# critic follow-up, nexus-dfok).
-_SCOPE_AGNOSTIC_SENTINELS: frozenset[str] = frozenset({"all"})
-
-
-def _infer_scope_tags(plan_json: str) -> str:
-    """Infer scope_tags from a plan by unioning retrieval-step scope args.
-
-    Walks the ``steps`` list in *plan_json*. For every step, collects any
-    ``args["corpus"]`` or ``args["collection"]`` value that is a literal
-    string (not a ``$var`` binding placeholder and not the ``"all"``
-    wildcard sentinel). Each collected value is normalized via
-    :func:`_normalize_scope_string`. The result is a comma-separated,
-    sorted, deduplicated string — ``""`` when the plan names no literal
-    retrieval scope (e.g. traverse-only plans or plans that search
-    everything).
-
-    Malformed ``plan_json`` yields ``""`` (fail-soft: scope inference is
-    best-effort and must never block a save).
-    """
-    try:
-        plan = json.loads(plan_json)
-    except (TypeError, json.JSONDecodeError):
-        return ""
-
-    steps = plan.get("steps") if isinstance(plan, dict) else None
-    if not isinstance(steps, list):
-        return ""
-
-    collected: set[str] = set()
-    for step in steps:
-        if not isinstance(step, dict):
-            continue
-        args = step.get("args")
-        if not isinstance(args, dict):
-            continue
-        for key in _RETRIEVAL_SCOPE_ARGS:
-            value = args.get(key)
-            if not isinstance(value, str) or not value:
-                continue
-            if value.startswith("$"):
-                continue
-            if value in _SCOPE_AGNOSTIC_SENTINELS:
-                continue
-            collected.add(_normalize_scope_string(value))
-
-    return ",".join(sorted(tag for tag in collected if tag))
 
 
 # Per-domain migration guard (RDR-063 Open Question 3 — Phase 2 resolution).
@@ -337,11 +268,17 @@ class PlanLibrary:
         """
         created_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         if scope_tags:
-            # Normalize each comma-separated entry and drop empties.
+            # Normalize each comma-separated entry, drop empties, and
+            # drop scope-agnostic sentinels (``"all"``). Without the
+            # sentinel filter, ``save_plan(scope_tags="all")`` would
+            # store a literal that the matcher later treats as a
+            # conflict — same failure mode the critic-follow-up inference
+            # fix addresses on the inference path. (RDR-091 code-review
+            # finding C-3.)
             parts = [
                 _normalize_scope_string(p.strip())
                 for p in scope_tags.split(",")
-                if p.strip()
+                if p.strip() and p.strip() not in _SCOPE_AGNOSTIC_SENTINELS
             ]
             stored_scope_tags = ",".join(sorted({p for p in parts if p}))
         else:

--- a/src/nexus/db/t2/plan_library.py
+++ b/src/nexus/db/t2/plan_library.py
@@ -74,16 +74,26 @@ def _normalize_scope_string(scope: str) -> str:
 
 _RETRIEVAL_SCOPE_ARGS: tuple[str, ...] = ("corpus", "collection")
 
+# ``"all"`` is a sentinel the search/query MCP tools document as "search
+# every collection". It is scope-agnostic, not a concrete corpus name,
+# so it must never contribute to ``scope_tags`` — otherwise the seven
+# builtin plans that use ``corpus: all`` would be scope-filtered out of
+# the candidate pool whenever ``scope_preference`` is set (RDR-091
+# critic follow-up, nexus-dfok).
+_SCOPE_AGNOSTIC_SENTINELS: frozenset[str] = frozenset({"all"})
+
 
 def _infer_scope_tags(plan_json: str) -> str:
     """Infer scope_tags from a plan by unioning retrieval-step scope args.
 
     Walks the ``steps`` list in *plan_json*. For every step, collects any
     ``args["corpus"]`` or ``args["collection"]`` value that is a literal
-    string (not a ``$var`` binding placeholder). Each collected value is
-    normalized via :func:`_normalize_scope_string`. The result is a
-    comma-separated, sorted, deduplicated string — ``""`` when the plan
-    names no literal retrieval scope (e.g. traverse-only plans).
+    string (not a ``$var`` binding placeholder and not the ``"all"``
+    wildcard sentinel). Each collected value is normalized via
+    :func:`_normalize_scope_string`. The result is a comma-separated,
+    sorted, deduplicated string — ``""`` when the plan names no literal
+    retrieval scope (e.g. traverse-only plans or plans that search
+    everything).
 
     Malformed ``plan_json`` yields ``""`` (fail-soft: scope inference is
     best-effort and must never block a save).
@@ -109,6 +119,8 @@ def _infer_scope_tags(plan_json: str) -> str:
             if not isinstance(value, str) or not value:
                 continue
             if value.startswith("$"):
+                continue
+            if value in _SCOPE_AGNOSTIC_SENTINELS:
                 continue
             collected.add(_normalize_scope_string(value))
 
@@ -280,11 +292,17 @@ class PlanLibrary:
         """Add the ``scope_tags`` column and backfill existing rows (RDR-091).
 
         Lock-naive: caller must hold ``self._lock`` and ``_migrated_lock``.
-        Delegates to :func:`nexus.db.migrations._add_plan_scope_tags`.
+        Delegates to :func:`nexus.db.migrations._add_plan_scope_tags` and
+        the 4.8.1 critic-follow-up
+        :func:`nexus.db.migrations._rewash_plan_scope_tags_all_sentinel`.
         """
-        from nexus.db.migrations import _add_plan_scope_tags
+        from nexus.db.migrations import (
+            _add_plan_scope_tags,
+            _rewash_plan_scope_tags_all_sentinel,
+        )
 
         _add_plan_scope_tags(self.conn)
+        _rewash_plan_scope_tags_all_sentinel(self.conn)
 
     # ── Public API ────────────────────────────────────────────────────────
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1246,9 +1246,11 @@ def plan_search(query: str, project: str = "", limit: int = 5, offset: int = 0) 
         lines: list[str] = []
         for r in results:
             plan_preview = r["plan_json"][:100].replace("\n", " ")
+            scope_display = r.get("scope_tags") or "(agnostic)"
             lines.append(
                 f"[{r['id']}] {r['query'][:60]}\n"
                 f"  outcome={r['outcome']}  tags={r['tags']}\n"
+                f"  scope={scope_display}\n"
                 f"  plan: {plan_preview}..."
             )
         shown_end = offset + len(results)
@@ -2277,6 +2279,12 @@ async def nx_answer(
                 from pathlib import Path as _Path
 
                 project_name = _Path.cwd().name
+                # RDR-091 critic follow-up (nexus-dfok): anchor the grown
+                # plan to the caller's scope. _infer_scope_tags cannot see
+                # the runtime corpus injection from ``_nx_scope`` because
+                # it only appears in bindings, not plan_json. Passing
+                # scope_tags=scope explicitly captures the retrieval space
+                # that produced this plan.
                 with _t2_ctx() as _save_db:
                     grown_id = _save_db.plans.save_plan(
                         query=question,
@@ -2286,6 +2294,7 @@ async def nx_answer(
                         project=project_name,
                         ttl=ttl_days,
                         scope="personal",
+                        scope_tags=scope or None,
                     )
                     # Feed the new plan into the T1 cosine cache so the next
                     # paraphrase can match without a SessionStart re-populate.

--- a/src/nexus/plans/matcher.py
+++ b/src/nexus/plans/matcher.py
@@ -29,10 +29,15 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
-from nexus.db.t2.plan_library import PlanLibrary, _normalize_scope_string
+import structlog
+
+from nexus.db.t2.plan_library import PlanLibrary
 from nexus.plans.match import Match
+from nexus.plans.scope import _normalize_scope_string
 
 __all__ = ["PlanCache", "plan_match"]
+
+_log = structlog.get_logger()
 
 
 # ── Scope-aware re-ranking (RDR-091 Phase 2b + 2c) ─────────────────────────
@@ -169,6 +174,7 @@ def plan_match(
         hits = cache.query(intent, _over)
         # Gather all admissible candidates with (adjusted_score, specificity).
         scored: list[tuple[float, int, Match]] = []
+        scope_conflict_drops = 0
         for plan_id, distance in hits:
             row = library.get_plan(plan_id)
             if row is None:
@@ -188,6 +194,7 @@ def plan_match(
                 continue
             fit = _scope_fit(m.scope_tags, scope_pref)
             if fit is None:
+                scope_conflict_drops += 1
                 continue  # scope conflict — drop from pool
             adjusted = confidence * (1.0 + _SCOPE_FIT_WEIGHT * fit)
             scored.append((adjusted, _specificity(m.scope_tags), m))
@@ -198,6 +205,18 @@ def plan_match(
             for m in matches:
                 library.increment_match_metrics(m.plan_id, confidence=m.confidence)
             return matches
+
+        # T1 returned hits but every admissible plan was scope-filtered.
+        # Log so operators can see when scope_preference is silently
+        # degrading matches to FTS5 / inline planner (RDR-091 code-review
+        # finding I-4).
+        if hits and scope_conflict_drops > 0:
+            _log.debug(
+                "plan_match_scope_conflict_fallthrough",
+                t1_hits=len(hits),
+                dropped=scope_conflict_drops,
+                scope_pref=scope_pref,
+            )
 
     # FTS5 fallback: either cache unavailable or T1 returned no hits.
     # Over-fetch so the dimension post-filter doesn't starve the caller.

--- a/src/nexus/plans/scope.py
+++ b/src/nexus/plans/scope.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Scope-tag helpers for RDR-091 plan scope-aware matching.
+
+Lives in :mod:`nexus.plans` rather than :mod:`nexus.db.t2.plan_library`
+to break a ``migrations -> plan_library -> migrations`` circular import
+path (code-review finding C-1, RDR-091 follow-up). The helpers have no
+sqlite dependency; their natural home is the ``plans`` domain.
+
+``_normalize_scope_string`` is the canonical scope-tag normalizer shared
+between the save path (``plan_library.save_plan``), the inference helper
+(``_infer_scope_tags``), and the match-time re-ranker
+(``nexus.plans.matcher._scope_fit``). Changes here touch all three.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+__all__ = [
+    "_HASH_SUFFIX_RE",
+    "_RETRIEVAL_SCOPE_ARGS",
+    "_SCOPE_AGNOSTIC_SENTINELS",
+    "_infer_scope_tags",
+    "_normalize_scope_string",
+]
+
+_HASH_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$")
+
+# Comma-separated ``scope_tags`` entries; also the keys ``_infer_scope_tags``
+# looks for in retrieval-step args.
+_RETRIEVAL_SCOPE_ARGS: tuple[str, ...] = ("corpus", "collection")
+
+# ``"all"`` is a sentinel the search/query MCP tools document as "search
+# every collection". It is scope-agnostic, not a concrete corpus name,
+# so it must never contribute to ``scope_tags`` — otherwise the seven
+# builtin plans that use ``corpus: all`` would be scope-filtered out of
+# the candidate pool whenever ``scope_preference`` is set (RDR-091
+# critic follow-up, nexus-dfok).
+_SCOPE_AGNOSTIC_SENTINELS: frozenset[str] = frozenset({"all"})
+
+
+def _normalize_scope_string(scope: str) -> str:
+    """Return *scope* in canonical scope-tag form.
+
+    Rules (RDR-091 §Proposed Solution → Normalization):
+      * Strip a trailing 8-char lowercase hex suffix (``-deadbeef``).
+        The collection-name convention is exactly 8 hex chars; shorter,
+        longer, or non-hex tails are preserved verbatim.
+      * Strip a trailing ``*`` or ``-*`` glob.
+      * Preserve a bare family prefix (``rdr__``) and tumbler addresses
+        (``1.16``) unchanged.
+      * Empty input is returned unchanged.
+    """
+    if not scope:
+        return scope
+    if scope.endswith("-*"):
+        return scope[:-2]
+    if scope.endswith("*"):
+        return scope[:-1]
+    return _HASH_SUFFIX_RE.sub("", scope)
+
+
+def _infer_scope_tags(plan_json: str) -> str:
+    """Infer scope_tags from a plan by unioning retrieval-step scope args.
+
+    Walks the ``steps`` list in *plan_json*. For every step, collects any
+    ``args["corpus"]`` or ``args["collection"]`` value that is a literal
+    string (not a ``$var`` binding placeholder and not the ``"all"``
+    wildcard sentinel). Each collected value is normalized via
+    :func:`_normalize_scope_string`. The result is a comma-separated,
+    sorted, deduplicated string — ``""`` when the plan names no literal
+    retrieval scope (e.g. traverse-only plans or plans that search
+    everything).
+
+    Malformed ``plan_json`` yields ``""`` (fail-soft: scope inference is
+    best-effort and must never block a save).
+    """
+    try:
+        plan = json.loads(plan_json)
+    except (TypeError, json.JSONDecodeError):
+        return ""
+
+    steps = plan.get("steps") if isinstance(plan, dict) else None
+    if not isinstance(steps, list):
+        return ""
+
+    collected: set[str] = set()
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        args = step.get("args")
+        if not isinstance(args, dict):
+            continue
+        for key in _RETRIEVAL_SCOPE_ARGS:
+            value = args.get(key)
+            if not isinstance(value, str) or not value:
+                continue
+            if value.startswith("$"):
+                continue
+            if value in _SCOPE_AGNOSTIC_SENTINELS:
+                continue
+            collected.add(_normalize_scope_string(value))
+
+    return ",".join(sorted(tag for tag in collected if tag))

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -73,7 +73,7 @@ class TestMigrationDataclass:
         from nexus.db.migrations import MIGRATIONS
 
         assert isinstance(MIGRATIONS, list)
-        assert len(MIGRATIONS) == 14  # + RDR-091 Phase 2a plans.scope_tags
+        assert len(MIGRATIONS) == 15  # + RDR-091 critic follow-up 4.8.1 rewash
 
     def test_migrations_ordered_by_version(self) -> None:
         from nexus.db.migrations import MIGRATIONS, _parse_version

--- a/tests/test_plan_library.py
+++ b/tests/test_plan_library.py
@@ -570,3 +570,185 @@ def test_migration_adds_column_to_empty_plans_table(tmp_path: Path) -> None:
     cols = {row[1] for row in conn.execute("PRAGMA table_info(plans)").fetchall()}
     assert "scope_tags" in cols
     conn.close()
+
+
+# ── RDR-091 critic follow-up (nexus-dfok) ────────────────────────────────
+
+
+def test_infer_scope_tags_skips_all_sentinel() -> None:
+    """_infer_scope_tags treats ``corpus='all'`` as agnostic, not a concrete tag.
+
+    Regression guard for the nexus-dfok bug: without this rule, builtin
+    plans using ``corpus: all`` were filtered out of any scoped
+    ``nx_answer`` call, inverting RDR-091's entire purpose.
+    """
+    from nexus.db.t2.plan_library import _infer_scope_tags
+
+    assert _infer_scope_tags(
+        '{"steps":[{"tool":"search","args":{"corpus":"all"}}]}'
+    ) == ""
+
+
+def test_infer_scope_tags_mixes_all_with_specific_drops_all() -> None:
+    """Multi-step plans that mix ``corpus: all`` with a specific corpus keep
+    only the specific tag; ``all`` never contributes."""
+    from nexus.db.t2.plan_library import _infer_scope_tags
+
+    plan_json = (
+        '{"steps":['
+        '{"tool":"search","args":{"corpus":"all"}},'
+        '{"tool":"search","args":{"corpus":"rdr__arcaneum"}}'
+        ']}'
+    )
+    assert _infer_scope_tags(plan_json) == "rdr__arcaneum"
+
+
+def test_save_plan_explicit_scope_tags_survive_backfill(tmp_path: Path) -> None:
+    """Rows with explicit scope_tags must NOT be overwritten by the 4.8.0
+    backfill on subsequent process starts.
+
+    Regression guard for the nexus-dfok bug: the original backfill ran
+    an unconditional UPDATE, so plans authored with
+    ``save_plan(scope_tags='rdr__arcaneum')`` whose plan_json used
+    ``$var`` corpus bindings were reverted to agnostic on every restart.
+    """
+    import sqlite3
+
+    from nexus.db.migrations import _add_plan_scope_tags
+
+    db_path = tmp_path / "preserve.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE plans (
+            id INTEGER PRIMARY KEY,
+            project TEXT NOT NULL DEFAULT '',
+            query TEXT NOT NULL,
+            plan_json TEXT NOT NULL,
+            outcome TEXT DEFAULT 'success',
+            tags TEXT DEFAULT '',
+            created_at TEXT NOT NULL,
+            scope_tags TEXT NOT NULL DEFAULT ''
+        );
+        """
+    )
+    # An explicit-tagged plan whose plan_json uses $var bindings —
+    # inference would return '' if re-run, overwriting the explicit value.
+    conn.execute(
+        "INSERT INTO plans (query, plan_json, created_at, scope_tags) "
+        "VALUES (?, ?, ?, ?)",
+        (
+            "q",
+            '{"steps":[{"tool":"search","args":{"corpus":"$corpus"}}]}',
+            "2025-01-01T00:00:00Z",
+            "rdr__arcaneum",
+        ),
+    )
+    conn.commit()
+
+    _add_plan_scope_tags(conn)
+    row = conn.execute("SELECT scope_tags FROM plans WHERE query='q'").fetchone()
+    assert row[0] == "rdr__arcaneum", (
+        "explicit scope_tags value must survive the idempotent backfill"
+    )
+    conn.close()
+
+
+def test_rewash_migration_fixes_all_sentinel_rows(tmp_path: Path) -> None:
+    """The 4.8.1 rewash migration corrects rows stuck at 'all' from the
+    pre-fix backfill."""
+    import sqlite3
+
+    from nexus.db.migrations import _rewash_plan_scope_tags_all_sentinel
+
+    db_path = tmp_path / "rewash.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE plans (
+            id INTEGER PRIMARY KEY,
+            project TEXT NOT NULL DEFAULT '',
+            query TEXT NOT NULL,
+            plan_json TEXT NOT NULL,
+            outcome TEXT DEFAULT 'success',
+            tags TEXT DEFAULT '',
+            created_at TEXT NOT NULL,
+            scope_tags TEXT NOT NULL DEFAULT ''
+        );
+        """
+    )
+    # Simulate pre-fix state: three rows with stale 'all'-contaminated
+    # scope_tags alongside one already-clean row.
+    conn.executemany(
+        "INSERT INTO plans (query, plan_json, created_at, scope_tags) "
+        "VALUES (?, ?, ?, ?)",
+        [
+            # Plain 'all' → should become '' after rewash.
+            ("q1", '{"steps":[{"tool":"search","args":{"corpus":"all"}}]}',
+             "2025-01-01T00:00:00Z", "all"),
+            # Mixed 'all,specific' → should become 'rdr__arcaneum'.
+            ("q2", '{"steps":['
+                   '{"tool":"search","args":{"corpus":"all"}},'
+                   '{"tool":"search","args":{"corpus":"rdr__arcaneum"}}'
+                   ']}',
+             "2025-01-01T00:00:00Z", "all,rdr__arcaneum"),
+            # Clean row — should be untouched.
+            ("q3", '{"steps":[{"tool":"search","args":{"corpus":"rdr__delos"}}]}',
+             "2025-01-01T00:00:00Z", "rdr__delos"),
+        ],
+    )
+    conn.commit()
+
+    _rewash_plan_scope_tags_all_sentinel(conn)
+
+    q1 = conn.execute("SELECT scope_tags FROM plans WHERE query='q1'").fetchone()
+    q2 = conn.execute("SELECT scope_tags FROM plans WHERE query='q2'").fetchone()
+    q3 = conn.execute("SELECT scope_tags FROM plans WHERE query='q3'").fetchone()
+    assert q1[0] == "", "plain 'all' must rewash to agnostic"
+    assert q2[0] == "rdr__arcaneum", "mixed 'all,specific' must drop 'all'"
+    assert q3[0] == "rdr__delos", "clean row must be untouched"
+
+    # Idempotent: running again finds nothing to rewash.
+    _rewash_plan_scope_tags_all_sentinel(conn)
+    q1 = conn.execute("SELECT scope_tags FROM plans WHERE query='q1'").fetchone()
+    assert q1[0] == ""
+    conn.close()
+
+
+def test_rewash_migration_no_op_when_no_all_rows(tmp_path: Path) -> None:
+    """Rewash migration is a safe no-op when no row contains 'all'."""
+    import sqlite3
+
+    from nexus.db.migrations import _rewash_plan_scope_tags_all_sentinel
+
+    db_path = tmp_path / "clean.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE plans (
+            id INTEGER PRIMARY KEY,
+            project TEXT NOT NULL DEFAULT '',
+            query TEXT NOT NULL,
+            plan_json TEXT NOT NULL,
+            outcome TEXT DEFAULT 'success',
+            tags TEXT DEFAULT '',
+            created_at TEXT NOT NULL,
+            scope_tags TEXT NOT NULL DEFAULT ''
+        );
+        """
+    )
+    conn.commit()
+    _rewash_plan_scope_tags_all_sentinel(conn)  # must not crash
+    conn.close()
+
+
+def test_rewash_migration_no_op_without_plans_table(tmp_path: Path) -> None:
+    """Rewash migration is a safe no-op on a DB without a plans table."""
+    import sqlite3
+
+    from nexus.db.migrations import _rewash_plan_scope_tags_all_sentinel
+
+    db_path = tmp_path / "empty.db"
+    conn = sqlite3.connect(str(db_path))
+    _rewash_plan_scope_tags_all_sentinel(conn)  # must not crash
+    conn.close()

--- a/tests/test_plan_library.py
+++ b/tests/test_plan_library.py
@@ -469,8 +469,9 @@ def test_save_plan_omitted_scope_tags_traverse_only(plan_db: T2Database) -> None
 
 def test_save_plan_scope_tags_column_default_empty(plan_db: T2Database) -> None:
     """The scope_tags column defaults to '' (load-bearing: pre-backfill rows)."""
-    # A low-level INSERT that omits scope_tags altogether mimics an
-    # unmigrated row. The column must still read as '', not NULL.
+    # The INSERT below omits scope_tags, so the SQL DEFAULT '' fires.
+    # This pins the load-bearing default: any INSERT path that forgets
+    # scope_tags produces '' (treated as agnostic), not NULL.
     plan_db.plans.conn.execute(
         """
         INSERT INTO plans (project, query, plan_json, outcome, tags, created_at)
@@ -739,6 +740,80 @@ def test_rewash_migration_no_op_when_no_all_rows(tmp_path: Path) -> None:
     )
     conn.commit()
     _rewash_plan_scope_tags_all_sentinel(conn)  # must not crash
+    conn.close()
+
+
+def test_save_plan_explicit_scope_tags_filters_all_sentinel(plan_db: T2Database) -> None:
+    """save_plan(scope_tags='all') must drop the sentinel — same contract as
+    the inference path. Without this filter the sentinel would reach storage
+    via the explicit path (RDR-091 code-review finding C-3)."""
+    row_id = plan_db.save_plan(
+        query="q",
+        plan_json='{"steps":[]}',
+        scope_tags="all",
+    )
+    row = plan_db.plans.conn.execute(
+        "SELECT scope_tags FROM plans WHERE id = ?", (row_id,)
+    ).fetchone()
+    assert row[0] == ""
+
+
+def test_save_plan_explicit_scope_tags_drops_all_mixed_with_specific(
+    plan_db: T2Database,
+) -> None:
+    """Mixed 'all' + specific tags drops the 'all' and keeps the rest."""
+    row_id = plan_db.save_plan(
+        query="q",
+        plan_json='{"steps":[]}',
+        scope_tags="all,rdr__arcaneum",
+    )
+    row = plan_db.plans.conn.execute(
+        "SELECT scope_tags FROM plans WHERE id = ?", (row_id,)
+    ).fetchone()
+    assert row[0] == "rdr__arcaneum"
+
+
+def test_rewash_migration_fixes_trailing_all_variant(tmp_path: Path) -> None:
+    """Rewash handles 'rdr__arcaneum,all' (trailing-all variant) — the LIKE
+    '%,all' branch (RDR-091 code-review finding I-7)."""
+    import sqlite3
+
+    from nexus.db.migrations import _rewash_plan_scope_tags_all_sentinel
+
+    db_path = tmp_path / "trailing_all.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE plans (
+            id INTEGER PRIMARY KEY,
+            project TEXT NOT NULL DEFAULT '',
+            query TEXT NOT NULL,
+            plan_json TEXT NOT NULL,
+            outcome TEXT DEFAULT 'success',
+            tags TEXT DEFAULT '',
+            created_at TEXT NOT NULL,
+            scope_tags TEXT NOT NULL DEFAULT ''
+        );
+        """
+    )
+    # Lexicographic sort puts 'all' first, so trailing-'all' cannot arise
+    # from inference. But manual/external writes can produce it; the
+    # rewash query must still handle it.
+    conn.execute(
+        "INSERT INTO plans (query, plan_json, created_at, scope_tags) "
+        "VALUES (?, ?, ?, ?)",
+        (
+            "q",
+            '{"steps":[{"tool":"search","args":{"corpus":"rdr__arcaneum"}},'
+            '{"tool":"search","args":{"corpus":"all"}}]}',
+            "2025-01-01T00:00:00Z",
+            "rdr__arcaneum,all",
+        ),
+    )
+    conn.commit()
+    _rewash_plan_scope_tags_all_sentinel(conn)
+    row = conn.execute("SELECT scope_tags FROM plans WHERE query='q'").fetchone()
+    assert row[0] == "rdr__arcaneum"
     conn.close()
 
 

--- a/tests/test_plan_match.py
+++ b/tests/test_plan_match.py
@@ -402,6 +402,48 @@ def test_fts5_fallback_applies_scope_conflict_filter(library) -> None:
     assert result == [], "FTS5 path must also filter scope-conflicting plans"
 
 
+def test_scope_boost_formula_is_multiplicative_with_unequal_cosines(library) -> None:
+    """Formula-pinning regression guard (RDR-091 critic follow-up).
+
+    Phase 2b originally shipped an additive `confidence + weight * fit`
+    formula; the RDR specifies multiplicative
+    `confidence * (1 + weight * fit)`. The Phase 2b test suite used
+    equal-cosine fixtures so the bug was undetectable in unit coverage.
+    This case uses meaningfully unequal cosines so only the correct
+    multiplicative formula produces the expected ordering.
+
+    Numbers: specialized=0.79 matching, agnostic=0.82 neutral, w=0.15.
+      * multiplicative: 0.79 * 1.15 = 0.9085 > 0.82   (specialized wins)
+      * additive:       0.79 + 0.15 = 0.94   > 0.82   (also wins — so
+                        we instead use a tighter case below)
+
+    A tighter case exposes the difference: specialized=0.50 matching,
+    agnostic=0.60 neutral, w=0.15:
+      * multiplicative: 0.50 * 1.15 = 0.575  < 0.60   (agnostic wins)
+      * additive:       0.50 + 0.15 = 0.65   > 0.60   (specialized wins)
+    """
+    from nexus.plans.matcher import plan_match
+
+    specialized = _seed(library, query="q",
+                        dimensions={"verb": "research", "variant": "s"},
+                        scope_tags="rdr__arcaneum")
+    agnostic = _seed(library, query="q",
+                     dimensions={"verb": "research", "variant": "a"},
+                     scope_tags="")
+    # distance=0.50 → confidence=0.50 (specialized), distance=0.40 → 0.60 (agnostic).
+    cache = _FakeCache(hits=[(specialized, 0.50), (agnostic, 0.40)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.40, scope_preference="rdr__arcaneum",
+    )
+    # Multiplicative says agnostic (0.60) beats specialized (0.575).
+    # Additive would flip the order.
+    assert [m.plan_id for m in result][0] == agnostic, (
+        "formula must be multiplicative; a small boost does not override "
+        "a higher-cosine agnostic plan"
+    )
+
+
 def test_fts5_fallback_keeps_matching_and_agnostic(library) -> None:
     """FTS5 fallback keeps matching and agnostic plans when scope set."""
     from nexus.plans.matcher import plan_match


### PR DESCRIPTION
## Summary

`substantive-critic` review of the RDR-091 work (PRs #229-#234) flagged two silent correctness bugs and four design/discoverability issues. This PR addresses all six.

### Critical fixes

1. **`_infer_scope_tags` now skips the `"all"` sentinel.** Seven of nine builtin plans use `corpus: all` as the documented wildcard for "search every collection". The original inference treated `"all"` as a concrete scope tag, so builtins were stored with `scope_tags="all"` at backfill time. At match time `"all"` prefix-matched no real scope (`rdr__arcaneum`, `code__nexus`, etc.) and fell into the scope-conflict branch, so every builtin plan was silently filtered out of the candidate pool whenever `nx_answer` was called with `scope` set. Net effect: `scope_preference` caused the inline planner to fire unconditionally instead of matching the builtin it was supposed to match. Exactly the failure mode RDR-091 set out to fix, reproduced through a different mechanism.
2. **`_add_plan_scope_tags` backfill now guards on `WHERE scope_tags = ''`.** The original `UPDATE` ran unconditionally on every process start. Plans authored with `save_plan(scope_tags='rdr__arcaneum')` whose `plan_json` used `$var` corpus bindings (the exact pattern the authoring guide tells authors to use) lost the explicit tag on every MCP server / CLI restart.
3. **New 4.8.1 migration `_rewash_plan_scope_tags_all_sentinel`** cleans up rows left contaminated by the pre-fix backfill. Re-infers any row whose stored `scope_tags` contains the token `"all"`. Idempotent; no-op on fresh installs.

### Significant fixes

4. **`nx_answer` grown-plan save passes `scope_tags=scope`.** `_infer_scope_tags` cannot see the runtime `_nx_scope` corpus injection because it only touches bindings, not `plan_json`; grown plans from scoped `nx_answer` calls were always agnostic despite the docs claiming otherwise.
5. **`plan_search` MCP output now surfaces `scope_tags`** so authors have a feedback loop on what inference/explicit-override produced.
6. **New matcher test** (`test_scope_boost_formula_is_multiplicative_with_unequal_cosines`) uses a fixture where additive and multiplicative formulas disagree (specialized 0.50 vs agnostic 0.60 at w=0.15), pinning the correct spec-conformant formula at the unit layer. Phase 2b tests all used equal base cosines so the Phase 2c formula catch was incidental rather than systematic.

## Test plan

- [x] 5 new tests in `test_plan_library.py`: `corpus=all` inference skip, mixed-all plan keeps specific tags, explicit scope_tags survives backfill, 4.8.1 rewash correctness + idempotence, rewash no-op paths.
- [x] 1 new test in `test_plan_match.py` pinning multiplicative formula at the unit layer.
- [x] `MIGRATIONS` count bump 14 -> 15.
- [x] 325/325 plan-subsystem + adjacent suites pass (plan_library, plan_match, plan_run, plan_cache_sentinel, plan_template_schema, migrations, nx_answer, rdr_084_plan_grow, traverse_step, doctor_cmd).
- [ ] Full unit suite (running on main branch background).

## References

- RDR: `docs/rdr/rdr-091-scope-aware-plan-matching.md` (implementation_notes updated with critic follow-up)
- Bead: `nexus-dfok`
- Prior: PRs #229-#234 (RDR-091 Phase 1 + 2a/2b/2c/2d)