### PR TITLE
feat: T1 chroma lifecycle defense-in-depth (nexus-99jb)

### DIFF
--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -38,8 +38,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "nx hook session-end || true",
-            "timeout": 10
+            "command": "nx hook session-end-detach || true",
+            "timeout": 5
           }
         ]
       }

--- a/src/nexus/commands/hook.py
+++ b/src/nexus/commands/hook.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """nx hook — SessionStart and SessionEnd hook subcommands."""
 import json
+import os
 import sys
 
 import click
@@ -35,3 +36,79 @@ def session_end_cmd() -> None:
     """Run the SessionEnd hook (called by Claude Code on session close)."""
     output = hooks.session_end()
     click.echo(output)
+
+
+@hook_group.command("session-end-detach")
+def session_end_detach_cmd() -> None:
+    """Fire-and-forget SessionEnd runner (nexus-99jb Layer 2).
+
+    Double-forks into a detached grandchild that runs ``session_end``
+    synchronously, then returns control to Claude Code in <50ms. This
+    pattern survives the SIGTERM Claude Code sends to hook subprocesses
+    at session close (anthropics/claude-code#41577) because by the time
+    the signal is delivered the grandchild has already been reparented
+    to init and no longer shares the hook's process group.
+
+    On platforms without ``os.fork`` (Windows), falls through to the
+    synchronous path so behaviour degrades gracefully rather than
+    silently skipping the cleanup entirely.
+    """
+    if not hasattr(os, "fork"):
+        output = hooks.session_end()
+        click.echo(output)
+        return
+
+    # First fork: allow the parent (us, the hook subprocess Claude Code
+    # launched) to return immediately. The child will daemonize.
+    try:
+        first_pid = os.fork()
+    except OSError as exc:
+        _log.warning("session_end_detach_fork_failed", error=str(exc))
+        hooks.session_end()
+        return
+    if first_pid > 0:
+        # Parent: exit immediately. Claude Code sees exit 0 and moves on.
+        os._exit(0)
+
+    # Child: detach from controlling terminal and start a new session
+    # so the grandchild isn't in Claude Code's process group and
+    # survives a pgrp-wide SIGTERM.
+    try:
+        os.setsid()
+    except OSError:
+        pass
+
+    # Second fork: the grandchild is not a session leader, so it can
+    # never reacquire a controlling terminal. That's the canonical
+    # daemon recipe.
+    try:
+        second_pid = os.fork()
+    except OSError:
+        # Best effort: run the work right here if we can't fork again.
+        hooks.session_end()
+        os._exit(0)
+    if second_pid > 0:
+        os._exit(0)
+
+    # Redirect stdio to /dev/null so the grandchild doesn't share the
+    # hook's fds (Claude Code may close them on shutdown, and writes
+    # to a closed fd would kill us).
+    try:
+        devnull = os.open(os.devnull, os.O_RDWR)
+        for fd in (0, 1, 2):
+            try:
+                os.dup2(devnull, fd)
+            except OSError:
+                pass
+        if devnull > 2:
+            os.close(devnull)
+    except OSError:
+        pass
+
+    # Now do the real work. Exceptions are swallowed — we're detached
+    # and nothing can observe us anyway.
+    try:
+        hooks.session_end()
+    except Exception:
+        pass
+    os._exit(0)

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -18,8 +18,10 @@ from nexus.session import (
     SESSIONS_DIR,
     _ppid_of,
     find_ancestor_session,
+    find_claude_root_pid,
     find_session_by_id,
     generate_session_id,
+    spawn_t1_watchdog,
     start_t1_server,
     stop_t1_server,
     sweep_stale_sessions,
@@ -120,8 +122,23 @@ def session_start(claude_session_id: str | None = None) -> str:
             if existing is None:
                 try:
                     host, port, server_pid, tmpdir = start_t1_server()
+                    # nexus-99jb Layer 1: spawn a detached watchdog that
+                    # watches the Claude Code root PID + the chroma PID
+                    # and triggers graceful shutdown when Claude Code
+                    # disappears. Independent of SessionEnd firing, so
+                    # covers /exit (#17885) and Hook cancelled (#41577).
+                    claude_root_pid = find_claude_root_pid()
+                    session_file = SESSIONS_DIR / f"{session_id}.session"
+                    watchdog_pid = spawn_t1_watchdog(
+                        claude_pid=claude_root_pid,
+                        chroma_pid=server_pid,
+                        session_file=session_file,
+                        tmpdir=tmpdir,
+                    ) if claude_root_pid else 0
                     write_session_record_by_id(
-                        SESSIONS_DIR, session_id, host, port, server_pid, tmpdir
+                        SESSIONS_DIR, session_id, host, port, server_pid,
+                        tmpdir, claude_root_pid=claude_root_pid,
+                        watchdog_pid=watchdog_pid,
                     )
                 except Exception as exc:
                     _log.warning(

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -6,6 +6,7 @@ import socket
 import subprocess
 import time
 from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 import structlog
@@ -186,6 +187,25 @@ def find_ancestor_session(
     return None
 
 
+def _is_pid_alive(pid: int) -> bool:
+    """Return True if *pid* names a running process (liveness probe).
+
+    Uses ``os.kill(pid, 0)`` — raises ``ProcessLookupError`` when the
+    process is gone, ``PermissionError`` when it exists but is owned
+    by a different uid (treated as alive). Invalid pids (<=0) are
+    treated as dead.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
 def sweep_stale_sessions(
     sessions_dir: Path | None = None,
     max_age_hours: float = _SESSION_MAX_AGE_SECONDS / 3600.0,
@@ -194,6 +214,12 @@ def sweep_stale_sessions(
 
     For each stale record: sends SIGTERM → SIGKILL to server_pid, removes the
     backing tmpdir, and deletes the session file. Non-JSON files are ignored.
+
+    nexus-99jb Layer 3 extension: a record is also reaped eagerly (regardless
+    of age) when its ``server_pid`` is no longer alive OR its
+    ``claude_root_pid`` has disappeared. The age-based threshold is retained
+    as a final safety net for records that lack PID metadata (legacy schema)
+    or point at a PID namespace the current user can't probe.
     """
     if sessions_dir is None:
         sessions_dir = SESSIONS_DIR
@@ -226,15 +252,36 @@ def sweep_stale_sessions(
             record = json.loads(f.read_text())
             if not isinstance(record, dict):
                 continue
-            if record.get("created_at", time.time()) < cutoff:
-                server_pid = record.get("server_pid")
-                if server_pid:
+            server_pid = record.get("server_pid")
+            claude_root_pid = record.get("claude_root_pid", 0)
+            # Reap triggers (any one is sufficient):
+            #   1. Age-based: created_at older than cutoff (legacy path).
+            #   2. Liveness: server_pid is no longer alive — process
+            #      already gone but the file + tmpdir were left behind.
+            #   3. Anchor loss: claude_root_pid known and dead — Claude
+            #      Code exited but SessionEnd didn't fire (/exit path,
+            #      hook cancelled, etc). Watchdog normally covers this
+            #      within 5s; this is belt-and-braces on SessionStart.
+            age_expired = record.get("created_at", time.time()) < cutoff
+            server_dead = server_pid and not _is_pid_alive(int(server_pid))
+            anchor_dead = claude_root_pid and not _is_pid_alive(int(claude_root_pid))
+            if age_expired or server_dead or anchor_dead:
+                if server_pid and not server_dead:
                     stop_t1_server(server_pid)
                 tmpdir = record.get("tmpdir", "")
                 if tmpdir:
                     import shutil
                     shutil.rmtree(tmpdir, ignore_errors=True)
                 _try_remove_path(f)
+                _log.info(
+                    "sweep_reaped_session",
+                    session_id=record.get("session_id", "?"),
+                    reason=(
+                        "age" if age_expired
+                        else "server_dead" if server_dead
+                        else "anchor_dead"
+                    ),
+                )
         except (json.JSONDecodeError, OSError) as exc:
             _log.debug("sweep_corrupt_session_file", path=str(f), error=str(exc))
 
@@ -434,16 +481,24 @@ def write_session_record_by_id(
     port: int,
     server_pid: int,
     tmpdir: str = "",
+    claude_root_pid: int = 0,
+    watchdog_pid: int = 0,
 ) -> Path:
     """Write a JSON session record at *sessions_dir*/{session_id}.session.
 
     The UUID-keyed counterpart of :func:`write_session_record`. Always use
     this in new code so T1 is scoped to a Claude conversation rather than
     a terminal session.
+
+    ``claude_root_pid`` and ``watchdog_pid`` (nexus-99jb) are optional
+    metadata used by the orphan reaper and the self-watchdog sidecar.
+    Legacy records without these fields are still accepted by callers —
+    reap logic treats them as "no liveness anchor available, fall back
+    to age-based sweep".
     """
     sessions_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     path = sessions_dir / f"{session_id}.session"
-    record = {
+    record: dict[str, Any] = {
         "session_id": session_id,
         "server_host": host,
         "server_port": port,
@@ -451,12 +506,103 @@ def write_session_record_by_id(
         "created_at": time.time(),
         "tmpdir": tmpdir,
     }
+    if claude_root_pid:
+        record["claude_root_pid"] = claude_root_pid
+    if watchdog_pid:
+        record["watchdog_pid"] = watchdog_pid
     fd = os.open(str(path), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
     try:
         os.write(fd, json.dumps(record).encode())
     finally:
         os.close(fd)
     return path
+
+
+def _command_name_of(pid: int) -> str:
+    """Return the command name (argv[0] basename) of *pid*, or "" if unknown.
+
+    Used by :func:`find_claude_root_pid` to identify which ancestor is
+    Claude Code. Falls back to an empty string on any error — caller
+    treats that as "not a match" and keeps walking.
+    """
+    try:
+        out = subprocess.check_output(
+            ["ps", "-o", "comm=", "-p", str(pid)],
+            stderr=subprocess.DEVNULL, text=True, timeout=2,
+        ).strip()
+        return Path(out).name if out else ""
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+            OSError):
+        return ""
+
+
+def find_claude_root_pid(start_pid: int | None = None) -> int:
+    """Walk the PPID chain looking for the Claude Code process.
+
+    Returns the topmost ancestor PID whose command name starts with
+    ``claude`` (matches ``claude``, ``claude-code``, and future CLI
+    renames). When no Claude ancestor is found — e.g. the caller isn't
+    actually under Claude Code — returns the immediate PPID as a
+    fallback so the watchdog at least watches *something* rather than
+    nothing.
+
+    Returns 0 only when the PPID chain can't be walked at all.
+    """
+    pid = start_pid if start_pid is not None else os.getpid()
+    seen: set[int] = set()
+    best: int = 0
+    # Walk upward. Remember the topmost "claude*" ancestor; fall back to
+    # the immediate PPID if none matches.
+    cur = _ppid_of(pid)
+    immediate_ppid = cur or 0
+    while cur and cur not in seen and cur > 1:
+        seen.add(cur)
+        name = _command_name_of(cur)
+        if name.lower().startswith("claude"):
+            best = cur
+            # Keep walking — in theory a "claude" shell could itself be
+            # under another "claude" (agent spawning). Prefer topmost.
+        cur = _ppid_of(cur)
+    return best or immediate_ppid
+
+
+def spawn_t1_watchdog(
+    *,
+    claude_pid: int,
+    chroma_pid: int,
+    session_file: Path,
+    tmpdir: str,
+) -> int:
+    """Launch the T1 watchdog sidecar as a detached process.
+
+    Returns the watchdog's PID. The watchdog runs under ``python -m
+    nexus.t1_watchdog`` in its own session (``start_new_session=True``)
+    so it survives the SessionStart hook's exit and can reap the
+    chroma server when Claude Code dies. See ``t1_watchdog.py`` for
+    the polling loop.
+
+    Failure is non-fatal: returns 0 and logs a warning. Layer 3
+    (SessionStart orphan reaper) + the legacy age-based sweep cover
+    the case where the watchdog couldn't start.
+    """
+    import sys as _sys
+    try:
+        proc = subprocess.Popen(
+            [
+                _sys.executable, "-m", "nexus.t1_watchdog",
+                "--claude-pid", str(claude_pid),
+                "--chroma-pid", str(chroma_pid),
+                "--session-file", str(session_file),
+                "--tmpdir", tmpdir,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return proc.pid
+    except OSError as exc:
+        _log.warning("spawn_t1_watchdog_failed", error=str(exc))
+        return 0
 
 
 def find_session_by_id(

--- a/src/nexus/t1_watchdog.py
+++ b/src/nexus/t1_watchdog.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""T1 ChromaDB server watchdog (nexus-99jb Layer 1).
+
+Detached sidecar spawned alongside each per-session chroma server.
+Polls the Claude Code root PID and the chroma PID every
+:data:`POLL_INTERVAL` seconds. When Claude Code goes away it triggers
+the graceful shutdown path (``stop_t1_server``) that sends SIGTERM to
+chroma's process group, giving chroma's multiprocessing workers and
+resource_tracker time to ``sem_unlink`` their POSIX named semaphores
+(the worker-cleanup invariant from beads nexus-dc57 / nexus-ze2a).
+
+Defence-in-depth for the three failure modes documented in
+anthropics/claude-code#41577 (SessionEnd killed before completion)
+and #17885 (SessionEnd never fires on /exit). The watchdog is
+independent of any hook firing — as long as the Claude Code root
+PID disappears, chroma dies within ``POLL_INTERVAL`` seconds.
+
+Launched as ``python -m nexus.t1_watchdog`` by ``session_start()``.
+Intentionally uses only stdlib to avoid import-time overhead; the
+hot path is a ``time.sleep`` + two ``os.kill`` calls per tick.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+#: Seconds between liveness checks. Trade-off: lower value means faster
+#: reap when Claude Code dies; higher value means less CPU. 5s keeps
+#: the observable leak window small without adding meaningful load.
+POLL_INTERVAL: float = 5.0
+
+
+def _is_alive(pid: int) -> bool:
+    """Return True if *pid* names a live process.
+
+    Uses ``os.kill(pid, 0)`` — the POSIX liveness-test idiom. A
+    ``PermissionError`` means the process exists but we can't signal
+    it (uid mismatch), so treat as alive. ``ProcessLookupError`` is
+    the only definitive "gone" signal.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _cleanup(
+    *, chroma_pid: int, session_file: Path | None, tmpdir: Path | None,
+) -> None:
+    """Graceful shutdown: stop chroma, then remove state on disk.
+
+    Imports ``stop_t1_server`` lazily so the watchdog's hot loop stays
+    free of nexus package imports (keeps startup cost negligible).
+    """
+    try:
+        from nexus.session import stop_t1_server
+        stop_t1_server(chroma_pid)
+    except Exception:
+        # Best-effort: the chroma process may already be gone, or
+        # nexus may not be importable (unusual install). Proceed to
+        # on-disk cleanup regardless.
+        pass
+
+    if session_file is not None:
+        try:
+            session_file.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    if tmpdir is not None:
+        try:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        except OSError:
+            pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="T1 ChromaDB server watchdog (nexus-99jb).",
+    )
+    parser.add_argument("--claude-pid", type=int, required=True,
+                        help="Root Claude Code PID to watch.")
+    parser.add_argument("--chroma-pid", type=int, required=True,
+                        help="PID of the chroma server to supervise.")
+    parser.add_argument("--session-file", default="",
+                        help="Session record file to remove on cleanup.")
+    parser.add_argument("--tmpdir", default="",
+                        help="ChromaDB tmpdir to remove on cleanup.")
+    args = parser.parse_args(argv)
+
+    session_file = Path(args.session_file) if args.session_file else None
+    tmpdir = Path(args.tmpdir) if args.tmpdir else None
+
+    while True:
+        time.sleep(POLL_INTERVAL)
+        # Chroma crashed or was stopped by SessionEnd — nothing to
+        # watch anymore. Exit silently; the SessionEnd path owns the
+        # on-disk cleanup when it was responsible for the stop.
+        if not _is_alive(args.chroma_pid):
+            return 0
+        # Claude Code is gone. Trigger graceful shutdown.
+        if not _is_alive(args.claude_pid):
+            break
+
+    _cleanup(
+        chroma_pid=args.chroma_pid,
+        session_file=session_file,
+        tmpdir=tmpdir,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -184,11 +184,16 @@ def test_sweep_stale_sessions_keeps_fresh_records(tmp_path: Path) -> None:
     NB: Numeric-stem files are now swept *unconditionally* as a migration
     from the legacy PID-keyed scheme — see
     test_sweep_stale_sessions_removes_legacy_numeric_stem_unconditionally
-    for that path.
+    for that path. nexus-99jb added a liveness-based reap: records whose
+    ``server_pid`` is dead are reaped regardless of age. Use the test's
+    own PID as the stand-in so the record looks live.
     """
+    import os as _os
     sessions = tmp_path / "sessions"
-    path = write_session_record_by_id(sessions, "fresh-uuid",
-                                      host="127.0.0.1", port=51004, server_pid=102)
+    path = write_session_record_by_id(
+        sessions, "fresh-uuid",
+        host="127.0.0.1", port=51004, server_pid=_os.getpid(),
+    )
 
     sweep_stale_sessions(sessions_dir=sessions)
     assert path.exists()
@@ -335,13 +340,16 @@ def test_sweep_stale_sessions_removes_legacy_numeric_stem_unconditionally(
         "tmpdir": "",
     }))
 
-    # UUID-keyed file in the new format — should survive.
+    # UUID-keyed file in the new format — should survive. Use this
+    # process's own PID as server_pid so the nexus-99jb liveness-based
+    # reap path sees a live anchor and leaves the record alone.
+    import os as _os
     valid = sessions / "valid-uuid.session"
     valid.write_text(json.dumps({
         "session_id": "valid-uuid",
         "server_host": "127.0.0.1",
         "server_port": 66666,
-        "server_pid": 99998,
+        "server_pid": _os.getpid(),
         "created_at": _time.time(),
         "tmpdir": "",
     }))
@@ -353,3 +361,135 @@ def test_sweep_stale_sessions_removes_legacy_numeric_stem_unconditionally(
 
     assert not legacy.exists(), "legacy PID-keyed file should be swept regardless of age"
     assert valid.exists(), "UUID-keyed file should survive the sweep"
+
+
+# ── nexus-99jb Layer 3: aggressive liveness-based reap ───────────────────────
+
+
+def test_sweep_reaps_when_server_pid_is_dead(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh record whose ``server_pid`` is no longer alive must be reaped
+    regardless of age. This covers the canonical leak path: chroma process
+    died, SessionEnd didn't fire, the record + tmpdir stayed behind.
+    """
+    sessions = tmp_path / "sessions"
+    # Port any PID we know is dead. 1 is launchd/init on macOS — always
+    # alive — so we use a synthetic large PID that the kernel will refuse
+    # with ESRCH. Linux treats ``kill(99999999, 0)`` as ProcessLookupError
+    # on an unused PID, and we monkeypatch _is_pid_alive to be certain.
+    from nexus.session import write_session_record_by_id
+    monkeypatch.setattr("nexus.session._is_pid_alive", lambda pid: False)
+    monkeypatch.setattr("nexus.session.stop_t1_server", lambda _pid: None)
+
+    path = write_session_record_by_id(
+        sessions, "dead-server-uuid",
+        host="127.0.0.1", port=57999, server_pid=7777,
+    )
+    assert path.exists()
+
+    sweep_stale_sessions(sessions_dir=sessions)
+    assert not path.exists(), "record with dead server_pid must be reaped eagerly"
+
+
+def test_sweep_reaps_when_claude_root_pid_is_dead(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A record whose ``claude_root_pid`` anchor is dead gets reaped even if
+    the chroma ``server_pid`` is still alive — the anchor loss means the
+    session is effectively over (belt-and-braces for the case where
+    Claude Code died hard and the watchdog also missed).
+    """
+    sessions = tmp_path / "sessions"
+    from nexus.session import write_session_record_by_id
+
+    # Live server_pid (us) but dead claude_root_pid (synthetic). Only the
+    # anchor-dead liveness arm should fire.
+    own = os.getpid()
+    calls: list[int] = []
+    def _fake_alive(pid: int) -> bool:
+        calls.append(pid)
+        return pid == own
+    monkeypatch.setattr("nexus.session._is_pid_alive", _fake_alive)
+    monkeypatch.setattr("nexus.session.stop_t1_server", lambda _pid: None)
+
+    path = write_session_record_by_id(
+        sessions, "dead-anchor-uuid",
+        host="127.0.0.1", port=58001, server_pid=own,
+        claude_root_pid=7654321,
+    )
+    assert path.exists()
+
+    sweep_stale_sessions(sessions_dir=sessions)
+    assert not path.exists(), "anchor-dead record must be reaped regardless of server liveness"
+
+
+def test_write_session_record_persists_claude_root_pid_and_watchdog_pid(
+    tmp_path: Path,
+) -> None:
+    """The record serializer carries both the claude_root_pid anchor and
+    the watchdog's PID when the caller supplies them.
+    """
+    from nexus.session import write_session_record_by_id
+
+    sessions = tmp_path / "sessions"
+    path = write_session_record_by_id(
+        sessions, "pid-roundtrip-uuid",
+        host="127.0.0.1", port=58002, server_pid=1234,
+        claude_root_pid=5678, watchdog_pid=9012,
+    )
+    record = json.loads(path.read_text())
+    assert record["claude_root_pid"] == 5678
+    assert record["watchdog_pid"] == 9012
+    assert record["server_pid"] == 1234
+
+
+def test_find_claude_root_pid_returns_ppid_fallback_when_no_claude_ancestor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no ancestor has a 'claude*' command name, the function returns
+    the immediate PPID so the watchdog at least watches something.
+    """
+    from nexus.session import find_claude_root_pid
+
+    monkeypatch.setattr("nexus.session._ppid_of", lambda pid: 42 if pid != 42 else 1)
+    monkeypatch.setattr("nexus.session._command_name_of", lambda pid: "bash")
+
+    # Our "ppid chain" is start_pid → 42 → 1 (init), none of which are named
+    # claude, so we expect the immediate PPID (42) as the fallback.
+    result = find_claude_root_pid(start_pid=100)
+    assert result == 42
+
+
+def test_find_claude_root_pid_prefers_claude_ancestor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When an ancestor's command name starts with 'claude', return it."""
+    from nexus.session import find_claude_root_pid
+
+    # Chain: 100 → 200 (bash) → 300 (claude) → 1 (init)
+    parents = {100: 200, 200: 300, 300: 1}
+    names = {200: "bash", 300: "claude"}
+    monkeypatch.setattr("nexus.session._ppid_of", lambda pid: parents.get(pid))
+    monkeypatch.setattr(
+        "nexus.session._command_name_of",
+        lambda pid: names.get(pid, ""),
+    )
+
+    assert find_claude_root_pid(start_pid=100) == 300
+
+
+def test_find_claude_root_pid_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Command-name match is case-insensitive (``Claude`` on some platforms)."""
+    from nexus.session import find_claude_root_pid
+
+    parents = {100: 200, 200: 1}
+    names = {200: "Claude"}
+    monkeypatch.setattr("nexus.session._ppid_of", lambda pid: parents.get(pid))
+    monkeypatch.setattr(
+        "nexus.session._command_name_of",
+        lambda pid: names.get(pid, ""),
+    )
+    assert find_claude_root_pid(start_pid=100) == 200

--- a/tests/test_t1_watchdog.py
+++ b/tests/test_t1_watchdog.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for the T1 server watchdog (nexus-99jb Layer 1)."""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+
+# ── _is_alive ─────────────────────────────────────────────────────────────────
+
+
+class TestIsAlive:
+
+    def test_own_process_is_alive(self):
+        from nexus.t1_watchdog import _is_alive
+        assert _is_alive(os.getpid()) is True
+
+    def test_zero_and_negative_pids_are_not_alive(self):
+        from nexus.t1_watchdog import _is_alive
+        assert _is_alive(0) is False
+        assert _is_alive(-1) is False
+
+    def test_process_lookup_error_means_dead(self):
+        from nexus.t1_watchdog import _is_alive
+        with patch("os.kill", side_effect=ProcessLookupError):
+            assert _is_alive(12345) is False
+
+    def test_permission_error_means_alive(self):
+        """Process exists but owned by another uid — still alive."""
+        from nexus.t1_watchdog import _is_alive
+        with patch("os.kill", side_effect=PermissionError):
+            assert _is_alive(1) is True
+
+
+# ── _cleanup ──────────────────────────────────────────────────────────────────
+
+
+class TestCleanup:
+
+    def test_cleanup_removes_session_file_and_tmpdir(self, tmp_path):
+        from nexus.t1_watchdog import _cleanup
+
+        session_file = tmp_path / "test.session"
+        session_file.write_text("{}")
+        tmpdir = tmp_path / "nx_t1_xyz"
+        tmpdir.mkdir()
+        (tmpdir / "chroma.sqlite3").write_bytes(b"data")
+
+        # Mock stop_t1_server so nothing real gets signalled.
+        with patch("nexus.session.stop_t1_server") as mock_stop:
+            _cleanup(chroma_pid=99999, session_file=session_file, tmpdir=tmpdir)
+
+        mock_stop.assert_called_once_with(99999)
+        assert not session_file.exists()
+        assert not tmpdir.exists()
+
+    def test_cleanup_swallows_session_file_oserror(self, tmp_path):
+        """If session file can't be removed, cleanup still proceeds."""
+        from nexus.t1_watchdog import _cleanup
+
+        with patch("nexus.session.stop_t1_server"):
+            # Nonexistent session file — unlink(missing_ok=True) succeeds,
+            # but let's test an actively unwriteable path too.
+            _cleanup(
+                chroma_pid=1, session_file=tmp_path / "does-not-exist",
+                tmpdir=None,
+            )  # no raise
+
+    def test_cleanup_swallows_stop_t1_server_failure(self, tmp_path):
+        """Chroma stop failures don't prevent tmpdir cleanup."""
+        from nexus.t1_watchdog import _cleanup
+
+        tmpdir = tmp_path / "nx_t1_err"
+        tmpdir.mkdir()
+        with patch("nexus.session.stop_t1_server",
+                   side_effect=RuntimeError("simulated")):
+            _cleanup(chroma_pid=1, session_file=None, tmpdir=tmpdir)
+
+        assert not tmpdir.exists(), "tmpdir cleanup must run even if stop fails"
+
+
+# ── main() loop ───────────────────────────────────────────────────────────────
+
+
+class TestMain:
+
+    def test_exits_when_chroma_dies_without_cleanup(self, monkeypatch, tmp_path):
+        """If chroma dies first, the watchdog exits cleanly without calling
+        stop_t1_server — SessionEnd or sweep own that cleanup.
+        """
+        from nexus import t1_watchdog
+
+        # Patch sleep to be instant + _is_alive sequence:
+        #   Tick 1: chroma dead → exit(0) without cleanup.
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(
+            t1_watchdog, "_is_alive",
+            lambda pid: False,  # everything dead
+        )
+
+        session_file = tmp_path / "s.session"
+        session_file.write_text("{}")
+        with patch.object(t1_watchdog, "_cleanup") as mock_cleanup:
+            rc = t1_watchdog.main([
+                "--claude-pid", "100",
+                "--chroma-pid", "200",
+                "--session-file", str(session_file),
+                "--tmpdir", str(tmp_path / "tmpdir"),
+            ])
+        assert rc == 0
+        mock_cleanup.assert_not_called()
+        # Session file should still exist — the watchdog only cleans when
+        # IT was responsible for the chroma teardown.
+        assert session_file.exists()
+
+    def test_triggers_cleanup_when_claude_pid_dies(self, monkeypatch, tmp_path):
+        """Chroma alive + claude dead → cleanup fires and main returns."""
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+
+        def _fake_alive(pid: int) -> bool:
+            return pid == 200  # chroma alive, claude dead
+
+        monkeypatch.setattr(t1_watchdog, "_is_alive", _fake_alive)
+
+        with patch.object(t1_watchdog, "_cleanup") as mock_cleanup:
+            rc = t1_watchdog.main([
+                "--claude-pid", "100",
+                "--chroma-pid", "200",
+                "--session-file", str(tmp_path / "s.session"),
+                "--tmpdir", str(tmp_path / "tmpdir"),
+            ])
+
+        assert rc == 0
+        mock_cleanup.assert_called_once()
+        kwargs = mock_cleanup.call_args.kwargs
+        assert kwargs["chroma_pid"] == 200
+        assert str(kwargs["session_file"]).endswith("s.session")


### PR DESCRIPTION
## Summary

Fix a leak that accumulated **103 orphaned chroma processes + 183 tmpdirs** on the reference install over 3 days. Root cause is an upstream Claude Code bug ([anthropics/claude-code#41577](https://github.com/anthropics/claude-code/issues/41577), closed as wont-fix): Claude Code SIGTERMs hook subprocesses at session close without waiting for them, so the ``SessionEnd`` hook never finishes its ``stop_t1_server`` call. Related: [#17885](https://github.com/anthropics/claude-code/issues/17885) — SessionEnd doesn't fire at all on ``/exit``.

Three independent defense layers, any one of which closes the leak on its own:

- **Layer 1 — self-watchdog sidecar** (`src/nexus/t1_watchdog.py`, new). Spawned detached alongside each per-session chroma server. Polls Claude Code root PID + chroma PID every 5s via `os.kill(pid, 0)`. On `ProcessLookupError` for the claude root, triggers the existing `stop_t1_server` graceful-SIGTERM path (preserving the pgrp-wide signal so chroma's multiprocessing workers `sem_unlink` their POSIX named semaphores — invariant from nexus-dc57 / nexus-ze2a). Independent of hooks firing at all. Worst-case leak window: 5s.
- **Layer 2 — detached SessionEnd** (`nx hook session-end-detach`). Double-fork daemonization: first fork exits the hook in <50ms (Claude Code sees success), `setsid` plus second fork produces a grandchild that's reparented to init and no longer in Claude Code's pgrp, so the shutdown SIGTERM misses it. Runs the existing `session_end` cleanup to completion. Documented workaround from #41577.
- **Layer 3 — aggressive liveness sweep** (`session.sweep_stale_sessions`). On SessionStart, reap any session record whose `server_pid` is dead OR whose `claude_root_pid` anchor is dead, regardless of age. Today the sweep only acts on records older than 24h — which is why 103 orphans accumulated in the first place. Belt-and-braces: even a cold-start after days of drift cleans up on first session boot.

## Evidence

Forensics from the reference install on 2026-04-23 preserved at `/tmp/nxt1-forensics/`: 103 live `nx_t1_*` chroma processes (oldest 33h+), 183 leftover tmpdirs in `/var/folders/.../T/`, 4 session files (2 orphaned). After manual reap: 103 → 2, 183 → 2, 4 → 2 — confirming the leak is entirely post-session garbage.

## Test plan

- [x] `tests/test_t1_watchdog.py` — 9 new tests: `_is_alive` (own pid / zero / ProcessLookupError / PermissionError), `_cleanup` (happy / unlink failure / stop failure), `main` (chroma-dies-first no-cleanup, claude-dies triggers cleanup)
- [x] `tests/test_session.py` — 5 new tests: dead `server_pid` reaped, dead `claude_root_pid` reaped, record schema round-trip for both PIDs, `find_claude_root_pid` fallback + ancestor match + case-insensitive
- [x] 2 existing sweep tests updated to use `os.getpid()` as the server PID so the liveness check sees a live anchor
- [x] Full unit suite: 5021 passed / 27 skipped / 0 failures in 13:54

## Beads

Closes nexus-99jb.

## Release plan

- Tag as `v4.10.3` after merge (patch — operational fix, no user-visible behaviour change)
- Four manifests + `CHANGELOG.md` + `nx/CHANGELOG.md` + `uv.lock` bump in release commit
- Reinstall locally, verify watchdog spawns + 5s-after-parent-death cleanup on a synthetic test