### PR TITLE
chore(hooks): trim startup-hook injections (-1100 tok/session, -360 tok/dispatch)

### DIFF
--- a/nx/hooks/scripts/subagent-start.sh
+++ b/nx/hooks/scripts/subagent-start.sh
@@ -82,14 +82,21 @@ for p in set(paths[:5]):  # cap at 5 to keep it fast
   fi
 fi
 
-# Relay template (required fields only)
-RELAY_TEMPLATE="$CLAUDE_PLUGIN_ROOT/agents/_shared/RELAY_TEMPLATE.md"
-if [[ -f "$RELAY_TEMPLATE" ]]; then
-  echo ""
-  echo "## Relay Format"
-  echo ""
-  awk '/^## Optional Fields/{exit} {print}' "$RELAY_TEMPLATE"
-fi
+# Relay format — inline (was: awk-truncated RELAY_TEMPLATE.md). Keep compact.
+cat <<'RELAY'
+
+## Relay Format (Required Fields)
+
+| Field | Description |
+|-------|-------------|
+| Task | 1-2 sentence summary |
+| Bead | Bead ID with status, or 'none' |
+| Input Artifacts | nx store, nx memory, nx scratch, files |
+| Deliverable | What the agent should produce |
+| Quality Criteria | Checkbox list |
+
+Relays are constructed by the caller. Subagents output "Recommended Next Step" blocks for the caller to use.
+RELAY
 
 # Serena + Context7 guidance injected by sn plugin (sn/hooks/scripts/mcp-inject.sh).
 
@@ -98,72 +105,36 @@ cat <<'NXTOOLS'
 
 ## nx Storage Tools
 
-All results from search/list tools are **paged**. Response footer shows `Next page: offset=N`. Re-call with that offset to get more.
+Results from search/list are paged — footer shows `offset=N` for next page.
 
-T1 scratch — session-scoped, shared across all sibling agents:
-  Tool: mcp__plugin_nx_nexus__scratch
-    scratch(action="put", content="...", tags="hypothesis,decision")
-    scratch(action="search", query="...", limit=5)
-    scratch(action="list")
-    scratch(action="get", entry_id="...")
-    scratch(action="delete", entry_id="...")
-  Tool: mcp__plugin_nx_nexus__scratch_manage
-    scratch_manage(action="flag", entry_id="...", project="...", title="...")
+T1 scratch (session-scoped, shared across siblings):
+  mcp__plugin_nx_nexus__scratch(action="put|search|list|get|delete", content, tags, query, limit, entry_id)
+  mcp__plugin_nx_nexus__scratch_manage(action="flag", entry_id, project, title)
 
-T2 memory — project-scoped, persistent:
-  Tool: mcp__plugin_nx_nexus__memory_get
-    memory_get(project="...", title="...")       read one entry
-    memory_get(project="...", title="")          list titles only
-  Tool: mcp__plugin_nx_nexus__memory_search
-    memory_search(query="...", project="...", limit=20, offset=0)
-  Tool: mcp__plugin_nx_nexus__memory_put
-    memory_put(content="...", project="...", title="...", ttl=30)
-  Tool: mcp__plugin_nx_nexus__memory_delete
-    memory_delete(project="...", title="...")
+T2 memory (project-scoped, persistent):
+  mcp__plugin_nx_nexus__memory_get(project, title="" → list titles only)
+  mcp__plugin_nx_nexus__memory_search(query, project, limit=20, offset=0)
+  mcp__plugin_nx_nexus__memory_put(content, project, title, ttl=30)
+  mcp__plugin_nx_nexus__memory_delete(project, title)
 
-T3 knowledge — permanent, semantic search:
-  Tool: mcp__plugin_nx_nexus__search
-    search(query="...", corpus="knowledge", limit=10, offset=0, where="bib_year>=2023", cluster_by="", topic="")
-    → where: section_type!=references filters noise. cluster_by="semantic" groups by topic. topic="Label" pre-filters to a topic cluster
-  Tool: mcp__plugin_nx_nexus__query
-    query(question="...", corpus="knowledge", where="bib_year>=2020", limit=10,
-          author="", content_type="", follow_links="cites", depth=1, subtree="1.1")
-    → document-level results; catalog params scope search; taxonomy-boosted ranking
-    → subtree: all descendants of tumbler prefix (e.g. "1.1" = all nexus docs)
-    → follow_links: enrich results with linked docs (any link type)
-  Tool: mcp__plugin_nx_nexus__store_list
-    store_list(collection="knowledge", limit=20, offset=0)
-    store_list(collection="knowledge__art", docs=true)   → document-level view
-  Tool: mcp__plugin_nx_nexus__store_get
-    store_get(doc_id="...", collection="knowledge")
-  Tool: mcp__plugin_nx_nexus__store_put
-    store_put(content="...", collection="knowledge", title="...", tags="...")
-    AUTO-LINKING: store_put checks T1 scratch for link-context (tag: "link-context") and auto-creates catalog links.
-    If no link-context in scratch, self-seed: catalog_search your task references → scratch put with targets.
-    You MUST call store_put before returning — findings not stored are findings lost.
-  Tool: mcp__plugin_nx_nexus__collection_list
+T3 knowledge (permanent, semantic search):
+  mcp__plugin_nx_nexus__search(query, corpus="knowledge", limit=10, offset=0, where, cluster_by, topic)
+    where: "section_type!=references" filters noise; cluster_by="semantic" groups; topic="Label" pre-filters
+  mcp__plugin_nx_nexus__query(question, corpus, where, limit, author, content_type, follow_links="cites", depth=1, subtree)
+    document-level, catalog-aware, taxonomy-boosted; subtree="1.1" = all descendants of tumbler prefix
+  mcp__plugin_nx_nexus__store_list(collection, limit=20, offset=0, docs=false)
+  mcp__plugin_nx_nexus__store_get(doc_id, collection)
+  mcp__plugin_nx_nexus__store_put(content, collection, title, tags)
+    AUTO-LINKS via T1 scratch tag "link-context"; self-seed via catalog_search → scratch put if absent.
+    Findings not stored are findings lost — call before returning.
+  mcp__plugin_nx_nexus__collection_list
 
 Plan library (T2):
-  Tool: mcp__plugin_nx_nexus__plan_search
-    plan_search(query="...", project="...", limit=5)
-  Tool: mcp__plugin_nx_nexus__plan_save
-    plan_save(query="...", plan_json="...", project="...", tags="...", ttl=30)
+  mcp__plugin_nx_nexus__plan_search(query, project, limit=5)
+  mcp__plugin_nx_nexus__plan_save(query, plan_json, project, tags, ttl=30)
 
-Routing: T1 for sibling sharing → T2 for project persistence → T3 for semantic knowledge.
+Routing: T1 (sibling sharing) → T2 (project persistence) → T3 (semantic knowledge).
 NXTOOLS
-
-# L1 Knowledge Map (per-repo, RDR-072) — outside quoted heredoc so $(…) expands
-CONTEXT_DIR="$HOME/.config/nexus/context"
-REPO_HASH=$(echo -n "$(pwd -P)" | shasum -a 1 | cut -c1-8)
-REPO_NAME=$(basename "$(pwd -P)")
-CONTEXT_FILE="$CONTEXT_DIR/${REPO_NAME}-${REPO_HASH}.txt"
-if [ ! -f "$CONTEXT_FILE" ]; then
-  CONTEXT_FILE="$HOME/.config/nexus/context_l1.txt"
-fi
-if [ -f "$CONTEXT_FILE" ]; then
-  echo ""
-  cat "$CONTEXT_FILE"
-fi
 fi
 
 cat <<'SEQTHINK'
@@ -180,15 +151,15 @@ cat <<'OPERATORS'
 
 ## Analytical Operators (RDR-080)
 
-Five MCP tools wrap the five operations — each spawns `claude -p` (default timeout 120s). Call them directly; no Agent dispatch.
+Five MCP tools wrap the five operations — each spawns `claude -p` (default timeout 120s). Call directly; no Agent dispatch.
 
-  mcp__plugin_nx_nexus__operator_summarize(content="<text>", cited=True)
-  mcp__plugin_nx_nexus__operator_extract(inputs=["doc1","doc2"], fields="title,year,author")
-  mcp__plugin_nx_nexus__operator_rank(items=["a","b","c"], criterion="<criterion>")
-  mcp__plugin_nx_nexus__operator_compare(items=["x","y"], focus="<aspect>")
-  mcp__plugin_nx_nexus__operator_generate(template="<template>", context="<source material>")
+  mcp__plugin_nx_nexus__operator_summarize(content, cited=True)
+  mcp__plugin_nx_nexus__operator_extract(inputs=[...], fields="title,year,author")
+  mcp__plugin_nx_nexus__operator_rank(items=[...], criterion)
+  mcp__plugin_nx_nexus__operator_compare(items=[...], focus)
+  mcp__plugin_nx_nexus__operator_generate(template, context)
 
-For plan-matched multi-step retrieval use `mcp__plugin_nx_nexus__nx_answer` — it composes search/query/operators under a plan-match-first gate.
+For plan-matched multi-step retrieval use mcp__plugin_nx_nexus__nx_answer — it composes search/query/operators under a plan-match-first gate.
 OPERATORS
 fi
 
@@ -200,25 +171,20 @@ if echo "$TASK_TEXT" | grep -qiE "author|cit(e|ation|es|ed)|who wrote|what did.*
 
 ## Catalog — Document Registry + Link Graph
 
-Use catalog tools for metadata-first queries: author, corpus, title, citations, provenance, references.
-The `/nx:query` skill handles full catalog-aware plan execution.
+Catalog tools for metadata-first queries (author, corpus, title, citations, provenance). /nx:query handles full catalog-aware plan execution.
 
-  mcp__plugin_nx_nexus-catalog__search(query="...", author="...", corpus="...", owner="...", file_path="...", content_type="...")
-  mcp__plugin_nx_nexus-catalog__show(tumbler="1.2.5")  — full entry with links_from + links_to
-  mcp__plugin_nx_nexus-catalog__links(tumbler="1.2.5", direction="in", link_type="cites", depth=2)
-    Returns {"nodes": [CatalogEntry dicts], "edges": [link dicts]}.
-    Only live documents — deleted nodes excluded. Use mcp__plugin_nx_nexus-catalog__link_query for all links.
-  mcp__plugin_nx_nexus-catalog__link(from_tumbler="...", to_tumbler="...", link_type="cites", created_by="agent-name",
-    from_span="chash:<sha256hex>", to_span="chash:<sha256hex>")
-    Accepts titles or tumblers. Returns {"from", "to", "type", "created": true/false}.
-    SPAN FORMAT (preferred): "chash:<64-char-hex>" — content-addressed, survives re-indexing.
-    Sub-chunk precision: "chash:<64-char-hex>:<start>-<end>" — character range within a chunk.
-    Get chunk hashes from search result metadata: each chunk has chunk_text_hash field.
-    Fallback spans: "42-57" (line range) or "3:100-250" (chunk:char) — positional, may go stale.
-  mcp__plugin_nx_nexus-catalog__link_query(link_type="cites", created_by="bib_enricher", created_at_before="...", limit=50)
-    All links including orphans. Admin/audit — not a planner step.
-  mcp__plugin_nx_nexus-catalog__resolve(owner="1.1", corpus="schema-evolution")  — → collection names
-  Link types: cites, implements-heuristic, supersedes, quotes, relates, comments, implements
+  mcp__plugin_nx_nexus-catalog__search(query, author, corpus, owner, file_path, content_type)
+  mcp__plugin_nx_nexus-catalog__show(tumbler) — full entry with links_from + links_to
+  mcp__plugin_nx_nexus-catalog__links(tumbler, direction="in", link_type="cites", depth=2)
+    → {"nodes":[CatalogEntry], "edges":[link]}; live documents only (use link_query for orphans)
+  mcp__plugin_nx_nexus-catalog__link(from_tumbler, to_tumbler, link_type, created_by, from_span, to_span)
+    spans: "chash:<sha256hex>" preferred (content-addressed); "chash:<sha256hex>:<start>-<end>" sub-chunk;
+    fallback "L-L" line range or "C:S-E" chunk:char (positional, may go stale).
+    chash from search result chunk_text_hash metadata.
+  mcp__plugin_nx_nexus-catalog__link_query(link_type, created_by, created_at_before, limit=50) — admin/audit, all links
+  mcp__plugin_nx_nexus-catalog__resolve(owner, corpus) — → collection names
+
+Link types: cites, implements-heuristic, supersedes, quotes, relates, comments, implements
 CATALOG
   fi
 fi

--- a/nx/hooks/scripts/subagent-start.sh
+++ b/nx/hooks/scripts/subagent-start.sh
@@ -135,6 +135,19 @@ Plan library (T2):
 
 Routing: T1 (sibling sharing) → T2 (project persistence) → T3 (semantic knowledge).
 NXTOOLS
+
+# L1 Knowledge Map (per-repo, RDR-072) — outside the heredoc so $(…) expands
+CONTEXT_DIR="$HOME/.config/nexus/context"
+REPO_HASH=$(echo -n "$(pwd -P)" | shasum -a 1 | cut -c1-8)
+REPO_NAME=$(basename "$(pwd -P)")
+CONTEXT_FILE="$CONTEXT_DIR/${REPO_NAME}-${REPO_HASH}.txt"
+if [ ! -f "$CONTEXT_FILE" ]; then
+  CONTEXT_FILE="$HOME/.config/nexus/context_l1.txt"
+fi
+if [ -f "$CONTEXT_FILE" ]; then
+  echo ""
+  cat "$CONTEXT_FILE"
+fi
 fi
 
 cat <<'SEQTHINK'

--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -1,164 +1,87 @@
 ---
 name: using-nx-skills
-description: Use when starting any conversation or task — establishes that nx skills must be checked before every response, including clarifying questions
+description: Use when starting any conversation or task — establishes that nx skills must be checked before every response, including clarifying questions. If a skill plausibly applies, invoke it.
 effort: low
 ---
 
-<EXTREMELY-IMPORTANT>
-If you think there is even a 1% chance a skill might apply to what you are doing, you MUST invoke the skill.
-
-IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
-
-This is not negotiable. This is not optional. You cannot rationalize your way out of this.
-</EXTREMELY-IMPORTANT>
-
 # Using nx Skills
 
-## The Rule
-
-**Invoke relevant skills BEFORE any response or action.** Even a 1% chance a skill might apply means you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you do not need to use it.
+If a skill plausibly applies, invoke it. False positives are cheap; misses cost time. Skills evolve — read the current version, don't rely on memory.
 
 ## Plan Reuse
 
-Before dispatching any multi-agent pipeline:
-1. Call `mcp__plugin_nx_nexus__plan_search(query="<task description>", limit=3)`
-2. If a matching template is returned, present it to the user and offer to use it as the starting structure
-3. If no match ("No matching plans."), proceed with standard routing
+Before any multi-agent pipeline:
+1. `mcp__plugin_nx_nexus__plan_search(query="<task description>", limit=3)`
+2. If a match returns, present it as a starting structure
+3. If "No matching plans.", route normally
 
-After a multi-agent pipeline completes successfully:
-1. Call `mcp__plugin_nx_nexus__plan_save(query="<task description>", plan_json=<relay chain as JSON>, tags="<agent names>")`
-2. The `plan_json` should capture: `{"steps": [...], "tools_used": [...], "outcome_notes": "..."}`
+After a successful pipeline:
+- `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")`
 
-Plan reuse is opportunistic — the skill functions normally when the plan library is empty.
+## Routing
 
-## Routing: What Skill Do I Use?
+**Before code:**
+- About to implement → `/nx:brainstorming-gate` (mandatory)
+- Multi-step → `/nx:create-plan`
+- Needs design across modules → `/nx:architecture` then `/nx:create-plan`
 
-**Before writing any code:**
-- About to implement? → `/nx:brainstorming-gate` FIRST (mandatory, no exceptions)
-- Multi-step work? → `/nx:create-plan` before touching code
-- Feature needs design (APIs, data models, component boundaries, integration)? → `/nx:architecture`
-
-**Something is broken:**
-- Test failure, exception, unexpected behavior → `/nx:debug` IMMEDIATELY (do not guess-and-retry)
-- After 2 failed fix attempts without `/nx:debug` → you are wasting time, invoke it NOW
+**Something broken:**
+- Failure / exception / unexpected behaviour → `/nx:debug` immediately
+- 2 failed fix attempts without `/nx:debug` → invoke now
 
 **Analyzing code:**
-- Need to understand structure, patterns, dependencies → `/nx:analyze-code`
-- Need to investigate WHY something behaves a certain way → `/nx:deep-analysis`
-- Rule: if `analyze-code` didn't answer the question, escalate to `deep-analysis`
+- Structure / dependencies → `/nx:analyze-code`
+- Why something behaves a certain way → `/nx:deep-analysis`
 
-**Executing work:**
-- Plan approved, ready to build? → `/nx:implement`
-- Beads need enrichment after audit? → `/nx:enrich-plan`
+**Executing:**
+- Plan approved → `/nx:implement`
+- Beads need enrichment → `/nx:enrich-plan`
 
 **Quality gates:**
-- Code changes ready? → `/nx:review-code`
-- Plan exists? → `/nx:plan-audit` (validates against codebase reality)
-- Want logic/structure critique? → `/nx:substantive-critique` (reasoning soundness)
-- Tests written? → `/nx:test-validate`
+- Code ready → `/nx:review-code`
+- Plan ready → `/nx:plan-audit` (validates against codebase)
+- Critique reasoning soundness → `/nx:substantive-critique`
+- Tests written → `/nx:test-validate`
 
-**Research and knowledge — ALL analytical questions go through `nx_answer`:**
-- Any "how does…", "what tradeoffs…", "compare X vs Y", "why was this designed…" question → `/nx:query` (calls `nx_answer`)
-- Design/architecture walks from concept to code → `/nx:research` (verb-scoped `nx_answer`)
-- Critiquing or auditing a change set → `/nx:review`
+**Analytical questions (route through `nx_answer`):**
+- "how does…" / "tradeoffs…" / "compare…" / "why was this designed…" → `/nx:query`
+- Design walks from concept to code → `/nx:research`
+- Critique a change set → `/nx:review`
 - Cross-corpus synthesis or ranking → `/nx:analyze`
-- Debugging-by-design-intent (why was this written this way?) → `/nx:debug`
-- Documentation coverage gaps → `/nx:document`
-- 3+ validated findings worth keeping → `/nx:knowledge-tidy`
+- Why was this written this way → `/nx:debug`
+- Documentation gaps → `/nx:document`
+- 3+ validated findings to keep → `/nx:knowledge-tidy`
 - PDF to index → `/nx:pdf-process`
 
-**Direct `search` / `query` MCP calls are for:** keyword retrieval with
-no composition required ("find X in collection Y"). If the question has
-a verb shape, route it through `nx_answer` — the plan library and
-operator bundling make composed retrieval strictly more useful than
-raw chunks.
+Direct `search` / `query` MCP calls are for keyword retrieval ("find X in collection Y"). Verb-shaped questions go through `nx_answer`.
 
-**RDR lifecycle:** `/nx:rdr-create` → `/nx:rdr-research` → `/nx:rdr-gate` → `/nx:rdr-accept` → `/nx:rdr-close`
-- List: `/nx:rdr-list` | Show: `/nx:rdr-show NNN`
-- Audit the base rate of silent-scope-reduction on a project: `/nx:rdr-audit [project]`
+**RDR lifecycle:** `/nx:rdr-create` → `/nx:rdr-research` → `/nx:rdr-gate` → `/nx:rdr-accept` → `/nx:rdr-close`. List/show: `/nx:rdr-list`, `/nx:rdr-show NNN`. Audit: `/nx:rdr-audit`.
 
-**Git workflow:**
-- Need workspace isolation? → `/nx:git-worktrees`
-- Implementation done, ready to merge/PR? → `/nx:finishing-branch`
-- Receiving review feedback? → `/nx:receiving-review` (verify before implementing)
+**Git:** isolation → `/nx:git-worktrees`. Done → `/nx:finishing-branch`. Receiving review → `/nx:receiving-review`.
 
-**Catalog and linking:**
-- Working with catalog entries, links, or tumblers → `/nx:catalog`
-- Seeding link context before `store_put` → `/nx:catalog` (Seed section)
+**Catalog/linking:** entries, links, tumblers, link-context seeding → `/nx:catalog`.
 
-**Reference skills (invoke when relevant, no agent dispatch):**
-- Symbol navigation (definitions, callers, renames) → `/nx:serena-code-nav`
-- nx CLI usage → `/nx:nexus`
-- Interactive CLI/REPL control → `/nx:cli-controller`
-- Creating/editing nx skills → `/nx:writing-nx-skills`
+**Reference (no agent dispatch):** `/nx:serena-code-nav`, `/nx:nexus`, `/nx:cli-controller`, `/nx:writing-nx-skills`.
 
-## Essential MCP Tools
+## Essential MCP Tools (always available)
 
-**Use these directly — they are always available, no skill invocation needed.**
-
-**Sequential Thinking** (`mcp__plugin_nx_sequential-thinking__sequentialthinking`):
-Use for any non-trivial decision: debugging hypotheses, design choices, plan evaluation, risk assessment. State hypothesis → gather evidence → evaluate → branch or proceed. Set `needsMoreThoughts: true` to continue, `isRevision: true` to correct.
+**Sequential Thinking** (`mcp__plugin_nx_sequential-thinking__sequentialthinking`): debugging hypotheses, design choices, plan evaluation. `needsMoreThoughts: true` to continue, `isRevision: true` to correct.
 
 **nx Storage Tiers** (read widest → narrowest before any work):
-- **T3** `nx search`: Permanent knowledge across all sessions and projects — check before researching
-- **T2** `nx memory`: Project decisions, findings, session context — check before project work
-- **T1** `nx scratch`: This session's discoveries, shared across all agents — check before duplicating sibling work
+- T3 `nx search`: permanent knowledge across all sessions/projects
+- T2 `nx memory`: project decisions, findings, session context
+- T1 `nx scratch`: this session's discoveries, shared across all agents
 
-**Write path:** T1 (immediate, shared) → `--persist` flag to T2 (survives session end) → `/nx:knowledge-tidy` to T3 (permanent, cross-project).
-
-## Skill Priority
-
-When multiple skills could apply:
-
-1. **Discipline skills first** (brainstorming-gate) — these determine HOW to approach
-2. **Process skills second** (strategic-planning, code-review) — these guide workflow
-3. **Implementation skills third** (development, debugging) — these execute work
+Write path: T1 (immediate, shared) → `--persist` to T2 (survives session) → `/nx:knowledge-tidy` to T3 (permanent, cross-project).
 
 ## Common Mistakes
 
-| Mistake | Correct Action |
-|---------|---------------|
-| `mcp__plugin_nx_nexus__search(query="how does X work", …)` for an analytical question | `mcp__plugin_nx_nexus__nx_answer(question="how does X work", …)` via `/nx:query` or a verb skill |
-| `mcp__plugin_nx_nexus__search(query="tradeoffs in Y")` | `mcp__plugin_nx_nexus__nx_answer` via `/nx:analyze` — `search` returns chunks, you need composition |
-| `mcp__plugin_nx_nexus__search(query="compare X across projects")` | `mcp__plugin_nx_nexus__nx_answer` via `/nx:analyze` — cross-corpus compare is exactly what plan operators do |
-| Test fails → try a different fix | Test fails → `/nx:debug` |
-| "Simple" feature → start coding | Any feature → `brainstorming-gate` first |
-| Complex feature → `/nx:create-plan` | Complex feature → `/nx:architecture` THEN `/nx:create-plan` |
-| Plan looks good → start implementing | Plan exists → `/nx:plan-audit` first |
-| grep for symbol callers | Symbol navigation → `/nx:serena-code-nav` |
-| Read whole file to find a method | Symbol lookup → `/nx:serena-code-nav` |
-| Skip review, it's a small change | Any change → `/nx:review-code` before commit |
-| Implement review feedback blindly | Receiving feedback → `/nx:receiving-review` first |
-| Merge without verifying tests | Branch done → `/nx:finishing-branch` |
-| Manual worktree setup | Need isolation → `/nx:git-worktrees` or `isolation: "worktree"` on Agent tool |
-
-## Red Flags
-
-These thoughts mean STOP — you are rationalizing:
-
-| Thought | Reality |
-|---------|---------|
-| "This is just a simple question" | Questions are tasks. Check for skills. |
-| "I need more context first" | Skill check comes BEFORE gathering context. |
-| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
-| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
-| "Let me gather information first" | Skills tell you HOW to gather information. |
-| "This doesn't need a formal skill" | If a skill exists, use it. |
-| "I remember this skill" | Skills evolve. Read current version. |
-| "This doesn't count as a task" | Action = task. Check for skills. |
-| "The skill is overkill" | Simple things become complex. Use it. |
-| "I'll just do this one thing first" | Check BEFORE doing anything. |
-| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
-| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
-
-## Skill Types
-
-**Rigid** (brainstorming-gate): Follow exactly. Do not adapt away discipline.
-
-**Flexible** (patterns, reference): Adapt principles to context.
-
-The skill itself tells you which type it is.
-
-## User Instructions
-
-Instructions say WHAT, not HOW. "Add X" or "Fix Y" does not mean skip workflows. Always check skills first.
+| Mistake | Correction |
+|---------|------------|
+| `search` for an analytical question | `nx_answer` via `/nx:query` or a verb skill |
+| Test fails → try a different fix | `/nx:debug` |
+| Implement without brainstorming-gate | `brainstorming-gate` first |
+| Plan exists, start implementing | `/nx:plan-audit` first |
+| Symbol callers via grep | `/nx:serena-code-nav` |
+| Implement review feedback blindly | `/nx:receiving-review` first |
+| Manual worktree setup | `isolation: "worktree"` on Agent tool, or `/nx:git-worktrees` |


### PR DESCRIPTION
## Summary

Apply the 5 recommendations from the startup-hook injection review (in conversation post #318/#319 cleanup).

Two file changes, no behaviour changes — purely content trim of what the SessionStart and SubagentStart hooks inject into Claude's context.

## Changes

| File | Change | Saving |
|---|---|---|
| `nx/skills/using-nx-skills/SKILL.md` | Drop hectoring preamble, "The Rule" duplicate of preamble, "Skill Priority" abstract section, "User Instructions" tail tautology, "Red Flags" emotional table. Dedupe Common Mistakes rows that already appear in Routing. | -54% (8681→3964 chars, **~1180 tok/session**) |
| `nx/hooks/scripts/subagent-start.sh` | Compact `nx Storage Tools` heredoc to single-line tool signatures; drop L1 Knowledge Map duplication (parent already injects); replace awk-truncated `RELAY_TEMPLATE.md` with inline compact 5-row table; condense Catalog span format prose to one line. | -31% on empty-stdin output (4703→3252 chars, **~360 tok/dispatch**) |

## Verification

- `bash -n nx/hooks/scripts/subagent-start.sh` — clean
- Dry-run with empty stdin produces expected output, all sections render correctly
- `uv run pytest tests/test_plugin_structure.py` — 580 passed, 26 skipped, 0 failed
- `RELAY_TEMPLATE.md` left unchanged (still serves as human reference doc); only the awk-truncated injection in `subagent-start.sh` was replaced with inline content

## Net effect

Across a typical 50-dispatch session: **~1180 + (50 × 360) ≈ 19k tokens saved per session**, with no loss of operational signal.

## Closes

- Closes nexus-w2dh