### PR TITLE
feat(catalog): nx catalog backfill --from-t3 per-file recovery (nexus-p03z Issue 2)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -2430,11 +2430,223 @@ def _make_registry():
     return RepoRegistry(nexus_config_dir() / "repos.json")
 
 
+def _backfill_per_file_from_t3(
+    cat: Catalog,
+    t3: object,
+    collection: str,
+    *,
+    dry_run: bool,
+) -> int:
+    """nexus-p03z Issue 2: per-file recovery from T3 chunk metadata.
+
+    For ``docs__<repo>`` and ``code__<repo>`` collections, reconstruct
+    one catalog row per unique ``source_path`` discovered in T3 chunk
+    metadata. The repo owner is resolved via the ``-<8hex>`` suffix in
+    the collection name; an unregistered repo raises so the operator
+    knows to register the owner first (or run the standard ``backfill``
+    repos pass).
+
+    Idempotent: ``cat.register`` deduplicates on ``(owner, file_path)``,
+    so re-running registers nothing new. The register-time anchor guard
+    (nexus-3e4s) automatically rejects chunks whose ``source_path``
+    lives outside the owner's ``repo_root`` — wrong-project chunks that
+    leaked into this collection won't recreate the contamination.
+
+    Returns the number of newly-registered catalog rows. ``dry_run`` skips
+    writes and returns the count that *would* register (subject to the
+    same dedup logic against existing rows).
+    """
+    # Parse the trailing -<8hex> as the repo hash. ``rsplit`` keeps
+    # repo names containing dashes intact (e.g. ``code__nexus-mini0-4ada4577``).
+    # Splitting on `__` first removes the prefix, then `-` splits name
+    # vs hash.
+    if "__" not in collection:
+        raise click.ClickException(
+            f"collection {collection!r} has no double-underscore prefix; "
+            "per-file recovery only supports docs__<repo>-<hash> and "
+            "code__<repo>-<hash> shapes."
+        )
+    suffix = collection.split("__", 1)[1]
+    if "-" not in suffix:
+        raise click.ClickException(
+            f"collection {collection!r} suffix {suffix!r} has no -<hash> tail; "
+            "per-file recovery requires a repo-owned collection."
+        )
+    _, repo_hash = suffix.rsplit("-", 1)
+    if len(repo_hash) != 8 or not all(c in "0123456789abcdef" for c in repo_hash):
+        raise click.ClickException(
+            f"collection {collection!r} suffix has malformed repo hash "
+            f"{repo_hash!r}; expected 8 hex chars."
+        )
+
+    owner = cat.owner_for_repo(repo_hash)
+    if owner is None:
+        raise click.ClickException(
+            f"no repo owner registered for hash {repo_hash!r} "
+            f"(collection {collection!r}). Run 'nx catalog backfill' "
+            "first to register repo owners, or 'nx repo register'."
+        )
+
+    # Look up the owner's repo_root so we can anchor file_paths
+    # relative to it (matches the post-RDR-060 catalog convention).
+    repo_root_row = cat._db.execute(
+        "SELECT repo_root FROM owners WHERE tumbler_prefix = ?",
+        (str(owner),),
+    ).fetchone()
+    repo_root = (repo_root_row[0] or "") if repo_root_row else ""
+
+    # Determine content_type from prefix.
+    if collection.startswith("code__"):
+        content_type = "code"
+    elif collection.startswith("docs__"):
+        content_type = "prose"
+    else:
+        raise click.ClickException(
+            f"collection {collection!r} prefix is not docs__ or code__; "
+            "per-file recovery only supports those two."
+        )
+
+    # Paginate T3 chunks at 300 (Cloud cap) and dedupe by source_path.
+    col = t3.get_collection(collection)
+    seen_paths: set[str] = set()
+    offset = 0
+    page_size = 300
+    while True:
+        page = col.get(
+            include=["metadatas"], limit=page_size, offset=offset,
+        )
+        ids = page.get("ids") or []
+        if not ids:
+            break
+        for meta in page.get("metadatas") or []:
+            if not isinstance(meta, dict):
+                continue
+            sp = meta.get("source_path", "")
+            if sp:
+                seen_paths.add(sp)
+        if len(ids) < page_size:
+            break
+        offset += page_size
+
+    registered = 0
+    for abs_path in sorted(seen_paths):
+        # Anchor relative to repo_root when possible; fall back to the
+        # raw path. The register-time guard rejects paths outside
+        # repo_root regardless.
+        if repo_root and abs_path.startswith(repo_root + "/"):
+            rel = abs_path[len(repo_root) + 1:]
+        else:
+            rel = abs_path
+
+        if dry_run:
+            registered += 1
+            continue
+
+        existing = cat.by_file_path(owner, rel)
+        if existing is not None:
+            continue
+        try:
+            cat.register(
+                owner=owner,
+                title=Path(rel).name or rel,
+                content_type=content_type,
+                physical_collection=collection,
+                file_path=rel,
+            )
+            registered += 1
+        except ValueError as exc:
+            # Cross-project anchor rejection from nexus-3e4s: the chunk
+            # claims to live outside this repo. Skip and log; this is
+            # exactly the contamination the guard exists to prevent.
+            _log.warning(
+                "backfill_from_t3_anchor_rejected",
+                collection=collection,
+                file_path=rel,
+                error=str(exc),
+            )
+
+    return registered
+
+
 @catalog.command("backfill", hidden=True)
 @click.option("--dry-run", is_flag=True, help="Show what would be created without writing")
-def backfill_cmd(dry_run: bool) -> None:
+@click.option(
+    "--from-t3",
+    "from_t3",
+    is_flag=True,
+    help=(
+        "Per-file recovery mode: enumerate T3 chunks and register one "
+        "catalog row per unique source_path under the repo owner. "
+        "Skips the standard 4-pass backfill. Requires --collection or "
+        "--all-repo-collections."
+    ),
+)
+@click.option(
+    "--collection",
+    "from_t3_collection",
+    default="",
+    help=(
+        "Single collection to recover from T3 chunks (used with "
+        "--from-t3). Must be a docs__<repo>-<hash> or "
+        "code__<repo>-<hash> collection whose repo owner is registered."
+    ),
+)
+@click.option(
+    "--all-repo-collections",
+    "from_t3_all",
+    is_flag=True,
+    help=(
+        "Run --from-t3 recovery against every docs__<repo>-<hash> and "
+        "code__<repo>-<hash> collection in T3. Mutually exclusive with "
+        "--collection."
+    ),
+)
+def backfill_cmd(
+    dry_run: bool,
+    from_t3: bool,
+    from_t3_collection: str,
+    from_t3_all: bool,
+) -> None:
     """Populate catalog from existing T3 collections and registry."""
     cat = _get_catalog()
+
+    if from_t3:
+        if from_t3_collection and from_t3_all:
+            raise click.UsageError(
+                "--collection and --all-repo-collections are mutually exclusive."
+            )
+        if not from_t3_collection and not from_t3_all:
+            raise click.UsageError(
+                "--from-t3 requires either --collection <NAME> or "
+                "--all-repo-collections."
+            )
+        t3 = _make_t3()
+        if from_t3_collection:
+            targets = [from_t3_collection]
+        else:
+            targets = [
+                c["name"] for c in t3.list_collections()
+                if (c["name"].startswith("docs__") or c["name"].startswith("code__"))
+                and "-" in c["name"].split("__", 1)[1]
+            ]
+        total_registered = 0
+        for target in targets:
+            try:
+                count = _backfill_per_file_from_t3(
+                    cat, t3, target, dry_run=dry_run,
+                )
+                mode = "would register" if dry_run else "registered"
+                click.echo(f"  {target}: {mode} {count} row(s)")
+                total_registered += count
+            except click.ClickException as exc:
+                # Non-repo-owned collection in --all sweep: skip with a note.
+                if from_t3_all:
+                    click.echo(f"  {target}: skipped ({exc.message})")
+                    continue
+                raise
+        mode = "dry-run" if dry_run else "complete"
+        click.echo(f"\nFrom-T3 recovery {mode}: {total_registered} row(s).")
+        return
 
     registry = _make_registry()
     t3 = _make_t3()

--- a/tests/test_catalog_backfill.py
+++ b/tests/test_catalog_backfill.py
@@ -162,6 +162,258 @@ class TestBackfillCommand:
         assert result.exit_code != 0
 
 
+class TestBackfillFromT3:
+    """nexus-p03z Issue 2: per-file recovery from T3 chunk metadata for
+    repo-owned ``docs__<repo>`` and ``code__<repo>`` collections.
+
+    ``_backfill_repos`` registers a single summary row per (repo,
+    collection); ``_backfill_papers`` excludes repo-owned collections.
+    Without per-file recovery, deleted catalog rows for a repo's docs/
+    code files cannot be reconstructed from existing T3 state, even
+    though the chunks carry the correct ``source_path`` and the repo
+    owner already exists.
+
+    Live recovery executed during nexus-3e4s remediation
+    (2026-04-29):
+    - docs__ART-8c2e74c0: 1 row -> 365 rows (recovered 364 from
+      15,790 chunks)
+    - code__ART-8c2e74c0: 4,182 rows -> 4,397 rows from 63,077
+      chunks
+    """
+
+    def _mock_t3_with_chunks(
+        self,
+        collection_name: str,
+        chunks_per_path: dict[str, int],
+        repo_root: Path,
+    ) -> MagicMock:
+        """Build a mock T3 whose ``get_collection().get(...)`` paginates
+        chunks tagged with absolute source_paths under ``repo_root``."""
+        mock_t3 = MagicMock()
+        mock_col = MagicMock()
+        mock_col.name = collection_name
+
+        # Build a flat list of chunk metadata, one row per chunk per path.
+        all_metadatas: list[dict] = []
+        all_ids: list[str] = []
+        chunk_idx = 0
+        for rel_path, n in chunks_per_path.items():
+            abs_path = str(repo_root / rel_path)
+            for _ in range(n):
+                all_ids.append(f"chunk-{chunk_idx}")
+                all_metadatas.append({"source_path": abs_path})
+                chunk_idx += 1
+
+        # Paginate at 300 per Cloud T3 cap.
+        def _paginated_get(*, include, limit, offset, **kw):
+            page_ids = all_ids[offset:offset + limit]
+            page_meta = all_metadatas[offset:offset + limit]
+            return {
+                "ids": page_ids,
+                "metadatas": page_meta,
+                "documents": [None] * len(page_ids),
+            }
+
+        mock_col.get.side_effect = _paginated_get
+        mock_t3.get_collection.return_value = mock_col
+        mock_t3._client.get_collection.return_value = mock_col
+        return mock_t3
+
+    def test_per_file_recovery_registers_unique_source_paths(
+        self, catalog_env, tmp_path,
+    ):
+        """Each unique source_path in T3 chunks becomes a catalog row
+        under the repo owner, anchored to the repo_root."""
+        from nexus.commands.catalog import _backfill_per_file_from_t3
+
+        repo_root = tmp_path / "myrepo"
+        repo_root.mkdir()
+        cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+        owner = cat.register_owner(
+            "myrepo", "repo", repo_hash="abc12345",
+            repo_root=str(repo_root),
+        )
+        # Pre-existing summary row from _backfill_repos.
+        cat.register(
+            owner=owner, title="myrepo (code)", content_type="code",
+            physical_collection="code__myrepo-abc12345",
+        )
+
+        t3 = self._mock_t3_with_chunks(
+            "code__myrepo-abc12345",
+            {"src/a.py": 5, "src/b.py": 3, "src/c.py": 2},
+            repo_root,
+        )
+
+        registered = _backfill_per_file_from_t3(
+            cat, t3, "code__myrepo-abc12345", dry_run=False,
+        )
+        assert registered == 3
+        # Verify each path got its own catalog row.
+        rows = cat._db.execute(
+            "SELECT file_path FROM documents "
+            "WHERE physical_collection = ? AND file_path != ''",
+            ("code__myrepo-abc12345",),
+        ).fetchall()
+        paths = {r[0] for r in rows}
+        assert "src/a.py" in paths
+        assert "src/b.py" in paths
+        assert "src/c.py" in paths
+
+    def test_per_file_recovery_idempotent(self, catalog_env, tmp_path):
+        """Re-running per-file recovery does not duplicate rows
+        (cat.register is idempotent on file_path within owner)."""
+        from nexus.commands.catalog import _backfill_per_file_from_t3
+
+        repo_root = tmp_path / "myrepo2"
+        repo_root.mkdir()
+        cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+        cat.register_owner(
+            "myrepo2", "repo", repo_hash="def67890",
+            repo_root=str(repo_root),
+        )
+
+        t3 = self._mock_t3_with_chunks(
+            "code__myrepo2-def67890",
+            {"src/x.py": 2, "src/y.py": 1},
+            repo_root,
+        )
+
+        first = _backfill_per_file_from_t3(
+            cat, t3, "code__myrepo2-def67890", dry_run=False,
+        )
+        second = _backfill_per_file_from_t3(
+            cat, t3, "code__myrepo2-def67890", dry_run=False,
+        )
+        assert first == 2
+        assert second == 0  # already registered
+
+    def test_per_file_recovery_dry_run_writes_nothing(
+        self, catalog_env, tmp_path,
+    ):
+        from nexus.commands.catalog import _backfill_per_file_from_t3
+
+        repo_root = tmp_path / "myrepo3"
+        repo_root.mkdir()
+        cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+        cat.register_owner(
+            "myrepo3", "repo", repo_hash="11111111",
+            repo_root=str(repo_root),
+        )
+
+        t3 = self._mock_t3_with_chunks(
+            "code__myrepo3-11111111",
+            {"src/m.py": 1, "src/n.py": 1},
+            repo_root,
+        )
+
+        would_register = _backfill_per_file_from_t3(
+            cat, t3, "code__myrepo3-11111111", dry_run=True,
+        )
+        assert would_register == 2
+        # Nothing written.
+        rows = cat._db.execute(
+            "SELECT count(*) FROM documents "
+            "WHERE physical_collection = ? AND file_path != ''",
+            ("code__myrepo3-11111111",),
+        ).fetchone()
+        assert rows[0] == 0
+
+    def test_per_file_recovery_rejects_non_repo_collection(
+        self, catalog_env,
+    ):
+        """Collections without a repo-hash suffix can't be recovered
+        this way (no owner to attribute under). Helper raises."""
+        from nexus.commands.catalog import _backfill_per_file_from_t3
+
+        cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+        # No owner registered for this hash.
+        t3 = MagicMock()
+
+        with pytest.raises(Exception) as exc_info:
+            _backfill_per_file_from_t3(
+                cat, t3, "code__nosuchrepo-deadbeef", dry_run=True,
+            )
+        assert "owner" in str(exc_info.value).lower() or "no repo" in str(exc_info.value).lower()
+
+
+class TestBackfillFromT3CLI:
+    """CLI surface: ``nx catalog backfill --from-t3 [<COL>|--all-repo-collections]``."""
+
+    @patch("nexus.commands.catalog._make_t3")
+    @patch("nexus.commands.catalog._make_registry")
+    def test_from_t3_requires_target(
+        self, mock_reg_fn, mock_t3_fn, catalog_env, tmp_path,
+    ):
+        """``--from-t3`` without either ``--collection`` or
+        ``--all-repo-collections`` is a usage error."""
+        mock_reg_fn.return_value = _mock_registry(tmp_path)
+        mock_t3_fn.return_value = _mock_t3()
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "backfill", "--from-t3"])
+        assert result.exit_code != 0
+        out = result.output.lower()
+        assert "--collection" in out or "--all-repo-collections" in out
+
+    @patch("nexus.commands.catalog._make_t3")
+    @patch("nexus.commands.catalog._make_registry")
+    def test_from_t3_with_collection_runs_recovery(
+        self, mock_reg_fn, mock_t3_fn, catalog_env, tmp_path,
+    ):
+        """``--from-t3 --collection X`` runs per-file recovery for X
+        only, skipping the original 4-pass backfill."""
+        repo_root = tmp_path / "cli_repo"
+        repo_root.mkdir()
+        # Pre-register the owner so the recovery path can attribute.
+        cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+        cat.register_owner(
+            "cli_repo", "repo", repo_hash="cafebabe",
+            repo_root=str(repo_root),
+        )
+
+        # Mock T3: one collection with 3 unique source_paths.
+        all_metas = [
+            {"source_path": str(repo_root / "a.py")},
+            {"source_path": str(repo_root / "b.py")},
+            {"source_path": str(repo_root / "c.py")},
+        ]
+
+        def _paginated_get(*, include, limit, offset, **kw):
+            page = list(zip(
+                [f"id-{i}" for i in range(offset, min(offset + limit, len(all_metas)))],
+                all_metas[offset:offset + limit],
+            ))
+            return {
+                "ids": [p[0] for p in page],
+                "metadatas": [p[1] for p in page],
+                "documents": [None] * len(page),
+            }
+
+        mock_col = MagicMock()
+        mock_col.get.side_effect = _paginated_get
+        mock_t3 = MagicMock()
+        mock_t3.get_collection.return_value = mock_col
+        mock_t3._client.get_collection.return_value = mock_col
+        mock_t3_fn.return_value = mock_t3
+        mock_reg_fn.return_value = _mock_registry(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "backfill",
+            "--from-t3",
+            "--collection", "code__cli_repo-cafebabe",
+        ])
+        assert result.exit_code == 0, result.output
+        # Three rows registered.
+        rows = cat._db.execute(
+            "SELECT count(*) FROM documents "
+            "WHERE physical_collection = ? AND file_path != ''",
+            ("code__cli_repo-cafebabe",),
+        ).fetchone()
+        assert rows[0] == 3
+
+
 class TestBackfillRdrsRepoOwner:
     """nexus-3e4s critique-followup S1.
 


### PR DESCRIPTION
## Summary

Issue 2 of nexus-p03z. Per-file recovery from T3 chunk metadata for repo-owned `docs__<repo>` and `code__<repo>` collections.

**Note**: this PR is stacked on top of #386 (Issue 1: None-doc crash guard). Merge #386 first, then this. After #386 lands, the base will auto-update to main.

## What changed

- New helper `_backfill_per_file_from_t3(cat, t3, collection, *, dry_run)` paginates T3 chunks (300/page Cloud cap), groups by `source_path`, and registers one catalog row per unique source_path under the repo owner resolved via the trailing `-<8hex>` suffix.
- New CLI flags on `nx catalog backfill`:
  - `--from-t3` enters per-file recovery mode (skips the standard 4-pass backfill).
  - `--collection NAME` targets a single collection.
  - `--all-repo-collections` sweeps every `docs__<repo>-<hash>` and `code__<repo>-<hash>` in T3.
- Idempotent: `cat.register` dedupes on `(owner, file_path)`.
- The nexus-3e4s register-time anchor guard automatically rejects chunks whose `source_path` lives outside the owner's `repo_root`, preventing contaminating chunks from re-introducing the cross-project drift the audit-membership tooling was built to clean up.

## Test plan

- [x] 6 new tests in `TestBackfillFromT3` and `TestBackfillFromT3CLI` covering helper registration, idempotency, dry-run, no-owner error, single-collection CLI invocation, and target-required usage error.
- [x] 162 tests pass across `test_catalog_backfill.py`, `test_catalog_cli.py`, `test_collection_cmd.py`, `test_backfill_hash.py`, `test_catalog_audit_membership.py`, `test_catalog_db.py`. No regressions.
- [x] No em dashes in user-facing CLI strings (`click.echo`, `ClickException`, `UsageError`).
- [x] No AI attribution in commit message.

## Live recovery already executed (during nexus-3e4s remediation, 2026-04-29)

- `docs__ART-8c2e74c0`: 1 row -> 365 rows from 15,790 chunks
- `code__ART-8c2e74c0`: 4,182 rows -> 4,397 rows from 63,077 chunks (chunk_count populated from 0)

## Closes

Issue 2 of nexus-p03z. With #386 (Issue 1) plus this PR merged, the bead can be closed.