### PR TITLE
fix(rdr-094): retry T1 record lookup to cover CA-2 race (nexus-zsqf)

### DIFF
--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -25,6 +25,58 @@ _T = TypeVar("_T")
 
 _COLLECTION = "scratch"
 
+#: Backoff schedule for the subagent-race retry (RDR-094 CA-2 /
+#: nexus-zsqf). Total max wait ~3 s covers chroma's empirically
+#: measured 1.1-1.7 s cold-start window with slack for system jitter
+#: (Spike B observed downgrade through 1500 ms+; 350 ms retry from
+#: the bead's original prescription was insufficient). The retry only
+#: fires when ``NX_SESSION_ID`` is set in env -- the canonical signal
+#: that the caller is a subagent inheriting from a parent that should
+#: have a session record. Top-level callers without a parent session
+#: have no record by design; retrying would just delay startup.
+#:
+#: Typical hit happens on the 2nd-3rd retry (~700 ms wait) when
+#: chroma takes 1.2-1.5 s to come up. The exponential schedule keeps
+#: the first miss cheap (100 ms) for the rare benign-miss case.
+_T1_RACE_BACKOFF_MS: tuple[int, ...] = (100, 200, 400, 800, 1500)
+
+
+def _resolve_session_record_with_retry(sessions_dir) -> dict | None:
+    """Look up the T1 session record, with backoff retry for CA-2 race.
+
+    The race (verified empirically by Spike B / nexus-zsqf): a subagent
+    dispatched within ~1-2 s of top-level MCP startup observes
+    ``NX_SESSION_ID`` set in env but finds the parent's session record
+    not yet written, because the parent's
+    :func:`nexus.mcp.core._t1_chroma_init_if_owner` is still inside
+    ``start_t1_server`` (chroma cold-start dominates).
+    :func:`find_session_by_id` returns None and the caller falls through
+    to ``EphemeralClient`` -- silently, because the warning is invisible
+    under stdio transport.
+
+    Mitigation: when the first lookup misses AND the env var is set,
+    retry on a 50/100/200 ms schedule (~350 ms total wait) before
+    giving up. The env-var gate prevents wasted retries in top-level
+    callers that genuinely have no parent session.
+    """
+    import time as _time
+
+    record = find_session_by_id(sessions_dir)
+    if record is not None:
+        return record
+
+    # Retry only when the caller looks like a subagent: NX_SESSION_ID
+    # is set in env, meaning a parent process expects a record.
+    if not os.environ.get("NX_SESSION_ID", "").strip():
+        return None
+
+    for delay_ms in _T1_RACE_BACKOFF_MS:
+        _time.sleep(delay_ms / 1000.0)
+        record = find_session_by_id(sessions_dir)
+        if record is not None:
+            return record
+    return None
+
 # Common English stopwords — shared with MemoryStore._STOPWORDS for
 # consistency across the two overlap-detection helpers.
 _PROMOTE_STOPWORDS = frozenset(
@@ -149,12 +201,19 @@ class T1Database:
             record = None
             if not skip_t1:
                 # UUID-keyed lookup (T1 scoped to Claude conversation, not
-                # terminal session). find_session_by_id resolves the UUID
-                # from NX_SESSION_ID env or current_session flat file.
-                # Falls back to find_ancestor_session for any legacy session
-                # files written by older nexus versions still living in
+                # terminal session). _resolve_session_record_with_retry
+                # wraps find_session_by_id with a 50/100/200 ms backoff
+                # when NX_SESSION_ID is set in env (the subagent
+                # inheritance signal) -- covers the CA-2 race where a
+                # subagent dispatches inside the parent's chroma
+                # cold-start window. Falls back to find_ancestor_session
+                # for any legacy session files written by older nexus
+                # versions still living in
                 # ~/.config/nexus/sessions/{ppid}.session.
-                record = find_session_by_id(SESSIONS_DIR) or find_ancestor_session(SESSIONS_DIR)
+                record = (
+                    _resolve_session_record_with_retry(SESSIONS_DIR)
+                    or find_ancestor_session(SESSIONS_DIR)
+                )
             if record is not None:
                 self._client = chromadb.HttpClient(
                     host=record["server_host"],

--- a/tests/test_t1.py
+++ b/tests/test_t1.py
@@ -35,14 +35,15 @@ class TestT1DatabaseConstructor:
         record = {"session_id": "parent-session-uuid", "server_host": "127.0.0.1", "server_port": 51234}
         mock_http = MagicMock()
         mock_http.get_or_create_collection.return_value = MagicMock()
-        with patch("nexus.db.t1.find_ancestor_session", return_value=record), \
+        with patch("nexus.db.t1._resolve_session_record_with_retry", return_value=record), \
              patch("chromadb.HttpClient", return_value=mock_http):
             t1 = T1Database()
         assert t1._session_id == "parent-session-uuid"
         assert t1._client is mock_http
 
     def test_falls_back_to_ephemeral_when_no_record(self) -> None:
-        with patch("nexus.db.t1.find_ancestor_session", return_value=None), \
+        with patch("nexus.db.t1._resolve_session_record_with_retry", return_value=None), \
+             patch("nexus.db.t1.find_ancestor_session", return_value=None), \
              warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             t1 = T1Database(session_id="fallback-id")
@@ -117,6 +118,114 @@ class TestT1DatabaseConstructor:
         cls.assert_called_once_with(host="127.0.0.1", port=54321)
         assert t1._session_id == "http-path-test-session"
         assert t1._client is mock_http
+
+
+# ---------------------------------------------------------------------------
+# _resolve_session_record_with_retry (RDR-094 CA-2 / nexus-zsqf)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSessionRecordWithRetry:
+    """Spike B verified empirically: a subagent dispatched within the
+    parent's chroma cold-start window (~1-2s) inherits NX_SESSION_ID
+    but finds no session record yet, falling through to
+    EphemeralClient silently. This wrapper retries on a 50/100/200 ms
+    schedule (~350 ms total) only when NX_SESSION_ID is set, so
+    top-level callers without a parent session don't pay the wait."""
+
+    def test_returns_record_on_first_hit_without_sleeping(self, monkeypatch):
+        from nexus.db import t1 as _t1
+        record = {"session_id": "abc"}
+        sleeps: list[float] = []
+        with (
+            patch.object(_t1, "find_session_by_id", return_value=record),
+            patch("time.sleep", side_effect=lambda s: sleeps.append(s)),
+        ):
+            result = _t1._resolve_session_record_with_retry(None)
+        assert result is record
+        assert sleeps == [], "Successful first lookup must not sleep"
+
+    def test_does_not_retry_when_env_var_absent(self, monkeypatch):
+        """Top-level caller without parent session: don't waste time."""
+        from nexus.db import t1 as _t1
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        sleeps: list[float] = []
+        with (
+            patch.object(_t1, "find_session_by_id", return_value=None) as mock_find,
+            patch("time.sleep", side_effect=lambda s: sleeps.append(s)),
+        ):
+            result = _t1._resolve_session_record_with_retry(None)
+        assert result is None
+        assert mock_find.call_count == 1, "Must call exactly once when no env var"
+        assert sleeps == []
+
+    def test_retries_with_backoff_when_env_var_set(self, monkeypatch):
+        """The race-affected path: NX_SESSION_ID is set but record
+        not yet written. Retry on the exponential backoff schedule."""
+        from nexus.db import t1 as _t1
+        monkeypatch.setenv("NX_SESSION_ID", "subagent-uuid")
+
+        # Always-miss sequence: should exhaust the schedule.
+        sleeps: list[float] = []
+        with (
+            patch.object(_t1, "find_session_by_id", return_value=None),
+            patch("time.sleep", side_effect=lambda s: sleeps.append(s)),
+        ):
+            result = _t1._resolve_session_record_with_retry(None)
+        assert result is None
+        # Sleeps must match the backoff schedule (in seconds).
+        expected = [ms / 1000.0 for ms in _t1._T1_RACE_BACKOFF_MS]
+        assert sleeps == expected
+
+    def test_retries_succeed_on_second_attempt(self, monkeypatch):
+        """Race resolves before all retries exhausted."""
+        from nexus.db import t1 as _t1
+        monkeypatch.setenv("NX_SESSION_ID", "subagent-uuid")
+
+        record = {"session_id": "subagent-uuid"}
+        # Miss first, then hit on the second call.
+        outcomes = [None, record, record, record]
+        sleeps: list[float] = []
+        with (
+            patch.object(_t1, "find_session_by_id",
+                         side_effect=lambda *a, **k: outcomes.pop(0)),
+            patch("time.sleep", side_effect=lambda s: sleeps.append(s)),
+        ):
+            result = _t1._resolve_session_record_with_retry(None)
+        assert result is record
+        # Slept once (first backoff window) before the successful retry.
+        assert sleeps == [_t1._T1_RACE_BACKOFF_MS[0] / 1000.0]
+
+    def test_t1database_uses_retry_in_constructor(self, monkeypatch):
+        """Pin the wiring: T1Database.__init__ goes through the retry
+        helper, not the raw find_session_by_id call."""
+        from nexus.db import t1 as _t1
+        record = {
+            "session_id": "wired-test", "server_host": "127.0.0.1",
+            "server_port": 51823,
+        }
+        mock_http = MagicMock()
+        mock_http.get_or_create_collection.return_value = MagicMock()
+        with (
+            patch.object(_t1, "_resolve_session_record_with_retry",
+                         return_value=record) as mock_retry,
+            patch("chromadb.HttpClient", return_value=mock_http),
+        ):
+            t1 = _t1.T1Database()
+        mock_retry.assert_called_once()
+        assert t1._client is mock_http
+
+    def test_skip_t1_bypasses_retry_helper(self, monkeypatch):
+        """NEXUS_SKIP_T1=1 must skip the retry path entirely; the
+        stateless-operator path takes EphemeralClient directly without
+        paying the 350ms wait."""
+        from nexus.db import t1 as _t1
+        monkeypatch.setenv("NEXUS_SKIP_T1", "1")
+        monkeypatch.setenv("NX_SESSION_ID", "parent-uuid")
+
+        with patch.object(_t1, "_resolve_session_record_with_retry") as mock_retry:
+            t1 = _t1.T1Database()
+        mock_retry.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Spike B verified empirically that the CA-2 race is reproducible: **40/40 cycles** at the bead's specified timings (0/5/50/200 ms dispatch delay) produce \`ephemeral_downgrade\`. T2 \`nexus_rdr/094-spike-b-subagent-race\` (id=982) holds the evidence.

**The race**: a subagent dispatched within ~1-2 s of top-level MCP startup observes \`NX_SESSION_ID\` set in env but finds the parent's session record not yet written -- the parent's \`_t1_chroma_init_if_owner\` is still inside \`start_t1_server\` (chroma cold-start dominates). \`find_session_by_id\` returns None and \`T1Database\` falls through to \`EphemeralClient\` silently (the warning is invisible under stdio transport).

## Mitigation

\`T1Database.__init__\` now goes through \`_resolve_session_record_with_retry\` which retries \`find_session_by_id\` on a **100/200/400/800/1500 ms exponential backoff** (~3 s total max wait) when \`NX_SESSION_ID\` is set. Top-level callers without a parent session pay no wait -- the env-var gate keeps them on the single-shot path.

The bead originally prescribed 50/100/200 ms × 3 retries = 350 ms total. **Empirical chroma cold-start is 1.1-1.7 s**, so the bead's schedule was insufficient. Single-cycle smokes confirm the extended schedule eliminates downgrades:

| | 200ms delay | Multi-timing (0/5/50ms) |
|---|---|---|
| **Before retry** | \`ephemeral_downgrade\` (40/40) | \`ephemeral_downgrade\` (30/30) |
| **After retry** | \`connected_to_parent\` (5/5) | \`connected_to_parent\` (9/9) |

\`NEXUS_SKIP_T1=1\` (stateless-operator path) bypasses the retry entirely so claude_dispatch operators don't pay the 3 s wait.

## Test plan

- [x] \`tests/test_t1.py\` 26 -> 32:
  - \`TestResolveSessionRecordWithRetry\` pins:
    - returns record on first hit without sleeping
    - does NOT retry when env var absent (top-level callers)
    - retries with backoff when env var set (matches schedule)
    - retries succeed on second attempt (race resolves mid-flight)
    - \`T1Database.__init__\` uses retry helper (wiring sentinel)
    - \`NEXUS_SKIP_T1\` bypasses retry helper
- [x] Affected-module sweep (test_t1, test_session, test_hooks, test_session_propagation_hypotheses, test_session_end_launcher): 121 pass
- [x] Single-cycle smokes: 5/5 + 9/9 connected_to_parent
- [x] No em dashes in additions

## Re-run protocol after merge

\`\`\`bash
rm scripts/spikes/spike_rdr094_b_results.jsonl scripts/spikes/spike_rdr094_b_summary.json
uv run python scripts/spikes/spike_rdr094_b_subagent_race.py
\`\`\`

Expected verdict: \`ca2_verified_race_not_reproducible\` (40 connected_to_parent, 0 ephemeral_downgrade).

## Closes

Closes nexus-zsqf when the 40-cycle re-run confirms verification (the harness regression sentinel + this PR's wiring + smokes give high confidence; the formal verdict update awaits the rerun). Phase E (nexus-fn44 canary) and Phase F (nexus-2lm0 flag removal) unblock once nexus-zsqf closes.