### PR TITLE
feat(rdr-101): phase 3 PR δ stage B.3 — PDF writes doc_id; PDFs now registered in catalog

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -476,3 +476,5 @@
 {"id":"int-be34023a","kind":"field_change","created_at":"2026-05-01T17:33:13.658029Z","actor":"Hellblazer","issue_id":"nexus-2k1y","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-0d7645ef","kind":"field_change","created_at":"2026-05-01T17:48:30.432587Z","actor":"Hellblazer","issue_id":"nexus-2k1y","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-93463786","kind":"field_change","created_at":"2026-05-01T17:53:32.015103Z","actor":"Hellblazer","issue_id":"nexus-6qy0","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-a3d28072","kind":"field_change","created_at":"2026-05-01T17:58:51.796473Z","actor":"Hellblazer","issue_id":"nexus-6qy0","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-2c110872","kind":"field_change","created_at":"2026-05-01T17:59:17.314547Z","actor":"Hellblazer","issue_id":"nexus-n1uo","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -721,6 +721,7 @@ def _index_pdf_file(
     *,
     embed_fn: Callable | None = None,
     stage_timers: "StageTimers | None" = None,
+    doc_id_resolver: Callable[[Path], str] | None = None,
 ) -> int:
     """Index a single PDF file into the docs__ collection.
 
@@ -733,6 +734,11 @@ def _index_pdf_file(
     ``stage_timers`` (nexus-7niu) is an optional :class:`StageTimers` that
     accumulates chunking / embed / upload / retry time for this file.
     ``None`` is the fast path — the instrumented blocks are no-ops.
+
+    ``doc_id_resolver`` (RDR-101 Phase 3 PR δ Stage B.3) returns the
+    catalog ``Document.doc_id`` for *file* so PDF chunks land in T3 with
+    a back-reference to the catalog. ``None`` is the legacy /
+    no-catalog path.
     """
     import hashlib as _hl
     from nexus.doc_indexer import _embed_with_fallback, _pdf_chunks
@@ -780,6 +786,11 @@ def _index_pdf_file(
         prefix = "## " + "  ".join(prefix_parts)
         embed_texts_pdf.append(f"{prefix}\n\n{doc}")
 
+    # Catalog Document.doc_id (RDR-101 Phase 3 PR δ Stage B.3): resolved
+    # once per file. Empty string when no catalog handle exists;
+    # ``normalize`` Step 4c drops the field on the way to T3.
+    catalog_doc_id = doc_id_resolver(file) if doc_id_resolver is not None else ""
+
     # Augment metadata with repo-indexer fields.
     # Filter empty/zero values from _pdf_chunks to stay under ChromaDB's
     # 32-key metadata limit. PDF chunks produce ~31 raw keys; augmentation
@@ -803,6 +814,7 @@ def _index_pdf_file(
             "source_agent": "nexus-indexer",
             "ttl_days": 0,
             "frecency_score": float(score),
+            "doc_id": catalog_doc_id,
             **{k: v for k, v in git_meta.items() if v},
         }
         metadatas.append(augmented)
@@ -1250,6 +1262,12 @@ def _run_index(
         indexed_for_catalog.append((f, "code", code_collection))
     for _, f in prose_files:
         indexed_for_catalog.append((f, "prose", docs_collection))
+    # RDR-101 Phase 3 PR δ Stage B.3: PDFs were missing from
+    # ``indexed_for_catalog`` pre-Stage-B.3 (B.1 surfaced this gap during
+    # verification). Register them upfront so the resolver returns a
+    # tumbler for PDF chunks too.
+    for _, f in pdf_files:
+        indexed_for_catalog.append((f, "pdf", docs_collection))
     if rdr_abs_paths:
         rdr_col_name = _rdr_coll_name_for_repo(repo)
         for rdr_dir in rdr_abs_paths:
@@ -1347,6 +1365,7 @@ def _run_index(
             chunk_chars=tuning.pdf_chunk_chars,
             embed_fn=_embed_fn,
             stage_timers=timers,
+            doc_id_resolver=_doc_id_resolver,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)

--- a/tests/test_pdf_indexer_doc_id.py
+++ b/tests/test_pdf_indexer_doc_id.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""WITH TEETH: PDF indexing must write the catalog tumbler as ``doc_id``
+into T3 chunk metadata at chunk-write time (RDR-101 Phase 3 PR δ Stage B.3).
+
+Mirrors B.1 (prose) and B.2 (code) for the PDF path. Stage B.3 also closes
+a separate gap discovered during B.1: PDFs were never registered in the
+catalog at all (``indexed_for_catalog`` only contained code + prose + RDR
+files). This test exercises both fixes together — PDFs land in the
+catalog AND PDF chunks carry doc_id back to that catalog entry.
+
+Reverting either half of the fix breaks the test:
+- removing ``(f, "pdf", docs_collection)`` from the pre-index registration
+  list -> catalog entry missing -> ``cat.by_file_path(...)`` returns None
+- removing ``doc_id=catalog_doc_id`` from the augmented metadata
+  -> chunk doc_id is empty -> normalize Step 4c drops it
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.tumbler import Tumbler
+from nexus.db.t3 import T3Database
+from nexus.registry import RepoRegistry
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture(autouse=True)
+def git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k, v in [
+        ("GIT_AUTHOR_NAME", "Test"),
+        ("GIT_AUTHOR_EMAIL", "test@test.invalid"),
+        ("GIT_COMMITTER_NAME", "Test"),
+        ("GIT_COMMITTER_EMAIL", "test@test.invalid"),
+    ]:
+        monkeypatch.setenv(k, v)
+
+
+@pytest.fixture
+def pdf_repo(tmp_path: Path, simple_pdf: Path) -> Path:
+    repo = tmp_path / "pdf-repo"
+    repo.mkdir()
+    shutil.copy2(simple_pdf, repo / "doc.pdf")
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@nexus")
+    _git(repo, "config", "user.name", "Nexus Test")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "Initial commit")
+    return repo
+
+
+@pytest.fixture
+def local_t3() -> T3Database:
+    return T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+
+
+@pytest.fixture
+def registry(tmp_path: Path, pdf_repo: Path) -> RepoRegistry:
+    reg = RepoRegistry(tmp_path / "repos.json")
+    reg.add(pdf_repo)
+    return reg
+
+
+@pytest.fixture
+def catalog_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    catalog_dir = tmp_path / "catalog"
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+    Catalog.init(catalog_dir)
+    return catalog_dir
+
+
+@pytest.fixture(autouse=True)
+def mock_voyage_client():
+    """Local-mode test: voyageai client is never called, but
+    ``voyageai.Client`` may still be constructed by the orchestrator."""
+    ef = DefaultEmbeddingFunction()
+    mock_client = MagicMock()
+
+    def fake_embed(texts, model, input_type="document"):
+        r = MagicMock()
+        r.embeddings = ef(texts)
+        return r
+
+    def fake_contextualized_embed(inputs, model, input_type="document"):
+        r = MagicMock()
+        br = MagicMock()
+        br.embeddings = ef(inputs[0])
+        r.results = [br]
+        return r
+
+    mock_client.embed.side_effect = fake_embed
+    mock_client.contextualized_embed.side_effect = fake_contextualized_embed
+    with patch("voyageai.Client", return_value=mock_client):
+        yield mock_client
+
+
+def _local_embed(chunks, model, api_key, input_type="document", timeout=120.0, on_progress=None):
+    """Shape-#2 embed adapter (returns embeddings, model)."""
+    ef = DefaultEmbeddingFunction()
+    return ef(chunks), model
+
+
+def _do_index(repo: Path, registry: RepoRegistry, t3: T3Database, monkeypatch) -> None:
+    from nexus.indexer import index_repository
+
+    monkeypatch.setenv("NX_LOCAL", "1")
+    with patch("nexus.db.make_t3", return_value=t3), \
+         patch("nexus.config.get_credential", side_effect=lambda k: "test-key"), \
+         patch("nexus.doc_indexer._embed_with_fallback", side_effect=_local_embed):
+        index_repository(repo, registry, force=False)
+
+
+def test_pdf_indexer_writes_doc_id_into_t3_chunk_metadata(
+    pdf_repo: Path,
+    registry: RepoRegistry,
+    local_t3: T3Database,
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-pass indexing of a fresh PDF corpus must:
+      1) Register the PDF in the catalog (was: skipped — PDFs missing from
+         ``indexed_for_catalog`` pre-Stage-B.3).
+      2) Populate ``doc_id`` in every PDF chunk's T3 metadata, matching
+         the catalog tumbler.
+    """
+    _do_index(pdf_repo, registry, local_t3, monkeypatch)
+
+    cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+    info = registry.get(pdf_repo)
+    assert info is not None
+    docs_collection = info.get("docs_collection")
+    assert docs_collection, "registry should record docs_collection after indexing"
+
+    docs_col = local_t3.get_collection(docs_collection)
+    result = docs_col.get(include=["metadatas"])
+    assert result["ids"], "expected at least one PDF chunk in T3 docs collection"
+
+    # Filter to PDF chunks (the docs__ collection holds prose + PDF mixed).
+    pdf_metas = [m for m in result["metadatas"] if m.get("store_type") == "pdf"]
+    assert pdf_metas, "expected at least one chunk with store_type='pdf'"
+
+    # Resolve the catalog owner and the PDF's catalog entry.
+    owner_row = cat._db.execute(
+        "SELECT tumbler_prefix FROM owners LIMIT 1"
+    ).fetchone()
+    assert owner_row is not None, "expected catalog owner registered by indexer"
+    owner_t = Tumbler.parse(owner_row[0])
+
+    pdf_entry = cat.by_file_path(owner_t, "doc.pdf")
+    assert pdf_entry is not None, (
+        "catalog has no entry for doc.pdf - PDFs must be in "
+        "``indexed_for_catalog`` so the orchestrator's pre-index "
+        "registration creates a tumbler for them."
+    )
+    assert pdf_entry.content_type == "pdf", (
+        f"expected catalog content_type='pdf', got {pdf_entry.content_type!r}"
+    )
+
+    expected_doc_id = str(pdf_entry.tumbler)
+    for m in pdf_metas:
+        assert m.get("doc_id") == expected_doc_id, (
+            f"PDF chunk carries doc_id={m.get('doc_id')!r}, "
+            f"expected {expected_doc_id!r} (catalog tumbler)"
+        )
+
+
+def test_pdf_indexer_doc_id_absent_when_catalog_uninitialized(
+    pdf_repo: Path,
+    registry: RepoRegistry,
+    local_t3: T3Database,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no catalog exists, PDF indexing must still succeed and emit
+    chunks WITHOUT ``doc_id`` (schema drops empty doc_id at the funnel).
+    """
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "no-catalog"))
+
+    _do_index(pdf_repo, registry, local_t3, monkeypatch)
+
+    info = registry.get(pdf_repo)
+    assert info is not None
+    docs_collection = info.get("docs_collection")
+    assert docs_collection
+    docs_col = local_t3.get_collection(docs_collection)
+    result = docs_col.get(include=["metadatas"])
+    assert result["ids"], "indexer should still write chunks when catalog absent"
+
+    pdf_metas = [m for m in result["metadatas"] if m.get("store_type") == "pdf"]
+    assert pdf_metas, "expected at least one PDF chunk"
+
+    for m in pdf_metas:
+        assert "doc_id" not in m, (
+            "doc_id must be dropped (normalize Step 4c) when no catalog "
+            "entry exists; saw doc_id=%r" % m.get("doc_id")
+        )


### PR DESCRIPTION
Closes two related gaps for the PDF path. Bead: `nexus-n1uo`. Sibling beads remaining: B.4 (commands), B.5 (mcp_infra), B.6 (doctor regression test).

## Two gaps closed

1. **PDFs were missing from `indexed_for_catalog`** pre-Stage-B.3 (B.1 surfaced this during verification — code + prose + RDR were registered upfront but PDFs were silently skipped). PDF chunks landed in T3 with no corresponding catalog Document at all. The B.3 test exercises both branches: catalog entry must exist AND its tumbler must match the chunk metadata.
2. **`_index_pdf_file` did not accept a `doc_id_resolver`** — even after fixing #1 the chunks would carry no doc_id back-reference.

## What changed

- **`src/nexus/indexer.py`**:
  - `_run_index` pre-index registration loop now appends `(f, "pdf", docs_collection)` for every PDF file alongside code / prose / RDR.
  - `_index_pdf_file` accepts `doc_id_resolver` kwarg; resolves `catalog_doc_id` once per file; injects it into the augmented metadata dict literal (after `_pdf_chunks` builds the raw metadata — matching how PDF augments title/tags/category/etc.).
  - `_run_index` passes the resolver at the per-file PDF loop.

The PDF path is unique among indexers because metadata is built in `doc_indexer._pdf_chunks` and augmented in `_index_pdf_file`; the doc_id injection happens at the augmentation site rather than at `make_chunk_metadata` (single edit point, doesn't perturb `_pdf_chunks`).

## Tests

`tests/test_pdf_indexer_doc_id.py` (new, 2 tests):

1. **WITH TEETH** — indexing a fresh PDF corpus must register the PDF in the catalog AND populate `doc_id` in every PDF chunk's T3 metadata matching the catalog tumbler. **Verified:** stashing `indexer.py` causes the test to fail with `catalog has no entry for doc.pdf`.
2. **Guard** — when no catalog exists, PDF chunks land without `doc_id` (schema drops empty `doc_id` at the funnel).

Reuses session-scoped `simple_pdf` fixture from `tests/conftest.py`. Patches `nexus.doc_indexer._embed_with_fallback` with a local-mode adapter so the test runs without Voyage credentials.

## Test results

- Targeted suite (`catalog | event_log | projector | rdr101 | mcp | metadata_schema | metadata_consistency | prose_indexer | code_indexer | pdf | indexer`): **1481 passed, 1 skipped**.
- `test_metadata_consistency.py` (12 tests including `test_pdf_indexer_emits_full_keyset` + `test_pipeline_pdf_emits_full_keyset`): all pass — confirms `doc_id` is now part of the canonical PDF keyset.

## Test plan

- [x] Failing integration test exists and was verified to fail before implementation.
- [x] Reverting `indexer.py` wiring breaks the test deterministically (WITH TEETH).
- [x] Existing PDF tests pass (no regression: `test_pdf_e2e`, `test_index_pdf_batch`, `test_pdf_chunker_integration`, `test_doc_indexer`).
- [x] No-catalog fallback test exercises `Catalog.is_initialized → False` path.
- [x] Catalog `content_type='pdf'` recorded for the registered PDF entry.