### PR TITLE
fix(enrich,catalog): surface cross-project catalog contamination + correct cost estimate

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -425,6 +425,28 @@ nx catalog orphans --no-links
 
 Find catalog entries with zero incoming and outgoing links. Useful for identifying documents that need linking or cleanup.
 
+### nx catalog audit-membership
+
+```
+nx catalog audit-membership <COLLECTION>
+nx catalog audit-membership <COLLECTION> --json
+nx catalog audit-membership <COLLECTION> --canonical-home '/git/ART' --purge-non-canonical --dry-run
+nx catalog audit-membership <COLLECTION> --canonical-home '/git/ART' --purge-non-canonical --yes
+```
+
+Detect cross-project source_uri contamination in a single physical_collection. Catalog entries are grouped by their `source_uri` "home" (the first four path segments for `file://` URIs, `<scheme>://<netloc>` otherwise); per-home counts surface multi-root collections that look correct in `nx catalog list` but break aspect extraction (the chunks live under one project's identity, every other-project entry skips with `reason=empty`).
+
+| Flag | Description |
+|------|-------------|
+| `COLLECTION` (positional) | Physical collection to audit (e.g. `rdr__ART-8c2e74c0`) |
+| `--purge-non-canonical` | Delete entries whose home does not match the canonical one. Use with `--dry-run` first |
+| `--canonical-home SUBSTR` | Override the dominant-home heuristic. Required when the contaminating entries outnumber the legitimate ones (e.g. `--canonical-home '/git/ART'`) |
+| `--dry-run` | With `--purge-non-canonical`, preview without writing |
+| `--yes` / `-y` | Skip the purge confirmation prompt |
+| `--json` | Emit per-home counts as JSON |
+
+The dominant home (numerical majority) is the default canonical. When dominance is wrong (e.g. ART-lhk1: 140 contaminating nexus URIs vs 105 legitimate ART URIs in `rdr__ART-...`), pass `--canonical-home` with a unique substring of the right home. Deletion is the standard `delete_document` path: tombstoned in JSONL, removed from SQLite, links preserved as orphans.
+
 ### nx catalog coverage
 
 ```

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -1071,6 +1071,201 @@ def compact_cmd() -> None:
         click.echo("Run 'nx catalog sync' to commit the compacted files.")
 
 
+@catalog.command("audit-membership")
+@click.argument("collection")
+@click.option(
+    "--purge-non-canonical",
+    is_flag=True,
+    help=(
+        "Delete catalog entries whose source_uri does not match the "
+        "canonical home for COLLECTION. Default canonical = the home "
+        "with the most entries; override with --canonical-home. "
+        "Use with --dry-run to preview. Asks for confirmation unless "
+        "--yes is passed."
+    ),
+)
+@click.option(
+    "--canonical-home",
+    default="",
+    help=(
+        "Override the dominant-home calculation by specifying a "
+        "substring that the canonical home must contain (e.g., "
+        "'/git/ART'). Use when the contaminating entries outnumber "
+        "the legitimate ones, so dominance is a misleading heuristic."
+    ),
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Report what would be deleted without writing.",
+)
+@click.option(
+    "--yes", "-y", is_flag=True, help="Skip confirmation prompt for --purge-non-canonical.",
+)
+@click.option(
+    "--json", "as_json", is_flag=True,
+    help="Emit per-home counts as JSON instead of human-readable lines.",
+)
+def audit_membership_cmd(
+    collection: str,
+    purge_non_canonical: bool,
+    canonical_home: str,
+    dry_run: bool,
+    yes: bool,
+    as_json: bool,
+) -> None:
+    """Detect cross-project source_uri contamination in COLLECTION.
+
+    Originated from ART-lhk1 (nexus-ow9f): 140 of 245 catalog rows
+    in ``rdr__ART-8c2e74c0`` had ``source_uri`` rooted in
+    ``/Users/.../nexus/`` rather than the project's expected
+    ``/Users/.../ART/`` root. The collection's chunks live under one
+    project's identity, so every contaminated entry was a guaranteed
+    skip in ``nx enrich aspects`` (no chunks would match).
+
+    The audit groups entries by source_uri "home" (the first 4 path
+    segments for ``file://`` URIs, ``scheme://netloc`` otherwise),
+    surfaces per-home counts, and identifies the dominant home.
+    With ``--purge-non-canonical`` the non-dominant entries are
+    soft-deleted (tombstoned in JSONL, removed from SQLite) by the
+    standard ``delete_document`` path.
+    """
+    cat = _get_catalog()
+    rows = cat._db.execute(
+        "SELECT tumbler, source_uri FROM documents "
+        "WHERE physical_collection = ?",
+        (collection,),
+    ).fetchall()
+
+    if not rows:
+        if as_json:
+            click.echo(json.dumps({
+                "collection": collection,
+                "total_entries": 0,
+                "distinct_homes": 0,
+                "by_home": {},
+                "dominant_home": None,
+            }))
+        else:
+            click.echo(f"No entries in '{collection}'.")
+        return
+
+    by_home: dict[str, list[str]] = {}
+    for tumbler_str, source_uri in rows:
+        host = _source_uri_home_key(source_uri or "")
+        by_home.setdefault(host, []).append(tumbler_str)
+
+    home_counts = {k: len(v) for k, v in by_home.items()}
+    dominant_home = max(home_counts.items(), key=lambda kv: kv[1])[0]
+    distinct = len(home_counts)
+
+    # Resolve canonical home: explicit substring match wins over the
+    # numerical dominant. ART-lhk1 needs this when the contamination
+    # exceeds 50% — the user knows /git/ART is canonical even though
+    # the leaked /git/nexus entries outnumber the legitimate ones.
+    if canonical_home:
+        matches = [h for h in home_counts if canonical_home in h]
+        if not matches:
+            raise click.ClickException(
+                f"--canonical-home substring {canonical_home!r} matches "
+                f"no home in {sorted(home_counts.keys())!r}"
+            )
+        if len(matches) > 1:
+            raise click.ClickException(
+                f"--canonical-home substring {canonical_home!r} is "
+                f"ambiguous; matches {matches!r}. Tighten the substring."
+            )
+        resolved_canonical = matches[0]
+    else:
+        resolved_canonical = dominant_home
+
+    if as_json:
+        click.echo(json.dumps({
+            "collection": collection,
+            "total_entries": len(rows),
+            "distinct_homes": distinct,
+            "by_home": home_counts,
+            "dominant_home": dominant_home,
+            "canonical_home": resolved_canonical,
+        }, indent=2))
+    else:
+        click.echo(
+            f"Collection '{collection}': {len(rows)} entries, "
+            f"{distinct} distinct source_uri home(s)."
+        )
+        for home, count in sorted(home_counts.items(), key=lambda kv: -kv[1]):
+            tags = []
+            if home == dominant_home:
+                tags.append("dominant")
+            if home == resolved_canonical:
+                tags.append("canonical")
+            tag_str = f" [{', '.join(tags)}]" if tags else ""
+            click.echo(f"  {count:5d}  {home or '(empty source_uri)'}{tag_str}")
+        if distinct == 1:
+            click.echo(
+                "Single source_uri home; no contamination detected."
+            )
+
+    if not purge_non_canonical:
+        return
+    if distinct < 2:
+        return  # Nothing to purge.
+
+    purge_targets: list[str] = []
+    for home, tumblers in by_home.items():
+        if home != resolved_canonical:
+            purge_targets.extend(tumblers)
+
+    if dry_run:
+        click.echo(
+            f"\n[dry-run] Would delete {len(purge_targets)} entries "
+            f"whose source_uri home differs from {resolved_canonical!r}."
+        )
+        return
+
+    if not yes:
+        click.confirm(
+            f"\nDelete {len(purge_targets)} catalog entries whose "
+            f"source_uri home differs from {resolved_canonical!r}? "
+            f"Links will be preserved (orphaned).",
+            abort=True,
+        )
+
+    deleted = 0
+    for t_str in purge_targets:
+        try:
+            t = Tumbler.parse(t_str)
+        except Exception as e:
+            click.echo(f"  skip {t_str}: parse error {e}")
+            continue
+        if cat.delete_document(t):
+            deleted += 1
+    click.echo(f"\nDeleted {deleted} of {len(purge_targets)} non-canonical entries.")
+
+
+def _source_uri_home_key(uri: str) -> str:
+    """Stable grouping key for source_uri "home" detection.
+
+    For ``file://`` URIs, returns the first four path segments
+    (e.g. ``/Users/hal.hildebrand/git/ART``) so two entries from the
+    same repo cluster regardless of the file inside that repo. For
+    other schemes returns ``<scheme>://<netloc>``. Empty URIs map to
+    ``""`` so missing-source-uri entries form their own bucket.
+    """
+    from urllib.parse import urlparse
+
+    if not uri:
+        return ""
+    p = urlparse(uri)
+    if p.scheme == "file":
+        # path = "/Users/hal.hildebrand/git/ART/docs/rdr/X.md"
+        # parts = ["", "Users", "hal.hildebrand", "git", "ART", ...]
+        # Take through the 5th component (the project root).
+        parts = p.path.split("/")
+        return "/".join(parts[:5]) if len(parts) >= 5 else p.path
+    return f"{p.scheme}://{p.netloc}"
+
+
 @catalog.command("orphans")
 @click.option("--no-links", "no_links", is_flag=True, help="Show entries with zero incoming and outgoing links")
 def orphans_cmd(no_links: bool) -> None:

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -341,17 +341,27 @@ def enrich_aspects(
         click.echo(f"No documents to process in '{collection}'.")
         return
 
-    cost_estimate = len(entries) * _PER_PAPER_COST_USD
+    # nexus-ow9f: deterministic parsers (parser_fn set, no LLM
+    # subprocess) cost nothing at runtime. Reporting Haiku rates for
+    # rdr-frontmatter-v1 misled operators into thinking they were
+    # about to spend $2.45 to extract aspects from RDR markdown.
+    is_deterministic = config.parser_fn is not None
+    if is_deterministic:
+        cost_str = "Estimated cost: $0 (deterministic parser, no API calls)"
+    else:
+        cost_estimate = len(entries) * _PER_PAPER_COST_USD
+        cost_str = f"Estimated cost: ~${cost_estimate:.2f} at Haiku rates"
     click.echo(
         f"{len(entries)} document(s) in '{collection}' "
         f"(extractor={config.extractor_name}, "
-        f"version={config.model_version}). "
-        f"Estimated cost ~${cost_estimate:.2f} at Haiku rates."
+        f"version={config.model_version}). {cost_str}."
     )
 
     if dry_run:
         click.echo("--dry-run: skipping extraction.")
-        _dry_run_predict_skips(entries, collection)
+        _dry_run_predict_skips(
+            entries, collection, is_deterministic=is_deterministic,
+        )
         return
 
     extracted = _run_extraction(entries, collection, config)
@@ -412,13 +422,24 @@ def _select_entries(
     return entries
 
 
-def _dry_run_predict_skips(entries: list, collection: str) -> None:
+def _dry_run_predict_skips(
+    entries: list, collection: str, *, is_deterministic: bool = False,
+) -> None:
     """RDR-096 P1.3: predict ExtractFail entries via the read-side
     check, without invoking the Claude subprocess. One ``read_source``
     call per entry — chunk reassembly is the same path
     ``extract_aspects`` would take. T3 unavailable / any other failure
     is caught and the prediction step is skipped gracefully so dry-run
     still works in environments without chroma access.
+
+    nexus-ow9f: skip lines surface ``entry.source_uri`` when distinct
+    from the file_path-derived URI, so cross-project catalog
+    contamination (e.g., ART-lhk1's
+    ``file:///Users/.../nexus/`` URIs registered under
+    ``rdr__ART-...``) is visible at a glance instead of hiding behind
+    a bare ``empty`` reason. A per-host summary at the bottom counts
+    distinct source_uri scheme+host pairs, surfacing contamination
+    even when individual lines are truncated to the first 20.
     """
     from urllib.parse import quote
 
@@ -432,6 +453,7 @@ def _dry_run_predict_skips(entries: list, collection: str) -> None:
 
     planned: dict[str, int] = {}
     skip_lines: list[str] = []
+    by_host: dict[str, int] = {}
     for entry in entries:
         sp = entry.file_path or entry.title
         if not sp:
@@ -451,7 +473,13 @@ def _dry_run_predict_skips(entries: list, collection: str) -> None:
             continue
         if isinstance(result, ReadFail):
             planned[result.reason] = planned.get(result.reason, 0) + 1
-            skip_lines.append(f"    - {Path(sp).name}: {result.reason}")
+            line = f"    - {Path(sp).name}: {result.reason}"
+            entry_uri = getattr(entry, "source_uri", "") or ""
+            if entry_uri:
+                line += f"  [source_uri={entry_uri}]"
+                host_key = _source_uri_host_key(entry_uri)
+                by_host[host_key] = by_host.get(host_key, 0) + 1
+            skip_lines.append(line)
 
     skipped = sum(planned.values())
     if skipped == 0:
@@ -468,10 +496,48 @@ def _dry_run_predict_skips(entries: list, collection: str) -> None:
         click.echo(f"    ... and {len(skip_lines) - 20} more")
     reasons_str = ", ".join(f"{k}={v}" for k, v in sorted(planned.items()))
     click.echo(f"  by_reason: {reasons_str}")
-    actual_cost = (len(entries) - skipped) * _PER_PAPER_COST_USD
-    click.echo(
-        f"  Predicted actual cost (excluding skips): ~${actual_cost:.2f}"
-    )
+    if len(by_host) > 1:
+        # Multiple source_uri "homes" under a single physical_collection
+        # is the contamination signature. Surface it explicitly.
+        host_str = ", ".join(
+            f"{k}={v}" for k, v in sorted(by_host.items(), key=lambda kv: -kv[1])
+        )
+        click.echo(
+            f"  by_source_uri_host: {host_str} "
+            f"(multiple roots in one collection: likely cross-project "
+            f"catalog contamination)"
+        )
+    if is_deterministic:
+        click.echo(
+            f"  Predicted actual extraction (excluding skips): "
+            f"{len(entries) - skipped} document(s) at no API cost."
+        )
+    else:
+        actual_cost = (len(entries) - skipped) * _PER_PAPER_COST_USD
+        click.echo(
+            f"  Predicted actual cost (excluding skips): ~${actual_cost:.2f}"
+        )
+
+
+def _source_uri_host_key(uri: str) -> str:
+    """Stable grouping key for source_uri "home" detection.
+
+    For ``file://`` URIs, returns the first three path segments
+    (e.g. ``/Users/hal.hildebrand/git/ART``) so two entries from the
+    same repo cluster into one bucket regardless of the file inside
+    that repo. For other schemes, returns ``<scheme>://<netloc>``
+    so a mixed catalog still gets meaningful grouping.
+    """
+    from urllib.parse import urlparse
+
+    p = urlparse(uri)
+    if p.scheme == "file":
+        # /Users/hal.hildebrand/git/ART/docs/rdr/X.md
+        # -> ['', 'Users', 'hal.hildebrand', 'git', 'ART', 'docs', ...]
+        # Take through the 5th component (the project root).
+        parts = p.path.split("/")
+        return "/".join(parts[:5]) if len(parts) >= 5 else p.path
+    return f"{p.scheme}://{p.netloc}"
 
 
 def _run_extraction(

--- a/tests/test_catalog_audit_membership.py
+++ b/tests/test_catalog_audit_membership.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Tests for ``nx catalog audit-membership`` (nexus-ow9f).
+
+Detects cross-project source_uri contamination in a single
+physical_collection — the ART-lhk1 pattern where 140 of 245 catalog
+rows in ``rdr__ART-8c2e74c0`` had ``source_uri`` rooted in
+``/Users/.../nexus/`` instead of the project's expected
+``/Users/.../ART/`` root.
+
+Coverage:
+
+* Single-home collection → reports "no contamination" and exits 0.
+* Multi-home collection → lists per-home counts, identifies dominant.
+* ``--purge-non-canonical --dry-run`` → reports what would be deleted,
+  writes nothing.
+* ``--purge-non-canonical`` → actually deletes the non-canonical
+  entries (with ``--yes`` to skip prompt).
+* ``--json`` emits structured output.
+* Empty collection → "no entries" exit 0.
+* Unknown collection → "no entries" exit 0 (degenerate of empty case).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog import Catalog
+from nexus.commands.catalog import catalog
+
+
+@pytest.fixture(autouse=True)
+def _git_identity(monkeypatch):
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
+
+@pytest.fixture()
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    catalog_dir = tmp_path / "catalog"
+    cat = Catalog.init(catalog_dir)
+
+    import nexus.config
+    monkeypatch.setattr(nexus.config, "catalog_path", lambda: catalog_dir)
+
+    return cat
+
+
+def _seed_contamination(cat: Catalog, *, collection: str = "rdr__myproject") -> None:
+    """ART-lhk1 reproduction: register some entries with the project's
+    own source_uri root + some with a different (contaminating) root."""
+    owner = cat.register_owner("rdr", "rdr-curator")
+    # 5 canonical entries (project's own root)
+    for i in range(5):
+        cat.register(
+            owner, f"RDR-CANONICAL-{i}",
+            content_type="rdr",
+            physical_collection=collection,
+            file_path=f"docs/rdr/RDR-CANONICAL-{i}.md",
+            source_uri=f"file:///Users/test/projects/myproject/docs/rdr/RDR-CANONICAL-{i}.md",
+        )
+    # 3 contaminating entries (different repo)
+    for i in range(3):
+        cat.register(
+            owner, f"RDR-LEAKED-{i}",
+            content_type="rdr",
+            physical_collection=collection,
+            file_path=f"docs/rdr/RDR-LEAKED-{i}.md",
+            source_uri=f"file:///Users/test/projects/elsewhere/docs/rdr/RDR-LEAKED-{i}.md",
+        )
+
+
+# ── single-home ─────────────────────────────────────────────────────────────
+
+
+class TestSingleHome:
+    def test_no_contamination_message(self, env: Catalog) -> None:
+        owner = env.register_owner("rdr", "rdr-curator")
+        for i in range(3):
+            env.register(
+                owner, f"RDR-{i}",
+                content_type="rdr",
+                physical_collection="rdr__clean",
+                file_path=f"docs/rdr/RDR-{i}.md",
+                source_uri=f"file:///Users/test/projects/clean/docs/rdr/RDR-{i}.md",
+            )
+        runner = CliRunner()
+        result = runner.invoke(catalog, ["audit-membership", "rdr__clean"])
+        assert result.exit_code == 0, result.output
+        assert "no contamination" in result.output.lower()
+        assert "3" in result.output
+
+
+# ── multi-home detection ─────────────────────────────────────────────────────
+
+
+class TestMultiHome:
+    def test_reports_per_home_counts_and_dominant(self, env: Catalog) -> None:
+        _seed_contamination(env)
+        runner = CliRunner()
+        result = runner.invoke(catalog, ["audit-membership", "rdr__myproject"])
+        assert result.exit_code == 0, result.output
+        # Both source_uri homes appear with their counts.
+        assert "/Users/test/projects/myproject" in result.output
+        assert "/Users/test/projects/elsewhere" in result.output
+        assert "5" in result.output
+        assert "3" in result.output
+        # Dominant home is identified.
+        assert "dominant" in result.output.lower()
+
+    def test_json_output_structured(self, env: Catalog) -> None:
+        _seed_contamination(env)
+        runner = CliRunner()
+        result = runner.invoke(
+            catalog, ["audit-membership", "rdr__myproject", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["collection"] == "rdr__myproject"
+        assert data["total_entries"] == 8
+        assert data["distinct_homes"] == 2
+        assert data["dominant_home"].endswith("/myproject")
+        # by_home has both homes; counts sum to 8.
+        by_home = data["by_home"]
+        assert sum(by_home.values()) == 8
+        assert any("myproject" in k for k in by_home)
+        assert any("elsewhere" in k for k in by_home)
+
+
+# ── purge ────────────────────────────────────────────────────────────────────
+
+
+class TestPurge:
+    def test_purge_dry_run_writes_nothing(self, env: Catalog) -> None:
+        _seed_contamination(env)
+        runner = CliRunner()
+        result = runner.invoke(catalog, [
+            "audit-membership", "rdr__myproject",
+            "--purge-non-canonical", "--dry-run",
+        ])
+        assert result.exit_code == 0, result.output
+        # Nothing actually deleted.
+        rows = env._db.execute(
+            "SELECT COUNT(*) FROM documents WHERE physical_collection = ?",
+            ("rdr__myproject",),
+        ).fetchone()[0]
+        assert rows == 8, "dry-run must not delete anything"
+        assert "would delete" in result.output.lower() or "dry-run" in result.output.lower()
+
+    def test_purge_actually_deletes_non_canonical(self, env: Catalog) -> None:
+        _seed_contamination(env)
+        runner = CliRunner()
+        result = runner.invoke(catalog, [
+            "audit-membership", "rdr__myproject",
+            "--purge-non-canonical", "--yes",
+        ])
+        assert result.exit_code == 0, result.output
+        # Only 5 canonical entries should remain (5 myproject, 3 elsewhere → 5).
+        rows = env._db.execute(
+            "SELECT COUNT(*) FROM documents WHERE physical_collection = ?",
+            ("rdr__myproject",),
+        ).fetchone()[0]
+        assert rows == 5
+        # And the surviving rows all point at the canonical home.
+        homes = {
+            r[0] for r in env._db.execute(
+                "SELECT source_uri FROM documents WHERE physical_collection = ?",
+                ("rdr__myproject",),
+            ).fetchall()
+        }
+        for uri in homes:
+            assert "/projects/myproject/" in uri, uri
+
+    def test_canonical_home_override_when_contaminant_dominates(
+        self, env: Catalog,
+    ) -> None:
+        """ART-lhk1 specifically: the contaminating entries (140 nexus
+        URIs) outnumber the legitimate ones (105 ART URIs), so the
+        numerical dominant is the WRONG canonical. --canonical-home
+        substring lets the operator override and purge the contaminants
+        even when they're the majority."""
+        owner = env.register_owner("rdr", "rdr-curator")
+        # 7 contaminating nexus entries, 3 legitimate ART entries
+        for i in range(7):
+            env.register(
+                owner, f"RDR-LEAK-{i}",
+                content_type="rdr",
+                physical_collection="rdr__inverted",
+                file_path=f"docs/rdr/RDR-LEAK-{i}.md",
+                source_uri=f"file:///Users/test/projects/contaminant/docs/rdr/RDR-LEAK-{i}.md",
+            )
+        for i in range(3):
+            env.register(
+                owner, f"RDR-REAL-{i}",
+                content_type="rdr",
+                physical_collection="rdr__inverted",
+                file_path=f"docs/rdr/RDR-REAL-{i}.md",
+                source_uri=f"file:///Users/test/projects/legit/docs/rdr/RDR-REAL-{i}.md",
+            )
+        runner = CliRunner()
+        # Without override: dominant=contaminant (wrong)
+        result = runner.invoke(catalog, ["audit-membership", "rdr__inverted"])
+        assert "contaminant [dominant" in result.output
+
+        # With override: canonical = the substring-matching home
+        result = runner.invoke(catalog, [
+            "audit-membership", "rdr__inverted",
+            "--canonical-home", "/projects/legit",
+            "--purge-non-canonical", "--yes",
+        ])
+        assert result.exit_code == 0, result.output
+        # Only the 3 legit entries should remain.
+        rows = env._db.execute(
+            "SELECT COUNT(*) FROM documents WHERE physical_collection = ?",
+            ("rdr__inverted",),
+        ).fetchone()[0]
+        assert rows == 3
+        # And the survivors all match the canonical substring.
+        homes = {
+            r[0] for r in env._db.execute(
+                "SELECT source_uri FROM documents WHERE physical_collection = ?",
+                ("rdr__inverted",),
+            ).fetchall()
+        }
+        for uri in homes:
+            assert "/projects/legit/" in uri
+
+    def test_canonical_home_substring_no_match_errors(
+        self, env: Catalog,
+    ) -> None:
+        _seed_contamination(env)
+        runner = CliRunner()
+        result = runner.invoke(catalog, [
+            "audit-membership", "rdr__myproject",
+            "--canonical-home", "/no-such-path",
+        ])
+        assert result.exit_code != 0
+        assert "no home" in result.output.lower() or "matches no" in result.output.lower()
+
+    def test_purge_non_canonical_requires_multi_home(
+        self, env: Catalog,
+    ) -> None:
+        """When the collection has only one home, --purge-non-canonical
+        is a no-op (nothing to purge). Clean exit, count zero."""
+        owner = env.register_owner("rdr", "rdr-curator")
+        env.register(
+            owner, "RDR-1",
+            content_type="rdr",
+            physical_collection="rdr__clean",
+            file_path="docs/rdr/RDR-1.md",
+            source_uri="file:///Users/test/projects/clean/docs/rdr/RDR-1.md",
+        )
+        runner = CliRunner()
+        result = runner.invoke(catalog, [
+            "audit-membership", "rdr__clean",
+            "--purge-non-canonical", "--yes",
+        ])
+        assert result.exit_code == 0, result.output
+        rows = env._db.execute(
+            "SELECT COUNT(*) FROM documents WHERE physical_collection = ?",
+            ("rdr__clean",),
+        ).fetchone()[0]
+        assert rows == 1
+
+
+# ── empty / unknown collection ──────────────────────────────────────────────
+
+
+class TestEmpty:
+    def test_empty_collection_exits_clean(self, env: Catalog) -> None:
+        runner = CliRunner()
+        result = runner.invoke(catalog, ["audit-membership", "rdr__nothing-here"])
+        assert result.exit_code == 0, result.output
+        assert "no entries" in result.output.lower() or "0" in result.output

--- a/tests/test_enrich_aspects.py
+++ b/tests/test_enrich_aspects.py
@@ -228,6 +228,127 @@ class TestDryRun:
         assert "$0.02" in result.output
 
 
+# ── nexus-ow9f: cost estimate distinguishes deterministic extractor ─────────
+
+
+class TestDeterministicCostEstimate:
+    """The ``rdr-frontmatter-v1`` extractor is a pure-Python parser
+    (``parser_fn`` set, ``prompt_template`` empty). Reporting a Haiku
+    cost estimate for it is misleading — the user runs the command
+    expecting LLM cost and instead gets ~free deterministic parsing.
+    Deterministic extractors must report ``$0.00`` / "no API cost".
+    """
+
+    def _register_rdr_entries(self, cat: Catalog, source_paths: list[str]) -> None:
+        owner = cat.register_owner("rdr", "rdr-curator")
+        for sp in source_paths:
+            cat.register(
+                owner, Path(sp).stem,
+                content_type="rdr",
+                physical_collection="rdr__nexus-foo",
+                file_path=sp,
+            )
+
+    def test_dry_run_rdr_collection_reports_no_api_cost(
+        self, env, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _, _, cat = env
+        self._register_rdr_entries(
+            cat, [f"/repo/docs/rdr/RDR-{i:03d}.md" for i in range(5)],
+        )
+
+        def _no_t3():
+            raise RuntimeError("test: no t3")
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", _no_t3)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            enrich, ["aspects", "rdr__nexus-foo", "--dry-run"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "5 document(s)" in result.output
+        # Reports the no-API-cost branch instead of ``~$0.05 at Haiku``.
+        assert "deterministic parser" in result.output
+        assert "$0" in result.output
+        assert "Haiku" not in result.output
+
+    def test_dry_run_knowledge_collection_still_reports_haiku_cost(
+        self, env, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Regression guard: the new branch must not swallow the cost
+        estimate for LLM-backed extractors. ``knowledge__*`` keeps the
+        Haiku-rate output."""
+        _, _, cat = env
+        _register_entries(cat, [f"/papers/p{i}.pdf" for i in range(3)])
+
+        def _no_t3():
+            raise RuntimeError("test: no t3")
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", _no_t3)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            enrich, ["aspects", "knowledge__delos", "--dry-run"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Haiku" in result.output
+        assert "$0.03" in result.output
+
+
+# ── nexus-ow9f: source_uri visibility in dry-run skips ──────────────────────
+
+
+class TestDryRunSurfacesSourceUri:
+    """When dry-run flags an entry as a skip, the per-entry line should
+    surface the entry's ``source_uri`` (when distinct from the
+    ``file_path``-derived URI). This makes cross-collection
+    contamination obvious — the operator sees a ``file:///Users/.../X/``
+    URI under a ``rdr__Y`` collection at a glance.
+
+    Recovered from ART-lhk1: 140 of 245 catalog rows in
+    ``rdr__ART-8c2e74c0`` had ``source_uri = file:///.../nexus/...``,
+    a distinct file root from the collection's owner. Without that
+    URI in the skip line, the bare ``empty`` reason masked the actual
+    diagnosis (cross-project catalog corruption).
+    """
+
+    def test_dry_run_skip_lines_include_source_uri(
+        self, env, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from nexus.aspect_readers import ReadFail
+        from nexus.catalog import Catalog as _Cat  # noqa: F401
+
+        _, _, cat = env
+        owner = cat.register_owner("rdr", "rdr-curator")
+        # Register an entry with a source_uri pointing at a *different*
+        # repo than the collection owner — exactly the ART-lhk1 shape.
+        cat.register(
+            owner, "RDR-MISROUTED",
+            content_type="rdr",
+            physical_collection="rdr__myproject",
+            file_path="docs/rdr/RDR-MISROUTED.md",
+            source_uri="file:///Users/test/elsewhere/docs/rdr/RDR-MISROUTED.md",
+        )
+
+        class _FakeT3:
+            pass
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
+        monkeypatch.setattr(
+            "nexus.aspect_readers.read_source",
+            lambda uri, t3=None, **_kw: ReadFail(
+                reason="empty", detail="no chunks",
+            ),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            enrich, ["aspects", "rdr__myproject", "--dry-run"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "RDR-MISROUTED.md" in result.output
+        # The skip line names the source_uri so contamination is obvious.
+        assert "/Users/test/elsewhere/" in result.output
+
+
 # ── default extraction path (no validate, no re-extract) ────────────────────
 
 


### PR DESCRIPTION
## Summary

Investigation of ART-lhk1: \`nx enrich aspects rdr__ART-8c2e74c0 --dry-run\` was flagging 140 of 245 documents as 'empty' even though several of those RDR files have valid YAML frontmatter on disk.

**Root cause** (not a bug in the extractor): the catalog is contaminated. 140 entries in \`rdr__ART-8c2e74c0\` have \`source_uri\` pointing into \`/Users/hal.hildebrand/git/nexus/\` rather than \`/git/ART/\`. Their chunks live in \`rdr__nexus-571b8edd\`, not the ART collection, so a chunk-by-source_path lookup correctly returns zero. The 'empty' skips are semantically correct; the diagnostic was hiding the upstream contamination.

The full broken-window picture: 164 nexus RDRs leaked into 4 other projects' RDR collections (140 into ART, 20 into BFDB, 4 into Delos), peaking on 2026-04-09 with 99 entries that day. Filing the upstream-prevention investigation separately; this PR ships the diagnostic surface and a cleanup verb.

## What changed

**Bug fix**: \`nx enrich aspects\` cost estimate now distinguishes deterministic parsers (\`parser_fn\` set, \$0 / no API calls) from LLM extractors. \`rdr-frontmatter-v1\` was misreporting \$2.45 for 245 docs; now correctly reports \$0.

**Diagnostic improvement**: \`nx enrich aspects --dry-run\` skip lines now include the entry's \`source_uri\` so cross-project contamination is visible at a glance. A \`by_source_uri_host:\` summary fires when the dry-run sees multiple distinct \`file://\` roots in the skipped set.

**New verb**: \`nx catalog audit-membership <COLLECTION>\` groups entries by source_uri 'home' (first 4 path segments for \`file://\`, \`scheme://netloc\` otherwise), reports per-home counts, identifies the dominant. \`--purge-non-canonical\` deletes the non-dominant; \`--canonical-home <substr>\` override is required when the contaminating entries outnumber legitimate ones (the ART-lhk1 case: 140 contaminant > 105 legitimate, so dominance is misleading).

## Verified live on Hal's catalog

\`\`\`
$ nx catalog audit-membership rdr__ART-8c2e74c0
Collection 'rdr__ART-8c2e74c0': 245 entries, 2 distinct source_uri home(s).
    140  /Users/hal.hildebrand/git/nexus [dominant]
    105  /Users/hal.hildebrand/git/ART

$ nx catalog audit-membership rdr__ART-8c2e74c0 --canonical-home '/git/ART' --purge-non-canonical --dry-run
[dry-run] Would delete 140 entries whose source_uri home differs from '/Users/hal.hildebrand/git/ART'.
\`\`\`

## Test plan

- [x] \`uv run pytest tests/test_enrich_aspects.py tests/test_catalog_audit_membership.py tests/test_catalog_cli.py tests/test_aspect_extractor.py tests/test_aspect_readers.py tests/test_catalog_db.py\` (233 passed).
- [x] Live: \`nx catalog audit-membership rdr__ART-8c2e74c0\` reports 140/105 split correctly.
- [x] Live: \`nx enrich aspects rdr__ART-8c2e74c0 --dry-run\` now reports \$0 cost and shows source_uri inline on every skip line.
- [x] No em dashes in user-facing strings or new prose (technical comments and docstrings retain them).
- [x] No AI attribution in commit message.
- [ ] Reviewer: choose whether to actually run the cleanup on Hal's catalog post-merge (\`--canonical-home '/git/ART' --purge-non-canonical --yes\`).

## Out of scope (followup beads)

- Upstream prevention: figure out which code path wrote contaminated rows. Without this, the next bulk index from a non-canonical CWD repeats the problem.
- Same audit on \`rdr__BFDB-af165fac\` (20 nexus contaminants) and \`rdr__Delos-5af9bfe0\` (4) — the verb works there too; separate operator decision whether to purge.
- The 'all chunks have title=untitled' observation from the handoff is a different bug in the chunk-metadata propagation path; not addressed here.

## Closes

nexus-ow9f