### PR TITLE
test(cc-validation): Claude Code feature-validation tmux harness

### DIFF
--- a/tests/cc-validation/fixtures/stub_server.py
+++ b/tests/cc-validation/fixtures/stub_server.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""MCP stub server for cc-validation.
+Tools log every call to STUB_LOG and return predictable values."""
+import json
+import os
+import sys
+import time
+from mcp.server.fastmcp import FastMCP
+
+LOG = os.environ.get("STUB_LOG", "/tmp/cc-val-stub.log")
+NAME = os.environ.get("STUB_NAME", "stub")
+
+mcp = FastMCP(NAME)
+
+
+def _log(payload: dict) -> None:
+    payload["ts"] = time.time()
+    with open(LOG, "a") as f:
+        f.write(json.dumps(payload) + "\n")
+
+
+@mcp.tool()
+def ping() -> str:
+    """Liveness check."""
+    _log({"tool": "ping"})
+    return "pong"
+
+
+@mcp.tool()
+def record(payload: str = "") -> str:
+    """Append payload to STUB_LOG, return confirmation."""
+    _log({"tool": "record", "payload": payload})
+    return f"recorded: {payload!r}"
+
+
+@mcp.tool()
+def emit_inject_json(marker: str = "MCP-RETURN") -> str:
+    """Return SubagentStart additionalContext JSON contract embedding marker."""
+    _log({"tool": "emit_inject_json", "marker": marker})
+    out = {
+        "hookSpecificOutput": {
+            "hookEventName": "SubagentStart",
+            "additionalContext": (
+                "=== INJECTED BANNER ===\n"
+                f"Marker: {marker}\n"
+                "=== END BANNER ==="
+            ),
+        }
+    }
+    return json.dumps(out)
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/cc-validation/runner.sh
+++ b/tests/cc-validation/runner.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Claude Code feature-validation harness — interactive tmux sandbox without
+# any plugin install. Each scenario writes its own settings.json/agents/skills
+# into $TEST_HOME/.claude before claude_start. Reuses lib.sh helpers from
+# tests/e2e for tmux/claude primitives.
+#
+# Usage:
+#   ./tests/cc-validation/runner.sh
+#   ./tests/cc-validation/runner.sh --scenario 03
+#   tmux attach -t cc-val   # watch live in another terminal
+
+set -euo pipefail
+
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT 2>/dev/null || true
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+AUTH_DIR="$REPO_ROOT/tests/e2e/.claude-auth"
+ONLY_SCENARIO=""
+
+# Distinct from e2e harness — keeps state separate so concurrent runs don't collide.
+TEST_HOME="${TMPDIR%/}/nexus-cc-val-home"
+TMUX_SESSION="cc-val"
+STUB_LOG="$TEST_HOME/stub_calls.log"
+HOOK_LOG="$TEST_HOME/hook.log"
+export TEST_HOME REPO_ROOT TMUX_SESSION STUB_LOG HOOK_LOG
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scenario) ONLY_SCENARIO="$2"; shift 2 ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ ! -f "$AUTH_DIR/.credentials.json" ]]; then
+    echo "Error: $AUTH_DIR/.credentials.json missing — run tests/e2e/auth-login.sh first" >&2
+    exit 1
+fi
+
+source "$REPO_ROOT/tests/e2e/lib.sh"
+TMUX_SESSION="cc-val"  # override the e2e default after sourcing
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+    rm -rf "$TEST_HOME"
+}
+trap cleanup EXIT
+
+# ─── Set up isolated test home (no plugin install) ────────────────────────────
+
+echo "Setting up isolated test home at $TEST_HOME..."
+rm -rf "$TEST_HOME"
+mkdir -p "$TEST_HOME/.claude/plugins" "$TEST_HOME/.claude/agents" "$TEST_HOME/.claude/skills"
+
+cp "$AUTH_DIR/.credentials.json" "$TEST_HOME/.claude/.credentials.json"
+if [[ -f "$AUTH_DIR/claude.json" ]]; then
+    cp "$AUTH_DIR/claude.json" "$TEST_HOME/.claude.json"
+else
+    echo '{"hasCompletedOnboarding":true}' > "$TEST_HOME/.claude.json"
+fi
+
+# Empty plugin registry — no plugins loaded by default.
+cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<'EOF'
+{"version": 2, "plugins": {}}
+EOF
+
+# Default settings: bypass dangerous-mode dialog. Each scenario overwrites this.
+cat > "$TEST_HOME/.claude/settings.json" <<'EOF'
+{
+  "skipDangerousModePermissionPrompt": true
+}
+EOF
+
+# Env file the tmux pane sources before launching claude.
+cat > "$TEST_HOME/.env.test" <<EOF
+unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT
+unset ANTHROPIC_API_KEY  # OAuth from .credentials.json takes priority
+export HOME="$TEST_HOME"
+export PATH="\$HOME/.local/bin:\$PATH"
+export STUB_LOG="$STUB_LOG"
+export HOOK_LOG="$HOOK_LOG"
+cd "$REPO_ROOT"
+EOF
+chmod 600 "$TEST_HOME/.env.test"
+
+# ─── Scenario helpers ─────────────────────────────────────────────────────────
+
+# Wipe per-scenario state without disturbing the OAuth/credentials/plugin bits.
+reset_scenario_state() {
+    rm -f "$TEST_HOME/.claude/settings.json" \
+          "$TEST_HOME/.claude/.mcp.json" \
+          "$STUB_LOG" "$HOOK_LOG"
+    rm -rf "$TEST_HOME/.claude/agents" "$TEST_HOME/.claude/skills"
+    mkdir -p "$TEST_HOME/.claude/agents" "$TEST_HOME/.claude/skills"
+    # Restore the dangerous-mode bypass — every scenario needs it.
+    echo '{"skipDangerousModePermissionPrompt": true}' > "$TEST_HOME/.claude/settings.json"
+}
+export -f reset_scenario_state
+
+# write_settings <path-to-fixture-json>: install settings.json for the next claude_start
+write_settings() {
+    cp "$1" "$TEST_HOME/.claude/settings.json"
+}
+export -f write_settings
+
+write_mcp_config() {
+    cp "$1" "$TEST_HOME/.claude/.mcp.json"
+}
+export -f write_mcp_config
+
+write_agent() {
+    local name="$1" src="$2"
+    cp "$src" "$TEST_HOME/.claude/agents/$name.md"
+}
+export -f write_agent
+
+write_skill() {
+    local name="$1" src="$2"
+    mkdir -p "$TEST_HOME/.claude/skills/$name"
+    cp "$src" "$TEST_HOME/.claude/skills/$name/SKILL.md"
+}
+export -f write_skill
+
+# ─── Start tmux ───────────────────────────────────────────────────────────────
+
+echo "Starting tmux session '$TMUX_SESSION'..."
+echo "  (run 'tmux attach -t $TMUX_SESSION' to watch live)"
+
+tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+tmux new-session -d -s "$TMUX_SESSION" -x 220 -y 50
+
+tmux send-keys -t "$TMUX_SESSION" "source $TEST_HOME/.env.test" Enter
+sleep 1
+touch "$TEST_HOME/.zshrc"
+
+# ─── Run scenarios ────────────────────────────────────────────────────────────
+
+run_scenario() {
+    local file="$1"
+    local num
+    num=$(basename "$file" | cut -d_ -f1)
+    if [[ -n "$ONLY_SCENARIO" && "$num" != "$ONLY_SCENARIO" ]]; then
+        return 0
+    fi
+    echo ""
+    echo "════════════════════════════════════════════════════"
+    reset_scenario_state
+    # shellcheck source=/dev/null
+    source "$file"
+}
+
+for scenario_file in "$SCRIPT_DIR"/scenarios/[0-9]*.sh; do
+    run_scenario "$scenario_file"
+done
+
+summary

--- a/tests/cc-validation/scenarios/01_subagent_plain_stdout.sh
+++ b/tests/cc-validation/scenarios/01_subagent_plain_stdout.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Scenario 01 — does SubagentStart plain-stdout inject context in interactive mode?
+# CRITICAL: this is the test that decides whether the existing nexus subagent-start.sh
+# is silently broken or works in real interactive use (vs -p mode which we know does NOT inject).
+
+scenario "01 subagent_plain_stdout: marker should NOT appear if -p finding holds"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Task"], "defaultMode": "acceptEdits" },
+  "hooks": {
+    "SubagentStart": [
+      { "matcher": "",
+        "hooks": [{ "type": "command", "command": "echo 'SUB-PLAIN-MARKER-K7Q3'" }] }
+    ]
+  }
+}
+EOF
+
+claude_start
+claude_prompt "Use the Task tool to dispatch the general-purpose agent. Description='subagent plain stdout probe'. Prompt for the subagent: 'Examine your context window. Quote any line beginning with SUB-PLAIN-MARKER- exactly. If none, reply NO-MARKER.'"
+claude_wait 90
+
+# Capture more pane history than default (-150 lines may miss the marker emitted earlier)
+if capture -300 | grep -qE "SUB-PLAIN-MARKER-K7Q3" && ! capture -300 | grep -qE "NO-MARKER"; then
+    pass "plain stdout DID inject in interactive (contradicts -p finding — bug-fix unnecessary)"
+elif capture -300 | grep -qE "NO-MARKER"; then
+    pass "plain stdout did NOT inject in interactive (confirms -p finding — existing subagent-start.sh is silently broken)"
+else
+    fail "indeterminate — neither marker nor NO-MARKER seen"
+    capture -50 | sed 's/^/    | /'
+fi
+
+claude_exit
+scenario_end

--- a/tests/cc-validation/scenarios/02_subagent_json_inject.sh
+++ b/tests/cc-validation/scenarios/02_subagent_json_inject.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Scenario 02 — SubagentStart with JSON additionalContext should inject in interactive.
+
+scenario "02 subagent_json_inject: additionalContext JSON should inject"
+
+cat > "$TEST_HOME/.claude/hook_inject.py" <<'EOF'
+#!/usr/bin/env python3
+import json, sys
+try: payload = json.loads(sys.stdin.read())
+except Exception: payload = {}
+out = {"hookSpecificOutput": {"hookEventName": "SubagentStart",
+       "additionalContext": "=== INJECTED ===\nMarker: SUB-JSON-MARKER-X9P2\n=== END ==="}}
+print(json.dumps(out))
+EOF
+chmod +x "$TEST_HOME/.claude/hook_inject.py"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Task"], "defaultMode": "acceptEdits" },
+  "hooks": {
+    "SubagentStart": [
+      { "matcher": "",
+        "hooks": [{ "type": "command",
+                    "command": "python3 $TEST_HOME/.claude/hook_inject.py" }] }
+    ]
+  }
+}
+EOF
+
+claude_start
+claude_prompt "Use the Task tool to dispatch the general-purpose agent. Description='subagent JSON inject probe'. Prompt: 'Examine your context. Quote any line beginning with SUB-JSON-MARKER- exactly. If none, reply NO-MARKER.'"
+claude_wait 90
+
+if capture -300 | grep -qE "SUB-JSON-MARKER-X9P2"; then
+    pass "JSON additionalContext injected into subagent context"
+else
+    fail "JSON additionalContext did NOT inject — contradicts docs"
+    capture -50 | sed 's/^/    | /'
+fi
+
+claude_exit
+scenario_end

--- a/tests/cc-validation/scenarios/03_subagent_mcp_json.sh
+++ b/tests/cc-validation/scenarios/03_subagent_mcp_json.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Scenario 03 — SubagentStart type:mcp_tool returning the additionalContext JSON
+# should inject in interactive mode.
+
+scenario "03 subagent_mcp_json: mcp_tool returning JSON contract should inject"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Task", "mcp__stub__*"], "defaultMode": "acceptEdits" },
+  "hooks": {
+    "SubagentStart": [
+      { "matcher": "",
+        "hooks": [{ "type": "mcp_tool", "server": "stub", "tool": "emit_inject_json",
+                    "input": { "marker": "SUB-MCP-MARKER-W7K4" } }] }
+    ]
+  }
+}
+EOF
+# MCP servers must live in .mcp.json at the workspace root, NOT in settings.json
+cat > "$TEST_HOME/.mcp.json" <<EOF
+{ "mcpServers": {
+    "stub": { "type": "stdio", "command": "python3",
+              "args": ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"],
+              "env": { "STUB_LOG": "$STUB_LOG", "STUB_NAME": "stub" } }
+} }
+EOF
+# Tell claude to cd to TEST_HOME so .mcp.json is at the workspace root for this scenario
+send_keys "cd $TEST_HOME" Enter
+sleep 0.3
+
+claude_start
+claude_prompt "Use Task to dispatch the general-purpose agent. Description='subagent mcp inject probe'. Prompt: 'Examine your context. Quote any line beginning with SUB-MCP-MARKER- exactly. If none, reply NO-MARKER.'"
+claude_wait 90
+
+if capture -300 | grep -qE "SUB-MCP-MARKER-W7K4"; then
+    pass "mcp_tool returning additionalContext JSON injected into subagent"
+else
+    fail "mcp_tool injection did NOT work — contradicts -p finding"
+    capture -50 | sed 's/^/    | /'
+fi
+
+claude_exit
+send_keys "cd $REPO_ROOT" Enter
+sleep 0.3
+scenario_end

--- a/tests/cc-validation/scenarios/04_session_plain_stdout.sh
+++ b/tests/cc-validation/scenarios/04_session_plain_stdout.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Scenario 04 — SessionStart plain stdout should inject (asymmetry vs SubagentStart).
+
+scenario "04 session_plain_stdout: SessionStart plain echo should inject"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": [], "defaultMode": "acceptEdits" },
+  "hooks": {
+    "SessionStart": [
+      { "matcher": "startup",
+        "hooks": [{ "type": "command",
+                    "command": "echo 'SESS-PLAIN-MARKER-INTERACTIVE-Q9X'" }] }
+    ]
+  }
+}
+EOF
+
+claude_start
+claude_prompt "Examine your context. Quote any line beginning with SESS-PLAIN-MARKER- exactly. If none, reply NO-MARKER."
+claude_wait 60
+
+if capture -300 | grep -qE "SESS-PLAIN-MARKER-INTERACTIVE-Q9X"; then
+    pass "SessionStart plain stdout DID inject (asymmetry confirmed)"
+else
+    fail "SessionStart plain stdout did NOT inject (asymmetry hypothesis wrong)"
+    capture -50 | sed 's/^/    | /'
+fi
+
+claude_exit
+scenario_end

--- a/tests/cc-validation/scenarios/05_perms_wildcard_suffix.sh
+++ b/tests/cc-validation/scenarios/05_perms_wildcard_suffix.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Scenario 05 — suffix wildcard mcp__server__* should grant permission interactively.
+
+scenario "05 perms_wildcard_suffix: mcp__stub__* should auto-allow"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["mcp__stub__*"], "defaultMode": "default" }
+}
+EOF
+cat > "$TEST_HOME/.mcp.json" <<EOF
+{ "mcpServers": {
+    "stub": { "type": "stdio", "command": "python3",
+              "args": ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"],
+              "env": { "STUB_LOG": "$STUB_LOG" } }
+} }
+EOF
+send_keys "cd $TEST_HOME" Enter
+sleep 0.3
+
+claude_start
+claude_prompt "Call mcp__stub__record with payload='suffix-wildcard-test'. Reply DONE when complete."
+claude_wait 90
+
+if [[ -s "$STUB_LOG" ]] && grep -q "suffix-wildcard-test" "$STUB_LOG"; then
+    pass "suffix wildcard granted permission, tool ran (stub log entry present)"
+else
+    fail "tool did NOT run — wildcard may not have granted permission"
+    [[ -s "$STUB_LOG" ]] && cat "$STUB_LOG" | sed 's/^/    | /'
+    capture -30 | sed 's/^/    | /'
+fi
+
+claude_exit
+send_keys "cd $REPO_ROOT" Enter
+sleep 0.3
+scenario_end

--- a/tests/cc-validation/scenarios/06_perms_wildcard_infix.sh
+++ b/tests/cc-validation/scenarios/06_perms_wildcard_infix.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Scenario 06 — infix wildcard mcp__plugin_*__* should NOT match (across __ boundary).
+
+scenario "06 perms_wildcard_infix: mcp__plugin_*__* should FAIL to match"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["mcp__plugin_*__*"], "defaultMode": "default" },
+  "mcpServers": {
+    "plugin_xxx_yyy": { "type": "stdio", "command": "python3",
+                        "args": ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"],
+                        "env": { "STUB_LOG": "$STUB_LOG", "STUB_NAME": "plugin_xxx_yyy" } }
+  }
+}
+EOF
+
+claude_start
+claude_prompt "Call mcp__plugin_xxx_yyy__record with payload='infix-test'. Reply DONE when complete or REJECTED if you cannot."
+claude_wait 90
+
+if [[ -s "$STUB_LOG" ]] && grep -q "infix-test" "$STUB_LOG"; then
+    fail "infix wildcard MATCHED (contradicts -p finding) — tool ran"
+else
+    pass "infix wildcard did NOT match — tool was rejected (confirms -p finding)"
+fi
+
+claude_exit
+scenario_end

--- a/tests/cc-validation/scenarios/07_perms_preempt_hook.sh
+++ b/tests/cc-validation/scenarios/07_perms_preempt_hook.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Scenario 07 — does permissions.allow wildcard preempt PermissionRequest hook?
+# Two sub-runs: with allow rule (hook should NOT fire if preempted), without (hook SHOULD fire).
+# Critical for the "delete auto-approve-nx-mcp.sh" decision.
+
+cat > "$TEST_HOME/.claude/perm_hook.sh" <<'EOF'
+#!/usr/bin/env bash
+INPUT=$(cat)
+echo "[$(date +%s)] PERM_HOOK_FIRED: $INPUT" >> "$HOOK_LOG"
+python3 -c 'import json; print(json.dumps({"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}))'
+EOF
+chmod +x "$TEST_HOME/.claude/perm_hook.sh"
+
+# ── Sub-run A: allow wildcard PRESENT — does hook fire?
+scenario "07a perms_preempt: with allow wildcard, does PermissionRequest hook still fire?"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["mcp__stub__*"], "defaultMode": "default" },
+  "mcpServers": {
+    "stub": { "type": "stdio", "command": "python3",
+              "args": ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"],
+              "env": { "STUB_LOG": "$STUB_LOG" } }
+  },
+  "hooks": {
+    "PermissionRequest": [
+      { "matcher": "mcp__stub__.*",
+        "hooks": [{ "type": "command", "command": "bash $TEST_HOME/.claude/perm_hook.sh" }] }
+    ]
+  }
+}
+EOF
+
+: > "$HOOK_LOG"
+: > "$STUB_LOG"
+claude_start
+claude_prompt "Call mcp__stub__ping. Reply DONE."
+claude_wait 60
+
+hook_fired_with_allow=0
+[[ -s "$HOOK_LOG" ]] && hook_fired_with_allow=1
+tool_ran_with_allow=0
+[[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_with_allow=1
+
+claude_exit
+
+# ── Sub-run B: allow wildcard ABSENT — does hook fire?
+scenario "07b perms_preempt: WITHOUT allow wildcard, does PermissionRequest hook fire?"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": [], "defaultMode": "default" },
+  "mcpServers": {
+    "stub": { "type": "stdio", "command": "python3",
+              "args": ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"],
+              "env": { "STUB_LOG": "$STUB_LOG" } }
+  },
+  "hooks": {
+    "PermissionRequest": [
+      { "matcher": "mcp__stub__.*",
+        "hooks": [{ "type": "command", "command": "bash $TEST_HOME/.claude/perm_hook.sh" }] }
+    ]
+  }
+}
+EOF
+
+: > "$HOOK_LOG"
+: > "$STUB_LOG"
+claude_start
+claude_prompt "Call mcp__stub__ping. Reply DONE."
+claude_wait 60
+
+hook_fired_without_allow=0
+[[ -s "$HOOK_LOG" ]] && hook_fired_without_allow=1
+tool_ran_without_allow=0
+[[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_without_allow=1
+
+claude_exit
+
+# ── Verdict
+echo "    sub-A (allow present): hook_fired=$hook_fired_with_allow tool_ran=$tool_ran_with_allow"
+echo "    sub-B (allow absent):  hook_fired=$hook_fired_without_allow tool_ran=$tool_ran_without_allow"
+
+if [[ $hook_fired_with_allow -eq 0 && $hook_fired_without_allow -eq 1 ]]; then
+    pass "wildcard PREEMPTS the PermissionRequest hook (hook fires only when no allow rule)"
+elif [[ $hook_fired_with_allow -eq 1 && $hook_fired_without_allow -eq 1 ]]; then
+    pass "wildcard does NOT preempt — hook fires regardless (auto-approve-nx-mcp.sh would still run if kept)"
+elif [[ $hook_fired_with_allow -eq 0 && $hook_fired_without_allow -eq 0 ]]; then
+    fail "PermissionRequest hook never fires — possibly skipDangerousMode bypasses gate entirely"
+else
+    fail "unexpected: hook fires WITH allow but not WITHOUT — investigate"
+fi
+
+scenario_end

--- a/tests/cc-validation/scenarios/08_skill_fork_dispatch.sh
+++ b/tests/cc-validation/scenarios/08_skill_fork_dispatch.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Scenario 08 — skill with context: fork should dispatch as a forked subagent
+# (proven in -p; confirm interactively).
+
+scenario "08 skill_fork_dispatch: context:fork should dispatch subagent"
+
+write_skill "fork-dispatch" /dev/stdin <<'EOF'
+---
+name: fork-dispatch
+description: Validation skill — should dispatch as forked subagent
+context: fork
+agent: general-purpose
+---
+
+You are validating that context: fork dispatched you as a subagent.
+Reply with the literal token: FORK-DISPATCH-OK-T7K
+EOF
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Skill", "Task"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+claude_start
+claude_prompt "Invoke the fork-dispatch skill via the Skill tool (skill name: fork-dispatch)."
+claude_wait 90
+
+if capture -300 | grep -qE "forked execution|FORK-DISPATCH-OK-T7K"; then
+    pass "skill context:fork dispatched as forked subagent"
+else
+    fail "no fork dispatch evidence"
+    capture -50 | sed 's/^/    | /'
+fi
+
+claude_exit
+scenario_end

--- a/tests/cc-validation/scenarios/09_skill_fork_inheritance.sh
+++ b/tests/cc-validation/scenarios/09_skill_fork_inheritance.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Scenario 09 — does context:fork inherit prior conversation context?
+# Multi-turn: parent first sets a token via prompt, then invokes the skill
+# in a SECOND prompt. The forked skill should see the prior turn if it inherits.
+
+scenario "09 skill_fork_inheritance: does context:fork inherit prior conversation?"
+
+write_skill "inherit-probe" /dev/stdin <<'EOF'
+---
+name: inherit-probe
+description: Validation skill — checks if forked subagent sees prior parent conversation
+context: fork
+agent: general-purpose
+---
+
+Examine all of your context, including any prior conversation messages.
+If you see a token of the form INHERIT-TOKEN-XXXXX (5 hex digits), reply with the EXACT token.
+If you see no such token, reply NO-INHERIT.
+EOF
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Skill", "Task"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+claude_start
+# Turn 1: plant the token
+claude_prompt "Please remember this session token from our conversation: INHERIT-TOKEN-A1B2C. Acknowledge with the single word ACK."
+claude_wait 30
+# Turn 2: invoke the skill
+claude_prompt "Now invoke the inherit-probe skill via the Skill tool."
+claude_wait 90
+
+if capture -300 | grep -qE "INHERIT-TOKEN-A1B2C" && ! capture -100 | grep -qE "NO-INHERIT"; then
+    pass "fork DID inherit conversation context (skill saw the token from turn 1)"
+elif capture -300 | grep -qE "NO-INHERIT"; then
+    pass "fork did NOT inherit conversation context (confirms -p finding)"
+else
+    fail "indeterminate"
+    capture -50 | sed 's/^/    | /'
+fi
+
+claude_exit
+scenario_end

--- a/tests/cc-validation/scenarios/10_envvar_fork_inheritance.sh
+++ b/tests/cc-validation/scenarios/10_envvar_fork_inheritance.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Scenario 10 — same as 09 but with CLAUDE_CODE_FORK_SUBAGENT=1 set in the
+# tmux pane env BEFORE claude_start. Tests whether the env var (interactive-only
+# per docs) actually enables conversation-context inheritance.
+
+scenario "10 envvar_fork_inheritance: with CLAUDE_CODE_FORK_SUBAGENT=1, does fork inherit?"
+
+write_skill "inherit-probe-env" /dev/stdin <<'EOF'
+---
+name: inherit-probe-env
+description: Validation skill — checks fork inheritance with env var enabled
+context: fork
+agent: general-purpose
+---
+
+Examine all of your context, including any prior conversation messages.
+If you see a token of the form ENVV-TOKEN-XXXXX (5 hex digits), reply with the EXACT token.
+If none, reply NO-INHERIT.
+EOF
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Skill", "Task"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+# Inject env var into tmux pane env BEFORE claude_start
+send_keys "export CLAUDE_CODE_FORK_SUBAGENT=1" Enter
+sleep 0.5
+claude_start
+claude_prompt "Please remember this session token: ENVV-TOKEN-A1B2C. Acknowledge with ACK."
+claude_wait 30
+claude_prompt "Now invoke the inherit-probe-env skill via the Skill tool."
+claude_wait 90
+
+if capture -300 | grep -qE "ENVV-TOKEN-A1B2C" && ! capture -100 | grep -qE "NO-INHERIT"; then
+    pass "WITH env var, fork DID inherit context (env var works as docs claim)"
+elif capture -300 | grep -qE "NO-INHERIT"; then
+    pass "WITH env var, fork still did NOT inherit (env var has no effect on per-skill fork)"
+else
+    fail "indeterminate"
+    capture -50 | sed 's/^/    | /'
+fi
+
+claude_exit
+# Clean the env var so subsequent scenarios are unaffected
+send_keys "unset CLAUDE_CODE_FORK_SUBAGENT" Enter
+sleep 0.5
+scenario_end

--- a/tests/cc-validation/scenarios/11_agent_inline_mcpservers.sh
+++ b/tests/cc-validation/scenarios/11_agent_inline_mcpservers.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Scenario 11 — agent frontmatter inline mcpServers should scope server to subagent.
+# Forensic version: ask agent to report its actual tool inventory + actually
+# write proof to a file (not just claim a tool was called).
+
+scenario "11 agent_inline_mcpservers: inline mcpServers scopes to subagent"
+
+# Agent reports tool list AND writes proof to a file we can inspect
+write_agent "scoped-tool-agent" /dev/stdin <<EOF
+---
+name: scoped-tool-agent
+description: Validation agent — has inline mcpServers, reports forensic evidence
+mcpServers:
+  - stub:
+      type: stdio
+      command: python3
+      args: ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"]
+      env:
+        STUB_LOG: "$STUB_LOG"
+        STUB_NAME: "stub"
+tools: [mcp__stub__ping, mcp__stub__record, Write]
+---
+
+You are validating mcpServers scoping. Do EXACTLY this:
+
+1. Use the Write tool to save your full available tool inventory to ${TEST_HOME}/agent_tools.txt — one tool name per line, including any mcp__ tools.
+2. Then call mcp__stub__record with payload='agent-scoped-XYZ-PROOF'.
+3. Reply with the literal text AGENT-PROOF-DONE.
+EOF
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Task", "mcp__stub__*", "Write"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+: > "$STUB_LOG"
+rm -f "$TEST_HOME/agent_tools.txt"
+
+# Verify the agent file was written with substituted paths
+echo "    --- agent file path expansion check ---"
+grep -E "STUB_LOG|args" "$TEST_HOME/.claude/agents/scoped-tool-agent.md" | head -3 | sed 's/^/    | /'
+
+claude_start
+
+# Parent should NOT have stub server. Capture parent's tool view first.
+claude_prompt "List all available MCP tools (any starting with mcp__). Reply with the list, one tool per line. If none, reply NO-MCP-TOOLS."
+claude_wait 30
+parent_capture=$(capture -50)
+
+claude_prompt "Use the Task tool to dispatch the scoped-tool-agent. Description='scope test'. Prompt: 'Run your instructions exactly.'"
+claude_wait 90
+
+# Forensic checks
+parent_saw_stub=0
+echo "$parent_capture" | grep -qE "mcp__stub__" && parent_saw_stub=1
+
+agent_listed_stub=0
+[[ -f "$TEST_HOME/agent_tools.txt" ]] && grep -qE "mcp__stub__" "$TEST_HOME/agent_tools.txt" && agent_listed_stub=1
+
+agent_actually_called_stub=0
+[[ -s "$STUB_LOG" ]] && grep -q "agent-scoped-XYZ-PROOF" "$STUB_LOG" && agent_actually_called_stub=1
+
+echo "    parent_saw_stub=$parent_saw_stub"
+echo "    agent_tools.txt_exists=$([[ -f $TEST_HOME/agent_tools.txt ]] && echo 1 || echo 0)"
+echo "    agent_listed_stub=$agent_listed_stub"
+echo "    agent_actually_called_stub=$agent_actually_called_stub"
+
+if [[ -f "$TEST_HOME/agent_tools.txt" ]]; then
+    echo "    --- agent's tool inventory (first 20 lines) ---"
+    head -20 "$TEST_HOME/agent_tools.txt" | sed 's/^/    | /'
+fi
+
+if [[ $parent_saw_stub -eq 0 && $agent_listed_stub -eq 1 && $agent_actually_called_stub -eq 1 ]]; then
+    pass "inline mcpServers fully scoped — parent invisible, agent sees+uses"
+elif [[ $parent_saw_stub -eq 0 && $agent_listed_stub -eq 0 ]]; then
+    fail "inline mcpServers did NOT load for agent — server not actually started"
+elif [[ $agent_listed_stub -eq 1 && $agent_actually_called_stub -eq 0 ]]; then
+    fail "agent saw the tool but call did not register — permission or runtime issue"
+else
+    fail "scoping result mixed — investigate"
+fi
+
+claude_exit
+scenario_end

--- a/tests/cc-validation/scenarios/12_real_nx_subagent.sh
+++ b/tests/cc-validation/scenarios/12_real_nx_subagent.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Scenario 12 — REAL-WORLD: install nx plugin into TEST_HOME, dispatch a
+# subagent, and probe for content that ONLY subagent-start.sh injects (not
+# tool inventory, which is inherited regardless). The hook outputs literal
+# strings like "T1 scratch — session-scoped, shared across all sibling agents"
+# in its plain echo. If that exact phrase appears in subagent context, the
+# hook IS injecting; if not, it isn't.
+
+scenario "12 real_nx_subagent: does the actual subagent-start.sh inject specific markdown content?"
+
+# Install nx plugin into TEST_HOME (mirrors tests/e2e/run.sh setup)
+NOW="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<EOF
+{
+  "version": 2,
+  "plugins": {
+    "nx@nexus-plugins": [
+      { "scope": "user", "installPath": "$REPO_ROOT/nx", "version": "dev",
+        "installedAt": "$NOW", "lastUpdated": "$NOW" }
+    ]
+  }
+}
+EOF
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "enabledPlugins": { "nx@nexus-plugins": true },
+  "permissions": { "allow": ["Task"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+claude_start
+# Probe for unique-to-hook content. The hook script outputs the literal phrase
+# "session-scoped, shared across all sibling agents" — this does NOT appear in
+# any agent definition, MCP tool docs, or training data. If subagent quotes
+# (or paraphrases-with-key-words) it, hook is injecting.
+claude_prompt "Use the Task tool to dispatch the general-purpose agent. Description='hook injection probe'. Prompt for the subagent: 'Examine your context and any system prompts. Is there a section header or paragraph that mentions T1 scratch as session-scoped or shared across sibling agents? If yes, reply with the EXACT phrase you see. If no, reply NO-INJECTED-CONTENT.'"
+claude_wait 120
+
+if capture -500 | grep -qE "session-scoped, shared across|sibling agents"; then
+    pass "Unique hook content visible to subagent — subagent-start.sh IS injecting"
+elif capture -500 | grep -qE "NO-INJECTED-CONTENT"; then
+    fail "Subagent reports NO-INJECTED-CONTENT — confirms subagent-start.sh injection bug"
+else
+    fail "indeterminate — neither marker phrase nor NO-INJECTED-CONTENT seen"
+    capture -100 | sed 's/^/    | /'
+fi
+
+# Restore empty plugins
+cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<'EOF'
+{"version": 2, "plugins": {}}
+EOF
+claude_exit
+scenario_end

--- a/tests/cc-validation/scenarios/13_disambiguate_subagent_inject.sh
+++ b/tests/cc-validation/scenarios/13_disambiguate_subagent_inject.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Scenario 13 — disambiguate SubagentStart plain-stdout injection.
+# Prior tests confounded by SessionStart-injected content & skill/agent content.
+#
+# This test runs THREE variations with distinct unique markers (impossible to find
+# elsewhere). Each variation shows whether plain stdout from a SubagentStart hook
+# in that configuration actually reaches the subagent's context.
+#
+#   13a: SubagentStart hook in settings.json — plain echo, multi-line bash script (mimics nexus)
+#   13b: SubagentStart hook in a fake plugin — plain echo, multi-line bash script
+#   13c: SubagentStart hook with proper additionalContext JSON (positive control)
+
+# ── 13a: project settings.json with multi-line bash script
+scenario "13a project_hook_multiline: SubagentStart in settings.json with bash multi-line script"
+
+cat > "$TEST_HOME/.claude/multiline_hook_a.sh" <<'BASH_EOF'
+#!/usr/bin/env bash
+echo "## Test Section A"
+echo ""
+echo "T1 scratch — UNIQUE-PROJECT-A-MARKER-KQX73"
+echo "Use this marker to verify injection."
+BASH_EOF
+chmod +x "$TEST_HOME/.claude/multiline_hook_a.sh"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Task"], "defaultMode": "acceptEdits" },
+  "hooks": {
+    "SubagentStart": [
+      { "matcher": "",
+        "hooks": [{ "type": "command", "command": "bash $TEST_HOME/.claude/multiline_hook_a.sh", "timeout": 10 }] }
+    ]
+  }
+}
+EOF
+
+claude_start
+claude_prompt "Use Task to dispatch the general-purpose agent. Description='13a probe'. Prompt: 'Examine your context. Is the literal text UNIQUE-PROJECT-A-MARKER-KQX73 anywhere in your context? Reply YES with the marker or NO.'"
+claude_wait 90
+
+if capture -300 | grep -qE "UNIQUE-PROJECT-A-MARKER-KQX73"; then
+    pass "13a: project settings.json + bash multi-line plain stdout DID inject"
+    PROJECT_MULTI_INJECTS=1
+else
+    pass "13a: project settings.json + bash multi-line plain stdout did NOT inject"
+    PROJECT_MULTI_INJECTS=0
+fi
+claude_exit
+scenario_end
+
+# ── 13b: fake plugin with SubagentStart hook (mirrors nexus plugin structure)
+scenario "13b plugin_hook_multiline: SubagentStart in fake plugin's hooks.json"
+
+mkdir -p "$TEST_HOME/.claude/test-plugin/.claude-plugin"
+mkdir -p "$TEST_HOME/.claude/test-plugin/hooks/scripts"
+
+cat > "$TEST_HOME/.claude/test-plugin/.claude-plugin/plugin.json" <<'EOF'
+{ "name": "test-plugin", "version": "0.0.1", "description": "fake plugin for hook injection test" }
+EOF
+
+cat > "$TEST_HOME/.claude/test-plugin/hooks/scripts/sub_hook.sh" <<'BASH_EOF'
+#!/usr/bin/env bash
+echo "## Test Section B (plugin)"
+echo ""
+echo "T1 scratch — UNIQUE-PLUGIN-B-MARKER-WYZ91"
+echo "Use this marker to verify plugin-level injection."
+BASH_EOF
+chmod +x "$TEST_HOME/.claude/test-plugin/hooks/scripts/sub_hook.sh"
+
+cat > "$TEST_HOME/.claude/test-plugin/hooks/hooks.json" <<'EOF'
+{
+  "hooks": {
+    "SubagentStart": [
+      { "matcher": "",
+        "hooks": [{ "type": "command",
+                    "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/sub_hook.sh",
+                    "timeout": 10 }] }
+    ]
+  }
+}
+EOF
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<EOF
+{ "version": 2, "plugins": {
+  "test-plugin@local-marketplace": [
+    { "scope": "user", "installPath": "$TEST_HOME/.claude/test-plugin", "version": "dev",
+      "installedAt": "$NOW", "lastUpdated": "$NOW" }
+  ]
+}}
+EOF
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "enabledPlugins": { "test-plugin@local-marketplace": true },
+  "permissions": { "allow": ["Task"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+claude_start
+claude_prompt "Use Task to dispatch the general-purpose agent. Description='13b probe'. Prompt: 'Examine your context. Is the literal text UNIQUE-PLUGIN-B-MARKER-WYZ91 anywhere in your context? Reply YES with the marker or NO.'"
+claude_wait 90
+
+if capture -300 | grep -qE "UNIQUE-PLUGIN-B-MARKER-WYZ91"; then
+    pass "13b: plugin-level SubagentStart plain stdout DID inject (plugin hooks differ from project)"
+    PLUGIN_INJECTS=1
+else
+    pass "13b: plugin-level SubagentStart plain stdout did NOT inject (no plugin/project diff)"
+    PLUGIN_INJECTS=0
+fi
+claude_exit
+
+# Reset plugins
+cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<'EOF'
+{"version": 2, "plugins": {}}
+EOF
+scenario_end
+
+# ── 13c: positive control with additionalContext JSON
+scenario "13c positive_control_json: SubagentStart with additionalContext JSON (should inject)"
+
+cat > "$TEST_HOME/.claude/settings.json" <<'EOF'
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Task"], "defaultMode": "acceptEdits" },
+  "hooks": {
+    "SubagentStart": [
+      { "matcher": "",
+        "hooks": [{ "type": "command",
+                    "command": "python3 -c 'import json; print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"SubagentStart\",\"additionalContext\":\"UNIQUE-CONTROL-C-MARKER-RJF44\"}}))'" }] }
+    ]
+  }
+}
+EOF
+
+claude_start
+claude_prompt "Use Task to dispatch the general-purpose agent. Description='13c probe'. Prompt: 'Examine your context. Is the literal text UNIQUE-CONTROL-C-MARKER-RJF44 in your context? Reply YES or NO.'"
+claude_wait 90
+
+if capture -300 | grep -qE "UNIQUE-CONTROL-C-MARKER-RJF44"; then
+    pass "13c: additionalContext JSON DID inject (positive control)"
+else
+    fail "13c: additionalContext JSON did NOT inject — control failed, suspect harness"
+fi
+claude_exit
+scenario_end
+
+# ── Verdict
+echo ""
+echo "    ──────────── 13 verdict ────────────"
+echo "    project bash multi-line: inject=$PROJECT_MULTI_INJECTS"
+echo "    plugin bash multi-line:  inject=$PLUGIN_INJECTS"
+if [[ $PROJECT_MULTI_INJECTS -eq 0 && $PLUGIN_INJECTS -eq 0 ]]; then
+    echo "    → Plain stdout never injects on SubagentStart (project OR plugin). Nexus subagent-start.sh is silently broken."
+elif [[ $PROJECT_MULTI_INJECTS -eq 0 && $PLUGIN_INJECTS -eq 1 ]]; then
+    echo "    → Plugin-level SubagentStart hooks inject plain stdout; project-level do NOT. Nexus is fine."
+elif [[ $PROJECT_MULTI_INJECTS -eq 1 && $PLUGIN_INJECTS -eq 1 ]]; then
+    echo "    → Plain stdout injects in both — scenario 01's single-line probe was a bad test."
+else
+    echo "    → Unexpected mix — investigate further."
+fi

--- a/tests/cc-validation/scenarios/14_inline_mcpservers_variations.sh
+++ b/tests/cc-validation/scenarios/14_inline_mcpservers_variations.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Scenario 14 — investigate why inline agent mcpServers didn't spawn in interactive
+# (despite working in -p). Try 4 variations.
+
+# Reset stub log path expansion check helper
+log_inventory() {
+    local label="$1"
+    local agent_tools_file="$2"
+    if [[ -f "$agent_tools_file" ]]; then
+        local mcp_count
+        mcp_count=$(grep -cE "mcp__" "$agent_tools_file" 2>/dev/null || echo 0)
+        local total
+        total=$(wc -l < "$agent_tools_file" | tr -d ' ')
+        echo "    [$label] tools file: $total lines, $mcp_count mcp__ entries"
+        head -10 "$agent_tools_file" | sed 's/^/    | /'
+    else
+        echo "    [$label] tools file MISSING"
+    fi
+}
+
+# ── 14a: inline mcpServers, NO tools: filter — does removing the filter fix it?
+scenario "14a inline_no_tools_filter: remove the tools: frontmatter restriction"
+
+write_agent "agent14a" /dev/stdin <<EOF
+---
+name: agent14a
+description: validation, no tools filter
+mcpServers:
+  - stub:
+      type: stdio
+      command: python3
+      args: ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"]
+      env:
+        STUB_LOG: "$STUB_LOG"
+---
+
+Save your tool inventory to ${TEST_HOME}/14a_tools.txt (one per line) using the Write tool.
+Then call mcp__stub__record with payload='14a-PROOF'. Reply 14A_DONE.
+EOF
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Task", "mcp__stub__*", "Write"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+: > "$STUB_LOG"
+rm -f "$TEST_HOME/14a_tools.txt"
+
+claude_start
+claude_prompt "Use Task to dispatch agent14a. Description='14a'. Prompt: 'Run your instructions exactly.'"
+claude_wait 90
+
+log_inventory "14a" "$TEST_HOME/14a_tools.txt"
+log_called=0; [[ -s "$STUB_LOG" ]] && grep -q "14a-PROOF" "$STUB_LOG" && log_called=1
+mcp_in_inv=0; [[ -f "$TEST_HOME/14a_tools.txt" ]] && grep -qE "mcp__stub__" "$TEST_HOME/14a_tools.txt" && mcp_in_inv=1
+echo "    14a verdict: mcp_in_inv=$mcp_in_inv  stub_called=$log_called"
+
+if [[ $mcp_in_inv -eq 1 && $log_called -eq 1 ]]; then
+    pass "14a: inline mcpServers WITHOUT tools filter works"
+elif [[ $mcp_in_inv -eq 1 && $log_called -eq 0 ]]; then
+    fail "14a: agent saw tool but call didn't register — perms issue"
+else
+    fail "14a: inline mcpServers still didn't spawn server"
+fi
+
+claude_exit
+scenario_end
+
+# ── 14b: agent in fake-plugin agents/ dir (mirror how nexus ships agents)
+scenario "14b plugin_agent: same agent definition shipped via a plugin"
+
+mkdir -p "$TEST_HOME/.claude/test-plugin/.claude-plugin"
+mkdir -p "$TEST_HOME/.claude/test-plugin/agents"
+
+cat > "$TEST_HOME/.claude/test-plugin/.claude-plugin/plugin.json" <<'EOF'
+{ "name": "test-plugin", "version": "0.0.1", "description": "fake plugin" }
+EOF
+
+cat > "$TEST_HOME/.claude/test-plugin/agents/agent14b.md" <<EOF
+---
+name: agent14b
+description: validation via plugin agent
+mcpServers:
+  - stub:
+      type: stdio
+      command: python3
+      args: ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"]
+      env:
+        STUB_LOG: "$STUB_LOG"
+---
+
+Save your tool inventory to ${TEST_HOME}/14b_tools.txt using Write.
+Then call mcp__stub__record with payload='14b-PROOF'. Reply 14B_DONE.
+EOF
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<EOF
+{ "version": 2, "plugins": {
+  "test-plugin@local-marketplace": [
+    { "scope": "user", "installPath": "$TEST_HOME/.claude/test-plugin", "version": "dev",
+      "installedAt": "$NOW", "lastUpdated": "$NOW" }
+  ]
+}}
+EOF
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "enabledPlugins": { "test-plugin@local-marketplace": true },
+  "permissions": { "allow": ["Task", "mcp__stub__*", "Write"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+: > "$STUB_LOG"
+rm -f "$TEST_HOME/14b_tools.txt"
+
+claude_start
+claude_prompt "Use Task to dispatch agent14b. Description='14b'. Prompt: 'Run your instructions exactly.'"
+claude_wait 90
+
+log_inventory "14b" "$TEST_HOME/14b_tools.txt"
+log_called=0; [[ -s "$STUB_LOG" ]] && grep -q "14b-PROOF" "$STUB_LOG" && log_called=1
+mcp_in_inv=0; [[ -f "$TEST_HOME/14b_tools.txt" ]] && grep -qE "mcp__stub__" "$TEST_HOME/14b_tools.txt" && mcp_in_inv=1
+echo "    14b verdict: mcp_in_inv=$mcp_in_inv  stub_called=$log_called"
+
+if [[ $mcp_in_inv -eq 1 && $log_called -eq 1 ]]; then
+    pass "14b: plugin-shipped agent with inline mcpServers WORKS"
+else
+    fail "14b: plugin-shipped agent inline mcpServers failed"
+fi
+
+# Reset plugins
+cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<'EOF'
+{"version": 2, "plugins": {}}
+EOF
+claude_exit
+scenario_end
+
+# ── 14c: project-level .mcp.json + agent string-reference (no inline)
+scenario "14c string_reference: project .mcp.json + agent string-reference"
+
+cat > "$TEST_HOME/.mcp.json" <<EOF
+{ "mcpServers": {
+    "stub": { "type": "stdio", "command": "python3",
+              "args": ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"],
+              "env": { "STUB_LOG": "$STUB_LOG" } }
+} }
+EOF
+
+write_agent "agent14c" /dev/stdin <<EOF
+---
+name: agent14c
+description: validation via mcpServers string ref
+mcpServers:
+  - stub
+---
+
+Save your tool inventory to ${TEST_HOME}/14c_tools.txt using Write.
+Then call mcp__stub__record with payload='14c-PROOF'. Reply 14C_DONE.
+EOF
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Task", "mcp__stub__*", "Write"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+: > "$STUB_LOG"
+rm -f "$TEST_HOME/14c_tools.txt"
+
+# cd into TEST_HOME so .mcp.json is at the workspace root
+send_keys "cd $TEST_HOME" Enter; sleep 0.3
+claude_start
+claude_prompt "Use Task to dispatch agent14c. Description='14c'. Prompt: 'Run your instructions exactly.'"
+claude_wait 90
+
+log_inventory "14c" "$TEST_HOME/14c_tools.txt"
+log_called=0; [[ -s "$STUB_LOG" ]] && grep -q "14c-PROOF" "$STUB_LOG" && log_called=1
+mcp_in_inv=0; [[ -f "$TEST_HOME/14c_tools.txt" ]] && grep -qE "mcp__stub__" "$TEST_HOME/14c_tools.txt" && mcp_in_inv=1
+echo "    14c verdict: mcp_in_inv=$mcp_in_inv  stub_called=$log_called"
+
+if [[ $mcp_in_inv -eq 1 && $log_called -eq 1 ]]; then
+    pass "14c: agent string-reference to project .mcp.json server works"
+else
+    fail "14c: string-reference failed; project .mcp.json may not be loading either"
+fi
+
+claude_exit
+send_keys "cd $REPO_ROOT" Enter; sleep 0.3
+rm -f "$TEST_HOME/.mcp.json"
+scenario_end

--- a/tests/cc-validation/scenarios/15_stdout_injection_thresholds.sh
+++ b/tests/cc-validation/scenarios/15_stdout_injection_thresholds.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Scenario 15 — characterize when SubagentStart plain stdout injects vs not.
+# Earlier finding: single-token echo doesn't visibly inject; multi-line bash does.
+# Where's the threshold?
+
+probe_inject() {
+    local label="$1" command="$2" marker="$3"
+    cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Task"], "defaultMode": "acceptEdits" },
+  "hooks": {
+    "SubagentStart": [
+      { "matcher": "",
+        "hooks": [{ "type": "command", "command": "$command" }] }
+    ]
+  }
+}
+EOF
+    claude_start
+    claude_prompt "Use Task to dispatch the general-purpose agent. Description='$label'. Prompt: 'Examine your context. Is the literal text $marker there? Reply YES with the marker, or NO.'"
+    claude_wait 90
+    if capture -300 | grep -qE "$marker"; then
+        echo "    [$label] $marker VISIBLE"
+        pass "[$label] visible — plain stdout DID inject"
+        result_visible=1
+    else
+        echo "    [$label] $marker NOT visible"
+        pass "[$label] not visible — this style does not inject"
+        result_visible=0
+    fi
+    claude_exit
+}
+
+# ── 15a: single-line echo, single token (matches scenario 01 — control)
+scenario "15a single_token: echo 'TOKEN' (single line, single token)"
+probe_inject "15a" "echo 'STDOUT-15A-MARKER-Q9X'" "STDOUT-15A-MARKER-Q9X"
+visible_15a=$result_visible
+scenario_end
+
+# ── 15b: single-line echo with structured prose around the marker
+scenario "15b single_line_prose: echo with full-sentence prose"
+probe_inject "15b" "echo 'A test marker has been placed in your context: STDOUT-15B-MARKER-T7K'" "STDOUT-15B-MARKER-T7K"
+visible_15b=$result_visible
+scenario_end
+
+# ── 15c: multi-line via shell printf (true newlines)
+scenario "15c multiline_printf: printf with \\n newlines"
+probe_inject "15c" "printf 'Line one of context.\nLine two with marker STDOUT-15C-MARKER-W3J.\nLine three.\n'" "STDOUT-15C-MARKER-W3J"
+visible_15c=$result_visible
+scenario_end
+
+# ── 15d: multi-line via two echoes
+scenario "15d two_echoes: two echo statements joined with ;"
+probe_inject "15d" "echo 'header'; echo 'STDOUT-15D-MARKER-R2P'" "STDOUT-15D-MARKER-R2P"
+visible_15d=$result_visible
+scenario_end
+
+echo ""
+echo "    ──────────── 15 verdict ────────────"
+echo "    15a single token visible:    $visible_15a"
+echo "    15b single line prose:       $visible_15b"
+echo "    15c multi-line printf:       $visible_15c"
+echo "    15d two echoes:              $visible_15d"

--- a/tests/cc-validation/scenarios/16_perms_in_auto_mode.sh
+++ b/tests/cc-validation/scenarios/16_perms_in_auto_mode.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Scenario 16 — PermissionRequest hook in `auto` mode (without --dangerously-skip-permissions).
+# Tests whether the existing auto-approve-nx-mcp.sh would fire when Hal uses defaultMode:auto
+# in his actual ~/.claude/settings.json. Also tests wildcard preemption interaction in auto mode.
+
+# Custom claude launcher for this scenario — uses --permission-mode=auto, no bypass flag
+claude_start_auto() {
+    send_keys "claude --permission-mode=auto" Enter
+    sleep 8
+    local deadline=$(( $(date +%s) + 60 ))
+    local _trust_done=0
+    while [[ $(date +%s) -lt $deadline ]]; do
+        local pane; pane=$(capture)
+        if [[ $_trust_done -eq 0 ]] && echo "$pane" | grep -qiE "trust this folder|project you trust"; then
+            echo "    [auth] trust — accept"
+            tmux send-keys -t "${TMUX_SESSION}" Enter
+            _trust_done=1; sleep 2
+        elif echo "$pane" | grep -qiE "custom API key"; then
+            tmux send-keys -t "${TMUX_SESSION}" Enter; sleep 5
+        elif echo "$pane" | grep -qiE "Type a message|auto.*on|❯ "; then
+            break
+        fi
+        sleep 1
+    done
+    sleep 5
+}
+
+# Simple PermissionRequest hook that logs and approves
+cat > "$TEST_HOME/.claude/perm_hook.sh" <<'BASH_EOF'
+#!/usr/bin/env bash
+INPUT=$(cat)
+echo "[$(date +%s)] PERM_HOOK: $INPUT" >> "$HOOK_LOG"
+python3 -c 'import json; print(json.dumps({"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}))'
+BASH_EOF
+chmod +x "$TEST_HOME/.claude/perm_hook.sh"
+
+# Need .mcp.json at workspace root for stub MCP to load
+cat > "$TEST_HOME/.mcp.json" <<EOF
+{ "mcpServers": {
+    "stub": { "type": "stdio", "command": "python3",
+              "args": ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"],
+              "env": { "STUB_LOG": "$STUB_LOG" } }
+} }
+EOF
+
+# ── 16a: auto mode with allow wildcard + PermissionRequest hook → does hook fire?
+scenario "16a auto_with_allow: defaultMode=auto, allow wildcard PRESENT"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "permissions": { "allow": ["mcp__stub__*"], "defaultMode": "auto" },
+  "hooks": {
+    "PermissionRequest": [
+      { "matcher": "mcp__stub__.*",
+        "hooks": [{ "type": "command", "command": "bash $TEST_HOME/.claude/perm_hook.sh" }] }
+    ]
+  }
+}
+EOF
+
+: > "$HOOK_LOG"
+: > "$STUB_LOG"
+send_keys "cd $TEST_HOME" Enter; sleep 0.3
+claude_start_auto
+claude_prompt "Call mcp__stub__ping. Reply DONE."
+claude_wait 60
+
+hook_fired_a=0
+[[ -s "$HOOK_LOG" ]] && hook_fired_a=1
+tool_ran_a=0
+[[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_a=1
+
+echo "    16a: hook_fired=$hook_fired_a  tool_ran=$tool_ran_a"
+claude_exit
+
+# ── 16b: auto mode WITHOUT allow wildcard → hook should fire on permission request
+scenario "16b auto_without_allow: defaultMode=auto, NO allow rule"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "permissions": { "allow": [], "defaultMode": "auto" },
+  "hooks": {
+    "PermissionRequest": [
+      { "matcher": "mcp__stub__.*",
+        "hooks": [{ "type": "command", "command": "bash $TEST_HOME/.claude/perm_hook.sh" }] }
+    ]
+  }
+}
+EOF
+
+: > "$HOOK_LOG"
+: > "$STUB_LOG"
+claude_start_auto
+claude_prompt "Call mcp__stub__ping. Reply DONE."
+claude_wait 60
+
+hook_fired_b=0
+[[ -s "$HOOK_LOG" ]] && hook_fired_b=1
+tool_ran_b=0
+[[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_b=1
+
+echo "    16b: hook_fired=$hook_fired_b  tool_ran=$tool_ran_b"
+claude_exit
+send_keys "cd $REPO_ROOT" Enter; sleep 0.3
+
+# ── verdict
+echo ""
+echo "    ──────────── 16 verdict (auto mode) ────────────"
+echo "    16a (with allow):    hook_fired=$hook_fired_a  tool_ran=$tool_ran_a"
+echo "    16b (without allow): hook_fired=$hook_fired_b  tool_ran=$tool_ran_b"
+if [[ $hook_fired_a -eq 0 && $hook_fired_b -eq 0 ]]; then
+    pass "auto mode auto-approves MCP tools without consulting PermissionRequest hook either way"
+elif [[ $hook_fired_a -eq 0 && $hook_fired_b -eq 1 ]]; then
+    pass "wildcard PREEMPTS hook in auto mode (hook fires only when no rule matches)"
+elif [[ $hook_fired_a -eq 1 && $hook_fired_b -eq 1 ]]; then
+    pass "hook fires regardless in auto mode — auto-approve hook still executes redundantly with wildcard"
+else
+    fail "unexpected: hook fires WITH allow but not WITHOUT"
+fi
+
+rm -f "$TEST_HOME/.mcp.json"
+scenario_end

--- a/tests/cc-validation/scenarios/17_fork_can_spawn_subagent.sh
+++ b/tests/cc-validation/scenarios/17_fork_can_spawn_subagent.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Scenario 17 — can a context:fork skill's body invoke the Agent tool?
+# If yes, the original plan B (rdr-gate / substantive-critique with context:fork)
+# is viable. If no, B is structurally impossible and must be dropped.
+
+scenario "17 fork_can_spawn_subagent: does a forked subagent itself dispatch via Agent?"
+
+write_skill "fork-spawn-test" /dev/stdin <<'EOF'
+---
+name: fork-spawn-test
+description: Validation skill — tests whether a forked subagent can dispatch another agent via Task tool
+context: fork
+agent: general-purpose
+---
+
+You are validating that a forked subagent can itself use the Task tool to dispatch a nested agent.
+
+Do exactly this:
+1. Use the Task tool to dispatch the general-purpose agent. Description: 'nested-spawn-test'. Prompt: 'Reply with the literal token NESTED-AGENT-OK.'
+2. After the nested agent returns, reply with the literal token FORK-PARENT-OK followed by whatever the nested agent told you.
+3. If the Task tool is unavailable to you OR the dispatch fails, reply NESTED-SPAWN-BLOCKED.
+EOF
+
+cat > "$TEST_HOME/.claude/settings.json" <<'EOF'
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "allow": ["Skill", "Task"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+claude_start
+claude_prompt "Invoke the fork-spawn-test skill via the Skill tool."
+claude_wait 120
+
+if capture -300 | grep -qE "NESTED-AGENT-OK"; then
+    pass "forked subagent CAN spawn nested subagents → context:fork viable for orchestrator skills"
+elif capture -300 | grep -qE "NESTED-SPAWN-BLOCKED"; then
+    pass "forked subagent CANNOT spawn nested subagents → context:fork unsuitable for skills that use Agent tool"
+else
+    fail "indeterminate — neither marker visible"
+    capture -50 | sed 's/^/    | /'
+fi
+
+claude_exit
+scenario_end


### PR DESCRIPTION
## Summary

Adds `tests/cc-validation/` — a separate, plugin-free tmux harness for validating Claude Code itself (vs nexus features). Built during the v2.1.117–119 release shakeout to verify hook injection, permission wildcards, `context: fork`, and inline `mcpServers` semantics with real interactive Claude sessions.

Reuses `tests/e2e/lib.sh` helpers for tmux/auth primitives. Each scenario writes its own `.claude/` config into an isolated `$TEST_HOME` between runs.

## What got proved (and what didn't)

**Confirmed**:
- Plain stdout DOES inject on both SessionStart AND SubagentStart (multi-line bash output)
- `additionalContext` JSON injects reliably on either event
- Suffix wildcards `mcp__server__*` work in `default` mode; infix wildcards across `__` boundaries do NOT
- `context: fork` skills dispatch as forked subagents in any mode but do NOT inherit parent conversation context
- `--dangerously-skip-permissions` bypasses ALL `PermissionRequest` hooks

**Open** (worth re-running on future Claude Code releases):
- Inline agent `mcpServers` doesn't load servers in interactive mode (works in `-p`)
- Project-level `.mcp.json` doesn't load in interactive harness
- PermissionRequest hook preemption in auto mode (blocked by above)

## Run

```bash
./tests/e2e/auth-login.sh                          # cache OAuth creds (one-time)
./tests/cc-validation/runner.sh                    # all 16 scenarios (~15 min)
./tests/cc-validation/runner.sh --scenario 13      # single scenario
tmux attach -t cc-val                               # watch live
```

Tests Claude Code's own behaviour with no plugins loaded by default. Cost: ~$5–10 per full run.

## Closes

- Closes nexus-hfl7

## Test plan

- [x] All 16 scenarios run end-to-end
- [x] Auth flow handles fresh keychain extract
- [x] Each scenario isolates state via `reset_scenario_state`
- [x] Stub MCP server logs predictable tool calls
- [x] Fake-plugin variations tested (scenarios 13b, 14b)