### PR TITLE
fix(catalog): nx catalog update --source-uri emits clean error, not traceback (nexus-fb6x)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -538,8 +538,15 @@ def update_cmd(
             entries = cat.find(search_query)
         if not entries:
             raise click.ClickException("No entries matched")
-        for entry in entries:
-            cat.update(entry.tumbler, **fields)
+        try:
+            for entry in entries:
+                cat.update(entry.tumbler, **fields)
+        except ValueError as exc:
+            # nexus-fb6x: source_uri / file_path validation can raise
+            # ValueError (unknown scheme, malformed URI, owner-root
+            # mismatch). Re-raise as ClickException so the operator
+            # sees a clean error line instead of a stack trace.
+            raise click.ClickException(str(exc)) from exc
         click.echo(f"Updated {len(entries)} entries")
         return
 
@@ -547,7 +554,11 @@ def update_cmd(
     if not tumbler:
         raise click.ClickException("Provide a tumbler/title or use --owner/--search for batch")
     t = _resolve_tumbler(cat, tumbler)
-    cat.update(t, **fields)
+    try:
+        cat.update(t, **fields)
+    except ValueError as exc:
+        # nexus-fb6x: same UX-cleanup as the batch path.
+        raise click.ClickException(str(exc)) from exc
     click.echo(f"Updated: {t}")
 
 

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -361,7 +361,13 @@ class TestUpdateCommand:
     ):
         """Unknown URI schemes are rejected at the register-boundary
         validator (``_normalize_source_uri``); the CLI must surface
-        the failure cleanly rather than silently persist garbage."""
+        the failure cleanly rather than silently persist garbage.
+
+        nexus-fb6x: pre-fix, the ValueError propagated uncaught and
+        the operator saw a 30-line Python stack trace. Post-fix, the
+        CLI catches and re-raises as ClickException so the output is
+        a clean ``Error: unknown source_uri scheme '...'`` line.
+        """
         runner = CliRunner()
         runner.invoke(main, [
             "catalog", "register",
@@ -374,6 +380,10 @@ class TestUpdateCommand:
             "--source-uri", "imaginary-scheme://nope",
         ])
         assert result.exit_code != 0
+        # nexus-fb6x: friendly message present, no traceback leak.
+        assert "unknown" in result.output.lower()
+        assert "imaginary-scheme" in result.output
+        assert "Traceback" not in result.output
 
 
 class TestDeleteCommand:


### PR DESCRIPTION
## Summary

`_normalize_source_uri` raises `ValueError` on unknown URI schemes / malformed URIs / owner-root mismatch. `update_cmd` called `cat.update()` without catching, so the exception propagated through Click's handler unmodified — operators saw a 30-line Python stack trace instead of the friendly `Error: unknown source_uri scheme '...'` line.

## Fix

Wrap both call sites (single-tumbler + batch via `--owner`/`--search`) in `try/except ValueError -> ClickException(str(e))`. The underlying error message already names the offending scheme and lists known schemes, so the re-raised `ClickException` is fully informative.

## Test plan

- [x] `test_update_source_uri_validates_scheme` strengthened: asserts `unknown` in lower-cased output, the bad scheme name appears verbatim, and `Traceback` is absent.
- [x] 75 catalog CLI tests pass.
- [x] **Live verified**: `nx catalog update 1.653.83 --source-uri imaginary-scheme://nope` now emits a single-line clean error.
- [x] No em dashes in user-facing strings.
- [x] No AI attribution in commit message.

## Closes

nexus-fb6x