### PR TITLE
rdr-101(phase1): shadow-emit events alongside JSONL writes (gated)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -441,3 +441,5 @@
 {"id":"int-4233f296","kind":"field_change","created_at":"2026-05-01T03:16:44.532441Z","actor":"Hellblazer","issue_id":"nexus-2iig","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-dc537d9f","kind":"field_change","created_at":"2026-05-01T03:16:44.844463Z","actor":"Hellblazer","issue_id":"nexus-z1p8","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-abcf612c","kind":"field_change","created_at":"2026-05-01T08:34:40.061282Z","actor":"Hellblazer","issue_id":"nexus-knn3","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-4052e6f0","kind":"field_change","created_at":"2026-05-01T08:40:30.671327Z","actor":"Hellblazer","issue_id":"nexus-knn3","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-35b074b8","kind":"field_change","created_at":"2026-05-01T08:47:09.231391Z","actor":"Hellblazer","issue_id":"nexus-ebz6","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -20,6 +20,36 @@ import structlog
 if TYPE_CHECKING:
     from chromadb.api import ClientAPI
 
+# RDR-101 Phase 1 PR F: shadow event-log emit gate. Read once at
+# Catalog.__init__ time. Recognised "on" values match the boolean-env
+# convention used elsewhere in the codebase (1/true/yes/on).
+_SHADOW_EMIT_ENV = "NEXUS_EVENT_LOG_SHADOW"
+
+
+def _read_shadow_gate() -> bool:
+    val = os.environ.get(_SHADOW_EMIT_ENV, "").strip().lower()
+    return val in ("1", "true", "yes", "on")
+
+
+# Imported lazily inside Catalog methods so a process that never
+# constructs a Catalog (e.g. an MCP-only consumer) does not pay the
+# events-module import cost. Re-aliased to ``_Event`` here for the
+# ``_emit_shadow_event`` type hint.
+from nexus.catalog.events import (  # noqa: E402
+    DocumentAliasedPayload as _DocumentAliasedPayload,
+    DocumentDeletedPayload as _DocumentDeletedPayload,
+    DocumentEnrichedPayload as _DocumentEnrichedPayload,
+    DocumentRegisteredPayload as _DocumentRegisteredPayload,
+    DocumentRenamedPayload as _DocumentRenamedPayload,
+    Event as _Event,
+    LinkCreatedPayload as _LinkCreatedPayload,
+    LinkDeletedPayload as _LinkDeletedPayload,
+    OwnerRegisteredPayload as _OwnerRegisteredPayload,
+    SCHEMA_BIB_S2_V1 as _SCHEMA_BIB_S2_V1,
+    SCHEMA_SCHOLARLY_PAPER_V1 as _SCHEMA_SCHOLARLY_PAPER_V1,
+    make_event as _make_event,
+)
+
 # Span format: "line_start-line_end" or "chunk_idx:char_start-char_end" or
 # "chash:<sha256hex>" or "".  Empty string means "the whole document".
 _SPAN_PATTERN = re.compile(
@@ -414,6 +444,12 @@ class Catalog:
         self._owners_path = catalog_dir / "owners.jsonl"
         self._documents_path = catalog_dir / "documents.jsonl"
         self._links_path = catalog_dir / "links.jsonl"
+        # RDR-101 Phase 1 PR F (nexus-ebz6): shadow event log lives next to
+        # the existing JSONL files. Off by default; opt in via
+        # NEXUS_EVENT_LOG_SHADOW=1. Phase 3 cuts production writes over to
+        # this log; Phase 1 only shadow-emits when an operator opts in.
+        self._events_path = catalog_dir / "events.jsonl"
+        self._shadow_emit_enabled = _read_shadow_gate()
         self.degraded: bool = False
         # Storage review S-4: mtime cache so every Catalog() instantiation
         # doesn't re-parse the full JSONL corpus and re-build the SQLite
@@ -592,6 +628,37 @@ class Catalog:
         with path.open("a") as f:
             f.write(json.dumps(record, default=str) + "\n")
 
+    # ── RDR-101 Phase 1 PR F: shadow event-log emit ─────────────────────
+
+    def _emit_shadow_event(self, event: "_Event") -> None:
+        """Append ``event`` to ``events.jsonl`` if shadow emit is enabled.
+
+        Caller MUST hold the catalog directory flock — this method does
+        not acquire its own. Mirrors ``_append_jsonl``'s contract so the
+        emit happens inside the same critical section as the JSONL +
+        SQLite writes the event corresponds to (no torn cross-file state
+        if the process crashes between writes).
+
+        Off-by-default. Read the gate once at ``Catalog.__init__`` time
+        from ``NEXUS_EVENT_LOG_SHADOW``; runtime flips require a fresh
+        Catalog construction. Phase 3 will flip the default and remove
+        the gate.
+
+        v: 0 schema is used so the existing Phase 1 projector handlers
+        apply unchanged. Phase 3 introduces v: 1 native-write semantics
+        with new projector handlers.
+        """
+        if not self._shadow_emit_enabled:
+            return
+        if not self._events_path.exists():
+            self._events_path.touch()
+        line = json.dumps(
+            event.to_dict(), default=str, separators=(",", ":"),
+        )
+        with self._events_path.open("a") as f:
+            f.write(line)
+            f.write("\n")
+
     # ── Owners ─────────────────────────────────────────────────────────────
 
     def register_owner(
@@ -636,6 +703,17 @@ class Catalog:
                 (prefix, name, owner_type, repo_hash, description, repo_root),
             )
             self._db.commit()
+            self._emit_shadow_event(_make_event(
+                _OwnerRegisteredPayload(
+                    owner_id=prefix,
+                    name=name,
+                    owner_type=owner_type,
+                    repo_root=repo_root,
+                    repo_hash=repo_hash,
+                    description=description,
+                ),
+                v=0,
+            ))
             return Tumbler.parse(prefix)
         finally:
             self._release_lock(dir_fd)
@@ -847,6 +925,33 @@ class Catalog:
                 ),
             )
             self._db.commit()
+            self._emit_shadow_event(_make_event(
+                _DocumentRegisteredPayload(
+                    # Phase 1 stand-in: tumbler doubles as doc_id until
+                    # Phase 3 mints UUID7 doc_ids via the new write path.
+                    doc_id=str(tumbler),
+                    owner_id=str(owner),
+                    content_type=content_type,
+                    source_uri=source_uri,
+                    coll_id=physical_collection,
+                    title=title,
+                    source_mtime=source_mtime,
+                    indexed_at_doc=now,
+                    # Legacy fields needed for the v: 0 projection.
+                    tumbler=str(tumbler),
+                    author=author,
+                    year=year,
+                    file_path=file_path,
+                    corpus=corpus,
+                    physical_collection=physical_collection,
+                    chunk_count=chunk_count,
+                    head_hash=head_hash,
+                    indexed_at=now,
+                    alias_of="",
+                    meta=dict(meta or {}),
+                ),
+                v=0,
+            ))
             return tumbler
         finally:
             self._release_lock(dir_fd)
@@ -1015,6 +1120,13 @@ class Catalog:
             alias_of=str(canonical),
         )
         self._append_jsonl(self._documents_path, updated.__dict__)
+        self._emit_shadow_event(_make_event(
+            _DocumentAliasedPayload(
+                alias_doc_id=str(tumbler),
+                canonical_doc_id=str(canonical),
+            ),
+            v=0,
+        ))
 
     def resolve_path(self, tumbler: Tumbler) -> Path | None:
         """Return absolute path for the document's file_path.
@@ -1350,6 +1462,42 @@ class Catalog:
                 ),
             )
             self._db.commit()
+            # Shadow-emit the canonical event for the kind of update that
+            # happened. ``update()`` is overloaded — source_uri rename and
+            # bib enrichment both flow through here. The projector
+            # idempotently INSERT OR REPLACEs the documents row from a
+            # DocumentRegistered with the full updated payload, which is
+            # equivalent to applying a DocumentRenamed and/or
+            # DocumentEnriched plus the prior register. Phase 1 takes
+            # the lossless path: emit DocumentRegistered with the post-
+            # update field set, mirroring what the synthesizer does for
+            # documents.jsonl rows that have been mutated. Phase 3
+            # introduces fine-grained event types (DocumentRenamed,
+            # DocumentEnriched) that capture intent rather than state.
+            self._emit_shadow_event(_make_event(
+                _DocumentRegisteredPayload(
+                    doc_id=rec_dict["tumbler"],
+                    owner_id=str(entry.tumbler.owner_address()),
+                    content_type=rec_dict["content_type"],
+                    source_uri=rec_dict.get("source_uri", ""),
+                    coll_id=rec_dict["physical_collection"],
+                    title=rec_dict["title"],
+                    source_mtime=float(rec_dict.get("source_mtime", 0.0) or 0.0),
+                    indexed_at_doc=rec_dict["indexed_at"],
+                    tumbler=rec_dict["tumbler"],
+                    author=rec_dict["author"],
+                    year=int(rec_dict["year"] or 0),
+                    file_path=rec_dict["file_path"],
+                    corpus=rec_dict["corpus"],
+                    physical_collection=rec_dict["physical_collection"],
+                    chunk_count=int(rec_dict["chunk_count"] or 0),
+                    head_hash=rec_dict["head_hash"],
+                    indexed_at=rec_dict["indexed_at"],
+                    alias_of=entry.alias_of or "",
+                    meta=dict(rec_dict["meta"]),
+                ),
+                v=0,
+            ))
         finally:
             self._release_lock(dir_fd)
 
@@ -1436,6 +1584,13 @@ class Catalog:
             self._append_jsonl(self._documents_path, tombstone)
             self._db.execute("DELETE FROM documents WHERE tumbler = ?", (str(tumbler),))
             self._db.commit()
+            self._emit_shadow_event(_make_event(
+                _DocumentDeletedPayload(
+                    doc_id=str(tumbler),
+                    reason="catalog.delete_document",
+                ),
+                v=0,
+            ))
             return True
         finally:
             self._release_lock(dir_fd)
@@ -1684,6 +1839,19 @@ class Catalog:
             )
             self._append_jsonl(self._links_path, rec.__dict__)
             self._db.commit()
+            self._emit_shadow_event(_make_event(
+                _LinkCreatedPayload(
+                    from_doc=str(from_t),
+                    to_doc=str(to_t),
+                    link_type=link_type,
+                    creator=row[1],
+                    from_span=from_span,
+                    to_span=to_span,
+                    created_at=row[3] or now,
+                    meta=dict(existing_meta),
+                ),
+                v=0,
+            ))
             return False
         else:
             combined_meta = dict(meta)
@@ -1701,6 +1869,19 @@ class Catalog:
             )
             self._append_jsonl(self._links_path, rec.__dict__)
             self._db.commit()
+            self._emit_shadow_event(_make_event(
+                _LinkCreatedPayload(
+                    from_doc=str(from_t),
+                    to_doc=str(to_t),
+                    link_type=link_type,
+                    creator=created_by,
+                    from_span=from_span,
+                    to_span=to_span,
+                    created_at=now,
+                    meta=dict(combined_meta),
+                ),
+                v=0,
+            ))
             return True
 
     def link(
@@ -1811,6 +1992,19 @@ class Catalog:
             )
             self._append_jsonl(self._links_path, rec.__dict__)
             self._db.commit()
+            self._emit_shadow_event(_make_event(
+                _LinkCreatedPayload(
+                    from_doc=str(from_t),
+                    to_doc=str(to_t),
+                    link_type=link_type,
+                    creator=created_by,
+                    from_span=from_span,
+                    to_span=to_span,
+                    created_at=now,
+                    meta=dict(combined_meta),
+                ),
+                v=0,
+            ))
             return True
         finally:
             self._release_lock(dir_fd)
@@ -1850,6 +2044,15 @@ class Catalog:
                 }
                 self._append_jsonl(self._links_path, tombstone)
                 self._db.execute("DELETE FROM links WHERE id = ?", (row_id,))
+                self._emit_shadow_event(_make_event(
+                    _LinkDeletedPayload(
+                        from_doc=str(from_t),
+                        to_doc=str(to_t),
+                        link_type=lt,
+                        reason="catalog.unlink",
+                    ),
+                    v=0,
+                ))
 
             self._db.commit()
             return len(rows)
@@ -2009,6 +2212,15 @@ class Catalog:
                     "DELETE FROM links WHERE from_tumbler=? AND to_tumbler=? AND link_type=?",
                     (str(lnk.from_tumbler), str(lnk.to_tumbler), lnk.link_type),
                 )
+                self._emit_shadow_event(_make_event(
+                    _LinkDeletedPayload(
+                        from_doc=str(lnk.from_tumbler),
+                        to_doc=str(lnk.to_tumbler),
+                        link_type=lnk.link_type,
+                        reason="catalog.bulk_unlink",
+                    ),
+                    v=0,
+                ))
             self._db.commit()
             return len(matching)
         finally:

--- a/tests/test_catalog_shadow_emit.py
+++ b/tests/test_catalog_shadow_emit.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 1 PR F shadow-emit path.
+
+Coverage:
+- Default (gate OFF, no env var): no events.jsonl content after any
+  catalog mutation; existing JSONL + SQLite behavior is unchanged.
+- Env-var parsing: 1/true/yes/on → ON; 0/false/no/off/empty/unset → OFF.
+- With gate ON, every supported write site emits the corresponding
+  typed event with the right payload:
+    register_owner → OwnerRegistered
+    register → DocumentRegistered
+    update → DocumentRegistered (lossless replay; Phase 3 introduces
+             fine-grained DocumentRenamed / DocumentEnriched intent types)
+    set_alias → DocumentAliased
+    delete_document → DocumentDeleted
+    link → LinkCreated
+    unlink → LinkDeleted
+    bulk_unlink → LinkDeleted per matching link
+- Round-trip: with gate ON, drive a sequence of catalog mutations,
+  then replay events.jsonl through the projector against a fresh
+  CatalogDB → equal to the live db (events alone are sufficient to
+  reproduce the SQLite state).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog, _read_shadow_gate
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.projector import Projector
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def cat_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Catalog:
+    """Catalog constructed with shadow emit OFF (default)."""
+    monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+    d = tmp_path / "catalog"
+    d.mkdir()
+    return Catalog(d, d / ".catalog.db")
+
+
+@pytest.fixture()
+def cat_on(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Catalog:
+    """Catalog constructed with shadow emit ON."""
+    monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+    d = tmp_path / "catalog"
+    d.mkdir()
+    return Catalog(d, d / ".catalog.db")
+
+
+def _read_events(cat: Catalog) -> list[ev.Event]:
+    if not cat._events_path.exists():
+        return []
+    out: list[ev.Event] = []
+    with cat._events_path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            out.append(ev.Event.from_dict(json.loads(line)))
+    return out
+
+
+# ── Gate parsing ─────────────────────────────────────────────────────────
+
+
+class TestGateParsing:
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "True", "yes", "ON", "on"])
+    def test_on_values(self, monkeypatch: pytest.MonkeyPatch, val: str):
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", val)
+        assert _read_shadow_gate() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_off_values(self, monkeypatch: pytest.MonkeyPatch, val: str):
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", val)
+        assert _read_shadow_gate() is False
+
+    def test_unset_is_off(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        assert _read_shadow_gate() is False
+
+
+# ── Default (gate OFF) — no behavior change ──────────────────────────────
+
+
+class TestDefaultOff:
+    def test_no_events_after_register(self, cat_off: Catalog):
+        owner = cat_off.register_owner("nexus", "repo", repo_hash="ababab")
+        cat_off.register(owner, "doc-A.md", content_type="prose", file_path="doc-A.md")
+        # events.jsonl either doesn't exist or is empty.
+        if cat_off._events_path.exists():
+            assert cat_off._events_path.read_text() == ""
+
+    def test_existing_jsonl_writes_unchanged(self, cat_off: Catalog):
+        owner = cat_off.register_owner("nexus", "repo", repo_hash="cdcdcd")
+        cat_off.register(owner, "doc-A.md", content_type="prose", file_path="doc-A.md")
+        # owners.jsonl + documents.jsonl land as before.
+        assert cat_off._owners_path.read_text().count("\n") >= 1
+        assert cat_off._documents_path.read_text().count("\n") >= 1
+
+
+# ── Gate ON — emits per write site ───────────────────────────────────────
+
+
+class TestEmitsOnRegisterOwner:
+    def test_owner_registered_event_emitted(self, cat_on: Catalog):
+        owner = cat_on.register_owner(
+            "nexus", "repo", repo_hash="ababab",
+            description="test repo", repo_root="/git/nexus",
+        )
+        evs = _read_events(cat_on)
+        assert len(evs) == 1
+        e = evs[0]
+        assert e.type == ev.TYPE_OWNER_REGISTERED
+        assert e.v == 0
+        assert e.payload.owner_id == str(owner)
+        assert e.payload.name == "nexus"
+        assert e.payload.owner_type == "repo"
+        assert e.payload.repo_hash == "ababab"
+        assert e.payload.repo_root == "/git/nexus"
+        assert e.payload.description == "test repo"
+
+
+class TestEmitsOnRegister:
+    def test_document_registered_event_emitted(self, cat_on: Catalog):
+        owner = cat_on.register_owner("nexus", "repo", repo_hash="ababab")
+        tumbler = cat_on.register(
+            owner, "doc-A.md", content_type="prose",
+            file_path="doc-A.md", chunk_count=12, head_hash="aaaa1111",
+        )
+
+        evs = _read_events(cat_on)
+        # Owner + document emit.
+        assert len(evs) == 2
+        owner_e, doc_e = evs
+        assert owner_e.type == ev.TYPE_OWNER_REGISTERED
+        assert doc_e.type == ev.TYPE_DOCUMENT_REGISTERED
+        assert doc_e.v == 0
+        p = doc_e.payload
+        assert p.tumbler == str(tumbler)
+        assert p.doc_id == str(tumbler)  # Phase 1 stand-in
+        assert p.owner_id == str(owner)
+        assert p.title == "doc-A.md"
+        assert p.content_type == "prose"
+        assert p.file_path == "doc-A.md"
+        assert p.chunk_count == 12
+        assert p.head_hash == "aaaa1111"
+
+
+class TestEmitsOnUpdate:
+    def test_update_emits_document_registered_with_new_state(self, cat_on: Catalog):
+        owner = cat_on.register_owner("nexus", "repo", repo_hash="ababab")
+        tumbler = cat_on.register(
+            owner, "doc-A.md", content_type="prose",
+            file_path="doc-A.md", chunk_count=0,
+        )
+        cat_on.update(tumbler, chunk_count=42, head_hash="newhash")
+
+        evs = _read_events(cat_on)
+        assert len(evs) == 3  # owner + register + update
+        upd = evs[-1]
+        assert upd.type == ev.TYPE_DOCUMENT_REGISTERED
+        assert upd.payload.tumbler == str(tumbler)
+        assert upd.payload.chunk_count == 42
+        assert upd.payload.head_hash == "newhash"
+
+
+class TestEmitsOnSetAlias:
+    def test_set_alias_emits_document_aliased(self, cat_on: Catalog):
+        owner = cat_on.register_owner("nexus", "repo", repo_hash="ababab")
+        canonical = cat_on.register(owner, "canonical.md", content_type="prose")
+        alias = cat_on.register(owner, "alias.md", content_type="prose")
+        cat_on.set_alias(alias, canonical)
+
+        evs = _read_events(cat_on)
+        # owner + 2 registers + 1 alias-register-rewrite + 1 aliased event.
+        # set_alias appends a DocumentRecord (with alias_of populated)
+        # via _append_jsonl + emits DocumentAliased.
+        types = [e.type for e in evs]
+        assert types.count(ev.TYPE_DOCUMENT_ALIASED) == 1
+        aliased = next(e for e in evs if e.type == ev.TYPE_DOCUMENT_ALIASED)
+        assert aliased.payload.alias_doc_id == str(alias)
+        assert aliased.payload.canonical_doc_id == str(canonical)
+
+
+class TestEmitsOnDeleteDocument:
+    def test_delete_document_emits_document_deleted(self, cat_on: Catalog):
+        owner = cat_on.register_owner("nexus", "repo", repo_hash="ababab")
+        tumbler = cat_on.register(owner, "doc-A.md", content_type="prose")
+        assert cat_on.delete_document(tumbler) is True
+
+        evs = _read_events(cat_on)
+        types = [e.type for e in evs]
+        assert types.count(ev.TYPE_DOCUMENT_DELETED) == 1
+        deleted = next(e for e in evs if e.type == ev.TYPE_DOCUMENT_DELETED)
+        assert deleted.payload.doc_id == str(tumbler)
+        assert deleted.payload.reason == "catalog.delete_document"
+
+
+class TestEmitsOnLinkUnlink:
+    def test_link_emits_link_created(self, cat_on: Catalog):
+        owner = cat_on.register_owner("nexus", "repo", repo_hash="ababab")
+        a = cat_on.register(owner, "a.md", content_type="prose")
+        b = cat_on.register(owner, "b.md", content_type="prose")
+        created = cat_on.link(a, b, link_type="cites", created_by="manual")
+        assert created is True
+
+        evs = _read_events(cat_on)
+        link_events = [e for e in evs if e.type == ev.TYPE_LINK_CREATED]
+        assert len(link_events) == 1
+        p = link_events[0].payload
+        assert p.from_doc == str(a)
+        assert p.to_doc == str(b)
+        assert p.link_type == "cites"
+        assert p.creator == "manual"
+
+    def test_unlink_emits_link_deleted(self, cat_on: Catalog):
+        owner = cat_on.register_owner("nexus", "repo", repo_hash="ababab")
+        a = cat_on.register(owner, "a.md", content_type="prose")
+        b = cat_on.register(owner, "b.md", content_type="prose")
+        cat_on.link(a, b, link_type="cites", created_by="manual")
+        n = cat_on.unlink(a, b, link_type="cites")
+        assert n == 1
+
+        evs = _read_events(cat_on)
+        types = [e.type for e in evs]
+        assert ev.TYPE_LINK_DELETED in types
+        deleted = next(e for e in evs if e.type == ev.TYPE_LINK_DELETED)
+        assert deleted.payload.from_doc == str(a)
+        assert deleted.payload.to_doc == str(b)
+        assert deleted.payload.link_type == "cites"
+
+
+# ── Round-trip: events.jsonl ⇒ projector ⇒ live SQLite ────────────────────
+
+
+class TestShadowReplayRoundTrip:
+    """The most important test: real catalog mutations leave an
+    events.jsonl that, replayed through the projector, reproduces the
+    SQLite state. This is the ground truth check that shadow emit
+    captures every state change the catalog's tumbler-keyed schema
+    cares about.
+    """
+
+    def test_register_register_link_unlink_delete(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+
+        owner = cat.register_owner("nexus", "repo", repo_hash="ababab")
+        a = cat.register(owner, "a.md", content_type="prose", file_path="a.md")
+        b = cat.register(owner, "b.md", content_type="prose", file_path="b.md")
+        cat.link(a, b, link_type="cites", created_by="manual")
+        cat.unlink(a, b, link_type="cites")
+        cat.delete_document(b)
+
+        # Replay events.jsonl into a fresh CatalogDB.
+        log = EventLog(cat_dir)
+        projected_path = tmp_path / "projected.db"
+        proj_db = CatalogDB(projected_path)
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        # Compare row sets (strip links.id autoincrement, same as PR C).
+        live_conn = sqlite3.connect(str(cat_dir / ".catalog.db"))
+        proj_conn = sqlite3.connect(str(projected_path))
+        try:
+            for table in ("owners", "documents"):
+                cur = live_conn.execute(
+                    f"PRAGMA table_info({table})"
+                )
+                cols = ", ".join(r[1] for r in cur.fetchall())
+                live_rows = sorted(live_conn.execute(
+                    f"SELECT {cols} FROM {table} ORDER BY {cols}"
+                ).fetchall())
+                proj_rows = sorted(proj_conn.execute(
+                    f"SELECT {cols} FROM {table} ORDER BY {cols}"
+                ).fetchall())
+                assert live_rows == proj_rows, (
+                    f"{table} rows differ:\n"
+                    f"  live:      {live_rows}\n"
+                    f"  projected: {proj_rows}"
+                )
+            # Links: both should be empty (link + unlink + delete leave 0 links).
+            assert live_conn.execute("SELECT COUNT(*) FROM links").fetchone()[0] == 0
+            assert proj_conn.execute("SELECT COUNT(*) FROM links").fetchone()[0] == 0
+        finally:
+            live_conn.close()
+            proj_conn.close()


### PR DESCRIPTION
## Summary

Phase 1 PR F of RDR-101. Shadow-emit typed events to `events.jsonl` in parallel with the existing JSONL+SQLite writes, gated behind the `NEXUS_EVENT_LOG_SHADOW` env var (default OFF). When OFF, no events are emitted and behavior is byte-for-byte unchanged. When ON, every supported catalog mutation appends a v: 0 event so the events.jsonl log can be replayed through the Phase 1 projector to reproduce the SQLite state exactly.

### Gated approach (per direction 2026-05-01)

- Default OFF: `NEXUS_EVENT_LOG_SHADOW=0` (or unset). Opt-in via env var. Phase 3 will flip the default and remove the gate.
- Shadow emit uses v: 0 schema so the existing Phase 1 projector handlers apply unchanged. Phase 3 introduces v: 1 native-write semantics with new projector handlers.
- `doc_id` field on emitted events stands in as the tumbler for Phase 1 (same as the synthesizer). Phase 2 backfill mints fresh UUID7 doc_ids; Phase 3 makes UUID7 the canonical doc_id at write time.
- `update()` emits a `DocumentRegistered` with the post-update field set rather than splitting into `DocumentRenamed` + `DocumentEnriched`. The projector's `INSERT OR REPLACE` makes the lossless-replay equivalent. Phase 3 introduces fine-grained event types that capture intent rather than state.

### Write sites covered

Each gets one `self._emit_shadow_event` call after the existing JSONL+SQLite writes succeed, inside the same dir-flock critical section so cross-file state stays consistent under a crash:

- `register_owner` → `OwnerRegistered`
- `register` → `DocumentRegistered`
- `update` → `DocumentRegistered` (lossless replay; covers source_uri rename and bib enrichment uniformly)
- `set_alias` → `DocumentAliased`
- `delete_document` → `DocumentDeleted`
- `_link_unlocked` + `link_if_absent` → `LinkCreated`
- `unlink` → `LinkDeleted` (one event per matching row)
- `bulk_unlink` → `LinkDeleted` (one event per matching row)

### Implementation notes

- `Catalog.__init__` reads the env var once and caches it as `self._shadow_emit_enabled`. Runtime flips require a fresh Catalog construction.
- `_emit_shadow_event(event)` mirrors `_append_jsonl`'s contract (caller holds the dir flock). Touch-if-missing on first emit so `events.jsonl` materializes lazily.
- Module-level `_Event` / `_*Payload` / `_make_event` aliases keep emit call sites compact.

### Test plan (23 new tests in `tests/test_catalog_shadow_emit.py`)

- [x] Gate parsing: `1`/`true`/`yes`/`on` (case-insensitive) → ON; `0`/`false`/`no`/`off`/empty/unset → OFF.
- [x] Default OFF: no `events.jsonl` content after register; existing JSONL+SQLite writes byte-equal to pre-PR behavior.
- [x] Per-write-site: each method emits exactly the right typed event with the documented payload fields populated.
- [x] **Round-trip**: with gate ON, drive a real sequence (`register_owner` + 2 `register` + `link` + `unlink` + `delete_document`) and replay the `events.jsonl` through the Phase 1 projector — owners and documents rows match the live SQLite, links table is empty in both.
- [x] 505 tests passing across catalog + chash + Phase 1 modules locally.
- [ ] One pre-existing flake (`test_collection_audit.py::TestLiveDistanceProbe::test_live_histogram_empty_when_collection_empty`) unrelated to this PR.
- [ ] CI green.

### Refs

- RDR-101 §Implementation Plan / Phase 1
- RDR-101 §Migration from current state Phase 1

Bead: `nexus-ebz6` (Phase 1 sub-PR F under `nexus-o6aa.7`).