### PR TITLE
fix(hooks): drop PreToolUse Bash timeout 300s -> 5s

### DIFF
--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -100,7 +100,7 @@
           {
             "type": "command",
             "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/pre_close_verification_hook.sh",
-            "timeout": 300
+            "timeout": 5
           }
         ]
       }

--- a/tests/hooks/test_verification_integration.py
+++ b/tests/hooks/test_verification_integration.py
@@ -112,10 +112,23 @@ class TestHooksJsonStructure:
         assert hook["timeout"] == 180
 
     def test_hooks_json_pretooluse_timeout(self) -> None:
+        """The advisory hook must have a tight ceiling.
+
+        Was 300s in the original RDR-024 / RDR-065 wiring; tightened
+        to 5s to match the SessionStart fast-path hooks. The script
+        body (read stdin, JSON out, exit 0) completes in <100ms, so
+        a long ceiling masks real stalls. Pinning low (<=10s) so any
+        future drift toward "minutes" trips this test rather than
+        blocking every Bash tool call for that ceiling.
+        """
         data = json.loads(HOOKS_JSON.read_text())
         pre_hooks = data["hooks"]["PreToolUse"]
         hook = pre_hooks[0]["hooks"][0]
-        assert hook["timeout"] == 300
+        assert hook["timeout"] <= 10, (
+            f"PreToolUse Bash timeout {hook['timeout']}s is too high; "
+            f"the advisory hook should never need >5s. A long ceiling "
+            f"masks real stalls."
+        )
 
     def test_hooks_json_pretooluse_matcher_is_bash(self) -> None:
         data = json.loads(HOOKS_JSON.read_text())

--- a/tests/test_upgrade_e2e.py
+++ b/tests/test_upgrade_e2e.py
@@ -219,6 +219,39 @@ class TestSC8HooksJson:
         assert startup_hooks[0]["command"].startswith("nx upgrade --auto")
         assert startup_hooks[0]["timeout"] == 30
 
+    def test_pretooluse_bash_timeout_is_short(self) -> None:
+        """PreToolUse Bash timeout must stay short.
+
+        ``pre_close_verification_hook.sh`` is advisory (read stdin, JSON
+        out, exit 0); the body completes in <100 ms. A long timeout is a
+        footgun: a future bug or filesystem stall would block every
+        ``Bash`` tool call by that ceiling. Pinning low so any drift
+        toward "minutes" trips this test instead of the user.
+
+        Earlier shape used ``timeout: 300`` which would have masked a
+        five-minute stall in the hook with no operator visibility. The
+        bound here matches the SessionStart fast-path hooks (5 s).
+        """
+        hooks_path = Path(__file__).parent.parent / "nx" / "hooks" / "hooks.json"
+        data = json.loads(hooks_path.read_text())
+        bash_blocks = [
+            h for h in data["hooks"].get("PreToolUse", [])
+            if h.get("matcher") == "Bash"
+        ]
+        assert bash_blocks, "PreToolUse Bash matcher missing from hooks.json"
+        for block in bash_blocks:
+            for hook in block.get("hooks", []):
+                timeout = hook.get("timeout")
+                assert isinstance(timeout, int), (
+                    f"PreToolUse Bash hook missing/invalid timeout: {hook!r}"
+                )
+                assert timeout <= 10, (
+                    f"PreToolUse Bash timeout {timeout}s is too high. "
+                    f"This hook is advisory and should never need >5 s. "
+                    f"A long ceiling masks real stalls — keep it tight "
+                    f"(<=10 s)."
+                )
+
 
 # ── SC-9: Existing install bootstrapping ────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `nx/hooks/hooks.json` PreToolUse Bash matcher: `timeout: 300` → `timeout: 5`
- New test `TestSC8HooksJson::test_pretooluse_bash_timeout_is_short` pinning the bound at <=10s

## Why

`pre_close_verification_hook.sh` is fast by construction. Two no-op fast paths exit before any heavy work (non-Bash tool → exit; non-`bd close|done|create` command → exit). Even on the slow paths it's three python3 invocations totalling ~100 ms.

The 300s ceiling was a footgun. If anything ever stalled — fs slow, T1 scratch unreachable, python3 import hang — every `Bash` tool call would block for five minutes with no operator visibility. 5s matches the SessionStart fast-path hooks and is comfortably above the actual budget.

## Context

Surfaced during v4.18.0 release prep. The proximate cause of the multi-minute hangs in that session was the third-party `hookify` plugin PostToolUse Python on every tool call, NOT this hook. This change is defense-in-depth hardening: keeps the RDR-065 commitment-metadata enforcement and the RDR-024 review-marker advisory intact, just stops a hypothetical future stall from masking itself behind a 5-minute ceiling.

## Test plan

- [x] `uv run pytest tests/test_upgrade_e2e.py::TestSC8HooksJson` passes (2 tests).
- [x] No other tests reference the previous 300s timeout (grepped).
- [x] Hook script body unchanged — only the manifest timeout flips.