### PR TITLE
rdr-101(phase2): nx catalog t3-backfill-doc-id verb

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -448,3 +448,5 @@
 {"id":"int-d7241a43","kind":"field_change","created_at":"2026-05-01T09:08:58.935031Z","actor":"Hellblazer","issue_id":"nexus-tn8i","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-f18ab824","kind":"field_change","created_at":"2026-05-01T09:13:49.68973Z","actor":"Hellblazer","issue_id":"nexus-tn8i","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-4be6f52b","kind":"field_change","created_at":"2026-05-01T09:20:35.213518Z","actor":"Hellblazer","issue_id":"nexus-isro","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-2a7ec5d3","kind":"field_change","created_at":"2026-05-01T09:28:40.382333Z","actor":"Hellblazer","issue_id":"nexus-isro","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-33b7c849","kind":"field_change","created_at":"2026-05-01T09:29:11.926357Z","actor":"Hellblazer","issue_id":"nexus-6qjo","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3579,3 +3579,198 @@ def _print_synthesize_log_text(report: dict) -> None:
         click.echo("Wrote events.jsonl.")
     else:
         click.echo("(no write performed.)")
+
+
+# ── RDR-101 Phase 2: t3-backfill-doc-id verb ─────────────────────────────
+
+
+@catalog.command("t3-backfill-doc-id")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help=(
+        "Walk events.jsonl and report what would change in T3, without "
+        "calling ChromaDB.update. Use to size the backfill (per-"
+        "collection chunk count, orphan count) before committing."
+    ),
+)
+@click.option(
+    "--collection",
+    "collection_filter",
+    default="",
+    help=(
+        "Restrict the backfill to one collection name. Default is "
+        "every collection that appears in the event log. Use to "
+        "stage a per-collection rollout on a large catalog."
+    ),
+)
+@click.option(
+    "--json", "as_json", is_flag=True,
+    help="Emit machine-readable JSON instead of text output.",
+)
+def t3_backfill_doc_id_cmd(
+    dry_run: bool, collection_filter: str, as_json: bool,
+) -> None:
+    """RDR-101 Phase 2: backfill T3 chunks with the doc_id from the event log.
+
+    Reads ``events.jsonl`` for ``ChunkIndexed`` events (which the Phase 2
+    ``synthesize-log --chunks`` walker emits with resolved ``doc_id``
+    values), opens every collection that appears in the log, and calls
+    ``col.update(ids=[chunk_id], metadatas=[{..existing.., doc_id: X}])``
+    for each chunk whose stored metadata does not already carry a matching
+    doc_id. Idempotent — re-running on already-backfilled chunks is a
+    cheap no-op.
+
+    Orphan chunks (``synthesized_orphan=True``) are skipped and surfaced
+    in the report; the operator runs ``nx catalog repair-orphan-chunks``
+    to assign them manually before they GC after the orphan window.
+    """
+    from nexus.catalog.catalog import Catalog
+    from nexus.catalog.event_log import EventLog
+    from nexus.catalog import events as ev
+    from nexus.config import catalog_path
+    from nexus.db import make_t3
+
+    cat_dir = catalog_path()
+    if not Catalog.is_initialized(cat_dir):
+        raise click.ClickException(
+            f"Catalog not initialized at {cat_dir}. "
+            "Run 'nx catalog setup' to create and populate it."
+        )
+
+    log = EventLog(cat_dir)
+    if not log.path.exists() or log.path.stat().st_size == 0:
+        raise click.ClickException(
+            f"events.jsonl is empty at {log.path}. Run 'nx catalog "
+            "synthesize-log --chunks' first to populate the log with "
+            "ChunkIndexed events."
+        )
+
+    # Group ChunkIndexed events by collection so each ChromaDB
+    # collection is opened once, regardless of how many chunks live in
+    # it. Skip orphans (no doc_id to backfill).
+    by_coll: dict[str, list] = {}
+    orphans_total = 0
+    for event in log.replay():
+        if event.type != ev.TYPE_CHUNK_INDEXED:
+            continue
+        if event.payload.synthesized_orphan or not event.payload.doc_id:
+            orphans_total += 1
+            continue
+        if collection_filter and event.payload.coll_id != collection_filter:
+            continue
+        by_coll.setdefault(event.payload.coll_id, []).append(event.payload)
+
+    chunks_updated = 0
+    chunks_already_correct = 0
+    errors: list[dict] = []
+
+    if not dry_run:
+        try:
+            t3 = make_t3()
+        except Exception as exc:
+            raise click.ClickException(
+                f"Failed to open T3 client: {exc}. Check ChromaDB credentials."
+            )
+
+    for coll_name, payloads in by_coll.items():
+        if dry_run:
+            chunks_updated += len(payloads)
+            continue
+        try:
+            col = t3._client.get_collection(name=coll_name)
+        except Exception as exc:
+            errors.append({
+                "collection": coll_name,
+                "stage": "open",
+                "error": str(exc),
+            })
+            continue
+
+        # Idempotency: read current metadata in batches; only update
+        # chunks that don't already carry the right doc_id.
+        ids = [p.chunk_id for p in payloads]
+        for batch_start in range(0, len(ids), 300):
+            batch_ids = ids[batch_start:batch_start + 300]
+            batch_payloads = payloads[batch_start:batch_start + 300]
+            try:
+                existing = col.get(ids=batch_ids, include=["metadatas"])
+            except Exception as exc:
+                errors.append({
+                    "collection": coll_name,
+                    "stage": "read",
+                    "batch_size": len(batch_ids),
+                    "error": str(exc),
+                })
+                continue
+
+            existing_meta = {
+                cid: m for cid, m in zip(
+                    existing.get("ids") or [],
+                    existing.get("metadatas") or [],
+                )
+            }
+
+            update_ids: list[str] = []
+            update_metas: list[dict] = []
+            for payload in batch_payloads:
+                current = existing_meta.get(payload.chunk_id) or {}
+                if current.get("doc_id") == payload.doc_id:
+                    chunks_already_correct += 1
+                    continue
+                merged = dict(current)
+                merged["doc_id"] = payload.doc_id
+                update_ids.append(payload.chunk_id)
+                update_metas.append(merged)
+
+            if not update_ids:
+                continue
+            try:
+                col.update(ids=update_ids, metadatas=update_metas)
+                chunks_updated += len(update_ids)
+            except Exception as exc:
+                errors.append({
+                    "collection": coll_name,
+                    "stage": "update",
+                    "batch_size": len(update_ids),
+                    "error": str(exc),
+                })
+
+    report = {
+        "dry_run": dry_run,
+        "events_path": str(log.path),
+        "collection_filter": collection_filter or "(all)",
+        "collections_processed": len(by_coll),
+        "chunks_eligible": sum(len(p) for p in by_coll.values()),
+        "chunks_updated": chunks_updated,
+        "chunks_already_correct": chunks_already_correct,
+        "orphans_skipped": orphans_total,
+        "errors": errors,
+    }
+
+    if as_json:
+        click.echo(json.dumps(report, indent=2))
+    else:
+        _print_t3_backfill_text(report)
+
+    if errors and not dry_run:
+        # Surface a non-zero exit so an operator running this in a
+        # script can detect partial failure.
+        raise click.exceptions.Exit(1)
+
+
+def _print_t3_backfill_text(report: dict) -> None:
+    click.echo(f"Events path:           {report['events_path']}")
+    click.echo(f"Collection filter:     {report['collection_filter']}")
+    click.echo(f"Collections processed: {report['collections_processed']}")
+    click.echo(f"Chunks eligible:       {report['chunks_eligible']}")
+    if report["dry_run"]:
+        click.echo("(dry-run — no T3 writes performed.)")
+    else:
+        click.echo(f"Chunks updated:        {report['chunks_updated']}")
+        click.echo(f"Already correct:       {report['chunks_already_correct']}")
+    click.echo(f"Orphans skipped:       {report['orphans_skipped']}")
+    if report["errors"]:
+        click.echo(f"\nErrors ({len(report['errors'])}):")
+        for e in report["errors"][:10]:
+            click.echo(f"  {e['collection']} ({e['stage']}): {e['error']}")

--- a/tests/test_catalog_t3_backfill.py
+++ b/tests/test_catalog_t3_backfill.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 2 PR γ ``nx catalog t3-backfill-doc-id`` verb.
+
+Coverage:
+- Verb fails loudly when catalog is not initialized or events.jsonl is empty.
+- ``--dry-run`` reports counts without calling ChromaDB.update.
+- Default behavior writes doc_id metadata into T3 chunks.
+- Idempotency: re-running on already-backfilled chunks is a no-op.
+- ``--collection`` filter scopes the backfill.
+- Orphan chunks (synthesized_orphan=True) are skipped and counted.
+- ``--json`` emits a structured report.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.event_log import EventLog
+from nexus.commands.catalog import t3_backfill_doc_id_cmd
+
+
+@pytest.fixture()
+def isolated_nexus(tmp_path: Path) -> Path:
+    return tmp_path / "test-catalog"
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def chroma_client():
+    """Reset the EphemeralClient at fixture build."""
+    client = chromadb.EphemeralClient()
+    for col in list(client.list_collections()):
+        try:
+            client.delete_collection(col.name)
+        except Exception:
+            pass
+    return client
+
+
+def _seed(client, name: str, chunks: list[dict]) -> None:
+    col = client.get_or_create_collection(
+        name=name, embedding_function=DefaultEmbeddingFunction(),
+    )
+    col.add(
+        ids=[c["id"] for c in chunks],
+        documents=[c["content"] for c in chunks],
+        metadatas=[c["metadata"] for c in chunks],
+    )
+
+
+def _seed_event_log(catalog_dir: Path, events: list[ev.Event]) -> None:
+    """Skip Catalog construction; just write events.jsonl directly."""
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    Catalog.init(catalog_dir)
+    log = EventLog(catalog_dir)
+    log.append_many(events)
+
+
+def _make_chunk_event(
+    chunk_id: str, doc_id: str, coll_id: str,
+    *, synthesized_orphan: bool = False, chash: str = "h",
+) -> ev.Event:
+    return ev.Event(
+        type=ev.TYPE_CHUNK_INDEXED, v=0,
+        payload=ev.ChunkIndexedPayload(
+            chunk_id=chunk_id, chash=chash, doc_id=doc_id,
+            coll_id=coll_id, position=0,
+            synthesized_orphan=synthesized_orphan,
+        ),
+        ts="2026-04-30T00:00:00Z",
+    )
+
+
+# ── Usage ────────────────────────────────────────────────────────────────
+
+
+class TestUsage:
+    def test_missing_catalog(self, isolated_nexus, runner):
+        result = runner.invoke(t3_backfill_doc_id_cmd, [])
+        assert result.exit_code != 0
+        assert "not initialized" in result.output.lower()
+
+    def test_empty_event_log(self, isolated_nexus, runner):
+        Catalog.init(isolated_nexus)
+        # events.jsonl exists but is empty after Catalog.init.
+        result = runner.invoke(t3_backfill_doc_id_cmd, [])
+        assert result.exit_code != 0
+        assert "empty" in result.output.lower()
+
+
+# ── Dry-run + filter ─────────────────────────────────────────────────────
+
+
+class TestDryRun:
+    def test_dry_run_reports_without_writing(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [
+            _make_chunk_event("ch1", "uuid7-A", "code__test"),
+            _make_chunk_event("ch2", "uuid7-A", "code__test"),
+        ]
+        _seed_event_log(isolated_nexus, events)
+        _seed(chroma_client, "code__test", [
+            {"id": "ch1", "content": "x", "metadata": {"chunk_text_hash": "h1"}},
+            {"id": "ch2", "content": "y", "metadata": {"chunk_text_hash": "h2"}},
+        ])
+
+        result = runner.invoke(
+            t3_backfill_doc_id_cmd, ["--dry-run", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["dry_run"] is True
+        assert payload["chunks_eligible"] == 2
+        assert payload["chunks_updated"] == 2
+        # No actual update, no doc_id in metadata yet.
+        col = chroma_client.get_collection("code__test")
+        meta = col.get(ids=["ch1"], include=["metadatas"])["metadatas"][0]
+        assert "doc_id" not in meta
+
+
+# ── Happy path: writes doc_id into T3 ────────────────────────────────────
+
+
+class TestBackfillUpdates:
+    def test_writes_doc_id_into_chunks(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [
+            _make_chunk_event("ch1", "uuid7-A", "code__test"),
+            _make_chunk_event("ch2", "uuid7-B", "code__test"),
+        ]
+        _seed_event_log(isolated_nexus, events)
+        _seed(chroma_client, "code__test", [
+            {"id": "ch1", "content": "x", "metadata": {"chunk_text_hash": "h1"}},
+            {"id": "ch2", "content": "y", "metadata": {"chunk_text_hash": "h2"}},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        result = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["chunks_updated"] == 2
+        assert payload["chunks_already_correct"] == 0
+
+        col = chroma_client.get_collection("code__test")
+        for cid, expected in [("ch1", "uuid7-A"), ("ch2", "uuid7-B")]:
+            meta = col.get(ids=[cid], include=["metadatas"])["metadatas"][0]
+            assert meta["doc_id"] == expected
+            # Existing keys preserved.
+            assert "chunk_text_hash" in meta
+
+    def test_idempotent_second_run_is_noop(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [_make_chunk_event("ch1", "uuid7-A", "code__test")]
+        _seed_event_log(isolated_nexus, events)
+        _seed(chroma_client, "code__test", [
+            {"id": "ch1", "content": "x", "metadata": {"chunk_text_hash": "h1"}},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        first = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
+        assert first.exit_code == 0
+        first_payload = json.loads(first.output)
+        assert first_payload["chunks_updated"] == 1
+
+        second = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
+        assert second.exit_code == 0
+        second_payload = json.loads(second.output)
+        assert second_payload["chunks_updated"] == 0
+        assert second_payload["chunks_already_correct"] == 1
+
+
+# ── Filter + orphan handling ─────────────────────────────────────────────
+
+
+class TestCollectionFilter:
+    def test_filter_scopes_backfill(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [
+            _make_chunk_event("ch1", "uuid7-A", "code__a"),
+            _make_chunk_event("ch2", "uuid7-B", "code__b"),
+        ]
+        _seed_event_log(isolated_nexus, events)
+        _seed(chroma_client, "code__a", [
+            {"id": "ch1", "content": "x", "metadata": {"chunk_text_hash": "h1"}},
+        ])
+        _seed(chroma_client, "code__b", [
+            {"id": "ch2", "content": "y", "metadata": {"chunk_text_hash": "h2"}},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        result = runner.invoke(
+            t3_backfill_doc_id_cmd,
+            ["--collection", "code__a", "--json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["collections_processed"] == 1
+        assert payload["chunks_updated"] == 1
+
+        # code__b chunk untouched.
+        col_b = chroma_client.get_collection("code__b")
+        meta = col_b.get(ids=["ch2"], include=["metadatas"])["metadatas"][0]
+        assert "doc_id" not in meta
+
+
+class TestOrphanSkip:
+    def test_orphans_not_updated(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [
+            _make_chunk_event("ch1", "uuid7-A", "code__test"),
+            _make_chunk_event(
+                "orphan", "", "code__test",
+                synthesized_orphan=True,
+            ),
+        ]
+        _seed_event_log(isolated_nexus, events)
+        _seed(chroma_client, "code__test", [
+            {"id": "ch1", "content": "x", "metadata": {"chunk_text_hash": "h1"}},
+            {"id": "orphan", "content": "y", "metadata": {"chunk_text_hash": "h2"}},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        result = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["chunks_updated"] == 1
+        assert payload["orphans_skipped"] == 1
+
+        col = chroma_client.get_collection("code__test")
+        # Orphan chunk has no doc_id metadata.
+        orphan_meta = col.get(ids=["orphan"], include=["metadatas"])["metadatas"][0]
+        assert "doc_id" not in orphan_meta
+        # Non-orphan does.
+        other_meta = col.get(ids=["ch1"], include=["metadatas"])["metadatas"][0]
+        assert other_meta["doc_id"] == "uuid7-A"


### PR DESCRIPTION
## Summary

Phase 2 PR γ of RDR-101. Reads ``ChunkIndexed`` events from ``events.jsonl`` (synthesized by PR β) and propagates the resolved ``doc_id`` into the matching T3 chunk's metadata via ``ChromaDB.update``. Idempotent against chunks already carrying the right doc_id; skips synthesized orphans (those land in PR ε).

### Verb

``nx catalog t3-backfill-doc-id [--dry-run] [--collection X] [--json]``

- Walks ``events.jsonl``, groups ``ChunkIndexed`` events by ``coll_id``, opens each collection once, batches ``col.get`` / ``col.update`` in 300-row pages (ChromaDB Cloud row limit).
- Reads existing metadata before writing; merges ``{doc_id: X}`` on top of the existing dict so other keys survive the update.
- Skips chunks whose stored ``doc_id`` already matches (idempotent).
- Skips ``synthesized_orphan=True`` events; surfaces the count.
- ``--dry-run`` reports counts without calling update.
- ``--collection X`` scopes the backfill to one ``coll_id``.
- ``--json``: ``{dry_run, events_path, collection_filter, collections_processed, chunks_eligible, chunks_updated, chunks_already_correct, orphans_skipped, errors}``.
- Exits non-zero if any per-batch error landed (so a wrapping shell script can detect partial failure).

### Test plan (7 new tests)

- [x] Missing catalog → ClickException.
- [x] Empty events.jsonl → ClickException pointing at synthesize-log.
- [x] ``--dry-run`` reports counts without writing T3.
- [x] Default writes doc_id into chunk metadata; existing keys (``chunk_text_hash``, etc.) survive.
- [x] Idempotent: second run reports 0 updated, N already-correct.
- [x] ``--collection`` filter scopes the backfill.
- [x] Orphans (``synthesized_orphan=True``) are skipped and counted; non-orphans in the same collection still update.
- [x] 240 tests passing across catalog + Phase 1 + Phase 2 modules locally.
- [ ] CI green.

### Refs

- RDR-101 §Implementation Plan / Phase 2 — "T3 metadata backfill: per chunk, ``ChromaDB.update(metadata={doc_id: X, ...existing})``. Idempotent; can re-run."

Bead: ``nexus-6qjo`` (Phase 2 sub-PR γ under ``nexus-o6aa.8``).