### PR TITLE
feat(catalog): t3-backfill batch-bisect O(log N) recovery (nexus-o6aa.9.19)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3881,6 +3881,81 @@ def _print_synthesize_log_text(report: dict) -> None:
 # ── RDR-101 Phase 2: t3-backfill-doc-id verb ─────────────────────────────
 
 
+# nexus-o6aa.9.18: deferred-class detector for the per-chunk retry
+# path. Errors carrying a class string in this set are treated as
+# expected during the Phase 4 transition (chunks over the 32-key
+# NumMetadataKeys cap that pre-date the cap or carry deprecated
+# metadata Phase 4 will prune). They land in ``chunks_deferred``
+# rather than ``errors`` so the verb exits 0 — the operator sees
+# a deferred-cleanup list, not a failure.
+_DEFERRED_QUOTA_HINTS: tuple[str, ...] = (
+    "NumMetadataKeys",
+    "Number of metadata dictionary keys",
+)
+
+
+def _is_deferred_error(exc_text: str) -> bool:
+    return any(hint in exc_text for hint in _DEFERRED_QUOTA_HINTS)
+
+
+def _bisect_update(
+    col, ids: list[str], metas: list[dict], coll_name: str,
+) -> tuple[int, list[dict], list[dict]]:
+    """Recurse-and-halve to isolate failing chunks (nexus-o6aa.9.19).
+
+    On a batch update failure, halving recovers from a small number
+    of failing chunks in O(log N) col.update calls instead of the
+    O(N) per-chunk retry. Worst case (1 over-cap chunk per batch of
+    300): ~9 update calls instead of 300, ~30× faster against Cloud
+    T3 latency.
+
+    Returns ``(updated_count, deferred_records, error_records)``.
+
+    Single-chunk failures classify the same way as before:
+    deferred-class quotas (``NumMetadataKeys``) → deferred_records;
+    everything else → error_records (operator-visible exit 1).
+    """
+    if not ids:
+        return 0, [], []
+
+    # Try the full slice first. Cheap to retry the whole thing — if
+    # it now succeeds (transient network blip), we save log(N) calls.
+    try:
+        col.update(ids=ids, metadatas=metas)
+        return len(ids), [], []
+    except Exception as exc:
+        if len(ids) == 1:
+            # Leaf failure — classify and return.
+            cid = ids[0]
+            meta = metas[0]
+            msg = str(exc)
+            record = {
+                "collection": coll_name,
+                "chunk_id": cid,
+                "key_count": len(meta),
+                "error": msg[:200],
+            }
+            if _is_deferred_error(msg):
+                return 0, [record], []
+            return 0, [], [{
+                **record, "stage": "update_per_chunk", "batch_size": 1,
+            }]
+
+        # Bisect: split in half, recurse on each side.
+        mid = len(ids) // 2
+        left_ok, left_def, left_err = _bisect_update(
+            col, ids[:mid], metas[:mid], coll_name,
+        )
+        right_ok, right_def, right_err = _bisect_update(
+            col, ids[mid:], metas[mid:], coll_name,
+        )
+        return (
+            left_ok + right_ok,
+            left_def + right_def,
+            left_err + right_err,
+        )
+
+
 @catalog.command("t3-backfill-doc-id")
 @click.option(
     "--dry-run",
@@ -3971,21 +4046,6 @@ def t3_backfill_doc_id_cmd(
                 f"Failed to open T3 client: {exc}. Check ChromaDB credentials."
             )
 
-    # nexus-o6aa.9.18: deferred-class detector for the per-chunk
-    # retry path. Errors carrying a class string in this set are
-    # treated as expected during the Phase 4 transition (chunks
-    # over the 32-key NumMetadataKeys cap that pre-date the cap or
-    # carry deprecated metadata Phase 4 will prune). They land in
-    # ``chunks_deferred`` rather than ``errors`` so the verb exits
-    # 0 — the operator sees a deferred-cleanup list, not a failure.
-    DEFERRED_QUOTA_HINTS: tuple[str, ...] = (
-        "NumMetadataKeys",
-        "Number of metadata dictionary keys",
-    )
-
-    def _is_deferred_error(exc_text: str) -> bool:
-        return any(hint in exc_text for hint in DEFERRED_QUOTA_HINTS)
-
     for coll_name, payloads in by_coll.items():
         if dry_run:
             chunks_updated += len(payloads)
@@ -4038,36 +4098,21 @@ def t3_backfill_doc_id_cmd(
 
             if not update_ids:
                 continue
-            try:
-                col.update(ids=update_ids, metadatas=update_metas)
-                chunks_updated += len(update_ids)
-            except Exception as exc:
-                # nexus-o6aa.9.18: batch-level rejection is all-or-nothing.
-                # Fall back to per-chunk updates so clean chunks in a
-                # batch with one over-cap chunk still get doc_id; only
-                # the genuinely-failing chunks land in chunks_deferred.
-                # Pre-fix this swept ~22k clean chunks into the deferred
-                # list because ChromaDB's 32-key NumMetadataKeys cap
-                # rejected the whole batch on the first over-cap chunk.
-                for cid, meta in zip(update_ids, update_metas):
-                    try:
-                        col.update(ids=[cid], metadatas=[meta])
-                        chunks_updated += 1
-                    except Exception as inner_exc:
-                        msg = str(inner_exc)
-                        record = {
-                            "collection": coll_name,
-                            "chunk_id": cid,
-                            "key_count": len(meta),
-                            "error": msg[:200],
-                        }
-                        if _is_deferred_error(msg):
-                            chunks_deferred.append(record)
-                        else:
-                            errors.append({
-                                **record, "stage": "update_per_chunk",
-                                "batch_size": 1,
-                            })
+            # nexus-o6aa.9.18 + .9.19: batch-level rejection is
+            # all-or-nothing on Cloud T3. _bisect_update tries the
+            # whole slice first; on failure it bisects-and-recurses
+            # to isolate the failing chunks in O(log N) update calls
+            # instead of O(N) per-chunk retry. The .9.18 per-chunk
+            # path was correct but took ~30 min wall-clock against
+            # Cloud T3 latency on a 9k-chunk over-cap surface; .9.19
+            # brings that down to ~log2(300) = 9 calls per failed
+            # batch (~30× faster).
+            ok, deferred_records, error_records = _bisect_update(
+                col, update_ids, update_metas, coll_name,
+            )
+            chunks_updated += ok
+            chunks_deferred.extend(deferred_records)
+            errors.extend(error_records)
 
     report = {
         "dry_run": dry_run,

--- a/tests/test_catalog_t3_backfill_partial_failure.py
+++ b/tests/test_catalog_t3_backfill_partial_failure.py
@@ -373,3 +373,96 @@ def test_genuine_per_chunk_error_still_fails_verb(
     assert err["chunk_id"] == "ch2"
     assert err["stage"] == "update_per_chunk"
     assert "schema validation" in err["error"]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Batch-bisect O(log N) recovery (.9.19)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_bisect_uses_log_n_calls_for_isolated_overcap_chunk(
+    isolated_nexus, runner, chroma_client, monkeypatch,
+):
+    """nexus-o6aa.9.19: when ONE over-cap chunk is buried in a batch
+    of N, the bisect-and-recurse retry isolates it in ~log2(N)
+    ``col.update`` calls instead of N per-chunk retries.
+
+    Live-migration motivation: Hal's first migration ran the .9.18
+    per-chunk retry path against ~9k over-cap chunks scattered across
+    105 batches of 300. Worst-case 105 × 300 = 31,500 individual
+    ``col.update`` round-trips at ~50–100 ms each = 26–52 minutes.
+    With bisect, each failed batch resolves in ~log2(300) = 9 calls.
+
+    With N=16 and one over-cap chunk:
+    - .9.18 per-chunk retry path: 16 + 1 = 17 ``col.update`` calls
+    - .9.19 bisect path: ≤ 2 × log2(16) + 1 = 9 calls (worst case)
+
+    WITH TEETH: assert call count is bisect-shaped, not per-chunk.
+    """
+    n = 16
+    overcap_idx = 7
+
+    events = [
+        _chunk_event(f"ch{i:02d}", f"uuid-{i}", "code__test")
+        for i in range(n)
+    ]
+    _seed_event_log(isolated_nexus, events)
+
+    chunks: list[dict] = []
+    for i in range(n):
+        if i == overcap_idx:
+            chunks.append({
+                "id": f"ch{i:02d}", "content": "x",
+                "metadata": {f"k{j}": f"v{j}" for j in range(35)},
+            })
+        else:
+            chunks.append({
+                "id": f"ch{i:02d}", "content": "x",
+                "metadata": {"chunk_text_hash": f"h{i}"},
+            })
+    _seed(chroma_client, "code__test", chunks)
+
+    fault_client = _OverCapFaultClient(chroma_client)
+
+    # Wrap col.update to count invocations during the verb's run.
+    call_count = {"n": 0}
+    real_get_collection = fault_client.get_collection
+
+    def counting_get_collection(name):
+        col = real_get_collection(name)
+        outer_update = col.update
+
+        def counted_update(*a, **kw):
+            call_count["n"] += 1
+            return outer_update(*a, **kw)
+
+        col.update = counted_update
+        return col
+
+    fault_client.get_collection = counting_get_collection
+
+    class _CountT3:
+        _client = fault_client
+
+    monkeypatch.setattr("nexus.db.make_t3", lambda: _CountT3())
+    result = runner.invoke(t3_backfill_doc_id_cmd, ["--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = _parse_json_payload(result.output)
+    assert payload["chunks_updated"] == n - 1, payload
+    assert payload["chunks_deferred_count"] == 1, payload
+    assert payload["chunks_deferred"][0]["chunk_id"] == f"ch{overcap_idx:02d}"
+
+    # WITH TEETH: bisect of N=16 with one bad leaf takes at most
+    # 2*log2(N)+1 = 9 col.update calls. Per-chunk retry would take
+    # N+1 = 17 (initial batch + N singletons). If this number creeps
+    # up, the bisect has degraded — fail loudly so the regression is
+    # caught in CI.
+    max_expected = 2 * 4 + 1  # 2 * log2(16) + 1
+    assert call_count["n"] <= max_expected, (
+        f"bisect issued {call_count['n']} col.update calls for N={n}; "
+        f"expected ≤ {max_expected} (worst case 2*log2(N)+1). "
+        f"Per-chunk retry would be {n + 1} = {n}+1. If this assertion "
+        f"fails high, the bisect degraded to per-chunk and the .9.19 "
+        f"speedup was lost."
+    )


### PR DESCRIPTION
## Summary
- O(log N) batch-bisect replaces O(N) per-chunk retry from #459 — fixes the 30+ minute wall-clock cost of the .9.18 recovery path against Cloud T3 latency on Hal's live migration.
- Single recursive helper `_bisect_update`: tries the whole slice → on failure, halves and recurses → at len=1, classifies (deferred-class vs genuine error) using the same `_DEFERRED_QUOTA_HINTS` logic .9.18 introduced.
- Verb's outer try/except is folded into `_bisect_update` so the top-level attempt serves both roles — eliminates the redundant duplicate retry .9.18 had.

## Live-migration motivation
Hal's 2026-05-01 migration rerun discovered the per-chunk path takes 30+ min wall-clock on Cloud T3:
- 105 failed batches × 300 chunks = 31,500 individual `col.update` round-trips.
- Each round-trip ~50–100 ms on Cloud T3 → 26–52 min total.
- Bisect: ~log2(300) = ~18 calls per failed batch → ~30× speedup.

## Behavioural compatibility
- Deferred-class quotas (`NumMetadataKeys`) → `chunks_deferred`, verb exits 0.
- Genuine errors (network, schema, auth) → `errors`, verb exits 1.
- Same JSON report shape, same exit-code semantics as .9.18.

## WITH TEETH
New regression test seeds N=16 batch with one over-cap chunk at idx 7 and counts `col.update` invocations.

| Path | Calls (N=16) | Calls (N=300) |
|------|-------------:|--------------:|
| Per-chunk (.9.18) | 17 | 301 |
| Bisect (.9.19) | 9 | ~18 |

Asserts `call_count ≤ 2*log2(N)+1`. Pre-fix code (stashed and re-tested in this branch) issued 17 calls — confirms the test fails on .9.18 and the .9.19 speedup is locked in.

## Test plan
- [x] `pytest tests/test_catalog_t3_backfill_partial_failure.py -v` (4/4 passing — 3 .9.18 + 1 new .9.19 bisect)
- [x] Wider catalog suite: `tests/test_catalog_migrate.py`, `tests/test_catalog_backfill.py`, `tests/test_catalog_doctor_replay_equality.py`, `tests/test_catalog_doctor_t3_coverage.py` — 43/43 passing.
- [x] Stash-revert verification: with .9.19 helper code stashed, the new test fails with 17 calls.

## Stack
- Base: #459 (`.9.18` per-chunk retry).
- Bead: `nexus-o6aa.9.19`.
- Together with #460 (`.9.17` progress output), closes the live-migration UX response loop.
