### PR TITLE
feat(rdr-094): add stdio_pipe_break phase to spike harness (nexus-sawb)

### DIFF
--- a/scripts/spikes/spike_rdr094_lifecycle.py
+++ b/scripts/spikes/spike_rdr094_lifecycle.py
@@ -3,7 +3,7 @@
 """RDR-094 Critical Assumption #1 + #3 lifecycle probe.
 
 Spike A from RDR-094 §Implementation Plan > Prerequisites. Validates
-the chroma-cleanup completion rate by source for four phases:
+the chroma-cleanup completion rate by source for five phases:
 
   1. Clean shutdown via SIGTERM to nx-mcp.
        Expect: FastMCP lifespan finally fires (anyio cancellation
@@ -28,6 +28,22 @@ the chroma-cleanup completion rate by source for four phases:
        SIGTERM to mcp_pid, mcp's lifespan finally runs, chroma exits
        within MCP_GRACE_SECS=2s + POLL_INTERVAL=5s.
        Target: claude-crash path covers >=95% of runs.
+
+  5. stdio pipe break (nexus-sawb / fifth failure mode).
+       The harness closes nx-mcp's stdin abruptly without sending any
+       signal. Tests the silent-death pattern observed 2026-04-25
+       (nx-mcp pid 94433 went idle for 25 minutes with NO
+       mcp_server_stopping AND NO mcp_server_crashed event). Lifespan
+       finally + signal handlers + atexit are all bypassed if the
+       stdio reader hangs on EOF.
+       Expect: dual-watch watchdog (--mcp-pid trigger) catches the
+       mcp_pid death and cleans chroma. cleanup_path of
+       ``watchdog_mcp`` (crash event recorded) or ``watchdog_unknown``
+       (no mcp lifecycle event at all) signals the fifth mode is
+       reachable; ``mcp_owned_lifespan`` would mean stdin EOF cleanly
+       drove lifespan and the wild observation has another root cause.
+       Target: chroma cleanup at 100% (any path acceptable for now;
+       the diagnostic is which path).
 
 Each run records: phase, run_id, mcp_pid, chroma_pid, signal sent,
 chroma_alive_after_grace (bool), cleanup_path (one of: lifespan,
@@ -246,6 +262,18 @@ def _classify_cleanup_path(
     if signal_sent in ("SIGKILL", "SIGSEGV"):
         # Direct kill; lifespan + signal handler bypassed.
         return "watchdog_mcp"
+    if signal_sent == "stdin_close":
+        # Phase 5 (nexus-sawb): no signal delivered. saw_signal_stop is
+        # impossible by construction. saw_clean_exit means the stdio
+        # EOF reached lifespan finally cleanly; saw_crash means anyio
+        # raised through to the crash hook. No event with chroma dead
+        # is the "fifth-mode" silent-death signature: watchdog cleaned
+        # chroma without any mcp lifecycle event at all.
+        if saw_clean_exit:
+            return "mcp_owned_lifespan"
+        if saw_crash:
+            return "watchdog_mcp"
+        return "watchdog_unknown"
     # SIGTERM phase. If the signal-stop event made it to the log,
     # nx-mcp's signal handler ran (mcp-owned). If only the clean-
     # exit event fired (rare on stdio), it's the lifespan path.
@@ -551,6 +579,88 @@ def _run_phase_claude_crash(run_id: int) -> RunRecord:
     )
 
 
+def _run_phase_stdio_pipe_break(run_id: int) -> RunRecord:
+    """Phase 5 (nexus-sawb): close nx-mcp's stdin without any signal.
+
+    Tests the fifth failure mode observed 2026-04-25 (nx-mcp pid 94433
+    went silent for 25 minutes with NO mcp_server_stopping and NO
+    mcp_server_crashed events). The hypothesis is that Claude Code's
+    MCP client broke the stdio pipe rather than delivering SIGTERM,
+    so the FastMCP stdio reader hit EOF and either exited cleanly
+    via lifespan (which would mean the wild observation has a
+    different root cause) or hung silently (only the watchdog's
+    --mcp-pid trigger catches it).
+
+    Steps:
+      1. Spawn nx-mcp the same way the other phases do.
+      2. Wait for chroma to come up.
+      3. ``proc.stdin.close()`` -- no signal sent.
+      4. Wait CLEANUP_TIMEOUT_S; classify the cleanup path.
+      5. Belt-and-braces SIGKILL of any leak so the next run starts clean.
+    """
+    log_start = _log_size()
+    proc = _spawn_nx_mcp()
+    chroma_pid = _wait_for_chroma_pid(SPAWN_TIMEOUT_S)
+    if chroma_pid is None:
+        try:
+            proc.kill()
+            proc.wait(timeout=2)
+        except Exception:
+            pass
+        return RunRecord(
+            phase="stdio_pipe_break", run_id=run_id, mcp_pid=proc.pid,
+            chroma_pid=0, signal_sent="stdin_close",
+            chroma_alive_after_grace=False, cleanup_path="setup_failed",
+            elapsed_until_cleanup_s=0.0, setup_failed=True,
+            error="chroma_pid not observed within SPAWN_TIMEOUT_S",
+        )
+
+    t0 = time.monotonic()
+    if proc.stdin is not None:
+        try:
+            proc.stdin.close()
+        except OSError:
+            pass
+
+    # Wait for either lifespan-driven exit OR watchdog --mcp-pid trigger.
+    # CLEANUP_TIMEOUT_S = 10s covers the 5s poll + 2s grace + slack.
+    try:
+        proc.wait(timeout=CLEANUP_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        # nx-mcp didn't exit on its own: stdio handler is wedged on
+        # EOF. The watchdog still cleans chroma when we SIGKILL below
+        # so the next run starts clean; the "no exit on stdin EOF"
+        # signal is captured in chroma_alive_after_grace + cleanup_path.
+        pass
+
+    elapsed = time.monotonic() - t0
+    chroma_alive = _is_alive(chroma_pid)
+    log_lines = _read_log_tail_after(log_start)
+    cleanup_path = _classify_cleanup_path(
+        log_lines, chroma_alive, "stdin_close",
+    )
+    if chroma_alive:
+        try:
+            os.kill(chroma_pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    if _is_alive(proc.pid):
+        try:
+            proc.kill()
+            proc.wait(timeout=2)
+        except Exception:
+            pass
+    return RunRecord(
+        phase="stdio_pipe_break", run_id=run_id, mcp_pid=proc.pid,
+        chroma_pid=chroma_pid,
+        signal_sent="stdin_close",
+        chroma_alive_after_grace=chroma_alive,
+        cleanup_path=cleanup_path,
+        elapsed_until_cleanup_s=round(elapsed, 2),
+        setup_failed=False, error=None,
+    )
+
+
 def _aggregate(records: list[RunRecord]) -> dict[str, Any]:
     by_phase: dict[str, list[RunRecord]] = {}
     for r in records:
@@ -611,10 +721,11 @@ def main() -> int:
     )
     parser.add_argument(
         "--phases", type=str,
-        default="clean,mcp_sigkill,mcp_oom,claude_crash",
+        default="clean,mcp_sigkill,mcp_oom,claude_crash,stdio_pipe_break",
         help=(
-            "Comma-separated phase list. Default runs all four. "
-            "Use --phases clean for a quick lifespan-only smoke."
+            "Comma-separated phase list. Default runs all five. "
+            "Use --phases clean for a quick lifespan-only smoke; "
+            "use --phases stdio_pipe_break for the fifth-mode probe."
         ),
     )
     parser.add_argument(
@@ -666,6 +777,8 @@ def main() -> int:
                     rec = _run_phase_kill(run_id, signal.SIGSEGV, "mcp_oom")
                 elif phase == "claude_crash":
                     rec = _run_phase_claude_crash(run_id)
+                elif phase == "stdio_pipe_break":
+                    rec = _run_phase_stdio_pipe_break(run_id)
                 else:
                     print(f"unknown phase: {phase}", file=sys.stderr)
                     continue

--- a/tests/test_spike_rdr094_lifecycle.py
+++ b/tests/test_spike_rdr094_lifecycle.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Deterministic tests for the RDR-094 Spike A lifecycle harness.
+
+The harness itself spawns real subprocesses, so end-to-end exercise is
+out of scope for unit tests (10-run evidence is collected by Hal on
+demand and appended to T2 ``nexus_rdr/094-spike-a-lifecycle``). What we
+*can* pin here are the pure-python pieces that classify cleanup paths
+and the phase dispatch wiring -- the parts that decide whether a real
+run counts as ``mcp_owned_lifespan`` vs ``watchdog_mcp`` vs
+``watchdog_unknown`` for the new fifth-mode probe (nexus-sawb).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SPIKE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "spikes"
+    / "spike_rdr094_lifecycle.py"
+)
+
+
+@pytest.fixture(scope="module")
+def harness():
+    spec = importlib.util.spec_from_file_location("spike_rdr094_a", _SPIKE_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["spike_rdr094_a"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── _classify_cleanup_path: stdin_close branch (Phase 5 / nexus-sawb) ────────
+
+
+class TestClassifyStdinClose:
+    """The fifth-mode probe needs three discriminations:
+
+    * ``mcp_owned_lifespan`` -- stdin EOF cleanly drove the lifespan
+      finally; the wild silent-death observation has another root cause.
+    * ``watchdog_mcp`` -- nx-mcp crashed, watchdog cleaned chroma; the
+      crash event signature confirms FastMCP's reader raised on EOF.
+    * ``watchdog_unknown`` -- chroma is dead but no mcp lifecycle event
+      ever fired. This is the fifth-mode silent-death signature.
+    """
+
+    def test_clean_exit_event_classifies_as_lifespan(self, harness):
+        log_lines = [
+            "2026-04-25 17:31:00 nx INFO event='mcp_server_stopping' "
+            "reason='exit' pid=42",
+        ]
+        path = harness._classify_cleanup_path(
+            log_lines, chroma_alive=False, signal_sent="stdin_close",
+        )
+        assert path == "mcp_owned_lifespan"
+
+    def test_crash_event_classifies_as_watchdog_mcp(self, harness):
+        log_lines = [
+            "2026-04-25 17:31:00 nx ERROR event='mcp_server_crashed' pid=42",
+        ]
+        path = harness._classify_cleanup_path(
+            log_lines, chroma_alive=False, signal_sent="stdin_close",
+        )
+        assert path == "watchdog_mcp"
+
+    def test_no_event_with_chroma_dead_is_silent_fifth_mode(self, harness):
+        """The fifth-mode signature: chroma dead, no mcp lifecycle event."""
+        path = harness._classify_cleanup_path(
+            [], chroma_alive=False, signal_sent="stdin_close",
+        )
+        assert path == "watchdog_unknown"
+
+    def test_chroma_alive_means_none_path(self, harness):
+        """Regression sentinel: chroma still alive => cleanup didn't run."""
+        path = harness._classify_cleanup_path(
+            [], chroma_alive=True, signal_sent="stdin_close",
+        )
+        assert path == "none"
+
+    def test_signal_stop_event_is_impossible_for_stdin_close(self, harness):
+        """No signal was delivered, so any 'reason=signal' event in the
+        log must be from a prior run that didn't get cleaned up. Our
+        branch does not consider it; saw_clean_exit / saw_crash drive
+        the verdict."""
+        log_lines = [
+            "old: event='mcp_server_stopping' reason='signal' pid=999",
+            "event='mcp_server_stopping' reason='exit' pid=42",
+        ]
+        # Clean-exit event in the same window classifies as lifespan
+        # despite the stale signal-stop entry.
+        path = harness._classify_cleanup_path(
+            log_lines, chroma_alive=False, signal_sent="stdin_close",
+        )
+        assert path == "mcp_owned_lifespan"
+
+
+# ── Existing classify branches: regression sentinel ──────────────────────────
+
+
+class TestClassifyExistingBranches:
+    """Pin the classify_cleanup_path behaviour for the four pre-existing
+    phases so the new branch addition does not perturb them."""
+
+    def test_sigterm_with_signal_stop_event(self, harness):
+        log_lines = [
+            "event='mcp_server_stopping' reason='signal' pid=42",
+        ]
+        path = harness._classify_cleanup_path(
+            log_lines, chroma_alive=False, signal_sent="SIGTERM",
+        )
+        assert path == "mcp_owned_signal"
+
+    def test_sigkill_classifies_as_watchdog_mcp(self, harness):
+        path = harness._classify_cleanup_path(
+            [], chroma_alive=False, signal_sent="SIGKILL",
+        )
+        assert path == "watchdog_mcp"
+
+    def test_harness_sigkill_classifies_as_watchdog_claude(self, harness):
+        path = harness._classify_cleanup_path(
+            [], chroma_alive=False, signal_sent="harness_SIGKILL",
+        )
+        assert path == "watchdog_claude"
+
+
+# ── Phase dispatcher wiring ──────────────────────────────────────────────────
+
+
+class TestPhaseRegistration:
+    """Verify the new phase is wired into both the default --phases list
+    and the main() dispatcher branch."""
+
+    def test_stdio_pipe_break_in_default_phase_list(self, harness):
+        """Default --phases must include stdio_pipe_break so a no-arg
+        invocation runs the fifth-mode probe alongside the other four."""
+        source = _SPIKE_PATH.read_text()
+        assert 'default="clean,mcp_sigkill,mcp_oom,claude_crash,stdio_pipe_break"' in source
+
+    def test_run_phase_function_exists(self, harness):
+        assert hasattr(harness, "_run_phase_stdio_pipe_break")
+        assert callable(harness._run_phase_stdio_pipe_break)
+
+    def test_dispatcher_routes_phase_name(self, harness):
+        """main()'s dispatcher must have a branch for stdio_pipe_break."""
+        source = _SPIKE_PATH.read_text()
+        assert 'phase == "stdio_pipe_break"' in source
+        assert "_run_phase_stdio_pipe_break(run_id)" in source


### PR DESCRIPTION
## Summary

Spike A's four-phase harness (clean / mcp_sigkill / mcp_oom / claude_crash) did not exercise a fifth failure mode observed in the wild on 2026-04-25: nx-mcp pid 94433 went silent for 25 minutes with **no** \`mcp_server_stopping\` and **no** \`mcp_server_crashed\` event. atexit did not run, signal handlers did not run. Likely cause: stdio pipe break from Claude Code's MCP client (client SIGKILL'd the server without delivering SIGTERM, or the stdio buffer broke during a tool response).

This adds Phase 5 \`stdio_pipe_break\` so the harness can reproduce the silent-death pattern and measure whether the watchdog's \`--mcp-pid\` trigger covers it.

## Changes

- \`scripts/spikes/spike_rdr094_lifecycle.py\`:
  - \`_run_phase_stdio_pipe_break()\` -- spawns nx-mcp, waits for chroma, calls \`proc.stdin.close()\` with no signal, waits \`CLEANUP_TIMEOUT_S\` (10s) for either lifespan-driven exit or watchdog \`--mcp-pid\` trigger; belt-and-braces SIGKILL on leak
  - \`_classify_cleanup_path()\` gains a \`stdin_close\` branch with three diagnostic outcomes:
    - \`mcp_owned_lifespan\` -- stdin EOF cleanly drove lifespan finally (wild observation has another root cause)
    - \`watchdog_mcp\` -- nx-mcp crashed, watchdog cleaned chroma (FastMCP reader raised on EOF)
    - \`watchdog_unknown\` -- chroma dead, **no** mcp lifecycle event ever fired (the fifth-mode silent-death signature)
  - Default \`--phases\` list expanded to include \`stdio_pipe_break\`
  - Top-of-file docstring documents Phase 5 alongside the existing four

- \`tests/test_spike_rdr094_lifecycle.py\` (new, 11 deterministic tests):
  - \`TestClassifyStdinClose\` pins each of the three diagnostic outcomes plus the \`chroma_alive => none\` regression sentinel
  - \`TestClassifyExistingBranches\` is a regression sentinel for the four pre-existing phases
  - \`TestPhaseRegistration\` verifies the dispatcher wiring and default phase list

## Evidence collection

Real 10-run evidence is collected by Hal on demand under a fresh \`NEXUS_CONFIG_DIR\` tmpdir:

\`\`\`bash
NEXUS_MCP_OWNS_T1=1 uv run python scripts/spikes/spike_rdr094_lifecycle.py \\
    --phases stdio_pipe_break --runs 10
\`\`\`

Per the bead's acceptance: 10 runs at \`watchdog_mcp\` 100% closes the gap; less than 100% files a follow-up bead. Either way, results append to T2 \`nexus_rdr/094-spike-a-lifecycle\`.

## Test plan

- [x] 11 new deterministic tests in tests/test_spike_rdr094_lifecycle.py (0.05s)
- [x] No em dashes in additions
- [x] Explicit-path \`git add\`; \`.beads/interactions.jsonl\` left alone

## Closes

Closes nexus-sawb (RDR-094 Phase I: Add stdio_pipe_break phase to spike harness).