### PR TITLE
fix(catalog): coerce None → {} in Catalog.update() (nexus-ga48)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1810,7 +1810,18 @@ class Catalog:
                 "chunk_count": entry.chunk_count,
                 "head_hash": entry.head_hash,
                 "indexed_at": entry.indexed_at,
-                "meta": entry.meta,
+                # nexus-ga48: coerce ``None`` → ``{}`` at the source so
+                # the downstream merge (line ~1830), event payload
+                # (~1874), and SQL serialisation (~1909) all see a
+                # dict shape. Pre-fix, a row whose SQLite ``metadata``
+                # column held the literal ``'null'`` string decoded
+                # back through resolve() as Python ``None``, which
+                # then crashed in ``dict(None)`` at the merge or
+                # event-payload sites — silently blocking any
+                # ``update()`` on the 11 affected rows in Hal's
+                # catalog. The boundary serialisation at line 1909
+                # also gets ``or {}`` defence-in-depth.
+                "meta": entry.meta or {},
                 "source_mtime": entry.source_mtime,
                 # RDR-096 P3.1: preserve source_uri across updates.
                 # Without this carry-over, every update() call would
@@ -1906,7 +1917,8 @@ class Catalog:
                         rec_dict["year"], rec_dict["content_type"], rec_dict["file_path"],
                         rec_dict["corpus"], rec_dict["physical_collection"],
                         rec_dict["chunk_count"], rec_dict["head_hash"],
-                        rec_dict["indexed_at"], json.dumps(rec_dict["meta"]),
+                        rec_dict["indexed_at"],
+                        json.dumps(rec_dict["meta"] or {}),
                         rec_dict.get("source_mtime", 0.0),
                         rec_dict.get("source_uri", ""),
                         rec_dict["alias_of"],

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -460,6 +460,59 @@ class TestUpdate:
         with pytest.raises(KeyError):
             cat.update(Tumbler.parse("1.1.999"), title="x")
 
+    def test_update_heals_null_metadata_column(self, cat_with_owner):
+        """nexus-ga48: when SQLite's ``metadata`` column already holds
+        the literal string ``'null'`` (a self-perpetuating shape that
+        slipped in through historical writes pre-coercion), the next
+        ``update()`` must heal it to ``'{}'`` rather than re-emit
+        ``'null'``.
+
+        Pre-fix path: ``Catalog.update`` at catalog.py:1909 wrote
+        ``json.dumps(rec_dict["meta"])``; resolve() decoded the column
+        with ``json.loads(row[11]) if row[11] else {}`` which turns
+        the literal ``'null'`` into Python ``None`` (truthy string,
+        loads to None); update then re-serialised None back to the
+        literal ``'null'``. The synthesizer emits ``meta={}``, so
+        ``doctor --replay-equality`` reports FAIL on every such row.
+        Post-fix: any non-dict ``rec_dict["meta"]`` (None, missing,
+        etc.) is coerced to ``{}`` before serialisation.
+
+        Reproduction injects the bad shape via direct SQL because
+        ``register()`` already coerces None at write time; the only
+        way to land ``'null'`` is to bypass register's coercion or
+        to migrate from a historical state that lacked it.
+        """
+        cat, owner = cat_with_owner
+        doc = cat.register(owner, "a.py", content_type="code", file_path="a.py")
+
+        # Forcibly write the legacy bad shape into the metadata column.
+        cat._db.execute(
+            "UPDATE documents SET metadata = 'null' WHERE tumbler = ?",
+            (str(doc),),
+        )
+        cat._db.commit()
+
+        # Confirm the bad shape is in place pre-fix.
+        before = cat._db.execute(
+            "SELECT metadata FROM documents WHERE tumbler = ?", (str(doc),),
+        ).fetchone()[0]
+        assert before == "null", (
+            f"setup failed: SQL inject did not land 'null'; got {before!r}"
+        )
+
+        # Update an unrelated field — should heal metadata as a side effect.
+        cat.update(doc, title="renamed")
+
+        after = cat._db.execute(
+            "SELECT metadata FROM documents WHERE tumbler = ?", (str(doc),),
+        ).fetchone()[0]
+        assert after == "{}", (
+            f"update() must heal 'null' → '{{}}'; got {after!r}. "
+            f"If this fails with 'null' the coerce-or-{{}} fix at "
+            f"catalog.py:1909 was reverted or the resolve→update path "
+            f"is leaking None through additional sites."
+        )
+
 
 class TestEnsureConsistent:
     def test_malformed_jsonl_no_crash(self, tmp_path):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -486,7 +486,7 @@ class TestUpdate:
         doc = cat.register(owner, "a.py", content_type="code", file_path="a.py")
 
         # Forcibly write the legacy bad shape into the metadata column.
-        cat._db.execute(
+        cat._db.execute(  # epsilon-allow: inject historical metadata='null' that the public API can no longer produce (register coerces); needed to exercise the heal path (RDR-101 ε)
             "UPDATE documents SET metadata = 'null' WHERE tumbler = ?",
             (str(doc),),
         )


### PR DESCRIPTION
## Summary
1-line-style coercion fix for `Catalog.update()` when SQLite's `documents.metadata` column holds the legacy literal string `'null'`.

The bead's premise was correct in spirit but wrong on mechanism: `update()` doesn't *perpetuate* null on those rows — it *crashes* on them with `TypeError: 'NoneType' object is not iterable` at one of two earlier sites (`dict(rec_dict["meta"])` at the meta-merge path or the event-payload construction). Without this fix, any catalog with even one `metadata='null'` row could not be `update()`'d.

## What changed
1. `src/nexus/catalog/catalog.py` — line ~1813: coerce `entry.meta or {}` when building `rec_dict`. This makes the merge (~1830), event payload (~1874), and SQL serialisation (~1909) all see a dict shape.
2. Same file, line ~1909: `json.dumps(rec_dict["meta"] or {})` — defence-in-depth at the SQL boundary, matching the bead's original specification.
3. `tests/test_catalog.py::TestUpdate::test_update_heals_null_metadata_column` — regression test that injects `metadata='null'` via direct SQL (bypassing `register()`'s coercion), calls `update()`, and asserts the column heals to `'{}'`.

## Real-world motivation
Found while preparing Hal's catalog for RDR-101 migration: 11 of 8,163 rows (0.13%) carry `metadata='null'`. Spans 2026-04-08 → 2026-04-27 — intermittent. `doctor --replay-equality` reports FAIL on those rows because the synthesizer emits `meta={}` while live SQLite has `'null'`. Without this fix the rows can't be updated to heal them.

## Test plan
- [x] `pytest tests/test_catalog.py::TestUpdate -v` — 5/5 green (4 existing + 1 new).
- [x] Wider catalog suite: `tests/test_catalog.py`, `tests/test_catalog_doctor_replay_equality.py`, `tests/test_catalog_event_sourced_register.py`, `tests/test_catalog_event_sourced_mutators.py`, `tests/test_catalog_migrate.py` — 158/158 green.
- [x] Reproducer pre-fix: confirmed `TypeError: 'NoneType' object is not iterable` at `catalog.py:1874` before the coerce; clean post-fix.

## Stack
- Independent of the .9.x stack (#459/460/461/462). Doesn't touch event-sourced write paths.
- Bead: `nexus-ga48` (P2 BUG).
