### PR TITLE
fix(bib-openalex): validate returned title against source (nexus-yy1m)

### DIFF
--- a/src/nexus/bib_enricher_openalex.py
+++ b/src/nexus/bib_enricher_openalex.py
@@ -63,7 +63,12 @@ def _strip_doi_prefix(value: str) -> str:
 
 def _build_result(work: dict) -> dict[str, Any]:
     """Shared shape-builder. Maps an OpenAlex /works object to the
-    canonical bib_enricher result dict."""
+    canonical bib_enricher result dict.
+
+    The transient ``_lookup_title`` field carries the OpenAlex
+    ``display_name`` so callers (or :func:`_direct_lookup`) can
+    validate identity post-lookup. It is stripped before storage.
+    """
     authorships = work.get("authorships") or []
     authors = ", ".join(
         (a.get("author") or {}).get("display_name", "")
@@ -82,13 +87,87 @@ def _build_result(work: dict) -> dict[str, Any]:
         "openalex_id": _strip_openalex_prefix(work.get("id", "")) or "",
         "doi": _strip_doi_prefix(work.get("doi", "") or ""),
         "references": refs,
+        "_lookup_title": work.get("display_name", "") or "",
     }
 
 
-def _direct_lookup(url: str) -> dict[str, Any]:
+# nexus-yy1m: title-validation post-lookup. The DOI/arXiv-aware lookup
+# (PR #394 / #395 / #396) trusts whatever identifier shows up in the
+# document body, but academic papers have entire reference lists with
+# DOIs that belong to OTHER papers. v4.21.0 shakeout caught this: a
+# CacheRAG preprint without its own DOI got a citation DOI extracted
+# and stamped with the citation's metadata. The validator below is the
+# fallback gate: if the OpenAlex-returned title shares too few
+# substantive tokens with the source title, reject the result so the
+# caller falls through to fuzzy title search.
+
+# Stopwords kept short. Punctuation strip + lowercase + length>=4 token
+# filter does most of the work, and over-aggressive stopwording just
+# undershoots the "are these the same paper" question.
+_TITLE_STOPWORDS: frozenset[str] = frozenset({
+    "with", "from", "into", "this", "that", "these", "those",
+    "their", "them", "they", "your", "yours", "ours", "have",
+    "been", "being", "such", "what", "when", "where", "which",
+    "while", "without", "within", "about", "above", "after",
+    "before", "between", "during", "through", "based", "over",
+    "under",
+})
+
+# Jaccard threshold tuned so:
+#   * exact / near-duplicate titles (typical OpenAlex hit) clear easily
+#     (overlap is typically > 0.6 even with title variations)
+#   * citation-DOI-poisoned titles (entirely different paper) reject
+#     (overlap is typically < 0.05)
+# A real false positive would be two papers with overlapping topical
+# vocabulary but different identities; in practice the rejection
+# fall-through to fuzzy title search of the SOURCE title catches this.
+_TITLE_JACCARD_THRESHOLD: float = 0.20
+
+
+def _tokenize_title(title: str) -> frozenset[str]:
+    """Lowercase, strip non-alphanumerics, drop short / stopword tokens.
+
+    Returns a frozenset of substantive tokens. Caller computes Jaccard
+    over two such sets.
+    """
+    if not title:
+        return frozenset()
+    cleaned = "".join(c if c.isalnum() else " " for c in title.lower())
+    tokens = (t for t in cleaned.split() if len(t) >= 4)
+    return frozenset(t for t in tokens if t not in _TITLE_STOPWORDS)
+
+
+def _titles_compatible(source: str, returned: str) -> bool:
+    """Return True when *source* and *returned* are plausibly the same paper.
+
+    Used to gate identifier-based lookups (DOI / arXiv) so a citation
+    DOI extracted from the references section cannot stamp a foreign
+    paper's metadata. Empty inputs are treated as incompatible (caller
+    should fall through, not stamp empty bib).
+    """
+    a = _tokenize_title(source)
+    b = _tokenize_title(returned)
+    if not a or not b:
+        return False
+    intersection = a & b
+    union = a | b
+    if not union:
+        return False
+    return (len(intersection) / len(union)) >= _TITLE_JACCARD_THRESHOLD
+
+
+def _direct_lookup(url: str, *, expected_title: str = "") -> dict[str, Any]:
     """Direct ``/works/<id>`` GET. Returns the canonical bib dict on
     success, ``{}`` on failure (404, network error, malformed payload).
-    Same retry shape as :func:`enrich` for 429s."""
+    Same retry shape as :func:`enrich` for 429s.
+
+    When ``expected_title`` is non-empty, the OpenAlex-returned title
+    is validated against it via :func:`_titles_compatible`. A
+    low-similarity match returns ``{}`` and logs the rejection so
+    the caller can fall through (nexus-yy1m citation-DOI guard).
+    The transient ``_lookup_title`` field is stripped from the
+    returned dict regardless.
+    """
     import time
 
     params = {}
@@ -104,7 +183,18 @@ def _direct_lookup(url: str) -> dict[str, Any]:
                 time.sleep(wait)
                 continue
             resp.raise_for_status()
-            return _build_result(resp.json())
+            result = _build_result(resp.json())
+            lookup_title = result.pop("_lookup_title", "")
+            if expected_title and not _titles_compatible(expected_title, lookup_title):
+                _log.warning(
+                    "openalex_title_mismatch_rejected",
+                    url=url,
+                    expected_title=expected_title,
+                    returned_title=lookup_title,
+                    rejected_openalex_id=result.get("openalex_id", ""),
+                )
+                return {}
+            return result
         except (
             httpx.HTTPError,
             httpx.TimeoutException,
@@ -116,21 +206,31 @@ def _direct_lookup(url: str) -> dict[str, Any]:
     return {}
 
 
-def enrich_by_doi(doi: str) -> dict[str, Any]:
+def enrich_by_doi(doi: str, *, expected_title: str = "") -> dict[str, Any]:
     """Look up a paper by DOI directly. ``doi`` is the bare form
     (``10.1145/X.Y``); the URL-prefixed form is also accepted.
 
-    Unambiguous: OpenAlex resolves DOIs without fuzzy matching, so
-    ``mfaz`` no longer becomes a 1996 Developmental Brain Research
-    paper. Returns ``{}`` on miss / network error / malformed payload.
+    When ``expected_title`` is non-empty (nexus-yy1m), the returned
+    OpenAlex title is validated against it via :func:`_titles_compatible`.
+    A low-similarity match returns ``{}`` so the caller can fall
+    through to fuzzy title search instead of stamping the wrong paper.
+    The validator is what catches the "citation-DOI poisoning" case
+    where a DOI extracted from a paper's references section resolves
+    a foreign paper.
+
+    Returns ``{}`` on miss / network error / malformed payload, or on
+    title-validation rejection.
     """
     if not doi:
         return {}
     bare = _strip_doi_prefix(doi)
-    return _direct_lookup(f"https://api.openalex.org/works/doi:{bare}")
+    return _direct_lookup(
+        f"https://api.openalex.org/works/doi:{bare}",
+        expected_title=expected_title,
+    )
 
 
-def enrich_by_arxiv_id(arxiv_id: str) -> dict[str, Any]:
+def enrich_by_arxiv_id(arxiv_id: str, *, expected_title: str = "") -> dict[str, Any]:
     """Look up an arXiv paper directly. ``arxiv_id`` is the bare
     form (``2503.07641``, no version suffix).
 
@@ -139,6 +239,9 @@ def enrich_by_arxiv_id(arxiv_id: str) -> dict[str, Any]:
     DOI namespace: ``10.48550/arXiv.<id>``. We construct that DOI
     and reuse the by-DOI endpoint. Unambiguous when the paper is
     in OpenAlex; returns ``{}`` on 404 (paper not indexed).
+
+    When ``expected_title`` is non-empty (nexus-yy1m), the returned
+    OpenAlex title is validated; see :func:`enrich_by_doi`.
     """
     if not arxiv_id:
         return {}
@@ -147,7 +250,10 @@ def enrich_by_arxiv_id(arxiv_id: str) -> dict[str, Any]:
     # registered, in which case OpenAlex 404s and we fall through
     # to title search.
     arxiv_doi = f"10.48550/arXiv.{arxiv_id}"
-    return _direct_lookup(f"https://api.openalex.org/works/doi:{arxiv_doi}")
+    return _direct_lookup(
+        f"https://api.openalex.org/works/doi:{arxiv_doi}",
+        expected_title=expected_title,
+    )
 
 
 def enrich(title: str) -> dict[str, Any]:
@@ -178,30 +284,24 @@ def enrich(title: str) -> dict[str, Any]:
             data = resp.json().get("results") or []
             if not data:
                 return {}
-            work = data[0]
-
-            authorships = work.get("authorships") or []
-            authors = ", ".join(
-                (a.get("author") or {}).get("display_name", "")
-                for a in authorships[:5]
-            )
-
-            primary = work.get("primary_location") or {}
-            source = (primary.get("source") or {}) if isinstance(primary, dict) else {}
-            venue = source.get("display_name", "") if isinstance(source, dict) else ""
-
-            referenced = work.get("referenced_works") or []
-            refs = [_strip_openalex_prefix(r) for r in referenced if r]
-
-            return {
-                "year": work.get("publication_year", 0) or 0,
-                "venue": venue or "",
-                "authors": authors or "",
-                "citation_count": work.get("cited_by_count", 0) or 0,
-                "openalex_id": _strip_openalex_prefix(work.get("id", "")) or "",
-                "doi": _strip_doi_prefix(work.get("doi", "") or ""),
-                "references": refs,
-            }
+            result = _build_result(data[0])
+            lookup_title = result.pop("_lookup_title", "")
+            # nexus-yy1m: OpenAlex title search returns SOMETHING for
+            # almost every query, ranked by its relevance score. When
+            # the real paper isn't indexed (preprint, not yet accepted),
+            # the first result is whatever happens to share some tokens
+            # with the query, frequently a completely unrelated paper.
+            # Apply the same title-validation guard as the by-id paths
+            # to refuse wildly-mismatched fuzzy matches.
+            if not _titles_compatible(title, lookup_title):
+                _log.warning(
+                    "openalex_title_search_rejected",
+                    query_title=title,
+                    returned_title=lookup_title,
+                    rejected_openalex_id=result.get("openalex_id", ""),
+                )
+                return {}
+            return result
         except (
             httpx.HTTPError,
             httpx.TimeoutException,

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -329,12 +329,15 @@ def _resolve_bib_for_title(
     ids = extract_identifiers(filename=filename, body_text=body_text)
 
     if ids["doi"]:
-        bib = enrich_by_doi(ids["doi"])
+        # nexus-yy1m: pass our title so the OpenAlex backend can reject
+        # a citation-DOI poisoning (a DOI extracted from references that
+        # resolves to a foreign paper). On rejection, fall through.
+        bib = enrich_by_doi(ids["doi"], expected_title=title)
         if bib:
             bib["_resolved_via"] = "doi"
             return bib
     if ids["arxiv"]:
-        bib = enrich_by_arxiv_id(ids["arxiv"])
+        bib = enrich_by_arxiv_id(ids["arxiv"], expected_title=title)
         if bib:
             bib["_resolved_via"] = "arxiv"
             return bib

--- a/tests/test_bib_enricher_openalex.py
+++ b/tests/test_bib_enricher_openalex.py
@@ -163,13 +163,14 @@ def test_enrich_authors_truncated_to_five():
     from nexus.bib_enricher_openalex import enrich
 
     work = dict(_VALID_WORK)
+    work["display_name"] = "Multi-Author Paper Heuristic Methods"
     work["authorships"] = [
         {"author": {"id": f"A{i}", "display_name": f"Author {i}"}}
         for i in range(10)
     ]
     mock_resp = _make_response(200, {"results": [work]})
     with patch("httpx.get", return_value=mock_resp):
-        result = enrich("Multi-Author Paper")
+        result = enrich("Multi-Author Paper Heuristic Methods")
 
     names = [n.strip() for n in result["authors"].split(",")]
     assert len(names) == 5
@@ -183,11 +184,12 @@ def test_enrich_handles_null_authorships_and_references():
     from nexus.bib_enricher_openalex import enrich
 
     work = dict(_VALID_WORK)
+    work["display_name"] = "Sparse Paper Sparse Authors Sparse References"
     work["authorships"] = None
     work["referenced_works"] = None
     mock_resp = _make_response(200, {"results": [work]})
     with patch("httpx.get", return_value=mock_resp):
-        result = enrich("Sparse Paper")
+        result = enrich("Sparse Paper Sparse Authors Sparse References")
 
     assert result["authors"] == ""
     assert result["references"] == []
@@ -199,10 +201,11 @@ def test_enrich_handles_missing_primary_location():
     from nexus.bib_enricher_openalex import enrich
 
     work = dict(_VALID_WORK)
+    work["display_name"] = "Venueless Paper Without Primary Location"
     work.pop("primary_location")
     mock_resp = _make_response(200, {"results": [work]})
     with patch("httpx.get", return_value=mock_resp):
-        result = enrich("Venue-Less Paper")
+        result = enrich("Venueless Paper Without Primary Location")
     assert result["venue"] == ""
     assert result["openalex_id"] == "W2741809807"
 
@@ -211,10 +214,11 @@ def test_enrich_handles_missing_doi():
     from nexus.bib_enricher_openalex import enrich
 
     work = dict(_VALID_WORK)
+    work["display_name"] = "DOIless Paper Lacking Identifier"
     work.pop("doi")
     mock_resp = _make_response(200, {"results": [work]})
     with patch("httpx.get", return_value=mock_resp):
-        result = enrich("DOI-Less Paper")
+        result = enrich("DOIless Paper Lacking Identifier")
     assert result["doi"] == ""
 
 
@@ -355,3 +359,138 @@ def test_direct_lookup_includes_mailto(monkeypatch):
         enrich_by_doi("10.x/y")
 
     assert captured["params"]["mailto"] == "test@example.com"
+
+
+# ── nexus-yy1m: title-validation post-lookup ────────────────────────────────
+
+
+def test_titles_compatible_helper_basics():
+    """The helper is exported so callers (commands/enrich._resolve_bib_for_title)
+    can validate title shapes outside the OpenAlex backend too. Source-paper
+    title vs. citation-poisoned title is the canonical reject case."""
+    from nexus.bib_enricher_openalex import _titles_compatible
+
+    # CacheRAG-ish vs the embedded-systems paper W2912099628 returned for
+    # the citation DOI 10.1145/3742872. These share zero substantive tokens.
+    assert not _titles_compatible(
+        "Cacherag A Semantic Caching System For Retrieval Augmented Generation In Knowledge Graph Question Answering",
+        "Power Management Strategies for Embedded Multicore Systems",
+    )
+
+    # Same paper, slightly different capitalization / punctuation.
+    assert _titles_compatible(
+        "CacheRAG: A Semantic Caching System for RAG in Knowledge Graph QA",
+        "CacheRAG - a semantic caching system for retrieval-augmented generation in knowledge graph question answering",
+    )
+
+    # Empty inputs do not crash; treat as incompatible (caller should
+    # fall through to next path, not stamp empty metadata).
+    assert not _titles_compatible("", "anything")
+    assert not _titles_compatible("anything", "")
+    assert not _titles_compatible("", "")
+
+
+def test_enrich_by_doi_title_validation_rejects_mismatch():
+    """nexus-yy1m: when expected_title is supplied, a low-similarity
+    OpenAlex result is rejected with {}, so callers can fall through to
+    the next lookup path instead of stamping the wrong paper."""
+    from nexus.bib_enricher_openalex import enrich_by_doi
+
+    # OpenAlex returns a paper unrelated to the expected title.
+    foreign_work = {
+        **_VALID_WORK,
+        "id": "https://openalex.org/W9999",
+        "display_name": "Power Management for Embedded Multicore Systems",
+    }
+    with patch("httpx.get", return_value=_make_response(200, foreign_work)):
+        result = enrich_by_doi(
+            "10.1145/3742872",
+            expected_title="CacheRAG: A Semantic Caching System for RAG in KGQA",
+        )
+
+    assert result == {}, (
+        f"expected {{}} when lookup-title and expected-title disagree, got {result!r}"
+    )
+
+
+def test_enrich_by_doi_title_validation_accepts_match():
+    """nexus-yy1m: a high-similarity title passes through unchanged."""
+    from nexus.bib_enricher_openalex import enrich_by_doi
+
+    matching_work = {
+        **_VALID_WORK,
+        "id": "https://openalex.org/W9001",
+        "display_name": "Attention Is All You Need: Transformers for Sequence Transduction",
+    }
+    with patch("httpx.get", return_value=_make_response(200, matching_work)):
+        result = enrich_by_doi(
+            "10.5555/3295222.3295349",
+            expected_title="Attention Is All You Need",
+        )
+
+    assert result.get("openalex_id") == "W9001", (
+        f"expected the lookup result through unchanged, got {result!r}"
+    )
+
+
+def test_enrich_by_doi_no_expected_title_keeps_legacy_behavior():
+    """nexus-yy1m back-compat: callers that don't pass expected_title
+    keep the pre-fix shape (return whatever OpenAlex says without
+    title-checking)."""
+    from nexus.bib_enricher_openalex import enrich_by_doi
+
+    foreign_work = {
+        **_VALID_WORK,
+        "display_name": "Some Completely Different Paper",
+    }
+    with patch("httpx.get", return_value=_make_response(200, foreign_work)):
+        result = enrich_by_doi("10.x/y")  # no expected_title
+
+    assert result.get("openalex_id") == "W2741809807"
+
+
+def test_enrich_title_search_rejects_irrelevant_top_hit():
+    """nexus-yy1m: OpenAlex /works?search= returns SOMETHING for almost
+    every query, ranked by its relevance score. When the real paper
+    isn't indexed (preprint, not yet accepted), the first result is
+    frequently a completely unrelated paper that shares a token or two
+    with the query. The validator must reject these so the caller does
+    not stamp the wrong paper's metadata.
+
+    Live shakeout case: a CacheRAG title query against OpenAlex returned
+    a 'Proceedings of ... Compilers, Architecture, and Synthesis for
+    Embedded Systems' paper (W2912099628) at the top of the results.
+    """
+    from nexus.bib_enricher_openalex import enrich
+
+    irrelevant_work = {
+        **_VALID_WORK,
+        "id": "https://openalex.org/W2912099628",
+        "display_name": "Proceedings of the International Conference on Compilers, Architecture, and Synthesis for Embedded Systems",
+    }
+    mock_resp = _make_response(200, {"results": [irrelevant_work]})
+    with patch("httpx.get", return_value=mock_resp):
+        result = enrich(
+            "Cacherag A Semantic Caching System For Retrieval Augmented Generation In Knowledge Graph Question Answering"
+        )
+
+    assert result == {}, (
+        f"expected {{}} when the title-search top hit is irrelevant, got {result!r}"
+    )
+
+
+def test_enrich_by_arxiv_id_title_validation_rejects_mismatch():
+    """nexus-yy1m: same guard on the arXiv path."""
+    from nexus.bib_enricher_openalex import enrich_by_arxiv_id
+
+    foreign_work = {
+        **_VALID_WORK,
+        "display_name": "Power Management for Embedded Multicore Systems",
+    }
+    with patch("httpx.get", return_value=_make_response(200, foreign_work)):
+        result = enrich_by_arxiv_id(
+            "2503.07641",
+            expected_title="CacheRAG: A Semantic Caching System for RAG",
+        )
+
+    assert result == {}

--- a/tests/test_enrich_command.py
+++ b/tests/test_enrich_command.py
@@ -254,7 +254,9 @@ def test_enrich_openalex_prefers_doi_over_title_search(
         ["bib", "knowledge__test", "--delay", "0", "--source", "openalex"],
     )
     assert result.exit_code == 0, result.output
-    mock_doi.assert_called_once_with("10.1145/X.Y")
+    # nexus-yy1m: caller passes the source title as expected_title so
+    # the OpenAlex backend can reject citation-DOI poisoning.
+    mock_doi.assert_called_once_with("10.1145/X.Y", expected_title="mfaz")
     mock_title.assert_not_called()
     assert "via DOI/arXiv ID" in result.output
 
@@ -297,7 +299,8 @@ def test_enrich_openalex_falls_back_to_arxiv_when_no_doi(
         enrich, ["bib", "knowledge__test", "--delay", "0", "--source", "openalex"],
     )
     assert result.exit_code == 0, result.output
-    mock_arxiv.assert_called_once_with("1706.03762")
+    # nexus-yy1m: caller passes the source title as expected_title.
+    mock_arxiv.assert_called_once_with("1706.03762", expected_title="Attention")
     mock_title.assert_not_called()
     assert "via DOI/arXiv ID" in result.output
 


### PR DESCRIPTION
## Summary

v4.21.0 live shakeout caught a citation-DOI poisoning failure mode in the OpenAlex bib enricher. The DOI / arXiv-aware lookup added in 4.21.0 trusts whatever identifier shows up in the document body, but academic papers have full reference lists with DOIs that belong to OTHER papers. A CacheRAG preprint without its own DOI got a citation DOI extracted, looked up against OpenAlex, and stamped a foreign embedded-systems proceedings paper's metadata across all 174 chunks.

The OpenAlex `/works?search=` title-search path had the same failure mode (returns SOMETHING for almost every query, ranked by relevance, so an irrelevant paper wins when the real one is not indexed).

Both lookup paths now post-validate the returned `display_name` against the source title via Jaccard token similarity (threshold 0.20 over substantive 4+-character non-stopword tokens). Low-similarity matches return `{}` and emit a structured `openalex_title_*_rejected` warning.

The Semantic Scholar backend is unaffected (does not do direct-by-DOI lookup) and unchanged.

## Test plan

- [x] 6 new tests in `tests/test_bib_enricher_openalex.py` covering the helper, both by-id paths, the title-search path, and back-compat (legacy callers without `expected_title` keep their behavior)
- [x] 4 existing tests updated to use matching display_names (the input title was incidental; tests are exercising field-shape handling)
- [x] 2 caller-arg-shape tests updated in `tests/test_enrich_command.py`
- [x] Live verification: re-running `nx enrich bib knowledge__rag-papers --source openalex` now logs `openalex_title_search_rejected` and leaves bib fields empty (was: stamped W2912099628 metadata)
- [x] 114 enrich-related tests pass

## Closes

Closes nexus-yy1m