### PR TITLE
fix(enrich): use abspath from source_uri for chroma lookup so docs__ aspects extract (nexus-v9az)

### DIFF
--- a/src/nexus/aspect_extractor.py
+++ b/src/nexus/aspect_extractor.py
@@ -827,6 +827,8 @@ def extract_aspects(
     content: str,
     source_path: str,
     collection: str,
+    *,
+    lookup_path: str = "",
 ) -> AspectRecord | ExtractFail | None:
     """Synchronously extract aspects from ``content`` and return either
     a populated ``AspectRecord``, an :class:`ExtractFail` sentinel
@@ -838,9 +840,9 @@ def extract_aspects(
 
     * ``content`` non-empty → used directly.
     * ``content == ""`` → construct
-      ``chroma://<collection>/<source_path>`` and dispatch through
-      :func:`nexus.aspect_readers.read_source`. The chroma reader
-      reassembles the document from T3 chunks via the
+      ``chroma://<collection>/<lookup_path or source_path>`` and
+      dispatch through :func:`nexus.aspect_readers.read_source`. The
+      chroma reader reassembles the document from T3 chunks via the
       ``CHROMA_IDENTITY_FIELD`` dispatch table (``title`` for
       ``knowledge__*`` collections, ``source_path`` for everything
       else).
@@ -848,6 +850,15 @@ def extract_aspects(
       no row written. Replaces the prior null-field-row contract that
       let drift cases (catalog-stale paths, slug-shaped sources)
       pollute downstream SQL.
+
+    nexus-v9az: ``lookup_path`` decouples the chroma identity match
+    from the storage key. ``source_path`` is preserved on the
+    ``AspectRecord`` for downstream joins; ``lookup_path`` (when
+    provided) is used to build the chroma URI. Use case: catalog
+    rows recovered via ``--from-t3`` carry relative ``file_path`` but
+    chunks were ingested with absolute ``source_path``; the caller
+    passes the absolute path as ``lookup_path`` so the chroma reader
+    actually finds the chunks.
 
     On unsupported collection (no config match) returns ``None``; the
     caller (post-store hook) should no-op.
@@ -864,19 +875,15 @@ def extract_aspects(
 
     if not content:
         # P1.2: URI-based source dispatch. The URI is constructed from
-        # ``(collection, source_path)`` at extract-time; Phase 2 will
-        # route through a stored ``source_uri`` column on
-        # ``document_aspects``. The ``chroma://`` reader handles both
-        # identity-field shapes (knowledge__* → ``title``,
-        # rdr__/docs__/code__ → ``source_path``) via the dispatch
-        # table in :mod:`nexus.aspect_readers`.
-        #
-        # ``source_path`` is percent-encoded so values containing
-        # ``#`` (markdown anchors) or ``?`` (query params) don't get
-        # split off as URI fragments / queries by ``urlparse`` in the
-        # reader. ``safe='/'`` preserves directory separators in
-        # filesystem-shaped paths (``docs/rdr/rdr-090.md``).
-        uri = f"chroma://{collection}/{quote(source_path, safe='/')}"
+        # ``(collection, lookup_path or source_path)`` at extract-time.
+        # nexus-v9az: ``lookup_path`` overrides the URI's identity
+        # segment when it differs from the storage ``source_path``
+        # (relative-vs-absolute reconciliation after ``--from-t3``
+        # recovery). ``source_path`` percent-encoding keeps directory
+        # separators intact (``safe='/'``) and avoids ``#``/``?``
+        # being parsed as URI fragments / queries by the reader.
+        uri_identity = lookup_path or source_path
+        uri = f"chroma://{collection}/{quote(uri_identity, safe='/')}"
         try:
             t3 = get_t3()
         except Exception as exc:

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -455,7 +455,7 @@ def _dry_run_predict_skips(
     skip_lines: list[str] = []
     by_host: dict[str, int] = {}
     for entry in entries:
-        sp = entry.file_path or entry.title
+        sp = _chroma_source_id_for_entry(entry)
         if not sp:
             continue
         uri = f"chroma://{collection}/{quote(sp, safe='/')}"
@@ -517,6 +517,34 @@ def _dry_run_predict_skips(
         click.echo(
             f"  Predicted actual cost (excluding skips): ~${actual_cost:.2f}"
         )
+
+
+def _chroma_source_id_for_entry(entry: object) -> str:
+    """nexus-v9az: return the identity value the chroma reader should
+    match against ``source_path`` metadata in T3 chunks.
+
+    Rationale: after nexus-p03z's ``--from-t3`` recovery, catalog rows
+    for ``docs__<repo>`` and ``code__<repo>`` collections carry
+    relative ``file_path`` values (anchored to ``repo_root`` by the
+    nexus-3e4s register-time guard). T3 chunks for those same files
+    were ingested with absolute ``source_path`` metadata, so a lookup
+    keyed on the relative path returns zero chunks ("empty" skip).
+
+    The catalog row's ``source_uri`` is the absolute ``file://`` URI
+    set at register time — exactly the form we need for the chroma
+    lookup. Use it when present; fall back to the legacy
+    ``file_path`` (or ``title`` for slug-shaped knowledge entries)
+    when the URI is missing or non-file (curator owners, legacy rows
+    pre-source_uri).
+    """
+    from urllib.parse import unquote, urlparse
+
+    uri = getattr(entry, "source_uri", "") or ""
+    if uri:
+        p = urlparse(uri)
+        if p.scheme == "file" and p.path:
+            return unquote(p.path)
+    return getattr(entry, "file_path", "") or getattr(entry, "title", "")
 
 
 def _source_uri_host_key(uri: str) -> str:
@@ -582,10 +610,18 @@ def _run_extraction(
                 click.echo(f"  [{i}/{len(entries)}] (no source_path) — skipped")
                 continue
 
+            # nexus-v9az: chunks were ingested with absolute source_path
+            # metadata. After --from-t3 recovery (nexus-p03z), catalog
+            # rows may carry relative file_path, anchored to repo_root
+            # by the nexus-3e4s register-time guard. Pass the absolute
+            # path as ``lookup_path`` so the chroma reader's identity
+            # match succeeds. ``source_path`` is preserved as the
+            # storage key for AspectRecord.
             record = extract_aspects(
                 content="",
                 source_path=source_path,
                 collection=collection,
+                lookup_path=_chroma_source_id_for_entry(entry),
             )
             if record is None:
                 # Defensive — select_config already passed at the parent

--- a/tests/test_enrich_aspects.py
+++ b/tests/test_enrich_aspects.py
@@ -349,6 +349,136 @@ class TestDryRunSurfacesSourceUri:
         assert "/Users/test/elsewhere/" in result.output
 
 
+# ── nexus-v9az: relative-vs-absolute path mismatch ─────────────────────────
+
+
+class TestSourceUriResolutionForChromaLookup:
+    """nexus-v9az: when an entry's ``file_path`` is relative (the
+    nexus-3e4s anchor guard rewrites them at register time) but T3
+    chunks were ingested with absolute ``source_path`` metadata, the
+    chroma reader must build its lookup URI from the absolute path,
+    not the relative file_path.
+
+    Without the fix, every entry from a docs__<repo> collection that
+    went through ``--from-t3`` recovery skips with reason='empty'
+    (zero chunks match `where={source_path: <relative>}`). The
+    register-time ``source_uri`` already holds the correct absolute
+    URI; the fix uses that as the lookup key when present.
+
+    Live repro 2026-04-30: ``nx enrich aspects docs__ART-8c2e74c0
+    --dry-run`` reported 365/365 empty skips against a freshly-
+    recovered catalog. After the fix, those entries reach the chroma
+    reader with the absolute path that matches the chunks' source_path
+    field.
+    """
+
+    def test_dry_run_uses_source_uri_abspath_when_available(
+        self, env, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from nexus.aspect_readers import ReadOk
+
+        _, _, cat = env
+        # Register an owner with a repo_root, then an entry whose
+        # file_path is relative (anchored). The source_uri at register
+        # time is the absolute file:// URI.
+        owner = cat.register_owner(
+            "myrepo", "repo", repo_hash="abcd1234",
+            repo_root="/Users/test/myrepo",
+        )
+        cat.register(
+            owner=owner, title="paper.pdf",
+            content_type="prose",
+            physical_collection="docs__myrepo-abcd1234",
+            file_path="docs/paper.pdf",
+        )
+
+        # Capture the URIs the reader is asked to read.
+        seen_uris: list[str] = []
+
+        def fake_read(uri, t3=None, **_kw):
+            seen_uris.append(uri)
+            return ReadOk(text="content", metadata={})
+
+        class _FakeT3:
+            pass
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.aspect_readers.read_source", fake_read)
+
+        # docs__ collections route through scholarly-paper-v1; that
+        # config is registered in aspect_extractor's _REGISTRY for
+        # ``docs__`` prefix at runtime — patch select_config to return
+        # a stub if needed.
+        from nexus.aspect_extractor import ExtractorConfig, _REGISTRY
+        # Minimal config: parser_fn=None forces the LLM path that
+        # builds the chroma URI.
+        if "docs__" not in _REGISTRY:
+            _REGISTRY["docs__"] = ExtractorConfig(
+                extractor_name="test-stub",
+                model_version="test",
+                parser_fn=None,
+                prompt_template="",
+            )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            enrich, ["aspects", "docs__myrepo-abcd1234", "--dry-run"],
+        )
+        assert result.exit_code == 0, result.output
+        # The constructed URI must reference the ABSOLUTE path so the
+        # chroma reader's ``where={source_path: <abs>}`` lookup matches
+        # what the indexer actually wrote.
+        assert any("/Users/test/myrepo/docs/paper.pdf" in u for u in seen_uris), (
+            f"expected chroma URI with absolute source_path; got {seen_uris!r}"
+        )
+        # And explicitly NOT the bare relative path that doesn't match
+        # absolute-path chunk metadata.
+        assert not any(u.endswith("/docs/paper.pdf") and "/Users/" not in u for u in seen_uris), (
+            f"reader should not be queried with bare relative path; got {seen_uris!r}"
+        )
+
+    def test_dry_run_falls_back_to_file_path_when_source_uri_empty(
+        self, env, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Curator-owned entries (no repo_root) and pre-fix legacy
+        rows have empty source_uri. The lookup must fall back to
+        file_path so existing flows aren't regressed."""
+        from nexus.aspect_readers import ReadOk
+
+        _, _, cat = env
+        # Curator owners legitimately span sources; no repo_root.
+        owner = cat.register_owner("papers", "curator")
+        # Register with absolute file_path (the legacy paper path).
+        cat.register(
+            owner=owner, title="legacy.pdf",
+            content_type="paper",
+            physical_collection="knowledge__delos",
+            file_path="/abs/path/to/legacy.pdf",
+        )
+
+        seen_uris: list[str] = []
+
+        def fake_read(uri, t3=None, **_kw):
+            seen_uris.append(uri)
+            return ReadOk(text="content", metadata={})
+
+        class _FakeT3:
+            pass
+        monkeypatch.setattr("nexus.mcp_infra.get_t3", lambda: _FakeT3())
+        monkeypatch.setattr("nexus.aspect_readers.read_source", fake_read)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            enrich, ["aspects", "knowledge__delos", "--dry-run"],
+        )
+        assert result.exit_code == 0, result.output
+        # source_uri ends up as file:///abs/path/... at register time
+        # (curator owners get the abspath fallback in
+        # _normalize_source_uri); the lookup uses that.
+        assert any("/abs/path/to/legacy.pdf" in u for u in seen_uris), (
+            f"reader should be queried with the absolute path; got {seen_uris!r}"
+        )
+
+
 # ── default extraction path (no validate, no re-extract) ────────────────────
 
 
@@ -363,7 +493,7 @@ class TestDefaultExtraction:
 
         extracted_calls: list[str] = []
 
-        def fake_extract(content, source_path, collection):
+        def fake_extract(content, source_path, collection, **_kw):
             extracted_calls.append(source_path)
             return _make_record(source_path=source_path)
 
@@ -403,7 +533,7 @@ class TestDefaultExtraction:
             "/papers/ghost-empty.pdf",
         ])
 
-        def fake_extract(content, source_path, collection):
+        def fake_extract(content, source_path, collection, **_kw):
             if "good" in source_path:
                 return _make_record(source_path=source_path)
             if "ghost-stale" in source_path:
@@ -453,7 +583,7 @@ class TestDefaultExtraction:
         _, _, cat = env
         _register_entries(cat, ["/papers/p1.pdf"])
 
-        def fake_extract(content, source_path, collection):
+        def fake_extract(content, source_path, collection, **_kw):
             return _make_record(
                 source_path=source_path,
                 problem_formulation=None,
@@ -503,7 +633,7 @@ class TestReExtract:
 
         re_extracted: list[str] = []
 
-        def fake_extract(content, source_path, collection):
+        def fake_extract(content, source_path, collection, **_kw):
             re_extracted.append(source_path)
             return _make_record(source_path=source_path)
 
@@ -548,7 +678,7 @@ class TestValidateSample:
 
         monkeypatch.setattr(
             "nexus.aspect_extractor.extract_aspects",
-            lambda content, source_path, collection: _make_record(
+            lambda content, source_path, collection, **_kw: _make_record(
                 source_path=source_path,
             ),
         )
@@ -591,7 +721,7 @@ class TestValidateSample:
 
         monkeypatch.setattr(
             "nexus.aspect_extractor.extract_aspects",
-            lambda content, source_path, collection: _make_record(
+            lambda content, source_path, collection, **_kw: _make_record(
                 source_path=source_path,
             ),
         )


### PR DESCRIPTION
## Summary

After nexus-p03z's `--from-t3` recovery, `docs__<repo>` and `code__<repo>` catalog rows carry RELATIVE `file_path` values (anchored to `repo_root` by the nexus-3e4s register-time guard). T3 chunks for those same files were ingested with ABSOLUTE `source_path` metadata. `extract_aspects` built `chroma://{collection}/{relative_path}` and the chroma reader's `where={source_path: <relative>}` returned zero chunks, so every entry skipped with `reason='empty'`.

**Live repro 2026-04-30**: `nx enrich aspects docs__ART-8c2e74c0 --dry-run` reported 365/365 documents would skip. **After fix**: `All entries readable; full extraction would proceed.`

## Approach

Catalog entries already carry `source_uri` (the absolute `file://` URI set at register time, anchored to repo_root by `_normalize_source_uri`). Use that as the chroma identity when present; fall back to `file_path`/`title` for curator-owned and legacy entries.

- New helper `_chroma_source_id_for_entry(entry)` in `commands/enrich.py` parses `source_uri`'s path (when `scheme=file`) or falls back.
- `_dry_run_predict_skips` uses the helper to build the URI.
- `_run_extraction` passes the helper's value as the new `lookup_path` param to `extract_aspects`, preserving the relative `file_path` as the `AspectRecord` storage key while fixing the chroma lookup.
- `extract_aspects` gains a keyword-only `lookup_path` parameter that overrides `source_path` for chroma URI construction. Defaults to empty string for backward compat (existing callers use `source_path` for both lookup and storage as before).

## Test plan

- [x] New `TestSourceUriResolutionForChromaLookup` (2 cases): relative file_path + absolute source_uri → reader gets abs path; curator owner with absolute file_path → source_uri carries same abs path, lookup unchanged.
- [x] Pre-existing test fakes updated to accept `**_kw` so the new `lookup_path` keyword doesn't break monkeypatched signatures.
- [x] 167 tests pass across `test_enrich_aspects.py`, `test_enrich_command.py`, `test_aspect_extractor.py`, `test_aspect_readers.py`, `test_catalog_backfill.py`, `test_catalog_audit_membership.py`. No regressions.
- [x] **Live verified** on `docs__ART-8c2e74c0` (365 documents): dry-run flips from 365/365 empty → all readable.
- [x] No em dashes in user-facing strings.
- [x] No AI attribution in commit message.

## Closes

nexus-v9az