### PR TITLE
fix(plan_match): tighten scope_fit so bare prefix doesn't admit specific (nexus-smhc)

### DIFF
--- a/src/nexus/plans/matcher.py
+++ b/src/nexus/plans/matcher.py
@@ -58,12 +58,21 @@ _SCOPE_FIT_WEIGHT: float = 0.15
 def _scope_fit(plan_scope_tags: str, normalized_scope_pref: str) -> float | None:
     """Return scope-fit in ``{0.0, 1.0}`` or ``None`` for a conflict.
 
-    Semantics (RDR-091 §Proposed Solution → scope-fit):
+    Semantics (RDR-091 §Proposed Solution → scope-fit, tightened by
+    RDR-090 P1.2 / nexus-smhc):
+
       * empty caller scope → always ``0.0`` (no preference; no filter)
       * empty plan scope_tags (agnostic plan) → ``0.0`` (neutral; stays)
-      * any tag in *plan_scope_tags* prefix-matches the caller scope in
-        either direction (``tag.startswith(scope) or scope.startswith(tag)``)
-        → ``1.0`` (bare-family plans serve narrower queries and vice versa)
+      * **direction 1** (caller is at least as specific as the plan
+        tag): ``scope.startswith(tag)`` → ``1.0``. Bare-family plans
+        (``rdr__``) serve narrower callers (``rdr__nexus``).
+      * **direction 2** (plan is more specific than the caller):
+        ``tag.startswith(scope)`` is admitted ONLY when the caller's
+        scope is itself a canonical family-prefix (ends with ``__``).
+        Without the ``__`` boundary marker, a bare prefix like ``rdr``
+        would silently widen to ``rdr__arcaneum`` and pull
+        cross-project plans into the candidate set — the plan #52
+        leakage documented in the RDR-090 spike.
       * otherwise → ``None`` (conflict; caller filters out)
 
     Prefix matching is **case-insensitive**. Real collection names in
@@ -79,10 +88,18 @@ def _scope_fit(plan_scope_tags: str, normalized_scope_pref: str) -> float | None
     if not plan_scope_tags:
         return 0.0
     scope_lower = normalized_scope_pref.lower()
+    scope_is_family_prefix = scope_lower.endswith("__")
     tags = [t for t in plan_scope_tags.split(",") if t]
     for tag in tags:
         tag_lower = tag.lower()
-        if tag_lower.startswith(scope_lower) or scope_lower.startswith(tag_lower):
+        # Direction 1: caller is more-or-equally specific than plan tag.
+        if scope_lower.startswith(tag_lower):
+            return 1.0
+        # Direction 2: plan is more specific than caller — only admit
+        # when caller's scope ends with the family-prefix boundary.
+        # Without this guard, bare 'rdr' (no '__') silently widens to
+        # admit specific cross-project plans like 'rdr__arcaneum'.
+        if scope_is_family_prefix and tag_lower.startswith(scope_lower):
             return 1.0
     return None
 

--- a/tests/test_plan_match.py
+++ b/tests/test_plan_match.py
@@ -402,6 +402,90 @@ def test_fts5_fallback_applies_scope_conflict_filter(library) -> None:
     assert result == [], "FTS5 path must also filter scope-conflicting plans"
 
 
+# ── RDR-090 P1.2 / nexus-smhc: bare-prefix scope no longer admits ──────────
+# specific-collection plans. Caller scope='rdr' must NOT match plan tag
+# 'rdr__arcaneum' — that's the plan #52 leakage the spike documented.
+
+
+def test_bare_prefix_caller_does_not_admit_specific_plan(library) -> None:
+    """Caller scope='rdr' (no '__') against plan tag 'rdr__arcaneum'.
+
+    Pre-fix: bidirectional prefix match silently widened bare 'rdr' to
+    cover any 'rdr__*' plan, so plan #52 ('across-arcaneum-s-rdrs',
+    hardcoded corpus 'rdr__arcaneum-2ad2825c') matched on nexus-specific
+    questions. Post-fix: the caller must use the canonical family form
+    ('rdr__') for direction-2 admission to fire — without the '__'
+    boundary, a bare prefix is treated as exact-only (matches agnostic
+    or exactly-equal plans).
+    """
+    from nexus.plans.matcher import plan_match
+
+    leaky_id = _seed(library, query="across arcaneum's rdrs collection",
+                     dimensions={"verb": "research", "variant": "arc"},
+                     scope_tags="rdr__arcaneum")
+    cache = _FakeCache(hits=[(leaky_id, 0.10)])
+    result = plan_match(
+        intent="how does chash work in nexus", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="rdr",
+    )
+    assert result == [], (
+        f"bare 'rdr' caller must drop 'rdr__arcaneum' plan; got "
+        f"{[m.plan_id for m in result]}"
+    )
+
+
+def test_canonical_family_prefix_still_admits_specific_plan(library) -> None:
+    """Caller scope='rdr__' (canonical family form) still matches
+    plan tag 'rdr__arcaneum' — the legitimate broaden case is preserved.
+    """
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(library, query="q",
+                    dimensions={"verb": "research"},
+                    scope_tags="rdr__arcaneum")
+    cache = _FakeCache(hits=[(plan_id, 0.10)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="rdr__",
+    )
+    assert [m.plan_id for m in result] == [plan_id]
+
+
+def test_bare_prefix_caller_still_matches_exact_bare_tag(library) -> None:
+    """Caller scope='rdr' against plan tag exactly 'rdr' still matches
+    via direction-1 (caller is at least as specific). Regression guard
+    against over-tightening the fix.
+    """
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(library, query="q",
+                    dimensions={"verb": "research"},
+                    scope_tags="rdr")
+    cache = _FakeCache(hits=[(plan_id, 0.10)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="rdr",
+    )
+    assert [m.plan_id for m in result] == [plan_id]
+
+
+def test_bare_prefix_caller_still_passes_agnostic_plan(library) -> None:
+    """Bare-prefix scope tightening must not break the agnostic-plan
+    pass-through (empty scope_tags → neutral weight, kept).
+    """
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(library, query="q",
+                    dimensions={"verb": "research"},
+                    scope_tags="")
+    cache = _FakeCache(hits=[(plan_id, 0.10)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="rdr",
+    )
+    assert [m.plan_id for m in result] == [plan_id]
+
+
 def test_scope_fit_case_insensitive_prefix_match(library) -> None:
     """_scope_fit matches across case on both sides (nexus-yi7m).
 


### PR DESCRIPTION
## Summary

Closes nexus-smhc (P2). The ``_scope_fit`` helper at ``src/nexus/plans/matcher.py:58`` admitted plans whose ``scope_tags`` prefix-matched the caller's scope in either direction, which silently widened a bare-prefix caller scope to admit specific cross-project plans.

Concrete failure (RDR-090 spike): plan #52 (``across-arcaneum-s-rdrs-collection``, scope_tags=``rdr__arcaneum``) matched at confidence 0.476 on nexus-specific questions when the caller passed ``scope='rdr'``. The bidirectional rule fired because ``rdr__arcaneum``.startswith(``rdr``) is True, so the matcher returned arcaneum RDRs (RDR-013/RDR-009/RDR-003) for nexus chash and hooks questions.

## The fix

Tighten direction 2 (plan more specific than caller). It fires only when the caller's scope ends with the canonical family-prefix boundary ``__``. Without that boundary marker, a bare prefix like ``rdr`` falls through to direction-1-only semantics, where the plan tag must be a prefix (or equal) of the caller's scope. Plan #52's ``rdr__arcaneum`` is not a prefix of ``rdr``, so it correctly drops as a conflict.

## Cases preserved

- caller ``rdr__nexus`` + plan ``rdr__``        → match (direction 1)
- caller ``rdr__``      + plan ``rdr__arcaneum`` → match (direction 2, caller is canonical family form)
- caller ``rdr``        + plan ``rdr``           → match (direction 1, exact equality)
- empty plan scope_tags → neutral pass-through unchanged

## Case newly tightened

- caller ``rdr``        + plan ``rdr__arcaneum`` → conflict (was silently admitted; the bug)

## Test plan

4 new TDD tests in ``tests/test_plan_match.py``:

- [x] ``test_bare_prefix_caller_does_not_admit_specific_plan``: leakage reproduction (the bug)
- [x] ``test_canonical_family_prefix_still_admits_specific_plan``: regression guard for the legitimate broaden case
- [x] ``test_bare_prefix_caller_still_matches_exact_bare_tag``: exact equality still works
- [x] ``test_bare_prefix_caller_still_passes_agnostic_plan``: empty-tag plans still pass through

Plus regression suites:

- [x] 38 plan_match tests
- [x] 182 plan-stack tests (plan_match + plan_run + plan_library + plan_grow)

## Closes

Closes nexus-smhc.