### PR TITLE
docs(readme): point at Post 0 + Post 00; update featured image

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/conexus)](https://pypi.org/project/conexus/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-<a href="https://i0.wp.com/tensegrity.blog/wp-content/uploads/2026/04/tensegrity-69e5247d907e5.png?w=1024&ssl=1">
-  <img src="https://i0.wp.com/tensegrity.blog/wp-content/uploads/2026/04/tensegrity-69e5247d907e5.png?w=480&ssl=1" alt="The steam-driven semantic engine, illustration from the Nexus by Example blog post" align="right" width="320" />
+<a href="https://i0.wp.com/tensegrity.blog/wp-content/uploads/2026/04/a-stately-pleasure-dome.png?w=1024&ssl=1">
+  <img src="https://i0.wp.com/tensegrity.blog/wp-content/uploads/2026/04/a-stately-pleasure-dome.png?w=480&ssl=1" alt="A brass-ribbed crystal dome on a hilltop at dusk, the establishing shot for the Tensegrity blog series on Nexus" align="right" width="320" />
 </a>
 
 Nexus is a lightweight knowledge management system for AI coding agents. It provides persistent memory and semantic search through tiered storage that preserves decisions, findings, and project knowledge across agent sessions. That knowledge compounds over time, becoming more valuable as the corpus grows.
 
 Nexus includes RDR (Research-Design-Review), an integrated human-AI design and audit system. RDRs capture the reasoning behind technical decisions (problem, research, chosen approach, rejected alternatives) as structured, searchable documents that live in the repository alongside the code. Nexus indexes the RDR corpus so team members and their agents can quickly get up to speed on a project's design history and stay aligned as the codebase evolves.
 
-> **New to Nexus?** Read [**Nexus by Example**](https://tensegrity.blog/2026/04/19/nexus-by-example/) on the Tensegrity blog: a guided walkthrough of how the pieces fit together in practice.
+> **New to Nexus?** Start on the Tensegrity blog: [**How I actually use Nexus**](https://tensegrity.blog/2026/04/26/how-i-actually-use-nexus/) is the conceptual overview, and [**Installing Nexus**](https://tensegrity.blog/2026/04/26/installing-nexus/) is the ten-minute install walkthrough. After that, [**Nexus by Example**](https://tensegrity.blog/2026/04/19/nexus-by-example/) shows the pieces fitting together in practice.
 
 ## What it does
 
@@ -164,6 +164,8 @@ Full details: [CLI Reference](https://github.com/Hellblazer/nexus/blob/main/docs
 | [Configuration](https://github.com/Hellblazer/nexus/blob/main/docs/configuration.md) | Config hierarchy, .nexus.yml, tuning parameters |
 | [Architecture](https://github.com/Hellblazer/nexus/blob/main/docs/architecture.md) | Module map, design decisions |
 | [Contributing](https://github.com/Hellblazer/nexus/blob/main/docs/contributing.md) | Dev setup, testing, code style |
+| [How I actually use Nexus](https://tensegrity.blog/2026/04/26/how-i-actually-use-nexus/) | Blog overview: the substrate as a control surface for developers, teams, and agents |
+| [Installing Nexus](https://tensegrity.blog/2026/04/26/installing-nexus/) | Blog install walkthrough: prerequisites, CLI, plugin, short tour |
 | [Nexus by Example](https://tensegrity.blog/2026/04/19/nexus-by-example/) | Blog walkthrough of the steam-driven semantic engine in practice |
 
 **RDR (Research-Design-Review):**


### PR DESCRIPTION
## Summary
- Lead the "New to Nexus?" callout with [Post 0 — *How I actually use Nexus*](https://tensegrity.blog/2026/04/26/how-i-actually-use-nexus/) (the conceptual overview) and [Post 00 — *Installing Nexus*](https://tensegrity.blog/2026/04/26/installing-nexus/) (the ten-minute install walkthrough), keeping Post 1 (*Nexus by Example*) as the practice walkthrough that follows.
- Swap the README header image to `a-stately-pleasure-dome.png` — the establishing shot for the Tensegrity blog series and Post 0's featured image — replacing the Post 1 illustration.
- Add rows for Post 0 and Post 00 to the Documentation table above the existing Post 1 row.

## Test plan
- [x] Verified slugs against `wp post list` on tensegrity.blog (`installing-nexus`, `how-i-actually-use-nexus`, both published 2026-04-26).
- [x] No em dashes in the diff (`grep '—' README.md` empty).
- [x] Image URL resolves on i0.wp.com (CDN cache of `a-stately-pleasure-dome.png`).