### PR TITLE
fix(session): sweep stale T1 records on UUID rollover (nexus-886w)

### DIFF
--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -220,12 +220,21 @@ def sweep_stale_sessions(
     ``claude_root_pid`` has disappeared. The age-based threshold is retained
     as a final safety net for records that lack PID metadata (legacy schema)
     or point at a PID namespace the current user can't probe.
+
+    nexus-886w extension: a record whose ``session_id`` does not match the
+    ``current_session`` pointer is reaped even when both PIDs are alive.
+    Covers the same-claude-different-UUID case (``/clear`` or ``/resume``
+    rollover within a single live claude process) where the watchdog
+    keeps seeing the parent PID alive and never fires. The previous
+    fourth gap in the GC coverage: bounded to 24h via the age threshold,
+    but not closed.
     """
     if sessions_dir is None:
         sessions_dir = SESSIONS_DIR
     if not sessions_dir.exists():
         return
     cutoff = time.time() - max_age_hours * 3600.0
+    current_uuid = read_claude_session_id()
     for f in sessions_dir.glob("*.session"):
         # Migration: numeric-stem files come from the legacy PID-keyed scheme
         # that bound T1 to the terminal session instead of the Claude
@@ -265,7 +274,22 @@ def sweep_stale_sessions(
             age_expired = record.get("created_at", time.time()) < cutoff
             server_dead = server_pid and not _is_pid_alive(int(server_pid))
             anchor_dead = claude_root_pid and not _is_pid_alive(int(claude_root_pid))
-            if age_expired or server_dead or anchor_dead:
+            # nexus-886w: same claude process rolled to a different
+            # conversation UUID (``/clear`` or ``/resume``). The record is
+            # for a UUID that no longer matches ``current_session`` even
+            # though claude itself is still alive, so the watchdog never
+            # fires. Requires claude_root_pid to be alive — otherwise the
+            # anchor_dead arm owns the reap and reports the more specific
+            # reason.
+            record_uuid = record.get("session_id", "")
+            uuid_stale = bool(
+                current_uuid
+                and record_uuid
+                and record_uuid != current_uuid
+                and claude_root_pid
+                and not anchor_dead
+            )
+            if age_expired or server_dead or anchor_dead or uuid_stale:
                 if server_pid and not server_dead:
                     stop_t1_server(server_pid)
                 tmpdir = record.get("tmpdir", "")
@@ -279,7 +303,8 @@ def sweep_stale_sessions(
                     reason=(
                         "age" if age_expired
                         else "server_dead" if server_dead
-                        else "anchor_dead"
+                        else "anchor_dead" if anchor_dead
+                        else "uuid_mismatch"
                     ),
                 )
         except (json.JSONDecodeError, OSError) as exc:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -392,6 +392,144 @@ def test_sweep_reaps_when_server_pid_is_dead(
     assert not path.exists(), "record with dead server_pid must be reaped eagerly"
 
 
+def test_sweep_reaps_on_uuid_mismatch_with_live_claude(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nexus-886w: record's session_id doesn't match the current_session
+    pointer AND claude_root_pid is alive → reap as 'uuid_mismatch'.
+
+    This closes the same-claude-different-UUID leak the earlier
+    nexus-99jb defense-in-depth layers did not cover (watchdog keeps
+    seeing the parent PID alive, anchor_dead false, server_dead false,
+    age below threshold → no reap trigger).
+    """
+    sessions = tmp_path / "sessions"
+    from nexus.session import write_session_record_by_id
+
+    # Both PIDs 'alive' via monkeypatch. The old session's UUID differs
+    # from the current-session pointer — the only reap arm that should
+    # fire is uuid_mismatch.
+    own = os.getpid()
+    monkeypatch.setattr("nexus.session._is_pid_alive", lambda _pid: True)
+    monkeypatch.setattr("nexus.session.stop_t1_server", lambda _pid: None)
+    monkeypatch.setattr(
+        "nexus.session.read_claude_session_id",
+        lambda: "current-uuid-after-clear",
+    )
+
+    path = write_session_record_by_id(
+        sessions, "stale-uuid-pre-clear",
+        host="127.0.0.1", port=58010, server_pid=own,
+        claude_root_pid=own,
+    )
+    assert path.exists()
+
+    sweep_stale_sessions(sessions_dir=sessions)
+    assert not path.exists(), (
+        "record with session_id != current_session must be reaped "
+        "when claude_root_pid is alive (uuid_mismatch trigger)"
+    )
+
+
+def test_sweep_keeps_record_matching_current_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nexus-886w: the current session's own record must NOT be reaped by
+    the uuid_mismatch arm — the whole point of the trigger is to spare
+    live sessions.
+    """
+    sessions = tmp_path / "sessions"
+    from nexus.session import write_session_record_by_id
+
+    own = os.getpid()
+    monkeypatch.setattr("nexus.session._is_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        "nexus.session.read_claude_session_id",
+        lambda: "active-uuid",
+    )
+
+    path = write_session_record_by_id(
+        sessions, "active-uuid",
+        host="127.0.0.1", port=58011, server_pid=own,
+        claude_root_pid=own,
+    )
+    sweep_stale_sessions(sessions_dir=sessions)
+    assert path.exists(), "active session must survive sweep"
+
+
+def test_sweep_keeps_record_when_current_session_pointer_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nexus-886w: when read_claude_session_id returns None (flat file
+    absent or unreadable), the uuid_mismatch arm must not fire — that
+    would regress the pre-change behaviour to reap every session.
+    """
+    sessions = tmp_path / "sessions"
+    from nexus.session import write_session_record_by_id
+
+    own = os.getpid()
+    monkeypatch.setattr("nexus.session._is_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        "nexus.session.read_claude_session_id", lambda: None,
+    )
+
+    path = write_session_record_by_id(
+        sessions, "some-uuid",
+        host="127.0.0.1", port=58012, server_pid=own,
+        claude_root_pid=own,
+    )
+    sweep_stale_sessions(sessions_dir=sessions)
+    assert path.exists(), (
+        "missing current_session pointer must not trigger uuid_mismatch"
+    )
+
+
+def test_sweep_uuid_mismatch_deferred_to_anchor_dead_when_claude_exited(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nexus-886w: when claude_root_pid is dead AND uuid also mismatches,
+    the reap should be attributed to ``anchor_dead`` (the more specific
+    reason), not ``uuid_mismatch``. Observability contract: logs must
+    pin the primary failure mode.
+    """
+    sessions = tmp_path / "sessions"
+    from nexus.session import write_session_record_by_id
+
+    own = os.getpid()
+    # server alive, anchor dead, uuid also mismatches.
+    def _alive(pid: int) -> bool:
+        return pid == own
+
+    monkeypatch.setattr("nexus.session._is_pid_alive", _alive)
+    monkeypatch.setattr("nexus.session.stop_t1_server", lambda _pid: None)
+    monkeypatch.setattr(
+        "nexus.session.read_claude_session_id", lambda: "new-uuid",
+    )
+
+    logged: list[dict] = []
+    def _fake_info(event: str, **kw):  # noqa: ANN001
+        kw["event"] = event
+        logged.append(kw)
+
+    monkeypatch.setattr("nexus.session._log.info", _fake_info)
+
+    path = write_session_record_by_id(
+        sessions, "old-uuid",
+        host="127.0.0.1", port=58013, server_pid=own,
+        claude_root_pid=999_999_999,  # dead
+    )
+    sweep_stale_sessions(sessions_dir=sessions)
+    assert not path.exists()
+    reasons = [e.get("reason") for e in logged if e.get("event") == "sweep_reaped_session"]
+    assert "anchor_dead" in reasons, (
+        "anchor_dead must win when both triggers apply; got "
+        f"{reasons}"
+    )
+    assert "uuid_mismatch" not in reasons, (
+        "specific reason (anchor_dead) must win over uuid_mismatch"
+    )
+
+
 def test_sweep_reaps_when_claude_root_pid_is_dead(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Closes the last gap in the 4.10.3 three-layer T1 chroma GC. When `/clear` or `/resume` rolls the Claude conversation UUID **within a single living claude process**, the old session's chroma stays alive because:
- SessionEnd for the old UUID may not fire (timing / hook behaviour)
- `t1_watchdog` sees `--claude-pid` still alive, keeps chroma running
- `sweep_stale_sessions` saw `server_pid` alive, `claude_root_pid` alive, age < 24h → no reap trigger

Old chroma orphaned until the 24h age threshold eventually catches it.

**Live evidence** from this session's filesystem (2026-04-24): two chroma processes anchored to the same claude PID, one for yesterday's `/resume`-start UUID and one for today's `/clear`'d UUID. Neither would be reaped by the pre-fix logic until the 24h age gate.

## Fix

One new reap trigger in `sweep_stale_sessions` at `src/nexus/session.py:209`:

```python
uuid_stale = bool(
    current_uuid
    and record_uuid
    and record_uuid != current_uuid
    and claude_root_pid
    and not anchor_dead
)
```

Specific-reason ordering preserved in the structured log: `age`, `server_dead`, `anchor_dead` still win when multiple triggers apply, so observability pins the primary failure mode. `uuid_mismatch` is the new least-specific reason.

**Does NOT change behavior for compact events** — compaction keeps the same session UUID, so `record.session_id == current_session` and the new arm is inert.

## Test plan

- [x] `uv run pytest tests/test_session.py -v` — 36 passed (4 new)
  - `test_sweep_reaps_on_uuid_mismatch_with_live_claude` — primary contract
  - `test_sweep_keeps_record_matching_current_session` — active session preserved
  - `test_sweep_keeps_record_when_current_session_pointer_missing` — legacy fallback
  - `test_sweep_uuid_mismatch_deferred_to_anchor_dead_when_claude_exited` — specificity
- [x] `uv run pytest tests/test_session.py tests/test_session_propagation_hypotheses.py tests/test_hooks.py` — 66 passed

## Closes

Closes nexus-886w.