### PR TITLE
feat(rdr-094): wire t1_watchdog logging to watchdog.log (nexus-aqna)

### DIFF
--- a/src/nexus/logging_setup.py
+++ b/src/nexus/logging_setup.py
@@ -43,7 +43,7 @@ def _resolve_level(mode: str, verbose: bool) -> int:
 
 
 def configure_logging(
-    mode: Literal["cli", "console", "mcp", "hook"],
+    mode: Literal["cli", "console", "mcp", "hook", "watchdog"],
     verbose: bool = False,
 ) -> None:
     """Configure logging for the given nexus entry point.
@@ -58,9 +58,10 @@ def configure_logging(
     Modes:
       * ``cli``: stderr only, WARNING default. Kept legacy-compatible so
         the human-facing CLI does not gain noise from this change.
-      * ``console`` / ``mcp`` / ``hook``: stderr + RotatingFileHandler at
-        ``<config_dir>/logs/<mode>.log``, INFO default. Lifecycle events,
-        tool dispatches, and structured warnings now land in the log file.
+      * ``console`` / ``mcp`` / ``hook`` / ``watchdog``: stderr +
+        RotatingFileHandler at ``<config_dir>/logs/<mode>.log``, INFO
+        default. Lifecycle events, tool dispatches, and structured
+        warnings now land in the log file.
 
     The level is overridable via the ``NEXUS_LOG_LEVEL`` env var; useful
     for one-off DEBUG runs without code changes.

--- a/src/nexus/t1_watchdog.py
+++ b/src/nexus/t1_watchdog.py
@@ -29,6 +29,10 @@ import sys
 import time
 from pathlib import Path
 
+import structlog
+
+from nexus.logging_setup import configure_logging
+
 #: Seconds between liveness checks. Trade-off: lower value means faster
 #: reap when Claude Code dies; higher value means less CPU. 5s keeps
 #: the observable leak window small without adding meaningful load.
@@ -140,38 +144,67 @@ def main(argv: list[str] | None = None) -> int:
                         help="ChromaDB tmpdir to remove on cleanup.")
     args = parser.parse_args(argv)
 
+    configure_logging("watchdog")
+    log = structlog.get_logger("nexus.t1_watchdog")
+
     session_file = Path(args.session_file) if args.session_file else None
     tmpdir = Path(args.tmpdir) if args.tmpdir else None
     dual_watch = args.mcp_pid > 0
 
+    log.info(
+        "watchdog_started",
+        claude_pid=args.claude_pid,
+        chroma_pid=args.chroma_pid,
+        mcp_pid=args.mcp_pid,
+        dual_watch=dual_watch,
+        poll_interval_s=POLL_INTERVAL,
+    )
+
     while True:
         time.sleep(POLL_INTERVAL)
+        log.debug(
+            "poll_tick",
+            chroma_pid=args.chroma_pid,
+            claude_pid=args.claude_pid,
+            mcp_pid=args.mcp_pid,
+        )
         # Chroma crashed or was stopped by some other path (lifespan,
         # atexit, SessionEnd in legacy mode) -- nothing to watch
         # anymore. Exit silently; whoever stopped chroma owns the
         # on-disk cleanup.
         if not _is_alive(args.chroma_pid):
+            log.info(
+                "watchdog_exiting",
+                reason="chroma_died_externally",
+                chroma_pid=args.chroma_pid,
+            )
             return 0
         # Dual-watch mode (RDR-094 FM-NEW-1): MCP server died without
         # its lifespan/atexit firing (SIGKILL, segfault). Clean chroma
         # directly via the chroma-pgrp belt-and-braces path.
         if dual_watch and not _is_alive(args.mcp_pid):
+            log.info("mcp_pid_disappeared", mcp_pid=args.mcp_pid)
             break
         # Claude Code is gone.
         if not _is_alive(args.claude_pid):
+            log.info("claude_pid_disappeared", claude_pid=args.claude_pid)
             # Dual-watch + Claude crash: signal mcp_pid first so its
             # lifespan finally runs (cleans chroma cleanly), then fall
             # through to the chroma-pgrp belt-and-braces in case the
             # MCP server's finally is wedged or already ran.
             if dual_watch and _is_alive(args.mcp_pid):
+                log.info("signalling_mcp_pid", mcp_pid=args.mcp_pid)
                 _signal_then_kill(args.mcp_pid)
             break
 
+    log.info("chroma_cleanup_started", chroma_pid=args.chroma_pid)
     _cleanup(
         chroma_pid=args.chroma_pid,
         session_file=session_file,
         tmpdir=tmpdir,
     )
+    log.info("chroma_cleanup_complete", chroma_pid=args.chroma_pid)
+    log.info("watchdog_exiting", reason="cleanup_complete")
     return 0
 
 

--- a/tests/test_t1_watchdog.py
+++ b/tests/test_t1_watchdog.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import os
 from unittest.mock import patch
 
+import pytest
+import structlog
+
 
 # ── _is_alive ─────────────────────────────────────────────────────────────────
 
@@ -288,3 +291,199 @@ class TestDualWatch:
         sigs = {s for _, s in kills}
         assert _signal.SIGTERM in sigs
         assert _signal.SIGKILL in sigs
+
+
+# ── Lifecycle logging (RDR-094 Phase G / nexus-aqna) ─────────────────────────
+
+
+@pytest.fixture
+def captured_events(monkeypatch):
+    """Capture every structlog event emitted by t1_watchdog.
+
+    Routes ``structlog.get_logger("nexus.t1_watchdog")`` to a recording
+    bound logger so tests can assert on event names + kwargs without
+    touching the real RotatingFileHandler. The ``configure_logging``
+    call inside ``main()`` is also stubbed so it does not reset the
+    capture wrapper.
+    """
+    events: list[dict] = []
+
+    def _capture_processor(logger, method_name, event_dict):
+        events.append({"_method": method_name, **event_dict})
+        raise structlog.DropEvent
+
+    structlog.configure(
+        processors=[_capture_processor],
+        wrapper_class=structlog.make_filtering_bound_logger(0),  # DEBUG
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=False,
+    )
+
+    from nexus import t1_watchdog
+
+    monkeypatch.setattr(t1_watchdog, "configure_logging", lambda _mode: None)
+    return events
+
+
+class TestLifecycleLogging:
+    """The watchdog must emit structlog events at every lifecycle
+    transition so Spike B (Phase D) and the Phase E canary can attribute
+    chroma cleanups to the right trigger."""
+
+    def test_emits_watchdog_started_with_pid_args(
+        self, monkeypatch, tmp_path, captured_events,
+    ):
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(t1_watchdog, "_is_alive", lambda pid: False)
+
+        t1_watchdog.main([
+            "--claude-pid", "100",
+            "--chroma-pid", "200",
+            "--mcp-pid", "300",
+            "--session-file", str(tmp_path / "s.session"),
+            "--tmpdir", str(tmp_path / "tmpdir"),
+        ])
+
+        started = next(
+            e for e in captured_events if e.get("event") == "watchdog_started"
+        )
+        assert started["claude_pid"] == 100
+        assert started["chroma_pid"] == 200
+        assert started["mcp_pid"] == 300
+        assert started["dual_watch"] is True
+
+    def test_chroma_dies_externally_path_emits_exit_event(
+        self, monkeypatch, tmp_path, captured_events,
+    ):
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(t1_watchdog, "_is_alive", lambda pid: False)
+
+        with patch.object(t1_watchdog, "_cleanup") as mock_cleanup:
+            t1_watchdog.main([
+                "--claude-pid", "100", "--chroma-pid", "200",
+                "--session-file", str(tmp_path / "s"),
+                "--tmpdir", str(tmp_path / "td"),
+            ])
+
+        mock_cleanup.assert_not_called()
+        exit_events = [
+            e for e in captured_events if e.get("event") == "watchdog_exiting"
+        ]
+        assert len(exit_events) == 1
+        assert exit_events[0]["reason"] == "chroma_died_externally"
+
+    def test_mcp_pid_disappeared_path_logs_full_sequence(
+        self, monkeypatch, tmp_path, captured_events,
+    ):
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+
+        def _alive(pid: int) -> bool:
+            return pid != 300  # mcp dead, others alive
+
+        monkeypatch.setattr(t1_watchdog, "_is_alive", _alive)
+        with patch.object(t1_watchdog, "_cleanup"):
+            t1_watchdog.main([
+                "--claude-pid", "100", "--chroma-pid", "200",
+                "--mcp-pid", "300",
+                "--session-file", str(tmp_path / "s"),
+                "--tmpdir", str(tmp_path / "td"),
+            ])
+
+        names = [e.get("event") for e in captured_events]
+        assert "watchdog_started" in names
+        assert "mcp_pid_disappeared" in names
+        assert "chroma_cleanup_started" in names
+        assert "chroma_cleanup_complete" in names
+        assert names.count("watchdog_exiting") == 1
+        # Ordering invariant: started → mcp_disappeared → cleanup_started
+        # → cleanup_complete → exiting.
+        assert names.index("mcp_pid_disappeared") < names.index(
+            "chroma_cleanup_started",
+        )
+        assert names.index("chroma_cleanup_started") < names.index(
+            "chroma_cleanup_complete",
+        )
+
+    def test_claude_pid_disappeared_path_logs_signal_then_cleanup(
+        self, monkeypatch, tmp_path, captured_events,
+    ):
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+
+        def _alive(pid: int) -> bool:
+            return pid != 100  # claude dead, mcp + chroma alive
+
+        monkeypatch.setattr(t1_watchdog, "_is_alive", _alive)
+        with patch.object(t1_watchdog, "_cleanup"), \
+             patch.object(t1_watchdog, "_signal_then_kill"):
+            t1_watchdog.main([
+                "--claude-pid", "100", "--chroma-pid", "200",
+                "--mcp-pid", "300",
+                "--session-file", str(tmp_path / "s"),
+                "--tmpdir", str(tmp_path / "td"),
+            ])
+
+        names = [e.get("event") for e in captured_events]
+        assert "claude_pid_disappeared" in names
+        assert "signalling_mcp_pid" in names
+        assert "chroma_cleanup_complete" in names
+
+    def test_single_watch_mode_does_not_emit_signalling_event(
+        self, monkeypatch, tmp_path, captured_events,
+    ):
+        """With no --mcp-pid, claude-death must skip the signalling step."""
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+
+        def _alive(pid: int) -> bool:
+            return pid == 200  # only chroma alive
+
+        monkeypatch.setattr(t1_watchdog, "_is_alive", _alive)
+        with patch.object(t1_watchdog, "_cleanup"):
+            t1_watchdog.main([
+                "--claude-pid", "100", "--chroma-pid", "200",
+                "--session-file", str(tmp_path / "s"),
+                "--tmpdir", str(tmp_path / "td"),
+            ])
+
+        names = [e.get("event") for e in captured_events]
+        assert "claude_pid_disappeared" in names
+        assert "signalling_mcp_pid" not in names
+
+
+class TestWatchdogLogConfiguration:
+    """``configure_logging('watchdog')`` must produce a real rotating
+    file handler at ``<config>/logs/watchdog.log``. We only check the
+    file appears + structlog events flow through; rotation is covered
+    by the stdlib RotatingFileHandler tests upstream."""
+
+    def test_watchdog_log_file_created_under_nexus_config_dir(
+        self, monkeypatch, tmp_path,
+    ):
+        cfg_dir = tmp_path / "nexus_config"
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(cfg_dir))
+
+        from nexus.logging_setup import configure_logging
+
+        configure_logging("watchdog")
+        log = structlog.get_logger("nexus.t1_watchdog")
+        log.info("watchdog_started", claude_pid=1, chroma_pid=2, mcp_pid=0)
+
+        # Force the handler to flush.
+        import logging
+        for h in logging.getLogger().handlers:
+            h.flush()
+
+        log_file = cfg_dir / "logs" / "watchdog.log"
+        assert log_file.exists()
+        body = log_file.read_text()
+        assert "watchdog_started" in body
+        assert "claude_pid=1" in body


### PR DESCRIPTION
## Summary

The T1 watchdog sidecar (`src/nexus/t1_watchdog.py`) was invisible: spawned with stdout/stderr redirected to DEVNULL and no persistent log surface. Spike A's 40-run cleanup evidence could not attribute *which* trigger fired (`--mcp-pid` death vs `--claude-pid` death), and Phase D's Spike B (subagent T1 sharing race / CA-2) cannot distinguish "watchdog cleaned chroma post-detection" from "watchdog never fired and chroma leaked".

This wires the watchdog into the same logging surface MCP/console/hook use (added in PR #286): structlog events route through the stdlib `RotatingFileHandler` at `~/.config/nexus/logs/watchdog.log` (10 MB, 5 backups, INFO default).

## Changes

- `nexus.logging_setup`: add `watchdog` to the `Literal[...]` mode list. Same INFO default + RotatingFileHandler as MCP.
- `nexus.t1_watchdog`: call `configure_logging('watchdog')` once at top of `main()`. Emit structlog events at every lifecycle transition:
  - `watchdog_started` — pid args + `dual_watch` flag + `poll_interval_s`
  - `poll_tick` — DEBUG, suppressed at INFO (visible via `NEXUS_LOG_LEVEL=DEBUG`)
  - `mcp_pid_disappeared` — RDR-094 FM-NEW-1 dual-watch trigger
  - `claude_pid_disappeared` + `signalling_mcp_pid` (dual-watch + claude-crash path)
  - `chroma_cleanup_started` / `chroma_cleanup_complete`
  - `watchdog_exiting` with `reason` (`chroma_died_externally` or `cleanup_complete`)

Hot-path import discipline preserved: `configure_logging` only pulls stdlib + structlog. `nexus.session.stop_t1_server` remains lazy-imported inside `_cleanup()`, so the poll loop pays no `nexus.*` import cost.

## Test plan

- [x] `tests/test_t1_watchdog.py` grows from 14 to 20 (0.06s):
  - `TestLifecycleLogging` asserts each exit path emits the expected event sequence and ordering
  - `TestWatchdogLogConfiguration` writes to a real `RotatingFileHandler` under a `tmp_path` `NEXUS_CONFIG_DIR` and asserts the file appears with the structlog event in the body
  - Capture fixture stubs `configure_logging` inside `main()` so per-test capture wrappers aren't reset
- [x] Affected modules sweep (logging_setup, session, mcp_chroma_lifecycle, session_end_launcher, silent_error_logging, mcp_server, mcp_package, mcp_concurrency): 180 tests pass
- [x] No em dashes in additions
- [x] Hot-path import audit: only stdlib + structlog at module level

## Closes

Closes nexus-aqna (RDR-094 Phase G: Wire t1_watchdog logging to watchdog.log).