### PR TITLE
feat(t3): doc_id-keyed chunk lookups for incremental sync (nexus-dcym PR-A)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -2890,12 +2890,18 @@ class Catalog:
                 from nexus.db import make_t3
                 t3 = make_t3()
                 col = t3.get_or_create_collection(entry.physical_collection)
-                # Query by chunk_index metadata for deterministic ordering
-                where_filter: dict = {"chunk_index": chunk_idx}
-                if entry.file_path:
-                    where_filter["source_path"] = entry.file_path
+                # nexus-dcym: chunk identity is the catalog ``doc_id``,
+                # not the legacy ``source_path``. ``doc_id`` is stored
+                # by the projector under ``meta.doc_id``; older entries
+                # predate that and fall back to ``str(entry.tumbler)``
+                # (Phase 1's stand-in for ``doc_id``).
+                doc_id = entry.meta.get("doc_id") or str(entry.tumbler)
+                where_filter: dict = {
+                    "chunk_index": chunk_idx,
+                    "doc_id": doc_id,
+                }
                 result = col.get(
-                    where=where_filter if len(where_filter) == 1 else {"$and": [{k: v} for k, v in where_filter.items()]},
+                    where={"$and": [{k: v} for k, v in where_filter.items()]},
                     include=["documents"],
                     limit=1,
                 )

--- a/src/nexus/code_indexer.py
+++ b/src/nexus/code_indexer.py
@@ -320,8 +320,16 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
     comment_char = _COMMENT_CHARS.get(language, "#")
     rel_path = file_path.relative_to(ctx.repo_path)
 
-    # Staleness check — skip if content + model unchanged
-    if not ctx.force and check_staleness(ctx.col, file_path, content_hash, ctx.embedding_model):
+    # Staleness check — skip if content + model unchanged.
+    # nexus-dcym: prefer doc_id-keyed lookup when the catalog hook
+    # supplied a resolver; falls back to source_path for legacy chunks.
+    catalog_doc_id_for_staleness = (
+        ctx.doc_id_resolver(file_path) if ctx.doc_id_resolver is not None else ""
+    )
+    if not ctx.force and check_staleness(
+        ctx.col, file_path, content_hash, ctx.embedding_model,
+        doc_id=catalog_doc_id_for_staleness,
+    ):
         return 0
 
     # nexus-7niu: per-stage timer instrumentation. Silent when

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -1051,6 +1051,53 @@ class T3Database:
             self._delete_batch(col, collection_name, ids)
         return len(ids)
 
+    def ids_for_doc_id(self, collection_name: str, doc_id: str) -> list[str]:
+        """Return all chunk IDs for a given catalog ``doc_id``. No content fetch.
+
+        Companion to :meth:`ids_for_source`; switches the chunk-lookup
+        identity field from ``source_path`` to ``doc_id`` (RDR-101 Phase 4
+        reader migration). Paginates ``col.get()`` to respect the ChromaDB
+        Cloud 300-record limit. Returns empty list if the collection does
+        not exist.
+        """
+        try:
+            col = self._client_for(collection_name).get_collection(collection_name)
+        except _ChromaNotFoundError:
+            return []
+        ids: list[str] = []
+        offset = 0
+        page_limit = QUOTAS.MAX_RECORDS_PER_WRITE
+        while True:
+            result = _chroma_with_retry(
+                col.get,
+                where={"doc_id": doc_id},
+                include=[],
+                limit=page_limit,
+                offset=offset,
+            )
+            page_ids = result["ids"]
+            ids.extend(page_ids)
+            offset += len(page_ids)
+            if len(page_ids) < page_limit:
+                break
+        return ids
+
+    def delete_by_doc_id(self, collection_name: str, doc_id: str) -> int:
+        """Delete all chunks for a given catalog ``doc_id``. Returns count.
+
+        Companion to :meth:`delete_by_source` (RDR-101 Phase 4 reader
+        migration). Uses paginated ``col.get()`` keyed on ``doc_id`` to
+        avoid the ChromaDB Cloud 300-record truncation limit.
+        """
+        try:
+            col = self._client_for(collection_name).get_collection(collection_name)
+        except _ChromaNotFoundError:
+            return 0
+        ids = self.ids_for_doc_id(collection_name, doc_id)
+        if ids:
+            self._delete_batch(col, collection_name, ids)
+        return len(ids)
+
     def update_source_path(
         self, collection_name: str, old_path: str, new_path: str
     ) -> int:

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -749,8 +749,16 @@ def _index_pdf_file(
             content_hash.update(block)
     content_hash_hex = content_hash.hexdigest()
 
-    # Staleness check
-    if not force and check_staleness(col, file, content_hash_hex, target_model):
+    # Staleness check.
+    # nexus-dcym: prefer doc_id-keyed lookup when the catalog hook
+    # supplied a resolver; falls back to source_path for legacy chunks.
+    catalog_doc_id_for_staleness = (
+        doc_id_resolver(file) if doc_id_resolver is not None else ""
+    )
+    if not force and check_staleness(
+        col, file, content_hash_hex, target_model,
+        doc_id=catalog_doc_id_for_staleness,
+    ):
         return 0
 
     # nexus-7niu: per-stage timer instrumentation. Silent when
@@ -974,32 +982,49 @@ def _prune_misclassified(
     prose_files: list[Path],
     pdf_files: list[Path],
     db: object,
+    *,
+    file_to_doc_id: dict[Path, str] | None = None,
 ) -> None:
     """Remove chunks from the wrong collection after reclassification.
 
     If a file was previously classified as code but is now prose (or vice versa),
     its chunks in the old collection must be removed.
+
+    nexus-dcym: when ``file_to_doc_id`` is supplied (always populated by
+    the catalog hook), the chunk-prune lookup keys on ``doc_id``. Files
+    not in the map fall back to the legacy ``source_path`` lookup so
+    chunks indexed before catalog backfill keep getting cleaned up.
     """
     code_col = db.get_or_create_collection(code_collection)
     docs_col = db.get_or_create_collection(docs_collection)
+    file_to_doc_id = file_to_doc_id or {}
+
+    def _prune_one(col: object, path: Path, kind: str) -> None:
+        doc_id = file_to_doc_id.get(path, "")
+        where: dict
+        log_field: dict
+        if doc_id:
+            where = {"doc_id": doc_id}
+            log_field = {"doc_id": doc_id, "source_path": str(path)}
+        else:
+            where = {"source_path": str(path)}
+            log_field = {"source_path": str(path)}
+        existing = _paginated_get(col, include=[], where=where)
+        if existing["ids"]:
+            _batched_delete(col, existing["ids"])
+            _log.debug(
+                f"pruned misclassified chunks from {kind} collection",
+                count=len(existing["ids"]),
+                **log_field,
+            )
 
     # Prose + PDF files should NOT have chunks in the code__ collection
-    docs_paths = {str(f) for f in prose_files} | {str(f) for f in pdf_files}
-    for source_path in docs_paths:
-        existing = _paginated_get(code_col, include=[], where={"source_path": source_path})
-        if existing["ids"]:
-            _batched_delete(code_col, existing["ids"])
-            _log.debug("pruned misclassified chunks from code collection",
-                       source_path=source_path, count=len(existing["ids"]))
+    for path in set(prose_files) | set(pdf_files):
+        _prune_one(code_col, path, "code")
 
     # Code files should NOT have chunks in the docs__ collection
-    code_paths = {str(f) for f in code_files}
-    for source_path in code_paths:
-        existing = _paginated_get(docs_col, include=[], where={"source_path": source_path})
-        if existing["ids"]:
-            _batched_delete(docs_col, existing["ids"])
-            _log.debug("pruned misclassified chunks from docs collection",
-                       source_path=source_path, count=len(existing["ids"]))
+    for path in set(code_files):
+        _prune_one(docs_col, path, "docs")
 
 
 def _prune_deleted_files(
@@ -1421,6 +1446,7 @@ def _run_index(
             [f for _, f in prose_files],
             [f for _, f in pdf_files],
             db,
+            file_to_doc_id=file_to_doc_id,
         )
         _phase(f"Pruning misclassified done ({time.monotonic() - _t:.1f}s)")
 

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -181,6 +181,8 @@ def check_staleness(
     source_file: object,
     content_hash: str,
     embedding_model: str,
+    *,
+    doc_id: str = "",
 ) -> bool:
     """Return True if the file is already indexed with an identical hash and model.
 
@@ -192,14 +194,21 @@ def check_staleness(
         source_file: Path (or string) of the source file being checked.
         content_hash: SHA-256 hex digest of the current file content.
         embedding_model: Target embedding model name.
+        doc_id: Catalog ``doc_id`` for the file. When non-empty (RDR-101
+            Phase 4, nexus-dcym), the chunk lookup keys on ``doc_id`` so
+            that the staleness check stays consistent across renames and
+            owner-scope changes. Empty falls back to the legacy
+            ``source_path``-keyed lookup for chunks predating the
+            doc_id backfill.
 
     Returns:
         True when the stored chunk has the same content_hash AND embedding_model,
         meaning the file is current and can be skipped.  False otherwise.
     """
+    where: dict = {"doc_id": doc_id} if doc_id else {"source_path": str(source_file)}
     existing = _chroma_with_retry(
         col.get,  # type: ignore[attr-defined]
-        where={"source_path": str(source_file)},
+        where=where,
         include=["metadatas"],
         limit=1,
     )

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -47,8 +47,16 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
 
     content_hash = _hl.sha256(content.encode()).hexdigest()
 
-    # Staleness check — skip if content + model unchanged
-    if not ctx.force and check_staleness(ctx.col, file_path, content_hash, ctx.embedding_model):
+    # Staleness check — skip if content + model unchanged.
+    # nexus-dcym: prefer doc_id-keyed lookup when the catalog hook
+    # supplied a resolver; falls back to source_path for legacy chunks.
+    catalog_doc_id_for_staleness = (
+        ctx.doc_id_resolver(file_path) if ctx.doc_id_resolver is not None else ""
+    )
+    if not ctx.force and check_staleness(
+        ctx.col, file_path, content_hash, ctx.embedding_model,
+        doc_id=catalog_doc_id_for_staleness,
+    ):
         return 0
 
     # nexus-7niu: per-stage timer instrumentation. Silent when

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -799,6 +799,58 @@ def test_prune_misclassified_paginates(tmp_path):
     assert d == {f"s-{i}" for i in range(310)}
 
 
+def test_prune_misclassified_uses_doc_id_when_supplied(tmp_path):
+    """nexus-dcym: chunk lookup for the prune keys on doc_id when the
+    catalog hook's ``file_to_doc_id`` map is supplied. WITH TEETH:
+    a stash-revert to the source_path-keyed form makes the assertion
+    on the ``where`` filter fail.
+    """
+    from nexus.indexer import _prune_misclassified
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    bp = repo / "ambiguous.md"
+    bp.write_text("# a\n")
+    cc = MagicMock()
+    cc.get.return_value = {"ids": ["chunk-abc"]}
+    dc = MagicMock()
+    dc.get.return_value = {"ids": []}
+    db = MagicMock()
+    db.get_or_create_collection.side_effect = {"code__repo": cc, "docs__repo": dc}.get
+    _prune_misclassified(
+        repo, "code__repo", "docs__repo",
+        [], [bp], [], db,
+        file_to_doc_id={bp: "ART-deadbeef"},
+    )
+    where = cc.get.call_args.kwargs["where"]
+    assert where == {"doc_id": "ART-deadbeef"}
+    cc.delete.assert_called_once_with(ids=["chunk-abc"])
+
+
+def test_prune_misclassified_falls_back_to_source_path_for_unmapped_files(tmp_path):
+    """Files missing from ``file_to_doc_id`` use the legacy source_path
+    lookup so chunks indexed before the catalog backfill keep getting
+    cleaned up.
+    """
+    from nexus.indexer import _prune_misclassified
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    bp = repo / "legacy.md"
+    bp.write_text("# l\n")
+    cc = MagicMock()
+    cc.get.return_value = {"ids": ["chunk-legacy"]}
+    dc = MagicMock()
+    dc.get.return_value = {"ids": []}
+    db = MagicMock()
+    db.get_or_create_collection.side_effect = {"code__repo": cc, "docs__repo": dc}.get
+    _prune_misclassified(
+        repo, "code__repo", "docs__repo",
+        [], [bp], [], db,
+        file_to_doc_id={},
+    )
+    where = cc.get.call_args.kwargs["where"]
+    assert where == {"source_path": str(bp)}
+
+
 # ── Lock file cleanup ───────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("side_effect", [None, RuntimeError("boom"), CredentialsMissingError("x")])

--- a/tests/test_indexer_modules.py
+++ b/tests/test_indexer_modules.py
@@ -67,6 +67,36 @@ def test_check_staleness_no_existing_chunks(tmp_path):
     assert check_staleness(mock_col, tmp_path / "foo.py", "abc123", "voyage-code-3") is False
 
 
+def test_check_staleness_uses_doc_id_when_provided(tmp_path):
+    """nexus-dcym: when caller passes ``doc_id``, the where-filter must
+    key on doc_id, not the legacy source_path. WITH TEETH: a stash-revert
+    of indexer_utils.py to the source_path-keyed form makes the assertion
+    on ``where`` fail.
+    """
+    mock_col = MagicMock()
+    mock_col.get.return_value = {
+        "metadatas": [{"content_hash": "abc", "embedding_model": "voyage-code-3"}],
+        "ids": ["id1"],
+    }
+    result = check_staleness(
+        mock_col, tmp_path / "shared.py", "abc", "voyage-code-3",
+        doc_id="ART-deadbeef",
+    )
+    assert result is True
+    where = mock_col.get.call_args.kwargs["where"]
+    assert where == {"doc_id": "ART-deadbeef"}
+
+
+def test_check_staleness_falls_back_to_source_path_when_no_doc_id(tmp_path):
+    """No doc_id passed → legacy source_path lookup (back-compat)."""
+    mock_col = MagicMock()
+    mock_col.get.return_value = {"metadatas": [], "ids": []}
+    file_path = tmp_path / "foo.py"
+    check_staleness(mock_col, file_path, "abc", "voyage-code-3")
+    where = mock_col.get.call_args.kwargs["where"]
+    assert where == {"source_path": str(file_path)}
+
+
 # ── check_credentials ────────────────────────────────────────────────────────
 
 def test_check_credentials_both_present():

--- a/tests/test_rdr053_verification.py
+++ b/tests/test_rdr053_verification.py
@@ -249,3 +249,71 @@ class TestResolveSpanText:
         with patch("nexus.db.make_t3", return_value=mock_t3):
             result = cat.resolve_span_text(doc, f"chash:{HASH_B}")
         assert result is None
+
+    def test_resolve_span_text_chunk_char_uses_doc_id(self, tmp_path):
+        """Chunk:char span resolves via doc_id, not source_path (nexus-dcym).
+
+        WITH TEETH: two distinct catalog documents that share the same
+        ``source_path`` (e.g. a file re-registered under a renamed owner,
+        or a copy-on-write fork). A pre-fix code path keying on
+        ``source_path`` can return the wrong document's chunk; the
+        ``doc_id``-keyed lookup distinguishes them.
+        """
+        col_name = _col_name(tmp_path)
+        cat = _make_catalog(tmp_path)
+        t3 = chromadb.EphemeralClient()
+        col = t3.get_or_create_collection(col_name)
+
+        owner_a = cat.register_owner("nexus", "repo-a", repo_hash="aaaa")
+        owner_b = cat.register_owner("nexus", "repo-b", repo_hash="bbbb")
+        doc_a = cat.register(
+            owner_a, "a.py", content_type="code", file_path="shared.py",
+            physical_collection=col_name,
+        )
+        doc_b = cat.register(
+            owner_b, "b.py", content_type="code", file_path="shared.py",
+            physical_collection=col_name,
+        )
+        assert str(doc_a) != str(doc_b), "registration setup must yield distinct tumblers"
+
+        # Two chunks at chunk_index=0 sharing the same source_path but
+        # belonging to different doc_ids. Pre-fix code keys on source_path
+        # and returns whichever chunk happens to come first; post-fix
+        # code keys on doc_id and returns the correct chunk.
+        col.add(
+            ids=["doc_a-0", "doc_b-0"],
+            documents=["AAAAAAAAAA", "BBBBBBBBBB"],
+            metadatas=[
+                {
+                    "source_path": "shared.py",
+                    "chunk_index": 0,
+                    "doc_id": str(doc_a),
+                },
+                {
+                    "source_path": "shared.py",
+                    "chunk_index": 0,
+                    "doc_id": str(doc_b),
+                },
+            ],
+        )
+
+        from unittest.mock import patch
+
+        class _T3Wrapper:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *exc):
+                return False
+
+            def get_or_create_collection(self_inner, name):
+                return t3.get_or_create_collection(name)
+
+        with patch("nexus.db.make_t3", return_value=_T3Wrapper()):
+            # Span "0:2-5" → chunk index 0, char range 2-5 → "AAA" or "BBB".
+            text_a = cat.resolve_span_text(doc_a, "0:2-5")
+            text_b = cat.resolve_span_text(doc_b, "0:2-5")
+
+        # Each tumbler resolves to its own chunk's slice, never the other's.
+        assert text_a == "AAA", f"doc_a slice mismatched: {text_a!r}"
+        assert text_b == "BBB", f"doc_b slice mismatched: {text_b!r}"

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -773,6 +773,74 @@ def test_delete_by_source_nonexistent_collection_returns_zero(mock_chromadb):
     assert db.delete_by_source("code__nonexistent", "src/file.py") == 0
 
 
+# ── ids_for_doc_id / delete_by_doc_id (nexus-dcym) ────────────────────────
+
+
+@pytest.mark.parametrize("col,doc_id,returned_ids,expected_count", [
+    ("code__myrepo", "ART-deadbeef", ["a1", "a2", "a3"], 3),
+    ("knowledge__wiki", "ART-cafe1234", ["x1"], 1),
+    ("code__myrepo", "ART-nonexistent", [], 0),
+])
+def test_ids_for_doc_id(mock_db, col, doc_id, returned_ids, expected_count):
+    """ids_for_doc_id queries on the doc_id metadata field, not source_path."""
+    db, mock_col, _ = mock_db
+    mock_col.get.return_value = {"ids": returned_ids}
+    result = db.ids_for_doc_id(col, doc_id)
+    assert result == returned_ids
+    assert len(result) == expected_count
+    # The chunk-lookup must use doc_id, NOT source_path. WITH TEETH:
+    # if the implementation accidentally falls back to source_path, this fails.
+    where = mock_col.get.call_args.kwargs["where"]
+    assert where == {"doc_id": doc_id}
+
+
+def test_ids_for_doc_id_nonexistent_collection_returns_empty(mock_chromadb):
+    _, mock_client = mock_chromadb
+    mock_client.get_collection.side_effect = chromadb.errors.NotFoundError("Collection not found")
+    db = T3Database(tenant="t", database="d", api_key="k")
+    assert db.ids_for_doc_id("code__nonexistent", "ART-deadbeef") == []
+
+
+def test_ids_for_doc_id_paginates_over_300_record_quota(mock_db):
+    """Cloud has a 300-record limit per get(); helper must page."""
+    db, mock_col, _ = mock_db
+    page1 = {"ids": [f"id-{i}" for i in range(300)]}
+    page2 = {"ids": [f"id-{i}" for i in range(300, 450)]}
+    mock_col.get.side_effect = [page1, page2]
+    result = db.ids_for_doc_id("code__myrepo", "ART-large")
+    assert len(result) == 450
+    assert mock_col.get.call_count == 2
+    # offset advances by page size
+    assert mock_col.get.call_args_list[0].kwargs["offset"] == 0
+    assert mock_col.get.call_args_list[1].kwargs["offset"] == 300
+
+
+@pytest.mark.parametrize("col,doc_id,returned_ids,expected_count,expect_delete", [
+    ("code__myrepo", "ART-deadbeef", ["a1", "a2", "a3"], 3, True),
+    ("knowledge__wiki", "ART-cafe1234", ["x1", "x2"], 2, True),
+    ("code__myrepo", "ART-nonexistent", [], 0, False),
+])
+def test_delete_by_doc_id(mock_db, col, doc_id, returned_ids, expected_count, expect_delete):
+    db, mock_col, _ = mock_db
+    mock_col.get.return_value = {"ids": returned_ids}
+    result = db.delete_by_doc_id(col, doc_id)
+    assert result == expected_count
+    if expect_delete:
+        mock_col.delete.assert_called_once_with(ids=returned_ids)
+    else:
+        mock_col.delete.assert_not_called()
+    # The lookup leg must filter on doc_id.
+    where = mock_col.get.call_args.kwargs["where"]
+    assert where == {"doc_id": doc_id}
+
+
+def test_delete_by_doc_id_nonexistent_collection_returns_zero(mock_chromadb):
+    _, mock_client = mock_chromadb
+    mock_client.get_collection.side_effect = chromadb.errors.NotFoundError("Collection not found")
+    db = T3Database(tenant="t", database="d", api_key="k")
+    assert db.delete_by_doc_id("code__nonexistent", "ART-deadbeef") == 0
+
+
 # ── update_source_path ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
RDR-101 Phase 4 reader migration, first slice. Switches chunk lookups from `source_path` to the catalog `doc_id` along the indexer family. Five sites total; the doc_indexer + pipeline_stages slice ships separately as PR-B.

## Summary

**T3Database additions**
- `ids_for_doc_id(collection, doc_id)` companion to `ids_for_source`.
- `delete_by_doc_id(collection, doc_id)` companion to `delete_by_source`.
- The `_source` variants stay as aliases until `.10.3` prune-deprecated-keys lands.

**Caller migrations**
- `catalog/catalog.py:resolve_span_text` chunk:char span lookup keys on `entry.meta.doc_id` with `str(entry.tumbler)` as the Phase 1 fallback.
- `indexer_utils.py:check_staleness` accepts `doc_id=` keyword; falls back to `source_path` when caller has no `doc_id` (legacy chunks).
- `code_indexer.py:index_code_file`, `prose_indexer.py:index_prose_file`, `indexer.py:_index_pdf_file` pass `ctx.doc_id_resolver(path)` into `check_staleness`.
- `indexer.py:_prune_misclassified` accepts `file_to_doc_id=` map and uses `doc_id`-keyed delete; per-file fallback to `source_path` for unmapped files. Caller threads the catalog hook's existing map through.

## Test plan

All TDD; each WITH-TEETH test stash-revert verified (fails on pre-fix code, passes with the fix):

- [x] `tests/test_t3.py`: 9 cases covering `ids_for_doc_id` pagination, `delete_by_doc_id`, missing-collection short-circuits, and direct assertion that the ChromaDB where-filter is `{\"doc_id\": ...}`.
- [x] `tests/test_indexer_modules.py`: `doc_id`-keyed staleness lookup + `source_path` back-compat.
- [x] `tests/test_indexer.py`: `doc_id` prune path + `source_path` fallback for legacy files.
- [x] `tests/test_rdr053_verification.py`: two distinct catalog documents sharing a `source_path` resolve to their own chunks via `doc_id` filter (this case fails on pre-fix code).
- [x] Wider regression sweep: 1272 tests pass across `indexer`/`t3`/`staleness`/`catalog`/`rdr053`.

## Out of scope (follow-up beads)

- `_run_index_frecency_only` (indexer.py:573): no `doc_id_resolver` in scope; needs a catalog read at frecency time.
- `aspect_extractor.py:_source_content_from_t3` + `aspect_worker` batch path: requires a `doc_id` field on the `AspectExtractionQueue` row.
- `doc_indexer.py` / `pipeline_stages.py`: covered by PR-B (separate branch).

## Closes

Partially addresses `nexus-dcym`. Bead remains open until PR-B and the deferred frecency / aspect_worker slices ship.