### PR TITLE
fix: bump MIGRATIONS sentinel count to 21 (nexus-ntbg follow-up)

### DIFF
--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -77,11 +77,12 @@ class TestMigrationDataclass:
         # Baseline 16 + RDR-092 Phase 0d backfill (4.9.12) +
         # RDR-092 Phase 3.1 match_text column (4.9.13) +
         # legacy operation-shape retirement (4.10.1) +
-        # builtin-bindings backfill (4.10.2) = 20.
+        # builtin-bindings backfill (4.10.2) +
+        # hook_telemetry table (4.14.0, nexus-ntbg) = 21.
         # Prefer the name-based checks in TestBackfillPlanDimensions
         # and TestAddPlanMatchTextColumn for future guards; this
         # count is a cheap sentinel only.
-        assert len(MIGRATIONS) == 20
+        assert len(MIGRATIONS) == 21
 
     def test_migrations_ordered_by_version(self) -> None:
         from nexus.db.migrations import MIGRATIONS, _parse_version


### PR DESCRIPTION
## Summary

Hotfix for main CI: PR #318 added the 21st migration but its squash merge landed before the test sentinel update could be folded in. This bumps `assert len(MIGRATIONS) == 20` → `21` to match the registry.

## Test plan

- [x] `uv run pytest tests/test_migrations.py tests/test_hook_telemetry.py` — 117/117 pass locally
- [ ] CI green