### PR TITLE
feat(rdr-094): Spike A lifecycle harness + nx doctor --check-tmpdirs

### DIFF
--- a/scripts/spikes/spike_rdr094_lifecycle.py
+++ b/scripts/spikes/spike_rdr094_lifecycle.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env -S uv run python
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-094 Critical Assumption #1 + #3 lifecycle probe.
+
+Spike A from RDR-094 §Implementation Plan > Prerequisites. Validates
+the chroma-cleanup completion rate by source for four phases:
+
+  1. Clean shutdown via SIGTERM to nx-mcp.
+       Expect: FastMCP lifespan finally fires (anyio cancellation
+       through async finally, RDR-094 §Approach), chroma exits
+       within seconds, no watchdog action.
+       Target: lifespan covers >=90% of runs.
+
+  2. SIGKILL to nx-mcp (no lifespan, no atexit).
+       Expect: dual-watch watchdog (--mcp-pid trigger) detects mcp_pid
+       gone within POLL_INTERVAL=5s, pgrp-signals chroma.
+       Target: watchdog covers >=95% of runs, chroma cleanup <=5s.
+
+  3. Simulated OOM via SIGSEGV.
+       Expect: same as SIGKILL (signal that bypasses Python handlers).
+       Target: same as SIGKILL.
+
+  4. Claude-crash simulation (RDR-094 FM-NEW-1, issue #1935).
+       The harness acts as the "Claude" parent that spawns nx-mcp;
+       killing the harness mid-run simulates Claude Code dying with
+       nx-mcp still alive.
+       Expect: dual-watch watchdog (--claude-pid trigger) sends
+       SIGTERM to mcp_pid, mcp's lifespan finally runs, chroma exits
+       within MCP_GRACE_SECS=2s + POLL_INTERVAL=5s.
+       Target: claude-crash path covers >=95% of runs.
+
+Each run records: phase, run_id, mcp_pid, chroma_pid, signal sent,
+chroma_alive_after_grace (bool), cleanup_path (one of: lifespan,
+atexit, watchdog_mcp, watchdog_claude, none), elapsed_until_cleanup.
+
+cleanup_path attribution comes from mcp.log: events
+``mcp_server_stopping`` (with reason='exit' meaning lifespan fired)
+or ``mcp_server_crashed`` (lifespan did not fire) discriminate the
+graceful path from the fatal-signal path. ``sweep_reaped_orphan_*``
+events from the next session start would attribute to the sweep, but
+this harness does not start a follow-on session within a single run.
+
+Per-phase API budget: $0 (no claude_dispatch). Wall-clock per run:
+~10s (5s poll + 2s grace + 3s slack). Default 5 runs/phase = 20 runs
+= ~3-4 minutes total. Pass --runs 10 for the full 40-run protocol
+that the RDR's Critical Assumption #1+#3 target.
+
+Usage::
+
+    NEXUS_MCP_OWNS_T1=1 python scripts/spikes/spike_rdr094_lifecycle.py [--runs N]
+
+Output: scripts/spikes/spike_rdr094_results.jsonl (per-run records)
+      + scripts/spikes/spike_rdr094_summary.json (aggregate).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Optional
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RESULTS_PATH = SCRIPT_DIR / "spike_rdr094_results.jsonl"
+SUMMARY_PATH = SCRIPT_DIR / "spike_rdr094_summary.json"
+
+#: Where nx-mcp writes its lifecycle log. Honors NEXUS_CONFIG_DIR.
+MCP_LOG_PATH = Path(
+    os.environ.get(
+        "NEXUS_CONFIG_DIR",
+        os.path.expanduser("~/.config/nexus"),
+    )
+) / "logs" / "mcp.log"
+
+#: Time the harness gives the system to spawn chroma after starting
+#: nx-mcp before the harness considers the run a setup failure.
+SPAWN_TIMEOUT_S: float = 8.0
+
+#: Time the harness waits after sending the kill signal before
+#: checking chroma liveness. Covers the watchdog poll (5s) plus the
+#: MCP grace period (2s) plus 1s slack for fs flushes.
+CLEANUP_TIMEOUT_S: float = 10.0
+
+
+@dataclass
+class RunRecord:
+    phase: str
+    run_id: int
+    mcp_pid: int
+    chroma_pid: int
+    signal_sent: str
+    chroma_alive_after_grace: bool
+    cleanup_path: str
+    elapsed_until_cleanup_s: float
+    setup_failed: bool
+    error: Optional[str]
+
+
+def _is_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _spawn_nx_mcp(env_overrides: Optional[dict] = None) -> subprocess.Popen:
+    """Spawn nx-mcp as a child process under this harness.
+
+    The harness becomes the "Claude" parent for the FM-NEW-1 simulation.
+    Each run gets its own process group via ``start_new_session=True``
+    so we can kill nx-mcp without affecting the harness when needed.
+
+    Inherits the harness's stdio so any pre-lifespan errors are visible.
+    Overrides ``NEXUS_MCP_OWNS_T1=1`` (forced) and merges any caller
+    overrides.
+    """
+    env = {**os.environ, "NEXUS_MCP_OWNS_T1": "1"}
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.Popen(
+        [sys.executable, "-m", "nexus.mcp.core"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+        env=env,
+    )
+
+
+def _wait_for_chroma_pid(timeout: float) -> Optional[int]:
+    """Poll the active session record for the chroma server_pid.
+
+    The MCP server's _t1_chroma_init_if_owner writes the record before
+    yielding from the lifespan; we tail the sessions directory for a
+    record whose write mtime is newer than the harness start.
+    """
+    from nexus.db.t1 import SESSIONS_DIR
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if SESSIONS_DIR.exists():
+            for f in sorted(
+                SESSIONS_DIR.glob("*.session"),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            ):
+                try:
+                    rec = json.loads(f.read_text())
+                except (OSError, json.JSONDecodeError):
+                    continue
+                pid = rec.get("server_pid")
+                if isinstance(pid, int) and pid > 0 and _is_alive(pid):
+                    return pid
+        time.sleep(0.1)
+    return None
+
+
+def _classify_cleanup_path(
+    log_lines_after: list[str], chroma_alive: bool, signal_sent: str,
+) -> str:
+    """Inspect mcp.log lines emitted after the kill signal and
+    attribute the cleanup path.
+
+    Heuristics in priority order:
+      * mcp_server_stopping reason='exit' => lifespan fired (graceful).
+      * mcp_server_crashed => fatal signal, lifespan did not fire.
+        If chroma is dead anyway, watchdog covered it.
+      * No relevant log line + chroma dead => watchdog (no-emit path).
+      * No relevant log line + chroma alive => none (regression).
+
+    Watchdog mcp-pid vs claude-pid trigger discrimination is
+    inferred from signal_sent (if SIGTERM came from harness, the
+    harness was the "Claude" so claude-pid trigger; if SIGKILL or
+    SIGSEGV against nx-mcp directly, mcp-pid trigger).
+    """
+    saw_lifespan_exit = any(
+        "mcp_server_stopping" in line and "reason='exit'" in line
+        for line in log_lines_after
+    )
+    saw_crash = any(
+        "mcp_server_crashed" in line for line in log_lines_after
+    )
+    if saw_lifespan_exit:
+        return "lifespan"
+    if not chroma_alive:
+        if saw_crash:
+            return "watchdog_mcp"
+        if signal_sent in ("SIGKILL", "SIGSEGV"):
+            return "watchdog_mcp"
+        if signal_sent == "harness_SIGKILL":
+            return "watchdog_claude"
+        return "watchdog_unknown"
+    return "none"
+
+
+def _read_log_tail_after(start_pos: int) -> list[str]:
+    """Return mcp.log lines written after byte offset start_pos.
+
+    Best-effort: file may not exist (logging not configured) or may
+    have rotated; in either case return [].
+    """
+    if not MCP_LOG_PATH.exists():
+        return []
+    try:
+        with MCP_LOG_PATH.open("r") as f:
+            f.seek(start_pos)
+            return f.readlines()
+    except OSError:
+        return []
+
+
+def _log_size() -> int:
+    try:
+        return MCP_LOG_PATH.stat().st_size
+    except OSError:
+        return 0
+
+
+def _run_phase_clean(run_id: int) -> RunRecord:
+    """Phase 1: SIGTERM to nx-mcp, expect lifespan finally to clean."""
+    log_start = _log_size()
+    proc = _spawn_nx_mcp()
+    chroma_pid = _wait_for_chroma_pid(SPAWN_TIMEOUT_S)
+    if chroma_pid is None:
+        # Setup failure: nx-mcp didn't spawn chroma.
+        try:
+            proc.kill()
+            proc.wait(timeout=2)
+        except Exception:
+            pass
+        return RunRecord(
+            phase="clean", run_id=run_id, mcp_pid=proc.pid,
+            chroma_pid=0, signal_sent="SIGTERM",
+            chroma_alive_after_grace=False, cleanup_path="setup_failed",
+            elapsed_until_cleanup_s=0.0, setup_failed=True,
+            error="chroma_pid not observed within SPAWN_TIMEOUT_S",
+        )
+
+    t0 = time.monotonic()
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=CLEANUP_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+    # Give the lifespan finally + watchdog a moment to settle the
+    # filesystem before we measure.
+    time.sleep(1.0)
+    elapsed = time.monotonic() - t0
+    chroma_alive = _is_alive(chroma_pid)
+    log_lines = _read_log_tail_after(log_start)
+    cleanup_path = _classify_cleanup_path(
+        log_lines, chroma_alive, "SIGTERM",
+    )
+    if chroma_alive:
+        # Cleanup the chroma we leaked so the harness can keep running.
+        try:
+            os.kill(chroma_pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    return RunRecord(
+        phase="clean", run_id=run_id, mcp_pid=proc.pid,
+        chroma_pid=chroma_pid, signal_sent="SIGTERM",
+        chroma_alive_after_grace=chroma_alive,
+        cleanup_path=cleanup_path, elapsed_until_cleanup_s=round(elapsed, 2),
+        setup_failed=False, error=None,
+    )
+
+
+def _run_phase_kill(run_id: int, kill_signal: int, label: str) -> RunRecord:
+    """Phases 2 + 3: bypass the lifespan via SIGKILL or SIGSEGV.
+
+    Watchdog --mcp-pid trigger is the expected cleanup path.
+    """
+    log_start = _log_size()
+    proc = _spawn_nx_mcp()
+    chroma_pid = _wait_for_chroma_pid(SPAWN_TIMEOUT_S)
+    if chroma_pid is None:
+        try:
+            proc.kill()
+            proc.wait(timeout=2)
+        except Exception:
+            pass
+        return RunRecord(
+            phase=label, run_id=run_id, mcp_pid=proc.pid,
+            chroma_pid=0, signal_sent=label.upper(),
+            chroma_alive_after_grace=False, cleanup_path="setup_failed",
+            elapsed_until_cleanup_s=0.0, setup_failed=True,
+            error="chroma_pid not observed within SPAWN_TIMEOUT_S",
+        )
+
+    t0 = time.monotonic()
+    proc.send_signal(kill_signal)
+    try:
+        proc.wait(timeout=2.0)
+    except subprocess.TimeoutExpired:
+        pass
+    # Wait for the dual-watch watchdog to detect mcp_pid gone (5s poll)
+    # and clean chroma. CLEANUP_TIMEOUT_S has the slack budget.
+    time.sleep(CLEANUP_TIMEOUT_S)
+    elapsed = time.monotonic() - t0
+    chroma_alive = _is_alive(chroma_pid)
+    log_lines = _read_log_tail_after(log_start)
+    cleanup_path = _classify_cleanup_path(
+        log_lines, chroma_alive,
+        "SIGKILL" if kill_signal == signal.SIGKILL else "SIGSEGV",
+    )
+    if chroma_alive:
+        try:
+            os.kill(chroma_pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    return RunRecord(
+        phase=label, run_id=run_id, mcp_pid=proc.pid,
+        chroma_pid=chroma_pid,
+        signal_sent="SIGKILL" if kill_signal == signal.SIGKILL else "SIGSEGV",
+        chroma_alive_after_grace=chroma_alive,
+        cleanup_path=cleanup_path, elapsed_until_cleanup_s=round(elapsed, 2),
+        setup_failed=False, error=None,
+    )
+
+
+def _run_phase_claude_crash(run_id: int) -> RunRecord:
+    """Phase 4 (FM-NEW-1): kill the harness's grandparent simulation.
+
+    The harness fork-and-exit pattern: we spawn an intermediate "fake
+    Claude" process that itself spawns nx-mcp, then kill the
+    intermediate. The dual-watch watchdog should observe claude_pid
+    gone (the intermediate is what's recorded in the watchdog spawn
+    via find_claude_root_pid).
+
+    Note: find_claude_root_pid walks the PPID chain looking for a
+    'claude' or 'Claude' command name. Our intermediate runs python,
+    so it will not be detected as the Claude root. To work around
+    this for the spike, we set NEXUS_FAKE_CLAUDE_PID env so the
+    nx-mcp records our intermediate's PID as the claude_root_pid.
+    The spike harness reads this env in nx-mcp's
+    find_claude_root_pid override; absent the override, this phase
+    skips with setup_failed.
+    """
+    # The override hook is intentionally not implemented in the
+    # production code path (don't pollute the production claude
+    # detection for a spike). For the spike, mark this phase as
+    # "needs harness-side hook" and document the manual-test
+    # alternative below.
+    return RunRecord(
+        phase="claude_crash", run_id=run_id, mcp_pid=0, chroma_pid=0,
+        signal_sent="harness_SIGKILL",
+        chroma_alive_after_grace=False, cleanup_path="not_implemented",
+        elapsed_until_cleanup_s=0.0, setup_failed=True,
+        error=(
+            "Phase 4 requires either (a) the harness to be started "
+            "from a process whose name is 'claude'/'Claude' so "
+            "find_claude_root_pid resolves to it, or (b) a "
+            "NEXUS_FAKE_CLAUDE_PID hook in find_claude_root_pid. "
+            "Run manually instead: spawn `claude` with "
+            "NEXUS_MCP_OWNS_T1=1, kill the claude process with -9, "
+            "and observe whether watchdog cleans chroma within ~7s "
+            "(5s poll + 2s grace). Capture mcp.log for evidence."
+        ),
+    )
+
+
+def _aggregate(records: list[RunRecord]) -> dict[str, Any]:
+    by_phase: dict[str, list[RunRecord]] = {}
+    for r in records:
+        by_phase.setdefault(r.phase, []).append(r)
+
+    summary: dict[str, Any] = {"phases": {}, "totals": {}}
+    grand_total = 0
+    grand_clean = 0
+    for phase, recs in by_phase.items():
+        n = len(recs)
+        setup_failed = sum(1 for r in recs if r.setup_failed)
+        usable = [r for r in recs if not r.setup_failed]
+        chroma_dead = sum(
+            1 for r in usable if not r.chroma_alive_after_grace
+        )
+        path_counts: dict[str, int] = {}
+        for r in usable:
+            path_counts[r.cleanup_path] = path_counts.get(r.cleanup_path, 0) + 1
+        summary["phases"][phase] = {
+            "runs": n,
+            "setup_failed": setup_failed,
+            "usable": len(usable),
+            "chroma_cleaned": chroma_dead,
+            "cleanup_rate": (
+                round(chroma_dead / len(usable), 3) if usable else None
+            ),
+            "path_counts": path_counts,
+            "median_elapsed_s": (
+                round(
+                    sorted(r.elapsed_until_cleanup_s for r in usable)[
+                        len(usable) // 2
+                    ],
+                    2,
+                )
+                if usable
+                else None
+            ),
+        }
+        grand_total += n
+        grand_clean += chroma_dead
+    summary["totals"] = {
+        "runs": grand_total,
+        "chroma_cleaned": grand_clean,
+        "overall_cleanup_rate": (
+            round(grand_clean / grand_total, 3) if grand_total else None
+        ),
+    }
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="RDR-094 Spike A: T1 chroma lifecycle probe.",
+    )
+    parser.add_argument(
+        "--runs", type=int, default=5,
+        help="Runs per phase (default 5; RDR target is 10).",
+    )
+    parser.add_argument(
+        "--phases", type=str, default="clean,mcp_sigkill,mcp_oom",
+        help=(
+            "Comma-separated phase list. Defaults skip "
+            "claude_crash because it requires manual setup; pass "
+            "--phases all to include it as a not-implemented record."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.phases == "all":
+        phases = ["clean", "mcp_sigkill", "mcp_oom", "claude_crash"]
+    else:
+        phases = [p.strip() for p in args.phases.split(",") if p.strip()]
+
+    results: list[RunRecord] = []
+    RESULTS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with RESULTS_PATH.open("a") as out:
+        for phase in phases:
+            for run_id in range(args.runs):
+                if phase == "clean":
+                    rec = _run_phase_clean(run_id)
+                elif phase == "mcp_sigkill":
+                    rec = _run_phase_kill(run_id, signal.SIGKILL, "mcp_sigkill")
+                elif phase == "mcp_oom":
+                    rec = _run_phase_kill(run_id, signal.SIGSEGV, "mcp_oom")
+                elif phase == "claude_crash":
+                    rec = _run_phase_claude_crash(run_id)
+                else:
+                    print(f"unknown phase: {phase}", file=sys.stderr)
+                    continue
+                out.write(json.dumps(asdict(rec)) + "\n")
+                out.flush()
+                results.append(rec)
+                print(
+                    f"[{phase}/{run_id}] cleanup_path={rec.cleanup_path} "
+                    f"chroma_alive={rec.chroma_alive_after_grace} "
+                    f"elapsed={rec.elapsed_until_cleanup_s:.2f}s",
+                    flush=True,
+                )
+
+    summary = _aggregate(results)
+    SUMMARY_PATH.write_text(json.dumps(summary, indent=2))
+    print("\n=== SUMMARY ===")
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -170,6 +170,111 @@ def _run_check_schema() -> None:
 _MIN_GLOBAL_BUILTIN_COUNT: int = 9
 
 
+def _run_check_tmpdirs(*, reap: bool, json_out: bool) -> None:
+    """List or reap orphan ``nx_t1_*`` tmpdirs (RDR-094 Phase 3).
+
+    Read-only by default: enumerates candidates that
+    :func:`nexus.session.sweep_orphan_tmpdirs` would reap (no session
+    record reference, mtime > 24h). With ``--reap-tmpdirs``, calls
+    the sweep function and reports the count actually deleted.
+
+    Exits non-zero when reap reports zero candidates and ``--reap-
+    tmpdirs`` was passed (so the operator can spot a no-op run in
+    automation).
+    """
+    import json
+    import tempfile
+    import time
+    from pathlib import Path
+
+    from nexus.db.t1 import SESSIONS_DIR
+    from nexus.session import sweep_orphan_tmpdirs
+
+    tmpdir_root = Path(tempfile.gettempdir())
+    cutoff_hours = 24.0
+    cutoff = time.time() - cutoff_hours * 3600.0
+
+    referenced: set[str] = set()
+    if SESSIONS_DIR.exists():
+        for f in SESSIONS_DIR.glob("*.session"):
+            try:
+                rec = json.loads(f.read_text())
+                if isinstance(rec, dict):
+                    td = rec.get("tmpdir", "")
+                    if td:
+                        referenced.add(str(Path(td).resolve()))
+            except (json.JSONDecodeError, OSError):
+                continue
+
+    candidates: list[dict] = []
+    if tmpdir_root.exists():
+        for d in sorted(tmpdir_root.glob("nx_t1_*")):
+            if not d.is_dir():
+                continue
+            try:
+                resolved = str(d.resolve())
+            except OSError:
+                continue
+            if resolved in referenced:
+                continue
+            try:
+                mtime = d.stat().st_mtime
+            except OSError:
+                continue
+            age_h = (time.time() - mtime) / 3600.0
+            if mtime >= cutoff:
+                continue
+            try:
+                size_kb = sum(
+                    p.stat().st_size for p in d.rglob("*") if p.is_file()
+                ) / 1024.0
+            except OSError:
+                size_kb = 0.0
+            candidates.append({
+                "path": str(d),
+                "age_hours": round(age_h, 2),
+                "size_kb": round(size_kb, 1),
+            })
+
+    payload: dict = {
+        "tmpdir_root": str(tmpdir_root),
+        "cutoff_hours": cutoff_hours,
+        "candidates": candidates,
+        "reaped": 0,
+    }
+
+    if reap:
+        payload["reaped"] = sweep_orphan_tmpdirs(
+            sessions_dir=SESSIONS_DIR, tmpdir_root=tmpdir_root,
+            max_age_hours=cutoff_hours,
+        )
+
+    if json_out:
+        click.echo(json.dumps(payload, indent=2))
+    else:
+        if not candidates:
+            click.echo(
+                f"No orphan nx_t1_* tmpdirs older than {cutoff_hours}h "
+                f"under {tmpdir_root}."
+            )
+        else:
+            click.echo(
+                f"Orphan nx_t1_* candidates under {tmpdir_root}: "
+                f"{len(candidates)}"
+            )
+            for c in candidates:
+                click.echo(
+                    f"  {c['path']}  age={c['age_hours']}h  "
+                    f"size={c['size_kb']}KB"
+                )
+        if reap:
+            click.echo(f"Reaped: {payload['reaped']}")
+
+    if reap and payload["reaped"] == 0 and candidates:
+        # All candidates failed to delete; surface as non-zero.
+        raise click.exceptions.Exit(1)
+
+
 def _run_check_plan_library() -> None:
     """Report plan-library dimensional health. RDR-092 Phase 0c.2.
 
@@ -368,6 +473,25 @@ def _run_trim_telemetry(days: int) -> None:
          "Phase 0c.2.",
 )
 @click.option(
+    "--check-tmpdirs",
+    "check_tmpdirs",
+    is_flag=True,
+    default=False,
+    help="List orphan nx_t1_* tmpdirs that no session record points "
+         "at AND are older than 24h. Reap candidates from RDR-094 "
+         "Phase 3 sweep_orphan_tmpdirs. Read-only; pair with "
+         "--reap-tmpdirs to actually delete them.",
+)
+@click.option(
+    "--reap-tmpdirs",
+    "reap_tmpdirs",
+    is_flag=True,
+    default=False,
+    help="With --check-tmpdirs, run sweep_orphan_tmpdirs and report "
+         "the count reaped. Without --check-tmpdirs this flag is "
+         "ignored.",
+)
+@click.option(
     "--json",
     "json_out",
     is_flag=True,
@@ -394,7 +518,9 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                fix_paths: bool, dry_run: bool, check_schema: bool,
                check_search: bool, check_resources: bool,
                check_quotas: bool, check_taxonomy: bool,
-               check_plan_library: bool, json_out: bool,
+               check_plan_library: bool,
+               check_tmpdirs: bool, reap_tmpdirs: bool,
+               json_out: bool,
                trim_telemetry: bool, days: int) -> None:
     """Verify that all required services and credentials are available."""
     if check_schema:
@@ -412,6 +538,10 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if check_quotas:
         _run_check_quotas(json_out=json_out)
+        return
+
+    if check_tmpdirs:
+        _run_check_tmpdirs(reap=reap_tmpdirs, json_out=json_out)
         return
 
     if check_taxonomy:

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -689,3 +689,103 @@ class TestCheckPlanLibrary:
         # count should appear in the report regardless.
         assert "backfill" in result.output.lower()
 
+
+
+# ── --check-tmpdirs (RDR-094 Phase 3) ───────────────────────────────────────
+
+
+class TestCheckTmpdirs:
+    """``nx doctor --check-tmpdirs`` surfaces orphan ``nx_t1_*``
+    tmpdirs (no session record reference, mtime > 24h). Read-only
+    by default; ``--reap-tmpdirs`` actually deletes."""
+
+    def test_no_candidates_exits_zero(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        # Empty tmproot => zero candidates.
+        empty_root = tmp_path / "empty"
+        empty_root.mkdir()
+        with patch(
+            "tempfile.gettempdir", return_value=str(empty_root),
+        ):
+            result = runner.invoke(main, ["doctor", "--check-tmpdirs"])
+        assert result.exit_code == 0, result.output
+        assert "No orphan" in result.output
+
+    def test_lists_candidates_without_reap(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        import os as _os
+        import time as _time
+
+        tmproot = tmp_path / "tmp"
+        tmproot.mkdir()
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        old_orphan = tmproot / "nx_t1_old"
+        old_orphan.mkdir()
+        backdate = _time.time() - 30 * 3600
+        _os.utime(old_orphan, (backdate, backdate))
+
+        with patch(
+            "tempfile.gettempdir", return_value=str(tmproot),
+        ), patch("nexus.db.t1.SESSIONS_DIR", sessions):
+            result = runner.invoke(main, ["doctor", "--check-tmpdirs"])
+        assert result.exit_code == 0, result.output
+        assert "nx_t1_old" in result.output
+        # Read-only mode: candidate still on disk.
+        assert old_orphan.exists()
+
+    def test_reap_actually_deletes(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        import os as _os
+        import time as _time
+
+        tmproot = tmp_path / "tmp"
+        tmproot.mkdir()
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        old_orphan = tmproot / "nx_t1_old"
+        old_orphan.mkdir()
+        backdate = _time.time() - 30 * 3600
+        _os.utime(old_orphan, (backdate, backdate))
+
+        with patch(
+            "tempfile.gettempdir", return_value=str(tmproot),
+        ), patch("nexus.db.t1.SESSIONS_DIR", sessions):
+            result = runner.invoke(
+                main, ["doctor", "--check-tmpdirs", "--reap-tmpdirs"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Reaped: 1" in result.output
+        assert not old_orphan.exists()
+
+    def test_json_out_emits_machine_parseable(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        import json as _json
+        import os as _os
+        import time as _time
+
+        tmproot = tmp_path / "tmp"
+        tmproot.mkdir()
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        orphan = tmproot / "nx_t1_x"
+        orphan.mkdir()
+        backdate = _time.time() - 30 * 3600
+        _os.utime(orphan, (backdate, backdate))
+
+        with patch(
+            "tempfile.gettempdir", return_value=str(tmproot),
+        ), patch("nexus.db.t1.SESSIONS_DIR", sessions):
+            result = runner.invoke(
+                main, ["doctor", "--check-tmpdirs", "--json"],
+            )
+        assert result.exit_code == 0, result.output
+        payload = _json.loads(result.output)
+        assert payload["cutoff_hours"] == 24.0
+        assert len(payload["candidates"]) == 1
+        assert payload["candidates"][0]["path"].endswith("nx_t1_x")
+        assert payload["reaped"] == 0


### PR DESCRIPTION
## Summary

Two operator-facing pieces that complement Phase 1+2+3 (PRs #289 + #290): a spike harness for Critical Assumption #1 + #3 evidence collection, and a `nx doctor` flag for visibility on orphan tmpdirs.

## What changed

### `scripts/spikes/spike_rdr094_lifecycle.py` (new)

Authored, not run. Operator invokes with `NEXUS_MCP_OWNS_T1=1 python scripts/spikes/spike_rdr094_lifecycle.py [--runs N]` to gather evidence. Output goes to `scripts/spikes/spike_rdr094_results.jsonl` + summary JSON, following the RDR-088 / RDR-093 spike convention.

Three runnable phases + one manual:

| Phase | Signal | Expected cleanup path | Target |
|--|--|--|--|
| clean | SIGTERM to nx-mcp | FastMCP lifespan finally | >=90% |
| mcp_sigkill | SIGKILL to nx-mcp | watchdog (mcp-pid trigger) | >=95% within 5s |
| mcp_oom | SIGSEGV to nx-mcp | watchdog (mcp-pid trigger) | >=95% within 5s |
| claude_crash | manual: SIGKILL Claude Code | watchdog (claude-pid trigger) | >=95% within 7s |

claude_crash is not auto-run because `find_claude_root_pid` walks the PPID chain for a `claude`/`Claude` command name and the harness is `python`. The phase record carries an error message with the manual-test alternative.

`cleanup_path` is attributed from `mcp.log`:
- `mcp_server_stopping reason='exit'` → lifespan
- `mcp_server_crashed` + dead chroma → watchdog (no-emit path)
- nothing logged + dead chroma → watchdog (no-emit)
- nothing logged + alive chroma → none (regression)

Default 5 runs/phase = 15. Pass `--runs 10` for the RDR target. API budget: $0.

### `src/nexus/commands/doctor.py`

New flags:

- `--check-tmpdirs`: enumerate orphan `nx_t1_*` tmpdirs (no session record reference, mtime > 24h). Read-only.
- `--reap-tmpdirs`: with `--check-tmpdirs`, run `sweep_orphan_tmpdirs` and report count reaped. Exits 1 if candidates existed but the sweep deleted zero.

Honors `--json` for machine-parseable output.

### `tests/test_doctor_cmd.py::TestCheckTmpdirs`

4 new tests: no-candidates-exits-zero, lists-without-reap, reap-deletes, json-output.

## Live verification

```
scripts/reinstall-tool.sh && nx doctor --check-tmpdirs --json
{
  "tmpdir_root": "/var/folders/57/.../T",
  "cutoff_hours": 24.0,
  "candidates": [],
  "reaped": 0
}

uv run python scripts/spikes/spike_rdr094_lifecycle.py --help
[CLI parses cleanly, all flags present]
```

## Regression

```
uv run pytest tests/test_doctor_cmd.py tests/test_session.py \
    tests/test_hooks.py tests/test_t1_watchdog.py \
    tests/test_mcp_chroma_lifecycle.py
136 passed in 35.99s
```

## Out of scope

- Running the spike. Operator's call after review.
- Spike C (issue #40207 mid-session SIGTERM probe). 30-minute idle Claude session; manual setup with mcp.log capture.
- RDR-094 acceptance, still pending spike data.

## Test plan

- [x] Local: 136 pass; new tests + regression on the affected surface.
- [x] Live: `nx doctor --check-tmpdirs --json` returns valid JSON.
- [x] Live: spike harness `--help` parses cleanly.
- [ ] CI green on this PR.