### PR TITLE
fix(mcp): three bug-report-2026-04-22 fixes + scratch get diagnostics (nexus-3o3t)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`catalog_search` rejected `content_type` as a sole filter** (`src/nexus/mcp/catalog.py`). The structured-filter trigger condition (`if owner or corpus or file_path or (author and not query)`) omitted `content_type`, so a sole `content_type` value fell through to the FTS5 path which requires a free-text query. Documented behaviour was wrong for callers asking "show me everything of type prose" without a search term. Added `content_type` to the trigger; pre-existing structured-filter SQL already handled `content_type = ?` correctly. (nexus-3o3t)
+- **`store_list --docs=true` showed `?` for chunk count on every entry** (`src/nexus/mcp/core.py`). Per-doc `chunk_count` was read from chunk metadata, but `store_put` doesn't set that field — only the PDF indexer does. The dedup pass now derives the chunk count per content-hash; the page-count column is omitted entirely when no document carries one (was always `?p` for non-PDF entries). (nexus-3o3t)
+- **`store_get` failed silently when given a title** (`src/nexus/mcp/core.py`). `store_list` displays titles; `store_put`/`search` return hashes; the MCP tool docstring promised hashes but the natural `list → get` copy-paste flow was broken. Now: try the input as a hash first; if not found and it doesn't look like a 16-char hex hash, fall back to `find_ids_by_title()`; on multi-match, list candidate hashes; on miss, error message names both the hash and title paths. Also surfaces the 16-char content-hash in the `--docs=true` listing so a hash is always within copy-paste reach. (nexus-3o3t)
+
+### Changed
+
+- **`T1Database.get` and `_reconnect` emit structured diagnostic logs** (`src/nexus/db/t1.py`). A user-reported `scratch put` → `scratch get` round-trip failure (`Not found` on the freshly-returned UUID) couldn't be reproduced in isolation. Added `t1_get_miss` (with requested_id, session_id, client_type, dead) and `t1_reconnect_to_different_server` (with prior + new session_id and host:port) so the next occurrence carries enough context to diagnose. No behaviour change. (nexus-3o3t)
+
 ## [4.9.6] - 2026-04-22
 
 ### Added

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -193,6 +193,7 @@ class T1Database:
             return
         self._dead = True  # set before any I/O to prevent loops on re-entry
 
+        prior_session_id = self._session_id
         record = find_ancestor_session(SESSIONS_DIR)
         if record is not None:
             self._client = chromadb.HttpClient(
@@ -200,6 +201,13 @@ class T1Database:
                 port=record["server_port"],
             )
             self._session_id = record["session_id"]
+            _log.warning(
+                "t1_reconnect_to_different_server",
+                prior_session_id=prior_session_id,
+                new_session_id=record["session_id"],
+                new_host=record["server_host"],
+                new_port=record["server_port"],
+            )
         else:
             warnings.warn(
                 "T1 reconnect falling back to EphemeralClient — "
@@ -273,6 +281,19 @@ class T1Database:
         """Return the document dict for *id*, or None if not found."""
         result = self._exec(lambda: self._col.get(ids=[id], include=["documents", "metadatas"]))
         if not result["ids"]:
+            # Bug 1 (nexus-bug-report-2026-04-22): users hit Not-found on
+            # ids freshly returned by put(). The path is unreproducible in
+            # isolation; this log captures the state the next time it fires
+            # so the cause can be diagnosed (stale singleton after a silent
+            # _reconnect, dual MCP servers writing to different chroma
+            # collections, etc.).
+            _log.warning(
+                "t1_get_miss",
+                requested_id=id,
+                session_id=self._session_id,
+                client_type=type(self._client).__name__,
+                dead=self._dead,
+            )
             return None
         # Update access tracking (F-3: preserve existing metadata)
         existing = result["metadatas"][0] or {}

--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -57,8 +57,11 @@ def catalog_search(
         from nexus.catalog.tumbler import Tumbler
         import json as _json
 
-        # Structured filters via SQL when provided
-        if owner or corpus or file_path or (author and not query):
+        # Structured filters via SQL when provided. content_type alone (no
+        # query/author/etc.) routes here too — the FTS5 path below requires
+        # a free-text query, but content_type is a perfectly valid sole filter
+        # ("show me everything of type prose") and the docstring promises it.
+        if owner or corpus or file_path or content_type or (author and not query):
             conditions = ["1=1"]
             params: list = []
             if owner:

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -611,12 +611,13 @@ def store_put(
 
 @mcp.tool()
 def store_get(doc_id: str, collection: str = "knowledge") -> str:
-    """Retrieve the full content and metadata of a T3 knowledge entry by document ID.
+    """Retrieve the full content and metadata of a T3 knowledge entry by document ID or title.
 
     Use after store_list or search to read the complete document.
 
     Args:
-        doc_id: Exact document ID (from store_list or store_put output)
+        doc_id: Exact 16-char content-hash document ID (from store_list / store_put / search),
+                OR an exact title (looked up via metadata).
         collection: Collection name or prefix (default: knowledge)
     """
     try:
@@ -626,7 +627,22 @@ def store_get(doc_id: str, collection: str = "knowledge") -> str:
         t3 = _get_t3()
         entry = t3.get_by_id(col_name, doc_id)
         if entry is None:
-            return f"Not found: {doc_id!r} in {col_name}"
+            # Title fallback: 16 lowercase hex chars looks like a hash;
+            # anything else, try treating it as an exact title (matches what
+            # store_list / search display, since hashes aren't surfaced there).
+            looks_like_hash = len(doc_id) == 16 and all(c in "0123456789abcdef" for c in doc_id)
+            if not looks_like_hash:
+                ids = t3.find_ids_by_title(col_name, doc_id)
+                if len(ids) == 1:
+                    entry = t3.get_by_id(col_name, ids[0])
+                elif len(ids) > 1:
+                    return (
+                        f"Multiple documents with title {doc_id!r} in {col_name}: "
+                        + ", ".join(ids[:5]) + (" …" if len(ids) > 5 else "")
+                        + " — pass a 16-char content-hash to disambiguate."
+                    )
+        if entry is None:
+            return f"Not found: {doc_id!r} in {col_name} (pass a 16-char content-hash from store_list/store_put/search, or an exact title)"
         title = entry.get("source_title") or entry.get("title", "")
         tags = entry.get("tags", "")
         indexed_at = (entry.get("indexed_at") or "")[:10]
@@ -787,8 +803,16 @@ def store_list(
 
 
 def _store_list_docs(t3, col_name: str, total: int) -> str:
-    """Document-level view: deduplicate chunks by content_hash."""
+    """Document-level view: deduplicate chunks by content_hash.
+
+    Per-doc chunk count is derived from the dedup pass — entries written by
+    ``store_put`` don't set a ``chunk_count`` metadata field (only the PDF
+    indexer does), so reading it from metadata produced ``?`` for everything.
+    The page-count column is omitted entirely when no document carries it,
+    rather than showing ``?p`` for non-PDF entries.
+    """
     seen: dict[str, dict] = {}
+    chunks_by_hash: dict[str, int] = {}
     offset = 0
     while offset < total:
         entries = t3.list_store(col_name, limit=300, offset=offset)
@@ -798,20 +822,29 @@ def _store_list_docs(t3, col_name: str, total: int) -> str:
             h = e.get("content_hash", e.get("id", ""))
             if h not in seen:
                 seen[h] = e
+            chunks_by_hash[h] = chunks_by_hash.get(h, 0) + 1
         offset += 300
 
     if not seen:
         return f"No documents in {col_name}."
 
-    docs = sorted(seen.values(), key=lambda d: d.get("source_title") or d.get("title") or "")
+    docs = sorted(seen.items(), key=lambda kv: kv[1].get("source_title") or kv[1].get("title") or "")
+    show_pages = any(d.get("page_count") for _, d in docs)
     lines = [f"{col_name}  ({len(docs)} documents, {total} chunks)"]
-    for i, d in enumerate(docs, 1):
-        title = (d.get("source_title") or d.get("title") or "untitled")[:60]
-        chunks = d.get("chunk_count", "?")
-        pages = d.get("page_count", "?")
+    for i, (h, d) in enumerate(docs, 1):
+        # 16-char content-hash prefix surfaces the doc_id store_get expects —
+        # without this column the natural list → get flow had no path from
+        # title to hash.
+        doc_id = (d.get("id") or h)[:16]
+        title = (d.get("source_title") or d.get("title") or "untitled")[:50]
+        chunks = chunks_by_hash.get(h, "?")
         method = d.get("extraction_method", "")
         indexed = (d.get("indexed_at") or "")[:10]
-        lines.append(f"  {i:3d}. {title:<60}  {chunks:>4} chunks  {pages:>3}p  {method:<8}  {indexed}")
+        if show_pages:
+            pages = d.get("page_count", "?")
+            lines.append(f"  {i:3d}. {doc_id}  {title:<50}  {chunks:>4} chunks  {pages:>3}p  {method:<8}  {indexed}")
+        else:
+            lines.append(f"  {i:3d}. {doc_id}  {title:<50}  {chunks:>4} chunks  {method:<8}  {indexed}")
     return "\n".join(lines)
 
 

--- a/tests/test_catalog_mcp.py
+++ b/tests/test_catalog_mcp.py
@@ -105,6 +105,17 @@ def test_search_requires_param(cat) -> None:
     assert "error" in catalog_search()[0]
 
 
+def test_search_by_content_type_alone(cat) -> None:
+    """content_type alone is a valid filter — fixed in 4.9.6 follow-up."""
+    catalog_register(title="alpha", owner="1.1", content_type="prose")
+    catalog_register(title="beta", owner="1.1", content_type="code")
+    catalog_register(title="gamma", owner="1.1", content_type="prose")
+    results = catalog_search(content_type="prose")
+    assert all("error" not in r for r in results)
+    titles = sorted(r["title"] for r in results if "title" in r)
+    assert titles == ["alpha", "gamma"]
+
+
 def test_list_all(cat) -> None:
     catalog_register(title="A", owner="1.1")
     catalog_register(title="B", owner="1.1")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -217,6 +217,32 @@ def test_store_get_no_ansi(t3):
     assert not ANSI_RE.search(result), f"ANSI codes found in: {result[:100]}"
 
 
+def test_store_get_by_title_fallback(t3):
+    """store_get accepts an exact title when the input doesn't look like a
+    16-char content hash — fixed in 4.9.6 follow-up (was silent Not found)."""
+    _put_id("findable by title", title="title-lookup-test")
+    result = store_get(doc_id="title-lookup-test", collection="knowledge")
+    assert not result.startswith("Error:")
+    assert "findable by title" in result
+
+
+def test_store_get_unknown_title_actionable_error(t3):
+    """The Not-found message hints at the hash-vs-title distinction."""
+    result = store_get(doc_id="totally-not-a-real-title", collection="knowledge")
+    assert "not found" in result.lower()
+    assert "content-hash" in result.lower() or "title" in result.lower()
+
+
+def test_store_list_docs_chunk_count_numeric(t3):
+    """--docs=true derives chunk count from the dedup pass; previously
+    showed `?` for every entry because metadata didn't carry chunk_count."""
+    store_put(content="single chunk doc", collection="knowledge", title="docs-count-test")
+    result = store_list(collection="knowledge", docs=True)
+    assert "?" not in result.split("\n")[1] if "\n" in result else True
+    # A 1-chunk doc should report `1 chunks` (or `1 chunk`)
+    assert "1 chunks" in result
+
+
 # ── Memory ───────────────────────────────────────────────────────────────────
 
 def test_memory_put(t2_path):


### PR DESCRIPTION
## Summary

Four findings from `nexus-bug-report-2026-04-22.md` (`nexus-3o3t`).

| # | Pri | Tool | Fix |
|---|-----|------|-----|
| 2 | Med | `catalog_search` | Add `content_type` to the structured-filter trigger (was treated as non-counting, fell through to FTS5 query-required path). |
| 3 | Low | `store_list --docs=true` | Derive chunk count from dedup pass (was reading `chunk_count` from metadata, which `store_put` doesn't set). Drop `?p` page column when no document carries one. |
| 4 | Low UX | `store_get` | Accept exact title as fallback when input isn't 16-char hex; surface 16-char content-hash in `--docs=true` listing; actionable error message. |
| 1 | High (deferred) | `scratch get` | Unreproducible in isolation. Added `t1_get_miss` and `t1_reconnect_to_different_server` structured logs so the next occurrence carries diagnostic evidence. No behaviour change. |

Bug-report observations 5 and 6 are state-specific to the reporter's machine; not actioned.

## Test plan

- [x] `tests/test_catalog_mcp.py::test_search_by_content_type_alone` — Bug 2
- [x] `tests/test_mcp_server.py::test_store_list_docs_chunk_count_numeric` — Bug 3
- [x] `tests/test_mcp_server.py::test_store_get_by_title_fallback` — Bug 4 happy path
- [x] `tests/test_mcp_server.py::test_store_get_unknown_title_actionable_error` — Bug 4 error message
- [x] All 184 affected tests pass (`tests/test_mcp_server.py`, `tests/test_catalog_mcp.py`, `tests/test_t1.py`, `tests/test_scratch_cmd.py`, `tests/test_store_cmd.py`)

bead: nexus-3o3t