### PR TITLE
fix(corpus): bare-prefix resolver bridges to 2-segment legacy collection (#535)

### DIFF
--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -232,8 +232,26 @@ def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
     if t3 is None or user_arg == promoted:
         return promoted
     try:
-        if not t3.collection_exists(promoted) and t3.collection_exists(user_arg):  # type: ignore[attr-defined]
-            return user_arg
+        if not t3.collection_exists(promoted):  # type: ignore[attr-defined]
+            if t3.collection_exists(user_arg):  # type: ignore[attr-defined]
+                return user_arg
+            # Bare-prefix legacy fallback (#535 / nexus-6mr0): when the
+            # operator typed only the content_type (``"knowledge"``)
+            # and the conformant target is absent, bridge to the
+            # documented 2-segment legacy shape ``f"{ct}__{owner_segment}"``
+            # if it exists. Without this, the bare-prefix shorthand on
+            # installs with pre-RDR-103 collections (e.g.
+            # ``knowledge__knowledge``) reads from a missing conformant
+            # name and operators see "No entries" while the data is
+            # right there. Symmetric with the nexus-hmxi grandfathering
+            # design intent ("pre-existing legacy collections remain
+            # readable") extended to the shorthand form.
+            legacy_two_segment = f"{ct}__{owner_segment}"
+            if (
+                legacy_two_segment != user_arg
+                and t3.collection_exists(legacy_two_segment)  # type: ignore[attr-defined]
+            ):
+                return legacy_two_segment
     except Exception:
         # collection_exists probe is best-effort. On failure (cloud
         # quota error, transient network) fall through to the

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -337,6 +337,57 @@ def test_t3_collection_name_no_t3_always_promotes() -> None:
     )
 
 
+def test_t3_collection_name_bare_prefix_falls_back_to_2segment_legacy() -> None:
+    """Bare-prefix arg ('knowledge') must reach the documented
+    legacy 2-segment collection ('knowledge__knowledge') when that's
+    the only physical collection that exists (#535, nexus-6mr0).
+
+    Pre-fix: nx store list (no args, default --collection knowledge)
+    on installs with knowledge__knowledge from before the RDR-103
+    transition returned 'No entries' because the resolver promoted
+    to knowledge__knowledge__voyage-context-3__v1 (which does not
+    exist) and never tried the 2-segment legacy fallback.
+
+    The grandfathering branch must probe the synthesised legacy
+    shape f'{ct}__{owner_segment}' in addition to user_arg itself,
+    so the bare-prefix shorthand bridges to the legacy collection
+    when the conformant target is absent.
+    """
+    legacy_2seg = "knowledge__knowledge"
+    conformant = "knowledge__knowledge__voyage-context-3__v1"
+    t3 = _FakeT3({legacy_2seg})  # only legacy exists, no conformant
+    # The user typed the bare prefix 'knowledge'. The resolver should
+    # bridge to 'knowledge__knowledge' (the 2-segment legacy shape)
+    # rather than returning the missing conformant name.
+    assert t3_collection_name("knowledge", t3=t3) == legacy_2seg
+
+
+def test_t3_collection_name_bare_prefix_promotes_when_no_legacy() -> None:
+    """Symmetric: bare-prefix on a fresh install (no legacy 2-segment
+    collection on disk) promotes to the conformant shape so new
+    writes satisfy the strict-naming guard. Only the legacy install
+    case grandfathers; greenfield installs land on conformant.
+    """
+    t3 = _FakeT3(set())  # nothing on disk
+    assert (
+        t3_collection_name("knowledge", t3=t3)
+        == "knowledge__knowledge__voyage-context-3__v1"
+    )
+
+
+def test_t3_collection_name_bare_prefix_prefers_conformant_when_both_exist() -> None:
+    """Mid-migration state: both legacy 2-segment AND conformant
+    exist for the bare-prefix shorthand. The resolver returns the
+    conformant target so new writes converge instead of forking
+    back to the legacy shape (matches the existing both-exist
+    behaviour for the 2-segment input form).
+    """
+    legacy_2seg = "knowledge__knowledge"
+    conformant = "knowledge__knowledge__voyage-context-3__v1"
+    t3 = _FakeT3({legacy_2seg, conformant})
+    assert t3_collection_name("knowledge", t3=t3) == conformant
+
+
 def test_t3_collection_name_t3_probe_failure_falls_through_to_promoted() -> None:
     """When the t3 probe raises (cloud transient / quota error), the
     resolver falls through to the auto-promoted shape; legacy reads


### PR DESCRIPTION
## Summary

Closes **#535**. On installs with legacy 2-segment collections (e.g. ``knowledge__knowledge`` from before the RDR-103 transition), ``nx store list`` and ``mcp store_list(collection="knowledge")`` returned "No entries" because the bare-prefix resolver promoted to the conformant 4-segment name (which does not exist) and never tried the 2-segment legacy fallback.

## Root cause

Reporter's caller audit confirmed every read-side caller passes ``t3=`` correctly. The bug is in ``t3_collection_name`` in ``src/nexus/corpus.py:189-243``:

```python
# user_arg = "knowledge"  (bare prefix, the documented shorthand)
# 1. Not conformant; no '__'  →  ct='knowledge', rest='knowledge'
# 2. promoted = 'knowledge__knowledge__voyage-context-3__v1'
# 3. Probes promoted (does not exist on legacy install)
# 4. Probes user_arg 'knowledge' (does not exist either)
# 5. Returns the missing promoted name → "No entries"
#
# Never probes the 2-segment legacy shape 'knowledge__knowledge'
# that's actually on disk.
```

## Fix

In the grandfathering branch, after the existing user_arg probe fails, also probe the synthesised legacy shape ``f"{ct}__{owner_segment}"``. Symmetric with the nexus-hmxi grandfathering design intent extended to the bare-prefix shorthand.

## Test plan

- [x] ``test_t3_collection_name_bare_prefix_falls_back_to_2segment_legacy`` — bare prefix on legacy-only install returns ``knowledge__knowledge`` (was: missing conformant name).
- [x] ``test_t3_collection_name_bare_prefix_promotes_when_no_legacy`` — bare prefix on greenfield install promotes to conformant (no regression).
- [x] ``test_t3_collection_name_bare_prefix_prefers_conformant_when_both_exist`` — mid-migration state returns conformant (writes converge).
- [x] 60/60 ``test_corpus.py`` regression green.

## Out of scope (filed separately)

- **nexus-zpw6** (P3) — reporter's secondary finding: scratch ``get``/``delete`` should accept 8-char prefix matching scratch ``list`` display + memory_get's nexus-e59o resolution.
- Write-side policy for bare-prefix puts — the index-side comment at ``commands/index.py:647-654`` argues for "always conformant, rename legacy first". Read-fix here is sufficient for the hostile case (operator can't see their own data).

Bead: nexus-6mr0
Issue: GH #535