### PR TITLE
feat(session-end): print tier-write summary to stderr at session close

### DIFF
--- a/src/nexus/_session_end_launcher.py
+++ b/src/nexus/_session_end_launcher.py
@@ -121,7 +121,74 @@ def _daemonize_and_run() -> None:
     os._exit(0)
 
 
+def _print_tier_status_summary() -> None:
+    """Print a one-line tier-write summary to stderr BEFORE the fork.
+
+    Phase 1C of the tier-discipline restoration initiative
+    (nexus-a52i). Closes the visibility loop: every session that
+    persists findings now sees its own contribution count at close.
+
+    Best-effort: any failure is swallowed so launcher startup never
+    breaks. Suppressed entirely when there are zero writes (no point
+    printing for a transactional session that didn't intend to
+    persist anything).
+
+    Resolution: NX_SESSION_ID env, then read_claude_session_id from
+    the session file. Mirrors the same chain ``nx tier-status``
+    uses so the two surfaces agree.
+    """
+    try:
+        import sqlite3
+        from pathlib import Path
+
+        from nexus.commands._helpers import default_db_path
+        from nexus.session import read_claude_session_id
+
+        session_id = (
+            os.environ.get("NX_SESSION_ID", "").strip()
+            or read_claude_session_id()
+        )
+        if not session_id:
+            return
+        db_path = default_db_path()
+        if not Path(db_path).exists():
+            return
+        conn = sqlite3.connect(str(db_path))
+        try:
+            has_table = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='tier_writes'"
+            ).fetchone()
+            if not has_table:
+                return
+            rows = conn.execute(
+                "SELECT tier, COUNT(*) FROM tier_writes "
+                "WHERE session_id = ? GROUP BY tier",
+                (session_id,),
+            ).fetchall()
+        finally:
+            conn.close()
+        by_tier = {tier: n for tier, n in rows}
+        total = sum(by_tier.values())
+        if total == 0:
+            return
+        parts = [
+            f"{tier}={by_tier.get(tier, 0)}"
+            for tier in ("T1", "T2", "T3", "plan")
+            if by_tier.get(tier, 0)
+        ]
+        sys.stderr.write(
+            f"nx tier writes (session {session_id[:8]}): "
+            f"total={total} {' '.join(parts)}\n"
+        )
+        sys.stderr.flush()
+    except Exception:
+        # Telemetry must never break session close.
+        pass
+
+
 def main() -> None:
+    _print_tier_status_summary()
     if not hasattr(os, "fork"):
         # Windows etc — no fork, run synchronously.
         _run_session_end_synchronously()

--- a/tests/test_session_end_tier_summary.py
+++ b/tests/test_session_end_tier_summary.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Phase 1C: SessionEnd launcher tier-write summary (nexus-a52i).
+
+The launcher daemonizes and detaches stdio after main(), so the
+summary must print BEFORE the fork. This test suite locks in:
+
+- Sessions with writes get a one-line stderr summary at close.
+- Sessions with zero writes are silent (no noise on transactional runs).
+- Failures (missing table, unreadable DB, no session resolvable) are
+  swallowed — telemetry must never break session close.
+"""
+from __future__ import annotations
+
+import io
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _seed(db_path: Path, rows: list[tuple]) -> None:
+    """Insert tier_writes rows. Each row: (session_id, tool, tier)."""
+    from nexus.db.migrations import migrate_tier_writes
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        migrate_tier_writes(conn)
+        ts = datetime.now(timezone.utc).isoformat()
+        for sid, tool, tier in rows:
+            conn.execute(
+                "INSERT INTO tier_writes "
+                "(session_id, ts, tool, tier) VALUES (?, ?, ?, ?)",
+                (sid, ts, tool, tier),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def isolated_t2(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    from nexus.commands import _helpers
+    db = tmp_path / "t.db"
+    monkeypatch.setattr(_helpers, "default_db_path", lambda: db)
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
+    import nexus.session
+    monkeypatch.setattr(nexus.session, "read_claude_session_id", lambda: None)
+    return db
+
+
+class TestPrintTierStatusSummary:
+    def test_prints_summary_when_session_has_writes(
+        self,
+        isolated_t2: Path,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from nexus._session_end_launcher import _print_tier_status_summary
+
+        sid = "abc12345-1111-2222-3333-1234567890ab"
+        monkeypatch.setenv("NX_SESSION_ID", sid)
+        _seed(isolated_t2, [
+            (sid, "memory_put", "T2"),
+            (sid, "memory_put", "T2"),
+            (sid, "scratch_put", "T1"),
+            (sid, "store_put", "T3"),
+        ])
+
+        _print_tier_status_summary()
+
+        out = capsys.readouterr().err
+        assert "nx tier writes" in out
+        assert sid[:8] in out
+        assert "total=4" in out
+        assert "T1=1" in out
+        assert "T2=2" in out
+        assert "T3=1" in out
+        # plan not in this run, must be omitted
+        assert "plan=" not in out
+
+    def test_silent_when_zero_writes(
+        self,
+        isolated_t2: Path,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Zero writes ⇒ no output. Transactional sessions don't need
+        the noise."""
+        from nexus._session_end_launcher import _print_tier_status_summary
+
+        sid = "empty-session-no-writes-zzzzzzzz"
+        monkeypatch.setenv("NX_SESSION_ID", sid)
+        _seed(isolated_t2, [
+            ("other-session", "memory_put", "T2"),  # for someone else
+        ])
+
+        _print_tier_status_summary()
+        assert capsys.readouterr().err == ""
+
+    def test_silent_when_no_session_resolvable(
+        self,
+        isolated_t2: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """No NX_SESSION_ID, no claude session file → silent (the launcher
+        would have nothing meaningful to summarise)."""
+        from nexus._session_end_launcher import _print_tier_status_summary
+
+        _print_tier_status_summary()
+        assert capsys.readouterr().err == ""
+
+    def test_silent_when_db_missing(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """DB file absent → silent. Fresh installs that haven't done any
+        tier writes yet shouldn't error at close."""
+        from nexus.commands import _helpers
+        from nexus._session_end_launcher import _print_tier_status_summary
+
+        # Path that does NOT exist.
+        absent = tmp_path / "missing.db"
+        monkeypatch.setattr(_helpers, "default_db_path", lambda: absent)
+        monkeypatch.setenv("NX_SESSION_ID", "any")
+
+        _print_tier_status_summary()
+        assert capsys.readouterr().err == ""
+
+    def test_silent_when_table_not_initialized(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """DB exists but tier_writes table not yet created (no writes ever) → silent."""
+        from nexus.commands import _helpers
+        from nexus._session_end_launcher import _print_tier_status_summary
+
+        empty = tmp_path / "empty.db"
+        sqlite3.connect(str(empty)).close()
+        monkeypatch.setattr(_helpers, "default_db_path", lambda: empty)
+        monkeypatch.setenv("NX_SESSION_ID", "any")
+
+        _print_tier_status_summary()
+        assert capsys.readouterr().err == ""
+
+    def test_swallows_unexpected_exception(
+        self,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Any unexpected error in the summary path must NOT propagate.
+        Telemetry breaking the launcher is the worst regression class."""
+        from nexus._session_end_launcher import _print_tier_status_summary
+
+        # Sabotage: make default_db_path raise.
+        from nexus.commands import _helpers
+
+        def boom():
+            raise RuntimeError("simulated default_db_path failure")
+
+        monkeypatch.setattr(_helpers, "default_db_path", boom)
+        monkeypatch.setenv("NX_SESSION_ID", "any")
+
+        # Must not raise.
+        _print_tier_status_summary()
+        assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Summary

Phase 1C of the tier-discipline restoration initiative. Adds a one-line stderr summary at session close so every session that writes findings sees its own contribution count without having to invoke ``nx tier-status`` manually.

```
nx tier writes (session abc12345): total=4 T1=1 T2=2 T3=1
```

## Why

The launcher daemonizes and detaches stdio after ``main()``, so any synchronous output must happen BEFORE the fork. ``_print_tier_status_summary`` runs first, queries ``tier_writes`` for the current session, emits one stderr line, then yields to the existing daemonization path.

## Suppression

Output is suppressed when:
- No session resolvable (``NX_SESSION_ID`` env or claude session file).
- T2 DB absent (fresh installs).
- ``tier_writes`` table not yet initialised (no writes ever — recorder creates lazily).
- Session has zero writes (transactional sessions don't need noise).

Best-effort: any failure swallowed. Telemetry must NEVER break session close.

## Test plan

- [x] 6 cases in tests/test_session_end_tier_summary.py: happy path, silent-zero, silent-no-session, silent-db-missing, silent-table-uninit, exception-swallowing.
- [x] 54 adjacent launcher/session tests green.

Bead: nexus-a52i (Phase 1C)