### PR TITLE
release: v4.12.1 — fix mcp_server_crashed on clean stdin-EOF + SIGTERM race

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.12.0"
+      "version": "4.12.1"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.12.0"
+      "version": "4.12.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.12.1] - 2026-04-25
+
+Shakeout patch for 4.12.0. Production sessions on Hal's reference install showed `mcp_server_crashed` events in `mcp.log` on every clean shutdown after the default-on flag flip. Root cause: stdin-EOF + SIGTERM race. Claude Code closes the MCP client's stdio pipe and sends SIGTERM near-simultaneously; the lifespan finally fires (clean-exit path) and starts running `_t1_chroma_shutdown` → `stop_t1_server`'s 100ms poll loop; the SIGTERM signal handler then runs on top of the paused frame, calls `sys.exit(0)`, and the resulting `SystemExit` propagates through anyio's TaskGroup as an unhandled error. Chroma was always cleaned up correctly (the watchdog confirmed via `chroma_cleanup_complete` events; `nx doctor --check-tmpdirs` was clean), but every clean shutdown logged a misleading multi-thousand-character traceback as a "crash".
+
+Spike A's 40-cycle SIGTERM evidence didn't surface this because the spike sent only SIGTERM (no stdin EOF); only one cleanup path fired per cycle. Production has BOTH paths firing simultaneously.
+
+### Fixed
+
+- **`_sigterm_handler` no longer races the lifespan finally** (`src/nexus/mcp/core.py`). Two coordinated changes:
+  - New module-scope `_SHUTDOWN_IN_FLIGHT` flag — set by `_t1_chroma_shutdown` on first entry, never cleared. Re-entrant calls (signal handler firing during in-flight cleanup) short-circuit at the top of `_t1_chroma_shutdown` before touching `_OWNED_CHROMA`. Catches the case where the lifespan finally is paused inside `stop_t1_server`'s poll loop and SIGTERM arrives.
+  - `_sigterm_handler` checks `_SHUTDOWN_IN_FLIGHT` first: returns immediately when the lifespan owns the exit path. When it's the first signal (SIGTERM-only path with no prior stdin EOF), it drives the shutdown then calls `os._exit(0)` instead of `sys.exit(0)`. `os._exit` terminates the process without raising `SystemExit`, so anyio doesn't see a TaskGroup error and `mcp.log` no longer records spurious crash events on clean shutdowns.
+
+Tests: `tests/test_mcp_chroma_lifecycle.py` 15 → 19, with explicit regression sentinels (`test_in_flight_flag_blocks_reentrant_call`, `test_returns_silently_when_shutdown_in_flight`, `test_drives_shutdown_and_os_exit_when_first_signal`, `test_does_not_use_sys_exit`).
+
 ## [4.12.0] - 2026-04-25
 
 Closes RDR-094 Phase 4 (MCP-Owned T1 Chroma Lifecycle) end-to-end and **flips the `NEXUS_MCP_OWNS_T1` flag default-on**. The chroma server's lifecycle is now owned by nx-mcp's lifespan / atexit / signal handlers by default, and the watchdog sidecar dual-watches both the MCP and Claude Code root PIDs so any failure mode (clean SIGTERM, SIGKILL, SIGSEGV, Claude crash, stdio pipe break) gets cleaned up within ~10s. Spike A (40/40), Spike B (CA-2 race verified after the retry mitigation), and Spike C (issue #40207 verified-negative for vanilla stdio) all pass at full sample size.

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.12.1] - 2026-04-25
+
+Plugin version aligned with conexus 4.12.1. No plugin-level functional changes. See root `CHANGELOG.md` for the 4.12.0 shakeout fix: `mcp_server_crashed` events on clean shutdowns were a SystemExit race between stdin EOF and SIGTERM, fixed by switching the signal handler to `os._exit` and adding a sticky in-flight flag that short-circuits re-entrant shutdown calls.
+
 ## [4.12.0] - 2026-04-25
 
 Plugin version aligned with conexus 4.12.0. Two SessionEnd changes ship from RDR-094 Phase C: the `nx hook session-end-detach` fallback is dropped from `hooks.json` (it raced the same cold-start window the `nx-session-end-launcher` exists to solve, so falling back to it on launcher failure was a footgun), and the launcher's grandchild now dispatches to `hooks.session_end_flush` instead of `hooks.session_end`. Storage-only flush stays in the hook path; chroma teardown is owned by the t1_watchdog sidecar (dual-watch under the new default `NEXUS_MCP_OWNS_T1=on`). SessionEnd timeout drops from 5s to 3s: sub-second flush means a wedged hook is reaped faster. See root `CHANGELOG.md` for the full RDR-094 Phase 4 surface (default-on flag flip, T1 race retry, watchdog logging, `nx doctor --check-mcp-logs`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.12.0"
+version = "4.12.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -227,21 +227,39 @@ def _resolve_top_level_session_id() -> str | None:
         return None
 
 
+#: Sticky flag set by :func:`_t1_chroma_shutdown` on first entry so a
+#: signal arriving mid-cleanup (the production stdin-EOF + SIGTERM
+#: race that produced spurious ``mcp_server_crashed`` events on every
+#: clean shutdown post-4.12.0) can short-circuit instead of racing
+#: the in-flight teardown. Once set, never cleared: shutdown is
+#: one-shot per process.
+_SHUTDOWN_IN_FLIGHT: bool = False
+
+
 def _t1_chroma_shutdown() -> None:
     """Stop chroma + remove the session record. Idempotent.
 
-    Called from the lifespan finally (primary), atexit (secondary), and
-    SIGTERM/SIGINT handlers (also secondary). The first to fire performs
-    the cleanup; the rest are no-ops because ``_OWNED_CHROMA`` is cleared
-    on completion.
+    Called from the lifespan finally (primary on clean stdin EOF),
+    atexit (belt-and-braces for SystemExit / clean Python exit), and
+    SIGTERM/SIGINT handlers (primary on stdio under SIGTERM).
+    The first to fire performs the cleanup; the rest short-circuit
+    via ``_SHUTDOWN_IN_FLIGHT`` (set on entry, never cleared) so a
+    re-entrant call from a signal handler that interrupted an
+    in-flight ``stop_t1_server`` doesn't double-execute.
     """
+    global _SHUTDOWN_IN_FLIGHT
+    if _SHUTDOWN_IN_FLIGHT:
+        return
     if not _OWNED_CHROMA:
         return
     if _OWNED_CHROMA.get("nested") or _OWNED_CHROMA.get("reused"):
         # Nested: parent owns chroma. Reused: another MCP server in the
         # same session owns it. We must not stop it on our exit.
+        _SHUTDOWN_IN_FLIGHT = True
         _OWNED_CHROMA.clear()
         return
+
+    _SHUTDOWN_IN_FLIGHT = True
 
     from pathlib import Path
     import shutil
@@ -271,16 +289,31 @@ def _t1_chroma_shutdown() -> None:
 
 
 def _sigterm_handler(_signo: int, _frame: Any) -> None:
-    """Run the shutdown path then exit cleanly.
+    """Run the shutdown path then exit.
 
-    Belt-and-braces for the cancellation paths where the FastMCP
-    lifespan does not fire. ``sys.exit(0)`` lets atexit handlers run,
-    so the second-pass _t1_chroma_shutdown call is a no-op.
+    When invoked while the lifespan finally is already running cleanup
+    (stdin-EOF + SIGTERM race observed in production after 4.12.0
+    default-on shipped), ``_SHUTDOWN_IN_FLIGHT`` is already True and
+    we return immediately so the in-flight teardown completes cleanly.
+    Otherwise (SIGTERM-only path with no prior stdin EOF) we drive the
+    shutdown ourselves and ``os._exit(0)`` to terminate.
+
+    Why ``os._exit`` instead of ``sys.exit``: ``sys.exit`` raises
+    ``SystemExit``, which propagates through anyio's TaskGroup and
+    gets logged as ``mcp_server_crashed`` even though the actual
+    shutdown succeeded. ``os._exit`` terminates the process
+    immediately without raising; chroma is already cleaned up at
+    this point so there is nothing left to coordinate.
     """
-    import sys as _sys
+    if _SHUTDOWN_IN_FLIGHT:
+        # Lifespan / atexit is already running shutdown. Don't
+        # interfere -- they hold the cleanup contract for this exit.
+        return
+
+    import os as _os
 
     _t1_chroma_shutdown()
-    _sys.exit(0)
+    _os._exit(0)
 
 
 from contextlib import asynccontextmanager

--- a/tests/test_mcp_chroma_lifecycle.py
+++ b/tests/test_mcp_chroma_lifecycle.py
@@ -22,17 +22,22 @@ import pytest
 
 @contextmanager
 def _clean_owned_chroma():
-    """Reset _OWNED_CHROMA before and after each test so module-scope
-    state from one test does not leak into the next."""
+    """Reset _OWNED_CHROMA + _SHUTDOWN_IN_FLIGHT before and after each
+    test so module-scope state from one test does not leak into the
+    next. Both are sticky module globals; tests that exercise
+    _t1_chroma_shutdown must start from a clean slate."""
     from nexus.mcp import core as core_mod
 
     saved = dict(core_mod._OWNED_CHROMA)
+    saved_in_flight = core_mod._SHUTDOWN_IN_FLIGHT
     core_mod._OWNED_CHROMA.clear()
+    core_mod._SHUTDOWN_IN_FLIGHT = False
     try:
         yield
     finally:
         core_mod._OWNED_CHROMA.clear()
         core_mod._OWNED_CHROMA.update(saved)
+        core_mod._SHUTDOWN_IN_FLIGHT = saved_in_flight
 
 
 # ── _tcp_probe_alive ────────────────────────────────────────────────────────
@@ -270,6 +275,98 @@ class TestShutdown:
                 core_mod._t1_chroma_shutdown()
                 core_mod._t1_chroma_shutdown()
             assert mock_stop.call_count == 1
+
+    def test_in_flight_flag_blocks_reentrant_call(self):
+        """Regression sentinel for the production stdin-EOF + SIGTERM
+        race that produced spurious mcp_server_crashed events on every
+        clean shutdown post-4.12.0. When the lifespan finally is in
+        the middle of running stop_t1_server (Python is paused inside
+        ``time.sleep``), a SIGTERM-driven re-entrant call to
+        _t1_chroma_shutdown must short-circuit instead of running
+        cleanup again from the signal handler frame."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            core_mod._OWNED_CHROMA.update({
+                "session_id": "y", "server_pid": 12345,
+                "tmpdir": "", "session_file": "",
+            })
+            # Simulate "lifespan finally is in flight": the flag is
+            # set but _OWNED_CHROMA has not yet been cleared.
+            core_mod._SHUTDOWN_IN_FLIGHT = True
+            with patch("nexus.session.stop_t1_server") as mock_stop:
+                core_mod._t1_chroma_shutdown()
+            mock_stop.assert_not_called(), (
+                "Re-entrant call must short-circuit while shutdown "
+                "is in flight to avoid double-execute / SystemExit "
+                "race through anyio TaskGroup."
+            )
+
+
+# ── _sigterm_handler (4.12.1 race fix) ──────────────────────────────────────
+
+
+class TestSigtermHandler:
+    """Pin the production race fix: stdin-EOF + SIGTERM must NOT log
+    mcp_server_crashed when the lifespan finally is already running
+    cleanup."""
+
+    def test_returns_silently_when_shutdown_in_flight(self):
+        """Lifespan finally has entered _t1_chroma_shutdown; signal
+        handler must return without sys.exit so the in-flight teardown
+        completes without SystemExit propagating through anyio."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            core_mod._SHUTDOWN_IN_FLIGHT = True
+            with (
+                patch.object(core_mod, "_t1_chroma_shutdown") as mock_shutdown,
+                patch("os._exit") as mock_exit,
+            ):
+                core_mod._sigterm_handler(15, None)  # SIGTERM
+            mock_shutdown.assert_not_called(), (
+                "In-flight handler must not re-call shutdown"
+            )
+            mock_exit.assert_not_called(), (
+                "In-flight handler must not os._exit -- lifespan "
+                "owns the exit path"
+            )
+
+    def test_drives_shutdown_and_os_exit_when_first_signal(self):
+        """SIGTERM-only path (no prior stdin EOF): handler runs the
+        shutdown then os._exit(0). Critically uses os._exit rather
+        than sys.exit -- the latter raises SystemExit which anyio's
+        TaskGroup logs as mcp_server_crashed."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            with (
+                patch.object(core_mod, "_t1_chroma_shutdown") as mock_shutdown,
+                patch("os._exit") as mock_exit,
+            ):
+                core_mod._sigterm_handler(15, None)
+            mock_shutdown.assert_called_once()
+            mock_exit.assert_called_once_with(0)
+
+    def test_does_not_use_sys_exit(self):
+        """Regression sentinel: sys.exit raises SystemExit which
+        propagates through anyio's TaskGroup as 'unhandled error',
+        logged as mcp_server_crashed. The handler must use os._exit
+        to exit the process without raising."""
+        import sys
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            with (
+                patch.object(core_mod, "_t1_chroma_shutdown"),
+                patch("os._exit"),
+                patch.object(sys, "exit") as mock_sys_exit,
+            ):
+                core_mod._sigterm_handler(15, None)
+            mock_sys_exit.assert_not_called(), (
+                "sys.exit raises SystemExit through anyio TaskGroup; "
+                "must use os._exit instead"
+            )
 
 
 # ── _t1_chroma_lifespan async cm ────────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.12.0"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Production shakeout of 4.12.0 default-on surfaced spurious \`mcp_server_crashed\` events on **every clean shutdown**. The actual cleanup ran correctly (chroma stopped, no orphan tmpdirs); only the logging was misleading.

## Root cause

Stdin-EOF + SIGTERM race:
1. Claude Code closes the MCP client's stdio pipe → nx-mcp's stdin EOFs
2. The lifespan \`async finally\` fires → calls \`_t1_chroma_shutdown\` → enters \`stop_t1_server\`'s 100ms poll loop
3. SIGTERM arrives ~near-simultaneously → signal handler runs **on top of the paused frame**
4. Old handler called \`_t1_chroma_shutdown\` (re-entrant; \`_OWNED_CHROMA\` not yet cleared, so it proceeds) then \`sys.exit(0)\`
5. \`SystemExit\` propagates through anyio's TaskGroup as "unhandled error" → \`mcp_server_crashed\` logged with a multi-thousand-character traceback

Spike A's 40-cycle evidence didn't surface this because the spike sent only SIGTERM (no stdin EOF); only one cleanup path fired per cycle. Production has both paths racing.

## Fix

Two coordinated changes in \`src/nexus/mcp/core.py\`:

- **New \`_SHUTDOWN_IN_FLIGHT\` sticky flag**, set by \`_t1_chroma_shutdown\` on first entry, never cleared. Re-entrant calls short-circuit at the top of the function before touching \`_OWNED_CHROMA\`. Catches the case where the lifespan finally is paused inside \`stop_t1_server\` and a signal-driven re-entry attempts to run cleanup again.

- **\`_sigterm_handler\` checks the flag first**: returns immediately when the lifespan owns the exit path. When it's the first signal (SIGTERM-only path with no prior stdin EOF), it drives the shutdown then calls \`os._exit(0)\` instead of \`sys.exit(0)\`. \`os._exit\` terminates without raising \`SystemExit\`, so anyio doesn't see a TaskGroup error.

## Test plan

- [x] \`tests/test_mcp_chroma_lifecycle.py\` 15 → 19. Three new regression sentinels:
  - \`test_in_flight_flag_blocks_reentrant_call\` — re-entrant \`_t1_chroma_shutdown\` short-circuits during in-flight cleanup
  - \`test_returns_silently_when_shutdown_in_flight\` — sigterm handler returns without calling shutdown or os._exit when lifespan is running
  - \`test_drives_shutdown_and_os_exit_when_first_signal\` — handler drives cleanup + os._exit on first signal
  - \`test_does_not_use_sys_exit\` — explicit anti-regression sentinel for the SystemExit-through-anyio bug
- [x] **Pre-tag full unit suite** (\`uv run pytest -m "not integration" -q\`): **5211 passed, 27 skipped, 30 deselected** in 9m 37s
- [x] No em dashes in additions
- [x] Explicit-path \`git add\`

## Tag procedure (after merge)

\`\`\`bash
git checkout main && git pull origin main
git tag -a v4.12.1 -m "Release 4.12.1 — fix stdin-EOF + SIGTERM race"
git push origin v4.12.1   # tag-push workflow auto-publishes to PyPI
scripts/reinstall-tool.sh
\`\`\`