### PR TITLE
rdr-101(phase2): synthesize-log --chunks (T3 chunk synthesis)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -446,3 +446,5 @@
 {"id":"int-f379e4fd","kind":"field_change","created_at":"2026-05-01T08:54:08.946892Z","actor":"Hellblazer","issue_id":"nexus-ebz6","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-4e77a879","kind":"field_change","created_at":"2026-05-01T08:54:09.639937Z","actor":"Hellblazer","issue_id":"nexus-o6aa.7","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-d7241a43","kind":"field_change","created_at":"2026-05-01T09:08:58.935031Z","actor":"Hellblazer","issue_id":"nexus-tn8i","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-f18ab824","kind":"field_change","created_at":"2026-05-01T09:13:49.68973Z","actor":"Hellblazer","issue_id":"nexus-tn8i","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-4be6f52b","kind":"field_change","created_at":"2026-05-01T09:20:35.213518Z","actor":"Hellblazer","issue_id":"nexus-isro","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/events.py
+++ b/src/nexus/catalog/events.py
@@ -274,6 +274,15 @@ class ChunkIndexedPayload:
     events emitted from existing T3 state, the legacy
     ``f"{content_hash[:16]}_{chunk_index}"`` shape is copied verbatim.
     Either way the projector treats ``chunk_id`` as opaque.
+
+    ``synthesized_orphan`` flags chunks that the Phase 2
+    ``synthesize-log --chunks`` walker could not resolve to a document
+    via the source_path → source_uri → tumbler → doc_id chain or via
+    the title fallback (Phase 0 ``CHROMA_IDENTITY_FIELD`` pattern).
+    Such chunks are emitted with ``doc_id=""`` and
+    ``synthesized_orphan=True`` so the doctor verb (PR δ) can report
+    them rather than the GC silently collecting them after the
+    orphan window.
     """
 
     chunk_id: str
@@ -283,6 +292,7 @@ class ChunkIndexedPayload:
     position: int
     content_hash: str = ""
     embedded_at: str = ""
+    synthesized_orphan: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nexus/catalog/synthesizer.py
+++ b/src/nexus/catalog/synthesizer.py
@@ -434,3 +434,141 @@ def _owner_prefix_of(tumbler: str) -> str:
     if len(parts) < 2:
         return ""
     return ".".join(parts[:2])
+
+
+# ── T3 chunk synthesis (Phase 2 PR β) ────────────────────────────────────
+
+
+_CHUNK_PAGE_SIZE = 300  # matches the ChromaDB Cloud 300-row limit
+
+
+def synthesize_t3_chunks(
+    client: Any,
+    document_events: list[Event],
+) -> Iterator[Event]:
+    """Walk every collection on ``client`` and emit one ``ChunkIndexed``
+    v: 0 event per chunk.
+
+    ``document_events`` is the list of ``DocumentRegistered`` events the
+    document-side synthesizer just produced; this function reads
+    ``payload.source_uri`` / ``payload.title`` / ``payload.coll_id`` /
+    ``payload.doc_id`` to build reverse maps that resolve each T3 chunk's
+    ``source_path`` to a doc_id.
+
+    Resolution priority per chunk:
+
+    1. ``source_path`` exact match against ``source_uri`` after the
+       canonical ``file://`` prefix (the catalog stores file-scheme URIs
+       as ``file:///abs/path``; T3 chunks store the bare path).
+    2. ``title`` exact match (the Phase 0 ``CHROMA_IDENTITY_FIELD``
+       fallback for ``knowledge__*`` collections that legitimately have
+       empty source_uri rows in the catalog).
+    3. None — emit ``ChunkIndexed`` with ``doc_id=""`` and
+       ``synthesized_orphan=True`` so the Phase 2 doctor coverage
+       check (PR δ) can report the orphan rather than the GC silently
+       collecting it after the orphan window.
+
+    The walker uses paginated ``col.get(limit=300, offset=...)`` so a
+    multi-thousand-chunk collection does not exceed the ChromaDB Cloud
+    page limit. Chunks with empty / missing chash metadata are still
+    emitted (chash is empty in the event) — the corresponding catalog
+    rows existed before the chash_index landed (RDR-086) and would
+    otherwise vanish from the synthesized log.
+    """
+    # Build reverse maps once.
+    source_uri_to_doc_id: dict[str, str] = {}
+    title_to_doc_id: dict[str, str] = {}
+    coll_to_doc_ids: dict[str, set[str]] = {}
+    for ev_obj in document_events:
+        if ev_obj.type != ev.TYPE_DOCUMENT_REGISTERED:
+            continue
+        p = ev_obj.payload
+        if p.source_uri:
+            source_uri_to_doc_id[p.source_uri] = p.doc_id
+        if p.title:
+            # Last-write-wins: a title collision means the synthesized
+            # event log can only resolve to one of them; the doctor
+            # verb will surface the ambiguity downstream.
+            title_to_doc_id[p.title] = p.doc_id
+        if p.coll_id:
+            coll_to_doc_ids.setdefault(p.coll_id, set()).add(p.doc_id)
+
+    try:
+        collections = list(client.list_collections())
+    except Exception as exc:
+        _log.warning("synthesizer_t3_list_collections_failed", error=str(exc))
+        return
+
+    for col in collections:
+        coll_name = getattr(col, "name", None) or str(col)
+        try:
+            yield from _synthesize_collection_chunks(
+                col, coll_name,
+                source_uri_to_doc_id=source_uri_to_doc_id,
+                title_to_doc_id=title_to_doc_id,
+            )
+        except Exception as exc:
+            _log.warning(
+                "synthesizer_t3_collection_walk_failed",
+                collection=coll_name, error=str(exc),
+            )
+            continue
+
+
+def _synthesize_collection_chunks(
+    col: Any,
+    coll_name: str,
+    *,
+    source_uri_to_doc_id: dict[str, str],
+    title_to_doc_id: dict[str, str],
+) -> Iterator[Event]:
+    """Paginate one collection and yield ``ChunkIndexed`` per chunk."""
+    offset = 0
+    while True:
+        page = col.get(limit=_CHUNK_PAGE_SIZE, offset=offset, include=["metadatas"])
+        ids = page.get("ids") or []
+        metadatas = page.get("metadatas") or []
+        if not ids:
+            break
+        for chunk_id, meta in zip(ids, metadatas):
+            meta = meta or {}
+            source_path = meta.get("source_path") or ""
+            chunk_title = meta.get("title") or ""
+            chash = meta.get("chunk_text_hash") or ""
+            content_hash = meta.get("content_hash") or ""
+            chunk_index = int(meta.get("chunk_index", 0) or 0)
+            embedded_at = meta.get("indexed_at") or meta.get("embedded_at") or ""
+
+            # 1. source_path → file://source_path → source_uri map.
+            doc_id = ""
+            if source_path:
+                candidate = (
+                    source_path
+                    if source_path.startswith(("file://", "chroma://", "https://", "http://", "x-devonthink-item://"))
+                    else f"file://{source_path}"
+                )
+                doc_id = source_uri_to_doc_id.get(candidate, "")
+            # 2. Title fallback (CHROMA_IDENTITY_FIELD pattern).
+            if not doc_id and chunk_title:
+                doc_id = title_to_doc_id.get(chunk_title, "")
+            orphan = not doc_id
+
+            yield Event(
+                type=ev.TYPE_CHUNK_INDEXED,
+                v=0,
+                payload=ev.ChunkIndexedPayload(
+                    chunk_id=chunk_id,
+                    chash=chash,
+                    doc_id=doc_id,
+                    coll_id=coll_name,
+                    position=chunk_index,
+                    content_hash=content_hash,
+                    embedded_at=embedded_at,
+                    synthesized_orphan=orphan,
+                ),
+                ts=embedded_at,
+            )
+
+        if len(ids) < _CHUNK_PAGE_SIZE:
+            break
+        offset += _CHUNK_PAGE_SIZE

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3451,10 +3451,25 @@ def _print_replay_equality_text(report: dict) -> None:
     ),
 )
 @click.option(
+    "--chunks/--no-chunks",
+    default=False,
+    help=(
+        "Also walk every T3 collection and emit one ChunkIndexed event "
+        "per chunk, with doc_id resolved from source_path → catalog "
+        "source_uri → tumbler → doc_id (or the title fallback for "
+        "knowledge__* collections that have empty source_uri rows). "
+        "Off by default so synthesizing the document side does not "
+        "require ChromaDB credentials. Phase 2 deployment guides will "
+        "set this on for the canonical synthesis run."
+    ),
+)
+@click.option(
     "--json", "as_json", is_flag=True,
     help="Emit machine-readable JSON instead of text output.",
 )
-def synthesize_log_cmd(dry_run: bool, force: bool, as_json: bool) -> None:
+def synthesize_log_cmd(
+    dry_run: bool, force: bool, chunks: bool, as_json: bool,
+) -> None:
     """RDR-101 Phase 2: synthesize events.jsonl from existing JSONL state.
 
     Walks ``owners.jsonl`` + ``documents.jsonl`` + ``links.jsonl``,
@@ -3497,24 +3512,49 @@ def synthesize_log_cmd(dry_run: bool, force: bool, as_json: bool) -> None:
         )
 
     events = list(synthesize_from_jsonl(cat_dir, mint_doc_id=True))
+    chunk_events: list = []
+    orphan_count = 0
+    if chunks:
+        from nexus.catalog.synthesizer import synthesize_t3_chunks
+        from nexus.db import make_t3
+
+        try:
+            t3 = make_t3()
+            chunk_events = list(
+                synthesize_t3_chunks(t3._client, events)
+            )
+            orphan_count = sum(
+                1 for e in chunk_events
+                if getattr(e.payload, "synthesized_orphan", False)
+            )
+        except Exception as exc:
+            raise click.ClickException(
+                f"Failed to walk T3 chunks: {exc}. Pass --no-chunks to "
+                "skip the chunk synthesis pass and re-run later once "
+                "ChromaDB credentials are configured."
+            )
+
+    all_events = events + chunk_events
 
     counts: dict[str, int] = {}
-    for e in events:
+    for e in all_events:
         counts[e.type] = counts.get(e.type, 0) + 1
 
     report = {
         "dry_run": dry_run,
         "events_path": str(log.path),
         "existing_bytes": existing_size,
-        "events_total": len(events),
+        "events_total": len(all_events),
         "events_by_type": counts,
+        "chunks_synthesized": chunks,
+        "orphan_chunks": orphan_count,
         "wrote": False,
     }
 
     if not dry_run:
         if existing_size > 0 and force:
             log.truncate()
-        log.append_many(events)
+        log.append_many(all_events)
         report["wrote"] = True
 
     if as_json:
@@ -3527,6 +3567,8 @@ def _print_synthesize_log_text(report: dict) -> None:
     click.echo(f"Events path:    {report['events_path']}")
     click.echo(f"Existing size:  {report['existing_bytes']} bytes")
     click.echo(f"Events total:   {report['events_total']}")
+    if report.get("chunks_synthesized"):
+        click.echo(f"Orphan chunks:  {report.get('orphan_chunks', 0)}")
     if report["events_by_type"]:
         click.echo("By type:")
         for t, c in sorted(report["events_by_type"].items(), key=lambda kv: kv[0]):

--- a/tests/test_catalog_synthesize_chunks.py
+++ b/tests/test_catalog_synthesize_chunks.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 2 PR β chunk synthesis path.
+
+Coverage:
+- ``synthesize_t3_chunks(client, document_events)`` resolves doc_ids
+  via source_path → file://source_path → source_uri map.
+- Title fallback resolves chunks for empty-source_uri documents.
+- Unmatched chunks emit ``ChunkIndexed`` with ``doc_id=""`` and
+  ``synthesized_orphan=True``.
+- Pagination works for >300-chunk collections.
+- ``synthesize-log --chunks`` integrates document + chunk synthesis.
+- ``synthesize-log --chunks`` reports orphan count in the JSON payload.
+
+Tests use ``chromadb.EphemeralClient`` + ``DefaultEmbeddingFunction`` so
+no Cloud credentials are needed (matches the pattern in
+``tests/test_t3_prune_stale.py``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.synthesizer import synthesize_t3_chunks
+
+
+@pytest.fixture()
+def isolated_nexus(tmp_path: Path) -> Path:
+    return tmp_path / "test-catalog"
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def chroma_client():
+    """EphemeralClient gives an in-process ChromaDB with no Cloud creds.
+
+    EphemeralClient is process-singleton-ish — collections from earlier
+    tests can leak into the next. Drop everything at fixture build so
+    the test sees a truly empty client (matches the pattern in
+    ``tests/test_t3_prune_stale.py``).
+    """
+    client = chromadb.EphemeralClient()
+    for col in list(client.list_collections()):
+        try:
+            client.delete_collection(col.name)
+        except Exception:
+            pass
+    return client
+
+
+def _seed_collection(
+    client, name: str, chunks: list[dict],
+) -> None:
+    """Seed ``name`` with the given chunks. Each dict carries
+    ``id``, ``content``, and a ``metadata`` dict."""
+    col = client.get_or_create_collection(
+        name=name, embedding_function=DefaultEmbeddingFunction(),
+    )
+    col.add(
+        ids=[c["id"] for c in chunks],
+        documents=[c["content"] for c in chunks],
+        metadatas=[c["metadata"] for c in chunks],
+    )
+
+
+def _make_doc_events(*specs: dict) -> list[ev.Event]:
+    """Build DocumentRegistered events from spec dicts; convenience for
+    test setup so we don't have to drive a real Catalog."""
+    out: list[ev.Event] = []
+    for s in specs:
+        out.append(ev.Event(
+            type=ev.TYPE_DOCUMENT_REGISTERED, v=0,
+            payload=ev.DocumentRegisteredPayload(
+                doc_id=s["doc_id"],
+                owner_id=s.get("owner_id", "1.1"),
+                content_type=s.get("content_type", "code"),
+                source_uri=s.get("source_uri", ""),
+                coll_id=s.get("coll_id", ""),
+                title=s.get("title", ""),
+                tumbler=s.get("tumbler", ""),
+            ),
+            ts="2026-04-30T00:00:00Z",
+        ))
+    return out
+
+
+# ── Direct synthesizer tests ─────────────────────────────────────────────
+
+
+class TestChunkSynthesisHappyPath:
+    def test_emits_one_event_per_chunk(self, chroma_client):
+        _seed_collection(chroma_client, "code__test", [
+            {
+                "id": "ch1", "content": "hello",
+                "metadata": {
+                    "source_path": "/git/x/foo.py",
+                    "chunk_text_hash": "abc1",
+                    "content_hash": "h1",
+                    "chunk_index": 0,
+                },
+            },
+            {
+                "id": "ch2", "content": "world",
+                "metadata": {
+                    "source_path": "/git/x/foo.py",
+                    "chunk_text_hash": "abc2",
+                    "content_hash": "h1",
+                    "chunk_index": 1,
+                },
+            },
+        ])
+        doc_events = _make_doc_events({
+            "doc_id": "uuid7-foo", "owner_id": "1.1",
+            "source_uri": "file:///git/x/foo.py",
+            "coll_id": "code__test",
+            "tumbler": "1.1.1",
+            "title": "foo.py",
+        })
+
+        events = list(synthesize_t3_chunks(chroma_client, doc_events))
+        assert len(events) == 2
+        for e in events:
+            assert e.type == ev.TYPE_CHUNK_INDEXED
+            assert e.v == 0
+            assert e.payload.doc_id == "uuid7-foo"
+            assert e.payload.coll_id == "code__test"
+            assert e.payload.synthesized_orphan is False
+        # Position is preserved from chunk_index.
+        positions = sorted(e.payload.position for e in events)
+        assert positions == [0, 1]
+        # chash propagates.
+        assert {e.payload.chash for e in events} == {"abc1", "abc2"}
+
+    def test_resolves_via_title_fallback(self, chroma_client):
+        # Document has empty source_uri; chunk has source_path that
+        # doesn't match, but title matches.
+        _seed_collection(chroma_client, "knowledge__papers", [
+            {
+                "id": "p1", "content": "abstract",
+                "metadata": {
+                    "source_path": "/legacy/path/missing",
+                    "title": "Some Paper",
+                    "chunk_text_hash": "p1hash",
+                    "chunk_index": 0,
+                },
+            },
+        ])
+        doc_events = _make_doc_events({
+            "doc_id": "uuid7-paper", "owner_id": "1.2",
+            "content_type": "paper",
+            "source_uri": "",
+            "coll_id": "knowledge__papers",
+            "tumbler": "1.2.42",
+            "title": "Some Paper",
+        })
+
+        events = list(synthesize_t3_chunks(chroma_client, doc_events))
+        assert len(events) == 1
+        e = events[0]
+        assert e.payload.doc_id == "uuid7-paper"
+        assert e.payload.synthesized_orphan is False
+
+
+class TestChunkSynthesisOrphans:
+    def test_unmatched_chunk_is_orphan(self, chroma_client):
+        _seed_collection(chroma_client, "code__abandoned", [
+            {
+                "id": "orphan", "content": "stale",
+                "metadata": {
+                    "source_path": "/git/deleted/gone.py",
+                    "title": "gone.py",
+                    "chunk_text_hash": "orphanhash",
+                    "chunk_index": 0,
+                },
+            },
+        ])
+        # No DocumentRegistered events — every chunk should orphan.
+        events = list(synthesize_t3_chunks(chroma_client, []))
+        assert len(events) == 1
+        e = events[0]
+        assert e.payload.doc_id == ""
+        assert e.payload.synthesized_orphan is True
+        assert e.payload.chash == "orphanhash"
+
+
+class TestChunkSynthesisPagination:
+    """Confirm the synthesizer handles >300 chunks per collection.
+
+    EphemeralClient does not enforce the Cloud 300-row limit but the
+    walker still has to call get() with limit/offset; if the loop exit
+    condition is wrong we'd loop forever or miss chunks.
+    """
+
+    def test_walks_a_400_chunk_collection(self, chroma_client):
+        chunks = [
+            {
+                "id": f"c{i:03d}", "content": f"chunk-{i}",
+                "metadata": {
+                    "source_path": "/git/big/file.py",
+                    "chunk_text_hash": f"h{i:03d}",
+                    "chunk_index": i,
+                },
+            }
+            for i in range(400)
+        ]
+        _seed_collection(chroma_client, "code__big", chunks)
+        doc_events = _make_doc_events({
+            "doc_id": "uuid7-big",
+            "source_uri": "file:///git/big/file.py",
+            "coll_id": "code__big",
+            "tumbler": "1.1.1",
+            "title": "file.py",
+        })
+
+        events = list(synthesize_t3_chunks(chroma_client, doc_events))
+        assert len(events) == 400
+        ids = {e.payload.chunk_id for e in events}
+        assert ids == {f"c{i:03d}" for i in range(400)}
+
+
+# ── synthesize-log --chunks integration ──────────────────────────────────
+
+
+class TestSynthesizeLogChunksFlag:
+    def test_chunks_flag_produces_chunk_events(
+        self, isolated_nexus, runner,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Build a real catalog with one document.
+        Catalog.init(isolated_nexus)
+        cat = Catalog(isolated_nexus, isolated_nexus / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="571b8edd")
+        cat.register(
+            owner, "doc-A.md", content_type="prose",
+            file_path="doc-A.md",
+            physical_collection="docs__nexus-test",
+        )
+        cat._db.close()
+
+        # Set up a chromadb instance with chunks for that document.
+        # Reset the singleton-ish EphemeralClient so a previous test's
+        # collections don't leak in.
+        client = chromadb.EphemeralClient()
+        for col in list(client.list_collections()):
+            try:
+                client.delete_collection(col.name)
+            except Exception:
+                pass
+        # Owner repo_root is empty in this fixture; resolve_path
+        # falls through, so source_path on the chunks just needs to
+        # match what _normalize_source_uri produces. We use the
+        # absolute path of doc-A.md inside the test working dir.
+        # _normalize_source_uri turns bare relative paths into
+        # ``file://<repo_root>/file_path`` when repo_root is set; here
+        # it falls back to ``file://<cwd>/file_path`` which matches the
+        # path the runner captures. Read the catalog row to learn the
+        # actual source_uri it stored.
+        cat = Catalog(isolated_nexus, isolated_nexus / ".catalog.db")
+        entries = list(cat._db.execute("SELECT source_uri FROM documents").fetchall())
+        cat._db.close()
+        source_uri = entries[0][0]
+        # Strip "file://" → source_path the chunk will carry.
+        assert source_uri.startswith("file://")
+        source_path = source_uri[len("file://"):]
+
+        _seed_collection(client, "docs__nexus-test", [
+            {
+                "id": "ch1", "content": "doc-A content",
+                "metadata": {
+                    "source_path": source_path,
+                    "chunk_text_hash": "ahash",
+                    "chunk_index": 0,
+                },
+            },
+        ])
+
+        # Patch make_t3 so the verb finds our EphemeralClient.
+        class _FakeT3:
+            _client = client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        from nexus.commands.catalog import synthesize_log_cmd
+        result = runner.invoke(
+            synthesize_log_cmd, ["--chunks", "--json"],
+        )
+        assert result.exit_code == 0, (
+            f"verb failed: {result.output}\n{result.exception!r}"
+        )
+        payload = json.loads(result.output)
+        assert payload["chunks_synthesized"] is True
+        assert payload["events_by_type"].get("ChunkIndexed", 0) == 1
+        assert payload["orphan_chunks"] == 0
+
+        # Confirm events.jsonl on disk has the ChunkIndexed event.
+        log = EventLog(isolated_nexus)
+        events = list(log.replay())
+        chunk_events = [e for e in events if e.type == ev.TYPE_CHUNK_INDEXED]
+        assert len(chunk_events) == 1
+        assert chunk_events[0].payload.chunk_id == "ch1"
+        assert chunk_events[0].payload.synthesized_orphan is False
+        # doc_id is the UUID7 the document synthesis minted.
+        doc_events = [e for e in events if e.type == ev.TYPE_DOCUMENT_REGISTERED]
+        assert chunk_events[0].payload.doc_id == doc_events[0].payload.doc_id
+
+    def test_no_chunks_flag_skips_t3(
+        self, isolated_nexus, runner,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        Catalog.init(isolated_nexus)
+        cat = Catalog(isolated_nexus, isolated_nexus / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="cdcdcd")
+        cat.register(owner, "doc-A.md", content_type="prose", file_path="doc-A.md")
+        cat._db.close()
+
+        # If the verb tried to access make_t3 we'd find out.
+        def _boom():
+            raise AssertionError("make_t3 must not be called when --chunks is off")
+
+        monkeypatch.setattr("nexus.db.make_t3", _boom)
+
+        from nexus.commands.catalog import synthesize_log_cmd
+        result = runner.invoke(synthesize_log_cmd, ["--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["chunks_synthesized"] is False
+        assert "ChunkIndexed" not in payload["events_by_type"]


### PR DESCRIPTION
## Summary

Phase 2 PR β of RDR-101. Extends ``nx catalog synthesize-log`` with a ``--chunks`` flag that walks every T3 collection via ChromaDB and emits one ``ChunkIndexed`` v: 0 event per chunk, with ``doc_id`` resolved from the just-minted document events. Off by default so synthesizing the document side does not require ChromaDB credentials.

### What lands

- ``ChunkIndexedPayload`` gains ``synthesized_orphan: bool = False`` so the doctor coverage check (PR δ) can report unmatched chunks.
- ``synthesizer.synthesize_t3_chunks(client, document_events)`` — paginated walker. Resolution priority: ``source_path`` → ``file://source_path`` → ``source_uri`` map (1) → ``title`` fallback (2) → orphan with ``doc_id=""`` and ``synthesized_orphan=True`` (3).
- ``synthesize-log --chunks`` flag wires the walker behind ``make_t3`` and appends to events.jsonl. JSON report adds ``chunks_synthesized`` + ``orphan_chunks`` fields.

### Test plan (6 new tests)

- [x] Happy path: source_path → source_uri match resolves doc_id.
- [x] Title fallback: empty-source_uri document + chunk title match.
- [x] Orphan: unmatched chunk → ``doc_id=""``, ``synthesized_orphan=True``.
- [x] Pagination: 400-chunk collection walks in two pages.
- [x] ``synthesize-log --chunks`` integration: real Catalog + EphemeralClient, patched ``make_t3``, JSON payload reports the right counts.
- [x] ``synthesize-log`` (no ``--chunks``) does not call ``make_t3``.
- [x] 298 tests passing across catalog + chash + Phase 1 + Phase 2 modules locally.
- [ ] CI green.

### Refs

- RDR-101 §Implementation Plan / Phase 2
- RDR-101 §Migration from current state Phase 1 — empty-source_uri title fallback + ``_synthesized_orphan`` tag

Bead: ``nexus-isro`` (Phase 2 sub-PR β under ``nexus-o6aa.8``).