### PR TITLE
fix(hook): nx hook session-start no longer hangs on TTY stdin (nexus-rv2x)

### DIFF
--- a/src/nexus/commands/hook.py
+++ b/src/nexus/commands/hook.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+from typing import IO
 
 import click
 import structlog
@@ -10,6 +11,43 @@ import structlog
 from nexus import hooks
 
 _log = structlog.get_logger()
+
+
+def _read_stdin_session_id(stream: IO[str]) -> str | None:
+    """Read and parse a Claude-Code SessionStart JSON payload from *stream*.
+
+    Returns the ``session_id`` field or ``None`` when no usable payload
+    is available. Designed to be safe against the three problematic
+    inputs that produced nexus-rv2x:
+
+    * **TTY stdin** (no piped input). Reading would block until EOF
+      (Ctrl+D) or process death. Detected via ``isatty()`` and skipped
+      without calling ``read()``.
+    * **Empty / closed pipe**. ``read()`` returns ``""`` promptly;
+      ``json.loads`` raises; helper returns ``None``.
+    * **Malformed JSON**. Same swallow-and-return-None as empty.
+
+    The Claude Code invocation path is unchanged: a pipe carrying a
+    valid JSON payload reads and returns the ``session_id`` as before.
+    """
+    try:
+        if stream.isatty():
+            return None
+        raw = stream.read()
+    except Exception as exc:
+        _log.debug("session_start_stdin_read_failed", error=str(exc))
+        return None
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except Exception as exc:
+        _log.debug("session_start_stdin_parse_failed", error=str(exc))
+        return None
+    if not isinstance(data, dict):
+        return None
+    sid = data.get("session_id")
+    return sid if isinstance(sid, str) and sid else None
 
 
 @click.group("hook")
@@ -20,13 +58,9 @@ def hook_group() -> None:
 @hook_group.command("session-start")
 def session_start_cmd() -> None:
     """Run the SessionStart hook (called by Claude Code on session open)."""
-    # Claude Code pipes a JSON payload to stdin with session_id
-    claude_session_id = None
-    try:
-        data = json.loads(sys.stdin.read())
-        claude_session_id = data.get("session_id")
-    except Exception as exc:
-        _log.debug("session_start_stdin_parse_failed", error=str(exc))
+    # nexus-rv2x: TTY-aware stdin parse. Skips read() on a TTY so
+    # ``nx hook session-start`` invoked from a shell does not hang.
+    claude_session_id = _read_stdin_session_id(sys.stdin)
     output = hooks.session_start(claude_session_id=claude_session_id)
     click.echo(output)
 

--- a/tests/test_hook_cli.py
+++ b/tests/test_hook_cli.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-rv2x: ``nx hook session-start`` must not hang on TTY stdin.
+
+The bug: ``session_start_cmd`` calls ``sys.stdin.read()`` unconditionally
+to parse the Claude-Code JSON payload. When stdin is a TTY with no data
+(any non-Claude-Code invocation: shell pipeline, ad-hoc CLI run with no
+piped input, test harness), the call blocks indefinitely. Claude Code
+itself remains usable because the 10s timeout in ``nx/hooks/hooks.json``
+bounds the SessionStart entry, but the CLI surface is broken for any
+out-of-band invocation.
+
+Repro that surfaced the bug::
+
+    nx hook session-start | wc -lc      # hangs forever; ^C to escape
+    echo '{}' | nx hook session-start    # returns immediately (correct)
+
+The fix: factor the stdin-payload read into a helper that is testable
+without going through Click's CliRunner (which substitutes its own
+StringIO for sys.stdin and so cannot reproduce the TTY-blocked case).
+The helper checks ``isatty()`` first; if True, it returns ``None``
+without reading.
+"""
+from __future__ import annotations
+
+import io
+
+
+# ── _read_stdin_session_id helper ──────────────────────────────────────────
+
+
+class TestReadStdinSessionId:
+    """The helper extracted from ``session_start_cmd``.
+
+    Tests pass an explicit stdin so the TTY-vs-pipe behaviour can be
+    exercised directly. CliRunner-based tests can't reproduce the bug
+    because Click substitutes its own StringIO for sys.stdin.
+    """
+
+    def test_tty_stdin_returns_none_without_reading(self):
+        """When stdin.isatty() is True, the helper returns None and
+        does NOT call .read() (which would block forever on a real TTY).
+        """
+        from nexus.commands.hook import _read_stdin_session_id
+
+        class _TtyStream(io.StringIO):
+            def isatty(self) -> bool:
+                return True
+
+            def read(self, *a, **kw):
+                raise AssertionError(
+                    "must not call read() when isatty()=True"
+                )
+
+        result = _read_stdin_session_id(_TtyStream())
+        assert result is None
+
+    def test_piped_json_with_session_id_returns_id(self):
+        """Pipe carrying valid JSON with session_id returns the id."""
+        from nexus.commands.hook import _read_stdin_session_id
+
+        stdin = io.StringIO('{"session_id": "abc-123"}')
+        # StringIO.isatty() returns False by default — matches a real pipe.
+        assert _read_stdin_session_id(stdin) == "abc-123"
+
+    def test_piped_json_without_session_id_returns_none(self):
+        from nexus.commands.hook import _read_stdin_session_id
+
+        stdin = io.StringIO("{}")
+        assert _read_stdin_session_id(stdin) is None
+
+    def test_empty_piped_stdin_returns_none(self):
+        """Closed/empty pipe returns None (read() returns '', JSON
+        decode fails, helper swallows and returns None).
+        """
+        from nexus.commands.hook import _read_stdin_session_id
+
+        stdin = io.StringIO("")
+        assert _read_stdin_session_id(stdin) is None
+
+    def test_malformed_json_returns_none(self):
+        """Malformed JSON is logged-and-swallowed; the helper does not
+        raise to the CLI surface.
+        """
+        from nexus.commands.hook import _read_stdin_session_id
+
+        stdin = io.StringIO("not json {{")
+        assert _read_stdin_session_id(stdin) is None
+
+    def test_unexpected_read_exception_returns_none(self):
+        """If stdin.read() raises (closed file, OS error), the helper
+        returns None instead of crashing the hook.
+        """
+        from nexus.commands.hook import _read_stdin_session_id
+
+        class _BrokenStdin(io.StringIO):
+            def isatty(self) -> bool:
+                return False
+
+            def read(self, *a, **kw):
+                raise OSError("simulated read failure")
+
+        result = _read_stdin_session_id(_BrokenStdin())
+        assert result is None


### PR DESCRIPTION
Closes nexus-rv2x. P2 bug.

## Stacking

Stacked on #360, which is stacked on #359. Will retarget when the parent merges.

## The bug

\`nx hook session-start\` calls \`sys.stdin.read()\` unconditionally to parse the Claude-Code JSON payload. When stdin is a TTY with no piped data (any non-Claude-Code invocation: shell pipeline, ad-hoc CLI run with no piped input, test harness), the read blocks forever.

Original repro that surfaced the bug:

\`\`\`
nx hook session-start | wc -lc      # hangs forever; ^C to escape
echo '{}' | nx hook session-start    # returns immediately (correct)
\`\`\`

In production the 10s timeout in \`nx/hooks/hooks.json\` bounds the SessionStart entry, so Claude Code remains usable. The CLI surface, validation harnesses, and shell pipelines were all broken.

## The fix

Extract a \`_read_stdin_session_id(stream)\` helper that short-circuits on \`stream.isatty() == True\` without calling \`read()\`. Pipes and files (the Claude Code path) are unchanged.

The helper is also testable without going through Click's \`CliRunner\` (which substitutes its own StringIO for \`sys.stdin\` and so cannot reproduce the TTY-blocked case). Tests pass an explicit stream so \`isatty()\` can be controlled.

## Tests (6 new)

| Case | Behaviour |
|------|-----------|
| TTY stdin | returns None, never calls read() |
| Piped JSON with session_id | returns the id |
| Piped JSON without session_id | returns None |
| Empty piped stdin | returns None |
| Malformed JSON | returns None (swallowed) |
| read() exception | returns None (swallowed) |

46 hook-related tests green (\`test_hooks\`, \`test_hook_telemetry\`, \`test_hook_drift_guard\`, \`test_hook_cli\`).

## Test plan

- [x] \`tests/test_hook_cli.py\`: 6 new tests green.
- [x] \`tests/test_hooks.py\` + \`tests/test_hook_telemetry.py\` + \`tests/test_hook_drift_guard.py\`: 40 existing tests green (no regressions).
- [x] Real CLI smoke: \`nx hook session-start < /dev/null\` returns promptly; \`echo '{"session_id":"x"}' | nx hook session-start\` parses the id.
- [ ] Sandbox smoke: not required (\`commands/hook.py\` is not in the trigger surface).

## Out of scope

The bead notes that other \`nx hook *\` subcommands probably have the same hazard. \`session_end\`, \`session-end-flush\`, and \`session-end-detach\` were audited in this fix: none of them read stdin, so the hazard is isolated to \`session-start\`.