### PR TITLE
fix(rdr-094): correct Spike B classifier + aggregator (nexus-zsqf)

### DIFF
--- a/scripts/spikes/spike_rdr094_b_subagent_race.py
+++ b/scripts/spikes/spike_rdr094_b_subagent_race.py
@@ -105,21 +105,36 @@ class RunRecord:
     elapsed_ms: float
     setup_failed: bool
     error: Optional[str]
+    # Diagnostic tail when the probe failed to produce a parseable
+    # outcome line. Empty string when the cycle classified cleanly.
+    child_stderr_tail: str = ""
+
+
+#: Substring that appears in T1Database.__init__'s warning when the
+#: subagent falls through to chromadb.EphemeralClient(). The warning
+#: is the canonical signal for the silent-downgrade because both
+#: HttpClient and EphemeralClient are factory functions returning
+#: ``chromadb.api.client.Client``; ``type(client).__name__`` cannot
+#: distinguish them.
+_DOWNGRADE_WARNING = "falling back to local EphemeralClient"
 
 
 def _classify_outcome(child_stdout: str, setup_failed: bool) -> str:
     """Classify a cycle outcome from the child's reported state.
 
     Vocabulary:
-      * ``connected_to_parent`` -- child's ``T1Database._client`` is a
-        ``HttpClient`` pointed at the parent's chroma.
-      * ``ephemeral_downgrade`` -- child's ``_client`` is an
-        ``EphemeralClient`` (the silent-downgrade signature).
+      * ``connected_to_parent`` -- the subagent's
+        :class:`T1Database` resolved a session record and connected
+        via ``HttpClient``. Probe records this as
+        ``outcome=connected_to_parent``.
+      * ``ephemeral_downgrade`` -- the subagent fell through to
+        ``chromadb.EphemeralClient`` (the silent-downgrade signature).
+        Probe records this as ``outcome=ephemeral_downgrade``.
       * ``setup_failed`` -- the harness could not get nx-mcp +
         chroma up at all; CA-2 cannot be tested in this cycle.
       * ``unknown`` -- the child never printed a parseable outcome
-        line. Treated as a hard failure (probably nx-mcp crash or
-        child timeout).
+        line. Treated as inconclusive (probably nx-mcp crash, child
+        import error, or timeout).
     """
     if setup_failed:
         return "setup_failed"
@@ -131,11 +146,17 @@ def _classify_outcome(child_stdout: str, setup_failed: bool) -> str:
             obj = json.loads(line)
         except json.JSONDecodeError:
             continue
-        client_kind = obj.get("client_class", "")
-        if "HttpClient" in client_kind:
-            return "connected_to_parent"
-        if "Ephemeral" in client_kind:
-            return "ephemeral_downgrade"
+        # Probe-side classification (preferred): the child computed
+        # the outcome directly from the warnings stream.
+        outcome = obj.get("outcome", "")
+        if outcome in ("connected_to_parent", "ephemeral_downgrade"):
+            return outcome
+        # Fallback for older harness output: warnings inspection.
+        for w in obj.get("warnings", []) or []:
+            if _DOWNGRADE_WARNING in str(w):
+                return "ephemeral_downgrade"
+        # Probe ran but produced no diagnostic signal -- keep as unknown
+        # rather than silently classifying as connected_to_parent.
     return "unknown"
 
 
@@ -143,14 +164,16 @@ _SUBAGENT_PROBE = """
 # Subagent T1 race probe.
 #
 # Inherits NX_SESSION_ID + NEXUS_CONFIG_DIR from parent. Constructs a
-# fresh T1Database and prints {client_class, session_id} on stdout.
+# fresh T1Database; computes the outcome directly from the captured
+# warning stream (chromadb.HttpClient and chromadb.EphemeralClient
+# both return chromadb.api.client.Client, so type() cannot
+# distinguish them; the T1Database fallback warning is the canonical
+# signal).
 import json
 import os
 import sys
 import warnings
 
-# Capture downgrade warning for diagnostic context (not for outcome
-# classification -- the client class is the authoritative signal).
 warnings.simplefilter("always")
 captured: list[str] = []
 
@@ -162,7 +185,9 @@ warnings.showwarning = _capture
 from nexus.db.t1 import T1Database
 
 t1 = T1Database()
+downgraded = any("falling back to local EphemeralClient" in str(w) for w in captured)
 print(json.dumps({
+    "outcome": "ephemeral_downgrade" if downgraded else "connected_to_parent",
     "client_class": type(t1._client).__name__,
     "session_id": t1._session_id,
     "warnings": captured,
@@ -232,7 +257,7 @@ def _run_cycle(timing_variant_ms: int, run_id: int) -> RunRecord:
             time.sleep(timing_variant_ms / 1000.0)
 
         try:
-            stdout, _stderr, _rc = _spawn_subagent_probe(env, CHILD_TIMEOUT_S)
+            stdout, stderr, _rc = _spawn_subagent_probe(env, CHILD_TIMEOUT_S)
         except subprocess.TimeoutExpired:
             elapsed_ms = (time.monotonic() - t0) * 1000.0
             return RunRecord(
@@ -251,12 +276,19 @@ def _run_cycle(timing_variant_ms: int, run_id: int) -> RunRecord:
         record_path = cycle_dir / "sessions" / f"{session_id}.session"
         record_present = record_path.exists()
         outcome = _classify_outcome(stdout, setup_failed=not record_present and stdout == "")
+        # Capture child stderr tail when classification couldn't read
+        # a positive signal -- gives the operator something to debug
+        # without spelunking through 40 cycles of tmpdirs.
+        stderr_tail = ""
+        if outcome == "unknown" and stderr:
+            stderr_tail = stderr.strip().splitlines()[-1][:300] if stderr.strip() else ""
         return RunRecord(
             timing_variant_ms=timing_variant_ms,
             run_id=run_id, outcome=outcome,
             elapsed_ms=round(elapsed_ms, 2),
             setup_failed=outcome == "setup_failed",
             error=None,
+            child_stderr_tail=stderr_tail,
         )
     finally:
         if parent is not None and parent.poll() is None:
@@ -303,14 +335,15 @@ def _aggregate(records: list[RunRecord]) -> dict[str, Any]:
         "ephemeral_downgrade": grand_downgrade,
         "setup_failed": grand_setup_failed,
     }
-    usable = grand_total - grand_setup_failed
+    # Verification needs POSITIVE evidence (>=1 connected_to_parent) AND
+    # zero downgrades. All-unknown / all-setup-failed is inconclusive,
+    # not verified -- otherwise a probe that always crashes would
+    # falsely confirm CA-2.
     if grand_downgrade > 0:
         summary["interpretation"] = "ca2_failed_race_reproducible"
-    elif usable > 0:
+    elif grand_connected > 0:
         summary["interpretation"] = "ca2_verified_race_not_reproducible"
     else:
-        # Every cycle setup-failed: no usable data points, cannot
-        # conclude either way.
         summary["interpretation"] = "inconclusive"
     return summary
 

--- a/tests/test_spike_rdr094_b_subagent_race.py
+++ b/tests/test_spike_rdr094_b_subagent_race.py
@@ -39,33 +39,52 @@ def harness():
 
 
 class TestClassifyOutcome:
-    """Three diagnostic verdicts encode CA-2's pass/fail rule:
+    """Four diagnostic verdicts encode CA-2's pass/fail rule:
 
-    * ``connected_to_parent`` -- subagent's T1Database._client is an
-      HttpClient pointing at the parent's chroma. CA-2 holds.
-    * ``ephemeral_downgrade`` -- _client is an EphemeralClient. The
-      silent-downgrade signature; CA-2 fails for this cycle.
+    * ``connected_to_parent`` -- subagent's T1Database resolved a
+      session record and connected via HttpClient. CA-2 holds.
+    * ``ephemeral_downgrade`` -- T1Database fell through to
+      chromadb.EphemeralClient (the silent-downgrade signature).
     * ``setup_failed`` -- harness couldn't get nx-mcp + chroma up.
-      Excluded from the pass/fail tally.
+    * ``unknown`` -- probe ran but gave no parseable signal.
+
+    chromadb.HttpClient and chromadb.EphemeralClient are factory
+    functions that BOTH return ``chromadb.api.client.Client``, so
+    ``type(client).__name__`` cannot distinguish them. The probe
+    inspects the warnings stream and emits ``outcome`` directly;
+    classifier reads that field with a warnings-fallback for
+    robustness.
     """
 
-    def test_http_client_classifies_as_connected(self, harness):
-        stdout = json.dumps({
-            "client_class": "HttpClient",
-            "session_id": "abc",
-        }) + "\n"
+    def test_explicit_outcome_connected(self, harness):
+        stdout = json.dumps({"outcome": "connected_to_parent"}) + "\n"
         assert harness._classify_outcome(stdout, setup_failed=False) == "connected_to_parent"
 
-    def test_ephemeral_client_classifies_as_downgrade(self, harness):
+    def test_explicit_outcome_downgrade(self, harness):
+        stdout = json.dumps({"outcome": "ephemeral_downgrade"}) + "\n"
+        assert harness._classify_outcome(stdout, setup_failed=False) == "ephemeral_downgrade"
+
+    def test_warnings_fallback_classifies_downgrade(self, harness):
+        """Old harness output without explicit outcome: warnings inspection."""
         stdout = json.dumps({
-            "client_class": "EphemeralClient",
-            "session_id": "abc",
+            "warnings": [
+                "No T1 server found; falling back to local EphemeralClient. "
+                "Cross-agent scratch sharing is unavailable for this session.",
+            ],
         }) + "\n"
         assert harness._classify_outcome(stdout, setup_failed=False) == "ephemeral_downgrade"
 
+    def test_no_outcome_no_warnings_is_unknown(self, harness):
+        """Probe ran but produced neither explicit outcome nor downgrade
+        warning. Conservative: return unknown, do NOT silently classify
+        as connected_to_parent (otherwise a probe with broken warning
+        capture would falsely confirm CA-2)."""
+        stdout = json.dumps({"client_class": "Client"}) + "\n"
+        assert harness._classify_outcome(stdout, setup_failed=False) == "unknown"
+
     def test_setup_failed_short_circuits(self, harness):
-        """Harness-detected setup failure outranks any client output."""
-        stdout = json.dumps({"client_class": "HttpClient"}) + "\n"
+        """Harness-detected setup failure outranks any probe output."""
+        stdout = json.dumps({"outcome": "connected_to_parent"}) + "\n"
         assert harness._classify_outcome(stdout, setup_failed=True) == "setup_failed"
 
     def test_blank_stdout_is_unknown(self, harness):
@@ -79,18 +98,9 @@ class TestClassifyOutcome:
         stdout = (
             "warning: something happened\n"
             "more text\n"
-            + json.dumps({"client_class": "HttpClient"})
+            + json.dumps({"outcome": "connected_to_parent"})
             + "\n"
         )
-        assert harness._classify_outcome(stdout, setup_failed=False) == "connected_to_parent"
-
-    def test_persistent_client_class_classifies_as_connected(self, harness):
-        """Some chromadb versions name the http client variant slightly
-        differently; substring 'HttpClient' is the load-bearing token."""
-        stdout = json.dumps({
-            "client_class": "FastAPIHttpClient",
-            "session_id": "abc",
-        }) + "\n"
         assert harness._classify_outcome(stdout, setup_failed=False) == "connected_to_parent"
 
 
@@ -138,6 +148,24 @@ class TestAggregate:
         # Without any usable cycles, we cannot conclude either way.
         assert summary["interpretation"] == "inconclusive"
 
+    def test_all_unknown_is_inconclusive_not_verified(self, harness):
+        """Regression sentinel for the bug found on the first 40-cycle
+        run: every cycle classified as 'unknown' (probe never produced
+        a parseable signal) was wrongly interpreted as
+        ca2_verified_race_not_reproducible. Verification must require
+        positive evidence (>=1 connected_to_parent), not merely zero
+        downgrades.
+        """
+        records = [_make_record(harness, t, i, "unknown")
+                   for t in (0, 5, 50, 200)
+                   for i in range(10)]
+        summary = harness._aggregate(records)
+        assert summary["totals"]["ephemeral_downgrade"] == 0
+        assert summary["totals"]["connected_to_parent"] == 0
+        assert summary["interpretation"] == "inconclusive", (
+            "All-unknown must NOT verify CA-2 -- positive evidence required"
+        )
+
     def test_per_timing_breakdown_includes_all_outcomes(self, harness):
         records = [
             _make_record(harness, 0, 0, "connected_to_parent"),
@@ -182,6 +210,16 @@ class TestSpikeStructure:
         assert "T1Database" in harness._SUBAGENT_PROBE
         assert "T1Database()" in harness._SUBAGENT_PROBE
         assert "client_class" in harness._SUBAGENT_PROBE
+
+    def test_subagent_probe_emits_explicit_outcome(self, harness):
+        """Probe must emit an explicit outcome field (not rely on
+        type(client).__name__ which collapses HttpClient and
+        EphemeralClient to 'Client')."""
+        assert '"outcome"' in harness._SUBAGENT_PROBE
+        assert "ephemeral_downgrade" in harness._SUBAGENT_PROBE
+        assert "connected_to_parent" in harness._SUBAGENT_PROBE
+        # The decision predicate must inspect the warnings stream.
+        assert "falling back to local EphemeralClient" in harness._SUBAGENT_PROBE
 
     def test_run_cycle_function_exists(self, harness):
         assert callable(harness._run_cycle)


### PR DESCRIPTION
## Summary

The first 40-cycle Spike B pass produced **40/40 \`unknown\`** outcomes but the aggregator reported \`ca2_verified_race_not_reproducible\` -- two bugs masked each other.

## Bug 1: probe classification

\`chromadb.HttpClient(...)\` and \`chromadb.EphemeralClient()\` are factory functions that **both return \`chromadb.api.client.Client\`**, so \`type(client).__name__ == "Client"\` for both. The classifier's substring check (\`"HttpClient"\` / \`"Ephemeral"\`) matched neither and returned \`unknown\` for every cycle.

**Fix**: probe now computes outcome directly from the captured warnings stream (\`"falling back to local EphemeralClient"\` is \`T1Database\`'s canonical fallback signal) and emits an explicit \`outcome\` field. Classifier reads that field with a warnings-inspection fallback for older harness output.

## Bug 2: aggregator verification logic

Required only \`grand_downgrade == 0\`, allowing all-unknown to verify CA-2. **Verification now requires POSITIVE evidence (\`>= 1 connected_to_parent\`) AND zero downgrades.** All-unknown is inconclusive.

## Empirical result with the fixed harness

| Dispatch delay | Outcome |
|---|---|
| 200ms | \`ephemeral_downgrade\` |
| 3000ms | \`connected_to_parent\` |

CA-2 race IS reproducible at the bead's specified timings (0/5/50/200ms) because chroma's cold start is ~1-2s. The 200ms window falls inside the race; the 3000ms case is well after the parent has written the session record.

The retry-with-backoff fix in \`T1Database.__init__\` remains warranted; it will be filed as a follow-up bead after the user re-runs the 40 cycles to confirm the failure mode is reproducible at scale (not just one anecdotal cycle).

## Diagnostics

\`RunRecord\` gains \`child_stderr_tail\` for diagnosis when probes classify as \`unknown\` -- operator can spot import errors / timeouts without spelunking through 40 tmpdirs.

## Test plan

- [x] \`tests/test_spike_rdr094_b_subagent_race.py\` 16 -> 19:
  - \`explicit_outcome_connected\` / \`_downgrade\` (new probe contract)
  - \`warnings_fallback_classifies_downgrade\` (back-compat)
  - \`no_outcome_no_warnings_is_unknown\` (the original Bug 1 regression sentinel)
  - \`all_unknown_is_inconclusive_not_verified\` (the original Bug 2 regression sentinel)
  - \`subagent_probe_emits_explicit_outcome\` (probe-side contract)
- [x] No em dashes in additions
- [x] Single-cycle smokes verify probe behavior at 200ms and 3000ms

## Re-run protocol

After merge:

\`\`\`bash
rm scripts/spikes/spike_rdr094_b_results.jsonl scripts/spikes/spike_rdr094_b_summary.json
uv run python scripts/spikes/spike_rdr094_b_subagent_race.py
\`\`\`

Expected new verdict: \`ca2_failed_race_reproducible\`. The retry-with-backoff follow-up bead is filed at that point.

## Closes

Does NOT close nexus-zsqf -- that bead stays open until the rerun + the retry mitigation lands. This PR ships the harness corrections so the rerun produces a meaningful verdict.