### PR TITLE
fix(catalog): cross-project source_uri guard + relative-path anchor (nexus-3e4s)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -232,7 +232,9 @@ _KNOWN_URI_SCHEMES: frozenset[str] = frozenset({
 })
 
 
-def _normalize_source_uri(source_uri: str, file_path: str) -> str:
+def _normalize_source_uri(
+    source_uri: str, file_path: str, *, repo_root: str = "",
+) -> str:
     """RDR-096 P3.1 register-boundary URI validation.
 
     * Empty ``source_uri`` + non-empty ``file_path`` → derive
@@ -244,10 +246,20 @@ def _normalize_source_uri(source_uri: str, file_path: str) -> str:
       have a recognized scheme. Malformed URIs raise ``ValueError``
       at the register boundary, NOT silently persisted (RDR-096
       Risks and Mitigations).
+
+    nexus-3e4s: when ``file_path`` is relative AND ``repo_root`` is
+    provided, the abspath is anchored on ``repo_root`` rather than
+    the process CWD. This is the upstream fix for the catalog
+    contamination bug class — without it, indexing repo ``A`` from
+    a CWD inside repo ``B`` produced ``source_uri`` rows pointing
+    to ``B``'s tree, leaving the row attributed to ``A``'s owner.
     """
     if not source_uri:
         if file_path:
-            return "file://" + os.path.abspath(file_path)
+            base = file_path
+            if repo_root and not os.path.isabs(file_path):
+                base = os.path.join(repo_root, file_path)
+            return "file://" + os.path.abspath(base)
         return ""
 
     parsed = urlparse(source_uri)
@@ -265,6 +277,13 @@ def _normalize_source_uri(source_uri: str, file_path: str) -> str:
             f"new scheme, register a reader in nexus.aspect_readers.",
         )
     return source_uri
+
+
+# nexus-3e4s: env-var escape hatch for the cross-project guard. Set to
+# ``"1"`` only to recover from emergency situations (e.g. a known-good
+# cleanup script that legitimately needs to register rows across project
+# boundaries). Never the right answer for normal indexing.
+_CROSS_PROJECT_OVERRIDE_ENV = "NEXUS_CATALOG_ALLOW_CROSS_PROJECT"
 
 
 @dataclass
@@ -629,6 +648,86 @@ class Catalog:
 
     # ── Documents ──────────────────────────────────────────────────────────
 
+    def _owner_repo_root(self, owner: Tumbler) -> str:
+        """Return the owner's ``repo_root``, or ``""`` if unknown.
+
+        nexus-3e4s: register() and update() call this to anchor relative
+        ``file_path`` values to the owner's working tree instead of CWD.
+        """
+        row = self._db.execute(
+            "SELECT repo_root FROM owners WHERE tumbler_prefix = ?",
+            (str(owner),),
+        ).fetchone()
+        if not row:
+            return ""
+        return row[0] or ""
+
+    def _check_source_uri_in_repo_root(
+        self, owner: Tumbler, source_uri: str,
+    ) -> None:
+        """Reject cross-project ``source_uri`` attribution at register time.
+
+        nexus-3e4s: this is the load-bearing guard against the bug class
+        where owner ``A``'s tumbler accumulates rows whose ``source_uri``
+        lives in a different project's working tree. The signature was
+        observed in the live catalog as ~6,500 rows where, for example,
+        the ART repo's owner registered files under nexus's source tree.
+
+        The guard is owner-type-aware:
+
+        * ``repo`` owners with a non-empty ``repo_root`` enforce the match;
+        * ``curator`` owners (no ``repo_root``) legitimately span sources
+          and skip the check;
+        * pre-RDR-060 ``repo`` owners persisted before ``repo_root`` was
+          a column have ``repo_root=""`` and skip the check (back-compat).
+
+        Only ``file://`` URIs carry a project association — ``chroma://``,
+        ``https://``, ``x-devonthink-item://``, etc. have no filesystem
+        identity to compare against and pass through unchanged.
+
+        Set ``NEXUS_CATALOG_ALLOW_CROSS_PROJECT=1`` to bypass for
+        emergency recovery; this is never the right answer for normal
+        indexing.
+        """
+        if os.environ.get(_CROSS_PROJECT_OVERRIDE_ENV) == "1":
+            return
+        if not source_uri:
+            return
+        parsed = urlparse(source_uri)
+        if parsed.scheme != "file":
+            return
+        row = self._db.execute(
+            "SELECT owner_type, repo_root FROM owners WHERE tumbler_prefix = ?",
+            (str(owner),),
+        ).fetchone()
+        if not row:
+            # Owner-not-found is its own bug class; the existing
+            # foreign-key flow surfaces it elsewhere. Don't double-fault.
+            return
+        owner_type, repo_root = row[0], row[1] or ""
+        if owner_type != "repo" or not repo_root:
+            return
+        # Realpath both sides so symlinked roots (notably macOS's
+        # /private/var ↔ /var) and ``..`` segments don't trigger
+        # false positives. realpath() tolerates non-existent paths.
+        from urllib.parse import unquote
+
+        file_abs = unquote(parsed.path)
+        real_file = os.path.realpath(file_abs)
+        real_root = os.path.realpath(repo_root)
+        try:
+            Path(real_file).relative_to(real_root)
+        except ValueError:
+            raise ValueError(
+                f"cross-project source_uri rejected (nexus-3e4s): "
+                f"owner {owner} has repo_root={repo_root!r} but "
+                f"source_uri {source_uri!r} resolves to {real_file!r} "
+                f"which is outside the owner's repo_root. This is the "
+                f"signature of the contamination bug class. Set "
+                f"{_CROSS_PROJECT_OVERRIDE_ENV}=1 to bypass for "
+                f"emergency recovery."
+            ) from None
+
     def register(
         self,
         owner: Tumbler,
@@ -646,12 +745,22 @@ class Catalog:
         source_mtime: float = 0.0,
         source_uri: str = "",
     ) -> Tumbler:
+        # nexus-3e4s: anchor relative file_path values to the owner's
+        # repo_root, not CWD. Without this, indexing repo A from a CWD
+        # inside repo B writes source_uris pointing to B's tree but
+        # attributed to A's owner — the contamination signature.
+        owner_repo_root = self._owner_repo_root(owner)
         # RDR-096 P3.1: validate / derive source_uri at the register
         # boundary. Bare paths normalize to ``file://``; explicit URIs
         # are validated for scheme; malformed URIs raise ValueError
         # rather than silently persist (matches the RDR's risk
         # mitigation strategy).
-        source_uri = _normalize_source_uri(source_uri, file_path)
+        source_uri = _normalize_source_uri(
+            source_uri, file_path, repo_root=owner_repo_root,
+        )
+        # nexus-3e4s: cross-project attribution guard. Reject when the
+        # source_uri lives outside the owner's repo_root prefix.
+        self._check_source_uri_in_repo_root(owner, source_uri)
         dir_fd = self._acquire_lock()
         try:
             # Idempotency: check by file_path if non-empty
@@ -1194,9 +1303,17 @@ class Catalog:
             # If a caller passes ``source_uri=...`` through ``fields``,
             # validate it through the same boundary as register —
             # malformed URIs are hard errors, not silent persistence.
+            # Anchor on the owner's repo_root so relative file_paths
+            # don't fall through to CWD-based abspath (nexus-3e4s).
             if "source_uri" in fields:
                 rec_dict["source_uri"] = _normalize_source_uri(
                     rec_dict["source_uri"], rec_dict.get("file_path", ""),
+                    repo_root=self._owner_repo_root(entry.tumbler.owner_address()),
+                )
+                # And re-run the cross-project guard so update() can't
+                # be used as a back door around register's check.
+                self._check_source_uri_in_repo_root(
+                    entry.tumbler.owner_address(), rec_dict["source_uri"],
                 )
             self._append_jsonl(self._documents_path, rec_dict)
             # Upsert SQLite

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -790,3 +790,255 @@ class TestLinkChashValidation:
         cat, _, a, b = cat_with_two_docs
         assert cat.link(a, b, "cites", "test-agent",
                         from_span="chash:" + "a" * 64, allow_dangling=True) is True
+
+
+class TestCrossProjectGuard:
+    """nexus-3e4s: register-time guard against cross-project source_uri
+    contamination.
+
+    Background: ~6,500 catalog rows in Hal's catalog have nexus's own
+    files attributed to OTHER projects' physical_collections (the
+    smoking gun: owner X with repo_root=/path/to/X registered files
+    whose source_uri is /path/to/Y/foo.py). The guard fails loudly
+    at register time so the bug class cannot recur even when the
+    upstream code path is unknown.
+    """
+
+    @pytest.fixture
+    def cat_with_repo_owner(self, cat, tmp_path):
+        repo_root = tmp_path / "fake_project"
+        repo_root.mkdir()
+        owner = cat.register_owner(
+            "fake-project", "repo",
+            repo_hash="abcd1234",
+            repo_root=str(repo_root),
+        )
+        return cat, owner, repo_root
+
+    def test_register_inside_repo_root_succeeds(self, cat_with_repo_owner):
+        cat, owner, repo_root = cat_with_repo_owner
+        f = repo_root / "src" / "foo.py"
+        f.parent.mkdir(parents=True)
+        f.touch()
+        doc = cat.register(
+            owner, "foo.py", content_type="code",
+            file_path=str(f),
+        )
+        entry = cat.resolve(doc)
+        assert entry is not None
+        assert "fake_project" in entry.source_uri
+
+    def test_register_outside_repo_root_rejected(
+        self, cat_with_repo_owner, tmp_path,
+    ):
+        """Smoking gun: file whose path is OUTSIDE owner.repo_root is
+        the contamination signature. Reject with both URIs in message.
+        """
+        cat, owner, repo_root = cat_with_repo_owner
+        other = tmp_path / "other_project" / "bar.py"
+        other.parent.mkdir(parents=True)
+        other.touch()
+        with pytest.raises(ValueError) as exc_info:
+            cat.register(
+                owner, "bar.py", content_type="code",
+                file_path=str(other),
+            )
+        msg = str(exc_info.value)
+        assert "cross-project" in msg
+        # Both URIs must appear so operators can diagnose without
+        # rerunning the failed call.
+        assert str(repo_root) in msg
+        assert "bar.py" in msg
+
+    def test_register_outside_repo_root_via_explicit_source_uri_rejected(
+        self, cat_with_repo_owner, tmp_path,
+    ):
+        """The guard also catches the case where the caller supplies an
+        explicit ``source_uri=`` that lives outside the owner's root,
+        not just the auto-derived path."""
+        cat, owner, repo_root = cat_with_repo_owner
+        bogus = "file://" + str(tmp_path / "elsewhere" / "x.py")
+        with pytest.raises(ValueError, match="cross-project"):
+            cat.register(
+                owner, "x.py", content_type="code",
+                file_path="x.py",
+                source_uri=bogus,
+            )
+
+    def test_register_curator_owner_skips_guard(self, cat, tmp_path):
+        """Curator owners legitimately span sources (PDFs, mirrored
+        docs, etc.) — no repo_root, no enforcement.
+        """
+        owner = cat.register_owner("hal-papers", "curator")
+        # Source URI from any path — no project association to enforce.
+        far_away = tmp_path / "anywhere" / "paper.pdf"
+        far_away.parent.mkdir(parents=True)
+        far_away.touch()
+        doc = cat.register(
+            owner, "paper", content_type="paper",
+            file_path=str(far_away),
+        )
+        assert cat.resolve(doc) is not None
+
+    def test_register_repo_owner_without_repo_root_skips_guard(
+        self, cat, tmp_path,
+    ):
+        """Pre-RDR-060 owners persisted before repo_root was a column —
+        the guard cannot enforce what wasn't recorded. Skip rather
+        than reject (back-compat).
+        """
+        owner = cat.register_owner(
+            "legacy-repo", "repo", repo_hash="legacyhash",
+            # repo_root deliberately omitted to mimic a pre-RDR-060 row.
+        )
+        far = tmp_path / "anywhere" / "x.py"
+        far.parent.mkdir(parents=True)
+        far.touch()
+        doc = cat.register(
+            owner, "x.py", content_type="code", file_path=str(far),
+        )
+        assert cat.resolve(doc) is not None
+
+    def test_register_chroma_uri_skips_guard(self, cat_with_repo_owner):
+        """``chroma://`` URIs have no filesystem identity; the project
+        check does not apply.
+        """
+        cat, owner, _ = cat_with_repo_owner
+        doc = cat.register(
+            owner, "remote", content_type="paper",
+            source_uri="chroma://knowledge__delos/foo.pdf",
+        )
+        assert cat.resolve(doc) is not None
+
+    def test_register_devonthink_uri_skips_guard(self, cat_with_repo_owner):
+        cat, owner, _ = cat_with_repo_owner
+        doc = cat.register(
+            owner, "dt-paper", content_type="paper",
+            source_uri="x-devonthink-item://8EDC855D-213F-40AD-A9CF-9543CC76476B",
+        )
+        assert cat.resolve(doc) is not None
+
+    def test_register_https_uri_skips_guard(self, cat_with_repo_owner):
+        cat, owner, _ = cat_with_repo_owner
+        doc = cat.register(
+            owner, "html-mirror", content_type="paper",
+            source_uri="https://example.com/paper",
+        )
+        assert cat.resolve(doc) is not None
+
+    def test_register_empty_source_uri_skips_guard(self, cat_with_repo_owner):
+        """Synthesized records (no path, no URI) bypass the guard so
+        ghost-registration paths still work.
+        """
+        cat, owner, _ = cat_with_repo_owner
+        doc = cat.register(owner, "ghost", content_type="paper")
+        assert cat.resolve(doc) is not None
+
+    def test_env_override_allows_cross_project_register(
+        self, cat_with_repo_owner, tmp_path, monkeypatch,
+    ):
+        """Emergency recovery escape hatch: setting
+        ``NEXUS_CATALOG_ALLOW_CROSS_PROJECT=1`` bypasses the guard.
+        """
+        cat, owner, _ = cat_with_repo_owner
+        other = tmp_path / "other_project" / "qux.py"
+        other.parent.mkdir(parents=True)
+        other.touch()
+        monkeypatch.setenv("NEXUS_CATALOG_ALLOW_CROSS_PROJECT", "1")
+        doc = cat.register(
+            owner, "qux.py", content_type="code",
+            file_path=str(other),
+        )
+        assert cat.resolve(doc) is not None
+
+    def test_existing_contaminated_rows_remain_readable(
+        self, cat_with_repo_owner, tmp_path,
+    ):
+        """Migration concern: the guard is register-time only. Catalogs
+        with pre-existing contaminated rows (~6,500 in Hal's catalog
+        on 2026-04-29) must still load read-only without losing data.
+
+        We bypass register() and INSERT a contaminated row directly
+        via the underlying SQLite connection, then verify resolve()
+        and by_file_path() return it unchanged.
+        """
+        cat, owner, _ = cat_with_repo_owner
+        # Direct INSERT to mimic a contaminated row already in the DB
+        # — exactly what Hal's live catalog looks like.
+        contaminated_uri = "file://" + str(
+            tmp_path / "wrong_project" / "stowaway.py",
+        )
+        cat._db.execute(
+            "INSERT INTO documents "
+            "(tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, "
+            "indexed_at, metadata, source_mtime, source_uri) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                f"{owner}.999",
+                "stowaway.py", "", 0, "code",
+                "wrong_project/stowaway.py",
+                "code", "code__contaminated", 0, "",
+                "2026-04-09T00:00:00+00:00", "{}", 0.0,
+                contaminated_uri,
+            ),
+        )
+        cat._db.commit()
+        # Read-back must succeed: contamination cleanup is a separate
+        # operation (PR #381's audit-membership), not the guard's job.
+        entry = cat.resolve(Tumbler.parse(f"{owner}.999"))
+        assert entry is not None
+        assert entry.source_uri == contaminated_uri
+        assert entry.title == "stowaway.py"
+
+    def test_register_relative_file_path_anchors_on_owner_repo_root(
+        self, cat_with_repo_owner, tmp_path, monkeypatch,
+    ):
+        """nexus-3e4s upstream regression: when ``file_path`` is
+        relative AND the owner has a ``repo_root``, the derived
+        ``source_uri`` MUST anchor on ``repo_root`` rather than CWD.
+
+        Pre-fix: ``os.path.abspath("src/foo.py")`` would resolve
+        against the process CWD, producing ``source_uri`` rows that
+        pointed to nexus's tree even when the indexed repo was ART.
+        That was the contamination signature for ~6,500 rows.
+        """
+        cat, owner, repo_root = cat_with_repo_owner
+        # Force CWD to a totally unrelated directory to exercise the
+        # bug class — pre-fix this would attribute the URI to CWD.
+        foreign_cwd = tmp_path / "foreign_workspace"
+        foreign_cwd.mkdir()
+        monkeypatch.chdir(foreign_cwd)
+
+        (repo_root / "src").mkdir()
+        (repo_root / "src" / "main.py").touch()
+
+        doc = cat.register(
+            owner, "main.py", content_type="code",
+            file_path="src/main.py",  # relative — the bug pathway
+        )
+        entry = cat.resolve(doc)
+        assert entry is not None
+        # URI must anchor on owner's repo_root, not the foreign CWD.
+        assert str(repo_root) in entry.source_uri
+        assert str(foreign_cwd) not in entry.source_uri
+
+    def test_register_inside_nested_worktree_under_repo_root_succeeds(
+        self, cat_with_repo_owner,
+    ):
+        """A file under ``repo_root/.claude/worktrees/X/foo.py`` is
+        still legitimately under the owner's repo_root prefix-wise,
+        so the guard does NOT fire. (Worktrees that are themselves
+        separate owners must be registered to a different owner; this
+        test covers the case where the file IS still owned by the
+        outer repo.)
+        """
+        cat, owner, repo_root = cat_with_repo_owner
+        nested = repo_root / ".claude" / "worktrees" / "agent-x" / "code.py"
+        nested.parent.mkdir(parents=True)
+        nested.touch()
+        doc = cat.register(
+            owner, "code.py", content_type="code",
+            file_path=str(nested),
+        )
+        assert cat.resolve(doc) is not None


### PR DESCRIPTION
## What

Catalog-side guard against the cross-project `source_uri` contamination bug class (nexus-3e4s) **plus** the upstream root-cause fix that produced ~6,500 contaminated rows in the live catalog.

## Root cause

`_normalize_source_uri()` derived the `source_uri` from a relative `file_path` via `os.path.abspath()`, which resolves against the **process CWD** rather than the owner's `repo_root`.

The catalog hook (`indexer._catalog_hook`) ALWAYS passes a relative `file_path` (computed via `abs_path.relative_to(repo)`). So any time `nx index <repo>` ran with a CWD outside the indexed repo (notably the release-sandbox shakeout, which runs from the nexus checkout while indexing other projects), the resulting `source_uri` rows pointed to the nexus tree but were attributed to the OTHER repo's owner. That is the contamination signature.

## Two fixes, one PR

These ship together because shipping the guard alone would break legitimate `nx index` flows the moment it landed (every catalog-hook call would fail the guard).

### 1. `Catalog._check_source_uri_in_repo_root` — register-time guard

Raises `ValueError` when:
- owner is `repo` type with non-empty `repo_root`, AND
- `source_uri` is `file://`, AND
- the resolved file path is outside the owner's `repo_root` (after `os.path.realpath()` normalization for macOS `/private/var` symlinks).

Skip cases:
- Curator owners (legitimately span sources).
- Pre-RDR-060 repo owners with empty `repo_root` (back-compat).
- Non-`file://` URIs (`chroma://`, `https://`, `x-devonthink-item://`).
- Empty `source_uri` (synthesized records).

Existing contaminated rows stay readable — the guard fires only at register/update.

`update()` runs the same guard so it cannot back-door past register.

### 2. `_normalize_source_uri(repo_root=...)` — anchor relative paths on owner repo_root

When the caller supplies a relative `file_path` and the owner has a `repo_root`, `os.path.join(repo_root, file_path)` becomes the abspath base. Absolute paths still pass through unchanged (Path-join semantics).

`Catalog.register()` and `Catalog.update()` now lookup the owner's `repo_root` via the new `_owner_repo_root()` helper and pass it through.

## Tests

13 new tests covering:
- Inside / outside `repo_root` boundary (auto-derived AND explicit `source_uri`)
- Curator skip, no-repo_root skip
- All non-file URI schemes pass through
- Empty `source_uri` skip
- `NEXUS_CATALOG_ALLOW_CROSS_PROJECT=1` env override
- Existing contaminated rows remain readable
- Nested-worktree-under-repo_root succeeds
- Regression: relative `file_path` from foreign CWD now anchors correctly

All 163 catalog-suite tests pass (110 original + 13 new + PR #381's 19 audit-membership + e2e + isolation + indexer-hook + path).

## Emergency escape hatch

`NEXUS_CATALOG_ALLOW_CROSS_PROJECT=1` bypasses the guard. Documented in code; not exposed via CLI. For one-off recovery scripts only.

## Out of scope

- The `nx catalog audit-membership --all-collections` summary mode (Phase 3 in the brief) — defer to a follow-up bead.
- Cleanup of the existing ~6,500 contaminated rows — PR #381's `audit-membership ... --purge-non-canonical` already does that. Hal will decide when to apply.

Closes nexus-3e4s
