### PR TITLE
fix(aspect): drop docs__ from extractor registry, revert of #377 (nexus-z70w)

### DIFF
--- a/src/nexus/aspect_extractor.py
+++ b/src/nexus/aspect_extractor.py
@@ -34,8 +34,9 @@ binding for the null-row DELETE migration):
   are the operator's signal that a real triage event happened
   (not a pre-RDR-096 ghost).
 
-Phase 1 ships exactly one extractor config — ``scholarly-paper-v1``,
-keyed on the ``knowledge__*`` collection prefix. Other prefixes
+Two extractor configs ship: ``scholarly-paper-v1`` (LLM-backed, keyed
+on ``knowledge__*``) and ``rdr-frontmatter-v1`` (deterministic parser,
+keyed on ``rdr__*``). Other prefixes (``docs__``, ``code__``, etc.)
 return ``None`` from ``extract_aspects``; the calling hook should
 no-op on ``None``.
 
@@ -252,15 +253,17 @@ _SCHOLARLY_PAPER_CONFIG = ExtractorConfig(
 
 _REGISTRY: dict[str, ExtractorConfig] = {
     "knowledge__": _SCHOLARLY_PAPER_CONFIG,
-    # docs__* (#377): markdown / ADR / design-doc collections produced
-    # by `nx index repo` hold the same kind of substantive prose that
-    # `knowledge__*` does — architecturally identical to scholarly
-    # papers from the aspect-extraction perspective. Reuse the same
-    # config so problem_formulation / proposed_method / etc. fields
-    # apply uniformly. If a dedicated docs-prose schema ever
-    # warrants splitting, the alias here can be replaced with a
-    # purpose-built ExtractorConfig.
-    "docs__": _SCHOLARLY_PAPER_CONFIG,
+    # docs__* — NOT registered (nexus-z70w reverted #377). docs__<repo>
+    # is populated by `nx index repo`, which sweeps any prose file in
+    # the tree: markdown docs, .dict dictionaries, .jsonl fixtures,
+    # .dot graphs. The 5-field paper schema (problem_formulation,
+    # method, datasets, baselines, results) doesn't fit any of these
+    # shapes, and scholarly-paper-v1 hallucinates structure when
+    # forced. Paper-shaped content in a repo should be ingested via
+    # `nx index pdf --collection knowledge__<repo>-papers` (the
+    # convention nexus-olg5 established for the ART corpus split).
+    # If a dedicated doc-summary extractor with the right schema
+    # ever lands, register it here.
     # rdr__* — pure-Python extractor (RDR-089 Phase F). RDRs carry
     # YAML frontmatter + labelled markdown sections; a deterministic
     # parser is more reliable and zero-cost compared to forcing the

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -456,8 +456,15 @@ def enrich_aspects(
         click.echo(
             f"No extractor config registered for collection "
             f"'{collection}'. Supported prefixes: knowledge__*, "
-            f"rdr__*, docs__*. Aborting."
+            f"rdr__*. Aborting."
         )
+        if collection.startswith("docs__"):
+            click.echo(
+                "Note: docs__* collections are not paper-shaped (nexus-z70w "
+                "reverted the #377 routing). Index academic PDFs into "
+                "knowledge__<name> via 'nx index pdf --collection "
+                "knowledge__<name>' for aspect extraction."
+            )
         return
 
     if re_extract and not extractor_version:

--- a/tests/test_aspect_extractor.py
+++ b/tests/test_aspect_extractor.py
@@ -117,18 +117,32 @@ class TestCollectionRouting:
         assert select_config("code__nexus") is None
         assert select_config("taxonomy__centroids") is None
 
-    def test_docs_prefix_routes_to_scholarly_config(self) -> None:
-        """#377: docs__* collections (markdown / ADR / design docs
-        from `nx index repo`) hold the same kind of substantive prose
-        as knowledge__*. They route to the same scholarly-paper-v1
-        config so problem_formulation / proposed_method / etc. apply
-        uniformly. Until #377 landed, docs__* was unconditionally
-        rejected with 'No extractor config registered'."""
+    def test_docs_prefix_returns_none_revert_of_377(self) -> None:
+        """nexus-z70w: revert of #377. docs__<repo> collections are
+        populated by ``nx index repo``, which sweeps ANY prose file:
+        markdown documentation, dictionary text (.dict), JSONL test
+        fixtures, dot graphs. None of these are paper-shaped, but
+        scholarly-paper-v1 happily hallucinates 5-field aspect rows
+        (problem_formulation / proposed_method / datasets / baselines
+        / results) on whatever it sees.
+
+        Live evidence (ART, 2026-04-30): pre-revert, 286 of 287
+        aspect rows extracted on docs__ART content where the input
+        was markdown documentation, .dict phonetic dictionaries, and
+        .jsonl test fixtures. All technically 'populated' but the
+        extracted fields were uniformly hallucinated against
+        non-paper input.
+
+        Post-revert: docs__* matches no config, so
+        ``nx enrich aspects docs__<X>`` short-circuits at the
+        select_config gate (same shape as code__<X> today). Papers
+        in a repo go through ``nx index pdf`` into
+        knowledge__<repo>-papers, which routes correctly.
+        """
         from nexus.aspect_extractor import select_config
 
-        config = select_config("docs__handbook")
-        assert config is not None
-        assert config.extractor_name == "scholarly-paper-v1"
+        assert select_config("docs__handbook") is None
+        assert select_config("docs__ART-8c2e74c0") is None
 
     def test_extract_aspects_returns_none_for_unsupported_collection(
         self, tmp_path: Path,

--- a/tests/test_enrich_aspects.py
+++ b/tests/test_enrich_aspects.py
@@ -407,17 +407,22 @@ class TestSourceUriResolutionForChromaLookup:
         # docs__ collections route through scholarly-paper-v1; that
         # config is registered in aspect_extractor's _REGISTRY for
         # ``docs__`` prefix at runtime — patch select_config to return
-        # a stub if needed.
+        # a stub if needed. nexus-z70w removed docs__ from the
+        # production _REGISTRY, so this test must seed a stub
+        # explicitly to exercise the LLM path.
         from nexus.aspect_extractor import ExtractorConfig, _REGISTRY
-        # Minimal config: parser_fn=None forces the LLM path that
-        # builds the chroma URI.
         if "docs__" not in _REGISTRY:
-            _REGISTRY["docs__"] = ExtractorConfig(
+            monkeypatch.setitem(_REGISTRY, "docs__", ExtractorConfig(
                 extractor_name="test-stub",
                 model_version="test",
-                parser_fn=None,
                 prompt_template="",
-            )
+                required_fields=(
+                    "problem_formulation", "proposed_method",
+                    "experimental_datasets", "experimental_baselines",
+                    "experimental_results",
+                ),
+                parser_fn=None,
+            ))
 
         runner = CliRunner()
         result = runner.invoke(


### PR DESCRIPTION
## Summary

#377 added `docs__ → scholarly-paper-v1` to the aspect extractor's `_REGISTRY` on the rationale that markdown / ADR / design-doc collections from `nx index repo` hold paper-shaped substantive prose. In practice, `docs__<repo>` collections sweep ANY prose file in the tree: markdown docs, `.dict` text dictionaries, `.jsonl` test fixtures, `.dot` graph files. None fit the 5-field paper schema, and scholarly-paper-v1 hallucinates structure when forced.

**Live evidence (ART, 2026-04-30)**: pre-revert, `nx enrich aspects docs__ART-8c2e74c0` produced 286 of 287 "populated" aspect rows against input including a CMU phonetic dictionary, JSONL determiner-noun agreement test fixtures, and dot-graph architecture diagrams. All technically populated; all hallucinated. ~$1 of the original $3.65 docs__ART enrichment was wasted on non-paper content.

## Fix

- Drop `docs__` from `_REGISTRY`. `select_config('docs__<X>')` now returns None, same shape as `code__<X>`.
- `nx enrich aspects docs__<X>` emits a follow-up note: *"docs__\* collections are not paper-shaped (nexus-z70w reverted the #377 routing). Index academic PDFs into knowledge__<name> via 'nx index pdf --collection knowledge__<name>' for aspect extraction."*
- The convention established by nexus-olg5 (split paper PDFs into `knowledge__<repo>-papers`) is now the explicit recommendation.

## Test plan

- [x] `test_docs_prefix_routes_to_scholarly_config` flipped to `test_docs_prefix_returns_none_revert_of_377` with empirical hallucination evidence in the docstring.
- [x] Pre-existing `TestSourceUriResolutionForChromaLookup.test_dry_run_uses_source_uri_abspath_when_available` test seeds a `docs__` stub at runtime via `monkeypatch.setitem` (since the production registry no longer has it).
- [x] 189 tests pass across `test_aspect_extractor.py`, `test_enrich_aspects.py`, `test_enrich_command.py`, `test_catalog_knowledge_hook.py`, `test_bib_enricher.py`, `test_bib_enricher_openalex.py`, `test_catalog_cli.py`.
- [x] Live smoke: `nx enrich aspects docs__ART-8c2e74c0` now returns the descriptive error + redirect note.
- [x] No em dashes in user-facing strings.
- [x] No AI attribution in commit message.

## Out of scope

A dedicated doc-summary extractor with a fitting schema (decision/context/consequences for ADRs, summary/sections for design docs) would be the right way to support `docs__` extraction. That's a separate feature; this PR is the immediate guardrail against re-accumulation of hallucinated rows.

## Closes

nexus-z70w