### PR TITLE
feat(rdr-094): Phase 1+2 MCP-owned T1 chroma lifecycle (feature-flagged)

### DIFF
--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -92,13 +92,21 @@ def session_start(claude_session_id: str | None = None) -> str:
     inherited = os.environ.get("NX_SESSION_ID", "").strip() or None
     session_id = inherited or claude_session_id or generate_session_id()
 
-    # Honor NEXUS_SKIP_T1 — set by ``claude_dispatch`` (and any caller of
-    # ``claude -p`` where T1 inheritance is undesirable) so short-lived
-    # operator subprocesses don't pay the chroma startup cost or pollute
-    # session bookkeeping. The T1 client (``db/t1.py``) falls back to
-    # EphemeralClient when this env is set, so skipping the server start
-    # here yields the right "no T1" semantics automatically.
+    # Honor NEXUS_SKIP_T1, set by ``claude_dispatch`` (and any caller
+    # of ``claude -p`` where T1 inheritance is undesirable) so short-
+    # lived operator subprocesses don't pay the chroma startup cost
+    # or pollute session bookkeeping. The T1 client (``db/t1.py``)
+    # falls back to EphemeralClient when this env is set.
+    #
+    # Honor NEXUS_MCP_OWNS_T1 (RDR-094 Phase 1, feature-flagged opt-in)
+    # so chroma spawn moves to the nx-mcp lifespan. When set, the hook
+    # leaves chroma to the MCP server; the hook still runs the sweep
+    # and writes ``current_session`` so other tools (legacy CLI usage,
+    # subagent T1 inheritance) keep working.
     skip_t1 = os.environ.get("NEXUS_SKIP_T1", "").strip().lower() in ("1", "true", "yes")
+    mcp_owns_t1 = os.environ.get("NEXUS_MCP_OWNS_T1", "").strip().lower() in ("1", "true", "yes")
+    if mcp_owns_t1:
+        skip_t1 = True
 
     if not skip_t1:
         # Acquire an exclusive lock before the find+write sequence to prevent

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -37,7 +37,247 @@ from nexus.mcp_infra import (
 )
 from nexus.ttl import parse_ttl
 
-mcp = FastMCP("nexus")
+# ── T1 chroma lifecycle (RDR-094, feature-flagged) ──────────────────────────
+#
+# Phase 1 + Phase 2 of RDR-094 land here under the NEXUS_MCP_OWNS_T1 flag.
+# When set, this module:
+#   1. Spawns chroma in the FastMCP lifespan __aenter__ (primary cleanup
+#      via async finally in the lifespan exit). The hook's chroma-spawn
+#      block becomes a no-op (gated on the same env flag in hooks.py).
+#   2. Registers atexit + SIGTERM/SIGINT handlers as belt-and-braces for
+#      kill paths where lifespan does not fire (research RQ2).
+#   3. Spawns the watchdog with both --mcp-pid and --claude-pid so the
+#      Claude-crash-orphan failure mode (issue #1935, FM-NEW-1) is covered.
+#   4. TCP-probes any existing session record at startup; if reachable,
+#      reuses the existing chroma (FM-NEW-2 mitigation for the Claude Code
+#      issue #40207 mid-session SIGTERM-restart cycle).
+#
+# Default off. Existing installs see no behaviour change. Spike work flips
+# the flag to validate the design (RDR-094 §Critical Assumptions).
+
+import os as _os
+
+_MCP_OWNS_T1: bool = _os.environ.get(
+    "NEXUS_MCP_OWNS_T1", "",
+).strip().lower() in ("1", "true", "yes")
+
+#: Module-scope state for the owned chroma. Populated by
+#: ``_t1_chroma_init_if_owner`` and consumed by ``_t1_chroma_shutdown``.
+#: ``reused=True`` when the TCP-probe path detected a still-alive chroma
+#: from an earlier MCP server in the same session: that chroma is shared,
+#: and we must not stop it on our own shutdown.
+_OWNED_CHROMA: dict[str, Any] = {}
+
+
+def _tcp_probe_alive(host: str, port: int, timeout: float = 0.5) -> bool:
+    """Return True if a TCP connection to ``(host, port)`` succeeds.
+
+    Used by the FM-NEW-2 reuse path: at MCP startup, probe any existing
+    session record's chroma before spawning a new one. If the previous
+    MCP server's chroma is still listening (e.g. the prior server was
+    killed by issue #40207's mid-session SIGTERM but its chroma sidecar
+    survives because the lifespan finally was interrupted), connect to
+    it instead of starting a duplicate.
+    """
+    import socket
+
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (OSError, socket.timeout):
+        return False
+
+
+def _t1_chroma_init_if_owner() -> None:
+    """Spawn (or reuse) chroma for this MCP server's session.
+
+    Subagent detection: if ``NX_SESSION_ID`` is set AND an ancestor's
+    session record is reachable, this is a nested MCP server and we
+    skip spawn entirely (chroma is the parent's). Top-level MCP servers
+    fall through to the spawn-or-reuse path.
+
+    Reuse path (FM-NEW-2): probe any existing session record for the
+    same session_id; if the address is reachable, mark
+    ``_OWNED_CHROMA["reused"] = True`` and return. The shutdown path
+    skips cleanup of reused chroma.
+
+    Spawn path: starts a new chroma server, writes the session record
+    with both ``server_pid`` and ``claude_root_pid``, and spawns the
+    watchdog in dual-watch mode (--mcp-pid + --claude-pid).
+    """
+    if _OWNED_CHROMA:
+        return  # idempotent: lifespan + atexit may both call this
+    from pathlib import Path
+
+    from nexus.db.t1 import SESSIONS_DIR
+    from nexus.session import (
+        find_claude_root_pid,
+        find_session_by_id,
+        spawn_t1_watchdog,
+        start_t1_server,
+        write_session_record_by_id,
+    )
+
+    # Subagent: a nested MCP server (claude_dispatch sets NX_SESSION_ID
+    # on the child env) inherits the parent's chroma via PPID walk. The
+    # T1 client handles the lookup; we just must not spawn a sibling.
+    inherited = _os.environ.get("NX_SESSION_ID", "").strip()
+    if inherited:
+        ancestor = find_session_by_id(SESSIONS_DIR, inherited)
+        if ancestor and _tcp_probe_alive(
+            ancestor.get("server_host", ""), int(ancestor.get("server_port", 0)),
+        ):
+            _OWNED_CHROMA["nested"] = True
+            return
+
+    own_id = inherited or _resolve_top_level_session_id()
+    if not own_id:
+        # No session id resolvable: skip; T1 falls back to EphemeralClient.
+        return
+
+    # FM-NEW-2: TCP-probe an existing record before spawning. If the
+    # prior chroma is still listening, reuse it.
+    existing = find_session_by_id(SESSIONS_DIR, own_id)
+    if existing and _tcp_probe_alive(
+        existing.get("server_host", ""), int(existing.get("server_port", 0)),
+    ):
+        _OWNED_CHROMA["reused"] = True
+        _OWNED_CHROMA["session_id"] = own_id
+        return
+
+    # Spawn fresh chroma + dual-watch watchdog.
+    try:
+        host, port, server_pid, tmpdir = start_t1_server()
+    except Exception as exc:
+        import structlog
+
+        structlog.get_logger().warning(
+            "t1_chroma_spawn_failed",
+            error=str(exc),
+            session_id=own_id,
+        )
+        return
+
+    claude_root_pid = find_claude_root_pid()
+    session_file = SESSIONS_DIR / f"{own_id}.session"
+    watchdog_pid = spawn_t1_watchdog(
+        claude_pid=claude_root_pid or 0,
+        chroma_pid=server_pid,
+        session_file=session_file,
+        tmpdir=tmpdir,
+        mcp_pid=_os.getpid(),  # FM-NEW-1: dual-watch
+    ) if claude_root_pid else 0
+
+    write_session_record_by_id(
+        SESSIONS_DIR, own_id, host, port, server_pid, tmpdir,
+        claude_root_pid=claude_root_pid,
+        watchdog_pid=watchdog_pid,
+    )
+    _OWNED_CHROMA.update({
+        "session_id": own_id,
+        "server_pid": server_pid,
+        "tmpdir": str(tmpdir),
+        "session_file": str(session_file),
+    })
+
+
+def _resolve_top_level_session_id() -> str | None:
+    """Return the conversation UUID from current_session, or None.
+
+    The SessionStart hook writes the UUID via ``write_claude_session_id``
+    before any MCP tool call. Reading it here lets the lifespan match the
+    record key the hook (or a previous MCP run) wrote.
+    """
+    try:
+        from nexus.session import read_claude_session_id
+
+        sid = read_claude_session_id()
+        return sid if sid else None
+    except Exception:
+        return None
+
+
+def _t1_chroma_shutdown() -> None:
+    """Stop chroma + remove the session record. Idempotent.
+
+    Called from the lifespan finally (primary), atexit (secondary), and
+    SIGTERM/SIGINT handlers (also secondary). The first to fire performs
+    the cleanup; the rest are no-ops because ``_OWNED_CHROMA`` is cleared
+    on completion.
+    """
+    if not _OWNED_CHROMA:
+        return
+    if _OWNED_CHROMA.get("nested") or _OWNED_CHROMA.get("reused"):
+        # Nested: parent owns chroma. Reused: another MCP server in the
+        # same session owns it. We must not stop it on our exit.
+        _OWNED_CHROMA.clear()
+        return
+
+    from pathlib import Path
+    import shutil
+
+    from nexus.session import stop_t1_server
+
+    server_pid = _OWNED_CHROMA.get("server_pid")
+    tmpdir = _OWNED_CHROMA.get("tmpdir")
+    session_file = _OWNED_CHROMA.get("session_file")
+
+    try:
+        if server_pid:
+            stop_t1_server(int(server_pid))
+    except Exception:
+        pass
+    if tmpdir:
+        try:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        except OSError:
+            pass
+    if session_file:
+        try:
+            Path(session_file).unlink(missing_ok=True)
+        except OSError:
+            pass
+    _OWNED_CHROMA.clear()
+
+
+def _sigterm_handler(_signo: int, _frame: Any) -> None:
+    """Run the shutdown path then exit cleanly.
+
+    Belt-and-braces for the cancellation paths where the FastMCP
+    lifespan does not fire. ``sys.exit(0)`` lets atexit handlers run,
+    so the second-pass _t1_chroma_shutdown call is a no-op.
+    """
+    import sys as _sys
+
+    _t1_chroma_shutdown()
+    _sys.exit(0)
+
+
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def _t1_chroma_lifespan(_app: Any):
+    """FastMCP lifespan that owns chroma's lifecycle.
+
+    Primary cleanup path (research RQ2): anyio installs a SIGTERM
+    handler that cancels the running task group; cancellation
+    propagates through this ``async finally`` block so
+    ``_t1_chroma_shutdown`` runs without a manual SIGTERM handler.
+    The atexit + signal handlers in ``main()`` are the secondary
+    path for kills where lifespan doesn't fire.
+    """
+    _t1_chroma_init_if_owner()
+    try:
+        yield
+    finally:
+        _t1_chroma_shutdown()
+
+
+mcp = FastMCP(
+    "nexus",
+    lifespan=_t1_chroma_lifespan if _MCP_OWNS_T1 else None,
+)
 
 _DEFAULT_PAGE_SIZE = 10
 
@@ -3151,7 +3391,9 @@ def main():
     captured stderr (which is not surfaced through any user-visible
     path).
     """
+    import atexit
     import os
+    import signal
 
     import structlog
 
@@ -3166,7 +3408,17 @@ def main():
         transport="stdio",
         pid=os.getpid(),
         ppid=os.getppid(),
+        mcp_owns_t1=_MCP_OWNS_T1,
     )
+    if _MCP_OWNS_T1:
+        # Belt-and-braces for the kill paths where the FastMCP lifespan
+        # finally does not fire. The lifespan is the primary cleanup path
+        # (anyio cancellation through ``async finally``); these handlers
+        # cover SIGTERM-without-cancellation and the abrupt-exit case.
+        # _t1_chroma_shutdown is idempotent so double-firing is safe.
+        atexit.register(_t1_chroma_shutdown)
+        signal.signal(signal.SIGTERM, _sigterm_handler)
+        signal.signal(signal.SIGINT, _sigterm_handler)
     try:
         check_version_compatibility()
         mcp.run(transport="stdio")

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -597,6 +597,7 @@ def spawn_t1_watchdog(
     chroma_pid: int,
     session_file: Path,
     tmpdir: str,
+    mcp_pid: int = 0,
 ) -> int:
     """Launch the T1 watchdog sidecar as a detached process.
 
@@ -606,20 +607,30 @@ def spawn_t1_watchdog(
     chroma server when Claude Code dies. See ``t1_watchdog.py`` for
     the polling loop.
 
+    When ``mcp_pid`` is non-zero, the watchdog is launched in
+    dual-watch mode (RDR-094 FM-NEW-1): it fires on EITHER mcp_pid
+    death (clean chroma directly because the MCP server's lifespan
+    did not run) OR claude_pid death (orphaned MCP, signal SIGTERM
+    to mcp_pid then clean chroma). Default 0 preserves the single-
+    watch claude-only mode for hook-spawned watchdogs.
+
     Failure is non-fatal: returns 0 and logs a warning. Layer 3
     (SessionStart orphan reaper) + the legacy age-based sweep cover
     the case where the watchdog couldn't start.
     """
     import sys as _sys
+    cmd: list[str] = [
+        _sys.executable, "-m", "nexus.t1_watchdog",
+        "--claude-pid", str(claude_pid),
+        "--chroma-pid", str(chroma_pid),
+        "--session-file", str(session_file),
+        "--tmpdir", tmpdir,
+    ]
+    if mcp_pid > 0:
+        cmd.extend(["--mcp-pid", str(mcp_pid)])
     try:
         proc = subprocess.Popen(
-            [
-                _sys.executable, "-m", "nexus.t1_watchdog",
-                "--claude-pid", str(claude_pid),
-                "--chroma-pid", str(chroma_pid),
-                "--session-file", str(session_file),
-                "--tmpdir", tmpdir,
-            ],
+            cmd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             start_new_session=True,

--- a/src/nexus/t1_watchdog.py
+++ b/src/nexus/t1_watchdog.py
@@ -84,14 +84,56 @@ def _cleanup(
             pass
 
 
+#: Grace period for the MCP server's lifespan finally / atexit to
+#: clean chroma after we send SIGTERM on Claude crash. Long enough
+#: for anyio cancellation to propagate through the async context
+#: manager but short enough that the watchdog reaps quickly if the
+#: MCP server is wedged.
+MCP_GRACE_SECS: float = 2.0
+
+
+def _signal_then_kill(pid: int) -> None:
+    """SIGTERM the pid, wait MCP_GRACE_SECS, SIGKILL if still alive.
+
+    Used on Claude-crash trigger to give the orphaned MCP server a
+    chance to run its lifespan finally block before we fall through
+    to the chroma-pgrp belt-and-braces cleanup.
+    """
+    import signal
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        return
+    time.sleep(MCP_GRACE_SECS)
+    if _is_alive(pid):
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="T1 ChromaDB server watchdog (nexus-99jb).",
+        description="T1 ChromaDB server watchdog (nexus-99jb / RDR-094).",
     )
     parser.add_argument("--claude-pid", type=int, required=True,
                         help="Root Claude Code PID to watch.")
     parser.add_argument("--chroma-pid", type=int, required=True,
                         help="PID of the chroma server to supervise.")
+    parser.add_argument(
+        "--mcp-pid", type=int, default=0,
+        help=(
+            "Optional MCP server PID for dual-watch mode (RDR-094 "
+            "FM-NEW-1). When set, OR-trigger logic fires: mcp_pid "
+            "death cleans chroma directly (lifespan/atexit did not "
+            "run); claude_pid death sends SIGTERM to mcp_pid (giving "
+            "lifespan finally a chance to run), waits MCP_GRACE_SECS, "
+            "then SIGKILLs and cleans chroma. When 0 (default), "
+            "single-watch claude-only mode is preserved for backwards "
+            "compat with the hook-spawned watchdog."
+        ),
+    )
     parser.add_argument("--session-file", default="",
                         help="Session record file to remove on cleanup.")
     parser.add_argument("--tmpdir", default="",
@@ -100,16 +142,29 @@ def main(argv: list[str] | None = None) -> int:
 
     session_file = Path(args.session_file) if args.session_file else None
     tmpdir = Path(args.tmpdir) if args.tmpdir else None
+    dual_watch = args.mcp_pid > 0
 
     while True:
         time.sleep(POLL_INTERVAL)
-        # Chroma crashed or was stopped by SessionEnd — nothing to
-        # watch anymore. Exit silently; the SessionEnd path owns the
-        # on-disk cleanup when it was responsible for the stop.
+        # Chroma crashed or was stopped by some other path (lifespan,
+        # atexit, SessionEnd in legacy mode) -- nothing to watch
+        # anymore. Exit silently; whoever stopped chroma owns the
+        # on-disk cleanup.
         if not _is_alive(args.chroma_pid):
             return 0
-        # Claude Code is gone. Trigger graceful shutdown.
+        # Dual-watch mode (RDR-094 FM-NEW-1): MCP server died without
+        # its lifespan/atexit firing (SIGKILL, segfault). Clean chroma
+        # directly via the chroma-pgrp belt-and-braces path.
+        if dual_watch and not _is_alive(args.mcp_pid):
+            break
+        # Claude Code is gone.
         if not _is_alive(args.claude_pid):
+            # Dual-watch + Claude crash: signal mcp_pid first so its
+            # lifespan finally runs (cleans chroma cleanly), then fall
+            # through to the chroma-pgrp belt-and-braces in case the
+            # MCP server's finally is wedged or already ran.
+            if dual_watch and _is_alive(args.mcp_pid):
+                _signal_then_kill(args.mcp_pid)
             break
 
     _cleanup(

--- a/tests/test_mcp_chroma_lifecycle.py
+++ b/tests/test_mcp_chroma_lifecycle.py
@@ -1,0 +1,333 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for the MCP-owned T1 chroma lifecycle (RDR-094 Phase 1+2).
+
+Covers the feature-flagged path under ``NEXUS_MCP_OWNS_T1=1``:
+
+  * ``_t1_chroma_init_if_owner`` spawn / reuse / nested-skip branches.
+  * ``_t1_chroma_shutdown`` idempotency + skip-on-reuse / skip-on-nested.
+  * ``_tcp_probe_alive`` happy path + connection-refused path.
+  * The lifespan async context manager wires init + shutdown.
+
+All tests mock the subprocess + filesystem boundaries so the suite runs
+fast and deterministically. Live-I/O coverage lands in the RDR-094
+spike harness.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@contextmanager
+def _clean_owned_chroma():
+    """Reset _OWNED_CHROMA before and after each test so module-scope
+    state from one test does not leak into the next."""
+    from nexus.mcp import core as core_mod
+
+    saved = dict(core_mod._OWNED_CHROMA)
+    core_mod._OWNED_CHROMA.clear()
+    try:
+        yield
+    finally:
+        core_mod._OWNED_CHROMA.clear()
+        core_mod._OWNED_CHROMA.update(saved)
+
+
+# ── _tcp_probe_alive ────────────────────────────────────────────────────────
+
+
+class TestTcpProbeAlive:
+
+    def test_returns_true_when_connect_succeeds(self):
+        from nexus.mcp.core import _tcp_probe_alive
+
+        # Bind a real ephemeral socket so the probe has something to
+        # connect to. Port 0 lets the OS pick a free port.
+        import socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        host, port = sock.getsockname()
+        try:
+            assert _tcp_probe_alive(host, port, timeout=1.0) is True
+        finally:
+            sock.close()
+
+    def test_returns_false_on_connection_refused(self):
+        from nexus.mcp.core import _tcp_probe_alive
+
+        # 127.0.0.1:1 is reserved as the well-known unused port; nothing
+        # should ever listen there. ``timeout`` keeps the test fast.
+        assert _tcp_probe_alive("127.0.0.1", 1, timeout=0.2) is False
+
+
+# ── _t1_chroma_init_if_owner ────────────────────────────────────────────────
+
+
+class TestInitIfOwner:
+
+    def test_idempotent_when_already_owned(self, monkeypatch):
+        """Second call is a no-op so lifespan + atexit both calling
+        the init path is safe."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            core_mod._OWNED_CHROMA["session_id"] = "X"
+            with patch("nexus.session.start_t1_server") as mock_start:
+                core_mod._t1_chroma_init_if_owner()
+            mock_start.assert_not_called()
+
+    def test_nested_skip_when_ancestor_session_reachable(self, monkeypatch):
+        """When NX_SESSION_ID is set AND an ancestor record's chroma is
+        TCP-reachable, the nested MCP server skips spawn entirely."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            monkeypatch.setenv("NX_SESSION_ID", "abc-123")
+            ancestor_record = {
+                "server_host": "127.0.0.1", "server_port": 12345,
+            }
+            with patch(
+                "nexus.session.find_session_by_id", return_value=ancestor_record,
+            ), patch.object(
+                core_mod, "_tcp_probe_alive", return_value=True,
+            ), patch("nexus.session.start_t1_server") as mock_start:
+                core_mod._t1_chroma_init_if_owner()
+
+            assert core_mod._OWNED_CHROMA.get("nested") is True
+            mock_start.assert_not_called()
+
+    def test_reuse_path_when_existing_record_reachable(self, monkeypatch):
+        """FM-NEW-2: existing record for own session_id is reachable,
+        so reuse instead of spawning. _OWNED_CHROMA is marked reused
+        so the shutdown path skips cleanup."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            monkeypatch.delenv("NX_SESSION_ID", raising=False)
+            existing = {"server_host": "127.0.0.1", "server_port": 22222}
+            with patch.object(
+                core_mod, "_resolve_top_level_session_id", return_value="own-id",
+            ), patch(
+                "nexus.session.find_session_by_id", return_value=existing,
+            ), patch.object(
+                core_mod, "_tcp_probe_alive", return_value=True,
+            ), patch("nexus.session.start_t1_server") as mock_start:
+                core_mod._t1_chroma_init_if_owner()
+
+            assert core_mod._OWNED_CHROMA.get("reused") is True
+            assert core_mod._OWNED_CHROMA.get("session_id") == "own-id"
+            mock_start.assert_not_called()
+
+    def test_spawn_path_writes_record_with_dual_watch_watchdog(
+        self, monkeypatch, tmp_path,
+    ):
+        """Fresh session: spawn chroma, write record, spawn watchdog
+        with mcp_pid passed (RDR-094 FM-NEW-1 dual-watch)."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            monkeypatch.delenv("NX_SESSION_ID", raising=False)
+            spawn_calls: dict = {}
+
+            def _fake_spawn_watchdog(**kwargs):
+                spawn_calls.update(kwargs)
+                return 7777
+
+            with patch.object(
+                core_mod, "_resolve_top_level_session_id",
+                return_value="fresh-id",
+            ), patch(
+                "nexus.session.find_session_by_id", return_value=None,
+            ), patch(
+                "nexus.session.start_t1_server",
+                return_value=("127.0.0.1", 33333, 4444, str(tmp_path / "td")),
+            ), patch(
+                "nexus.session.find_claude_root_pid", return_value=8888,
+            ), patch(
+                "nexus.session.spawn_t1_watchdog",
+                side_effect=_fake_spawn_watchdog,
+            ), patch(
+                "nexus.session.write_session_record_by_id",
+            ) as mock_write:
+                core_mod._t1_chroma_init_if_owner()
+
+            assert core_mod._OWNED_CHROMA["session_id"] == "fresh-id"
+            assert core_mod._OWNED_CHROMA["server_pid"] == 4444
+            # FM-NEW-1: watchdog gets BOTH claude_pid and mcp_pid.
+            assert spawn_calls.get("claude_pid") == 8888
+            assert spawn_calls.get("chroma_pid") == 4444
+            assert spawn_calls.get("mcp_pid") > 0  # this process's pid
+            mock_write.assert_called_once()
+
+    def test_spawn_failure_logs_warning_and_returns(self, monkeypatch):
+        """If start_t1_server raises, the init path logs and returns
+        without populating _OWNED_CHROMA. T1 falls back to ephemeral."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            monkeypatch.delenv("NX_SESSION_ID", raising=False)
+            with patch.object(
+                core_mod, "_resolve_top_level_session_id",
+                return_value="x",
+            ), patch(
+                "nexus.session.find_session_by_id", return_value=None,
+            ), patch(
+                "nexus.session.start_t1_server",
+                side_effect=RuntimeError("port-in-use"),
+            ):
+                core_mod._t1_chroma_init_if_owner()
+
+            assert core_mod._OWNED_CHROMA == {}
+
+
+# ── _t1_chroma_shutdown ─────────────────────────────────────────────────────
+
+
+class TestShutdown:
+
+    def test_no_op_when_not_owned(self):
+        """No state, nothing to clean. Idempotent under double-fire
+        from the lifespan finally + atexit + signal handler."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            with patch("nexus.session.stop_t1_server") as mock_stop:
+                core_mod._t1_chroma_shutdown()
+            mock_stop.assert_not_called()
+
+    def test_skip_on_nested(self):
+        """Nested MCP server: the parent owns chroma; shutdown must
+        not stop it."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            core_mod._OWNED_CHROMA["nested"] = True
+            with patch("nexus.session.stop_t1_server") as mock_stop:
+                core_mod._t1_chroma_shutdown()
+            mock_stop.assert_not_called()
+            assert core_mod._OWNED_CHROMA == {}
+
+    def test_skip_on_reused(self):
+        """FM-NEW-2 reuse: another MCP server in the same session
+        owns chroma; shutdown must not stop it."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            core_mod._OWNED_CHROMA.update({
+                "reused": True, "session_id": "x",
+            })
+            with patch("nexus.session.stop_t1_server") as mock_stop:
+                core_mod._t1_chroma_shutdown()
+            mock_stop.assert_not_called()
+            assert core_mod._OWNED_CHROMA == {}
+
+    def test_full_cleanup_when_owned(self, tmp_path):
+        """Owned chroma: stop_t1_server is called, tmpdir is removed,
+        session file is unlinked, state is cleared."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            tmpdir = tmp_path / "td"
+            tmpdir.mkdir()
+            (tmpdir / "chroma.sqlite3").write_bytes(b"x")
+            session_file = tmp_path / "s.session"
+            session_file.write_text("{}")
+
+            core_mod._OWNED_CHROMA.update({
+                "session_id": "y",
+                "server_pid": 12345,
+                "tmpdir": str(tmpdir),
+                "session_file": str(session_file),
+            })
+            with patch("nexus.session.stop_t1_server") as mock_stop:
+                core_mod._t1_chroma_shutdown()
+
+            mock_stop.assert_called_once_with(12345)
+            assert not tmpdir.exists()
+            assert not session_file.exists()
+            assert core_mod._OWNED_CHROMA == {}
+
+    def test_idempotent_under_double_fire(self, tmp_path):
+        """Lifespan finally + atexit + signal handler may all call
+        shutdown. The first to fire performs the work; the rest are
+        no-ops because _OWNED_CHROMA is cleared."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            session_file = tmp_path / "s.session"
+            session_file.write_text("{}")
+            core_mod._OWNED_CHROMA.update({
+                "session_id": "y",
+                "server_pid": 12345,
+                "tmpdir": str(tmp_path / "td_unused"),
+                "session_file": str(session_file),
+            })
+            with patch("nexus.session.stop_t1_server") as mock_stop:
+                core_mod._t1_chroma_shutdown()
+                core_mod._t1_chroma_shutdown()
+                core_mod._t1_chroma_shutdown()
+            assert mock_stop.call_count == 1
+
+
+# ── _t1_chroma_lifespan async cm ────────────────────────────────────────────
+
+
+class TestLifespan:
+    """The lifespan context manager is the FastMCP entry point. Verify
+    init runs on enter and shutdown runs on exit, with shutdown also
+    firing if the body raises (so anyio cancellation propagation
+    cleans up correctly)."""
+
+    @pytest.mark.asyncio
+    async def test_lifespan_runs_init_then_shutdown(self):
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            with patch.object(
+                core_mod, "_t1_chroma_init_if_owner",
+            ) as mock_init, patch.object(
+                core_mod, "_t1_chroma_shutdown",
+            ) as mock_shutdown:
+                async with core_mod._t1_chroma_lifespan(MagicMock()):
+                    mock_init.assert_called_once()
+                    mock_shutdown.assert_not_called()
+                mock_shutdown.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_lifespan_runs_shutdown_on_exception(self):
+        """anyio cancellation through the body must still trigger the
+        finally block. Simulate by raising inside the async body."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            with patch.object(
+                core_mod, "_t1_chroma_init_if_owner",
+            ), patch.object(
+                core_mod, "_t1_chroma_shutdown",
+            ) as mock_shutdown:
+                with pytest.raises(RuntimeError, match="cancellation"):
+                    async with core_mod._t1_chroma_lifespan(MagicMock()):
+                        raise RuntimeError("cancellation")
+                mock_shutdown.assert_called_once()
+
+
+# ── Feature flag wiring ─────────────────────────────────────────────────────
+
+
+class TestFeatureFlag:
+
+    def test_lifespan_only_attached_when_flag_set(self):
+        """The lifespan kwarg passed to FastMCP() at module import depends
+        on the env var. Verify the helper variable matches reality. (The
+        env var is read once at module import, so this test is asserting
+        the read happened correctly under the active env.)"""
+        import os
+
+        from nexus.mcp import core as core_mod
+
+        flag = os.environ.get("NEXUS_MCP_OWNS_T1", "").strip().lower()
+        expected = flag in ("1", "true", "yes")
+        assert core_mod._MCP_OWNS_T1 is expected

--- a/tests/test_t1_watchdog.py
+++ b/tests/test_t1_watchdog.py
@@ -137,3 +137,154 @@ class TestMain:
         kwargs = mock_cleanup.call_args.kwargs
         assert kwargs["chroma_pid"] == 200
         assert str(kwargs["session_file"]).endswith("s.session")
+
+
+# ── Dual-watch (RDR-094 FM-NEW-1) ───────────────────────────────────────────
+
+
+class TestDualWatch:
+    """RDR-094 FM-NEW-1: when --mcp-pid is set, the watchdog OR-triggers
+    on either MCP server death (clean chroma directly) or Claude Code
+    death (signal SIGTERM to mcp_pid then clean chroma)."""
+
+    def test_mcp_pid_death_triggers_cleanup_directly(self, monkeypatch, tmp_path):
+        """Dual-watch: chroma alive + claude alive + mcp dead → cleanup
+        fires immediately (lifespan/atexit did not run on the dead MCP
+        server, so the watchdog cleans chroma)."""
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+
+        def _fake_alive(pid: int) -> bool:
+            if pid == 200:  # chroma
+                return True
+            if pid == 100:  # claude
+                return True
+            if pid == 300:  # mcp_pid
+                return False
+            return False
+
+        monkeypatch.setattr(t1_watchdog, "_is_alive", _fake_alive)
+
+        with patch.object(t1_watchdog, "_cleanup") as mock_cleanup, \
+             patch.object(t1_watchdog, "_signal_then_kill") as mock_signal:
+            rc = t1_watchdog.main([
+                "--claude-pid", "100",
+                "--chroma-pid", "200",
+                "--mcp-pid", "300",
+                "--session-file", str(tmp_path / "s.session"),
+                "--tmpdir", str(tmp_path / "tmpdir"),
+            ])
+
+        assert rc == 0
+        mock_cleanup.assert_called_once()
+        # MCP death path does NOT signal mcp_pid (it's already dead).
+        mock_signal.assert_not_called()
+
+    def test_claude_pid_death_signals_mcp_then_cleans(self, monkeypatch, tmp_path):
+        """Dual-watch: chroma alive + mcp alive + claude dead → SIGTERM
+        the orphaned MCP server (giving its lifespan finally a chance to
+        run), then fall through to cleanup as belt-and-braces."""
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+
+        def _fake_alive(pid: int) -> bool:
+            if pid == 200:  # chroma alive
+                return True
+            if pid == 100:  # claude DEAD
+                return False
+            if pid == 300:  # mcp alive
+                return True
+            return False
+
+        monkeypatch.setattr(t1_watchdog, "_is_alive", _fake_alive)
+
+        with patch.object(t1_watchdog, "_cleanup") as mock_cleanup, \
+             patch.object(t1_watchdog, "_signal_then_kill") as mock_signal:
+            rc = t1_watchdog.main([
+                "--claude-pid", "100",
+                "--chroma-pid", "200",
+                "--mcp-pid", "300",
+                "--session-file", str(tmp_path / "s.session"),
+                "--tmpdir", str(tmp_path / "tmpdir"),
+            ])
+
+        assert rc == 0
+        mock_signal.assert_called_once_with(300)
+        mock_cleanup.assert_called_once()
+
+    def test_single_watch_mode_unchanged_when_no_mcp_pid(self, monkeypatch, tmp_path):
+        """Backwards compat: omitting --mcp-pid preserves the old
+        single-watch claude-only behaviour for hook-spawned watchdogs."""
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+
+        def _fake_alive(pid: int) -> bool:
+            return pid == 200  # only chroma alive
+
+        monkeypatch.setattr(t1_watchdog, "_is_alive", _fake_alive)
+
+        with patch.object(t1_watchdog, "_cleanup") as mock_cleanup, \
+             patch.object(t1_watchdog, "_signal_then_kill") as mock_signal:
+            rc = t1_watchdog.main([
+                "--claude-pid", "100",
+                "--chroma-pid", "200",
+                "--session-file", str(tmp_path / "s.session"),
+                "--tmpdir", str(tmp_path / "tmpdir"),
+            ])
+
+        assert rc == 0
+        mock_cleanup.assert_called_once()
+        mock_signal.assert_not_called()
+
+    def test_signal_then_kill_sigterm_first(self, monkeypatch):
+        """_signal_then_kill sends SIGTERM, sleeps grace, SIGKILL
+        only if still alive afterwards."""
+        import signal as _signal
+
+        from nexus import t1_watchdog
+
+        sleeps: list[float] = []
+        kills: list[tuple[int, int]] = []
+
+        def _fake_kill(pid: int, sig: int) -> None:
+            kills.append((pid, sig))
+            if sig == 0:  # liveness check inside _is_alive
+                return
+
+        def _fake_sleep(s: float) -> None:
+            sleeps.append(s)
+
+        monkeypatch.setattr(t1_watchdog.os, "kill", _fake_kill)
+        monkeypatch.setattr(t1_watchdog.time, "sleep", _fake_sleep)
+        monkeypatch.setattr(t1_watchdog, "_is_alive", lambda pid: False)
+
+        t1_watchdog._signal_then_kill(300)
+
+        assert kills[0] == (300, _signal.SIGTERM)
+        assert sleeps == [t1_watchdog.MCP_GRACE_SECS]
+        # Process is dead by the time we re-check, so no SIGKILL.
+        assert _signal.SIGKILL not in {s for _, s in kills}
+
+    def test_signal_then_kill_falls_through_to_sigkill(self, monkeypatch):
+        """If process is still alive after grace, SIGKILL fires."""
+        import signal as _signal
+
+        from nexus import t1_watchdog
+
+        kills: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            t1_watchdog.os, "kill",
+            lambda pid, sig: kills.append((pid, sig)),
+        )
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(t1_watchdog, "_is_alive", lambda pid: True)
+
+        t1_watchdog._signal_then_kill(300)
+
+        # Both SIGTERM and SIGKILL should have been sent.
+        sigs = {s for _, s in kills}
+        assert _signal.SIGTERM in sigs
+        assert _signal.SIGKILL in sigs


### PR DESCRIPTION
## Summary

Implements the design in RDR-094 §Implementation Plan Phase 1+2 under the `NEXUS_MCP_OWNS_T1` feature flag. **Default off**, so existing installs see zero behaviour change. Spike work flips the flag to validate Critical Assumptions 1, 3, and 4 against live Claude Code subprocess shutdown semantics.

## What this lands

Four design points the research surfaced in PR #288:

1. **FastMCP `lifespan=` as primary cleanup path** (anyio cancellation propagation through `async finally`), with `atexit` + `SIGTERM` / `SIGINT` handlers as belt-and-braces.
2. **TCP-probe-and-reuse** in `_t1_chroma_init_if_owner` before spawning fresh chroma. FM-NEW-2 mitigation for issue #40207's mid-session SIGTERM-restart cycle.
3. **Watchdog dual-watch**: `--mcp-pid` + `--claude-pid` with OR-trigger logic. FM-NEW-1 mitigation for issue #1935's orphaned-MCP-on-Claude-crash.
4. **Idempotent shutdown** so lifespan + atexit + signal handler can all call `_t1_chroma_shutdown` safely; first-fires-wins.

## Files

- `src/nexus/mcp/core.py`: `_MCP_OWNS_T1` flag, `_OWNED_CHROMA` state dict, `_tcp_probe_alive`, `_t1_chroma_init_if_owner` (subagent-skip / reuse / spawn branches), `_t1_chroma_shutdown` (idempotent, skip on nested/reused), `_t1_chroma_lifespan` async cm. `main()` registers atexit + signal handlers when the flag is set; `mcp_server_starting` log event includes `mcp_owns_t1` so the active mode is visible in `mcp.log`.
- `src/nexus/t1_watchdog.py`: optional `--mcp-pid` argument (default 0 preserves single-watch backwards compat). New `_signal_then_kill` helper. Polling loop OR-trigger in dual-watch mode.
- `src/nexus/session.py`: `spawn_t1_watchdog(... mcp_pid=0)` kwarg added.
- `src/nexus/hooks.py`: `session_start` gates the chroma-spawn block on `NEXUS_MCP_OWNS_T1`. Sweep + `current_session` write + "Nexus ready" message all unchanged.

## Tests

- `tests/test_t1_watchdog.py` extended with `TestDualWatch` (5 tests).
- `tests/test_mcp_chroma_lifecycle.py` new (15 tests across 5 classes covering tcp_probe, init, shutdown, lifespan, feature flag).

All tests mock subprocess + filesystem boundaries so the suite is fast and deterministic. Live-I/O coverage lands in the RDR-094 spike harness.

## Regression

```
uv run pytest tests/test_logging_setup.py tests/test_mcp_package.py \
    tests/test_mcp_chroma_lifecycle.py tests/test_t1_watchdog.py \
    tests/test_session.py tests/test_hooks.py \
    tests/test_operator_dispatch.py tests/test_plan_run.py \
    tests/test_voyage_retry.py tests/test_silent_error_logging.py \
    tests/test_structlog_events.py tests/test_nx_answer.py

369 passed, 1 skipped in 35.31s
```

## How to exercise locally

```
NEXUS_MCP_OWNS_T1=1 nx-mcp
```

Or in a Claude Code session: `export NEXUS_MCP_OWNS_T1=1` before starting `claude`. Then check `~/.config/nexus/logs/mcp.log` for the lifecycle events. The `mcp_owns_t1=true` field on `mcp_server_starting` confirms the new path is active.

## Status

RDR-094 stays `status: draft`. Acceptance still pending the spike work; this PR lands the code the spike will run against.

## Test plan

- [x] Local: 369 pass on the affected surface.
- [ ] CI green on this PR (default-off path is exercised; flag-on path covered by mock-only unit tests).
- [ ] Spike harness uses this PR's flag-on path to gather Critical Assumption evidence (deferred to spike work).