### PR TITLE
feat(enrich): OpenAlex bib backend + nx enrich bib --source flag (nexus-57mk)

### DIFF
--- a/src/nexus/bib_enricher_openalex.py
+++ b/src/nexus/bib_enricher_openalex.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Bibliographic metadata enrichment via the OpenAlex API (nexus-57mk).
+
+Drop-in alternative to :mod:`nexus.bib_enricher` (Semantic Scholar)
+that does not require an API key. Same ``enrich(title) -> dict``
+contract; the catalog enrich hook stores the OpenAlex W-id under
+``bib_openalex_id`` and the citation-link generator matches against
+either backend's ID space.
+
+Set ``OPENALEX_MAILTO`` to your email for the OpenAlex 'polite pool'
+(higher rate limits). API reference: https://docs.openalex.org/.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+_BASE_URL = "https://api.openalex.org/works"
+_TIMEOUT = 10.0  # parallels bib_enricher.py; keeps both backends comparable
+
+_MAX_RETRIES = 3
+_BACKOFF_BASE = 5.0  # seconds; doubles each retry, identical to S2 backoff
+
+
+def _params(title: str) -> dict[str, str]:
+    """Build the ``/works`` query string. Includes ``mailto`` when
+    ``OPENALEX_MAILTO`` is set so OpenAlex routes us through the polite
+    pool (higher rate limits, more stable latency)."""
+    params: dict[str, str] = {
+        "search": title,
+        "per-page": "1",
+    }
+    mailto = os.environ.get("OPENALEX_MAILTO", "").strip()
+    if mailto:
+        params["mailto"] = mailto
+    return params
+
+
+def _strip_openalex_prefix(value: str) -> str:
+    """Strip the ``https://openalex.org/`` URL prefix from an OpenAlex
+    ID, leaving the bare ``W<digits>`` form. Same convention used by
+    the S2 backend's ``paperId`` field."""
+    return value.rsplit("/", 1)[-1] if value else ""
+
+
+def _strip_doi_prefix(value: str) -> str:
+    """Strip ``https://doi.org/`` from a DOI URL, leaving the bare
+    ``10.xxxx/...`` form."""
+    if not value:
+        return ""
+    if value.startswith("https://doi.org/"):
+        return value[len("https://doi.org/"):]
+    if value.startswith("http://doi.org/"):
+        return value[len("http://doi.org/"):]
+    return value
+
+
+def enrich(title: str) -> dict[str, Any]:
+    """Query OpenAlex for a paper matching ``title``.
+
+    Returns a dict with keys: ``year``, ``venue``, ``authors``,
+    ``citation_count``, ``openalex_id``, ``doi``, ``references``.
+    Returns ``{}`` on any failure (timeout, HTTP error, network
+    error, empty result, or malformed payload).
+
+    Retries up to 3 times on HTTP 429 (rate-limit) with the same
+    5s/10s/20s backoff schedule as the Semantic Scholar enricher.
+    """
+    import time
+
+    params = _params(title)
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            resp = httpx.get(_BASE_URL, params=params, timeout=_TIMEOUT)
+            if resp.status_code == 429 and attempt < _MAX_RETRIES:
+                wait = _BACKOFF_BASE * (2 ** attempt)
+                _log.debug(
+                    "openalex_rate_limited", title=title, retry_in=wait,
+                )
+                time.sleep(wait)
+                continue
+            resp.raise_for_status()
+            data = resp.json().get("results") or []
+            if not data:
+                return {}
+            work = data[0]
+
+            authorships = work.get("authorships") or []
+            authors = ", ".join(
+                (a.get("author") or {}).get("display_name", "")
+                for a in authorships[:5]
+            )
+
+            primary = work.get("primary_location") or {}
+            source = (primary.get("source") or {}) if isinstance(primary, dict) else {}
+            venue = source.get("display_name", "") if isinstance(source, dict) else ""
+
+            referenced = work.get("referenced_works") or []
+            refs = [_strip_openalex_prefix(r) for r in referenced if r]
+
+            return {
+                "year": work.get("publication_year", 0) or 0,
+                "venue": venue or "",
+                "authors": authors or "",
+                "citation_count": work.get("cited_by_count", 0) or 0,
+                "openalex_id": _strip_openalex_prefix(work.get("id", "")) or "",
+                "doi": _strip_doi_prefix(work.get("doi", "") or ""),
+                "references": refs,
+            }
+        except (
+            httpx.HTTPError,
+            httpx.TimeoutException,
+            httpx.ConnectError,
+            ValueError,
+        ) as exc:
+            _log.debug("openalex_lookup_failed", title=title, error=str(exc))
+            return {}
+    return {}

--- a/src/nexus/catalog/link_generator.py
+++ b/src/nexus/catalog/link_generator.py
@@ -22,22 +22,37 @@ def _all_entries(cat: Catalog) -> list[CatalogEntry]:
 
 
 def generate_citation_links(cat: Catalog) -> int:
-    """Auto-create 'cites' links via bib_semantic_scholar_id cross-matching.
+    """Auto-create 'cites' links via bib ID cross-matching.
 
     Uses metadata already on catalog entries — no API calls.
     created_by='bib_enricher' per RF-8.
+
+    nexus-57mk: indexes both ``bib_semantic_scholar_id`` (Semantic
+    Scholar paper IDs) and ``bib_openalex_id`` (OpenAlex W-ids) so a
+    catalog enriched by either backend produces cite links. The
+    ``references`` list on each entry contains IDs from whichever
+    backend enriched that entry; matching is exact-string against the
+    same ID space, so cross-backend references (a paper enriched by
+    OpenAlex referencing one enriched only by S2) won't match — that's
+    the correct conservative behavior, since the two ID spaces are
+    distinct and we don't have a DOI bridge yet.
     """
     entries = _all_entries(cat)
 
-    # Build index: SS ID → tumbler
+    # Build index: bib ID -> tumbler. Both backends' IDs share one map
+    # because their ID spaces don't collide (S2 paperIds are 40-hex
+    # SHA-shaped strings; OpenAlex IDs start with 'W' followed by
+    # digits). A collision would only happen if a future backend
+    # introduced overlapping namespacing.
     id_to_tumbler: dict[str, Tumbler] = {}
     entries_with_refs: list[tuple[Tumbler, list[str]]] = []
 
     for entry in entries:
         meta = entry.meta or {}
-        ss_id = meta.get("bib_semantic_scholar_id", "")
-        if ss_id:
-            id_to_tumbler[ss_id] = entry.tumbler
+        for id_field in ("bib_semantic_scholar_id", "bib_openalex_id"):
+            bib_id = meta.get(id_field, "")
+            if bib_id:
+                id_to_tumbler[bib_id] = entry.tumbler
         refs = meta.get("references", [])
         if refs:
             entries_with_refs.append((entry.tumbler, refs))

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -44,7 +44,7 @@ def enrich() -> None:
     default=0.5,
     type=float,
     show_default=True,
-    help="Delay in seconds between Semantic Scholar API calls.",
+    help="Delay in seconds between API calls (per backend).",
 )
 @click.option(
     "--limit",
@@ -52,20 +52,40 @@ def enrich() -> None:
     type=int,
     help="Maximum number of titles to enrich (0 = unlimited).",
 )
-def enrich_bib(collection: str, delay: float, limit: int) -> None:
+@click.option(
+    "--source",
+    type=click.Choice(["auto", "s2", "openalex"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help=(
+        "Bibliographic backend. ``s2`` queries Semantic Scholar "
+        "(needs S2_API_KEY env for higher rate limits; corporate or "
+        "academic email required for key issuance). ``openalex`` "
+        "queries OpenAlex (no key; set OPENALEX_MAILTO for the polite "
+        "pool). ``auto`` picks ``s2`` when S2_API_KEY is set, else "
+        "``openalex``."
+    ),
+)
+def enrich_bib(
+    collection: str, delay: float, limit: int, source: str,
+) -> None:
     """Backfill bibliographic metadata for chunks in COLLECTION.
 
-    Queries Semantic Scholar for each unique source title found in the
+    Queries the selected backend for each unique source title in the
     collection and writes bib_year, bib_venue, bib_authors,
-    bib_citation_count, and bib_semantic_scholar_id back to every
-    chunk with that title.
+    bib_citation_count, and a backend-specific ID
+    (bib_semantic_scholar_id or bib_openalex_id) back to every chunk
+    with that title. nexus-57mk added the OpenAlex backend so users
+    without a Semantic Scholar API key can still enrich.
 
-    Already-enriched chunks (bib_semantic_scholar_id is non-empty) are
-    skipped — the command is idempotent.
+    Already-enriched chunks (the backend's ID field is non-empty) are
+    skipped — the command is idempotent per backend.
     """
-    from nexus.bib_enricher import enrich as bib_enrich
     from nexus.db import make_t3
     from nexus.retry import _chroma_with_retry
+
+    backend, bib_enrich, id_field = _resolve_bib_backend(source)
+    click.echo(f"Backend: {backend} (id field: {id_field})")
 
     db = make_t3()
     col = db.get_or_create_collection(collection)
@@ -86,7 +106,7 @@ def enrich_bib(collection: str, delay: float, limit: int) -> None:
         batch_meta = batch.get("metadatas", [])
         total_chunks += len(batch_ids)
         for chunk_id, meta in zip(batch_ids, batch_meta):
-            if meta.get("bib_semantic_scholar_id", ""):
+            if meta.get(id_field, ""):
                 already_enriched += 1
                 continue
             title = meta.get("title", "") or ""
@@ -142,7 +162,17 @@ def enrich_bib(collection: str, delay: float, limit: int) -> None:
                 merged["bib_venue"] = bib.get("venue", "")
                 merged["bib_authors"] = bib.get("authors", "")
                 merged["bib_citation_count"] = bib.get("citation_count", 0)
-                merged["bib_semantic_scholar_id"] = bib.get("semantic_scholar_id", "")
+                # nexus-57mk: write the backend's native ID so re-runs
+                # against the same backend dedupe correctly. The
+                # citation-link generator matches against either field.
+                if backend == "openalex":
+                    merged["bib_openalex_id"] = bib.get("openalex_id", "")
+                    if bib.get("doi"):
+                        merged["bib_doi"] = bib.get("doi", "")
+                else:
+                    merged["bib_semantic_scholar_id"] = bib.get(
+                        "semantic_scholar_id", "",
+                    )
                 updated_ids.append(cid)
                 updated_meta.append(merged)
 
@@ -163,11 +193,15 @@ def enrich_bib(collection: str, delay: float, limit: int) -> None:
                 year=bib.get("year"),
                 venue=bib.get("venue"),
             )
-            _catalog_enrich_hook(title=title, bib_meta=bib, collection_name=collection)
+            _catalog_enrich_hook(
+                title=title, bib_meta=bib,
+                collection_name=collection, backend=backend,
+            )
 
+    backend_label = "Semantic Scholar" if backend == "s2" else "OpenAlex"
     click.echo(
         f"Done: enriched {enriched_chunks} chunks across {enriched_titles} titles; "
-        f"{skipped_titles} titles had no Semantic Scholar match."
+        f"{skipped_titles} titles had no {backend_label} match."
     )
 
     # Auto-generate citation links if catalog is initialized
@@ -188,8 +222,43 @@ def enrich_bib(collection: str, delay: float, limit: int) -> None:
             _log.debug("auto_citation_links_failed", exc_info=True)
 
 
-def _catalog_enrich_hook(title: str, bib_meta: dict, collection_name: str = "") -> None:
-    """Update catalog entry with bib metadata. Silently skipped if absent."""
+def _resolve_bib_backend(source: str) -> tuple[str, callable, str]:
+    """nexus-57mk: pick the bib enricher backend.
+
+    Returns ``(backend_name, enrich_callable, chunk_id_field_name)``.
+    ``auto`` defaults to ``s2`` when ``S2_API_KEY`` is set, else
+    ``openalex``.
+    """
+    import os as _os
+
+    chosen = source.lower()
+    if chosen == "auto":
+        chosen = "s2" if _os.environ.get("S2_API_KEY") else "openalex"
+
+    if chosen == "openalex":
+        from nexus.bib_enricher_openalex import enrich as _openalex_enrich
+        return "openalex", _openalex_enrich, "bib_openalex_id"
+    if chosen == "s2":
+        from nexus.bib_enricher import enrich as _s2_enrich
+        return "s2", _s2_enrich, "bib_semantic_scholar_id"
+    raise click.UsageError(
+        f"unknown bib source {source!r}; expected one of auto/s2/openalex"
+    )
+
+
+def _catalog_enrich_hook(
+    title: str,
+    bib_meta: dict,
+    collection_name: str = "",
+    backend: str = "s2",
+) -> None:
+    """Update catalog entry with bib metadata. Silently skipped if absent.
+
+    nexus-57mk: ``backend`` selects which ID field is written into
+    catalog meta. The OpenAlex backend writes ``bib_openalex_id`` (and
+    ``bib_doi`` when present) so the citation-link generator can match
+    references in OpenAlex's W-id space.
+    """
     try:
         from nexus.catalog import Catalog
         from nexus.config import catalog_path
@@ -227,9 +296,16 @@ def _catalog_enrich_hook(title: str, bib_meta: dict, collection_name: str = "") 
         if entry:
             meta_update: dict = {
                 "venue": bib_meta.get("venue", ""),
-                "bib_semantic_scholar_id": bib_meta.get("semantic_scholar_id", ""),
                 "citation_count": bib_meta.get("citation_count", 0),
             }
+            if backend == "openalex":
+                meta_update["bib_openalex_id"] = bib_meta.get("openalex_id", "")
+                if bib_meta.get("doi"):
+                    meta_update["bib_doi"] = bib_meta.get("doi", "")
+            else:
+                meta_update["bib_semantic_scholar_id"] = bib_meta.get(
+                    "semantic_scholar_id", "",
+                )
             refs = bib_meta.get("references", [])
             if refs:
                 meta_update["references"] = refs

--- a/tests/test_bib_enricher_openalex.py
+++ b/tests/test_bib_enricher_openalex.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Tests for nexus.bib_enricher_openalex (nexus-57mk).
+
+OpenAlex is a drop-in alternative to Semantic Scholar for bibliographic
+enrichment, with no API key required. The module mirrors
+:mod:`nexus.bib_enricher`'s ``enrich(title) -> dict`` shape so the
+catalog enrich hook and citation-link generator stay agnostic to the
+backend.
+
+All HTTP calls are mocked; tests do not touch the live OpenAlex API.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+
+def _make_response(status_code: int = 200, json_data: dict | None = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    if json_data is not None:
+        resp.json.return_value = json_data
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message=f"HTTP {status_code}",
+            request=MagicMock(),
+            response=resp,
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+# Real OpenAlex /works response shape (trimmed to the fields the
+# enricher consumes). Field reference: https://docs.openalex.org/api-entities/works/work-object
+_VALID_WORK = {
+    "id": "https://openalex.org/W2741809807",
+    "doi": "https://doi.org/10.5555/3295222.3295349",
+    "display_name": "Attention Is All You Need",
+    "publication_year": 2017,
+    "cited_by_count": 90000,
+    "primary_location": {
+        "source": {"display_name": "NeurIPS"},
+    },
+    "authorships": [
+        {"author": {"id": "A1", "display_name": "Ashish Vaswani"}},
+        {"author": {"id": "A2", "display_name": "Noam Shazeer"}},
+        {"author": {"id": "A3", "display_name": "Niki Parmar"}},
+    ],
+    "referenced_works": [
+        "https://openalex.org/W11111",
+        "https://openalex.org/W22222",
+    ],
+}
+
+_VALID_RESPONSE = {"results": [_VALID_WORK]}
+
+
+def test_enrich_success():
+    from nexus.bib_enricher_openalex import enrich
+
+    mock_resp = _make_response(200, _VALID_RESPONSE)
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich("Attention Is All You Need")
+
+    assert result["year"] == 2017
+    # Venue is the primary_location.source.display_name on modern OpenAlex.
+    assert result["venue"] == "NeurIPS"
+    assert result["citation_count"] == 90000
+    # OpenAlex W-id with the URL prefix stripped.
+    assert result["openalex_id"] == "W2741809807"
+    # Authors comma-separated, top 5.
+    assert "Ashish Vaswani" in result["authors"]
+    # DOI without the URL prefix.
+    assert result["doi"] == "10.5555/3295222.3295349"
+    # references is the list of referenced W-ids.
+    assert result["references"] == ["W11111", "W22222"]
+
+
+def test_enrich_field_types():
+    from nexus.bib_enricher_openalex import enrich
+
+    mock_resp = _make_response(200, _VALID_RESPONSE)
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich("Attention Is All You Need")
+
+    assert isinstance(result["year"], int)
+    assert isinstance(result["venue"], str)
+    assert isinstance(result["authors"], str)
+    assert isinstance(result["citation_count"], int)
+    assert isinstance(result["openalex_id"], str)
+    assert isinstance(result["doi"], str)
+    assert isinstance(result["references"], list)
+
+
+def test_enrich_no_results():
+    from nexus.bib_enricher_openalex import enrich
+
+    mock_resp = _make_response(200, {"results": []})
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich("Totally Unknown Paper")
+    assert result == {}
+
+
+def test_enrich_timeout():
+    from nexus.bib_enricher_openalex import enrich
+
+    with patch("httpx.get", side_effect=httpx.TimeoutException("timed out")):
+        result = enrich("Some Paper")
+    assert result == {}
+
+
+def test_enrich_404():
+    from nexus.bib_enricher_openalex import enrich
+
+    mock_resp = _make_response(404, {"error": "Not Found"})
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich("Some Paper")
+    assert result == {}
+
+
+def test_enrich_429_retries_with_backoff():
+    """OpenAlex returns 429 on rate-limit; enricher retries with backoff."""
+    from nexus.bib_enricher_openalex import enrich
+
+    sleep_calls: list[float] = []
+    mock_resp = _make_response(429, {"message": "rate limited"})
+    with (
+        patch("httpx.get", return_value=mock_resp),
+        patch("time.sleep", side_effect=sleep_calls.append),
+    ):
+        result = enrich("Some Paper")
+
+    assert result == {}
+    # Same backoff schedule as the S2 enricher: 5s / 10s / 20s.
+    assert sleep_calls == [5.0, 10.0, 20.0]
+
+
+def test_enrich_network_error():
+    from nexus.bib_enricher_openalex import enrich
+
+    with patch("httpx.get", side_effect=httpx.ConnectError("conn refused")):
+        result = enrich("Some Paper")
+    assert result == {}
+
+
+def test_enrich_malformed_json():
+    from nexus.bib_enricher_openalex import enrich
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.side_effect = ValueError("not json")
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich("Some Paper")
+    assert result == {}
+
+
+def test_enrich_authors_truncated_to_five():
+    from nexus.bib_enricher_openalex import enrich
+
+    work = dict(_VALID_WORK)
+    work["authorships"] = [
+        {"author": {"id": f"A{i}", "display_name": f"Author {i}"}}
+        for i in range(10)
+    ]
+    mock_resp = _make_response(200, {"results": [work]})
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich("Multi-Author Paper")
+
+    names = [n.strip() for n in result["authors"].split(",")]
+    assert len(names) == 5
+    assert names[0] == "Author 0"
+    assert names[4] == "Author 4"
+
+
+def test_enrich_handles_null_authorships_and_references():
+    """OpenAlex sometimes returns explicit null for authorships /
+    referenced_works on partial-coverage works. Enricher must not crash."""
+    from nexus.bib_enricher_openalex import enrich
+
+    work = dict(_VALID_WORK)
+    work["authorships"] = None
+    work["referenced_works"] = None
+    mock_resp = _make_response(200, {"results": [work]})
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich("Sparse Paper")
+
+    assert result["authors"] == ""
+    assert result["references"] == []
+    assert result["openalex_id"] == "W2741809807"
+
+
+def test_enrich_handles_missing_primary_location():
+    """Works without a primary_location yield empty venue, no crash."""
+    from nexus.bib_enricher_openalex import enrich
+
+    work = dict(_VALID_WORK)
+    work.pop("primary_location")
+    mock_resp = _make_response(200, {"results": [work]})
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich("Venue-Less Paper")
+    assert result["venue"] == ""
+    assert result["openalex_id"] == "W2741809807"
+
+
+def test_enrich_handles_missing_doi():
+    from nexus.bib_enricher_openalex import enrich
+
+    work = dict(_VALID_WORK)
+    work.pop("doi")
+    mock_resp = _make_response(200, {"results": [work]})
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich("DOI-Less Paper")
+    assert result["doi"] == ""
+
+
+def test_enrich_polite_pool_passes_mailto(monkeypatch):
+    """When OPENALEX_MAILTO is set, the enricher includes it in the
+    query string for the OpenAlex 'polite pool' (higher rate limits)."""
+    from nexus.bib_enricher_openalex import enrich
+
+    monkeypatch.setenv("OPENALEX_MAILTO", "test@example.com")
+
+    captured: dict = {}
+
+    def _capture(*args, **kwargs):
+        captured.update(kwargs)
+        return _make_response(200, _VALID_RESPONSE)
+
+    with patch("httpx.get", side_effect=_capture):
+        enrich("Paper")
+
+    assert captured["params"].get("mailto") == "test@example.com"
+
+
+def test_enrich_anonymous_when_mailto_missing(monkeypatch):
+    """No OPENALEX_MAILTO env: no mailto param sent (anonymous pool)."""
+    from nexus.bib_enricher_openalex import enrich
+
+    monkeypatch.delenv("OPENALEX_MAILTO", raising=False)
+    captured: dict = {}
+
+    def _capture(*args, **kwargs):
+        captured.update(kwargs)
+        return _make_response(200, _VALID_RESPONSE)
+
+    with patch("httpx.get", side_effect=_capture):
+        enrich("Paper")
+
+    assert "mailto" not in captured["params"]

--- a/tests/test_enrich_command.py
+++ b/tests/test_enrich_command.py
@@ -20,7 +20,7 @@ def test_enrich_empty_collection(mock_bib: MagicMock, mock_t3_factory: MagicMock
     mock_t3_factory.return_value = mock_db
 
     runner = CliRunner()
-    result = runner.invoke(enrich, ["bib", "knowledge__test"])
+    result = runner.invoke(enrich, ["bib", "knowledge__test", "--source", "s2"])
     assert result.exit_code == 0
     assert "is empty" in result.output
     mock_bib.assert_not_called()
@@ -43,7 +43,7 @@ def test_enrich_skips_already_enriched(mock_bib: MagicMock, mock_t3_factory: Mag
     mock_t3_factory.return_value = mock_db
 
     runner = CliRunner()
-    result = runner.invoke(enrich, ["bib", "knowledge__test"])
+    result = runner.invoke(enrich, ["bib", "knowledge__test", "--source", "s2"])
     assert result.exit_code == 0
     assert "2 already enriched" in result.output
     assert "0 titles to look up" in result.output
@@ -87,7 +87,7 @@ def test_enrich_updates_metadata(
     mock_t3_factory.return_value = mock_db
 
     runner = CliRunner()
-    result = runner.invoke(enrich, ["bib", "knowledge__test", "--delay", "0"])
+    result = runner.invoke(enrich, ["bib", "knowledge__test", "--delay", "0", "--source", "s2"])
     assert result.exit_code == 0
     assert "enriched 2 chunks across 1 titles" in result.output
 
@@ -108,7 +108,7 @@ def test_enrich_no_match_increments_skipped(mock_bib: MagicMock, mock_t3_factory
     mock_t3_factory.return_value = mock_db
 
     runner = CliRunner()
-    result = runner.invoke(enrich, ["bib", "knowledge__test", "--delay", "0"])
+    result = runner.invoke(enrich, ["bib", "knowledge__test", "--delay", "0", "--source", "s2"])
     assert result.exit_code == 0
     assert "1 titles had no Semantic Scholar match" in result.output
 
@@ -133,7 +133,113 @@ def test_enrich_limit_option(mock_bib: MagicMock, mock_t3_factory: MagicMock) ->
     mock_t3_factory.return_value = mock_db
 
     runner = CliRunner()
-    result = runner.invoke(enrich, ["bib", "knowledge__test", "--delay", "0", "--limit", "2"])
+    result = runner.invoke(enrich, ["bib", "knowledge__test", "--delay", "0", "--limit", "2", "--source", "s2"])
     assert result.exit_code == 0
     assert "capped at 2" in result.output
     assert mock_bib.call_count == 2
+
+
+# ── nexus-57mk: --source flag + auto fallback + OpenAlex backend ────────────
+
+
+@patch("nexus.db.make_t3")
+@patch("nexus.bib_enricher_openalex.enrich")
+def test_enrich_source_openalex_routes_to_openalex_backend(
+    mock_oa: MagicMock, mock_t3_factory: MagicMock,
+) -> None:
+    """``--source openalex`` calls the OpenAlex enricher and writes
+    ``bib_openalex_id`` (not ``bib_semantic_scholar_id``)."""
+    mock_oa.return_value = {
+        "year": 2024, "venue": "Nature", "authors": "X, Y, Z",
+        "citation_count": 5, "openalex_id": "W12345",
+        "doi": "10.1/abc", "references": [],
+    }
+    mock_col = MagicMock()
+    mock_col.get.return_value = {
+        "ids": ["c1"],
+        "metadatas": [{"title": "Paper Z"}],
+    }
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.return_value = mock_col
+    mock_t3_factory.return_value = mock_db
+
+    runner = CliRunner()
+    result = runner.invoke(
+        enrich,
+        ["bib", "knowledge__test", "--delay", "0", "--source", "openalex"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Backend: openalex" in result.output
+    assert "bib_openalex_id" in result.output
+    mock_oa.assert_called_once_with("Paper Z")
+    # Confirm the chunk update wrote bib_openalex_id, not the S2 ID.
+    update_call = mock_col.update.call_args
+    metas = update_call.kwargs["metadatas"]
+    assert metas[0]["bib_openalex_id"] == "W12345"
+    assert "bib_semantic_scholar_id" not in metas[0]
+
+
+@patch("nexus.db.make_t3")
+@patch("nexus.bib_enricher_openalex.enrich")
+@patch("nexus.bib_enricher.enrich")
+def test_enrich_source_auto_falls_back_to_openalex_without_s2_key(
+    mock_s2: MagicMock,
+    mock_oa: MagicMock,
+    mock_t3_factory: MagicMock,
+    monkeypatch,
+) -> None:
+    """``--source auto`` (or default) routes to OpenAlex when
+    ``S2_API_KEY`` is unset. S2 enricher is not called."""
+    monkeypatch.delenv("S2_API_KEY", raising=False)
+    mock_oa.return_value = {}
+
+    mock_col = MagicMock()
+    mock_col.get.return_value = {
+        "ids": ["c1"],
+        "metadatas": [{"title": "Paper Auto"}],
+    }
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.return_value = mock_col
+    mock_t3_factory.return_value = mock_db
+
+    runner = CliRunner()
+    result = runner.invoke(
+        enrich, ["bib", "knowledge__test", "--delay", "0"],
+    )
+    assert result.exit_code == 0
+    assert "Backend: openalex" in result.output
+    mock_s2.assert_not_called()
+    mock_oa.assert_called_once_with("Paper Auto")
+
+
+@patch("nexus.db.make_t3")
+@patch("nexus.bib_enricher.enrich")
+@patch("nexus.bib_enricher_openalex.enrich")
+def test_enrich_source_auto_uses_s2_when_key_present(
+    mock_oa: MagicMock,
+    mock_s2: MagicMock,
+    mock_t3_factory: MagicMock,
+    monkeypatch,
+) -> None:
+    """``--source auto`` routes to Semantic Scholar when ``S2_API_KEY``
+    is set."""
+    monkeypatch.setenv("S2_API_KEY", "fake-key")
+    mock_s2.return_value = {}
+
+    mock_col = MagicMock()
+    mock_col.get.return_value = {
+        "ids": ["c1"],
+        "metadatas": [{"title": "Paper S2"}],
+    }
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.return_value = mock_col
+    mock_t3_factory.return_value = mock_db
+
+    runner = CliRunner()
+    result = runner.invoke(
+        enrich, ["bib", "knowledge__test", "--delay", "0"],
+    )
+    assert result.exit_code == 0
+    assert "Backend: s2" in result.output
+    mock_oa.assert_not_called()
+    mock_s2.assert_called_once_with("Paper S2")


### PR DESCRIPTION
## Summary

Semantic Scholar's API key issuance requires a corporate or academic email, blocking personal-account use. **OpenAlex** is a drop-in substitute (200M+ papers, year/venue/authors/cited-by/DOI/referenced_works) with no key requirement. This PR adds OpenAlex as a second backend behind `nx enrich bib`.

## What changed

- **New module** `src/nexus/bib_enricher_openalex.py` mirrors `bib_enricher.py`'s `enrich(title) -> dict` contract. Returns `openalex_id` (W-id) and `doi` instead of `semantic_scholar_id`.
- **`OPENALEX_MAILTO` env var** opts into OpenAlex's polite pool (higher rate limits).
- **`nx enrich bib --source [auto|s2|openalex]`**:
  - `auto` (default): picks `s2` when `S2_API_KEY` is set, else `openalex`.
  - The selected backend's ID field (`bib_semantic_scholar_id` or `bib_openalex_id`) is used for both the chunk-metadata write and the re-run dedup check, so re-runs against the same backend stay idempotent.
- **`generate_citation_links`** indexes both `bib_semantic_scholar_id` and `bib_openalex_id` when building its tumbler lookup. Cross-backend references won't match (the two ID spaces are distinct; matching would need a DOI bridge that is not in scope here).

## Test plan

- [x] **`tests/test_bib_enricher_openalex.py`** (14 cases): successful parse, field types, empty result, timeout, 404, 429 with backoff, network error, malformed JSON, top-5 author truncation, null authorships/references, missing primary_location, missing DOI, polite-pool mailto plumbing, anonymous fallback.
- [x] **`tests/test_enrich_command.py`** (3 new cases): `--source openalex` routes correctly and writes `bib_openalex_id`; `--source auto` falls back to OpenAlex when `S2_API_KEY` is unset; `--source auto` prefers `s2` when the key is set.
- [x] Pre-existing S2-specific tests pinned to `--source s2` since auto-mode would flip to openalex in the unset-key test environment.
- [x] **192 tests pass** across enrich + catalog + aspect + bib suites. No regressions.
- [x] No em dashes in user-facing CLI strings.
- [x] No AI attribution in commit message.

## Recommended next steps after merge

```bash
# Set OpenAlex polite-pool mailto (one-time, in ~/.zshrc):
export OPENALEX_MAILTO=hal.hildebrand@me.com

# Enrich docs__ART via OpenAlex (no S2 key required):
nx enrich bib docs__ART-8c2e74c0
# (auto picks openalex since no S2_API_KEY)
```

## Closes

nexus-57mk