### PR TITLE
RDR-092 Phase 2: per-call min_confidence override (Option A)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -2121,9 +2121,9 @@ async def nx_answer(
             :data:`_PLAN_MATCH_MIN_CONFIDENCE` (0.40, per RDR-079 P5).
             Verb skills that have validated a stricter precision-first
             floor (0.50 per R9 against a 5+5 probe corpus) pin the
-            tighter value per-call without moving the global knob —
-            the global default waits on Phase 5's larger-corpus
-            validation.
+            tighter value per-call without moving the global knob; the
+            global default waits on Phase 5's larger-corpus
+            validation. Must be in ``[0.0, 1.0]`` when supplied.
 
     Returns:
         The final step's output — a string by default, or the envelope
@@ -2154,7 +2154,14 @@ async def nx_answer(
 
     # ── Step 1: plan-match gate ──────────────────────────────────────────
     # RDR-092 Phase 2 Option A: effective floor is the caller's override
-    # when supplied, otherwise the RDR-079 P5 default (0.40).
+    # when supplied, otherwise the RDR-079 P5 default (0.40). Bounds-
+    # check the override so an agent caller passing a degenerate value
+    # fails loudly (code-review S-4) instead of silently admitting
+    # every match (negative) or rejecting every cosine match (> 1.0).
+    if min_confidence is not None and not (0.0 <= min_confidence <= 1.0):
+        return _result(
+            f"min_confidence must be in [0.0, 1.0], got {min_confidence!r}"
+        )
     effective_min_confidence = (
         min_confidence if min_confidence is not None
         else _PLAN_MATCH_MIN_CONFIDENCE

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1849,15 +1849,21 @@ Pattern B (operator auto-hydration shortcut):
 """
 
 
-def _nx_answer_match_is_hit(confidence: float | None) -> bool:
+def _nx_answer_match_is_hit(
+    confidence: float | None,
+    threshold: float = _PLAN_MATCH_MIN_CONFIDENCE,
+) -> bool:
     """Return True when a plan_match confidence qualifies as a hit.
 
     ``confidence is None`` (FTS5 sentinel, RF-11) is always a hit.
-    Numeric confidence must be >= 0.40 (RDR-079 P5 calibration).
+    Numeric confidence must be >= *threshold*. RDR-092 Phase 2 Option A
+    makes the threshold caller-overridable: the default tracks the
+    RDR-079 P5 calibration (0.40), and verb skills that have validated
+    a stricter floor (0.50 per R9) can pin it per-call.
     """
     if confidence is None:
         return True
-    return confidence >= _PLAN_MATCH_MIN_CONFIDENCE
+    return confidence >= threshold
 
 
 def _nx_answer_classify_plan(match: Any) -> str:
@@ -2076,6 +2082,7 @@ async def nx_answer(
     trace: bool = True,
     dimensions: dict[str, Any] | None = None,
     structured: bool = False,
+    min_confidence: float | None = None,
 ) -> "str | dict":
     """Answer a knowledge question using plan-match-first retrieval. RDR-080 P1.
 
@@ -2109,6 +2116,14 @@ async def nx_answer(
             without a second fetch. The single-step guard path produces
             the same envelope shape — the guard logic itself is unchanged.
             On pure-generate plans or retrieval misses, ``chunks`` is ``[]``.
+        min_confidence: Per-call plan-match floor override (RDR-092 Phase
+            2 Option A). ``None`` (default) uses the global
+            :data:`_PLAN_MATCH_MIN_CONFIDENCE` (0.40, per RDR-079 P5).
+            Verb skills that have validated a stricter precision-first
+            floor (0.50 per R9 against a 5+5 probe corpus) pin the
+            tighter value per-call without moving the global knob —
+            the global default waits on Phase 5's larger-corpus
+            validation.
 
     Returns:
         The final step's output — a string by default, or the envelope
@@ -2138,6 +2153,12 @@ async def nx_answer(
         }
 
     # ── Step 1: plan-match gate ──────────────────────────────────────────
+    # RDR-092 Phase 2 Option A: effective floor is the caller's override
+    # when supplied, otherwise the RDR-079 P5 default (0.40).
+    effective_min_confidence = (
+        min_confidence if min_confidence is not None
+        else _PLAN_MATCH_MIN_CONFIDENCE
+    )
     try:
         with _t2_ctx() as db:
             cache = get_t1_plan_cache(populate_from=db.plans)
@@ -2148,13 +2169,15 @@ async def nx_answer(
                 dimensions=dimensions,
                 scope_preference=scope,
                 context={"user_context": context} if context else None,
-                min_confidence=_PLAN_MATCH_MIN_CONFIDENCE,
+                min_confidence=effective_min_confidence,
                 n=5,
             )
     except Exception as exc:
         return _result(f"Error during plan match: {exc}")
 
-    if not matches or not _nx_answer_match_is_hit(matches[0].confidence):
+    if not matches or not _nx_answer_match_is_hit(
+        matches[0].confidence, threshold=effective_min_confidence,
+    ):
         # Plan miss — inline LLM planner via claude_dispatch.
         _log.info(
             "nx_answer_plan_miss",

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -136,6 +136,102 @@ class TestPlanMatchGate:
         assert _nx_answer_match_is_hit(0.0) is False
 
 
+# ── min_confidence override (RDR-092 Phase 2, Option A) ──────────────────────
+
+
+class TestMinConfidenceOverride:
+    """Per-call ``min_confidence`` override on ``nx_answer`` / the hit
+    helper. RDR-092 Phase 2 Option A: the global
+    ``_PLAN_MATCH_MIN_CONFIDENCE`` stays at 0.40 (RDR-079 calibration);
+    verb skills that validated a stricter floor (0.50 per R9) opt in
+    by passing it explicitly.
+    """
+
+    def test_hit_helper_accepts_threshold_arg(self):
+        from nexus.mcp.core import _nx_answer_match_is_hit
+        # Default threshold unchanged (0.40).
+        assert _nx_answer_match_is_hit(0.40) is True
+        assert _nx_answer_match_is_hit(0.45) is True
+        # Caller can pin 0.50.
+        assert _nx_answer_match_is_hit(0.45, threshold=0.50) is False
+        assert _nx_answer_match_is_hit(0.50, threshold=0.50) is True
+
+    def test_fts5_sentinel_ignores_threshold(self):
+        from nexus.mcp.core import _nx_answer_match_is_hit
+        # ``None`` sentinel is a hit at any threshold (RF-11).
+        assert _nx_answer_match_is_hit(None, threshold=0.99) is True
+
+    @pytest.mark.asyncio
+    async def test_nx_answer_accepts_min_confidence_kwarg(self):
+        """Override flows into plan_match *and* governs the hit check."""
+        from nexus.mcp.core import nx_answer
+
+        captured: dict = {}
+
+        def fake_match(question, **kwargs):
+            captured.update(kwargs)
+            # Return a confidence just above 0.40 but below the caller's
+            # override — the hit check must reject it and the planner
+            # miss path must kick in.
+            return [_make_match(plan_id=1, confidence=0.45)]
+
+        async def fake_miss(question, scope="", max_steps=6):
+            return _make_match(plan_id=0, confidence=None)
+
+        plan_run_result = MagicMock()
+        plan_run_result.steps = [{"text": "ok"}]
+
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = MagicMock(return_value=1)
+        db_stub.plans.get_plan = MagicMock(return_value={"id": 1})
+
+        with patch("nexus.plans.matcher.plan_match", side_effect=fake_match), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(side_effect=fake_miss)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=plan_run_result)), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(question="q", min_confidence=0.50)
+
+        # plan_match saw the caller-supplied floor.
+        assert captured.get("min_confidence") == 0.50
+
+    @pytest.mark.asyncio
+    async def test_nx_answer_default_threshold_unchanged(self):
+        """With no override, the 0.40 floor still matches RDR-079."""
+        from nexus.mcp.core import nx_answer, _PLAN_MATCH_MIN_CONFIDENCE
+
+        assert _PLAN_MATCH_MIN_CONFIDENCE == 0.40
+
+        captured: dict = {}
+
+        def fake_match(question, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        async def fake_miss(question, scope="", max_steps=6):
+            return _make_match(plan_id=0, confidence=None)
+
+        plan_run_result = MagicMock()
+        plan_run_result.steps = [{"text": "ok"}]
+
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = MagicMock(return_value=1)
+        db_stub.plans.get_plan = MagicMock(return_value={"id": 1})
+
+        with patch("nexus.plans.matcher.plan_match", side_effect=fake_match), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(side_effect=fake_miss)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=plan_run_result)), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(question="q")
+
+        assert captured.get("min_confidence") == 0.40
+
+
 # ── Single-step guard ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -231,6 +231,76 @@ class TestMinConfidenceOverride:
 
         assert captured.get("min_confidence") == 0.40
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_value", [-0.01, -1.0, 1.01, 2.0])
+    async def test_nx_answer_rejects_out_of_range_min_confidence(
+        self, bad_value: float,
+    ):
+        """RDR-092 code-review S-4: values outside [0, 1] must fail
+        loudly rather than silently admitting (negative) or rejecting
+        (> 1.0) every match.
+        """
+        from nexus.mcp.core import nx_answer
+
+        match_called = MagicMock()
+
+        def fake_match(question, **kwargs):
+            match_called()
+            return []
+
+        with patch("nexus.plans.matcher.plan_match", side_effect=fake_match), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = MagicMock()
+            result = await nx_answer(
+                question="q", min_confidence=bad_value,
+            )
+
+        assert "min_confidence must be in [0.0, 1.0]" in result
+        assert str(bad_value) in result
+        assert not match_called.called, (
+            "plan_match must never be reached with an invalid floor"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("ok_value", [0.0, 0.25, 0.5, 1.0])
+    async def test_nx_answer_accepts_boundary_min_confidence(
+        self, ok_value: float,
+    ):
+        """The validator accepts both endpoints (0.0 and 1.0) plus
+        anything in between so verb skills can pin the most permissive
+        and most restrictive floors without hitting the guard.
+        """
+        from nexus.mcp.core import nx_answer
+
+        captured: dict = {}
+
+        def fake_match(question, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        async def fake_miss(question, scope="", max_steps=6):
+            return _make_match(plan_id=0, confidence=None)
+
+        plan_run_result = MagicMock()
+        plan_run_result.steps = [{"text": "ok"}]
+
+        db_stub = MagicMock()
+        db_stub.plans.save_plan = MagicMock(return_value=1)
+        db_stub.plans.get_plan = MagicMock(return_value={"id": 1})
+
+        with patch("nexus.plans.matcher.plan_match", side_effect=fake_match), \
+             patch("nexus.mcp.core._nx_answer_plan_miss", AsyncMock(side_effect=fake_miss)), \
+             patch("nexus.plans.runner.plan_run", AsyncMock(return_value=plan_run_result)), \
+             patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+             patch("nexus.mcp.core.scratch", return_value="ok"), \
+             patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+            t2_ctx.return_value.__enter__.return_value = db_stub
+            await nx_answer(question="q", min_confidence=ok_value)
+
+        assert captured.get("min_confidence") == ok_value
+
 
 # ── Single-step guard ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Phase 2 of RDR-092, **Option A** (per-call override, keep global
0.40). Adds an optional `min_confidence` kwarg to `nx_answer` so
verb skills that have validated a stricter floor (0.50 per R9) can
opt in without moving the global knob.

## Why Option A

R9 measured `min_confidence = 0.50` as the sweet spot against a 5+5
probe corpus (100% legit recall + 100% noise reject). Sample size is
small, so raising `_PLAN_MATCH_MIN_CONFIDENCE` globally would gamble
production traffic on a population of one experiment.

Option A is additive and reversible.

## Test plan

- [x] `tests/test_nx_answer.py::TestMinConfidenceOverride` — 4 new cases
- [x] `tests/test_nx_answer.py::TestPlanMatchGate` — 5 RDR-079 tests untouched
- [x] 136 pass across nx_answer / rdr_084_plan_grow / plan_match / plan_run

## Closes

- Closes nexus-1jxp (Phase 2.1)