### PR TITLE
feat(rdr-101): phase 3 PR δ stage B.5 — MCP store_put writes doc_id at chunk-write time

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -480,3 +480,5 @@
 {"id":"int-2c110872","kind":"field_change","created_at":"2026-05-01T17:59:17.314547Z","actor":"Hellblazer","issue_id":"nexus-n1uo","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-58956959","kind":"field_change","created_at":"2026-05-01T18:06:36.304507Z","actor":"Hellblazer","issue_id":"nexus-n1uo","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-79d435c2","kind":"field_change","created_at":"2026-05-01T18:14:30.660049Z","actor":"Hellblazer","issue_id":"nexus-ds8e","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-ad019d3f","kind":"field_change","created_at":"2026-05-01T18:23:47.090555Z","actor":"Hellblazer","issue_id":"nexus-ds8e","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-db480321","kind":"field_change","created_at":"2026-05-01T18:27:37.675187Z","actor":"Hellblazer","issue_id":"nexus-y3um","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -880,26 +880,37 @@ def store_put(
         ttl_days = days if days is not None else 0
         col_name = t3_collection_name(collection)
         t3 = _get_t3()
+
+        # RDR-101 Phase 3 PR δ Stage B.5: pre-register the catalog entry
+        # so the T3 chunk can carry the resulting tumbler as ``doc_id``
+        # at write-time. Same pattern as the CLI ``nx store put`` (B.4).
+        # The chunk_chroma_id is deterministic (sha256 of "{coll}:{title}"),
+        # matching ``T3Database.put``'s internal derivation.
+        import hashlib as _hl
+        chunk_chroma_id = _hl.sha256(f"{col_name}:{title}".encode()).hexdigest()[:16]
+        catalog_doc_id = ""
+        try:
+            from nexus.commands.store import _catalog_store_hook
+            catalog_doc_id = _catalog_store_hook(
+                title=title, doc_id=chunk_chroma_id, collection_name=col_name,
+            )
+        except Exception:
+            import structlog
+            structlog.get_logger().warning(
+                "catalog_store_hook_failed",
+                doc_id=chunk_chroma_id,
+                collection=col_name,
+                exc_info=True,
+            )
+
         doc_id = t3.put(
             collection=col_name,
             content=content,
             title=title,
             tags=tags,
             ttl_days=ttl_days,
+            catalog_doc_id=catalog_doc_id,
         )
-        # Register in catalog (same hook the CLI uses). Non-fatal — T3 row is
-        # source of truth — but log so #253 orphan shape is observable.
-        try:
-            from nexus.commands.store import _catalog_store_hook
-            _catalog_store_hook(title=title, doc_id=doc_id, collection_name=col_name)
-        except Exception:
-            import structlog
-            structlog.get_logger().warning(
-                "catalog_store_hook_failed",
-                doc_id=doc_id,
-                collection=col_name,
-                exc_info=True,
-            )
         # Auto-link from T1 scratch link-context
         try:
             n = _catalog_auto_link(doc_id)

--- a/tests/test_catalog_e2e.py
+++ b/tests/test_catalog_e2e.py
@@ -257,6 +257,16 @@ class TestLinks:
 
 
 def test_store_put_registers_in_catalog(tmp_path, monkeypatch):
+    """RDR-101 Phase 3 PR δ Stage B.5 changed the timing so the catalog
+    hook now runs BEFORE the T3 write (so the chunk can carry the
+    catalog tumbler as ``doc_id``). The catalog's legacy
+    ``meta.doc_id`` lookup field is therefore populated with the real
+    deterministic ``chunk_chroma_id`` (sha256 of "{collection}:{title}"
+    truncated), not whatever a mocked ``db.put`` echoes back. The real
+    ``db.put`` returns the same hash, so the production behaviour is
+    unchanged — only the test setup needs to match.
+    """
+    import hashlib as _hl
     from nexus.mcp_server import _reset_singletons, store_put
 
     catalog_dir = tmp_path / "catalog"
@@ -274,7 +284,14 @@ def test_store_put_registers_in_catalog(tmp_path, monkeypatch):
             tags="research,embeddings",
         )
     assert "Stored" in result
-    entry = Catalog(catalog_dir, catalog_dir / ".catalog.db").by_doc_id("doc-abc123")
+    # The catalog now stores the deterministic chunk_chroma_id, matching
+    # what the real T3Database.put returns (independent of the mock).
+    expected_chunk_chroma_id = _hl.sha256(
+        b"knowledge__knowledge:research-vector-indexing"
+    ).hexdigest()[:16]
+    entry = Catalog(catalog_dir, catalog_dir / ".catalog.db").by_doc_id(
+        expected_chunk_chroma_id,
+    )
     assert entry is not None and entry.title == "research-vector-indexing"
 
 

--- a/tests/test_mcp_store_put_doc_id.py
+++ b/tests/test_mcp_store_put_doc_id.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""WITH TEETH: MCP ``store_put`` must write the catalog tumbler as
+``doc_id`` into T3 chunk metadata at write-time (RDR-101 Phase 3 PR δ
+Stage B.5).
+
+Mirrors B.4's CLI-side ``nx store put`` test for the MCP-side
+``store_put`` tool (mcp/core.py). MCP ``store_put`` is the hot path —
+Claude subagents call it for findings, research notes, and decision
+artefacts. Pre-Stage-B.5 the catalog hook ran AFTER the T3 write, so
+chunks landed without doc_id back-ref.
+
+Reverting the wiring (resolver -> ctx.catalog_doc_id ->
+``T3Database.put(catalog_doc_id=...)``) breaks the test deterministically.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+from nexus.catalog.catalog import Catalog
+from nexus.db.t3 import T3Database
+
+
+@pytest.fixture
+def local_t3() -> T3Database:
+    return T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+
+
+@pytest.fixture
+def catalog_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    catalog_dir = tmp_path / "catalog"
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+    Catalog.init(catalog_dir)
+    return catalog_dir
+
+
+def _no_op(*args, **kwargs):
+    pass
+
+
+@pytest.fixture
+def inject_local_t3(local_t3: T3Database):
+    """Inject ``local_t3`` into the mcp_infra ``_t3_instance`` singleton
+    AND patch the local-name binding in ``mcp.core``. Both layers are
+    necessary because:
+      - Other tests (e.g. ``test_mcp_server.py::t3``) leak a different
+        injected T3 into the singleton across test boundaries; without
+        ``_inject_t3(local_t3)`` here, the global lookup serves the
+        leaked instance.
+      - ``mcp.core`` imports ``get_t3 as _get_t3`` at module-load time,
+        so patching the local name is the per-test belt to the global
+        suspenders.
+    """
+    from nexus.mcp_infra import inject_t3
+    inject_t3(local_t3)
+    yield local_t3
+    # Reset singleton after the test so we don't leak into the next.
+    inject_t3(None)
+
+
+def test_mcp_store_put_writes_catalog_doc_id_into_t3_chunk_metadata(
+    inject_local_t3: T3Database,
+    catalog_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MCP ``store_put`` must populate ``doc_id`` in the T3 chunk's
+    metadata, matching the catalog tumbler created by the store hook.
+    """
+    from nexus.mcp.core import store_put
+    local_t3 = inject_local_t3
+
+    with patch("nexus.mcp.core._get_t3", return_value=local_t3), \
+         patch("nexus.mcp.core._fire_post_store_hooks", side_effect=_no_op), \
+         patch("nexus.mcp.core._fire_post_store_batch_hooks", side_effect=_no_op), \
+         patch("nexus.mcp.core._fire_post_document_hooks", side_effect=_no_op), \
+         patch("nexus.mcp.core._catalog_auto_link", return_value=0):
+        result = store_put(
+            content="# MCP finding: nexus-mcp-doc-id\n\nSubagents need catalog backref.",
+            collection="knowledge",
+            title="mcp-finding-doc-id",
+            tags="rdr-101,mcp,test",
+        )
+
+    assert "Stored" in result, f"store_put failed: {result}"
+
+    # Extract the stored collection name from the result message
+    # ("Stored: <chunk_id>  →  <collection>"). ChromaDB's EphemeralClient
+    # shares process-wide state, so other tests in the suite may have
+    # populated unrelated knowledge__ collections; we must scope to the
+    # exact collection this MCP invocation wrote to.
+    stored_col_name = result.split("->")[-1].strip()
+
+    cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+    rows = cat._db.execute(
+        "SELECT tumbler FROM documents WHERE title = 'mcp-finding-doc-id'"
+    ).fetchall()
+    assert rows, "expected catalog entry for the mcp-stored doc"
+    expected_doc_id = rows[0][0]
+
+    stored_col = local_t3._client.get_collection(stored_col_name)
+    chunk_result = stored_col.get(include=["metadatas"])
+    matching_metas = [
+        m for m in chunk_result["metadatas"]
+        if m.get("title") == "mcp-finding-doc-id"
+    ]
+    assert matching_metas, "expected a chunk with title='mcp-finding-doc-id'"
+
+    for m in matching_metas:
+        assert m.get("doc_id") == expected_doc_id, (
+            f"MCP-stored chunk carries doc_id={m.get('doc_id')!r}, "
+            f"expected {expected_doc_id!r} (catalog tumbler)"
+        )
+
+
+def test_mcp_store_put_doc_id_absent_when_catalog_uninitialized(
+    inject_local_t3: T3Database,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no catalog exists, MCP store_put still succeeds and emits a
+    chunk WITHOUT doc_id (schema drops empty doc_id at the funnel)."""
+    from nexus.mcp.core import store_put
+    local_t3 = inject_local_t3
+
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "no-catalog"))
+
+    with patch("nexus.mcp.core._get_t3", return_value=local_t3), \
+         patch("nexus.mcp.core._fire_post_store_hooks", side_effect=_no_op), \
+         patch("nexus.mcp.core._fire_post_store_batch_hooks", side_effect=_no_op), \
+         patch("nexus.mcp.core._fire_post_document_hooks", side_effect=_no_op), \
+         patch("nexus.mcp.core._catalog_auto_link", return_value=0):
+        result = store_put(
+            content="# MCP finding without catalog\n\nNo-catalog path test.",
+            collection="knowledge",
+            title="mcp-finding-no-catalog",
+            tags="test",
+        )
+    assert "Stored" in result, f"store_put failed: {result}"
+
+    stored_col_name = result.split("->")[-1].strip()
+    stored_col = local_t3._client.get_collection(stored_col_name)
+    chunk_result = stored_col.get(include=["metadatas"])
+
+    for m in chunk_result["metadatas"]:
+        if m.get("title") == "mcp-finding-no-catalog":
+            assert "doc_id" not in m, (
+                "doc_id must be dropped (normalize Step 4c) when no catalog "
+                "entry exists; saw doc_id=%r" % m.get("doc_id")
+            )

--- a/tests/test_store_enrich_doc_id.py
+++ b/tests/test_store_enrich_doc_id.py
@@ -55,6 +55,20 @@ def _no_op_post_store(*args, **kwargs):
     pass
 
 
+@pytest.fixture(autouse=True)
+def _isolate_t3_singleton():
+    """Reset the mcp_infra ``_t3_instance`` global before / after each
+    test. Other tests in the suite (notably ``test_mcp_server.py::t3``)
+    inject a T3 instance into this global without resetting it; the
+    leak masks our ``patch("nexus.commands.store._t3", ...)`` because
+    downstream hooks (``fire_post_store_hooks`` etc.) read the global
+    directly. Belt-and-suspenders isolation."""
+    from nexus.mcp_infra import inject_t3
+    inject_t3(None)
+    yield
+    inject_t3(None)
+
+
 def test_store_put_cli_writes_catalog_doc_id_into_t3_chunk_metadata(
     local_t3: T3Database,
     catalog_env: Path,
@@ -90,6 +104,14 @@ def test_store_put_cli_writes_catalog_doc_id_into_t3_chunk_metadata(
     assert result.exit_code == 0, f"store put failed: {result.output}"
     assert "Stored:" in result.output
 
+    # Extract the stored collection name from the CLI output
+    # ("Stored: <chunk_id>  →  <collection>"). ChromaDB's EphemeralClient
+    # shares process-wide state, so other tests in the suite may have
+    # populated unrelated knowledge__ collections; we must scope to the
+    # exact collection this CLI invocation wrote to.
+    stored_line = next(line for line in result.output.splitlines() if "Stored:" in line)
+    stored_col_name = stored_line.split("→")[-1].strip()
+
     # Catalog should now have an entry for the stored doc.
     cat = Catalog(catalog_env, catalog_env / ".catalog.db")
     rows = cat._db.execute(
@@ -98,18 +120,11 @@ def test_store_put_cli_writes_catalog_doc_id_into_t3_chunk_metadata(
     assert rows, "expected catalog entry for the stored doc"
     expected_doc_id = rows[0][0]
 
-    # Find the actual stored collection (resolved from "knowledge" via
-    # t3_collection_name → "knowledge__knowledge" in the default routing).
-    cols = local_t3._client.list_collections()
-    stored_col = None
-    for c in cols:
-        if c.name.startswith("knowledge"):
-            stored_col = c
-            break
-    assert stored_col is not None, "expected a knowledge__ collection"
-
+    stored_col = local_t3._client.get_collection(stored_col_name)
     chunk_result = stored_col.get(include=["metadatas"])
-    assert chunk_result["ids"], "expected at least one chunk in knowledge collection"
+    assert chunk_result["ids"], (
+        f"expected at least one chunk in {stored_col_name}"
+    )
 
     matching_metas = [
         m for m in chunk_result["metadatas"]
@@ -156,13 +171,9 @@ def test_store_put_doc_id_absent_when_catalog_uninitialized(
         ], catch_exceptions=False)
     assert result.exit_code == 0, f"store put failed: {result.output}"
 
-    cols = local_t3._client.list_collections()
-    stored_col = None
-    for c in cols:
-        if c.name.startswith("knowledge"):
-            stored_col = c
-            break
-    assert stored_col is not None
+    stored_line = next(line for line in result.output.splitlines() if "Stored:" in line)
+    stored_col_name = stored_line.split("→")[-1].strip()
+    stored_col = local_t3._client.get_collection(stored_col_name)
     chunk_result = stored_col.get(include=["metadatas"])
     assert chunk_result["ids"]
 


### PR DESCRIPTION
Final indexer-side wiring for Stage B. Bead: `nexus-y3um`. Only B.6 (doctor regression test) remains.

The MCP `store_put` is the hot path: Claude subagents call it for findings, research notes, and decision artefacts. Pre-Stage-B.5 the catalog hook ran AFTER the T3 write, so chunks landed without a `doc_id` back-ref.

## What changed

**`src/nexus/mcp/core.py`** — same option (a) pattern as the CLI `nx store put` (B.4): pre-register the catalog entry BEFORE the T3 write. Compute the deterministic `chunk_chroma_id` (sha256 of `{coll}:{title}`) upfront, pass to `_catalog_store_hook` for legacy `meta.doc_id` dedup, thread the returned tumbler into `T3Database.put(catalog_doc_id=...)`.

## Tests

`tests/test_mcp_store_put_doc_id.py` (new, 2 tests):
- **WITH TEETH** — MCP `store_put` writes the catalog tumbler as `doc_id` in the T3 chunk's metadata. Reverting the wiring breaks the test.
- **Guard** — when no catalog exists, `store_put` still succeeds and the chunk lands without `doc_id` (schema drops empty `doc_id` at the funnel).

## Test-isolation cleanup (cross-cutting)

ChromaDB `EphemeralClient` shares process-wide state — tests that filter collections by `startswith("knowledge")` race against unrelated `knowledge__` collections populated by earlier tests in the same session. Both B.4 and B.5 tests now extract the exact stored collection name from the `"Stored: ... -> <coll>"` output and call `get_collection(stored_col_name)` directly.

Also added singleton-reset fixtures (`inject_local_t3` in B.5, autouse `_isolate_t3_singleton` in B.4) to dodge the `mcp_infra._t3_instance` leak from `test_mcp_server.py::t3`.

## Existing test update

`tests/test_catalog_e2e.py::test_store_put_registers_in_catalog`: the legacy assertion looked up the catalog by the mock-fabricated `"doc-abc123"` string. After Stage B.5's reordering, the catalog receives the real deterministic `chunk_chroma_id` (sha256 of `"knowledge__knowledge:research-vector-indexing"`), independent of what the mock echoes. Updated the test to compute the deterministic value — production behaviour is unchanged because the real `T3Database.put` returns the same hash.

## Test results

Targeted suite (`catalog | event_log | projector | rdr101 | mcp | metadata_schema | metadata_consistency | prose_indexer | code_indexer | pdf | indexer | store | enrich | t3`): **1940 passed, 2 skipped**.

## Test plan

- [x] Failing integration test exists and was verified to fail before implementation.
- [x] Reverting `mcp/core.py` wiring breaks the test deterministically (WITH TEETH).
- [x] Existing `test_store_put_registers_in_catalog` updated and passing.
- [x] Test-isolation cleanup verified by running with `test_mcp_server.py` first.
- [x] No-catalog fallback test exercises `Catalog.is_initialized → False` path.