### PR TITLE
rdr-101(phase1): projector + JSONL synthesizer + replay-equality test

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -434,3 +434,5 @@
 {"id":"int-ef9a6ce5","kind":"field_change","created_at":"2026-04-30T20:14:45.599263Z","actor":"Hellblazer","issue_id":"nexus-fb6x","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Shipped in PR #399 (squash merged 2026-04-30)"}}
 {"id":"int-4138e2fc","kind":"field_change","created_at":"2026-05-01T02:07:18.100069Z","actor":"Hellblazer","issue_id":"nexus-o6aa.7","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-d5cdd756","kind":"field_change","created_at":"2026-05-01T02:09:35.326367Z","actor":"Hellblazer","issue_id":"nexus-digx","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-435c143a","kind":"field_change","created_at":"2026-05-01T02:32:40.841668Z","actor":"Hellblazer","issue_id":"nexus-digx","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-f16a9966","kind":"field_change","created_at":"2026-05-01T02:35:07.854277Z","actor":"Hellblazer","issue_id":"nexus-tu0d","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/events.py
+++ b/src/nexus/catalog/events.py
@@ -175,6 +175,16 @@ class DocumentRegisteredPayload:
     ``doc_id`` is a fresh UUID7 (RF-101-1). ``source_uri`` is the canonical
     URI; for files it is the ``file://`` form. ``coll_id`` records which
     collection the document's chunks live in.
+
+    The trailing block of fields preserves the existing tumbler-keyed
+    ``documents`` row schema during the Phase 1 transition: v: 0 events
+    synthesized from ``documents.jsonl`` populate them so the projector
+    can produce a SQLite state byte-equal to today's ``Catalog.rebuild()``
+    output (replay-equality test). v: 1 native writes (Phase 3+) leave
+    them empty and rely on canonical fields plus separate projections
+    (Provenance, Frecency, Aspect) for the rest. Phase 5 drops the
+    legacy columns from the SQLite schema; the events keep them so the
+    log is replayable into older schemas during a downgrade.
     """
 
     doc_id: str
@@ -185,6 +195,18 @@ class DocumentRegisteredPayload:
     title: str = ""
     source_mtime: float = 0.0
     indexed_at_doc: str = ""
+    # ── Legacy tumbler-keyed schema fields (Phase 1 transition) ────────────
+    tumbler: str = ""
+    author: str = ""
+    year: int = 0
+    file_path: str = ""
+    corpus: str = ""
+    physical_collection: str = ""
+    chunk_count: int = 0
+    head_hash: str = ""
+    indexed_at: str = ""
+    alias_of: str = ""
+    meta: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -283,6 +305,10 @@ class LinkCreatedPayload:
     (matching the existing ``links.jsonl`` ``from_t``/``to_t`` shape).
     Phase 3+ may carry ``doc_id`` UUID7 values; the projector chooses the
     join column at read time.
+
+    ``created_at`` and ``meta`` preserve fields the existing
+    ``links.jsonl`` carries so v: 0 synthesis can reproduce the
+    tumbler-keyed ``links`` SQLite row.
     """
 
     from_doc: str
@@ -292,6 +318,8 @@ class LinkCreatedPayload:
     creator: str = ""
     from_span: str = ""  # legacy positional span (RDR-053); empty for chash-spanned links
     to_span: str = ""
+    created_at: str = ""
+    meta: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+
+"""RDR-101 Phase 1: project events to catalog SQLite state.
+
+Phase 1 targets the *existing* ``CatalogDB`` schema (owners + documents +
+documents_fts + links — the tumbler-keyed pre-Phase-5 layout). Replay
+equality is the binding test: feeding a synthesizer's v: 0 event stream
+into ``Projector`` produces a SQLite state byte-for-byte equal to what
+``Catalog.rebuild()`` writes from the same JSONL files. If the two
+disagree, the projector or the synthesizer is wrong — never an
+acceptable runtime divergence.
+
+Dispatch is on ``(type, v)`` per RF-101-2: ``(DocumentRegistered, 0)`` is
+the legacy projection rule, ``(DocumentRegistered, 1)`` is the canonical
+post-Phase-3 rule. Phase 1 implements the v: 0 paths fully and the v: 1
+paths as no-ops with a structured warning, since no production writer
+emits v: 1 yet (Phase 3 ships those). Unknown ``(type, v)`` pairs log
+``event_log_unknown_dispatch`` and skip — this is deliberate forward
+compat: the projector running against a future log version must not
+crash, it must surface the new event type so an operator can decide.
+
+Idempotency: re-projecting the same event sequence is a no-op past the
+first run. ``DocumentRegistered`` uses ``INSERT OR REPLACE`` keyed on
+``tumbler`` so re-applying overwrites with identical data.
+``LinkCreated`` uses ``INSERT OR IGNORE`` against the existing UNIQUE
+INDEX on ``(from_tumbler, to_tumbler, link_type)`` so duplicate links are
+silently dropped. ``DocumentDeleted`` issues ``DELETE FROM documents
+WHERE tumbler = ?``; re-deleting a missing row is a no-op.
+
+The projector does NOT manage the SQLite schema or migrations — it
+takes a constructed ``CatalogDB`` and writes to whatever schema is
+already there. The caller (``rebuild_via_log()``, ``nx catalog doctor
+--replay-equality`` in PR C) constructs a fresh ``CatalogDB`` against
+an ephemeral path so replay-equality has a clean slate.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any
+
+import structlog
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.events import Event
+
+_log = structlog.get_logger()
+
+
+class Projector:
+    """Apply events to a ``CatalogDB``. Idempotent and dispatch-on-(type, v)."""
+
+    def __init__(self, db: CatalogDB) -> None:
+        self._db = db
+
+    # ── Public API ───────────────────────────────────────────────────────
+
+    def apply(self, event: Event) -> None:
+        """Apply one event. Unknown (type, v) pairs are logged and skipped."""
+        handler = _DISPATCH.get((event.type, event.v))
+        if handler is None:
+            _log.warning(
+                "event_log_unknown_dispatch",
+                type=event.type,
+                v=event.v,
+                ts=event.ts,
+            )
+            return
+        handler(self, event.payload)
+
+    def apply_all(self, events: Iterable[Event]) -> int:
+        """Apply a stream of events; return the count actually applied.
+
+        ``CatalogDB.commit()`` is called once at the end so a long
+        replay is one transaction (atomic against external readers and
+        ~50x faster than per-event commits on the live host catalog).
+        """
+        applied = 0
+        for event in events:
+            self.apply(event)
+            applied += 1
+        self._db.commit()
+        return applied
+
+    # ── v: 0 handlers (synthesized from existing JSONL state) ────────────
+
+    def _v0_owner_registered(self, payload: Any) -> None:
+        self._db.execute(
+            "INSERT OR REPLACE INTO owners "
+            "(tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                payload.owner_id,
+                payload.name,
+                payload.owner_type,
+                payload.repo_hash,
+                payload.description,
+                payload.repo_root,
+            ),
+        )
+
+    def _v0_document_registered(self, payload: Any) -> None:
+        # The existing schema is tumbler-keyed; v: 0 synthesis stuffs the
+        # tumbler into both ``payload.tumbler`` (legacy) and ``payload.doc_id``
+        # (canonical-stand-in). Prefer the legacy slot for clarity.
+        tumbler = payload.tumbler or payload.doc_id
+        if not tumbler:
+            _log.warning("projector_document_registered_no_tumbler",
+                         payload=payload)
+            return
+        self._db.execute(
+            "INSERT OR REPLACE INTO documents "
+            "(tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, "
+            "indexed_at, metadata, source_mtime, alias_of, source_uri) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                tumbler,
+                payload.title,
+                payload.author,
+                payload.year,
+                payload.content_type,
+                payload.file_path,
+                payload.corpus,
+                payload.physical_collection or payload.coll_id,
+                payload.chunk_count,
+                payload.head_hash,
+                # ``indexed_at`` is the legacy column; ``indexed_at_doc`` is
+                # the canonical name. v: 0 synthesis populates both from the
+                # JSONL ``indexed_at`` field — prefer the legacy slot to
+                # match the column.
+                payload.indexed_at or payload.indexed_at_doc,
+                json.dumps(payload.meta),
+                payload.source_mtime,
+                payload.alias_of,
+                payload.source_uri,
+            ),
+        )
+
+    def _v0_document_aliased(self, payload: Any) -> None:
+        # The Phase 1 SQLite schema stores ``alias_of`` as a column on the
+        # ``documents`` row. ``DocumentRegistered`` populated it already
+        # for v: 0 synthesis; ``DocumentAliased`` is a no-op for the
+        # tumbler-keyed projection. Future projections (a separate
+        # ``aliases`` table or alias-graph view) consume this event;
+        # Phase 1 just keeps the dispatch entry registered so the doctor
+        # verb can verify the alias graph round-trips through the log.
+        return
+
+    def _v0_document_renamed(self, payload: Any) -> None:
+        # v: 0 synthesis never emits this event today (renames before the
+        # event log existed are flattened into the ``last_seen`` snapshot
+        # by ``synthesizer._synthesize_documents``). Kept registered so
+        # dispatch on (DocumentRenamed, 0) doesn't trigger the
+        # unknown-dispatch warning if someone hand-emits one.
+        if not payload.doc_id or not payload.new_source_uri:
+            return
+        self._db.execute(
+            "UPDATE documents SET source_uri = ? WHERE tumbler = ?",
+            (payload.new_source_uri, payload.doc_id),
+        )
+
+    def _v0_document_deleted(self, payload: Any) -> None:
+        if not payload.doc_id:
+            return
+        self._db.execute(
+            "DELETE FROM documents WHERE tumbler = ?",
+            (payload.doc_id,),
+        )
+
+    def _v0_document_enriched(self, payload: Any) -> None:
+        # Enrichment merges the payload dict into ``documents.metadata``.
+        # The current rebuild path already round-trips ``meta`` verbatim,
+        # so the v: 0 enrichment data lives in
+        # ``DocumentRegisteredPayload.meta`` for the synthesized-state
+        # case; this event is a no-op for v: 0 synthesis. Phase 3+ uses
+        # v: 1 ``DocumentEnriched`` to write structured Aspect rows.
+        return
+
+    def _v0_owner_or_collection_noop(self, payload: Any) -> None:
+        # ``CollectionCreated`` / ``CollectionSuperseded`` have no
+        # corresponding row in the Phase 1 SQLite schema (the existing
+        # ``documents.physical_collection`` column carries the collection
+        # name). The projector accepts these events so the dispatch table
+        # is complete; future schema gains a ``collections`` table that
+        # consumes them.
+        return
+
+    def _v0_chunk_indexed(self, payload: Any) -> None:
+        # Phase 1 SQLite has no ``chunks`` table. The chunk count is
+        # already on ``documents.chunk_count`` from
+        # ``DocumentRegistered``. No-op here; Phase 5 SQLite gains a
+        # chunks table and this handler will materialise rows.
+        return
+
+    def _v0_chunk_orphaned(self, payload: Any) -> None:
+        return  # symmetric to chunk_indexed
+
+    def _v0_link_created(self, payload: Any) -> None:
+        if not payload.from_doc or not payload.to_doc or not payload.link_type:
+            return
+        self._db.execute(
+            "INSERT OR IGNORE INTO links "
+            "(from_tumbler, to_tumbler, link_type, from_span, to_span, "
+            "created_by, created_at, metadata) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                payload.from_doc,
+                payload.to_doc,
+                payload.link_type,
+                payload.from_span,
+                payload.to_span,
+                payload.creator,
+                payload.created_at,
+                json.dumps(payload.meta),
+            ),
+        )
+
+    def _v0_link_deleted(self, payload: Any) -> None:
+        if not payload.from_doc or not payload.to_doc or not payload.link_type:
+            return
+        self._db.execute(
+            "DELETE FROM links "
+            "WHERE from_tumbler = ? AND to_tumbler = ? AND link_type = ?",
+            (payload.from_doc, payload.to_doc, payload.link_type),
+        )
+
+    # ── v: 1 handlers (Phase 3+ native writes) ───────────────────────────
+    #
+    # Phase 1 does not write the new SQLite schema (Document.doc_id
+    # column, Chunk table, etc.) — that lands in Phase 3. The v: 1
+    # handlers are placeholders so the dispatch table is symmetric and
+    # the doctor verb can flag "v: 1 event in log but no v: 1 SQLite
+    # writer" as a Phase-3-incomplete failure mode rather than a silent
+    # drop.
+
+    def _v1_unsupported(self, payload: Any) -> None:
+        _log.warning(
+            "projector_v1_not_implemented_phase1",
+            payload=type(payload).__name__,
+            note="v: 1 native writes land in RDR-101 Phase 3",
+        )
+
+
+# Dispatch table built once at import. Maps (type, v) → bound-method names.
+# Constructed from the Projector class so the names stay in sync with the
+# methods even after refactoring.
+def _build_dispatch() -> dict[tuple[str, int], Any]:
+    return {
+        # v: 0 — synthesized from existing JSONL
+        (ev.TYPE_OWNER_REGISTERED, 0):       Projector._v0_owner_registered,
+        (ev.TYPE_COLLECTION_CREATED, 0):     Projector._v0_owner_or_collection_noop,
+        (ev.TYPE_COLLECTION_SUPERSEDED, 0):  Projector._v0_owner_or_collection_noop,
+        (ev.TYPE_DOCUMENT_REGISTERED, 0):    Projector._v0_document_registered,
+        (ev.TYPE_DOCUMENT_RENAMED, 0):       Projector._v0_document_renamed,
+        (ev.TYPE_DOCUMENT_ALIASED, 0):       Projector._v0_document_aliased,
+        (ev.TYPE_DOCUMENT_ENRICHED, 0):      Projector._v0_document_enriched,
+        (ev.TYPE_DOCUMENT_DELETED, 0):       Projector._v0_document_deleted,
+        (ev.TYPE_CHUNK_INDEXED, 0):          Projector._v0_chunk_indexed,
+        (ev.TYPE_CHUNK_ORPHANED, 0):         Projector._v0_chunk_orphaned,
+        (ev.TYPE_LINK_CREATED, 0):           Projector._v0_link_created,
+        (ev.TYPE_LINK_DELETED, 0):           Projector._v0_link_deleted,
+        # v: 1 — Phase 3 ships these
+        (ev.TYPE_OWNER_REGISTERED, 1):       Projector._v1_unsupported,
+        (ev.TYPE_COLLECTION_CREATED, 1):     Projector._v1_unsupported,
+        (ev.TYPE_COLLECTION_SUPERSEDED, 1):  Projector._v1_unsupported,
+        (ev.TYPE_DOCUMENT_REGISTERED, 1):    Projector._v1_unsupported,
+        (ev.TYPE_DOCUMENT_RENAMED, 1):       Projector._v1_unsupported,
+        (ev.TYPE_DOCUMENT_ALIASED, 1):       Projector._v1_unsupported,
+        (ev.TYPE_DOCUMENT_ENRICHED, 1):      Projector._v1_unsupported,
+        (ev.TYPE_DOCUMENT_DELETED, 1):       Projector._v1_unsupported,
+        (ev.TYPE_CHUNK_INDEXED, 1):          Projector._v1_unsupported,
+        (ev.TYPE_CHUNK_ORPHANED, 1):         Projector._v1_unsupported,
+        (ev.TYPE_LINK_CREATED, 1):           Projector._v1_unsupported,
+        (ev.TYPE_LINK_DELETED, 1):           Projector._v1_unsupported,
+    }
+
+
+_DISPATCH: dict[tuple[str, int], Any] = _build_dispatch()

--- a/src/nexus/catalog/synthesizer.py
+++ b/src/nexus/catalog/synthesizer.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+
+"""RDR-101 Phase 1: synthesize v: 0 events from existing JSONL state.
+
+Reads ``owners.jsonl`` / ``documents.jsonl`` / ``links.jsonl`` and emits
+``Event`` envelopes that, when fed through ``Projector``, reproduce the
+SQLite state today's ``Catalog.rebuild()`` writes from the same files.
+
+The v: 0 envelope is the bridge: it represents catalog history that
+predates the event log. Phase 2 will write these synthesized events to
+``events.jsonl``; Phase 1 only synthesizes them into memory for the
+replay-equality test.
+
+Per RF-101-2 the v: 0 path needs three explicit sub-cases:
+
+- Tombstoned rows (``_deleted: True`` in JSONL) project as
+  ``DocumentRegistered`` followed by ``DocumentDeleted`` so the projector
+  can detect resurrection bugs (a v: 0 projector that just re-INSERTs
+  every row would silently revive deleted documents).
+- Aliased rows (``alias_of != ""``) project as ``DocumentRegistered``
+  with ``alias_of`` populated AND a paired ``DocumentAliased`` so future
+  projections that materialize an alias graph see them as first-class
+  edges. The Phase 1 SQLite projection stores ``alias_of`` as a column;
+  ``DocumentAliased`` is a no-op for it, but the doctor verb still
+  asserts the alias graph round-trips through the log.
+- Empty-``source_uri`` rows are tagged so the doctor reports them; they
+  are still emitted as ``DocumentRegistered`` so the SQLite row exists.
+
+Each synthesized event sets ``v=0``. The legacy fields on
+``DocumentRegisteredPayload`` carry the existing JSONL row's data
+verbatim; the canonical RDR-101 fields (``doc_id``, ``coll_id``) are
+populated where the source allows (``coll_id`` from
+``physical_collection``, ``doc_id`` synthesized fresh) and otherwise
+left empty.
+
+The synthesizer is read-only against the catalog directory: no JSONL
+file is touched, no SQLite is opened. The output is an iterator of
+``Event`` envelopes the caller can feed to a ``Projector`` (Phase 1
+replay-equality test) or ``EventLog.append_many`` (Phase 2 backfill).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from nexus.catalog import events as ev
+from nexus.catalog.events import Event
+
+_log = structlog.get_logger()
+
+
+def synthesize_from_jsonl(catalog_dir: Path) -> Iterator[Event]:
+    """Yield v: 0 events that reproduce the catalog state under ``catalog_dir``.
+
+    Order: owners → documents → links. Within each file, JSONL append order
+    is preserved (last-write-wins is collapsed before emit so the projector
+    sees one or two events per logical key, not the full append history).
+
+    Skips a file if it does not exist (fresh catalog with partial state).
+    """
+    owners_path = catalog_dir / "owners.jsonl"
+    docs_path = catalog_dir / "documents.jsonl"
+    links_path = catalog_dir / "links.jsonl"
+
+    if owners_path.exists():
+        yield from _synthesize_owners(owners_path)
+    if docs_path.exists():
+        yield from _synthesize_documents(docs_path)
+    if links_path.exists():
+        yield from _synthesize_links(links_path)
+
+
+# ── Owners ───────────────────────────────────────────────────────────────
+
+
+def _synthesize_owners(path: Path) -> Iterator[Event]:
+    """Owners use last-line-wins; tombstones are not used in practice today
+    (``owners.jsonl`` is append-only with re-registration overwriting).
+    """
+    seen: dict[str, dict[str, Any]] = {}
+    for obj in _iter_jsonl(path):
+        key = obj.get("owner")
+        if not key:
+            continue
+        if obj.get("_deleted"):
+            seen.pop(key, None)
+        else:
+            seen[key] = obj
+
+    for owner_id, obj in seen.items():
+        payload = ev.OwnerRegisteredPayload(
+            owner_id=owner_id,
+            name=obj.get("name", ""),
+            owner_type=obj.get("owner_type", ""),
+            repo_root=obj.get("repo_root", ""),
+            repo_hash=obj.get("repo_hash", ""),
+            description=obj.get("description", ""),
+        )
+        yield Event(
+            type=ev.TYPE_OWNER_REGISTERED, v=0,
+            payload=payload, ts=_synthesized_ts(obj),
+        )
+
+
+# ── Documents ────────────────────────────────────────────────────────────
+
+
+def _synthesize_documents(path: Path) -> Iterator[Event]:
+    """Walk documents.jsonl, collapse last-write-wins per tumbler, and emit
+    one (or two) events per logical row.
+
+    The collapse is deliberate: today's ``read_documents`` does the same
+    thing (a tombstone followed by a re-register yields the re-register
+    only). Faithfully replaying the full append history would re-emit
+    intermediate states the catalog already discarded; the synthesizer's
+    contract is "events that reproduce today's effective state", not
+    "events that reproduce the full audit trail".
+    """
+    last_seen: dict[str, dict[str, Any]] = {}
+    tombstoned: dict[str, dict[str, Any]] = {}
+
+    for obj in _iter_jsonl(path):
+        key = obj.get("tumbler")
+        if not key:
+            continue
+        if obj.get("_deleted"):
+            # Stash the tombstone *with the data from the row that was
+            # tombstoned* so we can emit a faithful Registered event for
+            # the doc the tombstone refers to. JSONL tombstones today
+            # carry the full DocumentRecord fields (see catalog.py
+            # delete_document()).
+            tombstoned[key] = obj
+            last_seen.pop(key, None)
+        else:
+            last_seen[key] = obj
+            tombstoned.pop(key, None)
+
+    # Live documents → DocumentRegistered (+ DocumentAliased if alias_of set).
+    for tumbler, obj in last_seen.items():
+        yield _document_registered_event(obj, synthesized=True)
+        alias_of = (obj.get("alias_of") or "").strip()
+        if alias_of:
+            yield Event(
+                type=ev.TYPE_DOCUMENT_ALIASED,
+                v=0,
+                payload=ev.DocumentAliasedPayload(
+                    alias_doc_id=tumbler,         # Phase 1: tumbler stands in for doc_id
+                    canonical_doc_id=alias_of,
+                ),
+                ts=_synthesized_ts(obj),
+            )
+
+    # Tombstoned documents → DocumentRegistered + DocumentDeleted (RF-101-2).
+    # Without the explicit Registered the projector has no Document state to
+    # tombstone against; without the Deleted the projector silently resurrects
+    # the row. Both are required.
+    for tumbler, obj in tombstoned.items():
+        yield _document_registered_event(obj, synthesized=True)
+        yield Event(
+            type=ev.TYPE_DOCUMENT_DELETED,
+            v=0,
+            payload=ev.DocumentDeletedPayload(
+                doc_id=tumbler,
+                reason="synthesized_from_tombstone",
+            ),
+            ts=_synthesized_ts(obj),
+        )
+
+
+def _document_registered_event(
+    obj: dict[str, Any], *, synthesized: bool,
+) -> Event:
+    """Build a ``DocumentRegistered`` v: 0 event from a documents.jsonl row.
+
+    Populates both the canonical fields (``doc_id``, ``coll_id``,
+    ``source_uri``, ``content_type``, ``title``, ``source_mtime``) and the
+    legacy tumbler-schema fields so the Phase 1 projector can write a
+    SQLite row identical to the one ``Catalog.rebuild()`` produces.
+
+    ``doc_id`` is set to the tumbler so the v: 0 path has a stable join
+    key during Phase 1; a fresh UUID7 doc_id is what Phase 2 backfill will
+    assign once the doc_id column lands in the SQLite schema.
+    """
+    tumbler = obj.get("tumbler", "")
+    physical_collection = obj.get("physical_collection", "")
+    payload = ev.DocumentRegisteredPayload(
+        # Canonical
+        doc_id=tumbler,  # Phase 1 stand-in; Phase 2 mints a fresh UUID7
+        owner_id=_owner_prefix_of(tumbler),
+        content_type=obj.get("content_type", ""),
+        source_uri=obj.get("source_uri", ""),
+        coll_id=physical_collection,
+        title=obj.get("title", ""),
+        source_mtime=float(obj.get("source_mtime", 0.0) or 0.0),
+        indexed_at_doc=obj.get("indexed_at", ""),
+        # Legacy (Phase 1 SQLite schema)
+        tumbler=tumbler,
+        author=obj.get("author", ""),
+        year=int(obj.get("year", 0) or 0),
+        file_path=obj.get("file_path", ""),
+        corpus=obj.get("corpus", ""),
+        physical_collection=physical_collection,
+        chunk_count=int(obj.get("chunk_count", 0) or 0),
+        head_hash=obj.get("head_hash", ""),
+        indexed_at=obj.get("indexed_at", ""),
+        alias_of=obj.get("alias_of", "") or "",
+        meta=dict(obj.get("meta") or {}),
+    )
+    return Event(
+        type=ev.TYPE_DOCUMENT_REGISTERED, v=0, payload=payload,
+        ts=_synthesized_ts(obj),
+    )
+
+
+# ── Links ────────────────────────────────────────────────────────────────
+
+
+def _synthesize_links(path: Path) -> Iterator[Event]:
+    """Walk links.jsonl, collapse by composite key, emit LinkCreated /
+    LinkDeleted as needed.
+
+    Composite key: ``(from_t, to_t, link_type)`` matching the existing
+    SQLite UNIQUE INDEX on the ``links`` table.
+    """
+    last_seen: dict[tuple[str, str, str], dict[str, Any]] = {}
+    tombstoned: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    for obj in _iter_jsonl(path):
+        # F2: backward compat — old JSONL uses "created", new uses "created_at"
+        if "created" in obj and "created_at" not in obj:
+            obj["created_at"] = obj.pop("created")
+        try:
+            key = (obj["from_t"], obj["to_t"], obj["link_type"])
+        except KeyError:
+            continue
+        if obj.get("_deleted"):
+            tombstoned[key] = obj
+            last_seen.pop(key, None)
+        else:
+            last_seen[key] = obj
+            tombstoned.pop(key, None)
+
+    for key, obj in last_seen.items():
+        from_t, to_t, link_type = key
+        yield Event(
+            type=ev.TYPE_LINK_CREATED, v=0,
+            payload=ev.LinkCreatedPayload(
+                from_doc=from_t,
+                to_doc=to_t,
+                link_type=link_type,
+                from_span=obj.get("from_span", "") or "",
+                to_span=obj.get("to_span", "") or "",
+                creator=obj.get("created_by", "") or "",
+                created_at=obj.get("created_at", "") or "",
+                meta=dict(obj.get("meta") or {}),
+            ),
+            ts=_synthesized_ts(obj),
+        )
+
+    for key, obj in tombstoned.items():
+        from_t, to_t, link_type = key
+        # Emit Created (with the row's last-known data) followed by Deleted
+        # so the projector sees the lifecycle even though the live SQLite
+        # row never gets created.
+        yield Event(
+            type=ev.TYPE_LINK_CREATED, v=0,
+            payload=ev.LinkCreatedPayload(
+                from_doc=from_t,
+                to_doc=to_t,
+                link_type=link_type,
+                from_span=obj.get("from_span", "") or "",
+                to_span=obj.get("to_span", "") or "",
+                creator=obj.get("created_by", "") or "",
+                created_at=obj.get("created_at", "") or "",
+                meta=dict(obj.get("meta") or {}),
+            ),
+            ts=_synthesized_ts(obj),
+        )
+        yield Event(
+            type=ev.TYPE_LINK_DELETED, v=0,
+            payload=ev.LinkDeletedPayload(
+                from_doc=from_t,
+                to_doc=to_t,
+                link_type=link_type,
+                reason="synthesized_from_tombstone",
+            ),
+            ts=_synthesized_ts(obj),
+        )
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    """Yield parsed JSON objects, one per non-empty line, skipping garbage.
+
+    Mirrors the existing ``read_*`` readers' tolerance: garbage lines are
+    logged and skipped, not fatal. Catalog JSONL is git-managed and
+    machine-edited; one bad line should not brick the synthesizer.
+    """
+    with path.open() as f:
+        for lineno, raw in enumerate(f, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                _log.warning(
+                    "synthesizer_jsonl_parse_error",
+                    path=str(path), lineno=lineno, preview=line[:80],
+                )
+                continue
+
+
+def _synthesized_ts(obj: dict[str, Any]) -> str:
+    """Pick the best available timestamp from a JSONL row.
+
+    ``indexed_at`` for documents, ``created_at`` for links, falls back to
+    empty string when neither is present. The doctor verb tags
+    empty-ts events as synthesized-from-pre-event-log records.
+    """
+    return obj.get("indexed_at") or obj.get("created_at") or ""
+
+
+def _owner_prefix_of(tumbler: str) -> str:
+    """Extract the ``store.owner`` prefix from a document tumbler.
+
+    ``1.7.42`` → ``1.7``. Returns empty string for malformed input rather
+    than raising; the caller can detect zero-length owner_id and report.
+    """
+    if not tumbler:
+        return ""
+    parts = tumbler.split(".")
+    if len(parts) < 2:
+        return ""
+    return ".".join(parts[:2])

--- a/tests/test_catalog_projector.py
+++ b/tests/test_catalog_projector.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for nexus.catalog.projector + nexus.catalog.synthesizer.
+
+Replay-equality is the binding test: ``Catalog.rebuild()`` reading JSONL
+into SQLite and ``Projector.apply_all(synthesize_from_jsonl())`` driving
+events into a fresh SQLite must produce identical row sets. If they
+disagree, the synthesizer or the projector is wrong (RF-101-2).
+
+Coverage:
+- Replay-equality on a non-trivial fixture catalog
+- Tombstones don't resurrect (RF-101-2 sub-case)
+- Aliases preserve their alias_of column AND emit a paired
+  ``DocumentAliased`` event (RF-101-2 sub-case)
+- Idempotency: applying the same events twice is a no-op
+- Unknown (type, v) pairs skip with the unknown-dispatch warning
+- ``apply_all`` reports the number of events applied
+- ``DocumentRenamed`` v: 0 updates source_uri without recreating the row
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.projector import Projector
+from nexus.catalog.synthesizer import synthesize_from_jsonl
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _dump_table(conn: sqlite3.Connection, table: str) -> list[tuple]:
+    """Snapshot a table's rows in stable order for comparison."""
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    cols = [row[1] for row in cur.fetchall()]
+    if not cols:
+        return []
+    sort_cols = ", ".join(cols)
+    rows = conn.execute(
+        f"SELECT {sort_cols} FROM {table} ORDER BY {sort_cols}"
+    ).fetchall()
+    return rows
+
+
+def _snapshot(db_path: Path) -> dict[str, list[tuple]]:
+    """Snapshot owners + documents + links from a SQLite catalog db."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return {
+            "owners": _dump_table(conn, "owners"),
+            "documents": _dump_table(conn, "documents"),
+            "links": _dump_table(conn, "links"),
+        }
+    finally:
+        conn.close()
+
+
+def _appendl(path: Path, obj: dict) -> None:
+    with path.open("a") as f:
+        f.write(json.dumps(obj) + "\n")
+
+
+def _build_fixture_catalog(catalog_dir: Path) -> Path:
+    """Build a JSONL-only catalog with several non-trivial cases.
+
+    Returns the catalog directory so the caller can drive
+    ``Catalog.rebuild()`` against it.
+    """
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    owners = catalog_dir / "owners.jsonl"
+    documents = catalog_dir / "documents.jsonl"
+    links = catalog_dir / "links.jsonl"
+
+    # Two owners
+    _appendl(owners, {
+        "owner": "1.1", "name": "nexus", "owner_type": "repo",
+        "repo_hash": "571b8edd", "description": "Git repo: nexus",
+        "repo_root": "/git/nexus", "next_seq": 99,
+    })
+    _appendl(owners, {
+        "owner": "1.2", "name": "ART", "owner_type": "repo",
+        "repo_hash": "8c2e74c0", "description": "Git repo: ART",
+        "repo_root": "/git/ART", "next_seq": 4181,
+    })
+
+    # Document A: live
+    _appendl(documents, {
+        "tumbler": "1.1.1", "title": "doc-A.md", "author": "alice",
+        "year": 2024, "content_type": "prose", "file_path": "doc-A.md",
+        "corpus": "knowledge", "physical_collection": "docs__nexus-571b8edd",
+        "chunk_count": 12, "head_hash": "aaaa1111",
+        "indexed_at": "2026-04-01T00:00:00Z",
+        "meta": {"author_email": "alice@example.org"},
+        "source_mtime": 1714000000.0, "alias_of": "",
+        "source_uri": "file:///git/nexus/doc-A.md",
+    })
+
+    # Document B: live with non-empty alias_of (alias of 1.1.1)
+    _appendl(documents, {
+        "tumbler": "1.1.2", "title": "doc-A.md", "author": "alice",
+        "year": 2024, "content_type": "prose", "file_path": "doc-A.md",
+        "corpus": "knowledge", "physical_collection": "docs__nexus-571b8edd",
+        "chunk_count": 12, "head_hash": "aaaa1111",
+        "indexed_at": "2026-04-01T01:00:00Z",
+        "meta": {}, "source_mtime": 1714000010.0,
+        "alias_of": "1.1.1",
+        "source_uri": "file:///git/nexus/doc-A.md",
+    })
+
+    # Document C: registered then tombstoned (last write is _deleted=true)
+    _appendl(documents, {
+        "tumbler": "1.2.7", "title": "deleted.txt", "author": "",
+        "year": 0, "content_type": "code", "file_path": "deleted.txt",
+        "corpus": "", "physical_collection": "code__ART-8c2e74c0",
+        "chunk_count": 3, "head_hash": "ccccccc",
+        "indexed_at": "2026-04-02T00:00:00Z",
+        "meta": {"reason": "still-here"}, "source_mtime": 1714100000.0,
+        "alias_of": "",
+        "source_uri": "file:///git/ART/deleted.txt",
+    })
+    _appendl(documents, {
+        "tumbler": "1.2.7", "_deleted": True,
+        "title": "deleted.txt", "author": "", "year": 0,
+        "content_type": "code", "file_path": "deleted.txt",
+        "corpus": "", "physical_collection": "code__ART-8c2e74c0",
+        "chunk_count": 3, "head_hash": "ccccccc",
+        "indexed_at": "2026-04-02T01:00:00Z",
+        "meta": {"reason": "still-here"}, "source_mtime": 1714100000.0,
+        "alias_of": "",
+        "source_uri": "file:///git/ART/deleted.txt",
+    })
+
+    # Document D: empty source_uri (legacy paper row)
+    _appendl(documents, {
+        "tumbler": "1.2.42", "title": "Some Paper", "author": "Smith, J.",
+        "year": 2020, "content_type": "paper", "file_path": "",
+        "corpus": "papers", "physical_collection": "papers__art-curator",
+        "chunk_count": 50, "head_hash": "ddddeeee",
+        "indexed_at": "2026-04-03T00:00:00Z",
+        "meta": {}, "source_mtime": 0.0, "alias_of": "",
+        "source_uri": "",
+    })
+
+    # Two links: one live, one tombstoned
+    _appendl(links, {
+        "from_t": "1.1.1", "to_t": "1.2.42", "link_type": "cites",
+        "from_span": "", "to_span": "", "created_by": "bib_enricher",
+        "created_at": "2026-04-04T00:00:00Z", "meta": {},
+        "_deleted": False,
+    })
+    _appendl(links, {
+        "from_t": "1.1.1", "to_t": "1.1.2", "link_type": "implements",
+        "from_span": "", "to_span": "", "created_by": "manual",
+        "created_at": "2026-04-04T01:00:00Z", "meta": {},
+        "_deleted": False,
+    })
+    _appendl(links, {
+        "from_t": "1.1.1", "to_t": "1.1.2", "link_type": "implements",
+        "from_span": "", "to_span": "", "created_by": "manual",
+        "created_at": "2026-04-04T02:00:00Z", "meta": {},
+        "_deleted": True,
+    })
+
+    return catalog_dir
+
+
+def _project_via_log(
+    catalog_dir: Path, fresh_db_path: Path,
+) -> CatalogDB:
+    """Drive synthesizer → projector against a fresh CatalogDB."""
+    db = CatalogDB(fresh_db_path)
+    Projector(db).apply_all(synthesize_from_jsonl(catalog_dir))
+    return db
+
+
+# ── Replay equality ──────────────────────────────────────────────────────
+
+
+class TestReplayEquality:
+    """The binding test for Phase 1.
+
+    ``Catalog.rebuild()`` is the established JSONL → SQLite path; the
+    projector is the new path. Both must produce the same SQLite for
+    the same JSONL inputs.
+    """
+
+    def test_replay_equality_full_fixture(self, tmp_path):
+        catalog_dir = _build_fixture_catalog(tmp_path / "catalog")
+
+        # Path A: existing rebuild() via Catalog construction.
+        cat_a = Catalog(catalog_dir, tmp_path / "rebuild.db")
+        cat_a._db.commit()
+        snap_a = _snapshot(tmp_path / "rebuild.db")
+
+        # Path B: fresh CatalogDB driven by synthesizer + projector.
+        db_b = _project_via_log(catalog_dir, tmp_path / "projected.db")
+        db_b.close()
+        snap_b = _snapshot(tmp_path / "projected.db")
+
+        assert snap_a["owners"] == snap_b["owners"], (
+            f"owners differ:\n  rebuild: {snap_a['owners']}\n  projected: {snap_b['owners']}"
+        )
+        assert snap_a["documents"] == snap_b["documents"], (
+            f"documents differ:\n  rebuild: {snap_a['documents']}\n  projected: {snap_b['documents']}"
+        )
+        # ``links.id`` is an autoincrement PK; the projector's INSERT
+        # order matches the synthesizer's collapse order, which matches
+        # rebuild()'s iteration order, so ids should align. If this
+        # assertion ever flakes we will need to compare links sans id.
+        assert snap_a["links"] == snap_b["links"], (
+            f"links differ:\n  rebuild: {snap_a['links']}\n  projected: {snap_b['links']}"
+        )
+
+
+# ── Sub-cases per RF-101-2 ───────────────────────────────────────────────
+
+
+class TestTombstones:
+    """Tombstoned documents must NOT resurrect via the projector."""
+
+    def test_tombstoned_doc_not_in_projected_state(self, tmp_path):
+        catalog_dir = _build_fixture_catalog(tmp_path / "catalog")
+        db = _project_via_log(catalog_dir, tmp_path / "projected.db")
+
+        rows = db.execute(
+            "SELECT tumbler FROM documents WHERE tumbler = ?",
+            ("1.2.7",),
+        ).fetchall()
+        assert rows == [], (
+            "Tombstoned document 1.2.7 must not appear in the SQLite "
+            "projection. RF-101-2 sub-case: synthesized tombstones produce "
+            "DocumentRegistered + DocumentDeleted; the projector must apply "
+            "the deletion."
+        )
+        db.close()
+
+
+class TestAliases:
+    """Alias rows project with alias_of populated AND emit DocumentAliased."""
+
+    def test_alias_column_populated(self, tmp_path):
+        catalog_dir = _build_fixture_catalog(tmp_path / "catalog")
+        db = _project_via_log(catalog_dir, tmp_path / "projected.db")
+
+        row = db.execute(
+            "SELECT alias_of FROM documents WHERE tumbler = ?",
+            ("1.1.2",),
+        ).fetchone()
+        assert row is not None, "alias row must exist in projection"
+        assert row[0] == "1.1.1"
+        db.close()
+
+    def test_aliased_event_emitted_for_alias_rows(self, tmp_path):
+        catalog_dir = _build_fixture_catalog(tmp_path / "catalog")
+        events = list(synthesize_from_jsonl(catalog_dir))
+
+        aliased = [
+            e for e in events if e.type == ev.TYPE_DOCUMENT_ALIASED
+        ]
+        assert len(aliased) == 1, (
+            f"Expected 1 DocumentAliased event for the alias row in the "
+            f"fixture; got {len(aliased)}: {aliased!r}"
+        )
+        assert aliased[0].payload.alias_doc_id == "1.1.2"
+        assert aliased[0].payload.canonical_doc_id == "1.1.1"
+
+    def test_tombstoned_rows_emit_delete_event(self, tmp_path):
+        catalog_dir = _build_fixture_catalog(tmp_path / "catalog")
+        events = list(synthesize_from_jsonl(catalog_dir))
+
+        deleted = [e for e in events if e.type == ev.TYPE_DOCUMENT_DELETED]
+        assert len(deleted) == 1
+        assert deleted[0].payload.doc_id == "1.2.7"
+        assert deleted[0].payload.reason == "synthesized_from_tombstone"
+
+
+# ── Idempotency ──────────────────────────────────────────────────────────
+
+
+class TestIdempotency:
+    """Applying the same event sequence twice is a no-op past the first run."""
+
+    def test_double_apply_yields_same_state(self, tmp_path):
+        catalog_dir = _build_fixture_catalog(tmp_path / "catalog")
+
+        db = CatalogDB(tmp_path / "projected.db")
+        proj = Projector(db)
+        # First application
+        proj.apply_all(synthesize_from_jsonl(catalog_dir))
+        first = _snapshot(tmp_path / "projected.db")
+        # Second application against the same DB
+        proj.apply_all(synthesize_from_jsonl(catalog_dir))
+        second = _snapshot(tmp_path / "projected.db")
+        db.close()
+
+        # Documents and owners use INSERT OR REPLACE → identical.
+        assert first["owners"] == second["owners"]
+        assert first["documents"] == second["documents"]
+        # Links use INSERT OR IGNORE on the (from, to, type) UNIQUE
+        # index → identical row count.
+        assert len(first["links"]) == len(second["links"])
+
+
+# ── Forward compat ───────────────────────────────────────────────────────
+
+
+class TestUnknownDispatch:
+    def test_unknown_type_is_skipped(self, tmp_path, caplog):
+        db = CatalogDB(tmp_path / "x.db")
+        proj = Projector(db)
+
+        unknown = ev.Event(
+            type="FutureEventType", v=1,
+            payload={"a": 1}, ts="2026-04-30T12:00:00+00:00",
+        )
+        # No raise; no-op on SQLite.
+        proj.apply(unknown)
+        rows = db.execute("SELECT count(*) FROM documents").fetchone()
+        assert rows[0] == 0
+        db.close()
+
+    def test_v1_known_type_is_logged_skipped(self, tmp_path):
+        # Phase 3 will ship v: 1 handlers; Phase 1 logs and skips so the
+        # doctor verb can flag "v: 1 in log but Phase 3 not deployed".
+        db = CatalogDB(tmp_path / "x.db")
+        proj = Projector(db)
+
+        e = ev.make_event(
+            ev.DocumentDeletedPayload(doc_id="1.7.42", reason="x"),
+            v=1,
+        )
+        proj.apply(e)
+        # v: 1 path is the v1_unsupported no-op for Phase 1.
+        rows = db.execute(
+            "SELECT count(*) FROM documents WHERE tumbler = ?",
+            ("1.7.42",),
+        ).fetchone()
+        assert rows[0] == 0
+        db.close()
+
+
+# ── apply_all return value + DocumentRenamed ─────────────────────────────
+
+
+class TestApplyAll:
+    def test_apply_all_returns_count(self, tmp_path):
+        catalog_dir = _build_fixture_catalog(tmp_path / "catalog")
+        db = CatalogDB(tmp_path / "projected.db")
+        events = list(synthesize_from_jsonl(catalog_dir))
+        n = Projector(db).apply_all(iter(events))
+        assert n == len(events)
+        db.close()
+
+
+class TestDocumentRenamed:
+    def test_renamed_event_updates_source_uri(self, tmp_path):
+        # Set up a registered doc, then apply a rename event.
+        db = CatalogDB(tmp_path / "x.db")
+        proj = Projector(db)
+        proj.apply(ev.Event(
+            type=ev.TYPE_DOCUMENT_REGISTERED, v=0,
+            payload=ev.DocumentRegisteredPayload(
+                doc_id="1.7.42", owner_id="1.7",
+                content_type="code",
+                source_uri="file:///old.py",
+                coll_id="code__test",
+                tumbler="1.7.42",
+            ),
+            ts="2026-04-30T00:00:00Z",
+        ))
+        proj.apply(ev.Event(
+            type=ev.TYPE_DOCUMENT_RENAMED, v=0,
+            payload=ev.DocumentRenamedPayload(
+                doc_id="1.7.42",
+                new_source_uri="file:///new.py",
+            ),
+            ts="2026-04-30T01:00:00Z",
+        ))
+        db.commit()
+
+        row = db.execute(
+            "SELECT source_uri FROM documents WHERE tumbler = ?",
+            ("1.7.42",),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "file:///new.py"
+        db.close()


### PR DESCRIPTION
## Summary

Phase 1 PR B of RDR-101. Drives events through to the existing tumbler-keyed catalog SQLite schema and proves the round-trip is byte-equal to today's `Catalog.rebuild()` output. No production write path changes; the synthesizer reads JSONL and the projector writes a fresh `CatalogDB` only under test today.

### What lands

- **`src/nexus/catalog/synthesizer.py`** (new): `synthesize_from_jsonl(catalog_dir)` yields v: 0 events that reproduce the catalog state `Catalog.rebuild()` reads from `owners.jsonl` / `documents.jsonl` / `links.jsonl`. Per RF-101-2 sub-cases, tombstoned rows emit `DocumentRegistered + DocumentDeleted`, aliased rows emit `DocumentRegistered` with `alias_of` populated **and** a paired `DocumentAliased`, tombstoned links emit `LinkCreated + LinkDeleted`. Last-write-wins is collapsed before emit (matches today's `read_*` semantics).
- **`src/nexus/catalog/projector.py`** (new): `Projector.apply(event)` dispatches on `(type, v)`; unknown pairs log `event_log_unknown_dispatch` and skip (forward compat). v: 0 handlers write the existing schema with `INSERT OR REPLACE` for owners/documents and `INSERT OR IGNORE` for links, keeping re-projection idempotent. v: 1 handlers are placeholders that log `projector_v1_not_implemented_phase1` so the doctor verb (PR C) can flag a Phase-3-incomplete deployment instead of silently dropping events.
- **`src/nexus/catalog/events.py`** (update): `DocumentRegisteredPayload` gains `tumbler/author/year/file_path/corpus/physical_collection/chunk_count/head_hash/indexed_at/alias_of/meta` as optional legacy fields. v: 0 synthesis populates them; v: 1 native writes (Phase 3+) leave them empty and rely on canonical fields plus separate Provenance/Frecency/Aspect projections. `LinkCreatedPayload` gains `created_at` and `meta`.

### What does NOT land

Per the Phase 1 decomposition:

- `nx catalog doctor --replay-equality` verb — PR C
- Frecency projection schema + `Document` bib columns — PR D
- `chash_index.doc_id` → `chunk_chroma_id` rename — PR E
- Shadow-write path emitting events alongside JSONL — PR F

### Test plan

- [x] `tests/test_catalog_projector.py` (10 new tests):
  - **Replay-equality** on a non-trivial fixture catalog (2 owners, 4 docs incl. 1 alias and 1 tombstoned, 3 links incl. 1 tombstoned). `owners`, `documents`, `links` tables byte-equal between `Catalog.rebuild()` and `synthesizer + projector` paths.
  - Tombstone non-resurrection (RF-101-2 C3 fix).
  - Alias column populated AND `DocumentAliased` event emitted.
  - Idempotency: applying the same events twice yields the same SQLite.
  - Unknown `(type, v)` pairs skip with the warning, no SQLite write.
  - v: 1 known events log and skip (Phase 3 placeholder).
  - `DocumentRenamed` v: 0 updates `source_uri` without recreating the row.
- [x] PR A's tests still pass: `tests/test_catalog_events.py` (15) + `tests/test_catalog_event_log.py` (16) — no regression.
- [x] Existing catalog + console suites pass: 171 tests across `test_catalog.py`, `test_catalog_db.py`, `test_catalog_e2e.py`, `test_console_health_aspect_queue.py` — no regression.
- [ ] CI green.

### Refs

- RDR-101 §Implementation Plan / Phase 1, §Event log, RF-101-2
- RDR-101 §Migration from current state Phase 1 — synthesizer sub-cases

Bead: `nexus-tu0d` (Phase 1 sub-PR B under `nexus-o6aa.7`).