### PR TITLE
docs(plugin): RDR-103 Phase 6 — examples shaped to conformant 4-segment

### DIFF
--- a/nx/agents/_shared/CONTEXT_PROTOCOL.md
+++ b/nx/agents/_shared/CONTEXT_PROTOCOL.md
@@ -128,7 +128,7 @@ Use the right search form for the task:
 | Search document subtree | mcp__plugin_nx_nexus__query( `question="topic", subtree="1.1"` |
 | Search within a topic cluster | mcp__plugin_nx_nexus__search( `query="question", topic="PDF Extraction"` |
 | Cross-corpus research | Use query tool with `corpus="all"` or multiple query calls |
-| List documents in a collection | mcp__plugin_nx_nexus__store_list( `collection="knowledge__art", docs=true` |
+| List documents in a collection | mcp__plugin_nx_nexus__store_list( `collection="knowledge__art-1-1__voyage-context-3__v1", docs=true` (RDR-103 4-segment shape) |
 
 **When NOT to use search:**
 - When the relay already contains the information needed

--- a/nx/agents/_shared/ERROR_HANDLING.md
+++ b/nx/agents/_shared/ERROR_HANDLING.md
@@ -93,9 +93,11 @@ ttl_days > 0 AND expires_at < now
 - Fallback: Store in T2 with `tags="pending-t3-promotion"` for later batch upload
 
 **Collection name validation**:
-- Collection names use `__` as separator (NOT `::`)
-- Valid: `knowledge__myproject`, `code__nexus`
-- Invalid: `knowledge::myproject` (colons are invalid in ChromaDB collection names)
+- Collection names use `__` as separator (NOT `::`).
+- Conformant shape (RDR-103): `<content_type>__<owner>__<embedding_model>__v<n>`, e.g. `knowledge__myproject-1-1__voyage-context-3__v1`, `code__nexus-1-1__voyage-code-3__v1`.
+- Operators may type the short form `knowledge__myproject` to MCP / `nx` commands; `t3_collection_name` auto-promotes it to the conformant 4-segment shape before any T3 write.
+- Pre-existing legacy 2-segment collections remain readable; only NEW non-conformant creations are blocked at `T3Database.get_or_create_collection`.
+- Invalid: `knowledge::myproject` (colons are not permitted in ChromaDB collection names).
 
 **Duplicate document ID**:
 - Error: `Document ID already exists`

--- a/nx/agents/codebase-deep-analyzer.md
+++ b/nx/agents/codebase-deep-analyzer.md
@@ -93,8 +93,8 @@ You are an elite codebase architect and analysis specialist with deep expertise 
 
 Before analysis, ensure the codebase is indexed:
 1. Run `nx index repo <path>` to index the repository (if not already done)
-2. mcp__plugin_nx_nexus__search(query="query", corpus="code__<repo>", limit=20 for semantic code search throughout analysis
-3. mcp__plugin_nx_nexus__search(query="query", corpus="code" for cross-repo searches
+2. mcp__plugin_nx_nexus__search(query="query", corpus="code__<owner>__voyage-code-3__v1", limit=20 for semantic code search throughout analysis (RDR-103: collections are `<content_type>__<owner>__<embedding_model>__v<n>`)
+3. mcp__plugin_nx_nexus__search(query="query", corpus="code" for cross-repo searches (the bare prefix expands to all matching collections)
 
 This provides semantic search + ripgrep + git frecency, far more powerful than grep alone.
 

--- a/nx/agents/deep-research-synthesizer.md
+++ b/nx/agents/deep-research-synthesizer.md
@@ -109,11 +109,11 @@ You have access to and will actively leverage:
   - mcp__plugin_nx_nexus__query(question="research question", corpus="knowledge" -- document-level search with metadata
   - mcp__plugin_nx_nexus__query(question="topic", where="bib_year>=2023" -- filter by year, citations, tags
   - mcp__plugin_nx_nexus__search(query="query", corpus="knowledge", limit=5 -- chunk-level semantic search
-  - mcp__plugin_nx_nexus__store_list(collection="knowledge__art", docs=true -- enumerate all documents
-  - mcp__plugin_nx_nexus__store_put(content="content", collection="knowledge", title="title", tags="tags" -- store findings
+  - mcp__plugin_nx_nexus__store_list(collection="knowledge__art-1-1__voyage-context-3__v1", docs=true -- enumerate all documents (RDR-103: collections are `<content_type>__<owner>__<embedding_model>__v<n>`)
+  - mcp__plugin_nx_nexus__store_put(content="content", collection="knowledge", title="title", tags="tags" -- store findings (the bare prefix is auto-promoted to a conformant 4-segment name)
 - **nx code index**: Semantic code search across indexed repositories
   - mcp__plugin_nx_nexus__search(query="query", corpus="code", limit=20 -- hybrid semantic + ripgrep
-  - mcp__plugin_nx_nexus__search(query="query", corpus="code__<repo>", limit=20 -- repo-specific
+  - mcp__plugin_nx_nexus__search(query="query", corpus="code__<owner>__voyage-code-3__v1", limit=20 -- repo-specific
 - **nx T2 memory**: For accessing previous research and contextual information
   - mcp__plugin_nx_nexus__memory_get(project="{project}", title="{filename}" -- read
   - mcp__plugin_nx_nexus__memory_put(content="content", project="{project}", title="{filename}" -- write

--- a/nx/commands/pdf-process.md
+++ b/nx/commands/pdf-process.md
@@ -36,6 +36,8 @@ $ARGUMENTS
 Run `nx index pdf <file> --collection <name>` for each PDF. For batch processing, use a loop:
 
 ```bash
+# Short form: t3_collection_name auto-promotes to the conformant
+# 4-segment shape knowledge__<corpus>__voyage-context-3__v1.
 for f in *.pdf; do nx index pdf "$f" --collection knowledge__<corpus>; done
 ```
 

--- a/nx/skills/debug/SKILL.md
+++ b/nx/skills/debug/SKILL.md
@@ -53,8 +53,9 @@ falls through to an inline `claude -p` planner.
 
 A single-corpus RDR lookup — e.g. "find the RDR that covers this
 module's error-handling approach" — is fine via
-`mcp__plugin_nx_nexus__search(query=..., corpus="rdr__<repo>")`. Fast,
-cheap, and the chunks often contain the design rationale directly.
+`mcp__plugin_nx_nexus__search(query=..., corpus="rdr__<owner>__voyage-context-3__v1")`
+(or the bare `rdr` prefix to fan out to all matching collections).
+Fast, cheap, and the chunks often contain the design rationale directly.
 
 Use this skill when: the question needs to *walk* the catalog's
 per-file links (code → RDR → related RDRs) or synthesize across

--- a/nx/skills/nexus/SKILL.md
+++ b/nx/skills/nexus/SKILL.md
@@ -29,8 +29,8 @@ mcp__plugin_nx_nexus__search(query="query", structured=True         # returns {i
 mcp__plugin_nx_nexus__query(question="...", corpus="knowledge", follow_links="cites"    # catalog-aware, document-level
 
 # Batch hydrate chunks past the ChromaDB 300-record quota
-mcp__plugin_nx_nexus__store_get_many(ids=["id1","id2","id3"], collections="knowledge__art"
-mcp__plugin_nx_nexus__store_get_many(ids="id1,id2", collections="rdr__nexus", structured=True
+mcp__plugin_nx_nexus__store_get_many(ids=["id1","id2","id3"], collections="knowledge__art-1-1__voyage-context-3__v1"
+mcp__plugin_nx_nexus__store_get_many(ids="id1,id2", collections="rdr__nexus-1-1__voyage-context-3__v1", structured=True
 
 # Walk the catalog link graph (depth capped at 3 — SC-4)
 mcp__plugin_nx_nexus__traverse(seeds=["1.1.635"], link_types=["implements","cites"], depth=2
@@ -112,7 +112,7 @@ nx index repo <path>                 # index repo (classifies into code + docs c
 
 ## Collection Naming
 
-Always `__` as separator: `code__myrepo`, `docs__corpus`, `knowledge__topic`
+RDR-103 conformant shape: `<content_type>__<owner>__<embedding_model>__v<n>`. Examples: `code__nexus-1-1__voyage-code-3__v1`, `docs__nexus-1-1__voyage-context-3__v1`, `knowledge__art-1-1__voyage-context-3__v1`. The short legacy form (`knowledge__topic`) is accepted at the `--collection` boundary and auto-promoted by `t3_collection_name`. Pre-existing legacy 2-segment collections remain readable. Always `__` as the segment separator (colons are invalid in ChromaDB names).
 
 ## Title Conventions
 

--- a/nx/skills/nexus/reference.md
+++ b/nx/skills/nexus/reference.md
@@ -31,7 +31,7 @@ Semantic search across T3 knowledge collections.
 mcp__plugin_nx_nexus__search(query="query"                                  # knowledge + code + docs (default)
 mcp__plugin_nx_nexus__search(query="query", corpus="all"                    # all T3 collections
 mcp__plugin_nx_nexus__search(query="query", corpus="code"                   # code collections only
-mcp__plugin_nx_nexus__search(query="query", corpus="knowledge__art", limit=15  # specific collection
+mcp__plugin_nx_nexus__search(query="query", corpus="knowledge__art-1-1__voyage-context-3__v1", limit=15  # specific collection (RDR-103: 4-segment)
 mcp__plugin_nx_nexus__search(query="query", where="bib_year>=2023"          # filter by year
 mcp__plugin_nx_nexus__search(query="query", where="section_type!=references" # exclude reference sections
 mcp__plugin_nx_nexus__search(query="query", cluster_by="semantic"           # group results by topic
@@ -52,7 +52,7 @@ Document-level semantic search for analytical questions. Unlike `search` which r
 
 ```
 mcp__plugin_nx_nexus__query(question="adaptive resonance theory cortical maps"
-mcp__plugin_nx_nexus__query(question="speech processing", corpus="knowledge__art", where="page_count>=50"
+mcp__plugin_nx_nexus__query(question="speech processing", corpus="knowledge__art-1-1__voyage-context-3__v1", where="page_count>=50"
 mcp__plugin_nx_nexus__query(question="error handling patterns", corpus="code", limit=5
 ```
 
@@ -112,8 +112,8 @@ Batch-hydrate document content by ID past the ChromaDB 300-record read cap (RDR-
 | `structured` | bool | `false` | Return `{contents, missing}` dict when True; human-readable string when False |
 
 ```
-mcp__plugin_nx_nexus__store_get_many(ids=["id1","id2"], collections="knowledge__art"
-mcp__plugin_nx_nexus__store_get_many(ids="id1,id2", collections="rdr__nexus", structured=True
+mcp__plugin_nx_nexus__store_get_many(ids=["id1","id2"], collections="knowledge__art-1-1__voyage-context-3__v1"
+mcp__plugin_nx_nexus__store_get_many(ids="id1,id2", collections="rdr__nexus-1-1__voyage-context-3__v1", structured=True
 ```
 
 ### operator_summarize
@@ -254,9 +254,9 @@ List entries in a T3 knowledge collection.
 | `docs` | bool | `false` | Show unique documents instead of individual chunks. Deduplicates by content_hash, shows title, chunk count, page count, extraction method |
 
 ```
-mcp__plugin_nx_nexus__store_list(collection="knowledge"
-mcp__plugin_nx_nexus__store_list(collection="knowledge__art", docs=true       # document-level view
-mcp__plugin_nx_nexus__store_list(collection="knowledge__notes", limit=50, offset=100
+mcp__plugin_nx_nexus__store_list(collection="knowledge"                       # auto-promoted to conformant
+mcp__plugin_nx_nexus__store_list(collection="knowledge__art-1-1__voyage-context-3__v1", docs=true  # document-level view (RDR-103: 4-segment)
+mcp__plugin_nx_nexus__store_list(collection="knowledge__notes-1-1__voyage-context-3__v1", limit=50, offset=100
 ```
 
 ### memory_put
@@ -444,7 +444,7 @@ nx index repo <path>                       # register and index a repo
 nx index repo <path> --frecency-only       # refresh git frecency scores only (fast)
 nx index repo <path> --chunk-size 80       # smaller chunks for better precision
 nx index pdf <path> --corpus my-papers
-nx index pdf --dir <path> --collection knowledge__art  # batch index directory
+nx index pdf --dir <path> --collection knowledge__art  # auto-promoted to conformant 4-segment
 nx index md  <path> --corpus notes
 ```
 
@@ -471,7 +471,7 @@ nx mineru stop                             # stop server
 - **T2 memory**: cross-session state, agent relay notes, active project context
 - **T3 knowledge**: validated findings, architectural decisions, reusable patterns — anything worth keeping permanently
 
-**Collection naming**: always `__` as separator — `code__myrepo`, `docs__corpus`, `knowledge__topic`. Colons are invalid in ChromaDB collection names.
+**Collection naming** (RDR-103): always `__` as separator (colons are invalid in ChromaDB collection names). The conformant shape is `<content_type>__<owner>__<embedding_model>__v<n>`, for example `code__nexus-1-1__voyage-code-3__v1`, `docs__nexus-1-1__voyage-context-3__v1`, `knowledge__art-1-1__voyage-context-3__v1`. Operators may type the short legacy form (`knowledge__topic`) at the `--collection` boundary; `t3_collection_name` auto-promotes to the 4-segment shape before any T3 write. Pre-existing legacy 2-segment collections remain readable; only NEW non-conformant creations are blocked at `T3Database.get_or_create_collection`.
 
 **Title conventions** (use hyphens, not colons):
 - `research-{topic}` — research findings

--- a/nx/skills/rdr-gate/SKILL.md
+++ b/nx/skills/rdr-gate/SKILL.md
@@ -111,7 +111,7 @@ Structured critique with pass/warn/fail per finalization gate criterion:
 - First, try catalog (structured metadata): `mcp__plugin_nx_nexus-catalog__search(query="relevant terms from problem statement", content_type="rdr")`
   - If results found, use `mcp__plugin_nx_nexus-catalog__links(tumbler="<result>", direction="both")` to discover related RDRs in the graph
 - If catalog empty or not initialized, fall back to T3 semantic search:
-  - Use store_list tool to enumerate collections, filter for `rdr__`
+  - Use store_list tool to enumerate collections, filter by the `rdr__` prefix (RDR-103 conformant names start `rdr__<owner>__voyage-context-3__v1`)
   - mcp__plugin_nx_nexus__search(query="relevant query terms from RDR problem statement", corpus="{each_collection}", limit=5
 If no collections found: "No prior RDRs indexed. Cross-project prior-art search will improve as RDRs are indexed and closed."
 

--- a/nx/skills/review/SKILL.md
+++ b/nx/skills/review/SKILL.md
@@ -52,7 +52,9 @@ when it exists, falling back to `strategy:default` otherwise.
 
 If you just need to find the RDR or chunk that defines something — e.g.
 "show me where RDR-053 states the auth middleware contract" —
-`mcp__plugin_nx_nexus__search` against `rdr__<repo>` is the right tool.
+`mcp__plugin_nx_nexus__search` against `rdr__<owner>__voyage-context-3__v1`
+(or the bare `rdr` prefix, which expands to all matching collections)
+is the right tool.
 This skill earns its cost when the review has to *align* multiple
 RDRs against a change set and extract drift claims.
 


### PR DESCRIPTION
## Summary

Closes the RDR-103 doc tail (`nexus-yqnr.8`): plugin-layer markdown examples now match the conformant `<content_type>__<owner>__<embedding_model>__v<n>` shape that Phase 5 made the public contract.

- Replaced legacy 2-segment example collection names across `nx/agents/`, `nx/commands/`, `nx/skills/`.
- Where the short form is still valid operator input (auto-promoted by `t3_collection_name`), the docs now call that out so readers know both shapes work and which one is the contract.
- Rewrote the collection-naming sections in `nx/skills/nexus/SKILL.md` + `reference.md` and `nx/agents/_shared/ERROR_HANDLING.md` to describe the 4-segment shape as the public contract, with the read-side grandfathering of legacy collections noted explicitly.

Documentation-only; no runtime impact (P3).

## Test plan

- [x] `tests/test_plugin_structure.py` — 576 passed
- [x] Acceptance grep clean: no remaining bare `code__<repo>`, `knowledge__art`, `rdr__nexus`, `code__myrepo`, `knowledge__topic`, or `docs__corpus` literals in `nx/` outside `CHANGELOG.md`
- [ ] CI on this PR (Python 3.12 + 3.13)

## Closes

`nexus-yqnr.8` — RDR-103 Phase 6 plugin-layer documentation pass.