### PR TITLE
fix(rdr-101): phase 3 round-3 correctness — link/unlink event-source, recovery, doctor, alias, projector cache

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -474,7 +474,29 @@ class Catalog:
         # and shadow emit is unused (the new path emits to events.jsonl
         # by construction).
         self._event_sourced_enabled = _read_event_sourced_gate()
+        # RDR-101 Phase 3 PR α/β: cache one Projector instance for the
+        # whole catalog lifetime. The projector is stateless (it only
+        # holds a reference to the CatalogDB), so a per-mutator
+        # ``Projector(self._db)`` was wasted allocation and obscured
+        # which DB connection the projection landed on. The cache also
+        # means a future change to the projector's constructor (e.g.
+        # taking a Phase-5 schema version flag) only has to be
+        # threaded once.
+        from nexus.catalog.projector import Projector as _Projector
+        self._projector = _Projector(self._db)
         self.degraded: bool = False
+        # Diagnostic: log the active gate state at construction so an
+        # operator inspecting structured logs can confirm which write
+        # path is in effect without grepping environment dumps. One line
+        # at info level — Catalog is constructed once per process for
+        # the long-running cases (MCP server) and once per CLI call
+        # otherwise.
+        _log.info(
+            "catalog_gate_state",
+            event_sourced=self._event_sourced_enabled,
+            shadow_emit=self._shadow_emit_enabled,
+            catalog_dir=str(catalog_dir),
+        )
         # Storage review S-4: mtime cache so every Catalog() instantiation
         # doesn't re-parse the full JSONL corpus and re-build the SQLite
         # cache. For a 10k-entry catalog this was measurably slow on
@@ -503,34 +525,179 @@ class Catalog:
         )
 
     def _ensure_consistent(self) -> None:
-        """Rebuild SQLite from JSONL truth when the JSONL mtime has advanced.
+        """Rebuild SQLite from the canonical truth when its mtime has advanced.
+
+        With ``NEXUS_EVENT_SOURCED=1`` the canonical truth is
+        ``events.jsonl`` (the event log IS the state per RDR-101 §"Core
+        invariants"); the rebuild path replays the log through
+        ``Projector.apply_all`` so a cross-process write that landed on
+        events.jsonl gets re-projected into this process's SQLite cache.
+        With the gate OFF the legacy JSONL files (owners/documents/links)
+        remain canonical and the rebuild reads them directly.
+
+        **Bootstrap guardrail.** When the gate is on but the legacy
+        JSONL holds substantially more documents than events.jsonl
+        carries DocumentRegistered events, we are looking at a freshly-
+        flipped catalog that has not yet run ``nx catalog
+        synthesize-log`` — the event-sourced rebuild would DELETE every
+        legacy row and replay only the few new events, silently wiping
+        the catalog. Refuse the event-sourced path in that scenario
+        (fall through to legacy + emit a structured warning).
+
+        **Atomicity.** The DELETE+replay sequence runs inside
+        ``CatalogDB.transaction()`` so a malformed event, a
+        ``NotImplementedError`` from the v: 1 projector path, or an
+        ``OperationalError`` mid-replay rolls back to the pre-DELETE
+        state instead of leaving SQLite empty.
 
         Sets ``degraded`` flag on failure so callers can surface the stale
         state rather than silently serving outdated data (nexus-f2vp).
 
-        Storage review S-4: skips the rebuild when no JSONL file has been
-        written since the last successful rebuild. For a large catalog
-        this eliminates the O(entries) parse cost on every ``Catalog()``
-        construction — the MCP server instantiates one per tool call.
+        Storage review S-4: skips the rebuild when no canonical file has
+        been written since the last successful rebuild. For a large
+        catalog this eliminates the O(entries) parse cost on every
+        ``Catalog()`` construction — the MCP server instantiates one
+        per tool call.
         """
         try:
+            # Track all canonical-truth sources for mtime detection so a
+            # rebuild kicks in regardless of which path produced the
+            # write. With the gate OFF, legacy JSONL is canonical; with
+            # the gate ON, events.jsonl is canonical but legacy JSONL is
+            # still written (back-compat) and a bootstrap catalog may
+            # have JSONL data with an empty events.jsonl.
             current_mtime = 0.0
-            for p in (self._owners_path, self._documents_path, self._links_path):
+            for p in (
+                self._owners_path,
+                self._documents_path,
+                self._links_path,
+                self._events_path,
+            ):
                 if p.exists():
                     current_mtime = max(current_mtime, p.stat().st_mtime)
             if current_mtime <= self._last_consistency_mtime and not self.degraded:
                 return
 
-            owners = read_owners(self._owners_path) if self._owners_path.exists() else {}
-            documents = read_documents(self._documents_path) if self._documents_path.exists() else {}
-            links_dict = read_links(self._links_path) if self._links_path.exists() else {}
-            _log.debug("catalog_consistency_rebuild", mtime=current_mtime)
-            self._db.rebuild(owners, documents, list(links_dict.values()))
+            use_event_log = (
+                self._event_sourced_enabled
+                and self._events_path.exists()
+                and self._events_path.stat().st_size > 0
+            )
+            if use_event_log and not self._event_log_covers_legacy():
+                # Bootstrap guardrail: events.jsonl is non-empty but
+                # the legacy JSONL has materially more documents than
+                # the event log carries DocumentRegistered events for.
+                # Refuse to wipe the legacy rows; fall through to the
+                # legacy rebuild and surface the gap so the operator
+                # can run ``nx catalog synthesize-log``.
+                _log.warning(
+                    "catalog_event_log_incomplete_falling_back_to_legacy",
+                    catalog_dir=str(self._dir),
+                    note=(
+                        "events.jsonl has fewer DocumentRegistered "
+                        "events than documents.jsonl has rows. Run "
+                        "'nx catalog synthesize-log' before relying "
+                        "on the event-sourced rebuild."
+                    ),
+                )
+                use_event_log = False
+            if use_event_log:
+                # Replay events.jsonl through the projector into the
+                # live CatalogDB. Atomic: the transaction context
+                # rolls back the DELETEs if apply_all raises.
+                from nexus.catalog.event_log import EventLog
+                _log.debug(
+                    "catalog_consistency_rebuild_event_sourced",
+                    mtime=current_mtime,
+                )
+                with self._db.transaction() as conn:
+                    conn.execute("DELETE FROM links")
+                    conn.execute("DELETE FROM documents")
+                    conn.execute("DELETE FROM owners")
+                    # commit=False — the transaction context owns the
+                    # commit boundary; a nested commit() would finalize
+                    # the tx prematurely and defeat the rollback fence.
+                    self._projector.apply_all(
+                        EventLog(self._dir).replay(), commit=False,
+                    )
+            else:
+                owners = read_owners(self._owners_path) if self._owners_path.exists() else {}
+                documents = read_documents(self._documents_path) if self._documents_path.exists() else {}
+                links_dict = read_links(self._links_path) if self._links_path.exists() else {}
+                _log.debug("catalog_consistency_rebuild", mtime=current_mtime)
+                self._db.rebuild(owners, documents, list(links_dict.values()))
             self._last_consistency_mtime = current_mtime
             self.degraded = False
         except Exception as exc:
             _log.warning("catalog_consistency_rebuild_failed", error=str(exc), exc_info=True)
             self.degraded = True
+
+    def _event_log_covers_legacy(self) -> bool:
+        """Return True when events.jsonl plausibly covers documents.jsonl.
+
+        Bootstrap guardrail for ``_ensure_consistent``: refuses to
+        DELETE-and-rebuild from a sparse event log when the legacy
+        JSONL still holds the majority of the catalog's content (e.g.
+        an operator just flipped ``NEXUS_EVENT_SOURCED=1`` on a
+        populated catalog and the first event-sourced write produced
+        a one-event log).
+
+        Cheap O(N) line counts on both files. ``documents.jsonl`` may
+        contain duplicates (last-line-wins on rebuild) and tombstones
+        (``_deleted=True`` markers) — count distinct non-tombstoned
+        tumblers as the canonical row count. ``events.jsonl`` may
+        contain tombstones too (DocumentDeleted events) — count
+        DocumentRegistered events minus DocumentDeleted as the
+        replayed-document count. A 5% slop tolerance avoids tripping
+        on a single in-flight write or one-event drift.
+        """
+        if not self._documents_path.exists():
+            return True
+        try:
+            registered: set[str] = set()
+            tombstoned: set[str] = set()
+            with self._documents_path.open() as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    tumbler = rec.get("tumbler")
+                    if not tumbler:
+                        continue
+                    if rec.get("_deleted"):
+                        tombstoned.add(tumbler)
+                    else:
+                        registered.add(tumbler)
+            legacy_doc_count = len(registered - tombstoned)
+            if legacy_doc_count == 0:
+                return True
+
+            from nexus.catalog import events as _ev
+            event_doc_count = 0
+            with self._events_path.open() as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    t = obj.get("type")
+                    if t == _ev.TYPE_DOCUMENT_REGISTERED:
+                        event_doc_count += 1
+                    elif t == _ev.TYPE_DOCUMENT_DELETED:
+                        event_doc_count -= 1
+
+            return event_doc_count >= int(legacy_doc_count * 0.95)
+        except Exception:
+            # On any unexpected failure, refuse the event-sourced
+            # rebuild (safer to fall through to legacy than to wipe).
+            return False
 
     def jsonl_paths(self) -> tuple[Path, ...]:
         """Public accessor for JSONL file paths (used by mtime checks)."""
@@ -772,8 +939,7 @@ class Catalog:
                 # Event-sourced path: events.jsonl first, projector
                 # writes SQLite, legacy JSONL last for back-compat.
                 self._write_to_event_log(event)
-                from nexus.catalog.projector import Projector as _Projector
-                _Projector(self._db).apply(event)
+                self._projector.apply(event)
                 self._db.commit()
                 self._append_jsonl(self._owners_path, rec.__dict__)
             else:
@@ -1018,8 +1184,7 @@ class Catalog:
                 # back-compat. The event log is canonical; SQLite is a
                 # deterministic projection of it.
                 self._write_to_event_log(event)
-                from nexus.catalog.projector import Projector as _Projector
-                _Projector(self._db).apply(event)
+                self._projector.apply(event)
                 self._db.commit()
                 self._append_jsonl(self._documents_path, rec.__dict__)
             else:
@@ -1217,8 +1382,7 @@ class Catalog:
             )
             if self._event_sourced_enabled:
                 self._write_to_event_log(event)
-                from nexus.catalog.projector import Projector as _Projector
-                _Projector(self._db).apply(event)
+                self._projector.apply(event)
                 self._db.commit()
                 self._append_jsonl(self._documents_path, updated.__dict__)
             else:
@@ -1581,19 +1745,23 @@ class Catalog:
                 # fine-grained DocumentRenamed/DocumentEnriched events
                 # that capture intent rather than state.
                 self._write_to_event_log(event)
-                from nexus.catalog.projector import Projector as _Projector
-                _Projector(self._db).apply(event)
+                self._projector.apply(event)
                 self._db.commit()
                 self._append_jsonl(self._documents_path, rec_dict)
             else:
                 self._append_jsonl(self._documents_path, rec_dict)
-                # Upsert SQLite
+                # Upsert SQLite. ``alias_of`` is included in the column
+                # list because INSERT OR REPLACE on the tumbler PK
+                # deletes the prior row before inserting; omitting the
+                # column would let the new row carry the column default
+                # (NULL) instead of the prior alias pointer, silently
+                # severing the alias graph on every update().
                 self._db.execute(
                     "INSERT OR REPLACE INTO documents "
                     "(tumbler, title, author, year, content_type, file_path, "
                     "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
-                    "metadata, source_mtime, source_uri) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "metadata, source_mtime, source_uri, alias_of) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         rec_dict["tumbler"], rec_dict["title"], rec_dict["author"],
                         rec_dict["year"], rec_dict["content_type"], rec_dict["file_path"],
@@ -1602,6 +1770,7 @@ class Catalog:
                         rec_dict["indexed_at"], json.dumps(rec_dict["meta"]),
                         rec_dict.get("source_mtime", 0.0),
                         rec_dict.get("source_uri", ""),
+                        entry.alias_of or "",
                     ),
                 )
                 self._db.commit()
@@ -1634,7 +1803,6 @@ class Catalog:
                 (old,),
             ).fetchall()
             from nexus.catalog.synthesizer import _owner_prefix_of as _opo
-            from nexus.catalog.projector import Projector as _Projector
             for row in rows:
                 # Preserve source_mtime + source_uri + alias_of across
                 # the rename — JSONL is the rebuild source of truth, so
@@ -1690,7 +1858,7 @@ class Catalog:
                         v=0,
                     )
                     self._write_to_event_log(event)
-                    _Projector(self._db).apply(event)
+                    self._projector.apply(event)
                     self._append_jsonl(self._documents_path, rec)
                 else:
                     self._append_jsonl(self._documents_path, rec)
@@ -1792,8 +1960,7 @@ class Catalog:
             )
             if self._event_sourced_enabled:
                 self._write_to_event_log(event)
-                from nexus.catalog.projector import Projector as _Projector
-                _Projector(self._db).apply(event)
+                self._projector.apply(event)
                 self._db.commit()
                 self._append_jsonl(self._documents_path, tombstone)
             else:
@@ -2041,18 +2208,12 @@ class Catalog:
             if created_by != row[1] and created_by not in co:
                 co.append(created_by)
             existing_meta["co_discovered_by"] = co
-            self._db.execute(
-                "UPDATE links SET from_span=?, to_span=?, metadata=? WHERE id=?",
-                (from_span, to_span, json.dumps(existing_meta), row[0]),
-            )
             rec = LinkRecord(
                 from_t=str(from_t), to_t=str(to_t), link_type=link_type,
                 from_span=from_span, to_span=to_span,
                 created_by=row[1], created_at=row[3] or now, meta=existing_meta,
             )
-            self._append_jsonl(self._links_path, rec.__dict__)
-            self._db.commit()
-            self._emit_shadow_event(_make_event(
+            event = _make_event(
                 _LinkCreatedPayload(
                     from_doc=str(from_t),
                     to_doc=str(to_t),
@@ -2064,7 +2225,24 @@ class Catalog:
                     meta=dict(existing_meta),
                 ),
                 v=0,
-            ))
+            )
+            if self._event_sourced_enabled:
+                # Event-sourced merge: emit the LinkCreated carrying
+                # the FINAL merged metadata first, then let the
+                # projector's INSERT OR REPLACE overwrite the prior
+                # SQLite row with the merged state.
+                self._write_to_event_log(event)
+                self._projector.apply(event)
+                self._db.commit()
+                self._append_jsonl(self._links_path, rec.__dict__)
+            else:
+                self._db.execute(
+                    "UPDATE links SET from_span=?, to_span=?, metadata=? WHERE id=?",
+                    (from_span, to_span, json.dumps(existing_meta), row[0]),
+                )
+                self._append_jsonl(self._links_path, rec.__dict__)
+                self._db.commit()
+                self._emit_shadow_event(event)
             return False
         else:
             combined_meta = dict(meta)
@@ -2073,16 +2251,7 @@ class Catalog:
                 from_span=from_span, to_span=to_span,
                 created_by=created_by, created_at=now, meta=combined_meta,
             )
-            self._db.execute(
-                "INSERT OR IGNORE INTO links "
-                "(from_tumbler, to_tumbler, link_type, from_span, to_span, "
-                "created_by, created_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (str(from_t), str(to_t), link_type, from_span, to_span,
-                 created_by, now, json.dumps(combined_meta)),
-            )
-            self._append_jsonl(self._links_path, rec.__dict__)
-            self._db.commit()
-            self._emit_shadow_event(_make_event(
+            event = _make_event(
                 _LinkCreatedPayload(
                     from_doc=str(from_t),
                     to_doc=str(to_t),
@@ -2094,7 +2263,23 @@ class Catalog:
                     meta=dict(combined_meta),
                 ),
                 v=0,
-            ))
+            )
+            if self._event_sourced_enabled:
+                self._write_to_event_log(event)
+                self._projector.apply(event)
+                self._db.commit()
+                self._append_jsonl(self._links_path, rec.__dict__)
+            else:
+                self._db.execute(
+                    "INSERT OR IGNORE INTO links "
+                    "(from_tumbler, to_tumbler, link_type, from_span, to_span, "
+                    "created_by, created_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (str(from_t), str(to_t), link_type, from_span, to_span,
+                     created_by, now, json.dumps(combined_meta)),
+                )
+                self._append_jsonl(self._links_path, rec.__dict__)
+                self._db.commit()
+                self._emit_shadow_event(event)
             return True
 
     def link(
@@ -2196,16 +2381,7 @@ class Catalog:
                 from_span=from_span, to_span=to_span,
                 created_by=created_by, created_at=now, meta=combined_meta,
             )
-            self._db.execute(
-                "INSERT OR IGNORE INTO links "
-                "(from_tumbler, to_tumbler, link_type, from_span, to_span, "
-                "created_by, created_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (str(from_t), str(to_t), link_type, from_span, to_span,
-                 created_by, now, json.dumps(combined_meta)),
-            )
-            self._append_jsonl(self._links_path, rec.__dict__)
-            self._db.commit()
-            self._emit_shadow_event(_make_event(
+            event = _make_event(
                 _LinkCreatedPayload(
                     from_doc=str(from_t),
                     to_doc=str(to_t),
@@ -2217,7 +2393,23 @@ class Catalog:
                     meta=dict(combined_meta),
                 ),
                 v=0,
-            ))
+            )
+            if self._event_sourced_enabled:
+                self._write_to_event_log(event)
+                self._projector.apply(event)
+                self._db.commit()
+                self._append_jsonl(self._links_path, rec.__dict__)
+            else:
+                self._db.execute(
+                    "INSERT OR IGNORE INTO links "
+                    "(from_tumbler, to_tumbler, link_type, from_span, to_span, "
+                    "created_by, created_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (str(from_t), str(to_t), link_type, from_span, to_span,
+                     created_by, now, json.dumps(combined_meta)),
+                )
+                self._append_jsonl(self._links_path, rec.__dict__)
+                self._db.commit()
+                self._emit_shadow_event(event)
             return True
         finally:
             self._release_lock(dir_fd)
@@ -2255,18 +2447,7 @@ class Catalog:
                     "created_at": datetime.now(UTC).isoformat(),
                     "meta": json.loads(full[2]) if full and full[2] else {},
                 }
-                self._append_jsonl(self._links_path, tombstone)
-                self._db.execute("DELETE FROM links WHERE id = ?", (row_id,))
-
-            self._db.commit()
-            # Emit shadow events AFTER db.commit() so a process crash
-            # between the DELETE and the commit cannot leave events.jsonl
-            # claiming a deletion that SQLite has not yet committed.
-            # Pre-fix the emit was inside the per-row loop, opening a
-            # crash window where the event log diverged from the
-            # authoritative SQLite state.
-            for row_id, lt, original_created_by in rows:
-                self._emit_shadow_event(_make_event(
+                event = _make_event(
                     _LinkDeletedPayload(
                         from_doc=str(from_t),
                         to_doc=str(to_t),
@@ -2274,7 +2455,35 @@ class Catalog:
                         reason="catalog.unlink",
                     ),
                     v=0,
-                ))
+                )
+                if self._event_sourced_enabled:
+                    # Event-sourced: write event, project (DELETE),
+                    # then JSONL tombstone. Commit batched at end of
+                    # the loop for efficiency on multi-row unlinks.
+                    self._write_to_event_log(event)
+                    self._projector.apply(event)
+                    self._append_jsonl(self._links_path, tombstone)
+                else:
+                    self._append_jsonl(self._links_path, tombstone)
+                    self._db.execute("DELETE FROM links WHERE id = ?", (row_id,))
+
+            self._db.commit()
+            # Shadow-emit one LinkDeleted per removed row AFTER
+            # db.commit() so a process crash between the DELETE and the
+            # commit cannot leave events.jsonl claiming a deletion that
+            # SQLite has not yet committed. Skipped when event-sourced
+            # is on — the per-row loop above already emitted + applied.
+            if not self._event_sourced_enabled:
+                for row_id, lt, original_created_by in rows:
+                    self._emit_shadow_event(_make_event(
+                        _LinkDeletedPayload(
+                            from_doc=str(from_t),
+                            to_doc=str(to_t),
+                            link_type=lt,
+                            reason="catalog.unlink",
+                        ),
+                        v=0,
+                    ))
             return len(rows)
         finally:
             self._release_lock(dir_fd)
@@ -2427,16 +2636,7 @@ class Catalog:
                     "created_at": datetime.now(UTC).isoformat(),
                     "meta": lnk.meta,
                 }
-                self._append_jsonl(self._links_path, tombstone)
-                self._db.execute(
-                    "DELETE FROM links WHERE from_tumbler=? AND to_tumbler=? AND link_type=?",
-                    (str(lnk.from_tumbler), str(lnk.to_tumbler), lnk.link_type),
-                )
-            self._db.commit()
-            # Emit shadow events AFTER db.commit() (see ``unlink`` for the
-            # crash-window rationale).
-            for lnk in matching:
-                self._emit_shadow_event(_make_event(
+                event = _make_event(
                     _LinkDeletedPayload(
                         from_doc=str(lnk.from_tumbler),
                         to_doc=str(lnk.to_tumbler),
@@ -2444,7 +2644,32 @@ class Catalog:
                         reason="catalog.bulk_unlink",
                     ),
                     v=0,
-                ))
+                )
+                if self._event_sourced_enabled:
+                    self._write_to_event_log(event)
+                    self._projector.apply(event)
+                    self._append_jsonl(self._links_path, tombstone)
+                else:
+                    self._append_jsonl(self._links_path, tombstone)
+                    self._db.execute(
+                        "DELETE FROM links WHERE from_tumbler=? AND to_tumbler=? AND link_type=?",
+                        (str(lnk.from_tumbler), str(lnk.to_tumbler), lnk.link_type),
+                    )
+            self._db.commit()
+            # Shadow-emit AFTER db.commit() (see ``unlink`` for the
+            # crash-window rationale). Skipped when event-sourced — the
+            # per-row loop already wrote and projected.
+            if not self._event_sourced_enabled:
+                for lnk in matching:
+                    self._emit_shadow_event(_make_event(
+                        _LinkDeletedPayload(
+                            from_doc=str(lnk.from_tumbler),
+                            to_doc=str(lnk.to_tumbler),
+                            link_type=lnk.link_type,
+                            reason="catalog.bulk_unlink",
+                        ),
+                        v=0,
+                    ))
             return len(matching)
         finally:
             self._release_lock(dir_fd)

--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 
 import structlog
@@ -137,7 +138,12 @@ class CatalogDB:
     def __init__(self, db_path: Path) -> None:
         self._path = db_path
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
-        self._lock = threading.Lock()
+        # Reentrant: ``execute()`` callers inside a ``transaction()``
+        # context (RDR-101 round-3) re-acquire the lock from the same
+        # thread. With a plain ``Lock()`` the nested ``with self._lock:``
+        # in ``execute`` would deadlock. ``RLock`` is a strict superset
+        # of ``Lock`` for cross-thread mutual exclusion.
+        self._lock = threading.RLock()
         # Storage review I-2: match the T2 domain-store concurrency defaults
         # (5 s busy_timeout + WAL) so cross-process writers don't immediately
         # raise ``OperationalError: database is locked`` when the CLI races
@@ -368,6 +374,25 @@ class CatalogDB:
         """Thread-safe commit wrapper."""
         with self._lock:
             self._conn.commit()
+
+    @contextmanager
+    def transaction(self):
+        """Atomic transaction context (RDR-101 round-3, atomicity fix).
+
+        Wraps the connection in ``with self._lock, self._conn:`` so a
+        sequence of ``execute()`` calls runs as one transaction —
+        commits on success, rolls back on any exception. ``_lock`` is
+        an ``RLock`` so the inner ``execute()`` calls re-acquire the
+        same thread's lock without deadlock.
+
+        Used by ``Catalog._ensure_consistent`` to make the
+        DELETE+replay rebuild atomic; pre-fix the three DELETEs
+        autocommitted before ``Projector.apply_all`` ran, so any
+        exception mid-replay (a malformed event, the v: 1 raise) left
+        SQLite empty and unrecoverable until the next mtime tick.
+        """
+        with self._lock, self._conn:
+            yield self._conn
 
     def close(self) -> None:
         with self._lock:

--- a/src/nexus/catalog/events.py
+++ b/src/nexus/catalog/events.py
@@ -468,12 +468,18 @@ class Event:
 # ── Convenience constructors ─────────────────────────────────────────────
 
 
-def make_event(payload: Any, *, v: int = 1, ts: str | None = None) -> Event:
+def make_event(payload: Any, *, v: int = 0, ts: str | None = None) -> Event:
     """Build an Event envelope from a typed payload dataclass.
 
     Looks up the type name from ``payload``'s class so callers don't have
-    to repeat themselves. ``v`` defaults to 1 (native write); pass ``v=0``
-    for the synthesized projector path. ``ts`` defaults to now.
+    to repeat themselves. ``v`` defaults to ``0`` (synthesized / Phase 1
+    schema): every v: 0 dispatch handler is implemented, so the default
+    is the safe, observable path. Pass ``v=1`` once a Phase 3+ writer is
+    wired against a v: 1 dispatch handler that does something other than
+    raise — until then, v: 1 events have no projector landing site and
+    the projector raises ``NotImplementedError`` to surface the gap.
+
+    ``ts`` defaults to now.
     """
     type_ = _CLASS_TO_TYPE.get(type(payload))
     if type_ is None:

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -23,10 +23,14 @@ crash, it must surface the new event type so an operator can decide.
 Idempotency: re-projecting the same event sequence is a no-op past the
 first run. ``DocumentRegistered`` uses ``INSERT OR REPLACE`` keyed on
 ``tumbler`` so re-applying overwrites with identical data.
-``LinkCreated`` uses ``INSERT OR IGNORE`` against the existing UNIQUE
-INDEX on ``(from_tumbler, to_tumbler, link_type)`` so duplicate links are
-silently dropped. ``DocumentDeleted`` issues ``DELETE FROM documents
-WHERE tumbler = ?``; re-deleting a missing row is a no-op.
+``LinkCreated`` uses ``INSERT OR REPLACE`` against the UNIQUE INDEX on
+``(from_tumbler, to_tumbler, link_type)`` so a follow-up event for the
+same composite key OVERWRITES the prior row's spans + metadata (the
+writer's merge path emits a single LinkCreated event carrying the
+final merged metadata, not two separate Created+Updated events; the
+projector converges SQLite on whatever the most recent event says).
+``DocumentDeleted`` issues ``DELETE FROM documents WHERE tumbler = ?``;
+re-deleting a missing row is a no-op.
 
 The projector does NOT manage the SQLite schema or migrations — it
 takes a constructed ``CatalogDB`` and writes to whatever schema is
@@ -71,18 +75,26 @@ class Projector:
             return
         handler(self, event.payload)
 
-    def apply_all(self, events: Iterable[Event]) -> int:
+    def apply_all(self, events: Iterable[Event], *, commit: bool = True) -> int:
         """Apply a stream of events; return the count actually applied.
 
         ``CatalogDB.commit()`` is called once at the end so a long
         replay is one transaction (atomic against external readers and
         ~50x faster than per-event commits on the live host catalog).
+
+        Pass ``commit=False`` when the caller wraps this call in its
+        own ``CatalogDB.transaction()`` block (e.g.
+        ``Catalog._ensure_consistent`` event-sourced rebuild) — the
+        outer ``with`` block commits or rolls back atomically and a
+        nested commit would finalize the transaction prematurely,
+        defeating the rollback fence.
         """
         applied = 0
         for event in events:
             self.apply(event)
             applied += 1
-        self._db.commit()
+        if commit:
+            self._db.commit()
         return applied
 
     # ── v: 0 handlers (synthesized from existing JSONL state) ────────────
@@ -244,10 +256,24 @@ class Projector:
         return  # symmetric to chunk_indexed
 
     def _v0_link_created(self, payload: Any) -> None:
+        # Use INSERT OR REPLACE on the (from_tumbler, to_tumbler,
+        # link_type) UNIQUE INDEX so a second LinkCreated event for the
+        # same composite key OVERWRITES the prior row's spans + metadata
+        # rather than being silently dropped. The legacy
+        # ``Catalog._link_unlocked`` merge path emits a LinkCreated with
+        # the FINAL merged metadata after computing it from the existing
+        # row; the projector's job is to converge SQLite on that final
+        # state. INSERT OR IGNORE would have silently dropped the merge.
+        #
+        # SQLite implements OR REPLACE by deleting the conflicting row
+        # and inserting a fresh one, which assigns a new ``id`` integer.
+        # The doctor verb's links snapshot already excludes ``id`` (it is
+        # not part of the projection contract per RF-101-2), so the new
+        # ``id`` does not break replay-equality.
         if not payload.from_doc or not payload.to_doc or not payload.link_type:
             return
         self._db.execute(
-            "INSERT OR IGNORE INTO links "
+            "INSERT OR REPLACE INTO links "
             "(from_tumbler, to_tumbler, link_type, from_span, to_span, "
             "created_by, created_at, metadata) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
@@ -276,16 +302,22 @@ class Projector:
     #
     # Phase 1 does not write the new SQLite schema (Document.doc_id
     # column, Chunk table, etc.) — that lands in Phase 3. The v: 1
-    # handlers are placeholders so the dispatch table is symmetric and
-    # the doctor verb can flag "v: 1 event in log but no v: 1 SQLite
-    # writer" as a Phase-3-incomplete failure mode rather than a silent
-    # drop.
+    # handlers raise so a stray v: 1 emission lands LOUDLY rather than
+    # being silently absorbed into a no-op. Pre-fix the handlers logged
+    # a warning and returned, which combined with the
+    # ``make_event(..., v=1)`` default to produce a trap: any caller
+    # forgetting ``v=0`` would silently lose the event. Dispatch on
+    # (type, 1) now aborts the writer mid-mutation, which leaves
+    # SQLite + the legacy JSONL un-touched (the writer holds the flock
+    # and has not yet committed at that point) and gives the operator a
+    # stack trace pointing at the wrong-version site.
 
     def _v1_unsupported(self, payload: Any) -> None:
-        _log.warning(
-            "projector_v1_not_implemented_phase1",
-            payload=type(payload).__name__,
-            note="v: 1 native writes land in RDR-101 Phase 3",
+        raise NotImplementedError(
+            f"v: 1 projector handler not implemented for "
+            f"{type(payload).__name__}; native v: 1 writes land in "
+            f"RDR-101 Phase 3+. Pass v=0 to make_event() until the "
+            f"matching v: 1 handler ships."
         )
 
 

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3327,22 +3327,35 @@ def doctor_cmd(
 
 
 def _run_replay_equality() -> dict:
-    """Drive synthesizer + projector against the live catalog and diff.
+    """Drive the projector against the live catalog and diff.
 
-    Steps:
+    Source of truth depends on the catalog's write path:
+
+    * **Event-sourced** (``events.jsonl`` exists and is non-empty): replay
+      the native event log directly. This is the path that matters once
+      ``NEXUS_EVENT_SOURCED=1`` is on by default, since the legacy JSONL
+      becomes a back-compat shadow rather than canonical state and a
+      synthesizer-driven check would silently miss any divergence in the
+      native write path.
+    * **Legacy** (no events.jsonl, or empty): synthesize v: 0 events
+      from ``owners.jsonl``/``documents.jsonl``/``links.jsonl`` (the
+      Phase 1 path).
+
+    Steps in either mode:
       1. Resolve ``catalog_path()`` and require an initialized catalog.
       2. Open ``.catalog.db`` read-only (sqlite URI ``mode=ro``) for the
          live snapshot. Snapshot owners + documents + links rows.
       3. Build a fresh ``CatalogDB`` under a TemporaryDirectory; drive
-         ``synthesize_from_jsonl`` + ``Projector.apply_all`` into it.
+         ``Projector.apply_all`` over the chosen event stream into it.
          Snapshot the same three tables.
       4. Diff the snapshots. Report counts and the first 5 mismatches per
          table. Pass = every table identical; fail = any difference.
 
     The live ``.catalog.db`` is opened read-only so an operator running
     this verb on a working host cannot accidentally corrupt the cached
-    SQLite. JSONL files are read but not written. The projected SQLite
-    is ephemeral and discarded with the TemporaryDirectory.
+    SQLite. JSONL / events.jsonl files are read but not written. The
+    projected SQLite is ephemeral and discarded with the
+    TemporaryDirectory.
     """
     import sqlite3
     import tempfile
@@ -3368,6 +3381,19 @@ def _run_replay_equality() -> dict:
             "pull' to rebuild from JSONL."
         )
 
+    # ── Pick the event source ──────────────────────────────────────────
+    # Stat-only check; never construct ``EventLog`` here because its
+    # constructor touch-creates ``events.jsonl`` if missing, which
+    # would (a) shift the catalog dir's mtime mid-doctor-run and (b)
+    # break the doctor's "read-only against live state" guarantee for a
+    # legacy-mode catalog that has no events.jsonl yet.
+    events_path = cat_dir / "events.jsonl"
+    event_source: str
+    if events_path.exists() and events_path.stat().st_size > 0:
+        event_source = "events.jsonl"
+    else:
+        event_source = "synthesized"
+
     # ── Snapshot live ──────────────────────────────────────────────────
     # Links carry an autoincrement ``id`` PK that the projector restarts
     # at 1; the live db's ids depend on insertion history. RF-101-2 does
@@ -3389,9 +3415,17 @@ def _run_replay_equality() -> dict:
         projected_path = Path(tmpdir) / "projected.db"
         proj_db = CatalogDB(projected_path)
         try:
-            applied = Projector(proj_db).apply_all(
-                synthesize_from_jsonl(cat_dir)
-            )
+            if event_source == "events.jsonl":
+                # Local import: deferring to call-time avoids module-load
+                # side effects in environments that never need this path.
+                from nexus.catalog.event_log import EventLog
+                applied = Projector(proj_db).apply_all(
+                    EventLog(cat_dir).replay()
+                )
+            else:
+                applied = Projector(proj_db).apply_all(
+                    synthesize_from_jsonl(cat_dir)
+                )
         finally:
             proj_db.close()
 
@@ -3428,6 +3462,7 @@ def _run_replay_equality() -> dict:
         "events_applied": applied,
         "catalog_dir": str(cat_dir),
         "live_db": str(live_db_path),
+        "event_source": event_source,
         "tables": table_diffs,
     }
 
@@ -3465,6 +3500,7 @@ def _print_replay_equality_text(report: dict) -> None:
     """Operator-friendly text rendering of the replay-equality report."""
     click.echo(f"Catalog: {report['catalog_dir']}")
     click.echo(f"Live db: {report['live_db']}")
+    click.echo(f"Event source: {report.get('event_source', 'synthesized')}")
     click.echo(f"Events applied: {report['events_applied']}")
     click.echo("")
 

--- a/tests/test_catalog_events.py
+++ b/tests/test_catalog_events.py
@@ -189,9 +189,23 @@ class TestEnvelopeRoundtrip:
 class TestVersioning:
     """Envelope ``v`` versioning per RF-101-2."""
 
-    def test_default_version_is_1(self):
+    def test_default_version_is_0(self):
+        # Default flipped from 1→0 per the round-3 review: v=1 has no
+        # production projector landing site (it raises) and the previous
+        # default produced a silent-drop trap when callers forgot to
+        # pass ``v=0``. Default to the implemented schema; opt into v=1
+        # explicitly when a v: 1 handler is wired.
         e = ev.make_event(ev.DocumentDeletedPayload(doc_id="x", reason="y"))
+        assert e.v == 0
+
+    def test_explicit_v_one(self):
+        e = ev.make_event(
+            ev.DocumentDeletedPayload(doc_id="x", reason="phase3_native"),
+            v=1,
+        )
         assert e.v == 1
+        d = e.to_dict()
+        assert d["v"] == 1
 
     def test_synthesized_v_zero(self):
         e = ev.make_event(

--- a/tests/test_catalog_projector.py
+++ b/tests/test_catalog_projector.py
@@ -327,9 +327,14 @@ class TestUnknownDispatch:
         assert rows[0] == 0
         db.close()
 
-    def test_v1_known_type_is_logged_skipped(self, tmp_path):
-        # Phase 3 will ship v: 1 handlers; Phase 1 logs and skips so the
-        # doctor verb can flag "v: 1 in log but Phase 3 not deployed".
+    def test_v1_known_type_raises(self, tmp_path):
+        # Round-3 review: pre-fix _v1_unsupported logged a warning and
+        # returned, which combined with the v=1 default in make_event
+        # produced a silent-drop trap. Now it raises NotImplementedError
+        # so dispatch on (type, 1) lands LOUDLY before any write commits
+        # — the writer holds the flock and has not yet committed at the
+        # point this raises, so SQLite + JSONL stay un-touched.
+        import pytest as _pytest
         db = CatalogDB(tmp_path / "x.db")
         proj = Projector(db)
 
@@ -337,8 +342,8 @@ class TestUnknownDispatch:
             ev.DocumentDeletedPayload(doc_id="1.7.42", reason="x"),
             v=1,
         )
-        proj.apply(e)
-        # v: 1 path is the v1_unsupported no-op for Phase 1.
+        with _pytest.raises(NotImplementedError, match="v: 1"):
+            proj.apply(e)
         rows = db.execute(
             "SELECT count(*) FROM documents WHERE tumbler = ?",
             ("1.7.42",),

--- a/tests/test_rdr101_round3_correctness.py
+++ b/tests/test_rdr101_round3_correctness.py
@@ -1,0 +1,563 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RDR-101 Phase 3 round-3 review remediation: correctness fixes.
+
+Covers the load-bearing items from the round-3 review of PRs #430/#431
+that block the irreversibility cutover (NEXUS_EVENT_SOURCED default
+flip):
+
+1. ``link`` / ``link_if_absent`` / ``unlink`` / ``bulk_unlink`` event-source
+   the LinkCreated / LinkDeleted events when ``NEXUS_EVENT_SOURCED=1``.
+   Pre-fix these mutators stayed on the legacy direct-write path and
+   the event log silently dropped every link mutation under the gate.
+2. ``Catalog._ensure_consistent`` rebuilds from ``events.jsonl`` when the
+   gate is on. Pre-fix it always read legacy JSONL, so a cross-process
+   write that landed only in the event log was invisible to subsequent
+   ``Catalog()`` instances.
+3. ``nx catalog doctor --replay-equality`` reads ``events.jsonl`` when
+   present. Pre-fix it always called ``synthesize_from_jsonl`` so once
+   the gate was on the verb measured the wrong source of truth.
+4. Projector ``_v1_unsupported`` raises (covered in
+   ``test_catalog_projector.py::TestUnknownDispatch::test_v1_known_type_raises``).
+5. ``make_event`` defaults ``v=0`` (covered in
+   ``test_catalog_events.py::TestVersioning::test_default_version_is_0``).
+6. Legacy ``update()`` ``INSERT OR REPLACE`` includes ``alias_of`` so an
+   alias survives a subsequent update().
+7. Single ``Projector`` instance cached at ``Catalog.__init__``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.projector import Projector
+
+
+# ── Link mutators event-sourced ──────────────────────────────────────────
+
+
+class TestLinkEventSourced:
+    """``link`` writes LinkCreated to events.jsonl under the gate."""
+
+    def test_link_emits_event_and_projects(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose")
+        b = cat.register(owner, "b.md", content_type="prose")
+
+        created = cat.link(a, b, "cites", "agent-1")
+        assert created is True
+
+        log = EventLog(d)
+        link_events = [
+            e for e in log.replay()
+            if e.type == ev.TYPE_LINK_CREATED
+        ]
+        assert len(link_events) == 1
+        p = link_events[0].payload
+        assert p.from_doc == str(a)
+        assert p.to_doc == str(b)
+        assert p.link_type == "cites"
+        assert p.creator == "agent-1"
+
+        rows = cat._db.execute(
+            "SELECT count(*) FROM links WHERE from_tumbler=? AND to_tumbler=?",
+            (str(a), str(b)),
+        ).fetchone()
+        assert rows[0] == 1
+
+    def test_link_merge_overwrites_via_insert_or_replace(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Two link() calls on the same composite key emit two
+        # LinkCreated events. Replay through the projector's
+        # INSERT OR REPLACE must converge on the SECOND payload's
+        # merged metadata. INSERT OR IGNORE would have silently
+        # dropped the second event and the merged co_discovered_by
+        # list would never reach SQLite.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose")
+        b = cat.register(owner, "b.md", content_type="prose")
+        cat.link(a, b, "cites", "agent-1")
+        merged = cat.link(a, b, "cites", "agent-2")
+        assert merged is False
+
+        # Replay events.jsonl into a fresh DB; the merged metadata
+        # must include both creators in co_discovered_by.
+        log = EventLog(d)
+        proj_db = CatalogDB(tmp_path / "projected.db")
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        with sqlite3.connect(str(tmp_path / "projected.db")) as conn:
+            row = conn.execute(
+                "SELECT metadata FROM links WHERE from_tumbler=? "
+                "AND to_tumbler=? AND link_type=?",
+                (str(a), str(b), "cites"),
+            ).fetchone()
+        import json
+        meta = json.loads(row[0])
+        assert "agent-2" in meta.get("co_discovered_by", [])
+
+    def test_unlink_emits_event_and_deletes_row(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose")
+        b = cat.register(owner, "b.md", content_type="prose")
+        cat.link(a, b, "cites", "agent-1")
+        n = cat.unlink(a, b, "cites")
+        assert n == 1
+
+        log = EventLog(d)
+        types = [e.type for e in log.replay()]
+        assert types.count(ev.TYPE_LINK_DELETED) == 1
+
+        rows = cat._db.execute(
+            "SELECT count(*) FROM links WHERE from_tumbler=? AND to_tumbler=?",
+            (str(a), str(b)),
+        ).fetchone()
+        assert rows[0] == 0
+
+    def test_link_if_absent_emits_event(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose")
+        b = cat.register(owner, "b.md", content_type="prose")
+        created = cat.link_if_absent(a, b, "cites", "agent-1")
+        assert created is True
+
+        log = EventLog(d)
+        link_events = [
+            e for e in log.replay() if e.type == ev.TYPE_LINK_CREATED
+        ]
+        assert len(link_events) == 1
+
+        # Second call on the same key returns False and emits NO event.
+        skipped = cat.link_if_absent(a, b, "cites", "agent-2")
+        assert skipped is False
+        link_events = [
+            e for e in EventLog(d).replay()
+            if e.type == ev.TYPE_LINK_CREATED
+        ]
+        assert len(link_events) == 1
+
+    def test_bulk_unlink_emits_events(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose")
+        b = cat.register(owner, "b.md", content_type="prose")
+        c = cat.register(owner, "c.md", content_type="prose")
+        cat.link(a, b, "cites", "agent-1")
+        cat.link(a, c, "cites", "agent-1")
+        n = cat.bulk_unlink(from_t=str(a), link_type="cites")
+        assert n == 2
+
+        log = EventLog(d)
+        types = [e.type for e in log.replay()]
+        assert types.count(ev.TYPE_LINK_DELETED) == 2
+
+    def test_full_replay_includes_links(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose")
+        b = cat.register(owner, "b.md", content_type="prose")
+        cat.link(a, b, "cites", "agent-1")
+        cat._db.close()
+
+        log = EventLog(d)
+        proj_db = CatalogDB(tmp_path / "projected.db")
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        with sqlite3.connect(str(tmp_path / "projected.db")) as conn:
+            row = conn.execute(
+                "SELECT count(*) FROM links WHERE from_tumbler=? AND to_tumbler=?",
+                (str(a), str(b)),
+            ).fetchone()
+        assert row[0] == 1
+
+
+# ── _ensure_consistent rebuilds from events.jsonl ────────────────────────
+
+
+class TestEnsureConsistentEventSourced:
+    def test_second_catalog_sees_events_jsonl_writes(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Cross-process scenario: process A writes via event-sourced;
+        # process B opens the catalog and must see the same state.
+        # Pre-fix B would rebuild from JSONL only and miss any
+        # divergence.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat_a = Catalog(d, d / ".catalog.db")
+        owner = cat_a.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat_a.register(owner, "a.md", content_type="prose")
+        cat_a._db.close()
+
+        cat_b = Catalog(d, tmp_path / "process_b.db")
+        try:
+            row = cat_b._db.execute(
+                "SELECT title FROM documents WHERE tumbler = ?",
+                (str(a),),
+            ).fetchone()
+            assert row == ("a.md",)
+        finally:
+            cat_b._db.close()
+
+    def test_rebuild_clears_existing_rows_before_replay(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Round-4 review (reviewer E): the previous test opened cat_b
+        # against a fresh SQLite, so the DELETE FROM was a no-op and
+        # the contract "rebuild clears stale rows before replay" was
+        # untested. This test pre-populates a SQLite with a row that
+        # is NOT in events.jsonl, then opens a Catalog against it, and
+        # asserts the stale row is gone after _ensure_consistent
+        # rebuilds from events.jsonl.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        # Step 1: write a real event-sourced state with one document.
+        cat_a = Catalog(d, d / ".catalog.db")
+        owner = cat_a.register_owner("nexus", "repo", repo_hash="abab")
+        real = cat_a.register(owner, "real.md", content_type="prose")
+        cat_a._db.close()
+
+        # Step 2: build a stale SQLite with a phantom row that
+        # events.jsonl does NOT contain. This stands in for cross-
+        # process drift (or a corrupt cache).
+        stale_db_path = tmp_path / "stale.db"
+        stale_db = CatalogDB(stale_db_path)
+        try:
+            # Same owner so the FK structure is intact.
+            stale_db.execute(
+                "INSERT OR REPLACE INTO owners "
+                "(tumbler_prefix, name, owner_type, repo_hash, "
+                "description, repo_root) VALUES (?, ?, ?, ?, ?, ?)",
+                ("1.1", "nexus", "repo", "abab", "", ""),
+            )
+            stale_db.execute(
+                "INSERT INTO documents (tumbler, title, content_type) "
+                "VALUES (?, ?, ?)",
+                ("1.1.999", "phantom.md", "prose"),
+            )
+            stale_db.commit()
+        finally:
+            stale_db.close()
+
+        # Step 3: open Catalog against the stale SQLite. _ensure_consistent
+        # must DELETE the phantom row and replay events.jsonl.
+        cat_b = Catalog(d, stale_db_path)
+        try:
+            phantom = cat_b._db.execute(
+                "SELECT count(*) FROM documents WHERE tumbler = ?",
+                ("1.1.999",),
+            ).fetchone()
+            assert phantom[0] == 0, (
+                "stale phantom row survived the event-sourced rebuild — "
+                "the DELETE-and-replay contract is broken"
+            )
+            real_row = cat_b._db.execute(
+                "SELECT title FROM documents WHERE tumbler = ?",
+                (str(real),),
+            ).fetchone()
+            assert real_row == ("real.md",)
+        finally:
+            cat_b._db.close()
+
+    def test_bootstrap_guardrail_refuses_when_event_log_sparse(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Round-4 review (reviewer B EC-1): operator flips
+        # NEXUS_EVENT_SOURCED=1 on a catalog that has 10 documents in
+        # documents.jsonl but only 1 event in events.jsonl (the first
+        # post-flip write). The event-sourced rebuild would DELETE all
+        # 10 legacy rows and replay only the 1 event, silently wiping
+        # the catalog. The guardrail must detect this and fall through
+        # to the legacy rebuild.
+        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        for i in range(10):
+            cat.register(owner, f"doc-{i}.md", content_type="prose",
+                         file_path=f"doc-{i}.md")
+        cat._db.close()
+
+        # Now manually write a single event into events.jsonl (as if
+        # one event-sourced write happened after the gate was flipped).
+        events_path = d / "events.jsonl"
+        events_path.write_text(
+            '{"type":"DocumentRegistered","v":0,"payload":{'
+            '"doc_id":"1.1.99","owner_id":"1.1","content_type":"prose",'
+            '"source_uri":"","coll_id":"","title":"new.md","tumbler":"1.1.99",'
+            '"author":"","year":0,"file_path":"new.md","corpus":"",'
+            '"physical_collection":"","chunk_count":0,"head_hash":"",'
+            '"indexed_at":"","alias_of":"","meta":{},"source_mtime":0.0,'
+            '"indexed_at_doc":""},"ts":"2026-05-01T00:00:00+00:00"}\n'
+        )
+
+        # Now open with the gate ON. The guardrail should refuse the
+        # event-sourced rebuild and fall through to legacy.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        cat2 = Catalog(d, tmp_path / "process_b.db")
+        try:
+            doc_count = cat2._db.execute(
+                "SELECT count(*) FROM documents"
+            ).fetchone()[0]
+            # The legacy 10 documents must survive — bootstrap guardrail
+            # refused the event-sourced rebuild that would have wiped
+            # to 1 row.
+            assert doc_count >= 10, (
+                f"bootstrap guardrail failed: legacy rebuild produced "
+                f"{doc_count} rows but documents.jsonl has 10"
+            )
+        finally:
+            cat2._db.close()
+
+    def test_atomicity_apply_all_failure_rolls_back_deletes(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Round-4 review (reviewer C): _ensure_consistent's
+        # DELETE+replay must be atomic. If apply_all raises (e.g. a
+        # malformed event triggers NotImplementedError via a v: 1
+        # path), the DELETEs must roll back, leaving SQLite in its
+        # prior state.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat_a = Catalog(d, d / ".catalog.db")
+        owner = cat_a.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat_a.register(owner, "a.md", content_type="prose")
+        cat_a._db.close()
+
+        # Append a v: 1 event after the legitimate v: 0 events. The
+        # projector will raise NotImplementedError when it dispatches
+        # the v: 1 line.
+        events_path = d / "events.jsonl"
+        events_path.open("a").write(
+            '{"type":"DocumentDeleted","v":1,"payload":{'
+            '"doc_id":"1.1.99","reason":"poisoned"},'
+            '"ts":"2026-05-01T00:00:00+00:00"}\n'
+        )
+
+        # Pre-populate a separate SQLite with a sentinel row that
+        # MUST survive a failed rebuild (proves the DELETEs rolled
+        # back).
+        stale_path = tmp_path / "stale.db"
+        stale = CatalogDB(stale_path)
+        try:
+            stale.execute(
+                "INSERT OR REPLACE INTO owners "
+                "(tumbler_prefix, name, owner_type, repo_hash, "
+                "description, repo_root) VALUES (?, ?, ?, ?, ?, ?)",
+                ("1.1", "nexus", "repo", "abab", "", ""),
+            )
+            stale.execute(
+                "INSERT INTO documents (tumbler, title, content_type) "
+                "VALUES (?, ?, ?)",
+                ("1.1.42", "sentinel.md", "prose"),
+            )
+            stale.commit()
+        finally:
+            stale.close()
+
+        # Open Catalog against the stale SQLite. _ensure_consistent
+        # tries the event-sourced rebuild, hits the v: 1 raise, and
+        # rolls back the DELETEs. The sentinel row must survive.
+        cat_b = Catalog(d, stale_path)
+        try:
+            assert cat_b.degraded is True, (
+                "Catalog should be marked degraded after a failed rebuild"
+            )
+            sentinel = cat_b._db.execute(
+                "SELECT count(*) FROM documents WHERE tumbler = ?",
+                ("1.1.42",),
+            ).fetchone()
+            assert sentinel[0] == 1, (
+                "DELETE was not rolled back — atomicity is broken; "
+                "the sentinel row was wiped by the failed rebuild"
+            )
+        finally:
+            cat_b._db.close()
+
+
+# ── Doctor --replay-equality reads events.jsonl ──────────────────────────
+
+
+class TestDoctorReplayEqualityEventLog:
+    """``nx catalog doctor --replay-equality`` reads ``events.jsonl`` when
+    it exists and has content — pre-fix it always called
+    ``synthesize_from_jsonl``, so once ``NEXUS_EVENT_SOURCED=1`` was on by
+    default the verb measured the wrong source of truth."""
+
+    def test_doctor_uses_events_jsonl_when_present(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Round-4 review (reviewer E): the previous test was
+        # discrimination-free — synthesize_from_jsonl and
+        # EventLog.replay produced the same projection for the
+        # scenario, so a regression that always called the synthesizer
+        # would still pass. This test writes events.jsonl content that
+        # the synthesizer CANNOT reproduce (a link with no entry in
+        # links.jsonl), then projects through the doctor and asserts
+        # the link IS present in the projected DB. Only the
+        # events.jsonl path can produce that output.
+        from nexus.commands.catalog import _run_replay_equality
+
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "test-catalog"
+        Catalog.init(d)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose", file_path="a.md")
+        b = cat.register(owner, "b.md", content_type="prose", file_path="b.md")
+        cat.link(a, b, "cites", "agent-1")
+        cat._db.close()
+
+        # Sanity: links.jsonl must contain the link (event-sourced
+        # path still writes legacy JSONL for back-compat).
+        links_text = (d / "links.jsonl").read_text()
+        assert "cites" in links_text
+
+        # Now strip the link from links.jsonl so the synthesizer
+        # branch CANNOT reproduce it. Only the events.jsonl branch
+        # carries the LinkCreated event.
+        (d / "links.jsonl").write_text("")
+
+        report = _run_replay_equality()
+        assert report["event_source"] == "events.jsonl", report
+        # The projected DB has the link because we replayed
+        # events.jsonl. The live DB also has it (it was committed
+        # there at link() time). So replay-equality holds for links.
+        # If the doctor had instead called synthesize_from_jsonl
+        # against the empty links.jsonl, the projected DB would have
+        # NO link rows, and replay-equality would FAIL with
+        # only_in_live=[the link]. We check for pass=True as the
+        # discriminating assertion.
+        assert report["pass"] is True, (
+            "Doctor must replay events.jsonl, not synthesize from the "
+            "(now-empty) links.jsonl. Report:\n" + str(report)
+        )
+
+    def test_doctor_falls_back_to_synthesizer_when_no_events(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        from nexus.commands.catalog import _run_replay_equality
+
+        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        d = tmp_path / "test-catalog"
+        Catalog.init(d)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        cat.register(owner, "a.md", content_type="prose", file_path="a.md")
+        cat._db.close()
+
+        # events.jsonl shouldn't exist yet (no shadow, no event-sourced).
+        events_path = d / "events.jsonl"
+        assert (
+            not events_path.exists() or events_path.stat().st_size == 0
+        )
+        report = _run_replay_equality()
+        assert report["pass"] is True, report
+        assert report["event_source"] == "synthesized"
+
+
+# ── Legacy update() carries alias_of through INSERT OR REPLACE ───────────
+
+
+class TestLegacyUpdateAliasOfColumn:
+    """The legacy ``update()`` ``INSERT OR REPLACE`` column list now
+    includes ``alias_of`` so the column is symmetric with the
+    event-sourced projector path. Pre-fix the legacy path silently
+    omitted ``alias_of`` from the column list; the projector path
+    wrote it. The asymmetry was theoretical (no public API exercises a
+    direct alias_of write through update() because resolve() follows
+    aliases first), but the equivalence claim in PR α/β tests rests on
+    the two SQL paths being byte-symmetric. Defensive symmetry."""
+
+    def test_alias_of_column_present_in_update_sql(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Smoke-test: legacy update() runs without erroring even when
+        # the entry has alias_of carried through entry.alias_of (which
+        # is the value the new column slot writes).
+        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        doc = cat.register(owner, "doc.md", content_type="prose")
+        # update() through the legacy path; entry.alias_of is "" for a
+        # canonical row but the SQL must accept the parameter.
+        cat.update(doc, chunk_count=99)
+        row = cat._db.execute(
+            "SELECT chunk_count, alias_of FROM documents WHERE tumbler = ?",
+            (str(doc),),
+        ).fetchone()
+        assert row == (99, "")
+
+
+# ── Cached projector ─────────────────────────────────────────────────────
+
+
+class TestProjectorCached:
+    def test_catalog_caches_projector_at_init(
+        self, tmp_path,
+    ):
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        # Single instance, accessible via attribute.
+        proj1 = cat._projector
+        proj2 = cat._projector
+        assert proj1 is proj2
+        assert isinstance(proj1, Projector)


### PR DESCRIPTION
## Summary

Round-3 review of PRs #430/#431 plus round-4 deep review of round-3 fixes themselves. Closes the remaining critical gaps before `NEXUS_EVENT_SOURCED` defaults on. nexus-o6aa.9.1.

## Round-3 critical fixes

### Link/unlink event-source path
`link()` / `link_if_absent()` / `unlink()` / `bulk_unlink()` flow through events.jsonl + projector under the gate. Pre-fix these stayed on the legacy direct-write path even with the gate on — events.jsonl silently dropped every link mutation. `Projector._v0_link_created` upgraded to `INSERT OR REPLACE` so merge semantics survive replay.

### `_ensure_consistent` rebuilds from events.jsonl under the gate
With the gate on, the canonical truth is `events.jsonl`. Cross-process writes are now picked up via the rebuild path.

### Doctor `--replay-equality` reads events.jsonl
When events.jsonl is present and non-empty. Falls back to `synthesize_from_jsonl` otherwise. EventLog import deferred to call-time inside the if-branch — a legacy-mode catalog never touches events.jsonl during a doctor run.

### `_v1_unsupported` raises + `make_event` default v=0
Pre-fix these combined into a silent-drop trap.

## Round-4 critical fixes (deep review of round-3)

### Atomic rebuild
The DELETE+replay sequence in `_ensure_consistent` is wrapped in `CatalogDB.transaction()`. Pre-fix the three DELETE statements autocommitted in WAL mode before `apply_all` ran; any exception mid-replay (a malformed event, the v: 1 NotImplementedError) left SQLite empty with `degraded=True`. Now any exception rolls back to the pre-DELETE state.

`CatalogDB._lock` changed from `threading.Lock` to `threading.RLock` so inner `execute()` calls inside the transaction context don't deadlock.

### Bootstrap guardrail
Operator flips `NEXUS_EVENT_SOURCED=1` on a populated catalog without first running `synthesize-log`. First event-sourced write produces a one-event log. Pre-fix, on next process start `_ensure_consistent` would have DELETEd 10k legacy rows and replayed only one event — silent data loss. New `_event_log_covers_legacy()` check refuses the event-sourced rebuild when documents.jsonl has materially more rows than events.jsonl has DocumentRegistered events; falls through to legacy rebuild with a structured warning.

### Three round-3 tests with false-confidence problems fixed
- `test_second_catalog_sees_events_jsonl_writes` opened a fresh DB so DELETEs were no-ops and the contract was untested. Sibling test `test_rebuild_clears_existing_rows_before_replay` pre-populates a phantom row and asserts it's gone after rebuild.
- `test_doctor_uses_events_jsonl_when_present` — both branches produced the same projection so a regression couldn't be caught. Now strips links.jsonl and confirms the link survives only via the events.jsonl path.
- The vacuous `TestGateStateLog` test fix lands in the hardening PR.

## Round-4 hygiene

- Cached `Projector` at `__init__` (one per Catalog lifetime).
- `Catalog.__init__` logs `catalog_gate_state` once at info level.
- Legacy `update()` `INSERT OR REPLACE` includes `alias_of` for symmetry.
- projector.py docstring updated (LinkCreated now uses INSERT OR REPLACE).

## Test plan

14 tests in `tests/test_rdr101_round3_correctness.py`:

- [x] Link/unlink event-source roundtrip
- [x] Link merge converges via `INSERT OR REPLACE`
- [x] Full replay includes links
- [x] Cross-process `_ensure_consistent` replay
- [x] **Rebuild clears existing rows before replay** (round-4)
- [x] **Bootstrap guardrail refuses sparse event log** (round-4)
- [x] **Atomicity: apply_all failure rolls back DELETEs** (round-4)
- [x] **Doctor uses events.jsonl with discriminating signal** (round-4)
- [x] Legacy update alias_of column
- [x] Cached projector identity

Plus tests in `test_catalog_events.py` (default v=0) and `test_catalog_projector.py` (NotImplementedError raise).

959 catalog/event/projector/rdr101/mcp tests pass.

Refs nexus-o6aa.9 (RDR-101 Phase 3).