### PR TITLE
docs(rdr-094): integrate research findings into the design

### DIFF
--- a/docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md
+++ b/docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md
@@ -25,8 +25,8 @@ exit needs the watchdog, UUID rollover needs the sweep, cold-start
 timing needs the fork-first launcher. Each layer addresses a case
 the layer above cannot, and the result is a five-piece machine
 (hook + detach launcher + watchdog + sweep + tmpdir) that exists
-only because the process tree we're trying to couple to — the
-Claude Code session itself — isn't directly addressable.
+only because the process tree we're trying to couple to, the
+Claude Code session itself, isn't directly addressable.
 
 The MCP server subprocess (`nx-mcp`, spawned by Claude Code via
 stdio) **is** directly addressable. Claude Code owns its lifetime,
@@ -51,10 +51,10 @@ logic before SIGTERM arrives, the cleanup does not run. The
 4.10.3 `nx hook session-end-detach` double-forks into a
 daemonised grandchild that survives the SIGTERM, but the fork
 itself runs only after Click parses argv and after
-`nexus.*` imports complete — ~2 seconds of cold-start cost on a
+`nexus.*` imports complete, ~2 seconds of cold-start cost on a
 reference install. The 4.11.1 `nx-session-end-launcher` console
 script (nexus-2u7o) shrinks this to ~256ms by forking before any
-`nexus.*` import, but the race is still a race — a sufficiently
+`nexus.*` import, but the race is still a race, a sufficiently
 aggressive Claude Code shutdown on a contested host would still
 cancel it. The fix is stacking mitigations around a fundamentally
 misaligned lifecycle anchor rather than changing the anchor.
@@ -70,7 +70,7 @@ rediscovered and patched separately.
 
 When `/clear` or `/resume` rolls the conversation UUID without
 killing Claude Code, the existing session record's `server_pid`
-and `claude_root_pid` both remain alive — the watchdog sees the
+and `claude_root_pid` both remain alive, the watchdog sees the
 claude parent alive and does not fire; the `server_dead` and
 `anchor_dead` sweep triggers are both satisfied (as in,
 not-dead); and the orphan chroma would stay alive until the
@@ -78,7 +78,7 @@ not-dead); and the orphan chroma would stay alive until the
 arm (nexus-886w) addressed this by comparing the record's
 `session_id` against the `current_session` flat-file pointer,
 reaping when they disagree. The fix is correct but shouldn't be
-necessary — if the MCP server owns chroma and Claude Code
+necessary, if the MCP server owns chroma and Claude Code
 restarts the MCP server on UUID rollover, the old MCP subprocess's
 `atexit` kills the old chroma before the new subprocess writes a
 new record. No intermediate-state sweep required.
@@ -97,7 +97,7 @@ total ~900KB of stable cruft. Every one of them is unreachable
 through any sweep trigger. If the MCP server owns both the tmpdir
 creation and the tmpdir removal as paired operations in the same
 process, there is no intermediate state where the tmpdir exists
-without an owner — the process is the owner, and its `atexit`
+without an owner, the process is the owner, and its `atexit`
 removes the directory.
 
 **Impact**: bounded but monotonic disk-cruft accumulation, and a
@@ -114,7 +114,7 @@ started by `SessionStart`, reachable by subagents via the PPID
 chain. RDR-034 (Closed, 2026-03-11) introduced the MCP server
 process as the storage interface. RDR-062 (Closed, 2026-03-14)
 split the MCP server into `nx-mcp` (core) and `nx-mcp-catalog`
-(catalog) — these are the subprocesses Claude Code spawns via
+(catalog), these are the subprocesses Claude Code spawns via
 stdio.
 
 The lifecycle machinery layered on top of RDR-010:
@@ -140,27 +140,27 @@ independently of all five.
 
 ### Technical Environment
 
-- `src/nexus/mcp/core.py` — `nx-mcp` server entry point (`main()`,
+- `src/nexus/mcp/core.py`, `nx-mcp` server entry point (`main()`,
   FastMCP instance at module scope). Long-lived subprocess owned by
   Claude Code via stdio.
-- `src/nexus/mcp/catalog.py` — `nx-mcp-catalog` server. Separate
+- `src/nexus/mcp/catalog.py`, `nx-mcp-catalog` server. Separate
   process; typically doesn't need T1.
-- `src/nexus/session.py` — `start_t1_server()`, `stop_t1_server()`,
+- `src/nexus/session.py`, `start_t1_server()`, `stop_t1_server()`,
   `sweep_stale_sessions()`, `find_claude_root_pid()`, session
   record I/O.
-- `src/nexus/hooks.py` — `session_start()`, `session_end()`. Called
+- `src/nexus/hooks.py`, `session_start()`, `session_end()`. Called
   by the hook subcommands.
-- `src/nexus/commands/hook.py` — `nx hook session-start`, `nx hook
+- `src/nexus/commands/hook.py`, `nx hook session-start`, `nx hook
   session-end`, `nx hook session-end-detach` subcommands. The
   SessionStart hook runs synchronously; SessionEnd fires via the
   launcher.
-- `src/nexus/_session_end_launcher.py` — 4.11.1 fork-first console
+- `src/nexus/_session_end_launcher.py`, 4.11.1 fork-first console
   script. Minimal imports at top level.
-- `src/nexus/t1_watchdog.py` — 4.10.3 sidecar. Watches
+- `src/nexus/t1_watchdog.py`, 4.10.3 sidecar. Watches
   `--claude-pid` + `--chroma-pid`, kills chroma when claude dies.
-- `src/nexus/db/t1.py` — T1 ChromaDB client. Resolves session by
+- `src/nexus/db/t1.py`, T1 ChromaDB client. Resolves session by
   `NX_SESSION_ID` env / `current_session` flat file / PPID walk.
-- `nx/hooks/hooks.json` — SessionStart + SessionEnd wired to the
+- `nx/hooks/hooks.json`, SessionStart + SessionEnd wired to the
   corresponding `nx hook ...` commands.
 
 ## Research Findings
@@ -170,7 +170,7 @@ independently of all five.
 Claude Code's MCP-subprocess lifecycle observed through plugin
 use: the server is spawned on session start and killed before
 Claude Code finishes exiting, with stdio handshake for both
-boundaries. No "Hook cancelled" analog exists for MCP servers —
+boundaries. No "Hook cancelled" analog exists for MCP servers -
 Claude Code blocks on the server's close before completing
 session teardown. Empirically observed across 4.10.x / 4.11.x
 sessions: MCP server deaths correlate exactly with Claude Code
@@ -197,93 +197,411 @@ exist as a stable per-session subprocess to inherit from.
 - **Verified** (`src/nexus/db/t1.py`): the T1 client already has
   the ancestor-detection logic needed for subagent connection
   (NX_SESSION_ID env + current_session pointer + PPID walk). None
-  of that has to change — only the SPAWN side moves.
+  of that has to change, only the SPAWN side moves.
 - **Assumed**: Claude Code sends SIGTERM (not SIGKILL) to MCP
   servers on clean shutdown, giving Python time to run `atexit`.
-  **Status**: Unverified — **Method**: instrumented spike on a
+  **Status**: Unverified, **Method**: instrumented spike on a
   local Claude Code install; run 10 graceful close cycles, 10
   `kill -9 claude` cycles, 10 OOM simulations; measure fraction of
   runs where atexit-based chroma stop reached completion.
 - **Assumed**: MCP server crash/restart within a live Claude
-  session is rare in practice. **Status**: Unverified —
+  session is rare in practice. **Status**: Unverified -
   **Method**: Layer 3 watchdog continues to exist for this case;
   the spike above will also measure MCP-restart frequency.
 
 ### Critical Assumptions
 
 - [ ] Claude Code's MCP-server shutdown ordering delivers SIGTERM
-      with enough time for Python `atexit` handlers to run chroma
-      cleanup. — **Status**: Unverified — **Method**: 30-run spike
-      across graceful / SIGKILL / OOM paths.
+      with enough time for the FastMCP lifespan `finally` block (or
+      atexit fallback) to run chroma cleanup. **Status**: Unverified
+      **Method**: 30-run spike across graceful / SIGKILL / OOM paths.
 - [ ] Moving chroma spawn from the SessionStart hook to MCP-server
-      startup does not regress subagent T1 sharing. — **Status**:
-      Unverified — **Method**: integration test dispatching a
-      subagent chain and asserting scratch read/write across the
-      tree.
-- [ ] The watchdog's pivot from `--claude-pid` to `--mcp-pid`
-      preserves coverage of the "MCP dies without atexit firing"
-      case. — **Status**: Unverified — **Method**: controlled
-      `kill -9` of the MCP server in a test harness; assert
-      watchdog reaps chroma within 5s.
+      startup does not regress subagent T1 sharing. **Status**:
+      Unverified. **Method**: integration test dispatching a subagent
+      chain and asserting scratch read/write across the tree.
+- [ ] The dual-watch watchdog (`--mcp-pid` + `--claude-pid` with
+      OR-trigger logic) preserves coverage of BOTH the "MCP dies
+      without atexit firing" case AND the "Claude Code crashes and
+      orphans the MCP server" case (Claude Code issue #1935).
+      **Status**: Unverified. **Method**: controlled `kill -9` of the
+      MCP server in a test harness asserts watchdog reaps chroma
+      within 5s; controlled `kill -9` of Claude Code asserts the
+      watchdog signals SIGTERM to mcp_pid, lifespan finally runs,
+      chroma stops within 7s (5s poll + 2s grace).
+- [ ] Claude Code issue #40207's mid-session SIGTERM (10-60s after
+      successful connection) does NOT apply to vanilla stdio servers
+      like nx-mcp, OR if it does, the FM-NEW-2 mitigation (TCP-probe
+      reuse of an existing session record) prevents the 1-5s T1 gap.
+      **Status**: Unverified. **Method**: instrument the spike harness
+      to log every SIGTERM received by the MCP server during a
+      30-minute idle session; if observed, run a follow-up probe with
+      the TCP-reuse code path enabled and assert no T1 gap surfaces
+      to the runner.
+
+## Research Appendix (2026-04-24)
+
+Multi-source research synthesis addressing six questions for gate
+evidence. Sources: MCP spec, Python runtime docs, Claude Code
+GitHub issues, FastMCP GitHub issues, OpenAI Codex GitHub issues,
+nexus source analysis.
+
+### RQ1: Sidecar Subprocess Prior Art in MCP Servers
+
+No production MCP server implementation was found that spawns a
+separate HTTP server sidecar subprocess from within the MCP server
+process. Community examples (mcp-toolbox, python-sdk lifespan
+examples, kanban-mcp) use connection pools or embedded databases
+cleaned up via async context manager finally blocks. The nexus
+ChromaDB sidecar pattern is architecturally novel.
+
+Prior art for the inverse problem (MCP server orphaned by client
+crash) is documented in openai/codex issues #16256 and #18881.
+The Codex McpConnectionManager lacked a Drop implementation; 492
+orphaned child processes accumulated over 15 hours, each consuming
+approximately 35% CPU. The failure mode, client dies without
+cleaning up server, server dies without cleaning up its children
+- is confirmed real in production MCP deployments.
+
+### RQ2: Python atexit and Signal Handler Patterns
+
+Python documentation is explicit: atexit handlers are NOT called
+"when the program is killed by a signal not handled by Python."
+SIGTERM is unhandled by default. The canonical bridge:
+
+```
+signal.signal(SIGTERM, lambda s, f: sys.exit(0))
+atexit.register(cleanup)
+```
+
+For FastMCP servers (anyio-backed), the lifespan context manager
+is the more robust pattern. anyio installs its own SIGTERM handler
+that cancels the running task group. Async cancellation propagates
+through `async finally` blocks, making the lifespan `finally`
+block fire on SIGTERM without a manual signal handler. FastMCP
+supports `lifespan=` in the constructor (same API as FastAPI).
+
+Known FastMCP signal handling bugs: issue modelcontextprotocol
+python-sdk #514 (SSE transport hangs after processing one request);
+PrefectHQ fastmcp #2837 (stdio transport requires multiple Ctrl-C
+for clean exit). These confirm the SIGTERM-to-cleanup path is
+fragile and the watchdog backstop is not optional.
+
+**Implementation recommendation**: use the FastMCP lifespan
+context manager as the primary cleanup path, not raw atexit +
+signal handler. The `signal.signal(SIGTERM, ...)` handler in the
+proposed design is still correct as insurance, but the lifespan
+`finally` block should own the cleanup call so anyio's cancellation
+is the authoritative path.
+
+### RQ3: Claude Code MCP Client Shutdown Semantics
+
+MCP specification 2025-03-26 (authoritative), stdio shutdown:
+
+1. Client closes the input stream (stdin EOF) to the server.
+2. Wait for the server to exit.
+3. Send SIGTERM if the server does not exit within a "reasonable
+   time" (no specific timeout defined).
+4. Send SIGKILL if no exit within "reasonable time" after SIGTERM.
+
+No shutdown RPC exists. "Reasonable time" is unspecified.
+
+Claude Code's observed sequence (issue #7718 strace evidence):
+
+1. SIGINT (not in spec).
+2. SIGTERM (if SIGINT fails).
+3. SIGKILL (if SIGTERM fails).
+4. "Cleanup timeout reached" + SIGABRT on Claude Code itself.
+
+**Critical finding, issue #40207**: Claude Code has an internal
+mid-session timeout that sends SIGTERM to healthy stdio MCP servers
+10-60 seconds after successful connection. The timeout shrinks over
+session lifetime: 60s, 30s, 10s. All MCP servers killed at the
+same second in evidence. Note: issue #40207 involves a proxy
+wrapper (mcp-stdio-proxy.sh); whether this applies to vanilla
+stdio servers like nx-mcp requires the Critical Assumption spike
+to verify. If it applies, chroma would restart multiple times
+within a single Claude session.
+
+**Critical finding, issue #1935**: Claude Code does NOT reliably
+kill its MCP server children when Claude Code itself crashes.
+Users documented 40+ orphaned MCP server processes (Docker
+containers, Python processes including chroma-mcp, Node.js servers)
+dating back days. This challenges the stated assumption "Claude
+Code owns its lifetime, negotiates shutdown, and waits for it to
+exit." The assumption holds for graceful exit; it does not hold
+for crash.
+
+### RQ4: Three-Level Process Chain (A owns B owns C)
+
+For Claude Code (A) to nx-mcp (B) to chroma (C) on macOS:
+
+`prctl(PR_SET_PDEATHSIG)`: Linux-only. macOS has no equivalent.
+Cannot use for macOS-first deployment.
+
+Process group: chroma in nx-mcp's pgroup would receive pgroup
+signals. Incompatible with `start_new_session=True` isolation that
+is load-bearing for POSIX semaphore cleanup (nexus-dc57/ze2a).
+
+Polling watchdog: correct architecture for macOS. No OS-specific
+primitives. 5s poll acceptable. The watchdog's own
+`start_new_session=True` ensures it survives nx-mcp pgroup kill.
+
+Conclusion: the polling watchdog is the right pattern. No change
+to the fundamental watchdog design is needed.
+
+### RQ5: Failure Mode Enumeration
+
+Failure modes solved by MCP ownership (confirmed):
+
+- Hook race vs shutdown: eliminated. MCP server exit is the anchor.
+- UUID rollover orphan: eliminated. Old MCP atexit fires before
+  the new MCP server starts, so no intermediate-state orphan is
+  possible.
+- Orphan tmpdir gap: eliminated. Same process creates and removes
+  the tmpdir; no state where tmpdir exists without an owner.
+
+New failure modes introduced by MCP ownership:
+
+**FM-NEW-1: MCP server orphaned by Claude Code crash (HIGH)**
+
+Issue #1935 documents Claude Code regularly leaving MCP servers
+alive after crash. In the current design, the watchdog watches
+`claude_root_pid`: Claude dies => watchdog fires within 5s.
+In the proposed design, the watchdog watches `mcp_pid`: Claude dies
+and MCP server survives as an orphan => watchdog sees mcp_pid alive
+and never fires. Chroma stays alive until the 24h sweep.
+
+This is a regression relative to the current watchdog behavior
+for the Claude-crash failure mode.
+
+MITIGATION REQUIRED before gate: the watchdog must watch BOTH
+`mcp_pid` (fires when MCP dies without atexit) AND `claude_root_pid`
+(fires when Claude dies while MCP server is still alive and thus
+orphaned). The session record already stores `claude_root_pid`; no
+schema change is needed. The watchdog argument interface needs to
+accept both PIDs and implement OR-trigger logic.
+
+**FM-NEW-2: Mid-session MCP restart creates T1 gap (LOW-MEDIUM)**
+
+If the #40207 mid-session timeout applies to nx-mcp, each timeout
+fires the atexit (chroma stops), then the restarted MCP server
+spawns a fresh chroma. The gap is estimated at 1-5 seconds during
+which T1 falls back to EphemeralClient. Hook-based chroma is
+immune because chroma lives independently of the MCP lifecycle.
+
+Mitigation: at MCP startup, TCP-probe the address in any existing
+session record. If reachable, reuse it rather than spawning a new
+chroma. This eliminates the gap for mid-session restart cases.
+
+Retained failure modes (behavior identical in both designs):
+
+- MCP SIGKILL without atexit: watchdog detects mcp_pid gone, cleans
+  up chroma within 5s.
+- Watchdog also killed: sweep server_dead trigger on next
+  SessionStart.
+
+### RQ6: Crash-Restart Semantics
+
+On nx-mcp crash (SIGSEGV, OOM, unhandled exception):
+
+- atexit and lifespan finally block do not fire (fatal signal).
+- Watchdog (watching mcp_pid) detects mcp_pid gone within 5s.
+- Watchdog runs in its own session (start_new_session=True) and
+  survives pgroup kill of nx-mcp.
+- Fallback if watchdog also killed: sweep server_dead on next
+  SessionStart.
+
+On Claude Code crash where nx-mcp is orphaned (FM-NEW-1):
+
+- A watchdog watching mcp_pid only sees mcp_pid alive, never fires.
+- Sweep anchor_dead trigger (claude_root_pid in session record)
+  fires on next SessionStart. This coverage already exists.
+- The regression is 5s watchdog detection becoming SessionStart-only
+  detection. This is acceptable if FM-NEW-1 mitigation is added.
+
+### Summary for Gate Decision
+
+**Overall recommendation: PROCEED with modifications.**
+
+The core premise is sound. The MCP server is a better lifecycle
+anchor than hooks. The three documented gaps are genuinely
+eliminated. The complexity reduction (five-piece to three-piece)
+is real.
+
+One required design change before gate accept:
+
+- Watchdog dual-watch: pass both `--mcp-pid` and `--claude-pid`
+  to the watchdog. The watchdog fires if mcp_pid dies while chroma
+  is alive (atexit didn't run) AND signals the MCP server to exit
+  if claude_root_pid dies while mcp_pid is alive (orphaned MCP
+  server). The existing session record already stores both PIDs;
+  the watchdog argument interface is the only change.
+
+One recommended improvement for implementation (not a gate blocker):
+
+- Use the FastMCP lifespan context manager as the primary cleanup
+  path rather than raw atexit + manual signal handler. anyio's
+  cancellation propagation through async finally blocks is more
+  reliable for FastMCP than the atexit chain.
+
+The Critical Assumption spike (30-run lifecycle probe) remains the
+essential gate prerequisite.
+
+### Research Sources
+
+- MCP spec 2025-03-26 lifecycle:
+  https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle
+- Python atexit docs:
+  https://docs.python.org/3/library/atexit.html
+- Claude Code issue #40207 (mid-session SIGTERM to MCP servers):
+  https://github.com/anthropics/claude-code/issues/40207
+- Claude Code issue #1935 (orphaned MCP server processes):
+  https://github.com/anthropics/claude-code/issues/1935
+- Claude Code issue #7718 (SIGABRT on shutdown):
+  https://github.com/anthropics/claude-code/issues/7718
+- Claude Code issue #37127 (TaskStop SIGTERM/SIGKILL):
+  https://github.com/anthropics/claude-code/issues/37127
+- FastMCP / python-sdk issue #514 (SSE signal handling):
+  https://github.com/modelcontextprotocol/python-sdk/issues/514
+- FastMCP issue #2837 (stdio Ctrl-C):
+  https://github.com/PrefectHQ/fastmcp/issues/2837
+- OpenAI Codex issue #16256 (MCP orphaned processes):
+  https://github.com/openai/codex/issues/16256
+- OpenAI Codex issue #18881 (McpConnectionManager leak):
+  https://github.com/openai/codex/issues/18881
 
 ## Proposed Solution
 
 ### Approach
 
 Move chroma spawn to `nx-mcp` server startup and chroma teardown
-to `atexit` + `SIGTERM` handlers in the same process. Keep the
-`t1_watchdog` sidecar but pivot it to watch the MCP server's PID.
+to a FastMCP `lifespan` context manager (anyio cancellation
+propagation through `async finally`) backed by `atexit` + a
+`SIGTERM` handler as belt-and-braces for the cancellation paths
+where lifespan does not fire (research RQ2: anyio installs its
+own SIGTERM handler that cancels the running task group, making
+the lifespan finally block fire on SIGTERM without a manual
+handler; raw atexit + signal handler are the secondary path).
+
+Pivot the `t1_watchdog` sidecar to watch BOTH `--mcp-pid` AND
+`--claude-pid` with OR-trigger logic. This is required to cover
+the FM-NEW-1 failure mode (Claude Code issue #1935: Claude Code
+does not reliably clean up MCP server children on crash, leaving
+the MCP server orphaned and chroma alive). A watchdog watching
+only `--mcp-pid` would never fire when Claude Code crashes and
+the MCP server survives. The session record already stores both
+PIDs; only the watchdog argument interface and polling loop change.
+
 Keep the `sweep_stale_sessions` liveness sweep as final belt-and-
-braces for the rare case of both `atexit` and watchdog failing.
-Retire the `SessionStart` and `SessionEnd` hooks' chroma-management
-responsibilities; keep the hooks for scratch-flush and memory-
-expire which remain hook-native tasks.
+braces for the combined-failure scenario (MCP SIGKILL + watchdog
+also killed). Retire the `SessionStart` and `SessionEnd` hooks'
+chroma-management responsibilities; keep the hooks for scratch-
+flush and memory-expire which remain hook-native tasks.
 
 ### Technical Design
 
 **`nx-mcp` server lifecycle** (`src/nexus/mcp/core.py`):
 
+Primary path: FastMCP `lifespan=` context manager (research RQ2,
+recommended over raw atexit). Secondary: `atexit` + a `SIGTERM`
+signal handler as belt-and-braces for kill paths where lifespan
+does not fire.
+
 ```text
+@asynccontextmanager
+async def _t1_chroma_lifespan(_app):
+    _t1_chroma_init_if_owner()
+    try:
+        yield
+    finally:
+        _t1_chroma_shutdown()      # PRIMARY cleanup path
+
+mcp = FastMCP("nexus", lifespan=_t1_chroma_lifespan)
+
 main():
-    # Existing FastMCP setup unchanged.
-    _t1_chroma_init_if_owner()       # NEW
-    atexit.register(_t1_chroma_shutdown)
-    signal.signal(SIGTERM, _sigterm_handler)
-    signal.signal(SIGINT, _sigterm_handler)
-    # FastMCP run loop.
-    mcp.run()
+    configure_logging("mcp")
+    atexit.register(_t1_chroma_shutdown)              # SECONDARY
+    signal.signal(SIGTERM, _sigterm_handler)          # SECONDARY
+    signal.signal(SIGINT, _sigterm_handler)           # SECONDARY
+    log.info("mcp_server_starting", server="nx-mcp")
+    try:
+        mcp.run(transport="stdio")
+    except BaseException as exc:
+        log.exception("mcp_server_crashed", error=str(exc))
+        raise
+    finally:
+        log.info("mcp_server_stopping")
 
 _t1_chroma_init_if_owner():
-    # Subagent detection — same logic t1.py already has.
+    # Subagent detection, same logic t1.py already has.
     if os.environ.get("NX_SESSION_ID") and _find_ancestor_session():
         return   # Nested MCP server; connect to ancestor, don't spawn.
-    # Top-level MCP server → own the chroma lifecycle.
+    # TCP-probe any existing session record for the same session_id
+    # (FM-NEW-2 mitigation): if the address is reachable, reuse it
+    # rather than spawning fresh. This eliminates the 1-5s T1 gap
+    # that issue #40207's mid-session SIGTERM-restart cycle would
+    # otherwise create.
+    own_id = _resolve_own_session_id()
+    existing = read_session_record_by_id(SESSIONS_DIR, own_id)
+    if existing and _tcp_probe_alive(existing["host"], existing["port"]):
+        _OWNED_CHROMA.update({"reused": True})
+        return
+    # Top-level MCP server, own the chroma lifecycle.
     host, port, pid, tmpdir = start_t1_server()
     _OWNED_CHROMA.update({"pid": pid, "tmpdir": tmpdir})
     write_session_record_by_id(
-        SESSIONS_DIR, session_id=_resolve_own_session_id(),
+        SESSIONS_DIR, session_id=own_id,
         host=host, port=port, server_pid=pid,
         claude_root_pid=find_claude_root_pid(),
-        watchdog_pid=spawn_t1_watchdog(mcp_pid=os.getpid(), chroma_pid=pid),
+        watchdog_pid=spawn_t1_watchdog(
+            mcp_pid=os.getpid(),
+            claude_pid=find_claude_root_pid(),    # FM-NEW-1 dual-watch
+            chroma_pid=pid,
+        ),
     )
 
 _t1_chroma_shutdown():
-    if not _OWNED_CHROMA:
-        return
+    if not _OWNED_CHROMA or _OWNED_CHROMA.get("reused"):
+        return                                          # idempotent
     stop_t1_server(_OWNED_CHROMA["pid"])
     shutil.rmtree(_OWNED_CHROMA["tmpdir"], ignore_errors=True)
     _remove_own_session_record()
+    _OWNED_CHROMA.clear()                               # idempotent
 ```
 
-**Watchdog pivot** (`src/nexus/t1_watchdog.py`):
+`_t1_chroma_shutdown` is idempotent so the lifespan finally block,
+the atexit handler, and the SIGTERM handler can each call it
+safely; the first to fire performs the work, the rest are no-ops.
 
-The `--claude-pid` flag renames to `--mcp-pid`. The polling loop
-swaps target but otherwise unchanged — still uses `os.kill(pid, 0)`
-for liveness probe, still pgrp-signals chroma on parent death.
-Watchdog continues to be spawned detached so it survives the MCP
-server's clean shutdown, then observes the MCP's exit code to
-decide whether cleanup is already done (atexit fired) or needs to
-happen from the sidecar (MCP SIGKILL'd).
+**Watchdog dual-watch** (`src/nexus/t1_watchdog.py`):
+
+The watchdog accepts `--mcp-pid` AND keeps `--claude-pid` (research
+FM-NEW-1, Claude Code issue #1935: Claude Code does not reliably
+clean up MCP children on crash). Polling loop now uses OR-trigger
+logic:
+
+```text
+while True:
+    if not _alive(mcp_pid):
+        # MCP server died without atexit firing (SIGKILL, segfault).
+        _stop_chroma_pgrp()
+        break
+    if not _alive(claude_pid):
+        # Claude Code died and orphaned the MCP server. Send SIGTERM
+        # to mcp_pid so its lifespan finally runs (cleans chroma),
+        # then exit.
+        os.kill(mcp_pid, SIGTERM)
+        time.sleep(2)                  # Grace for lifespan finally.
+        if _alive(mcp_pid):
+            os.kill(mcp_pid, SIGKILL)
+        _stop_chroma_pgrp()            # Belt-and-braces.
+        break
+    time.sleep(_POLL_INTERVAL)
+```
+
+Watchdog continues to be spawned detached (`start_new_session=True`)
+so it survives the MCP server's clean shutdown and is not killed by
+the MCP server's pgroup teardown. The 5s poll interval is unchanged.
 
 **Hook retirement** (`nx/hooks/hooks.json`):
 
@@ -293,7 +611,7 @@ happen from the sidecar (MCP SIGKILL'd).
 - `SessionEnd` hook: retain scratch-flush + memory-expire (called
   via `nx hook session-end-flush`, a renamed subcommand that does
   everything `session_end()` does today MINUS the chroma stop).
-  Remove `nx-session-end-launcher` from the hook chain — it
+  Remove `nx-session-end-launcher` from the hook chain, it
   becomes vestigial. The launcher script stays in the codebase as
   a fallback but is no longer wired in.
 
@@ -323,7 +641,7 @@ Two complementary paths:
 | --- | --- | --- |
 | Chroma spawn at MCP startup | `nexus.hooks.session_start` | **Move**: port the chroma-spawn block from hooks.py into a new `_t1_chroma_init_if_owner` in mcp/core.py. Keep the session-start hook for non-chroma work. |
 | Chroma teardown at MCP exit | `nexus.hooks.session_end` (chroma block) | **Move to atexit**: reuse `stop_t1_server` + tmpdir rmtree + record removal as an atexit handler. Keep `session_end_flush` for scratch-flush + memory-expire. |
-| Watchdog target PID | `nexus.t1_watchdog` | **Rename flag**: `--claude-pid` → `--mcp-pid`. Same observer, different target. |
+| Watchdog target PIDs | `nexus.t1_watchdog` | **Add second flag**: keep `--claude-pid`, add `--mcp-pid`, OR-trigger logic. Both PIDs already in the session record; only the watchdog argument interface and polling loop change. Required to cover Claude Code issue #1935 (orphaned MCP on Claude crash). |
 | Sweep | `sweep_stale_sessions` | **Keep + extend**: all four current triggers stay; optional tmpdir-scan pass added for Gap 3. |
 | SessionEnd hook / launcher | `nx/hooks/hooks.json` + `_session_end_launcher.py` | **Retire from chroma path**: launcher stays as code but is unwired. Hook shrinks to scratch/memory cleanup via `nx hook session-end-flush`. |
 
@@ -340,7 +658,7 @@ The retention of watchdog + sweep is deliberate. MCP-SIGKILL is
 the one case where `atexit` does not run; the watchdog still
 needs to cover that path. Sweep is cheap insurance for the
 combined-failure scenario (MCP SIGKILL + watchdog pgrp-signaled
-to death). The point isn't to remove all defense-in-depth — it's
+to death). The point isn't to remove all defense-in-depth, it's
 to make the primary path reliable enough that the other layers
 fire in exceptional cases only.
 
@@ -373,7 +691,7 @@ both Claude Code and the MCP server that owns all T1 lifecycle.
 internals. Clean separation.
 
 **Cons**: Adds a new long-lived process to the per-session surface.
-No natural lifecycle anchor — back to simulating Claude Code
+No natural lifecycle anchor, back to simulating Claude Code
 liveness. Re-introduces every problem the current machinery
 exists to solve.
 
@@ -384,7 +702,7 @@ problem we don't.
 
 - **Use `nx-mcp-catalog` as the anchor**: catalog server doesn't
   need T1 and the catalog lifecycle is narrower. Using `nx-mcp`
-  is correct — T1 clients are the natural consumer.
+  is correct, T1 clients are the natural consumer.
 - **Have chroma spawn inline in the nx-mcp main() without the
   subagent-detection check**: would create N chroma servers (one
   per nested MCP server) and destroy the cross-agent scratch
@@ -406,8 +724,10 @@ problem we don't.
   launcher for a direct `nx hook session-end-flush` call. The
   5s timeout stays; work inside the hook is now milliseconds, not
   seconds.
-- `t1_watchdog.py` renames `--claude-pid` to `--mcp-pid`. One-line
-  semantics change.
+- `t1_watchdog.py` keeps `--claude-pid` and adds `--mcp-pid`; the
+  polling loop uses OR-trigger logic. The argument interface and
+  the polling block are the only changes. Required to cover the
+  orphaned-MCP-on-Claude-crash case (issue #1935, FM-NEW-1).
 - `sweep_stale_sessions` gains an optional tmpdir-scan pass for
   historical orphan cleanup (Gap 3). The four record-based
   triggers unchanged.
@@ -422,7 +742,7 @@ problem we don't.
   than documented and doesn't give Python time to run atexit
   handlers, leaving chroma orphaned on every clean shutdown.
   **Mitigation**: Critical Assumption #1 requires a spike before
-  accept. If the spike fails, the watchdog is the fallback —
+  accept. If the spike fails, the watchdog is the fallback -
   same coverage the hook-era setup has now for ungraceful exit.
 
 - **Risk**: A future Claude Code release changes MCP shutdown
@@ -433,7 +753,7 @@ problem we don't.
   Code version bump. Explicit break condition rather than silent
   regression.
 
-- **Risk**: Migration leaves deployments in a mixed state —
+- **Risk**: Migration leaves deployments in a mixed state -
   plugin 4.12.0 installed but conexus CLI still on 4.11.1, or
   vice versa. If plugin hooks.json no longer spawns chroma but
   MCP server doesn't yet own chroma, no T1 scratch works.
@@ -454,31 +774,87 @@ problem we don't.
   code used today; the assertion just pins it to the new spawn
   site.
 
+- **Risk (FM-NEW-1)**: Claude Code crashes and orphans the MCP
+  server. Issue #1935 documents 40+ orphaned MCP server processes
+  surviving Claude Code crashes in the wild (Docker, Python, Node).
+  A watchdog watching only `--mcp-pid` would never fire, leaving
+  chroma alive until the next session's sweep finds it.
+  **Mitigation**: dual-PID watchdog described in the Approach and
+  Technical Design sections. Watchdog watches BOTH `mcp_pid` and
+  `claude_root_pid`; on Claude crash, the watchdog signals SIGTERM
+  to mcp_pid (lifespan finally runs, chroma stops) then exits.
+  Critical Assumption #3 verifies this end-to-end on a controlled
+  Claude-kill harness.
+
+- **Risk (FM-NEW-2)**: Claude Code issue #40207 documents an
+  internal mid-session timeout that sends SIGTERM to healthy stdio
+  MCP servers 10-60s after successful connection. If this affects
+  vanilla stdio servers like nx-mcp, every timeout cycle would
+  stop and restart chroma, creating a 1-5s window where T1 falls
+  back to EphemeralClient and cross-agent scratch breaks.
+  **Mitigation**: at MCP startup, TCP-probe any existing session
+  record for the same `session_id`; if reachable, reuse the
+  existing chroma rather than spawning fresh. The mid-session
+  restart cycle becomes a no-op for chroma. Critical Assumption
+  #4 verifies the timeout's applicability to nx-mcp and exercises
+  the TCP-reuse path under simulated mid-session SIGTERM.
+
 ### Failure Modes
 
-- **Visible**: MCP server startup fails to spawn chroma → T1 falls
+- **Visible**: MCP server startup fails to spawn chroma. T1 falls
   through to `EphemeralClient` (existing defense-in-depth); T2/T3
-  unaffected. Logged.
-- **Silent (resolved in design)**: UUID rollover orphan chroma —
-  eliminated by the move. Old MCP subprocess's atexit stops its
-  chroma before the new MCP subprocess starts.
-- **Silent (resolved in design)**: Orphan tmpdirs — eliminated by
+  unaffected. Logged via the new mcp.log path (PR #286).
+- **Visible**: MCP server crash. PR #286 wires `mcp_server_crashed`
+  with full traceback to mcp.log so post-mortem diagnosis no
+  longer depends on Claude Code's captured stderr. The dual-watch
+  watchdog detects mcp_pid gone within 5s and reaps chroma.
+- **Silent (resolved in design)**: UUID rollover orphan chroma.
+  Eliminated by the move. Old MCP subprocess's lifespan finally
+  block stops its chroma before the new MCP subprocess starts.
+- **Silent (resolved in design)**: Orphan tmpdirs. Eliminated by
   co-locating tmpdir creation and removal in the same process.
   One-time tmpdir-scan migration handles pre-existing cruft.
+- **Silent (resolved in design, FM-NEW-1)**: Claude Code crashes
+  and orphans the MCP server. Documented in issue #1935. The
+  dual-watch watchdog (`--mcp-pid` + `--claude-pid`) handles this
+  by signalling SIGTERM to mcp_pid when claude_pid disappears.
+  Without the dual-watch, this would be a silent regression
+  relative to the current hook-based design.
+- **Silent (resolved in design, FM-NEW-2)**: Claude Code mid-
+  session SIGTERM (issue #40207) repeatedly restarts the MCP
+  server, creating a T1 gap on each restart. Mitigated by the
+  TCP-probe-and-reuse path in `_t1_chroma_init_if_owner`. If the
+  spike (Critical Assumption #4) shows the issue does not affect
+  vanilla stdio servers, the TCP-reuse path remains as cheap
+  insurance; if it does affect nx-mcp, the path is load-bearing.
 
 ## Implementation Plan
 
 ### Prerequisites
 
-- [ ] Spike: instrumented 30-run lifecycle probe. Phases: 10 clean
-      shutdowns, 10 `kill -9` of Claude Code, 10 simulated OOM.
-      Measure chroma-cleanup completion rate by source (atexit,
-      watchdog, sweep, none). Target: atexit covers ≥90% of clean
-      shutdowns; watchdog covers ≥95% of SIGKILL/OOM.
-- [ ] Spike: subagent chain scratch-sharing integration test.
+- [ ] Spike A: instrumented 40-run lifecycle probe. Phases: 10
+      clean shutdowns, 10 `kill -9` of Claude Code (FM-NEW-1
+      regression-guard, watchdog dual-watch), 10 simulated OOM,
+      10 `kill -9` of the MCP server. Measure chroma-cleanup
+      completion rate by source (lifespan, atexit, watchdog,
+      sweep, none). Targets:
+      - lifespan finally covers >=90% of clean shutdowns
+      - watchdog (mcp-pid trigger) covers >=95% of MCP SIGKILL / OOM
+      - watchdog (claude-pid trigger) covers >=95% of Claude SIGKILL,
+        with chroma stopped within 7s (5s poll + 2s grace)
+- [ ] Spike B: subagent chain scratch-sharing integration test.
       Parent MCP server spawns chroma; 3-level-deep subagent
       dispatch writes to scratch; each level reads back sibling
       writes. Assert all reads succeed.
+- [ ] Spike C: mid-session SIGTERM probe (Claude Code issue
+      #40207). Run a 30-minute idle session with the spike harness
+      logging every signal received by nx-mcp. If SIGTERM is
+      observed mid-session, run the follow-up: enable the
+      TCP-probe-reuse path in `_t1_chroma_init_if_owner` and assert
+      no T1 gap surfaces during 5 simulated restart cycles. If
+      no SIGTERM is observed, document #40207 as not applicable
+      to vanilla stdio servers and keep the TCP-reuse path as
+      cheap insurance.
 
 ### Minimum Viable Validation
 
@@ -492,13 +868,21 @@ leaves zero orphan processes and zero orphan tmpdirs.
 #### Step 1: Add `_t1_chroma_init_if_owner` to `src/nexus/mcp/core.py`
 
 Port the chroma-spawn block from `nexus.hooks.session_start`.
-Register under a feature flag (`NEXUS_MCP_OWNS_T1=1`) initially
-so the migration is opt-in for spike validation.
+Add the TCP-probe-and-reuse path (FM-NEW-2 mitigation): if a
+session record for the same `session_id` exists and its address
+is reachable, reuse it rather than spawning fresh. Register
+under a feature flag (`NEXUS_MCP_OWNS_T1=1`) initially so the
+migration is opt-in for spike validation.
 
-#### Step 2: Register atexit + signal handlers
+#### Step 2: Wire FastMCP lifespan + atexit + signal handlers
 
-`_t1_chroma_shutdown` handles SIGTERM, SIGINT, and atexit.
-Idempotent (safe under double-fire).
+Primary cleanup path: pass `lifespan=_t1_chroma_lifespan` to the
+`FastMCP(...)` constructor. anyio's cancellation propagation
+through the `async finally` block fires on SIGTERM without a
+manual handler. Secondary: register `_t1_chroma_shutdown` via
+`atexit` and bind it to SIGTERM/SIGINT signal handlers as belt-
+and-braces. `_t1_chroma_shutdown` is idempotent (safe under
+double-fire from any combination of paths).
 
 #### Step 3: Keep hook spawn as fallback
 
@@ -506,12 +890,18 @@ Idempotent (safe under double-fire).
 the session record; if yes, no-op. If no, falls through to the
 current spawn path. Migration window safety.
 
-### Phase 2: Watchdog + hook retirement
+### Phase 2: Watchdog dual-watch + hook retirement
 
-#### Step 1: Pivot `t1_watchdog.py` to `--mcp-pid`
+#### Step 1: Extend `t1_watchdog.py` to dual-watch
 
-Rename flag, update `spawn_t1_watchdog` caller. Same observer
-logic.
+Add `--mcp-pid` to the argument interface, keep `--claude-pid`.
+Polling loop uses OR-trigger logic: fires `_stop_chroma_pgrp()`
+if mcp_pid disappears (MCP died without lifespan/atexit), or
+sends SIGTERM to mcp_pid (then SIGKILL after 2s grace) if
+claude_pid disappears (Claude crashed and orphaned the MCP
+server, FM-NEW-1). Update `spawn_t1_watchdog(...)` callers in
+`mcp/core.py` to pass both PIDs. Required to cover the Claude-
+crash failure mode that issue #1935 documents.
 
 #### Step 2: Split `hooks.session_end` into `session_end_flush`
 
@@ -553,53 +943,70 @@ path. Hook-era chroma-spawn block deleted from `session_start()`.
 
 ### New Dependencies
 
-None. Python `atexit` and `signal` are stdlib.
+None. Python `atexit`, `signal`, `socket` (TCP probe) are stdlib.
+The FastMCP `lifespan=` constructor argument is already supported
+by the `mcp.server.fastmcp.FastMCP` version pinned in `pyproject.toml`.
 
 ## Test Plan
 
-- **Scenario**: `nx-mcp` starts without `NX_SESSION_ID` env →
-  spawns chroma, writes session record, registers atexit. **Verify**:
-  session file exists, chroma process alive, atexit handler
-  registered.
+- **Scenario**: `nx-mcp` starts without `NX_SESSION_ID` env, no
+  existing session record. **Verify**: spawns chroma, writes
+  session record (with both `server_pid` and `claude_root_pid`),
+  registers lifespan + atexit + signal handlers.
 - **Scenario**: `nx-mcp` starts with `NX_SESSION_ID` pointing at
-  an ancestor's session → no chroma spawned, connects to ancestor.
-  **Verify**: no new chroma process, t1 client resolves to
-  ancestor server.
-- **Scenario**: Clean MCP shutdown (Claude Code SIGTERM) →
-  atexit fires. **Verify**: chroma process gone, session file
-  removed, tmpdir removed.
-- **Scenario**: MCP SIGKILL (no atexit) → watchdog detects dead
-  MCP PID, reaps chroma. **Verify**: chroma gone within 5s.
-- **Scenario**: MCP crash + watchdog also killed (pgrp SIGKILL)
-  → next SessionStart's sweep catches via `server_dead` or
-  `anchor_dead`. **Verify**: record and chroma reaped.
-- **Scenario**: Subagent chain scratch sharing → parent writes
+  an ancestor's session. **Verify**: no new chroma spawned, t1
+  client resolves to ancestor server.
+- **Scenario (FM-NEW-2)**: `nx-mcp` starts with an existing
+  session record for the same `session_id` and a reachable
+  address. **Verify**: TCP-probe succeeds, no new chroma spawned,
+  `_OWNED_CHROMA["reused"]=True`, the lifespan finally / atexit
+  paths skip cleanup.
+- **Scenario**: Clean MCP shutdown (Claude Code SIGTERM). **Verify**:
+  lifespan finally block runs, chroma process gone, session file
+  removed, tmpdir removed. atexit handler is a no-op (lifespan
+  already cleaned up; idempotent shutdown).
+- **Scenario**: MCP SIGKILL (no lifespan or atexit). **Verify**:
+  watchdog `mcp_pid` trigger fires, reaps chroma within 5s.
+- **Scenario (FM-NEW-1)**: Claude Code SIGKILL leaves MCP server
+  orphaned. **Verify**: watchdog `claude_pid` trigger fires,
+  signals SIGTERM to mcp_pid, lifespan finally runs, chroma stops
+  within 7s (5s poll + 2s grace).
+- **Scenario**: MCP crash + watchdog also killed (pgrp SIGKILL).
+  **Verify**: next SessionStart's sweep catches via `server_dead`
+  or `anchor_dead`; record and chroma reaped.
+- **Scenario**: Subagent chain scratch sharing. Parent writes
   scratch entry, 3-level-deep child reads it. **Verify**: read
   returns parent's value.
-- **Scenario**: UUID rollover (`/clear`) → old MCP subprocess
-  atexit fires → new MCP subprocess spawns fresh chroma. **Verify**:
-  old chroma gone, new chroma alive, `current_session` pointer
-  matches new chroma's record.
+- **Scenario**: UUID rollover (`/clear`). Old MCP subprocess
+  lifespan finally fires, new MCP subprocess spawns fresh chroma.
+  **Verify**: old chroma gone, new chroma alive, `current_session`
+  pointer matches new chroma's record.
 - **Scenario**: Tmpdir-scan pass finds 5 orphan tmpdirs older
-  than 24h with no session record → rmtree all 5. **Verify**:
-  directories removed, log entry per reap.
-- **Scenario**: Migration — conexus 4.12.0 installed, plugin
-  4.11.x on disk (old hook still spawns chroma) → MCP detects
-  existing record, no duplicate spawn. **Verify**: single chroma
-  process, single session record.
+  than 24h with no session record. **Verify**: rmtree all 5,
+  log entry per reap.
+- **Scenario**: Migration. conexus 4.12.0 installed, plugin
+  4.11.x on disk (old hook still spawns chroma). **Verify**: MCP
+  detects existing record via TCP-probe, single chroma process,
+  single session record (no duplicate spawn).
 
 ## Validation
 
 ### Testing Strategy
 
 Unit tests for the MCP-owned chroma spawn / teardown logic
-(mocked `start_t1_server` / `stop_t1_server`). Integration test
-exercising the full subagent-chain scratch-sharing path against
-a real chroma. Lifecycle test that brings up a real `nx-mcp`
-subprocess, sends SIGTERM, and asserts atexit-driven cleanup
-completed. Canary test (plugin-version-indexed) that runs each
-of the nine test-plan scenarios against the current Claude Code
-version, detecting MCP-shutdown-ordering regressions.
+(mocked `start_t1_server` / `stop_t1_server`), including the
+TCP-probe-and-reuse path and the idempotent-shutdown contract
+(double-fire safety). Integration test exercising the full
+subagent-chain scratch-sharing path against a real chroma.
+Lifecycle test that brings up a real `nx-mcp` subprocess, sends
+SIGTERM, and asserts the lifespan finally block (or atexit
+fallback) drove the cleanup to completion. FM-NEW-1 lifecycle
+test: same harness, SIGKILL Claude Code instead, assert dual-
+watch watchdog signals SIGTERM to mcp_pid and chroma exits
+within 7s. Canary test (plugin-version-indexed) that runs each
+test-plan scenario against the current Claude Code version,
+detecting MCP-shutdown-ordering regressions including the
+issue-#40207 mid-session SIGTERM case.
 
 ## Finalization Gate
 
@@ -607,21 +1014,21 @@ _To be completed during /nx:rdr-gate._
 
 ## References
 
-- RDR-010 — T1 Scratch: Cross-Process Session Sharing via
+- RDR-010, T1 Scratch: Cross-Process Session Sharing via
   ChromaDB Server + PPID Chain (original design).
-- RDR-034 — MCP Server for Agent Storage Operations.
-- RDR-062 — MCP Interface Tiering (`nx-mcp` + `nx-mcp-catalog` split).
-- RDR-078 — Dimensional plan identity (session-ID propagation
+- RDR-034, MCP Server for Agent Storage Operations.
+- RDR-062, MCP Interface Tiering (`nx-mcp` + `nx-mcp-catalog` split).
+- RDR-078, Dimensional plan identity (session-ID propagation
   consumer).
-- nexus-99jb — 4.10.3 three-layer defense-in-depth (watchdog +
+- nexus-99jb, 4.10.3 three-layer defense-in-depth (watchdog +
   session-end-detach + liveness sweep). Layer this RDR's primary
   path replaces.
-- nexus-886w — 4.11.0 uuid_mismatch sweep arm. Made largely
+- nexus-886w, 4.11.0 uuid_mismatch sweep arm. Made largely
   redundant by this RDR.
-- nexus-2u7o — 4.11.1 fork-first `nx-session-end-launcher`.
+- nexus-2u7o, 4.11.1 fork-first `nx-session-end-launcher`.
   Retires from the critical path under this RDR.
-- `src/nexus/mcp/core.py` — `nx-mcp` entry point (insertion site).
-- `src/nexus/session.py` — session record + chroma lifecycle
+- `src/nexus/mcp/core.py`, `nx-mcp` entry point (insertion site).
+- `src/nexus/session.py`, session record + chroma lifecycle
   helpers (reused, relocated callers).
-- `src/nexus/t1_watchdog.py` — PID pivot target.
-- `src/nexus/hooks.py` — hook bodies (shrink to scratch/memory only).
+- `src/nexus/t1_watchdog.py`, PID pivot target.
+- `src/nexus/hooks.py`, hook bodies (shrink to scratch/memory only).


### PR DESCRIPTION
## Summary

The deep-research-synthesizer agent produced the Research Appendix on RDR-094 (T2 `nexus_rdr/094-research-1` id=975, T3 `knowledge__nexus`, RDR file lines 229-460). This commit propagates the synthesis's two structural findings into the rest of the document so the design and implementation plan match what the research established. Also strips em-dashes throughout for style.

## Structural changes driven by research

### FM-NEW-1: Claude Code crash orphans the MCP server

Claude Code issue #1935 documents 40+ orphaned MCP server processes surviving Claude Code crashes in the wild (Docker, Python including chroma-mcp, Node.js). The original RDR pivoted the watchdog from `--claude-pid` to `--mcp-pid`, which would have left chroma alive indefinitely on Claude Code crash because the watchdog never fires when the orphaned MCP server is still alive.

Updated the watchdog to dual-watch BOTH `--mcp-pid` AND `--claude-pid` with OR-trigger logic. The session record already stores both PIDs; only the watchdog argument interface and polling loop change.

Touched: Approach, Technical Design (watchdog code block), Critical Assumptions (assumption 3 rewritten + new assumption 4), Existing Infrastructure Audit, Consequences, Risks and Mitigations, Failure Modes, Implementation Plan Phase 2 Step 1, Test Plan, Validation strategy.

### FM-NEW-2: Claude Code mid-session SIGTERM (issue #40207)

Issue #40207 documents Claude Code sending SIGTERM to healthy stdio MCP servers 10-60s after connection. Whether this affects vanilla stdio servers is unverified; if it does, every restart cycle creates a 1-5s T1 gap.

Added a TCP-probe-and-reuse path in `_t1_chroma_init_if_owner`: if an existing session record's address is reachable, reuse it rather than spawning fresh.

Touched: Approach, Technical Design (init code block, idempotent shutdown), Critical Assumptions (new assumption 4), Risks and Mitigations, Failure Modes, Implementation Plan Phase 1 Step 1+2, Test Plan, Prerequisites Spike C.

## Recommendation-driven changes

### FastMCP lifespan as primary cleanup path

Research RQ2: FastMCP's `lifespan=` context manager is more robust than raw atexit + SIGTERM because anyio installs its own SIGTERM handler that cancels the running task group, and cancellation propagates through `async finally`. Updated the Technical Design's `main()` pseudocode to pass `lifespan=_t1_chroma_lifespan` to the FastMCP constructor and demote atexit + signal handler to belt-and-braces. `_t1_chroma_shutdown` remains idempotent so any combination of paths can fire it safely.

### Spike protocol expansion

- Was: 30-run probe (10 clean / 10 Claude SIGKILL / 10 OOM).
- Now: 40-run probe (adds 10 `kill -9 nx-mcp` for FM-NEW-1 mcp-pid watchdog trigger; targets explicitly cover the dual-watch claude-pid trigger and the lifespan-primary cleanup path). Plus Spike C: 30-minute idle-session probe for issue #40207 mid-session SIGTERM behaviour, with TCP-reuse follow-up if observed.

## Hygiene

- Em-dashes removed throughout: 40 -> 0 (Hal's no-em-dashes rule). Pre-existing em-dashes from the original draft + the agent's appendix swept.
- Failure Modes section now references PR #286 (mcp.log visibility) which made this research possible: the prior dispatch crashed `nx-mcp` silently with no on-disk trace. PR #286 wires the lifecycle logging future spike work will rely on.

## Status

`status: draft` unchanged. RDR is ready for re-gate via `/nx:rdr-gate 094` once the spike work runs.

## Test plan

- [x] `python` doc-structure check: 12 sections, all required headers present, 1034 lines, frontmatter intact.
- [x] `grep —` returns 0.
- [ ] CI green (docs-only change; no code surface affected).