### PR TITLE
fix(db): T2Database records its own path_key in _upgrade_done (nexus-avwe)

### DIFF
--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -189,6 +189,18 @@ class T2Database:
                     apply_pending(conn, current_version)
                 finally:
                     conn.close()
+                # apply_pending() keys _upgrade_done by
+                # _connection_path_key(conn) (Path(row[2]).resolve() from
+                # PRAGMA database_list). The fast-path check above keys by
+                # str(path.resolve()) on the Path argument. The two forms
+                # are equivalent in nearly all cases but diverge in CI
+                # path-resolution edge cases (nexus-avwe), leaving the
+                # T2Database-form path_key absent from _upgrade_done after
+                # apply_pending populated only its own form. Recording the
+                # T2Database form here ensures a second construction with
+                # the same Path argument short-circuits without re-opening
+                # the connection.
+                _upgrade_done.add(path_key)
 
         # ── Construct domain stores ───────────────────────────────────
         self.memory: MemoryStore = MemoryStore(path)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -839,6 +839,20 @@ class TestT2DatabaseIntegration:
             mock_ap.assert_not_called()
             db2.close()
 
+    def test_t2database_records_path_key_in_upgrade_done(self, tmp_path: Path) -> None:
+        """T2Database records its own path_key form (str(path.resolve())) in
+        _upgrade_done, independent of _connection_path_key's form, so the
+        outer fast-path check on a subsequent construction is guaranteed to
+        short-circuit (nexus-avwe regression).
+        """
+        from nexus.db.migrations import _upgrade_done
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        db = T2Database(db_path)
+        db.close()
+        assert str(db_path.resolve()) in _upgrade_done
+
     def test_t2database_base_tables_exist(self, tmp_path: Path) -> None:
         """All four base schemas are created by transient connection."""
         from nexus.db.t2 import T2Database


### PR DESCRIPTION
## Symptom

`tests/test_migrations.py::TestT2DatabaseIntegration::test_t2database_fast_path_second_construction` was failing on PR #404 CI run 25196547556 with:

```
AssertionError: Expected 'apply_pending' to not have been called. Called 1 times.
Calls: [call(<sqlite3.Connection object at 0x...>, '4.21.2')].
```

The test asserts that a second `T2Database(db_path)` on the same path skips `apply_pending` entirely via the outer fast-path check. The check failed under CI conditions only; the test passed locally on macOS.

## Root cause

Two code paths key `_upgrade_done` differently:

- `T2Database.__init__()` at `src/nexus/db/t2/__init__.py:170` uses `str(path.resolve())` on the `Path` argument before opening the connection.
- `apply_pending()` uses `_connection_path_key(conn)` which is `Path(row[2]).resolve()` from `PRAGMA database_list`.

These are equivalent in nearly all cases (and stay equivalent locally on macOS), but diverge on certain CI runners. After `db1 = T2Database(db_path)` completes, `_upgrade_done` contains apply_pending's form but not T2Database's form. On `db2 = T2Database(db_path)`, the outer check `if path_key not in _upgrade_done` fails, the connection is re-opened, and `apply_pending` is invoked. apply_pending's own internal short-circuit still works (it finds its form), but the redundant call is observable to the test mock.

## Fix

`T2Database.__init__()` now records its own path_key form in `_upgrade_done` after `apply_pending` returns. Both forms coexist in the set; the duplication is harmless. The next construction with the same `Path` argument matches the outer fast-path check and skips opening the connection.

## Test

Adds `test_t2database_records_path_key_in_upgrade_done` to lock in the new invariant: after `T2Database(path)` constructs, `str(path.resolve())` is present in `_upgrade_done`.

## Why this fix is the right shape

The alternative (compute T2Database's path_key from the conn after opening it) would defeat the whole point of the outer fast-path check, which is to avoid opening the connection on second construction. Keeping the path-string-based check and ensuring T2Database's form is always recorded preserves the optimization while making the bookkeeping robust.

Closes nexus-avwe.