### PR TITLE
fix: 4.10.1 shakeout follow-ups (operator inputs rename / builtin bindings backfill)

### DIFF
--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -1079,6 +1079,120 @@ def _retire_legacy_operation_shape_plans(conn: sqlite3.Connection) -> None:
     )
 
 
+def _backfill_builtin_bindings(conn: sqlite3.Connection) -> None:
+    """Patch required_bindings/optional_bindings into existing builtin rows.
+
+    The 4.10.1 seed_loader fix (nexus-80tk) merges YAML binding
+    declarations into plan_json at save_plan time, but rows seeded
+    before 4.10.1 short-circuit the seed loader on re-run because
+    their ``(project, dimensions)`` pair already exists. Without
+    this backfill, ``_validate_bindings`` still sees an empty list
+    on upgraded installs and unresolved ``$var`` literals leak into
+    operator prompts.
+
+    For each builtin row whose plan_json lacks a ``required_bindings``
+    key, resolve the shipping YAML by ``(verb, scope, strategy)``
+    and patch the binding lists into the stored JSON. Idempotent
+    via the ``NOT LIKE '%required_bindings%'`` pre-filter.
+
+    Silent no-op when the shipping YAMLs are unreachable (exotic
+    install layouts) — the seed loader's fail-loud guard at
+    ``nx catalog setup`` is the escalation path for that case.
+    """
+    import json as _json
+
+    try:
+        import yaml as _yaml
+        from importlib.resources import as_file, files
+    except ModuleNotFoundError:
+        return
+
+    rows = conn.execute(
+        "SELECT id, plan_json, dimensions FROM plans "
+        "WHERE tags LIKE '%builtin%' "
+        "AND plan_json NOT LIKE '%required_bindings%'"
+    ).fetchall()
+    if not rows:
+        return
+
+    # Resolve the shipping YAML directory via package resources, with
+    # a repo-root fallback for dev-mode runs. Mirrors
+    # ``catalog._resolve_plugin_root`` but inlined so this migration
+    # stays in the db layer.
+    yaml_dir = None
+    try:
+        resource = files("nexus") / "_resources" / "plans" / "builtin"
+        with as_file(resource) as resolved:
+            from pathlib import Path as _Path
+            if _Path(resolved).is_dir():
+                yaml_dir = _Path(resolved)
+    except (ModuleNotFoundError, FileNotFoundError, TypeError):
+        pass
+    if yaml_dir is None:
+        from pathlib import Path as _Path
+        repo_candidate = _Path(__file__).resolve().parents[3] / "nx" / "plans" / "builtin"
+        if repo_candidate.is_dir():
+            yaml_dir = repo_candidate
+    if yaml_dir is None:
+        _log.warning(
+            "backfill_builtin_bindings_skip",
+            reason="shipping YAMLs unreachable; run 'nx catalog setup' to re-seed",
+        )
+        return
+
+    bindings_index: dict[tuple[str, str, str], tuple[list, list]] = {}
+    for entry in yaml_dir.iterdir():
+        if not entry.is_file() or entry.suffix not in (".yml", ".yaml"):
+            continue
+        try:
+            template = _yaml.safe_load(entry.read_text()) or {}
+        except Exception:
+            continue
+        dims = template.get("dimensions") or {}
+        key = (
+            str(dims.get("verb", "")),
+            str(dims.get("scope", "")),
+            str(dims.get("strategy", "")),
+        )
+        required = list(template.get("required_bindings") or [])
+        optional = list(template.get("optional_bindings") or [])
+        if required or optional:
+            bindings_index[key] = (required, optional)
+
+    if not bindings_index:
+        return
+
+    backfilled = 0
+    for row_id, plan_json_text, dims_text in rows:
+        try:
+            parsed = _json.loads(plan_json_text or "{}")
+            dims = _json.loads(dims_text or "{}")
+        except _json.JSONDecodeError:
+            continue
+        key = (
+            str(dims.get("verb", "")),
+            str(dims.get("scope", "")),
+            str(dims.get("strategy", "")),
+        )
+        bindings = bindings_index.get(key)
+        if not bindings:
+            continue
+        required, optional = bindings
+        if required:
+            parsed["required_bindings"] = required
+        if optional:
+            parsed["optional_bindings"] = optional
+        conn.execute(
+            "UPDATE plans SET plan_json = ? WHERE id = ?",
+            (_json.dumps(parsed), row_id),
+        )
+        backfilled += 1
+
+    if backfilled:
+        conn.commit()
+        _log.info("backfill_builtin_bindings", rows=backfilled)
+
+
 MIGRATIONS: list[Migration] = [
     Migration("1.10.0", "Memory FTS rebuild with title", migrate_memory_fts),
     Migration("2.8.0", "Add plan project column", migrate_plan_project),
@@ -1146,6 +1260,11 @@ MIGRATIONS: list[Migration] = [
         "4.10.1",
         "Retire legacy operation-shape plans (nexus-4m9b)",
         _retire_legacy_operation_shape_plans,
+    ),
+    Migration(
+        "4.10.2",
+        "Backfill required/optional bindings on builtin plans (nexus-uyc6)",
+        _backfill_builtin_bindings,
     ),
 ]
 

--- a/src/nexus/plans/runner.py
+++ b/src/nexus/plans/runner.py
@@ -641,10 +641,32 @@ def _hydrate_operator_args(
         if isinstance(template, dict):
             args["fields"] = ",".join(template.keys())
 
+    # nexus-yis0: translate step-passed ``inputs`` to the operator's
+    # expected arg name when a prior explicit ``store_get_many`` step
+    # already materialized content. The auto-hydration branch above
+    # handles the ``ids in args`` case; this handles the pre-hydrated
+    # case where the operator's args reference ``$stepN.contents``.
+    # Without this, isolated dispatch of summarize / rank / compare /
+    # generate fires with no positional arg and raises TypeError
+    # (plan 57 ``find-by-author`` is the canonical repro).
+    _INPUTS_TARGET: dict[str, str] = {
+        "operator_summarize": "content",
+        "operator_generate": "context",
+        "operator_rank": "items",
+        "operator_compare": "items",
+    }
+    target_key = _INPUTS_TARGET.get(resolved_tool)
+    if target_key and "inputs" in args and target_key not in args:
+        args[target_key] = args.pop("inputs")
+
     if resolved_tool == "operator_summarize" and isinstance(args.get("content"), list):
         args["content"] = "\n\n".join(str(x) for x in args["content"] if x)
     if resolved_tool == "operator_generate" and isinstance(args.get("context"), list):
         args["context"] = "\n\n".join(str(x) for x in args["context"] if x)
+    if resolved_tool in ("operator_rank", "operator_compare") and isinstance(
+        args.get("items"), list
+    ):
+        args["items"] = json.dumps(args["items"])
 
     return resolved_tool, args
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -76,11 +76,12 @@ class TestMigrationDataclass:
         assert isinstance(MIGRATIONS, list)
         # Baseline 16 + RDR-092 Phase 0d backfill (4.9.12) +
         # RDR-092 Phase 3.1 match_text column (4.9.13) +
-        # legacy operation-shape retirement (4.10.1) = 19.
+        # legacy operation-shape retirement (4.10.1) +
+        # builtin-bindings backfill (4.10.2) = 20.
         # Prefer the name-based checks in TestBackfillPlanDimensions
         # and TestAddPlanMatchTextColumn for future guards; this
         # count is a cheap sentinel only.
-        assert len(MIGRATIONS) == 19
+        assert len(MIGRATIONS) == 20
 
     def test_migrations_ordered_by_version(self) -> None:
         from nexus.db.migrations import MIGRATIONS, _parse_version
@@ -2071,4 +2072,206 @@ class TestRetireLegacyOperationShapePlans:
         )
         assert matches[0][0] >= "4.10.1", (
             f"must be introduced at >= 4.10.1, got {matches[0][0]!r}"
+        )
+
+
+# ── _backfill_builtin_bindings (nexus-uyc6) ──────────────────────────────────
+
+
+class TestBackfillBuiltinBindings:
+    """nexus-uyc6: the seed_loader fix merges binding declarations into
+    plan_json at save_plan time, but existing rows short-circuit via
+    ``get_plan_by_dimensions`` on re-seed. This migration patches the
+    declarations into pre-existing builtin rows by matching
+    ``(verb, scope, strategy)`` against the shipping YAMLs.
+    """
+
+    def _schema(self, conn: sqlite3.Connection) -> None:
+        conn.executescript("""
+            CREATE TABLE plans (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                query TEXT NOT NULL,
+                plan_json TEXT NOT NULL,
+                outcome TEXT DEFAULT 'success',
+                tags TEXT DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                project TEXT NOT NULL DEFAULT '',
+                verb TEXT,
+                scope TEXT,
+                dimensions TEXT,
+                name TEXT
+            );
+        """)
+        conn.commit()
+
+    def _write_yaml(self, path, name, verb, scope, strategy,
+                    required, optional):
+        import yaml as _yaml
+        doc = {
+            "name": name,
+            "description": f"{verb} / {strategy} test template",
+            "dimensions": {"verb": verb, "scope": scope, "strategy": strategy},
+            "plan_json": {"steps": [{"tool": "search", "args": {}}]},
+        }
+        if required:
+            doc["required_bindings"] = required
+        if optional:
+            doc["optional_bindings"] = optional
+        path.write_text(_yaml.safe_dump(doc))
+
+    def test_backfills_matching_row_by_dimensions(self, tmp_path, monkeypatch):
+        from nexus.db.migrations import _backfill_builtin_bindings
+
+        yaml_dir = tmp_path / "nx" / "plans" / "builtin"
+        yaml_dir.mkdir(parents=True)
+        self._write_yaml(
+            yaml_dir / "analyze.yml",
+            name="default", verb="analyze", scope="global",
+            strategy="default", required=["area", "criterion"],
+            optional=["limit"],
+        )
+
+        # Point the migration's repo-root fallback at our tmp layout.
+        # Migration walks __file__.parents[3]/nx/plans/builtin; a monkeypatch
+        # of the module-level ``Path`` lookup in the migration is brittle,
+        # so instead pivot on ``importlib.resources`` by setting up a
+        # resource stub. Simpler: mock ``importlib.resources.files`` to
+        # return an object whose ``joinpath`` chain resolves to tmp_path.
+        monkeypatch.chdir(tmp_path)
+
+        class _FakeResource:
+            def __init__(self, root):
+                self._root = root
+            def __truediv__(self, segment):
+                return _FakeResource(self._root / segment)
+            def is_dir(self):
+                return self._root.is_dir()
+            def iterdir(self):
+                return self._root.iterdir()
+
+        def fake_files(_pkg):
+            # Mirror the migration's expected layout: <pkg> / _resources
+            # / plans / builtin. We ship the YAMLs at tmp_path/nx/plans/
+            # builtin, so route _resources/plans/builtin to tmp_path/nx/
+            # plans/builtin via the FakeResource chain.
+            root = tmp_path / "nx"
+            # Eat the leading "_resources" segment by returning a resource
+            # rooted at tmp_path/nx so the subsequent / "plans" / "builtin"
+            # lands correctly. Requires a small shim: intercept the first
+            # / and redirect.
+            class _RedirectingFakeResource(_FakeResource):
+                def __truediv__(self, segment):
+                    if segment == "_resources":
+                        return _FakeResource(root)
+                    return _FakeResource(self._root / segment)
+            return _RedirectingFakeResource(root)
+
+        class _FakeAsFile:
+            def __init__(self, resource):
+                self._resource = resource
+            def __enter__(self):
+                return self._resource._root
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(
+            "importlib.resources.files", fake_files,
+        )
+        monkeypatch.setattr(
+            "importlib.resources.as_file",
+            lambda resource: _FakeAsFile(resource),
+        )
+
+        conn = sqlite3.connect(":memory:")
+        self._schema(conn)
+        conn.execute(
+            "INSERT INTO plans "
+            "(query, plan_json, tags, verb, scope, dimensions, name) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "Analysis and synthesis",
+                '{"steps": [{"tool": "search", "args": {}}]}',
+                "builtin-template,rdr-078,analyze",
+                "analyze", "global",
+                '{"scope":"global","strategy":"default","verb":"analyze"}',
+                "default",
+            ),
+        )
+        conn.commit()
+
+        _backfill_builtin_bindings(conn)
+
+        row = conn.execute(
+            "SELECT plan_json FROM plans WHERE name='default'"
+        ).fetchone()
+        parsed = json.loads(row[0])
+        assert parsed["required_bindings"] == ["area", "criterion"]
+        assert parsed["optional_bindings"] == ["limit"]
+
+    def test_idempotent_when_row_already_has_bindings(self, tmp_path, monkeypatch):
+        from nexus.db.migrations import _backfill_builtin_bindings
+
+        conn = sqlite3.connect(":memory:")
+        self._schema(conn)
+        already = json.dumps({
+            "steps": [{"tool": "search", "args": {}}],
+            "required_bindings": ["area"],
+        })
+        conn.execute(
+            "INSERT INTO plans "
+            "(query, plan_json, tags, verb, scope, dimensions, name) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("x", already, "builtin-template", "analyze", "global",
+             '{"verb":"analyze","scope":"global","strategy":"default"}',
+             "default"),
+        )
+        conn.commit()
+
+        _backfill_builtin_bindings(conn)
+
+        row = conn.execute(
+            "SELECT plan_json FROM plans WHERE name='default'"
+        ).fetchone()
+        assert row[0] == already
+
+    def test_skips_non_builtin_rows(self, tmp_path, monkeypatch):
+        """User ad-hoc rows (no ``builtin`` in tags) must not be touched
+        even if a dimension match exists in the shipping YAMLs.
+        """
+        from nexus.db.migrations import _backfill_builtin_bindings
+
+        conn = sqlite3.connect(":memory:")
+        self._schema(conn)
+        conn.execute(
+            "INSERT INTO plans "
+            "(query, plan_json, tags, verb, scope, dimensions, name) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("ad-hoc", '{"steps": []}', "ad-hoc,grown",
+             "analyze", "global",
+             '{"verb":"analyze","scope":"global","strategy":"default"}',
+             "default"),
+        )
+        conn.commit()
+
+        # Even with missing YAMLs the migration should no-op cleanly
+        # on non-builtin rows. Call it without fixture YAMLs.
+        _backfill_builtin_bindings(conn)
+
+        row = conn.execute(
+            "SELECT plan_json FROM plans WHERE name='default'"
+        ).fetchone()
+        assert row[0] == '{"steps": []}'
+
+    def test_registered_in_migrations_list(self):
+        from nexus.db.migrations import MIGRATIONS
+
+        matches = [
+            (m.introduced, m.name) for m in MIGRATIONS
+            if "backfill" in m.name.lower() and "binding" in m.name.lower()
+        ]
+        assert matches, (
+            "backfill-builtin-bindings migration must be in MIGRATIONS"
+        )
+        assert matches[0][0] >= "4.10.2", (
+            f"must be introduced at >= 4.10.2, got {matches[0][0]!r}"
         )

--- a/tests/test_plan_run.py
+++ b/tests/test_plan_run.py
@@ -645,3 +645,92 @@ class TestLegacyToolKeyAliases:
         disp = _FakeDispatcher()
         await plan_run(_match(plan), {}, dispatcher=disp)
         assert disp.calls[0][0] == "query"
+
+
+# ── _hydrate_operator_args: inputs-arg translation (nexus-yis0) ───────────────
+
+
+class TestHydrateInputsTranslation:
+    """nexus-yis0: when a prior explicit ``store_get_many`` step feeds an
+    operator via ``inputs: $stepN.contents`` (no ``ids`` key on the
+    operator step), ``_hydrate_operator_args`` must still rename
+    ``inputs`` to the operator's expected positional arg. Otherwise
+    the unknown-kwarg drop in ``_default_dispatcher`` strips the arg
+    and the operator fires with no positional, raising TypeError.
+    """
+
+    def test_summarize_renames_inputs_to_content(self):
+        from nexus.plans.runner import _hydrate_operator_args
+
+        tool, args = _hydrate_operator_args(
+            "summarize", {"inputs": "hydrated text"},
+        )
+        assert tool == "operator_summarize"
+        assert args == {"content": "hydrated text"}
+
+    def test_summarize_inputs_list_joined_to_content_string(self):
+        from nexus.plans.runner import _hydrate_operator_args
+
+        tool, args = _hydrate_operator_args(
+            "summarize", {"inputs": ["a", "b", "c"]},
+        )
+        assert tool == "operator_summarize"
+        assert args == {"content": "a\n\nb\n\nc"}
+
+    def test_generate_renames_inputs_to_context(self):
+        from nexus.plans.runner import _hydrate_operator_args
+
+        tool, args = _hydrate_operator_args(
+            "generate", {"template": "report", "inputs": ["x", "y"]},
+        )
+        assert tool == "operator_generate"
+        assert args == {"template": "report", "context": "x\n\ny"}
+
+    def test_rank_renames_inputs_to_items_json_encoded(self):
+        from nexus.plans.runner import _hydrate_operator_args
+
+        tool, args = _hydrate_operator_args(
+            "rank", {"inputs": ["first", "second"], "criterion": "relevance"},
+        )
+        assert tool == "operator_rank"
+        assert args == {
+            "items": json.dumps(["first", "second"]),
+            "criterion": "relevance",
+        }
+
+    def test_compare_renames_inputs_to_items(self):
+        from nexus.plans.runner import _hydrate_operator_args
+
+        tool, args = _hydrate_operator_args(
+            "compare", {"inputs": ["a", "b"], "focus": "diffs"},
+        )
+        assert tool == "operator_compare"
+        assert args == {
+            "items": json.dumps(["a", "b"]),
+            "focus": "diffs",
+        }
+
+    def test_rename_skipped_when_target_already_set(self):
+        """If the plan author correctly passes ``content`` already,
+        ``inputs`` is left untouched (no silent overwrite).
+        """
+        from nexus.plans.runner import _hydrate_operator_args
+
+        tool, args = _hydrate_operator_args(
+            "summarize", {"content": "keep me", "inputs": "ignored"},
+        )
+        assert tool == "operator_summarize"
+        assert args["content"] == "keep me"
+        assert args["inputs"] == "ignored"
+
+    def test_extract_keeps_inputs_unchanged(self):
+        """``operator_extract`` natively takes ``inputs`` so no rename
+        should happen.
+        """
+        from nexus.plans.runner import _hydrate_operator_args
+
+        tool, args = _hydrate_operator_args(
+            "extract", {"inputs": "item list", "fields": "a,b"},
+        )
+        assert tool == "operator_extract"
+        assert args == {"inputs": "item list", "fields": "a,b"}


### PR DESCRIPTION
## Summary

Two follow-up bugs surfaced by the 4.10.1 live shakeout, both tied to operator-step wiring.

- **nexus-yis0** (fix): `_hydrate_operator_args` only renamed `inputs` → `{content, context, items}` inside the auto-hydration branch that fires when `ids` is in the operator step's args. Plans with an explicit `store_get_many` step followed by an operator step (canonical repro: plan 57 `find-by-author`) pass `inputs: $stepN.contents` to the operator and so skipped the translation. `inputs` then got stripped by the unknown-kwarg drop in `_default_dispatcher` and the operator fired with no positional argument. Fix adds a dedicated rename pass after auto-hydration, plus list-to-string / list-to-JSON normalization for all four affected operators. `extract` is unchanged (uses `inputs` natively). Bundle path is untouched (uses its own arg-presentation logic).
- **nexus-uyc6** (feat): The 4.10.1 `seed_loader` fix (nexus-80tk) merges YAML binding declarations into `plan_json` at save time, but the seed loader short-circuits on rows that already exist — so rows seeded before 4.10.1 keep the old `plan_json` without `required_bindings`. On upgraded installs, `_validate_bindings` still sees an empty list and unresolved `$var` literals leak into operator prompts. New migration `_backfill_builtin_bindings` at 4.10.2 resolves the shipping YAMLs via `importlib.resources`, indexes them by `(verb, scope, strategy)`, and patches the declarations into matching rows. Idempotent, builtin-only (user ad-hoc plans untouched).

## Shakeout evidence

Against the reference 4.10.1 install (pre-fix):

- Plan 57 `find-by-author`, live `nx_answer`: `Error during plan execution: operator_summarize() missing 1 required positional argument: 'content'`
- Plan 53 `analyze-default`, live `nx_answer`: bundle prompt still contains raw `$criterion` because the existing row's `plan_json` never got re-seeded with the YAML's declared `required_bindings`

## Test plan

- [x] `tests/test_plan_run.py::TestHydrateInputsTranslation` — 7 cases covering rename + list handling for all four operators, plus extract-unchanged and no-overwrite guards
- [x] `tests/test_migrations.py::TestBackfillBuiltinBindings` — 4 cases covering dimensional match, idempotency, non-builtin skip, registry presence
- [x] Full unit suite: 5006 passed, 27 skipped, 0 failures in 13:41

## Beads

Closes nexus-yis0, nexus-uyc6.

## Release plan

- Tag as `v4.10.2` after merge (patch — fixes two shakeout-only paths the 4.10.1 release surfaced)
- All four manifests + `CHANGELOG.md` + `nx/CHANGELOG.md` + `uv.lock` bump in the release commit
- Reinstall locally after tag push per standing release protocol