### PR TITLE
fix(catalog): write consistency marker inside the rebuild transaction

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -754,19 +754,33 @@ class Catalog:
     def _write_consistency_marker(self, mtime: float) -> None:
         """Persist the highest successfully-projected canonical mtime.
 
-        nexus-wehp: stored inside the catalog SQLite. Commits explicitly
-        so other connections (in-process tests, cross-process MCP+CLI)
-        see the new marker on their next SELECT. Tolerate write failures
-        silently. Failing to update the marker means the next process
-        will re-do the rebuild; functionally identical to pre-fix
-        behaviour.
+        nexus-wehp: stored inside the catalog SQLite. Tolerates write
+        failures silently — failing to update the marker means the next
+        process will re-do the rebuild, which is correctness-preserving
+        (the rebuild is idempotent at the projection level).
+
+        RDR-104 critic Critical #2 fix: this write MUST live inside the
+        same transaction as the projector writes. Pre-fix it called
+        ``self._db.commit()`` independently, which created an asymmetric
+        failure window: a crash AFTER the marker commit but BEFORE the
+        outer transaction's projection writes committed (or while the
+        outer ``with self._conn:`` rolled back) advanced the marker
+        without advancing the projection. The next ``_ensure_consistent``
+        run would observe the new marker, conclude "nothing to do", and
+        permanently skip the events that should have been applied —
+        silent corruption with no recovery path.
+
+        Caller contract: this method is invoked from inside an active
+        ``CatalogDB.transaction()`` block. The connection-as-context-manager
+        commits the marker write atomically with the projection writes
+        on successful exit; rolls both back together on any exception.
+        Do NOT call ``self._db.commit()`` here.
         """
         try:
             self._db.execute(
                 "INSERT OR REPLACE INTO _meta (key, value) VALUES (?, ?)",
                 ("last_consistency_mtime", f"{mtime}"),
             )
-            self._db.commit()
         except sqlite3.OperationalError:
             pass
 
@@ -931,6 +945,18 @@ class Catalog:
                             self._projector.apply_all(
                                 EventLog(self._dir).replay(), commit=False,
                             )
+                        # RDR-104 critic Critical #2 fix: consistency marker
+                        # is written INSIDE the same transaction as the
+                        # projection writes. The transaction context commits
+                        # both atomically on success, rolls both back together
+                        # on any exception. Pre-fix the marker write lived
+                        # OUTSIDE this block in _write_consistency_marker()'s
+                        # own commit(), which left a refactoring hazard:
+                        # any rearrangement that put the marker commit before
+                        # the projection commit would silently skip events on
+                        # the next run (rollback of projection without rolling
+                        # back the marker).
+                        self._write_consistency_marker(current_mtime)
             else:
                 owners = read_owners(self._owners_path) if self._owners_path.exists() else {}
                 documents = read_documents(self._documents_path) if self._documents_path.exists() else {}
@@ -954,11 +980,18 @@ class Catalog:
                 with _rebuild_heartbeat(
                     "rebuilding projection", summary_builder=_summary,
                 ):
-                    self._db.rebuild(owners, documents, list(links_dict.values()))
+                    # RDR-104 critic Critical #2 fix: pass current_mtime so
+                    # the marker write happens INSIDE rebuild's transaction
+                    # block, atomic with the projection writes.
+                    self._db.rebuild(
+                        owners, documents, list(links_dict.values()),
+                        consistency_mtime=current_mtime,
+                    )
+            # In-memory mirror of the persisted marker. The DB write is
+            # already inside the rebuild transaction (event-sourced and
+            # legacy paths both); this assignment exists so subsequent
+            # in-process construction short-circuits without a SELECT.
             self._last_consistency_mtime = current_mtime
-            # nexus-wehp: persist the marker so next-process construction
-            # short-circuits this rebuild when nothing has changed.
-            self._write_consistency_marker(current_mtime)
             self.degraded = False
         except Exception as exc:
             _log.warning("catalog_consistency_rebuild_failed", error=str(exc), exc_info=True)

--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -383,6 +383,8 @@ class CatalogDB:
         owners: dict[str, OwnerRecord],
         documents: dict[str, DocumentRecord],
         links: list[LinkRecord],
+        *,
+        consistency_mtime: float | None = None,
     ) -> None:
         """Truncate all tables and reload from JSONL-derived dicts.
 
@@ -392,6 +394,17 @@ class CatalogDB:
         for tens of minutes on a catalog with hundreds of thousands of
         rows. With the fence, FTS5 segments are built once at the end
         in source order. See ``bulk_load_documents`` docstring.
+
+        ``consistency_mtime`` (RDR-104 critic Critical #2 fix): when
+        supplied, the consistency-marker write happens INSIDE the same
+        ``with self._lock, self._conn:`` block as the projection writes
+        — atomic. Pre-fix the marker was written by an independent
+        ``commit()`` after rebuild returned, which left a refactoring
+        hazard (any future code that put the marker write before the
+        projection commit would silently corrupt the projection by
+        skipping events on the next run). Putting both writes in the
+        same transaction makes the atomicity invariant trivially
+        true regardless of caller ordering.
         """
         with self._lock, self._conn, self.bulk_load_documents():
             # Delete from base tables. Triggers are dropped for the
@@ -450,6 +463,19 @@ class CatalogDB:
                         lnk.created_at,
                         json.dumps(lnk.meta),
                     ),
+                )
+
+            # RDR-104 critic Critical #2 fix: consistency marker write
+            # is part of the same transaction as the projection writes.
+            # On a mid-rebuild crash, the projection rolls back AND the
+            # marker stays at its pre-rebuild value — next run sees the
+            # stale marker and re-rebuilds correctly. Pre-fix this lived
+            # outside the transaction in `_write_consistency_marker`'s
+            # own commit().
+            if consistency_mtime is not None:
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO _meta (key, value) VALUES (?, ?)",
+                    ("last_consistency_mtime", f"{consistency_mtime}"),
                 )
 
         _log.debug("catalog_db.rebuild", owners=len(owners), documents=len(documents), links=len(links))

--- a/tests/test_catalog_consistency_marker.py
+++ b/tests/test_catalog_consistency_marker.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -205,4 +206,78 @@ def test_rebuild_silent_under_one_second(
     err = capsys.readouterr().err
     assert "Catalog: rebuild" not in err, (
         f"fast rebuild leaked progress line: {err!r}"
+    )
+
+
+def test_marker_does_not_advance_when_rebuild_raises(
+    seeded_catalog_dir: Path,
+) -> None:
+    """RDR-104 critic Critical #2: marker write must be atomic with
+    projection writes. Pre-fix the marker lived in its own ``commit()``
+    after the rebuild transaction closed; a refactor that put the marker
+    write before the projection commit would silently corrupt the
+    projection by skipping events on the next run (rolled-back
+    projection + advanced marker).
+
+    Test simulates the dangerous direction: ``Projector.apply_all`` (or
+    ``CatalogDB.rebuild``, depending on which path fires) raises
+    mid-transaction. Asserts that the marker stored in ``_meta`` did
+    NOT advance — same value as before the failed rebuild attempt.
+
+    Patches BOTH the event-sourced and legacy mid-transaction sites so
+    the invariant is pinned regardless of which path the seeded fixture
+    happens to exercise (depends on NEXUS_EVENT_SOURCED gating). This
+    is the load-bearing test for the atomicity fix.
+    """
+    cat1 = _make_catalog(seeded_catalog_dir)
+    initial_marker = cat1._last_consistency_mtime
+    assert initial_marker > 0
+    cat1._db.close()
+
+    # Force a rebuild — bump documents.jsonl mtime past the marker
+    docs_path = seeded_catalog_dir / "documents.jsonl"
+    future = initial_marker + 10
+    os.utime(docs_path, (future, future))
+
+    from nexus.catalog.catalog_db import CatalogDB
+    from nexus.catalog.projector import Projector
+
+    def db_rebuild_boom(self, *a, **kw):
+        # Open transaction, write something, raise — simulates a
+        # mid-rebuild crash on the legacy path. The transaction's
+        # __exit__ rollback fires.
+        with self._lock, self._conn:
+            self._conn.execute("DELETE FROM documents")
+            raise RuntimeError("simulated mid-rebuild crash (legacy)")
+
+    def projector_apply_all_boom(self, *a, **kw):
+        # The event-sourced path is wrapped in self._db.transaction()
+        # by _ensure_consistent. Raising here triggers that block's
+        # rollback before the marker write would have fired.
+        raise RuntimeError("simulated mid-rebuild crash (event-sourced)")
+
+    with patch.object(CatalogDB, "rebuild", db_rebuild_boom), \
+         patch.object(Projector, "apply_all", projector_apply_all_boom):
+        cat2 = _make_catalog(seeded_catalog_dir)
+
+    # _ensure_consistent's outer try/except catches the raise and
+    # sets degraded=True regardless of which path fired.
+    assert cat2.degraded is True, (
+        "rebuild raised — degraded must be set so callers know the "
+        "projection is potentially stale"
+    )
+
+    # Marker must NOT have advanced. This is the invariant the
+    # atomicity fix guarantees.
+    row = cat2._db.execute(
+        "SELECT value FROM _meta WHERE key = ?",
+        ("last_consistency_mtime",),
+    ).fetchone()
+    stored_marker = float(row[0]) if row else 0.0
+    assert stored_marker == initial_marker, (
+        f"rebuild raised but marker advanced from {initial_marker} "
+        f"to {stored_marker} — projection rollback would now be "
+        f"silently masked by the advanced marker; events that the "
+        f"rolled-back rebuild should have replayed will be skipped "
+        f"on the next run"
     )


### PR DESCRIPTION
RDR-104 critic Critical #2 fix shipped as a standalone patch.

The marker write previously ran its own `commit()` after the rebuild transaction's `with` block had closed. The current call ordering (projection-then-marker) makes the *current* failure direction benign — projection commits first, marker second, crash between them re-rebuilds idempotently. But the *inverse* ordering (marker first, projection rolls back) is a silent-corruption hazard one refactor away. The fix moves the marker write INSIDE the rebuild transaction so the two commit atomically and the ordering hazard disappears regardless of caller code.

## Changes

- `_write_consistency_marker`: dropped `commit()`; new caller contract documented (must run inside `CatalogDB.transaction()`).
- `CatalogDB.rebuild`: new keyword `consistency_mtime: float | None = None`. When supplied, writes the marker as the last statement inside the same `with self._lock, self._conn, bulk_load_documents()` block. Default `None` preserves the prior contract for un-migrated callers.
- `Catalog._ensure_consistent`: both paths updated. Event-sourced path calls `_write_consistency_marker` from inside its existing transaction block; legacy path passes `consistency_mtime=current_mtime` to `rebuild()`.

## Regression test

`tests/test_catalog_consistency_marker.py::test_marker_does_not_advance_when_rebuild_raises` — patches both `CatalogDB.rebuild` and `Projector.apply_all` to raise mid-transaction (covers both legacy and event-sourced paths), asserts `Catalog.degraded is True` AND the persisted `_meta.last_consistency_mtime` did NOT advance.

## Test plan

- [x] `uv run pytest tests/ -k catalog -q` → 944 passed
- [ ] CI clean

## Refs

- RDR-104 critic Critical #2 (T2: `nexus_rdr/RDR-104-gate-latest`)
- nexus-rr0u

This is the atomicity-only piece; the broader incremental rebuild design RDR-104 is in revision against this fixed baseline.