### PR TITLE
feat(rdr-101): phase 3 PR ε — lint gate forbidding direct catalog writes outside projector module

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -483,3 +483,5 @@
 {"id":"int-ad019d3f","kind":"field_change","created_at":"2026-05-01T18:23:47.090555Z","actor":"Hellblazer","issue_id":"nexus-ds8e","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-db480321","kind":"field_change","created_at":"2026-05-01T18:27:37.675187Z","actor":"Hellblazer","issue_id":"nexus-y3um","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-6748ccc6","kind":"field_change","created_at":"2026-05-01T18:53:57.034824Z","actor":"Hellblazer","issue_id":"nexus-ai9d","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-317924a9","kind":"field_change","created_at":"2026-05-01T19:07:45.798356Z","actor":"Hellblazer","issue_id":"nexus-ai9d","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-8727316b","kind":"field_change","created_at":"2026-05-01T19:21:24.948238Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.3","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/AGENTS.md
+++ b/src/nexus/catalog/AGENTS.md
@@ -49,3 +49,13 @@ The bar is **register a reader first, then add to the allow-list**. New schemes 
 - **JSONL is canonical, SQLite is cache.** Never write to SQLite without going through `Catalog.register/update/link`. Direct SQL writes will be overwritten on next mtime-driven rebuild.
 - **Tumblers are append-only.** Updating an entry preserves the tumbler; deletion creates a tombstone, not a free slot. Reusing a tumbler corrupts the link graph.
 - **Owners with `owner_type='repo'` MUST carry a `repo_hash`.** Enforced in `register_owner`. The empty-hash variant produced 83 orphan owners in the wild before the guard.
+
+## Direct catalog writes outside this module are forbidden (RDR-101 Phase 3 ε)
+
+Under RDR-101 the event log (`events.jsonl`) is canonical and the SQLite catalog is a deterministic projection. From PR ε onward, `tests/test_no_direct_catalog_writes_outside_projector.py` is a lint gate: no production source file outside `src/nexus/catalog/` may issue `INSERT / UPDATE / DELETE / REPLACE / CREATE / DROP / ALTER / TRUNCATE` through `_db.execute`. Reads (SELECT, plus `fetchone`/`fetchall` chains) remain fine.
+
+The lint gate scope is intentionally `src/nexus/catalog/`, not just `projector.py` — `catalog.py`'s legacy direct-write branches are gated behind `if not self._event_sourced_enabled:` and remain in-module. Mutations from anywhere else must travel through public Catalog API (`register`, `update`, `link`, `unlink`, `set_alias`, …), which under `NEXUS_EVENT_SOURCED=1` emits a domain event and projects it.
+
+Test fixtures that need to construct invariant-violating state (forced alias cycles, contaminated source_uri rows, backdated `created_at` for stale-span audits) tag the offending line with `# epsilon-allow: <reason>`. The reason is mandatory; bare markers do not suppress.
+
+Repair operations that previously ran as `cat._db.execute(...)` ad-hoc scripts must land as `nx catalog repair-*` verbs that emit events. The doctor's `--replay-equality` signal is reliable only if the event log is the only write path; PR ζ flips `NEXUS_EVENT_SOURCED=1` by default and depends on this gate.

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -358,7 +358,7 @@ class TestAliasResolution:
         cat.set_alias(a, b)
         # Bypass set_alias guard to force a cycle — the walker must still
         # terminate instead of looping forever.
-        cat._db.execute("UPDATE documents SET alias_of = ? WHERE tumbler = ?",
+        cat._db.execute("UPDATE documents SET alias_of = ? WHERE tumbler = ?",  # epsilon-allow: forced alias cycle, set_alias guard rejects it (RDR-101 ε)
                          (str(a), str(b)))
         cat._db.commit()
         result = cat.resolve_alias(a)
@@ -378,7 +378,7 @@ class TestAliasResolution:
         a = cat.register(owner, "a.py", content_type="code", file_path="a.py")
         # Point at a non-existent tumbler directly via SQL (bypassing
         # set_alias' validation, which doesn't verify existence).
-        cat._db.execute(
+        cat._db.execute(  # epsilon-allow: dangling alias fixture, set_alias does not verify target existence (RDR-101 ε)
             "UPDATE documents SET alias_of = ? WHERE tumbler = ?",
             ("1.99.99", str(a)),
         )
@@ -653,7 +653,7 @@ class TestLinkAuditStaleSpans:
     def test_stale_span_detected(self, cat_with_two_docs):
         cat, _, a, b = cat_with_two_docs
         cat.link(a, b, "quotes", created_by="user", from_span="10-20")
-        cat._db.execute("UPDATE links SET created_at = '2020-01-01T00:00:00Z' WHERE from_tumbler = ?", (str(a),))
+        cat._db.execute("UPDATE links SET created_at = '2020-01-01T00:00:00Z' WHERE from_tumbler = ?", (str(a),))  # epsilon-allow: backdate link.created_at to fixture-test stale_span audit (RDR-101 ε)
         cat._db.commit()
         cat.update(a, head_hash="new-hash")
         audit = cat.link_audit()
@@ -969,7 +969,7 @@ class TestCrossProjectGuard:
         contaminated_uri = "file://" + str(
             tmp_path / "wrong_project" / "stowaway.py",
         )
-        cat._db.execute(
+        cat._db.execute(  # epsilon-allow: simulate pre-guard contaminated source_uri row, register() now refuses these (RDR-101 ε)
             "INSERT INTO documents "
             "(tumbler, title, author, year, content_type, file_path, "
             "corpus, physical_collection, chunk_count, head_hash, "
@@ -1120,7 +1120,7 @@ class TestUpdateGuard:
         cat, owner, _ = cat_with_repo_owner
         # Inject a contaminated row by going around register().
         contaminated_uri = "file://" + str(tmp_path / "wrong_project" / "x.py")
-        cat._db.execute(
+        cat._db.execute(  # epsilon-allow: simulate pre-guard contaminated source_uri row for env-override test (RDR-101 ε)
             "INSERT INTO documents "
             "(tumbler, title, author, year, content_type, file_path, "
             "corpus, physical_collection, chunk_count, head_hash, "
@@ -1192,7 +1192,7 @@ class TestOwnerRepoRootDefensive:
             "x", "repo", repo_hash="aaaa1111",
             repo_root=str(tmp_path / "x"),
         )
-        cat._db.execute(
+        cat._db.execute(  # epsilon-allow: simulate legacy relative repo_root, register_owner now refuses non-absolute paths (RDR-101 ε)
             "UPDATE owners SET repo_root = ? WHERE tumbler_prefix = ?",
             ("relative/path", str(owner)),
         )

--- a/tests/test_no_direct_catalog_writes_outside_projector.py
+++ b/tests/test_no_direct_catalog_writes_outside_projector.py
@@ -1,0 +1,369 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-101 Phase 3 PR ε: lint gate.
+
+Forbids direct INSERT / UPDATE / DELETE / REPLACE / CREATE / DROP / ALTER /
+TRUNCATE against catalog SQLite from any consumer outside the catalog
+module (``src/nexus/catalog/``). The catalog module IS the projector and
+is the only authorised mutation surface. Every other write must flow
+through public catalog API (which under ``NEXUS_EVENT_SOURCED=1``
+emits an event and projects).
+
+WITH TEETH: this test guards the RDR-101 Phase 3 irreversibility window.
+Once PR ζ flips ``NEXUS_EVENT_SOURCED`` ON by default, any direct write
+outside the projector silently desyncs SQLite from the event log;
+``nx catalog doctor --replay-equality`` then becomes meaningless. The
+test must FAIL deterministically when a violating ``_db.execute`` call
+appears in any non-allowlisted file. Verified at authoring time by
+inserting a synthetic offender and re-running.
+
+Allowlist policy
+----------------
+* All of ``src/nexus/catalog/`` is allowed (it is the projector module).
+* Test fixtures that intentionally bypass the public API to construct
+  invariant-violating state (e.g. forced alias cycle, forced stale span)
+  are allowed when the offending line carries the trailing comment token
+  ``# epsilon-allow: <reason>``. The reason text must be present.
+
+Pattern reference: ``tests/test_hook_drift_guard.py`` uses the same
+AST-walk + offender-aggregation shape.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+PROJECT_ROOT = pathlib.Path(__file__).parent.parent
+SRC_ROOT = PROJECT_ROOT / "src" / "nexus"
+TESTS_ROOT = PROJECT_ROOT / "tests"
+SCRIPTS_ROOT = PROJECT_ROOT / "scripts"
+
+# Files / directories where direct catalog writes are authorised.
+# Path components are matched as POSIX-style relative paths.
+ALLOWED_PREFIXES: tuple[str, ...] = (
+    "src/nexus/catalog/",   # the projector module itself
+)
+
+# Allowlist for tests: lines tagged with this comment token are exempt
+# from the ban. The lint gate enforces that the comment carries a reason
+# (any non-empty trailing text after the colon).
+ALLOWLIST_TOKEN = "# epsilon-allow:"
+
+# SQL keywords that mutate catalog state. Every one of these on a
+# ``*._db.execute(<literal>, ...)`` call is a violation when the call
+# site sits outside ``ALLOWED_PREFIXES``.
+WRITE_KEYWORDS: frozenset[str] = frozenset({
+    "INSERT",
+    "UPDATE",
+    "DELETE",
+    "REPLACE",
+    "CREATE",
+    "DROP",
+    "ALTER",
+    "TRUNCATE",
+})
+
+
+def _is_db_execute_call(node: ast.AST) -> bool:
+    """True if *node* is a ``<expr>._db.execute(...)`` call.
+
+    Covers ``cat._db.execute``, ``self._db.execute``,
+    ``catalog._db.execute``, ``foo.bar._db.execute``, etc. Also catches
+    ``executemany`` / ``executescript`` even though no current call site
+    uses them — the lint must remain future-proof.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    if func.attr not in {"execute", "executemany", "executescript"}:
+        return False
+    inner = func.value
+    if not isinstance(inner, ast.Attribute):
+        return False
+    return inner.attr == "_db"
+
+
+def _extract_leading_sql_keyword(arg: ast.AST) -> str | None:
+    """Return the first SQL keyword (uppercase) from the SQL literal *arg*.
+
+    Handles:
+      * ``ast.Constant`` (plain string literal)
+      * ``ast.JoinedStr`` (f-string) — concatenates leading
+        ``ast.Constant`` segments to recover the literal prefix before
+        the first interpolation.
+
+    Returns ``None`` for any other node shape (e.g. SQL passed via a
+    variable). Variable-passed SQL is rare in this codebase and the few
+    occurrences will surface in code review.
+    """
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        text = arg.value
+    elif isinstance(arg, ast.JoinedStr):
+        prefix_parts: list[str] = []
+        for piece in arg.values:
+            if isinstance(piece, ast.Constant) and isinstance(piece.value, str):
+                prefix_parts.append(piece.value)
+            else:
+                break
+        text = "".join(prefix_parts)
+    else:
+        return None
+
+    text = text.lstrip()
+    if not text:
+        return None
+
+    first_token = text.split(None, 1)[0].upper().rstrip(";")
+    return first_token
+
+
+def _line_has_allowlist_marker(source_lines: list[str], lineno: int) -> bool:
+    """True if the line at *lineno* (1-indexed) carries the allowlist
+    token followed by a non-empty reason.
+
+    Matches the token anywhere on the line (so multi-line ``execute``
+    calls can carry the token on the first line of the call). The reason
+    text must be non-empty after the colon.
+    """
+    if lineno < 1 or lineno > len(source_lines):
+        return False
+
+    # Scan the call's first line plus a small forward window: a multi-line
+    # ``cat._db.execute(...)`` call may carry the marker on any of its
+    # constituent lines. 8 lines is generous; the existing fixtures span
+    # at most 2.
+    for offset in range(8):
+        idx = lineno - 1 + offset
+        if idx >= len(source_lines):
+            break
+        line = source_lines[idx]
+        token_pos = line.find(ALLOWLIST_TOKEN)
+        if token_pos < 0:
+            continue
+        reason = line[token_pos + len(ALLOWLIST_TOKEN):].strip()
+        if reason:
+            return True
+        # Token without reason text — keep scanning; the file may have
+        # the canonical marker further down.
+    return False
+
+
+def _scan_file(path: pathlib.Path, *, allow_marker: bool) -> list[str]:
+    """Return human-readable violation strings for *path*.
+
+    *allow_marker* enables the ``# epsilon-allow:`` allowlist comment.
+    For ``src/`` and ``scripts/`` the marker is disabled — production
+    code must never contain a direct write.
+    """
+    try:
+        source = path.read_text()
+    except (UnicodeDecodeError, OSError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    source_lines = source.splitlines()
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if not _is_db_execute_call(node):
+            continue
+        if not node.args:
+            continue
+
+        keyword = _extract_leading_sql_keyword(node.args[0])
+        if keyword is None or keyword not in WRITE_KEYWORDS:
+            continue
+
+        if allow_marker and _line_has_allowlist_marker(source_lines, node.lineno):
+            continue
+
+        violations.append(f"line {node.lineno}: {keyword} via _db.{node.func.attr}(...)")
+
+    return violations
+
+
+def _path_is_allowed(rel_posix: str) -> bool:
+    return any(rel_posix.startswith(prefix) for prefix in ALLOWED_PREFIXES)
+
+
+def _gather_violations(
+    root: pathlib.Path,
+    *,
+    allow_marker: bool,
+    skip_self: bool = False,
+) -> dict[str, list[str]]:
+    """Walk *root* and return ``{rel_path: [violations]}``.
+
+    *skip_self* skips this very test file (for the ``tests/`` walk).
+    """
+    if not root.exists():
+        return {}
+
+    self_rel = pathlib.Path(__file__).resolve().relative_to(PROJECT_ROOT).as_posix()
+    offenders: dict[str, list[str]] = {}
+
+    for py in root.rglob("*.py"):
+        rel = py.relative_to(PROJECT_ROOT).as_posix()
+        if _path_is_allowed(rel):
+            continue
+        if skip_self and rel == self_rel:
+            continue
+        hits = _scan_file(py, allow_marker=allow_marker)
+        if hits:
+            offenders[rel] = hits
+
+    return offenders
+
+
+def test_no_direct_catalog_writes_in_src() -> None:
+    """RDR-101 Phase 3 ε: no production source file outside
+    ``src/nexus/catalog/`` may issue an INSERT / UPDATE / DELETE /
+    REPLACE / CREATE / DROP / ALTER / TRUNCATE through ``_db.execute``.
+
+    Stage B (PRs #438–#445) closed every legitimate live-write path by
+    routing through the catalog hook. After this gate lands, PR ζ can
+    safely flip ``NEXUS_EVENT_SOURCED=1`` by default without exposing
+    unaudited direct writers.
+    """
+    offenders = _gather_violations(SRC_ROOT, allow_marker=False)
+
+    if offenders:
+        formatted = "\n".join(
+            f"  {path}:\n    " + "\n    ".join(hits)
+            for path, hits in sorted(offenders.items())
+        )
+        raise AssertionError(
+            "RDR-101 Phase 3 ε: direct catalog writes outside the "
+            "projector module are forbidden. Offenders must route "
+            "through Catalog public API (which under "
+            "NEXUS_EVENT_SOURCED=1 emits + projects). Violations:\n"
+            f"{formatted}"
+        )
+
+
+def test_no_direct_catalog_writes_in_scripts() -> None:
+    """Operator scripts may not bypass the projector either. Repair
+    operations should land as ``nx catalog repair-*`` verbs that emit
+    events through the public Catalog API.
+    """
+    offenders = _gather_violations(SCRIPTS_ROOT, allow_marker=False)
+
+    if offenders:
+        formatted = "\n".join(
+            f"  {path}:\n    " + "\n    ".join(hits)
+            for path, hits in sorted(offenders.items())
+        )
+        raise AssertionError(
+            "RDR-101 Phase 3 ε: scripts/ may not issue direct catalog "
+            "writes. Rewrite as `nx catalog repair-*` verbs or retire. "
+            "Violations:\n"
+            f"{formatted}"
+        )
+
+
+def test_no_direct_catalog_writes_in_tests_without_allowlist_marker() -> None:
+    """Tests may carry intentional invariant-violation fixtures (e.g.
+    forced alias cycle, forced stale span). Each such site MUST tag the
+    offending line with ``# epsilon-allow: <reason>`` so the lint gate
+    treats it as a documented exception. Untagged direct writes in
+    tests are still violations.
+    """
+    offenders = _gather_violations(TESTS_ROOT, allow_marker=True, skip_self=True)
+
+    if offenders:
+        formatted = "\n".join(
+            f"  {path}:\n    " + "\n    ".join(hits)
+            for path, hits in sorted(offenders.items())
+        )
+        raise AssertionError(
+            "RDR-101 Phase 3 ε: untagged direct catalog writes in tests. "
+            "Either rewrite to use Catalog public API, or tag the line "
+            f"with `{ALLOWLIST_TOKEN} <reason>`. Violations:\n"
+            f"{formatted}"
+        )
+
+
+def test_lint_gate_detects_synthetic_violation(tmp_path: pathlib.Path) -> None:
+    """Self-test: the AST walker must flag a freshly authored
+    ``cat._db.execute("DELETE FROM ...")`` call. Guards against silent
+    breakage of the gate (e.g. AST-shape regression after a Python
+    upgrade, or accidental short-circuit in ``_is_db_execute_call``).
+    """
+    fake = tmp_path / "fake_offender.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.execute('DELETE FROM documents WHERE id = ?', (1,))\n"
+    )
+
+    hits = _scan_file(fake, allow_marker=False)
+    assert hits, "lint gate failed to detect a literal DELETE — AST shape changed?"
+    assert "DELETE" in hits[0]
+
+
+def test_lint_gate_detects_fstring_violation(tmp_path: pathlib.Path) -> None:
+    """Self-test: f-string SQL must be detected via the leading
+    ``ast.Constant`` segment of the ``ast.JoinedStr``.
+    """
+    fake = tmp_path / "fake_fstring_offender.py"
+    fake.write_text(
+        "def f(cat, table):\n"
+        "    cat._db.execute(f'DELETE FROM {table} WHERE id = ?', (1,))\n"
+    )
+
+    hits = _scan_file(fake, allow_marker=False)
+    assert hits, "lint gate failed to detect an f-string DELETE"
+    assert "DELETE" in hits[0]
+
+
+def test_allowlist_marker_suppresses_violation(tmp_path: pathlib.Path) -> None:
+    """Self-test: the ``# epsilon-allow: <reason>`` marker must suppress
+    the violation when *and only when* a non-empty reason is present.
+    """
+    fake = tmp_path / "fake_with_marker.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.execute('UPDATE documents SET x = 1', ())  "
+        "# epsilon-allow: forced fixture for cycle test\n"
+    )
+
+    assert _scan_file(fake, allow_marker=True) == []
+    # Without the allow_marker flag (production scope), the marker is
+    # ignored and the line is still flagged.
+    assert _scan_file(fake, allow_marker=False), (
+        "marker must NOT suppress in production scope"
+    )
+
+
+def test_allowlist_marker_without_reason_does_not_suppress(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Self-test: a bare ``# epsilon-allow:`` with no reason text must
+    NOT suppress. The lint gate insists on documentation.
+    """
+    fake = tmp_path / "fake_bare_marker.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.execute('UPDATE documents SET x = 1', ())  # epsilon-allow:\n"
+    )
+
+    assert _scan_file(fake, allow_marker=True), (
+        "bare marker without reason must NOT suppress"
+    )
+
+
+def test_select_calls_are_not_flagged(tmp_path: pathlib.Path) -> None:
+    """Self-test: SELECT (and fetchone/fetchall callers) must never be
+    flagged. The lint gate is for mutations only.
+    """
+    fake = tmp_path / "fake_select.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    rows = cat._db.execute('SELECT * FROM documents').fetchall()\n"
+        "    return rows\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == []

--- a/tests/test_rdr053_verification.py
+++ b/tests/test_rdr053_verification.py
@@ -133,7 +133,7 @@ class TestLinkAuditChashVerification:
         cat.link(doc_a, doc_b, "quotes", "test-agent", from_span=f"chash:{HASH_A}")
 
         # Backdate the link so it's older than the document's indexed_at
-        cat._db.execute(
+        cat._db.execute(  # epsilon-allow: backdate link.created_at to assert chash spans survive re-indexing (RDR-101 ε)
             "UPDATE links SET created_at = '2020-01-01T00:00:00Z' WHERE from_tumbler = ?",
             (str(doc_a),),
         )
@@ -163,7 +163,7 @@ class TestStaleSpanToSide:
         cat.link(doc_a, doc_b, "quotes", "test-agent", to_span="10-20")
 
         # Backdate the link
-        cat._db.execute(
+        cat._db.execute(  # epsilon-allow: backdate link.created_at to assert to_span staleness detection (RDR-101 ε)
             "UPDATE links SET created_at = '2020-01-01T00:00:00Z' "
             "WHERE from_tumbler = ?", (str(doc_a),),
         )

--- a/tests/test_store_put_cli_parity.py
+++ b/tests/test_store_put_cli_parity.py
@@ -132,13 +132,17 @@ class TestMemoryPromoteCli:
 
         # T2 environment: a memory entry to promote. ``memory promote``
         # takes the integer entry_id as its positional argument.
-        db_path = tmp_path / "t2.db"
-        monkeypatch.setattr(
-            "nexus.commands._helpers.default_db_path", lambda: db_path,
-        )
+        # NEXUS_CONFIG_DIR is the documented isolation knob — patching
+        # ``nexus.commands._helpers.default_db_path`` does NOT reach
+        # ``memory._default_db_path`` because memory.py captures the
+        # function via ``from … import … as`` at module-load time.
+        # Setting the env var is read at call time inside
+        # ``nexus_config_dir()``, so it isolates every CLI subcommand.
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
         monkeypatch.setattr(
             "nexus.config.is_local_mode", lambda: True,
         )
+        db_path = tmp_path / "memory.db"
         db = T2Database(db_path)
         entry_id = db.put(
             project="proj-test", title="m-1", content="memory body",


### PR DESCRIPTION
## Summary

- AST-walker lint gate (`tests/test_no_direct_catalog_writes_outside_projector.py`) fails the build when any production source file outside `src/nexus/catalog/` issues an `INSERT / UPDATE / DELETE / REPLACE / CREATE / DROP / ALTER / TRUNCATE` through `_db.execute`. Covers literal SQL and f-strings; `executemany`/`executescript` future-proofed.
- Audit confirmed zero direct writes outside the catalog module in production. Every `_db.execute` site under `src/nexus/{,mcp/,commands/}` and `scripts/` is a SELECT.
- Eight intentional invariant-violation fixtures in `tests/test_catalog.py` and `tests/test_rdr053_verification.py` (forced alias cycle, dangling alias, contaminated `source_uri` rows, legacy relative `repo_root`, backdated `links.created_at` for stale-span audits) carry `# epsilon-allow: <reason>` tags. Bare markers without a reason do not suppress.
- `src/nexus/catalog/AGENTS.md` documents the prohibition and the in-module legacy-path exception.

WITH TEETH verified at authoring time: temporarily inserted `cat._db.execute('DELETE FROM documents WHERE 0=1')` into `src/nexus/health.py`, gate flagged it deterministically (`line 705: DELETE via _db.execute(...)`), reverted.

## Why now

Stage B (PRs #438–#445, beads `nexus-fecd` / `nexus-t6p0` / `nexus-6qy0` / `nexus-n1uo` / `nexus-ds8e` / `nexus-y3um` / `nexus-ai9d`) closed the live-write coverage gap by routing every indexer write through the catalog hook. PR ζ (flip `NEXUS_EVENT_SOURCED=1` default) needs this gate first: until direct writes are forbidden, ζ would silently expose any unaudited direct-write caller and corrupt catalog state under event-sourced mode.

## Scope

The lint gate scope is `src/nexus/` minus `src/nexus/catalog/` plus `scripts/` plus `tests/`. The catalog module itself remains free to mutate `_db` because:
- `projector.py` IS the projector;
- `catalog.py`'s direct writes (e.g. `DELETE FROM links` at line 2519) sit inside `else:` of `if self._event_sourced_enabled:` legacy branches, bypassed under ES mode;
- `dedupe.py:278/283/284` direct DELETEs are not gated by `is_event_sourced()` today and are flagged in the parent bead's *Open questions* as a follow-up — out of scope for ε per the handoff brief's interpretation.

## Test plan

- [x] `pytest tests/test_no_direct_catalog_writes_outside_projector.py -v` — 8/8 pass.
- [x] Targeted RDR-101 sweep (`catalog or event_log or projector or rdr101 or mcp or metadata_schema or metadata_consistency or prose_indexer or code_indexer or pdf or indexer or store or enrich or t3 or doctor or no_direct_catalog_writes or rdr053`): **2070 passed, 2 skipped, 4272 deselected** in 3:42.
- [x] WITH TEETH integration: synthetic `DELETE` in `src/nexus/health.py:705` flagged; reverted.
- [x] `tests/test_catalog.py` and `tests/test_rdr053_verification.py` still pass after allowlist-tag edits.

## Refs

- Parent: `nexus-o6aa.9` (Phase 3 sub-task umbrella)
- This bead: `nexus-o6aa.9.3`
- Depends on: `nexus-ai9d` (Stage B.6 doctor end-to-end coverage)
- Predecessor PRs: #438, #439, #441, #442, #443, #444, #445
- Successor: ζ — flip `NEXUS_EVENT_SOURCED=1` default (separate bead)