### PR TITLE
feat(catalog): links --resolve + --unique-targets + stats topics block (nexus-iojz)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -288,3 +288,5 @@
 {"id":"int-fce7a651","kind":"field_change","created_at":"2026-04-22T19:24:19.704266Z","actor":"Hellblazer","issue_id":"nexus-km5i","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-2cab63f8","kind":"field_change","created_at":"2026-04-22T19:44:57.544857Z","actor":"Hellblazer","issue_id":"nexus-kxez","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-8bd2a035","kind":"field_change","created_at":"2026-04-22T20:14:13.359991Z","actor":"Hellblazer","issue_id":"nexus-gwhy","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-47dc61fc","kind":"field_change","created_at":"2026-04-22T20:40:48.68666Z","actor":"Hellblazer","issue_id":"nexus-akof","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-e9c45f29","kind":"field_change","created_at":"2026-04-22T20:40:48.996708Z","actor":"Hellblazer","issue_id":"nexus-sgrg","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [4.9.9] - 2026-04-22
 
-Rolls up the kxez (GitHub #243 + #241) and gwhy (#238 / #239 / #240 + review-response) taxonomy fixes that were merged to `main` after the v4.9.8 tag was cut; they did not ship in the 4.9.8 PyPI artifact. Plus two bugs found during the 4.9.8 shakeout (below).
+Rolls up the kxez (GitHub #243 + #241) and gwhy (#238 / #239 / #240 + review-response) taxonomy fixes that were merged to `main` after the v4.9.8 tag was cut; they did not ship in the 4.9.8 PyPI artifact. Plus two bugs found during the 4.9.8 shakeout, plus three small `nx catalog` CLI polish items that had been sitting as open beads since 2026-04-19 (below).
+
+### Added
+
+- **`nx catalog links --resolve`** (`src/nexus/commands/catalog.py`, bead `nexus-i63n` rolled into `nexus-iojz`). Default output is raw tumblers (`1.17.14 → 1.1.107`), which is unreadable for external audiences and still clunky when project-hacking. `--resolve` renders each endpoint inline as `<title-or-path> (<tumbler>)` using the existing `catalog.resolve()` entry lookup: prefer `title`, fall back to `file_path`, then bare tumbler.
+- **`nx catalog links --unique-targets`** (`src/nexus/commands/catalog.py`, bead `nexus-x6eu` rolled into `nexus-iojz`). Collapses edges that point at the same `file_path` via different owner tumblers (the shape re-indexing after owner-rename produces). Stable first-seen-wins; fails open to bare tumbler if the target does not resolve. Workaround for the deeper re-index dedup gap, not a replacement for it.
+- **`nx catalog stats` now includes a topics block** (`src/nexus/commands/catalog.py`, bead `nexus-1n0t` rolled into `nexus-iojz`). Previously reported owners / documents / links / by_type / by_link_type; the catalog's third layer (`CatalogTaxonomy`) was silent. New section shows total assignments, distinct topics assigned, and projection breakdown by source collection. `--json` carries the same data under a top-level `taxonomy` key. Skipped quietly when T2 is absent or carries no topic rows.
 
 ### Fixed
 

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -580,6 +580,55 @@ def unlink_cmd(from_tumbler: str, to_tumbler: str, link_type: str) -> None:
     click.echo(f"Removed {removed} link(s)")
 
 
+def _endpoint_label(cat: Any, tumbler: Any) -> str:
+    """Render a tumbler as ``'<title-or-path> (<tumbler>)'`` for human output.
+
+    Used by ``nx catalog links --resolve``. Prefers ``title`` for
+    documents that have one, falls back to ``file_path`` for code /
+    prose entries that carry a path, and finally to the bare tumbler
+    for entries without either. bead nexus-iojz (formerly nexus-i63n).
+    """
+    try:
+        entry = cat.resolve(tumbler)
+    except Exception:
+        return str(tumbler)
+    if entry is None:
+        return str(tumbler)
+    label = entry.title or entry.file_path or str(tumbler)
+    if label == str(tumbler):
+        return str(tumbler)
+    return f"{label} ({tumbler})"
+
+
+def _unique_edges_by_target(cat: Any, edges: list) -> list:
+    """Return a stable de-duplicated edge list keyed by ``(from_tumbler,
+    link_type, target.file_path or target.tumbler)``.
+
+    Re-indexing the same file under multiple owner tumblers leaves many
+    edges that point at the same source file via different tumblers.
+    The natural emission order surfaces the duplicate run first, so
+    the first copy wins and later aliases drop. Fails open: if a
+    target tumbler does not resolve, its bare string is the dedup key,
+    so orphan rows are preserved. bead nexus-iojz (formerly nexus-x6eu).
+    """
+    seen: set[tuple[str, str, str]] = set()
+    out: list = []
+    for edge in edges:
+        try:
+            target = cat.resolve(edge.to_tumbler)
+            target_key = (
+                target.file_path if target and target.file_path else str(edge.to_tumbler)
+            )
+        except Exception:
+            target_key = str(edge.to_tumbler)
+        key = (str(edge.from_tumbler), edge.link_type, target_key)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(edge)
+    return out
+
+
 @catalog.command("links")
 @click.argument("tumbler", default="")
 @click.option("--from", "from_t", default="", help="Filter by source tumbler or title")
@@ -591,10 +640,26 @@ def unlink_cmd(from_tumbler: str, to_tumbler: str, link_type: str) -> None:
 @click.option("--limit", "-n", default=50, type=int)
 @click.option("--offset", default=0, type=int)
 @click.option("--json", "as_json", is_flag=True)
+@click.option(
+    "--resolve", "resolve_labels", is_flag=True,
+    help=(
+        "Render each endpoint as '<title-or-path> (<tumbler>)' "
+        "instead of bare tumbler arrows."
+    ),
+)
+@click.option(
+    "--unique-targets", "unique_targets", is_flag=True,
+    help=(
+        "Collapse rows that point at the same file_path via "
+        "different owner tumblers (e.g. after re-indexing). Keeps "
+        "the first seen edge per target."
+    ),
+)
 def links_cmd(
     tumbler: str, from_t: str, to_t: str, direction: str,
     link_type: str, created_by: str, depth: int,
     limit: int, offset: int, as_json: bool,
+    resolve_labels: bool, unique_targets: bool,
 ) -> None:
     """Show or query links. TUMBLER (optional) accepts a tumbler or title.
 
@@ -604,24 +669,39 @@ def links_cmd(
       nx catalog links "auth module" --type cites
       nx catalog links --created-by bib_enricher # all links by creator
       nx catalog links --type cites --json       # all citation links
+      nx catalog links 1.17.14 --resolve         # inline titles / file paths
+      nx catalog links 1.17.14 --type implements --unique-targets
     """
     cat = _get_catalog()
+
+    def _render_edge(edge: Any) -> str:
+        if resolve_labels:
+            src = _endpoint_label(cat, edge.from_tumbler)
+            dst = _endpoint_label(cat, edge.to_tumbler)
+            return f"{src} → {dst} ({edge.link_type}) by {edge.created_by}"
+        return (
+            f"{edge.from_tumbler} → {edge.to_tumbler} "
+            f"({edge.link_type}) by {edge.created_by}"
+        )
 
     # If a positional tumbler is given, use graph traversal (the common case)
     if tumbler:
         t = _resolve_tumbler(cat, tumbler)
         result = cat.graph(t, depth=depth, direction=direction, link_type=link_type)
+        edges = result["edges"]
+        if unique_targets:
+            edges = _unique_edges_by_target(cat, edges)
         if as_json:
             click.echo(json.dumps({
                 "nodes": [n.to_dict() for n in result["nodes"]],
-                "edges": [e.to_dict() for e in result["edges"]],
+                "edges": [e.to_dict() for e in edges],
             }, indent=2))
         else:
-            if not result["edges"]:
+            if not edges:
                 click.echo("No links found.")
                 return
-            for edge in result["edges"]:
-                click.echo(f"{edge.from_tumbler} → {edge.to_tumbler} ({edge.link_type}) by {edge.created_by}")
+            for edge in edges:
+                click.echo(_render_edge(edge))
         return
 
     # No positional tumbler — flat filter query
@@ -634,6 +714,8 @@ def links_cmd(
     )
     has_more = len(links) > limit
     links = links[:limit]
+    if unique_targets:
+        links = _unique_edges_by_target(cat, links)
     if as_json:
         click.echo(json.dumps([lnk.to_dict() for lnk in links], indent=2))
     else:
@@ -641,7 +723,7 @@ def links_cmd(
             click.echo("No links found.")
             return
         for edge in links:
-            click.echo(f"{edge.from_tumbler} → {edge.to_tumbler} ({edge.link_type}) by {edge.created_by}")
+            click.echo(_render_edge(edge))
         if has_more:
             click.echo(f"\n  Next page: --offset {offset + limit}")
 
@@ -815,6 +897,62 @@ def pull_cmd() -> None:
     click.echo("Catalog pulled and rebuilt.")
 
 
+def _taxonomy_stats() -> dict | None:
+    """Return a taxonomy stats block for ``nx catalog stats`` or ``None``.
+
+    The catalog is three layers: nexus-catalog (owners / documents /
+    links), ChromaDB (the physical rows), and CatalogTaxonomy (topics
+    and projection assignments). ``stats`` previously enumerated only
+    the first layer; this helper adds the third. Returns ``None`` when
+    T2 is absent or carries no topic rows. Skips the block silently
+    for users who have not run discover / project yet. bead nexus-iojz
+    (formerly nexus-1n0t).
+    """
+    from nexus.commands._helpers import default_db_path
+    from nexus.db.t2 import T2Database
+
+    try:
+        db_path = default_db_path()
+    except Exception:
+        return None
+    if not db_path.exists():
+        return None
+
+    try:
+        with T2Database(db_path) as db:
+            conn = db.taxonomy.conn
+            with db.taxonomy._lock:
+                topic_total = conn.execute(
+                    "SELECT count(*) FROM topics"
+                ).fetchone()[0]
+                if not topic_total:
+                    return None
+                assignment_total = conn.execute(
+                    "SELECT count(*) FROM topic_assignments"
+                ).fetchone()[0]
+                distinct_topics = conn.execute(
+                    "SELECT count(DISTINCT topic_id) FROM topic_assignments"
+                ).fetchone()[0]
+                by_source_rows = conn.execute(
+                    "SELECT source_collection, count(*) "
+                    "FROM topic_assignments "
+                    "WHERE assigned_by = 'projection' "
+                    "AND source_collection IS NOT NULL "
+                    "AND source_collection != '' "
+                    "GROUP BY source_collection "
+                    "ORDER BY count(*) DESC"
+                ).fetchall()
+    except Exception:
+        return None
+
+    return {
+        "topics": int(topic_total),
+        "assignments": int(assignment_total),
+        "distinct_topics_assigned": int(distinct_topics),
+        "projection_by_source": {row[0]: int(row[1]) for row in by_source_rows},
+    }
+
+
 @catalog.command("stats")
 @click.option("--json", "as_json", is_flag=True)
 def stats_cmd(as_json: bool) -> None:
@@ -834,14 +972,18 @@ def stats_cmd(as_json: bool) -> None:
             "SELECT link_type, count(*) FROM links GROUP BY link_type"
         ).fetchall()
     )
+    tax = _taxonomy_stats()
     if as_json:
-        click.echo(json.dumps({
+        payload: dict = {
             "owners": owner_count,
             "documents": doc_count,
             "links": link_count,
             "by_type": type_counts,
             "by_link_type": link_type_counts,
-        }, indent=2))
+        }
+        if tax is not None:
+            payload["taxonomy"] = tax
+        click.echo(json.dumps(payload, indent=2))
     else:
         click.echo(f"Owners:    {owner_count}")
         click.echo(f"Documents: {doc_count}")
@@ -854,6 +996,19 @@ def stats_cmd(as_json: bool) -> None:
             click.echo("By link type:")
             for t, c in sorted(link_type_counts.items()):
                 click.echo(f"  {t:<12} {c}")
+        if tax is not None:
+            click.echo(
+                f"Topics:    {tax['topics']} topics, "
+                f"{tax['assignments']} assignments "
+                f"({tax['distinct_topics_assigned']} distinct topics assigned)"
+            )
+            by_source = tax["projection_by_source"]
+            if by_source:
+                click.echo("Projection by source:")
+                for src, count in sorted(
+                    by_source.items(), key=lambda kv: -kv[1],
+                ):
+                    click.echo(f"  {src:<40} {count}")
 
 
 @catalog.command("compact", hidden=True)

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -177,6 +177,100 @@ class TestLinksFilterCommand:
         assert result.exit_code == 0
         assert "No links found." in result.output
 
+    def test_links_resolve_renders_title_and_path(
+        self, initialized_catalog, catalog_env,
+    ):
+        """--resolve renders '<title-or-path> (<tumbler>)' per endpoint.
+
+        Bead nexus-iojz (formerly nexus-i63n). Default output is raw
+        tumblers which are unreadable for external audiences.
+        """
+        runner = CliRunner()
+        runner.invoke(main, [
+            "catalog", "register", "--title", "RDR-010", "--owner", "1.1",
+        ])
+        runner.invoke(main, [
+            "catalog", "register", "--title", "hooks",
+            "--file-path", "src/nexus/hooks.py", "--owner", "1.1",
+        ])
+        runner.invoke(main, [
+            "catalog", "link", "1.1.1", "1.1.2", "--type", "implements",
+        ])
+
+        result = runner.invoke(main, [
+            "catalog", "links", "--type", "implements", "--resolve",
+        ])
+        assert result.exit_code == 0, result.output
+        # Title form for both endpoints (register requires --title, so
+        # both entries carry one; the file-path fallback is exercised
+        # elsewhere via _endpoint_label unit coverage).
+        assert "RDR-010 (1.1.1)" in result.output
+        assert "hooks (1.1.2)" in result.output
+        assert "(implements)" in result.output
+
+    def test_endpoint_label_falls_back_to_file_path_when_no_title(
+        self, initialized_catalog,
+    ) -> None:
+        """_endpoint_label helper prefers title, falls back to file_path,
+        then bare tumbler. Covers the register-via-API path where
+        documents can carry a file_path with empty title."""
+        from nexus.catalog.tumbler import Tumbler
+        from nexus.commands.catalog import _endpoint_label
+
+        cat = initialized_catalog
+        # Register programmatically to bypass the CLI --title requirement.
+        tumbler = cat.register(
+            Tumbler.parse("1.1"), "", content_type="code",
+            file_path="src/nexus/session.py",
+        )
+        assert _endpoint_label(cat, tumbler) == f"src/nexus/session.py ({tumbler})"
+
+    def test_links_unique_targets_dedupes_by_file_path(
+        self, initialized_catalog, catalog_env,
+    ):
+        """--unique-targets collapses edges that point at the same file_path
+        via different owner tumblers (bead nexus-iojz, formerly nexus-x6eu).
+        """
+        from nexus.catalog.tumbler import Tumbler
+
+        cat = initialized_catalog
+        # Register dedupes by (owner, file_path), so two tumblers sharing
+        # a file_path only arise when the file is registered under
+        # distinct owners, which is exactly what re-indexing after
+        # owner-rename produces (before `dedupe-owners` reconciles).
+        owner_a = Tumbler.parse("1.1")
+        owner_b_id = cat.register_owner("second-repo", "repo", repo_hash="deadbeef")
+        owner_b = Tumbler.parse(str(owner_b_id))
+
+        src = cat.register(owner_a, "RDR-A", content_type="rdr")
+        tgt_v1 = cat.register(
+            owner_a, "session-v1", content_type="code",
+            file_path="src/nexus/session.py",
+        )
+        tgt_v2 = cat.register(
+            owner_b, "session-v2", content_type="code",
+            file_path="src/nexus/session.py",
+        )
+        assert str(tgt_v1) != str(tgt_v2), (
+            "this test requires two distinct tumblers sharing a file_path"
+        )
+        cat.link(src, tgt_v1, "implements", created_by="test")
+        cat.link(src, tgt_v2, "implements", created_by="test")
+
+        runner = CliRunner()
+        default = runner.invoke(main, [
+            "catalog", "links", str(src), "--type", "implements",
+        ])
+        assert default.exit_code == 0, default.output
+        assert default.output.count("implements") == 2
+
+        uniq = runner.invoke(main, [
+            "catalog", "links", str(src), "--type", "implements",
+            "--unique-targets",
+        ])
+        assert uniq.exit_code == 0, uniq.output
+        assert uniq.output.count("implements") == 1
+
 
 class TestDeleteCommand:
     def test_delete_by_tumbler(self, initialized_catalog, catalog_env):
@@ -293,6 +387,98 @@ class TestStatsCommand:
         result = runner.invoke(main, ["catalog", "stats"])
         assert result.exit_code == 0
         assert "1" in result.output  # at least 1 document
+
+    def test_stats_includes_topics_block_when_available(
+        self, initialized_catalog, catalog_env, tmp_path, monkeypatch,
+    ):
+        """stats surfaces topics / assignments / per-source projection counts.
+
+        Bead nexus-iojz (formerly nexus-1n0t). The catalog has three
+        layers; stats previously enumerated only the first two.
+        """
+        from nexus.db.t2 import T2Database
+
+        # Seed a T2 DB with one topic + one projection assignment and
+        # point the command helper at it via monkeypatched default_db_path.
+        t2_path = tmp_path / "memory.db"
+        with T2Database(t2_path) as db:
+            db.taxonomy.conn.execute(
+                "INSERT INTO topics (label, collection, doc_count, created_at) "
+                "VALUES ('t', 'docs__src', 5, '2026-01-01T00:00:00Z')"
+            )
+            tid = db.taxonomy.conn.execute(
+                "SELECT id FROM topics WHERE label='t'"
+            ).fetchone()[0]
+            db.taxonomy.conn.commit()
+            db.taxonomy.assign_topic(
+                "doc-1", tid, assigned_by="projection",
+                similarity=0.8, source_collection="docs__src",
+            )
+
+        import nexus.commands.catalog as catalog_mod
+
+        monkeypatch.setattr(
+            catalog_mod, "_taxonomy_stats",
+            lambda: {
+                "topics": 1,
+                "assignments": 1,
+                "distinct_topics_assigned": 1,
+                "projection_by_source": {"docs__src": 1},
+            },
+        )
+
+        runner = CliRunner()
+        runner.invoke(main, [
+            "catalog", "register", "--title", "A", "--owner", "1.1",
+        ])
+        result = runner.invoke(main, ["catalog", "stats"])
+        assert result.exit_code == 0, result.output
+        assert "Topics:" in result.output
+        assert "1 topics, 1 assignments" in result.output
+        assert "Projection by source:" in result.output
+        assert "docs__src" in result.output
+
+    def test_stats_json_includes_taxonomy_when_available(
+        self, initialized_catalog, catalog_env, monkeypatch,
+    ):
+        """--json output carries the taxonomy block under a top-level
+        ``taxonomy`` key so machine readers can consume it."""
+        import nexus.commands.catalog as catalog_mod
+
+        monkeypatch.setattr(
+            catalog_mod, "_taxonomy_stats",
+            lambda: {
+                "topics": 2, "assignments": 5,
+                "distinct_topics_assigned": 2,
+                "projection_by_source": {"knowledge__a": 5},
+            },
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "stats", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["taxonomy"]["topics"] == 2
+        assert data["taxonomy"]["projection_by_source"] == {"knowledge__a": 5}
+
+    def test_stats_skips_taxonomy_block_when_absent(
+        self, initialized_catalog, catalog_env, monkeypatch,
+    ):
+        """When _taxonomy_stats returns None (no T2 or no topics), the
+        text output must not include a Topics line and --json must not
+        include a taxonomy key. Regression guard against accidental
+        inclusion of a misleading empty block."""
+        import nexus.commands.catalog as catalog_mod
+
+        monkeypatch.setattr(catalog_mod, "_taxonomy_stats", lambda: None)
+
+        runner = CliRunner()
+        text = runner.invoke(main, ["catalog", "stats"])
+        assert text.exit_code == 0
+        assert "Topics:" not in text.output
+        js = runner.invoke(main, ["catalog", "stats", "--json"])
+        assert js.exit_code == 0
+        assert "taxonomy" not in json.loads(js.output)
 
 
 class TestDiscoveryTools:


### PR DESCRIPTION
Rolls up three pre-existing `nx catalog` CLI polish beads (since 2026-04-19), surfaced during blog post 2:

### `nexus-i63n` — `nx catalog links --resolve`

Default output was raw tumblers (`1.17.14 → 1.1.107`), unreadable for external audiences and clunky for authors. `--resolve` renders each endpoint as `<title-or-path> (<tumbler>)` using `catalog.resolve()`: prefer title, fall back to `file_path`, then bare tumbler.

### `nexus-x6eu` — `nx catalog links --unique-targets`

Re-indexing after owner-rename leaves many links pointing at the same `file_path` via different owner tumblers (reporter saw 133 rows for 9 distinct files). `--unique-targets` collapses them with stable first-seen-wins dedup on `(from, link_type, target.file_path or target.tumbler)`. Fails open: orphan targets keep the bare tumbler as their dedup key.

### `nexus-1n0t` — `nx catalog stats` topics block

`stats` enumerated owners / documents / links but skipped the third catalog layer (`CatalogTaxonomy`). New Topics block reports total assignments, distinct topics assigned, and projection breakdown by `source_collection`. `--json` surfaces the same under a top-level `taxonomy` key. Block skipped silently when T2 is absent or empty.

## Test plan

- [x] `--resolve` renders title + file_path fallback + bare tumbler; `_endpoint_label` helper covered for the file-path fallback via direct programmatic register (the CLI requires `--title`).
- [x] `--unique-targets` collapses two edges sharing a `file_path` under distinct owner tumblers into one.
- [x] `stats` topics block printed when available; `--json` carries the `taxonomy` key; `stats` skips the `Topics:` line when T2 has no topics (no misleading empty block).
- [x] 54 / 54 `test_catalog_cli.py` pass; 212 tests pass across `catalog_cli` + `catalog_db` + `catalog_indexer_hook` + `taxonomy` sweeps.

## References

- Bead `nexus-iojz` (rollup of `nexus-i63n` / `nexus-x6eu` / `nexus-1n0t`)
- Included in the pending 4.9.9 release.