### PR TITLE
release: v4.13.0 — RDR-094 Phase F (NEXUS_MCP_OWNS_T1 gate removal)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.12.1"
+      "version": "4.13.0"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.12.1"
+      "version": "4.13.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.13.0] - 2026-04-25
+
+Closes RDR-094 Phase F (final phase of the MCP-Owned T1 Chroma Lifecycle epic). The `NEXUS_MCP_OWNS_T1` env-var gate from 4.12.0 is removed entirely; nx-mcp's lifespan unconditionally owns chroma's lifecycle. Net source diff: **-283 lines** (deletion of dead-but-gated code paths).
+
+This release is structurally a simplification: 4.12.0 already shipped the MCP-owned-T1 path as default-on; 4.12.1 fixed the stdin-EOF + SIGTERM signal-handler race that surfaced in the shakeout. 4.13.0 deletes the opt-out machinery now that the path is empirically validated. Same observable behaviour as 4.12.1 unless an operator was explicitly setting `NEXUS_MCP_OWNS_T1=0` to opt out: the env var is now silently ignored and the MCP-owned path runs anyway.
+
+### Removed
+
+- **`NEXUS_MCP_OWNS_T1` env-var gate** (`src/nexus/mcp/core.py`, `src/nexus/hooks.py`). Module-scope `_MCP_OWNS_T1` constant, `_flag_enabled` helper in `mcp/core.py`, and `_mcp_owns_t1_enabled` helper in `hooks.py` all deleted. FastMCP's `lifespan` kwarg is unconditionally `_t1_chroma_lifespan`; `main()` unconditionally registers atexit + SIGTERM/SIGINT handlers. Tests gain regression sentinels (`test_no_mcp_owns_t1_module_attr`) asserting the module attrs are gone.
+
+- **Hook-side chroma-spawn block** (`src/nexus/hooks.py:session_start`). The session.lock acquisition, `start_t1_server` call, `write_session_record_by_id` call, and `spawn_t1_watchdog` call are all deleted. nx-mcp's lifespan owns spawn; the hook now only runs the orphan-tmpdir sweep, resolves the session UUID (env > stdin > fresh), and writes `current_session` when this is a top-level session. Imports of `fcntl`, `shutil`, `find_ancestor_session`, `find_claude_root_pid`, `spawn_t1_watchdog`, `start_t1_server`, `stop_t1_server`, `write_session_record`, `write_session_record_by_id`, `_ppid_of` are dropped.
+
+- **Hook-side chroma-stop block** (`src/nexus/hooks.py:session_end`). `session_end` is now a thin pass-through to `session_end_flush` (`return session_end_flush()`). Chroma teardown is owned by nx-mcp's lifespan + signal handler + atexit chain (with the watchdog as the safety net), never by the hook.
+
+### Changed
+
+- **RDR-094 §Phase 4 marked COMPLETE** (`docs/rdr/rdr-094-mcp-owned-t1-chroma-lifecycle.md`). The Phase 4 prerequisites enumeration is replaced with a record of how each was cleared: CA-2 verified post-mitigation (Spike B 40/40 connected_to_parent, T2 id=983); Phase B+C shipped (PRs #306, #307); canary served by the v4.12.0 → v4.12.1 shakeout cycle (PR #314 fixed the stdin-EOF + SIGTERM signal-handler race that surfaced).
+
+- **RDR-093 closed as implemented** (`docs/rdr/rdr-093-groupby-aggregate-operators.md`). `operator_groupby` and `operator_aggregate` shipped in RDR-088's wake; per-gap pointers validated against the codebase. Ride-along close in this release.
+
 ## [4.12.1] - 2026-04-25
 
 Shakeout patch for 4.12.0. Production sessions on Hal's reference install showed `mcp_server_crashed` events in `mcp.log` on every clean shutdown after the default-on flag flip. Root cause: stdin-EOF + SIGTERM race. Claude Code closes the MCP client's stdio pipe and sends SIGTERM near-simultaneously; the lifespan finally fires (clean-exit path) and starts running `_t1_chroma_shutdown` → `stop_t1_server`'s 100ms poll loop; the SIGTERM signal handler then runs on top of the paused frame, calls `sys.exit(0)`, and the resulting `SystemExit` propagates through anyio's TaskGroup as an unhandled error. Chroma was always cleaned up correctly (the watchdog confirmed via `chroma_cleanup_complete` events; `nx doctor --check-tmpdirs` was clean), but every clean shutdown logged a misleading multi-thousand-character traceback as a "crash".

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.12.1",
+  "version": "4.13.0",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.13.0] - 2026-04-25
+
+Plugin version aligned with conexus 4.13.0. No plugin-level functional changes. See root `CHANGELOG.md` for the RDR-094 Phase F deliverable: the `NEXUS_MCP_OWNS_T1` env-var gate is removed entirely, nx-mcp's lifespan unconditionally owns chroma's lifecycle. Net source diff -283 lines.
+
 ## [4.12.1] - 2026-04-25
 
 Plugin version aligned with conexus 4.12.1. No plugin-level functional changes. See root `CHANGELOG.md` for the 4.12.0 shakeout fix: `mcp_server_crashed` events on clean shutdowns were a SystemExit race between stdin EOF and SIGTERM, fixed by switching the signal handler to `os._exit` and adding a sticky in-flight flag that short-circuits re-entrant shutdown calls.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.12.1"
+version = "4.13.0"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.12.1",
+  "version": "4.13.0",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.12.1"
+version = "4.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Closes RDR-094 Phase F. The \`NEXUS_MCP_OWNS_T1\` env-var gate from 4.12.0 is removed entirely; nx-mcp's lifespan unconditionally owns chroma's lifecycle. Net source diff: **-283 lines** (deletion of dead-but-gated code paths).

Same observable behaviour as 4.12.1 unless an operator was explicitly setting \`NEXUS_MCP_OWNS_T1=0\` to opt out: the env var is now silently ignored.

## Release rationale

| Release | What landed |
|---|---|
| **4.12.0** | Default-on flip (gate flipped, hook-side spawn block stayed gated) |
| **4.12.1** | stdin-EOF + SIGTERM signal-handler race fix (production shakeout) |
| **4.13.0** | Gate removal — pure simplification, no behavioural change |

This is a minor bump rather than patch because deleting the opt-out env var is technically a contract change (operators relying on \`NEXUS_MCP_OWNS_T1=0\` will silently get the MCP-owned path now).

## Files

- \`pyproject.toml\`: 4.12.1 → 4.13.0
- \`.claude-plugin/marketplace.json\` + \`nx/.claude-plugin/plugin.json\` + \`sn/.claude-plugin/plugin.json\`: parity (CI enforces)
- \`CHANGELOG.md\` + \`nx/CHANGELOG.md\`: 4.13.0 entries
- \`uv.lock\`: regenerated

The Phase F code change itself shipped in PR #315 (already on main). This release commit is the version bump + changelog only.

## Test plan

- [x] **Pre-tag full unit suite** (\`uv run pytest -m "not integration" -q\`): **5208 passed, 27 skipped, 30 deselected** in 9m 28s
- [x] No em dashes in additions
- [x] Explicit-path \`git add\`

## RDR-094 epic complete

The 14-PR / 9-bead arc that built the MCP-owned T1 chroma lifecycle:

| Phase | PR | Bead |
|---|---|---|
| A | #302 | nexus-5rea |
| B | #306 | nexus-2b9r |
| C | #307 | nexus-l828 |
| D | #308, #310, #311, #312 | nexus-zsqf |
| E | (closed: canary served by 4.12.0/4.12.1) | nexus-fn44 |
| F | #315 + this release | nexus-2lm0 |
| G | #303 | nexus-aqna |
| H | #305 + #309 | nexus-3f95, nexus-50u5 |
| I | #304 | nexus-sawb |

Epic nexus-4v5l auto-closed when the last child closed.

## Tag procedure (after merge)

\`\`\`bash
git checkout main && git pull origin main
git tag -a v4.13.0 -m "Release 4.13.0 — RDR-094 Phase F gate removal"
git push origin v4.13.0
scripts/reinstall-tool.sh
\`\`\`