### PR TITLE
feat(catalog): t3-backfill per-chunk retry + deferred-class quota differentiation (nexus-o6aa.9.18)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -493,3 +493,4 @@
 {"id":"int-97839c28","kind":"field_change","created_at":"2026-05-01T22:33:11.883549Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.10","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-533ba482","kind":"field_change","created_at":"2026-05-01T23:03:34.791321Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.11","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-4496909b","kind":"field_change","created_at":"2026-05-02T00:57:24.188922Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.14","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-9cdfe64f","kind":"field_change","created_at":"2026-05-02T01:57:49.587581Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.18","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3960,6 +3960,7 @@ def t3_backfill_doc_id_cmd(
 
     chunks_updated = 0
     chunks_already_correct = 0
+    chunks_deferred: list[dict] = []
     errors: list[dict] = []
 
     if not dry_run:
@@ -3969,6 +3970,21 @@ def t3_backfill_doc_id_cmd(
             raise click.ClickException(
                 f"Failed to open T3 client: {exc}. Check ChromaDB credentials."
             )
+
+    # nexus-o6aa.9.18: deferred-class detector for the per-chunk
+    # retry path. Errors carrying a class string in this set are
+    # treated as expected during the Phase 4 transition (chunks
+    # over the 32-key NumMetadataKeys cap that pre-date the cap or
+    # carry deprecated metadata Phase 4 will prune). They land in
+    # ``chunks_deferred`` rather than ``errors`` so the verb exits
+    # 0 — the operator sees a deferred-cleanup list, not a failure.
+    DEFERRED_QUOTA_HINTS: tuple[str, ...] = (
+        "NumMetadataKeys",
+        "Number of metadata dictionary keys",
+    )
+
+    def _is_deferred_error(exc_text: str) -> bool:
+        return any(hint in exc_text for hint in DEFERRED_QUOTA_HINTS)
 
     for coll_name, payloads in by_coll.items():
         if dry_run:
@@ -4026,12 +4042,32 @@ def t3_backfill_doc_id_cmd(
                 col.update(ids=update_ids, metadatas=update_metas)
                 chunks_updated += len(update_ids)
             except Exception as exc:
-                errors.append({
-                    "collection": coll_name,
-                    "stage": "update",
-                    "batch_size": len(update_ids),
-                    "error": str(exc),
-                })
+                # nexus-o6aa.9.18: batch-level rejection is all-or-nothing.
+                # Fall back to per-chunk updates so clean chunks in a
+                # batch with one over-cap chunk still get doc_id; only
+                # the genuinely-failing chunks land in chunks_deferred.
+                # Pre-fix this swept ~22k clean chunks into the deferred
+                # list because ChromaDB's 32-key NumMetadataKeys cap
+                # rejected the whole batch on the first over-cap chunk.
+                for cid, meta in zip(update_ids, update_metas):
+                    try:
+                        col.update(ids=[cid], metadatas=[meta])
+                        chunks_updated += 1
+                    except Exception as inner_exc:
+                        msg = str(inner_exc)
+                        record = {
+                            "collection": coll_name,
+                            "chunk_id": cid,
+                            "key_count": len(meta),
+                            "error": msg[:200],
+                        }
+                        if _is_deferred_error(msg):
+                            chunks_deferred.append(record)
+                        else:
+                            errors.append({
+                                **record, "stage": "update_per_chunk",
+                                "batch_size": 1,
+                            })
 
     report = {
         "dry_run": dry_run,
@@ -4042,6 +4078,8 @@ def t3_backfill_doc_id_cmd(
         "chunks_updated": chunks_updated,
         "chunks_already_correct": chunks_already_correct,
         "orphans_skipped": orphans_total,
+        "chunks_deferred": chunks_deferred,
+        "chunks_deferred_count": len(chunks_deferred),
         "errors": errors,
     }
 
@@ -4050,9 +4088,12 @@ def t3_backfill_doc_id_cmd(
     else:
         _print_t3_backfill_text(report)
 
+    # nexus-o6aa.9.18: deferred-class failures (NumMetadataKeys quota)
+    # are expected during the Phase 4 transition — they represent
+    # over-cap chunks awaiting the prune-deprecated-keys verb. Exit 0
+    # when the only failures were deferred-class. Genuine errors
+    # (network, auth, schema, etc.) still surface as exit 1.
     if errors and not dry_run:
-        # Surface a non-zero exit so an operator running this in a
-        # script can detect partial failure.
         raise click.exceptions.Exit(1)
 
 
@@ -4067,6 +4108,19 @@ def _print_t3_backfill_text(report: dict) -> None:
         click.echo(f"Chunks updated:        {report['chunks_updated']}")
         click.echo(f"Already correct:       {report['chunks_already_correct']}")
     click.echo(f"Orphans skipped:       {report['orphans_skipped']}")
+    deferred = report.get("chunks_deferred_count", 0)
+    if deferred:
+        click.echo(
+            f"Deferred (over-cap):   {deferred}  (Phase 4 prune-keys remediation)"
+        )
+        # First few examples for operator visibility.
+        for d in (report.get("chunks_deferred") or [])[:3]:
+            click.echo(
+                f"  {d['collection']} {d['chunk_id'][:24]}…  "
+                f"keys={d['key_count']}"
+            )
+        if deferred > 3:
+            click.echo(f"  …and {deferred - 3} more (use --json for full list)")
     if report["errors"]:
         click.echo(f"\nErrors ({len(report['errors'])}):")
         for e in report["errors"][:10]:

--- a/tests/test_catalog_t3_backfill_partial_failure.py
+++ b/tests/test_catalog_t3_backfill_partial_failure.py
@@ -1,24 +1,28 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""RDR-101 Phase 3 follow-up E (nexus-o6aa.9.11): partial-failure
-injection for ``nx catalog t3-backfill-doc-id``.
+"""RDR-101 Phase 3 follow-up E (nexus-o6aa.9.11) + .9.18 retry path:
+``nx catalog t3-backfill-doc-id`` partial-failure handling.
 
-The recovery story documented in ``docs/migration/rdr-101.md`` says:
+Two evolutions of the recovery story documented in
+``docs/migration/rdr-101.md``:
 
-  > **`t3-backfill-doc-id` partial** — some chunks missing `doc_id`
-  > metadata; `doctor --t3-doc-id-coverage` flags them. Re-run
-  > `nx catalog t3-backfill-doc-id`. Idempotent — already-backfilled
-  > chunks are no-ops.
+1. **Per-chunk retry on batch failure** (.9.18). ChromaDB's ``col.update``
+   is all-or-nothing: any chunk in the batch that violates a quota
+   rejects the whole batch. Pre-fix, this swept ~22k clean chunks
+   into the deferred list because they shared a batch with an
+   over-cap chunk. Post-fix, batch failure triggers per-chunk
+   updates so clean chunks land cleanly and only genuinely-failing
+   chunks are reported.
 
-This file validates that claim end-to-end. The .9.10 sandbox harness
-covers the happy path. Here we inject faults into ChromaDB's
-``col.update`` to simulate the network-blip / quota-error failure
-modes the migration doc names, and confirm:
+2. **Deferred-class quota differentiation** (.9.18). The
+   ``NumMetadataKeys`` quota class is expected during the Phase 4
+   transition (chunks at 35-36 keys can't accept ``doc_id`` until
+   Phase 4's prune-deprecated-keys verb ships). Errors carrying
+   that class land in ``chunks_deferred`` (an operator-readable
+   cleanup list) rather than ``errors``, and the verb exits 0.
+   Genuine failures (network, auth, schema) still exit 1.
 
-* The verb exits non-zero (so operator scripts can detect partial).
-* Successful chunks are persisted with ``doc_id`` set.
-* Failed chunks remain in their pre-update state.
-* Re-running the verb (without the fault injector) recovers cleanly:
-  exit 0, all chunks now carry ``doc_id``.
+Validates the recovery story end-to-end against synthetic faults
+that mimic the live failure mode Hal's first migration hit.
 """
 from __future__ import annotations
 
@@ -86,17 +90,24 @@ def _chunk_event(chunk_id: str, doc_id: str, coll_id: str) -> ev.Event:
     )
 
 
-class _FaultInjectingClient:
-    """Wraps a ChromaDB client; the FIRST ``col.update(...)`` call on
-    each collection raises ``RuntimeError("simulated 503")``. Subsequent
-    calls pass through. This simulates the canonical network-blip
-    failure mode the migration doc warns about.
+def _parse_json_payload(output: str) -> dict:
+    return json.loads(output[output.find("{"):])
 
-    Why "first call per collection, then pass": the verb batches in
-    300-id windows; with 4 chunks total in our sandbox the second
-    batch is empty, so a once-per-collection fault is enough to
-    exercise the partial-write recovery path without making the
-    fixture too clever.
+
+# ─────────────────────────────────────────────────────────────────────
+# Fault-injection client wrappers
+# ─────────────────────────────────────────────────────────────────────
+
+
+class _BatchOnlyFaultClient:
+    """First multi-id ``col.update`` per collection raises a transient
+    error; per-chunk (single-id) updates pass through. Simulates the
+    canonical ChromaDB Cloud quota response: batch all-or-nothing
+    rejection, but the same chunks update fine when retried
+    individually with the over-cap one isolated.
+
+    For the .9.18 per-chunk retry test: the verb retries the batch
+    chunk-by-chunk; each individual update succeeds.
     """
 
     def __init__(self, real_client):
@@ -110,35 +121,227 @@ class _FaultInjectingClient:
         class _FaultCol:
             _underlying = col
 
-            def get(self, *args, **kwargs):
-                return col.get(*args, **kwargs)
+            def get(self, *a, **kw):
+                return col.get(*a, **kw)
 
-            def update(self, *args, **kwargs):
-                if name not in outer._tripped:
+            def update(self, ids, metadatas, *a, **kw):
+                if name not in outer._tripped and len(ids) > 1:
                     outer._tripped.add(name)
                     raise RuntimeError(
-                        f"simulated 503 on first update to {name}"
+                        "simulated transient failure on batch update"
                     )
-                return col.update(*args, **kwargs)
+                return col.update(ids=ids, metadatas=metadatas, *a, **kw)
 
-            def add(self, *args, **kwargs):
-                return col.add(*args, **kwargs)
+            def add(self, *a, **kw):
+                return col.add(*a, **kw)
 
         return _FaultCol()
 
 
+class _OverCapFaultClient:
+    """Reject every ``col.update`` whose payload contains a chunk
+    with ``len(metadata) > MAX_KEYS``, raising a ChromaDB-shaped
+    error message. Multi-id calls reject if ANY chunk is over-cap
+    (matching ChromaDB Cloud's batch-all-or-nothing behaviour);
+    single-id calls reject only the offending chunk.
+
+    The error message includes the canonical
+    ``Number of metadata dictionary keys`` and ``NumMetadataKeys``
+    substrings so the verb's deferred-class detector trips on it.
+    """
+
+    MAX_KEYS = 32
+
+    def __init__(self, real_client):
+        self._real = real_client
+
+    def get_collection(self, name: str):
+        col = self._real.get_collection(name=name)
+        outer = self
+
+        class _OverCapCol:
+            _underlying = col
+
+            def get(self, *a, **kw):
+                return col.get(*a, **kw)
+
+            def update(self, ids, metadatas, *a, **kw):
+                for cid, m in zip(ids, metadatas):
+                    if len(m) > outer.MAX_KEYS:
+                        raise RuntimeError(
+                            "Quota exceeded: 'Number of metadata "
+                            "dictionary keys' exceeded quota limit "
+                            f"for action 'Update': current usage of "
+                            f"{len(m)} exceeds limit of {outer.MAX_KEYS}. "
+                            f"NumMetadataKeys"
+                        )
+                return col.update(ids=ids, metadatas=metadatas, *a, **kw)
+
+            def add(self, *a, **kw):
+                return col.add(*a, **kw)
+
+        return _OverCapCol()
+
+
+class _ChunkSpecificFaultClient:
+    """Reject ``col.update`` whose payload contains a specific
+    chunk_id. Models a chunk-specific transient (network blip,
+    permissions, schema validation) that is NOT the deferred-class
+    quota — should land in ``errors`` and produce exit 1.
+    """
+
+    def __init__(self, real_client, doomed_chunk_id: str):
+        self._real = real_client
+        self._doomed = doomed_chunk_id
+
+    def get_collection(self, name: str):
+        col = self._real.get_collection(name=name)
+        outer = self
+
+        class _DoomCol:
+            _underlying = col
+
+            def get(self, *a, **kw):
+                return col.get(*a, **kw)
+
+            def update(self, ids, metadatas, *a, **kw):
+                if outer._doomed in ids:
+                    raise RuntimeError(
+                        "schema validation failed: invalid metadata "
+                        "value type"
+                    )
+                return col.update(ids=ids, metadatas=metadatas, *a, **kw)
+
+            def add(self, *a, **kw):
+                return col.add(*a, **kw)
+
+        return _DoomCol()
+
+
 # ─────────────────────────────────────────────────────────────────────
-# Partial-failure path
+# Per-chunk retry on batch failure (.9.18)
 # ─────────────────────────────────────────────────────────────────────
 
 
-def test_first_update_per_collection_fails_then_recovers(
+def test_batch_fault_recovers_via_per_chunk_retry(
     isolated_nexus, runner, chroma_client, monkeypatch,
 ):
-    """Inject a fault on the first ``col.update`` call. Verb exits 1
-    (errors reported); chunks remain pre-update. Re-run without the
-    injector recovers cleanly — verb exits 0, all chunks now carry
-    ``doc_id``.
+    """RDR-101 Phase 3 follow-up .9.18: when ``col.update`` rejects
+    a batch but the per-chunk updates would succeed, the verb falls
+    back to per-chunk retry within the same run. Pre-fix the batch
+    rejection swept all chunks into ``errors`` and required an
+    operator re-run; post-fix recovery is automatic.
+    """
+    events = [
+        _chunk_event("ch1", "uuid7-A", "code__test"),
+        _chunk_event("ch2", "uuid7-B", "code__test"),
+        _chunk_event("ch3", "uuid7-C", "code__test"),
+    ]
+    _seed_event_log(isolated_nexus, events)
+    _seed(chroma_client, "code__test", [
+        {"id": "ch1", "content": "x", "metadata": {"chunk_text_hash": "h1"}},
+        {"id": "ch2", "content": "y", "metadata": {"chunk_text_hash": "h2"}},
+        {"id": "ch3", "content": "z", "metadata": {"chunk_text_hash": "h3"}},
+    ])
+
+    fault_client = _BatchOnlyFaultClient(chroma_client)
+
+    class _FaultT3:
+        _client = fault_client
+
+    monkeypatch.setattr("nexus.db.make_t3", lambda: _FaultT3())
+    result = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
+
+    assert result.exit_code == 0, (
+        "per-chunk retry should recover from batch fault and exit 0; "
+        f"output:\n{result.output}"
+    )
+    payload = _parse_json_payload(result.output)
+    assert payload["chunks_updated"] == 3, payload
+    assert payload["errors"] == [], payload
+    assert payload["chunks_deferred"] == [], payload
+
+    # Final verification: every chunk now carries doc_id.
+    col = chroma_client.get_collection("code__test")
+    for cid, want in [("ch1", "uuid7-A"), ("ch2", "uuid7-B"), ("ch3", "uuid7-C")]:
+        meta = col.get(ids=[cid], include=["metadatas"])["metadatas"][0]
+        assert meta["doc_id"] == want, (
+            f"chunk {cid} did not get doc_id post-retry: {meta!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Deferred-class quota differentiation (.9.18)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_overcap_chunk_lands_in_deferred_not_errors(
+    isolated_nexus, runner, chroma_client, monkeypatch,
+):
+    """A batch with one over-cap chunk (33+ keys) and two clean
+    chunks: pre-fix the whole batch was rejected and ALL three
+    chunks landed in ``errors``. Post-fix:
+
+    * Batch update fails on the over-cap chunk.
+    * Per-chunk retry runs:
+      - Clean chunks land cleanly (chunks_updated += 2).
+      - Over-cap chunk fails with the NumMetadataKeys error → recognized
+        as deferred-class → lands in ``chunks_deferred``, NOT ``errors``.
+    * Verb exits 0 because there are no genuine errors.
+    """
+    events = [
+        _chunk_event("ch1", "uuid7-A", "code__test"),
+        _chunk_event("ch2", "uuid7-B", "code__test"),
+        _chunk_event("ch3", "uuid7-C", "code__test"),
+    ]
+    _seed_event_log(isolated_nexus, events)
+    # ch2 has 35 keys; ch1, ch3 have 5. Adding doc_id pushes ch2 to 36.
+    fat_meta = {f"k{i}": f"v{i}" for i in range(35)}
+    _seed(chroma_client, "code__test", [
+        {"id": "ch1", "content": "x", "metadata": {"chunk_text_hash": "h1"}},
+        {"id": "ch2", "content": "y", "metadata": fat_meta},
+        {"id": "ch3", "content": "z", "metadata": {"chunk_text_hash": "h3"}},
+    ])
+
+    fault_client = _OverCapFaultClient(chroma_client)
+
+    class _OvercapT3:
+        _client = fault_client
+
+    monkeypatch.setattr("nexus.db.make_t3", lambda: _OvercapT3())
+    result = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
+
+    assert result.exit_code == 0, (
+        "deferred-class failures (NumMetadataKeys quota) must NOT "
+        "fail the verb; only genuine errors do. "
+        f"output:\n{result.output}"
+    )
+    payload = _parse_json_payload(result.output)
+
+    # Clean chunks landed.
+    assert payload["chunks_updated"] == 2, (
+        f"clean chunks ch1 and ch3 should land via per-chunk retry; "
+        f"got {payload['chunks_updated']} updated"
+    )
+    # Over-cap chunk in deferred list.
+    assert payload["chunks_deferred_count"] == 1, payload
+    assert len(payload["chunks_deferred"]) == 1
+    deferred_record = payload["chunks_deferred"][0]
+    assert deferred_record["chunk_id"] == "ch2"
+    assert deferred_record["collection"] == "code__test"
+    assert "NumMetadataKeys" in deferred_record["error"] or \
+           "Number of metadata dictionary keys" in deferred_record["error"]
+    # No genuine errors.
+    assert payload["errors"] == [], payload
+
+
+def test_genuine_per_chunk_error_still_fails_verb(
+    isolated_nexus, runner, chroma_client, monkeypatch,
+):
+    """Per-chunk retry that hits a non-deferred-class error
+    (e.g. schema validation) lands in ``errors`` and the verb
+    exits 1. Operators can detect genuine failures vs deferred-class
+    via the report shape and exit code.
     """
     events = [
         _chunk_event("ch1", "uuid7-A", "code__test"),
@@ -150,152 +353,23 @@ def test_first_update_per_collection_fails_then_recovers(
         {"id": "ch2", "content": "y", "metadata": {"chunk_text_hash": "h2"}},
     ])
 
-    # First run: inject fault.
-    fault_client = _FaultInjectingClient(chroma_client)
+    fault_client = _ChunkSpecificFaultClient(chroma_client, doomed_chunk_id="ch2")
 
-    class _FaultT3:
+    class _DoomT3:
         _client = fault_client
 
-    monkeypatch.setattr("nexus.db.make_t3", lambda: _FaultT3())
-    result_fault = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
+    monkeypatch.setattr("nexus.db.make_t3", lambda: _DoomT3())
+    result = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
 
-    # Verb exits 1 because errors were collected.
-    assert result_fault.exit_code != 0, (
-        "verb must exit non-zero on partial failure for operator-script "
-        "detectability"
+    assert result.exit_code != 0, (
+        "non-deferred-class error must fail the verb"
     )
-
-    # Strip any non-JSON prefix.
-    out = result_fault.output
-    payload = json.loads(out[out.find("{"):])
-    assert payload["chunks_updated"] == 0, (
-        "fault tripped on the only batch; no chunks should land"
-    )
-    assert len(payload["errors"]) == 1, (
-        f"expected one batch-update error; got {payload['errors']}"
-    )
-    assert payload["errors"][0]["stage"] == "update"
-    assert "simulated 503" in payload["errors"][0]["error"]
-
-    # Verify chunks did NOT receive doc_id metadata (the failed update
-    # never landed).
-    col = chroma_client.get_collection("code__test")
-    for cid in ("ch1", "ch2"):
-        meta = col.get(ids=[cid], include=["metadatas"])["metadatas"][0]
-        assert "doc_id" not in meta, (
-            f"chunk {cid} unexpectedly carries doc_id after failed batch"
-        )
-
-    # Second run: NO fault injector. Confirm idempotent recovery.
-    class _CleanT3:
-        _client = chroma_client
-
-    monkeypatch.setattr("nexus.db.make_t3", lambda: _CleanT3())
-    result_clean = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
-
-    assert result_clean.exit_code == 0, result_clean.output
-    out = result_clean.output
-    payload2 = json.loads(out[out.find("{"):])
-    assert payload2["chunks_updated"] == 2, (
-        f"recovery run should backfill the 2 chunks the fault dropped; "
-        f"got {payload2['chunks_updated']}"
-    )
-    assert payload2["chunks_already_correct"] == 0
-    assert payload2["errors"] == []
-
-    # Final verification: chunks now carry doc_id.
-    col = chroma_client.get_collection("code__test")
-    expected = {"ch1": "uuid7-A", "ch2": "uuid7-B"}
-    for cid, want in expected.items():
-        meta = col.get(ids=[cid], include=["metadatas"])["metadatas"][0]
-        assert meta["doc_id"] == want, (
-            f"chunk {cid} doc_id mismatch after recovery: got {meta!r}"
-        )
-
-
-def test_partial_completion_some_collections_succeed(
-    isolated_nexus, runner, chroma_client, monkeypatch,
-):
-    """When the fault injector trips on collection A's first update
-    but collection B has already completed, the verb reports the
-    partial state correctly: chunks_updated > 0, errors > 0,
-    exit non-zero. Re-running brings the failed collection up.
-    """
-    events = [
-        _chunk_event("ch1", "uuid7-A", "code__alpha"),
-        _chunk_event("ch2", "uuid7-B", "code__beta"),
-    ]
-    _seed_event_log(isolated_nexus, events)
-    _seed(chroma_client, "code__alpha", [
-        {"id": "ch1", "content": "x", "metadata": {"chunk_text_hash": "ha"}},
-    ])
-    _seed(chroma_client, "code__beta", [
-        {"id": "ch2", "content": "y", "metadata": {"chunk_text_hash": "hb"}},
-    ])
-
-    # The fault injector trips once per collection. With 1 chunk per
-    # collection there's only one batch each; both fail. To get one
-    # success and one failure, drop the fault for the second collection
-    # before its update lands.
-    class _FaultOnceClient:
-        """Trips on the FIRST update across all collections, then
-        passes for everything subsequent."""
-
-        def __init__(self, real_client):
-            self._real = real_client
-            self._tripped = False
-
-        def get_collection(self, name: str):
-            col = self._real.get_collection(name=name)
-            outer = self
-
-            class _FaultCol:
-                _underlying = col
-
-                def get(self, *args, **kwargs):
-                    return col.get(*args, **kwargs)
-
-                def update(self, *args, **kwargs):
-                    if not outer._tripped:
-                        outer._tripped = True
-                        raise RuntimeError("simulated 503 on first update")
-                    return col.update(*args, **kwargs)
-
-                def add(self, *args, **kwargs):
-                    return col.add(*args, **kwargs)
-
-            return _FaultCol()
-
-    fault_client = _FaultOnceClient(chroma_client)
-
-    class _FaultT3:
-        _client = fault_client
-
-    monkeypatch.setattr("nexus.db.make_t3", lambda: _FaultT3())
-    result = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])  # noqa: E501
-
-    assert result.exit_code != 0
-    out = result.output
-    payload = json.loads(out[out.find("{"):])
-
-    # One collection failed (errored), one succeeded (updated).
-    assert payload["chunks_updated"] == 1, (
-        f"expected 1 collection to land cleanly; got "
-        f"{payload['chunks_updated']}"
-    )
+    payload = _parse_json_payload(result.output)
+    # ch1 lands cleanly via per-chunk retry; ch2 fails persistently.
+    assert payload["chunks_updated"] == 1, payload
+    assert payload["chunks_deferred"] == [], payload
     assert len(payload["errors"]) == 1
-
-    # Re-run recovers the failed collection.
-    class _CleanT3:
-        _client = chroma_client
-
-    monkeypatch.setattr("nexus.db.make_t3", lambda: _CleanT3())
-    recover = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
-    assert recover.exit_code == 0, recover.output
-    out = recover.output
-    payload2 = json.loads(out[out.find("{"):])
-    # Idempotent: the already-good chunk is "already_correct"; the
-    # newly-good chunk is "updated".
-    assert payload2["chunks_updated"] == 1
-    assert payload2["chunks_already_correct"] == 1
-    assert payload2["errors"] == []
+    err = payload["errors"][0]
+    assert err["chunk_id"] == "ch2"
+    assert err["stage"] == "update_per_chunk"
+    assert "schema validation" in err["error"]


### PR DESCRIPTION
Real-data finding from Hal's live migration today (2026-05-01): of **277,074 chunks** across code__/docs__/rdr__ collections, **9,084 (3.3%) carry 35-36 metadata keys** — over Chroma Cloud's `NumMetadataKeys` cap of 32 for Update.

## Pre-fix problem

`col.update` is batch-all-or-nothing. The 9,084 over-cap chunks scattered across batches caused **105 batch failures**, sweeping in **~22,400 clean chunks** that just shared a batch with an over-cap one. Net: 31,500 chunks ended up without `doc_id`, only 9,084 of which were actually unrescuable.

## Two-part fix

### 1. Per-chunk retry on batch failure
When `col.update` raises on a batch, the verb now retries chunk-by-chunk. Clean chunks land cleanly; only genuinely-failing chunks are reported. Recoverable scope shrinks from up to 31,500 chunks deferred → exactly **9,084**.

### 2. Deferred-class quota differentiation
Errors carrying `NumMetadataKeys` or `Number of metadata dictionary keys` substrings land in a new `chunks_deferred` field, NOT in `errors`. Exit code stays 0 when the only failures are deferred-class — these are expected during the Phase 4 transition (the prune-deprecated-keys verb will drop the 6 RDR-101-deprecated keys post-Phase-4, freeing the budget for `doc_id`).

Genuine errors (network, auth, schema validation) still land in `errors` and exit 1.

## Operator output

```
Chunks updated:        163000
Already correct:       0
Orphans skipped:       140488
Deferred (over-cap):   9084  (Phase 4 prune-keys remediation)
  code__nexus  af231ba81…  keys=36
  docs__sch    7e4a92df0…  keys=36
  code__nexus  9d83fa81b…  keys=35
  …and 9081 more (use --json for full list)
```

JSON mode includes `chunks_deferred` (per-chunk records with collection/chunk_id/key_count/error) and `chunks_deferred_count` for machine consumers.

## Tests (rewritten)

- `test_batch_fault_recovers_via_per_chunk_retry` — batch transient fault → per-chunk retry → all chunks land.
- `test_overcap_chunk_lands_in_deferred_not_errors` — mixed batch (1 over-cap + 2 clean): clean chunks land; over-cap chunk in `chunks_deferred`; `errors=[]`; exit 0.
- `test_genuine_per_chunk_error_still_fails_verb` — schema validation error → `errors`, exit 1.

WITH TEETH: all 3 fail deterministically against pre-fix code.

## Sandbox + targeted sweep

- 3 new tests pass; full backfill/migrate/doctor sweep (20 tests) passes.
- For Hal's live catalog: re-running `t3-backfill-doc-id` with this fix would land **163k chunks cleanly** (vs 141k pre-fix) and report exactly **9,084 in `chunks_deferred`** (vs the cosmetic 31,500 pre-fix).

## Refs

- Bead: `nexus-o6aa.9.18` (P1, parent: `nexus-o6aa.9`)
- Discovered live during the operator's first real migration
- Phase 4 (`nexus-o6aa.10`) prune-deprecated-keys verb is the **actual fix** for the 9,084 over-cap chunks; this PR is the operator-resilient migration step that lets the migration complete cleanly during the Phase 4 wait.