### PR TITLE
feat(enrich): DOI/arXiv-aware bib lookup before fuzzy title search (nexus-sbzr)

### DIFF
--- a/src/nexus/bib_enricher_openalex.py
+++ b/src/nexus/bib_enricher_openalex.py
@@ -61,6 +61,87 @@ def _strip_doi_prefix(value: str) -> str:
     return value
 
 
+def _build_result(work: dict) -> dict[str, Any]:
+    """Shared shape-builder. Maps an OpenAlex /works object to the
+    canonical bib_enricher result dict."""
+    authorships = work.get("authorships") or []
+    authors = ", ".join(
+        (a.get("author") or {}).get("display_name", "")
+        for a in authorships[:5]
+    )
+    primary = work.get("primary_location") or {}
+    source = (primary.get("source") or {}) if isinstance(primary, dict) else {}
+    venue = source.get("display_name", "") if isinstance(source, dict) else ""
+    referenced = work.get("referenced_works") or []
+    refs = [_strip_openalex_prefix(r) for r in referenced if r]
+    return {
+        "year": work.get("publication_year", 0) or 0,
+        "venue": venue or "",
+        "authors": authors or "",
+        "citation_count": work.get("cited_by_count", 0) or 0,
+        "openalex_id": _strip_openalex_prefix(work.get("id", "")) or "",
+        "doi": _strip_doi_prefix(work.get("doi", "") or ""),
+        "references": refs,
+    }
+
+
+def _direct_lookup(url: str) -> dict[str, Any]:
+    """Direct ``/works/<id>`` GET. Returns the canonical bib dict on
+    success, ``{}`` on failure (404, network error, malformed payload).
+    Same retry shape as :func:`enrich` for 429s."""
+    import time
+
+    params = {}
+    mailto = os.environ.get("OPENALEX_MAILTO", "").strip()
+    if mailto:
+        params["mailto"] = mailto
+
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            resp = httpx.get(url, params=params, timeout=_TIMEOUT)
+            if resp.status_code == 429 and attempt < _MAX_RETRIES:
+                wait = _BACKOFF_BASE * (2 ** attempt)
+                time.sleep(wait)
+                continue
+            resp.raise_for_status()
+            return _build_result(resp.json())
+        except (
+            httpx.HTTPError,
+            httpx.TimeoutException,
+            httpx.ConnectError,
+            ValueError,
+        ) as exc:
+            _log.debug("openalex_direct_lookup_failed", url=url, error=str(exc))
+            return {}
+    return {}
+
+
+def enrich_by_doi(doi: str) -> dict[str, Any]:
+    """Look up a paper by DOI directly. ``doi`` is the bare form
+    (``10.1145/X.Y``); the URL-prefixed form is also accepted.
+
+    Unambiguous: OpenAlex resolves DOIs without fuzzy matching, so
+    ``mfaz`` no longer becomes a 1996 Developmental Brain Research
+    paper. Returns ``{}`` on miss / network error / malformed payload.
+    """
+    if not doi:
+        return {}
+    bare = _strip_doi_prefix(doi)
+    return _direct_lookup(f"https://api.openalex.org/works/doi:{bare}")
+
+
+def enrich_by_arxiv_id(arxiv_id: str) -> dict[str, Any]:
+    """Look up a paper by arXiv ID directly. ``arxiv_id`` is the bare
+    form (``2503.07641``, no version suffix).
+
+    OpenAlex indexes arXiv preprints by their ID under the
+    ``arxiv:`` namespace. Unambiguous when the ID is on the paper.
+    """
+    if not arxiv_id:
+        return {}
+    return _direct_lookup(f"https://api.openalex.org/works/arxiv:{arxiv_id}")
+
+
 def enrich(title: str) -> dict[str, Any]:
     """Query OpenAlex for a paper matching ``title``.
 

--- a/src/nexus/bib_extractor.py
+++ b/src/nexus/bib_extractor.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""DOI + arXiv-ID extractors for paper text (nexus-sbzr).
+
+Filename slugs and PDF metadata titles are unreliable signals for
+identifying a paper at OpenAlex / Semantic Scholar (live evidence:
+``mfaz.pdf`` matched a 1996 Developmental Brain Research paper at
+OpenAlex via fuzzy title search). DOIs and arXiv IDs are
+authoritative — papers print them on page 1, and both backends
+support direct ID lookup with no fuzzy matching.
+
+This module pulls the canonical identifier out of body text (or the
+filename, for arXiv preprints distributed as ``<id>.pdf``). The
+caller in ``nx enrich bib`` tries DOI first, then arXiv ID, then
+falls back to title search.
+
+All functions are pure-Python regex; no PDF parsing, no network.
+"""
+from __future__ import annotations
+
+import re
+from typing import TypedDict
+
+# DOI structure (Crossref / DataCite spec):
+#   10.NNNN(N)?/<suffix>
+#   - registrant: 10.<4-9 digits>
+#   - separator: /
+#   - suffix: any character except whitespace; in practice
+#     [-._;()/:A-Z0-9]+ covers ACM, IEEE, Nature, Springer, arXiv-DOI.
+# Trailing punctuation (.,);] is stripped post-match because body
+# text often has 'see (10.1145/X.Y).' patterns where the closing
+# punctuation isn't part of the DOI.
+_DOI_RE = re.compile(
+    r"\b(10\.\d{4,9}/[-._;()/:a-z0-9]+)",
+    re.IGNORECASE,
+)
+_DOI_TRAILING_PUNCT = re.compile(r"[.,;:)\]]+$")
+
+
+def extract_doi(text: str) -> str | None:
+    """Return the first DOI in ``text``, or None.
+
+    Strips trailing punctuation that body text accumulates around
+    the identifier ('see (10.1145/X.Y).' yields ``10.1145/X.Y``).
+    """
+    if not text:
+        return None
+    match = _DOI_RE.search(text)
+    if not match:
+        return None
+    doi = match.group(1)
+    return _DOI_TRAILING_PUNCT.sub("", doi)
+
+
+# arXiv IDs (post-April-2007): YYMM.NNNNN with optional vN suffix.
+# YY = 07-99, MM = 01-12 in practice but we don't enforce — the
+# 4-digit-then-dot-then-4-or-5-digit shape is distinctive enough.
+# Body-text matches require either an explicit ``arXiv:`` prefix
+# or filename context; bare 8-digit patterns in prose are too
+# ambiguous (page numbers, dates, etc.).
+_ARXIV_BODY_RE = re.compile(
+    # Two disambiguating shapes:
+    #   1. ``arXiv:NNNN.NNNNN`` — the canonical citation form, with or
+    #      without a version suffix.
+    #   2. ``NNNN.NNNNNvN`` — bare ID with a mandatory ``vN`` version
+    #      suffix. The version suffix excludes random year.page patterns
+    #      ('Page 2024.34567') from matching.
+    r"\barxiv[: ]\s*(\d{4}\.\d{4,5})(?:v\d+)?\b"
+    r"|"
+    r"\b(\d{4}\.\d{4,5})v\d+\b",
+    re.IGNORECASE,
+)
+# Filename match: <prefix>?<id>.pdf where id is the YYMM.NNNNN form.
+# The optional prefix lets ``deep-artmap-2503.07641.pdf`` parse —
+# many publishers prepend a slug before the arXiv id when archiving.
+_ARXIV_FILENAME_RE = re.compile(
+    r"(?:^|[/\-_])(\d{4}\.\d{4,5})(?:v\d+)?\.pdf$",
+    re.IGNORECASE,
+)
+
+
+def extract_arxiv_id(text: str) -> str | None:
+    """Return the first arXiv ID in ``text`` (body or filename), or None.
+
+    Body-text matches require an explicit ``arXiv:`` prefix to avoid
+    false positives on year+page-number patterns. Filename matches
+    accept the bare ID form since arXiv distributes papers as
+    ``<id>.pdf`` and other publishers re-archive them with prefix
+    slugs (``deep-artmap-2503.07641.pdf``).
+    """
+    if not text:
+        return None
+    fn_match = _ARXIV_FILENAME_RE.search(text)
+    if fn_match:
+        return fn_match.group(1)
+    body_match = _ARXIV_BODY_RE.search(text)
+    if body_match:
+        # Two alternatives in the regex; whichever matched.
+        return body_match.group(1) or body_match.group(2)
+    return None
+
+
+class _Identifiers(TypedDict):
+    doi: str | None
+    arxiv: str | None
+
+
+def extract_identifiers(
+    *, filename: str = "", body_text: str = "",
+) -> _Identifiers:
+    """Combined entry point. Pulls both DOI and arXiv ID from the
+    available context (body text + filename).
+
+    The caller decides preference order: DOI is more authoritative
+    (resolves both arXiv preprints and non-arXiv venues); arXiv ID
+    is the fallback for arXiv-only papers without a registered DOI.
+    """
+    doi = extract_doi(body_text)
+    arxiv = extract_arxiv_id(filename) or extract_arxiv_id(body_text)
+    return {"doi": doi, "arxiv": arxiv}

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -90,8 +90,11 @@ def enrich_bib(
     db = make_t3()
     col = db.get_or_create_collection(collection)
 
-    # Process incrementally: one batch at a time to bound memory usage.
+    # nexus-sbzr: also collect source_paths per title group so we can
+    # try DOI / arXiv-ID extraction from chunk text before falling
+    # through to fuzzy title search at the backend.
     title_to_ids: dict[str, list[str]] = {}
+    title_to_source_paths: dict[str, set[str]] = {}
     already_enriched = 0
     total_chunks = 0
     offset = 0
@@ -113,6 +116,9 @@ def enrich_bib(
             if not title:
                 continue
             title_to_ids.setdefault(title, []).append(chunk_id)
+            sp = meta.get("source_path", "") or ""
+            if sp:
+                title_to_source_paths.setdefault(title, set()).add(sp)
         if len(batch_ids) < 300:
             break
         offset += 300
@@ -136,12 +142,25 @@ def enrich_bib(
     enriched_titles = 0
     enriched_chunks = 0
     skipped_titles = 0
+    by_id_count = 0  # how many titles resolved via DOI / arXiv (nexus-sbzr)
 
     for i, (title, chunk_ids) in enumerate(titles_to_process):
         if i > 0:
             time.sleep(delay)
 
-        bib = bib_enrich(title)
+        bib = _resolve_bib_for_title(
+            title=title,
+            chunk_ids=chunk_ids,
+            source_paths=sorted(title_to_source_paths.get(title, set())),
+            col=col,
+            backend=backend,
+            bib_enrich=bib_enrich,
+        )
+        if bib.get("_resolved_via") in ("doi", "arxiv"):
+            by_id_count += 1
+            bib = {k: v for k, v in bib.items() if k != "_resolved_via"}
+        elif "_resolved_via" in bib:
+            bib = {k: v for k, v in bib.items() if k != "_resolved_via"}
         if not bib:
             skipped_titles += 1
             _log.debug("enrich_no_result", title=title)
@@ -208,8 +227,12 @@ def enrich_bib(
             )
 
     backend_label = "Semantic Scholar" if backend == "s2" else "OpenAlex"
+    via_id_note = (
+        f" ({by_id_count} via DOI/arXiv ID)" if by_id_count else ""
+    )
     click.echo(
-        f"Done: enriched {enriched_chunks} chunks across {enriched_titles} titles; "
+        f"Done: enriched {enriched_chunks} chunks across "
+        f"{enriched_titles} titles{via_id_note}; "
         f"{skipped_titles} titles had no {backend_label} match."
     )
 
@@ -229,6 +252,83 @@ def enrich_bib(
                     click.echo(f"Auto-generated {link_count} citation links in catalog.")
         except Exception:
             _log.debug("auto_citation_links_failed", exc_info=True)
+
+
+def _resolve_bib_for_title(
+    *,
+    title: str,
+    chunk_ids: list,
+    source_paths: list[str],
+    col,
+    backend: str,
+    bib_enrich,
+) -> dict:
+    """nexus-sbzr: DOI/arXiv-aware lookup with title fallback.
+
+    Tries identifiers in order:
+      1. DOI extracted from first chunk's body text -> openalex by-doi
+      2. arXiv ID from filename or first chunk text -> openalex by-arxiv
+      3. Title search at the backend (current behavior)
+
+    Returns the bib dict with a synthetic ``_resolved_via`` key
+    indicating which path produced the result (caller strips before
+    storage). Empty dict on miss across all three paths.
+
+    DOI/arXiv lookups are OpenAlex-only today; the S2 backend skips
+    straight to title search. If S2 ever adds direct-DOI lookup we
+    can extend the dispatcher.
+    """
+    if backend != "openalex":
+        bib = bib_enrich(title)
+        if bib:
+            bib["_resolved_via"] = "title"
+        return bib or {}
+
+    from nexus.bib_enricher_openalex import enrich_by_arxiv_id, enrich_by_doi
+    from nexus.bib_extractor import extract_identifiers
+    from nexus.retry import _chroma_with_retry
+
+    # Read first chunk text per source_path. One per title is enough
+    # in practice — papers rarely span multiple source_paths under
+    # one title — but try all if needed to find an identifier.
+    body_text = ""
+    filename = ""
+    if chunk_ids:
+        try:
+            head = _chroma_with_retry(
+                col.get, ids=chunk_ids[:1],
+                include=["documents", "metadatas"],
+            )
+            docs = head.get("documents") or []
+            metas = head.get("metadatas") or []
+            if docs and docs[0]:
+                body_text = docs[0][:8000]  # 8 KB enough for header/abstract
+            if metas and metas[0]:
+                filename = (metas[0] or {}).get("source_path", "")
+        except Exception as exc:
+            _log.debug("enrich_first_chunk_fetch_failed", title=title, error=str(exc))
+
+    # Filename fallback when chunk metadata didn't carry source_path.
+    if not filename and source_paths:
+        filename = source_paths[0]
+
+    ids = extract_identifiers(filename=filename, body_text=body_text)
+
+    if ids["doi"]:
+        bib = enrich_by_doi(ids["doi"])
+        if bib:
+            bib["_resolved_via"] = "doi"
+            return bib
+    if ids["arxiv"]:
+        bib = enrich_by_arxiv_id(ids["arxiv"])
+        if bib:
+            bib["_resolved_via"] = "arxiv"
+            return bib
+
+    bib = bib_enrich(title)
+    if bib:
+        bib["_resolved_via"] = "title"
+    return bib or {}
 
 
 def _resolve_bib_backend(source: str) -> tuple[str, callable, str]:

--- a/tests/test_bib_enricher_openalex.py
+++ b/tests/test_bib_enricher_openalex.py
@@ -252,3 +252,101 @@ def test_enrich_anonymous_when_mailto_missing(monkeypatch):
         enrich("Paper")
 
     assert "mailto" not in captured["params"]
+
+
+# ── nexus-sbzr: direct-by-id lookups ────────────────────────────────────────
+
+
+def test_enrich_by_doi_calls_correct_endpoint():
+    from nexus.bib_enricher_openalex import enrich_by_doi
+
+    captured: list[str] = []
+
+    def _capture(url, *args, **kwargs):
+        captured.append(url)
+        return _make_response(200, _VALID_WORK)
+
+    with patch("httpx.get", side_effect=_capture):
+        result = enrich_by_doi("10.5555/3295222.3295349")
+
+    assert captured == ["https://api.openalex.org/works/doi:10.5555/3295222.3295349"]
+    assert result["openalex_id"] == "W2741809807"
+    assert result["year"] == 2017
+    assert result["doi"] == "10.5555/3295222.3295349"
+
+
+def test_enrich_by_doi_strips_url_prefix():
+    """If caller passes ``https://doi.org/10.x/y`` the helper still
+    constructs the bare-DOI endpoint URL."""
+    from nexus.bib_enricher_openalex import enrich_by_doi
+
+    captured: list[str] = []
+
+    def _capture(url, *args, **kwargs):
+        captured.append(url)
+        return _make_response(200, _VALID_WORK)
+
+    with patch("httpx.get", side_effect=_capture):
+        enrich_by_doi("https://doi.org/10.5555/3295222.3295349")
+
+    assert "doi:10.5555/3295222.3295349" in captured[0]
+    assert "doi.org" not in captured[0]
+
+
+def test_enrich_by_doi_returns_empty_on_404():
+    from nexus.bib_enricher_openalex import enrich_by_doi
+
+    with patch("httpx.get", return_value=_make_response(404, {"error": "not found"})):
+        assert enrich_by_doi("10.x/missing") == {}
+
+
+def test_enrich_by_doi_empty_input_returns_empty():
+    from nexus.bib_enricher_openalex import enrich_by_doi
+
+    assert enrich_by_doi("") == {}
+    assert enrich_by_doi(None) == {}  # type: ignore[arg-type]
+
+
+def test_enrich_by_arxiv_id_calls_correct_endpoint():
+    from nexus.bib_enricher_openalex import enrich_by_arxiv_id
+
+    captured: list[str] = []
+
+    def _capture(url, *args, **kwargs):
+        captured.append(url)
+        return _make_response(200, _VALID_WORK)
+
+    with patch("httpx.get", side_effect=_capture):
+        result = enrich_by_arxiv_id("2503.07641")
+
+    assert captured == ["https://api.openalex.org/works/arxiv:2503.07641"]
+    assert result["openalex_id"] == "W2741809807"
+
+
+def test_enrich_by_arxiv_id_returns_empty_on_404():
+    from nexus.bib_enricher_openalex import enrich_by_arxiv_id
+
+    with patch("httpx.get", return_value=_make_response(404, {})):
+        assert enrich_by_arxiv_id("9999.99999") == {}
+
+
+def test_enrich_by_arxiv_id_empty_input_returns_empty():
+    from nexus.bib_enricher_openalex import enrich_by_arxiv_id
+
+    assert enrich_by_arxiv_id("") == {}
+
+
+def test_direct_lookup_includes_mailto(monkeypatch):
+    from nexus.bib_enricher_openalex import enrich_by_doi
+
+    monkeypatch.setenv("OPENALEX_MAILTO", "test@example.com")
+    captured: dict = {}
+
+    def _capture(url, *args, **kwargs):
+        captured.update(kwargs)
+        return _make_response(200, _VALID_WORK)
+
+    with patch("httpx.get", side_effect=_capture):
+        enrich_by_doi("10.x/y")
+
+    assert captured["params"]["mailto"] == "test@example.com"

--- a/tests/test_bib_extractor.py
+++ b/tests/test_bib_extractor.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Tests for nexus.bib_extractor (nexus-sbzr).
+
+DOI + arXiv ID regex extractors. These run against PDF body text to
+find the paper's canonical identifier before falling back to fuzzy
+title search at OpenAlex/Semantic Scholar. Filename slugs (e.g.
+``mfaz.pdf``) are too short to disambiguate via title-search; a DOI
+or arXiv ID guarantees the right paper.
+
+All extraction is text-only — no network, no PDF re-parsing.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── DOI extraction ──────────────────────────────────────────────────────────
+
+
+class TestExtractDoi:
+    def test_extracts_acm_doi(self) -> None:
+        from nexus.bib_extractor import extract_doi
+
+        text = "Published at SIGMOD 2024. DOI: 10.1145/3654657.3654729"
+        assert extract_doi(text) == "10.1145/3654657.3654729"
+
+    def test_extracts_ieee_doi(self) -> None:
+        from nexus.bib_extractor import extract_doi
+
+        text = "doi:10.1109/ICDE.2024.00123\nAuthors: ..."
+        assert extract_doi(text) == "10.1109/ICDE.2024.00123"
+
+    def test_extracts_nature_doi(self) -> None:
+        from nexus.bib_extractor import extract_doi
+
+        text = "https://doi.org/10.1038/s41586-021-04096-9"
+        assert extract_doi(text) == "10.1038/s41586-021-04096-9"
+
+    def test_extracts_first_doi_when_multiple(self) -> None:
+        """Papers often cite other DOIs in their references. The
+        canonical paper-DOI is on page 1 (header / footer / abstract)
+        and we want THAT one, not a citation. Take the first match."""
+        from nexus.bib_extractor import extract_doi
+
+        text = (
+            "Title of Paper\nDOI: 10.1145/AAAA.BBBB\n"
+            "References:\n[1] 10.1109/CCCC.DDDD\n[2] 10.1038/EEEE.FFFF"
+        )
+        assert extract_doi(text) == "10.1145/AAAA.BBBB"
+
+    def test_handles_arxiv_doi_form(self) -> None:
+        from nexus.bib_extractor import extract_doi
+
+        text = "arXiv:2503.07641. doi: 10.48550/arXiv.2503.07641"
+        assert extract_doi(text) == "10.48550/arXiv.2503.07641"
+
+    def test_strips_trailing_punctuation(self) -> None:
+        """DOIs in body text often end with comma/period/parenthesis
+        (e.g. 'see [42] (10.1145/X.Y).'). Strip those — they aren't
+        part of the DOI."""
+        from nexus.bib_extractor import extract_doi
+
+        for trailing in (".", ",", ");", ")", ";", "]", ":"):
+            assert extract_doi(f"see DOI 10.1145/A.B{trailing}") == "10.1145/A.B"
+
+    def test_returns_none_when_no_doi(self) -> None:
+        from nexus.bib_extractor import extract_doi
+
+        assert extract_doi("Just a paper with no DOI listed.") is None
+        assert extract_doi("") is None
+        assert extract_doi("10.123/x") is None  # too few digits in registrant
+        assert extract_doi("not.a.doi/at-all") is None
+
+    def test_case_insensitive(self) -> None:
+        from nexus.bib_extractor import extract_doi
+
+        text = "DOI: 10.1109/ABC.2024.012345"
+        assert extract_doi(text) == "10.1109/ABC.2024.012345"
+
+
+# ── arXiv ID extraction ─────────────────────────────────────────────────────
+
+
+class TestExtractArxivId:
+    def test_extracts_new_style_id(self) -> None:
+        """New-style arXiv IDs (post-April-2007): YYMM.NNNNN(vN)?
+        4-digit YYMM + 4-or-5-digit serial."""
+        from nexus.bib_extractor import extract_arxiv_id
+
+        assert extract_arxiv_id("Submitted as arXiv:2503.07641") == "2503.07641"
+        assert extract_arxiv_id("see 1706.03762v5 for details") == "1706.03762"
+
+    def test_extracts_from_filename(self) -> None:
+        """ArXiv often distributes papers as <id>.pdf, so the
+        filename alone identifies them."""
+        from nexus.bib_extractor import extract_arxiv_id
+
+        assert extract_arxiv_id("/papers/2503.07641.pdf") == "2503.07641"
+        assert extract_arxiv_id("deep-artmap-2503.07641.pdf") == "2503.07641"
+
+    def test_returns_none_when_absent(self) -> None:
+        from nexus.bib_extractor import extract_arxiv_id
+
+        assert extract_arxiv_id("just text with no arxiv id") is None
+        assert extract_arxiv_id("") is None
+        assert extract_arxiv_id("see paper 12.345") is None  # too few digits
+        assert extract_arxiv_id("see paper 12345.6789") is None  # too many YYMM digits
+
+    def test_does_not_match_on_random_8_digit_strings(self) -> None:
+        """Year+page-number patterns like '2024.34567' shouldn't match
+        unless preceded by 'arXiv:' or appearing as a filename."""
+        from nexus.bib_extractor import extract_arxiv_id
+
+        # A standalone 4-digit.5-digit pattern is ambiguous; require
+        # the arXiv: prefix or filename context for safety.
+        assert extract_arxiv_id("Page 2024.34567 of the chapter") is None
+
+    def test_strips_version_suffix(self) -> None:
+        from nexus.bib_extractor import extract_arxiv_id
+
+        assert extract_arxiv_id("arXiv:1706.03762v5") == "1706.03762"
+        assert extract_arxiv_id("arXiv:1706.03762v15") == "1706.03762"
+
+
+# ── Combined extractor ──────────────────────────────────────────────────────
+
+
+class TestExtractIdentifiers:
+    """The combined entry point picks the best identifier available
+    for a (filename, body_text) pair. Order: DOI > arXiv ID > None.
+    DOI is more authoritative because it can resolve arXiv preprints
+    AND non-arXiv venues; arXiv IDs only work for arXiv papers."""
+
+    def test_prefers_doi_over_arxiv(self) -> None:
+        from nexus.bib_extractor import extract_identifiers
+
+        ids = extract_identifiers(
+            filename="2503.07641.pdf",
+            body_text="DOI: 10.48550/arXiv.2503.07641\narXiv:2503.07641",
+        )
+        assert ids["doi"] == "10.48550/arXiv.2503.07641"
+        assert ids["arxiv"] == "2503.07641"
+
+    def test_arxiv_only(self) -> None:
+        from nexus.bib_extractor import extract_identifiers
+
+        ids = extract_identifiers(
+            filename="paper.pdf",
+            body_text="See arXiv:1706.03762 for the original.",
+        )
+        assert ids["doi"] is None
+        assert ids["arxiv"] == "1706.03762"
+
+    def test_doi_only(self) -> None:
+        from nexus.bib_extractor import extract_identifiers
+
+        ids = extract_identifiers(
+            filename="paper.pdf",
+            body_text="DOI: 10.1109/X.Y",
+        )
+        assert ids["doi"] == "10.1109/X.Y"
+        assert ids["arxiv"] is None
+
+    def test_both_none(self) -> None:
+        from nexus.bib_extractor import extract_identifiers
+
+        ids = extract_identifiers(filename="paper.pdf", body_text="just text")
+        assert ids == {"doi": None, "arxiv": None}

--- a/tests/test_enrich_command.py
+++ b/tests/test_enrich_command.py
@@ -212,6 +212,96 @@ def test_enrich_source_auto_falls_back_to_openalex_without_s2_key(
     mock_oa.assert_called_once_with("Paper Auto")
 
 
+@patch("nexus.bib_enricher_openalex.enrich_by_doi")
+@patch("nexus.bib_enricher_openalex.enrich")
+@patch("nexus.db.make_t3")
+def test_enrich_openalex_prefers_doi_over_title_search(
+    mock_t3_factory: MagicMock,
+    mock_title: MagicMock,
+    mock_doi: MagicMock,
+) -> None:
+    """nexus-sbzr: when chunk text contains a DOI, the enricher must
+    look up by DOI directly and skip the fuzzy title search. This
+    prevents 'mfaz.pdf' from matching a 1996 Developmental Brain
+    Research paper at OpenAlex."""
+    mock_doi.return_value = {
+        "year": 2024, "venue": "VLDB", "authors": "Author X",
+        "citation_count": 7, "openalex_id": "WDOI",
+        "doi": "10.1145/X.Y", "references": [],
+    }
+    mock_col = MagicMock()
+    mock_col.get.side_effect = [
+        # 1: chunk scan
+        {"ids": ["c1"], "metadatas": [{
+            "title": "mfaz", "source_path": "/papers/mfaz.pdf",
+        }]},
+        # 2: first chunk text fetch (for ID extraction)
+        {"ids": ["c1"],
+         "documents": ["Title. Authors A, B.\nDOI: 10.1145/X.Y\nAbstract..."],
+         "metadatas": [{"title": "mfaz", "source_path": "/papers/mfaz.pdf"}]},
+        # 3: chunk-merge fetch
+        {"ids": ["c1"], "metadatas": [{
+            "title": "mfaz", "source_path": "/papers/mfaz.pdf",
+        }]},
+    ]
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.return_value = mock_col
+    mock_t3_factory.return_value = mock_db
+
+    runner = CliRunner()
+    result = runner.invoke(
+        enrich,
+        ["bib", "knowledge__test", "--delay", "0", "--source", "openalex"],
+    )
+    assert result.exit_code == 0, result.output
+    mock_doi.assert_called_once_with("10.1145/X.Y")
+    mock_title.assert_not_called()
+    assert "via DOI/arXiv ID" in result.output
+
+
+@patch("nexus.bib_enricher_openalex.enrich_by_arxiv_id")
+@patch("nexus.bib_enricher_openalex.enrich_by_doi")
+@patch("nexus.bib_enricher_openalex.enrich")
+@patch("nexus.db.make_t3")
+def test_enrich_openalex_falls_back_to_arxiv_when_no_doi(
+    mock_t3_factory: MagicMock,
+    mock_title: MagicMock,
+    mock_doi: MagicMock,
+    mock_arxiv: MagicMock,
+) -> None:
+    """No DOI in text + arXiv-shaped filename -> by-arXiv lookup,
+    not title search."""
+    mock_doi.return_value = {}
+    mock_arxiv.return_value = {
+        "year": 2017, "venue": "NeurIPS", "authors": "V et al.",
+        "citation_count": 90000, "openalex_id": "WARX",
+        "doi": "", "references": [],
+    }
+    mock_col = MagicMock()
+    mock_col.get.side_effect = [
+        {"ids": ["c1"], "metadatas": [{
+            "title": "Attention", "source_path": "/papers/1706.03762.pdf",
+        }]},
+        {"ids": ["c1"], "documents": ["Abstract, no DOI here."],
+         "metadatas": [{"title": "Attention", "source_path": "/papers/1706.03762.pdf"}]},
+        {"ids": ["c1"], "metadatas": [{
+            "title": "Attention", "source_path": "/papers/1706.03762.pdf",
+        }]},
+    ]
+    mock_db = MagicMock()
+    mock_db.get_or_create_collection.return_value = mock_col
+    mock_t3_factory.return_value = mock_db
+
+    runner = CliRunner()
+    result = runner.invoke(
+        enrich, ["bib", "knowledge__test", "--delay", "0", "--source", "openalex"],
+    )
+    assert result.exit_code == 0, result.output
+    mock_arxiv.assert_called_once_with("1706.03762")
+    mock_title.assert_not_called()
+    assert "via DOI/arXiv ID" in result.output
+
+
 @patch("nexus.db.make_t3")
 @patch("nexus.bib_enricher.enrich")
 @patch("nexus.bib_enricher_openalex.enrich")


### PR DESCRIPTION
## Summary

Title-search at OpenAlex/Semantic Scholar produces wrong-paper matches when the chunk title is a short filename slug. **Live evidence on knowledge__delos**: `mfaz.pdf` matched a 1996 *Developmental Brain Research* paper (wrong field); `Aging Bloom Filter...` matched a *Nature Reviews Drug Discovery* paper. The mechanism worked but identity resolution was the bottleneck.

DOIs and arXiv IDs are authoritative — papers print them on page 1, and OpenAlex supports direct ID lookup with no fuzzy matching. This PR adds extractor + by-id lookups + CLI integration.

## What changed

**`src/nexus/bib_extractor.py`** (new):
- `extract_doi(text)` — first DOI in body, strips trailing punctuation, case-insensitive.
- `extract_arxiv_id(text)` — handles `arXiv:NNNN.NNNNN`, `NNNN.NNNNNvN`, and filename forms (`2503.07641.pdf`, `deep-artmap-2503.07641.pdf`).
- `extract_identifiers(filename, body_text)` — combined entry point.

**`bib_enricher_openalex.py`**:
- `enrich_by_doi(doi)` — direct `/works/doi:X.Y` lookup. Strips URL prefix if present.
- `enrich_by_arxiv_id(arxiv_id)` — direct `/works/arxiv:NNNN.NNNNN` lookup.
- Both use the same retry shape as `enrich()` (5s/10s/20s backoff on 429) and shared `_build_result` helper.

**`nx enrich bib` (OpenAlex backend)**: per title group, fetches first chunk text, extracts DOI then arXiv ID, dispatches to direct lookup. Title search only fires when neither identifier is present. Summary line shows `(X via DOI/arXiv ID)` count.

S2 backend still uses title search exclusively (S2 has different direct-ID endpoints; extending the dispatcher is out of scope). Auto-mode picks the right backend based on `S2_API_KEY`.

## Test plan

- [x] **`test_bib_extractor.py`** (17 cases): DOI ACM/IEEE/Nature/arXiv-DOI shapes, trailing-punctuation strip, multiple DOIs (first wins), arXiv new-style + filename + version-suffix forms, no-match, case-insensitivity, combined extractor preference.
- [x] **`test_bib_enricher_openalex.py`** (8 new cases): by-doi endpoint shape, URL-prefix-strip, 404, empty input, by-arxiv endpoint, by-arxiv 404, mailto plumbing on direct lookups.
- [x] **`test_enrich_command.py`** (2 new cases): DOI in chunk text routes to `enrich_by_doi` (title search not called); no-DOI + arXiv filename routes to `enrich_by_arxiv_id`; summary line surfaces the via-ID count.
- [x] **141 tests pass** across bib + enrich + aspect + catalog suites. No regressions.
- [x] No em dashes in user-facing strings.
- [x] No AI attribution in commit message.

## Closes

nexus-sbzr