### PR TITLE
feat(doc): doc_id-keyed chunk lookups in PDF/MD indexing (nexus-dcym PR-B)

### DIFF
--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -55,6 +55,57 @@ def _has_credentials() -> bool:
     return bool(get_credential("voyage_api_key") and get_credential("chroma_api_key"))
 
 
+def _lookup_existing_doc_id(file_path: str, corpus: str) -> str:
+    """nexus-dcym: pre-flight catalog lookup for an already-indexed file.
+
+    Returns the catalog ``doc_id`` (str) if a registration already exists
+    under the corpus's owner; empty string otherwise (catalog absent,
+    owner missing, or first-time registration). Best-effort: any failure
+    silently returns "" so callers fall back to the legacy
+    ``source_path``-keyed chunk lookup.
+
+    The pipeline registers PDFs in the catalog *after* the staleness
+    check, so on a fresh index this returns "" (no entry yet) and the
+    legacy lookup keeps working. On a re-index, the prior registration
+    is found and the chunk lookup keys on ``doc_id``.
+    """
+    try:
+        from nexus.catalog import Catalog  # noqa: PLC0415
+        from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
+        from nexus.config import catalog_path  # noqa: PLC0415
+
+        cat_path = catalog_path()
+        if not Catalog.is_initialized(cat_path):
+            return ""
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
+        owner_name = corpus or "standalone-pdfs"
+        row = cat._db.execute(
+            "SELECT tumbler_prefix FROM owners WHERE name = ?", (owner_name,)
+        ).fetchone()
+        if not row:
+            return ""
+        owner = Tumbler.parse(row[0])
+        existing = cat.by_file_path(owner, file_path)
+        if existing is None:
+            return ""
+        return str(existing.tumbler)
+    except Exception:
+        return ""
+
+
+def _identity_where(file_path: str, corpus: str) -> dict:
+    """nexus-dcym: chunk-identity where-filter for incremental sync sites.
+
+    Prefers a ``doc_id``-keyed lookup when the catalog already has an
+    entry for *file_path* under *corpus*; otherwise emits the legacy
+    ``source_path`` filter so chunks indexed before the catalog backfill
+    keep being detected. RDR-101 Phase 5b drops the ``source_path``
+    branch once the prune verb has run on every collection.
+    """
+    doc_id = _lookup_existing_doc_id(file_path, corpus)
+    return {"doc_id": doc_id} if doc_id else {"source_path": file_path}
+
+
 def _missing_credentials() -> list[str]:
     """Return the list of unset Voyage / Chroma credentials.
 
@@ -419,10 +470,13 @@ def _index_document(
         # cloud target_model differs from the locally-stored name).
         target_model = local_target_model
 
-    # Incremental sync: skip if file is already indexed with the same hash AND model
+    # Incremental sync: skip if file is already indexed with the same hash AND model.
+    # nexus-dcym: prefer doc_id-keyed lookup; falls back to source_path
+    # for first-time registrations and legacy chunks.
+    incremental_where = _identity_where(sp, corpus)
     existing = _chroma_with_retry(
         col.get,
-        where={"source_path": sp},
+        where=incremental_where,
         include=["metadatas"],
         limit=1,
     )
@@ -475,13 +529,19 @@ def _index_document(
 
     # Prune stale chunks from a previous (larger) version of this file.
     # Paginate: ChromaDB Cloud returns at most 300 records per get() call.
+    # nexus-dcym: doc_id keying so a re-index after rename still
+    # detects the prior chunk set. The catalog hook for this corpus
+    # registered the file before this point on prior indexes; on a
+    # first-ever index there is no prior chunk set so the where filter
+    # never matches and the legacy source_path branch is harmless.
+    prune_where = _identity_where(sp, corpus)
     current_ids_set = set(ids)
     stale_ids: list[str] = []
     offset = 0
     while True:
         batch = _chroma_with_retry(
             col.get,
-            where={"source_path": sp},
+            where=prune_where,
             include=[],
             limit=300,
             offset=offset,
@@ -612,14 +672,18 @@ def _index_pdf_incremental(
             on_progress(batch_end, total)
 
     # Prune stale chunks from a previous (larger) version of this file.
+    # nexus-dcym: prefer doc_id when the catalog already registered this
+    # file in a prior run; first-time indexes have no prior chunk set
+    # so the legacy source_path branch is harmless.
     col = t3.get_or_create_collection(collection_name)
+    prune_where = _identity_where(str(file_path), corpus)
     current_ids_set = set(ids_all)
     stale_ids: list[str] = []
     offset = 0
     while True:
         batch = _chroma_with_retry(
             col.get,
-            where={"source_path": str(file_path)},
+            where=prune_where,
             include=[],
             limit=300,
             offset=offset,
@@ -898,10 +962,13 @@ def index_pdf(
         # model so repeat-indexes are no-ops.
         target_model = local_target_model
 
-    # Incremental sync: skip if file is already indexed with the same hash AND model
+    # Incremental sync: skip if file is already indexed with the same hash AND model.
+    # nexus-dcym: prefer doc_id-keyed lookup; falls back to source_path
+    # for first-time registrations and legacy chunks.
+    incremental_where = _identity_where(str(pdf_path), corpus)
     existing = _chroma_with_retry(
         col.get,
-        where={"source_path": str(pdf_path)},
+        where=incremental_where,
         include=["metadatas"],
         limit=1,
     )
@@ -935,12 +1002,15 @@ def index_pdf(
             )
             if return_metadata:
                 # Query T3 for metadata after streaming upload.
+                # nexus-dcym: re-resolve doc_id since pipeline_index_pdf
+                # may have just registered the catalog entry.
+                meta_where = _identity_where(str(pdf_path), corpus)
                 all_meta: list[dict] = []
                 offset = 0
                 while True:
                     batch = _chroma_with_retry(
                         col.get,
-                        where={"source_path": str(pdf_path)},
+                        where=meta_where,
                         include=["metadatas"],
                         limit=300,
                         offset=offset,
@@ -1039,14 +1109,16 @@ def index_pdf(
     # reads source_path itself.
     fire_post_document_hooks(str(pdf_path), col_name, "")
 
-    # Prune stale chunks
+    # Prune stale chunks (nexus-dcym: doc_id-keyed when catalog has the
+    # entry; first-time indexes harmlessly use source_path).
+    prune_where = _identity_where(str(pdf_path), corpus)
     current_ids_set = set(ids)
     stale_ids: list[str] = []
     offset = 0
     while True:
         batch = _chroma_with_retry(
             col.get,
-            where={"source_path": str(pdf_path)},
+            where=prune_where,
             include=[],
             limit=300,
             offset=offset,

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -691,7 +691,7 @@ def pipeline_index_pdf(
             post_pass_ok = False
 
     # 3. Stale chunk pruning.
-    if not _prune_stale_chunks(col, str(pdf_path), content_hash):
+    if not _prune_stale_chunks(col, str(pdf_path), content_hash, corpus=corpus):
         post_pass_ok = False
 
     state = db.get_pipeline_state(content_hash)
@@ -867,23 +867,29 @@ def _update_chunk_metadata(
 
 
 def _prune_stale_chunks(
-    col: Any, pdf_path: str, content_hash: str,
+    col: Any, pdf_path: str, content_hash: str, *, corpus: str = "",
 ) -> bool:
     """Delete chunks from T3 that belong to a previous version of the same PDF.
 
     Returns True on success, False on failure.  Query and delete errors are
     handled separately so a delete failure reports how many stale chunks
     remain (nexus-tcwm).
+
+    nexus-dcym: when *corpus* is supplied and the catalog already
+    registered the file, the chunk lookup keys on ``doc_id``. Empty or
+    missing entries fall back to the legacy ``source_path`` lookup.
     """
+    from nexus.doc_indexer import _identity_where  # noqa: PLC0415
     stale_ids: list[str] = []
     offset = 0
+    where_filter = _identity_where(pdf_path, corpus)
 
     # Phase 1: query for stale chunks
     try:
         while True:
             batch = _chroma_with_retry(
                 col.get,
-                where={"source_path": pdf_path},
+                where=where_filter,
                 include=["metadatas"],
                 limit=300,
                 offset=offset,

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -13,9 +13,9 @@ from voyageai.object.contextualized_embeddings import (
 from voyageai.object.embeddings import EmbeddingsObject
 
 from nexus.doc_indexer import (
-    _batch_chunks_for_cce, _embed_with_fallback, _markdown_chunks,
-    _TokenBucket, batch_index_markdowns, batch_index_pdfs,
-    index_markdown, index_pdf,
+    _batch_chunks_for_cce, _embed_with_fallback, _identity_where,
+    _lookup_existing_doc_id, _markdown_chunks, _TokenBucket,
+    batch_index_markdowns, batch_index_pdfs, index_markdown, index_pdf,
 )
 from tests.conftest import set_credentials
 
@@ -147,6 +147,70 @@ def voyage_client():
     client = MagicMock()
     _add_cce_mock(client)
     return client
+
+
+# ── nexus-dcym: doc_id-keyed identity helpers ──────────────────────────────
+
+
+def test_lookup_existing_doc_id_returns_empty_when_catalog_absent(tmp_path, monkeypatch):
+    """nexus-dcym: catalog uninitialized → "". Caller falls back to source_path."""
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(tmp_path / "no-catalog"))
+    assert _lookup_existing_doc_id("/some/file.pdf", "any-corpus") == ""
+
+
+def test_lookup_existing_doc_id_finds_registered_entry(tmp_path, monkeypatch):
+    """When the catalog already registered *file_path* under *corpus*'s
+    owner, the helper returns the tumbler stringified as the doc_id."""
+    from nexus.catalog.catalog import Catalog
+    cat_dir = tmp_path / "cat"
+    cat = Catalog.init(cat_dir)
+    owner = cat.register_owner("mybook", "curator")
+    file_path = "/abs/path/paper.pdf"
+    doc = cat.register(
+        owner, "Paper Title", content_type="paper",
+        file_path=file_path, corpus="mybook",
+        physical_collection="docs__mybook",
+    )
+
+    monkeypatch.setattr("nexus.config.catalog_path", lambda: cat_dir)
+    result = _lookup_existing_doc_id(file_path, "mybook")
+    assert result == str(doc)
+
+
+def test_identity_where_prefers_doc_id(tmp_path, monkeypatch):
+    """nexus-dcym: when a catalog entry exists, the where filter keys
+    on doc_id; missing entries fall back to source_path. WITH TEETH:
+    if the helper accidentally drops the doc_id branch the test fails.
+    """
+    from nexus.catalog.catalog import Catalog
+    cat_dir = tmp_path / "cat"
+    cat = Catalog.init(cat_dir)
+    owner = cat.register_owner("mybook", "curator")
+    file_path = "/abs/path/paper.pdf"
+    doc = cat.register(
+        owner, "Paper", content_type="paper", file_path=file_path,
+        corpus="mybook", physical_collection="docs__mybook",
+    )
+
+    monkeypatch.setattr("nexus.config.catalog_path", lambda: cat_dir)
+
+    # Registered file → doc_id branch.
+    where = _identity_where(file_path, "mybook")
+    assert where == {"doc_id": str(doc)}
+
+    # Unregistered file → source_path branch (back-compat).
+    where_legacy = _identity_where("/abs/path/other.pdf", "mybook")
+    assert where_legacy == {"source_path": "/abs/path/other.pdf"}
+
+
+def test_identity_where_falls_back_when_corpus_owner_missing(tmp_path, monkeypatch):
+    """corpus that has no owner row → "" → source_path fallback."""
+    from nexus.catalog.catalog import Catalog
+    cat_dir = tmp_path / "cat"
+    Catalog.init(cat_dir)
+    monkeypatch.setattr("nexus.config.catalog_path", lambda: cat_dir)
+    where = _identity_where("/abs/path/x.pdf", "missing-corpus")
+    assert where == {"source_path": "/abs/path/x.pdf"}
 
 
 def test_index_md_falls_back_to_local_embedder_when_no_credentials(


### PR DESCRIPTION
RDR-101 Phase 4 reader migration, second slice. Migrates the six `where={\"source_path\": ...}` sites in `doc_indexer.py` and the one in `pipeline_stages.py:_prune_stale_chunks` to a `doc_id`-preferring filter.

Companion to #469 (PR-A: T3Database helpers + indexer family). Independent of #469: PR-B uses raw `col.get(where=...)` and does not depend on the new T3Database methods.

## Summary

**New helpers (doc_indexer.py)**
- `_lookup_existing_doc_id(file_path, corpus)`: pre-flight catalog lookup. Returns the registered `doc_id` (tumbler-stringified) if an entry exists under the corpus's owner; \"\" otherwise.
- `_identity_where(file_path, corpus)`: chunk-identity where filter. Emits `{\"doc_id\": ...}` when the catalog has the entry; falls back to `{\"source_path\": ...}` for first-time indexes and legacy chunks.

**Caller migrations**
- `doc_indexer.py:_index_doc_file_generic` pre-flight staleness check + post-upsert stale-chunk prune.
- `doc_indexer.py:_index_pdf_incremental` post-batch stale-chunk prune.
- `doc_indexer.py:index_pdf` pre-flight staleness check, post-streaming metadata fetch (re-resolves the doc_id since `pipeline_index_pdf` may have registered the catalog entry mid-call), and post-batch stale-chunk prune.
- `pipeline_stages.py:_prune_stale_chunks` accepts `corpus=` keyword, threaded through `pipeline_index_pdf`'s existing `corpus` parameter.

## Pipeline ordering rationale

The catalog registers PDFs *after* the staleness check and *after* chunk upsert. So on a first-ever index of a file, the helper returns `\"\"` and the legacy `source_path` branch is harmless (no prior chunks exist anyway). On every re-index, the prior registration is found and chunk lookups key on `doc_id`. This back-compat-preserving shape is why the migration is safe to ship without restructuring pipeline ordering.

## Test plan

All TDD; new helper tests assert directly on the where-dict shape.

- [x] `_lookup_existing_doc_id` returns `\"\"` for uninitialized catalog.
- [x] `_lookup_existing_doc_id` finds a registered entry's tumbler.
- [x] `_identity_where` prefers `doc_id` when registered, falls back to `source_path` when not.
- [x] `_identity_where` falls back when corpus owner is missing.
- [x] `tests/test_doc_indexer.py + test_pipeline_stages.py + test_indexer.py + test_indexer_modules.py`: 229 tests pass.
- [x] Wider PDF-related tests (test_pdf_e2e, test_pdf_indexer_doc_id, test_index_cmd, test_doc_indexer): 216 tests pass.

## Closes

Together with PR #469, completes `nexus-dcym`. Bead can be closed once both PRs merge.