### PR TITLE
Shakeout fixes: agent/skill tier discipline + AUTO-LINK observability + nx_answer retry

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -542,3 +542,5 @@
 {"id":"int-18ea43cb","kind":"field_change","created_at":"2026-05-05T22:15:34.861876Z","actor":"Hellblazer","issue_id":"nexus-if8y","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 {"id":"int-000e4655","kind":"field_change","created_at":"2026-05-05T22:15:35.192615Z","actor":"Hellblazer","issue_id":"nexus-rs6p","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 {"id":"int-1bc08ebe","kind":"field_change","created_at":"2026-05-06T00:40:10.060243Z","actor":"Hellblazer","issue_id":"nexus-1sy5","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-8b5f8ce8","kind":"field_change","created_at":"2026-05-06T02:13:40.231453Z","actor":"Hellblazer","issue_id":"nexus-t4ke","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-13568a73","kind":"field_change","created_at":"2026-05-06T03:04:47.668871Z","actor":"Hellblazer","issue_id":"nexus-a414","extra":{"field":"priority","new_value":"1","old_value":"2"}}

--- a/nx/agents/architect-planner.md
+++ b/nx/agents/architect-planner.md
@@ -55,22 +55,27 @@ retrieval plan.
 
 
 
-## Pre-flight (plan reuse + tier check)
+## Pre-flight (mandatory — including tasks where the answer feels directly available)
 
-Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
 1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
 2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
 4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
 
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+
 ## Post-flight (write-back — mandatory before returning)
 
-**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+**Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
-- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
-- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_nx_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 

--- a/nx/agents/code-review-expert.md
+++ b/nx/agents/code-review-expert.md
@@ -53,22 +53,27 @@ retrieval plan.
 
 
 
-## Pre-flight (plan reuse + tier check)
+## Pre-flight (mandatory — including tasks where the answer feels directly available)
 
-Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
 1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
 2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
 4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
 
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+
 ## Post-flight (write-back — mandatory before returning)
 
-**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+**Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
-- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
-- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_nx_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 

--- a/nx/agents/codebase-deep-analyzer.md
+++ b/nx/agents/codebase-deep-analyzer.md
@@ -55,22 +55,27 @@ retrieval plan.
 
 
 
-## Pre-flight (plan reuse + tier check)
+## Pre-flight (mandatory — including tasks where the answer feels directly available)
 
-Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
 1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
 2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
 4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
 
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+
 ## Post-flight (write-back — mandatory before returning)
 
-**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+**Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
-- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
-- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_nx_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 

--- a/nx/agents/debugger.md
+++ b/nx/agents/debugger.md
@@ -55,22 +55,27 @@ retrieval plan.
 
 
 
-## Pre-flight (plan reuse + tier check)
+## Pre-flight (mandatory — including tasks where the answer feels directly available)
 
-Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
 1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
 2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
 4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
 
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+
 ## Post-flight (write-back — mandatory before returning)
 
-**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+**Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
-- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
-- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_nx_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 

--- a/nx/agents/deep-analyst.md
+++ b/nx/agents/deep-analyst.md
@@ -55,22 +55,27 @@ retrieval plan.
 
 
 
-## Pre-flight (plan reuse + tier check)
+## Pre-flight (mandatory — including tasks where the answer feels directly available)
 
-Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
 1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
 2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
 4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
 
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+
 ## Post-flight (write-back — mandatory before returning)
 
-**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+**Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
-- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
-- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_nx_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 

--- a/nx/agents/deep-research-synthesizer.md
+++ b/nx/agents/deep-research-synthesizer.md
@@ -56,22 +56,27 @@ retrieval plan.
 
 
 
-## Pre-flight (plan reuse + tier check)
+## Pre-flight (mandatory — including tasks where the answer feels directly available)
 
-Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
 1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
 2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
 4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
 
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+
 ## Post-flight (write-back — mandatory before returning)
 
-**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+**Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
-- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
-- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_nx_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 

--- a/nx/agents/developer.md
+++ b/nx/agents/developer.md
@@ -55,22 +55,27 @@ retrieval plan.
 
 
 
-## Pre-flight (plan reuse + tier check)
+## Pre-flight (mandatory — including tasks where the answer feels directly available)
 
-Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
 1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
 2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
 4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
 
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+
 ## Post-flight (write-back — mandatory before returning)
 
-**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+**Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
-- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
-- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_nx_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 

--- a/nx/agents/strategic-planner.md
+++ b/nx/agents/strategic-planner.md
@@ -54,22 +54,27 @@ retrieval plan.
 
 
 
-## Pre-flight (plan reuse + tier check)
+## Pre-flight (mandatory — including tasks where the answer feels directly available)
 
-Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
 1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
 2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
 4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
 
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+
 ## Post-flight (write-back — mandatory before returning)
 
-**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+**Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
-- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
-- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_nx_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 

--- a/nx/agents/substantive-critic.md
+++ b/nx/agents/substantive-critic.md
@@ -54,22 +54,27 @@ retrieval plan.
 
 
 
-## Pre-flight (plan reuse + tier check)
+## Pre-flight (mandatory — including tasks where the answer feels directly available)
 
-Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
 1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
 2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
 4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
 
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+
 ## Post-flight (write-back — mandatory before returning)
 
-**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+**Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
-- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
-- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_nx_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 

--- a/nx/agents/test-validator.md
+++ b/nx/agents/test-validator.md
@@ -54,22 +54,27 @@ retrieval plan.
 
 
 
-## Pre-flight (plan reuse + tier check)
+## Pre-flight (mandatory — including tasks where the answer feels directly available)
 
-Before substantive work — these checks are cheap and avoid duplicating prior agent effort:
+Run these four reads BEFORE substantive work. Skipping on the grounds that "this task is structural / direct / tiers won't help here / I can read the code faster" is the rationalization the using-nx-skills Red Flags table warns about — sibling agents may have just done this work, prior project history may already cover it, and findings caught in passing (bugs noticed while mapping code, races spotted while implementing, perf gaps glimpsed while reviewing) get lost when post-flight write-back is also skipped:
 
 1. **Plan reuse**: `mcp__plugin_nx_nexus__plan_search(query="<your task>", limit=3)` — if a match returns, reuse it as a starting structure.
 2. **T2 (project)**: `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")` — prior project decisions, findings, session context.
 3. **T3 (cross-project)**: `mcp__plugin_nx_nexus__nx_answer(question="<verb-shape question>", scope="<corpus>")` for any "how / why / tradeoffs / compare" question; raw `mcp__plugin_nx_nexus__search(...)` only for single-step keyword lookups.
 4. **T1 (siblings)**: `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")` — sibling agents in the current session may have done this work already.
 
+The only valid skip is structural inapplicability (a tier physically cannot have what you need). A no-match in <300 ms still counts as a check — and frequently surfaces the unexpected.
+
 ## Post-flight (write-back — mandatory before returning)
 
-**Findings not stored are findings lost.** Before returning your result, persist what a future session would benefit from:
+**Findings not stored are findings lost.** Before returning your result, persist what downstream consumers would benefit from. Pick the tier(s) that match the audience:
 
-- **Permanent cross-project knowledge** → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
-- **Project-scoped decisions / findings** → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
+- **Sibling agents downstream THIS session** (T1, narrowest scope, cheapest write) → `mcp__plugin_nx_nexus__scratch(action="put", content=..., tags="<topic>")`. The next sibling the caller dispatches finds your work via `scratch search` and skips re-derivation.
+- **Permanent cross-project knowledge** (T3, future sessions everywhere) → `mcp__plugin_nx_nexus__store_put(content=..., collection="knowledge", title=..., tags=...)`. AUTO-LINKS via T1 scratch tag `link-context` — seed first via `catalog_search` → `scratch put` if you want catalog links auto-created.
+- **Project-scoped decisions / findings** (T2, future sessions this project) → `mcp__plugin_nx_nexus__memory_put(content=..., project="<repo>", title=..., ttl=30)`.
 - **Multi-step pipeline outcome** (caller orchestrating you alongside other agents) → `mcp__plugin_nx_nexus__plan_save(query="<task>", plan_json={"steps":[...],"tools_used":[...],"outcome_notes":"..."}, tags="<agents>")` so future runs of similar tasks get a plan-match hit.
+
+**Don't dismiss insights as "low-signal noise" because the surrounding work was structural.** If you noticed a bug, a race, a perf gap, an architectural observation, or a non-obvious cross-module connection while doing your primary task, that IS a finding worth persisting — for sibling agents this session (T1), or future sessions in this project (T2) or any project (T3). Bug-discoveries-in-passing are exactly the class of finding downstream work benefits from.
 
 ## Relay Reception (MANDATORY)
 

--- a/nx/skills/analyze/SKILL.md
+++ b/nx/skills/analyze/SKILL.md
@@ -11,9 +11,10 @@ effort: medium
    - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
    - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
 2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
-3. **Write back at end** — findings not stored are findings lost:
-   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
-   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+3. **Write back at end** — findings not stored are findings lost. Pick the tier that matches the audience:
+   - `mcp__plugin_nx_nexus__scratch(action="put", ..., tags="<topic>")` for sibling agents downstream THIS session (T1, narrowest scope, cheapest write).
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions, future sessions same project (T2).
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge, future sessions everywhere (T3).
    - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
 
 # analyze

--- a/nx/skills/debug/SKILL.md
+++ b/nx/skills/debug/SKILL.md
@@ -11,9 +11,10 @@ effort: medium
    - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
    - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
 2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
-3. **Write back at end** — findings not stored are findings lost:
-   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
-   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+3. **Write back at end** — findings not stored are findings lost. Pick the tier that matches the audience:
+   - `mcp__plugin_nx_nexus__scratch(action="put", ..., tags="<topic>")` for sibling agents downstream THIS session (T1, narrowest scope, cheapest write).
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions, future sessions same project (T2).
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge, future sessions everywhere (T3).
    - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
 
 # debug

--- a/nx/skills/deep-analysis/SKILL.md
+++ b/nx/skills/deep-analysis/SKILL.md
@@ -11,9 +11,10 @@ effort: high
    - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
    - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
 2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
-3. **Write back at end** — findings not stored are findings lost:
-   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
-   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+3. **Write back at end** — findings not stored are findings lost. Pick the tier that matches the audience:
+   - `mcp__plugin_nx_nexus__scratch(action="put", ..., tags="<topic>")` for sibling agents downstream THIS session (T1, narrowest scope, cheapest write).
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions, future sessions same project (T2).
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge, future sessions everywhere (T3).
    - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
 
 # Deep Analysis Skill

--- a/nx/skills/document/SKILL.md
+++ b/nx/skills/document/SKILL.md
@@ -11,9 +11,10 @@ effort: medium
    - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
    - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
 2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
-3. **Write back at end** — findings not stored are findings lost:
-   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
-   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+3. **Write back at end** — findings not stored are findings lost. Pick the tier that matches the audience:
+   - `mcp__plugin_nx_nexus__scratch(action="put", ..., tags="<topic>")` for sibling agents downstream THIS session (T1, narrowest scope, cheapest write).
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions, future sessions same project (T2).
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge, future sessions everywhere (T3).
    - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
 
 # document

--- a/nx/skills/knowledge-tidying/SKILL.md
+++ b/nx/skills/knowledge-tidying/SKILL.md
@@ -11,9 +11,10 @@ effort: low
    - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
    - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
 2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
-3. **Write back at end** — findings not stored are findings lost:
-   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
-   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+3. **Write back at end** — findings not stored are findings lost. Pick the tier that matches the audience:
+   - `mcp__plugin_nx_nexus__scratch(action="put", ..., tags="<topic>")` for sibling agents downstream THIS session (T1, narrowest scope, cheapest write).
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions, future sessions same project (T2).
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge, future sessions everywhere (T3).
    - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
 
 # Knowledge Tidying

--- a/nx/skills/query/SKILL.md
+++ b/nx/skills/query/SKILL.md
@@ -11,9 +11,10 @@ effort: medium
    - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
    - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
 2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
-3. **Write back at end** — findings not stored are findings lost:
-   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
-   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+3. **Write back at end** — findings not stored are findings lost. Pick the tier that matches the audience:
+   - `mcp__plugin_nx_nexus__scratch(action="put", ..., tags="<topic>")` for sibling agents downstream THIS session (T1, narrowest scope, cheapest write).
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions, future sessions same project (T2).
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge, future sessions everywhere (T3).
    - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
 
 # Query

--- a/nx/skills/research-synthesis/SKILL.md
+++ b/nx/skills/research-synthesis/SKILL.md
@@ -11,9 +11,10 @@ effort: medium
    - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
    - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
 2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
-3. **Write back at end** — findings not stored are findings lost:
-   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
-   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+3. **Write back at end** — findings not stored are findings lost. Pick the tier that matches the audience:
+   - `mcp__plugin_nx_nexus__scratch(action="put", ..., tags="<topic>")` for sibling agents downstream THIS session (T1, narrowest scope, cheapest write).
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions, future sessions same project (T2).
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge, future sessions everywhere (T3).
    - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
 
 # Research Synthesis Skill

--- a/nx/skills/research/SKILL.md
+++ b/nx/skills/research/SKILL.md
@@ -11,9 +11,10 @@ effort: medium
    - T2 (project): `mcp__plugin_nx_nexus__memory_search(query="<topic>", project="<repo>")`.
    - T1 (siblings, this session): `mcp__plugin_nx_nexus__scratch(action="search", query="<topic>")`.
 2. **Reuse plans** before dispatching multiple agents: `mcp__plugin_nx_nexus__plan_search(query="<task>", limit=3)`.
-3. **Write back at end** — findings not stored are findings lost:
-   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge.
-   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions.
+3. **Write back at end** — findings not stored are findings lost. Pick the tier that matches the audience:
+   - `mcp__plugin_nx_nexus__scratch(action="put", ..., tags="<topic>")` for sibling agents downstream THIS session (T1, narrowest scope, cheapest write).
+   - `mcp__plugin_nx_nexus__memory_put(...)` for project-scoped decisions, future sessions same project (T2).
+   - `mcp__plugin_nx_nexus__store_put(...)` for permanent cross-project knowledge, future sessions everywhere (T3).
    - `mcp__plugin_nx_nexus__plan_save(...)` for multi-agent pipeline outcomes (so future callers hit plan-match).
 
 # research

--- a/src/nexus/catalog/auto_linker.py
+++ b/src/nexus/catalog/auto_linker.py
@@ -25,6 +25,31 @@ class LinkContext:
     link_type: str
 
 
+@dataclass(frozen=True)
+class AutoLinkResult:
+    """Structured outcome of an :func:`auto_link` call.
+
+    Returned instead of a bare ``int`` (nexus-a414) so the caller can
+    distinguish the four states an AUTO-LINK invocation can end in:
+
+    - ``created > 0``: the recipe worked; some links materialised.
+    - ``skipped_invalid_tumbler > 0``: target strings did not parse as a
+      :class:`Tumbler` (e.g. T3 chash hex landed in scratch link-context
+      because the upstream agent didn't extract the tumbler field from
+      ``catalog_search`` results). Operationally actionable; surfaced at
+      WARNING in the auto-linker so recipe-compliant agents see the gap.
+    - ``skipped_missing_endpoint > 0``: tumbler parsed but no catalog
+      entry resolves. Less alarming (legitimate cleanup signal during
+      catalog rebuilds) but still tracked.
+    - all zero with empty input: no link-context in scratch; not a
+      failure, not a write.
+    """
+
+    created: int = 0
+    skipped_invalid_tumbler: int = 0
+    skipped_missing_endpoint: int = 0
+
+
 def read_link_contexts(entries: list[dict[str, Any]]) -> list[LinkContext]:
     """Parse T1 scratch entries into LinkContext objects.
 
@@ -59,25 +84,53 @@ def auto_link(
     cat: Catalog,
     source_tumbler: Tumbler,
     contexts: list[LinkContext],
-) -> int:
+) -> AutoLinkResult:
     """Create catalog links from source to each target in contexts.
 
-    Uses ``link_if_absent`` for idempotency. Skips targets whose tumblers
-    don't resolve. Returns the number of links actually created.
+    Uses ``link_if_absent`` for idempotency. Returns an
+    :class:`AutoLinkResult` with separated counts (nexus-a414) so the
+    caller can distinguish a clean miss (no contexts) from a recipe-
+    compliant call that produced zero links because of bad target data.
+
+    Skip behaviour:
+
+    - Targets that fail :meth:`Tumbler.parse` are logged at WARNING with
+      a recipe-compliance hint and counted in
+      ``skipped_invalid_tumbler``. WARNING (not DEBUG, the prior level)
+      because every recipe-compliant AUTO-LINK call that lands an
+      invalid target was a silent miss before nexus-a414.
+    - Targets whose tumbler parses but whose endpoint is not in the
+      catalog are logged at DEBUG and counted in
+      ``skipped_missing_endpoint``. Lower severity because the
+      legitimate cause (catalog rebuild in progress, link-context
+      pointing at not-yet-indexed target) is non-actionable from the
+      caller's side.
     """
     if not contexts:
-        return 0
+        return AutoLinkResult()
 
-    count = 0
+    created = 0
+    skipped_invalid = 0
+    skipped_missing = 0
+
     for ctx in contexts:
         try:
             target = Tumbler.parse(ctx.target_tumbler)
         except ValueError:
-            _log.debug("auto_link_skip_invalid_tumbler", tumbler=ctx.target_tumbler)
+            skipped_invalid += 1
+            _log.warning(
+                "auto_link_skip_invalid_tumbler",
+                tumbler=ctx.target_tumbler,
+                hint=(
+                    "AUTO-LINK recipe step 2 must scratch_put TUMBLER "
+                    "strings (e.g. '1.2.5'), not T3 chash hex. Extract "
+                    "the 'tumbler' field from catalog_search results."
+                ),
+            )
             continue
 
         try:
-            created = cat.link_if_absent(
+            was_created = cat.link_if_absent(
                 source_tumbler,
                 target,
                 ctx.link_type,
@@ -86,6 +139,7 @@ def auto_link(
         except ValueError as exc:
             # link_if_absent raises ValueError for missing endpoints;
             # log the message to distinguish from unexpected ValueErrors
+            skipped_missing += 1
             _log.debug(
                 "auto_link_skip_missing_endpoint",
                 source=str(source_tumbler),
@@ -94,8 +148,8 @@ def auto_link(
             )
             continue
 
-        if created:
-            count += 1
+        if was_created:
+            created += 1
             _log.debug(
                 "auto_link_created",
                 source=str(source_tumbler),
@@ -103,4 +157,8 @@ def auto_link(
                 link_type=ctx.link_type,
             )
 
-    return count
+    return AutoLinkResult(
+        created=created,
+        skipped_invalid_tumbler=skipped_invalid,
+        skipped_missing_endpoint=skipped_missing,
+    )

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -945,14 +945,29 @@ def store_put(
             ttl_days=ttl_days,
             catalog_doc_id=catalog_doc_id,
         )
-        # Auto-link from T1 scratch link-context
+        # Auto-link from T1 scratch link-context.
+        # nexus-a414: replace prior bare-except with named-exception capture
+        # so unexpected errors surface at WARNING instead of silently passing.
+        # The auto-link path itself stays non-fatal to store_put — the
+        # WARNING makes the failure visible without aborting the user's
+        # write. Specific skip-count observability lives one layer down in
+        # _catalog_auto_link.
         try:
             n = _catalog_auto_link(doc_id)
+        except Exception as auto_link_exc:
+            import structlog
+            structlog.get_logger().warning(
+                "store_put_auto_link_failed",
+                doc_id=doc_id,
+                error=type(auto_link_exc).__name__,
+                detail=str(auto_link_exc)[:200],
+            )
+        else:
             if n:
                 import structlog
-                structlog.get_logger().debug("store_put_auto_linked", doc_id=doc_id, link_count=n)
-        except Exception:
-            pass  # auto-linking is non-fatal
+                structlog.get_logger().debug(
+                    "store_put_auto_linked", doc_id=doc_id, link_count=n,
+                )
         # Both post-store chains fire from every storage event (RDR-095
         # symmetric-fire follow-up). Single-doc chain runs registered
         # per-doc consumers; batch chain runs with a 1-element list so
@@ -2982,7 +2997,38 @@ async def _nx_answer_plan_miss(
     # tool-choice enumeration). 120s was hitting the timeout on
     # non-trivial questions. Callers of nx_answer see the miss path
     # as a hang when this trips.
-    payload = await claude_dispatch(prompt, _PLANNER_SCHEMA, timeout=300.0)
+    #
+    # nexus-wr5o: claude -p occasionally returns malformed JSON despite
+    # --output-format json --json-schema (transient model output drift,
+    # partial stream, null structured_output on first attempt). One retry
+    # on OperatorOutputError catches the transient case; OperatorError
+    # (subprocess non-zero) and OperatorTimeoutError do NOT retry — those
+    # are not transient. Halved timeout on retry so a single hang doesn't
+    # double total wall time.
+    from nexus.operators.dispatch import OperatorOutputError as _OpOutputError
+    payload = None
+    last_output_error: _OpOutputError | None = None
+    for attempt in range(2):
+        attempt_timeout = 300.0 if attempt == 0 else 150.0
+        try:
+            payload = await claude_dispatch(
+                prompt, _PLANNER_SCHEMA, timeout=attempt_timeout,
+            )
+            break
+        except _OpOutputError as exc:
+            last_output_error = exc
+            import structlog as _slog
+            _slog.get_logger().warning(
+                "nx_answer_planner_output_error",
+                attempt=attempt + 1,
+                error=str(exc)[:300],
+            )
+    if payload is None:
+        # Both attempts hit OperatorOutputError. Re-raise the second one
+        # (most recent diagnostic) so the caller's error string carries
+        # the most-actionable snippet.
+        assert last_output_error is not None
+        raise last_output_error
     steps = payload.get("steps", []) if isinstance(payload, dict) else []
     if not steps:
         raise ValueError("planner returned empty plan")

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -304,7 +304,15 @@ def require_catalog():
 
 
 def catalog_auto_link(doc_id: str) -> int:
-    """Create catalog links from T1 link-context to the just-stored document."""
+    """Create catalog links from T1 link-context to the just-stored document.
+
+    Returns the number of links actually created (backward-compat int).
+    Skip counts are surfaced via structlog: WARNING for invalid tumbler
+    skips (recipe-compliance gap), DEBUG for missing endpoint skips
+    (legitimate cleanup signal). nexus-a414 made these visible after
+    the prior all-DEBUG behaviour silently swallowed every recipe-
+    compliant call that produced zero links.
+    """
     import structlog
     _log = structlog.get_logger()
 
@@ -325,7 +333,27 @@ def catalog_auto_link(doc_id: str) -> int:
         return 0
     from nexus.catalog.auto_linker import auto_link, read_link_contexts
     contexts = read_link_contexts(link_entries)
-    return auto_link(cat, entry.tumbler, contexts)
+    result = auto_link(cat, entry.tumbler, contexts)
+
+    # nexus-a414: surface non-zero outcomes so operators see what's happening.
+    # The all-zero case (no contexts) is already gated above. The interesting
+    # case is contexts present + zero created — that's the silent failure mode
+    # the bead exists for.
+    if result.created or result.skipped_invalid_tumbler or result.skipped_missing_endpoint:
+        recipe_compliant_zero = (
+            result.created == 0
+            and result.skipped_invalid_tumbler > 0
+        )
+        log_method = _log.warning if recipe_compliant_zero else _log.info
+        log_method(
+            "auto_link_summary",
+            doc_id=doc_id,
+            created=result.created,
+            skipped_invalid_tumbler=result.skipped_invalid_tumbler,
+            skipped_missing_endpoint=result.skipped_missing_endpoint,
+            recipe_compliant_zero=recipe_compliant_zero,
+        )
+    return result.created
 
 
 def resolve_tumbler_mcp(cat, value):

--- a/tests/test_auto_linker.py
+++ b/tests/test_auto_linker.py
@@ -33,9 +33,11 @@ class TestAutoLink:
         target_t = cat.register(owner, "Target Doc", content_type="knowledge")
 
         ctx = LinkContext(target_tumbler=str(target_t), link_type="relates")
-        count = auto_link(cat, source_t, [ctx])
+        result = auto_link(cat, source_t, [ctx])
 
-        assert count == 1
+        assert result.created == 1
+        assert result.skipped_invalid_tumbler == 0
+        assert result.skipped_missing_endpoint == 0
         links = cat.links_from(source_t, link_type="relates")
         assert len(links) == 1
         assert links[0].created_by == "auto-linker"
@@ -46,22 +48,29 @@ class TestAutoLink:
         owner = cat.register_owner("test", "curator")
         source_t = cat.register(owner, "Source Doc", content_type="knowledge")
 
-        count = auto_link(cat, source_t, [])
+        result = auto_link(cat, source_t, [])
 
-        assert count == 0
+        assert result.created == 0
+        assert result.skipped_invalid_tumbler == 0
+        assert result.skipped_missing_endpoint == 0
         links = cat.links_from(source_t)
         assert links == []
 
     def test_nonexistent_tumbler_graceful_skip(self, tmp_path):
-        """A LinkContext referencing a non-existent tumbler is silently skipped."""
+        """A LinkContext with valid-format-but-non-existent tumbler is counted in skipped_missing_endpoint."""
         cat = _make_catalog(tmp_path)
         owner = cat.register_owner("test", "curator")
         source_t = cat.register(owner, "Source Doc", content_type="knowledge")
 
         ctx = LinkContext(target_tumbler="99.99.99", link_type="relates")
-        count = auto_link(cat, source_t, [ctx])
+        result = auto_link(cat, source_t, [ctx])
 
-        assert count == 0
+        # nexus-a414: separate counts so the caller distinguishes
+        # parseable-but-missing (cleanup signal) from non-parseable
+        # (recipe-compliance gap).
+        assert result.created == 0
+        assert result.skipped_invalid_tumbler == 0
+        assert result.skipped_missing_endpoint == 1
         links = cat.links_from(source_t)
         assert links == []
 
@@ -77,9 +86,11 @@ class TestAutoLink:
             LinkContext(target_tumbler=str(target1_t), link_type="relates"),
             LinkContext(target_tumbler=str(target2_t), link_type="relates"),
         ]
-        count = auto_link(cat, source_t, contexts)
+        result = auto_link(cat, source_t, contexts)
 
-        assert count == 2
+        assert result.created == 2
+        assert result.skipped_invalid_tumbler == 0
+        assert result.skipped_missing_endpoint == 0
         links = cat.links_from(source_t, link_type="relates")
         assert len(links) == 2
 
@@ -133,9 +144,14 @@ class TestAutoLink:
 
         ctx = LinkContext(target_tumbler=str(target_t), link_type="relates")
         auto_link(cat, source_t, [ctx])
-        count2 = auto_link(cat, source_t, [ctx])
+        result2 = auto_link(cat, source_t, [ctx])
 
-        assert count2 == 0
+        # Idempotent: the second call re-attempts the same target, finds
+        # link already present (link_if_absent returns False), counts 0
+        # created. No skip — the tumbler resolves and the row exists.
+        assert result2.created == 0
+        assert result2.skipped_invalid_tumbler == 0
+        assert result2.skipped_missing_endpoint == 0
         links = cat.links_from(source_t, link_type="relates")
         assert len(links) == 1
 
@@ -157,6 +173,85 @@ class TestAutoLink:
         assert len(links) == 2
         for link in links:
             assert link.created_by == "auto-linker"
+
+
+class TestAutoLinkResult:
+    """nexus-a414: structured AutoLinkResult separates the silent-failure modes.
+
+    Before this change, ``auto_link`` returned a bare ``int`` (the created
+    count). Recipe-compliant agents calling ``store_put`` after the AUTO-LINK
+    recipe (catalog_search → scratch put with link-context tag → store_put)
+    landed bad target data (T3 chash hex instead of tumbler strings) and
+    saw zero links created with no error signal. The new dataclass surfaces
+    invalid-tumbler vs missing-endpoint as separate counts so the caller
+    layer can WARN on the recipe-compliance gap.
+    """
+
+    def test_invalid_tumbler_counts_as_invalid_skip(self, tmp_path):
+        """Non-parseable tumbler strings (e.g. T3 chash hex) → skipped_invalid_tumbler."""
+        from nexus.catalog.auto_linker import AutoLinkResult
+
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("test", "curator")
+        source_t = cat.register(owner, "Source Doc", content_type="knowledge")
+
+        # T3 chash hex (16 hex chars) is the canonical bug-causing input
+        # surfaced by the live shakeout. Tumbler.parse rejects it.
+        ctx = LinkContext(
+            target_tumbler="aca95577feec25d1", link_type="relates",
+        )
+        result = auto_link(cat, source_t, [ctx])
+
+        assert isinstance(result, AutoLinkResult)
+        assert result.created == 0
+        assert result.skipped_invalid_tumbler == 1
+        assert result.skipped_missing_endpoint == 0
+
+    def test_mixed_invalid_and_missing_separate_counts(self, tmp_path):
+        """A batch with both failure modes counts them separately."""
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("test", "curator")
+        source_t = cat.register(owner, "Source Doc", content_type="knowledge")
+
+        contexts = [
+            # Invalid tumbler format
+            LinkContext(target_tumbler="not-a-tumbler", link_type="relates"),
+            LinkContext(target_tumbler="ddbff7f16e4454e2", link_type="relates"),
+            # Valid tumbler format, missing endpoint
+            LinkContext(target_tumbler="99.99.99", link_type="relates"),
+        ]
+        result = auto_link(cat, source_t, contexts)
+
+        assert result.created == 0
+        assert result.skipped_invalid_tumbler == 2
+        assert result.skipped_missing_endpoint == 1
+
+    def test_partial_success_counts_correctly(self, tmp_path):
+        """Mixed valid + invalid + missing in one batch: each counted in its bucket."""
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("test", "curator")
+        source_t = cat.register(owner, "Source Doc", content_type="knowledge")
+        target_t = cat.register(owner, "Target Doc", content_type="knowledge")
+
+        contexts = [
+            LinkContext(target_tumbler=str(target_t), link_type="relates"),
+            LinkContext(target_tumbler="not-a-tumbler", link_type="relates"),
+            LinkContext(target_tumbler="99.99.99", link_type="cites"),
+        ]
+        result = auto_link(cat, source_t, contexts)
+
+        assert result.created == 1
+        assert result.skipped_invalid_tumbler == 1
+        assert result.skipped_missing_endpoint == 1
+
+    def test_default_construction_is_all_zero(self):
+        """AutoLinkResult() with no args defaults all counts to 0."""
+        from nexus.catalog.auto_linker import AutoLinkResult
+
+        result = AutoLinkResult()
+        assert result.created == 0
+        assert result.skipped_invalid_tumbler == 0
+        assert result.skipped_missing_endpoint == 0
 
 
 class TestCatalogAutoLinkIntegration:

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -1850,3 +1850,135 @@ class TestSubagentTimeoutFloor:
         assert "tool=nx_plan_audit" in emitted
         assert "requested=180" in emitted
         assert "floor=300" in emitted
+
+
+class TestNxAnswerPlannerRetry:
+    """nexus-wr5o: 1-shot retry on OperatorOutputError from claude_dispatch.
+
+    Transient JSON parse failures (model output drift, partial stream, null
+    structured_output on first attempt) are retried once with a halved
+    timeout. OperatorError (subprocess non-zero) and OperatorTimeoutError
+    are NOT retried — those failure modes are not transient.
+    """
+
+    @pytest.mark.asyncio
+    async def test_retry_succeeds_on_second_attempt(self):
+        """First call raises OperatorOutputError, second returns valid payload."""
+        from nexus.mcp.core import _nx_answer_plan_miss
+        from nexus.operators.dispatch import OperatorOutputError
+
+        valid_payload = {
+            "steps": [
+                {"tool": "search", "args": {"query": "$intent", "corpus": "knowledge"}},
+            ],
+        }
+        mock_dispatch = AsyncMock(side_effect=[
+            OperatorOutputError("transient JSON parse drift"),
+            valid_payload,
+        ])
+
+        with patch(
+            "nexus.operators.dispatch.claude_dispatch", mock_dispatch,
+        ), patch(
+            "nexus.mcp_infra.get_collection_names", return_value=["knowledge"],
+        ):
+            match = await _nx_answer_plan_miss("how does X work?")
+
+        # Synthetic match for inline-planner result.
+        assert match.plan_id == 0
+        assert match.name == "ad-hoc"
+        # Two attempts: first failed, second succeeded.
+        assert mock_dispatch.call_count == 2
+        # Verify the timeouts: 300 then 150.
+        assert mock_dispatch.call_args_list[0].kwargs["timeout"] == 300.0
+        assert mock_dispatch.call_args_list[1].kwargs["timeout"] == 150.0
+
+    @pytest.mark.asyncio
+    async def test_retry_exhausted_raises_second_error(self):
+        """Both attempts raise OperatorOutputError → raise the second one."""
+        from nexus.mcp.core import _nx_answer_plan_miss
+        from nexus.operators.dispatch import OperatorOutputError
+
+        mock_dispatch = AsyncMock(side_effect=[
+            OperatorOutputError("first attempt drift"),
+            OperatorOutputError("second attempt drift, this is the actionable one"),
+        ])
+
+        with patch(
+            "nexus.operators.dispatch.claude_dispatch", mock_dispatch,
+        ), patch(
+            "nexus.mcp_infra.get_collection_names", return_value=["knowledge"],
+        ):
+            with pytest.raises(OperatorOutputError) as excinfo:
+                await _nx_answer_plan_miss("how does X work?")
+
+        assert mock_dispatch.call_count == 2
+        # Caller gets the most recent (most actionable) error.
+        assert "second attempt" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_no_retry_for_operator_error(self):
+        """OperatorError (subprocess non-zero) raises immediately, no retry."""
+        from nexus.mcp.core import _nx_answer_plan_miss
+        from nexus.operators.dispatch import OperatorError
+
+        mock_dispatch = AsyncMock(
+            side_effect=OperatorError("claude -p exited 1: oops"),
+        )
+
+        with patch(
+            "nexus.operators.dispatch.claude_dispatch", mock_dispatch,
+        ), patch(
+            "nexus.mcp_infra.get_collection_names", return_value=["knowledge"],
+        ):
+            with pytest.raises(OperatorError):
+                await _nx_answer_plan_miss("how does X work?")
+
+        assert mock_dispatch.call_count == 1, (
+            "OperatorError must NOT trigger retry — non-zero exit is "
+            "not transient"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_retry_for_timeout_error(self):
+        """OperatorTimeoutError raises immediately — hangs are not transient."""
+        from nexus.mcp.core import _nx_answer_plan_miss
+        from nexus.operators.dispatch import OperatorTimeoutError
+
+        mock_dispatch = AsyncMock(
+            side_effect=OperatorTimeoutError("claude -p timed out after 300s"),
+        )
+
+        with patch(
+            "nexus.operators.dispatch.claude_dispatch", mock_dispatch,
+        ), patch(
+            "nexus.mcp_infra.get_collection_names", return_value=["knowledge"],
+        ):
+            with pytest.raises(OperatorTimeoutError):
+                await _nx_answer_plan_miss("how does X work?")
+
+        assert mock_dispatch.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_first_attempt_success_no_retry(self):
+        """If first call succeeds, no second call is made."""
+        from nexus.mcp.core import _nx_answer_plan_miss
+
+        valid_payload = {
+            "steps": [
+                {"tool": "search", "args": {"query": "$intent", "corpus": "knowledge"}},
+            ],
+        }
+        mock_dispatch = AsyncMock(return_value=valid_payload)
+
+        with patch(
+            "nexus.operators.dispatch.claude_dispatch", mock_dispatch,
+        ), patch(
+            "nexus.mcp_infra.get_collection_names", return_value=["knowledge"],
+        ):
+            match = await _nx_answer_plan_miss("how does X work?")
+
+        assert match.plan_id == 0
+        assert mock_dispatch.call_count == 1
+        # First-attempt path uses the full 300s timeout.
+        assert mock_dispatch.call_args.kwargs["timeout"] == 300.0


### PR DESCRIPTION
Fixes surfaced by the live shakeout of conexus 4.25.2 hooks/agents reinforcement, 2026-05-05.

## Summary

- **Tuning** — 10 agents + 8 skills now use audience-aware T1/T2/T3 write-back (T1 = sibling agents this session; T2/T3 = future sessions). Pre-flight wording closes the rationalization gap that let `codebase-deep-analyzer` skip all four tier reads on a pure code-mapping task ("the code is the answer").
- **nexus-a414** (P2) — `auto_link()` now returns `AutoLinkResult` dataclass with separated counts (created / skipped_invalid_tumbler / skipped_missing_endpoint). Invalid-tumbler skips upgrade from DEBUG to WARNING with a recipe-compliance hint. `catalog_auto_link` emits an INFO/WARNING summary so the silent-failure mode (recipe followed correctly, all targets skipped, zero links) is now visible. Bare-except in `mcp/core.py:948-955` tightened to log unexpected errors at WARNING via `store_put_auto_link_failed`.
- **nexus-wr5o** (P2) — `_nx_answer_plan_miss` retries once on `OperatorOutputError` (transient JSON parse drift) with halved 150s timeout. `OperatorError` and `OperatorTimeoutError` do NOT retry. Caller gets the second (most actionable) error message on exhaustion.

## Closes

- nexus-a414
- nexus-wr5o

## Background

Live shakeout of 4.25.2 (PRs #519 + #520) ran 6 dispatch probes against the new T1/T2/T3 + AUTO-LINK + nx_answer reinforcement at three layers (subagent-start hook, agent pre/post-flight blocks, skill tier-discipline blocks). Findings:

- Hook layer worked end-to-end (JSON envelope reaches every dispatch).
- Verb-shape and project-state task discipline held cleanly.
- Code-mapping discipline rationalized away — fixed in this PR.
- T1 sibling sharing worked (Probe-2 receiver found and used Probe-2 sender's scratch entry).
- AUTO-LINK recipe routing perfect; **executor produced zero links and no signal** (silent failure, the bead motivating the catalog fix).
- nx_answer planner hit a transient JSON parse error during one probe — fixed in this PR.

## Test plan

- [x] `uv run pytest tests/test_auto_linker.py tests/test_nx_answer.py tests/test_plugin_structure.py tests/test_hooks.py -q` → 704 passed
- [x] `uv run pytest tests/test_catalog*.py tests/test_mcp*.py tests/test_context.py -q` → 1010 passed
- [x] No regressions in mcp/core.py or mcp_infra.py callers
- [x] All 18 agent + skill prompts validated against `tests/test_plugin_structure.py`
- [ ] Manual shakeout re-run after merge (validate that the tightened code-mapping pre-flight + AUTO-LINK observability + retry actually changes agent behavior in production)

## Out of scope (filed separately, not this PR)

- MCP `catalog_search` response shape: agent fell back to T3 chash hex because tumblers came back empty under one query shape. The auto-linker observability fix surfaces this as a recipe-compliance WARNING, but the upstream catalog_search field-extraction docs gap should be its own bead if confirmed (current speculation; would need a follow-up probe to repro).
- Em dash style cleanup across agent/skill prompts (memory: no em dashes in prose). Not addressed here to keep this PR focused on behavior.