### PR TITLE
fix(dt): stamp DT URI on catalog entry after index (RDR-099 AC-1)

### DIFF
--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -51,6 +51,14 @@ def _index_record(
     summary line see the skip count without having to introspect the
     dispatcher's internals.
 
+    After the indexer registers the catalog entry (with the resolved
+    ``file://`` source_uri it sees), this function stamps the DT
+    identity onto the entry: ``source_uri = x-devonthink-item://<UUID>``
+    and ``meta.devonthink_uri`` set to the same value. RDR-099 AC-1
+    requires this — the catalog identity must be stable across DT
+    relocations, and the file path returned by osascript at index time
+    is not (DT moves files inside Files.noindex/ on its own schedule).
+
     Tests monkeypatch this single function rather than the heavyweight
     ``doc_indexer`` machinery so the CLI surface is exercised
     independently of Voyage credentials and Chroma clients.
@@ -69,6 +77,82 @@ def _index_record(
         index_pdf(file_path, corpus=corpus, collection_name=collection)
     else:  # .md — extension filtering happens in index_cmd
         index_markdown(file_path, corpus=corpus)
+
+    _stamp_dt_uri_on_entry(file_path, uuid)
+
+
+def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> None:
+    """Set ``source_uri`` and ``meta.devonthink_uri`` on the catalog
+    entry that was just indexed for ``file_path``.
+
+    The indexer registers the entry with the resolved local path as
+    ``source_uri`` (``file://...``); this is fine for non-DT ingest but
+    breaks RDR-099 AC-1, where the catalog identity must survive DT
+    moving the underlying file inside its ``Files.noindex/`` tree.
+    Looking up the entry by ``file_path`` immediately after the indexer
+    call is reliable because no other registrar runs between the two.
+
+    Failures are logged and swallowed: a stamp miss should not abort
+    the whole ``nx dt index`` run. The resulting catalog entry is still
+    usable, just without the round-trip property; ``nx catalog
+    remediate-paths`` (RDR-096 substrate) plus a manual ``nx catalog
+    update`` can recover after the fact.
+    """
+    from nexus.catalog import resolve_tumbler  # noqa: PLC0415
+    from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+    from nexus.config import catalog_path  # noqa: PLC0415
+
+    dt_uri = f"x-devonthink-item://{uuid}"
+    cat_path = catalog_path()
+    if not Catalog.is_initialized(cat_path):
+        _log.warning(
+            "dt_stamp_skipped_uninitialized_catalog",
+            file_path=str(file_path),
+            uuid=uuid,
+        )
+        return
+
+    cat = Catalog(cat_path, cat_path / ".catalog.db")
+    try:
+        # Globally find the entry by file_path — no owner constraint
+        # because we don't know it from here. ``documents`` is keyed
+        # by tumbler primary key plus a unique (file_path) row per
+        # indexed file, so this returns one row.
+        row = cat._db.execute(
+            "SELECT tumbler FROM documents WHERE file_path = ? LIMIT 1",
+            (str(file_path),),
+        ).fetchone()
+        if row is None:
+            _log.warning(
+                "dt_stamp_no_entry_found",
+                file_path=str(file_path),
+                uuid=uuid,
+            )
+            return
+
+        from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
+
+        tumbler = Tumbler.parse(row[0])
+        cat.update(
+            tumbler,
+            source_uri=dt_uri,
+            meta={"devonthink_uri": dt_uri},
+        )
+        _log.debug(
+            "dt_stamp_applied",
+            tumbler=str(tumbler),
+            uuid=uuid,
+            dt_uri=dt_uri,
+        )
+    except Exception as e:
+        _log.warning(
+            "dt_stamp_failed",
+            file_path=str(file_path),
+            uuid=uuid,
+            error=str(e),
+        )
+    finally:
+        cat._db.close()
 
 
 @click.group("dt")

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -644,3 +644,169 @@ class TestSelectDtUriFromEntry:
             _select_dt_uri_from_entry(entry)
             == "x-devonthink-item://FALLBACK"
         )
+
+
+# ── _stamp_dt_uri_on_entry (post-index identity stamp) ───────────────────────
+
+
+class TestStampDtUriOnEntry:
+    """RDR-099 AC-1 requires every catalog entry produced by
+    ``nx dt index`` to have ``source_uri == x-devonthink-item://<UUID>``
+    AND ``meta.devonthink_uri`` matching. The indexer registers the
+    entry with the resolved local ``file://`` path; ``_stamp_dt_uri_on_entry``
+    runs afterwards to overwrite both fields with the DT identity.
+    """
+
+    def _setup_catalog_with_entry(self, tmp_path, file_path):
+        """Stand up a catalog with a single registered entry pointing
+        at ``file_path`` (mimics the post-index state before the
+        stamp helper runs). Returns the catalog instance."""
+        from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+
+        cat = Catalog.init(tmp_path / "catalog")
+        owner = cat.register_owner(
+            "test-repo", "repo", repo_hash="cafebabe",
+        )
+        cat.register(
+            owner=owner,
+            title="A Test PDF",
+            file_path=str(file_path),
+            content_type="paper",
+        )
+        return cat
+
+    def test_stamps_source_uri_and_meta_devonthink_uri(
+        self, tmp_path, monkeypatch,
+    ):
+        """Happy path: indexer-registered entry with file:// source_uri
+        becomes a DT-keyed entry after the stamp runs."""
+        from nexus.commands.dt import _stamp_dt_uri_on_entry
+
+        file_path = tmp_path / "a.pdf"
+        file_path.write_bytes(b"%PDF-1.4 dt-stamp")
+        cat = self._setup_catalog_with_entry(tmp_path, file_path)
+        cat_dir = tmp_path / "catalog"
+        monkeypatch.setattr(
+            "nexus.config.catalog_path", lambda: cat_dir,
+        )
+
+        uuid = "8EDC855D-213F-40AD-A9CF-9543CC76476B"
+        _stamp_dt_uri_on_entry(file_path, uuid)
+
+        # Reopen so we read post-write state.
+        from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+
+        cat2 = Catalog(cat_dir, cat_dir / ".catalog.db")
+        try:
+            entries = cat2.all_documents()
+            target = next(
+                e for e in entries if e.file_path == str(file_path)
+            )
+            assert target.source_uri == f"x-devonthink-item://{uuid}"
+            assert target.meta.get("devonthink_uri") == (
+                f"x-devonthink-item://{uuid}"
+            )
+        finally:
+            cat2._db.close()
+
+    def test_no_entry_match_logs_and_returns(
+        self, tmp_path, monkeypatch,
+    ):
+        """When no catalog entry matches the file_path (rare —
+        post-index, but possible if a concurrent purge runs), the
+        stamp helper logs a warning and returns cleanly. It must not
+        raise."""
+        from nexus.commands.dt import _stamp_dt_uri_on_entry
+
+        # Initialise a catalog but DON'T register any entry.
+        from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+
+        cat_dir = tmp_path / "catalog"
+        Catalog.init(cat_dir)
+        monkeypatch.setattr(
+            "nexus.config.catalog_path", lambda: cat_dir,
+        )
+
+        file_path = tmp_path / "ghost.pdf"
+        # Should not raise.
+        _stamp_dt_uri_on_entry(file_path, "GHOST-UUID")
+
+    def test_uninitialized_catalog_logs_and_returns(
+        self, tmp_path, monkeypatch,
+    ):
+        """When the catalog is not initialised at all, the stamp
+        helper logs and returns instead of raising. Production callers
+        always initialise the catalog before indexing, but the
+        defence keeps the dt index summary intact rather than
+        bubbling a startup error."""
+        from nexus.commands.dt import _stamp_dt_uri_on_entry
+
+        # No Catalog.init call — catalog dir doesn't exist as a catalog.
+        bogus = tmp_path / "no-catalog-here"
+        bogus.mkdir()
+        monkeypatch.setattr(
+            "nexus.config.catalog_path", lambda: bogus,
+        )
+
+        # Should not raise.
+        _stamp_dt_uri_on_entry(tmp_path / "x.pdf", "ANY-UUID")
+
+    def test_index_record_invokes_stamp_helper(
+        self, monkeypatch, tmp_path,
+    ):
+        """``_index_record`` MUST call ``_stamp_dt_uri_on_entry`` after
+        the indexer runs — that's the contract that turns the
+        ``file://`` source_uri the indexer registers into the DT
+        identity AC-1 requires. Mocks both the indexer and the stamp
+        helper so we just verify the wiring."""
+        from nexus.commands import dt as dt_module
+
+        called: list[tuple[Path, str]] = []
+
+        def fake_stamp(file_path, uuid):
+            called.append((file_path, uuid))
+
+        def fake_index_pdf(*args, **kwargs):
+            return 0
+
+        monkeypatch.setattr(
+            dt_module, "_stamp_dt_uri_on_entry", fake_stamp,
+        )
+        monkeypatch.setattr(
+            "nexus.doc_indexer.index_pdf", fake_index_pdf,
+        )
+
+        dt_module._index_record(
+            uuid="UUID-WIRING",
+            path=str(tmp_path / "a.pdf"),
+            collection=None,
+            corpus="default",
+            dry_run=False,
+        )
+        assert len(called) == 1
+        assert called[0][0] == tmp_path / "a.pdf"
+        assert called[0][1] == "UUID-WIRING"
+
+    def test_index_record_dry_run_skips_stamp(
+        self, monkeypatch, tmp_path,
+    ):
+        """``--dry-run`` short-circuits — no indexer call, no stamp."""
+        from nexus.commands import dt as dt_module
+
+        stamps: list = []
+
+        def fake_stamp(file_path, uuid):
+            stamps.append((file_path, uuid))
+
+        monkeypatch.setattr(
+            dt_module, "_stamp_dt_uri_on_entry", fake_stamp,
+        )
+
+        dt_module._index_record(
+            uuid="UUID-DRY",
+            path=str(tmp_path / "a.pdf"),
+            collection=None,
+            corpus="default",
+            dry_run=True,
+        )
+        assert stamps == []


### PR DESCRIPTION
## Summary

Critical RDR-099 AC-1 fix. v4.19.0 shipped `nx dt index` but the resulting catalog entries carried `source_uri=file://...` (the resolved local path) and empty `meta`, NOT the DT identity. Caught during post-release live shakeout.

**RDR-099 AC-1 requires**:

- `source_uri == "x-devonthink-item://<UUID>"`
- `meta.devonthink_uri == "x-devonthink-item://<UUID>"`

Without the DT identity:

- Round-trip via `nx dt open <tumbler>` fails — tumbler resolution looks for DT URIs, finds none.
- DT relocations inside `Files.noindex/` break the `source_uri` silently (the whole point of the URI scheme is to be DT-stable).

## The fix

After `index_pdf` / `index_markdown` returns, look up the just-registered catalog row by `file_path` and call `cat.update(tumbler, source_uri=dt_uri, meta={"devonthink_uri": dt_uri})`. Failures log a warning and return — a stamp miss leaves a recoverable `file://` entry rather than aborting the whole batch.

## Live verification

Indexed real PRDTs PDF from DT (UUID `5321AD83-...`). Before the fix:

\`\`\`
URI: file:///Users/.../Files.noindex/pdf/26/PRDTs.pdf
meta: {}
\`\`\`

After the fix:

\`\`\`
URI: x-devonthink-item://5321AD83-38F8-42E7-BCFA-B9AAE95ED68F
\`\`\`

\`nx dt open 1.2163.1\` (tumbler form) successfully opens the record in DEVONthink — full round-trip verified end-to-end on a live DT installation.

## Test plan

- [x] 5 new tests in `TestStampDtUriOnEntry`: happy path, no-match-logs-and-returns, uninitialized-catalog-logs-and-returns, dispatcher-wiring, dry-run-skips-stamp.
- [x] All 41 tests in `tests/test_commands_dt.py` pass.
- [x] Live end-to-end verification on darwin against running DEVONthink — round-trip works.