### PR TITLE
feat(dt-plugin): /dt:index-selection + /dt:open-result wrappers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,12 @@
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
       "version": "4.19.2"
+    },
+    {
+      "name": "dt",
+      "source": "./dt",
+      "description": "Slash commands wrapping the nx dt CLI for DEVONthink integration: index DT-side selections into Nexus and open Nexus tumblers back in DEVONthink (macOS only).",
+      "version": "4.19.2"
     }
   ]
 }

--- a/dt/.claude-plugin/plugin.json
+++ b/dt/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "dt",
+  "version": "4.19.2",
+  "description": "Slash commands wrapping the nx dt CLI for DEVONthink integration: index DT-side selections into Nexus and open Nexus tumblers back in DEVONthink (macOS only)."
+}

--- a/dt/CHANGELOG.md
+++ b/dt/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to the dt plugin are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [4.19.2] - 2026-04-29
+
+Initial release. Plugin version aligned with conexus 4.19.2 (the release that hardened the `nx dt` CLI surface this plugin wraps).
+
+- `/dt:index-selection` slash command wrapping `nx dt index --selection`. Forwards `--collection` and `--corpus` to the underlying CLI.
+- `/dt:open-result <tumbler-or-uuid>` slash command wrapping `nx dt open`. Accepts catalog tumblers and raw DEVONthink UUIDs.
+- macOS-only. Requires `nx` CLI on `PATH` and DEVONthink running for live selectors.

--- a/dt/README.md
+++ b/dt/README.md
@@ -1,0 +1,60 @@
+# dt: DEVONthink Slash Command Plugin for Claude Code
+
+A Claude Code plugin that exposes the `nx dt` CLI as ergonomic slash commands.
+
+## What It Does
+
+DEVONthink users on macOS keep their reference corpora (PDFs, web archives, notes) in DT databases. Nexus indexes those records into T3 via `nx dt index ...` and resolves Nexus tumblers back to DEVONthink via `nx dt open <tumbler>`. The CLI is the source of truth.
+
+`dt` adds a thin slash command layer on top of that CLI:
+
+1. **`/dt:index-selection`** wraps `nx dt index --selection`. Index whatever is currently highlighted in DEVONthink's UI.
+2. **`/dt:open-result`** wraps `nx dt open <tumbler-or-uuid>`. Resolve a Nexus tumbler (or a raw DT UUID) to a `x-devonthink-item://` URL and open it.
+
+The plugin contains no MCP servers, no hooks, no agents. It is documentation plus two argument-bearing skills that delegate to the underlying CLI.
+
+## Install
+
+```bash
+/plugin install dt@nexus-plugins
+```
+
+### Prerequisites
+
+- **macOS** with DEVONthink running (the CLI is darwin-only and platform-checks before catalog I/O).
+- **`nx` CLI** installed and on `PATH`. The plugin assumes `conexus >= 4.19.2` (when `nx dt` shipped). Run `nx --version` to confirm.
+- **Catalog initialized** for the project. `/dt:open-result` needs the catalog to resolve tumblers; raw DT UUIDs work without it.
+
+## What Gets Wrapped
+
+| Skill | Underlying CLI | Notes |
+|-------|----------------|-------|
+| `/dt:index-selection` | `nx dt index --selection [--collection ... | --corpus ...] [--database ...] [--dry-run]` | Indexes currently selected DT records. Forwards optional `--collection` (e.g., `knowledge__papers`) and `--corpus` flags. |
+| `/dt:open-result` | `nx dt open <tumbler-or-uuid>` | Accepts a tumbler (e.g., `1.2.3`) or a raw DT UUID. UUID-shaped arguments skip the catalog and go straight to `x-devonthink-item://<UUID>`. |
+
+For the full flag surface (`--tag`, `--group`, `--smart-group`, `--uuid`, `--dry-run`, etc.) call the CLI directly: `nx dt index --help`.
+
+## Plugin Structure
+
+```
+dt/
+├── .claude-plugin/
+│   └── plugin.json
+├── skills/
+│   ├── dt-index-selection/
+│   │   └── SKILL.md
+│   └── dt-open-result/
+│       └── SKILL.md
+├── CHANGELOG.md
+└── README.md
+```
+
+## Relationship to nx and sn
+
+`dt` sits alongside `nx` and `sn` in the `nexus-plugins` marketplace. It depends on the `nx` CLI being installed but has no plugin-level dependency on the `nx` Claude Code plugin. Install whichever combination fits.
+
+| Plugin | Scope | What it provides |
+|--------|-------|------------------|
+| `nx` | Project-specific | Knowledge management, semantic search, agents, beads, RDR tracking |
+| `sn` | Universal | MCP tool guidance for subagents (Serena + Context7) |
+| `dt` | macOS-only, project-specific | Slash command wrappers around `nx dt` for DEVONthink workflows |

--- a/dt/skills/dt-index-selection/SKILL.md
+++ b/dt/skills/dt-index-selection/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: dt-index-selection
+description: Use when indexing the current DEVONthink selection into Nexus, capturing whatever the user has highlighted in DT's UI as T3 documents.
+effort: low
+---
+
+# DEVONthink Index Selection
+
+Wraps the `nx dt index --selection` CLI command. Index whatever records are currently selected in DEVONthink's UI into Nexus T3, with optional collection or corpus targeting.
+
+## When This Skill Activates
+
+- User invokes `/dt:index-selection`
+- User asks to index the current DEVONthink selection
+- User wants to capture DT-side highlights into a Nexus T3 collection without copying UUIDs by hand
+
+## Underlying Command
+
+```bash
+nx dt index --selection [--collection knowledge__<name>] [--corpus <name>] [--database <db>] [--dry-run]
+```
+
+Flag forwarding:
+
+- `--collection knowledge__<name>` routes to a `knowledge__*` collection (use for external reference corpora).
+- `--corpus <name>` routes to a `docs__<corpus>` collection (use for project-internal docs).
+- `--database <db>` scopes selectors to one open DEVONthink library.
+- `--dry-run` previews the records without writing to T3.
+
+If neither `--collection` nor `--corpus` is provided, records land in `docs__default`.
+
+## Behavior
+
+1. Confirm DEVONthink is running. The CLI fails fast on non-darwin platforms; surface that as a friendly error if the user is not on macOS.
+2. Decide collection routing:
+   - If the user passed a collection or corpus argument, forward it.
+   - Otherwise, ask whether to target `knowledge__<name>` (external reference) or `docs__<corpus>` (project doc), defaulting to `docs__default` on no answer.
+3. Run `nx dt index --selection` with the resolved flags. Show the count of indexed records and the collection name from the CLI's summary line.
+4. On `--dry-run`, report the records that would be indexed and stop.
+5. Catalog stamping happens in the CLI: every entry gets `source_uri = x-devonthink-item://<UUID>` and `meta.devonthink_uri`. Surface any stamp failures from the CLI summary so the user can rerun with `nx catalog update --source-uri` if needed.
+
+## Examples
+
+Index whatever is selected, default routing:
+
+```
+/dt:index-selection
+```
+
+Index selection into a knowledge collection:
+
+```
+/dt:index-selection --collection knowledge__delos
+```
+
+Preview without writing to T3:
+
+```
+/dt:index-selection --dry-run
+```
+
+Scope to one DEVONthink database:
+
+```
+/dt:index-selection --database "Reference Library" --collection knowledge__papers
+```
+
+## Success Criteria
+
+- [ ] CLI invoked with `--selection` and any forwarded flags
+- [ ] Indexed record count reported back to the user
+- [ ] Stamp failures (if any) surfaced explicitly from the CLI summary
+- [ ] `--dry-run` previews without writing
+- [ ] Friendly error on non-macOS or when DEVONthink is not running
+
+## Notes
+
+- This skill does not duplicate CLI logic. The actual indexing, chunking, embedding, and catalog stamping all happen inside `nx dt index`.
+- Use T1 scratch (`mcp__plugin_nx_nexus__scratch`) to capture indexing decisions during a multi-step research session if the user is processing several selections in a row.

--- a/dt/skills/dt-open-result/SKILL.md
+++ b/dt/skills/dt-open-result/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: dt-open-result
+description: Use when opening a Nexus search result back in DEVONthink, given a catalog tumbler or raw DEVONthink UUID, to inspect the source record in DT's UI.
+effort: low
+---
+
+# DEVONthink Open Result
+
+Wraps the `nx dt open <tumbler-or-uuid>` CLI command. Resolve a Nexus tumbler (or raw DEVONthink UUID) to a `x-devonthink-item://` URL and open it in DEVONthink.
+
+## When This Skill Activates
+
+- User invokes `/dt:open-result <tumbler-or-uuid>`
+- User wants to jump from a Nexus search hit (tumbler `1.2.3`) to the underlying DT record
+- User has a raw DEVONthink UUID and wants to open it without copying it into the DT URL by hand
+
+## Underlying Command
+
+```bash
+nx dt open <tumbler-or-uuid>
+```
+
+Argument resolution:
+
+- A UUID-shaped argument (`8-4-4-4-12` hex) is converted directly to `x-devonthink-item://<UUID>`. No catalog hit, no osascript.
+- A tumbler (e.g., `1.2.3`) is resolved through the catalog. The CLI prefers `meta.devonthink_uri` and falls back to `source_uri` when the entry was registered with a DT identity.
+- Anything else fails with an explanatory message.
+
+## Behavior
+
+1. Take the tumbler or UUID from the argument list.
+2. Run `nx dt open <arg>`. The CLI handles platform check, catalog lookup, and URL construction.
+3. On success, the macOS opener hands the URL to DEVONthink and the record opens. Confirm to the user that the open call returned cleanly.
+4. On a tumbler that resolves to no DT identity, surface the CLI's error message so the user knows the catalog entry was not registered through `nx dt index`.
+
+## Examples
+
+Open a tumbler from a recent search result:
+
+```
+/dt:open-result 1.2.3
+```
+
+Open by raw DEVONthink UUID (skips the catalog):
+
+```
+/dt:open-result 12345678-1234-1234-1234-123456789012
+```
+
+## Success Criteria
+
+- [ ] CLI invoked with the user-supplied argument verbatim
+- [ ] Successful open confirmed back to the user
+- [ ] Tumbler-to-DT-identity miss reported explicitly so the user knows the entry was not indexed via `nx dt`
+- [ ] Friendly error on non-macOS
+
+## Notes
+
+- This skill does not duplicate CLI logic. Catalog resolution, URL construction, and platform checks all live in `nx dt open`.
+- For tumbler resolution to work, the entry must have been indexed via `nx dt index ...` (which stamps `source_uri = x-devonthink-item://<UUID>` and `meta.devonthink_uri`). Entries indexed via `nx index` from a local filesystem path have no DT identity and will not resolve.
+- Use T1 scratch (`mcp__plugin_nx_nexus__scratch`) if the user is bouncing between several Nexus tumblers and DT records in one session.

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -704,3 +704,99 @@ class TestRdr080StubAgents:
             f"nx/agents/{agent_name}.md must reference an MCP tool "
             "(mcp__plugin_nx_nexus__*) as its redirect target (RDR-080)."
         )
+
+
+# ── dt/ plugin structure (RDR-099 nexus-mv0p.11) ─────────────────────────────
+
+DT_PLUGIN_DIR = REPO_ROOT / "dt"
+DT_MANIFEST = DT_PLUGIN_DIR / ".claude-plugin" / "plugin.json"
+DT_SKILLS = ("dt-index-selection", "dt-open-result")
+DT_REQUIRED_FILES = ("README.md", "CHANGELOG.md", ".claude-plugin/plugin.json")
+
+
+class TestDtPluginStructure:
+    """Structural guards for the dt/ Claude Code plugin (pure-skill wrapper
+    around the `nx dt` CLI). The dt plugin has no agents, hooks, MCP servers,
+    or registry, so the heavyweight nx-only assertions do not apply. What
+    must hold: manifest is parseable and version-pinned, skill files exist
+    with the standard frontmatter shape, and the marketplace lists the
+    plugin alongside nx and sn."""
+
+    def test_plugin_dir_exists(self) -> None:
+        assert DT_PLUGIN_DIR.is_dir(), "dt/ plugin directory missing"
+
+    @pytest.mark.parametrize("rel_path", DT_REQUIRED_FILES)
+    def test_required_file_exists_and_non_empty(self, rel_path: str) -> None:
+        full = DT_PLUGIN_DIR / rel_path
+        assert full.exists(), f"dt/{rel_path} missing"
+        assert full.stat().st_size > 0, f"dt/{rel_path} is empty"
+
+    def test_manifest_parses_and_has_required_fields(self) -> None:
+        data = json.loads(DT_MANIFEST.read_text())
+        assert data.get("name") == "dt", f"plugin.json name != 'dt': {data.get('name')!r}"
+        assert data.get("version"), "plugin.json missing version"
+        assert data.get("description"), "plugin.json missing description"
+
+    def test_manifest_version_matches_pyproject(self) -> None:
+        with PYPROJECT_PATH.open("rb") as f:
+            pv = tomllib.load(f)["project"]["version"]
+        data = json.loads(DT_MANIFEST.read_text())
+        assert data.get("version") == pv, (
+            f"dt/.claude-plugin/plugin.json version {data.get('version')!r} "
+            f"!= pyproject.toml {pv!r}"
+        )
+
+    @pytest.mark.parametrize("skill_name", DT_SKILLS)
+    def test_skill_directory_and_file_exist(self, skill_name: str) -> None:
+        skill_dir = DT_PLUGIN_DIR / "skills" / skill_name
+        assert skill_dir.is_dir(), f"dt/skills/{skill_name}/ missing"
+        assert (skill_dir / "SKILL.md").exists(), f"dt/skills/{skill_name}/SKILL.md missing"
+
+    @pytest.mark.parametrize("skill_name", DT_SKILLS)
+    def test_skill_frontmatter_valid(self, skill_name: str) -> None:
+        path = DT_PLUGIN_DIR / "skills" / skill_name / "SKILL.md"
+        text = path.read_text()
+        fm_match = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        assert fm_match, f"dt/skills/{skill_name}/SKILL.md: no YAML frontmatter"
+        raw = fm_match.group(1)
+        fm = yaml.safe_load(raw)
+        extra = set(fm.keys()) - {"name", "description", "effort"}
+        assert not extra, (
+            f"dt/skills/{skill_name}/SKILL.md: non-standard frontmatter fields {extra}"
+        )
+        comment_lines = [l for l in raw.splitlines() if l.strip().startswith("#")]
+        assert not comment_lines, (
+            f"dt/skills/{skill_name}/SKILL.md: YAML comments in frontmatter: {comment_lines}"
+        )
+        assert fm.get("name") == skill_name, (
+            f"dt/skills/{skill_name}/SKILL.md: frontmatter name {fm.get('name')!r} != dir name"
+        )
+        desc = fm.get("description", "")
+        assert desc.lower().startswith("use when"), (
+            f"dt/skills/{skill_name}/SKILL.md: description must start with 'Use when'. "
+            f"Got: {desc[:80]!r}"
+        )
+        for kw in ("Triggers:", "user says", "workflow", "process:"):
+            assert kw not in desc, (
+                f"dt/skills/{skill_name}/SKILL.md: description contains workflow keyword {kw!r}"
+            )
+
+    @pytest.mark.parametrize("skill_name", DT_SKILLS)
+    def test_skill_documents_underlying_cli(self, skill_name: str) -> None:
+        """Every dt/ skill is a thin wrapper around `nx dt`. The skill body
+        must reference the underlying CLI verb so a reader can see what is
+        actually being delegated. This guards against the skill drifting away
+        from the CLI surface (or someone replacing the wrapper with bespoke
+        logic, which contradicts the plugin's reason to exist)."""
+        path = DT_PLUGIN_DIR / "skills" / skill_name / "SKILL.md"
+        text = path.read_text()
+        assert "nx dt" in text, (
+            f"dt/skills/{skill_name}/SKILL.md: must reference the underlying `nx dt` CLI"
+        )
+
+    def test_marketplace_lists_dt(self) -> None:
+        plugins = json.loads(MARKETPLACE_PATH.read_text()).get("plugins", [])
+        names = {p.get("name") for p in plugins}
+        assert "dt" in names, (
+            f"marketplace.json does not list 'dt' plugin; found: {sorted(names)}"
+        )


### PR DESCRIPTION
## Summary

Add a third Claude Code plugin (`dt/`) alongside `nx/` and `sn/`. Pure-skill plugin (no agents, hooks, or MCP servers) wrapping the existing `nx dt` CLI for DEVONthink workflows.

- `/dt:index-selection` wraps `nx dt index --selection`. Indexes the current DEVONthink selection with optional `--collection` or `--corpus` routing.
- `/dt:open-result <tumbler-or-uuid>` wraps `nx dt open`. Resolves Nexus tumblers (or raw DT UUIDs) to `x-devonthink-item://` URLs.

This is the optional follow-up bead from RDR-099 v1. The CLI shipped in v4.19.0–v4.19.2; this PR adds the discoverable Claude Code plugin layer on top. No conexus version bump (additive plugin layer for the existing v4.19.2).

## What changed

- `dt/.claude-plugin/plugin.json`: `name=dt`, `version=4.19.2` (CI-enforced parity with `pyproject.toml`).
- `dt/skills/dt-index-selection/SKILL.md` and `dt/skills/dt-open-result/SKILL.md`: argument-bearing skills with the standard `name`/`description`/`effort` frontmatter. Bodies are documentation plus example invocations; all logic stays in `nx dt`.
- `dt/README.md` mirrors `sn/README.md` shape.
- `dt/CHANGELOG.md` initial entry for 4.19.2.
- `.claude-plugin/marketplace.json` third entry for `dt` alongside `nx` and `sn`.
- `tests/test_plugin_structure.py` adds `TestDtPluginStructure` (13 parametrized tests): manifest parses, version pinned, skills exist with valid frontmatter (description starts with "Use when", no workflow keywords, no extra fields), each skill references the underlying `nx dt` CLI, marketplace lists `dt`.

## Test plan

- [x] `uv run pytest tests/test_plugin_structure.py` passes (589 passed, 26 pre-existing skips).
- [x] `uv run pytest tests/test_plugin_structure.py::TestDtPluginStructure -v` confirms all 13 dt-specific tests pass.
- [x] No em dashes in any new prose (verified with grep).
- [x] No AI attribution in commit message.
- [ ] Reviewer: install plugin via `/plugin install dt@nexus-plugins` and confirm `/dt:index-selection` and `/dt:open-result` are discoverable.

## Closes

nexus-mv0p.11