### PR TITLE
fix(bib-openalex): asymmetric title validation accepts short-source matches (4.21.2)

### DIFF
--- a/src/nexus/bib_enricher_openalex.py
+++ b/src/nexus/bib_enricher_openalex.py
@@ -113,22 +113,32 @@ _TITLE_STOPWORDS: frozenset[str] = frozenset({
     "under",
 })
 
-# Jaccard threshold tuned so:
-#   * exact / near-duplicate titles (typical OpenAlex hit) clear easily
-#     (overlap is typically > 0.6 even with title variations)
-#   * citation-DOI-poisoned titles (entirely different paper) reject
-#     (overlap is typically < 0.05)
-# A real false positive would be two papers with overlapping topical
-# vocabulary but different identities; in practice the rejection
-# fall-through to fuzzy title search of the SOURCE title catches this.
-_TITLE_JACCARD_THRESHOLD: float = 0.20
+# Title-validation policy (4.21.2 refinement after v4.21.1 shakeout).
+# Pure Jaccard overpenalised short source titles ("Pbeegees" vs the
+# matching "pBeeGees: A Prudent Approach to Certificate-Decoupled BFT
+# Consensus" gave 1/6 = 0.167, rejecting a true positive). The
+# asymmetric rule below preserves the citation-poisoning rejection
+# (zero token overlap) while accepting the short-source case where one
+# title is genuinely just the matching tokens:
+#
+#   * intersection >= 2 substantive tokens: accept. Multi-token coincidence
+#     between unrelated papers is rare enough that this is a safe ceiling.
+#   * intersection == 1: accept only when the smaller token set has
+#     <= MAX_SHORT_SET_SIZE tokens (i.e., one side is essentially the
+#     intersection). Catches "Pbeegees" / "Hex Bloom" cases. Rejects
+#     coincidental single-token overlap in long titles (e.g.
+#     "Bloom Filter Survey" vs "Bloom Effects in Computer Graphics").
+#   * intersection == 0: reject. Disjoint vocabularies almost certainly
+#     mean different papers.
+_TITLE_MIN_INTERSECTION_FOR_AUTO_ACCEPT: int = 2
+_TITLE_MAX_SHORT_SET_SIZE: int = 2
 
 
 def _tokenize_title(title: str) -> frozenset[str]:
     """Lowercase, strip non-alphanumerics, drop short / stopword tokens.
 
-    Returns a frozenset of substantive tokens. Caller computes Jaccard
-    over two such sets.
+    Returns a frozenset of substantive tokens. Caller passes two such
+    sets to :func:`_titles_compatible`.
     """
     if not title:
         return frozenset()
@@ -144,16 +154,24 @@ def _titles_compatible(source: str, returned: str) -> bool:
     DOI extracted from the references section cannot stamp a foreign
     paper's metadata. Empty inputs are treated as incompatible (caller
     should fall through, not stamp empty bib).
+
+    The rule (4.21.2): two-or-more substantive token matches always
+    accept; a single-token match accepts only when one side is short
+    enough that the match is the bulk of the title (catches
+    filename-derived short source titles like "Pbeegees" matching the
+    full OpenAlex title "pBeeGees: A Prudent Approach to ...");
+    zero matches always reject.
     """
     a = _tokenize_title(source)
     b = _tokenize_title(returned)
     if not a or not b:
         return False
     intersection = a & b
-    union = a | b
-    if not union:
-        return False
-    return (len(intersection) / len(union)) >= _TITLE_JACCARD_THRESHOLD
+    if len(intersection) >= _TITLE_MIN_INTERSECTION_FOR_AUTO_ACCEPT:
+        return True
+    if len(intersection) == 1:
+        return min(len(a), len(b)) <= _TITLE_MAX_SHORT_SET_SIZE
+    return False
 
 
 def _direct_lookup(url: str, *, expected_title: str = "") -> dict[str, Any]:

--- a/tests/test_bib_enricher_openalex.py
+++ b/tests/test_bib_enricher_openalex.py
@@ -364,6 +364,41 @@ def test_direct_lookup_includes_mailto(monkeypatch):
 # ── nexus-yy1m: title-validation post-lookup ────────────────────────────────
 
 
+def test_titles_compatible_short_source_matching_long_returned():
+    """4.21.2 refinement: a 1-token source title that fully matches one
+    token of a longer returned title should ACCEPT, not reject.
+    Regression case from v4.21.1 shakeout: 'Pbeegees' (filename-derived)
+    vs OpenAlex's full 'pBeeGees: A Prudent Approach to Certificate-
+    Decoupled BFT Consensus' was rejected by pure Jaccard (1/6=0.167)
+    even though it was the genuine match. Same shape for 'Hex Bloom'
+    vs 'HEX-BLOOM: An Efficient Method for Authenticity ...'. The
+    asymmetric rule keeps these legitimate hits."""
+    from nexus.bib_enricher_openalex import _titles_compatible
+
+    # The actual v4.21.1 false-negative cases.
+    assert _titles_compatible(
+        "Pbeegees",
+        "pBeeGees: A Prudent Approach to Certificate-Decoupled BFT Consensus",
+    )
+    assert _titles_compatible(
+        "Hex Bloom",
+        "HEX-BLOOM: An Efficient Method for Authenticity and Integrity Verification in Privacy-preserving Computing",
+    )
+
+
+def test_titles_compatible_single_overlap_in_long_titles_rejects():
+    """4.21.2: when both titles are long and only ONE substantive token
+    overlaps, that's almost certainly a topical coincidence not a match.
+    Reject. Counter-case to the short-source acceptance above."""
+    from nexus.bib_enricher_openalex import _titles_compatible
+
+    # Both titles have multiple substantive tokens, only "bloom" overlaps.
+    assert not _titles_compatible(
+        "Bloom Filter Survey Methods Comparison",
+        "Bloom Effects Computer Graphics Real Time Rendering",
+    )
+
+
 def test_titles_compatible_helper_basics():
     """The helper is exported so callers (commands/enrich._resolve_bib_for_title)
     can validate title shapes outside the OpenAlex backend too. Source-paper


### PR DESCRIPTION
## Summary

v4.21.1 shipped Jaccard-based title validation to catch citation-DOI poisoning. Live shakeout against `knowledge__delos` surfaced the inverse failure mode: pure Jaccard over-rejects when the source title is a 1-2 token filename derivative and OpenAlex returns the full multi-word title. Two false negatives in 15 docs (`Pbeegees`, `Hex Bloom`).

This PR replaces the threshold rule with an asymmetric one:

- 2+ substantive token matches: accept (multi-token coincidence rare)
- Exactly 1 match: accept only when the smaller token set has <= 2 tokens (one side is essentially the intersection)
- 0 matches: reject

## Live shakeout result on `knowledge__delos` (15 docs)

|        | v4.21.1 | v4.21.2 |
|--------|---------|---------|
| Correct enrichments | 3 | 6 |
| False positives | 0 | 1 |
| False negatives | 2 | 0 |
| Net | +3 | +5 |

The 1 false positive is `Zanzibar` (single-word source title matched a 2007 malaria study via the place-name token). Filed as `nexus-5cez` P3 for richer validation (year-sanity + content-keyword cross-check).

## Test plan

- [x] 28 existing OpenAlex tests pass (Jaccard threshold removed; constants renamed; semantics covered by the new rule)
- [x] 2 new tests in `tests/test_bib_enricher_openalex.py`:
  - `test_titles_compatible_short_source_matching_long_returned` (regression for Pbeegees / Hex Bloom)
  - `test_titles_compatible_single_overlap_in_long_titles_rejects` (counter-case: long-vs-long single overlap still rejects)
- [x] 40 enrich-related tests pass total
- [x] Live verification on `knowledge__delos`: 7 enrichments (vs 3 in 4.21.1), 0 false negatives, 1 known false positive (Zanzibar, captured in nexus-5cez)

## Closes

(Continues nexus-yy1m. Follow-up: nexus-5cez)