### PR TITLE
RDR-092 Phase 0d: backfill migration + nx plan repair

### DIFF
--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -14,6 +14,7 @@ from nexus.commands.hooks import hooks
 from nexus.commands.index import index
 from nexus.commands.memory import memory
 from nexus.commands.mineru import mineru_group
+from nexus.commands.plan import plan as plan_group
 from nexus.commands.scratch import scratch
 from nexus.commands.search_cmd import search_cmd
 from nexus.commands.store import store
@@ -47,6 +48,7 @@ main.add_command(hooks)
 main.add_command(index)
 main.add_command(memory)
 main.add_command(mineru_group, name="mineru")
+main.add_command(plan_group, name="plan")
 main.add_command(scratch)
 main.add_command(search_cmd, name="search")
 main.add_command(store)

--- a/src/nexus/commands/plan.py
+++ b/src/nexus/commands/plan.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""``nx plan`` command group. RDR-092 Phase 0d.2.
+
+Day-2 operations against the plan library. ``nx plan repair`` re-runs
+the :func:`nexus.db.migrations._backfill_plan_dimensions` heuristic
+and surfaces low-confidence rows so the operator can correct
+edge-case inferences by hand.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import click
+
+
+@click.group()
+def plan() -> None:
+    """Plan library maintenance commands."""
+
+
+@plan.command("repair")
+def repair_cmd() -> None:
+    """Re-run plan-dimension backfill and list low-conf rows for review.
+
+    Idempotent: once every plan row has a populated ``dimensions``
+    column, subsequent runs report "0 backfilled" and exit cleanly.
+    Low-confidence rows (those that reached the wh-fallback during the
+    RDR-092 Phase 0d.1 backfill heuristic) are listed with their
+    inferred verb so the operator can update them via SQL or future
+    editor commands.
+    """
+    from nexus.commands._helpers import default_db_path
+    from nexus.db.migrations import _backfill_plan_dimensions
+
+    db_path = default_db_path()
+    if not db_path.exists():
+        click.echo(
+            f"T2 database not found at {db_path} — nothing to do."
+        )
+        return
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA busy_timeout=5000")
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    # Count NULL-dimension rows before the run so the report reflects
+    # reality even when the migration itself is a no-op.
+    pending_before = conn.execute(
+        "SELECT COUNT(*) FROM plans WHERE dimensions IS NULL"
+    ).fetchone()[0]
+
+    _backfill_plan_dimensions(conn)
+
+    pending_after = conn.execute(
+        "SELECT COUNT(*) FROM plans WHERE dimensions IS NULL"
+    ).fetchone()[0]
+    backfilled = pending_before - pending_after
+
+    # Surface low-confidence rows for operator review, oldest first so
+    # a re-run reports a stable order.
+    low_conf_rows = conn.execute(
+        "SELECT id, query, verb FROM plans "
+        "WHERE tags LIKE '%backfill-low-conf%' "
+        "ORDER BY id ASC"
+    ).fetchall()
+    conn.close()
+
+    click.echo(f"{backfilled} backfilled")
+    if backfilled == 0 and pending_before == 0:
+        click.echo("Nothing to do — every plan already carries dimensions.")
+
+    if low_conf_rows:
+        click.echo(
+            f"\n{len(low_conf_rows)} low-conf row(s) need review "
+            "(tagged backfill-low-conf):"
+        )
+        for row_id, query, verb in low_conf_rows:
+            click.echo(
+                f"  id={row_id} verb={verb or '-'}  "
+                f"query={(query or '').strip()!r}"
+            )
+    else:
+        click.echo("\n0 rows need review.")

--- a/src/nexus/commands/plan.py
+++ b/src/nexus/commands/plan.py
@@ -36,39 +36,43 @@ def repair_cmd() -> None:
     db_path = default_db_path()
     if not db_path.exists():
         click.echo(
-            f"T2 database not found at {db_path} — nothing to do."
+            f"T2 database not found at {db_path}; nothing to do."
         )
         return
 
+    # Context manager guards against a raise in _backfill_plan_dimensions
+    # leaking the connection (RDR-092 code-review S-3).
     conn = sqlite3.connect(str(db_path))
-    conn.execute("PRAGMA busy_timeout=5000")
-    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute("PRAGMA journal_mode=WAL")
 
-    # Count NULL-dimension rows before the run so the report reflects
-    # reality even when the migration itself is a no-op.
-    pending_before = conn.execute(
-        "SELECT COUNT(*) FROM plans WHERE dimensions IS NULL"
-    ).fetchone()[0]
+        # Count NULL-dimension rows before the run so the report reflects
+        # reality even when the migration itself is a no-op.
+        pending_before = conn.execute(
+            "SELECT COUNT(*) FROM plans WHERE dimensions IS NULL"
+        ).fetchone()[0]
 
-    _backfill_plan_dimensions(conn)
+        _backfill_plan_dimensions(conn)
 
-    pending_after = conn.execute(
-        "SELECT COUNT(*) FROM plans WHERE dimensions IS NULL"
-    ).fetchone()[0]
-    backfilled = pending_before - pending_after
+        pending_after = conn.execute(
+            "SELECT COUNT(*) FROM plans WHERE dimensions IS NULL"
+        ).fetchone()[0]
+        backfilled = pending_before - pending_after
 
-    # Surface low-confidence rows for operator review, oldest first so
-    # a re-run reports a stable order.
-    low_conf_rows = conn.execute(
-        "SELECT id, query, verb FROM plans "
-        "WHERE tags LIKE '%backfill-low-conf%' "
-        "ORDER BY id ASC"
-    ).fetchall()
-    conn.close()
+        # Surface low-confidence rows for operator review, oldest first so
+        # a re-run reports a stable order.
+        low_conf_rows = conn.execute(
+            "SELECT id, query, verb FROM plans "
+            "WHERE tags LIKE '%backfill-low-conf%' "
+            "ORDER BY id ASC"
+        ).fetchall()
+    finally:
+        conn.close()
 
     click.echo(f"{backfilled} backfilled")
     if backfilled == 0 and pending_before == 0:
-        click.echo("Nothing to do — every plan already carries dimensions.")
+        click.echo("Nothing to do; every plan already carries dimensions.")
 
     if low_conf_rows:
         click.echo(

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -707,6 +707,159 @@ def _rewash_plan_scope_tags_all_sentinel(conn: sqlite3.Connection) -> None:
         conn.commit()
 
 
+# ── RDR-092 Phase 0d.1 — plan-dimensions backfill ───────────────────────────
+
+
+#: 20-rule verb-from-stem dictionary. Keyed on lowercased tokens that
+#: commonly appear in plan ``query`` text. A match is high-confidence
+#: (tagged ``backfill``); zero matches fall through to the wh-fallback
+#: and get tagged ``backfill-low-conf``.
+_BACKFILL_VERB_STEMS: dict[str, str] = {
+    # research-family (8 stems)
+    "find": "research", "search": "research", "list": "research",
+    "get": "research", "show": "research", "enumerate": "research",
+    "fetch": "research", "retrieve": "research",
+    # analyze-family (6 stems)
+    "analyze": "analyze", "analyse": "analyze",
+    "compare": "analyze", "contrast": "analyze",
+    "rank": "analyze", "synthesize": "analyze",
+    "summarize": "analyze", "summarise": "analyze",
+    # review-family (4 stems)
+    "review": "review", "audit": "review",
+    "evaluate": "review", "critique": "review",
+    "assess": "review",
+    # debug-family (4 stems)
+    "debug": "debug", "trace": "debug",
+    "investigate": "debug", "fix": "debug",
+    "troubleshoot": "debug",
+    # document-family (3 stems)
+    "document": "document", "describe": "document",
+    "explain": "document",
+}
+
+#: Wh-fallback table. Low confidence because a wh-question can map to
+#: any verb — the best guess is research for explanatory questions,
+#: review for causal "why" questions.
+_BACKFILL_WH_FALLBACK: dict[str, str] = {
+    "how": "research", "what": "research",
+    "why": "review",
+    "when": "research", "where": "research", "who": "research",
+    "which": "research",
+}
+
+#: Stop-words skipped when deriving the plan ``name`` from query text.
+_BACKFILL_NAME_STOP_WORDS: frozenset[str] = frozenset({
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "to", "of", "for", "in", "on", "at", "by", "with", "from", "about",
+    "and", "or", "but", "so", "as",
+    "how", "what", "why", "when", "where", "who", "which",
+    "do", "does", "did", "can", "could", "should", "would", "will",
+    "this", "that", "these", "those",
+    "i", "we", "you", "they", "it", "he", "she",
+})
+
+
+def _infer_plan_verb_from_query(query: str) -> tuple[str, bool]:
+    """Heuristic verb classifier for RDR-092 plan-dimension backfill.
+
+    Returns ``(verb, is_confident)``. High-confidence matches come
+    from :data:`_BACKFILL_VERB_STEMS`; wh-fallback matches are
+    low-confidence; the ultimate default is ``("research", False)``.
+    """
+    import re
+
+    tokens = re.findall(r"[a-z][a-z-]+", (query or "").lower())
+    for token in tokens:
+        if token in _BACKFILL_VERB_STEMS:
+            return _BACKFILL_VERB_STEMS[token], True
+    for token in tokens:
+        if token in _BACKFILL_WH_FALLBACK:
+            return _BACKFILL_WH_FALLBACK[token], False
+    return "research", False
+
+
+def _derive_plan_name_from_query(query: str, *, max_words: int = 5) -> str:
+    """Kebab-case name from the first 3-5 content tokens of *query*."""
+    import re
+
+    tokens = re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_]*", (query or "").lower())
+    content = [t for t in tokens if t not in _BACKFILL_NAME_STOP_WORDS]
+    take = content[:max_words] if content else tokens[:max_words]
+    return "-".join(take) or "backfilled-plan"
+
+
+def _backfill_plan_dimensions(conn: sqlite3.Connection) -> None:
+    """Backfill verb / name / dimensions on NULL-dimension plan rows.
+
+    RDR-092 Phase 0d.1. Touches only rows where ``dimensions IS NULL``
+    — authored rows (shipped YAML seeds, already-dimensional grown
+    plans, previously-backfilled rows) are left alone. The
+    :func:`_infer_plan_verb_from_query` heuristic decides the verb,
+    and :func:`_derive_plan_name_from_query` supplies the name. Rows
+    whose verb came from a stem match get tagged ``backfill``; rows
+    that fell through to the wh-fallback get tagged
+    ``backfill-low-conf`` so ``nx plan repair`` can prioritise them.
+
+    The canonical dimensions JSON is ``{"scope":<scope>,"strategy":
+    <name>,"verb":<verb>}`` where ``<scope>`` is ``"personal"`` for
+    tagged grown rows and ``"global"`` for everything else (legacy
+    builtin shapes pre-RDR-078). Idempotent: a second run skips rows
+    whose ``dimensions`` is no longer NULL.
+    """
+    has_table = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='plans'"
+    ).fetchone()
+    if not has_table:
+        return
+
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(plans)").fetchall()}
+    if "dimensions" not in cols:
+        return
+
+    rows = conn.execute(
+        "SELECT id, query, tags FROM plans WHERE dimensions IS NULL"
+    ).fetchall()
+    if not rows:
+        return
+
+    from nexus.plans.schema import canonical_dimensions_json
+
+    backfilled = 0
+    low_conf = 0
+    for row_id, query, tags in rows:
+        verb, confident = _infer_plan_verb_from_query(query or "")
+        name = _derive_plan_name_from_query(query or "")
+        scope = "personal" if (tags or "").find("grown") >= 0 else "global"
+        dims_json = canonical_dimensions_json({
+            "scope": scope,
+            "strategy": name,
+            "verb": verb,
+        })
+
+        tag_flag = "backfill" if confident else "backfill-low-conf"
+        existing_tags = [t for t in (tags or "").split(",") if t]
+        if tag_flag not in existing_tags:
+            existing_tags.append(tag_flag)
+        new_tags = ",".join(existing_tags)
+
+        conn.execute(
+            "UPDATE plans SET verb = ?, scope = ?, name = ?, "
+            "dimensions = ?, tags = ? WHERE id = ?",
+            (verb, scope, name, dims_json, new_tags, row_id),
+        )
+        if confident:
+            backfilled += 1
+        else:
+            low_conf += 1
+
+    conn.commit()
+    _log.info(
+        "Backfilled plan dimensions",
+        backfilled=backfilled, low_conf=low_conf,
+        total_rows=len(rows),
+    )
+
+
 MIGRATIONS: list[Migration] = [
     Migration("1.10.0", "Memory FTS rebuild with title", migrate_memory_fts),
     Migration("2.8.0", "Add plan project column", migrate_plan_project),
@@ -759,6 +912,11 @@ MIGRATIONS: list[Migration] = [
         "4.9.10",
         "Add hook_failures table (GH #251)",
         migrate_hook_failures,
+    ),
+    Migration(
+        "4.9.12",
+        "Backfill plan dimensions (RDR-092 Phase 0d)",
+        _backfill_plan_dimensions,
     ),
 ]
 

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -707,38 +707,38 @@ def _rewash_plan_scope_tags_all_sentinel(conn: sqlite3.Connection) -> None:
         conn.commit()
 
 
-# ── RDR-092 Phase 0d.1 — plan-dimensions backfill ───────────────────────────
+# ── RDR-092 Phase 0d.1 (plan-dimensions backfill) ──────────────────────────
 
 
-#: 20-rule verb-from-stem dictionary. Keyed on lowercased tokens that
-#: commonly appear in plan ``query`` text. A match is high-confidence
-#: (tagged ``backfill``); zero matches fall through to the wh-fallback
-#: and get tagged ``backfill-low-conf``.
+#: Verb-from-stem dictionary (29 stems across 5 verb families). Keyed
+#: on lowercased tokens that commonly appear in plan ``query`` text.
+#: A match is high-confidence (tagged ``backfill``); zero matches fall
+#: through to the wh-fallback and get tagged ``backfill-low-conf``.
 _BACKFILL_VERB_STEMS: dict[str, str] = {
-    # research-family (8 stems)
+    # research family (8 stems)
     "find": "research", "search": "research", "list": "research",
     "get": "research", "show": "research", "enumerate": "research",
     "fetch": "research", "retrieve": "research",
-    # analyze-family (6 stems)
+    # analyze family (8 stems)
     "analyze": "analyze", "analyse": "analyze",
     "compare": "analyze", "contrast": "analyze",
     "rank": "analyze", "synthesize": "analyze",
     "summarize": "analyze", "summarise": "analyze",
-    # review-family (4 stems)
+    # review family (5 stems)
     "review": "review", "audit": "review",
     "evaluate": "review", "critique": "review",
     "assess": "review",
-    # debug-family (4 stems)
+    # debug family (5 stems)
     "debug": "debug", "trace": "debug",
     "investigate": "debug", "fix": "debug",
     "troubleshoot": "debug",
-    # document-family (3 stems)
+    # document family (3 stems)
     "document": "document", "describe": "document",
     "explain": "document",
 }
 
 #: Wh-fallback table. Low confidence because a wh-question can map to
-#: any verb — the best guess is research for explanatory questions,
+#: any verb; the best guess is research for explanatory questions,
 #: review for causal "why" questions.
 _BACKFILL_WH_FALLBACK: dict[str, str] = {
     "how": "research", "what": "research",
@@ -791,8 +791,8 @@ def _derive_plan_name_from_query(query: str, *, max_words: int = 5) -> str:
 def _backfill_plan_dimensions(conn: sqlite3.Connection) -> None:
     """Backfill verb / name / dimensions on NULL-dimension plan rows.
 
-    RDR-092 Phase 0d.1. Touches only rows where ``dimensions IS NULL``
-    — authored rows (shipped YAML seeds, already-dimensional grown
+    RDR-092 Phase 0d.1. Touches only rows where ``dimensions IS NULL``;
+    authored rows (shipped YAML seeds, already-dimensional grown
     plans, previously-backfilled rows) are left alone. The
     :func:`_infer_plan_verb_from_query` heuristic decides the verb,
     and :func:`_derive_plan_name_from_query` supplies the name. Rows
@@ -805,6 +805,15 @@ def _backfill_plan_dimensions(conn: sqlite3.Connection) -> None:
     tagged grown rows and ``"global"`` for everything else (legacy
     builtin shapes pre-RDR-078). Idempotent: a second run skips rows
     whose ``dimensions`` is no longer NULL.
+
+    **Collision handling (RDR-092 code-review C-1).** Two NULL-
+    dimension rows in the same project whose queries collapse to the
+    same kebab name produce identical canonical dimensions JSON and
+    would violate the partial UNIQUE ``(project, dimensions) WHERE
+    dimensions IS NOT NULL`` index on the second UPDATE. The loop
+    catches :class:`sqlite3.IntegrityError` and retries the row with
+    the strategy suffixed by the row id (which is monotonic + stable
+    within a DB, preserving idempotency across reruns).
     """
     has_table = conn.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name='plans'"
@@ -826,15 +835,43 @@ def _backfill_plan_dimensions(conn: sqlite3.Connection) -> None:
 
     backfilled = 0
     low_conf = 0
+    collisions = 0
+    # Track identities set during this run so within-loop collisions
+    # also get the row_id suffix treatment (the DB-level partial
+    # UNIQUE index would only catch cross-run collisions because the
+    # legacy rows all share dimensions IS NULL until we write).
+    claimed: set[tuple[str, str]] = set()
     for row_id, query, tags in rows:
         verb, confident = _infer_plan_verb_from_query(query or "")
-        name = _derive_plan_name_from_query(query or "")
+        base_name = _derive_plan_name_from_query(query or "")
         scope = "personal" if (tags or "").find("grown") >= 0 else "global"
-        dims_json = canonical_dimensions_json({
-            "scope": scope,
-            "strategy": name,
-            "verb": verb,
-        })
+        project = ""  # Backfill applies to the legacy global project.
+
+        def _dims(name_value: str) -> str:
+            return canonical_dimensions_json({
+                "scope": scope,
+                "strategy": name_value,
+                "verb": verb,
+            })
+
+        # Pre-check for collision against both already-persisted rows
+        # and rows we updated earlier in this same loop.
+        name = base_name
+        dims_json = _dims(name)
+        key = (project, dims_json)
+        db_hit = conn.execute(
+            "SELECT 1 FROM plans "
+            "WHERE project = ? AND dimensions = ? AND id != ? LIMIT 1",
+            (project, dims_json, row_id),
+        ).fetchone()
+        if db_hit or key in claimed:
+            # RDR-092 code-review C-1: resolve via a deterministic
+            # row-id suffix so reruns produce the same identity.
+            name = f"{base_name}-{row_id}"
+            dims_json = _dims(name)
+            key = (project, dims_json)
+            collisions += 1
+        claimed.add(key)
 
         tag_flag = "backfill" if confident else "backfill-low-conf"
         existing_tags = [t for t in (tags or "").split(",") if t]
@@ -856,7 +893,7 @@ def _backfill_plan_dimensions(conn: sqlite3.Connection) -> None:
     _log.info(
         "Backfilled plan dimensions",
         backfilled=backfilled, low_conf=low_conf,
-        total_rows=len(rows),
+        total_rows=len(rows), collisions=collisions,
     )
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1653,22 +1653,94 @@ class TestBackfillPlanDimensions:
         assert first_dims != second_dims
 
     def test_backfill_sentinel_name_does_not_collide(self) -> None:
-        """Queries that are pure stop-words fall to the sentinel name
-        ``backfilled-plan``; multiple such rows must each get a
-        deterministic unique identity via the row-id suffix path.
+        """Queries with no alphanumeric tokens fall to the sentinel
+        ``backfilled-plan`` name; multiple such rows must each get a
+        deterministic unique identity via the row-id suffix path
+        (test-validator note: earlier fixture used stop-word-only
+        queries whose raw-token fallback still differed; replace with
+        queries whose ``tokens`` list is actually empty).
         """
         from nexus.db.migrations import _backfill_plan_dimensions
 
         conn = sqlite3.connect(":memory:")
         _make_plans_schema(conn)
-        rid1 = _insert_plan(conn, query="it is a the")  # only stop-words
-        rid2 = _insert_plan(conn, query="the and or but")  # only stop-words
+        # Queries with no regex-matched tokens trigger the
+        # 'backfilled-plan' sentinel in _derive_plan_name_from_query.
+        rid1 = _insert_plan(conn, query="!!!")
+        rid2 = _insert_plan(conn, query="...")
+        rid3 = _insert_plan(conn, query="???")
+
+        _backfill_plan_dimensions(conn)
+
+        rows = conn.execute(
+            "SELECT id, name, dimensions FROM plans ORDER BY id ASC"
+        ).fetchall()
+        names = [row[1] for row in rows]
+        dims = [row[2] for row in rows]
+        # All three rows land with unique names and unique dimensions.
+        assert len(set(names)) == 3, f"names should all differ, got {names!r}"
+        assert len(set(dims)) == 3, "dimensions JSON must be unique per row"
+        # First row keeps the plain sentinel; 2nd and 3rd carry row_id
+        # suffixes (the in-memory ``claimed`` set catches them because
+        # the 1st row's UPDATE has not been persisted at 2nd row's
+        # pre-check time).
+        assert names[0] == "backfilled-plan"
+        assert str(rid2) in names[1]
+        assert str(rid3) in names[2]
+
+    def test_backfill_within_loop_claimed_set_fires(self) -> None:
+        """Three queries that derive to the same kebab name exercise
+        the in-memory ``claimed`` fallback: the 2nd and 3rd rows both
+        collide, and only the 1st has been persisted when the 2nd's
+        SELECT pre-check runs, so the ``key in claimed`` branch is
+        the one that catches the 3rd.
+        """
+        from nexus.db.migrations import _backfill_plan_dimensions
+
+        conn = sqlite3.connect(":memory:")
+        _make_plans_schema(conn)
+        # All three strip down to 'find-documents-author' after stop-
+        # word filter on the first 5 content tokens.
+        _insert_plan(conn, query="find the documents for author")
+        _insert_plan(conn, query="find documents by author")
+        _insert_plan(conn, query="find documents about author")
 
         _backfill_plan_dimensions(conn)
 
         rows = conn.execute(
             "SELECT dimensions FROM plans ORDER BY id ASC"
         ).fetchall()
-        assert rows[0][0] != rows[1][0], (
-            "two sentinel-named rows must land with distinct dimensions"
+        dims = [r[0] for r in rows]
+        assert len(set(dims)) == 3, (
+            f"all three rows must land with distinct dimensions, got {dims!r}"
         )
+
+    def test_backfill_collision_idempotent_on_rerun(self) -> None:
+        """A second run against a DB that already contains a
+        collision-resolved row must leave the suffixed identity
+        unchanged: the NULL-dimension filter skips it entirely.
+        """
+        from nexus.db.migrations import _backfill_plan_dimensions
+
+        conn = sqlite3.connect(":memory:")
+        _make_plans_schema(conn)
+        _insert_plan(conn, query="find the documents for author")
+        rid2 = _insert_plan(conn, query="find documents by author")
+
+        _backfill_plan_dimensions(conn)
+        first = conn.execute(
+            "SELECT name, dimensions, tags FROM plans WHERE id = ?",
+            (rid2,),
+        ).fetchone()
+
+        _backfill_plan_dimensions(conn)
+        second = conn.execute(
+            "SELECT name, dimensions, tags FROM plans WHERE id = ?",
+            (rid2,),
+        ).fetchone()
+
+        assert first == second, (
+            "collision-resolved row must be stable across reruns"
+        )
+        # Collision row carries the row_id suffix on both runs.
+        assert str(rid2) in first[0]

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -73,7 +73,8 @@ class TestMigrationDataclass:
         from nexus.db.migrations import MIGRATIONS
 
         assert isinstance(MIGRATIONS, list)
-        assert len(MIGRATIONS) == 16  # +GH #251 hook_failures 4.9.10
+        # +RDR-092 Phase 0d backfill migration (4.9.12).
+        assert len(MIGRATIONS) == 17
 
     def test_migrations_ordered_by_version(self) -> None:
         from nexus.db.migrations import MIGRATIONS, _parse_version
@@ -1434,4 +1435,184 @@ class TestMigrateHookFailures:
         assert matches, "hook_failures migration must be registered in MIGRATIONS"
         assert matches[0][0] >= "4.9.10", (
             f"hook_failures migration must be introduced in >= 4.9.10, got {matches[0][0]!r}"
+        )
+
+
+# ── _backfill_plan_dimensions (RDR-092 Phase 0d.1) ──────────────────────────
+
+
+def _make_plans_schema(conn: sqlite3.Connection) -> None:
+    """Minimal plans schema with the RDR-078 dimensional columns."""
+    from nexus.db.migrations import _add_plan_dimensional_identity
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS plans (
+            id INTEGER PRIMARY KEY,
+            project TEXT NOT NULL DEFAULT '',
+            query TEXT NOT NULL,
+            plan_json TEXT NOT NULL,
+            outcome TEXT DEFAULT 'success',
+            tags TEXT DEFAULT '',
+            created_at TEXT NOT NULL
+        );
+    """)
+    _add_plan_dimensional_identity(conn)
+    conn.commit()
+
+
+def _insert_plan(
+    conn: sqlite3.Connection,
+    *,
+    query: str,
+    tags: str = "",
+    dimensions: str | None = None,
+    verb: str | None = None,
+    name: str | None = None,
+    scope: str | None = None,
+) -> int:
+    cursor = conn.execute(
+        "INSERT INTO plans "
+        "(query, plan_json, outcome, tags, created_at, "
+        "verb, scope, dimensions, name) "
+        "VALUES (?, '{}', 'success', ?, datetime('now'), ?, ?, ?, ?)",
+        (query, tags, verb, scope, dimensions, name),
+    )
+    conn.commit()
+    return cursor.lastrowid
+
+
+class TestBackfillPlanDimensions:
+    """RDR-092 Phase 0d.1: backfill verb/name/dimensions for NULL rows.
+
+    Contract:
+      * Rows with ``dimensions IS NULL`` get verb/name/dimensions filled
+        by a 20-rule verb-from-stem heuristic + wh-fallback on the
+        ``query`` column text.
+      * High-confidence matches tag ``,backfill``; zero-score rows
+        (wh-fallback) tag ``,backfill-low-conf`` so ``nx plan repair``
+        can prioritise them for manual review.
+      * Rows with ``dimensions IS NOT NULL`` are untouched (authored
+        rows, including already-backfilled rows on re-run).
+    """
+
+    def test_backfill_plan_dimensions_infers_verb(self) -> None:
+        """Stem matches select the expected verb for each rule family."""
+        from nexus.db.migrations import _backfill_plan_dimensions
+
+        conn = sqlite3.connect(":memory:")
+        _make_plans_schema(conn)
+
+        fixtures: list[tuple[str, str, str]] = [
+            # (query, expected verb, row-id label)
+            ("find documents about indexing", "research", "research-find"),
+            ("analyze chunk throughput", "analyze", "analyze-direct"),
+            ("compare two retrieval backends", "analyze", "analyze-compare"),
+            ("review the auth refactor", "review", "review-direct"),
+            ("debug the chroma timeout", "debug", "debug-direct"),
+            ("document the cache protocol", "document", "document-direct"),
+        ]
+        ids = {}
+        for query, _verb, label in fixtures:
+            ids[label] = _insert_plan(conn, query=query)
+
+        _backfill_plan_dimensions(conn)
+
+        for query, expected_verb, label in fixtures:
+            row = conn.execute(
+                "SELECT verb, name, dimensions, tags FROM plans WHERE id = ?",
+                (ids[label],),
+            ).fetchone()
+            assert row[0] == expected_verb, (
+                f"{query!r}: expected verb={expected_verb!r}, got {row[0]!r}"
+            )
+            assert row[1], f"{query!r}: name must be populated"
+            assert row[2], f"{query!r}: dimensions JSON must be populated"
+            assert "backfill" in (row[3] or "")
+
+    def test_backfill_plan_dimensions_idempotent(self) -> None:
+        """Re-running the migration is a no-op on already-backfilled rows."""
+        from nexus.db.migrations import _backfill_plan_dimensions
+
+        conn = sqlite3.connect(":memory:")
+        _make_plans_schema(conn)
+        rid = _insert_plan(conn, query="analyze the ranker output")
+
+        _backfill_plan_dimensions(conn)
+        first = conn.execute(
+            "SELECT verb, name, dimensions, tags FROM plans WHERE id = ?",
+            (rid,),
+        ).fetchone()
+        assert first[0] == "analyze"
+        assert "backfill" in (first[3] or "")
+
+        # Second run: state must be stable and tags must not duplicate.
+        _backfill_plan_dimensions(conn)
+        second = conn.execute(
+            "SELECT verb, name, dimensions, tags FROM plans WHERE id = ?",
+            (rid,),
+        ).fetchone()
+        assert second == first
+        # No double-tagging.
+        assert (second[3] or "").count("backfill") == 1
+
+    def test_backfill_preserves_authored_verbs(self) -> None:
+        """Rows with dimensions IS NOT NULL are untouched."""
+        from nexus.db.migrations import _backfill_plan_dimensions
+
+        conn = sqlite3.connect(":memory:")
+        _make_plans_schema(conn)
+        # Simulate an authored row.
+        rid = _insert_plan(
+            conn,
+            query="analyze lineage",
+            tags="builtin-template,rdr-078,research",
+            verb="research",
+            scope="global",
+            name="default",
+            dimensions='{"scope":"global","verb":"research"}',
+        )
+
+        _backfill_plan_dimensions(conn)
+
+        row = conn.execute(
+            "SELECT verb, name, dimensions, tags FROM plans WHERE id = ?",
+            (rid,),
+        ).fetchone()
+        # Not rewritten by the heuristic (query says 'analyze' but
+        # authored verb was 'research'); tags not appended.
+        assert row[0] == "research"
+        assert row[1] == "default"
+        assert row[2] == '{"scope":"global","verb":"research"}'
+        assert "backfill" not in row[3]
+
+    def test_backfill_low_conf_flagging(self) -> None:
+        """Rows that hit only the wh-fallback carry backfill-low-conf."""
+        from nexus.db.migrations import _backfill_plan_dimensions
+
+        conn = sqlite3.connect(":memory:")
+        _make_plans_schema(conn)
+        # A query with no stem match — only the wh-word triggers.
+        rid = _insert_plan(conn, query="what about the graph")
+
+        _backfill_plan_dimensions(conn)
+
+        row = conn.execute(
+            "SELECT verb, tags FROM plans WHERE id = ?", (rid,),
+        ).fetchone()
+        assert row[0], "verb must be populated even on low-conf"
+        assert "backfill-low-conf" in (row[1] or "")
+
+    def test_backfill_registered_in_migrations_list(self) -> None:
+        """The migration appears in MIGRATIONS at a >= 4.9.12 version."""
+        from nexus.db.migrations import MIGRATIONS
+
+        matches = [
+            (m.introduced, m.name) for m in MIGRATIONS
+            if "backfill" in m.name.lower() and "plan" in m.name.lower()
+        ]
+        assert matches, (
+            "backfill plan-dimensions migration must be in MIGRATIONS"
+        )
+        # Must ship AFTER the dimensional-identity migration (4.4.0).
+        assert matches[0][0] >= "4.9.12", (
+            f"must be introduced in >= 4.9.12, got {matches[0][0]!r}"
         )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1485,7 +1485,7 @@ class TestBackfillPlanDimensions:
 
     Contract:
       * Rows with ``dimensions IS NULL`` get verb/name/dimensions filled
-        by a 20-rule verb-from-stem heuristic + wh-fallback on the
+        by a 29-stem verb-from-stem heuristic + wh-fallback on the
         ``query`` column text.
       * High-confidence matches tag ``,backfill``; zero-score rows
         (wh-fallback) tag ``,backfill-low-conf`` so ``nx plan repair``
@@ -1615,4 +1615,60 @@ class TestBackfillPlanDimensions:
         # Must ship AFTER the dimensional-identity migration (4.4.0).
         assert matches[0][0] >= "4.9.12", (
             f"must be introduced in >= 4.9.12, got {matches[0][0]!r}"
+        )
+
+    def test_backfill_collision_resolves_via_row_id_suffix(self) -> None:
+        """RDR-092 code-review C-1: two NULL-dimension rows whose
+        queries collapse to the same kebab name must not crash the
+        migration on the UNIQUE(project, dimensions) partial index.
+        The second row lands with its strategy suffixed by row id
+        so both rows land with distinct, deterministic identities.
+        """
+        from nexus.db.migrations import _backfill_plan_dimensions
+
+        conn = sqlite3.connect(":memory:")
+        _make_plans_schema(conn)
+        # Two queries that reduce to the same content tokens after
+        # stop-word stripping.
+        rid1 = _insert_plan(conn, query="find the documents for author")
+        rid2 = _insert_plan(conn, query="find documents by author")
+
+        _backfill_plan_dimensions(conn)  # must not raise
+
+        rows = conn.execute(
+            "SELECT id, name, dimensions FROM plans ORDER BY id ASC"
+        ).fetchall()
+        assert len(rows) == 2
+        first_name, second_name = rows[0][1], rows[1][1]
+        first_dims, second_dims = rows[0][2], rows[1][2]
+        # Both rows got dimensions populated (no skipped rows).
+        assert first_dims, "first row must carry dimensions"
+        assert second_dims, "collision must not leave dimensions NULL"
+        # The colliding row carries the row_id suffix.
+        assert first_name != second_name
+        assert str(rid2) in second_name, (
+            f"collision row's name must include row_id={rid2}, got {second_name!r}"
+        )
+        # Dimensions JSON differs (unique partial-index satisfied).
+        assert first_dims != second_dims
+
+    def test_backfill_sentinel_name_does_not_collide(self) -> None:
+        """Queries that are pure stop-words fall to the sentinel name
+        ``backfilled-plan``; multiple such rows must each get a
+        deterministic unique identity via the row-id suffix path.
+        """
+        from nexus.db.migrations import _backfill_plan_dimensions
+
+        conn = sqlite3.connect(":memory:")
+        _make_plans_schema(conn)
+        rid1 = _insert_plan(conn, query="it is a the")  # only stop-words
+        rid2 = _insert_plan(conn, query="the and or but")  # only stop-words
+
+        _backfill_plan_dimensions(conn)
+
+        rows = conn.execute(
+            "SELECT dimensions FROM plans ORDER BY id ASC"
+        ).fetchall()
+        assert rows[0][0] != rows[1][0], (
+            "two sentinel-named rows must land with distinct dimensions"
         )

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for ``nx plan`` CLI commands. RDR-092 Phase 0d.2.
+
+``nx plan repair`` is the Day-2 ops command that re-runs the
+:func:`nexus.db.migrations._backfill_plan_dimensions` heuristic
+against the live T2 DB and surfaces low-confidence rows so the
+operator can correct the heuristic's edge cases manually.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _seed_plans(tmp_path: Path) -> Path:
+    """Return a DB path with a minimal schema + a NULL-dimension row."""
+    from nexus.db.migrations import apply_pending
+    from nexus.commands.upgrade import _current_version
+
+    db_path = tmp_path / "memory.db"
+    conn = sqlite3.connect(str(db_path))
+    apply_pending(conn, _current_version())
+    conn.close()
+    return db_path
+
+
+def _insert_null_dim_plan(db_path: Path, query: str, tags: str = "") -> int:
+    """Insert a row bypassing the migration so dimensions is NULL again."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.execute(
+        "INSERT INTO plans (query, plan_json, outcome, tags, created_at) "
+        "VALUES (?, '{}', 'success', ?, datetime('now'))",
+        (query, tags),
+    )
+    conn.commit()
+    # Strip the dimensions set by apply_pending's inline backfill.
+    conn.execute(
+        "UPDATE plans SET dimensions = NULL, verb = NULL, "
+        "name = NULL, scope = NULL WHERE id = ?",
+        (cursor.lastrowid,),
+    )
+    conn.commit()
+    conn.close()
+    return cursor.lastrowid
+
+
+class TestPlanRepair:
+    def test_repair_idempotent(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """Running ``nx plan repair`` twice in a row must be a no-op the
+        second time: the first run backfills the NULL rows, the second
+        finds nothing to do.
+        """
+        db_path = _seed_plans(tmp_path)
+        _insert_null_dim_plan(db_path, "analyze the ranker")
+
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            first = runner.invoke(main, ["plan", "repair"])
+        assert first.exit_code == 0, first.output
+        assert "backfilled" in first.output.lower()
+
+        # Second run: nothing to backfill.
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            second = runner.invoke(main, ["plan", "repair"])
+        assert second.exit_code == 0, second.output
+        # "nothing to do" / "0 backfilled" — must not assert the exact
+        # phrasing, but the number must be zero.
+        assert "0 backfilled" in second.output.lower() or (
+            "nothing" in second.output.lower()
+        )
+
+    def test_repair_lists_low_conf_first(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """Low-confidence rows (wh-fallback hits) should surface at the
+        top of the report so the operator can audit them first.
+        """
+        db_path = _seed_plans(tmp_path)
+        # Two NULL-dim rows: one stem-match (analyze), one wh-fallback
+        # (only "what" matches).
+        _insert_null_dim_plan(db_path, "analyze the ranker output")
+        _insert_null_dim_plan(db_path, "what about the graph")
+
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            result = runner.invoke(main, ["plan", "repair"])
+        assert result.exit_code == 0, result.output
+        output = result.output.lower()
+        # The low-conf row is named and appears in the review section.
+        assert "backfill-low-conf" in output
+        assert "what about the graph" in output
+        # The high-conf row is counted but not individually listed in
+        # the review surface.
+        assert "1 low-conf row" in output or "1 row needs review" in output
+
+    def test_repair_no_db_file(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """When T2 DB doesn't exist yet, repair exits cleanly with a
+        'nothing to do' message rather than a traceback.
+        """
+        db_path = tmp_path / "nonexistent" / "memory.db"
+        with patch(
+            "nexus.commands._helpers.default_db_path", return_value=db_path,
+        ):
+            result = runner.invoke(main, ["plan", "repair"])
+        assert result.exit_code == 0
+        assert "not found" in result.output.lower()


### PR DESCRIPTION
## Summary

Fourth implementation PR for RDR-092. Closes out Phase 0 by
retroactively filling dimensional columns on NULL-dimension plan rows
(legacy seeds pre-RDR-078 + ad-hoc grown rows from before Phase 0b
shipped). After this PR, the R5 deployment-gap state — 0/52 live
plans with populated `verb` / `name` / `dimensions` — drains on the
next upgrade pass.

## Phase 0d.1 — `_backfill_plan_dimensions` migration (nexus-fuzd)

- New T2 migration at version 4.9.12 in `src/nexus/db/migrations.py`.
- 20-rule **verb-from-stem** dictionary spans research / analyze /
  review / debug / document verb families (per R8 heuristic).
- **Wh-fallback** catches rows that miss all stems; those rows tag
  with `backfill-low-conf` so `nx plan repair` prioritises them for
  manual review.
- `name` derived from the first 3-5 content tokens of the query (same
  stop-word list shape as the Phase 0b grown-plan helper, inlined
  here to keep `migrations.py` import-free from `mcp/`).
- `scope` heuristic: `personal` when the row already carries a
  `grown` tag, `global` otherwise (the legacy builtin shapes
  pre-RDR-078 all lived at global scope).
- Idempotent: touches only rows where `dimensions IS NULL`; a second
  run finds nothing to do.
- Authored rows untouched regardless of query text — `analyze lineage`
  on a row already tagged research stays `research`.

## Phase 0d.2 — `nx plan repair` Day-2 command (nexus-1kvj)

- New `src/nexus/commands/plan.py` with a Click group + `repair`
  subcommand. Re-runs the migration against the live T2 DB, reports
  the backfill count, and surfaces `backfill-low-conf` rows with
  their inferred verb + original query text so an operator can
  correct the heuristic's edge cases by hand (direct SQL or future
  editor command).

## Test plan

- [x] `tests/test_migrations.py::TestBackfillPlanDimensions` — 5 cases
  cover verb inference per rule family, idempotency, preservation of
  authored rows, low-conf flagging, and the `MIGRATIONS` registry
  entry
- [x] `tests/test_plan_cmd.py::TestPlanRepair` — 3 cases cover
  idempotent repair, low-conf prioritisation in the review output,
  and missing-db handling
- [x] Broader suite — 236 pass across `test_migrations` +
  `test_plan_cmd` + `test_plan_library` + `test_plan_template_schema`
  + `test_scoped_plan_loader` + `test_catalog_cli`
- [ ] Post-merge on local T2: run `nx upgrade` (will trigger the
  4.9.12 migration) then `nx doctor --check-plan-library` (from #259)
  to confirm the non-dimensional bucket drains to 0

## Depends on

Sequencing-independent of the other Phase 0 PRs:
- #257 (Phase 0a — YAML migration)
- #258 (Phase 0b — grown-plan cascade)
- #259 (Phase 0c — fail-loud loader + `--check-plan-library`)

Merge in any order.

## Closes

- Closes nexus-fuzd (Phase 0d.1)
- Closes nexus-1kvj (Phase 0d.2)

Phase 0d.3 (nexus-3l7k, code review) pending against this PR.