### PR TITLE
test: tighten unit suite 12:31 -> 8:02 (-4:30)

### DIFF
--- a/tests/test_bib_enricher.py
+++ b/tests/test_bib_enricher.py
@@ -104,14 +104,31 @@ def test_enrich_404():
 
 
 def test_enrich_rate_limit_429():
-    """HTTP 429 (rate-limit) returns empty dict."""
+    """HTTP 429 (rate-limit) returns empty dict.
+
+    ``enrich`` retries 3 times with exponential backoff
+    (5s / 10s / 20s = 35s) on persistent 429s. Patch ``time.sleep``
+    to a no-op so the test doesn't actually wait; we still verify
+    that the backoff was invoked the expected number of times
+    and with the documented durations.
+    """
     from nexus.bib_enricher import enrich
 
+    sleep_calls: list[float] = []
     mock_resp = _make_response(429, {"message": "Too Many Requests"})
-    with patch("httpx.get", return_value=mock_resp):
+    with (
+        patch("httpx.get", return_value=mock_resp),
+        patch("time.sleep", side_effect=sleep_calls.append),
+    ):
         result = enrich("Some Paper")
 
     assert result == {}
+    # Backoff schedule: attempt 0 waits 5s, attempt 1 waits 10s,
+    # attempt 2 waits 20s, attempt 3 is the last and raises-for-status
+    # without sleeping (429 without raise is the 4th attempt).
+    assert sleep_calls == [5.0, 10.0, 20.0], (
+        f"unexpected backoff schedule: {sleep_calls!r}"
+    )
 
 
 def test_enrich_network_error():

--- a/tests/test_doctor_search.py
+++ b/tests/test_doctor_search.py
@@ -143,10 +143,19 @@ class TestRunProbe:
 
 
 class TestDoctorCheckSearchCli:
+    @pytest.mark.slow
     def test_flag_invokes_probe(
         self, runner: CliRunner, tmp_path, monkeypatch,
     ) -> None:
-        """``nx doctor --check-search`` runs the probe and exits 0 on no errors."""
+        """``nx doctor --check-search`` runs the probe and exits 0 on no errors.
+
+        Marked ``slow`` — the full CLI invocation through
+        ``CliRunner`` loads the complete nexus import graph (the T3
+        ChromaDB client + Voyage + MinerU + FastAPI + all CLI
+        command modules) from cold, which costs ~2 minutes on a dev
+        machine. Deselected from the default pytest run; nightly
+        CI and pre-release runs opt in with ``-m slow``.
+        """
         from nexus.cli import main
 
         # Point rdr_dir at a temp dir so RdrResolver has a stable root.

--- a/tests/test_phase3_structured_chash.py
+++ b/tests/test_phase3_structured_chash.py
@@ -145,11 +145,26 @@ class TestQueryStructuredChashSurface:
 
 
 class TestNxAnswerStructuredEnvelope:
-    def test_nx_answer_structured_default_returns_string(self, t3, t1):
-        """Backward compat: default behavior must return a plain string."""
+    def test_nx_answer_structured_default_returns_string(self, t3, t1, monkeypatch):
+        """Backward compat: default behavior must return a plain string.
+
+        The plan-miss path spawns a ``claude -p`` subprocess via
+        ``claude_dispatch`` which adds ~45s of cold-start latency
+        per call. Mock the dispatcher to a cheap stub plan so the
+        test verifies the envelope-vs-string return shape without
+        the subprocess roundtrip.
+        """
         import asyncio
 
+        import nexus.operators.dispatch as _dispatch_mod
         from nexus.mcp.core import nx_answer
+
+        async def fake_dispatch(prompt, schema, timeout=60.0):
+            return {"steps": [
+                {"tool": "search", "args": {"query": "$intent"}},
+                {"tool": "summarize", "args": {"inputs": "$step1.ids"}},
+            ]}
+        monkeypatch.setattr(_dispatch_mod, "claude_dispatch", fake_dispatch)
 
         # No plan in library → inline planner miss path; result must be str.
         result = asyncio.run(nx_answer(
@@ -207,12 +222,26 @@ class TestNxAnswerStructuredEnvelope:
             assert "collection" in ch
 
     def test_nx_answer_structured_true_empty_results_has_chunks_key(
-        self, t3, t1,
+        self, t3, t1, monkeypatch,
     ):
-        """When retrieval yields nothing, envelope's chunks list is [] — not error."""
+        """When retrieval yields nothing, envelope's chunks list is [] — not error.
+
+        Mocks ``claude_dispatch`` for the same reason as
+        ``test_nx_answer_structured_default_returns_string``: the
+        subprocess roundtrip costs ~35s and does not need to run for
+        this envelope-shape assertion.
+        """
         import asyncio
 
+        import nexus.operators.dispatch as _dispatch_mod
         from nexus.mcp.core import nx_answer
+
+        async def fake_dispatch(prompt, schema, timeout=60.0):
+            return {"steps": [
+                {"tool": "search", "args": {"query": "$intent"}},
+                {"tool": "summarize", "args": {"inputs": "$step1.ids"}},
+            ]}
+        monkeypatch.setattr(_dispatch_mod, "claude_dispatch", fake_dispatch)
 
         result = asyncio.run(nx_answer(
             question="completely unknown topic that matches nothing",


### PR DESCRIPTION
## Summary

Three targeted fixes to the top-of-durations list. Full suite with
\`-m 'not integration and not slow'\` now runs 4904 tests in 8:02 on
a dev laptop (down from 12:31). No tests dropped.

## Changes

1. **\`test_doctor_search::test_flag_invokes_probe\`** (was 122.3s) —
   marked \`@pytest.mark.slow\`. The test exercises the full CLI
   invocation through \`CliRunner\` with a cold module graph; that
   coverage is duplicated at unit level by the \`TestRunProbe\`
   fixtures above it. Nightly CI and pre-release runs opt in with
   \`uv run pytest -m slow\`.

2. **\`test_bib_enricher::test_enrich_rate_limit_429\`** (was 35.0s) —
   patched \`time.sleep\` to a no-op \`sleep_calls.append\`. Now
   asserts the backoff schedule (\`[5.0, 10.0, 20.0]\`) instead of
   implicitly paying for it — strictly stronger coverage, faster.
   Runs in 0.05s.

3. **Two \`test_phase3_structured_chash\` tests** (48.7s + 35.6s)
   both took the plan-miss path, which spawns a real \`claude -p\`
   subprocess via \`claude_dispatch\`. Mocked the dispatcher with a
   cheap stub plan (same pattern \`TestPlanMissPlanner\` already
   uses). Combined 84.3s → 0.72s.

## Remaining top durations (all legit)

\`\`\`
 15.1s  test_plan_run auto-inject
 13.0s  test_exporter pagination (import)
 12.8s  test_exporter pagination (export)
 12.4s  test_t3 existing_ids pagination cap
  9.2s  test_indexer_e2e smart_index both collections
\`\`\`

## Test plan

- [x] Each modified test runs in isolation: 1 passed 0.05s,
  3 passed 0.72s.
- [x] Full suite: 4904 passed, 27 skipped, 27 deselected in 482s.
- [x] \`uv run pytest -m slow tests/test_doctor_search.py\` still
  runs the big \`test_flag_invokes_probe\` and passes.

No production code changed.