### PR TITLE
feat(collection): doc_id-aware reindex safety check (nexus-7b5n)

### DIFF
--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -12,6 +12,30 @@ from nexus.corpus import embedding_model_for_collection, index_model_for_collect
 _log = structlog.get_logger(__name__)
 
 
+def _doc_id_to_file_path(doc_id: str) -> str:
+    """nexus-7b5n: resolve a chunk's ``doc_id`` to the catalog's
+    ``file_path``. Returns "" when the catalog is uninitialized or has
+    no entry. Used by ``reindex_cmd``'s pre-delete safety check so
+    post-prune chunks (which lack ``source_path``) still drive the
+    reindex via the catalog projection. Best-effort; any failure
+    returns "" and the caller treats the chunk as sourceless.
+    """
+    try:
+        from nexus.catalog import Catalog
+        from nexus.config import catalog_path
+
+        cat_path = catalog_path()
+        if not Catalog.is_initialized(cat_path):
+            return ""
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
+        entry = cat.by_doc_id(doc_id)
+        if entry is None:
+            return ""
+        return entry.file_path or ""
+    except Exception:
+        return ""
+
+
 @click.group()
 def collection() -> None:
     """Manage ChromaDB collections (list, info, verify, delete)."""
@@ -254,7 +278,13 @@ def reindex_cmd(name: str, force: bool) -> None:
 
     before_count = info["count"]
 
-    # 2. Pre-delete safety: paginate for sourceless entries (nexus-unyc)
+    # 2. Pre-delete safety: paginate for sourceless entries (nexus-unyc).
+    # nexus-7b5n: a chunk is "reindexable" when it carries either
+    # ``source_path`` (legacy chunks predating the doc_id backfill) or
+    # ``doc_id`` (post-Phase-4 chunks). After the prune verb drops
+    # source_path from chunk metadata, doc_id is the only signal; the
+    # catalog row pointed to by doc_id holds the file_path used for
+    # the actual reindex.
     col = db.get_or_create_collection(name)
     sourceless: list[str] = []
     source_paths: set[str] = set()
@@ -262,9 +292,24 @@ def reindex_cmd(name: str, force: bool) -> None:
     while True:
         batch = col.get(limit=300, offset=offset, include=["metadatas"])
         for mid, meta in zip(batch["ids"], batch["metadatas"] or []):
-            sp = (meta or {}).get("source_path", "")
+            meta = meta or {}
+            sp = meta.get("source_path", "")
+            did = meta.get("doc_id", "")
             if sp:
                 source_paths.add(sp)
+            elif did:
+                # Post-prune chunk: source_path was dropped but the
+                # catalog still holds the file_path keyed on doc_id.
+                # Resolve it so the reindex driver below has the path.
+                resolved = _doc_id_to_file_path(did)
+                if resolved:
+                    source_paths.add(resolved)
+                else:
+                    # Catalog gap: treat as sourceless so the safety
+                    # check fires. Operator runs ``nx catalog
+                    # synthesize-log`` + ``t3-backfill-doc-id`` before
+                    # reindex.
+                    sourceless.append(mid)
             else:
                 sourceless.append(mid)
         if len(batch["ids"]) < 300:

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -261,6 +261,79 @@ def test_reindex_refuses_when_all_entries_sourceless(
     mock_db.delete_collection.assert_not_called()
 
 
+def test_reindex_treats_doc_id_only_chunk_as_reindexable(
+    runner, env_creds, mock_db, tmp_path,
+) -> None:
+    """nexus-7b5n: post-prune chunks lack source_path but carry
+    doc_id. The safety check must resolve doc_id → catalog file_path
+    and treat the chunk as reindexable, not sourceless.
+
+    WITH TEETH: a regression that drops the doc_id branch lands the
+    chunk in ``sourceless`` and triggers the all-sourceless refuse
+    path even though the catalog has a backing source.
+    """
+    doc_file = tmp_path / "doc.md"
+    doc_file.write_text("# Doc\ncontent")
+
+    mock_db.collection_info.return_value = {"count": 1, "metadata": {}}
+    mock_col = MagicMock()
+    # Chunk has only doc_id (post-prune shape); source_path absent.
+    mock_col.get.return_value = {
+        "ids": ["chunk-0"],
+        "metadatas": [{"doc_id": "ART-deadbeef"}],
+    }
+    mock_db.get_or_create_collection.return_value = mock_col
+    from nexus.db.t3 import VerifyResult
+    mock_db.delete_collection.return_value = None
+    after_col = MagicMock()
+    after_col.count.return_value = 1
+    mock_db.get_or_create_collection.side_effect = [mock_col, after_col]
+    vr = VerifyResult(status="healthy", doc_count=1, probe_doc_id="x", distance=0.05, metric="l2")
+
+    with patch(
+        "nexus.commands.collection._doc_id_to_file_path",
+        return_value=str(doc_file),
+    ), \
+         patch("nexus.commands.collection._t3", return_value=mock_db), \
+         patch("nexus.doc_indexer.index_markdown", return_value=1), \
+         patch("nexus.db.t3.verify_collection_deep", return_value=vr):
+        result = runner.invoke(
+            main, ["collection", "reindex", "docs__test", "--force"],
+        )
+    # Must NOT hit the all-sourceless refuse branch; reindex proceeds.
+    assert "refusing to reindex" not in result.output.lower()
+    mock_db.delete_collection.assert_called_once_with("docs__test")
+
+
+def test_reindex_treats_doc_id_with_no_catalog_entry_as_sourceless(
+    runner, env_creds, mock_db,
+) -> None:
+    """When the chunk carries doc_id but the catalog has no entry
+    (catalog gap / pre-Phase-3 chunks), the safety check falls back
+    to the sourceless path so the operator runs synthesize-log first.
+    """
+    mock_db.collection_info.return_value = {"count": 1, "metadata": {}}
+    mock_col = MagicMock()
+    mock_col.get.return_value = {
+        "ids": ["chunk-orphan"],
+        "metadatas": [{"doc_id": "ART-orphan"}],
+    }
+    mock_db.get_or_create_collection.return_value = mock_col
+
+    with patch(
+        "nexus.commands.collection._doc_id_to_file_path",
+        return_value="",
+    ), \
+         patch("nexus.commands.collection._t3", return_value=mock_db):
+        result = runner.invoke(
+            main, ["collection", "reindex", "docs__orphan", "--force"],
+        )
+    # All chunks resolve to "" file_path → all-sourceless refuse path.
+    assert result.exit_code != 0
+    assert "refusing to reindex" in result.output.lower()
+    mock_db.delete_collection.assert_not_called()
+
+
 def test_reindex_force_proceeds(runner, env_creds, mock_db, tmp_path) -> None:
     doc_file = tmp_path / "doc.md"
     doc_file.write_text("# Doc\ncontent")


### PR DESCRIPTION
RDR-101 Phase 4 follow-up to #474. Migrates the third site listed in `nexus-7b5n` (`commands/collection.py:265`) to recognize `doc_id` as a valid reindexability signal alongside `source_path`. Closes the bead.

## Summary

Pre-fix: `reindex_cmd`'s pre-delete safety check buckets a chunk as \"sourceless\" when `meta.source_path` is empty. After the prune verb (`.10.3`) drops `source_path` from chunk metadata, every post-prune chunk is incorrectly flagged sourceless and the all-sourceless refuse branch fires on collections that ARE reindexable via the catalog.

Post-fix:
- Chunks with `source_path`: bucketed as today (legacy / pre-prune).
- Chunks without `source_path` but with `doc_id`: catalog projection (`_doc_id_to_file_path`) resolves to `file_path`; chunk treated as reindexable.
- Chunks without `source_path` and without a resolvable `doc_id`: bucketed as sourceless (catalog gap; operator runs `synthesize-log` first).

## Test plan

- `test_reindex_treats_doc_id_only_chunk_as_reindexable`: post-prune shape with `doc_id` resolves via catalog. WITH TEETH: a regression that drops the doc_id branch fails the assertion that `delete_collection` was called.
- `test_reindex_treats_doc_id_with_no_catalog_entry_as_sourceless`: catalog-gap fallback engages the sourceless refuse branch.
- All 22 existing `collection_cmd` tests pass unchanged.

## Closes

Closes `nexus-7b5n` (third and final site of the catalog-walk migration).