### PR TITLE
feat(indexer): doc_id-keyed frecency-only update (nexus-f4z9)

### DIFF
--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -530,6 +530,48 @@ def index_repository(
                 pass  # already gone — harmless
 
 
+def _build_frecency_doc_id_map(
+    repo: Path, files: list[Path],
+) -> dict[Path, str]:
+    """nexus-f4z9: resolve each file's catalog ``doc_id`` so the
+    frecency-only update can key chunk lookups on ``doc_id`` instead
+    of ``source_path``. Returns a ``{abs_path: doc_id}`` mapping;
+    files without a catalog entry are absent from the map (the caller
+    falls back to the legacy ``source_path`` filter for those).
+
+    Best-effort: catalog absent / owner missing / lookup failure all
+    return an empty map so the caller's legacy path keeps working.
+    """
+    file_to_doc_id: dict[Path, str] = {}
+    try:
+        from nexus.catalog import Catalog
+        from nexus.config import catalog_path
+        from nexus.registry import _repo_identity
+
+        cat_path = catalog_path()
+        if not Catalog.is_initialized(cat_path):
+            return file_to_doc_id
+        cat = Catalog(cat_path, cat_path / ".catalog.db")
+        _, repo_hash = _repo_identity(repo)
+        owner = cat.owner_for_repo(repo_hash)
+        if owner is None:
+            return file_to_doc_id
+        for abs_path in files:
+            try:
+                rel_path = str(abs_path.relative_to(repo))
+            except ValueError:
+                rel_path = abs_path.name
+            try:
+                entry = cat.by_file_path(owner, rel_path)
+            except Exception:
+                continue
+            if entry is not None:
+                file_to_doc_id[abs_path] = str(entry.tumbler)
+    except Exception:
+        _log.debug("frecency_doc_id_map_failed", exc_info=True)
+    return file_to_doc_id
+
+
 def _run_index_frecency_only(repo: Path, registry: "RepoRegistry") -> None:
     """Update frecency_score metadata on all indexed chunks without re-embedding.
 
@@ -559,6 +601,12 @@ def _run_index_frecency_only(repo: Path, registry: "RepoRegistry") -> None:
     frecency_map = batch_frecency(repo)
     db = make_t3()
 
+    # nexus-f4z9: pre-resolve doc_ids once for all files so the chunk
+    # lookup can key on ``doc_id`` when the catalog has the entry.
+    # Files predating the catalog backfill fall through to the legacy
+    # ``source_path``-keyed filter.
+    file_to_doc_id = _build_frecency_doc_id_map(repo, list(frecency_map.keys()))
+
     # Update frecency in both collections
     collection_names = [code_collection]
     if docs_collection:
@@ -567,10 +615,12 @@ def _run_index_frecency_only(repo: Path, registry: "RepoRegistry") -> None:
     for collection_name in collection_names:
         col = db.get_or_create_collection(collection_name)
         for file, score in frecency_map.items():
+            doc_id = file_to_doc_id.get(file, "")
+            where = {"doc_id": doc_id} if doc_id else {"source_path": str(file)}
             existing = _paginated_get(
                 col,
                 include=["metadatas"],
-                where={"source_path": str(file)},
+                where=where,
             )
             if not existing["ids"]:
                 continue  # not yet indexed — needs full nx index repo

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -214,6 +214,65 @@ def test_frecency_only_updates_frecency_score(tmp_path):
     assert kw["metadatas"][0]["title"] == "main.py:1-1"
 
 
+def test_frecency_only_uses_doc_id_when_catalog_has_entry(tmp_path):
+    """nexus-f4z9: when the catalog has the file registered under
+    the repo owner, the chunk lookup keys on doc_id (post-prune
+    safe) instead of source_path. WITH TEETH: a regression that drops
+    the doc_id branch fails the where-filter assertion.
+    """
+    from nexus.indexer import _run_index_frecency_only
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    src = repo / "main.py"
+    src.write_text("x = 1\n")
+    old = {"frecency_score": 0.1, "source_path": str(src), "title": "main.py:1-1"}
+    col = MagicMock()
+    col.get.return_value = {"ids": ["c1"], "metadatas": [old]}
+    db = MagicMock()
+    db.get_or_create_collection.return_value = col
+
+    # Mock the catalog map so the file resolves to a known doc_id.
+    with patch(
+        "nexus.indexer._build_frecency_doc_id_map",
+        return_value={src: "1.1.1"},
+    ), \
+         patch("nexus.frecency.batch_frecency", return_value={src: 0.75}), \
+         patch("nexus.config.get_credential", return_value="fake-key"), \
+         patch("nexus.db.make_t3", return_value=db):
+        _run_index_frecency_only(repo, _reg())
+    where = col.get.call_args.kwargs["where"]
+    assert where == {"doc_id": "1.1.1"}, (
+        f"expected doc_id-keyed lookup, got {where!r}"
+    )
+
+
+def test_frecency_only_falls_back_to_source_path_when_no_catalog_entry(tmp_path):
+    """Files missing from the catalog map use the legacy source_path
+    filter so chunks predating the catalog backfill keep getting
+    frecency updates.
+    """
+    from nexus.indexer import _run_index_frecency_only
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    src = repo / "legacy.py"
+    src.write_text("z = 3\n")
+    old = {"frecency_score": 0.1, "source_path": str(src), "title": "legacy.py:1-1"}
+    col = MagicMock()
+    col.get.return_value = {"ids": ["c1"], "metadatas": [old]}
+    db = MagicMock()
+    db.get_or_create_collection.return_value = col
+    with patch(
+        "nexus.indexer._build_frecency_doc_id_map",
+        return_value={},
+    ), \
+         patch("nexus.frecency.batch_frecency", return_value={src: 0.42}), \
+         patch("nexus.config.get_credential", return_value="fake-key"), \
+         patch("nexus.db.make_t3", return_value=db):
+        _run_index_frecency_only(repo, _reg())
+    where = col.get.call_args.kwargs["where"]
+    assert where == {"source_path": str(src)}
+
+
 def test_frecency_only_skips_unindexed_files(tmp_path):
     from nexus.indexer import _run_index_frecency_only
     repo = tmp_path / "repo"; repo.mkdir()


### PR DESCRIPTION
RDR-101 Phase 4 final follow-up. `_run_index_frecency_only` previously called `col.get(where={'source_path': str(file)})` per file; with `source_path` slated for prune (`.10.3`), the lookup needs to switch to `doc_id`. Unlike the indexer-family sites migrated in #469, this function has no `_doc_id_resolver` in scope (it's a CLI entry that runs *after* main indexing, with no catalog hook fired during its execution), so the catalog read is done inline.

## Summary

- New helper `_build_frecency_doc_id_map(repo, files)` opens the catalog (best-effort), looks up the repo owner via `owner_for_repo`, and resolves each file via `cat.by_file_path`. Returns a `{abs_path: doc_id}` map; absent / missing-entry files simply aren't in the map.
- `_run_index_frecency_only` pre-resolves `doc_id`s once for the whole `frecency_map`, then per-file the where filter is `doc_id`-keyed when the map has the entry, `source_path`-keyed otherwise.

## Test plan (TDD)

- `test_frecency_only_uses_doc_id_when_catalog_has_entry`: WITH-TEETH assertion that the where filter is `{\"doc_id\": ...}` when the catalog has the file.
- `test_frecency_only_falls_back_to_source_path_when_no_catalog_entry`: legacy callers without a catalog still get the `source_path` filter.
- All 77 existing `test_indexer.py` tests pass unchanged.

## Closes

Closes `nexus-f4z9`. After this and `nexus-tdgc` (#478) merge, the prune verb (`.10.3`) has **zero remaining blockers**.