### PR TITLE
feat(nexus-bqda,nexus-srck): x-devonthink-item URI scheme + DT-aware remediate-paths

### DIFF
--- a/src/nexus/aspect_readers.py
+++ b/src/nexus/aspect_readers.py
@@ -13,6 +13,11 @@ Initial schemes (Phase 1):
 * ``file:///abs/path/to/file.md`` — disk read.
 * ``chroma://<collection>/<source-identifier>`` — chunk reassembly
   from T3 by metadata-field match.
+* ``x-devonthink-item://<UUID>`` — macOS-only, resolves the UUID to
+  a current filesystem path via the DEVONthink AppleScript bridge
+  (osascript) and reads the file. Lets DT-managed PDFs survive
+  relocations inside DT's database without breaking catalog URIs
+  (nexus-bqda).
 
 Knowledge collections (``knowledge__*``) identify documents by metadata
 field ``title`` (slug); ``nx index``-ingested collections
@@ -498,6 +503,122 @@ def _read_https_uri(
     )
 
 
+# ── x-devonthink-item:// reader (nexus-bqda) ─────────────────────────────────
+
+
+def _devonthink_resolver_default(uuid: str) -> tuple[str | None, str]:
+    """Resolve a DEVONthink record UUID to a filesystem path via osascript.
+
+    Returns ``(path, error_detail)``. On success ``path`` is the absolute
+    path reported by DEVONthink and ``error_detail`` is ``""``. On failure
+    ``path`` is ``None`` and ``error_detail`` describes the cause
+    (osascript not present, timeout, missing record, non-zero exit).
+
+    DEVONthink registers as application id ``DNtp`` so the script works
+    against any installed edition (DT 3 / DT Pro / DT Server). The
+    sentinel ``__NX_DT_MISSING__`` distinguishes "record not found" from
+    a literal empty path.
+    """
+    import subprocess  # noqa: PLC0415
+    script = (
+        'tell application id "DNtp"\n'
+        f'  set theItem to get record with uuid "{uuid}"\n'
+        '  if theItem is missing value then\n'
+        '    return "__NX_DT_MISSING__"\n'
+        '  else\n'
+        '    return path of theItem\n'
+        '  end if\n'
+        'end tell'
+    )
+    try:
+        proc = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True, text=True, timeout=10,
+        )
+    except FileNotFoundError:
+        return None, "osascript not found (macOS-only)"
+    except subprocess.TimeoutExpired:
+        return None, "osascript timed out resolving DEVONthink UUID"
+    except OSError as e:
+        return None, f"osascript failed: {type(e).__name__}: {e}"
+    if proc.returncode != 0:
+        return None, (
+            f"osascript rc={proc.returncode}: {proc.stderr.strip() or '(no stderr)'}"
+        )
+    path = proc.stdout.strip()
+    if not path or path == "__NX_DT_MISSING__":
+        return None, f"DEVONthink record {uuid!r} not found"
+    return path, ""
+
+
+def _read_devonthink_uri(
+    uri: str,
+    *,
+    dt_resolver: Callable[[str], tuple[str | None, str]] | None = None,
+    **_kw: Any,
+) -> ReadResult:
+    """Read an ``x-devonthink-item://<UUID>`` URI.
+
+    Resolves the UUID via DEVONthink (macOS app, registered as ``DNtp``)
+    using osascript, then reads the file at the resolved path. macOS-only;
+    on other platforms returns a clear ``ReadFail`` so callers don't have
+    to special-case the platform check themselves.
+
+    The ``dt_resolver`` keyword exists so tests can drive the reader
+    without launching osascript; production calls fall through to
+    :func:`_devonthink_resolver_default`.
+    """
+    import sys  # noqa: PLC0415
+
+    if dt_resolver is None:
+        if sys.platform != "darwin":
+            return ReadFail(
+                reason="unreachable",
+                detail="DEVONthink integration is macOS-only",
+            )
+        dt_resolver = _devonthink_resolver_default
+
+    parsed = urlparse(uri)
+    # ``urlparse`` puts the UUID in netloc when ``://`` is present;
+    # tolerate the path shape too in case a writer ever emits
+    # ``x-devonthink-item:UUID`` without the double slash.
+    uuid = parsed.netloc or parsed.path.lstrip("/")
+    if not uuid:
+        return ReadFail(
+            reason="unreachable",
+            detail=f"empty UUID in DEVONthink URI {uri!r}",
+        )
+
+    path, error_detail = dt_resolver(uuid)
+    if path is None:
+        return ReadFail(
+            reason="unreachable",
+            detail=error_detail or "DEVONthink resolver returned no path",
+        )
+
+    try:
+        with open(path, "rb") as fh:
+            data = fh.read()
+    except FileNotFoundError as e:
+        return ReadFail(reason="unreachable", detail=f"FileNotFoundError: {e}")
+    except PermissionError as e:
+        return ReadFail(reason="unauthorized", detail=f"PermissionError: {e}")
+    except OSError as e:
+        return ReadFail(reason="unreachable", detail=f"{type(e).__name__}: {e}")
+    if not data:
+        return ReadFail(reason="empty", detail=f"empty file at {path!r}")
+    text = data.decode("utf-8", errors="replace")
+    return ReadOk(
+        text=text,
+        metadata={
+            "scheme": "x-devonthink-item",
+            "uuid": uuid,
+            "resolved_path": path,
+            "bytes": len(data),
+        },
+    )
+
+
 # ── Reader registry + dispatch helper ────────────────────────────────────────
 
 
@@ -506,6 +627,7 @@ _READERS: dict[str, Callable[..., ReadResult]] = {
     "chroma": _read_chroma_uri,
     "nx-scratch": _read_scratch_uri,
     "https": _read_https_uri,
+    "x-devonthink-item": _read_devonthink_uri,
 }
 
 

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -222,9 +222,13 @@ def reset_chash_fallback_warning_for_tests() -> None:
 # (RDR-096); ``https`` and ``nx-scratch`` are reserved for Phase 4.
 # ``http`` is intentionally excluded — Phase 4's https reader does
 # NOT cover plain http; users with http URIs must upgrade to https
-# or wait for a dedicated reader.
+# or wait for a dedicated reader. ``x-devonthink-item`` (nexus-bqda)
+# is macOS-only — DEVONthink-managed PDFs carry a stable identity
+# URL that resolves to the current filesystem path via osascript;
+# the reader gates on ``sys.platform == 'darwin'`` and surfaces a
+# clear error elsewhere.
 _KNOWN_URI_SCHEMES: frozenset[str] = frozenset({
-    "file", "chroma", "https", "nx-scratch",
+    "file", "chroma", "https", "nx-scratch", "x-devonthink-item",
 })
 
 

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -437,8 +437,9 @@ def search_cmd(query: str, limit: int, offset: int, as_json: bool) -> None:
     help=(
         "Persistent URI identity (RDR-096 P3.1). Omit to derive "
         "'file://<abspath>' from --file-path automatically. Pass an "
-        "explicit URI (chroma://, https://, nx-scratch://) to store "
-        "verbatim. Malformed URIs are rejected at register-time."
+        "explicit URI (chroma://, https://, nx-scratch://, "
+        "x-devonthink-item://) to store verbatim. Malformed URIs "
+        "are rejected at register-time."
     ),
 )
 @click.option("--corpus", default="")
@@ -1961,6 +1962,39 @@ def _entry_needs_remediation(entry: object) -> tuple[bool, str]:
     return (False, "")
 
 
+def _resolve_via_devonthink(entry: object) -> Path | None:
+    """If ``entry.meta`` carries a ``devonthink_uri``, ask DEVONthink for
+    the current filesystem path and return it when the file exists on
+    disk. Returns ``None`` when no DT URI is recorded, when the platform
+    isn't macOS, when osascript fails, or when DT reports a path that
+    doesn't actually exist (a sign the resolver returned a stale cache).
+
+    This is the companion path to making ``x-devonthink-item://`` a
+    canonical source URI (nexus-bqda): even with a ``file://`` source URI
+    we can still recover from DT relocations using the meta we already
+    record on entries that came in via DEVONthink.
+    """
+    import sys  # noqa: PLC0415
+
+    if sys.platform != "darwin":
+        return None
+    meta = getattr(entry, "meta", {}) or {}
+    dt_uri = meta.get("devonthink_uri", "") if isinstance(meta, dict) else ""
+    if not dt_uri or not dt_uri.startswith("x-devonthink-item://"):
+        return None
+    uuid = dt_uri[len("x-devonthink-item://"):]
+    if not uuid:
+        return None
+    from nexus.aspect_readers import _devonthink_resolver_default  # noqa: PLC0415
+    path, _detail = _devonthink_resolver_default(uuid)
+    if path is None:
+        return None
+    p = Path(path)
+    if not p.exists():
+        return None
+    return p
+
+
 def _resolve_candidate(
     entry: object,
     candidates: list[Path],
@@ -2092,6 +2126,7 @@ def remediate_paths_cmd(
     transitions: list[tuple[object, str, str, Path | None, str]] = []
     skipped_ok = 0
     skipped_no_file_path = 0
+    n_devonthink = 0
     for entry in entries:
         needs, reason = _entry_needs_remediation(entry)
         if not needs:
@@ -2101,6 +2136,16 @@ def remediate_paths_cmd(
                 skipped_ok += 1
             continue
         basename = Path(entry.file_path).name
+        # nexus-srck: try DEVONthink resolution before basename scan.
+        # When meta carries devonthink_uri and DT reports an existing
+        # path, that's authoritative — no point ranking basename matches
+        # against a SOURCE_DIR walk that wouldn't include DT's
+        # Files.noindex tree anyway.
+        dt_path = _resolve_via_devonthink(entry)
+        if dt_path is not None:
+            n_devonthink += 1
+            transitions.append((entry, reason, "devonthink", dt_path, basename))
+            continue
         candidates = index.get(basename, [])
         chosen, note = _resolve_candidate(
             entry, candidates, prefer_deepest=prefer_deepest,
@@ -2118,6 +2163,8 @@ def remediate_paths_cmd(
         f"(skipped {skipped_ok} already-good, {skipped_no_file_path} no-file-path):"
     )
     click.echo(f"  {n_resolved:4d} resolvable")
+    if n_devonthink:
+        click.echo(f"    of which {n_devonthink:4d} via DEVONthink")
     click.echo(f"  {n_ambiguous:4d} ambiguous (multiple basename matches)")
     click.echo(f"  {n_missing:4d} no candidate found in SOURCE_DIR")
 

--- a/tests/test_aspect_readers.py
+++ b/tests/test_aspect_readers.py
@@ -884,3 +884,171 @@ class TestReadSourceDispatch:
         result = read_source("/just/a/path")
         assert isinstance(result, ReadFail)
         assert result.reason == "scheme_unknown"
+
+    def test_devonthink_scheme_dispatches_to_dt_reader(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        """``x-devonthink-item://`` URIs must reach the DT reader via
+        the registry. We can't drive osascript in tests, so we go
+        through the registry-aware ``read_source`` *and* monkeypatch
+        the default resolver so the reader's macOS gate doesn't reject
+        the call on Linux/Windows CI workers.
+        """
+        from nexus.aspect_readers import ReadOk, read_source
+
+        target = tmp_path / "dispatch.pdf"
+        target.write_bytes(b"%PDF-1.4 dispatched")
+
+        def fake_resolver(uuid: str) -> tuple[str | None, str]:
+            assert uuid == "DISPATCH-UUID"
+            return str(target), ""
+
+        monkeypatch.setattr(
+            "nexus.aspect_readers._devonthink_resolver_default",
+            fake_resolver,
+        )
+        # ``read_source`` doesn't pass dt_resolver — it must fall through
+        # to the patched default. We also patch sys.platform so the
+        # reader's macOS gate accepts the call on non-darwin runners.
+        monkeypatch.setattr("sys.platform", "darwin")
+
+        result = read_source("x-devonthink-item://DISPATCH-UUID")
+        assert isinstance(result, ReadOk)
+        assert result.metadata["scheme"] == "x-devonthink-item"
+        assert result.metadata["uuid"] == "DISPATCH-UUID"
+
+
+# ── x-devonthink-item:// reader (nexus-bqda) ────────────────────────────────
+
+
+class TestReadDevonthinkUri:
+    """The DT reader resolves a UUID via DEVONthink (osascript) to a
+    filesystem path, then reads the file. macOS-only — non-darwin
+    callers get a clear ``ReadFail`` rather than a silent crash trying
+    to invoke osascript.
+
+    All tests inject a stub resolver via the ``dt_resolver`` keyword to
+    avoid spawning a real subprocess.
+    """
+
+    def test_happy_path_resolves_and_reads_file(self, tmp_path: Path):
+        from nexus.aspect_readers import ReadOk, _read_devonthink_uri
+
+        target = tmp_path / "paper.pdf"
+        target.write_bytes(b"%PDF-1.4 dt body")
+
+        def resolver(uuid: str) -> tuple[str | None, str]:
+            assert uuid == "8EDC855D-213F-40AD-A9CF-9543CC76476B"
+            return str(target), ""
+
+        result = _read_devonthink_uri(
+            "x-devonthink-item://8EDC855D-213F-40AD-A9CF-9543CC76476B",
+            dt_resolver=resolver,
+        )
+        assert isinstance(result, ReadOk)
+        assert result.metadata["scheme"] == "x-devonthink-item"
+        assert result.metadata["uuid"] == "8EDC855D-213F-40AD-A9CF-9543CC76476B"
+        assert result.metadata["resolved_path"] == str(target)
+        assert result.metadata["bytes"] == len(b"%PDF-1.4 dt body")
+
+    def test_missing_record_returns_unreachable(self, tmp_path: Path):
+        """When DT replies that the UUID isn't found, the reader
+        surfaces an ``unreachable`` failure with the resolver's
+        detail so triage can tell "DT is up but doesn't know this
+        record" from "DT couldn't be reached at all".
+        """
+        from nexus.aspect_readers import ReadFail, _read_devonthink_uri
+
+        def resolver(uuid: str) -> tuple[str | None, str]:
+            return None, f"DEVONthink record {uuid!r} not found"
+
+        result = _read_devonthink_uri(
+            "x-devonthink-item://MISSING-UUID", dt_resolver=resolver,
+        )
+        assert isinstance(result, ReadFail)
+        assert result.reason == "unreachable"
+        assert "not found" in result.detail
+
+    def test_resolver_returning_path_that_doesnt_exist(self, tmp_path: Path):
+        """DT might report a path that has since been moved/deleted
+        out from under it (rare but possible). The reader should
+        surface a ``FileNotFoundError`` ``unreachable`` failure
+        rather than silently producing empty content.
+        """
+        from nexus.aspect_readers import ReadFail, _read_devonthink_uri
+
+        ghost = tmp_path / "ghost.pdf"  # never written
+
+        def resolver(uuid: str) -> tuple[str | None, str]:
+            return str(ghost), ""
+
+        result = _read_devonthink_uri(
+            "x-devonthink-item://GHOST-UUID", dt_resolver=resolver,
+        )
+        assert isinstance(result, ReadFail)
+        assert result.reason == "unreachable"
+        assert "FileNotFoundError" in result.detail
+
+    def test_empty_file_at_resolved_path(self, tmp_path: Path):
+        from nexus.aspect_readers import ReadFail, _read_devonthink_uri
+
+        empty = tmp_path / "empty.pdf"
+        empty.touch()
+
+        def resolver(uuid: str) -> tuple[str | None, str]:
+            return str(empty), ""
+
+        result = _read_devonthink_uri(
+            "x-devonthink-item://EMPTY-UUID", dt_resolver=resolver,
+        )
+        assert isinstance(result, ReadFail)
+        assert result.reason == "empty"
+
+    def test_empty_uuid_returns_unreachable(self):
+        from nexus.aspect_readers import ReadFail, _read_devonthink_uri
+
+        def resolver(uuid: str) -> tuple[str | None, str]:
+            raise AssertionError("resolver should not be called for empty UUID")
+
+        result = _read_devonthink_uri(
+            "x-devonthink-item://", dt_resolver=resolver,
+        )
+        assert isinstance(result, ReadFail)
+        assert result.reason == "unreachable"
+        assert "empty UUID" in result.detail
+
+    def test_non_macos_platform_returns_clear_unreachable(self, monkeypatch):
+        """On Linux/Windows the reader must NOT try to invoke
+        osascript. Surfacing a clean ``unreachable`` lets
+        cross-platform CI runners see the right error and skip
+        DT-keyed entries gracefully.
+        """
+        from nexus.aspect_readers import ReadFail, _read_devonthink_uri
+
+        monkeypatch.setattr("sys.platform", "linux")
+        result = _read_devonthink_uri("x-devonthink-item://UUID")
+        assert isinstance(result, ReadFail)
+        assert result.reason == "unreachable"
+        assert "macOS-only" in result.detail
+
+    def test_uuid_in_path_component_is_tolerated(self, tmp_path: Path):
+        """``urlparse`` puts the UUID in netloc when ``://`` is used
+        but writers that emit ``x-devonthink-item:UUID`` (single
+        colon) put it in ``path``. The reader handles both for
+        defensiveness; the canonical form remains the double-slash
+        shape that matches DEVONthink's own URL output.
+        """
+        from nexus.aspect_readers import ReadOk, _read_devonthink_uri
+
+        target = tmp_path / "compat.pdf"
+        target.write_bytes(b"%PDF-1.4 compat")
+
+        def resolver(uuid: str) -> tuple[str | None, str]:
+            assert uuid == "COMPAT-UUID"
+            return str(target), ""
+
+        result = _read_devonthink_uri(
+            "x-devonthink-item:COMPAT-UUID", dt_resolver=resolver,
+        )
+        assert isinstance(result, ReadOk)
+        assert result.metadata["uuid"] == "COMPAT-UUID"

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -158,6 +158,23 @@ class TestSourceUriRegistration:
         # file_path is preserved separately.
         assert entry.file_path == "bito-mirror.md"
 
+    def test_register_accepts_devonthink_uri(self, cat_with_owner):
+        """``x-devonthink-item://<UUID>`` is a first-class catalog URI
+        scheme (nexus-bqda). Registering with one stores it verbatim;
+        the macOS-only osascript bridge runs at extraction time, not
+        at register time, so this works on any platform.
+        """
+        cat, owner = cat_with_owner
+        explicit = "x-devonthink-item://8EDC855D-213F-40AD-A9CF-9543CC76476B"
+        doc = cat.register(
+            owner, "graph-rag", content_type="paper",
+            file_path="",
+            source_uri=explicit,
+        )
+        entry = cat.resolve(doc)
+        assert entry is not None
+        assert entry.source_uri == explicit
+
     def test_register_rejects_malformed_uri_no_scheme(self, cat_with_owner):
         cat, owner = cat_with_owner
         with pytest.raises(ValueError, match="no scheme"):
@@ -191,15 +208,17 @@ class TestSourceUriRegistration:
     def test_known_uri_schemes_table_is_locked_to_planned_set(self):
         """Lock the scheme registry against silent additions OR
         shrinking. Phase 1: ``file`` + ``chroma``. Phase 4:
-        ``nx-scratch`` (P4.1) + ``https`` (P4.2). Plain ``http`` is
-        intentionally excluded — Phase 4's https reader does NOT
-        cover plain http, so accepting http URIs at register would
-        succeed silently and fail at extraction. Adding a new scheme
-        requires landing the reader first AND updating this lock.
+        ``nx-scratch`` (P4.1) + ``https`` (P4.2). nexus-bqda adds
+        ``x-devonthink-item`` (macOS-only DT identity URLs). Plain
+        ``http`` is intentionally excluded — Phase 4's https reader
+        does NOT cover plain http, so accepting http URIs at register
+        would succeed silently and fail at extraction. Adding a new
+        scheme requires landing the reader first AND updating this
+        lock.
         """
         from nexus.catalog.catalog import _KNOWN_URI_SCHEMES
         assert _KNOWN_URI_SCHEMES == frozenset({
-            "file", "chroma", "https", "nx-scratch",
+            "file", "chroma", "https", "nx-scratch", "x-devonthink-item",
         })
 
     def test_register_rejects_http_scheme_until_reader_lands(

--- a/tests/test_catalog_remediate_paths.py
+++ b/tests/test_catalog_remediate_paths.py
@@ -389,3 +389,278 @@ class TestRemediatePathsCLI:
         ])
         assert result2.exit_code == 0, result2.output
         assert "0 entries need remediation" in result2.output
+
+
+# ── nexus-srck: DEVONthink-aware remediation ────────────────────────────────
+
+
+def _register_paper_with_meta(
+    cat: Catalog, title: str, file_path: str, *, meta: dict,
+) -> str:
+    """Variant of ``_register_paper`` that attaches arbitrary meta —
+    needed to plant ``devonthink_uri`` on a registered entry without
+    going through the (still-evolving) DT ingest path.
+    """
+    from nexus.catalog.tumbler import Tumbler
+    owner_row = cat._db.execute(
+        "SELECT tumbler_prefix FROM owners WHERE name = 'test-papers'",
+    ).fetchone()
+    owner = Tumbler.parse(owner_row[0])
+    tumbler = cat.register(
+        owner=owner, title=title, content_type="paper",
+        file_path=file_path, meta=meta,
+    )
+    return str(tumbler)
+
+
+class TestRemediateViaDevonthink:
+    """When an entry's meta carries ``devonthink_uri``, remediate-paths
+    should ask DEVONthink for the current path before falling back to
+    a SOURCE_DIR basename scan. Tests stub the AppleScript bridge so
+    they run on every platform and don't require DT to be installed.
+    """
+
+    def test_resolves_via_meta_when_dt_returns_existing_path(
+        self,
+        initialized_catalog: Catalog,
+        catalog_env: Path,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """The DT-resolved path takes precedence over basename scanning
+        — the file lives in DT's ``Files.noindex`` tree which is NOT
+        included in the SOURCE_DIR walk, but DT knows where it is.
+        """
+        # Plant the "real" DT-managed file outside SOURCE_DIR.
+        dt_tree = tmp_path / "DT" / "Files.noindex" / "pdf"
+        dt_tree.mkdir(parents=True)
+        real_pdf = dt_tree / "graph-rag.pdf"
+        real_pdf.write_bytes(b"%PDF-1.4 dt managed body")
+
+        # SOURCE_DIR is unrelated and contains no candidates.
+        source_dir = tmp_path / "papers"
+        source_dir.mkdir()
+
+        tumbler = _register_paper_with_meta(
+            initialized_catalog,
+            "Graph RAG",
+            "/old/broken/graph-rag.pdf",  # absolute, missing → triggers remediation
+            meta={"devonthink_uri": "x-devonthink-item://UUID-A"},
+        )
+
+        # Patch the DT resolver + force the macOS gate open so the
+        # remediator's _resolve_via_devonthink helper accepts the call
+        # on Linux/Windows runners.
+        def fake_resolver(uuid: str) -> tuple[str | None, str]:
+            assert uuid == "UUID-A"
+            return str(real_pdf), ""
+
+        monkeypatch.setattr(
+            "nexus.aspect_readers._devonthink_resolver_default", fake_resolver,
+        )
+        monkeypatch.setattr("sys.platform", "darwin")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(source_dir),
+        ])
+        assert result.exit_code == 0, result.output
+        assert "via DEVONthink" in result.output
+
+        from nexus.catalog.tumbler import Tumbler
+        cat2 = Catalog(catalog_env, catalog_env / ".catalog.db")
+        entry = cat2.resolve(Tumbler.parse(tumbler))
+        assert entry.file_path == str(real_pdf)
+
+    def test_falls_through_to_basename_when_dt_resolver_fails(
+        self,
+        initialized_catalog: Catalog,
+        catalog_env: Path,
+        papers_dir: Path,
+        monkeypatch,
+    ) -> None:
+        """If DT can't resolve (record missing, app not running, etc.)
+        the entry should still get the legacy basename treatment so
+        we never regress relative to pre-nexus-srck behavior.
+        """
+        tumbler = _register_paper_with_meta(
+            initialized_catalog,
+            "SAGE",
+            "sage.pdf",
+            meta={"devonthink_uri": "x-devonthink-item://NOT-IN-DT"},
+        )
+
+        def fake_resolver(uuid: str) -> tuple[str | None, str]:
+            return None, "record not found"
+
+        monkeypatch.setattr(
+            "nexus.aspect_readers._devonthink_resolver_default", fake_resolver,
+        )
+        monkeypatch.setattr("sys.platform", "darwin")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir),
+        ])
+        assert result.exit_code == 0, result.output
+
+        from nexus.catalog.tumbler import Tumbler
+        cat2 = Catalog(catalog_env, catalog_env / ".catalog.db")
+        entry = cat2.resolve(Tumbler.parse(tumbler))
+        # Basename scan succeeded → file_path now absolute under papers_dir.
+        assert entry.file_path.endswith("sage.pdf")
+        assert "/" in entry.file_path
+
+    def test_falls_through_when_dt_path_doesnt_exist_on_disk(
+        self,
+        initialized_catalog: Catalog,
+        catalog_env: Path,
+        papers_dir: Path,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """DT can return a path that's been moved/deleted out from
+        under it. Treat that as "DT doesn't really know" and fall
+        back to basename — never persist a path the resolver lied
+        about.
+        """
+        ghost = tmp_path / "ghost-dt-path.pdf"  # never written
+
+        tumbler = _register_paper_with_meta(
+            initialized_catalog,
+            "SAGE",
+            "sage.pdf",
+            meta={"devonthink_uri": "x-devonthink-item://STALE-UUID"},
+        )
+
+        def fake_resolver(uuid: str) -> tuple[str | None, str]:
+            return str(ghost), ""
+
+        monkeypatch.setattr(
+            "nexus.aspect_readers._devonthink_resolver_default", fake_resolver,
+        )
+        monkeypatch.setattr("sys.platform", "darwin")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir),
+        ])
+        assert result.exit_code == 0, result.output
+
+        from nexus.catalog.tumbler import Tumbler
+        cat2 = Catalog(catalog_env, catalog_env / ".catalog.db")
+        entry = cat2.resolve(Tumbler.parse(tumbler))
+        # Basename scan against papers_dir found sage.pdf.
+        assert entry.file_path.endswith("sage.pdf")
+        assert "ghost-dt-path" not in entry.file_path
+
+    def test_no_dt_meta_skips_dt_path_entirely(
+        self,
+        initialized_catalog: Catalog,
+        catalog_env: Path,
+        papers_dir: Path,
+        monkeypatch,
+    ) -> None:
+        """An entry without ``devonthink_uri`` must NOT trigger any
+        resolver call — keeps the resolver from being a hot path on
+        catalogs that have no DT-managed entries at all.
+        """
+        _register_paper_with_meta(
+            initialized_catalog, "SAGE", "sage.pdf", meta={"arxiv_id": "1234.5678"},
+        )
+
+        calls: list[str] = []
+
+        def tracking_resolver(uuid: str) -> tuple[str | None, str]:
+            calls.append(uuid)
+            return None, "should not be called"
+
+        monkeypatch.setattr(
+            "nexus.aspect_readers._devonthink_resolver_default", tracking_resolver,
+        )
+        monkeypatch.setattr("sys.platform", "darwin")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir),
+        ])
+        assert result.exit_code == 0, result.output
+        assert calls == []
+
+    def test_non_macos_platform_short_circuits_dt_resolution(
+        self,
+        initialized_catalog: Catalog,
+        catalog_env: Path,
+        papers_dir: Path,
+        monkeypatch,
+    ) -> None:
+        """On non-darwin runners the helper must early-return without
+        even reading meta — the resolver call would be meaningless.
+        """
+        _register_paper_with_meta(
+            initialized_catalog,
+            "SAGE",
+            "sage.pdf",
+            meta={"devonthink_uri": "x-devonthink-item://UUID-X"},
+        )
+
+        calls: list[str] = []
+
+        def tracking_resolver(uuid: str) -> tuple[str | None, str]:
+            calls.append(uuid)
+            return "/should/not/matter", ""
+
+        monkeypatch.setattr(
+            "nexus.aspect_readers._devonthink_resolver_default", tracking_resolver,
+        )
+        monkeypatch.setattr("sys.platform", "linux")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(papers_dir),
+        ])
+        assert result.exit_code == 0, result.output
+        assert calls == []
+
+    def test_dry_run_with_dt_does_not_write(
+        self,
+        initialized_catalog: Catalog,
+        catalog_env: Path,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        dt_tree = tmp_path / "DT" / "Files.noindex"
+        dt_tree.mkdir(parents=True)
+        real_pdf = dt_tree / "doc.pdf"
+        real_pdf.write_bytes(b"%PDF-1.4 body")
+
+        source_dir = tmp_path / "papers"
+        source_dir.mkdir()
+
+        tumbler = _register_paper_with_meta(
+            initialized_catalog,
+            "Doc",
+            "/old/missing/doc.pdf",
+            meta={"devonthink_uri": "x-devonthink-item://UUID-DRY"},
+        )
+
+        def fake_resolver(uuid: str) -> tuple[str | None, str]:
+            return str(real_pdf), ""
+
+        monkeypatch.setattr(
+            "nexus.aspect_readers._devonthink_resolver_default", fake_resolver,
+        )
+        monkeypatch.setattr("sys.platform", "darwin")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "remediate-paths", str(source_dir), "--dry-run",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "via DEVONthink" in result.output
+        assert "dry-run" in result.output.lower()
+
+        from nexus.catalog.tumbler import Tumbler
+        cat2 = Catalog(catalog_env, catalog_env / ".catalog.db")
+        entry = cat2.resolve(Tumbler.parse(tumbler))
+        assert entry.file_path == "/old/missing/doc.pdf"  # untouched


### PR DESCRIPTION
## Summary

- **nexus-bqda** — Make `x-devonthink-item://<UUID>` a first-class catalog `source_uri` scheme. Registers in the allow-list (`_KNOWN_URI_SCHEMES`) and adds a reader in `aspect_readers.py` that resolves the UUID via DEVONthink's AppleScript bridge (osascript → application id `DNtp`) and reads the file at the resolved path. macOS-only, gated on `sys.platform`.
- **nexus-srck** — Make `nx catalog remediate-paths` re-resolve via `meta.devonthink_uri` when an entry's `file_path` is missing. DT-managed PDFs live inside `Files.noindex` trees that aren't part of any papers archive, so basename scanning can't find them; asking DT directly recovers the path on its own.

Both paths share `_devonthink_resolver_default(uuid) -> (path|None, error_detail)`. Tests inject a stub resolver + monkeypatch `sys.platform` so the suite passes on non-macOS CI without invoking osascript.

## Behavior contract

`x-devonthink-item://` accepted at register time on every platform (the bridge runs at extraction time, not register). Reader returns:
- `ReadOk` with `metadata.scheme = "x-devonthink-item"`, `uuid`, `resolved_path`, `bytes` on the happy path
- `ReadFail("unreachable", ...)` for missing record, missing file at resolved path, empty UUID, or non-darwin platform
- `ReadFail("unauthorized", ...)` on a `PermissionError` reading the resolved file
- `ReadFail("empty", ...)` when the resolved file is zero bytes

`remediate-paths` consults DT before basename scanning. If DT returns a path that doesn't exist on disk, falls through to basename scan rather than persisting the lie.

## Test plan

- [x] `uv run pytest tests/test_aspect_readers.py tests/test_catalog_remediate_paths.py tests/test_catalog.py` (187 passed)
- [x] `uv run pytest -k "catalog or aspect"` (808 passed)
- [x] `nx catalog show 1.653.79` round-trips with the new scheme allow-list
- [ ] Manual: register a fresh DT-sourced PDF with `--source-uri x-devonthink-item://<UUID>` (smoke after merge)

## Closes

Closes #nexus-bqda
Closes #nexus-srck