### PR TITLE
rdr-101(phase3): event-sourced register path (gated, opt-in)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -460,3 +460,5 @@
 {"id":"int-08308fda","kind":"field_change","created_at":"2026-05-01T10:06:07.73708Z","actor":"Hellblazer","issue_id":"nexus-kpgy","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-0e48680b","kind":"field_change","created_at":"2026-05-01T10:13:16.455931Z","actor":"Hellblazer","issue_id":"nexus-kpgy","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-f1a5b682","kind":"field_change","created_at":"2026-05-01T10:30:53.767253Z","actor":"Hellblazer","issue_id":"nexus-thut","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-193ae308","kind":"field_change","created_at":"2026-05-01T10:38:24.694099Z","actor":"Hellblazer","issue_id":"nexus-thut","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-6f3d2448","kind":"field_change","created_at":"2026-05-01T10:47:01.136602Z","actor":"Hellblazer","issue_id":"nexus-8t7z","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -25,9 +25,26 @@ if TYPE_CHECKING:
 # convention used elsewhere in the codebase (1/true/yes/on).
 _SHADOW_EMIT_ENV = "NEXUS_EVENT_LOG_SHADOW"
 
+# RDR-101 Phase 3 PR α: event-sourced write path gate. When ON, the
+# new path inverts the JSONL+SQLite write order: emit DocumentRegistered
+# event FIRST, project to SQLite via Projector.apply, then append to
+# legacy documents.jsonl for back-compat (Phase 5 deprecates legacy
+# JSONL). When OFF (default), the legacy direct-write path runs and
+# shadow emit (PR F) optionally appends to events.jsonl after the fact.
+#
+# Default off so the gate flip is a deliberate operator action. The
+# IRREVERSIBILITY WINDOW (RDR-101 §Migration / Phase 3) only starts
+# when this default flips on, which is a later sub-PR in Phase 3.
+_EVENT_SOURCED_ENV = "NEXUS_EVENT_SOURCED"
+
 
 def _read_shadow_gate() -> bool:
     val = os.environ.get(_SHADOW_EMIT_ENV, "").strip().lower()
+    return val in ("1", "true", "yes", "on")
+
+
+def _read_event_sourced_gate() -> bool:
+    val = os.environ.get(_EVENT_SOURCED_ENV, "").strip().lower()
     return val in ("1", "true", "yes", "on")
 
 
@@ -451,6 +468,12 @@ class Catalog:
         # this log; Phase 1 only shadow-emits when an operator opts in.
         self._events_path = catalog_dir / "events.jsonl"
         self._shadow_emit_enabled = _read_shadow_gate()
+        # RDR-101 Phase 3 PR α (nexus-8t7z): event-sourced write path
+        # gate. Off by default; opt in via NEXUS_EVENT_SOURCED=1. When
+        # both gates are on, the event-sourced path takes precedence
+        # and shadow emit is unused (the new path emits to events.jsonl
+        # by construction).
+        self._event_sourced_enabled = _read_event_sourced_gate()
         self.degraded: bool = False
         # Storage review S-4: mtime cache so every Catalog() instantiation
         # doesn't re-parse the full JSONL corpus and re-build the SQLite
@@ -631,6 +654,24 @@ class Catalog:
 
     # ── RDR-101 Phase 1 PR F: shadow event-log emit ─────────────────────
 
+    def _write_to_event_log(self, event: "_Event") -> None:
+        """Append ``event`` to ``events.jsonl`` unconditionally.
+
+        Caller MUST hold the catalog directory flock and MUST handle
+        TypeError / OSError; this helper does no error suppression
+        (compare ``_emit_shadow_event``, which is best-effort).
+
+        The Phase 3 event-sourced write path uses this helper because
+        the event log IS the canonical source of truth — a failure to
+        append must abort the write, not be silently swallowed.
+        """
+        if not self._events_path.exists():
+            self._events_path.touch()
+        line = json.dumps(event.to_dict(), separators=(",", ":"))
+        with self._events_path.open("a") as f:
+            f.write(line)
+            f.write("\n")
+
     def _emit_shadow_event(self, event: "_Event") -> None:
         """Append ``event`` to ``events.jsonl`` if shadow emit is enabled.
 
@@ -663,13 +704,13 @@ class Catalog:
         """
         if not self._shadow_emit_enabled:
             return
+        # Skip shadow emit when the event-sourced path is on — the new
+        # path writes the same event via _write_to_event_log already,
+        # and a duplicate emit would write the line twice.
+        if self._event_sourced_enabled:
+            return
         try:
-            if not self._events_path.exists():
-                self._events_path.touch()
-            line = json.dumps(event.to_dict(), separators=(",", ":"))
-            with self._events_path.open("a") as f:
-                f.write(line)
-                f.write("\n")
+            self._write_to_event_log(event)
         except Exception as exc:
             event_type = getattr(event, "type", "?")
             _log.warning(
@@ -716,15 +757,7 @@ class Catalog:
                 description=description,
                 repo_root=repo_root,
             )
-            self._append_jsonl(self._owners_path, rec.__dict__)
-            # Upsert SQLite
-            self._db.execute(
-                "INSERT OR REPLACE INTO owners (tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (prefix, name, owner_type, repo_hash, description, repo_root),
-            )
-            self._db.commit()
-            self._emit_shadow_event(_make_event(
+            event = _make_event(
                 _OwnerRegisteredPayload(
                     owner_id=prefix,
                     name=name,
@@ -734,7 +767,25 @@ class Catalog:
                     description=description,
                 ),
                 v=0,
-            ))
+            )
+            if self._event_sourced_enabled:
+                # Event-sourced path: events.jsonl first, projector
+                # writes SQLite, legacy JSONL last for back-compat.
+                self._write_to_event_log(event)
+                from nexus.catalog.projector import Projector as _Projector
+                _Projector(self._db).apply(event)
+                self._db.commit()
+                self._append_jsonl(self._owners_path, rec.__dict__)
+            else:
+                self._append_jsonl(self._owners_path, rec.__dict__)
+                # Upsert SQLite
+                self._db.execute(
+                    "INSERT OR REPLACE INTO owners (tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (prefix, name, owner_type, repo_hash, description, repo_root),
+                )
+                self._db.commit()
+                self._emit_shadow_event(event)
             return Tumbler.parse(prefix)
         finally:
             self._release_lock(dir_fd)
@@ -932,21 +983,7 @@ class Catalog:
                 source_mtime=source_mtime,
                 source_uri=source_uri,
             )
-            self._append_jsonl(self._documents_path, rec.__dict__)
-            self._db.execute(
-                "INSERT INTO documents "
-                "(tumbler, title, author, year, content_type, file_path, "
-                "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
-                "metadata, source_mtime, source_uri) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    str(tumbler), title, author, year, content_type, file_path,
-                    corpus, physical_collection, chunk_count, head_hash, now,
-                    json.dumps(meta or {}), source_mtime, source_uri,
-                ),
-            )
-            self._db.commit()
-            self._emit_shadow_event(_make_event(
+            event = _make_event(
                 _DocumentRegisteredPayload(
                     # Phase 1 stand-in: tumbler doubles as doc_id until
                     # Phase 3 mints UUID7 doc_ids via the new write path.
@@ -972,7 +1009,37 @@ class Catalog:
                     meta=dict(meta or {}),
                 ),
                 v=0,
-            ))
+            )
+
+            if self._event_sourced_enabled:
+                # RDR-101 Phase 3 PR α — event-sourced write path.
+                # Order is inverted: events.jsonl FIRST, then SQLite
+                # via the projector, then legacy documents.jsonl for
+                # back-compat. The event log is canonical; SQLite is a
+                # deterministic projection of it.
+                self._write_to_event_log(event)
+                from nexus.catalog.projector import Projector as _Projector
+                _Projector(self._db).apply(event)
+                self._db.commit()
+                self._append_jsonl(self._documents_path, rec.__dict__)
+            else:
+                # Legacy direct-write path. Shadow emit (PR F) optionally
+                # writes the event AFTER the SQLite + JSONL commits.
+                self._append_jsonl(self._documents_path, rec.__dict__)
+                self._db.execute(
+                    "INSERT INTO documents "
+                    "(tumbler, title, author, year, content_type, file_path, "
+                    "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+                    "metadata, source_mtime, source_uri) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        str(tumbler), title, author, year, content_type, file_path,
+                        corpus, physical_collection, chunk_count, head_hash, now,
+                        json.dumps(meta or {}), source_mtime, source_uri,
+                    ),
+                )
+                self._db.commit()
+                self._emit_shadow_event(event)
             return tumbler
         finally:
             self._release_lock(dir_fd)

--- a/tests/test_catalog_event_sourced_register.py
+++ b/tests/test_catalog_event_sourced_register.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 3 PR α event-sourced register path.
+
+Coverage:
+- Gate parsing: 1/true/yes/on → ON; 0/false/no/off/unset → OFF.
+- Default (gate OFF): legacy direct-write path runs unchanged.
+- Gate ON: register_owner / register write events.jsonl FIRST, then
+  project to SQLite via Projector.apply, then append to legacy JSONL
+  for back-compat.
+- Equivalence: a sequence of register() calls under the new path
+  produces a SQLite state byte-equal to the same sequence under the
+  legacy path.
+- Replay: events.jsonl produced by the new path replays through a
+  fresh CatalogDB to a state byte-equal to the live DB.
+- Shadow emit suppression: when event-sourced is ON, shadow emit does
+  NOT double-write (would otherwise produce duplicate events.jsonl
+  lines).
+- Idempotency: register() under the new path keeps the same idempotency
+  guards (file_path dedup, head_hash+title dedup).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import (
+    Catalog,
+    _read_event_sourced_gate,
+)
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.projector import Projector
+
+
+# ── Gate parsing ─────────────────────────────────────────────────────────
+
+
+class TestEventSourcedGate:
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "ON"])
+    def test_on_values(self, monkeypatch: pytest.MonkeyPatch, val: str):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", val)
+        assert _read_event_sourced_gate() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_off_values(self, monkeypatch: pytest.MonkeyPatch, val: str):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", val)
+        assert _read_event_sourced_gate() is False
+
+    def test_unset_is_off(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        assert _read_event_sourced_gate() is False
+
+
+# ── Default (gate OFF) — legacy behaviour unchanged ──────────────────────
+
+
+class TestLegacyPathStillRuns:
+    def test_register_does_not_write_events_jsonl_by_default(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        cat.register(owner, "doc.md", content_type="prose", file_path="doc.md")
+
+        # events.jsonl either doesn't exist or is empty.
+        events_path = d / "events.jsonl"
+        if events_path.exists():
+            assert events_path.read_text() == ""
+
+        # SQLite + JSONL still written.
+        rows = cat._db.execute("SELECT count(*) FROM documents").fetchone()
+        assert rows[0] == 1
+
+
+# ── Gate ON — event-sourced path ─────────────────────────────────────────
+
+
+class TestEventSourcedPathWrites:
+    def test_register_owner_writes_event_log_first(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        cat.register_owner("nexus", "repo", repo_hash="abab")
+
+        # events.jsonl has one OwnerRegistered event.
+        log = EventLog(d)
+        events = list(log.replay())
+        assert len(events) == 1
+        assert events[0].type == ev.TYPE_OWNER_REGISTERED
+        assert events[0].payload.name == "nexus"
+
+        # SQLite has the row (via projector).
+        row = cat._db.execute(
+            "SELECT name, owner_type, repo_hash FROM owners "
+            "WHERE tumbler_prefix = ?", ("1.1",),
+        ).fetchone()
+        assert row == ("nexus", "repo", "abab")
+
+        # Legacy JSONL also written for back-compat.
+        owners_jsonl = (d / "owners.jsonl").read_text()
+        assert "nexus" in owners_jsonl
+
+    def test_register_writes_event_log_first(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "doc.md",
+            content_type="prose",
+            file_path="doc.md",
+            chunk_count=12,
+            head_hash="aaaa1111",
+        )
+
+        log = EventLog(d)
+        events = list(log.replay())
+        assert len(events) == 2
+        assert events[0].type == ev.TYPE_OWNER_REGISTERED
+        assert events[1].type == ev.TYPE_DOCUMENT_REGISTERED
+        p = events[1].payload
+        assert p.tumbler == str(tumbler)
+        assert p.title == "doc.md"
+        assert p.chunk_count == 12
+
+        # SQLite has the row.
+        row = cat._db.execute(
+            "SELECT title, chunk_count, head_hash FROM documents "
+            "WHERE tumbler = ?", (str(tumbler),),
+        ).fetchone()
+        assert row == ("doc.md", 12, "aaaa1111")
+
+
+# ── Equivalence: new path ≡ legacy path ──────────────────────────────────
+
+
+class TestEquivalence:
+    """A sequence of mutations under the new path produces a SQLite
+    state byte-equal to the same sequence under the legacy path."""
+
+    def _build_catalog(
+        self, tmp_path: Path, name: str, event_sourced: bool,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> Path:
+        if event_sourced:
+            monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        else:
+            monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        d = tmp_path / name
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner(
+            "nexus", "repo", repo_hash="571b8edd",
+            description="Test repo",
+        )
+        cat.register(
+            owner, "a.md", content_type="prose", file_path="a.md",
+            chunk_count=3, head_hash="a1",
+        )
+        cat.register(
+            owner, "b.md", content_type="prose", file_path="b.md",
+            chunk_count=7, head_hash="b1",
+        )
+        cat._db.close()
+        return d / ".catalog.db"
+
+    def _snap(self, db_path: Path) -> dict[str, list[tuple]]:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            return {
+                "owners": sorted(conn.execute(
+                    "SELECT tumbler_prefix, name, owner_type, repo_hash, "
+                    "description, repo_root FROM owners"
+                ).fetchall()),
+                "documents": sorted(conn.execute(
+                    "SELECT tumbler, title, author, year, content_type, "
+                    "file_path, corpus, physical_collection, chunk_count, "
+                    "head_hash, indexed_at, metadata, source_mtime, "
+                    "alias_of, source_uri FROM documents"
+                ).fetchall()),
+            }
+        finally:
+            conn.close()
+
+    def test_legacy_and_event_sourced_produce_same_sqlite(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        legacy_db = self._build_catalog(
+            tmp_path, "legacy", event_sourced=False, monkeypatch=monkeypatch,
+        )
+        es_db = self._build_catalog(
+            tmp_path, "event_sourced", event_sourced=True, monkeypatch=monkeypatch,
+        )
+
+        legacy_snap = self._snap(legacy_db)
+        es_snap = self._snap(es_db)
+
+        # owners are byte-equal
+        assert legacy_snap["owners"] == es_snap["owners"]
+
+        # documents are byte-equal modulo indexed_at (ISO timestamps).
+        # Strip the timestamp column for comparison.
+        def _strip_ts(rows):
+            # indexed_at is column index 10
+            return [r[:10] + r[11:] for r in rows]
+
+        assert _strip_ts(legacy_snap["documents"]) == _strip_ts(
+            es_snap["documents"]
+        )
+
+
+# ── Replay: events.jsonl produced by new path projects to same SQLite ────
+
+
+class TestNewPathReplays:
+    def test_events_jsonl_replay_matches_live_sqlite(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        cat.register(owner, "a.md", content_type="prose", file_path="a.md")
+        cat.register(owner, "b.md", content_type="prose", file_path="b.md")
+
+        # Replay events.jsonl into a fresh CatalogDB.
+        log = EventLog(d)
+        proj_db = CatalogDB(tmp_path / "projected.db")
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        # Both DBs must have the same owners + documents rows.
+        with sqlite3.connect(str(d / ".catalog.db")) as live:
+            live_owners = sorted(live.execute(
+                "SELECT tumbler_prefix, name FROM owners"
+            ).fetchall())
+            live_docs = sorted(live.execute(
+                "SELECT tumbler, title FROM documents"
+            ).fetchall())
+        with sqlite3.connect(str(tmp_path / "projected.db")) as proj:
+            proj_owners = sorted(proj.execute(
+                "SELECT tumbler_prefix, name FROM owners"
+            ).fetchall())
+            proj_docs = sorted(proj.execute(
+                "SELECT tumbler, title FROM documents"
+            ).fetchall())
+        assert live_owners == proj_owners
+        assert live_docs == proj_docs
+
+
+# ── Shadow emit suppression when event-sourced is ON ─────────────────────
+
+
+class TestShadowEmitSuppressedWhenEventSourced:
+    def test_no_double_write_when_both_gates_on(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Both gates on. The event-sourced path should write the event
+        # once via _write_to_event_log; shadow emit should NOT write a
+        # second copy after the SQLite commit.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        cat.register_owner("nexus", "repo", repo_hash="abab")
+
+        log = EventLog(d)
+        events = list(log.replay())
+        # Exactly ONE OwnerRegistered (not two).
+        assert len(events) == 1
+        assert events[0].type == ev.TYPE_OWNER_REGISTERED
+
+
+# ── Idempotency under the new path ───────────────────────────────────────
+
+
+class TestIdempotencyUnderEventSourced:
+    def test_register_same_file_path_twice_returns_same_tumbler(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        first = cat.register(
+            owner, "doc.md", content_type="prose", file_path="doc.md",
+        )
+        second = cat.register(
+            owner, "doc.md", content_type="prose", file_path="doc.md",
+        )
+        assert first == second
+        # Only one DocumentRegistered in the log.
+        log = EventLog(d)
+        doc_events = [
+            e for e in log.replay()
+            if e.type == ev.TYPE_DOCUMENT_REGISTERED
+        ]
+        assert len(doc_events) == 1


### PR DESCRIPTION
## Summary

Phase 3 PR α of RDR-101. Adds ``NEXUS_EVENT_SOURCED`` env gate (default OFF) that, when on, inverts the JSONL+SQLite write order in ``Catalog.register_owner`` and ``Catalog.register``: **emit the typed event to ``events.jsonl`` FIRST, project to SQLite via ``Projector.apply``, then append to legacy JSONL for back-compat**.

When OFF (default), legacy behaviour is byte-for-byte unchanged.

### IRREVERSIBILITY WINDOW does NOT start with this PR

RDR-101 §Migration / Phase 3 says "Direct writes to the catalog SQLite outside the projector are prohibited from Phase 3 onward." That window starts when this gate's default flips on, which is a later sub-PR in Phase 3. This PR only ships the new path behind an opt-in flag so the foundation can be exercised on real workloads before commitment.

### Implementation

- ``_read_event_sourced_gate()`` reads ``NEXUS_EVENT_SOURCED`` at ``Catalog`` construction; cached in ``self._event_sourced_enabled``.
- New ``_write_to_event_log`` helper: unconditional ``events.jsonl`` append. Caller MUST hold the catalog flock and MUST handle exceptions (contrast with ``_emit_shadow_event``, which is best-effort and gated).
- ``_emit_shadow_event`` suppresses itself when event-sourced is ON to prevent duplicate writes.
- ``register_owner`` and ``register`` branch on the gate: ON uses the inverted write order; OFF is byte-for-byte unchanged.

### Subsequent PRs (β/γ/δ/ε)

Extend the gate to ``update`` / ``delete_document`` / ``link`` / ``unlink`` / ``set_alias`` / ``rename_collection``, audit and migrate external callers off direct ``cat._db.execute()`` patterns, add a lint/grep gate, and finally flip the default on.

### Test plan (18 new tests)

- [x] Gate parsing (5 ON values, 5 OFF values, unset = off).
- [x] Default OFF: legacy SQLite + JSONL unchanged; events.jsonl untouched.
- [x] Gate ON ``register_owner``: events.jsonl gets ``OwnerRegistered``; SQLite projects via ``Projector``; legacy ``owners.jsonl`` also written.
- [x] Gate ON ``register``: same flow, ``DocumentRegistered`` event with the right payload fields.
- [x] **Equivalence**: legacy + event-sourced paths produce byte-equal SQLite (modulo ``indexed_at`` timestamps).
- [x] **Replay**: ``events.jsonl`` produced by the new path projects to a fresh ``CatalogDB`` to the same state as the live DB.
- [x] **Shadow emit suppression**: both gates on does NOT double-write.
- [x] Idempotency under new path: re-register same ``file_path`` returns existing tumbler; one event in log.
- [x] 323 tests passing across catalog + Phase 1 + Phase 2 + remediation + Phase 3 PR α modules locally.
- [ ] CI green.

### Refs

- RDR-101 §Implementation Plan / Phase 3, §Migration / Phase 3

Bead: ``nexus-8t7z``.