### PR TITLE
fix(plans): scope_tags case-insensitive match + upper-hex suffix (nexus-yi7m)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -282,3 +282,4 @@
 {"id":"int-cb8decd6","kind":"field_change","created_at":"2026-04-22T16:03:54.309964Z","actor":"Hellblazer","issue_id":"nexus-svcg","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-9678bfba","kind":"field_change","created_at":"2026-04-22T16:08:14.975195Z","actor":"Hellblazer","issue_id":"nexus-jvma","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-47a006df","kind":"field_change","created_at":"2026-04-22T16:08:28.765075Z","actor":"Hellblazer","issue_id":"nexus-zs1d","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-6f41b03b","kind":"field_change","created_at":"2026-04-22T16:46:17.920318Z","actor":"Hellblazer","issue_id":"nexus-dfok","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/src/nexus/plans/matcher.py
+++ b/src/nexus/plans/matcher.py
@@ -65,14 +65,24 @@ def _scope_fit(plan_scope_tags: str, normalized_scope_pref: str) -> float | None
         either direction (``tag.startswith(scope) or scope.startswith(tag)``)
         → ``1.0`` (bare-family plans serve narrower queries and vice versa)
       * otherwise → ``None`` (conflict; caller filters out)
+
+    Prefix matching is **case-insensitive**. Real collection names in
+    nexus carry mixed case (e.g. ``code__Delos-5af9bfe0`` alongside
+    ``knowledge__delos``), but ChromaDB's naming convention doesn't use
+    case to disambiguate identity. A caller passing the conventional
+    lowercase scope should match plans tagged with the mixed-case form
+    found in the wild (nexus-yi7m). Stored values preserve original case
+    so authoring output (``plan_search``) still shows the real name.
     """
     if not normalized_scope_pref:
         return 0.0
     if not plan_scope_tags:
         return 0.0
+    scope_lower = normalized_scope_pref.lower()
     tags = [t for t in plan_scope_tags.split(",") if t]
     for tag in tags:
-        if tag.startswith(normalized_scope_pref) or normalized_scope_pref.startswith(tag):
+        tag_lower = tag.lower()
+        if tag_lower.startswith(scope_lower) or scope_lower.startswith(tag_lower):
             return 1.0
     return None
 

--- a/src/nexus/plans/scope.py
+++ b/src/nexus/plans/scope.py
@@ -25,7 +25,7 @@ __all__ = [
     "_normalize_scope_string",
 ]
 
-_HASH_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$")
+_HASH_SUFFIX_RE = re.compile(r"-[0-9a-fA-F]{8}$")
 
 # Comma-separated ``scope_tags`` entries; also the keys ``_infer_scope_tags``
 # looks for in retrieval-step args.
@@ -44,12 +44,16 @@ def _normalize_scope_string(scope: str) -> str:
     """Return *scope* in canonical scope-tag form.
 
     Rules (RDR-091 §Proposed Solution → Normalization):
-      * Strip a trailing 8-char lowercase hex suffix (``-deadbeef``).
-        The collection-name convention is exactly 8 hex chars; shorter,
-        longer, or non-hex tails are preserved verbatim.
+      * Strip a trailing 8-char hex suffix in either case
+        (``-deadbeef`` or ``-5AF9BFE0``). Real collection names
+        (``code__Delos-5AF9BFE0``) use mixed case and must normalize
+        to the same family as their lowercase siblings.
       * Strip a trailing ``*`` or ``-*`` glob.
       * Preserve a bare family prefix (``rdr__``) and tumbler addresses
         (``1.16``) unchanged.
+      * Stored case is preserved; only the hex-suffix and glob tails
+        are removed. Case folding for comparison happens at match time
+        in :func:`nexus.plans.matcher._scope_fit`.
       * Empty input is returned unchanged.
     """
     if not scope:

--- a/tests/test_plan_library.py
+++ b/tests/test_plan_library.py
@@ -313,6 +313,18 @@ def test_normalize_scope_string_empty_passthrough() -> None:
     assert _normalize_scope_string("") == ""
 
 
+def test_normalize_scope_string_strips_uppercase_hex_suffix() -> None:
+    """Real collection names carry mixed-case hex (code__Delos-5AF9BFE0).
+    Normalization must strip those just like lowercase variants
+    (nexus-yi7m)."""
+    from nexus.plans.scope import _normalize_scope_string
+
+    assert _normalize_scope_string("code__Delos-5AF9BFE0") == "code__Delos"
+    assert _normalize_scope_string("knowledge__Delos-5af9bfe0") == "knowledge__Delos"
+    # Mixed-case hex also stripped.
+    assert _normalize_scope_string("rdr__arcaneum-2Ad2825C") == "rdr__arcaneum"
+
+
 def test_normalize_scope_string_does_not_strip_short_or_nonhex() -> None:
     """Only 8-char lowercase hex suffixes are stripped; other trailing
     segments survive (collection-name hash convention is strict)."""

--- a/tests/test_plan_match.py
+++ b/tests/test_plan_match.py
@@ -402,6 +402,81 @@ def test_fts5_fallback_applies_scope_conflict_filter(library) -> None:
     assert result == [], "FTS5 path must also filter scope-conflicting plans"
 
 
+def test_scope_fit_case_insensitive_prefix_match(library) -> None:
+    """_scope_fit matches across case on both sides (nexus-yi7m).
+
+    Live probe found a grown plan tagged ``knowledge__Delos`` (capital D,
+    from a real mixed-case collection namespace) that did NOT match a
+    caller scope ``knowledge__delos`` (lowercase, the ChromaDB
+    convention) because startswith is case-sensitive. ChromaDB's naming
+    convention doesn't use case to disambiguate, so the two should be
+    treated as the same keyspace."""
+    from nexus.plans.matcher import plan_match
+
+    # Plan tagged with mixed-case real-collection form.
+    plan_id = _seed(library, query="q",
+                    dimensions={"verb": "research", "variant": "d"},
+                    scope_tags="knowledge__Delos")
+    cache = _FakeCache(hits=[(plan_id, 0.10)])
+    # Caller uses the conventional lowercase form.
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="knowledge__delos",
+    )
+    assert [m.plan_id for m in result] == [plan_id]
+
+
+def test_scope_fit_case_insensitive_reverse_direction(library) -> None:
+    """Reverse: caller mixed-case, plan lowercase; still matches."""
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(library, query="q",
+                    dimensions={"verb": "research", "variant": "dl"},
+                    scope_tags="knowledge__delos")
+    cache = _FakeCache(hits=[(plan_id, 0.10)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="knowledge__Delos",
+    )
+    assert [m.plan_id for m in result] == [plan_id]
+
+
+def test_scope_fit_case_insensitive_bare_family_prefix(library) -> None:
+    """Bare-family prefix matching remains case-insensitive too:
+    caller ``knowledge__`` matches tag ``knowledge__Delos``."""
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(library, query="q",
+                    dimensions={"verb": "research", "variant": "bf"},
+                    scope_tags="knowledge__Delos")
+    cache = _FakeCache(hits=[(plan_id, 0.10)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="KNOWLEDGE__",
+    )
+    assert [m.plan_id for m in result] == [plan_id]
+
+
+def test_scope_fit_preserves_stored_case(library) -> None:
+    """Stored scope_tags value is untouched by case-insensitive compare.
+    The Match object reports the real mixed-case name so plan_search /
+    authoring output shows the actual collection reference."""
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(library, query="q",
+                    dimensions={"verb": "research", "variant": "preserve"},
+                    scope_tags="knowledge__Delos")
+    cache = _FakeCache(hits=[(plan_id, 0.10)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="knowledge__delos",
+    )
+    assert len(result) == 1
+    assert result[0].scope_tags == "knowledge__Delos", (
+        "stored case must be preserved; only comparison is folded"
+    )
+
+
 def test_scope_boost_formula_is_multiplicative_with_unequal_cosines(library) -> None:
     """Formula-pinning regression guard (RDR-091 critic follow-up).
 


### PR DESCRIPTION
## Summary

Live probe of RDR-091 surfaced a silent friction source: real nexus collections carry mixed-case names (e.g. `code__Delos-5af9bfe0` alongside `knowledge__delos`). `_scope_fit` used case-sensitive `startswith`, so a caller passing the conventional lowercase scope did NOT match a plan tagged with the wild-case form, silently falling through to the inline planner.

## Fix

1. `_HASH_SUFFIX_RE` accepts upper-hex too (`r'-[0-9a-fA-F]{8}$'`). Real collection hashes can be upper-cased; normalize to the same family as lowercase siblings.
2. `_scope_fit` folds both sides to lowercase before prefix comparison. Stored `scope_tags` preserve original case so `plan_search` / authoring output continues to show the real collection name. Only the compare is case-folded, not the stored data.

ChromaDB's collection-naming convention doesn't use case to disambiguate identity, so this matches authored intent on both sides.

## Live verification

Before: `scope='knowledge__delos'` returned 0 matches against a 52-plan library (fell through to inline planner).
After: plan 49 (`scope_tags='knowledge__Delos'`) correctly matches.

## Test plan

- [x] `_normalize_scope_string` strips UPPERCASE and mixed-case hex suffixes
- [x] `_scope_fit` matches across case (caller lowercase, tag mixed-case)
- [x] `_scope_fit` matches in reverse direction
- [x] Bare-family prefix is case-insensitive (`KNOWLEDGE__` matches `knowledge__Delos`)
- [x] `Match.scope_tags` preserves stored case despite case-folded compare
- [x] 282/282 plan-subsystem + adjacent suites pass

## References

- Bead: `nexus-yi7m`
- Related: RDR-091 (`docs/rdr/rdr-091-scope-aware-plan-matching.md`), PRs #229-#235
- No migration needed; comparison-layer fix, stored data untouched.