### PR TITLE
chore(rdr-101): phase 3 sandbox e2e migration validation harness (nexus-o6aa.9.10)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -490,3 +490,4 @@
 {"id":"int-ec93c5c9","kind":"field_change","created_at":"2026-05-01T21:30:22.984073Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.6","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-81a4170f","kind":"field_change","created_at":"2026-05-01T21:36:40.061953Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.7","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-140c3f2b","kind":"field_change","created_at":"2026-05-01T21:51:50.743853Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.8","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-97839c28","kind":"field_change","created_at":"2026-05-01T22:33:11.883549Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.10","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/docs/migration/rdr-101-e2e-validation.md
+++ b/docs/migration/rdr-101-e2e-validation.md
@@ -1,0 +1,77 @@
+# RDR-101 Phase 3 — sandbox e2e migration validation report
+
+Run date: 2026-05-01
+Bead: `nexus-o6aa.9.10`
+Harness: `scripts/validate/rdr-101-migration-e2e.sh`
+Sandbox: 3-document catalog under `NEXUS_CONFIG_DIR=$(mktemp -d)` + embedded local Chroma via `NX_LOCAL=1`.
+
+## Result
+
+**18 of 18 assertions pass.** No defects surface that block PR D (operator-polish migration verb + docs + TTY prompt).
+
+## What the harness exercises
+
+| Step | Scenario | Outcome |
+|---|---|---|
+| 1 | Sandbox + `nx catalog init` | catalog dir created |
+| 2 | Bootstrap legacy state under `NEXUS_EVENT_SOURCED=0` (index 2 docs) | `documents.jsonl` populated, `events.jsonl` empty |
+| 3a | Doctor with empty `events.jsonl` (ES default-on) | synthesizer path PASSes; **no bootstrap-fallback fires** — correct, this is a freshly-upgraded catalog with no ES mutations yet |
+| 3b | One ES mutation under default-on → sparse `events.jsonl` (1 line) vs `documents.jsonl` (3 lines) | bootstrap-fallback warning fires with `synthesize-log --force` remediation hint; doctor exits non-zero |
+| 4 | `nx catalog synthesize-log --force` | `events.jsonl` populated to 4 lines |
+| 5 | Doctor post-migration | PASS, no bootstrap-fallback warning |
+| 6 | Mutate post-migration (index 1 more doc) | doctor still PASS |
+| 7 | Rollback: `NEXUS_EVENT_SOURCED=0 nx catalog list` | rows present, legacy mode operative |
+| 8 | Parallel doctor + index | both succeed; `events.jsonl` JSON-clean (no torn writes) |
+| 9 | Performance: doctor wall time | median 0.34s on the sandbox-sized catalog |
+
+## Findings
+
+### Semantic clarification (bead description was sloppy)
+
+The original bead description said step 3 should expect bootstrap-fallback to fire on empty `events.jsonl` after the ζ default flip. **That was wrong.** `_ensure_consistent`'s logic is:
+
+```python
+use_event_log = (
+    self._event_sourced_enabled
+    and self._events_path.exists()
+    and self._events_path.stat().st_size > 0
+)
+if use_event_log and not self._event_log_covers_legacy():
+    # bootstrap-fallback path
+```
+
+When `events.jsonl` is empty or absent, `use_event_log = False` at the size gate before `_event_log_covers_legacy` ever runs. The catalog falls through to legacy-rebuild silently — and that is correct: a freshly-upgraded catalog with no ES mutations yet is not in a desync state, it's just running on legacy reads.
+
+Bootstrap-fallback only fires when the operator has done **at least one ES-mode mutation** that produced an event in `events.jsonl`, while `documents.jsonl` still has materially more rows than the event log carries `DocumentRegistered` events. The harness now exercises that specific state by triggering one ES-mode index call before the doctor check.
+
+### Doctor synthesizer path is the right behaviour for empty event log
+
+`doctor --replay-equality` with empty `events.jsonl` synthesizes events on the fly from the legacy JSONL and compares to live SQLite. PASS in this configuration is correct — the catalog is consistent with itself, just not yet on the ES write path. PR D's `nx catalog migrate` verb should not block on this state; instead it should be informational ("nothing to migrate").
+
+### `_check_bootstrap_status` performance is fine
+
+3 doctor runs at 0.342–0.365s, median 0.344s. Pure file inspection adds no measurable overhead on the 3-doc sandbox; the 0.34s baseline is dominated by Python interpreter startup + module import. On a large catalog the file-walk would scale linearly with `documents.jsonl` line count, but that's the same scale `_event_log_covers_legacy` itself walks — no new asymptote.
+
+### Concurrent writes do not corrupt `events.jsonl`
+
+Parallel `nx catalog doctor` + `nx index md` both succeed; every line in `events.jsonl` parses as JSON. The flock acquired by `apply_remove_plan` (PR #449) and the per-call flock in `EventLog.append` work as designed.
+
+### Rollback works
+
+`NEXUS_EVENT_SOURCED=0 nx catalog list` returns all sandbox docs. Legacy JSONL stays canonical when explicitly opted-out of ES.
+
+## Implications for PR D
+
+The harness validates that the surfaced state, the remediation, and the rollback all work end-to-end. PR D can proceed with these refinements:
+
+1. **`nx catalog migrate` verb** should pre-check `bootstrap_fallback_active`. If false (catalog is fully migrated OR has no ES events yet AND no sparse condition), report "nothing to do" and exit 0 without running `synthesize-log` (which would unnecessarily regenerate the event log).
+2. **Migration doc** should explain the empty-events-jsonl synthesizer-PASS case so operators don't think the absence of bootstrap-fallback warning means migration is already complete — they may still benefit from running `synthesize-log` to populate `events.jsonl` proactively.
+3. **TTY prompt** logic stays as designed — fires on `bootstrap_fallback_active = True`, suppresses otherwise. No change.
+
+## Rerun the harness
+
+```bash
+./scripts/validate/rdr-101-migration-e2e.sh
+```
+
+Self-cleaning sandbox (`/tmp/nexus-rdr101-e2e-XXXXXX`) on success; preserved on failure with transcript at `$SANDBOX/.cache/transcript.log`.

--- a/scripts/validate/rdr-101-migration-e2e.sh
+++ b/scripts/validate/rdr-101-migration-e2e.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# RDR-101 Phase 3 sandbox e2e migration validator (nexus-o6aa.9.10).
+#
+# Walks the actual operator upgrade workflow in an isolated NEXUS_CONFIG_DIR:
+#
+#   1. Bootstrap a "pre-RDR-101" catalog by running nx commands under
+#      NEXUS_EVENT_SOURCED=0 — populates the legacy JSONL files (no events.jsonl).
+#   2. Drop the gate (default ON under PR ζ); confirm bootstrap-fallback fires.
+#   3. Run synthesize-log --force + t3-backfill-doc-id; confirm doctor PASS.
+#   4. Mutate post-migration; confirm doctor stays PASS.
+#   5. Rollback test (NEXUS_EVENT_SOURCED=0); confirm legacy reads still work.
+#   6. Concurrency smoke; confirm events.jsonl stays well-formed.
+#   7. Performance baseline for doctor.
+#
+# Self-contained: spawns its own embedded Chroma via NX_LOCAL=1, isolates
+# config to a tmp dir, cleans up on exit. Non-destructive against the real
+# user catalog.
+#
+# Usage:
+#   ./scripts/validate/rdr-101-migration-e2e.sh
+#
+# Exit code 0 = all steps passed; non-zero = at least one assertion failed.
+# Transcript and per-step logs land in $SANDBOX/.cache/.
+
+set -uo pipefail
+
+# ── Sandbox bootstrap ────────────────────────────────────────────────────
+
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/nexus-rdr101-e2e-XXXXXX")"
+ORIG_HOME="$HOME"
+export HOME="$SANDBOX"
+export NX_LOCAL=1
+export NX_LOCAL_CHROMA_PATH="$SANDBOX/.local/share/nexus/chroma"
+export NEXUS_CONFIG_DIR="$SANDBOX/.config/nexus"
+export NEXUS_CATALOG_PATH="$SANDBOX/.config/nexus/catalog"
+mkdir -p "$NEXUS_CONFIG_DIR" "$NX_LOCAL_CHROMA_PATH" "$SANDBOX/.cache"
+TRANSCRIPT="$SANDBOX/.cache/transcript.log"
+
+cleanup() {
+    local rc=$?
+    if [[ $rc -eq 0 ]]; then
+        rm -rf "$SANDBOX"
+    else
+        printf "\nSandbox preserved at %s for inspection (transcript: %s)\n" \
+            "$SANDBOX" "$TRANSCRIPT" >&2
+    fi
+    exit $rc
+}
+trap cleanup EXIT INT TERM
+
+# ── Output helpers ────────────────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+FAILED_CASES=()
+
+ts()   { date +"%H:%M:%S"; }
+step() { printf "\n[%s] ═══ %s ═══\n" "$(ts)" "$*" | tee -a "$TRANSCRIPT" >&2; }
+info() { printf "[%s]    %s\n"        "$(ts)" "$*" | tee -a "$TRANSCRIPT" >&2; }
+pass() { printf "[%s]  ✓ %s\n"        "$(ts)" "$*" | tee -a "$TRANSCRIPT" >&2; PASS=$((PASS+1)); }
+fail() { printf "[%s]  ✗ %s\n"        "$(ts)" "$*" | tee -a "$TRANSCRIPT" >&2; FAIL=$((FAIL+1)); FAILED_CASES+=("$*"); }
+
+assert_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        pass "$label"
+    else
+        fail "$label  (expected substring: $needle)"
+        printf "    haystack head:\n%s\n" "$(echo "$haystack" | head -20 | sed 's/^/      /')" >&2
+    fi
+}
+
+assert_eq() {
+    local label="$1" got="$2" want="$3"
+    if [[ "$got" == "$want" ]]; then
+        pass "$label"
+    else
+        fail "$label  (got=$got want=$want)"
+    fi
+}
+
+run_capture() {
+    # run_capture <varname> <cmd...> — capture combined stdout+stderr into
+    # a variable, and also append to transcript.
+    local _name="$1"; shift
+    local _out
+    _out="$("$@" 2>&1)"
+    local _rc=$?
+    printf "[%s] $ %s\n%s\n" "$(ts)" "$*" "$_out" >> "$TRANSCRIPT"
+    printf -v "$_name" "%s" "$_out"
+    return $_rc
+}
+
+# ── Step 1: Sandbox initialized ──────────────────────────────────────────
+
+step "1. Sandbox initialized"
+info "Sandbox:           $SANDBOX"
+info "NEXUS_CONFIG_DIR:  $NEXUS_CONFIG_DIR"
+info "NX_LOCAL_CHROMA:   $NX_LOCAL_CHROMA_PATH"
+info "Transcript:        $TRANSCRIPT"
+
+# Initialize the catalog. nx catalog init expects to write to NEXUS_CATALOG_PATH.
+mkdir -p "$NEXUS_CATALOG_PATH"
+run_capture INIT_OUT uv run nx catalog init || true
+assert_contains "nx catalog init produces a catalog" "$INIT_OUT" "catalog"
+
+# ── Step 2: Bootstrap pre-RDR-101 state under legacy mode ────────────────
+
+step "2. Bootstrap legacy (pre-RDR-101) state"
+export NEXUS_EVENT_SOURCED=0
+
+# Hand-craft three small markdown files; index them under legacy mode so
+# the catalog's documents.jsonl / owners.jsonl get populated without
+# events.jsonl. This simulates a catalog from before PR α / β / γ.
+mkdir -p "$SANDBOX/repo"
+cat >"$SANDBOX/repo/alpha.md" <<'EOF'
+# Alpha
+The first sandbox document.
+EOF
+cat >"$SANDBOX/repo/beta.md" <<'EOF'
+# Beta
+The second sandbox document.
+EOF
+cat >"$SANDBOX/repo/gamma.md" <<'EOF'
+# Gamma
+The third sandbox document, for testing post-migration mutation.
+EOF
+
+# Index two of the three under legacy mode.
+run_capture IDX_A uv run nx index md "$SANDBOX/repo/alpha.md" --corpus sandbox || true
+info "alpha indexed: $(echo "$IDX_A" | tail -3 | head -1)"
+run_capture IDX_B uv run nx index md "$SANDBOX/repo/beta.md" --corpus sandbox || true
+info "beta indexed:  $(echo "$IDX_B" | tail -3 | head -1)"
+
+# Confirm the legacy JSONL files are populated.
+DOCS_JSONL="$NEXUS_CATALOG_PATH/documents.jsonl"
+EVENTS_JSONL="$NEXUS_CATALOG_PATH/events.jsonl"
+LEGACY_DOC_COUNT=$(grep -c '"_deleted"' "$DOCS_JSONL" 2>/dev/null || echo 0)
+LEGACY_LINE_COUNT=$(wc -l <"$DOCS_JSONL" 2>/dev/null || echo 0)
+info "documents.jsonl line count: $LEGACY_LINE_COUNT (deleted: $LEGACY_DOC_COUNT)"
+
+if [[ "$LEGACY_LINE_COUNT" -ge 2 ]]; then
+    pass "legacy documents.jsonl populated"
+else
+    fail "legacy documents.jsonl populated  (got $LEGACY_LINE_COUNT lines)"
+fi
+
+if [[ ! -s "$EVENTS_JSONL" ]]; then
+    pass "events.jsonl absent or empty (legacy bootstrap shape)"
+else
+    fail "events.jsonl unexpectedly populated under NEXUS_EVENT_SOURCED=0"
+    info "events.jsonl head:"
+    head -3 "$EVENTS_JSONL" >&2
+fi
+
+# ── Step 3a: Empty events.jsonl falls through cleanly ──────────────────
+
+step "3a. ES default ON with empty events.jsonl: synthesizer path PASSes"
+unset NEXUS_EVENT_SOURCED  # default is ON under PR ζ.
+
+run_capture DR0_OUT uv run nx catalog doctor --replay-equality
+DR0_RC=$?
+info "doctor exit: $DR0_RC"
+
+# When events.jsonl is empty, ``use_event_log`` is False at the size
+# gate before ``_event_log_covers_legacy`` runs — the guardrail does
+# not fire. Doctor's synthesizer then walks the legacy JSONL, emits
+# synthesized events on the fly, and PASSes. This is the correct
+# behaviour for a freshly-upgraded catalog that has not yet seen any
+# ES-mode mutations.
+if [[ $DR0_RC -eq 0 ]]; then
+    pass "doctor PASSes on empty-events catalog (synthesizer path)"
+else
+    fail "doctor unexpectedly fails on empty-events catalog (rc=$DR0_RC)"
+fi
+if [[ "$DR0_OUT" != *"bootstrap-fallback"* ]]; then
+    pass "no bootstrap-fallback warning when events.jsonl is empty"
+else
+    fail "bootstrap-fallback fires unexpectedly when events.jsonl is empty"
+fi
+
+# ── Step 3b: ES mutation makes events.jsonl sparse → bootstrap fires ───
+
+step "3b. ES mutation sparses events.jsonl; bootstrap-fallback fires"
+# A single index call under ES default-on emits one DocumentRegistered
+# (and one OwnerRegistered if the owner is new). Combined with the
+# legacy documents.jsonl (3 entries from step 2 plus the new one),
+# event_doc_count < threshold = max(1, int(N * 0.95)).
+mkdir -p "$SANDBOX/repo/sparse"
+cat >"$SANDBOX/repo/sparse/sparse-trigger.md" <<'EOF'
+# Sparse Trigger
+Indexed under ES to push events.jsonl past empty but well below
+documents.jsonl, exercising the guardrail's sparse-vs-legacy branch.
+EOF
+run_capture IDX_SPARSE uv run nx index md "$SANDBOX/repo/sparse/sparse-trigger.md" \
+    --corpus sandbox || true
+info "sparse-trigger indexed: $(echo "$IDX_SPARSE" | tail -3 | head -1)"
+
+EVT_LINES=$(wc -l <"$EVENTS_JSONL" 2>/dev/null || echo 0)
+DOC_LINES=$(wc -l <"$DOCS_JSONL" 2>/dev/null || echo 0)
+info "events.jsonl=$EVT_LINES lines  documents.jsonl=$DOC_LINES lines"
+
+run_capture DR_OUT uv run nx catalog doctor --replay-equality
+DR_RC=$?
+info "doctor exit: $DR_RC"
+
+assert_contains "bootstrap-fallback warning fires" "$DR_OUT" "bootstrap-fallback"
+assert_contains "remediation hint includes --force"  "$DR_OUT" "synthesize-log --force"
+
+if [[ $DR_RC -ne 0 ]]; then
+    pass "doctor exits non-zero under bootstrap fallback"
+else
+    fail "doctor exits non-zero under bootstrap fallback  (got $DR_RC)"
+fi
+
+# ── Step 4: Run the migration ─────────────────────────────────────────────
+
+step "4. Run nx catalog synthesize-log --force"
+run_capture SYN_OUT uv run nx catalog synthesize-log --force
+SYN_RC=$?
+info "synthesize-log exit: $SYN_RC"
+
+if [[ $SYN_RC -eq 0 ]]; then
+    pass "synthesize-log --force succeeds"
+else
+    fail "synthesize-log --force failed (rc=$SYN_RC)"
+    info "$SYN_OUT" | tail -5
+fi
+
+# events.jsonl must now be populated.
+if [[ -s "$EVENTS_JSONL" ]]; then
+    EVENT_LINE_COUNT=$(wc -l <"$EVENTS_JSONL")
+    pass "events.jsonl populated ($EVENT_LINE_COUNT lines)"
+else
+    fail "events.jsonl still empty after synthesize-log --force"
+fi
+
+step "5. Doctor PASSes after migration"
+run_capture DR2_OUT uv run nx catalog doctor --replay-equality
+DR2_RC=$?
+info "doctor exit: $DR2_RC"
+
+if [[ $DR2_RC -eq 0 ]]; then
+    pass "doctor --replay-equality PASS post-migration"
+else
+    fail "doctor --replay-equality fails post-migration  (rc=$DR2_RC)"
+    info "$DR2_OUT" | tail -10
+fi
+
+# bootstrap-fallback warning should NOT be present now.
+if [[ "$DR2_OUT" != *"bootstrap-fallback"* ]]; then
+    pass "bootstrap-fallback warning gone after migration"
+else
+    fail "bootstrap-fallback warning still present after migration"
+fi
+
+# ── Step 6: Mutate post-migration ─────────────────────────────────────────
+
+step "6. Mutate post-migration; doctor stays green"
+run_capture IDX_C uv run nx index md "$SANDBOX/repo/gamma.md" --corpus sandbox || true
+info "gamma indexed: $(echo "$IDX_C" | tail -3 | head -1)"
+
+run_capture DR3_OUT uv run nx catalog doctor --replay-equality
+DR3_RC=$?
+if [[ $DR3_RC -eq 0 ]]; then
+    pass "doctor still PASSes after a post-migration mutation"
+else
+    fail "doctor fails after a post-migration mutation (rc=$DR3_RC)"
+    info "$DR3_OUT" | tail -10
+fi
+
+# ── Step 7: Rollback to legacy mode ───────────────────────────────────────
+
+step "7. Rollback: NEXUS_EVENT_SOURCED=0 still reads catalog"
+run_capture LIST_OUT env NEXUS_EVENT_SOURCED=0 uv run nx catalog list
+if [[ -n "$LIST_OUT" ]]; then
+    pass "nx catalog list works under explicit legacy opt-out"
+else
+    fail "nx catalog list returned empty under explicit legacy opt-out"
+fi
+
+# Should see at least 2 of our 3 sandbox docs in the listing.
+SANDBOX_HITS=$(echo "$LIST_OUT" | grep -cE "alpha|beta|gamma" || echo 0)
+if [[ "$SANDBOX_HITS" -ge 2 ]]; then
+    pass "rollback list surfaces sandbox docs ($SANDBOX_HITS hits)"
+else
+    fail "rollback list missing sandbox docs (only $SANDBOX_HITS hits)"
+fi
+
+# ── Step 8: Concurrency smoke test ────────────────────────────────────────
+
+step "8. Concurrency: parallel doctor + register"
+# Two operations in parallel — doctor (read-only) + a fresh index.
+mkdir -p "$SANDBOX/repo/parallel"
+cat >"$SANDBOX/repo/parallel/concurrent.md" <<'EOF'
+# Concurrent
+Written during a parallel doctor run.
+EOF
+
+(uv run nx catalog doctor --replay-equality >"$SANDBOX/.cache/par-doctor.out" 2>&1) &
+DOCTOR_PID=$!
+(uv run nx index md "$SANDBOX/repo/parallel/concurrent.md" --corpus sandbox \
+    >"$SANDBOX/.cache/par-index.out" 2>&1) &
+INDEX_PID=$!
+
+wait $DOCTOR_PID
+DOC_RC=$?
+wait $INDEX_PID
+IDX_RC=$?
+
+if [[ $DOC_RC -eq 0 && $IDX_RC -eq 0 ]]; then
+    pass "parallel doctor + index both succeeded"
+else
+    fail "parallel doctor + index disagree (doctor=$DOC_RC index=$IDX_RC)"
+fi
+
+# events.jsonl must still be valid JSONL — no torn writes.
+INVALID_EVENT_LINES=0
+if [[ -s "$EVENTS_JSONL" ]]; then
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        if ! printf '%s\n' "$line" | python3 -c "import sys,json; json.loads(sys.stdin.read())" >/dev/null 2>&1; then
+            INVALID_EVENT_LINES=$((INVALID_EVENT_LINES+1))
+        fi
+    done <"$EVENTS_JSONL"
+fi
+if [[ "$INVALID_EVENT_LINES" -eq 0 ]]; then
+    pass "events.jsonl JSON-clean after concurrent writes"
+else
+    fail "events.jsonl has $INVALID_EVENT_LINES malformed line(s) after concurrent writes"
+fi
+
+# ── Step 9: Performance baseline ──────────────────────────────────────────
+
+step "9. Performance baseline for doctor"
+declare -a TIMES
+for i in 1 2 3; do
+    BEFORE=$(python3 -c "import time; print(time.monotonic())")
+    uv run nx catalog doctor --replay-equality >/dev/null 2>&1 || true
+    AFTER=$(python3 -c "import time; print(time.monotonic())")
+    DELTA=$(python3 -c "print(f'{$AFTER - $BEFORE:.3f}')")
+    info "doctor run $i: ${DELTA}s"
+    TIMES+=("$DELTA")
+done
+
+# Report median (sort, pick middle).
+MEDIAN=$(printf '%s\n' "${TIMES[@]}" | sort -n | sed -n '2p')
+info "median doctor wall time: ${MEDIAN}s"
+
+# Soft check — flag if median > 5s on the sandbox-sized catalog. This
+# isn't a hard fail; it's a heads-up if _check_bootstrap_status added
+# unexpected overhead.
+if python3 -c "import sys; sys.exit(0 if $MEDIAN < 5.0 else 1)"; then
+    pass "doctor median wall time under 5s threshold"
+else
+    fail "doctor median wall time exceeded 5s soft threshold (${MEDIAN}s)"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────
+
+step "Summary"
+info "PASS: $PASS"
+info "FAIL: $FAIL"
+if (( FAIL > 0 )); then
+    info "Failed cases:"
+    for c in "${FAILED_CASES[@]}"; do
+        info "  - $c"
+    done
+    exit 1
+fi
+info "All e2e migration validation steps passed."
+exit 0


### PR DESCRIPTION
## Summary

Real-world end-to-end validation of RDR-101 Phase 3 + follow-ups A/B/C. Unit tests passed (998 in targeted sweep, full suite green for #449/#453/#454), but the actual operator upgrade workflow had not been exercised against a populated catalog. This bead closes that gap; results inform PR D's design.

## Harness

`scripts/validate/rdr-101-migration-e2e.sh` — non-destructive bash harness with `NEXUS_CONFIG_DIR` isolation + `NX_LOCAL=1` embedded Chroma. Self-cleans on success; preserves sandbox + transcript on failure.

9 steps:

| | |
|---|---|
| 1 | Sandbox + `nx catalog init` |
| 2 | Bootstrap legacy state under `NEXUS_EVENT_SOURCED=0` |
| 3a | Doctor with empty `events.jsonl` → synthesizer PASS |
| 3b | ES mutation sparses `events.jsonl` → bootstrap-fallback fires |
| 4 | `nx catalog synthesize-log --force` recovers |
| 5 | Doctor PASSes post-migration |
| 6 | Mutate post-migration; doctor still PASSes |
| 7 | Rollback (`NEXUS_EVENT_SOURCED=0`) works |
| 8 | Concurrent doctor + index leave `events.jsonl` JSON-clean |
| 9 | Performance baseline (median 0.34s on sandbox) |

## Findings (full report in `docs/migration/rdr-101-e2e-validation.md`)

**18/18 assertions pass. No defects block PR D.**

Three operationally relevant observations:

1. **Empty `events.jsonl` ≠ bootstrap-fallback.** The bead's original step-3 expectation was sloppy. `_ensure_consistent`'s size gate falls through to legacy rebuild silently when `events.jsonl` is empty; the synthesizer path then passes doctor — correct, not a desync. Bootstrap-fallback fires only on the **sparse** state (events present but materially fewer DocumentRegistered than documents.jsonl rows). Harness now exercises both.

2. **`_check_bootstrap_status` performance is fine.** 0.34s median for `doctor --replay-equality` on a 3-doc catalog; pure-file inspection adds no measurable overhead.

3. **Concurrency is sound.** Parallel `doctor` + `index` produce well-formed `events.jsonl` — no torn writes. The flock plumbing from #449 + `EventLog.append` work as designed.

## Implications for PR D (`nexus-o6aa.9.9`)

- `nx catalog migrate` verb should pre-check `bootstrap_fallback_active`; exit 0 "nothing to do" if false.
- Migration doc should explain the empty-events synthesizer-PASS case so operators don't conclude they're migrated when they haven't yet populated `events.jsonl`.
- TTY prompt logic stays as designed.

## Refs

- Bead: `nexus-o6aa.9.10` (P1, parent: `nexus-o6aa.9`)
- Depends on: `nexus-o6aa.9.6` (#449) + `nexus-o6aa.9.7` (#453) + `nexus-o6aa.9.8` (#454) — all merged
- Unblocks: `nexus-o6aa.9.9` (PR D — migration polish)