### PR TITLE
feat(scripts): migrate ART PDFs from docs__ART to knowledge__art-papers (nexus-olg5)

### DIFF
--- a/scripts/migrate_art_papers.py
+++ b/scripts/migrate_art_papers.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-olg5: split docs__ART-8c2e74c0 by moving the 78 PDF papers
+under /docs/papers/ to a new ``knowledge__art-papers`` collection.
+
+Metadata-only migration: chunks keep their existing embeddings and
+documents (so no Voyage cost). Per-chunk metadata is rewritten so
+each chunk's ``title`` carries a paper-shaped name derived from the
+filename, ``category`` flips from "prose" to "paper", and
+``content_type`` stays "pdf".
+
+Three layers move together:
+
+1. **T3 chunks** — read from docs__ART, add to knowledge__art-papers
+   with same ids + embeddings + documents but rewritten metadata,
+   delete from docs__ART.
+2. **T2 aspects** — ``UPDATE document_aspects SET collection =
+   'knowledge__art-papers' WHERE source_path LIKE '%/docs/papers/%'``.
+3. **Catalog** — ``UPDATE documents SET physical_collection =
+   'knowledge__art-papers' WHERE physical_collection =
+   'docs__ART-8c2e74c0' AND file_path LIKE 'docs/papers/%'``.
+
+Run with ``--dry-run`` first to see what would change. Without
+``--dry-run`` the script asks for confirmation before writing.
+
+Reversible: the inverse migration would copy the chunks back, restore
+the old metadata (lost — backups not made), and reverse the SQL. In
+practice the reverse path is just "re-index the PDFs from disk", so
+we accept the metadata loss.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+# nx package import
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from nexus.db import make_t3
+from nexus.indexer_utils import derive_title
+from nexus.commands._helpers import default_db_path
+from nexus.config import catalog_path
+
+FROM_COLLECTION = "docs__ART-8c2e74c0"
+TO_COLLECTION = "knowledge__art-papers"
+PATH_PREFIX = "/Users/hal.hildebrand/git/ART/docs/papers/"
+T2_PATH_LIKE = "docs/papers/%"
+CATALOG_PATH_PREFIX = "docs/papers/"
+
+PAGE = 300  # ChromaDB Cloud read/write cap
+
+
+def _rewrite_metadata(meta: dict, source_path: str) -> dict:
+    """Rewrite chunk metadata for a paper-shaped collection.
+
+    Replaces the ``X.pdf:page-N`` placeholder title with a derived
+    title from the filename; flips category to "paper". Other fields
+    pass through unchanged so we don't lose embedding_model,
+    chunk_index, content_hash, git_meta, etc.
+    """
+    new = dict(meta)
+    pdf_path = Path(source_path)
+    new["title"] = derive_title(pdf_path, body=None)
+    new["category"] = "paper"
+    return new
+
+
+def _scan_pdf_chunks(col, prefix: str) -> tuple[list[str], list[Any], list[str], list[dict]]:
+    """Page through ``col`` and collect chunks whose source_path starts
+    with ``prefix``. Returns parallel lists.
+    """
+    ids: list[str] = []
+    embeds: list[Any] = []
+    docs: list[str] = []
+    metas: list[dict] = []
+
+    offset = 0
+    while True:
+        page = col.get(
+            limit=PAGE, offset=offset,
+            include=["embeddings", "documents", "metadatas"],
+        )
+        page_ids = page.get("ids") or []
+        if not page_ids:
+            break
+        # ChromaDB returns embeddings as numpy arrays; ``or`` triggers
+        # the ambiguous-truth check. Use explicit None comparison.
+        page_embeds = page.get("embeddings")
+        if page_embeds is None:
+            page_embeds = []
+        page_docs = page.get("documents") or []
+        page_metas = page.get("metadatas") or []
+        for cid, emb, doc, meta in zip(page_ids, page_embeds, page_docs, page_metas):
+            sp = (meta or {}).get("source_path", "")
+            if sp.startswith(prefix):
+                ids.append(cid)
+                embeds.append(emb)
+                docs.append(doc)
+                metas.append(meta)
+        if len(page_ids) < PAGE:
+            break
+        offset += PAGE
+
+    return ids, embeds, docs, metas
+
+
+def _add_in_batches(col, ids, embeds, docs, metas, batch: int = 200) -> None:
+    """ChromaDB Cloud caps writes at 300 records; use 200 for headroom."""
+    for i in range(0, len(ids), batch):
+        end = i + batch
+        col.add(
+            ids=ids[i:end],
+            embeddings=embeds[i:end],
+            documents=docs[i:end],
+            metadatas=metas[i:end],
+        )
+
+
+def _delete_in_batches(col, ids, batch: int = 200) -> None:
+    for i in range(0, len(ids), batch):
+        col.delete(ids=ids[i:i + batch])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Report without writing.")
+    parser.add_argument("--yes", action="store_true", help="Skip confirmation prompt.")
+    args = parser.parse_args()
+
+    db = make_t3()
+    src = db.get_or_create_collection(FROM_COLLECTION)
+    dst = db.get_or_create_collection(TO_COLLECTION)
+
+    print(f"Scanning {FROM_COLLECTION} for chunks under {PATH_PREFIX}...")
+    ids, embeds, docs, metas = _scan_pdf_chunks(src, PATH_PREFIX)
+    print(f"  Found {len(ids)} chunks across "
+          f"{len({(m or {}).get('source_path', '') for m in metas})} unique PDFs.")
+
+    if not ids:
+        print("Nothing to move. Exiting.")
+        return 0
+
+    print(f"\nRewriting metadata (new titles via derive_title)...")
+    rewritten_metas = [
+        _rewrite_metadata(m, (m or {}).get("source_path", ""))
+        for m in metas
+    ]
+    sample = sorted({m["title"] for m in rewritten_metas})[:5]
+    print(f"  Sample new titles:")
+    for t in sample:
+        print(f"    {t!r}")
+
+    # Plan T2 + catalog updates.
+    db_path = default_db_path()
+    cat_path = catalog_path()
+    cat_db = cat_path / ".catalog.db"
+
+    aspect_count = 0
+    catalog_count = 0
+    with sqlite3.connect(db_path) as t2_conn:
+        cur = t2_conn.execute(
+            "SELECT COUNT(*) FROM document_aspects "
+            "WHERE collection = ? AND source_path LIKE ?",
+            (FROM_COLLECTION, T2_PATH_LIKE),
+        )
+        aspect_count = cur.fetchone()[0]
+    with sqlite3.connect(cat_db) as cat_conn:
+        cur = cat_conn.execute(
+            "SELECT COUNT(*) FROM documents "
+            "WHERE physical_collection = ? AND file_path LIKE ?",
+            (FROM_COLLECTION, CATALOG_PATH_PREFIX + "%"),
+        )
+        catalog_count = cur.fetchone()[0]
+
+    print(f"\nPlan:")
+    print(f"  T3: add {len(ids)} chunks to {TO_COLLECTION}, delete same ids from {FROM_COLLECTION}.")
+    print(f"  T2: UPDATE {aspect_count} document_aspects rows to collection={TO_COLLECTION!r}.")
+    print(f"  Catalog: UPDATE {catalog_count} documents rows to physical_collection={TO_COLLECTION!r}.")
+
+    if args.dry_run:
+        print("\n[dry-run] No writes performed.")
+        return 0
+
+    if not args.yes:
+        confirm = input("\nProceed? (yes/no) ").strip().lower()
+        if confirm != "yes":
+            print("Aborted.")
+            return 1
+
+    print(f"\nWriting {len(ids)} chunks to {TO_COLLECTION}...")
+    _add_in_batches(dst, ids, embeds, docs, rewritten_metas)
+    print(f"  Done.")
+
+    print(f"Deleting {len(ids)} chunks from {FROM_COLLECTION}...")
+    _delete_in_batches(src, ids)
+    print(f"  Done.")
+
+    print(f"Updating T2 document_aspects ({aspect_count} rows)...")
+    with sqlite3.connect(db_path) as t2_conn:
+        t2_conn.execute(
+            "UPDATE document_aspects SET collection = ? "
+            "WHERE collection = ? AND source_path LIKE ?",
+            (TO_COLLECTION, FROM_COLLECTION, T2_PATH_LIKE),
+        )
+        t2_conn.commit()
+    print(f"  Done.")
+
+    print(f"Updating catalog documents ({catalog_count} rows)...")
+    # nexus-olg5 fix: catalog uses JSONL-as-truth + SQLite-as-cache.
+    # A direct SQL UPDATE writes to the cache only; the next
+    # consistency rebuild from JSONL silently reverts it. Use
+    # cat.update() so the change appends to JSONL too.
+    from nexus.catalog import Catalog as _Cat
+    from nexus.catalog.tumbler import Tumbler as _Tum
+    cat = _Cat(cat_path, cat_db)
+    rows = cat._db.execute(
+        "SELECT tumbler FROM documents "
+        "WHERE physical_collection = ? AND file_path LIKE ?",
+        (FROM_COLLECTION, CATALOG_PATH_PREFIX + "%"),
+    ).fetchall()
+    for (t_str,) in rows:
+        cat.update(_Tum.parse(t_str), physical_collection=TO_COLLECTION)
+    print(f"  Done.")
+
+    print(f"\nMigration complete. Verify:")
+    print(f"  nx collection list | grep -E 'docs__ART|knowledge__art-papers'")
+    print(f"  nx catalog audit-membership {TO_COLLECTION}")
+    print(f"  nx enrich bib {TO_COLLECTION}  # OpenAlex polite pool, no key needed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

One-off migration script that splits the 78 PDF papers in `docs__ART-8c2e74c0` (which were mixed with 287 markdown/dict/jsonl docs from the ART repo) into a new paper-shaped collection `knowledge__art-papers`. Live-run already executed against Hal's catalog on 2026-04-30; this PR records the script as repo history.

## Why

`docs__ART-8c2e74c0` was created via `nx index repo`, so its PDFs went through the prose ingestion path and got placeholder titles (`X.pdf:page-1`) instead of paper-shaped titles. `nx enrich bib` against this collection walked 8,593 unique chunk titles, of which only ~78 were real papers; the rest were doc placeholders that OpenAlex correctly returned no match for. Splitting the corpus by content type fixes both the bib lookup and clarifies the catalog shape.

## Approach (NO re-indexing, NO Voyage cost)

The 9,996 PDF chunks already had perfectly good embeddings in T3 chroma. The migration is metadata-only:

1. Read chunks (ids + embeddings + documents + metadatas) from `docs__ART-8c2e74c0` where `source_path` starts with `/docs/papers/`.
2. Rewrite each chunk's metadata: `title = derive_title(filename)`, `category = 'paper'`. Other fields preserved.
3. `coll.add(ids=..., embeddings=..., documents=..., metadatas=...)` to `knowledge__art-papers`. ChromaDB accepts pre-computed embeddings; no Voyage call.
4. Delete the same ids from `docs__ART-8c2e74c0`.
5. T2 document_aspects: SQL UPDATE `collection='knowledge__art-papers' WHERE source_path LIKE 'docs/papers/%'`. T2 has no JSONL split-brain; direct SQL is durable.
6. Catalog: `cat.update(tumbler, physical_collection=...)` for each of the 78 PDF rows. **The script initially used direct SQL UPDATE here and got bitten** — catalog SQLite is a cache of JSONL truth, so the next consistency rebuild reverted it. Using `cat.update()` appends to JSONL + SQLite atomically. Captured in the script's docstring as a gotcha for future migrations.

## Live results

| Layer | Result |
|---|---|
| T3 chunks | docs__ART: 15,790 → 5,794. knowledge__art-papers: 9,996. |
| Catalog rows | 78 paper entries under `knowledge__art-papers`; `audit-membership` shows single home, no contamination |
| T2 aspects | 78 rows, 77 populated (1 prior null-fields) |
| Bib (`nx enrich bib --source openalex`, no API key) | 75/78 OpenAlex matches; 9,518 chunks updated with `bib_openalex_id`, year, venue |
| Citation links | 1 (sparse — corpus only contains citing papers, not the cited works) |

## Caveats / followups

- **The catalog row's `title` column was not rewritten** (still has `docs/papers/X.pdf:page-1` placeholder). Cosmetic; doesn't affect search/aspects/bib enrichment.
- **`_catalog_enrich_hook` has a fallback bug** that prevented bib metadata from propagating to 74 of the 75 catalog rows post-enrich. The script used a side-call walking source_path → catalog row to backfill. Filed as **nexus-tv22**.

## Test plan

- [x] Live-run completed successfully against Hal's catalog (recorded in commit message + this PR).
- [x] `audit-membership knowledge__art-papers` shows 78 entries, single home, no contamination.
- [x] `nx enrich bib knowledge__art-papers` finds 75/78 OpenAlex matches (vs 0 in the original docs__ART form).
- [x] T3 chunk counts add up: 15,790 - 9,996 = 5,794 (matches docs__ART post-migration).
- [x] No em dashes in the script's prose.

## Closes

nexus-olg5