### PR TITLE
feat(rdr-101): phase 3 PR ζ — flip NEXUS_EVENT_SOURCED default to ON; irreversibility window opens

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -483,5 +483,5 @@
 {"id":"int-ad019d3f","kind":"field_change","created_at":"2026-05-01T18:23:47.090555Z","actor":"Hellblazer","issue_id":"nexus-ds8e","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-db480321","kind":"field_change","created_at":"2026-05-01T18:27:37.675187Z","actor":"Hellblazer","issue_id":"nexus-y3um","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-6748ccc6","kind":"field_change","created_at":"2026-05-01T18:53:57.034824Z","actor":"Hellblazer","issue_id":"nexus-ai9d","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
-{"id":"int-317924a9","kind":"field_change","created_at":"2026-05-01T19:07:45.798356Z","actor":"Hellblazer","issue_id":"nexus-ai9d","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
-{"id":"int-8727316b","kind":"field_change","created_at":"2026-05-01T19:21:24.948238Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.3","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-ec061874","kind":"field_change","created_at":"2026-05-01T20:56:53.028994Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.3","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-6fa65526","kind":"field_change","created_at":"2026-05-01T20:56:56.236748Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.4","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/src/nexus/catalog/AGENTS.md
+++ b/src/nexus/catalog/AGENTS.md
@@ -46,7 +46,9 @@ The bar is **register a reader first, then add to the allow-list**. New schemes 
 
 ## Key invariants
 
-- **JSONL is canonical, SQLite is cache.** Never write to SQLite without going through `Catalog.register/update/link`. Direct SQL writes will be overwritten on next mtime-driven rebuild.
+- **`events.jsonl` is canonical; SQLite is a deterministic projection.** Under RDR-101 Phase 3 PR ζ (`NEXUS_EVENT_SOURCED` default ON, nexus-o6aa.9.5) every catalog mutation flows through `Catalog.register / update / link / unlink / set_alias / dedupe`, which emits an event into `events.jsonl` first and then projects to SQLite. The legacy per-class JSONL files (`owners.jsonl`, `documents.jsonl`, `links.jsonl`) are still written for the cutover window but are no longer canonical — the doctor's `--replay-equality` signal is the binding test.
+- **Bootstrap guardrail.** Existing catalogs without an `events.jsonl` (or with one that is materially sparser than the legacy `documents.jsonl`) keep operating in legacy mode via `_event_log_covers_legacy()` in `_ensure_consistent`. Run `nx catalog synthesize-log --chunks --force` then `nx catalog t3-backfill-doc-id` to migrate; doctor `--replay-equality --t3-doc-id-coverage --strict-not-in-t3` validates the result.
+- **Opting out.** Set `NEXUS_EVENT_SOURCED=0` (or `false`/`no`/`off`) to fall back to the legacy direct-write path. Test fixtures that exercise legacy-only behaviour (shadow-emit invariants, `synthesize-log` tests, `doctor --replay-equality` synthesizer fallback, etc.) pin to `0` explicitly.
 - **Tumblers are append-only.** Updating an entry preserves the tumbler; deletion creates a tombstone, not a free slot. Reusing a tumbler corrupts the link graph.
 - **Owners with `owner_type='repo'` MUST carry a `repo_hash`.** Enforced in `register_owner`. The empty-hash variant produced 83 orphan owners in the wild before the guard.
 
@@ -58,4 +60,4 @@ The lint gate scope is intentionally `src/nexus/catalog/`, not just `projector.p
 
 Test fixtures that need to construct invariant-violating state (forced alias cycles, contaminated source_uri rows, backdated `created_at` for stale-span audits) tag the offending line with `# epsilon-allow: <reason>`. The reason is mandatory; bare markers do not suppress.
 
-Repair operations that previously ran as `cat._db.execute(...)` ad-hoc scripts must land as `nx catalog repair-*` verbs that emit events. The doctor's `--replay-equality` signal is reliable only if the event log is the only write path; PR ζ flips `NEXUS_EVENT_SOURCED=1` by default and depends on this gate.
+Repair operations that previously ran as `cat._db.execute(...)` ad-hoc scripts must land as `nx catalog repair-*` verbs that emit events. The doctor's `--replay-equality` signal is reliable only if the event log is the only write path; PR ζ (nexus-o6aa.9.5) flipped `NEXUS_EVENT_SOURCED=1` to ON by default and depends on this gate plus the dedupe-projector wiring (PR ζ-prereq, nexus-o6aa.9.4).

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -29,12 +29,19 @@ _SHADOW_EMIT_ENV = "NEXUS_EVENT_LOG_SHADOW"
 # new path inverts the JSONL+SQLite write order: emit DocumentRegistered
 # event FIRST, project to SQLite via Projector.apply, then append to
 # legacy documents.jsonl for back-compat (Phase 5 deprecates legacy
-# JSONL). When OFF (default), the legacy direct-write path runs and
-# shadow emit (PR F) optionally appends to events.jsonl after the fact.
+# JSONL). When OFF, the legacy direct-write path runs and shadow emit
+# (PR F) optionally appends to events.jsonl after the fact.
 #
-# Default off so the gate flip is a deliberate operator action. The
-# IRREVERSIBILITY WINDOW (RDR-101 §Migration / Phase 3) only starts
-# when this default flips on, which is a later sub-PR in Phase 3.
+# RDR-101 Phase 3 PR ζ (nexus-o6aa.9.5): default flipped to ON. The
+# irreversibility window opens here — the catalog event log is now the
+# canonical write path by default. Existing catalogs without an
+# events.jsonl fall through to the legacy rebuild via the
+# ``_event_log_covers_legacy`` bootstrap guardrail in
+# ``_ensure_consistent``, so the flip is safe for catalogs that have
+# not yet run ``nx catalog synthesize-log`` — they keep operating in
+# legacy mode until an operator runs the migration. Set
+# ``NEXUS_EVENT_SOURCED=0`` (or ``false``/``no``/``off``) to opt back
+# into the legacy path.
 _EVENT_SOURCED_ENV = "NEXUS_EVENT_SOURCED"
 
 
@@ -44,8 +51,17 @@ def _read_shadow_gate() -> bool:
 
 
 def _read_event_sourced_gate() -> bool:
+    """Return True when the event-sourced write path is enabled.
+
+    RDR-101 Phase 3 PR ζ: the default is ON. ``NEXUS_EVENT_SOURCED``
+    unset or set to any non-falsy value enables ES mode. Explicit
+    ``0`` / ``false`` / ``no`` / ``off`` opts back into the legacy
+    direct-write path.
+    """
     val = os.environ.get(_EVENT_SOURCED_ENV, "").strip().lower()
-    return val in ("1", "true", "yes", "on")
+    if val in ("0", "false", "no", "off"):
+        return False
+    return True
 
 
 # Module-level imports of the typed event payloads. Aliased with a

--- a/tests/test_catalog_dedupe_event_sourced.py
+++ b/tests/test_catalog_dedupe_event_sourced.py
@@ -196,11 +196,12 @@ def test_dedupe_emits_events_under_es(tmp_path, monkeypatch):
 
 
 def test_dedupe_legacy_mode_unchanged(tmp_path, monkeypatch):
-    """Regression guard: NEXUS_EVENT_SOURCED unset/0 still drives the
-    legacy direct-DELETE path. The function returns the same counts
-    and the orphan rows are gone from SQLite immediately.
+    """Regression guard: NEXUS_EVENT_SOURCED=0 still drives the legacy
+    direct-DELETE path. The function returns the same counts and the
+    orphan rows are gone from SQLite immediately.
     """
-    monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+    # PR ζ flipped the default to ON; opt back into legacy explicitly.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
     d = tmp_path / "catalog"
     d.mkdir()
     cat = Catalog(d, d / ".catalog.db")

--- a/tests/test_catalog_event_sourced_register.py
+++ b/tests/test_catalog_event_sourced_register.py
@@ -3,8 +3,10 @@
 """Tests for the RDR-101 Phase 3 PR α event-sourced register path.
 
 Coverage:
-- Gate parsing: 1/true/yes/on → ON; 0/false/no/off/unset → OFF.
-- Default (gate OFF): legacy direct-write path runs unchanged.
+- Gate parsing (PR ζ semantics, nexus-o6aa.9.5): 0/false/no/off → OFF;
+  1/true/yes/on/unset/empty → ON. The default flipped to ON in PR ζ.
+- Legacy path (gate explicitly OFF): legacy direct-write path runs
+  unchanged.
 - Gate ON: register_owner / register write events.jsonl FIRST, then
   project to SQLite via Projector.apply, then append to legacy JSONL
   for back-compat.
@@ -42,29 +44,36 @@ from nexus.catalog.projector import Projector
 
 
 class TestEventSourcedGate:
-    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "ON"])
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "ON", ""])
     def test_on_values(self, monkeypatch: pytest.MonkeyPatch, val: str):
+        # PR ζ (nexus-o6aa.9.5): empty string is ON (the default-on
+        # branch); only explicit falsy tokens flip it OFF.
         monkeypatch.setenv("NEXUS_EVENT_SOURCED", val)
         assert _read_event_sourced_gate() is True
 
-    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off"])
     def test_off_values(self, monkeypatch: pytest.MonkeyPatch, val: str):
         monkeypatch.setenv("NEXUS_EVENT_SOURCED", val)
         assert _read_event_sourced_gate() is False
 
-    def test_unset_is_off(self, monkeypatch: pytest.MonkeyPatch):
+    def test_unset_is_on(self, monkeypatch: pytest.MonkeyPatch):
+        # PR ζ: default flipped to ON. The irreversibility window
+        # opens here; the bootstrap guardrail in _ensure_consistent
+        # falls back to legacy when events.jsonl is empty / absent.
         monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
-        assert _read_event_sourced_gate() is False
+        assert _read_event_sourced_gate() is True
 
 
-# ── Default (gate OFF) — legacy behaviour unchanged ──────────────────────
+# ── Legacy path (gate explicitly OFF) — pre-ζ behaviour unchanged ────────
 
 
 class TestLegacyPathStillRuns:
     def test_register_does_not_write_events_jsonl_by_default(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch,
     ):
-        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        # PR ζ flipped the default to ES; opt back into legacy for
+        # this assertion that no events.jsonl is produced.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
         monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
         d = tmp_path / "catalog"
         d.mkdir()
@@ -161,7 +170,8 @@ class TestEquivalence:
         if event_sourced:
             monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
         else:
-            monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+            # PR ζ flipped default to ON; explicit OFF for legacy path.
+            monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
         monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
         d = tmp_path / name
         d.mkdir()

--- a/tests/test_catalog_shadow_emit.py
+++ b/tests/test_catalog_shadow_emit.py
@@ -43,8 +43,13 @@ from nexus.catalog.projector import Projector
 
 @pytest.fixture()
 def cat_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Catalog:
-    """Catalog constructed with shadow emit OFF (default)."""
+    """Catalog constructed with shadow emit OFF and ES OFF — the
+    historical "no events.jsonl" config. PR ζ (nexus-o6aa.9.5) flipped
+    the ES default to ON, so asserting an empty event log now requires
+    opting both gates out.
+    """
     monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
     d = tmp_path / "catalog"
     d.mkdir()
     return Catalog(d, d / ".catalog.db")
@@ -52,8 +57,12 @@ def cat_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Catalog:
 
 @pytest.fixture()
 def cat_on(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Catalog:
-    """Catalog constructed with shadow emit ON."""
+    """Catalog constructed with shadow emit ON and ES OFF — exercises
+    the shadow-only path. Under PR ζ this requires an explicit ES
+    opt-out so shadow is the only writer of events.jsonl.
+    """
     monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
     d = tmp_path / "catalog"
     d.mkdir()
     return Catalog(d, d / ".catalog.db")

--- a/tests/test_catalog_synthesize_chunks.py
+++ b/tests/test_catalog_synthesize_chunks.py
@@ -33,6 +33,16 @@ from nexus.catalog.event_log import EventLog
 from nexus.catalog.synthesizer import synthesize_t3_chunks
 
 
+@pytest.fixture(autouse=True)
+def _legacy_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PR ζ (nexus-o6aa.9.5) flipped NEXUS_EVENT_SOURCED default to ON.
+    The synthesize-log --chunks tests assume the source catalog only
+    has legacy JSONL state, otherwise events.jsonl is pre-populated
+    and the verb refuses to overwrite without --force. Pin to legacy.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+
+
 @pytest.fixture()
 def isolated_nexus(tmp_path: Path) -> Path:
     return tmp_path / "test-catalog"

--- a/tests/test_catalog_synthesize_log.py
+++ b/tests/test_catalog_synthesize_log.py
@@ -36,6 +36,17 @@ from nexus.catalog.projector import Projector
 from nexus.commands.catalog import synthesize_log_cmd
 
 
+@pytest.fixture(autouse=True)
+def _legacy_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RDR-101 Phase 3 PR ζ flipped NEXUS_EVENT_SOURCED default to ON.
+    Synthesize-log's premise is that the input catalog has only legacy
+    JSONL state — running ES on the source would prepopulate
+    events.jsonl and invalidate every "log untouched" / "log empty"
+    assertion in this file. Pin to legacy for the whole module.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+
+
 @pytest.fixture()
 def isolated_nexus(tmp_path: Path) -> Path:
     """Catalog dir set up by the autouse ``_isolate_catalog`` fixture in

--- a/tests/test_rdr101_correctness_remediation.py
+++ b/tests/test_rdr101_correctness_remediation.py
@@ -206,7 +206,12 @@ class TestUnlinkEventOrderingAfterCommit:
         loop's terminating commit. Post-fix, emits happen after the
         commit so a process crash leaves SQLite + events.jsonl
         consistent (or both reflecting the pre-delete state).
+
+        PR ζ (nexus-o6aa.9.5) flipped NEXUS_EVENT_SOURCED default to
+        ON; shadow emit is a no-op under ES so this test pins to the
+        legacy path explicitly to exercise the ordering invariant.
         """
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
         monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
         d = tmp_path / "catalog"
         d.mkdir()

--- a/tests/test_rdr101_meta_review_remediation.py
+++ b/tests/test_rdr101_meta_review_remediation.py
@@ -62,6 +62,10 @@ class TestShadowEmitFailureNonFatal:
     def test_typeerror_in_emit_does_not_abort_mutation(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch,
     ):
+        # PR ζ (nexus-o6aa.9.5) flipped NEXUS_EVENT_SOURCED default to
+        # ON; shadow emit is a no-op under ES, so pin to legacy to
+        # exercise the shadow-failure-non-fatal invariant.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
         monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
         d = tmp_path / "catalog"
         d.mkdir()

--- a/tests/test_rdr101_round3_correctness.py
+++ b/tests/test_rdr101_round3_correctness.py
@@ -490,7 +490,9 @@ class TestDoctorReplayEqualityEventLog:
     ):
         from nexus.commands.catalog import _run_replay_equality
 
-        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        # PR ζ flipped NEXUS_EVENT_SOURCED default to ON; the doctor
+        # synthesizer fallback is the legacy path, so pin explicitly.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
         monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
         d = tmp_path / "test-catalog"
         Catalog.init(d)
@@ -530,7 +532,8 @@ class TestLegacyUpdateAliasOfColumn:
     def test_alias_of_survives_legacy_update_through_alias(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch,
     ):
-        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        # PR ζ flipped default to ES; this is a legacy-path test.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
         monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
         d = tmp_path / "catalog"
         d.mkdir()
@@ -563,7 +566,9 @@ class TestLegacyUpdateAliasOfColumn:
         # VALUES read ``entry.alias_of``, silently dropping the
         # caller-supplied value. Round-4 fix threads
         # ``rec_dict["alias_of"]``.
-        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        #
+        # PR ζ flipped default to ES; this is a legacy-path test.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
         monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
         d = tmp_path / "catalog"
         d.mkdir()

--- a/tests/test_rdr101_round3_hardening.py
+++ b/tests/test_rdr101_round3_hardening.py
@@ -88,7 +88,8 @@ class TestDoctorReportSchema:
     ):
         from nexus.commands.catalog import _run_replay_equality
 
-        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        # PR ζ flipped default to ES; legacy-path assertion.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
         monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
         d = tmp_path / "test-catalog"
         Catalog.init(d)


### PR DESCRIPTION
## Summary

The catalog event log is now the canonical write path by default. \`events.jsonl\` is the source of truth; SQLite is a deterministic projection. The irreversibility window (RDR-101 §Migration Phase 3) opens here.

Prerequisites — both merged:

- ✅ **#446 (ε)** — lint gate forbidding direct catalog writes outside the projector module.
- ✅ **#447 (dedupe)** — \`apply_remove_plan\` routes deletes through \`LinkDeleted\` / \`DocumentDeleted\` / \`OwnerDeleted\` events under ES.

## Changes

**Production code** (1 file):

- \`src/nexus/catalog/catalog.py\` — \`_read_event_sourced_gate()\` inverted: env unset / empty / \`1\`/\`true\`/\`yes\`/\`on\` → ES ON; only explicit \`0\`/\`false\`/\`no\`/\`off\` → legacy. The bootstrap guardrail (\`_event_log_covers_legacy\`) in \`_ensure_consistent\` falls through to the legacy rebuild when \`events.jsonl\` is empty or sparse, so existing catalogs that have not yet run \`nx catalog synthesize-log\` keep working — they remain on the legacy path until an operator runs the migration.

**Documentation** (1 file):

- \`src/nexus/catalog/AGENTS.md\` — Key invariants block updated to name events.jsonl as canonical, document the bootstrap guardrail, name the \`NEXUS_EVENT_SOURCED=0\` opt-out, and credit nexus-o6aa.9.4 as the gating prerequisite alongside the lint gate.

**Test triage** (10 files): the targeted RDR-101 sweep surfaced 17 tests that asserted pre-ζ legacy default behaviour. Each falls into one of two buckets:

1. **Gate semantics** — empty string and unset are now ON. \`test_off_values[]\` moved into \`test_on_values\`; \`test_unset_is_off\` renamed to \`test_unset_is_on\`.
2. **Legacy-path assertions** — tests that exercise the legacy direct-write path, the shadow-emit invariants, the synthesizer fallback, or the synthesize-log verb (whose premise is "input catalog has only legacy JSONL state"). Each opts in explicitly via \`monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")\` with a "PR ζ legacy-path" comment.

Files updated:
- \`tests/test_catalog_event_sourced_register.py\` (gate semantics + TestLegacyPathStillRuns + \`TestEquivalence._build_catalog\`)
- \`tests/test_catalog_dedupe_event_sourced.py\` (\`test_dedupe_legacy_mode_unchanged\`)
- \`tests/test_catalog_shadow_emit.py\` (\`cat_off\`/\`cat_on\` fixtures pin to legacy)
- \`tests/test_catalog_synthesize_log.py\`, \`tests/test_catalog_synthesize_chunks.py\` (autouse \`_legacy_mode\` fixture at module level)
- \`tests/test_rdr101_correctness_remediation.py\` (\`test_unlink_does_not_emit_before_commit\`)
- \`tests/test_rdr101_meta_review_remediation.py\` (\`test_typeerror_in_emit_does_not_abort_mutation\`)
- \`tests/test_rdr101_round3_correctness.py\` (3 tests)
- \`tests/test_rdr101_round3_hardening.py\` (\`test_replay_equality_report_includes_event_source\`)

## Verification

- Targeted RDR-101 sweep (\`catalog or event_log or projector or rdr101 or dedupe or doctor or no_direct_catalog_writes\`): **967 passed, 1 skipped**.
- Full pytest suite: **6236 passed, 33 skipped, 1 failed** locally. The 1 failure is \`tests/test_rdr101_hardening.py::TestT3DocIdCoverageNotInT3IsWarning::test_strict_flag_makes_not_in_t3_a_failure\` which passes solo, passes within its file, and passes within the \`rdr101\` test cluster — cross-test isolation issue (likely ChromaDB EphemeralClient cross-talk per the handoff brief). CI on this branch will tell whether it's reproducible in CI's environment; if so I'll triage as a follow-up.

## Migration

For existing catalogs that have not yet run synthesize-log:

\`\`\`bash
nx catalog synthesize-log --chunks --force
nx catalog t3-backfill-doc-id
nx catalog doctor --replay-equality --t3-doc-id-coverage --strict-not-in-t3
\`\`\`

The bootstrap guardrail keeps unmigrated catalogs working; this migration unlocks the ES rebuild path and is required before \`doctor --replay-equality\` will pass.

## Refs

- Bead: \`nexus-o6aa.9.5\` (parent: \`nexus-o6aa.9\`)
- Depends on: \`nexus-o6aa.9.3\` (#446) + \`nexus-o6aa.9.4\` (#447) — both merged