### PR TITLE
fix(rdr-101): correctness fixes from Phase 1+2 review

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -453,3 +453,6 @@
 {"id":"int-01dbfbec","kind":"field_change","created_at":"2026-05-01T09:32:44.084463Z","actor":"Hellblazer","issue_id":"nexus-x7ah","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-001905c8","kind":"field_change","created_at":"2026-05-01T09:36:53.661303Z","actor":"Hellblazer","issue_id":"nexus-x7ah","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-e729fd4d","kind":"field_change","created_at":"2026-05-01T09:37:23.120256Z","actor":"Hellblazer","issue_id":"nexus-zbl0","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-f7d389b4","kind":"field_change","created_at":"2026-05-01T09:39:36.705109Z","actor":"Hellblazer","issue_id":"nexus-zbl0","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-387f3b3c","kind":"field_change","created_at":"2026-05-01T09:39:37.016139Z","actor":"Hellblazer","issue_id":"nexus-o6aa.8","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-4394fe2e","kind":"field_change","created_at":"2026-05-01T09:55:40.38574Z","actor":"Hellblazer","issue_id":"nexus-db3k","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -652,9 +652,11 @@ class Catalog:
             return
         if not self._events_path.exists():
             self._events_path.touch()
-        line = json.dumps(
-            event.to_dict(), default=str, separators=(",", ":"),
-        )
+        # Match EventLog.append: no default=str. Non-JSON-native values
+        # in the payload raise TypeError rather than round-tripping as
+        # silently-coerced strings. Catalog mutators must not stuff
+        # datetime / Path / Decimal into payload meta.
+        line = json.dumps(event.to_dict(), separators=(",", ":"))
         with self._events_path.open("a") as f:
             f.write(line)
             f.write("\n")
@@ -1092,41 +1094,50 @@ class Catalog:
         """
         if str(tumbler) == str(canonical):
             raise ValueError(f"self-alias rejected: {tumbler} → {canonical}")
-        # Read current row (by raw tumbler — do not follow alias, we want
-        # to update THIS row specifically).
-        raw = self.resolve(tumbler, follow_alias=False)
-        if raw is None:
-            return
-        self._db.execute(
-            "UPDATE documents SET alias_of = ? WHERE tumbler = ?",
-            (str(canonical), str(tumbler)),
-        )
-        self._db.commit()
-        # Append updated JSONL record so a future rebuild sees the alias.
-        updated = DocumentRecord(
-            tumbler=str(tumbler),
-            title=raw.title,
-            author=raw.author,
-            year=raw.year,
-            content_type=raw.content_type,
-            file_path=raw.file_path,
-            corpus=raw.corpus,
-            physical_collection=raw.physical_collection,
-            chunk_count=raw.chunk_count,
-            head_hash=raw.head_hash,
-            indexed_at=raw.indexed_at,
-            meta=raw.meta,
-            source_mtime=raw.source_mtime,
-            alias_of=str(canonical),
-        )
-        self._append_jsonl(self._documents_path, updated.__dict__)
-        self._emit_shadow_event(_make_event(
-            _DocumentAliasedPayload(
-                alias_doc_id=str(tumbler),
-                canonical_doc_id=str(canonical),
-            ),
-            v=0,
-        ))
+        # Acquire the catalog directory flock so the JSONL append and
+        # the shadow-event emit (which both have a "caller holds the
+        # flock" contract) cannot race a concurrent writer. Pre-PR-F
+        # this method was unlocked because it was JSONL+SQLite-only;
+        # adding the shadow emit made the lock load-bearing.
+        dir_fd = self._acquire_lock()
+        try:
+            # Read current row (by raw tumbler — do not follow alias, we want
+            # to update THIS row specifically).
+            raw = self.resolve(tumbler, follow_alias=False)
+            if raw is None:
+                return
+            self._db.execute(
+                "UPDATE documents SET alias_of = ? WHERE tumbler = ?",
+                (str(canonical), str(tumbler)),
+            )
+            self._db.commit()
+            # Append updated JSONL record so a future rebuild sees the alias.
+            updated = DocumentRecord(
+                tumbler=str(tumbler),
+                title=raw.title,
+                author=raw.author,
+                year=raw.year,
+                content_type=raw.content_type,
+                file_path=raw.file_path,
+                corpus=raw.corpus,
+                physical_collection=raw.physical_collection,
+                chunk_count=raw.chunk_count,
+                head_hash=raw.head_hash,
+                indexed_at=raw.indexed_at,
+                meta=raw.meta,
+                source_mtime=raw.source_mtime,
+                alias_of=str(canonical),
+            )
+            self._append_jsonl(self._documents_path, updated.__dict__)
+            self._emit_shadow_event(_make_event(
+                _DocumentAliasedPayload(
+                    alias_doc_id=str(tumbler),
+                    canonical_doc_id=str(canonical),
+                ),
+                v=0,
+            ))
+        finally:
+            self._release_lock(dir_fd)
 
     def resolve_path(self, tumbler: Tumbler) -> Path | None:
         """Return absolute path for the document's file_path.
@@ -1550,6 +1561,42 @@ class Catalog:
                 (new, old),
             )
             self._db.commit()
+            # Shadow-emit one DocumentRegistered per renamed row with
+            # the new physical_collection. The projector's INSERT OR
+            # REPLACE makes the replay state converge on the new
+            # collection name. Pre-fix this method emitted nothing,
+            # so a replayed events.jsonl produced rows with the OLD
+            # physical_collection, breaking the doctor's replay-equality
+            # check. Emitting after db.commit() (same crash-window
+            # discipline as unlink/bulk_unlink) keeps the event log
+            # consistent with the durable SQLite state.
+            owner_addr_for = lambda t: ".".join(t.split(".")[:2])
+            for row in rows:
+                meta_dict = json.loads(row[11]) if row[11] else {}
+                self._emit_shadow_event(_make_event(
+                    _DocumentRegisteredPayload(
+                        doc_id=row[0],
+                        owner_id=owner_addr_for(row[0]),
+                        content_type=row[4] or "",
+                        source_uri=row[13] or "",
+                        coll_id=new,
+                        title=row[1] or "",
+                        source_mtime=float(row[12] or 0.0),
+                        indexed_at_doc=row[10] or "",
+                        tumbler=row[0],
+                        author=row[2] or "",
+                        year=int(row[3] or 0),
+                        file_path=row[5] or "",
+                        corpus=row[6] or "",
+                        physical_collection=new,
+                        chunk_count=int(row[8] or 0),
+                        head_hash=row[9] or "",
+                        indexed_at=row[10] or "",
+                        alias_of="",
+                        meta=dict(meta_dict),
+                    ),
+                    v=0,
+                ))
             return len(rows)
         finally:
             self._release_lock(dir_fd)
@@ -1588,6 +1635,7 @@ class Catalog:
                 _DocumentDeletedPayload(
                     doc_id=str(tumbler),
                     reason="catalog.delete_document",
+                    tumbler=str(tumbler),
                 ),
                 v=0,
             ))
@@ -2044,6 +2092,15 @@ class Catalog:
                 }
                 self._append_jsonl(self._links_path, tombstone)
                 self._db.execute("DELETE FROM links WHERE id = ?", (row_id,))
+
+            self._db.commit()
+            # Emit shadow events AFTER db.commit() so a process crash
+            # between the DELETE and the commit cannot leave events.jsonl
+            # claiming a deletion that SQLite has not yet committed.
+            # Pre-fix the emit was inside the per-row loop, opening a
+            # crash window where the event log diverged from the
+            # authoritative SQLite state.
+            for row_id, lt, original_created_by in rows:
                 self._emit_shadow_event(_make_event(
                     _LinkDeletedPayload(
                         from_doc=str(from_t),
@@ -2053,8 +2110,6 @@ class Catalog:
                     ),
                     v=0,
                 ))
-
-            self._db.commit()
             return len(rows)
         finally:
             self._release_lock(dir_fd)
@@ -2212,6 +2267,10 @@ class Catalog:
                     "DELETE FROM links WHERE from_tumbler=? AND to_tumbler=? AND link_type=?",
                     (str(lnk.from_tumbler), str(lnk.to_tumbler), lnk.link_type),
                 )
+            self._db.commit()
+            # Emit shadow events AFTER db.commit() (see ``unlink`` for the
+            # crash-window rationale).
+            for lnk in matching:
                 self._emit_shadow_event(_make_event(
                     _LinkDeletedPayload(
                         from_doc=str(lnk.from_tumbler),
@@ -2221,7 +2280,6 @@ class Catalog:
                     ),
                     v=0,
                 ))
-            self._db.commit()
             return len(matching)
         finally:
             self._release_lock(dir_fd)

--- a/src/nexus/catalog/event_log.py
+++ b/src/nexus/catalog/event_log.py
@@ -72,8 +72,16 @@ class EventLog:
         log in append mode, writes one JSON line, and releases the lock.
         The lock pattern matches ``Catalog._acquire_lock`` exactly so
         Phase 1 writers and the existing JSONL writers don't race.
+
+        Raises ``TypeError`` if the event payload contains values
+        ``json.dumps`` cannot serialize (e.g. ``datetime``, ``Path``,
+        ``Decimal``). Earlier versions silently coerced these via
+        ``default=str``, which round-tripped them as strings on replay
+        and produced silent data corruption. Callers must ensure
+        ``meta`` and ``payload`` dict fields contain JSON-native
+        primitives before calling.
         """
-        line = json.dumps(event.to_dict(), default=str, separators=(",", ":"))
+        line = json.dumps(event.to_dict(), separators=(",", ":"))
         dir_fd = os.open(str(self._dir), os.O_RDONLY)
         try:
             fcntl.flock(dir_fd, fcntl.LOCK_EX)
@@ -91,11 +99,14 @@ class EventLog:
         catalog row produces multiple events (e.g. tombstoned row →
         ``DocumentRegistered`` + ``DocumentDeleted``). A single flock keeps
         the batch atomic with respect to other catalog writers.
+
+        Like ``append``, raises ``TypeError`` on non-JSON-serializable
+        payload values rather than silently coercing them.
         """
         if not events:
             return
         lines = [
-            json.dumps(e.to_dict(), default=str, separators=(",", ":"))
+            json.dumps(e.to_dict(), separators=(",", ":"))
             for e in events
         ]
         dir_fd = os.open(str(self._dir), os.O_RDONLY)
@@ -110,7 +121,17 @@ class EventLog:
             os.close(dir_fd)
 
     def replay(self) -> Iterator[Event]:
-        """Yield events in append order. Skips malformed lines with a warning."""
+        """Yield events in append order. Skips malformed lines with a warning.
+
+        Catches the full failure surface so one bad line does not abort the
+        iterator: JSONDecodeError on garbage text, missing-``type`` shape
+        errors, and any TypeError/AttributeError/ValueError that
+        ``Event.from_dict`` raises on a syntactically-valid JSON line whose
+        payload has the wrong shape (``payload: null``, ``payload: [1,2,3]``,
+        ``v: "abc"``, etc.). The catalog event log is git-managed and
+        machine-edited; a hard fail on a single malformed line would brick
+        the projector for the whole catalog.
+        """
         if not self._path.exists():
             return
         with self._path.open() as f:
@@ -136,7 +157,17 @@ class EventLog:
                         preview=line[:80],
                     )
                     continue
-                yield Event.from_dict(obj)
+                try:
+                    yield Event.from_dict(obj)
+                except (TypeError, AttributeError, ValueError) as exc:
+                    _log.warning(
+                        "event_log_payload_error",
+                        path=str(self._path),
+                        lineno=lineno,
+                        preview=line[:80],
+                        error=str(exc),
+                    )
+                    continue
 
     def truncate(self) -> None:
         """Drop the entire event log. Test-only — production code never calls."""

--- a/src/nexus/catalog/events.py
+++ b/src/nexus/catalog/events.py
@@ -259,10 +259,20 @@ class DocumentEnrichedPayload:
 
 @dataclass(frozen=True, slots=True)
 class DocumentDeletedPayload:
-    """Soft-delete tombstone. Chunks remain in T3 until ``nx t3 gc`` collects."""
+    """Soft-delete tombstone. Chunks remain in T3 until ``nx t3 gc`` collects.
+
+    ``tumbler`` is the legacy join key the v: 0 projector uses to find the
+    SQLite row to delete. When ``mint_doc_id=False`` (Phase 1 doctor verb)
+    ``doc_id`` IS the tumbler and the projector can use either; when
+    ``mint_doc_id=True`` (Phase 2 ``synthesize-log``) ``doc_id`` is a
+    UUID7 and ``tumbler`` is the only join key the tumbler-keyed schema
+    can match. Optional with empty default so v: 1 native writes don't
+    have to populate it.
+    """
 
     doc_id: str
     reason: str = ""
+    tumbler: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -418,10 +428,24 @@ class Event:
         keys are dropped silently (forward-compat). For unknown event
         types, the payload is preserved as a raw dict so the projector
         can emit the RF-101-2 unknown-(type, v) warning and skip.
+
+        Defensive against malformed line shapes:
+        - ``v`` that does not coerce to int falls back to 0 (synthesized);
+          a hard error here would propagate out of ``EventLog.replay`` and
+          abort the whole iterator on a single bad line.
+        - ``payload`` that is not a dict (list, int, null, etc.) is
+          treated as an empty dict so ``payload_raw.keys()`` does not
+          raise ``AttributeError``. The resulting Event has an empty
+          payload, which the projector handles via its unknown-key path.
         """
         type_ = d["type"]
-        v = int(d.get("v", 0))
-        payload_raw = d.get("payload") or {}
+        try:
+            v = int(d.get("v", 0))
+        except (TypeError, ValueError):
+            v = 0
+        payload_raw = d.get("payload")
+        if not isinstance(payload_raw, dict):
+            payload_raw = {}
         ts = d.get("ts", "")
 
         cls_ = payload_class(type_)

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -141,14 +141,33 @@ class Projector:
         )
 
     def _v0_document_aliased(self, payload: Any) -> None:
-        # The Phase 1 SQLite schema stores ``alias_of`` as a column on the
-        # ``documents`` row. ``DocumentRegistered`` populated it already
-        # for v: 0 synthesis; ``DocumentAliased`` is a no-op for the
-        # tumbler-keyed projection. Future projections (a separate
-        # ``aliases`` table or alias-graph view) consume this event;
-        # Phase 1 just keeps the dispatch entry registered so the doctor
-        # verb can verify the alias graph round-trips through the log.
-        return
+        # Two emit paths produce DocumentAliased events that the Phase 1
+        # SQLite schema (``documents.alias_of`` column) needs to track:
+        #
+        # 1. Synthesize-from-JSONL emits DocumentRegistered (with
+        #    ``alias_of`` populated) FOLLOWED BY DocumentAliased. The
+        #    DocumentRegistered's INSERT OR REPLACE already wrote the
+        #    correct alias_of column; the DocumentAliased UPDATE here
+        #    is idempotent on that row.
+        # 2. Shadow-emit ``Catalog.set_alias`` emits ONLY
+        #    DocumentAliased (no preceding DocumentRegistered for the
+        #    aliased row). Without an UPDATE here, replaying that log
+        #    leaves the projected SQLite row with empty alias_of,
+        #    breaking the alias graph.
+        #
+        # The UPDATE is keyed on ``alias_doc_id`` which equals the
+        # tumbler when ``mint_doc_id=False`` (the case for both
+        # shadow-emit and the Phase 1 doctor verb). For
+        # ``mint_doc_id=True`` synthesize-log paths the alias_doc_id is
+        # a UUID7 that no tumbler-keyed row matches, so the UPDATE is a
+        # safe no-op (and the alias_of column was already set by the
+        # preceding DocumentRegistered's INSERT OR REPLACE).
+        if not payload.alias_doc_id or not payload.canonical_doc_id:
+            return
+        self._db.execute(
+            "UPDATE documents SET alias_of = ? WHERE tumbler = ?",
+            (payload.canonical_doc_id, payload.alias_doc_id),
+        )
 
     def _v0_document_renamed(self, payload: Any) -> None:
         # v: 0 synthesis never emits this event today (renames before the
@@ -164,11 +183,19 @@ class Projector:
         )
 
     def _v0_document_deleted(self, payload: Any) -> None:
-        if not payload.doc_id:
+        # Prefer the legacy ``tumbler`` field for the v: 0 schema's
+        # tumbler-keyed DELETE. ``doc_id`` is a UUID7 when the Phase 2
+        # synthesizer ran with ``mint_doc_id=True``; using it as the
+        # WHERE clause would silently no-op the deletion. When
+        # ``tumbler`` is empty (e.g. v: 1 native writes that haven't
+        # populated it yet, or hand-emitted events), fall back to
+        # ``doc_id`` for back-compat with the Phase 1 doctor verb path.
+        tumbler = payload.tumbler or payload.doc_id
+        if not tumbler:
             return
         self._db.execute(
             "DELETE FROM documents WHERE tumbler = ?",
-            (payload.doc_id,),
+            (tumbler,),
         )
 
     def _v0_document_enriched(self, payload: Any) -> None:

--- a/src/nexus/catalog/synthesizer.py
+++ b/src/nexus/catalog/synthesizer.py
@@ -56,7 +56,10 @@ _log = structlog.get_logger()
 
 
 def synthesize_from_jsonl(
-    catalog_dir: Path, *, mint_doc_id: bool = False,
+    catalog_dir: Path,
+    *,
+    mint_doc_id: bool = False,
+    preserve_doc_ids: dict[str, str] | None = None,
 ) -> Iterator[Event]:
     """Yield v: 0 events that reproduce the catalog state under ``catalog_dir``.
 
@@ -79,6 +82,16 @@ def synthesize_from_jsonl(
       still writes a tumbler-keyed SQLite row, and the doc_id is carried
       in the event log for Phase 3+ canonical use.
 
+    ``preserve_doc_ids`` (Phase 2 ``synthesize-log --force`` use case):
+    a tumbler→doc_id mapping carried over from a prior synthesis run.
+    For each tumbler that appears in ``preserve_doc_ids``, that doc_id
+    is reused instead of minting a fresh UUID7. Tumblers absent from
+    the map get fresh UUID7s. Without this, ``--force`` would mint
+    new doc_ids and silently invalidate every T3 chunk's doc_id
+    metadata that the prior ``t3-backfill-doc-id`` run wrote — the
+    doctor's ``--t3-doc-id-coverage`` would catastrophically fail
+    until the operator re-ran the backfill.
+
     Aliased rows (``DocumentAliased`` events) follow the same rule: when
     ``mint_doc_id=True``, ``alias_doc_id`` and ``canonical_doc_id`` are
     the freshly-minted UUID7s for the alias and canonical rows
@@ -100,6 +113,14 @@ def synthesize_from_jsonl(
     tumbler_to_doc_id: dict[str, str]
     if mint_doc_id and docs_path.exists():
         tumbler_to_doc_id = _build_tumbler_to_doc_id(docs_path)
+        if preserve_doc_ids:
+            # Preserve doc_ids that already exist in the prior log so a
+            # re-synthesis (--force) does not invalidate downstream T3
+            # metadata. Tumblers absent from the prior log keep their
+            # freshly-minted UUID7.
+            for tumbler, doc_id in preserve_doc_ids.items():
+                if tumbler in tumbler_to_doc_id and doc_id:
+                    tumbler_to_doc_id[tumbler] = doc_id
     else:
         tumbler_to_doc_id = {}
 
@@ -248,6 +269,11 @@ def _synthesize_documents(
             payload=ev.DocumentDeletedPayload(
                 doc_id=deleted_doc_id,
                 reason="synthesized_from_tombstone",
+                # Always preserve the tumbler so the v: 0 projector's
+                # tumbler-keyed DELETE finds the SQLite row even when
+                # ``mint_doc_id=True`` mints a UUID7 doc_id that the
+                # tumbler-keyed schema doesn't know about.
+                tumbler=tumbler,
             ),
             ts=_synthesized_ts(obj),
         )

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3347,12 +3347,19 @@ def _run_replay_equality() -> dict:
         )
 
     # ── Snapshot live ──────────────────────────────────────────────────
+    # Links carry an autoincrement ``id`` PK that the projector restarts
+    # at 1; the live db's ids depend on insertion history. RF-101-2 does
+    # not claim the autoincrement is part of the projection contract, so
+    # both snapshots exclude the ``id`` column by name (not by position
+    # — a future schema migration that adds a column before ``id`` would
+    # silently strip the wrong field under positional indexing).
+    LINKS_EXCLUDE = ["id"]
     live_uri = f"file:{live_db_path}?mode=ro"
     with closing(sqlite3.connect(live_uri, uri=True)) as live_conn:
         live_snap = {
             "owners": _snapshot_table(live_conn, "owners"),
             "documents": _snapshot_table(live_conn, "documents"),
-            "links": _snapshot_table(live_conn, "links"),
+            "links": _snapshot_table(live_conn, "links", exclude_cols=LINKS_EXCLUDE),
         }
 
     # ── Project + snapshot ────────────────────────────────────────────
@@ -3370,7 +3377,7 @@ def _run_replay_equality() -> dict:
             projected_snap = {
                 "owners": _snapshot_table(proj_conn, "owners"),
                 "documents": _snapshot_table(proj_conn, "documents"),
-                "links": _snapshot_table(proj_conn, "links"),
+                "links": _snapshot_table(proj_conn, "links", exclude_cols=LINKS_EXCLUDE),
             }
 
     # ── Diff ──────────────────────────────────────────────────────────
@@ -3379,14 +3386,6 @@ def _run_replay_equality() -> dict:
     for table in ("owners", "documents", "links"):
         live_rows = live_snap[table]
         proj_rows = projected_snap[table]
-        # Links carry an autoincrement ``id`` PK that the projector
-        # restarts at 1; the live db's ids depend on insertion history.
-        # Strip the id column from both before comparing — the rest of
-        # the row is the actual content under test (RF-101-2 doesn't
-        # claim the autoincrement is part of the projection contract).
-        if table == "links":
-            live_rows = [r[1:] for r in live_rows]
-            proj_rows = [r[1:] for r in proj_rows]
         live_set = set(live_rows)
         proj_set = set(proj_rows)
         only_live = sorted(live_set - proj_set)
@@ -3411,17 +3410,28 @@ def _run_replay_equality() -> dict:
     }
 
 
-def _snapshot_table(conn, table: str) -> list[tuple]:
+def _snapshot_table(
+    conn, table: str, *, exclude_cols: list[str] | None = None,
+) -> list[tuple]:
     """Snapshot one catalog table in deterministic row order.
 
     Sort by every column so the comparison is independent of insertion
     order. ``documents.metadata`` and ``links.metadata`` are JSON blobs
     that round-trip as strings, which sort byte-wise.
+
+    ``exclude_cols`` removes named columns from both the SELECT and the
+    ORDER BY. Used by the doctor's links snapshot to exclude the
+    autoincrement ``id`` column without a fragile positional slice.
     """
     cur = conn.execute(f"PRAGMA table_info({table})")
     cols = [row[1] for row in cur.fetchall()]
     if not cols:
         return []
+    if exclude_cols:
+        exclude = set(exclude_cols)
+        cols = [c for c in cols if c not in exclude]
+        if not cols:
+            return []
     sort_cols = ", ".join(cols)
     rows = conn.execute(
         f"SELECT {sort_cols} FROM {table} ORDER BY {sort_cols}"
@@ -3551,7 +3561,25 @@ def synthesize_log_cmd(
             "before re-running."
         )
 
-    events = list(synthesize_from_jsonl(cat_dir, mint_doc_id=True))
+    # Preserve existing tumbler→doc_id mapping across --force re-synthesis
+    # so a prior ``t3-backfill-doc-id`` run's metadata stays valid. Without
+    # this, --force would mint fresh UUID7s and silently invalidate every
+    # T3 chunk's doc_id; the doctor's --t3-doc-id-coverage would
+    # catastrophically fail until the operator re-ran the backfill.
+    preserve_map: dict[str, str] = {}
+    if existing_size > 0:
+        from nexus.catalog import events as ev_mod
+        for prior in log.replay():
+            if prior.type != ev_mod.TYPE_DOCUMENT_REGISTERED:
+                continue
+            t = getattr(prior.payload, "tumbler", "") or ""
+            d = getattr(prior.payload, "doc_id", "") or ""
+            if t and d and t not in preserve_map:
+                preserve_map[t] = d
+
+    events = list(synthesize_from_jsonl(
+        cat_dir, mint_doc_id=True, preserve_doc_ids=preserve_map,
+    ))
     chunk_events: list = []
     orphan_count = 0
     if chunks:

--- a/tests/test_catalog_synthesize_log.py
+++ b/tests/test_catalog_synthesize_log.py
@@ -131,30 +131,49 @@ class TestWriteAndOverwrite:
         assert second.exit_code != 0
         assert "non-empty" in second.output.lower()
 
-    def test_force_truncates_and_rewrites(self, isolated_nexus, runner):
+    def test_force_truncates_and_preserves_doc_ids(
+        self, isolated_nexus, runner,
+    ):
+        """--force preserves the prior tumbler→doc_id mapping.
+
+        Pre-fix, --force minted fresh UUID7s for every tumbler, which
+        silently invalidated every T3 chunk's doc_id metadata that the
+        prior ``t3-backfill-doc-id`` had written and made the doctor's
+        --t3-doc-id-coverage check catastrophically fail. The
+        regression guard below asserts the post-fix contract:
+        doc_ids for tumblers that already appeared in the prior log
+        carry through the --force re-synthesis unchanged.
+        """
         cat = _build_initialized_catalog(isolated_nexus)
         cat._db.close()
 
         runner.invoke(synthesize_log_cmd, [])
         log = EventLog(isolated_nexus)
         first_events = list(log.replay())
-        first_doc_ids = {
-            e.payload.doc_id for e in first_events
-            if e.type == ev.TYPE_DOCUMENT_REGISTERED
+        first_by_tumbler = {
+            e.payload.tumbler: e.payload.doc_id
+            for e in first_events
+            if e.type == ev.TYPE_DOCUMENT_REGISTERED and e.payload.tumbler
         }
+        assert first_by_tumbler  # sanity
 
         result = runner.invoke(synthesize_log_cmd, ["--force"])
         assert result.exit_code == 0
         second_events = list(log.replay())
         # Same event count.
         assert len(second_events) == len(first_events)
-        second_doc_ids = {
-            e.payload.doc_id for e in second_events
-            if e.type == ev.TYPE_DOCUMENT_REGISTERED
+        second_by_tumbler = {
+            e.payload.tumbler: e.payload.doc_id
+            for e in second_events
+            if e.type == ev.TYPE_DOCUMENT_REGISTERED and e.payload.tumbler
         }
-        # Fresh UUID7s on every synthesize-log run — the canonical
-        # doc_ids are different even though the tumblers are the same.
-        assert first_doc_ids.isdisjoint(second_doc_ids)
+        # Every tumbler that existed in the prior log keeps its doc_id.
+        for tumbler, doc_id in first_by_tumbler.items():
+            assert second_by_tumbler.get(tumbler) == doc_id, (
+                f"--force changed the doc_id for tumbler {tumbler!r}: "
+                f"{first_by_tumbler[tumbler]!r} → "
+                f"{second_by_tumbler.get(tumbler)!r}"
+            )
 
 
 # ── UUID7 minting + tumbler preservation ─────────────────────────────────

--- a/tests/test_rdr101_correctness_remediation.py
+++ b/tests/test_rdr101_correctness_remediation.py
@@ -1,0 +1,457 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Regression tests for the RDR-101 Phase 1+2 correctness review.
+
+One test per finding so a future regression points at the exact
+contract that was broken. Findings:
+
+- C1: ``EventLog.replay`` must skip lines whose payload shape is
+  invalid (e.g. ``payload: null``, ``payload: [1,2,3]``, ``v: "abc"``)
+  rather than aborting the iterator.
+- C2: ``Catalog.set_alias`` must hold the catalog directory flock for
+  the duration of the JSONL append + shadow emit.
+- C3: ``Catalog.unlink`` and ``bulk_unlink`` must commit SQLite before
+  appending shadow events.
+- C4: ``nx catalog doctor --replay-equality`` must exclude the links
+  ``id`` autoincrement column by NAME, not by positional slice.
+- I-events-1: ``EventLog.append`` must not silently coerce
+  non-JSON-native payload values (raise TypeError instead).
+- I-events-2: ``Event.from_dict`` must not crash on a non-dict
+  payload (list, int, etc.).
+- I-events-3 (covered by C1): ``v: "abc"`` does not crash replay.
+- I-projector: ``_v0_document_deleted`` must use ``payload.tumbler`` to
+  find the SQLite row when ``mint_doc_id=True`` (Phase 2) emits a
+  UUID7 ``doc_id``.
+- I-catalog-rename: ``Catalog.rename_collection`` must shadow-emit
+  events so a replay reproduces the post-rename collection name.
+- I-catalog-alias: ``Projector._v0_document_aliased`` must UPDATE the
+  alias_of column so a replay of shadow-emitted ``set_alias`` events
+  reproduces the alias graph.
+- I-Phase2-force: ``synthesize-log --force`` must preserve doc_ids for
+  tumblers that already appeared in the prior log (covered by the
+  updated test in ``test_catalog_synthesize_log.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.projector import Projector
+
+
+# ── C1 + I-events-2 + I-events-3: EventLog.replay broad exception ────────
+
+
+class TestReplayResilientToBadPayloadShape:
+    def test_replay_skips_null_payload_for_known_type(self, tmp_path):
+        d = tmp_path / "catalog"
+        d.mkdir()
+        log = EventLog(d)
+        # Hand-craft a line with payload: null for a known type whose
+        # payload class has required fields.
+        log.path.write_text(
+            json.dumps({
+                "type": ev.TYPE_DOCUMENT_DELETED,
+                "v": 1,
+                "payload": None,
+                "ts": "2026-04-30T00:00:00Z",
+            }) + "\n"
+            + json.dumps({
+                "type": ev.TYPE_DOCUMENT_DELETED,
+                "v": 1,
+                "payload": {"doc_id": "x", "reason": "y"},
+                "ts": "2026-04-30T00:01:00Z",
+            }) + "\n"
+        )
+        # Pre-fix this aborted the iterator on the bad line; post-fix it
+        # logs and skips the bad line then yields the good one.
+        events = list(log.replay())
+        assert len(events) == 1
+        assert events[0].type == ev.TYPE_DOCUMENT_DELETED
+        assert events[0].payload.doc_id == "x"
+
+    def test_replay_skips_list_payload(self, tmp_path):
+        d = tmp_path / "catalog"
+        d.mkdir()
+        log = EventLog(d)
+        log.path.write_text(
+            json.dumps({
+                "type": ev.TYPE_DOCUMENT_DELETED,
+                "v": 1,
+                "payload": [1, 2, 3],
+                "ts": "t",
+            }) + "\n"
+            + json.dumps({
+                "type": ev.TYPE_DOCUMENT_DELETED,
+                "v": 1,
+                "payload": {"doc_id": "good", "reason": "y"},
+                "ts": "t",
+            }) + "\n"
+        )
+        events = list(log.replay())
+        # Bad line is logged + skipped; good line yields normally.
+        assert len(events) == 1
+        assert events[0].payload.doc_id == "good"
+
+    def test_replay_does_not_crash_on_non_int_v(self, tmp_path):
+        d = tmp_path / "catalog"
+        d.mkdir()
+        log = EventLog(d)
+        log.path.write_text(
+            json.dumps({
+                "type": ev.TYPE_DOCUMENT_DELETED,
+                "v": "abc",
+                "payload": {"doc_id": "x", "reason": "y"},
+                "ts": "t",
+            }) + "\n"
+        )
+        events = list(log.replay())
+        assert len(events) == 1
+        # Non-int v is coerced to 0 (synthesized) per the defensive
+        # guard in from_dict.
+        assert events[0].v == 0
+
+
+# ── I-events-1: append raises on non-JSON-serializable payload ───────────
+
+
+class TestAppendRaisesOnNonJsonPayload:
+    def test_datetime_in_meta_raises_typeerror(self, tmp_path):
+        d = tmp_path / "catalog"
+        d.mkdir()
+        log = EventLog(d)
+        bad_event = ev.make_event(ev.DocumentRegisteredPayload(
+            doc_id="x", owner_id="1.1", content_type="prose",
+            source_uri="file:///x.md", coll_id="c1",
+            meta={"when": datetime(2026, 1, 1, tzinfo=timezone.utc)},
+        ))
+        with pytest.raises(TypeError):
+            log.append(bad_event)
+
+    def test_path_in_meta_raises_typeerror(self, tmp_path):
+        d = tmp_path / "catalog"
+        d.mkdir()
+        log = EventLog(d)
+        bad_event = ev.make_event(ev.DocumentRegisteredPayload(
+            doc_id="x", owner_id="1.1", content_type="prose",
+            source_uri="file:///x.md", coll_id="c1",
+            meta={"path": Path("/foo/bar")},
+        ))
+        with pytest.raises(TypeError):
+            log.append(bad_event)
+
+
+# ── C2: set_alias holds the catalog flock ────────────────────────────────
+
+
+class TestSetAliasHoldsLock:
+    def test_set_alias_acquires_release_pattern(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Track lock acquisition / release calls.
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        canonical = cat.register(owner, "canon.md", content_type="prose")
+        alias = cat.register(owner, "alias.md", content_type="prose")
+
+        acquired: list[int] = []
+        released: list[int] = []
+        original_acquire = cat._acquire_lock
+        original_release = cat._release_lock
+
+        def tracked_acquire():
+            fd = original_acquire()
+            acquired.append(fd)
+            return fd
+
+        def tracked_release(fd):
+            released.append(fd)
+            return original_release(fd)
+
+        monkeypatch.setattr(cat, "_acquire_lock", tracked_acquire)
+        monkeypatch.setattr(cat, "_release_lock", tracked_release)
+
+        # set_alias before this PR did NOT call _acquire_lock at all;
+        # post-fix it calls acquire+release exactly once.
+        before = len(acquired)
+        cat.set_alias(alias, canonical)
+        assert len(acquired) == before + 1, (
+            "set_alias must acquire the catalog flock exactly once"
+        )
+        assert len(released) == before + 1, (
+            "set_alias must release the catalog flock exactly once"
+        )
+
+
+# ── C3: unlink emits LinkDeleted AFTER db.commit ─────────────────────────
+
+
+class TestUnlinkEventOrderingAfterCommit:
+    def test_unlink_does_not_emit_before_commit(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Track the order of db.commit() and _emit_shadow_event() calls.
+        Pre-fix, emits happened inside the per-row loop, BEFORE the
+        loop's terminating commit. Post-fix, emits happen after the
+        commit so a process crash leaves SQLite + events.jsonl
+        consistent (or both reflecting the pre-delete state).
+        """
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose")
+        b = cat.register(owner, "b.md", content_type="prose")
+        cat.link(a, b, link_type="cites", created_by="manual")
+
+        sequence: list[str] = []
+        original_commit = cat._db.commit
+        original_emit = cat._emit_shadow_event
+
+        def tracked_commit():
+            sequence.append("commit")
+            return original_commit()
+
+        def tracked_emit(event):
+            sequence.append(f"emit:{event.type}")
+            return original_emit(event)
+
+        monkeypatch.setattr(cat._db, "commit", tracked_commit)
+        monkeypatch.setattr(cat, "_emit_shadow_event", tracked_emit)
+
+        n = cat.unlink(a, b, link_type="cites")
+        assert n == 1
+
+        # Find the unlink-related sequence: the LinkDeleted emit must
+        # land AFTER the commit that follows the DELETE.
+        assert "commit" in sequence
+        commit_idx = sequence.index("commit")
+        link_deleted_idx = next(
+            i for i, s in enumerate(sequence) if s == f"emit:{ev.TYPE_LINK_DELETED}"
+        )
+        assert link_deleted_idx > commit_idx, (
+            f"LinkDeleted emitted before db.commit; sequence: {sequence}"
+        )
+
+
+# ── C4: doctor links snapshot strips id by NAME, not position ───────────
+
+
+class TestDoctorLinksSnapshotByName:
+    def test_snapshot_table_excludes_named_columns(self, tmp_path):
+        from nexus.commands.catalog import _snapshot_table
+
+        # Build a CatalogDB and seed one link.
+        db = CatalogDB(tmp_path / ".catalog.db")
+        db.execute(
+            "INSERT OR REPLACE INTO owners "
+            "(tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("1.1", "x", "repo", "h", "d", ""),
+        )
+        db.execute(
+            "INSERT INTO documents "
+            "(tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, "
+            "indexed_at, metadata, source_mtime, source_uri) "
+            "VALUES (?, ?, '', 0, '', '', '', '', 0, '', '', '{}', 0, '')",
+            ("1.1.1", "doc1"),
+        )
+        db.execute(
+            "INSERT INTO links "
+            "(from_tumbler, to_tumbler, link_type, from_span, to_span, "
+            "created_by, created_at, metadata) "
+            "VALUES (?, ?, ?, '', '', 'manual', '', '{}')",
+            ("1.1.1", "1.1.1", "self"),
+        )
+        db.commit()
+
+        rows_with_id = _snapshot_table(db._conn, "links")
+        rows_without_id = _snapshot_table(
+            db._conn, "links", exclude_cols=["id"],
+        )
+        assert len(rows_with_id[0]) == len(rows_without_id[0]) + 1
+        # The excluded column must be id (not a positional slice).
+        cur = db._conn.execute("PRAGMA table_info(links)")
+        cols = [r[1] for r in cur.fetchall()]
+        id_index = cols.index("id")
+        # rows_with_id[0][id_index] is the autoincrement; without_id
+        # must have all columns except that one.
+        with_minus_id = (
+            rows_with_id[0][:id_index] + rows_with_id[0][id_index + 1:]
+        )
+        assert rows_without_id[0] == with_minus_id
+        db.close()
+
+
+# ── I-projector: _v0_document_deleted prefers tumbler ────────────────────
+
+
+class TestV0DocumentDeletedUsesTumbler:
+    def test_delete_with_uuid7_doc_id_falls_back_to_tumbler(self, tmp_path):
+        """When mint_doc_id=True synthesizes a DocumentDeleted with
+        doc_id=UUID7, the projector must find the row by tumbler. Pre-
+        fix it issued WHERE tumbler=UUID7 and silently no-oped the
+        deletion; tombstoned documents resurrected on replay.
+        """
+        db = CatalogDB(tmp_path / ".catalog.db")
+        # Seed a document.
+        db.execute(
+            "INSERT INTO documents "
+            "(tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, "
+            "indexed_at, metadata, source_mtime, source_uri) "
+            "VALUES ('1.7.42', 'doc', '', 0, '', '', '', '', 0, '', '', "
+            "'{}', 0, '')"
+        )
+        db.commit()
+
+        # Apply DocumentDeleted with UUID7 doc_id but tumbler populated.
+        proj = Projector(db)
+        proj.apply(ev.Event(
+            type=ev.TYPE_DOCUMENT_DELETED, v=0,
+            payload=ev.DocumentDeletedPayload(
+                doc_id="019de2fc-2b2a-7bc4-9d84-6d0c17d2357e",
+                reason="tombstone",
+                tumbler="1.7.42",
+            ),
+            ts="t",
+        ))
+        db.commit()
+
+        rows = db.execute(
+            "SELECT tumbler FROM documents"
+        ).fetchall()
+        assert rows == [], (
+            "Document should be deleted via tumbler join; pre-fix the "
+            "WHERE tumbler=<UUID7> would not match and the row would "
+            "survive."
+        )
+        db.close()
+
+
+# ── I-catalog-rename: rename_collection emits events ─────────────────────
+
+
+class TestRenameCollectionEmitsEvents:
+    def test_rename_collection_with_shadow_emit_replays_correctly(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        cat.register(
+            owner, "doc.md", content_type="prose",
+            file_path="doc.md", physical_collection="docs__old",
+        )
+        n = cat.rename_collection("docs__old", "docs__new")
+        assert n == 1
+
+        # Replay events.jsonl into a fresh CatalogDB. The replayed row
+        # must carry the NEW physical_collection.
+        log = EventLog(d)
+        proj_db = CatalogDB(tmp_path / "projected.db")
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        with sqlite3.connect(str(tmp_path / "projected.db")) as pc:
+            row = pc.execute(
+                "SELECT physical_collection FROM documents"
+            ).fetchone()
+        assert row is not None
+        assert row[0] == "docs__new", (
+            f"Pre-fix rename_collection emitted no events; replay would "
+            f"see the OLD collection name. Got: {row[0]!r}"
+        )
+
+
+# ── I-catalog-alias: _v0_document_aliased UPDATEs alias_of ───────────────
+
+
+class TestV0DocumentAliasedUpdatesColumn:
+    def test_replayed_set_alias_event_populates_alias_of(self, tmp_path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        # Seed two documents.
+        for tumbler in ("1.1.1", "1.1.2"):
+            db.execute(
+                "INSERT INTO documents "
+                "(tumbler, title, author, year, content_type, file_path, "
+                "corpus, physical_collection, chunk_count, head_hash, "
+                "indexed_at, metadata, source_mtime, source_uri) "
+                f"VALUES ('{tumbler}', 'doc', '', 0, '', '', '', '', 0, "
+                "'', '', '{}', 0, '')"
+            )
+        db.commit()
+
+        proj = Projector(db)
+        proj.apply(ev.Event(
+            type=ev.TYPE_DOCUMENT_ALIASED, v=0,
+            payload=ev.DocumentAliasedPayload(
+                alias_doc_id="1.1.2",
+                canonical_doc_id="1.1.1",
+            ),
+            ts="t",
+        ))
+        db.commit()
+
+        row = db.execute(
+            "SELECT alias_of FROM documents WHERE tumbler = ?",
+            ("1.1.2",),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "1.1.1", (
+            "Pre-fix the v0 DocumentAliased handler was a no-op; "
+            "replaying a shadow-emitted set_alias event would leave "
+            "alias_of empty in the projected SQLite."
+        )
+        db.close()
+
+
+# ── End-to-end: shadow-emit set_alias replays correctly ──────────────────
+
+
+class TestSetAliasShadowEmitReplay:
+    """The combination of C2 (set_alias holds flock) and the alias
+    projector fix means replaying a shadow-emit log of a set_alias
+    sequence reproduces the alias graph in the projected SQLite."""
+
+    def test_round_trip(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        canonical = cat.register(owner, "canon.md", content_type="prose")
+        alias = cat.register(owner, "alias.md", content_type="prose")
+        cat.set_alias(alias, canonical)
+
+        log = EventLog(d)
+        proj_db = CatalogDB(tmp_path / "projected.db")
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        with sqlite3.connect(str(tmp_path / "projected.db")) as pc:
+            alias_row = pc.execute(
+                "SELECT alias_of FROM documents WHERE tumbler = ?",
+                (str(alias),),
+            ).fetchone()
+        assert alias_row is not None
+        assert alias_row[0] == str(canonical)


### PR DESCRIPTION
## Summary

Addresses 10 correctness findings from the parallel code review of the Phase 1 + Phase 2 sub-PRs (#414-#420 + #421-#426). Each fix has a targeted regression test plus broader-suite verification.

### Critical (4)

- **C1** — `event_log.replay()` now wraps `Event.from_dict` in a broad except (`TypeError`/`AttributeError`/`ValueError`) so a single line with valid JSON but invalid payload shape does not abort the iterator.
- **C2** — `Catalog.set_alias` now acquires the catalog directory flock for the duration of the JSONL append + shadow emit. Pre-existing race condition surfaced by PR F.
- **C3** — `Catalog.unlink` and `bulk_unlink` now emit shadow events AFTER `db.commit()`. Crash-window fix.
- **C4** — `nx catalog doctor --replay-equality` strips the links `id` autoincrement column by NAME (`_snapshot_table(exclude_cols=['id'])`), not via positional `r[1:]` slice.

### Important (6 correctness-affecting)

- **I-events-1** — `EventLog.append`/`append_many` and `Catalog._emit_shadow_event` no longer use `default=str` in `json.dumps`. Non-JSON-native values raise `TypeError` instead of silent string coercion.
- **I-events-2** — `Event.from_dict` guards payload being a non-dict (list, int, null) by treating as empty.
- **I-events-3** — `Event.from_dict` guards `int(d.get('v', 0))` with `try/except`; non-int `v` coerces to 0.
- **I-projector** — `Projector._v0_document_deleted` uses `payload.tumbler` preferentially. `DocumentDeletedPayload` gains an optional `tumbler: str = ""` field. Synthesizer + `Catalog.delete_document` populate it.
- **I-catalog-rename** — `Catalog.rename_collection` now emits one `DocumentRegistered` shadow event per renamed row.
- **I-catalog-alias** — `Projector._v0_document_aliased` now UPDATEs the `documents.alias_of` column. Idempotent for synthesize-log paths; load-bearing for shadow-emitted `set_alias`.
- **I-Phase2-force** — `synthesize-log --force` preserves the prior tumbler→doc_id mapping via the new `preserve_doc_ids` parameter on `synthesize_from_jsonl`. Avoids catastrophic invalidation of `t3-backfill-doc-id`'s prior work.

### Test plan

- [x] 12 new regression tests in `tests/test_rdr101_correctness_remediation.py`, one per finding.
- [x] Updated `test_force_truncates_and_preserves_doc_ids` (was `test_force_truncates_and_rewrites`) to assert the corrected `--force` contract.
- [x] 377 tests passing across catalog + Phase 1 + Phase 2 modules locally (no regressions).
- [ ] CI green.

### Refs

- Code review findings from 6 parallel `nx:code-review-expert` agents (Phase 1 events.py + event_log.py, Phase 1 projector + synthesizer, Phase 1 doctor, Phase 1 schema migrations, Phase 1 shadow emit, Phase 2 verbs)
- RDR-101 §RF-101-2 (event log resilience), §Migration / Phase 1 (synthesizer doc_id minting)

Bead: `nexus-db3k`.