### PR TITLE
fix: skip integration tests by default, dodge bash 5.3 heredoc deadlock in subagent hook

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -472,3 +472,5 @@
 {"id":"int-d15576f1","kind":"field_change","created_at":"2026-05-01T14:45:50.873916Z","actor":"Hellblazer","issue_id":"nexus-fecd","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-a3768676","kind":"field_change","created_at":"2026-05-01T15:48:19.982123Z","actor":"Hellblazer","issue_id":"nexus-fecd","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-bc12fe8e","kind":"field_change","created_at":"2026-05-01T16:07:43.764006Z","actor":"Hellblazer","issue_id":"nexus-t6p0","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-b1d598a1","kind":"field_change","created_at":"2026-05-01T17:04:00.591162Z","actor":"Hellblazer","issue_id":"nexus-t6p0","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-be34023a","kind":"field_change","created_at":"2026-05-01T17:33:13.658029Z","actor":"Hellblazer","issue_id":"nexus-2k1y","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/nx/hooks/scripts/subagent-start.sh
+++ b/nx/hooks/scripts/subagent-start.sh
@@ -101,40 +101,32 @@ RELAY
 # Serena + Context7 guidance injected by sn plugin (sn/hooks/scripts/mcp-inject.sh).
 
 if [[ $SKIP_STORAGE_DOCS -eq 0 ]]; then
-cat <<'NXTOOLS'
+# Heredoc bodies kept under 500 bytes each — bash 5.3.x deadlocks on
+# larger heredocs when the child writes the body to a pipe before
+# exec'ing cat (write blocks waiting for a reader that hasn't started
+# yet). /bin/bash 3.2 uses temp files so it's unaffected, but launchers
+# that pick homebrew bash via PATH lookup hang the whole subagent
+# dispatch. Splitting also trims redundant param signatures the agent
+# already sees in the live MCP tool list.
+cat <<'NX_TIERS'
 
-## nx Storage Tools
+## nx storage (call as mcp__plugin_nx_nexus__<tool>; pagination: footer shows offset=N)
 
-Results from search/list are paged — footer shows `offset=N` for next page.
+Tiers: T1 scratch (session, sibling-shared) -> T2 memory (project, persistent) -> T3 knowledge (semantic).
 
-T1 scratch (session-scoped, shared across siblings):
-  mcp__plugin_nx_nexus__scratch(action="put|search|list|get|delete", content, tags, query, limit, entry_id)
-  mcp__plugin_nx_nexus__scratch_manage(action="flag", entry_id, project, title)
+T1: scratch, scratch_manage
+T2: memory_get, memory_search, memory_put, memory_delete
+NX_TIERS
 
-T2 memory (project-scoped, persistent):
-  mcp__plugin_nx_nexus__memory_get(project, title="" → list titles only)
-  mcp__plugin_nx_nexus__memory_search(query, project, limit=20, offset=0)
-  mcp__plugin_nx_nexus__memory_put(content, project, title, ttl=30)
-  mcp__plugin_nx_nexus__memory_delete(project, title)
+cat <<'NX_T3'
+T3: search (where, cluster_by="semantic", topic), query (catalog-aware; follow_links, depth, subtree),
+    store_list, store_get, store_put (AUTO-LINKS via T1 tag "link-context"),
+    collection_list
+Plans (T2): plan_search, plan_save
 
-T3 knowledge (permanent, semantic search):
-  mcp__plugin_nx_nexus__search(query, corpus="knowledge", limit=10, offset=0, where, cluster_by, topic)
-    where: "section_type!=references" filters noise; cluster_by="semantic" groups; topic="Label" pre-filters
-  mcp__plugin_nx_nexus__query(question, corpus, where, limit, author, content_type, follow_links="cites", depth=1, subtree)
-    document-level, catalog-aware, taxonomy-boosted; subtree="1.1" = all descendants of tumbler prefix
-  mcp__plugin_nx_nexus__store_list(collection, limit=20, offset=0, docs=false)
-  mcp__plugin_nx_nexus__store_get(doc_id, collection)
-  mcp__plugin_nx_nexus__store_put(content, collection, title, tags)
-    AUTO-LINKS via T1 scratch tag "link-context"; self-seed via catalog_search → scratch put if absent.
-    Findings not stored are findings lost — call before returning.
-  mcp__plugin_nx_nexus__collection_list
-
-Plan library (T2):
-  mcp__plugin_nx_nexus__plan_search(query, project, limit=5)
-  mcp__plugin_nx_nexus__plan_save(query, plan_json, project, tags, ttl=30)
-
-Routing: T1 (sibling sharing) → T2 (project persistence) → T3 (semantic knowledge).
-NXTOOLS
+Hint: where="section_type!=references" filters noise.
+Findings not stored are findings lost - call store_put before returning.
+NX_T3
 
 # L1 Knowledge Map (per-repo, RDR-072) — outside the heredoc so $(…) expands
 CONTEXT_DIR="$HOME/.config/nexus/context"
@@ -162,17 +154,12 @@ SEQTHINK
 if [[ $SKIP_OPERATORS -eq 0 ]]; then
 cat <<'OPERATORS'
 
-## Analytical Operators (RDR-080)
+## Analytical operators (RDR-080)
 
-Five MCP tools wrap the five operations — each spawns `claude -p` (default timeout 120s). Call directly; no Agent dispatch.
+5 ops wrap claude -p (120s default). Call directly, no Agent dispatch:
+  operator_summarize, operator_extract, operator_rank, operator_compare, operator_generate
 
-  mcp__plugin_nx_nexus__operator_summarize(content, cited=True)
-  mcp__plugin_nx_nexus__operator_extract(inputs=[...], fields="title,year,author")
-  mcp__plugin_nx_nexus__operator_rank(items=[...], criterion)
-  mcp__plugin_nx_nexus__operator_compare(items=[...], focus)
-  mcp__plugin_nx_nexus__operator_generate(template, context)
-
-For plan-matched multi-step retrieval use mcp__plugin_nx_nexus__nx_answer — it composes search/query/operators under a plan-match-first gate.
+Multi-step retrieval (plan-match gate): nx_answer.
 OPERATORS
 fi
 
@@ -180,25 +167,25 @@ fi
 if echo "$TASK_TEXT" | grep -qiE "author|cit(e|ation|es|ed)|who wrote|what did.*write|papers? (by|about)|provenance|corpus|collection|tumbler|what research|informed by|based on|relationship|links? (from|to)|referenc|follow.on|build.on|what (implements|supersedes)|link (audit|query|graph)|orphan|catalog|rdr.*(close|accept|show|gate|research)|close.*rdr|accept.*rdr|supersed|consolidat|tidy|knowledge|research|synthesiz|archive|store_put|store put|debug.*finding|root.cause|prevention.pattern|architecture.*map|pattern.*catalog|architect.*decision|risk.assess|insight.*developer|analysis.*deep|analyz.*codebas"; then
   CATALOG_PATH="${NEXUS_CATALOG_PATH:-$HOME/.config/nexus/catalog}"
   if [[ -d "$CATALOG_PATH/.git" && -f "$CATALOG_PATH/documents.jsonl" ]]; then
-    cat <<'CATALOG'
+    cat <<'CATALOG_TOOLS'
 
-## Catalog — Document Registry + Link Graph
+## Catalog - metadata-first queries (author, corpus, citations, provenance)
+(call as mcp__plugin_nx_nexus-catalog__<tool>)
 
-Catalog tools for metadata-first queries (author, corpus, title, citations, provenance). /nx:query handles full catalog-aware plan execution.
+  search, show, resolve
+  links (direction="in"|"out", link_type, depth=2 -> nodes+edges; live docs only)
+  link (from_tumbler, to_tumbler, link_type, created_by, spans)
+  link_query (admin/audit; includes orphans)
+CATALOG_TOOLS
 
-  mcp__plugin_nx_nexus-catalog__search(query, author, corpus, owner, file_path, content_type)
-  mcp__plugin_nx_nexus-catalog__show(tumbler) — full entry with links_from + links_to
-  mcp__plugin_nx_nexus-catalog__links(tumbler, direction="in", link_type="cites", depth=2)
-    → {"nodes":[CatalogEntry], "edges":[link]}; live documents only (use link_query for orphans)
-  mcp__plugin_nx_nexus-catalog__link(from_tumbler, to_tumbler, link_type, created_by, from_span, to_span)
-    spans: "chash:<sha256hex>" preferred (content-addressed); "chash:<sha256hex>:<start>-<end>" sub-chunk;
-    fallback "L-L" line range or "C:S-E" chunk:char (positional, may go stale).
-    chash from search result chunk_text_hash metadata.
-  mcp__plugin_nx_nexus-catalog__link_query(link_type, created_by, created_at_before, limit=50) — admin/audit, all links
-  mcp__plugin_nx_nexus-catalog__resolve(owner, corpus) — → collection names
+    cat <<'CATALOG_LINKING'
+Link spans: "chash:<sha256hex>" preferred (content-addressed); ":<start>-<end>" sub-chunk;
+fallback "L-L" or "C:S-E" (positional, may go stale). chash via search chunk_text_hash.
 
-Link types: cites, implements-heuristic, supersedes, quotes, relates, comments, implements
-CATALOG
+Link types: cites, implements, implements-heuristic, supersedes, quotes, relates, comments.
+
+For full plan execution use /nx:query.
+CATALOG_LINKING
   fi
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,13 @@ include = [
 testpaths = ["tests"]
 pythonpath = ["scripts"]
 log_level = "WARNING"
+# Honour the documented default: integration / slow tests are opt-in.
+# Without this, ``pytest tests/`` runs everything including
+# ``tests/integration/test_nx_answer_equivalence.py`` which calls real
+# Voyage / Chroma APIs in retry loops without credentials and hangs
+# pytest indefinitely (239+ CLOSE_WAIT TCP sockets observed locally).
+# Run them explicitly with ``pytest -m integration`` or ``-m slow``.
+addopts = "-m 'not integration and not slow'"
 markers = [
     "integration: end-to-end tests requiring real services (deselect with '-m not integration')",
     "slow: expensive benchmarks (deselect with '-m not slow')",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -204,7 +204,7 @@ class TestSubagentHookInjection:
         cache_file.write_text("## Knowledge Map\n\ncode: Test Topic (42)\n")
 
         result = subprocess.run(
-            ["bash", str(self.HOOK_PATH)],
+            ["/bin/bash", str(self.HOOK_PATH)],  # /bin/bash 3.2 — homebrew bash 5.3 deadlocks on the NXTOOLS heredoc
             capture_output=True, text=True, timeout=10,
             cwd=str(repo_dir),
             env={**__import__("os").environ, "HOME": str(tmp_path)},
@@ -223,7 +223,7 @@ class TestSubagentHookInjection:
         repo_dir.mkdir()
 
         result = subprocess.run(
-            ["bash", str(self.HOOK_PATH)],
+            ["/bin/bash", str(self.HOOK_PATH)],  # /bin/bash 3.2 — homebrew bash 5.3 deadlocks on the NXTOOLS heredoc
             capture_output=True, text=True, timeout=10,
             cwd=str(repo_dir),
             env={**__import__("os").environ, "HOME": str(tmp_path)},
@@ -247,7 +247,7 @@ class TestSubagentHookInjection:
         repo_dir.mkdir()
 
         result = subprocess.run(
-            ["bash", str(self.HOOK_PATH)],
+            ["/bin/bash", str(self.HOOK_PATH)],  # /bin/bash 3.2 — homebrew bash 5.3 deadlocks on the NXTOOLS heredoc
             capture_output=True, text=True, timeout=10,
             cwd=str(repo_dir),
             env={**__import__("os").environ, "HOME": str(tmp_path)},


### PR DESCRIPTION
Three independent bugs that collectively made `pytest tests/` unusable on macOS with homebrew bash. All three are pre-existing.

## 1. Integration tests run by default and hang

`tests/integration/test_nx_answer_equivalence.py` is marked `pytestmark = pytest.mark.integration` and the docstring says *"Skipped by default. Run with: -m integration"* — but `pyproject.toml` had no `addopts` to deselect the marker.

Without credentials, `nx_answer → plan_run → search → _chroma_with_retry → voyageai.embed` spins in an SSL `recv_into` retry loop, accumulating 200+ CLOSE_WAIT sockets before pytest's wall clock fires.

**Fix:** add `addopts = \"-m 'not integration and not slow'\"` so `pytest tests/` honours the documented default. Run integration tests explicitly with `pytest -m integration`.

## 2. test_context.py::TestSubagentHookInjection hangs at 10s subprocess timeout

Sampled the hung child:

```
heredoc_write (in bash) + 52
  write (in libsystem_kernel.dylib) + 8     <- blocked here
```

Bash 5.3.x has a regression: the forked child writes the heredoc body to a pipe **before** exec'ing `cat`. When the body exceeds the pipe buffer (~500 bytes empirically), `write()` blocks waiting for a reader that will never start — cat hasn't been exec'd. `/bin/bash` 3.2 (macOS system) uses temp files unconditionally and is unaffected.

**Fix:** pin to `/bin/bash` in the three `subprocess.run` sites in `test_context.py` so PATH lookup doesn't pick homebrew bash 5.3.9.

## 3. Production hook hits the same deadlock under Claude Code's launcher

The same bash 5.3 bug affects `nx/hooks/scripts/subagent-start.sh` when Claude Code's launcher invokes it via PATH-resolved bash. **Multiple orphan `subagent-start.sh` processes were observed in `ps`** from real agent runs that hit the deadlock and never recovered.

**Fix:** split the three over-threshold heredocs and trim the content. Net: **3612 → 1537 bytes (57% reduction)** AND every chunk is bash-5.3-safe.

| Heredoc | Before | After | Result |
|---|---|---|---|
| NXTOOLS | 1786 | NX_TIERS 279 + NX_T3 362 | split |
| OPERATORS | 634 | 248 | trimmed |
| CATALOG | 1192 | CATALOG_TOOLS 337 + CATALOG_LINKING 311 | split |

Trimmed redundant param signatures the agent already sees in the live MCP tool list — all `mcp__plugin_nx_nexus__<tool>(args…)` lines now use short names with a one-line *\"call as mcp__…\"* prefix. The behavioural hints (where-filter, AUTO-LINKS, findings-not-stored, span format) are preserved.

## Verification

- Hook completes in **1.1–1.3s** under `/opt/homebrew/bin/bash 5.3.9` (was: deadlock indefinitely until killed). Both default and catalog-aware branches exercised.
- `tests/test_context.py`: **12 passed in 4.93s**.
- Full suite (`pytest tests/`): **6224 passed, 33 skipped, 61 deselected in 9:45**. Was: hung at ~27–34% mark accumulating 239+ CLOSE_WAIT sockets, never completed.

## Bead

nexus-2k1y

## Test plan

- [x] `tests/test_context.py::TestSubagentHookInjection` (3 tests) pass under homebrew bash via `/bin/bash` pin.
- [x] Hook script runs to completion under bash 5.3 with empty stdin (default branch) and catalog-aware stdin.
- [x] Full pytest suite completes (6224 passed, 33 skipped, 61 deselected in 9:45).
- [x] No regression in `test_prose_indexer_doc_id.py` or other catalog/indexer tests.
- [ ] Reviewer sanity-check: no semantic content lost from the trimmed heredocs that subagents actually depend on.