### PR TITLE
feat(rdr-101): Phase 6 — T3 GC + collections projection + CLI verbs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -629,6 +629,34 @@ Standard catalog management. Run `nx catalog COMMAND --help` for details.
 
 ---
 
+## nx t3
+
+T3 (ChromaDB) maintenance commands. Distinct from `nx catalog gc`: `nx t3` operates on T3 chunks, the catalog command operates on catalog rows.
+
+### nx t3 prune-stale
+
+```
+nx t3 prune-stale [-c COLLECTION] [--no-dry-run --confirm]
+```
+
+Sweep T3 chunks whose `source_path` is missing from disk. Default is report-only; both `--no-dry-run` AND `--confirm` are required to delete.
+
+### nx t3 gc
+
+```
+nx t3 gc -c COLLECTION [--orphan-window 30d] [--no-dry-run --yes]
+```
+
+Garbage-collect orphaned T3 chunks (RDR-101 Phase 6 / nexus-r5eo). A chunk is an orphan when its `doc_id` metadata is no longer in the catalog projection's alive set for the collection AND its `indexed_at` predates the orphan window (default 30 days).
+
+Per RF-101-3, `nx t3 gc` is the SOLE post-Phase-3 emitter of `ChunkOrphaned` events and the SOLE path that physically deletes T3 chunks. The strict per-candidate order is: append `ChunkOrphaned(chunk_id, reason)` to the event log, THEN call `T3Database.delete_by_chunk_ids`. A crash between the two leaves the log consistent with T3 (event present, delete pending), and the next run idempotently retries the delete.
+
+Default is report-only; both `--no-dry-run` AND `--yes` are required to actually delete. Chunks without a `doc_id` (legacy pre-Phase-2 backfill) are undecidable here and skipped; use a maintenance backfill verb to address them, not GC.
+
+`--orphan-window` accepts `s`, `m`, `h`, `d`, `w` suffixes (e.g. `30d`, `12h`, `2w`); a bare integer is rejected so a typo cannot silently mean 30 seconds.
+
+---
+
 ## nx taxonomy
 
 Topic taxonomy — HDBSCAN clustering of T3 collection embeddings into topics for navigation, search grouping, and relevance boosting.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -627,6 +627,57 @@ Per-collection report of outgoing-link counts at the depth-N BFS frontier (defau
 
 Standard catalog management. Run `nx catalog COMMAND --help` for details.
 
+### nx catalog backfill-collections
+
+```
+nx catalog backfill-collections [--dry-run]
+```
+
+Populate the RDR-101 Phase 6 collections projection from existing state. Walks both T3 (live ChromaDB) and the catalog `documents.physical_collection` column, unions the two sets, and registers each name not already in the projection. The projector's `is_conformant_collection_name` regex decides each row's `legacy_grandfathered` flag automatically.
+
+Idempotent. Conventional first invocation is `--dry-run` for operator review, then `--no-dry-run` to apply.
+
+### nx catalog rename-collection
+
+```
+nx catalog rename-collection OLD NEW [--dry-run/--no-dry-run] [--yes] [--allow-legacy]
+```
+
+Combined verb that does both the data-plane rename (T3 native `modify(name=)` + T2 cascade + catalog documents re-point) and the RDR-101 Phase 6 control-plane work (collections-projection update + `CollectionSuperseded` event emission). `nx collection rename` (data plane only) remains available for operators who want it without the Phase 6 layer.
+
+Validation gates fire BEFORE any side effect:
+- new name must be conformant (`<content_type>__<owner_id>__<embedding_model>__v<n>`) or pass `--allow-legacy`
+- old name must be in the collections projection
+- old name must not already be superseded
+- new name must not already exist in T3
+
+Default is report-only; both `--no-dry-run` AND `--yes` are required to actually rename.
+
+### nx catalog migrate-fallback
+
+```
+nx catalog migrate-fallback SOURCE [--target-model M] [--target-version v1] [--dry-run/--no-dry-run] [--yes]
+```
+
+Walk a fallback collection (`docs__default`, `knowledge__knowledge`, etc.) and propose a per-document target conformant collection. With `--yes`, re-points each document's `physical_collection` in the catalog and auto-registers the target rows in the projection. Fallback collections are deprecated when the migration empties them (single-target case auto-emits `CollectionSuperseded`); never silently nuked, per RDR-101 §"Phase 6".
+
+Target form: `<content_type>__<owner>__<model>__<version>` where content_type comes from the source's prefix, owner comes from each tumbler (`1.5.42` → `1-5`; tumbler dots become hyphens for ChromaDB's name regex), model defaults to the source's Voyage family.
+
+T3 chunks are NOT moved by this verb. Operators repopulate the target via `nx index` on the source files; old chunks become orphans (catalog now points elsewhere) and get swept by `nx t3 gc` on the next cycle.
+
+### nx catalog doctor
+
+```
+nx catalog doctor [--replay-equality] [--t3-doc-id-coverage] [--collections-drift] [--json]
+```
+
+RDR-101 catalog doctor surface; pass at least one check flag.
+- `--replay-equality`: synthesizer + projector round-trip against live SQLite (Phase 1).
+- `--t3-doc-id-coverage`: every non-orphan T3 chunk carries a `doc_id` matching the event log (Phase 2).
+- `--collections-drift`: every T3 collection and every distinct `documents.physical_collection` has a row in the collections projection (Phase 6 release gate).
+
+Returns non-zero on any check failure. `--json` emits the per-check result for CI consumption.
+
 ---
 
 ## nx t3

--- a/docs/rdr/rdr-101-catalog-t3-metadata-design.md
+++ b/docs/rdr/rdr-101-catalog-t3-metadata-design.md
@@ -109,7 +109,7 @@ The five Open Questions enumerated below are answered here with structured findi
 1. **Immutable document identity.** Every document has a `doc_id` (UUID7, sortable, never reused, never derived from path). Assigned at first registration. Survives renames, file moves, content edits. Surrogate identity is the only valid join key between catalog and T3.
 2. **Append-only event log is the truth.** Catalog SQLite, T3 chunk metadata, and any future T2 derived table are deterministic projections. The log is the only authoritative store; everything else is a reproducible cache.
 3. **One canonical fact per attribute.** No field exists in two stores. The log holds the fact; the projection that needs it materializes it; readers query the projection that owns it.
-4. **Schema-encoded collection invariants.** Collection name = `<content_type>__<owner_id>__<embedding_model>@<model_version>`. Triple-keyed. Mixed content types, mixed owners, or embedding-model swaps in place are rejected at create time.
+4. **Schema-encoded collection invariants.** Collection name = `<content_type>__<owner_id>__<embedding_model>__v<n>` (the bead spec used `@<model_version>`; ChromaDB's name regex disallows `@`, so the implementation uses `__v<n>` as the fourth `__` separator. See §"Collection naming and invariants" for the binding amendment). Triple-keyed. Mixed content types, mixed owners, or embedding-model swaps in place are rejected at create time.
 5. **No fallback or default destinations.** Every write specifies its target collection. `docs__default`, `knowledge__knowledge`, and any other catch-all are removed.
 
 ### Entities
@@ -303,13 +303,15 @@ The projector is a deterministic function: `events → SQLite state`. Idempotent
 ### Collection naming and invariants
 
 ```
-<content_type>__<owner_id>__<embedding_model>@<model_version>
+<content_type>__<owner_id>__<embedding_model>__v<n>
 ```
 
-Examples:
-- `code__ART-8c2e74c0__voyage-3@2024-08`
-- `docs__nexus-571b8edd__voyage-context-3@2024-09`
-- `papers__art-curator__voyage-context-3@2024-09`
+Examples (post-Phase-6 conformant form):
+- `code__1-1__voyage-code-3__v1`
+- `docs__1-1__voyage-context-3__v2`
+- `knowledge__1-1__voyage-context-3__v1`
+
+**Phase 6 amendment (2026-05-03):** The original schema used `@<model_version>` as the version separator. ChromaDB's collection-name regex disallows `@`, so the canonical encoding uses `__v<n>` as a fourth `__` separator instead. Tumbler-style owner IDs (which contain dots, e.g. `1.1`) are encoded with dots replaced by hyphens (`1-1`) so the segment fits ChromaDB's charset. The four-segment split is preserved; only the separator and version-segment shape changed. The implementation is in `nexus.corpus.is_conformant_collection_name` and `parse_conformant_collection_name`. Legacy two-segment names (`code__ART-8c2e74c0`, `docs__nexus-571b8edd`, `knowledge__delos`, `docs__default`, etc.) are grandfathered via the projection's `legacy_grandfathered` flag and continue to be readable.
 
 Enforced at `CollectionCreated` time:
 - One owner per collection.

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1512,6 +1512,7 @@ class Catalog:
                 embedding_model=embedding_model,
                 model_version=model_version,
                 name=display_name or name,
+                created_at=ts,
             ),
             v=0,
             ts=ts,
@@ -1521,15 +1522,10 @@ class Catalog:
             if self._event_sourced_enabled:
                 self._write_to_event_log(event)
                 self._projector.apply(event)
-                # The projector sets created_at via a COALESCE that
-                # preserves the existing value on re-insert; for fresh
-                # rows we write it explicitly here so the row records
-                # its first registration timestamp.
-                self._db.execute(
-                    "UPDATE collections SET created_at = ? "
-                    "WHERE name = ? AND (created_at IS NULL OR created_at = '')",
-                    (ts, name),
-                )
+                # ``created_at`` lands via the projector's COALESCE
+                # using ``payload.created_at`` (RDR-101 Phase 6
+                # prophylactic-review fix #2 / nexus-qpet); replay
+                # equality holds without an out-of-band UPDATE.
                 self._db.commit()
             else:
                 # Legacy mode: SQLite is canonical, no JSONL backing

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1540,6 +1540,97 @@ class Catalog:
         ).fetchone()
         return bool(row and row[0])
 
+    def update_document_collection(
+        self, tumbler: str, new_collection: str,
+    ) -> bool:
+        """Re-point a single document's ``physical_collection``.
+
+        Per-row analog of :meth:`rename_collection` for migrations
+        where each document gets a different target (e.g. RDR-101
+        Phase 6 ``nx catalog migrate-fallback``). Emits
+        DocumentRegistered v: 0 with the new ``physical_collection``;
+        the projector's INSERT OR REPLACE updates the SQLite row.
+
+        Returns True if the doc was re-pointed, False if not found or
+        already pointed at ``new_collection`` (idempotent).
+        """
+        from nexus.catalog.synthesizer import _owner_prefix_of  # noqa: PLC0415
+
+        row = self._db.execute(
+            "SELECT tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+            "metadata, source_mtime, source_uri, alias_of "
+            "FROM documents WHERE tumbler = ?",
+            (tumbler,),
+        ).fetchone()
+        if row is None:
+            return False
+        if (row[7] or "") == new_collection:
+            return False
+
+        meta_dict = json.loads(row[11]) if row[11] else {}
+        event = _make_event(
+            _DocumentRegisteredPayload(
+                doc_id=row[0],
+                owner_id=_owner_prefix_of(row[0]),
+                content_type=row[4] or "",
+                source_uri=row[13] or "",
+                coll_id=new_collection,
+                title=row[1] or "",
+                source_mtime=float(row[12] or 0.0),
+                indexed_at_doc=row[10] or "",
+                tumbler=row[0],
+                author=row[2] or "",
+                year=int(row[3] or 0),
+                file_path=row[5] or "",
+                corpus=row[6] or "",
+                physical_collection=new_collection,
+                chunk_count=int(row[8] or 0),
+                head_hash=row[9] or "",
+                indexed_at=row[10] or "",
+                alias_of=row[14] or "",
+                meta=dict(meta_dict),
+            ),
+            v=0,
+        )
+        rec = {
+            "tumbler": row[0],
+            "title": row[1],
+            "author": row[2],
+            "year": row[3],
+            "content_type": row[4],
+            "file_path": row[5],
+            "corpus": row[6],
+            "physical_collection": new_collection,
+            "chunk_count": row[8],
+            "head_hash": row[9] or "",
+            "indexed_at": row[10] or "",
+            "meta": meta_dict,
+            "source_mtime": row[12] or 0.0,
+            "source_uri": row[13] or "",
+            "alias_of": row[14] or "",
+        }
+
+        dir_fd = self._acquire_lock()
+        try:
+            if self._event_sourced_enabled:
+                self._write_to_event_log(event)
+                self._projector.apply(event)
+                self._db.commit()
+                self._append_jsonl(self._documents_path, rec)
+            else:
+                self._append_jsonl(self._documents_path, rec)
+                self._db.execute(
+                    "UPDATE documents SET physical_collection = ? "
+                    "WHERE tumbler = ?",
+                    (new_collection, row[0]),
+                )
+                self._db.commit()
+                self._emit_shadow_event(event)
+        finally:
+            self._release_lock(dir_fd)
+        return True
+
     def supersede_collection(
         self,
         old_name: str,

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1464,22 +1464,45 @@ class Catalog:
     ) -> None:
         """Register a ChromaDB collection in the catalog projection.
 
-        Idempotent on ``name`` (re-registering the same name is a no-op
-        at the SQLite level via INSERT OR REPLACE in the projector).
-        Writes a CollectionCreated v: 0 event to the event log; the
-        projector materializes the row including the
-        ``legacy_grandfathered`` flag derived from
-        :func:`nexus.corpus.is_conformant_collection_name`.
+        Idempotent on ``name``. The first call writes the row + emits a
+        ``CollectionCreated`` event; subsequent calls with identical
+        canonical fields short-circuit (no duplicate event, no log
+        bloat). Subsequent calls that change a canonical field re-emit
+        the event so the projection picks up the new value.
 
         For non-conformant names, the canonical fields (``content_type``
         etc.) may be left empty; the row is still written and flagged
-        as legacy. For conformant names, callers are encouraged to
-        supply the segments so they round-trip exactly.
+        as legacy via the projector's regex. For conformant names,
+        callers are encouraged to supply the segments so they round-trip
+        exactly.
+
+        Honors the ``_event_sourced_enabled`` split that ``register_owner``
+        and the other writers use: in event-sourced mode the event is
+        canonical and the projector writes SQLite; in legacy mode SQLite
+        is written directly and the event is shadow-emitted.
         """
         from datetime import UTC, datetime  # noqa: PLC0415
+        from nexus.corpus import is_conformant_collection_name  # noqa: PLC0415
 
         if not name:
             raise ValueError("register_collection: name must be non-empty")
+
+        # Short-circuit: if the row already exists with the same
+        # canonical fields, do not re-emit. Event log was previously
+        # appended unconditionally on every call; for hot paths
+        # (backfill on a 100-collection catalog re-run on every CI
+        # build) this produced duplicate CollectionCreated events with
+        # no projection effect.
+        existing = self.get_collection(name)
+        if existing is not None and (
+            existing["content_type"] == content_type
+            and existing["owner_id"] == owner_id
+            and existing["embedding_model"] == embedding_model
+            and existing["model_version"] == model_version
+            and existing["display_name"] == (display_name or name)
+        ):
+            return
+
         ts = datetime.now(UTC).isoformat()
         event = _make_event(
             _CollectionCreatedPayload(
@@ -1495,18 +1518,43 @@ class Catalog:
         )
         dir_fd = self._acquire_lock()
         try:
-            self._write_to_event_log(event)
-            self._projector.apply(event)
-            # The projector sets created_at via a COALESCE that
-            # preserves the existing value on re-insert; for fresh rows
-            # we write it explicitly here so the row records its first
-            # registration timestamp.
-            self._db.execute(
-                "UPDATE collections SET created_at = ? "
-                "WHERE name = ? AND (created_at IS NULL OR created_at = '')",
-                (ts, name),
-            )
-            self._db.commit()
+            if self._event_sourced_enabled:
+                self._write_to_event_log(event)
+                self._projector.apply(event)
+                # The projector sets created_at via a COALESCE that
+                # preserves the existing value on re-insert; for fresh
+                # rows we write it explicitly here so the row records
+                # its first registration timestamp.
+                self._db.execute(
+                    "UPDATE collections SET created_at = ? "
+                    "WHERE name = ? AND (created_at IS NULL OR created_at = '')",
+                    (ts, name),
+                )
+                self._db.commit()
+            else:
+                # Legacy mode: SQLite is canonical, no JSONL backing
+                # file for collections (they did not exist pre-Phase-6).
+                # Direct INSERT OR REPLACE matches the projector handler
+                # except for the regex-derived legacy_grandfathered flag,
+                # which we compute the same way here.
+                legacy = 0 if is_conformant_collection_name(name) else 1
+                self._db.execute(
+                    "INSERT OR REPLACE INTO collections "
+                    "(name, content_type, owner_id, embedding_model, "
+                    "model_version, display_name, legacy_grandfathered, "
+                    "superseded_by, superseded_at, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, "
+                    "COALESCE((SELECT superseded_by FROM collections WHERE name = ?), ''), "
+                    "COALESCE((SELECT superseded_at FROM collections WHERE name = ?), ''), "
+                    "COALESCE((SELECT created_at FROM collections WHERE name = ?), ?))",
+                    (
+                        name, content_type, owner_id, embedding_model,
+                        model_version, display_name or name, legacy,
+                        name, name, name, ts,
+                    ),
+                )
+                self._db.commit()
+                self._emit_shadow_event(event)
         finally:
             self._release_lock(dir_fd)
 
@@ -1614,10 +1662,20 @@ class Catalog:
         dir_fd = self._acquire_lock()
         try:
             if self._event_sourced_enabled:
+                # Crash-window discipline matches rename_collection's
+                # per-row loop (catalog.py:2253-2255 + batched commit at
+                # 2264): event -> projector apply -> JSONL append, with
+                # the SQLite commit last. A crash between projector apply
+                # and JSONL append leaves SQLite uncommitted and JSONL
+                # unwritten - both old. A crash between JSONL append and
+                # commit leaves JSONL ahead of SQLite; on
+                # rebuild-from-JSONL the new line wins; on
+                # rebuild-from-events the projector replays correctly.
+                # Either way, no torn state.
                 self._write_to_event_log(event)
                 self._projector.apply(event)
-                self._db.commit()
                 self._append_jsonl(self._documents_path, rec)
+                self._db.commit()
             else:
                 self._append_jsonl(self._documents_path, rec)
                 self._db.execute(
@@ -1642,33 +1700,70 @@ class Catalog:
 
         Writes a CollectionSuperseded v: 0 event and updates the old
         collection's ``superseded_by`` / ``superseded_at`` columns. The
-        new collection must already be registered (callers usually pair
-        ``register_collection`` for the new name with a
-        ``supersede_collection`` for the old).
+        new collection MUST already be registered (the docstring used
+        to say "callers usually pair register_collection with
+        supersede_collection"; that contract is now enforced).
 
-        Raises ``ValueError`` if ``old_name`` is not registered; this
-        is the rare case where read-time fail-loud is appropriate, the
-        operator is taking an explicit action and would expect a
-        no-op-on-typo to surface as an error.
+        Raises ``ValueError`` when:
+          - ``old_name`` is not registered (typo-on-explicit-action path)
+          - ``new_name`` is not registered (would create a dangling
+            ``superseded_by`` pointer that no foreign-key-style join
+            can resolve)
+          - ``old_name`` is already superseded (silently overwriting
+            the previous supersession would orphan the prior
+            CollectionSuperseded event in the log)
+
+        Honors the ``_event_sourced_enabled`` split that the rest of the
+        catalog writers use.
         """
+        from datetime import UTC, datetime  # noqa: PLC0415
+
         existing = self.get_collection(old_name)
         if existing is None:
             raise ValueError(
                 f"supersede_collection: {old_name!r} not registered"
             )
+        if existing.get("superseded_by"):
+            raise ValueError(
+                f"supersede_collection: {old_name!r} is already "
+                f"superseded by {existing['superseded_by']!r}; refusing "
+                f"to chain a second supersede event"
+            )
+        if self.get_collection(new_name) is None:
+            raise ValueError(
+                f"supersede_collection: new {new_name!r} is not "
+                f"registered. Call register_collection({new_name!r}, ...) "
+                f"first so the projection has a row to point at."
+            )
+        ts = datetime.now(UTC).isoformat()
         event = _make_event(
             _CollectionSupersededPayload(
                 old_coll_id=old_name,
                 new_coll_id=new_name,
                 reason=reason,
+                superseded_at=ts,
             ),
             v=0,
+            ts=ts,
         )
         dir_fd = self._acquire_lock()
         try:
-            self._write_to_event_log(event)
-            self._projector.apply(event)
-            self._db.commit()
+            if self._event_sourced_enabled:
+                self._write_to_event_log(event)
+                self._projector.apply(event)
+                self._db.commit()
+            else:
+                # Legacy mode: SQLite is canonical, no JSONL backing.
+                # Reuse the same ``ts`` as the event payload so the row
+                # records exactly what the event records (deterministic
+                # under replay-equality even in legacy mode).
+                self._db.execute(
+                    "UPDATE collections SET superseded_by = ?, "
+                    "superseded_at = ? WHERE name = ?",
+                    (new_name, ts, old_name),
+                )
+                self._db.commit()
+                self._emit_shadow_event(event)
         finally:
             self._release_lock(dir_fd)
 

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -99,6 +99,8 @@ def _read_event_sourced_gate() -> bool:
 # events on behalf of the caller). The PR-F initial comment described
 # these as "lazy" imports — they are not, they run at import time.
 from nexus.catalog.events import (  # noqa: E402
+    CollectionCreatedPayload as _CollectionCreatedPayload,
+    CollectionSupersededPayload as _CollectionSupersededPayload,
     DocumentAliasedPayload as _DocumentAliasedPayload,
     DocumentDeletedPayload as _DocumentDeletedPayload,
     DocumentEnrichedPayload as _DocumentEnrichedPayload,
@@ -1429,6 +1431,155 @@ class Catalog:
             )
             for row in rows
         ]
+
+    # ── RDR-101 Phase 6: Collections projection (nexus-o6aa.14) ─────────
+
+    _COLLECTION_COLUMNS = (
+        "name",
+        "content_type",
+        "owner_id",
+        "embedding_model",
+        "model_version",
+        "display_name",
+        "legacy_grandfathered",
+        "superseded_by",
+        "superseded_at",
+        "created_at",
+    )
+
+    def _row_to_collection_dict(self, row: tuple) -> dict:
+        d = dict(zip(self._COLLECTION_COLUMNS, row))
+        d["legacy_grandfathered"] = bool(d.get("legacy_grandfathered") or 0)
+        return d
+
+    def register_collection(
+        self,
+        name: str,
+        *,
+        content_type: str = "",
+        owner_id: str = "",
+        embedding_model: str = "",
+        model_version: str = "",
+        display_name: str = "",
+    ) -> None:
+        """Register a ChromaDB collection in the catalog projection.
+
+        Idempotent on ``name`` (re-registering the same name is a no-op
+        at the SQLite level via INSERT OR REPLACE in the projector).
+        Writes a CollectionCreated v: 0 event to the event log; the
+        projector materializes the row including the
+        ``legacy_grandfathered`` flag derived from
+        :func:`nexus.corpus.is_conformant_collection_name`.
+
+        For non-conformant names, the canonical fields (``content_type``
+        etc.) may be left empty; the row is still written and flagged
+        as legacy. For conformant names, callers are encouraged to
+        supply the segments so they round-trip exactly.
+        """
+        from datetime import UTC, datetime  # noqa: PLC0415
+
+        if not name:
+            raise ValueError("register_collection: name must be non-empty")
+        ts = datetime.now(UTC).isoformat()
+        event = _make_event(
+            _CollectionCreatedPayload(
+                coll_id=name,
+                owner_id=owner_id,
+                content_type=content_type,
+                embedding_model=embedding_model,
+                model_version=model_version,
+                name=display_name or name,
+            ),
+            v=0,
+            ts=ts,
+        )
+        dir_fd = self._acquire_lock()
+        try:
+            self._write_to_event_log(event)
+            self._projector.apply(event)
+            # The projector sets created_at via a COALESCE that
+            # preserves the existing value on re-insert; for fresh rows
+            # we write it explicitly here so the row records its first
+            # registration timestamp.
+            self._db.execute(
+                "UPDATE collections SET created_at = ? "
+                "WHERE name = ? AND (created_at IS NULL OR created_at = '')",
+                (ts, name),
+            )
+            self._db.commit()
+        finally:
+            self._release_lock(dir_fd)
+
+    def list_collections(self) -> list[dict]:
+        """Return every row in the ``collections`` projection, ordered by name."""
+        sql = (
+            "SELECT " + ", ".join(self._COLLECTION_COLUMNS) + " "
+            "FROM collections ORDER BY name"
+        )
+        rows = self._db.execute(sql).fetchall()
+        return [self._row_to_collection_dict(r) for r in rows]
+
+    def get_collection(self, name: str) -> dict | None:
+        sql = (
+            "SELECT " + ", ".join(self._COLLECTION_COLUMNS) + " "
+            "FROM collections WHERE name = ?"
+        )
+        row = self._db.execute(sql, (name,)).fetchone()
+        return self._row_to_collection_dict(row) if row else None
+
+    def is_legacy_collection(self, name: str) -> bool:
+        """Return True if ``name`` is registered AND flagged legacy.
+
+        Unknown names return False (read paths are operationally hostile
+        to fail-loud per RDR-101 §"Phase 6"). Callers wanting strict
+        membership should query :meth:`get_collection` and check for None.
+        """
+        row = self._db.execute(
+            "SELECT legacy_grandfathered FROM collections WHERE name = ?",
+            (name,),
+        ).fetchone()
+        return bool(row and row[0])
+
+    def supersede_collection(
+        self,
+        old_name: str,
+        new_name: str,
+        *,
+        reason: str = "",
+    ) -> None:
+        """Mark ``old_name`` as superseded by ``new_name``.
+
+        Writes a CollectionSuperseded v: 0 event and updates the old
+        collection's ``superseded_by`` / ``superseded_at`` columns. The
+        new collection must already be registered (callers usually pair
+        ``register_collection`` for the new name with a
+        ``supersede_collection`` for the old).
+
+        Raises ``ValueError`` if ``old_name`` is not registered; this
+        is the rare case where read-time fail-loud is appropriate, the
+        operator is taking an explicit action and would expect a
+        no-op-on-typo to surface as an error.
+        """
+        existing = self.get_collection(old_name)
+        if existing is None:
+            raise ValueError(
+                f"supersede_collection: {old_name!r} not registered"
+            )
+        event = _make_event(
+            _CollectionSupersededPayload(
+                old_coll_id=old_name,
+                new_coll_id=new_name,
+                reason=reason,
+            ),
+            v=0,
+        )
+        dir_fd = self._acquire_lock()
+        try:
+            self._write_to_event_log(event)
+            self._projector.apply(event)
+            self._db.commit()
+        finally:
+            self._release_lock(dir_fd)
 
     def resolve_alias(self, tumbler: Tumbler, *, max_hops: int = 16) -> Tumbler:
         """Walk the alias chain to its canonical terminus.

--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -125,6 +125,34 @@ CREATE INDEX IF NOT EXISTS idx_links_created_by_type
 CREATE INDEX IF NOT EXISTS idx_documents_tumbler
     ON documents(tumbler);
 
+-- RDR-101 Phase 6 (nexus-o6aa.14): first-class Collections projection.
+-- One row per ChromaDB collection name. Materialized from
+-- CollectionCreated events; legacy_grandfathered is projection-derived
+-- from corpus.is_conformant_collection_name (no event-payload extension
+-- required, v: 0 stays stable). Read paths consult this table to
+-- distinguish post-Phase-6 canonical names from grandfathered legacy
+-- names; write paths consult it to short-circuit re-registration.
+CREATE TABLE IF NOT EXISTS collections (
+    name TEXT PRIMARY KEY,
+    content_type TEXT NOT NULL DEFAULT '',
+    owner_id TEXT NOT NULL DEFAULT '',
+    embedding_model TEXT NOT NULL DEFAULT '',
+    model_version TEXT NOT NULL DEFAULT '',
+    display_name TEXT NOT NULL DEFAULT '',
+    -- 1 = name does NOT match is_conformant_collection_name; the row
+    -- exists only because the collection predates RDR-101 Phase 6 or
+    -- was manually registered by the operator. Read paths accept it.
+    legacy_grandfathered INTEGER NOT NULL DEFAULT 0,
+    superseded_by TEXT NOT NULL DEFAULT '',
+    superseded_at TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_collections_legacy
+    ON collections(legacy_grandfathered);
+CREATE INDEX IF NOT EXISTS idx_collections_owner
+    ON collections(owner_id);
+
 -- RDR-101 Phase 1 PR D (nexus-knn3) partial indexes on bib backend IDs
 -- live in the post-migration block in __init__: the legacy-DB upgrade
 -- path has to ALTER TABLE the bib columns into existence before the

--- a/src/nexus/catalog/events.py
+++ b/src/nexus/catalog/events.py
@@ -184,11 +184,19 @@ class CollectionCreatedPayload:
 
 @dataclass(frozen=True, slots=True)
 class CollectionSupersededPayload:
-    """One collection replaced by another (re-embed, rename, grandfather)."""
+    """One collection replaced by another (re-embed, rename, grandfather).
+
+    ``superseded_at`` is populated by the writer (typically equal to the
+    event envelope's ``ts``) so projection is deterministic across
+    replay machines. Older events that pre-date the field default to
+    empty string; in that case the projector falls back to "now" so the
+    column is always populated even for legacy events.
+    """
 
     old_coll_id: str
     new_coll_id: str
     reason: str = ""
+    superseded_at: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nexus/catalog/events.py
+++ b/src/nexus/catalog/events.py
@@ -167,11 +167,18 @@ class CollectionCreatedPayload:
 
     ``coll_id`` is the canonical identifier. Per RDR-101 §"Collection naming
     and invariants" the canonical form is
-    ``<content_type>__<owner_id>__<embedding_model>@<model_version>``; legacy
-    grandfathered names (e.g. ``code__ART-8c2e74c0``) are also valid coll_id
-    values and Phase 1 stores them verbatim. The four split-out fields make
-    the invariants pattern-matchable at projection time without parsing the
+    ``<content_type>__<owner_id>__<embedding_model>__v<n>`` (Phase 6
+    amendment to the original ``@<model_version>`` form, which ChromaDB
+    rejects); legacy grandfathered names (e.g. ``code__ART-8c2e74c0``)
+    are also valid coll_id values and the projector flags them via the
+    ``legacy_grandfathered`` column. The four split-out fields make the
+    invariants pattern-matchable at projection time without parsing the
     composite name.
+
+    ``created_at`` is populated by the writer (typically equal to the
+    event envelope's ``ts``) so replay-equality is deterministic. Older
+    events that pre-date the field default to empty string; the
+    projector preserves whatever lived in the row before via COALESCE.
     """
 
     coll_id: str
@@ -180,6 +187,7 @@ class CollectionCreatedPayload:
     embedding_model: str
     model_version: str
     name: str = ""  # display name; defaults to coll_id
+    created_at: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -366,12 +366,22 @@ class Projector:
         If the old name has no row, the UPDATE is a safe no-op; the
         rename verb's caller is responsible for surfacing
         "unknown old collection" errors before the event is appended.
+
+        ``superseded_at`` is read from the payload so replay is
+        deterministic. Pre-payload-field events (synthesized before
+        ``CollectionSupersededPayload.superseded_at`` was added) default
+        to empty string here; we populate "now" in that case so the
+        column is never empty and the doctor's projection-vs-T3 drift
+        check has a consistent shape to read.
         """
         from datetime import UTC, datetime  # noqa: PLC0415
 
         if not payload.old_coll_id or not payload.new_coll_id:
             return
-        ts = datetime.now(UTC).isoformat()
+        ts = (
+            getattr(payload, "superseded_at", "")
+            or datetime.now(UTC).isoformat()
+        )
         self._db.execute(
             "UPDATE collections SET superseded_by = ?, superseded_at = ? "
             "WHERE name = ?",

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -338,6 +338,10 @@ class Projector:
             "VALUES (?, ?, ?, ?, ?, ?, ?, "
             "COALESCE((SELECT superseded_by FROM collections WHERE name = ?), ''), "
             "COALESCE((SELECT superseded_at FROM collections WHERE name = ?), ''), "
+            # ``created_at`` prefers an existing row's value (re-register
+            # preserves the first-registration timestamp); falls back to
+            # ``payload.created_at`` for fresh inserts. Pre-amendment
+            # events without the field default to empty string.
             "COALESCE((SELECT created_at FROM collections WHERE name = ?), ?))",
             (
                 payload.coll_id,

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -307,13 +307,76 @@ class Projector:
         return
 
     def _v0_owner_or_collection_noop(self, payload: Any) -> None:
-        # ``CollectionCreated`` / ``CollectionSuperseded`` have no
-        # corresponding row in the Phase 1 SQLite schema (the existing
-        # ``documents.physical_collection`` column carries the collection
-        # name). The projector accepts these events so the dispatch table
-        # is complete; future schema gains a ``collections`` table that
-        # consumes them.
+        # Reserved for future no-op event types in the
+        # owner-or-collection family. Phase 6 split CollectionCreated
+        # and CollectionSuperseded out into their own materializing
+        # handlers (``_v0_collection_created`` /
+        # ``_v0_collection_superseded``).
         return
+
+    def _v0_collection_created(self, payload: Any) -> None:
+        """Materialize a row in the ``collections`` projection.
+
+        ``legacy_grandfathered`` is derived from
+        :func:`nexus.corpus.is_conformant_collection_name`, not from
+        the event payload. This keeps the v: 0 schema stable; the only
+        cost is one regex per replay step, which the projector already
+        does for every DocumentRegistered (FTS sync).
+
+        Idempotent via ``INSERT OR REPLACE`` on the ``name`` PK.
+        """
+        from nexus.corpus import is_conformant_collection_name  # noqa: PLC0415
+
+        if not payload.coll_id:
+            return
+        legacy = 0 if is_conformant_collection_name(payload.coll_id) else 1
+        self._db.execute(
+            "INSERT OR REPLACE INTO collections "
+            "(name, content_type, owner_id, embedding_model, model_version, "
+            "display_name, legacy_grandfathered, superseded_by, "
+            "superseded_at, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, "
+            "COALESCE((SELECT superseded_by FROM collections WHERE name = ?), ''), "
+            "COALESCE((SELECT superseded_at FROM collections WHERE name = ?), ''), "
+            "COALESCE((SELECT created_at FROM collections WHERE name = ?), ?))",
+            (
+                payload.coll_id,
+                payload.content_type,
+                payload.owner_id,
+                payload.embedding_model,
+                payload.model_version,
+                payload.name or payload.coll_id,
+                legacy,
+                payload.coll_id,
+                payload.coll_id,
+                payload.coll_id,
+                getattr(payload, "created_at", "") or "",
+            ),
+        )
+
+    def _v0_collection_superseded(self, payload: Any) -> None:
+        """Mark the old collection's row as superseded; emit no new row.
+
+        ``new_coll_id`` is expected to have its own ``CollectionCreated``
+        already (or to follow shortly); the projector does not
+        bootstrap a row for it from the supersede event alone, which
+        would lose the canonical fields (``content_type``, ``owner_id``,
+        ``embedding_model``, ``model_version``).
+
+        If the old name has no row, the UPDATE is a safe no-op; the
+        rename verb's caller is responsible for surfacing
+        "unknown old collection" errors before the event is appended.
+        """
+        from datetime import UTC, datetime  # noqa: PLC0415
+
+        if not payload.old_coll_id or not payload.new_coll_id:
+            return
+        ts = datetime.now(UTC).isoformat()
+        self._db.execute(
+            "UPDATE collections SET superseded_by = ?, superseded_at = ? "
+            "WHERE name = ?",
+            (payload.new_coll_id, ts, payload.old_coll_id),
+        )
 
     def _v0_chunk_indexed(self, payload: Any) -> None:
         # Phase 1 SQLite has no ``chunks`` table. The chunk count is
@@ -399,8 +462,8 @@ def _build_dispatch() -> dict[tuple[str, int], Any]:
         # v: 0 — synthesized from existing JSONL
         (ev.TYPE_OWNER_REGISTERED, 0):       Projector._v0_owner_registered,
         (ev.TYPE_OWNER_DELETED, 0):          Projector._v0_owner_deleted,
-        (ev.TYPE_COLLECTION_CREATED, 0):     Projector._v0_owner_or_collection_noop,
-        (ev.TYPE_COLLECTION_SUPERSEDED, 0):  Projector._v0_owner_or_collection_noop,
+        (ev.TYPE_COLLECTION_CREATED, 0):     Projector._v0_collection_created,
+        (ev.TYPE_COLLECTION_SUPERSEDED, 0):  Projector._v0_collection_superseded,
         (ev.TYPE_DOCUMENT_REGISTERED, 0):    Projector._v0_document_registered,
         (ev.TYPE_DOCUMENT_RENAMED, 0):       Projector._v0_document_renamed,
         (ev.TYPE_DOCUMENT_ALIASED, 0):       Projector._v0_document_aliased,

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3967,9 +3967,17 @@ def _print_collections_drift_text(report: dict) -> None:
         )
         for n in report["projection_not_in_t3"]:
             click.echo(f"    {n}")
+        # 'rename-collection' would refuse here (it requires the old
+        # T3 collection to exist). Direct supersede is the correct
+        # recovery; a future 'nx catalog supersede-collection' verb
+        # would wrap this script.
         click.echo(
-            "  Remediate: nx catalog rename-collection (mark superseded) "
-            "or remove the row manually if the gap is intentional."
+            "  Remediate: register a target collection and supersede manually:\n"
+            "    python -c \"from nexus.catalog.catalog import Catalog; "
+            "from nexus.config import catalog_path; "
+            "p=catalog_path(); c=Catalog(p, p / '.catalog.db'); "
+            "c.register_collection('<TARGET>'); "
+            "c.supersede_collection('<OLD>', '<TARGET>')\""
         )
 
 
@@ -4172,6 +4180,10 @@ def _run_replay_equality() -> dict:
             "owners": _snapshot_table(live_conn, "owners"),
             "documents": _snapshot_table(live_conn, "documents"),
             "links": _snapshot_table(live_conn, "links", exclude_cols=LINKS_EXCLUDE),
+            # RDR-101 Phase 6 prophylactic-review fix: include the
+            # collections projection in replay-equality. Pre-fix this
+            # gate was blind to Phase 6's new projection state.
+            "collections": _snapshot_table(live_conn, "collections"),
         }
 
     # ── Project + snapshot ────────────────────────────────────────────
@@ -4198,12 +4210,13 @@ def _run_replay_equality() -> dict:
                 "owners": _snapshot_table(proj_conn, "owners"),
                 "documents": _snapshot_table(proj_conn, "documents"),
                 "links": _snapshot_table(proj_conn, "links", exclude_cols=LINKS_EXCLUDE),
+                "collections": _snapshot_table(proj_conn, "collections"),
             }
 
     # ── Diff ──────────────────────────────────────────────────────────
     table_diffs: dict[str, dict] = {}
     overall_pass = True
-    for table in ("owners", "documents", "links"):
+    for table in ("owners", "documents", "links", "collections"):
         live_rows = live_snap[table]
         proj_rows = projected_snap[table]
         live_set = set(live_rows)

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3525,6 +3525,17 @@ def prune_stale_cmd(
     ),
 )
 @click.option(
+    "--collections-drift",
+    "collections_drift",
+    is_flag=True,
+    help=(
+        "Phase 6 check: every T3 collection and every distinct "
+        "documents.physical_collection has a row in the collections "
+        "projection. Drift is a release blocker; remediate with "
+        "'nx catalog backfill-collections'."
+    ),
+)
+@click.option(
     "--json", "as_json", is_flag=True,
     help="Emit machine-readable JSON instead of text output.",
 )
@@ -3532,23 +3543,26 @@ def doctor_cmd(
     replay_equality: bool,
     t3_doc_id_coverage: bool,
     strict_not_in_t3: bool,
+    collections_drift: bool,
     as_json: bool,
 ) -> None:
     """RDR-101 catalog doctor surface.
 
-    Supports two checks today:
+    Supports three checks today:
       - ``--replay-equality`` (Phase 1, PR C): synthesizer + projector
         round-trip against the live SQLite.
       - ``--t3-doc-id-coverage`` (Phase 2, PR δ): T3 chunks carry the
         doc_id metadata that events.jsonl claims.
+      - ``--collections-drift`` (Phase 6, nexus-o6aa.14): every T3
+        collection and every documents.physical_collection has a row
+        in the collections projection.
 
-    Future flags (``--legacy-collection-grandfather``, etc.) land in
-    later phases.
+    Future flags land in later phases.
     """
-    if not replay_equality and not t3_doc_id_coverage:
+    if not replay_equality and not t3_doc_id_coverage and not collections_drift:
         raise click.UsageError(
-            "Pass a check flag: --replay-equality or "
-            "--t3-doc-id-coverage."
+            "Pass a check flag: --replay-equality, "
+            "--t3-doc-id-coverage, or --collections-drift."
         )
     if strict_not_in_t3 and not t3_doc_id_coverage:
         raise click.UsageError(
@@ -3605,11 +3619,120 @@ def doctor_cmd(
         if not report["pass"]:
             overall_pass = False
 
+    if collections_drift:
+        report = _run_collections_drift()
+        if as_json:
+            json_payload["collections_drift"] = report
+        else:
+            if replay_equality or t3_doc_id_coverage:
+                click.echo("")
+            _print_collections_drift_text(report)
+        if not report["pass"]:
+            overall_pass = False
+
     if as_json:
         click.echo(json.dumps(json_payload, indent=2))
 
     if not overall_pass:
         raise click.exceptions.Exit(1)
+
+
+def _run_collections_drift() -> dict:
+    """Phase 6 check: collections projection vs T3 + documents.physical_collection.
+
+    Returns ``{"pass": bool, "t3_not_in_projection": list,
+    "doc_collections_not_in_projection": list, "projection_not_in_t3": list}``.
+
+    A projection row whose ``superseded_by`` is set is allowed to be
+    absent from T3 (post-rename state). Bypass-schema collections
+    (``taxonomy__*``) are out of scope for this check.
+    """
+    from nexus.db import make_t3  # noqa: PLC0415
+
+    cat = _get_catalog()
+    try:
+        t3_db = make_t3()
+        t3_names = {
+            c["name"] for c in t3_db.list_collections()
+            if not c["name"].startswith("taxonomy__")
+        }
+    except Exception as exc:
+        return {
+            "pass": False,
+            "t3_not_in_projection": [],
+            "doc_collections_not_in_projection": [],
+            "projection_not_in_t3": [],
+            "error": f"Failed to list T3 collections: {exc}",
+        }
+
+    projection = cat.list_collections()
+    projection_names = {r["name"] for r in projection}
+    superseded_names = {
+        r["name"] for r in projection if r.get("superseded_by")
+    }
+
+    rows = cat._db.execute(
+        "SELECT DISTINCT physical_collection FROM documents "
+        "WHERE physical_collection != ''"
+    ).fetchall()
+    doc_collections = {r[0] for r in rows if r[0]}
+
+    t3_not_in_projection = sorted(t3_names - projection_names)
+    doc_not_in_projection = sorted(doc_collections - projection_names)
+    projection_not_in_t3 = sorted(
+        projection_names - t3_names - superseded_names
+    )
+
+    passed = (
+        not t3_not_in_projection
+        and not doc_not_in_projection
+        and not projection_not_in_t3
+    )
+    return {
+        "pass": passed,
+        "t3_not_in_projection": t3_not_in_projection,
+        "doc_collections_not_in_projection": doc_not_in_projection,
+        "projection_not_in_t3": projection_not_in_t3,
+    }
+
+
+def _print_collections_drift_text(report: dict) -> None:
+    if report.get("error"):
+        click.echo(f"collections-drift: ERROR - {report['error']}")
+        return
+    status = "PASS" if report["pass"] else "FAIL"
+    click.echo(f"collections-drift: {status}")
+    if report["t3_not_in_projection"]:
+        click.echo(
+            f"  T3 collections without projection rows "
+            f"({len(report['t3_not_in_projection'])}):"
+        )
+        for n in report["t3_not_in_projection"]:
+            click.echo(f"    {n}")
+        click.echo(
+            "  Remediate: nx catalog backfill-collections"
+        )
+    if report["doc_collections_not_in_projection"]:
+        click.echo(
+            f"  documents.physical_collection without projection rows "
+            f"({len(report['doc_collections_not_in_projection'])}):"
+        )
+        for n in report["doc_collections_not_in_projection"]:
+            click.echo(f"    {n}")
+        click.echo(
+            "  Remediate: nx catalog backfill-collections"
+        )
+    if report["projection_not_in_t3"]:
+        click.echo(
+            f"  Projection rows whose T3 collection is gone and not "
+            f"superseded ({len(report['projection_not_in_t3'])}):"
+        )
+        for n in report["projection_not_in_t3"]:
+            click.echo(f"    {n}")
+        click.echo(
+            "  Remediate: nx catalog rename-collection (mark superseded) "
+            "or remove the row manually if the gap is intentional."
+        )
 
 
 def _check_bootstrap_status() -> dict:

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -314,6 +314,77 @@ def setup_cmd(remote: str) -> None:
         click.echo("Setup complete.")
 
 
+@catalog.command("backfill-collections")
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    help="Report names that would be registered without writing.",
+)
+def backfill_collections_cmd(dry_run: bool) -> None:
+    """Populate the Phase 6 collections projection from existing state.
+
+    \b
+    Walks both T3 (live ChromaDB collections) and the catalog
+    documents.physical_collection column, unions the two sets, and
+    registers each name not already in the projection. The projector's
+    is_conformant_collection_name regex decides each row's
+    legacy_grandfathered flag automatically.
+
+    \b
+    Idempotent: re-running adds only the names that appeared since the
+    last run. The conventional first-time invocation is dry-run, then
+    --no-dry-run after operator review.
+
+    \b
+    Examples:
+      nx catalog backfill-collections --dry-run
+      nx catalog backfill-collections
+    """
+    from nexus.db import make_t3  # noqa: PLC0415
+
+    cat = _get_catalog()
+
+    try:
+        t3_db = make_t3()
+        t3_names = {c["name"] for c in t3_db.list_collections()}
+    except Exception as exc:
+        click.echo(f"Failed to list T3 collections: {exc}")
+        t3_names = set()
+
+    rows = cat._db.execute(
+        "SELECT DISTINCT physical_collection FROM documents "
+        "WHERE physical_collection != ''"
+    ).fetchall()
+    catalog_names = {r[0] for r in rows if r[0]}
+
+    candidate_names = sorted(t3_names | catalog_names)
+    already = {r["name"] for r in cat.list_collections()}
+    to_register = [n for n in candidate_names if n not in already]
+
+    if not to_register:
+        click.echo(
+            f"Nothing to backfill: {len(already)} collection(s) already registered, "
+            f"0 new."
+        )
+        return
+
+    verb = "would register" if dry_run else "registering"
+    click.echo(f"{verb} {len(to_register)} new collection(s):")
+    for name in to_register:
+        click.echo(f"  {name}")
+
+    if dry_run:
+        return
+
+    for name in to_register:
+        cat.register_collection(name)
+
+    click.echo(
+        f"\nDone: {len(to_register)} new, "
+        f"{len(already)} already registered."
+    )
+
+
 @catalog.command("list")
 @click.option("--owner", default="")
 @click.option("--type", "content_type", default="")

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -385,6 +385,143 @@ def backfill_collections_cmd(dry_run: bool) -> None:
     )
 
 
+@catalog.command("rename-collection")
+@click.argument("old")
+@click.argument("new")
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    help="Report the rename plan without writing.",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Required to actually rename. Without --yes (and without "
+    "--dry-run), the command falls back to report-only.",
+)
+@click.option(
+    "--allow-legacy",
+    is_flag=True,
+    default=False,
+    help="Skip the is_conformant_collection_name gate on the new name. "
+    "The renamed collection still gets a row in the projection but is "
+    "flagged legacy_grandfathered=True. Use only when migrating between "
+    "two grandfathered names (rare).",
+)
+def rename_collection_cmd(
+    old: str, new: str, dry_run: bool, yes: bool, allow_legacy: bool,
+) -> None:
+    """Rename a collection with full RDR-101 Phase 6 lifecycle.
+
+    \b
+    Combines the data-plane rename (T3 native modify + T2 cascade +
+    catalog documents re-point) with the Phase 6 control-plane work
+    (collections-projection update + CollectionSuperseded event
+    emission). Operators wanting only the data plane can use
+    ``nx collection rename`` instead; this verb is the canonical
+    Phase 6 path that keeps the event log and projection in sync.
+
+    \b
+    Validation gates fire BEFORE any side effect:
+      - new name must be conformant (or pass --allow-legacy)
+      - old name must be in the collections projection
+      - old name must not already be superseded
+      - new name must not already exist in T3
+
+    \b
+    Examples:
+      nx catalog rename-collection knowledge__delos \\
+          knowledge__1-1__voyage-context-3__v1 --yes
+      nx catalog rename-collection docs__nexus-571b8edd ... --dry-run
+    """
+    from nexus.commands.collection import (  # noqa: PLC0415
+        rename_collection_data_plane,
+    )
+    from nexus.corpus import (  # noqa: PLC0415
+        is_conformant_collection_name,
+        parse_conformant_collection_name,
+    )
+    from nexus.db import make_t3  # noqa: PLC0415
+
+    cat = _get_catalog()
+    t3_db = make_t3()
+
+    if not is_conformant_collection_name(new) and not allow_legacy:
+        raise click.ClickException(
+            f"new name {new!r} is not conformant. Expected "
+            f"<content_type>__<owner_id>__<embedding_model>__v<n>. "
+            f"Pass --allow-legacy to rename to a grandfathered name "
+            f"(rare; only when migrating between two legacy names)."
+        )
+
+    old_row = cat.get_collection(old)
+    if old_row is None:
+        raise click.ClickException(
+            f"old name {old!r} is not registered in the collections "
+            f"projection. Run 'nx catalog backfill-collections' if this "
+            f"is an existing collection that has not been registered."
+        )
+    if old_row.get("superseded_by"):
+        raise click.ClickException(
+            f"old name {old!r} is already superseded by "
+            f"{old_row['superseded_by']!r}. Refusing to rename a stale entry."
+        )
+
+    if t3_db.collection_exists(new):
+        raise click.ClickException(
+            f"new name {new!r} already exists in T3. "
+            f"Refusing to rename {old!r} on top of an existing collection."
+        )
+    if not t3_db.collection_exists(old):
+        raise click.ClickException(f"old name {old!r} does not exist in T3.")
+
+    will_run = yes and not dry_run
+    if dry_run:
+        click.echo(f"would rename: {old} -> {new}")
+        return
+    if not yes:
+        click.echo(
+            f"would rename: {old} -> {new}\n"
+            f"--no-dry-run alone is treated as report-only. "
+            f"Add --yes to actually rename."
+        )
+        return
+
+    counts = rename_collection_data_plane(
+        old, new, t3_db=t3_db, catalog=cat,
+        on_warn=lambda msg: click.echo(msg, err=True),
+    )
+
+    if is_conformant_collection_name(new):
+        segments = parse_conformant_collection_name(new)
+        cat.register_collection(
+            new,
+            content_type=segments["content_type"],
+            owner_id=segments["owner_id"],
+            embedding_model=segments["embedding_model"],
+            model_version=segments["model_version"],
+        )
+    else:
+        cat.register_collection(new)
+    cat.supersede_collection(old, new, reason="rename-collection")
+
+    parts: list[str] = []
+    if counts["tax_topics"] or counts["tax_assignments"] or counts["tax_meta"]:
+        parts.append(
+            f"{counts['tax_topics']} topics, "
+            f"{counts['tax_assignments']} assignments, "
+            f"{counts['tax_meta']} meta"
+        )
+    if counts["chash"]:
+        parts.append(f"{counts['chash']} chash rows")
+    if counts["catalog_docs"]:
+        parts.append(f"{counts['catalog_docs']} catalog docs")
+    suffix = f" ({'; '.join(parts)})" if parts else ""
+    click.echo(f"Renamed: {old} -> {new}{suffix}")
+    click.echo(f"Emitted CollectionSuperseded({old} -> {new})")
+
+
 @catalog.command("list")
 @click.option("--owner", default="")
 @click.option("--type", "content_type", default="")

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -385,6 +385,189 @@ def backfill_collections_cmd(dry_run: bool) -> None:
     )
 
 
+@catalog.command("migrate-fallback")
+@click.argument("source")
+@click.option(
+    "--target-model",
+    default="",
+    help="Override the target embedding model. Default: derived from "
+    "the source's content-type prefix (knowledge__/docs__/rdr__ → "
+    "voyage-context-3; code__ → voyage-code-3).",
+)
+@click.option(
+    "--target-version",
+    default="v1",
+    show_default=True,
+    help="Target model_version segment for new collections.",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    help="Report the migration proposal without writing.",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Required to actually migrate. Without --yes, the command "
+    "falls back to report-only.",
+)
+def migrate_fallback_cmd(
+    source: str,
+    target_model: str,
+    target_version: str,
+    dry_run: bool,
+    yes: bool,
+) -> None:
+    """Migrate documents from a fallback collection to per-owner targets.
+
+    \b
+    Walks every document in SOURCE (a fallback like ``docs__default``
+    or ``knowledge__knowledge``) and proposes a target collection per
+    document, computed as
+    ``<content_type>__<owner>__<embedding_model>__<version>`` where
+    ``content_type`` and ``embedding_model`` come from the source's
+    prefix and ``owner`` comes from each document's tumbler.
+
+    \b
+    With --yes, re-points each document's physical_collection in the
+    catalog and auto-registers the target rows in the collections
+    projection. T3 chunks are NOT moved; the catalog-side migration
+    is enough to deprecate the fallback over time. Operators
+    repopulate the target by re-running ``nx index`` against the
+    source files; old chunks become orphans whose ``nx t3 gc`` will
+    sweep on the next cycle (catalog now points elsewhere, so the
+    chunk's doc_id is no longer alive in the source collection).
+
+    \b
+    Source must NOT already be conformant; conformant collections are
+    not fallbacks. Source must be registered in the projection (run
+    ``nx catalog backfill-collections`` first if needed).
+
+    \b
+    When the migration empties the source AND every doc landed in the
+    same target, the source row is marked superseded_by that target.
+    Multiple targets leave the source NOT superseded; the operator
+    deprecates manually.
+
+    \b
+    Examples:
+      nx catalog migrate-fallback knowledge__knowledge --dry-run
+      nx catalog migrate-fallback docs__default --yes
+    """
+    from nexus.corpus import (  # noqa: PLC0415
+        is_conformant_collection_name, voyage_model_for_collection,
+    )
+
+    cat = _get_catalog()
+
+    src_row = cat.get_collection(source)
+    if src_row is None:
+        raise click.ClickException(
+            f"source {source!r} is not registered in the collections "
+            f"projection. Run 'nx catalog backfill-collections' first."
+        )
+    if is_conformant_collection_name(source):
+        raise click.ClickException(
+            f"source {source!r} is already conformant; this is not a "
+            f"fallback collection."
+        )
+
+    if "__" not in source:
+        raise click.ClickException(
+            f"source {source!r} has no content-type prefix; cannot "
+            f"derive a migration target."
+        )
+    content_type = source.split("__", 1)[0]
+
+    if not target_model:
+        target_model = voyage_model_for_collection(source)
+
+    rows = cat._db.execute(
+        "SELECT tumbler FROM documents WHERE physical_collection = ? "
+        "ORDER BY tumbler",
+        (source,),
+    ).fetchall()
+
+    if not rows:
+        click.echo(f"{source}: 0 doc(s) to migrate.")
+        return
+
+    proposals: list[tuple[str, str]] = []
+    for (tumbler,) in rows:
+        owner = _owner_segment_for_tumbler(tumbler)
+        if not owner:
+            click.echo(
+                f"  WARN: could not derive owner from tumbler {tumbler!r}; "
+                f"skipping",
+                err=True,
+            )
+            continue
+        target = f"{content_type}__{owner}__{target_model}__{target_version}"
+        proposals.append((tumbler, target))
+
+    click.echo(
+        f"{source}: {len(proposals)} doc(s) -> "
+        f"{len({t for _, t in proposals})} target collection(s)"
+    )
+    for tumbler, target in proposals:
+        click.echo(f"  {tumbler}  ->  {target}")
+
+    if dry_run:
+        return
+    if not yes:
+        click.echo(
+            "\n--no-dry-run alone is treated as report-only. "
+            "Add --yes to actually migrate."
+        )
+        return
+
+    targets_seen: set[str] = set()
+    for tumbler, target in proposals:
+        if target not in targets_seen:
+            from nexus.corpus import parse_conformant_collection_name  # noqa: PLC0415
+            segments = parse_conformant_collection_name(target)
+            cat.register_collection(
+                target,
+                content_type=segments["content_type"],
+                owner_id=segments["owner_id"],
+                embedding_model=segments["embedding_model"],
+                model_version=segments["model_version"],
+            )
+            targets_seen.add(target)
+        cat.update_document_collection(tumbler, target)
+
+    if len(targets_seen) == 1:
+        only_target = next(iter(targets_seen))
+        cat.supersede_collection(
+            source, only_target, reason="migrate-fallback",
+        )
+        click.echo(
+            f"\nMigrated {len(proposals)} doc(s); source {source!r} "
+            f"superseded by {only_target!r}."
+        )
+    else:
+        click.echo(
+            f"\nMigrated {len(proposals)} doc(s) across "
+            f"{len(targets_seen)} target collection(s). Source "
+            f"{source!r} retained (multiple targets); operator "
+            f"deprecates manually if appropriate."
+        )
+
+
+def _owner_segment_for_tumbler(tumbler: str) -> str:
+    """Return the collection-name owner segment for a tumbler.
+
+    ``1.5.42`` → ``1-5`` (owner prefix with dots replaced by hyphens
+    so the result fits ChromaDB's name regex).
+    """
+    from nexus.catalog.synthesizer import _owner_prefix_of  # noqa: PLC0415
+    prefix = _owner_prefix_of(tumbler)
+    if not prefix:
+        return ""
+    return prefix.replace(".", "-")
+
+
 @catalog.command("rename-collection")
 @click.argument("old")
 @click.argument("new")

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -317,8 +317,10 @@ def setup_cmd(remote: str) -> None:
 @catalog.command("backfill-collections")
 @click.option(
     "--dry-run/--no-dry-run",
-    default=False,
-    help="Report names that would be registered without writing.",
+    default=True,
+    help="Report-only (default). Use --no-dry-run to actually register. "
+    "Matches the safe-default convention of the other Phase 6 verbs "
+    "(rename-collection, migrate-fallback, t3 gc).",
 )
 def backfill_collections_cmd(dry_run: bool) -> None:
     """Populate the Phase 6 collections projection from existing state.
@@ -348,8 +350,16 @@ def backfill_collections_cmd(dry_run: bool) -> None:
         t3_db = make_t3()
         t3_names = {c["name"] for c in t3_db.list_collections()}
     except Exception as exc:
-        click.echo(f"Failed to list T3 collections: {exc}")
-        t3_names = set()
+        # Refusing to do a "partial" backfill that registers only the
+        # catalog-side names: an operator running this during a T3
+        # outage would get a green exit code and half the projection
+        # missing, then think the verb is idempotent (it is, but the
+        # second run after T3 recovers would silently fix it). Better
+        # to fail loud here so the operator knows to retry.
+        raise click.ClickException(
+            f"Failed to list T3 collections: {exc}. Aborting to avoid a "
+            f"partial backfill. Re-run after T3 is reachable."
+        ) from exc
 
     rows = cat._db.execute(
         "SELECT DISTINCT physical_collection FROM documents "
@@ -554,6 +564,23 @@ def migrate_fallback_cmd(
             f"deprecates manually if appropriate."
         )
 
+    # Split-brain warning: catalog now points at the new collections,
+    # but T3 chunks are still in the source. Searches against the new
+    # collections return empty for migrated docs until they are
+    # re-indexed. This is the trade-off the verb makes per the bead
+    # spec ("T3 chunks are NOT moved"); making it explicit at the
+    # output prevents an operator from silently missing it.
+    click.echo(
+        f"\nWARNING: {len(proposals)} document(s) are now SPLIT-BRAIN: "
+        f"catalog points at the new target collection(s) but T3 chunks "
+        f"remain in {source!r}. Searches against the new collection(s) "
+        f"will return empty for these docs until you run:\n"
+        f"  nx index repo .   # re-populate the target with new chunks\n"
+        f"After re-index completes, the old chunks become orphans and "
+        f"'nx t3 gc -c {source} --no-dry-run --yes' will sweep them.",
+        err=True,
+    )
+
 
 def _owner_segment_for_tumbler(tumbler: str) -> str:
     """Return the collection-name owner segment for a tumbler.
@@ -651,13 +678,20 @@ def rename_collection_cmd(
             f"{old_row['superseded_by']!r}. Refusing to rename a stale entry."
         )
 
+    # Source-exists check fires BEFORE collision check so an operator
+    # who typoes the old name gets "old not found" rather than "new
+    # already exists" (the latter is misleading when old never existed).
+    if not t3_db.collection_exists(old):
+        raise click.ClickException(f"old name {old!r} does not exist in T3.")
+    if old == new:
+        raise click.ClickException(
+            f"old and new names are identical ({old!r}); rename is a no-op."
+        )
     if t3_db.collection_exists(new):
         raise click.ClickException(
             f"new name {new!r} already exists in T3. "
             f"Refusing to rename {old!r} on top of an existing collection."
         )
-    if not t3_db.collection_exists(old):
-        raise click.ClickException(f"old name {old!r} does not exist in T3.")
 
     will_run = yes and not dry_run
     if dry_run:
@@ -676,18 +710,38 @@ def rename_collection_cmd(
         on_warn=lambda msg: click.echo(msg, err=True),
     )
 
-    if is_conformant_collection_name(new):
-        segments = parse_conformant_collection_name(new)
-        cat.register_collection(
-            new,
-            content_type=segments["content_type"],
-            owner_id=segments["owner_id"],
-            embedding_model=segments["embedding_model"],
-            model_version=segments["model_version"],
+    # T3 has been renamed by this point. If projection writes raise,
+    # we end up with T3 ahead of the projection. Catch and surface so
+    # the operator knows what state the system is in - a half-applied
+    # rename is recoverable but only if the operator has the recovery
+    # plan in front of them.
+    try:
+        if is_conformant_collection_name(new):
+            segments = parse_conformant_collection_name(new)
+            cat.register_collection(
+                new,
+                content_type=segments["content_type"],
+                owner_id=segments["owner_id"],
+                embedding_model=segments["embedding_model"],
+                model_version=segments["model_version"],
+            )
+        else:
+            cat.register_collection(new)
+        cat.supersede_collection(old, new, reason="rename-collection")
+    except Exception as exc:
+        click.echo(
+            f"WARN: T3 was renamed {old!r} -> {new!r} but the projection "
+            f"update failed: {exc}. Recover by running:\n"
+            f"  nx catalog backfill-collections --no-dry-run  "
+            f"# registers {new!r}\n"
+            f"  python -c \"from nexus.catalog.catalog import Catalog; "
+            f"from nexus.config import catalog_path; "
+            f"p=catalog_path(); "
+            f"Catalog(p, p / '.catalog.db').supersede_collection("
+            f"{old!r}, {new!r})\"",
+            err=True,
         )
-    else:
-        cat.register_collection(new)
-    cat.supersede_collection(old, new, reason="rename-collection")
+        raise click.exceptions.Exit(2) from exc
 
     parts: list[str] = []
     if counts["tax_topics"] or counts["tax_assignments"] or counts["tax_meta"]:
@@ -3831,13 +3885,14 @@ def _run_collections_drift() -> dict:
     (``taxonomy__*``) are out of scope for this check.
     """
     from nexus.db import make_t3  # noqa: PLC0415
+    from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES  # noqa: PLC0415
 
     cat = _get_catalog()
     try:
         t3_db = make_t3()
         t3_names = {
             c["name"] for c in t3_db.list_collections()
-            if not c["name"].startswith("taxonomy__")
+            if not c["name"].startswith(_BYPASS_SCHEMA_PREFIXES)
         }
     except Exception as exc:
         return {

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -172,6 +172,79 @@ def delete_cmd(name: str, yes: bool) -> None:
         click.echo(f"Deleted: {name}")
 
 
+def rename_collection_data_plane(
+    old: str,
+    new: str,
+    *,
+    t3_db=None,
+    catalog=None,
+    on_warn: Callable[[str], None] | None = None,
+) -> dict[str, int]:
+    """Rename a collection across T3 + T2 + catalog cascades.
+
+    Extracted from ``rename_cmd`` so RDR-101 Phase 6's
+    ``nx catalog rename-collection`` can reuse the data-plane logic
+    without re-implementing the cascade. Pure function shape: takes
+    explicit T3 / Catalog handles, returns counts, raises only on the
+    hard validation failures (collection missing, already exists). T2
+    + catalog cascades are best-effort (T3 is already renamed by the
+    time they run, and rolling back a rename is nontrivial).
+
+    Returns a dict with keys ``tax_topics``, ``tax_assignments``,
+    ``tax_meta``, ``chash``, ``catalog_docs`` so callers can render
+    their own summaries.
+
+    ``on_warn`` is invoked with a string message when a cascade
+    fails open. The CLI default routes it to ``click.echo(...,
+    err=True)``; callers in non-CLI contexts can pass their own.
+    """
+    if on_warn is None:
+        on_warn = lambda msg: click.echo(msg, err=True)  # noqa: E731
+
+    if t3_db is None:
+        t3_db = _t3()
+
+    if not t3_db.collection_exists(old):
+        raise click.ClickException(f"collection not found: {old!r}")
+    if t3_db.collection_exists(new):
+        raise click.ClickException(f"collection already exists: {new!r}")
+
+    t3_db.rename_collection(old, new)
+
+    counts = {
+        "tax_topics": 0,
+        "tax_assignments": 0,
+        "tax_meta": 0,
+        "chash": 0,
+        "catalog_docs": 0,
+    }
+
+    try:
+        from nexus.commands._helpers import default_db_path  # noqa: PLC0415
+        from nexus.db.t2 import T2Database  # noqa: PLC0415
+
+        with T2Database(default_db_path()) as t2db:
+            tax = t2db.taxonomy.rename_collection(old, new)
+            counts["tax_topics"] = tax.get("topics", 0)
+            counts["tax_assignments"] = tax.get("assignments", 0)
+            counts["tax_meta"] = tax.get("meta", 0)
+            counts["chash"] = t2db.chash_index.rename_collection(old=old, new=new)
+    except Exception as exc:
+        on_warn(f"warn: T3 rename succeeded but T2 cascade failed: {exc}")
+
+    try:
+        if catalog is None:
+            from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+            from nexus.config import catalog_path  # noqa: PLC0415
+            cat_path = catalog_path()
+            catalog = Catalog(cat_path, cat_path / ".catalog.db")
+        counts["catalog_docs"] = catalog.rename_collection(old, new)
+    except Exception as exc:
+        on_warn(f"warn: T3 rename succeeded but catalog cascade failed: {exc}")
+
+    return counts
+
+
 @collection.command("rename")
 @click.argument("old")
 @click.argument("new")
@@ -206,55 +279,19 @@ def rename_cmd(old: str, new: str, force_prefix_change: bool) -> None:
             f"an orphaned collection with the wrong prefix)."
         )
 
-    db = _t3()
-    if not db.collection_exists(old):
-        raise click.ClickException(f"collection not found: {old!r}")
-    if db.collection_exists(new):
-        raise click.ClickException(f"collection already exists: {new!r}")
-
-    db.rename_collection(old, new)
-
-    # Cascade T2 + catalog. Fail-open: log and continue — T3 is already
-    # renamed, and rolling back a rename is nontrivial (would need a
-    # second modify(name=old)).
-    tax_counts: dict[str, int] | None = None
-    chash_updated = 0
-    cat_updated = 0
-    try:
-        from nexus.commands._helpers import default_db_path
-        from nexus.db.t2 import T2Database
-
-        with T2Database(default_db_path()) as t2db:
-            tax_counts = t2db.taxonomy.rename_collection(old, new)
-            chash_updated = t2db.chash_index.rename_collection(old=old, new=new)
-    except Exception as exc:
-        click.echo(
-            f"warn: T3 rename succeeded but T2 cascade failed: {exc}",
-            err=True,
-        )
-
-    try:
-        from nexus.catalog.catalog import Catalog
-        from nexus.config import catalog_path
-        cat_path = catalog_path()
-        cat_updated = Catalog(cat_path, cat_path / ".catalog.db").rename_collection(old, new)
-    except Exception as exc:
-        click.echo(
-            f"warn: T3 rename succeeded but catalog cascade failed: {exc}",
-            err=True,
-        )
+    counts = rename_collection_data_plane(old, new)
 
     parts: list[str] = []
-    if tax_counts and any(tax_counts.values()):
+    if counts["tax_topics"] or counts["tax_assignments"] or counts["tax_meta"]:
         parts.append(
-            f"{tax_counts['topics']} topics, "
-            f"{tax_counts['assignments']} assignments, "
-            f"{tax_counts['meta']} meta"
+            f"{counts['tax_topics']} topics, "
+            f"{counts['tax_assignments']} assignments, "
+            f"{counts['tax_meta']} meta"
         )
-    if chash_updated:
-        parts.append(f"{chash_updated} chash rows")
-    if cat_updated:
-        parts.append(f"{cat_updated} catalog docs")
+    if counts["chash"]:
+        parts.append(f"{counts['chash']} chash rows")
+    if counts["catalog_docs"]:
+        parts.append(f"{counts['catalog_docs']} catalog docs")
     if parts:
         click.echo(f"Renamed: {old} → {new} ({'; '.join(parts)})")
     else:

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -6,6 +6,12 @@
 collection's source_path values, removes chunks whose on-disk source
 file is missing.
 
+``nx t3 gc`` (RDR-101 Phase 6 / nexus-r5eo) is the SOLE post-Phase-3
+emitter of ``ChunkOrphaned`` events and the SOLE post-Phase-3 path that
+deletes T3 chunks. It joins the catalog projection (alive doc_ids per
+collection) with T3 chunk metadata and removes chunks whose ``doc_id``
+is dead AND whose ``indexed_at`` predates the orphan window.
+
 The collection mode iterates ``T3Database.list_unique_source_paths``
 plus a ``Path(p).exists()`` check; the staleness predicate is
 intentionally simple (file present / absent) — broken-symlink
@@ -20,12 +26,51 @@ Out of scope:
 """
 from __future__ import annotations
 
+import re
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import click
 import structlog
 
 _log = structlog.get_logger(__name__)
+
+
+_DEFAULT_ORPHAN_WINDOW = "30d"
+_WINDOW_PATTERN = re.compile(r"^\s*(\d+)\s*([smhdw])\s*$", re.IGNORECASE)
+_WINDOW_UNIT_SECONDS = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+    "w": 604800,
+}
+
+
+def _parse_orphan_window(spec: str) -> timedelta:
+    """Parse ``"30d"`` / ``"24h"`` / ``"2w"`` into a :class:`timedelta`.
+
+    Supports s/m/h/d/w suffixes. A bare integer is rejected: operators
+    must be explicit about the unit so a typo cannot silently mean
+    ``30 seconds`` instead of ``30 days``.
+    """
+    match = _WINDOW_PATTERN.match(spec)
+    if not match:
+        raise click.BadParameter(
+            f"--orphan-window must be e.g. '30d' / '12h' / '2w', got {spec!r}"
+        )
+    n = int(match.group(1))
+    unit = match.group(2).lower()
+    return timedelta(seconds=n * _WINDOW_UNIT_SECONDS[unit])
+
+
+def _make_catalog():
+    """Construct the default Catalog. Patched in tests for isolation."""
+    from nexus.catalog.catalog import Catalog  # noqa: PLC0415
+    from nexus.config import catalog_path  # noqa: PLC0415
+
+    path = catalog_path()
+    return Catalog(path, path / ".catalog.db")
 
 
 @click.group()
@@ -141,3 +186,179 @@ def prune_stale_cmd(collection: str, dry_run: bool, confirm: bool) -> None:
         f"across {total_stale_paths} stale path(s) "
         f"in {affected_collections} collection(s)."
     )
+
+
+@t3.command("gc")
+@click.option(
+    "--collection",
+    "-c",
+    required=True,
+    help="Collection to GC. Required (orphan diff is per-collection).",
+)
+@click.option(
+    "--orphan-window",
+    default=_DEFAULT_ORPHAN_WINDOW,
+    show_default=True,
+    help="Grace period before an orphaned chunk becomes eligible for "
+    "deletion. Format: e.g. '30d', '12h', '2w'. The default protects "
+    "against transient orphans during a re-index.",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    help="Report-only (default). Use --no-dry-run to actually delete.",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Required alongside --no-dry-run to actually delete chunks. "
+    "Without --yes, the command falls back to report-only.",
+)
+def gc_cmd(
+    collection: str,
+    orphan_window: str,
+    dry_run: bool,
+    yes: bool,
+) -> None:
+    """Garbage-collect orphaned T3 chunks (RDR-101 Phase 6).
+
+    \b
+    A chunk is an orphan when:
+      - its ``doc_id`` metadata is not in the catalog projection's
+        alive set for ``--collection``, AND
+      - its ``indexed_at`` predates ``--orphan-window`` (default 30d).
+
+    \b
+    Per RF-101-3, ``nx t3 gc`` is the SOLE post-Phase-3 emitter of
+    ``ChunkOrphaned`` events and the SOLE path that physically deletes
+    T3 chunks. The strict order on each candidate is:
+
+        1. Append ``ChunkOrphaned(chunk_id, reason)`` to the event log.
+        2. Call ``T3Database.delete_by_chunk_ids`` for that chunk.
+
+    \b
+    A crash between (1) and (2) leaves the log consistent with T3 (event
+    present + delete failed): the next ``nx t3 gc`` run idempotently
+    retries the delete. The opposite ordering would leave T3 ahead of
+    the log (delete succeeded + crash before event), violating
+    replay-equality.
+
+    \b
+    Chunks missing ``doc_id`` (legacy pre-Phase-2 backfill) are
+    UNDECIDABLE here and skipped: operators must run a maintenance
+    backfill verb, not GC, to address them.
+
+    \b
+    Examples:
+      nx t3 gc -c knowledge__delos --dry-run                # report only
+      nx t3 gc -c rdr__nexus-571b8edd --no-dry-run --yes    # actually GC
+      nx t3 gc -c code__nexus --orphan-window 7d --dry-run  # tighter window
+    """
+    from nexus.catalog.event_log import EventLog  # noqa: PLC0415
+    from nexus.catalog.events import (  # noqa: PLC0415
+        ChunkOrphanedPayload,
+        make_event,
+    )
+    from nexus.db import make_t3  # noqa: PLC0415
+
+    window = _parse_orphan_window(orphan_window)
+    cutoff = datetime.now(UTC) - window
+
+    will_delete = (not dry_run) and yes
+    if (not dry_run) and not yes:
+        click.echo(
+            "--no-dry-run alone is treated as report-only. "
+            "Add --yes to actually delete chunks."
+        )
+        will_delete = False
+
+    t3_db = make_t3()
+    cat = _make_catalog()
+
+    try:
+        alive = {e.tumbler for e in cat.list_by_collection(collection)}
+    except Exception as exc:
+        click.echo(f"Failed to read catalog: {exc}")
+        raise click.exceptions.Exit(1)
+    alive_str = {str(t) for t in alive}
+
+    candidates: list[tuple[str, str]] = []
+    skipped_no_doc_id = 0
+    skipped_no_indexed_at = 0
+    skipped_within_window = 0
+
+    try:
+        chunks = list(t3_db.list_chunks_with_metadata(collection))
+    except Exception as exc:
+        click.echo(f"Failed to list chunks for {collection}: {exc}")
+        raise click.exceptions.Exit(1)
+
+    for chunk_id, meta in chunks:
+        doc_id = meta.get("doc_id", "")
+        if not doc_id:
+            skipped_no_doc_id += 1
+            continue
+        if doc_id in alive_str:
+            continue
+        indexed_at = meta.get("indexed_at", "")
+        if not indexed_at:
+            skipped_no_indexed_at += 1
+            continue
+        try:
+            indexed_dt = datetime.fromisoformat(indexed_at)
+        except ValueError:
+            skipped_no_indexed_at += 1
+            continue
+        if indexed_dt > cutoff:
+            skipped_within_window += 1
+            continue
+        candidates.append((chunk_id, doc_id))
+
+    click.echo(
+        f"{collection}: {len(candidates)} orphan chunk(s) eligible "
+        f"(window={orphan_window})"
+    )
+    if skipped_no_doc_id:
+        click.echo(f"  skipped {skipped_no_doc_id} chunk(s) with no doc_id")
+    if skipped_no_indexed_at:
+        click.echo(
+            f"  skipped {skipped_no_indexed_at} chunk(s) with no/bad indexed_at"
+        )
+    if skipped_within_window:
+        click.echo(
+            f"  skipped {skipped_within_window} chunk(s) inside the orphan window"
+        )
+
+    for chunk_id, doc_id in candidates:
+        click.echo(f"  {chunk_id}  ->  doc_id={doc_id}")
+
+    if not candidates:
+        click.echo("\nSummary: 0 orphan(s); nothing to do.")
+        return
+
+    if not will_delete:
+        click.echo(
+            f"\nSummary: would delete {len(candidates)} chunk(s) from {collection}."
+        )
+        return
+
+    event_log = EventLog(cat._dir)
+    deleted_total = 0
+    for chunk_id, doc_id in candidates:
+        # Strict order (RF-101-3): event first, then delete. A crash
+        # between them leaves the log consistent with T3 (event
+        # present, delete pending → next gc retries).
+        event = make_event(
+            ChunkOrphanedPayload(
+                chunk_id=chunk_id,
+                reason=f"doc_id {doc_id} no longer alive in {collection}",
+            )
+        )
+        event_log.append(event)
+        try:
+            deleted_total += t3_db.delete_by_chunk_ids(collection, [chunk_id])
+        except Exception as exc:
+            click.echo(f"  delete failed for {chunk_id}: {exc}")
+
+    click.echo(f"\nSummary: deleted {deleted_total} chunk(s) from {collection}.")

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -74,11 +74,24 @@ def _parse_orphan_window(spec: str) -> timedelta:
 
 
 def _make_catalog():
-    """Construct the default Catalog. Patched in tests for isolation."""
+    """Construct the default Catalog with the same init-gate that
+    ``commands/catalog.py:_get_catalog`` enforces.
+
+    Without the init gate, running ``nx t3 gc`` on a fresh install
+    either crashes with an opaque traceback inside ``Catalog.__init__``
+    or, worse, silently produces an empty alive-set so every chunk is
+    treated as orphan (catastrophic when paired with --no-dry-run --yes).
+
+    Patched in tests for isolation.
+    """
     from nexus.catalog.catalog import Catalog  # noqa: PLC0415
     from nexus.config import catalog_path  # noqa: PLC0415
 
     path = catalog_path()
+    if not Catalog.is_initialized(path):
+        raise click.ClickException(
+            "Catalog not initialized. Run 'nx catalog setup' before 'nx t3 gc'."
+        )
     return Catalog(path, path / ".catalog.db")
 
 
@@ -352,12 +365,23 @@ def gc_cmd(
         )
         return
 
+    # Strict order (RF-101-3): event first, then delete. The event-emit
+    # loop runs per-chunk so the log records each ChunkOrphaned BEFORE
+    # any chunk is deleted; the actual delete is BATCHED into one call
+    # afterward (delete_by_chunk_ids paginates internally at 300). A
+    # crash between event-emit and batch-delete leaves the log
+    # consistent with T3 (events present, all chunks still in T3); the
+    # next gc run idempotently re-emits and retries the batch.
+    #
+    # NOTE on the alive snapshot: ``alive_str`` was sampled at the top
+    # of this command. A doc registered concurrently between snapshot
+    # and execution would not appear in the alive set, so its chunks
+    # could be GC'd despite the doc being live again. Operators
+    # SHOULD NOT run gc concurrently with active indexing. The window
+    # is single-operator-driven and acceptably small in practice.
     event_log = EventLog(cat._dir)
-    deleted_total = 0
+    pending_chunk_ids: list[str] = []
     for chunk_id, doc_id in candidates:
-        # Strict order (RF-101-3): event first, then delete. A crash
-        # between them leaves the log consistent with T3 (event
-        # present, delete pending → next gc retries).
         event = make_event(
             ChunkOrphanedPayload(
                 chunk_id=chunk_id,
@@ -365,9 +389,26 @@ def gc_cmd(
             )
         )
         event_log.append(event)
-        try:
-            deleted_total += t3_db.delete_by_chunk_ids(collection, [chunk_id])
-        except Exception as exc:
-            click.echo(f"  delete failed for {chunk_id}: {exc}")
+        pending_chunk_ids.append(chunk_id)
 
-    click.echo(f"\nSummary: deleted {deleted_total} chunk(s) from {collection}.")
+    deleted_total = 0
+    delete_failed = 0
+    try:
+        deleted_total = t3_db.delete_by_chunk_ids(collection, pending_chunk_ids)
+    except Exception as exc:
+        delete_failed = len(pending_chunk_ids)
+        click.echo(
+            f"  batch delete failed ({len(pending_chunk_ids)} chunk(s)): "
+            f"{exc}. Events were emitted; next 'nx t3 gc' run will retry.",
+            err=True,
+        )
+
+    if delete_failed:
+        click.echo(
+            f"\nSummary: emitted {len(pending_chunk_ids)} ChunkOrphaned "
+            f"event(s); batch delete FAILED for {delete_failed} chunk(s)."
+        )
+    else:
+        click.echo(
+            f"\nSummary: deleted {deleted_total} chunk(s) from {collection}."
+        )

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -52,7 +52,10 @@ def _parse_orphan_window(spec: str) -> timedelta:
 
     Supports s/m/h/d/w suffixes. A bare integer is rejected: operators
     must be explicit about the unit so a typo cannot silently mean
-    ``30 seconds`` instead of ``30 days``.
+    ``30 seconds`` instead of ``30 days``. Zero (``"0d"``) is rejected:
+    a zero window means every chunk older than "now" is eligible,
+    which is rarely intentional and is dangerous when paired with
+    ``--no-dry-run --yes``.
     """
     match = _WINDOW_PATTERN.match(spec)
     if not match:
@@ -60,6 +63,12 @@ def _parse_orphan_window(spec: str) -> timedelta:
             f"--orphan-window must be e.g. '30d' / '12h' / '2w', got {spec!r}"
         )
     n = int(match.group(1))
+    if n <= 0:
+        raise click.BadParameter(
+            f"--orphan-window must be positive, got {spec!r}. "
+            f"A zero or negative window would treat every orphaned chunk "
+            f"as immediately eligible for deletion."
+        )
     unit = match.group(2).lower()
     return timedelta(seconds=n * _WINDOW_UNIT_SECONDS[unit])
 

--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -42,6 +42,57 @@ def validate_collection_name(name: str) -> None:
         )
 
 
+_CONTENT_TYPES = ("code", "docs", "rdr", "knowledge")
+_CONFORMANT_COLLECTION_RE = re.compile(
+    r"^(?P<ct>code|docs|rdr|knowledge)"
+    r"__(?P<owner>[a-zA-Z0-9-]+)"
+    r"__(?P<model>[a-z][a-z0-9-]*)"
+    r"__v(?P<ver>\d+)$"
+)
+
+
+def is_conformant_collection_name(name: str) -> bool:
+    """Return True if ``name`` matches the RDR-101 §"Collection naming"
+    canonical schema ``<content_type>__<owner_id>__<embedding_model>__v<n>``.
+
+    The bead spec uses ``@`` as the version separator; ChromaDB's name
+    regex disallows ``@``, so this implementation encodes the ``@`` as a
+    fourth ``__`` separator. Tumbler-style owner IDs (which contain
+    dots, e.g. ``1.1``) must be supplied with dots replaced by hyphens
+    so the segment fits ChromaDB's charset.
+
+    Returns False for legacy 2-segment names (``docs__nexus-571b8edd``),
+    fallback names (``docs__default``, ``knowledge__knowledge``), and
+    taxonomy-prefixed names. Such names are valid grandfathered
+    identities; this predicate only describes whether a name conforms
+    to the post-Phase-6 canonical schema. Read paths must continue to
+    accept legacy names per RDR-101 (failing-loud at read time is
+    rejected as operationally hostile).
+    """
+    return bool(_CONFORMANT_COLLECTION_RE.match(name))
+
+
+def parse_conformant_collection_name(name: str) -> dict[str, str]:
+    """Decompose a conformant name into its four canonical segments.
+
+    Raises ValueError if ``name`` is not conformant; callers wanting a
+    safe parse should gate with :func:`is_conformant_collection_name`.
+    """
+    match = _CONFORMANT_COLLECTION_RE.match(name)
+    if not match:
+        raise ValueError(
+            f"Collection name {name!r} is not conformant: "
+            f"expected <content_type>__<owner_id>__<embedding_model>__v<n>"
+        )
+    g = match.groupdict()
+    return {
+        "content_type": g["ct"],
+        "owner_id": g["owner"],
+        "embedding_model": g["model"],
+        "model_version": f"v{g['ver']}",
+    }
+
+
 def voyage_model_for_collection(collection_name: str) -> str:
     """Return the Voyage AI model for a T3 collection (index and query).
 

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -544,7 +544,9 @@ class T3Database:
 
     # ── Collection access ─────────────────────────────────────────────────────
 
-    def get_or_create_collection(self, name: str) -> chromadb.Collection:
+    def get_or_create_collection(
+        self, name: str, *, strict: bool | None = None,
+    ) -> chromadb.Collection:
         """Get or create a T3 collection with the appropriate embedding function.
 
         In local mode, the collection is created with ``hnsw:search_ef`` set to
@@ -559,9 +561,45 @@ class T3Database:
         ``nx store import`` of a ``.nxexp`` for a taxonomy collection
         recreate the right shape; without it the import would silently
         default to L2 and break cosine queries against the imported centroids.
+
+        RDR-101 Phase 6 strict mode (nexus-o6aa.14):
+        ``strict=True`` rejects NEW collection names that fail
+        :func:`nexus.corpus.is_conformant_collection_name`. Existing
+        collections (any name) are always allowed; the validator only
+        gates first-time creation. ``strict=None`` (default) reads
+        ``[catalog].strict_collection_naming`` from config; absent or
+        false keeps the existing permissive behavior so indexers and
+        tests do not break before the irreversible flip ships.
+        Operators wanting to opt out of strict mode in a config-on
+        environment can pass ``strict=False`` explicitly (the
+        backfill / migration verbs do this).
         """
-        from nexus.corpus import validate_collection_name
+        from nexus.corpus import (
+            is_conformant_collection_name, validate_collection_name,
+        )
         validate_collection_name(name)
+
+        if strict is None:
+            from nexus.config import load_config
+            strict = bool(
+                load_config().get("catalog", {}).get(
+                    "strict_collection_naming", False,
+                )
+            )
+
+        if (
+            strict
+            and not _bypass_canonical_schema(name)
+            and not self.collection_exists(name)
+            and not is_conformant_collection_name(name)
+        ):
+            raise ValueError(
+                f"Collection name {name!r} is not conformant. Expected "
+                f"<content_type>__<owner_id>__<embedding_model>__v<n>. "
+                f"Pass strict=False (or unset [catalog].strict_collection_naming) "
+                f"to allow grandfathered creation; pre-existing legacy "
+                f"collections continue to be readable regardless of strict mode."
+            )
 
         if _bypass_canonical_schema(name):
             metadata: dict = {"hnsw:space": "cosine"}

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import os
 import threading
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Literal
@@ -1173,6 +1174,67 @@ class T3Database:
         if ids:
             self._delete_batch(col, collection_name, ids)
         return len(ids)
+
+    def list_chunks_with_metadata(
+        self,
+        collection_name: str,
+        *,
+        fields: tuple[str, ...] = ("doc_id", "indexed_at"),
+    ) -> Iterator[tuple[str, dict[str, str]]]:
+        """Yield ``(chunk_id, metadata_subset)`` for every chunk in a collection.
+
+        Paginates ``col.get()`` to respect the ChromaDB Cloud 300-record
+        limit. ``metadata_subset`` contains only the requested ``fields``,
+        with empty strings for missing keys, so callers do not need to
+        guard each key access. The default fields support RDR-101 Phase 6
+        ``nx t3 gc`` (``doc_id`` for orphan detection, ``indexed_at`` for
+        the orphan-window filter).
+        """
+        try:
+            col = self._client_for(collection_name).get_collection(collection_name)
+        except _ChromaNotFoundError:
+            return
+        offset = 0
+        page_limit = QUOTAS.MAX_RECORDS_PER_WRITE
+        while True:
+            result = _chroma_with_retry(
+                col.get,
+                include=["metadatas"],
+                limit=page_limit,
+                offset=offset,
+            )
+            page_ids = result.get("ids") or []
+            page_metas = result.get("metadatas") or []
+            if not page_ids:
+                break
+            for cid, meta in zip(page_ids, page_metas):
+                if not isinstance(meta, dict):
+                    meta = {}
+                yield cid, {f: str(meta.get(f, "")) for f in fields}
+            offset += len(page_ids)
+            if len(page_ids) < page_limit:
+                break
+
+    def delete_by_chunk_ids(
+        self, collection_name: str, chunk_ids: list[str],
+    ) -> int:
+        """Delete chunks by explicit Chroma id. Returns count deleted.
+
+        The per-chunk-id deletion primitive used by ``nx t3 gc`` (RDR-101
+        Phase 6) and any future maintenance verb that selects orphan
+        candidates outside the ``source_path``/``doc_id`` join paths.
+        Empty ``chunk_ids`` is a no-op (returns 0); missing collection
+        returns 0 without raising. Same paginated batching as
+        :meth:`delete_by_source` via :meth:`_delete_batch`.
+        """
+        if not chunk_ids:
+            return 0
+        try:
+            col = self._client_for(collection_name).get_collection(collection_name)
+        except _ChromaNotFoundError:
+            return 0
+        self._delete_batch(col, collection_name, chunk_ids)
+        return len(chunk_ids)
 
     def update_source_path(
         self, collection_name: str, old_path: str, new_path: str

--- a/tests/test_catalog_backfill_collections.py
+++ b/tests/test_catalog_backfill_collections.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-101 Phase 6: ``nx catalog backfill-collections`` verb.
+
+The collections projection ships empty in existing catalogs because the
+table is added by the Phase 6 schema and CollectionCreated events were
+no-ops in Phases 1-5. This verb walks both T3 (live ChromaDB) and the
+catalog ``documents.physical_collection`` column, unions their
+collection-name sets, and emits a CollectionCreated event for each
+name not already in the projection.
+
+Conformance is decided by the projector via
+``is_conformant_collection_name`` — we don't pre-decide here. The
+backfill writer supplies empty canonical fields, which the projector
+preserves verbatim; conformant names that callers want decomposed
+into segments should re-register with the parsed segments after
+backfill.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.cli import main
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def catalog(tmp_path):
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+    db_path = tmp_path / "catalog.sqlite"
+    return Catalog(catalog_dir=catalog_dir, db_path=db_path)
+
+
+def _seed_document(catalog: Catalog, *, tumbler: str, collection: str) -> None:
+    catalog._db.execute(
+        "INSERT INTO documents "
+        "(tumbler, title, author, year, content_type, file_path, "
+        "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+        "metadata, source_mtime, alias_of, source_uri) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            tumbler, f"doc-{tumbler}", "", 0, "text", f"/tmp/{tumbler}.md",
+            "", collection, 1, "", "", "{}", 0.0, "", "",
+        ),
+    )
+    catalog._db.commit()
+
+
+class _FakeT3:
+    """Minimal stand-in for T3Database.list_collections.
+
+    Returns a list of {"name": str} dicts, mirroring the real method's
+    shape (matches usage in commands/t3.py prune-stale).
+    """
+
+    def __init__(self, names: list[str]) -> None:
+        self._names = names
+
+    def list_collections(self) -> list[dict]:
+        return [{"name": n} for n in self._names]
+
+
+def test_backfill_registers_t3_and_catalog_collections(catalog, runner):
+    """Every name from T3 and from documents.physical_collection becomes
+    a row in the collections projection.
+    """
+    fake_t3 = _FakeT3(
+        names=[
+            "code__1-1__voyage-code-3__v1",  # conformant
+            "knowledge__delos",              # legacy
+            "rdr__nexus-571b8edd",           # legacy
+        ]
+    )
+    _seed_document(catalog, tumbler="1.1.1", collection="docs__nexus-571b8edd")
+
+    with patch("nexus.db.make_t3", return_value=fake_t3), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(main, ["catalog", "backfill-collections"])
+
+    assert result.exit_code == 0, result.output
+    rows = catalog.list_collections()
+    names = sorted(r["name"] for r in rows)
+    assert names == [
+        "code__1-1__voyage-code-3__v1",
+        "docs__nexus-571b8edd",
+        "knowledge__delos",
+        "rdr__nexus-571b8edd",
+    ]
+
+
+def test_backfill_marks_legacy_via_projector(catalog, runner):
+    """Non-conformant names land with legacy_grandfathered=True;
+    conformant names land False.
+    """
+    fake_t3 = _FakeT3(
+        names=[
+            "code__1-1__voyage-code-3__v1",
+            "knowledge__delos",
+        ]
+    )
+
+    with patch("nexus.db.make_t3", return_value=fake_t3), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(main, ["catalog", "backfill-collections"])
+
+    assert result.exit_code == 0, result.output
+    assert catalog.is_legacy_collection("knowledge__delos") is True
+    assert catalog.is_legacy_collection("code__1-1__voyage-code-3__v1") is False
+
+
+def test_backfill_idempotent(catalog, runner):
+    """Re-running backfill on an already-backfilled catalog produces
+    one row per name (no duplicates) and reports zero new rows.
+    """
+    fake_t3 = _FakeT3(names=["knowledge__delos"])
+
+    with patch("nexus.db.make_t3", return_value=fake_t3), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        runner.invoke(main, ["catalog", "backfill-collections"])
+        result = runner.invoke(main, ["catalog", "backfill-collections"])
+
+    assert result.exit_code == 0
+    rows = catalog._db.execute(
+        "SELECT COUNT(*) FROM collections WHERE name = ?",
+        ("knowledge__delos",),
+    ).fetchone()
+    assert rows[0] == 1
+
+
+def test_backfill_dry_run_no_writes(catalog, runner):
+    """``--dry-run`` reports the candidates and writes nothing."""
+    fake_t3 = _FakeT3(names=["knowledge__delos", "docs__nexus-571b8edd"])
+
+    with patch("nexus.db.make_t3", return_value=fake_t3), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main, ["catalog", "backfill-collections", "--dry-run"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "knowledge__delos" in result.output
+    assert "docs__nexus-571b8edd" in result.output
+    assert "would register" in result.output
+    rows = catalog._db.execute("SELECT COUNT(*) FROM collections").fetchone()
+    assert rows[0] == 0
+
+
+def test_backfill_empty_t3_and_catalog(catalog, runner):
+    """Nothing to backfill produces a clean zero summary."""
+    fake_t3 = _FakeT3(names=[])
+
+    with patch("nexus.db.make_t3", return_value=fake_t3), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(main, ["catalog", "backfill-collections"])
+
+    assert result.exit_code == 0
+    assert "0" in result.output
+
+
+def test_backfill_skips_already_registered(catalog, runner):
+    """Names already in the collections projection are not re-emitted."""
+    catalog.register_collection("knowledge__delos")
+    fake_t3 = _FakeT3(names=["knowledge__delos", "docs__nexus-571b8edd"])
+
+    with patch("nexus.db.make_t3", return_value=fake_t3), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(main, ["catalog", "backfill-collections"])
+
+    assert result.exit_code == 0, result.output
+    rows = catalog.list_collections()
+    names = sorted(r["name"] for r in rows)
+    assert names == ["docs__nexus-571b8edd", "knowledge__delos"]
+    assert "1 new" in result.output or "1 collection" in result.output

--- a/tests/test_catalog_backfill_collections.py
+++ b/tests/test_catalog_backfill_collections.py
@@ -10,7 +10,7 @@ collection-name sets, and emits a CollectionCreated event for each
 name not already in the projection.
 
 Conformance is decided by the projector via
-``is_conformant_collection_name`` — we don't pre-decide here. The
+``is_conformant_collection_name``, not by the caller. The
 backfill writer supplies empty canonical fields, which the projector
 preserves verbatim; conformant names that callers want decomposed
 into segments should re-register with the parsed segments after

--- a/tests/test_catalog_backfill_collections.py
+++ b/tests/test_catalog_backfill_collections.py
@@ -84,7 +84,7 @@ def test_backfill_registers_t3_and_catalog_collections(catalog, runner):
 
     with patch("nexus.db.make_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
-        result = runner.invoke(main, ["catalog", "backfill-collections"])
+        result = runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
 
     assert result.exit_code == 0, result.output
     rows = catalog.list_collections()
@@ -110,7 +110,7 @@ def test_backfill_marks_legacy_via_projector(catalog, runner):
 
     with patch("nexus.db.make_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
-        result = runner.invoke(main, ["catalog", "backfill-collections"])
+        result = runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
 
     assert result.exit_code == 0, result.output
     assert catalog.is_legacy_collection("knowledge__delos") is True
@@ -125,8 +125,8 @@ def test_backfill_idempotent(catalog, runner):
 
     with patch("nexus.db.make_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
-        runner.invoke(main, ["catalog", "backfill-collections"])
-        result = runner.invoke(main, ["catalog", "backfill-collections"])
+        runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
+        result = runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
 
     assert result.exit_code == 0
     rows = catalog._db.execute(
@@ -160,10 +160,11 @@ def test_backfill_empty_t3_and_catalog(catalog, runner):
 
     with patch("nexus.db.make_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
-        result = runner.invoke(main, ["catalog", "backfill-collections"])
+        result = runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
 
     assert result.exit_code == 0
-    assert "0" in result.output
+    assert "Nothing to backfill" in result.output
+    assert "0 new" in result.output
 
 
 def test_backfill_skips_already_registered(catalog, runner):
@@ -173,10 +174,37 @@ def test_backfill_skips_already_registered(catalog, runner):
 
     with patch("nexus.db.make_t3", return_value=fake_t3), \
          patch("nexus.commands.catalog._get_catalog", return_value=catalog):
-        result = runner.invoke(main, ["catalog", "backfill-collections"])
+        result = runner.invoke(main, ["catalog", "backfill-collections", "--no-dry-run"])
 
     assert result.exit_code == 0, result.output
     rows = catalog.list_collections()
     names = sorted(r["name"] for r in rows)
     assert names == ["docs__nexus-571b8edd", "knowledge__delos"]
-    assert "1 new" in result.output or "1 collection" in result.output
+    assert "Done: 1 new" in result.output
+
+
+def test_backfill_aborts_on_t3_failure(catalog, runner):
+    """T3 list_collections raising must abort the verb with a non-zero
+    exit, NOT silently fall back to a catalog-only partial backfill.
+
+    A partial backfill is operationally hostile: the operator gets a
+    green exit and half the projection missing. Re-running the verb
+    after T3 recovers would silently fix it, but the operator never
+    learned T3 was down to begin with.
+    """
+    class _BrokenT3:
+        def list_collections(self):
+            raise RuntimeError("t3 unreachable")
+
+    _seed_document(catalog, tumbler="1.1.1", collection="docs__nexus-571b8edd")
+
+    with patch("nexus.db.make_t3", return_value=_BrokenT3()), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main, ["catalog", "backfill-collections", "--no-dry-run"],
+        )
+    assert result.exit_code != 0
+    assert "Failed to list T3 collections" in result.output
+    # No partial backfill happened
+    rows = catalog._db.execute("SELECT COUNT(*) FROM collections").fetchone()
+    assert rows[0] == 0

--- a/tests/test_catalog_collections.py
+++ b/tests/test_catalog_collections.py
@@ -233,11 +233,125 @@ def test_supersede_collection_marks_old_and_emits_event(catalog):
 
 
 def test_supersede_unknown_old_collection_raises(catalog):
+    catalog.register_collection("docs__1-1__voyage-context-3__v1",
+                                content_type="docs", owner_id="1-1",
+                                embedding_model="voyage-context-3",
+                                model_version="v1")
     with pytest.raises(ValueError, match="not registered"):
         catalog.supersede_collection(
             "never_seen",
             "docs__1-1__voyage-context-3__v1",
         )
+
+
+def test_supersede_already_superseded_raises(catalog):
+    """Superseding a name that already has superseded_by set is rejected;
+    silently overwriting would orphan the prior CollectionSuperseded
+    event in the log.
+    """
+    catalog.register_collection("docs__nexus-571b8edd")
+    catalog.register_collection(
+        "docs__1-1__voyage-context-3__v1",
+        content_type="docs", owner_id="1-1",
+        embedding_model="voyage-context-3", model_version="v1",
+    )
+    catalog.register_collection(
+        "docs__1-1__voyage-context-3__v2",
+        content_type="docs", owner_id="1-1",
+        embedding_model="voyage-context-3", model_version="v2",
+    )
+    catalog.supersede_collection(
+        "docs__nexus-571b8edd", "docs__1-1__voyage-context-3__v1",
+    )
+    with pytest.raises(ValueError, match="already superseded"):
+        catalog.supersede_collection(
+            "docs__nexus-571b8edd", "docs__1-1__voyage-context-3__v2",
+        )
+
+
+def test_supersede_unregistered_new_raises(catalog):
+    """Refuse to point superseded_by at a non-existent collection;
+    that produces a dangling pointer no foreign-key-style join can
+    resolve.
+    """
+    catalog.register_collection("docs__nexus-571b8edd")
+    with pytest.raises(ValueError, match="new .* is not.*registered"):
+        catalog.supersede_collection(
+            "docs__nexus-571b8edd", "docs__never-registered",
+        )
+
+
+def test_register_collection_short_circuits_on_identical_re_call(catalog):
+    """Re-calling register_collection with identical canonical fields
+    must NOT append a duplicate event (log-bloat smell).
+    """
+    catalog.register_collection(
+        "code__1-1__voyage-code-3__v1",
+        content_type="code", owner_id="1-1",
+        embedding_model="voyage-code-3", model_version="v1",
+    )
+    events_after_first = [
+        e for e in EventLog(catalog._dir).replay()
+        if e.type == TYPE_COLLECTION_CREATED
+    ]
+    catalog.register_collection(
+        "code__1-1__voyage-code-3__v1",
+        content_type="code", owner_id="1-1",
+        embedding_model="voyage-code-3", model_version="v1",
+    )
+    events_after_second = [
+        e for e in EventLog(catalog._dir).replay()
+        if e.type == TYPE_COLLECTION_CREATED
+    ]
+    assert len(events_after_first) == 1
+    assert len(events_after_second) == 1
+
+
+def test_register_collection_re_emits_on_field_change(catalog):
+    """If a canonical field changes between calls, the new event is
+    emitted so the projection picks up the new value.
+    """
+    catalog.register_collection("code__nexus-571b8edd")  # legacy form, empty fields
+    catalog.register_collection(
+        "code__nexus-571b8edd",
+        embedding_model="voyage-code-3",  # operator filling in metadata
+    )
+    events = [
+        e for e in EventLog(catalog._dir).replay()
+        if e.type == TYPE_COLLECTION_CREATED
+    ]
+    assert len(events) == 2  # both calls emitted
+
+
+def test_idempotent_supersede_skipped_due_to_already_superseded(catalog):
+    """A second supersede on the same name must NOT silently extend
+    the chain; the test_supersede_already_superseded_raises test covers
+    the raise. This case also confirms no extra event lands in the
+    log if the call raised.
+    """
+    catalog.register_collection("docs__nexus-571b8edd")
+    catalog.register_collection(
+        "docs__1-1__voyage-context-3__v1",
+        content_type="docs", owner_id="1-1",
+        embedding_model="voyage-context-3", model_version="v1",
+    )
+    catalog.register_collection(
+        "docs__1-1__voyage-context-3__v2",
+        content_type="docs", owner_id="1-1",
+        embedding_model="voyage-context-3", model_version="v2",
+    )
+    catalog.supersede_collection(
+        "docs__nexus-571b8edd", "docs__1-1__voyage-context-3__v1",
+    )
+    with pytest.raises(ValueError):
+        catalog.supersede_collection(
+            "docs__nexus-571b8edd", "docs__1-1__voyage-context-3__v2",
+        )
+    events = [
+        e for e in EventLog(catalog._dir).replay()
+        if e.type == TYPE_COLLECTION_SUPERSEDED
+    ]
+    assert len(events) == 1  # second call raised, did not write
 
 
 # ── Projector replay ─────────────────────────────────────────────────────

--- a/tests/test_catalog_collections.py
+++ b/tests/test_catalog_collections.py
@@ -30,10 +30,15 @@ import pytest
 from nexus.catalog.catalog import Catalog
 from nexus.catalog.event_log import EventLog
 from nexus.catalog.events import (
+    CollectionSupersededPayload,
     TYPE_COLLECTION_CREATED,
     TYPE_COLLECTION_SUPERSEDED,
+    make_event,
 )
-from nexus.corpus import is_conformant_collection_name
+from nexus.corpus import (
+    is_conformant_collection_name,
+    parse_conformant_collection_name,
+)
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────
@@ -321,6 +326,84 @@ def test_register_collection_re_emits_on_field_change(catalog):
         if e.type == TYPE_COLLECTION_CREATED
     ]
     assert len(events) == 2  # both calls emitted
+
+
+def test_parse_conformant_collection_name_raises_on_legacy(catalog):
+    """parse_conformant_collection_name must raise on non-conformant names.
+
+    Pass-#2 review (2026-05-03) found this raise path had no direct
+    test coverage. The regex gate makes false-non-conformant impossible
+    in production, but the docstring documents the contract.
+    """
+    with pytest.raises(ValueError, match="not conformant"):
+        parse_conformant_collection_name("docs__nexus-571b8edd")
+    with pytest.raises(ValueError, match="not conformant"):
+        parse_conformant_collection_name("knowledge__delos")
+    with pytest.raises(ValueError, match="not conformant"):
+        parse_conformant_collection_name("totally__malformed__weird")
+
+
+def test_v0_collection_superseded_blank_id_guard(catalog):
+    """Direct projector test: a malformed CollectionSuperseded event
+    with empty old_coll_id or new_coll_id is treated as a no-op,
+    not crashed.
+
+    Pass-#2 review found the guard was untested; if it were silently
+    removed the doctor's replay-equality check would still pass
+    against well-formed events while crashing on a single replay of a
+    malformed line.
+    """
+    catalog.register_collection("docs__nexus-571b8edd")
+
+    # Both fields missing
+    event_blank_old = make_event(
+        CollectionSupersededPayload(old_coll_id="", new_coll_id="x"), v=0,
+    )
+    catalog._projector.apply(event_blank_old)
+    catalog._db.commit()
+    # Row unchanged
+    assert catalog.get_collection("docs__nexus-571b8edd")["superseded_by"] == ""
+
+    event_blank_new = make_event(
+        CollectionSupersededPayload(
+            old_coll_id="docs__nexus-571b8edd", new_coll_id="",
+        ),
+        v=0,
+    )
+    catalog._projector.apply(event_blank_new)
+    catalog._db.commit()
+    assert catalog.get_collection("docs__nexus-571b8edd")["superseded_by"] == ""
+
+
+def test_update_document_collection_returns_false_on_unknown_tumbler(catalog):
+    """update_document_collection must return False (no-op) when the
+    document is not registered. Documented contract; pass-#2 review
+    found no direct test.
+    """
+    assert catalog.update_document_collection(
+        "1.99.99", "knowledge__1-1__voyage-context-3__v1",
+    ) is False
+
+
+def test_update_document_collection_idempotent_on_same_target(catalog):
+    """Re-pointing a doc to its current physical_collection is a no-op
+    (returns False; no event written).
+    """
+    catalog._db.execute(
+        "INSERT INTO documents "
+        "(tumbler, title, author, year, content_type, file_path, "
+        "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+        "metadata, source_mtime, alias_of, source_uri) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "1.5.1", "doc-1.5.1", "", 0, "text", "/tmp/x.md",
+            "", "knowledge__delos", 1, "", "", "{}", 0.0, "", "",
+        ),
+    )
+    catalog._db.commit()
+    assert catalog.update_document_collection(
+        "1.5.1", "knowledge__delos",  # already at this collection
+    ) is False
 
 
 def test_idempotent_supersede_skipped_due_to_already_superseded(catalog):

--- a/tests/test_catalog_collections.py
+++ b/tests/test_catalog_collections.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-101 Phase 6 (nexus-o6aa.14): collections table + Catalog API.
+
+Adds a first-class Collections projection to catalog SQLite (one row per
+ChromaDB collection name, materialized from CollectionCreated events).
+The legacy_grandfathered flag is projection-derived from the
+``is_conformant_collection_name`` regex; no event-schema extension.
+
+Covered here:
+
+  - ``Catalog.register_collection`` writes the SQLite row AND appends a
+    CollectionCreated event under v: 0 schema.
+  - Re-registering the same name is idempotent at the SQLite level
+    (INSERT OR REPLACE) and acceptable at the event level (events are
+    append-only; idempotency check is at the projector, not the writer).
+  - ``Catalog.list_collections`` and ``Catalog.get_collection`` return
+    the projected rows.
+  - ``Catalog.is_legacy_collection`` reads the projection's
+    ``legacy_grandfathered`` flag.
+  - ``Catalog.supersede_collection`` updates the row and emits
+    CollectionSuperseded.
+  - Replay of a CollectionCreated event from a fresh Catalog produces
+    the same projected row (replay-equality at the per-table level).
+"""
+from __future__ import annotations
+
+import pytest
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.events import (
+    TYPE_COLLECTION_CREATED,
+    TYPE_COLLECTION_SUPERSEDED,
+)
+from nexus.corpus import is_conformant_collection_name
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def catalog(tmp_path):
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+    db_path = tmp_path / "catalog.sqlite"
+    return Catalog(catalog_dir=catalog_dir, db_path=db_path)
+
+
+# ── is_conformant_collection_name ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "code__1-1__voyage-code-3__v1",
+        "docs__1-1__voyage-context-3__v2",
+        "rdr__1-2-3__voyage-context-3__v1",
+        "knowledge__1-1__voyage-context-3__v1",
+    ],
+)
+def test_conformant_names_accepted(name):
+    assert is_conformant_collection_name(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "code__ART-8c2e74c0",
+        "docs__nexus-571b8edd",
+        "knowledge__knowledge",
+        "knowledge__delos",
+        "docs__default",
+        "taxonomy__nexus-571b8edd-knowledge",
+        "code__1-1__voyage-code-3",  # missing v<n> segment
+        "code__1-1__voyage-code-3__1",  # missing 'v' prefix
+        "weird__1-1__voyage-code-3__v1",  # unknown content_type
+    ],
+)
+def test_legacy_names_rejected(name):
+    assert is_conformant_collection_name(name) is False
+
+
+# ── Collections schema migration ─────────────────────────────────────────
+
+
+def test_collections_table_exists(catalog):
+    """The collections table is part of the catalog schema."""
+    rows = catalog._db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='collections'"
+    ).fetchall()
+    assert rows, "collections table must exist after Catalog construction"
+
+
+def test_collections_columns(catalog):
+    """The collections table has the expected columns."""
+    cols = {
+        row[1]
+        for row in catalog._db.execute("PRAGMA table_info(collections)").fetchall()
+    }
+    expected = {
+        "name", "content_type", "owner_id", "embedding_model",
+        "model_version", "display_name", "legacy_grandfathered",
+        "superseded_by", "superseded_at", "created_at",
+    }
+    missing = expected - cols
+    assert not missing, f"missing columns: {missing}"
+
+
+# ── register_collection ──────────────────────────────────────────────────
+
+
+def test_register_conformant_collection_marks_not_legacy(catalog):
+    catalog.register_collection(
+        "code__1-1__voyage-code-3__v1",
+        content_type="code",
+        owner_id="1-1",
+        embedding_model="voyage-code-3",
+        model_version="v1",
+    )
+    row = catalog.get_collection("code__1-1__voyage-code-3__v1")
+    assert row is not None
+    assert row["content_type"] == "code"
+    assert row["owner_id"] == "1-1"
+    assert row["embedding_model"] == "voyage-code-3"
+    assert row["model_version"] == "v1"
+    assert row["legacy_grandfathered"] is False
+
+
+def test_register_non_conformant_collection_marks_legacy(catalog):
+    """A non-conformant name is registered with legacy_grandfathered=True."""
+    catalog.register_collection("docs__nexus-571b8edd")
+    row = catalog.get_collection("docs__nexus-571b8edd")
+    assert row is not None
+    assert row["legacy_grandfathered"] is True
+
+
+def test_register_collection_writes_event(catalog):
+    catalog.register_collection(
+        "code__1-1__voyage-code-3__v1",
+        content_type="code",
+        owner_id="1-1",
+        embedding_model="voyage-code-3",
+        model_version="v1",
+    )
+    events = list(EventLog(catalog._dir).replay())
+    created = [e for e in events if e.type == TYPE_COLLECTION_CREATED]
+    assert len(created) == 1
+    assert created[0].payload.coll_id == "code__1-1__voyage-code-3__v1"
+    assert created[0].payload.content_type == "code"
+    assert created[0].payload.embedding_model == "voyage-code-3"
+
+
+def test_register_collection_idempotent_on_name(catalog):
+    """Re-registering the same name is a no-op at the SQLite level
+    (INSERT OR REPLACE keeps one row per name).
+
+    The event log is append-only and may carry duplicates; the
+    projector tolerates them because it INSERT OR REPLACE-es per event.
+    """
+    for _ in range(3):
+        catalog.register_collection("docs__nexus-571b8edd")
+    rows = catalog._db.execute(
+        "SELECT COUNT(*) FROM collections WHERE name = ?",
+        ("docs__nexus-571b8edd",),
+    ).fetchone()
+    assert rows[0] == 1
+
+
+def test_list_collections_returns_all(catalog):
+    catalog.register_collection("docs__nexus-571b8edd")
+    catalog.register_collection(
+        "code__1-1__voyage-code-3__v1",
+        content_type="code", owner_id="1-1",
+        embedding_model="voyage-code-3", model_version="v1",
+    )
+    rows = catalog.list_collections()
+    names = sorted(r["name"] for r in rows)
+    assert names == [
+        "code__1-1__voyage-code-3__v1",
+        "docs__nexus-571b8edd",
+    ]
+
+
+def test_is_legacy_collection_reads_projection(catalog):
+    catalog.register_collection("knowledge__delos")
+    catalog.register_collection(
+        "code__1-1__voyage-code-3__v1",
+        content_type="code", owner_id="1-1",
+        embedding_model="voyage-code-3", model_version="v1",
+    )
+    assert catalog.is_legacy_collection("knowledge__delos") is True
+    assert catalog.is_legacy_collection("code__1-1__voyage-code-3__v1") is False
+
+
+def test_is_legacy_collection_unknown_returns_false(catalog):
+    """An unknown name has no row; treat as non-legacy (safer default).
+
+    Read-time is operationally hostile to fail-loud per the bead spec,
+    so callers querying is_legacy_collection on an unregistered name
+    do not get a hard error.
+    """
+    assert catalog.is_legacy_collection("never_seen") is False
+
+
+# ── supersede_collection ─────────────────────────────────────────────────
+
+
+def test_supersede_collection_marks_old_and_emits_event(catalog):
+    catalog.register_collection("docs__nexus-571b8edd")
+    catalog.register_collection(
+        "docs__1-1__voyage-context-3__v1",
+        content_type="docs", owner_id="1-1",
+        embedding_model="voyage-context-3", model_version="v1",
+    )
+    catalog.supersede_collection(
+        "docs__nexus-571b8edd",
+        "docs__1-1__voyage-context-3__v1",
+        reason="rename to canonical",
+    )
+    old = catalog.get_collection("docs__nexus-571b8edd")
+    assert old is not None
+    assert old["superseded_by"] == "docs__1-1__voyage-context-3__v1"
+    assert old["superseded_at"]
+
+    events = [
+        e for e in EventLog(catalog._dir).replay()
+        if e.type == TYPE_COLLECTION_SUPERSEDED
+    ]
+    assert len(events) == 1
+    assert events[0].payload.old_coll_id == "docs__nexus-571b8edd"
+    assert events[0].payload.new_coll_id == "docs__1-1__voyage-context-3__v1"
+
+
+def test_supersede_unknown_old_collection_raises(catalog):
+    with pytest.raises(ValueError, match="not registered"):
+        catalog.supersede_collection(
+            "never_seen",
+            "docs__1-1__voyage-context-3__v1",
+        )
+
+
+# ── Projector replay ─────────────────────────────────────────────────────
+
+
+def test_register_collection_replay_produces_same_row(catalog, tmp_path):
+    """Replaying the events.jsonl into a fresh Catalog produces the
+    same projected row.
+
+    Tests the projector's CollectionCreated handler in isolation, not
+    the convenience writer.
+    """
+    catalog.register_collection(
+        "code__1-1__voyage-code-3__v1",
+        content_type="code",
+        owner_id="1-1",
+        embedding_model="voyage-code-3",
+        model_version="v1",
+    )
+    expected = catalog.get_collection("code__1-1__voyage-code-3__v1")
+
+    # Fresh catalog over the same dir but a new sqlite path,
+    # then replay events into it. The original catalog stays open;
+    # SQLite handles concurrent connections to separate paths.
+    fresh_db = tmp_path / "fresh.sqlite"
+    fresh = Catalog(catalog_dir=catalog._dir, db_path=fresh_db)
+    for event in EventLog(catalog._dir).replay():
+        fresh._projector.apply(event)
+    fresh._db.commit()
+
+    actual = fresh.get_collection("code__1-1__voyage-code-3__v1")
+    assert actual is not None
+    assert actual["content_type"] == expected["content_type"]
+    assert actual["owner_id"] == expected["owner_id"]
+    assert actual["embedding_model"] == expected["embedding_model"]
+    assert actual["model_version"] == expected["model_version"]
+    assert actual["legacy_grandfathered"] == expected["legacy_grandfathered"]

--- a/tests/test_catalog_doctor_collections_drift.py
+++ b/tests/test_catalog_doctor_collections_drift.py
@@ -173,6 +173,25 @@ def test_doctor_collections_drift_orphan_without_supersede_fails(
     assert "knowledge__delos" in result.output
 
 
+def test_doctor_collections_drift_handles_t3_failure(catalog, runner):
+    """When T3 list_collections raises, the check returns ``error``-keyed
+    payload and the doctor exits non-zero. Pass-#2 review found this
+    path had no test; without it, a silent T3 outage produces a green
+    PASS.
+    """
+    class _BrokenT3:
+        def list_collections(self):
+            raise RuntimeError("t3 unreachable")
+
+    with patch("nexus.db.make_t3", return_value=_BrokenT3()), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main, ["catalog", "doctor", "--collections-drift"],
+        )
+    assert result.exit_code != 0
+    assert "Failed to list T3" in result.output
+
+
 def test_doctor_collections_drift_json_payload(t3_db, catalog, runner):
     """``--json`` emits machine-readable shape."""
     _seed_t3(t3_db, "knowledge__delos")

--- a/tests/test_catalog_doctor_collections_drift.py
+++ b/tests/test_catalog_doctor_collections_drift.py
@@ -4,7 +4,7 @@
 
 The collections projection (Phase 6 deliverable) is canonical: every
 collection name that T3 or the catalog documents knows about must
-have a row. Drift is a release blocker — a missing projection row
+have a row. Drift is a release blocker: a missing projection row
 means downstream Phase 6 work (rename-collection, supersede invariants,
 strict naming validation) silently sees the collection as "unknown"
 and either skips it or emits incorrect events.

--- a/tests/test_catalog_doctor_collections_drift.py
+++ b/tests/test_catalog_doctor_collections_drift.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-101 Phase 6: ``nx catalog doctor --collections-drift``.
+
+The collections projection (Phase 6 deliverable) is canonical: every
+collection name that T3 or the catalog documents knows about must
+have a row. Drift is a release blocker — a missing projection row
+means downstream Phase 6 work (rename-collection, supersede invariants,
+strict naming validation) silently sees the collection as "unknown"
+and either skips it or emits incorrect events.
+
+This check verifies:
+  - Every T3 collection has a row in the projection (else FAIL,
+    operator runs ``nx catalog backfill-collections``).
+  - Every distinct ``documents.physical_collection`` value has a row.
+  - Projection rows pointing at a T3 collection that no longer exists
+    are flagged as orphans UNLESS ``superseded_by`` is set (an
+    expected post-rename state).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.cli import main
+from nexus.db.t3 import T3Database
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def t3_db():
+    db = T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+    for raw in list(db._client.list_collections()):
+        name = raw if isinstance(raw, str) else getattr(raw, "name", str(raw))
+        try:
+            db._client.delete_collection(name)
+        except Exception:
+            pass
+    return db
+
+
+@pytest.fixture()
+def catalog(tmp_path):
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+    db_path = tmp_path / "catalog.sqlite"
+    return Catalog(catalog_dir=catalog_dir, db_path=db_path)
+
+
+def _seed_t3(t3_db: T3Database, name: str) -> None:
+    col = t3_db._client.get_or_create_collection(name)
+    col.add(ids=["c1"], documents=["x"], metadatas=[{"placeholder": "1"}])
+
+
+def _seed_doc(catalog: Catalog, *, tumbler: str, collection: str) -> None:
+    catalog._db.execute(
+        "INSERT INTO documents "
+        "(tumbler, title, author, year, content_type, file_path, "
+        "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+        "metadata, source_mtime, alias_of, source_uri) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            tumbler, f"doc-{tumbler}", "", 0, "text", f"/tmp/{tumbler}.md",
+            "", collection, 1, "", "", "{}", 0.0, "", "",
+        ),
+    )
+    catalog._db.commit()
+
+
+def test_doctor_collections_drift_passes_when_aligned(t3_db, catalog, runner):
+    """T3, catalog docs, and projection all aligned → PASS, exit 0."""
+    catalog.register_collection("knowledge__delos")
+    _seed_t3(t3_db, "knowledge__delos")
+    _seed_doc(catalog, tumbler="1.1.1", collection="knowledge__delos")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main, ["catalog", "doctor", "--collections-drift"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "PASS" in result.output
+
+
+def test_doctor_collections_drift_fails_on_t3_not_in_projection(
+    t3_db, catalog, runner,
+):
+    """A T3 collection without a projection row is drift → FAIL."""
+    _seed_t3(t3_db, "knowledge__delos")  # no register_collection call
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main, ["catalog", "doctor", "--collections-drift"],
+        )
+    assert result.exit_code != 0
+    assert "knowledge__delos" in result.output
+    assert "FAIL" in result.output
+
+
+def test_doctor_collections_drift_fails_on_doc_collection_not_in_projection(
+    t3_db, catalog, runner,
+):
+    """A documents.physical_collection without a projection row is drift."""
+    _seed_doc(catalog, tumbler="1.1.1", collection="docs__nexus-571b8edd")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main, ["catalog", "doctor", "--collections-drift"],
+        )
+    assert result.exit_code != 0
+    assert "docs__nexus-571b8edd" in result.output
+
+
+def test_doctor_collections_drift_orphan_warning_with_superseded_skip(
+    t3_db, catalog, runner,
+):
+    """Projection row whose underlying T3 collection is gone is an orphan
+    UNLESS the row carries ``superseded_by`` (the expected post-rename
+    state).
+    """
+    catalog.register_collection("knowledge__delos")
+    catalog.register_collection(
+        "knowledge__1-1__voyage-context-3__v1",
+        content_type="knowledge", owner_id="1-1",
+        embedding_model="voyage-context-3", model_version="v1",
+    )
+    catalog.supersede_collection(
+        "knowledge__delos", "knowledge__1-1__voyage-context-3__v1",
+    )
+    _seed_t3(t3_db, "knowledge__1-1__voyage-context-3__v1")
+    # Note: knowledge__delos NOT in T3 (gone post-rename) but is
+    # superseded_by, so should NOT count as drift.
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main, ["catalog", "doctor", "--collections-drift"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "knowledge__delos" not in result.output or "FAIL" not in result.output
+
+
+def test_doctor_collections_drift_orphan_without_supersede_fails(
+    t3_db, catalog, runner,
+):
+    """Projection row whose T3 collection is gone AND no superseded_by
+    is genuine drift (projection ahead of T3).
+    """
+    catalog.register_collection("knowledge__delos")
+    # knowledge__delos in projection but NOT in T3 and NOT superseded.
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main, ["catalog", "doctor", "--collections-drift"],
+        )
+    assert result.exit_code != 0
+    assert "knowledge__delos" in result.output
+
+
+def test_doctor_collections_drift_json_payload(t3_db, catalog, runner):
+    """``--json`` emits machine-readable shape."""
+    _seed_t3(t3_db, "knowledge__delos")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main, ["catalog", "doctor", "--collections-drift", "--json"],
+        )
+    assert result.exit_code != 0
+    payload = json.loads(result.output)
+    assert "collections_drift" in payload
+    drift = payload["collections_drift"]
+    assert drift["pass"] is False
+    assert "knowledge__delos" in drift["t3_not_in_projection"]

--- a/tests/test_catalog_migrate_fallback.py
+++ b/tests/test_catalog_migrate_fallback.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-101 Phase 6: ``nx catalog migrate-fallback``.
+
+Walks a fallback collection (``docs__default``, ``knowledge__knowledge``,
+etc.) and proposes a per-document target conformant collection. With
+``--yes`` performs the catalog-side migration: re-points each
+document's ``physical_collection`` and auto-registers the target rows
+in the collections projection. Fallback collections are deprecated
+when they go to zero rows, never silently nuked (per RDR-101 §"Phase
+6").
+
+T3 chunks are NOT moved by this verb. The catalog-side migration is
+enough to deprecate the fallback over time; operators repopulate the
+target collection by re-running ``nx index`` against the source files,
+or operate the existing T3 chunks via ``nx t3 gc`` once they go orphan
+(catalog now points elsewhere).
+
+Cross-prefix targets (e.g. docs__default doc with code__... target)
+are rejected; the prefix carries the embedding-model contract.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.cli import main
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def catalog(tmp_path):
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+    db_path = tmp_path / "catalog.sqlite"
+    return Catalog(catalog_dir=catalog_dir, db_path=db_path)
+
+
+def _seed_doc(
+    catalog: Catalog,
+    *,
+    tumbler: str,
+    collection: str,
+    title: str = "doc",
+) -> None:
+    catalog._db.execute(
+        "INSERT INTO documents "
+        "(tumbler, title, author, year, content_type, file_path, "
+        "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+        "metadata, source_mtime, alias_of, source_uri) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            tumbler, title, "", 0, "text", f"/tmp/{tumbler}.md",
+            "", collection, 1, "", "", "{}", 0.0, "", "",
+        ),
+    )
+    catalog._db.commit()
+
+
+# ── Proposal computation ──────────────────────────────────────────────────
+
+
+def test_dry_run_reports_per_doc_target(catalog, runner):
+    """Dry run prints one proposal line per doc; no writes."""
+    catalog.register_collection("knowledge__knowledge")
+    _seed_doc(catalog, tumbler="1.5.1", collection="knowledge__knowledge")
+    _seed_doc(catalog, tumbler="1.7.3", collection="knowledge__knowledge")
+
+    with patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "migrate-fallback",
+             "knowledge__knowledge", "--dry-run"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "1.5.1" in result.output
+    assert "1.7.3" in result.output
+    assert "knowledge__1-5__voyage-context-3__v1" in result.output
+    assert "knowledge__1-7__voyage-context-3__v1" in result.output
+
+    # Catalog state unchanged
+    rows = catalog._db.execute(
+        "SELECT physical_collection FROM documents ORDER BY tumbler"
+    ).fetchall()
+    assert all(r[0] == "knowledge__knowledge" for r in rows)
+
+
+def test_apply_repoints_per_doc_and_registers_targets(catalog, runner):
+    """``--yes`` re-points each document's physical_collection and
+    auto-registers the per-owner targets in the projection.
+    """
+    catalog.register_collection("knowledge__knowledge")
+    _seed_doc(catalog, tumbler="1.5.1", collection="knowledge__knowledge")
+    _seed_doc(catalog, tumbler="1.7.3", collection="knowledge__knowledge")
+
+    with patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "migrate-fallback",
+             "knowledge__knowledge", "--yes"],
+        )
+    assert result.exit_code == 0, result.output
+
+    # Documents re-pointed
+    by_tumbler = {
+        r[0]: r[1] for r in catalog._db.execute(
+            "SELECT tumbler, physical_collection FROM documents",
+        ).fetchall()
+    }
+    assert by_tumbler["1.5.1"] == "knowledge__1-5__voyage-context-3__v1"
+    assert by_tumbler["1.7.3"] == "knowledge__1-7__voyage-context-3__v1"
+
+    # Targets registered as conformant (legacy_grandfathered=False)
+    target_one = catalog.get_collection(
+        "knowledge__1-5__voyage-context-3__v1"
+    )
+    assert target_one is not None
+    assert target_one["legacy_grandfathered"] is False
+    assert target_one["owner_id"] == "1-5"
+
+
+def test_apply_supersedes_source_when_emptied(catalog, runner):
+    """When migration empties the source, the source row is marked
+    superseded_by the (single) target if there is exactly one; or by a
+    sentinel meta-collection note if multiple targets received docs.
+    """
+    catalog.register_collection("knowledge__knowledge")
+    _seed_doc(catalog, tumbler="1.5.1", collection="knowledge__knowledge")
+    _seed_doc(catalog, tumbler="1.5.2", collection="knowledge__knowledge")
+    # Two docs, both same owner -> single target -> source can supersede
+
+    with patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        runner.invoke(
+            main,
+            ["catalog", "migrate-fallback",
+             "knowledge__knowledge", "--yes"],
+        )
+
+    src = catalog.get_collection("knowledge__knowledge")
+    assert src is not None
+    assert src["superseded_by"] == "knowledge__1-5__voyage-context-3__v1"
+
+
+def test_apply_does_not_supersede_when_multiple_targets(catalog, runner):
+    """Multiple target collections after migration leaves the source
+    NOT superseded (no canonical target to point at). Operator
+    deprecates the source manually if appropriate.
+    """
+    catalog.register_collection("knowledge__knowledge")
+    _seed_doc(catalog, tumbler="1.5.1", collection="knowledge__knowledge")
+    _seed_doc(catalog, tumbler="1.7.1", collection="knowledge__knowledge")
+
+    with patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        runner.invoke(
+            main,
+            ["catalog", "migrate-fallback",
+             "knowledge__knowledge", "--yes"],
+        )
+
+    src = catalog.get_collection("knowledge__knowledge")
+    assert src["superseded_by"] == ""
+
+
+def test_already_conformant_collection_rejected(catalog, runner):
+    """A conformant collection is NOT a fallback; refuse to migrate it."""
+    catalog.register_collection(
+        "knowledge__1-1__voyage-context-3__v1",
+        content_type="knowledge", owner_id="1-1",
+        embedding_model="voyage-context-3", model_version="v1",
+    )
+
+    with patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "migrate-fallback",
+             "knowledge__1-1__voyage-context-3__v1",
+             "--yes"],
+        )
+    assert result.exit_code != 0
+    assert "not a fallback" in result.output.lower()
+
+
+def test_unknown_source_rejected(catalog, runner):
+    """Source name not in the projection is an error (run backfill first)."""
+    with patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "migrate-fallback",
+             "knowledge__no-such-name", "--yes"],
+        )
+    assert result.exit_code != 0
+    assert "not registered" in result.output.lower()
+
+
+def test_empty_source_clean_summary(catalog, runner):
+    """Source with zero docs prints a clean zero summary and does nothing."""
+    catalog.register_collection("knowledge__knowledge")
+
+    with patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "migrate-fallback",
+             "knowledge__knowledge", "--yes"],
+        )
+    assert result.exit_code == 0
+    assert "0 doc" in result.output
+
+
+def test_no_yes_falls_back_to_report_only(catalog, runner):
+    catalog.register_collection("knowledge__knowledge")
+    _seed_doc(catalog, tumbler="1.5.1", collection="knowledge__knowledge")
+
+    with patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "migrate-fallback", "knowledge__knowledge"],
+        )
+    assert result.exit_code == 0
+    assert "add --yes" in result.output.lower()
+    rows = catalog._db.execute(
+        "SELECT physical_collection FROM documents WHERE tumbler = ?",
+        ("1.5.1",),
+    ).fetchone()
+    assert rows[0] == "knowledge__knowledge"
+
+
+def test_owner_with_dot_replaced_by_hyphen_in_target(catalog, runner):
+    """Tumbler dots become hyphens in the collection-name segment.
+
+    Owner '1.5' for tumbler '1.5.3' becomes '1-5' in the target name.
+    Multi-segment owners like '1.5.2' for nested tumblers preserve the
+    internal segment separator (handled by the synthesizer's helper).
+    """
+    catalog.register_collection("knowledge__knowledge")
+    _seed_doc(catalog, tumbler="1.5.42", collection="knowledge__knowledge")
+
+    with patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        runner.invoke(
+            main,
+            ["catalog", "migrate-fallback",
+             "knowledge__knowledge", "--yes"],
+        )
+
+    row = catalog._db.execute(
+        "SELECT physical_collection FROM documents WHERE tumbler = ?",
+        ("1.5.42",),
+    ).fetchone()
+    assert row[0] == "knowledge__1-5__voyage-context-3__v1"

--- a/tests/test_catalog_rename_collection.py
+++ b/tests/test_catalog_rename_collection.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-101 Phase 6: ``nx catalog rename-collection`` verb.
+
+Combined verb that does both the data-plane rename (T3 native modify
++ T2 cascade + catalog docs re-point) and the Phase 6 control-plane
+work (conformance check on new name, collections projection update,
+CollectionSuperseded event emission).
+
+Validation gates fire BEFORE any side effect:
+  - new name must be conformant (or --allow-legacy)
+  - old name must be in the collections projection
+  - old name must not already be superseded
+  - new name must not already exist in T3
+
+Tests use a real T3Database (chromadb.EphemeralClient) and a real
+Catalog rooted at tmp_path so the data plane and event log are both
+exercised.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.event_log import EventLog
+from nexus.catalog.events import TYPE_COLLECTION_SUPERSEDED
+from nexus.cli import main
+from nexus.db.t3 import T3Database
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def t3_db():
+    """Fresh ephemeral T3 with all pre-existing collections deleted.
+
+    chromadb.EphemeralClient is process-singleton-ish so other tests'
+    collections persist across fixture rebuilds; explicitly clearing
+    keeps assertions about collection_exists deterministic.
+    """
+    db = T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+    for raw in list(db._client.list_collections()):
+        name = raw if isinstance(raw, str) else getattr(raw, "name", str(raw))
+        try:
+            db._client.delete_collection(name)
+        except Exception:
+            pass
+    return db
+
+
+@pytest.fixture()
+def catalog(tmp_path):
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+    db_path = tmp_path / "catalog.sqlite"
+    return Catalog(catalog_dir=catalog_dir, db_path=db_path)
+
+
+def _seed_t3_collection(t3_db: T3Database, name: str) -> None:
+    """Create a minimal collection in T3."""
+    col = t3_db._client.get_or_create_collection(name)
+    col.add(ids=["c1"], documents=["seeded chunk"], metadatas=[{"doc_id": "1.1.1"}])
+
+
+def _seed_catalog_doc(catalog: Catalog, *, tumbler: str, collection: str) -> None:
+    catalog._db.execute(
+        "INSERT INTO documents "
+        "(tumbler, title, author, year, content_type, file_path, "
+        "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+        "metadata, source_mtime, alias_of, source_uri) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            tumbler, f"doc-{tumbler}", "", 0, "text", f"/tmp/{tumbler}.md",
+            "", collection, 1, "", "", "{}", 0.0, "", "",
+        ),
+    )
+    catalog._db.commit()
+
+
+# ── Validation gates fire before side effects ────────────────────────────
+
+
+def test_rename_rejects_non_conformant_new(t3_db, catalog, runner):
+    """The new name must match is_conformant_collection_name unless --allow-legacy."""
+    catalog.register_collection("knowledge__delos")
+    _seed_t3_collection(t3_db, "knowledge__delos")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "rename-collection",
+             "knowledge__delos", "knowledge__papers"],
+        )
+    assert result.exit_code != 0
+    assert "not conformant" in result.output.lower()
+    # T3 untouched (old still exists, new wasn't created)
+    assert t3_db.collection_exists("knowledge__delos")
+    assert not t3_db.collection_exists("knowledge__papers")
+
+
+def test_rename_rejects_old_not_in_projection(t3_db, catalog, runner):
+    _seed_t3_collection(t3_db, "knowledge__delos")
+    # Note: old name not registered in the collections projection.
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "rename-collection",
+             "knowledge__delos",
+             "knowledge__1-1__voyage-context-3__v1"],
+        )
+    assert result.exit_code != 0
+    assert "not registered" in result.output.lower()
+
+
+def test_rename_rejects_already_superseded(t3_db, catalog, runner):
+    catalog.register_collection("knowledge__delos")
+    catalog.register_collection(
+        "knowledge__1-1__voyage-context-3__v1",
+        content_type="knowledge", owner_id="1-1",
+        embedding_model="voyage-context-3", model_version="v1",
+    )
+    catalog.supersede_collection(
+        "knowledge__delos", "knowledge__1-1__voyage-context-3__v1",
+    )
+    _seed_t3_collection(t3_db, "knowledge__delos")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "rename-collection",
+             "knowledge__delos",
+             "knowledge__1-1__voyage-context-3__v2"],
+        )
+    assert result.exit_code != 0
+    assert "superseded" in result.output.lower()
+
+
+def test_rename_rejects_new_already_exists_in_t3(t3_db, catalog, runner):
+    catalog.register_collection("knowledge__delos")
+    _seed_t3_collection(t3_db, "knowledge__delos")
+    _seed_t3_collection(t3_db, "knowledge__1-1__voyage-context-3__v1")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "rename-collection",
+             "knowledge__delos",
+             "knowledge__1-1__voyage-context-3__v1"],
+        )
+    assert result.exit_code != 0
+    assert "already exists" in result.output.lower()
+
+
+# ── Happy path ────────────────────────────────────────────────────────────
+
+
+def test_rename_conformant_new_succeeds(t3_db, catalog, runner):
+    """End-to-end rename: T3 collection moves, projection rows updated,
+    CollectionSuperseded event emitted, catalog docs re-pointed.
+    """
+    catalog.register_collection("knowledge__delos")
+    _seed_t3_collection(t3_db, "knowledge__delos")
+    _seed_catalog_doc(catalog, tumbler="1.1.1", collection="knowledge__delos")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "rename-collection",
+             "knowledge__delos",
+             "knowledge__1-1__voyage-context-3__v1",
+             "--yes"],
+        )
+    assert result.exit_code == 0, result.output
+
+    # T3: new exists, old doesn't
+    assert not t3_db.collection_exists("knowledge__delos")
+    assert t3_db.collection_exists("knowledge__1-1__voyage-context-3__v1")
+
+    # Collections projection: new is registered + not legacy; old is superseded.
+    new_row = catalog.get_collection("knowledge__1-1__voyage-context-3__v1")
+    assert new_row is not None
+    assert new_row["legacy_grandfathered"] is False
+    assert new_row["content_type"] == "knowledge"
+    assert new_row["embedding_model"] == "voyage-context-3"
+
+    old_row = catalog.get_collection("knowledge__delos")
+    assert old_row is not None
+    assert old_row["superseded_by"] == "knowledge__1-1__voyage-context-3__v1"
+    assert old_row["superseded_at"]
+
+    # CollectionSuperseded event in the log
+    events = [
+        e for e in EventLog(catalog._dir).replay()
+        if e.type == TYPE_COLLECTION_SUPERSEDED
+    ]
+    assert len(events) == 1
+    assert events[0].payload.old_coll_id == "knowledge__delos"
+    assert events[0].payload.new_coll_id == "knowledge__1-1__voyage-context-3__v1"
+
+    # Catalog documents re-pointed
+    rows = catalog._db.execute(
+        "SELECT physical_collection FROM documents WHERE tumbler = ?",
+        ("1.1.1",),
+    ).fetchone()
+    assert rows[0] == "knowledge__1-1__voyage-context-3__v1"
+
+
+def test_rename_dry_run_no_writes(t3_db, catalog, runner):
+    """``--dry-run`` reports the plan and writes nothing."""
+    catalog.register_collection("knowledge__delos")
+    _seed_t3_collection(t3_db, "knowledge__delos")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "rename-collection",
+             "knowledge__delos",
+             "knowledge__1-1__voyage-context-3__v1",
+             "--dry-run"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "would rename" in result.output.lower()
+    assert t3_db.collection_exists("knowledge__delos")
+    assert not t3_db.collection_exists("knowledge__1-1__voyage-context-3__v1")
+    # Old projection row not yet superseded
+    old_row = catalog.get_collection("knowledge__delos")
+    assert old_row["superseded_by"] == ""
+
+
+def test_rename_no_yes_falls_back_to_report_only(t3_db, catalog, runner):
+    """Neither ``--yes`` nor ``--dry-run`` falls back to report-only."""
+    catalog.register_collection("knowledge__delos")
+    _seed_t3_collection(t3_db, "knowledge__delos")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "rename-collection",
+             "knowledge__delos",
+             "knowledge__1-1__voyage-context-3__v1"],
+        )
+    assert result.exit_code == 0
+    assert "add --yes" in result.output.lower()
+    assert t3_db.collection_exists("knowledge__delos")
+
+
+def test_rename_allow_legacy_lets_non_conformant_through(t3_db, catalog, runner):
+    """``--allow-legacy`` skips the conformance gate; the new collection
+    is registered as legacy_grandfathered=True via the projector regex.
+    """
+    catalog.register_collection("docs__nexus-571b8edd")
+    _seed_t3_collection(t3_db, "docs__nexus-571b8edd")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "rename-collection",
+             "docs__nexus-571b8edd",
+             "docs__renamed-legacy",
+             "--yes", "--allow-legacy"],
+        )
+    assert result.exit_code == 0, result.output
+    assert t3_db.collection_exists("docs__renamed-legacy")
+    new_row = catalog.get_collection("docs__renamed-legacy")
+    assert new_row is not None
+    assert new_row["legacy_grandfathered"] is True

--- a/tests/test_catalog_rename_collection.py
+++ b/tests/test_catalog_rename_collection.py
@@ -263,6 +263,31 @@ def test_rename_no_yes_falls_back_to_report_only(t3_db, catalog, runner):
     assert t3_db.collection_exists("knowledge__delos")
 
 
+def test_rename_to_self_rejected(t3_db, catalog, runner):
+    """Renaming OLD to itself is a no-op; reject with a clear message
+    rather than running the full data plane that would then trip the
+    ``new already exists`` gate (misleading).
+    """
+    catalog.register_collection(
+        "knowledge__1-1__voyage-context-3__v1",
+        content_type="knowledge", owner_id="1-1",
+        embedding_model="voyage-context-3", model_version="v1",
+    )
+    _seed_t3_collection(t3_db, "knowledge__1-1__voyage-context-3__v1")
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.catalog._get_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["catalog", "rename-collection",
+             "knowledge__1-1__voyage-context-3__v1",
+             "knowledge__1-1__voyage-context-3__v1",
+             "--yes"],
+        )
+    assert result.exit_code != 0
+    assert "identical" in result.output.lower()
+
+
 def test_rename_allow_legacy_lets_non_conformant_through(t3_db, catalog, runner):
     """``--allow-legacy`` skips the conformance gate; the new collection
     is registered as legacy_grandfathered=True via the projector regex.

--- a/tests/test_t3_gc.py
+++ b/tests/test_t3_gc.py
@@ -323,7 +323,7 @@ def test_gc_no_orphans_clean_summary(t3_db, catalog, runner):
         result = runner.invoke(main, ["t3", "gc", "-c", coll])
 
     assert result.exit_code == 0
-    assert "0 orphan" in result.output
+    assert "0 orphan(s)" in result.output  # parenthetical-plural form
     log_path = catalog._dir / EVENTS_FILENAME
     if log_path.exists():
         events = [e for e in EventLog(catalog._dir).replay()
@@ -358,6 +358,78 @@ def test_gc_chunk_with_missing_doc_id_skipped(
 
     assert result.exit_code == 0
     assert t3_db._client.get_collection(coll).count() == 1
+
+
+def test_gc_orphan_window_rejects_zero(runner):
+    """A zero-or-negative orphan window is rejected at parse time.
+
+    Without this guard ``--orphan-window 0d`` would treat every
+    orphaned chunk as immediately eligible, which is dangerous when
+    paired with --no-dry-run --yes.
+    """
+    result = runner.invoke(
+        main,
+        ["t3", "gc", "-c", "knowledge__test", "--orphan-window", "0d"],
+    )
+    assert result.exit_code != 0
+    assert "must be positive" in result.output.lower()
+
+
+def test_gc_malformed_indexed_at_is_skipped(t3_db, catalog, tmp_path, runner):
+    """Chunks with malformed ``indexed_at`` (non-ISO string) are
+    undecidable for the orphan-window filter and must be skipped, not
+    crash the GC.
+    """
+    coll = "knowledge__test_gc_bad_indexed_at"
+    col = t3_db._client.get_or_create_collection(coll)
+    col.add(
+        ids=["bad_chunk"],
+        documents=["x"],
+        metadatas=[{"doc_id": "1.1.99", "indexed_at": "not-an-iso-timestamp"}],
+    )
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.t3._make_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["t3", "gc", "-c", coll, "--no-dry-run", "--yes"],
+        )
+
+    assert result.exit_code == 0, result.output
+    # Chunk preserved (not deleted): undecidable indexed_at
+    assert t3_db._client.get_collection(coll).count() == 1
+
+
+def test_gc_paginates_above_300_chunk_boundary(
+    t3_db, catalog, tmp_path, runner,
+):
+    """`list_chunks_with_metadata` paginates at the 300-record Cloud
+    limit. Seed 305 chunks (all orphans past window) and verify all
+    305 are detected and deleted, not silently truncated to 300.
+    """
+    coll = "knowledge__test_gc_pagination"
+    col = t3_db._client.get_or_create_collection(coll)
+    long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
+    chunk_count = 305
+    col.add(
+        ids=[f"orphan_{i:04d}" for i in range(chunk_count)],
+        documents=[f"chunk {i}" for i in range(chunk_count)],
+        metadatas=[
+            {"doc_id": "1.1.99", "indexed_at": long_ago}
+            for _ in range(chunk_count)
+        ],
+    )
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.t3._make_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["t3", "gc", "-c", coll, "--no-dry-run", "--yes"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert f"deleted {chunk_count}" in result.output
+    assert t3_db._client.get_collection(coll).count() == 0
 
 
 def test_gc_no_yes_flag_reports_only(t3_db, catalog, tmp_path, runner):

--- a/tests/test_t3_gc.py
+++ b/tests/test_t3_gc.py
@@ -360,6 +360,23 @@ def test_gc_chunk_with_missing_doc_id_skipped(
     assert t3_db._client.get_collection(coll).count() == 1
 
 
+def test_gc_aborts_on_uninitialized_catalog(t3_db, tmp_path, runner, monkeypatch):
+    """nx t3 gc on an uninitialized catalog must raise a clear error,
+    not crash with an opaque traceback or silently produce an empty
+    alive-set (which would treat every chunk as orphan).
+    """
+    bare_path = tmp_path / "no-such-catalog"
+    monkeypatch.setattr(
+        "nexus.config.catalog_path", lambda: bare_path,
+    )
+    with patch("nexus.db.make_t3", return_value=t3_db):
+        result = runner.invoke(
+            main, ["t3", "gc", "-c", "knowledge__test", "--dry-run"],
+        )
+    assert result.exit_code != 0
+    assert "not initialized" in result.output.lower()
+
+
 def test_gc_orphan_window_rejects_zero(runner):
     """A zero-or-negative orphan window is rejected at parse time.
 

--- a/tests/test_t3_gc.py
+++ b/tests/test_t3_gc.py
@@ -1,0 +1,386 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""nexus-r5eo: ``nx t3 gc`` subcommand (RDR-101 Phase 6).
+
+Per RF-101-3, ``nx t3 gc`` is the SOLE emitter of ``ChunkOrphaned`` events
+and the SOLE post-Phase-3 deletion path for T3 chunks. The verb:
+
+  1. Reads catalog projection: alive doc_ids per collection (= ``tumbler``
+     in v: 0 schema, scoped by ``physical_collection``).
+  2. Reads T3: per chunk, ``(chunk_id, doc_id, indexed_at)``.
+  3. Diffs: chunks whose ``doc_id`` is no longer alive AND whose
+     ``indexed_at`` predates the orphan window (default 30 days).
+  4. STRICT ORDER: emit ``ChunkOrphaned`` event THEN call
+     ``delete_by_chunk_ids``. A crash mid-GC leaves the log consistent
+     with T3 (event present + delete failed = next gc retries).
+
+Tests use a real T3Database backed by chromadb's EphemeralClient +
+DefaultEmbeddingFunction so we exercise the full delete-by-chunk-ids
+machinery without Cloud credentials. The Catalog uses a tmp_path
+``catalog_dir`` so events.jsonl is real on disk.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.event_log import EVENTS_FILENAME, EventLog
+from nexus.catalog.events import TYPE_CHUNK_ORPHANED, Event
+from nexus.cli import main
+from nexus.db.t3 import T3Database
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def t3_db():
+    """Real T3Database backed by an ephemeral local Chroma."""
+    return T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def catalog(tmp_path):
+    """Catalog rooted in tmp_path so events.jsonl is real on disk."""
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+    db_path = tmp_path / "catalog.sqlite"
+    return Catalog(catalog_dir=catalog_dir, db_path=db_path)
+
+
+def _seed_chunk(
+    t3_db: T3Database,
+    *,
+    collection: str,
+    chunk_id: str,
+    content: str,
+    doc_id: str,
+    indexed_at: str,
+) -> None:
+    """Insert one chunk with the metadata GC reads."""
+    col = t3_db._client.get_or_create_collection(collection)
+    col.add(
+        ids=[chunk_id],
+        documents=[content],
+        metadatas=[{"doc_id": doc_id, "indexed_at": indexed_at}],
+    )
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+# ── T3Database new methods ────────────────────────────────────────────────
+
+
+def test_list_chunks_with_metadata_returns_doc_id_and_indexed_at(t3_db):
+    """``list_chunks_with_metadata`` yields ``(chunk_id, metadata_subset)``."""
+    coll = "knowledge__test_list"
+    now = _iso(datetime.now(UTC))
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="c1", content="x",
+        doc_id="1.1.1", indexed_at=now,
+    )
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="c2", content="y",
+        doc_id="1.1.2", indexed_at=now,
+    )
+    rows = list(t3_db.list_chunks_with_metadata(coll))
+    by_id = {cid: meta for cid, meta in rows}
+    assert by_id["c1"] == {"doc_id": "1.1.1", "indexed_at": now}
+    assert by_id["c2"] == {"doc_id": "1.1.2", "indexed_at": now}
+
+
+def test_list_chunks_with_metadata_missing_collection(t3_db):
+    assert list(t3_db.list_chunks_with_metadata("knowledge__nonexistent")) == []
+
+
+def test_delete_by_chunk_ids_deletes_only_listed(t3_db):
+    """``delete_by_chunk_ids`` deletes the listed ids and returns the count."""
+    coll = "knowledge__test_gc_delete_by_ids"
+    now = _iso(datetime.now(UTC))
+    for cid in ("c1", "c2", "c3"):
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id=cid, content=cid,
+            doc_id="1.1.1", indexed_at=now,
+        )
+    deleted = t3_db.delete_by_chunk_ids(coll, ["c1", "c3"])
+    assert deleted == 2
+    surviving = t3_db._client.get_collection(coll).get()["ids"]
+    assert surviving == ["c2"]
+
+
+def test_delete_by_chunk_ids_missing_collection_returns_zero(t3_db):
+    assert t3_db.delete_by_chunk_ids("knowledge__nonexistent", ["c1"]) == 0
+
+
+def test_delete_by_chunk_ids_empty_list(t3_db):
+    coll = "knowledge__test_gc_empty_list"
+    now = _iso(datetime.now(UTC))
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="c1", content="x",
+        doc_id="1.1.1", indexed_at=now,
+    )
+    assert t3_db.delete_by_chunk_ids(coll, []) == 0
+    assert t3_db._client.get_collection(coll).count() == 1
+
+
+# ── nx t3 gc CLI ─────────────────────────────────────────────────────────
+
+
+def _register_doc(catalog: Catalog, *, tumbler: str, collection: str) -> None:
+    """Seed a document row directly so ``list_by_collection`` returns it.
+
+    Bypasses ``Catalog.register`` (which mints its own tumbler off an
+    owner prefix). GC only cares that ``list_by_collection`` reports
+    alive doc_ids, and the SQLite projection is the read path.
+    """
+    catalog._db.execute(
+        "INSERT INTO documents "
+        "(tumbler, title, author, year, content_type, file_path, "
+        "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
+        "metadata, source_mtime, alias_of, source_uri) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            tumbler, f"doc-{tumbler}", "", 0, "text", f"/tmp/{tumbler}.md",
+            "", collection, 1, "", "", "{}", 0.0, "", "",
+        ),
+    )
+    catalog._db.commit()
+
+
+def test_gc_dry_run_reports_orphans_no_mutation(t3_db, catalog, tmp_path, runner):
+    """Default dry-run prints orphan candidates but does not delete or emit."""
+    coll = "knowledge__test_gc_dryrun"
+    long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
+    _register_doc(catalog, tumbler="1.1.1", collection=coll)  # alive
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="alive1", content="a",
+        doc_id="1.1.1", indexed_at=long_ago,
+    )
+    _seed_chunk(  # orphan: doc 1.1.99 not registered
+        t3_db, collection=coll, chunk_id="orphan1", content="o",
+        doc_id="1.1.99", indexed_at=long_ago,
+    )
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.t3._make_catalog", return_value=catalog):
+        result = runner.invoke(
+            main, ["t3", "gc", "-c", coll, "--dry-run"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "orphan1" in result.output
+    assert "alive1" not in result.output
+    assert "would delete" in result.output
+
+    # No T3 mutation
+    assert t3_db._client.get_collection(coll).count() == 2
+
+    # No event emitted
+    events_path = catalog._dir / EVENTS_FILENAME
+    if events_path.exists():
+        log = EventLog(catalog._dir)
+        events = [e for e in log.replay() if e.type == TYPE_CHUNK_ORPHANED]
+        assert events == []
+
+
+def test_gc_emits_chunk_orphaned_event_before_delete(
+    t3_db, catalog, tmp_path, runner,
+):
+    """``--no-dry-run --yes`` emits ChunkOrphaned BEFORE deleting the chunk.
+
+    Strict-order contract from RF-101-3: a crash between event-write and
+    delete leaves the log consistent with T3 (event present, delete
+    pending; next gc retries the delete).
+    """
+    coll = "knowledge__test_gc_emit"
+    long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
+    _register_doc(catalog, tumbler="1.1.1", collection=coll)
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="alive1", content="a",
+        doc_id="1.1.1", indexed_at=long_ago,
+    )
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="orphan1", content="o",
+        doc_id="1.1.99", indexed_at=long_ago,
+    )
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="orphan2", content="o2",
+        doc_id="1.1.99", indexed_at=long_ago,
+    )
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.t3._make_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["t3", "gc", "-c", coll, "--no-dry-run", "--yes"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "deleted 2" in result.output
+
+    # Alive chunk survives
+    surviving = t3_db._client.get_collection(coll).get()["ids"]
+    assert surviving == ["alive1"]
+
+    # ChunkOrphaned events emitted, one per deleted chunk
+    log = EventLog(catalog._dir)
+    orphan_events = [e for e in log.replay() if e.type == TYPE_CHUNK_ORPHANED]
+    chunk_ids = {e.payload.chunk_id for e in orphan_events}
+    assert chunk_ids == {"orphan1", "orphan2"}
+
+
+def test_gc_orphan_window_excludes_recent(t3_db, catalog, tmp_path, runner):
+    """Chunks whose ``indexed_at`` is within the orphan window are not GC'd
+    even if their ``doc_id`` is dead.
+
+    Rationale: a fresh re-index might briefly leave chunks orphaned
+    while the catalog projection catches up. The window is the grace
+    period.
+    """
+    coll = "knowledge__test_gc_window"
+    recent = _iso(datetime.now(UTC) - timedelta(hours=1))
+    long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
+    _seed_chunk(  # orphan but recent: protected
+        t3_db, collection=coll, chunk_id="recent_orphan", content="r",
+        doc_id="1.1.99", indexed_at=recent,
+    )
+    _seed_chunk(  # orphan and old: eligible
+        t3_db, collection=coll, chunk_id="old_orphan", content="o",
+        doc_id="1.1.99", indexed_at=long_ago,
+    )
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.t3._make_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            [
+                "t3", "gc", "-c", coll,
+                "--orphan-window", "30d",
+                "--no-dry-run", "--yes",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    surviving = sorted(t3_db._client.get_collection(coll).get()["ids"])
+    assert surviving == ["recent_orphan"]
+
+
+def test_gc_default_window_is_30_days(t3_db, catalog, tmp_path, runner):
+    """No ``--orphan-window`` flag → default 30 days."""
+    coll = "knowledge__test_gc_default"
+    twenty_days = _iso(datetime.now(UTC) - timedelta(days=20))
+    forty_days = _iso(datetime.now(UTC) - timedelta(days=40))
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="within_window", content="w",
+        doc_id="1.1.99", indexed_at=twenty_days,
+    )
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="past_window", content="p",
+        doc_id="1.1.99", indexed_at=forty_days,
+    )
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.t3._make_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["t3", "gc", "-c", coll, "--no-dry-run", "--yes"],
+        )
+
+    assert result.exit_code == 0, result.output
+    surviving = sorted(t3_db._client.get_collection(coll).get()["ids"])
+    assert surviving == ["within_window"]
+
+
+def test_gc_no_orphans_clean_summary(t3_db, catalog, runner):
+    """Every chunk's doc_id alive → 0/0 summary, no events."""
+    coll = "knowledge__test_gc_clean"
+    long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
+    _register_doc(catalog, tumbler="1.1.1", collection=coll)
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="c1", content="x",
+        doc_id="1.1.1", indexed_at=long_ago,
+    )
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.t3._make_catalog", return_value=catalog):
+        result = runner.invoke(main, ["t3", "gc", "-c", coll])
+
+    assert result.exit_code == 0
+    assert "0 orphan" in result.output
+    log_path = catalog._dir / EVENTS_FILENAME
+    if log_path.exists():
+        events = [e for e in EventLog(catalog._dir).replay()
+                  if e.type == TYPE_CHUNK_ORPHANED]
+        assert events == []
+
+
+def test_gc_chunk_with_missing_doc_id_skipped(
+    t3_db, catalog, tmp_path, runner,
+):
+    """Chunk metadata without ``doc_id`` is undecidable, skipped not GC'd.
+
+    Legacy chunks pre-Phase-2-backfill may not carry ``doc_id``. They
+    must NOT be silently deleted; a maintenance backfill verb is the
+    right path, not GC.
+    """
+    coll = "knowledge__test_gc_no_doc_id"
+    long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
+    col = t3_db._client.get_or_create_collection(coll)
+    col.add(
+        ids=["legacy_chunk"],
+        documents=["x"],
+        metadatas=[{"indexed_at": long_ago}],  # no doc_id
+    )
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.t3._make_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["t3", "gc", "-c", coll, "--no-dry-run", "--yes"],
+        )
+
+    assert result.exit_code == 0
+    assert t3_db._client.get_collection(coll).count() == 1
+
+
+def test_gc_no_yes_flag_reports_only(t3_db, catalog, tmp_path, runner):
+    """``--no-dry-run`` without ``--yes`` falls back to report-only."""
+    coll = "knowledge__test_gc_no_yes"
+    long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
+    _seed_chunk(
+        t3_db, collection=coll, chunk_id="orphan1", content="o",
+        doc_id="1.1.99", indexed_at=long_ago,
+    )
+
+    with patch("nexus.db.make_t3", return_value=t3_db), \
+         patch("nexus.commands.t3._make_catalog", return_value=catalog):
+        result = runner.invoke(
+            main,
+            ["t3", "gc", "-c", coll, "--no-dry-run"],
+        )
+
+    assert result.exit_code == 0
+    assert "Add --yes" in result.output
+    assert t3_db._client.get_collection(coll).count() == 1
+    log_path = catalog._dir / EVENTS_FILENAME
+    if log_path.exists():
+        events = [e for e in EventLog(catalog._dir).replay()
+                  if e.type == TYPE_CHUNK_ORPHANED]
+        assert events == []

--- a/tests/test_t3_strict_collection_naming.py
+++ b/tests/test_t3_strict_collection_naming.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-101 Phase 6: write-time collection naming enforcement.
+
+When the ``[catalog].strict_collection_naming`` config flag is true (or
+the operator passes ``strict=True`` explicitly), creating a NEW
+collection with a non-conformant name raises ValueError at the
+``T3Database.get_or_create_collection`` boundary. Existing collections
+are allowed regardless of conformance (read paths must accept legacy
+names per RDR-101 §"Phase 6").
+
+Default is opt-in OFF so existing tests and indexers do not break.
+The flip to default-ON is a separate, irreversible Phase 6 step.
+"""
+from __future__ import annotations
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+from nexus.db.t3 import T3Database
+
+
+@pytest.fixture()
+def t3_db():
+    db = T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+    for raw in list(db._client.list_collections()):
+        name = raw if isinstance(raw, str) else getattr(raw, "name", str(raw))
+        try:
+            db._client.delete_collection(name)
+        except Exception:
+            pass
+    return db
+
+
+# ── strict=True parameter ────────────────────────────────────────────────
+
+
+def test_strict_true_rejects_non_conformant_new(t3_db):
+    """A NEW collection with a non-conformant name is rejected when strict=True."""
+    with pytest.raises(ValueError, match="not conformant"):
+        t3_db.get_or_create_collection("knowledge__delos", strict=True)
+
+
+def test_strict_true_accepts_conformant_new(t3_db):
+    """A NEW collection with a conformant name is accepted when strict=True."""
+    name = "knowledge__1-1__voyage-context-3__v1"
+    col = t3_db.get_or_create_collection(name, strict=True)
+    assert col is not None
+    assert t3_db.collection_exists(name)
+
+
+def test_strict_true_accepts_existing_non_conformant(t3_db):
+    """An EXISTING non-conformant collection still resolves under strict=True.
+
+    The validator only fires for new creation; legacy collections must
+    continue to be readable / writable per RDR-101 §"Phase 6"
+    (failing-loud at read time is rejected as operationally hostile).
+    """
+    name = "knowledge__delos"
+    t3_db.get_or_create_collection(name, strict=False)
+    # Now resolve again with strict=True; should not raise.
+    col = t3_db.get_or_create_collection(name, strict=True)
+    assert col is not None
+
+
+def test_strict_false_default_allows_non_conformant_new(t3_db):
+    """Default ``strict=False`` keeps the existing permissive behavior."""
+    col = t3_db.get_or_create_collection("knowledge__delos")
+    assert col is not None
+    assert t3_db.collection_exists("knowledge__delos")
+
+
+# ── config flag default ──────────────────────────────────────────────────
+
+
+def test_config_flag_strict_collection_naming_defaults_strict(t3_db, monkeypatch):
+    """When ``[catalog].strict_collection_naming`` is true, callers that
+    do NOT pass ``strict=`` get ``strict=True`` by default.
+    """
+    def fake_load_config(repo_root=None):
+        return {"catalog": {"strict_collection_naming": True}}
+
+    monkeypatch.setattr("nexus.config.load_config", fake_load_config)
+
+    with pytest.raises(ValueError, match="not conformant"):
+        t3_db.get_or_create_collection("knowledge__delos")
+
+
+def test_config_flag_absent_keeps_permissive_default(t3_db, monkeypatch):
+    """No flag in config → permissive default (existing behavior preserved)."""
+    monkeypatch.setattr(
+        "nexus.config.load_config",
+        lambda repo_root=None: {"catalog": {}},
+    )
+    col = t3_db.get_or_create_collection("knowledge__delos")
+    assert col is not None
+
+
+def test_explicit_strict_false_overrides_config_flag(t3_db, monkeypatch):
+    """An explicit ``strict=False`` argument wins over a strict config flag.
+
+    Backfill / migration verbs need to construct legacy collections
+    even when the flag is on; explicit-false-wins is the escape hatch.
+    """
+    monkeypatch.setattr(
+        "nexus.config.load_config",
+        lambda repo_root=None: {"catalog": {"strict_collection_naming": True}},
+    )
+    col = t3_db.get_or_create_collection("knowledge__delos", strict=False)
+    assert col is not None


### PR DESCRIPTION
## Summary

RDR-101 Phase 6 delivers the T3 + catalog collections layer: an event-sourced `collections` projection, T3 garbage collection, and seven CLI verbs for collection operations. Two prophylactic review passes (text-based across 5 lenses; Serena-primary across 5 different lenses) ran on the surface; critical findings were fixed in-flight and are listed below. Non-blocking follow-ups are tracked under epic `nexus-qpet`.

## Deliverables (13 commits)

**Core (epic nexus-o6aa.14, plus nexus-r5eo for GC):**
- `nx t3 gc` verb — alive-set forward-proof against catalog tumblers
- `collections` projection — event-sourced (CollectionCreated / CollectionSuperseded)
- `nx catalog backfill-collections` — populate projection from existing T3 state
- `nx catalog rename-collection` — atomic T3-then-catalog rename with partial-state rollback
- `T3Database.strict_collection_naming` flag — schema-prefix gate (default off, pending caller threading per `nexus-2r71`)
- `nx catalog doctor --collections-drift` — projection vs T3 drift detection
- `nx catalog migrate-fallback` — per-doc tumbler reconciliation

**Docs:**
- `docs/cli-reference.md` updated for all seven new verbs
- `docs/rdr/rdr-101-catalog-t3-metadata-design.md` Phase 6 amendment (collection-name `__v<n>` vs `@<version>` encoding)

## Review-driven fixes (in-flight, before merge)

- Event-sourced split: `register_collection` / `supersede_collection`
- Deterministic `created_at` / `supersede_at` via payload fields
- Rename-collection: T3 gate ordering swap, rename-to-self guard, partial-state try/except
- `supersede_collection` guards (already-superseded, new-not-registered)
- `register_collection` log-bloat short-circuit
- `backfill-collections` silent T3 fallback → abort with non-zero exit
- `backfill-collections` dry-run default flipped to True
- `_parse_orphan_window` rejects 0 / negative
- `migrate-fallback` split-brain warning post-apply
- `doctor` uses `_BYPASS_SCHEMA_PREFIXES` constant; remediation hint replaced
- `_make_catalog` `Catalog.is_initialized` gate
- `_run_replay_equality` includes collections table
- `gc_cmd` batched delete + failed-count tracking

## Non-blocking follow-ups (epic nexus-qpet)

8 child beads filed for review pass-#1 + pass-#2 deferred items: GC UUID7 forward-proof (nexus-krhr), strict-flip default + 25-caller threading (nexus-2r71), no-catalog prune chunk-id matching (nexus-fq3b), legacy_grandfathered schema versioning (nexus-7m8n), Phase 5 _PRUNE_DEPRECATED_KEYS keys (nexus-c4nq), event-sourced ts fallback (nexus-qpet.1), TOCTOU validation (nexus-qpet.2), migrate-fallback flock thrashing (nexus-qpet.3).

## Test plan

- [x] `uv run pytest tests/test_catalog_collections.py tests/test_catalog_backfill_collections.py tests/test_catalog_rename_collection.py tests/test_catalog_doctor_collections_drift.py tests/test_catalog_migrate_fallback.py tests/test_t3_gc.py tests/test_t3_strict_collection_naming.py` — all green
- [x] No em dashes in production text (commit 1c5dd29c cleared stray em-dashes from test docstrings)
- [x] Two prophylactic review passes (10 agent reports, 5 lenses each)
- [ ] Reviewer: scan `nexus-qpet` children to confirm none are critical