### PR TITLE
fix(rdr-099): post-v4.19.1 audit followups + Closes #377

### DIFF
--- a/docs/devonthink-smart-rules.md
+++ b/docs/devonthink-smart-rules.md
@@ -61,9 +61,19 @@ Key points:
   triage the rule itself the same way you triage `nx` failures.
 
 Replace `/usr/local/bin/nx` with the absolute path your `nx` is
-installed at if it differs. AppleScript's `PATH` is bare; the
-absolute path avoids the "command not found" silent failure when you
-run `nx` from a `.zshrc`-style shell.
+installed at. The example placeholder is wrong for most modern Mac
+setups. Common locations:
+
+| Install method | Path |
+| --- | --- |
+| `uv tool install conexus` | `~/.local/bin/nx` |
+| Homebrew (Apple Silicon) | `/opt/homebrew/bin/nx` |
+| Homebrew (Intel) | `/usr/local/bin/nx` |
+| pipx | `~/.local/bin/nx` |
+
+Run `which nx` from your shell once and paste the result. AppleScript's
+`PATH` is bare, so the absolute path avoids the "command not found"
+silent failure when you run `nx` from a `.zshrc`-style shell.
 
 ### 2. Save location
 
@@ -105,10 +115,13 @@ should show the `nx dt index --uuid <UUID>` invocation's stdout. Once
 the indexer finishes, confirm the catalog has the entry:
 
 ```bash
-nx catalog list --source-uri-prefix x-devonthink-item://
+nx catalog list --json \
+  | jq '.[] | select(.source_uri | startswith("x-devonthink-item://"))'
 ```
 
-The newest entry should match the PDF you dropped.
+`nx catalog list` has no built-in `--source-uri-prefix` flag in v1; the
+JSON pipe is the canonical query path. The newest entry (last line of
+the jq output) should match the PDF you dropped.
 
 ## Error handling
 

--- a/src/nexus/aspect_extractor.py
+++ b/src/nexus/aspect_extractor.py
@@ -230,32 +230,44 @@ its ``source_path`` line.
 """
 
 
-_REGISTRY: dict[str, ExtractorConfig] = {
-    "knowledge__": ExtractorConfig(
-        extractor_name="scholarly-paper-v1",
-        # The model is pinned at config; the actual Claude CLI may
-        # use a different model based on user config. This is the
-        # *expected* model version for this extractor recipe and is
-        # what gets stored in document_aspects.model_version so the
-        # version-filter query (list_by_extractor_version) can
-        # identify rows captured under an outdated recipe.
-        model_version="claude-haiku-4-5-20251001",
-        prompt_template=_SCHOLARLY_PAPER_PROMPT,
-        required_fields=(
-            "problem_formulation",
-            "proposed_method",
-            "experimental_datasets",
-            "experimental_baselines",
-            "experimental_results",
-        ),
+_SCHOLARLY_PAPER_CONFIG = ExtractorConfig(
+    extractor_name="scholarly-paper-v1",
+    # The model is pinned at config; the actual Claude CLI may
+    # use a different model based on user config. This is the
+    # *expected* model version for this extractor recipe and is
+    # what gets stored in document_aspects.model_version so the
+    # version-filter query (list_by_extractor_version) can
+    # identify rows captured under an outdated recipe.
+    model_version="claude-haiku-4-5-20251001",
+    prompt_template=_SCHOLARLY_PAPER_PROMPT,
+    required_fields=(
+        "problem_formulation",
+        "proposed_method",
+        "experimental_datasets",
+        "experimental_baselines",
+        "experimental_results",
     ),
+)
+
+
+_REGISTRY: dict[str, ExtractorConfig] = {
+    "knowledge__": _SCHOLARLY_PAPER_CONFIG,
+    # docs__* (#377): markdown / ADR / design-doc collections produced
+    # by `nx index repo` hold the same kind of substantive prose that
+    # `knowledge__*` does — architecturally identical to scholarly
+    # papers from the aspect-extraction perspective. Reuse the same
+    # config so problem_formulation / proposed_method / etc. fields
+    # apply uniformly. If a dedicated docs-prose schema ever
+    # warrants splitting, the alias here can be replaced with a
+    # purpose-built ExtractorConfig.
+    "docs__": _SCHOLARLY_PAPER_CONFIG,
     # rdr__* — pure-Python extractor (RDR-089 Phase F). RDRs carry
     # YAML frontmatter + labelled markdown sections; a deterministic
     # parser is more reliable and zero-cost compared to forcing the
     # 5-field LLM extraction shape onto the document.
     "rdr__": ExtractorConfig(
         extractor_name="rdr-frontmatter-v1",
-        model_version="rdr-frontmatter-v1",  # not a real model — pinned to recipe id
+        model_version="rdr-frontmatter-v1",  # not a real model, pinned to recipe id
         prompt_template="",  # unused (parser_fn shortcut)
         required_fields=(
             "problem_formulation",

--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -454,7 +454,7 @@ def aspect_extraction_enqueue_hook(
     (RDR-089 P1.3 spike finding). Instead it:
 
       1. Skips collections without a registered extractor config
-         (Phase 1 = ``knowledge__*`` only).
+         (currently ``knowledge__*``, ``rdr__*``, ``docs__*``).
       2. Writes a pending row to ``aspect_extraction_queue``
          (microsecond-scale T2 INSERT). The row carries ``content``
          when non-empty (MCP path) so the worker has the document

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -486,16 +486,30 @@ def register_cmd(
 @click.option("--year", default=0, type=int)
 @click.option("--corpus", default="")
 @click.option("--meta", default="", help="JSON string of additional metadata")
+@click.option(
+    "--source-uri",
+    "source_uri",
+    default="",
+    help="Catalog source identity URI (e.g. x-devonthink-item://<UUID>). "
+         "Recovery path for entries whose DT-URI stamp failed during "
+         "nx dt index, or for manual reassignment of catalog identity.",
+)
 @click.option("--owner", default="", help="Batch: update all entries for this owner")
 @click.option("--search", "search_query", default="", help="Batch: update all entries matching this search")
 def update_cmd(
     tumbler: str, title: str, author: str, year: int, corpus: str, meta: str,
-    owner: str, search_query: str,
+    source_uri: str, owner: str, search_query: str,
 ) -> None:
     """Update catalog entry metadata. TUMBLER can be a tumbler or title.
 
     Batch mode: use --owner or --search to update multiple entries at once.
     Example: nx catalog update --owner 1.9 --corpus schema-evolution
+
+    --source-uri sets or replaces the catalog identity URI. Use this to
+    recover an entry whose DT-URI stamp failed during 'nx dt index'
+    (the entry will carry source_uri=file://… instead of x-devonthink-
+    item://<UUID>). The URI is validated against the same scheme allowlist
+    as register-time.
     """
     cat = _get_catalog()
     fields: dict = {}
@@ -509,6 +523,8 @@ def update_cmd(
         fields["corpus"] = corpus
     if meta:
         fields["meta"] = json.loads(meta)
+    if source_uri:
+        fields["source_uri"] = source_uri
     if not fields:
         raise click.ClickException("No fields to update")
 

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -429,6 +429,17 @@ def open_cmd(tumbler_or_uuid: str) -> None:
     preferring ``meta.devonthink_uri`` and falling back to
     ``source_uri`` when the entry was registered with a DT identity.
     """
+    # Platform gate fires before any branch-specific work so non-darwin
+    # users get the documented "macOS-only" message regardless of
+    # argument shape. Previously the tumbler branch would open the
+    # catalog and resolve the tumbler before checking platform, leaking
+    # catalog errors (uninitialized, not-found) ahead of the real
+    # diagnostic.
+    if not _is_darwin():
+        raise click.ClickException(
+            "DEVONthink integration is macOS-only",
+        )
+
     if _UUID_RE.match(tumbler_or_uuid):
         uri = f"x-devonthink-item://{tumbler_or_uuid}"
     elif _TUMBLER_RE.match(tumbler_or_uuid):
@@ -441,11 +452,6 @@ def open_cmd(tumbler_or_uuid: str) -> None:
         raise click.ClickException(
             "argument is neither a tumbler (e.g. 1.2.3) nor a UUID "
             "(e.g. 8EDC855D-213F-40AD-A9CF-9543CC76476B).",
-        )
-
-    if not _is_darwin():
-        raise click.ClickException(
-            "DEVONthink integration is macOS-only",
         )
 
     subprocess.run(["open", uri], check=True)  # noqa: S603,S607

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -76,7 +76,7 @@ def _index_record(
     if ext == ".pdf":
         index_pdf(file_path, corpus=corpus, collection_name=collection)
     else:  # .md — extension filtering happens in index_cmd
-        index_markdown(file_path, corpus=corpus)
+        index_markdown(file_path, corpus=corpus, collection_name=collection)
 
     _stamp_dt_uri_on_entry(file_path, uuid)
 

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -43,7 +43,7 @@ def _index_record(
     collection: str | None,
     corpus: str,
     dry_run: bool,
-) -> None:
+) -> bool:
     """Dispatch a single supported ``(uuid, path)`` to the right indexer.
 
     The caller (``index_cmd``) is responsible for filtering unsupported
@@ -59,6 +59,11 @@ def _index_record(
     relocations, and the file path returned by osascript at index time
     is not (DT moves files inside Files.noindex/ on its own schedule).
 
+    Returns the stamp's success status (``True`` when the catalog entry
+    now carries the DT identity, ``False`` otherwise) so the caller can
+    surface stamp misses in the summary line. Indexing itself is
+    treated as a precondition: an indexer exception will propagate.
+
     Tests monkeypatch this single function rather than the heavyweight
     ``doc_indexer`` machinery so the CLI surface is exercised
     independently of Voyage credentials and Chroma clients.
@@ -67,7 +72,7 @@ def _index_record(
         # Dry-run is handled in the command body before this function
         # is reached. If a caller invokes us with dry_run=True anyway,
         # treat it as a no-op rather than a silent indexing run.
-        return
+        return True
 
     from nexus.doc_indexer import index_markdown, index_pdf  # noqa: PLC0415
 
@@ -78,10 +83,10 @@ def _index_record(
     else:  # .md — extension filtering happens in index_cmd
         index_markdown(file_path, corpus=corpus, collection_name=collection)
 
-    _stamp_dt_uri_on_entry(file_path, uuid)
+    return _stamp_dt_uri_on_entry(file_path, uuid)
 
 
-def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> None:
+def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> bool:
     """Set ``source_uri`` and ``meta.devonthink_uri`` on the catalog
     entry that was just indexed for ``file_path``.
 
@@ -92,11 +97,13 @@ def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> None:
     Looking up the entry by ``file_path`` immediately after the indexer
     call is reliable because no other registrar runs between the two.
 
-    Failures are logged and swallowed: a stamp miss should not abort
-    the whole ``nx dt index`` run. The resulting catalog entry is still
-    usable, just without the round-trip property; ``nx catalog
-    remediate-paths`` (RDR-096 substrate) plus a manual ``nx catalog
-    update`` can recover after the fact.
+    Returns ``True`` when the entry now carries the DT identity,
+    ``False`` on any miss (uninitialized catalog, no matching row,
+    SQLite exception). Failures are logged and surfaced in the dt
+    index summary line by the caller; the function does not raise so
+    a stamp miss leaves a recoverable ``file://`` entry rather than
+    aborting the whole batch. ``nx catalog update --source-uri`` can
+    recover after the fact.
     """
     from nexus.catalog import resolve_tumbler  # noqa: PLC0415
     from nexus.catalog.catalog import Catalog  # noqa: PLC0415
@@ -110,7 +117,7 @@ def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> None:
             file_path=str(file_path),
             uuid=uuid,
         )
-        return
+        return False
 
     cat = Catalog(cat_path, cat_path / ".catalog.db")
     try:
@@ -128,7 +135,7 @@ def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> None:
                 file_path=str(file_path),
                 uuid=uuid,
             )
-            return
+            return False
 
         from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
 
@@ -144,6 +151,7 @@ def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> None:
             uuid=uuid,
             dt_uri=dt_uri,
         )
+        return True
     except Exception as e:
         _log.warning(
             "dt_stamp_failed",
@@ -151,6 +159,7 @@ def _stamp_dt_uri_on_entry(file_path: Path, uuid: str) -> None:
             uuid=uuid,
             error=str(e),
         )
+        return False
     finally:
         cat._db.close()
 
@@ -280,6 +289,7 @@ def index_cmd(
 
     indexed = 0
     skipped = 0
+    stamp_failed = 0
     for uuid, path in records:
         ext = Path(path).suffix.lower()
         if ext not in _SUPPORTED_EXTS:
@@ -291,7 +301,7 @@ def index_cmd(
             )
             skipped += 1
             continue
-        _index_record(
+        stamped = _index_record(
             uuid,
             path,
             collection=collection,
@@ -299,7 +309,25 @@ def index_cmd(
             dry_run=False,
         )
         indexed += 1
-    click.echo(f"Indexed {indexed} record(s) ({skipped} skipped).")
+        if not stamped:
+            stamp_failed += 1
+    summary = f"Indexed {indexed} record(s) ({skipped} skipped"
+    if stamp_failed:
+        # Stamp failure leaves the entry recoverable via
+        # 'nx catalog update --source-uri x-devonthink-item://<UUID>'
+        # — flag it so the operator knows the round-trip is broken
+        # for those records.
+        summary += f", {stamp_failed} DT-URI stamp-failed"
+    summary += ")."
+    click.echo(summary)
+    if stamp_failed:
+        click.echo(
+            "Some records were indexed but their catalog entry still "
+            "carries source_uri=file://… instead of x-devonthink-item://"
+            "<UUID>. Inspect ~/Library/Logs (or your structlog sink) "
+            "for 'dt_stamp_failed' events and recover with "
+            "'nx catalog update <tumbler> --source-uri x-devonthink-item://<UUID>'.",
+        )
 
 
 def _gather_records(

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -317,7 +317,7 @@ def enrich_aspects(
         click.echo(
             f"No extractor config registered for collection "
             f"'{collection}'. Supported prefixes: knowledge__*, "
-            f"rdr__*. Aborting."
+            f"rdr__*, docs__*. Aborting."
         )
         return
 

--- a/tests/test_aspect_extractor.py
+++ b/tests/test_aspect_extractor.py
@@ -111,9 +111,24 @@ class TestCollectionRouting:
     def test_unrelated_collection_returns_none(self) -> None:
         from nexus.aspect_extractor import select_config
 
-        assert select_config("docs__handbook") is None
+        # code__* targets source-code chunks, not prose claims —
+        # aspect extraction does not apply, so no config is registered.
+        # taxonomy__* holds embedding centroids with no source docs.
         assert select_config("code__nexus") is None
-        # rdr__* now has its own config (RDR-089 Phase F).
+        assert select_config("taxonomy__centroids") is None
+
+    def test_docs_prefix_routes_to_scholarly_config(self) -> None:
+        """#377: docs__* collections (markdown / ADR / design docs
+        from `nx index repo`) hold the same kind of substantive prose
+        as knowledge__*. They route to the same scholarly-paper-v1
+        config so problem_formulation / proposed_method / etc. apply
+        uniformly. Until #377 landed, docs__* was unconditionally
+        rejected with 'No extractor config registered'."""
+        from nexus.aspect_extractor import select_config
+
+        config = select_config("docs__handbook")
+        assert config is not None
+        assert config.extractor_name == "scholarly-paper-v1"
 
     def test_extract_aspects_returns_none_for_unsupported_collection(
         self, tmp_path: Path,
@@ -973,11 +988,13 @@ class TestBatchExtraction:
         from nexus.aspect_extractor import extract_aspects_batch
 
         # Unsupported collection only → no subprocess call.
+        # code__* is unsupported by design (aspect extraction targets
+        # prose claims, not source-code chunks).
         with patch("subprocess.run", side_effect=AssertionError(
             "must not call subprocess for unsupported-only batch",
         )):
             records = extract_aspects_batch([
-                ("docs__handbook", "/p1.md", "content"),
+                ("code__nexus", "/p1.py", "content"),
             ])
         assert records == [None]
 
@@ -1008,7 +1025,7 @@ class TestBatchExtraction:
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         records = extract_aspects_batch([
-            ("docs__handbook", "/skip.md", "content"),  # unsupported
+            ("code__nexus", "/skip.py", "content"),  # unsupported
             ("knowledge__delos", "/p1.pdf", "content 1"),
         ])
 

--- a/tests/test_aspect_extractor.py
+++ b/tests/test_aspect_extractor.py
@@ -1029,7 +1029,7 @@ class TestBatchExtraction:
             ("knowledge__delos", "/p1.pdf", "content 1"),
         ])
 
-        assert records[0] is None  # docs__handbook → unsupported
+        assert records[0] is None  # code__nexus → unsupported
         assert records[1].source_path == "/p1.pdf"
         assert records[1].problem_formulation == "P1"
 

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -108,13 +108,15 @@ class TestWorkerDrain:
     def test_worker_unsupported_collection_drops_silently(
         self, _isolate_t2: Path,
     ) -> None:
-        """If extract_aspects returns ``None`` (unsupported collection),
-        the worker still mark_dones the queue row so it doesn't loop
-        forever. No document_aspects row is written."""
+        """If extract_aspects returns ``None`` (unsupported collection
+        OR transient failure), the worker still mark_dones the queue
+        row so it doesn't loop forever. No document_aspects row is
+        written. Uses code__* — unsupported by design — to avoid
+        coupling to whichever prefix is currently in the registry."""
         from nexus.aspect_worker import AspectExtractionWorker
 
         with T2Database(_isolate_t2) as db:
-            db.aspect_queue.enqueue("docs__handbook", "/p1.md")
+            db.aspect_queue.enqueue("code__nexus", "/p1.py")
 
         def fake_extract(content, source_path, collection):
             return None  # unsupported collection
@@ -130,7 +132,7 @@ class TestWorkerDrain:
                 worker.stop(timeout=5.0)
 
         with T2Database(_isolate_t2) as db:
-            rec = db.document_aspects.get("docs__handbook", "/p1.md")
+            rec = db.document_aspects.get("code__nexus", "/p1.py")
         assert rec is None
 
     def test_worker_null_fields_record_persists_without_retry(
@@ -383,16 +385,23 @@ class TestEnqueueHook:
         self, _isolate_t2: Path,
     ) -> None:
         """Hook is a no-op for collections that have no extractor
-        config — no queue row, no worker started, no T3 read."""
+        config — no queue row, no worker started, no T3 read.
+
+        ``code__*`` is unsupported by design: aspect extraction
+        targets prose claims (problem_formulation, proposed_method,
+        etc.), which don't map to source-code AST chunks. After #377,
+        ``docs__*`` is no longer the canonical 'unsupported' example
+        — it routes to scholarly-paper-v1 like ``knowledge__*``.
+        """
         from nexus.aspect_worker import (
             aspect_extraction_enqueue_hook,
             get_worker,
         )
 
         aspect_extraction_enqueue_hook(
-            source_path="/p1.md",
-            collection="docs__handbook",
-            content="some text",
+            source_path="/p1.py",
+            collection="code__nexus",
+            content="def foo(): pass",
         )
         with T2Database(_isolate_t2) as db:
             rows = db.aspect_queue.list_pending()

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -327,6 +327,55 @@ class TestLinksFilterCommand:
         assert uniq.output.count("implements") == 1
 
 
+class TestUpdateCommand:
+    def test_update_source_uri_recovery_path(
+        self, initialized_catalog, catalog_env,
+    ):
+        """``nx catalog update <tumbler> --source-uri <uri>`` is the
+        recovery path for entries whose DT-URI stamp failed during
+        ``nx dt index``. The flag must accept any URI in the
+        ``_KNOWN_URI_SCHEMES`` allowlist (validated at register-boundary).
+        """
+        runner = CliRunner()
+        # Register an entry with a file:// source_uri (mimics what a
+        # plain indexer registers before the dt stamp would run).
+        runner.invoke(main, [
+            "catalog", "register",
+            "--title", "Stamp-recovery target",
+            "--owner", "1.1",
+            "--file-path", "/Users/x/a.pdf",
+        ])
+
+        result = runner.invoke(main, [
+            "catalog", "update", "1.1.1",
+            "--source-uri",
+            "x-devonthink-item://8EDC855D-213F-40AD-A9CF-9543CC76476B",
+        ])
+        assert result.exit_code == 0, result.output
+
+        show = runner.invoke(main, ["catalog", "show", "1.1.1"])
+        assert "x-devonthink-item://8EDC855D" in show.output
+
+    def test_update_source_uri_validates_scheme(
+        self, initialized_catalog, catalog_env,
+    ):
+        """Unknown URI schemes are rejected at the register-boundary
+        validator (``_normalize_source_uri``); the CLI must surface
+        the failure cleanly rather than silently persist garbage."""
+        runner = CliRunner()
+        runner.invoke(main, [
+            "catalog", "register",
+            "--title", "x",
+            "--owner", "1.1",
+            "--file-path", "/Users/x/a.pdf",
+        ])
+        result = runner.invoke(main, [
+            "catalog", "update", "1.1.1",
+            "--source-uri", "imaginary-scheme://nope",
+        ])
+        assert result.exit_code != 0
+
+
 class TestDeleteCommand:
     def test_delete_by_tumbler(self, initialized_catalog, catalog_env):
         runner = CliRunner()

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -474,6 +474,33 @@ class TestDtOpenUuidForm:
         assert "macOS-only" in result.output
         assert fake_open == []  # no spawn attempt
 
+    def test_tumbler_form_on_non_darwin_does_not_touch_catalog(
+        self, runner, fake_open, monkeypatch,
+    ):
+        """The platform gate fires BEFORE tumbler resolution. A
+        non-darwin user passing a tumbler argument should see
+        ``macOS-only``, not a catalog-not-initialized error or a
+        tumbler-not-found error. Asserts the resolver helper isn't
+        called at all on non-darwin."""
+        from nexus.cli import main
+
+        resolver_calls: list[str] = []
+
+        def must_not_resolve(tumbler):
+            resolver_calls.append(tumbler)
+            raise AssertionError("resolver must not run on non-darwin")
+
+        monkeypatch.setattr(
+            "nexus.commands.dt._resolve_dt_uri_from_tumbler",
+            must_not_resolve,
+        )
+        monkeypatch.setattr("sys.platform", "linux")
+        result = runner.invoke(main, ["dt", "open", "1.2.3"])
+        assert result.exit_code != 0
+        assert "macOS-only" in result.output
+        assert resolver_calls == []
+        assert fake_open == []
+
 
 class TestDtOpenTumblerForm:
     def test_tumbler_uses_devonthink_uri_from_meta(

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -77,7 +77,7 @@ def fake_dispatcher(monkeypatch) -> list[dict]:
         collection: str | None,
         corpus: str,
         dry_run: bool,
-    ) -> None:
+    ) -> bool:
         calls.append({
             "uuid": uuid,
             "path": path,
@@ -85,6 +85,10 @@ def fake_dispatcher(monkeypatch) -> list[dict]:
             "corpus": corpus,
             "dry_run": dry_run,
         })
+        # Default success — tests that want to exercise the
+        # stamp-failed summary path replace the dispatcher with
+        # their own fake.
+        return True
 
     monkeypatch.setattr("nexus.commands.dt._index_record", record)
     return calls
@@ -398,6 +402,55 @@ class TestErrorHandling:
         result = runner.invoke(main, ["dt", "index", "--selection"])
         assert result.exit_code != 0
         assert "macOS-only" in result.output
+
+
+# ── stamp-failure summary surfacing ──────────────────────────────────────────
+
+
+class TestStampFailedSummary:
+    """When ``_index_record`` returns ``False`` (the stamp helper
+    couldn't apply the DT identity), ``index_cmd`` must surface the
+    miss in its summary line so the operator knows the round-trip
+    is broken for some records. Silent stamp failures were a
+    significant audit finding from v4.19.1 post-release scrub.
+    """
+
+    def test_summary_includes_stamp_failed_count(
+        self, runner, fake_selectors, monkeypatch,
+    ):
+        from nexus.cli import main
+
+        fake_selectors["selection"].return_value = [
+            ("U-OK", "/a.pdf"),
+            ("U-FAIL-1", "/b.pdf"),
+            ("U-FAIL-2", "/c.md"),
+        ]
+
+        # Dispatcher returns False for the two that should fail to stamp.
+        def maybe_fail(uuid, path, *, collection, corpus, dry_run):
+            return uuid == "U-OK"
+
+        monkeypatch.setattr("nexus.commands.dt._index_record", maybe_fail)
+
+        result = runner.invoke(main, ["dt", "index", "--selection"])
+        assert result.exit_code == 0, result.output
+        assert "Indexed 3 record(s)" in result.output
+        assert "2 DT-URI stamp-failed" in result.output
+        # Recovery hint should appear so the operator knows what to do.
+        assert "nx catalog update" in result.output
+
+    def test_summary_omits_stamp_failed_when_zero(
+        self, runner, fake_selectors, fake_dispatcher,
+    ):
+        """No stamp failures → no mention of stamp-failed in the
+        summary line. Keeps the happy path uncluttered."""
+        from nexus.cli import main
+
+        fake_selectors["selection"].return_value = [("U", "/a.pdf")]
+        result = runner.invoke(main, ["dt", "index", "--selection"])
+        assert result.exit_code == 0, result.output
+        assert "Indexed 1 record(s)" in result.output
+        assert "stamp-failed" not in result.output
 
 
 # ── nx dt open ───────────────────────────────────────────────────────────────

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -762,11 +762,13 @@ class TestStampDtUriOnEntry:
         from nexus.commands import dt as dt_module
 
         called: list[tuple[Path, str]] = []
+        pdf_kwargs: list[dict] = []
 
         def fake_stamp(file_path, uuid):
             called.append((file_path, uuid))
 
         def fake_index_pdf(*args, **kwargs):
+            pdf_kwargs.append(kwargs)
             return 0
 
         monkeypatch.setattr(
@@ -779,13 +781,53 @@ class TestStampDtUriOnEntry:
         dt_module._index_record(
             uuid="UUID-WIRING",
             path=str(tmp_path / "a.pdf"),
-            collection=None,
+            collection="knowledge__test",
             corpus="default",
             dry_run=False,
         )
         assert len(called) == 1
         assert called[0][0] == tmp_path / "a.pdf"
         assert called[0][1] == "UUID-WIRING"
+        # PDF path must forward --collection.
+        assert pdf_kwargs[0].get("collection_name") == "knowledge__test"
+        assert pdf_kwargs[0].get("corpus") == "default"
+
+    def test_index_record_md_forwards_collection(
+        self, monkeypatch, tmp_path,
+    ):
+        """The .md branch must forward ``--collection`` the same as
+        the .pdf branch. This test catches a regression where
+        index_markdown was invoked without ``collection_name``,
+        silently dropping the operator's flag and routing every .md
+        file into ``docs__default`` regardless of intent.
+        """
+        from nexus.commands import dt as dt_module
+
+        md_kwargs: list[dict] = []
+
+        def fake_index_markdown(*args, **kwargs):
+            md_kwargs.append(kwargs)
+            return 0
+
+        # Stamp + indexer fakes — we only care about the collection
+        # forwarding, not the catalog stamp here.
+        monkeypatch.setattr(
+            dt_module, "_stamp_dt_uri_on_entry", lambda *a, **kw: None,
+        )
+        monkeypatch.setattr(
+            "nexus.doc_indexer.index_markdown", fake_index_markdown,
+        )
+
+        dt_module._index_record(
+            uuid="UUID-MD",
+            path=str(tmp_path / "note.md"),
+            collection="knowledge__notes",
+            corpus="default",
+            dry_run=False,
+        )
+        assert len(md_kwargs) == 1
+        assert md_kwargs[0].get("collection_name") == "knowledge__notes"
+        assert md_kwargs[0].get("corpus") == "default"
 
     def test_index_record_dry_run_skips_stamp(
         self, monkeypatch, tmp_path,


### PR DESCRIPTION
## Summary

Bundles findings from two parallel audits run after v4.19.1 shipped:

- **DT-surface scrub** (RDR-099 AC-1-class bugs, doc drift, mutual-exclusion holes, etc.).
- **#377-pattern prefix-registry scrub** (extractor config, `_KNOWN_URI_SCHEMES`, embedder dispatch, etc.).

All findings landed as separate commits so review is per-finding.

## Commits

1. **`docs(dt): fix smart-rules drift + path-default guidance`** — `docs/devonthink-smart-rules.md` still referenced the nonexistent `nx catalog list --source-uri-prefix` flag (PR #374 missed this second file). Plus `/usr/local/bin/nx` is the wrong default for Apple Silicon Homebrew + uv installs; replaced with a path table covering the four common install methods.

2. **`fix(dt): forward --collection to index_markdown for .md files`** — `_index_record` passed `collection_name=collection` to `index_pdf` but called `index_markdown` without it. Operators' `--collection knowledge__notes` flag was silently dropped for `.md` records. New `test_index_record_md_forwards_collection` exercises the real `_index_record` body with `index_markdown` mocked.

3. **`fix(dt): hoist darwin gate above tumbler resolution in nx dt open`** — UUID-form gated correctly but tumbler-form ran catalog I/O before checking platform, leaking catalog errors instead of `macOS-only`. New regression test asserts the resolver is not called at all on non-darwin.

4. **`fix(dt): surface stamp failures in nx dt index summary`** — `_stamp_dt_uri_on_entry` failures were logged-and-swallowed; the summary still reported success. `_index_record` and `_stamp_dt_uri_on_entry` now return `bool`; `index_cmd` accumulates a `stamp_failed` count and adds `<N> DT-URI stamp-failed` to the summary plus a recovery hint pointing at `nx catalog update`.

5. **`feat(catalog): nx catalog update --source-uri`** — `Catalog.update()` already accepted `source_uri` via `**fields` but the CLI exposed no flag. Adds `--source-uri` so operators can recover stamp-failed entries without delete + re-index. Same scheme allowlist as register-time.

6. **`feat(enrich): docs__* aspect extraction (Closes #377)`** — `_REGISTRY` adds `docs__ → scholarly-paper-v1` (alias of the `knowledge__` config). Companion edits: error string in `enrich.py`, stale comment in `aspect_worker.py`, two test updates plus a new `test_docs_prefix_routes_to_scholarly_config` covering the fix.

## Closes

Closes #377.

## Test plan

- [x] `uv run pytest tests/test_commands_dt.py tests/test_devonthink.py tests/test_devonthink_live.py tests/test_aspect_extractor.py tests/test_catalog_cli.py tests/test_catalog.py tests/test_catalog_prune_stale.py tests/test_enrich_command.py tests/test_enrich_aspects.py` → **329 passed, 6 skipped**.
- [x] Each commit's tests run independently green.
- Manual smoke: not blocking — the dt round-trip was verified live during the audit; this PR adds tracking + recovery for the failure path that wasn't visible before.

Targeted at v4.19.2 patch release.