### PR TITLE
rdr-101(phase2): nx catalog repair-orphan-chunks verb

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -451,3 +451,5 @@
 {"id":"int-2a7ec5d3","kind":"field_change","created_at":"2026-05-01T09:28:40.382333Z","actor":"Hellblazer","issue_id":"nexus-isro","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-33b7c849","kind":"field_change","created_at":"2026-05-01T09:29:11.926357Z","actor":"Hellblazer","issue_id":"nexus-6qjo","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-01dbfbec","kind":"field_change","created_at":"2026-05-01T09:32:44.084463Z","actor":"Hellblazer","issue_id":"nexus-x7ah","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-001905c8","kind":"field_change","created_at":"2026-05-01T09:36:53.661303Z","actor":"Hellblazer","issue_id":"nexus-x7ah","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-e729fd4d","kind":"field_change","created_at":"2026-05-01T09:37:23.120256Z","actor":"Hellblazer","issue_id":"nexus-zbl0","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -4013,3 +4013,198 @@ def _print_t3_doc_id_coverage_text(report: dict) -> None:
         click.echo("PASS — every non-orphan chunk carries the expected doc_id.")
     else:
         click.echo("FAIL — T3 doc_id metadata diverges from the event log.")
+
+
+# ── RDR-101 Phase 2: repair-orphan-chunks verb ───────────────────────────
+
+
+@catalog.command("repair-orphan-chunks")
+@click.option(
+    "--list",
+    "list_mode",
+    is_flag=True,
+    help=(
+        "List orphan ChunkIndexed events from events.jsonl (chunks the "
+        "Phase 2 synthesizer could not resolve to a document). Default "
+        "mode when neither --list nor --assign is passed."
+    ),
+)
+@click.option(
+    "--assign",
+    "assignments",
+    multiple=True,
+    help=(
+        "Repeatable. Format: CHUNK_ID:DOC_ID. Each pair appends a "
+        "corrective ChunkIndexed event with synthesized_orphan=False and "
+        "the assigned doc_id; the projector applies last-event-wins so "
+        "the orphan is healed without rewriting the existing log lines."
+    ),
+)
+@click.option(
+    "--collection",
+    "collection_filter",
+    default="",
+    help="Restrict listing/assignment to one collection name.",
+)
+@click.option(
+    "--json", "as_json", is_flag=True,
+    help="Emit machine-readable JSON instead of text output.",
+)
+def repair_orphan_chunks_cmd(
+    list_mode: bool,
+    assignments: tuple,
+    collection_filter: str,
+    as_json: bool,
+) -> None:
+    """RDR-101 Phase 2: list or repair orphan ChunkIndexed events.
+
+    The Phase 2 synthesizer (``synthesize-log --chunks``) emits
+    ``ChunkIndexed`` events with ``doc_id=""`` and
+    ``synthesized_orphan=True`` for chunks whose ``source_path`` did not
+    match any catalog ``source_uri`` and whose ``title`` did not match
+    any catalog title. This verb lets an operator review and repair
+    those orphans before the GC sweeps them after the orphan window.
+
+    Repair appends a new ``ChunkIndexed`` event with the resolved
+    ``doc_id`` and ``synthesized_orphan=False``. The original orphan
+    event stays in the log; the projector dispatches on the last event
+    per ``(coll_id, chunk_id)``, so replay sees the corrected state.
+    """
+    from nexus.catalog.catalog import Catalog
+    from nexus.catalog.event_log import EventLog
+    from nexus.catalog import events as ev
+    from nexus.config import catalog_path
+
+    cat_dir = catalog_path()
+    if not Catalog.is_initialized(cat_dir):
+        raise click.ClickException(
+            f"Catalog not initialized at {cat_dir}. "
+            "Run 'nx catalog setup' to create and populate it."
+        )
+    log = EventLog(cat_dir)
+    if not log.path.exists() or log.path.stat().st_size == 0:
+        raise click.ClickException(
+            f"events.jsonl is empty at {log.path}. Run 'nx catalog "
+            "synthesize-log --chunks' first."
+        )
+
+    if not list_mode and not assignments:
+        list_mode = True  # default to listing
+
+    if list_mode and assignments:
+        raise click.UsageError(
+            "Pass either --list (default) or --assign, not both."
+        )
+
+    # Build the current orphan set: walk events.jsonl, apply last-write
+    # semantics per (coll_id, chunk_id), and surface those that end up
+    # synthesized_orphan=True.
+    state: dict[tuple[str, str], dict] = {}
+    for event in log.replay():
+        if event.type != ev.TYPE_CHUNK_INDEXED:
+            continue
+        key = (event.payload.coll_id, event.payload.chunk_id)
+        state[key] = {
+            "coll_id": event.payload.coll_id,
+            "chunk_id": event.payload.chunk_id,
+            "doc_id": event.payload.doc_id,
+            "chash": event.payload.chash,
+            "synthesized_orphan": event.payload.synthesized_orphan,
+        }
+    orphans = [
+        s for s in state.values()
+        if s["synthesized_orphan"]
+        and (not collection_filter or s["coll_id"] == collection_filter)
+    ]
+
+    if list_mode:
+        report = {
+            "mode": "list",
+            "collection_filter": collection_filter or "(all)",
+            "events_path": str(log.path),
+            "orphans": orphans,
+            "orphans_count": len(orphans),
+        }
+        if as_json:
+            click.echo(json.dumps(report, indent=2))
+        else:
+            click.echo(f"Events path:       {log.path}")
+            click.echo(f"Collection filter: {collection_filter or '(all)'}")
+            click.echo(f"Orphans:           {len(orphans)}")
+            click.echo("")
+            for o in orphans[:50]:
+                click.echo(
+                    f"  {o['chunk_id']:<40} {o['coll_id']:<35} chash={o['chash'][:16]}"
+                )
+            if len(orphans) > 50:
+                click.echo(f"  ... and {len(orphans) - 50} more")
+        return
+
+    # Assign mode. Parse CHUNK_ID:DOC_ID pairs.
+    pairs: list[tuple[str, str]] = []
+    for raw in assignments:
+        if ":" not in raw:
+            raise click.UsageError(
+                f"--assign expects CHUNK_ID:DOC_ID, got {raw!r}"
+            )
+        chunk_id, _, doc_id = raw.partition(":")
+        chunk_id = chunk_id.strip()
+        doc_id = doc_id.strip()
+        if not chunk_id or not doc_id:
+            raise click.UsageError(
+                f"--assign expects non-empty CHUNK_ID and DOC_ID, got {raw!r}"
+            )
+        pairs.append((chunk_id, doc_id))
+
+    # Resolve each assignment to a current orphan to copy chash / coll_id
+    # from. Refuse to assign a chunk that is not currently an orphan.
+    orphan_by_chunk_id = {
+        o["chunk_id"]: o for o in orphans
+    }
+
+    repairs: list = []
+    skipped: list = []
+    for chunk_id, doc_id in pairs:
+        if chunk_id not in orphan_by_chunk_id:
+            skipped.append({
+                "chunk_id": chunk_id,
+                "doc_id": doc_id,
+                "reason": (
+                    "not currently an orphan (already resolved or unknown)"
+                ),
+            })
+            continue
+        orphan = orphan_by_chunk_id[chunk_id]
+        repairs.append(ev.Event(
+            type=ev.TYPE_CHUNK_INDEXED, v=0,
+            payload=ev.ChunkIndexedPayload(
+                chunk_id=chunk_id,
+                chash=orphan["chash"],
+                doc_id=doc_id,
+                coll_id=orphan["coll_id"],
+                position=0,
+                synthesized_orphan=False,
+            ),
+            ts=ev.now_ts(),
+        ))
+
+    log.append_many(repairs)
+
+    report = {
+        "mode": "assign",
+        "collection_filter": collection_filter or "(all)",
+        "events_path": str(log.path),
+        "repairs_count": len(repairs),
+        "skipped_count": len(skipped),
+        "skipped": skipped,
+        "remaining_orphans": len(orphans) - len(repairs),
+    }
+    if as_json:
+        click.echo(json.dumps(report, indent=2))
+    else:
+        click.echo(f"Repairs applied:   {len(repairs)}")
+        if skipped:
+            click.echo(f"Skipped:           {len(skipped)}")
+            for s in skipped[:10]:
+                click.echo(f"  {s['chunk_id']}: {s['reason']}")
+        click.echo(f"Remaining orphans: {report['remaining_orphans']}")

--- a/tests/test_catalog_repair_orphan_chunks.py
+++ b/tests/test_catalog_repair_orphan_chunks.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 2 PR ε ``repair-orphan-chunks`` verb.
+
+Coverage:
+- Verb fails when catalog is not initialized or events.jsonl is empty.
+- Default mode lists orphan ChunkIndexed events.
+- ``--list`` filters by ``--collection``.
+- ``--assign CHUNK_ID:DOC_ID`` appends a corrective event with the right
+  doc_id and synthesized_orphan=False.
+- Multiple ``--assign`` pairs in one invocation.
+- ``--assign`` for a non-orphan chunk is skipped (the orphan was already
+  resolved or the chunk_id is unknown), surfaced in the skipped report.
+- ``--assign`` malformed pair → usage error.
+- Last-event-wins: replay of the log after assignment shows the chunk
+  resolved (the original orphan event stays in the log; the projector
+  dispatches on the latest event per chunk_id).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.event_log import EventLog
+from nexus.commands.catalog import repair_orphan_chunks_cmd
+
+
+@pytest.fixture()
+def isolated_nexus(tmp_path: Path) -> Path:
+    return tmp_path / "test-catalog"
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _seed(catalog_dir: Path, events: list[ev.Event]) -> None:
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    Catalog.init(catalog_dir)
+    log = EventLog(catalog_dir)
+    log.append_many(events)
+
+
+def _chunk(
+    chunk_id: str, doc_id: str, coll_id: str,
+    *, orphan: bool = False, chash: str = "h",
+) -> ev.Event:
+    return ev.Event(
+        type=ev.TYPE_CHUNK_INDEXED, v=0,
+        payload=ev.ChunkIndexedPayload(
+            chunk_id=chunk_id, chash=chash, doc_id=doc_id,
+            coll_id=coll_id, position=0,
+            synthesized_orphan=orphan,
+        ),
+        ts="2026-04-30T00:00:00Z",
+    )
+
+
+# ── Usage ────────────────────────────────────────────────────────────────
+
+
+class TestUsage:
+    def test_missing_catalog(self, isolated_nexus, runner):
+        result = runner.invoke(repair_orphan_chunks_cmd, [])
+        assert result.exit_code != 0
+        assert "not initialized" in result.output.lower()
+
+    def test_empty_log(self, isolated_nexus, runner):
+        Catalog.init(isolated_nexus)
+        result = runner.invoke(repair_orphan_chunks_cmd, [])
+        assert result.exit_code != 0
+        assert "empty" in result.output.lower()
+
+    def test_list_and_assign_together(self, isolated_nexus, runner):
+        _seed(isolated_nexus, [_chunk("ch1", "", "code__test", orphan=True)])
+        result = runner.invoke(
+            repair_orphan_chunks_cmd,
+            ["--list", "--assign", "ch1:doc-7"],
+        )
+        assert result.exit_code != 0
+        assert "not both" in (result.output + (result.stderr or ""))
+
+    def test_assign_malformed_pair(self, isolated_nexus, runner):
+        _seed(isolated_nexus, [_chunk("ch1", "", "code__test", orphan=True)])
+        for bad in ["ch1", ":doc-7", "ch1:", ""]:
+            result = runner.invoke(
+                repair_orphan_chunks_cmd, ["--assign", bad],
+            )
+            assert result.exit_code != 0
+
+
+# ── List mode ────────────────────────────────────────────────────────────
+
+
+class TestListMode:
+    def test_default_lists_orphans(self, isolated_nexus, runner):
+        _seed(isolated_nexus, [
+            _chunk("ch1", "uuid7-A", "code__test"),  # not orphan
+            _chunk("orph1", "", "code__test", orphan=True),
+            _chunk("orph2", "", "knowledge__paper", orphan=True),
+        ])
+        result = runner.invoke(
+            repair_orphan_chunks_cmd, ["--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["mode"] == "list"
+        assert payload["orphans_count"] == 2
+        chunk_ids = {o["chunk_id"] for o in payload["orphans"]}
+        assert chunk_ids == {"orph1", "orph2"}
+
+    def test_collection_filter(self, isolated_nexus, runner):
+        _seed(isolated_nexus, [
+            _chunk("orph1", "", "code__a", orphan=True),
+            _chunk("orph2", "", "code__b", orphan=True),
+        ])
+        result = runner.invoke(
+            repair_orphan_chunks_cmd,
+            ["--list", "--collection", "code__a", "--json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        chunk_ids = {o["chunk_id"] for o in payload["orphans"]}
+        assert chunk_ids == {"orph1"}
+
+
+# ── Assign mode ──────────────────────────────────────────────────────────
+
+
+class TestAssignMode:
+    def test_assign_appends_corrective_event(self, isolated_nexus, runner):
+        _seed(isolated_nexus, [
+            _chunk("orph1", "", "code__test", orphan=True, chash="ch1hash"),
+        ])
+        result = runner.invoke(
+            repair_orphan_chunks_cmd,
+            ["--assign", "orph1:doc-uuid7-A", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["repairs_count"] == 1
+        assert payload["skipped_count"] == 0
+        assert payload["remaining_orphans"] == 0
+
+        # Replay events.jsonl: the latest event per (coll, chunk_id) must
+        # carry doc_id="doc-uuid7-A" and synthesized_orphan=False, AND
+        # the chash from the original orphan must survive.
+        log = EventLog(isolated_nexus)
+        events = list(log.replay())
+        last_for_chunk = events[-1]
+        assert last_for_chunk.type == ev.TYPE_CHUNK_INDEXED
+        assert last_for_chunk.payload.chunk_id == "orph1"
+        assert last_for_chunk.payload.doc_id == "doc-uuid7-A"
+        assert last_for_chunk.payload.synthesized_orphan is False
+        assert last_for_chunk.payload.chash == "ch1hash"
+
+    def test_assign_multiple_pairs(self, isolated_nexus, runner):
+        _seed(isolated_nexus, [
+            _chunk("orph1", "", "code__test", orphan=True),
+            _chunk("orph2", "", "code__test", orphan=True),
+        ])
+        result = runner.invoke(
+            repair_orphan_chunks_cmd,
+            ["--assign", "orph1:doc-1", "--assign", "orph2:doc-2", "--json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["repairs_count"] == 2
+        assert payload["remaining_orphans"] == 0
+
+    def test_assign_unknown_chunk_is_skipped(
+        self, isolated_nexus, runner,
+    ):
+        _seed(isolated_nexus, [
+            _chunk("orph1", "", "code__test", orphan=True),
+        ])
+        result = runner.invoke(
+            repair_orphan_chunks_cmd,
+            ["--assign", "ch-not-orphan:doc-1", "--json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["repairs_count"] == 0
+        assert payload["skipped_count"] == 1
+        assert payload["skipped"][0]["chunk_id"] == "ch-not-orphan"
+
+    def test_assign_already_resolved_chunk_is_skipped(
+        self, isolated_nexus, runner,
+    ):
+        # Chunk was orphan, then resolved by an earlier corrective event.
+        _seed(isolated_nexus, [
+            _chunk("ch1", "", "code__test", orphan=True),
+            _chunk("ch1", "doc-1", "code__test"),  # corrective from earlier run
+        ])
+        result = runner.invoke(
+            repair_orphan_chunks_cmd,
+            ["--assign", "ch1:doc-2", "--json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        # ch1 is no longer an orphan after the earlier corrective event,
+        # so a second --assign on it is a no-op.
+        assert payload["repairs_count"] == 0
+        assert payload["skipped_count"] == 1
+        assert "not currently an orphan" in payload["skipped"][0]["reason"]
+
+
+# ── List mode shows zero orphans after a complete repair ─────────────────
+
+
+class TestListAfterRepair:
+    def test_list_reports_zero_after_repair_assign(self, isolated_nexus, runner):
+        _seed(isolated_nexus, [
+            _chunk("orph1", "", "code__test", orphan=True),
+        ])
+        # Repair.
+        runner.invoke(
+            repair_orphan_chunks_cmd,
+            ["--assign", "orph1:doc-1"],
+        )
+        # List → 0.
+        result = runner.invoke(
+            repair_orphan_chunks_cmd, ["--list", "--json"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["orphans_count"] == 0


### PR DESCRIPTION
## Summary

Phase 2 PR ε of RDR-101 — closes the Phase 2 sub-PR set. Operator-facing fixup for orphan chunks the synthesizer (PR β) could not resolve via the ``source_path`` → ``source_uri`` → ``tumbler`` → ``doc_id`` chain or the title fallback. Lists orphans and assigns doc_ids manually so the doctor coverage check (PR δ) subsequently passes.

### Verb

``nx catalog repair-orphan-chunks [--list | --assign CHUNK_ID:DOC_ID...] [--collection X] [--json]``

- ``--list`` (default): walks events.jsonl, applies last-event-wins per ``(coll_id, chunk_id)``, prints what's still orphaned.
- ``--assign``: appends a corrective ``ChunkIndexed`` event with the assigned doc_id and ``synthesized_orphan=False``. The original orphan event stays in the log; the projector dispatches on the latest event per chunk_id, so replay sees the corrected state — no log rewrite required.
- ``--assign`` for a non-orphan (already resolved or unknown) is skipped and surfaced rather than failing the whole batch.
- ``--collection X`` scopes both modes.
- ``--json`` payload: ``{mode, orphans|repairs|skipped, remaining_orphans, ...}``.

### Test plan (11 new tests)

- [x] Missing catalog / empty log → ClickException.
- [x] ``--list`` + ``--assign`` together → usage error.
- [x] Malformed ``--assign`` pair (missing ``:``, empty halves, etc.) → usage error.
- [x] Default mode lists orphans; ``--collection`` filter scopes.
- [x] ``--assign`` appends a corrective event with the right doc_id; original chash preserved.
- [x] Multiple ``--assign`` pairs in one invocation.
- [x] ``--assign`` for an unknown chunk_id → skipped.
- [x] ``--assign`` for an already-resolved chunk → skipped (last-event-wins).
- [x] Repair → ``--list`` shows 0 remaining (round-trip).
- [ ] CI green.

### Phase 2 status

This closes the Phase 2 sub-PR set:

| Sub-PR | Status | Description |
|---|---|---|
| α | ✅ #421 | ``synthesize-log`` (UUID7 minting + JSONL → events.jsonl) |
| β | ✅ #423 | ``synthesize-log --chunks`` (T3 chunk synthesis) |
| γ | ✅ #424 | ``t3-backfill-doc-id`` (write doc_id into chunk metadata) |
| δ | ✅ #425 | ``doctor --t3-doc-id-coverage`` (verify) |
| ε | this PR | ``repair-orphan-chunks`` (operator fixup) |

Bead: ``nexus-zbl0`` (Phase 2 sub-PR ε under ``nexus-o6aa.8``). Closing ``nexus-o6aa.8`` once this merges.

### Refs

- RDR-101 §Implementation Plan / Phase 2 — "Operator runs ``nx catalog repair-orphan-chunks`` for manual assignment of orphan set."