### PR TITLE
fix(mcp-catalog): list filters by content_type in SQL + resolve emits typed error (nexus-blk2)

### DIFF
--- a/src/nexus/mcp/catalog.py
+++ b/src/nexus/mcp/catalog.py
@@ -175,16 +175,28 @@ def catalog_list(
 
         if owner:
             entries = cat.by_owner(Tumbler.parse(owner))
-            entries = entries[offset:offset + limit]
+            if content_type:
+                entries = [e for e in entries if e.content_type == content_type]
+            entries = entries[offset:offset + limit + 1]
         else:
             import json as _json
 
-            rows = cat._db.execute(
+            # Push content_type into the SQL WHERE so pagination is correct.
+            # nexus-blk2 Part 1: previously filtered in Python AFTER LIMIT,
+            # so list(content_type='rdr', limit=5) returned [] when the first
+            # 5 rows happened not to be rdr.
+            sql = (
                 "SELECT tumbler, title, author, year, content_type, file_path, "
                 "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata "
-                "FROM documents LIMIT ? OFFSET ?",
-                (limit, offset),
-            ).fetchall()
+                "FROM documents"
+            )
+            params: list = []
+            if content_type:
+                sql += " WHERE content_type = ?"
+                params.append(content_type)
+            sql += " LIMIT ? OFFSET ?"
+            params.extend([limit + 1, offset])
+            rows = cat._db.execute(sql, params).fetchall()
             from nexus.catalog.catalog import CatalogEntry
 
             entries = [
@@ -196,11 +208,10 @@ def catalog_list(
                 )
                 for r in rows
             ]
-        if content_type:
-            entries = [e for e in entries if e.content_type == content_type]
+        has_more = len(entries) > limit
         page = entries[:limit]
         result = [e.to_dict() for e in page]
-        if len(entries) > limit:
+        if has_more:
             result.append({"_pagination": {"next_offset": offset + limit, "limit": limit}})
         return result
     except Exception as e:
@@ -445,13 +456,30 @@ def catalog_resolve(
     try:
         from nexus.catalog.tumbler import Tumbler
 
+        # nexus-blk2 Part 2: dotted-tumbler form is required (e.g. "1.2.3"
+        # for a document, "1.2" for an owner). The dashed format produced
+        # by ``nx doctor`` (e.g. "1-2188", "Luciferase-f2d57dbc") is the
+        # physical-collection prefix shape, NOT a tumbler. Tumbler.parse
+        # used to leak its int() ValueError to the caller; catch and
+        # surface an actionable diagnostic instead.
+        def _parse_tumbler_or_raise(raw: str, field: str) -> Tumbler:
+            try:
+                return Tumbler.parse(raw)
+            except (ValueError, TypeError) as exc:
+                raise ValueError(
+                    f"{field}={raw!r}: not a dotted tumbler (e.g. '1.2.3'). "
+                    f"If you have a physical collection prefix like "
+                    f"'1-2188' from `nx doctor`, that is NOT a tumbler. "
+                    f"underlying: {exc}"
+                ) from exc
+
         collections: set[str] = set()
         if tumbler:
-            entry = cat.resolve(Tumbler.parse(tumbler))
+            entry = cat.resolve(_parse_tumbler_or_raise(tumbler, "tumbler"))
             if entry and entry.physical_collection:
                 collections.add(entry.physical_collection)
         if owner:
-            entries = cat.by_owner(Tumbler.parse(owner))
+            entries = cat.by_owner(_parse_tumbler_or_raise(owner, "owner"))
             for e in entries:
                 if e.physical_collection:
                     collections.add(e.physical_collection)

--- a/tests/test_catalog_mcp.py
+++ b/tests/test_catalog_mcp.py
@@ -127,6 +127,57 @@ def test_list_by_owner(cat) -> None:
     assert len(catalog_list(owner="1.1")) == 1
 
 
+def test_list_filters_by_content_type_with_pagination(cat) -> None:
+    """catalog_list(content_type=X) must push the filter into SQL so
+    pagination is correct (nexus-blk2 Part 1).
+
+    Pre-fix: filtering happened in Python AFTER the SQL LIMIT/OFFSET,
+    so catalog_list(content_type='rdr', limit=5) returned [] when the
+    first 5 entries weren't rdr. Live repro: catalog had 2,270 rdr
+    docs but list(content_type='rdr', limit=5) returned [] because
+    the LIMIT 5 saw 5 non-rdr docs and the post-filter dropped them
+    all.
+
+    This test reproduces the bug at small scale: 10 code docs +
+    2 rdr docs, limit=5. Pre-fix list(content_type='rdr', limit=5)
+    returns [] because the SQL grabs the first 5 (all code) then the
+    Python filter empties them. Post-fix the SQL filter is applied
+    first so the rdr docs are returned.
+    """
+    # Front-load 10 code docs so they fill the LIMIT 5 page.
+    for i in range(10):
+        catalog_register(title=f"code-{i}", owner="1.1", content_type="code")
+    # Add 2 rdr docs at the end (would fall outside LIMIT 5 without
+    # SQL-side filter).
+    catalog_register(title="rdr-A", owner="1.1", content_type="rdr")
+    catalog_register(title="rdr-B", owner="1.1", content_type="rdr")
+
+    rdr_paged = catalog_list(content_type="rdr", limit=5)
+    titles = sorted(r["title"] for r in rdr_paged if "title" in r)
+    assert titles == ["rdr-A", "rdr-B"], (
+        f"content_type filter not pushed into SQL: got {titles!r}"
+    )
+
+
+def test_resolve_dashed_owner_returns_typed_error(cat) -> None:
+    """catalog_resolve(owner='1-2188') used to leak ValueError from
+    Tumbler.parse (nexus-blk2 Part 2). The dashed format is the
+    *collection-prefix* shape produced by ``nx doctor``, not the
+    tumbler shape resolve expects. The handler must catch the
+    parse failure and return a useful diagnostic instead of the
+    raw int() error.
+    """
+    result = catalog_resolve(owner="1-2188", corpus="code")
+    assert len(result) == 1
+    assert result[0].startswith("Error:")
+    # The error message must point at the actionable cause: dotted-tumbler
+    # form expected. Do NOT leak the raw int() ValueError.
+    err_lower = result[0].lower()
+    assert (
+        "tumbler" in err_lower or "dotted" in err_lower
+    ), f"unhelpful error: {result[0]!r}"
+
+
 def test_update(cat) -> None:
     catalog_register(title="Old Title", owner="1.1")
     catalog_update(tumbler="1.1.1", title="New Title")


### PR DESCRIPTION
## Summary

**nexus-blk2** — two MCP catalog contract bugs surfaced during the 4.25.3 shakeout.

## Part 1: ``catalog_list`` ignored ``content_type`` at the SQL layer

The docstring promised the filter; the SQL didn't apply it. Filtering was a Python list-comprehension AFTER the LIMIT/OFFSET, so ``list(content_type='rdr', limit=5)`` returned ``[]`` when the first 5 rows were any other type.

Fix: push ``content_type`` into the SQL ``WHERE`` clause. Pagination is now correct regardless of the filter ratio.

## Part 2: ``catalog_resolve`` leaked ``Tumbler.parse`` ``ValueError``

The dashed format produced by ``nx doctor`` (e.g. ``1-2188``, ``Luciferase-f2d57dbc``) is the physical-collection prefix, not a tumbler. ``Tumbler.parse`` called ``int()`` on the dashed string and leaked the raw ``invalid literal for int() with base 10`` error.

Fix: wrap ``Tumbler.parse`` with a typed diagnostic that explains the dotted-tumbler requirement and explicitly notes that ``nx doctor`` output is NOT a tumbler.

## Test plan

- [x] ``test_list_filters_by_content_type_with_pagination``: 10 code docs + 2 rdr; ``list(content_type='rdr', limit=5)`` must return both rdr.
- [x] ``test_resolve_dashed_owner_returns_typed_error``: ``resolve(owner='1-2188')`` returns an error mentioning 'tumbler' or 'dotted', not the raw ``ValueError``.
- [x] 32/32 ``test_catalog_mcp.py`` tests pass.

Bead: nexus-blk2