### PR TITLE
test(integration): accept 'cannot be answered' as graceful-degrade marker

### DIFF
--- a/tests/integration/test_nx_answer_equivalence.py
+++ b/tests/integration/test_nx_answer_equivalence.py
@@ -165,7 +165,7 @@ class TestGracefulDegradation:
             # Inline-planner graceful-degrade: recognises it can't answer
             "no real-time", "no weather", "out of scope",
             "not available", "does not contain", "no information",
-            "cannot answer", "unable to", "no data",
+            "cannot answer", "cannot be answered", "unable to", "no data",
             "no results", "no documents",
         )
         assert any(m in lowered for m in accepted_markers), (


### PR DESCRIPTION
## Summary

- ``test_plan_miss_returns_clear_message`` had ``cannot answer`` in its accepted-marker tuple but missed the passive ``cannot be answered``. The inline-planner's natural response uses the passive voice (``"The current weather in Tokyo cannot be answered from this retrieval system"``), so the substring check failed even though the response was a textbook graceful-degrade.
- Pre-existing brittleness; surfaced now because the 4.25.3 shakeout deleted the user-saved ``weather-tokyo-right-now`` plan that previously made this question hit the saved-plan path.

## Test plan

- [x] Failing test now passes 3 consecutive times in isolation.
- [x] Other graceful-degrade markers preserved.

Required for 4.25.4 release (full integration suite must be green pre-tag).