### PR TITLE
docs(rdr-094): document Claude Code MCP log surface for silent-death diagnosis (nexus-3f95)

### DIFF
--- a/docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md
+++ b/docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md
@@ -1110,6 +1110,45 @@ future Claude Code behaviour changes).
 | Session records | `ls ~/.config/nexus/sessions/` | cat `<uuid>.session` | removed by MCP atexit | `nx doctor` T1 section | N/A |
 | Tmpdir scan | `find /var/folders -name 'nx_t1_*'` | `du -sh` | sweep pass | `nx doctor --check-tmpdirs` | N/A |
 
+#### Diagnosing nx-mcp silent death (Phase H / nexus-3f95)
+
+When nx-mcp dies without emitting `mcp_server_stopping` or
+`mcp_server_crashed` (the fifth failure mode probed by Phase I /
+nexus-sawb), three log surfaces must be correlated to find the trigger:
+
+1. **nexus side -- mcp.log** at `~/.config/nexus/logs/mcp.log`. This
+   is nx-mcp's own structlog output. If the fifth mode triggered, the
+   server had no chance to flush a stopping event before the transport
+   broke; the gap in the log is the diagnostic.
+2. **nexus side -- watchdog.log** at `~/.config/nexus/logs/watchdog.log`
+   (PR #303 / nexus-aqna). The watchdog records `mcp_pid_disappeared`
+   the moment it observes nx-mcp's PID gone. Compare the timestamp
+   against the gap in mcp.log to confirm "the server was alive a
+   moment ago, then the PID vanished without a lifecycle event".
+3. **Claude Code side -- per-server mcp-logs JSONL** at
+   `~/Library/Caches/claude-cli-nodejs/<project-slug>/mcp-logs-<server>/`.
+   Claude Code records every MCP-client-side transport event. The
+   silent-death signatures are:
+   - `"debug":"STDIO connection dropped after Ns uptime"`
+   - `"debug":"Closing transport (stdio transport error: <Type>)"`
+
+   These events fire even when nx-mcp itself logged nothing -- the
+   MCP client observed the transport break from its own side.
+
+The 2026-04-25 reference incident (session
+`0c700072-0841-4bd6-9fd7-f2933e33a065`, nx-mcp pid 94433) recorded
+both signatures at `2026-04-25T00:20:34Z` after 23092s of uptime,
+followed by an auto-reconnect at `00:22:40`. nexus-side logs from
+that span show the gap directly: the last event before the drop was
+a normal `Tool 'query' failed after 9s: MCP error -32001:
+AbortError` (client-side abort), then nothing until the new
+connection attempt.
+
+The follow-up bead (filed) wires this correlation into
+`nx doctor --check-mcp-logs`. T2 entry
+`nexus_rdr/094-claude-mcp-log-investigation` (id 981, permanent)
+holds the full event-signature catalogue.
+
 ### New Dependencies
 
 None. Python `atexit`, `signal`, `socket` (TCP probe) are stdlib.


### PR DESCRIPTION
## Summary

Phase H of RDR-094 (research-only) investigates whether Claude Code surfaces any log we can use to attribute MCP-server silent deaths. **Yes, it does.** Per-server JSONL logs at \`~/Library/Caches/claude-cli-nodejs/<project-slug>/mcp-logs-<server>/\` record \`STDIO connection dropped after Ns uptime\` + \`Closing transport (stdio transport error: ...)\` even when nx-mcp itself logged nothing. The 2026-04-25 reference incident (nx-mcp pid 94433, session 0c700072) recorded both signatures at \`00:20:34Z\` after 23092s of uptime.

## What this PR ships

**Code: none.** This is the research output specified in the bead's deliverable: T2 entry + RDR §Day 2 Operations subsection.

- \`docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md\`: §Day 2 Operations gains a \"Diagnosing nx-mcp silent death\" subsection describing the three-log correlation:
  1. \`~/.config/nexus/logs/mcp.log\` (nx-mcp's perspective)
  2. \`~/.config/nexus/logs/watchdog.log\` (watchdog's perspective, post PR #303)
  3. Claude Code's \`mcp-logs-<server>/*.jsonl\` (client's perspective)

The fifth failure mode (Phase I / nexus-sawb) lives in the gap: nexus-side silent, Claude-side records the transport drop.

## Acceptance criteria (from the bead)

- [x] T2 \`nexus_rdr/094-claude-mcp-log-investigation\` entry created (id=981, permanent TTL) with the full event-signature catalogue
- [x] RDR-094 §Day 2 Operations updated with the \"how to diagnose nx-mcp silent death\" subsection
- [x] Follow-up bead filed for the doctor check (nexus-50u5 P3, parented under epic nexus-4v5l)

## Closes

Closes nexus-3f95 (RDR-094 Phase H: Investigate Claude Code MCP-server-death log surface).

The nexus-50u5 follow-up bead carries the doctor-check implementation forward; it remains open under the RDR-094 Phase 4 epic.