### PR TITLE
chore: 4.9.11 — shift RDR gap enforcement from close to gate (nexus-4qpb)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.9.10"
+      "version": "4.9.11"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.9.10"
+      "version": "4.9.11"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.9.11] - 2026-04-23
+
+Plugin-side hardening. Shifts the `#### Gap N:` structural requirement in RDR Problem Statements from `/nx:rdr-close` (detected at close time) to `/nx:rdr-gate` (detected at gate time, before accept) so authors meet the rule before it bites. Closes the surprise-at-close pattern that bit RDR-091 on 2026-04-22: the RDR accepted cleanly without gap headings, then failed the close preamble, and the gap structure had to be retrofitted after the fact.
+
+### Added
+
+- **`/nx:rdr-gate` Layer 1 gap-structure check** (`nx/commands/rdr-gate.md`, `nx/skills/rdr-gate/SKILL.md`, `nexus-4qpb`). For RDRs with `id >= 65`, the preamble now validates the `## Problem Statement` section contains at least one `#### Gap N: <title>` heading. Missing headings emit a BLOCKED outcome with the same error and regex the close skill uses; the assistant stops at Layer 1 without running the assumption audit or AI critique. Legacy RDRs (`id < 65`) are grandfathered. `--skip-gaps` bypasses the check for rare RDRs where the structure does not fit; the override is recorded in the gate audit trail.
+
+### Changed
+
+- **`/nx:rdr-create` template and SKILL both reinforce the gap convention** (`nx/resources/rdr/TEMPLATE.md`, `nx/skills/rdr-create/SKILL.md`). Template comment now explicitly names both gate enforcement points (`/nx:rdr-gate` and `/nx:rdr-close`) so authors see "missing gaps will block the gate" at drafting time, not just at close. The Gap 1 + Gap 2 placeholders remain in place.
+
+### Fixed
+
+- **RDR-091 retrofitted with the gap heading it was drafted without** (`docs/rdr/rdr-091-scope-aware-plan-matching.md`). The RDR was drafted and accepted before gate-time enforcement landed, so the close skill flagged the missing structure after all the Phase 2a–2d work had already shipped. Added `#### Gap 1: plan_match silently drops scope_preference, so specialized plans lose to generic ones on scoped questions` to the Problem Statement and flipped frontmatter `status: accepted` → `status: closed` with `closed_pointers: Gap1=src/nexus/plans/matcher.py:77` for audit trail.
+
 ## [4.9.10] - 2026-04-23
 
 Post-4.9.9 hardening — five GitHub issues filed on 2026-04-23 from the 4.9.9 shakeout (#249–#253), all observability or UX fixes to the boundaries between the catalog, taxonomy, and storage tiers. No user-facing behaviour changes on the `store_put` / `taxonomy-assign` / `split` paths; they just leave evidence now when something goes sideways. Rolls up as PR #254.

--- a/docs/rdr/rdr-091-scope-aware-plan-matching.md
+++ b/docs/rdr/rdr-091-scope-aware-plan-matching.md
@@ -2,12 +2,15 @@
 title: "RDR-091: Scope-Aware Plan Matching (nexus-zs1d Phase 2)"
 id: RDR-091
 type: Feature
-status: accepted
+status: closed
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-22
 accepted_date: 2026-04-22
+closed_date: 2026-04-23
+closed_reason: implemented
+closed_pointers: "Gap1=src/nexus/plans/matcher.py:77"
 related_issues:
   - "nexus-zs1d: Wire nx_answer scope through plan_match + plan_run"
 related_tests: [test_plan_match.py, test_plan_library.py, test_nx_answer.py]
@@ -18,6 +21,8 @@ implementation_notes: "scope_fit_weight=0.15 picked Phase 2c (nexus-svcg): motiv
 # RDR-091: Scope-Aware Plan Matching (nexus-zs1d Phase 2)
 
 ## Problem Statement
+
+#### Gap 1: plan_match silently drops `scope_preference`, so specialized plans lose to generic ones on scoped questions
 
 `plan_match` today selects plans purely on question similarity. The
 `scope_preference` parameter is accepted and documented but unused

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.9.10",
+  "version": "4.9.11",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.9.11] - 2026-04-23
+
+Adds a Layer 1 gap-structure pre-check to `/nx:rdr-gate` so the `#### Gap N: <title>` requirement in Problem Statements is caught at gate time, not at close. Same regex and post-65 grandfathering the close skill already uses. `--skip-gaps` is the audit-trail override. Template and `rdr-create` SKILL both name both enforcement points so authors see "gate will block" during drafting. See root `CHANGELOG.md` for the RDR-091 retrofit that motivated the fix.
+
 ## [4.9.10] - 2026-04-23
 
 Plugin version aligned with Nexus CLI 4.9.10. No plugin-level functional changes. See root `CHANGELOG.md` for the post-4.9.9 hardening arc (GitHub #249 / #250 / #251 / #252 / #253) shipped in this release — `nx catalog verify`, the `hook_failures` observability table, `nx doctor --check-taxonomy`, the `split → label` next-step hint, and the catalog-store-hook log fix.

--- a/nx/commands/rdr-gate.md
+++ b/nx/commands/rdr-gate.md
@@ -143,6 +143,50 @@ print()
 def strip_code_blocks(src):
     return re.sub(r'```.*?```', '', src, flags=re.DOTALL)
 
+
+# Gap-structure pre-check (nexus-4qpb): the close skill enforces
+# `#### Gap N: <title>` headings in Problem Statement for post-65 RDRs.
+# Enforcing it only at close meant authors could gate, accept, and
+# then discover the rule at the worst possible time. Shift left: block
+# the gate here so missing gaps can't survive to close. Matches the
+# close skill's regex and grandfathering threshold (id < 65).
+_skip_gaps = '--skip-gaps' in args
+_problem_idx = text.find('## Problem Statement')
+if _problem_idx == -1:
+    _problem_idx = text.find('## Problem')
+_problem_section = ''
+if _problem_idx != -1:
+    _rest = text[_problem_idx:]
+    _nxt = re.search(r'\n## ', _rest[1:])
+    _problem_section = _rest[:_nxt.start() + 1] if _nxt else _rest
+_gap_headings = re.findall(r'^#{3,5} Gap (\d+)([^\n:]*):\s*(.*)$', _problem_section, re.MULTILINE)
+try:
+    _rdr_id_int = int(t2_key)
+except ValueError:
+    _rdr_id_int = -1
+
+if _rdr_id_int >= 65 and len(_gap_headings) == 0 and not _skip_gaps:
+    print(f"> **BLOCKED** (Layer 1 — gap structure): RDR-{t2_key} has no `#### Gap N: <title>` "
+          f"headings in `## Problem Statement` or `## Problem`.")
+    print(r"> Expected format: `#### Gap 1: <gap title>` (regex: `^#{3,5} Gap \d+:`).")
+    print(">")
+    print("> The close skill enforces the same structure and will block `/nx:rdr-close "
+          "--reason implemented`. Add the headings now before accept, or re-run the gate "
+          "with `--skip-gaps` to record an intentional override in the audit trail.")
+    sys.exit(0)
+elif _rdr_id_int >= 65 and len(_gap_headings) > 0:
+    print(f"#### Gap structure: {len(_gap_headings)} gap heading(s) present")
+    print()
+    for _num, _qual, _title in _gap_headings:
+        _qual_str = _qual.strip()
+        _qual_disp = f" {_qual_str}" if _qual_str else ""
+        print(f"- Gap{_num}{_qual_disp}: {_title.strip()}")
+    print()
+elif _rdr_id_int < 65 and len(_gap_headings) == 0:
+    print(f"> **Note**: RDR-{t2_key} predates the gap-structure convention (id < 65) — "
+          "skipping the Layer 1 gap check.")
+    print()
+
 clean = strip_code_blocks(text)
 
 # Section headings (structural completeness check — Layer 1)

--- a/nx/resources/rdr/TEMPLATE.md
+++ b/nx/resources/rdr/TEMPLATE.md
@@ -23,7 +23,7 @@ Refine as research deepens understanding.]
 
 ### Enumerated gaps to close
 
-*The close skill greps for `^#### Gap \d+:` headings in this section. Use exactly this format — one heading per gap.*
+*`/nx:rdr-gate` (Layer 1) and `/nx:rdr-close` (for `--reason implemented`) enforce this structure for post-65 RDRs. Missing or malformed headings will block the gate — not just the close. Use exactly the `#### Gap N: <title>` format (regex `^#{3,5} Gap \d+:`). One heading per distinct gap. Replacing the Problem Statement with free-form prose will fail the gate; prefer adding real gap headings, or override with `/nx:rdr-gate <id> --skip-gaps` only when the structure truly does not fit.*
 
 #### Gap 1: <gap title>
 

--- a/nx/skills/rdr-create/SKILL.md
+++ b/nx/skills/rdr-create/SKILL.md
@@ -53,7 +53,7 @@ If `$RDR_DIR` does not exist:
 
 If `$CLAUDE_PLUGIN_ROOT` is not available, use the templates inline (they are embedded below in the Templates section).
 
-> **Gap convention**: the Problem / Problem Statement section must use `#### Gap N: <title>` headings (regex: `^#{3,5} Gap \d+:`). The close skill uses this format to enumerate gaps and require per-gap closure pointers when `--reason implemented` is passed. Authors must fill in concrete gap headings before the RDR is accepted. Both `## Problem` and `## Problem Statement` are accepted as the section heading.
+> **Gap convention** (enforced at `/nx:rdr-gate` Layer 1 and `/nx:rdr-close` for post-65 RDRs): the `## Problem Statement` (or `## Problem`) section must contain one or more `#### Gap N: <title>` headings (regex: `^#{3,5} Gap \d+:`). Fill these in during drafting — the template scaffolds `Gap 1` and `Gap 2` placeholders. Replacing the Problem Statement with free-form prose and removing the gap headings will fail the gate at accept time, not just at close time. Authors can override with `/nx:rdr-gate <id> --skip-gaps` when the gap structure truly does not fit (audit-trail escape only; prefer adding real gap headings).
 
 ### Step 2: Assign ID
 

--- a/nx/skills/rdr-gate/SKILL.md
+++ b/nx/skills/rdr-gate/SKILL.md
@@ -41,6 +41,8 @@ Read the RDR markdown file. Check that these sections are present AND non-empty 
 
 **Heading matching**: RDRs use varied heading names. Match any of the variants listed above (separated by `/`). If none of the variants match, report the section as missing — do NOT silently skip it.
 
+**Gap-structure sub-check (post-65 RDRs only)**: the `## Problem Statement` (or `## Problem`) section must contain one or more `#### Gap N: <title>` headings (regex `^#{3,5} Gap \d+:`). The command preamble script emits a BLOCKED outcome automatically when this check fails — the gate skill should not attempt to run Layers 2 or 3 after that block. Legacy RDRs with `id < 65` are grandfathered and skip the gap check. Use `/nx:rdr-gate <id> --skip-gaps` to override for the rare RDR where the structure does not fit; the override is recorded in the gate audit trail.
+
 **If any section is missing or contains only placeholder text** (e.g., `[What is the specific challenge]`):
 - Report which sections are incomplete
 - STOP — do not proceed to Layer 2 or 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.9.10"
+version = "4.9.11"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.9.10",
+  "version": "4.9.11",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.9.10"
+version = "4.9.11"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
Closes the surprise-at-close pattern that bit RDR-091 on 2026-04-22. The `#### Gap N:` requirement shipped with RDR-065 was only enforced at `/nx:rdr-close`, so authors could draft, gate, and accept an RDR without the structure — then discover the rule after all the implementation had shipped.

This release shifts the enforcement moment from close to gate. Same regex, same post-65 grandfathering, same audit-trail override. Authors now meet the rule at the cheap moment (before accept) rather than at the expensive moment (after implementation).

## Changes

- **`/nx:rdr-gate` Layer 1 gap-structure pre-check** (`nx/commands/rdr-gate.md`, `nx/skills/rdr-gate/SKILL.md`). Emits a BLOCKED outcome when a post-65 RDR's Problem Statement has zero `#### Gap N:` headings. The preamble script exits before Layer 2 / Layer 3 fire, so the critic isn't dispatched on a structurally-invalid RDR. `--skip-gaps` is the audit-trail override for rare cases where the structure truly doesn't fit.
- **`/nx:rdr-create` SKILL + template reinforce the convention** (`nx/resources/rdr/TEMPLATE.md`, `nx/skills/rdr-create/SKILL.md`). Template comment now names both enforcement points explicitly so authors see "gate will block" at drafting time, not only at close.
- **RDR-091 retrofit** (`docs/rdr/rdr-091-scope-aware-plan-matching.md`). The RDR was drafted and accepted before gate-time enforcement; adding `#### Gap 1: plan_match silently drops scope_preference...` lets it close through the same gate it now enforces. Frontmatter flipped `accepted → closed` with `closed_pointers: Gap1=src/nexus/plans/matcher.py:77` for the audit trail.

## Version

Plugin-side change only — no CLI functional differences — but marketplace parity requires all four manifests to bump together: `pyproject.toml`, `.claude-plugin/marketplace.json` (both entries), `nx/.claude-plugin/plugin.json`, `sn/.claude-plugin/plugin.json`. Plus `uv.lock`, `CHANGELOG.md`, `nx/CHANGELOG.md`.

## Test plan

- [x] `uv run pytest` — **4850 passed, 27 skipped** (same as 4.9.10 baseline — no regressions)
- [x] `uv run pytest tests/test_plugin_structure.py tests/test_sn_plugin.py` — **602 passed, 26 skipped** (version parity enforced by CI)
- [x] Manual verification: `/nx:rdr-gate` blocks an RDR with zero gap headings, passes with at least one, emits the grandfathering note for legacy (`id < 65`) RDRs
- [x] Manual verification: `/nx:rdr-close 091 --reason implemented --pointers 'Gap1=src/nexus/plans/matcher.py:77'` now passes with the retrofitted heading

## Rebased on #255

This PR was rebased on `a3ab3d0` (nexus-346q check-taxonomy refinement, PR #255) before opening so the v4.9.11 tag carries both fixes. Linear history — no merge commit.

## Closes

Closes nexus-4qpb