### PR TITLE
feat(rdr-094): add Spike B subagent T1 race-probe harness (nexus-zsqf)

### DIFF
--- a/scripts/spikes/spike_rdr094_b_subagent_race.py
+++ b/scripts/spikes/spike_rdr094_b_subagent_race.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env -S uv run python
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-094 Spike B: subagent T1 sharing race verification (CA-2).
+
+Verifies the silent-downgrade race described in RDR §Critical
+Assumptions CA-2: a subagent dispatched within milliseconds of
+top-level MCP startup may observe ``NX_SESSION_ID`` set but find
+the parent's session record not yet written, causing a silent
+``EphemeralClient`` downgrade in :class:`nexus.db.t1.T1Database`.
+
+## Hypothesis
+
+The subagent's :func:`T1Database.__init__` calls
+:func:`find_session_by_id` which reads
+``$NEXUS_CONFIG_DIR/sessions/{session_id}.session``. If that file
+has not yet been written by the parent's
+:func:`write_session_record_by_id` call, the subagent silently falls
+through to ``chromadb.EphemeralClient()`` (with a ``warnings.warn``
+that is invisible in production stdio transport).
+
+## Protocol
+
+Per cycle:
+
+  1. Set up an isolated ``NEXUS_CONFIG_DIR`` tmpdir.
+  2. Spawn nx-mcp with ``NEXUS_MCP_OWNS_T1=1`` and a fresh
+     ``NX_SESSION_ID`` (so MCP's ``_t1_chroma_init_if_owner`` runs
+     ``start_t1_server`` + ``write_session_record_by_id``).
+  3. Wait ``timing_variant_ms`` from the moment nx-mcp was spawned.
+     ``timing_variant_ms`` of 0 is "spawn the subagent simultaneously
+     with nx-mcp"; 200 is "wait until nx-mcp's session record is
+     almost certainly written".
+  4. Spawn a child subprocess (the "subagent") that inherits
+     ``NX_SESSION_ID`` + ``NEXUS_CONFIG_DIR`` and constructs a fresh
+     :class:`T1Database`. The child prints a JSON line to stdout
+     reporting whether the inner client is
+     ``HttpClient`` (parent's chroma) or ``EphemeralClient``
+     (silent downgrade).
+  5. Parse the child's output, classify the cycle, and tear both
+     processes down.
+
+Default protocol: 10 runs × 4 timing variants (0 / 5 / 50 / 200 ms)
+= 40 cycles.
+
+## Decision rule
+
+  * 0 ``ephemeral_downgrade`` events => CA-2 verified, race not
+    reproducible. Phase E + F unblocked.
+  * >=1 ``ephemeral_downgrade`` event at any timing variant => race
+    reproducible. File a follow-up bead to add retry-with-backoff
+    in :func:`T1Database.__init__` (or in
+    :func:`_resolve_top_level_session_id` per the bead's note).
+
+Each run records: timing_variant_ms, run_id, outcome
+(``connected_to_parent`` | ``ephemeral_downgrade`` | ``setup_failed``),
+elapsed_ms.
+
+Usage::
+
+    uv run python scripts/spikes/spike_rdr094_b_subagent_race.py [--runs 10]
+
+Output: ``scripts/spikes/spike_rdr094_b_results.jsonl`` (per-run records)
+      + ``scripts/spikes/spike_rdr094_b_summary.json`` (aggregate).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RESULTS_PATH = SCRIPT_DIR / "spike_rdr094_b_results.jsonl"
+SUMMARY_PATH = SCRIPT_DIR / "spike_rdr094_b_summary.json"
+
+#: Default timing variants in milliseconds. Tests dispatch latency
+#: from nx-mcp spawn to subagent T1Database construction.
+DEFAULT_TIMINGS_MS: tuple[int, ...] = (0, 5, 50, 200)
+
+#: Wall clock budget for nx-mcp + chroma to come up. The child probe
+#: tries the T1Database resolve regardless; setup failure is its own
+#: outcome category.
+PARENT_SPAWN_TIMEOUT_S: float = 8.0
+
+#: Wall clock budget for the child (subagent) probe to print its
+#: outcome line. Only the import + T1Database construction is on
+#: the hot path; 5s is generous.
+CHILD_TIMEOUT_S: float = 10.0
+
+
+@dataclass
+class RunRecord:
+    timing_variant_ms: int
+    run_id: int
+    outcome: str
+    elapsed_ms: float
+    setup_failed: bool
+    error: Optional[str]
+
+
+def _classify_outcome(child_stdout: str, setup_failed: bool) -> str:
+    """Classify a cycle outcome from the child's reported state.
+
+    Vocabulary:
+      * ``connected_to_parent`` -- child's ``T1Database._client`` is a
+        ``HttpClient`` pointed at the parent's chroma.
+      * ``ephemeral_downgrade`` -- child's ``_client`` is an
+        ``EphemeralClient`` (the silent-downgrade signature).
+      * ``setup_failed`` -- the harness could not get nx-mcp +
+        chroma up at all; CA-2 cannot be tested in this cycle.
+      * ``unknown`` -- the child never printed a parseable outcome
+        line. Treated as a hard failure (probably nx-mcp crash or
+        child timeout).
+    """
+    if setup_failed:
+        return "setup_failed"
+    for line in reversed(child_stdout.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        client_kind = obj.get("client_class", "")
+        if "HttpClient" in client_kind:
+            return "connected_to_parent"
+        if "Ephemeral" in client_kind:
+            return "ephemeral_downgrade"
+    return "unknown"
+
+
+_SUBAGENT_PROBE = """
+# Subagent T1 race probe.
+#
+# Inherits NX_SESSION_ID + NEXUS_CONFIG_DIR from parent. Constructs a
+# fresh T1Database and prints {client_class, session_id} on stdout.
+import json
+import os
+import sys
+import warnings
+
+# Capture downgrade warning for diagnostic context (not for outcome
+# classification -- the client class is the authoritative signal).
+warnings.simplefilter("always")
+captured: list[str] = []
+
+def _capture(message, category, filename, lineno, file=None, line=None):
+    captured.append(str(message))
+
+warnings.showwarning = _capture
+
+from nexus.db.t1 import T1Database
+
+t1 = T1Database()
+print(json.dumps({
+    "client_class": type(t1._client).__name__,
+    "session_id": t1._session_id,
+    "warnings": captured,
+    "nx_session_id_env": os.environ.get("NX_SESSION_ID", ""),
+}), flush=True)
+sys.exit(0)
+"""
+
+
+def _spawn_nx_mcp(env: dict) -> subprocess.Popen:
+    """Spawn nx-mcp under this harness so the parent owns chroma.
+
+    Inherits NEXUS_CONFIG_DIR + NEXUS_MCP_OWNS_T1 + NX_SESSION_ID
+    from *env* (built by the per-cycle isolation in :func:`_run_cycle`).
+    """
+    return subprocess.Popen(
+        [sys.executable, "-m", "nexus.mcp.core"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+        env=env,
+    )
+
+
+def _spawn_subagent_probe(env: dict, timeout_s: float) -> tuple[str, str, int]:
+    """Run the subagent probe synchronously.
+
+    Returns ``(stdout, stderr, returncode)``. Times out at *timeout_s*
+    -- the probe should finish in well under a second when chroma is
+    reachable; longer means we hung in the import path.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", _SUBAGENT_PROBE],
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        env=env,
+        check=False,
+    )
+    return proc.stdout, proc.stderr, proc.returncode
+
+
+def _run_cycle(timing_variant_ms: int, run_id: int) -> RunRecord:
+    """One race-probe cycle for the given dispatch-delay timing variant."""
+    cycle_dir = Path(tempfile.mkdtemp(prefix=f"nx_spike094b_{run_id}_"))
+    (cycle_dir / "logs").mkdir(parents=True, exist_ok=True)
+    (cycle_dir / "sessions").mkdir(parents=True, exist_ok=True)
+
+    session_id = str(uuid.uuid4())
+    env = {
+        **os.environ,
+        "NEXUS_CONFIG_DIR": str(cycle_dir),
+        "NEXUS_MCP_OWNS_T1": "1",
+        "NX_SESSION_ID": session_id,
+    }
+
+    parent: subprocess.Popen | None = None
+    t0 = time.monotonic()
+    try:
+        parent = _spawn_nx_mcp(env)
+        # Wait the requested dispatch delay before the subagent fires.
+        # The subagent inherits NX_SESSION_ID; parent's MCP must have
+        # written the session record by the time the subagent's
+        # T1Database resolves -- if not, the silent downgrade fires.
+        if timing_variant_ms > 0:
+            time.sleep(timing_variant_ms / 1000.0)
+
+        try:
+            stdout, _stderr, _rc = _spawn_subagent_probe(env, CHILD_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            elapsed_ms = (time.monotonic() - t0) * 1000.0
+            return RunRecord(
+                timing_variant_ms=timing_variant_ms,
+                run_id=run_id, outcome="unknown",
+                elapsed_ms=round(elapsed_ms, 2),
+                setup_failed=False,
+                error="subagent probe timed out",
+            )
+
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+
+        # Parent didn't even reach session-record write if it died
+        # early. Distinguish that from an actual race by checking
+        # whether the session file exists at all.
+        record_path = cycle_dir / "sessions" / f"{session_id}.session"
+        record_present = record_path.exists()
+        outcome = _classify_outcome(stdout, setup_failed=not record_present and stdout == "")
+        return RunRecord(
+            timing_variant_ms=timing_variant_ms,
+            run_id=run_id, outcome=outcome,
+            elapsed_ms=round(elapsed_ms, 2),
+            setup_failed=outcome == "setup_failed",
+            error=None,
+        )
+    finally:
+        if parent is not None and parent.poll() is None:
+            try:
+                parent.send_signal(signal.SIGTERM)
+                parent.wait(timeout=2)
+            except (subprocess.TimeoutExpired, ProcessLookupError, OSError):
+                try:
+                    parent.kill()
+                except Exception:
+                    pass
+
+
+def _aggregate(records: list[RunRecord]) -> dict[str, Any]:
+    by_timing: dict[int, list[RunRecord]] = {}
+    for r in records:
+        by_timing.setdefault(r.timing_variant_ms, []).append(r)
+
+    summary: dict[str, Any] = {"by_timing": {}, "totals": {}}
+    grand_total = 0
+    grand_downgrade = 0
+    grand_connected = 0
+    grand_setup_failed = 0
+    for timing, recs in by_timing.items():
+        n = len(recs)
+        connected = sum(1 for r in recs if r.outcome == "connected_to_parent")
+        downgrade = sum(1 for r in recs if r.outcome == "ephemeral_downgrade")
+        setup_failed = sum(1 for r in recs if r.setup_failed)
+        unknown = sum(1 for r in recs if r.outcome == "unknown")
+        summary["by_timing"][str(timing)] = {
+            "runs": n,
+            "connected_to_parent": connected,
+            "ephemeral_downgrade": downgrade,
+            "setup_failed": setup_failed,
+            "unknown": unknown,
+        }
+        grand_total += n
+        grand_connected += connected
+        grand_downgrade += downgrade
+        grand_setup_failed += setup_failed
+    summary["totals"] = {
+        "runs": grand_total,
+        "connected_to_parent": grand_connected,
+        "ephemeral_downgrade": grand_downgrade,
+        "setup_failed": grand_setup_failed,
+    }
+    usable = grand_total - grand_setup_failed
+    if grand_downgrade > 0:
+        summary["interpretation"] = "ca2_failed_race_reproducible"
+    elif usable > 0:
+        summary["interpretation"] = "ca2_verified_race_not_reproducible"
+    else:
+        # Every cycle setup-failed: no usable data points, cannot
+        # conclude either way.
+        summary["interpretation"] = "inconclusive"
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="RDR-094 Spike B: subagent T1 sharing race probe.",
+    )
+    parser.add_argument(
+        "--runs", type=int, default=10,
+        help="Runs per timing variant (default 10; RDR target is 10).",
+    )
+    parser.add_argument(
+        "--timings", type=str,
+        default=",".join(str(t) for t in DEFAULT_TIMINGS_MS),
+        help=(
+            "Comma-separated dispatch-delay timing variants in ms. "
+            f"Default {','.join(str(t) for t in DEFAULT_TIMINGS_MS)}."
+        ),
+    )
+    args = parser.parse_args()
+
+    timings = [int(t.strip()) for t in args.timings.split(",") if t.strip()]
+    if not timings:
+        print("no timing variants supplied", file=sys.stderr)
+        return 1
+
+    print(
+        f"Spike B: {args.runs} runs x {len(timings)} timings = "
+        f"{args.runs * len(timings)} cycles. Timings (ms): {timings}",
+        flush=True,
+    )
+
+    results: list[RunRecord] = []
+    RESULTS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with RESULTS_PATH.open("a") as out:
+        for timing in timings:
+            for run_id in range(args.runs):
+                rec = _run_cycle(timing, run_id)
+                out.write(json.dumps(asdict(rec)) + "\n")
+                out.flush()
+                results.append(rec)
+                print(
+                    f"[t={timing}ms/run={run_id}] outcome={rec.outcome} "
+                    f"elapsed={rec.elapsed_ms:.1f}ms",
+                    flush=True,
+                )
+
+    summary = _aggregate(results)
+    SUMMARY_PATH.write_text(json.dumps(summary, indent=2))
+    print("\n=== SUMMARY ===")
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_spike_rdr094_b_subagent_race.py
+++ b/tests/test_spike_rdr094_b_subagent_race.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Deterministic tests for the RDR-094 Spike B race-probe harness.
+
+The harness itself spawns real subprocesses (nx-mcp + a Python child
+that constructs T1Database), so end-to-end exercise is out of scope
+for unit tests -- the 40-cycle evidence pass is run by Hal on demand
+and persisted to T2 ``nexus_rdr/094-spike-b-subagent-race``. What we
+*can* pin here are the pure-python pieces: outcome classification +
+aggregation + module structure (nexus-zsqf).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SPIKE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "spikes"
+    / "spike_rdr094_b_subagent_race.py"
+)
+
+
+@pytest.fixture(scope="module")
+def harness():
+    spec = importlib.util.spec_from_file_location("spike_rdr094_b", _SPIKE_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["spike_rdr094_b"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── _classify_outcome ───────────────────────────────────────────────────────
+
+
+class TestClassifyOutcome:
+    """Three diagnostic verdicts encode CA-2's pass/fail rule:
+
+    * ``connected_to_parent`` -- subagent's T1Database._client is an
+      HttpClient pointing at the parent's chroma. CA-2 holds.
+    * ``ephemeral_downgrade`` -- _client is an EphemeralClient. The
+      silent-downgrade signature; CA-2 fails for this cycle.
+    * ``setup_failed`` -- harness couldn't get nx-mcp + chroma up.
+      Excluded from the pass/fail tally.
+    """
+
+    def test_http_client_classifies_as_connected(self, harness):
+        stdout = json.dumps({
+            "client_class": "HttpClient",
+            "session_id": "abc",
+        }) + "\n"
+        assert harness._classify_outcome(stdout, setup_failed=False) == "connected_to_parent"
+
+    def test_ephemeral_client_classifies_as_downgrade(self, harness):
+        stdout = json.dumps({
+            "client_class": "EphemeralClient",
+            "session_id": "abc",
+        }) + "\n"
+        assert harness._classify_outcome(stdout, setup_failed=False) == "ephemeral_downgrade"
+
+    def test_setup_failed_short_circuits(self, harness):
+        """Harness-detected setup failure outranks any client output."""
+        stdout = json.dumps({"client_class": "HttpClient"}) + "\n"
+        assert harness._classify_outcome(stdout, setup_failed=True) == "setup_failed"
+
+    def test_blank_stdout_is_unknown(self, harness):
+        assert harness._classify_outcome("", setup_failed=False) == "unknown"
+
+    def test_garbage_stdout_is_unknown(self, harness):
+        assert harness._classify_outcome("not-json\n", setup_failed=False) == "unknown"
+
+    def test_last_json_line_wins(self, harness):
+        """Probe may print warnings before the final JSON line."""
+        stdout = (
+            "warning: something happened\n"
+            "more text\n"
+            + json.dumps({"client_class": "HttpClient"})
+            + "\n"
+        )
+        assert harness._classify_outcome(stdout, setup_failed=False) == "connected_to_parent"
+
+    def test_persistent_client_class_classifies_as_connected(self, harness):
+        """Some chromadb versions name the http client variant slightly
+        differently; substring 'HttpClient' is the load-bearing token."""
+        stdout = json.dumps({
+            "client_class": "FastAPIHttpClient",
+            "session_id": "abc",
+        }) + "\n"
+        assert harness._classify_outcome(stdout, setup_failed=False) == "connected_to_parent"
+
+
+# ── _aggregate ──────────────────────────────────────────────────────────────
+
+
+def _make_record(harness, timing_ms: int, run_id: int, outcome: str):
+    return harness.RunRecord(
+        timing_variant_ms=timing_ms,
+        run_id=run_id,
+        outcome=outcome,
+        elapsed_ms=10.0,
+        setup_failed=outcome == "setup_failed",
+        error=None,
+    )
+
+
+class TestAggregate:
+
+    def test_zero_downgrade_verifies_ca2(self, harness):
+        records = [
+            _make_record(harness, t, i, "connected_to_parent")
+            for t in (0, 50)
+            for i in range(3)
+        ]
+        summary = harness._aggregate(records)
+        assert summary["totals"]["ephemeral_downgrade"] == 0
+        assert summary["totals"]["connected_to_parent"] == 6
+        assert summary["interpretation"] == "ca2_verified_race_not_reproducible"
+
+    def test_any_downgrade_fails_ca2(self, harness):
+        records = [
+            _make_record(harness, 0, 0, "connected_to_parent"),
+            _make_record(harness, 0, 1, "ephemeral_downgrade"),  # the failure
+            _make_record(harness, 50, 0, "connected_to_parent"),
+        ]
+        summary = harness._aggregate(records)
+        assert summary["totals"]["ephemeral_downgrade"] == 1
+        assert summary["interpretation"] == "ca2_failed_race_reproducible"
+
+    def test_all_setup_failed_is_inconclusive(self, harness):
+        records = [_make_record(harness, 0, i, "setup_failed") for i in range(3)]
+        summary = harness._aggregate(records)
+        assert summary["totals"]["setup_failed"] == 3
+        # Without any usable cycles, we cannot conclude either way.
+        assert summary["interpretation"] == "inconclusive"
+
+    def test_per_timing_breakdown_includes_all_outcomes(self, harness):
+        records = [
+            _make_record(harness, 0, 0, "connected_to_parent"),
+            _make_record(harness, 0, 1, "ephemeral_downgrade"),
+            _make_record(harness, 0, 2, "setup_failed"),
+            _make_record(harness, 0, 3, "unknown"),
+        ]
+        summary = harness._aggregate(records)
+        bucket = summary["by_timing"]["0"]
+        assert bucket["runs"] == 4
+        assert bucket["connected_to_parent"] == 1
+        assert bucket["ephemeral_downgrade"] == 1
+        assert bucket["setup_failed"] == 1
+        assert bucket["unknown"] == 1
+
+
+# ── Module structure ────────────────────────────────────────────────────────
+
+
+class TestSpikeStructure:
+    """Verify the harness exposes the surfaces other harnesses (and the
+    runtime evidence pass on Hal's machine) rely on."""
+
+    def test_default_timings_match_rdr_protocol(self, harness):
+        """RDR §CA-2 specifies 0/5/50/200 ms dispatch delays."""
+        assert harness.DEFAULT_TIMINGS_MS == (0, 5, 50, 200)
+
+    def test_run_record_has_required_fields(self, harness):
+        rec = _make_record(harness, 0, 0, "connected_to_parent")
+        # asdict round-trip ensures the dataclass schema is stable.
+        from dataclasses import asdict
+        d = asdict(rec)
+        for key in (
+            "timing_variant_ms", "run_id", "outcome",
+            "elapsed_ms", "setup_failed", "error",
+        ):
+            assert key in d, f"RunRecord missing field {key!r}"
+
+    def test_subagent_probe_imports_t1database(self, harness):
+        """The probe code injected into the child must end up calling
+        T1Database; otherwise the spike measures nothing."""
+        assert "T1Database" in harness._SUBAGENT_PROBE
+        assert "T1Database()" in harness._SUBAGENT_PROBE
+        assert "client_class" in harness._SUBAGENT_PROBE
+
+    def test_run_cycle_function_exists(self, harness):
+        assert callable(harness._run_cycle)
+
+    def test_main_dispatcher_callable(self, harness):
+        assert callable(harness.main)


### PR DESCRIPTION
## Summary

Phase D verifies CA-2 from RDR-094: a subagent dispatched within milliseconds of top-level MCP startup may observe \`NX_SESSION_ID\` set but find the parent's session record not yet written, causing a **silent** \`EphemeralClient\` downgrade in \`T1Database.__init__\`. The race window lives between MCP's \`start_t1_server()\` and its \`write_session_record_by_id()\` call.

## Per-cycle protocol

Modeled on \`spike_rdr094_lifecycle.py\`:

1. Set up isolated \`NEXUS_CONFIG_DIR\` tmpdir.
2. Spawn nx-mcp with \`NEXUS_MCP_OWNS_T1=1\` and a fresh \`NX_SESSION_ID\`.
3. Wait \`timing_variant_ms\` from the moment nx-mcp was spawned.
4. Spawn a child subprocess (the "subagent") that inherits \`NX_SESSION_ID\` + \`NEXUS_CONFIG_DIR\` and constructs \`T1Database\`. Child prints \`{client_class, session_id, warnings}\` on stdout.
5. Classify cycle by inspecting the inner client class:
    - \`HttpClient\` -> \`connected_to_parent\` (CA-2 holds)
    - \`EphemeralClient\` -> \`ephemeral_downgrade\` (CA-2 fails)
    - \`setup_failed\` -> nx-mcp didn't get chroma up (excluded)
    - \`unknown\` -> child timed out / no parseable output

Default protocol: 10 runs x 4 timings (0/5/50/200 ms) = **40 cycles**.

## Decision rule

- 0 \`ephemeral_downgrade\` across all cycles -> CA-2 verified, race not reproducible. Phase E + F unblocked.
- \`>=1\` \`ephemeral_downgrade\` at any timing -> race reproducible. File a follow-up bead for retry-with-backoff in \`T1Database.__init__\` (or \`_resolve_top_level_session_id\` per the bead's note).

## Test plan

- [x] \`tests/test_spike_rdr094_b_subagent_race.py\` -- 16 deterministic tests (0.04s):
  - \`TestClassifyOutcome\` pins the four verdicts (HttpClient / EphemeralClient / setup_failed / unknown) plus a "persistent client class variant" sentinel
  - \`TestAggregate\` pins the CA-2 interpretation: \`ca2_verified\` / \`ca2_failed\` / \`inconclusive\` (when every cycle setup-failed)
  - \`TestSpikeStructure\` verifies default timings match RDR §CA-2 (0/5/50/200 ms), the \`_SUBAGENT_PROBE\` actually imports \`T1Database\`, and the dispatcher signature is intact
- [x] No em dashes in additions

## Evidence collection

Real 40-cycle evidence is collected by Hal on demand:

\`\`\`bash
uv run python scripts/spikes/spike_rdr094_b_subagent_race.py
\`\`\`

Results append to \`scripts/spikes/spike_rdr094_b_results.jsonl\` and \`scripts/spikes/spike_rdr094_b_summary.json\`. Per the bead's acceptance, the summary's \`interpretation\` field drives the next step:
- \`ca2_verified_race_not_reproducible\` -> persist to T2 \`nexus_rdr/094-spike-b-subagent-race\`, mark CA-2 VERIFIED in RDR-094, unblock Phase E/F
- \`ca2_failed_race_reproducible\` -> file the retry-with-backoff follow-up, implement, re-run

## Closes

Closes nexus-zsqf when 40-cycle evidence is collected and CA-2 is annotated. The harness + classification logic ship in this PR; the runtime evidence pass is hand-driven (same pattern as PR #304 nexus-sawb).