### PR TITLE
feat(rdr-101): phase 3 PR δ stage B.4 — store put writes doc_id; enrich preserves round-trip

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -478,3 +478,5 @@
 {"id":"int-93463786","kind":"field_change","created_at":"2026-05-01T17:53:32.015103Z","actor":"Hellblazer","issue_id":"nexus-6qy0","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-a3d28072","kind":"field_change","created_at":"2026-05-01T17:58:51.796473Z","actor":"Hellblazer","issue_id":"nexus-6qy0","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-2c110872","kind":"field_change","created_at":"2026-05-01T17:59:17.314547Z","actor":"Hellblazer","issue_id":"nexus-n1uo","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-58956959","kind":"field_change","created_at":"2026-05-01T18:06:36.304507Z","actor":"Hellblazer","issue_id":"nexus-n1uo","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-79d435c2","kind":"field_change","created_at":"2026-05-01T18:14:30.660049Z","actor":"Hellblazer","issue_id":"nexus-ds8e","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/store.py
+++ b/src/nexus/commands/store.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+import hashlib
 import sys
 from pathlib import Path
 
@@ -99,6 +100,18 @@ def put_cmd(
 
     col_name = t3_collection_name(collection)
     db = _t3()
+
+    # RDR-101 Phase 3 PR δ Stage B.4: pre-register the catalog entry
+    # so the T3 chunk can carry the resulting tumbler as ``doc_id``
+    # at write-time. The chunk_chroma_id (sha256 of "{collection}:{title}")
+    # is deterministic, so we can compute it here and pass to the hook
+    # for legacy meta.doc_id dedup. The hook returns the catalog
+    # tumbler string (or "" when the catalog is absent).
+    chunk_chroma_id = hashlib.sha256(f"{col_name}:{title}".encode()).hexdigest()[:16]
+    catalog_doc_id = _catalog_store_hook(
+        title=title, doc_id=chunk_chroma_id, collection_name=col_name,
+    )
+
     doc_id = db.put(
         collection=col_name,
         content=content,
@@ -108,9 +121,9 @@ def put_cmd(
         session_id=session_id,
         source_agent=agent,
         ttl_days=ttl_days,
+        catalog_doc_id=catalog_doc_id,
     )
     click.echo(f"Stored: {doc_id}  →  {col_name}")
-    _catalog_store_hook(title=title, doc_id=doc_id, collection_name=col_name)
     # nexus-9099: fire the three post-store hook chains so the chash
     # index, taxonomy assignment, and aspect-extraction queue see CLI
     # store-put events. RDR-095 symmetric-fire; this path was missed by
@@ -120,21 +133,33 @@ def put_cmd(
     fire_store_chains([doc_id], col_name, [content])
 
 
-def _catalog_store_hook(title: str, doc_id: str, collection_name: str) -> None:
-    """Register knowledge entry in catalog. Silently skipped if absent."""
+def _catalog_store_hook(title: str, doc_id: str, collection_name: str) -> str:
+    """Register knowledge entry in catalog. Silently skipped if absent.
+
+    Returns the catalog ``Document.doc_id`` (Tumbler string) so the
+    caller can pass it to ``T3Database.put()`` as ``catalog_doc_id``
+    for chunk-write-time embedding (RDR-101 Phase 3 PR δ Stage B.4).
+    Returns ``""`` when the catalog is absent or an error occurs — the
+    schema funnel drops empty doc_id at the boundary.
+
+    ``doc_id`` here is the legacy T3 chunk Chroma natural-id
+    (sha256-of-collection-and-title), used for dedup against the
+    legacy ``meta.doc_id`` mapping.
+    """
     try:
         from nexus.catalog import Catalog
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
-            return
+            return ""
 
         cat = Catalog(cat_path, cat_path / ".catalog.db")
 
-        # Dedup by doc_id
-        if cat.by_doc_id(doc_id) is not None:
-            return
+        # Dedup by chunk_chroma_id stored in legacy meta.doc_id.
+        existing = cat.by_doc_id(doc_id)
+        if existing is not None:
+            return str(existing.tumbler)
 
         # Get or create "knowledge" curator owner
         rows = cat._db.execute(
@@ -146,13 +171,15 @@ def _catalog_store_hook(title: str, doc_id: str, collection_name: str) -> None:
         else:
             owner = cat.register_owner("knowledge", "curator")
 
-        cat.register(
+        tumbler = cat.register(
             owner=owner, title=title, content_type="knowledge",
             physical_collection=collection_name,
             meta={"doc_id": doc_id},
         )
+        return str(tumbler)
     except Exception:
         _log.debug("catalog_store_hook_failed", exc_info=True)
+        return ""
 
 
 @store.command("list")

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -511,6 +511,7 @@ class T3Database:
         source_agent: str = "",
         store_type: str = "knowledge",
         ttl_days: int = 0,
+        catalog_doc_id: str = "",
     ) -> str:
         """Upsert *content* into *collection*. Returns the document ID.
 
@@ -529,6 +530,14 @@ class T3Database:
         ALLOWED_TOP_LEVEL field is populated and the chash dual-write hook
         gets the chunk_text_hash it needs (closes the RDR-086 coverage hole
         for MCP-stored docs).
+
+        ``catalog_doc_id`` (RDR-101 Phase 3 PR δ Stage B.4) is the
+        catalog ``Document.doc_id`` (Tumbler string) for the
+        single-chunk doc. Caller registers the catalog entry FIRST and
+        passes the resulting tumbler so the T3 chunk lands with a
+        cross-reference back to the catalog at write-time. Empty
+        string is the legacy / no-catalog path; ``normalize`` Step 4c
+        drops the field on the way to T3.
         """
         from nexus.metadata_schema import make_chunk_metadata  # noqa: PLC0415
 
@@ -581,6 +590,7 @@ class T3Database:
             ttl_days=ttl_days,
             source_agent=source_agent,
             session_id=session_id,
+            doc_id=catalog_doc_id,
         )
 
         col = self.get_or_create_collection(collection)

--- a/tests/test_store_enrich_doc_id.py
+++ b/tests/test_store_enrich_doc_id.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""WITH TEETH: nx store put must write the catalog tumbler as ``doc_id``
+into T3 chunk metadata at write-time; nx enrich must preserve doc_id
+round-trip (RDR-101 Phase 3 PR δ Stage B.4).
+
+Two independent CLI write paths that don't go through ``index_repository``:
+
+1. ``nx store put`` writes a single T3 chunk via ``T3Database.put()``.
+   Pre-Stage-B.4 the catalog hook ran AFTER the T3 write, so chunk
+   metadata never carried the catalog tumbler.
+
+2. ``nx enrich bib`` re-writes existing chunk metadata with bib_*
+   fields via ``col.update(metadatas=...)``. The contract here is
+   pass-through: doc_id present pre-enrich must be present post-enrich.
+
+Reverting either fix breaks the corresponding test deterministically.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.tumbler import Tumbler
+from nexus.db.t3 import T3Database
+
+
+@pytest.fixture
+def local_t3() -> T3Database:
+    return T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+
+
+@pytest.fixture
+def catalog_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    catalog_dir = tmp_path / "catalog"
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+    Catalog.init(catalog_dir)
+    return catalog_dir
+
+
+def _no_op_post_store(*args, **kwargs):
+    """Disable post-store hook chains (chash, taxonomy, aspect-extraction).
+    The Stage B.4 contract is just about the T3 chunk's doc_id metadata,
+    not about side-effect hook chains; the hooks rely on T2 schema state
+    that isn't initialised in this test fixture.
+    """
+    pass
+
+
+def test_store_put_cli_writes_catalog_doc_id_into_t3_chunk_metadata(
+    local_t3: T3Database,
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``nx store put`` CLI command must populate ``doc_id`` in the T3
+    chunk's metadata, matching the catalog tumbler created by the store
+    hook (Stage B.4 contract).
+    """
+    from click.testing import CliRunner
+    from nexus.commands.store import store
+
+    # Create a temp file to feed to ``nx store put``
+    (catalog_env.parent / "finding.md").write_text(
+        "# Finding: nexus-doc-id-pin\n\nT3 chunks must carry catalog tumbler.",
+        encoding="utf-8",
+    )
+
+    with patch("nexus.commands.store._t3", return_value=local_t3), \
+         patch("nexus.mcp_infra.fire_store_chains", side_effect=_no_op_post_store), \
+         patch("nexus.mcp_infra.fire_post_store_hooks", side_effect=_no_op_post_store), \
+         patch("nexus.mcp_infra.fire_post_store_batch_hooks", side_effect=_no_op_post_store), \
+         patch("nexus.mcp_infra.fire_post_document_hooks", side_effect=_no_op_post_store):
+        runner = CliRunner()
+        result = runner.invoke(store, [
+            "put",
+            str(catalog_env.parent / "finding.md"),
+            "--collection", "knowledge",
+            "--title", "finding-doc-id-pin",
+            "--tags", "rdr-101,test",
+        ], catch_exceptions=False)
+
+    assert result.exit_code == 0, f"store put failed: {result.output}"
+    assert "Stored:" in result.output
+
+    # Catalog should now have an entry for the stored doc.
+    cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+    rows = cat._db.execute(
+        "SELECT tumbler FROM documents WHERE title = 'finding-doc-id-pin'"
+    ).fetchall()
+    assert rows, "expected catalog entry for the stored doc"
+    expected_doc_id = rows[0][0]
+
+    # Find the actual stored collection (resolved from "knowledge" via
+    # t3_collection_name → "knowledge__knowledge" in the default routing).
+    cols = local_t3._client.list_collections()
+    stored_col = None
+    for c in cols:
+        if c.name.startswith("knowledge"):
+            stored_col = c
+            break
+    assert stored_col is not None, "expected a knowledge__ collection"
+
+    chunk_result = stored_col.get(include=["metadatas"])
+    assert chunk_result["ids"], "expected at least one chunk in knowledge collection"
+
+    matching_metas = [
+        m for m in chunk_result["metadatas"]
+        if m.get("title") == "finding-doc-id-pin"
+    ]
+    assert matching_metas, "expected a chunk with title='finding-doc-id-pin'"
+
+    for m in matching_metas:
+        assert m.get("doc_id") == expected_doc_id, (
+            f"chunk for finding-doc-id-pin carries doc_id={m.get('doc_id')!r}, "
+            f"expected {expected_doc_id!r} (catalog tumbler)"
+        )
+
+
+def test_store_put_doc_id_absent_when_catalog_uninitialized(
+    local_t3: T3Database,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no catalog exists, store put must still succeed and emit a
+    chunk WITHOUT doc_id (schema drops empty doc_id at the funnel).
+    """
+    from click.testing import CliRunner
+    from nexus.commands.store import store
+
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "no-catalog"))
+    (tmp_path / "finding-nocat.md").write_text(
+        "# Finding without catalog backing\n\nstore put no-catalog path.",
+        encoding="utf-8",
+    )
+
+    with patch("nexus.commands.store._t3", return_value=local_t3), \
+         patch("nexus.mcp_infra.fire_store_chains", side_effect=_no_op_post_store), \
+         patch("nexus.mcp_infra.fire_post_store_hooks", side_effect=_no_op_post_store), \
+         patch("nexus.mcp_infra.fire_post_store_batch_hooks", side_effect=_no_op_post_store), \
+         patch("nexus.mcp_infra.fire_post_document_hooks", side_effect=_no_op_post_store):
+        runner = CliRunner()
+        result = runner.invoke(store, [
+            "put",
+            str(tmp_path / "finding-nocat.md"),
+            "--collection", "knowledge",
+            "--title", "finding-no-catalog",
+            "--tags", "test",
+        ], catch_exceptions=False)
+    assert result.exit_code == 0, f"store put failed: {result.output}"
+
+    cols = local_t3._client.list_collections()
+    stored_col = None
+    for c in cols:
+        if c.name.startswith("knowledge"):
+            stored_col = c
+            break
+    assert stored_col is not None
+    chunk_result = stored_col.get(include=["metadatas"])
+    assert chunk_result["ids"]
+
+    for m in chunk_result["metadatas"]:
+        if m.get("title") == "finding-no-catalog":
+            assert "doc_id" not in m, (
+                "doc_id must be dropped (normalize Step 4c) when no catalog "
+                "entry exists; saw doc_id=%r" % m.get("doc_id")
+            )
+
+
+def test_enrich_preserves_doc_id_round_trip(
+    local_t3: T3Database,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``nx enrich bib`` re-writes chunk metadata with bib_* fields. If a
+    chunk already carries doc_id (from a Stage B.1 / B.2 / B.3 ingest),
+    the enrich update must NOT drop it — the catalog cross-reference is
+    load-bearing for the ζ cutover.
+    """
+    from click.testing import CliRunner
+    from nexus.commands.enrich import enrich
+
+    # Set up: a fake docs__ collection with a pre-Stage-B.4 chunk that
+    # already carries doc_id (simulating a Stage B.1 / B.2 / B.3 ingest).
+    coll_name = "docs__test-enrich-roundtrip"
+    col = local_t3.get_or_create_collection(coll_name)
+    chunk_meta = {
+        "content_type": "prose",
+        "source_path": "/tmp/fake.md",
+        "title": "Round-Trip Test Title",
+        "chunk_index": 0,
+        "chunk_count": 1,
+        "chunk_text_hash": "deadbeef",
+        "content_hash": "deadbeef",
+        "chunk_start_char": 0,
+        "chunk_end_char": 50,
+        "indexed_at": "2026-05-01T00:00:00+00:00",
+        "embedding_model": "voyage-context-3",
+        "store_type": "prose",
+        "corpus": coll_name,
+        "tags": "test",
+        "category": "prose",
+        "frecency_score": 0.0,
+        "doc_id": "1.42.7",  # pre-existing catalog tumbler
+        "ttl_days": 0,
+    }
+    col.add(
+        ids=["chunk-1"],
+        documents=["Round-trip preservation matters."],
+        metadatas=[chunk_meta],
+    )
+
+    # Stub the bib backend resolver so the test runs offline.
+    def fake_resolve(title, *args, **kwargs):
+        return {
+            "year": 2024,
+            "venue": "Test Journal",
+            "authors": "Doe, Jane",
+            "citation_count": 42,
+            "semantic_scholar_id": "test-ssid",
+            "_resolved_via": "title",
+        }
+
+    with patch("nexus.db.make_t3", return_value=local_t3), \
+         patch("nexus.commands.enrich._resolve_bib_for_title", side_effect=fake_resolve), \
+         patch("nexus.commands.enrich._catalog_enrich_hook"):
+        runner = CliRunner()
+        result = runner.invoke(enrich, [
+            "bib", coll_name,
+            "--source", "s2",
+            "--delay", "0",
+        ], catch_exceptions=False)
+
+    assert result.exit_code == 0, f"enrich bib failed: {result.output}"
+
+    # Re-read the chunk and verify doc_id survived the col.update merge.
+    after = col.get(ids=["chunk-1"], include=["metadatas"])
+    assert after["ids"] == ["chunk-1"]
+    after_meta = after["metadatas"][0]
+    assert after_meta.get("bib_year") == 2024, (
+        f"enrich should have written bib_year=2024; got {after_meta.get('bib_year')!r}"
+    )
+    assert after_meta.get("doc_id") == "1.42.7", (
+        f"doc_id must round-trip through enrich; got {after_meta.get('doc_id')!r}"
+    )


### PR DESCRIPTION
Two CLI write paths that bypass `_run_index`. Bead: `nexus-ds8e`. Sibling beads remaining: B.5 (mcp_infra store_put), B.6 (doctor regression test).

## What changed

### `nx store put` — restructured

The existing `_catalog_store_hook` already created a catalog entry, but it ran AFTER the T3 write, so chunks landed without a `doc_id` back-reference. The fix reorders:

1. Compute the deterministic `chunk_chroma_id` (sha256 of `{collection}:{title}`) upfront — same formula `db.put` uses internally.
2. Call `_catalog_store_hook` first → registers the catalog entry (or finds existing via legacy `meta.doc_id` dedup) → returns the tumbler string.
3. Pass tumbler to `db.put(catalog_doc_id=tumbler)`.

`_catalog_store_hook` now returns the catalog tumbler (was: `None`); `T3Database.put` accepts `catalog_doc_id: str = ""` and plumbs to `make_chunk_metadata(... doc_id=catalog_doc_id)`.

### `nx enrich bib` — verified, no code change

The existing `merged = dict(meta)` + `col.update(metadatas=merged)` pattern in `enrich_bib` already preserves `doc_id` round-trip. Stage B.4 just **locks this in with a regression test** — without the test, a future refactor could silently drop the field on enrich and the catalog cross-reference would rot for already-enriched corpora.

## Tests

`tests/test_store_enrich_doc_id.py` (new, 3 tests):

1. **WITH TEETH** — `nx store put` writes the catalog tumbler as `doc_id` in the T3 chunk's metadata. **Verified:** stashing `store.py` causes the test to fail with `doc_id=None`.
2. **Guard** — when no catalog exists, `store put` still succeeds and emits a chunk without `doc_id` (schema drops empty `doc_id` at the funnel).
3. **Round-trip** — `enrich bib` preserves a pre-existing `doc_id` through its `col.update` merge.

All three tests use Click's `CliRunner` to exercise the actual command entry points. Post-store hook chains (chash dual-write, taxonomy assignment, aspect-extraction queue) are stubbed because they require T2 schema state outside the Stage B.4 contract.

## Test results

- Targeted suite (`catalog | event_log | projector | rdr101 | mcp | metadata_schema | metadata_consistency | prose_indexer | code_indexer | pdf | indexer | store | enrich | t3`): **1938 passed, 2 skipped**.
- `test_catalog_e2e::test_store_put_registers_in_catalog`: pass — no regression on the existing catalog-side dedup contract.

## Test plan

- [x] Failing integration test exists and was verified to fail before implementation.
- [x] Reverting `store.py` wiring breaks the test deterministically (WITH TEETH).
- [x] Round-trip enrich test passes today (locks current behavior).
- [x] No-catalog fallback test exercises `Catalog.is_initialized → False` path.
- [x] Existing `_catalog_store_hook` dedup contract intact (legacy `meta.doc_id` lookup still works for re-runs).