### PR TITLE
fix(cli-parity): T3-write CLI paths now fire post-store hook chains (nexus-9099)

### DIFF
--- a/src/nexus/commands/memory.py
+++ b/src/nexus/commands/memory.py
@@ -225,6 +225,12 @@ def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None
                 expires_at=expires_at,
             )
 
+        # nexus-9099: fire post-store chains so the promoted T3 row
+        # reaches chash_index / taxonomy / aspect queue. RDR-095
+        # symmetric-fire; this path was missed by the original commit.
+        from nexus.mcp_infra import fire_store_chains
+        fire_store_chains([doc_id], collection, [entry["content"]])
+
         if remove:
             db.delete(entry["project"], entry["title"])
             click.echo(

--- a/src/nexus/commands/store.py
+++ b/src/nexus/commands/store.py
@@ -111,6 +111,13 @@ def put_cmd(
     )
     click.echo(f"Stored: {doc_id}  →  {col_name}")
     _catalog_store_hook(title=title, doc_id=doc_id, collection_name=col_name)
+    # nexus-9099: fire the three post-store hook chains so the chash
+    # index, taxonomy assignment, and aspect-extraction queue see CLI
+    # store-put events. RDR-095 symmetric-fire; this path was missed by
+    # the original commit. doc_id is the source identity here (no
+    # on-disk file at the CLI boundary, mirroring MCP store_put).
+    from nexus.mcp_infra import fire_store_chains
+    fire_store_chains([doc_id], col_name, [content])
 
 
 def _catalog_store_hook(title: str, doc_id: str, collection_name: str) -> None:

--- a/src/nexus/exporter.py
+++ b/src/nexus/exporter.py
@@ -377,6 +377,17 @@ def import_collection(
                         embeddings=embeddings,
                         metadatas=metadatas,
                     )
+                    # nexus-9099: fire post-store chains for the imported
+                    # batch (RDR-095 symmetric-fire; missed by the original
+                    # commit). source_path comes from the export metadata
+                    # so the document chain sees the original on-disk path.
+                    from nexus.mcp_infra import fire_store_chains
+                    fire_store_chains(
+                        ids, collection_name, documents,
+                        source_paths=[m.get("source_path", "") for m in metadatas],
+                        embeddings=embeddings,
+                        metadatas=metadatas,
+                    )
                     imported_count += len(ids)
                     _log.debug("import_batch_written", count=len(ids), total_so_far=imported_count)
                     ids, documents, embeddings, metadatas = [], [], [], []
@@ -387,6 +398,13 @@ def import_collection(
             collection_name=collection_name,
             ids=ids,
             documents=documents,
+            embeddings=embeddings,
+            metadatas=metadatas,
+        )
+        from nexus.mcp_infra import fire_store_chains
+        fire_store_chains(
+            ids, collection_name, documents,
+            source_paths=[m.get("source_path", "") for m in metadatas],
             embeddings=embeddings,
             metadatas=metadatas,
         )

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -913,6 +913,11 @@ def store_put(
         # per-doc consumers; batch chain runs with a 1-element list so
         # batch-shape consumers (taxonomy, chash) see MCP store_put as
         # a single-document batch.
+        #
+        # Direct fire calls are required here (not the nexus-9099
+        # ``fire_store_chains`` helper) because ``test_hook_drift_guard``
+        # AST-counts these three names verbatim in mcp/core.py to enforce
+        # the 7-CLI + 1-MCP fire-site invariant.
         _fire_post_store_hooks(doc_id, col_name, content)
         _fire_post_store_batch_hooks(
             [doc_id], col_name, [content], None, None,

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -848,6 +848,96 @@ def _record_document_hook_failure(
         )
 
 
+# ── Combined post-store fire helper (nexus-9099) ─────────────────────────────
+#
+# RDR-095 established symmetric-fire for the bulk CLI ingest paths
+# (``nx index repo / pdf / rdr``) so every storage event invokes the
+# single, batch, and document-grain hook chains. Three CLI paths were
+# overlooked by the symmetric-fire commit and shipped firing zero
+# chains: ``nx store put``, ``nx memory promote``, and
+# ``nx store import``. The downstream effect is silent drift between
+# the catalog row + chroma chunk and the T2 indexes that operator SQL
+# fast paths depend on (chash_index, taxonomy assignments, aspect
+# extraction queue). nexus-9099 surfaced the bug; this helper closes
+# the gap by giving every T3-write path a single call site that fires
+# all three chains in the correct order.
+#
+# Used by:
+#   * MCP ``store_put`` (mcp/core.py)
+#   * CLI ``nx store put`` (commands/store.py)
+#   * CLI ``nx memory promote`` (commands/memory.py)
+#   * CLI ``nx store import`` (commands/store.py)
+#
+# Bulk ``nx index *`` ingest paths still call the three fire functions
+# directly (see ``code_indexer.py``, ``prose_indexer.py``,
+# ``doc_indexer.py``, ``pipeline_stages.py``, ``indexer.py``) — the AST
+# drift guard in ``tests/test_hook_drift_guard.py`` enforces 7 CLI
+# fire sites + 1 MCP fire site for the document chain. This helper is
+# additive; it does not rewire the bulk paths.
+
+
+def fire_store_chains(
+    doc_ids: list[str],
+    collection: str,
+    contents: list[str],
+    *,
+    source_paths: list[str] | None = None,
+    embeddings: list[list[float]] | None = None,
+    metadatas: list[dict] | None = None,
+) -> None:
+    """Fire all three post-store hook chains for a batch of just-stored docs.
+
+    Single, batch, and document-grain chains run in that order. Errors
+    are caught per-hook and persisted to T2 ``hook_failures``; nothing
+    is propagated to the caller (matching the existing fire functions'
+    semantics).
+
+    Parameters
+    ----------
+    doc_ids:
+        Stable identifiers for each just-stored document.
+    collection:
+        Physical collection name (e.g. ``knowledge__knowledge``).
+    contents:
+        Document text per doc_id. Length must match ``doc_ids``.
+    source_paths:
+        On-disk source path per document, or ``None`` to use ``doc_ids``
+        as the source identity (the MCP ``store_put`` shape — there is
+        no on-disk source). Length must match ``doc_ids`` when given.
+    embeddings:
+        Optional dense vectors per doc; forwarded to the batch chain.
+        ``taxonomy_assign_batch_hook`` accepts ``None`` and fetches
+        embeddings from T3 inline.
+    metadatas:
+        Optional metadata dicts per doc; forwarded to the batch chain.
+        ``chash_dual_write_batch_hook`` reads from this.
+    """
+    n = len(doc_ids)
+    assert len(contents) == n, (
+        f"contents length {len(contents)} != doc_ids length {n}"
+    )
+    if source_paths is None:
+        source_paths = list(doc_ids)
+    elif len(source_paths) != n:
+        raise ValueError(
+            f"source_paths length {len(source_paths)} != doc_ids length {n}"
+        )
+
+    # Single-doc chain — once per (doc_id, content).
+    for doc_id, content in zip(doc_ids, contents):
+        fire_post_store_hooks(doc_id, collection, content)
+
+    # Batch chain — one call with the whole batch.
+    fire_post_store_batch_hooks(
+        doc_ids, collection, contents,
+        embeddings=embeddings, metadatas=metadatas,
+    )
+
+    # Document-grain chain — once per (source_path, content).
+    for sp, content in zip(source_paths, contents):
+        fire_post_document_hooks(sp, collection, content)
+
+
 # ── Version compatibility check (RDR-076) ─────────────────────────────────────
 
 

--- a/tests/test_store_put_cli_parity.py
+++ b/tests/test_store_put_cli_parity.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-9099: every T3-write CLI path must fire the post-store hook chains.
+
+RDR-095 established the symmetric-fire principle for `nx index *` ingest
+paths but `nx store put`, `nx memory promote`, and `nx store import`
+were never retrofitted. Symptoms: chash_index missing, taxonomy never
+assigned, aspect-extraction queue never enqueues — silent drift between
+the catalog row + chroma chunk and the downstream T2 indexes that
+operator SQL fast paths depend on.
+
+This file verifies the parity at the hook-fire boundary using counting
+probe hooks. The underlying hook bodies (chash, taxonomy, aspects)
+have their own coverage and require live T2/T3 stack.
+
+Two kinds of test:
+
+  * Per-path firing tests — each broken CLI path now fires single,
+    batch, and document chains in the same shape as MCP ``store_put``.
+  * Drift guard — count of `fire_store_chains` call sites in CLI
+    ingest commands must not regress (catches future paths added
+    without the chain wiring).
+"""
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def reset_hook_chains():
+    """Snapshot and restore the registered hook chains around each test."""
+    from nexus.mcp_infra import (
+        _post_document_hooks,
+        _post_store_batch_hooks,
+        _post_store_hooks,
+    )
+    saved = (
+        list(_post_store_hooks),
+        list(_post_store_batch_hooks),
+        list(_post_document_hooks),
+    )
+    yield
+    _post_store_hooks[:] = saved[0]
+    _post_store_batch_hooks[:] = saved[1]
+    _post_document_hooks[:] = saved[2]
+
+
+def _make_stub_t3():
+    """Stub T3Database for CLI helpers — deterministic doc_id, no chroma."""
+    import hashlib
+
+    class _StubT3:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def put(self, *, collection, content, title="", **kwargs):
+            return hashlib.sha256(f"{collection}:{title}".encode()).hexdigest()[:16]
+
+    return lambda: _StubT3()
+
+
+# ── nx store put ────────────────────────────────────────────────────────────
+
+
+class TestStorePutCli:
+    """``nx store put`` fires single, batch, document chains identically to MCP."""
+
+    def test_fires_all_three_chains_in_one_invocation(
+        self, reset_hook_chains, tmp_path,
+    ):
+        from nexus.cli import main
+        from nexus.mcp_infra import (
+            register_post_document_hook,
+            register_post_store_batch_hook,
+            register_post_store_hook,
+        )
+
+        single, batch, doc = [], [], []
+        register_post_store_hook(lambda d, c, content: single.append(d))
+        register_post_store_batch_hook(
+            lambda ds, c, cs, e, m: batch.append(list(ds))
+        )
+        register_post_document_hook(lambda src, c, content: doc.append(src))
+
+        f = tmp_path / "doc.md"
+        f.write_text("body for store put parity")
+
+        with patch("nexus.commands.store._t3", _make_stub_t3()):
+            runner = CliRunner()
+            result = runner.invoke(main, [
+                "store", "put", str(f),
+                "--collection", "knowledge",
+                "--title", "parity-store-put",
+            ])
+
+        assert result.exit_code == 0, result.output
+        assert len(single) == 1
+        assert len(batch) == 1
+        assert len(batch[0]) == 1
+        assert len(doc) == 1
+        # All chains see the same doc_id derived from content.
+        assert single[0] == batch[0][0]
+
+
+# ── nx memory promote ──────────────────────────────────────────────────────
+
+
+class TestMemoryPromoteCli:
+    """``nx memory promote`` fires the chains when promoting T2 → T3."""
+
+    def test_fires_all_three_chains_when_promoting(
+        self, reset_hook_chains, tmp_path, monkeypatch,
+    ):
+        from nexus.cli import main
+        from nexus.db.t2 import T2Database
+        from nexus.mcp_infra import (
+            register_post_document_hook,
+            register_post_store_batch_hook,
+            register_post_store_hook,
+        )
+
+        # T2 environment: a memory entry to promote. ``memory promote``
+        # takes the integer entry_id as its positional argument.
+        db_path = tmp_path / "t2.db"
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+        monkeypatch.setattr(
+            "nexus.config.is_local_mode", lambda: True,
+        )
+        db = T2Database(db_path)
+        entry_id = db.put(
+            project="proj-test", title="m-1", content="memory body",
+            tags="", ttl=None,
+        )
+        db.close()
+
+        single, batch, doc = [], [], []
+        register_post_store_hook(lambda d, c, content: single.append(d))
+        register_post_store_batch_hook(
+            lambda ds, c, cs, e, m: batch.append(list(ds))
+        )
+        register_post_document_hook(lambda src, c, content: doc.append(src))
+
+        with patch("nexus.db.make_t3", _make_stub_t3()):
+            runner = CliRunner()
+            result = runner.invoke(main, [
+                "memory", "promote", str(entry_id),
+                "--collection", "knowledge__memory",
+            ])
+
+        assert result.exit_code == 0, result.output
+        assert len(single) == 1, f"single chain not fired: {result.output}"
+        assert len(batch) == 1, f"batch chain not fired: {result.output}"
+        assert len(doc) == 1, f"document chain not fired: {result.output}"
+
+
+# ── nx store import ────────────────────────────────────────────────────────
+
+
+class TestStoreImportCli:
+    """``nx store import`` fires the chains for the imported batch."""
+
+    def test_fires_chains_with_full_batch(
+        self, reset_hook_chains, tmp_path,
+    ):
+        """A 3-record export imports as a 3-element batch on the chains."""
+        import gzip
+        import json
+
+        import msgpack
+
+        from nexus.cli import main
+        from nexus.mcp_infra import (
+            register_post_document_hook,
+            register_post_store_batch_hook,
+            register_post_store_hook,
+        )
+
+        # Synthesize a minimal .nxexp file: one header line + msgpack body.
+        export_path = tmp_path / "test.nxexp"
+        records = [
+            {
+                "id": f"id-{i}",
+                "document": f"content {i}",
+                "metadata": {"source_path": f"/x/doc-{i}.md"},
+                # 1024-dim float32 zero embedding (matches voyage-context-3
+                # collections' expected dim; size is what _validate uses,
+                # not the actual values).
+                "embedding": (b"\x00\x00\x00\x00" * 1024),
+            }
+            for i in range(3)
+        ]
+        with open(export_path, "wb") as f:
+            header = {
+                "format_version": 1,
+                "collection_name": "knowledge__import_test",
+                "embedding_model": "voyage-context-3",
+            }
+            f.write(json.dumps(header).encode() + b"\n")
+            with gzip.GzipFile(fileobj=f, mode="wb") as gz:
+                packer = msgpack.Packer()
+                for rec in records:
+                    gz.write(packer.pack(rec))
+
+        single, batch, doc = [], [], []
+        register_post_store_hook(lambda d, c, content: single.append(d))
+        register_post_store_batch_hook(
+            lambda ds, c, cs, e, m: batch.append(list(ds))
+        )
+        register_post_document_hook(lambda src, c, content: doc.append(src))
+
+        # Stub T3.upsert_chunks_with_embeddings so we don't write to chroma.
+        upsert_calls: list[dict] = []
+
+        class _StubT3:
+            def upsert_chunks_with_embeddings(self, **kwargs):
+                upsert_calls.append(kwargs)
+
+        with patch("nexus.commands.store._t3", lambda: _StubT3()):
+            runner = CliRunner()
+            result = runner.invoke(main, [
+                "store", "import", str(export_path),
+            ])
+
+        assert result.exit_code == 0, result.output
+        assert len(upsert_calls) == 1
+        # Every record fires the single + document chains;
+        # the batch fires once with all 3.
+        assert len(single) == 3
+        assert len(batch) == 1 and len(batch[0]) == 3
+        assert len(doc) == 3
+        # Document chain sees the source_path field, not the doc_id.
+        assert sorted(doc) == ["/x/doc-0.md", "/x/doc-1.md", "/x/doc-2.md"]
+
+
+# ── Drift guard: ensure new T3-write CLI paths don't skip the helper ───────
+
+
+class TestDriftGuard:
+    """AST-level guard: every T3-write CLI command calls fire_store_chains.
+
+    Catches the regression shape that produced nexus-9099: a new CLI
+    command that calls T3.put() / upsert_chunks_with_embeddings() but
+    forgets to fire the post-store chains.
+    """
+
+    def test_known_t3_write_paths_use_fire_store_chains(self):
+        """The three known broken paths now reference fire_store_chains."""
+        store_py = Path("src/nexus/commands/store.py").read_text()
+        memory_py = Path("src/nexus/commands/memory.py").read_text()
+        exporter_py = Path("src/nexus/exporter.py").read_text()
+
+        assert "fire_store_chains" in store_py, (
+            "src/nexus/commands/store.py must call fire_store_chains "
+            "from put_cmd (nexus-9099 regression)"
+        )
+        assert "fire_store_chains" in memory_py, (
+            "src/nexus/commands/memory.py must call fire_store_chains "
+            "from promote (nexus-9099 regression)"
+        )
+        assert "fire_store_chains" in exporter_py, (
+            "src/nexus/exporter.py must call fire_store_chains "
+            "from import_collection (nexus-9099 regression)"
+        )
+
+    def test_fire_store_chains_called_after_t3_put_in_put_cmd(self):
+        """In commands/store.py:put_cmd, fire_store_chains must follow t3.put."""
+        src = Path("src/nexus/commands/store.py").read_text()
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "put_cmd":
+                names = [
+                    n.func.attr if isinstance(n.func, ast.Attribute)
+                    else (n.func.id if isinstance(n.func, ast.Name) else "")
+                    for n in ast.walk(node) if isinstance(n, ast.Call)
+                ]
+                assert "fire_store_chains" in names, (
+                    "put_cmd must call fire_store_chains after t3.put"
+                )
+                return
+        pytest.fail("put_cmd not found in commands/store.py")


### PR DESCRIPTION
Closes nexus-9099. Closes #335.

## The bug

RDR-095 established symmetric-fire for the bulk `nx index *` ingest paths but three CLI paths shipped firing zero hook chains:

| CLI path | single-doc chain | batch chain | document chain |
|----------|------------------|-------------|----------------|
| `nx store put` | missing | missing | missing |
| `nx memory promote` | missing | missing | missing |
| `nx store import` | missing | missing | missing |

Downstream effect: chash_index never gets the row (RDR-086), taxonomy never assigned (RDR-070), aspect-extraction queue never enqueues (RDR-089). Catalog row + chroma chunk are correct; everything that depends on post-store enrichment misses the document.

`nx collection audit` and `nx collection health` don't flag the drift because they only count chroma chunks, not the chash/topic alignment.

## Gap analysis (from this session)

| Hook chain | MCP `store_put` | CLI bulk `nx index *` | CLI `nx store put` | CLI `nx memory promote` | CLI `nx store import` |
|------------|-----------------|----------------------|--------------------|-----------------------|----------------------|
| single-doc | yes | yes (7 sites) | **no** | **no** | **no** |
| batch | yes | yes (7 sites) | **no** | **no** | **no** |
| document-grain | yes | yes (7 sites) | **no** | **no** | **no** |
| catalog auto-link | yes | no (intentional, CLAUDE.md) | no | no | no |
| relevance log | yes | no (intentional) | no | no | no |

## The fix

New helper `mcp_infra.fire_store_chains(doc_ids, collection, contents, *, source_paths=None, embeddings=None, metadatas=None)` that fires single-doc, batch, and document-grain chains in order with consistent error handling. Wired into:

- `commands/store.py:put_cmd` (1-element batch, source_path=doc_id)
- `commands/memory.py:promote_cmd` (1-element batch, source_path=doc_id)
- `exporter.py:import_collection` (full batch, source_paths from metadata so the document chain sees original on-disk paths)

MCP `store_put` continues to call the three fire functions directly because `test_hook_drift_guard` AST-counts those three names verbatim in mcp/core.py to enforce the 7-CLI + 1-MCP fire-site invariant. Added a comment at the call site explaining why the direct calls stay.

## Test plan

- [x] 5 new tests in `tests/test_store_put_cli_parity.py` (per-path firing + drift guard).
- [x] 88 existing hook + drift-guard + MCP-server tests green.
- [x] 148 store + memory + exporter + post_store_hook tests green.
- [x] **Sandbox smoke**: PASSED (changes touch `src/nexus/mcp/**` and `src/nexus/exporter.py`).

## Acceptance criteria

- [x] (1) Audit CLI vs MCP and converge on shared upsert function: `fire_store_chains` is the shared helper.
- [ ] (2) Verify-roundtrip after upsert: out of scope for this PR. The actual bug was hook-chain divergence, not chunks failing to land in chroma. Filing as follow-up if needed.
- [x] (3) Integration test writes via CLI and confirms hook firing in same test (no mocks at the storage boundary for the hook fire, the test uses real registered probes that count invocations).
- [ ] (4) `nx collection audit --verify-chroma` mode: explicitly listed as a separate bead in the original nexus-9099 description.

## RDR-095 follow-up consideration

This is the second time the symmetric-fire RDR-095 was missed for a CLI write path. Consider expanding the AST drift guard in `tests/test_hook_drift_guard.py` to scan all `commands/*.py` modules for `t3.put` / `db.put` / `upsert_chunks_with_embeddings` calls and require a corresponding `fire_store_chains` call. Filing as a follow-up bead.