### PR TITLE
fix(build): exclude editable-install symlink from wheel (v4.9.13 PyPI fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,18 @@ nx-mcp-catalog = "nexus.mcp.catalog:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/nexus"]
 
+# Exclude the editable-install symlink so hatch does not walk into
+# it via the packages= directive and then re-add the same files via
+# force-include below, which produces a wheel with duplicate local-
+# header filenames that PyPI rejects with a 400 "Duplicate filename
+# in local headers." The symlink exists for editable installs to
+# resolve ``importlib.resources.files('nexus') / '_resources'`` into
+# the repo's ``nx/plans`` tree; force-include is the wheel-install
+# path. Exactly one of the two should land files into the wheel.
+exclude = [
+    "src/nexus/_resources",
+]
+
 # RDR-092 nexus-b9f3: ship the nx plugin's plan YAMLs as package data
 # so installed CLIs can resolve them via ``importlib.resources.files
 # ("nexus") / "_resources"``. Without this, ``_seed_plan_templates``


### PR DESCRIPTION
## Summary

The \`release.yml\` run for \`v4.9.13\` failed PyPI upload with:

\`\`\`
400 Invalid distribution file. ZIP archive not accepted:
Duplicate filename in local headers.
\`\`\`

## Root cause

The editable-install symlink at \`src/nexus/_resources/plans\` (→ \`../../../nx/plans\`) was picked up twice during wheel build:

1. Hatch's \`packages = ["src/nexus"]\` walk traversed the symlink, including every \`nx/plans/builtin/*.yml\` under \`nexus/_resources/plans/\` in the wheel.
2. The \`[tool.hatch.build.targets.wheel.force-include]\` mapping \`"nx/plans" = "nexus/_resources/plans"\` landed the same files at the same path.

Both sources produced the same local-header filenames → ZIP duplicate → PyPI 400.

## Fix

Add \`src/nexus/_resources\` to the wheel \`exclude\` list. Hatch no longer walks the symlink; force-include is the sole source of data files in the wheel, matching the design intent. The symlink stays on disk for editable installs (where force-include does not apply and \`importlib.resources.files('nexus') / '_resources'\` resolves through the symlink to \`nx/plans\`).

## Verification

\`\`\`
$ rm -rf dist/ && uv build --wheel
Successfully built dist/conexus-4.9.13-py3-none-any.whl
$ python -c "import zipfile; z = zipfile.ZipFile('dist/conexus-4.9.13-py3-none-any.whl'); ...
_resources entries: 14
No duplicate filenames.
\`\`\`

14 = 12 builtin YAMLs + dimensions.yml + purposes.yml. All present, none duplicated.

## Next steps after merge

- Delete the existing \`v4.9.13\` tag (local + remote + no GitHub release to delete — release.yml didn't reach that step).
- Re-tag \`v4.9.13\` at the new main HEAD with this fix.
- \`git push origin v4.9.13\` refires \`release.yml\`; this time the wheel build yields a clean artefact and PyPI accepts it.