### PR TITLE
RDR-092 Phase 4: docs update for Phases 0-3 surfaces

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -824,6 +824,21 @@ nx doctor --check-schema          # Validate T2 database schema and report pendi
 ```
 
 ```
+nx doctor --check-plan-library    # Report plan-library dimensional health (RDR-092 Phase 0c)
+```
+
+The `--check-plan-library` flag (introduced 4.9.13, nexus-4x9q) buckets
+every row in the `plans` table into **authored** (dimensions populated,
+not `backfill`-tagged), **backfilled** (dimensions populated, tagged
+`backfill` or `backfill-low-conf` by the Phase 0d migration), and
+**non-dimensional** (`dimensions IS NULL`, legacy pre-RDR-078 seeds).
+Also reports the global-tier builtin count. Exits 1 when that count
+falls below 9 (the RDR-078 builtin floor, which signals that
+`nx catalog setup` was never run against the current plugin install).
+Non-dimensional rows surface a `nx plan repair` hint pointing to the
+day-2 command that drains them.
+
+```
 nx doctor --trim-telemetry              # Delete search_telemetry rows older than 30 days (RDR-087)
 nx doctor --trim-telemetry --days 7     # Aggressive retention (minimum 1 day)
 ```
@@ -840,6 +855,36 @@ The `--check-quotas` flag (introduced 4.9.0, nexus-c590) emits a three-section p
 Exit codes:
 - `0` — reachable cloud tenant or local-mode (limits are reference-only).
 - `1` — cloud tenant unreachable in cloud mode; the report is not actionable without a working client. Suitable as a CI gate.
+
+---
+
+## nx plan
+
+Plan library maintenance commands (RDR-092 Phase 0d).
+
+```
+nx plan repair                   # Backfill dimensions on legacy rows + list low-conf entries
+```
+
+The `repair` subcommand (introduced 4.9.12, nexus-1kvj) re-runs the
+RDR-092 Phase 0d.1 plan-dimension backfill heuristic against the live
+T2 DB. On every run it:
+
+- backfills `verb` / `name` / `dimensions` on any row where
+  `dimensions IS NULL`, using a 20-rule verb-from-stem dictionary
+  over the `query` column;
+- falls back to a wh-question heuristic (`how` / `what` → research;
+  `why` → review) for rows that miss every stem rule;
+- tags confident matches with `backfill` and low-confidence
+  wh-fallback rows with `backfill-low-conf`;
+- prints the backfill count, then lists each `backfill-low-conf`
+  row with its id, inferred verb, and original query text so an
+  operator can correct edge cases by hand (direct SQL, or a future
+  editor command).
+
+Idempotent: a second run reports `0 backfilled` and exits cleanly.
+When the T2 DB is absent, exits 0 with "nothing to do" rather than a
+traceback.
 
 ---
 

--- a/docs/plan-authoring-guide.md
+++ b/docs/plan-authoring-guide.md
@@ -75,8 +75,9 @@ plan_json:
 
 ### What makes a good description
 
-`plan_match` is a cosine retrieval against the description text. Rule
-of thumb: write what would come out of the mouth of an agent that
+`plan_match` is a cosine / FTS5 retrieval against the synthesised
+`match_text` payload, whose prefix is the description text. Rule of
+thumb: write what would come out of the mouth of an agent that
 should invoke this plan.
 
 **Bad:** `"research plan"` — no discriminative signal.
@@ -85,6 +86,15 @@ should invoke this plan.
 The description should name the verb, the objects, and the outcome.
 Two plans whose descriptions differ only by paraphrase will compete
 for matches; the better-worded one wins.
+
+RDR-092 Phase 1 + Phase 3 appended a dimensional suffix to the
+embedded payload. The description still does the heavy lifting; the
+matcher now also sees `<verb> <name> scope <scope>` so queries that
+know the identity (e.g. `research find-by-author`) hit even when
+their phrasing does not overlap the description. Authoring guidance
+is unchanged: write a crisp description; the suffix is automatic.
+See [Plan-Centric Retrieval § match_text synthesis](plan-centric-retrieval.md#match_text-synthesis)
+for the full shape.
 
 ### Dimension conventions
 
@@ -385,6 +395,17 @@ the `"all"` wildcard end up agnostic (`scope_tags=""`) in that case.
   dedup will reject the second. Differentiate on `strategy`, or
   publish at a different scope.
 
+## Day-2 operations
+
+- `nx doctor --check-plan-library` (RDR-092 Phase 0c) reports plan
+  rows by bucket (authored vs backfilled vs non-dimensional) and
+  flags a stale global tier. Run after any plugin install to
+  confirm `nx catalog setup` seeded the 12 builtins.
+- `nx plan repair` (RDR-092 Phase 0d) backfills `verb` / `name` /
+  `dimensions` on legacy NULL-dimension rows using a 20-rule stem
+  dictionary + wh-fallback, and lists `backfill-low-conf` rows for
+  manual review. Idempotent.
+
 ## See also
 
 - `nx/plans/dimensions.yml` — registered dimension keys.
@@ -392,3 +413,5 @@ the `"all"` wildcard end up agnostic (`scope_tags=""`) in that case.
 - `src/nexus/plans/schema.py` — the validator enforcing this schema.
 - `src/nexus/plans/runner.py` — `plan_run` implementation.
 - `src/nexus/plans/matcher.py` — `plan_match` (T1 cosine + FTS5 fallback).
+- `src/nexus/db/t2/plan_library.py::_synthesize_match_text`, the
+  hybrid match-text synthesiser (RDR-092 Phase 1 + Phase 3).

--- a/docs/plan-centric-retrieval.md
+++ b/docs/plan-centric-retrieval.md
@@ -18,7 +18,7 @@ sequence:
 question
   │
   ▼
-[plan_match]  ─── T1 cosine (plans__session cache) ─► hit → Match(confidence≥0.40)
+[plan_match]  ─── T1 cosine (plans__session cache) ─► hit → Match(confidence≥min)
   │           └── FTS5 fallback (when T1 empty) ────► hit → Match(confidence=None)
   │
   │  (no match)
@@ -42,6 +42,16 @@ final text
 No step here is optional.  The record step runs even on plan-miss + planner-
 failure paths so every invocation leaves a trace.
 
+Both lanes of `plan_match` (T1 cosine, T2 FTS5) key off the same
+`match_text` payload synthesised at save time; see
+[§match_text synthesis](#match_text-synthesis) below.
+
+The default `min_confidence` floor is `0.40` (RDR-079 P5 calibration);
+callers can pass `min_confidence=<float>` to `nx_answer` for a
+per-call override (RDR-092 Phase 2 Option A). Verb skills that
+validated a stricter precision-first floor (0.50 per R9's 5+5 probe
+corpus) opt in this way without moving the global knob.
+
 ## Plans have dimensions
 
 Every plan in the library pins a **dimensional identity**:
@@ -59,26 +69,82 @@ dimensions in the same project will collide at seed time.  This is how
 the seed loader stays idempotent: a second run of `nx catalog setup` with
 unchanged templates produces zero inserts.
 
-## The 9 builtin scenario templates
+## The 12 builtin scenario templates
 
 `nx catalog setup` seeds these from `nx/plans/builtin/*.yml` as
 `scope:global` plans:
 
-| Template | Verb | What it does |
-|----------|------|--------------|
-| `research-default` | research | Walks prose corpus → `traverse` to implementing code → hydrate → summarise with citations |
-| `review-default` | review | Resolves changed files → walks `decision-evolution` edges → extracts decisions → compares vs proposed change |
-| `analyze-default` | analyze | Gathers prose + code → walks `reference-chain` → ranks by criterion → summarises |
-| `debug-default` | debug | Resolves failing path to catalog → hydrates authoring RDRs → summarises design context |
-| `document-default` | document | Prose search + code search → walks `documentation-for` → compares doc-coverage |
-| `plan-author-default` | plan-author | Fetches authoring guide + dimension registry → surveys prior art → generates plan template |
-| `plan-inspect-default` | plan-inspect | Looks up plan metrics (use_count, match_count, success/failure) |
-| `plan-inspect-dimensions` | plan-inspect (variant) | Enumerates the dimension registry + usage |
-| `plan-promote-propose` | plan-promote | Ranks plans worth promoting from personal → project → global |
+| Template | Verb + strategy | What it does |
+|----------|-----------------|--------------|
+| `research-default` | research / default | Walks prose corpus → `traverse` to implementing code → hydrate → summarise with citations |
+| `review-default` | review / default | Resolves changed files → walks `decision-evolution` edges → extracts decisions → compares vs proposed change |
+| `analyze-default` | analyze / default | Gathers prose + code → walks `reference-chain` → ranks by criterion → summarises |
+| `debug-default` | debug / default | Resolves failing path to catalog → hydrates authoring RDRs → summarises design context |
+| `document-default` | document / default | Prose search + code search → walks `documentation-for` → compares doc-coverage |
+| `plan-author-default` | plan-author / default | Fetches authoring guide + dimension registry → surveys prior art → generates plan template |
+| `plan-inspect-default` | plan-inspect / default | Looks up plan metrics (use_count, match_count, success/failure) |
+| `plan-inspect-dimensions` | plan-inspect / dimensions | Enumerates the dimension registry + usage |
+| `plan-promote-propose` | plan-promote / propose | Ranks plans worth promoting from personal → project → global |
+| `find-by-author` | research / find-by-author | Catalog author-index lookup → hydrate → summarise an author's contribution surface |
+| `citation-traversal` | research / citation-traversal | Resolve seed → walk `reference-chain` both directions → hydrate → summarise |
+| `type-scoped-search` | research / type-scoped | Catalog content-type filter → semantic query within that bucket → summarise |
 
-The first 5 are the "verb" scenarios — they correspond to the 5 RDR-078
-verb skills (`/nx:research`, `/nx:review`, …).  The last 4 are meta-seeds
-for the plan-library itself.
+The first 5 are the "verb" scenarios: they correspond to the 5
+RDR-078 verb skills (`/nx:research`, `/nx:review`, …). The next 4 are
+meta-seeds for the plan-library itself. The last 3 (RDR-092 Phase 0a
+migrations) replace the legacy `_PLAN_TEMPLATES` array retired from
+`src/nexus/commands/catalog.py`; two further legacy shapes (provenance
+and cross-corpus compare) were retired as redundant with
+`research-default` and `analyze-default` respectively.
+
+## match_text synthesis
+
+Both lanes of `plan_match` key off a single payload:
+
+- **T1 cosine:** the `plans__session` ChromaDB collection embeds each
+  plan's `match_text` via the local ONNX MiniLM function.
+- **T2 FTS5:** the `plans_fts` virtual table indexes `match_text`,
+  `tags`, and `project`.
+
+`match_text` is a hybrid string built from the plan's dimensional
+identity (RDR-092 Phase 1 + Phase 3):
+
+```
+<description>. <verb> <name> scope <scope>
+```
+
+Examples:
+
+| Row | match_text |
+|-----|------------|
+| `find-by-author` builtin | `Find documents attributed to a specific author... research find-by-author scope global` |
+| A grown research plan named `compare-ranker-outputs` | `compare ranker outputs. research compare-ranker-outputs scope personal` |
+| A legacy row whose `dimensions IS NULL` | raw `query` text only |
+
+Design rationale, in order of decreasing weight:
+
+1. **description-first keeps verb-accuracy honest.** The natural
+   language prefix is what R10 verified against a baseline of
+   raw-description embeddings: adding the suffix produced zero
+   verb-accuracy regression while lifting the cosine score for
+   queries that actually know the dimensional identity.
+2. **dimensional suffix gives the cosine lane a reliable hook.** A
+   caller that asks for `research find-by-author` hits the matching
+   plan even when their phrasing does not overlap the description.
+3. **scope appears only when populated.** `scope:personal` rows whose
+   scope column is set get the full suffix; `scope IS NULL` rows drop
+   `scope <…>` from the tail rather than emitting the literal word
+   `None`.
+4. **legacy fallback never breaks.** A row with `verb IS NULL` or
+   `name IS NULL` still embeds its raw `query` text, so no signal is
+   ever lost to an empty suffix.
+
+The synthesiser lives at `nexus.db.t2.plan_library._synthesize_match_text`
+and is called both from `save_plan` (so T2 FTS indexes the hybrid
+form on every insert) and from the T1 session cache's `_upsert_row`
+(so the cosine lane sees the same payload). Existing rows picked up
+from pre-RDR-092 databases are backfilled by the 4.9.13 migration
+`_add_plan_match_text_column`.
 
 ## Invocation patterns
 
@@ -106,9 +172,16 @@ mcp__plugin_nx_nexus__nx_answer(
     scope="global",
     context="recently changed: src/nexus/plans/, RDR-078",
     max_steps=6,
-    budget_usd=0.50,  # reserved for future enforcement
+    budget_usd=0.50,       # reserved for future enforcement
+    min_confidence=0.50,   # RDR-092 Phase 2 Option A, optional precision-first floor
 )
 ```
+
+The `min_confidence` kwarg defaults to `None`, which routes through
+the global `_PLAN_MATCH_MIN_CONFIDENCE` constant (`0.40`, set by
+RDR-079 P5). Passing an explicit float overrides both the `plan_match`
+gate and the `_nx_answer_match_is_hit` check so a tighter precision
+floor is honoured consistently.
 
 ### Via /nx:query
 


### PR DESCRIPTION
## Summary

Phase 4 of RDR-092. Updates the three user-facing guides so they
track the code shipped in Phases 0-3:

- `docs/cli-reference.md`
- `docs/plan-centric-retrieval.md`
- `docs/plan-authoring-guide.md`

## cli-reference.md

- New `nx doctor --check-plan-library` block (RDR-092 Phase 0c,
  #259). Documents the authored / backfilled / non-dimensional
  bucketing, the global-tier builtin count gate, the exit-1
  semantics, and the `nx plan repair` hint on non-dimensional rows.
- New `nx plan` section documenting the `repair` Day-2 subcommand
  (RDR-092 Phase 0d, #260): 20-rule verb-from-stem, wh-fallback,
  `backfill` / `backfill-low-conf` tagging, idempotency,
  missing-DB handling.

## plan-centric-retrieval.md

- Builtin-templates table bumped 9 → 12 with the three RDR-092
  Phase 0a migrations (`find-by-author`, `citation-traversal`,
  `type-scoped-search`) plus a note on the two retired legacy
  shapes (provenance, multi-corpus compare) that got absorbed by
  `research-default` and `analyze-default` respectively.
- New **match_text synthesis** section: the hybrid shape
  `<description>. <verb> <name> scope <scope>`, examples, R10-
  verified design rationale (description-first, dimensional suffix
  as hook, optional scope, legacy fallback), and the synthesiser's
  home at `nexus.db.t2.plan_library._synthesize_match_text`.
- Retrieval-trunk diagram now shows `confidence >= min` (not
  hard-coded 0.40) plus a footnote on the RDR-092 Phase 2 Option A
  per-call override.
- `nx_answer` invocation example shows `min_confidence=0.50` as the
  precision-first opt-in.

## plan-authoring-guide.md

- "What makes a good description" clarified: the description is the
  prefix of the embedded `match_text`; the dimensional suffix rides
  along automatically, so authoring guidance does not change.
- New **Day-2 operations** section pointing at the new
  `nx doctor --check-plan-library` and `nx plan repair` commands.
- See-also entry for `_synthesize_match_text`.

## Prose

All 10 new em-dashes normalised to Hal's standing style (commas /
colons / parentheses) so the additions do not reintroduce punctuation
that earlier review flagged.

## Test plan

- [x] `git diff docs/` visually inspected; no orphaned lines or
  broken markdown tables after the em-dash substitutions
- [x] `grep -c '—'` on the diff output confirms zero em-dashes in
  my additions (pre-existing em-dashes in unchanged blocks left
  alone)
- [ ] Post-merge: render the three files through the project's
  mkdocs equivalent and eyeball the headings + tables on a live
  preview

## Depends on

Independent of #257 / #258 / #259 / #260 / #261 / #262 / #263.
Technically docs-only, so it can land before, during, or after the
implementation PRs without risk.

## Closes

- Closes nexus-x5da (Phase 4.1)

Phase 4.2 (nexus-cnls, substantive-critic review) pending against
this PR.