### PR TITLE
fix: 4.10.0 shakeout fixes (nx_answer_runs / binding validation / legacy plans)

### DIFF
--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -1017,6 +1017,68 @@ def _add_plan_match_text_column(conn: sqlite3.Connection) -> None:
     )
 
 
+def _retire_legacy_operation_shape_plans(conn: sqlite3.Connection) -> None:
+    """Delete plans whose plan_json uses the pre-RDR-078 ``operation`` shape.
+
+    RDR-092 Phase 0a retired the ``_PLAN_TEMPLATES`` seed array but did
+    not migrate the rows it had previously seeded. Those rows — plus
+    user ad-hoc plans saved before the RDR-078 runner landed — carry
+    step dicts like ``{"step": 1, "operation": "search", "params":
+    {...}}`` rather than the current ``{"tool": "search", "args":
+    {...}}``. ``plan_run`` cannot dispatch them; they exist only to
+    pollute plan-match results and mask modern replacements (e.g.
+    legacy ``find-documents-author`` beating the YAML builtin
+    ``find-by-author``).
+
+    Idempotent: after the first run, no legacy-shape rows remain; the
+    guarded SELECT returns 0 rows on retry.
+    """
+    import json as _json
+
+    candidates = conn.execute(
+        "SELECT id, plan_json FROM plans WHERE plan_json LIKE '%\"operation\"%'"
+    ).fetchall()
+    if not candidates:
+        return
+
+    legacy_ids: list[int] = []
+    for row_id, plan_json_text in candidates:
+        try:
+            parsed = _json.loads(plan_json_text or "{}")
+        except _json.JSONDecodeError:
+            continue
+        steps = parsed.get("steps") if isinstance(parsed, dict) else None
+        if not isinstance(steps, list) or not steps:
+            continue
+        # Legacy shape: any step has "operation" key AND no step has
+        # "tool" key. A plan_json that happens to mention "operation"
+        # inside an args payload but uses "tool" correctly is not
+        # legacy — the check above (LIKE) is a pre-filter only.
+        has_operation = any(
+            isinstance(s, dict) and "operation" in s for s in steps
+        )
+        has_tool = any(
+            isinstance(s, dict) and "tool" in s for s in steps
+        )
+        if has_operation and not has_tool:
+            legacy_ids.append(int(row_id))
+
+    if not legacy_ids:
+        return
+
+    placeholders = ",".join("?" * len(legacy_ids))
+    conn.execute(
+        f"DELETE FROM plans WHERE id IN ({placeholders})",
+        legacy_ids,
+    )
+    conn.commit()
+    _log.info(
+        "retired_legacy_operation_shape_plans",
+        deleted=len(legacy_ids),
+        ids=legacy_ids,
+    )
+
+
 MIGRATIONS: list[Migration] = [
     Migration("1.10.0", "Memory FTS rebuild with title", migrate_memory_fts),
     Migration("2.8.0", "Add plan project column", migrate_plan_project),
@@ -1079,6 +1141,11 @@ MIGRATIONS: list[Migration] = [
         "4.9.13",
         "Add plans.match_text column + rebuild plans_fts (RDR-092 Phase 3)",
         _add_plan_match_text_column,
+    ),
+    Migration(
+        "4.10.1",
+        "Retire legacy operation-shape plans (nexus-4m9b)",
+        _retire_legacy_operation_shape_plans,
     ),
 ]
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -2288,7 +2288,7 @@ async def nx_answer(
             try:
                 with _t2_ctx() as db:
                     _nx_answer_record_run(
-                        db.conn, question=question, plan_id=None,
+                        db.telemetry.conn, question=question, plan_id=None,
                         matched_confidence=matches[0].confidence if matches else None,
                         step_count=0, final_text=f"Planner error: {exc}",
                         cost_usd=0.0, duration_ms=elapsed_ms, trace=trace,
@@ -2395,7 +2395,7 @@ async def nx_answer(
             try:
                 with _t2_ctx() as db:
                     _nx_answer_record_run(
-                        db.conn, question=question, plan_id=best.plan_id,
+                        db.telemetry.conn, question=question, plan_id=best.plan_id,
                         matched_confidence=best.confidence, step_count=1,
                         final_text=str(result_text)[:2000], cost_usd=0.0,
                         duration_ms=elapsed_ms, trace=trace,
@@ -2414,7 +2414,7 @@ async def nx_answer(
             try:
                 with _t2_ctx() as db:
                     _nx_answer_record_run(
-                        db.conn, question=question, plan_id=best.plan_id,
+                        db.telemetry.conn, question=question, plan_id=best.plan_id,
                         matched_confidence=best.confidence, step_count=1,
                         final_text=f"Error: {exc}", cost_usd=0.0,
                         duration_ms=elapsed_ms, trace=trace,
@@ -2454,7 +2454,7 @@ async def nx_answer(
         try:
             with _t2_ctx() as db:
                 _nx_answer_record_run(
-                    db.conn, question=question, plan_id=best.plan_id,
+                    db.telemetry.conn, question=question, plan_id=best.plan_id,
                     matched_confidence=best.confidence, step_count=0,
                     final_text=f"Error: {exc}", cost_usd=0.0,
                     duration_ms=elapsed_ms, trace=trace,
@@ -2585,7 +2585,7 @@ async def nx_answer(
     try:
         with _t2_ctx() as db:
             _nx_answer_record_run(
-                db.conn, question=question, plan_id=best.plan_id,
+                db.telemetry.conn, question=question, plan_id=best.plan_id,
                 matched_confidence=best.confidence, step_count=len(result.steps),
                 final_text=final_text[:2000], cost_usd=0.0,
                 duration_ms=elapsed_ms, trace=trace,

--- a/src/nexus/plans/seed_loader.py
+++ b/src/nexus/plans/seed_loader.py
@@ -155,9 +155,24 @@ def load_seed_directory(
             continue
 
         dimensions = template["dimensions"]
+        # Carry binding declarations into the stored plan_json so
+        # ``Match.from_plan_row`` can recover them (nexus-80tk). The
+        # YAML author declares required_bindings/optional_bindings at
+        # the top level; without this merge they never reach the DB,
+        # and ``_validate_bindings`` sees an empty list and lets
+        # unfilled ``$var`` placeholders leak into operator prompts.
+        plan_json_payload: dict[str, Any] = dict(template["plan_json"])
+        if template.get("required_bindings"):
+            plan_json_payload["required_bindings"] = list(
+                template["required_bindings"]
+            )
+        if template.get("optional_bindings"):
+            plan_json_payload["optional_bindings"] = list(
+                template["optional_bindings"]
+            )
         library.save_plan(
             query=template["description"],
-            plan_json=json.dumps(template["plan_json"]),
+            plan_json=json.dumps(plan_json_payload),
             outcome=outcome,
             tags=template.get("tags", "") or "",
             project=project,

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -6,6 +6,7 @@ They will fail until migrations.py is implemented (nexus-6cn).
 """
 from __future__ import annotations
 
+import json
 import sqlite3
 import threading
 from pathlib import Path
@@ -74,11 +75,12 @@ class TestMigrationDataclass:
 
         assert isinstance(MIGRATIONS, list)
         # Baseline 16 + RDR-092 Phase 0d backfill (4.9.12) +
-        # RDR-092 Phase 3.1 match_text column (4.9.13) = 18.
+        # RDR-092 Phase 3.1 match_text column (4.9.13) +
+        # legacy operation-shape retirement (4.10.1) = 19.
         # Prefer the name-based checks in TestBackfillPlanDimensions
         # and TestAddPlanMatchTextColumn for future guards; this
         # count is a cheap sentinel only.
-        assert len(MIGRATIONS) == 18
+        assert len(MIGRATIONS) == 19
 
     def test_migrations_ordered_by_version(self) -> None:
         from nexus.db.migrations import MIGRATIONS, _parse_version
@@ -1955,4 +1957,118 @@ class TestAddPlanMatchTextColumn:
         ).fetchone()
         assert "research citation-traversal scope global" in row[0], (
             f"backfill must synthesize match_text on retry, got {row[0]!r}"
+        )
+
+
+# ── _retire_legacy_operation_shape_plans (nexus-4m9b) ────────────────────────
+
+
+class TestRetireLegacyOperationShapePlans:
+    """nexus-4m9b: RDR-092 Phase 0a retired the ``_PLAN_TEMPLATES`` seed
+    array but did not migrate the rows it had previously seeded. Those
+    rows, plus pre-RDR-078 user ad-hoc plans, carry step entries shaped
+    like ``{"operation": "X", "params": {...}}`` that ``plan_run``
+    cannot dispatch. The migration deletes them so modern replacements
+    win during plan-match routing.
+    """
+
+    def _schema(self, conn: sqlite3.Connection) -> None:
+        conn.executescript("""
+            CREATE TABLE plans (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                query TEXT NOT NULL,
+                plan_json TEXT NOT NULL,
+                outcome TEXT DEFAULT 'success',
+                tags TEXT DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+        """)
+        conn.commit()
+
+    def test_deletes_legacy_operation_shape(self) -> None:
+        from nexus.db.migrations import _retire_legacy_operation_shape_plans
+
+        conn = sqlite3.connect(":memory:")
+        self._schema(conn)
+        legacy = json.dumps({
+            "steps": [
+                {"step": 1, "operation": "catalog_search", "params": {"author": "x"}},
+            ],
+        })
+        modern = json.dumps({
+            "steps": [{"tool": "search", "args": {"query": "x"}}],
+        })
+        conn.execute(
+            "INSERT INTO plans (query, plan_json) VALUES (?, ?)",
+            ("legacy", legacy),
+        )
+        conn.execute(
+            "INSERT INTO plans (query, plan_json) VALUES (?, ?)",
+            ("modern", modern),
+        )
+        conn.commit()
+
+        _retire_legacy_operation_shape_plans(conn)
+
+        remaining = [r[0] for r in conn.execute(
+            "SELECT query FROM plans ORDER BY id"
+        ).fetchall()]
+        assert remaining == ["modern"]
+
+    def test_idempotent(self) -> None:
+        from nexus.db.migrations import _retire_legacy_operation_shape_plans
+
+        conn = sqlite3.connect(":memory:")
+        self._schema(conn)
+        conn.execute(
+            "INSERT INTO plans (query, plan_json) VALUES (?, ?)",
+            ("legacy",
+             '{"steps": [{"operation": "search", "params": {}}]}'),
+        )
+        conn.commit()
+
+        _retire_legacy_operation_shape_plans(conn)
+        _retire_legacy_operation_shape_plans(conn)  # no raise
+
+        count = conn.execute("SELECT COUNT(*) FROM plans").fetchone()[0]
+        assert count == 0
+
+    def test_preserves_rows_that_mention_operation_in_args(self) -> None:
+        """A modern plan whose args payload happens to contain the word
+        ``operation`` (e.g. a ``purpose: reference-operation`` string)
+        must not be retired. The post-parse ``has_tool`` check decides.
+        """
+        from nexus.db.migrations import _retire_legacy_operation_shape_plans
+
+        conn = sqlite3.connect(":memory:")
+        self._schema(conn)
+        plan_json = json.dumps({
+            "steps": [{
+                "tool": "traverse",
+                "args": {"purpose": "reference-operation"},
+            }],
+        })
+        conn.execute(
+            "INSERT INTO plans (query, plan_json) VALUES (?, ?)",
+            ("false-positive guard", plan_json),
+        )
+        conn.commit()
+
+        _retire_legacy_operation_shape_plans(conn)
+
+        count = conn.execute("SELECT COUNT(*) FROM plans").fetchone()[0]
+        assert count == 1
+
+    def test_registered_in_migrations_list(self) -> None:
+        from nexus.db.migrations import MIGRATIONS
+
+        matches = [
+            (m.introduced, m.name) for m in MIGRATIONS
+            if "legacy" in m.name.lower() and "operation" in m.name.lower()
+        ]
+        assert matches, (
+            "retire-legacy-operation-shape migration must be in MIGRATIONS"
+        )
+        assert matches[0][0] >= "4.10.1", (
+            f"must be introduced at >= 4.10.1, got {matches[0][0]!r}"
         )

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -389,6 +389,34 @@ class TestRunRecording:
         assert row[1] == "[redacted]"   # question
         assert row[5] == "[redacted]"   # final_text
 
+    def test_record_run_lands_via_t2_telemetry_conn(self, tmp_path):
+        """Regression for nexus-598n: the MCP call sites write through
+        ``db.telemetry.conn``, not a nonexistent ``db.conn``.
+
+        Prior to this fix, every ``_nx_answer_record_run`` call in
+        ``mcp/core.py`` passed ``db.conn`` to this function; after the
+        RDR-063 T2Database split removed the facade-level ``.conn``
+        attribute, those writes raised ``AttributeError`` under
+        ``except Exception: pass`` — silently dropping every run
+        record. Asserting the lookup here locks the contract.
+        """
+        from nexus.db.t2 import T2Database
+        from nexus.mcp.core import _nx_answer_record_run
+
+        path = tmp_path / "mem.db"
+        with T2Database(path) as db:
+            assert hasattr(db, "telemetry") and hasattr(db.telemetry, "conn")
+            _nx_answer_record_run(
+                db.telemetry.conn, question="integration-probe",
+                plan_id=7, matched_confidence=0.8, step_count=2,
+                final_text="ok", cost_usd=0.0, duration_ms=42,
+                trace=True,
+            )
+            row = db.telemetry.conn.execute(
+                "SELECT question, plan_id, step_count FROM nx_answer_runs"
+            ).fetchone()
+            assert row == ("integration-probe", 7, 2)
+
 
 # ── Plan-run use_count / success_count / failure_count telemetry ──────────────
 

--- a/tests/test_scoped_plan_loader.py
+++ b/tests/test_scoped_plan_loader.py
@@ -341,6 +341,40 @@ def test_ci_schema_check_fails_on_invalid_plan(fs, library) -> None:
     assert rc != 0
 
 
+def test_seed_loader_carries_required_bindings_into_plan_json(fs, library) -> None:
+    """Regression for nexus-80tk: required/optional bindings declared at
+    YAML top level must land inside the stored plan_json so
+    ``Match.from_plan_row`` can recover them. Without this, unfilled
+    ``$var`` placeholders leak into operator prompts instead of failing
+    upfront with ``PlanRunBindingError``.
+    """
+    from nexus.plans.loader import load_all_tiers
+    from nexus.plans.match import Match
+
+    plugin_root, repo_root = fs
+    template = _plan_yaml("analyze", strategy="bindings-check")
+    template["required_bindings"] = ["area", "criterion"]
+    template["optional_bindings"] = ["limit"]
+    template["default_bindings"] = {"limit": 10}
+    (plugin_root / "plans" / "builtin" / "bindings-check.yml").write_text(
+        yaml.safe_dump(template)
+    )
+
+    load_all_tiers(
+        plugin_root=plugin_root, repo_root=repo_root, library=library,
+    )
+
+    rows = library.list_plans()
+    hit = next(r for r in rows if r.get("name") == "bindings-check")
+    stored = json.loads(hit["plan_json"])
+    assert stored["required_bindings"] == ["area", "criterion"]
+    assert stored["optional_bindings"] == ["limit"]
+
+    match = Match.from_plan_row(hit, confidence=0.9)
+    assert match.required_bindings == ["area", "criterion"]
+    assert match.optional_bindings == ["limit"]
+
+
 def test_ci_workflow_file_present() -> None:
     """GitHub Actions workflow shipping the CI check exists."""
     workflow = (


### PR DESCRIPTION
## Summary

Three fixes surfaced by a live 4.10.0 shakeout against the reference install.

- **nexus-598n** (fix): `nx_answer_runs` has been silently empty since the RDR-063 T2Database split — all five call sites in `src/nexus/mcp/core.py` passed `db.conn` to `_nx_answer_record_run`, but the facade no longer exposes a top-level `conn` attribute (each domain store owns its own). The `AttributeError` was swallowed by the surrounding `except Exception: pass` on every invocation. Route through `db.telemetry.conn` semantically and fix the five sites.
- **nexus-80tk** (fix): `seed_loader` stored only `template["plan_json"]` at save time, dropping the YAML-declared `required_bindings` / `optional_bindings`. `Match.from_plan_row` then saw an empty list, `_validate_bindings` passed every call through, and unresolved `$var` literals leaked into operator prompts. Merge the binding lists into the stored `plan_json` at save time. No schema change.
- **nexus-4m9b** (feat): RDR-092 Phase 0a retired the `_PLAN_TEMPLATES` seed array but left 11 previously-seeded legacy-shape rows in place (`operation` / `params` keys instead of `tool` / `args`). They cannot be dispatched and mask modern replacements in plan-match. New migration `_retire_legacy_operation_shape_plans` at 4.10.1 deletes them generically on next `nx upgrade`, with a post-parse guard against false-positives from plans whose args payloads happen to mention the word `operation`.

## Shakeout evidence

Before this PR, on the reference install at 4.10.0:

```
nx_answer_runs                 rows: 0       (since RDR-080 P1 shipped)
plans.use_count  SUM           0       
analyze-default bundle prompt  leaked `$criterion` / `$area` verbatim
plan-match routing             legacy plan 30 out-ranked modern plan 57
```

Telemetry wiring for `plans.use_count` / `success_count` / `failure_count` introduced in 4.10.0 was verified working during the shakeout (plans 30 and 53 showed correct increments through `db.plans.*`). That path is unchanged.

## Test plan

- [x] `tests/test_nx_answer.py::TestRunRecording::test_record_run_lands_via_t2_telemetry_conn` — opens real `T2Database`, writes via documented path, asserts row lands
- [x] `tests/test_scoped_plan_loader.py::test_seed_loader_carries_required_bindings_into_plan_json` — round-trips YAML through seeder + `Match.from_plan_row`, asserts both lists preserved
- [x] `tests/test_migrations.py::TestRetireLegacyOperationShapePlans` — 4 tests: delete-only-legacy, idempotency, false-positive guard, registry presence at ≥ 4.10.1
- [x] Full unit suite: 4995 passed, 27 skipped, 0 failures in 14:37
- [x] `nx doctor --check-plan-library` green

## Beads

Closes nexus-598n, nexus-80tk, nexus-4m9b.

## Release plan

- Tag as `v4.10.1` after merge (patch — no behaviour change on upgrade, only internal correctness + cleanup migration)
- All four manifests (`pyproject.toml`, `.claude-plugin/marketplace.json`, `nx/.claude-plugin/plugin.json`, `sn/.claude-plugin/plugin.json`) will bump in the release commit
- Reinstall locally after tag push per standing release protocol