### PR TITLE
fix(doctor): --check-taxonomy O(N×M) hang → O(N+M) on real catalogs

### DIFF
--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -1345,22 +1345,30 @@ def _run_check_taxonomy() -> None:
     # flagging drift. Shakeout on live data: 15 of 20 residual drift
     # rows after a backfill were isolated topics that could never
     # produce a link.
+    # The NOT EXISTS form (``tl.from_topic_id = ta.topic_id OR
+    # tl.to_topic_id = ta.topic_id``) defeats SQLite's index planner —
+    # the OR forces a covering scan of topic_links per outer row, which
+    # multiplies with the topic_assignments scan into billions of row
+    # touches on real-size catalogs (~526k × 13k = ~7B comparisons in
+    # one production database, hanging the check past 30s). Pre-build
+    # the linked-topic set with a UNION (uses the topic_links primary
+    # key for both halves) and reduce to a single fast NOT IN.
     drift_rows = conn.execute(
         """
         SELECT DISTINCT ta.topic_id, t.label, t.collection
           FROM topic_assignments ta
           LEFT JOIN topics t ON t.id = ta.topic_id
          WHERE ta.assigned_by = 'projection'
+           AND ta.topic_id NOT IN (
+               SELECT from_topic_id FROM topic_links
+               UNION
+               SELECT to_topic_id   FROM topic_links
+           )
            AND EXISTS (
                SELECT 1 FROM topic_assignments ta2
                 WHERE ta2.doc_id      = ta.doc_id
                   AND ta2.topic_id    != ta.topic_id
                   AND ta2.assigned_by = 'projection'
-           )
-           AND NOT EXISTS (
-               SELECT 1 FROM topic_links tl
-                WHERE tl.from_topic_id = ta.topic_id
-                   OR tl.to_topic_id   = ta.topic_id
            )
         """
     ).fetchall()

--- a/tests/e2e/devonthink-manual.md
+++ b/tests/e2e/devonthink-manual.md
@@ -91,9 +91,11 @@ Each AC corresponds to a bullet in [RDR-099 § Acceptance criteria](../../docs/r
    selected record. No catalog write.
 3. `nx dt index --selection`; verify summary line `Indexed N
    record(s) (M skipped).` where `N` matches step 2's count.
-4. `nx catalog list --source-uri-prefix x-devonthink-item://`;
-   verify N new entries appear (the prefix filter narrows to DT-keyed
-   entries indexed in step 3).
+4. `nx catalog list --json | jq '.[] | select(.source_uri | startswith("x-devonthink-item://"))'`;
+   verify N new entries appear (the JSON filter narrows to DT-keyed
+   entries indexed in step 3). `nx catalog list` has no built-in
+   `--source-uri-prefix` flag in v1; the JSON pipe is the canonical
+   query path.
 5. For each new entry, `nx catalog show <tumbler> --json`; verify
    `source_uri == "x-devonthink-item://<UUID>"` and
    `meta.devonthink_uri` matches.
@@ -102,7 +104,8 @@ Each AC corresponds to a bullet in [RDR-099 § Acceptance criteria](../../docs/r
 
 ```bash
 nx dt index --uuid "$NEXUS_DT_TEST_UUID"
-nx catalog list --source-uri-prefix "x-devonthink-item://$NEXUS_DT_TEST_UUID"
+nx catalog list --json | jq --arg u "$NEXUS_DT_TEST_UUID" \
+  '.[] | select(.source_uri == "x-devonthink-item://" + $u)'
 ```
 
 Verify: exactly one entry, with `source_uri == x-devonthink-item://$NEXUS_DT_TEST_UUID`
@@ -166,7 +169,9 @@ Switch to DT; verify the record is selected and visible.
 
 ```bash
 # Tumbler form; uses an entry indexed earlier (e.g. from AC-1).
-nx catalog list --source-uri-prefix x-devonthink-item:// | head -5
+nx catalog list --json \
+  | jq -r '.[] | select(.source_uri | startswith("x-devonthink-item://")) | .tumbler' \
+  | head -5
 nx dt open <tumbler-from-list>
 ```
 
@@ -208,7 +213,8 @@ doesn't see stale data:
 
 ```bash
 # List DT-keyed entries created during the smoke.
-nx catalog list --source-uri-prefix x-devonthink-item://
+nx catalog list --json \
+  | jq '.[] | select(.source_uri | startswith("x-devonthink-item://"))'
 
 # Remove them by tumbler (one at a time, or pipe through xargs).
 nx catalog remove <tumbler>


### PR DESCRIPTION
## Summary

`nx doctor --check-taxonomy` hangs past 30s with no output on real-size catalogs. Caught during v4.19.0 live shakeout.

**Root cause**: the drift-detection query uses `NOT EXISTS` with an `OR`:

\`\`\`sql
NOT EXISTS (
    SELECT 1 FROM topic_links tl
     WHERE tl.from_topic_id = ta.topic_id
        OR tl.to_topic_id   = ta.topic_id
)
\`\`\`

The `OR` defeats SQLite's index planner. Instead of using the `topic_links` primary-key index `(from_topic_id, to_topic_id)`, each outer row triggers a covering scan of all `topic_links` rows.

\`EXPLAIN QUERY PLAN\`:

\`\`\`
|--SCAN ta                                    ← 526k rows
|--CORRELATED SCALAR SUBQUERY 1
|  `--SEARCH ta2 USING INDEX (doc_id=?)        ← OK
|--CORRELATED SCALAR SUBQUERY 2
|  `--SCAN tl USING COVERING INDEX             ← 13k rows × every outer row
\`\`\`

On one local DB: 526,100 × 13,178 ≈ **6.93 billion row comparisons**. Hangs at 30s+, no result.

**Fix**: restructure as `NOT IN (SELECT from_topic_id UNION SELECT to_topic_id)`. Each half uses the primary-key index; the union materialises into a hash set the outer scan probes once per row.

Same catalog: **30s+ → 0.42s** (>71× improvement). Drift output unchanged.

## Closes

Closes nexus-qi19.

## Test plan

- [x] All 6 `tests/test_phase5_integration.py::TestDoctorCheckTaxonomy` tests pass — query is semantically equivalent, only the query plan changes.
- [x] Manually verified on production-size DB: 526k assignments / 13k links / 2127 topics → 0.42s with same drift result.