### PR TITLE
fix(rdr-101): phase 3 cleanup — lint gate hardening + cascade + ES coverage gaps (nexus-o6aa.9.8)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -489,3 +489,4 @@
 {"id":"int-6ec1eb80","kind":"field_change","created_at":"2026-05-01T21:12:49.747406Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 {"id":"int-ec93c5c9","kind":"field_change","created_at":"2026-05-01T21:30:22.984073Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.6","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-81a4170f","kind":"field_change","created_at":"2026-05-01T21:36:40.061953Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.7","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-140c3f2b","kind":"field_change","created_at":"2026-05-01T21:51:50.743853Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.8","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -50,17 +50,46 @@ def _read_shadow_gate() -> bool:
     return val in ("1", "true", "yes", "on")
 
 
+_KNOWN_EVENT_SOURCED_VALUES: frozenset[str] = frozenset(
+    ("", "0", "1", "true", "false", "yes", "no", "on", "off"),
+)
+# Module-scoped sentinel — log the unrecognized-value warning at most
+# once per process so a tight loop reading the gate doesn't spam logs.
+_unrecognized_event_sourced_value_logged: set[str] = set()
+
+
 def _read_event_sourced_gate() -> bool:
     """Return True when the event-sourced write path is enabled.
 
     RDR-101 Phase 3 PR ζ: the default is ON. ``NEXUS_EVENT_SOURCED``
-    unset or set to any non-falsy value enables ES mode. Explicit
-    ``0`` / ``false`` / ``no`` / ``off`` opts back into the legacy
-    direct-write path.
+    unset or set to ``1`` / ``true`` / ``yes`` / ``on`` (or empty)
+    enables ES mode. Explicit ``0`` / ``false`` / ``no`` / ``off``
+    opts back into the legacy direct-write path.
+
+    RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8): unrecognized values
+    (typos like ``ofg`` / ``nope`` / ``legacy``) silently activate ES
+    under the new default-ON semantics — pre-fix the gate flipped
+    from safe-by-default (only on for explicit truthy) to dangerous-
+    by-default. Log a structured warning the first time we see an
+    unrecognized value so an operator's typo is detectable.
     """
-    val = os.environ.get(_EVENT_SOURCED_ENV, "").strip().lower()
+    raw = os.environ.get(_EVENT_SOURCED_ENV, "")
+    val = raw.strip().lower()
     if val in ("0", "false", "no", "off"):
         return False
+    if val not in _KNOWN_EVENT_SOURCED_VALUES:
+        if raw not in _unrecognized_event_sourced_value_logged:
+            _unrecognized_event_sourced_value_logged.add(raw)
+            _log.warning(
+                "catalog_event_sourced_gate_unrecognized_value",
+                value=raw,
+                effective="ON",
+                note=(
+                    "NEXUS_EVENT_SOURCED carries an unrecognized value; "
+                    "treating as ON (default). Use 0/false/no/off to "
+                    "opt out, or 1/true/yes/on to make ES explicit."
+                ),
+            )
     return True
 
 
@@ -721,7 +750,14 @@ class Catalog:
                 return True
 
             from nexus.catalog import events as _ev
-            event_doc_count = 0
+            # Net document registrations: DocumentRegistered − DocumentDeleted.
+            # Can go negative (a dedupe-only event stream against a
+            # legacy catalog produces only DocumentDeleted), which the
+            # ``>= threshold`` check below relies on to fall through to
+            # legacy. RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8):
+            # renamed from ``event_doc_count`` to make the negative
+            # values intentional rather than surprising.
+            net_registered = 0
             with self._events_path.open() as f:
                 for line in f:
                     line = line.strip()
@@ -733,9 +769,9 @@ class Catalog:
                         continue
                     t = obj.get("type")
                     if t == _ev.TYPE_DOCUMENT_REGISTERED:
-                        event_doc_count += 1
+                        net_registered += 1
                     elif t == _ev.TYPE_DOCUMENT_DELETED:
-                        event_doc_count -= 1
+                        net_registered -= 1
 
             # RDR-101 Phase 3 follow-up B (nexus-o6aa.9.7): floor the
             # threshold at 1. ``int(1 * 0.95) == 0`` and ``0 >= 0`` is
@@ -749,7 +785,7 @@ class Catalog:
             # log before ES rebuild is allowed at the smallest catalog
             # sizes.
             threshold = max(1, int(legacy_doc_count * 0.95))
-            return event_doc_count >= threshold
+            return net_registered >= threshold
         except Exception:
             # On any unexpected failure, refuse the event-sourced
             # rebuild (safer to fall through to legacy than to wipe).

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -141,7 +141,44 @@ class Projector:
         # DocumentDeleted events; we do not cascade here because the
         # projection contract is one event = one row mutation.
         if not payload.owner_id:
+            # nexus-o6aa.9.8: malformed event (hand-emitted, synthesis
+            # bug, or a future v: 1 path that didn't populate the
+            # field). Surface it in the structured log rather than
+            # silently absorbing — replay should be observable.
+            _log.warning(
+                "projector_owner_deleted_no_owner_id",
+                payload=str(payload),
+            )
             return
+
+        # nexus-o6aa.9.8: protocol invariant — OwnerDeleted MUST be
+        # preceded by DocumentDeleted events for every document under
+        # the owner. The projection contract has no FK CASCADE; if a
+        # caller emits OwnerDeleted while documents under the prefix
+        # still exist in SQLite, the orphaned rows point at a
+        # non-existent owner. Surface this so a hand-emitted or
+        # synthesis-driven OwnerDeleted that skipped its DocumentDeleted
+        # prerequisites lands as a loud structured warning rather than
+        # a silently corrupted projection.
+        descendants = self._db.execute(
+            "SELECT COUNT(*) FROM documents WHERE tumbler LIKE ?",
+            (f"{payload.owner_id}.%",),
+        ).fetchone()
+        descendant_count = descendants[0] if descendants else 0
+        if descendant_count > 0:
+            _log.warning(
+                "projector_owner_deleted_with_extant_documents",
+                owner_id=payload.owner_id,
+                descendant_count=descendant_count,
+                note=(
+                    "OwnerDeleted projected while documents under the "
+                    "owner prefix still exist; protocol requires "
+                    "DocumentDeleted for every descendant first. "
+                    "Orphaned document rows now point at a non-existent "
+                    "owner."
+                ),
+            )
+
         self._db.execute(
             "DELETE FROM owners WHERE tumbler_prefix = ?",
             (payload.owner_id,),

--- a/tests/test_catalog_events.py
+++ b/tests/test_catalog_events.py
@@ -69,10 +69,32 @@ class TestPayloadRegistry:
         assert ev.payload_class("FutureEventType") is None
 
     def test_event_type_count_matches_rdr_101(self):
-        # RDR-101 §Event log enumerated 12 event types at Phase 1; Phase 3
-        # follow-up nexus-o6aa.9.4 added OwnerDeleted (v: 0 dedupe path).
-        # Update this assertion alongside any addition.
-        assert len(ev.ALL_EVENT_TYPES) == 13
+        # RDR-101 §Event log enumerated 12 event types at Phase 1;
+        # Phase 3 follow-up nexus-o6aa.9.4 added OwnerDeleted (v: 0
+        # dedupe path). Asserting both the count AND the explicit
+        # set membership so a future addition fails with a clear
+        # diagnostic instead of an opaque count mismatch (RDR-101
+        # Phase 3 follow-up C, nexus-o6aa.9.8).
+        expected = {
+            ev.TYPE_OWNER_REGISTERED,
+            ev.TYPE_OWNER_DELETED,  # added Phase 3 follow-up
+            ev.TYPE_COLLECTION_CREATED,
+            ev.TYPE_COLLECTION_SUPERSEDED,
+            ev.TYPE_DOCUMENT_REGISTERED,
+            ev.TYPE_DOCUMENT_RENAMED,
+            ev.TYPE_DOCUMENT_ALIASED,
+            ev.TYPE_DOCUMENT_ENRICHED,
+            ev.TYPE_DOCUMENT_DELETED,
+            ev.TYPE_CHUNK_INDEXED,
+            ev.TYPE_CHUNK_ORPHANED,
+            ev.TYPE_LINK_CREATED,
+            ev.TYPE_LINK_DELETED,
+        }
+        assert ev.ALL_EVENT_TYPES == expected, (
+            f"event-type set drifted; difference: "
+            f"added={ev.ALL_EVENT_TYPES - expected} "
+            f"removed={expected - ev.ALL_EVENT_TYPES}"
+        )
 
 
 class TestEnvelopeRoundtrip:

--- a/tests/test_catalog_shadow_emit.py
+++ b/tests/test_catalog_shadow_emit.py
@@ -265,6 +265,13 @@ class TestShadowReplayRoundTrip:
     def test_register_register_link_unlink_delete(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ):
+        # RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8): pin to legacy
+        # explicitly so the shadow path is the only writer of
+        # events.jsonl. Pre-fix this test inherited PR ζ's default-ON
+        # ES gate and silently exercised the ES write path while
+        # purporting to test shadow round-trip — passing for the
+        # wrong reason because ES also writes events.jsonl.
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
         monkeypatch.setenv("NEXUS_EVENT_LOG_SHADOW", "1")
         cat_dir = tmp_path / "catalog"
         cat_dir.mkdir()
@@ -309,6 +316,70 @@ class TestShadowReplayRoundTrip:
             # Links: both should be empty (link + unlink + delete leave 0 links).
             assert live_conn.execute("SELECT COUNT(*) FROM links").fetchone()[0] == 0
             assert proj_conn.execute("SELECT COUNT(*) FROM links").fetchone()[0] == 0
+        finally:
+            live_conn.close()
+            proj_conn.close()
+
+    def test_register_register_link_unlink_delete_under_es(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """ES-mode companion (RDR-101 Phase 3 follow-up C,
+        nexus-o6aa.9.8). The legacy-mode test above pins the shadow
+        path's round-trip invariant; this one exercises the same
+        register/link/unlink/delete sequence under
+        ``NEXUS_EVENT_SOURCED=1`` so the ES write path's events.jsonl
+        is similarly verified to replay into a byte-equal SQLite.
+
+        Without this test, a regression in the ES write path that
+        emits a malformed event (or omits one) would slip through —
+        the shadow-path test above runs only in legacy mode.
+        """
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+
+        owner = cat.register_owner("nexus", "repo", repo_hash="ababab")
+        a = cat.register(owner, "a.md", content_type="prose", file_path="a.md")
+        b = cat.register(owner, "b.md", content_type="prose", file_path="b.md")
+        cat.link(a, b, link_type="cites", created_by="manual")
+        cat.unlink(a, b, link_type="cites")
+        cat.delete_document(b)
+
+        log = EventLog(cat_dir)
+        projected_path = tmp_path / "projected.db"
+        proj_db = CatalogDB(projected_path)
+        try:
+            Projector(proj_db).apply_all(log.replay())
+        finally:
+            proj_db.close()
+
+        live_conn = sqlite3.connect(str(cat_dir / ".catalog.db"))
+        proj_conn = sqlite3.connect(str(projected_path))
+        try:
+            for table in ("owners", "documents"):
+                cur = live_conn.execute(
+                    f"PRAGMA table_info({table})"
+                )
+                cols = ", ".join(r[1] for r in cur.fetchall())
+                live_rows = sorted(live_conn.execute(
+                    f"SELECT {cols} FROM {table} ORDER BY {cols}"
+                ).fetchall())
+                proj_rows = sorted(proj_conn.execute(
+                    f"SELECT {cols} FROM {table} ORDER BY {cols}"
+                ).fetchall())
+                assert live_rows == proj_rows, (
+                    f"ES mode: {table} rows differ:\n"
+                    f"  live:      {live_rows}\n"
+                    f"  projected: {proj_rows}"
+                )
+            assert live_conn.execute(
+                "SELECT COUNT(*) FROM links",
+            ).fetchone()[0] == 0
+            assert proj_conn.execute(
+                "SELECT COUNT(*) FROM links",
+            ).fetchone()[0] == 0
         finally:
             live_conn.close()
             proj_conn.close()

--- a/tests/test_no_direct_catalog_writes_outside_projector.py
+++ b/tests/test_no_direct_catalog_writes_outside_projector.py
@@ -44,9 +44,15 @@ ALLOWED_PREFIXES: tuple[str, ...] = (
 )
 
 # Allowlist for tests: lines tagged with this comment token are exempt
-# from the ban. The lint gate enforces that the comment carries a reason
-# (any non-empty trailing text after the colon).
+# from the ban. The lint gate enforces that the comment carries a
+# meaningful reason — at least 8 characters of trailing text after the
+# colon, which forces a short documentary phrase rather than a placeholder.
+# RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8): pre-fix any non-empty
+# string passed; ``# epsilon-allow: x`` was indistinguishable from no
+# reason. Existing fixture allowlist reasons (forced alias cycle, stale
+# span audit, etc.) all pass the 8-char threshold.
 ALLOWLIST_TOKEN = "# epsilon-allow:"
+ALLOWLIST_REASON_MIN_LENGTH = 8
 
 # SQL keywords that mutate catalog state. Every one of these on a
 # ``*._db.execute(<literal>, ...)`` call is a violation when the call
@@ -63,13 +69,55 @@ WRITE_KEYWORDS: frozenset[str] = frozenset({
 })
 
 
-def _is_db_execute_call(node: ast.AST) -> bool:
-    """True if *node* is a ``<expr>._db.execute(...)`` call.
+def _collect_db_aliases(tree: ast.AST) -> frozenset[str]:
+    """Return Name targets that are bound to ``<expr>._db`` somewhere in
+    *tree*. Detects the alias-evasion pattern ``db = cat._db`` (then
+    ``db.execute("DELETE...")``) that the bare ``_db.execute`` AST
+    matcher would miss (deep-analyst review, 2026-05-01: 7 such sites
+    in ``commands/catalog.py`` are currently SELECT-only but one
+    character from a write violation).
 
-    Covers ``cat._db.execute``, ``self._db.execute``,
-    ``catalog._db.execute``, ``foo.bar._db.execute``, etc. Also catches
-    ``executemany`` / ``executescript`` even though no current call site
-    uses them — the lint must remain future-proof.
+    Module-scoped — aliases bound inside one function are visible
+    everywhere. Conservative (false-positive friendly) since the
+    keyword filter still requires the call site to issue a write SQL
+    before the lint flags it.
+    """
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        value = node.value
+        if isinstance(target, ast.Name) and isinstance(value, ast.Attribute):
+            if value.attr == "_db":
+                aliases.add(target.id)
+    return frozenset(aliases)
+
+
+def _receiver_chain_touches_db(receiver: ast.AST) -> bool:
+    """Walk a receiver attribute chain. Return True if any segment is
+    ``_db`` — catches nested patterns like ``cat._db._conn.execute(...)``
+    where the immediate receiver is ``_conn`` but ``_db`` sits one hop
+    above.
+    """
+    cur: ast.AST = receiver
+    while isinstance(cur, ast.Attribute):
+        if cur.attr == "_db":
+            return True
+        cur = cur.value
+    return False
+
+
+def _is_db_execute_call(
+    node: ast.AST, *, db_aliases: frozenset[str] = frozenset(),
+) -> bool:
+    """True if *node* is a ``<expr>._db.execute(...)`` call OR an
+    aliased equivalent (``db = cat._db; db.execute(...)``) OR a nested
+    ``_db.<...>.execute(...)`` chain.
+
+    Covers ``execute`` / ``executemany`` / ``executescript``.
     """
     if not isinstance(node, ast.Call):
         return False
@@ -79,43 +127,90 @@ def _is_db_execute_call(node: ast.AST) -> bool:
     if func.attr not in {"execute", "executemany", "executescript"}:
         return False
     inner = func.value
-    if not isinstance(inner, ast.Attribute):
-        return False
-    return inner.attr == "_db"
+
+    # Direct ``<expr>._db.execute(...)`` — immediate receiver is _db.
+    if isinstance(inner, ast.Attribute) and inner.attr == "_db":
+        return True
+
+    # Aliased ``<name>.execute(...)`` where <name> was bound to ``_db``
+    # somewhere in the module.
+    if isinstance(inner, ast.Name) and inner.id in db_aliases:
+        return True
+
+    # Nested chain ``<expr>._db.<x>.<y>.execute(...)`` — receiver is
+    # an Attribute whose ancestry includes ``_db``. Catches
+    # ``cat._db._conn.execute(...)``.
+    if isinstance(inner, ast.Attribute) and _receiver_chain_touches_db(inner):
+        return True
+
+    return False
 
 
-def _extract_leading_sql_keyword(arg: ast.AST) -> str | None:
-    """Return the first SQL keyword (uppercase) from the SQL literal *arg*.
+def _extract_sql_text(arg: ast.AST) -> str | None:
+    """Recover the literal SQL text from *arg* if possible.
 
-    Handles:
-      * ``ast.Constant`` (plain string literal)
-      * ``ast.JoinedStr`` (f-string) — concatenates leading
-        ``ast.Constant`` segments to recover the literal prefix before
-        the first interpolation.
+    Handles ``ast.Constant`` (plain string literal) and ``ast.JoinedStr``
+    (f-string — concatenates leading ``ast.Constant`` segments to recover
+    the literal prefix before the first interpolation).
 
-    Returns ``None`` for any other node shape (e.g. SQL passed via a
-    variable). Variable-passed SQL is rare in this codebase and the few
-    occurrences will surface in code review.
+    Returns ``None`` for variable-passed SQL or string concatenation
+    (``ast.BinOp``). Those scope boundaries are documented in the
+    negative self-tests below; future expansion would need dataflow,
+    not just AST shape.
     """
     if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
-        text = arg.value
-    elif isinstance(arg, ast.JoinedStr):
+        return arg.value
+    if isinstance(arg, ast.JoinedStr):
         prefix_parts: list[str] = []
         for piece in arg.values:
             if isinstance(piece, ast.Constant) and isinstance(piece.value, str):
                 prefix_parts.append(piece.value)
             else:
                 break
-        text = "".join(prefix_parts)
-    else:
-        return None
+        return "".join(prefix_parts)
+    return None
 
+
+def _extract_leading_sql_keyword(arg: ast.AST) -> str | None:
+    """Return the first SQL keyword (uppercase) from the SQL literal *arg*.
+
+    Returns ``None`` if no keyword can be recovered (variable SQL,
+    empty f-string prefix, etc.).
+    """
+    text = _extract_sql_text(arg)
+    if text is None:
+        return None
     text = text.lstrip()
     if not text:
         return None
+    return text.split(None, 1)[0].upper().rstrip(";")
 
-    first_token = text.split(None, 1)[0].upper().rstrip(";")
-    return first_token
+
+def _extract_all_sql_keywords(arg: ast.AST) -> list[str]:
+    """Return every leading-statement keyword from a multi-statement
+    SQL string. ``executescript`` accepts a script of ``;``-delimited
+    statements; the leading-keyword check would miss a write hiding
+    after a benign first statement (e.g. ``"SELECT 1; DELETE FROM
+    documents"``). Walk every statement and return its leading
+    keyword.
+
+    For non-script callers (``execute``, ``executemany``) this is
+    typically a single-element list; the caller still benefits from
+    the multi-statement scan since SQLite happily accepts trailing
+    statements in ``execute()`` too.
+    """
+    text = _extract_sql_text(arg)
+    if text is None:
+        return []
+    keywords: list[str] = []
+    for stmt in text.split(";"):
+        stripped = stmt.lstrip()
+        if not stripped:
+            continue
+        kw = stripped.split(None, 1)[0].upper().rstrip(";")
+        if kw:
+            keywords.append(kw)
+    return keywords
 
 
 def _line_has_allowlist_marker(source_lines: list[str], lineno: int) -> bool:
@@ -142,7 +237,7 @@ def _line_has_allowlist_marker(source_lines: list[str], lineno: int) -> bool:
         if token_pos < 0:
             continue
         reason = line[token_pos + len(ALLOWLIST_TOKEN):].strip()
-        if reason:
+        if len(reason) >= ALLOWLIST_REASON_MIN_LENGTH:
             return True
         # Token without reason text — keep scanning; the file may have
         # the canonical marker further down.
@@ -167,16 +262,23 @@ def _scan_file(path: pathlib.Path, *, allow_marker: bool) -> list[str]:
 
     source_lines = source.splitlines()
     violations: list[str] = []
+    db_aliases = _collect_db_aliases(tree)
 
     for node in ast.walk(tree):
-        if not _is_db_execute_call(node):
+        if not _is_db_execute_call(node, db_aliases=db_aliases):
             continue
         if not node.args:
             continue
 
-        keyword = _extract_leading_sql_keyword(node.args[0])
-        if keyword is None or keyword not in WRITE_KEYWORDS:
+        # ``executescript`` accepts a ``;``-delimited script; check
+        # every statement's leading keyword. ``execute`` and
+        # ``executemany`` typically take a single statement but SQLite
+        # tolerates trailing ones, so the same scan applies.
+        keywords = _extract_all_sql_keywords(node.args[0])
+        write_kw = next((k for k in keywords if k in WRITE_KEYWORDS), None)
+        if write_kw is None:
             continue
+        keyword = write_kw
 
         if allow_marker and _line_has_allowlist_marker(source_lines, node.lineno):
             continue
@@ -355,6 +457,26 @@ def test_allowlist_marker_without_reason_does_not_suppress(
     )
 
 
+def test_allowlist_marker_with_trivial_reason_does_not_suppress(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Self-test (nexus-o6aa.9.8): a one- or few-character "reason"
+    after the marker must not suppress. The 8-char minimum forces a
+    short documentary phrase rather than a placeholder.
+    """
+    fake = tmp_path / "fake_trivial_reason.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.execute('UPDATE documents SET x = 1', ())  "
+        "# epsilon-allow: x\n"
+    )
+
+    assert _scan_file(fake, allow_marker=True), (
+        "trivial single-char reason must NOT suppress; require at "
+        "least ALLOWLIST_REASON_MIN_LENGTH chars"
+    )
+
+
 def test_select_calls_are_not_flagged(tmp_path: pathlib.Path) -> None:
     """Self-test: SELECT (and fetchone/fetchall callers) must never be
     flagged. The lint gate is for mutations only.
@@ -364,6 +486,166 @@ def test_select_calls_are_not_flagged(tmp_path: pathlib.Path) -> None:
         "def f(cat):\n"
         "    rows = cat._db.execute('SELECT * FROM documents').fetchall()\n"
         "    return rows\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8): expanded coverage of
+# evasion patterns that the original ε gate missed (substantive-critic
+# + code-review-expert review, 2026-05-01).
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_lint_gate_detects_alias_pattern(tmp_path: pathlib.Path) -> None:
+    """Self-test: the alias-evasion ``db = cat._db; db.execute(...)``
+    pattern must be flagged. ``commands/catalog.py`` already has 7
+    such alias sites (currently SELECT-only) — without this detector
+    a single character change to one of them would slip past the gate.
+    """
+    fake = tmp_path / "fake_alias.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    db = cat._db\n"
+        "    db.execute('DELETE FROM documents WHERE id = ?', (1,))\n"
+    )
+
+    hits = _scan_file(fake, allow_marker=False)
+    assert hits, "alias evasion not flagged — _is_db_execute_call missed it"
+    assert "DELETE" in hits[0]
+
+
+def test_lint_gate_does_not_flag_alias_pattern_for_select(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Self-test: the alias detector is conservative (catches every
+    aliased ``execute`` call) but the keyword filter still requires a
+    write SQL before flagging. Aliased SELECT must pass.
+    """
+    fake = tmp_path / "fake_alias_select.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    db = cat._db\n"
+        "    rows = db.execute('SELECT * FROM documents').fetchall()\n"
+        "    return rows\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == []
+
+
+def test_lint_gate_detects_nested_db_chain(tmp_path: pathlib.Path) -> None:
+    """Self-test: ``cat._db._conn.execute('DELETE...')`` — the
+    immediate receiver is ``_conn`` but ``_db`` is one hop above. The
+    receiver-chain walker must catch this.
+    """
+    fake = tmp_path / "fake_nested.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db._conn.execute('DELETE FROM documents WHERE id = ?', (1,))\n"
+    )
+
+    hits = _scan_file(fake, allow_marker=False)
+    assert hits, "nested _db.<x>.execute chain not flagged"
+    assert "DELETE" in hits[0]
+
+
+def test_lint_gate_detects_executescript_with_trailing_write(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Self-test: ``executescript('SELECT 1; DELETE FROM x')`` — the
+    leading-keyword check would clear it on ``SELECT`` and miss the
+    trailing ``DELETE``. The full-script walker must flag it.
+    """
+    fake = tmp_path / "fake_executescript.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.executescript('SELECT 1; DELETE FROM documents')\n"
+    )
+
+    hits = _scan_file(fake, allow_marker=False)
+    assert hits, "executescript trailing DELETE not flagged"
+    assert "DELETE" in hits[0]
+
+
+def test_lint_gate_does_not_flag_executescript_all_select(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Self-test: ``executescript('SELECT 1; SELECT 2')`` — multiple
+    statements, all reads. Must not be flagged.
+    """
+    fake = tmp_path / "fake_executescript_select.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.executescript('SELECT 1; SELECT 2')\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Documented scope boundaries — patterns the gate intentionally does
+# NOT detect today. Encoded as negative self-tests so the boundary is
+# explicit in code rather than buried in docstring prose; if a future
+# regression makes one of these flag, the developer is forced to
+# decide whether the new behaviour is desired.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_lint_gate_does_not_detect_variable_sql(tmp_path: pathlib.Path) -> None:
+    """Documented scope: SQL passed via a variable (``stmt = "DELETE
+    ..."; cat._db.execute(stmt)``) is not detected. Detection would
+    require dataflow analysis. The pattern is rare in this codebase
+    today; will surface in code review.
+    """
+    fake = tmp_path / "fake_variable_sql.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    stmt = 'DELETE FROM documents WHERE id = ?'\n"
+        "    cat._db.execute(stmt, (1,))\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == [], (
+        "variable-SQL detection unexpectedly enabled — review the gate "
+        "design before pruning this negative test"
+    )
+
+
+def test_lint_gate_does_not_detect_string_concat(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Documented scope: SQL constructed via ``+`` concatenation
+    (``cat._db.execute("DELETE" + " FROM documents")``) is not
+    detected — the AST node is ``ast.BinOp``, not ``ast.Constant`` or
+    ``ast.JoinedStr``. The pattern is unidiomatic; SQL formatting via
+    Python ``%`` / ``.format`` / explicit ``+`` is a security
+    anti-pattern (parameter binding fixes injection without breaking
+    the gate).
+    """
+    fake = tmp_path / "fake_concat.py"
+    fake.write_text(
+        "def f(cat):\n"
+        "    cat._db.execute('DELETE' + ' FROM documents WHERE id = ?', (1,))\n"
+    )
+
+    assert _scan_file(fake, allow_marker=False) == []
+
+
+def test_lint_gate_does_not_detect_fstring_with_interpolated_first_token(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Documented scope: f-string where the leading SQL keyword sits
+    inside an interpolated expression (``f"{op} FROM documents"``).
+    The ``ast.JoinedStr`` value list starts with a ``FormattedValue``,
+    not an ``ast.Constant``, so the leading-keyword extractor returns
+    empty. Detection would require constant-folding of the
+    interpolated expression — not worth the implementation cost for
+    a pattern that does not occur today.
+    """
+    fake = tmp_path / "fake_fstring_interp.py"
+    fake.write_text(
+        "def f(cat, op):\n"
+        "    cat._db.execute(f'{op} FROM documents WHERE id = ?', (1,))\n"
     )
 
     assert _scan_file(fake, allow_marker=False) == []

--- a/tests/test_rdr101_round3_correctness.py
+++ b/tests/test_rdr101_round3_correctness.py
@@ -595,6 +595,62 @@ class TestLegacyUpdateAliasOfColumn:
             "rec_dict['alias_of'] is not threaded through"
         )
 
+    def test_explicit_alias_of_in_es_fields_lands(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """RDR-101 Phase 3 follow-up C (nexus-o6aa.9.8): the
+        legacy-path coverage of the round-4 ``rec_dict['alias_of']``
+        threading fix did not have an ES-mode counterpart. Without
+        this test, a regression in the ES write path that silently
+        drops caller-supplied ``alias_of`` would not be caught.
+
+        Run the same scenario under ``NEXUS_EVENT_SOURCED=1`` so the
+        update emits a ``DocumentRegistered`` event AND projects to
+        SQLite. Both surfaces must reflect the explicit ``alias_of``.
+        """
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        monkeypatch.delenv("NEXUS_EVENT_LOG_SHADOW", raising=False)
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        a = cat.register(owner, "a.md", content_type="prose")
+        b = cat.register(owner, "b.md", content_type="prose")
+        cat.update(a, alias_of=str(b))
+
+        # Live SQLite (post-projection).
+        live_row = cat._db.execute(
+            "SELECT alias_of FROM documents WHERE tumbler = ?",
+            (str(a),),
+        ).fetchone()
+        assert live_row[0] == str(b), (
+            "ES update(t, alias_of='X') silently dropped the value — "
+            "rec_dict['alias_of'] is not threaded through to the "
+            "event payload OR the projection"
+        )
+
+        # Replay the event log into a fresh DB and assert the
+        # projection still carries the alias_of. This confirms the
+        # event payload itself (not just the live SQLite write)
+        # carries the value.
+        from nexus.catalog.event_log import EventLog
+        from nexus.catalog.projector import Projector
+        from nexus.catalog.catalog_db import CatalogDB
+
+        replay_db = CatalogDB(tmp_path / "replay.db")
+        try:
+            Projector(replay_db).apply_all(EventLog(d).replay())
+            replay_row = replay_db.execute(
+                "SELECT alias_of FROM documents WHERE tumbler = ?",
+                (str(a),),
+            ).fetchone()
+            assert replay_row[0] == str(b), (
+                "ES event log does not carry alias_of — replay produces "
+                "a projection with empty alias_of, breaking replay-equality"
+            )
+        finally:
+            replay_db.close()
+
 
 # ── Cached projector ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
Replaces #452 (auto-closed when its base feature branch was deleted by #453's merge).

## Summary

Bundle of cleanup items from the convergent review (substantive-critic + deep-analyst + code-review-expert + test-validator, 2026-05-01). Companion to the just-merged #449 (atomic dedupe) and #453 (bootstrap guardrail).

## Lint gate hardening (C5)

- **Alias detection** — ``db = cat._db; db.execute("DELETE...")`` now caught. ``commands/catalog.py`` already has 7 SELECT-only alias sites; one character from a write violation pre-fix.
- **Nested chain detection** — ``cat._db._conn.execute(...)`` caught via receiver-chain walker.
- **executescript multi-statement** — ``executescript("SELECT 1; DELETE FROM ...")`` now caught (full-script keyword scan).
- **Negative self-tests for documented blind spots** — variable SQL, string concatenation, f-string-with-interpolated-leading-token are intentionally NOT detected. Encoded as negative self-tests so the boundary is explicit in code.
- **Allowlist reason length floor (S1)** — ``# epsilon-allow: x`` no longer passes (8-char minimum).

## Other cleanup

- **Mistyped opt-out warning (I2)** — ``NEXUS_EVENT_SOURCED=ofg`` now logs a structured warning once per process.
- **OwnerDeleted cascade + empty-id (I4 + S2)** — projector ``_v0_owner_deleted`` warns on empty ``owner_id`` AND on extant document descendants (protocol violation).
- **ES ``alias_of`` test counterpart (I5)** — round-4 threading is now tested under ``NEXUS_EVENT_SOURCED=1``, including a replay-equality assertion.
- **Shadow round-trip ES companion (I6)** — original test pinned to legacy explicitly (was silently testing ES under ζ default); new ES companion added.
- **``event_doc_count`` rename (S3)** — to ``net_registered``.
- **``ALL_EVENT_TYPES`` membership (S4)** — set comparison instead of count.

## I1 note

The ``dedupe.py`` import refactor was already done in #449 (bead A). No-op here.

## Verification

Targeted RDR-101 sweep: **998 passed, 1 skipped, 5366 deselected**.

## Refs

- Bead: ``nexus-o6aa.9.8`` (P2, parent: ``nexus-o6aa.9``)
- Depends on: ``nexus-o6aa.9.6`` (#449, MERGED) + ``nexus-o6aa.9.7`` (#453, MERGED)
- Followed by: ``nexus-o6aa.9.9`` (D — migration polish)