### PR TITLE
feat(operators): two-sided operator_compare for cross-corpus DAGs (nexus-km5i)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -284,3 +284,4 @@
 {"id":"int-47a006df","kind":"field_change","created_at":"2026-04-22T16:08:28.765075Z","actor":"Hellblazer","issue_id":"nexus-zs1d","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-6f41b03b","kind":"field_change","created_at":"2026-04-22T16:46:17.920318Z","actor":"Hellblazer","issue_id":"nexus-dfok","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-980ce5d7","kind":"field_change","created_at":"2026-04-22T17:44:20.391777Z","actor":"Hellblazer","issue_id":"nexus-yi7m","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-ca2b874e","kind":"field_change","created_at":"2026-04-22T19:15:55.776291Z","actor":"Hellblazer","issue_id":"nexus-3o3t","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4.9.7] - 2026-04-22
 
+### Added
+
+- **`operator_compare` gains two-sided mode** (`src/nexus/mcp/core.py`). Plans that need to compare extractions from two separate corpora (a cross-corpus DAG like "how does project A frame X vs how does project B frame X") can now pass `items_a` / `items_b` / `label_a` / `label_b` as independent args. The resolver substitutes each `$stepN.<field>` reference at top level, which the previous one-sided `items` arg could not do (the no-inline-interpolation rule means references embedded in a `focus` string stay literal). The two-sided prompt asks for shared axes, divergent decisions, side-only axes, and philosophy difference. One-sided `items` mode preserved unchanged; list / dict values in any of the `items*` args are now JSON-serialized before prompt interpolation so the LLM sees clean JSON instead of Python repr. Live cross-corpus run against Arcaneum + Nexus RDR corpora produced a clean synthesis (shared-axes table, divergent-decisions table, philosophy paragraph) with zero training-data fill-in. (nexus-km5i)
+
 ### Fixed
 
 - **`catalog_search` rejected `content_type` as a sole filter** (`src/nexus/mcp/catalog.py`). The structured-filter trigger condition (`if owner or corpus or file_path or (author and not query)`) omitted `content_type`, so a sole `content_type` value fell through to the FTS5 path which requires a free-text query. Documented behaviour was wrong for callers asking "show me everything of type prose" without a search term. Added `content_type` to the trigger; pre-existing structured-filter SQL already handled `content_type = ?` correctly. (nexus-3o3t)

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1443,21 +1443,81 @@ async def operator_rank(items: str, criterion: str, timeout: float = 300.0) -> d
 
 
 @mcp.tool()
-async def operator_compare(items: str, focus: str = "", timeout: float = 300.0) -> dict:
+async def operator_compare(
+    items: str = "",
+    focus: str = "",
+    timeout: float = 300.0,
+    *,
+    items_a: str = "",
+    items_b: str = "",
+    label_a: str = "A",
+    label_b: str = "B",
+) -> dict:
     """Compare items and return a structured comparison using claude -p.
 
+    Two modes:
+
+    * **One-sided** (original): pass *items* only. The comparison runs
+      across entries within a single set. Keyword-only ``items_a`` /
+      ``items_b`` may be omitted or empty.
+    * **Two-sided** (nexus-km5i): pass *items_a* and *items_b* together
+      for a cross-set compare. The prompt becomes "Compare set {label_a}
+      vs set {label_b}" and asks for shared axes, divergent decisions,
+      and philosophy differences. Useful for cross-corpus DAGs where a
+      plan needs to align extractions from two different collections
+      under one synthesis. ``focus`` scopes both modes.
+
+    List / dict values in ``items`` / ``items_a`` / ``items_b`` are
+    JSON-serialized before prompt interpolation so the LLM sees clean
+    JSON instead of Python ``repr`` output.
+
     Args:
-        items: Items to compare (plain text or JSON array string).
+        items: Items to compare (plain text or JSON array string). Used
+            in one-sided mode; ignored when both ``items_a`` and
+            ``items_b`` are provided.
         focus: Optional aspect to focus the comparison on.
-        timeout: Seconds before the subprocess is killed. Default 300s (5 min) — the claude -p substrate handles multi-step analytical workloads; 120s was hitting false timeouts on real input.
+        timeout: Seconds before the subprocess is killed. Default 300s
+            (5 min). The claude -p substrate handles multi-step
+            analytical workloads; 120s hit false timeouts on real input.
+        items_a: Side A items for two-sided compare.
+        items_b: Side B items for two-sided compare.
+        label_a: Human-readable label for side A (default "A").
+        label_b: Human-readable label for side B (default "B").
     """
+    import json as _json
+
     from nexus.operators.dispatch import claude_dispatch
 
+    def _fmt(v) -> str:
+        if isinstance(v, (list, dict)):
+            return _json.dumps(v, indent=2, default=str)
+        return v if isinstance(v, str) else str(v)
+
     focus_clause = f" Focus on: {focus}." if focus else ""
-    prompt = (
-        f"Compare the following items.{focus_clause}\n\n"
-        f"Items:\n{items}"
-    )
+    if items_a and items_b:
+        a_text = _fmt(items_a)
+        b_text = _fmt(items_b)
+        prompt = (
+            f"Compare two sets of items across corpora.{focus_clause}\n\n"
+            f"Set {label_a}:\n{a_text}\n\n"
+            f"Set {label_b}:\n{b_text}\n\n"
+            "Name:\n"
+            f"  * **Shared axes**: concerns both {label_a} and {label_b} "
+            "address with comparable intent (even if mechanism differs).\n"
+            f"  * **Divergent decisions**: places where {label_a} and {label_b} "
+            "take different approaches on the same question; attribute each "
+            "choice to its side.\n"
+            f"  * **Side-only axes**: concerns that appear in {label_a} or "
+            f"{label_b} but not both.\n"
+            "  * **Philosophy difference**: one or two sentences on the "
+            "underlying stance difference, if one emerges from the evidence."
+        )
+    else:
+        items_text = _fmt(items)
+        prompt = (
+            f"Compare the following items.{focus_clause}\n\n"
+            f"Items:\n{items_text}"
+        )
     schema = {
         "type": "object",
         "required": ["comparison"],

--- a/tests/test_operator_dispatch.py
+++ b/tests/test_operator_dispatch.py
@@ -503,6 +503,93 @@ class TestOperatorCompare:
         result = await operator_compare(items='["A", "B"]')
         assert "comparison" in result
 
+    @pytest.mark.asyncio
+    async def test_one_sided_prompt_uses_items(self, monkeypatch) -> None:
+        """One-sided compare (only items) keeps the original prompt shape."""
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import operator_compare
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout):
+            captured["prompt"] = prompt
+            return {"comparison": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await operator_compare(items='["A", "B"]', focus="hotness")
+        assert "Compare the following items" in captured["prompt"]
+        assert "Focus on: hotness" in captured["prompt"]
+        assert "Items:" in captured["prompt"]
+        # Two-sided markers must NOT appear in one-sided mode.
+        assert "Set A:" not in captured["prompt"]
+        assert "Shared axes" not in captured["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_two_sided_prompt_when_both_items_ab_given(self, monkeypatch) -> None:
+        """items_a + items_b switches to the cross-corpus compare prompt."""
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import operator_compare
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout):
+            captured["prompt"] = prompt
+            return {"comparison": "cross"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await operator_compare(
+            items_a=[{"rdr": "A-001", "decision": "alpha"}],
+            items_b=[{"rdr": "B-001", "decision": "beta"}],
+            label_a="Arcaneum",
+            label_b="Nexus",
+            focus="bulk indexing",
+        )
+        p = captured["prompt"]
+        assert "Compare two sets of items" in p
+        assert "Set Arcaneum:" in p
+        assert "Set Nexus:" in p
+        assert "Shared axes" in p
+        assert "Divergent decisions" in p
+        assert "Philosophy difference" in p
+        assert "Focus on: bulk indexing" in p
+
+    @pytest.mark.asyncio
+    async def test_list_items_json_serialized_in_prompt(self, monkeypatch) -> None:
+        """List args render as clean JSON, not Python repr."""
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import operator_compare
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout):
+            captured["prompt"] = prompt
+            return {"comparison": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        await operator_compare(items=[{"name": "A"}, {"name": "B"}])
+        # JSON double-quotes instead of Python single-quote repr.
+        assert '"name"' in captured["prompt"]
+        assert "'name'" not in captured["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_one_sided_fires_when_items_b_empty(self, monkeypatch) -> None:
+        """Only one of items_a/items_b given falls back to one-sided on items."""
+        import nexus.operators.dispatch as _mod
+        from nexus.mcp.core import operator_compare
+
+        captured = {}
+
+        async def fake(prompt, schema, timeout):
+            captured["prompt"] = prompt
+            return {"comparison": "ok"}
+
+        monkeypatch.setattr(_mod, "claude_dispatch", fake)
+        # items_a provided but items_b empty → degrade to one-sided on items.
+        await operator_compare(items='["fallback"]', items_a="only-a", items_b="")
+        assert "Compare the following items" in captured["prompt"]
+        assert "fallback" in captured["prompt"]
+        assert "Set A:" not in captured["prompt"]
+
 
 class TestOperatorSummarize:
 


### PR DESCRIPTION
## Summary

Post-5 worked-example claim: plans can compose a cross-corpus compare (*"how does project A frame X vs how does project B frame X"*) in a single DAG. Running the live example against the Arcaneum + Nexus RDR corpora surfaced a plumbing gap: `operator_compare` took a single `items` string. Authors who wanted a cross-corpus compare had to reference the second side via `\$step6.extractions` embedded inside the `focus` prompt string, which the resolver does not substitute (no-inline-interpolation rule, documented in `plan-authoring-guide`). Compare then filled the missing side in from training-data knowledge, producing partially-hallucinated output.

## Change

`operator_compare` gains keyword-only `items_a` / `items_b` / `label_a` / `label_b`. When both `items_a` and `items_b` are non-empty, the prompt becomes a two-sided compare asking for:
- **Shared axes**: concerns both sides address (even if mechanism differs)
- **Divergent decisions**: same question, different choice per side (attributed)
- **Side-only axes**: concerns one side has, the other does not
- **Philosophy difference**: one or two sentences

One-sided behaviour with only `items` preserved unchanged. List / dict values in any `items*` arg are now JSON-serialized (`json.dumps indent=2`) before prompt interpolation, so the LLM sees clean JSON instead of Python `repr` output.

## Live verification

Ran a cross-corpus plan against real Arcaneum (1879 chunks) and Nexus (3867 chunks) RDR corpora (`search` → `store_get_many` → `extract` on each, then `compare` with `items_a` / `items_b`). Produced a clean two-sided synthesis with:
- 4 shared axes (throughput, observability, incremental reindex, pagination tuning)
- 5-row divergent-decisions table (reindex auto-detect vs opt-in, HNSW tuning vs quota-bounded, source safety, destructive-op scope, pipeline-version granularity)
- 5 Arcaneum-only + 5 Nexus-only axes
- Philosophy paragraph: *"Arcaneum treats the vector store as a knob-tunable component it owns... Nexus treats it as a metered-quota SaaS it doesn't control and a multi-prefix catalog with user-authored entries mixed in..."*

Zero training-data fill-in. Every claim cited to the two extraction sets.

## Test plan

5 new cases in `TestOperatorCompare`:
- [x] original `returns_comparison_key` preserved (regression)
- [x] one-sided prompt uses `Items:` and `focus` clause
- [x] two-sided prompt emits `Set {label}:` and four section markers
- [x] list / dict `items` JSON-serialize (double quotes, not Python repr)
- [x] degrade to one-sided when `items_b` empty but `items` provided
- [x] 277 plan-subsystem + adjacent tests pass

## Related

- `nexus-sgrg`: plan 51 grown with `author='arcaneum'` catalog filter returning zero. Separate bug, separate bead.