### PR TITLE
fix(versions): sync plugin manifests + uv.lock to pyproject 4.21.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.21.2"
+      "version": "4.21.4"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.21.2"
+      "version": "4.21.4"
     }
   ]
 }

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.21.2",
+  "version": "4.21.4",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.21.2",
+  "version": "4.21.4",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.21.2"
+version = "4.21.4"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },
@@ -695,6 +695,7 @@ dependencies = [
     { name = "structlog" },
     { name = "tqdm" },
     { name = "tree-sitter-language-pack" },
+    { name = "uuid7-standard" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "voyageai" },
 ]
@@ -738,6 +739,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.0" },
     { name = "tqdm", specifier = ">=4.65" },
     { name = "tree-sitter-language-pack", specifier = "==0.7.1" },
+    { name = "uuid7-standard", marker = "python_full_version < '3.14'", specifier = ">=1.1.0" },
     { name = "uvicorn", extras = ["standard"] },
     { name = "voyageai", specifier = ">=0.2" },
 ]
@@ -5985,6 +5987,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/36/2d24b2cbe78547c6532da33fb8613debd3126eccc33a6374ab788f5e46e9/uuid_utils-0.14.1-cp39-abi3-win32.whl", hash = "sha256:b54d6aa6252d96bac1fdbc80d26ba71bad9f220b2724d692ad2f2310c22ef523", size = 183476, upload-time = "2026-02-20T22:50:32.745Z" },
     { url = "https://files.pythonhosted.org/packages/83/92/2d7e90df8b1a69ec4cff33243ce02b7a62f926ef9e2f0eca5a026889cd73/uuid_utils-0.14.1-cp39-abi3-win_amd64.whl", hash = "sha256:fc27638c2ce267a0ce3e06828aff786f91367f093c80625ee21dad0208e0f5ba", size = 187147, upload-time = "2026-02-20T22:50:45.807Z" },
     { url = "https://files.pythonhosted.org/packages/d9/26/529f4beee17e5248e37e0bc17a2761d34c0fa3b1e5729c88adb2065bae6e/uuid_utils-0.14.1-cp39-abi3-win_arm64.whl", hash = "sha256:b04cb49b42afbc4ff8dbc60cf054930afc479d6f4dd7f1ec3bbe5dbfdde06b7a", size = 188132, upload-time = "2026-02-20T22:50:41.718Z" },
+]
+
+[[package]]
+name = "uuid7-standard"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/0d/bbb440a1fad38c1be8cdc4c379e061ec10661061e43b68cf7e9ae718455b/uuid7_standard-1.1.0.tar.gz", hash = "sha256:c7efdef8309265444fd11439bda8df10bd6469b56be62c1d3d78e014d16b4b9a", size = 2181, upload-time = "2025-07-04T21:00:12.768Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/3e/568b8382627e0fec58ef3c83c3cafa241b86ff41ba37874df057693c12d1/uuid7_standard-1.1.0-py3-none-any.whl", hash = "sha256:725f8f9202662dd6212df6b8caa1e101c2a61935261f43438bca842e058c5726", size = 2561, upload-time = "2025-07-04T21:00:11.939Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase 1 PRs E (#418) and D (#419) bumped ``pyproject.toml``'s version to 4.21.3 then 4.21.4 to ensure ``apply_pending`` picks up the new ``chash_index`` rename and Frecency migrations. The plugin manifests and ``uv.lock`` were not updated in lockstep, so the version-match test gates in ``tests/test_plugin_structure.py`` and ``tests/test_sn_plugin.py`` started failing on main once #418 merged.

### Changes

- ``.claude-plugin/marketplace.json``: ``nx`` + ``sn`` versions 4.21.2 → 4.21.4.
- ``nx/.claude-plugin/plugin.json``: 4.21.2 → 4.21.4.
- ``sn/.claude-plugin/plugin.json``: 4.21.2 → 4.21.4.
- ``uv.lock``: refreshed via ``uv lock`` (also picks up ``uuid7-standard==1.1.0`` that #414 added to pyproject but didn't lock).

### Test plan

- [x] All 8 version-match assertions now pass locally (``TestMarketplaceVersion`` + ``TestSnMarketplace``).
- [x] The 8 errors in ``TestSnHookOutput`` are unrelated (subprocess timeouts on ``mcp-inject.sh`` — environment, not code) and pre-exist this commit.
- [ ] CI green on Linux.

### Going forward

Any pyproject version bump must also update both plugin manifests, the marketplace.json file, AND uv.lock; the ``TestMarketplaceVersion`` / ``TestSnMarketplace`` gates surface mismatches on the next CI run.