### PR TITLE
fix(catalog-cli): nx catalog list --owner accepts owner name (#537)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1687,6 +1687,29 @@ class Catalog:
         ).fetchone()
         return Tumbler.parse(row[0]) if row else None
 
+    def owner_tumblers_by_name(self, name: str) -> list[Tumbler]:
+        """Return tumblers of all owners with this name.
+
+        UNIQUE constraint is ``(name, owner_type)`` per nexus-7vuw, so
+        a single name can map to multiple owners across types (e.g.
+        a repo and a curator both named ``nexus``). Callers that need
+        a unique answer should disambiguate on the returned list
+        (typical CLI flow: error when ``len(...) > 1`` and surface
+        the candidates).
+
+        Returns ``[]`` if no owner has this name. Used by the
+        ``--owner`` CLI flags on ``nx catalog list`` (and friends)
+        to resolve operator-typed names to tumblers without leaking
+        the ``Tumbler.parse → int()`` ``ValueError`` (#537,
+        nexus-1lx7).
+        """
+        rows = self._db.execute(
+            "SELECT tumbler_prefix FROM owners WHERE name = ? "
+            "ORDER BY tumbler_prefix",
+            (name,),
+        ).fetchall()
+        return [Tumbler.parse(r[0]) for r in rows]
+
     def ensure_owner_for_repo(
         self, repo: Path, *, repo_name: str = "", description: str = "",
     ) -> Tumbler:

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -832,7 +832,33 @@ def list_cmd(owner: str, content_type: str, limit: int, offset: int, as_json: bo
     """List catalog entries."""
     cat = _get_catalog()
     if owner:
-        entries = cat.by_owner(Tumbler.parse(owner))
+        # Resolve --owner to a Tumbler. Try the dotted-tumbler form first
+        # (the canonical input), then fall back to looking up by owner
+        # name (#537 / nexus-1lx7) so operators can paste back the
+        # human-readable name they see in catalog output. Without this
+        # fallback, non-dotted strings leaked the raw int() ValueError
+        # from Tumbler.parse as a stack trace.
+        owner_tumbler: Tumbler | None
+        try:
+            owner_tumbler = Tumbler.parse(owner)
+        except (ValueError, TypeError):
+            matches = cat.owner_tumblers_by_name(owner)
+            if not matches:
+                raise click.ClickException(
+                    f"--owner {owner!r}: not a dotted tumbler "
+                    f"(e.g. '1.2') and no owner has this name. "
+                    f"Use `nx catalog stats` to list known owners."
+                )
+            if len(matches) > 1:
+                candidates = ", ".join(str(t) for t in matches)
+                raise click.ClickException(
+                    f"--owner {owner!r}: ambiguous; "
+                    f"{len(matches)} owners share this name across "
+                    f"types ({candidates}). Pass the dotted tumbler "
+                    f"directly to disambiguate."
+                )
+            owner_tumbler = matches[0]
+        entries = cat.by_owner(owner_tumbler)
     else:
         entries = cat.all_documents(limit=limit + offset + 1)
     if content_type:

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -167,6 +167,63 @@ class TestListCommand:
         assert isinstance(data, list)
         assert len(data) >= 1
 
+    def test_list_owner_by_name_resolves_to_tumbler(
+        self, initialized_catalog, catalog_env,
+    ):
+        """nx catalog list --owner <name> resolves the named owner
+        ('test-repo' from the fixture) to its tumbler prefix and
+        returns its entries (#537, nexus-1lx7).
+
+        Pre-fix: this leaked Tumbler.parse's int() ValueError to the
+        user as a stack trace. Schema has owners.name; CLI should
+        resolve by name when the input doesn't parse as a tumbler.
+        """
+        runner = CliRunner()
+        runner.invoke(main, [
+            "catalog", "register", "--title", "A", "--owner", "1.1",
+        ])
+        runner.invoke(main, [
+            "catalog", "register", "--title", "B", "--owner", "1.1",
+        ])
+        result = runner.invoke(main, [
+            "catalog", "list", "--owner", "test-repo",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "A" in result.output
+        assert "B" in result.output
+
+    def test_list_owner_unknown_emits_clean_error(
+        self, initialized_catalog, catalog_env,
+    ):
+        """An owner that is neither a valid tumbler nor a known name
+        must emit a friendly error, not a Tumbler.parse stack trace.
+        """
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "catalog", "list", "--owner", "no-such-owner-12345",
+        ])
+        # ClickException → exit code 1; output names the owner.
+        assert result.exit_code != 0
+        out_lower = result.output.lower()
+        assert "no-such-owner-12345" in result.output
+        # The raw int() ValueError from Tumbler.parse must NOT leak.
+        assert "invalid literal for int" not in out_lower
+        assert "traceback" not in out_lower
+
+    def test_list_owner_tumbler_form_still_works(
+        self, initialized_catalog, catalog_env,
+    ):
+        """No regression for the documented dotted-tumbler form."""
+        runner = CliRunner()
+        runner.invoke(main, [
+            "catalog", "register", "--title", "A", "--owner", "1.1",
+        ])
+        result = runner.invoke(main, [
+            "catalog", "list", "--owner", "1.1",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "A" in result.output
+
 
 class TestSearchCommand:
     def test_search(self, initialized_catalog, catalog_env):


### PR DESCRIPTION
## Summary

Closes **#537**. ``nx catalog list --owner <name>`` raised an unhandled ``ValueError: invalid literal for int()`` from ``Tumbler.parse`` when the input was a name (e.g. ``canon-conductor-compose``) instead of a dotted-numeric tumbler. Same shape as nexus-blk2 Part 2 fixed for the MCP catalog_resolve, but on the CLI side.

## Fix

1. New ``Catalog.owner_tumblers_by_name(name) → list[Tumbler]``. Plural because the schema's UNIQUE constraint is ``(name, owner_type)`` (nexus-7vuw), so a repo and a curator can share a name.
2. ``nx catalog list --owner`` resolution chain: try ``Tumbler.parse`` → on parse failure, look up by name → empty: clean error; one match: use it; multi-match: clean error listing candidates.
3. No raw ``ValueError`` leak anywhere.

## Test plan

- [x] ``test_list_owner_by_name_resolves_to_tumbler`` — fixture name 'test-repo' resolves to its tumbler.
- [x] ``test_list_owner_unknown_emits_clean_error`` — unknown owner surfaces a friendly message; no Tumbler.parse stack trace, no ``invalid literal for int`` in output.
- [x] ``test_list_owner_tumbler_form_still_works`` — existing dotted form '1.1' unchanged (no regression).
- [x] 84/84 test_catalog_cli regression green.

## Out of scope

Applying the same name-resolution to other catalog CLI subcommands (nx catalog show, nx catalog resolve). One bite per release.

Bead: nexus-1lx7
Issue: GH #537