### PR TITLE
docs(rdr-094): mark CA-2 VERIFIED after retry mitigation (nexus-zsqf)

### DIFF
--- a/docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md
+++ b/docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md
@@ -217,35 +217,39 @@ exist as a stable per-session subprocess to inherit from.
       chroma within ~11s, attributed to `mcp_owned_signal` path.
       T2 nexus_rdr/094-spike-a-lifecycle (id=976), T3
       knowledge__nexus 9f1c77b683a9f429.
-- [ ] Moving chroma spawn from the SessionStart hook to MCP-server
+- [x] Moving chroma spawn from the SessionStart hook to MCP-server
       startup does not regress subagent T1 sharing. **Status**:
-      Unverified (Spike B scope). **Hard prerequisite for Phase 4
-      flag removal.** **Method**: integration test dispatching a
-      subagent chain and asserting scratch read/write across the
-      tree.
+      VERIFIED 2026-04-25 via Spike B (after retry mitigation in
+      PR #311). **Evidence**: 40/40 cycles across 4 timing variants
+      (0/5/50/200 ms dispatch delay) connect to parent's chroma
+      with zero `ephemeral_downgrade` events. T2
+      `nexus_rdr/094-spike-b-subagent-race-verified` (id=983);
+      pre-mitigation evidence at id=982.
 
-      **Specific race the spike must rule out** (substantive-critic
-      finding, 2026-04-25): the new code path has one structural
-      difference vs the hook-era code that warrants direct
-      verification. The hook writes the session record synchronously
-      before any subagent dispatch. The MCP server's lifespan is
-      async and may not have completed the
-      `write_session_record_by_id` call by the time Claude Code
-      dispatches the first subagent. If a subagent observes
-      `NX_SESSION_ID` set but the parent's session record absent,
-      its `_t1_chroma_init_if_owner` falls through the ancestor-
-      record check, lands on `_resolve_top_level_session_id`, which
-      reads `current_session`. If that's also unwritten at that
-      moment, the subagent gets `own_id = None` and skips spawn
-      entirely (silent EphemeralClient downgrade with no log
-      that would identify the cause).
+      **The race was reproducible at the spike's timings** (40/40
+      `ephemeral_downgrade` before the mitigation): a subagent
+      dispatched within chroma's cold-start window (~1.1-1.7 s on
+      the reference install) observes `NX_SESSION_ID` set but finds
+      `find_session_by_id` returning None. `T1Database.__init__`
+      falls through to `EphemeralClient` silently because the
+      fallback `warnings.warn` is invisible under stdio transport.
 
-      Spike B protocol: dispatch a subagent within milliseconds of
-      top-level MCP startup (before
-      `write_session_record_by_id` completes); assert the
-      subagent's T1 client connects to the parent's chroma. If the
-      race is reproducible, add a retry-with-backoff loop in
-      `_resolve_top_level_session_id` before Phase 4 lands.
+      **Mitigation shipped in PR #311**:
+      `_resolve_session_record_with_retry` in
+      `src/nexus/db/t1.py` retries `find_session_by_id` on a
+      100/200/400/800/1500 ms exponential backoff (~3 s total max
+      wait) when `NX_SESSION_ID` is set in env. Top-level callers
+      without a parent session pay no wait (env-var gate);
+      `NEXUS_SKIP_T1=1` (stateless-operator path) bypasses the
+      retry entirely.
+
+      The retry placement deviates from the bead's original
+      prescription (`_resolve_top_level_session_id` with
+      50/100/200 ms × 3 = 350 ms): the subagent's race lives in
+      the T1 client's record lookup (not the parent's resolver),
+      and chroma's empirical 1.1-1.7 s cold-start required a
+      longer schedule than 350 ms. Both decisions were validated
+      by single-cycle and 40-cycle smokes.
 - [x] The dual-watch watchdog (`--mcp-pid` + `--claude-pid` with
       OR-trigger logic) preserves coverage of BOTH the "MCP dies
       without atexit firing" case AND the "Claude Code crashes and


### PR DESCRIPTION
## Summary

Spike B / nexus-zsqf is complete. CA-2 (subagent T1 sharing race) is now **VERIFIED** after the retry mitigation.

## Evidence trail

| Pass | Result | Notes |
|---|---|---|
| #308 ships harness | -- | 16 unit tests pin classifier + dispatcher |
| 1st 40-cycle pass | 40/40 \`unknown\` (false-verified) | Two harness bugs masked each other |
| #310 fixes harness | -- | Probe-side classification + aggregator now requires positive evidence |
| 2nd 40-cycle pass | 40/40 \`ephemeral_downgrade\` | T2 id=982; race confirmed reproducible |
| #311 ships mitigation | -- | \`_resolve_session_record_with_retry\` in T1Database |
| **3rd 40-cycle pass** | **40/40 \`connected_to_parent\`** | T2 id=983; \`ca2_verified_race_not_reproducible\` |

## Bead-prescription deviations (validated empirically)

The retry's placement and schedule both deviate from the bead's original prescription:

| | Bead prescription | Shipped (PR #311) | Why |
|---|---|---|---|
| Placement | \`_resolve_top_level_session_id\` (parent's resolver) | \`T1Database.__init__\` (subagent's lookup) | The subagent's race lives in the T1 client's \`find_session_by_id\` call |
| Schedule | 50/100/200 ms × 3 retries (350 ms total) | 100/200/400/800/1500 ms exponential (~3 s max) | Empirical chroma cold-start was 1.1-1.7 s; 350 ms always missed |

Both deviations were calibrated by single-cycle smokes (5/5 + 9/9 \`connected_to_parent\` post-fix) and validated by the 40-cycle pass.

## RDR §Critical Assumptions CA-2 now reflects

- **VERIFIED** status with the post-mitigation evidence
- The race was empirically reproducible (40/40 downgrade pre-fix)
- The mitigation as implemented (placement + schedule)
- Why the bead's original prescription was insufficient

## Phase 4 unblocked

Phase E (nexus-fn44 canary opt-in) and Phase F (nexus-2lm0 flag removal) are now formally unblocked.

## Closes

Closes nexus-zsqf (Phase D / Spike B).