### PR TITLE
feat(dt): route PDFs to knowledge__ by default, not docs__ (nexus-cvaw)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -214,9 +214,11 @@ nx dt index --selection --dry-run
 | `--smart-group <name>` | Run the smart group's saved query and index its results |
 | `--uuid <UUID>` | Index a single record; repeat for batch ingest |
 | `--database <name>` | Limit selectors to one DT library (default: every open library) |
-| `--collection <name>` | T3 collection override (e.g. `knowledge__papers`) |
-| `--corpus <name>` | Corpus name for `docs__` collection (default: `default`) |
+| `--collection <name>` | T3 collection override. Wins over the extension-based default (e.g. `--collection knowledge__delos`) |
+| `--corpus <name>` | Corpus name used to derive the default collection (default: `dt`). PDFs route to `knowledge__<corpus>-papers` (paper-shaped, aspect-eligible); markdown notes route to `docs__<corpus>` |
 | `--dry-run` | Print records that would be indexed; make no T3 writes |
+
+**Default routing by extension** (nexus-cvaw): `nx dt index --uuid X` without `--collection` picks the home based on file type. PDFs land in `knowledge__<corpus>-papers` so `nx enrich aspects` can extract structured fields via `scholarly-paper-v1`. Markdown notes land in `docs__<corpus>` (no aspect extraction; `docs__` is reserved for non-paper prose per nexus-z70w). Pre-nexus-cvaw both extensions defaulted to `docs__default`, which stranded paper PDFs.
 
 Multi-database default is the right behaviour for tags shared across
 libraries (a `nexus-test` tag in both `Inbox` and a project library

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -36,6 +36,33 @@ _log = structlog.get_logger(__name__)
 _SUPPORTED_EXTS: frozenset[str] = frozenset({".pdf", ".md"})
 
 
+def _resolve_dt_collection(
+    collection: str | None, corpus: str, ext: str,
+) -> str:
+    """nexus-cvaw: pick the right T3 collection for a DT-sourced record.
+
+    ``--collection X`` always wins (operator override). Otherwise:
+
+    * PDF (``.pdf``) -> ``knowledge__<corpus>-papers``. Paper-shaped
+      content goes to a knowledge__ collection so scholarly-paper-v1
+      can aspect-extract it.
+    * Markdown (``.md``) -> ``docs__<corpus>``. Notes / clippings /
+      doc-shaped content goes to docs__, which deliberately doesn't
+      route to any aspect extractor (nexus-z70w).
+
+    Pre-nexus-cvaw default was ``docs__default`` for both extensions,
+    which stranded paper PDFs ingested via ``nx dt index`` (no aspect
+    eligibility, no curated home). The split-by-extension default
+    matches the corpus split established by nexus-olg5 (ART papers
+    in knowledge__art-papers, ART repo docs in docs__ART-...).
+    """
+    if collection:
+        return collection
+    if ext == ".pdf":
+        return f"knowledge__{corpus}-papers"
+    return f"docs__{corpus}"
+
+
 def _index_record(
     uuid: str,
     path: str,
@@ -217,13 +244,24 @@ def dt() -> None:
 @click.option(
     "--collection",
     default=None,
-    help="T3 collection override (e.g. knowledge__papers). Forwarded to the underlying indexer.",
+    help=(
+        "T3 collection override. Wins over the extension-based "
+        "default. e.g. ``--collection knowledge__delos``."
+    ),
 )
 @click.option(
     "--corpus",
-    default="default",
+    default="dt",
     show_default=True,
-    help="Corpus name for docs__ collection (used when --collection is not set).",
+    help=(
+        "Corpus name used to derive the default collection when "
+        "--collection is not set. PDFs route to "
+        "``knowledge__<corpus>-papers`` (paper-shaped, aspect-eligible "
+        "via scholarly-paper-v1); markdown notes route to "
+        "``docs__<corpus>``. Pre-nexus-cvaw the default was "
+        "``default`` and PDFs landed in ``docs__default`` where "
+        "aspect extraction is intentionally disabled (nexus-z70w)."
+    ),
 )
 @click.option(
     "--dry-run",
@@ -301,10 +339,11 @@ def index_cmd(
             )
             skipped += 1
             continue
+        resolved_collection = _resolve_dt_collection(collection, corpus, ext)
         stamped = _index_record(
             uuid,
             path,
-            collection=collection,
+            collection=resolved_collection,
             corpus=corpus,
             dry_run=False,
         )

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -372,6 +372,87 @@ class TestPassthroughFlags:
         assert fake_dispatcher[0]["corpus"] == "knowledge"
 
 
+# ── nexus-cvaw: paper PDFs route to knowledge__ by default ──────────────────
+
+
+class TestDefaultCollectionByExtension:
+    """nexus-cvaw: nx dt index without --collection should pick a
+    paper-shaped home for PDFs (knowledge__<corpus>-papers, where
+    aspect extraction routes to scholarly-paper-v1) and a doc-shaped
+    home for markdown (docs__<corpus>). Pre-fix, both extensions
+    landed in docs__<corpus>, which after nexus-z70w (PR #393)
+    cannot route to any aspect extractor. PDFs ingested by the
+    default were stranded.
+
+    Tests assert the resolved collection_name passed to the
+    fake dispatcher, since the per-record routing is what determines
+    the paper's downstream eligibility for aspects + bib enrichment.
+    """
+
+    def test_pdf_default_routes_to_knowledge_papers(
+        self, runner, fake_selectors, fake_dispatcher,
+    ):
+        from nexus.cli import main
+
+        fake_selectors["selection"].return_value = [("U", "/foo/paper.pdf")]
+        result = runner.invoke(main, ["dt", "index", "--selection"])
+        assert result.exit_code == 0, result.output
+        # No --collection: PDF default is knowledge__dt-papers.
+        assert fake_dispatcher[0]["collection"] == "knowledge__dt-papers"
+
+    def test_pdf_with_corpus_routes_to_knowledge_papers_corpus(
+        self, runner, fake_selectors, fake_dispatcher,
+    ):
+        from nexus.cli import main
+
+        fake_selectors["selection"].return_value = [("U", "/foo/paper.pdf")]
+        result = runner.invoke(main, [
+            "dt", "index", "--selection", "--corpus", "rag",
+        ])
+        assert result.exit_code == 0, result.output
+        assert fake_dispatcher[0]["collection"] == "knowledge__rag-papers"
+
+    def test_markdown_default_routes_to_docs_dt(
+        self, runner, fake_selectors, fake_dispatcher,
+    ):
+        from nexus.cli import main
+
+        fake_selectors["selection"].return_value = [("U", "/foo/note.md")]
+        result = runner.invoke(main, ["dt", "index", "--selection"])
+        assert result.exit_code == 0, result.output
+        # Markdown notes go to docs__<corpus> (current behavior, but
+        # corpus default flipped from "default" to "dt" so the note
+        # corpus matches the paper corpus by convention).
+        assert fake_dispatcher[0]["collection"] == "docs__dt"
+
+    def test_markdown_with_corpus_routes_to_docs_corpus(
+        self, runner, fake_selectors, fake_dispatcher,
+    ):
+        from nexus.cli import main
+
+        fake_selectors["selection"].return_value = [("U", "/foo/note.md")]
+        result = runner.invoke(main, [
+            "dt", "index", "--selection", "--corpus", "rag",
+        ])
+        assert result.exit_code == 0, result.output
+        assert fake_dispatcher[0]["collection"] == "docs__rag"
+
+    def test_explicit_collection_overrides_default(
+        self, runner, fake_selectors, fake_dispatcher,
+    ):
+        """``--collection X`` always wins over the extension-based
+        default — the operator has explicitly requested X."""
+        from nexus.cli import main
+
+        fake_selectors["selection"].return_value = [("U", "/foo/paper.pdf")]
+        result = runner.invoke(main, [
+            "dt", "index", "--selection",
+            "--collection", "knowledge__custom-thing",
+        ])
+        assert result.exit_code == 0, result.output
+        assert fake_dispatcher[0]["collection"] == "knowledge__custom-thing"
+
+
 # ── Error handling ───────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`nx dt index --uuid X` without `--collection` landed every record in `docs__default`. After **nexus-z70w** (PR #393) `docs__` collections deliberately don't route to any aspect extractor, so paper PDFs ingested via the default were stranded — no aspect eligibility, no curated home.

**Live evidence (CacheRAG, 2026-04-30)**: `nx dt index` of an 18-page RAG paper landed in `docs__default`. `nx enrich aspects` refused. Required a manual migration to `knowledge__rag-papers` (174-chunk metadata-only move) before the paper could be aspect-extracted and topic-discovered.

## Fix

New `_resolve_dt_collection(collection, corpus, ext)` helper picks the right home by file extension when no override:

| Extension | Resolved collection |
|---|---|
| `.pdf` | `knowledge__<corpus>-papers` (paper-shaped, aspect-eligible via `scholarly-paper-v1`) |
| `.md` | `docs__<corpus>` (notes / clippings; no aspect extraction per nexus-z70w) |

Default `--corpus` flipped from `default` to `dt` so the new defaults are coherent: `knowledge__dt-papers` + `docs__dt`. `--collection X` override always wins.

## Behavior change

`nx dt index` without flags now puts PDFs in `knowledge__dt-papers` (was `docs__default`). The override path (`--collection X`) preserves the old behavior for anyone who wants `docs__` placement explicitly.

## Test plan

- [x] **`TestDefaultCollectionByExtension`** (5 new cases): PDF default, PDF with `--corpus`, markdown default, markdown with `--corpus`, explicit `--collection` override.
- [x] 50 `test_commands_dt.py` tests pass; 90 across dt + dt-install-scripts + devonthink suites. No regressions.
- [x] CLI help reflects the new defaults.
- [x] `docs/cli-reference.md` updated with the new defaults + extension-routing note.
- [x] No em dashes in user-facing strings.
- [x] No AI attribution in commit message.

## Closes

nexus-cvaw