### PR TITLE
fix(enrich): catalog hook matches by source_path, drops LIMIT-1 fallback (nexus-tv22)

### DIFF
--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -153,6 +153,11 @@ def enrich_bib(
         _BATCH = 200
         updated_ids: list[str] = []
         updated_meta: list[dict] = []
+        # nexus-tv22: collect distinct source_paths in this title
+        # group so the catalog hook can match catalog rows by
+        # file_path (unambiguous) instead of by title (which drifts
+        # after derive_title rewrites in --from-t3 recovery).
+        source_paths: set[str] = set()
         for batch_start in range(0, len(chunk_ids), _BATCH):
             batch_ids = chunk_ids[batch_start:batch_start + _BATCH]
             fetch = _chroma_with_retry(col.get, ids=batch_ids, include=["metadatas"])
@@ -175,6 +180,9 @@ def enrich_bib(
                     )
                 updated_ids.append(cid)
                 updated_meta.append(merged)
+                sp = meta.get("source_path", "") if meta else ""
+                if sp:
+                    source_paths.add(sp)
 
         if updated_ids:
             for batch_start in range(0, len(updated_ids), _BATCH):
@@ -196,6 +204,7 @@ def enrich_bib(
             _catalog_enrich_hook(
                 title=title, bib_meta=bib,
                 collection_name=collection, backend=backend,
+                source_paths=sorted(source_paths),
             )
 
     backend_label = "Semantic Scholar" if backend == "s2" else "OpenAlex"
@@ -251,6 +260,7 @@ def _catalog_enrich_hook(
     bib_meta: dict,
     collection_name: str = "",
     backend: str = "s2",
+    source_paths: list[str] | None = None,
 ) -> None:
     """Update catalog entry with bib metadata. Silently skipped if absent.
 
@@ -258,9 +268,25 @@ def _catalog_enrich_hook(
     catalog meta. The OpenAlex backend writes ``bib_openalex_id`` (and
     ``bib_doi`` when present) so the citation-link generator can match
     references in OpenAlex's W-id space.
+
+    nexus-tv22: ``source_paths`` (the absolute paths of the chunks
+    being enriched) is the authoritative way to find the catalog row.
+    Title matching can drift after migrations that rewrite chunk
+    titles (e.g. derive_title) while leaving catalog row titles as
+    placeholders. Match by ``file_path`` (the catalog row's
+    relative-or-absolute path) against each ``source_path`` and apply
+    the update to every matching row.
+
+    The pre-fix LIMIT-1-on-collection fallback caused all 75 ART
+    enrich calls to clobber the same first row in the collection,
+    instead of finding the correct one per paper. That fallback is
+    removed: when no source_paths are supplied AND the title doesn't
+    match, the hook is a silent no-op rather than randomly picking a
+    row to corrupt.
     """
     try:
         from nexus.catalog import Catalog
+        from nexus.catalog.tumbler import Tumbler
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
@@ -269,48 +295,85 @@ def _catalog_enrich_hook(
 
         cat = Catalog(cat_path, cat_path / ".catalog.db")
 
-        # Look up by collection + title jointly for precision
-        entry = None
-        if collection_name:
-            from nexus.catalog.tumbler import Tumbler
+        target_tumblers: list[Tumbler] = []
+
+        # nexus-tv22: prefer source_path match (unique per document).
+        # Catalog rows store either absolute or relative file_path
+        # (relative is canonical post-RDR-060; absolute lingers from
+        # legacy ingests). Try both forms so the lookup works either
+        # way.
+        if source_paths:
+            for sp in source_paths:
+                if not sp:
+                    continue
+                rows = cat._db.execute(
+                    "SELECT tumbler FROM documents "
+                    "WHERE (physical_collection = ? OR ? = '') "
+                    "AND (file_path = ? OR file_path = ? "
+                    "OR ? LIKE '%/' || file_path)",
+                    (
+                        collection_name, collection_name,
+                        sp, sp.lstrip("/"), sp,
+                    ),
+                ).fetchall()
+                for (t_str,) in rows:
+                    target_tumblers.append(Tumbler.parse(t_str))
+
+        # Title match as fallback when source_paths are not provided
+        # (preserves backward compatibility with callers that haven't
+        # been updated yet — e.g. third-party scripts).
+        if not target_tumblers and collection_name:
             row = cat._db.execute(
-                "SELECT tumbler FROM documents WHERE physical_collection = ? AND title = ? LIMIT 1",
+                "SELECT tumbler FROM documents "
+                "WHERE physical_collection = ? AND title = ? LIMIT 1",
                 (collection_name, title),
             ).fetchone()
             if row:
-                entry = cat.resolve(Tumbler.parse(row[0]))
-            if entry is None:
-                # Fallback: collection-only (for renamed/enriched titles)
-                row = cat._db.execute(
-                    "SELECT tumbler FROM documents WHERE physical_collection = ? LIMIT 1",
-                    (collection_name,),
-                ).fetchone()
-                if row:
-                    entry = cat.resolve(Tumbler.parse(row[0]))
+                target_tumblers.append(Tumbler.parse(row[0]))
 
-        # Fallback to FTS title search (no collection context)
-        if entry is None:
+        # Last-resort FTS title search across the whole catalog
+        # (legacy path; only fires when the caller passed neither
+        # source_paths nor a title that matches inside the collection).
+        if not target_tumblers:
             entries = cat.find(title, content_type="paper")
-            entry = entries[0] if entries else None
+            if entries:
+                target_tumblers.append(entries[0].tumbler)
 
-        if entry:
-            meta_update: dict = {
-                "venue": bib_meta.get("venue", ""),
-                "citation_count": bib_meta.get("citation_count", 0),
-            }
-            if backend == "openalex":
-                meta_update["bib_openalex_id"] = bib_meta.get("openalex_id", "")
-                if bib_meta.get("doi"):
-                    meta_update["bib_doi"] = bib_meta.get("doi", "")
-            else:
-                meta_update["bib_semantic_scholar_id"] = bib_meta.get(
-                    "semantic_scholar_id", "",
-                )
-            refs = bib_meta.get("references", [])
-            if refs:
-                meta_update["references"] = refs
+        if not target_tumblers:
+            _log.debug(
+                "catalog_enrich_hook_no_match",
+                title=title,
+                collection=collection_name,
+                source_paths=source_paths or [],
+            )
+            return
+
+        # Build the update payload once, apply to every matched row.
+        meta_update: dict = {
+            "venue": bib_meta.get("venue", ""),
+            "citation_count": bib_meta.get("citation_count", 0),
+        }
+        if backend == "openalex":
+            meta_update["bib_openalex_id"] = bib_meta.get("openalex_id", "")
+            if bib_meta.get("doi"):
+                meta_update["bib_doi"] = bib_meta.get("doi", "")
+        else:
+            meta_update["bib_semantic_scholar_id"] = bib_meta.get(
+                "semantic_scholar_id", "",
+            )
+        refs = bib_meta.get("references", [])
+        if refs:
+            meta_update["references"] = refs
+
+        # Dedupe in case multiple source_paths matched the same row.
+        seen: set[str] = set()
+        for tumbler in target_tumblers:
+            key = str(tumbler)
+            if key in seen:
+                continue
+            seen.add(key)
             cat.update(
-                entry.tumbler,
+                tumbler,
                 author=bib_meta.get("authors", ""),
                 year=bib_meta.get("year", 0),
                 meta=meta_update,

--- a/tests/test_catalog_knowledge_hook.py
+++ b/tests/test_catalog_knowledge_hook.py
@@ -169,3 +169,192 @@ class TestEnrichHook:
 
         monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "no-catalog"))
         _catalog_enrich_hook(title="Test", bib_meta={})
+
+
+class TestEnrichHookSourcePathMatching:
+    """nexus-tv22: when chunk title and catalog title diverge (e.g. after
+    a migration that rewrites chunk titles via derive_title while
+    catalog rows retain their original placeholder titles), the hook
+    must NOT fall back to a LIMIT-1 collection-only match. That
+    fallback caused all 75 ART enrich calls to silently clobber the
+    same first row instead of finding the right one per paper.
+
+    Fix: caller passes ``source_paths`` (the unique identity of each
+    document on disk) and the hook matches by ``file_path``. The
+    chunk metadata always carries source_path; the catalog row's
+    ``file_path`` mirrors it (anchored relative to repo_root by the
+    nexus-3e4s register-time guard).
+    """
+
+    def test_source_path_match_picks_right_row_when_titles_differ(
+        self, tmp_path, monkeypatch,
+    ):
+        """Two papers in same collection. Titles in catalog don't
+        match the title used for bib lookup. Hook should still update
+        only the matching row, by source_path."""
+        from nexus.commands.enrich import _catalog_enrich_hook
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner(
+            "myproject", "repo", repo_hash="abcd1234",
+            repo_root="/tmp/myproject",
+        )
+        # Two papers, both with placeholder-shaped catalog titles
+        # (the post-migration drift state). The bib lookup will use
+        # the derive_title-shaped name which doesn't match either.
+        cat.register(
+            owner, "papers/A.pdf:page-1",
+            content_type="paper",
+            physical_collection="knowledge__myproject-papers",
+            file_path="papers/A.pdf",
+        )
+        cat.register(
+            owner, "papers/B.pdf:page-1",
+            content_type="paper",
+            physical_collection="knowledge__myproject-papers",
+            file_path="papers/B.pdf",
+        )
+
+        # Enrich paper A only.
+        _catalog_enrich_hook(
+            title="A Real Paper Title",  # placeholder-divergent
+            bib_meta={
+                "authors": "Author A",
+                "year": 2020,
+                "venue": "Venue A",
+                "openalex_id": "WAAA",
+                "references": ["WX", "WY"],
+            },
+            collection_name="knowledge__myproject-papers",
+            backend="openalex",
+            source_paths=["/tmp/myproject/papers/A.pdf"],
+        )
+
+        # Paper A has the new metadata.
+        entry_a = cat.by_file_path(owner, "papers/A.pdf")
+        assert entry_a is not None
+        assert entry_a.year == 2020
+        assert entry_a.author == "Author A"
+        assert entry_a.meta.get("bib_openalex_id") == "WAAA"
+        assert entry_a.meta.get("references") == ["WX", "WY"]
+
+        # Paper B is untouched (was the bug: the LIMIT-1 fallback
+        # clobbered the first-by-tumbler row regardless of identity).
+        entry_b = cat.by_file_path(owner, "papers/B.pdf")
+        assert entry_b is not None
+        assert entry_b.year == 0
+        assert entry_b.author == ""
+        assert entry_b.meta.get("bib_openalex_id", "") == ""
+
+    def test_source_paths_fan_out_across_multiple_rows(
+        self, tmp_path, monkeypatch,
+    ):
+        """One title group may map to multiple source_paths (rare but
+        legal — duplicate titles across files). Hook updates each."""
+        from nexus.commands.enrich import _catalog_enrich_hook
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner(
+            "myproject", "repo", repo_hash="abcd1234",
+            repo_root="/tmp/myproject",
+        )
+        cat.register(
+            owner, "Same Title",
+            content_type="paper",
+            physical_collection="knowledge__myproject-papers",
+            file_path="papers/A.pdf",
+        )
+        cat.register(
+            owner, "Same Title",
+            content_type="paper",
+            physical_collection="knowledge__myproject-papers",
+            file_path="papers/B.pdf",
+        )
+
+        _catalog_enrich_hook(
+            title="Same Title",
+            bib_meta={"year": 2021, "openalex_id": "WBOTH"},
+            collection_name="knowledge__myproject-papers",
+            backend="openalex",
+            source_paths=[
+                "/tmp/myproject/papers/A.pdf",
+                "/tmp/myproject/papers/B.pdf",
+            ],
+        )
+
+        a = cat.by_file_path(owner, "papers/A.pdf")
+        b = cat.by_file_path(owner, "papers/B.pdf")
+        assert a.year == 2021 and a.meta.get("bib_openalex_id") == "WBOTH"
+        assert b.year == 2021 and b.meta.get("bib_openalex_id") == "WBOTH"
+
+    def test_no_source_paths_no_silent_clobber(self, tmp_path, monkeypatch):
+        """Caller passes no source_paths and the title doesn't match
+        any catalog row. Hook must NOT clobber an arbitrary row.
+        Old behavior: LIMIT-1 fallback updated whichever row had the
+        smallest tumbler. New behavior: silent no-op."""
+        from nexus.commands.enrich import _catalog_enrich_hook
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner(
+            "myproject", "repo", repo_hash="abcd1234",
+            repo_root="/tmp/myproject",
+        )
+        cat.register(
+            owner, "X.pdf:page-1", content_type="paper",
+            physical_collection="knowledge__myproject-papers",
+            file_path="papers/X.pdf",
+        )
+
+        _catalog_enrich_hook(
+            title="Not Matching Anything",
+            bib_meta={"year": 2099, "openalex_id": "WBOGUS"},
+            collection_name="knowledge__myproject-papers",
+            backend="openalex",
+            source_paths=[],
+        )
+
+        entry = cat.by_file_path(owner, "papers/X.pdf")
+        assert entry.year == 0  # untouched
+        assert entry.meta.get("bib_openalex_id", "") == ""
+
+    def test_references_list_propagates_with_openalex(
+        self, tmp_path, monkeypatch,
+    ):
+        """The OpenAlex backend returns a ``references`` list
+        (W-id strings); the hook must persist it on the catalog row
+        so generate_citation_links can build cites edges. Pre-fix,
+        references were dropped on the hook's collection-only fallback
+        because that fallback used the wrong row."""
+        from nexus.commands.enrich import _catalog_enrich_hook
+
+        catalog_dir, cat = _make_catalog(tmp_path)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+
+        owner = cat.register_owner(
+            "p", "repo", repo_hash="abcd1234", repo_root="/tmp/p",
+        )
+        cat.register(
+            owner, "p.pdf:page-1", content_type="paper",
+            physical_collection="knowledge__p-papers",
+            file_path="papers/p.pdf",
+        )
+
+        _catalog_enrich_hook(
+            title="Real Title",
+            bib_meta={
+                "year": 2020, "openalex_id": "W1",
+                "references": ["WA", "WB", "WC"],
+            },
+            collection_name="knowledge__p-papers",
+            backend="openalex",
+            source_paths=["/tmp/p/papers/p.pdf"],
+        )
+
+        entry = cat.by_file_path(owner, "papers/p.pdf")
+        assert entry.meta.get("references") == ["WA", "WB", "WC"]


### PR DESCRIPTION
## Summary

`_catalog_enrich_hook` was matching by `(collection, title)` exact-match, then falling back to LIMIT-1 across the collection when the title didn't match. The fallback caused 74 of 75 ART `enrich-bib` calls to silently clobber the same first row in the collection because chunk titles had been rewritten by `derive_title` (during the nexus-olg5 migration) while catalog row titles retained placeholder shape (`'docs/papers/X.pdf:page-1'`). Result: 1 catalog row carried the metadata; 74 silently lost it.

## Fix

Callers now pass `source_paths` — the chunk metadata's `source_path` values, distinct per title group. The hook matches catalog rows by `file_path` against each source_path in absolute, leading-slash-stripped, and trailing-suffix forms so it works whether the catalog stores absolute or relative paths.

**The LIMIT-1 collection-only fallback is removed.** When no `source_paths` are supplied AND the title doesn't match, the hook is a silent no-op rather than randomly picking a row to corrupt.

Backward-compat preserved: title fallback still fires for callers that haven't been updated; FTS title search remains as a last resort for legacy paths.

## Side effects

- Multiple catalog rows can now be updated when a title group spans several files (rare but legal — duplicate titles across files). Each matching row gets the same bib metadata.
- The `references` list propagates correctly to matched catalog rows alongside `year`/`venue`/`openalex_id`, so `generate_citation_links` can build `cites` edges from a single enrich pass — no more manual references-refetch script.

## Test plan

- [x] **`TestEnrichHookSourcePathMatching`** (4 new cases):
  - `test_source_path_match_picks_right_row_when_titles_differ` — only the targeted source_path updates; the other row is untouched (was the bug).
  - `test_source_paths_fan_out_across_multiple_rows` — one title, multiple source_paths, all relevant rows update.
  - `test_no_source_paths_no_silent_clobber` — title-mismatch + empty source_paths = silent no-op (regression guard).
  - `test_references_list_propagates_with_openalex` — references list ends up on the catalog row, ready for citation linking.
- [x] 207 tests pass across `test_catalog_knowledge_hook.py`, `test_enrich_command.py`, `test_enrich_aspects.py`, `test_bib_enricher.py`, `test_bib_enricher_openalex.py`, `test_catalog_cli.py`, `test_catalog_db.py`, `test_catalog_backfill.py`, `test_catalog_audit_membership.py`. No regressions.
- [x] No em dashes in user-facing strings.
- [x] No AI attribution in commit message.

## Closes

nexus-tv22