### PR TITLE
fix(aspect-queue): normalize last_attempt_at in reclaim_stale SQL (nexus-7yoz)

### DIFF
--- a/src/nexus/db/t2/aspect_extraction_queue.py
+++ b/src/nexus/db/t2/aspect_extraction_queue.py
@@ -423,6 +423,14 @@ class AspectExtractionQueue:
         timeout matches a generous extraction wall-clock.
 
         Returns the number of rows reclaimed.
+
+        ``last_attempt_at`` is wrapped in ``datetime()`` to normalize
+        the comparison: production writes ISO 8601 with ``T`` separator
+        and ``+00:00`` suffix (``datetime.now(UTC).isoformat()``), while
+        SQLite's ``datetime('now', ...)`` returns space-separated, no-tz
+        format. Without normalization, lexicographic compare fails
+        (``'T' (0x54) > ' ' (0x20)``) and reclaim matches zero rows
+        regardless of staleness.
         """
         cutoff_clause = f"datetime('now', '-{int(timeout_seconds)} seconds')"
         with self._lock:
@@ -430,7 +438,7 @@ class AspectExtractionQueue:
                 "UPDATE aspect_extraction_queue "
                 "SET status = 'pending', last_attempt_at = NULL "
                 "WHERE status = 'in_progress' "
-                f"  AND last_attempt_at < {cutoff_clause}",
+                f"  AND datetime(last_attempt_at) < {cutoff_clause}",
             )
             self.conn.commit()
             return cur.rowcount

--- a/tests/test_aspect_extraction_queue.py
+++ b/tests/test_aspect_extraction_queue.py
@@ -375,6 +375,55 @@ class TestReclaimStale:
         assert reclaimed == 0
         assert row[0] == "in_progress"
 
+    def test_reclaim_stale_handles_iso8601_timezone_format(
+        self, tmp_path: Path,
+    ) -> None:
+        """Production writes ``last_attempt_at`` as
+        ``datetime.now(UTC).isoformat()`` which produces e.g.
+        ``2026-05-06T03:01:51.332866+00:00`` (T separator, +00:00
+        suffix, microseconds). SQLite's ``datetime('now', '-N seconds')``
+        returns ``2026-05-06 10:01:54`` (space, no timezone). String
+        compare fails: ``'T' (0x54) > ' ' (0x20)``, so all in_progress
+        rows of production format sort AFTER the cutoff and never
+        match the WHERE clause — reclaim returns 0 regardless of
+        staleness.
+
+        Pre-fix repro: this test fails (reclaim_stale returns 0).
+        Bug found in 4.25.3 shakeout 2026-05-06 (nexus-7yoz).
+        """
+        from datetime import datetime, timedelta, timezone
+
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        store = AspectExtractionQueue(tmp_path / "t2.db")
+        try:
+            store.enqueue("knowledge__delos", "/p1.pdf")
+            store.claim_next()
+            # Inject a stale timestamp using the EXACT format production
+            # uses (datetime.now(UTC).isoformat() — T separator, +00:00).
+            stale_ts = (
+                datetime.now(timezone.utc) - timedelta(seconds=600)
+            ).isoformat()
+            store.conn.execute(
+                "UPDATE aspect_extraction_queue SET last_attempt_at = ?",
+                (stale_ts,),
+            )
+            store.conn.commit()
+
+            reclaimed = store.reclaim_stale(timeout_seconds=60)
+            row = store.conn.execute(
+                "SELECT status, last_attempt_at "
+                "FROM aspect_extraction_queue"
+            ).fetchone()
+        finally:
+            store.close()
+        assert reclaimed == 1, (
+            "reclaim_stale must match production-formatted ISO 8601 "
+            "timestamps with timezone suffix"
+        )
+        assert row[0] == "pending"
+        assert row[1] is None
+
 
 # ── Pending count + listing ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `reclaim_stale` SQL compares `last_attempt_at < datetime('now', '-N seconds')`. Production writes `last_attempt_at` via `datetime.now(UTC).isoformat()` (`2026-05-06T03:01:51.332866+00:00`), but SQLite's `datetime('now', ...)` returns `2026-05-06 10:01:54`. String compare fails because `'T' (0x54) > ' ' (0x20)`.
- Effect: `reclaim_stale` matches zero rows in production regardless of staleness. Worker process death leaves rows orphaned forever.
- Found during 4.25.3 shakeout 2026-05-06: 5 rows in_progress for 6.85 hours despite 300s reclaim timeout. Repro on the live DB confirmed `WHERE ... last_attempt_at < cutoff` returns 0; wrapping `datetime(last_attempt_at)` returns 5.

The fix wraps `last_attempt_at` in SQLite's `datetime()` so both formats normalize before comparison. Single SQL change.

## Test plan

- [x] New test `TestReclaimStale::test_reclaim_stale_handles_iso8601_timezone_format` injects `last_attempt_at` via `datetime.now(UTC).isoformat()` (matching production format) and asserts `reclaim_stale` returns 1. RED before fix, GREEN after.
- [x] Existing `TestReclaimStale` tests still pass (3/3).
- [x] Full `test_aspect_extraction_queue.py` suite: 27/27 pass.

## Why existing tests didn't catch this

Both prior tests inject `last_attempt_at` via SQL `datetime('now', '-N minutes')`, which produces the same space-separated format as the cutoff. The compare worked in tests but always failed in production because real writes use Python's `isoformat()`. The new test mirrors production format.

## Bead

nexus-7yoz