### PR TITLE
fix(doctor): skip taxonomy__* collections in pipeline-version check

### DIFF
--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -328,6 +328,10 @@ def _check_t3_cloud() -> list[HealthResult]:
             )
             cols = client.list_collections()
             for col in cols:
+                # taxonomy__* collections are BERTopic aggregates (RDR-070),
+                # not indexer outputs — PIPELINE_VERSION does not apply.
+                if col.name.startswith("taxonomy__"):
+                    continue
                 stored = get_collection_pipeline_version(col)
                 if stored is None:
                     pipeline_results.append(HealthResult(

--- a/tests/test_pipeline_version.py
+++ b/tests/test_pipeline_version.py
@@ -200,3 +200,44 @@ def test_doctor_handles_no_version_stamp():
         result = runner.invoke(main, ["doctor"])
 
     assert "no version stamp" in result.output
+
+
+def test_doctor_skips_taxonomy_collections():
+    """Taxonomy collections are not indexer outputs and must be skipped.
+
+    taxonomy__centroids is a BERTopic c-TF-IDF aggregate (RDR-070), not a
+    product of the embedding pipeline. The PIPELINE_VERSION semantics
+    (voyage-* + CCE prefixes + RDR-028 language registry) do not apply,
+    and no code path stamps it — so doctor should not nag about it.
+    """
+    from unittest.mock import patch
+    from click.testing import CliRunner
+
+    runner = CliRunner()
+
+    centroid_col = MagicMock()
+    centroid_col.name = "taxonomy__centroids"
+    centroid_col.metadata = {}
+
+    code_col = MagicMock()
+    code_col.name = "code__myrepo"
+    code_col.metadata = {}
+
+    mock_client = MagicMock()
+    mock_client.list_collections.return_value = [centroid_col, code_col]
+
+    mock_reg = MagicMock()
+    mock_reg.all.return_value = []
+
+    from nexus.cli import main
+    with (
+        patch("nexus.config.is_local_mode", return_value=False),
+        patch("nexus.config.get_credential", return_value="sk-key"),
+        patch("nexus.health.shutil.which", return_value="/usr/bin/rg"),
+        patch("nexus.registry.RepoRegistry", return_value=mock_reg),
+        patch("nexus.health.chromadb.CloudClient", return_value=mock_client),
+    ):
+        result = runner.invoke(main, ["doctor"])
+
+    assert "taxonomy__centroids" not in result.output
+    assert "code__myrepo" in result.output


### PR DESCRIPTION
## Summary
- `taxonomy__centroids` is a BERTopic c-TF-IDF aggregate (RDR-070), not an embedding-pipeline output. `PIPELINE_VERSION` (voyage-* + CCE prefixes + RDR-028 language registry) doesn't describe it, and no code path stamps taxonomy collections.
- Result: `nx doctor` was nagging "no version stamp (index with --force to stamp)" against `taxonomy__centroids` even though `--force` on `nx index repo` would never stamp it — the indexer's stamp loop only touches `code__` / `docs__` / `rdr__` (`indexer.py:1995-2009`).
- Fix: skip any collection whose name starts with `taxonomy__` in the doctor pipeline-version loop.

## Test plan
- [x] `uv run pytest tests/test_pipeline_version.py` — 14 passed (1 new test)
- [x] `uv run pytest tests/ -k "doctor or health"` — 317 passed, no regressions
- [ ] After merge: `nx doctor` no longer reports `taxonomy__centroids`

## Closes
Closes nexus-l6mz