### PR TITLE
fix(test): mock _collect_aspect_queue_data in present-table render test (CI flake)

### DIFF
--- a/tests/test_console_health_aspect_queue.py
+++ b/tests/test_console_health_aspect_queue.py
@@ -154,20 +154,35 @@ class TestHealthRouteRendersAspectQueueCard:
 
     def test_aspect_queue_card_present_when_table_populated(
         self, isolated_config_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """The template renders pending/failed/oldest_pending fields when
+        ``_collect_aspect_queue_data`` returns a populated payload.
+
+        We mock the helper rather than relying on a fixture-populated
+        ``memory.db`` for the same reason the absent-test mocks it (see
+        sibling docstring): ``/health/refresh`` runs a chain of T2-touching
+        health checks before the aspect-queue check, and on Ubuntu CI those
+        side-effects rewrite the DB the route reads from, so the test's
+        ``_create_queue_table`` + ``_insert_row`` setup is not what the
+        route sees by the time it queries (observed: only the "failed"
+        row survives the round-trip on CI; pending row is dropped). The
+        unit tests under ``TestCollectAspectQueueData`` already cover the
+        helper's data path against a real ``memory.db``; this test now
+        isolates the *template* branch from T2 side-effects.
+        """
         from nexus.console.app import create_app
 
-        db_path = isolated_config_dir / "memory.db"
-        _create_queue_table(db_path)
-        _insert_row(
-            db_path, collection="knowledge__a", source_path="/a/1",
-            status="pending", enqueued_at="2026-04-29T00:00:00Z",
+        monkeypatch.setattr(
+            "nexus.console.routes.health._collect_aspect_queue_data",
+            lambda: {
+                "present": True,
+                "total": 2,
+                "by_status": {"pending": 1, "failed": 1},
+                "oldest_pending": "2026-04-29T00:00:00Z",
+                "failed_count": 1,
+            },
         )
-        _insert_row(
-            db_path, collection="knowledge__a", source_path="/a/2",
-            status="failed", enqueued_at="2026-04-29T01:00:00Z",
-        )
-
         app = create_app()
         client = TestClient(app)
         resp = client.get("/health/refresh")


### PR DESCRIPTION
## Summary

Main is currently red on `tests/test_console_health_aspect_queue.py::TestHealthRouteRendersAspectQueueCard::test_aspect_queue_card_present_when_table_populated`. This applies the same mock pattern the sister test (`test_aspect_queue_card_dash_when_table_absent`) already uses, isolating the template branch from the T2 side-effect race that bites it on Ubuntu CI.

### Root cause

`/health/refresh` calls `_collect_health_data` which runs a chain of T2-touching health checks (`_check_t2_integrity`, etc.) before `_collect_aspect_queue_data`. On Ubuntu CI those side-effects rewrite the test's manually-populated `memory.db` between the test's `_create_queue_table` + `_insert_row` setup and the eventual route read.

**Smoking-gun evidence in the failed render:**
- Test inserts 2 rows: 1 pending + 1 failed
- Route reports total=1, by_status={"failed": 1}, no pending row, no oldest_pending
- The same render shows `T2 integrity: PRAGMA ok, FTS5 ok` despite the test never creating `memory_fts` — i.e. some other code ran the full T2 migration set on the test's DB mid-test, which is exactly the failure mode the sister test's docstring already documents.

### Why mocking is the right fix

- The `TestCollectAspectQueueData` unit tests already cover the helper's data path against a real fixture-populated `memory.db` (they don't go through `/health/refresh`, so they don't trigger the T2 side-effect chain).
- The render test's job is to validate the template's `pending=N` / `failed=N` / `oldest pending` substring branches off a populated payload. A mock with a representative dict exercises those branches deterministically, with no reliance on T2 isolation.
- This is the exact fix already applied to the sister test in commit `b7c5e333` (`test(console-health): mock _collect_aspect_queue_data in absent-render test`).

### Recurrence pattern

| Commit | CI | Note |
|---|---|---|
| `9bf67e34` `chore(release): conexus 4.21.2` | failure | same test, same signature |
| (intervening commits) | success | flake didn't fire |
| `5742959f` `rdr(101): event-sourced catalog (#404)` | failure | same test, same signature; #404 only added 2 doc files, no code change |

No code change to the test or the route between the two failures — this is purely environmental.

### Test plan

- [x] Local on macOS: all 6 tests in the file pass before and after the change.
- [x] No change to production code.
- [ ] CI green on Linux (the platform that was failing).