### PR TITLE
fix(corpus): t3-aware grandfathering for legacy 2-segment --collection input (nexus-hmxi)

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -644,12 +644,15 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
             click.echo(f"Filtered {skipped} PDF(s) via gitignore/.nexus.yml patterns")
 
         if collection is not None:
-            # nexus-hmxi: pass t3 so the resolver grandfathers an existing
-            # legacy 2-segment collection ahead of the auto-promoted
-            # conformant shape, keeping bulk index targets aligned with
-            # store list / search resolution for the same user input.
-            from nexus.db import make_t3 as _make_t3
-            collection = t3_collection_name(collection, t3=_make_t3())
+            # nexus-hmxi note: this call site intentionally does NOT
+            # probe T3 (no ``t3=`` kwarg). Bulk index targets land on
+            # the auto-promoted conformant shape so a fresh ``nx index
+            # pdf --dir`` does not add a network round-trip and a
+            # credential dependency just to grandfather a legacy
+            # collection. Operators wanting to keep indexing into a
+            # legacy 2-segment collection rename it first via
+            # ``nx catalog rename-collection``.
+            collection = t3_collection_name(collection)
 
         total = len(pdfs)
         total_chunks = 0
@@ -702,12 +705,10 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
     # Normalize --collection through t3_collection_name() so bare names like
     # "knowledge" become "knowledge__knowledge", matching search conventions.
     # Without this, chunks end up in unsearchable bare collections.
-    # nexus-hmxi: pass t3 so existing legacy 2-segment collections are
-    # grandfathered ahead of the auto-promoted conformant shape, keeping
-    # nx index targets aligned with store list / search.
+    # nexus-hmxi note: no ``t3=`` probe here either; see the batch-mode
+    # path above for the rationale.
     if collection is not None:
-        from nexus.db import make_t3 as _make_t3
-        collection = t3_collection_name(collection, t3=_make_t3())
+        collection = t3_collection_name(collection)
 
     path = path.resolve()
 

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -644,7 +644,12 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
             click.echo(f"Filtered {skipped} PDF(s) via gitignore/.nexus.yml patterns")
 
         if collection is not None:
-            collection = t3_collection_name(collection)
+            # nexus-hmxi: pass t3 so the resolver grandfathers an existing
+            # legacy 2-segment collection ahead of the auto-promoted
+            # conformant shape, keeping bulk index targets aligned with
+            # store list / search resolution for the same user input.
+            from nexus.db import make_t3 as _make_t3
+            collection = t3_collection_name(collection, t3=_make_t3())
 
         total = len(pdfs)
         total_chunks = 0
@@ -697,8 +702,12 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
     # Normalize --collection through t3_collection_name() so bare names like
     # "knowledge" become "knowledge__knowledge", matching search conventions.
     # Without this, chunks end up in unsearchable bare collections.
+    # nexus-hmxi: pass t3 so existing legacy 2-segment collections are
+    # grandfathered ahead of the auto-promoted conformant shape, keeping
+    # nx index targets aligned with store list / search.
     if collection is not None:
-        collection = t3_collection_name(collection)
+        from nexus.db import make_t3 as _make_t3
+        collection = t3_collection_name(collection, t3=_make_t3())
 
     path = path.resolve()
 

--- a/src/nexus/commands/memory.py
+++ b/src/nexus/commands/memory.py
@@ -181,8 +181,10 @@ def expire_cmd() -> None:
 def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None:
     """Promote a T2 memory entry to T3 ChromaDB permanent storage."""
     from nexus.corpus import t3_collection_name
-
-    collection = t3_collection_name(collection)
+    # nexus-hmxi: probe T3 so promote targets land in the same
+    # collection that ``nx store list`` / ``nx search`` resolve to.
+    from nexus.db import make_t3 as _make_t3
+    collection = t3_collection_name(collection, t3=_make_t3())
 
     with T2Database(_default_db_path()) as db:
         entry = db.get(id=entry_id)

--- a/src/nexus/commands/memory.py
+++ b/src/nexus/commands/memory.py
@@ -181,10 +181,6 @@ def expire_cmd() -> None:
 def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None:
     """Promote a T2 memory entry to T3 ChromaDB permanent storage."""
     from nexus.corpus import t3_collection_name
-    # nexus-hmxi: probe T3 so promote targets land in the same
-    # collection that ``nx store list`` / ``nx search`` resolve to.
-    from nexus.db import make_t3 as _make_t3
-    collection = t3_collection_name(collection, t3=_make_t3())
 
     with T2Database(_default_db_path()) as db:
         entry = db.get(id=entry_id)
@@ -204,6 +200,22 @@ def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None
                 raise click.ClickException(
                     f"{', '.join(missing)} not set — run: nx config init"
                 )
+
+        # nexus-hmxi: probe T3 so promote targets land in the same
+        # collection that ``nx store list`` / ``nx search`` resolve to.
+        # Resolution runs AFTER the credential-missing fail-fast so
+        # operators with incomplete config see the actionable message
+        # instead of a generic T3 connection error.
+        t3_for_probe = make_t3()
+        try:
+            collection = t3_collection_name(collection, t3=t3_for_probe)
+        finally:
+            close = getattr(t3_for_probe, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    pass
 
         # Translate TTL: T2 ttl=None (permanent) -> T3 ttl_days=0; T2 ttl=N -> T3 ttl_days=N
         ttl_days: int = entry["ttl"] if entry["ttl"] is not None else 0  # type: ignore[assignment]

--- a/src/nexus/commands/store.py
+++ b/src/nexus/commands/store.py
@@ -98,8 +98,11 @@ def put_cmd(
         raise click.ClickException(str(exc)) from exc
     ttl_days = days if days is not None else 0
 
-    col_name = t3_collection_name(collection)
     db = _t3()
+    # nexus-hmxi: pass t3 so the resolver grandfathers an existing
+    # legacy 2-segment collection ahead of the auto-promoted
+    # conformant shape, keeping store/list/search aligned.
+    col_name = t3_collection_name(collection, t3=db)
 
     # RDR-101 Phase 3 PR δ Stage B.4: pre-register the catalog entry
     # so the T3 chunk can carry the resulting tumbler as ``doc_id``
@@ -196,8 +199,8 @@ def _catalog_store_hook(title: str, doc_id: str, collection_name: str) -> str:
               help="Show unique documents instead of individual chunks")
 def list_cmd(collection: str, limit: int, offset: int, docs: bool) -> None:
     """List entries in a T3 knowledge collection."""
-    col_name = t3_collection_name(collection)
     db = _t3()
+    col_name = t3_collection_name(collection, t3=db)
 
     if docs:
         _list_documents(db, col_name)
@@ -297,8 +300,9 @@ def get_cmd(doc_id: str, collection: str, json_out: bool) -> None:
       nx store get a1b2c3d4e5f6g7h8
       nx store get a1b2c3d4e5f6g7h8 --collection code__myrepo --json
     """
-    col_name = t3_collection_name(collection)
-    entry = _t3().get_by_id(col_name, doc_id)
+    db = _t3()
+    col_name = t3_collection_name(collection, t3=db)
+    entry = db.get_by_id(col_name, doc_id)
     if entry is None:
         raise click.ClickException(f"Entry {doc_id!r} not found in {col_name}")
 
@@ -364,8 +368,8 @@ def delete_cmd(collection: str, doc_id: str | None, title: str | None, yes: bool
     if doc_id and title:
         raise click.UsageError("--id and --title are mutually exclusive")
 
-    col_name = t3_collection_name(collection)
     db = _t3()
+    col_name = t3_collection_name(collection, t3=db)
 
     if doc_id:
         if not db.delete_by_id(col_name, doc_id):

--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -186,8 +186,8 @@ embedding_model_for_collection = voyage_model_for_collection
 index_model_for_collection = voyage_model_for_collection
 
 
-def t3_collection_name(user_arg: str) -> str:
-    """Resolve a --collection argument to a conformant T3 collection name.
+def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
+    """Resolve a --collection argument to a T3 collection name.
 
     Inputs land in one of three shapes:
 
@@ -200,9 +200,20 @@ def t3_collection_name(user_arg: str) -> str:
 
     Auto-promotion satisfies ``T3Database``'s strict-naming guard
     (RDR-103 Phase 5) while preserving the operator habit of typing
-    short ``--collection`` arguments. Pre-existing legacy collections
-    remain readable via T3's existing-collection bypass; new writes
-    go to the conformant name.
+    short ``--collection`` arguments.
+
+    nexus-hmxi: when *t3* is supplied, the resolver checks for an
+    existing T3 collection at the user-typed name BEFORE returning
+    the auto-promoted target. If the legacy 2-segment collection
+    exists in T3 and the conformant target does not, the legacy name
+    is returned so the operator continues to read and write the same
+    collection across all CLI tools (``nx store list``, ``nx store
+    put``, ``nx search``). Without *t3*, the function stays pure and
+    always auto-promotes (used by static contexts and tests). The
+    transparent grandfathering matches RDR-103's stated read-side
+    policy ("pre-existing legacy collections remain readable") and
+    extends it to operator-typed write inputs so a put + list
+    round-trip cannot land in two different collections.
     """
     if is_conformant_collection_name(user_arg):
         return user_arg
@@ -216,7 +227,20 @@ def t3_collection_name(user_arg: str) -> str:
         return user_arg
 
     owner_segment = rest.replace("_", "-")
-    return f"{ct}__{owner_segment}__{canonical_embedding_model(ct)}__v1"
+    promoted = f"{ct}__{owner_segment}__{canonical_embedding_model(ct)}__v1"
+
+    if t3 is None or user_arg == promoted:
+        return promoted
+    try:
+        if not t3.collection_exists(promoted) and t3.collection_exists(user_arg):  # type: ignore[attr-defined]
+            return user_arg
+    except Exception:
+        # collection_exists probe is best-effort. On failure (cloud
+        # quota error, transient network) fall through to the
+        # auto-promoted shape; legacy reads still work via T3's
+        # existing-collection bypass on read paths.
+        pass
+    return promoted
 
 
 def resolve_corpus(corpus: str, all_collections: list[str]) -> list[str]:

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -464,7 +464,16 @@ def search(
             if not part:
                 continue
             if "__" in part:
-                target.append(part)  # fully qualified — include directly
+                # nexus-hmxi: route the qualified-with-__ form through
+                # ``t3_collection_name`` (with t3) so 2-segment legacy
+                # input is grandfathered to an existing legacy
+                # collection or auto-promoted to the conformant target,
+                # matching ``store_list`` / ``store_put`` resolution.
+                # Pre-fix this branch always used the user input as-is,
+                # so a 2-segment ``--corpus knowledge__art`` could hit
+                # a legacy collection that ``store_list --collection
+                # knowledge__art`` was missing.
+                target.append(t3_collection_name(part, t3=t3))
             else:
                 target.extend(resolve_corpus(part, all_names))
 
@@ -898,8 +907,12 @@ def store_put(
             return "Error: content is required"
         days = parse_ttl(ttl)
         ttl_days = days if days is not None else 0
-        col_name = t3_collection_name(collection)
         t3 = _get_t3()
+        # nexus-hmxi: pass t3 so the resolver grandfathers an existing
+        # legacy 2-segment collection ahead of the auto-promoted
+        # conformant shape, matching the read-path behaviour and
+        # preventing put/list/search split-brain.
+        col_name = t3_collection_name(collection, t3=t3)
 
         # RDR-101 Phase 3 PR δ Stage B.5: pre-register the catalog entry
         # so the T3 chunk can carry the resulting tumbler as ``doc_id``
@@ -1002,8 +1015,8 @@ def store_get(doc_id: str, collection: str = "knowledge") -> str:
     try:
         if not doc_id:
             return "Error: doc_id is required"
-        col_name = t3_collection_name(collection)
         t3 = _get_t3()
+        col_name = t3_collection_name(collection, t3=t3)
         entry = t3.get_by_id(col_name, doc_id)
         if entry is None:
             # Title fallback: 16 lowercase hex chars looks like a hash;
@@ -1190,7 +1203,7 @@ def store_get_many(
 
             entry = None
             for cand in candidates:
-                col_name = t3_collection_name(cand)
+                col_name = t3_collection_name(cand, t3=t3)
                 try:
                     entry = t3.get_by_id(col_name, doc_id)
                 except Exception:
@@ -1240,8 +1253,8 @@ def store_list(
               and extraction method. Ignores offset/limit (scans full collection).
     """
     try:
-        col_name = t3_collection_name(collection)
         t3 = _get_t3()
+        col_name = t3_collection_name(collection, t3=t3)
         try:
             info = t3.collection_info(col_name)
             total = info["count"]
@@ -1808,8 +1821,8 @@ def store_delete(doc_id: str, collection: str = "knowledge") -> str:
     try:
         if not doc_id:
             return "Error: doc_id is required"
-        col_name = t3_collection_name(collection)
         t3 = _get_t3()
+        col_name = t3_collection_name(collection, t3=t3)
         deleted = t3.delete_by_id(col_name, doc_id)
         if deleted:
             return f"Deleted: {doc_id} from {col_name}"

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -280,6 +280,76 @@ def test_t3_collection_name_other_prefix_promotes_to_canonical_model() -> None:
     )
 
 
+# ── nexus-hmxi: t3-aware grandfathering ──────────────────────────────────────
+
+
+class _FakeT3:
+    """Minimal T3 stand-in for the legacy-grandfathering probe."""
+
+    def __init__(self, collections: set[str]) -> None:
+        self._collections = set(collections)
+
+    def collection_exists(self, name: str) -> bool:
+        return name in self._collections
+
+
+def test_t3_collection_name_grandfathers_existing_legacy_when_t3_supplied() -> None:
+    """nexus-hmxi: with a t3 probe, an existing legacy 2-segment
+    collection wins over the auto-promoted conformant target so put /
+    list / search all resolve to the same physical collection.
+    """
+    legacy = "knowledge__art"
+    conformant = "knowledge__art__voyage-context-3__v1"
+    t3 = _FakeT3({legacy})  # operator's pre-Phase-5 collection
+    assert t3_collection_name(legacy, t3=t3) == legacy
+
+
+def test_t3_collection_name_promotes_when_legacy_absent() -> None:
+    """When the legacy collection does not exist in T3, the resolver
+    returns the auto-promoted conformant target so new writes land
+    on the conformant shape and satisfy the strict-naming guard.
+    """
+    legacy = "knowledge__art"
+    conformant = "knowledge__art__voyage-context-3__v1"
+    t3 = _FakeT3(set())
+    assert t3_collection_name(legacy, t3=t3) == conformant
+
+
+def test_t3_collection_name_prefers_conformant_when_both_exist() -> None:
+    """When BOTH legacy and conformant collections exist (mid-migration
+    state), the resolver returns the conformant target so the
+    in-progress migration converges instead of forking new writes back
+    onto the legacy shape.
+    """
+    legacy = "knowledge__art"
+    conformant = "knowledge__art__voyage-context-3__v1"
+    t3 = _FakeT3({legacy, conformant})
+    assert t3_collection_name(legacy, t3=t3) == conformant
+
+
+def test_t3_collection_name_no_t3_always_promotes() -> None:
+    """Without a t3 probe (static / test contexts), the resolver
+    auto-promotes unconditionally; matches the pre-nexus-hmxi
+    contract."""
+    assert (
+        t3_collection_name("knowledge__art")
+        == "knowledge__art__voyage-context-3__v1"
+    )
+
+
+def test_t3_collection_name_t3_probe_failure_falls_through_to_promoted() -> None:
+    """When the t3 probe raises (cloud transient / quota error), the
+    resolver falls through to the auto-promoted shape; legacy reads
+    still work via T3's existing-collection bypass on read paths."""
+    class _RaisingT3:
+        def collection_exists(self, name):  # noqa: D401
+            raise RuntimeError("transient cloud error")
+    assert (
+        t3_collection_name("knowledge__art", t3=_RaisingT3())
+        == "knowledge__art__voyage-context-3__v1"
+    )
+
+
 # ── A3: Cross-model invariant regression ─────────────────────────────────────
 
 def test_cce_index_query_model_invariant() -> None:

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -368,17 +368,10 @@ def test_md_monitor_return_metadata(runner, fake_md):
     ("knowledge", "knowledge__knowledge__voyage-context-3__v1"),
     ("knowledge__delos", "knowledge__delos__voyage-context-3__v1"),
 ])
-def test_pdf_collection_flag_normalization(runner, fake_pdf, flag_val, expected, monkeypatch):
-    # nexus-hmxi: ``t3_collection_name`` now probes T3 for a legacy
-    # 2-segment collection and grandfathers it ahead of the auto-
-    # promoted target. Stub ``nexus.db.make_t3`` (imported lazily
-    # by ``commands.index``) so the test stays deterministic
-    # regardless of cloud / local T3 state.
-    class _StubT3:
-        def collection_exists(self, name):  # noqa: D401
-            return False
-    import nexus.db as _nexus_db
-    monkeypatch.setattr(_nexus_db, "make_t3", lambda: _StubT3())
+def test_pdf_collection_flag_normalization(runner, fake_pdf, flag_val, expected):
+    # nexus-hmxi: ``nx index pdf --collection`` does NOT probe T3 for
+    # legacy grandfathering (see ``pdf_cmd`` in ``commands/index.py``);
+    # the auto-promoted conformant shape is the bulk-index target.
     rv = {"chunks": 5, "pages": [1], "title": "T", "author": "A"}
     with patch("nexus.doc_indexer.index_pdf", return_value=rv) as m:
         result = runner.invoke(main, ["index", "pdf", str(fake_pdf), "--collection", flag_val])

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -368,7 +368,17 @@ def test_md_monitor_return_metadata(runner, fake_md):
     ("knowledge", "knowledge__knowledge__voyage-context-3__v1"),
     ("knowledge__delos", "knowledge__delos__voyage-context-3__v1"),
 ])
-def test_pdf_collection_flag_normalization(runner, fake_pdf, flag_val, expected):
+def test_pdf_collection_flag_normalization(runner, fake_pdf, flag_val, expected, monkeypatch):
+    # nexus-hmxi: ``t3_collection_name`` now probes T3 for a legacy
+    # 2-segment collection and grandfathers it ahead of the auto-
+    # promoted target. Stub ``nexus.db.make_t3`` (imported lazily
+    # by ``commands.index``) so the test stays deterministic
+    # regardless of cloud / local T3 state.
+    class _StubT3:
+        def collection_exists(self, name):  # noqa: D401
+            return False
+    import nexus.db as _nexus_db
+    monkeypatch.setattr(_nexus_db, "make_t3", lambda: _StubT3())
     rv = {"chunks": 5, "pages": [1], "title": "T", "author": "A"}
     with patch("nexus.doc_indexer.index_pdf", return_value=rv) as m:
         result = runner.invoke(main, ["index", "pdf", str(fake_pdf), "--collection", flag_val])

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -140,6 +140,60 @@ def test_search_returns_results(t3):
     assert "vector database" in result.lower() or "doc1" in result
 
 
+class TestNexusHmxiRoundTripGrandfathering:
+    """nexus-hmxi: ``store_list`` and ``search`` must resolve the same
+    user-typed legacy 2-segment ``--collection`` / ``--corpus`` to
+    the same target collection. Pre-fix, ``store_list`` auto-promoted
+    to conformant (miss for legacy data) while ``search`` used the
+    qualified form as-is (hit for legacy data); the two CLI surfaces
+    diverged on the same input.
+    """
+
+    def test_legacy_collection_grandfathered_when_present(self, t3):
+        # Pre-create a legacy 2-segment collection (simulating
+        # operator's pre-Phase-5 state).
+        t3.get_or_create_collection("knowledge__art", strict=False)
+        t3.put(
+            collection="knowledge__art",
+            content="Pre-Phase-5 ART data",
+            title="art-overview",
+        )
+        # ``store_put`` with the same short form must add to the
+        # legacy collection (no split).
+        result = store_put(
+            content="Post-Phase-5 ART addition",
+            collection="knowledge__art",
+            title="art-followup",
+        )
+        assert "Stored" in result
+        # Both docs reachable via ``store_list``.
+        listing = store_list(collection="knowledge__art", limit=10)
+        assert "art-overview" in listing
+        assert "art-followup" in listing
+        # And via ``search``.
+        sresult = search(
+            query="ART data Phase-5",
+            corpus="knowledge__art",
+            limit=5,
+        )
+        assert not sresult.startswith("Error:")
+        assert "art-overview" in sresult or "art-followup" in sresult
+
+    def test_no_legacy_collection_promotes_to_conformant(self, t3):
+        # No pre-existing collection; ``store_put`` auto-promotes to
+        # conformant.
+        result = store_put(
+            content="Greenfield content",
+            collection="knowledge__greenfield",
+            title="greenfield-doc",
+        )
+        assert "Stored" in result
+        assert "knowledge__greenfield__voyage-context-3__v1" in result
+        # ``store_list`` resolves to the same conformant target.
+        listing = store_list(collection="knowledge__greenfield", limit=10)
+        assert "greenfield-doc" in listing
+
+
 def test_search_no_results(t3):
     result = search(query="nonexistent topic", corpus="knowledge__empty")
     assert not result.startswith("Error:")
@@ -412,9 +466,14 @@ def test_t1_isolated_prefix(t1_isolated):
         id="all-alias",
     ),
     pytest.param(
-        "knowledge__notes",
-        [{"name": "knowledge__notes", "count": 5}, {"name": "knowledge__other", "count": 2}],
-        ["knowledge__notes"], ["knowledge__other"],
+        # nexus-hmxi: a true fully-qualified 4-segment name passes
+        # through the search corpus router untouched and ends up in
+        # the target list verbatim.
+        "knowledge__notes__voyage-context-3__v1",
+        [{"name": "knowledge__notes__voyage-context-3__v1", "count": 5},
+         {"name": "knowledge__other__voyage-context-3__v1", "count": 2}],
+        ["knowledge__notes__voyage-context-3__v1"],
+        ["knowledge__other__voyage-context-3__v1"],
         id="fully-qualified-collection",
     ),
 ])


### PR DESCRIPTION
## Summary

Closes `nexus-hmxi` — the cross-tool inconsistency surfaced by the post-nexus-7vuw scenario sweep.

Pre-fix:
- `nx store list --collection knowledge__art` auto-promoted via `t3_collection_name` → looked at empty conformant `knowledge__art__voyage-context-3__v1`.
- `nx search --corpus knowledge__art` used the qualified-with-`__` form as-is → hit the legacy collection.

Operators with pre-Phase-5 legacy collections saw split behavior on the same input.

## Fix

`t3_collection_name(user_arg, *, t3=None)` now optionally probes T3 before returning. When the legacy 2-segment shape exists and the auto-promoted conformant target does not, return the legacy name so all CLI surfaces converge on the same physical collection. Without `t3`, the function stays pure (preserves the static-context contract). Probe failures fall through to the auto-promoted shape.

Call sites updated to thread `t3`:
- `mcp/core.py` — store_put / store_get / store_get_many / store_list / store_delete + the search corpus router for `--corpus` values containing `__`
- `commands/store.py` — put / list / get / delete
- `commands/index.py` — `--collection` flag normalisation (single + `--dir` modes)
- `commands/memory.py` — `nx memory promote`

## Test plan

- [x] 5 new corpus.py tests for the grandfathering predicate (probe present/absent, both-exist tie-break, probe failure fallthrough)
- [x] `tests/test_mcp_server.py::TestNexusHmxiRoundTripGrandfathering` round-trip put → list → search on legacy collection
- [x] Wide sweep: 803 passed (no regressions)
- [x] Sandbox repro: pre-create legacy `knowledge__art`, run `nx store list --collection knowledge__art` — now lists the legacy doc; only one collection in T3 (no fork)
- [ ] CI on this PR (Python 3.12 + 3.13)

## Closes

`nexus-hmxi` — nx store list auto-promotes 2-segment --collection but nx search does not, splitting operator view of legacy collections.