### PR TITLE
RDR-092 Phase 0c: fail-loud loader + nx doctor --check-plan-library

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -129,8 +129,8 @@ def _seed_plan_templates() -> int:
             library=db.plans,
         )
 
-        # RDR-092 Phase 0c.1 — fail loud on an empty global tier. A
-        # missing / empty ``nx/plans/builtin`` is a deployment gap
+        # RDR-092 Phase 0c.1: fail loud on an empty global tier. A
+        # missing or empty ``nx/plans/builtin`` is a deployment gap
         # (plugin root misrouted, YAMLs deleted) that silently leaves
         # the library without dimensional seeds. The loader normally
         # logs this via ``_log.info("seed_directory_missing")``; the
@@ -142,8 +142,8 @@ def _seed_plan_templates() -> int:
         )
         if global_scanned == 0:
             raise click.ClickException(
-                "Plan library seed failed: global tier is empty — no "
-                f"YAML builtins found at {plugin_root / 'plans' / 'builtin'}. "
+                "Plan library seed failed: global tier is empty (no "
+                f"YAML builtins found at {plugin_root / 'plans' / 'builtin'}). "
                 "This typically means the plugin root is misconfigured "
                 "or the shipped builtin YAMLs were removed. Re-install "
                 "the nx plugin or run 'nx doctor --check-plan-library' "

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -128,11 +128,43 @@ def _seed_plan_templates() -> int:
             repo_root=repo_root,
             library=db.plans,
         )
+
+        # RDR-092 Phase 0c.1 — fail loud on an empty global tier. A
+        # missing / empty ``nx/plans/builtin`` is a deployment gap
+        # (plugin root misrouted, YAMLs deleted) that silently leaves
+        # the library without dimensional seeds. The loader normally
+        # logs this via ``_log.info("seed_directory_missing")``; the
+        # setup CLI needs a user-visible failure, not a structured
+        # info.
+        global_result = tier_results.get("global")
+        global_scanned = (
+            global_result.total_scanned if global_result is not None else 0
+        )
+        if global_scanned == 0:
+            raise click.ClickException(
+                "Plan library seed failed: global tier is empty — no "
+                f"YAML builtins found at {plugin_root / 'plans' / 'builtin'}. "
+                "This typically means the plugin root is misconfigured "
+                "or the shipped builtin YAMLs were removed. Re-install "
+                "the nx plugin or run 'nx doctor --check-plan-library' "
+                "for diagnostics."
+            )
+
         for scope, result in tier_results.items():
             for source, error in result.errors:
+                # Structured log for machine consumption.
                 _log.warning(
                     "rdr078_seed_load_error",
                     scope=scope, source=source, error=error,
+                )
+                # User-visible echo so setup output distinguishes
+                # 'files found but some malformed' from the quiet
+                # healthy case. Stays on stderr to preserve stdout
+                # for the success count.
+                click.echo(
+                    f"  warning: seed load error in {scope} tier "
+                    f"({source}): {error}",
+                    err=True,
                 )
             seeded += len(result.inserted)
 

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -163,6 +163,103 @@ def _run_check_schema() -> None:
         click.echo("\nAll checks passed.")
 
 
+#: Minimum number of global-tier builtin plan rows expected after
+#: ``nx catalog setup`` has run on a fresh install. RDR-078 shipped 9;
+#: RDR-092 Phase 0a brings that to 12, but the check only fails below 9
+#: so a partial install on an older plugin is still tolerated.
+_MIN_GLOBAL_BUILTIN_COUNT: int = 9
+
+
+def _run_check_plan_library() -> None:
+    """Report plan-library dimensional health. RDR-092 Phase 0c.2.
+
+    Categories counted:
+
+      * **authored** — rows whose ``dimensions`` column is populated
+        AND whose ``tags`` do not include ``backfill`` (shipped YAML
+        seeds or grown plans with full identity).
+      * **backfilled** — rows whose ``tags`` contain ``backfill`` /
+        ``backfill-low-conf`` (Phase 0d heuristic migration output).
+      * **non-dimensional** — rows with ``dimensions IS NULL``
+        (legacy / pre-RDR-078 seeds that need ``nx plan repair``).
+
+    Exits non-zero when the global-tier builtin count
+    (``project='' AND tags LIKE '%builtin-template%'``) falls below
+    :data:`_MIN_GLOBAL_BUILTIN_COUNT` — that state signals the scoped
+    loader never seeded (typically ``nx catalog setup`` was never
+    re-run after the RDR-078 loader landed).
+    """
+    import sqlite3
+
+    from nexus.commands._helpers import default_db_path
+
+    db_path = default_db_path()
+    if not db_path.exists():
+        click.echo("T2 database not found — nothing to check.")
+        click.echo("Fix: run 'nx catalog setup' to initialise the library.")
+        raise click.exceptions.Exit(1)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    def _count(where: str) -> int:
+        row = conn.execute(
+            f"SELECT COUNT(*) FROM plans WHERE {where}"
+        ).fetchone()
+        return int(row[0] or 0)
+
+    total = _count("1=1")
+    non_dimensional = _count("dimensions IS NULL")
+    backfilled = _count(
+        "dimensions IS NOT NULL AND "
+        "(tags LIKE '%backfill%' OR tags LIKE '%backfill-low-conf%')"
+    )
+    authored = _count(
+        "dimensions IS NOT NULL AND "
+        "NOT (tags LIKE '%backfill%' OR tags LIKE '%backfill-low-conf%')"
+    )
+    global_builtin = _count(
+        "project = '' AND tags LIKE '%builtin-template%'"
+    )
+
+    conn.close()
+
+    click.echo("Plan library check:")
+    click.echo(f"  total rows:         {total}")
+    click.echo(f"  authored:           {authored}")
+    click.echo(f"  backfilled:         {backfilled}")
+    click.echo(f"  non-dimensional:    {non_dimensional}")
+    click.echo(f"  global-tier builtin count: {global_builtin}")
+    click.echo("")
+
+    failed = False
+    if global_builtin < _MIN_GLOBAL_BUILTIN_COUNT:
+        click.echo(
+            f"  FAIL: global-tier builtin count {global_builtin} "
+            f"< expected {_MIN_GLOBAL_BUILTIN_COUNT}",
+            err=True,
+        )
+        click.echo("    Fix: run 'nx catalog setup'.", err=True)
+        failed = True
+    if non_dimensional:
+        click.echo(
+            f"  WARN: {non_dimensional} non-dimensional row(s) "
+            "(legacy / pre-RDR-078 seeds).",
+            err=True,
+        )
+        click.echo(
+            "    Fix: run 'nx plan repair' to backfill dimensions "
+            "heuristically.",
+            err=True,
+        )
+
+    if not failed:
+        click.echo("All checks passed.")
+    else:
+        raise click.exceptions.Exit(1)
+
+
 def _run_trim_telemetry(days: int) -> None:
     """Delete search_telemetry rows older than *days* (RDR-087 Phase 2.4)."""
     from nexus.commands._helpers import default_db_path
@@ -258,6 +355,16 @@ def _run_trim_telemetry(days: int) -> None:
          "(GH #252). Exits 1 on drift.",
 )
 @click.option(
+    "--check-plan-library",
+    "check_plan_library",
+    is_flag=True,
+    default=False,
+    help="Report plan-library dimensional health: authored vs "
+         "backfilled vs non-dimensional row counts, plus global-tier "
+         "builtin count. Exits 1 when builtin count < 9. RDR-092 "
+         "Phase 0c.2.",
+)
+@click.option(
     "--json",
     "json_out",
     is_flag=True,
@@ -283,7 +390,8 @@ def _run_trim_telemetry(days: int) -> None:
 def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                fix_paths: bool, dry_run: bool, check_schema: bool,
                check_search: bool, check_resources: bool,
-               check_quotas: bool, check_taxonomy: bool, json_out: bool,
+               check_quotas: bool, check_taxonomy: bool,
+               check_plan_library: bool, json_out: bool,
                trim_telemetry: bool, days: int) -> None:
     """Verify that all required services and credentials are available."""
     if check_schema:
@@ -305,6 +413,10 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if check_taxonomy:
         _run_check_taxonomy()
+        return
+
+    if check_plan_library:
+        _run_check_plan_library()
         return
 
     if trim_telemetry:

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -175,17 +175,17 @@ def _run_check_plan_library() -> None:
 
     Categories counted:
 
-      * **authored** — rows whose ``dimensions`` column is populated
+      * **authored**: rows whose ``dimensions`` column is populated
         AND whose ``tags`` do not include ``backfill`` (shipped YAML
         seeds or grown plans with full identity).
-      * **backfilled** — rows whose ``tags`` contain ``backfill`` /
+      * **backfilled**: rows whose ``tags`` contain ``backfill`` /
         ``backfill-low-conf`` (Phase 0d heuristic migration output).
-      * **non-dimensional** — rows with ``dimensions IS NULL``
+      * **non-dimensional**: rows with ``dimensions IS NULL``
         (legacy / pre-RDR-078 seeds that need ``nx plan repair``).
 
     Exits non-zero when the global-tier builtin count
     (``project='' AND tags LIKE '%builtin-template%'``) falls below
-    :data:`_MIN_GLOBAL_BUILTIN_COUNT` — that state signals the scoped
+    :data:`_MIN_GLOBAL_BUILTIN_COUNT`; that state signals the scoped
     loader never seeded (typically ``nx catalog setup`` was never
     re-run after the RDR-078 loader landed).
     """
@@ -195,35 +195,38 @@ def _run_check_plan_library() -> None:
 
     db_path = default_db_path()
     if not db_path.exists():
-        click.echo("T2 database not found — nothing to check.")
+        click.echo("T2 database not found; nothing to check.")
         click.echo("Fix: run 'nx catalog setup' to initialise the library.")
         raise click.exceptions.Exit(1)
 
+    # Context manager guards against a raise inside the count loop
+    # leaking the connection (RDR-092 code-review S-3).
     conn = sqlite3.connect(str(db_path))
-    conn.execute("PRAGMA busy_timeout=5000")
-    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute("PRAGMA journal_mode=WAL")
 
-    def _count(where: str) -> int:
-        row = conn.execute(
-            f"SELECT COUNT(*) FROM plans WHERE {where}"
-        ).fetchone()
-        return int(row[0] or 0)
+        def _count(where: str) -> int:
+            row = conn.execute(
+                f"SELECT COUNT(*) FROM plans WHERE {where}"
+            ).fetchone()
+            return int(row[0] or 0)
 
-    total = _count("1=1")
-    non_dimensional = _count("dimensions IS NULL")
-    backfilled = _count(
-        "dimensions IS NOT NULL AND "
-        "(tags LIKE '%backfill%' OR tags LIKE '%backfill-low-conf%')"
-    )
-    authored = _count(
-        "dimensions IS NOT NULL AND "
-        "NOT (tags LIKE '%backfill%' OR tags LIKE '%backfill-low-conf%')"
-    )
-    global_builtin = _count(
-        "project = '' AND tags LIKE '%builtin-template%'"
-    )
-
-    conn.close()
+        total = _count("1=1")
+        non_dimensional = _count("dimensions IS NULL")
+        backfilled = _count(
+            "dimensions IS NOT NULL AND "
+            "(tags LIKE '%backfill%' OR tags LIKE '%backfill-low-conf%')"
+        )
+        authored = _count(
+            "dimensions IS NOT NULL AND "
+            "NOT (tags LIKE '%backfill%' OR tags LIKE '%backfill-low-conf%')"
+        )
+        global_builtin = _count(
+            "project = '' AND tags LIKE '%builtin-template%'"
+        )
+    finally:
+        conn.close()
 
     click.echo("Plan library check:")
     click.echo(f"  total rows:         {total}")

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -366,6 +367,90 @@ class TestSeedPlanTemplates:
         for p in plans:
             assert "builtin-template" in p["tags"]
         db.close()
+
+    def test_setup_fails_loud_on_zero_global_tier(
+        self, tmp_path, monkeypatch,
+    ):
+        """RDR-092 Phase 0c.1: when the global-tier YAML directory is
+        empty or missing, _seed_plan_templates must raise a
+        ``click.ClickException`` rather than silently returning 0.
+
+        Rationale: an empty global tier signals a deployment gap
+        (plugin_root misrouted, YAMLs deleted, stale install). Silent
+        zero results are how RDR-092 discovered 0/52 live plans had
+        dimensional columns populated.
+        """
+        from nexus.plans.seed_loader import SeedLoadResult
+
+        db_path = tmp_path / "t2.db"
+        monkeypatch.setattr("nexus.commands._helpers.default_db_path", lambda: db_path)
+        # Force the scoped loader to report an empty global tier.
+        monkeypatch.setattr(
+            "nexus.plans.loader.load_all_tiers",
+            lambda **_kw: {"global": SeedLoadResult()},
+        )
+
+        from nexus.commands.catalog import _seed_plan_templates
+        with pytest.raises(click.exceptions.ClickException) as excinfo:
+            _seed_plan_templates()
+        assert "global" in str(excinfo.value.message).lower()
+
+    def test_setup_fails_loud_when_global_tier_absent(
+        self, tmp_path, monkeypatch,
+    ):
+        """RDR-092 Phase 0c.1: when ``load_all_tiers`` returns no
+        ``global`` key at all (plugin_root path does not exist), the
+        seeder must also raise — not silently succeed with zero rows.
+        """
+        db_path = tmp_path / "t2.db"
+        monkeypatch.setattr("nexus.commands._helpers.default_db_path", lambda: db_path)
+        monkeypatch.setattr(
+            "nexus.plans.loader.load_all_tiers",
+            lambda **_kw: {},
+        )
+
+        from nexus.commands.catalog import _seed_plan_templates
+        with pytest.raises(click.exceptions.ClickException) as excinfo:
+            _seed_plan_templates()
+        msg = str(excinfo.value.message).lower()
+        assert "global" in msg
+
+    def test_setup_surfaces_per_tier_errors_to_user(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        """RDR-092 Phase 0c.1: per-tier load errors must land on stderr
+        via ``click.echo`` (not only the structured log), so the setup
+        run visibly differentiates 'files found but some malformed'
+        from the quiet healthy case.
+        """
+        from nexus.plans.seed_loader import SeedLoadResult
+
+        db_path = tmp_path / "t2.db"
+        monkeypatch.setattr("nexus.commands._helpers.default_db_path", lambda: db_path)
+
+        # Give the global tier one healthy insert so the fail-loud
+        # zero-guard does not fire; rdr-099 scope surfaces an error.
+        monkeypatch.setattr(
+            "nexus.plans.loader.load_all_tiers",
+            lambda **_kw: {
+                "global": SeedLoadResult(
+                    inserted=["ok.yml"],
+                    skipped_existing=[],
+                    errors=[],
+                ),
+                "rdr-099": SeedLoadResult(
+                    inserted=[],
+                    skipped_existing=[],
+                    errors=[("/path/broken.yml", "schema: missing verb")],
+                ),
+            },
+        )
+
+        from nexus.commands.catalog import _seed_plan_templates
+        _seed_plan_templates()
+        err = capsys.readouterr().err
+        assert "broken.yml" in err
+        assert "rdr-099" in err
 
     def test_seed_templates_no_ttl(self, tmp_path, monkeypatch):
         from nexus.db.t2 import T2Database

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -571,3 +571,121 @@ class TestCheckQuotas:
         assert "voyage-code-3" in data["voyage"]["models"]
         assert data["voyage"]["api_key_set"] is True
         assert data["retry"]["total_count"] == 0
+
+class TestCheckPlanLibrary:
+    """RDR-092 Phase 0c.2: nx doctor --check-plan-library. Reports
+    authored vs backfilled vs non-dimensional plan row counts; exits
+    non-zero when the global-tier builtin count falls below the 9 shipped
+    by RDR-078 + RDR-092 (12 as of Phase 0a).
+    """
+
+    def test_check_plan_library_flags_missing_dimensions(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """When the plans table carries rows with NULL dimensions
+        (legacy seeds pre-RDR-078), the check reports them as
+        non-dimensional and exits non-zero.
+        """
+        import sqlite3
+
+        from nexus.db.migrations import apply_pending
+        from nexus.commands.upgrade import _current_version
+
+        db_path = tmp_path / "memory.db"
+        conn = sqlite3.connect(str(db_path))
+        apply_pending(conn, _current_version())
+        # Insert one legacy-shape row (NULL dimensions) to trigger the flag.
+        conn.execute(
+            "INSERT INTO plans (query, plan_json, outcome, tags, created_at) "
+            "VALUES (?, ?, 'success', 'builtin-template,legacy', datetime('now'))",
+            ("legacy plan", '{"steps": []}'),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch("nexus.commands._helpers.default_db_path", return_value=db_path):
+            result = runner.invoke(main, ["doctor", "--check-plan-library"])
+
+        # Non-zero exit because global builtin count is 0 (no YAMLs seeded).
+        assert result.exit_code != 0, result.output
+        # Output distinguishes the row categories.
+        assert "non-dimensional" in result.output.lower() or "no dimensions" in result.output.lower()
+
+    def test_check_plan_library_flags_zero_global_builtins(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """With an empty plans table, the check exits non-zero and calls
+        out that global-tier YAML builtins never seeded.
+        """
+        import sqlite3
+
+        from nexus.db.migrations import apply_pending
+        from nexus.commands.upgrade import _current_version
+
+        db_path = tmp_path / "memory.db"
+        conn = sqlite3.connect(str(db_path))
+        apply_pending(conn, _current_version())
+        conn.close()
+
+        with patch("nexus.commands._helpers.default_db_path", return_value=db_path):
+            result = runner.invoke(main, ["doctor", "--check-plan-library"])
+
+        assert result.exit_code != 0, result.output
+        assert "global" in result.output.lower()
+
+    def test_check_plan_library_passes_on_healthy_seed(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """Seeding the YAML builtins and re-running the check exits 0."""
+        import sqlite3
+
+        from nexus.db.migrations import apply_pending
+        from nexus.commands.upgrade import _current_version
+
+        db_path = tmp_path / "memory.db"
+        conn = sqlite3.connect(str(db_path))
+        apply_pending(conn, _current_version())
+        conn.close()
+
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+        from nexus.commands.catalog import _seed_plan_templates
+        _seed_plan_templates()
+
+        with patch("nexus.commands._helpers.default_db_path", return_value=db_path):
+            result = runner.invoke(main, ["doctor", "--check-plan-library"])
+
+        assert result.exit_code == 0, result.output
+        assert "global" in result.output.lower()
+
+    def test_check_plan_library_counts_backfilled_rows(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """Rows tagged 'backfill' are reported in a distinct bucket so
+        the operator can see day-2 heuristic rows without mistaking them
+        for freshly-authored dimensional seeds.
+        """
+        import sqlite3
+
+        from nexus.db.migrations import apply_pending
+        from nexus.commands.upgrade import _current_version
+
+        db_path = tmp_path / "memory.db"
+        conn = sqlite3.connect(str(db_path))
+        apply_pending(conn, _current_version())
+        conn.execute(
+            "INSERT INTO plans (query, plan_json, outcome, tags, verb, scope, dimensions, name, created_at) "
+            "VALUES (?, ?, 'success', 'builtin-template,backfill', 'research', 'global', ?, 'bf-one', datetime('now'))",
+            ("backfilled plan", '{"steps": []}', '{"scope":"global","verb":"research"}'),
+        )
+        conn.commit()
+        conn.close()
+
+        with patch("nexus.commands._helpers.default_db_path", return_value=db_path):
+            result = runner.invoke(main, ["doctor", "--check-plan-library"])
+
+        # Non-zero because global builtin count < 9, but the backfill
+        # count should appear in the report regardless.
+        assert "backfill" in result.output.lower()
+


### PR DESCRIPTION
## Summary

Third implementation PR for RDR-092. Adds operator-visible guards
against the R5 deployment-gap class of silent failures — the same
class that produced the 0/52 live-plan dimensional-column state the
RDR set out to fix.

## Phase 0c.1 — loader fail-loud (nexus-qmg0)

`_seed_plan_templates` now raises `click.ClickException` when the
global tier's `total_scanned` is 0 (plugin_root is missing or its
`plans/builtin/` directory is empty). The loader previously logged a
structured info and silently returned zero — fine for machines, but
invisible to the operator running `nx catalog setup`.

Per-tier schema errors additionally fan out to stderr via `click.echo`
so setup output distinguishes "files found but some malformed" from
the healthy quiet case. The structured log is retained for machine
consumption.

## Phase 0c.2 — `nx doctor --check-plan-library` (nexus-4x9q)

New `doctor` subcommand at `src/nexus/commands/doctor.py`. Buckets
plan rows into three categories and reports the global-tier builtin
count:

- **authored** — dimensions populated, not tagged `backfill`
- **backfilled** — dimensions populated, tagged `backfill` /
  `backfill-low-conf` (Phase 0d heuristic output)
- **non-dimensional** — `dimensions IS NULL` (legacy / pre-RDR-078)

Exits 1 when global-tier builtin count falls below 9 (the pre-Phase-0a
floor — partial installs on older plugin versions still pass). Non-
dimensional rows surface a `nx plan repair` hint pointing to the
Phase 0d day-2 command.

## Test plan

- [x] `tests/test_catalog_cli.py::TestSeedPlanTemplates` — 3 new cases
  cover the zero-global-tier raise path and per-tier stderr fan-out
- [x] `tests/test_doctor_cmd.py::TestCheckPlanLibrary` — 4 cases cover
  missing-dimensions, zero-global-builtins, healthy-seed, and
  backfilled-row reporting
- [x] Broader suite — 193 pass across `test_catalog_cli` +
  `test_rdr052_verification` + `test_doctor_cmd` +
  `test_phase5_integration` + `test_upgrade_e2e`
- [ ] Post-merge on local T2: run `nx doctor --check-plan-library`
  against the live DB; expect `global-tier builtin count: 5` (legacy
  NULL-dimension rows only) and `FAIL: ... < 9` — the diagnostic that
  validates R5's deployment-gap framing.

## Depends on

Independent of #257 (Phase 0a) and #258 (Phase 0b). Merge in any order.

## Closes

- Closes nexus-qmg0 (Phase 0c.1)
- Closes nexus-4x9q (Phase 0c.2)

Phase 0c.3 (nexus-cmbz, code review) pending against this PR.