### PR TITLE
feat(catalog): nx catalog remediate-paths for basename + ghost file_paths

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -1883,3 +1883,254 @@ def backfill_cmd(dry_run: bool) -> None:
     click.echo(f"  Knowledge: {knowledge_count}")
     if not dry_run:
         click.echo(f"  Hash:      {hash_updated} chunks updated")
+
+
+# ── nx catalog remediate-paths ──────────────────────────────────────────────
+
+
+# Default file extensions the remediator considers candidates. Mirrors the
+# set of types the catalog tracks: PDFs (papers / docs__), markdown (RDR /
+# docs__ prose). Code files are excluded by design — code ingest stores
+# absolute paths from a registered repo root, not loose basenames.
+_REMEDIATE_DEFAULT_EXTENSIONS: frozenset[str] = frozenset({
+    ".pdf", ".md", ".markdown",
+})
+
+
+def _build_basename_index(
+    source_dir: Path,
+    extensions: frozenset[str] | None = _REMEDIATE_DEFAULT_EXTENSIONS,
+) -> dict[str, list[Path]]:
+    """Walk *source_dir* and return ``{basename: [absolute_path, ...]}``.
+
+    Symlinks are followed; hidden directories (``.git``, ``.venv``) are
+    pruned because they don't carry curated source documents and they
+    would dominate the walk on large repos. ``extensions=None`` matches
+    every file regardless of suffix (used by ``--extensions *``).
+    """
+    import os as _os
+    index: dict[str, list[Path]] = {}
+    for root, dirs, files in _os.walk(
+        str(source_dir.resolve()), followlinks=True,
+    ):
+        # Prune hidden dirs in-place so os.walk doesn't descend into them.
+        dirs[:] = [d for d in dirs if not d.startswith(".")]
+        root_path = Path(root)
+        for fname in files:
+            if extensions is not None and Path(fname).suffix.lower() not in extensions:
+                continue
+            index.setdefault(fname, []).append(root_path / fname)
+    return index
+
+
+def _entry_needs_remediation(entry: object) -> tuple[bool, str]:
+    """Return ``(needs_fix, reason)`` for a catalog entry.
+
+    Reasons:
+    * ``"basename"`` — file_path has no slash; resolves against cwd.
+    * ``"missing"`` — file_path is absolute but does not exist on disk.
+    * ``""`` — file_path is fine.
+
+    Empty file_path entries (MCP-stored knowledge with no source file)
+    are not remediable here — they return ``(False, "no-file-path")``.
+    """
+    fp = getattr(entry, "file_path", "") or ""
+    if not fp:
+        return (False, "no-file-path")
+    if "/" not in fp:
+        return (True, "basename")
+    if not Path(fp).exists():
+        return (True, "missing")
+    return (False, "")
+
+
+def _resolve_candidate(
+    entry: object,
+    candidates: list[Path],
+    *,
+    prefer_deepest: bool = False,
+) -> tuple[Path | None, str]:
+    """Pick a single candidate path for *entry*, or ``None``.
+
+    Returns ``(path, note)`` where *note* explains the choice:
+      * ``"unique"`` — exactly one candidate
+      * ``"deepest"`` — multiple, picked the longest path
+      * ``"ambiguous"`` — multiple and no resolution strategy applied
+      * ``"none"`` — no candidates
+    """
+    if not candidates:
+        return (None, "none")
+    if len(candidates) == 1:
+        return (candidates[0], "unique")
+    if prefer_deepest:
+        return (max(candidates, key=lambda p: len(str(p))), "deepest")
+    return (None, "ambiguous")
+
+
+@catalog.command("remediate-paths")
+@click.argument(
+    "source_dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option(
+    "--dry-run", is_flag=True,
+    help="Show the transition table without writing.",
+)
+@click.option(
+    "--collection", default="",
+    help="Limit remediation to entries in this physical collection.",
+)
+@click.option(
+    "--owner", default="",
+    help="Limit remediation to entries under this owner tumbler prefix.",
+)
+@click.option(
+    "--prefer-deepest", is_flag=True,
+    help="When multiple candidates share a basename, pick the deepest path "
+         "(longest absolute path string). Default: skip ambiguous entries.",
+)
+@click.option(
+    "--mark-missing", is_flag=True,
+    help="For entries with no candidate found in SOURCE_DIR, set "
+         "meta.status='missing' so 'nx catalog gc' can sweep them.",
+)
+@click.option(
+    "--extensions", default="",
+    help="Comma-separated extensions to scan (default: .pdf,.md,.markdown). "
+         "Use '*' to scan every file regardless of extension.",
+)
+def remediate_paths_cmd(
+    source_dir: Path,
+    dry_run: bool,
+    collection: str,
+    owner: str,
+    prefer_deepest: bool,
+    mark_missing: bool,
+    extensions: str,
+) -> None:
+    """Repair catalog entries whose file_path is a basename or has gone missing.
+
+    Walks SOURCE_DIR and matches catalog entries by basename. For each
+    remediable entry, updates file_path to an absolute path under
+    SOURCE_DIR. Use this after moving PDFs from ~/Downloads into a
+    git-backed papers archive, or any time the original ingest paths
+    no longer exist on disk.
+
+    \b
+    Examples:
+      nx catalog remediate-paths ~/papers-archive --dry-run
+      nx catalog remediate-paths ~/papers --collection knowledge__hybridrag
+      nx catalog remediate-paths ~/papers --prefer-deepest --mark-missing
+
+    Strategy:
+      * Catalog entries with file_path = basename only (no slash) → look up
+        by basename, update on unique match.
+      * Catalog entries with file_path = absolute path that doesn't exist
+        on disk → same lookup; treat as moved/recovered.
+      * Multiple basename matches in SOURCE_DIR → ambiguous, skip
+        (use --prefer-deepest to break ties by path length).
+      * No basename match → leave alone, optionally mark with --mark-missing.
+
+    Idempotent: re-running on the same SOURCE_DIR is a no-op once entries
+    are resolved.
+    """
+    ext_filter: frozenset[str] | None
+    if extensions == "*":
+        ext_filter = None  # match every file
+    elif extensions:
+        ext_filter = frozenset(
+            e if e.startswith(".") else f".{e}"
+            for e in (s.strip().lower() for s in extensions.split(","))
+            if e
+        )
+    else:
+        ext_filter = _REMEDIATE_DEFAULT_EXTENSIONS
+
+    cat = _get_catalog()
+
+    click.echo(f"Scanning {source_dir.resolve()}…")
+    index = _build_basename_index(source_dir, ext_filter)
+    click.echo(f"Indexed {sum(len(v) for v in index.values())} files "
+               f"({len(index)} unique basenames).")
+
+    # Select entries to consider.
+    entries: list = []
+    if owner:
+        entries = cat.by_owner(Tumbler.parse(owner))
+    elif collection:
+        # CatalogTaxonomy doesn't expose by_physical_collection directly;
+        # walk all_documents and filter.
+        entries = [
+            e for e in cat.all_documents()
+            if e.physical_collection == collection
+        ]
+    else:
+        entries = cat.all_documents()
+
+    if not entries:
+        click.echo("No catalog entries to consider.")
+        return
+
+    # Categorise.
+    transitions: list[tuple[object, str, str, Path | None, str]] = []
+    skipped_ok = 0
+    skipped_no_file_path = 0
+    for entry in entries:
+        needs, reason = _entry_needs_remediation(entry)
+        if not needs:
+            if reason == "no-file-path":
+                skipped_no_file_path += 1
+            else:
+                skipped_ok += 1
+            continue
+        basename = Path(entry.file_path).name
+        candidates = index.get(basename, [])
+        chosen, note = _resolve_candidate(
+            entry, candidates, prefer_deepest=prefer_deepest,
+        )
+        transitions.append((entry, reason, note, chosen, basename))
+
+    # Report.
+    n_total = len(transitions)
+    n_resolved = sum(1 for _, _, _, p, _ in transitions if p is not None)
+    n_ambiguous = sum(1 for _, _, n, _, _ in transitions if n == "ambiguous")
+    n_missing = sum(1 for _, _, n, _, _ in transitions if n == "none")
+
+    click.echo(
+        f"\n{n_total} entries need remediation "
+        f"(skipped {skipped_ok} already-good, {skipped_no_file_path} no-file-path):"
+    )
+    click.echo(f"  {n_resolved:4d} resolvable")
+    click.echo(f"  {n_ambiguous:4d} ambiguous (multiple basename matches)")
+    click.echo(f"  {n_missing:4d} no candidate found in SOURCE_DIR")
+
+    if not transitions:
+        return
+
+    # Show first ~20 transitions for visibility.
+    click.echo("\nSample (first 20):")
+    for entry, why, note, chosen, basename in transitions[:20]:
+        old = entry.file_path or "(empty)"
+        new = str(chosen) if chosen else f"<{note}>"
+        click.echo(f"  [{why:8s}] {entry.tumbler}  {basename}\n    {old}\n  → {new}")
+
+    if dry_run:
+        click.echo("\n(dry-run — no catalog writes performed.)")
+        return
+
+    # Apply.
+    n_updated = 0
+    n_marked = 0
+    for entry, _why, _note, chosen, _basename in transitions:
+        if chosen is not None:
+            cat.update(entry.tumbler, file_path=str(chosen))
+            n_updated += 1
+        elif mark_missing:
+            cat.update(entry.tumbler, meta={"status": "missing"})
+            n_marked += 1
+
+    click.echo(
+        f"\nDone: updated {n_updated} file_paths"
+        + (f", marked {n_marked} as missing" if mark_missing else "")
+        + "."
+    )

--- a/tests/test_catalog_remediate_paths.py
+++ b/tests/test_catalog_remediate_paths.py
@@ -1,0 +1,391 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for ``nx catalog remediate-paths``.
+
+Two layers:
+
+  * Pure-function unit tests for the ``_build_basename_index``,
+    ``_entry_needs_remediation``, ``_resolve_candidate`` helpers.
+  * CLI integration tests that drive the full Click command against a
+    real catalog backed by tmp_path.
+
+The pure-function helpers carry the actual logic; the CLI command is a
+thin wrapper around them. Cover both so a future refactor that moves
+logic between the two surfaces still verifies the contract.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.cli import main
+from nexus.commands.catalog import (
+    _build_basename_index,
+    _entry_needs_remediation,
+    _resolve_candidate,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def git_identity(monkeypatch):
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
+
+@pytest.fixture
+def catalog_env(tmp_path, monkeypatch):
+    catalog_dir = tmp_path / "catalog"
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+    return catalog_dir
+
+
+@pytest.fixture
+def initialized_catalog(catalog_env):
+    cat = Catalog.init(catalog_env)
+    cat.register_owner("test-papers", "curator")
+    return cat
+
+
+@pytest.fixture
+def papers_dir(tmp_path: Path) -> Path:
+    """A simulated git-backed papers archive with a few files."""
+    root = tmp_path / "papers"
+    (root / "ml").mkdir(parents=True)
+    (root / "db").mkdir(parents=True)
+    (root / "ml" / "sage.pdf").write_bytes(b"%PDF-1.4 SAGE")
+    (root / "db" / "delos.pdf").write_bytes(b"%PDF-1.4 DELOS")
+    (root / "db" / "consensus.pdf").write_bytes(b"%PDF-1.4 CONSENSUS")
+    (root / "ml" / "notes.md").write_text("# notes")
+    return root
+
+
+# ── Helper: _build_basename_index ───────────────────────────────────────────
+
+
+def test_basename_index_walks_recursively(papers_dir: Path) -> None:
+    idx = _build_basename_index(papers_dir)
+    assert "sage.pdf" in idx
+    assert "delos.pdf" in idx
+    assert "consensus.pdf" in idx
+    assert "notes.md" in idx
+    assert all(len(v) == 1 for v in idx.values())
+
+
+def test_basename_index_collects_duplicates(tmp_path: Path) -> None:
+    """Two files sharing a basename in different dirs both land in the index."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "a" / "dup.pdf").write_bytes(b"A")
+    (tmp_path / "b" / "dup.pdf").write_bytes(b"B")
+    idx = _build_basename_index(tmp_path)
+    assert len(idx["dup.pdf"]) == 2
+
+
+def test_basename_index_filters_by_extension(papers_dir: Path) -> None:
+    """Default extensions filter excludes non-PDF/MD files."""
+    (papers_dir / "ignore.bin").write_bytes(b"x")
+    idx = _build_basename_index(papers_dir)
+    assert "ignore.bin" not in idx
+
+
+def test_basename_index_extensions_none_matches_all(papers_dir: Path) -> None:
+    """``extensions=None`` is the ``--extensions *`` flag — matches everything."""
+    (papers_dir / "ignore.bin").write_bytes(b"x")
+    idx = _build_basename_index(papers_dir, extensions=None)
+    assert "ignore.bin" in idx
+    assert "sage.pdf" in idx
+
+
+def test_basename_index_prunes_hidden_dirs(tmp_path: Path) -> None:
+    """``.git``, ``.venv`` etc. are pruned to keep walk fast on real repos."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "junk.pdf").write_bytes(b"x")
+    (tmp_path / "real.pdf").write_bytes(b"y")
+    idx = _build_basename_index(tmp_path)
+    assert "real.pdf" in idx
+    assert "junk.pdf" not in idx
+
+
+def test_basename_index_returns_absolute_paths(papers_dir: Path) -> None:
+    idx = _build_basename_index(papers_dir)
+    for paths in idx.values():
+        for p in paths:
+            assert p.is_absolute()
+
+
+# ── Helper: _entry_needs_remediation ───────────────────────────────────────
+
+
+class _FakeEntry:
+    """Stand-in for CatalogEntry — only file_path matters for these tests."""
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+
+
+def test_needs_remediation_detects_basename_only() -> None:
+    needs, reason = _entry_needs_remediation(_FakeEntry("paper.pdf"))
+    assert needs
+    assert reason == "basename"
+
+
+def test_needs_remediation_detects_missing_abspath(tmp_path: Path) -> None:
+    needs, reason = _entry_needs_remediation(_FakeEntry(str(tmp_path / "ghost.pdf")))
+    assert needs
+    assert reason == "missing"
+
+
+def test_needs_remediation_passes_existing_abspath(papers_dir: Path) -> None:
+    needs, reason = _entry_needs_remediation(
+        _FakeEntry(str(papers_dir / "ml" / "sage.pdf")),
+    )
+    assert not needs
+    assert reason == ""
+
+
+def test_needs_remediation_skips_empty_file_path() -> None:
+    """MCP-stored knowledge entries have file_path='' and aren't remediable."""
+    needs, reason = _entry_needs_remediation(_FakeEntry(""))
+    assert not needs
+    assert reason == "no-file-path"
+
+
+# ── Helper: _resolve_candidate ─────────────────────────────────────────────
+
+
+def test_resolve_candidate_unique() -> None:
+    chosen, note = _resolve_candidate(
+        _FakeEntry("x.pdf"), [Path("/a/x.pdf")],
+    )
+    assert chosen == Path("/a/x.pdf")
+    assert note == "unique"
+
+
+def test_resolve_candidate_none() -> None:
+    chosen, note = _resolve_candidate(_FakeEntry("x.pdf"), [])
+    assert chosen is None
+    assert note == "none"
+
+
+def test_resolve_candidate_ambiguous_default_skips() -> None:
+    chosen, note = _resolve_candidate(
+        _FakeEntry("x.pdf"),
+        [Path("/a/x.pdf"), Path("/b/x.pdf")],
+    )
+    assert chosen is None
+    assert note == "ambiguous"
+
+
+def test_resolve_candidate_prefer_deepest_picks_longest() -> None:
+    chosen, note = _resolve_candidate(
+        _FakeEntry("x.pdf"),
+        [Path("/short/x.pdf"), Path("/very/much/longer/path/x.pdf")],
+        prefer_deepest=True,
+    )
+    assert chosen == Path("/very/much/longer/path/x.pdf")
+    assert note == "deepest"
+
+
+# ── CLI integration ────────────────────────────────────────────────────────
+
+
+def _register_paper(cat: Catalog, title: str, file_path: str,
+                    physical_collection: str = "") -> str:
+    """Helper: register a paper entry with a custom file_path. Returns tumbler."""
+    from nexus.catalog.tumbler import Tumbler
+    owner_row = cat._db.execute(
+        "SELECT tumbler_prefix FROM owners WHERE name = 'test-papers'",
+    ).fetchone()
+    owner = Tumbler.parse(owner_row[0])
+    tumbler = cat.register(
+        owner=owner, title=title, content_type="paper",
+        file_path=file_path,
+        physical_collection=physical_collection,
+    )
+    return str(tumbler)
+
+
+class TestRemediatePathsCLI:
+    def test_dry_run_reports_without_writing(
+        self, initialized_catalog: Catalog, catalog_env: Path, papers_dir: Path,
+    ) -> None:
+        """--dry-run shows the transition table and writes nothing."""
+        tumbler = _register_paper(initialized_catalog, "SAGE", "sage.pdf")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir), "--dry-run",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "1 entries need remediation" in result.output
+        assert "1 resolvable" in result.output
+        assert "dry-run" in result.output.lower()
+
+        # Confirm the catalog is unchanged
+        from nexus.catalog.tumbler import Tumbler
+        entry = initialized_catalog.resolve(Tumbler.parse(tumbler))
+        assert entry.file_path == "sage.pdf"  # unchanged
+
+    def test_resolves_basename_to_absolute(
+        self, initialized_catalog: Catalog, catalog_env: Path, papers_dir: Path,
+    ) -> None:
+        """A basename file_path is updated to the matching absolute path."""
+        tumbler = _register_paper(initialized_catalog, "SAGE", "sage.pdf")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir),
+        ])
+        assert result.exit_code == 0, result.output
+
+        from nexus.catalog.tumbler import Tumbler
+        # Re-open the catalog so we read the freshly-written JSONL state.
+        cat2 = Catalog(catalog_env, catalog_env / ".catalog.db")
+        entry = cat2.resolve(Tumbler.parse(tumbler))
+        expected = (papers_dir / "ml" / "sage.pdf").resolve()
+        assert entry.file_path == str(expected)
+
+    def test_skips_already_good_entries(
+        self, initialized_catalog: Catalog, catalog_env: Path, papers_dir: Path,
+    ) -> None:
+        """Entries with a valid abspath are not touched."""
+        good_path = str((papers_dir / "ml" / "sage.pdf").resolve())
+        _register_paper(initialized_catalog, "SAGE", good_path)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir),
+        ])
+        assert result.exit_code == 0, result.output
+        assert "0 entries need remediation" in result.output
+        assert "skipped 1 already-good" in result.output
+
+    def test_ambiguous_entry_skipped_by_default(
+        self, initialized_catalog: Catalog, catalog_env: Path, tmp_path: Path,
+    ) -> None:
+        """Two basename matches → entry is skipped (no update) by default."""
+        src = tmp_path / "src"
+        (src / "a").mkdir(parents=True)
+        (src / "b").mkdir(parents=True)
+        (src / "a" / "dup.pdf").write_bytes(b"A")
+        (src / "b" / "dup.pdf").write_bytes(b"B")
+
+        tumbler = _register_paper(initialized_catalog, "Dup", "dup.pdf")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(src),
+        ])
+        assert result.exit_code == 0, result.output
+        assert "1 ambiguous" in result.output
+
+        from nexus.catalog.tumbler import Tumbler
+        cat2 = Catalog(catalog_env, catalog_env / ".catalog.db")
+        entry = cat2.resolve(Tumbler.parse(tumbler))
+        assert entry.file_path == "dup.pdf"  # unchanged
+
+    def test_prefer_deepest_breaks_ambiguity(
+        self, initialized_catalog: Catalog, catalog_env: Path, tmp_path: Path,
+    ) -> None:
+        src = tmp_path / "src"
+        (src / "shallow").mkdir(parents=True)
+        (src / "very" / "deep" / "nested").mkdir(parents=True)
+        (src / "shallow" / "dup.pdf").write_bytes(b"A")
+        (src / "very" / "deep" / "nested" / "dup.pdf").write_bytes(b"B")
+
+        tumbler = _register_paper(initialized_catalog, "Dup", "dup.pdf")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(src), "--prefer-deepest",
+        ])
+        assert result.exit_code == 0, result.output
+
+        from nexus.catalog.tumbler import Tumbler
+        cat2 = Catalog(catalog_env, catalog_env / ".catalog.db")
+        entry = cat2.resolve(Tumbler.parse(tumbler))
+        assert "very/deep/nested" in entry.file_path
+
+    def test_no_candidate_leaves_alone_by_default(
+        self, initialized_catalog: Catalog, catalog_env: Path, papers_dir: Path,
+    ) -> None:
+        """Entries with no matching basename in SOURCE_DIR are untouched."""
+        tumbler = _register_paper(initialized_catalog, "Lost", "missing.pdf")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir),
+        ])
+        assert result.exit_code == 0, result.output
+        assert "1 no candidate found" in result.output
+
+        from nexus.catalog.tumbler import Tumbler
+        cat2 = Catalog(catalog_env, catalog_env / ".catalog.db")
+        entry = cat2.resolve(Tumbler.parse(tumbler))
+        assert entry.file_path == "missing.pdf"
+        assert entry.meta.get("status") != "missing"
+
+    def test_mark_missing_tags_unrecoverable_entries(
+        self, initialized_catalog: Catalog, catalog_env: Path, papers_dir: Path,
+    ) -> None:
+        tumbler = _register_paper(initialized_catalog, "Lost", "missing.pdf")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir), "--mark-missing",
+        ])
+        assert result.exit_code == 0, result.output
+
+        from nexus.catalog.tumbler import Tumbler
+        cat2 = Catalog(catalog_env, catalog_env / ".catalog.db")
+        entry = cat2.resolve(Tumbler.parse(tumbler))
+        assert entry.meta.get("status") == "missing"
+
+    def test_collection_filter_scopes_to_one_collection(
+        self, initialized_catalog: Catalog, catalog_env: Path, papers_dir: Path,
+    ) -> None:
+        """--collection limits remediation to one physical_collection."""
+        from nexus.catalog.tumbler import Tumbler
+        t1 = Tumbler.parse(_register_paper(
+            initialized_catalog, "SAGE", "sage.pdf",
+            physical_collection="knowledge__a",
+        ))
+        t2 = Tumbler.parse(_register_paper(
+            initialized_catalog, "DELOS", "delos.pdf",
+            physical_collection="knowledge__b",
+        ))
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir),
+            "--collection", "knowledge__a",
+        ])
+        assert result.exit_code == 0, result.output
+
+        cat2 = Catalog(catalog_env, catalog_env / ".catalog.db")
+        # SAGE was scoped in → updated to abspath.
+        sage = cat2.resolve(t1)
+        assert sage.file_path.endswith("sage.pdf")
+        assert "/" in sage.file_path
+        # DELOS was out of scope → still basename.
+        delos = cat2.resolve(t2)
+        assert delos.file_path == "delos.pdf"
+
+    def test_idempotent(
+        self, initialized_catalog: Catalog, catalog_env: Path, papers_dir: Path,
+    ) -> None:
+        """Running twice is a no-op the second time."""
+        _register_paper(initialized_catalog, "SAGE", "sage.pdf")
+        runner = CliRunner()
+        runner.invoke(main, ["catalog", "remediate-paths", str(papers_dir)])
+        result2 = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir),
+        ])
+        assert result2.exit_code == 0, result2.output
+        assert "0 entries need remediation" in result2.output


### PR DESCRIPTION
## Summary

- New ``nx catalog remediate-paths <SOURCE_DIR>`` command for repairing catalog entries whose ``file_path`` is a basename or points to a no-longer-existing path. Walks SOURCE_DIR (default extensions: .pdf, .md, .markdown), builds a basename index, and updates each broken entry to the matching absolute path under SOURCE_DIR.
- Workflow: user moves loose ingested papers from ``~/Downloads`` into a git-backed papers archive, points the command at the archive root, gets every catalog entry's ``file_path`` repaired in one pass.
- Idempotent. Dry-run mode prints the transition table without writing.
- Options: ``--dry-run``, ``--collection``, ``--owner``, ``--prefer-deepest`` (break ambiguity by picking longest path), ``--mark-missing`` (tag unrecoverable entries with ``meta.status="missing"`` for ``nx catalog gc``), ``--extensions`` (override default set or ``*`` for everything).

Verified end-to-end on the live nexus catalog: correctly identifies the SAGE basename entry (1.653.77) for repair to its abspath under ``~/Downloads/arxiv-papers`` and flags the orphan 2408.04948 entry as no-candidate.

## Test plan

- [x] ``uv run pytest tests/test_catalog_remediate_paths.py -q`` (23 passed)
- [x] ``uv run pytest tests/test_catalog_*.py -q`` (138 passed across the catalog suite)
- [x] Live dry-run on production catalog: ``nx catalog remediate-paths ~/Downloads/arxiv-papers --dry-run --collection knowledge__hybridrag`` correctly classifies the three real-world cases (resolvable, no-candidate, no-file-path).

## Out of scope (follow-up)

- T3-side metadata backfill (source_title -> title migration, section_type re-derivation from chunk text on already-indexed chunks). Documented in ``docs/metadata-consistency-matrix.md`` from #324.
- chash-strategy disambiguation (when two basenames match, hash candidate files and pick the one matching the catalog entry's ``content_hash``). Designed but not implemented; useful when ``--prefer-deepest`` is too coarse.