### PR TITLE
fix(catalog): FTS5 bulk-load + heartbeat on rebuild path

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -7,10 +7,14 @@ import fcntl
 import json
 import os
 import sqlite3
+import sys
+import threading
+import time
 from urllib.parse import urlparse
 import re
 import subprocess
 from collections import deque
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -20,6 +24,59 @@ import structlog
 
 if TYPE_CHECKING:
     from chromadb.api import ClientAPI
+
+
+# Heartbeat cadence for long catalog operations. The first heartbeat
+# fires after this delay (so fast operations stay silent) and then every
+# ``_HEARTBEAT_INTERVAL`` until the operation completes.
+_HEARTBEAT_INTERVAL = 5.0
+
+
+@contextmanager
+def _rebuild_heartbeat(label: str):
+    """Print elapsed-time heartbeats to stderr while a long catalog
+    operation runs.
+
+    Spawns a daemon thread that wakes every :data:`_HEARTBEAT_INTERVAL`
+    seconds and writes ``Catalog: {label} (Ns)\\r`` so the user has a
+    visible signal during the projection rebuild — which can run for
+    tens of minutes on a project with hundreds of thousands of events
+    while SQLite FTS5 merges segments at COMMIT.
+
+    Pre-fix the ``_ensure_consistent`` rebuild was completely silent.
+    Operators running ``nx index repo`` saw the indexer hook print
+    ``Catalog: housekeeping…\\r`` and then nothing for 15-20 minutes
+    while the catalog DB churned. Indistinguishable from a hang.
+
+    The first heartbeat is delayed by one full interval so operations
+    that finish in <5s stay completely silent. On exit, prints a
+    summary line if the operation took >1s.
+    """
+    stop = threading.Event()
+    started = time.monotonic()
+
+    def _beat() -> None:
+        # Wait one interval before the first beat so fast ops stay silent.
+        if stop.wait(_HEARTBEAT_INTERVAL):
+            return
+        while not stop.is_set():
+            elapsed = time.monotonic() - started
+            sys.stderr.write(f"  Catalog: {label} ({elapsed:.0f}s)\r")
+            sys.stderr.flush()
+            if stop.wait(_HEARTBEAT_INTERVAL):
+                return
+
+    thread = threading.Thread(target=_beat, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        thread.join(timeout=1.0)
+        elapsed = time.monotonic() - started
+        if elapsed > 1.0:
+            sys.stderr.write(f"  Catalog: {label} done ({elapsed:.1f}s)\n")
+            sys.stderr.flush()
 
 # RDR-101 Phase 1 PR F: shadow event-log emit gate. Read once at
 # Catalog.__init__ time. Recognised "on" values match the boolean-env
@@ -739,27 +796,44 @@ class Catalog:
                 # Replay events.jsonl through the projector into the
                 # live CatalogDB. Atomic: the transaction context
                 # rolls back the DELETEs if apply_all raises.
+                #
+                # The bulk_load_documents fence drops the documents_fts
+                # triggers for the duration of the replay and rebuilds
+                # the FTS5 index in one shot at the end. Without this
+                # fence, every replayed INSERT queues per-row hash
+                # entries that SQLite cannot merge until COMMIT — turning
+                # the COMMIT into a 15-20 min FTS5 merge for a catalog
+                # with hundreds of thousands of events. The heartbeat
+                # surfaces elapsed time during the rebuild so operators
+                # can distinguish "catalog is grinding" from "catalog
+                # has hung." See nexus-rr0u for the deeper architectural
+                # fix (incremental projection against last_applied_event_id)
+                # which would eliminate the rebuild from firing at all
+                # in steady state.
                 from nexus.catalog.event_log import EventLog
                 _log.debug(
                     "catalog_consistency_rebuild_event_sourced",
                     mtime=current_mtime,
                 )
-                with self._db.transaction() as conn:
-                    conn.execute("DELETE FROM links")
-                    conn.execute("DELETE FROM documents")
-                    conn.execute("DELETE FROM owners")
-                    # commit=False — the transaction context owns the
-                    # commit boundary; a nested commit() would finalize
-                    # the tx prematurely and defeat the rollback fence.
-                    self._projector.apply_all(
-                        EventLog(self._dir).replay(), commit=False,
-                    )
+                with _rebuild_heartbeat("rebuilding projection"):
+                    with self._db.transaction() as conn:
+                        with self._db.bulk_load_documents():
+                            conn.execute("DELETE FROM links")
+                            conn.execute("DELETE FROM documents")
+                            conn.execute("DELETE FROM owners")
+                            # commit=False — the transaction context owns the
+                            # commit boundary; a nested commit() would finalize
+                            # the tx prematurely and defeat the rollback fence.
+                            self._projector.apply_all(
+                                EventLog(self._dir).replay(), commit=False,
+                            )
             else:
                 owners = read_owners(self._owners_path) if self._owners_path.exists() else {}
                 documents = read_documents(self._documents_path) if self._documents_path.exists() else {}
                 links_dict = read_links(self._links_path) if self._links_path.exists() else {}
                 _log.debug("catalog_consistency_rebuild", mtime=current_mtime)
-                self._db.rebuild(owners, documents, list(links_dict.values()))
+                with _rebuild_heartbeat("rebuilding projection"):
+                    self._db.rebuild(owners, documents, list(links_dict.values()))
             self._last_consistency_mtime = current_mtime
             # nexus-wehp: persist the marker so next-process construction
             # short-circuits this rebuild when nothing has changed.

--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -16,6 +16,34 @@ from nexus.db.t2 import _sanitize_fts5
 
 _log = structlog.get_logger()
 
+# FTS5 trigger DDL extracted as standalone strings so the bulk-load
+# fence (``CatalogDB.bulk_load_documents``) can drop and recreate them
+# inside a transaction without re-running the entire schema script. Keep
+# in sync with the inline copies in ``_SCHEMA_SQL`` below — the inline
+# ones run on initial schema creation, these run on the rebuild path.
+_DOCUMENTS_FTS_TRIGGERS: tuple[str, ...] = (
+    """\
+CREATE TRIGGER IF NOT EXISTS documents_ai AFTER INSERT ON documents BEGIN
+    INSERT INTO documents_fts(rowid, title, author, corpus, file_path)
+        VALUES (new.rowid, new.title, new.author, new.corpus, new.file_path);
+END
+""",
+    """\
+CREATE TRIGGER IF NOT EXISTS documents_ad AFTER DELETE ON documents BEGIN
+    INSERT INTO documents_fts(documents_fts, rowid, title, author, corpus, file_path)
+        VALUES ('delete', old.rowid, old.title, old.author, old.corpus, old.file_path);
+END
+""",
+    """\
+CREATE TRIGGER IF NOT EXISTS documents_au AFTER UPDATE ON documents BEGIN
+    INSERT INTO documents_fts(documents_fts, rowid, title, author, corpus, file_path)
+        VALUES ('delete', old.rowid, old.title, old.author, old.corpus, old.file_path);
+    INSERT INTO documents_fts(rowid, title, author, corpus, file_path)
+        VALUES (new.rowid, new.title, new.author, new.corpus, new.file_path);
+END
+""",
+)
+
 _SCHEMA_SQL = """\
 PRAGMA journal_mode=WAL;
 
@@ -356,9 +384,19 @@ class CatalogDB:
         documents: dict[str, DocumentRecord],
         links: list[LinkRecord],
     ) -> None:
-        """Truncate all tables and reload from JSONL-derived dicts."""
-        with self._lock, self._conn:
-            # Delete from base tables — triggers sync FTS automatically
+        """Truncate all tables and reload from JSONL-derived dicts.
+
+        Uses the FTS5 bulk-load fence (drop triggers + INSERT-rebuild)
+        so the per-row ``documents_ai`` trigger does NOT queue every
+        column for every replayed document — that pattern stalls COMMIT
+        for tens of minutes on a catalog with hundreds of thousands of
+        rows. With the fence, FTS5 segments are built once at the end
+        in source order. See ``bulk_load_documents`` docstring.
+        """
+        with self._lock, self._conn, self.bulk_load_documents():
+            # Delete from base tables. Triggers are dropped for the
+            # duration of the bulk_load_documents fence; FTS5 is
+            # rebuilt in one pass at fence-exit.
             self._conn.execute("DELETE FROM links")
             self._conn.execute("DELETE FROM documents")
             self._conn.execute("DELETE FROM owners")
@@ -508,6 +546,55 @@ class CatalogDB:
         """
         with self._lock, self._conn:
             yield self._conn
+
+    @contextmanager
+    def bulk_load_documents(self):
+        """FTS5 bulk-load fence around mass document writes.
+
+        Drops the ``documents_ai`` / ``documents_au`` / ``documents_ad``
+        FTS5 triggers, yields to the caller (which performs the writes),
+        then recreates the triggers and runs FTS5's ``rebuild`` command
+        to materialize the index in one pass from the final document
+        rows.
+
+        Why this exists: the projection-rebuild path in
+        ``Catalog._ensure_consistent`` deletes every document and replays
+        the entire event log inside one transaction. With per-row FTS5
+        triggers active, each replayed INSERT queues every term/column
+        in an in-memory hash. SQLite cannot incrementally merge that
+        hash into on-disk segments mid-transaction; the merge happens at
+        COMMIT, in one shot, and walks every queued entry. On a project
+        with hundreds of thousands of events the COMMIT alone takes
+        15-20 minutes of CPU on ``fts5IndexCrisismerge`` /
+        ``fts5HashEntrySort``, with no user-visible signal that anything
+        is happening.
+
+        FTS5's documented bulk-load idiom — ``INSERT INTO fts(fts) VALUES
+        ('rebuild')`` — is dramatically faster because it builds segments
+        directly from the content table in source order, skipping the
+        per-row hash queue entirely.
+
+        MUST be called inside a ``transaction()`` block so the schema
+        changes (DROP/CREATE TRIGGER) and the rebuild are part of the
+        same atomic unit as the DELETE+replay. If the caller's transaction
+        rolls back, the triggers come back too.
+        """
+        with self._lock:
+            for trig in ("documents_ai", "documents_au", "documents_ad"):
+                self._conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+        try:
+            yield
+        finally:
+            with self._lock:
+                for sql in _DOCUMENTS_FTS_TRIGGERS:
+                    self._conn.execute(sql)
+                # Bulk-rebuild FTS5 from the final state of `documents`.
+                # Cheap when the table is small; orders of magnitude
+                # faster than the per-row trigger path on rebuilds with
+                # >1k documents.
+                self._conn.execute(
+                    "INSERT INTO documents_fts(documents_fts) VALUES ('rebuild')"
+                )
 
     def close(self) -> None:
         with self._lock:

--- a/tests/test_catalog_db.py
+++ b/tests/test_catalog_db.py
@@ -192,6 +192,83 @@ class TestFTS5Search:
         assert isinstance(results, list)
 
 
+class TestBulkLoadDocuments:
+    """Regression tests for the FTS5 bulk-load fence (nexus-rr0u
+    pre-work). The fence drops the documents_ai/au/ad triggers, lets
+    the caller perform mass writes without per-row trigger overhead,
+    then recreates the triggers and runs FTS5's ``rebuild`` command.
+
+    Behavioural invariants:
+      1. Search results after a bulk-load match what they would be
+         with triggers active throughout (no rows missing from the
+         FTS5 index, no stale entries pointing to deleted rowids).
+      2. Triggers are reinstated after the fence so subsequent writes
+         maintain FTS5 incrementally.
+      3. The fence is reentrant within a transaction (the rebuild
+         path uses it nested inside ``transaction()``).
+    """
+
+    def test_rebuild_via_bulk_load_matches_search_results(self, tmp_path):
+        """``CatalogDB.rebuild`` now uses ``bulk_load_documents``.
+        Search results must be identical to a per-row-trigger rebuild.
+        Pre-fix this would have been per-row trigger; now it's a
+        single FTS5 ``rebuild`` at fence-exit. The user-visible behaviour
+        is identical."""
+        db = CatalogDB(tmp_path / ".catalog.db")
+        owners = {"1.1": _make_owner()}
+        docs = {
+            "1.1.1": _make_doc(tumbler="1.1.1", title="authentication module"),
+            "1.1.2": _make_doc(tumbler="1.1.2", title="database schema"),
+            "1.1.3": _make_doc(tumbler="1.1.3", title="payment processor"),
+        }
+        db.rebuild(owners, docs, [])
+
+        assert {r["tumbler"] for r in db.search("authentication")} == {"1.1.1"}
+        assert {r["tumbler"] for r in db.search("schema")} == {"1.1.2"}
+        assert {r["tumbler"] for r in db.search("payment")} == {"1.1.3"}
+
+    def test_triggers_reinstated_after_bulk_load(self, tmp_path):
+        """After ``rebuild`` the documents_ai trigger must fire on a
+        subsequent direct INSERT — otherwise post-rebuild writes silently
+        fall out of the FTS5 index until the next rebuild."""
+        db = CatalogDB(tmp_path / ".catalog.db")
+        db.rebuild({"1.1": _make_owner()}, {}, [])
+
+        # Direct INSERT — bypasses the rebuild path. Trigger must fire.
+        db.execute(
+            "INSERT INTO documents (tumbler, title, author, year, content_type, "
+            "file_path, corpus, physical_collection, chunk_count, head_hash, "
+            "indexed_at, metadata, source_mtime, alias_of, source_uri) "
+            "VALUES (?, 'reinstated-doc', '', 0, 'code', 'src/reinstated.py', "
+            "'', 'code__test', 0, '', '', '{}', 0.0, '', '')",
+            ("1.1.99",),
+        )
+        db.commit()
+
+        results = db.search("reinstated")
+        assert len(results) == 1
+        assert results[0]["tumbler"] == "1.1.99"
+
+    def test_bulk_load_replaces_stale_entries(self, tmp_path):
+        """Two successive rebuilds — the second must produce search
+        results matching only the second's documents (no leftovers
+        from the first). Catches the failure mode where the bulk
+        rebuild forgets to clear the prior FTS5 segments."""
+        db = CatalogDB(tmp_path / ".catalog.db")
+        owners = {"1.1": _make_owner()}
+
+        # First rebuild
+        docs1 = {"1.1.1": _make_doc(tumbler="1.1.1", title="alpha apple")}
+        db.rebuild(owners, docs1, [])
+        assert {r["tumbler"] for r in db.search("apple")} == {"1.1.1"}
+
+        # Second rebuild — completely different content
+        docs2 = {"1.1.2": _make_doc(tumbler="1.1.2", title="beta banana")}
+        db.rebuild(owners, docs2, [])
+        assert db.search("apple") == []
+        assert {r["tumbler"] for r in db.search("banana")} == {"1.1.2"}
+
+
 class TestNextDocumentNumber:
     def test_empty_owner(self, tmp_path):
         db = CatalogDB(tmp_path / ".catalog.db")


### PR DESCRIPTION
## Summary

The catalog projection rebuild was both slow and silent. ART's catalog with 435K events in events.jsonl took 17+ min of CPU on FTS5 segment merges with no operator-visible signal.

Two compounding problems in ``Catalog._ensure_consistent`` and ``CatalogDB.rebuild``:

1. **Per-row FTS5 trigger inserts during mass replay.** SQLite's FTS5 cannot merge index entries incrementally during a transaction; the per-row ``documents_ai`` trigger queues every term/column in an in-memory hash and merges into on-disk segments at COMMIT. ART's WAL grew to 38 MB pending the entire time.
2. **No heartbeat.** Operators see ``Catalog: housekeeping…\r`` from the indexer hook and then nothing for 15-20 minutes — indistinguishable from a hang.

## Fix

### FTS5 bulk-load fence

New context manager ``CatalogDB.bulk_load_documents``:

```python
with self._db.bulk_load_documents():
    conn.execute("DELETE FROM documents")
    self._projector.apply_all(events, commit=False)
# fence-exit: triggers recreated + INSERT INTO documents_fts(documents_fts) VALUES('rebuild')
```

Drops the three ``documents_fts`` triggers, lets the caller do the mass writes, then recreates them and runs FTS5's documented bulk-load idiom (``INSERT INTO fts(fts) VALUES('rebuild')``) which materializes the index in source order from the content table — far cheaper than per-row hash queue plus commit-time merge.

Wired into both rebuild paths:
- ``Catalog._ensure_consistent`` event-sourced replay path
- ``CatalogDB.rebuild`` legacy JSONL fallback path

### Heartbeat

New helper ``_rebuild_heartbeat`` in ``catalog.py``: daemon thread that writes ``Catalog: rebuilding projection (Ns)\r`` to stderr every 5 s after a 5-second warmup. Fast operations (<5 s) stay completely silent; long ones get elapsed-time signal. Wraps both rebuild paths.

## What this does NOT fix

The rebuild still fires on every ``Catalog()`` construction whenever any canonical-truth file is newer than the persisted ``_last_consistency_mtime`` marker. On a hot project that means a single new event re-replays the entire 435K-event log. The FTS5 fence makes this much faster but the architectural fix is incremental projection against ``last_applied_event_id``. Filed as **nexus-rr0u** for the next arc.

## Test plan

Added in ``tests/test_catalog_db.py::TestBulkLoadDocuments``:
- search results match expected after rebuild via the bulk-load path
- ``documents_ai`` trigger is reinstated after fence-exit so subsequent direct INSERTs still update FTS5 incrementally
- successive rebuilds produce only the new state's search results (no leftover entries from the prior content)

- [x] ``uv run pytest tests/ -k catalog -q`` → 941 passed
- [x] ``uv run pytest tests/test_catalog_db.py tests/test_catalog.py tests/test_catalog_consistency_marker.py tests/test_catalog_dedupe_event_sourced.py tests/test_rdr101_round3_correctness.py`` → 174 passed
- [ ] CI clean

## Refs

- Filed: **nexus-rr0u** — Catalog _ensure_consistent: replay only events newer than last_applied_event_id (P1)
- Discovered during ART repo ``nx index repo`` after the 4.24.1 ``ignorePatterns`` fix took effect