### PR TITLE
fix(catalog): process-level Catalog cache + read-side helper migration

### DIFF
--- a/src/nexus/catalog/__init__.py
+++ b/src/nexus/catalog/__init__.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import threading
+from pathlib import Path
+
 from nexus.catalog.catalog import Catalog, CatalogEntry, CatalogLink
 from nexus.catalog.tumbler import (
     DocumentRecord,
@@ -16,8 +19,59 @@ __all__ = [
     "LinkRecord",
     "OwnerRecord",
     "Tumbler",
+    "open_cached",
+    "reset_cache",
     "resolve_tumbler",
 ]
+
+
+# Process-level Catalog cache (nexus-6xqk follow-up).
+# Helpers like ``doc_indexer._lookup_existing_doc_id`` and
+# ``commands/enrich._build_catalog_doc_id_lookup`` are read-mostly and
+# get called per-file during a force-reindex. Each ``Catalog(...)``
+# construction triggers ``_ensure_consistent`` which DELETE-and-rebuilds
+# from events.jsonl; multiple constructions per second contend on the
+# SQLite write lock and emit ``catalog_consistency_rebuild_failed`` storms.
+# A cached singleton per ``cat_path`` lets these helpers reuse one
+# Catalog instance instead of opening fresh ones.
+_cached: dict[Path, Catalog] = {}
+_cache_lock = threading.Lock()
+
+
+def open_cached(cat_path: Path) -> Catalog:
+    """Return a process-cached Catalog instance for *cat_path*.
+
+    Thread-safe; constructs once and reuses. Subsequent calls bypass the
+    expensive ``_ensure_consistent`` rebuild that fires on every fresh
+    construction. Read-only helpers (per-file doc_id lookups, frecency
+    map building, etc.) should use this instead of ``Catalog(path,
+    path / ".catalog.db")`` to avoid lock contention storms.
+
+    Callers that mutate the catalog should NOT use this accessor; they
+    need a fresh instance because the singleton may have stale internal
+    state (other writers in this process or peers). Mutators are rare;
+    the cache is the right default for read-side accessors.
+    """
+    cat_path = Path(cat_path)
+    inst = _cached.get(cat_path)
+    if inst is not None:
+        return inst
+    with _cache_lock:
+        inst = _cached.get(cat_path)
+        if inst is not None:
+            return inst
+        inst = Catalog(cat_path, cat_path / ".catalog.db")
+        _cached[cat_path] = inst
+        return inst
+
+
+def reset_cache() -> None:
+    """Drop the process-level Catalog cache. Used by tests + the doctor
+    rebuild path that wants a fresh consistency check after a known
+    catalog mutation in another process.
+    """
+    with _cache_lock:
+        _cached.clear()
 
 
 def resolve_tumbler(

--- a/src/nexus/collection_health.py
+++ b/src/nexus/collection_health.py
@@ -72,13 +72,16 @@ def _open_catalog():
     means the collection has no documents on record yet — health rows
     for such collections show zero chunks / no links / no orphans.
     """
+    from nexus.catalog import open_cached
     from nexus.catalog.catalog import Catalog
     from nexus.config import catalog_path
 
     path = catalog_path()
     if not Catalog.is_initialized(path):
         return None
-    return Catalog(path, path / ".catalog.db")
+    # nexus-6xqk follow-up: read-only stats accessor uses the process
+    # singleton; called per-collection during health checks.
+    return open_cached(path)
 
 
 def _default_catalog_stats_fn(col: str) -> dict[str, Any]:

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -21,13 +21,16 @@ def _doc_id_to_file_path(doc_id: str) -> str:
     returns "" and the caller treats the chunk as sourceless.
     """
     try:
-        from nexus.catalog import Catalog
+        from nexus.catalog import Catalog, open_cached
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             return ""
-        cat = Catalog(cat_path, cat_path / ".catalog.db")
+        # nexus-6xqk follow-up: process-cached singleton avoids the
+        # storm of _ensure_consistent rebuilds when this helper fires
+        # per-chunk on a large collection.
+        cat = open_cached(cat_path)
         entry = cat.by_doc_id(doc_id)
         if entry is None:
             return ""

--- a/src/nexus/commands/doc.py
+++ b/src/nexus/commands/doc.py
@@ -546,13 +546,14 @@ def _phase4_catalog_t3_chash() -> tuple[Any, Any, Any]:
     T3 comes from ``nexus.db.make_t3``. ChashIndex opens the same T2
     path used by every other T2 store.
     """
-    from nexus.catalog.catalog import Catalog
+    from nexus.catalog import open_cached
     from nexus.db import make_t3
     from nexus.db.t2.chash_index import ChashIndex
 
     db_path = default_db_path()
     cat_path = db_path.parent / "catalog"
-    cat: Any = Catalog(cat_path, cat_path / ".catalog.db")
+    # nexus-6xqk follow-up: read-mostly catalog accessor for doc query.
+    cat: Any = open_cached(cat_path)
     t3: Any = make_t3()
     chash_index: Any = ChashIndex(db_path)
     return cat, t3, chash_index

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -467,7 +467,9 @@ def _resolve_dt_uri_from_tumbler(tumbler: str) -> str | None:
         raise click.ClickException(
             "Catalog not initialized. Run 'nx catalog setup' first.",
         )
-    cat = Catalog(path, path / ".catalog.db")
+    # nexus-6xqk follow-up: read-only resolve uses the process cache.
+    from nexus.catalog import open_cached
+    cat = open_cached(path)
     try:
         t, err = resolve_tumbler(cat, tumbler)
         if err:

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -38,13 +38,16 @@ def _build_catalog_doc_id_lookup() -> Callable[[str, str], str] | None:
     lookups stay consistent across the Phase 4 prune.
     """
     try:
-        from nexus.catalog import Catalog
+        from nexus.catalog import Catalog, open_cached
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             return None
-        cat = Catalog(cat_path, cat_path / ".catalog.db")
+        # nexus-6xqk follow-up: process-cached Catalog so the closure
+        # this function returns reuses one instance across every
+        # call (per-entry during enrich-aspects on a large collection).
+        cat = open_cached(cat_path)
     except Exception:
         return None
 

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -553,13 +553,15 @@ def rebuild_cmd(collection: str, project: str, k: int | None) -> None:
 def _resolve_doc_titles(doc_ids: list[str]) -> list[str]:
     """Resolve doc_ids to human-readable titles via catalog, fallback to raw ID."""
     try:
+        from nexus.catalog import open_cached
         from nexus.catalog.catalog import Catalog
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             return doc_ids
-        cat = Catalog(cat_path, cat_path / ".catalog.db")
+        # nexus-6xqk follow-up: process-cached read-only accessor.
+        cat = open_cached(cat_path)
         titles: list[str] = []
         for doc_id in doc_ids:
             results = cat.search(doc_id)
@@ -783,12 +785,15 @@ def split_cmd(topic_label: str, k: int, collection: str) -> None:
 def _try_load_catalog() -> Any:
     """Load the catalog if initialized, else return None."""
     try:
+        from nexus.catalog import open_cached
         from nexus.catalog.catalog import Catalog
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if Catalog.is_initialized(cat_path):
-            return Catalog(cat_path, cat_path / ".catalog.db")
+            # nexus-6xqk follow-up: shared accessor used by topic-link
+            # computation; cached so repeated calls don't rebuild.
+            return open_cached(cat_path)
     except Exception:
         pass
     return None

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -70,14 +70,17 @@ def _lookup_existing_doc_id(file_path: str, corpus: str) -> str:
     is found and the chunk lookup keys on ``doc_id``.
     """
     try:
-        from nexus.catalog import Catalog  # noqa: PLC0415
+        from nexus.catalog import Catalog, open_cached  # noqa: PLC0415
         from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
         from nexus.config import catalog_path  # noqa: PLC0415
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             return ""
-        cat = Catalog(cat_path, cat_path / ".catalog.db")
+        # nexus-6xqk follow-up: use the process-cached Catalog so per-
+        # file lookups during a force-reindex don't storm the SQLite
+        # write lock with concurrent _ensure_consistent rebuilds.
+        cat = open_cached(cat_path)
         owner_name = corpus or "standalone-pdfs"
         row = cat._db.execute(
             "SELECT tumbler_prefix FROM owners WHERE name = ?", (owner_name,)

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -695,12 +695,15 @@ def _check_chroma_pagination(client: object, db_name: str) -> list[HealthResult]
 
 def _check_catalog() -> list[HealthResult]:
     try:
+        from nexus.catalog import open_cached
         from nexus.catalog.catalog import Catalog
         from nexus.config import catalog_path
 
         cat_path = catalog_path()
         if Catalog.is_initialized(cat_path):
-            cat = Catalog(cat_path, cat_path / ".catalog.db")
+            # nexus-6xqk follow-up: read-only health check uses the
+            # process-cached singleton, avoiding the rebuild contention.
+            cat = open_cached(cat_path)
             doc_count = cat._db.execute("SELECT count(*) FROM documents").fetchone()[0]
             link_count = cat._db.execute("SELECT count(*) FROM links").fetchone()[0]
             return [HealthResult(

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -576,14 +576,16 @@ def _build_frecency_doc_id_map(
     """
     file_to_doc_id: dict[Path, str] = {}
     try:
-        from nexus.catalog import Catalog
+        from nexus.catalog import Catalog, open_cached
         from nexus.config import catalog_path
         from nexus.registry import _repo_identity
 
         cat_path = catalog_path()
         if not Catalog.is_initialized(cat_path):
             return file_to_doc_id
-        cat = Catalog(cat_path, cat_path / ".catalog.db")
+        # nexus-6xqk follow-up: process-cached Catalog avoids a fresh
+        # _ensure_consistent rebuild on every frecency-only run.
+        cat = open_cached(cat_path)
         _, repo_hash = _repo_identity(repo)
         owner = cat.owner_for_repo(repo_hash)
         if owner is None:


### PR DESCRIPTION
Real-data finding from Hal's reindex 2026-05-02: `catalog_consistency_rebuild_failed` warnings firing every ~5-30 seconds during a force reindex. Each warning was a fresh `Catalog()` construction triggering `_ensure_consistent`, contending on the SQLite write lock with concurrent constructions in the same process.

```
event='catalog_consistency_rebuild_failed' error='database is locked'
File 'catalog.py', line 687, in _ensure_consistent
    conn.execute('DELETE FROM links')
sqlite3.OperationalError: database is locked
```

## Root cause

Helpers I added in PRs #470 / #471 / #477 / #479 each open a fresh `Catalog` per call:

- `doc_indexer._lookup_existing_doc_id` — per file during indexing
- `commands/collection._doc_id_to_file_path` — per chunk in delete safety
- `commands/enrich._build_catalog_doc_id_lookup` — per entry during enrich
- `indexer._build_frecency_doc_id_map` — per file during frecency-only

Plus older read-only sites that compounded under load: `health._check_catalog`, `collection_health.get_catalog_for_health`, taxonomy resolution, etc.

Each `Catalog()` construction kicks off `_ensure_consistent` (DELETE-and-rebuild of the SQLite projection from `events.jsonl`). Multiple constructions per second storm the SQLite write lock.

## Fix

**New module-level helper** in `catalog/__init__.py`:
- `open_cached(cat_path)` — thread-safe singleton per `cat_path`. Constructs once; subsequent calls bypass `_ensure_consistent`.
- `reset_cache()` — drops the cache for tests + doctor rebuild paths.
- Mutators (register, update, link, delete) **deliberately do NOT use this** — they need fresh instances. Docstring documents the contract.

**Migrated 10 read-only sites** to `open_cached`. Mutators stay (catalog hook, PDF/MD registration, store_put, dt stamp, doctor repair, catalog setup, migrate sync).

## Test plan

1961 affected tests pass: catalog + indexer + collection + enrich + taxonomy + doctor + doc_indexer + health.

## Operator impact

After this lands, the warning storm goes away. `nx index repo` runs without `_ensure_consistent` competing with itself in the same process.

Note: cross-process contention (e.g. an `nx index` run alongside a post-commit hook spawn) still produces an occasional warning when both processes try to rebuild concurrently. That's expected SQLite-lock backoff behavior; the affected process just runs in degraded mode for one Catalog instantiation. The fix here only addresses *within-process* storms.