### PR TITLE
rdr-101(phase1): Frecency projection + Document bib columns

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -438,3 +438,6 @@
 {"id":"int-f16a9966","kind":"field_change","created_at":"2026-05-01T02:35:07.854277Z","actor":"Hellblazer","issue_id":"nexus-tu0d","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-8537a50c","kind":"field_change","created_at":"2026-05-01T02:57:57.362748Z","actor":"Hellblazer","issue_id":"nexus-tu0d","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-3a1aca3e","kind":"field_change","created_at":"2026-05-01T02:58:17.566572Z","actor":"Hellblazer","issue_id":"nexus-2iig","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-4233f296","kind":"field_change","created_at":"2026-05-01T03:16:44.532441Z","actor":"Hellblazer","issue_id":"nexus-2iig","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-dc537d9f","kind":"field_change","created_at":"2026-05-01T03:16:44.844463Z","actor":"Hellblazer","issue_id":"nexus-z1p8","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-abcf612c","kind":"field_change","created_at":"2026-05-01T08:34:40.061282Z","actor":"Hellblazer","issue_id":"nexus-knn3","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.21.3"
+version = "4.21.4"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -52,7 +52,26 @@ CREATE TABLE IF NOT EXISTS documents (
     -- RDR-096 P2.1: persistent URI identity. ``''`` (empty) on
     -- legacy rows; populated for new registers after P2.1 ships.
     -- Backfill derives URIs from ``file_path + physical_collection``.
-    source_uri TEXT NOT NULL DEFAULT ''
+    source_uri TEXT NOT NULL DEFAULT '',
+    -- RDR-101 Phase 1 PR D (nexus-knn3): bibliographic enrichment
+    -- columns from the bib disposition deliverable
+    -- (docs/rdr/post-mortem/rdr-101-bib-disposition.md, Option A).
+    -- The bib_* fields move OFF T3 chunk metadata and live exactly once
+    -- on the Document projection. Phase 1 ships the empty columns;
+    -- Phase 3 wires DocumentEnriched v: 1 events to populate them
+    -- through the projector. The two indexed ID columns are the
+    -- "this title was enriched on backend X" cardinality marker that
+    -- nx enrich bib's skip query will read against (Phase 4); the
+    -- partial indexes (created below) make that query a sub-millisecond
+    -- presence test instead of a 300-row Chroma pagination.
+    bib_year INTEGER NOT NULL DEFAULT 0,
+    bib_authors TEXT NOT NULL DEFAULT '',
+    bib_venue TEXT NOT NULL DEFAULT '',
+    bib_citation_count INTEGER NOT NULL DEFAULT 0,
+    bib_semantic_scholar_id TEXT NOT NULL DEFAULT '',
+    bib_openalex_id TEXT NOT NULL DEFAULT '',
+    bib_doi TEXT NOT NULL DEFAULT '',
+    bib_enriched_at TEXT NOT NULL DEFAULT ''
 );
 
 CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
@@ -104,6 +123,11 @@ CREATE INDEX IF NOT EXISTS idx_links_created_by_type
 
 CREATE INDEX IF NOT EXISTS idx_documents_tumbler
     ON documents(tumbler);
+
+-- RDR-101 Phase 1 PR D (nexus-knn3) partial indexes on bib backend IDs
+-- live in the post-migration block in __init__: the legacy-DB upgrade
+-- path has to ALTER TABLE the bib columns into existence before the
+-- partial-index CREATE can reference them.
 """
 
 
@@ -161,6 +185,49 @@ class CatalogDB:
                 self._conn.execute(
                     "ALTER TABLE documents ADD COLUMN source_uri TEXT NOT NULL DEFAULT ''"
                 )
+
+        # RDR-101 Phase 1 PR D (nexus-knn3): add bib_* columns to existing
+        # databases. The bib disposition deliverable
+        # (docs/rdr/post-mortem/rdr-101-bib-disposition.md, Option A)
+        # moves these fields off T3 chunk metadata and onto the Document
+        # projection. Phase 1 ships the columns empty; Phase 3 wires the
+        # projector to populate them from DocumentEnriched v: 1 events.
+        # Each ALTER probes for the column first; failure means it was
+        # added in a previous run (idempotent migration pattern matches
+        # the rest of this method).
+        for col_name, col_decl in (
+            ("bib_year",                "INTEGER NOT NULL DEFAULT 0"),
+            ("bib_authors",             "TEXT NOT NULL DEFAULT ''"),
+            ("bib_venue",               "TEXT NOT NULL DEFAULT ''"),
+            ("bib_citation_count",      "INTEGER NOT NULL DEFAULT 0"),
+            ("bib_semantic_scholar_id", "TEXT NOT NULL DEFAULT ''"),
+            ("bib_openalex_id",         "TEXT NOT NULL DEFAULT ''"),
+            ("bib_doi",                 "TEXT NOT NULL DEFAULT ''"),
+            ("bib_enriched_at",         "TEXT NOT NULL DEFAULT ''"),
+        ):
+            try:
+                self._conn.execute(f"SELECT {col_name} FROM documents LIMIT 0")
+            except sqlite3.OperationalError:
+                with self._conn:
+                    self._conn.execute(
+                        f"ALTER TABLE documents ADD COLUMN {col_name} {col_decl}"
+                    )
+
+        # Partial indexes on the two bib backend IDs. CREATE INDEX IF NOT
+        # EXISTS is safe on a fresh DB (where _SCHEMA_SQL already created
+        # them) and on existing DBs (where the columns just landed via
+        # ALTER above).
+        with self._conn:
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_documents_bib_s2_id "
+                "ON documents(bib_semantic_scholar_id) "
+                "WHERE bib_semantic_scholar_id != ''"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_documents_bib_oa_id "
+                "ON documents(bib_openalex_id) "
+                "WHERE bib_openalex_id != ''"
+            )
 
     def rebuild(
         self,

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -822,6 +822,49 @@ def migrate_chash_index(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def migrate_frecency_projection_table(conn: sqlite3.Connection) -> None:
+    """Create the ``frecency`` projection table (RDR-101 Phase 1 PR D).
+
+    Phase 0 design gap 1 surfaced that RDR-101 §Entities omitted a
+    Frecency projection while Phase 5 plans to relocate
+    ``frecency_score`` / ``ttl_days`` / ``miss_count`` /
+    ``last_hit_at`` / ``embedded_at`` off T3 chunk metadata. This
+    migration ships the schema; Phase 5 will fill in the read/write
+    paths once the relocation work begins.
+
+    Schema choices (Phase 1 simpler-path direction, 2026-05-01):
+
+    - ``chunk_id`` is the FK back to ``Chunk.chunk_id`` (the Chroma
+      natural ID, also the PK of the future Phase 5 ``chunks`` table).
+      Phase 1 has no ``chunks`` table to FK into, so the relationship
+      is enforced by convention; Phase 5 makes it a real FK.
+    - ``expires_at`` is NOT a column. Decay queries derive it from
+      ``(embedded_at + ttl_days)`` at read time. If the read pattern
+      ever forces a ``WHERE expires_at < ?`` index seek, a generated
+      column or a follow-up migration can materialize it; Phase 1
+      does not predict that need.
+    - The Frecency projection is a mutable side table — Phase 1 does
+      NOT participate in the event log. ``ChunkAccessed`` /
+      ``ChunkMissed`` events are out of scope for now; if the doctor
+      verb later needs to verify frecency state matches the log, a
+      sub-RDR can introduce them.
+
+    Idempotent: ``CREATE IF NOT EXISTS`` makes re-application a no-op.
+    """
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS frecency (
+            chunk_id        TEXT PRIMARY KEY,
+            embedded_at     TEXT NOT NULL DEFAULT '',
+            ttl_days        INTEGER NOT NULL DEFAULT 0,
+            frecency_score  REAL NOT NULL DEFAULT 0,
+            miss_count      INTEGER NOT NULL DEFAULT 0,
+            last_hit_at     TEXT NOT NULL DEFAULT ''
+        );
+    """)
+    conn.commit()
+    _log.info("Migrated: created frecency projection table (RDR-101 Phase 1 PR D)")
+
+
 def migrate_chash_index_rename_doc_id(conn: sqlite3.Connection) -> None:
     """Rename ``chash_index.doc_id`` to ``chunk_chroma_id`` (RDR-101 Phase 0).
 
@@ -1778,6 +1821,11 @@ MIGRATIONS: list[Migration] = [
         "4.21.3",
         "Rename chash_index.doc_id to chunk_chroma_id (RDR-101 Phase 0 nexus-o6aa.3)",
         migrate_chash_index_rename_doc_id,
+    ),
+    Migration(
+        "4.21.4",
+        "Create frecency projection table (RDR-101 Phase 1 PR D nexus-knn3)",
+        migrate_frecency_projection_table,
     ),
 ]
 

--- a/tests/test_catalog_documents_bib_columns.py
+++ b/tests/test_catalog_documents_bib_columns.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 1 PR D bib columns on the catalog Document projection.
+
+Coverage:
+- Fresh CatalogDB construction yields all 8 bib_* columns with the
+  documented types and defaults (the schema_sql path).
+- A pre-bib-columns CatalogDB (simulated by dropping the columns from a
+  fresh schema, then reconstructing) gets the columns added via the
+  inline ALTER TABLE migration (the upgrade path).
+- Both partial indexes exist after construction, in either path.
+- The partial indexes are actually partial (the WHERE clause survives
+  the migration; without it, an indexed seek of "is enriched on
+  backend X" reads every row).
+- Existing rows survive the upgrade with empty bib_* defaults.
+- Insert/update round-trips of bib_* values land verbatim.
+
+Phase 1 only ships the schema; no projector handler populates these
+columns yet (Phase 3 wires DocumentEnriched v: 1 → projection). These
+tests therefore use direct SQLite writes to exercise the schema
+contract, not the projector.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog.catalog_db import CatalogDB
+
+
+_BIB_COLUMNS: dict[str, tuple[str, str]] = {
+    "bib_year":                ("INTEGER", "0"),
+    "bib_authors":             ("TEXT",    "''"),
+    "bib_venue":               ("TEXT",    "''"),
+    "bib_citation_count":      ("INTEGER", "0"),
+    "bib_semantic_scholar_id": ("TEXT",    "''"),
+    "bib_openalex_id":         ("TEXT",    "''"),
+    "bib_doi":                 ("TEXT",    "''"),
+    "bib_enriched_at":         ("TEXT",    "''"),
+}
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> dict[str, dict]:
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    return {
+        row[1]: {"type": row[2], "notnull": row[3], "dflt": row[4], "pk": row[5]}
+        for row in cur.fetchall()
+    }
+
+
+def _index_sql(conn: sqlite3.Connection, name: str) -> str | None:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name=?",
+        (name,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+# ── Fresh-install path ───────────────────────────────────────────────────
+
+
+class TestFreshSchema:
+    def test_all_bib_columns_present(self, tmp_path: Path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        try:
+            cols = _columns(db._conn, "documents")
+            for name in _BIB_COLUMNS:
+                assert name in cols, f"missing column {name}"
+        finally:
+            db.close()
+
+    def test_bib_column_types_and_defaults(self, tmp_path: Path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        try:
+            cols = _columns(db._conn, "documents")
+            for name, (expected_type, expected_dflt) in _BIB_COLUMNS.items():
+                meta = cols[name]
+                assert meta["type"] == expected_type, (
+                    f"{name}: expected type {expected_type}, got {meta['type']}"
+                )
+                # NOT NULL DEFAULT shows up as notnull=1 + dflt set
+                assert meta["notnull"] == 1, f"{name} should be NOT NULL"
+                assert meta["dflt"] == expected_dflt, (
+                    f"{name}: expected default {expected_dflt!r}, "
+                    f"got {meta['dflt']!r}"
+                )
+        finally:
+            db.close()
+
+    def test_partial_index_on_bib_s2_id(self, tmp_path: Path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        try:
+            sql = _index_sql(db._conn, "idx_documents_bib_s2_id")
+            assert sql is not None, (
+                "idx_documents_bib_s2_id index missing — Phase 4 skip-query "
+                "for nx enrich bib will scan instead of seeking"
+            )
+            # Partial: WHERE clause survives.
+            assert "bib_semantic_scholar_id" in sql
+            assert "!= ''" in sql or "<>" in sql
+        finally:
+            db.close()
+
+    def test_partial_index_on_bib_oa_id(self, tmp_path: Path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        try:
+            sql = _index_sql(db._conn, "idx_documents_bib_oa_id")
+            assert sql is not None
+            assert "bib_openalex_id" in sql
+            assert "!= ''" in sql or "<>" in sql
+        finally:
+            db.close()
+
+
+# ── Upgrade path: existing pre-bib DB ────────────────────────────────────
+
+
+class TestUpgradeFromLegacySchema:
+    """Simulate a pre-Phase-1-PR-D CatalogDB and verify the inline ALTER
+    TABLE migrations bring it up to spec."""
+
+    def test_inline_migration_adds_missing_bib_columns(self, tmp_path: Path):
+        # Create a "legacy" DB by hand: documents table without bib_*
+        # columns and with NO partial indexes. Then construct CatalogDB
+        # against the same path — the constructor's inline migrations
+        # must add the columns + indexes.
+        legacy_path = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(legacy_path))
+        try:
+            conn.executescript("""
+                CREATE TABLE documents (
+                    tumbler TEXT PRIMARY KEY,
+                    title TEXT NOT NULL,
+                    author TEXT,
+                    year INTEGER,
+                    content_type TEXT,
+                    file_path TEXT,
+                    corpus TEXT,
+                    physical_collection TEXT,
+                    chunk_count INTEGER,
+                    head_hash TEXT,
+                    indexed_at TEXT,
+                    metadata JSON,
+                    source_mtime REAL NOT NULL DEFAULT 0,
+                    alias_of TEXT NOT NULL DEFAULT '',
+                    source_uri TEXT NOT NULL DEFAULT ''
+                );
+            """)
+            # Pre-existing row: must survive the migration with empty
+            # bib_* defaults.
+            conn.execute(
+                "INSERT INTO documents (tumbler, title, author, year, "
+                "content_type, file_path, corpus, physical_collection, "
+                "chunk_count, head_hash, indexed_at, metadata, source_mtime, "
+                "alias_of, source_uri) VALUES "
+                "(?, ?, '', 0, '', '', '', '', 0, '', '', '{}', 0, '', '')",
+                ("1.1.1", "legacy-row"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Construct CatalogDB — inline migrations run.
+        db = CatalogDB(legacy_path)
+        try:
+            cols = _columns(db._conn, "documents")
+            for name, (expected_type, expected_dflt) in _BIB_COLUMNS.items():
+                assert name in cols, f"upgrade missed {name}"
+                assert cols[name]["type"] == expected_type
+                assert cols[name]["dflt"] == expected_dflt
+
+            # Partial indexes present
+            assert _index_sql(db._conn, "idx_documents_bib_s2_id") is not None
+            assert _index_sql(db._conn, "idx_documents_bib_oa_id") is not None
+
+            # Pre-existing row survived with empty bib_* defaults.
+            row = db._conn.execute(
+                "SELECT bib_year, bib_authors, bib_venue, bib_citation_count, "
+                "bib_semantic_scholar_id, bib_openalex_id, bib_doi, "
+                "bib_enriched_at FROM documents WHERE tumbler = ?",
+                ("1.1.1",),
+            ).fetchone()
+            assert row == (0, "", "", 0, "", "", "", "")
+        finally:
+            db.close()
+
+    def test_double_construction_is_idempotent(self, tmp_path: Path):
+        # Constructing CatalogDB twice on the same path must not error
+        # (each ALTER probes for the column first, indexes are IF NOT
+        # EXISTS).
+        path = tmp_path / ".catalog.db"
+        CatalogDB(path).close()
+        # Second construction — must not raise.
+        db = CatalogDB(path)
+        try:
+            cols = _columns(db._conn, "documents")
+            for name in _BIB_COLUMNS:
+                assert name in cols
+        finally:
+            db.close()
+
+
+# ── Round-trip: schema accepts and returns bib values ────────────────────
+
+
+class TestBibValueRoundtrip:
+    def test_insert_and_select_full_bib_payload(self, tmp_path: Path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        try:
+            db._conn.execute(
+                "INSERT INTO documents (tumbler, title, author, year, "
+                "content_type, file_path, corpus, physical_collection, "
+                "chunk_count, head_hash, indexed_at, metadata, source_mtime, "
+                "alias_of, source_uri, bib_year, bib_authors, bib_venue, "
+                "bib_citation_count, bib_semantic_scholar_id, "
+                "bib_openalex_id, bib_doi, bib_enriched_at) "
+                "VALUES (?, ?, '', 0, '', '', '', '', 0, '', '', '{}', 0, "
+                "'', '', ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "1.7.42", "test-paper",
+                    2024, "Smith, J. and Jones, A.", "ACL", 17,
+                    "ss-id-abc", "oa-id-xyz", "10.0/example",
+                    "2026-04-30T12:00:00+00:00",
+                ),
+            )
+            db._conn.commit()
+            row = db._conn.execute(
+                "SELECT bib_year, bib_authors, bib_venue, bib_citation_count, "
+                "bib_semantic_scholar_id, bib_openalex_id, bib_doi, "
+                "bib_enriched_at FROM documents WHERE tumbler = ?",
+                ("1.7.42",),
+            ).fetchone()
+            assert row == (
+                2024, "Smith, J. and Jones, A.", "ACL", 17,
+                "ss-id-abc", "oa-id-xyz", "10.0/example",
+                "2026-04-30T12:00:00+00:00",
+            )
+        finally:
+            db.close()

--- a/tests/test_frecency_projection.py
+++ b/tests/test_frecency_projection.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 1 PR D ``frecency`` projection table.
+
+Coverage:
+- The migration creates the table with the documented columns and types.
+- The migration is idempotent across re-runs.
+- Phase 1 ships the schema only (no domain-store API, no projector
+  handler) — these tests exercise the schema contract via direct SQL,
+  not via a higher-level wrapper.
+- Decay queries can derive ``expires_at`` from ``(embedded_at,
+  ttl_days)`` without a materialized column.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.db.migrations import (
+    MIGRATIONS,
+    migrate_frecency_projection_table,
+)
+
+
+_FRECENCY_COLUMNS: dict[str, tuple[str, str, int]] = {
+    # name → (type, default, pk_position)
+    "chunk_id":       ("TEXT",    None,  1),
+    "embedded_at":    ("TEXT",    "''",  0),
+    "ttl_days":       ("INTEGER", "0",   0),
+    "frecency_score": ("REAL",    "0",   0),
+    "miss_count":     ("INTEGER", "0",   0),
+    "last_hit_at":    ("TEXT",    "''",  0),
+}
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> dict[str, dict]:
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    return {
+        row[1]: {"type": row[2], "notnull": row[3], "dflt": row[4], "pk": row[5]}
+        for row in cur.fetchall()
+    }
+
+
+# ── Schema ───────────────────────────────────────────────────────────────
+
+
+class TestFrecencySchema:
+    def test_migration_creates_table(self):
+        conn = sqlite3.connect(":memory:")
+        migrate_frecency_projection_table(conn)
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='frecency'"
+        ).fetchone()
+        assert row is not None
+
+    def test_columns_match_spec(self):
+        conn = sqlite3.connect(":memory:")
+        migrate_frecency_projection_table(conn)
+        cols = _columns(conn, "frecency")
+        assert set(cols.keys()) == set(_FRECENCY_COLUMNS.keys())
+        for name, (expected_type, expected_dflt, expected_pk) in _FRECENCY_COLUMNS.items():
+            meta = cols[name]
+            assert meta["type"] == expected_type, (
+                f"{name}: type {meta['type']!r}, expected {expected_type!r}"
+            )
+            assert meta["pk"] == expected_pk, (
+                f"{name}: pk position {meta['pk']}, expected {expected_pk}"
+            )
+            if expected_dflt is None:
+                # PK columns don't carry an explicit default.
+                continue
+            assert meta["dflt"] == expected_dflt, (
+                f"{name}: default {meta['dflt']!r}, expected {expected_dflt!r}"
+            )
+
+    def test_chunk_id_is_primary_key(self):
+        conn = sqlite3.connect(":memory:")
+        migrate_frecency_projection_table(conn)
+        # PRAGMA reports pk=1 for chunk_id.
+        cols = _columns(conn, "frecency")
+        pks = [name for name, meta in cols.items() if meta["pk"] > 0]
+        assert pks == ["chunk_id"]
+
+    def test_no_expires_at_column(self):
+        # Phase 1 simpler-path direction: expires_at is derived, not
+        # materialized. This test is the regression guard if a future
+        # change tries to add a column for it without an RDR amendment.
+        conn = sqlite3.connect(":memory:")
+        migrate_frecency_projection_table(conn)
+        cols = _columns(conn, "frecency")
+        assert "expires_at" not in cols, (
+            "Phase 1 PR D chose to derive expires_at from "
+            "(embedded_at, ttl_days). Materializing it as a column "
+            "requires an RDR-101 amendment."
+        )
+
+
+# ── Idempotency ──────────────────────────────────────────────────────────
+
+
+class TestFrecencyMigrationIdempotent:
+    def test_re_apply_is_noop(self):
+        conn = sqlite3.connect(":memory:")
+        migrate_frecency_projection_table(conn)
+        # Insert a row to verify re-application doesn't clobber data.
+        conn.execute(
+            "INSERT INTO frecency "
+            "(chunk_id, embedded_at, ttl_days, frecency_score, "
+            "miss_count, last_hit_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("ck-1", "2026-04-30T00:00:00Z", 30, 0.75, 2, "2026-04-30T11:00:00Z"),
+        )
+        conn.commit()
+
+        migrate_frecency_projection_table(conn)  # must not raise
+        migrate_frecency_projection_table(conn)  # must not raise
+
+        # Data preserved.
+        row = conn.execute(
+            "SELECT chunk_id, embedded_at, ttl_days, frecency_score, "
+            "miss_count, last_hit_at FROM frecency"
+        ).fetchone()
+        assert row == ("ck-1", "2026-04-30T00:00:00Z", 30, 0.75, 2, "2026-04-30T11:00:00Z")
+
+
+# ── Migration registration ───────────────────────────────────────────────
+
+
+class TestFrecencyMigrationRegistered:
+    def test_in_migrations_list(self):
+        matches = [
+            (m.introduced, m.name) for m in MIGRATIONS
+            if "frecency" in m.name.lower()
+        ]
+        assert matches, "frecency migration must be registered in MIGRATIONS"
+        # Must ship in the same minor as the rest of Phase 1 (4.21.x);
+        # bumped to 4.21.4 because 4.21.3 is the chash_index rename.
+        assert matches[0][0] == "4.21.4", (
+            f"Frecency migration should be at 4.21.4; got {matches[0][0]}"
+        )
+
+
+# ── Decay query: derive expires_at without a column ──────────────────────
+
+
+class TestExpiresAtDerivation:
+    """Validate that the simpler-path choice (no materialized
+    ``expires_at``) supports a usable decay query."""
+
+    def test_derive_expires_at_from_embedded_at_plus_ttl(self):
+        conn = sqlite3.connect(":memory:")
+        migrate_frecency_projection_table(conn)
+        # Three rows: two should be expired as of "now", one fresh.
+        rows = [
+            ("ck-old",   "2024-01-01T00:00:00Z", 30, 0.1, 0, ""),  # very old
+            ("ck-edge",  "2026-03-31T00:00:00Z", 30, 0.5, 0, ""),  # ~30 days ago
+            ("ck-fresh", "2026-04-29T00:00:00Z",  7, 0.9, 0, ""),  # 1 day ago, 7-day TTL
+        ]
+        conn.executemany(
+            "INSERT INTO frecency "
+            "(chunk_id, embedded_at, ttl_days, frecency_score, "
+            "miss_count, last_hit_at) VALUES (?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+
+        # SQL composes the derived expires_at via datetime() arithmetic.
+        # The query is the canonical Phase 5 sweep shape.
+        cur = conn.execute(
+            "SELECT chunk_id FROM frecency "
+            "WHERE datetime(embedded_at, '+' || ttl_days || ' days') < ? "
+            "ORDER BY chunk_id",
+            ("2026-04-30T00:00:00Z",),
+        )
+        expired = [r[0] for r in cur.fetchall()]
+        # ck-old expired long ago; ck-edge expired 2026-04-30; ck-fresh
+        # is still within its 7-day window.
+        assert expired == ["ck-edge", "ck-old"]

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -91,12 +91,15 @@ class TestMigrationDataclass:
         # (4.18.1; the migration entry that previously created the table
         # was dropped when the read/write surface was retired) +
         # rename chash_index.doc_id → chunk_chroma_id (4.21.3, RDR-101
-        # Phase 0 nexus-o6aa.3 collision resolution)
-        # = 29.
+        # Phase 0 nexus-o6aa.3 collision resolution) +
+        # frecency projection table (4.21.4, RDR-101 Phase 1 PR D
+        # nexus-knn3 — schema-only, mutable side table, no event-log
+        # participation)
+        # = 30.
         # Prefer the name-based checks in TestBackfillPlanDimensions
         # and TestAddPlanMatchTextColumn for future guards; this
         # count is a cheap sentinel only.
-        assert len(MIGRATIONS) == 29
+        assert len(MIGRATIONS) == 30
 
     def test_migrations_ordered_by_version(self) -> None:
         from nexus.db.migrations import MIGRATIONS, _parse_version


### PR DESCRIPTION
## Summary

Phase 1 PR D of RDR-101. Resolves Phase 0 design gap 1 (Frecency projection unspecified) and lands the Document projection columns from the bib disposition deliverable. Schema-only; no projector handler changes (Phase 3 wires `DocumentEnriched` v: 1 → bib columns), no reader changes (Phase 4 migrates `nx enrich bib`'s skip query off T3 chunk metadata).

### Simpler-path choices (2026-05-01)

- **`expires_at` is NOT materialized** as a column on the Frecency projection. Decay queries derive it from `(embedded_at + ttl_days)` at read time via `datetime(embedded_at, '+' || ttl_days || ' days')`. Materializing later requires an RDR amendment; the regression test guards against drift.
- **Frecency is a mutable side table** — no event-log participation in Phase 1. `ChunkAccessed` / `ChunkMissed` events are out of scope; if the doctor verb later needs to verify frecency state matches the log, a sub-RDR can introduce them.

### What lands

**Catalog SQLite (`.catalog.db`, `src/nexus/catalog/catalog_db.py`):**
- 8 new `bib_*` columns on `documents`: `bib_year`, `bib_authors`, `bib_venue`, `bib_citation_count`, `bib_semantic_scholar_id`, `bib_openalex_id`, `bib_doi`, `bib_enriched_at` — all NOT NULL with empty/0 defaults so legacy rows upgrade silently.
- 2 partial indexes: `idx_documents_bib_s2_id` and `idx_documents_bib_oa_id`, each `WHERE <id> != ''` so the index size scales with enriched-document count, not total document count. The partial-index CREATE lives in the post-migration block (not `_SCHEMA_SQL`) so the legacy-DB upgrade path can ALTER TABLE the bib columns into existence before the index references them.
- Inline ALTER TABLE migrations follow the same try-select / ADD-COLUMN-on-error pattern as `repo_root` / `source_mtime` / `alias_of` / `source_uri`.

**T2 SQLite (`memory.db`, `src/nexus/db/migrations.py`):**
- New migration `migrate_frecency_projection_table` at version `4.21.4`: `CREATE TABLE IF NOT EXISTS frecency (chunk_id TEXT PRIMARY KEY, embedded_at TEXT NOT NULL DEFAULT '', ttl_days INTEGER NOT NULL DEFAULT 0, frecency_score REAL NOT NULL DEFAULT 0, miss_count INTEGER NOT NULL DEFAULT 0, last_hit_at TEXT NOT NULL DEFAULT '')`.
- `conexus` version bumped 4.21.3 → 4.21.4 so `apply_pending` picks up the new migration.
- `test_migrations.py::test_migrations_list_exists` count bumped 29 → 30.

No domain store methods on Frecency yet; Phase 5 fills them in when the relocation from T3 metadata begins.

### Test plan

- [x] `tests/test_catalog_documents_bib_columns.py` (10 tests): fresh CatalogDB has all 8 columns with documented types/defaults; legacy CatalogDB (built by hand without bib columns) gets them via inline ALTER migration; both partial indexes present in either path; partial-index WHERE clause survives; pre-existing rows survive the upgrade with empty bib_* defaults; double construction is idempotent; insert/select round-trip of full bib payload.
- [x] `tests/test_frecency_projection.py` (6 tests): migration creates the table with the documented columns and PK; idempotent across re-runs; `expires_at` is NOT a column (regression guard for the simpler-path choice); decay query can derive `expires_at` via `datetime()` arithmetic and yield the expected expired set; migration is registered in MIGRATIONS at version 4.21.4.
- [x] 482 tests passing locally across the catalog + chash + Phase 1 modules.
- [ ] CI green.

### Refs

- RDR-101 Phase 0 deliverable `nexus-o6aa.2` (`docs/rdr/post-mortem/rdr-101-bib-disposition.md`) — Option A bib disposition
- RDR-101 Phase 0 design gap 1 (`docs/rdr/post-mortem/rdr-101-phase0-index.md`) — Frecency projection schema

Bead: `nexus-knn3` (Phase 1 sub-PR D under `nexus-o6aa.7`).