### PR TITLE
tier 2 batch: plan-cache + plan-match hygiene fixes (RDR-090 P1.1/P1.2/P1.3 + nexus-qgjr)

### DIFF
--- a/src/nexus/db/t2/plan_library.py
+++ b/src/nexus/db/t2/plan_library.py
@@ -218,6 +218,10 @@ class PlanLibrary:
         self._lock = threading.Lock()
         self.conn = sqlite3.connect(str(path), check_same_thread=False)
         self.conn.execute("PRAGMA busy_timeout=5000")
+        # Public read-only attribute so callers (e.g. the mtime-guarded
+        # plan cache in mcp_infra) can stat the underlying file without
+        # peeking through ``self.conn`` internals (nexus-qgjr).
+        self.path: Path = path
         try:
             canonical_key = str(path.resolve())
         except OSError:

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -2948,6 +2948,7 @@ async def nx_answer(
     dimensions: dict[str, Any] | None = None,
     structured: bool = False,
     min_confidence: float | None = None,
+    force_dynamic: bool = False,
 ) -> "str | dict":
     """Answer a knowledge question using plan-match-first retrieval. RDR-080 P1.
 
@@ -2989,6 +2990,14 @@ async def nx_answer(
             tighter value per-call without moving the global knob; the
             global default waits on Phase 5's larger-corpus
             validation. Must be in ``[0.0, 1.0]`` when supplied.
+        force_dynamic: RDR-090 P1.1 (nexus-dslg). When True, skip the
+            plan-match gate entirely and route directly to the inline
+            LLM planner / dynamic-generation path. Default False
+            preserves the plan-match-first flow. Used by the
+            AgenticScholar bench harness path C to isolate dynamic
+            generation from the matched-plan path on collection-scoped
+            questions where ``scope`` would otherwise act as a forced-
+            miss proxy.
 
     Returns:
         The final step's output — a string by default, or the envelope
@@ -3031,21 +3040,30 @@ async def nx_answer(
         min_confidence if min_confidence is not None
         else _PLAN_MATCH_MIN_CONFIDENCE
     )
-    try:
-        with _t2_ctx() as db:
-            cache = get_t1_plan_cache(populate_from=db.plans)
-            matches = _plan_match(
-                question,
-                library=db.plans,
-                cache=cache,
-                dimensions=dimensions,
-                scope_preference=scope,
-                context={"user_context": context} if context else None,
-                min_confidence=effective_min_confidence,
-                n=5,
-            )
-    except Exception as exc:
-        return _result(f"Error during plan match: {exc}")
+    if force_dynamic:
+        # RDR-090 P1.1: skip the plan-match gate entirely. The
+        # dynamic-planner path below picks up matches=[].
+        _log.info(
+            "nx_answer_force_dynamic",
+            question=question[:100] if trace else "[redacted]",
+        )
+        matches: list = []
+    else:
+        try:
+            with _t2_ctx() as db:
+                cache = get_t1_plan_cache(populate_from=db.plans)
+                matches = _plan_match(
+                    question,
+                    library=db.plans,
+                    cache=cache,
+                    dimensions=dimensions,
+                    scope_preference=scope,
+                    context={"user_context": context} if context else None,
+                    min_confidence=effective_min_confidence,
+                    n=5,
+                )
+        except Exception as exc:
+            return _result(f"Error during plan match: {exc}")
 
     if not matches or not _nx_answer_match_is_hit(
         matches[0].confidence, threshold=effective_min_confidence,

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -154,20 +154,49 @@ _PLAN_CACHE_UNAVAILABLE = object()  # sentinel — distinct from None
 _plan_cache_instance = None
 _plan_cache_lock = threading.Lock()
 _plan_cache_populated: bool = False
+#: SQLite file mtime captured at the most recent populate. Used by the
+#: mtime-guarded refresh in :func:`get_t1_plan_cache` to detect plan
+#: library mutation (a re-seeded builtin, an added or deleted row)
+#: without requiring an MCP-server restart. nexus-qgjr.
+_plan_cache_mtime: float = 0.0
+
+
+def _plan_library_mtime(library) -> float:
+    """Return the SQLite file mtime for *library*, or 0.0 when unknown.
+
+    Falls back to 0.0 when the library does not expose a ``path``
+    attribute (in-memory or test-stub libraries) or when the file is
+    missing — both produce a stable repopulate-never-runs fallback that
+    matches the legacy single-populate contract.
+    """
+    path = getattr(library, "path", None)
+    if path is None:
+        return 0.0
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
 
 
 def get_t1_plan_cache(*, populate_from=None):
     """Return the T1 ``plans__session`` cache, lazy-populated on first call.
 
-    When *populate_from* (a PlanLibrary) is supplied and the cache has not yet
-    been populated this process, the full active plan set is loaded. Subsequent
-    calls short-circuit — the ``plan_save`` MCP hook keeps the cache fresh.
+    When *populate_from* (a PlanLibrary) is supplied, the cache is
+    populated from its rows on first call and **repopulated whenever
+    the underlying SQLite file mtime advances** (nexus-qgjr). The mtime
+    check mirrors the catalog's ``_last_consistency_mtime`` pattern at
+    ``catalog.py:405`` — cheap when nothing changed, rebuilds when a
+    write moves the file's stat-time.
 
-    Returns ``None`` when no T1 client is reachable — the matcher falls back
-    to FTS5 in that case.  Subsequent calls after an init failure return
-    ``None`` immediately without re-entering the lock (see sentinel above).
+    Libraries without a ``path`` attribute fall back to populate-once
+    semantics; the mtime tier costs them nothing.
+
+    Returns ``None`` when no T1 client is reachable — the matcher falls
+    back to FTS5 in that case. Subsequent calls after an init failure
+    return ``None`` immediately without re-entering the lock (see
+    sentinel above).
     """
-    global _plan_cache_instance, _plan_cache_populated
+    global _plan_cache_instance, _plan_cache_populated, _plan_cache_mtime
     if _plan_cache_instance is _PLAN_CACHE_UNAVAILABLE:
         return None
     if _plan_cache_instance is None:
@@ -183,25 +212,29 @@ def get_t1_plan_cache(*, populate_from=None):
                     _plan_cache_instance = _PLAN_CACHE_UNAVAILABLE
     if _plan_cache_instance is _PLAN_CACHE_UNAVAILABLE:
         return None
-    if (
-        populate_from is not None
-        and not _plan_cache_populated
-    ):
+    if populate_from is not None:
+        current_mtime = _plan_library_mtime(populate_from)
         with _plan_cache_lock:
-            if not _plan_cache_populated:
+            stale = (
+                not _plan_cache_populated
+                or (current_mtime > 0.0 and current_mtime > _plan_cache_mtime)
+            )
+            if stale:
                 try:
                     _plan_cache_instance.populate(populate_from)
                 finally:
                     _plan_cache_populated = True
+                    _plan_cache_mtime = current_mtime
     return _plan_cache_instance
 
 
 def reset_plan_cache_for_tests() -> None:
     """Test helper: drop the cache singleton so the next call re-init."""
-    global _plan_cache_instance, _plan_cache_populated
+    global _plan_cache_instance, _plan_cache_populated, _plan_cache_mtime
     with _plan_cache_lock:
         _plan_cache_instance = None
         _plan_cache_populated = False
+        _plan_cache_mtime = 0.0
 
 
 # ── Catalog management ────────────────────────────────────────────────────────

--- a/src/nexus/plans/matcher.py
+++ b/src/nexus/plans/matcher.py
@@ -54,6 +54,33 @@ _log = structlog.get_logger()
 # much boost that a genuinely higher-cosine agnostic plan gets drowned.
 _SCOPE_FIT_WEIGHT: float = 0.15
 
+# RDR-090 P1.3 (nexus-zgko): plans saved by the inline-planner via the
+# RDR-084 plan-grow path inherit the originating question's match-text.
+# That match-text is signal for paraphrases of the same question but
+# noise for any unrelated question that shares scaffolding (e.g.
+# 'which RDR…'). The spike found plan #67 (saved from Q1 'Which RDR
+# introduced catalog tumblers?') firing at confidence 0.476 on
+# unrelated Q3 (taxonomy/BERTopic) and Q4 (hooks comparative). We
+# require grown plans to clear a higher floor — paraphrase-quality
+# matches still fire; loose prefix-overlap drops.
+#
+# 0.55 sits a clear margin above the observed 0.476 leakage and just
+# above the precision-first 0.50 calibration documented in RDR-079 P5
+# (precision 0.90 / recall 0.19 at 0.50).
+_GROWN_PLAN_MIN_CONFIDENCE: float = 0.55
+
+
+def _is_grown_plan_tags(tags: str | None) -> bool:
+    """Return True when *tags* identifies a grown plan.
+
+    The plan-grow save path at ``nx_answer`` writes ``ad-hoc,grown``;
+    we match the comma-token presence so future tag additions don't
+    silently break the detection (RDR-090 P1.3 / nexus-zgko).
+    """
+    if not tags:
+        return False
+    return "grown" in [t.strip() for t in tags.split(",")]
+
 
 def _scope_fit(plan_scope_tags: str, normalized_scope_pref: str) -> float | None:
     """Return scope-fit in ``{0.0, 1.0}`` or ``None`` for a conflict.
@@ -216,6 +243,14 @@ def plan_match(
             confidence = max(0.0, 1.0 - float(distance))
             if confidence < min_confidence:
                 continue
+            # RDR-090 P1.3: grown plans need a higher cosine floor so
+            # broad scaffolding ('which RDR…') in their match-text
+            # cannot fire against unrelated questions. Caller floor
+            # always wins when stricter.
+            if _is_grown_plan_tags(row.get("tags")):
+                grown_floor = max(min_confidence, _GROWN_PLAN_MIN_CONFIDENCE)
+                if confidence < grown_floor:
+                    continue
             m = Match.from_plan_row(row, confidence=confidence)
             if filter_dims and not _superset(m.dimensions, filter_dims):
                 continue

--- a/src/nexus/plans/matcher.py
+++ b/src/nexus/plans/matcher.py
@@ -58,12 +58,21 @@ _SCOPE_FIT_WEIGHT: float = 0.15
 def _scope_fit(plan_scope_tags: str, normalized_scope_pref: str) -> float | None:
     """Return scope-fit in ``{0.0, 1.0}`` or ``None`` for a conflict.
 
-    Semantics (RDR-091 §Proposed Solution → scope-fit):
+    Semantics (RDR-091 §Proposed Solution → scope-fit, tightened by
+    RDR-090 P1.2 / nexus-smhc):
+
       * empty caller scope → always ``0.0`` (no preference; no filter)
       * empty plan scope_tags (agnostic plan) → ``0.0`` (neutral; stays)
-      * any tag in *plan_scope_tags* prefix-matches the caller scope in
-        either direction (``tag.startswith(scope) or scope.startswith(tag)``)
-        → ``1.0`` (bare-family plans serve narrower queries and vice versa)
+      * **direction 1** (caller is at least as specific as the plan
+        tag): ``scope.startswith(tag)`` → ``1.0``. Bare-family plans
+        (``rdr__``) serve narrower callers (``rdr__nexus``).
+      * **direction 2** (plan is more specific than the caller):
+        ``tag.startswith(scope)`` is admitted ONLY when the caller's
+        scope is itself a canonical family-prefix (ends with ``__``).
+        Without the ``__`` boundary marker, a bare prefix like ``rdr``
+        would silently widen to ``rdr__arcaneum`` and pull
+        cross-project plans into the candidate set — the plan #52
+        leakage documented in the RDR-090 spike.
       * otherwise → ``None`` (conflict; caller filters out)
 
     Prefix matching is **case-insensitive**. Real collection names in
@@ -79,10 +88,18 @@ def _scope_fit(plan_scope_tags: str, normalized_scope_pref: str) -> float | None
     if not plan_scope_tags:
         return 0.0
     scope_lower = normalized_scope_pref.lower()
+    scope_is_family_prefix = scope_lower.endswith("__")
     tags = [t for t in plan_scope_tags.split(",") if t]
     for tag in tags:
         tag_lower = tag.lower()
-        if tag_lower.startswith(scope_lower) or scope_lower.startswith(tag_lower):
+        # Direction 1: caller is more-or-equally specific than plan tag.
+        if scope_lower.startswith(tag_lower):
+            return 1.0
+        # Direction 2: plan is more specific than caller — only admit
+        # when caller's scope ends with the family-prefix boundary.
+        # Without this guard, bare 'rdr' (no '__') silently widens to
+        # admit specific cross-project plans like 'rdr__arcaneum'.
+        if scope_is_family_prefix and tag_lower.startswith(scope_lower):
             return 1.0
     return None
 

--- a/tests/test_force_dynamic.py
+++ b/tests/test_force_dynamic.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-dslg: ``nx_answer(force_dynamic=True)`` skips plan_match.
+
+RDR-090 P1.1. The bench harness's path C (forced-dynamic generation)
+needs a way to bypass the plan-match gate without using ``scope`` as
+a forced-miss proxy. The flag opts in to the inline-LLM-planner +
+``plan_run`` dynamic path with no plan-library lookup.
+
+Contracts pinned here:
+
+  - ``force_dynamic=False`` (default): plan_match runs as today.
+  - ``force_dynamic=True``: plan_match is NOT called — even when the
+    library carries a matching plan, the dynamic planner runs.
+  - ``force_dynamic=True`` with no matches AND no inline planner
+    available behaves identically to the existing plan-miss path
+    (the planner-failed fallback message).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nexus.plans.match import Match
+
+
+def _ad_hoc_match() -> Match:
+    return Match(
+        plan_id=0,
+        name="ad-hoc",
+        description="what is the meaning of life",
+        confidence=None,
+        dimensions={},
+        tags="ad-hoc",
+        plan_json=json.dumps({
+            "steps": [
+                {"tool": "search", "args": {"query": "$intent",
+                                            "corpus": "knowledge"}},
+                {"tool": "summarize", "args": {"content": "$step1.ids"}},
+            ],
+        }),
+        required_bindings=["intent"],
+        optional_bindings=[],
+        default_bindings={"intent": "what is the meaning of life"},
+        parent_dims=None,
+    )
+
+
+def _matched_plan(plan_id: int = 7) -> Match:
+    return Match(
+        plan_id=plan_id,
+        name="library-plan",
+        description="library plan",
+        confidence=0.55,
+        dimensions={},
+        tags="builtin-template",
+        plan_json=json.dumps({
+            "steps": [
+                {"tool": "search", "args": {"query": "$intent"}},
+                {"tool": "summarize", "args": {"content": "$step1.ids"}},
+            ],
+        }),
+        required_bindings=["intent"],
+        optional_bindings=[],
+        default_bindings={"intent": "q"},
+        parent_dims=None,
+    )
+
+
+def _plan_run_success():
+    result = MagicMock()
+    result.steps = [{"text": "dynamic answer"}]
+    return result
+
+
+@pytest.mark.asyncio
+async def test_default_calls_plan_match() -> None:
+    """force_dynamic=False (default): plan_match is called once."""
+    from nexus.mcp.core import nx_answer
+
+    db_stub = MagicMock()
+    db_stub.plans.save_plan = MagicMock(return_value=999)
+    db_stub.plans.get_plan = MagicMock(return_value={"id": 999, "query": "q"})
+    plan_match_mock = MagicMock(return_value=[_matched_plan(plan_id=7)])
+
+    with patch("nexus.plans.matcher.plan_match", plan_match_mock), \
+         patch("nexus.plans.runner.plan_run",
+               AsyncMock(return_value=_plan_run_success())), \
+         patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+         patch("nexus.mcp.core.scratch", return_value="ok"), \
+         patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+        t2_ctx.return_value.__enter__.return_value = db_stub
+        await nx_answer(question="some question")
+
+    assert plan_match_mock.called, (
+        "plan_match must run on the default code path"
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_dynamic_skips_plan_match() -> None:
+    """force_dynamic=True: plan_match is not called; inline planner fires."""
+    from nexus.mcp.core import nx_answer
+
+    db_stub = MagicMock()
+    db_stub.plans.save_plan = MagicMock(return_value=999)
+    db_stub.plans.get_plan = MagicMock(return_value={"id": 999, "query": "q"})
+    plan_match_mock = MagicMock(return_value=[_matched_plan(plan_id=7)])
+    plan_miss_mock = AsyncMock(return_value=_ad_hoc_match())
+
+    with patch("nexus.plans.matcher.plan_match", plan_match_mock), \
+         patch("nexus.mcp.core._nx_answer_plan_miss", plan_miss_mock), \
+         patch("nexus.plans.runner.plan_run",
+               AsyncMock(return_value=_plan_run_success())), \
+         patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+         patch("nexus.mcp.core.scratch", return_value="ok"), \
+         patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+        t2_ctx.return_value.__enter__.return_value = db_stub
+        await nx_answer(question="some question", force_dynamic=True)
+
+    assert not plan_match_mock.called, (
+        "plan_match must NOT run when force_dynamic=True"
+    )
+    assert plan_miss_mock.called, (
+        "inline planner must run on force_dynamic=True"
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_dynamic_ignores_lib_plans_even_when_present() -> None:
+    """force_dynamic=True wins even when a library plan would match.
+
+    Provided as a regression test against a future refactor that
+    might "optimize" the flag away when matches are available.
+    """
+    from nexus.mcp.core import nx_answer
+
+    db_stub = MagicMock()
+    db_stub.plans.save_plan = MagicMock(return_value=999)
+    db_stub.plans.get_plan = MagicMock(return_value={"id": 999, "query": "q"})
+
+    # Even if plan_match WERE called, it would return a matching plan.
+    # The flag must short-circuit before that observation is possible.
+    plan_match_mock = MagicMock(return_value=[_matched_plan(plan_id=7)])
+    plan_miss_mock = AsyncMock(return_value=_ad_hoc_match())
+    plan_run_mock = AsyncMock(return_value=_plan_run_success())
+
+    with patch("nexus.plans.matcher.plan_match", plan_match_mock), \
+         patch("nexus.mcp.core._nx_answer_plan_miss", plan_miss_mock), \
+         patch("nexus.plans.runner.plan_run", plan_run_mock), \
+         patch("nexus.mcp.core._t2_ctx") as t2_ctx, \
+         patch("nexus.mcp.core.scratch", return_value="ok"), \
+         patch("nexus.mcp_infra.get_t1_plan_cache", return_value=None):
+        t2_ctx.return_value.__enter__.return_value = db_stub
+        await nx_answer(question="some question", force_dynamic=True)
+
+    # The matched plan's plan_id was 7. Verify the path that ran was
+    # the dynamic one — best.plan_id == 0 (ad-hoc) — by checking that
+    # save_plan was called with the ad-hoc tags (RDR-084 plan-grow
+    # path), not the matched-plan path which never saves.
+    assert db_stub.plans.save_plan.called, (
+        "ad-hoc save path must be taken; matched-plan path skips save"
+    )
+    save_kwargs = db_stub.plans.save_plan.call_args.kwargs
+    assert "ad-hoc" in (save_kwargs.get("tags") or ""), (
+        "save_plan must carry the ad-hoc tag, proving dynamic path "
+        f"was chosen; got tags={save_kwargs.get('tags')!r}"
+    )

--- a/tests/test_plan_cache_mtime_invalidation.py
+++ b/tests/test_plan_cache_mtime_invalidation.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-qgjr: T1 plan-cache mtime-guarded refresh.
+
+When the underlying SQLite ``plans`` table mutates (a new builtin
+seeded, an existing description tweaked, a row deleted) the in-process
+``plans__session`` cache must repopulate on next access without
+requiring an MCP-server restart. Pattern mirrors the catalog
+``_last_consistency_mtime`` trick at ``catalog.py:405``.
+
+The fix:
+
+  - Track the mtime of the SQLite file feeding the cache.
+  - On every ``get_t1_plan_cache(populate_from=lib)`` call, compare
+    the file's current mtime to the cached value; repopulate when
+    advanced.
+
+Two scenarios prove the contract:
+
+  1. mtime advance triggers re-populate.
+  2. mtime stable triggers no extra populate (steady-state cost).
+
+These tests do not exercise the live T1 ChromaDB. They patch
+``PlanSessionCache`` so the populate count is observable.
+"""
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    from nexus.mcp_infra import reset_plan_cache_for_tests
+    reset_plan_cache_for_tests()
+    yield
+    reset_plan_cache_for_tests()
+
+
+def _stub_t1():
+    """Return a (t1, lock) pair where t1 has the attributes
+    ``PlanSessionCache.__init__`` reads (``_client``, ``session_id``).
+    """
+    t1 = MagicMock()
+    t1._client = MagicMock()
+    t1.session_id = "test-session"
+    return (t1, MagicMock())
+
+
+def _bump_mtime(path: Path, delta: float = 1.5) -> None:
+    """Advance the mtime by *delta* seconds. Filesystems with second
+    granularity need a >1s nudge to register the change."""
+    st = path.stat()
+    new_t = st.st_mtime + delta
+    os.utime(str(path), (new_t, new_t))
+
+
+def test_initial_populate_runs_once(tmp_path: Path) -> None:
+    from nexus.db.t2.plan_library import PlanLibrary
+    from nexus.mcp_infra import get_t1_plan_cache
+
+    db_path = tmp_path / "plans.sqlite"
+    lib = PlanLibrary(path=db_path)
+
+    fake_cache = MagicMock()
+    fake_cache.populate.return_value = 0
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        cache = get_t1_plan_cache(populate_from=lib)
+        # Subsequent call with no mutation must NOT re-populate.
+        get_t1_plan_cache(populate_from=lib)
+        get_t1_plan_cache(populate_from=lib)
+
+    assert cache is fake_cache
+    assert fake_cache.populate.call_count == 1, (
+        f"expected exactly one populate, got {fake_cache.populate.call_count}"
+    )
+
+
+def test_mtime_advance_triggers_repopulate(tmp_path: Path) -> None:
+    """nexus-qgjr core contract: file mtime > cached mtime → populate again.
+
+    Tests the path the symptom hit: re-seeding a builtin updates the
+    SQLite file, the next ``get_t1_plan_cache`` call must rebuild
+    without an MCP restart.
+    """
+    from nexus.db.t2.plan_library import PlanLibrary
+    from nexus.mcp_infra import get_t1_plan_cache
+
+    db_path = tmp_path / "plans.sqlite"
+    lib = PlanLibrary(path=db_path)
+
+    fake_cache = MagicMock()
+    fake_cache.populate.return_value = 0
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        get_t1_plan_cache(populate_from=lib)
+        assert fake_cache.populate.call_count == 1
+
+        _bump_mtime(db_path)
+
+        get_t1_plan_cache(populate_from=lib)
+        assert fake_cache.populate.call_count == 2, (
+            "mtime advanced — populate should have fired again"
+        )
+
+        # No further mtime change → no further populate.
+        get_t1_plan_cache(populate_from=lib)
+        assert fake_cache.populate.call_count == 2
+
+
+def test_no_populate_without_populate_from_arg(tmp_path: Path) -> None:
+    """Sanity: callers that don't pass populate_from never trigger populate."""
+    from nexus.db.t2.plan_library import PlanLibrary  # noqa: F401
+    from nexus.mcp_infra import get_t1_plan_cache
+
+    fake_cache = MagicMock()
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        get_t1_plan_cache()
+        get_t1_plan_cache()
+
+    assert fake_cache.populate.call_count == 0
+
+
+def test_reset_for_tests_clears_mtime(tmp_path: Path) -> None:
+    """reset_plan_cache_for_tests must clear the mtime so the next
+    populate_from call rebuilds against the fresh DB."""
+    from nexus.db.t2.plan_library import PlanLibrary
+    from nexus.mcp_infra import get_t1_plan_cache, reset_plan_cache_for_tests
+
+    db_path = tmp_path / "plans.sqlite"
+    lib = PlanLibrary(path=db_path)
+
+    fake_cache = MagicMock()
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        get_t1_plan_cache(populate_from=lib)
+        assert fake_cache.populate.call_count == 1
+
+        reset_plan_cache_for_tests()
+
+        get_t1_plan_cache(populate_from=lib)
+        assert fake_cache.populate.call_count == 2, (
+            "post-reset populate should fire even without mtime change"
+        )
+
+
+def test_missing_path_attr_falls_back_safely(tmp_path: Path) -> None:
+    """A library object without a ``path`` attribute (e.g. an in-memory
+    fixture) falls back to single-populate semantics — no raise, no
+    extra populate calls.
+    """
+    from nexus.mcp_infra import get_t1_plan_cache
+
+    class _FakeLib:
+        def list_active_plans(self, *, project=""):
+            return []
+
+    fake_cache = MagicMock()
+    with patch("nexus.mcp_infra.get_t1", return_value=_stub_t1()), \
+         patch("nexus.plans.session_cache.PlanSessionCache",
+               return_value=fake_cache):
+        get_t1_plan_cache(populate_from=_FakeLib())
+        get_t1_plan_cache(populate_from=_FakeLib())
+
+    # Without a path → no mtime tracking → behaves like the legacy
+    # populate-once contract. Acceptable fallback.
+    assert fake_cache.populate.call_count == 1

--- a/tests/test_plan_grow_match_hygiene.py
+++ b/tests/test_plan_grow_match_hygiene.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-zgko: plan-grow match hygiene to prevent over-broad re-firing.
+
+RDR-090 P1.3. Plans saved by the inline-planner via the RDR-084
+plan-grow path inherit the originating question's match-text. The
+match-text is good for paraphrases of the same question but bad for
+unrelated questions that happen to share scaffolding ("which RDR…").
+The spike found plan #67 (saved from Q1 'Which RDR introduced
+catalog tumblers?') firing on Q3 (taxonomy/BERTopic) and Q4 (hooks
+comparative) and dutifully returning rdr-049 for both.
+
+The fix is a higher confidence floor on grown plans (tagged
+``ad-hoc,grown``). High-cosine paraphrases still fire; loose
+prefix-overlap matches drop.
+
+Contract pinned here:
+
+  - Grown plan + below-grown-floor cosine → drops from candidate pool.
+  - Grown plan + above-grown-floor cosine → admits as today.
+  - Library plan (non-grown) + above-min-confidence cosine → admits
+    as today (the floor is grown-specific).
+  - Caller-supplied ``min_confidence`` higher than the grown floor →
+    the higher value wins (the floor is additive, not authoritative).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def library(tmp_path: Path):
+    """Fresh PlanLibrary with the RDR-078 schema applied."""
+    from nexus.db.migrations import _add_plan_dimensional_identity
+    from nexus.db.t2.plan_library import PlanLibrary
+
+    lib = PlanLibrary(tmp_path / "plans.db")
+    _add_plan_dimensional_identity(lib.conn)
+    lib.conn.commit()
+    return lib
+
+
+def _seed(library, *, query: str, dimensions: dict | None = None,
+          tags: str = "", scope_tags: str | None = None) -> int:
+    from nexus.plans.schema import canonical_dimensions_json
+    dims_json = canonical_dimensions_json(dimensions) if dimensions else None
+    return library.save_plan(
+        query=query,
+        plan_json=json.dumps({"steps": []}),
+        tags=tags,
+        project="personal",
+        dimensions=dims_json,
+        verb=(dimensions or {}).get("verb"),
+        scope=(dimensions or {}).get("scope", "personal"),
+        name=(dimensions or {}).get("strategy", "default"),
+        scope_tags=scope_tags,
+    )
+
+
+class _FakeCache:
+    def __init__(self, hits: list[tuple[int, float]] | None = None,
+                 available: bool = True) -> None:
+        self._hits = list(hits or [])
+        self._available = available
+
+    @property
+    def is_available(self) -> bool:
+        return self._available
+
+    def query(self, intent: str, n: int) -> list[tuple[int, float]]:
+        return self._hits[:n]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+
+def test_grown_plan_drops_below_grown_floor(library) -> None:
+    """A 'grown' plan with cosine 0.50 (below the grown floor of 0.60)
+    must not be returned, even though the caller's min_confidence is
+    only 0.40 — this is the plan #67 leakage scenario.
+    """
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(
+        library,
+        query="Which RDR introduced catalog tumblers?",
+        dimensions={"verb": "research", "strategy": "rdr-introduced-catalog"},
+        tags="ad-hoc,grown",
+    )
+    # cosine distance 0.50 → confidence 0.50 (below the grown floor)
+    cache = _FakeCache(hits=[(plan_id, 0.50)])
+    result = plan_match(
+        intent="how does the BERTopic taxonomy work",
+        library=library, cache=cache,
+        min_confidence=0.40, n=5,
+    )
+    assert result == [], (
+        f"grown plan with 0.50 cosine should drop below grown floor; "
+        f"got {[(m.plan_id, m.confidence) for m in result]}"
+    )
+
+
+def test_grown_plan_admits_above_grown_floor(library) -> None:
+    """High-cosine paraphrases of the originating question still fire.
+
+    A grown plan with cosine 0.85 clears even the stricter grown floor.
+    """
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(
+        library,
+        query="Which RDR introduced catalog tumblers?",
+        dimensions={"verb": "research", "strategy": "rdr-introduced-catalog"},
+        tags="ad-hoc,grown",
+    )
+    cache = _FakeCache(hits=[(plan_id, 0.15)])  # confidence 0.85
+    result = plan_match(
+        intent="what is the RDR that introduced catalog tumblers",
+        library=library, cache=cache,
+        min_confidence=0.40, n=5,
+    )
+    assert [m.plan_id for m in result] == [plan_id]
+
+
+def test_library_plan_admits_at_default_floor(library) -> None:
+    """Non-grown library plans use the caller's min_confidence directly
+    — the grown floor must NOT apply to them. Regression guard against
+    accidentally tightening every plan.
+    """
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(
+        library,
+        query="research walkthrough",
+        dimensions={"verb": "research", "strategy": "default"},
+        tags="builtin-template,rdr-078",
+    )
+    cache = _FakeCache(hits=[(plan_id, 0.50)])  # confidence 0.50
+    result = plan_match(
+        intent="walkthrough", library=library, cache=cache,
+        min_confidence=0.40, n=5,
+    )
+    assert [m.plan_id for m in result] == [plan_id], (
+        "non-grown plan above caller's min_confidence must admit"
+    )
+
+
+def test_caller_min_confidence_above_grown_floor_wins(library) -> None:
+    """When the caller passes a min_confidence higher than the grown
+    floor, the higher value wins (the floor is additive, not
+    authoritative).
+
+    Use an intent with no FTS5 keyword overlap with the grown plan's
+    query, so the FTS5 fallback can't re-admit the plan after the
+    cosine path's tighter filter drops it.
+    """
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(
+        library,
+        query="Which RDR introduced catalog tumblers?",
+        dimensions={"verb": "research", "strategy": "rdr-intro"},
+        tags="ad-hoc,grown",
+    )
+    # confidence 0.65 — above grown floor but below caller's 0.70.
+    cache = _FakeCache(hits=[(plan_id, 0.35)])
+    result = plan_match(
+        intent="unrelated abstract pipeline topic",
+        library=library, cache=cache,
+        min_confidence=0.70, n=5,
+    )
+    assert result == [], (
+        "caller's higher min_confidence must win over the grown floor"
+    )
+
+
+def test_grown_floor_does_not_break_fts5_fallback(library) -> None:
+    """The FTS5 fallback path uses confidence=None as a sentinel meaning
+    'skill-level gate decides'. Grown plans on the FTS5 path must still
+    be admitted — the cosine-floor logic only applies to numeric
+    confidence values.
+    """
+    from nexus.plans.matcher import plan_match
+
+    _seed(
+        library,
+        query="catalog tumblers introduction RDR",
+        dimensions={"verb": "research", "strategy": "rdr-intro"},
+        tags="ad-hoc,grown",
+    )
+    # No cache → FTS5 fallback. Match returns confidence=None.
+    result = plan_match(
+        intent="catalog tumblers", library=library, cache=None,
+        min_confidence=0.40, n=5,
+    )
+    # The FTS5 hit should pass through; the cosine-floor check is a
+    # numeric comparison and confidence=None should not be excluded by it.
+    assert result, "FTS5 fallback for grown plans must still admit"
+    assert result[0].confidence is None

--- a/tests/test_plan_match.py
+++ b/tests/test_plan_match.py
@@ -402,6 +402,90 @@ def test_fts5_fallback_applies_scope_conflict_filter(library) -> None:
     assert result == [], "FTS5 path must also filter scope-conflicting plans"
 
 
+# ── RDR-090 P1.2 / nexus-smhc: bare-prefix scope no longer admits ──────────
+# specific-collection plans. Caller scope='rdr' must NOT match plan tag
+# 'rdr__arcaneum' — that's the plan #52 leakage the spike documented.
+
+
+def test_bare_prefix_caller_does_not_admit_specific_plan(library) -> None:
+    """Caller scope='rdr' (no '__') against plan tag 'rdr__arcaneum'.
+
+    Pre-fix: bidirectional prefix match silently widened bare 'rdr' to
+    cover any 'rdr__*' plan, so plan #52 ('across-arcaneum-s-rdrs',
+    hardcoded corpus 'rdr__arcaneum-2ad2825c') matched on nexus-specific
+    questions. Post-fix: the caller must use the canonical family form
+    ('rdr__') for direction-2 admission to fire — without the '__'
+    boundary, a bare prefix is treated as exact-only (matches agnostic
+    or exactly-equal plans).
+    """
+    from nexus.plans.matcher import plan_match
+
+    leaky_id = _seed(library, query="across arcaneum's rdrs collection",
+                     dimensions={"verb": "research", "variant": "arc"},
+                     scope_tags="rdr__arcaneum")
+    cache = _FakeCache(hits=[(leaky_id, 0.10)])
+    result = plan_match(
+        intent="how does chash work in nexus", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="rdr",
+    )
+    assert result == [], (
+        f"bare 'rdr' caller must drop 'rdr__arcaneum' plan; got "
+        f"{[m.plan_id for m in result]}"
+    )
+
+
+def test_canonical_family_prefix_still_admits_specific_plan(library) -> None:
+    """Caller scope='rdr__' (canonical family form) still matches
+    plan tag 'rdr__arcaneum' — the legitimate broaden case is preserved.
+    """
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(library, query="q",
+                    dimensions={"verb": "research"},
+                    scope_tags="rdr__arcaneum")
+    cache = _FakeCache(hits=[(plan_id, 0.10)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="rdr__",
+    )
+    assert [m.plan_id for m in result] == [plan_id]
+
+
+def test_bare_prefix_caller_still_matches_exact_bare_tag(library) -> None:
+    """Caller scope='rdr' against plan tag exactly 'rdr' still matches
+    via direction-1 (caller is at least as specific). Regression guard
+    against over-tightening the fix.
+    """
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(library, query="q",
+                    dimensions={"verb": "research"},
+                    scope_tags="rdr")
+    cache = _FakeCache(hits=[(plan_id, 0.10)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="rdr",
+    )
+    assert [m.plan_id for m in result] == [plan_id]
+
+
+def test_bare_prefix_caller_still_passes_agnostic_plan(library) -> None:
+    """Bare-prefix scope tightening must not break the agnostic-plan
+    pass-through (empty scope_tags → neutral weight, kept).
+    """
+    from nexus.plans.matcher import plan_match
+
+    plan_id = _seed(library, query="q",
+                    dimensions={"verb": "research"},
+                    scope_tags="")
+    cache = _FakeCache(hits=[(plan_id, 0.10)])
+    result = plan_match(
+        intent="q", library=library, cache=cache,
+        min_confidence=0.5, scope_preference="rdr",
+    )
+    assert [m.plan_id for m in result] == [plan_id]
+
+
 def test_scope_fit_case_insensitive_prefix_match(library) -> None:
     """_scope_fit matches across case on both sides (nexus-yi7m).
 


### PR DESCRIPTION
Combined PR superseding #344, #346, #347, #348. Four small, related plan-stack fixes that all touch `src/nexus/mcp/**` or `src/nexus/plans/**`.

## Closes

- Closes #qgjr (bead nexus-qgjr): plan-cache mtime-guarded refresh.
- Closes #dslg (bead nexus-dslg): nx_answer force_dynamic kwarg (RDR-090 P1.1).
- Closes #smhc (bead nexus-smhc): scope_fit boundary fix (RDR-090 P1.2).
- Closes #zgko (bead nexus-zgko): grown-plan cosine floor (RDR-090 P1.3).

Supersedes #344, #346, #347, #348 (will be closed after this lands).

## Commits (in order)

1. `fix(mcp): plan-cache mtime-guarded refresh on T2 mutation` (nexus-qgjr)
2. `feat(nx_answer): force_dynamic kwarg skips plan_match (RDR-090 P1.1)` (nexus-dslg)
3. `fix(plan_match): tighten scope_fit so bare prefix doesn't admit specific (RDR-090 P1.2)` (nexus-smhc)
4. `fix(plan_match): higher cosine floor for grown plans (RDR-090 P1.3)` (nexus-zgko)

## Why combined

All four touch the plan-match / plan-cache subsystem and shipped within hours of each other. They form one "plan-stack hygiene" arc in the run-up to RDR-090 Phase 1.

## Test plan

- [x] `tests/test_force_dynamic.py`: 3 green.
- [x] `tests/test_plan_match.py`: 38 green (covers smhc + general scope_fit).
- [x] `tests/test_plan_grow_match_hygiene.py`: 5 green (zgko's cosine floor).
- [x] `tests/test_plan_cache_mtime_invalidation.py`: 5 green (qgjr).
- [x] Combined: 51/51 green on the affected modules.
- [x] **Sandbox smoke** (`./tests/e2e/release-sandbox.sh smoke`): PASSED. Required because the changes touch `src/nexus/mcp/**` per CLAUDE.md trigger surface.

## Follow-up after merge

PR #343's `tests/test_hybrid_plan_factual_qa.py` carries a `reset_plan_cache_for_tests` workaround pinned to nexus-qgjr (the first commit in this batch). Once this PR merges, push a follow-up commit on #343 to drop the workaround (or invert the docstring rationale).