### PR TITLE
fix(cli): defer sklearn/scipy/numpy from nexus.db.t2 import surface

### DIFF
--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -55,35 +55,73 @@ extend the tier.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import sqlite3
 
 import structlog
 
-from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
-from nexus.db.t2.chash_index import ChashIndex
-from nexus.db.t2.memory_store import (
-    AccessPolicy,
-    MemoryStore,
-    _sanitize_fts5,  # re-exported for nexus.catalog.catalog_db
-)
-from nexus.db.t2.plan_library import PlanLibrary
-from nexus.db.t2.telemetry import Telemetry
+# Cheap import only: ``_sanitize_fts5`` is needed by
+# ``nexus.catalog.catalog_db`` at module import time, and the
+# memory_store module's top-level imports are stdlib + structlog only
+# (no sklearn/scipy/numpy). Heavy submodule imports are deferred via
+# the module __getattr__ at the bottom of this file.
+from nexus.db.t2.memory_store import _sanitize_fts5
+
+if TYPE_CHECKING:
+    # Type-only: re-exposed for static type checking. The runtime
+    # bindings come from ``__getattr__`` below, which lazy-loads each
+    # submodule on first attribute access. The CLI cold-start path
+    # (nexus.cli -> nexus.commands.catalog -> nexus.catalog.catalog ->
+    # nexus.catalog.catalog_db -> from nexus.db.t2 import _sanitize_fts5)
+    # therefore stops here without pulling sklearn -> scipy -> numpy
+    # via CatalogTaxonomy.
+    from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
+    from nexus.db.t2.chash_index import ChashIndex
+    from nexus.db.t2.memory_store import AccessPolicy, MemoryStore
+    from nexus.db.t2.plan_library import PlanLibrary
+    from nexus.db.t2.telemetry import Telemetry
 
 _log = structlog.get_logger()
 
-# Re-export for backward compatibility — ``catalog/catalog_db.py`` and
-# ``tests/test_t2.py`` still ``from nexus.db.t2 import _sanitize_fts5``.
+# Re-export surface for backward compatibility. Resolution happens
+# lazily through the module-level ``__getattr__`` below; the eager
+# imports were pulling sklearn/scipy/numpy through CatalogTaxonomy on
+# every CLI invocation that touched any nexus.db.t2 symbol.
 __all__ = [
     "AccessPolicy",
     "CatalogTaxonomy",
+    "ChashIndex",
     "MemoryStore",
     "PlanLibrary",
     "T2Database",
     "Telemetry",
     "_sanitize_fts5",
 ]
+
+
+def __getattr__(name: str) -> Any:  # PEP 562
+    """Lazy resolver for heavy re-exports.
+
+    Map each public name to its owning submodule and import on demand.
+    Only fires the first time a name is accessed (Python caches the
+    attribute on the module after a successful resolve).
+    """
+    _MAP = {
+        "AccessPolicy":     "nexus.db.t2.memory_store",
+        "MemoryStore":      "nexus.db.t2.memory_store",
+        "CatalogTaxonomy":  "nexus.db.t2.catalog_taxonomy",
+        "ChashIndex":       "nexus.db.t2.chash_index",
+        "PlanLibrary":      "nexus.db.t2.plan_library",
+        "Telemetry":        "nexus.db.t2.telemetry",
+    }
+    if name in _MAP:
+        import importlib
+        mod = importlib.import_module(_MAP[name])
+        value = getattr(mod, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # ── Database facade ───────────────────────────────────────────────────────────
@@ -100,6 +138,16 @@ class T2Database:
     """
 
     def __init__(self, path: Path) -> None:
+        # Lazy-load the four store classes here rather than at module
+        # import time so the CLI cold-start path (which only needs
+        # ``_sanitize_fts5``) does not pull sklearn/scipy/numpy through
+        # CatalogTaxonomy.
+        from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
+        from nexus.db.t2.chash_index import ChashIndex
+        from nexus.db.t2.memory_store import MemoryStore
+        from nexus.db.t2.plan_library import PlanLibrary
+        from nexus.db.t2.telemetry import Telemetry
+
         path.parent.mkdir(parents=True, exist_ok=True)
 
         # ── Transient connection: run pending migrations (RDR-076) ────


### PR DESCRIPTION
## Summary

Second torch-style import-chain leak after PR #293. User hit a CLI hang again with a different bottom-of-stack:

```
nexus.cli
  -> nexus.commands.catalog
  -> nexus.catalog.catalog
  -> nexus.catalog.catalog_db: from nexus.db.t2 import _sanitize_fts5
  -> nexus.db.t2.__init__:64: from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
  -> nexus.db.t2.catalog_taxonomy:46: from sklearn.cluster import HDBSCAN
  -> sklearn -> scipy -> numpy
```

`_sanitize_fts5` is the only symbol the CLI cold-start needs from `nexus.db.t2`, but the `__init__` re-exported four heavy stores eagerly. Any import from the package fired all of them.

## Fix

`src/nexus/db/t2/__init__.py`:

- Top-level imports trimmed to just `_sanitize_fts5` (memory_store is stdlib + structlog only).
- `TYPE_CHECKING` block keeps the type re-exports for static checkers.
- Module-level `__getattr__` (PEP 562) lazy-resolves CatalogTaxonomy / ChashIndex / MemoryStore / PlanLibrary / Telemetry / AccessPolicy on first attribute access. Python caches the resolved attribute so subsequent reads are zero-cost.
- `T2Database.__init__` lazy-imports the store classes inside the constructor body. Same construction-time cost.

Existing call sites `from nexus.db.t2 import CatalogTaxonomy` (etc.) work unchanged — they hit the `__getattr__` resolver.

## Cold-start measurement

| | After #293 only | After #293 + this PR |
|--|--|--|
| `nx --version` wall | 1.08s | **0.31s** |
| total imported modules | 3757 | **946** |
| sklearn/scipy modules | many | **0** |

Combined improvement vs the original CLI hang (PR #286 baseline): **7x faster** (2.33s -> 0.31s) on this install.

## Regression

```
uv run pytest tests/test_voyage_retry.py tests/test_session.py \
    tests/test_hooks.py tests/test_doctor_cmd.py \
    tests/test_t1_watchdog.py tests/test_mcp_chroma_lifecycle.py \
    tests/test_logging_setup.py tests/test_mcp_package.py \
    tests/test_silent_error_logging.py tests/test_structlog_events.py \
    tests/test_nx_answer.py tests/test_t2.py tests/test_taxonomy.py

506 passed, 1 skipped in 68.25s
```

`tests/test_t2.py` + `tests/test_taxonomy.py` exercise the `__getattr__` lazy path implicitly via real construction calls.

## Test plan

- [x] Local: 506 pass on the affected surface.
- [x] Cold-start measured: 0.31s.
- [x] `nx doctor --check-tmpdirs --json` still works.
- [ ] CI green on this PR.