### PR TITLE
feat(agents,skills): reinforce T1/T2/T3 + plan_search + nx_answer + WRITE-BACK

### DIFF
--- a/nx/agents/architect-planner.md
+++ b/nx/agents/architect-planner.md
@@ -55,6 +55,23 @@ retrieval plan.
 
 
 
+## Pre-flight (plan reuse + tier check)
+
+Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+
+1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
+4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+
+## Post-flight (write-back — mandatory before returning)
+
+**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+
+- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
 ## Relay Reception (MANDATORY)
 
 Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):

--- a/nx/agents/code-review-expert.md
+++ b/nx/agents/code-review-expert.md
@@ -53,6 +53,23 @@ retrieval plan.
 
 
 
+## Pre-flight (plan reuse + tier check)
+
+Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+
+1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
+4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+
+## Post-flight (write-back — mandatory before returning)
+
+**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+
+- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
 ## Relay Reception (MANDATORY)
 
 Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):

--- a/nx/agents/codebase-deep-analyzer.md
+++ b/nx/agents/codebase-deep-analyzer.md
@@ -55,6 +55,23 @@ retrieval plan.
 
 
 
+## Pre-flight (plan reuse + tier check)
+
+Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+
+1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
+4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+
+## Post-flight (write-back — mandatory before returning)
+
+**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+
+- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
 ## Relay Reception (MANDATORY)
 
 Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):

--- a/nx/agents/debugger.md
+++ b/nx/agents/debugger.md
@@ -55,6 +55,23 @@ retrieval plan.
 
 
 
+## Pre-flight (plan reuse + tier check)
+
+Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+
+1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
+4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+
+## Post-flight (write-back — mandatory before returning)
+
+**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+
+- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
 ## Relay Reception (MANDATORY)
 
 Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):

--- a/nx/agents/deep-analyst.md
+++ b/nx/agents/deep-analyst.md
@@ -55,6 +55,23 @@ retrieval plan.
 
 
 
+## Pre-flight (plan reuse + tier check)
+
+Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+
+1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
+4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+
+## Post-flight (write-back — mandatory before returning)
+
+**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+
+- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
 ## Relay Reception (MANDATORY)
 
 Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):

--- a/nx/agents/deep-research-synthesizer.md
+++ b/nx/agents/deep-research-synthesizer.md
@@ -56,6 +56,23 @@ retrieval plan.
 
 
 
+## Pre-flight (plan reuse + tier check)
+
+Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+
+1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
+4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+
+## Post-flight (write-back — mandatory before returning)
+
+**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+
+- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
 ## Relay Reception (MANDATORY)
 
 Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):

--- a/nx/agents/developer.md
+++ b/nx/agents/developer.md
@@ -55,6 +55,23 @@ retrieval plan.
 
 
 
+## Pre-flight (plan reuse + tier check)
+
+Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+
+1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
+4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+
+## Post-flight (write-back — mandatory before returning)
+
+**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+
+- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
 ## Relay Reception (MANDATORY)
 
 Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):

--- a/nx/agents/strategic-planner.md
+++ b/nx/agents/strategic-planner.md
@@ -54,6 +54,23 @@ retrieval plan.
 
 
 
+## Pre-flight (plan reuse + tier check)
+
+Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+
+1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
+4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+
+## Post-flight (write-back — mandatory before returning)
+
+**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+
+- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
 ## Relay Reception (MANDATORY)
 
 Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):

--- a/nx/agents/substantive-critic.md
+++ b/nx/agents/substantive-critic.md
@@ -54,6 +54,23 @@ retrieval plan.
 
 
 
+## Pre-flight (plan reuse + tier check)
+
+Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+
+1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
+4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+
+## Post-flight (write-back — mandatory before returning)
+
+**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+
+- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
 ## Relay Reception (MANDATORY)
 
 Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):

--- a/nx/agents/test-validator.md
+++ b/nx/agents/test-validator.md
@@ -54,6 +54,23 @@ retrieval plan.
 
 
 
+## Pre-flight (plan reuse + tier check)
+
+Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+
+1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
+2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
+3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
+4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
+
+## Post-flight (write-back — mandatory before returning)
+
+**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+
+- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
 ## Relay Reception (MANDATORY)
 
 Before starting, validate the relay contains all required fields per [RELAY_TEMPLATE.md](./_shared/RELAY_TEMPLATE.md):

--- a/nx/skills/analyze/SKILL.md
+++ b/nx/skills/analyze/SKILL.md
@@ -4,6 +4,18 @@ description: Use when synthesising across prose and code corpora or ranking cand
 effort: medium
 ---
 
+**Tier-aware discipline** — apply at session start and before every major step:
+
+1. **Read** widest → narrowest before duplicating effort:
+   - T3 (cross-project): `mcp__plugin_nx_nexus__nx_answer(...)` for verb-shape questions; `mcp__plugin_nx_nexus__search(...)` for keyword lookup.
+   - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
+   - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
+2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
+3. **Write back at end** — findings not stored are findings lost:
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+   - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
+
 # analyze
 
 **You MUST call `nx_answer` for cross-corpus synthesis or ranking. Direct

--- a/nx/skills/debug/SKILL.md
+++ b/nx/skills/debug/SKILL.md
@@ -4,6 +4,18 @@ description: Use when debugging a failing code path (intentionally flat — Sere
 effort: medium
 ---
 
+**Tier-aware discipline** — apply at session start and before every major step:
+
+1. **Read** widest → narrowest before duplicating effort:
+   - T3 (cross-project): `mcp__plugin_nx_nexus__nx_answer(...)` for verb-shape questions; `mcp__plugin_nx_nexus__search(...)` for keyword lookup.
+   - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
+   - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
+2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
+3. **Write back at end** — findings not stored are findings lost:
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+   - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
+
 # debug
 
 **You MUST call `nx_answer` when investigating *why* a code path was

--- a/nx/skills/deep-analysis/SKILL.md
+++ b/nx/skills/deep-analysis/SKILL.md
@@ -4,6 +4,18 @@ description: Use when surface-level analysis is insufficient and problems requir
 effort: high
 ---
 
+**Tier-aware discipline** — apply at session start and before every major step:
+
+1. **Read** widest → narrowest before duplicating effort:
+   - T3 (cross-project): `mcp__plugin_nx_nexus__nx_answer(...)` for verb-shape questions; `mcp__plugin_nx_nexus__search(...)` for keyword lookup.
+   - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
+   - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
+2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
+3. **Write back at end** — findings not stored are findings lost:
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+   - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
+
 # Deep Analysis Skill
 
 Delegates to the **deep-analyst** agent.

--- a/nx/skills/document/SKILL.md
+++ b/nx/skills/document/SKILL.md
@@ -4,6 +4,18 @@ description: Use when authoring or auditing documentation against existing cover
 effort: medium
 ---
 
+**Tier-aware discipline** — apply at session start and before every major step:
+
+1. **Read** widest → narrowest before duplicating effort:
+   - T3 (cross-project): `mcp__plugin_nx_nexus__nx_answer(...)` for verb-shape questions; `mcp__plugin_nx_nexus__search(...)` for keyword lookup.
+   - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
+   - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
+2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
+3. **Write back at end** — findings not stored are findings lost:
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+   - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
+
 # document
 
 **You MUST call `nx_answer` for documentation-coverage questions. Direct

--- a/nx/skills/knowledge-tidying/SKILL.md
+++ b/nx/skills/knowledge-tidying/SKILL.md
@@ -4,6 +4,18 @@ description: Use when validated findings need to be consolidated in nx T3 knowle
 effort: low
 ---
 
+**Tier-aware discipline** — apply at session start and before every major step:
+
+1. **Read** widest → narrowest before duplicating effort:
+   - T3 (cross-project): `mcp__plugin_nx_nexus__nx_answer(...)` for verb-shape questions; `mcp__plugin_nx_nexus__search(...)` for keyword lookup.
+   - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
+   - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
+2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
+3. **Write back at end** — findings not stored are findings lost:
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+   - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
+
 # Knowledge Tidying
 
 Calls the `nx_tidy` MCP tool. No agent spawn needed.

--- a/nx/skills/query/SKILL.md
+++ b/nx/skills/query/SKILL.md
@@ -4,6 +4,18 @@ description: Use when answering any analytical question over nx knowledge collec
 effort: medium
 ---
 
+**Tier-aware discipline** — apply at session start and before every major step:
+
+1. **Read** widest → narrowest before duplicating effort:
+   - T3 (cross-project): `mcp__plugin_nx_nexus__nx_answer(...)` for verb-shape questions; `mcp__plugin_nx_nexus__search(...)` for keyword lookup.
+   - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
+   - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
+2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
+3. **Write back at end** — findings not stored are findings lost:
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+   - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
+
 # Query
 
 **This skill wraps one MCP call — `nx_answer`. If you are asked an

--- a/nx/skills/research-synthesis/SKILL.md
+++ b/nx/skills/research-synthesis/SKILL.md
@@ -4,6 +4,18 @@ description: Use when researching unfamiliar topics, comparing technology approa
 effort: medium
 ---
 
+**Tier-aware discipline** — apply at session start and before every major step:
+
+1. **Read** widest → narrowest before duplicating effort:
+   - T3 (cross-project): `mcp__plugin_nx_nexus__nx_answer(...)` for verb-shape questions; `mcp__plugin_nx_nexus__search(...)` for keyword lookup.
+   - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
+   - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
+2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
+3. **Write back at end** — findings not stored are findings lost:
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+   - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
+
 # Research Synthesis Skill
 
 Delegates to the **deep-research-synthesizer** agent.

--- a/nx/skills/research/SKILL.md
+++ b/nx/skills/research/SKILL.md
@@ -4,6 +4,18 @@ description: Use when doing design / architecture / planning work that walks fro
 effort: medium
 ---
 
+**Tier-aware discipline** — apply at session start and before every major step:
+
+1. **Read** widest → narrowest before duplicating effort:
+   - T3 (cross-project): `mcp__plugin_nx_nexus__nx_answer(...)` for verb-shape questions; `mcp__plugin_nx_nexus__search(...)` for keyword lookup.
+   - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
+   - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
+2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
+3. **Write back at end** — findings not stored are findings lost:
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+   - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
+
 # research
 
 **You MUST call `nx_answer` for research questions. Direct `search`/`query`


### PR DESCRIPTION
## Summary

Builds on nexus-xxsj (shipped in 4.25.1) which restored hook-side guidance for composed retrieval. Probes confirmed the SubagentStart hook drives behavior end-to-end:

- **Probe A** (verb-shape question): subagent called `nx_answer` and `memory_put`, citing the verbatim hook guidance for both.
- **Probe B** (research-and-link task): subagent followed the full 3-step AUTO-LINK recipe — `catalog_search` → `scratch put (link-context)` → `store_put` — citing each step's verbatim guidance.

But the agents' own role descriptions were the one place the guidance hadn't landed. This PR reinforces in the agent's own voice — same signal, different surface, redundant by design.

## What changed

**10 non-stub agents** get a Pre-flight + Post-flight block (17 lines each, inserted before `## Relay Reception`):

> architect-planner, code-review-expert, codebase-deep-analyzer, debugger, deep-analyst, deep-research-synthesizer, developer, strategic-planner, substantive-critic, test-validator

**Pre-flight**: `plan_search` → `memory_search` → `nx_answer` for verb-shape questions → `scratch search` for sibling work-in-progress.

**Post-flight**: `store_put` (T3 cross-project), `memory_put` (T2 project), `plan_save` for pipeline outcomes. *"Findings not stored are findings lost."*

**8 producing skills** get a tier-discipline block (12 lines each, inserted right after frontmatter):

> research, research-synthesis, deep-analysis, analyze, query, document, knowledge-tidying, debug

Same shape — read widest→narrowest, reuse plans before dispatch, write back at end.

## Out of scope (intentionally untouched)

- **Stub agents** (`knowledge-tidier`, `plan-auditor`, `plan-enricher`) — already MCP-delegated; agent file is a thin redirect.
- **Reference skills** (`serena-code-nav`, `nexus`, `cli-controller`) — describe tooling, don't produce findings.
- **Discipline gates** (`brainstorming-gate`, `finishing-branch`, `git-worktrees`, `plan-first`, `plan-validation`) — process gates, not retrieval/synthesis.

## Token cost

~150 tokens per agent invocation when that agent is selected. Subagent dispatch cost (SubagentStart hook content) unchanged — agent files only weigh in when the agent is dispatched.

User accepted the bloat trade-off explicitly: *"We can always trim if we need to."*

## Test plan

- [x] `uv run pytest tests/test_plugin_structure.py tests/test_context.py tests/test_hooks.py` — 604 passed, 26 skipped
- [x] Block consistency: same Pre-flight + Post-flight structure across all 10 agents (each +17 lines / +1685 bytes)
- [x] Skill block consistency: same tier-discipline structure across all 8 skills (each +12 lines / +935 bytes)

## Closes

Closes nexus-t4ke