### PR TITLE
perf(indexer): batched misclassified-prune + collection-wide staleness cache

### DIFF
--- a/src/nexus/code_indexer.py
+++ b/src/nexus/code_indexer.py
@@ -329,6 +329,7 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
     if not ctx.force and check_staleness(
         ctx.col, file_path, content_hash, ctx.embedding_model,
         doc_id=catalog_doc_id_for_staleness,
+        cache=ctx.staleness_cache,
     ):
         return 0
 

--- a/src/nexus/index_context.py
+++ b/src/nexus/index_context.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from nexus.config import TuningConfig
+    from nexus.indexer_utils import StalenessCache
 
 
 @dataclass
@@ -77,6 +78,13 @@ class IndexContext:
     # builds a fresh instance per file and appends to the caller-side
     # collector so end-of-run aggregation is deterministic.
     stage_timers: "StageTimers | None" = field(default=None)
+
+    # Pre-computed staleness map for *col*. When supplied, the per-file
+    # ``check_staleness`` becomes a dict lookup instead of a ChromaDB
+    # roundtrip — turning a no-op ``nx index repo`` (everything already
+    # current) from O(N) round-trips into a single paginated sweep.
+    # ``None`` is the legacy / fall-through path.
+    staleness_cache: "StalenessCache | None" = field(default=None)
 
 
 if TYPE_CHECKING:

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -31,6 +31,7 @@ from nexus.corpus import index_model_for_collection
 from nexus.retry import _chroma_with_retry, _voyage_with_retry  # noqa: F401 — re-exported for any existing imports
 from nexus.errors import CredentialsMissingError  # re-exported for backward compatibility
 from nexus.indexer_utils import (
+    build_staleness_cache,
     check_credentials,
     check_local_path_writable,
     check_staleness,
@@ -52,6 +53,7 @@ _log = structlog.get_logger(__name__)
 if TYPE_CHECKING:
     from nexus.catalog.catalog import Catalog
     from nexus.catalog.tumbler import Tumbler
+    from nexus.indexer_utils import StalenessCache
     from nexus.registry import RepoRegistry
     from nexus.stage_timers import StageTimers
 
@@ -1053,6 +1055,7 @@ def _index_code_file(
     embed_fn: Callable | None = None,
     stage_timers: "StageTimers | None" = None,
     doc_id_resolver: Callable[[Path], str] | None = None,
+    staleness_cache: "StalenessCache | None" = None,
 ) -> int:
     """Index a single code file.  Delegates to nexus.code_indexer.index_code_file.
 
@@ -1067,6 +1070,10 @@ def _index_code_file(
     catalog ``Document.doc_id`` for *file* so code chunks land in T3
     with a back-reference to the catalog. ``None`` is the legacy /
     no-catalog path.
+
+    ``staleness_cache`` is the orchestrator-built collection-wide
+    staleness map. When supplied, the per-file ``check_staleness`` is
+    a dict lookup instead of a Chroma roundtrip.
     """
     from nexus.code_indexer import index_code_file
     from nexus.index_context import IndexContext
@@ -1087,6 +1094,7 @@ def _index_code_file(
         embed_fn=embed_fn,
         stage_timers=stage_timers,
         doc_id_resolver=doc_id_resolver,
+        staleness_cache=staleness_cache,
     )
     return index_code_file(ctx, file)
 
@@ -1108,6 +1116,7 @@ def _index_prose_file(
     embed_fn: Callable | None = None,
     stage_timers: "StageTimers | None" = None,
     doc_id_resolver: Callable[[Path], str] | None = None,
+    staleness_cache: "StalenessCache | None" = None,
 ) -> int:
     """Index a single prose file.  Delegates to nexus.prose_indexer.index_prose_file.
 
@@ -1142,6 +1151,7 @@ def _index_prose_file(
         embed_fn=embed_fn,
         stage_timers=stage_timers,
         doc_id_resolver=doc_id_resolver,
+        staleness_cache=staleness_cache,
     )
     return index_prose_file(ctx, file)
 
@@ -1423,6 +1433,75 @@ def _batched_delete(col: object, ids: list[str]) -> int:
     return deleted
 
 
+def _prune_misclassified_in_collection(
+    col: object,
+    target_paths: set[Path],
+    file_to_doc_id: dict[Path, str],
+    *,
+    kind: str,
+) -> int:
+    """Find and delete chunks in *col* whose ``doc_id`` matches any
+    file in *target_paths*. Returns the number of chunks pruned.
+
+    Batched over ``where={"doc_id": {"$in": [batch]}}``. ChromaDB
+    accepts list-valued ``$in`` against a metadata column with a
+    single round-trip; ``_paginated_get`` then walks the full match
+    set in 300-chunk pages. Net result: ~ceil(N / _CHROMA_PAGE_SIZE)
+    queries instead of N — for ART (~4,800 files) that's ~17 calls
+    per collection-direction instead of ~4,800.
+
+    Files not present in *file_to_doc_id* (legacy / pre-RDR-102 D2
+    rows) fall back to per-path ``source_path`` lookup so collections
+    that pre-date the catalog backfill keep getting cleaned up. The
+    legacy set is typically small post-backfill.
+    """
+    doc_ids: list[str] = []
+    legacy_paths: list[str] = []
+    for path in target_paths:
+        d = file_to_doc_id.get(path, "")
+        if d:
+            doc_ids.append(d)
+        else:
+            legacy_paths.append(str(path))
+
+    pruned = 0
+
+    # Batched doc_id sweep — the load-bearing optimization. _CHROMA_PAGE_SIZE
+    # caps the ``$in`` list per query (matches the doc-id pagination cap
+    # and stays well within ChromaDB Cloud's where-predicate budget).
+    for i in range(0, len(doc_ids), _CHROMA_PAGE_SIZE):
+        batch = doc_ids[i : i + _CHROMA_PAGE_SIZE]
+        if not batch:
+            continue
+        existing = _paginated_get(
+            col, include=[], where={"doc_id": {"$in": batch}},
+        )
+        if existing["ids"]:
+            _batched_delete(col, existing["ids"])
+            pruned += len(existing["ids"])
+            _log.debug(
+                f"pruned misclassified chunks from {kind} collection",
+                count=len(existing["ids"]),
+                doc_id_batch_size=len(batch),
+            )
+
+    # Legacy fallback — one query per unmapped path. Cardinality is
+    # bounded by the number of files indexed before catalog backfill,
+    # which on a repo that has been on a recent nexus is typically zero.
+    for src in legacy_paths:
+        existing = _paginated_get(col, include=[], where={"source_path": src})
+        if existing["ids"]:
+            _batched_delete(col, existing["ids"])
+            pruned += len(existing["ids"])
+            _log.debug(
+                f"pruned misclassified chunks from {kind} collection (legacy)",
+                count=len(existing["ids"]),
+                source_path=src,
+            )
+
+    return pruned
+
+
 def _prune_misclassified(
     repo: Path,
     code_collection: str,
@@ -1443,37 +1522,49 @@ def _prune_misclassified(
     the catalog hook), the chunk-prune lookup keys on ``doc_id``. Files
     not in the map fall back to the legacy ``source_path`` lookup so
     chunks indexed before catalog backfill keep getting cleaned up.
+
+    Pre-batching history: this function used to do one
+    ``col.get(where={"doc_id": <id>})`` per file. For ART (~4,800 files)
+    that meant ~9,600 sequential ChromaDB Cloud roundtrips at
+    50-200 ms each — 8 to 30 minutes of pure round-trip cost where the
+    actual work (chunks to delete) was almost always zero. The batched
+    ``where={"doc_id": {"$in": [batch]}}`` form collapses that to
+    ~ceil(N / _CHROMA_PAGE_SIZE) queries per direction (~34 total for
+    ART) — about a 300x reduction in roundtrips.
     """
+    from tqdm import tqdm
+
     code_col = db.get_or_create_collection(code_collection)
     docs_col = db.get_or_create_collection(docs_collection)
     file_to_doc_id = file_to_doc_id or {}
 
-    def _prune_one(col: object, path: Path, kind: str) -> None:
-        doc_id = file_to_doc_id.get(path, "")
-        where: dict
-        log_field: dict
-        if doc_id:
-            where = {"doc_id": doc_id}
-            log_field = {"doc_id": doc_id, "source_path": str(path)}
-        else:
-            where = {"source_path": str(path)}
-            log_field = {"source_path": str(path)}
-        existing = _paginated_get(col, include=[], where=where)
-        if existing["ids"]:
-            _batched_delete(col, existing["ids"])
-            _log.debug(
-                f"pruned misclassified chunks from {kind} collection",
-                count=len(existing["ids"]),
-                **log_field,
-            )
+    # Prose + PDF files should NOT have chunks in the code__ collection.
+    # Code files should NOT have chunks in the docs__ collection. Each
+    # sweep runs as one batched operation against the relevant collection.
+    code_targets = set(prose_files) | set(pdf_files)
+    docs_targets = set(code_files)
+    pruned_chunks = 0
 
-    # Prose + PDF files should NOT have chunks in the code__ collection
-    for path in set(prose_files) | set(pdf_files):
-        _prune_one(code_col, path, "code")
+    bar = tqdm(
+        total=2,
+        disable=None,  # auto-disable on non-tty
+        desc="Pruning misclassified",
+        unit="sweep",
+    )
+    try:
+        pruned_chunks += _prune_misclassified_in_collection(
+            code_col, code_targets, file_to_doc_id, kind="code",
+        )
+        bar.set_postfix_str(f"chunks={pruned_chunks}", refresh=False)
+        bar.update(1)
 
-    # Code files should NOT have chunks in the docs__ collection
-    for path in set(code_files):
-        _prune_one(docs_col, path, "docs")
+        pruned_chunks += _prune_misclassified_in_collection(
+            docs_col, docs_targets, file_to_doc_id, kind="docs",
+        )
+        bar.set_postfix_str(f"chunks={pruned_chunks}", refresh=False)
+        bar.update(1)
+    finally:
+        bar.close()
 
 
 def _prune_deleted_files(
@@ -1844,6 +1935,36 @@ def _run_index(
     def _doc_id_resolver(path: Path) -> str:
         return file_to_doc_id.get(path, "")
 
+    # Pre-build the per-collection staleness cache (nexus-rr0u follow-up).
+    # One paginated sweep per collection up front replaces N per-file
+    # ``col.get(where={doc_id})`` round-trips inside the indexing loop.
+    # The orchestrator builds the caches AFTER catalog registration so a
+    # fresh ``doc_id`` for a just-registered file is already present in
+    # the metadata sweep below — no race against the registration write.
+    # On a healthy repo (most files current) this turns ``nx index repo``
+    # from O(N) Chroma round-trips into O(total_chunks / 300) — minutes
+    # become seconds.
+    if on_phase is not None:
+        on_phase("Building staleness caches…")
+    _staleness_t0 = time.monotonic()
+    code_staleness = build_staleness_cache(code_col)
+    docs_staleness = build_staleness_cache(docs_col)
+    _log.info(
+        "staleness_caches_built",
+        code_doc_ids=len(code_staleness.by_doc_id),
+        code_source_paths=len(code_staleness.by_source_path),
+        docs_doc_ids=len(docs_staleness.by_doc_id),
+        docs_source_paths=len(docs_staleness.by_source_path),
+        elapsed_seconds=time.monotonic() - _staleness_t0,
+    )
+    if on_phase is not None:
+        on_phase(
+            f"Staleness caches built — "
+            f"code: {len(code_staleness.by_doc_id):,} docs, "
+            f"docs: {len(docs_staleness.by_doc_id):,} docs "
+            f"({time.monotonic() - _staleness_t0:.1f}s)"
+        )
+
     # Index code files → code__ (voyage-code-3, AST chunking)
     # NOTE: calls _index_code_file (the module-level wrapper) so that tests
     # patching nexus.indexer._index_code_file continue to intercept correctly.
@@ -1866,6 +1987,7 @@ def _run_index(
             embed_fn=_embed_fn,
             stage_timers=timers,
             doc_id_resolver=_doc_id_resolver,
+            staleness_cache=code_staleness,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)
@@ -1891,6 +2013,7 @@ def _run_index(
             embed_fn=_embed_fn,
             stage_timers=timers,
             doc_id_resolver=_doc_id_resolver,
+            staleness_cache=docs_staleness,
         )
         if on_file:
             on_file(file, chunks, time.monotonic() - t0)

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import fnmatch
 import re
 import subprocess
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import structlog
@@ -235,6 +236,88 @@ def is_gitignored(path: Path, repo_root: Path) -> bool:
         return False
 
 
+@dataclass
+class StalenessCache:
+    """Pre-fetched ``{lookup_key: (content_hash, embedding_model)}`` map
+    for a single ChromaDB collection.
+
+    Built once by :func:`build_staleness_cache` from a single paginated
+    sweep of the collection's chunk metadata; consumed many times by
+    :func:`check_staleness` so per-file checks become O(1) dict lookups
+    instead of O(N) ChromaDB roundtrips.
+
+    Two indexes:
+
+    - ``by_doc_id`` keys on the catalog tumbler stored in chunk
+      metadata. Populated only for chunks whose stored ``doc_id`` field
+      is non-empty. The post-RDR-101-Phase-4 write path stamps
+      ``doc_id`` on every new chunk; legacy chunks predating the
+      backfill are absent from this index, which the cached
+      ``check_staleness`` correctly treats as a cache miss → "stale" →
+      re-index → ghost-chunk healed.
+    - ``by_source_path`` keys on the chunk's ``source_path`` metadata.
+      Populated for every chunk that carries a non-empty source_path
+      (most of them; RDR-102 D2 dropped source_path from the canonical
+      schema, so post-D2 chunks won't appear here — they live only in
+      ``by_doc_id``). Used only when the caller has no doc_id (legacy /
+      catalog absent code path).
+
+    Why the cache exists: ``nx index repo`` on a healthy repo where
+    nothing has changed is dominated by per-file
+    ``col.get(where={doc_id})`` roundtrips just to confirm "yes,
+    current, skip." On ART (~4,800 files) that's ~4,800 sequential
+    ChromaDB Cloud calls at 50-200 ms each — 8-30 minutes of pure
+    network latency before any actual indexing work. With the cache,
+    the entire staleness phase is a single paginated sweep
+    (~ceil(total_chunks / 300) calls) plus per-file dict lookups.
+    """
+
+    by_doc_id: dict[str, tuple[str, str]] = field(default_factory=dict)
+    by_source_path: dict[str, tuple[str, str]] = field(default_factory=dict)
+
+
+def build_staleness_cache(col: object) -> StalenessCache:
+    """Walk *col* once and index its chunks for fast staleness lookup.
+
+    Pulls every chunk's ``include=["metadatas"]`` via the standard
+    paginated helper. Calls per pull are ChromaDB Cloud's 300-record
+    cap, so the total round-trip count is ``ceil(N / 300)`` where N is
+    the collection's chunk count — independent of the number of files
+    being indexed.
+
+    Errors are tolerated: a build failure returns an empty cache and
+    callers fall through to the per-file Chroma path. Failing to
+    populate the cache must never block indexing; it just costs latency.
+    """
+    cache = StalenessCache()
+    try:
+        # Local import to avoid a circular dependency at module-load
+        # time. ``_paginated_get`` lives in nexus.indexer (the
+        # orchestrator), which itself imports from this module.
+        from nexus.indexer import _paginated_get
+
+        all_chunks = _paginated_get(col, include=["metadatas"])
+    except Exception:
+        return cache
+
+    metadatas = all_chunks.get("metadatas") or []
+    for meta in metadatas:
+        if not meta:
+            continue
+        content_hash = meta.get("content_hash", "")
+        model = meta.get("embedding_model", "")
+        if not (content_hash and model):
+            continue
+        value = (content_hash, model)
+        doc_id = meta.get("doc_id", "")
+        if doc_id:
+            cache.by_doc_id[doc_id] = value
+        source_path = meta.get("source_path", "")
+        if source_path:
+            cache.by_source_path[source_path] = value
+    return cache
+
+
 def check_staleness(
     col: object,
     source_file: object,
@@ -242,14 +325,28 @@ def check_staleness(
     embedding_model: str,
     *,
     doc_id: str = "",
+    cache: StalenessCache | None = None,
 ) -> bool:
     """Return True if the file is already indexed with an identical hash and model.
 
-    Performs a ChromaDB get() wrapped in _chroma_with_retry.  The retry logic
-    is part of the staleness check's contract — callers must NOT wrap this call.
+    Two execution modes:
+
+    - **Cached (preferred when the orchestrator passes a cache).**
+      Looks up ``doc_id`` in :attr:`StalenessCache.by_doc_id` (or
+      ``source_file`` in :attr:`StalenessCache.by_source_path` for
+      legacy / no-catalog callers). Pure dict lookup, no ChromaDB
+      roundtrip. The orchestrator builds the cache once per collection
+      via :func:`build_staleness_cache` before the per-file loop, so
+      ``nx index repo`` on a healthy repo (most files current) pays
+      one paginated sweep instead of one Chroma query per file.
+    - **Per-file (back-compat).** When *cache* is ``None``, performs a
+      ChromaDB ``get()`` wrapped in ``_chroma_with_retry``. The retry
+      logic is part of the staleness check's contract — callers must
+      NOT wrap this call. Direct test callers and any caller that has
+      not migrated to the cache stay on this path.
 
     Args:
-        col: ChromaDB collection object.
+        col: ChromaDB collection object. Unused when *cache* is supplied.
         source_file: Path (or string) of the source file being checked.
         content_hash: SHA-256 hex digest of the current file content.
         embedding_model: Target embedding model name.
@@ -259,11 +356,31 @@ def check_staleness(
             owner-scope changes. Empty falls back to the legacy
             ``source_path``-keyed lookup for chunks predating the
             doc_id backfill.
+        cache: Optional :class:`StalenessCache`. When supplied the
+            check is a dict lookup; when ``None`` the check is a Chroma
+            roundtrip.
 
     Returns:
         True when the stored chunk has the same content_hash AND embedding_model,
         meaning the file is current and can be skipped.  False otherwise.
     """
+    if cache is not None:
+        if doc_id:
+            stored = cache.by_doc_id.get(doc_id)
+            # Cache miss when the caller has a doc_id heals a ghost
+            # chunk by treating the file as stale: re-index will write
+            # a chunk carrying doc_id metadata and the next sweep
+            # populates by_doc_id for it. Mirrors the Chroma-path
+            # behaviour at indexer_utils.check_staleness:291.
+            if stored is None:
+                return False
+            return stored == (content_hash, embedding_model)
+        # Legacy / no-doc_id caller: fall back to source_path lookup.
+        stored = cache.by_source_path.get(str(source_file))
+        if stored is None:
+            return False
+        return stored == (content_hash, embedding_model)
+
     where: dict = {"doc_id": doc_id} if doc_id else {"source_path": str(source_file)}
     existing = _chroma_with_retry(
         col.get,  # type: ignore[attr-defined]

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -56,6 +56,7 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
     if not ctx.force and check_staleness(
         ctx.col, file_path, content_hash, ctx.embedding_model,
         doc_id=catalog_doc_id_for_staleness,
+        cache=ctx.staleness_cache,
     ):
         return 0
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -946,6 +946,11 @@ def test_prune_misclassified_uses_doc_id_when_supplied(tmp_path):
     catalog hook's ``file_to_doc_id`` map is supplied. WITH TEETH:
     a stash-revert to the source_path-keyed form makes the assertion
     on the ``where`` filter fail.
+
+    Updated for the batched ``$in`` form (~300x roundtrip reduction
+    on large repos): the where clause is now
+    ``{"doc_id": {"$in": [<id>, ...]}}``. The intent — that doc_id is
+    the lookup column, not source_path — is preserved.
     """
     from nexus.indexer import _prune_misclassified
     repo = tmp_path / "repo"
@@ -964,7 +969,7 @@ def test_prune_misclassified_uses_doc_id_when_supplied(tmp_path):
         file_to_doc_id={bp: "ART-deadbeef"},
     )
     where = cc.get.call_args.kwargs["where"]
-    assert where == {"doc_id": "ART-deadbeef"}
+    assert where == {"doc_id": {"$in": ["ART-deadbeef"]}}
     cc.delete.assert_called_once_with(ids=["chunk-abc"])
 
 

--- a/tests/test_indexer_utils_repo.py
+++ b/tests/test_indexer_utils_repo.py
@@ -5,7 +5,12 @@ from unittest.mock import patch
 
 import pytest
 
+from unittest.mock import MagicMock, patch
+
 from nexus.indexer_utils import (
+    StalenessCache,
+    build_staleness_cache,
+    check_staleness,
     find_repo_root,
     is_gitignored,
     load_ignore_patterns,
@@ -216,3 +221,212 @@ def test_indexer_default_ignore_matches() -> None:
     from nexus.indexer import DEFAULT_IGNORE
     from nexus.indexer_utils import _DEFAULT_IGNORE
     assert DEFAULT_IGNORE is _DEFAULT_IGNORE
+
+
+# ── StalenessCache + cached check_staleness ──────────────────────────────────
+
+
+class TestStalenessCache:
+    """Pre-built staleness cache replaces N per-file Chroma roundtrips
+    with one paginated sweep. Caller-side ``check_staleness(cache=…)``
+    becomes a dict lookup.
+    """
+
+    def test_build_indexes_doc_id_and_source_path(self) -> None:
+        """One sweep of the collection populates both the doc_id-keyed
+        and source_path-keyed indexes from chunk metadata."""
+        col = MagicMock()
+        # Two chunks per file is realistic; both chunks share the same
+        # content_hash + embedding_model so they collapse to a single
+        # cache entry per (doc_id, source_path) pair.
+        col.get.return_value = {
+            "ids": ["c1", "c2", "c3"],
+            "metadatas": [
+                {
+                    "doc_id": "1.1.1",
+                    "source_path": "src/a.py",
+                    "content_hash": "hash-a",
+                    "embedding_model": "voyage-code-3",
+                },
+                {
+                    "doc_id": "1.1.1",
+                    "source_path": "src/a.py",
+                    "content_hash": "hash-a",
+                    "embedding_model": "voyage-code-3",
+                },
+                # Legacy chunk: source_path only, no doc_id
+                {
+                    "doc_id": "",
+                    "source_path": "legacy/old.py",
+                    "content_hash": "hash-l",
+                    "embedding_model": "voyage-code-3",
+                },
+            ],
+        }
+
+        cache = build_staleness_cache(col)
+
+        assert cache.by_doc_id == {"1.1.1": ("hash-a", "voyage-code-3")}
+        assert cache.by_source_path == {
+            "src/a.py": ("hash-a", "voyage-code-3"),
+            "legacy/old.py": ("hash-l", "voyage-code-3"),
+        }
+
+    def test_build_skips_chunks_missing_required_fields(self) -> None:
+        """Chunks without content_hash or embedding_model (corrupted
+        metadata, partial backfill) are skipped — the cache only holds
+        rows with both load-bearing fields, so a hit always implies a
+        real comparison can succeed."""
+        col = MagicMock()
+        col.get.return_value = {
+            "ids": ["good", "no-hash", "no-model"],
+            "metadatas": [
+                {
+                    "doc_id": "1.1.1",
+                    "content_hash": "hash-a",
+                    "embedding_model": "voyage-code-3",
+                },
+                {"doc_id": "1.1.2", "content_hash": "", "embedding_model": "x"},
+                {"doc_id": "1.1.3", "content_hash": "h", "embedding_model": ""},
+            ],
+        }
+
+        cache = build_staleness_cache(col)
+        assert cache.by_doc_id == {"1.1.1": ("hash-a", "voyage-code-3")}
+
+    def test_build_returns_empty_on_chroma_error(self) -> None:
+        """A failure inside the paginated sweep yields an empty cache
+        rather than raising — callers fall through to the per-file
+        Chroma path. Failing to populate the cache must never block
+        indexing."""
+        col = MagicMock()
+        col.get.side_effect = RuntimeError("network glitch")
+
+        cache = build_staleness_cache(col)
+
+        assert cache.by_doc_id == {}
+        assert cache.by_source_path == {}
+
+    def test_check_staleness_with_cache_hit_returns_true(self) -> None:
+        """Cache hit + matching hash + matching model = stale (skip)."""
+        cache = StalenessCache(
+            by_doc_id={"1.1.1": ("hash-a", "voyage-code-3")},
+        )
+        result = check_staleness(
+            col=MagicMock(),
+            source_file="src/a.py",
+            content_hash="hash-a",
+            embedding_model="voyage-code-3",
+            doc_id="1.1.1",
+            cache=cache,
+        )
+        assert result is True
+
+    def test_check_staleness_with_cache_hit_wrong_hash_returns_false(self) -> None:
+        """Cache hit but content has changed = NOT stale (re-index)."""
+        cache = StalenessCache(
+            by_doc_id={"1.1.1": ("hash-OLD", "voyage-code-3")},
+        )
+        result = check_staleness(
+            col=MagicMock(),
+            source_file="src/a.py",
+            content_hash="hash-NEW",
+            embedding_model="voyage-code-3",
+            doc_id="1.1.1",
+            cache=cache,
+        )
+        assert result is False
+
+    def test_check_staleness_with_cache_miss_returns_false(self) -> None:
+        """No cache entry = NOT stale (re-index, possibly heals a ghost
+        chunk by writing new metadata that includes doc_id)."""
+        cache = StalenessCache()  # empty
+        result = check_staleness(
+            col=MagicMock(),
+            source_file="src/a.py",
+            content_hash="hash-a",
+            embedding_model="voyage-code-3",
+            doc_id="1.1.1",
+            cache=cache,
+        )
+        assert result is False
+
+    def test_check_staleness_cache_does_not_call_chroma(self) -> None:
+        """The whole point of the cache is to avoid the per-file Chroma
+        roundtrip. A cache argument must short-circuit the network
+        call entirely. Pin it explicitly so a future refactor that
+        accidentally falls through to ``col.get`` is caught.
+        """
+        col = MagicMock()
+        cache = StalenessCache(
+            by_doc_id={"1.1.1": ("hash-a", "voyage-code-3")},
+        )
+
+        # Hit
+        check_staleness(
+            col=col, source_file="src/a.py",
+            content_hash="hash-a", embedding_model="voyage-code-3",
+            doc_id="1.1.1", cache=cache,
+        )
+        # Miss
+        check_staleness(
+            col=col, source_file="src/b.py",
+            content_hash="hash-b", embedding_model="voyage-code-3",
+            doc_id="1.1.99", cache=cache,
+        )
+
+        assert col.get.call_count == 0, (
+            f"cache path leaked to col.get: {col.get.call_args_list}"
+        )
+
+    def test_check_staleness_falls_back_to_chroma_when_no_cache(self) -> None:
+        """``cache=None`` (the default) preserves the legacy per-file
+        Chroma roundtrip. Critical for back-compat: any direct caller
+        that has not migrated to the cache stays on the original
+        path with the same retry/quota semantics.
+        """
+        col = MagicMock()
+        col.get.return_value = {
+            "metadatas": [
+                {
+                    "doc_id": "1.1.1",
+                    "content_hash": "hash-a",
+                    "embedding_model": "voyage-code-3",
+                },
+            ],
+        }
+
+        with patch(
+            "nexus.indexer_utils._chroma_with_retry",
+            side_effect=lambda fn, **kw: fn(**kw),
+        ):
+            result = check_staleness(
+                col=col, source_file="src/a.py",
+                content_hash="hash-a", embedding_model="voyage-code-3",
+                doc_id="1.1.1",
+                # no cache=
+            )
+
+        assert result is True
+        assert col.get.call_count == 1
+
+    def test_check_staleness_legacy_path_uses_source_path(self) -> None:
+        """Caller with ``doc_id=''`` (legacy / no catalog) uses the
+        source_path index."""
+        cache = StalenessCache(
+            by_source_path={"legacy/old.py": ("hash-l", "voyage-code-3")},
+        )
+
+        # Hit on source_path
+        assert check_staleness(
+            col=MagicMock(), source_file="legacy/old.py",
+            content_hash="hash-l", embedding_model="voyage-code-3",
+            doc_id="", cache=cache,
+        ) is True
+
+        # Miss on source_path
+        assert check_staleness(
+            col=MagicMock(), source_file="legacy/missing.py",
+            content_hash="hash-x", embedding_model="voyage-code-3",
+            doc_id="", cache=cache,
+        ) is False


### PR DESCRIPTION
Two compounding ChromaDB-roundtrip blowups, both fixed by batching.

**(1) _prune_misclassified**: ~9,600 per-file col.get calls → ~34 batched where={"doc_id": {"$in": batch}} calls (300 ids/batch).

**(2) Pre-built staleness cache**: ~4,800 per-file check_staleness round-trips → one paginated sweep per collection (~150 calls) → O(1) dict lookups via StalenessCache. Built once in _run_index after catalog registration; passed down via IndexContext.staleness_cache.

For an "all current, skip" run on a hot repo: 8-30 min of network latency → ~1s.

Back-compat: cache=None keeps the legacy Chroma path; existing callers unaffected. Ghost-chunk healing preserved (cache miss with non-empty doc_id returns False, triggering re-index).

Tests added: 10-case TestStalenessCache covering build behavior, hit/miss semantics, error handling, and a call_count == 0 pin against the cache short-circuit. Existing prune test updated to assert the batched $in shape.

Local: uv run pytest tests/test_indexer*.py tests/test_index_cmd.py tests/test_doc_indexer.py -q → 297 passed.

Refs **nexus-rr0u**.