### PR TITLE
feat(aspects): doc_id-keyed queue + hook + 9 fire sites (nexus-tdgc)

### DIFF
--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -301,10 +301,21 @@ class AspectExtractionWorker:
             # store_put). For CLI rows where content was not in scope
             # at enqueue, ``row.content`` is "" and the extractor's
             # content-sourcing fallback will read source_path.
+            # nexus-tdgc: when the queue row carries a doc_id, build a
+            # lookup callable so the chroma reader can route to the
+            # doc_id-keyed chunk lookup. Empty doc_id passes through as
+            # a None lookup; the extractor falls back to legacy probes.
+            queued_doc_id = getattr(row, "doc_id", "") or ""
+            doc_id_lookup = (
+                (lambda _coll, _sid, _d=queued_doc_id: _d)
+                if queued_doc_id
+                else None
+            )
             record = _extract_aspects(
                 content=row.content,
                 source_path=row.source_path,
                 collection=row.collection,
+                doc_id_lookup=doc_id_lookup,
             )
         except Exception as exc:
             _log.warning(
@@ -445,6 +456,8 @@ def aspect_extraction_enqueue_hook(
     source_path: str,
     collection: str,
     content: str,
+    *,
+    doc_id: str = "",
 ) -> None:
     """Post-document hook: enqueue a row for async aspect extraction.
 
@@ -482,6 +495,7 @@ def aspect_extraction_enqueue_hook(
         with t2_ctx() as t2:
             t2.aspect_queue.enqueue(
                 collection, source_path, content=content,
+                doc_id=doc_id,
             )
     except Exception:
         _log.warning(

--- a/src/nexus/code_indexer.py
+++ b/src/nexus/code_indexer.py
@@ -487,7 +487,11 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
             fire_post_store_hooks(_did, ctx.corpus, _doc)
         # RDR-089 document-grain chain — once per code-file boundary.
         # content="" (chunk-level scope only); hook reads source_path.
-        fire_post_document_hooks(str(file_path), ctx.corpus, "")
+        # nexus-tdgc: forward catalog doc_id when available.
+        fire_post_document_hooks(
+            str(file_path), ctx.corpus, "",
+            doc_id=catalog_doc_id,
+        )
 
     return len(ids)
 

--- a/src/nexus/db/t2/aspect_extraction_queue.py
+++ b/src/nexus/db/t2/aspect_extraction_queue.py
@@ -80,6 +80,7 @@ _ASPECT_QUEUE_SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS aspect_extraction_queue (
     collection      TEXT NOT NULL,
     source_path     TEXT NOT NULL,
+    doc_id          TEXT NOT NULL DEFAULT '',
     content_hash    TEXT NOT NULL DEFAULT '',
     content         TEXT NOT NULL DEFAULT '',
     status          TEXT NOT NULL DEFAULT 'pending',
@@ -116,10 +117,17 @@ class QueueRow:
     ``content`` is the document text captured at enqueue time. The
     MCP ``store_put`` path passes ``content=<full text>`` (the only
     moment the text is in scope before T3 commits); CLI ingest paths
-    pass ``content=""`` because chunk-level scope only — those rows
+    pass ``content=""`` because chunk-level scope only; those rows
     rely on the worker re-reading ``source_path`` from disk at
     extraction time. The worker prefers ``content`` over file read
     when non-empty.
+
+    ``doc_id`` (nexus-tdgc / RDR-101 Phase 4) is the catalog identity
+    of the source document. Captured at enqueue time so the worker
+    can build a ``doc_id_lookup`` for the chroma reader without a
+    second catalog round-trip. Empty string for legacy rows
+    enqueued before the column was added; the worker treats empty
+    ``doc_id`` as "fall back to source_path".
     """
 
     collection: str
@@ -127,6 +135,7 @@ class QueueRow:
     content_hash: str
     content: str
     retry_count: int
+    doc_id: str = ""
 
 
 # ── AspectExtractionQueue ───────────────────────────────────────────────────
@@ -155,6 +164,20 @@ class AspectExtractionQueue:
         with self._lock:
             self.conn.executescript("PRAGMA journal_mode=WAL;")
             self.conn.executescript(_ASPECT_QUEUE_SCHEMA_SQL)
+            # nexus-tdgc: in-place migration for tables created before
+            # the doc_id column was added. ADD COLUMN with a NOT NULL
+            # DEFAULT '' fills legacy rows with the empty string; the
+            # worker treats empty doc_id as "fall back to source_path".
+            cols = {
+                r[1] for r in self.conn.execute(
+                    "PRAGMA table_info(aspect_extraction_queue)"
+                ).fetchall()
+            }
+            if "doc_id" not in cols:
+                self.conn.execute(
+                    "ALTER TABLE aspect_extraction_queue "
+                    "ADD COLUMN doc_id TEXT NOT NULL DEFAULT ''"
+                )
             self.conn.commit()
 
     # ── Public API ────────────────────────────────────────────────────────
@@ -165,6 +188,8 @@ class AspectExtractionQueue:
         source_path: str,
         content_hash: str = "",
         content: str = "",
+        *,
+        doc_id: str = "",
     ) -> None:
         """Persist a new pending row for ``(collection, source_path)``.
 
@@ -178,7 +203,13 @@ class AspectExtractionQueue:
         CLI paths pass ``""`` and the worker re-reads ``source_path``
         from disk. Both shapes are valid.
 
-        Empty ``collection`` or ``source_path`` raises ``ValueError`` —
+        ``doc_id`` (nexus-tdgc) is the catalog identity. Caller passes
+        ``ctx.doc_id_resolver(path)`` (or equivalent) when known; empty
+        string is acceptable and routes the worker through the legacy
+        source_path path. Stored on the row so the worker can build a
+        chroma reader ``doc_id_lookup`` without a catalog round-trip.
+
+        Empty ``collection`` or ``source_path`` raises ``ValueError``;
         these are caller-side bugs that should fail fast.
         """
         if not collection:
@@ -189,10 +220,10 @@ class AspectExtractionQueue:
         with self._lock:
             self.conn.execute(
                 "INSERT OR REPLACE INTO aspect_extraction_queue "
-                "(collection, source_path, content_hash, content, status, "
-                " retry_count, enqueued_at, last_attempt_at, last_error) "
-                "VALUES (?, ?, ?, ?, 'pending', 0, ?, NULL, NULL)",
-                (collection, source_path, content_hash, content, now),
+                "(collection, source_path, doc_id, content_hash, content, "
+                " status, retry_count, enqueued_at, last_attempt_at, last_error) "
+                "VALUES (?, ?, ?, ?, ?, 'pending', 0, ?, NULL, NULL)",
+                (collection, source_path, doc_id, content_hash, content, now),
             )
             self.conn.commit()
 
@@ -225,7 +256,7 @@ class AspectExtractionQueue:
             with self._lock:
                 row = self.conn.execute(
                     "SELECT collection, source_path, content_hash, content, "
-                    "       retry_count "
+                    "       retry_count, doc_id "
                     "FROM aspect_extraction_queue "
                     "WHERE status = 'pending' "
                     "ORDER BY enqueued_at ASC, source_path ASC "
@@ -233,7 +264,7 @@ class AspectExtractionQueue:
                 ).fetchone()
                 if row is None:
                     return None
-                collection, source_path, content_hash, content, retry_count = row
+                collection, source_path, content_hash, content, retry_count, doc_id = row
                 cur = self.conn.execute(
                     "UPDATE aspect_extraction_queue "
                     "SET status = 'in_progress', last_attempt_at = ? "
@@ -250,6 +281,7 @@ class AspectExtractionQueue:
                         content_hash=content_hash,
                         content=content,
                         retry_count=retry_count,
+                        doc_id=doc_id or "",
                     )
                 # rowcount == 0 → another process / thread won the
                 # CAS; loop and try a different row.

--- a/src/nexus/db/t2/aspect_extraction_queue.py
+++ b/src/nexus/db/t2/aspect_extraction_queue.py
@@ -168,16 +168,37 @@ class AspectExtractionQueue:
             # the doc_id column was added. ADD COLUMN with a NOT NULL
             # DEFAULT '' fills legacy rows with the empty string; the
             # worker treats empty doc_id as "fall back to source_path".
+            # The PRAGMA-then-ALTER pattern races under concurrent
+            # T2Database construction: thread A reads cols (no doc_id),
+            # thread B reads cols (no doc_id), A commits ALTER, B's
+            # ALTER raises "duplicate column name". Catching the
+            # specific error keeps construction idempotent across
+            # threads. Same SQLite catch pattern used in nexus.db.migrations.
             cols = {
                 r[1] for r in self.conn.execute(
                     "PRAGMA table_info(aspect_extraction_queue)"
                 ).fetchall()
             }
             if "doc_id" not in cols:
-                self.conn.execute(
-                    "ALTER TABLE aspect_extraction_queue "
-                    "ADD COLUMN doc_id TEXT NOT NULL DEFAULT ''"
-                )
+                try:
+                    self.conn.execute(
+                        "ALTER TABLE aspect_extraction_queue "
+                        "ADD COLUMN doc_id TEXT NOT NULL DEFAULT ''"
+                    )
+                except sqlite3.OperationalError as exc:
+                    # Another constructor raced ahead of us and added
+                    # the column first; verify it really exists before
+                    # swallowing the error so a genuinely broken ALTER
+                    # still surfaces.
+                    if "duplicate column" not in str(exc).lower():
+                        raise
+                    cols_after = {
+                        r[1] for r in self.conn.execute(
+                            "PRAGMA table_info(aspect_extraction_queue)"
+                        ).fetchall()
+                    }
+                    if "doc_id" not in cols_after:
+                        raise
             self.conn.commit()
 
     # ── Public API ────────────────────────────────────────────────────────

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -525,7 +525,12 @@ def _index_document(
     # RDR-089 document-grain chain — fires once per file boundary.
     # content="" because only chunk text is in scope here; the hook
     # reads source_path itself per the P0.1 content-sourcing contract.
-    fire_post_document_hooks(sp, collection_name, "")
+    # nexus-tdgc: pre-flight catalog lookup so the aspect-queue hook
+    # can capture the doc_id alongside source_path.
+    fire_post_document_hooks(
+        sp, collection_name, "",
+        doc_id=_lookup_existing_doc_id(sp, corpus),
+    )
 
     # Prune stale chunks from a previous (larger) version of this file.
     # Paginate: ChromaDB Cloud returns at most 300 records per get() call.
@@ -1061,8 +1066,13 @@ def index_pdf(
         # incremental-branch tail. content="" (chunks already paginated
         # through T3); the hook reads source_path itself per the P0.1
         # content-sourcing contract.
+        # nexus-tdgc: forward the catalog doc_id (lookup is post-register
+        # so the entry exists by this point in the incremental path).
         from nexus.mcp_infra import fire_post_document_hooks
-        fire_post_document_hooks(str(pdf_path), col_name, "")
+        fire_post_document_hooks(
+            str(pdf_path), col_name, "",
+            doc_id=_lookup_existing_doc_id(str(pdf_path), corpus),
+        )
         if return_metadata:
             return {
                 "chunks": len(metadatas),
@@ -1107,7 +1117,11 @@ def index_pdf(
     # RDR-089 document-grain chain — fires once per small-doc PDF boundary.
     # content="" (full document text not retained in this path); the hook
     # reads source_path itself.
-    fire_post_document_hooks(str(pdf_path), col_name, "")
+    # nexus-tdgc: forward the catalog doc_id post-register.
+    fire_post_document_hooks(
+        str(pdf_path), col_name, "",
+        doc_id=_lookup_existing_doc_id(str(pdf_path), corpus),
+    )
 
     # Prune stale chunks (nexus-dcym: doc_id-keyed when catalog has the
     # entry; first-time indexes harmlessly use source_path).

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -866,7 +866,11 @@ def _index_pdf_file(
         # the `nx index repo` PDF path. content="" (chunk-level scope
         # only); the hook reads source_path itself per the P0.1
         # content-sourcing contract.
-        fire_post_document_hooks(str(file), collection_name, "")
+        # nexus-tdgc: forward catalog doc_id when available.
+        fire_post_document_hooks(
+            str(file), collection_name, "",
+            doc_id=catalog_doc_id,
+        )
 
     return len(prepared)
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -956,7 +956,9 @@ def store_put(
         # source_path is doc_id here — there is no on-disk file at the
         # MCP boundary, so the doc_id serves as the stable identifier
         # the hook uses for failure attribution.
-        _fire_post_document_hooks(doc_id, col_name, content)
+        # nexus-tdgc: forward doc_id explicitly so the aspect-queue
+        # hook can store it on the queue row alongside source_path.
+        _fire_post_document_hooks(doc_id, col_name, content, doc_id=doc_id)
         # RDR-061 E2: log relevance correlation for the most recent search in
         # this session. Only the newest trace is used to minimize noise —
         # older traces are unlikely to have driven this store_put.

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -760,6 +760,8 @@ def register_post_document_hook(fn) -> None:
 
 def fire_post_document_hooks(
     source_path: str, collection: str, content: str,
+    *,
+    doc_id: str = "",
 ) -> None:
     """Invoke all registered document-grain hooks. Per-hook failures are
     captured, logged, and persisted to T2 ``hook_failures`` with
@@ -776,12 +778,21 @@ def fire_post_document_hooks(
       may need to read ``source_path`` itself. The framework forwards
       both arguments unchanged; content-sourcing is the hook's
       responsibility, not the framework's.
+
+    ``doc_id`` (nexus-tdgc / RDR-101 Phase 4) is the catalog identity
+    of the source document. Forwarded to every registered hook as a
+    keyword arg; hooks that don't accept the kw are called without it
+    so older registrations keep working during the migration window.
     """
     import structlog
     _hook_log = structlog.get_logger()
     for hook in _post_document_hooks:
         try:
-            hook(source_path, collection, content)
+            try:
+                hook(source_path, collection, content, doc_id=doc_id)
+            except TypeError:
+                # Back-compat: hook predates the doc_id keyword.
+                hook(source_path, collection, content)
         except Exception as exc:
             hook_name = getattr(hook, "__name__", "?")
             _hook_log.warning(
@@ -949,8 +960,12 @@ def fire_store_chains(
     )
 
     # Document-grain chain — once per (source_path, content).
-    for sp, content in zip(source_paths, contents):
-        fire_post_document_hooks(sp, collection, content)
+    # nexus-tdgc: doc_id is forwarded so the aspect-queue hook can
+    # capture it at enqueue time. The doc_ids list is the same one
+    # the post_store + batch chains use; for the document chain it is
+    # the catalog identity.
+    for did, sp, content in zip(doc_ids, source_paths, contents):
+        fire_post_document_hooks(sp, collection, content, doc_id=did)
 
 
 # ── Version compatibility check (RDR-076) ─────────────────────────────────────

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -739,8 +739,14 @@ def pipeline_index_pdf(
     # RDR-089 document-grain chain — once per PDF boundary at the streaming
     # pipeline tail. content="" (PDF text streamed not retained); the hook
     # reads source_path itself per the P0.1 content-sourcing contract.
+    # nexus-tdgc: _catalog_pdf_hook ran above so the catalog entry now
+    # exists; resolve the doc_id and forward it to the document chain.
+    from nexus.doc_indexer import _lookup_existing_doc_id
     from nexus.mcp_infra import fire_post_document_hooks
-    fire_post_document_hooks(str(pdf_path), collection, "")
+    fire_post_document_hooks(
+        str(pdf_path), collection, "",
+        doc_id=_lookup_existing_doc_id(str(pdf_path), corpus),
+    )
 
     return total_chunks
 

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -261,7 +261,11 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
             fire_post_store_hooks(_did, ctx.corpus, _doc)
         # RDR-089 document-grain chain — once per prose-file boundary.
         # content="" (chunk-level scope only); hook reads source_path.
-        fire_post_document_hooks(str(file_path), ctx.corpus, "")
+        # nexus-tdgc: forward catalog doc_id when available.
+        fire_post_document_hooks(
+            str(file_path), ctx.corpus, "",
+            doc_id=catalog_doc_id,
+        )
 
     return len(ids)
 

--- a/tests/test_aspect_extraction_queue.py
+++ b/tests/test_aspect_extraction_queue.py
@@ -165,6 +165,50 @@ class TestEnqueue:
         assert row.content == body
         assert row.content_hash == "hashabc"
 
+    def test_enqueue_with_doc_id_round_trips_via_claim(
+        self, tmp_path: Path,
+    ) -> None:
+        """nexus-tdgc: doc_id captured at enqueue is retrievable on
+        claim. WITH TEETH: a regression that drops the doc_id column
+        write or the claim_next read fails the round-trip assertion.
+        Worker uses this value to build a doc_id_lookup for the chroma
+        reader without a second catalog round-trip.
+        """
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            store.enqueue(
+                "knowledge__delos",
+                "/abs/path/paper.pdf",
+                content_hash="hash",
+                content="body",
+                doc_id="ART-deadbeef",
+            )
+            row = store.claim_next()
+        finally:
+            store.close()
+        assert row is not None
+        assert row.doc_id == "ART-deadbeef"
+
+    def test_enqueue_without_doc_id_defaults_to_empty(
+        self, tmp_path: Path,
+    ) -> None:
+        """Legacy callers that don't pass doc_id get an empty string
+        on the queue row; the worker treats this as a signal to fall
+        back to source_path-keyed extraction.
+        """
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            store.enqueue("docs__legacy", "/abs/path/doc.md")
+            row = store.claim_next()
+        finally:
+            store.close()
+        assert row is not None
+        assert row.doc_id == ""
+
 
 # ── Claim / mark_done / mark_failed / mark_retry ─────────────────────────────
 

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -73,7 +73,7 @@ class TestWorkerDrain:
         with T2Database(_isolate_t2) as db:
             db.aspect_queue.enqueue("knowledge__delos", "/p1.pdf")
 
-        def fake_extract(content, source_path, collection):
+        def fake_extract(content, source_path, collection, **_kw):
             return AspectRecord(
                 collection=collection,
                 source_path=source_path,
@@ -118,7 +118,7 @@ class TestWorkerDrain:
         with T2Database(_isolate_t2) as db:
             db.aspect_queue.enqueue("code__nexus", "/p1.py")
 
-        def fake_extract(content, source_path, collection):
+        def fake_extract(content, source_path, collection, **_kw):
             return None  # unsupported collection
 
         with patch("nexus.aspect_worker._extract_aspects", fake_extract):
@@ -150,7 +150,7 @@ class TestWorkerDrain:
 
         call_count = [0]
 
-        def fake_extract(content, source_path, collection):
+        def fake_extract(content, source_path, collection, **_kw):
             call_count[0] += 1
             return AspectRecord(
                 collection=collection,
@@ -216,7 +216,7 @@ class TestWorkerDrain:
         # Capture what extract_aspects sees.
         seen: list[tuple[str, str]] = []
 
-        def fake_extract(content, source_path, collection):
+        def fake_extract(content, source_path, collection, **_kw):
             seen.append((content, source_path))
             return AspectRecord(
                 collection=collection,
@@ -274,7 +274,7 @@ class TestWorkerDrain:
         with T2Database(_isolate_t2) as db:
             db.aspect_queue.enqueue("knowledge__delos", "/p1.pdf")
 
-        def fake_extract(content, source_path, collection):
+        def fake_extract(content, source_path, collection, **_kw):
             raise RuntimeError("worker-level failure (not extractor)")
 
         with patch("nexus.aspect_worker._extract_aspects", fake_extract):
@@ -513,7 +513,7 @@ class TestBatchPath:
                 for c, sp, _content in items
             ]
 
-        def fake_single(content, source_path, collection):
+        def fake_single(content, source_path, collection, **_kw):
             single_calls.append(source_path)
             raise AssertionError("single path should not fire on batch>=2")
 
@@ -564,7 +564,7 @@ class TestBatchPath:
             batch_calls.append(len(items))
             raise AssertionError("batch path should not fire for 1 row")
 
-        def fake_single(content, source_path, collection):
+        def fake_single(content, source_path, collection, **_kw):
             single_calls.append(source_path)
             return AspectRecord(
                 collection=collection, source_path=source_path,


### PR DESCRIPTION
RDR-101 Phase 4 follow-up. Implements the migration plan documented in `docs/migration/rdr-101-phase4-fire-chains-audit.md` (#475). Threads catalog `doc_id` through the document-grain post-store chain so the aspect-extraction worker can route the chroma reader to its `doc_id`-keyed lookup without a second catalog round-trip.

Closes `nexus-tdgc` and the implementation half of `nexus-buv0` (the audit-only PR #475 remains as the design record).

## Summary

**Queue schema** (`db/t2/aspect_extraction_queue.py`)
- `aspect_extraction_queue` gains `doc_id TEXT NOT NULL DEFAULT ''`. In-place `ALTER TABLE` migration during `_init_schema`; legacy rows fill with the empty string.
- `QueueRow` dataclass gains `doc_id: str = \"\"`.
- `enqueue()` accepts `doc_id` keyword; `claim_next()` reads/returns it.

**Hook signature** (`mcp_infra.py`)
- `fire_post_document_hooks(*, doc_id=\"\")` forwards the kwarg to every registered hook. Back-compat: if a hook predates the kwarg, the call retries without it (`TypeError` caught and re-issued).
- `fire_store_chains` zips its existing `doc_ids` list into the per-document fire calls.

**Hook implementation** (`aspect_worker.py`)
- `aspect_extraction_enqueue_hook` accepts `doc_id` and forwards to `queue.enqueue()` so the row carries it.
- Worker drain (`_process_row`) builds a `doc_id_lookup` callable from `row.doc_id` and passes it to `extract_aspects`. Empty `doc_id` passes `None` as the lookup; the extractor falls back to legacy probes.

**9 fire-site migrations**
- `mcp/core.py:944`: explicit `doc_id=` kwarg (the `source_path` positional was already the `doc_id` slug at the MCP boundary).
- `indexer.py:869`, `code_indexer.py:490`, `prose_indexer.py:264`: pull the existing `catalog_doc_id` local (RDR-101 Phase 3 plumbing) and pass it through.
- `doc_indexer.py:528, 1065, 1110`, `pipeline_stages.py:743`: pre-flight catalog lookup via `_lookup_existing_doc_id` (helper added in #470 / `nexus-dcym`).

## Test plan

- `test_enqueue_with_doc_id_round_trips_via_claim`: WITH-TEETH assertion that `doc_id` captured at enqueue is retrievable on `claim_next`.
- `test_enqueue_without_doc_id_defaults_to_empty`: legacy callers get empty string on the row; the worker fallback path engages.
- `aspect_worker` test fakes updated to accept `**_kw` so the new `doc_id_lookup` keyword passes through cleanly.
- 812 affected-module tests pass: `aspect`, `hook_drift`, `fire_post`, `fire_store`, `indexer`, `pipeline`, `doc_indexer`.

## Closes

Closes `nexus-tdgc` (queue schema + hook signature). The audit-only PR #475 satisfies `nexus-buv0`'s deliverable; both beads can close once this lands.

## Unblocks

`nexus-o6aa.10.3` (prune verb) — only `nexus-f4z9` (frecency) remains as a blocker after this merges.