### PR TITLE
feat(testing): release-sandbox framework for high-fidelity pre-merge verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,27 @@ Use beads (`/beads:*` skills) for task tracking and T2 memory (`nx memory`) for 
 Branch naming: `feature/<bead-id>-<short-description>`
 Never push directly to `main` — all changes via PR.
 
+## Sandbox Testing
+
+Editable installs (`uv sync`) and wheel installs (`uv tool install`) resolve package data and version-gated migrations differently. Pytest runs the editable shape; users run the wheel shape. Bugs that pass tests and ship broken usually live in that gap.
+
+`tests/e2e/release-sandbox.sh` mirrors the wheel shape locally + runs the canary surface. **Required before merging any PR that touches:**
+
+- `pyproject.toml`, `uv.lock`
+- `src/nexus/db/migrations.py` (T2 migrations are version-gated)
+- `src/nexus/mcp/**`
+- `nx/**` (plugin manifest, hooks, agents, skills)
+- `.claude-plugin/**`
+- `src/nexus/commands/{doctor,upgrade}.py`
+
+```bash
+./tests/e2e/release-sandbox.sh smoke    # ~2 min, all checks must pass
+```
+
+Modes: `smoke` (canary), `shell` (manual nx exercise), `tmux` (Claude Code against sandbox), `reset`. Manual: `tests/e2e/release-sandbox.md`.
+
+If `smoke` fails: stop, fix on the same PR. Do not merge intending to fix on main.
+
 ## Release
 
 See `docs/contributing.md` for the full release checklist. Files that change every release: `pyproject.toml`, `uv.lock` (must be committed), `CHANGELOG.md`, `nx/CHANGELOG.md`, `.claude-plugin/marketplace.json`.

--- a/tests/e2e/release-sandbox.md
+++ b/tests/e2e/release-sandbox.md
@@ -65,6 +65,38 @@ Reinstall + drop into a sandbox bash subshell with `HOME=$SANDBOX`. Use for hand
 
 The subshell prompt is `(sandbox) $`. Plain `exit` tears down the env.
 
+### `shakedown`
+
+Full ensemble pipeline check. Reinstall + sandbox setup + every nx surface in sequence, with a T1 lifecycle sniff bracketing the run. Catches deployment-shape bugs (`smoke`'s job) AND ensemble bugs that only surface when pipelines interact (auto-linker on real index, post-store hooks under load, T1 propagation across CLI invocations).
+
+```bash
+./tests/e2e/release-sandbox.sh shakedown    # ~5–10 min, all 9 steps must complete
+```
+
+Sequence (each step prefixed with `── N/9 ──`):
+
+1. `nx catalog setup` — seeds plan library + catalog
+2. `nx index repo $REPO_ROOT` — code chunker, embedder, T3 write, code__ collection
+3. `nx index pdf tests/fixtures/tc-sql.pdf --collection knowledge__shakedown` — PDF pipeline (Docling/MinerU/PyMuPDF), prose chunker, CCE embeddings, bib enricher, auto-linker
+4. `nx index rdr` — RDR indexer + status reconciliation hook
+5. `nx search` — cross-corpus search (code + docs + rdr + knowledge)
+6. `nx memory put / get` — T2 roundtrip
+7. `nx scratch put / list` — T1 use + readback (verifies T1 actually wired)
+8. `nx catalog links-for-file` — link graph readback
+9. `nx doctor --check-{schema,plan-library,taxonomy,hooks,tmpdirs}` — invariants under load
+
+**T1 sniff** runs before and after, counting `~/.config/nexus/sessions/*.session` and `${TMPDIR}/nx_t1_*` tmpdirs. Net delta > 2 in either dimension prints a turd-risk warning. Steady-state delta should be 1 (this session's record).
+
+PDF fixture: `tests/fixtures/tc-sql.pdf` (~385 KB, smallest available). Heavier fixtures available if you need to stress the PDF pipeline:
+
+```bash
+ls -lhS tests/fixtures/*.pdf
+```
+
+When to use this vs `smoke`:
+- `smoke`: gates merging install/migration/MCP changes. Fast, focused.
+- `shakedown`: pre-release sanity on a full pipeline path. Slower, thorough. Run before any release tag, after any cross-cutting refactor (catalog, indexer, MCP server, RDR-095 post-store hook framework, etc.).
+
 ### `tmux`
 
 Reinstall + isolated `$HOME` + launch Claude Code in a tmux pane against the sandbox. Use for end-to-end exercises against the real MCP / plugin / hooks surface.

--- a/tests/e2e/release-sandbox.md
+++ b/tests/e2e/release-sandbox.md
@@ -1,0 +1,122 @@
+# release-sandbox: high-fidelity local pre-merge verification
+
+A unified entry point that combines wheel-shape install, isolated `$HOME`, and (optionally) tmux-driven Claude Code, so any change touching the deployment surface can be exercised end-to-end before it lands on main.
+
+Source: `tests/e2e/release-sandbox.sh`. Companion gist: https://gist.github.com/Hellblazer/511a05e1bf79dd6ea20be962d0ca04af
+
+## When you must run this
+
+Required before merging any PR that touches:
+
+- `pyproject.toml`, `uv.lock` (dependency or version surface)
+- `src/nexus/db/migrations.py` (T2 schema migrations — version-gated, only fire on real installs)
+- `src/nexus/mcp/**` (MCP servers — registration only resolves in installed venv)
+- `nx/**` (plugin manifest, hooks, agents, skills — `$CLAUDE_PLUGIN_ROOT` resolution depends on install layout)
+- `.claude-plugin/**` (marketplace + plugin descriptors)
+- `src/nexus/commands/doctor.py`, `src/nexus/commands/upgrade.py`
+- Any code path that reads T2 / T3 state and ships to users
+
+Recommended for any change that "feels like it might ship differently than it tests."
+
+## Why merging-to-test is dangerous
+
+Editable installs (`uv sync` / `pip install -e .`) walk the source tree for package data. A wheel install (`uv tool install`) only sees what `pyproject.toml` declared as package data. Files that exist on disk but are not in the wheel manifest disappear silently.
+
+Same hazard for version-gated migrations: `apply_pending` filters by `pyproject.toml`'s version, so a migration written at `4.14.0` is invisible to a tool venv still on `4.13.0`. CI sees the new migration in the source tree and runs it; users with stale local installs do not.
+
+`release-sandbox.sh` mirrors a fresh PyPI install and runs the canary checks against that, so deployment gaps surface here instead of in user reports.
+
+## Modes
+
+### `smoke`
+
+Reinstall the tool venv, create a fresh isolated `$HOME`, then run from `/tmp`:
+
+- `nx --version` (sanity)
+- `nx upgrade --dry-run` (preview migrations)
+- `nx upgrade` (apply)
+- `nx doctor --check-schema` (T2 schema sanity)
+- `nx doctor --check-plan-library` (builtin plan count)
+- `nx doctor --check-taxonomy` (topic_links invariant)
+- `nx doctor --check-hooks` (slow PostToolUse firings)
+
+Pass / fail per check. Total time ~2 min including reinstall.
+
+```bash
+./tests/e2e/release-sandbox.sh smoke
+```
+
+**Known fresh-sandbox failures** (not script bugs, expected for a clean sandbox):
+
+- `--check-plan-library`: reports `global-tier builtin count 0 < expected 9` because `nx catalog setup` has not run in the sandbox. To exercise plan-library code paths against the canonical seeded set, drop into `shell` mode and run `nx catalog setup` first.
+- `nx upgrade` may report `OldLayoutDetected` if your shell environment has cloud ChromaDB credentials pointing at a legacy four-database tenant. Unset `CHROMA_*` before running, or expect the noise.
+
+### `shell`
+
+Reinstall + drop into a sandbox bash subshell with `HOME=$SANDBOX`. Use for hand-driving `nx index`, `nx search`, `nx catalog`, `nx taxonomy` against a clean state.
+
+```bash
+./tests/e2e/release-sandbox.sh shell
+(sandbox) nx catalog setup
+(sandbox) nx index repo /path/to/test-repo
+(sandbox) nx search "..."
+(sandbox) exit       # normal exit restores your real $HOME
+```
+
+The subshell prompt is `(sandbox) $`. Plain `exit` tears down the env.
+
+### `tmux`
+
+Reinstall + isolated `$HOME` + launch Claude Code in a tmux pane against the sandbox. Use for end-to-end exercises against the real MCP / plugin / hooks surface.
+
+Prerequisites: `tests/e2e/.claude-auth/.credentials.json` must exist. Run `tests/e2e/auth-login.sh` once to cache OAuth from the macOS Keychain.
+
+```bash
+./tests/e2e/auth-login.sh         # one-time cache
+./tests/e2e/release-sandbox.sh tmux
+# tmux attaches automatically; Ctrl-b d to detach
+```
+
+Inside tmux, you have a real Claude Code session running against the wheel-installed `nx`, isolated from your live config.
+
+### `reset`
+
+Tear down `~/nexus-sandbox` without reinstalling. Useful when you want to start clean without paying the install cost.
+
+```bash
+./tests/e2e/release-sandbox.sh reset
+```
+
+## Options
+
+- `--skip-install`: skip the reinstall step. Reuse the current tool venv. Useful when iterating on shell or tmux flow without re-paying the install cost.
+- `--keep-existing`: reuse `$HOME/nexus-sandbox` if it exists. Default behaviour blows it away and recreates it for reproducibility.
+
+## The `/tmp` rule
+
+Every `nx` invocation in `smoke` mode runs from `/tmp`. This is load-bearing.
+
+When `nx` runs from inside the source tree, package-data resolution can fall back to walking parent directories until it finds the source layout. From `/tmp`, only the wheel manifest matters. Bugs that pass in-repo and fail in-deployment surface in `/tmp` and not before.
+
+If you write your own ad-hoc verification, run from `/tmp` too.
+
+## Decide: ship or fix
+
+After `smoke`:
+
+- All checks pass → safe to merge / tag / release.
+- Any check fails → **stop**. Open a fix-it commit on the same PR (or a separate hotfix PR) before continuing. Do not merge intending to fix on main; the gap was visible here, fix here.
+
+A failing `--check-plan-library` on a fresh sandbox is the only expected failure (see Known above). Anything else is real.
+
+## Cleanup
+
+`shell` mode tears down on subshell exit. `tmux` mode requires `tmux kill-session -t nexus-sandbox` (or detach + let it idle). `smoke` leaves the sandbox in place for inspection; run `reset` when done.
+
+Sandbox lives at `~/nexus-sandbox`. Safe to `rm -rf` directly if anything goes wrong.
+
+## What this does not catch
+
+- Cloud-only behaviour (Voyage AI rate limits, ChromaDB Cloud quota exhaustion at scale). For those, run `pytest -m integration` against real credentials.
+- Concurrent-write races in T1 / T3. Worth a separate harness when relevant.
+- UI / interactive surface that requires keystrokes. Use `tmux` mode plus the `tests/cc-validation/` scenario harness.

--- a/tests/e2e/release-sandbox.sh
+++ b/tests/e2e/release-sandbox.sh
@@ -178,14 +178,19 @@ case "$MODE" in
         # against the wheel install. Uses the smaller PDF fixture (tc-sql)
         # for speed. T1 sniff at the start + end catches lifecycle bugs
         # (orphan tmpdirs, leaked session files).
-        echo "[3/3] Shakedown: full pipeline ensemble (running from /tmp)"
+        #
+        # Force local mode so the shakedown does not contact ChromaDB Cloud
+        # even if the parent shell has CHROMA_* set. Mirrors tests/e2e/run.sh.
+        export NX_LOCAL=1
+        unset CHROMA_API_KEY CHROMA_TENANT CHROMA_DATABASE
+        echo "[3/3] Shakedown: full pipeline ensemble (running from /tmp, NX_LOCAL=1)"
         cd /tmp
 
         echo
         echo "── T1 sniff: BEFORE ──"
         T1_DIR_PARENT="${TMPDIR%/}"; [[ -z "$T1_DIR_PARENT" ]] && T1_DIR_PARENT=/tmp
-        BEFORE_SESSIONS=$(ls "$HOME/.config/nexus/sessions/" 2>/dev/null | wc -l | tr -d ' ')
-        BEFORE_TMPDIRS=$(ls -d "$T1_DIR_PARENT"/nx_t1_* 2>/dev/null | wc -l | tr -d ' ')
+        BEFORE_SESSIONS=$( { ls "$HOME/.config/nexus/sessions/" 2>/dev/null || true; } | wc -l | tr -d ' ')
+        BEFORE_TMPDIRS=$( { ls -d "$T1_DIR_PARENT"/nx_t1_* 2>/dev/null || true; } | wc -l | tr -d ' ')
         echo "  session files: $BEFORE_SESSIONS  | tmpdirs: $BEFORE_TMPDIRS"
 
         echo
@@ -212,7 +217,7 @@ case "$MODE" in
 
         echo
         echo "── 5/9 cross-corpus search ──"
-        nx search "catalog link graph" --limit 3 2>&1 | tail -10 | sed 's/^/  /' || true
+        nx search "catalog link graph" -m 3 2>&1 | tail -10 | sed 's/^/  /' || true
 
         echo
         echo "── 6/9 T2 memory roundtrip ──"
@@ -224,19 +229,23 @@ case "$MODE" in
 
         echo
         echo "── 7/9 T1 scratch use (write + readback) ──"
-        SCRATCH_OUT=$(nx scratch put "shakedown probe $SHAKE_TS" --tags=shakedown 2>&1)
-        echo "  put: $(echo \"$SCRATCH_OUT\" | tail -1)"
-        SCRATCH_HIT=$(nx scratch list 2>&1 | grep -c "shakedown" || true)
-        if (( SCRATCH_HIT > 0 )); then
-            echo "  list: scratch entry visible (T1 alive)"
+        # Note: outside a Claude Code session, no SessionStart hook fires to
+        # spawn the per-session ChromaDB HTTP server, so each `nx scratch *`
+        # invocation falls back to its own EphemeralClient. Cross-invocation
+        # readback is only possible inside a real Claude Code session. This
+        # shakedown verifies put returns a doc id; cross-process visibility
+        # is tested separately by the cc-validation harness.
+        SCRATCH_OUT=$(nx scratch put "shakedown probe $SHAKE_TS" --tags=shakedown 2>&1 | tail -1)
+        if echo "$SCRATCH_OUT" | grep -qE "Stored:"; then
+            echo "  put: ok ($SCRATCH_OUT)"
         else
-            echo "  list: [WARN] scratch entry NOT visible — T1 may not be wired"
+            echo "  put: [WARN] unexpected output — $SCRATCH_OUT"
         fi
+        echo "  note: cross-invocation readback only works inside a Claude Code session"
 
         echo
-        echo "── 8/9 catalog link readback ──"
-        nx catalog links-for-file "$REPO_ROOT/src/nexus/catalog/catalog.py" 2>&1 \
-            | head -10 | sed 's/^/  /' || true
+        echo "── 8/9 catalog stats (registry + link graph readback) ──"
+        nx catalog stats 2>&1 | head -15 | sed 's/^/  /' || true
 
         echo
         echo "── 9/9 nx doctor (all checks, post-activity) ──"
@@ -248,8 +257,8 @@ case "$MODE" in
 
         echo
         echo "── T1 sniff: AFTER ──"
-        AFTER_SESSIONS=$(ls "$HOME/.config/nexus/sessions/" 2>/dev/null | wc -l | tr -d ' ')
-        AFTER_TMPDIRS=$(ls -d "$T1_DIR_PARENT"/nx_t1_* 2>/dev/null | wc -l | tr -d ' ')
+        AFTER_SESSIONS=$( { ls "$HOME/.config/nexus/sessions/" 2>/dev/null || true; } | wc -l | tr -d ' ')
+        AFTER_TMPDIRS=$( { ls -d "$T1_DIR_PARENT"/nx_t1_* 2>/dev/null || true; } | wc -l | tr -d ' ')
         echo "  session files: $AFTER_SESSIONS (was $BEFORE_SESSIONS)"
         echo "  tmpdirs:       $AFTER_TMPDIRS (was $BEFORE_TMPDIRS)"
         DELTA_S=$((AFTER_SESSIONS - BEFORE_SESSIONS))

--- a/tests/e2e/release-sandbox.sh
+++ b/tests/e2e/release-sandbox.sh
@@ -14,12 +14,14 @@
 # T2/T3 state, or anything tagged "ships to users".
 #
 # Modes:
-#   smoke    — install + activate + post-install canary checks. ~2 min.
-#   shell    — install + activate + drop into a subshell with sandbox env.
-#              Exit the subshell to tear down (HOME restored automatically).
-#   tmux     — install + activate + launch Claude Code in tmux against
-#              the sandbox. Useful for exercising MCP / hooks / skills.
-#   reset    — tear down ~/nexus-sandbox without reinstalling.
+#   smoke     — install + activate + post-install canary checks. ~2 min.
+#   shakedown — full ensemble: smoke + index repo/pdf/rdr + search/query/T1/T2 +
+#               link graph readback + T1 turd sniff. ~5–10 min.
+#   shell     — install + activate + drop into a subshell with sandbox env.
+#               Exit the subshell to tear down (HOME restored automatically).
+#   tmux      — install + activate + launch Claude Code in tmux against
+#               the sandbox. Useful for exercising MCP / hooks / skills.
+#   reset     — tear down ~/nexus-sandbox without reinstalling.
 #
 # Source-of-truth doc: tests/e2e/release-sandbox.md
 # Companion gist: https://gist.github.com/Hellblazer/511a05e1bf79dd6ea20be962d0ca04af
@@ -42,7 +44,11 @@ Usage: $0 <mode> [options]
 
 Modes:
   smoke      Reinstall + activate + run nx upgrade --dry-run + nx doctor checks.
-             Verifies the wheel install + migrations + health surface.
+             Verifies the wheel install + migrations + health surface. ~2 min.
+  shakedown  Full ensemble: smoke + nx index repo/pdf/rdr + cross-corpus search
+             + T2 memory roundtrip + T1 scratch use + catalog link readback +
+             T1 turd sniff. Exercises every pipeline against a fresh install.
+             ~5–10 min. Uses tests/fixtures/tc-sql.pdf as the PDF probe.
   shell      Reinstall + activate + drop into a subshell with HOME=\$SANDBOX.
              Use this for manual nx index, nx search, etc. Exit normally to
              tear down.
@@ -109,7 +115,7 @@ if [[ "$MODE" == "reset" ]]; then
     exit 0
 fi
 
-if [[ "$MODE" != "smoke" && "$MODE" != "shell" && "$MODE" != "tmux" ]]; then
+if [[ "$MODE" != "smoke" && "$MODE" != "shakedown" && "$MODE" != "shell" && "$MODE" != "tmux" ]]; then
     _die "unknown mode: $MODE (use $0 help)"
 fi
 
@@ -164,6 +170,99 @@ case "$MODE" in
             fi
             echo
         done
+        echo "[done] Sandbox state at $SANDBOX. Run '$0 reset' to tear down."
+        ;;
+
+    shakedown)
+        # Ensemble pipeline check: every nx surface exercised in sequence
+        # against the wheel install. Uses the smaller PDF fixture (tc-sql)
+        # for speed. T1 sniff at the start + end catches lifecycle bugs
+        # (orphan tmpdirs, leaked session files).
+        echo "[3/3] Shakedown: full pipeline ensemble (running from /tmp)"
+        cd /tmp
+
+        echo
+        echo "── T1 sniff: BEFORE ──"
+        T1_DIR_PARENT="${TMPDIR%/}"; [[ -z "$T1_DIR_PARENT" ]] && T1_DIR_PARENT=/tmp
+        BEFORE_SESSIONS=$(ls "$HOME/.config/nexus/sessions/" 2>/dev/null | wc -l | tr -d ' ')
+        BEFORE_TMPDIRS=$(ls -d "$T1_DIR_PARENT"/nx_t1_* 2>/dev/null | wc -l | tr -d ' ')
+        echo "  session files: $BEFORE_SESSIONS  | tmpdirs: $BEFORE_TMPDIRS"
+
+        echo
+        echo "── nx --version + upgrade ──"
+        nx --version | sed 's/^/  /'
+        nx upgrade 2>&1 | sed 's/^/  /' || true
+
+        echo
+        echo "── 1/9 nx catalog setup (seeds plan library) ──"
+        nx catalog setup 2>&1 | tail -5 | sed 's/^/  /' || true
+
+        echo
+        echo "── 2/9 nx index repo ($REPO_ROOT) ──"
+        nx index repo "$REPO_ROOT" 2>&1 | tail -5 | sed 's/^/  /' || true
+
+        echo
+        echo "── 3/9 nx index pdf (tests/fixtures/tc-sql.pdf) ──"
+        nx index pdf "$REPO_ROOT/tests/fixtures/tc-sql.pdf" \
+            --collection knowledge__shakedown 2>&1 | tail -5 | sed 's/^/  /' || true
+
+        echo
+        echo "── 4/9 nx index rdr ──"
+        nx index rdr "$REPO_ROOT" 2>&1 | tail -5 | sed 's/^/  /' || true
+
+        echo
+        echo "── 5/9 cross-corpus search ──"
+        nx search "catalog link graph" --limit 3 2>&1 | tail -10 | sed 's/^/  /' || true
+
+        echo
+        echo "── 6/9 T2 memory roundtrip ──"
+        SHAKE_TS=$(date +%s)
+        nx memory put "shakedown marker $SHAKE_TS" \
+            --project nexus_shakedown --title shakedown.md 2>&1 | tail -2 | sed 's/^/  /' || true
+        nx memory get --project nexus_shakedown --title shakedown.md 2>&1 \
+            | head -3 | sed 's/^/  /' || true
+
+        echo
+        echo "── 7/9 T1 scratch use (write + readback) ──"
+        SCRATCH_OUT=$(nx scratch put "shakedown probe $SHAKE_TS" --tags=shakedown 2>&1)
+        echo "  put: $(echo \"$SCRATCH_OUT\" | tail -1)"
+        SCRATCH_HIT=$(nx scratch list 2>&1 | grep -c "shakedown" || true)
+        if (( SCRATCH_HIT > 0 )); then
+            echo "  list: scratch entry visible (T1 alive)"
+        else
+            echo "  list: [WARN] scratch entry NOT visible — T1 may not be wired"
+        fi
+
+        echo
+        echo "── 8/9 catalog link readback ──"
+        nx catalog links-for-file "$REPO_ROOT/src/nexus/catalog/catalog.py" 2>&1 \
+            | head -10 | sed 's/^/  /' || true
+
+        echo
+        echo "── 9/9 nx doctor (all checks, post-activity) ──"
+        for check in --check-schema --check-plan-library --check-taxonomy \
+                     --check-hooks --check-tmpdirs; do
+            echo "  $check:"
+            nx doctor "$check" 2>&1 | tail -5 | sed 's/^/    /' || true
+        done
+
+        echo
+        echo "── T1 sniff: AFTER ──"
+        AFTER_SESSIONS=$(ls "$HOME/.config/nexus/sessions/" 2>/dev/null | wc -l | tr -d ' ')
+        AFTER_TMPDIRS=$(ls -d "$T1_DIR_PARENT"/nx_t1_* 2>/dev/null | wc -l | tr -d ' ')
+        echo "  session files: $AFTER_SESSIONS (was $BEFORE_SESSIONS)"
+        echo "  tmpdirs:       $AFTER_TMPDIRS (was $BEFORE_TMPDIRS)"
+        DELTA_S=$((AFTER_SESSIONS - BEFORE_SESSIONS))
+        DELTA_T=$((AFTER_TMPDIRS - BEFORE_TMPDIRS))
+        echo "  delta:         sessions+$DELTA_S  tmpdirs+$DELTA_T"
+        if (( DELTA_S > 2 || DELTA_T > 2 )); then
+            echo "  [WARN] T1 turd risk: net delta exceeds expected steady-state"
+            echo "         Investigate $HOME/.config/nexus/sessions/ and $T1_DIR_PARENT/nx_t1_*"
+        else
+            echo "  [ok] T1 lifecycle within expected bounds"
+        fi
+
+        echo
         echo "[done] Sandbox state at $SANDBOX. Run '$0 reset' to tear down."
         ;;
 

--- a/tests/e2e/release-sandbox.sh
+++ b/tests/e2e/release-sandbox.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# release-sandbox.sh — high-fidelity local pre-merge verification.
+#
+# Combines:
+#   - scripts/reinstall-tool.sh   (wheel-equivalent install via uv tool)
+#   - tests/e2e/sandbox.sh        (isolated $HOME for Claude Code state)
+#   - tests/cc-validation/lib.sh  (tmux primitives, used by tmux mode)
+#
+# Why this exists: merging to main to "test things out" is dangerous because
+# the wheel-install path (uv tool install) resolves package data and version-
+# gated migrations differently from the editable install that pytest uses.
+# Run this BEFORE pushing/merging anything that touches: install/packaging,
+# T2 migrations, MCP servers, hooks, plugin manifests, commands that read
+# T2/T3 state, or anything tagged "ships to users".
+#
+# Modes:
+#   smoke    — install + activate + post-install canary checks. ~2 min.
+#   shell    — install + activate + drop into a subshell with sandbox env.
+#              Exit the subshell to tear down (HOME restored automatically).
+#   tmux     — install + activate + launch Claude Code in tmux against
+#              the sandbox. Useful for exercising MCP / hooks / skills.
+#   reset    — tear down ~/nexus-sandbox without reinstalling.
+#
+# Source-of-truth doc: tests/e2e/release-sandbox.md
+# Companion gist: https://gist.github.com/Hellblazer/511a05e1bf79dd6ea20be962d0ca04af
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SANDBOX="$HOME/nexus-sandbox"
+TMUX_SESSION="${TMUX_SESSION:-nexus-sandbox}"
+
+MODE="${1:-help}"
+shift || true
+
+_die() { echo "ERROR: $*" >&2; exit 1; }
+
+_print_help() {
+    cat <<EOF
+Usage: $0 <mode> [options]
+
+Modes:
+  smoke      Reinstall + activate + run nx upgrade --dry-run + nx doctor checks.
+             Verifies the wheel install + migrations + health surface.
+  shell      Reinstall + activate + drop into a subshell with HOME=\$SANDBOX.
+             Use this for manual nx index, nx search, etc. Exit normally to
+             tear down.
+  tmux       Reinstall + activate + launch Claude Code interactively in tmux.
+             Useful for end-to-end exercises against MCP / plugin / hooks.
+             Requires tests/e2e/.claude-auth/.credentials.json (run
+             tests/e2e/auth-login.sh first).
+  reset      Remove ~/nexus-sandbox. Does NOT reinstall.
+  help       Print this message.
+
+Common options (post-mode):
+  --skip-install   Skip the reinstall step. Useful when the tool venv is
+                   already at the version you want to exercise.
+  --keep-existing  Reuse \$HOME/nexus-sandbox if it exists (default: blow away
+                   and recreate so state is reproducible).
+
+Examples:
+  # Pre-merge smoke after a refactor
+  $0 smoke
+
+  # Hand-test indexing into the sandbox
+  $0 shell
+  (sandbox) nx index repo /path/to/test-repo
+  (sandbox) nx taxonomy status
+  (sandbox) exit
+
+  # Spin up Claude Code against the sandbox
+  $0 tmux
+
+  # Skip reinstall (e.g. iterating on shell flow)
+  $0 shell --skip-install
+
+EOF
+}
+
+# ── Option parsing ───────────────────────────────────────────────────────────
+
+SKIP_INSTALL=0
+KEEP_EXISTING=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-install) SKIP_INSTALL=1; shift ;;
+        --keep-existing) KEEP_EXISTING=1; shift ;;
+        --help|-h) _print_help; exit 0 ;;
+        *) _die "unknown option: $1 (use $0 help)" ;;
+    esac
+done
+
+# ── Mode dispatch ────────────────────────────────────────────────────────────
+
+if [[ "$MODE" == "help" || "$MODE" == "--help" || "$MODE" == "-h" ]]; then
+    _print_help
+    exit 0
+fi
+
+if [[ "$MODE" == "reset" ]]; then
+    if [[ -d "$SANDBOX" ]]; then
+        echo "Removing $SANDBOX ..."
+        rm -rf "$SANDBOX"
+        echo "Sandbox removed."
+    else
+        echo "No sandbox at $SANDBOX — nothing to reset."
+    fi
+    exit 0
+fi
+
+if [[ "$MODE" != "smoke" && "$MODE" != "shell" && "$MODE" != "tmux" ]]; then
+    _die "unknown mode: $MODE (use $0 help)"
+fi
+
+# ── Step 1 — reinstall (unless skipped) ──────────────────────────────────────
+
+if (( SKIP_INSTALL == 0 )); then
+    echo "[1/3] Reinstalling nx CLI from $REPO_ROOT ..."
+    (cd "$REPO_ROOT" && uv sync >/dev/null 2>&1)
+    "$REPO_ROOT/scripts/reinstall-tool.sh" >/dev/null
+    echo "      $(nx --version 2>/dev/null || echo 'nx --version failed')"
+else
+    echo "[1/3] Skipping reinstall (--skip-install). nx version: $(nx --version 2>/dev/null || echo 'unknown')"
+fi
+
+# ── Step 2 — create sandbox HOME ─────────────────────────────────────────────
+
+if [[ -d "$SANDBOX" && $KEEP_EXISTING -eq 0 ]]; then
+    echo "[2/3] Recreating sandbox at $SANDBOX (use --keep-existing to reuse)"
+    rm -rf "$SANDBOX"
+elif [[ -d "$SANDBOX" ]]; then
+    echo "[2/3] Reusing existing sandbox at $SANDBOX"
+fi
+
+if [[ ! -d "$SANDBOX" ]]; then
+    echo "[2/3] Creating fresh sandbox at $SANDBOX ..."
+    "$REPO_ROOT/tests/e2e/sandbox.sh" >/dev/null
+fi
+
+# ── Step 3 — execute mode ────────────────────────────────────────────────────
+
+# shellcheck source=/dev/null
+. "$SANDBOX/activate"
+
+case "$MODE" in
+    smoke)
+        echo "[3/3] Smoke checks (running from /tmp to catch package-data bugs):"
+        cd /tmp
+        echo "  nx --version: $(nx --version)"
+        echo
+        echo "  nx upgrade --dry-run:"
+        nx upgrade --dry-run 2>&1 | sed 's/^/    /' || true
+        echo
+        echo "  nx upgrade (apply):"
+        nx upgrade 2>&1 | sed 's/^/    /' || true
+        echo
+        for check in --check-schema --check-plan-library --check-taxonomy --check-hooks; do
+            echo "  nx doctor $check:"
+            if nx doctor "$check" 2>&1 | sed 's/^/    /'; then
+                echo "    [pass]"
+            else
+                echo "    [FAIL] -- exit non-zero" >&2
+            fi
+            echo
+        done
+        echo "[done] Sandbox state at $SANDBOX. Run '$0 reset' to tear down."
+        ;;
+
+    shell)
+        echo "[3/3] Dropping into subshell with HOME=$SANDBOX ..."
+        echo "      Exit the subshell to restore your real \$HOME."
+        echo
+        # Subshell: env stays sandboxed, exit returns control + restores HOME.
+        cd "$SANDBOX"
+        exec env \
+            HOME="$SANDBOX" \
+            PATH="$SANDBOX/.local/bin:$PATH" \
+            VOYAGE_API_KEY="${VOYAGE_API_KEY:-}" \
+            CHROMA_API_KEY="${CHROMA_API_KEY:-}" \
+            CHROMA_TENANT="${CHROMA_TENANT:-}" \
+            CHROMA_DATABASE="${CHROMA_DATABASE:-default_database}" \
+            ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" \
+            NEXUS_SANDBOX=1 \
+            PS1="(sandbox) $ " \
+            bash --noprofile --norc -i
+        ;;
+
+    tmux)
+        if ! command -v tmux >/dev/null 2>&1; then
+            _die "tmux not installed (brew install tmux)"
+        fi
+        AUTH_DIR="$REPO_ROOT/tests/e2e/.claude-auth"
+        if [[ ! -f "$AUTH_DIR/.credentials.json" ]]; then
+            _die "missing $AUTH_DIR/.credentials.json — run tests/e2e/auth-login.sh first"
+        fi
+        # Reuse cc-validation lib for tmux primitives + claude_start.
+        export TEST_HOME="$SANDBOX"
+        export TMUX_SESSION
+        echo "[3/3] Launching Claude Code in tmux session '$TMUX_SESSION' ..."
+        echo "      Detach: Ctrl-b d   |   Kill: tmux kill-session -t $TMUX_SESSION"
+        echo
+        # shellcheck source=/dev/null
+        . "$REPO_ROOT/tests/e2e/lib.sh"
+        # Ensure auth credentials are reachable inside the sandbox HOME.
+        mkdir -p "$SANDBOX/.claude"
+        cp "$AUTH_DIR/.credentials.json" "$SANDBOX/.claude/.credentials.json"
+        if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
+            tmux kill-session -t "$TMUX_SESSION"
+        fi
+        tmux new-session -d -s "$TMUX_SESSION" -x 220 -y 50 \
+            "env HOME='$SANDBOX' PATH='$SANDBOX/.local/bin:$PATH' bash -i"
+        sleep 1
+        tmux send-keys -t "$TMUX_SESSION" "claude" Enter
+        echo "Attaching ... (Ctrl-b d to detach without killing)"
+        tmux attach -t "$TMUX_SESSION"
+        ;;
+esac

--- a/tests/e2e/sandbox.sh
+++ b/tests/e2e/sandbox.sh
@@ -15,7 +15,10 @@ SANDBOX="$HOME/nexus-sandbox"
 # Load API keys
 [[ -f "$REPO_ROOT/.env" ]] && set -a && source "$REPO_ROOT/.env" && set +a
 
-: "${ANTHROPIC_API_KEY:?'ANTHROPIC_API_KEY must be set'}"
+# ANTHROPIC_API_KEY is optional: needed only when the sandbox will spawn Claude
+# Code (interactive / tmux modes). Pure CLI smoke (release-sandbox.sh smoke) and
+# the `shell` mode that just exercises `nx` do not need it.
+: "${ANTHROPIC_API_KEY:=}"
 
 # Bare Claude home
 rm -rf "$SANDBOX"
@@ -27,7 +30,7 @@ cat > "$SANDBOX/activate" <<EOF
 export SANDBOX_ORIG_HOME="\$HOME"
 export HOME="$SANDBOX"
 export PATH="$SANDBOX/.local/bin:\$PATH"
-export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}"
+export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}"
 export VOYAGE_API_KEY="${VOYAGE_API_KEY:-}"
 export CHROMA_API_KEY="${CHROMA_API_KEY:-}"
 export CHROMA_TENANT="${CHROMA_TENANT:-}"

--- a/tests/test_post_store_hook.py
+++ b/tests/test_post_store_hook.py
@@ -322,9 +322,18 @@ def test_fire_post_store_batch_hooks_partial_commit_failure_mode(
 def test_fire_post_store_batch_hooks_falls_back_to_scalar_when_columns_absent(
     tmp_path: Path, monkeypatch,
 ) -> None:
-    """If batch_doc_ids/is_batch columns aren't migrated yet (P1.1 merged
-    before P1.2), the failure capture writes a scalar-only row rather than
-    crashing."""
+    """If batch_doc_ids/is_batch columns aren't present on the live DB
+    (mixed-version operator scenario: a write path running fresh code
+    against an older T2 schema), the failure capture writes a scalar-
+    only row rather than crashing.
+
+    Bypasses ``T2Database`` because at this package version the auto-
+    migration would create the new columns immediately. Builds a raw
+    sqlite connection at the pre-4.14.1 schema and mocks ``t2_ctx``
+    to expose just the surface ``_record_batch_hook_failure`` reads
+    (``taxonomy.conn`` + ``taxonomy._lock``).
+    """
+    import threading
     import nexus.mcp_infra as mod
     from nexus.db.migrations import migrate_hook_failures
     from nexus.mcp_infra import (
@@ -334,11 +343,30 @@ def test_fire_post_store_batch_hooks_falls_back_to_scalar_when_columns_absent(
     import sqlite3
 
     db_path = tmp_path / "pre_migration.db"
-    T2Database(db_path).close()
-    conn = sqlite3.connect(str(db_path))
-    migrate_hook_failures(conn)  # but NOT migrate_hook_failures_batch_columns
-    conn.close()
-    monkeypatch.setattr(mod, "t2_ctx", lambda: T2Database(db_path))
+    raw = sqlite3.connect(str(db_path), isolation_level=None)
+    migrate_hook_failures(raw)  # only 4.9.10; NOT 4.14.1
+
+    cols = {
+        r[1] for r in raw.execute("PRAGMA table_info(hook_failures)").fetchall()
+    }
+    assert "batch_doc_ids" not in cols, (
+        "pre-condition: hook_failures must lack batch_doc_ids before the test runs"
+    )
+
+    class _FakeTaxonomy:
+        def __init__(self, conn: sqlite3.Connection) -> None:
+            self.conn = conn
+            self._lock = threading.RLock()
+
+    class _FakeT2:
+        def __init__(self, conn: sqlite3.Connection) -> None:
+            self.taxonomy = _FakeTaxonomy(conn)
+        def __enter__(self) -> "_FakeT2":
+            return self
+        def __exit__(self, *_: object) -> None:
+            return None
+
+    monkeypatch.setattr(mod, "t2_ctx", lambda: _FakeT2(raw))
 
     def raising(doc_ids, collection, contents, embeddings, metadatas):
         raise RuntimeError("kaboom")
@@ -348,17 +376,11 @@ def test_fire_post_store_batch_hooks_falls_back_to_scalar_when_columns_absent(
         ["d1", "d2"], "code__nexus", ["c1", "c2"], None, None,
     )
 
-    with T2Database(db_path) as db:
-        cols = {
-            r[1] for r in db.taxonomy.conn.execute(
-                "PRAGMA table_info(hook_failures)"
-            ).fetchall()
-        }
-        rows = db.taxonomy.conn.execute(
-            "SELECT doc_id, hook_name, error FROM hook_failures"
-        ).fetchall()
+    rows = raw.execute(
+        "SELECT doc_id, hook_name, error FROM hook_failures"
+    ).fetchall()
+    raw.close()
 
-    assert "batch_doc_ids" not in cols  # confirm the pre-migration shape
     assert len(rows) == 1
     assert rows[0][0] == "d1"
     assert rows[0][1] == "raising"


### PR DESCRIPTION
## Summary

Combines wheel-shape install, isolated `\$HOME`, and (optional) tmux Claude Code into one entry point so any change touching the deployment surface can be exercised end-to-end before merge.

## Why

Editable installs (`uv sync`) and wheel installs (`uv tool install`) resolve package data and version-gated migrations differently. Reviewers see the editable shape; users get the wheel shape. Bugs that pass pytest and ship broken usually live in that gap.

RDR-095 closure surfaced this: 5275 unit tests passed but the wheel-install MCP path was never exercised. `release-sandbox.sh smoke` catches this class in ~2 min.

## Changes

- `tests/e2e/release-sandbox.sh` (new, 218 lines) — entry point with 4 modes: `smoke`, `shell`, `tmux`, `reset`. Reuses `scripts/reinstall-tool.sh`, `tests/e2e/sandbox.sh`, and `tests/e2e/lib.sh`.
- `tests/e2e/release-sandbox.md` (new, 122 lines) — operator manual: when to run, mode reference, the /tmp rule, decide-ship-or-fix, known fresh-sandbox failures, what this does NOT catch.
- `tests/e2e/sandbox.sh` (modified) — removed the hard `ANTHROPIC_API_KEY` requirement; only needed for tmux mode now. Smoke + shell modes work without it.
- `CLAUDE.md` (modified) — adds `## Sandbox Testing` section with trigger globs and the hard rule: smoke must pass before merging anything touching install/migrations/MCP/hooks/plugin manifests/doctor/upgrade surfaces.

## Verification

`./tests/e2e/release-sandbox.sh smoke` runs end-to-end against the local install. Surfaced two documented fresh-sandbox findings:
- `OldLayoutDetected` during `nx upgrade` when `CHROMA_*` env vars point at a legacy tenant
- `--check-plan-library` reports 0 builtins until `nx catalog setup` runs

Both are expected and documented in `release-sandbox.md`.

## Closes

- Closes nexus-e1no

Companion gist: https://gist.github.com/Hellblazer/511a05e1bf79dd6ea20be962d0ca04af