### PR TITLE
refactor(rdr-094): remove NEXUS_MCP_OWNS_T1 gate (Phase F / nexus-2lm0)

### DIFF
--- a/docs/rdr/rdr-093-groupby-aggregate-operators.md
+++ b/docs/rdr/rdr-093-groupby-aggregate-operators.md
@@ -2,12 +2,14 @@
 title: "RDR-093: GroupBy and Aggregate Operators"
 id: RDR-093
 type: Feature
-status: accepted
+status: closed
 priority: medium
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-04-24
 accepted_date: 2026-04-24
+closed_date: 2026-04-25
+close_reason: implemented
 related_issues: []
 related_tests: [test_operator_dispatch.py, test_plan_run.py, test_plan_bundle.py]
 related: [RDR-042, RDR-078, RDR-079, RDR-088, RDR-089]

--- a/docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md
+++ b/docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md
@@ -1057,50 +1057,42 @@ Clean up the 10 orphan tmpdirs from 2026-04-23. One-shot.
 
 ### Phase 4: Feature-flag removal
 
-Phase 4 is gated on three prerequisites, not just code-level flag
-removal:
+**Status: COMPLETE 2026-04-25 (conexus 4.13.0).** All three
+prerequisites cleared:
 
-1. **Spike B (CA-2 subagent T1 sharing) verified.** This is a hard
-   prerequisite. The specific race the spike must rule out: a
-   subagent dispatched within milliseconds of the top-level MCP
-   server starting can observe `NX_SESSION_ID` set but the parent's
-   session record not yet written by `write_session_record_by_id`
-   (the MCP lifespan is async and may not have completed by the
-   time Claude Code dispatches the first subagent). If the
-   subagent's `_t1_chroma_init_if_owner` falls through the
-   ancestor-record check it lands on `_resolve_top_level_session_id`
-   which reads `current_session`. If `current_session` is also
-   unwritten at that moment, `own_id = None` and the subagent has
-   no T1 at all (silent EphemeralClient downgrade). This race is
-   absent in the hook-based code because the hook writes the
-   session record synchronously. Spike B test: dispatch a subagent
-   within milliseconds of MCP startup; assert subagent's T1 is
-   connected to the parent's chroma. If the race is reproducible,
-   add a retry loop in the subagent's session resolution path
-   before Phase 4 lands.
-2. **Phase 2 Steps 2 + 3 shipped.** `session_end_flush` split,
-   hooks.json swapped from `nx-session-end-launcher` to `nx hook
-   session-end-flush`, and `_session_end_launcher.py` unwired (it
-   stays in the codebase as fallback code but no hook references
-   it). Without these, Phase 4 cannot cleanly remove the
-   `NEXUS_MCP_OWNS_T1` gate inside `session_end()`.
-3. **One release cycle of canary evidence under the flag.** Operators
-   running with `NEXUS_MCP_OWNS_T1=1` for at least one full release
-   without observable regressions (orphan chroma, T1 unavailable
-   warnings, watchdog mis-fires). Spike A + C cover the ~5 min
-   workload; canary covers the long-tail of real-world session
-   shapes.
+1. **Spike B (CA-2 subagent T1 sharing) verified.** Race confirmed
+   reproducible, mitigation shipped in
+   `T1Database._resolve_session_record_with_retry` (PR #311), final
+   40-cycle pass at 40/40 connected_to_parent (T2 id=983). See
+   §Critical Assumptions CA-2.
+2. **Phase 2 Steps 2 + 3 shipped.** `session_end_flush` split (PR
+   #306 / Phase B / nexus-2b9r), hooks.json launcher dispatches to
+   the storage-only entry (PR #307 / Phase C / nexus-l828).
+3. **Canary evidence collected.** v4.12.0 default-on flip shipped
+   2026-04-25; v4.12.0 -> v4.12.1 shakeout (PR #314) caught the
+   stdin-EOF + SIGTERM signal-handler race. Three clean shutdowns
+   recorded post-4.12.1 with `reason='exit'`, zero spurious
+   `mcp_server_crashed` events; mcp.log + watchdog.log + `nx doctor
+   --check-mcp-logs` all clean. The default-on flip itself stood in
+   for the explicit canary cycle (Phase E / nexus-fn44 closed
+   2026-04-25 with that rationale).
 
-When all three are met, Phase 4 lands:
+Phase 4 deliverables (shipped in 4.13.0 / PR #nexus-2lm0):
 
-- Remove `NEXUS_MCP_OWNS_T1` conditionals in `src/nexus/mcp/core.py`
-  (module-scope flag check + main() registrations) and
-  `src/nexus/hooks.py` (session_start chroma-spawn skip,
-  session_end chroma-stop skip).
-- Delete the hook-era chroma-spawn block from `session_start()`.
-- Retire `nx-session-end-launcher` from hooks.json (Phase 2 Step 3
-  prerequisite).
-- Update RDR-094 to record Phase 4 as complete.
+- `NEXUS_MCP_OWNS_T1` env-var gate removed entirely from
+  `src/nexus/mcp/core.py` (module-scope `_MCP_OWNS_T1` flag deleted,
+  lifespan unconditionally attached, atexit + signal handlers
+  unconditionally registered).
+- Hook-era chroma-spawn block deleted from `session_start()`. The
+  hook now only runs the orphan-tmpdir sweep, resolves the session
+  UUID, and (when top-level) writes `current_session`.
+- `session_end()` reduced to a thin wrapper around
+  `session_end_flush()`. Chroma teardown is owned exclusively by
+  nx-mcp's lifespan + signal handler + atexit chain, with the
+  watchdog as the safety net.
+- `_session_end_launcher.py` retained (Phase C launcher pattern is
+  load-bearing for the cold-start race); the launcher's grandchild
+  dispatches to `session_end_flush` directly.
 
 The TCP-probe-and-reuse path in `_t1_chroma_init_if_owner` stays
 (Spike C cleared CA-4 negative; the path is cheap insurance against

--- a/src/nexus/_session_end_launcher.py
+++ b/src/nexus/_session_end_launcher.py
@@ -17,15 +17,12 @@ module. Then in the fully detached grandchild it imports
 ``nexus.hooks`` and runs ``session_end_flush()``. Wall-clock cost
 to return control to Claude Code: ~17ms.
 
-RDR-094 Phase C swap: the launcher now dispatches to
-``hooks.session_end_flush`` (storage-only path, fork-safe) instead of
-``hooks.session_end``. With the MCP server owning chroma's lifecycle
-under ``NEXUS_MCP_OWNS_T1`` (Phase 4), a hook-side
-``stop_t1_server`` raced the MCP lifespan/atexit/signal-handler
-cleanup. Pointing the launcher at the flush-only entry retires that
-race entirely. The legacy ``hooks.session_end`` chroma-stop block is
-still reachable via ``nx hook session-end`` for the flag-off rollout
-window and as a manual-debug entry point.
+RDR-094 Phase C swap: the launcher dispatches to
+``hooks.session_end_flush`` (storage-only path, fork-safe). nx-mcp
+owns chroma teardown via its FastMCP lifespan + signal handler +
+atexit chain (Phase 4, unconditional as of 4.13.0); the watchdog
+sidecar is the safety net if all three of those paths fail. The
+hook does T1 flush + T2 expire only, which is fork-safe.
 
 **BANNED invariant**: this module must never import any ``nexus.*``
 module before ``os.fork()``. The whole point is that the parent
@@ -56,11 +53,10 @@ def _run_session_end_synchronously() -> None:
     already configures (RotatingFileHandler under ~/.config/nexus/logs).
 
     RDR-094 Phase C: dispatches to ``session_end_flush`` (storage-only)
-    rather than ``session_end`` (storage + chroma teardown). The
-    chroma teardown is owned by the MCP server's lifespan/atexit/
-    signal handlers under ``NEXUS_MCP_OWNS_T1``; calling it here
-    races those paths and was the documented source of double-stop
-    failures.
+    rather than ``session_end``. Chroma teardown is owned by the MCP
+    server's lifespan/atexit/signal handlers (Phase 4, unconditional
+    as of 4.13.0); calling stop_t1_server here would race those paths
+    and was the documented source of double-stop failures.
     """
     try:
         from nexus import hooks

--- a/src/nexus/commands/hook.py
+++ b/src/nexus/commands/hook.py
@@ -42,10 +42,10 @@ def session_end_cmd() -> None:
 def session_end_flush_cmd() -> None:
     """Run only the storage-flush portion of SessionEnd (RDR-094 Phase B).
 
-    Runs T1 scratch flush + T2 expire; does NOT touch chroma. Used by
-    Phase C (nexus-l828) once hooks.json swaps the launcher's internal
-    dispatch to this entry point under the MCP-owned-T1 default-on
-    rollout. Safe to invoke whether NEXUS_MCP_OWNS_T1 is set or not.
+    Runs T1 scratch flush + T2 expire; does NOT touch chroma. The
+    nx-session-end-launcher's grandchild dispatches to this entry
+    point (Phase C / nexus-l828); the chroma teardown is owned by
+    nx-mcp's lifespan + signal handler + atexit chain.
     """
     output = hooks.session_end_flush()
     click.echo(output)

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -3,10 +3,8 @@
 """SessionStart and SessionEnd hook logic for Claude Code integration."""
 from __future__ import annotations
 
-import fcntl
 import json
 import os
-import shutil
 import sqlite3
 import subprocess
 from pathlib import Path
@@ -16,18 +14,10 @@ import structlog
 from nexus.db.t2 import T2Database
 from nexus.session import (
     SESSIONS_DIR,
-    _ppid_of,
-    find_ancestor_session,
-    find_claude_root_pid,
     find_session_by_id,
     generate_session_id,
-    spawn_t1_watchdog,
-    start_t1_server,
-    stop_t1_server,
     sweep_stale_sessions,
     write_claude_session_id,
-    write_session_record,
-    write_session_record_by_id,
 )
 
 
@@ -48,20 +38,6 @@ def _open_t2() -> T2Database:
 def _open_t1():
     from nexus.db.t1 import T1Database
     return T1Database()
-
-
-def _mcp_owns_t1_enabled() -> bool:
-    """Return True when nx-mcp owns the chroma lifecycle (RDR-094 Phase 4).
-
-    Default ON as of conexus 4.12.0. ``NEXUS_MCP_OWNS_T1=0`` (or
-    ``false`` / ``no`` / ``off``) is the emergency opt-out; absence
-    of the env var means ON.
-    """
-    raw = os.environ.get("NEXUS_MCP_OWNS_T1", "").strip().lower()
-    if raw in ("0", "false", "no", "off"):
-        return False
-    # Default ON: empty string OR explicit truthy values.
-    return True
 
 
 def _infer_repo() -> str:
@@ -116,70 +92,13 @@ def session_start(claude_session_id: str | None = None) -> str:
     inherited = os.environ.get("NX_SESSION_ID", "").strip() or None
     session_id = inherited or claude_session_id or generate_session_id()
 
-    # Honor NEXUS_SKIP_T1, set by ``claude_dispatch`` (and any caller
-    # of ``claude -p`` where T1 inheritance is undesirable) so short-
-    # lived operator subprocesses don't pay the chroma startup cost
-    # or pollute session bookkeeping. The T1 client (``db/t1.py``)
-    # falls back to EphemeralClient when this env is set.
-    #
-    # NEXUS_MCP_OWNS_T1 (RDR-094 Phase 4, default-on as of 4.12.0)
-    # moves chroma spawn to the nx-mcp lifespan. The hook leaves chroma
-    # to the MCP server; we still run the sweep and write
-    # ``current_session`` so other tools (legacy CLI usage, subagent
-    # T1 inheritance) keep working. Set ``NEXUS_MCP_OWNS_T1=0`` (or
-    # false / no / off) as the emergency opt-out.
-    skip_t1 = os.environ.get("NEXUS_SKIP_T1", "").strip().lower() in ("1", "true", "yes")
-    mcp_owns_t1 = _mcp_owns_t1_enabled()
-    if mcp_owns_t1:
-        skip_t1 = True
-
-    if not skip_t1:
-        # Acquire an exclusive lock before the find+write sequence to prevent
-        # two sibling agents (same UUID, both see record-absent simultaneously)
-        # from each starting their own ChromaDB server and orphaning the first.
-        SESSIONS_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
-        _session_lock = SESSIONS_DIR / "session.lock"
-        from nexus.indexer import _clear_stale_lock
-        _clear_stale_lock(_session_lock)
-        lock_fd = os.open(str(_session_lock), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
-        try:
-            os.write(lock_fd, str(os.getpid()).encode())
-            os.fsync(lock_fd)
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
-            # UUID-keyed lookup: T1 is scoped to a Claude conversation, not a
-            # terminal session. Two ``claude`` invocations in the same shell
-            # get distinct UUIDs → distinct session files → distinct T1
-            # servers. Subagents within one conversation share via the
-            # ``current_session`` flat file written below.
-            existing = find_session_by_id(SESSIONS_DIR, session_id)
-            if existing is None:
-                try:
-                    host, port, server_pid, tmpdir = start_t1_server()
-                    # nexus-99jb Layer 1: spawn a detached watchdog that
-                    # watches the Claude Code root PID + the chroma PID
-                    # and triggers graceful shutdown when Claude Code
-                    # disappears. Independent of SessionEnd firing, so
-                    # covers /exit (#17885) and Hook cancelled (#41577).
-                    claude_root_pid = find_claude_root_pid()
-                    session_file = SESSIONS_DIR / f"{session_id}.session"
-                    watchdog_pid = spawn_t1_watchdog(
-                        claude_pid=claude_root_pid,
-                        chroma_pid=server_pid,
-                        session_file=session_file,
-                        tmpdir=tmpdir,
-                    ) if claude_root_pid else 0
-                    write_session_record_by_id(
-                        SESSIONS_DIR, session_id, host, port, server_pid,
-                        tmpdir, claude_root_pid=claude_root_pid,
-                        watchdog_pid=watchdog_pid,
-                    )
-                except Exception as exc:
-                    _log.warning(
-                        "session_start: T1 server unavailable; T1 will be local-only",
-                        error=str(exc),
-                    )
-        finally:
-            os.close(lock_fd)  # closing the fd releases the flock automatically
+    # nx-mcp owns chroma's lifecycle (RDR-094 Phase 4, unconditional as
+    # of 4.13.0). The hook no longer spawns chroma or the watchdog; the
+    # MCP server does both via its FastMCP lifespan. We only persist the
+    # session UUID below so child agents and shell-side tools can find
+    # the parent's record. ``NEXUS_SKIP_T1`` is still honoured downstream
+    # by ``T1Database.__init__`` (db/t1.py) for the stateless-operator
+    # path; the hook itself does no T1 work.
 
     # Persist the UUID via ``current_session`` flat file — only when this is
     # a TOP-LEVEL session. Nested subprocesses (operator ``claude -p`` calls,
@@ -282,34 +201,12 @@ def session_end_flush() -> str:
 
 
 def session_end() -> str:
-    """Execute the SessionEnd hook (legacy entry point).
+    """Execute the SessionEnd hook.
 
-    Calls :func:`session_end_flush` for storage work, then -- when this
-    process owns the session record AND ``NEXUS_MCP_OWNS_T1`` is not
-    set -- stops the ChromaDB server and removes the session record +
-    tmpdir.
-
-    The ``NEXUS_MCP_OWNS_T1`` gate is the in-place mitigation from
-    PR #300: when the MCP server owns chroma, hook-side teardown
-    races the lifespan/atexit/signal-handler cleanup. Phase C
-    (nexus-l828) swaps hooks.json's internal call to
-    :func:`session_end_flush` directly so the gate becomes redundant;
-    it stays here for the flag-off rollout window.
+    Thin wrapper around :func:`session_end_flush`. nx-mcp owns chroma
+    teardown via its FastMCP lifespan + signal handler + atexit chain
+    (RDR-094 Phase 4, unconditional as of 4.13.0); the watchdog is the
+    safety net if all three of those paths fail. The hook does T1
+    flush + T2 expire only.
     """
-    _, own_record, own_file, _ = _resolve_session_records()
-    summary = session_end_flush()
-
-    mcp_owns_t1 = _mcp_owns_t1_enabled()
-    if own_record and own_file is not None and not mcp_owns_t1:
-        server_pid = own_record.get("server_pid", 0)
-        if server_pid:
-            stop_t1_server(server_pid)
-        try:
-            own_file.unlink(missing_ok=True)
-        except OSError:
-            pass  # intentional: best-effort session file deletion
-        tmpdir = own_record.get("tmpdir", "")
-        if tmpdir:
-            shutil.rmtree(tmpdir, ignore_errors=True)
-
-    return summary
+    return session_end_flush()

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -39,7 +39,7 @@ from nexus.ttl import parse_ttl
 
 # ── T1 chroma lifecycle (RDR-094, feature-flagged) ──────────────────────────
 #
-# RDR-094 Phase 4 (default-on as of 4.12.0). This module:
+# RDR-094 Phase 4 (unconditional as of 4.13.0). This module:
 #   1. Spawns chroma in the FastMCP lifespan __aenter__. Three cleanup
 #      paths run on shutdown, all calling the same idempotent
 #      _t1_chroma_shutdown:
@@ -53,9 +53,6 @@ from nexus.ttl import parse_ttl
 #          through async finally. Skipped on stdio (no anyio handler).
 #        * atexit -- belt-and-braces for clean stdin EOF / SystemExit
 #          paths that arrive without a signal.
-#      The hook's chroma-spawn block becomes a no-op (gated on the same
-#      env flag in hooks.py); the SessionEnd hook also skips its chroma-
-#      stop block under the flag (one-line gate in hooks.py:session_end).
 #   2. Spawns the watchdog with both --mcp-pid and --claude-pid so the
 #      Claude-crash-orphan failure mode (issue #1935, FM-NEW-1) is covered.
 #   3. TCP-probes any existing session record at startup; if reachable,
@@ -63,33 +60,16 @@ from nexus.ttl import parse_ttl
 #      cleared issue #40207 not applicable to nx-mcp, so this path is
 #      cheap insurance against future Claude Code behaviour changes).
 #
-# Default ON (4.12.0). Set ``NEXUS_MCP_OWNS_T1=0`` (or ``false``/``no``)
-# as an emergency opt-out if the MCP-owned path ever needs to be
-# disabled in production. Spike A (40/40), Spike B (CA-2 verified
+# The 4.12.0-era ``NEXUS_MCP_OWNS_T1`` opt-out gate was removed in
+# Phase F (4.13.0): Spike A (40/40), Spike B (CA-2 verified
 # post-mitigation), and Spike C (issue #40207 verified-negative for
-# stdio) all clear; the gate stays as a safety hatch only.
+# stdio) all cleared, plus a clean v4.12.0 -> v4.12.1 shakeout cycle
+# in production confirmed no regression. The hook-era chroma-spawn
+# path was already disconnected by Phase B (session_end split) and
+# Phase C (hooks.json launcher swap), so deletion was a pure
+# simplification with no behavioural delta.
 
 import os as _os
-
-
-def _flag_enabled(name: str, default: bool) -> bool:
-    """Read a tri-state env flag with a default.
-
-    Truthy: ``1`` / ``true`` / ``yes`` / ``on`` (case-insensitive).
-    Falsy:  ``0`` / ``false`` / ``no`` / ``off``.
-    Anything else (including empty string) returns ``default``.
-    """
-    raw = _os.environ.get(name, "").strip().lower()
-    if raw in ("1", "true", "yes", "on"):
-        return True
-    if raw in ("0", "false", "no", "off"):
-        return False
-    return default
-
-
-# Default ON (RDR-094 Phase 4 default-on, 4.12.0). NEXUS_MCP_OWNS_T1=0
-# (or false / no / off) is the emergency opt-out.
-_MCP_OWNS_T1: bool = _flag_enabled("NEXUS_MCP_OWNS_T1", default=True)
 
 #: Module-scope state for the owned chroma. Populated by
 #: ``_t1_chroma_init_if_owner`` and consumed by ``_t1_chroma_shutdown``.
@@ -349,10 +329,7 @@ async def _t1_chroma_lifespan(_app: Any):
         _t1_chroma_shutdown()
 
 
-mcp = FastMCP(
-    "nexus",
-    lifespan=_t1_chroma_lifespan if _MCP_OWNS_T1 else None,
-)
+mcp = FastMCP("nexus", lifespan=_t1_chroma_lifespan)
 
 _DEFAULT_PAGE_SIZE = 10
 
@@ -3483,27 +3460,25 @@ def main():
         transport="stdio",
         pid=os.getpid(),
         ppid=os.getppid(),
-        mcp_owns_t1=_MCP_OWNS_T1,
     )
-    if _MCP_OWNS_T1:
-        # The FastMCP lifespan finally is the design's primary cleanup
-        # path; the signal handlers below are belt-and-braces for the
-        # cases where the lifespan does not fire. Empirically, FastMCP's
-        # stdio transport on macOS does NOT have anyio install a
-        # SIGTERM handler that propagates cancellation through the
-        # lifespan async finally (RDR-094 spike, 2026-04-25). Without
-        # our explicit handlers, SIGTERM kills the process silently,
-        # atexit does NOT run (Python only fires atexit on clean exit),
-        # and chroma orphans. The watchdog covers it eventually but
-        # the MCP-owned cleanup path simply doesn't run. So we install
-        # the signal handlers for SIGTERM and SIGINT to call
-        # _t1_chroma_shutdown directly. atexit stays as the third
-        # belt-and-braces for clean exits via stdin EOF / SystemExit.
-        # _t1_chroma_shutdown is idempotent so all three paths can fire
-        # without double-cleaning.
-        atexit.register(_t1_chroma_shutdown)
-        signal.signal(signal.SIGTERM, _sigterm_handler)
-        signal.signal(signal.SIGINT, _sigterm_handler)
+    # The FastMCP lifespan finally is the design's primary cleanup
+    # path; the signal handlers below are belt-and-braces for the
+    # cases where the lifespan does not fire. Empirically, FastMCP's
+    # stdio transport on macOS does NOT have anyio install a
+    # SIGTERM handler that propagates cancellation through the
+    # lifespan async finally (RDR-094 spike, 2026-04-25). Without
+    # our explicit handlers, SIGTERM kills the process silently,
+    # atexit does NOT run (Python only fires atexit on clean exit),
+    # and chroma orphans. The watchdog covers it eventually but
+    # the MCP-owned cleanup path simply doesn't run. So we install
+    # the signal handlers for SIGTERM and SIGINT to call
+    # _t1_chroma_shutdown directly. atexit stays as the third
+    # belt-and-braces for clean exits via stdin EOF / SystemExit.
+    # _t1_chroma_shutdown is idempotent so all three paths can fire
+    # without double-cleaning.
+    atexit.register(_t1_chroma_shutdown)
+    signal.signal(signal.SIGTERM, _sigterm_handler)
+    signal.signal(signal.SIGINT, _sigterm_handler)
     try:
         check_version_compatibility()
         mcp.run(transport="stdio")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -11,38 +11,21 @@ from nexus.hooks import session_end, session_end_flush, session_start
 
 
 # ── session_start ────────────────────────────────────────────────────────────
-
-def _patch_session_start(tmp_path: Path, *, ancestor=None, server_raises=False):
-    """Return a context manager bundle that patches session_start dependencies."""
-    db_path = tmp_path / "memory.db"
-    server_result = ("127.0.0.1", 51823, 9900, str(tmp_path / "t1_tmp"))
-
-    patches = [
-        patch("nexus.hooks._default_db_path", return_value=db_path),
-        patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_ancestor_session", return_value=ancestor),
-        patch("nexus.hooks.write_claude_session_id"),
-    ]
-    if ancestor is None:
-        if server_raises:
-            patches.append(patch("nexus.hooks.start_t1_server",
-                                 side_effect=RuntimeError("chroma not found")))
-        else:
-            patches.append(patch("nexus.hooks.start_t1_server", return_value=server_result))
-        patches.append(patch("nexus.hooks.write_session_record"))
-    return patches
+#
+# RDR-094 Phase F (4.13.0 / nexus-2lm0) deleted the hook-side chroma
+# spawn block: ``start_t1_server``, ``write_session_record_by_id``,
+# ``find_ancestor_session``, the session.lock acquisition, and the
+# watchdog spawn all moved to nx-mcp's FastMCP lifespan. The hook now
+# does sweep + UUID resolution + (optionally) current_session write.
+# These tests pin that minimal contract.
 
 
 @patch("nexus.hooks.generate_session_id", return_value="test-uuid")
-def test_session_start_returns_session_id(mock_sid, tmp_path: Path) -> None:
-    """session_start returns the session ID line (T2 memory is surfaced by separate hook)."""
+def test_session_start_returns_session_id(_mock_sid, tmp_path: Path) -> None:
+    """session_start returns the session ID line."""
     with (
-        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
         patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_ancestor_session", return_value=None),
         patch("nexus.hooks.write_claude_session_id"),
-        patch("nexus.hooks.start_t1_server", return_value=("127.0.0.1", 51823, 9900, "/tmp/x")),
-        patch("nexus.hooks.write_session_record"),
     ):
         output = session_start()
 
@@ -50,41 +33,8 @@ def test_session_start_returns_session_id(mock_sid, tmp_path: Path) -> None:
     assert "Nexus ready" in output
 
 
-def test_session_start_adopts_existing_session_for_same_uuid(tmp_path: Path) -> None:
-    """Subagent with the same Claude session UUID adopts the existing T1 server.
-
-    Pre-fix this was achieved via a PPID walk (broken — it adopted the
-    login shell's session). Post-fix it falls out of UUID-keyed lookup:
-    the subagent's hook is invoked with the parent's session_id (read
-    from current_session flat file), find_session_by_id returns the
-    existing record, no new server is started.
-    """
-    existing = {
-        "session_id": "parent-session-uuid",
-        "server_host": "127.0.0.1",
-        "server_port": 51823,
-        "server_pid": 9900,
-        "tmpdir": "",
-        "created_at": 0,
-    }
-    mock_start = MagicMock()
-
-    with (
-        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
-        patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_session_by_id", return_value=existing),
-        patch("nexus.hooks.write_claude_session_id"),
-        patch("nexus.hooks.start_t1_server", mock_start),
-        patch("nexus.hooks._infer_repo", return_value="myrepo"),
-    ):
-        output = session_start(claude_session_id="parent-session-uuid")
-
-    assert "parent-session-uuid" in output
-    mock_start.assert_not_called()  # should NOT start a new server
-
-
 def test_session_start_does_not_overwrite_current_session_when_inherited(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Nested subprocess (NX_SESSION_ID set in env) must NOT stomp the
     parent's ``current_session`` flat file. Without this guard, every
@@ -96,86 +46,59 @@ def test_session_start_does_not_overwrite_current_session_when_inherited(
     mock_write = MagicMock()
 
     with (
-        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
         patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_session_by_id", return_value=None),
-        patch("nexus.hooks.start_t1_server", side_effect=RuntimeError("no T1")),
         patch("nexus.hooks.write_claude_session_id", mock_write),
-        patch("nexus.hooks._infer_repo", return_value="myrepo"),
     ):
         output = session_start(claude_session_id="my-own-transient-uuid")
 
-    # The hook should have used the inherited UUID (not the stdin one)
     assert "parent-uuid-keep-me" in output
-    # And must NOT have written current_session — that would stomp the parent
     mock_write.assert_not_called()
 
 
 def test_session_start_writes_current_session_when_top_level(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Top-level Claude session (no NX_SESSION_ID inherited) writes
-    ``current_session`` as today, populating the cross-tree pointer
-    that shell tools and subagents rely on.
-    """
+    ``current_session``, populating the cross-tree pointer that shell
+    tools and subagents rely on."""
     monkeypatch.delenv("NX_SESSION_ID", raising=False)
     mock_write = MagicMock()
 
     with (
-        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
         patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_session_by_id", return_value=None),
-        patch("nexus.hooks.start_t1_server", side_effect=RuntimeError("no T1")),
         patch("nexus.hooks.write_claude_session_id", mock_write),
-        patch("nexus.hooks._infer_repo", return_value="myrepo"),
     ):
         session_start(claude_session_id="top-level-uuid")
 
     mock_write.assert_called_once_with("top-level-uuid")
 
 
-def test_session_start_skips_t1_when_env_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """NEXUS_SKIP_T1 honoured: claude_dispatch (and similar one-shot
-    `claude -p` callers) sets this so the subprocess does not pay the
-    chroma startup cost. The T1 client falls back to EphemeralClient
-    when no server record is found, which is the intended behaviour for
-    stateless operator subprocesses.
-    """
-    monkeypatch.setenv("NEXUS_SKIP_T1", "1")
-    mock_start = MagicMock()
-    mock_write_record = MagicMock()
-
+def test_session_start_uses_inherited_session_id(tmp_path: Path, monkeypatch) -> None:
+    """When ``NX_SESSION_ID`` is set in env, the hook uses it verbatim
+    rather than generating a new UUID or honouring the stdin payload.
+    Subagents inherit the parent's ID this way."""
+    monkeypatch.setenv("NX_SESSION_ID", "inherited-uuid")
     with (
-        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
         patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_session_by_id", return_value=None),
         patch("nexus.hooks.write_claude_session_id"),
-        patch("nexus.hooks.start_t1_server", mock_start),
-        patch("nexus.hooks.write_session_record_by_id", mock_write_record),
-        patch("nexus.hooks._infer_repo", return_value="myrepo"),
-        patch("nexus.hooks.generate_session_id", return_value="skip-t1-uuid"),
+    ):
+        output = session_start(claude_session_id="ignored-stdin-uuid")
+    assert "inherited-uuid" in output
+    assert "ignored-stdin-uuid" not in output
+
+
+def test_session_start_falls_back_to_generated_uuid(tmp_path, monkeypatch) -> None:
+    """No NX_SESSION_ID env and no stdin payload: generate a fresh UUID
+    so invocations outside Claude Code (e.g. ``nx hook session-start``
+    from a script) still produce a usable session pointer."""
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
+    with (
+        patch("nexus.hooks.sweep_stale_sessions"),
+        patch("nexus.hooks.write_claude_session_id"),
+        patch("nexus.hooks.generate_session_id", return_value="fresh-uuid"),
     ):
         output = session_start()
-
-    assert "skip-t1-uuid" in output
-    mock_start.assert_not_called()  # server NOT started
-    mock_write_record.assert_not_called()  # no session record written
-
-
-def test_session_start_server_failure_is_graceful(tmp_path: Path) -> None:
-    """If start_t1_server raises, session_start completes without crashing."""
-    with (
-        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
-        patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_session_by_id", return_value=None),
-        patch("nexus.hooks.write_claude_session_id"),
-        patch("nexus.hooks.start_t1_server", side_effect=RuntimeError("chroma not found")),
-        patch("nexus.hooks.generate_session_id", return_value="fallback-uuid"),
-        patch("nexus.hooks._infer_repo", return_value="myrepo"),
-    ):
-        output = session_start()  # must not raise
-
-    assert "fallback-uuid" in output
+    assert "fresh-uuid" in output
 
 
 # ── session_end ──────────────────────────────────────────────────────────────
@@ -216,35 +139,31 @@ def test_session_end_no_session_record(tmp_path: Path, monkeypatch: pytest.Monke
     assert "Expired 0" in output
 
 
-def test_session_end_with_session_record(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """When this process owns the session record AND the MCP-owned-T1
-    opt-out is set, T1 is flushed and server stopped via the legacy
-    hook path. Default-on (4.12.0) leaves chroma teardown to nx-mcp;
-    this test pins the opt-out fallback path."""
+def test_session_end_owner_path_does_not_stop_chroma(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """RDR-094 Phase F (unconditional as of 4.13.0): session_end is a
+    thin wrapper around session_end_flush. nx-mcp owns chroma
+    teardown via its lifespan/atexit/signal-handler chain; the hook
+    must NEVER call stop_t1_server even when this process owns the
+    session record."""
     sessions = tmp_path / "sessions"
     _make_session_record(sessions, session_id="end-test-uuid", server_pid=9900)
     monkeypatch.setenv("NX_SESSION_ID", "end-test-uuid")
-    # Explicit opt-out of MCP-ownership so session_end's chroma-stop
-    # block runs (the flag is default-on as of 4.12.0).
-    monkeypatch.setenv("NEXUS_MCP_OWNS_T1", "0")
 
     mock_t1 = MagicMock()
     mock_t1.flagged_entries.return_value = []
-    mock_stop = MagicMock()
     db_path = tmp_path / "memory.db"
 
     with (
         patch("nexus.hooks.SESSIONS_DIR", sessions),
         patch("nexus.hooks._default_db_path", return_value=db_path),
         patch("nexus.hooks._open_t1", return_value=mock_t1),
-        patch("nexus.hooks.stop_t1_server", mock_stop),
     ):
         output = session_end()
 
     assert "Flushed 0" in output
-    mock_stop.assert_called_once_with(9900)
-    # Session file should be cleaned up
-    assert not (sessions / "end-test-uuid.session").exists()
+    # Session file must survive: the MCP server's lifespan (or the
+    # watchdog as belt-and-braces) is responsible for unlinking it.
+    assert (sessions / "end-test-uuid.session").exists()
 
 
 def test_session_end_flushes_flagged_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -265,7 +184,6 @@ def test_session_end_flushes_flagged_entries(tmp_path: Path, monkeypatch: pytest
         patch("nexus.hooks.SESSIONS_DIR", sessions),
         patch("nexus.hooks._default_db_path", return_value=db_path),
         patch("nexus.hooks._open_t1", return_value=mock_t1),
-        patch("nexus.hooks.stop_t1_server"),
     ):
         output = session_end()
 
@@ -313,7 +231,6 @@ def test_session_end_child_does_not_stop_server(tmp_path: Path, monkeypatch: pyt
         patch("nexus.hooks.find_session_by_id", return_value=parent_record),
         patch("nexus.hooks._default_db_path", return_value=db_path),
         patch("nexus.hooks._open_t1", return_value=mock_t1),
-        patch("nexus.hooks.stop_t1_server", mock_stop),
     ):
         output = session_end()
 
@@ -328,7 +245,6 @@ def test_session_end_db_error_doesnt_crash(tmp_path: Path) -> None:
 
     with (
         patch("nexus.hooks.SESSIONS_DIR", sessions),
-        patch("nexus.hooks.find_ancestor_session", return_value=None),
         patch("nexus.hooks._default_db_path", return_value=tmp_path / "nonexistent_dir" / "memory.db"),
     ):
         output = session_end()
@@ -382,16 +298,14 @@ class TestSessionEndFlush:
             patch("nexus.hooks.SESSIONS_DIR", sessions),
             patch("nexus.hooks._default_db_path", return_value=db_path),
             patch("nexus.hooks._open_t1", return_value=mock_t1),
-            patch("nexus.hooks.stop_t1_server") as mock_stop,
         ):
             output = session_end_flush()
 
         assert "Flushed 1" in output
         mock_t1.clear.assert_called_once()
-        # The flush function MUST NOT touch chroma -- this is the
-        # whole point of the split.
-        mock_stop.assert_not_called()
-        # ...and must NOT delete the session record.
+        # The flush function MUST NOT delete the session record. nx-mcp
+        # owns chroma teardown (lifespan + signal + atexit); hook just
+        # flushes.
         assert (sessions / "flush-only-uuid.session").exists()
 
         with T2Database(db_path) as db:
@@ -416,25 +330,24 @@ class TestSessionEndFlush:
             patch("nexus.hooks.SESSIONS_DIR", sessions),
             patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
             patch("nexus.hooks._open_t1", return_value=mock_t1),
-            patch("nexus.hooks.stop_t1_server") as mock_stop,
         ):
             session_end_flush()
 
-        mock_stop.assert_not_called()
         # Session file must survive a flush-only run.
         assert (sessions / "owner-uuid.session").exists()
 
 
-def test_session_end_default_on_skips_chroma_without_env_var(
+def test_session_end_never_stops_chroma_phase_f(
     tmp_path, monkeypatch,
 ):
-    """RDR-094 Phase 4 default-on (4.12.0): absence of
-    NEXUS_MCP_OWNS_T1 means MCP owns chroma. session_end must NOT
-    call stop_t1_server even when this process owns the record."""
+    """RDR-094 Phase F (unconditional as of 4.13.0): session_end is
+    a thin wrapper around session_end_flush. The hook must NOT call
+    stop_t1_server -- nx-mcp owns chroma teardown via lifespan +
+    signal handler + atexit chain, with the watchdog as belt-and-
+    braces. Regression sentinel for the gate removal."""
     sessions = tmp_path / "sessions"
-    _make_session_record(sessions, session_id="default-on-uuid", server_pid=42)
-    monkeypatch.setenv("NX_SESSION_ID", "default-on-uuid")
-    monkeypatch.delenv("NEXUS_MCP_OWNS_T1", raising=False)
+    _make_session_record(sessions, session_id="phase-f-uuid", server_pid=42)
+    monkeypatch.setenv("NX_SESSION_ID", "phase-f-uuid")
 
     mock_t1 = MagicMock()
     mock_t1.flagged_entries.return_value = []
@@ -443,43 +356,12 @@ def test_session_end_default_on_skips_chroma_without_env_var(
         patch("nexus.hooks.SESSIONS_DIR", sessions),
         patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
         patch("nexus.hooks._open_t1", return_value=mock_t1),
-        patch("nexus.hooks.stop_t1_server") as mock_stop,
     ):
         output = session_end()
 
     assert "Session ended" in output
-    mock_stop.assert_not_called(), "default-on: hook must not stop chroma"
-    # Session file must survive when MCP owns T1.
-    assert (sessions / "default-on-uuid.session").exists()
-
-
-def test_session_end_skips_chroma_when_mcp_owns_t1(
-    tmp_path, monkeypatch,
-):
-    """Explicit NEXUS_MCP_OWNS_T1=1 still gates correctly under
-    default-on (back-compat sentinel for callers that set the flag
-    explicitly even though it's the new default).
-    """
-    sessions = tmp_path / "sessions"
-    _make_session_record(sessions, session_id="mcp-owned-uuid", server_pid=42)
-    monkeypatch.setenv("NX_SESSION_ID", "mcp-owned-uuid")
-    monkeypatch.setenv("NEXUS_MCP_OWNS_T1", "1")
-
-    mock_t1 = MagicMock()
-    mock_t1.flagged_entries.return_value = []
-
-    with (
-        patch("nexus.hooks.SESSIONS_DIR", sessions),
-        patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
-        patch("nexus.hooks._open_t1", return_value=mock_t1),
-        patch("nexus.hooks.stop_t1_server") as mock_stop,
-    ):
-        output = session_end()
-
-    assert "Session ended" in output
-    mock_stop.assert_not_called()
-    # Session file must survive when MCP owns T1.
-    assert (sessions / "mcp-owned-uuid.session").exists()
+    # Session file must survive: lifespan / watchdog owns the unlink.
+    assert (sessions / "phase-f-uuid.session").exists()
 
 
 # ── nx hook session-end-flush CLI subcommand ────────────────────────────────
@@ -499,7 +381,6 @@ def test_session_end_flush_cli_subcommand(tmp_path, monkeypatch):
         patch("nexus.hooks.SESSIONS_DIR", sessions),
         patch("nexus.hooks.find_session_by_id", return_value=None),
         patch("nexus.hooks._default_db_path", return_value=tmp_path / "memory.db"),
-        patch("nexus.hooks.stop_t1_server") as mock_stop,
     ):
         runner = CliRunner()
         result = runner.invoke(hook_group, ["session-end-flush"])
@@ -507,74 +388,19 @@ def test_session_end_flush_cli_subcommand(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert "Flushed 0" in result.output
     assert "Expired 0" in result.output
-    # Critical: the flush subcommand never calls stop_t1_server.
-    mock_stop.assert_not_called()
 
 
 # ── session lock stale cleanup ───────────────────────────────────────────────
 
 
-def test_session_start_writes_pid_to_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """session_start writes its PID into session.lock for stale detection.
-
-    Default-on (4.12.0) routes the hook through skip_t1, which bypasses
-    the lock acquisition because nx-mcp owns chroma. Opt out explicitly
-    so this test exercises the legacy lock-creation path that's still
-    relevant when ``NEXUS_MCP_OWNS_T1=0``.
-    """
-    monkeypatch.setenv("NEXUS_MCP_OWNS_T1", "0")
-    sessions = tmp_path / "sessions"
-    sessions.mkdir()
-
-    with (
-        patch("nexus.hooks.SESSIONS_DIR", sessions),
-        patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_ancestor_session", return_value=None),
-        patch("nexus.hooks.write_claude_session_id"),
-        patch("nexus.hooks.start_t1_server", return_value=("127.0.0.1", 51823, 9900, "/tmp/x")),
-        patch("nexus.hooks.write_session_record"),
-        patch("nexus.hooks.generate_session_id", return_value="lock-test-uuid"),
-    ):
-        session_start()
-
-    lock_file = sessions / "session.lock"
-    assert lock_file.exists()
-    pid_text = lock_file.read_text().strip()
-    assert pid_text == str(os.getpid())
-
-
-def test_session_start_clears_stale_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """session_start removes a stale session.lock before acquiring.
-
-    Same opt-out as ``test_session_start_writes_pid_to_lock``: default-on
-    bypasses the lock entirely.
-    """
-    monkeypatch.setenv("NEXUS_MCP_OWNS_T1", "0")
-    from nexus.indexer import _LOCK_STALE_SECONDS
-
-    sessions = tmp_path / "sessions"
-    sessions.mkdir()
-
-    # Create stale empty lock file
-    lock_file = sessions / "session.lock"
-    lock_file.touch()
-    old_time = time.time() - _LOCK_STALE_SECONDS - 1
-    os.utime(lock_file, (old_time, old_time))
-
-    with (
-        patch("nexus.hooks.SESSIONS_DIR", sessions),
-        patch("nexus.hooks.sweep_stale_sessions"),
-        patch("nexus.hooks.find_ancestor_session", return_value=None),
-        patch("nexus.hooks.write_claude_session_id"),
-        patch("nexus.hooks.start_t1_server", return_value=("127.0.0.1", 51823, 9900, "/tmp/x")),
-        patch("nexus.hooks.write_session_record"),
-        patch("nexus.hooks.generate_session_id", return_value="lock-test-uuid"),
-    ):
-        session_start()  # must not deadlock on stale lock
-
-    # Lock file should now contain current PID, not be stale
-    assert lock_file.exists()
-    assert lock_file.read_text().strip() == str(os.getpid())
+# Phase F (RDR-094 / nexus-2lm0) deleted the hook-side chroma-spawn
+# block, including the session.lock acquisition. The lock guarded
+# concurrent siblings from each calling start_t1_server. Now nx-mcp's
+# lifespan owns spawn, the hook does no T1 work, and there is no
+# lock to test. The pre-Phase-F tests
+# (test_session_start_writes_pid_to_lock,
+# test_session_start_clears_stale_lock) were removed with the code
+# they covered.
 
 
 # ── _infer_repo ──────────────────────────────────────────────────────────────

--- a/tests/test_mcp_chroma_lifecycle.py
+++ b/tests/test_mcp_chroma_lifecycle.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Unit tests for the MCP-owned T1 chroma lifecycle (RDR-094 Phase 1+2).
+"""Unit tests for the MCP-owned T1 chroma lifecycle (RDR-094 Phase 4).
 
-Covers the feature-flagged path under ``NEXUS_MCP_OWNS_T1=1``:
+Covers the unconditional MCP-owns-chroma path (the 4.12.0-era
+``NEXUS_MCP_OWNS_T1`` opt-out gate was removed in Phase F / 4.13.0):
 
   * ``_t1_chroma_init_if_owner`` spawn / reuse / nested-skip branches.
   * ``_t1_chroma_shutdown`` idempotency + skip-on-reuse / skip-on-nested.
@@ -411,25 +412,51 @@ class TestLifespan:
                 mock_shutdown.assert_called_once()
 
 
-# ── Feature flag wiring ─────────────────────────────────────────────────────
+# ── Lifespan wiring (Phase F / 4.13.0: unconditional) ──────────────────────
 
 
-class TestFeatureFlag:
+class TestLifespanWiring:
+    """The 4.12.0-era ``NEXUS_MCP_OWNS_T1`` opt-out gate was removed
+    in Phase F / 4.13.0. The lifespan is now unconditionally attached
+    to the FastMCP instance; there is no env-var path to disable it.
+    """
 
-    def test_lifespan_attached_by_default(self):
-        """Default-on as of conexus 4.12.0: the lifespan kwarg is
-        attached unless NEXUS_MCP_OWNS_T1 is explicitly opted out
-        via 0/false/no/off. The env var is read once at module
-        import; this test asserts the resolved bool matches the
-        active env."""
-        import os
-
+    def test_lifespan_unconditionally_attached(self):
+        """``mcp.run`` always uses ``_t1_chroma_lifespan`` -- there is
+        no flag-off path that constructs FastMCP with ``lifespan=None``.
+        """
         from nexus.mcp import core as core_mod
 
-        raw = os.environ.get("NEXUS_MCP_OWNS_T1", "").strip().lower()
-        if raw in ("0", "false", "no", "off"):
-            expected = False
-        else:
-            # Empty string OR explicit truthy values -> default-on.
-            expected = True
-        assert core_mod._MCP_OWNS_T1 is expected
+        # FastMCP's ``settings`` carries the lifespan it was constructed
+        # with. Verify it points at our async cm, not None.
+        # The ``_lifespan_cm`` attribute is the canonical store for the
+        # callable across FastMCP versions; fall back to ``settings``
+        # for older minor releases.
+        lifespan = (
+            getattr(core_mod.mcp, "_lifespan", None)
+            or getattr(core_mod.mcp, "_lifespan_cm", None)
+            or getattr(getattr(core_mod.mcp, "settings", None), "lifespan", None)
+        )
+        assert lifespan is not None, (
+            "FastMCP must have a lifespan attached after Phase F"
+        )
+        # Whichever attribute carried it, the function name must match.
+        # The lifespan stored may be the function itself or a wrapper;
+        # checking the qualname covers both shapes.
+        qualname = getattr(lifespan, "__qualname__", repr(lifespan))
+        assert "_t1_chroma_lifespan" in qualname, (
+            f"Expected _t1_chroma_lifespan; got {qualname}"
+        )
+
+    def test_no_mcp_owns_t1_module_attr(self):
+        """Regression sentinel: the ``_MCP_OWNS_T1`` module attribute
+        was removed in Phase F. Any reference to it in production
+        code or tests is a stale gate from 4.12.x."""
+        from nexus.mcp import core as core_mod
+
+        assert not hasattr(core_mod, "_MCP_OWNS_T1"), (
+            "_MCP_OWNS_T1 was removed in Phase F (RDR-094 / nexus-2lm0)"
+        )
+        assert not hasattr(core_mod, "_flag_enabled"), (
+            "_flag_enabled was removed with the gate"
+        )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -130,8 +130,7 @@ def test_session_end_flushes_flagged_t1_entries(
     with patch("nexus.hooks.SESSIONS_DIR", sessions):
         with patch("nexus.hooks._open_t1", return_value=mock_t1):
             with patch("nexus.hooks.T2Database", return_value=_t2_cm):
-                with patch("nexus.hooks.stop_t1_server"):
-                    result = runner.invoke(main, ["hook", "session-end"])
+                result = runner.invoke(main, ["hook", "session-end"])
 
     assert result.exit_code == 0, result.output
     mock_t2.put.assert_called_once_with(
@@ -143,17 +142,16 @@ def test_session_end_flushes_flagged_t1_entries(
     )
 
 
-def test_session_end_clears_t1_and_removes_session_file(
+def test_session_end_clears_t1_and_keeps_session_file(
     runner: CliRunner, fake_home: Path, tmp_path: Path, monkeypatch
 ) -> None:
-    """SessionEnd clears T1 and removes the UUID-keyed session file
-    under the legacy hook-owned chroma path.
+    """SessionEnd clears T1 and leaves the session file intact.
 
-    Default-on (4.12.0) routes chroma teardown to nx-mcp; the hook
-    no longer removes the session file. This test pins the legacy
-    flag-off behaviour with explicit ``NEXUS_MCP_OWNS_T1=0``.
+    Phase F (RDR-094 / nexus-2lm0, unconditional as of 4.13.0):
+    nx-mcp's lifespan owns chroma teardown AND session-file unlink.
+    The hook does flush + expire only; the session file MUST survive
+    a hook invocation (lifespan/watchdog removes it on actual exit).
     """
-    monkeypatch.setenv("NEXUS_MCP_OWNS_T1", "0")
     sessions = tmp_path / "sessions"
     session_id = "test-session-id"
     session_file = sessions / f"{session_id}.session"
@@ -175,12 +173,13 @@ def test_session_end_clears_t1_and_removes_session_file(
     with patch("nexus.hooks.SESSIONS_DIR", sessions):
         with patch("nexus.hooks._open_t1", return_value=mock_t1):
             with patch("nexus.hooks.T2Database", return_value=_t2_cm):
-                with patch("nexus.hooks.stop_t1_server"):
-                    result = runner.invoke(main, ["hook", "session-end"])
+                result = runner.invoke(main, ["hook", "session-end"])
 
     assert result.exit_code == 0, result.output
     mock_t1.clear.assert_called_once()
-    assert not session_file.exists()
+    # Phase F: session file MUST survive a hook invocation; nx-mcp's
+    # lifespan owns the unlink on actual process exit.
+    assert session_file.exists()
 
 
 def test_session_end_runs_expire(runner: CliRunner, fake_home: Path) -> None:

--- a/tests/test_session_end_launcher.py
+++ b/tests/test_session_end_launcher.py
@@ -8,9 +8,9 @@ Contract pins:
   * ``main()`` returns to the caller via the first-fork parent path
     (in the real world ~17ms; here we simulate the fork).
   * ``_run_session_end_synchronously`` calls
-    ``nexus.hooks.session_end_flush`` (Phase C swap from
-    ``session_end`` to drop the chroma-stop race against
-    NEXUS_MCP_OWNS_T1) and swallows exceptions.
+    ``nexus.hooks.session_end_flush`` (storage-only path; chroma
+    teardown is owned by nx-mcp's lifespan + signal handler + atexit
+    chain, unconditional as of 4.13.0) and swallows exceptions.
   * Platform-without-fork fallback runs synchronously.
 """
 from __future__ import annotations
@@ -44,9 +44,11 @@ def test_module_does_not_import_nexus_submodules_at_top_level() -> None:
 def test_run_session_end_synchronously_invokes_session_end_flush() -> None:
     """RDR-094 Phase C: grandchild path dispatches to session_end_flush.
 
-    The pre-Phase-C contract was ``session_end`` which both flushes and
-    stops chroma. Under NEXUS_MCP_OWNS_T1 (Phase 4) the MCP server owns
-    chroma teardown, so the launcher must use the storage-only entry.
+    The pre-Phase-C contract was ``session_end`` which both flushed
+    and stopped chroma. nx-mcp owns chroma teardown via its lifespan
+    + signal handler + atexit chain (unconditional as of 4.13.0), so
+    the launcher uses the storage-only entry to avoid racing the
+    MCP-owned cleanup paths.
     """
     import nexus._session_end_launcher as launcher
 
@@ -62,13 +64,14 @@ def test_run_session_end_synchronously_invokes_session_end_flush() -> None:
 
 
 def test_run_session_end_synchronously_does_not_call_session_end() -> None:
-    """Regression sentinel: launcher must NOT route through session_end.
+    """Regression sentinel: launcher must call session_end_flush by name.
 
-    session_end runs the chroma-stop block when NEXUS_MCP_OWNS_T1 is
-    unset, which races MCP-owned cleanup. The Phase C contract is to
-    point the launcher at session_end_flush exclusively; the legacy
-    session_end path stays only for nx hook session-end (manual debug)
-    and for the flag-off rollout window.
+    ``session_end`` is now a thin pass-through (4.13.0 / Phase F), so
+    routing through it would still produce the right result. But
+    pinning the launcher to ``session_end_flush`` directly preserves
+    the explicit "no chroma teardown here" contract -- if a future
+    refactor adds anything to ``session_end``, the launcher's
+    fork-first guarantee stays unaffected.
     """
     import nexus._session_end_launcher as launcher
 


### PR DESCRIPTION
## Summary

Phase F deliverable. The 4.12.0-era \`NEXUS_MCP_OWNS_T1\` opt-out gate is gone; nx-mcp's lifespan unconditionally owns chroma's lifecycle. Net diff: **+226 / -509 lines** (deletion of dead-but-gated code).

## Source changes

- **\`src/nexus/mcp/core.py\`**:
  - Delete \`_flag_enabled\` helper and \`_MCP_OWNS_T1\` module variable.
  - FastMCP construction always passes lifespan (no \`if _MCP_OWNS_T1 else None\`).
  - \`main()\` unconditionally registers atexit + SIGTERM/SIGINT handlers.
- **\`src/nexus/hooks.py\`**:
  - Delete \`_mcp_owns_t1_enabled\` helper.
  - Delete the hook-side chroma-spawn block from \`session_start\` (lock acquisition, \`start_t1_server\`, \`write_session_record_by_id\`, watchdog spawn — all owned by nx-mcp's lifespan now).
  - \`session_end\` reduced to a thin pass-through to \`session_end_flush\`.
  - Drop now-unused imports: \`fcntl\`, \`shutil\`, \`find_ancestor_session\`, \`find_claude_root_pid\`, \`spawn_t1_watchdog\`, \`start_t1_server\`, \`stop_t1_server\`, \`write_session_record\`, \`write_session_record_by_id\`, \`_ppid_of\`.
- **\`src/nexus/_session_end_launcher.py\` + \`commands/hook.py\`**: docstring updates.

## Test changes

- **\`tests/test_hooks.py\`**: rewrite \`session_start\` tests to match the minimal post-Phase-F surface (no chroma-spawn patches needed); **remove** the lock-creation + stale-lock tests (the lock was deleted with the spawn block); rename the gate-related test to \`test_session_end_never_stops_chroma_phase_f\` as a regression sentinel.
- **\`tests/test_mcp_chroma_lifecycle.py\`**: replace \`TestFeatureFlag\` with \`TestLifespanWiring\` — pin that the lifespan is unconditionally attached and that \`_MCP_OWNS_T1\` / \`_flag_enabled\` module attrs are **GONE** (regression sentinel).
- **\`tests/test_plugin.py\`**: rename test to \`test_session_end_clears_t1_and_keeps_session_file\` — the hook no longer unlinks the session file (lifespan/watchdog owns the unlink on actual process exit).

## RDR

- **\`docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md\`**: §Phase 4 marked **COMPLETE 2026-04-25 (4.13.0)**. Records the three prerequisites cleared:
  - CA-2 verified post-mitigation (Spike B 40/40 connected_to_parent, T2 id=983)
  - Phase B+C shipped (PRs #306, #307)
  - Canary served by the v4.12.0 → v4.12.1 shakeout cycle (PR #314 fixed the stdin-EOF + SIGTERM signal-handler race that surfaced)

- **\`docs/rdr/rdr-093-groupby-aggregate-operators.md\`**: ride-along close (status: \`closed\`, \`close_reason: implemented\`, gap pointers validated). Separate semantic change but minimal diff so it batches cleanly.

## Test plan

- [x] Pre-commit full unit suite (\`uv run pytest -m "not integration" -q\`): **5208 passed, 27 skipped, 30 deselected** in 9m 32s
- [x] Targeted Phase-F-surface sweep (test_hooks + test_mcp_chroma_lifecycle + test_session_end_launcher + test_plugin + test_t1 + test_session + test_mcp_server + test_session_propagation_hypotheses + test_t1_watchdog + test_plugin_structure): **821 pass**
- [x] Regression sentinels in \`tests/test_mcp_chroma_lifecycle.py\` for \`_MCP_OWNS_T1\` and \`_flag_enabled\` removal
- [x] No em dashes in additions
- [x] Explicit-path \`git add\`

## Closes

Closes nexus-2lm0 (RDR-094 Phase F: Remove NEXUS_MCP_OWNS_T1 feature flag). Also closes nexus-fn44 (Phase E canary, satisfied by the v4.12.0 default-on flip — closed 2026-04-25 ahead of this PR). Together with the RDR-094 Phase 4 epic (nexus-4v5l), this completes the entire RDR-094 implementation.