### PR TITLE
RDR-092 Phase 0b: grown plans carry verb/name/dimensions (nexus-kcq6)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1860,6 +1860,77 @@ def _nx_answer_match_is_hit(confidence: float | None) -> bool:
     return confidence >= _PLAN_MATCH_MIN_CONFIDENCE
 
 
+#: Common English stop-words stripped when synthesizing a grown plan's
+#: ``name`` from the question. Kept narrow on purpose — aggressive
+#: filtering drops the content words R10 needs for match-text signal.
+_GROWN_PLAN_NAME_STOP_WORDS: frozenset[str] = frozenset({
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "to", "of", "for", "in", "on", "at", "by", "with", "from", "about",
+    "and", "or", "but", "so", "as",
+    "how", "what", "why", "when", "where", "who", "which",
+    "do", "does", "did", "can", "could", "should", "would", "will",
+    "this", "that", "these", "those",
+    "i", "we", "you", "they", "it", "he", "she",
+})
+
+
+def _infer_grown_plan_verb(
+    *,
+    caller_dimensions: dict[str, Any] | None,
+    plan_json: str,
+) -> str:
+    """Three-tier verb cascade for a grown plan. RDR-092 Phase 0b.
+
+    Tier 1: caller-supplied ``dimensions["verb"]``.
+    Tier 2: operator-shape inference from ``plan_json.steps``:
+        compare step → analyze; extract+rank → analyze;
+        traverse+search+summarize → research.
+    Tier 3: ``"research"`` fallback.
+    """
+    if caller_dimensions:
+        pinned = caller_dimensions.get("verb")
+        if isinstance(pinned, str) and pinned.strip():
+            return pinned.strip().lower()
+    try:
+        plan = json.loads(plan_json) if isinstance(plan_json, str) else plan_json
+    except (json.JSONDecodeError, TypeError):
+        return "research"
+    steps = plan.get("steps") if isinstance(plan, dict) else None
+    if not isinstance(steps, list):
+        return "research"
+    tools = {
+        step.get("tool", "").strip().lower()
+        for step in steps if isinstance(step, dict)
+    }
+    tools.discard("")
+    if "compare" in tools:
+        return "analyze"
+    if {"extract", "rank"}.issubset(tools):
+        return "analyze"
+    if {"traverse", "search", "summarize"}.issubset(tools):
+        return "research"
+    return "research"
+
+
+def _infer_grown_plan_name(
+    question: str, *, max_words: int = 5,
+) -> str:
+    """Kebab-case name from first 3-5 content words of *question*.
+
+    RDR-092 Phase 0b. Drops a narrow set of common English stop-words
+    (see :data:`_GROWN_PLAN_NAME_STOP_WORDS`), lowercases the rest, and
+    joins up to *max_words* tokens with ``-``. Empty / whitespace-only
+    input returns ``"grown-plan"`` so a grown row always has an
+    identifier.
+    """
+    import re
+
+    tokens = re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_]*", question.lower())
+    content = [t for t in tokens if t not in _GROWN_PLAN_NAME_STOP_WORDS]
+    take = content[:max_words] if content else tokens[:max_words]
+    return "-".join(take) or "grown-plan"
+
+
 def _nx_answer_classify_plan(match: Any) -> str:
     """Classify a matched plan: ``"single_query"`` | ``"retrieval_only"`` | ``"needs_operators"``."""
     from nexus.plans.runner import _OPERATOR_TOOL_MAP
@@ -2393,6 +2464,22 @@ async def nx_answer(
                 # it only appears in bindings, not plan_json. Passing
                 # scope_tags=scope explicitly captures the retrieval space
                 # that produced this plan.
+                # RDR-092 Phase 0b: R6 three-tier verb cascade populates
+                # verb / name / dimensions so the grown row participates in
+                # the dimensional identity index instead of landing as a
+                # NULL-dimension legacy ghost.
+                from nexus.plans.schema import canonical_dimensions_json
+
+                grown_verb = _infer_grown_plan_verb(
+                    caller_dimensions=dimensions,
+                    plan_json=best.plan_json,
+                )
+                grown_name = _infer_grown_plan_name(question)
+                grown_dimensions = canonical_dimensions_json({
+                    "verb": grown_verb,
+                    "scope": "personal",
+                    "strategy": grown_name,
+                })
                 with _t2_ctx() as _save_db:
                     grown_id = _save_db.plans.save_plan(
                         query=question,
@@ -2403,6 +2490,9 @@ async def nx_answer(
                         ttl=ttl_days,
                         scope="personal",
                         scope_tags=scope or None,
+                        verb=grown_verb,
+                        name=grown_name,
+                        dimensions=grown_dimensions,
                     )
                     # Feed the new plan into the T1 cosine cache so the next
                     # paraphrase can match without a SessionStart re-populate.

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1861,7 +1861,7 @@ def _nx_answer_match_is_hit(confidence: float | None) -> bool:
 
 
 #: Common English stop-words stripped when synthesizing a grown plan's
-#: ``name`` from the question. Kept narrow on purpose — aggressive
+#: ``name`` from the question. Kept narrow on purpose; aggressive
 #: filtering drops the content words R10 needs for match-text signal.
 _GROWN_PLAN_NAME_STOP_WORDS: frozenset[str] = frozenset({
     "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -364,6 +364,240 @@ class TestPlanMissPlanner:
         assert "nexus.mcp_infra" not in str(dispatch_calls), "pool path must not be taken"
 
 
+# ── Grown plan dimensional columns (RDR-092 Phase 0b) ─────────────────────────
+
+
+def _ad_hoc_match_for_grow(plan_json_steps: list[dict]) -> Match:
+    """Build an ad-hoc Match whose plan_json has the given steps shape."""
+    return Match(
+        plan_id=0,
+        name="ad-hoc",
+        description="what is the meaning of life",
+        confidence=None,
+        dimensions={},
+        tags="ad-hoc",
+        plan_json=json.dumps({"steps": plan_json_steps}),
+        required_bindings=["intent"],
+        optional_bindings=[],
+        default_bindings={"intent": "what is the meaning of life"},
+        parent_dims=None,
+    )
+
+
+def _plan_run_ok():
+    result = MagicMock()
+    result.steps = [{"text": "the answer is 42"}]
+    return result
+
+
+class TestGrownPlanDimensionalColumns:
+    """RDR-092 Phase 0b: grown plans pass verb/name/dimensions on save_plan.
+
+    The R6 three-tier cascade resolves verb:
+      1. caller-supplied ``dimensions["verb"]``
+      2. inferred from ``plan_json.steps`` operator shape
+      3. ``"research"`` fallback
+    """
+
+    @pytest.mark.asyncio
+    async def test_grown_plan_has_dimensional_columns(self):
+        """save_plan on an ad-hoc grow path receives verb, name, dimensions."""
+        from nexus.mcp.core import nx_answer
+
+        match = _ad_hoc_match_for_grow([
+            {"tool": "search", "args": {"query": "$intent"}},
+            {"tool": "summarize", "args": {"inputs": "$step1.ids"}},
+        ])
+        save_mock = MagicMock(return_value=999)
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = save_mock
+        db_stub.plans.get_plan = MagicMock(return_value={"id": 999})
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[]), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(return_value=match)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=_plan_run_ok())), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(question="what is the meaning of life")
+
+        assert save_mock.called, "save_plan must be called on ad-hoc success"
+        kwargs = save_mock.call_args.kwargs
+        assert kwargs.get("verb"), "grown plan must carry a verb"
+        assert kwargs.get("name"), "grown plan must carry a name"
+        assert kwargs.get("dimensions"), "grown plan must carry canonical dimensions"
+        # dimensions string is canonical JSON: sorted keys, lowercased strings
+        parsed = json.loads(kwargs["dimensions"])
+        assert parsed["verb"] == kwargs["verb"]
+        assert parsed["scope"] == "personal"
+        # name is kebab-case; strategy mirrors it so each grown plan is unique
+        assert "-" in kwargs["name"] or kwargs["name"].isalpha()
+        assert parsed.get("strategy") == kwargs["name"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "steps,expected_verb",
+        [
+            # Tier 2.1: compare step → analyze
+            (
+                [
+                    {"tool": "search", "args": {}},
+                    {"tool": "compare", "args": {}},
+                ],
+                "analyze",
+            ),
+            # Tier 2.2: extract + rank → analyze
+            (
+                [
+                    {"tool": "search", "args": {}},
+                    {"tool": "extract", "args": {}},
+                    {"tool": "rank", "args": {}},
+                ],
+                "analyze",
+            ),
+            # Tier 2.3: traverse + search + summarize → research
+            (
+                [
+                    {"tool": "search", "args": {}},
+                    {"tool": "traverse", "args": {}},
+                    {"tool": "summarize", "args": {}},
+                ],
+                "research",
+            ),
+            # Tier 3: flat shape falls back to research
+            (
+                [
+                    {"tool": "search", "args": {}},
+                    {"tool": "summarize", "args": {}},
+                ],
+                "research",
+            ),
+        ],
+        ids=["compare→analyze", "extract+rank→analyze",
+             "traverse+search+summarize→research", "flat→research"],
+    )
+    async def test_grown_plan_verb_inference_from_plan_json(
+        self, steps, expected_verb,
+    ):
+        from nexus.mcp.core import nx_answer
+
+        match = _ad_hoc_match_for_grow(steps)
+        save_mock = MagicMock(return_value=1)
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = save_mock
+        db_stub.plans.get_plan = MagicMock(return_value={"id": 1})
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[]), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(return_value=match)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=_plan_run_ok())), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(question="how does X behave")
+
+        assert save_mock.call_args.kwargs.get("verb") == expected_verb
+
+    @pytest.mark.asyncio
+    async def test_caller_dimensions_verb_wins(self):
+        """Tier 1: caller-supplied dimensions['verb'] overrides inference."""
+        from nexus.mcp.core import nx_answer
+
+        # Plan shape would otherwise infer as "analyze" (has compare step),
+        # but the caller pinned verb:debug.
+        match = _ad_hoc_match_for_grow([
+            {"tool": "search", "args": {}},
+            {"tool": "compare", "args": {}},
+        ])
+        save_mock = MagicMock(return_value=1)
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = save_mock
+        db_stub.plans.get_plan = MagicMock(return_value={"id": 1})
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[]), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(return_value=match)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=_plan_run_ok())), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(
+                question="test q",
+                dimensions={"verb": "debug"},
+            )
+
+        assert save_mock.call_args.kwargs.get("verb") == "debug"
+
+    @pytest.mark.asyncio
+    async def test_name_is_kebab_case_from_content_words(self):
+        """Name skips stop-words and kebab-cases 3-5 content tokens."""
+        from nexus.mcp.core import nx_answer
+
+        match = _ad_hoc_match_for_grow([
+            {"tool": "search", "args": {}},
+            {"tool": "summarize", "args": {}},
+        ])
+        save_mock = MagicMock(return_value=1)
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = save_mock
+        db_stub.plans.get_plan = MagicMock(return_value={"id": 1})
+
+        with patch("nexus.plans.matcher.plan_match", return_value=[]), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(return_value=match)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=_plan_run_ok())), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(question="How does the chroma cache evict?")
+
+        name = save_mock.call_args.kwargs.get("name") or ""
+        # Stop-words ('how', 'does', 'the') are dropped; content words remain.
+        assert "how" not in name.split("-")
+        assert "does" not in name.split("-")
+        assert "chroma" in name or "cache" in name
+        # Kebab-case: lowercase, no spaces
+        assert name == name.lower()
+        assert " " not in name
+
+    def test_infer_grown_plan_verb_helper_exposed(self):
+        """The verb-inference helper is importable for direct unit tests
+        and docs examples.
+        """
+        from nexus.mcp.core import _infer_grown_plan_verb
+
+        plan = json.dumps({"steps": [
+            {"tool": "search"}, {"tool": "compare"},
+        ]})
+        assert _infer_grown_plan_verb(
+            caller_dimensions=None, plan_json=plan,
+        ) == "analyze"
+        # Caller override wins.
+        assert _infer_grown_plan_verb(
+            caller_dimensions={"verb": "review"}, plan_json=plan,
+        ) == "review"
+        # Unparseable plan → fallback.
+        assert _infer_grown_plan_verb(
+            caller_dimensions=None, plan_json="not-json",
+        ) == "research"
+
+    def test_infer_grown_plan_name_helper_exposed(self):
+        from nexus.mcp.core import _infer_grown_plan_name
+
+        # Drops common stop-words, keeps content tokens, joins with '-'.
+        name = _infer_grown_plan_name("How does the chroma cache evict entries?")
+        parts = name.split("-")
+        assert "how" not in parts and "does" not in parts
+        assert any(p in parts for p in ("chroma", "cache", "evict"))
+        # Max 5 content words.
+        long_q = "one two three four five six seven eight nine ten"
+        long_name = _infer_grown_plan_name(long_q)
+        assert len(long_name.split("-")) <= 5
+        # Empty / whitespace-only falls back to a sentinel.
+        assert _infer_grown_plan_name("") == "grown-plan"
+
+
 # ── nx_tidy ───────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Second implementation PR for [RDR-092](https://github.com/Hellblazer/nexus/pull/257).
Ships the R6 three-tier verb cascade for grown plans so the ad-hoc
plan-miss growth path populates verb / name / dimensions on save_plan
instead of landing NULL-dimension rows into T2.

## Cascade

- **Tier 1** — caller-supplied `dimensions["verb"]` wins when pinned
  (verb skills can still route their ad-hoc questions to a specific
  verb bucket).
- **Tier 2** — operator-shape inference from `plan_json.steps`:
  - `compare` step → `analyze`
  - `extract + rank` → `analyze`
  - `traverse + search + summarize` → `research`
- **Tier 3** — `research` fallback.

## Name synthesis

`_infer_grown_plan_name` keeps the first 3-5 content tokens of the
question (after dropping a narrow set of common English stop-words),
lowercases them, and joins with `-`. The name feeds both the `name`
column and the `strategy` axis of the canonical dimensions JSON so
distinct grown plans carry distinct identities and the existing
UNIQUE `(project, dimensions)` partial index dedupes paraphrases
naturally.

## Test plan

- [x] `tests/test_nx_answer.py::TestGrownPlanDimensionalColumns` — 9
  cases cover cascade tiers, name synthesis, and the helper surface
- [x] Broader suite — 214 pass across `test_nx_answer` +
  `test_rdr_084_plan_grow` + `test_plan_run` + `test_plan_match` +
  `test_plan_library` + `test_plan_template_schema`
- [ ] Post-merge: grep prod T2 for `tags LIKE '%grown%' AND verb IS
  NULL` to confirm the backlog has been drained (expected empty after
  RDR-092 Phase 0d migration; Phase 0b only fixes the forward path)

## Depends on

This PR is independent of #257 (different files — `mcp/core.py` vs
`commands/catalog.py` + `nx/plans/builtin/*.yml`). Merge in any order.

## Closes

- Closes nexus-kcq6 (Phase 0b.1)

Phase 0b.2 (nexus-rmx3, code review) pending against this PR.