### PR TITLE
feat(telemetry): hook duration_ms capture + nx doctor --check-hooks

### DIFF
--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -115,6 +115,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/hook_telemetry.py",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PermissionRequest": [

--- a/nx/hooks/scripts/hook_telemetry.py
+++ b/nx/hooks/scripts/hook_telemetry.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""PostToolUse hook — captures slow tool durations to T2 hook_telemetry.
+
+Reads the hook event JSON from stdin, extracts ``duration_ms``, and writes
+a row to T2's ``hook_telemetry`` table when the duration exceeds the
+threshold (env var ``NX_HOOK_TELEMETRY_THRESHOLD_MS``, default 2000ms).
+
+Direct sqlite3 write — does NOT import the full ``nexus.db.t2`` stack to
+keep per-invocation startup under ~150ms. The hook fires on every tool
+call, so the cheap-fast path matters. Failures are silent (hook must
+never block tool execution).
+
+Schema is created/migrated by the ``nx`` CLI on first run via
+``migrations.migrate_hook_telemetry``. This script assumes the table
+exists; it skips writing silently if not (the user just hasn't run nx
+yet, no point in failing the hook).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+DEFAULT_THRESHOLD_MS = 2000
+
+
+def _t2_path() -> Path:
+    """Resolve T2 path WITHOUT importing nexus (avoids heavy startup)."""
+    config_dir = os.environ.get("NEXUS_CONFIG_DIR")
+    if config_dir:
+        return Path(config_dir) / "memory.db"
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "nexus" / "memory.db"
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    duration_ms = payload.get("duration_ms")
+    if not isinstance(duration_ms, int):
+        return 0
+
+    threshold = int(os.environ.get("NX_HOOK_TELEMETRY_THRESHOLD_MS", str(DEFAULT_THRESHOLD_MS)))
+    if duration_ms < threshold:
+        return 0
+
+    db_path = _t2_path()
+    if not db_path.exists():
+        return 0
+
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=2.0)
+        try:
+            conn.execute(
+                "INSERT INTO hook_telemetry "
+                "(ts, hook_event_name, tool_name, duration_ms, session_id, cwd) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    datetime.now(UTC).isoformat(),
+                    str(payload.get("hook_event_name", "")),
+                    str(payload.get("tool_name", "")),
+                    duration_ms,
+                    str(payload.get("session_id", "")),
+                    str(payload.get("cwd", "")),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except (sqlite3.OperationalError, sqlite3.DatabaseError):
+        # Table missing (first run before migration) or DB locked — silent skip.
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -608,6 +608,62 @@ def _run_trim_telemetry(days: int) -> None:
     )
 
 
+# ── --check-hooks (nexus-ntbg) ───────────────────────────────────────────────
+
+
+def _run_check_hooks(*, threshold_ms: int, days: int, json_out: bool) -> None:
+    """Report slow PostToolUse hook firings recorded in T2 hook_telemetry."""
+    from nexus.commands._helpers import default_db_path
+    from nexus.db.t2.telemetry import Telemetry
+
+    db_path = default_db_path()
+    if not db_path.exists():
+        if json_out:
+            click.echo('{"rows": [], "count": 0, "note": "T2 db not found"}')
+        else:
+            click.echo("T2 database not found — no hook telemetry available.")
+        return
+
+    telemetry = Telemetry(db_path)
+    try:
+        rows = telemetry.query_slow_hooks(
+            threshold_ms=threshold_ms, days=days, limit=200,
+        )
+    finally:
+        telemetry.close()
+
+    if json_out:
+        import json as _json
+        click.echo(_json.dumps({"rows": rows, "count": len(rows)}))
+        return
+
+    if not rows:
+        click.echo(
+            f"No slow-hook records in last {days} days "
+            f"(threshold ≥{threshold_ms}ms)."
+        )
+        click.echo(
+            "  Tune writer threshold via env "
+            "NX_HOOK_TELEMETRY_THRESHOLD_MS (default 2000ms)."
+        )
+        return
+
+    click.echo(
+        f"Slow hook firings (last {days}d, ≥{threshold_ms}ms, "
+        f"top {len(rows)}):"
+    )
+    click.echo("")
+    # Brief table
+    click.echo(f"  {'TIMESTAMP':27} {'DURATION':>10}  {'EVENT':18} TOOL")
+    click.echo(f"  {'-'*27} {'-'*10}  {'-'*18} {'-'*30}")
+    for r in rows:
+        ts = (r.get("ts") or "")[:26]
+        dur = f"{r.get('duration_ms', 0)}ms"
+        evt = (r.get("hook_event_name") or "")[:18]
+        tool = (r.get("tool_name") or "")[:48]
+        click.echo(f"  {ts:27} {dur:>10}  {evt:18} {tool}")
+
+
 @click.command("doctor")
 @click.option(
     "--clean-checkpoints",
@@ -745,6 +801,23 @@ def _run_trim_telemetry(days: int) -> None:
          "cap T2 disk use. RDR-087 Phase 2.4.",
 )
 @click.option(
+    "--check-hooks",
+    "check_hooks",
+    is_flag=True,
+    default=False,
+    help="Report slow PostToolUse hook firings captured into "
+         "T2 hook_telemetry. Tunable via NX_HOOK_TELEMETRY_THRESHOLD_MS "
+         "(default 2000ms) on the hook side. nexus-ntbg.",
+)
+@click.option(
+    "--hook-threshold",
+    "hook_threshold",
+    default=0,
+    type=click.IntRange(min=0),
+    show_default=True,
+    help="Additional duration_ms filter for --check-hooks (0 = include all stored).",
+)
+@click.option(
     "--days",
     "days",
     default=30,
@@ -760,7 +833,8 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                check_tmpdirs: bool, reap_tmpdirs: bool,
                check_mcp_logs: bool, mcp_log_hours: int,
                json_out: bool,
-               trim_telemetry: bool, days: int) -> None:
+               trim_telemetry: bool, days: int,
+               check_hooks: bool, hook_threshold: int) -> None:
     """Verify that all required services and credentials are available."""
     if check_schema:
         _run_check_schema()
@@ -797,6 +871,10 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if trim_telemetry:
         _run_trim_telemetry(days=days)
+        return
+
+    if check_hooks:
+        _run_check_hooks(threshold_ms=hook_threshold, days=days, json_out=json_out)
         return
 
     if fix:

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -373,6 +373,33 @@ def migrate_search_telemetry(conn: sqlite3.Connection) -> None:
     _log.info("Migrated: created search_telemetry table (RDR-087)")
 
 
+def migrate_hook_telemetry(conn: sqlite3.Connection) -> None:
+    """Create the ``hook_telemetry`` table for nexus-ntbg slow-hook capture.
+
+    Schema duplicated from telemetry._TELEMETRY_SCHEMA_SQL so existing T2
+    databases get the table on upgrade. Idempotent — no-op if already present.
+    """
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='hook_telemetry'"
+    ).fetchone()
+    if row is not None:
+        return
+    conn.executescript("""
+        CREATE TABLE hook_telemetry (
+            ts               TEXT    NOT NULL,
+            hook_event_name  TEXT    NOT NULL,
+            tool_name        TEXT,
+            duration_ms      INTEGER NOT NULL,
+            session_id       TEXT,
+            cwd              TEXT
+        );
+        CREATE INDEX idx_hook_tel_ts        ON hook_telemetry(ts);
+        CREATE INDEX idx_hook_tel_duration  ON hook_telemetry(duration_ms);
+    """)
+    conn.commit()
+    _log.info("Migrated: created hook_telemetry table (nexus-ntbg)")
+
+
 def migrate_rename_dropped_to_kept(conn: sqlite3.Connection) -> None:
     """Rename ``search_telemetry.dropped_count`` → ``kept_count`` and flip values.
 
@@ -1265,6 +1292,11 @@ MIGRATIONS: list[Migration] = [
         "4.10.2",
         "Backfill required/optional bindings on builtin plans (nexus-uyc6)",
         _backfill_builtin_bindings,
+    ),
+    Migration(
+        "4.14.0",
+        "Add hook_telemetry table (nexus-ntbg — Claude Code v2.1.119+ duration_ms capture)",
+        migrate_hook_telemetry,
     ),
 ]
 

--- a/src/nexus/db/t2/telemetry.py
+++ b/src/nexus/db/t2/telemetry.py
@@ -99,6 +99,24 @@ CREATE INDEX IF NOT EXISTS idx_search_tel_collection
     ON search_telemetry(collection);
 CREATE INDEX IF NOT EXISTS idx_search_tel_ts
     ON search_telemetry(ts);
+
+-- nexus-ntbg: hook duration_ms telemetry (Claude Code v2.1.119+).
+-- One row per slow PostToolUse firing (above threshold) — written by
+-- nx/hooks/scripts/hook_telemetry.py. Surfaced via ``nx doctor --check-hooks``.
+-- Schema duplicated in migrations.migrate_hook_telemetry for upgrades.
+CREATE TABLE IF NOT EXISTS hook_telemetry (
+    ts               TEXT    NOT NULL,
+    hook_event_name  TEXT    NOT NULL,
+    tool_name        TEXT,
+    duration_ms      INTEGER NOT NULL,
+    session_id       TEXT,
+    cwd              TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_hook_tel_ts
+    ON hook_telemetry(ts);
+CREATE INDEX IF NOT EXISTS idx_hook_tel_duration
+    ON hook_telemetry(duration_ms);
 """
 
 _RELEVANCE_LOG_COLUMNS = (
@@ -326,6 +344,71 @@ class Telemetry:
             "zero_hit_rate": zero_rate,
             "median_top_distance": median,
         }
+
+    # ── hook_telemetry (nexus-ntbg) ─────────────────────────────────────
+
+    def log_hook_event(
+        self,
+        hook_event_name: str,
+        tool_name: str,
+        duration_ms: int,
+        session_id: str = "",
+        cwd: str = "",
+    ) -> None:
+        """Record a slow hook firing (above caller's threshold).
+
+        The hook script is responsible for thresholding — this method writes
+        unconditionally. Append-only; periodic ``trim_hook_telemetry`` keeps
+        the table bounded.
+        """
+        ts = datetime.now(UTC).isoformat()
+        with self._lock:
+            self.conn.execute(
+                "INSERT INTO hook_telemetry "
+                "(ts, hook_event_name, tool_name, duration_ms, session_id, cwd) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (ts, hook_event_name, tool_name, duration_ms, session_id, cwd),
+            )
+            self.conn.commit()
+
+    def query_slow_hooks(
+        self,
+        threshold_ms: int = 0,
+        days: int = 7,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return slow-hook records, newest first.
+
+        ``threshold_ms`` filters in addition to whatever the writer used —
+        defaults to 0 (return everything stored). ``days`` bounds the lookback
+        window. ``limit`` caps result count.
+        """
+        if days < 1:
+            raise ValueError(f"days must be >= 1; got {days}")
+        cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT ts, hook_event_name, tool_name, duration_ms, session_id, cwd "
+                "FROM hook_telemetry "
+                "WHERE ts >= ? AND duration_ms >= ? "
+                "ORDER BY ts DESC LIMIT ?",
+                (cutoff, threshold_ms, limit),
+            ).fetchall()
+        cols = ("ts", "hook_event_name", "tool_name", "duration_ms", "session_id", "cwd")
+        return [dict(zip(cols, row)) for row in rows]
+
+    def trim_hook_telemetry(self, days: int = 30) -> int:
+        """Delete ``hook_telemetry`` rows older than *days* days."""
+        if days < 1:
+            raise ValueError(f"days must be >= 1; got {days}")
+        cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+        with self._lock:
+            cur = self.conn.execute(
+                "DELETE FROM hook_telemetry WHERE ts < ?",
+                (cutoff,),
+            )
+            self.conn.commit()
+        return cur.rowcount
 
     def trim_search_telemetry(self, days: int = 30) -> int:
         """Delete ``search_telemetry`` rows older than *days* days (Phase 2.4).

--- a/tests/test_hook_telemetry.py
+++ b/tests/test_hook_telemetry.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for nexus-ntbg: hook duration_ms telemetry capture.
+
+Verifies:
+- T2 hook_telemetry table schema (created via _TELEMETRY_SCHEMA_SQL)
+- Telemetry.log_hook_event / query_slow_hooks / trim_hook_telemetry
+- Migration migrate_hook_telemetry on a legacy DB without the table
+- nx/hooks/scripts/hook_telemetry.py threshold gating + write
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from nexus.db.t2 import T2Database
+from nexus.db.migrations import migrate_hook_telemetry
+
+
+@pytest.fixture()
+def t2():
+    with tempfile.TemporaryDirectory() as d:
+        db = T2Database(Path(d) / "t2.db")
+        yield db
+
+
+# ── Schema & method tests ──────────────────────────────────────────────────
+
+
+def test_hook_telemetry_table_exists(t2):
+    cols = {
+        r[1]
+        for r in t2.telemetry.conn.execute(
+            "PRAGMA table_info(hook_telemetry)"
+        ).fetchall()
+    }
+    assert cols == {
+        "ts", "hook_event_name", "tool_name",
+        "duration_ms", "session_id", "cwd",
+    }
+
+
+def test_log_hook_event_inserts_row(t2):
+    t2.telemetry.log_hook_event(
+        hook_event_name="PostToolUse",
+        tool_name="Bash",
+        duration_ms=2500,
+        session_id="sess-test",
+        cwd="/tmp/test",
+    )
+    rows = t2.telemetry.conn.execute(
+        "SELECT hook_event_name, tool_name, duration_ms, session_id, cwd "
+        "FROM hook_telemetry"
+    ).fetchall()
+    assert rows == [("PostToolUse", "Bash", 2500, "sess-test", "/tmp/test")]
+
+
+def test_query_slow_hooks_filters_by_threshold(t2):
+    for d in (500, 2500, 5500):
+        t2.telemetry.log_hook_event("PostToolUse", "Bash", d)
+    rows = t2.telemetry.query_slow_hooks(threshold_ms=2000, days=7)
+    durations = sorted(r["duration_ms"] for r in rows)
+    assert durations == [2500, 5500]
+
+
+def test_query_slow_hooks_returns_newest_first(t2):
+    import time
+    t2.telemetry.log_hook_event("PostToolUse", "Bash", 3000)
+    time.sleep(0.01)
+    t2.telemetry.log_hook_event("PostToolUse", "Edit", 4000)
+    rows = t2.telemetry.query_slow_hooks(days=7)
+    assert [r["tool_name"] for r in rows] == ["Edit", "Bash"]
+
+
+def test_query_slow_hooks_respects_limit(t2):
+    for i in range(10):
+        t2.telemetry.log_hook_event("PostToolUse", f"tool{i}", 3000)
+    rows = t2.telemetry.query_slow_hooks(limit=3, days=7)
+    assert len(rows) == 3
+
+
+def test_trim_hook_telemetry_deletes_old(t2):
+    from datetime import UTC, datetime, timedelta
+    old_ts = (datetime.now(UTC) - timedelta(days=60)).isoformat()
+    fresh_ts = datetime.now(UTC).isoformat()
+    with t2.telemetry._lock:
+        t2.telemetry.conn.executemany(
+            "INSERT INTO hook_telemetry "
+            "(ts, hook_event_name, tool_name, duration_ms) VALUES (?, ?, ?, ?)",
+            [(old_ts, "PostToolUse", "Old", 3000),
+             (fresh_ts, "PostToolUse", "Fresh", 3000)],
+        )
+        t2.telemetry.conn.commit()
+    deleted = t2.telemetry.trim_hook_telemetry(days=30)
+    assert deleted == 1
+    remaining = t2.telemetry.conn.execute(
+        "SELECT tool_name FROM hook_telemetry"
+    ).fetchall()
+    assert remaining == [("Fresh",)]
+
+
+def test_query_slow_hooks_rejects_bad_days(t2):
+    with pytest.raises(ValueError):
+        t2.telemetry.query_slow_hooks(days=0)
+
+
+def test_trim_hook_telemetry_rejects_bad_days(t2):
+    with pytest.raises(ValueError):
+        t2.telemetry.trim_hook_telemetry(days=0)
+
+
+# ── Migration test (legacy DB without the table) ───────────────────────────
+
+
+def test_migrate_hook_telemetry_creates_table_on_legacy_db():
+    """Legacy DB lacking hook_telemetry gets the table on migration."""
+    with tempfile.TemporaryDirectory() as d:
+        db_path = Path(d) / "legacy.db"
+        # Build a minimal "legacy" T2 without the hook_telemetry table
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE memory (id INTEGER PRIMARY KEY)")
+        conn.commit()
+
+        # Verify the table doesn't exist yet
+        assert (
+            conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='hook_telemetry'"
+            ).fetchone()
+            is None
+        )
+
+        migrate_hook_telemetry(conn)
+
+        # Now the table exists
+        assert (
+            conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='hook_telemetry'"
+            ).fetchone()
+            is not None
+        )
+
+        # Idempotent — second call is a no-op
+        migrate_hook_telemetry(conn)
+        conn.close()
+
+
+# ── Hook script: threshold gating + write ──────────────────────────────────
+
+
+def _hook_script_path() -> Path:
+    return (
+        Path(__file__).parent.parent
+        / "nx" / "hooks" / "scripts" / "hook_telemetry.py"
+    )
+
+
+def _run_hook(payload: dict, env: dict) -> int:
+    proc = subprocess.run(
+        [sys.executable, str(_hook_script_path())],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={**os.environ, **env},
+        timeout=10,
+    )
+    return proc.returncode
+
+
+def test_hook_script_below_threshold_does_not_write():
+    with tempfile.TemporaryDirectory() as d:
+        T2Database(Path(d) / "memory.db")  # creates table
+        env = {
+            "NEXUS_CONFIG_DIR": d,
+            "NX_HOOK_TELEMETRY_THRESHOLD_MS": "2000",
+        }
+        rc = _run_hook(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Bash",
+                "duration_ms": 500,
+                "session_id": "s",
+                "cwd": "/tmp",
+            },
+            env,
+        )
+        assert rc == 0
+        conn = sqlite3.connect(str(Path(d) / "memory.db"))
+        rows = conn.execute("SELECT COUNT(*) FROM hook_telemetry").fetchone()
+        conn.close()
+        assert rows == (0,)
+
+
+def test_hook_script_above_threshold_writes_row():
+    with tempfile.TemporaryDirectory() as d:
+        T2Database(Path(d) / "memory.db")
+        env = {
+            "NEXUS_CONFIG_DIR": d,
+            "NX_HOOK_TELEMETRY_THRESHOLD_MS": "1000",
+        }
+        rc = _run_hook(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Bash",
+                "duration_ms": 3500,
+                "session_id": "s1",
+                "cwd": "/tmp/foo",
+            },
+            env,
+        )
+        assert rc == 0
+        conn = sqlite3.connect(str(Path(d) / "memory.db"))
+        row = conn.execute(
+            "SELECT hook_event_name, tool_name, duration_ms, session_id, cwd "
+            "FROM hook_telemetry"
+        ).fetchone()
+        conn.close()
+        assert row == ("PostToolUse", "Bash", 3500, "s1", "/tmp/foo")
+
+
+def test_hook_script_silent_when_db_missing():
+    """Hook must never block tool execution — missing DB returns 0 silently."""
+    with tempfile.TemporaryDirectory() as d:
+        env = {"NEXUS_CONFIG_DIR": d}  # no DB created
+        rc = _run_hook(
+            {"hook_event_name": "PostToolUse", "tool_name": "Bash",
+             "duration_ms": 5000},
+            env,
+        )
+        assert rc == 0
+
+
+def test_hook_script_silent_on_invalid_input():
+    """Garbage stdin returns 0 without crashing."""
+    proc = subprocess.run(
+        [sys.executable, str(_hook_script_path())],
+        input="not json {{{",
+        capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 0
+
+
+def test_hook_script_silent_when_duration_missing():
+    """Hook payload without duration_ms field is a silent no-op."""
+    with tempfile.TemporaryDirectory() as d:
+        T2Database(Path(d) / "memory.db")
+        env = {"NEXUS_CONFIG_DIR": d}
+        rc = _run_hook(
+            {"hook_event_name": "PostToolUse", "tool_name": "Bash"},  # no duration_ms
+            env,
+        )
+        assert rc == 0
+        conn = sqlite3.connect(str(Path(d) / "memory.db"))
+        rows = conn.execute("SELECT COUNT(*) FROM hook_telemetry").fetchone()
+        conn.close()
+        assert rows == (0,)


### PR DESCRIPTION
## Summary

Claude Code v2.1.119 added `duration_ms` to PostToolUse hook payloads. Wires it into a generic `""` matcher PostToolUse hook that thresholds on `NX_HOOK_TELEMETRY_THRESHOLD_MS` (default 2000ms) and writes slow firings to a new T2 `hook_telemetry` table.

Surface via `nx doctor --check-hooks` (table or `--json`) for visibility into per-tool latency that was previously invisible.

Built on the cc-validation finding (PR #317) that `duration_ms` is reliably present in PostToolUse hook stdin (probed in scenario `expDur`, returned `1403ms` for a `sleep 1; echo done` Bash call).

## What's added

- `src/nexus/db/t2/telemetry.py` — `hook_telemetry` schema + `log_hook_event` / `query_slow_hooks` / `trim_hook_telemetry`
- `src/nexus/db/migrations.py` — `migrate_hook_telemetry` @ 4.14.0 for upgrades
- `nx/hooks/scripts/hook_telemetry.py` — minimal direct-sqlite writer (~150ms cold start, no `nexus` imports). Silent on missing DB / bad input — a hook must never block tool execution
- `nx/hooks/hooks.json` — adds the `""` matcher PostToolUse entry alongside the existing `Write|Edit` divergence-language-guard
- `src/nexus/commands/doctor.py` — `--check-hooks` flag with `--hook-threshold` filter + `--json` output
- `tests/test_hook_telemetry.py` — 14 tests cover schema, methods, migration on legacy DB, threshold gating, silent-failure invariants

## Test plan

- [x] `uv run pytest tests/test_hook_telemetry.py` — 14/14 pass
- [x] `uv run pytest tests/test_plugin_structure.py` — 581/581 pass
- [x] `nx doctor --check-hooks` table output verified against injected smoke records
- [x] `nx doctor --check-hooks --json` machine-parseable output verified
- [x] Hook silent-skip on missing DB confirmed
- [x] Hook silent-skip on invalid stdin confirmed
- [x] Migration idempotent on legacy DB

## Closes

- Closes nexus-ntbg