### PR TITLE
fix(rdr-101): bootstrap guardrail floor + operator-visible signal (nexus-o6aa.9.7)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -485,3 +485,7 @@
 {"id":"int-6748ccc6","kind":"field_change","created_at":"2026-05-01T18:53:57.034824Z","actor":"Hellblazer","issue_id":"nexus-ai9d","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-ec061874","kind":"field_change","created_at":"2026-05-01T20:56:53.028994Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.3","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-6fa65526","kind":"field_change","created_at":"2026-05-01T20:56:56.236748Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.4","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-0d208d6b","kind":"field_change","created_at":"2026-05-01T21:12:39.337015Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.5","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-6ec1eb80","kind":"field_change","created_at":"2026-05-01T21:12:49.747406Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-ec93c5c9","kind":"field_change","created_at":"2026-05-01T21:30:22.984073Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.6","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-81a4170f","kind":"field_change","created_at":"2026-05-01T21:36:40.061953Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.7","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -502,6 +502,14 @@ class Catalog:
         from nexus.catalog.projector import Projector as _Projector
         self._projector = _Projector(self._db)
         self.degraded: bool = False
+        # RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): set when
+        # ``_ensure_consistent`` runtime-decides to fall back to the
+        # legacy rebuild via ``_event_log_covers_legacy``. Surfaces
+        # the silent state where ``_event_sourced_enabled`` is True
+        # but reads come from legacy JSONL — operator-visible signal
+        # for ``nx catalog doctor``. Never read from the env; the
+        # condition is purely runtime.
+        self.bootstrap_fallback_active: bool = False
         # Diagnostic: log the active gate state at construction so an
         # operator inspecting structured logs can confirm which write
         # path is in effect without grepping environment dumps. Debug
@@ -609,19 +617,34 @@ class Catalog:
                 # the legacy JSONL has materially more documents than
                 # the event log carries DocumentRegistered events for.
                 # Refuse to wipe the legacy rows; fall through to the
-                # legacy rebuild and surface the gap so the operator
-                # can run ``nx catalog synthesize-log``.
+                # legacy rebuild and flag the state so operators see
+                # it via ``nx catalog doctor`` (not just structlog).
+                #
+                # RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): the
+                # remediation hint must say ``--force`` because
+                # ``synthesize-log`` refuses non-empty events.jsonl
+                # without it. Pre-fix the message read "Run 'nx
+                # catalog synthesize-log'", which sent operators into
+                # a "log is non-empty, --force required" error loop.
+                self.bootstrap_fallback_active = True
                 _log.warning(
                     "catalog_event_log_incomplete_falling_back_to_legacy",
                     catalog_dir=str(self._dir),
                     note=(
-                        "events.jsonl has fewer DocumentRegistered "
-                        "events than documents.jsonl has rows. Run "
-                        "'nx catalog synthesize-log' before relying "
-                        "on the event-sourced rebuild."
+                        "events.jsonl is non-empty but has fewer "
+                        "DocumentRegistered events than documents.jsonl "
+                        "has rows. ES writes are landing in the log "
+                        "but reads come from legacy JSONL — replay "
+                        "equality is silently broken until the log "
+                        "catches up. Run 'nx catalog synthesize-log "
+                        "--force' to rebuild events.jsonl from the "
+                        "legacy state, then 'nx catalog t3-backfill-"
+                        "doc-id' to align T3 chunks."
                     ),
                 )
                 use_event_log = False
+            else:
+                self.bootstrap_fallback_active = False
             if use_event_log:
                 # Replay events.jsonl through the projector into the
                 # live CatalogDB. Atomic: the transaction context
@@ -714,7 +737,19 @@ class Catalog:
                     elif t == _ev.TYPE_DOCUMENT_DELETED:
                         event_doc_count -= 1
 
-            return event_doc_count >= int(legacy_doc_count * 0.95)
+            # RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): floor the
+            # threshold at 1. ``int(1 * 0.95) == 0`` and ``0 >= 0`` is
+            # True, so a 1-document legacy catalog with a non-empty-but-
+            # ``DocumentRegistered``-free ``events.jsonl`` (e.g. a
+            # ChunkIndexed-only log from a partial Phase 2 synthesis,
+            # or a dedupe-only event stream that pushes
+            # ``event_doc_count`` to 0) used to bypass the guardrail
+            # and silently wipe the single legacy row. The floor
+            # guarantees a real DocumentRegistered must exist in the
+            # log before ES rebuild is allowed at the smallest catalog
+            # sizes.
+            threshold = max(1, int(legacy_doc_count * 0.95))
+            return event_doc_count >= threshold
         except Exception:
             # On any unexpected failure, refuse the event-sourced
             # rebuild (safer to fall through to legacy than to wipe).

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3299,6 +3299,31 @@ def doctor_cmd(
     overall_pass = True
     json_payload: dict = {}
 
+    # RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): surface bootstrap
+    # fallback state to the operator. When _ensure_consistent runtime-
+    # decides to fall back to legacy reads (events.jsonl is non-empty
+    # but sparse vs documents.jsonl), ES writes still land in the log
+    # while reads come from legacy JSONL — a silent split state where
+    # replay-equality is fundamentally not testing what it claims.
+    # Construct a Catalog up front so _ensure_consistent runs and
+    # bootstrap_fallback_active is current.
+    bootstrap_status = _check_bootstrap_status()
+    if bootstrap_status["fallback_active"]:
+        if as_json:
+            json_payload["bootstrap_fallback"] = bootstrap_status
+        else:
+            click.echo(
+                "WARNING: catalog is operating in bootstrap-fallback mode.\n"
+                "  events.jsonl is non-empty but sparse vs documents.jsonl;\n"
+                "  ES writes are landing in the log but reads come from\n"
+                "  legacy JSONL — replay equality is silently broken.\n"
+                "  Remediate with:\n"
+                "    nx catalog synthesize-log --force\n"
+                "    nx catalog t3-backfill-doc-id\n",
+                err=True,
+            )
+        overall_pass = False
+
     if replay_equality:
         report = _run_replay_equality()
         if as_json:
@@ -3324,6 +3349,109 @@ def doctor_cmd(
 
     if not overall_pass:
         raise click.exceptions.Exit(1)
+
+
+def _check_bootstrap_status() -> dict:
+    """Inspect the canonical-truth files at the configured catalog
+    path and report whether the ES rebuild path would currently fall
+    back to legacy (RDR-101 Phase 3 follow-up B, nexus-o6aa.9.7).
+
+    Returns ``{"fallback_active": bool, "events_path": str,
+    "documents_path": str}``. Used by the doctor verb to surface the
+    silent split state where ``NEXUS_EVENT_SOURCED`` is on but reads
+    come from legacy JSONL.
+
+    Pure file inspection — does NOT construct a ``Catalog`` instance.
+    Constructing one would trigger ``_ensure_consistent``, which
+    re-projects events.jsonl into SQLite. That re-projection would
+    silently overwrite any operator-injected drift the downstream
+    doctor checks (e.g. ``--replay-equality``) are meant to detect.
+    """
+    from nexus.config import catalog_path
+    from nexus.catalog.catalog import _read_event_sourced_gate
+    from nexus.catalog import events as _ev
+
+    cat_path = catalog_path()
+    if not Catalog.is_initialized(cat_path):
+        return {"fallback_active": False, "reason": "catalog_not_initialized"}
+
+    events_path = cat_path / "events.jsonl"
+    documents_path = cat_path / "documents.jsonl"
+
+    if not _read_event_sourced_gate():
+        # Legacy mode: no ES rebuild path runs, no fallback state.
+        return {
+            "fallback_active": False,
+            "events_path": str(events_path),
+            "documents_path": str(documents_path),
+        }
+    if (
+        not events_path.exists()
+        or events_path.stat().st_size == 0
+        or not documents_path.exists()
+    ):
+        # ``use_event_log`` is False at the size gate before the
+        # guardrail check fires; not a fallback state.
+        return {
+            "fallback_active": False,
+            "events_path": str(events_path),
+            "documents_path": str(documents_path),
+        }
+
+    # Replicate the ``_event_log_covers_legacy`` math non-mutatively.
+    try:
+        registered: set[str] = set()
+        tombstoned: set[str] = set()
+        with documents_path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                tumbler = rec.get("tumbler")
+                if not tumbler:
+                    continue
+                if rec.get("_deleted"):
+                    tombstoned.add(tumbler)
+                else:
+                    registered.add(tumbler)
+        legacy_doc_count = len(registered - tombstoned)
+        if legacy_doc_count == 0:
+            return {
+                "fallback_active": False,
+                "events_path": str(events_path),
+                "documents_path": str(documents_path),
+            }
+
+        event_doc_count = 0
+        with events_path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                t = obj.get("type")
+                if t == _ev.TYPE_DOCUMENT_REGISTERED:
+                    event_doc_count += 1
+                elif t == _ev.TYPE_DOCUMENT_DELETED:
+                    event_doc_count -= 1
+
+        threshold = max(1, int(legacy_doc_count * 0.95))
+        fallback_active = event_doc_count < threshold
+    except Exception:
+        fallback_active = False
+
+    return {
+        "fallback_active": fallback_active,
+        "events_path": str(events_path),
+        "documents_path": str(documents_path),
+    }
 
 
 def _run_replay_equality() -> dict:

--- a/tests/test_catalog_bootstrap_guardrail.py
+++ b/tests/test_catalog_bootstrap_guardrail.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): bootstrap guardrail
+correctness + operator-visible signal.
+
+Two convergent review findings on the
+``Catalog._event_log_covers_legacy`` guardrail (code-review-expert +
+deep-analyst, 2026-05-01):
+
+* **C1** — ``int(legacy_doc_count * 0.95)`` evaluates to 0 when
+  ``legacy_doc_count == 1``. ``event_doc_count >= 0`` is True even
+  when events.jsonl carries zero ``DocumentRegistered`` events.
+  A 1-document legacy catalog with a non-empty-but-DocumentRegistered-
+  free ``events.jsonl`` (e.g. a ChunkIndexed-only log from partial
+  Phase 2 synthesis, or a dedupe-only event stream that drives
+  ``event_doc_count`` to 0) bypassed the guardrail and silently wiped
+  the single legacy row. Floor the threshold at 1.
+
+* **C2** — when ``_ensure_consistent`` runtime-decides to fall back to
+  legacy reads, ``cat._event_sourced_enabled`` remains True. ES writes
+  still land in events.jsonl while reads come from legacy JSONL —
+  silent split state where replay-equality is fundamentally not
+  testing what it claims. ``Catalog.bootstrap_fallback_active`` now
+  reflects this decision so the doctor verb can surface it.
+
+Includes a doctor-surface assertion: ``nx catalog doctor`` must emit
+an operator-visible warning when the bootstrap fallback is active.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.commands.catalog import doctor_cmd
+
+
+def _init_catalog(tmp_path: Path) -> Path:
+    d = tmp_path / "test-catalog"
+    Catalog.init(d)
+    return d
+
+
+def _write_event_line(events_path: Path, payload_dict: dict) -> None:
+    """Append a raw event line to events.jsonl. Used to simulate
+    states the public API does not produce directly (e.g. a
+    ChunkIndexed-only log).
+    """
+    if not events_path.exists():
+        events_path.touch()
+    with events_path.open("a") as f:
+        f.write(json.dumps(payload_dict, separators=(",", ":")))
+        f.write("\n")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# C1: legacy_doc_count=1 floor regression
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_guardrail_refuses_es_rebuild_for_single_doc_with_no_registered_events(
+    tmp_path, monkeypatch,
+):
+    """Pre-fix: ``int(1 * 0.95) == 0`` and ``0 >= 0`` is True, so a
+    1-document legacy catalog with a non-empty-but-DocumentRegistered-
+    free events.jsonl bypassed the guardrail and the ES rebuild
+    silently wiped the legacy row. Post-fix: the floor at 1 forces a
+    real ``DocumentRegistered`` event before ES rebuild proceeds.
+    """
+    # Set up a 1-document legacy catalog under legacy mode so the
+    # legacy JSONL is the source of truth.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_catalog(tmp_path)
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    cat.register(
+        owner, "doc-1.md", content_type="prose", file_path="doc-1.md",
+    )
+    cat._db.close()
+
+    # Inject a non-empty events.jsonl that carries only a ChunkIndexed
+    # event (no DocumentRegistered). Pre-fix: guardrail passes
+    # because event_doc_count=0 >= int(1 * 0.95) = 0.
+    events_path = d / "events.jsonl"
+    _write_event_line(events_path, {
+        "type": "ChunkIndexed", "v": 0,
+        "payload": {
+            "chunk_id": "ch1", "chash": "h" * 64, "doc_id": "uuid7-A",
+            "coll_id": "code__test", "position": 0,
+        },
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    # Now flip ES on and re-open the catalog. _ensure_consistent must
+    # detect the sparse log and fall back to legacy.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    cat2 = Catalog(d, d / ".catalog.db")
+    try:
+        # Live catalog must still have the 1 document — guardrail
+        # protected it from ES rebuild.
+        doc_count = cat2._db.execute(
+            "SELECT count(*) FROM documents",
+        ).fetchone()[0]
+        assert doc_count == 1, (
+            "guardrail floor regression: 1-document catalog was wiped "
+            "by ES rebuild because int(1 * 0.95) == 0 made the "
+            "threshold trivially passable. Floor must be max(1, ...)."
+        )
+        assert cat2.bootstrap_fallback_active, (
+            "bootstrap_fallback_active must be set when guardrail "
+            "fires — the silent split state is what doctor surfaces."
+        )
+    finally:
+        cat2._db.close()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# C2: bootstrap fallback flag is set when guardrail fires
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_bootstrap_fallback_active_set_when_guardrail_fires(
+    tmp_path, monkeypatch,
+):
+    """When ``_ensure_consistent`` decides to fall back to legacy
+    because events.jsonl is sparse, ``cat.bootstrap_fallback_active``
+    must be True so the doctor verb can surface the state. Pre-fix
+    the only signal was a structlog warning operators rarely see.
+    """
+    # Build legacy state: 10 docs, no events.jsonl.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_catalog(tmp_path)
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    for i in range(10):
+        cat.register(
+            owner, f"doc-{i}.md", content_type="prose",
+            file_path=f"doc-{i}.md",
+        )
+    cat._db.close()
+
+    # Inject one stray event so events.jsonl is non-empty but sparse
+    # vs the 10-row documents.jsonl. Guardrail should fire on flip.
+    events_path = d / "events.jsonl"
+    _write_event_line(events_path, {
+        "type": "DocumentRegistered", "v": 0,
+        "payload": {
+            "doc_id": "1.1.99", "owner_id": "1.1",
+            "content_type": "prose", "source_uri": "",
+            "coll_id": "", "title": "stray.md", "tumbler": "1.1.99",
+            "author": "", "year": 0, "file_path": "stray.md",
+            "corpus": "", "physical_collection": "",
+            "chunk_count": 0, "head_hash": "", "indexed_at": "",
+            "alias_of": "", "meta": {}, "source_mtime": 0.0,
+            "indexed_at_doc": "",
+        },
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    cat2 = Catalog(d, d / ".catalog.db")
+    try:
+        assert cat2.bootstrap_fallback_active is True, (
+            "guardrail fired but bootstrap_fallback_active not set; "
+            "doctor cannot surface the silent state to operators."
+        )
+        # Live state still has all 10 legacy docs (guardrail saved
+        # them from being wiped).
+        live = cat2._db.execute(
+            "SELECT count(*) FROM documents",
+        ).fetchone()[0]
+        assert live >= 10
+    finally:
+        cat2._db.close()
+
+
+def test_bootstrap_fallback_clears_when_log_catches_up(
+    tmp_path, monkeypatch,
+):
+    """Once events.jsonl carries ≥ ``int(legacy_doc_count * 0.95)``
+    DocumentRegistered events (e.g. after ``nx catalog synthesize-log
+    --force``), the next rebuild promotes to ES and the flag clears.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_catalog(tmp_path)
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    cat.register(
+        owner, "doc-1.md", content_type="prose", file_path="doc-1.md",
+    )
+    cat._db.close()
+
+    # Flip ES on. events.jsonl is empty → ``use_event_log`` is False
+    # at the .size > 0 gate, never reaches the guardrail check, so
+    # ``bootstrap_fallback_active`` stays False.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    cat_empty_log = Catalog(d, d / ".catalog.db")
+    try:
+        assert cat_empty_log.bootstrap_fallback_active is False
+    finally:
+        cat_empty_log._db.close()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Doctor surface
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_doctor_surfaces_bootstrap_fallback_in_text_output(
+    tmp_path, monkeypatch,
+):
+    """``nx catalog doctor`` must emit an operator-visible warning to
+    stderr when the bootstrap fallback is active. Structlog alone is
+    not enough — operators inspecting doctor output must see the
+    state and the remediation hint.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_catalog(tmp_path)
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    cat.register(
+        owner, "doc-1.md", content_type="prose", file_path="doc-1.md",
+    )
+    cat._db.close()
+
+    events_path = d / "events.jsonl"
+    _write_event_line(events_path, {
+        "type": "DocumentDeleted", "v": 0,
+        "payload": {
+            "doc_id": "1.1.99", "tumbler": "1.1.99",
+            "reason": "test",
+        },
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        doctor_cmd, ["--replay-equality"],
+    )
+
+    # Doctor exits non-zero because bootstrap fallback fails the
+    # overall pass.
+    assert result.exit_code == 1, result.output
+    # The warning is written via click.echo(..., err=True). Click
+    # 8.3+ CliRunner exposes stderr separately when invoked without
+    # explicit mixing (the param was removed). Fall back to combined
+    # output for older Click semantics so the test is robust.
+    text = (result.stderr or "") + (result.output or "")
+    assert "bootstrap-fallback" in text, text
+    assert "synthesize-log --force" in text, (
+        "remediation hint must include --force; pre-fix the warning "
+        "told operators to run synthesize-log without --force, which "
+        "fails on a non-empty events.jsonl."
+    )
+
+
+def test_doctor_surfaces_bootstrap_fallback_in_json_output(
+    tmp_path, monkeypatch,
+):
+    """``nx catalog doctor --json`` must include a
+    ``bootstrap_fallback`` key when the state is active so machine
+    consumers (CI, monitoring) can detect it.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_catalog(tmp_path)
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    cat.register(
+        owner, "doc-1.md", content_type="prose", file_path="doc-1.md",
+    )
+    cat._db.close()
+
+    events_path = d / "events.jsonl"
+    _write_event_line(events_path, {
+        "type": "DocumentDeleted", "v": 0,
+        "payload": {
+            "doc_id": "1.1.99", "tumbler": "1.1.99",
+            "reason": "test",
+        },
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    # Suppress structlog noise so it doesn't interleave with the JSON.
+    import structlog
+    saved = structlog.get_config()
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(50),
+    )
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            doctor_cmd, ["--replay-equality", "--json"],
+        )
+    finally:
+        structlog.configure(**saved)
+
+    assert result.exit_code == 1, result.output
+    # Strip any non-JSON prefix (the warning text path may emit some
+    # before the JSON dump even in --json mode).
+    out = result.output
+    start = out.find("{")
+    payload = json.loads(out[start:])
+    assert "bootstrap_fallback" in payload, payload
+    assert payload["bootstrap_fallback"]["fallback_active"] is True

--- a/tests/test_rdr101_round3_correctness.py
+++ b/tests/test_rdr101_round3_correctness.py
@@ -372,7 +372,16 @@ class TestEnsureConsistentEventSourced:
         d.mkdir()
         cat_a = Catalog(d, d / ".catalog.db")
         owner = cat_a.register_owner("nexus", "repo", repo_hash="abab")
+        # Register enough documents that the bootstrap guardrail
+        # (RDR-101 Phase 3 follow-up B floor at 1) unambiguously
+        # passes — leaving the v:1 raise as the failure path the
+        # test is exercising. With one document, a poisoned v:1
+        # DocumentDeleted decrements event_doc_count to 0 < 1, the
+        # guardrail fires before the rebuild attempt, and the
+        # atomicity invariant has nothing to assert against.
         a = cat_a.register(owner, "a.md", content_type="prose")
+        cat_a.register(owner, "b.md", content_type="prose")
+        cat_a.register(owner, "c.md", content_type="prose")
         cat_a._db.close()
 
         # Append a v: 1 event after the legitimate v: 0 events. The


### PR DESCRIPTION
**Stacked on #449.** Will rebase to main once the parent merges.

## Summary

Fixes two convergent review findings on `_event_log_covers_legacy` and the silent desync state it leaves behind.

- **C1** — `int(1 * 0.95) == 0`; a 1-document legacy catalog with a non-empty-but-DocumentRegistered-free events.jsonl bypassed the guardrail and the ES rebuild silently wiped the single legacy row.
- **C2** — when `_ensure_consistent` runtime-decides to fall back to legacy, `cat._event_sourced_enabled` remained True. ES mutations still emit to events.jsonl while reads come from legacy JSONL — silent split state, only signal was a structlog warning.
- **I3** — guardrail warning text said "run nx catalog synthesize-log" but the verb refuses non-empty events.jsonl without `--force`. Operators following the diagnostic hit an unhelpful error.

## Changes

**`src/nexus/catalog/catalog.py`**:
- Floor the threshold at `max(1, int(legacy_doc_count * 0.95))`.
- New `Catalog.bootstrap_fallback_active` flag, set when guardrail fires, cleared on rebuild path.
- Updated warning text with explicit `synthesize-log --force` + `t3-backfill-doc-id` remediation hint.

**`src/nexus/commands/catalog.py`**:
- New `_check_bootstrap_status` helper — **pure file inspection**, does NOT construct a Catalog. Constructing one would trigger `_ensure_consistent` and re-project events.jsonl into SQLite, overwriting any operator-injected drift the doctor verb is meant to detect downstream.
- `doctor_cmd` calls the helper up front. Active fallback: stderr WARNING (text mode) or `bootstrap_fallback` key (JSON). Either way exits non-zero.

**`tests/test_catalog_bootstrap_guardrail.py`** (new): 5 tests covering the floor, flag, doctor text + JSON surfaces. **All 5 fail deterministically against pre-fix code** (verified via `git stash`).

**`tests/test_rdr101_round3_correctness.py::test_atomicity_apply_all_failure_rolls_back_deletes`**: register 3 docs (was 1) so the new threshold floor doesn't catch the v:1-raise atomicity path before the rebuild attempt. Pre-floor that test passed by accident on tiny catalogs.

## Verification

- All 5 new tests pass; TEETH confirmed.
- Targeted RDR-101 sweep (`catalog or event_log or projector or rdr101 or dedupe or doctor or no_direct_catalog_writes or bootstrap`): **987 passed, 1 skipped, 5366 deselected**.

## Strategic note

This bead **replaces Phase 4's (nexus-o6aa.10) telemetry-counter deliverable**. The substantive Phase 4 is observability of the actual desync condition, not counters of "did anyone read source_path." That conversation is in the meta-thread; the .10 bead description should be revised separately.

## Refs

- Bead: `nexus-o6aa.9.7` (P1, parent: `nexus-o6aa.9`)
- Depends on: `nexus-o6aa.9.6` (#449 — atomic dedupe)
- Companion: `nexus-o6aa.9.8` (P2 — lint gate hardening + cleanup, next up)