### PR TITLE
rdr-101(phase2): nx catalog doctor --t3-doc-id-coverage flag

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -450,3 +450,4 @@
 {"id":"int-4be6f52b","kind":"field_change","created_at":"2026-05-01T09:20:35.213518Z","actor":"Hellblazer","issue_id":"nexus-isro","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-2a7ec5d3","kind":"field_change","created_at":"2026-05-01T09:28:40.382333Z","actor":"Hellblazer","issue_id":"nexus-isro","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-33b7c849","kind":"field_change","created_at":"2026-05-01T09:29:11.926357Z","actor":"Hellblazer","issue_id":"nexus-6qjo","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-01dbfbec","kind":"field_change","created_at":"2026-05-01T09:32:44.084463Z","actor":"Hellblazer","issue_id":"nexus-x7ah","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3239,28 +3239,68 @@ def prune_stale_cmd(
     ),
 )
 @click.option(
+    "--t3-doc-id-coverage",
+    "t3_doc_id_coverage",
+    is_flag=True,
+    help=(
+        "Walk every T3 collection and report doc_id coverage. PASS = "
+        "every non-orphan chunk in every collection carries a doc_id "
+        "matching what events.jsonl claims. Read-only against T3 and "
+        "the catalog. Run after 'nx catalog t3-backfill-doc-id' to "
+        "confirm Phase 2 is complete on a host."
+    ),
+)
+@click.option(
     "--json", "as_json", is_flag=True,
     help="Emit machine-readable JSON instead of text output.",
 )
-def doctor_cmd(replay_equality: bool, as_json: bool) -> None:
+def doctor_cmd(
+    replay_equality: bool, t3_doc_id_coverage: bool, as_json: bool,
+) -> None:
     """RDR-101 catalog doctor surface.
 
-    Phase 1 supports only ``--replay-equality``; future flags
-    (``--t3-doc-id-coverage``, ``--legacy-collection-grandfather``, etc.)
-    land in later phases.
+    Supports two checks today:
+      - ``--replay-equality`` (Phase 1, PR C): synthesizer + projector
+        round-trip against the live SQLite.
+      - ``--t3-doc-id-coverage`` (Phase 2, PR δ): T3 chunks carry the
+        doc_id metadata that events.jsonl claims.
+
+    Future flags (``--legacy-collection-grandfather``, etc.) land in
+    later phases.
     """
-    if not replay_equality:
+    if not replay_equality and not t3_doc_id_coverage:
         raise click.UsageError(
-            "Pass a check flag, e.g. --replay-equality. "
-            "Phase 1 supports only --replay-equality."
+            "Pass a check flag: --replay-equality or "
+            "--t3-doc-id-coverage."
         )
 
-    report = _run_replay_equality()
+    overall_pass = True
+    json_payload: dict = {}
+
+    if replay_equality:
+        report = _run_replay_equality()
+        if as_json:
+            json_payload["replay_equality"] = report
+        else:
+            _print_replay_equality_text(report)
+        if not report["pass"]:
+            overall_pass = False
+
+    if t3_doc_id_coverage:
+        report = _run_t3_doc_id_coverage()
+        if as_json:
+            json_payload["t3_doc_id_coverage"] = report
+        else:
+            if replay_equality:
+                click.echo("")  # separator between checks
+            _print_t3_doc_id_coverage_text(report)
+        if not report["pass"]:
+            overall_pass = False
+
     if as_json:
-        click.echo(json.dumps(report, indent=2))
-    else:
-        _print_replay_equality_text(report)
-    if not report["pass"]:
+        click.echo(json.dumps(json_payload, indent=2))
+
+    if not overall_pass:
         raise click.exceptions.Exit(1)
 
 
@@ -3774,3 +3814,202 @@ def _print_t3_backfill_text(report: dict) -> None:
         click.echo(f"\nErrors ({len(report['errors'])}):")
         for e in report["errors"][:10]:
             click.echo(f"  {e['collection']} ({e['stage']}): {e['error']}")
+
+
+# ── RDR-101 Phase 2: doctor --t3-doc-id-coverage ─────────────────────────
+
+
+def _run_t3_doc_id_coverage() -> dict:
+    """Walk every T3 collection in events.jsonl and report doc_id coverage.
+
+    Steps:
+      1. Read events.jsonl. Build the expected doc_id per (coll_id, chunk_id)
+         from ChunkIndexed events. Track orphans separately.
+      2. For each collection, paginate col.get(limit=300, offset=...,
+         include=["metadatas"]); compare each chunk's actual doc_id against
+         the expected one.
+      3. Report per-collection counts: total_chunks, with_doc_id,
+         missing_doc_id, mismatched_doc_id, expected_orphans.
+      4. PASS = every non-orphan event has a matching T3 chunk with the
+         right doc_id, AND no T3 chunk lacks a doc_id outside the
+         expected-orphan set.
+
+    Read-only against T3 (col.get only, no col.update).
+    """
+    from nexus.catalog.catalog import Catalog
+    from nexus.catalog.event_log import EventLog
+    from nexus.catalog import events as ev
+    from nexus.config import catalog_path
+    from nexus.db import make_t3
+
+    cat_dir = catalog_path()
+    if not Catalog.is_initialized(cat_dir):
+        raise click.ClickException(
+            f"Catalog not initialized at {cat_dir}. "
+            "Run 'nx catalog setup' to create and populate it."
+        )
+    log = EventLog(cat_dir)
+    if not log.path.exists() or log.path.stat().st_size == 0:
+        raise click.ClickException(
+            f"events.jsonl is empty at {log.path}. Run 'nx catalog "
+            "synthesize-log --chunks' first."
+        )
+
+    # Build expected (coll_id, chunk_id) → doc_id; track orphans.
+    expected: dict[str, dict[str, str]] = {}
+    expected_orphans: dict[str, set[str]] = {}
+    for event in log.replay():
+        if event.type != ev.TYPE_CHUNK_INDEXED:
+            continue
+        coll = event.payload.coll_id
+        cid = event.payload.chunk_id
+        if event.payload.synthesized_orphan:
+            expected_orphans.setdefault(coll, set()).add(cid)
+            continue
+        expected.setdefault(coll, {})[cid] = event.payload.doc_id
+
+    try:
+        t3 = make_t3()
+    except Exception as exc:
+        raise click.ClickException(
+            f"Failed to open T3 client: {exc}. Check ChromaDB credentials."
+        )
+
+    per_coll: dict[str, dict] = {}
+    overall_pass = True
+
+    for coll_name, expected_chunks in expected.items():
+        try:
+            col = t3._client.get_collection(name=coll_name)
+        except Exception as exc:
+            per_coll[coll_name] = {
+                "error": f"open: {exc}",
+                "expected_chunks": len(expected_chunks),
+            }
+            overall_pass = False
+            continue
+
+        total = 0
+        with_doc_id = 0
+        mismatched: list[dict] = []
+        missing: list[str] = []
+        seen: set[str] = set()
+        offset = 0
+        while True:
+            try:
+                page = col.get(
+                    limit=300, offset=offset, include=["metadatas"],
+                )
+            except Exception as exc:
+                per_coll[coll_name] = {
+                    "error": f"get: {exc}",
+                    "expected_chunks": len(expected_chunks),
+                }
+                overall_pass = False
+                break
+            ids = page.get("ids") or []
+            metas = page.get("metadatas") or []
+            if not ids:
+                break
+            for cid, meta in zip(ids, metas):
+                meta = meta or {}
+                total += 1
+                seen.add(cid)
+                actual = meta.get("doc_id", "") or ""
+                expected_doc_id = expected_chunks.get(cid, "")
+                is_orphan = cid in expected_orphans.get(coll_name, set())
+                if actual:
+                    with_doc_id += 1
+                    if expected_doc_id and actual != expected_doc_id:
+                        mismatched.append({
+                            "chunk_id": cid,
+                            "actual": actual,
+                            "expected": expected_doc_id,
+                        })
+                else:
+                    if not is_orphan:
+                        missing.append(cid)
+            if len(ids) < 300:
+                break
+            offset += 300
+
+        # Chunks the event log expected but T3 doesn't have.
+        not_in_t3 = sorted(set(expected_chunks) - seen)
+
+        coverage = with_doc_id / total if total else 1.0
+        pass_for_coll = (
+            not mismatched
+            and not missing
+            and not not_in_t3
+        )
+        per_coll[coll_name] = {
+            "total_chunks": total,
+            "with_doc_id": with_doc_id,
+            "expected_chunks": len(expected_chunks),
+            "expected_orphans": len(expected_orphans.get(coll_name, set())),
+            "missing_doc_id_sample": missing[:5],
+            "missing_doc_id_count": len(missing),
+            "mismatched_doc_id_sample": mismatched[:5],
+            "mismatched_doc_id_count": len(mismatched),
+            "not_in_t3_sample": not_in_t3[:5],
+            "not_in_t3_count": len(not_in_t3),
+            "coverage": round(coverage, 4),
+            "pass": pass_for_coll,
+        }
+        if not pass_for_coll:
+            overall_pass = False
+
+    return {
+        "pass": overall_pass,
+        "events_path": str(log.path),
+        "collections_in_log": len(expected),
+        "tables": per_coll,
+    }
+
+
+def _print_t3_doc_id_coverage_text(report: dict) -> None:
+    click.echo("=== T3 doc_id coverage ===")
+    click.echo(f"Events path:        {report['events_path']}")
+    click.echo(f"Collections in log: {report['collections_in_log']}")
+    click.echo("")
+    for coll_name, diff in report["tables"].items():
+        if "error" in diff:
+            click.echo(
+                f"  ✗ {coll_name:<40}  ERROR: {diff['error']} "
+                f"(expected {diff['expected_chunks']} chunks)"
+            )
+            continue
+        marker = "✓" if diff["pass"] else "✗"
+        click.echo(
+            f"  {marker} {coll_name:<40}  "
+            f"total={diff['total_chunks']:>6}  "
+            f"with_doc_id={diff['with_doc_id']:>6}  "
+            f"coverage={diff['coverage']:.2%}"
+        )
+        if diff["mismatched_doc_id_count"]:
+            click.echo(
+                f"     mismatched: {diff['mismatched_doc_id_count']} "
+                f"(first {len(diff['mismatched_doc_id_sample'])} shown)"
+            )
+            for m in diff["mismatched_doc_id_sample"]:
+                click.echo(
+                    f"       {m['chunk_id']}: actual={m['actual']!r} "
+                    f"expected={m['expected']!r}"
+                )
+        if diff["missing_doc_id_count"]:
+            click.echo(
+                f"     missing doc_id: {diff['missing_doc_id_count']} "
+                f"(first {len(diff['missing_doc_id_sample'])} shown): "
+                f"{diff['missing_doc_id_sample']}"
+            )
+        if diff["not_in_t3_count"]:
+            click.echo(
+                f"     in event log but not in T3: {diff['not_in_t3_count']} "
+                f"(first {len(diff['not_in_t3_sample'])} shown): "
+                f"{diff['not_in_t3_sample']}"
+            )
+    click.echo("")
+    if report["pass"]:
+        click.echo("PASS — every non-orphan chunk carries the expected doc_id.")
+    else:
+        click.echo("FAIL — T3 doc_id metadata diverges from the event log.")

--- a/tests/test_catalog_doctor_replay_equality.py
+++ b/tests/test_catalog_doctor_replay_equality.py
@@ -107,7 +107,9 @@ class TestReplayEqualityPasses:
 
         result = runner.invoke(doctor_cmd, ["--replay-equality", "--json"])
         assert result.exit_code == 0
-        payload = json.loads(result.output)
+        # Phase 2 PR δ wraps each check's payload under its flag name so
+        # multiple checks can be invoked in one run.
+        payload = json.loads(result.output)["replay_equality"]
         assert payload["pass"] is True
         assert payload["events_applied"] >= 3  # 1 owner + 2 documents
         assert "tables" in payload
@@ -179,7 +181,8 @@ class TestReplayEqualityFails:
 
         result = runner.invoke(doctor_cmd, ["--replay-equality", "--json"])
         assert result.exit_code == 1
-        payload = json.loads(result.output)
+        # Phase 2 PR δ wraps each check's payload under its flag name.
+        payload = json.loads(result.output)["replay_equality"]
         assert payload["pass"] is False
         # Documents table is the source of the disagreement
         docs_diff = payload["tables"]["documents"]

--- a/tests/test_catalog_doctor_t3_coverage.py
+++ b/tests/test_catalog_doctor_t3_coverage.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 2 PR δ ``--t3-doc-id-coverage`` doctor flag.
+
+Coverage:
+- Verb fails with usage error when no flag is passed.
+- ``--t3-doc-id-coverage`` PASSes when every chunk carries the right doc_id.
+- FAILs when chunks lack doc_id metadata.
+- FAILs when chunks carry the wrong doc_id.
+- FAILs when the event log claims chunks T3 doesn't have.
+- Orphan chunks (synthesized_orphan=True) without doc_id do not fail.
+- ``--json`` payload contains per-collection counts.
+- Combined with ``--replay-equality``: both checks run, JSON has both keys.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.event_log import EventLog
+from nexus.commands.catalog import doctor_cmd
+
+
+@pytest.fixture()
+def isolated_nexus(tmp_path: Path) -> Path:
+    return tmp_path / "test-catalog"
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def chroma_client():
+    client = chromadb.EphemeralClient()
+    for col in list(client.list_collections()):
+        try:
+            client.delete_collection(col.name)
+        except Exception:
+            pass
+    return client
+
+
+def _seed(client, name: str, chunks: list[dict]) -> None:
+    col = client.get_or_create_collection(
+        name=name, embedding_function=DefaultEmbeddingFunction(),
+    )
+    col.add(
+        ids=[c["id"] for c in chunks],
+        documents=[c["content"] for c in chunks],
+        metadatas=[c["metadata"] for c in chunks],
+    )
+
+
+def _seed_log(catalog_dir: Path, events: list[ev.Event]) -> None:
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    Catalog.init(catalog_dir)
+    log = EventLog(catalog_dir)
+    log.append_many(events)
+
+
+def _chunk(
+    chunk_id: str, doc_id: str, coll_id: str,
+    *, orphan: bool = False,
+) -> ev.Event:
+    return ev.Event(
+        type=ev.TYPE_CHUNK_INDEXED, v=0,
+        payload=ev.ChunkIndexedPayload(
+            chunk_id=chunk_id, chash="h", doc_id=doc_id,
+            coll_id=coll_id, position=0,
+            synthesized_orphan=orphan,
+        ),
+        ts="2026-04-30T00:00:00Z",
+    )
+
+
+# ── Usage ────────────────────────────────────────────────────────────────
+
+
+class TestUsage:
+    def test_no_flag_is_usage_error(self, isolated_nexus, runner):
+        result = runner.invoke(doctor_cmd, [])
+        assert result.exit_code != 0
+        assert "Pass a check flag" in (result.output + (result.stderr or ""))
+
+
+# ── Pass paths ───────────────────────────────────────────────────────────
+
+
+class TestCoveragePasses:
+    def test_full_coverage_passes(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [_chunk("ch1", "uuid7-A", "code__test")]
+        _seed_log(isolated_nexus, events)
+        _seed(chroma_client, "code__test", [
+            {
+                "id": "ch1", "content": "x",
+                "metadata": {"doc_id": "uuid7-A"},
+            },
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        result = runner.invoke(
+            doctor_cmd, ["--t3-doc-id-coverage", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        assert payload["pass"] is True
+        assert payload["tables"]["code__test"]["coverage"] == 1.0
+
+    def test_orphan_without_doc_id_does_not_fail(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [
+            _chunk("orphan", "", "code__test", orphan=True),
+            _chunk("ch1", "uuid7-A", "code__test"),
+        ]
+        _seed_log(isolated_nexus, events)
+        _seed(chroma_client, "code__test", [
+            {"id": "orphan", "content": "x", "metadata": {"_": "_"}},
+            {"id": "ch1", "content": "y", "metadata": {"doc_id": "uuid7-A"}},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        result = runner.invoke(
+            doctor_cmd, ["--t3-doc-id-coverage", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        assert payload["pass"] is True
+        coll = payload["tables"]["code__test"]
+        assert coll["expected_orphans"] == 1
+        assert coll["with_doc_id"] == 1
+        assert coll["total_chunks"] == 2
+
+
+# ── Fail paths ───────────────────────────────────────────────────────────
+
+
+class TestCoverageFails:
+    def test_missing_doc_id_fails(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [_chunk("ch1", "uuid7-A", "code__test")]
+        _seed_log(isolated_nexus, events)
+        _seed(chroma_client, "code__test", [
+            {"id": "ch1", "content": "x", "metadata": {"_": "_"}},  # no doc_id
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        result = runner.invoke(
+            doctor_cmd, ["--t3-doc-id-coverage", "--json"],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        assert payload["pass"] is False
+        coll = payload["tables"]["code__test"]
+        assert "ch1" in coll["missing_doc_id_sample"]
+
+    def test_mismatched_doc_id_fails(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [_chunk("ch1", "uuid7-A", "code__test")]
+        _seed_log(isolated_nexus, events)
+        _seed(chroma_client, "code__test", [
+            {
+                "id": "ch1", "content": "x",
+                "metadata": {"doc_id": "uuid7-WRONG"},
+            },
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        result = runner.invoke(
+            doctor_cmd, ["--t3-doc-id-coverage", "--json"],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        coll = payload["tables"]["code__test"]
+        assert coll["mismatched_doc_id_count"] == 1
+        m = coll["mismatched_doc_id_sample"][0]
+        assert m["actual"] == "uuid7-WRONG"
+        assert m["expected"] == "uuid7-A"
+
+    def test_chunk_in_log_but_not_in_t3_fails(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [_chunk("missing-from-t3", "uuid7-A", "code__test")]
+        _seed_log(isolated_nexus, events)
+        _seed(chroma_client, "code__test", [
+            # Some other chunk; not the one the log references.
+            {
+                "id": "different-chunk", "content": "x",
+                "metadata": {"doc_id": "uuid7-A"},
+            },
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        result = runner.invoke(
+            doctor_cmd, ["--t3-doc-id-coverage", "--json"],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        coll = payload["tables"]["code__test"]
+        assert coll["not_in_t3_count"] == 1
+        assert "missing-from-t3" in coll["not_in_t3_sample"]
+
+
+# ── Combined check ───────────────────────────────────────────────────────
+
+
+class TestCombined:
+    def test_both_flags_run_both_checks(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Build a real catalog so --replay-equality can run.
+        Catalog.init(isolated_nexus)
+        cat = Catalog(isolated_nexus, isolated_nexus / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        cat.register(owner, "doc.md", content_type="prose", file_path="doc.md")
+        cat._db.close()
+
+        # Add a ChunkIndexed event so coverage check has something to check.
+        log = EventLog(isolated_nexus)
+        log.append_many([_chunk("ch1", "uuid7-A", "code__test")])
+        _seed(chroma_client, "code__test", [
+            {
+                "id": "ch1", "content": "x",
+                "metadata": {"doc_id": "uuid7-A"},
+            },
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        result = runner.invoke(
+            doctor_cmd,
+            ["--replay-equality", "--t3-doc-id-coverage", "--json"],
+        )
+        # Replay equality may or may not pass depending on whether the
+        # synthesized log matches the live SQLite — what we care about
+        # here is that both checks ran and got a payload.
+        payload = json.loads(result.output)
+        assert "replay_equality" in payload
+        assert "t3_doc_id_coverage" in payload
+        assert payload["t3_doc_id_coverage"]["pass"] is True


### PR DESCRIPTION
## Summary

Phase 2 PR δ of RDR-101. Adds the verification flag operators run after ``t3-backfill-doc-id`` (PR γ) to confirm Phase 2 is complete on a host. Walks every T3 collection that appears in ``events.jsonl``, compares each chunk's stored ``doc_id`` metadata against what the event log claims, and reports per-collection coverage.

### Verb

``nx catalog doctor [--replay-equality] [--t3-doc-id-coverage] [--json]``

PASS = every non-orphan event has a matching T3 chunk with the right ``doc_id``, AND no T3 chunk lacks a ``doc_id`` outside the expected-orphan set.

### JSON payload nesting

The doctor now runs N independent checks; each one's output is wrapped under its flag name (``replay_equality``, ``t3_doc_id_coverage``) so multi-flag invocations have a non-colliding payload. PR C's two ``test_json_*_payload`` tests are updated to read from the wrapped key.

### Test plan (7 new + 2 updated)

- [x] No flag → usage error.
- [x] Full coverage passes; coverage = 1.0.
- [x] Orphan chunks without doc_id metadata don't fail.
- [x] Missing doc_id metadata fails; missing chunk_id in ``missing_doc_id_sample``.
- [x] Mismatched doc_id fails with explicit actual / expected pair.
- [x] Chunk in event log but not in T3 fails; chunk_id in ``not_in_t3_sample``.
- [x] Combined ``--replay-equality`` + ``--t3-doc-id-coverage`` runs both checks.
- [x] PR C's JSON tests updated to the new ``["replay_equality"]`` wrapper.
- [ ] CI green.

### Refs

- RDR-101 §Implementation Plan / Phase 2 — "Verify: ``nx catalog doctor --t3-doc-id-coverage`` reports 100% coverage on all collections."

Bead: ``nexus-x7ah`` (Phase 2 sub-PR δ under ``nexus-o6aa.8``).