### PR TITLE
fix(indexer): stamp pipeline_version on every successful run

### DIFF
--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -336,7 +336,7 @@ def _check_t3_cloud() -> list[HealthResult]:
                 if stored is None:
                     pipeline_results.append(HealthResult(
                         label=f"pipeline ({col.name})", ok=True,
-                        detail="no version stamp (index with --force to stamp)",
+                        detail="no version stamp (next 'nx index repo' will stamp)",
                     ))
                 elif stored != PIPELINE_VERSION:
                     stale_count += 1

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1991,23 +1991,26 @@ def _run_index(
         )
         _phase(f"Pruning deleted files done ({time.monotonic() - _t:.1f}s)")
 
-        # Stamp pipeline version on force indexing (after all work completes)
-        if force:
-            _phase("Stamping pipeline version on forced collections…")
-            _t = time.monotonic()
-            stamp_collection_version(code_col)
-            stamp_collection_version(docs_col)
-            # Stamp RDR collection if it was indexed
-            if rdr_indexed > 0:
-                # RDR-103 Phase 3a: catalog-first resolution; legacy
-                # fallback retained for catalog-absent test paths.
-                rdr_col_name = _repo_collection_or_legacy(repo, "rdr")
-                try:
-                    rdr_col = db.get_or_create_collection(rdr_col_name)
-                    stamp_collection_version(rdr_col)
-                except Exception:
-                    _log.debug("rdr_stamp_skipped", collection=rdr_col_name)
-            _phase(f"Pipeline version stamped ({time.monotonic() - _t:.1f}s)")
+        # Stamp pipeline version after all work completes (nexus-7yfm).
+        # Stamps on every successful run, not just --force: the stamp asserts
+        # "these embeddings were produced by PIPELINE_VERSION code", and that
+        # is true regardless of whether --force was used. Gating the stamp on
+        # --force forced operators to re-pay for full re-embedding to repair
+        # a state that should never have existed.
+        _phase("Stamping pipeline version…")
+        _t = time.monotonic()
+        stamp_collection_version(code_col)
+        stamp_collection_version(docs_col)
+        if rdr_indexed > 0:
+            # RDR-103 Phase 3a: catalog-first resolution; legacy
+            # fallback retained for catalog-absent test paths.
+            rdr_col_name = _repo_collection_or_legacy(repo, "rdr")
+            try:
+                rdr_col = db.get_or_create_collection(rdr_col_name)
+                stamp_collection_version(rdr_col)
+            except Exception:
+                _log.debug("rdr_stamp_skipped", collection=rdr_col_name)
+        _phase(f"Pipeline version stamped ({time.monotonic() - _t:.1f}s)")
 
         # Catalog registration ran upfront (RDR-101 Phase 3 PR δ Stage B)
         # so prose chunks could carry ``doc_id`` at chunk-write time.

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -758,18 +758,27 @@ def test_on_phase_none_is_safe(tmp_path):
         run(repo, _reg())  # on_phase omitted → None default
 
 
-def test_on_phase_includes_stamp_phase_on_force(tmp_path):
-    """The pipeline-version stamp phase only fires when ``force=True``."""
+def test_on_phase_includes_stamp_phase_every_run(tmp_path):
+    """Pipeline-version stamp phase fires on every successful run (nexus-7yfm).
+
+    Earlier behaviour gated stamping on ``force=True``; that meant
+    incremental runs that wrote v4 embeddings produced unstamped
+    collections, which doctor then nagged about. The remediation
+    "index with --force" forced a costly full re-embed to repair a
+    state that should never have existed. Stamp now writes
+    unconditionally on a successful run.
+    """
     run, repo = _cb_repo(tmp_path)
     db, _ = _mock_db()
 
-    # Without force → no stamp phase
+    # Without force → stamp phase present
     phases_no_force: list[str] = []
     with _cb_patches(db):
         run(repo, _reg(), on_phase=phases_no_force.append)
-    assert not any("Stamping pipeline version" in p for p in phases_no_force)
+    assert any("Stamping pipeline version" in p for p in phases_no_force)
+    assert any("Pipeline version stamped" in p for p in phases_no_force)
 
-    # With force → stamp phase present
+    # With force → stamp phase still present (regression guard)
     phases_force: list[str] = []
     with _cb_patches(db):
         run(repo, _reg(), force=True, on_phase=phases_force.append)

--- a/tests/test_indexer_e2e.py
+++ b/tests/test_indexer_e2e.py
@@ -318,6 +318,40 @@ def test_index_frecency_only_preserves_count(
     assert col.count() == count
 
 
+def test_index_stamps_pipeline_version_without_force(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database
+) -> None:
+    """nexus-7yfm: incremental index writes pipeline_version stamp.
+
+    The stamp asserts "these embeddings were produced by PIPELINE_VERSION
+    code." Whether ``--force`` was used does not change which pipeline
+    produced them — both paths run the same chunker + embedder. So the
+    stamp must be written on every successful index, not only on force.
+    """
+    from nexus.indexer import PIPELINE_VERSION, get_collection_pipeline_version
+
+    _index(rich_repo, rich_registry, local_t3)
+    info = rich_registry.get(rich_repo)
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+    assert get_collection_pipeline_version(code_col) == PIPELINE_VERSION
+    assert get_collection_pipeline_version(docs_col) == PIPELINE_VERSION
+
+
+def test_index_stamps_pipeline_version_with_force(
+    rich_repo: Path, rich_registry: RepoRegistry, local_t3: T3Database
+) -> None:
+    """Regression guard — --force still stamps after the always-stamp fix."""
+    from nexus.indexer import PIPELINE_VERSION, get_collection_pipeline_version
+
+    _index(rich_repo, rich_registry, local_t3, force=True)
+    info = rich_registry.get(rich_repo)
+    code_col = local_t3.get_or_create_collection(info["code_collection"])
+    docs_col = local_t3.get_or_create_collection(info["docs_collection"])
+    assert get_collection_pipeline_version(code_col) == PIPELINE_VERSION
+    assert get_collection_pipeline_version(docs_col) == PIPELINE_VERSION
+
+
 # ── Smart indexing: dual collection ───────────────────────────────────────────
 
 def test_smart_index_creates_both_collections(


### PR DESCRIPTION
## Summary
Stamp gate was tied to the wrong knob. \`--force\` only bypasses per-file staleness; it does not change which pipeline produces embeddings. So an incremental \`nx index repo\` writes v4 embeddings just like \`--force\` does, but the stamp was withheld — causing \`nx doctor\` to nag about \"no version stamp\" against current collections, with a remediation (\`--force\`) that re-pays for thousands of files of Voyage embedding to repair a state that should never have existed.

This fix stamps on every successful \`index_repository\` run. Safe because:

- The indexer always uses the current pipeline for any chunks it writes
- If everything skipped (all files current), the stamp is still correct
- If the run fails mid-flight, the stamp is not written (same as before — the stamp call sits at the end of the success path)

Doctor's remediation message changes from \`(index with --force to stamp)\` to \`(next 'nx index repo' will stamp)\`.

## Test plan
- [x] \`uv run pytest tests/test_indexer.py tests/test_indexer_e2e.py tests/test_pipeline_version.py\` — 121 passed (2 new e2e tests, 1 updated)
- [x] \`uv run pytest\` — 6515 passed, no regressions
- [ ] After release: \`nx index repo .\` (no \`--force\`) writes \`pipeline_version\` to collection metadata

## Closes
Closes nexus-7yfm