### PR TITLE
feat(subagent-hook): AGENT TAG guidance for memory_put attribution

### DIFF
--- a/nx/hooks/scripts/subagent-start.sh
+++ b/nx/hooks/scripts/subagent-start.sh
@@ -182,6 +182,8 @@ AUTO-LINK RECIPE (drives store_put -> catalog links):
   3. store_put -- auto-creates catalog links from scratch context
 
 If link-context already in scratch (sibling agent did 1+2), skip to step 3.
+
+AGENT TAG: pass agent="<your-role>" to memory_put so nx tier-status slices writes by agent (nexus-9clx).
 NX_AUTOLINK
 
 # L1 Knowledge Map (per-repo, RDR-072) — outside the heredoc so $(…) expands


### PR DESCRIPTION
## Summary

One-line addition to the SubagentStart hook's NX_AUTOLINK heredoc:

> AGENT TAG: pass ``agent="<your-role>"`` to memory_put so nx tier-status slices writes by agent (nexus-9clx).

Closes the Phase 1B loop. PR #527 added the kwarg; this teaches every dispatched subagent to use it via the SubagentStart injection point. Single change reaches all agents — beats updating 10+ agent files individually.

## Test plan

- [x] Heredoc still under the 500-byte bash 5.3 deadlock guard (322 → 428 bytes).
- [x] tests/test_context.py + tests/test_hooks.py: 28/28 pass.
- [x] Live smoke against the hook (``echo '{}' | bash subagent-start.sh``) confirms ``AGENT TAG`` lands in additionalContext.

Bead: nexus-9clx (follow-up)