### PR TITLE
gate(rdr-094): in-place fixes for 1 CRITICAL + 2 SIGNIFICANT — PASSED

### DIFF
--- a/docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md
+++ b/docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md
@@ -219,12 +219,33 @@ exist as a stable per-session subprocess to inherit from.
       knowledge__nexus 9f1c77b683a9f429.
 - [ ] Moving chroma spawn from the SessionStart hook to MCP-server
       startup does not regress subagent T1 sharing. **Status**:
-      Unverified. **Method**: integration test dispatching a subagent
-      chain and asserting scratch read/write across the tree.
-      Note: not exercised by Spike A; subagent path is structurally
-      identical to the top-level path through the `nested=True`
-      short-circuit and the existing `find_ancestor_session` walk.
-      Worth a focused integration test before Phase 4 flag removal.
+      Unverified (Spike B scope). **Hard prerequisite for Phase 4
+      flag removal.** **Method**: integration test dispatching a
+      subagent chain and asserting scratch read/write across the
+      tree.
+
+      **Specific race the spike must rule out** (substantive-critic
+      finding, 2026-04-25): the new code path has one structural
+      difference vs the hook-era code that warrants direct
+      verification. The hook writes the session record synchronously
+      before any subagent dispatch. The MCP server's lifespan is
+      async and may not have completed the
+      `write_session_record_by_id` call by the time Claude Code
+      dispatches the first subagent. If a subagent observes
+      `NX_SESSION_ID` set but the parent's session record absent,
+      its `_t1_chroma_init_if_owner` falls through the ancestor-
+      record check, lands on `_resolve_top_level_session_id`, which
+      reads `current_session`. If that's also unwritten at that
+      moment, the subagent gets `own_id = None` and skips spawn
+      entirely (silent EphemeralClient downgrade with no log
+      that would identify the cause).
+
+      Spike B protocol: dispatch a subagent within milliseconds of
+      top-level MCP startup (before
+      `write_session_record_by_id` completes); assert the
+      subagent's T1 client connects to the parent's chroma. If the
+      race is reproducible, add a retry-with-backoff loop in
+      `_resolve_top_level_session_id` before Phase 4 lands.
 - [x] The dual-watch watchdog (`--mcp-pid` + `--claude-pid` with
       OR-trigger logic) preserves coverage of BOTH the "MCP dies
       without atexit firing" case AND the "Claude Code crashes and
@@ -578,15 +599,22 @@ async def _t1_chroma_lifespan(_app):
     try:
         yield
     finally:
-        _t1_chroma_shutdown()      # PRIMARY cleanup path
+        _t1_chroma_shutdown()      # PRIMARY on HTTP/SSE
+                                   # (anyio cancels task group on SIGTERM
+                                   #  there); skipped on stdio because
+                                   #  anyio does not install a SIGTERM
+                                   #  handler under the stdio transport.
 
 mcp = FastMCP("nexus", lifespan=_t1_chroma_lifespan)
 
 main():
     configure_logging("mcp")
-    atexit.register(_t1_chroma_shutdown)              # SECONDARY
-    signal.signal(SIGTERM, _sigterm_handler)          # SECONDARY
-    signal.signal(SIGINT, _sigterm_handler)           # SECONDARY
+    atexit.register(_t1_chroma_shutdown)              # BELT-AND-BRACES
+    signal.signal(SIGTERM, _sigterm_handler)          # PRIMARY on stdio
+    signal.signal(SIGINT, _sigterm_handler)           # PRIMARY on stdio
+    # Spike A 2026-04-25 evidence: 10/10 SIGTERM cycles on stdio
+    # attributed to `mcp_owned_signal` path. atexit covers clean
+    # stdin EOF + SystemExit paths that arrive without a signal.
     log.info("mcp_server_starting", server="nx-mcp")
     try:
         mcp.run(transport="stdio")
@@ -986,15 +1014,30 @@ crash failure mode that issue #1935 documents.
 
 #### Step 2: Split `hooks.session_end` into `session_end_flush`
 
-Extract scratch-flush + memory-expire into a new function. The
-chroma-stop path is conditional on MCP ownership: if MCP owns,
-skip; if hook-era ownership (fallback), run.
+**Status: deferred to a pre-Phase-4 follow-up bead.** Extract
+scratch-flush + memory-expire into a new function and retire the
+chroma-stop block from the hook entirely. Tracked separately
+because the in-place gate below is sufficient for Phase 1+2+3 to
+ship behind the flag without the double-stop race.
+
+**In-place mitigation that landed in PR #289 follow-up**:
+`hooks.session_end()` checks `NEXUS_MCP_OWNS_T1` and skips its
+chroma-stop block when the flag is active. The MCP server's
+shutdown path (signal handler / lifespan / atexit) owns chroma
+cleanup exclusively under the flag. The hook still flushes scratch
+and runs memory-expire, which are hook-native tasks unaffected by
+chroma ownership.
 
 #### Step 3: Update `nx/hooks/hooks.json`
 
-SessionEnd command swaps `nx-session-end-launcher` for
-`nx hook session-end-flush`. Timeout reduced from 5s to 3s (flush
-is sub-second).
+**Status: deferred to a pre-Phase-4 follow-up bead.** SessionEnd
+command swaps `nx-session-end-launcher` for `nx hook session-end-
+flush` and timeout reduces from 5s to 3s. Currently the launcher
+still wires through and runs the gated `session_end()` (Step 2
+mitigation above keeps the chroma-stop side of that call inert
+under the flag), so functional correctness holds; the hook just
+runs more code than it needs to. Phase 4 cannot retire the
+launcher cleanly until both Step 2 and Step 3 land.
 
 ### Phase 3: Tmpdir-scan sweep + one-time cleanup
 
@@ -1010,9 +1053,54 @@ Clean up the 10 orphan tmpdirs from 2026-04-23. One-shot.
 
 ### Phase 4: Feature-flag removal
 
-After Phase 1–3 land and one release of canary evidence, remove
-`NEXUS_MCP_OWNS_T1` gate. MCP-owned chroma becomes the default
-path. Hook-era chroma-spawn block deleted from `session_start()`.
+Phase 4 is gated on three prerequisites, not just code-level flag
+removal:
+
+1. **Spike B (CA-2 subagent T1 sharing) verified.** This is a hard
+   prerequisite. The specific race the spike must rule out: a
+   subagent dispatched within milliseconds of the top-level MCP
+   server starting can observe `NX_SESSION_ID` set but the parent's
+   session record not yet written by `write_session_record_by_id`
+   (the MCP lifespan is async and may not have completed by the
+   time Claude Code dispatches the first subagent). If the
+   subagent's `_t1_chroma_init_if_owner` falls through the
+   ancestor-record check it lands on `_resolve_top_level_session_id`
+   which reads `current_session`. If `current_session` is also
+   unwritten at that moment, `own_id = None` and the subagent has
+   no T1 at all (silent EphemeralClient downgrade). This race is
+   absent in the hook-based code because the hook writes the
+   session record synchronously. Spike B test: dispatch a subagent
+   within milliseconds of MCP startup; assert subagent's T1 is
+   connected to the parent's chroma. If the race is reproducible,
+   add a retry loop in the subagent's session resolution path
+   before Phase 4 lands.
+2. **Phase 2 Steps 2 + 3 shipped.** `session_end_flush` split,
+   hooks.json swapped from `nx-session-end-launcher` to `nx hook
+   session-end-flush`, and `_session_end_launcher.py` unwired (it
+   stays in the codebase as fallback code but no hook references
+   it). Without these, Phase 4 cannot cleanly remove the
+   `NEXUS_MCP_OWNS_T1` gate inside `session_end()`.
+3. **One release cycle of canary evidence under the flag.** Operators
+   running with `NEXUS_MCP_OWNS_T1=1` for at least one full release
+   without observable regressions (orphan chroma, T1 unavailable
+   warnings, watchdog mis-fires). Spike A + C cover the ~5 min
+   workload; canary covers the long-tail of real-world session
+   shapes.
+
+When all three are met, Phase 4 lands:
+
+- Remove `NEXUS_MCP_OWNS_T1` conditionals in `src/nexus/mcp/core.py`
+  (module-scope flag check + main() registrations) and
+  `src/nexus/hooks.py` (session_start chroma-spawn skip,
+  session_end chroma-stop skip).
+- Delete the hook-era chroma-spawn block from `session_start()`.
+- Retire `nx-session-end-launcher` from hooks.json (Phase 2 Step 3
+  prerequisite).
+- Update RDR-094 to record Phase 4 as complete.
+
+The TCP-probe-and-reuse path in `_t1_chroma_init_if_owner` stays
+(Spike C cleared CA-4 negative; the path is cheap insurance against
+future Claude Code behaviour changes).
 
 ### Day 2 Operations
 

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -256,7 +256,18 @@ def session_end() -> str:
         _log.warning("session_end: storage error during flush/expire", error=str(exc))
 
     # Stop server and clean up only if this process owns the session.
-    if own_record and own_file is not None:
+    # Skip the chroma-stop block when NEXUS_MCP_OWNS_T1 is active: the
+    # MCP server's signal handler / lifespan / atexit owns shutdown,
+    # and a hook-side stop_t1_server + tmpdir-rm here races MCP's own
+    # cleanup. The flag-on path is chroma-owned-by-MCP exclusively;
+    # this hook degrades to scratch-flush + memory-expire only (which
+    # already ran above). RDR-094 Phase 2 Step 2's session_end_flush
+    # split is deferred to a follow-up bead; this gate is the in-place
+    # mitigation that prevents the double-stop in the meantime.
+    mcp_owns_t1 = os.environ.get(
+        "NEXUS_MCP_OWNS_T1", "",
+    ).strip().lower() in ("1", "true", "yes")
+    if own_record and own_file is not None and not mcp_owns_t1:
         server_pid = own_record.get("server_pid", 0)
         if server_pid:
             stop_t1_server(server_pid)

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -41,19 +41,31 @@ from nexus.ttl import parse_ttl
 #
 # Phase 1 + Phase 2 of RDR-094 land here under the NEXUS_MCP_OWNS_T1 flag.
 # When set, this module:
-#   1. Spawns chroma in the FastMCP lifespan __aenter__ (primary cleanup
-#      via async finally in the lifespan exit). The hook's chroma-spawn
-#      block becomes a no-op (gated on the same env flag in hooks.py).
-#   2. Registers atexit + SIGTERM/SIGINT handlers as belt-and-braces for
-#      kill paths where lifespan does not fire (research RQ2).
-#   3. Spawns the watchdog with both --mcp-pid and --claude-pid so the
+#   1. Spawns chroma in the FastMCP lifespan __aenter__. Three cleanup
+#      paths run on shutdown, all calling the same idempotent
+#      _t1_chroma_shutdown:
+#        * signal handler (SIGTERM/SIGINT) -- PRIMARY on stdio transport
+#          (Spike A 2026-04-25: 10/10 SIGTERM cycles on stdio attributed
+#          to mcp_owned_signal). anyio does not install a SIGTERM
+#          handler under FastMCP stdio, so the explicit handler IS the
+#          path that runs.
+#        * lifespan async finally -- PRIMARY on HTTP/SSE transports.
+#          anyio installs SIGTERM there and propagates cancellation
+#          through async finally. Skipped on stdio (no anyio handler).
+#        * atexit -- belt-and-braces for clean stdin EOF / SystemExit
+#          paths that arrive without a signal.
+#      The hook's chroma-spawn block becomes a no-op (gated on the same
+#      env flag in hooks.py); the SessionEnd hook also skips its chroma-
+#      stop block under the flag (one-line gate in hooks.py:session_end).
+#   2. Spawns the watchdog with both --mcp-pid and --claude-pid so the
 #      Claude-crash-orphan failure mode (issue #1935, FM-NEW-1) is covered.
-#   4. TCP-probes any existing session record at startup; if reachable,
-#      reuses the existing chroma (FM-NEW-2 mitigation for the Claude Code
-#      issue #40207 mid-session SIGTERM-restart cycle).
+#   3. TCP-probes any existing session record at startup; if reachable,
+#      reuses the existing chroma (FM-NEW-2 mitigation; Spike C 2026-04-25
+#      cleared issue #40207 not applicable to nx-mcp, so this path is
+#      cheap insurance against future Claude Code behaviour changes).
 #
-# Default off. Existing installs see no behaviour change. Spike work flips
-# the flag to validate the design (RDR-094 §Critical Assumptions).
+# Default off. Existing installs see no behaviour change. Spike work
+# already validated CA-1, CA-3, CA-4 (RDR-094 §Critical Assumptions).
 
 import os as _os
 
@@ -260,12 +272,24 @@ from contextlib import asynccontextmanager
 async def _t1_chroma_lifespan(_app: Any):
     """FastMCP lifespan that owns chroma's lifecycle.
 
-    Primary cleanup path (research RQ2): anyio installs a SIGTERM
-    handler that cancels the running task group; cancellation
-    propagates through this ``async finally`` block so
+    Primary cleanup path on **HTTP / SSE transports**: anyio installs
+    a SIGTERM handler that cancels the running task group;
+    cancellation propagates through this ``async finally`` block so
     ``_t1_chroma_shutdown`` runs without a manual SIGTERM handler.
-    The atexit + signal handlers in ``main()`` are the secondary
-    path for kills where lifespan doesn't fire.
+
+    On **stdio transport** the lifespan ``async finally`` does NOT
+    fire under SIGTERM. anyio does not install a SIGTERM handler in
+    that mode (Spike A 2026-04-25 evidence: 10/10 SIGTERM cycles
+    attributed to ``mcp_owned_signal``, zero to lifespan). The
+    explicit signal handler registered in ``main()`` is the primary
+    cleanup path on stdio. The lifespan still runs on clean stdin
+    EOF (the ``async finally`` block fires when ``mcp.run()``
+    returns normally), which keeps the lifespan path live for
+    that exit shape.
+
+    ``_t1_chroma_shutdown`` is idempotent so any combination of
+    paths firing is safe: lifespan finally on HTTP/SSE, signal
+    handler on stdio SIGTERM, atexit on clean exit.
     """
     _t1_chroma_init_if_owner()
     try:


### PR DESCRIPTION
## Summary

`/nx:rdr-gate 094` substantive-critic verdict: partial PASS with 1 CRITICAL + 2 SIGNIFICANT findings, all fix-in-place per the RDR-088 / RDR-093 gate-fix protocol. All four recommendations applied here.

## CRITICAL: pseudocode label inversion contradicted §Approach + spike evidence

The §Technical Design pseudocode block, `_t1_chroma_lifespan` docstring, and module-level comment all labeled the lifespan as `PRIMARY` and signal handlers as `SECONDARY`. This directly contradicted the §Approach prose (correctly describing primary-by-transport) and Spike A evidence (10/10 stdio SIGTERM cycles attributed to `mcp_owned_signal`, zero to lifespan).

Fixed all three locations:

- signal handler PRIMARY on stdio (anyio doesn't install SIGTERM under stdio, the explicit handler IS the path that runs).
- lifespan PRIMARY on HTTP/SSE (anyio installs SIGTERM there, cancellation propagates through `async finally`).
- atexit always belt-and-braces for clean stdin EOF / SystemExit.

## SIGNIFICANT-1: CA-2 subagent T1 sharing race

Critic identified a specific race the original CA-2 entry did not acknowledge: a subagent dispatched within milliseconds of MCP startup may observe `NX_SESSION_ID` set but the parent's session record not yet written. The subagent's `_t1_chroma_init_if_owner` falls through both the ancestor-record check and the `current_session` fallback if both are unwritten at that moment, returning `own_id = None` and silently downgrading to EphemeralClient with no log.

CA-2 entry strengthened to mark Spike B as a HARD prerequisite for Phase 4 flag removal, with the specific race protocol documented. Recommended retry-with-backoff loop if reproducible.

## SIGNIFICANT-2: Phase 2 Steps 2+3 not shipped

PR #289's commit message claimed "Phase 1+2" but two of three Phase 2 steps are missing: `session_end_flush` split + `hooks.json` swap.

**In-place mitigation landed here**: `hooks.py:session_end()` now gates the chroma-stop block on `NEXUS_MCP_OWNS_T1`, so the hook's `stop_t1_server` + `tmpdir-rm` doesn't race the MCP server's own lifecycle cleanup under the flag. Sufficient to ship Phase 1+2+3 cleanly behind the flag without the full split.

RDR §Phase 2 sections marked deferred to a pre-Phase-4 bead. §Phase 4 rewritten to enumerate three hard prerequisites (Spike B, Phase 2 steps, canary release) instead of "Phase 1-3 land then remove flag."

## Files

- `docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md`: pseudocode + CA-2 + Phase 2 + Phase 4 updates; em-dash sweep (1 → 0).
- `src/nexus/mcp/core.py`: module-level comment + `_t1_chroma_lifespan` docstring updated.
- `src/nexus/hooks.py`: `NEXUS_MCP_OWNS_T1` gate added in `session_end()` chroma-stop block.

## Verification

```
uv run pytest tests/test_hooks.py tests/test_session.py tests/test_mcp_chroma_lifecycle.py
73 passed in 2.56s
```

## Gate verdict

**PASSED.** T2 record: `nexus_rdr/094-gate-latest` (id=978).

`/nx:rdr-accept 094` ready to run after merge.

## Test plan

- [x] Local: 73 pass on the affected surface.
- [x] Em-dash check: 0 in the RDR.
- [ ] CI green on this PR.