### PR TITLE
test(ci): mark e2e files integration; mark pagination giants slow

### DIFF
--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -340,11 +340,19 @@ class TestPagination:
                     embeddings=embeddings[mid:], metadatas=metadatas[mid:])
         return n
 
+    # Both pagination tests below seed >300 records to cross the
+    # _PAGE/MAX_QUERY_RESULTS boundary. Real coverage of the 300-cap
+    # contract, but the boundary doesn't drift between releases — paying
+    # ~53s/each on every CI push is overhead, not signal. Marked ``slow``
+    # so default ``pytest`` deselects them; run with
+    # ``uv run pytest -m slow`` or as part of the release shakedown.
+    @pytest.mark.slow
     def test_export_pagination(self, ephemeral_db: T3Database, tmp_path: Path):
         n = self._seed_large(ephemeral_db, "code__large", "id")
         _, result = _export(ephemeral_db, "code__large", tmp_path)
         assert result["exported_count"] == n
 
+    @pytest.mark.slow
     def test_import_pagination(self, ephemeral_db: T3Database, tmp_path: Path):
         n = self._seed_large(ephemeral_db, "code__big_src", "big")
         _, _, import_result = _export_import(

--- a/tests/test_indexer_e2e.py
+++ b/tests/test_indexer_e2e.py
@@ -14,6 +14,15 @@ from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
 from nexus.db.t3 import T3Database
 from nexus.registry import RepoRegistry
 
+# All tests in this module are end-to-end: real ChromaDB, real local
+# embeddings, real CLI subprocesses. They average ~5.8s/test on CI and
+# accounted for ~138s (16%) of the pre-marker pytest runtime. Per the
+# project convention (pyproject.toml addopts deselects integration), e2e
+# suites belong under the ``integration`` marker. Run explicitly with
+# ``uv run pytest -m integration``; release-shakedown already exercises
+# the same code paths through ``nx index repo`` end-to-end on every tag.
+pytestmark = pytest.mark.integration
+
 _CORPUS_FILES = [
     "src/nexus/ttl.py",
     "src/nexus/corpus.py",

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -1189,8 +1189,16 @@ def test_existing_ids_missing_collection_is_empty(local_t3: T3Database):
     ) == set()
 
 
+@pytest.mark.slow
 def test_existing_ids_pagination_respects_300_cap(local_t3: T3Database):
-    """existing_ids pages at 300 ids per call (ChromaDB Cloud cap)."""
+    """existing_ids pages at 300 ids per call (ChromaDB Cloud cap).
+
+    Marked ``slow``: seeds 305 entries to cross the 300-cap boundary;
+    runs ~56s on CI (single biggest test in the suite). The boundary it
+    guards (the QUOTAS._PAGE constant) does not drift between releases,
+    so paying the cost on every PR is overhead rather than coverage.
+    Run explicitly with ``uv run pytest -m slow``.
+    """
     col = "knowledge__existing_ids_paging"
     # Seed 305 entries so the sweep must page twice.
     seeded: list[str] = []

--- a/tests/test_taxonomy_e2e.py
+++ b/tests/test_taxonomy_e2e.py
@@ -22,6 +22,13 @@ from nexus.db.local_ef import LocalEmbeddingFunction
 from nexus.db.t2 import T2Database
 from nexus.types import SearchResult
 
+# Full e2e pipeline: real ChromaDB clients (Ephemeral + Persistent), real
+# MiniLM embeddings, real HDBSCAN clustering. ~2.9s/test average on CI,
+# 43s total. Belongs under the ``integration`` marker per project
+# convention so default ``pytest`` deselects it; run explicitly with
+# ``uv run pytest -m integration``.
+pytestmark = pytest.mark.integration
+
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Cut CI pytest runtime ~30% by deferring integration-shape and pagination-boundary tests off the per-PR critical path.

## Measured baseline

CI pytest runtime: **14m42s** (882s) for 6518 tests on `main`, against the recent CI run on PR #509. Distribution from the CI log:

| File | Time | Tests | Avg |
|---|---|---|---|
| `test_indexer_e2e.py` | 138s | 24 | 5.8s/test |
| `test_exporter.py` | 123s | 49 | 2.5s/test (mostly 2 tests) |
| `test_t3.py` | 62s | 94 | 0.6s/test (mostly 1 test) |
| `test_taxonomy_e2e.py` | 43s | 15 | 2.9s/test |

These four files = 366s = **41% of pytest runtime**. None were marked.

## Changes

- `tests/test_indexer_e2e.py`, `tests/test_taxonomy_e2e.py`: module-level `pytestmark = pytest.mark.integration`. Both files are textbook integration suites: real ChromaDB clients, real local embeddings, real CLI subprocesses. `pyproject.toml` `addopts` already deselects `integration` by default, so this is wiring an existing convention to existing reality.
- `test_t3.py::test_existing_ids_pagination_respects_300_cap`: `@pytest.mark.slow` (~56s)
- `test_exporter.py::TestPagination::test_export_pagination`: `@pytest.mark.slow` (~53s)
- `test_exporter.py::TestPagination::test_import_pagination`: `@pytest.mark.slow` (~53s)

The three pagination tests each seed >300 records to cross `QUOTAS._PAGE` / `MAX_QUERY_RESULTS`. The boundary they guard doesn't drift between releases, so paying ~162s on every PR push for unchanged-boundary coverage is overhead. They still run under `-m slow`.

## Expected CI impact

| Metric | Before | After |
|---|---|---|
| pytest runtime | 14m42s | ~9m |
| Total job time | 15–17m | ~11–13m |
| Tests run by default | 6518 | 6471 |

## Coverage impact

Zero, conditional on continuing to run the full suite at release time. Both markers are already exercised by `tests/e2e/release-sandbox.sh shakedown`:

- `nx index repo` end-to-end (covers `test_indexer_e2e.py` paths)
- exporter pagination via real T3 round-trip in step 6/11 (cross-corpus search)
- taxonomy pipeline runs in `nx index repo` step 2/11 (clustering 3,312 chunks → 57 topics)

The shakedown runs on every release tag and is the load-bearing release gate.

## How to run them locally

```
uv run pytest -m integration            # 44 e2e tests
uv run pytest -m slow                   # 3 pagination giants
uv run pytest -m "integration or slow"  # both
```

## Test plan

- [x] `uv run pytest --collect-only -q tests/test_indexer_e2e.py tests/test_taxonomy_e2e.py` → "no tests collected (44 deselected)"
- [x] `uv run pytest --collect-only -q -m integration tests/test_indexer_e2e.py tests/test_taxonomy_e2e.py` → 44 collected
- [x] `uv run pytest --collect-only -q <three pagination tests>` → "no tests collected (3 deselected)"
- [x] `uv run pytest --collect-only -q -m slow <three pagination tests>` → 3 collected
- [ ] CI shows runtime drop on this PR