### PR TITLE
feat(plan-runner): emit nx_answer_step_start/complete per segment (nexus-0qi9)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -3268,6 +3268,17 @@ async def nx_answer(
     3. **Execute plan**: run via ``plan_run``.
     4. **Record**: write run metrics to T2 ``nx_answer_runs``.
 
+    **Latency.** This is NOT a sub-second call in the general case.
+    Each operator step (extract, rank, summarize, generate, …) spawns a
+    ``claude -p`` subprocess with a 300-second timeout. Empirical
+    distribution from 100 production runs (memory: tier-discipline-
+    audit-2026-05-06): 32% finish under 5s, 5% in 5–30s, 40% in
+    30s–2min, 23% in 2–5min. The plan-miss path adds an inline-planner
+    subprocess (also up to 300s) on top. ``plan_run`` emits per-step
+    structured ``nx_answer_step_start`` / ``nx_answer_step_complete``
+    events to ``structlog`` (nexus-0qi9) so callers tailing
+    ``~/.config/nexus/logs/mcp.log`` can see progress in real time.
+
     Args:
         question: Natural-language question to answer.
         scope: Catalog subtree or corpus filter (e.g. ``"1.2"`` or ``"knowledge"``).

--- a/src/nexus/plans/runner.py
+++ b/src/nexus/plans/runner.py
@@ -43,6 +43,7 @@ import asyncio
 import inspect
 import json
 import re
+import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Protocol
 
@@ -1036,6 +1037,30 @@ async def plan_run(
         segments = flat
 
     for seg in segments:
+        # nexus-0qi9: per-step progress visibility. Emit start/complete
+        # log events at each segment boundary so the silent claude -p
+        # chain becomes audible. Without this, a 4-step plan that takes
+        # 10+ minutes is indistinguishable from a hang from the caller's
+        # seat. Events flow to structlog which the MCP server's logger
+        # routes to ~/.config/nexus/logs/mcp.log; downstream ``nx
+        # tier-status``-style commands can join on the same session_id.
+        _seg_started_at = time.monotonic()
+        if isinstance(seg, OperatorBundleSlice):
+            _seg_kind = "bundle"
+            _seg_indices = list(seg.plan_indices)
+            _seg_tools = [_extract_tool(steps[bi]) for bi in seg.plan_indices]
+        else:
+            _seg_kind = "isolated"
+            _seg_indices = [seg.plan_index]
+            _seg_tools = [_extract_tool(seg.step)]
+        _log.info(
+            "nx_answer_step_start",
+            kind=_seg_kind,
+            step_indices=_seg_indices,
+            tools=_seg_tools,
+            total_steps=len(steps),
+        )
+
         if isinstance(seg, OperatorBundleSlice):
             # ── Bundle path: ≥2 contiguous operator steps → single dispatch ──
             deferred_indices = set(seg.plan_indices)
@@ -1108,6 +1133,13 @@ async def plan_run(
                             ),
                         )
                     step_outputs.append(result)
+                _log.info(
+                    "nx_answer_step_complete",
+                    kind="bundle_fallback",
+                    step_indices=_seg_indices,
+                    tools=_seg_tools,
+                    elapsed_ms=int((time.monotonic() - _seg_started_at) * 1000),
+                )
                 continue
 
             bundle_result = await dispatch_bundle(bundle)
@@ -1126,6 +1158,13 @@ async def plan_run(
                     ),
                 )
             step_outputs.append(bundle_result)
+            _log.info(
+                "nx_answer_step_complete",
+                kind="bundle",
+                step_indices=_seg_indices,
+                tools=_seg_tools,
+                elapsed_ms=int((time.monotonic() - _seg_started_at) * 1000),
+            )
             continue
 
         # ── Isolated path: IsolatedStep → one dispatcher call ──
@@ -1184,6 +1223,13 @@ async def plan_run(
                 ),
             )
         step_outputs.append(result)
+        _log.info(
+            "nx_answer_step_complete",
+            kind="isolated",
+            step_indices=_seg_indices,
+            tools=_seg_tools,
+            elapsed_ms=int((time.monotonic() - _seg_started_at) * 1000),
+        )
 
     return PlanResult(
         steps=step_outputs,

--- a/tests/test_plan_run.py
+++ b/tests/test_plan_run.py
@@ -1676,3 +1676,89 @@ class TestPlanRunBundledAggregateCount:
         for agg in aggregate_out["aggregates"]:
             assert isinstance(agg.get("key_value"), str)
             assert isinstance(agg.get("summary"), str)
+
+
+# ── nx_answer step progress logs (nexus-0qi9) ───────────────────────────────
+
+
+class TestPlanRunStepProgressLogs:
+    """Per-step structured log events for nx_answer progress visibility.
+
+    Pre-fix: a multi-step plan run was indistinguishable from a hang
+    from the caller's seat. With these events on structlog, downstream
+    log readers (mcp.log tail, ``nx tier-status`` joins, etc.) can see
+    where the run is in real time.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _info_level(self):
+        """Default conftest sets structlog to WARNING; the progress
+        events fire at INFO. Lower the threshold for this class so
+        capture_logs sees them. The autouse _restore_structlog_after_test
+        in conftest.py undoes this between tests."""
+        import logging
+        import structlog
+        structlog.configure(
+            wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        )
+
+    @pytest.mark.asyncio
+    async def test_isolated_steps_emit_start_and_complete(self) -> None:
+        """Each isolated segment emits paired start + complete events
+        with step indices, tool names, and elapsed_ms on completion."""
+        import structlog.testing
+
+        from nexus.plans.runner import plan_run
+
+        plan = {
+            "steps": [
+                {"tool": "search", "args": {"query": "x"}},
+                {"tool": "query",  "args": {"question": "y"}},
+            ],
+        }
+        disp = _FakeDispatcher([
+            {"text": "r1"}, {"text": "r2"},
+        ])
+        with structlog.testing.capture_logs() as captured:
+            await plan_run(_match(plan), {}, dispatcher=disp)
+
+        starts = [
+            e for e in captured if e.get("event") == "nx_answer_step_start"
+        ]
+        completes = [
+            e for e in captured if e.get("event") == "nx_answer_step_complete"
+        ]
+        assert len(starts) == 2, f"expected 2 starts, got {captured}"
+        assert len(completes) == 2, f"expected 2 completes, got {captured}"
+        # Step indices monotonically increase.
+        assert starts[0]["step_indices"] == [0]
+        assert starts[1]["step_indices"] == [1]
+        # Tools land in the event.
+        assert starts[0]["tools"] == ["search"]
+        assert starts[1]["tools"] == ["query"]
+
+    @pytest.mark.asyncio
+    async def test_complete_event_carries_elapsed_ms(self) -> None:
+        """The complete event must include elapsed_ms so callers can
+        diagnose slow steps after the fact."""
+        import structlog.testing
+
+        from nexus.plans.runner import plan_run
+
+        plan = {"steps": [{"tool": "search", "args": {"query": "x"}}]}
+        disp = _FakeDispatcher([{"text": "r"}])
+
+        with structlog.testing.capture_logs() as captured:
+            await plan_run(_match(plan), {}, dispatcher=disp)
+
+        completes = [
+            e for e in captured if e.get("event") == "nx_answer_step_complete"
+        ]
+        assert len(completes) == 1
+        ev = completes[0]
+        assert "elapsed_ms" in ev, (
+            f"complete event missing elapsed_ms: {ev!r}"
+        )
+        assert isinstance(ev["elapsed_ms"], int)
+        assert ev["elapsed_ms"] >= 0
+        assert ev["kind"] == "isolated"


### PR DESCRIPTION
## Summary

**nexus-0qi9** — close the visibility gap that made multi-step ``nx_answer`` runs feel like a hang. Each segment in ``plan_run`` now emits paired structured log events at INFO so callers tailing ``mcp.log`` (or downstream log readers) can see progress in real time.

## Why

Empirical from 100 production runs (memory: tier-discipline-audit-2026-05-06): 32% finished under 5s, 5% in 5–30s, **40% in 30s–2min**, **23% in 2–5min**. With zero per-step signal, anything past 5s looked like a hang. One verb-shaped plan-miss query during the 4.25.3 shakeout was cancelled by the user because the silent ``claude -p`` chain was indistinguishable from a wedge.

## Changes

- ``plan_run`` emits ``nx_answer_step_start`` at the top of each segment iteration and ``nx_answer_step_complete`` at each successful finish (bundle, bundle-oversized fallback, isolated). Fields: ``kind``, ``step_indices``, ``tools``, ``total_steps``; complete adds ``elapsed_ms``.
- ``nx_answer`` docstring now documents the empirical latency distribution and points at the new step events.

## Test plan

- [x] ``test_isolated_steps_emit_start_and_complete``: 2-step plan emits 2 starts + 2 completes; step indices and tool names land on the events.
- [x] ``test_complete_event_carries_elapsed_ms``: complete event has integer ``elapsed_ms >= 0`` and ``kind == "isolated"``.
- [x] 75/75 ``test_plan_run.py`` regression green.

## Out of scope

Caller-surfaceable progress signal beyond log events (incremental return, callback shape) — separate RDR/feature work. The log-event contract here is the minimum-viable observability that unblocks downstream log-tailing tooling.

Bead: nexus-0qi9