### PR TITLE
fix(rdr-094): observer filter pre-existing log entries (nexus-5rea)

### DIFF
--- a/scripts/spikes/spike_rdr094_mid_session_observer.py
+++ b/scripts/spikes/spike_rdr094_mid_session_observer.py
@@ -72,6 +72,7 @@ Summary (json):
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import json
 import os
 import re
@@ -101,6 +102,12 @@ _PATTERN_STOPPING = re.compile(
 )
 _PATTERN_CRASHED = re.compile(r"event='mcp_server_crashed'")
 _PATTERN_PID = re.compile(r"\bpid=(\d+)")
+#: Structlog ``TimeStamper(fmt='iso', utc=True)`` field. Used to skip
+#: log entries that predate the observer start so historical content
+#: in mcp.log isn't replayed as if it occurred during the window
+#: (the original Spike C run mis-classified pre-existing entries as
+#: +0.0s mcp_events because pos was initialised to 0).
+_PATTERN_EVENT_TIMESTAMP = re.compile(r"timestamp='([^']+)'")
 
 #: Process-state poll cadence (seconds).
 PROC_POLL_S: float = 30.0
@@ -109,8 +116,25 @@ PROC_POLL_S: float = 30.0
 RESTART_WINDOW_S: float = 90.0
 
 
+def _extract_event_timestamp(line: str) -> float | None:
+    """Return epoch seconds from the structlog ``timestamp=...`` field, or None.
+
+    The MCP server's structlog chain emits ``timestamp='<ISO>'`` via
+    ``TimeStamper(fmt='iso', utc=True)``. Both ``Z`` and ``+00:00``
+    suffixes are accepted; missing or malformed fields return None.
+    """
+    m = _PATTERN_EVENT_TIMESTAMP.search(line)
+    if not m:
+        return None
+    raw = m.group(1).replace("Z", "+00:00")
+    try:
+        return _dt.datetime.fromisoformat(raw).timestamp()
+    except ValueError:
+        return None
+
+
 def _parse_log_line(line: str) -> dict[str, Any] | None:
-    """Return a {event_type, raw, fields} dict for nx-mcp events, or None."""
+    """Return a {event_type, pid, event_ts, raw} dict for nx-mcp events, or None."""
     if _PATTERN_STARTING.search(line):
         ev = "starting"
     elif (m := _PATTERN_STOPPING.search(line)):
@@ -121,7 +145,25 @@ def _parse_log_line(line: str) -> dict[str, Any] | None:
         return None
     pid_match = _PATTERN_PID.search(line)
     pid = int(pid_match.group(1)) if pid_match else 0
-    return {"event_type": ev, "pid": pid, "raw": line.rstrip()}
+    return {
+        "event_type": ev,
+        "pid": pid,
+        "event_ts": _extract_event_timestamp(line),
+        "raw": line.rstrip(),
+    }
+
+
+def _is_historical(parsed: dict[str, Any], observer_started: float) -> bool:
+    """True if the parsed event's structlog timestamp predates the observer.
+
+    Entries without a parseable ``timestamp=...`` field are NOT classified
+    as historical: better to over-emit one event with a missing timestamp
+    than to silently drop live activity.
+    """
+    ts = parsed.get("event_ts")
+    if ts is None:
+        return False
+    return ts < observer_started
 
 
 def _list_nx_mcp_pids() -> list[tuple[int, int, int]]:
@@ -269,6 +311,10 @@ def main() -> int:
         for line in _follow_log(MCP_LOG_PATH, deadline):
             if line:
                 parsed = _parse_log_line(line)
+                if parsed and _is_historical(parsed, started):
+                    # Pre-existing mcp.log content; do not replay as if
+                    # it occurred during the observation window.
+                    parsed = None
                 if parsed:
                     _emit(out, {
                         "event_type": "mcp_event",

--- a/tests/test_spike_rdr094_observer.py
+++ b/tests/test_spike_rdr094_observer.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Deterministic unit tests for the RDR-094 Spike C observer.
+
+The observer (``scripts/spikes/spike_rdr094_mid_session_observer.py``) tails
+``mcp.log`` for the lifecycle events emitted by ``nexus.mcp.core``. The
+original implementation seeked from byte 0 on startup, replaying every
+historical entry as if it had just occurred. This test pins the
+timestamp-filter fix per nexus-5rea acceptance criteria.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SPIKE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "spikes"
+    / "spike_rdr094_mid_session_observer.py"
+)
+
+
+@pytest.fixture(scope="module")
+def observer():
+    spec = importlib.util.spec_from_file_location("spike_rdr094_obs", _SPIKE_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["spike_rdr094_obs"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _epoch(year: int, month: int, day: int, hour: int = 0) -> float:
+    return _dt.datetime(year, month, day, hour, tzinfo=_dt.timezone.utc).timestamp()
+
+
+def test_extract_event_timestamp_iso_z(observer):
+    line = (
+        "2026-04-25 17:31:00 nexus INFO event='mcp_server_starting' "
+        "timestamp='2026-04-25T17:31:00.500000Z' level='info' pid=42"
+    )
+    expected = _dt.datetime(
+        2026, 4, 25, 17, 31, 0, 500000, tzinfo=_dt.timezone.utc
+    ).timestamp()
+    assert observer._extract_event_timestamp(line) == pytest.approx(expected)
+
+
+def test_extract_event_timestamp_iso_offset(observer):
+    line = "event='x' timestamp='2026-04-25T17:31:00.123456+00:00' pid=1"
+    expected = _dt.datetime(
+        2026, 4, 25, 17, 31, 0, 123456, tzinfo=_dt.timezone.utc
+    ).timestamp()
+    assert observer._extract_event_timestamp(line) == pytest.approx(expected)
+
+
+def test_extract_event_timestamp_missing_returns_none(observer):
+    assert observer._extract_event_timestamp("no timestamp anywhere") is None
+
+
+def test_extract_event_timestamp_malformed_returns_none(observer):
+    assert observer._extract_event_timestamp("timestamp='not-a-date'") is None
+
+
+def test_parse_log_line_includes_event_ts(observer):
+    line = (
+        "2026-04-25 17:31:00 nexus INFO event='mcp_server_starting' "
+        "timestamp='2026-04-25T17:31:00Z' level='info' pid=42"
+    )
+    parsed = observer._parse_log_line(line)
+    assert parsed is not None
+    assert parsed["event_type"] == "starting"
+    assert parsed["pid"] == 42
+    assert parsed["event_ts"] is not None
+
+
+def test_parse_log_line_no_event_marker_returns_none(observer):
+    assert observer._parse_log_line("plain stdlib log line, no event field") is None
+
+
+def test_parse_log_line_stopping_extracts_reason(observer):
+    line = (
+        "event='mcp_server_stopping' timestamp='2026-04-25T17:31:00Z' "
+        "level='info' reason='signal' pid=42"
+    )
+    parsed = observer._parse_log_line(line)
+    assert parsed is not None
+    assert parsed["event_type"] == "stopping_signal"
+
+
+def test_is_historical_skips_pre_observer_entries(observer):
+    started = _epoch(2026, 4, 25, 12)
+    parsed = {"event_ts": _epoch(2020, 1, 1)}
+    assert observer._is_historical(parsed, started) is True
+
+
+def test_is_historical_passes_post_observer_entries(observer):
+    started = _epoch(2026, 4, 25, 12)
+    parsed = {"event_ts": _epoch(2026, 4, 25, 13)}
+    assert observer._is_historical(parsed, started) is False
+
+
+def test_is_historical_passes_when_timestamp_unparseable(observer):
+    """No timestamp -> err on the side of processing rather than dropping."""
+    started = _epoch(2026, 4, 25, 12)
+    assert observer._is_historical({"event_ts": None}, started) is False
+
+
+def test_historical_entries_are_filtered_in_a_seeded_log(observer):
+    """End-to-end on the parse+filter path without spawning the tail loop.
+
+    Seeds two raw log lines: one historical, one current. Verifies the
+    main-loop predicate (`_is_historical`) correctly partitions them.
+    """
+    started = _epoch(2026, 4, 25, 12)
+
+    historical = (
+        "2020-01-01 00:00:00 nexus INFO event='mcp_server_starting' "
+        "timestamp='2020-01-01T00:00:00Z' level='info' pid=111"
+    )
+    current = (
+        "2026-04-25 12:01:00 nexus INFO event='mcp_server_starting' "
+        "timestamp='2026-04-25T12:01:00Z' level='info' pid=222"
+    )
+
+    parsed_old = observer._parse_log_line(historical)
+    parsed_new = observer._parse_log_line(current)
+    assert parsed_old is not None and parsed_new is not None
+    assert observer._is_historical(parsed_old, started) is True
+    assert observer._is_historical(parsed_new, started) is False


### PR DESCRIPTION
## Summary

The Spike C observer (`scripts/spikes/spike_rdr094_mid_session_observer.py`) initialised its tail position to byte 0 on startup, replaying every pre-existing entry in `mcp.log` as if it had occurred during the observation window. That produced false `+0.0s` `mcp_events` and spurious `restart_cycle` classifications, contaminating Spike C's CA-4 evidence run.

**Fix**: filter each parsed event by comparing the structlog `timestamp=` field against the observer's start time. This is robust against log rotation (the alternative seek-to-EOF approach loses entries written between rotation and the seek call). Lines without a parseable timestamp are processed normally rather than dropped, so we err toward over-emission rather than silent loss.

## Implementation

- New helper `_extract_event_timestamp(line)` parses the structlog `timestamp='<ISO>'` field. Accepts both `Z` and `+00:00` suffixes; returns None on missing/malformed.
- `_parse_log_line(line)` now includes `event_ts` (epoch seconds or None).
- New helper `_is_historical(parsed, observer_started)` — single-purpose predicate, easy to unit-test.
- Main loop short-circuits to `parsed = None` when `_is_historical` is true, so the silent skip is one branch.

## Test plan

- [x] `tests/test_spike_rdr094_observer.py` (11 tests, all deterministic, 0.05s):
  - `_extract_event_timestamp` accepts ISO-Z, ISO offset; returns None on missing/malformed input
  - `_parse_log_line` populates `event_ts` and still extracts `pid` + `event_type` correctly
  - `_is_historical` returns True for pre-observer timestamps, False for post-observer, False for None (over-emit policy)
  - End-to-end seeded scenario: historical entry filtered, current entry passes
- [x] No em dashes in modified files
- [x] No `git add -A`; explicit paths only

## Closes

Closes nexus-5rea (RDR-094 Phase A: Fix Spike C observer historical-replay bug).