### PR TITLE
fix(t3): bypass canonical schema for taxonomy collections (nexus-o6aa.9.16)

### DIFF
--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -77,6 +77,24 @@ def _normalize_for_write(metadata: dict, collection_name: str) -> dict:
     return normalize(metadata, content_type=content_type)
 
 
+# nexus-o6aa.9.16: collection prefixes whose writes bypass the canonical
+# chunk schema. These are programmatically-populated collections that
+# carry their own metadata vocabulary — applying the canonical
+# normalize/validate would strip every collection-specific key. The
+# production writers (e.g. ``catalog_taxonomy._batched_upsert``) already
+# bypass by calling ``coll.upsert()`` directly; this set keeps the
+# T3-public write path symmetric so .nxexp round-trips don't silently
+# strip the collection's metadata at import time.
+_BYPASS_SCHEMA_PREFIXES: tuple[str, ...] = ("taxonomy__",)
+
+
+def _bypass_canonical_schema(collection_name: str) -> bool:
+    """Return ``True`` if *collection_name* should skip canonical schema
+    normalisation/validation (nexus-o6aa.9.16).
+    """
+    return collection_name.startswith(_BYPASS_SCHEMA_PREFIXES)
+
+
 def _rewrite_collection_metadata(
     t3_db: T3Database,
     collection_name: str,
@@ -422,11 +440,21 @@ class T3Database:
         # ``git_*`` into ``git_meta``; ``validate()`` then fails loud if
         # anything still violates the 30-key ceiling or schema rules —
         # never silently drops fields by insertion order.
-        metadatas = [
-            _normalize_for_write(m, collection_name) for m in metadatas
-        ]
-        for m in metadatas:
-            validate(m)
+        #
+        # nexus-o6aa.9.16: programmatic vector-only collections
+        # (``taxonomy__*``) carry collection-specific metadata
+        # (``topic_id``, ``label``, ``doc_count``, ``collection``) that
+        # is not part of the canonical chunk schema. Production writes
+        # bypass this funnel entirely (``catalog_taxonomy._batched_upsert``
+        # calls ``coll.upsert()`` directly); the import path must do the
+        # same or .nxexp round-trips for taxonomy collections silently
+        # strip every taxonomy-specific key, breaking export-as-backup.
+        if not _bypass_canonical_schema(collection_name):
+            metadatas = [
+                _normalize_for_write(m, collection_name) for m in metadatas
+            ]
+            for m in metadatas:
+                validate(m)
 
         size = QUOTAS.MAX_RECORDS_PER_WRITE
         with self._write_sem(collection_name):
@@ -671,10 +699,15 @@ class T3Database:
         Every record is funnelled through the canonical metadata schema
         (nexus-40t) so enrichment post-passes can't overrun Chroma's
         32-key cap by merging fields on top of an already-full row.
+
+        nexus-o6aa.9.16: programmatic vector-only collections
+        (``taxonomy__*``) bypass the canonical schema — see
+        :func:`_bypass_canonical_schema`.
         """
-        metadatas = [_normalize_for_write(m, collection) for m in metadatas]
-        for m in metadatas:
-            validate(m)
+        if not _bypass_canonical_schema(collection):
+            metadatas = [_normalize_for_write(m, collection) for m in metadatas]
+            for m in metadatas:
+                validate(m)
         col = self.get_or_create_collection(collection)
         size = QUOTAS.MAX_RECORDS_PER_WRITE
         with self._write_sem(collection):

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -134,6 +134,70 @@ class TestRoundTrip:
         restored_emb = restored_col.get(ids=["id-000"], include=["embeddings"])["embeddings"][0]
         np.testing.assert_allclose(orig_emb, restored_emb, rtol=1e-6)
 
+    def test_round_trip_preserves_taxonomy_metadata(
+        self, ephemeral_db: T3Database, tmp_path: Path,
+    ):
+        """nexus-o6aa.9.16: programmatic vector-only collections
+        (``taxonomy__*``) carry collection-specific metadata
+        (``topic_id``, ``label``, ``doc_count``, ``collection``) that
+        is not part of the canonical chunk schema. Pre-fix, the
+        canonical normalize/validate funnel in T3Database stripped
+        every taxonomy-specific key on import — silently turning the
+        .nxexp round-trip from a faithful backup into a lossy one.
+
+        This regression test seeds a ``taxonomy__centroids``-shape
+        collection, exports it, imports into a fresh collection,
+        and asserts every taxonomy key round-trips intact.
+        """
+        col_name = "taxonomy__centroids"
+        ids = ["taxonomy__centroids:1", "taxonomy__centroids:2"]
+        # Vector-only entries: no documents, just embeddings + metadata.
+        # _seed_collection requires non-empty docs to compute embeddings,
+        # so we seed with placeholder docs but then read back the
+        # metadata only.
+        docs = ["", ""]
+        # Hand-craft metadatas that mirror catalog_taxonomy._batched_upsert.
+        metadatas = [
+            {
+                "topic_id": 1,
+                "label": "neural laminar circuits",
+                "collection": "papers__grossberg",
+                "doc_count": 12,
+            },
+            {
+                "topic_id": 2,
+                "label": "phoneme blocking dynamics",
+                "collection": "papers__grossberg",
+                "doc_count": 8,
+            },
+        ]
+        embeddings = [_EF(["x"])[0], _EF(["y"])[0]]
+        col = ephemeral_db.get_or_create_collection(col_name)
+        col.upsert(
+            ids=ids, documents=docs, embeddings=embeddings, metadatas=metadatas,
+        )
+
+        _export_import(
+            ephemeral_db, col_name, tmp_path, target="taxonomy__restored",
+        )
+
+        restored = ephemeral_db._client_for(
+            "taxonomy__restored",
+        ).get_collection("taxonomy__restored")
+        result = restored.get(ids=ids, include=["metadatas"])
+        meta_by_id = dict(zip(result["ids"], result["metadatas"]))
+        # WITH TEETH — every taxonomy key must survive the round trip.
+        for original_id, original_meta in zip(ids, metadatas):
+            roundtripped = meta_by_id[original_id]
+            for key, expected in original_meta.items():
+                assert roundtripped.get(key) == expected, (
+                    f"taxonomy key {key!r} did not round-trip on "
+                    f"{original_id!r}: expected {expected!r}, "
+                    f"got {roundtripped!r}. If this fails the canonical "
+                    f"schema funnel stripped the key — re-check the "
+                    f"_bypass_canonical_schema guard in t3.py."
+                )
+
 
 # ── Unit: gzip compression ───────────────────────────────────────────────────
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -172,7 +172,18 @@ class TestRoundTrip:
             },
         ]
         embeddings = [_EF(["x"])[0], _EF(["y"])[0]]
-        col = ephemeral_db.get_or_create_collection(col_name)
+        # Mirror catalog_taxonomy._create_centroid_collection: use the
+        # underlying chromadb client directly with hnsw:space=cosine.
+        # NOT ephemeral_db.get_or_create_collection — that injects an
+        # embedding_function and defaults to L2, which pollutes
+        # process-wide chromadb state and breaks downstream
+        # test_projection_quality similarity assertions when test
+        # ordering co-locates these tests in the same process.
+        col = ephemeral_db._client.get_or_create_collection(
+            col_name,
+            embedding_function=None,
+            metadata={"hnsw:space": "cosine"},
+        )
         col.upsert(
             ids=ids, documents=docs, embeddings=embeddings, metadatas=metadatas,
         )


### PR DESCRIPTION
## Summary
.nxexp round-trip for `taxonomy__*` collections was lossy: export preserved every taxonomy key, but import sent everything through `T3Database._write_batch`'s canonical schema funnel — which strips any key outside `ALLOWED_TOP_LEVEL`. After import, the only surviving metadata was `{'content_type': 'prose'}`. Taxonomy backups silently lost the taxonomy.

## Root cause
Production taxonomy writes via `catalog_taxonomy._batched_upsert` already bypass the canonical funnel — they call `coll.upsert()` directly on the chromadb client. The import path is asymmetric: it goes through `T3Database.upsert_chunks_with_embeddings` which routes through `_write_batch` → `_normalize_for_write` → `validate`.

This patch restores symmetry. Programmatic vector-only collections matching `_BYPASS_SCHEMA_PREFIXES` (currently `("taxonomy__",)`) skip canonical normalization/validation in both `_write_batch` and `update_chunks`. Standard chunk collections (`code__`/`docs__`/`knowledge__`/`rdr__`/`papers__`/etc.) continue to enforce the 32-key cap and the `ALLOWED_TOP_LEVEL` whitelist unchanged.

## Surface area
- New helper: `_bypass_canonical_schema(collection_name) -> bool` in `src/nexus/db/t3.py`.
- Two call sites guarded: `_write_batch` (line ~425), `update_chunks` (line ~675).
- Schema set extensible: `_BYPASS_SCHEMA_PREFIXES: tuple[str, ...]` — add additional programmatic-vector prefixes here without restructuring the canonical schema.

## WITH TEETH test
`tests/test_exporter.py::TestRoundTrip::test_round_trip_preserves_taxonomy_metadata`:
1. Seed a `taxonomy__centroids`-shape collection with `topic_id`/`label`/`collection`/`doc_count`.
2. Export → import into a fresh collection.
3. Assert every taxonomy key round-trips.

Stash-revert verification: pre-fix the test fails with `{'content_type': 'prose'}` as the only surviving metadata, confirming the schema funnel was the culprit.

## Found alongside
This was discovered as a follow-up to `nexus-o6aa.9.15` (PR #458) — once `.nxexp` imports for vector-only collections stopped crashing on `document=None`, the metadata-stripping defect underneath became visible.

## Test plan
- [x] `pytest tests/test_exporter.py` — 52/52 green (4 RoundTrip + 48 others).
- [x] `pytest tests/test_t3.py tests/test_metadata_schema.py` — 118/118 green (no regression in standard-collection schema enforcement).
- [x] WITH TEETH stash-revert: confirmed pre-fix failure mode.

## Stack
- Independent of the .9.x stack (#459/460/461/462) and #463.
- Bead: `nexus-o6aa.9.16` (P3 BUG, parent `nexus-o6aa.9` Phase 3 closed).
