### PR TITLE
fix(search-cmd): nx search --corpus accepts CSV (#538)

### DIFF
--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -144,7 +144,9 @@ def _rg_hit_to_result(hit: dict) -> SearchResult:
 @click.argument("query")
 @click.argument("path", required=False, default=None)
 @click.option("--corpus", multiple=True, default=("knowledge", "code", "docs"),
-              show_default=True, help="Corpus prefix or full collection name (repeatable)")
+              show_default=True,
+              help="Corpus prefix or full collection name "
+                   "(repeatable: --corpus a --corpus b; or comma-separated: --corpus a,b)")
 @click.option("--n", "-m", "--max-results", "n", default=10, show_default=True,
               help="Max results to return")
 @click.option("--hybrid", is_flag=True, default=False,
@@ -267,8 +269,19 @@ def search_cmd(
     db = _t3()
     all_collections = [c["name"] for c in db.list_collections()]
 
+    # Pre-split each --corpus value on commas so the CLI accepts the
+    # same CSV form that MCP search(corpus=...) documents (#538 /
+    # nexus-v8cj). Mixed forms work: `--corpus a,b --corpus c` expands
+    # to ["a", "b", "c"].
+    expanded_corpus: list[str] = []
+    for raw in corpus:
+        for part in raw.split(","):
+            part = part.strip()
+            if part:
+                expanded_corpus.append(part)
+
     target_collections: list[str] = []
-    for c in corpus:
+    for c in expanded_corpus:
         matched = resolve_corpus(c, all_collections)
         if not matched:
             click.echo(f"Warning: no collections match --corpus {c!r}", err=True)

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -106,6 +106,71 @@ def test_corpus_long_form_still_works(runner: CliRunner, cloud_env) -> None:
     assert "Error" not in result.output or result.exit_code == 0
 
 
+def test_corpus_csv_form_matches_repeat_form(
+    runner: CliRunner, cloud_env,
+) -> None:
+    """nexus-v8cj (#538): --corpus a,b must hit the same collections
+    as --corpus a --corpus b. Pre-fix the CSV form was treated as a
+    single literal corpus name, emitted 'no collections match', and
+    the search returned no results.
+    """
+    mock_t3 = _mock_t3(["knowledge__test", "rdr__nexus"])
+    with patch("nexus.commands.search_cmd._t3", return_value=mock_t3), \
+         patch("nexus.commands.search_cmd.search_cross_corpus", return_value=[]) as ms:
+        result = runner.invoke(
+            main, ["search", "query", "--corpus", "knowledge,rdr"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "no collections match" not in result.output.lower()
+    # The CSV expanded into both targets reaching search_cross_corpus.
+    call_kwargs = ms.call_args.kwargs if ms.call_args else {}
+    targets = call_kwargs.get("collections") or (ms.call_args.args[1] if ms.call_args else [])
+    target_names = sorted(targets)
+    assert "knowledge__test" in target_names
+    assert "rdr__nexus" in target_names
+
+
+def test_corpus_csv_and_repeat_forms_can_mix(
+    runner: CliRunner, cloud_env,
+) -> None:
+    """Combined: --corpus a,b --corpus c expands to three corpora."""
+    mock_t3 = _mock_t3(["knowledge__test", "rdr__nexus", "code__one"])
+    with patch("nexus.commands.search_cmd._t3", return_value=mock_t3), \
+         patch("nexus.commands.search_cmd.search_cross_corpus", return_value=[]) as ms:
+        result = runner.invoke(
+            main, ["search", "query",
+                   "--corpus", "knowledge,rdr",
+                   "--corpus", "code"],
+        )
+    assert result.exit_code == 0, result.output
+    call_kwargs = ms.call_args.kwargs if ms.call_args else {}
+    targets = call_kwargs.get("collections") or (ms.call_args.args[1] if ms.call_args else [])
+    target_names = sorted(targets)
+    assert "knowledge__test" in target_names
+    assert "rdr__nexus" in target_names
+    assert "code__one" in target_names
+
+
+def test_corpus_csv_handles_whitespace(
+    runner: CliRunner, cloud_env,
+) -> None:
+    """Whitespace around comma-separated values is stripped; empty
+    components are dropped (`'a,,b '` → `['a', 'b']`).
+    """
+    mock_t3 = _mock_t3(["knowledge__test", "rdr__nexus"])
+    with patch("nexus.commands.search_cmd._t3", return_value=mock_t3), \
+         patch("nexus.commands.search_cmd.search_cross_corpus", return_value=[]) as ms:
+        result = runner.invoke(
+            main, ["search", "query", "--corpus", " knowledge , , rdr "],
+        )
+    assert result.exit_code == 0, result.output
+    call_kwargs = ms.call_args.kwargs if ms.call_args else {}
+    targets = call_kwargs.get("collections") or (ms.call_args.args[1] if ms.call_args else [])
+    target_names = sorted(targets)
+    assert "knowledge__test" in target_names
+    assert "rdr__nexus" in target_names
+
+
 def test_m_flag_limits_results(runner: CliRunner, cloud_env) -> None:
     results_pool = [
         _make_result(f"r{i}", f"line {i}", distance=float(i) * 0.1)


### PR DESCRIPTION
## Summary

Closes **#538**. CLI ``nx search --corpus a,b`` was silently treated as a single literal corpus name (emitted "no collections match"), while the MCP ``search(corpus="a,b")`` tool documented and accepted CSV. Operators bouncing between the two surfaces hit this regularly.

## Fix

Pre-split each ``--corpus`` value on commas before resolving. Mixed forms work too. Help text updated.

## Test plan

- [x] CSV form matches repeat-flag form.
- [x] Mixed: ``--corpus a,b --corpus c`` expands to 3 corpora.
- [x] Whitespace around commas is stripped; empty components dropped.
- [x] 60/60 ``test_search_cmd.py`` regression green.

Bead: nexus-v8cj
Issue: GH #538