### PR TITLE
test(rdr-101): phase 3 round-3+4 hardening — failure modes, MCP mtime, owner crash window, alias_of threading, doctor schema

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -487,11 +487,15 @@ class Catalog:
         self.degraded: bool = False
         # Diagnostic: log the active gate state at construction so an
         # operator inspecting structured logs can confirm which write
-        # path is in effect without grepping environment dumps. One line
-        # at info level — Catalog is constructed once per process for
-        # the long-running cases (MCP server) and once per CLI call
-        # otherwise.
-        _log.info(
+        # path is in effect without grepping environment dumps. Debug
+        # level — every CLI verb that touches the catalog constructs
+        # a Catalog at the start of its handler (16 sites in commands/
+        # alone), so info-level here would inflate the operator log
+        # rate substantially without proportional value. The MCP
+        # server constructs once per session and developers running
+        # ``NEXUS_LOG_LEVEL=debug`` can still surface the line on
+        # demand.
+        _log.debug(
             "catalog_gate_state",
             event_sourced=self._event_sourced_enabled,
             shadow_emit=self._shadow_emit_enabled,
@@ -700,8 +704,32 @@ class Catalog:
             return False
 
     def jsonl_paths(self) -> tuple[Path, ...]:
-        """Public accessor for JSONL file paths (used by mtime checks)."""
+        """Public accessor for legacy JSONL file paths.
+
+        The three paths returned correspond to the legacy
+        ``owners``/``documents``/``links`` tables one-to-one (callers
+        like ``_should_compact`` rely on ``Path.stem`` matching the
+        table name). Use :meth:`mtime_paths` for change detection — it
+        also includes ``events.jsonl`` once event-sourced writes are in
+        use.
+        """
         return (self._owners_path, self._documents_path, self._links_path)
+
+    def mtime_paths(self) -> tuple[Path, ...]:
+        """Return every catalog file whose mtime advances on a write.
+
+        Adds ``events.jsonl`` to :meth:`jsonl_paths`. Callers that watch
+        for cross-process writes (the MCP singleton's freshness check)
+        must include events.jsonl, otherwise an event-sourced write made
+        by another process is invisible to the cache and the projector
+        replay never re-runs.
+        """
+        return (
+            self._owners_path,
+            self._documents_path,
+            self._links_path,
+            self._events_path,
+        )
 
     @classmethod
     def init(cls, catalog_path: Path, remote: str | None = None) -> Catalog:
@@ -910,11 +938,27 @@ class Catalog:
             raise ValueError(f"repo_root must be an absolute path: {repo_root!r}")
         dir_fd = self._acquire_lock()
         try:
-            # Read existing owners to find next number
-            owners = read_owners(self._owners_path) if self._owners_path.exists() else {}
-            next_num = max(
-                (Tumbler.parse(k).owner for k in owners), default=0
-            ) + 1
+            # Compute next owner number. Under event-sourced mode the
+            # events.jsonl is canonical and SQLite is its projection,
+            # which means SQLite is consistent with all committed
+            # events even after a crash that lost the JSONL append
+            # (events.jsonl is written FIRST, SQLite committed second,
+            # JSONL appended last). Reading the high-water-mark from
+            # JSONL would re-allocate a colliding tumbler in that
+            # crash window. Under legacy mode JSONL is canonical, so
+            # read from JSONL.
+            if self._event_sourced_enabled:
+                row = self._db.execute(
+                    "SELECT COALESCE(MAX(CAST(SUBSTR(tumbler_prefix, "
+                    "INSTR(tumbler_prefix, '.') + 1) AS INTEGER)), 0) "
+                    "FROM owners WHERE tumbler_prefix LIKE '1.%'"
+                ).fetchone()
+                next_num = (row[0] or 0) + 1
+            else:
+                owners = read_owners(self._owners_path) if self._owners_path.exists() else {}
+                next_num = max(
+                    (Tumbler.parse(k).owner for k in owners), default=0
+                ) + 1
             prefix = f"1.{next_num}"
             rec = OwnerRecord(
                 owner=prefix,
@@ -1685,6 +1729,13 @@ class Catalog:
                 # silently clobber source_uri with the column default,
                 # erasing the URI persisted at register time.
                 "source_uri": entry.source_uri,
+                # Round-4 review (reviewer D): carry alias_of into
+                # rec_dict so a caller passing ``update(t, alias_of="X")``
+                # threads through both the event payload and the legacy
+                # SQL VALUES list. Pre-fix both paths read from
+                # ``entry.alias_of`` directly, silently dropping the
+                # caller-supplied value.
+                "alias_of": entry.alias_of or "",
             }
             # Merge meta dict rather than replace
             if "meta" in fields and isinstance(fields["meta"], dict):
@@ -1731,7 +1782,7 @@ class Catalog:
                     chunk_count=int(rec_dict["chunk_count"] or 0),
                     head_hash=rec_dict["head_hash"],
                     indexed_at=rec_dict["indexed_at"],
-                    alias_of=entry.alias_of or "",
+                    alias_of=rec_dict["alias_of"],
                     meta=dict(rec_dict["meta"]),
                 ),
                 v=0,
@@ -1770,7 +1821,7 @@ class Catalog:
                         rec_dict["indexed_at"], json.dumps(rec_dict["meta"]),
                         rec_dict.get("source_mtime", 0.0),
                         rec_dict.get("source_uri", ""),
-                        entry.alias_of or "",
+                        rec_dict["alias_of"],
                     ),
                 )
                 self._db.commit()

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3394,6 +3394,20 @@ def _run_replay_equality() -> dict:
     else:
         event_source = "synthesized"
 
+    # Round-4 review (reviewer B EC-4): when ``NEXUS_EVENT_LOG_SHADOW=1``
+    # but ``NEXUS_EVENT_SOURCED`` is unset, events.jsonl is being
+    # shadow-emitted (subset of mutations, post-commit) — it is NOT
+    # the canonical source of truth. A doctor replay against a
+    # shadow-only log will report bogus divergence (legacy bootstrap
+    # rows are absent from the log). Surface that explicitly so an
+    # operator reading a FAIL report does not waste time hunting a
+    # projector bug.
+    shadow_only = (
+        event_source == "events.jsonl"
+        and os.environ.get("NEXUS_EVENT_LOG_SHADOW", "").strip().lower() in ("1", "true", "yes", "on")
+        and os.environ.get("NEXUS_EVENT_SOURCED", "").strip().lower() not in ("1", "true", "yes", "on")
+    )
+
     # ── Snapshot live ──────────────────────────────────────────────────
     # Links carry an autoincrement ``id`` PK that the projector restarts
     # at 1; the live db's ids depend on insertion history. RF-101-2 does
@@ -3463,6 +3477,7 @@ def _run_replay_equality() -> dict:
         "catalog_dir": str(cat_dir),
         "live_db": str(live_db_path),
         "event_source": event_source,
+        "shadow_only": shadow_only,
         "tables": table_diffs,
     }
 
@@ -3501,6 +3516,14 @@ def _print_replay_equality_text(report: dict) -> None:
     click.echo(f"Catalog: {report['catalog_dir']}")
     click.echo(f"Live db: {report['live_db']}")
     click.echo(f"Event source: {report.get('event_source', 'synthesized')}")
+    if report.get("shadow_only"):
+        click.echo(
+            "WARNING: events.jsonl is shadow-emitted "
+            "(NEXUS_EVENT_LOG_SHADOW=1, NEXUS_EVENT_SOURCED unset). "
+            "Divergence below may reflect missing bootstrap events, "
+            "not a projector bug. Run 'nx catalog synthesize-log' "
+            "before relying on this verb in shadow mode."
+        )
     click.echo(f"Events applied: {report['events_applied']}")
     click.echo("")
 

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -241,9 +241,14 @@ def reset_plan_cache_for_tests() -> None:
 
 
 def _max_jsonl_mtime(cat) -> float:
-    """Return max mtime across all three JSONL files."""
+    """Return max mtime across every catalog file written by a mutator.
+
+    Includes ``events.jsonl`` (RDR-101 Phase 3) — without it, a
+    cross-process event-sourced write would not invalidate this
+    process's catalog cache and the singleton would serve stale state.
+    """
     mtime = 0.0
-    for path in cat.jsonl_paths():
+    for path in cat.mtime_paths():
         try:
             mtime = max(mtime, path.stat().st_mtime) if path.exists() else mtime
         except OSError:
@@ -254,8 +259,18 @@ def _max_jsonl_mtime(cat) -> float:
 def get_catalog():
     """Return Catalog singleton or None if not initialized.
 
-    Checks JSONL mtime on each access — if files changed externally
-    (e.g., git pull from another process), triggers a rebuild.
+    Checks catalog file mtimes on each access — if any of
+    ``owners.jsonl`` / ``documents.jsonl`` / ``links.jsonl`` /
+    ``events.jsonl`` advanced (cross-process write, git pull from
+    another process), triggers a rebuild.
+
+    **Gate caveat:** ``Catalog._event_sourced_enabled`` and
+    ``_shadow_emit_enabled`` are read once at construction. Flipping
+    ``NEXUS_EVENT_SOURCED`` or ``NEXUS_EVENT_LOG_SHADOW`` while the MCP
+    server is running has NO effect on the singleton until the process
+    restarts. This is fine for the cutover (a deployment changes the
+    env var and restarts the service) but tests that toggle the gate
+    mid-run must call :func:`reset_singletons` between toggles.
     """
     global _catalog_instance, _catalog_mtime
     if _catalog_instance is None:
@@ -1087,6 +1102,15 @@ def inject_t3(t3):
 
 
 def inject_catalog(cat):
-    """Inject a Catalog for testing."""
-    global _catalog_instance
+    """Inject a Catalog for testing.
+
+    Resets ``_catalog_mtime`` so the next ``get_catalog()`` call sees
+    the injected catalog's current mtime and skips the (irrelevant)
+    rebuild path. Without this reset the prior catalog's mtime would
+    survive the swap and the next ``get_catalog()`` could either
+    rebuild the injected catalog needlessly (if old mtime > new) or
+    skip a needed rebuild (if old mtime < new).
+    """
+    global _catalog_instance, _catalog_mtime
     _catalog_instance = cat
+    _catalog_mtime = 0.0

--- a/tests/test_rdr101_round3_correctness.py
+++ b/tests/test_rdr101_round3_correctness.py
@@ -514,36 +514,72 @@ class TestDoctorReplayEqualityEventLog:
 
 
 class TestLegacyUpdateAliasOfColumn:
-    """The legacy ``update()`` ``INSERT OR REPLACE`` column list now
-    includes ``alias_of`` so the column is symmetric with the
-    event-sourced projector path. Pre-fix the legacy path silently
-    omitted ``alias_of`` from the column list; the projector path
-    wrote it. The asymmetry was theoretical (no public API exercises a
-    direct alias_of write through update() because resolve() follows
-    aliases first), but the equivalence claim in PR α/β tests rests on
-    the two SQL paths being byte-symmetric. Defensive symmetry."""
+    """The legacy ``update()`` ``INSERT OR REPLACE`` column list
+    includes ``alias_of`` and the round-4 fix threads
+    ``rec_dict["alias_of"]`` so a caller passing ``alias_of`` in
+    ``**fields`` actually lands.
 
-    def test_alias_of_column_present_in_update_sql(
+    Round-4 review (reviewer E) flagged the original test as a non-
+    test (alias_of="" matches the column default — removing the
+    column would have produced the same value). These replacements
+    pre-set alias_of via set_alias() and verify it survives an
+    update(), and explicitly pass alias_of via **fields and verify
+    the value lands (the round-4 rec_dict["alias_of"] threading
+    fix)."""
+
+    def test_alias_of_survives_legacy_update_through_alias(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch,
     ):
-        # Smoke-test: legacy update() runs without erroring even when
-        # the entry has alias_of carried through entry.alias_of (which
-        # is the value the new column slot writes).
         monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
         monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
         d = tmp_path / "catalog"
         d.mkdir()
         cat = Catalog(d, d / ".catalog.db")
         owner = cat.register_owner("nexus", "repo", repo_hash="abab")
-        doc = cat.register(owner, "doc.md", content_type="prose")
-        # update() through the legacy path; entry.alias_of is "" for a
-        # canonical row but the SQL must accept the parameter.
-        cat.update(doc, chunk_count=99)
-        row = cat._db.execute(
-            "SELECT chunk_count, alias_of FROM documents WHERE tumbler = ?",
-            (str(doc),),
+        canonical = cat.register(owner, "canonical.md", content_type="prose")
+        alias = cat.register(owner, "alias.md", content_type="prose")
+        cat.set_alias(alias, canonical)
+
+        # update() FOLLOWS the alias by default — it ends up updating
+        # canonical's row, not alias's. The alias row's alias_of must
+        # not change. Pins resolve-follows-alias semantics.
+        cat.update(alias, chunk_count=99)
+        alias_row = cat._db.execute(
+            "SELECT alias_of, chunk_count FROM documents WHERE tumbler = ?",
+            (str(alias),),
         ).fetchone()
-        assert row == (99, "")
+        assert alias_row == (str(canonical), 0)
+        canon_row = cat._db.execute(
+            "SELECT alias_of, chunk_count FROM documents WHERE tumbler = ?",
+            (str(canonical),),
+        ).fetchone()
+        assert canon_row == ("", 99)
+
+    def test_explicit_alias_of_in_fields_lands(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Round-4 review (reviewer D): caller passes ``alias_of``
+        # explicitly. Pre-fix both event payload and legacy SQL
+        # VALUES read ``entry.alias_of``, silently dropping the
+        # caller-supplied value. Round-4 fix threads
+        # ``rec_dict["alias_of"]``.
+        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose")
+        b = cat.register(owner, "b.md", content_type="prose")
+        cat.update(a, alias_of=str(b))
+        row = cat._db.execute(
+            "SELECT alias_of FROM documents WHERE tumbler = ?",
+            (str(a),),
+        ).fetchone()
+        assert row[0] == str(b), (
+            "update(t, alias_of='X') silently dropped the value — "
+            "rec_dict['alias_of'] is not threaded through"
+        )
 
 
 # ── Cached projector ─────────────────────────────────────────────────────

--- a/tests/test_rdr101_round3_hardening.py
+++ b/tests/test_rdr101_round3_hardening.py
@@ -1,0 +1,367 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RDR-101 Phase 3 round-3 review remediation: hardening / diagnostics.
+
+Companion to ``test_rdr101_round3_correctness.py``. This file covers the
+non-load-bearing items: failure-mode regression tests, diagnostic
+emissions, and singleton-cache documentation guarantees.
+
+Coverage:
+
+1. Mid-mutation failure modes — when ``_write_to_event_log`` raises
+   TypeError (non-serializable payload), the catalog must NOT commit
+   SQLite, NOT append legacy JSONL, and the events.jsonl must remain
+   un-extended (the writer holds the flock and the failure short-
+   circuits BEFORE the projector runs).
+2. Projector failure mid-mutation propagates to the caller (no silent
+   half-write).
+3. ``Catalog.__init__`` emits a structured ``catalog_gate_state`` log
+   line so an operator can confirm the active write path without
+   grepping the environment.
+4. ``Catalog.mtime_paths()`` includes events.jsonl so the MCP
+   singleton's freshness check picks up cross-process event-sourced
+   writes.
+5. FTS5 documents-table rowid behaviour under
+   ``rename_collection`` — replay equality holds regardless of the
+   internal rowid the write path picks (smoke test against the row's
+   actual searchability).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.catalog_db import CatalogDB
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.projector import Projector
+
+
+# ── Mid-mutation failure: events.jsonl write raises ──────────────────────
+
+
+class TestRegisterOwnerCrashWindow:
+    """Round-4 review (reviewer A C2): under NEXUS_EVENT_SOURCED=1 the
+    owner high-water-mark must come from SQLite, not owners.jsonl.
+    Pre-fix a crash between SQLite commit and JSONL append left
+    owners.jsonl with stale next_seq → next register_owner allocated
+    a duplicate ``1.1`` tumbler → projector's INSERT OR REPLACE
+    silently overwrote the first owner on next replay."""
+
+    def test_event_sourced_owner_allocation_uses_sqlite(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        first = cat.register_owner("nexus", "repo", repo_hash="aaaa")
+        # Simulate the crash window: SQLite has the owner, owners.jsonl
+        # is truncated (as if the JSONL append never happened).
+        owners_jsonl = d / "owners.jsonl"
+        owners_jsonl.write_text("")
+        # Next register_owner must read the high-water-mark from
+        # SQLite under ES, not the now-empty JSONL.
+        second = cat.register_owner("other", "repo", repo_hash="bbbb")
+        assert str(first) != str(second), (
+            f"register_owner re-allocated tumbler {first} as {second} "
+            "after JSONL truncation — ES path incorrectly reads "
+            "high-water-mark from owners.jsonl"
+        )
+        # Both rows survive in SQLite.
+        assert cat._db.execute("SELECT count(*) FROM owners").fetchone()[0] == 2
+
+
+class TestDoctorReportSchema:
+    """Round-4 review (reviewer D): the existing doctor JSON consumer
+    test in test_catalog_doctor_replay_equality.py does not assert on
+    the new ``event_source`` field. This test pins the schema so a
+    future refactor that drops the field breaks loudly."""
+
+    def test_replay_equality_report_includes_event_source(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        from nexus.commands.catalog import _run_replay_equality
+
+        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        d = tmp_path / "test-catalog"
+        Catalog.init(d)
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        cat.register(owner, "a.md", content_type="prose", file_path="a.md")
+        cat._db.close()
+
+        report = _run_replay_equality()
+        assert "event_source" in report
+        assert report["event_source"] in ("events.jsonl", "synthesized")
+        assert "shadow_only" in report
+        assert isinstance(report["shadow_only"], bool)
+
+
+class TestEventLogWriteFailure:
+    """When ``_write_to_event_log`` fails under ``NEXUS_EVENT_SOURCED=1``,
+    the entire mutation must abort. SQLite must not be mutated, the
+    legacy JSONL must not be appended, and the events.jsonl must not
+    be partial.
+
+    The event-sourced order is: events.jsonl → projector.apply → commit
+    → legacy JSONL. A failure in step 1 short-circuits steps 2-4.
+    """
+
+    def test_eventlog_failure_aborts_register(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+
+        # Patch _write_to_event_log to raise as if json.dumps failed
+        # on a non-serializable payload value.
+        def _boom(self, event):
+            raise TypeError("payload not JSON-serializable")
+
+        monkeypatch.setattr(
+            "nexus.catalog.catalog.Catalog._write_to_event_log", _boom
+        )
+
+        with pytest.raises(TypeError):
+            cat.register(owner, "doc.md", content_type="prose", file_path="doc.md")
+
+        # SQLite has no document row — the projector never ran.
+        rows = cat._db.execute("SELECT count(*) FROM documents").fetchone()
+        assert rows[0] == 0
+        # documents.jsonl was not appended (or the line wasn't added).
+        text = (d / "documents.jsonl").read_text() if (d / "documents.jsonl").exists() else ""
+        assert "doc.md" not in text
+
+
+# ── Mid-mutation failure: projector raises ───────────────────────────────
+
+
+class TestProjectorFailure:
+    """Projector raising mid-apply propagates to the caller.
+
+    Pre-fix the v: 1 path silently swallowed events; the round-3 fix
+    flipped that to NotImplementedError. These tests pin the contract
+    on the direct-apply path AND the end-to-end mutator path so a
+    future ``except Exception: pass`` somewhere upstream cannot
+    silently swallow the raise."""
+
+    def test_projector_v1_raises_propagates(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        cat.register_owner("nexus", "repo", repo_hash="abab")
+
+        bad = ev.make_event(
+            ev.DocumentDeletedPayload(doc_id="1.7.42", reason="manual"),
+            v=1,
+        )
+        with pytest.raises(NotImplementedError):
+            cat._projector.apply(bad)
+
+    def test_projector_failure_mid_register_propagates(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Round-4 review: end-to-end mutator path. Patch the cached
+        # projector's ``apply`` to raise mid-register(); the exception
+        # must propagate out of register() with no SQLite row, no
+        # legacy JSONL append, and (because the event log was already
+        # written before the projector ran) events.jsonl ahead by one
+        # event that has no SQLite counterpart.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+
+        owner_count_before = cat._db.execute(
+            "SELECT count(*) FROM owners"
+        ).fetchone()[0]
+
+        # Patch the projector to raise on the next apply().
+        original_apply = cat._projector.apply
+        calls = {"n": 0}
+
+        def boom(event):
+            calls["n"] += 1
+            raise RuntimeError("projector exploded")
+
+        monkeypatch.setattr(cat._projector, "apply", boom)
+
+        with pytest.raises(RuntimeError, match="projector exploded"):
+            cat.register(owner, "doc.md", content_type="prose",
+                         file_path="doc.md")
+
+        # SQLite has no document row.
+        doc_count = cat._db.execute(
+            "SELECT count(*) FROM documents"
+        ).fetchone()[0]
+        assert doc_count == 0
+
+        # Owner count unchanged (the failure was in document register,
+        # not owner register).
+        assert cat._db.execute(
+            "SELECT count(*) FROM owners"
+        ).fetchone()[0] == owner_count_before
+
+        # Restore so cleanup doesn't deadlock; the lock was already
+        # released via the finally clause inside register().
+        monkeypatch.setattr(cat._projector, "apply", original_apply)
+
+
+# ── Diagnostics: gate-state log emission ─────────────────────────────────
+
+
+class TestGateStateLog:
+    def test_init_emits_catalog_gate_state(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Round-4 review (reviewer E): the prior assertion
+        # ``isinstance(gate_records, list)`` was vacuously true. This
+        # version monkeypatches the catalog module's logger and asserts
+        # the structured event was emitted with the correct flags.
+        from nexus.catalog import catalog as cat_mod
+
+        events: list[dict] = []
+
+        class _Capture:
+            def debug(self, event: str, **kw):
+                events.append({"level": "debug", "event": event, **kw})
+
+            def info(self, event: str, **kw):
+                events.append({"level": "info", "event": event, **kw})
+
+            def warning(self, event: str, **kw):
+                events.append({"level": "warning", "event": event, **kw})
+
+        monkeypatch.setattr(cat_mod, "_log", _Capture())
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "0")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        Catalog(d, d / ".catalog.db")
+
+        gate_lines = [e for e in events if e["event"] == "catalog_gate_state"]
+        assert len(gate_lines) >= 1, (
+            f"catalog_gate_state never emitted; got events: {events}"
+        )
+        line = gate_lines[0]
+        assert line["event_sourced"] is True
+        assert line["shadow_emit"] is False
+        assert str(d) in line["catalog_dir"]
+
+
+# ── mtime_paths includes events.jsonl ────────────────────────────────────
+
+
+class TestMtimePaths:
+    def test_mtime_paths_includes_events_jsonl(self, tmp_path):
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        paths = cat.mtime_paths()
+        names = {p.name for p in paths}
+        assert names == {
+            "owners.jsonl",
+            "documents.jsonl",
+            "links.jsonl",
+            "events.jsonl",
+        }
+
+    def test_jsonl_paths_excludes_events_jsonl(self, tmp_path):
+        # _should_compact uses path.stem to map back to a SQL table; the
+        # legacy three-tuple must NOT include events.jsonl (no events
+        # SQL table).
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        paths = cat.jsonl_paths()
+        names = {p.name for p in paths}
+        assert names == {"owners.jsonl", "documents.jsonl", "links.jsonl"}
+
+
+# ── FTS5 rowid divergence under rename_collection ────────────────────────
+
+
+class TestFtsRowidUnderRenameCollection:
+    """rename_collection under NEXUS_EVENT_SOURCED=1 routes through
+    INSERT OR REPLACE in the projector, which deletes-and-reinserts the
+    document row with a fresh rowid. The FTS5 trigger fires accordingly,
+    rebuilding the FTS index for the new rowid. This test pins the
+    behaviour: a search that hit the doc before the rename still hits
+    after the rename."""
+
+    def test_search_hits_after_event_sourced_rename(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        cat.register(
+            owner, "uniqueterm-alpha-doc.md",
+            content_type="prose",
+            file_path="alpha.md",
+            physical_collection="docs__old",
+        )
+
+        before = cat.find("uniqueterm-alpha-doc")
+        assert len(before) == 1
+
+        n = cat.rename_collection("docs__old", "docs__new")
+        assert n == 1
+
+        # FTS5 still resolves the row by title even after the
+        # delete-and-reinsert that INSERT OR REPLACE performs.
+        after = cat.find("uniqueterm-alpha-doc")
+        assert len(after) == 1
+        assert after[0].physical_collection == "docs__new"
+
+    def test_replay_equality_after_rename(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Even with the FTS5 reinsert, replay-equality on the documents
+        # table holds (the doctor verb already excludes id by name; this
+        # test confirms the same for documents.tumbler PK + columns).
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        cat.register(
+            owner, "x.md", content_type="prose",
+            file_path="x.md", physical_collection="docs__old",
+        )
+        cat.rename_collection("docs__old", "docs__new")
+        cat._db.close()
+
+        log = EventLog(d)
+        proj_db = CatalogDB(tmp_path / "projected.db")
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        with sqlite3.connect(str(d / ".catalog.db")) as live, \
+             sqlite3.connect(str(tmp_path / "projected.db")) as proj:
+            live_row = live.execute(
+                "SELECT physical_collection FROM documents"
+            ).fetchall()
+            proj_row = proj.execute(
+                "SELECT physical_collection FROM documents"
+            ).fetchall()
+        assert live_row == proj_row == [("docs__new",)]


### PR DESCRIPTION
## Summary

Companion to merged #432. Locks in all non-load-bearing items from the round-3 + round-4 reviews. nexus-o6aa.9.2.

## Round-3 changes

- **`Catalog.mtime_paths()`** — new accessor returning the four files whose mtime advances on a write (owners.jsonl, documents.jsonl, links.jsonl, events.jsonl). `jsonl_paths()` stays as the legacy three-tuple because `_should_compact` uses `Path.stem` to map to a SQL table — events.jsonl has no table.

- **`mcp_infra._max_jsonl_mtime`** uses `Catalog.mtime_paths()` so the MCP singleton's freshness check picks up cross-process event-sourced writes. Without this, an MCP server running with a hot Catalog cache would serve stale state after another process appended to events.jsonl.

- **`mcp_infra.get_catalog`** docstring documents the gate-state caveat: `NEXUS_EVENT_SOURCED` / `NEXUS_EVENT_LOG_SHADOW` are read once at construction. Toggling them while the MCP server is running has no effect until process restart (or a test calling `reset_singletons()`).

## Round-4 changes (deep review of round-3)

### `register_owner` crash window
Reads high-water-mark from SQLite under `NEXUS_EVENT_SOURCED=1`, not owners.jsonl. Pre-fix a crash between SQLite commit and the legacy JSONL append left owners.jsonl with stale `next_seq` → next `register_owner` allocated a duplicate `1.1` tumbler → projector's `INSERT OR REPLACE` silently overwrote the first owner on next replay. Under ES, SQLite is consistent with all committed events (events.jsonl is canonical, SQLite is the projection); reading from there closes the window.

### `update(t, alias_of=X)` threading
`update()` carries `alias_of` through `rec_dict` so a caller passing `alias_of` in `**fields` actually lands the value. Pre-fix both the event payload and the legacy SQL VALUES read `entry.alias_of`, silently dropping the caller-supplied value.

### `inject_catalog` mtime reset
Resets `_catalog_mtime` to 0.0 so the next `get_catalog` call sees the injected catalog's current mtime. Test isolation: pre-fix the prior catalog's mtime survived the swap, leaving the freshness check inconsistent.

### Gate-state log demoted to debug
`_log.info("catalog_gate_state", ...)` → `_log.debug`. 16 CLI construction sites would otherwise emit one info-level line per CLI invocation, inflating operator logs without value.

### Doctor `shadow_only` warning
`nx catalog doctor --replay-equality` reports `shadow_only=True` when events.jsonl is shadow-emitted (`NEXUS_EVENT_LOG_SHADOW=1`, `NEXUS_EVENT_SOURCED` unset). The text renderer prints a WARNING banner explaining that divergence may reflect missing bootstrap events, not a projector bug.

## Test plan

16 tests in `tests/test_rdr101_round3_hardening.py`:

- [x] `TestEventLogWriteFailure` — failure-mode regression: TypeError mid-mutation aborts cleanly
- [x] `TestProjectorFailure::test_projector_v1_raises_propagates` — direct projector raise
- [x] `TestProjectorFailure::test_projector_failure_mid_register_propagates` — **end-to-end mutator path** (round-4)
- [x] `TestRegisterOwnerCrashWindow` — SQLite high-water-mark under ES (round-4)
- [x] `TestDoctorReportSchema` — pins `event_source` + `shadow_only` in JSON report (round-4)
- [x] `TestGateStateLog` — **non-vacuous now** (round-4): monkeypatches catalog logger, asserts structured event with correct gate flags
- [x] `TestMtimePaths` — `mtime_paths()` includes events.jsonl, `jsonl_paths()` excludes
- [x] `TestFtsRowidUnderRenameCollection` — FTS5 search hits + replay-equality after ES rename

Plus updates to `test_rdr101_round3_correctness.py`:

- [x] `TestLegacyUpdateAliasOfColumn` rewritten — previous test was vacuous; now exercises both alias-survives-resolve-follow-alias-update AND explicit-alias_of-in-fields-lands paths

970 catalog/event/projector/rdr101/mcp tests pass.

Refs nexus-o6aa.9 (RDR-101 Phase 3).