### PR TITLE
fix(catalog): drop UNIQUE(name) on owners; extend Phase 4 migration to path-derived synth (nexus-7vuw)

### DIFF
--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -21,11 +21,21 @@ PRAGMA journal_mode=WAL;
 
 CREATE TABLE IF NOT EXISTS owners (
     tumbler_prefix TEXT PRIMARY KEY,
-    name TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
     owner_type TEXT NOT NULL,
     repo_hash TEXT,
     description TEXT,
-    repo_root TEXT DEFAULT ''
+    repo_root TEXT DEFAULT '',
+    -- nexus-7vuw: name UNIQUE was a too-strict invariant. A repo and a
+    -- curator are different namespaces, so a repo named "nexus" should
+    -- coexist with a curator named "nexus" (e.g. ``nx index pdf
+    -- --corpus nexus`` after ``nx index repo .``). Pre-fix, the second
+    -- INSERT OR REPLACE silently obliterated the first row via the
+    -- name UNIQUE conflict, leaving owner_for_repo(repo_hash) returning
+    -- None and the indexer falling through to path-derived collection
+    -- naming. Composite UNIQUE keeps name-collision detection where it
+    -- belongs (within an owner_type).
+    UNIQUE(name, owner_type)
 );
 
 CREATE TABLE IF NOT EXISTS documents (
@@ -192,6 +202,62 @@ class CatalogDB:
         except sqlite3.OperationalError:
             with self._conn:
                 self._conn.execute("ALTER TABLE owners ADD COLUMN repo_root TEXT DEFAULT ''")
+
+        # nexus-7vuw: drop the legacy single-column UNIQUE(name) index
+        # on owners (replaced with composite UNIQUE(name, owner_type) in
+        # the schema above). Pre-fix DBs carry a sqlite_autoindex_owners_*
+        # index backing the old single-column constraint; SQLite cannot
+        # ALTER a constraint in place, so the migration rebuilds the
+        # owners table from existing rows. Idempotent: skipped when the
+        # auto-index is already absent.
+        legacy_unique = self._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND tbl_name='owners' AND name LIKE 'sqlite_autoindex_owners_%' "
+            "AND sql IS NULL"
+        ).fetchall()
+        if legacy_unique:
+            # Detect: probe the auto-index. If it indexes only ``name``,
+            # we have the pre-fix shape and need to rebuild. The
+            # composite UNIQUE(name, owner_type) declared in the schema
+            # above creates an auto-index on TWO columns, so single-column
+            # auto-indexes can only mean the legacy constraint survived
+            # from an older DB.
+            needs_rebuild = False
+            for (idx_name,) in legacy_unique:
+                cols = self._conn.execute(
+                    f"PRAGMA index_info({idx_name!r})"
+                ).fetchall()
+                if len(cols) == 1 and cols[0][2] == "name":
+                    needs_rebuild = True
+                    break
+            if needs_rebuild:
+                with self._conn:
+                    self._conn.execute(
+                        "CREATE TABLE owners_nexus7vuw_new ("
+                        "    tumbler_prefix TEXT PRIMARY KEY, "
+                        "    name TEXT NOT NULL, "
+                        "    owner_type TEXT NOT NULL, "
+                        "    repo_hash TEXT, "
+                        "    description TEXT, "
+                        "    repo_root TEXT DEFAULT '', "
+                        "    UNIQUE(name, owner_type)"
+                        ")"
+                    )
+                    # INSERT OR IGNORE so any pre-existing colliding rows
+                    # (which the legacy UNIQUE name constraint would have
+                    # already prevented) are dropped silently rather than
+                    # tripping the new composite constraint.
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO owners_nexus7vuw_new "
+                        "(tumbler_prefix, name, owner_type, repo_hash, "
+                        " description, repo_root) "
+                        "SELECT tumbler_prefix, name, owner_type, repo_hash, "
+                        "       description, repo_root FROM owners"
+                    )
+                    self._conn.execute("DROP TABLE owners")
+                    self._conn.execute(
+                        "ALTER TABLE owners_nexus7vuw_new RENAME TO owners"
+                    )
 
         # nexus-8luh: add source_mtime column to existing databases so
         # RDR-087 Phase 3.4's stale_source_ratio has something to read

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -319,9 +319,7 @@ def _legacy_collection_name(repo: "Path", content_type: str) -> str:
     ``(repo, content_type)``. Used by :func:`_migrate_legacy_collections`
     to detect existing legacy collections in T3 so they can be renamed
     in place to the conformant 4-segment shape on the first index after
-    the catalog upgrade. The migration helper is the only legitimate
-    consumer of the legacy shape post Phase 5; all name-minting paths
-    emit conformant.
+    the catalog upgrade.
     """
     from nexus.registry import _repo_identity, _safe_collection  # noqa: PLC0415
 
@@ -331,6 +329,59 @@ def _legacy_collection_name(repo: "Path", content_type: str) -> str:
         )
     basename, repo_hash = _repo_identity(repo)
     return _safe_collection(f"{content_type}__", basename, repo_hash)
+
+
+def _migration_source_candidates(
+    repo: "Path", content_type: str,
+) -> list[str]:
+    """Return ordered candidate "source" collection names that the
+    migration helper should consider for rename to the catalog-derived
+    target.
+
+    Two shapes can carry pre-migration data for ``(repo, content_type)``:
+
+    - The pre-RDR-103 legacy 2-segment ``<ct>__<basename>-<hash8>``
+      (older installs that indexed before Phase 1 introduced
+      ``CollectionName``).
+    - The Phase-5 path-derived 4-segment synth
+      ``<ct>__<basename>-<hash8>__<canonical_model>__v1``
+      (post-Phase-5 installs that indexed before the catalog owner
+      was registered, so ``_repo_collection_or_legacy`` fell through
+      to :func:`_conformant_name_for_repo`).
+
+    nexus-7vuw: the Phase-5 synth shape was missed by the original
+    migration helper, leaving operator data orphaned at the
+    path-derived collection while the indexer wrote fresh chunks to
+    the catalog-derived ``<ct>__<owner-tumbler>__<canonical_model>__v1``
+    target. Both shapes now flow through the same migration path.
+
+    Order matters: the 2-segment legacy is checked first so existing
+    Phase 4 migration semantics are preserved on pre-Phase-5 installs;
+    the path-derived 4-segment is the fallback for installs that have
+    already crossed the Phase-5 strict-flip and accumulated synth-shape
+    collections.
+    """
+    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.registry import _repo_identity, _safe_collection  # noqa: PLC0415
+
+    if content_type not in ("code", "docs", "rdr"):
+        raise ValueError(
+            f"_migration_source_candidates: unknown content_type {content_type!r}"
+        )
+    basename, repo_hash = _repo_identity(repo)
+    sanitised = basename.replace("_", "-")
+    model = canonical_embedding_model(content_type)
+    return [
+        # Pre-RDR-103 legacy 2-segment.
+        _safe_collection(f"{content_type}__", basename, repo_hash),
+        # Phase-5 path-derived 4-segment synth (mirrors the synthesis
+        # in ``_conformant_name_for_repo``: underscores in the
+        # basename are sanitised to hyphens for owner-segment grammar).
+        _safe_collection(
+            f"{content_type}__", sanitised, repo_hash,
+            suffix=f"__{model}__v1",
+        ),
+    ]
 
 
 def _migrate_legacy_collections(
@@ -405,14 +456,34 @@ def _migrate_legacy_collections(
         return result
 
     for ct in _MIGRATION_CONTENT_TYPES:
-        legacy = _legacy_collection_name(repo, ct)
         conformant = cat_obj.collection_for(
             content_type=ct,
             owner=owner,
             embedding_model=canonical_embedding_model(ct),
         ).render()
 
-        legacy_exists = bool(t3_db.collection_exists(legacy))  # type: ignore[attr-defined]
+        # nexus-7vuw: pick the first source candidate that exists in T3.
+        # Two shapes can carry pre-migration data:
+        #   1. legacy 2-segment ``<ct>__<basename>-<hash8>`` (pre-RDR-103)
+        #   2. Phase-5 path-derived 4-segment synth.
+        # If both exist, prefer the legacy 2-segment (rename happens
+        # first; the synth becomes the case-3 partial-state collision
+        # message and is left for operator cleanup).
+        legacy = None
+        for candidate in _migration_source_candidates(repo, ct):
+            if candidate == conformant:
+                # The candidate IS the target; no migration needed
+                # because the indexer is already writing to the right
+                # place.
+                continue
+            if t3_db.collection_exists(candidate):  # type: ignore[attr-defined]
+                legacy = candidate
+                break
+        if legacy is None:
+            legacy = _legacy_collection_name(repo, ct)
+            legacy_exists = False
+        else:
+            legacy_exists = True
         conformant_exists = bool(t3_db.collection_exists(conformant))  # type: ignore[attr-defined]
 
         if legacy_exists and not conformant_exists:

--- a/tests/test_catalog_db.py
+++ b/tests/test_catalog_db.py
@@ -274,3 +274,122 @@ class TestClose:
         db.close()
         with pytest.raises(Exception):
             db._conn.execute("SELECT 1")
+
+
+class TestNexus7vuwOwnerNameUniqueRelaxation:
+    """nexus-7vuw: a repo and a curator with the same name must coexist.
+
+    Pre-fix the ``owners`` table had a single-column ``UNIQUE(name)``
+    that caused INSERT OR REPLACE on the second registration to
+    silently obliterate the first row (SQLite resolves UNIQUE conflicts
+    by deleting the conflicting row before inserting the new one).
+    The visible symptom: ``Catalog.owner_for_repo(repo_hash)`` returned
+    None even though events.jsonl carried the OwnerRegistered event,
+    causing the indexer to fall back to path-derived collection naming
+    while a peer code path used the catalog tumbler, splitting RDR
+    chunks across two conformant collections.
+    """
+
+    def test_repo_and_curator_with_same_name_coexist(self, tmp_path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        # Register a repo owner.
+        db._conn.execute(
+            "INSERT INTO owners "
+            "(tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("1.1", "nexus", "repo", "571b8edd", "Git repository: nexus",
+             "/Users/hal/git/nexus"),
+        )
+        # Register a curator owner with the same name.
+        db._conn.execute(
+            "INSERT INTO owners "
+            "(tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("1.2", "nexus", "curator", "", "", ""),
+        )
+        rows = db._conn.execute(
+            "SELECT tumbler_prefix, name, owner_type, repo_hash "
+            "FROM owners ORDER BY tumbler_prefix"
+        ).fetchall()
+        assert rows == [
+            ("1.1", "nexus", "repo", "571b8edd"),
+            ("1.2", "nexus", "curator", ""),
+        ]
+
+    def test_same_name_same_type_still_collides(self, tmp_path):
+        """Composite UNIQUE(name, owner_type) keeps the within-type
+        collision check that protected register_owner from creating
+        duplicate curators with the same name.
+        """
+        db = CatalogDB(tmp_path / ".catalog.db")
+        db._conn.execute(
+            "INSERT INTO owners "
+            "(tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("1.1", "papers", "curator", "", "", ""),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            db._conn.execute(
+                "INSERT INTO owners "
+                "(tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("1.2", "papers", "curator", "", "", ""),
+            )
+
+    def test_legacy_unique_name_index_migrated(self, tmp_path):
+        """Pre-fix DBs (with the legacy single-column UNIQUE(name) auto-
+        index) get the table rebuilt to the new composite UNIQUE on
+        first open, preserving existing rows.
+        """
+        # Hand-craft a pre-fix DB: build the legacy schema, insert one
+        # row, then close. The migration in CatalogDB.__init__ should
+        # detect the auto-index and rebuild.
+        db_path = tmp_path / ".catalog.db"
+        legacy = sqlite3.connect(str(db_path))
+        legacy.execute(
+            "CREATE TABLE owners ("
+            "    tumbler_prefix TEXT PRIMARY KEY, "
+            "    name TEXT NOT NULL UNIQUE, "
+            "    owner_type TEXT NOT NULL, "
+            "    repo_hash TEXT, "
+            "    description TEXT, "
+            "    repo_root TEXT DEFAULT ''"
+            ")"
+        )
+        legacy.execute(
+            "INSERT INTO owners VALUES (?, ?, ?, ?, ?, ?)",
+            ("1.1", "nexus", "repo", "571b8edd", "Git repository: nexus", ""),
+        )
+        legacy.commit()
+        legacy.close()
+
+        # Open through CatalogDB; migration runs.
+        db = CatalogDB(db_path)
+        rows = db._conn.execute(
+            "SELECT tumbler_prefix, name, owner_type FROM owners"
+        ).fetchall()
+        assert rows == [("1.1", "nexus", "repo")]
+        # Verify the legacy single-column UNIQUE auto-index is gone.
+        legacy_indexes = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND tbl_name='owners' AND name LIKE 'sqlite_autoindex_owners_%' "
+            "AND sql IS NULL"
+        ).fetchall()
+        for (idx_name,) in legacy_indexes:
+            cols = db._conn.execute(
+                f"PRAGMA index_info({idx_name!r})"
+            ).fetchall()
+            assert len(cols) > 1 or cols[0][2] != "name", (
+                f"Legacy single-column UNIQUE(name) auto-index "
+                f"{idx_name!r} survived migration: {cols}"
+            )
+        # And the post-migration repo+curator coexistence holds.
+        db._conn.execute(
+            "INSERT INTO owners "
+            "(tumbler_prefix, name, owner_type, repo_hash, description, repo_root) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("1.2", "nexus", "curator", "", "", ""),
+        )
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM owners WHERE name = 'nexus'"
+        ).fetchone()[0] == 2

--- a/tests/test_indexer_e2e.py
+++ b/tests/test_indexer_e2e.py
@@ -529,6 +529,10 @@ def test_migration_moves_prose_from_code_to_docs(
         "migration must prune the seed chunk via the doc_id-keyed "
         "_prune_misclassified path"
     )
+    # nexus-7vuw: ``_migrate_legacy_collections`` may have renamed the
+    # registry's path-derived ``docs_collection`` to the catalog-derived
+    # conformant shape; re-read the registry to follow the rename.
+    info = reg.get(rich_repo)
     assert any("README.md" in p for p in _get_sources(local_t3, info["docs_collection"]))
 
 


### PR DESCRIPTION
## Summary

Fixes nexus-7vuw, the RDR-collection split surfaced by the post-Phase-5 sandbox shakedown. Two coupled bugs:

1. **owners.name UNIQUE conflict silently obliterated the repo owner.** When two owners shared a name (repo "nexus" + curator "nexus"), SQLite's INSERT OR REPLACE resolved the UNIQUE conflict by *deleting the existing row* before inserting the new one. `owner_for_repo(repo_hash)` then returned None, the indexer fell through to path-derived collection naming, and `nx index rdr` wrote to a different collection than `nx index repo`.
2. **`_migrate_legacy_collections` didn't know about the Phase-5 path-derived synth shape**, so existing path-derived data was orphaned when the catalog owner became visible on the next run.

## Fix

- `owners` schema: `UNIQUE(name)` → `UNIQUE(name, owner_type)`. Repo/curator namespaces are properly distinct.
- One-shot in-place migration in `CatalogDB.__init__` rebuilds pre-fix DBs (detects the legacy single-column auto-index, rebuilds owners table, preserves rows). `Catalog._ensure_consistent` rebuild from events.jsonl restores any owners the legacy schema had silently dropped.
- New helper `_migration_source_candidates` lists both legacy 2-segment AND Phase-5 path-derived 4-segment shapes; the migration loop picks the first one present in T3.

## Test plan

- [x] New regression tests in `tests/test_catalog_db.py::TestNexus7vuwOwnerNameUniqueRelaxation` (3 cases: coexistence, within-type collision, migration of pre-fix DB)
- [x] `tests/test_indexer_e2e.py::test_migration_moves_prose_from_code_to_docs` updated to re-read registry after second-index migration
- [x] Wide sweep: 937 tests passed
- [x] **Sandbox shakedown end-to-end: 10/10 steps pass, the bug reproduce is gone** — pre-fix listed both `rdr__1-1__...` and `rdr__nexus-571b8edd__...`; post-fix lists only `rdr__1-1__...`
- [ ] CI on this PR (Python 3.12 + 3.13)

## Closes

`nexus-7vuw` — Phase 5 produces split RDR collections: path-derived synth vs catalog-tumbler owner.