### PR TITLE
feat(enrich): aspects-show + aspects-list read verbs (nexus-bkvk)

### DIFF
--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -12,6 +12,7 @@ single command. Migration: ``nx enrich <coll>`` → ``nx enrich bib
 """
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 
@@ -1305,3 +1306,259 @@ def enrich_aspects_promote_field(
     click.echo(f"Backfilled {result.rows_backfilled} row(s).")
     if result.pruned:
         click.echo(f"Pruned {result.rows_pruned} extras key(s).")
+
+
+# ── nexus-bkvk: aspect read verbs (show / list) ─────────────────────────────
+
+
+_ASPECT_FIELDS: tuple[str, ...] = (
+    "problem_formulation",
+    "proposed_method",
+    "experimental_datasets",
+    "experimental_baselines",
+    "experimental_results",
+    "extras",
+    "confidence",
+)
+
+
+def _resolve_catalog_entry(tumbler_or_title: str):
+    """Resolve a tumbler or title to (catalog, entry). Raises
+    ClickException on miss."""
+    from nexus.catalog import Catalog, resolve_tumbler
+    from nexus.config import catalog_path
+
+    cat_path = catalog_path()
+    if not Catalog.is_initialized(cat_path):
+        raise click.ClickException(
+            "Catalog not initialized. Run 'nx catalog setup' first."
+        )
+    cat = Catalog(cat_path, cat_path / ".catalog.db")
+    t, err = resolve_tumbler(cat, tumbler_or_title)
+    if err:
+        raise click.ClickException(err)
+    entry = cat.resolve(t)
+    if entry is None:
+        raise click.ClickException(f"Not found: {tumbler_or_title}")
+    return cat, entry
+
+
+def _aspect_to_dict(record) -> dict:
+    """Serialize an AspectRecord for --json output."""
+    return {
+        "collection": record.collection,
+        "source_path": record.source_path,
+        "problem_formulation": record.problem_formulation,
+        "proposed_method": record.proposed_method,
+        "experimental_datasets": list(record.experimental_datasets or []),
+        "experimental_baselines": list(record.experimental_baselines or []),
+        "experimental_results": record.experimental_results,
+        "extras": dict(record.extras or {}),
+        "confidence": record.confidence,
+        "extracted_at": record.extracted_at,
+        "model_version": record.model_version,
+        "extractor_name": record.extractor_name,
+        "source_uri": record.source_uri,
+    }
+
+
+def _print_aspect_record(record, *, field: str = "") -> None:
+    """Human-readable formatter for `aspects-show`. ``field`` projects
+    a single aspect field (raw value, no labels)."""
+    if field:
+        if field not in _ASPECT_FIELDS:
+            raise click.ClickException(
+                f"Unknown field {field!r}. Choose from: {', '.join(_ASPECT_FIELDS)}"
+            )
+        value = getattr(record, field)
+        if isinstance(value, (list, dict)):
+            click.echo(json.dumps(value, indent=2))
+        elif value is None:
+            click.echo("")
+        else:
+            click.echo(value)
+        return
+
+    click.echo(f"Collection:     {record.collection}")
+    click.echo(f"Source path:    {record.source_path}")
+    click.echo(f"Source URI:     {record.source_uri or '(legacy: not set)'}")
+    click.echo(f"Extractor:      {record.extractor_name} ({record.model_version})")
+    click.echo(f"Extracted at:   {record.extracted_at}")
+    click.echo(f"Confidence:     {record.confidence if record.confidence is not None else '(null)'}")
+    click.echo("")
+    click.echo("--- Aspects ---")
+    click.echo("")
+    click.echo(f"problem_formulation:")
+    click.echo(f"  {record.problem_formulation or '(empty)'}")
+    click.echo("")
+    click.echo(f"proposed_method:")
+    click.echo(f"  {record.proposed_method or '(empty)'}")
+    click.echo("")
+    click.echo(f"experimental_datasets:  {record.experimental_datasets or '[]'}")
+    click.echo(f"experimental_baselines: {record.experimental_baselines or '[]'}")
+    click.echo("")
+    click.echo(f"experimental_results:")
+    click.echo(f"  {record.experimental_results or '(empty)'}")
+    click.echo("")
+    if record.extras:
+        click.echo("extras:")
+        click.echo(json.dumps(record.extras, indent=2))
+
+
+@enrich.command(name="aspects-show")
+@click.argument("tumbler_or_title")
+@click.option(
+    "--json", "as_json", is_flag=True,
+    help="Emit JSON instead of human-readable form.",
+)
+@click.option(
+    "--field", default="",
+    help=(
+        "Project a single aspect field (problem_formulation, "
+        "proposed_method, experimental_datasets, "
+        "experimental_baselines, experimental_results, extras, "
+        "confidence). Output is the raw value."
+    ),
+)
+def aspects_show_cmd(tumbler_or_title: str, as_json: bool, field: str) -> None:
+    """Display the aspect record for a single document.
+
+    nexus-bkvk: pre-this-verb the only way to inspect aspects was raw
+    SQL against ~/.config/nexus/memory.db. Resolves the tumbler (or
+    title) via the catalog, looks up the aspect row by
+    ``(physical_collection, file_path)``, and renders all fields.
+    """
+    from nexus.commands._helpers import default_db_path
+    from nexus.db.t2 import T2Database
+
+    _, entry = _resolve_catalog_entry(tumbler_or_title)
+    if not entry.physical_collection or not entry.file_path:
+        click.echo(
+            f"No aspect record for tumbler {entry.tumbler}: catalog "
+            "row has no physical_collection or file_path. Run "
+            "'nx enrich aspects <COLLECTION>' to extract."
+        )
+        return
+
+    with T2Database(default_db_path()) as db:
+        record = db.document_aspects.get(
+            entry.physical_collection, entry.file_path,
+        )
+
+    if record is None:
+        click.echo(
+            f"No aspect record extracted yet for tumbler "
+            f"{entry.tumbler} ({entry.title!r}). Run "
+            f"'nx enrich aspects {entry.physical_collection}' to extract."
+        )
+        return
+
+    if as_json:
+        click.echo(json.dumps(_aspect_to_dict(record), indent=2))
+        return
+    _print_aspect_record(record, field=field)
+
+
+@enrich.command(name="aspects-list")
+@click.option(
+    "--collection", required=True,
+    help="T3 collection to inspect (e.g. knowledge__papers).",
+)
+@click.option(
+    "--limit", default=20, show_default=True,
+    help="Maximum rows to display (0 = unlimited).",
+)
+@click.option(
+    "--missing", is_flag=True,
+    help=(
+        "Flip output: list catalog rows in COLLECTION that have NO "
+        "aspect record. Used to find gaps after partial enrichment."
+    ),
+)
+@click.option(
+    "--json", "as_json", is_flag=True,
+    help="Emit JSON array instead of human-readable form.",
+)
+def aspects_list_cmd(
+    collection: str, limit: int, missing: bool, as_json: bool,
+) -> None:
+    """List aspect records for COLLECTION, or the gaps with --missing.
+
+    nexus-bkvk: companion to aspects-show; gives the same data at
+    collection-level (preview/audit shape) instead of single-record
+    detail. With ``--missing`` the verb inverts to gap detection:
+    catalog rows in COLLECTION that don't have a matching aspect row.
+    """
+    from nexus.catalog import Catalog
+    from nexus.commands._helpers import default_db_path
+    from nexus.config import catalog_path
+    from nexus.db.t2 import T2Database
+
+    if missing:
+        cat_path = catalog_path()
+        if not Catalog.is_initialized(cat_path):
+            raise click.ClickException(
+                "Catalog not initialized. Run 'nx catalog setup' first."
+            )
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
+        entries = cat.list_by_collection(collection)
+        with T2Database(default_db_path()) as db:
+            existing = {
+                r.source_path for r in db.document_aspects.list_by_collection(
+                    collection,
+                )
+            }
+        gaps = [e for e in entries if e.file_path and e.file_path not in existing]
+        if as_json:
+            click.echo(json.dumps([
+                {
+                    "tumbler": str(e.tumbler),
+                    "title": e.title,
+                    "file_path": e.file_path,
+                }
+                for e in gaps
+            ], indent=2))
+            return
+        if not gaps:
+            click.echo(
+                f"No missing aspects in '{collection}': every catalog "
+                f"row has an extracted aspect record."
+            )
+            return
+        click.echo(
+            f"{len(gaps)} catalog row(s) in '{collection}' have no "
+            f"aspect record:"
+        )
+        for e in gaps[:limit] if limit else gaps:
+            click.echo(f"  {e.tumbler}  {e.file_path}")
+        if limit and len(gaps) > limit:
+            click.echo(f"  ... and {len(gaps) - limit} more.")
+        return
+
+    with T2Database(default_db_path()) as db:
+        records = db.document_aspects.list_by_collection(
+            collection, limit=(limit if limit else None),
+        )
+
+    if as_json:
+        click.echo(json.dumps(
+            [_aspect_to_dict(r) for r in records], indent=2,
+        ))
+        return
+
+    if not records:
+        click.echo(
+            f"No aspect records in '{collection}'. Run "
+            f"'nx enrich aspects {collection}' to extract."
+        )
+        return
+
+    click.echo(f"{len(records)} aspect record(s) in '{collection}':")
+    click.echo("")
+    for r in records:
+        problem = (r.problem_formulation or "")[:80]
+        method = (r.proposed_method or "")[:80]
+        click.echo(f"  {r.source_path}")
+        click.echo(f"    problem: {problem}{'...' if r.problem_formulation and len(r.problem_formulation) > 80 else ''}")
+        click.echo(f"    method:  {method}{'...' if r.proposed_method and len(r.proposed_method) > 80 else ''}")
+        click.echo("")

--- a/tests/test_enrich_aspects_read.py
+++ b/tests/test_enrich_aspects_read.py
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Tests for ``nx enrich aspects-show`` + ``nx enrich aspects-list`` (nexus-bkvk).
+
+The read-side companions to ``nx enrich aspects`` (batch extract).
+Pre-this-PR the only way to inspect extracted aspects was raw SQL
+against ``~/.config/nexus/memory.db``. These verbs surface the
+data via the CLI for human + script consumption.
+
+* ``aspects-show <TUMBLER>`` — display one document's full aspect
+  record. ``--json`` for structured output, ``--field <name>`` for
+  single-field projection.
+* ``aspects-list --collection X`` — tabular preview of all rows in
+  a collection. ``--missing`` flips to "catalog rows without aspect
+  rows" for gap detection. ``--json`` for structured output.
+
+Tumbler resolution reuses ``_resolve_tumbler`` so ``aspects-show``
+accepts both tumblers and titles, matching ``nx catalog show``.
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.aspect_extractor import AspectRecord
+from nexus.catalog import Catalog
+from nexus.commands.enrich import enrich
+from nexus.db.t2 import T2Database
+
+
+@pytest.fixture(autouse=True)
+def _git_identity(monkeypatch):
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
+
+@pytest.fixture()
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Tmp catalog + tmp T2 + plumbing patches."""
+    catalog_dir = tmp_path / "catalog"
+    cat = Catalog.init(catalog_dir)
+    db_path = tmp_path / "t2.db"
+
+    import nexus.config
+    monkeypatch.setattr(nexus.config, "catalog_path", lambda: catalog_dir)
+    import nexus.commands._helpers as h
+    monkeypatch.setattr(h, "default_db_path", lambda: db_path)
+    return catalog_dir, db_path, cat
+
+
+def _seed_one(env, *, source_path: str = "docs/papers/p.pdf") -> str:
+    """Register a paper-shaped catalog row + write its aspect record.
+    Returns the tumbler string."""
+    cat_dir, db_path, cat = env
+    owner = cat.register_owner(
+        "myrepo", "repo", repo_hash="abcd1234",
+        repo_root="/tmp/myrepo",
+    )
+    t = cat.register(
+        owner, "Sample Paper",
+        content_type="paper",
+        physical_collection="knowledge__myrepo-papers",
+        file_path=source_path,
+    )
+    rec = AspectRecord(
+        collection="knowledge__myrepo-papers",
+        source_path=source_path,
+        problem_formulation="Stale-reads in multi-region replicas.",
+        proposed_method="Vector-clock + bounded staleness reads with WAL replay.",
+        experimental_datasets=["YCSB-A", "TPC-C"],
+        experimental_baselines=["raft", "paxos-quorum"],
+        experimental_results="2.3x throughput at p99=120ms vs raft baseline.",
+        extras={"venue": "VLDB 2024", "ablations_present": True},
+        confidence=0.92,
+        extracted_at=datetime.now(UTC).isoformat(),
+        model_version="claude-haiku-4-5-20251001",
+        extractor_name="scholarly-paper-v1",
+        source_uri=f"file:///tmp/myrepo/{source_path}",
+    )
+    with T2Database(db_path) as db:
+        db.document_aspects.upsert(rec)
+    return str(t)
+
+
+# ── aspects-show ────────────────────────────────────────────────────────────
+
+
+class TestAspectsShow:
+    def test_show_displays_all_fields_by_tumbler(self, env) -> None:
+        tumbler = _seed_one(env)
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["aspects-show", tumbler])
+        assert result.exit_code == 0, result.output
+        # All 7 aspect fields surface in the output.
+        for marker in (
+            "Stale-reads in multi-region",
+            "Vector-clock + bounded",
+            "YCSB-A",
+            "raft",
+            "2.3x throughput",
+            "VLDB 2024",
+            "0.92",
+        ):
+            assert marker in result.output, f"missing {marker!r} in output"
+        # Extractor metadata also visible.
+        assert "scholarly-paper-v1" in result.output
+        assert "claude-haiku-4-5" in result.output
+
+    def test_show_resolves_by_title(self, env) -> None:
+        _seed_one(env)
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["aspects-show", "Sample Paper"])
+        assert result.exit_code == 0, result.output
+        assert "Stale-reads" in result.output
+
+    def test_show_json_emits_structured(self, env) -> None:
+        tumbler = _seed_one(env)
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["aspects-show", tumbler, "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["collection"] == "knowledge__myrepo-papers"
+        assert data["problem_formulation"].startswith("Stale-reads")
+        assert data["experimental_datasets"] == ["YCSB-A", "TPC-C"]
+        assert data["experimental_baselines"] == ["raft", "paxos-quorum"]
+        assert data["extras"]["venue"] == "VLDB 2024"
+        assert data["confidence"] == 0.92
+
+    def test_show_field_projection(self, env) -> None:
+        tumbler = _seed_one(env)
+        runner = CliRunner()
+        result = runner.invoke(
+            enrich, ["aspects-show", tumbler, "--field", "proposed_method"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Vector-clock" in result.output
+        # Other fields are NOT in projection output.
+        assert "YCSB-A" not in result.output
+        assert "scholarly-paper-v1" not in result.output
+
+    def test_show_unknown_field_errors(self, env) -> None:
+        tumbler = _seed_one(env)
+        runner = CliRunner()
+        result = runner.invoke(
+            enrich, ["aspects-show", tumbler, "--field", "made_up"],
+        )
+        assert result.exit_code != 0
+        assert "made_up" in result.output
+
+    def test_show_no_aspect_record_friendly_message(self, env) -> None:
+        """Catalog row exists but no aspect data extracted yet."""
+        cat_dir, db_path, cat = env
+        owner = cat.register_owner(
+            "myrepo", "repo", repo_hash="abcd1234",
+            repo_root="/tmp/myrepo",
+        )
+        t = cat.register(
+            owner, "Empty Paper",
+            content_type="paper",
+            physical_collection="knowledge__myrepo-papers",
+            file_path="docs/papers/empty.pdf",
+        )
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["aspects-show", str(t)])
+        assert result.exit_code == 0
+        assert "no aspect" in result.output.lower() or "not extracted" in result.output.lower()
+        # And nudge the operator to the extract verb.
+        assert "nx enrich aspects" in result.output
+
+    def test_show_unknown_tumbler_errors(self, env) -> None:
+        runner = CliRunner()
+        result = runner.invoke(enrich, ["aspects-show", "1.99.99"])
+        assert result.exit_code != 0
+
+
+# ── aspects-list ────────────────────────────────────────────────────────────
+
+
+class TestAspectsList:
+    def _seed_many(self, env, paths: list[str]) -> None:
+        cat_dir, db_path, cat = env
+        owner = cat.register_owner(
+            "myrepo", "repo", repo_hash="abcd1234",
+            repo_root="/tmp/myrepo",
+        )
+        with T2Database(db_path) as db:
+            for sp in paths:
+                cat.register(
+                    owner, Path(sp).stem,
+                    content_type="paper",
+                    physical_collection="knowledge__myrepo-papers",
+                    file_path=sp,
+                )
+                db.document_aspects.upsert(AspectRecord(
+                    collection="knowledge__myrepo-papers",
+                    source_path=sp,
+                    problem_formulation=f"Problem of {Path(sp).stem}",
+                    proposed_method=f"Method of {Path(sp).stem}",
+                    experimental_datasets=[],
+                    experimental_baselines=[],
+                    experimental_results="",
+                    extras={},
+                    confidence=0.5,
+                    extracted_at=datetime.now(UTC).isoformat(),
+                    model_version="m",
+                    extractor_name="scholarly-paper-v1",
+                ))
+
+    def test_list_returns_all_rows_in_collection(self, env) -> None:
+        self._seed_many(env, [
+            "docs/papers/a.pdf",
+            "docs/papers/b.pdf",
+            "docs/papers/c.pdf",
+        ])
+        runner = CliRunner()
+        result = runner.invoke(
+            enrich, ["aspects-list", "--collection", "knowledge__myrepo-papers"],
+        )
+        assert result.exit_code == 0, result.output
+        for name in ("a.pdf", "b.pdf", "c.pdf"):
+            assert name in result.output
+        assert "Problem of a" in result.output
+
+    def test_list_limit_caps_output(self, env) -> None:
+        self._seed_many(env, [
+            f"docs/papers/p{i}.pdf" for i in range(5)
+        ])
+        runner = CliRunner()
+        result = runner.invoke(enrich, [
+            "aspects-list",
+            "--collection", "knowledge__myrepo-papers",
+            "--limit", "2",
+        ])
+        assert result.exit_code == 0, result.output
+        # Two of the five sources appear, three are absent.
+        appearances = sum(
+            1 for i in range(5) if f"p{i}.pdf" in result.output
+        )
+        assert appearances == 2
+
+    def test_list_missing_shows_catalog_rows_without_aspects(self, env) -> None:
+        """``--missing`` filters to catalog rows in the collection that
+        have NO matching aspect record. Used to find gaps after partial
+        enrichment runs."""
+        cat_dir, db_path, cat = env
+        owner = cat.register_owner(
+            "myrepo", "repo", repo_hash="abcd1234",
+            repo_root="/tmp/myrepo",
+        )
+        # 3 catalog rows; only the first has aspects.
+        for i, sp in enumerate(("docs/papers/has.pdf",
+                                 "docs/papers/missing1.pdf",
+                                 "docs/papers/missing2.pdf")):
+            cat.register(
+                owner, Path(sp).stem,
+                content_type="paper",
+                physical_collection="knowledge__myrepo-papers",
+                file_path=sp,
+            )
+        with T2Database(db_path) as db:
+            db.document_aspects.upsert(AspectRecord(
+                collection="knowledge__myrepo-papers",
+                source_path="docs/papers/has.pdf",
+                problem_formulation="x", proposed_method="y",
+                experimental_datasets=[], experimental_baselines=[],
+                experimental_results="", extras={}, confidence=0.5,
+                extracted_at=datetime.now(UTC).isoformat(),
+                model_version="m", extractor_name="scholarly-paper-v1",
+            ))
+
+        runner = CliRunner()
+        result = runner.invoke(enrich, [
+            "aspects-list",
+            "--collection", "knowledge__myrepo-papers",
+            "--missing",
+        ])
+        assert result.exit_code == 0, result.output
+        # Both gaps surface; the seeded one does NOT.
+        assert "missing1.pdf" in result.output
+        assert "missing2.pdf" in result.output
+        assert "has.pdf" not in result.output
+
+    def test_list_json_emits_array(self, env) -> None:
+        self._seed_many(env, ["docs/papers/a.pdf", "docs/papers/b.pdf"])
+        runner = CliRunner()
+        result = runner.invoke(enrich, [
+            "aspects-list",
+            "--collection", "knowledge__myrepo-papers",
+            "--json",
+        ])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 2
+        assert {d["source_path"] for d in data} == {
+            "docs/papers/a.pdf", "docs/papers/b.pdf",
+        }
+
+    def test_list_empty_collection_friendly_message(self, env) -> None:
+        runner = CliRunner()
+        result = runner.invoke(enrich, [
+            "aspects-list", "--collection", "knowledge__no-such",
+        ])
+        assert result.exit_code == 0
+        assert "no aspect" in result.output.lower() or "0" in result.output


### PR DESCRIPTION
## Summary

`aspect_extractor` populates `document_aspects` in T2 with structured fields, but pre-this-PR the only way to inspect them was raw SQL against `~/.config/nexus/memory.db`. Two new verbs surface the data via the CLI.

## What changed

- **`nx enrich aspects-show <TUMBLER_OR_TITLE>`**: display one document's full aspect record (problem_formulation, proposed_method, experimental_datasets, experimental_baselines, experimental_results, extras, confidence) plus extractor metadata. `--json` for structured output, `--field NAME` for single-field projection.

- **`nx enrich aspects-list --collection X`**: tabular preview of all aspect records in a collection, with truncated problem + method previews. `--limit N` caps output. `--missing` flips to gap detection (catalog rows in the collection without aspect rows). `--json` for structured output.

Tumbler resolution reuses `resolve_tumbler` so both verbs accept tumblers and titles, matching `nx catalog show`'s contract.

The new verbs are siblings of the existing aspects extractor, not a sub-group, so no breaking change to `nx enrich aspects <COLL>`.

## Test plan

- [x] **`TestAspectsShow`** (7 cases): tumbler resolution, title resolution, `--json` shape, `--field` projection, unknown-field error, no-aspect-row friendly message (with redirect to `nx enrich aspects` extract verb), unknown-tumbler error.
- [x] **`TestAspectsList`** (5 cases): all-rows listing, `--limit` cap, `--missing` gap detection, `--json` array shape, empty-collection friendly message.
- [x] 68 tests pass across enrich aspects + enrich command + catalog hook suites. No regressions.
- [x] **Live verified** on `knowledge__rag-papers` (CacheRAG paper, tumbler `1.653.83`): `aspects-show` renders all 7 fields plus 11 extras; `aspects-list` gives the collection-level preview.
- [x] No em dashes in user-facing strings.
- [x] No AI attribution in commit message.

## Closes

nexus-bkvk