### PR TITLE
feat(catalog): nx catalog migrate + synthesize-log + t3-backfill progress output (nexus-o6aa.9.17)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -493,4 +493,4 @@
 {"id":"int-97839c28","kind":"field_change","created_at":"2026-05-01T22:33:11.883549Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.10","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-533ba482","kind":"field_change","created_at":"2026-05-01T23:03:34.791321Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.11","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-4496909b","kind":"field_change","created_at":"2026-05-02T00:57:24.188922Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.14","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
-{"id":"int-9cdfe64f","kind":"field_change","created_at":"2026-05-02T01:57:49.587581Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.18","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-db3b80c9","kind":"field_change","created_at":"2026-05-02T02:41:39.006509Z","actor":"Hellblazer","issue_id":"nexus-o6aa.9.17","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3806,15 +3806,42 @@ def synthesize_log_cmd(
                 )
             preserve_map[t] = d  # last-occurrence wins
 
+    # nexus-o6aa.9.17: stage-by-stage progress output. Stderr only so
+    # ``--json`` stdout stays machine-clean; suppressed when --json is
+    # set so JSON consumers see no progress noise.
+    import time as _time
+    show_progress = not as_json
+
+    if show_progress:
+        click.echo(
+            "  [synthesize-log] walking owners.jsonl + documents.jsonl + "
+            "links.jsonl…",
+            err=True,
+        )
+    _t0 = _time.monotonic()
     events = list(synthesize_from_jsonl(
         cat_dir, mint_doc_id=True, preserve_doc_ids=preserve_map,
     ))
+    if show_progress:
+        click.echo(
+            f"  [synthesize-log] {len(events)} events from JSONL in "
+            f"{_time.monotonic() - _t0:.1f}s",
+            err=True,
+        )
+
     chunk_events: list = []
     orphan_count = 0
     if chunks:
         from nexus.catalog.synthesizer import synthesize_t3_chunks
         from nexus.db import make_t3
 
+        if show_progress:
+            click.echo(
+                "  [synthesize-log] walking T3 collections (Chroma read; "
+                "may take several minutes on a large catalog)…",
+                err=True,
+            )
+        _tc = _time.monotonic()
         try:
             t3 = make_t3()
             chunk_events = list(
@@ -3824,6 +3851,13 @@ def synthesize_log_cmd(
                 1 for e in chunk_events
                 if getattr(e.payload, "synthesized_orphan", False)
             )
+            if show_progress:
+                click.echo(
+                    f"  [synthesize-log] {len(chunk_events)} chunk events "
+                    f"({orphan_count} orphans) in "
+                    f"{_time.monotonic() - _tc:.1f}s",
+                    err=True,
+                )
         except Exception as exc:
             raise click.ClickException(
                 f"Failed to walk T3 chunks: {exc}. Pass --no-chunks to "
@@ -4046,10 +4080,26 @@ def t3_backfill_doc_id_cmd(
                 f"Failed to open T3 client: {exc}. Check ChromaDB credentials."
             )
 
-    for coll_name, payloads in by_coll.items():
+    # nexus-o6aa.9.17: per-collection progress so operators see the
+    # verb is working through Cloud T3 (each collection is a network
+    # round-trip per 300-id batch; large collections can be tens of
+    # minutes). Stderr only; suppressed under --json.
+    import time as _time
+    show_progress = not dry_run and not as_json
+    coll_count = len(by_coll)
+
+    for coll_idx, (coll_name, payloads) in enumerate(by_coll.items(), start=1):
         if dry_run:
             chunks_updated += len(payloads)
             continue
+        if show_progress:
+            click.echo(
+                f"  [t3-backfill {coll_idx}/{coll_count}] {coll_name}: "
+                f"{len(payloads)} chunks…",
+                err=True,
+            )
+        _tc = _time.monotonic()
+        coll_updated_before = chunks_updated
         try:
             col = t3._client.get_collection(name=coll_name)
         except Exception as exc:
@@ -4058,6 +4108,12 @@ def t3_backfill_doc_id_cmd(
                 "stage": "open",
                 "error": str(exc),
             })
+            if show_progress:
+                click.echo(
+                    f"  [t3-backfill {coll_idx}/{coll_count}] {coll_name}: "
+                    f"could not open ({exc})",
+                    err=True,
+                )
             continue
 
         # Idempotency: read current metadata in batches; only update
@@ -4113,6 +4169,15 @@ def t3_backfill_doc_id_cmd(
             chunks_updated += ok
             chunks_deferred.extend(deferred_records)
             errors.extend(error_records)
+
+        if show_progress:
+            updated_here = chunks_updated - coll_updated_before
+            elapsed = _time.monotonic() - _tc
+            click.echo(
+                f"  [t3-backfill {coll_idx}/{coll_count}] {coll_name}: "
+                f"{updated_here}/{len(payloads)} updated in {elapsed:.1f}s",
+                err=True,
+            )
 
     report = {
         "dry_run": dry_run,
@@ -4742,10 +4807,17 @@ def migrate_cmd(
                 click.echo(f"  {step}")
         return
 
+    # nexus-o6aa.9.17: per-step timing so the operator sees how long
+    # each phase took. Real-data finding (Hal's first migration):
+    # synthesize-log was ~5 min, t3-backfill was ~3 min, doctor was
+    # ~1 min — but with no echo until the next step's "==>" line, the
+    # operator was guessing whether the process was alive.
+    import time as _time
+
     # Step 1: synthesize-log --force.
     click.echo("==> nx catalog synthesize-log --force"
                + ("" if no_chunks else " --chunks"))
-    syn_args = ["--force"] + ([] if no_chunks else ["--chunks"])
+    _step1_t0 = _time.monotonic()
     try:
         ctx.invoke(synthesize_log_cmd, **{
             "dry_run": False,
@@ -4758,10 +4830,14 @@ def migrate_cmd(
             f"synthesize-log failed: {exc.message}. Migration aborted; "
             "no further steps run."
         ) from exc
+    click.echo(
+        f"    synthesize-log: {_time.monotonic() - _step1_t0:.1f}s",
+    )
 
     # Step 2: t3-backfill-doc-id (unless --no-chunks).
     if not no_chunks:
         click.echo("==> nx catalog t3-backfill-doc-id")
+        _step2_t0 = _time.monotonic()
         try:
             ctx.invoke(t3_backfill_doc_id_cmd, **{
                 "dry_run": False,
@@ -4775,6 +4851,9 @@ def migrate_cmd(
                 "lack doc_id metadata. Re-run 'nx catalog "
                 "t3-backfill-doc-id' after fixing the underlying issue."
             ) from exc
+        click.echo(
+            f"    t3-backfill-doc-id: {_time.monotonic() - _step2_t0:.1f}s",
+        )
 
     # Synchronize live SQLite to events.jsonl before doctor runs.
     # nexus-o6aa.9.14: ``synthesize-log`` writes events.jsonl but does
@@ -4792,6 +4871,7 @@ def migrate_cmd(
     # replays events.jsonl into the live SQLite. After that, doctor's
     # comparison is apples-to-apples.
     click.echo("==> sync live SQLite to events.jsonl")
+    _sync_t0 = _time.monotonic()
     sync_cat = Catalog(cat_dir, cat_dir / ".catalog.db")
     try:
         # Constructor calls ``_ensure_consistent`` at the end of
@@ -4800,10 +4880,14 @@ def migrate_cmd(
         sync_cat._db.commit()
     finally:
         sync_cat._db.close()
+    click.echo(
+        f"    sync: {_time.monotonic() - _sync_t0:.1f}s",
+    )
 
     # Step 3: doctor verification.
     click.echo("==> nx catalog doctor --replay-equality"
                + ("" if no_chunks else " --t3-doc-id-coverage --strict-not-in-t3"))
+    _doc_t0 = _time.monotonic()
     try:
         ctx.invoke(doctor_cmd, **{
             "replay_equality": True,
@@ -4818,5 +4902,8 @@ def migrate_cmd(
                 "PASS. Inspect the report above; re-running this verb "
                 "is safe and idempotent."
             ) from exc
+    click.echo(
+        f"    doctor: {_time.monotonic() - _doc_t0:.1f}s",
+    )
 
     click.echo("\nMigration complete.")


### PR DESCRIPTION
## Why

Live during Hal's first real migration today: `nx catalog migrate` on a 14k-document / 312k-chunk catalog ran for **14 minutes** with no incremental output between the orchestration echo lines. Operator was left guessing whether the process was alive vs hung.

## Changes

### `synthesize_log_cmd`
- Stderr progress before/after the JSONL walk and the optional T3 chunk walk.
- "{N} events from JSONL in {T}s" / "{N} chunk events ({K} orphans) in {T}s".

### `t3_backfill_doc_id_cmd`
- Per-collection progress: `[c/C] <coll_name>: {N} chunks…` at start, `{updated}/{total} updated in {T}s` at end.
- Operator sees which collection is in flight, especially valuable on Cloud T3 where batch updates are network-bound.

### `migrate_cmd`
- Per-step elapsed timing after each `ctx.invoke` (synthesize-log, t3-backfill, sync, doctor).

## Why stderr for progress

Lets machine consumers pipe migrate's stdout (the report) into a tool while operators on a TTY still see progress. JSON output stays clean for non-TTY automation.

## Real-world impact preview

```
==> nx catalog synthesize-log --force --chunks
  [synthesize-log] walking owners.jsonl + documents.jsonl + links.jsonl…
  [synthesize-log] 36430 events from JSONL in 4.8s
  [synthesize-log] walking T3 collections (Chroma read; may take several minutes…)
  [synthesize-log] 312579 chunk events (140488 orphans) in 245.2s
    synthesize-log: 250.0s
==> nx catalog t3-backfill-doc-id
  [t3-backfill 1/38] code__ART-8c2e74c0: 12345 chunks…
  [t3-backfill 1/38] code__ART-8c2e74c0: 12345/12345 updated in 18.3s
  [t3-backfill 2/38] code__nexus-571b8edd: 24673 chunks…
  [t3-backfill 2/38] code__nexus-571b8edd: 21897/24673 updated in 287.4s
  …
    t3-backfill-doc-id: 412.7s
==> sync live SQLite to events.jsonl
    sync: 6.1s
==> nx catalog doctor --replay-equality --t3-doc-id-coverage --strict-not-in-t3
  [doctor output]
    doctor: 18.3s

Migration complete.
```

## Tests

26 existing tests pass (catalog_migrate / catalog_synthesize_log / catalog_t3_backfill). Progress lines are optional UX, not a behavior change.

## Refs

- Bead: `nexus-o6aa.9.17` (P2, parent: `nexus-o6aa.9`)
- Surfaced live during Hal's first real migration