### PR TITLE
docs(rdr-093): accept for GroupBy + Aggregate Operators

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -115,7 +115,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-090](rdr-090-realistic-agenticscholar-benchmark.md) | Realistic AgenticScholar Benchmark | Feature | Draft | 2026-04-17 |
 | [RDR-091](rdr-091-scope-aware-plan-matching.md) | Scope-Aware Plan Matching (nexus-zs1d Phase 2) | Feature | Closed (implemented) | 2026-04-23 |
 | [RDR-092](rdr-092-plan-match-text-from-dimensional-identity.md) | Plan Match-Text from Dimensional Identity | Feature | Closed (implemented) | 2026-04-23 |
-| [RDR-093](rdr-093-groupby-aggregate-operators.md) | GroupBy and Aggregate Operators | Feature | Draft | 2026-04-24 |
+| [RDR-093](rdr-093-groupby-aggregate-operators.md) | GroupBy and Aggregate Operators | Feature | Accepted | 2026-04-24 |
 
 ---
 

--- a/docs/rdr/rdr-093-groupby-aggregate-operators.md
+++ b/docs/rdr/rdr-093-groupby-aggregate-operators.md
@@ -2,12 +2,12 @@
 title: "RDR-093: GroupBy and Aggregate Operators"
 id: RDR-093
 type: Feature
-status: draft
+status: accepted
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-24
-accepted_date:
+accepted_date: 2026-04-24
 related_issues: []
 related_tests: [test_operator_dispatch.py, test_plan_run.py, test_plan_bundle.py]
 related: [RDR-042, RDR-078, RDR-079, RDR-088, RDR-089]


### PR DESCRIPTION
Accepts RDR-093 after PASSED gate (PR #282 merged with in-place fixes for 1 critical + 2 significant + 5 observations).

## Changes

- RDR-093 frontmatter: `status: draft` → `status: accepted`; `accepted_date: 2026-04-24`.
- README.md table: Draft → Accepted.

## T2 state (authoritative)

- `nexus_rdr/093` (id=967) — metadata, status=accepted, permanent TTL.
- `nexus_rdr/093-gate-latest` (id=966) — gate PASSED.
- `nexus_rdr/093-research-1` (id=965) — paper §D.4 parity check.

## Follow-up bead

- `nexus-3j6b` P3 — generalise `_OPERATOR_MAX_INPUTS` truncation metadata across the operator family (RDR-093's S-1 fix is operator_groupby-scoped).

## Next step after merge

Strategic planner dispatch to build the execution bead chain (mandatory per /nx:rdr-accept Step 8 for multi-phase RDRs).