### PR TITLE
fix(index): stop ETA ticker when post-pass phases begin

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -266,10 +266,20 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
             else:
                 click.echo(line)
 
+    post_pass_started = False
+
     def on_phase(msg: str) -> None:
         # nexus-vatx Gap 2: surface post-processing phases so the operator
         # knows the indexer is still busy after the per-file bar finishes.
         # Stderr so the line is visible even when stdout is redirected.
+        nonlocal post_pass_started
+        if not post_pass_started:
+            # nexus-6xqk follow-up: file walk is done by the time the
+            # first post-pass phase fires. Stop the ETA ticker so its
+            # 60-second loop doesn't spam the same "done" line on top
+            # of the post-pass output.
+            post_pass_started = True
+            eta_ticker.stop()
         click.echo(f"  [post] {msg}", err=True)
 
     def _emit_retry_summary() -> None:


### PR DESCRIPTION
Real-data UX finding from Hal's reindex 2026-05-02: file walk hit 100%, then the ETA ticker kept printing `[eta] 691/691 files · done` every 60s while post-passes (RDR indexing, prunes, frecency, catalog hook) ran for tens of minutes silently behind it.

```
nexus: 100%|██████| 691/691 [19:56<00:00, 76.39s/file, now=2604.15583.pdf]  [post] Discovering and indexing RDR markdown files…
  [eta] 691/691 files · 12,515 chunks · 1.7s/file avg · done
  [eta] 691/691 files · 12,515 chunks · 1.8s/file avg · done
  [eta] 691/691 files · 12,515 chunks · 1.9s/file avg · done
  ...
```

The ticker is hard-coded to stop only when `index_repository` returns (its outer finally), but post-passes are part of `index_repository` so the stop is too late.

## Fix

On the FIRST `on_phase` callback (which fires only during post-passes), stop the ETA ticker. Subsequent phases keep emitting their `[post]` lines without re-stopping.

After this lands, the post-pass output is clean:
```
nexus: 100%|██████| 691/691 [19:56<00:00, ...]
  [post] Discovering and indexing RDR markdown files…
  [post] RDR indexing done — 12 indexed, 130 current, 0 failed (45.2s)
  [post] Pruning misclassified chunks…
  [post] Pruning misclassified done (8.1s)
  ...
```

## Test plan

45 `test_index_cmd.py` tests pass.

bead: `nexus-6xqk`