### PR TITLE
fix(rdr-101): meta-review remediation (post-#427/#428 second-pass)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -458,3 +458,5 @@
 {"id":"int-4394fe2e","kind":"field_change","created_at":"2026-05-01T09:55:40.38574Z","actor":"Hellblazer","issue_id":"nexus-db3k","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-07c31aa0","kind":"field_change","created_at":"2026-05-01T10:05:45.941675Z","actor":"Hellblazer","issue_id":"nexus-db3k","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-08308fda","kind":"field_change","created_at":"2026-05-01T10:06:07.73708Z","actor":"Hellblazer","issue_id":"nexus-kpgy","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-0e48680b","kind":"field_change","created_at":"2026-05-01T10:13:16.455931Z","actor":"Hellblazer","issue_id":"nexus-kpgy","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-f1a5b682","kind":"field_change","created_at":"2026-05-01T10:30:53.767253Z","actor":"Hellblazer","issue_id":"nexus-thut","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -648,19 +648,37 @@ class Catalog:
         v: 0 schema is used so the existing Phase 1 projector handlers
         apply unchanged. Phase 3 introduces v: 1 native-write semantics
         with new projector handlers.
+
+        Failure handling: the shadow log is non-authoritative in Phase 1
+        (nothing reads it yet). A failed emit MUST NOT abort the
+        catalog mutation that triggered it — SQLite + the legacy JSONL
+        are already committed by the time this method runs. Pre-fix
+        ``json.dumps``'s default=str silently coerced bad payload
+        values; the post-fix raises TypeError, which would otherwise
+        propagate out of the mutator and leave the catalog in a
+        committed-but-unobservable state. Catch broadly here, log a
+        structured warning, and let the mutation succeed. The doctor
+        verb's ``--replay-equality`` will surface the resulting event
+        log gap at audit time.
         """
         if not self._shadow_emit_enabled:
             return
-        if not self._events_path.exists():
-            self._events_path.touch()
-        # Match EventLog.append: no default=str. Non-JSON-native values
-        # in the payload raise TypeError rather than round-tripping as
-        # silently-coerced strings. Catalog mutators must not stuff
-        # datetime / Path / Decimal into payload meta.
-        line = json.dumps(event.to_dict(), separators=(",", ":"))
-        with self._events_path.open("a") as f:
-            f.write(line)
-            f.write("\n")
+        try:
+            if not self._events_path.exists():
+                self._events_path.touch()
+            line = json.dumps(event.to_dict(), separators=(",", ":"))
+            with self._events_path.open("a") as f:
+                f.write(line)
+                f.write("\n")
+        except Exception as exc:
+            event_type = getattr(event, "type", "?")
+            _log.warning(
+                "shadow_emit_failed",
+                event_type=event_type,
+                error=str(exc),
+                error_type=type(exc).__name__,
+                path=str(self._events_path),
+            )
 
     # ── Owners ─────────────────────────────────────────────────────────────
 
@@ -1525,20 +1543,26 @@ class Catalog:
         """
         dir_fd = self._acquire_lock()
         try:
+            # Include ``alias_of`` in the SELECT so the rename's shadow
+            # emit can preserve it for any aliased document being
+            # renamed. Pre-fix the SELECT omitted alias_of and the emit
+            # hardcoded it to "", silently severing the alias graph
+            # for any renamed alias row on replay.
             rows = self._db.execute(
                 "SELECT tumbler, title, author, year, content_type, file_path, "
                 "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
-                "metadata, source_mtime, source_uri "
+                "metadata, source_mtime, source_uri, alias_of "
                 "FROM documents WHERE physical_collection = ?",
                 (old,),
             ).fetchall()
             for row in rows:
-                # Preserve source_mtime + source_uri across the rename
-                # — JSONL is the rebuild source of truth, so any
-                # column omitted here is reset to its default when
+                # Preserve source_mtime + source_uri + alias_of across
+                # the rename — JSONL is the rebuild source of truth, so
+                # any column omitted here is reset to its default when
                 # Catalog.rebuild() replays the log (review finding —
                 # Reviewer B/C1, nexus-1ccq follow-up; RDR-096 P3.1
-                # extended this to source_uri).
+                # extended this to source_uri; meta-review extended it
+                # to alias_of).
                 rec = {
                     "tumbler": row[0],
                     "title": row[1],
@@ -1554,6 +1578,7 @@ class Catalog:
                     "meta": json.loads(row[11]) if row[11] else {},
                     "source_mtime": row[12] or 0.0,
                     "source_uri": row[13] or "",
+                    "alias_of": row[14] or "",
                 }
                 self._append_jsonl(self._documents_path, rec)
             self._db.execute(
@@ -1571,33 +1596,44 @@ class Catalog:
             # check. Emitting after db.commit() (same crash-window
             # discipline as unlink/bulk_unlink) keeps the event log
             # consistent with the durable SQLite state.
-            owner_addr_for = lambda t: ".".join(t.split(".")[:2])
-            for row in rows:
-                meta_dict = json.loads(row[11]) if row[11] else {}
-                self._emit_shadow_event(_make_event(
-                    _DocumentRegisteredPayload(
-                        doc_id=row[0],
-                        owner_id=owner_addr_for(row[0]),
-                        content_type=row[4] or "",
-                        source_uri=row[13] or "",
-                        coll_id=new,
-                        title=row[1] or "",
-                        source_mtime=float(row[12] or 0.0),
-                        indexed_at_doc=row[10] or "",
-                        tumbler=row[0],
-                        author=row[2] or "",
-                        year=int(row[3] or 0),
-                        file_path=row[5] or "",
-                        corpus=row[6] or "",
-                        physical_collection=new,
-                        chunk_count=int(row[8] or 0),
-                        head_hash=row[9] or "",
-                        indexed_at=row[10] or "",
-                        alias_of="",
-                        meta=dict(meta_dict),
-                    ),
-                    v=0,
-                ))
+            #
+            # Hoist the gate check above the per-row payload
+            # construction: when shadow emit is OFF (the default), a
+            # 10k-row rename should not pay the cost of building 10k
+            # _DocumentRegisteredPayload objects only to discard them
+            # in _emit_shadow_event's first line.
+            if self._shadow_emit_enabled:
+                from nexus.catalog.synthesizer import _owner_prefix_of
+                for row in rows:
+                    meta_dict = json.loads(row[11]) if row[11] else {}
+                    self._emit_shadow_event(_make_event(
+                        _DocumentRegisteredPayload(
+                            doc_id=row[0],
+                            # Use the synthesizer's helper for owner
+                            # extraction so malformed tumblers (no dots)
+                            # produce "" rather than the whole tumbler
+                            # — matches synthesize_from_jsonl's contract.
+                            owner_id=_owner_prefix_of(row[0]),
+                            content_type=row[4] or "",
+                            source_uri=row[13] or "",
+                            coll_id=new,
+                            title=row[1] or "",
+                            source_mtime=float(row[12] or 0.0),
+                            indexed_at_doc=row[10] or "",
+                            tumbler=row[0],
+                            author=row[2] or "",
+                            year=int(row[3] or 0),
+                            file_path=row[5] or "",
+                            corpus=row[6] or "",
+                            physical_collection=new,
+                            chunk_count=int(row[8] or 0),
+                            head_hash=row[9] or "",
+                            indexed_at=row[10] or "",
+                            alias_of=row[14] or "",
+                            meta=dict(meta_dict),
+                        ),
+                        v=0,
+                    ))
             return len(rows)
         finally:
             self._release_lock(dir_fd)

--- a/src/nexus/catalog/events.py
+++ b/src/nexus/catalog/events.py
@@ -215,10 +215,18 @@ class DocumentRenamedPayload:
 
     Cross-owner moves use ``DocumentDeleted + DocumentRegistered`` per
     RDR-101 §"File rename (cross-owner)".
+
+    ``tumbler`` is the legacy join key the v: 0 projector uses to find
+    the SQLite row to UPDATE. Pre-fix the projector used ``doc_id`` as
+    the WHERE clause; with Phase 2's ``mint_doc_id=True`` that's a
+    UUID7 and the tumbler-keyed schema would silently drop the rename.
+    Mirrors the same fix already in ``DocumentDeletedPayload``. Optional
+    with empty default so v: 1 native writes don't have to populate it.
     """
 
     doc_id: str
     new_source_uri: str
+    tumbler: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -164,6 +164,15 @@ class Projector:
         # preceding DocumentRegistered's INSERT OR REPLACE).
         if not payload.alias_doc_id or not payload.canonical_doc_id:
             return
+        # Refuse self-alias: ``Catalog.set_alias`` rejects this with
+        # ``ValueError`` at the public API; a hand-emitted bad event
+        # would slip past that guard and leave alias_of pointing at
+        # the row's own tumbler — a 1-cycle in the alias graph that
+        # ``Catalog.resolve_alias``'s cycle protection then has to
+        # detect at every read. Bail out here so the projector is the
+        # second line of defense.
+        if payload.alias_doc_id == payload.canonical_doc_id:
+            return
         self._db.execute(
             "UPDATE documents SET alias_of = ? WHERE tumbler = ?",
             (payload.canonical_doc_id, payload.alias_doc_id),
@@ -175,11 +184,19 @@ class Projector:
         # by ``synthesizer._synthesize_documents``). Kept registered so
         # dispatch on (DocumentRenamed, 0) doesn't trigger the
         # unknown-dispatch warning if someone hand-emits one.
-        if not payload.doc_id or not payload.new_source_uri:
+        #
+        # Like ``_v0_document_deleted``, prefer ``payload.tumbler`` for
+        # the v: 0 schema's tumbler-keyed UPDATE — falling back to
+        # ``payload.doc_id`` when tumbler is empty. Pre-fix the WHERE
+        # clause used ``doc_id`` directly, which silently no-oped when
+        # Phase 2 / Phase 3 paths emit a UUID7 doc_id against the
+        # tumbler-keyed schema.
+        tumbler = getattr(payload, "tumbler", "") or payload.doc_id
+        if not tumbler or not payload.new_source_uri:
             return
         self._db.execute(
             "UPDATE documents SET source_uri = ? WHERE tumbler = ?",
-            (payload.new_source_uri, payload.doc_id),
+            (payload.new_source_uri, tumbler),
         )
 
     def _v0_document_deleted(self, payload: Any) -> None:

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3289,6 +3289,12 @@ def doctor_cmd(
             "Pass a check flag: --replay-equality or "
             "--t3-doc-id-coverage."
         )
+    if strict_not_in_t3 and not t3_doc_id_coverage:
+        raise click.UsageError(
+            "--strict-not-in-t3 requires --t3-doc-id-coverage; the "
+            "flag scopes the not-in-T3 fail behaviour of the coverage "
+            "check and is meaningless without it."
+        )
 
     overall_pass = True
     json_payload: dict = {}
@@ -3582,6 +3588,14 @@ def synthesize_log_cmd(
     # this, --force would mint fresh UUID7s and silently invalidate every
     # T3 chunk's doc_id; the doctor's --t3-doc-id-coverage would
     # catastrophically fail until the operator re-ran the backfill.
+    #
+    # LAST-occurrence wins (not first-occurrence): if a tumbler was
+    # tombstoned then re-registered with a new UUID7 (legitimate
+    # resurrection), the active doc_id is the LAST one in the log. A
+    # first-wins guard would preserve the dead doc_id and silently
+    # mismatch every T3 chunk that carries the post-resurrection id.
+    # Warn loudly when a tumbler appears with conflicting doc_ids so
+    # an operator can investigate.
     preserve_map: dict[str, str] = {}
     if existing_size > 0:
         from nexus.catalog import events as ev_mod
@@ -3590,8 +3604,20 @@ def synthesize_log_cmd(
                 continue
             t = getattr(prior.payload, "tumbler", "") or ""
             d = getattr(prior.payload, "doc_id", "") or ""
-            if t and d and t not in preserve_map:
-                preserve_map[t] = d
+            if not (t and d):
+                continue
+            if t in preserve_map and preserve_map[t] != d:
+                _log.warning(
+                    "synthesize_preserve_map_tumbler_conflict",
+                    tumbler=t,
+                    prior_doc_id=preserve_map[t],
+                    new_doc_id=d,
+                    note=(
+                        "tumbler appears with multiple doc_ids in prior "
+                        "log; last-occurrence wins"
+                    ),
+                )
+            preserve_map[t] = d  # last-occurrence wins
 
     events = list(synthesize_from_jsonl(
         cat_dir, mint_doc_id=True, preserve_doc_ids=preserve_map,
@@ -4014,6 +4040,7 @@ def _run_t3_doc_id_coverage(*, strict_not_in_t3: bool = False) -> dict:
         "pass": overall_pass,
         "events_path": str(log.path),
         "collections_in_log": len(expected),
+        "strict_not_in_t3": strict_not_in_t3,
         "tables": per_coll,
     }
 
@@ -4160,6 +4187,9 @@ def repair_orphan_chunks_cmd(
             "chunk_id": event.payload.chunk_id,
             "doc_id": event.payload.doc_id,
             "chash": event.payload.chash,
+            "position": event.payload.position,
+            "content_hash": event.payload.content_hash,
+            "embedded_at": event.payload.embedded_at,
             "synthesized_orphan": event.payload.synthesized_orphan,
         }
     orphans = [
@@ -4255,6 +4285,11 @@ def repair_orphan_chunks_cmd(
                 ),
             )
         orphan = orphan_by_chunk_id[chunk_id]
+        # Preserve the orphan's intrinsic chunk fields (position,
+        # content_hash, embedded_at) on the corrective event. Pre-fix
+        # ``position=0`` was hardcoded, dropping the original chunk
+        # ordering on every repair — Phase 5's chunks-table schema
+        # depends on position for reading-order reconstruction.
         repairs.append(ev.Event(
             type=ev.TYPE_CHUNK_INDEXED, v=0,
             payload=ev.ChunkIndexedPayload(
@@ -4262,7 +4297,9 @@ def repair_orphan_chunks_cmd(
                 chash=orphan["chash"],
                 doc_id=doc_id,
                 coll_id=orphan["coll_id"],
-                position=0,
+                position=int(orphan.get("position", 0) or 0),
+                content_hash=orphan.get("content_hash", "") or "",
+                embedded_at=orphan.get("embedded_at", "") or "",
                 synthesized_orphan=False,
             ),
             ts=ev.now_ts(),

--- a/tests/test_rdr101_meta_review_remediation.py
+++ b/tests/test_rdr101_meta_review_remediation.py
@@ -1,0 +1,510 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Regression tests for the RDR-101 meta-review remediation.
+
+After the first round of correctness + hardening PRs (#427, #428), six
+parallel reviewers found 4 genuine correctness bugs and several
+quality issues in the FIX surface itself. One test per finding so
+future regressions point at the exact contract that was relaxed.
+
+- M1: ``Catalog._emit_shadow_event`` swallows TypeError / OSError so a
+  bad payload does not abort the catalog mutation that triggered it.
+- M2: ``synthesize-log --force`` ``preserve_doc_ids`` map uses
+  last-occurrence-wins (not first-wins) so a tumbler that was
+  resurrected (tombstone → re-register) preserves the LIVE doc_id.
+- M3: ``Projector._v0_document_renamed`` uses ``payload.tumbler or
+  payload.doc_id`` for the WHERE clause (was: ``payload.doc_id``).
+  Mirrors the M-projector fix in PR #427 to ``_v0_document_deleted``.
+- M4: ``Catalog.rename_collection`` shadow events preserve
+  ``alias_of`` from the renamed row (was: hardcoded ``""``).
+- M5: ``Projector._v0_document_aliased`` rejects self-alias.
+- M8: ``doctor --strict-not-in-t3`` without ``--t3-doc-id-coverage``
+  is a UsageError, not a silent no-op.
+- M8b: JSON payload includes ``strict_not_in_t3: bool`` for auditability.
+- M9: ``repair-orphan-chunks --assign`` preserves the orphan's
+  ``position`` / ``content_hash`` / ``embedded_at`` on the corrective
+  event (was: hardcoded ``position=0``).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.projector import Projector
+from nexus.commands.catalog import (
+    doctor_cmd,
+    repair_orphan_chunks_cmd,
+    synthesize_log_cmd,
+)
+
+
+# ── M1: shadow emit failure does not abort catalog mutation ───────────────
+
+
+class TestShadowEmitFailureNonFatal:
+    """A bad payload (datetime in meta) used to silently coerce via
+    default=str (silent corruption); after PR #427 it raised TypeError
+    which propagated out of the catalog mutator and left SQLite +
+    legacy JSONL committed but events.jsonl write failed. This fix
+    catches broadly so the catalog mutation still completes.
+    """
+
+    def test_typeerror_in_emit_does_not_abort_mutation(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+
+        # Force _emit_shadow_event to raise via a poisoned to_dict.
+        # We do this by replacing make_event's output with an event
+        # whose to_dict raises TypeError unconditionally.
+        captured: list = []
+        original_emit = cat._emit_shadow_event
+
+        def _poisoned_emit(event):
+            class _Bad:
+                type = event.type
+                def to_dict(self_inner):
+                    raise TypeError("simulated non-JSON-native payload")
+            captured.append(event.type)
+            return original_emit(_Bad())
+
+        # First test: register_owner with poisoned emit. Mutation
+        # should still succeed; events.jsonl should be empty (the
+        # write failed before the file was opened).
+        monkeypatch.setattr(cat, "_emit_shadow_event", _poisoned_emit)
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        assert owner is not None  # mutation succeeded
+
+        # SQLite committed.
+        rows = cat._db.execute(
+            "SELECT name FROM owners WHERE tumbler_prefix = ?", (str(owner),),
+        ).fetchall()
+        assert rows == [("nexus",)]
+
+        # The poisoned emit was called; its inner TypeError did NOT
+        # propagate out of register_owner.
+        assert "OwnerRegistered" in captured
+
+
+# ── M2: --force preserve_doc_ids last-occurrence wins ─────────────────────
+
+
+class TestForcePreserveLastOccurrence:
+    """A tumbler tombstoned then re-registered should preserve the
+    LIVE (last) doc_id on --force, not the dead (first) one.
+    """
+
+    def test_resurrection_preserves_last_doc_id(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Hand-craft a prior events.jsonl with a tumbler that was
+        # registered with doc-A, deleted, then re-registered with doc-B.
+        # The live document is doc-B; that's what --force must preserve.
+        cat_dir = tmp_path / "test-catalog"
+        Catalog.init(cat_dir)
+        log = EventLog(cat_dir)
+        log.append_many([
+            ev.make_event(
+                ev.DocumentRegisteredPayload(
+                    doc_id="doc-A-dead",
+                    owner_id="1.1",
+                    content_type="prose",
+                    source_uri="file:///x.md",
+                    coll_id="docs__test",
+                    title="x.md",
+                    tumbler="1.1.1",
+                ),
+                v=0,
+            ),
+            ev.make_event(
+                ev.DocumentDeletedPayload(
+                    doc_id="doc-A-dead",
+                    reason="resurrection-test",
+                    tumbler="1.1.1",
+                ),
+                v=0,
+            ),
+            ev.make_event(
+                ev.DocumentRegisteredPayload(
+                    doc_id="doc-B-live",
+                    owner_id="1.1",
+                    content_type="prose",
+                    source_uri="file:///x.md",
+                    coll_id="docs__test",
+                    title="x.md",
+                    tumbler="1.1.1",
+                ),
+                v=0,
+            ),
+        ])
+
+        # Add a documents.jsonl row so the synthesizer's
+        # _build_tumbler_to_doc_id has a tumbler to mint for. Its
+        # mint will be overridden by preserve_map (which we want to
+        # carry doc-B-live, not doc-A-dead).
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        # The register call uses owner=1.1 internally; verify by reading
+        # the tumbler. We need a tumbler matching the prior log's "1.1.1".
+        # To be robust, just register one document and find its tumbler.
+        new_doc = cat.register(
+            owner, "x.md", content_type="prose", file_path="x.md",
+        )
+        cat._db.close()
+        # preserve_map's behaviour is what matters; the tumbler in the
+        # prior log might not match the test's freshly-registered doc.
+        # Inject a synthetic prior log row matching the new doc's tumbler.
+        log = EventLog(cat_dir)
+        # Truncate + re-seed the prior log with the resurrection
+        # sequence keyed to the actual tumbler.
+        log.truncate()
+        log.append_many([
+            ev.make_event(
+                ev.DocumentRegisteredPayload(
+                    doc_id="doc-A-dead",
+                    owner_id=str(owner),
+                    content_type="prose",
+                    source_uri="file:///x.md",
+                    coll_id="docs__test",
+                    title="x.md",
+                    tumbler=str(new_doc),
+                ),
+                v=0,
+            ),
+            ev.make_event(
+                ev.DocumentRegisteredPayload(
+                    doc_id="doc-B-live",
+                    owner_id=str(owner),
+                    content_type="prose",
+                    source_uri="file:///x.md",
+                    coll_id="docs__test",
+                    title="x.md",
+                    tumbler=str(new_doc),
+                ),
+                v=0,
+            ),
+        ])
+
+        runner = CliRunner()
+        result = runner.invoke(synthesize_log_cmd, ["--force", "--json"])
+        assert result.exit_code == 0, result.output
+
+        # Replay: the new events.jsonl's DocumentRegistered for
+        # tumbler new_doc must carry doc_id == doc-B-live (the LAST
+        # occurrence in the prior log), not doc-A-dead.
+        replayed = list(log.replay())
+        registered_for_new_doc = [
+            e for e in replayed
+            if e.type == ev.TYPE_DOCUMENT_REGISTERED
+            and e.payload.tumbler == str(new_doc)
+        ]
+        assert len(registered_for_new_doc) == 1
+        assert registered_for_new_doc[0].payload.doc_id == "doc-B-live"
+
+
+# ── M3: _v0_document_renamed uses tumbler fallback ────────────────────────
+
+
+class TestV0DocumentRenamedUsesTumbler:
+    def test_rename_with_uuid7_doc_id_falls_back_to_tumbler(self, tmp_path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        db.execute(
+            "INSERT INTO documents "
+            "(tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, "
+            "indexed_at, metadata, source_mtime, source_uri) "
+            "VALUES ('1.7.42', 'doc', '', 0, '', '', '', '', 0, '', '', "
+            "'{}', 0, 'file:///old.py')"
+        )
+        db.commit()
+
+        proj = Projector(db)
+        proj.apply(ev.Event(
+            type=ev.TYPE_DOCUMENT_RENAMED, v=0,
+            payload=ev.DocumentRenamedPayload(
+                doc_id="019de2fc-2b2a-7bc4-9d84-6d0c17d2357e",
+                new_source_uri="file:///new.py",
+                tumbler="1.7.42",
+            ),
+            ts="t",
+        ))
+        db.commit()
+
+        row = db.execute(
+            "SELECT source_uri FROM documents WHERE tumbler = ?",
+            ("1.7.42",),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "file:///new.py", (
+            "Pre-fix the projector used WHERE tumbler=<UUID7> and the "
+            "rename silently no-oped. Post-fix tumbler-or-doc_id falls "
+            "back to the tumbler field."
+        )
+        db.close()
+
+    def test_rename_falls_back_to_doc_id_when_tumbler_empty(self, tmp_path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        db.execute(
+            "INSERT INTO documents "
+            "(tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, "
+            "indexed_at, metadata, source_mtime, source_uri) "
+            "VALUES ('1.7.42', 'doc', '', 0, '', '', '', '', 0, '', '', "
+            "'{}', 0, 'file:///old.py')"
+        )
+        db.commit()
+
+        proj = Projector(db)
+        proj.apply(ev.Event(
+            type=ev.TYPE_DOCUMENT_RENAMED, v=0,
+            payload=ev.DocumentRenamedPayload(
+                doc_id="1.7.42",
+                new_source_uri="file:///new.py",
+            ),
+            ts="t",
+        ))
+        db.commit()
+
+        row = db.execute(
+            "SELECT source_uri FROM documents WHERE tumbler = ?",
+            ("1.7.42",),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "file:///new.py"
+        db.close()
+
+
+# ── M4: rename_collection preserves alias_of ──────────────────────────────
+
+
+class TestRenameCollectionPreservesAliasOf:
+    def test_aliased_doc_keeps_alias_of_after_rename(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        canonical = cat.register(
+            owner, "canonical.md", content_type="prose",
+            file_path="canonical.md",
+            physical_collection="docs__old",
+        )
+        alias = cat.register(
+            owner, "alias.md", content_type="prose",
+            file_path="alias.md",
+            physical_collection="docs__old",
+        )
+        cat.set_alias(alias, canonical)
+
+        # Confirm alias_of is set in the live SQLite before rename.
+        before = cat._db.execute(
+            "SELECT alias_of FROM documents WHERE tumbler = ?",
+            (str(alias),),
+        ).fetchone()
+        assert before[0] == str(canonical)
+
+        cat.rename_collection("docs__old", "docs__new")
+
+        # Replay events.jsonl into a fresh CatalogDB. The alias row's
+        # alias_of must survive the rename; pre-fix the rename's emit
+        # hardcoded alias_of="" and replay broke the alias graph.
+        log = EventLog(d)
+        proj_db = CatalogDB(tmp_path / "projected.db")
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        with sqlite3.connect(str(tmp_path / "projected.db")) as pc:
+            row = pc.execute(
+                "SELECT alias_of, physical_collection FROM documents "
+                "WHERE tumbler = ?",
+                (str(alias),),
+            ).fetchone()
+        assert row is not None
+        assert row[0] == str(canonical), (
+            f"alias_of lost after rename_collection replay: {row[0]!r}"
+        )
+        assert row[1] == "docs__new"
+
+
+# ── M5: _v0_document_aliased rejects self-alias ───────────────────────────
+
+
+class TestV0DocumentAliasedRejectsSelfAlias:
+    def test_self_alias_is_silent_noop(self, tmp_path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        db.execute(
+            "INSERT INTO documents "
+            "(tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, "
+            "indexed_at, metadata, source_mtime, source_uri) "
+            "VALUES ('1.1.1', 'doc', '', 0, '', '', '', '', 0, '', '', "
+            "'{}', 0, '')"
+        )
+        db.commit()
+
+        proj = Projector(db)
+        proj.apply(ev.Event(
+            type=ev.TYPE_DOCUMENT_ALIASED, v=0,
+            payload=ev.DocumentAliasedPayload(
+                alias_doc_id="1.1.1",
+                canonical_doc_id="1.1.1",  # self-alias — bad event
+            ),
+            ts="t",
+        ))
+        db.commit()
+
+        row = db.execute(
+            "SELECT alias_of FROM documents WHERE tumbler = ?",
+            ("1.1.1",),
+        ).fetchone()
+        # Pre-fix the projector would write alias_of="1.1.1" (self),
+        # creating a 1-cycle in the alias graph.
+        assert row[0] == "", (
+            f"Self-alias should be rejected; got alias_of={row[0]!r}"
+        )
+        db.close()
+
+
+# ── M8: --strict-not-in-t3 requires --t3-doc-id-coverage ──────────────────
+
+
+class TestStrictNotInT3RequiresCoverageFlag:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_strict_without_coverage_is_usage_error(self, tmp_path, runner):
+        from nexus.catalog.catalog import Catalog as _Cat
+        cat_dir = tmp_path / "test-catalog"
+        _Cat.init(cat_dir)
+
+        result = runner.invoke(
+            doctor_cmd,
+            ["--replay-equality", "--strict-not-in-t3"],
+        )
+        # Pre-fix this was a silent no-op; the strict flag was simply
+        # ignored when --t3-doc-id-coverage wasn't passed. Post-fix it
+        # raises a UsageError so an operator can see the dependency.
+        assert result.exit_code != 0
+        assert "strict-not-in-t3 requires" in result.output.lower() or (
+            "strict-not-in-t3 requires" in (result.stderr or "").lower()
+        )
+
+
+# ── M8b: JSON payload includes strict_not_in_t3 ───────────────────────────
+
+
+class TestStrictModeAuditableInJson:
+    """The per-collection ``pass`` reflects strict-vs-default mode, but
+    a JSON consumer reading historical reports cannot tell which mode
+    produced the result without the explicit field."""
+
+    def test_strict_flag_surfaced_in_json_payload(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        import chromadb
+
+        client = chromadb.EphemeralClient()
+        for c in list(client.list_collections()):
+            try:
+                client.delete_collection(c.name)
+            except Exception:
+                pass
+
+        cat_dir = tmp_path / "test-catalog"
+        Catalog.init(cat_dir)
+        log = EventLog(cat_dir)
+        log.append([
+            ev.Event(
+                type=ev.TYPE_CHUNK_INDEXED, v=0,
+                payload=ev.ChunkIndexedPayload(
+                    chunk_id="c1", chash="h", doc_id="uuid-A",
+                    coll_id="code__test", position=0,
+                ),
+                ts="t",
+            ),
+        ][0])
+        from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+        col = client.get_or_create_collection(
+            "code__test", embedding_function=DefaultEmbeddingFunction(),
+        )
+        col.add(
+            ids=["c1"], documents=["x"],
+            metadatas=[{"doc_id": "uuid-A"}],
+        )
+
+        class _FakeT3:
+            _client = client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        runner = CliRunner()
+        # Default mode.
+        r1 = runner.invoke(doctor_cmd, ["--t3-doc-id-coverage", "--json"])
+        p1 = json.loads(r1.output)["t3_doc_id_coverage"]
+        assert p1["strict_not_in_t3"] is False
+
+        # Strict mode.
+        r2 = runner.invoke(
+            doctor_cmd,
+            ["--t3-doc-id-coverage", "--strict-not-in-t3", "--json"],
+        )
+        p2 = json.loads(r2.output)["t3_doc_id_coverage"]
+        assert p2["strict_not_in_t3"] is True
+
+
+# ── M9: repair --assign preserves position / content_hash ─────────────────
+
+
+class TestRepairAssignPreservesPosition:
+    def test_position_carried_to_corrective_event(self, tmp_path):
+        cat_dir = tmp_path / "test-catalog"
+        Catalog.init(cat_dir)
+        log = EventLog(cat_dir)
+        log.append(ev.Event(
+            type=ev.TYPE_CHUNK_INDEXED, v=0,
+            payload=ev.ChunkIndexedPayload(
+                chunk_id="orph1", chash="hash1", doc_id="",
+                coll_id="code__test", position=42,
+                content_hash="contenthash1",
+                embedded_at="2026-04-30T12:00:00Z",
+                synthesized_orphan=True,
+            ),
+            ts="t",
+        ))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            repair_orphan_chunks_cmd,
+            ["--assign", "orph1:doc-uuid-A", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+
+        events = list(log.replay())
+        corrective = events[-1]
+        assert corrective.type == ev.TYPE_CHUNK_INDEXED
+        assert corrective.payload.chunk_id == "orph1"
+        assert corrective.payload.synthesized_orphan is False
+        assert corrective.payload.doc_id == "doc-uuid-A"
+        # Pre-fix position was hardcoded to 0 — the orphan's position
+        # was lost on repair. Post-fix it carries through.
+        assert corrective.payload.position == 42
+        assert corrective.payload.content_hash == "contenthash1"
+        assert corrective.payload.embedded_at == "2026-04-30T12:00:00Z"


### PR DESCRIPTION
## Summary

Six parallel reviewers of PRs #427 and #428 found **4 genuine correctness bugs** and **5 quality issues** in the FIX surface itself. This PR addresses all of them.

### Critical (4 — would bite production)

- **M1**: `_emit_shadow_event` wraps the file write in try/except so a `TypeError` from a non-JSON-native payload value does not abort the catalog mutation. Pre-fix removal of `default=str` (PR #427's I-events-1) converted silent corruption into a loud crash that left the catalog in a split state. Post-fix the shadow path is best-effort.
- **M2**: `synthesize-log --force` `preserve_doc_ids` now uses last-occurrence-wins (was: first-wins). Resurrected tumblers preserve the LIVE doc_id; conflicts surface a structured-log warning before overwrite.
- **M3**: `Projector._v0_document_renamed` mirrors PR #427's `_v0_document_deleted` fix — uses `payload.tumbler or payload.doc_id` for the WHERE clause. `DocumentRenamedPayload` gains an optional `tumbler` field.
- **M4**: `Catalog.rename_collection` preserves `alias_of` across the rename (SELECT extended, JSONL + shadow event carry it through). Pre-fix any aliased document being renamed had its alias silently severed on event-log replay.

### Important (5)

- **M5**: `_v0_document_aliased` rejects self-alias as a second line of defense (Catalog.set_alias already rejects at the public API).
- **M6**: `rename_collection`'s local `owner_addr_for` lambda replaced with the synthesizer's `_owner_prefix_of` helper — pre-fix divergence on malformed tumblers.
- **M7**: `rename_collection` emit loop hoisted behind a shadow-gate check; a 10k-row rename with shadow OFF no longer pays the per-row payload-construction cost.
- **M8**: `doctor --strict-not-in-t3` without `--t3-doc-id-coverage` is now a `UsageError` (was: silent no-op).
- **M8b**: JSON payload of `doctor --t3-doc-id-coverage` now includes `strict_not_in_t3: bool` for auditability.
- **M9**: `repair-orphan-chunks --assign` preserves the orphan's `position` / `content_hash` / `embedded_at` on the corrective event (was: hardcoded `position=0`).

### Test plan (9 new tests)

- [x] `TestShadowEmitFailureNonFatal::test_typeerror_in_emit_does_not_abort_mutation` — M1.
- [x] `TestForcePreserveLastOccurrence::test_resurrection_preserves_last_doc_id` — M2.
- [x] `TestV0DocumentRenamedUsesTumbler` (2 tests: UUID7 + fallback) — M3.
- [x] `TestRenameCollectionPreservesAliasOf::test_aliased_doc_keeps_alias_of_after_rename` — M4.
- [x] `TestV0DocumentAliasedRejectsSelfAlias::test_self_alias_is_silent_noop` — M5.
- [x] `TestStrictNotInT3RequiresCoverageFlag::test_strict_without_coverage_is_usage_error` — M8.
- [x] `TestStrictModeAuditableInJson::test_strict_flag_surfaced_in_json_payload` — M8b.
- [x] `TestRepairAssignPreservesPosition::test_position_carried_to_corrective_event` — M9.
- [x] 504 tests passing across catalog + Phase 1 + Phase 2 + correctness + hardening + meta-review modules; one pre-existing `test_collection_audit` flake unrelated.
- [ ] CI green.

### Refs

- 6 parallel `nx:code-review-expert` agents reviewing PRs #427 / #428.
- Each fix maps to a specific reviewer finding in the commit message.

Bead: `nexus-thut`.