### PR TITLE
feat(catalog): nx catalog prune-deprecated-keys verb (nexus-o6aa.10.3)

### DIFF
--- a/docs/migration/rdr-101.md
+++ b/docs/migration/rdr-101.md
@@ -115,6 +115,70 @@ The structured warning in structlog and the `bootstrap_fallback` key
 in `nx catalog doctor --json` continue to surface the state for
 machine consumers regardless.
 
+## Phase 4 cleanup: `nx catalog prune-deprecated-keys`
+
+Once Phase 4's reader migration is complete (every site listed in
+`docs/migration/rdr-101-phase4-reader-audit.md` ships) the operator
+runs `nx catalog prune-deprecated-keys` to drop five legacy chunk
+metadata keys and free room under the 32-key Cloud quota for
+`doc_id` plus future fields:
+
+* `source_path`
+* `git_branch`
+* `git_commit_hash`
+* `git_project_name`
+* `git_remote_url`
+
+`title` is intentionally *not* in this set; the `.10.2` audit
+(Category C) keeps it permanently as the slug-shaped identity for
+`knowledge__knowledge` and the universal display field across
+formatters.
+
+### Pre-flight gates
+
+The verb refuses to run unless both gates are clear:
+
+1. `--i-have-completed-the-reader-migration` is present. Without the
+   acknowledgement the verb errors out with a pointer at the audit
+   doc.
+2. `nx catalog doctor --t3-doc-id-coverage` reports 100% on every
+   target collection. Override with `--skip-coverage-check` only if
+   you have decided what to do about the missing-doc_id chunks; the
+   prune leaves them strictly unreachable for the post-Phase-5 reader.
+
+### Operator workflow
+
+```bash
+# 1. Confirm coverage on the target catalog.
+nx catalog doctor --t3-doc-id-coverage --json
+
+# 2. Dry-run to size the prune (no col.update calls issued).
+nx catalog prune-deprecated-keys --dry-run \
+    --i-have-completed-the-reader-migration
+
+# 3. Stage per-collection (recommended on a large catalog).
+nx catalog prune-deprecated-keys \
+    --collection knowledge__knowledge \
+    --i-have-completed-the-reader-migration
+
+# 4. Or sweep every collection at once.
+nx catalog prune-deprecated-keys \
+    --i-have-completed-the-reader-migration
+```
+
+The verb is idempotent: chunks that already lack the deprecated keys
+report as `chunks_already_pruned` and write nothing. Bisect-on-
+failure (`.9.19` pattern) isolates failing chunks in O(log N) update
+calls when batch-level Cloud quotas reject a slice.
+
+### Post-prune backfill
+
+After the prune lands, `nx catalog t3-backfill-doc-id --resume`
+should drain the `chunks_deferred` class to zero (the freed key
+slots are what blocked the previous backfill on over-cap chunks).
+`docs/migration/rdr-101-live-migration-postmortem.md` tracks the
+live numbers as that runs.
+
 ## Failure modes and recovery
 
 | Failure | Symptom | Recovery |

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -4951,3 +4951,332 @@ def migrate_cmd(
     )
 
     click.echo("\nMigration complete.")
+
+
+# ── RDR-101 Phase 4: prune-deprecated-keys verb (nexus-o6aa.10.3) ─────────
+
+
+# Five legacy chunk-metadata keys that the Phase 4 reader migrations
+# stopped depending on. ``title`` is intentionally NOT in this set; the
+# .10.2 audit (docs/migration/rdr-101-phase4-reader-audit.md, Category C)
+# kept it permanently as the slug-shaped identity for ``knowledge__knowledge``
+# and the universal display field across formatters.
+_PRUNE_DEPRECATED_KEYS: frozenset[str] = frozenset({
+    "source_path",
+    "git_branch",
+    "git_commit_hash",
+    "git_project_name",
+    "git_remote_url",
+})
+
+
+@catalog.command("prune-deprecated-keys")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help=(
+        "Walk every collection and report what would change without "
+        "calling col.update. Use to size the prune (per-collection "
+        "chunk count, total deprecated-key occurrences) before "
+        "committing."
+    ),
+)
+@click.option(
+    "--collection",
+    "collection_filter",
+    default="",
+    help=(
+        "Restrict the prune to one collection name. Default: every "
+        "collection in T3. Use to stage a per-collection rollout."
+    ),
+)
+@click.option(
+    "--json", "as_json", is_flag=True,
+    help="Emit machine-readable JSON instead of text output.",
+)
+@click.option(
+    "--i-have-completed-the-reader-migration",
+    "reader_migration_done",
+    is_flag=True,
+    default=False,
+    help=(
+        "REQUIRED. Acknowledges that every audit-listed reader "
+        "(docs/migration/rdr-101-phase4-reader-audit.md) has migrated "
+        "to doc_id-keyed lookups. Without this flag the verb refuses "
+        "to run; pruning before the readers migrate produces silent "
+        "empty results across aspect extraction, link boost, "
+        "incremental sync, and display formatters."
+    ),
+)
+@click.option(
+    "--skip-coverage-check",
+    is_flag=True,
+    default=False,
+    help=(
+        "Bypass the --t3-doc-id-coverage gate. The default refuses "
+        "to run on a collection whose chunks aren't 100%% covered by "
+        "doc_id metadata. Override is for operators who have a known "
+        "orphan-chunk class they intend to clean up post-prune."
+    ),
+)
+def prune_deprecated_keys_cmd(
+    dry_run: bool,
+    collection_filter: str,
+    as_json: bool,
+    reader_migration_done: bool,
+    skip_coverage_check: bool,
+) -> None:
+    """RDR-101 Phase 4: drop legacy metadata keys from every T3 chunk.
+
+    Removes the five keys whose readers migrated to doc_id-keyed
+    catalog lookups in Phase 4: ``source_path``, ``git_branch``,
+    ``git_commit_hash``, ``git_project_name``, ``git_remote_url``.
+    Idempotent: chunks that already lack the keys are no-ops.
+
+    The chunk metadata key budget on ChromaDB Cloud is 32 top-level
+    keys (``MAX_SAFE_TOP_LEVEL_KEYS``). Over-cap chunks on Hal's
+    catalog carry 35-36 keys; dropping these five brings them to
+    30-31 keys and leaves room for ``doc_id`` + future additions.
+
+    Pre-flight gates (refuse to proceed unless overridden):
+    - ``--i-have-completed-the-reader-migration`` is required. Without
+      it the verb errors out with the migration audit doc reference.
+    - Per-collection ``--t3-doc-id-coverage = 100%%`` (the
+      ``nx catalog doctor --t3-doc-id-coverage`` check). Override with
+      ``--skip-coverage-check`` only after deciding what to do about
+      the missing-doc_id chunks; the prune leaves them strictly
+      unreachable for the post-Phase-5 reader.
+
+    Bisect-on-failure (mirrors ``t3-backfill-doc-id`` per .9.19): on
+    a batch update failure, halve and recurse to isolate failing
+    chunks in O(log N) update calls instead of O(N) per-chunk retry.
+    """
+    from nexus.catalog.catalog import Catalog
+    from nexus.config import catalog_path
+    from nexus.db import make_t3
+
+    cat_dir = catalog_path()
+    if not Catalog.is_initialized(cat_dir):
+        raise click.ClickException(
+            f"Catalog not initialized at {cat_dir}. "
+            "Run 'nx catalog setup' to create and populate it."
+        )
+
+    if not reader_migration_done:
+        raise click.ClickException(
+            "Refusing to prune. The Phase 4 reader migration must be "
+            "complete first; pruning ahead of the readers produces "
+            "silent empty results.\n\n"
+            "Read docs/migration/rdr-101-phase4-reader-audit.md for "
+            "the migration scope, verify every listed reader has "
+            "shipped, then re-run with "
+            "--i-have-completed-the-reader-migration."
+        )
+
+    try:
+        t3 = make_t3()
+    except Exception as exc:
+        raise click.ClickException(
+            f"Failed to open T3 client: {exc}. Check ChromaDB credentials."
+        )
+
+    # Resolve target collections.
+    if collection_filter:
+        target_collections = [collection_filter]
+    else:
+        try:
+            target_collections = [
+                c["name"] if isinstance(c, dict) else c.name
+                for c in t3.list_collections()
+            ]
+        except Exception as exc:
+            raise click.ClickException(
+                f"Failed to list collections: {exc}"
+            )
+
+    # Coverage gate. Reuse the doctor's projection; refuse if any
+    # target collection drops below 100%.
+    if not skip_coverage_check:
+        try:
+            coverage_report = _run_t3_doc_id_coverage()
+        except click.ClickException:
+            raise
+        except Exception as exc:
+            raise click.ClickException(
+                f"Coverage check failed: {exc}. Re-run with "
+                "--skip-coverage-check to override."
+            )
+        per_coll = coverage_report.get("tables", {})
+        offenders: list[dict] = []
+        for name in target_collections:
+            row = per_coll.get(name)
+            if row is None:
+                continue  # not in events.jsonl: nothing claimed; skip.
+            total = row.get("total_chunks", 0)
+            with_doc_id = row.get("with_doc_id", 0)
+            if total > 0 and with_doc_id < total:
+                offenders.append({
+                    "collection": name,
+                    "total": total,
+                    "with_doc_id": with_doc_id,
+                    "missing": total - with_doc_id,
+                })
+        if offenders:
+            lines = [
+                f"  {o['collection']}: {o['with_doc_id']}/{o['total']} "
+                f"covered (missing={o['missing']})"
+                for o in offenders
+            ]
+            raise click.ClickException(
+                "Refusing to prune. The following collections have "
+                "chunks whose doc_id is unpopulated; pruning would "
+                "leave them strictly unreachable:\n"
+                + "\n".join(lines)
+                + "\n\nRun 'nx catalog t3-backfill-doc-id' on each, "
+                "or pass --skip-coverage-check to proceed anyway."
+            )
+
+    # Walk + rewrite.
+    import time as _time
+    show_progress = not dry_run and not as_json
+    chunks_updated = 0
+    chunks_already_pruned = 0
+    chunks_deferred: list[dict] = []
+    errors: list[dict] = []
+    per_collection_summary: dict[str, dict] = {}
+
+    for coll_idx, coll_name in enumerate(target_collections, start=1):
+        try:
+            col = t3._client.get_collection(name=coll_name)
+        except Exception as exc:
+            errors.append({
+                "collection": coll_name,
+                "stage": "open",
+                "error": str(exc),
+            })
+            continue
+
+        if show_progress:
+            click.echo(
+                f"  [prune {coll_idx}/{len(target_collections)}] "
+                f"{coll_name}…",
+                err=True,
+            )
+        _tc = _time.monotonic()
+        coll_updated_before = chunks_updated
+        coll_already_before = chunks_already_pruned
+
+        offset = 0
+        while True:
+            try:
+                page = col.get(
+                    limit=300, offset=offset, include=["metadatas"],
+                )
+            except Exception as exc:
+                errors.append({
+                    "collection": coll_name,
+                    "stage": "read",
+                    "offset": offset,
+                    "error": str(exc),
+                })
+                break
+            ids = page.get("ids") or []
+            metas = page.get("metadatas") or []
+            if not ids:
+                break
+            update_ids: list[str] = []
+            update_metas: list[dict] = []
+            for cid, meta in zip(ids, metas):
+                meta = meta or {}
+                deprecated_present = _PRUNE_DEPRECATED_KEYS.intersection(meta)
+                if not deprecated_present:
+                    chunks_already_pruned += 1
+                    continue
+                # ChromaDB's ``col.update(metadatas=...)`` MERGES rather
+                # than replaces; passing only the kept keys leaves the
+                # deprecated keys in place. The delete-key shape is
+                # ``{key: None}``, which removes the key from storage.
+                deletion_patch: dict = {k: None for k in deprecated_present}
+                update_ids.append(cid)
+                update_metas.append(deletion_patch)
+
+            if update_ids and not dry_run:
+                ok, deferred_records, error_records = _bisect_update(
+                    col, update_ids, update_metas, coll_name,
+                )
+                chunks_updated += ok
+                chunks_deferred.extend(deferred_records)
+                errors.extend(error_records)
+            elif update_ids:
+                # Dry run: count what would change.
+                chunks_updated += len(update_ids)
+
+            if len(ids) < 300:
+                break
+            offset += 300
+
+        per_collection_summary[coll_name] = {
+            "updated": chunks_updated - coll_updated_before,
+            "already_pruned": chunks_already_pruned - coll_already_before,
+            "elapsed_seconds": round(_time.monotonic() - _tc, 2),
+        }
+
+        if show_progress:
+            updated_here = chunks_updated - coll_updated_before
+            elapsed = _time.monotonic() - _tc
+            click.echo(
+                f"  [prune {coll_idx}/{len(target_collections)}] "
+                f"{coll_name}: {updated_here} updated "
+                f"in {elapsed:.1f}s",
+                err=True,
+            )
+
+    report = {
+        "dry_run": dry_run,
+        "collection_filter": collection_filter or "(all)",
+        "deprecated_keys": sorted(_PRUNE_DEPRECATED_KEYS),
+        "chunks_updated": chunks_updated,
+        "chunks_already_pruned": chunks_already_pruned,
+        "chunks_deferred": chunks_deferred,
+        "errors": errors,
+        "per_collection": per_collection_summary,
+    }
+
+    if as_json:
+        click.echo(json.dumps(report, indent=2, default=str))
+    else:
+        _print_prune_deprecated_keys_text(report)
+
+    if errors:
+        raise click.exceptions.Exit(1)
+
+
+def _print_prune_deprecated_keys_text(report: dict) -> None:
+    """Render the prune-deprecated-keys report in plain text."""
+    if report["dry_run"]:
+        click.echo("DRY RUN: no col.update calls issued.")
+    click.echo(
+        f"Pruned keys: {', '.join(report['deprecated_keys'])}"
+    )
+    click.echo(f"  chunks_updated:        {report['chunks_updated']}")
+    click.echo(f"  chunks_already_pruned: {report['chunks_already_pruned']}")
+    if report["chunks_deferred"]:
+        click.echo(
+            f"  chunks_deferred:       {len(report['chunks_deferred'])}"
+        )
+    if report["errors"]:
+        click.echo(f"  errors:                {len(report['errors'])}")
+        for err in report["errors"][:5]:
+            click.echo(f"    {err}")
+        if len(report["errors"]) > 5:
+            click.echo(
+                f"    ... and {len(report['errors']) - 5} more"
+            )
+    if report["per_collection"]:
+        click.echo("\nPer collection:")
+        for name, summary in sorted(report["per_collection"].items()):
+            click.echo(
+                f"  {name:<40}  updated={summary['updated']}  "
+                f"already={summary['already_pruned']}  "
+                f"elapsed={summary['elapsed_seconds']}s"
+            )

--- a/tests/test_catalog_prune_deprecated_keys.py
+++ b/tests/test_catalog_prune_deprecated_keys.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for the RDR-101 Phase 4 ``nx catalog prune-deprecated-keys`` verb.
+
+Coverage:
+- Refuses without ``--i-have-completed-the-reader-migration``.
+- Refuses on doc_id coverage gap (``--skip-coverage-check`` overrides).
+- Drops the 5 deprecated keys, preserves ``title`` + all other keys.
+- Idempotent: a second run on already-pruned chunks is a no-op.
+- ``--collection`` filter scopes the prune.
+- ``--dry-run`` reports without writing.
+- ``--json`` emits a structured report.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.catalog import events as ev
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.event_log import EventLog
+from nexus.commands.catalog import (
+    _PRUNE_DEPRECATED_KEYS,
+    prune_deprecated_keys_cmd,
+)
+
+
+@pytest.fixture
+def isolated_nexus(tmp_path: Path) -> Path:
+    return tmp_path / "test-catalog"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def chroma_client():
+    client = chromadb.EphemeralClient()
+    for col in list(client.list_collections()):
+        try:
+            client.delete_collection(col.name)
+        except Exception:
+            pass
+    return client
+
+
+def _seed(client, name: str, chunks: list[dict]) -> None:
+    col = client.get_or_create_collection(
+        name=name, embedding_function=DefaultEmbeddingFunction(),
+    )
+    col.add(
+        ids=[c["id"] for c in chunks],
+        documents=[c["content"] for c in chunks],
+        metadatas=[c["metadata"] for c in chunks],
+    )
+
+
+def _seed_event_log(catalog_dir: Path, events: list[ev.Event]) -> None:
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    Catalog.init(catalog_dir)
+    log = EventLog(catalog_dir)
+    log.append_many(events)
+
+
+def _chunk_event(
+    chunk_id: str, doc_id: str, coll_id: str,
+    *, synthesized_orphan: bool = False,
+) -> ev.Event:
+    return ev.Event(
+        type=ev.TYPE_CHUNK_INDEXED, v=0,
+        payload=ev.ChunkIndexedPayload(
+            chunk_id=chunk_id, chash="h", doc_id=doc_id,
+            coll_id=coll_id, position=0,
+            synthesized_orphan=synthesized_orphan,
+        ),
+        ts="2026-04-30T00:00:00Z",
+    )
+
+
+def _full_meta(doc_id: str = "ART-x") -> dict:
+    """Pre-prune chunk metadata: 5 deprecated keys + title + a few survivors."""
+    return {
+        # The 5 keys this verb drops.
+        "source_path": "/abs/path/file.py",
+        "git_branch": "main",
+        "git_commit_hash": "deadbeef",
+        "git_project_name": "nexus",
+        "git_remote_url": "https://github.com/Hellblazer/nexus.git",
+        # Permanently kept (per the .10.2 audit, Category C).
+        "title": "file.py:1-10",
+        # Other survivors.
+        "doc_id": doc_id,
+        "chunk_text_hash": "abc",
+        "indexed_at": "2026-04-30T00:00:00Z",
+        "chunk_index": 0,
+    }
+
+
+# ── Pre-flight gates ────────────────────────────────────────────────────────
+
+
+class TestReaderMigrationGate:
+    def test_refuses_without_reader_migration_flag(
+        self, isolated_nexus, runner,
+    ):
+        """nexus-o6aa.10.3: pruning before the readers migrate produces
+        silent empty results across aspect extraction, link boost,
+        incremental sync, and display formatters. The verb refuses to
+        run unless the operator acknowledges the migration is complete.
+        """
+        Catalog.init(isolated_nexus)
+        result = runner.invoke(prune_deprecated_keys_cmd, ["--dry-run"])
+        assert result.exit_code != 0
+        assert "reader migration must be complete" in result.output.lower()
+        assert "rdr-101-phase4-reader-audit.md" in result.output
+
+    def test_missing_catalog_errors_before_gate(
+        self, isolated_nexus, runner,
+    ):
+        result = runner.invoke(
+            prune_deprecated_keys_cmd,
+            ["--i-have-completed-the-reader-migration", "--dry-run"],
+        )
+        assert result.exit_code != 0
+        assert "not initialized" in result.output.lower()
+
+
+class TestCoverageGate:
+    def test_refuses_on_coverage_gap(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """When the doctor's t3-doc-id-coverage reports < 100% on a
+        target collection, the prune verb refuses to run rather than
+        leave the missing-doc_id chunks strictly unreachable.
+        """
+        # Event log claims a chunk; T3 has chunks but one lacks doc_id
+        # so coverage drops below 100%.
+        events = [_chunk_event("ch1", "ART-A", "code__test")]
+        _seed_event_log(isolated_nexus, events)
+        meta_no_doc_id = {k: v for k, v in _full_meta().items() if k != "doc_id"}
+        _seed(chroma_client, "code__test", [
+            {"id": "ch1", "content": "x", "metadata": meta_no_doc_id},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+            def list_collections(self_inner):
+                return [{"name": "code__test"}]
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        result = runner.invoke(
+            prune_deprecated_keys_cmd,
+            ["--i-have-completed-the-reader-migration"],
+        )
+        assert result.exit_code != 0
+        assert "refusing to prune" in result.output.lower()
+        assert "covered" in result.output.lower()
+
+    def test_skip_coverage_check_proceeds(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """``--skip-coverage-check`` bypasses the gate. The prune
+        proceeds even when chunks lack doc_id; the operator has
+        decided what to do about the orphan class post-prune.
+        """
+        Catalog.init(isolated_nexus)
+        _seed(chroma_client, "code__test", [
+            {"id": "ch1", "content": "x", "metadata": _full_meta()},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+            def list_collections(self_inner):
+                return [{"name": "code__test"}]
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        result = runner.invoke(
+            prune_deprecated_keys_cmd,
+            [
+                "--i-have-completed-the-reader-migration",
+                "--skip-coverage-check",
+                "--collection", "code__test",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["chunks_updated"] == 1
+
+
+# ── Prune behaviour ─────────────────────────────────────────────────────────
+
+
+class TestPruneBehaviour:
+    def test_drops_five_keys_preserves_title_and_others(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """WITH TEETH: the post-prune chunk has none of the 5 deprecated
+        keys, but ``title`` and every other key are preserved verbatim.
+        A regression that drops ``title`` (per the original 6-key design,
+        rejected by the .10.2 audit) fails here.
+        """
+        Catalog.init(isolated_nexus)
+        _seed(chroma_client, "code__test", [
+            {"id": "ch1", "content": "x", "metadata": _full_meta("ART-A")},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+            def list_collections(self_inner):
+                return [{"name": "code__test"}]
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        result = runner.invoke(
+            prune_deprecated_keys_cmd,
+            [
+                "--i-have-completed-the-reader-migration",
+                "--skip-coverage-check",
+                "--collection", "code__test",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        col = chroma_client.get_collection("code__test")
+        meta = col.get(ids=["ch1"], include=["metadatas"])["metadatas"][0]
+        # All 5 deprecated keys gone.
+        for k in _PRUNE_DEPRECATED_KEYS:
+            assert k not in meta, (
+                f"deprecated key {k!r} still present after prune"
+            )
+        # Title kept (audit Category C: load-bearing).
+        assert meta["title"] == "file.py:1-10"
+        # Every other survivor kept.
+        assert meta["doc_id"] == "ART-A"
+        assert meta["chunk_text_hash"] == "abc"
+        assert meta["indexed_at"] == "2026-04-30T00:00:00Z"
+        assert meta["chunk_index"] == 0
+
+    def test_idempotent_second_run_is_noop(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Re-running the verb on already-pruned chunks reports them
+        as ``already_pruned`` and writes nothing.
+        """
+        Catalog.init(isolated_nexus)
+        _seed(chroma_client, "code__test", [
+            {"id": "ch1", "content": "x", "metadata": _full_meta()},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+            def list_collections(self_inner):
+                return [{"name": "code__test"}]
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        first = runner.invoke(
+            prune_deprecated_keys_cmd,
+            [
+                "--i-have-completed-the-reader-migration",
+                "--skip-coverage-check",
+                "--collection", "code__test",
+                "--json",
+            ],
+        )
+        assert first.exit_code == 0
+        first_payload = json.loads(first.output)
+        assert first_payload["chunks_updated"] == 1
+        assert first_payload["chunks_already_pruned"] == 0
+
+        second = runner.invoke(
+            prune_deprecated_keys_cmd,
+            [
+                "--i-have-completed-the-reader-migration",
+                "--skip-coverage-check",
+                "--collection", "code__test",
+                "--json",
+            ],
+        )
+        assert second.exit_code == 0
+        second_payload = json.loads(second.output)
+        assert second_payload["chunks_updated"] == 0
+        assert second_payload["chunks_already_pruned"] == 1
+
+    def test_dry_run_reports_without_writing(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        Catalog.init(isolated_nexus)
+        _seed(chroma_client, "code__test", [
+            {"id": "ch1", "content": "x", "metadata": _full_meta()},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+            def list_collections(self_inner):
+                return [{"name": "code__test"}]
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        result = runner.invoke(
+            prune_deprecated_keys_cmd,
+            [
+                "--i-have-completed-the-reader-migration",
+                "--skip-coverage-check",
+                "--collection", "code__test",
+                "--dry-run", "--json",
+            ],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["dry_run"] is True
+        assert payload["chunks_updated"] == 1
+
+        # No actual update: keys still present.
+        col = chroma_client.get_collection("code__test")
+        meta = col.get(ids=["ch1"], include=["metadatas"])["metadatas"][0]
+        assert "source_path" in meta
+
+
+class TestCollectionFilter:
+    def test_filter_scopes_prune(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        Catalog.init(isolated_nexus)
+        _seed(chroma_client, "code__a", [
+            {"id": "ch-a", "content": "x", "metadata": _full_meta()},
+        ])
+        _seed(chroma_client, "code__b", [
+            {"id": "ch-b", "content": "y", "metadata": _full_meta()},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+            def list_collections(self_inner):
+                return [{"name": "code__a"}, {"name": "code__b"}]
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        result = runner.invoke(
+            prune_deprecated_keys_cmd,
+            [
+                "--i-have-completed-the-reader-migration",
+                "--skip-coverage-check",
+                "--collection", "code__a",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["chunks_updated"] == 1
+        assert payload["collection_filter"] == "code__a"
+
+        # code__a pruned; code__b untouched.
+        col_a = chroma_client.get_collection("code__a")
+        meta_a = col_a.get(ids=["ch-a"], include=["metadatas"])["metadatas"][0]
+        assert "source_path" not in meta_a
+
+        col_b = chroma_client.get_collection("code__b")
+        meta_b = col_b.get(ids=["ch-b"], include=["metadatas"])["metadatas"][0]
+        assert "source_path" in meta_b
+
+
+class TestKeyConstants:
+    def test_deprecated_keys_match_audit(self):
+        """Lock the 5-key set against the .10.2 audit's Category B
+        recommendation. Title is intentionally absent (Category C).
+        """
+        assert _PRUNE_DEPRECATED_KEYS == frozenset({
+            "source_path",
+            "git_branch",
+            "git_commit_hash",
+            "git_project_name",
+            "git_remote_url",
+        })
+        assert "title" not in _PRUNE_DEPRECATED_KEYS, (
+            "title is load-bearing (slug-shaped knowledge identity + "
+            "universal display field); audit Category C keeps it."
+        )


### PR DESCRIPTION
RDR-101 Phase 4. Implements the verb that mechanically clears the deferred-class population from Hal's catalog: drops 5 legacy metadata keys (`source_path`, `git_branch`, `git_commit_hash`, `git_project_name`, `git_remote_url`) from every T3 chunk so over-cap chunks fit under the 32-key Cloud quota with room for `doc_id`.

The `.10.2` audit (Category C) confirmed `title` is load-bearing (`knowledge__knowledge` slug identity + universal display field) and must NOT be pruned. **Five keys, not six.**

## Verb shape

Mirrors `t3-backfill-doc-id` for operator consistency:
- `--dry-run`: walk-and-report without `col.update` calls.
- `--collection NAME`: scope to one collection.
- `--json`: structured report for CI/operator tooling.
- `--i-have-completed-the-reader-migration`: **REQUIRED**. Without it the verb errors out pointing at the audit doc. Pruning ahead of the readers produces silent empty results across aspect extraction, link boost, incremental sync, and display formatters.
- `--skip-coverage-check`: bypass the `t3-doc-id-coverage = 100%` gate. Default refuses to run on a collection with missing `doc_id`; the prune would leave those chunks strictly unreachable.

## Implementation note

ChromaDB merge-vs-replace gotcha: `col.update(metadatas=...)` MERGES key-by-key (passing only the kept keys leaves deprecated ones in place). The delete-key shape is `{key: None}` which removes the key from storage. The verb sends a deletion patch (not a slimmed copy).

Bisect-on-failure: reuses `_bisect_update` from `.9.19` so a 1-of-300 failing chunk costs O(log N) update calls instead of O(N).

## Test plan (9 cases)

- Refuses without `--i-have-completed-the-reader-migration`.
- Refuses on coverage gap; `--skip-coverage-check` overrides.
- Drops the 5 keys, preserves `title` + every other key (WITH-TEETH on the 5-vs-6 audit decision).
- Idempotent second run (`chunks_already_pruned` increments).
- `--collection` filter scopes the prune.
- `--dry-run` reports without writing.
- `_PRUNE_DEPRECATED_KEYS` constant locked against the audit set.
- 991 affected-module tests pass (catalog + t3_backfill + doctor + prune).

## Operator docs

`docs/migration/rdr-101.md` gains a Phase 4 cleanup section with the operator workflow + post-prune backfill instructions.

## Closes

Closes `nexus-o6aa.10.3`. After this lands and the operator runs the verb against the live catalog (followed by `t3-backfill-doc-id --resume` to drain the now-fittable deferred class), Phase 4 is structurally complete; only `nexus-o6aa.10.4` (post-prune docs) remains.