### PR TITLE
fix(#336): raise CredentialsMissingError instead of silent return-0

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -512,7 +512,17 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
 
     from nexus.config import get_pdf_extractor
     from nexus.corpus import t3_collection_name
-    from nexus.doc_indexer import index_pdf
+    from nexus.doc_indexer import index_pdf as _index_pdf_raw
+    from nexus.errors import CredentialsMissingError
+
+    # Local wrapper: convert the typed credential error into a Click
+    # exception so the CLI shows a friendly message + exits non-zero
+    # rather than dumping a Python traceback to stderr (GH #336).
+    def index_pdf(*args, **kwargs):
+        try:
+            return _index_pdf_raw(*args, **kwargs)
+        except CredentialsMissingError as e:
+            raise click.ClickException(str(e)) from e
 
     if path is not None and dir_path is not None:
         raise click.UsageError("PATH and --dir are mutually exclusive.")
@@ -730,26 +740,32 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
 def index_md_cmd(path: Path, corpus: str, force: bool, monitor: bool) -> None:
     """Extract and index a Markdown file into T3 docs__CORPUS."""
     from nexus.doc_indexer import index_markdown
+    from nexus.errors import CredentialsMissingError
 
     path = path.resolve()
     label = "Force re-indexing" if force else "Indexing"
     click.echo(f"{label} {path}…")
-    if monitor or not sys.stdout.isatty():
-        chunk_bar = tqdm(total=0, desc="Embedding", unit="chunk", disable=None)
+    try:
+        if monitor or not sys.stdout.isatty():
+            chunk_bar = tqdm(total=0, desc="Embedding", unit="chunk", disable=None)
 
-        def on_chunk_progress(current: int, total: int) -> None:
-            chunk_bar.total = total
-            chunk_bar.n = current
-            chunk_bar.refresh()
+            def on_chunk_progress(current: int, total: int) -> None:
+                chunk_bar.total = total
+                chunk_bar.n = current
+                chunk_bar.refresh()
 
-        meta = index_markdown(path, corpus=corpus, force=force, return_metadata=True,
-                              on_progress=on_chunk_progress)
-        chunk_bar.close()
-        n = meta["chunks"]  # type: ignore[index]
-        sections = meta.get("sections", 0)  # type: ignore[union-attr]
-        click.echo(f"\n  Chunks: {n}  Sections: {sections}")
-    else:
-        n = index_markdown(path, corpus=corpus, force=force)
+            meta = index_markdown(path, corpus=corpus, force=force, return_metadata=True,
+                                  on_progress=on_chunk_progress)
+            chunk_bar.close()
+            n = meta["chunks"]  # type: ignore[index]
+            sections = meta.get("sections", 0)  # type: ignore[union-attr]
+            click.echo(f"\n  Chunks: {n}  Sections: {sections}")
+        else:
+            n = index_markdown(path, corpus=corpus, force=force)
+    except CredentialsMissingError as exc:
+        # GH #336: surface the silent failure visibly. Click maps
+        # ClickException to stderr + non-zero exit.
+        raise click.ClickException(str(exc)) from exc
     result_label = "Force re-indexed" if force else "Indexed"
     click.echo(f"{result_label} {n} chunk(s).")
 

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -55,6 +55,22 @@ def _has_credentials() -> bool:
     return bool(get_credential("voyage_api_key") and get_credential("chroma_api_key"))
 
 
+def _missing_credentials() -> list[str]:
+    """Return the list of unset Voyage / Chroma credentials.
+
+    Used to construct precise error messages — callers can tell the
+    user EXACTLY which key is missing rather than the generic
+    "credentials not configured" form. Empty list means both are set.
+    """
+    from nexus.config import get_credential
+    missing: list[str] = []
+    if not get_credential("voyage_api_key"):
+        missing.append("voyage_api_key")
+    if not get_credential("chroma_api_key"):
+        missing.append("chroma_api_key")
+    return missing
+
+
 _CCE_TOKEN_LIMIT = 24_000  # 75% of Voyage's 32K to account for token estimation error
 _CCE_TOTAL_TOKEN_LIMIT = 120_000  # Voyage API total token limit across all inputs
 # Note: per-batch limit of 32K means we never hit 120K in a single call
@@ -318,7 +334,21 @@ def _index_document(
     relative ``source_path`` stored in chunk metadata (RDR-060).
     """
     if embed_fn is None and not _has_credentials():
-        return 0
+        # GH #336: silent ``return 0`` here was the worst-of-all-worlds —
+        # the CLI reported "Indexed 0 chunks" with exit code 0, looking
+        # like a no-op success. Raise a precise error naming the missing
+        # credential(s); the CLI handlers in ``commands/index.py`` catch
+        # and format for the operator.
+        from nexus.errors import CredentialsMissingError  # noqa: PLC0415
+
+        missing = _missing_credentials()
+        raise CredentialsMissingError(
+            f"cannot index without {', '.join(missing)}. "
+            f"Set via 'nx config set <key> <value>' or the corresponding "
+            f"environment variable. Local-mode T3 reads work without these "
+            f"keys (see 'nx doctor'); ingestion does NOT — it currently "
+            f"requires Voyage embeddings + ChromaDB Cloud auth."
+        )
 
     # Normalize to absolute so staleness checks are path-form-independent.
     file_path = file_path.resolve()
@@ -768,7 +798,17 @@ def index_pdf(
 
     _empty_meta = {"chunks": 0, "pages": [], "title": "", "author": ""}
     if embed_fn is None and not _has_credentials():
-        return _empty_meta if return_metadata else 0
+        # GH #336 mirror: PDF ingestion had the same silent-return-0 bug.
+        from nexus.errors import CredentialsMissingError  # noqa: PLC0415
+
+        missing = _missing_credentials()
+        raise CredentialsMissingError(
+            f"cannot index without {', '.join(missing)}. "
+            f"Set via 'nx config set <key> <value>' or the corresponding "
+            f"environment variable. Local-mode T3 reads work without these "
+            f"keys (see 'nx doctor'); ingestion does NOT — it currently "
+            f"requires Voyage embeddings + ChromaDB Cloud auth."
+        )
 
     # Normalize to absolute so staleness checks are path-form-independent.
     pdf_path = pdf_path.resolve()

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -153,15 +153,37 @@ def voyage_client():
     ("pdf", "sample_pdf"),
     ("markdown", "sample_md"),
 ])
-def test_index_skips_without_credentials(indexer, fixture_name, sample_pdf, sample_md, monkeypatch):
+def test_index_raises_credentials_missing_when_unset(
+    indexer, fixture_name, sample_pdf, sample_md, monkeypatch,
+):
+    """GH #336: raise ``CredentialsMissingError`` instead of silently
+    returning 0. The prior silent-return-0 behavior reported "Indexed
+    0 chunks" with exit code 0 — indistinguishable from a no-op
+    success and the worst-of-all-worlds for operator triage. The
+    typed exception flows up to the CLI handlers, which translate it
+    to a ``ClickException`` (visible message + non-zero exit).
+    """
+    from nexus.errors import CredentialsMissingError
+
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+    # Also point the config-file reader at an empty path so the
+    # ``~/.config/nexus/config.yml`` fallback can't surface a key
+    # outside of the test's monkeypatch scope.
+    monkeypatch.setattr(
+        "nexus.config._global_config_path", lambda: Path("/nonexistent"),
+    )
     path = sample_pdf if indexer == "pdf" else sample_md
     fn = index_pdf if indexer == "pdf" else index_markdown
     with patch("nexus.doc_indexer.make_t3") as mock_factory:
-        result = fn(path, corpus="test")
-    assert result == 0
+        with pytest.raises(CredentialsMissingError) as excinfo:
+            fn(path, corpus="test")
+    # Make sure t3 client init was NOT attempted — we should fail
+    # fast at the credential check, not after constructing the client.
     mock_factory.assert_not_called()
+    # Operator-readable detail names the missing key(s).
+    assert "voyage_api_key" in str(excinfo.value)
+    assert "chroma_api_key" in str(excinfo.value)
 
 
 def test_index_pdf_skips_if_hash_unchanged(sample_pdf, monkeypatch):

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -114,6 +114,39 @@ def test_index_nonexistent_path_fails(runner, home, subcmd, ext):
     assert result.exit_code != 0
 
 
+@pytest.mark.parametrize("subcmd,fixture", [
+    ("pdf", "fake_pdf"),
+    ("md", "fake_md"),
+])
+def test_index_credentials_missing_exits_nonzero_with_message(
+    runner, request, subcmd, fixture, monkeypatch,
+):
+    """GH #336: when voyage_api_key / chroma_api_key are unset, the
+    indexer raises ``CredentialsMissingError`` instead of silently
+    returning 0. The CLI handler converts it to a ``ClickException``
+    so the operator sees a clear message + non-zero exit.
+    """
+    from nexus.errors import CredentialsMissingError
+
+    fixture_path = request.getfixturevalue(fixture)
+    fn_name = "index_pdf" if subcmd == "pdf" else "index_markdown"
+
+    # Make the indexer raise as if credentials were missing.
+    def _raise(*args, **kwargs):
+        raise CredentialsMissingError(
+            "cannot index without voyage_api_key, chroma_api_key. "
+            "Set via 'nx config set <key> <value>' ..."
+        )
+
+    with patch(f"nexus.doc_indexer.{fn_name}", side_effect=_raise):
+        result = runner.invoke(main, ["index", subcmd, str(fixture_path)])
+
+    assert result.exit_code != 0, result.output
+    # Click's ClickException prints the message to stdout in CliRunner.
+    assert "voyage_api_key" in result.output
+    assert "Set via" in result.output or "config set" in result.output
+
+
 # ── --frecency-only flag ─────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("flag,expected", [


### PR DESCRIPTION
## Closes

Closes #336

## Summary

Replaces the silent ``return 0`` in ``nexus.doc_indexer._index_document`` (line 320) and ``index_pdf`` (line 800) with a typed ``CredentialsMissingError`` naming the missing credential. The CLI handlers in ``commands/index.py`` for ``nx index md`` and ``nx index pdf`` catch and translate to ``click.ClickException`` — operator-readable message + non-zero exit.

This is the cheapest of the three options proposed in #336. The other two (``nx doctor`` flagging + local-embedder fallback) are higher-scope follow-ups left for a separate change.

## Before

\`\`\`bash
$ nx index md /tmp/test.md --corpus test
Indexing /private/tmp/test.md…
  Chunks: 0  Sections: 0
Indexed 0 chunk(s).
$ echo \$?
0
\`\`\`

## After

\`\`\`bash
$ nx index md /tmp/test.md --corpus test
Indexing /private/tmp/test.md…
Error: cannot index without voyage_api_key, chroma_api_key.
Set via 'nx config set <key> <value>' or the corresponding environment
variable. Local-mode T3 reads work without these keys (see 'nx doctor');
ingestion does NOT — it currently requires Voyage embeddings + ChromaDB
Cloud auth.
$ echo \$?
1
\`\`\`

## Tests

- ``test_index_raises_credentials_missing_when_unset`` (renamed from the prior ``test_index_skips_without_credentials``): pins the new exception-based contract on both ``index_pdf`` and ``index_markdown``; verifies T3 init is NOT attempted (fast-fail at the credential check) and that both missing credential names appear in the error message.
- ``test_index_credentials_missing_exits_nonzero_with_message`` (new): CLI integration test parametrized over ``(md, pdf)`` — verifies the ``ClickException`` → non-zero exit with the credential name in the message.
- Total: 133 tests across the affected suites green.

## Test plan

- [x] ``uv run pytest tests/test_doc_indexer.py tests/test_index_cmd.py`` — 133 passed
- [x] Live reproducer: env ``VOYAGE_API_KEY=""`` + config-file fallback patched away → exit code 1 with the 4-line clarifying message above

## What's NOT in this PR

- ``nx doctor`` flagging the missing voyage_api_key when prose/PDF indexing is reachable (#336 suggestion 2).
- Falling back to the local ONNX embedder that ``store_put`` already uses (#336 suggestion 3). Worth doing — the local embedder is right there — but it's a behavior change that warrants its own scope.

Bead ``nexus-f3b7``.