### PR TITLE
fix(doctor): --check-taxonomy excludes isolated projection topics (nexus-346q)

### DIFF
--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -677,14 +677,30 @@ def _run_check_taxonomy() -> None:
         return
 
     # Topics that have projection assignments but no row in topic_links
-    # (neither as source nor target) are drift — the materialized view
-    # is out of sync with the assignment table.
+    # (neither as source nor target) are drift — but only when a
+    # topic_links pair is structurally possible. A doc_id with exactly
+    # one projection assignment cannot produce a link (a link requires
+    # from + to), so flagging it as drift is a false positive. Same
+    # logic if the co-occurring topic was assigned via a non-projection
+    # path (centroid, bertopic) — refresh_projection_links only
+    # aggregates ``assigned_by='projection'`` rows, so a centroid
+    # partner does not contribute to topic_links. nexus-346q: require
+    # a co-occurring projection assignment on the same doc before
+    # flagging drift. Shakeout on live data: 15 of 20 residual drift
+    # rows after a backfill were isolated topics that could never
+    # produce a link.
     drift_rows = conn.execute(
         """
         SELECT DISTINCT ta.topic_id, t.label, t.collection
           FROM topic_assignments ta
           LEFT JOIN topics t ON t.id = ta.topic_id
          WHERE ta.assigned_by = 'projection'
+           AND EXISTS (
+               SELECT 1 FROM topic_assignments ta2
+                WHERE ta2.doc_id      = ta.doc_id
+                  AND ta2.topic_id    != ta.topic_id
+                  AND ta2.assigned_by = 'projection'
+           )
            AND NOT EXISTS (
                SELECT 1 FROM topic_links tl
                 WHERE tl.from_topic_id = ta.topic_id

--- a/tests/test_phase5_integration.py
+++ b/tests/test_phase5_integration.py
@@ -355,7 +355,9 @@ class TestDoctorCheckTaxonomy:
         assert "invariant holds" in result.output
 
     def test_drift_detected(self, runner: CliRunner, tmp_path: Path) -> None:
-        """Projection assignments without a matching topic_links row → exit 1."""
+        """Projection assignments with co-occurring projection partner but no
+        topic_links row → exit 1. nexus-346q: drift detection requires the
+        co-occurring partner since a link is structurally impossible without one."""
         db_path = self._setup_db(tmp_path)
         conn = sqlite3.connect(str(db_path))
         conn.execute(
@@ -364,9 +366,21 @@ class TestDoctorCheckTaxonomy:
             (42, "orphan-topic", "docs__test", 0, "2026-01-01T00:00:00Z"),
         )
         conn.execute(
+            "INSERT INTO topics (id, label, collection, doc_count, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (43, "partner-topic", "docs__other", 0, "2026-01-01T00:00:00Z"),
+        )
+        # Two projection assignments on the same doc — a topic_links pair is
+        # structurally possible here, so the absence of topic_links is real drift.
+        conn.execute(
             "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by) "
             "VALUES (?, ?, ?)",
             ("doc-xyz", 42, "projection"),
+        )
+        conn.execute(
+            "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by) "
+            "VALUES (?, ?, ?)",
+            ("doc-xyz", 43, "projection"),
         )
         conn.commit()
         conn.close()
@@ -378,6 +392,77 @@ class TestDoctorCheckTaxonomy:
         assert "topic_links drift" in result.output
         assert "orphan-topic" in result.output
         assert "nx taxonomy project" in result.output
+
+    def test_isolated_projection_topic_not_flagged(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """nexus-346q: a topic whose doc has exactly ONE projection assignment
+        cannot structurally produce a topic_links row (a link needs from + to).
+        The check must not flag these as drift — the 4.9.10 shakeout found 15
+        such false positives out of 20 residual after a backfill.
+        """
+        db_path = self._setup_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO topics (id, label, collection, doc_count, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (99, "solitary-topic", "docs__alone", 0, "2026-01-01T00:00:00Z"),
+        )
+        # Only ONE projection assignment for doc-solo — no pair possible.
+        conn.execute(
+            "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by) "
+            "VALUES (?, ?, ?)",
+            ("doc-solo", 99, "projection"),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch("nexus.commands._helpers.default_db_path", return_value=db_path):
+            result = runner.invoke(main, ["doctor", "--check-taxonomy"])
+
+        assert result.exit_code == 0, result.output
+        assert "invariant holds" in result.output
+        assert "solitary-topic" not in result.output
+
+    def test_co_occurring_must_also_be_projection(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """nexus-346q: a projection assignment whose only co-occurring topic
+        was assigned via a non-projection path (centroid, bertopic) is still
+        structurally isolated from the projection perspective — no projection
+        pair means no aggregated topic_links row. Must not flag as drift.
+        """
+        db_path = self._setup_db(tmp_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO topics (id, label, collection, doc_count, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (100, "projection-side", "docs__x", 0, "2026-01-01T00:00:00Z"),
+        )
+        conn.execute(
+            "INSERT INTO topics (id, label, collection, doc_count, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (101, "centroid-side", "docs__y", 0, "2026-01-01T00:00:00Z"),
+        )
+        conn.execute(
+            "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by) "
+            "VALUES (?, ?, ?)",
+            ("doc-mix", 100, "projection"),
+        )
+        conn.execute(
+            "INSERT INTO topic_assignments (doc_id, topic_id, assigned_by) "
+            "VALUES (?, ?, ?)",
+            ("doc-mix", 101, "centroid"),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch("nexus.commands._helpers.default_db_path", return_value=db_path):
+            result = runner.invoke(main, ["doctor", "--check-taxonomy"])
+
+        assert result.exit_code == 0, result.output
+        assert "invariant holds" in result.output
+        assert "projection-side" not in result.output
 
     def test_invariant_holds_with_matching_link(
         self, runner: CliRunner, tmp_path: Path


### PR DESCRIPTION
Follow-up to PR #254. The `--check-taxonomy` drift SQL shipped in v4.9.10 has a false-positive class that the day-1 shakeout surfaced: a doc_id with exactly one projection assignment cannot produce a `topic_links` row (a link needs `from` + `to`), yet the check flagged every such topic as drift.

## Evidence from the shakeout

Live re-check after running `nx taxonomy project --backfill --persist` over 243k projection assignments across 91 collections:

```
20 drift rows reported
 15 structurally impossible (isolated topics) ← THIS PR drops these
  9 below _PROJECTION_THRESHOLD in refresh_projection_links
```

## The fix

Add the co-occurring EXISTS clause before the `NOT EXISTS (topic_links)` clause:

```sql
AND EXISTS (
    SELECT 1 FROM topic_assignments ta2
     WHERE ta2.doc_id      = ta.doc_id
       AND ta2.topic_id    != ta.topic_id
       AND ta2.assigned_by = 'projection'
)
```

Same logic catches a secondary false-positive class: when the co-occurring topic was assigned via a non-projection path (centroid, bertopic), `refresh_projection_links` only aggregates `assigned_by='projection'` rows, so a centroid partner does not contribute to `topic_links`.

## Live verification

Same corpus, before and after:

```
Before: ✗ topic_links drift: 20/1533 topic(s)
After:  ✗ topic_links drift:  9/1533 topic(s)
```

55% reduction. The residual 9 are the `_PROJECTION_THRESHOLD` class — a separate design question (should the check know about the threshold?) that I'm not bundling here.

## Tests

- `test_drift_detected` updated — now seeds two projection assignments on the same doc so a pair is structurally possible (the prior single-assignment seed matched the false-positive shape we're now eliminating).
- `test_isolated_projection_topic_not_flagged` (new) — one projection assignment on a doc → no pair possible → invariant holds.
- `test_co_occurring_must_also_be_projection` (new) — projection + centroid co-occurring on the same doc → still isolated from the projection side → invariant holds.

Full suite on affected modules: 237 passed.

## Closes

Closes nexus-346q