### PR TITLE
fix(rdr-101): operational/diagnostic hardening from Phase 1+2 review

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -456,3 +456,5 @@
 {"id":"int-f7d389b4","kind":"field_change","created_at":"2026-05-01T09:39:36.705109Z","actor":"Hellblazer","issue_id":"nexus-zbl0","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-387f3b3c","kind":"field_change","created_at":"2026-05-01T09:39:37.016139Z","actor":"Hellblazer","issue_id":"nexus-o6aa.8","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 {"id":"int-4394fe2e","kind":"field_change","created_at":"2026-05-01T09:55:40.38574Z","actor":"Hellblazer","issue_id":"nexus-db3k","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-07c31aa0","kind":"field_change","created_at":"2026-05-01T10:05:45.941675Z","actor":"Hellblazer","issue_id":"nexus-db3k","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-08308fda","kind":"field_change","created_at":"2026-05-01T10:06:07.73708Z","actor":"Hellblazer","issue_id":"nexus-kpgy","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -31,10 +31,11 @@ def _read_shadow_gate() -> bool:
     return val in ("1", "true", "yes", "on")
 
 
-# Imported lazily inside Catalog methods so a process that never
-# constructs a Catalog (e.g. an MCP-only consumer) does not pay the
-# events-module import cost. Re-aliased to ``_Event`` here for the
-# ``_emit_shadow_event`` type hint.
+# Module-level imports of the typed event payloads. Aliased with a
+# leading underscore so callers outside this module don't reach in for
+# the private names (the public API is via Catalog methods that emit
+# events on behalf of the caller). The PR-F initial comment described
+# these as "lazy" imports — they are not, they run at import time.
 from nexus.catalog.events import (  # noqa: E402
     DocumentAliasedPayload as _DocumentAliasedPayload,
     DocumentDeletedPayload as _DocumentDeletedPayload,

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3251,11 +3251,27 @@ def prune_stale_cmd(
     ),
 )
 @click.option(
+    "--strict-not-in-t3",
+    "strict_not_in_t3",
+    is_flag=True,
+    help=(
+        "With --t3-doc-id-coverage: treat 'event log claims a chunk T3 "
+        "doesn't have' as a hard failure rather than a warning. Default "
+        "is warning so legitimate operational deletions (re-ingestion, "
+        "pruning) don't permanently red the doctor; pass --strict-not-"
+        "in-t3 to enforce 'event log = authoritative ledger, T3 must "
+        "match exactly'."
+    ),
+)
+@click.option(
     "--json", "as_json", is_flag=True,
     help="Emit machine-readable JSON instead of text output.",
 )
 def doctor_cmd(
-    replay_equality: bool, t3_doc_id_coverage: bool, as_json: bool,
+    replay_equality: bool,
+    t3_doc_id_coverage: bool,
+    strict_not_in_t3: bool,
+    as_json: bool,
 ) -> None:
     """RDR-101 catalog doctor surface.
 
@@ -3287,7 +3303,7 @@ def doctor_cmd(
             overall_pass = False
 
     if t3_doc_id_coverage:
-        report = _run_t3_doc_id_coverage()
+        report = _run_t3_doc_id_coverage(strict_not_in_t3=strict_not_in_t3)
         if as_json:
             json_payload["t3_doc_id_coverage"] = report
         else:
@@ -3847,7 +3863,7 @@ def _print_t3_backfill_text(report: dict) -> None:
 # ── RDR-101 Phase 2: doctor --t3-doc-id-coverage ─────────────────────────
 
 
-def _run_t3_doc_id_coverage() -> dict:
+def _run_t3_doc_id_coverage(*, strict_not_in_t3: bool = False) -> dict:
     """Walk every T3 collection in events.jsonl and report doc_id coverage.
 
     Steps:
@@ -3961,14 +3977,21 @@ def _run_t3_doc_id_coverage() -> dict:
                 break
             offset += 300
 
-        # Chunks the event log expected but T3 doesn't have.
+        # Chunks the event log expected but T3 doesn't have. By default
+        # this is a WARNING rather than a hard failure: the most common
+        # cause is legitimate operational deletion of T3 chunks (re-
+        # ingestion, pruning) without a corresponding event in the log,
+        # which over time would make the doctor permanently red. Pass
+        # ``--strict-not-in-t3`` to make it a hard failure (the contract
+        # then becomes "the event log is the authoritative ledger and
+        # T3 must match it exactly").
         not_in_t3 = sorted(set(expected_chunks) - seen)
 
         coverage = with_doc_id / total if total else 1.0
         pass_for_coll = (
             not mismatched
             and not missing
-            and not not_in_t3
+            and (not strict_not_in_t3 or not not_in_t3)
         )
         per_coll[coll_name] = {
             "total_chunks": total,
@@ -4169,7 +4192,11 @@ def repair_orphan_chunks_cmd(
         return
 
     # Assign mode. Parse CHUNK_ID:DOC_ID pairs.
-    pairs: list[tuple[str, str]] = []
+    # Parse and dedupe by chunk_id (last assignment wins). Pre-fix a
+    # duplicate `--assign chunk_id:X --assign chunk_id:Y` would silently
+    # under-count `remaining_orphans` because only the first match
+    # appended a repair while both pairs counted as input.
+    pairs_by_chunk: dict[str, str] = {}
     for raw in assignments:
         if ":" not in raw:
             raise click.UsageError(
@@ -4182,7 +4209,18 @@ def repair_orphan_chunks_cmd(
             raise click.UsageError(
                 f"--assign expects non-empty CHUNK_ID and DOC_ID, got {raw!r}"
             )
-        pairs.append((chunk_id, doc_id))
+        pairs_by_chunk[chunk_id] = doc_id  # later --assign wins
+
+    # Build the set of doc_ids that ever appeared in a DocumentRegistered
+    # event so we can warn the operator if they --assign a doc_id that
+    # was never registered (typo / typo'd UUID7 / unknown id). The doc
+    # log is the canonical source of truth for "what doc_ids exist."
+    known_doc_ids: set[str] = set()
+    for prior in log.replay():
+        if prior.type == ev.TYPE_DOCUMENT_REGISTERED:
+            d = getattr(prior.payload, "doc_id", "") or ""
+            if d:
+                known_doc_ids.add(d)
 
     # Resolve each assignment to a current orphan to copy chash / coll_id
     # from. Refuse to assign a chunk that is not currently an orphan.
@@ -4192,7 +4230,7 @@ def repair_orphan_chunks_cmd(
 
     repairs: list = []
     skipped: list = []
-    for chunk_id, doc_id in pairs:
+    for chunk_id, doc_id in pairs_by_chunk.items():
         if chunk_id not in orphan_by_chunk_id:
             skipped.append({
                 "chunk_id": chunk_id,
@@ -4202,6 +4240,20 @@ def repair_orphan_chunks_cmd(
                 ),
             })
             continue
+        if known_doc_ids and doc_id not in known_doc_ids:
+            # Soft warning: the doc_id is unknown to the event log. The
+            # repair still applies (operator may be intentionally
+            # introducing a forward-reference doc_id), but surface the
+            # mismatch so a typo is visible.
+            _log.warning(
+                "repair_orphan_unknown_doc_id",
+                chunk_id=chunk_id,
+                doc_id=doc_id,
+                note=(
+                    "doc_id does not appear in any DocumentRegistered "
+                    "event; check for typo or run synthesize-log first"
+                ),
+            )
         orphan = orphan_by_chunk_id[chunk_id]
         repairs.append(ev.Event(
             type=ev.TYPE_CHUNK_INDEXED, v=0,

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -900,9 +900,19 @@ def migrate_chash_index_rename_doc_id(conn: sqlite3.Connection) -> None:
     if "chunk_chroma_id" in cols:
         return
     if "doc_id" not in cols:
-        # Table exists but has neither column — schema is unrecognized;
-        # skip rather than risk corrupting it. The doctor verb will
-        # surface the divergence.
+        # Table exists but has neither column — schema is unrecognized.
+        # Log a warning so an operator can correlate it with the doctor
+        # verb's later divergence report rather than only finding out
+        # at query time when production code reads chunk_chroma_id.
+        _log.warning(
+            "chash_index_unrecognized_schema",
+            cols=sorted(cols),
+            note=(
+                "chash_index table exists but has neither doc_id nor "
+                "chunk_chroma_id; skipping rename. Run nx catalog "
+                "doctor to investigate."
+            ),
+        )
         return
     conn.execute(
         "ALTER TABLE chash_index RENAME COLUMN doc_id TO chunk_chroma_id"

--- a/src/nexus/db/t2/chash_index.py
+++ b/src/nexus/db/t2/chash_index.py
@@ -185,7 +185,7 @@ class ChashIndex:
         collide on the new PK. We defend by deleting any
         ``(chash, new)`` row that already exists before the UPDATE —
         rename is an atomic re-home so preserving the ``new``-side row
-        would drop our updated ``doc_id`` silently.
+        would drop our updated ``chunk_chroma_id`` silently.
         """
         with self._lock:
             # Drop any pre-existing new-collection rows that would collide
@@ -301,7 +301,10 @@ def dual_write_chash_index(
     ``T3Database.upsert_chunks_with_embeddings(...)``. Iterates the
     parallel ``ids`` and ``metadatas`` lists, extracts
     ``chunk_text_hash`` from each metadata dict, and registers the
-    ``(chash, collection, doc_id)`` tuple in T2.
+    ``(chash, collection, chunk_chroma_id)`` tuple in T2 (the
+    ``ids`` are Chroma natural IDs that the chash_index column
+    ``chunk_chroma_id`` was named for — pre-RDR-101-Phase-0 the
+    column was misleadingly called ``doc_id``).
 
     Best-effort: every insert is wrapped in a try/except that logs at
     warning level but does NOT re-raise. A T2 failure must never abort

--- a/tests/test_catalog_doctor_t3_coverage.py
+++ b/tests/test_catalog_doctor_t3_coverage.py
@@ -207,10 +207,15 @@ class TestCoverageFails:
         assert m["actual"] == "uuid7-WRONG"
         assert m["expected"] == "uuid7-A"
 
-    def test_chunk_in_log_but_not_in_t3_fails(
+    def test_chunk_in_log_but_not_in_t3_fails_under_strict(
         self, isolated_nexus, runner, chroma_client,
         monkeypatch: pytest.MonkeyPatch,
     ):
+        """Pre-hardening, ``not_in_t3`` was a hard fail by default.
+        Post-hardening, the default treats it as a warning so legitimate
+        T3 deletions don't permanently red the doctor; ``--strict-not-
+        in-t3`` opts back into the strict 'event log = authoritative'
+        contract."""
         events = [_chunk("missing-from-t3", "uuid7-A", "code__test")]
         _seed_log(isolated_nexus, events)
         _seed(chroma_client, "code__test", [
@@ -226,7 +231,8 @@ class TestCoverageFails:
 
         monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
         result = runner.invoke(
-            doctor_cmd, ["--t3-doc-id-coverage", "--json"],
+            doctor_cmd,
+            ["--t3-doc-id-coverage", "--strict-not-in-t3", "--json"],
         )
         assert result.exit_code == 1
         payload = json.loads(result.output)["t3_doc_id_coverage"]

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -95,11 +95,12 @@ class TestMigrationDataclass:
         # frecency projection table (4.21.4, RDR-101 Phase 1 PR D
         # nexus-knn3 — schema-only, mutable side table, no event-log
         # participation)
-        # = 30.
+        # = 30 at the time of writing.
         # Prefer the name-based checks in TestBackfillPlanDimensions
         # and TestAddPlanMatchTextColumn for future guards; this
-        # count is a cheap sentinel only.
-        assert len(MIGRATIONS) == 30
+        # count is a non-shrinking sentinel only — the >= form lets a
+        # PR add migrations without rote-bumping this assertion.
+        assert len(MIGRATIONS) >= 30
 
     def test_migrations_ordered_by_version(self) -> None:
         from nexus.db.migrations import MIGRATIONS, _parse_version

--- a/tests/test_rdr101_hardening.py
+++ b/tests/test_rdr101_hardening.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Regression tests for the RDR-101 Phase 1+2 hardening PR.
+
+One test per finding so a future regression points at the exact
+contract that was relaxed:
+
+- H1: ``migrate_chash_index_rename_doc_id`` warns when the table has
+  neither ``doc_id`` nor ``chunk_chroma_id`` instead of silently
+  skipping.
+- H2: migrations count assertion is ``>=`` not ``==``.
+- H5: ``doctor --t3-doc-id-coverage`` does NOT fail by default when
+  events.jsonl claims chunks T3 doesn't have; ``--strict-not-in-t3``
+  opts back into the strict contract.
+- H6: ``repair-orphan-chunks --assign`` deduplicates by chunk_id and
+  warns on an unknown doc_id.
+- Regression guard: ``Catalog.resolve_chash`` still surfaces the
+  ``doc_id`` key in the returned ChunkRef (Phase 4 back-compat
+  boundary; see Phase 0 nexus-o6aa.3 deliverable).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.event_log import EventLog
+from nexus.commands.catalog import doctor_cmd, repair_orphan_chunks_cmd
+
+
+@pytest.fixture()
+def isolated_nexus(tmp_path: Path) -> Path:
+    return tmp_path / "test-catalog"
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── H1: chash_index unrecognized-schema warning ──────────────────────────
+
+
+class TestChashIndexUnrecognizedSchemaWarn:
+    def test_warns_when_table_has_neither_column(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # caplog doesn't capture structlog reliably; intercept the
+        # warning call directly.
+        from nexus.db import migrations as _migrations
+
+        captured: list[tuple[str, dict]] = []
+
+        class _CapturingLogger:
+            def warning(self, event: str, **kw):
+                captured.append((event, kw))
+
+            def info(self, *a, **kw):
+                pass
+
+            def debug(self, *a, **kw):
+                pass
+
+        monkeypatch.setattr(_migrations, "_log", _CapturingLogger())
+
+        conn = sqlite3.connect(":memory:")
+        # Create a chash_index table with neither doc_id nor chunk_chroma_id.
+        conn.executescript("""
+            CREATE TABLE chash_index (
+                chash TEXT NOT NULL,
+                physical_collection TEXT NOT NULL,
+                some_other_column TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (chash, physical_collection)
+            );
+        """)
+        conn.commit()
+
+        _migrations.migrate_chash_index_rename_doc_id(conn)
+
+        assert any(
+            event == "chash_index_unrecognized_schema"
+            for event, _ in captured
+        ), (
+            f"migrate_chash_index_rename_doc_id should log a warning when "
+            f"the table has neither doc_id nor chunk_chroma_id; pre-fix "
+            f"it returned silently. Captured: {captured}"
+        )
+
+
+# ── H2: migration count is >= ────────────────────────────────────────────
+
+
+class TestMigrationCountNonShrinking:
+    def test_count_assertion_does_not_fail_on_added_migration(self):
+        # Smoke check that the assertion is >= not ==. Direct read of
+        # the test code: this is a guard that future PRs adding
+        # migrations don't get gated on bumping a sentinel.
+        from pathlib import Path
+
+        test_file = (
+            Path(__file__).parent / "test_migrations.py"
+        )
+        text = test_file.read_text()
+        assert "assert len(MIGRATIONS) >= 30" in text, (
+            "test_migrations.py should use >= for the migrations count "
+            "assertion (was == 30 pre-hardening, friction-magnet)"
+        )
+
+
+# ── H5: --strict-not-in-t3 default off ───────────────────────────────────
+
+
+class TestT3DocIdCoverageNotInT3IsWarning:
+    def _seed_log_and_chroma(
+        self, isolated_nexus, chroma_client, *, t3_chunk_id: str,
+        log_chunk_id: str,
+    ):
+        """Seed events.jsonl with a ChunkIndexed for log_chunk_id and
+        T3 with t3_chunk_id. If they differ, the log claims a chunk T3
+        doesn't have."""
+        from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+        Catalog.init(isolated_nexus)
+        log = EventLog(isolated_nexus)
+        log.append_many([
+            ev.Event(
+                type=ev.TYPE_CHUNK_INDEXED, v=0,
+                payload=ev.ChunkIndexedPayload(
+                    chunk_id=log_chunk_id, chash="h",
+                    doc_id="uuid7-A", coll_id="code__test",
+                    position=0,
+                ),
+                ts="t",
+            ),
+        ])
+        col = chroma_client.get_or_create_collection(
+            "code__test", embedding_function=DefaultEmbeddingFunction(),
+        )
+        col.add(
+            ids=[t3_chunk_id], documents=["x"],
+            metadatas=[{"doc_id": "uuid7-A"}],
+        )
+
+    def test_default_does_not_fail_on_not_in_t3(
+        self, isolated_nexus, runner, monkeypatch: pytest.MonkeyPatch,
+    ):
+        import chromadb
+
+        client = chromadb.EphemeralClient()
+        for c in list(client.list_collections()):
+            try:
+                client.delete_collection(c.name)
+            except Exception:
+                pass
+
+        self._seed_log_and_chroma(
+            isolated_nexus, client,
+            t3_chunk_id="ch1", log_chunk_id="ch1-deleted-from-t3",
+        )
+
+        class _FakeT3:
+            _client = client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        # Default: not_in_t3 is a warning. With one ChunkIndexed event
+        # whose chunk_id is missing from T3 and one T3 chunk that's NOT
+        # in the log, the doctor should still PASS (because the chunk
+        # T3 has carries the right doc_id, and the missing-from-t3
+        # chunk is treated as a warning rather than a hard fail).
+        result = runner.invoke(
+            doctor_cmd, ["--t3-doc-id-coverage", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        coll = payload["tables"]["code__test"]
+        assert coll["not_in_t3_count"] == 1
+        # PASS despite not_in_t3 — that's the new default.
+        assert coll["pass"] is True
+        assert payload["pass"] is True
+
+    def test_strict_flag_makes_not_in_t3_a_failure(
+        self, isolated_nexus, runner, monkeypatch: pytest.MonkeyPatch,
+    ):
+        import chromadb
+
+        client = chromadb.EphemeralClient()
+        for c in list(client.list_collections()):
+            try:
+                client.delete_collection(c.name)
+            except Exception:
+                pass
+
+        self._seed_log_and_chroma(
+            isolated_nexus, client,
+            t3_chunk_id="ch1", log_chunk_id="ch1-deleted-from-t3",
+        )
+
+        class _FakeT3:
+            _client = client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        result = runner.invoke(
+            doctor_cmd,
+            ["--t3-doc-id-coverage", "--strict-not-in-t3", "--json"],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        assert payload["pass"] is False
+        coll = payload["tables"]["code__test"]
+        assert coll["not_in_t3_count"] == 1
+        assert coll["pass"] is False
+
+
+# ── H6: --assign deduplicates and warns on unknown doc_id ────────────────
+
+
+class TestRepairAssignDedupAndUnknownDocId:
+    def _seed(self, catalog_dir: Path, events: list[ev.Event]) -> None:
+        catalog_dir.mkdir(parents=True, exist_ok=True)
+        Catalog.init(catalog_dir)
+        log = EventLog(catalog_dir)
+        log.append_many(events)
+
+    def test_duplicate_assign_chunk_id_keeps_last(self, isolated_nexus, runner):
+        # Two --assign pairs with the same chunk_id; later wins.
+        self._seed(isolated_nexus, [
+            ev.Event(
+                type=ev.TYPE_CHUNK_INDEXED, v=0,
+                payload=ev.ChunkIndexedPayload(
+                    chunk_id="orph1", chash="h", doc_id="",
+                    coll_id="code__test", position=0,
+                    synthesized_orphan=True,
+                ),
+                ts="t",
+            ),
+        ])
+        result = runner.invoke(
+            repair_orphan_chunks_cmd,
+            [
+                "--assign", "orph1:doc-first",
+                "--assign", "orph1:doc-second",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["repairs_count"] == 1
+        assert payload["skipped_count"] == 0
+
+        # The corrective event in the log must have the LAST assigned
+        # doc_id, not the first. Pre-fix the loop processed both
+        # pairs; the first wrote `repairs[0]` and the second silently
+        # disappeared because `orphan_by_chunk_id` had already been
+        # consumed.
+        log = EventLog(isolated_nexus)
+        last_event = list(log.replay())[-1]
+        assert last_event.payload.doc_id == "doc-second"
+
+    def test_unknown_doc_id_logs_warning(
+        self, isolated_nexus, runner, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Seed: one orphan + one DocumentRegistered with a known doc_id.
+        # --assign for an unknown doc_id should still apply (operator
+        # may know what they're doing) but log a warning.
+        self._seed(isolated_nexus, [
+            ev.Event(
+                type=ev.TYPE_DOCUMENT_REGISTERED, v=0,
+                payload=ev.DocumentRegisteredPayload(
+                    doc_id="known-doc",
+                    owner_id="1.1",
+                    content_type="prose",
+                    source_uri="file:///x.md",
+                    coll_id="code__test",
+                    tumbler="1.1.1",
+                ),
+                ts="t",
+            ),
+            ev.Event(
+                type=ev.TYPE_CHUNK_INDEXED, v=0,
+                payload=ev.ChunkIndexedPayload(
+                    chunk_id="orph1", chash="h", doc_id="",
+                    coll_id="code__test", position=0,
+                    synthesized_orphan=True,
+                ),
+                ts="t",
+            ),
+        ])
+
+        # Capture structlog warning calls via monkeypatch.
+        from nexus.commands import catalog as _catcmd
+
+        captured: list[tuple[str, dict]] = []
+
+        class _Capture:
+            def warning(self, event, **kw):
+                captured.append((event, kw))
+
+            def info(self, *a, **kw):
+                pass
+
+            def debug(self, *a, **kw):
+                pass
+
+            def error(self, *a, **kw):
+                pass
+
+        monkeypatch.setattr(_catcmd, "_log", _Capture())
+
+        result = runner.invoke(
+            repair_orphan_chunks_cmd,
+            ["--assign", "orph1:typo-id-not-in-log"],
+        )
+        assert result.exit_code == 0, result.output
+
+        warned = any(
+            event == "repair_orphan_unknown_doc_id"
+            for event, _ in captured
+        )
+        assert warned, (
+            f"Expected repair_orphan_unknown_doc_id warning. Captured: {captured}"
+        )
+
+
+# ── Regression guard: ChunkRef back-compat 'doc_id' key ──────────────────
+
+
+class TestResolveChashChunkRefHasDocIdKey:
+    """RDR-101 Phase 0 nexus-o6aa.3 deliberately kept ``doc_id`` in
+    Catalog.resolve_chash's returned dict for back-compat with Phase 4
+    callers. This test guards against a "cleanup" PR that would
+    inadvertently remove the back-compat shim before Phase 4 ships."""
+
+    def test_chunk_ref_dict_has_doc_id_key(self):
+        # Inspect the source for the literal ``"doc_id"`` key in
+        # _build_ref. Direct test would need a full T3 + chash_index
+        # setup; the source-level guard is sufficient as a regression
+        # signal for "this back-compat boundary still exists."
+        from nexus.catalog.catalog import Catalog as _Cat
+
+        import inspect
+        src = inspect.getsource(_Cat.resolve_chash)
+        assert '"doc_id"' in src, (
+            "Catalog.resolve_chash's returned ChunkRef dict must keep "
+            "the 'doc_id' key for back-compat with Phase 4 callers per "
+            "RDR-101 Phase 0 nexus-o6aa.3 deliverable. Phase 3 will "
+            "introduce a parallel chunk_chroma_id key alongside, not "
+            "replace doc_id."
+        )


### PR DESCRIPTION
## Summary

Operational and diagnostic improvements from the same parallel code review that produced the correctness PR (#427). Distinct from #427 — none of these affect data integrity or replay-equality, but they affect operator UX, code clarity, and future-proofing.

### Changes

- **H1**: ``migrate_chash_index_rename_doc_id`` warns on unrecognized-schema instead of silently skipping.
- **H2**: ``test_migrations.py`` count assertion ``== 30`` → ``>= 30``. Future migrations don't have to bump a friction-magnet sentinel.
- **H3**: Stale docstrings in ``chash_index.py`` (``rename_collection`` and ``dual_write_chash_index``) corrected.
- **H4**: "Lazy import" comment in ``catalog.py`` is factually wrong (imports are unconditional); rewritten to explain the underscore-aliasing convention.
- **H5**: ``doctor --t3-doc-id-coverage`` demotes ``not_in_t3`` from hard FAIL to WARNING by default. New ``--strict-not-in-t3`` opts into the strict 'event log = authoritative' contract. Default makes the doctor usable over a catalog's lifecycle without per-deletion log re-synthesis.
- **H6**: ``repair-orphan-chunks --assign`` deduplicates by chunk_id (last wins) and warns (``repair_orphan_unknown_doc_id``) when the supplied doc_id doesn't appear in any prior ``DocumentRegistered`` event.
- **Regression guard**: source-level inspection test on ``Catalog.resolve_chash`` to prevent a future cleanup from accidentally removing the ``doc_id`` back-compat key before Phase 4.

### Test plan (7 new + 1 updated)

- [x] Unrecognized-schema chash_index migration logs warning.
- [x] Migration count assertion uses ``>=``.
- [x] ``not_in_t3`` is a WARNING by default (PASS), FAIL under ``--strict-not-in-t3``.
- [x] ``--assign`` duplicate chunk_id keeps the last assignment.
- [x] ``--assign`` with unknown doc_id logs ``repair_orphan_unknown_doc_id`` warning.
- [x] ``Catalog.resolve_chash`` source carries the ``doc_id`` key.
- [x] Updated PR-δ test ``test_chunk_in_log_but_not_in_t3_fails_under_strict`` to use ``--strict-not-in-t3`` (the new opt-in for hard fail).
- [x] 495 tests passing across catalog + Phase 1 + Phase 2 modules locally.
- [ ] CI green.

### Refs

- Code review findings from 6 parallel ``nx:code-review-expert`` agents (Phase 1 + Phase 2)
- Operational/diagnostic findings: H1 (migration warn), H5 (not_in_t3 contract), H6 (repair hardening)

Bead: ``nexus-kpgy``.