### PR TITLE
docs+catalog: align operator-facing surfaces with post-RDR-101/103 reality

### DIFF
--- a/docs/metadata-consistency-matrix.md
+++ b/docs/metadata-consistency-matrix.md
@@ -1,5 +1,9 @@
 # T3 Chunk Metadata Consistency Matrix
 
+> **HISTORICAL (2026-04-26)**: this audit predates RDR-101 Phase 4 (`source_path` removed from chunk metadata) and Phase 5c (`corpus`, `store_type`, `git_meta` removed from the chunk-level allow-list). Several rows below describe fields that no longer exist in chunk metadata. For the current `ALLOWED_TOP_LEVEL` set see `src/nexus/metadata_schema.py`; for the rationale of the field reductions see `docs/rdr/rdr-101-catalog-t3-metadata-design.md`, `docs/rdr/rdr-102-phase4-completion.md`, and the post-mortems under `docs/rdr/post-mortem/`.
+>
+> Kept in-tree as the audit artifact that drove the RDR-101 / RDR-102 reductions; do NOT use as a current-state reference.
+
 **Date**: 2026-04-26
 **Branch**: `feature/nexus-b9g1-rdr-089-aspect-extraction`
 **Scope**: every `ALLOWED_TOP_LEVEL` field in `src/nexus/metadata_schema.py:49–88` × every indexer / chunker that writes T3 chunk metadata.

--- a/docs/repo-indexing.md
+++ b/docs/repo-indexing.md
@@ -230,8 +230,8 @@ version is bumped. This enables targeted re-indexing:
 In cloud mode, `nx doctor` reports the pipeline version status of each collection. In local mode, pipeline version is not checked — run `nx index repo --force-stale` after an upgrade to refresh any outdated collections.
 
 ```
-✓ pipeline (code__nexus-571b8edd): v4
-✓ pipeline (code__myrepo-abc12345): no version stamp (index with --force to stamp)
+✓ pipeline (code__nexus-1-1__voyage-code-3__v1): v4
+✓ pipeline (code__myrepo-1-1__voyage-code-3__v1): no version stamp (index with --force to stamp)
 ```
 
 Collections without a version stamp were indexed before pipeline versioning was introduced.

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -674,12 +674,13 @@ class Catalog:
                         "events.jsonl is non-empty but has fewer "
                         "DocumentRegistered events than documents.jsonl "
                         "has rows. ES writes are landing in the log "
-                        "but reads come from legacy JSONL — replay "
-                        "equality is silently broken until the log "
-                        "catches up. Run 'nx catalog synthesize-log "
-                        "--force' to rebuild events.jsonl from the "
-                        "legacy state, then 'nx catalog t3-backfill-"
-                        "doc-id' to align T3 chunks."
+                        "but reads come from legacy JSONL; replay "
+                        "equality is silently broken. The synthesize-log "
+                        "and t3-backfill-doc-id remediation verbs were "
+                        "retired post Phase 5b (nexus-iftc). Restore by "
+                        "deleting the catalog directory and re-running "
+                        "'nx catalog setup' to bootstrap from current "
+                        "T3 state."
                     ),
                 )
                 use_event_log = False

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -4726,32 +4726,31 @@ def _print_t3_doc_id_coverage_text(report: dict) -> None:
         for line in warn_lines:
             click.echo(line)
         click.echo(
-            "  Run 'nx catalog synthesize-log --force --chunks "
-            "--prefer-live-catalog' followed by 'nx catalog "
-            "t3-backfill-doc-id' to recover content_hash-matchable "
-            "orphans. See docs/migration/rdr-101-phase4-orphan-recovery.md."
+            "  The synthesize-log and t3-backfill-doc-id remediation "
+            "verbs were retired post Phase 5b (nexus-iftc). Re-index the "
+            "affected collections to repopulate orphan chunks with "
+            "current doc_id metadata; see docs/migration/"
+            "rdr-101-phase4-orphan-recovery.md for historical context."
         )
     click.echo("")
     if report["pass"]:
         click.echo("PASS — every non-orphan chunk carries the expected doc_id.")
     else:
         click.echo("FAIL — T3 doc_id metadata diverges from the event log.")
-        # nexus-o6aa.10.4: surface the next operator verb. The most
-        # common cause of a coverage FAIL is a pre-Phase-4 catalog
-        # whose chunks lack doc_id metadata; ``nx catalog migrate``
-        # is the single-command remediation. Mismatched doc_ids point
-        # at a different (rarer) class (synthesize-log drift)
-        # which is caught by the same verb's projection rebuild step.
+        # Post-iftc (RDR-101 Phase 5b irreversibility): the migrate /
+        # synthesize-log / t3-backfill-doc-id verbs are gone. A FAIL
+        # today means the catalog holds pre-Phase-4 state; restore by
+        # bootstrapping a fresh catalog from current T3.
         click.echo("")
         click.echo("Next step:")
-        click.echo("  nx catalog migrate --i-have-completed-the-reader-migration")
         click.echo(
-            "  (or 'nx catalog t3-backfill-doc-id' alone if you have not "
-            "shipped the Phase 4 reader migration yet)"
+            "  Delete the catalog directory and re-run 'nx catalog setup' "
+            "to bootstrap a fresh event log from current T3 state."
         )
         click.echo(
             "See docs/migration/rdr-101.md § 'Post-Phase-4 cleanup' for "
-            "the full remediation walk-through."
+            "the historical remediation walk-through (verbs retired "
+            "post Phase 5b)."
         )
 
 


### PR DESCRIPTION
## Summary

Systematic walk through user-facing docs and operator-visible source strings after the RDR-101 + RDR-103 arc landed. Caught four drifts:

| # | Surface | Drift | Fix |
|---|---------|-------|-----|
| 1 | `docs/repo-indexing.md:233` | `nx doctor` output example used legacy 2-segment collection names | Updated to conformant 4-segment shape |
| 2 | `docs/metadata-consistency-matrix.md` | 2026-04-26 audit lists `corpus`/`store_type`/`git_meta` as live (Phase 5c removed all three) | Added HISTORICAL header pointing at current authoritative state |
| 3 | `src/nexus/catalog/catalog.py:670-684` | bootstrap-fallback warning told operators to run deleted verbs `synthesize-log` + `t3-backfill-doc-id` | Post-iftc playbook: delete catalog dir + `nx catalog setup` |
| 4 | `src/nexus/commands/catalog.py:4720-4755` | doctor `--t3-doc-id-coverage` orphan-recovery + FAIL next-step pointed at deleted verbs | Re-index for orphans; bootstrap-fresh-catalog for FAIL |

## Surfaces verified clean

- `README.md`, `docs/architecture.md`, `docs/contributing.md`
- `docs/cli-reference.md`, `docs/catalog.md`, `docs/configuration.md`
- `docs/getting-started.md`, `docs/querying-guide.md`, `docs/storage-tiers.md`, `docs/mcp-servers.md`
- `nx/skills/nexus/SKILL.md`, `nx/skills/nexus/reference.md`, `nx/agents/_shared/ERROR_HANDLING.md` (these explicitly cite RDR-103 and use the conformant shape)

## Surfaces deliberately NOT touched

- `docs/rdr/**/*.md` and `docs/rdr/post-mortem/**` (frozen historical record)
- `docs/migration/rdr-101-*.md` (operator migration guides for the actual cutover; time-stamped)
- `CHANGELOG.md` / `nx/CHANGELOG.md` (release-note history is append-only; correctly describes what shipped at the time)

## Test plan
- [x] `uv run pytest tests/test_catalog_doctor_collections_drift.py tests/test_catalog_doctor_replay_equality.py tests/test_catalog_doctor_t3_coverage.py tests/test_catalog_bootstrap_guardrail.py` (32 passed)
- [x] Em-dash audit clean on staged diff
- [x] Re-sweep: zero deleted-verb references remain in `src/`
- [x] Re-sweep: zero legacy 2-segment patterns remain in operator-facing docs (skill files use conformant shape)