### PR TITLE
rdr-101(phase1): rename chash_index.doc_id → chunk_chroma_id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.21.2"
+version = "4.21.3"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1257,9 +1257,16 @@ class Catalog:
                     span_res = None
                 if span_res is None:
                     continue
+                # ``row["chunk_chroma_id"]`` carries the Chroma-natural-ID
+                # value the column has always held (renamed from ``doc_id``
+                # per RDR-101 Phase 0 nexus-o6aa.3 to disambiguate from
+                # ``Document.doc_id``). The public ``ChunkRef`` keeps the
+                # ``doc_id`` key in its returned dict for back-compat;
+                # Phase 3 will introduce a parallel ``chunk_chroma_id``
+                # key on the public surface.
                 return _build_ref(
                     coll=row["collection"],
-                    doc_id=row["doc_id"],
+                    doc_id=row["chunk_chroma_id"],
                     span_result=span_res,
                 )
 

--- a/src/nexus/collection_audit.py
+++ b/src/nexus/collection_audit.py
@@ -422,11 +422,13 @@ def compute_chash_coverage(collection: str) -> ChashCoverage | None:
                 ids = page.get("ids") or []
                 metadatas = page.get("metadatas") or []
                 if ids and metadatas:
-                    indexed_ids = idx.doc_ids_present_in_collection(
-                        collection, ids,
+                    indexed_chunk_chroma_ids = (
+                        idx.chunk_chroma_ids_present_in_collection(
+                            collection, ids,
+                        )
                     )
                     for cid in ids:
-                        if cid not in indexed_ids:
+                        if cid not in indexed_chunk_chroma_ids:
                             missing.append(cid)
                         if len(missing) >= 5:
                             break

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -822,6 +822,51 @@ def migrate_chash_index(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def migrate_chash_index_rename_doc_id(conn: sqlite3.Connection) -> None:
+    """Rename ``chash_index.doc_id`` to ``chunk_chroma_id`` (RDR-101 Phase 0).
+
+    The original column name collides with RDR-101's ``Document.doc_id``
+    (UUID7 document identity); this column has always carried the
+    ChromaDB-scoped chunk natural ID. Phase 0 deliverable nexus-o6aa.3
+    (``docs/rdr/post-mortem/rdr-101-rdr086-collision.md``) chose Option A
+    (rename) ahead of Phase 3 to remove the disambiguation tax across
+    every reader joining catalog and chash_index.
+
+    SQLite 3.25+ supports ``ALTER TABLE ... RENAME COLUMN`` natively. The
+    primary key ``(chash, physical_collection)`` is unaffected; the
+    secondary index ``idx_chash_index_collection`` on
+    ``physical_collection`` is unaffected.
+
+    Idempotent in three states:
+      1. Table absent (fresh install): no-op (the create-if-not-exists
+         path in ``ChashIndex._init_schema`` and ``migrate_chash_index``
+         already use the new name).
+      2. Table present with ``chunk_chroma_id`` column (already migrated):
+         no-op.
+      3. Table present with legacy ``doc_id`` column: rename column.
+    """
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='chash_index'"
+    ).fetchone()
+    if row is None:
+        return
+    cols = {
+        r[1]
+        for r in conn.execute("PRAGMA table_info(chash_index)").fetchall()
+    }
+    if "chunk_chroma_id" in cols:
+        return
+    if "doc_id" not in cols:
+        # Table exists but has neither column — schema is unrecognized;
+        # skip rather than risk corrupting it. The doctor verb will
+        # surface the divergence.
+        return
+    conn.execute(
+        "ALTER TABLE chash_index RENAME COLUMN doc_id TO chunk_chroma_id"
+    )
+    conn.commit()
+
+
 def _add_plan_disabled_at(conn: sqlite3.Connection) -> None:
     """Add the ``disabled_at`` column to ``plans`` (nexus-mrzp).
 
@@ -1728,6 +1773,11 @@ MIGRATIONS: list[Migration] = [
         "4.17.1",
         "Add plans.disabled_at column for soft-disable (nexus-mrzp)",
         _add_plan_disabled_at,
+    ),
+    Migration(
+        "4.21.3",
+        "Rename chash_index.doc_id to chunk_chroma_id (RDR-101 Phase 0 nexus-o6aa.3)",
+        migrate_chash_index_rename_doc_id,
     ),
 ]
 

--- a/src/nexus/db/t2/chash_index.py
+++ b/src/nexus/db/t2/chash_index.py
@@ -1,10 +1,20 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 Hal Hildebrand. All rights reserved.
-"""ChashIndex — global chunk-hash → (collection, doc_id) lookup table (RDR-086 Phase 1).
+"""ChashIndex — global chunk-hash → (collection, chunk_chroma_id) lookup table (RDR-086 Phase 1).
 
 Answers "given this ``chash:<hex>`` citation, which physical collection
-and doc_id hold the chunk?" in ~50 µs via a SQLite JOIN, replacing the
-~13-min serial-ChromaDB-filter alternative measured in RF-6.
+and Chroma-natural-id hold the chunk?" in ~50 µs via a SQLite JOIN,
+replacing the ~13-min serial-ChromaDB-filter alternative measured in RF-6.
+
+The third column was originally named ``doc_id`` (ChromaDB-scoped chunk
+natural ID, equivalent to RDR-101's ``Chunk.chunk_id``). RDR-101 introduces
+``Document.doc_id`` as a UUID7 document identity — a different namespace.
+Phase 0 nexus-o6aa.3 deliverable
+(``docs/rdr/post-mortem/rdr-101-rdr086-collision.md``) chose Option A
+(rename) before Phase 3 ships, so every reader joining across catalog and
+the chash_index sees one unambiguous ``doc_id`` meaning. The rename runs
+in lockstep with the Python read-path edits so an in-flight upgrade does
+not crash on the missing column.
 
 Every indexing write site in ``code_indexer``, ``prose_indexer``,
 ``doc_indexer``, and ``pipeline_stages`` dual-writes into this table
@@ -51,7 +61,7 @@ _CHASH_INDEX_SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS chash_index (
     chash                TEXT NOT NULL,
     physical_collection  TEXT NOT NULL,
-    doc_id               TEXT NOT NULL,
+    chunk_chroma_id      TEXT NOT NULL,
     created_at           TEXT NOT NULL,
     PRIMARY KEY (chash, physical_collection)
 );
@@ -92,11 +102,11 @@ class ChashIndex:
 
     # ── Public API ────────────────────────────────────────────────────────
 
-    def upsert(self, *, chash: str, collection: str, doc_id: str) -> None:
-        """Register ``chash`` as living in ``collection`` at ``doc_id``.
+    def upsert(self, *, chash: str, collection: str, chunk_chroma_id: str) -> None:
+        """Register ``chash`` as living in ``collection`` at ``chunk_chroma_id``.
 
         ``INSERT OR REPLACE`` semantics: re-indexing the same file
-        overwrites the existing row (updates ``doc_id`` and
+        overwrites the existing row (updates ``chunk_chroma_id`` and
         ``created_at``) rather than erroring. Compound PK
         ``(chash, collection)`` lets the same chunk text register in
         multiple collections without conflict.
@@ -104,38 +114,49 @@ class ChashIndex:
         Raises ``ValueError`` if any of the three identifiers is empty —
         empty values indicate caller-side bugs and are cheaper to fail
         fast than to silently accept.
+
+        Naming: ``chunk_chroma_id`` was renamed from ``doc_id`` per the
+        RDR-101 Phase 0 nexus-o6aa.3 deliverable to disambiguate from
+        ``Document.doc_id`` (UUID7 document identity) before Phase 3
+        ships.
         """
         if not chash:
             raise ValueError("chash must not be empty")
         if not collection:
             raise ValueError("collection must not be empty")
-        if not doc_id:
-            raise ValueError("doc_id must not be empty")
+        if not chunk_chroma_id:
+            raise ValueError("chunk_chroma_id must not be empty")
         now = datetime.now(UTC).isoformat()
         with self._lock:
             self.conn.execute(
                 "INSERT OR REPLACE INTO chash_index "
-                "(chash, physical_collection, doc_id, created_at) "
+                "(chash, physical_collection, chunk_chroma_id, created_at) "
                 "VALUES (?, ?, ?, ?)",
-                (chash, collection, doc_id, now),
+                (chash, collection, chunk_chroma_id, now),
             )
             self.conn.commit()
 
     def lookup(self, chash: str) -> list[dict[str, Any]]:
-        """Return all (collection, doc_id, created_at) rows for ``chash``.
+        """Return all (collection, chunk_chroma_id, created_at) rows for ``chash``.
 
         Phase 2's ``Catalog.resolve_chash`` tie-breaks multi-match by
         newest ``created_at``. Returns ``[]`` when ``chash`` is unknown.
+
+        The dict's ``chunk_chroma_id`` key carries the Chroma-natural-ID
+        meaning the column has always had; ``Catalog.resolve_chash``'s
+        public ``ChunkRef`` continues to surface this value under a
+        ``doc_id`` key for back-compat with downstream callers, until
+        RDR-101 Phase 3 disambiguates the public surface.
         """
         with self._lock:
             rows = self.conn.execute(
-                "SELECT physical_collection, doc_id, created_at "
+                "SELECT physical_collection, chunk_chroma_id, created_at "
                 "FROM chash_index WHERE chash = ?",
                 (chash,),
             ).fetchall()
         return [
-            {"collection": coll, "doc_id": did, "created_at": ts}
-            for coll, did, ts in rows
+            {"collection": coll, "chunk_chroma_id": cid, "created_at": ts}
+            for coll, cid, ts in rows
         ]
 
     def delete_collection(self, collection: str) -> int:
@@ -237,26 +258,29 @@ class ChashIndex:
             ).fetchone()
         return int(row[0]) if row else 0
 
-    def doc_ids_present_in_collection(
-        self, collection: str, doc_ids: list[str],
+    def chunk_chroma_ids_present_in_collection(
+        self, collection: str, chunk_chroma_ids: list[str],
     ) -> set[str]:
-        """Return the subset of ``doc_ids`` that are indexed in *collection*.
+        """Return the subset of ``chunk_chroma_ids`` indexed in *collection*.
 
         Targeted membership probe for ``compute_chash_coverage`` — takes a
-        caller-provided list of T3 chunk ids and returns the ones that
-        appear in ``chash_index`` for the given collection. Callers use
-        the set difference to surface missing ids.
+        caller-provided list of T3 Chroma natural IDs and returns the ones
+        that appear in ``chash_index`` for the given collection. Callers
+        use the set difference to surface missing ids.
 
-        Empty ``doc_ids`` → empty set (no query issued).
+        Empty ``chunk_chroma_ids`` → empty set (no query issued).
+
+        Renamed from ``doc_ids_present_in_collection`` per the RDR-101
+        Phase 0 nexus-o6aa.3 deliverable.
         """
-        if not doc_ids:
+        if not chunk_chroma_ids:
             return set()
-        placeholders = ",".join("?" * len(doc_ids))
+        placeholders = ",".join("?" * len(chunk_chroma_ids))
         with self._lock:
             rows = self.conn.execute(
-                f"SELECT doc_id FROM chash_index "
-                f"WHERE physical_collection = ? AND doc_id IN ({placeholders})",
-                (collection, *doc_ids),
+                f"SELECT chunk_chroma_id FROM chash_index "
+                f"WHERE physical_collection = ? AND chunk_chroma_id IN ({placeholders})",
+                (collection, *chunk_chroma_ids),
             ).fetchall()
         return {r[0] for r in rows}
 
@@ -295,17 +319,20 @@ def dual_write_chash_index(
     """
     if chash_index is None:
         return
-    for doc_id, meta in zip(ids, metadatas):
+    for chunk_chroma_id, meta in zip(ids, metadatas):
         chash = meta.get("chunk_text_hash", "") if isinstance(meta, dict) else ""
-        if not chash or not doc_id:
+        if not chash or not chunk_chroma_id:
             continue
         try:
-            chash_index.upsert(chash=chash, collection=collection, doc_id=doc_id)
+            chash_index.upsert(
+                chash=chash, collection=collection,
+                chunk_chroma_id=chunk_chroma_id,
+            )
         except Exception as exc:
             _log.warning(
                 "chash_index_dual_write_failed",
                 collection=collection,
-                doc_id=doc_id,
+                chunk_chroma_id=chunk_chroma_id,
                 chash_prefix=chash[:16],
                 error=str(exc),
             )

--- a/tests/test_backfill_hash.py
+++ b/tests/test_backfill_hash.py
@@ -166,7 +166,7 @@ class TestBackfillPopulatesT2ChashIndex:
             assert total == 2
 
             rows = sorted(store.conn.execute(
-                "SELECT chash, physical_collection, doc_id FROM chash_index"
+                "SELECT chash, physical_collection, chunk_chroma_id FROM chash_index"
             ).fetchall())
             alpha = hashlib.sha256(b"alpha code").hexdigest()
             beta = hashlib.sha256(b"beta code").hexdigest()
@@ -201,7 +201,7 @@ class TestBackfillPopulatesT2ChashIndex:
             assert total == 2
 
             rows = sorted(store.conn.execute(
-                "SELECT chash, physical_collection, doc_id FROM chash_index"
+                "SELECT chash, physical_collection, chunk_chroma_id FROM chash_index"
             ).fetchall())
             gamma = hashlib.sha256(b"gamma code").hexdigest()
             delta = hashlib.sha256(b"delta code").hexdigest()

--- a/tests/test_chash_index_store.py
+++ b/tests/test_chash_index_store.py
@@ -42,9 +42,9 @@ class TestChashIndexStoreBasics:
 
         store = ChashIndex(tmp_path / "t2.db")
         try:
-            store.upsert(chash="abc123", collection="code__foo", doc_id="d1")
+            store.upsert(chash="abc123", collection="code__foo", chunk_chroma_id="d1")
             rows = store.conn.execute(
-                "SELECT chash, physical_collection, doc_id FROM chash_index"
+                "SELECT chash, physical_collection, chunk_chroma_id FROM chash_index"
             ).fetchall()
             assert rows == [("abc123", "code__foo", "d1")]
         finally:
@@ -56,14 +56,14 @@ class TestChashIndexStoreBasics:
 
         store = ChashIndex(tmp_path / "t2.db")
         try:
-            store.upsert(chash="abc", collection="code__foo", doc_id="d1")
+            store.upsert(chash="abc", collection="code__foo", chunk_chroma_id="d1")
             first_created = store.conn.execute(
                 "SELECT created_at FROM chash_index WHERE chash=?", ("abc",)
             ).fetchone()[0]
             # Second write with different doc_id, same (chash, collection).
-            store.upsert(chash="abc", collection="code__foo", doc_id="d2")
+            store.upsert(chash="abc", collection="code__foo", chunk_chroma_id="d2")
             rows = store.conn.execute(
-                "SELECT chash, physical_collection, doc_id FROM chash_index"
+                "SELECT chash, physical_collection, chunk_chroma_id FROM chash_index"
             ).fetchall()
             assert rows == [("abc", "code__foo", "d2")]  # REPLACEd, not duplicated.
             new_created = store.conn.execute(
@@ -79,10 +79,10 @@ class TestChashIndexStoreBasics:
 
         store = ChashIndex(tmp_path / "t2.db")
         try:
-            store.upsert(chash="abc", collection="knowledge__delos",         doc_id="d1")
-            store.upsert(chash="abc", collection="knowledge__delos_docling", doc_id="d2")
+            store.upsert(chash="abc", collection="knowledge__delos",         chunk_chroma_id="d1")
+            store.upsert(chash="abc", collection="knowledge__delos_docling", chunk_chroma_id="d2")
             rows = sorted(store.conn.execute(
-                "SELECT chash, physical_collection, doc_id FROM chash_index"
+                "SELECT chash, physical_collection, chunk_chroma_id FROM chash_index"
             ).fetchall())
             assert rows == [
                 ("abc", "knowledge__delos",         "d1"),
@@ -97,18 +97,18 @@ class TestChashIndexStoreBasics:
 
         store = ChashIndex(tmp_path / "t2.db")
         try:
-            store.upsert(chash="abc", collection="A", doc_id="d1")
-            store.upsert(chash="abc", collection="B", doc_id="d2")
-            store.upsert(chash="xyz", collection="A", doc_id="d3")
+            store.upsert(chash="abc", collection="A", chunk_chroma_id="d1")
+            store.upsert(chash="abc", collection="B", chunk_chroma_id="d2")
+            store.upsert(chash="xyz", collection="A", chunk_chroma_id="d3")
 
             results = store.lookup("abc")
-            assert sorted((r["collection"], r["doc_id"]) for r in results) == [
+            assert sorted((r["collection"], r["chunk_chroma_id"]) for r in results) == [
                 ("A", "d1"),
                 ("B", "d2"),
             ]
 
             results = store.lookup("xyz")
-            assert [(r["collection"], r["doc_id"]) for r in results] == [("A", "d3")]
+            assert [(r["collection"], r["chunk_chroma_id"]) for r in results] == [("A", "d3")]
 
             results = store.lookup("notfound")
             assert results == []
@@ -121,15 +121,15 @@ class TestChashIndexStoreBasics:
 
         store = ChashIndex(tmp_path / "t2.db")
         try:
-            store.upsert(chash="abc", collection="A", doc_id="d1")
-            store.upsert(chash="abc", collection="B", doc_id="d2")
-            store.upsert(chash="xyz", collection="A", doc_id="d3")
+            store.upsert(chash="abc", collection="A", chunk_chroma_id="d1")
+            store.upsert(chash="abc", collection="B", chunk_chroma_id="d2")
+            store.upsert(chash="xyz", collection="A", chunk_chroma_id="d3")
 
             deleted = store.delete_collection("A")
             assert deleted == 2
 
             remaining = sorted(store.conn.execute(
-                "SELECT chash, physical_collection, doc_id FROM chash_index"
+                "SELECT chash, physical_collection, chunk_chroma_id FROM chash_index"
             ).fetchall())
             assert remaining == [("abc", "B", "d2")]
 
@@ -158,7 +158,7 @@ class TestChashIndexConcurrency:
                 store.upsert(
                     chash=f"chash_{i:04d}",
                     collection=f"coll_{i % 8}",
-                    doc_id=f"doc_{i}",
+                    chunk_chroma_id=f"doc_{i}",
                 )
 
             with ThreadPoolExecutor(max_workers=3) as ex:
@@ -186,7 +186,7 @@ class TestT2DatabaseFacadeWiring:
         try:
             assert hasattr(db, "chash_index"), "T2Database must expose db.chash_index"
             # Reachable through the facade + functional.
-            db.chash_index.upsert(chash="abc", collection="A", doc_id="d1")
+            db.chash_index.upsert(chash="abc", collection="A", chunk_chroma_id="d1")
             results = db.chash_index.lookup("abc")
             assert results and results[0]["collection"] == "A"
         finally:
@@ -215,7 +215,7 @@ class TestChashIndexErrors:
         store = ChashIndex(tmp_path / "t2.db")
         try:
             with pytest.raises(ValueError, match="chash"):
-                store.upsert(chash="", collection="A", doc_id="d1")
+                store.upsert(chash="", collection="A", chunk_chroma_id="d1")
         finally:
             store.close()
 
@@ -225,17 +225,17 @@ class TestChashIndexErrors:
         store = ChashIndex(tmp_path / "t2.db")
         try:
             with pytest.raises(ValueError, match="collection"):
-                store.upsert(chash="abc", collection="", doc_id="d1")
+                store.upsert(chash="abc", collection="", chunk_chroma_id="d1")
         finally:
             store.close()
 
-    def test_upsert_raises_on_empty_doc_id(self, tmp_path: Path) -> None:
+    def test_upsert_raises_on_empty_chunk_chroma_id(self, tmp_path: Path) -> None:
         from nexus.db.t2.chash_index import ChashIndex
 
         store = ChashIndex(tmp_path / "t2.db")
         try:
-            with pytest.raises(ValueError, match="doc_id"):
-                store.upsert(chash="abc", collection="A", doc_id="")
+            with pytest.raises(ValueError, match="chunk_chroma_id"):
+                store.upsert(chash="abc", collection="A", chunk_chroma_id="")
         finally:
             store.close()
 
@@ -255,8 +255,8 @@ class TestChashIndexEncapsulation:
 
         store = ChashIndex(tmp_path / "t2.db")
         try:
-            store.upsert(chash="aa", collection="c1", doc_id="d1")
-            store.upsert(chash="aa", collection="c2", doc_id="d2")
+            store.upsert(chash="aa", collection="c1", chunk_chroma_id="d1")
+            store.upsert(chash="aa", collection="c2", chunk_chroma_id="d2")
             removed = store.delete_stale(chash="aa", collection="c1")
             assert removed == 1
             rows = sorted(store.conn.execute(
@@ -287,7 +287,7 @@ class TestChashIndexEncapsulation:
             # Seed 100 rows, then have two threads racing delete_stale + upsert
             # on disjoint keys. Both must complete without DB lock errors.
             for i in range(100):
-                store.upsert(chash=f"h{i:03d}", collection="race", doc_id=f"d{i}")
+                store.upsert(chash=f"h{i:03d}", collection="race", chunk_chroma_id=f"d{i}")
 
             errors: list[BaseException] = []
 
@@ -305,7 +305,7 @@ class TestChashIndexEncapsulation:
                     for i in range(100, 150):
                         store.upsert(
                             chash=f"h{i:03d}", collection="race",
-                            doc_id=f"d{i}",
+                            chunk_chroma_id=f"d{i}",
                         )
                 except BaseException as e:
                     errors.append(e)
@@ -331,7 +331,7 @@ class TestChashIndexEncapsulation:
 
         store = ChashIndex(tmp_path / "t2.db")
         try:
-            store.upsert(chash="h", collection="c", doc_id="d")
+            store.upsert(chash="h", collection="c", chunk_chroma_id="d")
             assert store.is_empty() is False
         finally:
             store.close()
@@ -360,7 +360,7 @@ class TestDualWriteHelper:
             dual_write_chash_index(store, "code__foo", ids, metadatas)
 
             rows = sorted(store.conn.execute(
-                "SELECT chash, physical_collection, doc_id FROM chash_index"
+                "SELECT chash, physical_collection, chunk_chroma_id FROM chash_index"
             ).fetchall())
             assert rows == [
                 ("hash1", "code__foo", "doc1"),
@@ -392,7 +392,7 @@ class TestDualWriteHelper:
             dual_write_chash_index(store, "coll", ids, metadatas)
 
             rows = store.conn.execute(
-                "SELECT chash, doc_id FROM chash_index"
+                "SELECT chash, chunk_chroma_id FROM chash_index"
             ).fetchall()
             assert rows == [("hash1", "doc1")]
         finally:
@@ -419,7 +419,7 @@ class TestDualWriteHelper:
 
             # Rows with valid args still inserted.
             rows = sorted(store.conn.execute(
-                "SELECT chash, doc_id FROM chash_index"
+                "SELECT chash, chunk_chroma_id FROM chash_index"
             ).fetchall())
             assert rows == [("hash2", "doc2"), ("hash3", "doc3")]
         finally:
@@ -479,10 +479,10 @@ class TestChashDualWriteBatchEntryPoint:
 
         with T2Database(db_path) as db:
             assert db.chash_index.lookup("aa11") == [
-                {"collection": "code__example", "doc_id": "doc1",
+                {"collection": "code__example", "chunk_chroma_id": "doc1",
                  "created_at": db.chash_index.lookup("aa11")[0]["created_at"]},
             ]
-            assert db.chash_index.lookup("bb22")[0]["doc_id"] == "doc2"
+            assert db.chash_index.lookup("bb22")[0]["chunk_chroma_id"] == "doc2"
 
     def test_chash_dual_write_batch_empty_is_noop(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_collection_audit.py
+++ b/tests/test_collection_audit.py
@@ -404,7 +404,7 @@ class TestChashCoverageSection:
         idx = ChashIndex(db_path)
         try:
             for chash, coll, doc_id in rows:
-                idx.upsert(chash=chash, collection=coll, doc_id=doc_id)
+                idx.upsert(chash=chash, collection=coll, chunk_chroma_id=doc_id)
         finally:
             idx.close()
 

--- a/tests/test_collection_rename.py
+++ b/tests/test_collection_rename.py
@@ -39,9 +39,9 @@ class TestChashIndexRename:
         from nexus.db.t2.chash_index import ChashIndex
 
         idx = ChashIndex(tmp_path / "chash.db")
-        idx.upsert(chash="aa", collection="code__old", doc_id="d1")
-        idx.upsert(chash="bb", collection="code__old", doc_id="d2")
-        idx.upsert(chash="cc", collection="code__stays", doc_id="d3")
+        idx.upsert(chash="aa", collection="code__old", chunk_chroma_id="d1")
+        idx.upsert(chash="bb", collection="code__old", chunk_chroma_id="d2")
+        idx.upsert(chash="cc", collection="code__stays", chunk_chroma_id="d3")
 
         count = idx.rename_collection(old="code__old", new="code__new")
         assert count == 2
@@ -61,22 +61,22 @@ class TestChashIndexRename:
         assert (old_rows, new_rows, stays_rows) == (0, 2, 1)
 
     def test_pk_collision_new_side_wins(self, tmp_path: Path) -> None:
-        """When `(chash, new)` already exists, the rename's updated doc_id
+        """When `(chash, new)` already exists, the rename's updated chunk_chroma_id
         must win — pre-existing new-side row is cleared first."""
         from nexus.db.t2.chash_index import ChashIndex
 
         idx = ChashIndex(tmp_path / "chash.db")
-        idx.upsert(chash="aa", collection="code__old", doc_id="from_old")
-        idx.upsert(chash="aa", collection="code__new", doc_id="stale_new")
+        idx.upsert(chash="aa", collection="code__old", chunk_chroma_id="from_old")
+        idx.upsert(chash="aa", collection="code__new", chunk_chroma_id="stale_new")
 
         count = idx.rename_collection(old="code__old", new="code__new")
         assert count == 1
 
-        doc_id = idx.conn.execute(
-            "SELECT doc_id FROM chash_index WHERE chash = ? AND physical_collection = ?",
+        chunk_chroma_id = idx.conn.execute(
+            "SELECT chunk_chroma_id FROM chash_index WHERE chash = ? AND physical_collection = ?",
             ("aa", "code__new"),
         ).fetchone()[0]
-        assert doc_id == "from_old"
+        assert chunk_chroma_id == "from_old"
 
     def test_no_rows_returns_zero(self, tmp_path: Path) -> None:
         from nexus.db.t2.chash_index import ChashIndex
@@ -274,7 +274,7 @@ class TestRenameCLI:
         from nexus.db.t2 import T2Database
         with T2Database(db_path) as db:
             db.chash_index.upsert(
-                chash="aa", collection="code__old", doc_id="d1",
+                chash="aa", collection="code__old", chunk_chroma_id="d1",
             )
 
         fake = self._fake_t3(old_exists=True, new_exists=False)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -89,12 +89,14 @@ class TestMigrationDataclass:
         # plans.disabled_at column (4.17.1, nexus-mrzp soft-disable) +
         # retire hook_telemetry table — telemetry hook removed entirely
         # (4.18.1; the migration entry that previously created the table
-        # was dropped when the read/write surface was retired)
-        # = 28.
+        # was dropped when the read/write surface was retired) +
+        # rename chash_index.doc_id → chunk_chroma_id (4.21.3, RDR-101
+        # Phase 0 nexus-o6aa.3 collision resolution)
+        # = 29.
         # Prefer the name-based checks in TestBackfillPlanDimensions
         # and TestAddPlanMatchTextColumn for future guards; this
         # count is a cheap sentinel only.
-        assert len(MIGRATIONS) == 28
+        assert len(MIGRATIONS) == 29
 
     def test_migrations_ordered_by_version(self) -> None:
         from nexus.db.migrations import MIGRATIONS, _parse_version
@@ -1227,11 +1229,23 @@ class TestMigrateChashIndex:
         assert "chash_index" in tables
 
     def test_chash_index_schema_columns(self) -> None:
-        """Columns match the bead spec: chash, physical_collection, doc_id, created_at — all TEXT."""
-        from nexus.db.migrations import migrate_chash_index
+        """Columns match the post-RDR-101 spec: chash, physical_collection, chunk_chroma_id, created_at — all TEXT.
+
+        Both ``migrate_chash_index`` (RDR-086 Phase 1.1 install) and
+        ``migrate_chash_index_rename_doc_id`` (RDR-101 Phase 0
+        nexus-o6aa.3) must run together because production hosts always
+        receive both migrations: the install migration creates the table
+        with the legacy ``doc_id`` column, the rename migration renames
+        it to ``chunk_chroma_id``. Test reflects the production end state.
+        """
+        from nexus.db.migrations import (
+            migrate_chash_index,
+            migrate_chash_index_rename_doc_id,
+        )
 
         conn = sqlite3.connect(":memory:")
         migrate_chash_index(conn)
+        migrate_chash_index_rename_doc_id(conn)
 
         cols = {
             r[1]: r[2]
@@ -1239,10 +1253,10 @@ class TestMigrateChashIndex:
                 "PRAGMA table_info(chash_index)"
             ).fetchall()
         }
-        assert cols.keys() == {"chash", "physical_collection", "doc_id", "created_at"}
+        assert cols.keys() == {"chash", "physical_collection", "chunk_chroma_id", "created_at"}
         assert cols["chash"] == "TEXT"
         assert cols["physical_collection"] == "TEXT"
-        assert cols["doc_id"] == "TEXT"
+        assert cols["chunk_chroma_id"] == "TEXT"
         assert cols["created_at"] == "TEXT"
 
     def test_chash_index_compound_pk_allows_duplicate_hash_different_collection(self) -> None:
@@ -1252,10 +1266,14 @@ class TestMigrateChashIndex:
         Issue 1: knowledge__delos + knowledge__delos_docling both ingest a
         paper; every chunk's SHA-256 is identical.
         """
-        from nexus.db.migrations import migrate_chash_index
+        from nexus.db.migrations import (
+            migrate_chash_index,
+            migrate_chash_index_rename_doc_id,
+        )
 
         conn = sqlite3.connect(":memory:")
         migrate_chash_index(conn)
+        migrate_chash_index_rename_doc_id(conn)
 
         conn.execute(
             "INSERT INTO chash_index VALUES (?, ?, ?, ?)",
@@ -1268,7 +1286,7 @@ class TestMigrateChashIndex:
         conn.commit()
 
         rows = conn.execute(
-            "SELECT physical_collection, doc_id FROM chash_index WHERE chash = ? ORDER BY physical_collection",
+            "SELECT physical_collection, chunk_chroma_id FROM chash_index WHERE chash = ? ORDER BY physical_collection",
             ("abc123",),
         ).fetchall()
         assert rows == [
@@ -1337,25 +1355,90 @@ class TestMigrateChashIndex:
         assert [name for _, name in pk_cols] == ["chash", "physical_collection"]
 
     def test_chash_index_migration_idempotent(self) -> None:
-        """Re-applying on a populated DB must not raise or clobber data."""
-        from nexus.db.migrations import migrate_chash_index
+        """Re-applying on a populated DB must not raise or clobber data.
+
+        The full production sequence is install + rename; both must be
+        idempotent so a re-attempted upgrade after a partial failure
+        does not double-mutate.
+        """
+        from nexus.db.migrations import (
+            migrate_chash_index,
+            migrate_chash_index_rename_doc_id,
+        )
 
         conn = sqlite3.connect(":memory:")
         migrate_chash_index(conn)
+        migrate_chash_index_rename_doc_id(conn)
         conn.execute(
             "INSERT INTO chash_index VALUES (?, ?, ?, ?)",
             ("abc123", "knowledge__delos", "doc-1", "2026-04-18T00:00:00Z"),
         )
         conn.commit()
 
-        migrate_chash_index(conn)  # must not raise
-        migrate_chash_index(conn)  # must not raise
+        migrate_chash_index(conn)              # must not raise
+        migrate_chash_index_rename_doc_id(conn)  # must not raise (no-op when already renamed)
+        migrate_chash_index(conn)              # must not raise
+        migrate_chash_index_rename_doc_id(conn)  # must not raise
 
         # Data preserved.
         row = conn.execute(
-            "SELECT chash, physical_collection, doc_id FROM chash_index"
+            "SELECT chash, physical_collection, chunk_chroma_id FROM chash_index"
         ).fetchone()
         assert row == ("abc123", "knowledge__delos", "doc-1")
+
+    def test_chash_index_rename_doc_id_runs_against_legacy_column(self) -> None:
+        """The rename migration converts a legacy ``doc_id`` column to ``chunk_chroma_id``.
+
+        This exercises path 3 from ``migrate_chash_index_rename_doc_id``'s
+        idempotency contract: table present with legacy ``doc_id`` column
+        → ALTER TABLE renames in place.
+        """
+        from nexus.db.migrations import (
+            migrate_chash_index,
+            migrate_chash_index_rename_doc_id,
+        )
+
+        conn = sqlite3.connect(":memory:")
+        # Install creates the legacy ``doc_id`` column.
+        migrate_chash_index(conn)
+        legacy_cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(chash_index)").fetchall()
+        }
+        assert "doc_id" in legacy_cols
+        assert "chunk_chroma_id" not in legacy_cols
+
+        # Rename migration converts in place; data must survive.
+        conn.execute(
+            "INSERT INTO chash_index VALUES (?, ?, ?, ?)",
+            ("aa", "code__x", "chunk-7", "2026-04-30T00:00:00Z"),
+        )
+        conn.commit()
+        migrate_chash_index_rename_doc_id(conn)
+
+        new_cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(chash_index)").fetchall()
+        }
+        assert "chunk_chroma_id" in new_cols
+        assert "doc_id" not in new_cols
+
+        row = conn.execute(
+            "SELECT chash, physical_collection, chunk_chroma_id FROM chash_index"
+        ).fetchone()
+        assert row == ("aa", "code__x", "chunk-7")
+
+    def test_chash_index_rename_doc_id_no_op_on_fresh_install(self) -> None:
+        """Path 1: table absent → rename migration is a no-op (no error)."""
+        from nexus.db.migrations import migrate_chash_index_rename_doc_id
+
+        conn = sqlite3.connect(":memory:")
+        # No prior install of chash_index.
+        migrate_chash_index_rename_doc_id(conn)  # must not raise
+
+        # Table still absent.
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='chash_index'"
+        ).fetchone()
+        assert row is None
 
     def test_chash_index_in_migrations_list(self) -> None:
         from nexus.db.migrations import MIGRATIONS

--- a/tests/test_nexus_lub_collection_delete_cascade.py
+++ b/tests/test_nexus_lub_collection_delete_cascade.py
@@ -362,14 +362,14 @@ class TestChashIndexDeleteCascade:
         db_path = tmp_path / "memory.db"
         with T2Database(db_path) as db:
             db.chash_index.upsert(
-                chash="aa11", collection="code__gone", doc_id="d1",
+                chash="aa11", collection="code__gone", chunk_chroma_id="d1",
             )
             db.chash_index.upsert(
-                chash="bb22", collection="code__gone", doc_id="d2",
+                chash="bb22", collection="code__gone", chunk_chroma_id="d2",
             )
             # Row in a different collection — must survive the cascade.
             db.chash_index.upsert(
-                chash="cc33", collection="code__stays", doc_id="d3",
+                chash="cc33", collection="code__stays", chunk_chroma_id="d3",
             )
 
         fake_t3 = MagicMock()
@@ -414,7 +414,7 @@ class TestChashIndexDeleteCascade:
         db_path = tmp_path / "memory.db"
         with T2Database(db_path) as db:
             db.chash_index.upsert(
-                chash="aa11", collection="docs__orphan", doc_id="d1",
+                chash="aa11", collection="docs__orphan", chunk_chroma_id="d1",
             )
 
         fake_t3 = MagicMock()
@@ -456,7 +456,7 @@ class TestChashIndexDeleteCascade:
         with T2Database(db_path) as db:
             for i in range(5):
                 db.chash_index.upsert(
-                    chash=f"h{i:02d}", collection="code__reported", doc_id=f"d{i}",
+                    chash=f"h{i:02d}", collection="code__reported", chunk_chroma_id=f"d{i}",
                 )
 
         fake_t3 = MagicMock()

--- a/tests/test_phase4_doc_commands.py
+++ b/tests/test_phase4_doc_commands.py
@@ -58,7 +58,7 @@ def _seed_catalog_and_t3(tmp_path: Path):
 
     chash_index = ChashIndex(tmp_path / "t2.db")
     chash_index.upsert(
-        chash=chash, collection="knowledge__phase4", doc_id="doc:0:chunk:0",
+        chash=chash, collection="knowledge__phase4", chunk_chroma_id="doc:0:chunk:0",
     )
     return cat, t3, chash_index, chash
 

--- a/tests/test_phase5_doc_cite.py
+++ b/tests/test_phase5_doc_cite.py
@@ -48,7 +48,7 @@ def cite_env(tmp_path: Path):
 
     chash_index = ChashIndex(tmp_path / "t2.db")
     chash_index.upsert(
-        chash=chash_hex, collection="knowledge__cite", doc_id="doc:0:chunk:0",
+        chash=chash_hex, collection="knowledge__cite", chunk_chroma_id="doc:0:chunk:0",
     )
     yield cat, t3, chash_index, chash_hex
     chash_index.close()
@@ -211,10 +211,10 @@ class TestCiteTiedCandidatesNote:
 
         # Register a second row so the empty-index guard passes.
         chash_index.upsert(
-            chash=c1, collection="knowledge__cite", doc_id="doc:0:chunk:0",
+            chash=c1, collection="knowledge__cite", chunk_chroma_id="doc:0:chunk:0",
         )
         chash_index.upsert(
-            chash=c2, collection="knowledge__cite", doc_id="doc:0:chunk:0",
+            chash=c2, collection="knowledge__cite", chunk_chroma_id="doc:0:chunk:0",
         )
 
         def _fake_search(**kwargs):
@@ -245,10 +245,10 @@ class TestCiteTiedCandidatesNote:
         cat, t3, chash_index, _ = cite_env
         c1, c2 = "a" * 64, "b" * 64
         chash_index.upsert(
-            chash=c1, collection="knowledge__cite", doc_id="doc:0:chunk:0",
+            chash=c1, collection="knowledge__cite", chunk_chroma_id="doc:0:chunk:0",
         )
         chash_index.upsert(
-            chash=c2, collection="knowledge__cite", doc_id="doc:0:chunk:0",
+            chash=c2, collection="knowledge__cite", chunk_chroma_id="doc:0:chunk:0",
         )
 
         def _fake_search(**kwargs):

--- a/tests/test_resolve_chash.py
+++ b/tests/test_resolve_chash.py
@@ -44,7 +44,7 @@ def _seed_chunk(
         documents=[text],
         metadatas=[{"chunk_text_hash": chash, "source_path": "s.py"}],
     )
-    chash_index.upsert(chash=chash, collection=collection, doc_id=chunk_id)
+    chash_index.upsert(chash=chash, collection=collection, chunk_chroma_id=chunk_id)
 
 
 # ── ChunkRef type ────────────────────────────────────────────────────────────
@@ -117,13 +117,13 @@ class TestResolveChashT2Hit:
         with chash_index._lock:
             chash_index.conn.execute(
                 "INSERT OR REPLACE INTO chash_index "
-                "(chash, physical_collection, doc_id, created_at) "
+                "(chash, physical_collection, chunk_chroma_id, created_at) "
                 "VALUES (?, ?, ?, ?)",
                 (h, "code__old", "c-old", "2025-01-01T00:00:00+00:00"),
             )
             chash_index.conn.execute(
                 "INSERT OR REPLACE INTO chash_index "
-                "(chash, physical_collection, doc_id, created_at) "
+                "(chash, physical_collection, chunk_chroma_id, created_at) "
                 "VALUES (?, ?, ?, ?)",
                 (h, "code__new", "c-new", "2026-04-18T00:00:00+00:00"),
             )
@@ -160,7 +160,7 @@ class TestResolveChashSelfHeal:
         cat, t3, chash_index = resolve_env
         h = "e" * 64
         # Register a chash pointing at a collection that does not exist in T3.
-        chash_index.upsert(chash=h, collection="code__deleted", doc_id="ghost")
+        chash_index.upsert(chash=h, collection="code__deleted", chunk_chroma_id="ghost")
         # And a live one.
         _seed_chunk(t3, chash_index, "code__live", "real-id", "real text", h)
 


### PR DESCRIPTION
## Summary

Phase 1 PR E of RDR-101. Eliminates the namespace collision between RDR-086's ``chash_index.doc_id`` (ChromaDB-scoped chunk natural ID, equivalent to RDR-101's ``Chunk.chunk_id``) and RDR-101's ``Document.doc_id`` (UUID7 document identity) before Phase 3 ships native v: 1 writes. Option A from the Phase 0 deliverable ``docs/rdr/post-mortem/rdr-101-rdr086-collision.md``.

### What lands

**T2 schema:**
- New migration ``migrate_chash_index_rename_doc_id`` at version ``4.21.3``. Idempotent across three states: table absent (no-op), table present with ``chunk_chroma_id`` (already migrated, no-op), table present with legacy ``doc_id`` column (``ALTER TABLE RENAME COLUMN`` in place). PK ``(chash, physical_collection)`` and the ``idx_chash_index_collection`` secondary index untouched.
- ``_CHASH_INDEX_SCHEMA_SQL`` in ``chash_index.py`` uses the new column name for fresh installs.
- ``conexus`` version bumped to ``4.21.3`` so ``apply_pending`` picks up the new migration.

**Public API:**
- ``ChashIndex.upsert(*, doc_id=)`` → ``upsert(*, chunk_chroma_id=)``.
- ``ChashIndex.lookup()`` returns dicts with key ``chunk_chroma_id`` (was ``doc_id``).
- ``ChashIndex.doc_ids_present_in_collection`` → ``chunk_chroma_ids_present_in_collection``.
- ``dual_write_chash_index`` uses ``chunk_chroma_id`` local + structured-log field.

**Back-compat boundary (intentional):**
- ``Catalog.resolve_chash`` continues to surface the Chroma natural ID under the ``doc_id`` key on the returned ``ChunkRef``. The Phase 0 deliverable's Open Question recommends a parallel ``chunk_chroma_id`` key for that surface; it lands as part of RDR-101 Phase 3 with the wider ``doc_id``-vs-``chunk_chroma_id`` disambiguation, not here.
- Indirect callers (``commands/doc.py``, ``mcp_infra.dual_write_chash_index_batch_hook``, etc.) consume the ChunkRef via ``Catalog.resolve_chash`` and see no rename in this PR.

### Test updates

- ``tests/test_chash_index_store.py``: kwarg + dict-key + raw-SQL renames; ``test_upsert_raises_on_empty_doc_id`` renamed.
- ``tests/test_resolve_chash.py``, ``test_collection_rename.py``, ``test_collection_audit.py``, ``test_phase4_doc_commands.py``, ``test_phase5_doc_cite.py``, ``test_nexus_lub_collection_delete_cascade.py``, ``test_backfill_hash.py``: kwarg + raw-SQL renames.
- ``tests/test_migrations.py``: schema/idempotency tests now run both ``migrate_chash_index`` and ``migrate_chash_index_rename_doc_id`` (production end state); two new tests cover the rename's path 1 (table absent) and path 3 (legacy column → renamed); ``MIGRATIONS`` count bumped 28 → 29.

### Test plan

- [x] 461 tests passing across catalog + chash_index + Phase 1 modules locally.
- [ ] One pre-existing flake (``test_collection_audit.py::TestLiveDistanceProbe::test_live_histogram_empty_when_collection_empty``) passes alone but races a sibling test in the same file under broader-suite ordering — present on ``main`` before this PR; not introduced here.
- [ ] CI green.

### Refs

- RDR-101 Phase 0 deliverable nexus-o6aa.3 (``docs/rdr/post-mortem/rdr-101-rdr086-collision.md``)
- RDR-086 §Schema; RDR-101 §Entities (``Chunk.chunk_id PK 'Chroma natural ID, NOT chash'``)

Bead: ``nexus-z1p8`` (Phase 1 sub-PR E under ``nexus-o6aa.7``).