### PR TITLE
feat(cli): nx tier-status + doctor --check-tier-discipline (nexus-a52i)

### DIFF
--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -21,6 +21,7 @@ from nexus.commands.search_cmd import search_cmd
 from nexus.commands.store import store
 from nexus.commands.t3 import t3 as t3_group
 from nexus.commands.taxonomy_cmd import taxonomy
+from nexus.commands.tier_status import tier_status_cmd
 from nexus.commands.upgrade import upgrade
 
 @click.group()
@@ -67,4 +68,5 @@ main.add_command(search_cmd, name="search")
 main.add_command(store)
 main.add_command(t3_group, name="t3")
 main.add_command(taxonomy)
+main.add_command(tier_status_cmd, name="tier-status")
 main.add_command(upgrade)

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -700,6 +700,91 @@ def _run_check_aspect_queue() -> None:
         conn.close()
 
 
+# ── --check-tier-discipline (nexus-a52i) ─────────────────────────────────────
+
+
+def _run_check_tier_discipline() -> None:
+    """Audit tier-write activity for the current session.
+
+    Reads ``tier_writes`` from T2 and prints the same summary as
+    ``nx tier-status`` for the current session, plus a structured
+    warning when a session has zero tier writes (a soft signal that
+    the session may have produced findings without persisting them).
+
+    Heuristic only — does NOT exit non-zero. Visibility, not
+    enforcement.
+    """
+    import os as _os
+    import sqlite3 as _sqlite3
+    from pathlib import Path as _Path
+
+    from nexus.commands._helpers import default_db_path as _default_db_path
+    from nexus.session import read_claude_session_id as _read_claude_session_id
+
+    session_id = (
+        _os.environ.get("NX_SESSION_ID", "").strip()
+        or _read_claude_session_id()
+    )
+    if not session_id:
+        click.echo("Tier-discipline check:")
+        click.echo("  No current session resolvable (skip).")
+        return
+
+    db_path = _default_db_path()
+    if not _Path(db_path).exists():
+        click.echo("Tier-discipline check:")
+        click.echo(f"  T2 database not found at {db_path} (skip).")
+        return
+
+    conn = _sqlite3.connect(str(db_path))
+    try:
+        has_table = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='tier_writes'"
+        ).fetchone()
+        if not has_table:
+            click.echo("Tier-discipline check:")
+            click.echo("  tier_writes table not yet initialised (no writes seen).")
+            return
+        rows = conn.execute(
+            "SELECT tier, COUNT(*) FROM tier_writes "
+            "WHERE session_id = ? GROUP BY tier",
+            (session_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    by_tier = {tier: n for tier, n in rows}
+    total = sum(by_tier.values())
+
+    click.echo(f"Tier-discipline check (session {session_id}):")
+    if total == 0:
+        click.echo(
+            "  WARNING: zero tier writes recorded for this session. "
+            "Findings produced (if any) have not been persisted."
+        )
+        click.echo(
+            "  Run with `nx tier-status --session " + session_id +
+            "` for the structured view."
+        )
+        click.echo(
+            "  Pass --json for downstream tooling. Use `nx memory put`, "
+            "`nx scratch put`, or the MCP equivalents to write back."
+        )
+        return
+
+    click.echo(f"  total writes: {total}")
+    for tier in ("T1", "T2", "T3", "plan"):
+        n = by_tier.get(tier, 0)
+        if n:
+            click.echo(f"    {tier:<6} {n}")
+    if all(by_tier.get(t, 0) == 0 for t in ("T2", "T3")):
+        click.echo(
+            "  NOTE: writes are T1/plan only. No persistent (T2/T3) "
+            "write-back yet — durable findings are not surfaced."
+        )
+
+
 # ── --check-post-store-hooks (nexus-b0ka) ────────────────────────────────────
 
 
@@ -915,6 +1000,16 @@ def _run_check_mineru() -> None:
          "Linux/Windows. RDR-094 Phase H (nexus-50u5).",
 )
 @click.option(
+    "--check-tier-discipline",
+    "check_tier_discipline",
+    is_flag=True,
+    default=False,
+    help="Audit tier-write activity for the current session: prints "
+         "the tier-write summary from the tier_writes table and "
+         "warns when a substantive session has no write-back. "
+         "Phase 1B nexus-a52i.",
+)
+@click.option(
     "--mcp-log-hours",
     "mcp_log_hours",
     default=24,
@@ -992,7 +1087,8 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                json_out: bool,
                trim_telemetry: bool, days: int,
                check_post_store_hooks: bool,
-               check_aspect_queue: bool) -> None:
+               check_aspect_queue: bool,
+               check_tier_discipline: bool) -> None:
     """Verify that all required services and credentials are available."""
     if check_schema:
         _run_check_schema()
@@ -1041,6 +1137,10 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if check_aspect_queue:
         _run_check_aspect_queue()
+        return
+
+    if check_tier_discipline:
+        _run_check_tier_discipline()
         return
 
     if fix:

--- a/src/nexus/commands/tier_status.py
+++ b/src/nexus/commands/tier_status.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""``nx tier-status`` — audit tier-write activity per session.
+
+Phase 1B of the tier-discipline restoration initiative (nexus-a52i,
+follow-up to Phase 1A's ``tier_writes`` telemetry table at nexus-kren).
+
+Reads the ``tier_writes`` T2 table populated by ``_record_tier_write``
+in ``src/nexus/mcp/core.py``. By default reports the current session
+(via ``NX_SESSION_ID`` env or ``read_claude_session_id()``); other
+modes select by id, last-N, or time window.
+"""
+from __future__ import annotations
+
+import json as _json
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import click
+
+from nexus.commands._helpers import default_db_path
+from nexus.session import read_claude_session_id
+
+
+# Tier semantics — the order callers care about (T1 sibling-bus first,
+# then persistent T2/T3, then plan-library writes which sit in T2 but
+# carry distinct semantics for cold-start cost analysis).
+_TIER_ORDER = ("T1", "T2", "T3", "plan")
+_TOOL_TIER = {
+    "scratch_put": "T1",
+    "memory_put": "T2",
+    "store_put": "T3",
+    "plan_save": "plan",
+}
+
+
+def _resolve_session(session_arg: str | None) -> str | None:
+    """Return the session_id to query, or None for 'no specific session'."""
+    if session_arg:
+        return session_arg
+    env_sid = os.environ.get("NX_SESSION_ID", "").strip()
+    if env_sid:
+        return env_sid
+    return read_claude_session_id()
+
+
+def _query(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str | None,
+    since_ts: str | None,
+    last_n: int | None,
+) -> list[tuple[str, str, str | None, str | None, int]]:
+    """Return rows of ``(tool, tier, agent, project, count)`` filtered
+    by the requested criteria.
+
+    Filter precedence: ``last_n`` > ``session_id`` > ``since_ts``. At most
+    one path applies per call; the CLI surface enforces mutual exclusion
+    upstream.
+    """
+    if last_n:
+        recent_sids = [
+            r[0] for r in conn.execute(
+                "SELECT DISTINCT session_id FROM tier_writes "
+                "ORDER BY ts DESC LIMIT ?",
+                (last_n,),
+            )
+        ]
+        if not recent_sids:
+            return []
+        placeholders = ",".join("?" for _ in recent_sids)
+        rows = conn.execute(
+            f"SELECT tool, tier, agent, project, COUNT(*) "
+            f"FROM tier_writes "
+            f"WHERE session_id IN ({placeholders}) "
+            f"GROUP BY tool, tier, agent, project "
+            f"ORDER BY tier, tool",
+            recent_sids,
+        ).fetchall()
+        return rows
+    if session_id:
+        return conn.execute(
+            "SELECT tool, tier, agent, project, COUNT(*) "
+            "FROM tier_writes "
+            "WHERE session_id = ? "
+            "GROUP BY tool, tier, agent, project "
+            "ORDER BY tier, tool",
+            (session_id,),
+        ).fetchall()
+    if since_ts:
+        return conn.execute(
+            "SELECT tool, tier, agent, project, COUNT(*) "
+            "FROM tier_writes "
+            "WHERE datetime(ts) >= datetime(?) "
+            "GROUP BY tool, tier, agent, project "
+            "ORDER BY tier, tool",
+            (since_ts,),
+        ).fetchall()
+    return []
+
+
+def _summarize(rows: list[tuple]) -> dict[str, int]:
+    """Aggregate query rows into per-tier counts."""
+    summary: dict[str, int] = {tier: 0 for tier in _TIER_ORDER}
+    for _tool, tier, _agent, _project, n in rows:
+        if tier in summary:
+            summary[tier] += n
+        else:
+            summary.setdefault("other", 0)
+            summary["other"] += n
+    return summary
+
+
+@click.command("tier-status")
+@click.option(
+    "--session", "session_arg", default=None,
+    help="Specific session_id (default: current session via NX_SESSION_ID).",
+)
+@click.option(
+    "--last", "last_n", type=int, default=None,
+    help="Aggregate the last N sessions (most recent by ts).",
+)
+@click.option(
+    "--since", "since", default=None,
+    help="ISO 8601 timestamp; only count writes at or after this moment.",
+)
+@click.option(
+    "--json", "json_out", is_flag=True, default=False,
+    help="Emit structured JSON instead of the human table.",
+)
+def tier_status_cmd(
+    session_arg: str | None,
+    last_n: int | None,
+    since: str | None,
+    json_out: bool,
+) -> None:
+    """Audit tier-write activity. Phase 1B (nexus-a52i).
+
+    Default mode reports the current session. Override with --session,
+    --last, or --since (mutually exclusive — pick one).
+    """
+    if sum(1 for x in (session_arg, last_n, since) if x) > 1:
+        raise click.UsageError(
+            "--session, --last, and --since are mutually exclusive"
+        )
+
+    db_path = default_db_path()
+    if not Path(db_path).exists():
+        if json_out:
+            click.echo(_json.dumps({"error": "T2 database not found", "path": str(db_path)}))
+        else:
+            click.echo(f"T2 database not found at {db_path}.", err=True)
+        raise click.exceptions.Exit(1)
+
+    target_session = None
+    if not (last_n or since):
+        target_session = _resolve_session(session_arg)
+        if target_session is None and not session_arg:
+            if json_out:
+                click.echo(_json.dumps({"error": "no current session resolvable"}))
+            else:
+                click.echo(
+                    "No current session resolvable "
+                    "(NX_SESSION_ID env unset, no claude session file). "
+                    "Use --session, --last, or --since.",
+                    err=True,
+                )
+            raise click.exceptions.Exit(1)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # Migration is lazy in the recorder path; if no writes have ever
+        # been recorded the table won't exist. Treat as zero.
+        has_table = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='tier_writes'"
+        ).fetchone()
+        if not has_table:
+            rows = []
+        else:
+            rows = _query(
+                conn,
+                session_id=target_session,
+                since_ts=since,
+                last_n=last_n,
+            )
+    finally:
+        conn.close()
+
+    summary = _summarize(rows)
+    total = sum(summary.values())
+
+    if json_out:
+        payload = {
+            "scope": (
+                "last_n" if last_n
+                else "since" if since
+                else "session"
+            ),
+            "session_id": target_session,
+            "last_n": last_n,
+            "since": since,
+            "total_writes": total,
+            "by_tier": summary,
+            "rows": [
+                {"tool": t, "tier": ti, "agent": a, "project": p, "count": n}
+                for t, ti, a, p, n in rows
+            ],
+        }
+        click.echo(_json.dumps(payload, indent=2))
+        return
+
+    # Human table.
+    scope_label = (
+        f"last {last_n} session(s)" if last_n
+        else f"since {since}" if since
+        else f"session {target_session}"
+    )
+    click.echo(f"tier-write activity ({scope_label}):")
+    if total == 0:
+        click.echo("  (no writes)")
+        return
+    click.echo(f"  total: {total}")
+    for tier in _TIER_ORDER:
+        n = summary.get(tier, 0)
+        if n:
+            click.echo(f"    {tier:<6} {n}")
+    if rows:
+        click.echo()
+        click.echo(f"  {'tool':<14} {'tier':<6} {'agent':<14} {'project':<14} count")
+        click.echo(f"  {'-'*14} {'-'*6} {'-'*14} {'-'*14} -----")
+        for tool, tier, agent, project, n in rows:
+            click.echo(
+                f"  {tool:<14} {tier:<6} "
+                f"{(agent or '<none>'):<14} {(project or '<none>'):<14} {n}"
+            )

--- a/tests/test_cli_registration.py
+++ b/tests/test_cli_registration.py
@@ -39,6 +39,7 @@ def test_all_command_modules_registered():
         "mineru": "mineru",
         "search_cmd": "search",
         "taxonomy_cmd": "taxonomy",
+        "tier_status": "tier-status",
     }
 
     missing = []

--- a/tests/test_tier_status_cli.py
+++ b/tests/test_tier_status_cli.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Phase 1B nx tier-status CLI (nexus-a52i).
+
+Covers:
+- Default mode reads NX_SESSION_ID env, queries tier_writes, prints summary.
+- --session, --last, --since, --json modes.
+- Empty / missing-table cases produce clean output (no traceback).
+- Mutual exclusion of --session/--last/--since.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+def _seed_t2(db_path: Path, rows: list[tuple]) -> None:
+    """Insert tier_writes rows into a fresh tmp T2 DB.
+
+    Each row is (session_id, tool, tier, agent, project, target_title).
+    Timestamps auto-stamp at row time.
+    """
+    from nexus.db.migrations import migrate_tier_writes
+    conn = sqlite3.connect(str(db_path))
+    try:
+        migrate_tier_writes(conn)
+        ts = datetime.now(timezone.utc).isoformat()
+        for sid, tool, tier, agent, project, title in rows:
+            conn.execute(
+                "INSERT INTO tier_writes "
+                "(session_id, ts, tool, tier, agent, project, target_title) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (sid, ts, tool, tier, agent, project, title),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def isolated_t2(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect default_db_path to a tmp file."""
+    from nexus.commands import _helpers, tier_status as ts_mod
+    db = tmp_path / "t.db"
+    monkeypatch.setattr(_helpers, "default_db_path", lambda: db)
+    monkeypatch.setattr(ts_mod, "default_db_path", lambda: db)
+    return db
+
+
+class TestDefaultSession:
+    def test_default_uses_env_session_id(
+        self, isolated_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from nexus.commands.tier_status import tier_status_cmd
+
+        _seed_t2(isolated_t2, [
+            ("sess-A", "memory_put", "T2", None, "nexus", "finding-1"),
+            ("sess-A", "memory_put", "T2", None, "nexus", "finding-2"),
+            ("sess-A", "scratch_put", "T1", None, None, "hypothesis"),
+            ("sess-B", "memory_put", "T2", None, "other", "noise"),
+        ])
+
+        monkeypatch.setenv("NX_SESSION_ID", "sess-A")
+        result = CliRunner().invoke(tier_status_cmd, [])
+        assert result.exit_code == 0, result.output
+        assert "session sess-A" in result.output
+        assert "total: 3" in result.output
+        assert "T2" in result.output
+        assert "T1" in result.output
+        # sess-B's row must not leak into sess-A's count
+        assert "noise" not in result.output
+
+    def test_default_no_session_resolvable_exits_clean(
+        self, isolated_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from nexus.commands.tier_status import tier_status_cmd
+
+        # Pre-create the DB so the no-session-resolvable check fires
+        # before the missing-DB check.
+        sqlite3.connect(str(isolated_t2)).close()
+
+        # Ensure no session resolvable.
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        import nexus.commands.tier_status as ts_mod
+        monkeypatch.setattr(ts_mod, "read_claude_session_id", lambda: None)
+
+        result = CliRunner().invoke(tier_status_cmd, [])
+        assert result.exit_code == 1
+        assert "No current session resolvable" in result.output
+
+
+class TestExplicitFlags:
+    def test_session_flag_overrides_env(
+        self, isolated_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from nexus.commands.tier_status import tier_status_cmd
+        _seed_t2(isolated_t2, [
+            ("sess-X", "store_put", "T3", None, None, "permanent"),
+            ("sess-X", "plan_save", "plan", None, "nexus", "research-default"),
+            ("sess-Y", "memory_put", "T2", None, "nexus", "noise"),
+        ])
+        monkeypatch.setenv("NX_SESSION_ID", "sess-Y")  # ignored
+
+        result = CliRunner().invoke(tier_status_cmd, ["--session", "sess-X"])
+        assert result.exit_code == 0, result.output
+        assert "session sess-X" in result.output
+        assert "total: 2" in result.output
+        assert "T3" in result.output
+        assert "plan" in result.output
+        assert "noise" not in result.output
+
+    def test_last_n_aggregates_recent_sessions(self, isolated_t2: Path) -> None:
+        from nexus.commands.tier_status import tier_status_cmd
+        _seed_t2(isolated_t2, [
+            ("sess-1", "memory_put", "T2", None, "nexus", "a"),
+            ("sess-2", "memory_put", "T2", None, "nexus", "b"),
+            ("sess-3", "memory_put", "T2", None, "nexus", "c"),
+        ])
+
+        result = CliRunner().invoke(tier_status_cmd, ["--last", "3"])
+        assert result.exit_code == 0, result.output
+        assert "last 3 session(s)" in result.output
+        assert "total: 3" in result.output
+
+    def test_json_output_is_valid_and_complete(self, isolated_t2: Path) -> None:
+        from nexus.commands.tier_status import tier_status_cmd
+        _seed_t2(isolated_t2, [
+            ("sess-J", "memory_put", "T2", "developer", "nexus", "f1"),
+            ("sess-J", "scratch_put", "T1", None, None, "h1"),
+        ])
+
+        result = CliRunner().invoke(
+            tier_status_cmd, ["--session", "sess-J", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["session_id"] == "sess-J"
+        assert payload["total_writes"] == 2
+        assert payload["by_tier"]["T2"] == 1
+        assert payload["by_tier"]["T1"] == 1
+        assert payload["by_tier"]["T3"] == 0
+        assert any(r["tool"] == "memory_put" and r["agent"] == "developer"
+                   for r in payload["rows"])
+
+    def test_mutually_exclusive_flags(self, isolated_t2: Path) -> None:
+        from nexus.commands.tier_status import tier_status_cmd
+        result = CliRunner().invoke(
+            tier_status_cmd, ["--session", "x", "--last", "5"],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+
+class TestEmptyOrMissing:
+    def test_empty_session_prints_no_writes(
+        self, isolated_t2: Path,
+    ) -> None:
+        """Session with zero tier_writes prints '(no writes)' rather than
+        empty output or traceback."""
+        from nexus.commands.tier_status import tier_status_cmd
+        _seed_t2(isolated_t2, [
+            ("populated-sess", "memory_put", "T2", None, "nexus", "x"),
+        ])
+
+        result = CliRunner().invoke(
+            tier_status_cmd, ["--session", "empty-sess"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "no writes" in result.output
+
+    def test_missing_table_treated_as_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If tier_writes table doesn't exist (no recorder writes ever),
+        CLI prints zero rather than erroring on missing table."""
+        from nexus.commands import _helpers, tier_status as ts_mod
+        from nexus.commands.tier_status import tier_status_cmd
+
+        # Empty DB — no tier_writes table.
+        db = tmp_path / "empty.db"
+        sqlite3.connect(str(db)).close()
+        monkeypatch.setattr(_helpers, "default_db_path", lambda: db)
+        monkeypatch.setattr(ts_mod, "default_db_path", lambda: db)
+
+        result = CliRunner().invoke(
+            tier_status_cmd, ["--session", "any-sess"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "no writes" in result.output


### PR DESCRIPTION
## Summary

Phase 1B of the tier-discipline restoration initiative. Surfaces the ``tier_writes`` telemetry from Phase 1A (#525) to the user.

- ``nx tier-status``: per-session / per-window / aggregate tier-write report. Default reports the current session via ``NX_SESSION_ID`` env or ``read_claude_session_id``. ``--session``, ``--last``, ``--since`` override (mutually exclusive). ``--json`` for downstream tooling.
- ``nx doctor --check-tier-discipline``: audits current session, prints the tier-write summary, emits a soft warning when zero writes are recorded for a substantive session. Heuristic only; never exits non-zero.

## Why

Phase 1A captured the data. Phase 1B makes it visible. With these in place we can iterate the restoration the way PR #519 was iterated — telemetry-driven adjustment instead of guessing.

## Test plan

- [x] 8 CLI tests cover env-driven default, explicit flags, --json envelope, mutual-exclusion error, empty session, missing-table fall-through.
- [x] Live smoke against production T2 returns the real summary.
- [x] No regression in 129 adjacent tests (test_doctor_check_mcp_logs, test_doctor_post_store_hooks, test_memory, test_plan_bundle).

## Out of scope

SessionEnd hook tier-write summary: the launcher double-forks before any output reaches Claude Code, so a synchronous summary needs separate plumbing. Filed in nexus-a52i notes for follow-up.

Bead: nexus-a52i