### PR TITLE
fix(catalog): nx catalog backfill skip None documents instead of crashing

### DIFF
--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -4,9 +4,12 @@ import sys
 from collections.abc import Callable
 
 import click
+import structlog
 
 from nexus.commands.store import _t3
 from nexus.corpus import embedding_model_for_collection, index_model_for_collection
+
+_log = structlog.get_logger(__name__)
 
 
 @click.group()
@@ -485,6 +488,19 @@ def _backfill_chunk_text_hash(
                 # Reconciliation path: T3 already has the hash but T2 may not.
                 t2_ids.append(chunk_id)
                 t2_metas.append(dict(meta))
+                continue
+            if doc is None:
+                # nexus-p03z: Cloud T3 occasionally returns rows whose
+                # ``documents`` entry is None even when the chunk exists.
+                # Hashing a missing doc is impossible; skip and keep
+                # going. Without this guard, ``nx catalog backfill``
+                # crashes mid-pass and leaves the catalog half-recovered.
+                skipped += 1
+                _log.warning(
+                    "backfill_chunk_text_hash_none_doc",
+                    chunk_id=chunk_id,
+                    collection=getattr(col, "name", ""),
+                )
                 continue
             new_meta = dict(meta) if meta else {}
             new_meta["chunk_text_hash"] = hashlib.sha256(doc.encode()).hexdigest()

--- a/tests/test_backfill_hash.py
+++ b/tests/test_backfill_hash.py
@@ -91,6 +91,50 @@ class TestBackfillChunkTextHash:
         assert updated == 0
         assert skipped == 0
 
+    def test_backfill_skips_none_documents_without_crash(self):
+        """nexus-p03z Issue 1: when T3 returns ``documents[i] is None``
+        (an inconsistency that occurs in practice on rare chunks), the
+        previous code crashed on ``doc.encode()``. Guard skips those
+        rows, counts them as skipped, processes the remainder, and
+        returns normally.
+
+        Reproduces the live crash that made ``nx catalog backfill``
+        unusable on the host catalog. Uses a mocked collection because
+        chromadb's public ``add()`` rejects None document strings; the
+        None-document state is reachable in cloud T3 but not via local
+        EphemeralClient writes.
+        """
+        from unittest.mock import MagicMock
+
+        from nexus.commands.collection import _backfill_chunk_text_hash
+
+        col = MagicMock()
+        col.name = "code__none_doc_repro"
+        # First page: 3 chunks. Middle one has a None document. The
+        # other two have valid text and no chunk_text_hash so they
+        # should be hashed normally.
+        col.get.side_effect = [
+            {
+                "ids": ["c1", "c2", "c3"],
+                "documents": ["alpha", None, "gamma"],
+                "metadatas": [
+                    {"source_path": "a.py"},
+                    {"source_path": "b.py"},
+                    {"source_path": "c.py"},
+                ],
+            },
+            {"ids": [], "documents": [], "metadatas": []},
+        ]
+
+        updated, skipped, total = _backfill_chunk_text_hash(col)
+
+        assert total == 3
+        assert updated == 2  # alpha + gamma got hashed
+        assert skipped == 1  # the None doc skipped, not crashed
+        # The col.update call must NOT include the None-doc chunk.
+        update_call = col.update.call_args
+        assert "c2" not in update_call.kwargs["ids"]
+
 
 # ── Phase 1.3 (nexus-ppl) — T2 chash_index reconciliation ────────────────────
 


### PR DESCRIPTION
## Summary

Issue 1 of nexus-p03z. Cloud T3 occasionally returns rows whose `documents[i]` is `None` even when the chunk exists. `_backfill_chunk_text_hash` crashed with `AttributeError: 'NoneType' object has no attribute 'encode'` on the first such row, mid-pass, leaving the catalog half-recovered. `nx catalog backfill` was unusable on the live host catalog.

The fix is a guard: when `doc is None`, count as skipped, log a warning, continue.

Issue 2 (per-file recovery from T3 chunk metadata for repo-owned `docs__<repo>` and `code__<repo>` collections) follows in a separate PR per the bead's "split when fixing" guidance.

## Test plan

- [x] New regression test `TestBackfillChunkTextHash.test_backfill_skips_none_documents_without_crash` mocks the collection (chromadb's public `add()` rejects None docs; the None-document state is reachable via cloud T3 reads, not local EphemeralClient writes). Confirmed test fails before the fix and passes after.
- [x] 163 existing tests pass across `test_backfill_hash.py`, `test_collection_cmd.py`, `test_collection_health.py`, `test_collection_audit.py`, `test_catalog_backfill.py`, `test_catalog_cli.py`. No regressions.
- [x] No em dashes in user-facing prose.
- [x] No AI attribution in commit message.

## Closes

Issue 1 of nexus-p03z. The bead remains open until Issue 2 (`--from-t3` per-file recovery) ships in the followup PR.