### PR TITLE
feat(rdr-094): Phase 3 orphan tmpdir sweep + auto-fire from session_start

### DIFF
--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -79,6 +79,16 @@ def session_start(claude_session_id: str | None = None) -> str:
     # handles the migration: legacy numeric-stem session files written by
     # the old PID-keyed scheme are reaped unconditionally here.
     sweep_stale_sessions(SESSIONS_DIR)
+    # RDR-094 Phase 3: sweep orphan nx_t1_* tmpdirs that have no live
+    # session record and are older than 24h. The 24h cutoff protects
+    # in-flight tmpdirs (mkdtemp -> write_session_record_by_id has a
+    # small window; legitimate tmpdirs from active sessions never reach
+    # the cutoff because their record reaches the filter first).
+    try:
+        from nexus.session import sweep_orphan_tmpdirs
+        sweep_orphan_tmpdirs(SESSIONS_DIR)
+    except Exception as exc:
+        _log.debug("sweep_orphan_tmpdirs_failed", error=str(exc))
 
     # Resolve session_id with this precedence:
     #   1. ``NX_SESSION_ID`` env  — we're a nested subprocess our parent

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -4,6 +4,7 @@ import os
 import signal
 import socket
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -309,6 +310,86 @@ def sweep_stale_sessions(
                 )
         except (json.JSONDecodeError, OSError) as exc:
             _log.debug("sweep_corrupt_session_file", path=str(f), error=str(exc))
+
+
+def sweep_orphan_tmpdirs(
+    sessions_dir: Path | None = None,
+    tmpdir_root: Path | None = None,
+    max_age_hours: float = 24.0,
+) -> int:
+    """RDR-094 Phase 3: reap orphan ``nx_t1_*`` tmpdirs.
+
+    Scans *tmpdir_root* (defaults to the system tempdir) for
+    directories matching ``nx_t1_*`` (the prefix used by
+    :func:`start_t1_server`). For each:
+
+    * If a session record in *sessions_dir* points at the tmpdir,
+      skip (live; some other code path owns this tmpdir's lifecycle).
+    * If the tmpdir's mtime is younger than *max_age_hours*, skip
+      (might be in active spawn between :func:`tempfile.mkdtemp` and
+      the session-record write, or actively used by an MCP server
+      that hasn't written its record yet).
+    * Otherwise, ``rmtree`` with ``ignore_errors``.
+
+    Returns the count of directories reaped. Closes RDR-094 Gap 3:
+    tmpdirs whose session record was deleted but whose chroma
+    server crashed before the cleanup path completed had no other
+    reap trigger; the existing ``sweep_stale_sessions`` operates on
+    records, not on the filesystem itself.
+
+    Cheap on every-startup invocation: glob + stat per directory,
+    no I/O beyond rmtree on confirmed orphans. The 24h cutoff
+    prevents accidental reap of legitimate in-flight tmpdirs.
+    """
+    import shutil
+
+    if sessions_dir is None:
+        sessions_dir = SESSIONS_DIR
+    if tmpdir_root is None:
+        tmpdir_root = Path(tempfile.gettempdir())
+    if not tmpdir_root.exists():
+        return 0
+
+    # Collect every tmpdir path referenced by a current session record
+    # so we never reap a directory another component still owns.
+    referenced: set[str] = set()
+    if sessions_dir.exists():
+        for f in sessions_dir.glob("*.session"):
+            try:
+                rec = json.loads(f.read_text())
+                if isinstance(rec, dict):
+                    td = rec.get("tmpdir", "")
+                    if td:
+                        referenced.add(str(Path(td).resolve()))
+            except (json.JSONDecodeError, OSError):
+                continue
+
+    cutoff = time.time() - max_age_hours * 3600.0
+    reaped = 0
+    for d in tmpdir_root.glob("nx_t1_*"):
+        if not d.is_dir():
+            continue
+        try:
+            resolved = str(d.resolve())
+        except OSError:
+            continue
+        if resolved in referenced:
+            continue
+        try:
+            mtime = d.stat().st_mtime
+        except OSError:
+            continue
+        if mtime >= cutoff:
+            continue
+        shutil.rmtree(d, ignore_errors=True)
+        if not d.exists():
+            reaped += 1
+            _log.info(
+                "sweep_reaped_orphan_tmpdir",
+                path=str(d),
+                age_hours=round((time.time() - mtime) / 3600.0, 2),
+            )
+    return reaped
 
 
 def _find_chroma() -> str | None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -631,3 +631,172 @@ def test_find_claude_root_pid_case_insensitive(
         lambda pid: names.get(pid, ""),
     )
     assert find_claude_root_pid(start_pid=100) == 200
+
+
+# ── RDR-094 Phase 3: sweep_orphan_tmpdirs ───────────────────────────────────
+
+
+class TestSweepOrphanTmpdirs:
+    """RDR-094 Phase 3: reap nx_t1_* tmpdirs that no session record
+    points at AND are older than max_age_hours. Closes Gap 3 (orphan
+    tmpdirs from chroma crashes that the record-based sweep cannot
+    see)."""
+
+    def test_reaps_old_orphan_with_no_record(self, tmp_path: Path) -> None:
+        from nexus.session import sweep_orphan_tmpdirs
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        tmpdir_root = tmp_path / "tmproot"
+        tmpdir_root.mkdir()
+        orphan = tmpdir_root / "nx_t1_orphan_xyz"
+        orphan.mkdir()
+        (orphan / "chroma.sqlite3").write_bytes(b"data")
+        # Backdate 30 hours.
+        old = time.time() - 30 * 3600
+        os.utime(orphan, (old, old))
+
+        reaped = sweep_orphan_tmpdirs(
+            sessions_dir=sessions_dir, tmpdir_root=tmpdir_root,
+        )
+        assert reaped == 1
+        assert not orphan.exists()
+
+    def test_skips_recent_tmpdir(self, tmp_path: Path) -> None:
+        """In-flight tmpdir (created moments ago, no record yet) must
+        not be reaped. The 24h cutoff is the protection."""
+        from nexus.session import sweep_orphan_tmpdirs
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        tmpdir_root = tmp_path / "tmproot"
+        tmpdir_root.mkdir()
+        recent = tmpdir_root / "nx_t1_recent"
+        recent.mkdir()
+        # mtime is now, well within the cutoff.
+
+        reaped = sweep_orphan_tmpdirs(
+            sessions_dir=sessions_dir, tmpdir_root=tmpdir_root,
+        )
+        assert reaped == 0
+        assert recent.exists()
+
+    def test_skips_tmpdir_referenced_by_session_record(
+        self, tmp_path: Path,
+    ) -> None:
+        """A tmpdir mentioned in any session record must not be reaped
+        even if its mtime is old."""
+        from nexus.session import sweep_orphan_tmpdirs
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        tmpdir_root = tmp_path / "tmproot"
+        tmpdir_root.mkdir()
+        live = tmpdir_root / "nx_t1_live"
+        live.mkdir()
+        # Backdate; the record protects it regardless.
+        old = time.time() - 48 * 3600
+        os.utime(live, (old, old))
+
+        record = {
+            "session_id": "abc",
+            "server_host": "127.0.0.1",
+            "server_port": 1,
+            "server_pid": 1,
+            "tmpdir": str(live),
+            "created_at": time.time(),
+        }
+        (sessions_dir / "abc.session").write_text(json.dumps(record))
+
+        reaped = sweep_orphan_tmpdirs(
+            sessions_dir=sessions_dir, tmpdir_root=tmpdir_root,
+        )
+        assert reaped == 0
+        assert live.exists()
+
+    def test_handles_corrupt_session_files(self, tmp_path: Path) -> None:
+        """A corrupt session file must not abort the sweep; the orphan
+        next to it should still be reaped."""
+        from nexus.session import sweep_orphan_tmpdirs
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        (sessions_dir / "broken.session").write_text("{not-json")
+        tmpdir_root = tmp_path / "tmproot"
+        tmpdir_root.mkdir()
+        orphan = tmpdir_root / "nx_t1_orphan"
+        orphan.mkdir()
+        old = time.time() - 30 * 3600
+        os.utime(orphan, (old, old))
+
+        reaped = sweep_orphan_tmpdirs(
+            sessions_dir=sessions_dir, tmpdir_root=tmpdir_root,
+        )
+        assert reaped == 1
+        assert not orphan.exists()
+
+    def test_handles_missing_tmpdir_root(self, tmp_path: Path) -> None:
+        from nexus.session import sweep_orphan_tmpdirs
+
+        reaped = sweep_orphan_tmpdirs(
+            sessions_dir=tmp_path,
+            tmpdir_root=tmp_path / "does-not-exist",
+        )
+        assert reaped == 0
+
+    def test_ignores_non_nx_t1_directories(self, tmp_path: Path) -> None:
+        """Only nx_t1_* prefixed dirs are candidates. Other tmpdirs
+        from other tools are safe."""
+        from nexus.session import sweep_orphan_tmpdirs
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        tmpdir_root = tmp_path / "tmproot"
+        tmpdir_root.mkdir()
+        unrelated = tmpdir_root / "tmpXYZ_other"
+        unrelated.mkdir()
+        old = time.time() - 30 * 3600
+        os.utime(unrelated, (old, old))
+
+        reaped = sweep_orphan_tmpdirs(
+            sessions_dir=sessions_dir, tmpdir_root=tmpdir_root,
+        )
+        assert reaped == 0
+        assert unrelated.exists()
+
+    def test_reaps_multiple_old_orphans(self, tmp_path: Path) -> None:
+        from nexus.session import sweep_orphan_tmpdirs
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        tmpdir_root = tmp_path / "tmproot"
+        tmpdir_root.mkdir()
+        old = time.time() - 48 * 3600
+        for n in range(3):
+            d = tmpdir_root / f"nx_t1_o{n}"
+            d.mkdir()
+            os.utime(d, (old, old))
+
+        reaped = sweep_orphan_tmpdirs(
+            sessions_dir=sessions_dir, tmpdir_root=tmpdir_root,
+        )
+        assert reaped == 3
+
+    def test_uses_system_tempdir_when_root_unspecified(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When tmpdir_root is None, fall back to tempfile.gettempdir()."""
+        import tempfile as _tempfile
+
+        from nexus.session import sweep_orphan_tmpdirs
+
+        monkeypatch.setattr(_tempfile, "gettempdir", lambda: str(tmp_path))
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        orphan = tmp_path / "nx_t1_o"
+        orphan.mkdir()
+        old = time.time() - 30 * 3600
+        os.utime(orphan, (old, old))
+
+        reaped = sweep_orphan_tmpdirs(sessions_dir=sessions_dir)
+        assert reaped == 1


### PR DESCRIPTION
## Summary

Adds the Phase 3 piece of RDR-094: a sweep that reaps orphan `nx_t1_*` tmpdirs that no session record points at AND are older than 24h. Closes Gap 3 of the original problem statement: tmpdirs whose record was deleted but whose chroma server crashed before the cleanup path completed had no other reap trigger (`sweep_stale_sessions` operates on records, not the filesystem).

**Independent of the `NEXUS_MCP_OWNS_T1` feature flag.** Works in both hook-spawn and MCP-spawn modes because both create tmpdirs via `tempfile.mkdtemp(prefix='nx_t1_')`.

Empirical: this install has 22 such orphans accumulated from 4.10.x / 4.11.x crashes + this session's repeat respawns during the logging fix verification. The 24h cutoff means today's orphans become reap candidates tomorrow naturally; nothing pre-existing gets reaped immediately.

## What changed

- `src/nexus/session.py`:
  - `tempfile` imported at module scope (was implicitly available through `start_t1_server`).
  - New `sweep_orphan_tmpdirs(sessions_dir, tmpdir_root, max_age_hours)` function. Defaults: `SESSIONS_DIR` + `tempfile.gettempdir()` + 24h. Algorithm:
    1. Collect every tmpdir path referenced by any current session record (`resolve()`d for canonical comparison).
    2. Glob `nx_t1_*` in `tmpdir_root`.
    3. For each: skip if referenced; skip if mtime within cutoff; otherwise `rmtree(ignore_errors=True)` and log `sweep_reaped_orphan_tmpdir` with path + age_hours.
    4. Return count reaped.
- `src/nexus/hooks.py`: `session_start` now calls `sweep_orphan_tmpdirs(SESSIONS_DIR)` right after `sweep_stale_sessions`. Wrapped in try/except so a sweep failure can never break session start. Logs at debug.

## Tests

8 new tests in `tests/test_session.py::TestSweepOrphanTmpdirs`:

- `test_reaps_old_orphan_with_no_record`: backdate 30h, no record, expect 1 reap.
- `test_skips_recent_tmpdir`: fresh mtime, expect skip.
- `test_skips_tmpdir_referenced_by_session_record`: record-protected, expect skip even at 48h age.
- `test_handles_corrupt_session_files`: broken JSON next to a real orphan, expect orphan still reaped.
- `test_handles_missing_tmpdir_root`: returns 0 cleanly.
- `test_ignores_non_nx_t1_directories`: prefix filter holds.
- `test_reaps_multiple_old_orphans`: count is correct on 3 dirs.
- `test_uses_system_tempdir_when_root_unspecified`: `tempfile` fallback works.

## Regression

```
uv run pytest tests/test_logging_setup.py tests/test_mcp_package.py \
    tests/test_mcp_chroma_lifecycle.py tests/test_t1_watchdog.py \
    tests/test_session.py tests/test_hooks.py \
    tests/test_p0_regressions.py tests/test_voyage_retry.py \
    tests/test_silent_error_logging.py tests/test_structlog_events.py \
    tests/test_nx_answer.py

255 passed, 1 skipped, 2 warnings in 17.59s
```

## Out of scope

- One-time migration sweep against the 22 current orphans is left for the operator to run manually (`python -c 'from nexus.session import sweep_orphan_tmpdirs; print(sweep_orphan_tmpdirs())'`). 24h cutoff means today's orphans reap tomorrow naturally.
- `nx doctor --check-tmpdirs` CLI hook is a small follow-up; not blocking acceptance.

## Test plan

- [x] Local: 255 pass on the affected surface.
- [ ] CI green on this PR.