### PR TITLE
test: delete 6 type-system theatre tests (audit summary)

### DIFF
--- a/tests/test_catalog_collection_name.py
+++ b/tests/test_catalog_collection_name.py
@@ -22,15 +22,6 @@ from nexus.corpus import (
 
 # ── Constant: CANONICAL_EMBEDDING_MODELS ────────────────────────────────────
 
-def test_canonical_embedding_models_is_frozenset() -> None:
-    assert isinstance(CANONICAL_EMBEDDING_MODELS, frozenset)
-
-
-def test_canonical_embedding_models_string_members() -> None:
-    for m in CANONICAL_EMBEDDING_MODELS:
-        assert isinstance(m, str)
-
-
 def test_canonical_embedding_models_includes_voyage_context_3() -> None:
     assert "voyage-context-3" in CANONICAL_EMBEDDING_MODELS
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -791,12 +791,6 @@ class TestConstants:
 
         assert PRE_REGISTRY_VERSION == "4.1.2"
 
-    def test_upgrade_done_is_set(self) -> None:
-        from nexus.db.migrations import _upgrade_done
-
-        assert isinstance(_upgrade_done, set)
-
-
 # ── T2Database integration tests (Phase 3) ──────────────────────────────────
 
 

--- a/tests/test_t2.py
+++ b/tests/test_t2.py
@@ -75,11 +75,6 @@ def test_context_manager_closes_on_exception(tmp_path: Path) -> None:
         db.memory.conn.execute("SELECT 1")
 
 
-def test_context_manager_returns_self(tmp_path: Path) -> None:
-    with T2Database(tmp_path / "cm_self.db") as db:
-        assert isinstance(db, T2Database)
-
-
 def test_context_manager_does_not_suppress_exception(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="propagated"):
         with T2Database(tmp_path / "cm_nosup.db") as db:

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -664,13 +664,6 @@ def test_ef_override_bypasses_cache(mock_chromadb):
 # ── make_t3() factory ───────────────────────────────────────────────────────
 
 
-def test_make_t3_returns_t3database(mock_chromadb):
-    from nexus.db import make_t3
-    with patch("nexus.db.get_credential", side_effect=lambda k: f"val-{k}"):
-        db = make_t3()
-    assert isinstance(db, T3Database)
-
-
 def test_make_t3_uses_credentials(mock_chromadb):
     from nexus.db import make_t3
     creds = {"chroma_tenant": "my-tenant", "chroma_database": "my-db", "chroma_api_key": "ck-abc", "voyage_api_key": "vk-xyz"}

--- a/tests/test_upgrade_cmd.py
+++ b/tests/test_upgrade_cmd.py
@@ -178,8 +178,3 @@ class TestT3UpgradeStep:
         assert step.introduced == "4.2.0"
         assert step.name == "test"
         assert step.fn is fn
-
-    def test_t3_upgrades_list_exists(self) -> None:
-        from nexus.db.migrations import T3_UPGRADES
-
-        assert isinstance(T3_UPGRADES, list)


### PR DESCRIPTION
## Summary

Audit of weak-style tests in the suite. **6 deletions** from a static-analysis candidate pool of 135 — the rest, on inspection, are real tests written in weak style and would lose coverage if deleted.

## What was audited

AST scan against ~6500 tests flagged 135 candidates across four theatre patterns:

| Pattern | Count | Verdict |
|---|---|---|
| T1: mock-only assertion (only ``mock.assert_called*``) | 36 | mostly real interaction tests (e.g. ``test_local_mode_no_cloud_probe`` asserts ``CloudClient`` was not instantiated) |
| T2: ``isinstance`` only | 16 | **6 are pure type-system theatre — these get deleted.** 10 are discriminated-union or smoke-guard tests |
| T3: ``is not None`` only | 25 | mostly persistence round-trip / back-compat tests (the ``is not None`` is the assertion that the round-trip survived) |
| T4: zero assertions | 58 | mix of ``test_*_idempotent`` / no-raise guards (real) and a few candidates I'd want to mutation-test before deleting |

## What gets deleted

These 6 assert that a constant's type or a factory's return type matches exactly what the type annotation already enforces. A test that would still pass if the production type became the ground truth is theatre by definition.

| Test | Annotation enforces it |
|---|---|
| ``test_canonical_embedding_models_is_frozenset`` | ``Final[frozenset[str]]`` |
| ``test_canonical_embedding_models_string_members`` | same; built from string literals |
| ``test_upgrade_done_is_set`` | ``set[...]``, initialized ``= set()`` |
| ``test_context_manager_returns_self`` | ``__enter__ -> T2Database`` |
| ``test_make_t3_returns_t3database`` | ``make_t3() -> T3Database`` |
| ``test_t3_upgrades_list_exists`` | ``list[...]`` |

## Why not more

The point of the audit was to find tests that would still pass if the production code under them was replaced with ``raise NotImplementedError``. That's the strict definition of theatre. AST patterns are too coarse — they flag both:

- **Real "no-raise" guards** like ``validate_collection_name("a1b")  # should not raise`` (would fail loudly if validation regressed)
- **Real interaction tests** like ``mock_cloud.assert_not_called()`` (would fail if local-mode regressed to making cloud calls)

These look like theatre to the AST but aren't. The honest theatre count in this codebase is small — dozens, not hundreds.

## Test plan

- [x] ``uv run pytest tests/test_catalog_collection_name.py tests/test_migrations.py tests/test_t2.py tests/test_t3.py tests/test_upgrade_cmd.py -q`` → 319 passed (was 325, -6)
- [ ] CI clean