### PR TITLE
feat(search): catalog prefilter narrows on doc_id (nexus-ufyl)

### DIFF
--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -112,11 +112,18 @@ _OP_MAP = {"$eq": "=", "$gte": ">=", "$lte": "<=", "$gt": ">", "$lt": "<", "$ne"
 _PREDICATE_TO_COLUMN = {"bib_year": "year"}
 
 
-def _catalog_ids_for_predicates(db: sqlite3.Connection, predicates: dict) -> list[str]:
-    """Query catalog SQLite for file_paths matching *predicates*.
+def _catalog_doc_ids_for_predicates(
+    db: sqlite3.Connection, predicates: dict,
+) -> list[str]:
+    """Query catalog SQLite for ``doc_id`` values matching *predicates*.
 
     Only handles predicates that map to catalog columns (bib_year → year).
-    Returns file_path list (used as source_path filter in ChromaDB).
+    Returns the list of ``Document.doc_id`` values (extracted from
+    ``documents.metadata`` via ``json_extract($.doc_id)``) used as the
+    ``doc_id`` $in filter in ChromaDB. Rows whose metadata lacks a
+    ``doc_id`` are excluded — the prefilter relies on the catalog being
+    backfilled (``nx catalog t3-backfill-doc-id``) before it can narrow
+    against them; legacy rows fall through to standard search.
     """
     clauses: list[str] = []
     params: list[Any] = []
@@ -141,7 +148,8 @@ def _catalog_ids_for_predicates(db: sqlite3.Connection, predicates: dict) -> lis
 
     where = " AND ".join(clauses)
     rows = db.execute(
-        f"SELECT file_path FROM documents WHERE {where} AND file_path IS NOT NULL",
+        f"SELECT json_extract(metadata, '$.doc_id') FROM documents "
+        f"WHERE {where} AND json_extract(metadata, '$.doc_id') IS NOT NULL",
         params,
     ).fetchall()
     return [r[0] for r in rows]
@@ -150,11 +158,17 @@ def _catalog_ids_for_predicates(db: sqlite3.Connection, predicates: dict) -> lis
 def _prefilter_from_catalog(
     where: dict | None, catalog: Any | None,
 ) -> dict | None:
-    """Build a ChromaDB source_path pre-filter from catalog when selectivity is high.
+    """Build a ChromaDB ``doc_id`` pre-filter from catalog when selectivity is high.
 
-    Returns a ChromaDB ``where`` dict with ``source_path $in`` if the catalog
-    match set is small enough (<5% of total docs, ≤500 IDs).  Returns ``None``
-    to fall through to standard post-filtering otherwise.
+    Returns a ChromaDB ``where`` dict with ``doc_id $in`` if the catalog
+    match set is small enough (<5% of total docs, ≤500 IDs). Returns
+    ``None`` to fall through to standard post-filtering otherwise.
+
+    RDR-101 Phase 4 (nexus-ufyl) replaces the legacy ``source_path``-keyed
+    filter so the prune of deprecated chunk-metadata keys
+    (nexus-o6aa.10.3) can drop ``source_path`` without breaking catalog
+    prefiltering. The chunk-side identity field is the new ``doc_id``
+    metadata column populated by ``t3-backfill-doc-id``.
     """
     if not where or catalog is None:
         return None
@@ -171,23 +185,23 @@ def _prefilter_from_catalog(
     try:
         # Get the raw sqlite3 connection from CatalogDB wrapper
         conn = getattr(db, "_conn", db)
-        paths = _catalog_ids_for_predicates(conn, mappable)
+        doc_ids = _catalog_doc_ids_for_predicates(conn, mappable)
     except Exception:
         _log.debug("catalog_prefilter_failed", exc_info=True)
         return None
 
-    if not paths:
+    if not doc_ids:
         return None
-    if len(paths) > _MAX_PREFILTER_IDS:
-        _log.debug("catalog_prefilter_too_many", count=len(paths))
+    if len(doc_ids) > _MAX_PREFILTER_IDS:
+        _log.debug("catalog_prefilter_too_many", count=len(doc_ids))
         return None
 
     # Selectivity check
     total = catalog.doc_count() if hasattr(catalog, "doc_count") else 0
-    if total > 0 and len(paths) / total > _SELECTIVITY_THRESHOLD:
+    if total > 0 and len(doc_ids) / total > _SELECTIVITY_THRESHOLD:
         return None
 
-    return {"source_path": {"$in": paths}}
+    return {"doc_id": {"$in": doc_ids}}
 
 
 # ── Cross-corpus search ───────────────────────────────────────────────────────
@@ -286,13 +300,17 @@ def search_cross_corpus(
     )
 
     # Catalog pre-filter: for high-selectivity predicates, narrow the search
-    # space via source_path $in filter (Compass, RF-3).
+    # space via doc_id $in filter (Compass, RF-3; RDR-101 Phase 4 nexus-ufyl
+    # switched the key from source_path to doc_id).
     prefilter = _prefilter_from_catalog(where, catalog)
     if prefilter is not None:
-        # Merge pre-filter with original where — pre-filter uses source_path,
+        # Merge pre-filter with original where — pre-filter narrows on doc_id,
         # original where keeps the metadata predicates for ChromaDB post-filter.
         effective_where: dict | None = {"$and": [prefilter, where]} if where else prefilter
-        _log.debug("catalog_prefilter_applied", paths=len(prefilter.get("source_path", {}).get("$in", [])))
+        _log.debug(
+            "catalog_prefilter_applied",
+            doc_ids=len(prefilter.get("doc_id", {}).get("$in", [])),
+        )
     else:
         effective_where = where
 

--- a/tests/test_catalog_prefilter.py
+++ b/tests/test_catalog_prefilter.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Tests for catalog-scoped pre-filtering (RDR-056 Phase 3)."""
+"""Tests for catalog-scoped pre-filtering (RDR-056 Phase 3, RDR-101 Phase 4).
+
+RDR-101 Phase 4 (nexus-ufyl): the prefilter now emits a ``doc_id`` $in
+where-clause keyed on ``json_extract(metadata, '$.doc_id')`` from the
+catalog, replacing the legacy ``source_path``-keyed filter so that the
+T3 prune of deprecated keys (nexus-o6aa.10.3) can drop ``source_path``
+without breaking catalog prefiltering.
+"""
 from __future__ import annotations
 
 import json
@@ -14,7 +21,13 @@ from nexus.search_engine import _prefilter_from_catalog
 
 
 def _create_test_catalog_db(db_path: Path, entries: list[dict]) -> sqlite3.Connection:
-    """Create a minimal catalog SQLite database with test documents."""
+    """Create a minimal catalog SQLite database with test documents.
+
+    Each entry may carry a top-level ``doc_id`` field; it is stored inside
+    the ``metadata`` JSON column under ``$.doc_id`` to match the production
+    catalog schema (see ``Catalog.by_doc_id``). Pass an explicit ``metadata``
+    dict to bypass auto-injection.
+    """
     conn = sqlite3.connect(str(db_path))
     conn.execute(
         "CREATE TABLE IF NOT EXISTS documents ("
@@ -25,6 +38,9 @@ def _create_test_catalog_db(db_path: Path, entries: list[dict]) -> sqlite3.Conne
         ")"
     )
     for e in entries:
+        meta = dict(e.get("metadata", {}))
+        if "doc_id" in e and "doc_id" not in meta:
+            meta["doc_id"] = e["doc_id"]
         conn.execute(
             "INSERT INTO documents (tumbler, title, author, year, content_type, "
             "file_path, corpus, physical_collection, chunk_count, head_hash, "
@@ -41,7 +57,7 @@ def _create_test_catalog_db(db_path: Path, entries: list[dict]) -> sqlite3.Conne
                 e.get("chunk_count", 1),
                 e.get("head_hash"),
                 e.get("indexed_at"),
-                json.dumps(e.get("metadata", {})),
+                json.dumps(meta),
             ),
         )
     conn.commit()
@@ -55,28 +71,25 @@ class _FakeCatalog:
         self._db = db
         self._total_docs = total_docs
 
-    def ids_for_predicates(self, predicates: dict) -> list[str]:
-        """Query file_paths matching predicates."""
-        from nexus.search_engine import _catalog_ids_for_predicates
-        return _catalog_ids_for_predicates(self._db, predicates)
-
     def doc_count(self) -> int:
         return self._total_docs
 
 
 class TestPrefilterFromCatalog:
     def test_high_selectivity_year_filter(self) -> None:
-        """bib_year predicate with <5% match → returns source_path $in filter."""
+        """bib_year predicate with <5% match → returns doc_id $in filter."""
         with tempfile.TemporaryDirectory() as td:
             db = _create_test_catalog_db(
                 Path(td) / "cat.db",
                 [
                     {"tumbler": f"1.{i}", "title": f"doc{i}", "year": 2024,
-                     "file_path": f"/docs/paper_{i}.md"}
+                     "file_path": f"/docs/paper_{i}.md",
+                     "doc_id": f"new-{i}"}
                     for i in range(3)
                 ] + [
                     {"tumbler": f"2.{i}", "title": f"old{i}", "year": 2020,
-                     "file_path": f"/docs/old_{i}.md"}
+                     "file_path": f"/docs/old_{i}.md",
+                     "doc_id": f"old-{i}"}
                     for i in range(97)
                 ],
             )
@@ -84,8 +97,56 @@ class TestPrefilterFromCatalog:
             where = {"bib_year": {"$eq": 2024}}
             result = _prefilter_from_catalog(where, cat)
             assert result is not None
-            # Should contain source_path $in filter
-            assert "source_path" in str(result)
+            assert "doc_id" in result
+            assert "source_path" not in result
+            assert sorted(result["doc_id"]["$in"]) == ["new-0", "new-1", "new-2"]
+
+    def test_emits_doc_id_key_not_source_path(self) -> None:
+        """RDR-101 Phase 4 sentinel: the prefilter where-clause keys on
+        ``doc_id``, not ``source_path``. Pre-RDR-101 code would emit
+        ``{"source_path": {"$in": [<file_paths>]}}``; the migration switches
+        the key (and the lookup column) so that nx catalog prune-deprecated-keys
+        can drop ``source_path`` from chunk metadata without breaking
+        catalog prefiltering.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            db = _create_test_catalog_db(
+                Path(td) / "cat.db",
+                [
+                    {"tumbler": "1.1", "title": "doc1", "year": 2024,
+                     "file_path": "/docs/paper.md",
+                     "doc_id": "01HXYZ-doc-1"},
+                ],
+            )
+            cat = _FakeCatalog(db, total_docs=100)
+            result = _prefilter_from_catalog({"bib_year": {"$eq": 2024}}, cat)
+            assert result == {"doc_id": {"$in": ["01HXYZ-doc-1"]}}
+
+    def test_skips_rows_without_doc_id_metadata(self) -> None:
+        """Legacy rows lacking metadata.doc_id are silently skipped — the
+        prefilter only narrows on rows that have a doc_id, falling back
+        to standard search for the rest. If ALL rows lack a doc_id the
+        prefilter returns None (nothing to narrow against).
+        """
+        with tempfile.TemporaryDirectory() as td:
+            db = _create_test_catalog_db(
+                Path(td) / "cat.db",
+                # All matching rows have NO doc_id in metadata.
+                [
+                    {"tumbler": f"1.{i}", "title": f"doc{i}", "year": 2024,
+                     "file_path": f"/docs/paper_{i}.md",
+                     "metadata": {}}
+                    for i in range(3)
+                ] + [
+                    {"tumbler": f"2.{i}", "title": f"old{i}", "year": 2020,
+                     "file_path": f"/docs/old_{i}.md",
+                     "metadata": {}}
+                    for i in range(97)
+                ],
+            )
+            cat = _FakeCatalog(db, total_docs=100)
+            result = _prefilter_from_catalog({"bib_year": {"$eq": 2024}}, cat)
+            assert result is None
 
     def test_low_selectivity_skips_prefilter(self) -> None:
         """Predicate matching >5% of docs → returns None (use standard filter)."""
@@ -94,11 +155,13 @@ class TestPrefilterFromCatalog:
                 Path(td) / "cat.db",
                 [
                     {"tumbler": f"1.{i}", "title": f"doc{i}", "year": 2024,
-                     "file_path": f"/docs/paper_{i}.md"}
+                     "file_path": f"/docs/paper_{i}.md",
+                     "doc_id": f"new-{i}"}
                     for i in range(50)
                 ] + [
                     {"tumbler": f"2.{i}", "title": f"old{i}", "year": 2020,
-                     "file_path": f"/docs/old_{i}.md"}
+                     "file_path": f"/docs/old_{i}.md",
+                     "doc_id": f"old-{i}"}
                     for i in range(50)
                 ],
             )
@@ -124,7 +187,8 @@ class TestPrefilterFromCatalog:
                 Path(td) / "cat.db",
                 [
                     {"tumbler": f"1.{i}", "title": f"doc{i}", "year": 2024,
-                     "file_path": f"/docs/paper_{i}.md"}
+                     "file_path": f"/docs/paper_{i}.md",
+                     "doc_id": f"new-{i}"}
                     for i in range(501)
                 ],
             )
@@ -149,14 +213,15 @@ class TestPrefilterFromCatalog:
                 Path(td) / "cat.db",
                 [
                     {"tumbler": "1.1", "title": "new1", "year": 2024,
-                     "file_path": "/a.md"},
+                     "file_path": "/a.md", "doc_id": "doc-a"},
                     {"tumbler": "1.2", "title": "new2", "year": 2023,
-                     "file_path": "/b.md"},
+                     "file_path": "/b.md", "doc_id": "doc-b"},
                     {"tumbler": "1.3", "title": "old", "year": 2020,
-                     "file_path": "/c.md"},
+                     "file_path": "/c.md", "doc_id": "doc-c"},
                 ] + [
                     {"tumbler": f"2.{i}", "title": f"filler{i}", "year": 2010,
-                     "file_path": f"/filler_{i}.md"}
+                     "file_path": f"/filler_{i}.md",
+                     "doc_id": f"filler-{i}"}
                     for i in range(97)
                 ],
             )
@@ -164,13 +229,16 @@ class TestPrefilterFromCatalog:
             where = {"bib_year": {"$gte": 2023}}
             result = _prefilter_from_catalog(where, cat)
             assert result is not None
+            assert "doc_id" in result
+            assert sorted(result["doc_id"]["$in"]) == ["doc-a", "doc-b"]
 
     def test_unsupported_predicate_returns_none(self) -> None:
         """Predicate not mappable to catalog columns → returns None."""
         with tempfile.TemporaryDirectory() as td:
             db = _create_test_catalog_db(
                 Path(td) / "cat.db",
-                [{"tumbler": "1.1", "title": "t", "file_path": "/a.md"}],
+                [{"tumbler": "1.1", "title": "t", "file_path": "/a.md",
+                  "doc_id": "doc-a"}],
             )
             cat = _FakeCatalog(db, total_docs=100)
             where = {"custom_field": "value"}
@@ -178,30 +246,52 @@ class TestPrefilterFromCatalog:
             assert result is None
 
 
-class TestCatalogIdsForPredicates:
+class TestCatalogDocIdsForPredicates:
     def test_year_eq(self) -> None:
-        from nexus.search_engine import _catalog_ids_for_predicates
+        from nexus.search_engine import _catalog_doc_ids_for_predicates
         with tempfile.TemporaryDirectory() as td:
             db = _create_test_catalog_db(
                 Path(td) / "cat.db",
                 [
-                    {"tumbler": "1.1", "title": "a", "year": 2024, "file_path": "/a.md"},
-                    {"tumbler": "1.2", "title": "b", "year": 2020, "file_path": "/b.md"},
+                    {"tumbler": "1.1", "title": "a", "year": 2024,
+                     "file_path": "/a.md", "doc_id": "doc-a"},
+                    {"tumbler": "1.2", "title": "b", "year": 2020,
+                     "file_path": "/b.md", "doc_id": "doc-b"},
                 ],
             )
-            paths = _catalog_ids_for_predicates(db, {"bib_year": {"$eq": 2024}})
-            assert paths == ["/a.md"]
+            doc_ids = _catalog_doc_ids_for_predicates(db, {"bib_year": {"$eq": 2024}})
+            assert doc_ids == ["doc-a"]
 
     def test_year_gte(self) -> None:
-        from nexus.search_engine import _catalog_ids_for_predicates
+        from nexus.search_engine import _catalog_doc_ids_for_predicates
         with tempfile.TemporaryDirectory() as td:
             db = _create_test_catalog_db(
                 Path(td) / "cat.db",
                 [
-                    {"tumbler": "1.1", "title": "a", "year": 2024, "file_path": "/a.md"},
-                    {"tumbler": "1.2", "title": "b", "year": 2023, "file_path": "/b.md"},
-                    {"tumbler": "1.3", "title": "c", "year": 2020, "file_path": "/c.md"},
+                    {"tumbler": "1.1", "title": "a", "year": 2024,
+                     "file_path": "/a.md", "doc_id": "doc-a"},
+                    {"tumbler": "1.2", "title": "b", "year": 2023,
+                     "file_path": "/b.md", "doc_id": "doc-b"},
+                    {"tumbler": "1.3", "title": "c", "year": 2020,
+                     "file_path": "/c.md", "doc_id": "doc-c"},
                 ],
             )
-            paths = _catalog_ids_for_predicates(db, {"bib_year": {"$gte": 2023}})
-            assert sorted(paths) == ["/a.md", "/b.md"]
+            doc_ids = _catalog_doc_ids_for_predicates(db, {"bib_year": {"$gte": 2023}})
+            assert sorted(doc_ids) == ["doc-a", "doc-b"]
+
+    def test_skips_rows_without_doc_id(self) -> None:
+        """Rows whose metadata lacks $.doc_id are excluded (IS NOT NULL)."""
+        from nexus.search_engine import _catalog_doc_ids_for_predicates
+        with tempfile.TemporaryDirectory() as td:
+            db = _create_test_catalog_db(
+                Path(td) / "cat.db",
+                [
+                    {"tumbler": "1.1", "title": "a", "year": 2024,
+                     "file_path": "/a.md", "doc_id": "doc-a"},
+                    # No doc_id metadata — must be skipped.
+                    {"tumbler": "1.2", "title": "b", "year": 2024,
+                     "file_path": "/b.md", "metadata": {}},
+                ],
+            )
+            doc_ids = _catalog_doc_ids_for_predicates(db, {"bib_year": {"$eq": 2024}})
+            assert doc_ids == ["doc-a"]


### PR DESCRIPTION
## Summary

RDR-101 Phase 4 reader migration. `_prefilter_from_catalog` (search_engine.py:158) now emits `{"doc_id": {"$in": [...]}}` instead of `{"source_path": {"$in": [...]}}`, sourcing values from `json_extract(documents.metadata, '$.doc_id')`. This unblocks `nx catalog prune-deprecated-keys` (nexus-o6aa.10.3) so that `source_path` can be dropped from chunk metadata without losing the high-selectivity catalog narrowing path.

## Changes

- `_catalog_ids_for_predicates` → `_catalog_doc_ids_for_predicates` (search_engine.py:115). SELECT column switched to `json_extract(metadata, '$.doc_id')` with an `IS NOT NULL` filter.
- `_prefilter_from_catalog` (search_engine.py:158) returns `{"doc_id": ...}` and the call-site at `search_cross_corpus` (search_engine.py:303) logs `doc_ids=...` instead of `paths=...`.
- Selectivity / max-IDs / no-catalog / unmappable-predicate paths are unchanged.

## Migration semantics

Rows whose metadata lacks `$.doc_id` are excluded from the prefilter result. Legacy collections that have not yet been backfilled via `nx catalog t3-backfill-doc-id` (RDR-101 Phase 3) fall through to standard search. This matches the pattern in `Catalog.by_doc_id` (catalog.py:2270) and `nx catalog verify-doc-id` (commands/catalog.py:1548).

## Test plan

- [x] 12 existing prefilter cases ported to the new schema (entries carry a `doc_id` field that lands in `metadata.doc_id`)
- [x] New sentinel `test_emits_doc_id_key_not_source_path` asserts `result == {"doc_id": {"$in": [...]}}` and fails on pre-fix code with the stashed-implementation diff
- [x] New `test_skips_rows_without_doc_id_metadata` covers the legacy / partially-backfilled catalog mode
- [x] Stash-revert confirmed: pre-fix code fails the sentinel test with `source_path` vs `doc_id` mismatch
- [x] Full search/clusterer suite passes (64 tests, 0 failures)

## Closes

bead: nexus-ufyl
parent: nexus-o6aa.10
blocks: nexus-o6aa.10.3