### PR TITLE
rdr-101(phase2): nx catalog synthesize-log verb

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -443,3 +443,6 @@
 {"id":"int-abcf612c","kind":"field_change","created_at":"2026-05-01T08:34:40.061282Z","actor":"Hellblazer","issue_id":"nexus-knn3","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-4052e6f0","kind":"field_change","created_at":"2026-05-01T08:40:30.671327Z","actor":"Hellblazer","issue_id":"nexus-knn3","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-35b074b8","kind":"field_change","created_at":"2026-05-01T08:47:09.231391Z","actor":"Hellblazer","issue_id":"nexus-ebz6","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-f379e4fd","kind":"field_change","created_at":"2026-05-01T08:54:08.946892Z","actor":"Hellblazer","issue_id":"nexus-ebz6","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-4e77a879","kind":"field_change","created_at":"2026-05-01T08:54:09.639937Z","actor":"Hellblazer","issue_id":"nexus-o6aa.7","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-d7241a43","kind":"field_change","created_at":"2026-05-01T09:08:58.935031Z","actor":"Hellblazer","issue_id":"nexus-tn8i","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/synthesizer.py
+++ b/src/nexus/catalog/synthesizer.py
@@ -55,7 +55,9 @@ from nexus.catalog.events import Event
 _log = structlog.get_logger()
 
 
-def synthesize_from_jsonl(catalog_dir: Path) -> Iterator[Event]:
+def synthesize_from_jsonl(
+    catalog_dir: Path, *, mint_doc_id: bool = False,
+) -> Iterator[Event]:
     """Yield v: 0 events that reproduce the catalog state under ``catalog_dir``.
 
     Order: owners → documents → links. Within each file, JSONL append order
@@ -63,6 +65,25 @@ def synthesize_from_jsonl(catalog_dir: Path) -> Iterator[Event]:
     sees one or two events per logical key, not the full append history).
 
     Skips a file if it does not exist (fresh catalog with partial state).
+
+    ``mint_doc_id`` controls how ``DocumentRegisteredPayload.doc_id`` is
+    populated:
+
+    - ``False`` (Phase 1 default): ``doc_id`` is set to the tumbler. This
+      keeps ``synthesize_from_jsonl`` driving the Phase 1 doctor verb's
+      replay-equality test, where the projector reads ``payload.tumbler``
+      to write the SQLite tumbler-keyed row anyway.
+    - ``True`` (Phase 2 ``nx catalog synthesize-log``): ``doc_id`` is a
+      fresh UUID7 per RDR-101 §Migration / Phase 1. The original tumbler
+      is preserved in ``payload.tumbler`` so the projector's v: 0 path
+      still writes a tumbler-keyed SQLite row, and the doc_id is carried
+      in the event log for Phase 3+ canonical use.
+
+    Aliased rows (``DocumentAliased`` events) follow the same rule: when
+    ``mint_doc_id=True``, ``alias_doc_id`` and ``canonical_doc_id`` are
+    the freshly-minted UUID7s for the alias and canonical rows
+    respectively, so the alias graph in the event log is doc_id-keyed
+    even though the catalog-side schema still tracks aliases by tumbler.
     """
     owners_path = catalog_dir / "owners.jsonl"
     docs_path = catalog_dir / "documents.jsonl"
@@ -70,10 +91,45 @@ def synthesize_from_jsonl(catalog_dir: Path) -> Iterator[Event]:
 
     if owners_path.exists():
         yield from _synthesize_owners(owners_path)
+
+    # ``DocumentAliased`` references both the alias's and the canonical's
+    # doc_id. When mint_doc_id is True we have to mint per-tumbler doc_ids
+    # before emitting aliases so the alias graph stays consistent. Build
+    # the tumbler→doc_id map up front (one full read of documents.jsonl);
+    # subsequent emits read from the map.
+    tumbler_to_doc_id: dict[str, str]
+    if mint_doc_id and docs_path.exists():
+        tumbler_to_doc_id = _build_tumbler_to_doc_id(docs_path)
+    else:
+        tumbler_to_doc_id = {}
+
     if docs_path.exists():
-        yield from _synthesize_documents(docs_path)
+        yield from _synthesize_documents(
+            docs_path,
+            tumbler_to_doc_id=tumbler_to_doc_id,
+            mint_doc_id=mint_doc_id,
+        )
     if links_path.exists():
         yield from _synthesize_links(links_path)
+
+
+def _build_tumbler_to_doc_id(docs_path: Path) -> dict[str, str]:
+    """Walk documents.jsonl once and mint a fresh UUID7 doc_id per tumbler.
+
+    A tumbler that appears multiple times in the JSONL (re-register,
+    tombstone+re-register, alias rewrite) gets one consistent doc_id —
+    the first occurrence wins. Subsequent rewrites update other fields
+    on the same logical document, so the doc_id must stay constant
+    across them.
+    """
+    mapping: dict[str, str] = {}
+    for obj in _iter_jsonl(docs_path):
+        tumbler = obj.get("tumbler")
+        if not tumbler:
+            continue
+        if tumbler not in mapping:
+            mapping[tumbler] = ev.new_doc_id()
+    return mapping
 
 
 # ── Owners ───────────────────────────────────────────────────────────────
@@ -111,7 +167,12 @@ def _synthesize_owners(path: Path) -> Iterator[Event]:
 # ── Documents ────────────────────────────────────────────────────────────
 
 
-def _synthesize_documents(path: Path) -> Iterator[Event]:
+def _synthesize_documents(
+    path: Path,
+    *,
+    tumbler_to_doc_id: dict[str, str] | None = None,
+    mint_doc_id: bool = False,
+) -> Iterator[Event]:
     """Walk documents.jsonl, collapse last-write-wins per tumbler, and emit
     one (or two) events per logical row.
 
@@ -121,9 +182,14 @@ def _synthesize_documents(path: Path) -> Iterator[Event]:
     intermediate states the catalog already discarded; the synthesizer's
     contract is "events that reproduce today's effective state", not
     "events that reproduce the full audit trail".
+
+    ``tumbler_to_doc_id`` and ``mint_doc_id`` are passed through from the
+    public ``synthesize_from_jsonl``; see its docstring for the
+    contract.
     """
     last_seen: dict[str, dict[str, Any]] = {}
     tombstoned: dict[str, dict[str, Any]] = {}
+    mapping = tumbler_to_doc_id or {}
 
     for obj in _iter_jsonl(path):
         key = obj.get("tumbler")
@@ -143,15 +209,24 @@ def _synthesize_documents(path: Path) -> Iterator[Event]:
 
     # Live documents → DocumentRegistered (+ DocumentAliased if alias_of set).
     for tumbler, obj in last_seen.items():
-        yield _document_registered_event(obj, synthesized=True)
+        yield _document_registered_event(
+            obj, mapping=mapping, mint_doc_id=mint_doc_id,
+        )
         alias_of = (obj.get("alias_of") or "").strip()
         if alias_of:
+            # Resolve both endpoints through the mapping when minting
+            # so the alias graph in the event log uses the canonical
+            # doc_ids, not raw tumblers.
+            alias_doc_id = mapping.get(tumbler, tumbler) if mint_doc_id else tumbler
+            canonical_doc_id = (
+                mapping.get(alias_of, alias_of) if mint_doc_id else alias_of
+            )
             yield Event(
                 type=ev.TYPE_DOCUMENT_ALIASED,
                 v=0,
                 payload=ev.DocumentAliasedPayload(
-                    alias_doc_id=tumbler,         # Phase 1: tumbler stands in for doc_id
-                    canonical_doc_id=alias_of,
+                    alias_doc_id=alias_doc_id,
+                    canonical_doc_id=canonical_doc_id,
                 ),
                 ts=_synthesized_ts(obj),
             )
@@ -161,12 +236,17 @@ def _synthesize_documents(path: Path) -> Iterator[Event]:
     # tombstone against; without the Deleted the projector silently resurrects
     # the row. Both are required.
     for tumbler, obj in tombstoned.items():
-        yield _document_registered_event(obj, synthesized=True)
+        yield _document_registered_event(
+            obj, mapping=mapping, mint_doc_id=mint_doc_id,
+        )
+        deleted_doc_id = (
+            mapping.get(tumbler, tumbler) if mint_doc_id else tumbler
+        )
         yield Event(
             type=ev.TYPE_DOCUMENT_DELETED,
             v=0,
             payload=ev.DocumentDeletedPayload(
-                doc_id=tumbler,
+                doc_id=deleted_doc_id,
                 reason="synthesized_from_tombstone",
             ),
             ts=_synthesized_ts(obj),
@@ -174,7 +254,10 @@ def _synthesize_documents(path: Path) -> Iterator[Event]:
 
 
 def _document_registered_event(
-    obj: dict[str, Any], *, synthesized: bool,
+    obj: dict[str, Any],
+    *,
+    mapping: dict[str, str] | None = None,
+    mint_doc_id: bool = False,
 ) -> Event:
     """Build a ``DocumentRegistered`` v: 0 event from a documents.jsonl row.
 
@@ -183,15 +266,25 @@ def _document_registered_event(
     legacy tumbler-schema fields so the Phase 1 projector can write a
     SQLite row identical to the one ``Catalog.rebuild()`` produces.
 
-    ``doc_id`` is set to the tumbler so the v: 0 path has a stable join
-    key during Phase 1; a fresh UUID7 doc_id is what Phase 2 backfill will
-    assign once the doc_id column lands in the SQLite schema.
+    ``doc_id`` rule:
+
+    - When ``mint_doc_id=False`` (default, Phase 1 doctor verb):
+      ``doc_id`` is set to the tumbler so the v: 0 projector has a
+      stable join key.
+    - When ``mint_doc_id=True`` (Phase 2 ``synthesize-log`` verb):
+      ``doc_id`` is the freshly-minted UUID7 from ``mapping``; the
+      tumbler stays in ``payload.tumbler``.
     """
+    mapping = mapping or {}
     tumbler = obj.get("tumbler", "")
     physical_collection = obj.get("physical_collection", "")
+    if mint_doc_id and tumbler in mapping:
+        doc_id = mapping[tumbler]
+    else:
+        doc_id = tumbler
     payload = ev.DocumentRegisteredPayload(
         # Canonical
-        doc_id=tumbler,  # Phase 1 stand-in; Phase 2 mints a fresh UUID7
+        doc_id=doc_id,
         owner_id=_owner_prefix_of(tumbler),
         content_type=obj.get("content_type", ""),
         source_uri=obj.get("source_uri", ""),

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3426,3 +3426,114 @@ def _print_replay_equality_text(report: dict) -> None:
         click.echo("PASS — projector replay matches live SQLite for the current catalog state.")
     else:
         click.echo("FAIL — projector replay diverges from live SQLite. See diffs above.")
+
+
+# ── RDR-101 Phase 2: synthesize-log verb ─────────────────────────────────
+
+
+@catalog.command("synthesize-log")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help=(
+        "Walk the catalog JSONL and report what would be written to "
+        "events.jsonl, without actually writing. Use to size the log "
+        "before committing to the synthesis."
+    ),
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help=(
+        "Overwrite an existing events.jsonl. Default is to refuse so "
+        "an accidental re-synthesis cannot replace a log that already "
+        "carries production state."
+    ),
+)
+@click.option(
+    "--json", "as_json", is_flag=True,
+    help="Emit machine-readable JSON instead of text output.",
+)
+def synthesize_log_cmd(dry_run: bool, force: bool, as_json: bool) -> None:
+    """RDR-101 Phase 2: synthesize events.jsonl from existing JSONL state.
+
+    Walks ``owners.jsonl`` + ``documents.jsonl`` + ``links.jsonl``,
+    mints fresh UUID7 ``doc_id`` values per the RDR-101 §Migration /
+    Phase 1 rule, and writes the resulting v: 0 events to
+    ``catalog_dir/events.jsonl``.
+
+    Idempotent only against an empty events.jsonl: the verb refuses to
+    overwrite a non-empty log unless ``--force`` is passed. ``--dry-run``
+    reports counts and exits without writing.
+
+    Phase 1's ``synthesize_from_jsonl`` (used by ``nx catalog doctor
+    --replay-equality``) preserves the original tumbler-as-doc_id mapping
+    for replay-equality testing. This verb is the canonical Phase 2 +
+    bridge: it mints UUID7 doc_ids that Phase 3 native writes will adopt.
+    """
+    from nexus.catalog.catalog import Catalog
+    from nexus.catalog.event_log import EventLog
+    from nexus.catalog.synthesizer import synthesize_from_jsonl
+    from nexus.config import catalog_path
+
+    cat_dir = catalog_path()
+    if not Catalog.is_initialized(cat_dir):
+        raise click.ClickException(
+            f"Catalog not initialized at {cat_dir}. "
+            "Run 'nx catalog setup' to create and populate it."
+        )
+
+    log = EventLog(cat_dir)
+    existing_size = (
+        log.path.stat().st_size if log.path.exists() else 0
+    )
+
+    if existing_size > 0 and not force and not dry_run:
+        raise click.ClickException(
+            f"events.jsonl is non-empty ({existing_size} bytes) at "
+            f"{log.path}. Pass --force to overwrite, --dry-run to size "
+            "the synthesis without writing, or back up the existing log "
+            "before re-running."
+        )
+
+    events = list(synthesize_from_jsonl(cat_dir, mint_doc_id=True))
+
+    counts: dict[str, int] = {}
+    for e in events:
+        counts[e.type] = counts.get(e.type, 0) + 1
+
+    report = {
+        "dry_run": dry_run,
+        "events_path": str(log.path),
+        "existing_bytes": existing_size,
+        "events_total": len(events),
+        "events_by_type": counts,
+        "wrote": False,
+    }
+
+    if not dry_run:
+        if existing_size > 0 and force:
+            log.truncate()
+        log.append_many(events)
+        report["wrote"] = True
+
+    if as_json:
+        click.echo(json.dumps(report, indent=2))
+    else:
+        _print_synthesize_log_text(report)
+
+
+def _print_synthesize_log_text(report: dict) -> None:
+    click.echo(f"Events path:    {report['events_path']}")
+    click.echo(f"Existing size:  {report['existing_bytes']} bytes")
+    click.echo(f"Events total:   {report['events_total']}")
+    if report["events_by_type"]:
+        click.echo("By type:")
+        for t, c in sorted(report["events_by_type"].items(), key=lambda kv: kv[0]):
+            click.echo(f"  {t:<24} {c}")
+    if report["dry_run"]:
+        click.echo("(dry-run — events.jsonl was not written.)")
+    elif report["wrote"]:
+        click.echo("Wrote events.jsonl.")
+    else:
+        click.echo("(no write performed.)")

--- a/tests/test_catalog_synthesize_log.py
+++ b/tests/test_catalog_synthesize_log.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 2 ``nx catalog synthesize-log`` verb.
+
+Coverage:
+- Verb fails loudly when catalog is not initialized.
+- ``--dry-run`` reports counts without writing.
+- Default behavior refuses to overwrite a non-empty events.jsonl.
+- ``--force`` truncates the existing log before writing.
+- ``--json`` emits a structured report.
+- The written events have UUID7 doc_ids; the original tumbler is
+  preserved in payload.tumbler for back-compat.
+- Re-synthesizing the same catalog (with --force) produces the same
+  event counts but different doc_ids (UUID7 is fresh per run).
+- The persisted log replays through the projector against a fresh
+  CatalogDB and reproduces the live tumbler-keyed SQLite state (the
+  projector reads payload.tumbler, not payload.doc_id, for the v: 0
+  schema).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.projector import Projector
+from nexus.commands.catalog import synthesize_log_cmd
+
+
+@pytest.fixture()
+def isolated_nexus(tmp_path: Path) -> Path:
+    """Catalog dir set up by the autouse ``_isolate_catalog`` fixture in
+    tests/conftest.py via NEXUS_CATALOG_PATH."""
+    return tmp_path / "test-catalog"
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _build_initialized_catalog(catalog_dir: Path) -> Catalog:
+    Catalog.init(catalog_dir)
+    cat = Catalog(catalog_dir, catalog_dir / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="571b8edd")
+    cat.register(owner, "doc-A.md", content_type="prose", file_path="doc-A.md")
+    cat.register(owner, "doc-B.md", content_type="prose", file_path="doc-B.md")
+    return cat
+
+
+# ── Usage / fail-loud ────────────────────────────────────────────────────
+
+
+class TestUsage:
+    def test_missing_catalog_is_clean_error(self, isolated_nexus, runner):
+        result = runner.invoke(synthesize_log_cmd, [])
+        assert result.exit_code != 0
+        assert "not initialized" in result.output.lower()
+
+
+# ── Dry run ──────────────────────────────────────────────────────────────
+
+
+class TestDryRun:
+    def test_dry_run_reports_counts_no_write(self, isolated_nexus, runner):
+        cat = _build_initialized_catalog(isolated_nexus)
+        cat._db.close()
+
+        result = runner.invoke(synthesize_log_cmd, ["--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "dry-run" in result.output.lower()
+        # Owner + 2 documents → 3 events at minimum.
+        assert "OwnerRegistered" in result.output
+        assert "DocumentRegistered" in result.output
+
+        # events.jsonl untouched.
+        log = EventLog(isolated_nexus)
+        assert log.path.read_text() == ""
+
+    def test_dry_run_json_report(self, isolated_nexus, runner):
+        cat = _build_initialized_catalog(isolated_nexus)
+        cat._db.close()
+
+        result = runner.invoke(synthesize_log_cmd, ["--dry-run", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["dry_run"] is True
+        assert payload["wrote"] is False
+        assert payload["events_total"] >= 3
+        assert "OwnerRegistered" in payload["events_by_type"]
+        assert "DocumentRegistered" in payload["events_by_type"]
+
+
+# ── Default: refuse to overwrite, write to fresh log ─────────────────────
+
+
+class TestWriteAndOverwrite:
+    def test_writes_to_fresh_log(self, isolated_nexus, runner):
+        cat = _build_initialized_catalog(isolated_nexus)
+        cat._db.close()
+
+        result = runner.invoke(synthesize_log_cmd, [])
+        assert result.exit_code == 0, result.output
+        assert "Wrote events.jsonl" in result.output
+
+        log = EventLog(isolated_nexus)
+        events = list(log.replay())
+        assert len(events) >= 3
+        types = {e.type for e in events}
+        assert ev.TYPE_OWNER_REGISTERED in types
+        assert ev.TYPE_DOCUMENT_REGISTERED in types
+
+    def test_refuses_to_overwrite_non_empty_log(self, isolated_nexus, runner):
+        cat = _build_initialized_catalog(isolated_nexus)
+        cat._db.close()
+
+        # First run populates events.jsonl.
+        first = runner.invoke(synthesize_log_cmd, [])
+        assert first.exit_code == 0
+        # Second run without --force must refuse.
+        second = runner.invoke(synthesize_log_cmd, [])
+        assert second.exit_code != 0
+        assert "non-empty" in second.output.lower()
+
+    def test_force_truncates_and_rewrites(self, isolated_nexus, runner):
+        cat = _build_initialized_catalog(isolated_nexus)
+        cat._db.close()
+
+        runner.invoke(synthesize_log_cmd, [])
+        log = EventLog(isolated_nexus)
+        first_events = list(log.replay())
+        first_doc_ids = {
+            e.payload.doc_id for e in first_events
+            if e.type == ev.TYPE_DOCUMENT_REGISTERED
+        }
+
+        result = runner.invoke(synthesize_log_cmd, ["--force"])
+        assert result.exit_code == 0
+        second_events = list(log.replay())
+        # Same event count.
+        assert len(second_events) == len(first_events)
+        second_doc_ids = {
+            e.payload.doc_id for e in second_events
+            if e.type == ev.TYPE_DOCUMENT_REGISTERED
+        }
+        # Fresh UUID7s on every synthesize-log run — the canonical
+        # doc_ids are different even though the tumblers are the same.
+        assert first_doc_ids.isdisjoint(second_doc_ids)
+
+
+# ── UUID7 minting + tumbler preservation ─────────────────────────────────
+
+
+class TestUUID7Minting:
+    def test_doc_ids_are_uuid7(self, isolated_nexus, runner):
+        cat = _build_initialized_catalog(isolated_nexus)
+        cat._db.close()
+
+        runner.invoke(synthesize_log_cmd, [])
+        log = EventLog(isolated_nexus)
+        for e in log.replay():
+            if e.type != ev.TYPE_DOCUMENT_REGISTERED:
+                continue
+            # doc_id must parse as a UUID7.
+            u = uuid.UUID(e.payload.doc_id)
+            assert u.version == 7, (
+                f"DocumentRegistered.doc_id should be UUID7, got "
+                f"version {u.version}: {e.payload.doc_id}"
+            )
+
+    def test_tumbler_preserved_alongside_uuid7(self, isolated_nexus, runner):
+        cat = _build_initialized_catalog(isolated_nexus)
+        cat._db.close()
+
+        runner.invoke(synthesize_log_cmd, [])
+        log = EventLog(isolated_nexus)
+        doc_events = [
+            e for e in log.replay() if e.type == ev.TYPE_DOCUMENT_REGISTERED
+        ]
+        assert len(doc_events) == 2
+        for e in doc_events:
+            assert e.payload.tumbler != "", (
+                "Phase 2 synthesis must preserve the original tumbler "
+                "in payload.tumbler so the v: 0 projector keeps writing "
+                "to the existing tumbler-keyed SQLite schema."
+            )
+            # The two should differ in shape: doc_id is UUID7, tumbler is "1.X.Y".
+            assert e.payload.doc_id != e.payload.tumbler
+
+
+# ── Round-trip: synthesized log replays to live SQLite ───────────────────
+
+
+class TestReplayEquality:
+    """The synthesized log + projector must reproduce the live SQLite,
+    even though the events carry UUID7 doc_ids the live schema doesn't
+    know about. The v: 0 projector reads ``payload.tumbler`` for the
+    SQLite write."""
+
+    def test_synthesized_log_replays_to_match(self, isolated_nexus, runner, tmp_path):
+        cat = _build_initialized_catalog(isolated_nexus)
+        cat._db.close()
+
+        result = runner.invoke(synthesize_log_cmd, [])
+        assert result.exit_code == 0
+
+        # Replay events.jsonl into a fresh CatalogDB.
+        log = EventLog(isolated_nexus)
+        projected_path = tmp_path / "projected.db"
+        proj_db = CatalogDB(projected_path)
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        live_conn = sqlite3.connect(str(isolated_nexus / ".catalog.db"))
+        proj_conn = sqlite3.connect(str(projected_path))
+        try:
+            for table in ("owners", "documents"):
+                cur = live_conn.execute(f"PRAGMA table_info({table})")
+                cols = ", ".join(r[1] for r in cur.fetchall())
+                live_rows = sorted(live_conn.execute(
+                    f"SELECT {cols} FROM {table} ORDER BY {cols}"
+                ).fetchall())
+                proj_rows = sorted(proj_conn.execute(
+                    f"SELECT {cols} FROM {table} ORDER BY {cols}"
+                ).fetchall())
+                assert live_rows == proj_rows, (
+                    f"{table}: synthesized log replay diverged from live SQLite\n"
+                    f"  live:      {live_rows}\n"
+                    f"  projected: {proj_rows}"
+                )
+        finally:
+            live_conn.close()
+            proj_conn.close()
+
+
+# ── Synthesizer-level tumbler stability across re-emit ───────────────────
+
+
+class TestTumblerStableAcrossEmits:
+    """A single synthesizer invocation must give every appearance of the
+    same tumbler the same UUID7 doc_id (the mapping pass guarantees this).
+    Otherwise an alias graph would have alias_doc_id != the
+    DocumentRegistered's doc_id for the alias row."""
+
+    def test_alias_uses_same_doc_id_as_registered(self, isolated_nexus, runner):
+        Catalog.init(isolated_nexus)
+        cat = Catalog(isolated_nexus, isolated_nexus / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="ababab")
+        canonical = cat.register(owner, "canon.md", content_type="prose")
+        alias = cat.register(owner, "alias.md", content_type="prose")
+        cat.set_alias(alias, canonical)
+        cat._db.close()
+
+        result = runner.invoke(synthesize_log_cmd, [])
+        assert result.exit_code == 0
+
+        log = EventLog(isolated_nexus)
+        events = list(log.replay())
+
+        # Find the DocumentRegistered for the alias and the matching
+        # DocumentAliased event; their doc_id pair must be consistent.
+        registered_by_tumbler = {
+            e.payload.tumbler: e.payload.doc_id
+            for e in events if e.type == ev.TYPE_DOCUMENT_REGISTERED
+        }
+        aliased_events = [
+            e for e in events if e.type == ev.TYPE_DOCUMENT_ALIASED
+        ]
+        assert len(aliased_events) == 1
+        a = aliased_events[0]
+        # alias_doc_id and canonical_doc_id must be the UUID7s the
+        # corresponding DocumentRegistered events carried.
+        assert a.payload.alias_doc_id == registered_by_tumbler[str(alias)]
+        assert a.payload.canonical_doc_id == registered_by_tumbler[str(canonical)]


### PR DESCRIPTION
## Summary

Phase 2 PR α of RDR-101. Adds the operator verb that walks existing catalog JSONL, mints fresh UUID7 ``doc_id`` values per RDR-101 §Migration / Phase 1, and writes the resulting v: 0 events to ``events.jsonl``. The synthesized log is the canonical Phase 2+ source of truth; Phase 3 native v: 1 writes will append to it, and Phase 5 readers will project from it.

### Verb

``nx catalog synthesize-log [--dry-run] [--force] [--json]``

- Default: refuses to overwrite a non-empty ``events.jsonl``. Pass ``--force`` to overwrite or ``--dry-run`` to size without writing.
- ``--json`` emits ``{dry_run, events_path, existing_bytes, events_total, events_by_type, wrote}``.

### Synthesizer extension

``synthesize_from_jsonl(catalog_dir, *, mint_doc_id: bool = False)``:

- ``False`` (default): Phase 1 contract — ``doc_id == tumbler`` so the existing replay-equality test (``nx catalog doctor --replay-equality``) still passes.
- ``True`` (Phase 2 path): a single up-front pass over ``documents.jsonl`` builds the tumbler → UUID7 mapping; subsequent emits read from it so ``DocumentRegistered``, ``DocumentAliased``, and ``DocumentDeleted`` for the same logical document share one consistent doc_id within a synthesis run. The original tumbler is preserved in ``DocumentRegisteredPayload.tumbler`` for back-compat. The v: 0 projector reads ``payload.tumbler`` (not ``payload.doc_id``) for the SQLite write, so the synthesized log replays to a SQLite state byte-equal to today's ``Catalog.rebuild()``.

### Test plan (10 new tests)

- [x] Missing catalog → ClickException with helpful message.
- [x] ``--dry-run`` reports counts, doesn't write events.jsonl.
- [x] ``--dry-run --json`` emits structured payload.
- [x] Default writes to a fresh events.jsonl.
- [x] Default refuses to overwrite a non-empty log.
- [x] ``--force`` truncates and re-writes; doc_ids change between runs (UUID7 fresh per synthesis), event counts stay the same.
- [x] Every ``DocumentRegistered.doc_id`` parses as UUID7 (``uuid.UUID(s).version == 7``).
- [x] Original tumbler preserved alongside the UUID7 doc_id.
- [x] Synthesized log replays through the projector to a SQLite state byte-equal to the live catalog SQLite (proves UUID7 doc_ids don't break Phase 1 schema compatibility).
- [x] Aliased pair: ``DocumentAliased.alias_doc_id`` and ``canonical_doc_id`` are the same UUID7s the corresponding ``DocumentRegistered`` events carried, not raw tumblers.
- [x] 515 tests passing across catalog + chash + Phase 1/2 modules locally.
- [ ] CI green.

### What does NOT land in this PR

Per the Phase 2 decomposition:

- Walk T3 chunks → ``ChunkIndexed`` events (PR β)
- T3 metadata backfill via ``ChromaDB.update({doc_id: ...})`` (PR γ)
- ``nx catalog doctor --t3-doc-id-coverage`` verb (PR δ)
- ``nx catalog repair-orphan-chunks`` (PR ε)

### Refs

- RDR-101 §Implementation Plan / Phase 2
- RDR-101 §Migration from current state Phase 1

Bead: ``nexus-tn8i`` (Phase 2 sub-PR α under ``nexus-o6aa.8``).