### PR TITLE
fix(indexer): make ignorePatterns honour path-style globs

### DIFF
--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -140,12 +140,71 @@ def detect_git_metadata(path: Path) -> dict[str, str]:
     }
 
 
+def _path_glob_match(parts: tuple[str, ...], segs: list[str]) -> bool:
+    """Match a tuple of path components against pattern segments.
+
+    Segments are the result of ``pattern.split("/")``. Each non-``**``
+    segment is matched against one path component via ``fnmatch`` (so
+    ``*`` does NOT cross ``/`` boundaries — the path-aware semantic users
+    expect from a slash-separated glob). ``**`` matches zero or more
+    components.
+    """
+    def walk(i: int, j: int) -> bool:
+        while j < len(segs):
+            seg = segs[j]
+            if seg == "**":
+                # ** matches zero or more components — try every split.
+                for k in range(i, len(parts) + 1):
+                    if walk(k, j + 1):
+                        return True
+                return False
+            if i >= len(parts):
+                return False
+            if not fnmatch.fnmatch(parts[i], seg):
+                return False
+            i += 1
+            j += 1
+        return i == len(parts)
+    return walk(0, 0)
+
+
 def should_ignore(rel_path: Path, patterns: list[str]) -> bool:
-    """Return True if any component of *rel_path* matches any of *patterns*."""
-    for part in rel_path.parts:
-        for pattern in patterns:
-            if fnmatch.fnmatch(part, pattern):
+    """Return True if *rel_path* matches any of *patterns*.
+
+    Pattern semantics (.gitignore-flavored, path-aware):
+
+    - **Path-style** patterns (contain ``/``) match against the full
+      relative path component-by-component. ``*`` matches any single
+      component (does not cross ``/``); ``**`` matches zero or more
+      components. ``docs/papers/**`` matches every file under
+      ``docs/papers/`` at any depth; ``src/*.py`` matches Python files
+      directly under ``src/`` only.
+    - **Part-style** patterns (no ``/``) match against each path
+      component independently via ``fnmatch``. ``papers`` matches any
+      file under a ``papers/`` directory anywhere in its path;
+      ``*.lock`` matches any lock file; ``__pycache__`` matches any
+      ``__pycache__`` directory. This preserves the original behaviour
+      and the existing ``_DEFAULT_IGNORE`` patterns.
+
+    Pre-fix history: this function used to feed each path component to
+    ``fnmatch.fnmatch`` against every pattern. ``fnmatch`` treats ``/``
+    as a literal, so a path-style pattern like ``docs/papers/**`` was
+    silently ineffective — the matcher only ever saw the parts ``docs``,
+    ``papers``, and ``foo.pdf`` independently, none of which can match a
+    pattern containing ``/``. Configs that wrote ``docs/papers/**``
+    expecting subtree exclusion were silent no-ops; the only patterns
+    that worked were single-component or extension globs.
+    """
+    rel_parts = rel_path.parts
+    for pattern in patterns:
+        if "/" in pattern:
+            segs = pattern.split("/")
+            if _path_glob_match(rel_parts, segs):
                 return True
+        else:
+            for part in rel_parts:
+                if fnmatch.fnmatch(part, pattern):
+                    return True
     return False
 
 

--- a/tests/test_indexer_utils_repo.py
+++ b/tests/test_indexer_utils_repo.py
@@ -30,6 +30,50 @@ def test_should_ignore(path: str, expected: bool) -> None:
     assert should_ignore(Path(path), _DEFAULT_IGNORE) == expected
 
 
+# Path-style patterns (contain '/'): match against the full POSIX-form
+# relative path. Pre-fix, these patterns were silent no-ops because the
+# matcher only fed each path COMPONENT to fnmatch, which treats '/' as
+# a literal. ART's .nexus.yml shipped ``docs/papers/**`` for months
+# expecting subtree exclusion; it never excluded anything.
+@pytest.mark.parametrize("path,patterns,expected", [
+    # subtree wildcards
+    ("docs/papers/foo.pdf",         ["docs/papers/**"], True),
+    ("docs/papers/sub/foo.pdf",     ["docs/papers/**"], True),
+    ("docs/architecture.md",        ["docs/papers/**"], False),
+    ("src/main.py",                 ["docs/papers/**"], False),
+    # single-segment wildcard (only direct children)
+    ("src/main.py",                 ["src/*.py"],       True),
+    ("src/sub/main.py",             ["src/*.py"],       False),
+    # explicit nested path
+    ("a/b/c/d.txt",                 ["a/b/c/d.txt"],    True),
+    ("a/b/c/other.txt",             ["a/b/c/d.txt"],    False),
+    # path-style does NOT spuriously match part-style usage
+    ("papers/foo.pdf",              ["docs/papers/**"], False),
+])
+def test_should_ignore_path_style(
+    path: str, patterns: list[str], expected: bool,
+) -> None:
+    """Path-style patterns (with '/') match against the full path."""
+    assert should_ignore(Path(path), patterns) == expected
+
+
+# Part-style patterns (no '/'): match against any single component.
+# Behaviour preserved from pre-fix implementation so existing configs
+# (and _DEFAULT_IGNORE) continue to work.
+@pytest.mark.parametrize("path,patterns,expected", [
+    ("a/b/papers/file.pdf",         ["papers"],         True),
+    ("papers/file.pdf",             ["papers"],         True),
+    ("docs/architecture.md",        ["papers"],         False),
+    ("a/b/foo.lock",                ["*.lock"],         True),
+    ("src/foo.py",                  ["*.lock"],         False),
+])
+def test_should_ignore_part_style(
+    path: str, patterns: list[str], expected: bool,
+) -> None:
+    """Part-style patterns (no '/') match against any path component."""
+    assert should_ignore(Path(path), patterns) == expected
+
+
 # ── find_repo_root ──────────────────────────────────────────────────────────
 
 def test_find_repo_root_in_git_repo(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Patch fix. The ``.nexus.yml`` schema accepts path-style glob patterns under ``server.ignorePatterns`` (the example used in our own docs is ``docs/papers/**``), but the matcher was matching against path components only — so any pattern containing ``/`` was a silent no-op.

This bit ART. ``ART/.nexus.yml`` shipped ``- docs/papers/**`` with a block comment referencing the 10,264-duplicate-chunk cleanup the rule was meant to prevent; the rule never excluded anything. Re-indexing the repo walked the 79 papers every time.

## Pre-fix vs post-fix matcher

| Pattern | Path | Pre-fix | Post-fix |
|---|---|---|---|
| ``docs/papers/**`` | ``docs/papers/foo.pdf`` | ❌ no-match | ✓ match |
| ``docs/papers/**`` | ``docs/papers/sub/foo.pdf`` | ❌ no-match | ✓ match |
| ``docs/papers/**`` | ``docs/architecture.md`` | ❌ no-match | ❌ no-match |
| ``src/*.py`` | ``src/main.py`` | (matched, but for wrong reason) | ✓ match |
| ``src/*.py`` | ``src/sub/main.py`` | ❌ no-match | ❌ no-match (path-aware) |
| ``papers`` (part-style) | ``a/b/papers/foo.pdf`` | ✓ match | ✓ match (unchanged) |
| ``*.lock`` (part-style) | ``yarn.lock`` | ✓ match | ✓ match (unchanged) |

## Implementation

Path-style patterns (containing ``/``) now route through ``_path_glob_match``: a 17-line component walker that splits the pattern by ``/`` and matches segments against ``rel_path.parts`` using ``fnmatch`` per-segment. ``**`` matches zero or more components. ``*`` does not cross ``/``.

Part-style patterns (no ``/``) stay on the original code path: ``fnmatch`` against each component independently. ``_DEFAULT_IGNORE`` (``node_modules``, ``vendor``, ``__pycache__``, ``*.lock``, …) keeps working unchanged.

Hand-rolled matcher rather than pathlib's ``PurePath.match`` because that API's ``**`` handling varies between Python 3.12 and 3.13+.

## Test plan

Added in ``tests/test_indexer_utils_repo.py``:
- 9 path-style cases covering subtree wildcards, ``/*`` only-direct-children semantic, exact paths, and non-matching shorter prefixes
- 5 part-style regression cases to prove the unchanged code path still works

- [x] ``uv run pytest tests/test_indexer_utils_repo.py tests/test_indexer.py tests/test_index_cmd.py tests/test_indexer_modules.py -q`` → 186 passed
- [ ] CI clean

## Behavioural impact for existing configs

- Configs using only part-style patterns (most repos): zero change.
- Configs using path-style patterns expecting subtree exclusion (ART, possibly others): they start working. Files that were silently re-indexed will now be skipped on the next ``nx index repo`` run.
- Configs using path-style patterns whose author (incorrectly) relied on ``fnmatch``'s ``*``-crosses-``/`` behaviour to over-match: would now under-match. We don't expect any such configs to exist; if they did, the symptom would be "files I thought I excluded with ``foo/*`` are now indexed" and the fix is a one-character rewrite to ``foo/**``.