### PR TITLE
fix(collection): skip taxonomy__centroids in chunk_text_hash backfill

### DIFF
--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -492,6 +492,12 @@ def verify_cmd(name: str, deep: bool) -> None:
 
 _BACKFILL_BATCH = 300
 
+# Collections whose rows store embedding + label metadata only — no document
+# text — so chunk_text_hash backfill cannot meaningfully process them. Walking
+# them produces one ``backfill_chunk_text_hash_none_doc`` warning per row with
+# no actionable signal. nexus-uebj.
+_DOCUMENTLESS_COLLECTIONS: frozenset[str] = frozenset({"taxonomy__centroids"})
+
 
 def _backfill_chunk_text_hash(
     col,
@@ -511,6 +517,9 @@ def _backfill_chunk_text_hash(
             ``None`` (default) to preserve the T3-only behaviour that legacy
             callers in ``commands/catalog.py`` still rely on.
     """
+    if getattr(col, "name", "") in _DOCUMENTLESS_COLLECTIONS:
+        return (0, 0, 0)
+
     from nexus.db.t2.chash_index import dual_write_chash_index
 
     updated = 0

--- a/tests/test_backfill_hash.py
+++ b/tests/test_backfill_hash.py
@@ -91,6 +91,29 @@ class TestBackfillChunkTextHash:
         assert updated == 0
         assert skipped == 0
 
+    def test_backfill_skips_documentless_collections(self):
+        """nexus-uebj: ``taxonomy__centroids`` (and any other collection in
+        ``_DOCUMENTLESS_COLLECTIONS``) stores embedding + label metadata only,
+        no document text. Walking it would emit one
+        ``backfill_chunk_text_hash_none_doc`` warning per chunk with no
+        actionable signal. The early-return guard skips these collections
+        entirely without touching the collection at all.
+        """
+        from unittest.mock import MagicMock
+
+        from nexus.commands.collection import _backfill_chunk_text_hash
+
+        col = MagicMock()
+        col.name = "taxonomy__centroids"
+
+        updated, skipped, total = _backfill_chunk_text_hash(col)
+
+        assert (updated, skipped, total) == (0, 0, 0)
+        # The early-return must avoid touching the collection — no fetches,
+        # no updates, nothing logged about None documents.
+        col.get.assert_not_called()
+        col.update.assert_not_called()
+
     def test_backfill_skips_none_documents_without_crash(self):
         """nexus-p03z Issue 1: when T3 returns ``documents[i] is None``
         (an inconsistency that occurs in practice on rare chunks), the


### PR DESCRIPTION
## Summary
- `_backfill_chunk_text_hash` walked `taxonomy__centroids` and emitted one `backfill_chunk_text_hash_none_doc` warning per centroid (187 per project) because those rows have no document text, just an embedding plus label metadata.
- Early-return on a frozenset of documentless collection names. Single guard covers all three call sites: `nx collection backfill-hash --all`, `nx catalog backfill` Pass 4, and the in-process catalog refresh.
- Smoke-tested against a freshly-indexed cloud DB: zero `none_doc` warnings, all three real collections back-filled normally, `taxonomy__centroids` reports `all 0 chunks already have hash`.

## Closes
- nexus-uebj

## Test plan
- [x] `uv run pytest tests/test_backfill_hash.py tests/test_catalog_backfill.py tests/test_catalog_t3_backfill.py tests/test_catalog_t3_backfill_partial_failure.py tests/test_collection_cmd.py` (64 passed)
- [x] New regression test `test_backfill_skips_documentless_collections` mocks the collection and asserts the early-return path never touches `col.get` or `col.update`
- [x] Live smoke: `nx collection backfill-hash --all` against a 4-collection cloud DB, grep for `none_doc` warnings = 0