### PR TITLE
RDR-092 Phase 1: hybrid match-text synthesis for T1 plan cache

### DIFF
--- a/src/nexus/plans/session_cache.py
+++ b/src/nexus/plans/session_cache.py
@@ -210,7 +210,7 @@ def _synthesize_match_text(row: dict[str, Any]) -> str:
     optional and only appended when present.
 
     When verb or name is missing, falls back to the raw description
-    — legacy NULL-dimension rows still embed cleanly rather than
+    so legacy NULL-dimension rows still embed cleanly rather than
     losing all signal to an empty suffix. R10 validates the hybrid
     form: zero verb-accuracy regression vs raw-description, plus the
     dimensional suffix gives the matcher a reliable verb hook.

--- a/src/nexus/plans/session_cache.py
+++ b/src/nexus/plans/session_cache.py
@@ -30,7 +30,7 @@ import structlog
 from nexus.db.local_ef import LocalEmbeddingFunction
 from nexus.db.t2.plan_library import PlanLibrary
 
-__all__ = ["PlanSessionCache", "PLANS_COLLECTION"]
+__all__ = ["PlanSessionCache", "PLANS_COLLECTION", "_synthesize_match_text"]
 
 _log = structlog.get_logger(__name__)
 
@@ -175,8 +175,8 @@ class PlanSessionCache:
             return False
 
     def _upsert_row(self, row: dict[str, Any]) -> bool:
-        description = (row.get("query") or "").strip()
-        if not description:
+        match_text = _synthesize_match_text(row)
+        if not match_text:
             return False
         plan_id = row.get("id")
         if plan_id is None:
@@ -192,10 +192,43 @@ class PlanSessionCache:
         }
         try:
             self._col.upsert(
-                ids=[doc_id], documents=[description], metadatas=[meta],
+                ids=[doc_id], documents=[match_text], metadatas=[meta],
             )
         except Exception:
             _log.warning("plan_session_cache_upsert_failed",
                          plan_id=plan_id, exc_info=True)
             return False
         return True
+
+
+def _synthesize_match_text(row: dict[str, Any]) -> str:
+    """Hybrid description + dimensional suffix for T1 embedding. RDR-092 Phase 1.
+
+    Shape: ``"<description>. <verb> <name> scope <scope>"`` when the
+    row carries verb AND name (the identity signal the cosine lane
+    needs to differentiate otherwise-similar descriptions). Scope is
+    optional and only appended when present.
+
+    When verb or name is missing, falls back to the raw description
+    — legacy NULL-dimension rows still embed cleanly rather than
+    losing all signal to an empty suffix. R10 validates the hybrid
+    form: zero verb-accuracy regression vs raw-description, plus the
+    dimensional suffix gives the matcher a reliable verb hook.
+    """
+    description = (row.get("query") or "").strip()
+    verb = (row.get("verb") or "").strip()
+    name = (row.get("name") or "").strip()
+    scope = (row.get("scope") or "").strip()
+
+    if not verb or not name:
+        return description
+
+    suffix = f"{verb} {name}"
+    if scope:
+        suffix += f" scope {scope}"
+    if description:
+        # Collapse an existing trailing '.' so descriptions that already
+        # end with punctuation do not produce '..' in the match text.
+        core = description.rstrip(".").rstrip()
+        return f"{core}. {suffix}"
+    return suffix

--- a/tests/test_plan_session_cache_match_text.py
+++ b/tests/test_plan_session_cache_match_text.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for RDR-092 Phase 1 match-text synthesis in PlanSessionCache.
+
+The T1 plan cache now embeds a hybrid ``match_text`` shape instead of
+the raw ``query`` column, so the cosine lane benefits from the same
+dimensional signal the FTS lane gets (R10). Shape:
+
+    <description>. <verb> <name> scope <scope>
+
+When any of ``verb``, ``name``, ``scope`` is absent the synthesiser
+falls back to the raw description — a legacy NULL-dimension row still
+embeds cleanly.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import chromadb
+import pytest
+
+from nexus.plans.session_cache import (
+    PlanSessionCache,
+    _synthesize_match_text,
+)
+
+
+# ── Synthesiser unit tests ──────────────────────────────────────────────────
+
+
+class TestSynthesizeMatchText:
+    def test_full_dimensional_row_hybrid_form(self) -> None:
+        row = {
+            "query": "Find documents attributed to a specific author.",
+            "verb": "research",
+            "name": "find-by-author",
+            "scope": "global",
+        }
+        out = _synthesize_match_text(row)
+        assert out == (
+            "Find documents attributed to a specific author. "
+            "research find-by-author scope global"
+        )
+
+    def test_missing_verb_falls_back_to_description(self) -> None:
+        row = {
+            "query": "Legacy plan with no dimensions",
+            "verb": None,
+            "name": "find-by-author",
+            "scope": "global",
+        }
+        assert _synthesize_match_text(row) == "Legacy plan with no dimensions"
+
+    def test_missing_name_falls_back_to_description(self) -> None:
+        row = {
+            "query": "Legacy plan",
+            "verb": "research",
+            "name": None,
+            "scope": "global",
+        }
+        assert _synthesize_match_text(row) == "Legacy plan"
+
+    def test_missing_scope_still_synthesises_verb_and_name(self) -> None:
+        """Scope-less rows retain the verb+name suffix; scope is optional."""
+        row = {
+            "query": "Some plan",
+            "verb": "analyze",
+            "name": "default",
+            "scope": None,
+        }
+        assert _synthesize_match_text(row) == "Some plan. analyze default"
+
+    def test_empty_row_returns_empty(self) -> None:
+        assert _synthesize_match_text({}) == ""
+
+    def test_whitespace_only_description_with_dimensions(self) -> None:
+        """Description is stripped; dimensional suffix still ships."""
+        row = {
+            "query": "   ",
+            "verb": "research",
+            "name": "default",
+            "scope": "global",
+        }
+        assert _synthesize_match_text(row) == "research default scope global"
+
+
+# ── _upsert_row integration ─────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def cache() -> PlanSessionCache:
+    """Real EphemeralClient-backed cache (no network, no API keys)."""
+    client = chromadb.EphemeralClient()
+    return PlanSessionCache(client=client, session_id="test-session")
+
+
+class TestUpsertEmbedsMatchText:
+    """_upsert_row now embeds the synthesised match_text, not raw query."""
+
+    def test_upsert_embeds_match_text_on_dimensional_row(
+        self, cache: PlanSessionCache,
+    ) -> None:
+        """A cosine query against the dimensional suffix hits the row."""
+        cache.upsert({
+            "id": 1,
+            "query": "Find documents attributed to a specific author.",
+            "verb": "research",
+            "name": "find-by-author",
+            "scope": "global",
+            "tags": "builtin-template,rdr-092",
+            "project": "",
+        })
+        # Query that only overlaps the synthesised dimensional suffix
+        # (the description says "documents attributed", not "research
+        # find-by-author") — if match_text shipped, this still hits.
+        hits = cache.query("research find-by-author", n=3)
+        assert hits, "dimensional suffix must be part of the embedding"
+        assert hits[0][0] == 1
+
+    def test_upsert_legacy_row_still_embeds_raw_description(
+        self, cache: PlanSessionCache,
+    ) -> None:
+        """Rows missing dimensions retain their raw-description embedding."""
+        cache.upsert({
+            "id": 2,
+            "query": "legacy plan about chunk chunking pipeline",
+            "verb": None,
+            "name": None,
+            "scope": None,
+            "tags": "builtin-template",
+            "project": "",
+        })
+        hits = cache.query("chunk pipeline", n=3)
+        assert hits
+        assert hits[0][0] == 2
+
+    def test_upsert_called_with_match_text_as_document(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The Chroma ``upsert(documents=...)`` argument is the synthesised
+        match_text — a regression gate against accidentally reverting to
+        raw description.
+        """
+        client = chromadb.EphemeralClient()
+        cache = PlanSessionCache(client=client, session_id="sess")
+
+        spy = MagicMock(wraps=cache._col.upsert)
+        monkeypatch.setattr(cache._col, "upsert", spy)
+
+        cache.upsert({
+            "id": 42,
+            "query": "Analyze lineage across prose and code.",
+            "verb": "analyze",
+            "name": "default",
+            "scope": "global",
+        })
+
+        assert spy.called
+        docs = spy.call_args.kwargs.get("documents") or spy.call_args.args[1]
+        assert isinstance(docs, list) and len(docs) == 1
+        assert "analyze default scope global" in docs[0]


### PR DESCRIPTION
## Summary

Phase 1 of RDR-092. The T1 `plans__session` cache now embeds a
hybrid match-text shape instead of the raw `query` column so the
cosine lane benefits from the same dimensional signal the FTS lane
gets (RDR-078 / RDR-079).

## Shape (per R10)

    <description>. <verb> <name> scope <scope>

- description preserves all natural-language signal so verb-accuracy
  does not regress;
- the dimensional suffix adds a reliable verb / name hook the cosine
  embedding can differentiate on;
- scope is optional — emitted only when present;
- a description that already ends with `.` gets the trailing period
  stripped before the join so match-text does not carry `..`.

**Fallback.** When verb or name is missing, the synthesiser returns
the raw description — legacy NULL-dimension rows still embed cleanly
rather than losing all signal to an empty suffix. R10 validated the
hybrid form at zero verb-accuracy regression vs raw-description
baseline.

## Wiring

`_upsert_row` now calls `_synthesize_match_text(row)` and passes the
result as `documents=[match_text]` in the Chroma upsert. The metadata
dict is unchanged.

## Test plan

- [x] `tests/test_plan_session_cache_match_text.py::TestSynthesizeMatchText`
  — 6 unit cases: full hybrid, missing verb / name / scope fallbacks,
  empty-row, and whitespace-only description with populated
  dimensions
- [x] `tests/test_plan_session_cache_match_text.py::TestUpsertEmbedsMatchText`
  — 3 integration cases against a real EphemeralClient-backed cache:
  dimensional rows hit on a suffix-only probe; legacy rows still hit
  on a description-only probe; regression spy on `Chroma.upsert`
  confirms `match_text` (not raw description) is what ships.
- [x] Broader suite — 57 pass across
  `plan_session_cache_match_text` + `plan_cache_sentinel` +
  `plan_match` + `rdr_084_plan_grow`
- [ ] Post-merge on a session: run a verb-skill probe (e.g. search
  for `research find-by-author scope global` verbatim) and confirm
  the matching builtin lands at a high cosine score

## Depends on

Independent of #257 / #258 / #259 / #260 / #261. Merge in any order.

## Closes

- Closes nexus-tztf (Phase 1.1)

Phase 1.2 (nexus-mqy8, code review) pending against this PR.