### PR TITLE
fix(catalog): persist _last_consistency_mtime across processes (nexus-wehp)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -570,12 +570,48 @@ class Catalog:
         # Storage review S-4: mtime cache so every Catalog() instantiation
         # doesn't re-parse the full JSONL corpus and re-build the SQLite
         # cache. For a 10k-entry catalog this was measurably slow on
-        # every MCP tool invocation — the mtime-guarded check skips the
+        # every MCP tool invocation; the mtime-guarded check skips the
         # rebuild when nothing has changed since the last consistency
         # pass.
-        self._last_consistency_mtime: float = 0.0
+        #
+        # nexus-wehp: persist the marker to disk so cross-process
+        # invocations (CLI verbs while nx-mcp is running) don't each
+        # trigger a full DELETE+replay rebuild that contends with the
+        # MCP-held SQLite connection. The file holds the highest
+        # canonical-source mtime that was successfully projected; new
+        # processes read it on construction and only rebuild when an
+        # actual write has advanced the mtime past the marker.
+        self._consistency_marker_path = catalog_dir / ".last_consistency_mtime"
+        self._last_consistency_mtime: float = self._read_consistency_marker()
         if self._documents_path.exists():
             self._ensure_consistent()
+
+    def _read_consistency_marker(self) -> float:
+        """Return the persisted ``_last_consistency_mtime`` or 0.0.
+
+        nexus-wehp: cross-process consistency cache. Best-effort: any
+        read failure (missing file, malformed content, permission
+        error) returns 0.0 which forces a rebuild on this construction;
+        worst case the rebuild contends with a concurrent MCP-held
+        connection, which is the exact pre-fix behaviour.
+        """
+        try:
+            raw = self._consistency_marker_path.read_text().strip()
+            return float(raw)
+        except (FileNotFoundError, ValueError, OSError):
+            return 0.0
+
+    def _write_consistency_marker(self, mtime: float) -> None:
+        """Persist the highest successfully-projected canonical mtime.
+
+        nexus-wehp: tolerate write failures silently. Failing to update
+        the marker means the next process will re-do the rebuild;
+        functionally identical to pre-fix behaviour.
+        """
+        try:
+            self._consistency_marker_path.write_text(f"{mtime}")
+        except OSError:
+            pass
 
     @staticmethod
     def _prefix_sql(prefix: str) -> tuple[str, list]:
@@ -711,6 +747,9 @@ class Catalog:
                 _log.debug("catalog_consistency_rebuild", mtime=current_mtime)
                 self._db.rebuild(owners, documents, list(links_dict.values()))
             self._last_consistency_mtime = current_mtime
+            # nexus-wehp: persist the marker so next-process construction
+            # short-circuits this rebuild when nothing has changed.
+            self._write_consistency_marker(current_mtime)
             self.degraded = False
         except Exception as exc:
             _log.warning("catalog_consistency_rebuild_failed", error=str(exc), exc_info=True)

--- a/tests/test_catalog_consistency_marker.py
+++ b/tests/test_catalog_consistency_marker.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-wehp: cross-process consistency-marker regression test.
+
+The pre-fix behaviour: every Catalog() construction with a non-empty
+documents.jsonl reset _last_consistency_mtime to 0.0 and triggered a
+full DELETE+replay rebuild via _ensure_consistent. Two CLI processes
+running while nx-mcp held an open SQLite connection produced
+'database is locked' errors at write time because the rebuild's
+DELETE FROM links contended with MCP's held read transaction.
+
+The fix persists the highest successfully-projected canonical mtime
+to ``.last_consistency_mtime`` in the catalog directory; new
+processes read it on construction and skip the rebuild when no
+canonical-source file has been written since.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog.catalog import Catalog
+
+
+@pytest.fixture
+def seeded_catalog_dir(tmp_path: Path) -> Path:
+    """Catalog dir with a populated documents.jsonl so _ensure_consistent runs."""
+    cat = Catalog(tmp_path, tmp_path / "catalog.db")
+    owner = cat.register_owner(name="seed-owner", owner_type="repo", repo_hash="seed-hash")
+    cat.register(owner=owner, title="seed-doc", content_type="prose", file_path="seed.md")
+    return tmp_path
+
+
+def _make_catalog(catalog_dir: Path) -> Catalog:
+    return Catalog(catalog_dir, catalog_dir / "catalog.db")
+
+
+def test_consistency_marker_written_on_successful_rebuild(seeded_catalog_dir: Path) -> None:
+    """A successful _ensure_consistent run persists the marker file.
+
+    The seed fixture already constructed once; constructing again over
+    the seeded state writes the marker because _ensure_consistent
+    fires when documents.jsonl exists.
+    """
+    cat = _make_catalog(seeded_catalog_dir)
+    marker = seeded_catalog_dir / ".last_consistency_mtime"
+    assert marker.exists(), "construction over an existing catalog should write the marker"
+    persisted = float(marker.read_text().strip())
+    assert persisted > 0
+    assert cat._last_consistency_mtime == persisted
+
+
+def test_consistency_marker_skips_rebuild_when_unchanged(seeded_catalog_dir: Path) -> None:
+    """Two constructions back-to-back: the second skips the rebuild.
+
+    Verified by ensuring the second construction's _last_consistency_mtime
+    matches the persisted marker (set by the first), not 0.0 (the pre-fix
+    every-instance reset value).
+    """
+    cat1 = _make_catalog(seeded_catalog_dir)
+    first_mtime = cat1._last_consistency_mtime
+    assert first_mtime > 0
+
+    cat2 = _make_catalog(seeded_catalog_dir)
+    assert cat2._last_consistency_mtime == first_mtime, (
+        "second construction must read the persisted marker, "
+        "not reset to 0.0 and re-rebuild"
+    )
+
+
+def test_consistency_marker_missing_returns_zero(tmp_path: Path) -> None:
+    """First-ever construction with no marker file reads 0.0."""
+    cat = _make_catalog(tmp_path)
+    # No documents.jsonl exists, so _ensure_consistent isn't called;
+    # the in-memory marker reflects the read-from-disk value.
+    assert cat._last_consistency_mtime == 0.0
+    assert not (tmp_path / ".last_consistency_mtime").exists()
+
+
+def test_consistency_marker_malformed_falls_back_to_zero(tmp_path: Path) -> None:
+    """A corrupted marker file does not propagate as an exception."""
+    (tmp_path / ".last_consistency_mtime").write_text("not-a-float")
+    cat = _make_catalog(tmp_path)
+    assert cat._last_consistency_mtime == 0.0
+
+
+def test_consistency_marker_advances_after_external_write(seeded_catalog_dir: Path) -> None:
+    """A canonical-file mtime advance forces a rebuild and updates the marker.
+
+    Simulates the cross-process case: one writer commits while another
+    process is starting up. The new construction should detect the
+    advance and rebuild rather than serve a stale projection.
+    """
+    cat1 = _make_catalog(seeded_catalog_dir)
+    initial_mtime = cat1._last_consistency_mtime
+    assert initial_mtime > 0
+
+    docs_path = seeded_catalog_dir / "documents.jsonl"
+    future = initial_mtime + 10
+    os.utime(docs_path, (future, future))
+
+    cat2 = _make_catalog(seeded_catalog_dir)
+    assert cat2._last_consistency_mtime >= future, (
+        "second construction should detect the advanced documents.jsonl "
+        "mtime, rebuild, and update the marker"
+    )
+
+
+def test_consistency_marker_path_lives_in_catalog_dir(seeded_catalog_dir: Path) -> None:
+    """The marker is co-located with the catalog files (not in cwd, not in $HOME)."""
+    cat = _make_catalog(seeded_catalog_dir)
+    assert cat._consistency_marker_path == seeded_catalog_dir / ".last_consistency_mtime"


### PR DESCRIPTION
## Summary

Release-day operator-visible regression: \`nx catalog backfill-collections --no-dry-run\` fails with \`sqlite3.OperationalError: database is locked\` while \`nx-mcp\` is running. The new RDR-103 release gate (\`nx catalog doctor --collections-drift\`) directly tells operators to run backfill, so every v4.23.0 user with legacy 2-segment collections hits this on first upgrade.

## Root cause

\`Catalog.__init__\` calls \`_ensure_consistent\` which compares \`_last_consistency_mtime\` (per-instance, initialized to 0.0) against canonical-source file mtimes. New CLI processes always see \`mtime > 0\` and trigger the heavy \`DELETE FROM links\` + replay rebuild. While \`nx-mcp\` holds an open SQLite connection, the exclusive table rewrites contend and fail.

## Fix

Persist the highest successfully-projected canonical mtime to \`.last_consistency_mtime\` in the catalog directory. New processes read the marker on construction; \`_ensure_consistent\`'s mtime guard short-circuits when no canonical-source file has been written past the recorded value.

| File | Change |
|------|--------|
| \`src/nexus/catalog/catalog.py\` | \`__init__\` reads marker; \`_ensure_consistent\` writes it after successful rebuild. \`_read_consistency_marker\` and \`_write_consistency_marker\` helpers tolerate read/write failures silently (worst case = pre-fix behaviour). |
| \`tests/test_catalog_consistency_marker.py\` | New file: 6 regression cases (marker write on rebuild, skip-when-unchanged, missing-marker zero fallback, malformed-marker zero fallback, mtime-advance forces rebuild, marker co-located with catalog). |

## Verification
- [x] 6 new regression tests pass
- [x] 185 catalog tests pass (full local catalog suite)
- [x] Em-dash audit clean
- [x] Reproduces the lock contention symptom: pre-fix, every \`Catalog()\` construction with \`documents.jsonl\` resets \`_last_consistency_mtime\` to 0.0; post-fix, marker survives across constructions.

## Operator workaround for v4.23.0

Stop Claude Code (or kill \`nx-mcp\` + \`nx-mcp-catalog\`), run write-side catalog verbs, then \`/reload-plugins\`. Documented in the 4.23.1 changelog entry (next).

Closes nexus-wehp.