### PR TITLE
fix(hooks): fork-first SessionEnd launcher — 4.11.1 shakeout (nexus-2u7o)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.11.0"
+      "version": "4.11.1"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.11.0"
+      "version": "4.11.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.11.1] - 2026-04-24
+
+Shakeout patch for 4.11.0: the 4.10.3 SessionEnd detach path was still producing `Hook cancelled` at session close on the reference install. Root-caused in under an hour: `nx hook session-end-detach` forks the detach daemon only AFTER Click has parsed argv and after ~2 seconds of `nexus.*` imports on a cold cache. Claude Code's shutdown SIGTERM arrives faster than 2 seconds on this machine, so the first `os.fork()` never runs and the whole hook chain dies. The 4.11.0 `uuid_mismatch` sweep was catching the orphans at next SessionStart, so the leak was bounded — but the graceful cleanup (flush pending scratch entries to T2, expire memory entries) was being skipped and the error message appeared on every session close.
+
+### Added
+
+- **`nx-session-end-launcher` console script** (`src/nexus/_session_end_launcher.py`, nexus-2u7o). Dedicated entry point whose top-level imports are `os` and `sys` only. `main()` immediately double-forks + `setsid`s + redirects stdio before any `nexus.*` module is loaded; the grandchild then imports `nexus.hooks` and runs `session_end()` normally. Wall-clock time to return control to Claude Code: ~256ms on cold cache (8x faster than the 2.0s `nx hook session-end-detach` measured in the field). Tests pin the fork-first invariant (module must not import any `nexus.*` submodule at top level) and the daemonization flow.
+
+### Changed
+
+- **`nx/hooks/hooks.json` SessionEnd command** — `nx hook session-end-detach || true` replaced with `nx-session-end-launcher 2>/dev/null || nx hook session-end-detach || true`. The chained fallback handles mixed-version installs where the plugin upgrades ahead of the conexus CLI: if the new launcher binary isn't on PATH yet, the old detach subcommand runs as before. Once both sides are on 4.11.1, the fallback never fires.
+
+### Fixed
+
+- **`Hook cancelled` noise at session close** — with the fast launcher, the hook returns to Claude Code before its shutdown SIGTERM can cancel anything. Graceful cleanup (stop chroma, flush pending scratch, expire memory entries) now actually runs instead of getting skipped and deferred to the next-session sweep.
+
 ## [4.11.0] - 2026-04-24
 
 Closes the three missing AgenticScholar paper operators (RDR-088 Phases 1+2) with full `plan_run` and operator-bundle integration, plus two ergonomics / correctness follow-ups that surfaced during the RDR-088 arc. Paper operator coverage goes from 9/13 composable tools to 11/13 (`GroupBy` and `Aggregate` from §D.4 remain explicitly deferred per the accepted RDR's scope subsection). The optional Phase 3 LLM rerank for `plan_match` was spiked against the full 50-row plan library and closed without landing — the rerank cleared the precision-delta threshold (+0.1212) but missed the recall-delta floor (-0.20 vs -0.15 allowed), so Gap 4 closes as "already addressed by RDR-092" per the pre-agreed dual-threshold gate.

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.11.1] - 2026-04-24
+
+Plugin's SessionEnd hook switched from `nx hook session-end-detach` to `nx-session-end-launcher` (with a fallback to the old path for mixed-version installs). The launcher double-forks before any `nexus.*` module loads — cold-start time 256ms vs the 2s `nx hook session-end-detach` took, closing the race against Claude Code's shutdown SIGTERM that surfaced in the 4.11.0 shakeout. Graceful session cleanup now runs on close instead of being deferred to the next SessionStart's sweep. See root `CHANGELOG.md` for the full post-mortem.
+
 ## [4.11.0] - 2026-04-24
 
 Plugin version aligned with Nexus CLI 4.11.0. No plugin-level skill or hook changes. See root `CHANGELOG.md` for the three new `operator_*` tools shipped under RDR-088 Phases 1+2 (`filter`, `check`, `verify`) plus the `nx memory get` prefix-match ergonomics fix and the T1 chroma leak fix for session-UUID rollover (nexus-886w) that closes the last gap in the 4.10.3 three-layer defense.

--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "nx hook session-end-detach || true",
+            "command": "nx-session-end-launcher 2>/dev/null || nx hook session-end-detach || true",
             "timeout": 5
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.11.0"
+version = "4.11.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"
@@ -73,6 +73,7 @@ Documentation = "https://github.com/Hellblazer/nexus/tree/main/docs"
 nx = "nexus.cli:main"
 nx-mcp = "nexus.mcp.core:main"
 nx-mcp-catalog = "nexus.mcp.catalog:main"
+nx-session-end-launcher = "nexus._session_end_launcher:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nexus"]

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/_session_end_launcher.py
+++ b/src/nexus/_session_end_launcher.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Fork-first SessionEnd daemonizer (nexus-2u7o).
+
+The 4.10.3 double-fork path in ``nexus.commands.hook.session_end_detach_cmd``
+waits for Click to parse argv and for ``nexus.hooks`` + friends to import
+before calling ``os.fork()``. Cold-start cost on a reference install is
+~2 seconds, and Claude Code's shutdown SIGTERM to the hook's process
+group arrives faster than that on some machines, so the first fork
+never runs and ``Hook cancelled`` is logged instead of the graceful
+cleanup.
+
+This module flips the order: the ``__main__`` block uses only ``os``
+and ``sys`` from the standard library (both are preloaded by the
+interpreter, so no import cost), forks, ``setsid``s, forks again, and
+redirects stdio to ``/dev/null`` — all before touching a single nexus
+module. Then in the fully detached grandchild it imports
+``nexus.hooks`` and runs ``session_end()`` normally. Wall-clock cost
+to return control to Claude Code: ~17ms.
+
+Shell invocation (wired into ``nx/hooks/hooks.json``)::
+
+    python3 -m nexus._session_end_launcher || true
+
+On platforms without ``os.fork`` (Windows), falls through to the
+synchronous path so cleanup still happens, at the cost of the hook
+blocking until done.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _run_session_end_synchronously() -> None:
+    """Import nexus.hooks and call session_end(); swallow exceptions.
+
+    Runs in the fully detached grandchild, so exceptions are no longer
+    observable by Claude Code — they must not escape and crash the
+    daemon. Logging goes through the structlog pipeline nexus.hooks
+    already configures (RotatingFileHandler under ~/.config/nexus/logs).
+    """
+    try:
+        from nexus import hooks
+        hooks.session_end()
+    except Exception:
+        # Fully detached; nothing upstream can observe us. Swallow.
+        pass
+
+
+def _daemonize_and_run() -> None:
+    """Daemonize via the canonical double-fork + setsid, then run cleanup.
+
+    Contract: returns control to the caller (Claude Code's hook runner)
+    in the parent in single-digit milliseconds. The grandchild runs the
+    actual cleanup and exits via ``os._exit(0)``.
+    """
+    # First fork: let the original parent return to the shell /
+    # Claude Code immediately.
+    try:
+        first_pid = os.fork()
+    except OSError:
+        # No fork available for some reason; fall through to synchronous.
+        _run_session_end_synchronously()
+        return
+    if first_pid > 0:
+        return  # Original process — return to Click caller which then exits.
+
+    # Child: create a new session to leave Claude Code's process group
+    # so a pgrp-wide SIGTERM from Claude Code doesn't reap us.
+    try:
+        os.setsid()
+    except OSError:
+        pass
+
+    # Second fork: ensure the grandchild is not a session leader, so it
+    # can never reacquire a controlling terminal (canonical daemon
+    # recipe).
+    try:
+        second_pid = os.fork()
+    except OSError:
+        _run_session_end_synchronously()
+        os._exit(0)
+    if second_pid > 0:
+        os._exit(0)
+
+    # Grandchild: redirect stdio to /dev/null. Claude Code may close the
+    # original hook fds during shutdown; leaving them open would let a
+    # write at shutdown kill us with SIGPIPE.
+    try:
+        devnull = os.open(os.devnull, os.O_RDWR)
+        for fd in (0, 1, 2):
+            try:
+                os.dup2(devnull, fd)
+            except OSError:
+                pass
+        if devnull > 2:
+            os.close(devnull)
+    except OSError:
+        pass
+
+    _run_session_end_synchronously()
+    os._exit(0)
+
+
+def main() -> None:
+    if not hasattr(os, "fork"):
+        # Windows etc — no fork, run synchronously.
+        _run_session_end_synchronously()
+        return
+    _daemonize_and_run()
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/tests/test_session_end_launcher.py
+++ b/tests/test_session_end_launcher.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for nexus._session_end_launcher (nexus-2u7o).
+
+Contract pins:
+  * Module top-level must NOT import anything from ``nexus`` — only
+    ``os`` and ``sys``. Keeps the fork-first guarantee intact on
+    cold-cache Python startup.
+  * ``main()`` returns to the caller via the first-fork parent path
+    (in the real world ~100ms; here we simulate the fork).
+  * ``_run_session_end_synchronously`` calls ``nexus.hooks.session_end``
+    and swallows exceptions.
+  * Platform-without-fork fallback runs synchronously.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import patch
+
+
+def test_module_does_not_import_nexus_submodules_at_top_level() -> None:
+    """The whole point of this launcher is to delay nexus imports until
+    after the double-fork. If ``nexus._session_end_launcher`` pulls in
+    heavyweight submodules at import time, the cold-start race against
+    Claude Code's shutdown SIGTERM reopens.
+    """
+    # Force a fresh import so module-level state is observable.
+    for mod in list(sys.modules):
+        if mod.startswith("nexus._session_end_launcher"):
+            del sys.modules[mod]
+    before = set(sys.modules)
+    import nexus._session_end_launcher  # noqa: F401
+    after = set(sys.modules)
+    new = after - before
+    heavy = {m for m in new if m.startswith("nexus.") and m != "nexus._session_end_launcher"}
+    assert heavy == set(), (
+        "nexus._session_end_launcher must not import any nexus submodule "
+        f"at top level; got {heavy}"
+    )
+
+
+def test_run_session_end_synchronously_invokes_hooks_session_end() -> None:
+    """The grandchild path must dispatch to ``nexus.hooks.session_end``."""
+    import nexus._session_end_launcher as launcher
+
+    call_count = 0
+    def fake_session_end() -> str:
+        nonlocal call_count
+        call_count += 1
+        return "stub"
+
+    with patch("nexus.hooks.session_end", side_effect=fake_session_end):
+        launcher._run_session_end_synchronously()
+    assert call_count == 1
+
+
+def test_run_session_end_synchronously_swallows_exceptions() -> None:
+    """The grandchild is detached — exceptions must not propagate up or
+    we'd drop the ``os._exit(0)`` and leave a zombie.
+    """
+    import nexus._session_end_launcher as launcher
+
+    def boom() -> str:
+        raise RuntimeError("intentional failure from test")
+
+    with patch("nexus.hooks.session_end", side_effect=boom):
+        launcher._run_session_end_synchronously()  # must not raise
+
+
+def test_main_falls_through_to_sync_when_fork_unavailable() -> None:
+    """On platforms without ``os.fork`` (Windows), cleanup must still run
+    synchronously rather than be silently skipped.
+    """
+    import nexus._session_end_launcher as launcher
+
+    calls: list[str] = []
+    with (
+        patch("nexus._session_end_launcher.hasattr", return_value=False),
+        patch.object(launcher, "_run_session_end_synchronously",
+                     side_effect=lambda: calls.append("sync")),
+        patch.object(launcher, "_daemonize_and_run",
+                     side_effect=lambda: calls.append("daemon")),
+    ):
+        launcher.main()
+    assert calls == ["sync"], (
+        f"platform without fork must run sync path; got {calls}"
+    )
+
+
+def test_daemonize_parent_path_returns_without_running_cleanup() -> None:
+    """The first-fork parent returns immediately so Claude Code sees
+    exit 0 in single-digit milliseconds. Cleanup does NOT run in the
+    parent — only in the grandchild.
+    """
+    import nexus._session_end_launcher as launcher
+
+    cleanup_calls: list[None] = []
+
+    def fake_fork():
+        # Simulate parent side of first fork (non-zero pid).
+        return 12345
+
+    with (
+        patch("os.fork", side_effect=fake_fork),
+        patch.object(launcher, "_run_session_end_synchronously",
+                     side_effect=lambda: cleanup_calls.append(None)),
+    ):
+        launcher._daemonize_and_run()
+    assert cleanup_calls == [], (
+        "first-fork parent must return without running cleanup; "
+        f"got {len(cleanup_calls)} cleanup calls"
+    )
+
+
+def test_daemonize_falls_through_to_sync_on_oserror() -> None:
+    """If ``os.fork`` raises (e.g. fork rate-limit), fall through to
+    synchronous cleanup rather than drop it.
+    """
+    import nexus._session_end_launcher as launcher
+
+    calls: list[str] = []
+    with (
+        patch("os.fork", side_effect=OSError("fork unavailable")),
+        patch.object(launcher, "_run_session_end_synchronously",
+                     side_effect=lambda: calls.append("sync")),
+    ):
+        launcher._daemonize_and_run()
+    assert calls == ["sync"]

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.11.0"
+version = "4.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Shakeout patch for 4.11.0. The 4.10.3 `nx hook session-end-detach` path was still producing `Hook cancelled` at session close on the reference install. Root cause: it forks the detach daemon AFTER Click parses argv and after ~2s of `nexus.*` imports. Claude Code's shutdown SIGTERM arrives faster than 2s, so the first `os.fork()` never runs.

The 4.11.0 `uuid_mismatch` sweep was catching orphans at next SessionStart, so the leak was bounded — but graceful cleanup (flush pending scratch to T2, expire memory entries) was being skipped.

**Measurement:**

| Command | Wall-clock time to return |
|---|---|
| `nx hook session-end-detach` | 2005 ms |
| `nx-session-end-launcher` | 256 ms (8x) |

## Fix

New `nx-session-end-launcher` console script at `src/nexus/_session_end_launcher.py`. Top-level imports: `os` and `sys` only. `main()` double-forks + `setsid`s + redirects stdio BEFORE any `nexus.*` module loads. Grandchild then imports `nexus.hooks` and runs `session_end()` normally.

`nx/hooks/hooks.json` SessionEnd command switched to:
```
nx-session-end-launcher 2>/dev/null || nx hook session-end-detach || true
```

Chained fallback handles mixed-version installs where the plugin upgrades ahead of the conexus CLI. The old `nx hook session-end-detach` stays as-is for backward compat.

Version: 4.11.0 → 4.11.1 (shakeout patch; all four manifests + uv.lock in parity).

## Test plan

- [x] `uv run pytest tests/test_session_end_launcher.py tests/test_session.py tests/test_hooks.py` — 56 passed (6 new)
  - fork-first invariant: module must not import any `nexus.*` submodule at top level
  - grandchild dispatches to `nexus.hooks.session_end`
  - grandchild swallows exceptions (detached, can't report upstream)
  - no-fork platform fallback runs synchronously
  - first-fork parent returns without running cleanup
  - OSError from fork falls through to sync
- [ ] Full offline suite (running — will post result before tagging)
- [x] `time nx-session-end-launcher` reports under 300 ms on cold cache

## Closes

Closes nexus-2u7o.