### PR TITLE
feat(search): doc_id-keyed link boost + display_path priority (nexus-1qed)

### DIFF
--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -320,11 +320,14 @@ def search_cmd(
         click.echo("No results.")
         return
 
-    # Python-side path scoping (ChromaDB has no $startswith operator)
+    # Python-side path scoping (ChromaDB has no $startswith operator).
+    # nexus-1qed: prefer the catalog-resolved _display_path so post-prune
+    # chunks that no longer carry source_path still match the scope.
     if resolved is not None:
         results = [
             r for r in results
-            if r.metadata.get("file_path", "").startswith(resolved)
+            if (r.metadata.get("_display_path") or "").startswith(resolved)
+            or r.metadata.get("file_path", "").startswith(resolved)
             or r.metadata.get("source_path", "").startswith(resolved)
         ]
         if not results:
@@ -377,7 +380,15 @@ def search_cmd(
     # Also attach matched line numbers for downstream context windowing (RDR-027).
     if rg_file_paths:
         for r in results:
-            src = r.metadata.get("source_path", r.metadata.get("file_path", ""))
+            # nexus-1qed: rg paths are filesystem absolute; prefer the
+            # catalog-resolved _display_path so post-prune chunks still
+            # match. Falls through to source_path / file_path for legacy
+            # chunks predating the doc_id backfill.
+            src = (
+                r.metadata.get("_display_path")
+                or r.metadata.get("source_path")
+                or r.metadata.get("file_path", "")
+            )
             if src in rg_file_paths:
                 r.hybrid_score = min(1.0, r.hybrid_score + EXACT_MATCH_BOOST)
                 if src in rg_matched_lines:
@@ -386,8 +397,14 @@ def search_cmd(
     # Filter rg__cache signals from output. Promote rg-only results (files that
     # ripgrep found but vector search missed) with a penalty score.
     if hybrid:
+        # nexus-1qed: same path-priority as the rg exact-match boost so
+        # post-prune chunks dedupe correctly against rg results.
         vector_paths = {
-            r.metadata.get("source_path", r.metadata.get("file_path", ""))
+            (
+                r.metadata.get("_display_path")
+                or r.metadata.get("source_path")
+                or r.metadata.get("file_path", "")
+            )
             for r in results if r.collection != "rg__cache"
         }
         seen_rg_paths: set[str] = set()
@@ -416,9 +433,15 @@ def search_cmd(
         for line in format_vimgrep(results, query=query):
             click.echo(line)
     elif files_only:
+        # nexus-1qed: prefer the catalog-resolved _display_path so
+        # files-only output stays correct after the prune verb drops
+        # source_path from chunk metadata.
         seen: set[str] = set()
         for r in results:
-            file_path = r.metadata.get("source_path", "")
+            file_path = (
+                r.metadata.get("_display_path")
+                or r.metadata.get("source_path", "")
+            )
             if file_path and file_path not in seen:
                 seen.add(file_path)
                 click.echo(file_path)

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -565,7 +565,12 @@ def search(
                 lines.append(f"── {cluster_label} ──")
                 current_cluster = cluster_label
             title = r.metadata.get("title", "")
-            source = r.metadata.get("source_path", "")
+            # nexus-1qed: prefer the catalog-resolved _display_path so
+            # the label survives after the prune verb drops source_path.
+            source = (
+                r.metadata.get("_display_path")
+                or r.metadata.get("source_path", "")
+            )
             dist = f"{r.distance:.4f}"
             label = title or source or r.id
             snippet = r.content[:200].replace("\n", " ")
@@ -780,13 +785,18 @@ def query(
                 ],
             }
 
-        # Group by document: use content_hash or title as doc key
+        # Group by document: use doc_id (post-prune stable identity)
+        # then content_hash, title, _display_path, source_path as fallbacks.
+        # nexus-1qed: doc_id sits at the top so chunks of the same
+        # document group together even after source_path is pruned.
         docs: dict[str, dict] = {}  # doc_key → {meta, snippets, best_distance}
         for r in results:
             meta = r.metadata
             doc_key = (
-                meta.get("content_hash")
+                meta.get("doc_id")
+                or meta.get("content_hash")
                 or meta.get("title")
+                or meta.get("_display_path")
                 or meta.get("source_path")
                 or r.id
             )
@@ -804,7 +814,12 @@ def query(
                     # page_count / extraction_method / has_formulas are not in
                     # ALLOWED_TOP_LEVEL — normalize() drops them, so the read
                     # always returned "". Removed in nexus-59j0 cleanup.
-                    "source_path": meta.get("source_path", ""),
+                    # nexus-1qed: prefer catalog-resolved _display_path so
+                    # the response survives after source_path is pruned.
+                    "source_path": (
+                        meta.get("_display_path")
+                        or meta.get("source_path", "")
+                    ),
                 }
             elif r.distance < docs[doc_key]["distance"]:
                 # Better matching chunk — update snippet

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -206,44 +206,40 @@ def apply_link_boost(
 ) -> list[SearchResult]:
     """Boost hybrid_score for results whose source documents have outgoing links.
 
-    Looks up each result's source_path in the catalog, finds outgoing links,
-    and computes a link signal from type weights. Additive:
-    ``score += boost_weight * min(signal, 1.0)``.
+    nexus-1qed (RDR-101 Phase 4): keyed on the catalog ``doc_id`` rather
+    than on the legacy ``source_path``. The catalog projects ``doc_id``
+    onto ``tumbler`` directly, so the prune verb (.10.3) can drop
+    ``source_path`` from chunk metadata without breaking the link boost.
 
-    Only processes results that have ``source_path`` metadata and a matching
-    catalog entry. Results without catalog matches are untouched.
+    Only processes results that carry ``doc_id`` metadata. Chunks
+    predating the doc_id backfill are skipped. Additive:
+    ``score += boost_weight * min(signal, 1.0)``.
     """
     if not catalog:
         return results
     tw = type_weights if type_weights is not None else _LINK_BOOST_WEIGHTS
 
-    # Collect unique source_paths from results
-    source_paths: set[str] = set()
+    # Collect unique doc_ids from results.
+    doc_ids: set[str] = set()
     for r in results:
-        sp = r.metadata.get("source_path", "")
-        if sp:
-            source_paths.add(sp)
+        did = r.metadata.get("doc_id", "")
+        if did:
+            doc_ids.add(did)
 
-    if not source_paths:
+    if not doc_ids:
         return results
 
-    # Batch query: find all tumblers for these source_paths
-    placeholders = ",".join("?" for _ in source_paths)
-    rows = catalog._db.execute(
-        f"SELECT file_path, tumbler FROM documents WHERE file_path IN ({placeholders})",
-        list(source_paths),
-    ).fetchall()
-    path_to_tumbler: dict[str, str] = {row[0]: row[1] for row in rows}
-
-    if not path_to_tumbler:
-        return results
-
-    # Batch query: get all outgoing links for these tumblers
-    tumbler_strs = list(path_to_tumbler.values())
-    placeholders2 = ",".join("?" for _ in tumbler_strs)
+    # nexus-1qed: Phase 1 contract is ``doc_id == str(tumbler)`` (see
+    # catalog/catalog.py:_DocumentRegisteredPayload). The links table
+    # is keyed on tumbler, so doc_id can join links.from_tumbler
+    # directly without the source_path → tumbler indirection the
+    # legacy code carried. Phase 3 will mint UUID7 doc_ids distinct
+    # from tumblers; that change reintroduces a metadata.doc_id →
+    # tumbler projection step here.
+    placeholders = ",".join("?" for _ in doc_ids)
     link_rows = catalog._db.execute(
-        f"SELECT from_tumbler, link_type FROM links WHERE from_tumbler IN ({placeholders2})",
-        tumbler_strs,
+        f"SELECT from_tumbler, link_type FROM links WHERE from_tumbler IN ({placeholders})",
+        list(doc_ids),
     ).fetchall()
 
     # Aggregate: tumbler -> total weighted signal
@@ -252,13 +248,12 @@ def apply_link_boost(
         w = tw.get(link_type, 0.0)
         tumbler_signal[from_t] = tumbler_signal.get(from_t, 0.0) + w
 
-    # Apply boost
+    # Apply boost.
     for r in results:
-        sp = r.metadata.get("source_path", "")
-        t_str = path_to_tumbler.get(sp)
-        if not t_str:
+        did = r.metadata.get("doc_id", "")
+        if not did:
             continue
-        signal = min(tumbler_signal.get(t_str, 0.0), 1.0)
+        signal = min(tumbler_signal.get(did, 0.0), 1.0)
         if signal > 0:
             r.hybrid_score += boost_weight * signal
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -235,10 +235,14 @@ class TestLinkBoost:
         (cat_dir / "links.jsonl").touch()
         return Catalog(cat_dir, cat_dir / ".catalog.db")
 
-    def _make_result(self, source_path="src/foo.py", score=0.5, collection="code__test"):
+    def _make_result(self, doc_id="", score=0.5, collection="code__test"):
+        # nexus-1qed: link boost keys on doc_id (Phase 1: doc_id == str(tumbler)).
+        meta: dict = {}
+        if doc_id:
+            meta["doc_id"] = doc_id
         return SearchResult(
             id="r1", content="text", distance=0.3, collection=collection,
-            metadata={"source_path": source_path}, hybrid_score=score,
+            metadata=meta, hybrid_score=score,
         )
 
     def test_implements_link_boosts_score(self, tmp_path):
@@ -248,7 +252,7 @@ class TestLinkBoost:
         t2 = cat.register(owner, "bar.py", content_type="code", file_path="src/bar.py")
         cat.link(t1, t2, "implements", created_by="test")
 
-        r = self._make_result(source_path="src/foo.py", score=0.5)
+        r = self._make_result(doc_id=str(t1), score=0.5)
         apply_link_boost([r], cat)
         assert r.hybrid_score > 0.5  # boosted
 
@@ -259,7 +263,7 @@ class TestLinkBoost:
         t2 = cat.register(owner, "bar.py", content_type="code", file_path="src/bar.py")
         cat.link(t1, t2, "implements-heuristic", created_by="test")
 
-        r = self._make_result(source_path="src/foo.py", score=0.5)
+        r = self._make_result(doc_id=str(t1), score=0.5)
         apply_link_boost([r], cat)
         assert r.hybrid_score == 0.5  # unchanged
 
@@ -270,7 +274,25 @@ class TestLinkBoost:
 
     def test_no_matching_entry_unchanged(self, tmp_path):
         cat = self._make_catalog(tmp_path)
-        r = self._make_result(source_path="nonexistent.py", score=0.5)
+        r = self._make_result(doc_id="nonexistent-tumbler", score=0.5)
+        apply_link_boost([r], cat)
+        assert r.hybrid_score == 0.5
+
+    def test_chunk_without_doc_id_skipped(self, tmp_path):
+        """nexus-1qed: chunks predating the doc_id backfill are
+        skipped silently. WITH TEETH: a regression that re-introduces
+        the legacy source_path probe would boost the score."""
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("test", "repo", repo_hash="abc12345", repo_root=str(tmp_path))
+        t1 = cat.register(owner, "foo.py", content_type="code", file_path="src/foo.py")
+        t2 = cat.register(owner, "bar.py", content_type="code", file_path="src/bar.py")
+        cat.link(t1, t2, "implements", created_by="test")
+
+        # Chunk has source_path but no doc_id (pre-backfill shape).
+        r = SearchResult(
+            id="legacy-chunk", content="x", distance=0.3, collection="code__test",
+            metadata={"source_path": "src/foo.py"}, hybrid_score=0.5,
+        )
         apply_link_boost([r], cat)
         assert r.hybrid_score == 0.5
 
@@ -283,7 +305,7 @@ class TestLinkBoost:
             t_target = cat.register(owner, f"bar{i}.py", content_type="code", file_path=f"src/bar{i}.py")
             cat.link(t1, t_target, "implements", created_by="test")
 
-        r = self._make_result(source_path="src/foo.py", score=0.5)
+        r = self._make_result(doc_id=str(t1), score=0.5)
         apply_link_boost([r], cat, boost_weight=0.15)
         # signal capped at 1.0, so max boost is 0.15
         assert r.hybrid_score == pytest.approx(0.65, abs=0.01)
@@ -295,7 +317,7 @@ class TestLinkBoost:
         t2 = cat.register(owner, "bar.py", content_type="code", file_path="src/bar.py")
         cat.link(t1, t2, "relates", created_by="test")
 
-        r = self._make_result(source_path="src/foo.py", score=0.5)
+        r = self._make_result(doc_id=str(t1), score=0.5)
         apply_link_boost([r], cat, boost_weight=0.15)
         # relates = 0.5 weight, so boost = 0.15 * 0.5 = 0.075
         assert r.hybrid_score == pytest.approx(0.575, abs=0.01)
@@ -307,7 +329,7 @@ class TestLinkBoost:
         t2 = cat.register(owner, "bar.py", content_type="code", file_path="src/bar.py")
         cat.link(t1, t2, "implements", created_by="test")
 
-        r = self._make_result(source_path="src/foo.py", score=0.5)
+        r = self._make_result(doc_id=str(t1), score=0.5)
         apply_link_boost([r], cat, boost_weight=0.2, type_weights={"implements": 0.5})
         # 0.2 * 0.5 = 0.1
         assert r.hybrid_score == pytest.approx(0.6, abs=0.01)


### PR DESCRIPTION
RDR-101 Phase 4 follow-on to #472. Migrates the remaining four `nexus-1qed` sites to prefer the catalog-resolved `_display_path`, and switches `scoring.apply_link_boost` to a doc_id-keyed direct lookup.

Together with #472 this completes `nexus-1qed`'s reader-side scope.

## Summary

**`search_cmd.py`** (4 sites)
- Path-scoping filter (`--path`), rg-cache exact-match boost, vector vs rg dedup, files-only output. All four sites prepend `_display_path` to the priority chain so post-prune chunks (which lose `source_path`) keep the right path attribution.

**`mcp/core.py`** (3 sites)
- Search response label fallback: prefer `_display_path` over `source_path`.
- Group-by-document `doc_key`: `doc_id` is now the primary identity, with `content_hash` / `title` / `_display_path` / `source_path` as fallbacks. Chunks of the same document group together even after `source_path` is pruned.
- Output dict's `source_path` field reads `_display_path` first (dual-write transitional shape; the field name is API contract).

**`scoring.apply_link_boost`**
- Keys on `doc_id` instead of `source_path`. Phase 1 contract (`doc_id == str(tumbler)`) lets the link query join `links.from_tumbler` directly with no SQL projection step (audit recommendation: drops one indirection level). Phase 3's UUID7 `doc_id`s will reintroduce a `metadata.doc_id → tumbler` projection here.
- Chunks predating the doc_id backfill are skipped silently (regression-tested).

## Test plan

- `TestLinkBoost`: 7 cases. Existing `source_path`-based fixtures reseeded as `doc_id=str(tumbler)`. Added `test_chunk_without_doc_id_skipped` to lock the post-Phase-4 contract: legacy chunks no longer benefit from link boost (WITH TEETH regression-fail target if a future change re-introduces the legacy `source_path` probe).
- 188 affected-module tests pass (search_cmd + mcp_core + scoring + clusterer + formatter).

## Audit-confirmed scope

`search_clusterer.py:91` (`_cluster_label`) reads `meta.get("source")` not `meta.get("source_path")` — different metadata key, no migration needed. The audit reference was imprecise; the actual identity-aware fallback already prefers `title`.

## Closes

Together with #472, completes `nexus-1qed`. Bead can be closed once both merge.