### PR TITLE
feat(rdr-101): phase 3 dedupe through projector — emit LinkDeleted/DocumentDeleted/OwnerDeleted under NEXUS_EVENT_SOURCED=1

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -62,6 +62,7 @@ from nexus.catalog.events import (  # noqa: E402
     Event as _Event,
     LinkCreatedPayload as _LinkCreatedPayload,
     LinkDeletedPayload as _LinkDeletedPayload,
+    OwnerDeletedPayload as _OwnerDeletedPayload,
     OwnerRegisteredPayload as _OwnerRegisteredPayload,
     SCHEMA_BIB_S2_V1 as _SCHEMA_BIB_S2_V1,
     SCHEMA_SCHOLARLY_PAPER_V1 as _SCHEMA_SCHOLARLY_PAPER_V1,

--- a/src/nexus/catalog/dedupe.py
+++ b/src/nexus/catalog/dedupe.py
@@ -273,22 +273,80 @@ def apply_remove_plan(cat: "Catalog", op: OrphanPlan) -> tuple[int, int]:
         })
     cat._append_jsonl(cat._owners_path, {"owner": orphan_prefix, "_deleted": True})
 
-    # 4. SQL deletion.
-    if doc_tumblers:
-        cat._db.execute(
-            f"DELETE FROM links WHERE from_tumbler IN ({placeholders}) "
-            f"OR to_tumbler IN ({placeholders})",
-            (*doc_tumblers, *doc_tumblers),
+    # 4. SQL deletion. Under NEXUS_EVENT_SOURCED=1 every mutation must
+    # travel through events.jsonl so the projector's rebuild is the only
+    # source of truth (RDR-101 Phase 3, nexus-o6aa.9.4 — blocks ζ). The
+    # legacy direct-DELETE path is retained for backward compatibility
+    # under the gate-off configuration; the JSONL tombstones above are
+    # written in both modes (no-op under ES rebuild but kept for the
+    # cutover window).
+    if cat._event_sourced_enabled:
+        from nexus.catalog.catalog import (
+            _DocumentDeletedPayload,
+            _LinkDeletedPayload,
+            _OwnerDeletedPayload,
+            _make_event,
         )
-    cat._db.execute(f"DELETE FROM documents WHERE {clause}", params)
-    cat._db.execute(
-        "DELETE FROM owners WHERE tumbler_prefix = ?", (orphan_prefix,),
-    )
-    cat._db.commit()
+
+        # Order: links first (so the projector mutates dependent rows
+        # before the documents that anchor them), then documents, then
+        # the owner row last. The projector contract accepts any order
+        # for v: 0 events but operator-readable replay benefits from
+        # the natural dependency ordering.
+        for r in link_rows:
+            event = _make_event(
+                _LinkDeletedPayload(
+                    from_doc=r[0],
+                    to_doc=r[1],
+                    link_type=r[2],
+                    reason="dedupe.orphan",
+                ),
+                v=0,
+            )
+            cat._write_to_event_log(event)
+            cat._projector.apply(event)
+
+        for r in rows:
+            event = _make_event(
+                _DocumentDeletedPayload(
+                    doc_id=r[0],
+                    tumbler=r[0],
+                    reason="dedupe.orphan",
+                ),
+                v=0,
+            )
+            cat._write_to_event_log(event)
+            cat._projector.apply(event)
+
+        cat._write_to_event_log(
+            owner_event := _make_event(
+                _OwnerDeletedPayload(
+                    owner_id=orphan_prefix,
+                    reason="dedupe.orphan",
+                ),
+                v=0,
+            )
+        )
+        cat._projector.apply(owner_event)
+
+        cat._db.commit()
+    else:
+        if doc_tumblers:
+            cat._db.execute(
+                f"DELETE FROM links WHERE from_tumbler IN ({placeholders}) "
+                f"OR to_tumbler IN ({placeholders})",
+                (*doc_tumblers, *doc_tumblers),
+            )
+        cat._db.execute(f"DELETE FROM documents WHERE {clause}", params)
+        cat._db.execute(
+            "DELETE FROM owners WHERE tumbler_prefix = ?", (orphan_prefix,),
+        )
+        cat._db.commit()
 
     _log.info(
         "catalog.dedupe.remove_plan_applied",
         orphan=op.orphan_name, docs=len(rows), links=len(link_rows),
+        event_sourced=cat._event_sourced_enabled,
     )
     return len(rows), len(link_rows)
 

--- a/src/nexus/catalog/events.py
+++ b/src/nexus/catalog/events.py
@@ -81,6 +81,7 @@ def now_ts() -> str:
 # ── Event type names ─────────────────────────────────────────────────────
 
 TYPE_OWNER_REGISTERED = "OwnerRegistered"
+TYPE_OWNER_DELETED = "OwnerDeleted"
 TYPE_COLLECTION_CREATED = "CollectionCreated"
 TYPE_COLLECTION_SUPERSEDED = "CollectionSuperseded"
 TYPE_DOCUMENT_REGISTERED = "DocumentRegistered"
@@ -96,6 +97,7 @@ TYPE_LINK_DELETED = "LinkDeleted"
 ALL_EVENT_TYPES: frozenset[str] = frozenset(
     {
         TYPE_OWNER_REGISTERED,
+        TYPE_OWNER_DELETED,
         TYPE_COLLECTION_CREATED,
         TYPE_COLLECTION_SUPERSEDED,
         TYPE_DOCUMENT_REGISTERED,
@@ -136,6 +138,27 @@ class OwnerRegisteredPayload:
     repo_root: str = ""
     repo_hash: str = ""
     description: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class OwnerDeletedPayload:
+    """Tombstone for an owner.
+
+    Emitted by ``nx catalog dedupe`` (RDR-101 Phase 3 follow-up,
+    nexus-o6aa.9.4) when an orphan owner is being retired. Without this
+    event the projector's event-sourced rebuild would replay the owner's
+    original ``OwnerRegistered`` event and silently resurrect the row,
+    breaking ``doctor --replay-equality`` and the ζ default-flip
+    irreversibility.
+
+    ``owner_id`` is the tumbler prefix (e.g. ``1.7``) — same shape as
+    ``OwnerRegisteredPayload.owner_id`` so the projector can match on a
+    single column. ``reason`` is operator provenance for forensic
+    archaeology (e.g. ``"dedupe.orphan"``).
+    """
+
+    owner_id: str
+    reason: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -362,6 +385,7 @@ class LinkDeletedPayload:
 
 _PAYLOAD_CLASSES: dict[str, type] = {
     TYPE_OWNER_REGISTERED: OwnerRegisteredPayload,
+    TYPE_OWNER_DELETED: OwnerDeletedPayload,
     TYPE_COLLECTION_CREATED: CollectionCreatedPayload,
     TYPE_COLLECTION_SUPERSEDED: CollectionSupersededPayload,
     TYPE_DOCUMENT_REGISTERED: DocumentRegisteredPayload,

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -134,6 +134,19 @@ class Projector:
             ),
         )
 
+    def _v0_owner_deleted(self, payload: Any) -> None:
+        # nexus-o6aa.9.4: dedupe-driven owner retirement under
+        # NEXUS_EVENT_SOURCED=1. Re-deleting a missing row is a no-op.
+        # Documents under this owner come out via their own
+        # DocumentDeleted events; we do not cascade here because the
+        # projection contract is one event = one row mutation.
+        if not payload.owner_id:
+            return
+        self._db.execute(
+            "DELETE FROM owners WHERE tumbler_prefix = ?",
+            (payload.owner_id,),
+        )
+
     def _v0_document_registered(self, payload: Any) -> None:
         # The existing schema is tumbler-keyed; v: 0 synthesis stuffs the
         # tumbler into both ``payload.tumbler`` (legacy) and ``payload.doc_id``
@@ -348,6 +361,7 @@ def _build_dispatch() -> dict[tuple[str, int], Any]:
     return {
         # v: 0 — synthesized from existing JSONL
         (ev.TYPE_OWNER_REGISTERED, 0):       Projector._v0_owner_registered,
+        (ev.TYPE_OWNER_DELETED, 0):          Projector._v0_owner_deleted,
         (ev.TYPE_COLLECTION_CREATED, 0):     Projector._v0_owner_or_collection_noop,
         (ev.TYPE_COLLECTION_SUPERSEDED, 0):  Projector._v0_owner_or_collection_noop,
         (ev.TYPE_DOCUMENT_REGISTERED, 0):    Projector._v0_document_registered,
@@ -361,6 +375,7 @@ def _build_dispatch() -> dict[tuple[str, int], Any]:
         (ev.TYPE_LINK_DELETED, 0):           Projector._v0_link_deleted,
         # v: 1 — Phase 3 ships these
         (ev.TYPE_OWNER_REGISTERED, 1):       Projector._v1_unsupported,
+        (ev.TYPE_OWNER_DELETED, 1):          Projector._v1_unsupported,
         (ev.TYPE_COLLECTION_CREATED, 1):     Projector._v1_unsupported,
         (ev.TYPE_COLLECTION_SUPERSEDED, 1):  Projector._v1_unsupported,
         (ev.TYPE_DOCUMENT_REGISTERED, 1):    Projector._v1_unsupported,

--- a/tests/test_catalog_dedupe_event_sourced.py
+++ b/tests/test_catalog_dedupe_event_sourced.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-101 Phase 3 follow-up (nexus-o6aa.9.4): dedupe.apply_remove_plan
+must travel through the projector under ``NEXUS_EVENT_SOURCED=1``.
+
+Pre-fix, ``apply_remove_plan`` direct-DELETEs SQLite and appends
+tombstones only to legacy JSONL — which the event-sourced rebuild
+ignores. After dedupe, the next ``_ensure_consistent`` rebuild replays
+the events.jsonl log (which still carries the original
+``OwnerRegistered`` / ``DocumentRegistered`` / ``LinkCreated`` events)
+and silently RESURRECTS the orphan rows the operator just deleted.
+
+WITH TEETH: this test exercises the rebuild step explicitly. Pre-fix
+the test FAILS — the orphan owner / docs / links reappear after the
+rebuild. Post-fix the test PASSES because dedupe emits
+``LinkDeleted`` / ``DocumentDeleted`` / ``OwnerDeleted`` events into
+events.jsonl, and the projector applies them on rebuild.
+
+Blocks ζ (flip ``NEXUS_EVENT_SOURCED=1`` default) — without this fix,
+``nx catalog dedupe`` becomes silently lossy under ζ.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.dedupe import OrphanPlan, apply_remove_plan
+
+
+def _make_catalog_es(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Catalog:
+    """Construct a Catalog with NEXUS_EVENT_SOURCED=1 in the env at
+    construction time. The gate is read once in ``__init__``.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    d = tmp_path / "catalog"
+    d.mkdir()
+    return Catalog(d, d / ".catalog.db")
+
+
+def _populate_with_orphan(cat: Catalog) -> tuple[str, list[str]]:
+    """Register a canonical owner + docs and an orphan owner + docs +
+    cross-links. Returns ``(orphan_prefix, orphan_doc_tumblers)``.
+    """
+    canonical = cat.register_owner(
+        "nexus", "repo", repo_hash="571b8edd",
+        repo_root="/tmp/nexus",
+    )
+    canonical_doc = cat.register(
+        canonical, "main.py", content_type="code", file_path="main.py",
+    )
+
+    orphan = cat.register_owner("nexus-571b8edd", "curator")
+    orphan_a = cat.register(
+        orphan, "stowaway-a.py", content_type="code",
+        file_path="stowaway-a.py",
+    )
+    orphan_b = cat.register(
+        orphan, "stowaway-b.py", content_type="code",
+        file_path="stowaway-b.py",
+    )
+
+    # Cross-link the orphan documents to themselves and to the canonical
+    # owner so the link-delete path is exercised on both endpoints.
+    cat.link(orphan_a, orphan_b, "cites", "test", from_span="10-20")
+    cat.link(orphan_a, canonical_doc, "relates", "test", from_span="5-15")
+
+    return str(orphan), [str(orphan_a), str(orphan_b)]
+
+
+def _force_rebuild_from_events(cat: Catalog) -> None:
+    """Force ``_ensure_consistent`` to run an event-sourced rebuild from
+    events.jsonl. Resets the mtime watermark so the next call replays
+    the canonical log.
+    """
+    cat._last_consistency_mtime = 0.0
+    cat.degraded = False
+    cat._ensure_consistent()
+
+
+def test_dedupe_under_es_survives_rebuild(tmp_path, monkeypatch):
+    """Core invariant: after dedupe under ES mode, the next event-sourced
+    rebuild MUST NOT resurrect the deleted orphan rows. Pre-fix this
+    test fails because dedupe emits no events; the rebuild replays the
+    OwnerRegistered/DocumentRegistered/LinkCreated events from before
+    the dedupe and re-creates everything.
+    """
+    cat = _make_catalog_es(tmp_path, monkeypatch)
+    assert cat._event_sourced_enabled, "test requires NEXUS_EVENT_SOURCED=1"
+
+    orphan_prefix, orphan_docs = _populate_with_orphan(cat)
+
+    # Pre-dedupe sanity: orphan rows are present.
+    pre = cat._db.execute(
+        "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+        (f"{orphan_prefix}.%",),
+    ).fetchone()[0]
+    assert pre == 2, f"expected 2 orphan docs pre-dedupe; got {pre}"
+
+    plan = OrphanPlan(
+        orphan_prefix=orphan_prefix,
+        orphan_name="nexus-571b8edd",
+        action="remove",
+        doc_count=2,
+    )
+    deleted_docs, deleted_links = apply_remove_plan(cat, plan)
+    assert deleted_docs == 2
+    assert deleted_links == 2
+
+    # Immediate post-dedupe: SQLite reflects the deletion (irrespective
+    # of how dedupe achieved it).
+    immediate = cat._db.execute(
+        "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+        (f"{orphan_prefix}.%",),
+    ).fetchone()[0]
+    assert immediate == 0, "dedupe failed to remove orphan docs immediately"
+
+    # The teeth: force an event-sourced rebuild and assert the deletion
+    # SURVIVES. Pre-fix the orphans come back because no LinkDeleted /
+    # DocumentDeleted / OwnerDeleted events live in events.jsonl, and
+    # the projector replays the original Created events into a fresh
+    # SQLite state.
+    _force_rebuild_from_events(cat)
+
+    post = cat._db.execute(
+        "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+        (f"{orphan_prefix}.%",),
+    ).fetchone()[0]
+    assert post == 0, (
+        "RDR-101 Phase 3 ζ blocker: event-sourced rebuild RESURRECTED "
+        f"{post} orphan documents that dedupe deleted. dedupe must "
+        "emit LinkDeleted/DocumentDeleted/OwnerDeleted events under "
+        "NEXUS_EVENT_SOURCED=1."
+    )
+
+    owner_post = cat._db.execute(
+        "SELECT COUNT(*) FROM owners WHERE tumbler_prefix = ?",
+        (orphan_prefix,),
+    ).fetchone()[0]
+    assert owner_post == 0, (
+        "event-sourced rebuild RESURRECTED the orphan owner row; "
+        "dedupe must emit OwnerDeleted under NEXUS_EVENT_SOURCED=1."
+    )
+
+    link_post = cat._db.execute(
+        "SELECT COUNT(*) FROM links WHERE from_tumbler IN (?, ?) "
+        "OR to_tumbler IN (?, ?)",
+        (*orphan_docs, *orphan_docs),
+    ).fetchone()[0]
+    assert link_post == 0, (
+        f"event-sourced rebuild RESURRECTED {link_post} orphan links; "
+        "dedupe must emit one LinkDeleted per removed link under "
+        "NEXUS_EVENT_SOURCED=1."
+    )
+
+
+def test_dedupe_emits_events_under_es(tmp_path, monkeypatch):
+    """Direct check: dedupe under ES appends the right events to
+    events.jsonl. One ``LinkDeleted`` per link, one
+    ``DocumentDeleted`` per orphan doc, one ``OwnerDeleted`` for the
+    orphan owner.
+    """
+    import json
+
+    cat = _make_catalog_es(tmp_path, monkeypatch)
+    orphan_prefix, _ = _populate_with_orphan(cat)
+
+    pre_events = cat._events_path.read_text().splitlines()
+    pre_count = len(pre_events)
+
+    plan = OrphanPlan(
+        orphan_prefix=orphan_prefix,
+        orphan_name="nexus-571b8edd",
+        action="remove",
+        doc_count=2,
+    )
+    apply_remove_plan(cat, plan)
+
+    post_events = cat._events_path.read_text().splitlines()
+    new_events = [json.loads(line) for line in post_events[pre_count:]]
+    new_types = [e["type"] for e in new_events]
+
+    # 2 LinkDeleted (the two links from the orphan) + 2
+    # DocumentDeleted + 1 OwnerDeleted = 5 events. Order: links first
+    # (so dependent rows go before their owners), then documents, then
+    # the owner row last.
+    assert new_types.count("LinkDeleted") == 2, (
+        f"expected 2 LinkDeleted events; got {new_types}"
+    )
+    assert new_types.count("DocumentDeleted") == 2, (
+        f"expected 2 DocumentDeleted events; got {new_types}"
+    )
+    assert new_types.count("OwnerDeleted") == 1, (
+        f"expected 1 OwnerDeleted event; got {new_types}"
+    )
+
+
+def test_dedupe_legacy_mode_unchanged(tmp_path, monkeypatch):
+    """Regression guard: NEXUS_EVENT_SOURCED unset/0 still drives the
+    legacy direct-DELETE path. The function returns the same counts
+    and the orphan rows are gone from SQLite immediately.
+    """
+    monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+    d = tmp_path / "catalog"
+    d.mkdir()
+    cat = Catalog(d, d / ".catalog.db")
+    assert not cat._event_sourced_enabled, "legacy mode required"
+
+    canonical = cat.register_owner(
+        "nexus", "repo", repo_hash="571b8edd",
+        repo_root="/tmp/nexus",
+    )
+    cat.register(canonical, "main.py", content_type="code", file_path="main.py")
+    orphan = cat.register_owner("nexus-571b8edd", "curator")
+    cat.register(
+        orphan, "stowaway.py", content_type="code",
+        file_path="stowaway.py",
+    )
+
+    plan = OrphanPlan(
+        orphan_prefix=str(orphan),
+        orphan_name="nexus-571b8edd",
+        action="remove",
+        doc_count=1,
+    )
+    docs, _links = apply_remove_plan(cat, plan)
+
+    assert docs == 1
+    remaining = cat._db.execute(
+        "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+        (f"{orphan}.%",),
+    ).fetchone()[0]
+    assert remaining == 0

--- a/tests/test_catalog_events.py
+++ b/tests/test_catalog_events.py
@@ -69,9 +69,10 @@ class TestPayloadRegistry:
         assert ev.payload_class("FutureEventType") is None
 
     def test_event_type_count_matches_rdr_101(self):
-        # RDR-101 §Event log enumerates exactly 12 event types.
+        # RDR-101 §Event log enumerated 12 event types at Phase 1; Phase 3
+        # follow-up nexus-o6aa.9.4 added OwnerDeleted (v: 0 dedupe path).
         # Update this assertion alongside any addition.
-        assert len(ev.ALL_EVENT_TYPES) == 12
+        assert len(ev.ALL_EVENT_TYPES) == 13
 
 
 class TestEnvelopeRoundtrip:
@@ -135,6 +136,10 @@ class TestEnvelopeRoundtrip:
             ev.DocumentDeletedPayload(
                 doc_id=ev.new_doc_id(),
                 reason="user-requested",
+            ),
+            ev.OwnerDeletedPayload(
+                owner_id="1.42",
+                reason="dedupe.orphan",
             ),
             ev.ChunkIndexedPayload(
                 chunk_id=ev.new_chunk_id(),

--- a/tests/test_store_put_cli_parity.py
+++ b/tests/test_store_put_cli_parity.py
@@ -132,13 +132,17 @@ class TestMemoryPromoteCli:
 
         # T2 environment: a memory entry to promote. ``memory promote``
         # takes the integer entry_id as its positional argument.
-        db_path = tmp_path / "t2.db"
-        monkeypatch.setattr(
-            "nexus.commands._helpers.default_db_path", lambda: db_path,
-        )
+        # NEXUS_CONFIG_DIR is the documented isolation knob — patching
+        # ``nexus.commands._helpers.default_db_path`` does NOT reach
+        # ``memory._default_db_path`` because memory.py captures the
+        # function via ``from … import … as`` at module-load time.
+        # Setting the env var is read at call time inside
+        # ``nexus_config_dir()``, so it isolates every CLI subcommand.
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
         monkeypatch.setattr(
             "nexus.config.is_local_mode", lambda: True,
         )
+        db_path = tmp_path / "memory.db"
         db = T2Database(db_path)
         entry_id = db.put(
             project="proj-test", title="m-1", content="memory body",


### PR DESCRIPTION
## Summary

Hard blocker for ζ. Pre-fix `dedupe.apply_remove_plan` direct-DELETEs SQLite and writes only legacy JSONL tombstones — which the ES rebuild path ignores. Under `NEXUS_EVENT_SOURCED=1` the next `_ensure_consistent` rebuild replays events.jsonl (which still carries the original `OwnerRegistered` / `DocumentRegistered` / `LinkCreated` events for the deleted rows) and silently RESURRECTS the orphans. `doctor --replay-equality` then goes red. PR ζ would silently corrupt operator deletions until merged.

## Changes

- **`catalog/events.py`** — new `OwnerDeleted` event type with `OwnerDeletedPayload(owner_id, reason)`. Added to `ALL_EVENT_TYPES` (count → 13) and `_PAYLOAD_CLASSES`.
- **`catalog/projector.py`** — new `_v0_owner_deleted` handler (`DELETE FROM owners WHERE tumbler_prefix = ?`); idempotent. Wired into `_DISPATCH` for both v: 0 and v: 1 (v: 1 → `_v1_unsupported` per Phase 1 contract).
- **`catalog/catalog.py`** — imported `OwnerDeletedPayload as _OwnerDeletedPayload`.
- **`catalog/dedupe.py`** — `apply_remove_plan` branches on `cat._event_sourced_enabled`. Under ES, emits per-link `LinkDeleted` × N, per-document `DocumentDeleted` × N, then one `OwnerDeleted` in dependency order, threading each through `cat._write_to_event_log` + `cat._projector.apply` and committing once at the end. Legacy branch unchanged. Legacy JSONL tombstones written in both modes (no-op under ES, kept for the cutover window).

## Tests (TDD WITH TEETH)

`tests/test_catalog_dedupe_event_sourced.py`:

- **`test_dedupe_under_es_survives_rebuild`** — populates an orphan owner with 2 docs and 2 cross-links, runs dedupe, forces `_ensure_consistent` to replay events.jsonl, asserts the orphan rows STAY deleted. Confirmed FAILS pre-fix (rebuild resurrects 2 docs + 1 owner + 2 links); PASSES post-fix.
- **`test_dedupe_emits_events_under_es`** — verifies events.jsonl gains exactly 2 LinkDeleted + 2 DocumentDeleted + 1 OwnerDeleted.
- **`test_dedupe_legacy_mode_unchanged`** — regression guard for the gate-off path.

`tests/test_catalog_events.py` — drift-guard `ALL_EVENT_TYPES` count bumped 12 → 13; `OwnerDeletedPayload` added to the round-trip fixture.

## Verification

- All 18 dedupe tests pass (3 new + 15 existing).
- Targeted sweep (`catalog or event_log or projector or rdr101 or dedupe or doctor or no_direct_catalog_writes`): **967 passed, 1 skipped, 5371 deselected** in 2:15.
- Lint gate from PR #446 (ε) is unaffected — `dedupe.py` is in-module so within the catalog/ allow scope.

## Refs

- Bead: `nexus-o6aa.9.4` (parent: `nexus-o6aa.9`)
- Depends on: `nexus-o6aa.9.3` (PR #446 ε — lint gate)
- Blocks: ζ — default-flip `NEXUS_EVENT_SOURCED=1`
- Discovered via the audit pass that produced PR #446 (Open questions §1)