### PR TITLE
fix(test): pin spawn start method for multiprocessing concurrency tests + workflow timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,12 @@ jobs:
   test:
     name: pytest (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # Match the CI workflow's 15-min ceiling. Without this, a hanging
+    # test (e.g. an unreaped multiprocessing subprocess from a fork-with-
+    # threads deadlock) would stall the release job indefinitely, blocking
+    # PyPI publish until manually cancelled. Hit during the v4.18.0
+    # tag-push: pytest 3.13 ran 36+ min before manual cancel.
+    timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:

--- a/tests/test_mcp_concurrency.py
+++ b/tests/test_mcp_concurrency.py
@@ -4,6 +4,27 @@
 Uses multiprocessing.Process (not threads) to validate actual cross-process
 SQLite WAL contention, matching the real deployment scenario of multiple
 nx-mcp processes.
+
+Start method is pinned to ``spawn`` (via ``multiprocessing.get_context``)
+because ``fork`` is unsafe in this test's parent: pytest has imported
+chromadb + nexus.db.t1 + nexus.db.t3, all of which spin up background
+threads. Forking a multi-threaded parent can copy locks in an acquired
+state, which deadlocks the child indefinitely. The test originally hit
+this on Python 3.13 GitHub Actions runners during the v4.18.0 release
+job — one writer subprocess hung past the 30 s join timeout, leaving
+``p.exitcode == None`` and the assertion firing on a non-zero exit.
+The orphan subprocess then blocked pytest cleanup, hanging the whole
+job until manual cancellation.
+
+Python 3.12 raised ``DeprecationWarning: use of fork() may lead to
+deadlocks in the child``; 3.14 made ``forkserver`` the default on
+POSIX. Pinning ``spawn`` here removes the issue on every supported
+Python version (3.12 and 3.13). See:
+
+  * https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555
+  * https://github.com/python/cpython/issues/146313 (3.13 resource_tracker
+    shutdown waitpid hang on fork-spawned processes — a second 3.13
+    failure mode that ``spawn`` also avoids)
 """
 from __future__ import annotations
 
@@ -17,6 +38,14 @@ import pytest
 from nexus.db.t1 import T1Database
 from nexus.db.t2 import T2Database
 from nexus.db.t3 import T3Database
+
+# Module-scope context so every Process/Manager in this file uses spawn.
+# Do NOT use ``multiprocessing.set_start_method("spawn")`` — that is
+# process-global and clobbers other tests / fixtures that may rely on
+# the platform default. ``get_context("spawn")`` returns a scoped
+# context whose ``Process``/``Manager`` honour the spawn semantics
+# without touching global state.
+_MP = multiprocessing.get_context("spawn")
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -95,7 +124,7 @@ def test_t2_concurrent_writes():
     processes = []
 
     for i in range(n_processes):
-        p = multiprocessing.Process(
+        p = _MP.Process(
             target=_t2_writer,
             args=(str(db_path), f"proj-{i}", entries_per_process),
         )
@@ -135,14 +164,14 @@ def test_t2_concurrent_reads_during_writes():
         db.put(project="readtest", title=f"seed-{i}", content=f"seed content {i}")
     db.close()
 
-    manager = multiprocessing.Manager()
+    manager = _MP.Manager()
     result_list = manager.list()
 
     # Start a writer and reader concurrently
-    writer = multiprocessing.Process(
+    writer = _MP.Process(
         target=_t2_writer, args=(str(db_path), "readtest-write", 20)
     )
-    reader = multiprocessing.Process(
+    reader = _MP.Process(
         target=_t2_reader, args=(str(db_path), "readtest", result_list)
     )
 


### PR DESCRIPTION
## Summary

Root-causes the v4.18.0 release-job hang and adds defense-in-depth.

- `tests/test_mcp_concurrency.py`: switch from default `multiprocessing.Process` (fork on POSIX) to a module-scoped `multiprocessing.get_context("spawn")`. Eliminates the fork-with-threads deadlock that hung Python 3.13's release-job pytest run for 36+ min.
- `.github/workflows/release.yml`: add `timeout-minutes: 15` to the test job, matching ci.yml. So a future hang fails fast instead of stalling the publish step indefinitely.

## Root cause

`pytest` imports `chromadb` + `nexus.db.{t1,t3}`. Those libraries spin up background threads. When `multiprocessing.Process` forks the parent, **locks held by background threads at fork time are copied into the child in an acquired state**, and the child can deadlock trying to acquire one of them. Python 3.12 raised `DeprecationWarning: use of fork() may lead to deadlocks in the child` for exactly this case; Python 3.14 made `forkserver` the default on POSIX. We support 3.12 and 3.13, so the fix has to be explicit until we drop those.

The 3.13 job was hit harder than 3.12 partly because Python 3.13 also has a `resource_tracker` shutdown waitpid hang (cpython#146313) that compounds the problem on fork-spawned processes.

`spawn` always creates a fresh interpreter, so no parent state crosses the process boundary. No fork-with-threads issue, no resource_tracker hang.

## Test plan

- [x] `uv run pytest tests/test_mcp_concurrency.py -v` — 4/4 pass in 3.56 s on Python 3.12.
- [ ] CI exercises Python 3.13 — that's the path that was failing.

## After this merges

Re-tag v4.18.0 (delete the cancelled tag, re-push on the new commit) so the Release workflow re-fires with the fix included. PyPI doesn't have v4.18.0 yet — the cancelled run never hit the publish step.

## References

- https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555
- https://github.com/python/cpython/issues/146313