### PR TITLE
fix(rdr-101): phase 3 cleanup — lint gate hardening + cascade + ES coverage gaps (nexus-o6aa.9.8)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -485,3 +485,7 @@
 {"id":"int-6748ccc6","kind":"field_change","created_at":"2026-05-01T18:53:57.034824Z","actor":"Hellblazer","issue_id":"nexus-ai9d","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-ec061874","kind":"field_change","created_at":"2026-05-01T20:56:53.028994Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.3","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-6fa65526","kind":"field_change","created_at":"2026-05-01T20:56:56.236748Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.4","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-0d208d6b","kind":"field_change","created_at":"2026-05-01T21:12:39.337015Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.5","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-6ec1eb80","kind":"field_change","created_at":"2026-05-01T21:12:49.747406Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-ec93c5c9","kind":"field_change","created_at":"2026-05-01T21:30:22.984073Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.6","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-81a4170f","kind":"field_change","created_at":"2026-05-01T21:36:40.061953Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.7","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -489,3 +489,4 @@
 {"id":"int-6ec1eb80","kind":"field_change","created_at":"2026-05-01T21:12:49.747406Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 {"id":"int-ec93c5c9","kind":"field_change","created_at":"2026-05-01T21:30:22.984073Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.6","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-81a4170f","kind":"field_change","created_at":"2026-05-01T21:36:40.061953Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.7","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-140c3f2b","kind":"field_change","created_at":"2026-05-01T21:51:50.743853Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.8","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -50,17 +50,46 @@ def _read_shadow_gate() -> bool:
     return val in ("1", "true", "yes", "on")
 
 
+_KNOWN_EVENT_SOURCED_VALUES: frozenset[str] = frozenset(
+    ("", "0", "1", "true", "false", "yes", "no", "on", "off"),
+)
+# Module-scoped sentinel — log the unrecognized-value warning at most
+# once per process so a tight loop reading the gate doesn't spam logs.
+_unrecognized_event_sourced_value_logged: set[str] = set()
+
+
 def _read_event_sourced_gate() -> bool:
     """Return True when the event-sourced write path is enabled.
 
     RDR-101 Phase 3 PR ζ: the default is ON. ``NEXUS_EVENT_SOURCED``
-    unset or set to any non-falsy value enables ES mode. Explicit
-    ``0`` / ``false`` / ``no`` / ``off`` opts back into the legacy
-    direct-write path.
+    unset or set to ``1`` / ``true`` / ``yes`` / ``on`` (or empty)
+    enables ES mode. Explicit ``0`` / ``false`` / ``no`` / ``off``
+    opts back into the legacy direct-write path.
+
+    RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8): unrecognized values
+    (typos like ``ofg`` / ``nope`` / ``legacy``) silently activate ES
+    under the new default-ON semantics — pre-fix the gate flipped
+    from safe-by-default (only on for explicit truthy) to dangerous-
+    by-default. Log a structured warning the first time we see an
+    unrecognized value so an operator's typo is detectable.
     """
-    val = os.environ.get(_EVENT_SOURCED_ENV, "").strip().lower()
+    raw = os.environ.get(_EVENT_SOURCED_ENV, "")
+    val = raw.strip().lower()
     if val in ("0", "false", "no", "off"):
         return False
+    if val not in _KNOWN_EVENT_SOURCED_VALUES:
+        if raw not in _unrecognized_event_sourced_value_logged:
+            _unrecognized_event_sourced_value_logged.add(raw)
+            _log.warning(
+                "catalog_event_sourced_gate_unrecognized_value",
+                value=raw,
+                effective="ON",
+                note=(
+                    "NEXUS_EVENT_SOURCED carries an unrecognized value; "
+                    "treating as ON (default). Use 0/false/no/off to "
+                    "opt out, or 1/true/yes/on to make ES explicit."
+                ),
+            )
     return True
 
 
@@ -721,7 +750,14 @@ class Catalog:
                 return True
 
             from nexus.catalog import events as _ev
-            event_doc_count = 0
+            # Net document registrations: DocumentRegistered − DocumentDeleted.
+            # Can go negative (a dedupe-only event stream against a
+            # legacy catalog produces only DocumentDeleted), which the
+            # ``>= threshold`` check below relies on to fall through to
+            # legacy. RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8):
+            # renamed from ``event_doc_count`` to make the negative
+            # values intentional rather than surprising.
+            net_registered = 0
             with self._events_path.open() as f:
                 for line in f:
                     line = line.strip()
@@ -733,9 +769,9 @@ class Catalog:
                         continue
                     t = obj.get("type")
                     if t == _ev.TYPE_DOCUMENT_REGISTERED:
-                        event_doc_count += 1
+                        net_registered += 1
                     elif t == _ev.TYPE_DOCUMENT_DELETED:
-                        event_doc_count -= 1
+                        net_registered -= 1
 
             # RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): floor the
             # threshold at 1. ``int(1 * 0.95) == 0`` and ``0 >= 0`` is
@@ -749,7 +785,7 @@ class Catalog:
             # log before ES rebuild is allowed at the smallest catalog
             # sizes.
             threshold = max(1, int(legacy_doc_count * 0.95))
-            return event_doc_count >= threshold
+            return net_registered >= threshold
         except Exception:
             # On any unexpected failure, refuse the event-sourced
             # rebuild (safer to fall through to legacy than to wipe).

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -502,6 +502,14 @@ class Catalog:
         from nexus.catalog.projector import Projector as _Projector
         self._projector = _Projector(self._db)
         self.degraded: bool = False
+        # RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): set when
+        # ``_ensure_consistent`` runtime-decides to fall back to the
+        # legacy rebuild via ``_event_log_covers_legacy``. Surfaces
+        # the silent state where ``_event_sourced_enabled`` is True
+        # but reads come from legacy JSONL — operator-visible signal
+        # for ``nx catalog doctor``. Never read from the env; the
+        # condition is purely runtime.
+        self.bootstrap_fallback_active: bool = False
         # Diagnostic: log the active gate state at construction so an
         # operator inspecting structured logs can confirm which write
         # path is in effect without grepping environment dumps. Debug
@@ -609,19 +617,34 @@ class Catalog:
                 # the legacy JSONL has materially more documents than
                 # the event log carries DocumentRegistered events for.
                 # Refuse to wipe the legacy rows; fall through to the
-                # legacy rebuild and surface the gap so the operator
-                # can run ``nx catalog synthesize-log``.
+                # legacy rebuild and flag the state so operators see
+                # it via ``nx catalog doctor`` (not just structlog).
+                #
+                # RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): the
+                # remediation hint must say ``--force`` because
+                # ``synthesize-log`` refuses non-empty events.jsonl
+                # without it. Pre-fix the message read "Run 'nx
+                # catalog synthesize-log'", which sent operators into
+                # a "log is non-empty, --force required" error loop.
+                self.bootstrap_fallback_active = True
                 _log.warning(
                     "catalog_event_log_incomplete_falling_back_to_legacy",
                     catalog_dir=str(self._dir),
                     note=(
-                        "events.jsonl has fewer DocumentRegistered "
-                        "events than documents.jsonl has rows. Run "
-                        "'nx catalog synthesize-log' before relying "
-                        "on the event-sourced rebuild."
+                        "events.jsonl is non-empty but has fewer "
+                        "DocumentRegistered events than documents.jsonl "
+                        "has rows. ES writes are landing in the log "
+                        "but reads come from legacy JSONL — replay "
+                        "equality is silently broken until the log "
+                        "catches up. Run 'nx catalog synthesize-log "
+                        "--force' to rebuild events.jsonl from the "
+                        "legacy state, then 'nx catalog t3-backfill-"
+                        "doc-id' to align T3 chunks."
                     ),
                 )
                 use_event_log = False
+            else:
+                self.bootstrap_fallback_active = False
             if use_event_log:
                 # Replay events.jsonl through the projector into the
                 # live CatalogDB. Atomic: the transaction context
@@ -714,7 +737,19 @@ class Catalog:
                     elif t == _ev.TYPE_DOCUMENT_DELETED:
                         event_doc_count -= 1
 
-            return event_doc_count >= int(legacy_doc_count * 0.95)
+            # RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): floor the
+            # threshold at 1. ``int(1 * 0.95) == 0`` and ``0 >= 0`` is
+            # True, so a 1-document legacy catalog with a non-empty-but-
+            # ``DocumentRegistered``-free ``events.jsonl`` (e.g. a
+            # ChunkIndexed-only log from a partial Phase 2 synthesis,
+            # or a dedupe-only event stream that pushes
+            # ``event_doc_count`` to 0) used to bypass the guardrail
+            # and silently wipe the single legacy row. The floor
+            # guarantees a real DocumentRegistered must exist in the
+            # log before ES rebuild is allowed at the smallest catalog
+            # sizes.
+            threshold = max(1, int(legacy_doc_count * 0.95))
+            return event_doc_count >= threshold
         except Exception:
             # On any unexpected failure, refuse the event-sourced
             # rebuild (safer to fall through to legacy than to wipe).

--- a/src/nexus/catalog/dedupe.py
+++ b/src/nexus/catalog/dedupe.py
@@ -227,128 +227,169 @@ def apply_remove_plan(cat: "Catalog", op: OrphanPlan) -> tuple[int, int]:
     also dropped. Writes JSONL tombstones so the deletion survives a
     future rebuild.
 
+    Atomicity (RDR-101 Phase 3 follow-up A, nexus-o6aa.9.6):
+
+    - Acquires the catalog directory flock for the duration of the
+      whole operation. ``_write_to_event_log``'s contract requires the
+      caller to hold this lock (see ``Catalog._write_to_event_log`` at
+      catalog.py:852); every other ES mutator (``set_alias``,
+      ``unlink``, ``register``, …) acquires it. Pre-fix this function
+      did not, so a concurrent ``nx catalog register`` from another
+      process could interleave appends in events.jsonl AND the legacy
+      JSONL files.
+    - Under ES, writes ALL events to events.jsonl FIRST (a single
+      flock-held batch via the existing per-event helper, which honors
+      the outer flock), THEN projects them inside
+      ``cat._db.transaction()``. If projection raises on event N of M,
+      the SQLite transaction rolls back to the pre-dedupe state while
+      events.jsonl carries the full batch; the next
+      ``_ensure_consistent`` mtime tick replays events.jsonl through
+      the projector and converges on the intended post-dedupe state.
+      Pre-fix the per-event interleave (write log → project → write log
+      → project → … → single commit) split events from SQLite on
+      mid-loop projector failure with no operator-visible recovery.
+
     Returns ``(deleted_docs, deleted_links)``.
     """
     orphan_prefix = op.orphan_prefix
     clause, params = cat._prefix_sql(orphan_prefix)
 
-    # 1. Collect docs to delete (need the tombstone payload before SQL DELETE).
-    rows = cat._db.execute(
-        f"SELECT tumbler, title, author, year, content_type, file_path, "
-        f"corpus, physical_collection, chunk_count, head_hash, indexed_at, "
-        f"metadata, source_mtime, alias_of FROM documents WHERE {clause}",
-        params,
-    ).fetchall()
-    doc_tumblers = [r[0] for r in rows]
+    dir_fd = cat._acquire_lock()
+    try:
+        # 1. Collect docs to delete (need the tombstone payload before
+        # SQL DELETE).
+        rows = cat._db.execute(
+            f"SELECT tumbler, title, author, year, content_type, file_path, "
+            f"corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+            f"metadata, source_mtime, alias_of FROM documents WHERE {clause}",
+            params,
+        ).fetchall()
+        doc_tumblers = [r[0] for r in rows]
 
-    # 2. Collect links to delete.
-    placeholders = ",".join("?" * len(doc_tumblers)) if doc_tumblers else "''"
-    link_rows = cat._db.execute(
-        f"SELECT from_tumbler, to_tumbler, link_type, from_span, to_span, "
-        f"created_by, created_at, metadata FROM links "
-        f"WHERE from_tumbler IN ({placeholders}) OR to_tumbler IN ({placeholders})",
-        (*doc_tumblers, *doc_tumblers) if doc_tumblers else (),
-    ).fetchall() if doc_tumblers else []
-
-    # 3. JSONL tombstones — documents, links, owner.
-    import json as _json
-    for r in rows:
-        cat._append_jsonl(cat._documents_path, {
-            "tumbler": r[0], "title": r[1], "author": r[2], "year": r[3],
-            "content_type": r[4], "file_path": r[5], "corpus": r[6],
-            "physical_collection": r[7], "chunk_count": r[8],
-            "head_hash": r[9], "indexed_at": r[10],
-            "meta": _json.loads(r[11]) if r[11] else {},
-            "source_mtime": r[12] or 0.0,
-            "alias_of": r[13] or "",
-            "_deleted": True,
-        })
-    for r in link_rows:
-        cat._append_jsonl(cat._links_path, {
-            "from_t": r[0], "to_t": r[1], "link_type": r[2],
-            "from_span": r[3] or "", "to_span": r[4] or "",
-            "created_by": r[5], "created_at": r[6] or "",
-            "meta": _json.loads(r[7]) if r[7] else {},
-            "_deleted": True,
-        })
-    cat._append_jsonl(cat._owners_path, {"owner": orphan_prefix, "_deleted": True})
-
-    # 4. SQL deletion. Under NEXUS_EVENT_SOURCED=1 every mutation must
-    # travel through events.jsonl so the projector's rebuild is the only
-    # source of truth (RDR-101 Phase 3, nexus-o6aa.9.4 — blocks ζ). The
-    # legacy direct-DELETE path is retained for backward compatibility
-    # under the gate-off configuration; the JSONL tombstones above are
-    # written in both modes (no-op under ES rebuild but kept for the
-    # cutover window).
-    if cat._event_sourced_enabled:
-        from nexus.catalog.catalog import (
-            _DocumentDeletedPayload,
-            _LinkDeletedPayload,
-            _OwnerDeletedPayload,
-            _make_event,
+        # 2. Collect links to delete.
+        placeholders = (
+            ",".join("?" * len(doc_tumblers)) if doc_tumblers else "''"
         )
+        link_rows = cat._db.execute(
+            f"SELECT from_tumbler, to_tumbler, link_type, from_span, to_span, "
+            f"created_by, created_at, metadata FROM links "
+            f"WHERE from_tumbler IN ({placeholders}) "
+            f"OR to_tumbler IN ({placeholders})",
+            (*doc_tumblers, *doc_tumblers) if doc_tumblers else (),
+        ).fetchall() if doc_tumblers else []
 
-        # Order: links first (so the projector mutates dependent rows
-        # before the documents that anchor them), then documents, then
-        # the owner row last. The projector contract accepts any order
-        # for v: 0 events but operator-readable replay benefits from
-        # the natural dependency ordering.
-        for r in link_rows:
-            event = _make_event(
-                _LinkDeletedPayload(
-                    from_doc=r[0],
-                    to_doc=r[1],
-                    link_type=r[2],
-                    reason="dedupe.orphan",
-                ),
-                v=0,
-            )
-            cat._write_to_event_log(event)
-            cat._projector.apply(event)
-
+        # 3. JSONL tombstones — documents, links, owner. Written in
+        # both modes (no-op under ES rebuild but kept for the cutover
+        # window).
+        import json as _json
         for r in rows:
-            event = _make_event(
-                _DocumentDeletedPayload(
-                    doc_id=r[0],
-                    tumbler=r[0],
-                    reason="dedupe.orphan",
-                ),
-                v=0,
-            )
-            cat._write_to_event_log(event)
-            cat._projector.apply(event)
-
-        cat._write_to_event_log(
-            owner_event := _make_event(
-                _OwnerDeletedPayload(
-                    owner_id=orphan_prefix,
-                    reason="dedupe.orphan",
-                ),
-                v=0,
-            )
+            cat._append_jsonl(cat._documents_path, {
+                "tumbler": r[0], "title": r[1], "author": r[2], "year": r[3],
+                "content_type": r[4], "file_path": r[5], "corpus": r[6],
+                "physical_collection": r[7], "chunk_count": r[8],
+                "head_hash": r[9], "indexed_at": r[10],
+                "meta": _json.loads(r[11]) if r[11] else {},
+                "source_mtime": r[12] or 0.0,
+                "alias_of": r[13] or "",
+                "_deleted": True,
+            })
+        for r in link_rows:
+            cat._append_jsonl(cat._links_path, {
+                "from_t": r[0], "to_t": r[1], "link_type": r[2],
+                "from_span": r[3] or "", "to_span": r[4] or "",
+                "created_by": r[5], "created_at": r[6] or "",
+                "meta": _json.loads(r[7]) if r[7] else {},
+                "_deleted": True,
+            })
+        cat._append_jsonl(
+            cat._owners_path, {"owner": orphan_prefix, "_deleted": True},
         )
-        cat._projector.apply(owner_event)
 
-        cat._db.commit()
-    else:
-        if doc_tumblers:
+        # 4. SQL deletion. Under NEXUS_EVENT_SOURCED=1 every mutation
+        # travels through events.jsonl; the legacy direct-DELETE path
+        # is retained for backward compatibility under the gate-off
+        # configuration.
+        if cat._event_sourced_enabled:
+            # Import from events.py (the canonical source) rather than
+            # catalog.py's private aliases — pre-fix this depended on
+            # ``catalog.py`` re-exporting the underscore-prefixed
+            # private names, a hidden cross-module coupling.
+            from nexus.catalog.events import (
+                DocumentDeletedPayload,
+                LinkDeletedPayload,
+                OwnerDeletedPayload,
+                make_event,
+            )
+
+            # Phase A: build all event envelopes upfront — pure data,
+            # no mutation. Order: links first (dependent rows before
+            # the documents that anchor them), then documents, then
+            # the owner row last. The projector contract is
+            # order-agnostic for v: 0 events but operator-readable
+            # replay benefits from the natural dependency ordering.
+            events: list = []
+            for r in link_rows:
+                events.append(make_event(
+                    LinkDeletedPayload(
+                        from_doc=r[0], to_doc=r[1], link_type=r[2],
+                        reason="dedupe.orphan",
+                    ),
+                    v=0,
+                ))
+            for r in rows:
+                events.append(make_event(
+                    DocumentDeletedPayload(
+                        doc_id=r[0], tumbler=r[0], reason="dedupe.orphan",
+                    ),
+                    v=0,
+                ))
+            events.append(make_event(
+                OwnerDeletedPayload(
+                    owner_id=orphan_prefix, reason="dedupe.orphan",
+                ),
+                v=0,
+            ))
+
+            # Phase B: durably append every event to events.jsonl
+            # under the outer flock. The per-event helper does not
+            # re-acquire the flock (caller holds it); each line is
+            # flushed and closed before the next opens, so a crash
+            # mid-batch leaves a prefix of events on disk which the
+            # next replay handles deterministically (the orphan rows
+            # are still gone in the projection).
+            for event in events:
+                cat._write_to_event_log(event)
+
+            # Phase C: project every event into SQLite inside one
+            # transaction. If apply raises on event N of M, the tx
+            # rolls back to the pre-dedupe state while events.jsonl
+            # already carries the full batch. _ensure_consistent on
+            # the next mtime tick replays the durable batch and
+            # converges on the intended post-dedupe state.
+            with cat._db.transaction():
+                for event in events:
+                    cat._projector.apply(event)
+        else:
+            if doc_tumblers:
+                cat._db.execute(
+                    f"DELETE FROM links WHERE from_tumbler IN ({placeholders}) "
+                    f"OR to_tumbler IN ({placeholders})",
+                    (*doc_tumblers, *doc_tumblers),
+                )
+            cat._db.execute(f"DELETE FROM documents WHERE {clause}", params)
             cat._db.execute(
-                f"DELETE FROM links WHERE from_tumbler IN ({placeholders}) "
-                f"OR to_tumbler IN ({placeholders})",
-                (*doc_tumblers, *doc_tumblers),
+                "DELETE FROM owners WHERE tumbler_prefix = ?", (orphan_prefix,),
             )
-        cat._db.execute(f"DELETE FROM documents WHERE {clause}", params)
-        cat._db.execute(
-            "DELETE FROM owners WHERE tumbler_prefix = ?", (orphan_prefix,),
-        )
-        cat._db.commit()
+            cat._db.commit()
 
-    _log.info(
-        "catalog.dedupe.remove_plan_applied",
-        orphan=op.orphan_name, docs=len(rows), links=len(link_rows),
-        event_sourced=cat._event_sourced_enabled,
-    )
-    return len(rows), len(link_rows)
+        _log.info(
+            "catalog.dedupe.remove_plan_applied",
+            orphan=op.orphan_name, docs=len(rows), links=len(link_rows),
+            event_sourced=cat._event_sourced_enabled,
+        )
+        return len(rows), len(link_rows)
+    finally:
+        cat._release_lock(dir_fd)
 
 
 def apply_plan(

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -141,7 +141,44 @@ class Projector:
         # DocumentDeleted events; we do not cascade here because the
         # projection contract is one event = one row mutation.
         if not payload.owner_id:
+            # nexus-o6aa.9.8: malformed event (hand-emitted, synthesis
+            # bug, or a future v: 1 path that didn't populate the
+            # field). Surface it in the structured log rather than
+            # silently absorbing — replay should be observable.
+            _log.warning(
+                "projector_owner_deleted_no_owner_id",
+                payload=str(payload),
+            )
             return
+
+        # nexus-o6aa.9.8: protocol invariant — OwnerDeleted MUST be
+        # preceded by DocumentDeleted events for every document under
+        # the owner. The projection contract has no FK CASCADE; if a
+        # caller emits OwnerDeleted while documents under the prefix
+        # still exist in SQLite, the orphaned rows point at a
+        # non-existent owner. Surface this so a hand-emitted or
+        # synthesis-driven OwnerDeleted that skipped its DocumentDeleted
+        # prerequisites lands as a loud structured warning rather than
+        # a silently corrupted projection.
+        descendants = self._db.execute(
+            "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+            (f"{payload.owner_id}.%",),
+        ).fetchone()
+        descendant_count = descendants[0] if descendants else 0
+        if descendant_count > 0:
+            _log.warning(
+                "projector_owner_deleted_with_extant_documents",
+                owner_id=payload.owner_id,
+                descendant_count=descendant_count,
+                note=(
+                    "OwnerDeleted projected while documents under the "
+                    "owner prefix still exist; protocol requires "
+                    "DocumentDeleted for every descendant first. "
+                    "Orphaned document rows now point at a non-existent "
+                    "owner."
+                ),
+            )
+
         self._db.execute(
             "DELETE FROM owners WHERE tumbler_prefix = ?",
             (payload.owner_id,),

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3299,6 +3299,31 @@ def doctor_cmd(
     overall_pass = True
     json_payload: dict = {}
 
+    # RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): surface bootstrap
+    # fallback state to the operator. When _ensure_consistent runtime-
+    # decides to fall back to legacy reads (events.jsonl is non-empty
+    # but sparse vs documents.jsonl), ES writes still land in the log
+    # while reads come from legacy JSONL — a silent split state where
+    # replay-equality is fundamentally not testing what it claims.
+    # Construct a Catalog up front so _ensure_consistent runs and
+    # bootstrap_fallback_active is current.
+    bootstrap_status = _check_bootstrap_status()
+    if bootstrap_status["fallback_active"]:
+        if as_json:
+            json_payload["bootstrap_fallback"] = bootstrap_status
+        else:
+            click.echo(
+                "WARNING: catalog is operating in bootstrap-fallback mode.\n"
+                "  events.jsonl is non-empty but sparse vs documents.jsonl;\n"
+                "  ES writes are landing in the log but reads come from\n"
+                "  legacy JSONL — replay equality is silently broken.\n"
+                "  Remediate with:\n"
+                "    nx catalog synthesize-log --force\n"
+                "    nx catalog t3-backfill-doc-id\n",
+                err=True,
+            )
+        overall_pass = False
+
     if replay_equality:
         report = _run_replay_equality()
         if as_json:
@@ -3324,6 +3349,109 @@ def doctor_cmd(
 
     if not overall_pass:
         raise click.exceptions.Exit(1)
+
+
+def _check_bootstrap_status() -> dict:
+    """Inspect the canonical-truth files at the configured catalog
+    path and report whether the ES rebuild path would currently fall
+    back to legacy (RDR-101 Phase 3 follow-up B, nexus-o6aa.9.7).
+
+    Returns ``{"fallback_active": bool, "events_path": str,
+    "documents_path": str}``. Used by the doctor verb to surface the
+    silent split state where ``NEXUS_EVENT_SOURCED`` is on but reads
+    come from legacy JSONL.
+
+    Pure file inspection — does NOT construct a ``Catalog`` instance.
+    Constructing one would trigger ``_ensure_consistent``, which
+    re-projects events.jsonl into SQLite. That re-projection would
+    silently overwrite any operator-injected drift the downstream
+    doctor checks (e.g. ``--replay-equality``) are meant to detect.
+    """
+    from nexus.config import catalog_path
+    from nexus.catalog.catalog import _read_event_sourced_gate
+    from nexus.catalog import events as _ev
+
+    cat_path = catalog_path()
+    if not Catalog.is_initialized(cat_path):
+        return {"fallback_active": False, "reason": "catalog_not_initialized"}
+
+    events_path = cat_path / "events.jsonl"
+    documents_path = cat_path / "documents.jsonl"
+
+    if not _read_event_sourced_gate():
+        # Legacy mode: no ES rebuild path runs, no fallback state.
+        return {
+            "fallback_active": False,
+            "events_path": str(events_path),
+            "documents_path": str(documents_path),
+        }
+    if (
+        not events_path.exists()
+        or events_path.stat().st_size == 0
+        or not documents_path.exists()
+    ):
+        # ``use_event_log`` is False at the size gate before the
+        # guardrail check fires; not a fallback state.
+        return {
+            "fallback_active": False,
+            "events_path": str(events_path),
+            "documents_path": str(documents_path),
+        }
+
+    # Replicate the ``_event_log_covers_legacy`` math non-mutatively.
+    try:
+        registered: set[str] = set()
+        tombstoned: set[str] = set()
+        with documents_path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                tumbler = rec.get("tumbler")
+                if not tumbler:
+                    continue
+                if rec.get("_deleted"):
+                    tombstoned.add(tumbler)
+                else:
+                    registered.add(tumbler)
+        legacy_doc_count = len(registered - tombstoned)
+        if legacy_doc_count == 0:
+            return {
+                "fallback_active": False,
+                "events_path": str(events_path),
+                "documents_path": str(documents_path),
+            }
+
+        event_doc_count = 0
+        with events_path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                t = obj.get("type")
+                if t == _ev.TYPE_DOCUMENT_REGISTERED:
+                    event_doc_count += 1
+                elif t == _ev.TYPE_DOCUMENT_DELETED:
+                    event_doc_count -= 1
+
+        threshold = max(1, int(legacy_doc_count * 0.95))
+        fallback_active = event_doc_count < threshold
+    except Exception:
+        fallback_active = False
+
+    return {
+        "fallback_active": fallback_active,
+        "events_path": str(events_path),
+        "documents_path": str(documents_path),
+    }
 
 
 def _run_replay_equality() -> dict:

--- a/tests/test_catalog_bootstrap_guardrail.py
+++ b/tests/test_catalog_bootstrap_guardrail.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): bootstrap guardrail
+correctness + operator-visible signal.
+
+Two convergent review findings on the
+``Catalog._event_log_covers_legacy`` guardrail (code-review-expert +
+deep-analyst, 2026-05-01):
+
+* **C1** — ``int(legacy_doc_count * 0.95)`` evaluates to 0 when
+  ``legacy_doc_count == 1``. ``event_doc_count >= 0`` is True even
+  when events.jsonl carries zero ``DocumentRegistered`` events.
+  A 1-document legacy catalog with a non-empty-but-DocumentRegistered-
+  free ``events.jsonl`` (e.g. a ChunkIndexed-only log from partial
+  Phase 2 synthesis, or a dedupe-only event stream that drives
+  ``event_doc_count`` to 0) bypassed the guardrail and silently wiped
+  the single legacy row. Floor the threshold at 1.
+
+* **C2** — when ``_ensure_consistent`` runtime-decides to fall back to
+  legacy reads, ``cat._event_sourced_enabled`` remains True. ES writes
+  still land in events.jsonl while reads come from legacy JSONL —
+  silent split state where replay-equality is fundamentally not
+  testing what it claims. ``Catalog.bootstrap_fallback_active`` now
+  reflects this decision so the doctor verb can surface it.
+
+Includes a doctor-surface assertion: ``nx catalog doctor`` must emit
+an operator-visible warning when the bootstrap fallback is active.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.commands.catalog import doctor_cmd
+
+
+def _init_catalog(tmp_path: Path) -> Path:
+    d = tmp_path / "test-catalog"
+    Catalog.init(d)
+    return d
+
+
+def _write_event_line(events_path: Path, payload_dict: dict) -> None:
+    """Append a raw event line to events.jsonl. Used to simulate
+    states the public API does not produce directly (e.g. a
+    ChunkIndexed-only log).
+    """
+    if not events_path.exists():
+        events_path.touch()
+    with events_path.open("a") as f:
+        f.write(json.dumps(payload_dict, separators=(",", ":")))
+        f.write("\n")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# C1: legacy_doc_count=1 floor regression
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_guardrail_refuses_es_rebuild_for_single_doc_with_no_registered_events(
+    tmp_path, monkeypatch,
+):
+    """Pre-fix: ``int(1 * 0.95) == 0`` and ``0 >= 0`` is True, so a
+    1-document legacy catalog with a non-empty-but-DocumentRegistered-
+    free events.jsonl bypassed the guardrail and the ES rebuild
+    silently wiped the legacy row. Post-fix: the floor at 1 forces a
+    real ``DocumentRegistered`` event before ES rebuild proceeds.
+    """
+    # Set up a 1-document legacy catalog under legacy mode so the
+    # legacy JSONL is the source of truth.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_catalog(tmp_path)
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    cat.register(
+        owner, "doc-1.md", content_type="prose", file_path="doc-1.md",
+    )
+    cat._db.close()
+
+    # Inject a non-empty events.jsonl that carries only a ChunkIndexed
+    # event (no DocumentRegistered). Pre-fix: guardrail passes
+    # because event_doc_count=0 >= int(1 * 0.95) = 0.
+    events_path = d / "events.jsonl"
+    _write_event_line(events_path, {
+        "type": "ChunkIndexed", "v": 0,
+        "payload": {
+            "chunk_id": "ch1", "chash": "h" * 64, "doc_id": "uuid7-A",
+            "coll_id": "code__test", "position": 0,
+        },
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    # Now flip ES on and re-open the catalog. _ensure_consistent must
+    # detect the sparse log and fall back to legacy.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    cat2 = Catalog(d, d / ".catalog.db")
+    try:
+        # Live catalog must still have the 1 document — guardrail
+        # protected it from ES rebuild.
+        doc_count = cat2._db.execute(
+            "SELECT count(*) FROM documents",
+        ).fetchone()[0]
+        assert doc_count == 1, (
+            "guardrail floor regression: 1-document catalog was wiped "
+            "by ES rebuild because int(1 * 0.95) == 0 made the "
+            "threshold trivially passable. Floor must be max(1, ...)."
+        )
+        assert cat2.bootstrap_fallback_active, (
+            "bootstrap_fallback_active must be set when guardrail "
+            "fires — the silent split state is what doctor surfaces."
+        )
+    finally:
+        cat2._db.close()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# C2: bootstrap fallback flag is set when guardrail fires
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_bootstrap_fallback_active_set_when_guardrail_fires(
+    tmp_path, monkeypatch,
+):
+    """When ``_ensure_consistent`` decides to fall back to legacy
+    because events.jsonl is sparse, ``cat.bootstrap_fallback_active``
+    must be True so the doctor verb can surface the state. Pre-fix
+    the only signal was a structlog warning operators rarely see.
+    """
+    # Build legacy state: 10 docs, no events.jsonl.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_catalog(tmp_path)
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    for i in range(10):
+        cat.register(
+            owner, f"doc-{i}.md", content_type="prose",
+            file_path=f"doc-{i}.md",
+        )
+    cat._db.close()
+
+    # Inject one stray event so events.jsonl is non-empty but sparse
+    # vs the 10-row documents.jsonl. Guardrail should fire on flip.
+    events_path = d / "events.jsonl"
+    _write_event_line(events_path, {
+        "type": "DocumentRegistered", "v": 0,
+        "payload": {
+            "doc_id": "1.1.99", "owner_id": "1.1",
+            "content_type": "prose", "source_uri": "",
+            "coll_id": "", "title": "stray.md", "tumbler": "1.1.99",
+            "author": "", "year": 0, "file_path": "stray.md",
+            "corpus": "", "physical_collection": "",
+            "chunk_count": 0, "head_hash": "", "indexed_at": "",
+            "alias_of": "", "meta": {}, "source_mtime": 0.0,
+            "indexed_at_doc": "",
+        },
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    cat2 = Catalog(d, d / ".catalog.db")
+    try:
+        assert cat2.bootstrap_fallback_active is True, (
+            "guardrail fired but bootstrap_fallback_active not set; "
+            "doctor cannot surface the silent state to operators."
+        )
+        # Live state still has all 10 legacy docs (guardrail saved
+        # them from being wiped).
+        live = cat2._db.execute(
+            "SELECT count(*) FROM documents",
+        ).fetchone()[0]
+        assert live >= 10
+    finally:
+        cat2._db.close()
+
+
+def test_bootstrap_fallback_clears_when_log_catches_up(
+    tmp_path, monkeypatch,
+):
+    """Once events.jsonl carries ≥ ``int(legacy_doc_count * 0.95)``
+    DocumentRegistered events (e.g. after ``nx catalog synthesize-log
+    --force``), the next rebuild promotes to ES and the flag clears.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_catalog(tmp_path)
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    cat.register(
+        owner, "doc-1.md", content_type="prose", file_path="doc-1.md",
+    )
+    cat._db.close()
+
+    # Flip ES on. events.jsonl is empty → ``use_event_log`` is False
+    # at the .size > 0 gate, never reaches the guardrail check, so
+    # ``bootstrap_fallback_active`` stays False.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    cat_empty_log = Catalog(d, d / ".catalog.db")
+    try:
+        assert cat_empty_log.bootstrap_fallback_active is False
+    finally:
+        cat_empty_log._db.close()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Doctor surface
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_doctor_surfaces_bootstrap_fallback_in_text_output(
+    tmp_path, monkeypatch,
+):
+    """``nx catalog doctor`` must emit an operator-visible warning to
+    stderr when the bootstrap fallback is active. Structlog alone is
+    not enough — operators inspecting doctor output must see the
+    state and the remediation hint.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_catalog(tmp_path)
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    cat.register(
+        owner, "doc-1.md", content_type="prose", file_path="doc-1.md",
+    )
+    cat._db.close()
+
+    events_path = d / "events.jsonl"
+    _write_event_line(events_path, {
+        "type": "DocumentDeleted", "v": 0,
+        "payload": {
+            "doc_id": "1.1.99", "tumbler": "1.1.99",
+            "reason": "test",
+        },
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        doctor_cmd, ["--replay-equality"],
+    )
+
+    # Doctor exits non-zero because bootstrap fallback fails the
+    # overall pass.
+    assert result.exit_code == 1, result.output
+    # The warning is written via click.echo(..., err=True). Click
+    # 8.3+ CliRunner exposes stderr separately when invoked without
+    # explicit mixing (the param was removed). Fall back to combined
+    # output for older Click semantics so the test is robust.
+    text = (result.stderr or "") + (result.output or "")
+    assert "bootstrap-fallback" in text, text
+    assert "synthesize-log --force" in text, (
+        "remediation hint must include --force; pre-fix the warning "
+        "told operators to run synthesize-log without --force, which "
+        "fails on a non-empty events.jsonl."
+    )
+
+
+def test_doctor_surfaces_bootstrap_fallback_in_json_output(
+    tmp_path, monkeypatch,
+):
+    """``nx catalog doctor --json`` must include a
+    ``bootstrap_fallback`` key when the state is active so machine
+    consumers (CI, monitoring) can detect it.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_catalog(tmp_path)
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    cat.register(
+        owner, "doc-1.md", content_type="prose", file_path="doc-1.md",
+    )
+    cat._db.close()
+
+    events_path = d / "events.jsonl"
+    _write_event_line(events_path, {
+        "type": "DocumentDeleted", "v": 0,
+        "payload": {
+            "doc_id": "1.1.99", "tumbler": "1.1.99",
+            "reason": "test",
+        },
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    # Suppress structlog noise so it doesn't interleave with the JSON.
+    import structlog
+    saved = structlog.get_config()
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(50),
+    )
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            doctor_cmd, ["--replay-equality", "--json"],
+        )
+    finally:
+        structlog.configure(**saved)
+
+    assert result.exit_code == 1, result.output
+    # Strip any non-JSON prefix (the warning text path may emit some
+    # before the JSON dump even in --json mode).
+    out = result.output
+    start = out.find("{")
+    payload = json.loads(out[start:])
+    assert "bootstrap_fallback" in payload, payload
+    assert payload["bootstrap_fallback"]["fallback_active"] is True

--- a/tests/test_catalog_dedupe_event_sourced.py
+++ b/tests/test_catalog_dedupe_event_sourced.py
@@ -232,3 +232,142 @@ def test_dedupe_legacy_mode_unchanged(tmp_path, monkeypatch):
         (f"{orphan}.%",),
     ).fetchone()[0]
     assert remaining == 0
+
+
+# ─────────────────────────────────────────────────────────────────────
+# RDR-101 Phase 3 follow-up A (nexus-o6aa.9.6): atomicity tests.
+#
+# The pre-A implementation interleaved
+# ``_write_to_event_log + _projector.apply`` per event with a single
+# trailing commit. A mid-loop projector exception left events 1..N-1
+# durable in events.jsonl while the pending SQLite mutations rolled
+# back at the un-committed connection close — a split state with no
+# operator-visible diagnostic.
+#
+# Post-A: events are written first (durable batch), then projected
+# inside ``cat._db.transaction()``. A projector exception rolls the
+# whole projection back to the pre-dedupe state while events.jsonl
+# still carries the full batch; the next ``_ensure_consistent`` mtime
+# tick replays the durable batch and converges on the post-dedupe
+# state.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_dedupe_acquires_flock(tmp_path, monkeypatch):
+    """``apply_remove_plan`` must acquire the catalog directory flock
+    at entry. Pre-fix every other ES mutator did but dedupe didn't, so
+    a concurrent ``register`` call could interleave appends in
+    events.jsonl and the legacy JSONL files.
+    """
+    cat = _make_catalog_es(tmp_path, monkeypatch)
+    orphan_prefix, _ = _populate_with_orphan(cat)
+
+    acquired: list[int] = []
+    released: list[int] = []
+    original_acquire = cat._acquire_lock
+    original_release = cat._release_lock
+
+    def tracked_acquire():
+        fd = original_acquire()
+        acquired.append(fd)
+        return fd
+
+    def tracked_release(fd):
+        released.append(fd)
+        return original_release(fd)
+
+    monkeypatch.setattr(cat, "_acquire_lock", tracked_acquire)
+    monkeypatch.setattr(cat, "_release_lock", tracked_release)
+
+    plan = OrphanPlan(
+        orphan_prefix=orphan_prefix, orphan_name="nexus-571b8edd",
+        action="remove", doc_count=2,
+    )
+    apply_remove_plan(cat, plan)
+
+    assert len(acquired) == 1, (
+        f"apply_remove_plan must acquire flock exactly once; got {acquired}"
+    )
+    assert acquired == released, (
+        f"every acquire must be paired with a release; got "
+        f"acquired={acquired} released={released}"
+    )
+
+
+def test_projector_failure_rolls_back_sqlite_but_log_durable(
+    tmp_path, monkeypatch,
+):
+    """Atomicity invariant: if ``_projector.apply`` raises mid-batch,
+    SQLite reverts to the pre-dedupe state (transaction rollback)
+    while events.jsonl carries the full event batch (durable). The
+    next ``_ensure_consistent`` rebuild replays the batch and
+    converges on the post-dedupe state.
+
+    Pre-fix the per-event interleave produced events 1..N-1 durable
+    plus uncommitted SQLite mutations 1..N-1 that rolled back at
+    connection close — split state with no operator diagnostic.
+    """
+    cat = _make_catalog_es(tmp_path, monkeypatch)
+    orphan_prefix, orphan_docs = _populate_with_orphan(cat)
+
+    pre_doc_count = cat._db.execute(
+        "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+        (f"{orphan_prefix}.%",),
+    ).fetchone()[0]
+    pre_event_size = (
+        cat._events_path.read_text().count("\n")
+        if cat._events_path.exists() else 0
+    )
+
+    # Poison the projector to raise on the 3rd apply call.
+    original_apply = cat._projector.apply
+    call_count = [0]
+
+    def poisoned_apply(event):
+        call_count[0] += 1
+        if call_count[0] == 3:
+            raise RuntimeError("simulated projector failure on event 3")
+        return original_apply(event)
+
+    monkeypatch.setattr(cat._projector, "apply", poisoned_apply)
+
+    plan = OrphanPlan(
+        orphan_prefix=orphan_prefix, orphan_name="nexus-571b8edd",
+        action="remove", doc_count=2,
+    )
+    with pytest.raises(RuntimeError, match="simulated projector failure"):
+        apply_remove_plan(cat, plan)
+
+    # SQLite invariant: rolled back to pre-dedupe state.
+    post_doc_count = cat._db.execute(
+        "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+        (f"{orphan_prefix}.%",),
+    ).fetchone()[0]
+    assert post_doc_count == pre_doc_count, (
+        "SQLite must roll back on projector failure; "
+        f"pre={pre_doc_count} post={post_doc_count}"
+    )
+
+    # events.jsonl invariant: full batch durably written before
+    # projection started.
+    post_event_lines = cat._events_path.read_text().splitlines()
+    new_event_count = len(post_event_lines) - pre_event_size
+    # 2 LinkDeleted + 2 DocumentDeleted + 1 OwnerDeleted == 5 new events.
+    assert new_event_count == 5, (
+        f"events.jsonl must carry the full batch even when projection "
+        f"failed; got {new_event_count} new events"
+    )
+
+    # Convergence invariant: after restoring the projector, force a
+    # rebuild and assert orphans stay deleted (the durable events
+    # replay correctly).
+    monkeypatch.setattr(cat._projector, "apply", original_apply)
+    _force_rebuild_from_events(cat)
+    final_count = cat._db.execute(
+        "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+        (f"{orphan_prefix}.%",),
+    ).fetchone()[0]
+    assert final_count == 0, (
+        f"rebuild from durable events must converge on post-dedupe "
+        f"state; got {final_count} surviving orphan docs"
+    )

--- a/tests/test_catalog_events.py
+++ b/tests/test_catalog_events.py
@@ -69,10 +69,32 @@ class TestPayloadRegistry:
         assert ev.payload_class("FutureEventType") is None
 
     def test_event_type_count_matches_rdr_101(self):
-        # RDR-101 §Event log enumerated 12 event types at Phase 1; Phase 3
-        # follow-up nexus-o6aa.9.4 added OwnerDeleted (v: 0 dedupe path).
-        # Update this assertion alongside any addition.
-        assert len(ev.ALL_EVENT_TYPES) == 13
+        # RDR-101 §Event log enumerated 12 event types at Phase 1;
+        # Phase 3 follow-up nexus-o6aa.9.4 added OwnerDeleted (v: 0
+        # dedupe path). Asserting both the count AND the explicit
+        # set membership so a future addition fails with a clear
+        # diagnostic instead of an opaque count mismatch (RDR-101
+        # Phase 3 follow-up C, nexus-o6aa.9.8).
+        expected = {
+            ev.TYPE_OWNER_REGISTERED,
+            ev.TYPE_OWNER_DELETED,  # added Phase 3 follow-up
+            ev.TYPE_COLLECTION_CREATED,
+            ev.TYPE_COLLECTION_SUPERSEDED,
+            ev.TYPE_DOCUMENT_REGISTERED,
+            ev.TYPE_DOCUMENT_RENAMED,
+            ev.TYPE_DOCUMENT_ALIASED,
+            ev.TYPE_DOCUMENT_ENRICHED,
+            ev.TYPE_DOCUMENT_DELETED,
+            ev.TYPE_CHUNK_INDEXED,
+            ev.TYPE_CHUNK_ORPHANED,
+            ev.TYPE_LINK_CREATED,
+            ev.TYPE_LINK_DELETED,
+        }
+        assert ev.ALL_EVENT_TYPES == expected, (
+            f"event-type set drifted; difference: "
+            f"added={ev.ALL_EVENT_TYPES - expected} "
+            f"removed={expected - ev.ALL_EVENT_TYPES}"
+        )
 
 
 class TestEnvelopeRoundtrip:

--- a/tests/test_catalog_shadow_emit.py
+++ b/tests/test_catalog_shadow_emit.py
@@ -265,6 +265,13 @@ class TestShadowReplayRoundTrip:
     def test_register_register_link_unlink_delete(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ):
+        # RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8): pin to legacy
+        # explicitly so the shadow path is the only writer of
+        # events.jsonl. Pre-fix this test inherited PR ζ's default-ON
+        # ES gate and silently exercised the ES write path while
+        # purporting to test shadow round-trip — passing for the
+        # wrong reason because ES also writes events.jsonl.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
         monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
         cat_dir = tmp_path / "catalog"
         cat_dir.mkdir()
@@ -309,6 +316,70 @@ class TestShadowReplayRoundTrip:
             # Links: both should be empty (link + unlink + delete leave 0 links).
             assert live_conn.execute("SELECT COUNT(*) FROM links").fetchone()[0] == 0
             assert proj_conn.execute("SELECT COUNT(*) FROM links").fetchone()[0] == 0
+        finally:
+            live_conn.close()
+            proj_conn.close()
+
+    def test_register_register_link_unlink_delete_under_es(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """ES-mode companion (RDR-101 Phase 3 follow-up C,
+        nexus-o6aa.9.8). The legacy-mode test above pins the shadow
+        path's round-trip invariant; this one exercises the same
+        register/link/unlink/delete sequence under
+        ``NEXUS_EVENT_SOURCED=1`` so the ES write path's events.jsonl
+        is similarly verified to replay into a byte-equal SQLite.
+
+        Without this test, a regression in the ES write path that
+        emits a malformed event (or omits one) would slip through —
+        the shadow-path test above runs only in legacy mode.
+        """
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+
+        owner = cat.register_owner("nexus", "repo", repo_hash="ababab")
+        a = cat.register(owner, "a.md", content_type="prose", file_path="a.md")
+        b = cat.register(owner, "b.md", content_type="prose", file_path="b.md")
+        cat.link(a, b, link_type="cites", created_by="manual")
+        cat.unlink(a, b, link_type="cites")
+        cat.delete_document(b)
+
+        log = EventLog(cat_dir)
+        projected_path = tmp_path / "projected.db"
+        proj_db = CatalogDB(projected_path)
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        live_conn = sqlite3.connect(str(cat_dir / ".catalog.db"))
+        proj_conn = sqlite3.connect(str(projected_path))
+        try:
+            for table in ("owners", "documents"):
+                cur = live_conn.execute(
+                    f"PRAGMA table_info({table})"
+                )
+                cols = ", ".join(r[1] for r in cur.fetchall())
+                live_rows = sorted(live_conn.execute(
+                    f"SELECT {cols} FROM {table} ORDER BY {cols}"
+                ).fetchall())
+                proj_rows = sorted(proj_conn.execute(
+                    f"SELECT {cols} FROM {table} ORDER BY {cols}"
+                ).fetchall())
+                assert live_rows == proj_rows, (
+                    f"ES mode: {table} rows differ:\n"
+                    f"  live:      {live_rows}\n"
+                    f"  projected: {proj_rows}"
+                )
+            assert live_conn.execute(
+                "SELECT COUNT(*) FROM links",
+            ).fetchone()[0] == 0
+            assert proj_conn.execute(
+                "SELECT COUNT(*) FROM links",
+            ).fetchone()[0] == 0
         finally:
             live_conn.close()
             proj_conn.close()

--- a/tests/test_no_direct_catalog_writes_outside_projector.py
+++ b/tests/test_no_direct_catalog_writes_outside_projector.py
@@ -44,9 +44,15 @@ ALLOWED_PREFIXES: tuple[str, ...] = (
 )
 
 # Allowlist for tests: lines tagged with this comment token are exempt
-# from the ban. The lint gate enforces that the comment carries a reason
-# (any non-empty trailing text after the colon).
+# from the ban. The lint gate enforces that the comment carries a
+# meaningful reason — at least 8 characters of trailing text after the
+# colon, which forces a short documentary phrase rather than a placeholder.
+# RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8): pre-fix any non-empty
+# string passed; ``# epsilon-allow: x`` was indistinguishable from no
+# reason. Existing fixture allowlist reasons (forced alias cycle, stale
+# span audit, etc.) all pass the 8-char threshold.
 ALLOWLIST_TOKEN = "# epsilon-allow:"
+ALLOWLIST_REASON_MIN_LENGTH = 8
 
 # SQL keywords that mutate catalog state. Every one of these on a
 # ``*._db.execute(<literal>, ...)`` call is a violation when the call
@@ -63,13 +69,55 @@ WRITE_KEYWORDS: frozenset[str] = frozenset({
 })
 
 
-def _is_db_execute_call(node: ast.AST) -> bool:
-    """True if *node* is a ``<expr>._db.execute(...)`` call.
+def _collect_db_aliases(tree: ast.AST) -> frozenset[str]:
+    """Return Name targets that are bound to ``<expr>._db`` somewhere in
+    *tree*. Detects the alias-evasion pattern ``db = cat._db`` (then
+    ``db.execute("DELETE...")``) that the bare ``_db.execute`` AST
+    matcher would miss (deep-analyst review, 2026-05-01: 7 such sites
+    in ``commands/catalog.py`` are currently SELECT-only but one
+    character from a write violation).
 
-    Covers ``cat._db.execute``, ``self._db.execute``,
-    ``catalog._db.execute``, ``foo.bar._db.execute``, etc. Also catches
-    ``executemany`` / ``executescript`` even though no current call site
-    uses them — the lint must remain future-proof.
+    Module-scoped — aliases bound inside one function are visible
+    everywhere. Conservative (false-positive friendly) since the
+    keyword filter still requires the call site to issue a write SQL
+    before the lint flags it.
+    """
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        value = node.value
+        if isinstance(target, ast.Name) and isinstance(value, ast.Attribute):
+            if value.attr == "_db":
+                aliases.add(target.id)
+    return frozenset(aliases)
+
+
+def _receiver_chain_touches_db(receiver: ast.AST) -> bool:
+    """Walk a receiver attribute chain. Return True if any segment is
+    ``_db`` — catches nested patterns like ``cat._db._conn.execute(...)``
+    where the immediate receiver is ``_conn`` but ``_db`` sits one hop
+    above.
+    """
+    cur: ast.AST = receiver
+    while isinstance(cur, ast.Attribute):
+        if cur.attr == "_db":
+            return True
+        cur = cur.value
+    return False
+
+
+def _is_db_execute_call(
+    node: ast.AST, *, db_aliases: frozenset[str] = frozenset(),
+) -> bool:
+    """True if *node* is a ``<expr>._db.execute(...)`` call OR an
+    aliased equivalent (``db = cat._db; db.execute(...)``) OR a nested
+    ``_db.<...>.execute(...)`` chain.
+
+    Covers ``execute`` / ``executemany`` / ``executescript``.
     """
     if not isinstance(node, ast.Call):
         return False
@@ -79,43 +127,90 @@ def _is_db_execute_call(node: ast.AST) -> bool:
     if func.attr not in {"execute", "executemany", "executescript"}:
         return False
     inner = func.value
-    if not isinstance(inner, ast.Attribute):
-        return False
-    return inner.attr == "_db"
+
+    # Direct ``<expr>._db.execute(...)`` — immediate receiver is _db.
+    if isinstance(inner, ast.Attribute) and inner.attr == "_db":
+        return True
+
+    # Aliased ``<name>.execute(...)`` where <name> was bound to ``_db``
+    # somewhere in the module.
+    if isinstance(inner, ast.Name) and inner.id in db_aliases:
+        return True
+
+    # Nested chain ``<expr>._db.<x>.<y>.execute(...)`` — receiver is
+    # an Attribute whose ancestry includes ``_db``. Catches
+    # ``cat._db._conn.execute(...)``.
+    if isinstance(inner, ast.Attribute) and _receiver_chain_touches_db(inner):
+        return True
+
+    return False
 
 
-def _extract_leading_sql_keyword(arg: ast.AST) -> str | None:
-    """Return the first SQL keyword (uppercase) from the SQL literal *arg*.
+def _extract_sql_text(arg: ast.AST) -> str | None:
+    """Recover the literal SQL text from *arg* if possible.
 
-    Handles:
-      * ``ast.Constant`` (plain string literal)
-      * ``ast.JoinedStr`` (f-string) — concatenates leading
-        ``ast.Constant`` segments to recover the literal prefix before
-        the first interpolation.
+    Handles ``ast.Constant`` (plain string literal) and ``ast.JoinedStr``
+    (f-string — concatenates leading ``ast.Constant`` segments to recover
+    the literal prefix before the first interpolation).
 
-    Returns ``None`` for any other node shape (e.g. SQL passed via a
-    variable). Variable-passed SQL is rare in this codebase and the few
-    occurrences will surface in code review.
+    Returns ``None`` for variable-passed SQL or string concatenation
+    (``ast.BinOp``). Those scope boundaries are documented in the
+    negative self-tests below; future expansion would need dataflow,
+    not just AST shape.
     """
     if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
-        text = arg.value
-    elif isinstance(arg, ast.JoinedStr):
+        return arg.value
+    if isinstance(arg, ast.JoinedStr):
         prefix_parts: list[str] = []
         for piece in arg.values:
             if isinstance(piece, ast.Constant) and isinstance(piece.value, str):
                 prefix_parts.append(piece.value)
             else:
                 break
-        text = "".join(prefix_parts)
-    else:
-        return None
+        return "".join(prefix_parts)
+    return None
 
+
+def _extract_leading_sql_keyword(arg: ast.AST) -> str | None:
+    """Return the first SQL keyword (uppercase) from the SQL literal *arg*.
+
+    Returns ``None`` if no keyword can be recovered (variable SQL,
+    empty f-string prefix, etc.).
+    """
+    text = _extract_sql_text(arg)
+    if text is None:
+        return None
     text = text.lstrip()
     if not text:
         return None
+    return text.split(None, 1)[0].upper().rstrip(";")
 
-    first_token = text.split(None, 1)[0].upper().rstrip(";")
-    return first_token
+
+def _extract_all_sql_keywords(arg: ast.AST) -> list[str]:
+    """Return every leading-statement keyword from a multi-statement
+    SQL string. ``executescript`` accepts a script of ``;``-delimited
+    statements; the leading-keyword check would miss a write hiding
+    after a benign first statement (e.g. ``"SELECT 1; DELETE FROM
+    documents"``). Walk every statement and return its leading
+    keyword.
+
+    For non-script callers (``execute``, ``executemany``) this is
+    typically a single-element list; the caller still benefits from
+    the multi-statement scan since SQLite happily accepts trailing
+    statements in ``execute()`` too.
+    """
+    text = _extract_sql_text(arg)
+    if text is None:
+        return []
+    keywords: list[str] = []
+    for stmt in text.split(";"):
+        stripped = stmt.lstrip()
+        if not stripped:
+            continue
+        kw = stripped.split(None, 1)[0].upper().rstrip(";")
+        if kw:
+            keywords.append(kw)
+    return keywords
 
 
 def _line_has_allowlist_marker(source_lines: list[str], lineno: int) -> bool:
@@ -142,7 +237,7 @@ def _line_has_allowlist_marker(source_lines: list[str], lineno: int) -> bool:
         if token_pos < 0:
             continue
         reason = line[token_pos + len(ALLOWLIST_TOKEN):].strip()
-        if reason:
+        if len(reason) >= ALLOWLIST_REASON_MIN_LENGTH:
             return True
         # Token without reason text — keep scanning; the file may have
         # the canonical marker further down.
@@ -167,16 +262,23 @@ def _scan_file(path: pathlib.Path, *, allow_marker: bool) -> list[str]:
 
     source_lines = source.splitlines()
     violations: list[str] = []
+    db_aliases = _collect_db_aliases(tree)
 
     for node in ast.walk(tree):
-        if not _is_db_execute_call(node):
+        if not _is_db_execute_call(node, db_aliases=db_aliases):
             continue
         if not node.args:
             continue
 
-        keyword = _extract_leading_sql_keyword(node.args[0])
-        if keyword is None or keyword not in WRITE_KEYWORDS:
+        # ``executescript`` accepts a ``;``-delimited script; check
+        # every statement's leading keyword. ``execute`` and
+        # ``executemany`` typically take a single statement but SQLite
+        # tolerates trailing ones, so the same scan applies.
+        keywords = _extract_all_sql_keywords(node.args[0])
+        write_kw = next((k for k in keywords if k in WRITE_KEYWORDS), None)
+        if write_kw is None:
             continue
+        keyword = write_kw
 
         if allow_marker and _line_has_allowlist_marker(source_lines, node.lineno):
             continue
@@ -355,6 +457,26 @@ def test_allowlist_marker_without_reason_does_not_suppress(
     )
 
 
+def test_allowlist_marker_with_trivial_reason_does_not_suppress(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Self-test (nexus-o6aa.9.8): a one- or few-character "reason"
+    after the marker must not suppress. The 8-char minimum forces a
+    short documentary phrase rather than a placeholder.
+    """
+    fake = tmp_path / "fake_trivial_reason.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.execute('UPDATE documents SET x = 1', ())  "
+        "# epsilon-allow: x\n"
+    )
+
+    assert _scan_file(fake, allow_marker=True), (
+        "trivial single-char reason must NOT suppress; require at "
+        "least ALLOWLIST_REASON_MIN_LENGTH chars"
+    )
+
+
 def test_select_calls_are_not_flagged(tmp_path: pathlib.Path) -> None:
     """Self-test: SELECT (and fetchone/fetchall callers) must never be
     flagged. The lint gate is for mutations only.
@@ -364,6 +486,166 @@ def test_select_calls_are_not_flagged(tmp_path: pathlib.Path) -> None:
         "def f(cat):\n"
         "    rows = cat._db.execute('SELECT * FROM documents').fetchall()\n"
         "    return rows\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8): expanded coverage of
+# evasion patterns that the original ε gate missed (substantive-critic
+# + code-review-expert review, 2026-05-01).
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_lint_gate_detects_alias_pattern(tmp_path: pathlib.Path) -> None:
+    """Self-test: the alias-evasion ``db = cat._db; db.execute(...)``
+    pattern must be flagged. ``commands/catalog.py`` already has 7
+    such alias sites (currently SELECT-only) — without this detector
+    a single character change to one of them would slip past the gate.
+    """
+    fake = tmp_path / "fake_alias.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    db = cat._db\n"
+        "    db.execute('DELETE FROM documents WHERE id = ?', (1,))\n"
+    )
+
+    hits = _scan_file(fake, allow_marker=False)
+    assert hits, "alias evasion not flagged — _is_db_execute_call missed it"
+    assert "DELETE" in hits[0]
+
+
+def test_lint_gate_does_not_flag_alias_pattern_for_select(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Self-test: the alias detector is conservative (catches every
+    aliased ``execute`` call) but the keyword filter still requires a
+    write SQL before flagging. Aliased SELECT must pass.
+    """
+    fake = tmp_path / "fake_alias_select.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    db = cat._db\n"
+        "    rows = db.execute('SELECT * FROM documents').fetchall()\n"
+        "    return rows\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == []
+
+
+def test_lint_gate_detects_nested_db_chain(tmp_path: pathlib.Path) -> None:
+    """Self-test: ``cat._db._conn.execute('DELETE...')`` — the
+    immediate receiver is ``_conn`` but ``_db`` is one hop above. The
+    receiver-chain walker must catch this.
+    """
+    fake = tmp_path / "fake_nested.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db._conn.execute('DELETE FROM documents WHERE id = ?', (1,))\n"
+    )
+
+    hits = _scan_file(fake, allow_marker=False)
+    assert hits, "nested _db.<x>.execute chain not flagged"
+    assert "DELETE" in hits[0]
+
+
+def test_lint_gate_detects_executescript_with_trailing_write(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Self-test: ``executescript('SELECT 1; DELETE FROM x')`` — the
+    leading-keyword check would clear it on ``SELECT`` and miss the
+    trailing ``DELETE``. The full-script walker must flag it.
+    """
+    fake = tmp_path / "fake_executescript.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.executescript('SELECT 1; DELETE FROM documents')\n"
+    )
+
+    hits = _scan_file(fake, allow_marker=False)
+    assert hits, "executescript trailing DELETE not flagged"
+    assert "DELETE" in hits[0]
+
+
+def test_lint_gate_does_not_flag_executescript_all_select(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Self-test: ``executescript('SELECT 1; SELECT 2')`` — multiple
+    statements, all reads. Must not be flagged.
+    """
+    fake = tmp_path / "fake_executescript_select.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.executescript('SELECT 1; SELECT 2')\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Documented scope boundaries — patterns the gate intentionally does
+# NOT detect today. Encoded as negative self-tests so the boundary is
+# explicit in code rather than buried in docstring prose; if a future
+# regression makes one of these flag, the developer is forced to
+# decide whether the new behaviour is desired.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_lint_gate_does_not_detect_variable_sql(tmp_path: pathlib.Path) -> None:
+    """Documented scope: SQL passed via a variable (``stmt = "DELETE
+    ..."; cat._db.execute(stmt)``) is not detected. Detection would
+    require dataflow analysis. The pattern is rare in this codebase
+    today; will surface in code review.
+    """
+    fake = tmp_path / "fake_variable_sql.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    stmt = 'DELETE FROM documents WHERE id = ?'\n"
+        "    cat._db.execute(stmt, (1,))\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == [], (
+        "variable-SQL detection unexpectedly enabled — review the gate "
+        "design before pruning this negative test"
+    )
+
+
+def test_lint_gate_does_not_detect_string_concat(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Documented scope: SQL constructed via ``+`` concatenation
+    (``cat._db.execute("DELETE" + " FROM documents")``) is not
+    detected — the AST node is ``ast.BinOp``, not ``ast.Constant`` or
+    ``ast.JoinedStr``. The pattern is unidiomatic; SQL formatting via
+    Python ``%`` / ``.format`` / explicit ``+`` is a security
+    anti-pattern (parameter binding fixes injection without breaking
+    the gate).
+    """
+    fake = tmp_path / "fake_concat.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.execute('DELETE' + ' FROM documents WHERE id = ?', (1,))\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == []
+
+
+def test_lint_gate_does_not_detect_fstring_with_interpolated_first_token(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Documented scope: f-string where the leading SQL keyword sits
+    inside an interpolated expression (``f"{op} FROM documents"``).
+    The ``ast.JoinedStr`` value list starts with a ``FormattedValue``,
+    not an ``ast.Constant``, so the leading-keyword extractor returns
+    empty. Detection would require constant-folding of the
+    interpolated expression — not worth the implementation cost for
+    a pattern that does not occur today.
+    """
+    fake = tmp_path / "fake_fstring_interp.py"
+    fake.write_text(
+        "def f(cat, op):\n"
+        "    cat._db.execute(f'{op} FROM documents WHERE id = ?', (1,))\n"
     )
 
     assert _scan_file(fake, allow_marker=False) == []

--- a/tests/test_rdr101_round3_correctness.py
+++ b/tests/test_rdr101_round3_correctness.py
@@ -595,6 +595,62 @@ class TestLegacyUpdateAliasOfColumn:
             "rec_dict['alias_of'] is not threaded through"
         )
 
+    def test_explicit_alias_of_in_es_fields_lands(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8): the
+        legacy-path coverage of the round-4 ``rec_dict['alias_of']``
+        threading fix did not have an ES-mode counterpart. Without
+        this test, a regression in the ES write path that silently
+        drops caller-supplied ``alias_of`` would not be caught.
+
+        Run the same scenario under ``NEXUS_EVENT_SOURCED=1`` so the
+        update emits a ``DocumentRegistered`` event AND projects to
+        SQLite. Both surfaces must reflect the explicit ``alias_of``.
+        """
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose")
+        b = cat.register(owner, "b.md", content_type="prose")
+        cat.update(a, alias_of=str(b))
+
+        # Live SQLite (post-projection).
+        live_row = cat._db.execute(
+            "SELECT alias_of FROM documents WHERE tumbler = ?",
+            (str(a),),
+        ).fetchone()
+        assert live_row[0] == str(b), (
+            "ES update(t, alias_of='X') silently dropped the value — "
+            "rec_dict['alias_of'] is not threaded through to the "
+            "event payload OR the projection"
+        )
+
+        # Replay the event log into a fresh DB and assert the
+        # projection still carries the alias_of. This confirms the
+        # event payload itself (not just the live SQLite write)
+        # carries the value.
+        from nexus.catalog.event_log import EventLog
+        from nexus.catalog.projector import Projector
+        from nexus.catalog.catalog_db import CatalogDB
+
+        replay_db = CatalogDB(tmp_path / "replay.db")
+        try:
+            Projector(replay_db).apply_all(EventLog(d).replay())
+            replay_row = replay_db.execute(
+                "SELECT alias_of FROM documents WHERE tumbler = ?",
+                (str(a),),
+            ).fetchone()
+            assert replay_row[0] == str(b), (
+                "ES event log does not carry alias_of — replay produces "
+                "a projection with empty alias_of, breaking replay-equality"
+            )
+        finally:
+            replay_db.close()
+
 
 # ── Cached projector ─────────────────────────────────────────────────────
 

--- a/tests/test_rdr101_round3_correctness.py
+++ b/tests/test_rdr101_round3_correctness.py
@@ -372,7 +372,16 @@ class TestEnsureConsistentEventSourced:
         d.mkdir()
         cat_a = Catalog(d, d / ".catalog.db")
         owner = cat_a.register_owner("nexus", "repo", repo_hash="abab")
+        # Register enough documents that the bootstrap guardrail
+        # (RDR-101 Phase 3 follow-up B floor at 1) unambiguously
+        # passes — leaving the v:1 raise as the failure path the
+        # test is exercising. With one document, a poisoned v:1
+        # DocumentDeleted decrements event_doc_count to 0 < 1, the
+        # guardrail fires before the rebuild attempt, and the
+        # atomicity invariant has nothing to assert against.
         a = cat_a.register(owner, "a.md", content_type="prose")
+        cat_a.register(owner, "b.md", content_type="prose")
+        cat_a.register(owner, "c.md", content_type="prose")
         cat_a._db.close()
 
         # Append a v: 1 event after the legitimate v: 0 events. The


### PR DESCRIPTION
**Stacked on #450 → #449.** Will rebase to main once parents merge.

## Summary

Bundle of cleanup items from the convergent review (substantive-critic + deep-analyst + code-review-expert + test-validator, 2026-05-01). Companion to PR #449 (atomic dedupe) and PR #450 (bootstrap guardrail).

## Lint gate hardening (C5)

- **Alias detection** — ``db = cat._db; db.execute("DELETE...")`` now caught. ``commands/catalog.py`` already has 7 SELECT-only alias sites; one character from a write violation pre-fix.
- **Nested chain detection** — ``cat._db._conn.execute(...)`` caught via receiver-chain walker.
- **executescript multi-statement** — ``executescript("SELECT 1; DELETE FROM ...")`` now caught (full-script keyword scan instead of leading-keyword).
- **Negative self-tests for documented blind spots** — variable SQL, string concatenation, f-string-with-interpolated-leading-token are intentionally NOT detected (would require dataflow). Encoded as negative self-tests so the boundary is explicit in code.
- **Allowlist reason length floor (S1)** — ``# epsilon-allow: x`` no longer passes (8-char minimum).

## Other cleanup

- **Mistyped opt-out warning (I2)** — ``NEXUS_EVENT_SOURCED=ofg`` / ``nope`` / ``legacy`` now logs a structured warning once per process. Pre-fix any unrecognized value silently activated ES under the new default-ON semantics.
- **OwnerDeleted cascade + empty-id (I4 + S2)** — projector ``_v0_owner_deleted`` now logs a structured warning when an owner has extant document descendants (protocol violation: DocumentDeleted must precede OwnerDeleted) or when the payload's ``owner_id`` is empty. Pre-fix both were silent.
- **ES ``alias_of`` test counterpart (I5)** — round-4 ``rec_dict["alias_of"]`` threading is now tested under ``NEXUS_EVENT_SOURCED=1``, including a replay-equality assertion. Pre-fix the ES path could have silently dropped ``alias_of`` and the legacy-only test wouldn't have caught it.
- **Shadow round-trip ES companion (I6)** — ``test_register_register_link_unlink_delete`` pinned to legacy explicitly (was silently testing ES under ζ default and passing for the wrong reason). New ``..._under_es`` companion test added.
- **``event_doc_count`` rename (S3)** — renamed to ``net_registered`` to reflect that the variable can legitimately go negative.
- **``ALL_EVENT_TYPES`` membership (S4)** — count assertion replaced with explicit set membership comparison; future drift fails with a diagnostic naming the added/removed types.

## I1 note

The ``dedupe.py`` import refactor was already done in PR #449 (bead A). No-op here.

## Verification

Targeted RDR-101 sweep (``catalog or event_log or projector or rdr101 or dedupe or doctor or no_direct_catalog_writes or bootstrap``): **998 passed, 1 skipped, 5366 deselected**.

## Refs

- Bead: ``nexus-o6aa.9.8`` (P2, parent: ``nexus-o6aa.9``)
- Depends on: ``nexus-o6aa.9.6`` (#449) + ``nexus-o6aa.9.7`` (#450)