### PR TITLE
feat(scratch): T1 put + MCP scratch accept agent kwarg (nexus-9clx parity)

### DIFF
--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -311,17 +311,27 @@ class T1Database:
         persist: bool = False,
         flush_project: str = "",
         flush_title: str = "",
+        agent: str = "",
     ) -> str:
         """Store *content* in T1. Returns the new document ID.
 
         If *persist* is True the entry is pre-flagged for SessionEnd flush.
         Auto-destination (when no explicit project/title): ``scratch_sessions``
         / ``{session_id}_{doc_id}``.
+
+        ``agent`` (Phase 1B follow-up nexus-9clx) attributes the write to
+        a subagent role for the tier-discipline observability loop. Empty
+        string falls back to ``NX_AGENT`` env, then empty. Stored on
+        chroma metadata; ``nx tier-status`` slices by agent via the
+        ``tier_writes`` T2 mirror.
         """
+        import os as _os
         doc_id = str(uuid4())
         if persist:
             flush_project = flush_project or "scratch_sessions"
             flush_title = flush_title or f"{self._session_id}_{doc_id}"
+        if not agent:
+            agent = _os.environ.get("NX_AGENT", "")
         meta = {
             "session_id": self._session_id,
             "tags": tags,
@@ -330,6 +340,7 @@ class T1Database:
             "flush_title": flush_title,
             "access_count": 0,
             "last_accessed": "",
+            "agent": agent,
         }
         self._exec(lambda: self._col.add(ids=[doc_id], documents=[content], metadatas=[meta]))
         return doc_id

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1703,6 +1703,7 @@ def scratch(
     tags: str = "",
     entry_id: str = "",
     limit: int = 10,
+    agent: str = "",
 ) -> str:
     """T1 session scratch pad — ephemeral within-session storage.
 
@@ -1716,6 +1717,10 @@ def scratch(
         tags: Comma-separated tags (for "put")
         entry_id: Entry ID (for "get", "delete")
         limit: Max results for search/list (default 10)
+        agent: Optional subagent / role attribution for "put" (e.g.
+            "developer"). Empty falls back to ``NX_AGENT`` env, then
+            unspecified. Phase 1B follow-up (nexus-9clx) — lets
+            ``nx tier-status`` slice T1 writes by agent.
     """
     try:
         t1, isolated = _get_t1()
@@ -1724,9 +1729,11 @@ def scratch(
         if action == "put":
             if not content:
                 return "Error: content is required for put"
-            doc_id = t1.put(content=content, tags=tags)
+            agent_arg = agent if agent else ""  # T1.put falls back to NX_AGENT env
+            doc_id = t1.put(content=content, tags=tags, agent=agent_arg)
             _record_tier_write(
                 tool="scratch_put", tier="T1",
+                agent=agent_arg or None,
                 target_title=tags or doc_id,
             )
             return f"{prefix}Stored: {doc_id}"

--- a/tests/test_scratch_attribution.py
+++ b/tests/test_scratch_attribution.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Phase 1B follow-up: scratch put accepts + persists agent attribution
+(nexus-9clx parity for T1).
+
+T1 metadata model differs from T2 (chroma metadata dict, not SQL columns)
+so scratch attribution shipped in a separate change. Same pattern as
+memory_put: explicit kwarg wins, NX_AGENT env fall-back, attribution
+propagates to tier_writes.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import chromadb
+import pytest
+
+
+@pytest.fixture
+def t1_with_agent_capture(monkeypatch: pytest.MonkeyPatch):
+    """Inject a fresh T1Database with EphemeralClient so writes don't
+    bleed between tests, and clear NX_AGENT env."""
+    from nexus.db.t1 import T1Database
+    from nexus.mcp_infra import inject_t1, reset_singletons
+
+    reset_singletons()
+    monkeypatch.delenv("NX_AGENT", raising=False)
+    client = chromadb.EphemeralClient()
+    db = T1Database(session_id="scratch-attr-test", client=client)
+    inject_t1(db)
+    yield db
+    reset_singletons()
+
+
+@pytest.fixture
+def isolated_tier_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    import nexus.mcp_infra as infra
+    db = tmp_path / "tier.db"
+    monkeypatch.setattr(infra, "default_db_path", lambda: db)
+    monkeypatch.setenv("NX_SESSION_ID", "scratch-attr-test-session")
+    return db
+
+
+def _read_tier_writes(db: Path) -> list[tuple]:
+    if not db.exists():
+        return []
+    conn = sqlite3.connect(str(db))
+    try:
+        return list(conn.execute(
+            "SELECT tool, tier, agent, target_title FROM tier_writes ORDER BY id"
+        ))
+    finally:
+        conn.close()
+
+
+class TestT1PutAcceptsAgent:
+    def test_explicit_agent_persists_in_metadata(
+        self, t1_with_agent_capture,
+    ) -> None:
+        t1 = t1_with_agent_capture
+        doc_id = t1.put(content="hypothesis A", tags="probe", agent="developer")
+        entry = t1.get(doc_id)
+        assert entry is not None
+        assert entry["agent"] == "developer"
+
+    def test_env_fallback_when_kwarg_empty(
+        self, t1_with_agent_capture, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        t1 = t1_with_agent_capture
+        monkeypatch.setenv("NX_AGENT", "code-review-expert")
+        doc_id = t1.put(content="finding from review", tags="probe")
+        entry = t1.get(doc_id)
+        assert entry is not None
+        assert entry["agent"] == "code-review-expert"
+
+    def test_no_agent_persists_empty_string(
+        self, t1_with_agent_capture,
+    ) -> None:
+        """Backward compat: callers that don't pass agent get empty
+        string in metadata (NOT missing key)."""
+        t1 = t1_with_agent_capture
+        doc_id = t1.put(content="legacy call", tags="probe")
+        entry = t1.get(doc_id)
+        assert entry is not None
+        assert entry.get("agent", None) == ""
+
+
+class TestScratchMcpAttribution:
+    def test_explicit_agent_round_trips_to_tier_writes(
+        self,
+        t1_with_agent_capture,
+        isolated_tier_writes: Path,
+    ) -> None:
+        from nexus.mcp.core import scratch
+
+        result = scratch(
+            action="put",
+            content="end-to-end attribution",
+            tags="end-to-end",
+            agent="substantive-critic",
+        )
+        assert "Stored:" in result, result
+
+        rows = _read_tier_writes(isolated_tier_writes)
+        scratch_rows = [r for r in rows if r[0] == "scratch_put"]
+        assert len(scratch_rows) == 1
+        tool, tier, agent, target = scratch_rows[0]
+        assert tier == "T1"
+        assert agent == "substantive-critic"
+        assert target == "end-to-end"
+
+    def test_legacy_call_without_agent_still_works(
+        self,
+        t1_with_agent_capture,
+        isolated_tier_writes: Path,
+    ) -> None:
+        """Pre-existing scratch put callers (no agent kwarg) keep working;
+        tier_writes records agent=NULL for them."""
+        from nexus.mcp.core import scratch
+
+        result = scratch(action="put", content="legacy", tags="legacy")
+        assert "Stored:" in result, result
+
+        rows = _read_tier_writes(isolated_tier_writes)
+        scratch_rows = [r for r in rows if r[0] == "scratch_put"]
+        assert len(scratch_rows) == 1
+        _tool, _tier, agent, _target = scratch_rows[0]
+        assert agent is None


### PR DESCRIPTION
## Summary

T1 parity for the agent-attribution work that PR #527 shipped for memory_put. Scratch (T1) uses chroma metadata, not SQL columns, so it shipped separately. Same pattern: explicit kwarg wins, ``NX_AGENT`` env fall-back, attribution propagates to ``tier_writes``.

## Changes

- ``T1Database.put`` accepts ``agent`` (default ``""``). Empty string falls back to ``NX_AGENT`` env. Persisted in the chroma metadata dict so list_entries / search results carry it.
- MCP ``scratch(action="put")`` accepts ``agent``. Threaded into ``T1.put`` AND ``_record_tier_write`` so ``nx tier-status`` slices T1 writes by agent.

## Test plan

- [x] 5 cases in tests/test_scratch_attribution.py: T1.put explicit / env-fallback / empty-default; MCP end-to-end attribution to tier_writes; backward-compat for legacy callers.
- [x] 95 adjacent tests (test_scratch, test_scratch_cmd, test_t1) green.

Bead: nexus-9clx (T1 parity follow-up)