### PR TITLE
feat(rdr-101): nx catalog migrate + TTY upgrade prompt + migration guide (nexus-o6aa.9.9)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -490,4 +490,4 @@
 {"id":"int-ec93c5c9","kind":"field_change","created_at":"2026-05-01T21:30:22.984073Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.6","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-81a4170f","kind":"field_change","created_at":"2026-05-01T21:36:40.061953Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.7","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-140c3f2b","kind":"field_change","created_at":"2026-05-01T21:51:50.743853Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.8","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
-{"id":"int-97839c28","kind":"field_change","created_at":"2026-05-01T22:33:11.883549Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.10","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-5cef851c","kind":"field_change","created_at":"2026-05-01T22:41:29.22415Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.9","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/docs/migration/rdr-101.md
+++ b/docs/migration/rdr-101.md
@@ -1,0 +1,134 @@
+# RDR-101 — operator migration guide
+
+This guide walks an operator from a pre-RDR-101 catalog to the
+event-sourced canonical state shipped in Phase 3 (PRs #438 — #454, ε /
+dedupe / ζ / atomic dedupe / bootstrap guardrail / cleanup) and
+follow-up D's polish (PR for nexus-o6aa.9.9).
+
+Two scenarios cover ~all real catalogs:
+
+* **A — pre-RDR-101 install.** You upgraded nexus from a version
+  before commit `938a2b0a` (Phase 3 PR δ Stage A) and your catalog
+  has only legacy `documents.jsonl` / `links.jsonl` / `owners.jsonl`.
+  Possibly an empty or sparse `events.jsonl` from shadow-emit.
+* **B — already on Phase 1/2.** You ran `nx catalog synthesize-log` on
+  an earlier Phase build. `events.jsonl` already covers the legacy
+  state. No action needed.
+
+If you don't know which case you're in, run `nx catalog migrate
+--dry-run` — it will tell you and exit 0 either way.
+
+## TL;DR — the migration
+
+```bash
+nx catalog migrate
+```
+
+That's it. The verb is idempotent: if the catalog is already migrated,
+it reports "nothing to do" and exits 0. If migration is needed, it
+sequences `synthesize-log --force` + `t3-backfill-doc-id` + `doctor`
+verification, bailing on the first failure. Re-running is safe.
+
+If your catalog has no T3 collections yet, pass `--no-chunks` to skip
+the T3 backfill step.
+
+## What the verb does
+
+1. **Pre-check** the bootstrap state. If `events.jsonl` already covers
+   `documents.jsonl`, exit 0 with "nothing to do". If the catalog is
+   empty (no legacy docs), exit 0 with "nothing to do". Otherwise
+   proceed.
+2. **`nx catalog synthesize-log --force`** — walk the legacy JSONL
+   files, mint a UUID7 `doc_id` per document, emit the corresponding
+   `OwnerRegistered` / `DocumentRegistered` / `LinkCreated` events to
+   `events.jsonl`. The `--chunks` flag (default on; off under
+   `--no-chunks`) also emits one `ChunkIndexed` event per existing T3
+   chunk so the backfill in step 3 has the source-of-truth mapping.
+3. **`nx catalog t3-backfill-doc-id`** — for every chunk that
+   `events.jsonl` claims exists, write the `doc_id` metadata to the T3
+   chunk. Skipped under `--no-chunks`.
+4. **`nx catalog doctor --replay-equality --t3-doc-id-coverage
+   --strict-not-in-t3`** — verify. Replay-equality confirms that
+   replaying `events.jsonl` through the projector produces the same
+   SQLite as the live catalog. T3 doc_id coverage confirms every chunk
+   in T3 carries a `doc_id` that matches what the events claim.
+
+## Verification
+
+After migration:
+
+```bash
+nx catalog doctor --replay-equality --t3-doc-id-coverage --strict-not-in-t3
+```
+
+Expected: PASS, exit 0. Doctor's text output names every table and the
+T3 collections it walked.
+
+If doctor fails after migration, re-run `nx catalog migrate` — it is
+idempotent. The most common cause of a partial-migration is a network
+blip during T3 backfill; re-running will pick up where it left off.
+
+## Rollback
+
+If something goes wrong and you want the legacy direct-write path back:
+
+```bash
+NEXUS_EVENT_SOURCED=0 nx catalog ...
+```
+
+The legacy `documents.jsonl` / `links.jsonl` / `owners.jsonl` files are
+still written by the ES path under PR ζ default-on (back-compat dual
+write), so flipping back to legacy mode reads the same up-to-date data.
+
+This rollback works **until Phase 5c** (legacy JSONL removal). After
+5c, only `events.jsonl` is canonical and the env var has nothing to
+fall back to.
+
+## States and signals
+
+| State | `bootstrap_fallback_active` | `events.jsonl` | What you see |
+|---|---|---|---|
+| Already migrated | False | covers documents.jsonl | doctor PASS, no warning |
+| Freshly upgraded, no mutations | False | empty | doctor PASS via synthesizer; no warning, but `nx catalog migrate` will proactively populate the log |
+| Bootstrap fallback (sparse log) | True | non-empty, fewer events than legacy docs | structlog warning, doctor stderr WARNING, doctor exits non-zero, TTY prompt fires once |
+| Empty catalog | False | empty | doctor PASS (nothing to compare); `nx catalog migrate` exits "nothing to do" |
+
+The empty-events synthesizer-PASS row is the operationally subtle one:
+your catalog **isn't broken** in that state, but `events.jsonl` is also
+not yet canonical for replay. Running `nx catalog migrate` proactively
+populates the log, which is the right thing to do before any
+production-grade ES mutation happens. (After ζ default-on, every
+mutation already takes the ES path and writes to the log; the verb
+just makes sure the legacy state is reflected too.)
+
+## Suppressing the upgrade prompt
+
+The TTY-gated upgrade prompt fires once per nx CLI invocation when
+`bootstrap_fallback_active` is True and stderr is a real terminal.
+Suppress it with:
+
+```bash
+export NEXUS_NO_PROMPTS=1
+```
+
+The structured warning in structlog and the `bootstrap_fallback` key
+in `nx catalog doctor --json` continue to surface the state for
+machine consumers regardless.
+
+## Failure modes and recovery
+
+| Failure | Symptom | Recovery |
+|---|---|---|
+| `synthesize-log` fails mid-walk | exception from the verb | The verb is atomic — `events.jsonl` is left intact (or absent) until the full walk succeeds. Fix the underlying issue and re-run. |
+| `t3-backfill-doc-id` partial | some chunks missing `doc_id` metadata; `doctor --t3-doc-id-coverage` flags them | Re-run `nx catalog t3-backfill-doc-id`. Idempotent — already-backfilled chunks are no-ops. |
+| Hand-injected events | `_v0_owner_deleted` cascade warning, or replay-equality mismatch | Don't hand-inject. If you must, follow the protocol invariants documented at each `*Payload` definition. |
+| Concurrent CLI runs during migration | flock contention | Acquire-and-block — the second invocation waits. No corruption (verified by `scripts/validate/rdr-101-migration-e2e.sh` step 8). |
+
+## See also
+
+* `docs/migration/rdr-101-e2e-validation.md` — the e2e validation
+  report from `nexus-o6aa.9.10`.
+* `docs/rdr/rdr-101-catalog-t3-metadata-design.md` — the originating
+  RDR.
+* `src/nexus/catalog/AGENTS.md` — invariants and direct-write
+  prohibition (PR ε).

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -35,6 +35,16 @@ def main(ctx: click.Context, verbose: bool) -> None:
     ctx.obj["verbose"] = verbose
     configure_logging("cli", verbose=verbose)
 
+    # RDR-101 Phase 3 follow-up D (nexus-o6aa.9.9): TTY-gated upgrade
+    # prompt. When the catalog is in bootstrap-fallback mode, surface
+    # a one-time stderr warning to the operator so the silent split
+    # state does not linger unnoticed. Suppressed in non-TTY contexts
+    # (CI / cron / MCP / scripted runs) and via NEXUS_NO_PROMPTS=1.
+    # Hook is here, at the top-level Click group, so it fires once per
+    # CLI invocation rather than per Catalog construction.
+    from nexus.commands._migration_prompt import maybe_emit_bootstrap_prompt
+    maybe_emit_bootstrap_prompt()
+
 
 main.add_command(catalog)
 main.add_command(collection)

--- a/src/nexus/commands/_migration_prompt.py
+++ b/src/nexus/commands/_migration_prompt.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-101 Phase 3 follow-up D (nexus-o6aa.9.9): TTY-gated upgrade prompt.
+
+When ``Catalog._ensure_consistent`` decides to fall back to legacy reads
+because ``events.jsonl`` is non-empty but sparse vs ``documents.jsonl``
+(``Catalog.bootstrap_fallback_active = True`` after the call), this
+module surfaces an operator-visible warning to stderr — once per
+process, only when stderr is a TTY, and only when ``NEXUS_NO_PROMPTS``
+is not set.
+
+The hook lives here (and is wired into ``cli.main``) rather than in
+``Catalog.__init__`` because:
+
+  * The MCP server, library consumers, and tests all construct
+    ``Catalog`` instances; emitting from ``__init__`` would fire in
+    every context. The CLI group's callback fires once per invocation.
+  * The ``stderr.isatty()`` gate is meaningful only at the CLI surface.
+    Library callers may have replaced stderr; MCP runs without a TTY.
+
+structlog already logs the underlying warning every time the guardrail
+fires. The doctor verb's ``--json`` output also surfaces the
+``bootstrap_fallback`` key for machine consumers. This module is the
+human-visible nudge layer that complements both, not a replacement.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import click
+
+# Module-scoped sentinel — fire the prompt at most once per process.
+# Multiple Catalog constructions in one CLI run (e.g. doctor's
+# pre-check + the actual check) must not double-emit. The flag is
+# never reset; it dies with the process.
+_PROMPTED: bool = False
+
+# Env var name documented at the top of `docs/migration/rdr-101.md`.
+# When set to a truthy value, suppresses the prompt unconditionally.
+# Same semantics as pip's --quiet or npm's NPM_CONFIG_LOGLEVEL.
+_NO_PROMPTS_ENV = "NEXUS_NO_PROMPTS"
+
+
+def maybe_emit_bootstrap_prompt() -> None:
+    """Emit the bootstrap-fallback prompt to stderr if all gates clear:
+
+    1. ``_PROMPTED`` is False (haven't already fired in this process).
+    2. ``stderr`` is a TTY (operator at a real terminal).
+    3. ``NEXUS_NO_PROMPTS`` is not set to a truthy value.
+    4. The catalog is currently in bootstrap-fallback mode.
+
+    Best-effort — any exception in the gate logic suppresses the
+    prompt rather than disrupting the CLI invocation. The prompt is
+    advisory; the underlying state is already surfaced via structlog
+    and ``nx catalog doctor``.
+    """
+    global _PROMPTED
+    if _PROMPTED:
+        return
+
+    # Gate 2: TTY check.
+    try:
+        if not sys.stderr.isatty():
+            return
+    except (AttributeError, ValueError):
+        return
+
+    # Gate 3: NEXUS_NO_PROMPTS escape hatch.
+    raw = os.environ.get(_NO_PROMPTS_ENV, "").strip().lower()
+    if raw in ("1", "true", "yes", "on"):
+        return
+
+    # Gate 4: actual catalog state. Do this last because it touches
+    # the filesystem; the cheap gates run first.
+    try:
+        from nexus.commands.catalog import _check_bootstrap_status
+        status = _check_bootstrap_status()
+    except Exception:
+        return
+
+    if not status.get("fallback_active"):
+        return
+
+    _PROMPTED = True
+    click.echo(
+        "WARNING: catalog bootstrap-fallback active.\n"
+        "  events.jsonl is sparse vs documents.jsonl; ES writes are\n"
+        "  landing in the log but reads come from legacy JSONL. Run\n"
+        "  `nx catalog migrate` to rebuild events.jsonl from the\n"
+        "  legacy state and align T3 chunks. See docs/migration/rdr-101.md.\n"
+        "  Suppress this prompt with NEXUS_NO_PROMPTS=1.",
+        err=True,
+    )

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -4512,3 +4512,187 @@ def repair_orphan_chunks_cmd(
             for s in skipped[:10]:
                 click.echo(f"  {s['chunk_id']}: {s['reason']}")
         click.echo(f"Remaining orphans: {report['remaining_orphans']}")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# RDR-101 Phase 3 follow-up D (nexus-o6aa.9.9): one-shot migration verb.
+# ──────────────────────────────────────────────────────────────────────
+
+
+@catalog.command("migrate")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help=(
+        "Report what would happen without writing. Shows the current "
+        "bootstrap state (fallback active vs not), what synthesize-log "
+        "would produce, what t3-backfill would touch."
+    ),
+)
+@click.option(
+    "--no-chunks",
+    is_flag=True,
+    help=(
+        "Skip the T3 chunk synthesis + backfill steps. Use when the "
+        "catalog has no T3 collections yet, or when staging the "
+        "document-side migration before opening the T3 connection."
+    ),
+)
+@click.option(
+    "--json", "as_json", is_flag=True,
+    help="Emit machine-readable JSON instead of text output.",
+)
+@click.pass_context
+def migrate_cmd(
+    ctx: click.Context,
+    dry_run: bool,
+    no_chunks: bool,
+    as_json: bool,
+) -> None:
+    """RDR-101 Phase 3: one-shot migration to event-sourced canonical state.
+
+    Composed verb that sequences the three steps an upgrading operator
+    would otherwise run by hand:
+
+      1. ``nx catalog synthesize-log --force [--chunks]`` — rebuild
+         events.jsonl from the legacy JSONL state.
+      2. ``nx catalog t3-backfill-doc-id`` — write doc_id metadata to
+         existing T3 chunks (skipped under --no-chunks).
+      3. ``nx catalog doctor --replay-equality [--t3-doc-id-coverage
+         --strict-not-in-t3]`` — verify the result.
+
+    **Idempotent.** Pre-checks ``Catalog.bootstrap_fallback_active``.
+    If the catalog is already migrated (events.jsonl matches
+    documents.jsonl, no fallback) the verb exits 0 with "nothing to do"
+    rather than regenerating a perfectly-good event log. The empty-
+    events.jsonl synthesizer-PASS case (no ES mutations have happened
+    yet on a freshly-upgraded catalog) is treated as a proactive
+    migration opportunity, not a no-op — proactively populating the
+    log avoids the bootstrap-fallback state arising on first ES write.
+
+    Verified by ``scripts/validate/rdr-101-migration-e2e.sh`` (PR ζ
+    sandbox e2e harness, nexus-o6aa.9.10).
+    """
+    from nexus.catalog.catalog import Catalog
+    from nexus.catalog.event_log import EventLog
+    from nexus.config import catalog_path
+
+    cat_dir = catalog_path()
+    if not Catalog.is_initialized(cat_dir):
+        raise click.ClickException(
+            f"Catalog not initialized at {cat_dir}. "
+            "Run 'nx catalog setup' to create and populate it first."
+        )
+
+    status = _check_bootstrap_status()
+    fallback_active = status.get("fallback_active", False)
+
+    log = EventLog(cat_dir)
+    documents_path = cat_dir / "documents.jsonl"
+    has_legacy_docs = documents_path.exists() and documents_path.stat().st_size > 0
+    has_events = log.path.exists() and log.path.stat().st_size > 0
+
+    # Decision matrix:
+    #   has_legacy_docs=False & has_events=False → empty catalog: nothing to do
+    #   has_legacy_docs=True  & has_events=True  & not fallback_active
+    #     → already migrated cleanly: nothing to do
+    #   has_legacy_docs=True  & has_events=False
+    #     → freshly-upgraded, no ES mutations yet: proactively migrate
+    #   has_legacy_docs=True  & fallback_active   → migrate
+    needs_migration = has_legacy_docs and (not has_events or fallback_active)
+
+    if not needs_migration:
+        report = {
+            "needs_migration": False,
+            "reason": (
+                "catalog is empty"
+                if not has_legacy_docs
+                else "events.jsonl already covers documents.jsonl (no fallback active)"
+            ),
+            "fallback_active": fallback_active,
+            "documents_jsonl": str(documents_path),
+            "events_jsonl": str(log.path),
+        }
+        if as_json:
+            click.echo(json.dumps(report, indent=2))
+        else:
+            click.echo(f"Nothing to do — {report['reason']}.")
+        return
+
+    if dry_run:
+        report = {
+            "needs_migration": True,
+            "fallback_active": fallback_active,
+            "would_run": [
+                f"nx catalog synthesize-log --force"
+                + ("" if no_chunks else " --chunks"),
+            ] + (
+                [] if no_chunks else ["nx catalog t3-backfill-doc-id"]
+            ) + [
+                "nx catalog doctor --replay-equality"
+                + ("" if no_chunks else " --t3-doc-id-coverage --strict-not-in-t3"),
+            ],
+            "documents_jsonl": str(documents_path),
+            "events_jsonl": str(log.path),
+        }
+        if as_json:
+            click.echo(json.dumps(report, indent=2))
+        else:
+            click.echo("Migration plan:")
+            for step in report["would_run"]:
+                click.echo(f"  {step}")
+        return
+
+    # Step 1: synthesize-log --force.
+    click.echo("==> nx catalog synthesize-log --force"
+               + ("" if no_chunks else " --chunks"))
+    syn_args = ["--force"] + ([] if no_chunks else ["--chunks"])
+    try:
+        ctx.invoke(synthesize_log_cmd, **{
+            "dry_run": False,
+            "force": True,
+            "chunks": not no_chunks,
+            "as_json": False,
+        })
+    except click.ClickException as exc:
+        raise click.ClickException(
+            f"synthesize-log failed: {exc.message}. Migration aborted; "
+            "no further steps run."
+        ) from exc
+
+    # Step 2: t3-backfill-doc-id (unless --no-chunks).
+    if not no_chunks:
+        click.echo("==> nx catalog t3-backfill-doc-id")
+        try:
+            ctx.invoke(t3_backfill_doc_id_cmd, **{
+                "dry_run": False,
+                "collection_filter": "",
+                "as_json": False,
+            })
+        except click.ClickException as exc:
+            raise click.ClickException(
+                f"t3-backfill-doc-id failed: {exc.message}. Migration "
+                "partial; events.jsonl is current but T3 chunks may "
+                "lack doc_id metadata. Re-run 'nx catalog "
+                "t3-backfill-doc-id' after fixing the underlying issue."
+            ) from exc
+
+    # Step 3: doctor verification.
+    click.echo("==> nx catalog doctor --replay-equality"
+               + ("" if no_chunks else " --t3-doc-id-coverage --strict-not-in-t3"))
+    try:
+        ctx.invoke(doctor_cmd, **{
+            "replay_equality": True,
+            "t3_doc_id_coverage": not no_chunks,
+            "strict_not_in_t3": not no_chunks,
+            "as_json": False,
+        })
+    except click.exceptions.Exit as exc:
+        if exc.exit_code != 0:
+            raise click.ClickException(
+                "Migration completed but doctor verification did not "
+                "PASS. Inspect the report above; re-running this verb "
+                "is safe and idempotent."
+            ) from exc
+
+    click.echo("\nMigration complete.")

--- a/tests/test_catalog_migrate.py
+++ b/tests/test_catalog_migrate.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-101 Phase 3 follow-up D (nexus-o6aa.9.9): nx catalog migrate verb.
+
+Tests the one-shot migration verb that sequences synthesize-log + t3-
+backfill-doc-id + doctor verification. The verb is idempotent and
+pre-checks the bootstrap state to avoid regenerating a perfectly-good
+event log.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.commands.catalog import migrate_cmd
+
+
+def _init_legacy_catalog(tmp_path: Path) -> Path:
+    """Bootstrap a pre-RDR-101-style catalog: documents.jsonl populated,
+    events.jsonl empty.
+    """
+    d = tmp_path / "test-catalog"
+    Catalog.init(d)
+    return d
+
+
+def _populate_legacy(cat_dir: Path, n_docs: int = 2) -> None:
+    """Register *n_docs* under NEXUS_EVENT_SOURCED=0 so writes go to
+    legacy JSONL only. Caller must set the env var BEFORE this call.
+    """
+    cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    for i in range(n_docs):
+        cat.register(
+            owner, f"doc-{i}.md", content_type="prose",
+            file_path=f"doc-{i}.md",
+        )
+    cat._db.close()
+
+
+def _inject_event(events_path: Path, payload_dict: dict) -> None:
+    """Append a raw event line to events.jsonl. Used to construct the
+    sparse-state that triggers bootstrap_fallback_active.
+    """
+    if not events_path.exists():
+        events_path.touch()
+    with events_path.open("a") as f:
+        f.write(json.dumps(payload_dict, separators=(",", ":")))
+        f.write("\n")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Idempotency: nothing-to-do paths
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_migrate_no_op_on_empty_catalog(tmp_path, monkeypatch):
+    """An empty catalog (no documents.jsonl) should report "nothing to
+    do" and exit 0.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    d = tmp_path / "test-catalog"
+    Catalog.init(d)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    runner = CliRunner()
+    result = runner.invoke(migrate_cmd, ["--no-chunks"])
+
+    assert result.exit_code == 0, result.output
+    assert "nothing to do" in result.output.lower()
+    assert "catalog is empty" in result.output.lower()
+
+
+def test_migrate_no_op_when_already_migrated(tmp_path, monkeypatch):
+    """A catalog whose events.jsonl already covers documents.jsonl
+    should report "nothing to do" and not regenerate the event log.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    d = _init_legacy_catalog(tmp_path)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    # Populate under ES so events.jsonl is built alongside documents.jsonl
+    # — net_registered ≥ legacy_doc_count, no fallback.
+    cat = Catalog(d, d / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+    for i in range(3):
+        cat.register(
+            owner, f"doc-{i}.md", content_type="prose",
+            file_path=f"doc-{i}.md",
+        )
+    cat._db.close()
+
+    events_path = d / "events.jsonl"
+    pre_size = events_path.stat().st_size
+
+    runner = CliRunner()
+    result = runner.invoke(migrate_cmd, ["--no-chunks"])
+
+    assert result.exit_code == 0, result.output
+    assert "nothing to do" in result.output.lower()
+    # events.jsonl size unchanged — no regeneration.
+    assert events_path.stat().st_size == pre_size
+
+
+def test_migrate_dry_run_reports_plan(tmp_path, monkeypatch):
+    """--dry-run on a catalog that needs migration prints the plan
+    without writing anything.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_legacy_catalog(tmp_path)
+    _populate_legacy(d, n_docs=3)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    # Inject a stray event to trigger fallback_active.
+    _inject_event(d / "events.jsonl", {
+        "type": "DocumentRegistered", "v": 0,
+        "payload": {
+            "doc_id": "1.1.99", "owner_id": "1.1",
+            "content_type": "prose", "source_uri": "",
+            "coll_id": "", "title": "stray.md", "tumbler": "1.1.99",
+            "author": "", "year": 0, "file_path": "stray.md",
+            "corpus": "", "physical_collection": "",
+            "chunk_count": 0, "head_hash": "", "indexed_at": "",
+            "alias_of": "", "meta": {}, "source_mtime": 0.0,
+            "indexed_at_doc": "",
+        },
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    runner = CliRunner()
+    result = runner.invoke(migrate_cmd, ["--dry-run", "--no-chunks"])
+
+    assert result.exit_code == 0, result.output
+    assert "Migration plan" in result.output
+    assert "synthesize-log --force" in result.output
+    # --no-chunks: should NOT mention t3-backfill-doc-id in the plan.
+    assert "t3-backfill-doc-id" not in result.output
+
+
+def test_migrate_dry_run_json(tmp_path, monkeypatch):
+    """--dry-run --json emits a structured plan."""
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_legacy_catalog(tmp_path)
+    _populate_legacy(d, n_docs=2)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    _inject_event(d / "events.jsonl", {
+        "type": "DocumentDeleted", "v": 0,
+        "payload": {"doc_id": "1.1.99", "tumbler": "1.1.99", "reason": "test"},
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    runner = CliRunner()
+    result = runner.invoke(
+        migrate_cmd, ["--dry-run", "--no-chunks", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    out = result.output
+    payload = json.loads(out[out.find("{"):])
+    assert payload["needs_migration"] is True
+    assert payload["fallback_active"] is True
+    assert any("synthesize-log" in step for step in payload["would_run"])
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Active migration paths
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_migrate_proactive_populates_empty_event_log(tmp_path, monkeypatch):
+    """Freshly-upgraded catalog (legacy docs, empty events.jsonl).
+    The bootstrap-fallback flag is False, but the verb still
+    proactively populates events.jsonl so the log catches up before
+    any ES write happens.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_legacy_catalog(tmp_path)
+    _populate_legacy(d, n_docs=2)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    events_path = d / "events.jsonl"
+    assert (
+        not events_path.exists() or events_path.stat().st_size == 0
+    ), "precondition: events.jsonl empty"
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    runner = CliRunner()
+    result = runner.invoke(migrate_cmd, ["--no-chunks"])
+
+    assert result.exit_code == 0, result.output
+    assert "Migration complete" in result.output
+    # events.jsonl now populated.
+    assert events_path.exists()
+    assert events_path.stat().st_size > 0
+
+
+def test_migrate_recovers_from_bootstrap_fallback(tmp_path, monkeypatch):
+    """The textbook scenario: legacy docs + sparse events.jsonl =
+    bootstrap_fallback_active. migrate runs synthesize-log --force,
+    rebuilding the log to cover documents.jsonl. Doctor PASS post-
+    migration.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_legacy_catalog(tmp_path)
+    _populate_legacy(d, n_docs=4)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    # Sparse the event log: 1 stray DocumentDeleted vs 4 legacy docs.
+    _inject_event(d / "events.jsonl", {
+        "type": "DocumentDeleted", "v": 0,
+        "payload": {"doc_id": "1.1.99", "tumbler": "1.1.99", "reason": "stray"},
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    # Confirm fallback fires.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    cat = Catalog(d, d / ".catalog.db")
+    assert cat.bootstrap_fallback_active is True
+    cat._db.close()
+
+    runner = CliRunner()
+    result = runner.invoke(migrate_cmd, ["--no-chunks"])
+
+    assert result.exit_code == 0, result.output
+    assert "Migration complete" in result.output
+
+    # Post-migration the fallback flag must clear on a fresh Catalog.
+    cat2 = Catalog(d, d / ".catalog.db")
+    assert cat2.bootstrap_fallback_active is False
+    cat2._db.close()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Idempotency: re-run after migration
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_migrate_is_idempotent(tmp_path, monkeypatch):
+    """Running migrate twice in a row: the second run reports
+    "nothing to do" because the first one converged the log to cover
+    documents.jsonl.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_legacy_catalog(tmp_path)
+    _populate_legacy(d, n_docs=3)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    runner = CliRunner()
+    first = runner.invoke(migrate_cmd, ["--no-chunks"])
+    assert first.exit_code == 0
+    assert "Migration complete" in first.output
+
+    second = runner.invoke(migrate_cmd, ["--no-chunks"])
+    assert second.exit_code == 0
+    assert "nothing to do" in second.output.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Error paths
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_migrate_fails_loudly_when_catalog_uninitialized(tmp_path, monkeypatch):
+    """Catalog not initialized: clean error, no partial state."""
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    d = tmp_path / "missing-catalog"  # never created
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    runner = CliRunner()
+    result = runner.invoke(migrate_cmd, ["--no-chunks"])
+
+    assert result.exit_code != 0
+    assert "not initialized" in result.output.lower()

--- a/tests/test_migration_prompt.py
+++ b/tests/test_migration_prompt.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-101 Phase 3 follow-up D (nexus-o6aa.9.9): TTY-gated upgrade
+prompt for the bootstrap-fallback state.
+
+The prompt must:
+* Fire once per process (sentinel reset between tests).
+* Suppress in non-TTY contexts.
+* Suppress under NEXUS_NO_PROMPTS=1.
+* Suppress when fallback_active is False.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nexus.commands import _migration_prompt
+
+
+@pytest.fixture(autouse=True)
+def _reset_sentinel():
+    """The module-level _PROMPTED sentinel persists between tests in
+    the same process. Reset before each test so tests are independent.
+    """
+    _migration_prompt._PROMPTED = False
+    yield
+    _migration_prompt._PROMPTED = False
+
+
+def test_prompt_fires_once_when_fallback_active_and_tty(capsys):
+    """All gates pass: stderr is a TTY, NEXUS_NO_PROMPTS unset, fallback
+    active. Expect a stderr WARNING with the migration verb name.
+    """
+    with patch(
+        "nexus.commands.catalog._check_bootstrap_status",
+        return_value={"fallback_active": True},
+    ), patch("sys.stderr.isatty", return_value=True), \
+       patch.dict("os.environ", {}, clear=False):
+        # Make sure NEXUS_NO_PROMPTS is unset.
+        import os
+        os.environ.pop("NEXUS_NO_PROMPTS", None)
+
+        _migration_prompt.maybe_emit_bootstrap_prompt()
+
+    captured = capsys.readouterr()
+    assert "bootstrap-fallback active" in captured.err
+    assert "nx catalog migrate" in captured.err
+    assert "NEXUS_NO_PROMPTS" in captured.err
+
+
+def test_prompt_fires_only_once_per_process(capsys):
+    """Two consecutive calls when gates pass: only the first emits.
+    Multiple Catalog constructions in one CLI run must not double-
+    prompt.
+    """
+    with patch(
+        "nexus.commands.catalog._check_bootstrap_status",
+        return_value={"fallback_active": True},
+    ), patch("sys.stderr.isatty", return_value=True):
+        import os
+        os.environ.pop("NEXUS_NO_PROMPTS", None)
+        _migration_prompt.maybe_emit_bootstrap_prompt()
+        _migration_prompt.maybe_emit_bootstrap_prompt()
+
+    captured = capsys.readouterr()
+    # Single emission — count occurrences of the unique header line.
+    assert captured.err.count("bootstrap-fallback active") == 1
+
+
+def test_prompt_suppressed_when_not_tty(capsys):
+    """Non-TTY context (CI / cron / MCP / pipe redirect): no prompt."""
+    with patch(
+        "nexus.commands.catalog._check_bootstrap_status",
+        return_value={"fallback_active": True},
+    ), patch("sys.stderr.isatty", return_value=False):
+        import os
+        os.environ.pop("NEXUS_NO_PROMPTS", None)
+        _migration_prompt.maybe_emit_bootstrap_prompt()
+
+    captured = capsys.readouterr()
+    assert "bootstrap-fallback" not in captured.err
+
+
+def test_prompt_suppressed_by_nexus_no_prompts_env(capsys, monkeypatch):
+    """NEXUS_NO_PROMPTS=1 escape hatch: no prompt even in TTY context."""
+    monkeypatch.setenv("NEXUS_NO_PROMPTS", "1")
+    with patch(
+        "nexus.commands.catalog._check_bootstrap_status",
+        return_value={"fallback_active": True},
+    ), patch("sys.stderr.isatty", return_value=True):
+        _migration_prompt.maybe_emit_bootstrap_prompt()
+
+    captured = capsys.readouterr()
+    assert "bootstrap-fallback" not in captured.err
+
+
+@pytest.mark.parametrize("val", ["true", "yes", "on", "TRUE", "1"])
+def test_prompt_suppressed_by_truthy_no_prompts_values(
+    val: str, capsys, monkeypatch,
+):
+    """Several truthy spellings of NEXUS_NO_PROMPTS suppress."""
+    monkeypatch.setenv("NEXUS_NO_PROMPTS", val)
+    with patch(
+        "nexus.commands.catalog._check_bootstrap_status",
+        return_value={"fallback_active": True},
+    ), patch("sys.stderr.isatty", return_value=True):
+        _migration_prompt.maybe_emit_bootstrap_prompt()
+
+    captured = capsys.readouterr()
+    assert "bootstrap-fallback" not in captured.err
+
+
+def test_prompt_suppressed_when_fallback_not_active(capsys):
+    """Catalog is fine — no fallback. No prompt."""
+    with patch(
+        "nexus.commands.catalog._check_bootstrap_status",
+        return_value={"fallback_active": False},
+    ), patch("sys.stderr.isatty", return_value=True):
+        import os
+        os.environ.pop("NEXUS_NO_PROMPTS", None)
+        _migration_prompt.maybe_emit_bootstrap_prompt()
+
+    captured = capsys.readouterr()
+    assert "bootstrap-fallback" not in captured.err
+
+
+def test_prompt_swallows_check_exceptions(capsys):
+    """If _check_bootstrap_status raises (filesystem issue, etc.),
+    the prompt suppresses rather than disrupting the CLI invocation.
+    The prompt is advisory; the underlying state is logged via
+    structlog and surfaced in doctor's structured output regardless.
+    """
+    with patch(
+        "nexus.commands.catalog._check_bootstrap_status",
+        side_effect=RuntimeError("simulated check failure"),
+    ), patch("sys.stderr.isatty", return_value=True):
+        import os
+        os.environ.pop("NEXUS_NO_PROMPTS", None)
+        # Must not raise.
+        _migration_prompt.maybe_emit_bootstrap_prompt()
+
+    captured = capsys.readouterr()
+    assert "bootstrap-fallback" not in captured.err


### PR DESCRIPTION
Operator-facing migration polish on top of bead C's bootstrap-fallback observability. Builds on PR #455 (.9.10 e2e harness) which informed the verb's idempotency decisions.

## Summary

- **`nx catalog migrate`** — one-shot composed verb. Sequences `synthesize-log --force` (with `--chunks` by default) + `t3-backfill-doc-id` + `doctor --replay-equality --t3-doc-id-coverage --strict-not-in-t3`. Idempotent: exits 0 "nothing to do" when already migrated or catalog is empty. `--dry-run` reports the plan. `--no-chunks` for catalogs without T3.
- **TTY-gated upgrade prompt** at `nexus.cli.main`. Fires once per CLI invocation when `bootstrap_fallback_active` is True, stderr is a TTY, and `NEXUS_NO_PROMPTS` is unset. Suppresses everywhere else (MCP / cron / CI / scripts).
- **`docs/migration/rdr-101.md`** — operator guide. Two scenarios, command sequence, verification, rollback (`NEXUS_EVENT_SOURCED=0` until Phase 5c), four states/signals matrix, failure modes.

## Refinements informed by .9.10 (#455)

The harness surfaced that the bead's original spec had a sloppy expectation: bootstrap-fallback only fires on a **sparse** events.jsonl, not an **empty** one (the size gate falls through to legacy + synthesizer first). The migrate verb now handles both states explicitly:

| State | Verb behaviour |
|---|---|
| Empty catalog (no docs) | exit 0, "catalog is empty" |
| Already migrated (events.jsonl ≥ documents.jsonl) | exit 0, "no fallback active" |
| Freshly upgraded, empty events.jsonl | proactive populate (avoids bootstrap-fallback arising on first ES write) |
| Sparse events.jsonl, fallback active | full migration sequence |

## TTY prompt design

- **Hook point:** Click group callback in `cli.main`, NOT `Catalog.__init__`. The latter would fire from MCP / library / test contexts.
- **Escape hatch:** `NEXUS_NO_PROMPTS=1` / `true` / `yes` / `on`. Same pattern as pip's `--quiet` / npm's `NPM_CONFIG_LOGLEVEL`.
- **Once-per-process sentinel.** Multiple Catalog constructions in one CLI run (e.g. doctor's pre-check + the actual check) must not double-emit.
- **structlog warning + doctor `--json` `bootstrap_fallback` key stay** — TTY prompt is additive for humans, not a replacement.
- **Best-effort.** Any exception in the gate logic suppresses the prompt rather than disrupting the CLI invocation.

## Tests

- `tests/test_catalog_migrate.py` — 8 tests covering idempotency, dry-run, JSON, proactive populate, fallback recovery, double-run, error path.
- `tests/test_migration_prompt.py` — 11 tests covering all four gates, including 5-value parameterized truthy `NEXUS_NO_PROMPTS` matrix.

## Verification

Targeted sweep (`catalog or event_log or projector or rdr101 or dedupe or doctor or no_direct_catalog_writes or bootstrap or migrate or migration`): **1182 passed, 1 skipped, 5201 deselected**.

## Refs

- Bead: `nexus-o6aa.9.9` (P1, parent: `nexus-o6aa.9`)
- Depends on (all merged): `nexus-o6aa.9.6` (#449), `nexus-o6aa.9.7` (#453), `nexus-o6aa.9.8` (#454)
- Companion (in-flight): `nexus-o6aa.9.10` (#455 — e2e harness; semantically informed this work)