### PR TITLE
docs(rdr): add RDR-093 (groupby/aggregate) + revise RDR-089 forward-positioning

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -115,6 +115,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-090](rdr-090-realistic-agenticscholar-benchmark.md) | Realistic AgenticScholar Benchmark | Feature | Draft | 2026-04-17 |
 | [RDR-091](rdr-091-scope-aware-plan-matching.md) | Scope-Aware Plan Matching (nexus-zs1d Phase 2) | Feature | Closed (implemented) | 2026-04-23 |
 | [RDR-092](rdr-092-plan-match-text-from-dimensional-identity.md) | Plan Match-Text from Dimensional Identity | Feature | Closed (implemented) | 2026-04-23 |
+| [RDR-093](rdr-093-groupby-aggregate-operators.md) | GroupBy and Aggregate Operators | Feature | Draft | 2026-04-24 |
 
 ---
 

--- a/docs/rdr/rdr-089-structured-aspect-extraction-at-ingest.md
+++ b/docs/rdr/rdr-089-structured-aspect-extraction-at-ingest.md
@@ -10,7 +10,7 @@ created: 2026-04-17
 accepted_date:
 related_issues: []
 related_tests: [test_aspect_extractor.py]
-related: [RDR-042, RDR-044, RDR-078, RDR-088]
+related: [RDR-042, RDR-044, RDR-078, RDR-088, RDR-093]
 ---
 
 # RDR-089: Structured Aspect Extraction at Ingest
@@ -34,18 +34,27 @@ proposes implementing that extraction pass for `knowledge__*` and
 
 `bib_enricher.py` fetches author/venue/year/abstract from Semantic
 Scholar — a handful of bibliographic fields, no content attributes.
-`operator_extract` (`src/nexus/mcp/core.py:1318`) does structured
+`operator_extract` (`src/nexus/mcp/core.py:1399`) does structured
 extraction at *query time*, one call per query per paper. This is
 slow (N×M calls where N=papers, M=queries) and non-cumulative (each
-query re-extracts rather than consulting a shared index).
+query re-extracts rather than consulting a shared index). The
+4.10.0 operator-bundling path collapses consecutive operator steps
+within a single query into one dispatch, which softens the per-
+query overhead somewhat, but does not amortise across queries —
+the O(N×M) asymptote remains unchanged.
 
-#### Gap 2: Composable filters cannot operate on aspect content
+#### Gap 2: Composable analytics cannot operate on aspect content
 
-RDR-088 adds `operator_filter`, `operator_groupby`, `operator_aggregate`
-(GroupBy/Aggregate scoped as future work). Without indexed aspects
-these operators must LLM-extract on each call — prohibitive cost for
-operations over hundreds of documents. A structured attribute store
-turns a 500-paper group-by from a 500-LLM-call scan into a SQL query.
+RDR-088 (closed 2026-04-24) shipped `operator_filter` but
+**explicitly deferred** `operator_groupby` and `operator_aggregate`
+on the rationale that no concrete compositional query class had
+yet surfaced. RDR-093 reopens that decision and scopes those two
+operators as a forward-positioned follow-up. Either way, even with
+the full §D.4 quartet (`filter` + `groupby` + `aggregate`), the
+operators must LLM-extract per-paper content on every call unless
+the aspect store pre-extracts ingest-side — prohibitive cost at
+hundreds of documents. A structured attribute store turns a 500-
+paper group-by from a 500-LLM-call scan into a SQL query.
 
 #### Gap 3: `MatrixConstruct` is not supportable
 
@@ -116,7 +125,7 @@ problem-statement + method + evaluation structure.
 
 ### Critical Assumptions
 
-- [ ] Haiku produces schema-conformant output with ≥95% success rate across `knowledge__delos` (1397 chunks, ~200 papers) — **Status**: Unverified — **Method**: Spike
+- [x] Haiku produces schema-conformant output with ≥95% success rate across `knowledge__delos` — **Status**: Partially verified — RDR-088 Spike A measured 95% fully-stable / 99% micro-stable / 0% schema-validation errors across 100 `operator_check` dispatches on the same corpus. Same `claude_dispatch` substrate, same Haiku model. A targeted aspect-schema spike on 10 papers is still recommended to confirm the field-level shape, but the substrate reliability budget is known good. **Method**: small confirmation spike.
 - [ ] Aspect extraction adds &lt;2s per paper to ingest time — **Status**: Unverified — **Method**: Spike
 - [ ] T2 write contention under concurrent indexing is acceptable (aspect upserts during ingest) — **Status**: Unverified — **Method**: Source Search + spike
 
@@ -131,7 +140,7 @@ paper with fixed schema. Hook into indexing pipeline for
 
 ### Technical Design
 
-**Extraction schema**:
+**Extraction schema** (core five, open-ended extras):
 
 ```text
 {
@@ -140,12 +149,44 @@ paper with fixed schema. Hook into indexing pipeline for
   "experimental_datasets": ["string", ...],
   "experimental_baselines": ["string", ...],
   "experimental_results": "string (key metric + value + any delta)",
+  "extras": {                                 # optional, extractor-specific
+    "<aspect_name>": <string | array | object>
+  },
   "confidence": "number in [0,1]"
 }
 ```
 
+The five core fields track the paper's ExtractTemplate algorithm
+verbatim so MatrixConstruct-class consumers get the same structure
+AgenticScholar assumes. `extras` is an extensibility anchor — new
+aspect fields ("ablations", "code_release", "benchmark_suite",
+"datasheet_issues") land in the JSON blob without a schema
+migration. When a new field promotes to "queryable enough to
+warrant SQL indexing", it moves from `extras` into a fixed column
+via an additive migration and the extractor prompt is updated; old
+rows stay valid until re-extracted against the new `model_version`.
+
 `confidence` is self-reported by the extractor; low-confidence
 extractions are stored but flagged for human review.
+
+**Pluggable extractor** (`src/nexus/aspect_extractor.py`):
+
+One core entry point `extract_aspects(doc_text, doc_id, collection)`
+dispatches to a collection-scoped extractor config — prompt, schema,
+and `extras` key set — selected by collection prefix. Initial
+registrations:
+
+- `knowledge__*` → scholarly-paper extractor (the five core fields
+  plus paper-specific `extras` like `ablations`, `code_release`).
+- `rdr__*` → decision-doc extractor (mapped: `problem_formulation`,
+  `proposed_method` → "approach", `experimental_datasets` → null,
+  `experimental_results` → "acceptance_criteria"; `extras` carries
+  RDR-specific fields like `rdr_number`, `supersedes`,
+  `dependencies`).
+
+Adding a new domain (`docs__release-notes`, `knowledge__conference-
+proceedings`) is one extractor config registration plus a prompt;
+no change to the pipeline stage, the T2 store, or consumer operators.
 
 **T2 store** (`src/nexus/db/t2/document_aspects.py`):
 
@@ -158,12 +199,20 @@ CREATE TABLE document_aspects (
   experimental_datasets TEXT,  -- JSON array
   experimental_baselines TEXT, -- JSON array
   experimental_results TEXT,
+  extras TEXT,                 -- JSON object; extensibility anchor
   confidence REAL,
   extracted_at TEXT NOT NULL,
   model_version TEXT NOT NULL,
+  extractor_name TEXT NOT NULL,  -- which registered extractor ran
   PRIMARY KEY (collection, doc_id)
 );
 ```
+
+`extractor_name` is the registered key (e.g. `"scholarly-paper-v1"`,
+`"rdr-decision-v1"`) — paired with `model_version`, it gives
+re-extraction a precise filter (`WHERE extractor_name = ? AND
+model_version < ?`) so a schema or prompt change can be rolled out
+incrementally rather than all-or-nothing.
 
 No FTS5 index initially — queries go through `operator_filter` and
 `operator_groupby` (RDR-088 Phase 1 + future). Add FTS5 if usage
@@ -191,13 +240,32 @@ extraction inline when collection is in-scope.
 
 Ingest-time extraction is the only approach that amortizes cost
 across many queries. Per-query extraction (`operator_extract`) costs
-O(N×M) LLM calls; ingest-time is O(N). Storing in T2 (not T3) because
-aspects are structured metadata, not semantic content — queried by
-field equality, not similarity.
+O(N×M) LLM calls; ingest-time is O(N). The 4.10.0 operator-
+bundling path fuses consecutive operators within a single query
+into one dispatch, which amortises operator overhead inside the
+query but does not change the per-query extraction count — the
+asymptote is still O(N×M). Storing in T2 (not T3) because aspects
+are structured metadata, not semantic content — queried by field
+equality, not similarity.
 
-Scoping to `knowledge__*` and `rdr__*` keeps the change bounded.
-Expanding to `docs__*` later is cheap (same pipeline, different
-collection filter).
+Scoping to `knowledge__*` and `rdr__*` keeps the change bounded
+while targeting the two corpora whose query workloads (general
+research and design-intent respectively) most benefit from
+pre-extracted structure. Expanding to `docs__*` or additional
+`knowledge__*` sub-domains later is cheap: one extractor
+registration in the pluggable layer, no change to the pipeline
+stage, the T2 schema, or consumer operators. The `extras` JSON
+column absorbs domain-specific fields without a migration, so
+each new extractor can evolve its own schema without disturbing
+existing rows.
+
+The aspect store is built **forward-positioned** — we do not
+gate on a blocking concrete query. RDR-093 (GroupBy / Aggregate
+operators) pairs naturally with this store for per-field
+analytics, but the store lands on its own merits: `operator_filter`
+over aspect fields works today, and ad-hoc SQL queries over T2
+are available immediately for researchers who know what they want
+before an operator-composed plan exists.
 
 ## Alternatives Considered
 
@@ -343,4 +411,5 @@ _To be completed during /nx:rdr-gate._
 - `src/nexus/db/t2/` — T2 domain store pattern
 - RDR-042 — original call-out (unpicked bead nexus-erim)
 - RDR-076 — T2 migration framework
-- RDR-088 — operator_filter (consumer of this store)
+- RDR-088 — `operator_filter` (consumer of this store; also source of the Spike A reliability data partial-verifying Assumption #1)
+- RDR-093 — `operator_groupby` / `operator_aggregate` (paired analytical consumers; reopen of the GroupBy/Aggregate deferral)

--- a/docs/rdr/rdr-093-groupby-aggregate-operators.md
+++ b/docs/rdr/rdr-093-groupby-aggregate-operators.md
@@ -1,0 +1,511 @@
+---
+title: "RDR-093: GroupBy and Aggregate Operators"
+id: RDR-093
+type: Feature
+status: draft
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-04-24
+accepted_date:
+related_issues: []
+related_tests: [test_operator_dispatch.py, test_plan_run.py, test_plan_bundle.py]
+related: [RDR-042, RDR-078, RDR-079, RDR-088, RDR-089]
+---
+
+# RDR-093: GroupBy and Aggregate Operators
+
+Closes the last two AgenticScholar paper §D.4 operators that were
+explicitly deferred from RDR-088 ("no concrete compositional query
+class has surfaced needing this"). Reopened now because the target
+use case — general scholarly research over `knowledge__*` corpora
+— is load-bearing for the direction of the system, and waiting for
+a single blocking query to crystallize is the wrong posture when
+the foundation is inexpensive and the downstream consumers are
+known (MatrixConstruct, research synthesis, cross-paper analytics).
+
+Pairs with RDR-089 (ingest-time aspect extraction) to form the
+minimum viable §D.4 analytics quartet: `Filter → GroupBy →
+Aggregate` over structured aspects. Filter alone narrows; GroupBy
+partitions; Aggregate reduces. Together they let a plan ask "for
+each experimental dataset across these papers, what baseline method
+won on the reported metric" without a separate ad-hoc pipeline per
+question.
+
+Paper operator coverage after this RDR: **13/13 = 100%** of the
+§D.2 and §D.4 operators (Check, Verify, Filter from RDR-088;
+GroupBy and Aggregate from this RDR; Extract / Rank / Compare /
+Summarize / Generate already shipped).
+
+## Problem Statement
+
+### Enumerated gaps to close
+
+#### Gap 1: No partition-by operator exists
+
+Paper §D.4 defines `GroupBy(items, key) → groups` where `items` is
+a prior step's output and `key` is a natural-language or field-name
+partition expression. Nexus has no operator that turns a flat list
+of items into a keyed grouping. `operator_rank` orders items but
+does not partition; `operator_extract` pulls fields but does not
+group by them; `operator_filter` narrows a single pool but does
+not split one.
+
+**Impact**: any plan that needs per-subgroup analysis (per-dataset,
+per-method-family, per-year, per-venue) has to synthesize the
+grouping inside a free-text `operator_summarize` pass, losing the
+ability to feed each group into a downstream operator
+independently. Plans like "for each experimental dataset, which
+method won on the reported metric?" cannot be expressed as a DAG
+because there's no primitive that emits N distinct downstream
+branches keyed by a partition.
+
+#### Gap 2: No reducer operator exists
+
+Paper §D.4 defines `Aggregate(groups, reducer) → summary` — one
+summary per group, with `reducer` being a natural-language
+reduction instruction. Nexus has `operator_summarize` which reduces
+a single blob of content but not a keyed collection of
+sub-collections.
+
+**Impact**: even if GroupBy existed, there's no structured way to
+reduce each group to a per-group record. Callers would fall back
+to N `operator_summarize` calls, losing the group-key association
+that makes the output composable with downstream operators.
+
+#### Gap 3: MatrixConstruct (paper §5) remains unbuildable
+
+The paper's flagship discovery pipeline
+`FindNode → Traverse → MatrixConstruct → Generate` synthesizes a
+(problem × method) matrix and identifies empty cells (unexplored
+research directions). MatrixConstruct is
+`GroupBy(problem) → Aggregate(methods attempted) → cross-tabulate`
+— it cannot exist without GroupBy and Aggregate as primitives.
+RDR-089 provides the data layer; this RDR provides the operators
+that consume it.
+
+## Context
+
+### Background
+
+RDR-088 (accepted 2026-04-24, closed 2026-04-24) shipped
+`operator_filter`, `operator_check`, `operator_verify` as the three
+missing §D.2 and §D.4 operators. GroupBy and Aggregate were
+included in the paper-coverage analysis but explicitly deferred in
+the scope subsection with the rationale that no live query in the
+plan library or shakeout demanded them. The deferral note committed
+to a follow-up RDR if demand surfaced rather than reopening
+RDR-088.
+
+Demand surfaced in the 2026-04-24 review of RDR-089 when the
+decision was made to target general scholarly research and **build
+the foundation forward** rather than gate on concrete query
+demand. With RDR-089 landing (or even in parallel), the aspect
+store becomes a pre-extracted corpus of structured per-paper
+metadata. GroupBy / Aggregate become the operators that make that
+store composable — without them, the aspect store is a query-time
+lookup table, not an analytical substrate.
+
+### Technical Environment
+
+- `src/nexus/mcp/core.py:1399–1745` — current operator_* implementations
+  (extract, rank, compare, summarize, generate, filter, check,
+  verify). This RDR adds `operator_groupby` and `operator_aggregate`
+  following the same `claude_dispatch`-backed pattern.
+- `src/nexus/plans/runner.py::_OPERATOR_TOOL_MAP`,
+  `_INPUTS_TARGET`, ids-branch auto-hydration, list coercion — the
+  hot spots for the nexus-yis0 class of wiring bug. RDR-088 audit
+  carry-over surfaced these for each new operator; same rigor
+  applies here.
+- `src/nexus/plans/bundle.py::BUNDLEABLE_OPERATORS`,
+  `_describe_step`, `_terminal_schema` — bundle path extension,
+  also from the RDR-088 pattern.
+- `src/nexus/operators/dispatch.py` — `claude_dispatch` substrate
+  (no new infrastructure).
+
+## Research Findings
+
+### Investigation
+
+Primary source: `knowledge__agentic-scholar` §D.4 defining the
+operator algebra. The paper treats GroupBy and Aggregate as pure
+LLM operators that take items + a key / reducer expression and
+return structured output. No inline retrieval, no corpus access;
+pure reshaping of prior-step output.
+
+RDR-088 Spike A evidence: `operator_check` produced 95% fully-
+stable verdicts, 99% micro-stable run agreement, 0% schema-
+validation errors across 100 dispatches on `knowledge__delos`. The
+same `claude_dispatch` substrate backs GroupBy / Aggregate; the
+reliability budget for schema-conformant structured output is
+inherited.
+
+### Key Discoveries
+
+- **Verified** (`src/nexus/operators/dispatch.py`): JSON-schema
+  enforced output is reliable at scale (RDR-088 Spike A + 4.10.0
+  operator-bundling rollout both exercise the substrate).
+- **Verified** (RDR-088 Phase 2 bundle integration): the
+  `BUNDLEABLE_OPERATORS` set + per-verb `_describe_step` and
+  `_terminal_schema` branches successfully compose multi-operator
+  plans into a single `claude -p` dispatch. Same path extends to
+  groupby / aggregate.
+- **Cardinality scope**: `claude -p` handles O(100) items in a
+  prompt cleanly. Beyond that, prompt size degrades output
+  quality. Documented as a known limit; `operator_rank` in RDR-078
+  paired with an implicit pre-winnow (`_OPERATOR_MAX_INPUTS = 100`)
+  uses the same cap. This RDR inherits the cap — callers with
+  larger inputs pre-rank or pre-filter.
+
+### Critical Assumptions
+
+- [ ] `claude_dispatch` produces stable group assignments across
+      reruns (the partition does not shuffle items between groups
+      on identical input) — **Status**: Partially verified via
+      RDR-088 Spike A boolean-verdict stability; group-assignment
+      stability is a stronger contract but same substrate. **Method**:
+      re-run Spike A pattern with a 20-item partition fixture, measure
+      fraction of runs where the group assignment set (as a set-of-sets)
+      is identical to the modal run.
+- [ ] Aggregate's per-group reduction does not leak cross-group
+      content (summaries of group A reference only items in group A)
+      — **Status**: Unverified — **Method**: spike with adversarial
+      inputs where content overlap exists.
+
+## Proposed Solution
+
+### Approach
+
+Two new `@mcp.tool()` functions in `src/nexus/mcp/core.py`
+following the exact `operator_filter` / `operator_check` pattern
+from RDR-088. Both route through `claude_dispatch`. Plan-runner
+hydration and bundle integration extended in the same shape as
+the RDR-088 audit carry-over prescribed for filter / check /
+verify (four edits in `runner.py`, four branches in `bundle.py`).
+
+### Technical Design
+
+**`operator_groupby`** — signature:
+
+`groupby(items: str, key: str, timeout: float = 300.0) → {groups: list[{key_value, item_ids}]}`
+
+`items` is a JSON array string of prior-step outputs (each item
+expected to carry an `id` field for round-trip composability).
+`key` is a natural-language partition expression — it can name a
+structured field ("experimental_dataset"), an inferred property
+("method family"), or a derived attribute ("publication year
+bucket"). Output schema binds `key_value` (the group's label) to
+an ordered list of input `id` values that belong to the group. No
+item is assigned to more than one group; items the LLM cannot
+confidently assign land in a `key_value="unassigned"` group.
+
+```python
+schema: dict = {
+    "type": "object",
+    "required": ["groups"],
+    "properties": {
+        "groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["key_value", "item_ids"],
+                "properties": {
+                    "key_value": {"type": "string"},
+                    "item_ids": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        },
+    },
+}
+```
+
+**`operator_aggregate`** — signature:
+
+`aggregate(groups: str, reducer: str, timeout: float = 300.0) → {aggregates: list[{key_value, summary}]}`
+
+`groups` is a JSON-serialized `list[{key_value, item_ids, items}]`
+from a prior groupby step (the runner hydrates `items` content via
+`store_get_many` if the caller passed only ids). `reducer` is a
+natural-language reduction instruction ("winning baseline by
+reported metric", "most cited method", "earliest publication").
+Output preserves the `key_value` label so downstream operators can
+round-trip the grouping.
+
+```python
+schema: dict = {
+    "type": "object",
+    "required": ["aggregates"],
+    "properties": {
+        "aggregates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["key_value", "summary"],
+                "properties": {
+                    "key_value": {"type": "string"},
+                    "summary": {"type": "string"},
+                },
+            },
+        },
+    },
+}
+```
+
+**Plan-runner hydration** (`src/nexus/plans/runner.py`):
+
+- `_OPERATOR_TOOL_MAP`: add `"groupby": "operator_groupby"` and
+  `"aggregate": "operator_aggregate"`.
+- `_INPUTS_TARGET`: add `"operator_groupby": "items"`. **Deliberately
+  omit** `operator_aggregate` — its positional arg is `groups`, not
+  `items`, and a stray `inputs:` on an aggregate step should surface
+  as an authoring bug rather than be silently renamed. Same pattern
+  RDR-088 used for `operator_verify`.
+- ids-branch auto-hydration: `operator_groupby` joins the
+  `args.setdefault("items", json.dumps(non_empty))` pool.
+  `operator_aggregate` does not — its ids-branch shape is different
+  (ids-per-group, not a flat list) and the bundle path handles the
+  group hydration via `_describe_step`. Isolated dispatch of
+  aggregate expects `groups` already materialised.
+- List coercion: extend the trailing `json.dumps` block to include
+  `operator_groupby`.
+
+**Bundle integration** (`src/nexus/plans/bundle.py`):
+
+- `BUNDLEABLE_OPERATORS`: add `"groupby"`, `"aggregate"`,
+  `"operator_groupby"`, `"operator_aggregate"` (4 new entries, same
+  bare-and-resolved pattern).
+- `_describe_step`: two new `elif verb == ...` branches rendering
+  the key / reducer expression + prior-step chaining + terminal
+  output-shape guidance.
+- `_terminal_schema`: two new branches matching the standalone
+  schemas above.
+
+**Composition semantics**:
+
+| Plan step chain | Interpretation |
+|---|---|
+| `search → filter → groupby → aggregate` | Retrieve, narrow, partition, reduce each partition — canonical paper §D.4 pipeline |
+| `traverse → groupby → aggregate` | Walk link graph, partition hits, reduce |
+| `... → extract → groupby → aggregate` | Extract fields on-the-fly, partition by extracted field, reduce |
+| `... → groupby → rank` | Partition then rank the groups themselves (groupwise comparative ranking) |
+
+The RDR-089 aspect store does not require new operator wiring —
+any step that reads from T2 aspects emits items in the standard
+shape, and groupby accepts them directly.
+
+### Existing Infrastructure Audit
+
+| Proposed component | Existing module | Decision |
+| --- | --- | --- |
+| `operator_groupby`, `operator_aggregate` | `operator_extract` et al. | **Same pattern**: `@mcp.tool()` + `claude_dispatch` + fixed schema. No new substrate. |
+| Plan-runner hydration | `_hydrate_operator_args` (runner.py) | **Extend**: four edits per operator per the RDR-088 audit carry-over template. |
+| Bundle composition | `BUNDLEABLE_OPERATORS`, `_describe_step`, `_terminal_schema` | **Extend**: four entries + two verb branches + two schema branches. |
+
+### Decision Rationale
+
+The operators ship together because they are a pair — Aggregate
+without GroupBy has no input shape; GroupBy without Aggregate
+produces a structure that only `operator_summarize` can consume
+(and badly, because it discards the group keys). Separating them
+into two RDRs would create a partial-landing trap where one of
+the two never gets demanded on its own.
+
+Both operators are pure LLM reshaping of prior-step output — no
+inline retrieval, no corpus access, no new persistence. They
+slot into the operator family without a single new module;
+everything happens in the existing `core.py` + `runner.py` +
+`bundle.py` axis.
+
+## Alternatives Considered
+
+### Alternative 1: Ship GroupBy only, defer Aggregate
+
+**Description**: Land partition semantics; leave per-group reduction
+to ad-hoc `operator_summarize` calls.
+
+**Pros**: Smaller surface; one operator instead of two.
+
+**Cons**: Aggregate is the step that preserves the group key
+association. Without it, downstream plan steps lose the per-group
+label and can't round-trip through another operator. Users fall
+back to N ad-hoc summarize calls with a separate shell to re-associate
+output with keys — the exact ergonomic loss RDR-088 cited as
+justification for each of the paper's structured operators.
+
+**Reason for rejection**: half of a paired primitive delivers less
+than half the value.
+
+### Alternative 2: SQL-backed GroupBy over the RDR-089 aspect store
+
+**Description**: Implement GroupBy as a SQL query against
+`document_aspects` instead of an LLM call.
+
+**Pros**: Cheap; deterministic; scales to N > 100.
+
+**Cons**: Constrains the partition key to fields the aspect store
+has already extracted. Natural-language keys like "method family"
+or "year bucket" require secondary extraction. Ties the operator
+to one specific data layer (RDR-089) and bifurcates the user model
+(SQL groupby on aspects; LLM groupby on arbitrary content).
+
+**Reason for rejection**: the paper's GroupBy is specifically the
+natural-language-key variant that makes ad-hoc partitioning cheap
+to express. A SQL-aspect-store fast path can be added later as an
+optional optimisation under the same operator name when the aspect
+field happens to match the key verbatim; the LLM path stays the
+default contract.
+
+### Briefly rejected
+
+- **Fuse GroupBy + Aggregate into one `operator_partition_reduce` macro**: obscures the pair's composability; prevents GroupBy-then-Rank patterns.
+- **Emit groups as a `list[list[dict]]` (nested list) instead of a `list[{key_value, item_ids}]` record**: loses the explicit key label and breaks downstream `$stepN.key_value` reference composition.
+
+## Trade-offs
+
+### Consequences
+
+- Operator family grows 8 → 10. Composable plan-step tool count
+  12 → 14. Paper coverage 11/13 → 13/13 (100%).
+- Plan authors gain per-group analytical composition; MatrixConstruct
+  becomes expressible (paired with `operator_extract` or RDR-089
+  aspects for field-typed dimensions).
+- Latency: GroupBy adds one `claude -p` call per step (~3-10s);
+  Aggregate adds one per step. In a bundled `filter → groupby →
+  aggregate` chain, all three collapse into one dispatch per the
+  4.10.0 bundling path.
+- No persistent storage, no migrations, no new dependencies.
+
+### Risks and Mitigations
+
+- **Risk**: Group assignment instability across re-runs (same input,
+  different partitioning on different claude -p invocations) makes
+  plans non-deterministic in a user-visible way.
+  **Mitigation**: Spike with a 20-item partition fixture, measure
+  modal-run agreement. RDR-088 Spike A gives us 95% fully-stable on
+  boolean verdicts; expect partitioning to be at or above that
+  because the partition task is more constrained (assign each item
+  to exactly one key). Document the observed stability rate in the
+  operator docstring so callers know what to expect.
+
+- **Risk**: `operator_aggregate` leaks cross-group content into a
+  group's summary when the items share vocabulary (summary of group A
+  references items in group B).
+  **Mitigation**: Prompt framing isolates each group explicitly
+  ("For group X, summarising ONLY these items: ..."); test adversarial
+  inputs with near-identical content across groups.
+
+- **Risk**: Cardinality limit (O(100) items) surprises users who
+  expect arbitrary-sized groupby.
+  **Mitigation**: Same `_OPERATOR_MAX_INPUTS = 100` auto-hydration
+  cap already applied by the runner to other operators. Document
+  in operator docstrings; recommend `operator_rank` pre-winnow for
+  larger inputs.
+
+### Failure modes
+
+- **Visible**: schema-validation failure → `OperatorOutputError`
+  raised with snippet (delegated to `claude_dispatch` substrate).
+- **Silent**: partition hallucination (LLM invents a plausible key
+  value that's not grounded in the items). Mitigated by the
+  `key_value="unassigned"` convention; low-confidence callers can
+  inspect `unassigned` group size as a quality signal.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] Spike: 20-item partition fixture on `knowledge__delos`, 5
+      runs each, measure modal-set-agreement stability. Target
+      ≥95% fully-stable (modal set identical across all 5 runs).
+- [ ] Spike: adversarial cross-group content test, 10 runs with
+      near-identical items spread across 3 groups, inspect each
+      group's summary for cross-group leakage.
+
+### Minimum Viable Validation
+
+A plan chaining `search → operator_filter → operator_groupby →
+operator_aggregate` runs end-to-end via `plan_run`, returns a
+structured aggregate list keyed by partition label, and each
+operator's contract is exercised.
+
+### Phase 1: `operator_groupby`
+
+#### Step 1: Implement operator_groupby in core.py
+
+Follow the `operator_filter` pattern at `core.py:1618`. Define
+JSON schema, dispatch, surface typed errors.
+
+#### Step 2: Integrate with plan_run
+
+Extend `_OPERATOR_TOOL_MAP`, `_INPUTS_TARGET`, ids-branch,
+list-coercion per the RDR-088 audit carry-over template. Bundle
+integration: add to `BUNDLEABLE_OPERATORS`, implement
+`_describe_step` and `_terminal_schema` branches.
+
+### Phase 2: `operator_aggregate`
+
+#### Step 1: Implement operator_aggregate in core.py
+
+Schema + prompt + dispatch. Deliberately omit from `_INPUTS_TARGET`
+(takes `groups`, not `items`).
+
+#### Step 2: Integration test
+
+End-to-end plan: `search → filter → groupby → aggregate` on
+`knowledge__delos`. Shape assertions only (LLM content varies).
+
+### Phase 3: MVV integration
+
+Full four-step paper §D.4 pipeline end-to-end. Exercises every
+new operator's contract via `plan_run`. Verifies bundling fuses
+the operator run into one dispatch.
+
+### Day 2 Operations
+
+| Resource | List | Info | Delete | Verify | Backup |
+| --- | --- | --- | --- | --- | --- |
+| Operator registrations | `nx catalog search --type=operator` | N/A | N/A | integration test | code |
+
+### New Dependencies
+
+None. Same `claude_dispatch` substrate as the existing operator family.
+
+## Test Plan
+
+- **Scenario**: `operator_groupby` called with 10 items and the key "publication year" — **Verify**: output partitions items into year buckets, every input id lands in exactly one group, no item id invented.
+- **Scenario**: `operator_groupby` with an ambiguous key (items lacking the field) — **Verify**: ambiguous items land in `key_value="unassigned"`, confidence signal surfaced via group size.
+- **Scenario**: `operator_aggregate` called with 3 groups totalling 9 items and the reducer "most-cited method" — **Verify**: output has exactly 3 aggregates, each `key_value` preserved, each summary references only items in its group (adversarial cross-group test).
+- **Scenario**: `plan_run` chain `search → filter → groupby → aggregate` bundled into one dispatch — **Verify**: terminal step output is the aggregate list; intermediate steps are `BUNDLED_INTERMEDIATE` sentinels; no per-step claude -p subprocess spawned for the three operators.
+- **Scenario**: Cardinality cap (150 items passed) — **Verify**: `_OPERATOR_MAX_INPUTS` auto-hydration cap kicks in, groupby receives 100 items, runner logs the truncation.
+
+## Validation
+
+### Testing Strategy
+
+Unit tests per operator with mocked `claude_dispatch`
+(`test_operator_dispatch.py`) covering schema shape, prompt
+content, and output contract. Hydration tests
+(`test_plan_run.py::TestHydrateInputsTranslation`) cover the
+inputs-rename + ids-branch + list-coercion paths for each new
+operator. Bundle-composition tests (`test_plan_bundle.py`) cover
+`_describe_step` and `_terminal_schema` for both verbs. Live-I/O
+integration test (`tests/integration/test_rdr_088_operator_pipelines.py`
+extension or new file) runs the four-step paper §D.4 pipeline
+against `knowledge__delos` with shape-based assertions.
+
+## Finalization Gate
+
+_To be completed during /nx:rdr-gate._
+
+## References
+
+- Paper: `knowledge__agentic-scholar` §D.4 (GroupBy, Aggregate)
+- RDR-042 — original operator-model adoption
+- RDR-078 — dimensional plan identity + `_OPERATOR_MAX_INPUTS` cap
+- RDR-079 — operator dispatch substrate
+- RDR-088 — Filter / Check / Verify (sibling operators; defer note is the trigger for this RDR)
+- RDR-089 — ingest-time aspect extraction (natural data-layer partner; not a hard dependency)
+- `src/nexus/mcp/core.py:1399–1745` — existing `operator_*` implementations
+- `src/nexus/plans/runner.py::_hydrate_operator_args` — hydration hot spot
+- `src/nexus/plans/bundle.py` — operator-bundle composition
+- `src/nexus/operators/dispatch.py` — `claude_dispatch` substrate


### PR DESCRIPTION
## Summary

Creates RDR-093 for the two §D.4 operators that RDR-088 explicitly deferred, and revises RDR-089 (draft) with the context that has landed since it was drafted 2026-04-17.

## RDR-093: GroupBy and Aggregate Operators (new, draft)

Reopens the GroupBy / Aggregate decision. RDR-088's defer rationale was "no concrete compositional query class has surfaced." Re-reading RDR-089 surfaced the context: general research workflows are the target, the operator foundation is cheap to build, and waiting for a blocking query is the wrong posture when downstream consumers (MatrixConstruct, cross-paper analytics) are well-understood.

- Both operators ship together (aggregate without groupby has no input shape; groupby without aggregate discards keys for composition).
- Same `@mcp.tool()` + `claude_dispatch` + bundle-integration pattern RDR-088 used for filter/check/verify. No new infrastructure.
- Paper coverage 11/13 → 13/13 after landing.
- Critical assumptions: group-assignment stability (partially covered by RDR-088 Spike A on boolean verdict stability, same substrate) + cross-group content isolation.
- Cardinality cap inherited from `_OPERATOR_MAX_INPUTS = 100`.

## RDR-089 revisions (stays in draft; ready to gate with these corrections)

- **Gap 2 reframed.** RDR-088 shipped `operator_filter` only; GroupBy/Aggregate moved to RDR-093. Cost argument preserved: O(N) ingest amortises across O(M) queries.
- **Line pointer fix.** `core.py:1318` → `core.py:1399`.
- **Critical Assumption #1 upgraded** from Unverified to Partially verified — RDR-088 Spike A ran 100 `claude_dispatch`-backed operator calls on `knowledge__delos` at 95% fully-stable / 99% micro-stable / 0% schema errors. Same substrate, same model. Small confirmation spike still recommended for the aspect-schema field shape specifically.
- **Operator bundling acknowledged.** Amortises operator overhead inside a query, not across queries, so the O(N×M) asymptote still holds. Cost section updated so the framing isn't overstated.
- **Schema extensibility.** New `extras` JSON column for domain-specific fields that don't warrant a fixed column yet. New `extractor_name` column pairs with `model_version` for precise re-extraction filtering.
- **Pluggable extractor.** Collection-prefix-scoped registrations (scholarly-paper / rdr-decision / future `docs__*` and other `knowledge__*` sub-domains). Adding a domain is one registration + a prompt — no pipeline, T2 schema, or consumer-operator change.
- **Forward-positioning rationale made explicit.** No blocking concrete query. `operator_filter` over aspects works today; RDR-093 adds per-field analytics; ad-hoc SQL over T2 is available immediately. Consistent with the "general research, not limited by what isn't there yet" direction.

## Test plan

- [x] Docs-only changes; no code surface touched
- [x] RDR cross-links consistent (RDR-089 `related:` adds RDR-093; RDR-093 references RDR-088 spike + RDR-089 as data-layer partner)
- [x] README.md table updated with RDR-093 row

## Next steps after merge

Both RDRs stay in `draft`. Ready for `/nx:rdr-research` → `/nx:rdr-gate` → `/nx:rdr-accept` when you want to pick either one up.