### PR TITLE
fix(indexer): catalog hook + staleness escape route for ghost chunks

### DIFF
--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -283,6 +283,14 @@ def _catalog_hook(
         _progress = sys.stderr.write
         _progress(f"  Catalog: registering {len(indexed_files)} files…\r")
         new_tumblers = []
+        # nexus-o6aa.10.4 follow-up: track per-file failures so the
+        # catalog hook stops failing silently. Pre-fix, a single
+        # cat.register() exception inside the loop tripped the outer
+        # except at line ~362 which logs at DEBUG, suppressing the
+        # rest of the registrations and leaving file_to_doc_id empty
+        # for every subsequent file in this run. Found via Hal's
+        # ghost-chunk class on 2026-05-02.
+        skipped_files: list[tuple[Path, str]] = []
         for abs_path, content_type, collection_name in indexed_files:
             try:
                 rel_path = str(abs_path.relative_to(repo))
@@ -314,30 +322,54 @@ def _catalog_hook(
             except OSError:
                 file_hash = ""
 
-            existing = cat.by_file_path(owner, rel_path)
-            if existing is None:
-                tumbler = cat.register(
-                    owner=owner,
-                    title=abs_path.name,
-                    content_type=content_type,
-                    file_path=rel_path,
-                    physical_collection=collection_name,
-                    head_hash=head_hash,
-                    meta={"content_hash": file_hash} if file_hash else None,
-                    source_mtime=source_mtime,
+            try:
+                existing = cat.by_file_path(owner, rel_path)
+                if existing is None:
+                    tumbler = cat.register(
+                        owner=owner,
+                        title=abs_path.name,
+                        content_type=content_type,
+                        file_path=rel_path,
+                        physical_collection=collection_name,
+                        head_hash=head_hash,
+                        meta={"content_hash": file_hash} if file_hash else None,
+                        source_mtime=source_mtime,
+                    )
+                    new_tumblers.append(tumbler)
+                    file_to_doc_id[abs_path] = str(tumbler)
+                else:
+                    cat.update(
+                        existing.tumbler,
+                        head_hash=head_hash,
+                        physical_collection=collection_name,
+                        meta={"content_hash": file_hash} if file_hash else None,
+                        source_mtime=source_mtime,
+                    )
+                    file_to_doc_id[abs_path] = str(existing.tumbler)
+            except Exception as exc:
+                # Per-file failure must NOT abort the rest of the loop.
+                # The previous behaviour swallowed every subsequent
+                # registration too, leaving the entire repo's chunks
+                # without doc_id metadata (the ghost class).
+                skipped_files.append((abs_path, str(exc)))
+                _log.warning(
+                    "catalog_hook_register_failed",
+                    rel_path=rel_path,
+                    abs_path=str(abs_path),
+                    error=str(exc),
+                    exc_info=True,
                 )
-                new_tumblers.append(tumbler)
-                file_to_doc_id[abs_path] = str(tumbler)
-            else:
-                cat.update(
-                    existing.tumbler,
-                    head_hash=head_hash,
-                    physical_collection=collection_name,
-                    meta={"content_hash": file_hash} if file_hash else None,
-                    source_mtime=source_mtime,
-                )
-                file_to_doc_id[abs_path] = str(existing.tumbler)
-        _progress(f"  Catalog: {len(new_tumblers)} new, {len(indexed_files) - len(new_tumblers)} updated\n")
+        if skipped_files:
+            _progress(
+                f"  Catalog: {len(new_tumblers)} new, "
+                f"{len(indexed_files) - len(new_tumblers) - len(skipped_files)} updated, "
+                f"{len(skipped_files)} skipped (see structlog warnings)\n"
+            )
+        else:
+            _progress(
+                f"  Catalog: {len(new_tumblers)} new, "
+                f"{len(indexed_files) - len(new_tumblers)} updated\n"
+            )
 
         # Auto-generate links after registration (incremental: only new entries)
         links_created = 0

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -215,10 +215,23 @@ def check_staleness(
     if not existing["metadatas"]:
         return False
     stored = existing["metadatas"][0]
-    return (
-        stored.get("content_hash") == content_hash
-        and stored.get("embedding_model") == embedding_model
-    )
+    if (
+        stored.get("content_hash") != content_hash
+        or stored.get("embedding_model") != embedding_model
+    ):
+        return False
+    # nexus-o6aa.10.4 follow-up: ghost-chunk class. Stored chunk
+    # matches content_hash + model but lacks doc_id metadata. The
+    # staleness check would normally return True (skip re-index) and
+    # the ghost would persist forever. When the caller has a non-empty
+    # doc_id resolver result for this file, treat the stored chunk as
+    # metadata-stale so the indexer re-upserts and the ghost gets a
+    # doc_id. Found on Hal's catalog 2026-05-02: 499 chunks indexed
+    # under an old branch when the catalog hook silently failed,
+    # surviving content-hash dedup on every subsequent re-index.
+    if doc_id and not stored.get("doc_id"):
+        return False
+    return True
 
 
 def check_credentials(voyage_key: str, chroma_key: str) -> None:

--- a/tests/test_indexer_modules.py
+++ b/tests/test_indexer_modules.py
@@ -75,7 +75,11 @@ def test_check_staleness_uses_doc_id_when_provided(tmp_path):
     """
     mock_col = MagicMock()
     mock_col.get.return_value = {
-        "metadatas": [{"content_hash": "abc", "embedding_model": "voyage-code-3"}],
+        "metadatas": [{
+            "content_hash": "abc",
+            "embedding_model": "voyage-code-3",
+            "doc_id": "ART-deadbeef",
+        }],
         "ids": ["id1"],
     }
     result = check_staleness(
@@ -95,6 +99,50 @@ def test_check_staleness_falls_back_to_source_path_when_no_doc_id(tmp_path):
     check_staleness(mock_col, file_path, "abc", "voyage-code-3")
     where = mock_col.get.call_args.kwargs["where"]
     assert where == {"source_path": str(file_path)}
+
+
+def test_check_staleness_treats_chunk_without_doc_id_as_stale(tmp_path):
+    """nexus-o6aa.10.4 follow-up: ghost-chunk class. Stored chunk
+    matches content_hash + model but lacks doc_id metadata. When the
+    caller has a non-empty doc_id (catalog hook resolved it this run),
+    return False so the indexer re-upserts and writes the missing
+    doc_id. WITH TEETH: a regression that drops this branch resurrects
+    Hal's 499-chunk ghost class.
+    """
+    mock_col = MagicMock()
+    mock_col.get.return_value = {
+        "metadatas": [
+            # Stored chunk: matches content + model but no doc_id.
+            {"content_hash": "abc", "embedding_model": "voyage-code-3"},
+        ],
+        "ids": ["chunk-0"],
+    }
+    result = check_staleness(
+        mock_col, tmp_path / "foo.py", "abc", "voyage-code-3",
+        doc_id="ART-deadbeef",
+    )
+    assert result is False, (
+        "stored chunk lacks doc_id but the caller has one to write; "
+        "staleness must return False so the chunk gets re-upserted"
+    )
+
+
+def test_check_staleness_passes_when_chunk_has_matching_doc_id(tmp_path):
+    """Inverse: stored chunk has the same doc_id as caller → still stale."""
+    mock_col = MagicMock()
+    mock_col.get.return_value = {
+        "metadatas": [{
+            "content_hash": "abc",
+            "embedding_model": "voyage-code-3",
+            "doc_id": "ART-deadbeef",
+        }],
+        "ids": ["chunk-0"],
+    }
+    result = check_staleness(
+        mock_col, tmp_path / "foo.py", "abc", "voyage-code-3",
+        doc_id="ART-deadbeef",
+    )
+    assert result is True
 
 
 # ── check_credentials ────────────────────────────────────────────────────────


### PR DESCRIPTION
Two related fixes for the silent-failure path that produced 499 ghost chunks on Hal's catalog (chunks indexed without `doc_id` metadata, surviving every re-index via content-hash dedup).

## Diagnosis

Live finding 2026-05-02: 499 chunks in `code__nexus-571b8edd` had `indexed_at: 2026-05-02T02:03` but no `doc_id` field at all. `git_meta` showed branch `feature/nexus-o6aa-9-18-...` (a stale PR branch). Forensic trace:

1. The post-commit hook (`.git/hooks/post-commit`) runs `nx index repo` after every commit.
2. `_catalog_hook` registers files in catalog and returns `{abs_path: doc_id}`.
3. **A single failing `cat.register()` (or `cat.update()`) inside the per-file loop raised, tripping the outer `except` at the loop's parent scope.** That outer except logs at DEBUG only, so the failure was invisible. Every subsequent file in the same run got `file_to_doc_id=={}` → `doc_id=""` → `normalize()` Step 4c popped the empty field → chunks landed in T3 with no doc_id metadata at all.
4. On every subsequent re-index, `check_staleness` matched the existing chunk by source_path/doc_id, found `content_hash + embedding_model` matched, returned True, and skipped re-upsert. The ghost chunk's metadata stayed frozen forever.

## Changes

**`check_staleness` (`indexer_utils.py`)**
- When the caller passes a non-empty `doc_id` but the stored chunk lacks `doc_id`, return False (treat as metadata-stale even if `content_hash + embedding_model` match).
- Stored chunks WITH a matching `doc_id` still return True. The escape only fires when the `doc_id` field is missing entirely (the ghost class shape).

**`_catalog_hook` (`indexer.py`)**
- Wrap the per-file register/update in its own try block. A single failure no longer trips the outer except.
- Each failure now logs a structured WARNING with file path + error.
- Track skipped files; surface the count in the progress line: `Catalog: N new, M updated, K skipped (see structlog warnings)`.

## Test plan

- `test_check_staleness_treats_chunk_without_doc_id_as_stale`: WITH-TEETH lock on the escape branch.
- `test_check_staleness_passes_when_chunk_has_matching_doc_id`: inverse case (matching doc_id) still returns True.
- 298 indexer + catalog_hook tests pass.

## Operator workflow

After this lands, Hal can run `nx index repo /Users/hal.hildebrand/git/nexus --force` to force re-upsert of ghost chunks (the staleness check now returns False for chunks lacking doc_id when caller has one). Going forward, no new ghosts accumulate: per-file catalog failures surface as warnings, and the staleness escape catches metadata-only divergence on every re-index.

## Closes

Follow-up to `nexus-o6aa.10.4` (the live-run found these). Filed as a fix branch since the bead's scope was docs; this is a structural pre-existing pathology surfaced by the prune workflow.