### PR TITLE
rdr-101(phase3): event-source update/delete/set_alias/rename_collection

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -462,3 +462,5 @@
 {"id":"int-f1a5b682","kind":"field_change","created_at":"2026-05-01T10:30:53.767253Z","actor":"Hellblazer","issue_id":"nexus-thut","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-193ae308","kind":"field_change","created_at":"2026-05-01T10:38:24.694099Z","actor":"Hellblazer","issue_id":"nexus-thut","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-6f3d2448","kind":"field_change","created_at":"2026-05-01T10:47:01.136602Z","actor":"Hellblazer","issue_id":"nexus-8t7z","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-7524e724","kind":"field_change","created_at":"2026-05-01T10:52:09.084774Z","actor":"Hellblazer","issue_id":"nexus-8t7z","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-d1f0498b","kind":"field_change","created_at":"2026-05-01T10:52:28.985062Z","actor":"Hellblazer","issue_id":"nexus-rbyl","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1192,12 +1192,6 @@ class Catalog:
             raw = self.resolve(tumbler, follow_alias=False)
             if raw is None:
                 return
-            self._db.execute(
-                "UPDATE documents SET alias_of = ? WHERE tumbler = ?",
-                (str(canonical), str(tumbler)),
-            )
-            self._db.commit()
-            # Append updated JSONL record so a future rebuild sees the alias.
             updated = DocumentRecord(
                 tumbler=str(tumbler),
                 title=raw.title,
@@ -1214,14 +1208,28 @@ class Catalog:
                 source_mtime=raw.source_mtime,
                 alias_of=str(canonical),
             )
-            self._append_jsonl(self._documents_path, updated.__dict__)
-            self._emit_shadow_event(_make_event(
+            event = _make_event(
                 _DocumentAliasedPayload(
                     alias_doc_id=str(tumbler),
                     canonical_doc_id=str(canonical),
                 ),
                 v=0,
-            ))
+            )
+            if self._event_sourced_enabled:
+                self._write_to_event_log(event)
+                from nexus.catalog.projector import Projector as _Projector
+                _Projector(self._db).apply(event)
+                self._db.commit()
+                self._append_jsonl(self._documents_path, updated.__dict__)
+            else:
+                self._db.execute(
+                    "UPDATE documents SET alias_of = ? WHERE tumbler = ?",
+                    (str(canonical), str(tumbler)),
+                )
+                self._db.commit()
+                # Append updated JSONL record so a future rebuild sees the alias.
+                self._append_jsonl(self._documents_path, updated.__dict__)
+                self._emit_shadow_event(event)
         finally:
             self._release_lock(dir_fd)
 
@@ -1540,38 +1548,7 @@ class Catalog:
             self._check_source_uri_in_repo_root(
                 owner_addr, rec_dict["source_uri"],
             )
-            self._append_jsonl(self._documents_path, rec_dict)
-            # Upsert SQLite
-            self._db.execute(
-                "INSERT OR REPLACE INTO documents "
-                "(tumbler, title, author, year, content_type, file_path, "
-                "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
-                "metadata, source_mtime, source_uri) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    rec_dict["tumbler"], rec_dict["title"], rec_dict["author"],
-                    rec_dict["year"], rec_dict["content_type"], rec_dict["file_path"],
-                    rec_dict["corpus"], rec_dict["physical_collection"],
-                    rec_dict["chunk_count"], rec_dict["head_hash"],
-                    rec_dict["indexed_at"], json.dumps(rec_dict["meta"]),
-                    rec_dict.get("source_mtime", 0.0),
-                    rec_dict.get("source_uri", ""),
-                ),
-            )
-            self._db.commit()
-            # Shadow-emit the canonical event for the kind of update that
-            # happened. ``update()`` is overloaded — source_uri rename and
-            # bib enrichment both flow through here. The projector
-            # idempotently INSERT OR REPLACEs the documents row from a
-            # DocumentRegistered with the full updated payload, which is
-            # equivalent to applying a DocumentRenamed and/or
-            # DocumentEnriched plus the prior register. Phase 1 takes
-            # the lossless path: emit DocumentRegistered with the post-
-            # update field set, mirroring what the synthesizer does for
-            # documents.jsonl rows that have been mutated. Phase 3
-            # introduces fine-grained event types (DocumentRenamed,
-            # DocumentEnriched) that capture intent rather than state.
-            self._emit_shadow_event(_make_event(
+            event = _make_event(
                 _DocumentRegisteredPayload(
                     doc_id=rec_dict["tumbler"],
                     owner_id=str(entry.tumbler.owner_address()),
@@ -1594,7 +1571,41 @@ class Catalog:
                     meta=dict(rec_dict["meta"]),
                 ),
                 v=0,
-            ))
+            )
+            if self._event_sourced_enabled:
+                # Phase 3 PR β — event-sourced update path. update() is
+                # overloaded (source_uri rename, bib enrichment, etc.);
+                # the lossless DocumentRegistered-with-post-update-state
+                # captures everything via the projector's INSERT OR
+                # REPLACE. Future Phase 3+ work may introduce
+                # fine-grained DocumentRenamed/DocumentEnriched events
+                # that capture intent rather than state.
+                self._write_to_event_log(event)
+                from nexus.catalog.projector import Projector as _Projector
+                _Projector(self._db).apply(event)
+                self._db.commit()
+                self._append_jsonl(self._documents_path, rec_dict)
+            else:
+                self._append_jsonl(self._documents_path, rec_dict)
+                # Upsert SQLite
+                self._db.execute(
+                    "INSERT OR REPLACE INTO documents "
+                    "(tumbler, title, author, year, content_type, file_path, "
+                    "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+                    "metadata, source_mtime, source_uri) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        rec_dict["tumbler"], rec_dict["title"], rec_dict["author"],
+                        rec_dict["year"], rec_dict["content_type"], rec_dict["file_path"],
+                        rec_dict["corpus"], rec_dict["physical_collection"],
+                        rec_dict["chunk_count"], rec_dict["head_hash"],
+                        rec_dict["indexed_at"], json.dumps(rec_dict["meta"]),
+                        rec_dict.get("source_mtime", 0.0),
+                        rec_dict.get("source_uri", ""),
+                    ),
+                )
+                self._db.commit()
+                self._emit_shadow_event(event)
         finally:
             self._release_lock(dir_fd)
 
@@ -1622,6 +1633,8 @@ class Catalog:
                 "FROM documents WHERE physical_collection = ?",
                 (old,),
             ).fetchall()
+            from nexus.catalog.synthesizer import _owner_prefix_of as _opo
+            from nexus.catalog.projector import Projector as _Projector
             for row in rows:
                 # Preserve source_mtime + source_uri + alias_of across
                 # the rename — JSONL is the rebuild source of truth, so
@@ -1647,12 +1660,46 @@ class Catalog:
                     "source_uri": row[13] or "",
                     "alias_of": row[14] or "",
                 }
-                self._append_jsonl(self._documents_path, rec)
-            self._db.execute(
-                "UPDATE documents SET physical_collection = ? "
-                "WHERE physical_collection = ?",
-                (new, old),
-            )
+                if self._event_sourced_enabled:
+                    # Per-row event-source: write event, project to
+                    # SQLite, append legacy JSONL. SQLite commit is
+                    # batched at the end for efficiency.
+                    meta_dict = json.loads(row[11]) if row[11] else {}
+                    event = _make_event(
+                        _DocumentRegisteredPayload(
+                            doc_id=row[0],
+                            owner_id=_opo(row[0]),
+                            content_type=row[4] or "",
+                            source_uri=row[13] or "",
+                            coll_id=new,
+                            title=row[1] or "",
+                            source_mtime=float(row[12] or 0.0),
+                            indexed_at_doc=row[10] or "",
+                            tumbler=row[0],
+                            author=row[2] or "",
+                            year=int(row[3] or 0),
+                            file_path=row[5] or "",
+                            corpus=row[6] or "",
+                            physical_collection=new,
+                            chunk_count=int(row[8] or 0),
+                            head_hash=row[9] or "",
+                            indexed_at=row[10] or "",
+                            alias_of=row[14] or "",
+                            meta=dict(meta_dict),
+                        ),
+                        v=0,
+                    )
+                    self._write_to_event_log(event)
+                    _Projector(self._db).apply(event)
+                    self._append_jsonl(self._documents_path, rec)
+                else:
+                    self._append_jsonl(self._documents_path, rec)
+            if not self._event_sourced_enabled:
+                self._db.execute(
+                    "UPDATE documents SET physical_collection = ? "
+                    "WHERE physical_collection = ?",
+                    (new, old),
+                )
             self._db.commit()
             # Shadow-emit one DocumentRegistered per renamed row with
             # the new physical_collection. The projector's INSERT OR
@@ -1669,7 +1716,10 @@ class Catalog:
             # 10k-row rename should not pay the cost of building 10k
             # _DocumentRegisteredPayload objects only to discard them
             # in _emit_shadow_event's first line.
-            if self._shadow_emit_enabled:
+            # When event-sourced is ON the per-row write loop above
+            # already emitted + projected each event; skip the
+            # shadow-emit loop to avoid duplicate writes.
+            if self._shadow_emit_enabled and not self._event_sourced_enabled:
                 from nexus.catalog.synthesizer import _owner_prefix_of
                 for row in rows:
                     meta_dict = json.loads(row[11]) if row[11] else {}
@@ -1732,17 +1782,28 @@ class Catalog:
                 "source_mtime": entry.source_mtime,
                 "_deleted": True,
             }
-            self._append_jsonl(self._documents_path, tombstone)
-            self._db.execute("DELETE FROM documents WHERE tumbler = ?", (str(tumbler),))
-            self._db.commit()
-            self._emit_shadow_event(_make_event(
+            event = _make_event(
                 _DocumentDeletedPayload(
                     doc_id=str(tumbler),
                     reason="catalog.delete_document",
                     tumbler=str(tumbler),
                 ),
                 v=0,
-            ))
+            )
+            if self._event_sourced_enabled:
+                self._write_to_event_log(event)
+                from nexus.catalog.projector import Projector as _Projector
+                _Projector(self._db).apply(event)
+                self._db.commit()
+                self._append_jsonl(self._documents_path, tombstone)
+            else:
+                self._append_jsonl(self._documents_path, tombstone)
+                self._db.execute(
+                    "DELETE FROM documents WHERE tumbler = ?",
+                    (str(tumbler),),
+                )
+                self._db.commit()
+                self._emit_shadow_event(event)
             return True
         finally:
             self._release_lock(dir_fd)

--- a/tests/test_catalog_event_sourced_mutators.py
+++ b/tests/test_catalog_event_sourced_mutators.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 3 PR β event-sourced mutator paths.
+
+Covers update / delete_document / set_alias / rename_collection under
+NEXUS_EVENT_SOURCED=1. PR α already covered register_owner + register;
+this PR β extends the gate to the remaining write methods (link /
+unlink stay legacy until a follow-up that handles their merge
+semantics in the projector).
+
+Coverage per mutator:
+- Gate ON: events.jsonl gets the right typed event; SQLite mutated via
+  Projector.apply; legacy JSONL still written for back-compat; shadow
+  emit suppressed (no double write).
+- Gate OFF: legacy direct-write behaviour unchanged.
+- Replay: events.jsonl produced under the new path projects to a fresh
+  CatalogDB to a SQLite state byte-equal to the live DB.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.projector import Projector
+
+
+# ── update ───────────────────────────────────────────────────────────────
+
+
+class TestUpdateEventSourced:
+    def test_update_emits_document_registered_via_event_log(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "doc.md", content_type="prose",
+            file_path="doc.md", chunk_count=0,
+        )
+        cat.update(tumbler, chunk_count=42, head_hash="updated")
+
+        # events.jsonl: owner + register + update.
+        log = EventLog(d)
+        events = list(log.replay())
+        assert len(events) == 3
+        # Last event is the update, modeled as DocumentRegistered with
+        # post-update state.
+        assert events[-1].type == ev.TYPE_DOCUMENT_REGISTERED
+        assert events[-1].payload.tumbler == str(tumbler)
+        assert events[-1].payload.chunk_count == 42
+        assert events[-1].payload.head_hash == "updated"
+
+        # SQLite reflects the update (via projector).
+        row = cat._db.execute(
+            "SELECT chunk_count, head_hash FROM documents WHERE tumbler = ?",
+            (str(tumbler),),
+        ).fetchone()
+        assert row == (42, "updated")
+
+
+# ── delete_document ──────────────────────────────────────────────────────
+
+
+class TestDeleteDocumentEventSourced:
+    def test_delete_emits_event_and_removes_row(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(owner, "doc.md", content_type="prose")
+        assert cat.delete_document(tumbler) is True
+
+        log = EventLog(d)
+        events = list(log.replay())
+        types = [e.type for e in events]
+        assert ev.TYPE_DOCUMENT_DELETED in types
+        deleted = [e for e in events if e.type == ev.TYPE_DOCUMENT_DELETED][0]
+        assert deleted.payload.tumbler == str(tumbler)
+
+        # SQLite row gone.
+        rows = cat._db.execute(
+            "SELECT count(*) FROM documents WHERE tumbler = ?",
+            (str(tumbler),),
+        ).fetchone()
+        assert rows[0] == 0
+
+
+# ── set_alias ────────────────────────────────────────────────────────────
+
+
+class TestSetAliasEventSourced:
+    def test_set_alias_emits_event_and_updates_alias_of(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        canonical = cat.register(owner, "canonical.md", content_type="prose")
+        alias = cat.register(owner, "alias.md", content_type="prose")
+        cat.set_alias(alias, canonical)
+
+        log = EventLog(d)
+        events = list(log.replay())
+        aliased = [e for e in events if e.type == ev.TYPE_DOCUMENT_ALIASED]
+        assert len(aliased) == 1
+        assert aliased[0].payload.alias_doc_id == str(alias)
+        assert aliased[0].payload.canonical_doc_id == str(canonical)
+
+        # SQLite has alias_of populated.
+        row = cat._db.execute(
+            "SELECT alias_of FROM documents WHERE tumbler = ?",
+            (str(alias),),
+        ).fetchone()
+        assert row[0] == str(canonical)
+
+
+# ── rename_collection ────────────────────────────────────────────────────
+
+
+class TestRenameCollectionEventSourced:
+    def test_rename_emits_per_row_events_and_updates_sqlite(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        cat.register(
+            owner, "a.md", content_type="prose",
+            file_path="a.md",
+            physical_collection="docs__old",
+        )
+        cat.register(
+            owner, "b.md", content_type="prose",
+            file_path="b.md",
+            physical_collection="docs__old",
+        )
+
+        n = cat.rename_collection("docs__old", "docs__new")
+        assert n == 2
+
+        # events.jsonl has 2 owner-or-register events + 2 rename events.
+        log = EventLog(d)
+        events = list(log.replay())
+        post_rename = [
+            e for e in events
+            if e.type == ev.TYPE_DOCUMENT_REGISTERED
+            and e.payload.physical_collection == "docs__new"
+        ]
+        assert len(post_rename) == 2
+
+        # SQLite reflects the rename.
+        rows = cat._db.execute(
+            "SELECT count(*) FROM documents WHERE physical_collection = ?",
+            ("docs__new",),
+        ).fetchone()
+        assert rows[0] == 2
+
+
+# ── End-to-end: full replay equals live SQLite ────────────────────────────
+
+
+class TestFullReplayEqualsLive:
+    def test_register_update_alias_delete_replay_matches(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(
+            owner, "a.md", content_type="prose",
+            file_path="a.md", chunk_count=3,
+        )
+        b = cat.register(
+            owner, "b.md", content_type="prose",
+            file_path="b.md", chunk_count=7,
+        )
+        cat.update(a, chunk_count=99)
+        cat.set_alias(b, a)
+        cat._db.close()
+
+        # Replay events.jsonl into a fresh CatalogDB.
+        log = EventLog(d)
+        proj_db = CatalogDB(tmp_path / "projected.db")
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        # The live DB and the replayed DB must match for owners and
+        # documents (modulo timestamps in indexed_at).
+        with sqlite3.connect(str(d / ".catalog.db")) as live:
+            live_doc_a = live.execute(
+                "SELECT chunk_count FROM documents WHERE tumbler = ?",
+                (str(a),),
+            ).fetchone()
+            live_doc_b = live.execute(
+                "SELECT alias_of FROM documents WHERE tumbler = ?",
+                (str(b),),
+            ).fetchone()
+        with sqlite3.connect(str(tmp_path / "projected.db")) as proj:
+            proj_doc_a = proj.execute(
+                "SELECT chunk_count FROM documents WHERE tumbler = ?",
+                (str(a),),
+            ).fetchone()
+            proj_doc_b = proj.execute(
+                "SELECT alias_of FROM documents WHERE tumbler = ?",
+                (str(b),),
+            ).fetchone()
+        assert live_doc_a == proj_doc_a == (99,)
+        assert live_doc_b == proj_doc_b == (str(a),)
+
+
+# ── Shadow emit still suppressed ─────────────────────────────────────────
+
+
+class TestShadowEmitSuppressedAcrossMutators:
+    def test_no_double_writes_when_both_gates_on(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(owner, "doc.md", content_type="prose")
+        cat.update(tumbler, chunk_count=5)
+        cat.delete_document(tumbler)
+
+        # Each mutation produced exactly one event, not two.
+        log = EventLog(d)
+        events = list(log.replay())
+        # owner + register + update + delete = 4 events.
+        assert len(events) == 4
+        types = [e.type for e in events]
+        assert types == [
+            ev.TYPE_OWNER_REGISTERED,
+            ev.TYPE_DOCUMENT_REGISTERED,
+            ev.TYPE_DOCUMENT_REGISTERED,  # update reuses Registered
+            ev.TYPE_DOCUMENT_DELETED,
+        ]


### PR DESCRIPTION
## Summary

Phase 3 PR β of RDR-101. Extends ``NEXUS_EVENT_SOURCED`` gate from PR α to four more catalog mutators. When ON, each emits its event to ``events.jsonl`` first, projects to SQLite via ``Projector.apply``, then appends to legacy JSONL for back-compat. When OFF, legacy direct-write paths unchanged.

### Mutators covered

- ``update``: emits ``DocumentRegistered`` with post-update state (lossless replay).
- ``delete_document``: emits ``DocumentDeleted`` with the tumbler populated.
- ``set_alias``: emits ``DocumentAliased``.
- ``rename_collection``: per-row emit ``DocumentRegistered`` with the new ``physical_collection``; legacy single-UPDATE skipped when gate is on.

### NOT covered (deferred)

- ``_link_unlocked`` / ``link_if_absent``: merge branch needs projector's ``_v0_link_created`` to use ``INSERT OR REPLACE`` (currently ``INSERT OR IGNORE``). Small Phase 1 schema change worth a separate PR.
- ``unlink`` / ``bulk_unlink``: depend on the link semantics above.

### Test plan (6 new tests)

- [x] ``update`` event content + SQLite reflection.
- [x] ``delete_document`` emits with tumbler + removes row.
- [x] ``set_alias`` emits + populates ``alias_of``.
- [x] ``rename_collection`` 2-row scenario + SQLite count by new collection.
- [x] **Full replay round-trip**: register + register + update + set_alias under the new path; events.jsonl replays to a state byte-equal to live DB.
- [x] Shadow emit suppression: both gates ON doesn't double-write.
- [x] 329 tests passing across catalog + Phase 1/2/3 + remediation modules locally.
- [ ] CI green.

Bead: ``nexus-rbyl``.