### PR TITLE
fix(mcp-catalog): route query+content_type to FTS5, not SQL filter path (nexus-a414)

### DIFF
--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -57,11 +57,17 @@ def catalog_search(
         from nexus.catalog.tumbler import Tumbler
         import json as _json
 
-        # Structured filters via SQL when provided. content_type alone (no
-        # query/author/etc.) routes here too — the FTS5 path below requires
-        # a free-text query, but content_type is a perfectly valid sole filter
-        # ("show me everything of type prose") and the docstring promises it.
-        if owner or corpus or file_path or content_type or (author and not query):
+        # Structured filters via SQL when there's NO free-text query. The
+        # SQL path filters by exact-match structural fields (owner, corpus,
+        # file_path, content_type, author). When ``query`` IS provided
+        # alongside content_type, the FTS5 path below handles both via
+        # ``cat.find(query, content_type=...)``. The previous routing put
+        # content_type unconditionally on the SQL side, which silently
+        # dropped the ``query`` filter for the (query + content_type)
+        # combination — nexus-a414 Part 1.
+        if not query.strip() and (
+            owner or corpus or file_path or content_type or author
+        ):
             conditions = ["1=1"]
             params: list = []
             if owner:

--- a/tests/test_catalog_mcp.py
+++ b/tests/test_catalog_mcp.py
@@ -116,6 +116,36 @@ def test_search_by_content_type_alone(cat) -> None:
     assert titles == ["alpha", "gamma"]
 
 
+def test_search_query_plus_content_type_filters_both(cat) -> None:
+    """Query + content_type must filter on BOTH (nexus-a414 Part 1).
+
+    Pre-fix: the routing condition treated content_type as a SQL-path
+    trigger that ignored ``query``. Live repro: ``catalog_search(
+    query="incremental catalog projection rebuild", content_type="rdr")``
+    returned the first N rdr entries regardless of query content.
+
+    Expected: results match both filters; non-matching entries excluded
+    even when they share the content_type.
+    """
+    catalog_register(title="incremental catalog projection rebuild",
+                     owner="1.1", content_type="rdr")
+    catalog_register(title="unrelated rdr about something else",
+                     owner="1.1", content_type="rdr")
+    catalog_register(title="incremental catalog projection rebuild as code",
+                     owner="1.1", content_type="code")  # query match, wrong type
+
+    results = catalog_search(
+        query="incremental catalog projection",
+        content_type="rdr",
+    )
+    titles = sorted(r["title"] for r in results if "title" in r)
+    # Only the query+type match should land. The unrelated rdr (query miss)
+    # and the code entry (type miss) must both be excluded.
+    assert titles == ["incremental catalog projection rebuild"], (
+        f"query+content_type filtered wrong: {titles!r}"
+    )
+
+
 def test_list_all(cat) -> None:
     catalog_register(title="A", owner="1.1")
     catalog_register(title="B", owner="1.1")


### PR DESCRIPTION
## Summary

Part 1 of **nexus-a414**. The MCP ``catalog_search`` SQL filter path treated ``content_type`` as a structural-only trigger, silently losing the ``query`` filter when both were passed. Part 2 (auto_link silent-swallow + WARNING on invalid tumblers + AutoLinkResult counts) shipped in 4.25.3; this fixes the upstream data-quality bug that fed it bad data.

## Repro (live, 4.25.2)

```
catalog_search(query="RDR-104", content_type="rdr")
→ first 5 ART RDRs (RDR-001/002/003/...) — query ignored
```

Now:

```
catalog_search(query="incremental catalog projection rebuild", content_type="rdr")
→ matching RDR(s) only
```

## Fix

Route to the SQL filter path only when ``query`` is empty. When both ``query`` and ``content_type`` are provided, fall through to the FTS5 path which already supports ``content_type`` via ``cat.find(query, content_type=...)``.

## Test plan

- [x] New test ``test_search_query_plus_content_type_filters_both``: registers a query-matching rdr, an unrelated rdr (query miss), a query-matching code (type miss); asserts only the query+type intersection returns. RED before fix, GREEN after.
- [x] 31/31 ``test_catalog_mcp.py`` tests pass.

Bead: nexus-a414