### PR TITLE
fix(rdr-101): atomic dedupe — flock + batched events + transactional projection (nexus-o6aa.9.6)

### DIFF
--- a/src/nexus/catalog/dedupe.py
+++ b/src/nexus/catalog/dedupe.py
@@ -227,128 +227,169 @@ def apply_remove_plan(cat: "Catalog", op: OrphanPlan) -> tuple[int, int]:
     also dropped. Writes JSONL tombstones so the deletion survives a
     future rebuild.
 
+    Atomicity (RDR-101 Phase 3 follow-up A, nexus-o6aa.9.6):
+
+    - Acquires the catalog directory flock for the duration of the
+      whole operation. ``_write_to_event_log``'s contract requires the
+      caller to hold this lock (see ``Catalog._write_to_event_log`` at
+      catalog.py:852); every other ES mutator (``set_alias``,
+      ``unlink``, ``register``, …) acquires it. Pre-fix this function
+      did not, so a concurrent ``nx catalog register`` from another
+      process could interleave appends in events.jsonl AND the legacy
+      JSONL files.
+    - Under ES, writes ALL events to events.jsonl FIRST (a single
+      flock-held batch via the existing per-event helper, which honors
+      the outer flock), THEN projects them inside
+      ``cat._db.transaction()``. If projection raises on event N of M,
+      the SQLite transaction rolls back to the pre-dedupe state while
+      events.jsonl carries the full batch; the next
+      ``_ensure_consistent`` mtime tick replays events.jsonl through
+      the projector and converges on the intended post-dedupe state.
+      Pre-fix the per-event interleave (write log → project → write log
+      → project → … → single commit) split events from SQLite on
+      mid-loop projector failure with no operator-visible recovery.
+
     Returns ``(deleted_docs, deleted_links)``.
     """
     orphan_prefix = op.orphan_prefix
     clause, params = cat._prefix_sql(orphan_prefix)
 
-    # 1. Collect docs to delete (need the tombstone payload before SQL DELETE).
-    rows = cat._db.execute(
-        f"SELECT tumbler, title, author, year, content_type, file_path, "
-        f"corpus, physical_collection, chunk_count, head_hash, indexed_at, "
-        f"metadata, source_mtime, alias_of FROM documents WHERE {clause}",
-        params,
-    ).fetchall()
-    doc_tumblers = [r[0] for r in rows]
+    dir_fd = cat._acquire_lock()
+    try:
+        # 1. Collect docs to delete (need the tombstone payload before
+        # SQL DELETE).
+        rows = cat._db.execute(
+            f"SELECT tumbler, title, author, year, content_type, file_path, "
+            f"corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+            f"metadata, source_mtime, alias_of FROM documents WHERE {clause}",
+            params,
+        ).fetchall()
+        doc_tumblers = [r[0] for r in rows]
 
-    # 2. Collect links to delete.
-    placeholders = ",".join("?" * len(doc_tumblers)) if doc_tumblers else "''"
-    link_rows = cat._db.execute(
-        f"SELECT from_tumbler, to_tumbler, link_type, from_span, to_span, "
-        f"created_by, created_at, metadata FROM links "
-        f"WHERE from_tumbler IN ({placeholders}) OR to_tumbler IN ({placeholders})",
-        (*doc_tumblers, *doc_tumblers) if doc_tumblers else (),
-    ).fetchall() if doc_tumblers else []
-
-    # 3. JSONL tombstones — documents, links, owner.
-    import json as _json
-    for r in rows:
-        cat._append_jsonl(cat._documents_path, {
-            "tumbler": r[0], "title": r[1], "author": r[2], "year": r[3],
-            "content_type": r[4], "file_path": r[5], "corpus": r[6],
-            "physical_collection": r[7], "chunk_count": r[8],
-            "head_hash": r[9], "indexed_at": r[10],
-            "meta": _json.loads(r[11]) if r[11] else {},
-            "source_mtime": r[12] or 0.0,
-            "alias_of": r[13] or "",
-            "_deleted": True,
-        })
-    for r in link_rows:
-        cat._append_jsonl(cat._links_path, {
-            "from_t": r[0], "to_t": r[1], "link_type": r[2],
-            "from_span": r[3] or "", "to_span": r[4] or "",
-            "created_by": r[5], "created_at": r[6] or "",
-            "meta": _json.loads(r[7]) if r[7] else {},
-            "_deleted": True,
-        })
-    cat._append_jsonl(cat._owners_path, {"owner": orphan_prefix, "_deleted": True})
-
-    # 4. SQL deletion. Under NEXUS_EVENT_SOURCED=1 every mutation must
-    # travel through events.jsonl so the projector's rebuild is the only
-    # source of truth (RDR-101 Phase 3, nexus-o6aa.9.4 — blocks ζ). The
-    # legacy direct-DELETE path is retained for backward compatibility
-    # under the gate-off configuration; the JSONL tombstones above are
-    # written in both modes (no-op under ES rebuild but kept for the
-    # cutover window).
-    if cat._event_sourced_enabled:
-        from nexus.catalog.catalog import (
-            _DocumentDeletedPayload,
-            _LinkDeletedPayload,
-            _OwnerDeletedPayload,
-            _make_event,
+        # 2. Collect links to delete.
+        placeholders = (
+            ",".join("?" * len(doc_tumblers)) if doc_tumblers else "''"
         )
+        link_rows = cat._db.execute(
+            f"SELECT from_tumbler, to_tumbler, link_type, from_span, to_span, "
+            f"created_by, created_at, metadata FROM links "
+            f"WHERE from_tumbler IN ({placeholders}) "
+            f"OR to_tumbler IN ({placeholders})",
+            (*doc_tumblers, *doc_tumblers) if doc_tumblers else (),
+        ).fetchall() if doc_tumblers else []
 
-        # Order: links first (so the projector mutates dependent rows
-        # before the documents that anchor them), then documents, then
-        # the owner row last. The projector contract accepts any order
-        # for v: 0 events but operator-readable replay benefits from
-        # the natural dependency ordering.
-        for r in link_rows:
-            event = _make_event(
-                _LinkDeletedPayload(
-                    from_doc=r[0],
-                    to_doc=r[1],
-                    link_type=r[2],
-                    reason="dedupe.orphan",
-                ),
-                v=0,
-            )
-            cat._write_to_event_log(event)
-            cat._projector.apply(event)
-
+        # 3. JSONL tombstones — documents, links, owner. Written in
+        # both modes (no-op under ES rebuild but kept for the cutover
+        # window).
+        import json as _json
         for r in rows:
-            event = _make_event(
-                _DocumentDeletedPayload(
-                    doc_id=r[0],
-                    tumbler=r[0],
-                    reason="dedupe.orphan",
-                ),
-                v=0,
-            )
-            cat._write_to_event_log(event)
-            cat._projector.apply(event)
-
-        cat._write_to_event_log(
-            owner_event := _make_event(
-                _OwnerDeletedPayload(
-                    owner_id=orphan_prefix,
-                    reason="dedupe.orphan",
-                ),
-                v=0,
-            )
+            cat._append_jsonl(cat._documents_path, {
+                "tumbler": r[0], "title": r[1], "author": r[2], "year": r[3],
+                "content_type": r[4], "file_path": r[5], "corpus": r[6],
+                "physical_collection": r[7], "chunk_count": r[8],
+                "head_hash": r[9], "indexed_at": r[10],
+                "meta": _json.loads(r[11]) if r[11] else {},
+                "source_mtime": r[12] or 0.0,
+                "alias_of": r[13] or "",
+                "_deleted": True,
+            })
+        for r in link_rows:
+            cat._append_jsonl(cat._links_path, {
+                "from_t": r[0], "to_t": r[1], "link_type": r[2],
+                "from_span": r[3] or "", "to_span": r[4] or "",
+                "created_by": r[5], "created_at": r[6] or "",
+                "meta": _json.loads(r[7]) if r[7] else {},
+                "_deleted": True,
+            })
+        cat._append_jsonl(
+            cat._owners_path, {"owner": orphan_prefix, "_deleted": True},
         )
-        cat._projector.apply(owner_event)
 
-        cat._db.commit()
-    else:
-        if doc_tumblers:
+        # 4. SQL deletion. Under NEXUS_EVENT_SOURCED=1 every mutation
+        # travels through events.jsonl; the legacy direct-DELETE path
+        # is retained for backward compatibility under the gate-off
+        # configuration.
+        if cat._event_sourced_enabled:
+            # Import from events.py (the canonical source) rather than
+            # catalog.py's private aliases — pre-fix this depended on
+            # ``catalog.py`` re-exporting the underscore-prefixed
+            # private names, a hidden cross-module coupling.
+            from nexus.catalog.events import (
+                DocumentDeletedPayload,
+                LinkDeletedPayload,
+                OwnerDeletedPayload,
+                make_event,
+            )
+
+            # Phase A: build all event envelopes upfront — pure data,
+            # no mutation. Order: links first (dependent rows before
+            # the documents that anchor them), then documents, then
+            # the owner row last. The projector contract is
+            # order-agnostic for v: 0 events but operator-readable
+            # replay benefits from the natural dependency ordering.
+            events: list = []
+            for r in link_rows:
+                events.append(make_event(
+                    LinkDeletedPayload(
+                        from_doc=r[0], to_doc=r[1], link_type=r[2],
+                        reason="dedupe.orphan",
+                    ),
+                    v=0,
+                ))
+            for r in rows:
+                events.append(make_event(
+                    DocumentDeletedPayload(
+                        doc_id=r[0], tumbler=r[0], reason="dedupe.orphan",
+                    ),
+                    v=0,
+                ))
+            events.append(make_event(
+                OwnerDeletedPayload(
+                    owner_id=orphan_prefix, reason="dedupe.orphan",
+                ),
+                v=0,
+            ))
+
+            # Phase B: durably append every event to events.jsonl
+            # under the outer flock. The per-event helper does not
+            # re-acquire the flock (caller holds it); each line is
+            # flushed and closed before the next opens, so a crash
+            # mid-batch leaves a prefix of events on disk which the
+            # next replay handles deterministically (the orphan rows
+            # are still gone in the projection).
+            for event in events:
+                cat._write_to_event_log(event)
+
+            # Phase C: project every event into SQLite inside one
+            # transaction. If apply raises on event N of M, the tx
+            # rolls back to the pre-dedupe state while events.jsonl
+            # already carries the full batch. _ensure_consistent on
+            # the next mtime tick replays the durable batch and
+            # converges on the intended post-dedupe state.
+            with cat._db.transaction():
+                for event in events:
+                    cat._projector.apply(event)
+        else:
+            if doc_tumblers:
+                cat._db.execute(
+                    f"DELETE FROM links WHERE from_tumbler IN ({placeholders}) "
+                    f"OR to_tumbler IN ({placeholders})",
+                    (*doc_tumblers, *doc_tumblers),
+                )
+            cat._db.execute(f"DELETE FROM documents WHERE {clause}", params)
             cat._db.execute(
-                f"DELETE FROM links WHERE from_tumbler IN ({placeholders}) "
-                f"OR to_tumbler IN ({placeholders})",
-                (*doc_tumblers, *doc_tumblers),
+                "DELETE FROM owners WHERE tumbler_prefix = ?", (orphan_prefix,),
             )
-        cat._db.execute(f"DELETE FROM documents WHERE {clause}", params)
-        cat._db.execute(
-            "DELETE FROM owners WHERE tumbler_prefix = ?", (orphan_prefix,),
-        )
-        cat._db.commit()
+            cat._db.commit()
 
-    _log.info(
-        "catalog.dedupe.remove_plan_applied",
-        orphan=op.orphan_name, docs=len(rows), links=len(link_rows),
-        event_sourced=cat._event_sourced_enabled,
-    )
-    return len(rows), len(link_rows)
+        _log.info(
+            "catalog.dedupe.remove_plan_applied",
+            orphan=op.orphan_name, docs=len(rows), links=len(link_rows),
+            event_sourced=cat._event_sourced_enabled,
+        )
+        return len(rows), len(link_rows)
+    finally:
+        cat._release_lock(dir_fd)
 
 
 def apply_plan(

--- a/tests/test_catalog_dedupe_event_sourced.py
+++ b/tests/test_catalog_dedupe_event_sourced.py
@@ -232,3 +232,142 @@ def test_dedupe_legacy_mode_unchanged(tmp_path, monkeypatch):
         (f"{orphan}.%",),
     ).fetchone()[0]
     assert remaining == 0
+
+
+# ─────────────────────────────────────────────────────────────────────
+# RDR-101 Phase 3 follow-up A (nexus-o6aa.9.6): atomicity tests.
+#
+# The pre-A implementation interleaved
+# ``_write_to_event_log + _projector.apply`` per event with a single
+# trailing commit. A mid-loop projector exception left events 1..N-1
+# durable in events.jsonl while the pending SQLite mutations rolled
+# back at the un-committed connection close — a split state with no
+# operator-visible diagnostic.
+#
+# Post-A: events are written first (durable batch), then projected
+# inside ``cat._db.transaction()``. A projector exception rolls the
+# whole projection back to the pre-dedupe state while events.jsonl
+# still carries the full batch; the next ``_ensure_consistent`` mtime
+# tick replays the durable batch and converges on the post-dedupe
+# state.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_dedupe_acquires_flock(tmp_path, monkeypatch):
+    """``apply_remove_plan`` must acquire the catalog directory flock
+    at entry. Pre-fix every other ES mutator did but dedupe didn't, so
+    a concurrent ``register`` call could interleave appends in
+    events.jsonl and the legacy JSONL files.
+    """
+    cat = _make_catalog_es(tmp_path, monkeypatch)
+    orphan_prefix, _ = _populate_with_orphan(cat)
+
+    acquired: list[int] = []
+    released: list[int] = []
+    original_acquire = cat._acquire_lock
+    original_release = cat._release_lock
+
+    def tracked_acquire():
+        fd = original_acquire()
+        acquired.append(fd)
+        return fd
+
+    def tracked_release(fd):
+        released.append(fd)
+        return original_release(fd)
+
+    monkeypatch.setattr(cat, "_acquire_lock", tracked_acquire)
+    monkeypatch.setattr(cat, "_release_lock", tracked_release)
+
+    plan = OrphanPlan(
+        orphan_prefix=orphan_prefix, orphan_name="nexus-571b8edd",
+        action="remove", doc_count=2,
+    )
+    apply_remove_plan(cat, plan)
+
+    assert len(acquired) == 1, (
+        f"apply_remove_plan must acquire flock exactly once; got {acquired}"
+    )
+    assert acquired == released, (
+        f"every acquire must be paired with a release; got "
+        f"acquired={acquired} released={released}"
+    )
+
+
+def test_projector_failure_rolls_back_sqlite_but_log_durable(
+    tmp_path, monkeypatch,
+):
+    """Atomicity invariant: if ``_projector.apply`` raises mid-batch,
+    SQLite reverts to the pre-dedupe state (transaction rollback)
+    while events.jsonl carries the full event batch (durable). The
+    next ``_ensure_consistent`` rebuild replays the batch and
+    converges on the post-dedupe state.
+
+    Pre-fix the per-event interleave produced events 1..N-1 durable
+    plus uncommitted SQLite mutations 1..N-1 that rolled back at
+    connection close — split state with no operator diagnostic.
+    """
+    cat = _make_catalog_es(tmp_path, monkeypatch)
+    orphan_prefix, orphan_docs = _populate_with_orphan(cat)
+
+    pre_doc_count = cat._db.execute(
+        "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+        (f"{orphan_prefix}.%",),
+    ).fetchone()[0]
+    pre_event_size = (
+        cat._events_path.read_text().count("\n")
+        if cat._events_path.exists() else 0
+    )
+
+    # Poison the projector to raise on the 3rd apply call.
+    original_apply = cat._projector.apply
+    call_count = [0]
+
+    def poisoned_apply(event):
+        call_count[0] += 1
+        if call_count[0] == 3:
+            raise RuntimeError("simulated projector failure on event 3")
+        return original_apply(event)
+
+    monkeypatch.setattr(cat._projector, "apply", poisoned_apply)
+
+    plan = OrphanPlan(
+        orphan_prefix=orphan_prefix, orphan_name="nexus-571b8edd",
+        action="remove", doc_count=2,
+    )
+    with pytest.raises(RuntimeError, match="simulated projector failure"):
+        apply_remove_plan(cat, plan)
+
+    # SQLite invariant: rolled back to pre-dedupe state.
+    post_doc_count = cat._db.execute(
+        "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+        (f"{orphan_prefix}.%",),
+    ).fetchone()[0]
+    assert post_doc_count == pre_doc_count, (
+        "SQLite must roll back on projector failure; "
+        f"pre={pre_doc_count} post={post_doc_count}"
+    )
+
+    # events.jsonl invariant: full batch durably written before
+    # projection started.
+    post_event_lines = cat._events_path.read_text().splitlines()
+    new_event_count = len(post_event_lines) - pre_event_size
+    # 2 LinkDeleted + 2 DocumentDeleted + 1 OwnerDeleted == 5 new events.
+    assert new_event_count == 5, (
+        f"events.jsonl must carry the full batch even when projection "
+        f"failed; got {new_event_count} new events"
+    )
+
+    # Convergence invariant: after restoring the projector, force a
+    # rebuild and assert orphans stay deleted (the durable events
+    # replay correctly).
+    monkeypatch.setattr(cat._projector, "apply", original_apply)
+    _force_rebuild_from_events(cat)
+    final_count = cat._db.execute(
+        "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+        (f"{orphan_prefix}.%",),
+    ).fetchone()[0]
+    assert final_count == 0, (
+        f"rebuild from durable events must converge on post-dedupe "
+        f"state; got {final_count} surviving orphan docs"
+    )


### PR DESCRIPTION
## Summary

Fixes two convergent review findings on `dedupe.apply_remove_plan`'s ES path (substantive-critic + deep-analyst, 2026-05-01):

- **C3** — per-event interleave of `_write_to_event_log` + `_projector.apply` left a split state on mid-loop projector exception (events durable in events.jsonl, SQLite mutations rolled back at uncommitted close).
- **C4** — function did not acquire the catalog directory flock; every other ES mutator does. Concurrent register/dedupe produced non-linear interleaving in events.jsonl AND legacy JSONL.

## Changes

`src/nexus/catalog/dedupe.py::apply_remove_plan`:

1. **Flock at entry, release in finally.** Honors the contract `_write_to_event_log:872` requires.
2. **Three-phase ES branch:**
   - Phase A: build all event envelopes upfront (pure data).
   - Phase B: durably append every event to events.jsonl under the held flock.
   - Phase C: project every event into SQLite inside `cat._db.transaction()`. Mid-loop exception rolls SQLite back; events.jsonl carries the full durable batch; next `_ensure_consistent` mtime tick replays the batch and converges on the intended state.
3. **Imports moved** from `nexus.catalog.catalog`'s private aliases to `nexus.catalog.events` (canonical source).

## Tests

`tests/test_catalog_dedupe_event_sourced.py`:

- `test_dedupe_acquires_flock` — wraps `_acquire_lock`/`_release_lock`, asserts exactly one pair around `apply_remove_plan`. WITH TEETH: pre-fix `count=0`.
- `test_projector_failure_rolls_back_sqlite_but_log_durable` — poisons `_projector.apply` to raise on the 3rd call. Asserts (a) SQLite rolls back to pre-dedupe; (b) events.jsonl carries the full 5-event batch; (c) restoring the projector + forcing rebuild converges on the post-dedupe state. WITH TEETH: pre-fix the events.jsonl invariant fails (3 events, not 5).

Both new tests fail deterministically against the pre-fix code (verified via `git stash` + re-run).

## Verification

- 20/20 dedupe tests pass (3 pre-existing ES + 15 generic + 2 new).
- Targeted RDR-101 sweep (`catalog or event_log or projector or rdr101 or dedupe or doctor or no_direct_catalog_writes`): **977 passed, 1 skipped, 5371 deselected**.

## Refs

- Bead: `nexus-o6aa.9.6` (P0, parent: `nexus-o6aa.9`)
- Companion follow-ups (separate beads):
  - `nexus-o6aa.9.7` (P1) — bootstrap guardrail soundness + operator visibility
  - `nexus-o6aa.9.8` (P2) — lint gate hardening + cleanup