### PR TITLE
feat(migration): backfill document_aspects.source_uri empty rows (nexus-pnje)

### DIFF
--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -1668,6 +1668,70 @@ def migrate_document_aspects_source_uri(conn: sqlite3.Connection) -> None:
         )
 
 
+def migrate_document_aspects_source_uri_backfill_empty(conn: sqlite3.Connection) -> None:
+    """nexus-pnje: backfill ``document_aspects`` rows where
+    ``source_uri = ''`` (in addition to NULL).
+
+    The original RDR-096 P2.1 migration (``migrate_document_aspects_
+    source_uri`` above) only touched rows where ``source_uri IS NULL``.
+    Subsequent writer paths landed empty-string rows after the
+    migration ran; the live audit on production T2 (2026-05-06)
+    showed 61 of 579 rows (10.5%) with empty ``source_uri`` and
+    populated ``source_path``.
+
+    Prerequisite for ``nexus-ocu9.11`` (RDR-096 P5.2 — DROP COLUMN
+    ``source_path`` in 4.27.0). That migration's strict-audit step
+    blocks if any row has ``source_uri`` NULL or empty; this backfill
+    drops the count to zero so 4.27.0 ships cleanly without manual
+    triage.
+
+    Idempotent: only updates rows where source_uri is NULL OR ''
+    AND source_path is populated. Skipped rows (empty source_path
+    too) are left for manual triage and surfaced in the WARN log.
+    """
+    from nexus.aspect_readers import uri_for  # noqa: PLC0415
+
+    cols = {
+        r[1]
+        for r in conn.execute("PRAGMA table_info(document_aspects)").fetchall()
+    }
+    if not cols or "source_uri" not in cols:
+        return
+
+    rows = conn.execute(
+        "SELECT rowid, collection, source_path FROM document_aspects "
+        "WHERE (source_uri IS NULL OR source_uri = '') "
+        "  AND source_path IS NOT NULL "
+        "  AND source_path != ''",
+    ).fetchall()
+
+    backfilled = 0
+    skipped_uri_for_returned_none = 0
+    conn.execute("BEGIN")
+    try:
+        for rowid, collection, source_path in rows:
+            uri = uri_for(collection, source_path)
+            if uri is None:
+                skipped_uri_for_returned_none += 1
+                continue
+            conn.execute(
+                "UPDATE document_aspects SET source_uri = ? WHERE rowid = ?",
+                (uri, rowid),
+            )
+            backfilled += 1
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    if backfilled or skipped_uri_for_returned_none:
+        _log.info(
+            "migrate_document_aspects_source_uri_backfill_empty",
+            backfilled=backfilled,
+            skipped_uri_for_returned_none=skipped_uri_for_returned_none,
+        )
+
+
 def migrate_drop_null_aspect_rows(conn: sqlite3.Connection) -> None:
     """RDR-096 P2.2: drop pre-RDR-096 read-failure rows from
     ``document_aspects`` using the seven-clause discriminator from
@@ -1884,6 +1948,11 @@ MIGRATIONS: list[Migration] = [
         "4.25.5",
         "Create tier_writes table (Phase 1A tier-discipline telemetry, nexus-kren)",
         migrate_tier_writes,
+    ),
+    Migration(
+        "4.26.2",
+        "Backfill document_aspects.source_uri rows where empty string (nexus-pnje)",
+        migrate_document_aspects_source_uri_backfill_empty,
     ),
 ]
 

--- a/tests/test_migrations_rdr096.py
+++ b/tests/test_migrations_rdr096.py
@@ -242,6 +242,135 @@ class TestDocumentAspectsSourceUriMigration:
         migrate_document_aspects_source_uri(conn)  # must not raise
         conn.close()
 
+    def test_backfill_empty_string_rows_in_addition_to_null(
+        self, tmp_path: Path,
+    ) -> None:
+        """nexus-pnje: the original P2.1 migration only touched NULL
+        rows. Subsequent writer paths landed empty-string rows; the
+        live audit on production found 61 of 579 rows (10.5%) with
+        empty source_uri. The follow-up migration must backfill BOTH
+        NULL and '' rows.
+        """
+        from nexus.db.migrations import (
+            migrate_document_aspects_source_uri,
+            migrate_document_aspects_source_uri_backfill_empty,
+        )
+
+        db = tmp_path / "empty_backfill.db"
+        conn = sqlite3.connect(str(db))
+        self._seed_legacy_table(conn)
+        # Insert 3 rows BEFORE P2.1 so they have NULL source_uri after
+        # the column is added.
+        self._insert_row(conn, collection="rdr__a", source_path="x.md")
+        self._insert_row(conn, collection="rdr__b", source_path="y.md")
+        self._insert_row(conn, collection="rdr__c", source_path="z.md")
+
+        # Apply P2.1 — backfills all NULL rows.
+        migrate_document_aspects_source_uri(conn)
+
+        # Simulate the production gap: a writer path lands empty-string
+        # source_uri AFTER P2.1 ran. Mirrors the 61 rows seen on prod.
+        conn.execute(
+            "UPDATE document_aspects SET source_uri = '' "
+            "WHERE collection = 'rdr__a'"
+        )
+        # And one row that's still NULL (didn't get migrated for some
+        # reason — defensive: the new migration must catch this too).
+        conn.execute(
+            "UPDATE document_aspects SET source_uri = NULL "
+            "WHERE collection = 'rdr__b'"
+        )
+        # Third row keeps its valid URI from P2.1.
+        conn.commit()
+
+        # Pre-condition: 1 empty + 1 NULL + 1 valid.
+        before = conn.execute(
+            "SELECT collection, source_uri FROM document_aspects "
+            "ORDER BY collection",
+        ).fetchall()
+        # rdr__a empty, rdr__b NULL, rdr__c populated.
+        assert before[0] == ("rdr__a", "")
+        assert before[1] == ("rdr__b", None)
+        assert before[2][0] == "rdr__c"
+        assert before[2][1] and before[2][1].startswith("file://")
+
+        # Apply the new backfill migration.
+        migrate_document_aspects_source_uri_backfill_empty(conn)
+
+        # Post-condition: rdr__a + rdr__b backfilled to file:// URIs;
+        # rdr__c untouched.
+        after = dict(conn.execute(
+            "SELECT collection, source_uri FROM document_aspects",
+        ).fetchall())
+        conn.close()
+        assert after["rdr__a"].startswith("file://") and after["rdr__a"].endswith("x.md")
+        assert after["rdr__b"].startswith("file://") and after["rdr__b"].endswith("y.md")
+        assert after["rdr__c"] == before[2][1]  # unchanged
+
+    def test_backfill_empty_skips_when_source_path_also_empty(
+        self, tmp_path: Path,
+    ) -> None:
+        """Edge case: row with both source_uri='' AND source_path=''
+        cannot be backfilled. The migration leaves it alone for
+        manual triage rather than synthesising a bad URI.
+        """
+        from nexus.db.migrations import (
+            migrate_document_aspects_source_uri,
+            migrate_document_aspects_source_uri_backfill_empty,
+        )
+
+        db = tmp_path / "edge.db"
+        conn = sqlite3.connect(str(db))
+        self._seed_legacy_table(conn)
+        # P2.1's _insert_row helper requires non-empty source_path; do
+        # the empty insert directly so we exercise the both-empty case.
+        conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, extracted_at, model_version, extractor_name) "
+            "VALUES (?, '', ?, ?, ?)",
+            ("rdr__edge", "2026-04-27T00:00:00+00:00",
+             "claude-haiku-4-5-20251001", "scholarly-paper-v1"),
+        )
+        conn.commit()
+
+        migrate_document_aspects_source_uri(conn)
+        # Force empty-string rather than NULL.
+        conn.execute("UPDATE document_aspects SET source_uri = ''")
+        conn.commit()
+
+        migrate_document_aspects_source_uri_backfill_empty(conn)
+
+        row = conn.execute(
+            "SELECT source_path, source_uri FROM document_aspects",
+        ).fetchone()
+        conn.close()
+        # Both still empty — migration left the row for triage.
+        assert row == ("", "")
+
+    def test_backfill_empty_idempotent(self, tmp_path: Path) -> None:
+        """Re-running the backfill is a no-op (no UPDATE on already-
+        populated rows)."""
+        from nexus.db.migrations import (
+            migrate_document_aspects_source_uri,
+            migrate_document_aspects_source_uri_backfill_empty,
+        )
+
+        db = tmp_path / "idem.db"
+        conn = sqlite3.connect(str(db))
+        self._seed_legacy_table(conn)
+        self._insert_row(conn, collection="rdr__a", source_path="x.md")
+        migrate_document_aspects_source_uri(conn)
+        conn.execute("UPDATE document_aspects SET source_uri = ''")
+        conn.commit()
+
+        migrate_document_aspects_source_uri_backfill_empty(conn)
+        first = conn.execute("SELECT source_uri FROM document_aspects").fetchone()[0]
+        migrate_document_aspects_source_uri_backfill_empty(conn)  # re-run
+        second = conn.execute("SELECT source_uri FROM document_aspects").fetchone()[0]
+        conn.close()
+        assert first == second
+        assert first.startswith("file://")
+
 
 # ── catalog documents inline migration ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Follow-up to RDR-096 P2.1 migration. The original ``migrate_document_aspects_source_uri`` only touched rows where ``source_uri IS NULL``. Subsequent writer paths landed empty-string rows after the migration ran; the live audit on production found **61 of 579 rows (10.5%)** with empty ``source_uri`` and populated ``source_path``.

Prerequisite for ``nexus-ocu9.11`` (the 4.27.0 DROP COLUMN ``source_path`` migration). That migration's strict-audit step blocks if any row has ``source_uri`` NULL or empty; this backfill drops the count to zero so 4.27.0 ships cleanly.

## Migration

``migrate_document_aspects_source_uri_backfill_empty``: same shape as the P2.1 backfill, WHERE clause covers BOTH NULL and ``''``. Skipped rows (empty ``source_path`` too) left for manual triage. Registered at version 4.26.2.

## Test plan

- [x] ``backfill_empty_string_rows_in_addition_to_null``: empty + NULL + populated mix → only empty + NULL get backfilled.
- [x] ``backfill_empty_skips_when_source_path_also_empty``: both-empty row stays untouched.
- [x] ``backfill_empty_idempotent``: re-run on populated rows is a no-op.
- [x] 596/596 RDR-096 + plugin-structure regression green.

Bead: nexus-pnje