### PR TITLE
fix(mcp): plan-cache mtime-guarded refresh on T2 mutation (nexus-qgjr)

### DIFF
--- a/src/nexus/db/t2/plan_library.py
+++ b/src/nexus/db/t2/plan_library.py
@@ -218,6 +218,10 @@ class PlanLibrary:
         self._lock = threading.Lock()
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
         self.conn.execute("PRAGMA busy_timeout=5000")
+        # Public read-only attribute so callers (e.g. the mtime-guarded
+        # plan cache in mcp_infra) can stat the underlying file without
+        # peeking through ``self.conn`` internals (nexus-qgjr).
+        self.path: Path = path
         try:
             canonical_key = str(path.resolve())
         except OSError:

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -154,20 +154,49 @@ _PLAN_CACHE_UNAVAILABLE = object()  # sentinel — distinct from None
 _plan_cache_instance = None
 _plan_cache_lock = threading.Lock()
 _plan_cache_populated: bool = False
+#: SQLite file mtime captured at the most recent populate. Used by the
+#: mtime-guarded refresh in :func:`get_t1_plan_cache` to detect plan
+#: library mutation (a re-seeded builtin, an added or deleted row)
+#: without requiring an MCP-server restart. nexus-qgjr.
+_plan_cache_mtime: float = 0.0
+
+
+def _plan_library_mtime(library) -> float:
+    """Return the SQLite file mtime for *library*, or 0.0 when unknown.
+
+    Falls back to 0.0 when the library does not expose a ``path``
+    attribute (in-memory or test-stub libraries) or when the file is
+    missing — both produce a stable repopulate-never-runs fallback that
+    matches the legacy single-populate contract.
+    """
+    path = getattr(library, "path", None)
+    if path is None:
+        return 0.0
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
 
 
 def get_t1_plan_cache(*, populate_from=None):
     """Return the T1 ``plans__session`` cache, lazy-populated on first call.
 
-    When *populate_from* (a PlanLibrary) is supplied and the cache has not yet
-    been populated this process, the full active plan set is loaded. Subsequent
-    calls short-circuit — the ``plan_save`` MCP hook keeps the cache fresh.
+    When *populate_from* (a PlanLibrary) is supplied, the cache is
+    populated from its rows on first call and **repopulated whenever
+    the underlying SQLite file mtime advances** (nexus-qgjr). The mtime
+    check mirrors the catalog's ``_last_consistency_mtime`` pattern at
+    ``catalog.py:405`` — cheap when nothing changed, rebuilds when a
+    write moves the file's stat-time.
 
-    Returns ``None`` when no T1 client is reachable — the matcher falls back
-    to FTS5 in that case.  Subsequent calls after an init failure return
-    ``None`` immediately without re-entering the lock (see sentinel above).
+    Libraries without a ``path`` attribute fall back to populate-once
+    semantics; the mtime tier costs them nothing.
+
+    Returns ``None`` when no T1 client is reachable — the matcher falls
+    back to FTS5 in that case. Subsequent calls after an init failure
+    return ``None`` immediately without re-entering the lock (see
+    sentinel above).
     """
-    global _plan_cache_instance, _plan_cache_populated
+    global _plan_cache_instance, _plan_cache_populated, _plan_cache_mtime
     if _plan_cache_instance is _PLAN_CACHE_UNAVAILABLE:
         return None
     if _plan_cache_instance is None:
@@ -183,25 +212,29 @@ def get_t1_plan_cache(*, populate_from=None):
                     _plan_cache_instance = _PLAN_CACHE_UNAVAILABLE
     if _plan_cache_instance is _PLAN_CACHE_UNAVAILABLE:
         return None
-    if (
-        populate_from is not None
-        and not _plan_cache_populated
-    ):
+    if populate_from is not None:
+        current_mtime = _plan_library_mtime(populate_from)
         with _plan_cache_lock:
-            if not _plan_cache_populated:
+            stale = (
+                not _plan_cache_populated
+                or (current_mtime > 0.0 and current_mtime > _plan_cache_mtime)
+            )
+            if stale:
                 try:
                     _plan_cache_instance.populate(populate_from)
                 finally:
                     _plan_cache_populated = True
+                    _plan_cache_mtime = current_mtime
     return _plan_cache_instance
 
 
 def reset_plan_cache_for_tests() -> None:
     """Test helper: drop the cache singleton so the next call re-init."""
-    global _plan_cache_instance, _plan_cache_populated
+    global _plan_cache_instance, _plan_cache_populated, _plan_cache_mtime
     with _plan_cache_lock:
         _plan_cache_instance = None
         _plan_cache_populated = False
+        _plan_cache_mtime = 0.0
 
 
 # ── Catalog management ────────────────────────────────────────────────────────

--- a/tests/test_plan_cache_mtime_invalidation.py
+++ b/tests/test_plan_cache_mtime_invalidation.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-qgjr: T1 plan-cache mtime-guarded refresh.
+
+When the underlying SQLite ``plans`` table mutates (a new builtin
+seeded, an existing description tweaked, a row deleted) the in-process
+``plans__session`` cache must repopulate on next access without
+requiring an MCP-server restart. Pattern mirrors the catalog
+``_last_consistency_mtime`` trick at ``catalog.py:405``.
+
+The fix:
+
+  - Track the mtime of the SQLite file feeding the cache.
+  - On every ``get_t1_plan_cache(populate_from=lib)`` call, compare
+    the file's current mtime to the cached value; repopulate when
+    advanced.
+
+Two scenarios prove the contract:
+
+  1. mtime advance triggers re-populate.
+  2. mtime stable triggers no extra populate (steady-state cost).
+
+These tests do not exercise the live T1 ChromaDB. They patch
+``PlanSessionCache`` so the populate count is observable.
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    from nexus.mcp_infra import reset_plan_cache_for_tests
+    reset_plan_cache_for_tests()
+    yield
+    reset_plan_cache_for_tests()
+
+
+def _stub_t1():
+    """Return a (t1, lock) pair where t1 has the attributes
+    ``PlanSessionCache.__init__`` reads (``_client``, ``session_id``).
+    """
+    t1 = MagicMock()
+    t1._client = MagicMock()
+    t1.session_id = "test-session"
+    return (t1, MagicMock())
+
+
+def _bump_mtime(path: Path, delta: float = 1.5) -> None:
+    """Advance the mtime by *delta* seconds. Filesystems with second
+    granularity need a >1s nudge to register the change."""
+    st = path.stat()
+    new_t = st.st_mtime + delta
+    os.utime(str(path), (new_t, new_t))
+
+
+def test_initial_populate_runs_once(tmp_path: Path) -> None:
+    from nexus.db.t2.plan_library import PlanLibrary
+    from nexus.mcp_infra import get_t1_plan_cache
+
+    db_path = tmp_path / "plans.sqlite"
+    lib = PlanLibrary(path=db_path)
+
+    fake_cache = MagicMock()
+    fake_cache.populate.return_value = 0
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        cache = get_t1_plan_cache(populate_from=lib)
+        # Subsequent call with no mutation must NOT re-populate.
+        get_t1_plan_cache(populate_from=lib)
+        get_t1_plan_cache(populate_from=lib)
+
+    assert cache is fake_cache
+    assert fake_cache.populate.call_count == 1, (
+        f"expected exactly one populate, got {fake_cache.populate.call_count}"
+    )
+
+
+def test_mtime_advance_triggers_repopulate(tmp_path: Path) -> None:
+    """nexus-qgjr core contract: file mtime > cached mtime → populate again.
+
+    Tests the path the symptom hit: re-seeding a builtin updates the
+    SQLite file, the next ``get_t1_plan_cache`` call must rebuild
+    without an MCP restart.
+    """
+    from nexus.db.t2.plan_library import PlanLibrary
+    from nexus.mcp_infra import get_t1_plan_cache
+
+    db_path = tmp_path / "plans.sqlite"
+    lib = PlanLibrary(path=db_path)
+
+    fake_cache = MagicMock()
+    fake_cache.populate.return_value = 0
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        get_t1_plan_cache(populate_from=lib)
+        assert fake_cache.populate.call_count == 1
+
+        _bump_mtime(db_path)
+
+        get_t1_plan_cache(populate_from=lib)
+        assert fake_cache.populate.call_count == 2, (
+            "mtime advanced — populate should have fired again"
+        )
+
+        # No further mtime change → no further populate.
+        get_t1_plan_cache(populate_from=lib)
+        assert fake_cache.populate.call_count == 2
+
+
+def test_no_populate_without_populate_from_arg(tmp_path: Path) -> None:
+    """Sanity: callers that don't pass populate_from never trigger populate."""
+    from nexus.db.t2.plan_library import PlanLibrary  # noqa: F401
+    from nexus.mcp_infra import get_t1_plan_cache
+
+    fake_cache = MagicMock()
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        get_t1_plan_cache()
+        get_t1_plan_cache()
+
+    assert fake_cache.populate.call_count == 0
+
+
+def test_reset_for_tests_clears_mtime(tmp_path: Path) -> None:
+    """reset_plan_cache_for_tests must clear the mtime so the next
+    populate_from call rebuilds against the fresh DB."""
+    from nexus.db.t2.plan_library import PlanLibrary
+    from nexus.mcp_infra import get_t1_plan_cache, reset_plan_cache_for_tests
+
+    db_path = tmp_path / "plans.sqlite"
+    lib = PlanLibrary(path=db_path)
+
+    fake_cache = MagicMock()
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        get_t1_plan_cache(populate_from=lib)
+        assert fake_cache.populate.call_count == 1
+
+        reset_plan_cache_for_tests()
+
+        get_t1_plan_cache(populate_from=lib)
+        assert fake_cache.populate.call_count == 2, (
+            "post-reset populate should fire even without mtime change"
+        )
+
+
+def test_missing_path_attr_falls_back_safely(tmp_path: Path) -> None:
+    """A library object without a ``path`` attribute (e.g. an in-memory
+    fixture) falls back to single-populate semantics — no raise, no
+    extra populate calls.
+    """
+    from nexus.mcp_infra import get_t1_plan_cache
+
+    class _FakeLib:
+        def list_active_plans(self, *, project=""):
+            return []
+
+    fake_cache = MagicMock()
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        get_t1_plan_cache(populate_from=_FakeLib())
+        get_t1_plan_cache(populate_from=_FakeLib())
+
+    # Without a path → no mtime tracking → behaves like the legacy
+    # populate-once contract. Acceptable fallback.
+    assert fake_cache.populate.call_count == 1


### PR DESCRIPTION
## Summary

Fixes nexus-qgjr (P2 bug). The MCP server caches the plan library on first use and never refreshes, so re-seeding a builtin or adding a new plan does nothing visible to ``nx_answer`` until an MCP-server bounce. The bug surfaced during the RDR-098 abstract-themes smoke run (the implementer had to reach into Python and bypass ``nx_answer`` to test). RDR-097's P1.5 integration harness applies a manual ``reset_plan_cache_for_tests`` workaround for the same reason; with this fix that workaround can drop in a follow-up commit.

## The fix

The catalog already solves the same problem: ``Catalog._last_consistency_mtime`` at ``src/nexus/catalog/catalog.py:405`` stats the JSONL files and rebuilds when the mtime advances. The plan library now does the same for its SQLite file:

- ``PlanLibrary.path`` is a new public attribute. The mtime guard needs to ``stat`` the underlying SQLite file without peeking at ``self.conn`` internals.
- ``mcp_infra._plan_cache_mtime`` tracks the populate-time mtime. ``get_t1_plan_cache(populate_from=lib)`` re-populates whenever the current file mtime exceeds it.
- ``reset_plan_cache_for_tests`` resets all three flags (instance, populated, mtime).

Libraries without a ``path`` attribute (test stubs, in-memory fixtures) fall back to the legacy populate-once contract via ``_plan_library_mtime`` returning 0.0. No regression for those callers.

## Test plan

5 new tests in ``tests/test_plan_cache_mtime_invalidation.py`` covering the four contract paths:

- [x] ``test_initial_populate_runs_once``: first call populates, repeated calls without mutation do not.
- [x] ``test_mtime_advance_triggers_repopulate``: file ``utime`` bump fires populate again on next access.
- [x] ``test_no_populate_without_populate_from_arg``: callers that don't pass ``populate_from`` never fire populate.
- [x] ``test_reset_for_tests_clears_mtime``: post-reset populate fires even without mtime change.
- [x] ``test_missing_path_attr_falls_back_safely``: stub libraries without ``path`` keep populate-once semantics.

Plus regression suites:

- [x] 110 MCP tests (server, lifecycle, concurrency, package)
- [x] 172 plan-stack tests (cache_sentinel, library, match, run, mtime_invalidation)

## Relationship to PR #343

PR #343's P1.5 integration harness has a documented ``reset_plan_cache_for_tests`` workaround pinned to nexus-qgjr. Once this PR lands, that workaround can drop in a follow-up. The harness file lives on a different branch; no overlap with the diff here.

## Closes

Closes nexus-qgjr.