### PR TITLE
feat(rdr-101): phase 3 PR δ stage B.1 — prose_indexer writes doc_id at chunk-write time

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -464,3 +464,11 @@
 {"id":"int-6f3d2448","kind":"field_change","created_at":"2026-05-01T10:47:01.136602Z","actor":"Hellblazer","issue_id":"nexus-8t7z","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-7524e724","kind":"field_change","created_at":"2026-05-01T10:52:09.084774Z","actor":"Hellblazer","issue_id":"nexus-8t7z","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-d1f0498b","kind":"field_change","created_at":"2026-05-01T10:52:28.985062Z","actor":"Hellblazer","issue_id":"nexus-rbyl","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-94bb30f6","kind":"field_change","created_at":"2026-05-01T13:30:31.590252Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.1","extra":{"field":"status","new_value":"closed","old_value":"blocked"}}
+{"id":"int-a9beb86c","kind":"field_change","created_at":"2026-05-01T13:30:32.298797Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.2","extra":{"field":"status","new_value":"blocked","old_value":"in_progress"}}
+{"id":"int-9a8c8c26","kind":"field_change","created_at":"2026-05-01T13:42:53.749876Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.2","extra":{"field":"status","new_value":"closed","old_value":"blocked"}}
+{"id":"int-270c23a2","kind":"field_change","created_at":"2026-05-01T14:05:10.371213Z","actor":"Hellblazer","issue_id":"nexus-yhwu","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-edf32586","kind":"field_change","created_at":"2026-05-01T14:45:14.33911Z","actor":"Hellblazer","issue_id":"nexus-yhwu","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-d15576f1","kind":"field_change","created_at":"2026-05-01T14:45:50.873916Z","actor":"Hellblazer","issue_id":"nexus-fecd","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-a3768676","kind":"field_change","created_at":"2026-05-01T15:48:19.982123Z","actor":"Hellblazer","issue_id":"nexus-fecd","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-bc12fe8e","kind":"field_change","created_at":"2026-05-01T16:07:43.764006Z","actor":"Hellblazer","issue_id":"nexus-t6p0","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/index_context.py
+++ b/src/nexus/index_context.py
@@ -60,6 +60,16 @@ class IndexContext:
     # When set, replaces Voyage AI embedding in code_indexer and prose_indexer.
     embed_fn: Callable[[list[str]], list[list[float]]] | None = field(default=None)
 
+    # Catalog Document.doc_id resolver (RDR-101 Phase 3 PR δ Stage B).
+    # When set, indexers call ``doc_id_resolver(file_path)`` and pass the
+    # returned tumbler string into ``make_chunk_metadata``'s ``doc_id``
+    # argument so freshly-written T3 chunks carry the catalog
+    # cross-reference at chunk-write time. The orchestrator builds this
+    # closure from the pre-index catalog registration map; ``None`` is
+    # the legacy / no-catalog path (chunks ship without ``doc_id``,
+    # which ``metadata_schema.normalize`` Step 4c then drops).
+    doc_id_resolver: Callable[[Path], str] | None = field(default=None)
+
     # Per-stage intra-file timing bucket (nexus-7niu, vatx Gap 4b).
     # Populated only when the operator passes ``nx index repo --debug-timing``.
     # Silent when ``None`` — the per-file indexer skips the timing blocks

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -246,8 +246,17 @@ def _catalog_hook(
     repo_hash: str,
     head_hash: str,
     indexed_files: list[tuple[Path, str, str]],
-) -> None:
-    """Register/update indexed files in catalog. Silently skipped if catalog absent."""
+) -> dict[Path, str]:
+    """Register/update indexed files in catalog. Silently skipped if catalog absent.
+
+    Returns a ``{abs_path: doc_id}`` map (empty when the catalog is absent
+    or cannot be opened) so the orchestrator can build a
+    ``doc_id_resolver`` closure and inject it into ``IndexContext``
+    before per-file indexing runs (RDR-101 Phase 3 PR δ Stage B). The
+    return type is additive — existing test call sites that ignore the
+    return value continue to work unchanged.
+    """
+    file_to_doc_id: dict[Path, str] = {}
     try:
         from nexus.catalog import Catalog
         from nexus.config import catalog_path
@@ -255,7 +264,7 @@ def _catalog_hook(
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             _log.debug("catalog_hook_skipped", reason="catalog not initialized")
-            return
+            return file_to_doc_id
 
         cat = Catalog(cat_path, cat_path / ".catalog.db")
 
@@ -318,6 +327,7 @@ def _catalog_hook(
                     source_mtime=source_mtime,
                 )
                 new_tumblers.append(tumbler)
+                file_to_doc_id[abs_path] = str(tumbler)
             else:
                 cat.update(
                     existing.tumbler,
@@ -326,6 +336,7 @@ def _catalog_hook(
                     meta={"content_hash": file_hash} if file_hash else None,
                     source_mtime=source_mtime,
                 )
+                file_to_doc_id[abs_path] = str(existing.tumbler)
         _progress(f"  Catalog: {len(new_tumblers)} new, {len(indexed_files) - len(new_tumblers)} updated\n")
 
         # Auto-generate links after registration (incremental: only new entries)
@@ -348,6 +359,7 @@ def _catalog_hook(
         _progress(f"  Catalog: done ({len(new_tumblers)} new, {links_created} links)\n")
     except Exception:
         _log.debug("catalog_hook_failed", exc_info=True)
+    return file_to_doc_id
 
 
 def _run_housekeeping(
@@ -646,6 +658,7 @@ def _index_prose_file(
     *,
     embed_fn: Callable | None = None,
     stage_timers: "StageTimers | None" = None,
+    doc_id_resolver: Callable[[Path], str] | None = None,
 ) -> int:
     """Index a single prose file.  Delegates to nexus.prose_indexer.index_prose_file.
 
@@ -655,6 +668,11 @@ def _index_prose_file(
     ``stage_timers`` (nexus-7niu) is an optional :class:`StageTimers` the
     per-file indexer writes chunking / embed / upload / retry times into.
     ``None`` is the fast path: no overhead, no output.
+
+    ``doc_id_resolver`` (RDR-101 Phase 3 PR δ Stage B.1) returns the
+    catalog ``Document.doc_id`` for *file* so prose chunks land in T3
+    with a back-reference to the catalog. ``None`` is the legacy /
+    no-catalog path.
     """
     from nexus.prose_indexer import index_prose_file
     from nexus.index_context import IndexContext
@@ -674,6 +692,7 @@ def _index_prose_file(
         timeout=timeout,
         embed_fn=embed_fn,
         stage_timers=stage_timers,
+        doc_id_resolver=doc_id_resolver,
     )
     return index_prose_file(ctx, file)
 
@@ -1206,6 +1225,50 @@ def _run_index(
         else:
             _log.info("force_stale_skipped", reason="all collections current")
 
+    # ── Pre-index catalog registration (RDR-101 Phase 3 PR δ Stage B) ───────
+    # Register catalog entries BEFORE per-file indexing so the prose
+    # (and forthcoming code / PDF / RDR) indexers can write the catalog
+    # ``Document.doc_id`` into T3 chunk metadata at chunk-write time.
+    # ``_catalog_hook`` is a graceful no-op when the catalog is absent
+    # (returns an empty map), so the resolver becomes a noop closure
+    # and indexers fall back to the legacy / no-catalog code path.
+    #
+    # The hook also runs link generation and orphan housekeeping. Both
+    # are determined by the file LIST not by indexing OUTCOME, so
+    # running them up front is safe; on a CTRL-C mid-index, the next
+    # run re-derives them idempotently.
+    from nexus.registry import _rdr_collection_name as _rdr_coll_name_for_repo
+    indexed_for_catalog: list[tuple[Path, str, str]] = []
+    for _, f in code_files:
+        indexed_for_catalog.append((f, "code", code_collection))
+    for _, f in prose_files:
+        indexed_for_catalog.append((f, "prose", docs_collection))
+    if rdr_abs_paths:
+        rdr_col_name = _rdr_coll_name_for_repo(repo)
+        for rdr_dir in rdr_abs_paths:
+            if rdr_dir.is_dir():
+                for md_file in sorted(rdr_dir.rglob("*.md")):
+                    if md_file.is_file():
+                        indexed_for_catalog.append((md_file, "rdr", rdr_col_name))
+
+    if on_phase is not None:
+        on_phase(f"Registering {len(indexed_for_catalog)} catalog entries…")
+    _catalog_t0 = time.monotonic()
+    file_to_doc_id = _catalog_hook(
+        repo=repo,
+        repo_name=_repo_basename,
+        repo_hash=_repo_hash,
+        head_hash=_current_head(repo),
+        indexed_files=indexed_for_catalog,
+    )
+    if on_phase is not None:
+        on_phase(
+            f"Catalog registration done ({time.monotonic() - _catalog_t0:.1f}s)"
+        )
+
+    def _doc_id_resolver(path: Path) -> str:
+        return file_to_doc_id.get(path, "")
+
     # Index code files → code__ (voyage-code-3, AST chunking)
     # NOTE: calls _index_code_file (the module-level wrapper) so that tests
     # patching nexus.indexer._index_code_file continue to intercept correctly.
@@ -1251,6 +1314,7 @@ def _run_index(
             timeout=read_timeout_seconds,
             embed_fn=_embed_fn,
             stage_timers=timers,
+            doc_id_resolver=_doc_id_resolver,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)
@@ -1363,32 +1427,11 @@ def _run_index(
                     _log.debug("rdr_stamp_skipped", collection=rdr_col_name)
             _phase(f"Pipeline version stamped ({time.monotonic() - _t:.1f}s)")
 
-        # Catalog hook: register indexed files (opt-in, graceful absence)
-        indexed_for_catalog: list[tuple[Path, str, str]] = []
-        for _, f in code_files:
-            indexed_for_catalog.append((f, "code", code_collection))
-        for _, f in prose_files:
-            indexed_for_catalog.append((f, "prose", docs_collection))
-        # Include RDR files so code→RDR provenance links can be generated
-        # Register regardless of T3 indexing success — catalog tracks existence
-        if rdr_abs_paths:
-            from nexus.registry import _rdr_collection_name
-            rdr_col = _rdr_collection_name(repo)
-            for rdr_dir in rdr_abs_paths:
-                if rdr_dir.is_dir():
-                    for md_file in sorted(rdr_dir.rglob("*.md")):
-                        if md_file.is_file():
-                            indexed_for_catalog.append((md_file, "rdr", rdr_col))
-        _phase(f"Registering {len(indexed_for_catalog)} catalog entries…")
-        _t = time.monotonic()
-        _catalog_hook(
-            repo=repo,
-            repo_name=_repo_basename,
-            repo_hash=_repo_hash,
-            head_hash=_current_head(repo),
-            indexed_files=indexed_for_catalog,
-        )
-        _phase(f"Catalog registration done ({time.monotonic() - _t:.1f}s)")
+        # Catalog registration ran upfront (RDR-101 Phase 3 PR δ Stage B)
+        # so prose chunks could carry ``doc_id`` at chunk-write time.
+        # The "Registering …" / "Catalog registration done …" phase
+        # markers fire from the pre-index path (above the per-file loops),
+        # not from this block.
     except BaseException as exc:
         post_error = exc
         raise

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -77,9 +77,19 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
 
         from nexus.metadata_schema import make_chunk_metadata  # noqa: PLC0415
 
+        # Catalog Document.doc_id (RDR-101 Phase 3 PR δ): resolved once per
+        # file. Empty string when no catalog handle exists; ``normalize``
+        # Step 4c drops the field on the way to T3.
+        catalog_doc_id = (
+            ctx.doc_id_resolver(file_path) if ctx.doc_id_resolver is not None else ""
+        )
+
         for chunk in chunks:
             title = f"{file_path.relative_to(ctx.repo_path)}:chunk-{chunk.chunk_index}"
-            doc_id = _hl.sha256(f"{ctx.corpus}:{title}".encode()).hexdigest()[:32]
+            # ``chunk_chroma_id`` is the per-chunk Chroma natural-id
+            # (sha256-derived) — disambiguated from the catalog
+            # ``Document.doc_id`` per RDR-101 Phase 0 nexus-o6aa.3.
+            chunk_chroma_id = _hl.sha256(f"{ctx.corpus}:{title}".encode()).hexdigest()[:32]
             metadata = make_chunk_metadata(
                 content_type="markdown",
                 source_path=str(file_path),
@@ -100,8 +110,9 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
                 category="prose",
                 frecency_score=float(ctx.score),
                 git_meta=ctx.git_meta,
+                doc_id=catalog_doc_id,
             )
-            ids.append(doc_id)
+            ids.append(chunk_chroma_id)
             documents.append(chunk.text)
             metadatas.append(metadata)
             # Embed-only prefix: helps Voyage AI locate the right context without
@@ -136,9 +147,18 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
 
         from nexus.metadata_schema import make_chunk_metadata  # noqa: PLC0415
 
+        # Catalog Document.doc_id (RDR-101 Phase 3 PR δ): resolved once per
+        # file. Empty string when no catalog handle exists.
+        catalog_doc_id = (
+            ctx.doc_id_resolver(file_path) if ctx.doc_id_resolver is not None else ""
+        )
+
         for i, (ls, le, text) in enumerate(raw_chunks):
             title = f"{file_path.relative_to(ctx.repo_path)}:{ls}-{le}"
-            doc_id = _hl.sha256(f"{ctx.corpus}:{title}".encode()).hexdigest()[:32]
+            # ``chunk_chroma_id`` is the per-chunk Chroma natural-id —
+            # disambiguated from catalog ``Document.doc_id`` per RDR-101
+            # Phase 0 nexus-o6aa.3.
+            chunk_chroma_id = _hl.sha256(f"{ctx.corpus}:{title}".encode()).hexdigest()[:32]
             chunk_start_char = _line_offsets[ls - 1] if 0 < ls <= len(_line_offsets) else 0
             chunk_end_char = (
                 _line_offsets[le] if le < len(_line_offsets) else len(content)
@@ -172,8 +192,9 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
                 category="prose",
                 frecency_score=float(ctx.score),
                 git_meta=ctx.git_meta,
+                doc_id=catalog_doc_id,
             )
-            ids.append(doc_id)
+            ids.append(chunk_chroma_id)
             documents.append(text)
             metadatas.append(metadata)
 

--- a/tests/test_prose_indexer_doc_id.py
+++ b/tests/test_prose_indexer_doc_id.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""WITH TEETH: prose_indexer must write the catalog tumbler as ``doc_id``
+into T3 chunk metadata at chunk-write time (RDR-101 Phase 3 PR δ Stage B.1).
+
+Without the pre-index resolver wiring, ``index_prose_file`` calls
+``make_chunk_metadata`` with no ``doc_id`` argument, the schema funnel
+drops the (empty) field via ``normalize`` Step 4c, and chunks land in T3
+with no back-reference to the catalog Document. The catalog doctor's
+``--t3-doc-id-coverage`` check would then read 0% on freshly-indexed
+corpora — the gap PR δ Stage A's schema gate alone cannot close.
+
+Reverting the wiring (resolver -> ctx.doc_id_resolver -> prose_indexer's
+``make_chunk_metadata`` ``doc_id=`` argument) breaks the test
+deterministically.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.tumbler import Tumbler
+from nexus.db.t3 import T3Database
+from nexus.registry import RepoRegistry
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture(autouse=True)
+def git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k, v in [
+        ("GIT_AUTHOR_NAME", "Test"),
+        ("GIT_AUTHOR_EMAIL", "test@test.invalid"),
+        ("GIT_COMMITTER_NAME", "Test"),
+        ("GIT_COMMITTER_EMAIL", "test@test.invalid"),
+    ]:
+        monkeypatch.setenv(k, v)
+
+
+@pytest.fixture
+def prose_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "prose-repo"
+    repo.mkdir()
+    (repo / "README.md").write_text(
+        "# Hello\n\nThis is a markdown file.\n\n"
+        "## First Section\n\nFirst section body.\n\n"
+        "## Second Section\n\nSecond section body.\n",
+        encoding="utf-8",
+    )
+    # Non-markdown prose: ``.rst`` is classified as PROSE (not in the
+    # SKIP set, not code), exercising prose_indexer's line-chunk branch.
+    (repo / "guide.rst").write_text(
+        "Plain Prose Guide\n"
+        "=================\n\n"
+        "First line of plain prose.\n"
+        "Second line of plain prose.\n"
+        "Third line for chunking.\n",
+        encoding="utf-8",
+    )
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@nexus")
+    _git(repo, "config", "user.name", "Nexus Test")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Initial commit")
+    return repo
+
+
+@pytest.fixture
+def local_t3() -> T3Database:
+    return T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+
+
+@pytest.fixture
+def registry(tmp_path: Path, prose_repo: Path) -> RepoRegistry:
+    reg = RepoRegistry(tmp_path / "repos.json")
+    reg.add(prose_repo)
+    return reg
+
+
+@pytest.fixture
+def catalog_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    catalog_dir = tmp_path / "catalog"
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+    Catalog.init(catalog_dir)
+    return catalog_dir
+
+
+@pytest.fixture(autouse=True)
+def mock_voyage_client():
+    """Local-mode test: voyageai client is never called, but
+    `voyageai.Client` may still be constructed by the orchestrator."""
+    ef = DefaultEmbeddingFunction()
+    mock_client = MagicMock()
+
+    def fake_embed(texts, model, input_type="document"):
+        r = MagicMock()
+        r.embeddings = ef(texts)
+        return r
+
+    def fake_contextualized_embed(inputs, model, input_type="document"):
+        r = MagicMock()
+        br = MagicMock()
+        br.embeddings = ef(inputs[0])
+        r.results = [br]
+        return r
+
+    mock_client.embed.side_effect = fake_embed
+    mock_client.contextualized_embed.side_effect = fake_contextualized_embed
+    with patch("voyageai.Client", return_value=mock_client):
+        yield mock_client
+
+
+def _do_index(repo: Path, registry: RepoRegistry, t3: T3Database, monkeypatch) -> None:
+    from nexus.indexer import index_repository
+
+    monkeypatch.setenv("NX_LOCAL", "1")
+    with patch("nexus.db.make_t3", return_value=t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"):
+        index_repository(repo, registry, force=False)
+
+
+def test_prose_indexer_writes_doc_id_into_t3_chunk_metadata(
+    prose_repo: Path,
+    registry: RepoRegistry,
+    local_t3: T3Database,
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-pass indexing of a fresh prose corpus must populate ``doc_id``
+    in every chunk's T3 metadata, matching the catalog tumbler the
+    orchestrator registered before per-file indexing.
+
+    Covers both the markdown and non-markdown branches of
+    ``prose_indexer.index_prose_file``.
+    """
+    _do_index(prose_repo, registry, local_t3, monkeypatch)
+
+    cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+    info = registry.get(prose_repo)
+    assert info is not None
+    docs_collection = info.get("docs_collection")
+    assert docs_collection, "registry should record docs_collection after indexing"
+
+    docs_col = local_t3.get_collection(docs_collection)
+    result = docs_col.get(include=["metadatas"])
+    assert result["ids"], "expected at least one prose chunk in T3 docs collection"
+
+    # Group chunks by the prose file they came from
+    by_source: dict[str, list[dict]] = {}
+    for meta in result["metadatas"]:
+        by_source.setdefault(meta["source_path"], []).append(meta)
+
+    assert by_source, "expected metadatas to carry source_path"
+
+    # Resolve the catalog owner for this repo
+    owner_row = cat._db.execute(
+        "SELECT tumbler_prefix FROM owners LIMIT 1"
+    ).fetchone()
+    assert owner_row is not None, "expected catalog owner registered by indexer"
+    owner_t = Tumbler.parse(owner_row[0])
+
+    md_seen = False
+    rst_seen = False
+    for source_path, metas in by_source.items():
+        rel_path = str(Path(source_path).relative_to(prose_repo))
+        entry = cat.by_file_path(owner_t, rel_path)
+        assert entry is not None, (
+            f"catalog has no entry for {rel_path!r} — "
+            "pre-index registration should have created one"
+        )
+        expected_doc_id = str(entry.tumbler)
+        for m in metas:
+            assert m.get("doc_id") == expected_doc_id, (
+                f"chunk for {rel_path} carries doc_id={m.get('doc_id')!r}, "
+                f"expected {expected_doc_id!r} (catalog tumbler)"
+            )
+        if rel_path.endswith(".md"):
+            md_seen = True
+        if rel_path.endswith(".rst"):
+            rst_seen = True
+
+    assert md_seen, "markdown branch (SemanticMarkdownChunker) was not exercised"
+    assert rst_seen, "non-markdown branch (line_chunk) was not exercised"
+
+
+def test_prose_indexer_doc_id_absent_when_catalog_uninitialized(
+    prose_repo: Path,
+    registry: RepoRegistry,
+    local_t3: T3Database,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no catalog exists at NEXUS_CATALOG_PATH, ``index_prose_file``
+    must still succeed and emit chunks WITHOUT ``doc_id`` (the schema
+    drops empty doc_id at the funnel — see metadata_schema.normalize
+    Step 4c).
+
+    Guards against the resolver wiring crashing on absent catalogs:
+    the orchestrator must build a no-op resolver in that case so the
+    prose path stays oblivious to catalog presence.
+    """
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "no-catalog"))
+    # Note: catalog directory is intentionally NOT initialized.
+
+    _do_index(prose_repo, registry, local_t3, monkeypatch)
+
+    info = registry.get(prose_repo)
+    assert info is not None
+    docs_collection = info.get("docs_collection")
+    assert docs_collection
+    docs_col = local_t3.get_collection(docs_collection)
+    result = docs_col.get(include=["metadatas"])
+    assert result["ids"], "indexer should still write chunks when catalog absent"
+
+    for meta in result["metadatas"]:
+        assert "doc_id" not in meta, (
+            "doc_id must be dropped (normalize Step 4c) when no catalog "
+            "entry exists; saw doc_id=%r" % meta.get("doc_id")
+        )


### PR DESCRIPTION
Builds on PR δ Stage A (#438). Stage A landed the schema gate — `doc_id` in `ALLOWED_TOP_LEVEL`, `MAX_SAFE_TOP_LEVEL_KEYS=32`, `normalize` Step 4c drops empty `doc_id`. No call site populated the field. **Stage B.1 closes the gap for the prose path.**

Bead: nexus-t6p0. Sibling beads (to be created after this pattern is reviewed): B.2 (code_indexer), B.3 (PDF), B.4 (commands/store + enrich), B.5 (mcp_infra store_put), B.6 (doctor `--strict-not-in-t3` regression test).

## Approach — option (a): doc_id_resolver in IndexContext

Per the bead's two architectural options, **option (a)** wins:

- **(a) Resolver Callable in IndexContext** — orchestrator builds `{file_path → tumbler}` once, closes it into a resolver, threads through `IndexContext.doc_id_resolver`. Each indexer just calls `ctx.doc_id_resolver(file_path)` if non-None.
- **(b) Each indexer opens Catalog itself** — duplicates work, risks divergence between orchestrator's catalog state and what indexers see, leaks catalog-opening ceremony into every leaf indexer.

Option (a) keeps the prose/code/PDF indexers agnostic to catalog presence and gives a single chokepoint (the orchestrator) for the registration → resolution flow. This pattern fans out cleanly to B.2-B.5.

## What changed

- **`src/nexus/index_context.py`** — added optional `doc_id_resolver: Callable[[Path], str] | None` field. `None` is the legacy / no-catalog path.
- **`src/nexus/indexer.py`**:
  - `_catalog_hook` now returns `dict[Path, str]` (path → tumbler). Additive — existing test call sites that ignore the return value continue to work unchanged.
  - `_run_index` calls `_catalog_hook` **before** per-file indexing (was: after). Builds `_doc_id_resolver` closure from the returned map; threads it into `_index_prose_file`. Link generation and orphan housekeeping also run upfront — both are determined by the file LIST not by indexing OUTCOME, so the move is safe; on CTRL-C mid-index, the next run re-derives them idempotently.
  - Phase markers (`"Registering N catalog entries…"` / `"Catalog registration done (Xs)"`) fire from the new pre-index location to keep `test_on_phase_fires_on_post_processing_phases` green.
- **`src/nexus/prose_indexer.py`**:
  - Both branches (markdown via `SemanticMarkdownChunker`, non-markdown via `_line_chunk`) resolve `catalog_doc_id` once per file and pass `doc_id=` into `make_chunk_metadata`.
  - Local `doc_id` renamed to `chunk_chroma_id` per RDR-101 Phase 0 nexus-o6aa.3 to disambiguate from catalog `Document.doc_id`.

## Test discipline (WITH TEETH)

`tests/test_prose_indexer_doc_id.py` adds 2 integration tests:

1. **`test_prose_indexer_writes_doc_id_into_t3_chunk_metadata`** — indexes a small fresh prose corpus (markdown + .rst), reads chunks back from the local T3 collection, asserts every chunk's metadata carries `doc_id` matching the catalog tumbler for its source file. Exercises both prose branches.
   - **Verified:** stashing the `prose_indexer.py` wiring causes the test to fail with `doc_id=None` on the README.md chunks.
2. **`test_prose_indexer_doc_id_absent_when_catalog_uninitialized`** — guards the no-catalog fallback: when `NEXUS_CATALOG_PATH` points at an uninitialized directory, indexing must still succeed and emit chunks without `doc_id` (the schema's `normalize` Step 4c drops it). Catches a future regression where the resolver crashes on absent catalogs.

## Test results

- Targeted filter (`catalog | event_log | projector | rdr101 | mcp | metadata_schema | metadata_consistency | prose_indexer | indexer`): **1277 passed, 1 skipped** — green.
- The 3 `test_context.py::TestSubagentHookInjection` failures from a broader run reproduce on `main` (`subagent-start.sh` 10s timeout) — pre-existing, unrelated.

## Architecture invariants preserved

- Schema gate (PR δ Stage A): `doc_id` in `ALLOWED_TOP_LEVEL`, slot count at Chroma's hard cap (32), `normalize` Step 4c drops empty `doc_id`. No regression — Stage B.1 just starts populating the field.
- `_catalog_hook` is still graceful when catalog is absent (`Catalog.is_initialized` returns False → empty dict → resolver is a noop closure).
- Tumbler permanence (RDR-101 §Core invariants) — Stage B.1 reads `str(tumbler)` from already-registered Documents; doesn't mint new identities.
- `make_event(payload)` defaults to `v=0`; no v=1 events introduced here.

## Test plan

- [x] Failing integration test exists and was verified to fail before implementation.
- [x] Reverting `prose_indexer.py` wiring breaks the test deterministically (WITH TEETH).
- [x] Existing `test_indexer_modules.py::test_index_prose_file_*` and `test_indexer.py::test_on_phase_fires_on_post_processing_phases` pass.
- [x] No-catalog fallback test exercises `Catalog.is_initialized → False` path.
- [x] Targeted filter (catalog/event_log/projector/rdr101/mcp/metadata_schema/metadata_consistency/prose_indexer/indexer) green: 1277 passed, 1 skipped.
- [ ] Code review for: pre-index ordering safety (link generation + housekeeping), resolver Path-equality semantics, idempotency on re-index runs.