### PR TITLE
refactor(rdr-094): split session_end into session_end_flush + thin wrapper (nexus-2b9r)

### DIFF
--- a/src/nexus/commands/hook.py
+++ b/src/nexus/commands/hook.py
@@ -38,6 +38,19 @@ def session_end_cmd() -> None:
     click.echo(output)
 
 
+@hook_group.command("session-end-flush")
+def session_end_flush_cmd() -> None:
+    """Run only the storage-flush portion of SessionEnd (RDR-094 Phase B).
+
+    Runs T1 scratch flush + T2 expire; does NOT touch chroma. Used by
+    Phase C (nexus-l828) once hooks.json swaps the launcher's internal
+    dispatch to this entry point under the MCP-owned-T1 default-on
+    rollout. Safe to invoke whether NEXUS_MCP_OWNS_T1 is set or not.
+    """
+    output = hooks.session_end_flush()
+    click.echo(output)
+
+
 @hook_group.command("session-end-detach")
 def session_end_detach_cmd() -> None:
     """Fire-and-forget SessionEnd runner (nexus-99jb Layer 2).

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -185,21 +185,13 @@ def session_start(claude_session_id: str | None = None) -> str:
 
 # -- SessionEnd ---------------------------------------------------------------
 
-def session_end() -> str:
-    """Execute the SessionEnd hook.
 
-    1. Check whether this process owns the session (its parent wrote the record).
-    2. Flush flagged T1 entries to T2 (using whatever session is reachable via
-       PPID chain — works for both parent and child agents).
-    3. Run T2 expire().
-    4. If owner: stop the ChromaDB server and delete the session record + tmpdir.
-       Child agents skip the server-stop step.
+def _resolve_session_records() -> tuple[str | None, dict | None, Path | None, dict | None]:
+    """Resolve session id + owned record + flush record for the SessionEnd path.
 
-    Returns a summary string.
+    Shared between ``session_end_flush`` and the chroma-stop block in
+    ``session_end``. Returns ``(session_id, own_record, own_file, flush_record)``.
     """
-    # Resolve the Claude conversation UUID from the env var the SessionStart
-    # hook exported, or from the legacy ``current_session`` flat file as
-    # fallback for processes launched outside the SessionStart's child tree.
     session_id = os.environ.get("NX_SESSION_ID")
     if not session_id:
         from nexus.session import read_claude_session_id
@@ -210,7 +202,7 @@ def session_end() -> str:
     if session_id:
         own_file = SESSIONS_DIR / f"{session_id}.session"
         # Safe read: the file is written once at session_start by this
-        # process and only deleted later in this function — no external
+        # process and only deleted later in this function -- no external
         # writer can modify it between the exists() check and read_text().
         if own_file.exists():
             try:
@@ -224,9 +216,25 @@ def session_end() -> str:
                     error=str(exc),
                 )
 
-    # For T1 flush: prefer the owned record; otherwise look up by UUID
-    # (child-agent scenario where the env var was inherited).
     flush_record = own_record or find_session_by_id(SESSIONS_DIR, session_id)
+    return session_id, own_record, own_file, flush_record
+
+
+def session_end_flush() -> str:
+    """Run the storage-only portion of SessionEnd: T1 flush + T2 expire.
+
+    Splits cleanly out of ``session_end`` so Phase 4 (RDR-094) can wire
+    hooks.json directly at this entry point: it does no chroma teardown,
+    so it cannot race the MCP server's own lifespan/atexit/signal
+    cleanup. ``session_end`` keeps the chroma-stop block for the
+    feature-flag-off rollout window and is the legacy entry point.
+
+    Importantly: this function is fork-safe. It only opens T1/T2
+    SQLite handles (each call gets a fresh connection) and does not
+    touch any module-level state acquired before fork. Phase C
+    (nexus-l828) imports it post-fork in the launcher's grandchild.
+    """
+    _, _, _, flush_record = _resolve_session_records()
     if flush_record is None:
         _log.warning(
             "session_end: no T1 session record found; flagged scratch entries may not have been flushed"
@@ -255,15 +263,27 @@ def session_end() -> str:
     except (sqlite3.Error, OSError) as exc:
         _log.warning("session_end: storage error during flush/expire", error=str(exc))
 
-    # Stop server and clean up only if this process owns the session.
-    # Skip the chroma-stop block when NEXUS_MCP_OWNS_T1 is active: the
-    # MCP server's signal handler / lifespan / atexit owns shutdown,
-    # and a hook-side stop_t1_server + tmpdir-rm here races MCP's own
-    # cleanup. The flag-on path is chroma-owned-by-MCP exclusively;
-    # this hook degrades to scratch-flush + memory-expire only (which
-    # already ran above). RDR-094 Phase 2 Step 2's session_end_flush
-    # split is deferred to a follow-up bead; this gate is the in-place
-    # mitigation that prevents the double-stop in the meantime.
+    return f"Session ended. Flushed {flushed} scratch entries. Expired {expired} memory entries."
+
+
+def session_end() -> str:
+    """Execute the SessionEnd hook (legacy entry point).
+
+    Calls :func:`session_end_flush` for storage work, then -- when this
+    process owns the session record AND ``NEXUS_MCP_OWNS_T1`` is not
+    set -- stops the ChromaDB server and removes the session record +
+    tmpdir.
+
+    The ``NEXUS_MCP_OWNS_T1`` gate is the in-place mitigation from
+    PR #300: when the MCP server owns chroma, hook-side teardown
+    races the lifespan/atexit/signal-handler cleanup. Phase C
+    (nexus-l828) swaps hooks.json's internal call to
+    :func:`session_end_flush` directly so the gate becomes redundant;
+    it stays here for the flag-off rollout window.
+    """
+    _, own_record, own_file, _ = _resolve_session_records()
+    summary = session_end_flush()
+
     mcp_owns_t1 = os.environ.get(
         "NEXUS_MCP_OWNS_T1", "",
     ).strip().lower() in ("1", "true", "yes")
@@ -279,4 +299,4 @@ def session_end() -> str:
         if tmpdir:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
-    return f"Session ended. Flushed {flushed} scratch entries. Expired {expired} memory entries."
+    return summary

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nexus.hooks import session_end, session_start
+from nexus.hooks import session_end, session_end_flush, session_start
 
 
 # ── session_start ────────────────────────────────────────────────────────────
@@ -328,6 +328,156 @@ def test_session_end_db_error_doesnt_crash(tmp_path: Path) -> None:
         output = session_end()
 
     assert "Session ended" in output
+
+
+# ── session_end_flush (RDR-094 Phase B / nexus-2b9r) ────────────────────────
+
+
+class TestSessionEndFlush:
+    """The split-out flush function does T1 flush + T2 expire and never
+    touches chroma. Phase 4's hooks.json swap (Phase C / nexus-l828)
+    points at this function so the SessionEnd path cannot race the
+    MCP-owned chroma teardown."""
+
+    def test_flush_returns_summary_when_no_record(self, tmp_path, monkeypatch):
+        sessions = tmp_path / "sessions"
+        sessions.mkdir()
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+
+        with (
+            patch("nexus.hooks.SESSIONS_DIR", sessions),
+            patch("nexus.hooks.find_session_by_id", return_value=None),
+            patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
+        ):
+            output = session_end_flush()
+
+        assert "Flushed 0" in output
+        assert "Expired 0" in output
+
+    def test_flush_drains_flagged_entries_to_t2(self, tmp_path, monkeypatch):
+        from nexus.db.t2 import T2Database
+
+        sessions = tmp_path / "sessions"
+        _make_session_record(sessions, session_id="flush-only-uuid")
+        monkeypatch.setenv("NX_SESSION_ID", "flush-only-uuid")
+
+        mock_t1 = MagicMock()
+        mock_t1.flagged_entries.return_value = [
+            {
+                "content": "evidence A",
+                "flush_project": "p",
+                "flush_title": "a.md",
+                "tags": "",
+            },
+        ]
+        db_path = tmp_path / "memory.db"
+
+        with (
+            patch("nexus.hooks.SESSIONS_DIR", sessions),
+            patch("nexus.hooks._default_db_path", return_value=db_path),
+            patch("nexus.hooks._open_t1", return_value=mock_t1),
+            patch("nexus.hooks.stop_t1_server") as mock_stop,
+        ):
+            output = session_end_flush()
+
+        assert "Flushed 1" in output
+        mock_t1.clear.assert_called_once()
+        # The flush function MUST NOT touch chroma -- this is the
+        # whole point of the split.
+        mock_stop.assert_not_called()
+        # ...and must NOT delete the session record.
+        assert (sessions / "flush-only-uuid.session").exists()
+
+        with T2Database(db_path) as db:
+            entry = db.get(project="p", title="a.md")
+        assert entry is not None
+        assert entry["content"] == "evidence A"
+
+    def test_flush_does_not_touch_chroma_even_when_record_owned(
+        self, tmp_path, monkeypatch,
+    ):
+        """Owner-detection lives in session_end, not in session_end_flush."""
+        sessions = tmp_path / "sessions"
+        _make_session_record(
+            sessions, session_id="owner-uuid", server_pid=12345,
+        )
+        monkeypatch.setenv("NX_SESSION_ID", "owner-uuid")
+
+        mock_t1 = MagicMock()
+        mock_t1.flagged_entries.return_value = []
+
+        with (
+            patch("nexus.hooks.SESSIONS_DIR", sessions),
+            patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
+            patch("nexus.hooks._open_t1", return_value=mock_t1),
+            patch("nexus.hooks.stop_t1_server") as mock_stop,
+        ):
+            session_end_flush()
+
+        mock_stop.assert_not_called()
+        # Session file must survive a flush-only run.
+        assert (sessions / "owner-uuid.session").exists()
+
+
+def test_session_end_skips_chroma_when_mcp_owns_t1(
+    tmp_path, monkeypatch,
+):
+    """The PR #300 in-place gate stays in session_end (legacy path).
+
+    With NEXUS_MCP_OWNS_T1 set, session_end must flush + expire but
+    skip stop_t1_server + session-file unlink. Pinned here so the
+    refactor doesn't accidentally drop the gate before Phase C / F
+    take over.
+    """
+    sessions = tmp_path / "sessions"
+    _make_session_record(sessions, session_id="mcp-owned-uuid", server_pid=42)
+    monkeypatch.setenv("NX_SESSION_ID", "mcp-owned-uuid")
+    monkeypatch.setenv("NEXUS_MCP_OWNS_T1", "1")
+
+    mock_t1 = MagicMock()
+    mock_t1.flagged_entries.return_value = []
+
+    with (
+        patch("nexus.hooks.SESSIONS_DIR", sessions),
+        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
+        patch("nexus.hooks._open_t1", return_value=mock_t1),
+        patch("nexus.hooks.stop_t1_server") as mock_stop,
+    ):
+        output = session_end()
+
+    assert "Session ended" in output
+    mock_stop.assert_not_called()
+    # Session file must survive when MCP owns T1.
+    assert (sessions / "mcp-owned-uuid.session").exists()
+
+
+# ── nx hook session-end-flush CLI subcommand ────────────────────────────────
+
+
+def test_session_end_flush_cli_subcommand(tmp_path, monkeypatch):
+    """The new CLI subcommand routes to session_end_flush, not session_end."""
+    from click.testing import CliRunner
+
+    from nexus.commands.hook import hook_group
+
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
+
+    with (
+        patch("nexus.hooks.SESSIONS_DIR", sessions),
+        patch("nexus.hooks.find_session_by_id", return_value=None),
+        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
+        patch("nexus.hooks.stop_t1_server") as mock_stop,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(hook_group, ["session-end-flush"])
+
+    assert result.exit_code == 0
+    assert "Flushed 0" in result.output
+    assert "Expired 0" in result.output
+    # Critical: the flush subcommand never calls stop_t1_server.
+    mock_stop.assert_not_called()
 
 
 # ── session lock stale cleanup ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Phase 4's hooks.json swap (Phase C / nexus-l828) needs a function that does the storage-only portion of SessionEnd: T1 scratch flush + T2 expire, no chroma teardown. Without this split, hooks.json cannot point at a flush-only entry, and the PR #300 \`NEXUS_MCP_OWNS_T1\` in-place gate has to stay forever.

This refactor extracts the split cleanly while keeping \`session_end()\` as a backward-compatible thin wrapper. **Hard prereq for Phase C (hooks.json swap) and Phase F (flag removal).**

## Changes

- \`src/nexus/hooks.py\`:
  - \`_resolve_session_records()\` -- new helper, returns \`(session_id, own_record, own_file, flush_record)\`. Shared by both functions.
  - \`session_end_flush()\` -- new pure path. T1 flush + T2 expire only. **Fork-safe** (only opens fresh SQLite handles, no module-level state acquired before fork) so Phase C's launcher can import it post-fork in the grandchild.
  - \`session_end()\` -- thin wrapper. Calls \`session_end_flush()\` for storage work, then runs the chroma-stop block when this process owns the session record AND \`NEXUS_MCP_OWNS_T1\` is not set. The PR #300 gate stays for the flag-off rollout window; Phase C / Phase F will retire it.

- \`src/nexus/commands/hook.py\`:
  - \`nx hook session-end-flush\` -- new CLI subcommand mirroring \`session-end-detach\`. Routes to \`session_end_flush()\` directly so Phase C's hooks.json launcher dispatch can call it without going through the legacy \`session_end\` path.

## Test plan

- [x] \`tests/test_hooks.py\` 14 -> 19. New tests:
  - flush returns summary when no session record
  - flush drains flagged T1 entries to T2 and clears T1
  - flush does NOT touch chroma even when record is owned
  - \`session_end\` skips chroma when \`NEXUS_MCP_OWNS_T1\` (PR #300 gate regression sentinel)
  - the new CLI subcommand routes to \`session_end_flush\`
- [x] Affected-module sweep (test_hooks, test_session, test_session_end_launcher, test_t1_watchdog): 89 pass
- [x] No em dashes in additions
- [x] Explicit-path \`git add\`; \`.beads/interactions.jsonl\` left alone

## Closes

Closes nexus-2b9r (RDR-094 Phase B). Unblocks nexus-l828 (Phase C) and contributes to nexus-2lm0 (Phase F).