### PR TITLE
feat(search): catalog-resolved _display_path for formatters (nexus-1qed)

### DIFF
--- a/src/nexus/formatters.py
+++ b/src/nexus/formatters.py
@@ -15,6 +15,29 @@ from nexus.types import SearchResult
 _log = structlog.get_logger()
 
 
+def _display_path(meta: dict, default: str = "") -> str:
+    """nexus-1qed: return the best display path for a SearchResult's metadata.
+
+    Priority order:
+
+    1. ``_display_path`` (catalog-resolved path attached by
+       ``search_engine._attach_display_paths`` when a catalog is in scope).
+    2. ``source_path`` (legacy chunk metadata; survives until the prune
+       verb in nexus-o6aa.10.3 lands).
+    3. ``file_path`` (older chunk shape, used by some MCP-promoted entries).
+    4. *default* (caller-provided fallback string).
+
+    Formatters use this in place of direct ``meta.get("source_path", ...)``
+    reads so a single fallback chain serves catalog-resolved + legacy chunks.
+    """
+    return (
+        meta.get("_display_path")
+        or meta.get("source_path")
+        or meta.get("file_path")
+        or default
+    )
+
+
 def _find_matching_lines(
     chunk_text: str,
     query: str,
@@ -155,10 +178,11 @@ def _format_with_bat(
     """
     from collections import defaultdict
 
-    # Group results by source_path
+    # Group results by display path (nexus-1qed: prefer catalog-resolved
+    # _display_path, fall back to source_path / file_path for legacy chunks).
     groups: dict[str, list[SearchResult]] = defaultdict(list)
     for r in results:
-        src = r.metadata.get("source_path", r.metadata.get("file_path", "unknown"))
+        src = _display_path(r.metadata, default="unknown")
         groups[src].append(r)
 
     output_parts: list[str] = []
@@ -250,7 +274,7 @@ def format_compact(
     """
     output: list[str] = []
     for r in results:
-        source_path = r.metadata.get("source_path", "")
+        source_path = _display_path(r.metadata)
         line_start = int(r.metadata.get("line_start", 0))
         chunk_lines = r.content.splitlines()
         if not chunk_lines:
@@ -281,7 +305,7 @@ def format_vimgrep(results: list[SearchResult], query: str | None = None) -> lis
     """
     lines: list[str] = []
     for r in results:
-        source_path = r.metadata.get("source_path", "")
+        source_path = _display_path(r.metadata)
         line_start = int(r.metadata.get("line_start", 0))
         chunk_lines = r.content.splitlines() if r.content else [""]
 
@@ -331,7 +355,7 @@ def format_plain(results: list[SearchResult]) -> list[str]:
     """
     lines: list[str] = []
     for r in results:
-        source_path = r.metadata.get("source_path", "")
+        source_path = _display_path(r.metadata)
         if not source_path:
             title = r.metadata.get("title") or r.id
             snippet = r.content.splitlines()[0] if r.content else ""
@@ -367,7 +391,7 @@ def format_plain_with_context(
 
     output: list[str] = []
     for r in results:
-        source_path = r.metadata.get("source_path", "")
+        source_path = _display_path(r.metadata)
         line_start = int(r.metadata.get("line_start", 0))
         chunk_lines = r.content.splitlines()
         total = len(chunk_lines)

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -65,6 +65,50 @@ class SearchDiagnostics:
             return None
         return max(candidates, key=lambda item: item[2])
 
+def _attach_display_paths(
+    results: list[SearchResult], catalog: Any | None,
+) -> None:
+    """nexus-1qed: annotate each result's metadata with a derived
+    ``_display_path`` resolved through the catalog.
+
+    Mutates *results* in place. Formatters read ``meta["_display_path"]``
+    in preference to legacy ``source_path``; this keeps display sites
+    catalog-agnostic so the prune verb (nexus-o6aa.10.3) can drop
+    ``source_path`` from chunk metadata without breaking display.
+
+    No-op when *catalog* is ``None`` or no result carries a ``doc_id``.
+    A doc_id with no matching catalog entry leaves ``_display_path``
+    unset; the formatter helper then falls back to ``source_path`` /
+    ``file_path``. Best-effort by design: a display-path lookup must
+    never break a search.
+    """
+    if catalog is None or not results:
+        return
+    doc_ids = {
+        r.metadata.get("doc_id", "") for r in results
+        if r.metadata.get("doc_id")
+    }
+    if not doc_ids:
+        return
+    # Single-pass cache so repeated doc_ids (multi-chunk results) only
+    # hit the catalog once.
+    cache: dict[str, str] = {}
+    for did in doc_ids:
+        try:
+            entry = catalog.by_doc_id(did)
+        except Exception:
+            continue
+        if entry is not None and entry.file_path:
+            cache[did] = entry.file_path
+    if not cache:
+        return
+    for r in results:
+        did = r.metadata.get("doc_id", "")
+        path = cache.get(did) if did else None
+        if path:
+            r.metadata["_display_path"] = path
+
+
 # Maximum ID-set size for ChromaDB $in filter — cap to avoid payload bloat.
 _MAX_PREFILTER_IDS = 500
 
@@ -487,6 +531,12 @@ def search_cross_corpus(
             )
         except Exception:
             _log.debug("topic_boost_failed", exc_info=True)
+
+    # nexus-1qed: catalog-resolved display path attached as metadata
+    # so formatters never need to import the catalog. Best-effort;
+    # absent catalog or missing doc_ids leave _display_path unset and
+    # formatters fall back to source_path / file_path.
+    _attach_display_paths(all_results, catalog)
 
     return all_results
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -5,6 +5,7 @@ import subprocess
 import pytest
 
 from nexus.formatters import (
+    _display_path,
     _extract_context,
     _find_matching_lines,
     _is_bat_installed,
@@ -43,6 +44,72 @@ def test_vimgrep_missing_source_path() -> None:
     r = _result()
     r.metadata.pop("source_path")
     assert format_vimgrep([r])[0].startswith(":10:0:")
+
+
+# ── nexus-1qed: _display_path priority + formatter integration ──────────────
+
+
+class TestDisplayPathPriority:
+    """nexus-1qed: ``_display_path`` (catalog-resolved) wins over
+    ``source_path`` and ``file_path`` so chunks that no longer carry
+    ``source_path`` (post-prune) still render via the catalog projection.
+    """
+
+    def test_display_path_wins_over_source_path(self) -> None:
+        meta = {
+            "_display_path": "/abs/from/catalog.py",
+            "source_path": "src/legacy.py",
+        }
+        # WITH TEETH: a regression that drops the _display_path branch
+        # and reads source_path directly fails this assertion.
+        assert _display_path(meta) == "/abs/from/catalog.py"
+
+    def test_falls_back_to_source_path_when_display_path_absent(self) -> None:
+        assert _display_path({"source_path": "src/legacy.py"}) == "src/legacy.py"
+
+    def test_falls_back_to_file_path_when_neither_present(self) -> None:
+        assert _display_path({"file_path": "older/shape.md"}) == "older/shape.md"
+
+    def test_default_when_no_path_keys(self) -> None:
+        assert _display_path({}, default="unknown") == "unknown"
+
+
+def test_formatters_use_display_path_when_attached() -> None:
+    """nexus-1qed end-to-end: format_plain reads ``_display_path`` so a
+    chunk without ``source_path`` (post-prune shape) renders the
+    catalog-resolved path. Pre-fix code keys on source_path and renders
+    the fallback "[distance] title" form instead.
+    """
+    r = SearchResult(
+        id="r1",
+        content="def foo(): pass",
+        distance=0.1,
+        collection="code__x",
+        metadata={
+            # post-prune chunk shape: no source_path, only doc_id +
+            # _display_path attached by search_engine._attach_display_paths.
+            "_display_path": "/abs/path/to/foo.py",
+            "doc_id": "ART-deadbeef",
+            "line_start": 1,
+        },
+    )
+    out = format_plain([r])
+    assert out == ["/abs/path/to/foo.py:1:def foo(): pass"]
+
+
+def test_format_compact_prefers_display_path() -> None:
+    r = SearchResult(
+        id="r1",
+        content="def foo(): pass",
+        distance=0.1,
+        collection="code__x",
+        metadata={
+            "_display_path": "/abs/from/catalog.py",
+            "source_path": "stale/legacy.py",
+            "line_start": 5,
+        },
+    )
+    assert format_compact([r]) == ["/abs/from/catalog.py:5:def foo(): pass"]
 
 
 def test_vimgrep_multiple_results() -> None:

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -1,4 +1,5 @@
 """AC1–AC8: Search engine — hybrid scoring, reranking, output formatters."""
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,7 +12,7 @@ from nexus.scoring import (
     rerank_results,
     round_robin_interleave,
 )
-from nexus.search_engine import search_cross_corpus
+from nexus.search_engine import _attach_display_paths, search_cross_corpus
 from nexus.types import SearchResult
 
 
@@ -583,3 +584,87 @@ class TestSearchTelemetryHotPath:
             assert count == 1
         finally:
             telemetry.close()
+
+
+# ── nexus-1qed: _attach_display_paths catalog projection ────────────────────
+
+
+class TestAttachDisplayPaths:
+    """nexus-1qed: search_engine attaches catalog-resolved display paths
+    to results so formatters never need to import the catalog. Best-
+    effort: missing catalog / missing doc_ids leave the field unset."""
+
+    def _result(self, doc_id: str = "", source_path: str = "") -> SearchResult:
+        meta: dict = {}
+        if doc_id:
+            meta["doc_id"] = doc_id
+        if source_path:
+            meta["source_path"] = source_path
+        return SearchResult(
+            id=f"r-{doc_id or source_path or 'x'}",
+            content="x", distance=0.1, collection="code__c", metadata=meta,
+        )
+
+    def test_no_catalog_is_noop(self):
+        r = self._result(doc_id="ART-x", source_path="src/legacy.py")
+        _attach_display_paths([r], catalog=None)
+        assert "_display_path" not in r.metadata
+
+    def test_no_doc_ids_is_noop(self):
+        catalog = MagicMock()
+        r = self._result(source_path="src/legacy.py")
+        _attach_display_paths([r], catalog=catalog)
+        catalog.by_doc_id.assert_not_called()
+        assert "_display_path" not in r.metadata
+
+    def test_attaches_catalog_resolved_path(self):
+        """WITH TEETH: the resolved file_path lands on the metadata
+        dict under ``_display_path``. A regression that drops the
+        write or routes through the wrong key fails this test."""
+        catalog = MagicMock()
+        catalog.by_doc_id.return_value = SimpleNamespace(
+            file_path="/abs/from/catalog.py",
+        )
+        r = self._result(doc_id="ART-deadbeef", source_path="src/legacy.py")
+        _attach_display_paths([r], catalog=catalog)
+        catalog.by_doc_id.assert_called_once_with("ART-deadbeef")
+        assert r.metadata["_display_path"] == "/abs/from/catalog.py"
+        # source_path stays untouched: the prune verb owns its removal.
+        assert r.metadata["source_path"] == "src/legacy.py"
+
+    def test_doc_id_with_no_catalog_entry_leaves_field_unset(self):
+        catalog = MagicMock()
+        catalog.by_doc_id.return_value = None
+        r = self._result(doc_id="ART-orphan", source_path="src/legacy.py")
+        _attach_display_paths([r], catalog=catalog)
+        assert "_display_path" not in r.metadata
+
+    def test_repeated_doc_id_only_hits_catalog_once(self):
+        """Multi-chunk results sharing the same doc_id share one
+        catalog lookup. Pre-fix code that loops per result without a
+        cache hits the catalog N times (slow on large result sets).
+        """
+        catalog = MagicMock()
+        catalog.by_doc_id.return_value = SimpleNamespace(
+            file_path="/abs/foo.py",
+        )
+        results = [
+            self._result(doc_id="ART-shared"),
+            self._result(doc_id="ART-shared"),
+            self._result(doc_id="ART-shared"),
+        ]
+        _attach_display_paths(results, catalog=catalog)
+        assert catalog.by_doc_id.call_count == 1
+        for r in results:
+            assert r.metadata["_display_path"] == "/abs/foo.py"
+
+    def test_catalog_exception_does_not_break_search(self):
+        """A catalog read failure is logged-and-swallowed; the result
+        passes through with no _display_path. Display always degrades
+        gracefully."""
+        catalog = MagicMock()
+        catalog.by_doc_id.side_effect = RuntimeError("catalog dead")
+        r = self._result(doc_id="ART-x", source_path="src/legacy.py")
+        # Must not raise.
+        _attach_display_paths([r], catalog=catalog)
+        assert "_display_path" not in r.metadata


### PR DESCRIPTION
RDR-101 Phase 4 sub-task. The search engine now resolves each result's `doc_id` to a catalog `file_path` once and stores it on the result's metadata as `_display_path`; formatters read that derived field instead of touching the catalog or reading raw `source_path` / `file_path`. The prune verb (nexus-o6aa.10.3) can then drop `source_path` from chunk metadata without breaking display.

Per the audit's Category B.3 recommendation in `docs/migration/rdr-101-phase4-reader-audit.md`: *the search engine attaches a derived `_display_path` field to results so formatters stay schema-agnostic.* Cleaner than threading the catalog through every formatter.

## Summary

**`search_engine.py`**
- `_attach_display_paths(results, catalog)` iterates results, collects distinct `doc_id`s, batch-resolves each via `catalog.by_doc_id`, and caches the `(doc_id → file_path)` map so multi-chunk results sharing a `doc_id` only hit the catalog once. Best-effort: catalog absent or exception leaves `_display_path` unset; the formatter helper then falls back to `source_path` / `file_path`.
- `search_cross_corpus` calls `_attach_display_paths` before returning so every public-API search result picks up the derived field.

**`formatters.py`**
- `_display_path(meta, default=\"\")` helper centralises the priority chain: `_display_path` > `source_path` > `file_path` > `default`.
- `format_grouped_lines`, `format_compact`, `format_vimgrep`, `format_plain`, `format_plain_with_context` migrated to call the helper.

## Test plan (TDD)

- `TestDisplayPathPriority`: 4 cases. `_display_path` wins over `source_path`; falls back through `file_path`; default kicks in last. WITH TEETH: a regression that drops the `_display_path` branch and reads `source_path` directly fails the priority assertion.
- `test_formatters_use_display_path_when_attached` + `format_compact_prefers_display_path`: end-to-end `format_plain` / `format_compact` reading from a chunk that has only `doc_id` + `_display_path` (post-prune shape).
- `TestAttachDisplayPaths`: 6 cases. `catalog=None` noop, missing `doc_id`s noop, attaches catalog-resolved path, leaves field unset on missing entry, dedup cache (one catalog call for repeated `doc_id`s), graceful swallow on catalog exception.
- Wider regression sweep: 272 format / search / scoring / clusterer / mcp_core tests pass.

## Out of scope (separate PRs)

The bead lists 5 callers; this PR does the search-engine + formatters slice (the cleanest unit). Follow-up PRs for the remaining callers:

- `search_cmd.py` rg-cache + files-only output (4 sites).
- `mcp/core.py` search response builders + group-by-document (2+ sites).
- `scoring._apply_link_boost`: `doc_id → tumbler` direct lookup (drops one indirection level vs. the `source_path → tumbler` form).
- `search_clusterer._cluster_label` fallback.

## Closes

Partially addresses `nexus-1qed`. Bead remains in-progress until the four follow-up sites also migrate.