### PR TITLE
feat(aspects): doc_id-keyed dispatch for chroma reader (nexus-o6aa.10.1)

### DIFF
--- a/src/nexus/aspect_extractor.py
+++ b/src/nexus/aspect_extractor.py
@@ -75,6 +75,7 @@ import random
 import re
 import subprocess
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -832,6 +833,7 @@ def extract_aspects(
     collection: str,
     *,
     lookup_path: str = "",
+    doc_id_lookup: Callable[[str, str], str] | None = None,
 ) -> AspectRecord | ExtractFail | None:
     """Synchronously extract aspects from ``content`` and return either
     a populated ``AspectRecord``, an :class:`ExtractFail` sentinel
@@ -900,7 +902,7 @@ def extract_aspects(
                 reason="infra_unavailable",
                 detail=f"get_t3 failed: {type(exc).__name__}: {exc}",
             )
-        result = read_source(uri, t3=t3)
+        result = read_source(uri, t3=t3, doc_id_lookup=doc_id_lookup)
         if isinstance(result, ReadFail):
             _log.warning(
                 "aspect_extractor_source_unreadable",

--- a/src/nexus/aspect_readers.py
+++ b/src/nexus/aspect_readers.py
@@ -133,22 +133,35 @@ class ReadFail:
 ReadResult = ReadOk | ReadFail
 
 
-# ── Chroma identity-field dispatch (research-4, id 1011; P2.0 refined) ───────
+# ── Chroma identity-field dispatch (RDR-101 Phase 4, nexus-o6aa.10.1) ────────
 
 
-# Three collection-shape conventions live in T3 today:
-#   - nx index ingests (rdr__/docs__/code__/knowledge__<paper-coll>) populate
-#     ``source_path`` (filesystem path or PDF path).
-#   - store_put MCP / nx memory promote ingests (knowledge__knowledge) populate
-#     ``title`` (slug). The chunk has NO source_path metadata.
-#   - PDF papers ingested into knowledge__<corpus> via nx index pdf populate
-#     ``source_path`` (filesystem path); ``title`` is None on these chunks.
+# Post-Phase-4 dispatch: every collection prefix identifies chunks by the
+# catalog-stable ``doc_id`` (mirrors ``Document.doc_id``). The chroma reader
+# resolves the URI's source identifier to a ``doc_id`` via a caller-supplied
+# projection callable (``doc_id_lookup`` keyword on ``_read_chroma_uri`` /
+# ``read_source``); without that callable the reader falls back to the
+# legacy ``(source_path, title)`` probe so callers without catalog access
+# (tests, ad-hoc CLI runs) keep working.
 #
-# The mapping value is an ORDERED tuple: the reader tries each field in turn
-# and uses the first one that returns chunks. ``source_path`` is preferred
-# because it dominates the catalog by chunk-volume; ``title`` is the
-# slug-shaped fallback for memory-promoted entries.
+# Pre-Phase-4 the dispatch was per-prefix and per-shape: ``source_path`` for
+# ``nx index``-ingested collections, ``(source_path, title)`` for
+# ``knowledge__*`` to handle slug-shaped MCP-promoted notes. The legacy probe
+# below preserves that behavior for back-compat callers; the load-bearing
+# claim post-RDR-101 is the doc_id-keyed path.
 CHROMA_IDENTITY_FIELD: dict[str, tuple[str, ...]] = {
+    "rdr__":       ("doc_id",),
+    "docs__":      ("doc_id",),
+    "code__":      ("doc_id",),
+    "knowledge__": ("doc_id",),
+}
+
+
+# Legacy fallback fields, used by ``_read_chroma_uri`` only when the caller
+# does not supply a ``doc_id_lookup``. Mirrors the pre-Phase-4 dispatch
+# table. Slated for removal once the prune verb (.10.3) lands and chunks
+# uniformly carry ``doc_id`` metadata.
+_LEGACY_IDENTITY_FIELDS: dict[str, tuple[str, ...]] = {
     "rdr__":       ("source_path",),
     "docs__":      ("source_path",),
     "code__":      ("source_path",),
@@ -158,11 +171,24 @@ CHROMA_IDENTITY_FIELD: dict[str, tuple[str, ...]] = {
 
 def _identity_fields_for(collection: str) -> tuple[str, ...]:
     """Return the ordered tuple of chunk-metadata fields that identify
-    a source document in ``collection``. Falls back to
-    ``("source_path",)`` for unknown prefixes — the dominant
-    convention in legacy ingests.
+    a source document in ``collection``. Post-RDR-101 Phase 4 every
+    prefix maps to ``("doc_id",)`` uniformly; the legacy multi-field
+    probe lives behind ``_legacy_identity_fields_for`` for back-compat.
     """
     for prefix, fields in CHROMA_IDENTITY_FIELD.items():
+        if collection.startswith(prefix):
+            return fields
+    return ("doc_id",)
+
+
+def _legacy_identity_fields_for(collection: str) -> tuple[str, ...]:
+    """Return the pre-RDR-101 identity fields for *collection*.
+
+    ``source_path`` for ``nx index`` ingests, ``(source_path, title)``
+    for ``knowledge__*``. Used by ``_read_chroma_uri`` only when no
+    ``doc_id_lookup`` is supplied.
+    """
+    for prefix, fields in _LEGACY_IDENTITY_FIELDS.items():
         if collection.startswith(prefix):
             return fields
     return ("source_path",)
@@ -204,14 +230,97 @@ def _read_file_uri(uri: str, **_kw: Any) -> ReadResult:
 # ── chroma:// reader ─────────────────────────────────────────────────────────
 
 
-def _read_chroma_uri(uri: str, *, t3: Any = None, **_kw: Any) -> ReadResult:
+def _gather_chroma_chunks_by_field(
+    *,
+    coll: Any,
+    collection: str,
+    source_id: str,
+    identity_field: str,
+    match_value: str,
+) -> ReadResult:
+    """Page through ``coll.get(where={identity_field: match_value})`` and
+    return a ``ReadOk`` with chunks reassembled in ``chunk_index`` order
+    (insertion-sequence tiebreaker). ``ReadFail(reason='empty')`` when
+    no chunks match. Shared between the doc_id-keyed primary path
+    and the legacy multi-field probe.
+    """
+    chunks: list[tuple[int, int, str]] = []
+    seq = 0
+    offset = 0
+    page_limit = QUOTAS.MAX_QUERY_RESULTS
+    try:
+        while True:
+            page = coll.get(
+                where={identity_field: match_value},
+                limit=page_limit,
+                offset=offset,
+                include=["documents", "metadatas"],
+            )
+            docs = page.get("documents") or []
+            mds = page.get("metadatas") or []
+            if not docs:
+                break
+            for md, doc in zip(mds, docs):
+                if not doc:
+                    continue
+                ci = md.get("chunk_index", 0) if isinstance(md, dict) else 0
+                chunks.append((int(ci), seq, doc))
+                seq += 1
+            if len(docs) < page_limit:
+                break
+            offset += page_limit
+    except Exception as e:
+        return ReadFail(
+            reason="unreachable",
+            detail=(
+                f"chroma.get failed (field={identity_field!r}): "
+                f"{type(e).__name__}: {e}"
+            ),
+        )
+    if not chunks:
+        return ReadFail(
+            reason="empty",
+            detail=f"no chunks for {match_value!r} in {collection!r}",
+        )
+    chunks.sort(key=lambda triple: (triple[0], triple[1]))
+    text = "\n\n".join(doc for _, _, doc in chunks)
+    return ReadOk(
+        text=text,
+        metadata={
+            "scheme": "chroma",
+            "collection": collection,
+            "source_id": source_id,
+            "identity_field": identity_field,
+            "chunk_count": len(chunks),
+        },
+    )
+
+
+def _read_chroma_uri(
+    uri: str,
+    *,
+    t3: Any = None,
+    doc_id_lookup: Callable[[str, str], str] | None = None,
+    **_kw: Any,
+) -> ReadResult:
     """Reassemble a document from chroma chunks.
 
-    URI shape: ``chroma://<collection>/<source-identifier>``. The
-    identity field that ``<source-identifier>`` is matched against is
-    determined by the collection prefix via
-    :data:`CHROMA_IDENTITY_FIELD` — ``source_path`` for
-    rdr__/docs__/code__, ``title`` for knowledge__.
+    URI shape: ``chroma://<collection>/<source-identifier>``. Post
+    RDR-101 Phase 4 (nexus-o6aa.10.1), the ``<source-identifier>`` is
+    resolved to the catalog-stable ``doc_id`` via the caller's
+    ``doc_id_lookup`` projection, and the chunk lookup keys on
+    ``doc_id`` only. When no ``doc_id_lookup`` is provided the reader
+    falls back to the legacy ``(source_path, title)`` multi-field probe
+    so callers without catalog access (tests, ad-hoc CLI runs) keep
+    working.
+
+    ``doc_id_lookup`` is ``Callable[[collection, source_id], doc_id]``
+    where an empty-string return signals "no catalog entry maps this
+    source_id". An empty doc_id surfaces as
+    ``ReadFail(reason='unreachable')``, a structural failure shape
+    distinct from ``ReadFail(reason='empty')`` so the Phase 4 dry-run
+    gate can distinguish "chunk-set exists but unbacked by a catalog
+    row" (orphan / pre-backfill) from "no chunks at all".
 
     ``t3`` may be a ``T3Database`` instance, a raw chromadb client
     (``EphemeralClient`` / ``PersistentClient`` / ``CloudClient``),
@@ -236,7 +345,6 @@ def _read_chroma_uri(uri: str, *, t3: Any = None, **_kw: Any) -> ReadResult:
                 f"source_id={source_id!r})"
             ),
         )
-    identity_fields = _identity_fields_for(collection)
     try:
         coll = t3.get_collection(collection)
     except Exception as e:
@@ -244,75 +352,58 @@ def _read_chroma_uri(uri: str, *, t3: Any = None, **_kw: Any) -> ReadResult:
             reason="unreachable",
             detail=f"get_collection({collection!r}) failed: {type(e).__name__}: {e}",
         )
-    # Try each identity field in order; first non-empty result wins.
-    # Empirically (P2.0 spike survey 2026-04-27): knowledge__delos and
-    # knowledge__art chunks identify via ``source_path``; only
-    # knowledge__knowledge (slug-shaped MCP-promoted notes) identify via
-    # ``title``. The fallback list lets one reader handle both shapes.
-    matched_field = ""
-    chunks: list[tuple[int, int, str]] = []
-    page_limit = QUOTAS.MAX_QUERY_RESULTS
-    for identity_field in identity_fields:
-        # Tuple is (chunk_index, insertion_seq, text). The insertion
-        # sequence is the secondary sort key so chunks with missing
-        # or duplicate ``chunk_index`` values fall back to a
-        # deterministic arrival-order tiebreak rather than relying on
-        # chromadb's within-page ordering, which is not contractually
-        # stable.
-        chunks = []
-        seq = 0
-        offset = 0
+
+    # nexus-o6aa.10.1 doc_id-keyed path: resolve source_id → doc_id and
+    # query strictly on doc_id. An empty doc_id is a structural failure
+    # (catalog gap), not "no chunks".
+    if doc_id_lookup is not None:
         try:
-            while True:
-                page = coll.get(
-                    where={identity_field: source_id},
-                    limit=page_limit,
-                    offset=offset,
-                    include=["documents", "metadatas"],
-                )
-                docs = page.get("documents") or []
-                mds = page.get("metadatas") or []
-                if not docs:
-                    break
-                for md, doc in zip(mds, docs):
-                    if not doc:
-                        continue
-                    ci = md.get("chunk_index", 0) if isinstance(md, dict) else 0
-                    chunks.append((int(ci), seq, doc))
-                    seq += 1
-                if len(docs) < page_limit:
-                    break
-                offset += page_limit
+            doc_id = doc_id_lookup(collection, source_id) or ""
         except Exception as e:
             return ReadFail(
                 reason="unreachable",
                 detail=(
-                    f"chroma.get failed (field={identity_field!r}): "
+                    f"doc_id_lookup({collection!r}, {source_id!r}) raised "
                     f"{type(e).__name__}: {e}"
                 ),
             )
-        if chunks:
-            matched_field = identity_field
-            break
-    if not chunks:
-        return ReadFail(
-            reason="empty",
-            detail=(
-                f"no chunks for {source_id!r} in {collection!r} "
-                f"(identity_fields tried={list(identity_fields)})"
-            ),
+        if not doc_id:
+            return ReadFail(
+                reason="unreachable",
+                detail=(
+                    f"no doc_id mapped for {source_id!r} in {collection!r} "
+                    f"(catalog gap or pre-backfill chunk; the prune verb "
+                    f"requires --t3-doc-id-coverage=100% before running)"
+                ),
+            )
+        return _gather_chroma_chunks_by_field(
+            coll=coll, collection=collection, source_id=source_id,
+            identity_field="doc_id", match_value=doc_id,
         )
-    chunks.sort(key=lambda triple: (triple[0], triple[1]))
-    text = "\n\n".join(doc for _, _, doc in chunks)
-    return ReadOk(
-        text=text,
-        metadata={
-            "scheme": "chroma",
-            "collection": collection,
-            "source_id": source_id,
-            "identity_field": matched_field,
-            "chunk_count": len(chunks),
-        },
+
+    # Legacy multi-field probe (back-compat for callers without
+    # catalog access). Removed in Phase 5b once chunks uniformly carry
+    # doc_id and the prune verb has dropped source_path / title.
+    identity_fields = _legacy_identity_fields_for(collection)
+    last_fail: ReadFail | None = None
+    for identity_field in identity_fields:
+        result = _gather_chroma_chunks_by_field(
+            coll=coll, collection=collection, source_id=source_id,
+            identity_field=identity_field, match_value=source_id,
+        )
+        if isinstance(result, ReadOk):
+            return result
+        last_fail = result
+        # Only ``empty`` is retriable across the next legacy field;
+        # ``unreachable`` (chroma.get raised) means stop probing.
+        if result.reason != "empty":
+            return result
+    return last_fail or ReadFail(
+        reason="empty",
+        detail=(
+            f"no chunks for {source_id!r} in {collection!r} "
+            f"(identity_fields tried={list(identity_fields)})"
+        ),
     )
 
 
@@ -636,6 +727,7 @@ def read_source(
     *,
     t3: Any = None,
     scratch: Any = None,
+    doc_id_lookup: Callable[[str, str], str] | None = None,
 ) -> ReadResult:
     """Dispatch ``uri`` to its registered reader by scheme.
 
@@ -643,6 +735,10 @@ def read_source(
     upsert-guard in ``commands/enrich.py`` (Phase 1.3) logs and skips
     on any ``ReadFail``, so a missing reader is a visible-but-graceful
     failure mode, not a crash.
+
+    ``doc_id_lookup`` (RDR-101 Phase 4 / nexus-o6aa.10.1) is forwarded
+    to the chroma reader as the source-identifier → ``doc_id``
+    projection. Other readers ignore it.
     """
     if not uri:
         return ReadFail(reason="unreachable", detail="empty uri")
@@ -656,4 +752,4 @@ def read_source(
             reason="scheme_unknown",
             detail=f"no reader for scheme {scheme!r}",
         )
-    return reader(uri, t3=t3, scratch=scratch)
+    return reader(uri, t3=t3, scratch=scratch, doc_id_lookup=doc_id_lookup)

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -14,12 +14,57 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 import click
 import structlog
 
 _log = structlog.get_logger(__name__)
+
+
+def _build_catalog_doc_id_lookup() -> Callable[[str, str], str] | None:
+    """Build a ``doc_id_lookup(collection, source_id) -> doc_id``
+    callable backed by the catalog's ``physical_collection`` +
+    ``file_path`` (or ``title`` for slug-shaped knowledge entries)
+    SQL projection.
+
+    Returns ``None`` when the catalog is uninitialized; callers
+    treat that as "no lookup; fall back to the legacy probe".
+
+    nexus-o6aa.10.1: this is the catalog projection that the chroma
+    reader expects. It converts the URI's source identifier (legacy
+    source_path or slug-title) into the catalog's ``doc_id`` so chunk
+    lookups stay consistent across the Phase 4 prune.
+    """
+    try:
+        from nexus.catalog import Catalog
+        from nexus.config import catalog_path
+
+        cat_path = catalog_path()
+        if not Catalog.is_initialized(cat_path):
+            return None
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
+    except Exception:
+        return None
+
+    def _lookup(collection: str, source_id: str) -> str:
+        try:
+            row = cat._db.execute(
+                "SELECT json_extract(metadata, '$.doc_id') "
+                "FROM documents "
+                "WHERE physical_collection = ? "
+                "  AND (file_path = ? OR title = ?) "
+                "LIMIT 1",
+                (collection, source_id, source_id),
+            ).fetchone()
+        except Exception:
+            return ""
+        if not row:
+            return ""
+        return row[0] or ""
+
+    return _lookup
 
 
 @click.group(name="enrich")
@@ -714,6 +759,11 @@ def _dry_run_predict_skips(
         click.echo(f"  (read-side prediction skipped: {exc})")
         return
 
+    # nexus-o6aa.10.1: chroma reader resolves source_id → doc_id via
+    # this projection so the dry-run reflects post-prune behavior. ``None``
+    # falls back to the legacy probe (catalog absent / pre-Phase-3).
+    doc_id_lookup = _build_catalog_doc_id_lookup()
+
     planned: dict[str, int] = {}
     skip_lines: list[str] = []
     by_host: dict[str, int] = {}
@@ -723,7 +773,7 @@ def _dry_run_predict_skips(
             continue
         uri = f"chroma://{collection}/{quote(sp, safe='/')}"
         try:
-            result = read_source(uri, t3=t3)
+            result = read_source(uri, t3=t3, doc_id_lookup=doc_id_lookup)
         except Exception as exc:
             # Per-entry transient failure shouldn't abort the whole
             # prediction loop. Bucket under a synthetic ``read_error``
@@ -864,6 +914,11 @@ def _run_extraction(
     skipped_unreadable = 0
     by_reason: dict[str, int] = {}
 
+    # nexus-o6aa.10.1: a single catalog projection serves every entry
+    # in this collection. Built once outside the loop because the SQL
+    # connection inside the helper is cheap-but-not-free per-call.
+    doc_id_lookup = _build_catalog_doc_id_lookup()
+
     db_path = default_db_path()
     with T2Database(db_path) as db:
         for i, entry in enumerate(entries, 1):
@@ -885,6 +940,7 @@ def _run_extraction(
                 source_path=source_path,
                 collection=collection,
                 lookup_path=_chroma_source_id_for_entry(entry),
+                doc_id_lookup=doc_id_lookup,
             )
             if record is None:
                 # Defensive — select_config already passed at the parent

--- a/tests/test_aspect_readers.py
+++ b/tests/test_aspect_readers.py
@@ -82,36 +82,41 @@ class TestIdentityFieldDispatch:
     each in turn (P2.0 spike survey, 2026-04-27).
     """
 
-    def test_rdr_collection_uses_source_path(self):
+    def test_rdr_collection_uses_doc_id(self):
+        # nexus-o6aa.10.1: post-fix, every prefix dispatches on doc_id.
         from nexus.aspect_readers import _identity_fields_for
-        assert _identity_fields_for("rdr__nexus-571b8edd") == ("source_path",)
+        assert _identity_fields_for("rdr__nexus-571b8edd") == ("doc_id",)
 
-    def test_docs_collection_uses_source_path(self):
+    def test_docs_collection_uses_doc_id(self):
         from nexus.aspect_readers import _identity_fields_for
-        assert _identity_fields_for("docs__corpus") == ("source_path",)
+        assert _identity_fields_for("docs__corpus") == ("doc_id",)
 
-    def test_code_collection_uses_source_path(self):
+    def test_code_collection_uses_doc_id(self):
         from nexus.aspect_readers import _identity_fields_for
-        assert _identity_fields_for("code__nexus") == ("source_path",)
+        assert _identity_fields_for("code__nexus") == ("doc_id",)
 
-    def test_knowledge_collection_tries_source_path_then_title(self):
+    def test_knowledge_collection_uses_doc_id(self):
+        # Both paper-shaped (``knowledge__delos``) and slug-shaped
+        # (``knowledge__knowledge``) collections dispatch on doc_id;
+        # the source_path/title divergence is resolved by the catalog
+        # projection in ``doc_id_lookup``.
         from nexus.aspect_readers import _identity_fields_for
-        # source_path first (paper-shaped collections like
-        # knowledge__delos), title second (slug-shaped
-        # knowledge__knowledge).
-        assert _identity_fields_for("knowledge__knowledge") == ("source_path", "title")
-        assert _identity_fields_for("knowledge__delos") == ("source_path", "title")
+        assert _identity_fields_for("knowledge__knowledge") == ("doc_id",)
+        assert _identity_fields_for("knowledge__delos") == ("doc_id",)
 
-    def test_unknown_prefix_falls_back_to_source_path(self):
+    def test_unknown_prefix_falls_back_to_doc_id(self):
         from nexus.aspect_readers import _identity_fields_for
-        assert _identity_fields_for("future__newshape") == ("source_path",)
+        assert _identity_fields_for("future__newshape") == ("doc_id",)
 
-    def test_dispatch_table_exposes_all_known_prefixes(self):
+    def test_dispatch_table_uniformly_keyed_on_doc_id(self):
         from nexus.aspect_readers import CHROMA_IDENTITY_FIELD
-        assert CHROMA_IDENTITY_FIELD["rdr__"] == ("source_path",)
-        assert CHROMA_IDENTITY_FIELD["docs__"] == ("source_path",)
-        assert CHROMA_IDENTITY_FIELD["code__"] == ("source_path",)
-        assert CHROMA_IDENTITY_FIELD["knowledge__"] == ("source_path", "title")
+        # WITH TEETH: every dispatch entry must be the single-element
+        # tuple ('doc_id',). A regression that re-introduces source_path
+        # or title fails this assertion directly.
+        for prefix, fields in CHROMA_IDENTITY_FIELD.items():
+            assert fields == ("doc_id",), (
+                f"{prefix!r} dispatched on {fields!r}, expected ('doc_id',)"
+            )
 
 
 # ── file:// reader ───────────────────────────────────────────────────────────
@@ -500,6 +505,154 @@ class TestReadChromaUri:
         parts = result.text.split("\n\n")
         assert parts[0] == "c0"
         assert parts[-1] == f"c{n - 1}"
+
+
+# ── chroma:// reader: doc_id_lookup plumbing (nexus-o6aa.10.1) ───────────────
+
+
+class TestReadChromaUriDocIdLookup:
+    """nexus-o6aa.10.1: when ``doc_id_lookup`` is supplied, the reader
+    resolves ``(collection, source_id) → doc_id`` via the catalog
+    projection and queries on ``doc_id`` only. Without the lookup the
+    reader falls back to the legacy multi-field probe (back-compat for
+    callers without catalog access: tests, ad-hoc CLI runs).
+
+    The Phase 4 critical-gate: aspect extraction MUST run through this
+    path so chunks remain reachable after the prune verb (.10.3) drops
+    ``source_path`` and ``title`` from chunk metadata. Without the
+    rewrite, every aspect-extraction read would return ``empty`` and
+    structurally reproduce the ART-lhk1 failure.
+    """
+
+    def test_doc_id_lookup_queries_on_doc_id_metadata(self, t3_client):
+        from nexus.aspect_readers import ReadOk, _read_chroma_uri
+
+        col_name = "knowledge__lookup"
+        try:
+            t3_client.delete_collection(col_name)
+        except Exception:
+            pass
+        coll = t3_client.get_or_create_collection(col_name)
+        # Plant chunks with doc_id metadata only: NO source_path,
+        # NO title. Post-prune chunk shape.
+        coll.add(
+            ids=["chunk-0", "chunk-1"],
+            documents=["first chunk", "second chunk"],
+            metadatas=[
+                {"doc_id": "ART-deadbeef", "chunk_index": 0},
+                {"doc_id": "ART-deadbeef", "chunk_index": 1},
+            ],
+        )
+
+        # Source identity in the URI (e.g. legacy source_path) is
+        # mapped to doc_id via the lookup.
+        def lookup(coll: str, source_id: str) -> str:
+            assert coll == col_name
+            assert source_id == "/abs/path/paper.pdf"
+            return "ART-deadbeef"
+
+        result = _read_chroma_uri(
+            "chroma://knowledge__lookup//abs/path/paper.pdf",
+            t3=t3_client, doc_id_lookup=lookup,
+        )
+        assert isinstance(result, ReadOk)
+        assert result.text == "first chunk\n\nsecond chunk"
+        # WITH TEETH: identity_field is now ``doc_id`` for lookup-driven
+        # reads. Pre-fix code reports ``source_path`` or ``title`` here.
+        assert result.metadata["identity_field"] == "doc_id"
+
+    def test_doc_id_lookup_returns_empty_yields_unreachable(self, t3_client):
+        """Live-data gate semantics: a missing doc_id (catalog gap, orphan
+        chunk after Phase 1 synthesis) must report a structural failure
+        (``unreachable``), NOT ``empty``. The Phase 4 acceptance gate
+        explicitly forbids ``empty`` skips for documents that have
+        chunks; an empty-doc_id is a structural reason."""
+        from nexus.aspect_readers import ReadFail, _read_chroma_uri
+
+        col_name = "docs__nodocid"
+        try:
+            t3_client.delete_collection(col_name)
+        except Exception:
+            pass
+        t3_client.get_or_create_collection(col_name)
+
+        def lookup(_coll: str, _source_id: str) -> str:
+            return ""
+
+        result = _read_chroma_uri(
+            "chroma://docs__nodocid/orphan.md",
+            t3=t3_client, doc_id_lookup=lookup,
+        )
+        assert isinstance(result, ReadFail)
+        assert result.reason == "unreachable", (
+            f"missing-doc_id must report a structural reason "
+            f"(unreachable), not {result.reason!r}; the Phase 4 gate "
+            f"forbids 'empty' for documents that haven't been backfilled."
+        )
+
+    def test_no_doc_id_lookup_falls_back_to_legacy_probe(self, t3_client):
+        """Back-compat: callers without catalog access (tests, ad-hoc
+        CLI runs) call _read_chroma_uri without doc_id_lookup. The
+        reader falls back to the legacy ``(source_path, title)`` probe
+        so existing chunks remain readable.
+        """
+        from nexus.aspect_readers import ReadOk, _read_chroma_uri
+
+        title = "decision-bfdb-update-capture-rdr005"
+        _seed_chunks(
+            t3_client,
+            "knowledge__legacy",
+            identity_field="title",
+            source_id=title,
+            chunks=[(0, "legacy chunk")],
+        )
+        # No doc_id_lookup → legacy ``(source_path, title)`` probe.
+        result = _read_chroma_uri(
+            f"chroma://knowledge__legacy/{title}", t3=t3_client,
+        )
+        assert isinstance(result, ReadOk)
+        assert result.text == "legacy chunk"
+        # identity_field reports which legacy field actually matched.
+        assert result.metadata["identity_field"] == "title"
+
+    def test_doc_id_lookup_skips_legacy_probe(self, t3_client):
+        """When doc_id_lookup is provided, the reader does NOT probe
+        source_path or title, even if those metadata fields exist.
+        WITH TEETH: a regression that re-introduces the legacy probe
+        path under doc_id_lookup would surface a stale chunk and fail
+        this assertion.
+        """
+        from nexus.aspect_readers import ReadFail, _read_chroma_uri
+
+        col_name = "docs__strict"
+        try:
+            t3_client.delete_collection(col_name)
+        except Exception:
+            pass
+        coll = t3_client.get_or_create_collection(col_name)
+        # Chunk has source_path metadata but the wrong doc_id.
+        coll.add(
+            ids=["c-0"],
+            documents=["wrong-doc text"],
+            metadatas=[{
+                "doc_id": "ART-other",
+                "source_path": "/path/the_one_we_query.md",
+                "chunk_index": 0,
+            }],
+        )
+
+        # Lookup maps the source_path to a doc_id that ISN'T present.
+        def lookup(_coll: str, _source_id: str) -> str:
+            return "ART-target-not-here"
+
+        result = _read_chroma_uri(
+            "chroma://docs__strict//path/the_one_we_query.md",
+            t3=t3_client, doc_id_lookup=lookup,
+        )
+        # Pre-fix would match by source_path and return wrong-doc text;
+        # post-fix queries strictly on doc_id and returns empty.
+        assert isinstance(result, ReadFail)
+        assert result.reason == "empty"
 
 
 # ── nx-scratch:// reader (RDR-096 P4.1) ─────────────────────────────────────


### PR DESCRIPTION
RDR-101 Phase 4 critical-gate sub-task. Rewrites `aspect_readers.py` so every collection prefix dispatches on `doc_id`, not on `(source_path, title)` string match. Without this rewrite, Phase 5's removal of `source_path` and `title` from T3 metadata produces empty results for every aspect-extraction query, structurally reproducing the original ART-lhk1 / issue #333 failure.

## Dispatch table (`aspect_readers.py`)

- `CHROMA_IDENTITY_FIELD`: every prefix (`rdr__`, `docs__`, `code__`, `knowledge__`) maps to `("doc_id",)`. `_identity_fields_for()` returns `("doc_id",)` uniformly.
- `_LEGACY_IDENTITY_FIELDS` keeps the pre-Phase-4 `("source_path",)` / `("source_path", "title")` tuples for back-compat. Used only when no `doc_id_lookup` is supplied.

## Chroma reader (`_read_chroma_uri`)

- New keyword: `doc_id_lookup: Callable[[collection, source_id], doc_id]`.
- When supplied: resolves `source_id` to `doc_id`, queries strictly on `where={"doc_id": doc_id}`. Empty `doc_id` surfaces as `ReadFail(reason="unreachable")`, a structural failure shape distinct from `"empty"`; the Phase 4 dry-run gate forbids `"empty"` for chunks that exist but have no catalog row.
- When `None`: legacy multi-field probe over `(source_path, title)` for back-compat with callers without catalog access (tests, ad-hoc CLI).
- Shared chunk-gather helper `_gather_chroma_chunks_by_field()` backs both paths so pagination + tiebreak behavior stays in one place.

## Plumbing

- `read_source(uri, *, t3, scratch, doc_id_lookup)` forwards `doc_id_lookup`.
- `aspect_extractor.extract_aspects(*, doc_id_lookup)` forwards to `read_source`.
- `commands/enrich._build_catalog_doc_id_lookup()` builds a callable backed by SQL: `physical_collection + (file_path OR title)` lookup on the catalog's `documents` table; reads `json_extract(metadata, '$.doc_id')`. Returns `None` when catalog uninitialized.
- `_dry_run_predict_skips` and `_run_extraction` both build and pass the lookup, so the dry-run reflects post-prune behavior.

## Test plan (TDD, all stash-revert verified)

- `tests/test_aspect_readers.py::TestIdentityFieldDispatch`: 6 cases assert every prefix maps to `("doc_id",)`.
- `tests/test_aspect_readers.py::TestReadChromaUriDocIdLookup`: 4 new cases.
  - `doc_id_lookup` queries on `doc_id` metadata.
  - empty lookup yields `unreachable` (NOT `empty`).
  - absent lookup falls back to legacy probe.
  - supplied lookup skips legacy probe even when `source_path` metadata is present (would surface a stale chunk on a regression).
- 100 aspect_readers + aspect_extractor tests pass; 417 wider aspect/enrich tests pass.

## ⚠️ Live-data gate (BLOCKS Phase 5)

This PR ships the **structural changes + unit tests**. The Phase 4 acceptance gate per the bead description requires:

```
nx enrich aspects <coll> --dry-run
```

against `code__ART-8c2e74c0`, `docs__ART-8c2e74c0`, `docs__nexus-571b8edd`, `papers__art-curator`, `knowledge__knowledge` with **zero `empty` skips**. Skips, if any, must be `unreachable` or another structural reason (orphan chunk, missing extractor, unsupported content type), not `empty`.

This requires your sandbox catalog tarball and is surfaced as a manual integration step. The bead description is explicit: "Phase 4 is INCOMPLETE until this gate is green."

## Closes

Partially addresses `nexus-o6aa.10.1` (structural rewrite). Bead remains in-progress until the live-data gate is green.