### PR TITLE
RDR-092 Phase 3: match_text column + hybrid synthesis on save_plan

### DIFF
--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -707,7 +707,7 @@ def _rewash_plan_scope_tags_all_sentinel(conn: sqlite3.Connection) -> None:
         conn.commit()
 
 
-# ── RDR-092 Phase 3.1 — plans.match_text column + FTS rebuild ──────────────
+# ── RDR-092 Phase 3.1 (plans.match_text column + FTS rebuild) ──────────────
 
 
 def _add_plan_match_text_column(conn: sqlite3.Connection) -> None:

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -707,6 +707,110 @@ def _rewash_plan_scope_tags_all_sentinel(conn: sqlite3.Connection) -> None:
         conn.commit()
 
 
+# ── RDR-092 Phase 3.1 — plans.match_text column + FTS rebuild ──────────────
+
+
+def _add_plan_match_text_column(conn: sqlite3.Connection) -> None:
+    """Add ``match_text`` column to plans and rebuild ``plans_fts``.
+
+    RDR-092 Phase 3.1. The hybrid match-text synthesiser's output
+    becomes the FTS payload so the T2 FTS lane indexes the same
+    dimensional signal the T1 cosine cache embeds (R10 hybrid form).
+
+    Steps:
+      1. ``ALTER TABLE plans ADD COLUMN match_text TEXT NOT NULL
+         DEFAULT ''`` when the column is absent.
+      2. Drop the three ``plans_ai`` / ``plans_ad`` / ``plans_au``
+         triggers and the ``plans_fts`` virtual table (FTS5 does not
+         support ``ALTER COLUMN``; the only upgrade path is
+         drop+recreate).
+      3. Recreate ``plans_fts`` indexing
+         ``(match_text, tags, project)`` instead of
+         ``(query, tags, project)``.
+      4. Recreate triggers targeting ``match_text``.
+      5. Backfill existing rows: synthesise match_text from
+         ``query`` / ``verb`` / ``name`` / ``scope`` via the same
+         hybrid shape ``_synthesize_match_text`` ships with.
+      6. Rebuild the FTS index from the populated rows.
+
+    Idempotent: re-running on a DB that already has the column and
+    the new FTS shape is a no-op (the column guard short-circuits).
+    Must run AFTER :func:`_add_plan_dimensional_identity` so the
+    backfill has verb/name/scope to read.
+    """
+    has_plans = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='plans'"
+    ).fetchone()
+    if not has_plans:
+        return
+
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(plans)").fetchall()}
+    if "match_text" in cols:
+        # Already on the new schema; nothing to do.
+        return
+
+    _log.info("Adding plans.match_text column + rebuilding plans_fts")
+    conn.execute(
+        "ALTER TABLE plans ADD COLUMN match_text TEXT NOT NULL DEFAULT ''"
+    )
+
+    # Drop the legacy triggers + FTS table up-front so the backfill
+    # UPDATE below does not fan out into an external-content FTS that
+    # is about to be rebuilt anyway.
+    conn.executescript("""
+        DROP TRIGGER IF EXISTS plans_ai;
+        DROP TRIGGER IF EXISTS plans_ad;
+        DROP TRIGGER IF EXISTS plans_au;
+        DROP TABLE  IF EXISTS plans_fts;
+    """)
+
+    # Backfill existing rows from query / verb / name / scope using the
+    # same hybrid shape save_plan produces on new inserts.
+    from nexus.db.t2.plan_library import _synthesize_match_text
+
+    rows = conn.execute(
+        "SELECT id, query, verb, name, scope FROM plans"
+    ).fetchall()
+    for row_id, query, verb, name, scope in rows:
+        synthesised = _synthesize_match_text(
+            description=query, verb=verb, name=name, scope=scope,
+        )
+        conn.execute(
+            "UPDATE plans SET match_text = ? WHERE id = ?",
+            (synthesised, row_id),
+        )
+
+    # Recreate plans_fts + triggers on the populated match_text column
+    # and rebuild the FTS index from existing rows.
+    conn.executescript("""
+        CREATE VIRTUAL TABLE plans_fts USING fts5(
+            match_text, tags, project,
+            content=plans, content_rowid='id'
+        );
+
+        CREATE TRIGGER plans_ai AFTER INSERT ON plans BEGIN
+            INSERT INTO plans_fts(rowid, match_text, tags, project)
+                VALUES (new.id, new.match_text, new.tags, new.project);
+        END;
+        CREATE TRIGGER plans_ad AFTER DELETE ON plans BEGIN
+            INSERT INTO plans_fts(plans_fts, rowid, match_text, tags, project)
+                VALUES ('delete', old.id, old.match_text, old.tags, old.project);
+        END;
+        CREATE TRIGGER plans_au AFTER UPDATE ON plans BEGIN
+            INSERT INTO plans_fts(plans_fts, rowid, match_text, tags, project)
+                VALUES ('delete', old.id, old.match_text, old.tags, old.project);
+            INSERT INTO plans_fts(rowid, match_text, tags, project)
+                VALUES (new.id, new.match_text, new.tags, new.project);
+        END;
+    """)
+    conn.execute("INSERT INTO plans_fts(plans_fts) VALUES('rebuild')")
+    conn.commit()
+    _log.info(
+        "plans.match_text migration complete",
+        backfilled=len(rows),
+    )
+
+
 MIGRATIONS: list[Migration] = [
     Migration("1.10.0", "Memory FTS rebuild with title", migrate_memory_fts),
     Migration("2.8.0", "Add plan project column", migrate_plan_project),
@@ -759,6 +863,11 @@ MIGRATIONS: list[Migration] = [
         "4.9.10",
         "Add hook_failures table (GH #251)",
         migrate_hook_failures,
+    ),
+    Migration(
+        "4.9.13",
+        "Add plans.match_text column + rebuild plans_fts (RDR-092 Phase 3)",
+        _add_plan_match_text_column,
     ),
 ]
 

--- a/src/nexus/db/t2/plan_library.py
+++ b/src/nexus/db/t2/plan_library.py
@@ -171,7 +171,7 @@ def _synthesize_match_text(
     appended when present. A trailing ``.`` on *description* is
     collapsed so the output does not carry ``..``.
 
-    When verb or name is missing, returns the raw description —
+    When verb or name is missing, returns the raw description so
     legacy NULL-dimension rows still carry a usable FTS payload.
     R10 validates the hybrid form at zero verb-accuracy regression.
     """
@@ -315,7 +315,7 @@ class PlanLibrary:
         # RDR-092 Phase 3: synthesise the hybrid match_text alongside
         # the raw query so FTS5 indexes the same dimensional suffix the
         # T1 cosine cache embeds. Legacy NULL-dimension callers still
-        # get the raw query — no signal lost.
+        # get the raw query; no signal lost.
         match_text = _synthesize_match_text(
             description=query, verb=verb, name=name, scope=scope,
         )

--- a/src/nexus/db/t2/plan_library.py
+++ b/src/nexus/db/t2/plan_library.py
@@ -100,7 +100,13 @@ CREATE TABLE IF NOT EXISTS plans (
     -- hash-suffix-normalized. DEFAULT '' is load-bearing — Phase 2b
     -- treats '' as the scope-agnostic marker. Upgrade-in-place via the
     -- 4.8.0 ``_add_plan_scope_tags`` migration.
-    scope_tags      TEXT NOT NULL DEFAULT ''
+    scope_tags      TEXT NOT NULL DEFAULT '',
+    -- RDR-092 Phase 3: hybrid match_text. Fresh installs get this
+    -- column in the create; existing DBs pick it up via the 4.9.13
+    -- ``_add_plan_match_text_column`` migration (which also rebuilds
+    -- ``plans_fts`` so the FTS lane indexes match_text instead of
+    -- query).
+    match_text      TEXT NOT NULL DEFAULT ''
 );
 
 -- Indexes on the RDR-078 columns (verb/scope/dimensions) live in the
@@ -112,7 +118,7 @@ CREATE TABLE IF NOT EXISTS plans (
 -- migration that would add them has a chance to run. Issue #190.
 
 CREATE VIRTUAL TABLE IF NOT EXISTS plans_fts USING fts5(
-    query,
+    match_text,
     tags,
     project,
     content=plans,
@@ -120,18 +126,20 @@ CREATE VIRTUAL TABLE IF NOT EXISTS plans_fts USING fts5(
 );
 
 CREATE TRIGGER IF NOT EXISTS plans_ai AFTER INSERT ON plans BEGIN
-    INSERT INTO plans_fts(rowid, query, tags, project) VALUES (new.id, new.query, new.tags, new.project);
+    INSERT INTO plans_fts(rowid, match_text, tags, project)
+        VALUES (new.id, new.match_text, new.tags, new.project);
 END;
 
 CREATE TRIGGER IF NOT EXISTS plans_ad AFTER DELETE ON plans BEGIN
-    INSERT INTO plans_fts(plans_fts, rowid, query, tags, project)
-        VALUES ('delete', old.id, old.query, old.tags, old.project);
+    INSERT INTO plans_fts(plans_fts, rowid, match_text, tags, project)
+        VALUES ('delete', old.id, old.match_text, old.tags, old.project);
 END;
 
 CREATE TRIGGER IF NOT EXISTS plans_au AFTER UPDATE ON plans BEGIN
-    INSERT INTO plans_fts(plans_fts, rowid, query, tags, project)
-        VALUES ('delete', old.id, old.query, old.tags, old.project);
-    INSERT INTO plans_fts(rowid, query, tags, project) VALUES (new.id, new.query, new.tags, new.project);
+    INSERT INTO plans_fts(plans_fts, rowid, match_text, tags, project)
+        VALUES ('delete', old.id, old.match_text, old.tags, old.project);
+    INSERT INTO plans_fts(rowid, match_text, tags, project)
+        VALUES (new.id, new.match_text, new.tags, new.project);
 END;
 """
 
@@ -144,7 +152,44 @@ _PLAN_COLUMNS = (
     "success_count", "failure_count",
     # RDR-091 Phase 2a scope-tag column.
     "scope_tags",
+    # RDR-092 Phase 3 hybrid match-text column.
+    "match_text",
 )
+
+
+def _synthesize_match_text(
+    *,
+    description: str | None,
+    verb: str | None,
+    name: str | None,
+    scope: str | None,
+) -> str:
+    """Hybrid match-text synthesiser. RDR-092 Phase 3 / Phase 1.
+
+    Shape: ``"<description>. <verb> <name> scope <scope>"`` when both
+    *verb* and *name* are provided. Scope is optional and only
+    appended when present. A trailing ``.`` on *description* is
+    collapsed so the output does not carry ``..``.
+
+    When verb or name is missing, returns the raw description —
+    legacy NULL-dimension rows still carry a usable FTS payload.
+    R10 validates the hybrid form at zero verb-accuracy regression.
+    """
+    desc = (description or "").strip()
+    v = (verb or "").strip()
+    n = (name or "").strip()
+    s = (scope or "").strip()
+
+    if not v or not n:
+        return desc
+
+    suffix = f"{v} {n}"
+    if s:
+        suffix += f" scope {s}"
+    if desc:
+        core = desc.rstrip(".").rstrip()
+        return f"{core}. {suffix}"
+    return suffix
 
 _PLAN_SELECT_COLS = ", ".join(_PLAN_COLUMNS)
 
@@ -267,6 +312,13 @@ class PlanLibrary:
                 :func:`_normalize_scope_string` before storage.
         """
         created_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # RDR-092 Phase 3: synthesise the hybrid match_text alongside
+        # the raw query so FTS5 indexes the same dimensional suffix the
+        # T1 cosine cache embeds. Legacy NULL-dimension callers still
+        # get the raw query — no signal lost.
+        match_text = _synthesize_match_text(
+            description=query, verb=verb, name=name, scope=scope,
+        )
         if scope_tags:
             # Normalize each comma-separated entry, drop empties, and
             # drop scope-agnostic sentinels (``"all"``). Without the
@@ -289,14 +341,14 @@ class PlanLibrary:
                 INSERT INTO plans (
                     project, query, plan_json, outcome, tags, created_at, ttl,
                     name, verb, scope, dimensions, default_bindings, parent_dims,
-                    scope_tags
+                    scope_tags, match_text
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     project, query, plan_json, outcome, tags, created_at, ttl,
                     name, verb, scope, dimensions, default_bindings, parent_dims,
-                    stored_scope_tags,
+                    stored_scope_tags, match_text,
                 ),
             )
             self.conn.commit()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -73,7 +73,8 @@ class TestMigrationDataclass:
         from nexus.db.migrations import MIGRATIONS
 
         assert isinstance(MIGRATIONS, list)
-        assert len(MIGRATIONS) == 16  # +GH #251 hook_failures 4.9.10
+        # +RDR-092 Phase 3.1 match_text column (4.9.13).
+        assert len(MIGRATIONS) == 17
 
     def test_migrations_ordered_by_version(self) -> None:
         from nexus.db.migrations import MIGRATIONS, _parse_version
@@ -1434,4 +1435,144 @@ class TestMigrateHookFailures:
         assert matches, "hook_failures migration must be registered in MIGRATIONS"
         assert matches[0][0] >= "4.9.10", (
             f"hook_failures migration must be introduced in >= 4.9.10, got {matches[0][0]!r}"
+        )
+
+
+# ── _add_plan_match_text_column (RDR-092 Phase 3.1) ─────────────────────────
+
+
+class TestAddPlanMatchTextColumn:
+    """RDR-092 Phase 3.1: add ``match_text`` column to plans + rebuild
+    ``plans_fts`` so the T2 FTS lane indexes the same hybrid shape the
+    T1 cosine cache uses.
+
+    Idempotent. Must run after ``_add_plan_dimensional_identity`` so
+    verb/name/scope are present to feed the backfill synthesiser.
+    """
+
+    def _base_schema(self, conn: sqlite3.Connection) -> None:
+        """Plans table + dimensional columns, no match_text yet."""
+        from nexus.db.migrations import _add_plan_dimensional_identity
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS plans (
+                id INTEGER PRIMARY KEY,
+                project TEXT NOT NULL DEFAULT '',
+                query TEXT NOT NULL,
+                plan_json TEXT NOT NULL,
+                outcome TEXT DEFAULT 'success',
+                tags TEXT DEFAULT '',
+                created_at TEXT NOT NULL
+            );
+            CREATE VIRTUAL TABLE IF NOT EXISTS plans_fts USING fts5(
+                query, tags, project, content=plans, content_rowid='id'
+            );
+        """)
+        _add_plan_dimensional_identity(conn)
+        conn.commit()
+
+    def test_adds_column_idempotent(self) -> None:
+        from nexus.db.migrations import _add_plan_match_text_column
+
+        conn = sqlite3.connect(":memory:")
+        self._base_schema(conn)
+
+        _add_plan_match_text_column(conn)
+        _add_plan_match_text_column(conn)  # no raise
+
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(plans)").fetchall()}
+        assert "match_text" in cols
+
+    def test_fts_table_rebuilt_with_match_text(self) -> None:
+        from nexus.db.migrations import _add_plan_match_text_column
+
+        conn = sqlite3.connect(":memory:")
+        self._base_schema(conn)
+        _add_plan_match_text_column(conn)
+
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='plans_fts'"
+        ).fetchone()
+        assert row is not None
+        assert "match_text" in row[0], (
+            f"plans_fts must index match_text, got: {row[0]!r}"
+        )
+
+    def test_backfill_populates_dimensional_rows(self) -> None:
+        """Rows with verb/name/scope get a hybrid match_text; legacy
+        NULL-dimension rows keep the raw query text.
+        """
+        from nexus.db.migrations import _add_plan_match_text_column
+
+        conn = sqlite3.connect(":memory:")
+        self._base_schema(conn)
+
+        conn.execute(
+            "INSERT INTO plans "
+            "(query, plan_json, outcome, tags, created_at, "
+            "verb, scope, name) "
+            "VALUES (?, '{}', 'success', '', datetime('now'), ?, ?, ?)",
+            ("Find documents attributed to a specific author.",
+             "research", "global", "find-by-author"),
+        )
+        conn.execute(
+            "INSERT INTO plans "
+            "(query, plan_json, outcome, tags, created_at) "
+            "VALUES (?, '{}', 'success', '', datetime('now'))",
+            ("legacy plan text",),
+        )
+        conn.commit()
+
+        _add_plan_match_text_column(conn)
+
+        dimensional = conn.execute(
+            "SELECT match_text FROM plans WHERE name = 'find-by-author'"
+        ).fetchone()
+        assert dimensional is not None
+        assert "research find-by-author scope global" in dimensional[0]
+
+        legacy = conn.execute(
+            "SELECT match_text FROM plans WHERE query = 'legacy plan text'"
+        ).fetchone()
+        assert legacy is not None
+        assert legacy[0] == "legacy plan text"
+
+    def test_backfill_idempotent(self) -> None:
+        """Re-running the migration does not duplicate or corrupt
+        already-synthesised match_text values.
+        """
+        from nexus.db.migrations import _add_plan_match_text_column
+
+        conn = sqlite3.connect(":memory:")
+        self._base_schema(conn)
+        conn.execute(
+            "INSERT INTO plans "
+            "(query, plan_json, outcome, tags, created_at, "
+            "verb, scope, name) "
+            "VALUES (?, '{}', 'success', '', datetime('now'), ?, ?, ?)",
+            ("Analyze lineage across prose and code.",
+             "analyze", "global", "default"),
+        )
+        conn.commit()
+
+        _add_plan_match_text_column(conn)
+        first = conn.execute("SELECT match_text FROM plans").fetchone()[0]
+
+        _add_plan_match_text_column(conn)
+        second = conn.execute("SELECT match_text FROM plans").fetchone()[0]
+
+        assert first == second
+        assert "analyze default scope global" in first
+
+    def test_registered_in_migrations_list(self) -> None:
+        from nexus.db.migrations import MIGRATIONS
+
+        matches = [
+            (m.introduced, m.name) for m in MIGRATIONS
+            if "match_text" in m.name.lower()
+        ]
+        assert matches, (
+            "plan-match-text migration must be in MIGRATIONS"
+        )
+        assert matches[0][0] >= "4.9.13", (
+            f"must be introduced in >= 4.9.13, got {matches[0][0]!r}"
         )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -73,7 +73,15 @@ class TestMigrationDataclass:
         from nexus.db.migrations import MIGRATIONS
 
         assert isinstance(MIGRATIONS, list)
-        # +RDR-092 Phase 3.1 match_text column (4.9.13).
+        # This branch adds the Phase 3.1 match_text migration to the
+        # pre-RDR-092 baseline of 16: total 17. When PR #260 (Phase 0d
+        # backfill) lands first per the recommended merge order,
+        # rebasing this branch brings the total to 18 and this
+        # assertion must be bumped at merge time (code-review C-2).
+        # Prefer the name-based checks below (plus
+        # ``test_registered_in_migrations_list`` on the specific
+        # migrations) for future assertions; this count is a cheap
+        # sentinel only.
         assert len(MIGRATIONS) == 17
 
     def test_migrations_ordered_by_version(self) -> None:

--- a/tests/test_plan_library.py
+++ b/tests/test_plan_library.py
@@ -839,3 +839,79 @@ def test_rewash_migration_no_op_without_plans_table(tmp_path: Path) -> None:
     conn = sqlite3.connect(str(db_path))
     _rewash_plan_scope_tags_all_sentinel(conn)  # must not crash
     conn.close()
+
+
+# ── RDR-092 Phase 3.2: match_text wiring into save_plan + search_plans ──────
+
+
+def test_save_plan_computes_match_text_on_dimensional_insert(
+    plan_db: T2Database,
+) -> None:
+    """save_plan populates match_text using the hybrid synthesiser
+    whenever verb/name/scope are provided.
+    """
+    row_id = plan_db.save_plan(
+        query="Find documents attributed to a specific author.",
+        plan_json='{"steps":[]}',
+        verb="research",
+        scope="global",
+        name="find-by-author",
+    )
+    row = plan_db.plans.conn.execute(
+        "SELECT match_text FROM plans WHERE id = ?", (row_id,)
+    ).fetchone()
+    assert row is not None
+    assert "research find-by-author scope global" in row[0]
+
+
+def test_save_plan_match_text_falls_back_to_query_on_legacy_row(
+    plan_db: T2Database,
+) -> None:
+    """When verb/name are absent, match_text mirrors the raw query."""
+    row_id = plan_db.save_plan(
+        query="legacy plan about chunking",
+        plan_json='{"steps":[]}',
+    )
+    row = plan_db.plans.conn.execute(
+        "SELECT match_text FROM plans WHERE id = ?", (row_id,)
+    ).fetchone()
+    assert row[0] == "legacy plan about chunking"
+
+
+def test_search_plans_hits_on_dimensional_suffix(plan_db: T2Database) -> None:
+    """RDR-092 Phase 3.2: FTS now indexes match_text, so a probe
+    against the dimensional suffix hits the row even when the raw
+    query column doesn't mention the suffix tokens.
+    """
+    plan_db.save_plan(
+        query="Find documents attributed to a specific author.",
+        plan_json='{"steps":[]}',
+        verb="research",
+        scope="global",
+        name="find-by-author",
+        tags="builtin-template",
+    )
+    # Probe that only hits via the dimensional suffix, not the raw
+    # description.
+    results = plan_db.search_plans("find-by-author")
+    assert results, "match_text must expose the dimensional name to FTS"
+    assert results[0]["name"] == "find-by-author"
+
+
+def test_search_plans_still_matches_raw_description(
+    plan_db: T2Database,
+) -> None:
+    """Description text stays at the front of match_text so
+    existing callers that FTS-search on description tokens keep
+    working byte-for-byte.
+    """
+    plan_db.save_plan(
+        query="semantic search over code repositories",
+        plan_json='{"steps":[]}',
+        verb="research",
+        scope="global",
+        name="research-default",
+    )
+    results = plan_db.search_plans("semantic")
+    assert results, "description tokens still FTS-hit via match_text"
+    assert "semantic" in results[0]["query"]


### PR DESCRIPTION
## Summary

Phase 3 of RDR-092. Promotes the T1 match-text synthesis (Phase 1,
#262) into a first-class T2 column so the FTS5 lane indexes the same
hybrid shape the cosine lane embeds. Both lanes now see:

    <description>. <verb> <name> scope <scope>

so a probe on the dimensional suffix lights up the matching row
even when the raw query column does not mention those tokens, while
legacy description probes keep hitting via the same match_text.

## Phase 3.1 — schema + migration (nexus-28jn)

- `plan_library.py` — `_PLANS_SCHEMA_SQL` grows
  `match_text TEXT NOT NULL DEFAULT ''`; `plans_fts` switches from
  `(query, tags, project)` to `(match_text, tags, project)`;
  triggers retargeted to `match_text`.
- `_PLAN_COLUMNS` tuple — append `match_text` so `_row_to_dict`
  carries the new field to callers.
- `migrations.py` — new 4.9.13 migration
  `_add_plan_match_text_column`. Idempotent:
  `ALTER ADD COLUMN` is column-guarded; triggers and FTS recreate
  on every invocation via `DROP + CREATE`; backfill runs only when
  `match_text` is freshly empty.

**Order-of-operations trap.** Drop triggers and `plans_fts` BEFORE
the UPDATE backfill. Otherwise the UPDATE fans out into an
external-content FTS that is about to be rebuilt anyway, producing
`database disk image is malformed` on the first UPDATE statement.
The FTS rebuild runs last, after every match_text value is
populated.

## Phase 3.2 — save_plan wiring (nexus-9a29)

- `plan_library.py` — new `_synthesize_match_text` helper
  (kwarg-based). `save_plan` now computes match_text from
  `query / verb / name / scope` and writes it into the new column
  on every INSERT. The public `save_plan` signature stays
  byte-identical.

## Merge coordination with Phase 1 (#262)

Phase 1 defines `_synthesize_match_text` in `session_cache.py` with
a dict signature; this PR defines a kwargs signature in
`plan_library.py`. Whichever lands second should unify to a single
home — `plan_library` is the natural owner (lower-level;
`session_cache` already imports from it), and the kwargs signature
is the more explicit API surface.

## Test plan

- [x] `tests/test_migrations.py::TestAddPlanMatchTextColumn` — 5
  cases cover column-add idempotency, `plans_fts` rebuild target,
  backfill hybrid-form, legacy-fallback backfill, and the
  `MIGRATIONS` registry entry
- [x] `tests/test_plan_library.py` — 4 new cases cover save_plan's
  match_text write (hybrid + legacy fallback) and search_plans now
  hitting on the dimensional suffix (new) while retaining
  description-token matches (regression)
- [x] `test_migrations_list_exists` bumped 16 → 17
- [x] Broader suite — 430 pass across `migrations` / `plan_library`
  / `plan_match` / `plan_run` / `scoped_plan_loader` /
  `plan_template_schema` / `catalog_cli` / `rdr052_verification` /
  `builtin_plans` / `nx_answer` / `rdr_084_plan_grow`
- [ ] Post-merge on local T2: `nx upgrade` triggers the 4.9.13
  migration; then `nx doctor --check-plan-library` (from #259)
  should still pass, and `nx_answer` on a dimensional query should
  match the seeded builtin via match_text FTS rather than via the
  description-only legacy path.

## Depends on

Independent of #257 / #258 / #259 / #260 / #261 / #262 at the
file-level. Merge-coordination with #262 as noted above.

## Closes

- Closes nexus-28jn (Phase 3.1)
- Closes nexus-9a29 (Phase 3.2)

Phase 3.3 (nexus-k6q9, code review) pending against this PR.