### PR TITLE
fix(catalog): clean migration UX — sync live SQLite + import vector-only collections (nexus-o6aa.9.14 + .9.15)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -492,3 +492,4 @@
 {"id":"int-140c3f2b","kind":"field_change","created_at":"2026-05-01T21:51:50.743853Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.8","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-97839c28","kind":"field_change","created_at":"2026-05-01T22:33:11.883549Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.10","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-533ba482","kind":"field_change","created_at":"2026-05-01T23:03:34.791321Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.11","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-4496909b","kind":"field_change","created_at":"2026-05-02T00:57:24.188922Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.14","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -4677,6 +4677,31 @@ def migrate_cmd(
                 "t3-backfill-doc-id' after fixing the underlying issue."
             ) from exc
 
+    # Synchronize live SQLite to events.jsonl before doctor runs.
+    # nexus-o6aa.9.14: ``synthesize-log`` writes events.jsonl but does
+    # NOT re-project into SQLite — the live SQLite from before the
+    # migration retains its legacy-rebuild shape. Doctor's
+    # ``_run_replay_equality`` opens ``.catalog.db`` directly via
+    # ``sqlite3.connect(...mode=ro)`` (read-only snapshot) and bypasses
+    # ``Catalog._ensure_consistent`` entirely, so it never triggers
+    # the ES rebuild that would heal the live state. Without this
+    # explicit sync, doctor reports FAIL on every row whose JSONL
+    # shape differs from what the synthesizer emits (e.g. ``meta:
+    # null`` in JSONL → ``'null'`` in legacy SQLite vs ``'{}'`` in
+    # the projection). Constructing a fresh Catalog here triggers
+    # ``_ensure_consistent``'s ES rebuild path, which DELETEs and
+    # replays events.jsonl into the live SQLite. After that, doctor's
+    # comparison is apples-to-apples.
+    click.echo("==> sync live SQLite to events.jsonl")
+    sync_cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+    try:
+        # Constructor calls ``_ensure_consistent`` at the end of
+        # __init__; the rebuild is in the live ``.catalog.db`` by the
+        # time ``_db.commit()`` returns.
+        sync_cat._db.commit()
+    finally:
+        sync_cat._db.close()
+
     # Step 3: doctor verification.
     click.echo("==> nx catalog doctor --replay-equality"
                + ("" if no_chunks else " --t3-doc-id-coverage --strict-not-in-t3"))

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -377,28 +377,35 @@ class T3Database:
         """
         # Defense-in-depth: drop any document that exceeds the hard ChromaDB limit.
         # The chunker-level SAFE_CHUNK_BYTES cap should prevent this from ever firing.
+        # Vector-only entries (``taxonomy__centroids``) legitimately have
+        # ``document=None`` — treat as zero-byte rather than crashing on
+        # ``None.encode()`` (nexus-fxc1).
         max_bytes = QUOTAS.MAX_DOCUMENT_BYTES
+
+        def _doc_bytes(d: str | None) -> int:
+            return 0 if d is None else len(d.encode())
+
         valid = [
             i for i, doc in enumerate(documents)
-            if len(doc.encode()) <= max_bytes
+            if _doc_bytes(doc) <= max_bytes
         ]
         if len(valid) < len(documents):
             for i, doc in enumerate(documents):
-                if len(doc.encode()) > max_bytes:
+                if _doc_bytes(doc) > max_bytes:
                     source = metadatas[i].get("source_path", "<unknown>") if i < len(metadatas) else "<unknown>"
                     if fail_on_oversized:
                         from nexus.errors import PutOversizedError
 
                         raise PutOversizedError(
                             doc_id=ids[i],
-                            doc_bytes=len(doc.encode()),
+                            doc_bytes=_doc_bytes(doc),
                             max_bytes=max_bytes,
                             collection=collection_name,
                         )
                     _log.warning(
                         "write_batch_oversized_document_dropped",
                         source_path=source,
-                        doc_bytes=len(doc.encode()),
+                        doc_bytes=_doc_bytes(doc),
                         max_bytes=max_bytes,
                         collection=collection_name,
                     )

--- a/src/nexus/exporter.py
+++ b/src/nexus/exporter.py
@@ -336,7 +336,11 @@ def import_collection(
             unpacker = msgpack.Unpacker(gz, raw=False, max_buffer_size=10 * 1024 * 1024)
             for record in unpacker:
                 rec_id: str = record["id"]
-                doc: str = record["document"]
+                # Vector-only entries (e.g. ``taxonomy__centroids``) round-trip
+                # ``document=None``. Coerce to empty string so the downstream
+                # write path's byte-length checks don't trip on ``None.encode()``
+                # (nexus-fxc1).
+                doc: str = record["document"] or ""
                 meta: dict = record["metadata"]
                 emb_bytes: bytes = record["embedding"]
 

--- a/tests/test_catalog_migrate.py
+++ b/tests/test_catalog_migrate.py
@@ -278,3 +278,94 @@ def test_migrate_fails_loudly_when_catalog_uninitialized(tmp_path, monkeypatch):
 
     assert result.exit_code != 0
     assert "not initialized" in result.output.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# nexus-o6aa.9.14: migrate forces ES rebuild before doctor verification
+# so live SQLite reflects the post-synthesize-log state. Without the
+# rebuild step, doctor's _run_replay_equality opens .catalog.db
+# read-only and compares the legacy-rebuild SQLite to a fresh
+# projection of events.jsonl — they diverge on any row whose JSONL
+# shape differs from what the synthesizer emits.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_migrate_syncs_live_sqlite_to_events_for_doctor_pass(
+    tmp_path, monkeypatch,
+):
+    """The end-to-end UX assertion: a row whose legacy JSONL has
+    ``"meta": null`` produces the literal SQLite string ``'null'`` on
+    legacy rebuild but the synthesizer emits ``meta={}`` (default-
+    factory coercion). Pre-fix: migrate runs synth-log + doctor;
+    doctor compares un-rebuilt live (``'null'``) to projection
+    (``'{}'``) and FAILs. Post-fix: migrate forces a Catalog
+    construction between t3-backfill and doctor, triggering the ES
+    rebuild that synchronizes live SQLite to events.jsonl. Doctor
+    PASSes.
+    """
+    # Legacy populate.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    d = _init_legacy_catalog(tmp_path)
+    _populate_legacy(d, n_docs=3)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(d))
+
+    # Inject a row with ``meta: null`` directly into documents.jsonl
+    # to reproduce the shape drift Hal's real catalog has on 11 rows.
+    docs_path = d / "documents.jsonl"
+    with docs_path.open("a") as f:
+        f.write(json.dumps({
+            "tumbler": "1.1.99",
+            "title": "drift.py",
+            "author": "",
+            "year": 0,
+            "content_type": "code",
+            "file_path": "drift.py",
+            "corpus": "",
+            "physical_collection": "code__drift",
+            "chunk_count": 0,
+            "head_hash": "",
+            "indexed_at": "2026-04-08T16:55:55.193766+00:00",
+            "meta": None,
+            "source_mtime": 0.0,
+            "alias_of": "",
+            "source_uri": "file:///tmp/drift.py",
+            "_deleted": False,
+        }))
+        f.write("\n")
+
+    # Force a legacy rebuild so the null-meta row lands in SQLite.
+    cat = Catalog(d, d / ".catalog.db")
+    drift_meta = cat._db.execute(
+        "SELECT metadata FROM documents WHERE tumbler = ?", ("1.1.99",),
+    ).fetchone()
+    cat._db.close()
+    assert drift_meta is not None and drift_meta[0] == "null", (
+        f"legacy rebuild should produce 'null' from meta:null JSONL; "
+        f"got {drift_meta!r}"
+    )
+
+    # Now flip ES on and run migrate. Pre-fix this leaves live SQLite
+    # at 'null' while events project to '{}', so doctor would FAIL.
+    # Post-fix the migrate verb's explicit Catalog construction
+    # triggers _ensure_consistent's ES rebuild → live becomes '{}'.
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    runner = CliRunner()
+    result = runner.invoke(migrate_cmd, ["--no-chunks"])
+
+    assert result.exit_code == 0, (
+        f"migrate did not converge to a clean PASS post-fix; output:\n"
+        f"{result.output}"
+    )
+    assert "Migration complete" in result.output
+
+    # Verify the live SQLite was rebuilt: drift.py's metadata is now
+    # '{}' (events.jsonl shape), not 'null' (legacy shape).
+    cat2 = Catalog(d, d / ".catalog.db")
+    drift_meta_post = cat2._db.execute(
+        "SELECT metadata FROM documents WHERE tumbler = ?", ("1.1.99",),
+    ).fetchone()
+    cat2._db.close()
+    assert drift_meta_post[0] == "{}", (
+        f"migrate did not sync live SQLite to events.jsonl; the null "
+        f"row is still 'null' instead of '{{}}': got {drift_meta_post!r}"
+    )

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -468,3 +468,116 @@ class TestCorruptMsgpackBody:
         ephemeral_db.get_or_create_collection("knowledge__corrupt")
         with pytest.raises(Exception):
             import_collection(ephemeral_db, out)
+
+
+# ── Vector-only entries (document=None) ──────────────────────────────────────
+
+
+class TestVectorOnlyImport:
+    """Regression for nexus-fxc1: ``taxonomy__centroids`` and similar
+    vector-only collections store ``document=None`` and round-trip that
+    via ``.nxexp``.  The import path used to crash with
+    ``'NoneType' object has no attribute 'encode'`` because the
+    byte-length check in ``_write_batch`` called ``doc.encode()``
+    unconditionally.
+    """
+
+    def _write_nxexp_with_none_docs(
+        self, path: Path, collection_name: str, n_records: int = 3, dim: int = 16
+    ) -> None:
+        import msgpack
+
+        header = {
+            "format_version": FORMAT_VERSION,
+            "collection_name": collection_name,
+            "database_type": collection_name.split("__")[0],
+            "embedding_model": "voyage-code-3",
+            "record_count": n_records,
+            "embedding_dim": dim,
+            "exported_at": "2026-05-01T00:00:00+00:00",
+            "pipeline_version": "nexus-1",
+        }
+        with open(path, "wb") as f:
+            f.write(json.dumps(header).encode() + b"\n")
+            with gzip.GzipFile(fileobj=f, mode="wb") as gz:
+                rng = np.random.default_rng(seed=42)
+                for i in range(n_records):
+                    emb = rng.standard_normal(dim).astype(np.float32).tobytes()
+                    gz.write(msgpack.packb(
+                        {
+                            "id": f"vec-only-{i:03d}",
+                            "document": None,  # vector-only entry
+                            "metadata": {"topic_id": i, "label": f"cluster-{i}"},
+                            "embedding": emb,
+                        },
+                        use_bin_type=True,
+                    ))
+
+    def test_import_succeeds_when_documents_are_none(
+        self, ephemeral_db: T3Database, tmp_path: Path
+    ):
+        out = tmp_path / "vec_only.nxexp"
+        col_name = "taxonomy__test_centroids"
+        self._write_nxexp_with_none_docs(out, col_name, n_records=3)
+
+        # Pre-create the collection so the EF override applies — matches
+        # the production flow where the collection already exists.
+        ephemeral_db.get_or_create_collection(col_name)
+
+        result = import_collection(ephemeral_db, out)
+        assert result["imported_count"] == 3
+        assert result["collection_name"] == col_name
+
+        col = ephemeral_db._client_for(col_name).get_collection(col_name)
+        assert col.count() == 3
+        # Vector-only entries should have empty (or None) documents and
+        # the original embeddings preserved.
+        got = col.get(include=["documents", "embeddings"])
+        assert all((d == "" or d is None) for d in got["documents"])
+        assert len(got["embeddings"]) == 3
+        assert len(got["embeddings"][0]) == 16
+
+    def test_import_mixed_some_none_some_text(
+        self, ephemeral_db: T3Database, tmp_path: Path
+    ):
+        """Mixed batch: half ``document=None``, half real text. Both must import."""
+        import msgpack
+
+        col_name = "taxonomy__mixed"
+        out = tmp_path / "mixed.nxexp"
+        header = {
+            "format_version": FORMAT_VERSION,
+            "collection_name": col_name,
+            "database_type": "taxonomy",
+            "embedding_model": "voyage-code-3",
+            "record_count": 4,
+            "embedding_dim": 16,
+            "exported_at": "2026-05-01T00:00:00+00:00",
+            "pipeline_version": "nexus-1",
+        }
+        rng = np.random.default_rng(seed=7)
+        records = [
+            {"id": "a", "document": None,        "metadata": {"k": "v1"}},
+            {"id": "b", "document": "real text", "metadata": {"k": "v2"}},
+            {"id": "c", "document": None,        "metadata": {"k": "v3"}},
+            {"id": "d", "document": "more text", "metadata": {"k": "v4"}},
+        ]
+        with open(out, "wb") as f:
+            f.write(json.dumps(header).encode() + b"\n")
+            with gzip.GzipFile(fileobj=f, mode="wb") as gz:
+                for r in records:
+                    r["embedding"] = rng.standard_normal(16).astype(np.float32).tobytes()
+                    gz.write(msgpack.packb(r, use_bin_type=True))
+
+        ephemeral_db.get_or_create_collection(col_name)
+        result = import_collection(ephemeral_db, out)
+        assert result["imported_count"] == 4
+
+        col = ephemeral_db._client_for(col_name).get_collection(col_name)
+        assert col.count() == 4
+        got = col.get(ids=["a", "b"], include=["documents"])
+        # ``a`` was None, normalized to ""; ``b`` keeps its text.
+        a_doc = got["documents"][got["ids"].index("a")]
+        b_doc = got["documents"][got["ids"].index("b")]
+        assert a_doc in ("", None)
+        assert b_doc == "real text"


### PR DESCRIPTION
Two operator-experience defects surfaced by the .9.10 sandbox e2e harness running against Hal's real catalog clone (312k chunks, 142 collections).

## .9.14 — `nx catalog migrate` must force ES rebuild before doctor

**The bug:** `synthesize-log` writes events.jsonl but doesn't re-project SQLite. Doctor's `_run_replay_equality` opens `.catalog.db` directly via `sqlite3.connect(...mode=ro)` — bypasses `Catalog._ensure_consistent`, so live SQLite stays in its pre-migration state. Doctor compares stale-live to fresh-projection and FAILs on cosmetic shape drift (e.g. legacy SQLite has `'null'` from a JSONL `"meta": null`; synthesizer emits `meta={}`; projection has `'{}'`).

Hal's real catalog has 11 such rows. Pre-fix the migration would exit non-zero with confusing FAIL output for every operator on upgrade.

**Fix:** in `migrate_cmd`, after `t3-backfill` and before doctor, construct a fresh `Catalog(cat_dir, ...)`. The `__init__` calls `_ensure_consistent` which now sees populated events.jsonl, takes the ES rebuild branch, DELETEs and replays events into live SQLite. Doctor's subsequent read-only snapshot matches the projection. Clean PASS.

**Regression test** in `tests/test_catalog_migrate.py::test_migrate_syncs_live_sqlite_to_events_for_doctor_pass` — hand-injects a `"meta": null` row, runs migrate, asserts live SQLite is healed to `'{}'` and migrate exits 0. **TEETH confirmed**: pre-fix the test fails with the exact mismatch.

## .9.15 — `nx store import` crashes on vector-only collections

**The bug:** `taxonomy__centroids` import: `Error: Import failed: 'NoneType' object has no attribute 'encode'`. Centroids are vector-only entries with `document=None`; `src/nexus/db/t3.py:380` `_write_batch` called `doc.encode()` unconditionally in the oversize-doc check.

**Fix (two-layer defense):**
- `src/nexus/exporter.py:339` — coerce `record["document"] or ""` at import site.
- `src/nexus/db/t3.py:380-410` — `_doc_bytes()` helper returns 0 for None; defense in depth for any caller passing None to `_write_batch`.

**Regression tests** in `tests/test_exporter.py::TestVectorOnlyImport` — 2 cases (all-None, mixed). Verified end-to-end: previously-failing import now succeeds (`Imported 2014 records into taxonomy__centroids (0.5s)`).

## Out of scope (filed for follow-up)

The canonical metadata-schema funnel strips taxonomy-specific keys (`topic_id`, `label`, `doc_count`) on import. Imported centroid records lose taxonomy enrichment. Functional impact: low; worth filing a separate bead to whitelist taxonomy keys.

## Verification

- 74 tests pass across migrate / exporter / t3-backfill / partial-failure / bootstrap modules.
- TEETH confirmed for the migrate fix.
- Re-running the .9.10 sandbox cycle against Hal's real-catalog clone post-merge will validate both fixes converge to a clean PASS end-to-end.

## Refs

- Beads: `nexus-o6aa.9.14` (P1) + `nexus-o6aa.9.15` (P2), parent: `nexus-o6aa.9`
- Builds on `nexus-o6aa.9.10` (sandbox harness, MERGED) which surfaced both