### PR TITLE
fix(t3): import path creates taxonomy collections with cosine, not L2 (nexus-18wz)

### DIFF
--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -1603,8 +1603,12 @@ class CatalogTaxonomy:
         """Create or retrieve the ``taxonomy__centroids`` ChromaDB collection.
 
         Uses ``embedding_function=None`` (pre-computed MiniLM 384d vectors)
-        and ``hnsw:space=cosine`` (RF-070-11). Do NOT use
-        ``t3.get_or_create_collection()`` — it injects the wrong EF + L2.
+        and ``hnsw:space=cosine`` (RF-070-11). This direct chromadb-client
+        call predates ``T3Database.get_or_create_collection``'s
+        bypass-prefix branch (nexus-18wz) which now produces the same
+        shape; either is correct. Production code keeps this direct call
+        because it avoids the chromadb client lookup indirection on the
+        taxonomy hot path.
         """
         return client.get_or_create_collection(
             "taxonomy__centroids",

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -491,15 +491,33 @@ class T3Database:
         In local mode, the collection is created with ``hnsw:search_ef`` set to
         the configured value (default 256) so HNSW query recall is tuned at
         collection-creation time.  Cloud SPANN collections do not use this key.
+
+        nexus-18wz: programmatic vector-only collections matching
+        :data:`_BYPASS_SCHEMA_PREFIXES` (``taxonomy__*``) are created with
+        ``embedding_function=None`` and ``metadata={'hnsw:space': 'cosine'}``
+        regardless of local_mode — mirroring
+        :meth:`CatalogTaxonomy._create_centroid_collection`. This makes
+        ``nx store import`` of a ``.nxexp`` for a taxonomy collection
+        recreate the right shape; without it the import would silently
+        default to L2 and break cosine queries against the imported centroids.
         """
         from nexus.corpus import validate_collection_name
         validate_collection_name(name)
-        kwargs: dict = {"embedding_function": self._embedding_fn(name)}
-        if self._local_mode:
-            from nexus.config import load_config
-            cfg = load_config()
-            hnsw_ef = cfg.get("search", {}).get("hnsw_ef", 256)
-            kwargs["metadata"] = {"hnsw:search_ef": hnsw_ef}
+
+        if _bypass_canonical_schema(name):
+            metadata: dict = {"hnsw:space": "cosine"}
+            if self._local_mode:
+                from nexus.config import load_config
+                cfg = load_config()
+                metadata["hnsw:search_ef"] = cfg.get("search", {}).get("hnsw_ef", 256)
+            kwargs: dict = {"embedding_function": None, "metadata": metadata}
+        else:
+            kwargs = {"embedding_function": self._embedding_fn(name)}
+            if self._local_mode:
+                from nexus.config import load_config
+                cfg = load_config()
+                hnsw_ef = cfg.get("search", {}).get("hnsw_ef", 256)
+                kwargs["metadata"] = {"hnsw:search_ef": hnsw_ef}
         return _chroma_with_retry(
             self._client_for(name).get_or_create_collection,
             name, **kwargs,

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -275,14 +275,19 @@ class TestRoundTrip:
         # assertion above guarantees this; the secondary check guards
         # against future ChromaDB versions where ``metadata['hnsw:space']``
         # might decouple from the actual index space.
+        # Tolerance accounts for float underflow when querying a vector
+        # against itself (distance ~0 can dip to a tiny negative on
+        # some CPUs / ChromaDB builds — Linux CI runner hits this).
         query_result = restored.query(
             query_embeddings=[embeddings[0]],
             n_results=2,
             include=["distances"],
         )
+        eps = 1e-6
         for d in query_result["distances"][0]:
-            assert 0.0 <= d <= 2.0, (
-                f"distance {d} is outside cosine bounds [0, 2]"
+            assert -eps <= d <= 2.0 + eps, (
+                f"distance {d} is outside cosine bounds [0, 2] "
+                f"(tolerance {eps})"
             )
 
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -209,6 +209,82 @@ class TestRoundTrip:
                     f"_bypass_canonical_schema guard in t3.py."
                 )
 
+    def test_round_trip_preserves_taxonomy_distance_metric(
+        self, ephemeral_db: T3Database, tmp_path: Path,
+    ):
+        """nexus-18wz: ``taxonomy__*`` round-trip must preserve the
+        ``hnsw:space=cosine`` distance metric.
+
+        Pre-fix, the production import path (``upsert_chunks_with_embeddings``
+        → ``get_or_create_collection``) injected an embedding_function and
+        defaulted to L2, so a faithful-looking metadata round-trip silently
+        recreated the collection with the wrong metric. Cosine queries
+        against the imported collection then returned out-of-range
+        distances and broke any downstream similarity assignment.
+
+        The fix extends ``get_or_create_collection`` so bypass-prefix
+        collections (per ``_BYPASS_SCHEMA_PREFIXES``) are created with
+        ``embedding_function=None`` and ``metadata={'hnsw:space':
+        'cosine'}`` — mirroring ``catalog_taxonomy._create_centroid_collection``.
+        """
+        col_name = "taxonomy__centroids_metric"
+        target = "taxonomy__restored_metric"
+        ids = ["c:1", "c:2"]
+        docs = ["", ""]
+        # Use orthonormal-ish vectors so cosine and L2 disagree clearly:
+        # cosine_distance(e1, e2) = 1.0; L2_distance(e1, e2) = sqrt(2).
+        embeddings = [_EF(["alpha"])[0], _EF(["beta"])[0]]
+        metadatas = [
+            {"topic_id": 1, "label": "alpha", "collection": "x", "doc_count": 1},
+            {"topic_id": 2, "label": "beta", "collection": "x", "doc_count": 1},
+        ]
+        col = ephemeral_db._client.get_or_create_collection(
+            col_name,
+            embedding_function=None,
+            metadata={"hnsw:space": "cosine"},
+        )
+        col.upsert(
+            ids=ids, documents=docs, embeddings=embeddings, metadatas=metadatas,
+        )
+
+        _export_import(
+            ephemeral_db, col_name, tmp_path, target=target,
+        )
+
+        restored = ephemeral_db._client_for(target).get_collection(target)
+
+        # Direct metadata assertion as the load-bearing claim — pre-fix
+        # the import path passes no metadata kwarg in non-local mode, so
+        # ``restored.metadata`` is ``None`` and ChromaDB falls back to
+        # the L2 default. After the fix, bypass-prefix collections are
+        # created with ``metadata={'hnsw:space': 'cosine'}`` regardless
+        # of local_mode.
+        assert restored.metadata is not None, (
+            "imported collection metadata is None — the import path is "
+            "creating bypass-prefix collections without explicit "
+            "hnsw:space=cosine. Check get_or_create_collection's "
+            "bypass-prefix branch in src/nexus/db/t3.py (nexus-18wz)."
+        )
+        assert restored.metadata.get("hnsw:space") == "cosine", (
+            f"imported collection metadata: {restored.metadata!r} — "
+            f"expected hnsw:space=cosine (nexus-18wz)"
+        )
+
+        # Smoke check: a query against the imported collection returns
+        # distances within cosine bounds [0, 2]. A passing metadata
+        # assertion above guarantees this; the secondary check guards
+        # against future ChromaDB versions where ``metadata['hnsw:space']``
+        # might decouple from the actual index space.
+        query_result = restored.query(
+            query_embeddings=[embeddings[0]],
+            n_results=2,
+            include=["distances"],
+        )
+        for d in query_result["distances"][0]:
+            assert 0.0 <= d <= 2.0, (
+                f"distance {d} is outside cosine bounds [0, 2]"
+            )
+
 
 # ── Unit: gzip compression ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`T3Database.get_or_create_collection` now consults `_bypass_canonical_schema` when building creation kwargs. For `taxonomy__*` (and any future bypass-prefix) collections it sets `embedding_function=None` and `metadata={"hnsw:space": "cosine"}` regardless of `local_mode` — mirroring `CatalogTaxonomy._create_centroid_collection`.

## Bug context

`nx store import` for a `.nxexp` containing a `taxonomy__*` collection routes through `T3Database.upsert_chunks_with_embeddings` → `T3Database.get_or_create_collection`. Pre-fix, the latter passed no `metadata` kwarg in non-local mode, so chromadb defaulted to L2. The collection's chunk metadata round-tripped correctly (after nexus-o6aa.9.16), but the COLLECTION shape did not — every subsequent `assign_single` / `assign_batch` query against the imported centroids returned out-of-range similarity values.

This was surfaced during nexus-o6aa.9.16 CI investigation; the in-test workaround (seed via `client.get_or_create_collection` directly) didn't propagate to production until now.

## Files changed

- `src/nexus/db/t3.py:488` — `get_or_create_collection` consults `_bypass_canonical_schema(name)` and constructs the right kwargs for bypass-prefix collections.
- `src/nexus/db/t2/catalog_taxonomy.py:1602` — production warning updated; the direct chromadb-client call remains on the hot path but the "do not use t3.get_or_create_collection" advice is no longer accurate.
- `tests/test_exporter.py` — new `test_round_trip_preserves_taxonomy_distance_metric` regression test (sibling of the existing `test_round_trip_preserves_taxonomy_metadata`).

## Test plan

- [x] `test_round_trip_preserves_taxonomy_distance_metric` fails on pre-fix code with `restored.metadata is None` and a self-explanatory error pointing at `get_or_create_collection`'s bypass-prefix branch
- [x] All 5 `TestRoundTrip` cases pass post-fix
- [x] 238 taxonomy / projection / exporter / index_taxonomy tests pass with no new warnings
- [x] No production callers of `_create_centroid_collection` regress (its direct chromadb-client call is unchanged)

## Closes

bead: nexus-18wz
parent: nexus-o6aa.10
blocks: nexus-o6aa.10.3