### PR TITLE
feat(catalog): audit-membership --all-collections sweep mode (nexus-3e4s Phase 3)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -1072,7 +1072,17 @@ def compact_cmd() -> None:
 
 
 @catalog.command("audit-membership")
-@click.argument("collection")
+@click.argument("collection", required=False)
+@click.option(
+    "--all-collections",
+    is_flag=True,
+    help=(
+        "Sweep every physical_collection in the catalog and emit a "
+        "single summary report. nexus-3e4s Phase 3 — the post-fix "
+        "health check. Incompatible with --purge-non-canonical and "
+        "--canonical-home (per-collection contexts)."
+    ),
+)
 @click.option(
     "--purge-non-canonical",
     is_flag=True,
@@ -1107,7 +1117,8 @@ def compact_cmd() -> None:
     help="Emit per-home counts as JSON instead of human-readable lines.",
 )
 def audit_membership_cmd(
-    collection: str,
+    collection: str | None,
+    all_collections: bool,
     purge_non_canonical: bool,
     canonical_home: str,
     dry_run: bool,
@@ -1129,7 +1140,33 @@ def audit_membership_cmd(
     With ``--purge-non-canonical`` the non-dominant entries are
     soft-deleted (tombstoned in JSONL, removed from SQLite) by the
     standard ``delete_document`` path.
+
+    With ``--all-collections`` the audit runs across every
+    physical_collection in the catalog and emits one summary report
+    (nexus-3e4s Phase 3). Read-only — purge is per-collection only.
     """
+    if all_collections:
+        if purge_non_canonical:
+            raise click.UsageError(
+                "--all-collections is read-only; --purge-non-canonical "
+                "must be invoked per-collection so the canonical-home "
+                "decision can be reviewed before deletion.",
+            )
+        if canonical_home:
+            raise click.UsageError(
+                "--canonical-home is per-collection by definition; "
+                "use it with a single COLLECTION argument.",
+            )
+        if collection:
+            raise click.UsageError(
+                "Pass either COLLECTION or --all-collections, not both.",
+            )
+        _audit_membership_all(as_json=as_json)
+        return
+    if not collection:
+        raise click.UsageError(
+            "Specify a COLLECTION or use --all-collections.",
+        )
     cat = _get_catalog()
     rows = cat._db.execute(
         "SELECT tumbler, source_uri FROM documents "
@@ -1241,6 +1278,94 @@ def audit_membership_cmd(
         if cat.delete_document(t):
             deleted += 1
     click.echo(f"\nDeleted {deleted} of {len(purge_targets)} non-canonical entries.")
+
+
+def _audit_membership_all(*, as_json: bool) -> None:
+    """Sweep every physical_collection and emit a contamination summary.
+
+    nexus-3e4s Phase 3. Reads the catalog in a single pass and groups
+    rows by (collection, home) so each collection's home distribution
+    is computed in O(rows) total rather than one query per collection.
+    """
+    cat = _get_catalog()
+    rows = cat._db.execute(
+        "SELECT physical_collection, source_uri FROM documents "
+        "WHERE physical_collection != ''",
+    ).fetchall()
+
+    by_collection: dict[str, dict[str, int]] = {}
+    for collection, source_uri in rows:
+        home = _source_uri_home_key(source_uri or "")
+        by_collection.setdefault(collection, {})[home] = (
+            by_collection.setdefault(collection, {}).get(home, 0) + 1
+        )
+
+    records: list[dict] = []
+    for collection, home_counts in by_collection.items():
+        total = sum(home_counts.values())
+        dominant = max(home_counts.items(), key=lambda kv: kv[1])[0]
+        contaminated = total - home_counts[dominant]
+        records.append({
+            "collection": collection,
+            "total_entries": total,
+            "distinct_homes": len(home_counts),
+            "by_home": dict(home_counts),
+            "dominant_home": dominant,
+            "contaminated_entries": contaminated,
+        })
+
+    # Sort: contaminated count desc, then total desc, then name asc so
+    # the worst offenders surface first and the order is stable.
+    records.sort(key=lambda r: (
+        -r["contaminated_entries"], -r["total_entries"], r["collection"],
+    ))
+
+    contaminated_count = sum(1 for r in records if r["contaminated_entries"] > 0)
+    clean_count = len(records) - contaminated_count
+
+    if as_json:
+        click.echo(json.dumps({
+            "total_collections": len(records),
+            "contaminated_count": contaminated_count,
+            "clean_count": clean_count,
+            "collections": records,
+        }, indent=2))
+        return
+
+    if not records:
+        click.echo("0 collections in catalog.")
+        return
+
+    click.echo(
+        f"Audited {len(records)} collections: "
+        f"{contaminated_count} contaminated, {clean_count} clean.",
+    )
+    if contaminated_count == 0:
+        click.echo("No contamination detected.")
+        return
+
+    click.echo()
+    click.echo(f"Contaminated collections ({contaminated_count}):")
+    for r in records:
+        if r["contaminated_entries"] == 0:
+            continue
+        click.echo(
+            f"  {r['contaminated_entries']:6d} of {r['total_entries']:6d}  "
+            f"{r['collection']:40s}  "
+            f"{r['distinct_homes']} homes  "
+            f"dominant={r['dominant_home']}",
+        )
+
+    if clean_count:
+        click.echo()
+        click.echo(f"Clean collections ({clean_count}):")
+        for r in records:
+            if r["contaminated_entries"] != 0:
+                continue
+            click.echo(
+                f"  {r['total_entries']:6d}  {r['collection']}  "
+                f"({r['dominant_home']})",
+            )
 
 
 def _source_uri_home_key(uri: str) -> str:

--- a/tests/test_catalog_audit_membership.py
+++ b/tests/test_catalog_audit_membership.py
@@ -277,3 +277,93 @@ class TestEmpty:
         result = runner.invoke(catalog, ["audit-membership", "rdr__nothing-here"])
         assert result.exit_code == 0, result.output
         assert "no entries" in result.output.lower() or "0" in result.output
+
+
+# ── --all-collections sweep mode (nexus-3e4s Phase 3) ───────────────────────
+
+
+class TestAllCollections:
+    """Sweep audit across every physical_collection in one call.
+
+    Useful as a daily / post-release health check to confirm the
+    register-time guard is doing its job and no NEW contamination is
+    accumulating across the catalog.
+    """
+
+    def _seed_two_collections(self, cat: Catalog) -> None:
+        """One contaminated collection, one clean one."""
+        _seed_contamination(cat, collection="rdr__contaminated")
+        owner = cat.register_owner("clean", "clean-curator")
+        for i in range(4):
+            cat.register(
+                owner, f"R{i}", content_type="rdr",
+                physical_collection="rdr__clean",
+                file_path=f"x/R{i}.md",
+                source_uri=f"file:///Users/test/projects/clean/x/R{i}.md",
+            )
+
+    def test_sweep_lists_contaminated_first(self, env: Catalog) -> None:
+        self._seed_two_collections(env)
+        runner = CliRunner()
+        result = runner.invoke(catalog, ["audit-membership", "--all-collections"])
+        assert result.exit_code == 0, result.output
+        # Contaminated collection appears before clean in the output.
+        out = result.output
+        assert "rdr__contaminated" in out
+        assert "rdr__clean" in out
+        assert out.index("rdr__contaminated") < out.index("rdr__clean")
+
+    def test_sweep_json_emits_structured_report(self, env: Catalog) -> None:
+        self._seed_two_collections(env)
+        runner = CliRunner()
+        result = runner.invoke(
+            catalog, ["audit-membership", "--all-collections", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["total_collections"] == 2
+        assert data["contaminated_count"] == 1
+        assert data["clean_count"] == 1
+        # Per-collection records are sorted by contamination desc.
+        cols = data["collections"]
+        assert cols[0]["collection"] == "rdr__contaminated"
+        assert cols[0]["distinct_homes"] == 2
+        assert cols[0]["contaminated_entries"] == 3
+        assert cols[1]["collection"] == "rdr__clean"
+        assert cols[1]["distinct_homes"] == 1
+        assert cols[1]["contaminated_entries"] == 0
+
+    def test_sweep_empty_catalog(self, env: Catalog) -> None:
+        runner = CliRunner()
+        result = runner.invoke(catalog, ["audit-membership", "--all-collections"])
+        assert result.exit_code == 0, result.output
+        assert "0" in result.output or "no collections" in result.output.lower()
+
+    def test_sweep_rejects_purge_flag(self, env: Catalog) -> None:
+        """Bulk purge across all collections is too risky — the
+        canonical-home heuristic can be wrong per-collection. Refuse."""
+        self._seed_two_collections(env)
+        runner = CliRunner()
+        result = runner.invoke(catalog, [
+            "audit-membership", "--all-collections", "--purge-non-canonical",
+        ])
+        assert result.exit_code != 0
+        assert "purge" in result.output.lower()
+
+    def test_sweep_rejects_canonical_home_override(self, env: Catalog) -> None:
+        """A canonical-home override is per-collection by definition."""
+        self._seed_two_collections(env)
+        runner = CliRunner()
+        result = runner.invoke(catalog, [
+            "audit-membership", "--all-collections",
+            "--canonical-home", "/projects/myproject",
+        ])
+        assert result.exit_code != 0
+        assert "canonical-home" in result.output.lower()
+
+    def test_collection_arg_or_all_required(self, env: Catalog) -> None:
+        """Neither COLLECTION nor --all-collections → usage error."""
+        runner = CliRunner()
+        result = runner.invoke(catalog, ["audit-membership"])
+        assert result.exit_code != 0
+        assert "collection" in result.output.lower()


### PR DESCRIPTION
## What

`nx catalog audit-membership --all-collections` — single-shot health check that sweeps every physical_collection in the catalog and emits one contamination summary. nexus-3e4s Phase 3 (final).

## Why

PR #382 shipped the register-time guard that prevents NEW cross-project contamination. This sweep is the verification surface — run it post-release or on a schedule to confirm nothing's leaking.

## Behavior

- `--all-collections` walks every collection in O(rows) total (single SELECT, in-memory grouping).
- Output sorted contaminated-first, contamination count desc, total desc, name asc.
- `--json` mode emits a structured report consumable by alerting / dashboards.
- Read-only. `--purge-non-canonical` and `--canonical-home` raise UsageError when combined with `--all-collections` — those are per-collection decisions and the heuristic can be wrong differently for each collection.

Sample output against the live catalog:

```
Audited 140 collections: 22 contaminated, 118 clean.

Contaminated collections (22):
   105 of    245  rdr__ART-8c2e74c0     2 homes  dominant=/Users/hal.hildebrand/git/nexus
    20 of     66  rdr__BFDB-af165fac    2 homes  dominant=/Users/hal.hildebrand/git/BFDB
    11 of     22  docs__art-architecture 3 homes  dominant=/Users/hal.hildebrand/git/ART
   ...
```

## Tests

5 new tests in `TestAllCollections`: sweep ordering, JSON shape, empty catalog, purge/override rejection, collection-arg-or-flag required. 15 audit-membership tests pass total.

## Out of scope

Mass single-home contamination (e.g. `code__ART-8c2e74c0` has 4,182 entries all pointing to `/Users/.../nexus/`) is invisible to the dominant-home heuristic — the existing single-collection audit has the same blind spot, and PR #381's `--canonical-home` override is the right surface for that case. Not a regression introduced here.