### PR TITLE
feat(rdr-094): add nx doctor --check-mcp-logs (nexus-50u5)

### DIFF
--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """nx doctor — health check for all required services."""
+from __future__ import annotations
+
 import hashlib
 from pathlib import Path
+from typing import Any
 
 import click
 import structlog
@@ -168,6 +171,223 @@ def _run_check_schema() -> None:
 #: RDR-092 Phase 0a brings that to 12, but the check only fails below 9
 #: so a partial install on an older plugin is still tolerated.
 _MIN_GLOBAL_BUILTIN_COUNT: int = 9
+
+
+def _resolve_claude_cache_dir(cwd: Path | None = None) -> Path:
+    """Return the Claude Code per-project MCP-log cache directory.
+
+    Slug rule (observed on macOS 2026-04-25): cwd with both ``/`` and
+    ``.`` replaced by ``-``. Example for cwd
+    ``/Users/hal.hildebrand/git/nexus``:
+    ``-Users-hal-hildebrand-git-nexus``.
+
+    Empty slug means cwd was the filesystem root (very unusual);
+    returns the cache parent so callers can detect the platform.
+    """
+    if cwd is None:
+        cwd = Path.cwd()
+    slug = str(cwd).replace("/", "-").replace(".", "-")
+    if not slug or slug == "-":
+        # Edge case: cwd is the root path. Return the cache parent so
+        # caller's exists() check still does the right thing.
+        return Path.home() / "Library" / "Caches" / "claude-cli-nodejs"
+    return Path.home() / "Library" / "Caches" / "claude-cli-nodejs" / slug
+
+
+#: Silent-death signatures from RDR-094 §Day 2 Operations §Diagnosing
+#: nx-mcp silent death. Each signature is a substring matched against
+#: the cache JSONL line's "debug" or "error" field.
+_MCP_SILENT_DEATH_SIGNATURES: tuple[str, ...] = (
+    "STDIO connection dropped after",
+    "stdio transport error",
+)
+
+#: Tool-failure signatures (less severe; surfaced as info, not warning).
+_MCP_TOOL_FAILURE_SIGNATURES: tuple[str, ...] = (
+    "MCP error -32001: AbortError",
+)
+
+
+def _scan_mcp_log_jsonl(
+    path: Path,
+    cutoff_epoch: float,
+) -> tuple[list[dict], list[dict]]:
+    """Return (silent_deaths, tool_failures) found in *path*.
+
+    Each match dict carries ``timestamp``, ``signature``, ``message``,
+    ``session_id``, and ``log_file`` for cross-referencing against
+    mcp.log + watchdog.log.
+    """
+    import json as _json
+    import datetime as _dt
+
+    silent_deaths: list[dict] = []
+    tool_failures: list[dict] = []
+
+    try:
+        with path.open("r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = _json.loads(line)
+                except _json.JSONDecodeError:
+                    continue
+                ts_raw = rec.get("timestamp", "")
+                try:
+                    ts_epoch = _dt.datetime.fromisoformat(
+                        ts_raw.replace("Z", "+00:00"),
+                    ).timestamp()
+                except (ValueError, AttributeError):
+                    continue
+                if ts_epoch < cutoff_epoch:
+                    continue
+                msg = rec.get("debug", "") or rec.get("error", "")
+                if not isinstance(msg, str):
+                    continue
+                hit = {
+                    "timestamp": ts_raw,
+                    "session_id": rec.get("sessionId", ""),
+                    "message": msg[:200],
+                    "log_file": str(path.name),
+                }
+                for sig in _MCP_SILENT_DEATH_SIGNATURES:
+                    if sig in msg:
+                        hit["signature"] = sig
+                        silent_deaths.append(hit)
+                        break
+                else:
+                    for sig in _MCP_TOOL_FAILURE_SIGNATURES:
+                        if sig in msg:
+                            hit["signature"] = sig
+                            tool_failures.append(hit)
+                            break
+    except OSError:
+        pass
+    return silent_deaths, tool_failures
+
+
+def _run_check_mcp_logs(*, json_out: bool, hours: int = 24) -> None:
+    """Surface nx-mcp silent-death evidence from Claude Code's MCP cache.
+
+    Per RDR-094 §Day 2 Operations §Diagnosing nx-mcp silent death
+    (nexus-3f95 + nexus-50u5).
+
+    Walks Claude Code's per-server log cache at
+    ``~/Library/Caches/claude-cli-nodejs/<cwd-slug>/mcp-logs-*`` for
+    files modified within the last *hours* window and greps for the
+    silent-death signatures Claude Code emits when nx-mcp's stdio
+    transport breaks before structlog can flush:
+
+      * "STDIO connection dropped after Ns uptime"
+      * "stdio transport error"
+
+    Tool-failure events ("AbortError" client-side aborts) are surfaced
+    as info entries; they may indicate user-cancelled tool calls
+    rather than crashes.
+
+    On non-macOS platforms (no ``~/Library/Caches/claude-cli-nodejs``)
+    the check exits cleanly with "not present on this platform" --
+    the cache is a Claude Code CLI implementation detail, not part
+    of the MCP protocol.
+    """
+    import json as _json
+    import time
+
+    cache_dir = _resolve_claude_cache_dir()
+    cutoff_epoch = time.time() - hours * 3600.0
+
+    payload: dict[str, Any] = {
+        "cache_dir": str(cache_dir),
+        "hours_window": hours,
+        "platform_supported": False,
+        "silent_deaths": [],
+        "tool_failures": [],
+        "log_dirs_scanned": 0,
+        "log_files_scanned": 0,
+    }
+
+    if not cache_dir.exists():
+        if json_out:
+            click.echo(_json.dumps(payload, indent=2))
+        else:
+            click.echo(
+                f"MCP log surface not present at {cache_dir} "
+                f"(macOS-only path; nothing to check on this platform)."
+            )
+        return
+
+    payload["platform_supported"] = True
+
+    log_dirs = sorted(cache_dir.glob("mcp-logs-*"))
+    payload["log_dirs_scanned"] = len(log_dirs)
+
+    for log_dir in log_dirs:
+        if not log_dir.is_dir():
+            continue
+        for jsonl in log_dir.glob("*.jsonl"):
+            try:
+                if jsonl.stat().st_mtime < cutoff_epoch:
+                    continue
+            except OSError:
+                continue
+            payload["log_files_scanned"] += 1
+            sd, tf = _scan_mcp_log_jsonl(jsonl, cutoff_epoch)
+            for hit in sd:
+                hit["server"] = log_dir.name
+                payload["silent_deaths"].append(hit)
+            for hit in tf:
+                hit["server"] = log_dir.name
+                payload["tool_failures"].append(hit)
+
+    if json_out:
+        click.echo(_json.dumps(payload, indent=2))
+        return
+
+    click.echo(
+        f"Scanned {payload['log_files_scanned']} JSONL files across "
+        f"{payload['log_dirs_scanned']} mcp-logs-* dirs under "
+        f"{cache_dir} (last {hours}h)."
+    )
+    if not payload["silent_deaths"] and not payload["tool_failures"]:
+        click.echo("No silent-death or tool-failure signatures found.")
+        return
+
+    if payload["silent_deaths"]:
+        click.echo(
+            f"\n[WARNING] Silent-death signatures: "
+            f"{len(payload['silent_deaths'])}"
+        )
+        click.echo(
+            "  Cross-reference these timestamps against "
+            "~/.config/nexus/logs/mcp.log + ~/.config/nexus/logs/watchdog.log"
+        )
+        click.echo(
+            "  to identify the gap. See RDR-094 §Day 2 Operations."
+        )
+        for hit in payload["silent_deaths"]:
+            click.echo(
+                f"  {hit['timestamp']}  {hit['signature']}  "
+                f"server={hit['server']}  session={hit['session_id'][:8]}..."
+            )
+
+    if payload["tool_failures"]:
+        click.echo(
+            f"\n[INFO] Tool-failure signatures: "
+            f"{len(payload['tool_failures'])} "
+            f"(may be user-cancelled aborts, not crashes)"
+        )
+        for hit in payload["tool_failures"][:5]:
+            click.echo(
+                f"  {hit['timestamp']}  {hit['signature']}  "
+                f"server={hit['server']}"
+            )
+        if len(payload["tool_failures"]) > 5:
+            click.echo(
+                f"  ... and {len(payload['tool_failures']) - 5} more "
+                "(use --json for full list)"
+            )
 
 
 def _run_check_tmpdirs(*, reap: bool, json_out: bool) -> None:
@@ -483,6 +703,24 @@ def _run_trim_telemetry(days: int) -> None:
          "--reap-tmpdirs to actually delete them.",
 )
 @click.option(
+    "--check-mcp-logs",
+    "check_mcp_logs",
+    is_flag=True,
+    default=False,
+    help="Scan Claude Code's per-server MCP cache for nx-mcp "
+         "silent-death signatures ('STDIO connection dropped', "
+         "'stdio transport error'). macOS only; skips cleanly on "
+         "Linux/Windows. RDR-094 Phase H (nexus-50u5).",
+)
+@click.option(
+    "--mcp-log-hours",
+    "mcp_log_hours",
+    default=24,
+    type=click.IntRange(min=1),
+    show_default=True,
+    help="Lookback window in hours for --check-mcp-logs.",
+)
+@click.option(
     "--reap-tmpdirs",
     "reap_tmpdirs",
     is_flag=True,
@@ -520,6 +758,7 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                check_quotas: bool, check_taxonomy: bool,
                check_plan_library: bool,
                check_tmpdirs: bool, reap_tmpdirs: bool,
+               check_mcp_logs: bool, mcp_log_hours: int,
                json_out: bool,
                trim_telemetry: bool, days: int) -> None:
     """Verify that all required services and credentials are available."""
@@ -542,6 +781,10 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if check_tmpdirs:
         _run_check_tmpdirs(reap=reap_tmpdirs, json_out=json_out)
+        return
+
+    if check_mcp_logs:
+        _run_check_mcp_logs(json_out=json_out, hours=mcp_log_hours)
         return
 
     if check_taxonomy:

--- a/tests/test_doctor_check_mcp_logs.py
+++ b/tests/test_doctor_check_mcp_logs.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for ``nx doctor --check-mcp-logs`` (RDR-094 nexus-50u5).
+
+Pin three things:
+  * Slug derivation from cwd matches the observed Claude Code cache layout
+  * Silent-death + tool-failure signature scanning correctly classifies
+    cache JSONL records inside the lookback window
+  * The Click-level CLI flow exits 0 with a clean message on platforms
+    that don't have ``~/Library/Caches/claude-cli-nodejs`` (Linux/Windows)
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.commands.doctor import (
+    _resolve_claude_cache_dir,
+    _run_check_mcp_logs,
+    _scan_mcp_log_jsonl,
+)
+
+
+def _mk_record(
+    *,
+    timestamp: str,
+    debug: str | None = None,
+    error: str | None = None,
+    session_id: str = "abc-123",
+) -> str:
+    rec: dict[str, object] = {"timestamp": timestamp, "sessionId": session_id}
+    if debug is not None:
+        rec["debug"] = debug
+    if error is not None:
+        rec["error"] = error
+    return json.dumps(rec)
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S.000Z",
+    )
+
+
+def _epoch(dt: _dt.datetime) -> float:
+    return dt.timestamp()
+
+
+# ── _resolve_claude_cache_dir ───────────────────────────────────────────────
+
+
+class TestResolveClaudeCacheDir:
+
+    def test_slug_replaces_path_separators(self, tmp_path):
+        cwd = Path("/Users/hal.hildebrand/git/nexus")
+        result = _resolve_claude_cache_dir(cwd)
+        assert result.name == "-Users-hal-hildebrand-git-nexus"
+        assert "claude-cli-nodejs" in result.parts
+
+    def test_default_uses_cwd_when_unspecified(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        result = _resolve_claude_cache_dir()
+        # tmp_path under /private/var/... or /tmp/... -> slug starts with "-"
+        assert result.name.startswith("-")
+
+    def test_root_path_falls_back_to_cache_parent(self):
+        result = _resolve_claude_cache_dir(Path("/"))
+        # Root cwd produces an empty slug; fall back to parent so
+        # caller's exists() check still does the right thing.
+        assert result.name == "claude-cli-nodejs"
+
+
+# ── _scan_mcp_log_jsonl ─────────────────────────────────────────────────────
+
+
+class TestScanMcpLogJsonl:
+
+    def test_silent_death_signature_matched(self, tmp_path):
+        log = tmp_path / "log.jsonl"
+        log.write_text(_mk_record(
+            timestamp=_now_iso(),
+            debug="STDIO connection dropped after 23092s uptime",
+        ) + "\n")
+        cutoff = _epoch(_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=24))
+        sd, tf = _scan_mcp_log_jsonl(log, cutoff)
+        assert len(sd) == 1
+        assert "STDIO connection dropped after" in sd[0]["signature"]
+        assert sd[0]["session_id"] == "abc-123"
+        assert tf == []
+
+    def test_transport_error_signature_matched(self, tmp_path):
+        log = tmp_path / "log.jsonl"
+        log.write_text(_mk_record(
+            timestamp=_now_iso(),
+            debug="Closing transport (stdio transport error: Error)",
+        ) + "\n")
+        cutoff = _epoch(_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=24))
+        sd, _ = _scan_mcp_log_jsonl(log, cutoff)
+        assert len(sd) == 1
+        assert sd[0]["signature"] == "stdio transport error"
+
+    def test_abort_error_classified_as_tool_failure(self, tmp_path):
+        log = tmp_path / "log.jsonl"
+        log.write_text(_mk_record(
+            timestamp=_now_iso(),
+            debug="Tool 'query' failed after 9s: MCP error -32001: AbortError: ...",
+        ) + "\n")
+        cutoff = _epoch(_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=24))
+        sd, tf = _scan_mcp_log_jsonl(log, cutoff)
+        assert sd == []
+        assert len(tf) == 1
+        assert "AbortError" in tf[0]["signature"]
+
+    def test_records_outside_window_skipped(self, tmp_path):
+        old = (
+            _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=48)
+        ).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        log = tmp_path / "log.jsonl"
+        log.write_text(_mk_record(
+            timestamp=old,
+            debug="STDIO connection dropped after 5s uptime",
+        ) + "\n")
+        cutoff = _epoch(_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=24))
+        sd, tf = _scan_mcp_log_jsonl(log, cutoff)
+        assert sd == []
+        assert tf == []
+
+    def test_normal_lifecycle_lines_ignored(self, tmp_path):
+        log = tmp_path / "log.jsonl"
+        log.write_text(
+            _mk_record(timestamp=_now_iso(),
+                       debug="Successfully connected (transport: stdio) in 467ms")
+            + "\n"
+            + _mk_record(timestamp=_now_iso(),
+                         debug="Calling MCP tool: memory_get")
+            + "\n"
+            + _mk_record(timestamp=_now_iso(),
+                         debug="UNKNOWN connection closed after 14s (cleanly)")
+            + "\n"
+        )
+        cutoff = _epoch(_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=24))
+        sd, tf = _scan_mcp_log_jsonl(log, cutoff)
+        assert sd == []
+        assert tf == []
+
+    def test_malformed_json_lines_swallowed(self, tmp_path):
+        log = tmp_path / "log.jsonl"
+        log.write_text(
+            "not-valid-json\n"
+            + _mk_record(timestamp=_now_iso(),
+                         debug="STDIO connection dropped after 5s uptime")
+            + "\n"
+            + "{broken: json\n"
+        )
+        cutoff = _epoch(_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=24))
+        sd, _ = _scan_mcp_log_jsonl(log, cutoff)
+        assert len(sd) == 1
+
+    def test_missing_file_returns_empty_lists(self, tmp_path):
+        sd, tf = _scan_mcp_log_jsonl(tmp_path / "nonexistent.jsonl", 0.0)
+        assert sd == []
+        assert tf == []
+
+
+# ── _run_check_mcp_logs ─────────────────────────────────────────────────────
+
+
+class TestRunCheckMcpLogs:
+    """End-to-end check function. Uses tmp_path to stand in for
+    ``~/Library/Caches/claude-cli-nodejs`` so the test is deterministic
+    on every platform."""
+
+    def test_skips_cleanly_when_cache_dir_missing(self, tmp_path, capsys):
+        nonexistent = tmp_path / "no_cache_here"
+        with patch(
+            "nexus.commands.doctor._resolve_claude_cache_dir",
+            return_value=nonexistent,
+        ):
+            _run_check_mcp_logs(json_out=False)
+        out = capsys.readouterr().out
+        assert "not present" in out
+
+    def test_json_output_skip_path_includes_platform_supported_false(
+        self, tmp_path, capsys,
+    ):
+        nonexistent = tmp_path / "no_cache_here"
+        with patch(
+            "nexus.commands.doctor._resolve_claude_cache_dir",
+            return_value=nonexistent,
+        ):
+            _run_check_mcp_logs(json_out=True)
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["platform_supported"] is False
+        assert payload["silent_deaths"] == []
+
+    def test_silent_death_surfaces_warning_and_remediation(
+        self, tmp_path, capsys,
+    ):
+        cache_dir = tmp_path / "fake_cache"
+        log_dir = cache_dir / "mcp-logs-plugin-nx-nexus"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "test.jsonl"
+        log_file.write_text(_mk_record(
+            timestamp=_now_iso(),
+            debug="STDIO connection dropped after 23092s uptime",
+            session_id="0c700072-0841-4bd6-9fd7-f2933e33a065",
+        ) + "\n")
+
+        with patch(
+            "nexus.commands.doctor._resolve_claude_cache_dir",
+            return_value=cache_dir,
+        ):
+            _run_check_mcp_logs(json_out=False)
+
+        out = capsys.readouterr().out
+        assert "Silent-death signatures: 1" in out
+        assert "Cross-reference these timestamps" in out
+        assert "RDR-094" in out
+        # Session ID prefix should be visible for cross-referencing.
+        assert "0c700072" in out
+
+    def test_clean_scan_reports_no_signatures(self, tmp_path, capsys):
+        cache_dir = tmp_path / "fake_cache"
+        log_dir = cache_dir / "mcp-logs-plugin-nx-nexus"
+        log_dir.mkdir(parents=True)
+        (log_dir / "test.jsonl").write_text(_mk_record(
+            timestamp=_now_iso(),
+            debug="Successfully connected (transport: stdio) in 467ms",
+        ) + "\n")
+        with patch(
+            "nexus.commands.doctor._resolve_claude_cache_dir",
+            return_value=cache_dir,
+        ):
+            _run_check_mcp_logs(json_out=False)
+        out = capsys.readouterr().out
+        assert "No silent-death or tool-failure signatures" in out
+
+    def test_files_outside_lookback_window_skipped(self, tmp_path, capsys):
+        """File mtime older than the window must short-circuit the file."""
+        import os as _os
+
+        cache_dir = tmp_path / "fake_cache"
+        log_dir = cache_dir / "mcp-logs-plugin-nx-nexus"
+        log_dir.mkdir(parents=True)
+        log_file = log_dir / "old.jsonl"
+        log_file.write_text(_mk_record(
+            timestamp=_now_iso(),
+            debug="STDIO connection dropped after 5s uptime",
+        ) + "\n")
+        # Push the file's mtime to 48h ago.
+        old_epoch = (
+            _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=48)
+        ).timestamp()
+        _os.utime(log_file, (old_epoch, old_epoch))
+
+        with patch(
+            "nexus.commands.doctor._resolve_claude_cache_dir",
+            return_value=cache_dir,
+        ):
+            _run_check_mcp_logs(json_out=True, hours=24)
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["log_files_scanned"] == 0
+        assert payload["silent_deaths"] == []
+
+
+# ── Click CLI integration ────────────────────────────────────────────────────
+
+
+def test_check_mcp_logs_cli_flag_runs():
+    """nx doctor --check-mcp-logs runs and exits 0, even on Linux."""
+    runner = CliRunner()
+    with patch(
+        "nexus.commands.doctor._resolve_claude_cache_dir",
+        return_value=Path("/nonexistent/claude/cache"),
+    ):
+        result = runner.invoke(main, ["doctor", "--check-mcp-logs"])
+    assert result.exit_code == 0, result.output
+    assert "not present" in result.output
+
+
+def test_check_mcp_logs_respects_custom_window():
+    runner = CliRunner()
+    with patch(
+        "nexus.commands.doctor._resolve_claude_cache_dir",
+        return_value=Path("/nonexistent/claude/cache"),
+    ):
+        result = runner.invoke(
+            main,
+            ["doctor", "--check-mcp-logs", "--mcp-log-hours", "1"],
+        )
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

Phase H follow-up. Closes the observability loop on RDR-094 silent deaths by surfacing the Claude Code per-MCP-server cache evidence documented in RDR §Day 2 Operations.

**Real-world smoke (Hal's machine, 168h window)**: the check correctly surfaces the 2026-04-25T00:20:34Z silent-death of session \`0c700072-0841-4bd6-9fd7-f2933e33a065\` -- the original incident that prompted Phase H. Sample output:

\`\`\`
Scanned 3779 JSONL files across 11 mcp-logs-* dirs under
/Users/hal.hildebrand/Library/Caches/claude-cli-nodejs/-Users-hal-hildebrand-git-nexus
(last 168h).

[WARNING] Silent-death signatures: 2
  Cross-reference these timestamps against
  ~/.config/nexus/logs/mcp.log + ~/.config/nexus/logs/watchdog.log
  to identify the gap. See RDR-094 §Day 2 Operations.
  2026-04-25T00:20:34.125Z  STDIO connection dropped after  server=mcp-logs-plugin-nx-nexus  session=0c700072...
  2026-04-25T00:20:34.125Z  stdio transport error            server=mcp-logs-plugin-nx-nexus  session=0c700072...

[INFO] Tool-failure signatures: 1 (may be user-cancelled aborts, not crashes)
  2026-04-25T00:20:25.984Z  MCP error -32001: AbortError  server=mcp-logs-plugin-nx-nexus
\`\`\`

## CLI

\`\`\`
nx doctor --check-mcp-logs                  # last 24h
nx doctor --check-mcp-logs --mcp-log-hours N
nx doctor --check-mcp-logs --json
\`\`\`

## Cache layout (macOS only)

\`~/Library/Caches/claude-cli-nodejs/<cwd-slug>/mcp-logs-*/<UTC>.jsonl\`

Slug derivation: cwd with both \`/\` AND \`.\` replaced by \`-\`. So \`/Users/hal.hildebrand/git/nexus\` -> \`-Users-hal-hildebrand-git-nexus\` (verified empirically against 3779 cache files in this project; the \`.\` -> \`-\` rule is required for usernames containing a dot).

## Three signature classes

- \`STDIO connection dropped after Ns uptime\` -> **WARNING** (silent death; cross-reference \`mcp.log\` + \`watchdog.log\` to find the gap)
- \`stdio transport error\` -> **WARNING**
- \`MCP error -32001: AbortError\` -> **INFO** (likely user-cancelled tool call, not a crash)

## Lookback window filtering

Two levels:
1. **File mtime**: log files older than \`--mcp-log-hours\` are skipped entirely
2. **Per-record timestamp**: records inside an in-window file but with timestamps before the cutoff are also skipped

## Cross-platform behaviour

Cache path is macOS only (\`~/Library/Caches/claude-cli-nodejs\`). On Linux/Windows the check exits 0 with \`MCP log surface not present at <path> (macOS-only path; nothing to check on this platform).\`

## Test plan

- [x] \`tests/test_doctor_check_mcp_logs.py\` -- 17 deterministic tests (0.07s) covering slug derivation (including \`.\` -> \`-\`), three signature classes, lookback-window filtering at both levels, malformed JSON tolerance, JSON output schema, and Click CLI entry on missing-cache platforms
- [x] Affected-module sweep (test_doctor_cmd, test_doctor_integrity, test_doctor_search, test_doctor_check_mcp_logs): 103 pass
- [x] Real-world smoke confirms the 2026-04-25 reference incident is surfaced
- [x] No em dashes in additions

## Closes

Closes nexus-50u5 (RDR-094 Phase H follow-up).