### PR TITLE
feat(rdr-094): make claude_crash phase runnable + add Spike C observer

### DIFF
--- a/scripts/spikes/spike_rdr094_lifecycle.py
+++ b/scripts/spikes/spike_rdr094_lifecycle.py
@@ -334,44 +334,164 @@ def _run_phase_kill(run_id: int, kill_signal: int, label: str) -> RunRecord:
     )
 
 
-def _run_phase_claude_crash(run_id: int) -> RunRecord:
-    """Phase 4 (FM-NEW-1): kill the harness's grandparent simulation.
+_INTERMEDIATE_HANDOFF = SCRIPT_DIR / "_spike_intermediate_handoff.json"
 
-    The harness fork-and-exit pattern: we spawn an intermediate "fake
-    Claude" process that itself spawns nx-mcp, then kill the
-    intermediate. The dual-watch watchdog should observe claude_pid
-    gone (the intermediate is what's recorded in the watchdog spawn
-    via find_claude_root_pid).
 
-    Note: find_claude_root_pid walks the PPID chain looking for a
-    'claude' or 'Claude' command name. Our intermediate runs python,
-    so it will not be detected as the Claude root. To work around
-    this for the spike, we set NEXUS_FAKE_CLAUDE_PID env so the
-    nx-mcp records our intermediate's PID as the claude_root_pid.
-    The spike harness reads this env in nx-mcp's
-    find_claude_root_pid override; absent the override, this phase
-    skips with setup_failed.
+def _spawn_fake_claude_intermediate() -> subprocess.Popen:
+    """Spawn an intermediate "fake claude" process that owns nx-mcp.
+
+    The intermediate process:
+      1. Spawns nx-mcp with NEXUS_MCP_OWNS_T1=1.
+      2. Writes its own PID + nx-mcp's PID to a handoff file so the
+         outer harness can read them.
+      3. Sleeps forever (waiting to be killed).
+
+    When the outer harness SIGKILLs the intermediate, the dual-watch
+    watchdog (which has --claude-pid pointing at the intermediate)
+    sees claude_root_pid disappear, sends SIGTERM to mcp_pid, and
+    chroma is cleaned up by the lifespan finally inside nx-mcp.
+
+    find_claude_root_pid uses the immediate-PPID fallback when no
+    'claude' command-name ancestor is found. Since nx-mcp's PPID is
+    the intermediate, the watchdog gets the intermediate's PID
+    automatically without any rename trickery.
     """
-    # The override hook is intentionally not implemented in the
-    # production code path (don't pollute the production claude
-    # detection for a spike). For the spike, mark this phase as
-    # "needs harness-side hook" and document the manual-test
-    # alternative below.
+    bootstrap = (
+        "import json, os, subprocess, sys, time;\n"
+        "env = dict(os.environ);\n"
+        "env['NEXUS_MCP_OWNS_T1'] = '1';\n"
+        "p = subprocess.Popen(\n"
+        "    [sys.executable, '-m', 'nexus.mcp.core'],\n"
+        "    stdin=subprocess.PIPE, stdout=subprocess.PIPE,\n"
+        "    stderr=subprocess.PIPE, env=env,\n"
+        ");\n"
+        f"open({str(_INTERMEDIATE_HANDOFF)!r}, 'w').write(\n"
+        "    json.dumps({'mcp_pid': p.pid, 'intermediate_pid': os.getpid()})\n"
+        ");\n"
+        "while True:\n"
+        "    time.sleep(60)\n"
+    )
+    return subprocess.Popen(
+        [sys.executable, "-c", bootstrap],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def _run_phase_claude_crash(run_id: int) -> RunRecord:
+    """Phase 4 (RDR-094 FM-NEW-1, issue #1935): SIGKILL a "fake claude"
+    intermediate that owns nx-mcp, observe whether the dual-watch
+    watchdog's claude-pid trigger cleans chroma.
+
+    Steps:
+      1. Spawn an intermediate process that itself spawns nx-mcp
+         (nx-mcp's PPID is the intermediate, so
+         find_claude_root_pid's PPID-fallback resolves to the
+         intermediate's PID even without a 'claude' command name).
+      2. Wait for the intermediate to write nx-mcp's PID to a handoff
+         file, then for nx-mcp to publish chroma's PID via the session
+         record.
+      3. SIGKILL the intermediate (simulates Claude Code crash with
+         nx-mcp orphaned).
+      4. Wait CLEANUP_TIMEOUT_S for the watchdog: claude-pid trigger
+         fires within POLL_INTERVAL=5s, sends SIGTERM to nx-mcp,
+         lifespan finally runs (~MCP_GRACE_SECS=2s), chroma exits.
+      5. Check chroma liveness; classify cleanup path.
+    """
+    log_start = _log_size()
+    if _INTERMEDIATE_HANDOFF.exists():
+        _INTERMEDIATE_HANDOFF.unlink()
+
+    intermediate = _spawn_fake_claude_intermediate()
+    intermediate_pid = intermediate.pid
+
+    # Wait for the intermediate to publish nx-mcp's PID.
+    deadline = time.monotonic() + SPAWN_TIMEOUT_S
+    handoff: dict[str, int] | None = None
+    while time.monotonic() < deadline and handoff is None:
+        if _INTERMEDIATE_HANDOFF.exists():
+            try:
+                handoff = json.loads(_INTERMEDIATE_HANDOFF.read_text())
+            except (OSError, json.JSONDecodeError):
+                pass
+        if handoff is None:
+            time.sleep(0.1)
+    if handoff is None:
+        try:
+            intermediate.kill()
+            intermediate.wait(timeout=2)
+        except Exception:
+            pass
+        return RunRecord(
+            phase="claude_crash", run_id=run_id,
+            mcp_pid=0, chroma_pid=0, signal_sent="(setup-failed)",
+            chroma_alive_after_grace=False, cleanup_path="setup_failed",
+            elapsed_until_cleanup_s=0.0, setup_failed=True,
+            error="intermediate handoff file never appeared",
+        )
+
+    mcp_pid = int(handoff.get("mcp_pid", 0))
+    chroma_pid = _wait_for_chroma_pid(SPAWN_TIMEOUT_S)
+    if chroma_pid is None or mcp_pid == 0:
+        try:
+            intermediate.kill()
+            intermediate.wait(timeout=2)
+        except Exception:
+            pass
+        if mcp_pid and _is_alive(mcp_pid):
+            try:
+                os.kill(mcp_pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        return RunRecord(
+            phase="claude_crash", run_id=run_id,
+            mcp_pid=mcp_pid, chroma_pid=0,
+            signal_sent="(setup-failed)",
+            chroma_alive_after_grace=False, cleanup_path="setup_failed",
+            elapsed_until_cleanup_s=0.0, setup_failed=True,
+            error="chroma_pid not observed within SPAWN_TIMEOUT_S",
+        )
+
+    t0 = time.monotonic()
+    # SIGKILL the intermediate (simulates Claude Code crash).
+    try:
+        os.kill(intermediate_pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+    intermediate.wait(timeout=2)
+
+    # Wait for the watchdog's claude-pid trigger:
+    #   POLL_INTERVAL=5s + MCP_GRACE_SECS=2s + slack = CLEANUP_TIMEOUT_S
+    time.sleep(CLEANUP_TIMEOUT_S)
+    elapsed = time.monotonic() - t0
+    chroma_alive = _is_alive(chroma_pid)
+    log_lines = _read_log_tail_after(log_start)
+    cleanup_path = _classify_cleanup_path(
+        log_lines, chroma_alive, "harness_SIGKILL",
+    )
+    # Belt-and-braces cleanup of any leak so the next run starts clean.
+    if chroma_alive:
+        try:
+            os.kill(chroma_pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    if mcp_pid and _is_alive(mcp_pid):
+        try:
+            os.kill(mcp_pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    if _INTERMEDIATE_HANDOFF.exists():
+        _INTERMEDIATE_HANDOFF.unlink()
+
     return RunRecord(
-        phase="claude_crash", run_id=run_id, mcp_pid=0, chroma_pid=0,
+        phase="claude_crash", run_id=run_id,
+        mcp_pid=mcp_pid, chroma_pid=chroma_pid,
         signal_sent="harness_SIGKILL",
-        chroma_alive_after_grace=False, cleanup_path="not_implemented",
-        elapsed_until_cleanup_s=0.0, setup_failed=True,
-        error=(
-            "Phase 4 requires either (a) the harness to be started "
-            "from a process whose name is 'claude'/'Claude' so "
-            "find_claude_root_pid resolves to it, or (b) a "
-            "NEXUS_FAKE_CLAUDE_PID hook in find_claude_root_pid. "
-            "Run manually instead: spawn `claude` with "
-            "NEXUS_MCP_OWNS_T1=1, kill the claude process with -9, "
-            "and observe whether watchdog cleans chroma within ~7s "
-            "(5s poll + 2s grace). Capture mcp.log for evidence."
-        ),
+        chroma_alive_after_grace=chroma_alive,
+        cleanup_path=cleanup_path,
+        elapsed_until_cleanup_s=round(elapsed, 2),
+        setup_failed=False, error=None,
     )
 
 
@@ -434,19 +554,16 @@ def main() -> int:
         help="Runs per phase (default 5; RDR target is 10).",
     )
     parser.add_argument(
-        "--phases", type=str, default="clean,mcp_sigkill,mcp_oom",
+        "--phases", type=str,
+        default="clean,mcp_sigkill,mcp_oom,claude_crash",
         help=(
-            "Comma-separated phase list. Defaults skip "
-            "claude_crash because it requires manual setup; pass "
-            "--phases all to include it as a not-implemented record."
+            "Comma-separated phase list. Default runs all four. "
+            "Use --phases clean for a quick lifespan-only smoke."
         ),
     )
     args = parser.parse_args()
 
-    if args.phases == "all":
-        phases = ["clean", "mcp_sigkill", "mcp_oom", "claude_crash"]
-    else:
-        phases = [p.strip() for p in args.phases.split(",") if p.strip()]
+    phases = [p.strip() for p in args.phases.split(",") if p.strip()]
 
     results: list[RunRecord] = []
     RESULTS_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/spikes/spike_rdr094_mid_session_observer.py
+++ b/scripts/spikes/spike_rdr094_mid_session_observer.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env -S uv run python
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-094 Spike C observer for issue #40207 (mid-session SIGTERM).
+
+Run this script alongside a real Claude Code session to detect
+whether Claude Code's MCP client sends mid-session SIGTERM to
+nx-mcp. The probe is necessarily collaborative because the trigger
+under investigation lives inside Claude Code itself, not in
+anything this script can simulate.
+
+## Usage
+
+In one terminal::
+
+    uv run python scripts/spikes/spike_rdr094_mid_session_observer.py \\
+        --duration-min 30
+
+In another terminal::
+
+    NEXUS_MCP_OWNS_T1=1 claude
+
+Then leave the Claude session idle for the duration. The observer
+tails ~/.config/nexus/logs/mcp.log and watches for:
+
+  * mcp_server_starting events (each tracks a fresh nx-mcp spawn)
+  * mcp_server_stopping events with reason='signal' (SIGTERM /
+    SIGINT received during the session)
+  * mcp_server_crashed events (lifespan didn't fire)
+  * Time gaps between consecutive starting events (restart cycle)
+
+If issue #40207 applies to vanilla stdio servers like nx-mcp, the
+observer will see start/stop pairs at decreasing intervals
+(documented as 60s, 30s, 10s in the issue). If not, the start
+should fire once and stay stopping-free for the full duration.
+
+The observer also watches process state: it lists every nx-mcp
+process every 30 seconds and notes its PID, parent PID, and uptime.
+Restart cycles produce visible PID churn in the log.
+
+## Output
+
+  scripts/spikes/spike_rdr094_mid_session_log.jsonl
+  scripts/spikes/spike_rdr094_mid_session_summary.json
+
+Per-event records (jsonl):
+  {timestamp, event_type, source, payload}
+
+Summary (json):
+  {
+    duration_seconds,
+    start_count,
+    stop_count_signal,
+    stop_count_exit,
+    crash_count,
+    pid_set,
+    restart_cycles,  # observed start->stop->start within 90s
+    interpretation: "no_mid_session_sigterm" | "issue_40207_confirmed"
+                    | "inconclusive"
+  }
+
+## Decision rule
+
+  * 0 mid-session signals over the duration => issue #40207 does NOT
+    affect vanilla stdio servers; the FM-NEW-2 TCP-reuse path remains
+    cheap insurance, not a load-bearing mitigation.
+  * >=1 mid-session SIGTERM with restart cycles => confirmed; FM-NEW-2
+    is load-bearing and the spike work continues with the TCP-reuse
+    path enabled to verify it eliminates the T1 gap.
+  * Other => inconclusive; re-run with longer duration or document
+    the partial signal.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LOG_PATH = SCRIPT_DIR / "spike_rdr094_mid_session_log.jsonl"
+SUMMARY_PATH = SCRIPT_DIR / "spike_rdr094_mid_session_summary.json"
+
+MCP_LOG_PATH = Path(
+    os.environ.get(
+        "NEXUS_CONFIG_DIR",
+        os.path.expanduser("~/.config/nexus"),
+    )
+) / "logs" / "mcp.log"
+
+#: Lines emitted by lifecycle hooks (PR #286). Anchor patterns are
+#: substrings (KeyValueRenderer output is single-line).
+_PATTERN_STARTING = re.compile(r"event='mcp_server_starting'")
+_PATTERN_STOPPING = re.compile(
+    r"event='mcp_server_stopping'.*?reason='([^']+)'",
+)
+_PATTERN_CRASHED = re.compile(r"event='mcp_server_crashed'")
+_PATTERN_PID = re.compile(r"\bpid=(\d+)")
+
+#: Process-state poll cadence (seconds).
+PROC_POLL_S: float = 30.0
+
+#: Window inside which a stop-then-start counts as a restart cycle.
+RESTART_WINDOW_S: float = 90.0
+
+
+def _parse_log_line(line: str) -> dict[str, Any] | None:
+    """Return a {event_type, raw, fields} dict for nx-mcp events, or None."""
+    if _PATTERN_STARTING.search(line):
+        ev = "starting"
+    elif (m := _PATTERN_STOPPING.search(line)):
+        ev = f"stopping_{m.group(1)}"
+    elif _PATTERN_CRASHED.search(line):
+        ev = "crashed"
+    else:
+        return None
+    pid_match = _PATTERN_PID.search(line)
+    pid = int(pid_match.group(1)) if pid_match else 0
+    return {"event_type": ev, "pid": pid, "raw": line.rstrip()}
+
+
+def _list_nx_mcp_pids() -> list[tuple[int, int, int]]:
+    """Return [(pid, ppid, etime_s), ...] for every running nx-mcp.
+
+    Uses ``ps -e -o pid,ppid,etime,command`` and filters for the
+    nx-mcp command. etime is parsed best-effort; format is
+    ``[[dd-]hh:]mm:ss``.
+    """
+    try:
+        out = subprocess.check_output(
+            ["ps", "-e", "-o", "pid=,ppid=,etime=,command="],
+            text=True, timeout=2,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+            OSError):
+        return []
+    rows: list[tuple[int, int, int]] = []
+    for line in out.splitlines():
+        if "nx-mcp" not in line or "nx-mcp-catalog" in line:
+            # We track the core nx-mcp only. Catalog server is a
+            # separate subprocess and not the subject of #40207.
+            continue
+        parts = line.split(None, 3)
+        if len(parts) < 4:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        etime = _etime_seconds(parts[2])
+        rows.append((pid, ppid, etime))
+    return rows
+
+
+def _etime_seconds(s: str) -> int:
+    """Parse ps's etime format [[dd-]hh:]mm:ss into seconds."""
+    days = 0
+    if "-" in s:
+        d, s = s.split("-", 1)
+        days = int(d)
+    parts = s.split(":")
+    if len(parts) == 2:
+        h, m_s = "0", f"{parts[0]}:{parts[1]}"
+    else:
+        h = parts[0]
+        m_s = f"{parts[1]}:{parts[2]}"
+    m, sec = m_s.split(":")
+    return days * 86400 + int(h) * 3600 + int(m) * 60 + int(sec)
+
+
+def _follow_log(path: Path, stop_at: float) -> "Iterator[str]":
+    """Tail-f generator; yields every new line from path until stop_at.
+
+    Re-opens on rotation (RotatingFileHandler). Emits empty strings
+    on each idle poll so the consumer can check stop_at without
+    blocking on read().
+    """
+    pos = 0
+    last_inode = 0
+    while time.time() < stop_at:
+        try:
+            stat = path.stat()
+            if stat.st_ino != last_inode:
+                pos = 0
+                last_inode = stat.st_ino
+            with path.open("r") as f:
+                f.seek(pos)
+                chunk = f.read()
+                pos = f.tell()
+            if chunk:
+                for line in chunk.splitlines(keepends=False):
+                    yield line
+        except OSError:
+            pass
+        time.sleep(0.5)
+        yield ""
+
+
+def _emit(out, record: dict[str, Any]) -> None:
+    record["wallclock"] = time.time()
+    record["wallclock_iso"] = time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(record["wallclock"]),
+    )
+    out.write(json.dumps(record) + "\n")
+    out.flush()
+    print(json.dumps(record), flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="RDR-094 Spike C: mid-session SIGTERM observer.",
+    )
+    parser.add_argument(
+        "--duration-min", type=float, default=30.0,
+        help="Observation window in minutes (default 30).",
+    )
+    parser.add_argument(
+        "--proc-poll-s", type=float, default=PROC_POLL_S,
+        help=f"Seconds between process-state polls (default {PROC_POLL_S}).",
+    )
+    args = parser.parse_args()
+
+    duration_s = args.duration_min * 60.0
+    started = time.time()
+    deadline = started + duration_s
+    if not MCP_LOG_PATH.exists():
+        print(
+            f"WARNING: {MCP_LOG_PATH} does not exist yet. Will tail "
+            f"once nx-mcp creates it.",
+            file=sys.stderr,
+        )
+        MCP_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    print(
+        f"Observing for {args.duration_min:.1f} minutes. "
+        f"Tail: {MCP_LOG_PATH}; "
+        f"output: {LOG_PATH}",
+        flush=True,
+    )
+
+    summary = {
+        "started_at": started,
+        "duration_seconds": duration_s,
+        "start_count": 0,
+        "stop_count_signal": 0,
+        "stop_count_exit": 0,
+        "crash_count": 0,
+        "pid_set": [],
+        "restart_cycles": 0,
+        "interpretation": "inconclusive",
+    }
+    pid_seen: set[int] = set()
+    last_stop_at: float | None = None
+    last_proc_poll = 0.0
+
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_PATH.open("a") as out:
+        _emit(out, {
+            "event_type": "observer_started",
+            "duration_min": args.duration_min,
+        })
+
+        for line in _follow_log(MCP_LOG_PATH, deadline):
+            if line:
+                parsed = _parse_log_line(line)
+                if parsed:
+                    _emit(out, {
+                        "event_type": "mcp_event",
+                        "subtype": parsed["event_type"],
+                        "pid": parsed["pid"],
+                        "raw": parsed["raw"],
+                    })
+                    if parsed["event_type"] == "starting":
+                        summary["start_count"] += 1
+                        if last_stop_at is not None:
+                            gap = time.time() - last_stop_at
+                            if gap < RESTART_WINDOW_S:
+                                summary["restart_cycles"] += 1
+                                _emit(out, {
+                                    "event_type": "restart_cycle",
+                                    "gap_seconds": round(gap, 2),
+                                })
+                        if parsed["pid"]:
+                            pid_seen.add(parsed["pid"])
+                    elif parsed["event_type"] == "stopping_signal":
+                        summary["stop_count_signal"] += 1
+                        last_stop_at = time.time()
+                    elif parsed["event_type"] == "stopping_exit":
+                        summary["stop_count_exit"] += 1
+                        last_stop_at = time.time()
+                    elif parsed["event_type"] == "crashed":
+                        summary["crash_count"] += 1
+
+            now = time.time()
+            if now - last_proc_poll >= args.proc_poll_s:
+                last_proc_poll = now
+                rows = _list_nx_mcp_pids()
+                _emit(out, {
+                    "event_type": "proc_poll",
+                    "nx_mcp_count": len(rows),
+                    "details": [
+                        {"pid": p, "ppid": pp, "etime_s": e}
+                        for p, pp, e in rows
+                    ],
+                })
+
+        _emit(out, {"event_type": "observer_stopped"})
+
+    summary["pid_set"] = sorted(pid_seen)
+    summary["actual_duration_s"] = round(time.time() - started, 1)
+
+    # Decision rule.
+    if summary["stop_count_signal"] >= 1 and summary["restart_cycles"] >= 1:
+        summary["interpretation"] = "issue_40207_confirmed"
+    elif summary["stop_count_signal"] == 0 and summary["start_count"] >= 1:
+        summary["interpretation"] = "no_mid_session_sigterm"
+    else:
+        summary["interpretation"] = "inconclusive"
+
+    SUMMARY_PATH.write_text(json.dumps(summary, indent=2))
+    print("\n=== SUMMARY ===")
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

PR #291 left the `claude_crash` phase (FM-NEW-1, issue #1935) as "manual operator setup" and Spike C (issue #40207 mid-session SIGTERM) as "30-min idle Claude session" with no script. Both are now runnable.

## What changed

### `scripts/spikes/spike_rdr094_lifecycle.py`

`claude_crash` runs end-to-end via an intermediate "fake claude" process:

1. Intermediate process spawns nx-mcp with `NEXUS_MCP_OWNS_T1=1`.
2. Writes its own PID + nx-mcp's PID to a handoff file.
3. Sleeps until killed.

Because nx-mcp's PPID is the intermediate, `find_claude_root_pid` falls back to that PPID even though the intermediate is named `python` rather than `claude`. The watchdog gets `--claude-pid` pointing at the intermediate.

The harness then SIGKILLs the intermediate (simulates Claude Code crash), waits `CLEANUP_TIMEOUT_S=10s`, and asserts whether chroma was cleaned. Expected: dual-watch watchdog (claude-pid trigger) sends SIGTERM to mcp_pid, lifespan finally runs, chroma exits within ~7s.

Default `--phases` now runs all four: `clean,mcp_sigkill,mcp_oom,claude_crash`.

### `scripts/spikes/spike_rdr094_mid_session_observer.py` (new)

Tails `~/.config/nexus/logs/mcp.log` alongside a real Claude Code session and detects whether Claude Code's MCP client sends mid-session SIGTERM (issue #40207). The probe is collaborative because the trigger lives inside Claude Code itself.

Workflow:

```
# Terminal 1
uv run python scripts/spikes/spike_rdr094_mid_session_observer.py --duration-min 30

# Terminal 2
NEXUS_MCP_OWNS_T1=1 claude
# leave idle for 30 minutes
```

Detects:
- `mcp_server_starting` (= fresh nx-mcp spawn)
- `mcp_server_stopping reason='signal'` (mid-session SIGTERM/SIGINT)
- `mcp_server_crashed` (lifespan didn't fire)
- Restart cycles: stop -> start within 90s

Polls `ps -e` every 30s for nx-mcp processes; PID churn from restart cycles is visible alongside log events.

Decision rule:
- 0 signals + >=1 start => `no_mid_session_sigterm`
- >=1 SIGTERM + >=1 restart cycle => `issue_40207_confirmed`
- otherwise => `inconclusive`

Output: `spike_rdr094_mid_session_log.jsonl` + `spike_rdr094_mid_session_summary.json`.

## How to run the full evidence pass

```
scripts/reinstall-tool.sh

# Lifecycle probe (~10-15 min, $0 API):
NEXUS_MCP_OWNS_T1=1 uv run python \
    scripts/spikes/spike_rdr094_lifecycle.py --runs 10

# Spike C in two terminals:
uv run python scripts/spikes/spike_rdr094_mid_session_observer.py \
    --duration-min 30 &
NEXUS_MCP_OWNS_T1=1 claude
```

## Verification

- Both scripts' `--help` parse cleanly.
- `uv run pytest tests/test_doctor_cmd.py tests/test_session.py tests/test_hooks.py tests/test_t1_watchdog.py tests/test_mcp_chroma_lifecycle.py` -> 136 passed.

## Test plan

- [x] CLI parses on both spike scripts.
- [x] Targeted regression: 136 pass.
- [ ] CI green on this PR.
- [ ] Operator runs the spikes (next step after merge).