### PR TITLE
feat(t3): nx t3 prune-stale subcommand (nexus-u7r0)

### DIFF
--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -18,6 +18,7 @@ from nexus.commands.plan import plan as plan_group
 from nexus.commands.scratch import scratch
 from nexus.commands.search_cmd import search_cmd
 from nexus.commands.store import store
+from nexus.commands.t3 import t3 as t3_group
 from nexus.commands.taxonomy_cmd import taxonomy
 from nexus.commands.upgrade import upgrade
 
@@ -52,5 +53,6 @@ main.add_command(plan_group, name="plan")
 main.add_command(scratch)
 main.add_command(search_cmd, name="search")
 main.add_command(store)
+main.add_command(t3_group, name="t3")
 main.add_command(taxonomy)
 main.add_command(upgrade)

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""``nx t3`` command group — T3 (ChromaDB) maintenance.
+
+``nx t3 prune-stale`` (RDR-090 P1.4 / nexus-u7r0) sweeps each T3
+collection's source_path values, removes chunks whose on-disk source
+file is missing.
+
+The collection mode iterates ``T3Database.list_unique_source_paths``
+plus a ``Path(p).exists()`` check; the staleness predicate is
+intentionally simple (file present / absent) — broken-symlink
+handling and partial-content checks are out of scope.
+
+Out of scope:
+  - Catalog-side prune-stale (``nx catalog prune-stale``) is a
+    separate bead (nexus-zg4c).
+  - The ``nx collection audit --verify-chroma`` cross-check between
+    catalog chunk_ids and chroma chunk_ids (GH #335) shares the
+    drift-detection idea but is a different surface.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+
+@click.group()
+def t3() -> None:
+    """T3 (ChromaDB) maintenance commands."""
+
+
+@t3.command("prune-stale")
+@click.option(
+    "--collection",
+    "-c",
+    default="",
+    help="Limit to one collection. Omit to scan every T3 collection.",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    help="Report-only (default). Use --no-dry-run to perform deletions.",
+)
+@click.option(
+    "--confirm",
+    is_flag=True,
+    default=False,
+    help="Required alongside --no-dry-run to actually delete chunks "
+    "(the explicit-affirmation belt-and-suspenders pattern).",
+)
+def prune_stale_cmd(collection: str, dry_run: bool, confirm: bool) -> None:
+    """Delete T3 chunks whose ``source_path`` is missing from disk.
+
+    \b
+    Reports per-collection summary lines: stale source_paths and
+    chunk counts. By default this is read-only (--dry-run is on).
+
+    \b
+    To actually delete, pass BOTH --no-dry-run AND --confirm. The
+    two-flag dance is deliberate: --no-dry-run flips the intent,
+    --confirm verifies the operator typed it on purpose. Either flag
+    alone runs the report without deleting.
+
+    \b
+    Examples:
+      nx t3 prune-stale                              # report all collections
+      nx t3 prune-stale -c rdr__nexus-571b8edd       # one collection
+      nx t3 prune-stale --no-dry-run --confirm       # actually delete
+    """
+    from nexus.db import make_t3  # noqa: PLC0415
+
+    will_delete = (not dry_run) and confirm
+    if (not dry_run) and not confirm:
+        click.echo(
+            "--no-dry-run alone is treated as report-only. "
+            "Add --confirm to actually delete chunks."
+        )
+        will_delete = False
+
+    t3_db = make_t3()
+
+    if collection:
+        target_collections = [collection]
+    else:
+        try:
+            all_colls = t3_db.list_collections()
+        except Exception as exc:
+            click.echo(f"Failed to list collections: {exc}")
+            raise click.exceptions.Exit(1)
+        target_collections = [c["name"] for c in all_colls]
+
+    if not target_collections:
+        click.echo("No collections to scan.")
+        return
+
+    total_stale_paths = 0
+    total_stale_chunks = 0
+    affected_collections = 0
+
+    for coll_name in target_collections:
+        try:
+            unique_paths = t3_db.list_unique_source_paths(coll_name)
+        except Exception as exc:
+            click.echo(f"  {coll_name}: SKIP (list failed: {exc})")
+            continue
+
+        stale_paths: list[str] = [p for p in unique_paths if not Path(p).exists()]
+        if not stale_paths:
+            continue
+
+        affected_collections += 1
+        click.echo(f"\n{coll_name}: {len(stale_paths)} stale source_path(s)")
+        coll_chunks = 0
+        for p in stale_paths:
+            try:
+                ids = t3_db.ids_for_source(coll_name, p)
+            except Exception as exc:
+                click.echo(f"  {p}: SKIP (ids_for_source failed: {exc})")
+                continue
+            click.echo(f"  {p}  ->  {len(ids)} chunk(s)")
+            coll_chunks += len(ids)
+            if will_delete:
+                try:
+                    deleted = t3_db.delete_by_source(coll_name, p)
+                    if deleted != len(ids):
+                        click.echo(
+                            f"    WARN: deleted {deleted}, expected {len(ids)}"
+                        )
+                except Exception as exc:
+                    click.echo(f"    delete failed: {exc}")
+        total_stale_paths += len(stale_paths)
+        total_stale_chunks += coll_chunks
+
+    verb = "deleted" if will_delete else "would delete"
+    click.echo(
+        f"\nSummary: {verb} {total_stale_chunks} chunk(s) "
+        f"across {total_stale_paths} stale path(s) "
+        f"in {affected_collections} collection(s)."
+    )

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -915,6 +915,49 @@ class T3Database:
         with self._ef_lock:
             self._ef_cache.pop(old, None)
 
+    def list_unique_source_paths(self, collection_name: str) -> list[str]:
+        """Return every distinct ``source_path`` value present in *collection_name*.
+
+        Paginates ``col.get()`` to respect the ChromaDB Cloud 300-record
+        limit and dedupes locally. Empty / missing source_path values
+        are skipped — those are MCP-put chunks that have no on-disk
+        source by design (the prune-stale CLI must not flag them).
+
+        nexus-u7r0 (P1.4 / RDR-090): the staleness sweep needs to
+        iterate the unique source paths in a collection so it can
+        ``Path(...).exists()`` each one and ``delete_by_source`` the
+        misses. There was no batched accessor for this before.
+        Returns empty list if the collection does not exist.
+        """
+        try:
+            col = self._client_for(collection_name).get_collection(collection_name)
+        except _ChromaNotFoundError:
+            return []
+        seen: set[str] = set()
+        offset = 0
+        page_limit = QUOTAS.MAX_RECORDS_PER_WRITE
+        while True:
+            result = _chroma_with_retry(
+                col.get,
+                include=["metadatas"],
+                limit=page_limit,
+                offset=offset,
+            )
+            page_metas = result.get("metadatas") or []
+            page_ids = result.get("ids") or []
+            if not page_ids:
+                break
+            for meta in page_metas:
+                if not isinstance(meta, dict):
+                    continue
+                src = meta.get("source_path") or ""
+                if src:
+                    seen.add(src)
+            offset += len(page_ids)
+            if len(page_ids) < page_limit:
+                break
+        return sorted(seen)
+
     def ids_for_source(self, collection_name: str, source_path: str) -> list[str]:
         """Return all chunk IDs for a given source path. Does not fetch content.
 

--- a/tests/test_t3_prune_stale.py
+++ b/tests/test_t3_prune_stale.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-u7r0: ``nx t3 prune-stale`` subcommand.
+
+RDR-090 P1.4. Tests use a real T3Database backed by chromadb's
+EphemeralClient + DefaultEmbeddingFunction so we exercise the full
+delete-by-source machinery without Cloud credentials.
+
+Contracts pinned here:
+
+  - ``list_unique_source_paths`` deduplicates across multi-chunk
+    same-source documents and skips empty/missing source_path values.
+  - ``--dry-run`` (default) reports stale paths and chunk counts but
+    does not delete anything.
+  - ``--no-dry-run --confirm`` actually deletes; the two-flag dance
+    is required.
+  - ``--no-dry-run`` alone is treated as report-only (defensive).
+  - ``--collection`` scopes to one collection.
+  - Live source_paths (file present on disk) are never flagged.
+  - Empty source_path (MCP-put chunks) never flagged.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.db.t3 import T3Database
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def t3_db():
+    """Real T3Database backed by an ephemeral local Chroma."""
+    return T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _seed_chunk(
+    t3_db: T3Database,
+    *,
+    collection: str,
+    chunk_id: str,
+    content: str,
+    source_path: str,
+) -> None:
+    """Insert one chunk into *collection* with the given metadata.
+
+    Uses the underlying chroma collection ``add`` directly so we don't
+    invoke the indexing pipeline. The EphemeralClient + DefaultEF
+    handles the embedding inline.
+    """
+    col = t3_db._client.get_or_create_collection(collection)
+    col.add(ids=[chunk_id], documents=[content], metadatas=[{"source_path": source_path}])
+
+
+# ── list_unique_source_paths (db-level) ───────────────────────────────────
+
+
+def test_list_unique_source_paths_dedupes_by_source(t3_db, tmp_path):
+    """Multiple chunks with the same source_path collapse to one entry."""
+    coll = "knowledge__test_dedupe"
+    src = str(tmp_path / "doc-a.md")
+    _seed_chunk(t3_db, collection=coll, chunk_id="c1", content="a1", source_path=src)
+    _seed_chunk(t3_db, collection=coll, chunk_id="c2", content="a2", source_path=src)
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="c3", content="b1",
+        source_path=str(tmp_path / "doc-b.md"),
+    )
+    paths = t3_db.list_unique_source_paths(coll)
+    assert len(paths) == 2
+    assert sorted(paths) == sorted([
+        str(tmp_path / "doc-a.md"),
+        str(tmp_path / "doc-b.md"),
+    ])
+
+
+def test_list_unique_source_paths_skips_empty(t3_db, tmp_path):
+    """Chunks with empty source_path (MCP-put) are not returned."""
+    coll = "knowledge__test_empty"
+    _seed_chunk(t3_db, collection=coll, chunk_id="c1", content="x", source_path="")
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="c2", content="y",
+        source_path=str(tmp_path / "doc-real.md"),
+    )
+    paths = t3_db.list_unique_source_paths(coll)
+    assert paths == [str(tmp_path / "doc-real.md")]
+
+
+def test_list_unique_source_paths_missing_collection(t3_db):
+    assert t3_db.list_unique_source_paths("knowledge__nonexistent") == []
+
+
+# ── nx t3 prune-stale CLI (integration via patched make_t3) ───────────────
+
+
+def test_prune_stale_dry_run_reports_stale_only(t3_db, tmp_path, runner):
+    """Default dry-run reports stale source_paths + chunk counts; live
+    paths and empty source_path chunks are not flagged.
+    """
+    coll = "knowledge__test_dryrun"
+    real = tmp_path / "real.md"
+    real.write_text("hello")
+    stale = tmp_path / "ghost.md"  # never created
+    _seed_chunk(t3_db, collection=coll, chunk_id="r1", content="x", source_path=str(real))
+    _seed_chunk(t3_db, collection=coll, chunk_id="s1", content="y", source_path=str(stale))
+    _seed_chunk(t3_db, collection=coll, chunk_id="s2", content="z", source_path=str(stale))
+
+    with patch("nexus.db.make_t3", return_value=t3_db):
+        result = runner.invoke(
+            main, ["t3", "prune-stale", "-c", coll],
+        )
+    assert result.exit_code == 0, result.output
+    assert str(stale) in result.output
+    assert "2 chunk(s)" in result.output
+    assert str(real) not in result.output
+    assert "would delete" in result.output  # default report-only
+
+    # Live chunk + stale chunks all still present (dry-run)
+    col = t3_db._client.get_collection(coll)
+    assert col.count() == 3
+
+
+def test_prune_stale_no_confirm_treated_as_report_only(t3_db, tmp_path, runner):
+    """``--no-dry-run`` without ``--confirm`` is the safer middle path:
+    print the would-delete report, but do not modify T3.
+    """
+    coll = "knowledge__test_no_confirm"
+    stale = tmp_path / "ghost.md"
+    _seed_chunk(t3_db, collection=coll, chunk_id="s1", content="x", source_path=str(stale))
+
+    with patch("nexus.db.make_t3", return_value=t3_db):
+        result = runner.invoke(
+            main, ["t3", "prune-stale", "-c", coll, "--no-dry-run"],
+        )
+    assert result.exit_code == 0
+    assert "Add --confirm" in result.output
+    assert "would delete" in result.output
+    assert t3_db._client.get_collection(coll).count() == 1
+
+
+def test_prune_stale_no_dry_run_with_confirm_actually_deletes(
+    t3_db, tmp_path, runner,
+):
+    """``--no-dry-run --confirm`` removes the stale chunks; live ones survive."""
+    coll = "knowledge__test_delete"
+    real = tmp_path / "real.md"
+    real.write_text("hi")
+    stale = tmp_path / "ghost.md"
+    _seed_chunk(t3_db, collection=coll, chunk_id="r1", content="x", source_path=str(real))
+    _seed_chunk(t3_db, collection=coll, chunk_id="s1", content="y", source_path=str(stale))
+    _seed_chunk(t3_db, collection=coll, chunk_id="s2", content="z", source_path=str(stale))
+
+    with patch("nexus.db.make_t3", return_value=t3_db):
+        result = runner.invoke(
+            main,
+            ["t3", "prune-stale", "-c", coll, "--no-dry-run", "--confirm"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "deleted 2 chunk(s)" in result.output
+
+    col = t3_db._client.get_collection(coll)
+    assert col.count() == 1
+    surviving = col.get()
+    assert surviving["ids"] == ["r1"]
+
+
+def test_prune_stale_no_stale_paths_emits_clean_summary(
+    t3_db, tmp_path, runner,
+):
+    """When every source_path is live, the summary reads 0/0 cleanly."""
+    coll = "knowledge__test_clean"
+    real = tmp_path / "doc.md"
+    real.write_text("hi")
+    _seed_chunk(t3_db, collection=coll, chunk_id="c1", content="x", source_path=str(real))
+
+    with patch("nexus.db.make_t3", return_value=t3_db):
+        result = runner.invoke(main, ["t3", "prune-stale", "-c", coll])
+    assert result.exit_code == 0
+    assert "0 chunk(s)" in result.output
+    assert "0 stale path(s)" in result.output
+
+
+def test_prune_stale_no_collections_message(t3_db, runner):
+    """Empty Chroma → friendly 'no collections' message.
+
+    chromadb.EphemeralClient is a process-singleton-ish, so other
+    tests' collections may still be present. We delete all collections
+    at the start so this test exercises the truly-empty path.
+    """
+    for raw in list(t3_db._client.list_collections()):
+        name = raw if isinstance(raw, str) else getattr(raw, "name", str(raw))
+        try:
+            t3_db._client.delete_collection(name)
+        except Exception:
+            pass
+
+    with patch("nexus.db.make_t3", return_value=t3_db):
+        result = runner.invoke(main, ["t3", "prune-stale"])
+    assert result.exit_code == 0
+    assert "No collections" in result.output


### PR DESCRIPTION
## Summary

Closes nexus-u7r0 (P2). Promotes the spike's source-path staleness sweep into a first-class CLI subcommand. Empirical evidence: spike (research-1003) found 7.8% of ``rdr__nexus-571b8edd`` was stale chunks referring to renamed or deleted RDR files (4161 → 3837 chunks after delete; 12 unique stale paths, 324 chunks). The long tail did not pollute the N=5 spike top-3 retrievals but will surface at the N=30+ the bench operates at.

## Surface

```
nx t3 prune-stale [--collection <name>] [--dry-run/--no-dry-run] [--confirm]
```

Default is read-only. To actually delete:

```
nx t3 prune-stale --no-dry-run --confirm
```

The two-flag dance is intentional: ``--no-dry-run`` flips intent; ``--confirm`` verifies the operator typed it on purpose. Either flag alone runs the report without deleting (the safer middle path).

## Plumbing

- New ``T3Database.list_unique_source_paths(collection)`` helper: paginates ``col.get(include=['metadatas'])`` and dedupes ``source_path`` values locally. Empty source_path values (MCP-put chunks with no on-disk source) are skipped by design.
- New ``src/nexus/commands/t3.py`` module hosting the new ``nx t3`` group. Registered in ``cli.py``.

## Out of scope

- Catalog-side prune-stale (``nx catalog prune-stale``) is filed as a sibling bead (nexus-zg4c).
- The ``nx collection audit --verify-chroma`` cross-check (GH #335) shares the drift-detection idea but is a different surface; one could later refactor a shared "drift detector" library.

## Test plan

8 new tests in ``tests/test_t3_prune_stale.py``:

- [x] ``list_unique_source_paths``: dedupe multi-chunk same-source, skip empty source_path, missing collection returns ``[]``
- [x] dry-run reports stale + chunk counts; live + empty-source chunks not flagged
- [x] ``--no-dry-run`` alone is report-only (no deletion)
- [x] ``--no-dry-run --confirm`` actually deletes; live data survives
- [x] All-live-paths case emits clean 0/0 summary
- [x] Empty Chroma emits 'No collections' message

Tests use a real ``EphemeralClient`` + ``DefaultEmbeddingFunction`` so the delete-by-source machinery is exercised end-to-end without Cloud credentials. 62 cli_registration + doctor + new-test cases green.

## Closes

Closes nexus-u7r0.