### PR TITLE
feat(telemetry): tier_writes T2 table + recording in MCP write tools (nexus-kren)

### DIFF
--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -307,6 +307,49 @@ def _add_projection_quality_columns(conn: sqlite3.Connection) -> None:
         conn.commit()
 
 
+def migrate_tier_writes(conn: sqlite3.Connection) -> None:
+    """Create the ``tier_writes`` table for tier-discipline telemetry (nexus-kren).
+
+    One row per call to a tier-write MCP tool (memory_put, scratch put,
+    store_put, plan_save). Records (session_id, ts, tool, tier, agent,
+    project, target_title) so that ``nx tier-status`` can audit per-
+    session discipline and ``nx doctor --check-tier-discipline`` can
+    flag substantive sessions with no write-back.
+
+    Phase 1 of the tier-discipline restoration initiative. Past mining
+    of 2622 transcripts (memory: past-conversation-mining-2026-05-06)
+    showed only 1.7% of pre-trim sessions wrote back; PR #519's
+    surgical hook restoration was only possible because the trim left
+    a measurable footprint. This table is the equivalent measurement
+    rung for today's restorations.
+
+    Idempotent — no-op if the table already exists. Called lazily from
+    ``_record_tier_write`` so the table is created on first use.
+    """
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='tier_writes'"
+    ).fetchone()
+    if row is not None:
+        return
+    conn.executescript("""
+        CREATE TABLE tier_writes (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id   TEXT    NOT NULL,
+            ts           TEXT    NOT NULL,
+            tool         TEXT    NOT NULL,
+            tier         TEXT    NOT NULL,
+            agent        TEXT,
+            project      TEXT,
+            target_title TEXT
+        );
+        CREATE INDEX idx_tier_writes_session ON tier_writes(session_id);
+        CREATE INDEX idx_tier_writes_ts      ON tier_writes(ts);
+        CREATE INDEX idx_tier_writes_tool    ON tier_writes(tool);
+    """)
+    conn.commit()
+    _log.info("Migrated: created tier_writes table (nexus-kren)")
+
+
 def migrate_nx_answer_runs(conn: sqlite3.Connection) -> None:
     """Create the ``nx_answer_runs`` table for RDR-080 run telemetry.
 
@@ -1836,6 +1879,11 @@ MIGRATIONS: list[Migration] = [
         "4.21.4",
         "Create frecency projection table (RDR-101 Phase 1 PR D nexus-knn3)",
         migrate_frecency_projection_table,
+    ),
+    Migration(
+        "4.25.5",
+        "Create tier_writes table (Phase 1A tier-discipline telemetry, nexus-kren)",
+        migrate_tier_writes,
     ),
 ]
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -362,6 +362,65 @@ def _clamp_subagent_timeout(requested: float, tool_name: str) -> float:
         return _SUBAGENT_TIMEOUT_FLOOR
     return requested
 
+
+# ── Tier-discipline telemetry (Phase 1A nexus-kren) ─────────────────────────
+
+
+def _record_tier_write(
+    *,
+    tool: str,
+    tier: str,
+    agent: str | None = None,
+    project: str | None = None,
+    target_title: str | None = None,
+) -> None:
+    """Append one row to ``tier_writes`` recording a tier-write call.
+
+    Best-effort: any exception is swallowed. Telemetry must NEVER break
+    the hot path of the calling tool. ``session_id`` resolves from
+    ``NX_SESSION_ID`` env, then ``read_claude_session_id()``, then
+    ``"unknown"`` as a last-resort sentinel so rows are never lost.
+
+    Phase 1A of the tier-discipline restoration initiative
+    (memory: tier-discipline-audit-2026-05-06).
+
+    Lazy imports inside this function so monkey-patches of
+    ``nexus.mcp_infra.t2_ctx`` in tests are picked up at call time
+    rather than frozen at module-import time.
+    """
+    try:
+        import os
+        from datetime import datetime, timezone
+
+        from nexus.db.migrations import migrate_tier_writes
+        from nexus.mcp_infra import t2_ctx
+        from nexus.session import read_claude_session_id
+
+        session_id = (
+            os.environ.get("NX_SESSION_ID", "").strip()
+            or read_claude_session_id()
+            or "unknown"
+        )
+        ts = datetime.now(timezone.utc).isoformat()
+        with t2_ctx() as t2:
+            # Any domain conn points at the same SQLite file; reuse the
+            # taxonomy connection because it is constructed eagerly and
+            # carries the per-store lock semantics this insert needs.
+            conn = t2.taxonomy.conn
+            with t2.taxonomy._lock:
+                migrate_tier_writes(conn)
+                conn.execute(
+                    "INSERT INTO tier_writes "
+                    "(session_id, ts, tool, tier, agent, project, target_title) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (session_id, ts, tool, tier, agent, project, target_title),
+                )
+                conn.commit()
+    except Exception:
+        # Best-effort. Telemetry breaking a tool call is the worst kind of regression.
+        pass
+
+
 # ── Post-store hooks (register once at import) ──────────────────────────────
 #
 # RDR-095 + symmetric-fire follow-up: every storage event (MCP store_put or
@@ -1011,6 +1070,10 @@ def store_put(
         except Exception:
             import structlog
             structlog.get_logger().debug("relevance_log_store_failed", exc_info=True)
+        _record_tier_write(
+            tool="store_put", tier="T3",
+            target_title=title or doc_id,
+        )
         return f"Stored: {doc_id} -> {col_name}"
     except Exception as e:
         return f"Error: {e}"
@@ -1383,6 +1446,10 @@ def memory_put(
                 tags=tags,
                 ttl=ttl if ttl > 0 else None,
             )
+        _record_tier_write(
+            tool="memory_put", tier="T2",
+            project=project, target_title=title,
+        )
         return f"Stored: [{row_id}] {project}/{title}"
     except Exception as e:
         return f"Error: {e}"
@@ -1633,6 +1700,10 @@ def scratch(
             if not content:
                 return "Error: content is required for put"
             doc_id = t1.put(content=content, tags=tags)
+            _record_tier_write(
+                tool="scratch_put", tier="T1",
+                target_title=tags or doc_id,
+            )
             return f"{prefix}Stored: {doc_id}"
 
         elif action == "search":
@@ -1778,6 +1849,10 @@ def plan_save(
                 ttl=ttl,
                 scope_tags=scope_tags or None,
             )
+        _record_tier_write(
+            tool="plan_save", tier="plan",
+            project=project, target_title=query[:80],
+        )
         return f"Saved plan: [{row_id}] {query[:80]}"
     except Exception as e:
         return f"Error: {e}"

--- a/tests/test_tier_writes.py
+++ b/tests/test_tier_writes.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Phase 1A tier-discipline telemetry (nexus-kren).
+
+Covers:
+- Migration creates ``tier_writes`` table + indexes, idempotent.
+- ``_record_tier_write`` inserts rows correctly.
+- ``_record_tier_write`` swallows exceptions (telemetry must NEVER
+  break the hot path).
+- Wired-in MCP write tools (memory_put, store_put, scratch put,
+  plan_save) emit one row per call.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+# ── Migration ────────────────────────────────────────────────────────────────
+
+
+class TestMigration:
+    def test_creates_table_with_expected_columns(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_tier_writes
+
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        try:
+            migrate_tier_writes(conn)
+            cols = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(tier_writes)")
+            }
+        finally:
+            conn.close()
+        expected = {
+            "id", "session_id", "ts", "tool", "tier",
+            "agent", "project", "target_title",
+        }
+        assert expected.issubset(cols), f"missing columns: {expected - cols}"
+
+    def test_creates_three_indexes(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_tier_writes
+
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        try:
+            migrate_tier_writes(conn)
+            indexes = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='index' AND tbl_name='tier_writes'"
+                )
+            }
+        finally:
+            conn.close()
+        assert "idx_tier_writes_session" in indexes
+        assert "idx_tier_writes_ts" in indexes
+        assert "idx_tier_writes_tool" in indexes
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        """Second call must be a clean no-op (no exception, no double-create)."""
+        from nexus.db.migrations import migrate_tier_writes
+
+        conn = sqlite3.connect(str(tmp_path / "t.db"))
+        try:
+            migrate_tier_writes(conn)
+            migrate_tier_writes(conn)  # must not raise
+            count = conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='tier_writes'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 1
+
+
+# ── Recorder helper ──────────────────────────────────────────────────────────
+
+
+class TestRecorder:
+    def test_inserts_row_with_all_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Happy path: helper writes one row with all caller-supplied fields."""
+        import nexus.mcp_infra as infra
+        from nexus.db.t2 import T2Database
+        from nexus.mcp.core import _record_tier_write
+
+        db_path = tmp_path / "t.db"
+        monkeypatch.setattr(infra, "t2_ctx", lambda: T2Database(db_path))
+        monkeypatch.setenv("NX_SESSION_ID", "test-session-abc")
+
+        _record_tier_write(
+            tool="memory_put", tier="T2",
+            agent="developer", project="nexus", target_title="my-finding",
+        )
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT session_id, tool, tier, agent, project, target_title "
+                "FROM tier_writes"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row == (
+            "test-session-abc", "memory_put", "T2",
+            "developer", "nexus", "my-finding",
+        )
+
+    def test_swallows_exceptions_when_t2_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Helper MUST NOT raise into the caller's hot path even if T2
+        access fails. Telemetry breaking a tool call is the worst kind
+        of regression."""
+        import nexus.mcp_infra as infra
+        from nexus.mcp.core import _record_tier_write
+
+        def boom():
+            raise RuntimeError("simulated t2_ctx failure")
+
+        monkeypatch.setattr(infra, "t2_ctx", boom)
+
+        # Must not raise.
+        _record_tier_write(tool="memory_put", tier="T2")
+
+    def test_session_id_falls_back_when_env_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When NX_SESSION_ID is unset and read_claude_session_id returns
+        None, helper writes 'unknown' rather than failing or skipping."""
+        import nexus.mcp_infra as infra
+        from nexus.db.t2 import T2Database
+        from nexus.mcp.core import _record_tier_write
+
+        db_path = tmp_path / "t.db"
+        monkeypatch.setattr(infra, "t2_ctx", lambda: T2Database(db_path))
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        # Simulate no session file.
+        import nexus.session as ses
+        monkeypatch.setattr(ses, "read_claude_session_id", lambda: None)
+
+        _record_tier_write(tool="scratch_put", tier="T1")
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            sid = conn.execute(
+                "SELECT session_id FROM tier_writes"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert sid == "unknown"
+
+
+# ── Wired MCP write tools ────────────────────────────────────────────────────
+
+
+class TestWiring:
+    """Verify each tier-write MCP tool emits one tier_writes row per call.
+
+    These tests instantiate the MCP tools against a tmp T2 and assert
+    a row landed. Failures here mean the tool was changed without
+    updating the recorder wire-up.
+    """
+
+    def _setup(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        import nexus.mcp_infra as infra
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "t.db"
+        monkeypatch.setattr(infra, "t2_ctx", lambda: T2Database(db_path))
+        monkeypatch.setenv("NX_SESSION_ID", "wire-test")
+        return db_path
+
+    def _tier_writes(self, db_path: Path) -> list[tuple]:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            return list(conn.execute(
+                "SELECT tool, tier, project, target_title FROM tier_writes "
+                "ORDER BY id"
+            ))
+        finally:
+            conn.close()
+
+    def test_memory_put_records_T2(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        db_path = self._setup(tmp_path, monkeypatch)
+        from nexus.mcp.core import memory_put
+
+        memory_put(
+            content="hello", project="nexus", title="t1", tags="x", ttl=30,
+        )
+
+        rows = self._tier_writes(db_path)
+        assert ("memory_put", "T2", "nexus", "t1") in rows
+
+    def test_scratch_put_records_T1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """scratch action='put' writes T1; other actions (search/list)
+        do NOT emit a row (writes only)."""
+        db_path = self._setup(tmp_path, monkeypatch)
+        from nexus.mcp.core import scratch
+
+        scratch(action="put", content="ephemeral hypothesis", tags="probe")
+
+        rows = self._tier_writes(db_path)
+        tools = [r[0] for r in rows]
+        assert "scratch_put" in tools
+        assert all(r[1] == "T1" for r in rows if r[0] == "scratch_put")
+
+    def test_plan_save_records_plan_tier(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """plan_save writes tier='plan' (distinct from T2 because plan
+        retrieval / cold-start cost is the metric being tracked)."""
+        db_path = self._setup(tmp_path, monkeypatch)
+        from nexus.mcp.core import plan_save
+
+        plan_save(
+            query="how does X relate to Y in the catalog",
+            plan_json='{"steps":[{"tool":"search","args":{"query":"$intent"}}]}',
+            project="nexus",
+            tags="search",
+        )
+
+        rows = self._tier_writes(db_path)
+        plan_rows = [r for r in rows if r[0] == "plan_save"]
+        assert len(plan_rows) == 1
+        assert plan_rows[0][1] == "plan"
+        assert plan_rows[0][2] == "nexus"  # project


### PR DESCRIPTION
## Summary

Phase 1A of the tier-discipline restoration initiative. Adds per-call telemetry for the four tier-write MCP tools (``memory_put``, ``store_put``, ``scratch put``, ``plan_save``) so we can measure whether the restorations from PR #519 and PR #521 durably change behaviour.

## Why

Past mining of 2622 session transcripts shows only 1.7% of pre-trim sessions wrote back — the "working" baseline was always thin and lived in a tail of high-value sessions. PR #519's surgical hook restoration was only possible because PR #320 left a measurable footprint (search_telemetry + nx_answer_runs). Today's restorations have no equivalent measurement rung for tier-discipline. This bead adds it.

## Changes

- ``migrate_tier_writes`` (registered at 4.25.5) creates ``tier_writes`` (id, session_id, ts, tool, tier, agent, project, target_title) + three indexes.
- ``_record_tier_write`` helper in ``src/nexus/mcp/core.py``. Best-effort, swallows exceptions, lazy imports for test friendliness.
- Wired into 4 MCP write tools: memory_put → T2, store_put → T3, scratch put → T1, plan_save → plan.

## Test plan

- [x] Migration creates table + three indexes; idempotent on re-run.
- [x] Recorder happy path: row lands with all fields.
- [x] Recorder swallows exceptions when T2 unavailable (telemetry never breaks hot path).
- [x] Session-id fallback chain: env → claude_session_file → 'unknown'.
- [x] Wired tools: ``memory_put``, ``scratch put``, ``plan_save`` each emit one row.
- [x] No regression in 187 adjacent tests (test_memory, test_mcp_server, test_mcp_store_put_doc_id, test_plan_bundle).

## Out of scope

Phase 1B (nexus-a52i): ``nx tier-status`` CLI, ``nx doctor --check-tier-discipline``, SessionEnd hook summary.

Subagent attribution wire-up: blocked on nexus-9clx (memory_put + scratch_put accepting agent / session kwargs).

Bead: nexus-kren