### PR TITLE
refactor(rdr-094): swap launcher dispatch to session_end_flush, drop detach fallback (nexus-l828)

### DIFF
--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -38,8 +38,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "nx-session-end-launcher 2>/dev/null || nx hook session-end-detach || true",
-            "timeout": 5
+            "command": "nx-session-end-launcher",
+            "timeout": 3
           }
         ]
       }

--- a/src/nexus/_session_end_launcher.py
+++ b/src/nexus/_session_end_launcher.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Fork-first SessionEnd daemonizer (nexus-2u7o).
+"""Fork-first SessionEnd daemonizer (nexus-2u7o, RDR-094 Phase C).
 
 The 4.10.3 double-fork path in ``nexus.commands.hook.session_end_detach_cmd``
 waits for Click to parse argv and for ``nexus.hooks`` + friends to import
@@ -12,14 +12,30 @@ cleanup.
 This module flips the order: the ``__main__`` block uses only ``os``
 and ``sys`` from the standard library (both are preloaded by the
 interpreter, so no import cost), forks, ``setsid``s, forks again, and
-redirects stdio to ``/dev/null`` — all before touching a single nexus
+redirects stdio to ``/dev/null`` -- all before touching a single nexus
 module. Then in the fully detached grandchild it imports
-``nexus.hooks`` and runs ``session_end()`` normally. Wall-clock cost
+``nexus.hooks`` and runs ``session_end_flush()``. Wall-clock cost
 to return control to Claude Code: ~17ms.
+
+RDR-094 Phase C swap: the launcher now dispatches to
+``hooks.session_end_flush`` (storage-only path, fork-safe) instead of
+``hooks.session_end``. With the MCP server owning chroma's lifecycle
+under ``NEXUS_MCP_OWNS_T1`` (Phase 4), a hook-side
+``stop_t1_server`` raced the MCP lifespan/atexit/signal-handler
+cleanup. Pointing the launcher at the flush-only entry retires that
+race entirely. The legacy ``hooks.session_end`` chroma-stop block is
+still reachable via ``nx hook session-end`` for the flag-off rollout
+window and as a manual-debug entry point.
+
+**BANNED invariant**: this module must never import any ``nexus.*``
+module before ``os.fork()``. The whole point is that the parent
+process pays no nexus-import cost before forking off the daemon.
+Imports happen only inside ``_run_session_end_synchronously`` which
+runs in the grandchild.
 
 Shell invocation (wired into ``nx/hooks/hooks.json``)::
 
-    python3 -m nexus._session_end_launcher || true
+    nx-session-end-launcher
 
 On platforms without ``os.fork`` (Windows), falls through to the
 synchronous path so cleanup still happens, at the cost of the hook
@@ -32,16 +48,23 @@ import sys
 
 
 def _run_session_end_synchronously() -> None:
-    """Import nexus.hooks and call session_end(); swallow exceptions.
+    """Import nexus.hooks and call session_end_flush; swallow exceptions.
 
     Runs in the fully detached grandchild, so exceptions are no longer
-    observable by Claude Code — they must not escape and crash the
+    observable by Claude Code -- they must not escape and crash the
     daemon. Logging goes through the structlog pipeline nexus.hooks
     already configures (RotatingFileHandler under ~/.config/nexus/logs).
+
+    RDR-094 Phase C: dispatches to ``session_end_flush`` (storage-only)
+    rather than ``session_end`` (storage + chroma teardown). The
+    chroma teardown is owned by the MCP server's lifespan/atexit/
+    signal handlers under ``NEXUS_MCP_OWNS_T1``; calling it here
+    races those paths and was the documented source of double-stop
+    failures.
     """
     try:
         from nexus import hooks
-        hooks.session_end()
+        hooks.session_end_flush()
     except Exception:
         # Fully detached; nothing upstream can observe us. Swallow.
         pass

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -493,7 +493,7 @@ class TestHooks:
         assert "3.12" in py_req, f"engines.python should require >=3.12, got {py_req!r}"
 
     def test_session_end_hook_registered(self) -> None:
-        """Regression guard: SessionEnd must invoke ``nx hook session-end``.
+        """Regression guard: SessionEnd must run a nexus cleanup entry point.
 
         The hook was removed in v1.10.1 with the (incorrect) reasoning that
         the T1 chroma server stops with the parent process tree. It does not:
@@ -503,19 +503,26 @@ class TestHooks:
         reaping never collects it. Removing this hook leaks one chroma child
         per Claude Code session indefinitely. This test fails loudly if
         anyone drops the hook again.
+
+        RDR-094 Phase C (nexus-l828) swapped the dispatch from
+        ``nx hook session-end-detach`` to ``nx-session-end-launcher`` to
+        preserve the fork-first cold-start race fix. Either name is
+        acceptable as a SessionEnd entry; what matters is that *some*
+        nexus cleanup entry is registered.
         """
         data = json.loads(HOOKS_PATH.read_text())
         events = data.get("hooks", data)
         session_end = events.get("SessionEnd")
-        assert session_end, "SessionEnd hook is missing — see test docstring for why it must stay"
+        assert session_end, "SessionEnd hook is missing -- see test docstring for why it must stay"
         commands = [
             sub.get("command", "")
             for entry in session_end
             for sub in entry.get("hooks", [])
         ]
-        assert any("nx hook session-end" in cmd for cmd in commands), (
-            f"SessionEnd registered but does not invoke 'nx hook session-end'; "
-            f"found commands: {commands}"
+        valid_entries = ("nx hook session-end", "nx-session-end-launcher")
+        assert any(any(v in cmd for v in valid_entries) for cmd in commands), (
+            f"SessionEnd registered but does not invoke a nexus cleanup entry "
+            f"({valid_entries}); found commands: {commands}"
         )
 
 

--- a/tests/test_session_end_launcher.py
+++ b/tests/test_session_end_launcher.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Tests for nexus._session_end_launcher (nexus-2u7o).
+"""Tests for nexus._session_end_launcher (nexus-2u7o, RDR-094 Phase C).
 
 Contract pins:
-  * Module top-level must NOT import anything from ``nexus`` — only
+  * Module top-level must NOT import anything from ``nexus`` -- only
     ``os`` and ``sys``. Keeps the fork-first guarantee intact on
-    cold-cache Python startup.
+    cold-cache Python startup (BANNED invariant per nexus-l828).
   * ``main()`` returns to the caller via the first-fork parent path
-    (in the real world ~100ms; here we simulate the fork).
-  * ``_run_session_end_synchronously`` calls ``nexus.hooks.session_end``
-    and swallows exceptions.
+    (in the real world ~17ms; here we simulate the fork).
+  * ``_run_session_end_synchronously`` calls
+    ``nexus.hooks.session_end_flush`` (Phase C swap from
+    ``session_end`` to drop the chroma-stop race against
+    NEXUS_MCP_OWNS_T1) and swallows exceptions.
   * Platform-without-fork fallback runs synchronously.
 """
 from __future__ import annotations
@@ -39,23 +41,47 @@ def test_module_does_not_import_nexus_submodules_at_top_level() -> None:
     )
 
 
-def test_run_session_end_synchronously_invokes_hooks_session_end() -> None:
-    """The grandchild path must dispatch to ``nexus.hooks.session_end``."""
+def test_run_session_end_synchronously_invokes_session_end_flush() -> None:
+    """RDR-094 Phase C: grandchild path dispatches to session_end_flush.
+
+    The pre-Phase-C contract was ``session_end`` which both flushes and
+    stops chroma. Under NEXUS_MCP_OWNS_T1 (Phase 4) the MCP server owns
+    chroma teardown, so the launcher must use the storage-only entry.
+    """
     import nexus._session_end_launcher as launcher
 
     call_count = 0
-    def fake_session_end() -> str:
+    def fake_flush() -> str:
         nonlocal call_count
         call_count += 1
         return "stub"
 
-    with patch("nexus.hooks.session_end", side_effect=fake_session_end):
+    with patch("nexus.hooks.session_end_flush", side_effect=fake_flush):
         launcher._run_session_end_synchronously()
     assert call_count == 1
 
 
+def test_run_session_end_synchronously_does_not_call_session_end() -> None:
+    """Regression sentinel: launcher must NOT route through session_end.
+
+    session_end runs the chroma-stop block when NEXUS_MCP_OWNS_T1 is
+    unset, which races MCP-owned cleanup. The Phase C contract is to
+    point the launcher at session_end_flush exclusively; the legacy
+    session_end path stays only for nx hook session-end (manual debug)
+    and for the flag-off rollout window.
+    """
+    import nexus._session_end_launcher as launcher
+
+    with (
+        patch("nexus.hooks.session_end") as mock_full,
+        patch("nexus.hooks.session_end_flush", return_value="stub"),
+    ):
+        launcher._run_session_end_synchronously()
+    mock_full.assert_not_called()
+
+
 def test_run_session_end_synchronously_swallows_exceptions() -> None:
-    """The grandchild is detached — exceptions must not propagate up or
+    """The grandchild is detached -- exceptions must not propagate up or
     we'd drop the ``os._exit(0)`` and leave a zombie.
     """
     import nexus._session_end_launcher as launcher
@@ -63,7 +89,7 @@ def test_run_session_end_synchronously_swallows_exceptions() -> None:
     def boom() -> str:
         raise RuntimeError("intentional failure from test")
 
-    with patch("nexus.hooks.session_end", side_effect=boom):
+    with patch("nexus.hooks.session_end_flush", side_effect=boom):
         launcher._run_session_end_synchronously()  # must not raise
 
 
@@ -126,3 +152,84 @@ def test_daemonize_falls_through_to_sync_on_oserror() -> None:
     ):
         launcher._daemonize_and_run()
     assert calls == ["sync"]
+
+
+# ── nx/hooks/hooks.json contract (RDR-094 Phase C / nexus-l828) ─────────────
+
+
+def _read_plugin_hooks_json() -> dict:
+    import json
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    return json.loads((repo_root / "nx" / "hooks" / "hooks.json").read_text())
+
+
+def test_hooks_json_session_end_uses_launcher_not_flush_directly() -> None:
+    """The hooks.json SessionEnd entry MUST dispatch through
+    nx-session-end-launcher, never directly to ``nx hook session-end-flush``.
+
+    Reason: pointing hooks.json at the Click-routed entry reopens the
+    256ms-vs-2s cold-start race that the launcher exists to solve
+    (Click parses argv + nexus.hooks imports BEFORE os.fork). The
+    launcher's __main__ block forks first using only stdlib, then
+    imports nexus.hooks in the grandchild.
+    """
+    cfg = _read_plugin_hooks_json()
+    session_end = cfg["hooks"]["SessionEnd"]
+    assert session_end, "SessionEnd block must not be empty"
+
+    commands = [
+        h["command"]
+        for entry in session_end
+        for h in entry.get("hooks", [])
+    ]
+    assert any("nx-session-end-launcher" in c for c in commands), (
+        f"SessionEnd must invoke nx-session-end-launcher; got {commands!r}"
+    )
+    # The Click entry stays as a manual-debug entry point only -- it
+    # must NOT appear in hooks.json.
+    assert not any(
+        "nx hook session-end-flush" in c or "nx hook session-end" in c
+        for c in commands
+    ), (
+        "SessionEnd in hooks.json must not invoke 'nx hook session-end*' "
+        "directly -- the launcher is the only fork-first-safe entry. "
+        f"Got: {commands!r}"
+    )
+
+
+def test_hooks_json_session_end_timeout_is_three_seconds() -> None:
+    """Phase C reduces SessionEnd timeout from 5s to 3s.
+
+    Storage-only flush is sub-second on a typical install; the previous
+    5s window covered chroma teardown which the launcher no longer
+    triggers. Tighter timeout means a wedged hook is reaped faster.
+    """
+    cfg = _read_plugin_hooks_json()
+    timeouts = [
+        h["timeout"]
+        for entry in cfg["hooks"]["SessionEnd"]
+        for h in entry.get("hooks", [])
+    ]
+    assert timeouts == [3], f"expected SessionEnd timeout 3s; got {timeouts!r}"
+
+
+def test_hooks_json_session_end_drops_detach_fallback() -> None:
+    """Phase C drops the ``|| nx hook session-end-detach`` fallback.
+
+    The detach Click command imports nexus.hooks before forking and
+    has the same 2s cold-start race the launcher fixes. Falling back
+    to it on launcher failure was a footgun: a slow launcher that
+    reached the inner fork would still skip the SIGTERM -- the
+    fallback runs against the same race.
+    """
+    cfg = _read_plugin_hooks_json()
+    commands = [
+        h["command"]
+        for entry in cfg["hooks"]["SessionEnd"]
+        for h in entry.get("hooks", [])
+    ]
+    assert not any("session-end-detach" in c for c in commands), (
+        f"detach fallback must be removed from SessionEnd; got {commands!r}"
+    )


### PR DESCRIPTION
## Summary

Phase 4's MCP-owned-T1 default-on path needs the SessionEnd hook to do storage-only work; chroma teardown is owned by the MCP server's lifespan/atexit/signal handlers. Without this swap, the hook-side \`stop_t1_server\` races MCP's cleanup whenever \`NEXUS_MCP_OWNS_T1\` is set (the PR #300 in-place gate covered the gap but kept the legacy path forever).

**Per the bead's CRITICAL CORRECTION**: keep \`nx-session-end-launcher\` in hooks.json (the fork-first daemonizer), and **only switch what the grandchild dispatches to**. Pointing hooks.json at \`nx hook session-end-flush\` directly would reopen the 256ms-vs-2s cold-start race the launcher was built to solve (Click parses argv + nexus.hooks imports BEFORE \`os.fork\`).

## Changes

- \`src/nexus/_session_end_launcher.py\`:
  - \`_run_session_end_synchronously()\` dispatches to \`hooks.session_end_flush\` (was \`hooks.session_end\`). The grandchild runs storage-only flush; chroma teardown stays with the MCP server.
  - Docstrings rewritten with the **BANNED-invariant** note: this module must never import any \`nexus.*\` before \`os.fork()\`.

- \`nx/hooks/hooks.json\`:
  - SessionEnd command \`nx-session-end-launcher 2>/dev/null || nx hook session-end-detach || true\` -> \`nx-session-end-launcher\`. The detach fallback hits the same 2s cold-start race (Click + nexus imports before fork), so falling back to it on launcher failure was a footgun.
  - timeout 5 -> 3 (storage-only flush is sub-second; tighter window means a wedged hook is reaped faster).

- \`tests/test_session_end_launcher.py\`:
  - Updated existing test contract: launcher dispatches to \`session_end_flush\`, not \`session_end\`.
  - **New regression sentinel**: launcher must NOT call \`session_end\` (the chroma-stop block races MCP cleanup).
  - **New hooks.json contract tests**:
    * SessionEnd uses \`nx-session-end-launcher\`, not \`nx hook session-end*\` directly
    * timeout is 3s
    * detach fallback is dropped

- \`tests/test_plugin_structure.py\`:
  - SessionEnd-registered guard accepts either \`nx-session-end-launcher\` or \`nx hook session-end*\` as valid cleanup entries; old test relied on the substring matching the dropped detach fallback.

## Test plan

- [x] \`tests/test_session_end_launcher.py\` 7 -> 10 (3 new launcher tests + 3 new hooks.json contract tests merged into the same file)
- [x] \`tests/test_plugin_structure.py\` 577 pass (test_session_end_hook_registered updated)
- [x] Affected-module sweep (test_session_end_launcher, test_hooks, test_plugin_install, test_upgrade_e2e, test_phase5_integration): 96 pass
- [x] No em dashes in additions
- [x] BANNED invariant verified: launcher module imports only \`os\` and \`sys\` at top level

## Closes

Closes nexus-l828 (RDR-094 Phase C). Combined with nexus-2b9r (PR #306), this finishes the Phase B+C arc. Phase F (nexus-2lm0, flag removal) and Phase E (nexus-fn44, canary) can now build on this surface.