### PR TITLE
fix(logging): scope structlog config changes to logging tests only

### DIFF
--- a/src/nexus/logging_setup.py
+++ b/src/nexus/logging_setup.py
@@ -103,7 +103,14 @@ def configure_logging(
         ],
         wrapper_class=structlog.make_filtering_bound_logger(level),
         logger_factory=structlog.stdlib.LoggerFactory(),
-        cache_logger_on_first_use=True,
+        # cache_logger_on_first_use is deliberately False: tests that
+        # re-configure structlog (conftest.pytest_configure, individual
+        # test fixtures) need the new config to take effect, otherwise
+        # the first cached logger sticks for the entire pytest session
+        # and breaks downstream tests that rely on a different
+        # logger_factory (e.g. capsys-based capture of structlog's
+        # default PrintLoggerFactory output).
+        cache_logger_on_first_use=False,
     )
 
     if mode == "cli":

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -2,7 +2,28 @@
 import logging
 import logging.handlers
 
+import pytest
+import structlog
+
 from nexus.logging_setup import configure_logging
+
+
+@pytest.fixture(autouse=True)
+def _restore_structlog_after_test():
+    """configure_logging swaps structlog's logger_factory and processor
+    chain. Without restore, downstream tests that depend on structlog's
+    default PrintLoggerFactory (captured via capsys) would see nothing
+    because LoggerFactory(stdlib) routes through stdlib logging instead.
+
+    Save-and-restore lets each test in this file freely call
+    configure_logging without polluting the rest of the suite. The
+    save uses ``structlog.get_config()`` (returns a dict copy) and the
+    restore re-applies via ``structlog.configure(**saved)``.
+    """
+    saved = structlog.get_config()
+    yield
+    # structlog.get_config() returns a dict; pass back to configure as kwargs.
+    structlog.configure(**saved)
 
 
 def test_cli_mode_no_file_handler():


### PR DESCRIPTION
## Summary

PR #286's CI run failed (24918101423) with 21 broken tests across `test_voyage_retry`, `test_silent_error_logging`, `test_structlog_events`, and `test_nx_answer`. Root cause: `configure_logging` swapped `structlog.logger_factory` to `LoggerFactory(stdlib)` AND set `cache_logger_on_first_use=True`. Once a test in `test_logging_setup.py` called `configure_logging("mcp")`, every subsequent test in the session saw stdlib-routed logging instead of structlog's default `PrintLoggerFactory` writing to stdout. Tests that captured stdout via `capsys` saw nothing and asserted empty.

## What changed

### `src/nexus/logging_setup.py`

- `cache_logger_on_first_use=False` (was `True`). Tests reconfigure structlog and the cache would suppress those reconfigures. Comment explains the rationale.

### `tests/test_logging_setup.py`

New autouse fixture `_restore_structlog_after_test`:

- Saves `structlog.get_config()` before each test.
- Yields.
- Restores via `structlog.configure(**saved)` after the test.

This isolates `configure_logging` calls in this file from the rest of the suite. `conftest.pytest_configure` runs once at session start and sets the default (only `wrapper_class`, no `logger_factory` so structlog falls back to `PrintLoggerFactory`). That dict gets captured by the fixture's first save and restored after every test in this file. Subsequent test files run with the conftest-default factory and their `capsys` assertions work.

## Verification

```
uv run pytest tests/test_logging_setup.py tests/test_voyage_retry.py \
    tests/test_silent_error_logging.py tests/test_structlog_events.py \
    tests/test_nx_answer.py
151 passed, 1 skipped in 17.38s
```

Was: 21 failed in PR #286 CI run 24918101423.
Now: all green locally.

## Test plan

- [x] Local: 151 pass on the four affected test files.
- [ ] CI green on this PR.