### PR TITLE
fix(aspect-worker): partition heterogeneous batches by ExtractorConfig (nexus-nncy)

### DIFF
--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -215,8 +215,25 @@ class AspectExtractionWorker:
         from nexus.aspect_extractor import (
             _source_content_from_t3,
             extract_aspects_batch,
+            select_config,
         )
         from nexus.mcp_infra import t2_ctx
+
+        # extract_aspects_batch requires every input to share a single
+        # ExtractorConfig. claim_batch grabs FIFO across collections, so
+        # a knowledge__ row enqueued before an rdr__ row lands in the
+        # same claim and crosses the homogeneity boundary. Fall back to
+        # per-row processing instead of marking the whole batch failed.
+        configs = {select_config(row.collection) for row in rows}
+        if len(configs - {None}) > 1:
+            _log.info(
+                "aspect_worker_batch_heterogeneous_fallback",
+                row_count=len(rows),
+                configs=sorted(c.extractor_name for c in configs if c is not None),
+            )
+            for row in rows:
+                self._process_row(row)
+            return
 
         # Per-row content source: prefer queued content, fall back to
         # T3 reassembly (same text we indexed; section-filtered for

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -594,3 +594,81 @@ class TestBatchPath:
 
         assert batch_calls == []
         assert single_calls == ["/p1.pdf"]
+
+    def test_worker_falls_through_to_per_row_on_heterogeneous_batch(
+        self, _isolate_t2: Path,
+    ) -> None:
+        """When a claimed batch crosses ExtractorConfig boundaries
+        (e.g. knowledge__ + rdr__ rows in the same claim), the worker
+        falls through to per-row processing rather than letting
+        extract_aspects_batch raise on heterogeneous configs.
+
+        Pre-fix repro: this test would fail because ``_extract_aspects_batch``
+        was invoked once with mixed configs and raised
+        ``ValueError: extract_aspects_batch requires all items to share
+        a single ExtractorConfig``, marking every row in the batch
+        as failed.
+        """
+        from nexus.aspect_extractor import AspectRecord
+        from nexus.aspect_worker import AspectExtractionWorker
+
+        # 3 knowledge__ rows (scholarly-paper config) + 2 rdr__ rows
+        # (rdr-frontmatter config) — claimed together when batch_size=5.
+        with T2Database(_isolate_t2) as db:
+            for i in range(3):
+                db.aspect_queue.enqueue(
+                    "knowledge__delos",
+                    f"/papers/p{i}.pdf",
+                    content=f"paper {i}",
+                )
+            for i in range(2):
+                db.aspect_queue.enqueue(
+                    "rdr__test-aaaaaaaa",
+                    f"/rdrs/r{i}.md",
+                    content=f"---\ntitle: r{i}\n---\nbody",
+                )
+
+        batch_calls: list[int] = []
+        single_calls: list[str] = []
+
+        def fake_batch(items):
+            batch_calls.append(len(items))
+            raise AssertionError(
+                "batch path must NOT fire on heterogeneous configs"
+            )
+
+        def fake_single(content, source_path, collection, **_kw):
+            single_calls.append(source_path)
+            return AspectRecord(
+                collection=collection, source_path=source_path,
+                problem_formulation=f"P-{source_path}",
+                proposed_method="M",
+                experimental_datasets=["d"],
+                experimental_baselines=["b"],
+                experimental_results="R",
+                extras={}, confidence=0.9,
+                extracted_at="2026-05-06T00:00:00+00:00",
+                model_version="claude-haiku-4-5-20251001",
+                extractor_name="scholarly-paper-v1",
+            )
+
+        with patch("nexus.aspect_worker._extract_aspects_batch", fake_batch), \
+             patch("nexus.aspect_worker._extract_aspects", fake_single):
+            worker = AspectExtractionWorker(
+                poll_interval=0.05, batch_size=5,
+            )
+            worker.start()
+            try:
+                _wait_until(
+                    lambda: _queue_size(_isolate_t2) == 0, timeout=5.0,
+                )
+            finally:
+                worker.stop(timeout=5.0)
+
+        # Batch never fired — heterogeneity detected first.
+        assert batch_calls == []
+        # All 5 rows went through the single-row path.
+        assert sorted(single_calls) == sorted([
+            "/papers/p0.pdf", "/papers/p1.pdf", "/papers/p2.pdf",
+            "/rdrs/r0.md", "/rdrs/r1.md",
+        ])


### PR DESCRIPTION
## Summary

- `claim_batch` grabs FIFO rows across collection boundaries; when a `knowledge__` row sits in the queue alongside an `rdr__` row, the resulting batch crosses `ExtractorConfig` boundaries.
- `extract_aspects_batch` enforces single-config homogeneity and raises `ValueError`, marking the entire batch failed even though each row would have succeeded on its own.
- Eight rows had accumulated in `status=failed` since 2026-05-04 from this cause (surfaced during the 4.25.3 live shakeout, 2026-05-06).

The fix detects heterogeneity at the top of `_process_batch` and falls back to per-row processing. Homogeneous batches keep the existing amortised path.

## Test plan

- [x] New test `TestBatchPath::test_worker_falls_through_to_per_row_on_heterogeneous_batch` — 3 `knowledge__` + 2 `rdr__` rows enqueued together; asserts batch path never invoked and all 5 land via single path. Verified RED before fix, GREEN after.
- [x] Full `test_aspect_worker.py` suite: 14/14 pass.
- [x] Broader `test_aspect_extractor.py` + `test_aspect_extraction_queue.py`: 76/76 pass.
- [ ] Integration: after merge + reinstall + MCP restart, confirm the 8 reset-to-pending rows drain via the fix path on next worker tick.

## Bead

nexus-nncy