### PR TITLE
feat(memory_put): accept agent + session kwargs (nexus-9clx)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1425,6 +1425,8 @@ def memory_put(
     title: str,
     tags: str = "",
     ttl: int = 30,
+    agent: str = "",
+    session: str = "",
 ) -> str:
     """Store a memory entry in T2 (SQLite). Upserts by (project, title).
 
@@ -1434,10 +1436,31 @@ def memory_put(
         title: Entry title (unique within project)
         tags: Comma-separated tags
         ttl: Time-to-live in days (default 30, 0 for permanent)
+        agent: Optional subagent / role attribution (e.g. "developer",
+            "architect-planner"). When empty, falls back to
+            ``NX_AGENT`` env, then NULL. Phase 1B (nexus-9clx) — lets
+            ``nx tier-status`` slice tier writes by which agent did
+            the persisting.
+        session: Optional explicit session_id override. When empty,
+            falls back to the parent's session_id resolution chain
+            (``NX_SESSION_ID`` env → claude session file → NULL).
     """
     try:
         if not content:
             return "Error: content is required"
+        # Translate empty strings to None so MemoryStore.put's
+        # fall-back chain (NX_AGENT env, _read_session_id) takes
+        # over rather than persisting literal empty strings.
+        agent_arg = agent if agent else None
+        # Resolve session at the MCP layer so NX_SESSION_ID env wins
+        # over MemoryStore's legacy getsid-file fall-back. Subagents
+        # carry NX_SESSION_ID set by claude_dispatch (RDR-094); the
+        # legacy file is only present in non-MCP contexts.
+        if session:
+            session_arg: str | None = session
+        else:
+            import os as _os
+            session_arg = _os.environ.get("NX_SESSION_ID", "").strip() or None
         with _t2_ctx() as db:
             row_id = db.put(
                 project=project,
@@ -1445,10 +1468,12 @@ def memory_put(
                 content=content,
                 tags=tags,
                 ttl=ttl if ttl > 0 else None,
+                agent=agent_arg,
+                session=session_arg,
             )
         _record_tier_write(
             tool="memory_put", tier="T2",
-            project=project, target_title=title,
+            agent=agent_arg, project=project, target_title=title,
         )
         return f"Stored: [{row_id}] {project}/{title}"
     except Exception as e:

--- a/tests/test_memory_put_attribution.py
+++ b/tests/test_memory_put_attribution.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Phase 1B: memory_put MCP API accepts agent + session kwargs (nexus-9clx).
+
+Schema columns ``agent`` and ``session`` on the ``memory`` table have
+existed since the project's first commit but were never wired through
+the MCP layer. 1012 of 1012 production rows have both NULL because
+``memory_put`` MCP signature did not accept them.
+
+This test suite locks the new signature in:
+- Default behaviour: when neither kwarg is passed, falls back to
+  ``NX_AGENT`` env and ``_read_session_id()``.
+- Explicit kwargs: subagent role + caller-supplied session win.
+- Empty string vs None: MCP optional kwargs use ``""`` defaults; the
+  helper translates empty to None so the MemoryStore's own fall-back
+  chain takes over.
+- Tier-write attribution: when memory_put records to ``tier_writes``,
+  the same ``agent`` value is stamped there too.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_t2(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Redirect default_db_path so t2_ctx() opens a tmp DB.
+
+    Patching ``nexus.mcp_infra.default_db_path`` (rather than
+    ``t2_ctx`` itself) is the right hook because ``t2_ctx`` references
+    ``default_db_path`` at call time. Patching ``t2_ctx`` would only
+    affect callers that lazy-imported it; ``core._t2_ctx`` is bound at
+    module-import time and would not pick up the override. The recorder
+    helper uses lazy imports so it's covered too.
+    """
+    import nexus.mcp_infra as infra
+    db = tmp_path / "t.db"
+    monkeypatch.setattr(infra, "default_db_path", lambda: db)
+    monkeypatch.delenv("NX_AGENT", raising=False)
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
+    # Default: no claude session file present (prevents legacy session
+    # file from leaking into MemoryStore.put's session resolution).
+    import nexus.session
+    monkeypatch.setattr(
+        nexus.session, "read_session_id", lambda ppid=None: None,
+    )
+    return db
+
+
+def _read_memory(db: Path, project: str, title: str) -> tuple:
+    conn = sqlite3.connect(str(db))
+    try:
+        return conn.execute(
+            "SELECT agent, session, project, title FROM memory "
+            "WHERE project = ? AND title = ?",
+            (project, title),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def _read_tier_writes(db: Path) -> list[tuple]:
+    conn = sqlite3.connect(str(db))
+    try:
+        return list(conn.execute(
+            "SELECT tool, tier, agent, project, target_title FROM tier_writes "
+            "ORDER BY id"
+        ))
+    finally:
+        conn.close()
+
+
+class TestSignatureAcceptsKwargs:
+    def test_explicit_agent_and_session_persisted(
+        self, isolated_t2: Path,
+    ) -> None:
+        from nexus.mcp.core import memory_put
+
+        result = memory_put(
+            content="finding from developer",
+            project="nexus",
+            title="bug-investigation-2026-05-06",
+            agent="developer",
+            session="sess-explicit",
+        )
+        assert "Stored:" in result, result
+
+        row = _read_memory(isolated_t2, "nexus", "bug-investigation-2026-05-06")
+        assert row is not None
+        agent, session, project, title = row
+        assert agent == "developer"
+        assert session == "sess-explicit"
+        assert project == "nexus"
+        assert title == "bug-investigation-2026-05-06"
+
+    def test_default_kwargs_use_env_fallback(
+        self, isolated_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the MCP caller omits agent/session (or passes empty
+        strings), the MemoryStore fall-back chain kicks in:
+        NX_AGENT env → None, NX_SESSION_ID env → claude file → None."""
+        from nexus.mcp.core import memory_put
+
+        monkeypatch.setenv("NX_AGENT", "code-review-expert")
+        monkeypatch.setenv("NX_SESSION_ID", "sess-from-env")
+
+        memory_put(
+            content="review notes",
+            project="nexus",
+            title="env-fallback-test",
+        )
+
+        row = _read_memory(isolated_t2, "nexus", "env-fallback-test")
+        assert row is not None
+        agent, session, *_ = row
+        assert agent == "code-review-expert"
+        assert session == "sess-from-env"
+
+    def test_empty_strings_treated_as_unspecified(
+        self, isolated_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """MCP defaults to '' (FastMCP serialises None weirdly).
+        Empty string MUST translate to 'unspecified' so the
+        MemoryStore fall-backs run, NOT persist as a literal empty
+        string in the agent column."""
+        from nexus.mcp.core import memory_put
+
+        monkeypatch.setenv("NX_AGENT", "fallback-agent")
+
+        memory_put(
+            content="empty string test",
+            project="nexus",
+            title="empty-translation",
+            agent="",
+            session="",
+        )
+
+        row = _read_memory(isolated_t2, "nexus", "empty-translation")
+        assert row is not None
+        agent, session, *_ = row
+        # Empty string DID NOT win — the env fallback did.
+        assert agent == "fallback-agent"
+        # Session falls all the way through to None (no env, no file).
+        assert session is None
+
+    def test_agent_appears_in_tier_writes_telemetry(
+        self, isolated_t2: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """memory_put records to BOTH ``memory`` and ``tier_writes``;
+        the agent attribution must propagate so ``nx tier-status``
+        can slice by agent."""
+        from nexus.mcp.core import memory_put
+        monkeypatch.setenv("NX_SESSION_ID", "sess-tier-attr")
+
+        memory_put(
+            content="attribution end-to-end",
+            project="nexus",
+            title="attribution-test",
+            agent="substantive-critic",
+        )
+
+        rows = _read_tier_writes(isolated_t2)
+        agent_rows = [r for r in rows if r[0] == "memory_put"]
+        assert len(agent_rows) == 1
+        tool, tier, agent, project, target = agent_rows[0]
+        assert tool == "memory_put"
+        assert tier == "T2"
+        assert agent == "substantive-critic"
+        assert project == "nexus"
+        assert target == "attribution-test"
+
+    def test_no_kwargs_still_works_backward_compat(
+        self, isolated_t2: Path,
+    ) -> None:
+        """Existing callers that pass only the original five params
+        must continue to work unchanged. No agent/session ⇒ NULL in
+        both columns."""
+        from nexus.mcp.core import memory_put
+
+        result = memory_put(
+            content="legacy call",
+            project="nexus",
+            title="legacy-shape",
+            tags="x,y",
+            ttl=30,
+        )
+        assert "Stored:" in result, result
+
+        row = _read_memory(isolated_t2, "nexus", "legacy-shape")
+        assert row is not None
+        agent, session, *_ = row
+        assert agent is None
+        assert session is None


### PR DESCRIPTION
## Summary

The ``memory`` T2 table has had ``agent`` and ``session`` columns since project Phase 1 (March 2026), but MCP ``memory_put`` never accepted them — 1012 of 1012 production rows have both NULL. ``MemoryStore.put`` was already wired with env-driven fall-backs; this PR threads the API through.

Pairs with PR #525 (tier_writes telemetry) and PR #526 (``nx tier-status`` CLI). Together they unlock per-agent attribution.

## Changes

- ``memory_put`` grows two optional kwargs (``agent``, ``session``). Empty-string defaults translate to None so MemoryStore's fall-back chain runs (``NX_AGENT`` env, then ``_read_session_id``).
- Session resolution at the MCP layer reads ``NX_SESSION_ID`` env when no kwarg is supplied. Subagents launched via ``claude_dispatch`` carry this env var set by RDR-094.
- ``agent`` propagates to ``_record_tier_write`` so ``nx tier-status`` slices writes by agent.

## Test plan

- [x] 5 cases in tests/test_memory_put_attribution.py: explicit kwargs, NX_AGENT/NX_SESSION_ID fall-back, empty-string translation, tier_writes attribution, backward compat.
- [x] 119 adjacent tests (test_memory + test_mcp_server) green.
- [ ] Live: post-merge, after MCP restart, run ``memory_put`` from a subagent dispatched with ``NX_AGENT=<role>`` and verify ``nx tier-status`` slices by agent.

## Out of scope

- Backfilling 1012 existing NULL rows. Wire forward.
- Scratch put attribution: T1 metadata model differs (ChromaDB meta dict, not SQL columns). Separate bead.

Bead: nexus-9clx