### PR TITLE
docs: nexus-3e4s + audit-membership + dt install-scripts (PRs #380-383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`nx dt install-scripts`** (PR #380). Installs the bundled in-DEVONthink toolbar / menu AppleScript wrappers for `nx dt index` (selection, current group, knowledge selection) under `~/Library/Application Scripts/com.devon-technologies.think/Menu/`. Idempotent; skips files that already exist unless `--force` is passed.
+- **`nx catalog audit-membership <COLLECTION>`** (PR #381, nexus-ow9f). Detects cross-project `source_uri` contamination in a single physical_collection by grouping entries by their source_uri "home" (the first 4 path segments for `file://` URIs, `<scheme>://<netloc>` otherwise). Per-home counts surface multi-root collections; `--canonical-home SUBSTR` overrides the dominant-home heuristic when contamination outnumbers legitimate entries; `--purge-non-canonical` deletes the offending rows after `--dry-run` review and a confirmation prompt (suppressible with `--yes`). `--json` for structured output.
+- **`nx catalog audit-membership --all-collections`** (PR #383, nexus-3e4s Phase 3). Sweep mode: runs the audit across every physical_collection in a single pass and emits one summary report. Sorted contaminated-first. Read-only by design; `--purge-non-canonical` and `--canonical-home` are per-collection contexts and raise `UsageError` when combined with `--all-collections`. Use as a daily / post-release health check.
+- **`NEXUS_CATALOG_ALLOW_CROSS_PROJECT=1` env var** (PR #382, nexus-3e4s). Emergency-only escape hatch that bypasses the new register-time cross-project guard. Use only for known-good recovery scripts that legitimately need to register rows across project boundaries.
+
+### Fixed
+
+- **Catalog `register()` no longer writes cross-project `source_uri` rows** (PR #382, nexus-3e4s). `_normalize_source_uri()` was deriving `source_uri` from a relative `file_path` via `os.path.abspath()`, which resolves against the process CWD rather than the owner's `repo_root`. The catalog hook always passes a relative `file_path`, so any `nx index` run from a CWD outside the indexed repo wrote `source_uri` rows pointing into CWD's tree but attributed to the indexed repo's owner. That was the contamination signature for ~6,500 rows in the live catalog. Fix: `_normalize_source_uri(repo_root=...)` anchors relative paths on `owner.repo_root` when provided. Companion register-time guard `Catalog._check_source_uri_in_repo_root` raises `ValueError` on any `file://` URI that still resolves outside the owner's `repo_root`, so the bug class cannot recur even if a future code path bypasses the normalization. Owner-type-aware (curator and pre-RDR-060 owners with empty `repo_root` skip), scheme-aware (`chroma://`, `https://`, `x-devonthink-item://` pass through). `update()` runs the same guard so it cannot back-door register.
+
 ## [4.19.2] - 2026-04-29
 
 Patch release bundling six findings from a post-v4.19.1 audit (PR #378) plus the headline #377 fix. The audit ran two parallel deep-analyzer agents (one over the RDR-099 / `nx dt` surface, one over prefix-keyed config registries) and surfaced two critical bugs, three significant issues, and one feature gap.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -247,6 +247,21 @@ Reports link graph health: total counts by type and creator, orphaned links (poi
 
 Orphaned links are kept as historical record — they are not auto-deleted. Use `link-bulk-delete` to clean them up if needed.
 
+### Cross-project source_uri guard (nexus-3e4s)
+
+`Catalog.register()` and `Catalog.update()` enforce a register-time invariant: for `repo` owners with a `repo_root`, the entry's `source_uri` must resolve inside that root. A `file://` URI that lands outside the owner's tree raises a `ValueError` with both URIs in the message. This is the load-bearing guard against the contamination class that produced ~6,500 mis-attributed rows in the wild: entries whose `source_uri` pointed at one project's tree but were attributed to a different project's owner, silently breaking aspect extraction.
+
+The guard skips:
+
+- Curator owners (legitimately span sources: papers, mirrored docs, etc.).
+- Pre-RDR-060 repo owners with empty `repo_root` (back-compat).
+- Non-`file://` URIs (`chroma://`, `https://`, `x-devonthink-item://`). They have no filesystem identity to compare.
+- Empty `source_uri`. Synthesized records with no path identity.
+
+To detect or remediate pre-existing contamination see [`nx catalog audit-membership`](cli-reference.md#nx-catalog-audit-membership), including `--all-collections` for a single-shot health check across the entire catalog.
+
+Set `NEXUS_CATALOG_ALLOW_CROSS_PROJECT=1` to bypass the guard for emergency recovery only. Never the right answer for normal indexing.
+
 ### Backfill and recovery
 
 ```bash

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -485,18 +485,23 @@ nx catalog audit-membership <COLLECTION>
 nx catalog audit-membership <COLLECTION> --json
 nx catalog audit-membership <COLLECTION> --canonical-home '/git/ART' --purge-non-canonical --dry-run
 nx catalog audit-membership <COLLECTION> --canonical-home '/git/ART' --purge-non-canonical --yes
+nx catalog audit-membership --all-collections
+nx catalog audit-membership --all-collections --json
 ```
 
 Detect cross-project source_uri contamination in a single physical_collection. Catalog entries are grouped by their `source_uri` "home" (the first four path segments for `file://` URIs, `<scheme>://<netloc>` otherwise); per-home counts surface multi-root collections that look correct in `nx catalog list` but break aspect extraction (the chunks live under one project's identity, every other-project entry skips with `reason=empty`).
 
+`--all-collections` runs the audit across every physical_collection in the catalog and emits one sorted summary (contaminated first). Use it as a daily or post-release health check to confirm the register-time guard (see [Catalog](catalog.md#cross-project-source_uri-guard-nexus-3e4s)) is preventing new contamination. The sweep is read-only. `--purge-non-canonical` and `--canonical-home` are per-collection contexts and raise a usage error when combined with `--all-collections`.
+
 | Flag | Description |
 |------|-------------|
-| `COLLECTION` (positional) | Physical collection to audit (e.g. `rdr__ART-8c2e74c0`) |
-| `--purge-non-canonical` | Delete entries whose home does not match the canonical one. Use with `--dry-run` first |
-| `--canonical-home SUBSTR` | Override the dominant-home heuristic. Required when the contaminating entries outnumber the legitimate ones (e.g. `--canonical-home '/git/ART'`) |
+| `COLLECTION` (positional) | Physical collection to audit (e.g. `rdr__ART-8c2e74c0`). Required unless `--all-collections` is set |
+| `--all-collections` | Sweep every physical_collection in the catalog and emit a summary report. Read-only |
+| `--purge-non-canonical` | Delete entries whose home does not match the canonical one. Use with `--dry-run` first. Per-collection only |
+| `--canonical-home SUBSTR` | Override the dominant-home heuristic. Required when the contaminating entries outnumber the legitimate ones (e.g. `--canonical-home '/git/ART'`). Per-collection only |
 | `--dry-run` | With `--purge-non-canonical`, preview without writing |
 | `--yes` / `-y` | Skip the purge confirmation prompt |
-| `--json` | Emit per-home counts as JSON |
+| `--json` | Emit per-home counts as JSON. Works in both single-collection and `--all-collections` modes |
 
 The dominant home (numerical majority) is the default canonical. When dominance is wrong (e.g. ART-lhk1: 140 contaminating nexus URIs vs 105 legitimate ART URIs in `rdr__ART-...`), pass `--canonical-home` with a unique substring of the right home. Deletion is the standard `delete_document` path: tombstoned in JSONL, removed from SQLite, links preserved as orphans.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ Nexus auto-detects local mode when cloud credentials are absent. No configuratio
 | `NX_LOCAL_CHROMA_PATH` | `~/.local/share/nexus/chroma` | Override local ChromaDB storage path |
 | `NX_LOCAL_EMBED_MODEL` | (auto) | Force a specific local embedding model name |
 | `NEXUS_CATALOG_PATH` | `~/.config/nexus/catalog` | Override catalog git repo location |
+| `NEXUS_CATALOG_ALLOW_CROSS_PROJECT` | unset | Set to `1` to bypass the register-time cross-project source_uri guard. Emergency-only escape hatch for known-good recovery scripts that legitimately need to register rows across project boundaries; never the right answer for normal indexing |
 
 **Auto-detection**: When either `CHROMA_API_KEY` or `VOYAGE_API_KEY` is absent, local mode activates — both are required for cloud mode. Set `NX_LOCAL=1` to force local mode even with cloud credentials.
 


### PR DESCRIPTION
## What

User-facing documentation catch-up for the four merges sitting on main past v4.19.2. The release notes / CLI reference / configuration / catalog operator guide all reference flags, env vars, and behavior that already shipped to main but were not yet documented.

## Files

- **CHANGELOG.md `[Unreleased]`**: 4 Added entries + 1 Fixed entry. Covers PRs #380 (nx dt install-scripts), #381 (audit-membership single-collection), #382 (cross-project guard + root-cause fix + env override), #383 (--all-collections sweep).
- **docs/cli-reference.md**: `nx catalog audit-membership` section adds `--all-collections` to the synopsis and flag table; marks `--purge-non-canonical` and `--canonical-home` as per-collection only; cross-links to the new Catalog guard section.
- **docs/configuration.md**: env-var table gains `NEXUS_CATALOG_ALLOW_CROSS_PROJECT` (emergency-only escape hatch).
- **docs/catalog.md**: new "Cross-project source_uri guard (nexus-3e4s)" subsection under Admin and maintenance, documenting the register-time invariant, skip rules, and the env-var override.

No code changes. No new em dashes (Hal's standing rule for `docs/*.md`).