### PR TITLE
feat(index): cumulative chunks + skipped count on progress bar (nexus-6xqk)

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -225,6 +225,8 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
     bar: tqdm | None = None
     n = 0
     total = 0
+    total_chunks = 0
+    skipped_files = 0
     eta_ticker = _ETATicker(emit=lambda msg: click.echo(f"  {msg}", err=True))
 
     def on_start(count: int) -> None:
@@ -237,12 +239,25 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
         eta_ticker.start(count)
 
     def on_file(fpath: Path, chunks: int, elapsed: float) -> None:
-        nonlocal n
+        nonlocal n, total_chunks, skipped_files
         n += 1
+        total_chunks += chunks
+        if not chunks:
+            skipped_files += 1
         eta_ticker.record(chunks)
         if bar is not None:
             bar.update(1)
-            bar.set_postfix(now=fpath.name)
+            # nexus-6xqk: cumulative chunks + skipped count alongside
+            # current file. Surfaces real work progress even before
+            # the ETA ticker's warm-up sample lands. ``skip`` shows
+            # only when non-zero so healthy runs stay terse.
+            postfix: dict[str, object] = {
+                "now": fpath.name,
+                "chunks": f"{total_chunks:,}",
+            }
+            if skipped_files:
+                postfix["skip"] = skipped_files
+            bar.set_postfix(**postfix)
         if monitor or not sys.stdout.isatty():
             lbl = f"{chunks} chunks" if chunks else "skipped"
             line = f"  [{n}/{total}] {fpath.name} \u2014 {lbl}  ({elapsed:.1f}s)"


### PR DESCRIPTION
Real-data finding from Hal's reindex 2026-05-02: `nx index repo --force` showed `33/691 files · 0 chunks · no samples yet · pending` for the first minutes of the walk. The chunk counter + ETA ticker bootstrap only after the first ~10 files complete (warm-up sample window). Operator saw thin observability while the indexer was actually doing real work.

## Fix

Surface cumulative chunks + skipped count on the tqdm bar's postfix slot, updated per file via the `on_file` callback. Skip counter only renders when non-zero so healthy runs stay terse.

**Before:** `now=catalog_taxonomy.py`
**After:** `now=catalog_taxonomy.py, chunks=1,247`
```
nexus:   5%|█▏  | 33/691 [01:57<18:46,  1.71s/file, now=catalog_taxonomy.py, chunks=1,247]
```

The ETA ticker's stderr line still prints every 60s with the rolling-sample-based ETA; this just gives immediate chunk-progress feedback without waiting for the warm-up.

## Test plan

45 `test_index_cmd.py` tests pass.

## Out of scope

Filed under same bead `nexus-6xqk` for follow-up:
- Per-stage indicator (chunking/embedding/upserting) on slow files where one file dominates wall-time.
- Catalog-hook warning counter on the bar (currently log-only via #484).