### PR TITLE
fix(logging): wire structlog through stdlib so mcp.log actually writes

### DIFF
--- a/src/nexus/logging_setup.py
+++ b/src/nexus/logging_setup.py
@@ -19,34 +19,104 @@ def _config_dir() -> Path:
     return Path.home() / ".config" / "nexus"
 
 
+def _resolve_level(mode: str, verbose: bool) -> int:
+    """Resolve the effective log level.
+
+    Precedence (high to low):
+      1. ``NEXUS_LOG_LEVEL`` env var (DEBUG / INFO / WARNING / ERROR / CRITICAL)
+      2. ``verbose=True`` flag, DEBUG
+      3. mode default: ``cli`` is WARNING (zero behaviour change for the CLI),
+         non-cli (``console`` / ``mcp`` / ``hook``) is INFO so subprocess
+         lifecycle, tool dispatch, and structured warnings actually land in
+         the file handler.
+    """
+    override = os.environ.get("NEXUS_LOG_LEVEL", "").strip().upper()
+    if override:
+        resolved = getattr(logging, override, None)
+        if isinstance(resolved, int):
+            return resolved
+    if verbose:
+        return logging.DEBUG
+    if mode == "cli":
+        return logging.WARNING
+    return logging.INFO
+
+
 def configure_logging(
     mode: Literal["cli", "console", "mcp", "hook"],
     verbose: bool = False,
 ) -> None:
     """Configure logging for the given nexus entry point.
 
-    - **cli**: stderr only, WARNING default (matches prior behavior exactly).
-    - **console/mcp/hook**: stderr + RotatingFileHandler under ``<config_dir>/logs/<mode>.log``.
-    """
-    level = logging.DEBUG if verbose else logging.WARNING
-    logging.basicConfig(level=level, format="%(message)s", stream=sys.stderr, force=True)
-    structlog.configure(
-        wrapper_class=structlog.make_filtering_bound_logger(level),
-    )
+    Routes structlog events through the stdlib ``logging`` module so the
+    rotating file handler installed below catches them. Without this
+    bridge, ``structlog.get_logger().info(...)`` writes via structlog's
+    default ``PrintLoggerFactory`` which goes to stderr, bypassing the
+    file handler entirely (the historical reason ``mcp.log`` was a 0-byte
+    file even on a long-running server).
 
-    # Suppress noisy HTTP wire-trace loggers even in verbose mode
+    Modes:
+      * ``cli``: stderr only, WARNING default. Kept legacy-compatible so
+        the human-facing CLI does not gain noise from this change.
+      * ``console`` / ``mcp`` / ``hook``: stderr + RotatingFileHandler at
+        ``<config_dir>/logs/<mode>.log``, INFO default. Lifecycle events,
+        tool dispatches, and structured warnings now land in the log file.
+
+    The level is overridable via the ``NEXUS_LOG_LEVEL`` env var; useful
+    for one-off DEBUG runs without code changes.
+    """
+    level = _resolve_level(mode, verbose)
+
+    # Configure stdlib root logger first. ``force=True`` clears any prior
+    # handlers so re-invocation (e.g. server hot-restart) does not stack
+    # duplicates.
+    logging.basicConfig(level=level, format="%(message)s", stream=sys.stderr, force=True)
+
+    # Suppress noisy HTTP / telemetry wire-trace loggers even in verbose
+    # mode. These produce so much output at DEBUG that the signal in
+    # mcp.log would drown.
     for noisy in ("httpx", "httpcore", "chromadb.telemetry", "opentelemetry"):
         logging.getLogger(noisy).setLevel(logging.WARNING)
 
-    if mode == "cli":
-        return  # stderr only — zero behavior change
+    # Bridge structlog -> stdlib logging. Two things wired here:
+    #   1. ``LoggerFactory`` makes ``structlog.get_logger()`` return a
+    #      logger that writes via the stdlib logging module instead of
+    #      stderr-print.
+    #   2. The processor chain serialises the structured event to a
+    #      single-line key=value rendering before stdlib formats it.
+    #      ``add_log_level`` keeps the level visible in the rendered
+    #      message; ``TimeStamper`` adds an ISO timestamp; the final
+    #      ``KeyValueRenderer`` turns the event dict into a string the
+    #      file formatter can prepend with its own ``asctime / name /
+    #      levelname`` columns.
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.dev.set_exc_info,
+            structlog.processors.KeyValueRenderer(
+                key_order=["event", "timestamp", "level"],
+                drop_missing=True,
+            ),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
 
-    # Non-CLI modes get a rotating file handler
+    if mode == "cli":
+        return  # stderr only — zero behaviour change for the CLI entry point
+
+    # Non-CLI modes get a rotating file handler at <config>/logs/<mode>.log.
     logs_dir = _config_dir() / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     log_path = logs_dir / f"{mode}.log"
 
-    # Remove stale handler for the same file if re-called (e.g. server restart)
+    # Remove stale handler for the same file if re-called (e.g. server
+    # restart in tests). Without this, repeated configure_logging calls
+    # would stack handlers and write each event N times.
     root = logging.getLogger()
     for h in list(root.handlers):
         if isinstance(h, logging.handlers.RotatingFileHandler) and h.baseFilename == str(log_path):

--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -576,13 +576,46 @@ def catalog_link_bulk(
 
 
 def main():
-    """Run the catalog MCP server on stdio transport."""
+    """Run the catalog MCP server on stdio transport.
+
+    Lifecycle logging: emits ``mcp_server_starting``,
+    ``mcp_server_stopping``, and ``mcp_server_crashed`` events to
+    ``<config>/logs/mcp.log`` (shared file with the core server; the
+    ``server`` field discriminates).
+    """
+    import os
+
+    import structlog
+
     from nexus.logging_setup import configure_logging
     from nexus.mcp_infra import check_version_compatibility
 
     configure_logging("mcp")
-    check_version_compatibility()
-    mcp.run(transport="stdio")
+    log = structlog.get_logger("nexus.mcp.catalog")
+    log.info(
+        "mcp_server_starting",
+        server="nx-mcp-catalog",
+        transport="stdio",
+        pid=os.getpid(),
+        ppid=os.getppid(),
+    )
+    try:
+        check_version_compatibility()
+        mcp.run(transport="stdio")
+    except (KeyboardInterrupt, SystemExit):
+        log.info(
+            "mcp_server_stopping", server="nx-mcp-catalog", reason="signal",
+        )
+        raise
+    except BaseException as exc:
+        log.exception(
+            "mcp_server_crashed",
+            server="nx-mcp-catalog",
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        raise
+    else:
+        log.info("mcp_server_stopping", server="nx-mcp-catalog", reason="exit")
 
 
 if __name__ == "__main__":

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -3142,13 +3142,46 @@ async def nx_plan_audit(
 
 
 def main():
-    """Run the core MCP server on stdio transport."""
+    """Run the core MCP server on stdio transport.
+
+    Lifecycle logging: emits ``mcp_server_starting``,
+    ``mcp_server_stopping``, and ``mcp_server_crashed`` events to
+    ``<config>/logs/mcp.log``. Without these, a silent crash leaves
+    no on-disk trace and makes diagnosis dependent on Claude Code's
+    captured stderr (which is not surfaced through any user-visible
+    path).
+    """
+    import os
+
+    import structlog
+
     from nexus.logging_setup import configure_logging
     from nexus.mcp_infra import check_version_compatibility
 
     configure_logging("mcp")
-    check_version_compatibility()
-    mcp.run(transport="stdio")
+    log = structlog.get_logger("nexus.mcp.core")
+    log.info(
+        "mcp_server_starting",
+        server="nx-mcp",
+        transport="stdio",
+        pid=os.getpid(),
+        ppid=os.getppid(),
+    )
+    try:
+        check_version_compatibility()
+        mcp.run(transport="stdio")
+    except (KeyboardInterrupt, SystemExit):
+        log.info("mcp_server_stopping", server="nx-mcp", reason="signal")
+        raise
+    except BaseException as exc:
+        log.exception(
+            "mcp_server_crashed",
+            server="nx-mcp",
+            error=f"{type(exc).__name__}: {exc}",
+        )
+        raise
+    else:
+        log.info("mcp_server_stopping", server="nx-mcp", reason="exit")
 
 
 if __name__ == "__main__":

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -81,3 +81,116 @@ def test_repeated_call_does_not_accumulate_handlers(tmp_path, monkeypatch):
     # Cleanup
     root.removeHandler(file_handlers[0])
     file_handlers[0].close()
+
+
+def test_mcp_mode_default_sets_info(tmp_path, monkeypatch):
+    """Non-CLI modes default to INFO so subprocess lifecycle, tool
+    dispatch, and structured warnings actually land in the file
+    handler. Historically defaulted to WARNING which is why the
+    long-lived mcp.log was a 0-byte file even on a busy server."""
+    monkeypatch.delenv("NEXUS_LOG_LEVEL", raising=False)
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+    configure_logging("mcp")
+    assert logging.getLogger().level == logging.INFO
+    # Cleanup
+    root = logging.getLogger()
+    for h in [
+        h for h in root.handlers
+        if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]:
+        root.removeHandler(h)
+        h.close()
+
+
+def test_nexus_log_level_env_overrides_mode_default(tmp_path, monkeypatch):
+    """NEXUS_LOG_LEVEL env var overrides the mode-default level so
+    operators can force DEBUG without code changes."""
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("NEXUS_LOG_LEVEL", "DEBUG")
+    configure_logging("mcp")
+    assert logging.getLogger().level == logging.DEBUG
+    # Cleanup
+    root = logging.getLogger()
+    for h in [
+        h for h in root.handlers
+        if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]:
+        root.removeHandler(h)
+        h.close()
+
+
+def test_structlog_events_reach_file_handler(tmp_path, monkeypatch):
+    """The visibility regression fix: structlog events must route
+    through stdlib logging and land in the rotating file handler.
+    Without the LoggerFactory + processor chain wiring, structlog's
+    default PrintLoggerFactory writes to stderr only — bypassing the
+    file handler entirely. This test asserts the bridge: a structlog
+    event emitted after configure_logging("mcp") shows up in the
+    file. If this fails, mcp.log will go silent again."""
+    import structlog
+
+    monkeypatch.delenv("NEXUS_LOG_LEVEL", raising=False)
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+    configure_logging("mcp")
+    log_path = tmp_path / "logs" / "mcp.log"
+    assert log_path.exists()
+
+    # Emit a sentinel structlog event. The KeyValueRenderer at INFO
+    # level should funnel it through stdlib logging into the file.
+    structlog.get_logger("nexus.test").info(
+        "logging_smoke_test_sentinel", probe="abc-xyz-123",
+    )
+    # Force the handler to flush so the bytes are visible to the
+    # filesystem before we read.
+    for h in logging.getLogger().handlers:
+        h.flush()
+
+    contents = log_path.read_text()
+    assert "logging_smoke_test_sentinel" in contents, (
+        f"structlog event did not land in mcp.log; got:\n{contents!r}\n"
+        f"This means the structlog -> stdlib bridge in "
+        f"configure_logging is broken. mcp.log will go silent again."
+    )
+    assert "abc-xyz-123" in contents, (
+        f"structlog event reached the file but lost its key=value "
+        f"context (probe field missing). Renderer chain regression."
+    )
+    # Cleanup
+    root = logging.getLogger()
+    for h in [
+        h for h in root.handlers
+        if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]:
+        root.removeHandler(h)
+        h.close()
+
+
+def test_structlog_warning_below_default_filtered(tmp_path, monkeypatch):
+    """At INFO default, a structlog DEBUG event should NOT land in
+    the file. Pins the level filter so verbose-by-default never
+    happens silently."""
+    import structlog
+
+    monkeypatch.delenv("NEXUS_LOG_LEVEL", raising=False)
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+    configure_logging("mcp")
+    log_path = tmp_path / "logs" / "mcp.log"
+
+    structlog.get_logger("nexus.test").debug(
+        "debug_event_should_be_filtered", probe="never-emit-xyz",
+    )
+    for h in logging.getLogger().handlers:
+        h.flush()
+
+    contents = log_path.read_text() if log_path.exists() else ""
+    assert "never-emit-xyz" not in contents, (
+        "DEBUG event leaked through the INFO default filter"
+    )
+    # Cleanup
+    root = logging.getLogger()
+    for h in [
+        h for h in root.handlers
+        if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]:
+        root.removeHandler(h)
+        h.close()


### PR DESCRIPTION
## Summary

The MCP server's `mcp.log` was a 0-byte file even on a long-running server. Three issues in `configure_logging`:

1. **No structlog to stdlib bridge.** `structlog.configure()` set only a `wrapper_class`; without a `LoggerFactory` + processor chain, structlog events bypassed the root logger and the `RotatingFileHandler` never received a record. The handler held an open fd on the file but no writes ever flowed through it.
2. **WARNING default for non-CLI modes.** Even if the bridge had been wired, `_log.info(...)` calls would have been filtered out, so we would have only seen warnings and errors, not lifecycle events.
3. **No lifecycle logging in `main()`.** Both `nx-mcp` and `nx-mcp-catalog` ran `mcp.run()` with no surrounding `try/except` and no `mcp_server_starting` / `mcp_server_stopping` / `mcp_server_crashed` emits. Silent crashes left zero on-disk trace.

This was surfaced while diagnosing why `nx-mcp` disconnected during a long-running agent dispatch. With the fix, the next disconnect leaves a debuggable record. RDR-094 (MCP-Owned T1 Chroma Lifecycle) is gated on having this visibility, since its central claim is that the MCP server is a better lifecycle anchor than the hook stack and that argument is weaker without observability into the server itself.

## What changed

### `src/nexus/logging_setup.py`

- `_resolve_level()` helper. Precedence: `NEXUS_LOG_LEVEL` env var, then `verbose=True` flag, then mode default. Mode defaults: `cli=WARNING` (legacy, no behaviour change for the human CLI), `console / mcp / hook = INFO`.
- `structlog.configure()` now wires `LoggerFactory(stdlib)` + processor chain (`add_log_level`, `TimeStamper`, `StackInfoRenderer`, `format_exc_info`, `KeyValueRenderer`). Events route through stdlib logging and land on the rotating file handler.
- Comments explain the 0-byte regression so the next reader sees why the bridge is load-bearing.

### `src/nexus/mcp/core.py` and `src/nexus/mcp/catalog.py`

`main()` now wraps `mcp.run()` in `try/except/else/finally`:

- Logs `mcp_server_starting` with pid, ppid, server name, transport before the run.
- Logs `mcp_server_stopping` with `reason='signal'` for `KeyboardInterrupt` / `SystemExit`, `reason='exit'` for clean shutdown.
- Logs `mcp_server_crashed` (with full traceback via `structlog.exception`) on any other `BaseException`.
- Re-raises every exception so Claude Code's MCP client still sees the failure mode.

The two servers share `mcp.log`; the `server` field discriminates `nx-mcp` from `nx-mcp-catalog`.

### `tests/test_logging_setup.py`

Five new tests:

- `test_mcp_mode_default_sets_info`: non-CLI default is INFO (was WARNING).
- `test_nexus_log_level_env_overrides_mode_default`: env override works.
- `test_structlog_events_reach_file_handler`: the canonical regression guard. Emits a sentinel structlog event after `configure_logging('mcp')` and asserts both the event name and a key=value field land in `mcp.log`. If the bridge breaks again, this is the test that lights up.
- `test_structlog_warning_below_default_filtered`: DEBUG events do not reach the file at INFO default (no verbose-by-default surprise).

Existing `test_cli_mode_default_sets_warning` still passes; CLI default unchanged.

## Verification

```
uv run pytest tests/test_logging_setup.py
11 passed in 0.06s

scripts/reinstall-tool.sh && claude mcp list
# mcp.log now contains lifecycle events:
2026-04-24 17:31:55  nexus.mcp.core    INFO  mcp_server_starting   server='nx-mcp'         pid=42945
2026-04-24 17:31:55  nexus.mcp.catalog INFO  mcp_server_starting   server='nx-mcp-catalog' pid=42946
2026-04-24 17:31:57  nexus.mcp.catalog INFO  mcp_server_stopping   reason='exit'
2026-04-24 17:31:57  nexus.mcp.core    INFO  mcp_server_stopping   reason='exit'
```

Targeted regression: 114 passed in 0.47s (`test_logging_setup` + `test_mcp_package` + `test_session` + `operators` + `test_operator_dispatch`).

## Test plan

- [x] `uv run pytest tests/test_logging_setup.py` (11 passed)
- [x] Live verification: `scripts/reinstall-tool.sh && claude mcp list` produces start/stop events in `mcp.log`
- [ ] CI green on this PR