### PR TITLE
fix(cli): break the torch-import chain on cold start, halve nx wall

### DIFF
--- a/src/nexus/db/__init__.py
+++ b/src/nexus/db/__init__.py
@@ -10,11 +10,24 @@ tests can pass a fake client without hitting ChromaDB Cloud.
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from nexus.config import get_credential
-from nexus.db.t3 import T3Database
+
+if TYPE_CHECKING:
+    # Type-only import. T3Database transitively pulls voyageai ->
+    # transformers -> torch at module load. With this import at
+    # runtime, every `from nexus.db.<sub> import ...` triggers
+    # nexus.db.__init__ which fires the torch import (multi-second).
+    # The CLI hits this path via nexus.cli -> nexus.commands.catalog
+    # -> nexus.catalog.catalog -> nexus.catalog.catalog_db ->
+    # `from nexus.db.t2 import _sanitize_fts5`. Lazy-loading the
+    # T3Database import inside make_t3() removes torch from the cold-
+    # start cost of `nx <subcommand>` invocations.
+    from nexus.db.t3 import T3Database
 
 
-def make_t3(*, _client=None, _ef_override=None) -> T3Database:
+def make_t3(*, _client=None, _ef_override=None) -> "T3Database":
     """Return a :class:`T3Database` built from the current credentials.
 
     In local mode (``is_local_mode()`` returns True), returns a T3Database
@@ -32,6 +45,9 @@ def make_t3(*, _client=None, _ef_override=None) -> T3Database:
       ``DefaultEmbeddingFunction()``) to avoid Voyage AI API calls.
     """
     from nexus.config import is_local_mode, load_config, _default_local_path
+    # Runtime import of T3Database (was moved out of module-scope to
+    # break the eager torch-import chain during CLI startup).
+    from nexus.db.t3 import T3Database
 
     if is_local_mode() and _client is None:
         from nexus.db.local_ef import LocalEmbeddingFunction

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -18,7 +18,14 @@ from chromadb.errors import (
 )
 import structlog
 
-import voyageai
+# voyageai is imported lazily inside ``__init__`` only when cloud mode
+# is selected. The eager import here was pulling
+# voyageai -> langchain_text_splitters -> transformers -> torch
+# (multi-second cold start) into every CLI invocation through the
+# nexus.commands.store -> nexus.db.t3 chain. Type annotations using
+# ``voyageai.Client`` are stringified by ``from __future__ import
+# annotations`` at the top of this file so the lazy import does not
+# break static type checkers.
 
 from nexus.config import get_credential
 from nexus.corpus import embedding_model_for_collection, index_model_for_collection
@@ -227,10 +234,18 @@ class T3Database:
             return
 
         # ── Cloud mode ───────────────────────────────────────────────────
-        self._voyage_client: voyageai.Client | None = (
-            voyageai.Client(api_key=voyage_api_key, timeout=read_timeout_seconds, max_retries=0)
-            if voyage_api_key else None
-        )
+        # Lazy voyageai import: only loaded when cloud mode is actually
+        # used (the eager top-level import was multi-second cold-start
+        # cost on every CLI invocation through the indirect import chain).
+        if voyage_api_key:
+            import voyageai  # noqa: PLC0415
+            self._voyage_client = voyageai.Client(
+                api_key=voyage_api_key,
+                timeout=read_timeout_seconds,
+                max_retries=0,
+            )
+        else:
+            self._voyage_client = None
         if _client is not None:
             self._client = _client
         else:

--- a/src/nexus/retry.py
+++ b/src/nexus/retry.py
@@ -146,24 +146,40 @@ def _chroma_with_retry(
 
 
 # ── Voyage AI transient-error retry ──────────────────────────────────────────
+#
+# voyageai.error is imported lazily by ``_get_voyage_error_types()`` rather
+# than at module load. The eager import was pulling
+# voyageai -> langchain_text_splitters -> transformers -> torch into every
+# CLI invocation that touches retry.py (which is the entire indexer / scoring
+# / pipeline_stages graph). Lazy-init keeps ``nx <subcommand>`` cold-start
+# free of torch.
 
-import voyageai.error as _voyageai_error
+_VOYAGE_ERROR_TYPES: tuple[type, ...] | None = None
 
-#: Voyage errors we handle in ``_voyage_with_retry``. All transient classes
-#: are listed — ``voyageai.Client`` is constructed with ``max_retries=0`` at
-#: every nexus call site, so this wrapper is the sole retry authority and
-#: every retry decision surfaces through ``_log.warning`` (nexus-vatx Gap 1).
-#:
-#: Excluded: ``AuthenticationError``, ``InvalidRequestError``,
-#: ``MalformedRequestError`` (user/config errors — never transient).
-_VOYAGE_ERROR_TYPES: tuple[type, ...] = (
-    _voyageai_error.APIConnectionError,
-    _voyageai_error.TryAgain,
-    _voyageai_error.RateLimitError,
-    _voyageai_error.ServiceUnavailableError,
-    _voyageai_error.ServerError,
-    _voyageai_error.Timeout,
-)
+
+def _get_voyage_error_types() -> tuple[type, ...]:
+    """Return the voyage-error tuple, importing voyageai.error on first use.
+
+    All transient classes are listed; ``voyageai.Client`` is constructed
+    with ``max_retries=0`` at every nexus call site, so this wrapper is
+    the sole retry authority and every retry decision surfaces through
+    ``_log.warning`` (nexus-vatx Gap 1).
+
+    Excluded: ``AuthenticationError``, ``InvalidRequestError``,
+    ``MalformedRequestError`` (user/config errors, never transient).
+    """
+    global _VOYAGE_ERROR_TYPES
+    if _VOYAGE_ERROR_TYPES is None:
+        import voyageai.error as _voyageai_error  # noqa: PLC0415
+        _VOYAGE_ERROR_TYPES = (
+            _voyageai_error.APIConnectionError,
+            _voyageai_error.TryAgain,
+            _voyageai_error.RateLimitError,
+            _voyageai_error.ServiceUnavailableError,
+            _voyageai_error.ServerError,
+            _voyageai_error.Timeout,
+        )
+    return _VOYAGE_ERROR_TYPES
 
 
 def _is_retryable_voyage_error(exc: BaseException) -> bool:
@@ -175,7 +191,7 @@ def _is_retryable_voyage_error(exc: BaseException) -> bool:
     stalled." The two error spaces are disjoint; do not add Voyage AI types
     to :func:`_is_retryable_chroma_error`.
     """
-    return isinstance(exc, _VOYAGE_ERROR_TYPES)
+    return isinstance(exc, _get_voyage_error_types())
 
 
 def _voyage_with_retry(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,28 @@ def pytest_configure(config):
 
 
 @pytest.fixture(autouse=True)
+def _restore_structlog_after_test():
+    """Save and restore structlog config around every test so any test
+    that calls ``structlog.configure(...)`` (directly or via
+    ``nexus.logging_setup.configure_logging``) does not leak its
+    config to downstream tests.
+
+    Background: tests that swap ``logger_factory`` from the default
+    ``PrintLoggerFactory`` to ``LoggerFactory(stdlib)`` reroute every
+    structlog event from stderr to stdlib logging. ``capsys``-based
+    assertions in unrelated tests then read empty strings while the
+    event sits in caplog. The originally-affected test was
+    ``test_plan_audit_logs_warning_on_clamp``, which fails when run
+    after any test that pollutes structlog. Solving it per-file via
+    individual autouse fixtures drifted; a global one is cheap and
+    closes the door for new tests too.
+    """
+    saved = structlog.get_config()
+    yield
+    structlog.configure(**saved)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Redirect T1 SESSIONS_DIR so tests never discover real live server records.
 

--- a/tests/test_voyage_retry.py
+++ b/tests/test_voyage_retry.py
@@ -190,7 +190,9 @@ def test_retry_warn_log_fires_on_backoff(capsys) -> None:
 
 def test_t3_database_voyage_client_has_timeout() -> None:
     from nexus.db.t3 import T3Database
-    with patch("nexus.db.t3.voyageai.Client") as mock_ctor:
+    # Patch the voyageai module directly; nexus.db.t3 imports it lazily
+    # inside __init__ now (cold-start fix that breaks the torch chain).
+    with patch("voyageai.Client") as mock_ctor:
         mock_ctor.return_value = MagicMock()
         T3Database(voyage_api_key="test-key", read_timeout_seconds=60.0, _client=MagicMock())
         mock_ctor.assert_called_once_with(api_key="test-key", timeout=60.0, max_retries=0)
@@ -245,7 +247,13 @@ def test_retry_at_call_site(test_id: str) -> None:
         mock_voyage.contextualized_embed.side_effect = [
             _ve.APIConnectionError("down"), _make_cce_success(),
         ]
-        with patch("nexus.db.t3.voyageai.Client", return_value=mock_voyage), \
+        # Patch the voyageai module directly. The previous patch target
+        # was ``nexus.db.t3.voyageai.Client`` which depended on
+        # ``import voyageai`` being at module scope of ``nexus.db.t3``.
+        # That import is now lazy (loaded inside __init__) to break the
+        # CLI-cold-start torch chain, so the patch routes via the real
+        # voyageai module instead.
+        with patch("voyageai.Client", return_value=mock_voyage), \
              patch("nexus.retry.time.sleep"):
             db = T3Database(voyage_api_key="test-key", _client=MagicMock())
             result = db._cce_embed("hello world")


### PR DESCRIPTION
## Summary

User reported `nx <subcommand>` hanging on cold start. Traceback bottomed out in `import torch`. Root cause: a chain of eager top-level imports loaded `voyageai -> langchain -> transformers -> torch` on every CLI invocation, regardless of which subcommand was asked for.

```
nexus.cli
  -> nexus.commands.collection
  -> nexus.commands.store
  -> nexus.db.t3 (top-level: ``import voyageai``)
  -> voyageai.chunking
  -> langchain_text_splitters
  -> transformers
  -> torch    # multi-second cold load
```

Plus a parallel chain through `nexus.db.__init__` and `nexus.retry`.

## Cold-start measurement

| | Before | After |
|--|--|--|
| `time (nx --version)` wall | 2.33s | 1.08s |
| torch/transformers modules loaded | 750 | 0 |
| voyageai modules loaded | 25 | 1 (chromadb shim only) |

## What changed

- `src/nexus/db/__init__.py`: move `from nexus.db.t3 import T3Database` from module scope into `make_t3()`. `TYPE_CHECKING` re-import for the type annotation only.
- `src/nexus/db/t3.py`: move `import voyageai` from module scope into `__init__` only when `voyage_api_key` is set (cloud mode). `from __future__ import annotations` keeps the type hint string-based.
- `src/nexus/retry.py`: defer `import voyageai.error` to a lazy `_get_voyage_error_types()` helper that builds `_VOYAGE_ERROR_TYPES` on first call.
- `tests/conftest.py`: new autouse `_restore_structlog_after_test` fixture saves/restores `structlog.get_config()` around every test. Prevents `LoggerFactory(stdlib)` set by one test from leaking into capsys-based assertions in downstream tests. Was an order-dependent failure on `test_plan_audit_logs_warning_on_clamp` after `test_doctor_cmd.py`.
- `tests/test_voyage_retry.py`: two patch targets updated from `nexus.db.t3.voyageai.Client` -> `voyageai.Client` (voyageai no longer at module scope of nexus.db.t3).

## Regression

```
uv run pytest tests/test_voyage_retry.py tests/test_session.py \
    tests/test_hooks.py tests/test_doctor_cmd.py \
    tests/test_t1_watchdog.py tests/test_mcp_chroma_lifecycle.py \
    tests/test_logging_setup.py tests/test_mcp_package.py \
    tests/test_silent_error_logging.py tests/test_structlog_events.py \
    tests/test_nx_answer.py

298 passed, 1 skipped in 58.46s
```

All 21 originally-broken tests in PR #286 CI run plus the `test_plan_audit_logs_warning_on_clamp` ordering issue are green.

## Test plan

- [x] Local: 298 pass on the affected surface.
- [x] Cold-start time roughly halved (~2x improvement) confirmed on developer install.
- [x] `nx doctor --check-tmpdirs --json` returns valid JSON.
- [ ] CI green on this PR.