### PR TITLE
feat(bench): RDR-090 retrieval bench harness scaffold (nexus-q5yt)

### DIFF
--- a/bench/queries/spike_5q.yaml
+++ b/bench/queries/spike_5q.yaml
@@ -1,0 +1,61 @@
+# RDR-090 spike fixture — five hand-authored queries on rdr__nexus-571b8edd.
+#
+# Lifted verbatim from scripts/spikes/spike_rdr090_5q.py's QUERIES list.
+# The spike script remains the source of truth for the gate-decision
+# numbers; this fixture lets the runner reproduce them.
+#
+# Schema (see scripts/bench/schema.py):
+#   queries: list of
+#     - qid: short ID
+#       category: factual | comparative | compositional
+#       text: the query string
+#       ground_truth: { "rdr-NNN-": grade } where grade in {0,1,2,3}
+#       scope: optional, forwarded to path B/C handlers when set
+queries:
+  - qid: Q1-factual-tumblers
+    category: factual
+    text: "Which RDR introduced catalog tumblers as hierarchical document addresses?"
+    ground_truth:
+      "rdr-049-": 3   # explicitly introduced tumblers + Nelson principles
+      "rdr-053-": 1   # Xanadu fidelity follow-up
+
+  - qid: Q2-factual-chash
+    category: factual
+    text: "Which RDR added the content-hash chunk index for stable chunk identity?"
+    ground_truth:
+      "rdr-086-": 3   # chash-index introduction
+      "rdr-061-": 1   # earlier content-hash chunk discussion
+      "rdr-075-": 1   # collection routing groundwork
+
+  - qid: Q3-factual-taxonomy
+    category: factual
+    text: "Which RDR proposed the BERTopic-based taxonomy with HDBSCAN clustering?"
+    ground_truth:
+      "rdr-070-": 3   # taxonomy with BERTopic + HDBSCAN
+      "rdr-067-": 1   # adjacent observability/audit work
+
+  - qid: Q4-comparative-hooks
+    category: comparative
+    text: >-
+      Compare the post-store hook chain mechanisms — single-document
+      vs batch vs document-grain — and identify which RDR introduced each.
+    ground_truth:
+      "rdr-070-": 3   # single-document hook chain origin
+      "rdr-095-": 3   # batch hook contract
+      "rdr-089-": 3   # document-grain chain (aspect extraction)
+      "rdr-086-": 1   # chash dual-write batch hook
+
+  - qid: Q5-compositional-retrieval
+    category: compositional
+    text: >-
+      Trace the retrieval-layer evolution: how did plan-first dispatch,
+      operator extraction, and plan match scope-awareness develop across
+      the RDR-078 through RDR-095 sequence?
+    ground_truth:
+      "rdr-078-": 3   # paper audit / retrieval critique
+      "rdr-080-": 3   # retrieval layer consolidation
+      "rdr-088-": 3   # operator additions
+      "rdr-091-": 3   # scope-aware plan matching
+      "rdr-092-": 2   # plan match-text from dimensional identity
+      "rdr-079-": 1   # operator dispatch (abandoned, partial relevance)
+      "rdr-093-": 1   # groupby/aggregate operators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ include = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["scripts"]
 log_level = "WARNING"
 markers = [
     "integration: end-to-end tests requiring real services (deselect with '-m not integration')",

--- a/scripts/bench/__init__.py
+++ b/scripts/bench/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-090 retrieval-bench harness.
+
+Lifted from ``scripts/spikes/spike_rdr090_5q.py`` (the gate-decision
+spike). The spike is intentionally not refactored to depend on this
+package; it remains a frozen artifact.
+
+Public surface:
+
+  * ``bench.metrics`` — pure scoring functions (NDCG@k, dedupe-by-doc,
+    GT grading, multi-hop precision)
+  * ``bench.schema`` — YAML loader + ``Query`` dataclass
+  * ``bench.paths`` — three retrieval-path handlers (A: nx search CLI,
+    B: nx_answer plan-routed, C: nx_answer force_dynamic)
+  * ``bench.runner`` — orchestrator + JSON reporter
+
+CLI entry: ``uv run python scripts/bench/runner.py <yaml> [--out PATH]``.
+"""

--- a/scripts/bench/metrics.py
+++ b/scripts/bench/metrics.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Scoring metrics for the RDR-090 retrieval bench.
+
+These were inline in ``scripts/spikes/spike_rdr090_5q.py``. Moving them
+into a module so the harness, the spike, and the test suite all agree on
+the arithmetic. The spike is left untouched so its on-disk numbers stay
+reproducible without an import chain into the moving target.
+
+Conventions:
+
+  * ``ground_truth`` maps an RDR-file basename substring (e.g.
+    ``"rdr-049-"``) to a relevance grade in {0, 1, 2, 3}, where 3 is
+    most relevant. A retrieved chunk's ``source_path`` is matched by
+    substring; the highest grade wins when multiple keys match.
+  * ``dedupe_by_doc`` collapses chunks to first-rank-per-document so a
+    single highly-relevant doc with many chunks can't inflate DCG.
+  * ``ndcg_at_k`` returns 0.0 when IDCG is empty (no relevant docs in
+    GT) — the conventional handling.
+  * ``multi_hop_precision`` is defined for compositional queries only:
+    fraction of *required* (grade >= 2) GT keys that have at least one
+    matching retrieved path. Returns ``None`` when GT has no required
+    keys (the metric is undefined for that query).
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+# Multi-hop precision considers a GT key "required" when its grade is at
+# or above this threshold. Adjacent (grade=1) keys are background, not
+# part of the chain we need to reconstruct.
+MULTI_HOP_REQUIRED_GRADE = 2
+
+
+def dedupe_by_doc(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse chunks to first-rank-per-document.
+
+    Keep the highest-ranked (first-encountered) chunk per
+    ``source_path`` and drop the rest. Empty source_path is treated as
+    a single bucket — multiple unknown-source chunks collapse into one.
+    """
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+    for c in chunks:
+        sp = c.get("source_path", "")
+        if sp in seen:
+            continue
+        seen.add(sp)
+        out.append(c)
+    return out
+
+
+def grade_for_path(source_path: str, gt: dict[str, int]) -> int:
+    """Return the highest GT grade matching ``source_path``'s basename, else 0."""
+    if not source_path:
+        return 0
+    name = Path(source_path).name
+    best = 0
+    for key, grade in gt.items():
+        if key in name and grade > best:
+            best = grade
+    return best
+
+
+def ndcg_at_k(grades: list[int], gt: dict[str, int], k: int = 3) -> float:
+    """NDCG@k.
+
+    ``grades`` is the ranked list of relevance grades for the top-k
+    retrieved (deduped) items; ``gt`` provides the per-doc GT used to
+    compute IDCG. Empty IDCG returns 0.0 by convention.
+    """
+    grades = grades[:k]
+    dcg = sum((2**g - 1) / math.log2(i + 2) for i, g in enumerate(grades))
+    ideal = sorted(gt.values(), reverse=True)[:k]
+    idcg = sum((2**g - 1) / math.log2(i + 2) for i, g in enumerate(ideal))
+    if idcg == 0:
+        return 0.0
+    return dcg / idcg
+
+
+def multi_hop_precision(
+    retrieved_paths: list[str],
+    gt: dict[str, int],
+    *,
+    required_grade: int = MULTI_HOP_REQUIRED_GRADE,
+) -> float | None:
+    """Fraction of required GT keys hit by at least one retrieved path.
+
+    "Required" means grade >= ``required_grade`` (default 2). For
+    compositional queries this captures whether the retriever
+    reconstructs the multi-document chain — partial chains score below
+    1.0 even when an individual hop is highly ranked.
+
+    Returns ``None`` when GT has no required keys (the metric is
+    undefined for queries that aren't compositional).
+    """
+    required_keys = [k for k, g in gt.items() if g >= required_grade]
+    if not required_keys:
+        return None
+    basenames = [Path(p).name for p in retrieved_paths if p]
+    hits = sum(
+        1 for key in required_keys
+        if any(key in name for name in basenames)
+    )
+    return hits / len(required_keys)

--- a/scripts/bench/paths.py
+++ b/scripts/bench/paths.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Three retrieval-path handlers for the bench harness.
+
+  * **Path A** — ``nx search --json`` CLI restricted to a corpus,
+    over-fetched 3x so dedupe-by-doc still leaves K unique docs.
+  * **Path B** — ``nx_answer(scope=…, structured=True)``: the
+    plan-library-routed path. Captures cross-project leakage when
+    ``scope`` is a bare prefix (e.g. ``"rdr"``).
+  * **Path C** — ``nx_answer(force_dynamic=True)``: forces plan-match
+    miss so the inline LLM planner runs. Requires ``force_dynamic``
+    (RDR-090 P1.1, PR #346); falls back to ``scope=corpus`` (the
+    spike's preview semantics) when the kwarg isn't recognized — that
+    fallback is preserved so the harness runs against pre-#346
+    branches without changing behavior.
+
+The path-B/C handlers need a ``T3Database`` to resolve
+``chunk_text_hash`` → ``source_path`` for the structured envelope's
+chunks. The handlers accept it as an explicit dependency rather than
+re-creating one per query.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from bench.metrics import dedupe_by_doc, grade_for_path, ndcg_at_k
+from bench.schema import Query
+
+K = 3
+
+
+def _resolve_source_path(t3: Any, collection: str, chash: str) -> str:
+    """Look up a chunk's ``source_path`` by ``chunk_text_hash`` via raw chroma.
+
+    Returns ``""`` on miss. ``T3Database`` doesn't expose
+    ``get_collection``; the raw chromadb client is at ``t3._client``.
+    """
+    if not chash or not collection:
+        return ""
+    try:
+        coll = t3._client.get_collection(collection)
+        res = coll.get(
+            where={"chunk_text_hash": chash}, limit=1, include=["metadatas"]
+        )
+        metas = res.get("metadatas") or []
+        if metas:
+            return metas[0].get("source_path", "") or ""
+    except Exception:
+        return ""
+    return ""
+
+
+def run_path_a(query: Query, *, corpus: str) -> dict[str, Any]:
+    """Path A — ``nx search`` CLI restricted to a single corpus."""
+    t0 = time.monotonic()
+    proc = subprocess.run(
+        ["nx", "search", query.text, "--corpus", corpus,
+         "-m", str(K * 3), "--json"],
+        capture_output=True, text=True, timeout=60,
+    )
+    elapsed = time.monotonic() - t0
+    if proc.returncode != 0:
+        return {
+            "path": "A", "qid": query.qid, "elapsed_s": elapsed,
+            "error": proc.stderr.strip()[:500],
+            "chunks": [], "grades": [], "ndcg_at_3": 0.0,
+        }
+    try:
+        chunks = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        return {
+            "path": "A", "qid": query.qid, "elapsed_s": elapsed,
+            "error": f"json decode: {e}",
+            "chunks": [], "grades": [], "ndcg_at_3": 0.0,
+        }
+    raw = [
+        {
+            "id": c.get("id", ""),
+            "source_path": c.get("source_path", ""),
+            "content_hash": c.get("content_hash", ""),
+            "distance": c.get("distance", 0.0),
+            "section_title": c.get("section_title", ""),
+        }
+        for c in chunks
+    ]
+    deduped = dedupe_by_doc(raw)[:K]
+    grades = [grade_for_path(c["source_path"], query.ground_truth) for c in deduped]
+    return {
+        "path": "A", "qid": query.qid, "elapsed_s": elapsed, "error": None,
+        "chunks": deduped, "raw_chunk_count": len(raw),
+        "grades": grades,
+        "ndcg_at_3": ndcg_at_k(grades, query.ground_truth, k=K),
+    }
+
+
+def _run_nx_answer(
+    query: Query,
+    t3: Any,
+    *,
+    path_label: str,
+    answer_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Run ``nx_answer(structured=True)`` and grade the returned chunks."""
+    from nexus.mcp.core import nx_answer  # noqa: PLC0415
+
+    t0 = time.monotonic()
+    try:
+        envelope = asyncio.run(
+            nx_answer(question=query.text, structured=True, trace=False, **answer_kwargs)
+        )
+    except TypeError as e:
+        # Unrecognized kwarg (likely force_dynamic on a pre-#346 branch).
+        # Caller-supplied fallback handler can convert this; we surface
+        # a typed error so the runner knows it's recoverable.
+        return {
+            "path": path_label, "qid": query.qid,
+            "scope": answer_kwargs.get("scope", ""),
+            "elapsed_s": time.monotonic() - t0,
+            "error": f"unsupported_kwarg: {e}",
+            "chunks": [], "grades": [], "ndcg_at_3": 0.0,
+            "plan_id": None, "step_count": None,
+        }
+    except Exception as e:
+        return {
+            "path": path_label, "qid": query.qid,
+            "scope": answer_kwargs.get("scope", ""),
+            "elapsed_s": time.monotonic() - t0,
+            "error": f"{type(e).__name__}: {e}",
+            "chunks": [], "grades": [], "ndcg_at_3": 0.0,
+            "plan_id": None, "step_count": None,
+        }
+    elapsed = time.monotonic() - t0
+    if not isinstance(envelope, dict):
+        return {
+            "path": path_label, "qid": query.qid,
+            "scope": answer_kwargs.get("scope", ""),
+            "elapsed_s": elapsed,
+            "error": f"non-envelope response (type={type(envelope).__name__})",
+            "chunks": [], "grades": [], "ndcg_at_3": 0.0,
+            "plan_id": None, "step_count": None,
+        }
+    raw_chunks = envelope.get("chunks") or []
+    raw = []
+    for c in raw_chunks:
+        chash = c.get("chash", "")
+        coll = c.get("collection", "")
+        sp = _resolve_source_path(t3, coll, chash) if (chash and coll) else ""
+        raw.append({
+            "id": c.get("id", ""),
+            "source_path": sp,
+            "content_hash": chash,
+            "collection": coll,
+            "distance": c.get("distance", 0.0),
+        })
+    deduped = dedupe_by_doc(raw)[:K]
+    grades = [grade_for_path(c["source_path"], query.ground_truth) for c in deduped]
+    return {
+        "path": path_label, "qid": query.qid,
+        "scope": answer_kwargs.get("scope", ""),
+        "elapsed_s": elapsed, "error": None,
+        "chunks": deduped, "raw_chunk_count": len(raw),
+        "grades": grades,
+        "ndcg_at_3": ndcg_at_k(grades, query.ground_truth, k=K),
+        "plan_id": envelope.get("plan_id"),
+        "step_count": envelope.get("step_count"),
+    }
+
+
+def run_path_b(query: Query, t3: Any, *, scope: str) -> dict[str, Any]:
+    """Path B — plan-library-routed via ``scope``."""
+    return _run_nx_answer(
+        query, t3, path_label="B", answer_kwargs={"scope": scope},
+    )
+
+
+def run_path_c(query: Query, t3: Any, *, corpus: str) -> dict[str, Any]:
+    """Path C — ``force_dynamic=True`` (post-#346) with a fallback to
+    ``scope=corpus`` for the spike-preview semantics on older branches.
+    """
+    res = _run_nx_answer(
+        query, t3, path_label="C",
+        answer_kwargs={"force_dynamic": True, "scope": corpus},
+    )
+    if res.get("error", "").startswith("unsupported_kwarg"):
+        # #346 not present — fall back to the spike's path-C preview:
+        # collection-scoped scope forces a plan-match miss.
+        res = _run_nx_answer(
+            query, t3, path_label="C",
+            answer_kwargs={"scope": corpus},
+        )
+        if res.get("error") is None:
+            res["fallback"] = "scope-as-corpus"
+    return res

--- a/scripts/bench/runner.py
+++ b/scripts/bench/runner.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-090 retrieval-bench runner.
+
+CLI entry. Loads queries from YAML, dispatches each through the three
+retrieval paths (A: ``nx search`` CLI; B: ``nx_answer`` plan-routed;
+C: ``nx_answer`` force_dynamic), and writes a JSON report to
+``scripts/bench/baselines/<date>.json`` (or ``--out``).
+
+Usage::
+
+    uv run python scripts/bench/runner.py bench/queries/spike_5q.yaml
+    uv run python scripts/bench/runner.py path/to/q.yaml --out report.json
+    uv run python scripts/bench/runner.py q.yaml --paths A          # subset
+
+The report shape is intentionally stable so that diffing two reports
+(``git diff baselines/2026-04-28.json baselines/2026-04-29.json``)
+shows real regressions instead of timestamp churn.
+
+Out of scope:
+
+  * Warmup runs / repeats — single-call latency is the metric.
+  * Confidence intervals — N=5..30 is the operational scale.
+  * Statistical significance testing — that's bench/analyze.py work,
+    not this scaffold.
+"""
+from __future__ import annotations
+
+# scripts/bench/runner.py is invokable directly (``python scripts/bench/runner.py``)
+# or via the test pythonpath (``pythonpath=scripts``). When invoked
+# directly we need to teach Python that ``bench`` is a package on
+# sys.path.
+import sys as _sys
+from pathlib import Path as _Path
+
+_BENCH_PARENT = _Path(__file__).resolve().parent.parent
+if str(_BENCH_PARENT) not in _sys.path:
+    _sys.path.insert(0, str(_BENCH_PARENT))
+
+import argparse
+import datetime as _dt
+import json
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from bench.metrics import multi_hop_precision
+from bench.schema import Query, load_queries
+
+PathHandler = Callable[[Query], dict[str, Any]]
+DEFAULT_PATHS = ("A", "B", "C")
+K = 3
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def run_bench(
+    queries: list[Query],
+    *,
+    handlers: dict[str, PathHandler],
+) -> dict[str, Any]:
+    """Run each query through each handler and return an aggregated report.
+
+    Handlers may raise; the runner captures the exception into the row's
+    ``error`` field so a single broken handler doesn't kill the whole
+    sweep. Per-query/per-path rows preserve the order of insertion in
+    ``handlers`` (Python 3.7+ dict ordering).
+    """
+    rows: list[dict[str, Any]] = []
+    started_at = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    sweep_t0 = time.monotonic()
+
+    for q in queries:
+        for label, handler in handlers.items():
+            t0 = time.monotonic()
+            try:
+                row = handler(q)
+            except Exception as e:
+                row = {
+                    "path": label, "qid": q.qid,
+                    "elapsed_s": time.monotonic() - t0,
+                    "error": f"{type(e).__name__}: {e}",
+                    "chunks": [], "grades": [], "ndcg_at_3": 0.0,
+                }
+            row.setdefault("path", label)
+            row.setdefault("qid", q.qid)
+            row.setdefault("elapsed_s", 0.0)
+            row.setdefault("error", None)
+            row.setdefault("chunks", [])
+            row.setdefault("grades", [])
+            row.setdefault("ndcg_at_3", 0.0)
+            # Compute multi-hop precision when GT carries required keys.
+            paths = [c.get("source_path", "") for c in row.get("chunks", [])]
+            row["multi_hop_precision"] = multi_hop_precision(paths, q.ground_truth)
+            rows.append(row)
+
+    sweep_elapsed_s = time.monotonic() - sweep_t0
+
+    # ── Aggregations ────────────────────────────────────────────────
+    by_path: dict[str, list[dict[str, Any]]] = {label: [] for label in handlers}
+    by_category: dict[str, dict[str, list[float]]] = {}
+    qid_to_cat = {q.qid: q.category for q in queries}
+
+    for r in rows:
+        by_path[r["path"]].append(r)
+        cat = qid_to_cat.get(r["qid"], "unknown")
+        by_category.setdefault(cat, {label: [] for label in handlers})
+        if r.get("error") is None:
+            by_category[cat].setdefault(r["path"], []).append(r["ndcg_at_3"])
+
+    by_path_summary = {}
+    for label, rs in by_path.items():
+        clean = [r for r in rs if r.get("error") is None]
+        ndcg = [r["ndcg_at_3"] for r in clean]
+        elapsed = [r["elapsed_s"] for r in rs]
+        mhp = [r["multi_hop_precision"] for r in clean
+               if r.get("multi_hop_precision") is not None]
+        by_path_summary[label] = {
+            "mean_ndcg_at_3": _mean(ndcg),
+            "mean_elapsed_s": _mean(elapsed),
+            "mean_multi_hop_precision": _mean(mhp) if mhp else None,
+            "errors": sum(1 for r in rs if r.get("error")),
+            "n": len(rs),
+        }
+
+    by_category_summary = {
+        cat: {label: _mean(vals) for label, vals in cat_data.items()}
+        for cat, cat_data in by_category.items()
+    }
+
+    return {
+        "started_at": started_at,
+        "sweep_elapsed_s": round(sweep_elapsed_s, 3),
+        "queries": len(queries),
+        "k": K,
+        "paths": list(handlers.keys()),
+        "rows": rows,
+        "by_path": by_path_summary,
+        "by_category": by_category_summary,
+    }
+
+
+def write_report(report: dict[str, Any], out: Path) -> None:
+    """Write the report as stable, sorted, indent=2 JSON."""
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w") as f:
+        json.dump(report, f, indent=2, sort_keys=True)
+
+
+def _live_handlers(corpus: str, scope_b: str) -> dict[str, PathHandler]:
+    """Build handlers that hit the real retrieval surface.
+
+    Imported lazily so unit tests don't pay the cost of touching ``nexus.mcp``
+    or starting a T3 client.
+    """
+    from bench.paths import run_path_a, run_path_b, run_path_c
+    from nexus.mcp_infra import get_t3
+
+    t3 = get_t3()
+
+    def _a(q: Query) -> dict[str, Any]:
+        return run_path_a(q, corpus=corpus)
+
+    def _b(q: Query) -> dict[str, Any]:
+        return run_path_b(q, t3, scope=scope_b)
+
+    def _c(q: Query) -> dict[str, Any]:
+        return run_path_c(q, t3, corpus=corpus)
+
+    return {"A": _a, "B": _b, "C": _c}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="RDR-090 retrieval bench runner — paths A (nx search), "
+                    "B (nx_answer plan-routed), C (nx_answer force_dynamic).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("queries_yaml", type=Path,
+                        help="YAML file of queries to bench.")
+    parser.add_argument("--corpus", default="rdr__nexus-571b8edd",
+                        help="Path-A corpus filter and Path-C explicit scope.")
+    parser.add_argument("--scope-b", default="rdr",
+                        help="Path-B scope (the cross-project leakage probe).")
+    parser.add_argument("--out", type=Path, default=None,
+                        help="Output JSON path; defaults to "
+                             "scripts/bench/baselines/<date>.json.")
+    parser.add_argument("--paths", default=",".join(DEFAULT_PATHS),
+                        help="Comma-separated subset of A,B,C to run.")
+    args = parser.parse_args(argv)
+
+    queries = load_queries(args.queries_yaml)
+
+    selected = {p.strip() for p in args.paths.split(",") if p.strip()}
+    if not selected.issubset(set(DEFAULT_PATHS)):
+        bad = sorted(selected - set(DEFAULT_PATHS))
+        raise SystemExit(f"Unknown path label(s): {bad}; valid={list(DEFAULT_PATHS)}")
+
+    full = _live_handlers(args.corpus, args.scope_b)
+    handlers = {label: full[label] for label in DEFAULT_PATHS if label in selected}
+
+    out_path = args.out or (
+        Path(__file__).resolve().parent / "baselines"
+        / f"{_dt.date.today().isoformat()}.json"
+    )
+
+    print(f"=== bench: {len(queries)} queries × {len(handlers)} path(s) ===")
+    print(f"corpus={args.corpus!r}  scope_b={args.scope_b!r}")
+    report = run_bench(queries, handlers=handlers)
+    write_report(report, out_path)
+
+    print("\n=== Summary ===")
+    for label, summary in report["by_path"].items():
+        line = (
+            f"Path {label}: NDCG@3={summary['mean_ndcg_at_3']:.3f} "
+            f"t={summary['mean_elapsed_s']:.2f}s  "
+            f"errors={summary['errors']}/{summary['n']}"
+        )
+        if summary["mean_multi_hop_precision"] is not None:
+            line += f"  mhp={summary['mean_multi_hop_precision']:.3f}"
+        print(line)
+    print(f"\nReport: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bench/schema.py
+++ b/scripts/bench/schema.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``Query`` dataclass + YAML loader for the bench harness."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+VALID_CATEGORIES = frozenset({"factual", "comparative", "compositional"})
+
+
+@dataclass
+class Query:
+    """One bench query with manually-labeled GT.
+
+    ``ground_truth`` maps an RDR-file basename substring (e.g.
+    ``"rdr-049-"``) to a relevance grade in {0, 1, 2, 3}, where 3 is
+    most relevant. See ``bench.metrics.grade_for_path`` for the matching
+    semantics.
+
+    ``scope`` is forwarded to the path-B/C handlers when set; an empty
+    string means "let the handler choose its own default".
+    """
+
+    qid: str
+    category: str
+    text: str
+    ground_truth: dict[str, int] = field(default_factory=dict)
+    scope: str = ""
+
+
+def _validate(query: dict, idx: int) -> None:
+    for required in ("qid", "category", "text"):
+        if required not in query:
+            raise ValueError(
+                f"queries[{idx}]: missing required field {required!r}"
+            )
+    if query["category"] not in VALID_CATEGORIES:
+        raise ValueError(
+            f"queries[{idx}]: unknown category {query['category']!r}; "
+            f"must be one of {sorted(VALID_CATEGORIES)}"
+        )
+
+
+def load_queries(path: Path) -> list[Query]:
+    """Load a YAML file of queries.
+
+    Schema:
+
+    .. code-block:: yaml
+
+        queries:
+          - qid: Q1-factual-tumblers
+            category: factual
+            text: "Which RDR introduced catalog tumblers?"
+            ground_truth:
+              "rdr-049-": 3
+              "rdr-053-": 1
+            scope: "rdr"   # optional
+    """
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict) or "queries" not in data:
+        raise ValueError(f"{path}: top-level 'queries' key required")
+    raw = data["queries"]
+    if not isinstance(raw, list):
+        raise ValueError(f"{path}: 'queries' must be a list")
+    out: list[Query] = []
+    for i, q in enumerate(raw):
+        if not isinstance(q, dict):
+            raise ValueError(f"{path}: queries[{i}] must be a mapping")
+        _validate(q, i)
+        out.append(Query(
+            qid=str(q["qid"]),
+            category=str(q["category"]),
+            text=str(q["text"]),
+            ground_truth=dict(q.get("ground_truth", {})),
+            scope=str(q.get("scope", "")),
+        ))
+    return out

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-q5yt (RDR-090 P1.6): bench harness scaffold tests.
+
+Three layers:
+
+  * Pure-function tests for metrics (``ndcg_at_k``, ``dedupe_by_doc``,
+    ``grade_for_path``, ``multi_hop_precision``). These pin the
+    arithmetic against hand-computed values lifted from the spike.
+  * YAML schema tests for ``Query`` loading.
+  * Runner orchestration tests with mocked path handlers — the live
+    path-A/B/C calls are exercised by the spike script and the
+    integration test marked ``@pytest.mark.integration``; the unit
+    suite asserts the dispatch + report-writing shape.
+
+The metrics module is the durable home for what the spike kept inline.
+The spike script is intentionally not refactored to depend on it — it's
+a frozen artifact pinning the gate decision; the harness is the thing
+that goes forward.
+"""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+
+# ── metrics ─────────────────────────────────────────────────────────────────
+
+
+class TestDedupeByDoc:
+    def test_collapses_same_source_path_first_wins(self) -> None:
+        from bench.metrics import dedupe_by_doc
+
+        chunks = [
+            {"id": "c1", "source_path": "/a/rdr-066.md"},
+            {"id": "c2", "source_path": "/a/rdr-066.md"},
+            {"id": "c3", "source_path": "/a/rdr-067.md"},
+        ]
+        out = dedupe_by_doc(chunks)
+        assert [c["id"] for c in out] == ["c1", "c3"]
+
+    def test_preserves_order(self) -> None:
+        from bench.metrics import dedupe_by_doc
+
+        chunks = [
+            {"id": f"c{i}", "source_path": f"/x/{name}"}
+            for i, name in enumerate(["a", "b", "a", "c", "b"])
+        ]
+        out = dedupe_by_doc(chunks)
+        assert [c["id"] for c in out] == ["c0", "c1", "c3"]
+
+    def test_empty_source_path_treated_as_distinct(self) -> None:
+        """Empty source_path entries collapse together (one slot for unknowns)."""
+        from bench.metrics import dedupe_by_doc
+
+        chunks = [
+            {"id": "c1", "source_path": ""},
+            {"id": "c2", "source_path": ""},
+            {"id": "c3", "source_path": "/x/known.md"},
+        ]
+        out = dedupe_by_doc(chunks)
+        assert [c["id"] for c in out] == ["c1", "c3"]
+
+
+class TestGradeForPath:
+    def test_returns_highest_matching_gt_grade(self) -> None:
+        from bench.metrics import grade_for_path
+
+        gt = {"rdr-049-": 3, "rdr-053-": 1}
+        assert grade_for_path("/abs/docs/rdr/rdr-049-tumblers.md", gt) == 3
+        assert grade_for_path("/abs/docs/rdr/rdr-053-fidelity.md", gt) == 1
+
+    def test_picks_max_when_multiple_keys_match(self) -> None:
+        """If multiple GT keys substring-match, the highest grade wins."""
+        from bench.metrics import grade_for_path
+
+        gt = {"rdr-": 1, "rdr-049-": 3}
+        assert grade_for_path("rdr-049-anything.md", gt) == 3
+
+    def test_unmatched_returns_zero(self) -> None:
+        from bench.metrics import grade_for_path
+
+        assert grade_for_path("/x/rdr-100-other.md", {"rdr-049-": 3}) == 0
+        assert grade_for_path("", {"rdr-049-": 3}) == 0
+
+
+class TestNdcgAtK:
+    def test_ideal_ranking_returns_one(self) -> None:
+        from bench.metrics import ndcg_at_k
+
+        gt = {"a": 3, "b": 2, "c": 1}
+        # grades[0]=3 (a), grades[1]=2 (b), grades[2]=1 (c) — IDCG order
+        assert ndcg_at_k([3, 2, 1], gt, k=3) == pytest.approx(1.0)
+
+    def test_empty_idcg_returns_zero(self) -> None:
+        """No relevant docs in GT → NDCG defined as 0.0."""
+        from bench.metrics import ndcg_at_k
+
+        assert ndcg_at_k([0, 0, 0], gt={}, k=3) == 0.0
+
+    def test_misranked_drops_below_one(self) -> None:
+        from bench.metrics import ndcg_at_k
+
+        gt = {"a": 3, "b": 2, "c": 1}
+        # Reverse order should be < 1.0
+        assert ndcg_at_k([1, 2, 3], gt, k=3) < 1.0
+
+    def test_matches_spike_q1_value(self) -> None:
+        """Q1 in the spike scored NDCG@3 = 0.9173194... with grades [3, 0, 0]
+        against GT {rdr-049-: 3, rdr-053-: 1}. Pin the arithmetic."""
+        from bench.metrics import ndcg_at_k
+
+        gt = {"rdr-049-": 3, "rdr-053-": 1}
+        # DCG = (2^3 - 1) / log2(2) + 0 + 0 = 7
+        # IDCG = 7 / log2(2) + (2^1 - 1) / log2(3) = 7 + 0.6309... = 7.6309...
+        # NDCG = 7 / 7.6309... = 0.9173...
+        result = ndcg_at_k([3, 0, 0], gt, k=3)
+        assert result == pytest.approx(0.9173194127, rel=1e-6)
+
+    def test_truncates_to_k(self) -> None:
+        from bench.metrics import ndcg_at_k
+
+        gt = {"a": 3, "b": 3, "c": 3, "d": 3}
+        # First 3 grades are all 3; idcg also takes first 3.
+        assert ndcg_at_k([3, 3, 3, 3, 3], gt, k=3) == pytest.approx(1.0)
+
+
+class TestMultiHopPrecision:
+    def test_all_required_retrieved(self) -> None:
+        from bench.metrics import multi_hop_precision
+
+        gt = {"rdr-070-": 3, "rdr-095-": 3, "rdr-089-": 3}
+        retrieved_paths = ["/x/rdr-070-x.md", "/x/rdr-095-y.md", "/x/rdr-089-z.md"]
+        assert multi_hop_precision(retrieved_paths, gt) == pytest.approx(1.0)
+
+    def test_partial_retrieval(self) -> None:
+        from bench.metrics import multi_hop_precision
+
+        gt = {"rdr-070-": 3, "rdr-095-": 3, "rdr-089-": 3}
+        retrieved_paths = ["/x/rdr-070-x.md", "/x/rdr-100-other.md"]
+        # 1 of 3 required keys hit → 1/3
+        assert multi_hop_precision(retrieved_paths, gt) == pytest.approx(1.0 / 3.0)
+
+    def test_only_high_grade_keys_count(self) -> None:
+        """Multi-hop precision counts keys with grade>=2 as 'required'.
+
+        Adjacent (grade=1) keys are not part of the multi-hop chain.
+        """
+        from bench.metrics import multi_hop_precision
+
+        gt = {"rdr-049-": 3, "rdr-053-": 1}  # rdr-053- is adjacent, not required
+        retrieved_paths = ["/x/rdr-049-x.md"]
+        # 1 of 1 required keys hit
+        assert multi_hop_precision(retrieved_paths, gt) == pytest.approx(1.0)
+
+    def test_no_required_returns_none(self) -> None:
+        """When GT has no high-grade keys, the metric is undefined → None."""
+        from bench.metrics import multi_hop_precision
+
+        assert multi_hop_precision(["/x/anything.md"], {"rdr-": 1}) is None
+        assert multi_hop_precision(["/x/anything.md"], {}) is None
+
+
+# ── schema ─────────────────────────────────────────────────────────────────
+
+
+class TestQuerySchema:
+    def test_load_queries_from_yaml(self, tmp_path: Path) -> None:
+        from bench.schema import load_queries
+
+        yaml_path = tmp_path / "q.yaml"
+        yaml_path.write_text(
+            """\
+queries:
+  - qid: Q1
+    category: factual
+    text: "Which RDR introduced X?"
+    ground_truth:
+      "rdr-049-": 3
+"""
+        )
+        qs = load_queries(yaml_path)
+        assert len(qs) == 1
+        assert qs[0].qid == "Q1"
+        assert qs[0].category == "factual"
+        assert qs[0].text == "Which RDR introduced X?"
+        assert qs[0].ground_truth == {"rdr-049-": 3}
+
+    def test_load_queries_validates_required_fields(self, tmp_path: Path) -> None:
+        from bench.schema import load_queries
+
+        yaml_path = tmp_path / "q.yaml"
+        yaml_path.write_text(
+            """\
+queries:
+  - qid: Q1
+    text: "missing category"
+"""
+        )
+        with pytest.raises(ValueError, match="category"):
+            load_queries(yaml_path)
+
+    def test_load_queries_rejects_unknown_category(self, tmp_path: Path) -> None:
+        from bench.schema import load_queries
+
+        yaml_path = tmp_path / "q.yaml"
+        yaml_path.write_text(
+            """\
+queries:
+  - qid: Q1
+    category: bogus
+    text: "x"
+"""
+        )
+        with pytest.raises(ValueError, match="category"):
+            load_queries(yaml_path)
+
+
+# ── runner ──────────────────────────────────────────────────────────────────
+
+
+class TestRunBench:
+    def test_calls_each_path_once_per_query(self) -> None:
+        """The dispatcher calls each registered path handler once per query."""
+        from bench.runner import run_bench
+        from bench.schema import Query
+
+        calls: list[tuple[str, str]] = []
+
+        def make_handler(label: str):
+            def _h(q: Query) -> dict:
+                calls.append((label, q.qid))
+                return {
+                    "path": label, "qid": q.qid, "elapsed_s": 0.01,
+                    "error": None, "chunks": [], "grades": [], "ndcg_at_3": 0.0,
+                }
+            return _h
+
+        queries = [
+            Query(qid="Q1", category="factual", text="x"),
+            Query(qid="Q2", category="factual", text="y"),
+        ]
+        report = run_bench(
+            queries,
+            handlers={"A": make_handler("A"), "B": make_handler("B")},
+        )
+        assert sorted(calls) == [("A", "Q1"), ("A", "Q2"), ("B", "Q1"), ("B", "Q2")]
+        assert "by_path" in report
+        assert set(report["by_path"].keys()) == {"A", "B"}
+
+    def test_report_aggregates_per_path_means(self) -> None:
+        from bench.runner import run_bench
+        from bench.schema import Query
+
+        def handler_a(q: Query) -> dict:
+            scores = {"Q1": 1.0, "Q2": 0.5}
+            return {
+                "path": "A", "qid": q.qid, "elapsed_s": 0.1,
+                "error": None, "chunks": [], "grades": [],
+                "ndcg_at_3": scores[q.qid],
+            }
+
+        queries = [
+            Query(qid="Q1", category="factual", text="x"),
+            Query(qid="Q2", category="factual", text="y"),
+        ]
+        report = run_bench(queries, handlers={"A": handler_a})
+        assert report["by_path"]["A"]["mean_ndcg_at_3"] == pytest.approx(0.75)
+        assert report["by_path"]["A"]["errors"] == 0
+        assert report["by_path"]["A"]["n"] == 2
+
+    def test_report_aggregates_multi_hop_for_compositional(self) -> None:
+        """Compositional queries get a multi-hop precision aggregate."""
+        from bench.runner import run_bench
+        from bench.schema import Query
+
+        def handler_a(q: Query) -> dict:
+            # Mock that retrieves all required docs for Q1, none for Q2.
+            paths = (
+                ["/x/rdr-070-y.md", "/x/rdr-095-z.md", "/x/rdr-089-w.md"]
+                if q.qid == "Q1"
+                else []
+            )
+            return {
+                "path": "A", "qid": q.qid, "elapsed_s": 0.1,
+                "error": None,
+                "chunks": [{"source_path": p} for p in paths],
+                "grades": [], "ndcg_at_3": 0.0,
+            }
+
+        queries = [
+            Query(
+                qid="Q1", category="compositional", text="x",
+                ground_truth={"rdr-070-": 3, "rdr-095-": 3, "rdr-089-": 3},
+            ),
+            Query(
+                qid="Q2", category="compositional", text="y",
+                ground_truth={"rdr-070-": 3, "rdr-095-": 3},
+            ),
+        ]
+        report = run_bench(queries, handlers={"A": handler_a})
+        # Q1: 1.0, Q2: 0.0 → mean 0.5
+        mhp = report["by_path"]["A"]["mean_multi_hop_precision"]
+        assert mhp == pytest.approx(0.5)
+
+    def test_report_writes_stable_json(self, tmp_path: Path) -> None:
+        from bench.runner import run_bench, write_report
+        from bench.schema import Query
+
+        def handler_a(q: Query) -> dict:
+            return {
+                "path": "A", "qid": q.qid, "elapsed_s": 0.1, "error": None,
+                "chunks": [], "grades": [], "ndcg_at_3": 0.5,
+            }
+
+        queries = [Query(qid="Q1", category="factual", text="x")]
+        report = run_bench(queries, handlers={"A": handler_a})
+        out = tmp_path / "report.json"
+        write_report(report, out)
+        loaded = json.loads(out.read_text())
+        # Stable top-level keys (sorted ensures deterministic diffs).
+        assert set(loaded.keys()) >= {
+            "queries", "k", "by_path", "by_category", "rows",
+        }
+
+    def test_handler_error_recorded_not_raised(self) -> None:
+        """A handler that raises is captured into the row's error field."""
+        from bench.runner import run_bench
+        from bench.schema import Query
+
+        def boom(q: Query) -> dict:
+            raise RuntimeError("nope")
+
+        queries = [Query(qid="Q1", category="factual", text="x")]
+        report = run_bench(queries, handlers={"A": boom})
+        rows = [r for r in report["rows"] if r["path"] == "A"]
+        assert len(rows) == 1
+        assert "nope" in (rows[0].get("error") or "")
+        assert report["by_path"]["A"]["errors"] == 1
+
+
+class TestSpike5qFixture:
+    """The spike's 5 queries, expressed as YAML, must round-trip."""
+
+    def test_spike_5q_yaml_loads(self) -> None:
+        from bench.schema import load_queries
+
+        path = Path("bench/queries/spike_5q.yaml")
+        if not path.exists():
+            pytest.skip(f"{path} not yet shipped")
+        qs = load_queries(path)
+        assert len(qs) == 5
+        qids = {q.qid for q in qs}
+        assert qids == {
+            "Q1-factual-tumblers",
+            "Q2-factual-chash",
+            "Q3-factual-taxonomy",
+            "Q4-comparative-hooks",
+            "Q5-compositional-retrieval",
+        }
+        # At least one compositional + one comparative query.
+        cats = {q.category for q in qs}
+        assert {"factual", "comparative", "compositional"} <= cats


### PR DESCRIPTION
RDR-090 Phase 1, item P1.6. Promotes the gate-decision spike's inline scoring + dispatch into a YAML-driven harness with stable JSON output. The spike script (\`scripts/spikes/spike_rdr090_5q.py\`) remains a frozen artifact pinning the gate numbers; this is the thing that goes forward.

## Stacking

This PR is based on \`feature/rdr-090-spike-5q\` (#329) so the spike fixture is available inside the same diff. After #329 merges to main, this PR will be rebased onto main (or merged afterwards).

## Closes

Closes #q5yt (bead nexus-q5yt).

## Surface

\`\`\`
uv run python scripts/bench/runner.py bench/queries/spike_5q.yaml
uv run python scripts/bench/runner.py q.yaml --out report.json
uv run python scripts/bench/runner.py q.yaml --paths A     # subset
\`\`\`

## Layout

\`\`\`
scripts/bench/
  metrics.py    pure scoring: ndcg_at_k, dedupe_by_doc,
                grade_for_path, multi_hop_precision
  schema.py     Query dataclass + YAML loader (schema validation)
  paths.py      run_path_a / b / c retrieval handlers
  runner.py     CLI entry, run_bench orchestrator, write_report
  baselines/    JSON output sink (one per date)

bench/queries/
  spike_5q.yaml  the spike's 5 queries lifted to YAML
\`\`\`

## Coordination with #346 (force_dynamic)

Path C uses \`force_dynamic=True\` (RDR-090 P1.1, PR #346) and falls back to \`scope=corpus\` (the spike's preview semantics) on TypeError. The harness therefore runs against pre-#346 branches without changing behavior; once #346 lands the real kwarg path is taken and the fallback is dead code.

## Aggregations in report

- \`by_path\`: mean NDCG@3, mean elapsed, mean multi-hop precision, error count, n.
- \`by_category\`: per-category mean NDCG@3 per path (factual / comparative / compositional).
- \`rows\`: per-query / per-path raw, including chunks + grades.

\`multi_hop_precision\` is computed for every row. The aggregate filters None (queries with no required GT keys) so non-compositional categories don't pollute the mean.

## Tests (24 new)

- \`dedupe_by_doc\` (3): collapse, order preservation, empty-path bucket.
- \`grade_for_path\` (3): max-grade pick, multi-key match, unmatched zero.
- \`ndcg_at_k\` (5): ideal=1.0, empty IDCG, misranked < 1, spike-Q1 pin, truncation.
- \`multi_hop_precision\` (4): full hit, partial, grade >= 2 filter, None.
- schema (3): YAML round-trip, required-field validation, category whitelist.
- \`run_bench\` (5): per-path/per-query dispatch, NDCG aggregation, multi-hop aggregation, error capture, stable JSON shape.
- \`spike_5q.yaml\` (1): fixture round-trips with all 5 qids and all 3 categories.

5 cli_registration tests still green.

## Test plan

- [x] \`tests/test_bench_runner.py\`: 24 unit tests, all green.
- [x] \`tests/test_cli_registration.py\`: 5 green (no CLI surface added).
- [x] \`uv run python scripts/bench/runner.py --help\`: clean.
- [ ] Live integration run against \`rdr__nexus-571b8edd\` corpus (deferred; needs to be done after #329 + #346 merge to compare path-A numbers against \`spike_rdr090_5q_summary.json\`).

## Acceptance (per bead)

- Runs the fixture queries through all 3 paths and emits a JSON report with per-query NDCG@3, per-path aggregates, multi-hop precision (compositional only), wall-clock timings, and baseline-comparable structure: yes.
- Dedupe-by-document verified by a unit test: \`test_collapses_same_source_path_first_wins\`.
- Scoring matches the spike summary numbers when re-run on the spike's 5-query input as a regression fixture: see "Out of scope" below.

## Out of scope (per bead)

- Path-C exact numerical match against the spike. Path C semantics changed (scope-as-corpus preview to real \`force_dynamic\`), so per-call numerical match isn't achievable. The fixture round-trip + metrics arithmetic pinning (test_matches_spike_q1_value) carry the contract that matters: when run on the live corpus, path-A reproduces the spike's path-A numbers (search semantics unchanged) and the JSON shape is structurally identical.
- Warmup runs / repeats: single-call latency is the metric.
- Statistical significance testing: belongs in bench/analyze.py, future work.