### PR TITLE
rdr-101(phase1): nx catalog doctor --replay-equality verb

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -436,3 +436,5 @@
 {"id":"int-d5cdd756","kind":"field_change","created_at":"2026-05-01T02:09:35.326367Z","actor":"Hellblazer","issue_id":"nexus-digx","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-435c143a","kind":"field_change","created_at":"2026-05-01T02:32:40.841668Z","actor":"Hellblazer","issue_id":"nexus-digx","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-f16a9966","kind":"field_change","created_at":"2026-05-01T02:35:07.854277Z","actor":"Hellblazer","issue_id":"nexus-tu0d","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-8537a50c","kind":"field_change","created_at":"2026-05-01T02:57:57.362748Z","actor":"Hellblazer","issue_id":"nexus-tu0d","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-3a1aca3e","kind":"field_change","created_at":"2026-05-01T02:58:17.566572Z","actor":"Hellblazer","issue_id":"nexus-2iig","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3221,3 +3221,208 @@ def prune_stale_cmd(
 
     click.echo(f"\nDone: deleted {n_deleted} catalog entr"
                f"{'y' if n_deleted == 1 else 'ies'}.")
+
+
+# ── RDR-101 Phase 1: doctor --replay-equality ────────────────────────────
+
+
+@catalog.command("doctor")
+@click.option(
+    "--replay-equality",
+    "replay_equality",
+    is_flag=True,
+    help=(
+        "Drive the synthesizer + projector against the live catalog and "
+        "diff the projected SQLite against the live .catalog.db. "
+        "Confirms that the event-sourced projection is deterministic for "
+        "the current catalog state. Read-only against the live catalog."
+    ),
+)
+@click.option(
+    "--json", "as_json", is_flag=True,
+    help="Emit machine-readable JSON instead of text output.",
+)
+def doctor_cmd(replay_equality: bool, as_json: bool) -> None:
+    """RDR-101 catalog doctor surface.
+
+    Phase 1 supports only ``--replay-equality``; future flags
+    (``--t3-doc-id-coverage``, ``--legacy-collection-grandfather``, etc.)
+    land in later phases.
+    """
+    if not replay_equality:
+        raise click.UsageError(
+            "Pass a check flag, e.g. --replay-equality. "
+            "Phase 1 supports only --replay-equality."
+        )
+
+    report = _run_replay_equality()
+    if as_json:
+        click.echo(json.dumps(report, indent=2))
+    else:
+        _print_replay_equality_text(report)
+    if not report["pass"]:
+        raise click.exceptions.Exit(1)
+
+
+def _run_replay_equality() -> dict:
+    """Drive synthesizer + projector against the live catalog and diff.
+
+    Steps:
+      1. Resolve ``catalog_path()`` and require an initialized catalog.
+      2. Open ``.catalog.db`` read-only (sqlite URI ``mode=ro``) for the
+         live snapshot. Snapshot owners + documents + links rows.
+      3. Build a fresh ``CatalogDB`` under a TemporaryDirectory; drive
+         ``synthesize_from_jsonl`` + ``Projector.apply_all`` into it.
+         Snapshot the same three tables.
+      4. Diff the snapshots. Report counts and the first 5 mismatches per
+         table. Pass = every table identical; fail = any difference.
+
+    The live ``.catalog.db`` is opened read-only so an operator running
+    this verb on a working host cannot accidentally corrupt the cached
+    SQLite. JSONL files are read but not written. The projected SQLite
+    is ephemeral and discarded with the TemporaryDirectory.
+    """
+    import sqlite3
+    import tempfile
+    from contextlib import closing
+
+    from nexus.catalog.catalog import Catalog
+    from nexus.catalog.catalog_db import CatalogDB
+    from nexus.catalog.projector import Projector
+    from nexus.catalog.synthesizer import synthesize_from_jsonl
+    from nexus.config import catalog_path
+
+    cat_dir = catalog_path()
+    if not Catalog.is_initialized(cat_dir):
+        raise click.ClickException(
+            f"Catalog not initialized at {cat_dir}. "
+            "Run 'nx catalog setup' to create and populate it."
+        )
+
+    live_db_path = cat_dir / ".catalog.db"
+    if not live_db_path.exists():
+        raise click.ClickException(
+            f"Catalog SQLite missing at {live_db_path}; run 'nx catalog "
+            "pull' to rebuild from JSONL."
+        )
+
+    # ── Snapshot live ──────────────────────────────────────────────────
+    live_uri = f"file:{live_db_path}?mode=ro"
+    with closing(sqlite3.connect(live_uri, uri=True)) as live_conn:
+        live_snap = {
+            "owners": _snapshot_table(live_conn, "owners"),
+            "documents": _snapshot_table(live_conn, "documents"),
+            "links": _snapshot_table(live_conn, "links"),
+        }
+
+    # ── Project + snapshot ────────────────────────────────────────────
+    with tempfile.TemporaryDirectory() as tmpdir:
+        projected_path = Path(tmpdir) / "projected.db"
+        proj_db = CatalogDB(projected_path)
+        try:
+            applied = Projector(proj_db).apply_all(
+                synthesize_from_jsonl(cat_dir)
+            )
+        finally:
+            proj_db.close()
+
+        with closing(sqlite3.connect(str(projected_path))) as proj_conn:
+            projected_snap = {
+                "owners": _snapshot_table(proj_conn, "owners"),
+                "documents": _snapshot_table(proj_conn, "documents"),
+                "links": _snapshot_table(proj_conn, "links"),
+            }
+
+    # ── Diff ──────────────────────────────────────────────────────────
+    table_diffs: dict[str, dict] = {}
+    overall_pass = True
+    for table in ("owners", "documents", "links"):
+        live_rows = live_snap[table]
+        proj_rows = projected_snap[table]
+        # Links carry an autoincrement ``id`` PK that the projector
+        # restarts at 1; the live db's ids depend on insertion history.
+        # Strip the id column from both before comparing — the rest of
+        # the row is the actual content under test (RF-101-2 doesn't
+        # claim the autoincrement is part of the projection contract).
+        if table == "links":
+            live_rows = [r[1:] for r in live_rows]
+            proj_rows = [r[1:] for r in proj_rows]
+        live_set = set(live_rows)
+        proj_set = set(proj_rows)
+        only_live = sorted(live_set - proj_set)
+        only_proj = sorted(proj_set - live_set)
+        equal = not only_live and not only_proj
+        table_diffs[table] = {
+            "live_count": len(live_rows),
+            "projected_count": len(proj_rows),
+            "only_in_live": [list(r) for r in only_live[:5]],
+            "only_in_projected": [list(r) for r in only_proj[:5]],
+            "equal": equal,
+        }
+        if not equal:
+            overall_pass = False
+
+    return {
+        "pass": overall_pass,
+        "events_applied": applied,
+        "catalog_dir": str(cat_dir),
+        "live_db": str(live_db_path),
+        "tables": table_diffs,
+    }
+
+
+def _snapshot_table(conn, table: str) -> list[tuple]:
+    """Snapshot one catalog table in deterministic row order.
+
+    Sort by every column so the comparison is independent of insertion
+    order. ``documents.metadata`` and ``links.metadata`` are JSON blobs
+    that round-trip as strings, which sort byte-wise.
+    """
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    cols = [row[1] for row in cur.fetchall()]
+    if not cols:
+        return []
+    sort_cols = ", ".join(cols)
+    rows = conn.execute(
+        f"SELECT {sort_cols} FROM {table} ORDER BY {sort_cols}"
+    ).fetchall()
+    return rows
+
+
+def _print_replay_equality_text(report: dict) -> None:
+    """Operator-friendly text rendering of the replay-equality report."""
+    click.echo(f"Catalog: {report['catalog_dir']}")
+    click.echo(f"Live db: {report['live_db']}")
+    click.echo(f"Events applied: {report['events_applied']}")
+    click.echo("")
+
+    for table, diff in report["tables"].items():
+        marker = "✓" if diff["equal"] else "✗"
+        click.echo(
+            f"  {marker} {table:<10}  live={diff['live_count']:>6}  "
+            f"projected={diff['projected_count']:>6}"
+        )
+        if not diff["equal"]:
+            if diff["only_in_live"]:
+                click.echo(
+                    f"    only in live ({len(diff['only_in_live'])} sample"
+                    + ("s" if len(diff["only_in_live"]) != 1 else "")
+                    + "):"
+                )
+                for row in diff["only_in_live"]:
+                    click.echo(f"      {row!r}")
+            if diff["only_in_projected"]:
+                click.echo(
+                    f"    only in projected "
+                    f"({len(diff['only_in_projected'])} sample"
+                    + ("s" if len(diff["only_in_projected"]) != 1 else "")
+                    + "):"
+                )
+                for row in diff["only_in_projected"]:
+                    click.echo(f"      {row!r}")
+
+    click.echo("")
+    if report["pass"]:
+        click.echo("PASS — projector replay matches live SQLite for the current catalog state.")
+    else:
+        click.echo("FAIL — projector replay diverges from live SQLite. See diffs above.")

--- a/tests/test_catalog_doctor_replay_equality.py
+++ b/tests/test_catalog_doctor_replay_equality.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for nx catalog doctor --replay-equality (RDR-101 Phase 1 PR C).
+
+Coverage:
+- Verb fails loudly when catalog is not initialized (no JSONL files).
+- Verb requires a check flag (passing nothing is a usage error).
+- Verb passes on a freshly-rebuilt catalog (synthesizer + projector
+  produce the same state as Catalog.rebuild()).
+- Verb fails and reports diffs when the live SQLite drifts from JSONL.
+- ``--json`` mode emits a structured report consumable by other tooling.
+- Verb is read-only against the live ``.catalog.db`` (mtime unchanged).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.commands.catalog import doctor_cmd
+
+
+def _appendl(path: Path, obj: dict) -> None:
+    with path.open("a") as f:
+        f.write(json.dumps(obj) + "\n")
+
+
+def _build_initialized_catalog(catalog_dir: Path) -> Path:
+    """Build a fresh Catalog with a few rows so rebuild() produces a non-trivial db."""
+    Catalog.init(catalog_dir)
+    cat = Catalog(catalog_dir, catalog_dir / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="571b8edd")
+    cat.register(owner, "doc-A.md", content_type="prose", file_path="doc-A.md")
+    cat.register(owner, "doc-B.md", content_type="prose", file_path="doc-B.md")
+    cat._db.close()
+    return catalog_dir
+
+
+@pytest.fixture()
+def isolated_nexus(tmp_path: Path) -> Path:
+    """Return the catalog dir the autouse ``_isolate_catalog`` fixture in
+    ``tests/conftest.py`` configures via ``NEXUS_CATALOG_PATH``.
+
+    The autouse fixture sets ``NEXUS_CATALOG_PATH`` to
+    ``tmp_path/test-catalog`` so tests can never pollute the real user
+    catalog. The doctor verb's ``catalog_path()`` honours that env var
+    before falling back to ``NEXUS_CONFIG_DIR``, so any catalog we want
+    the verb to inspect must live at exactly that path.
+    """
+    return tmp_path / "test-catalog"
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── Usage / fail-loud paths ──────────────────────────────────────────────
+
+
+class TestUsage:
+    def test_no_flag_is_usage_error(self, isolated_nexus, runner):
+        # ``nx catalog doctor`` with no flags should be a usage error
+        # (Phase 1 only supports --replay-equality; future flags arrive
+        # in later phases and the verb fails loud rather than running an
+        # unspecified default).
+        result = runner.invoke(doctor_cmd, [])
+        assert result.exit_code != 0
+        assert "Pass a check flag" in (result.output + (result.stderr or ""))
+
+    def test_missing_catalog_is_clean_error(self, isolated_nexus, runner):
+        # No catalog initialized at NEXUS_CONFIG_DIR. The verb must
+        # surface a helpful message, not a stack trace.
+        result = runner.invoke(doctor_cmd, ["--replay-equality"])
+        assert result.exit_code != 0
+        assert "not initialized" in result.output.lower()
+
+
+# ── Happy path: replay equality passes ───────────────────────────────────
+
+
+class TestReplayEqualityPasses:
+    def test_passes_on_freshly_rebuilt_catalog(self, isolated_nexus, runner):
+        cat_dir = isolated_nexus
+        _build_initialized_catalog(cat_dir)
+
+        result = runner.invoke(doctor_cmd, ["--replay-equality"])
+        assert result.exit_code == 0, (
+            f"Expected pass, got exit {result.exit_code}\n"
+            f"stdout: {result.output}\nexc: {result.exception!r}"
+        )
+        assert "PASS" in result.output
+        # Sanity: each table line has a checkmark
+        assert "owners" in result.output
+        assert "documents" in result.output
+        assert "links" in result.output
+
+    def test_json_mode_emits_structured_report(self, isolated_nexus, runner):
+        cat_dir = isolated_nexus
+        _build_initialized_catalog(cat_dir)
+
+        result = runner.invoke(doctor_cmd, ["--replay-equality", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["pass"] is True
+        assert payload["events_applied"] >= 3  # 1 owner + 2 documents
+        assert "tables" in payload
+        assert payload["tables"]["owners"]["equal"] is True
+        assert payload["tables"]["documents"]["equal"] is True
+        assert payload["tables"]["documents"]["live_count"] == 2
+
+    def test_does_not_mutate_live_catalog_db(self, isolated_nexus, runner):
+        cat_dir = isolated_nexus
+        _build_initialized_catalog(cat_dir)
+        live_db = cat_dir / ".catalog.db"
+        before_mtime = live_db.stat().st_mtime
+        # Sleep one filesystem-resolution-tick so a write would shift mtime
+        # detectably even on coarse-grained Linux filesystems.
+        import time as _time
+        _time.sleep(0.05)
+
+        result = runner.invoke(doctor_cmd, ["--replay-equality"])
+        assert result.exit_code == 0
+
+        after_mtime = live_db.stat().st_mtime
+        assert before_mtime == after_mtime, (
+            "doctor --replay-equality must be read-only against "
+            ".catalog.db; mtime advanced from "
+            f"{before_mtime} to {after_mtime}"
+        )
+
+
+# ── Failure path: live SQLite diverges from JSONL ────────────────────────
+
+
+class TestReplayEqualityFails:
+    def test_reports_diff_when_live_db_drifts(self, isolated_nexus, runner):
+        cat_dir = isolated_nexus
+        _build_initialized_catalog(cat_dir)
+
+        # Inject a divergence by directly mutating the live SQLite (not
+        # via Catalog API, which would also rewrite JSONL).
+        live_db = cat_dir / ".catalog.db"
+        conn = sqlite3.connect(str(live_db))
+        try:
+            conn.execute(
+                "UPDATE documents SET title = 'TAMPERED' "
+                "WHERE tumbler = (SELECT tumbler FROM documents LIMIT 1)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = runner.invoke(doctor_cmd, ["--replay-equality"])
+        assert result.exit_code == 1
+        assert "FAIL" in result.output
+        # The diff section names the documents table
+        assert "documents" in result.output
+        assert "only in live" in result.output or "only in projected" in result.output
+
+    def test_json_failure_payload(self, isolated_nexus, runner):
+        cat_dir = isolated_nexus
+        _build_initialized_catalog(cat_dir)
+
+        # Introduce a divergence: remove a row from the live db.
+        live_db = cat_dir / ".catalog.db"
+        conn = sqlite3.connect(str(live_db))
+        try:
+            conn.execute("DELETE FROM documents")
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = runner.invoke(doctor_cmd, ["--replay-equality", "--json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["pass"] is False
+        # Documents table is the source of the disagreement
+        docs_diff = payload["tables"]["documents"]
+        assert docs_diff["equal"] is False
+        assert docs_diff["live_count"] == 0
+        assert docs_diff["projected_count"] >= 1


### PR DESCRIPTION
## Summary

Phase 1 PR C of RDR-101. Wires the synthesizer + projector from PR B behind a CLI verb that operators can run against the live host catalog to confirm the event-sourced projection is deterministic for the current catalog state. Read-only against the live ``.catalog.db`` (sqlite URI ``mode=ro``); the projected SQLite is ephemeral under ``TemporaryDirectory()``.

### Verb

``nx catalog doctor --replay-equality [--json]``

- Phase 1 supports only ``--replay-equality``. No flag → usage error. Future flags (``--t3-doc-id-coverage``, ``--legacy-collection-grandfather``, etc.) land in later phases.
- Resolves ``catalog_path()``, requires an initialized catalog, opens ``.catalog.db`` read-only, snapshots ``owners`` + ``documents`` + ``links``.
- Builds a fresh ``CatalogDB`` under a ``TemporaryDirectory``, drives ``synthesize_from_jsonl`` + ``Projector.apply_all`` into it, snapshots the same three tables.
- Diffs row sets per table (strips ``links.id`` since the autoincrement is not part of the projection contract). Reports up to 5 mismatches per table.
- Exit 0 on PASS; exit 1 on FAIL. ``--json`` emits a structured payload: ``{pass, events_applied, catalog_dir, live_db, tables: {<name>: {live_count, projected_count, only_in_live, only_in_projected, equal}}}``.

### Tests (7 cases)

- No flag → usage error.
- Missing catalog → ClickException with helpful message.
- Pass on a freshly-rebuilt 1-owner / 2-doc catalog.
- ``--json`` mode emits structured report with per-table equal flags.
- Read-only against ``.catalog.db``: mtime unchanged across the verb run (regression guard for the read-only contract).
- Fail-with-diff when the live SQLite is tampered (`UPDATE documents SET title = 'TAMPERED'`).
- Fail-with-counts in JSON mode when the live SQLite has fewer rows than the projection (`DELETE FROM documents`).

Tests use the autouse ``_isolate_catalog`` fixture's ``NEXUS_CATALOG_PATH`` so the verb operates against ``tmp_path/test-catalog`` — never the user's live catalog.

219 tests passing across the Phase 1 modules + the existing catalog + console aspect-queue suites.

### Refs

- RDR-101 §Implementation Plan / Phase 1
- RDR-101 §Read paths / Sequence: Doctor (deterministic drift detection)

Bead: ``nexus-2iig`` (Phase 1 sub-PR C under ``nexus-o6aa.7``).