### PR TITLE
fix(cli): line-buffer stdout/stderr to flush progress in non-TTY (#370)

### DIFF
--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -1,5 +1,25 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+import sys
+
 import click
+
+# Issue #370: line-buffer stdout/stderr at CLI entry so progress lines
+# from long-running commands (nx index repo, nx enrich aspects) flush
+# immediately when running in non-interactive contexts (background
+# process, piped output, subprocess). Python's default stdout buffering
+# is line-buffered when attached to a terminal but FULLY buffered
+# otherwise, which leaves progress invisible for 10+ minutes on large
+# repos. ``reconfigure(line_buffering=True)`` lands the same flush-on-
+# newline behaviour regardless of terminal attachment.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(line_buffering=True)
+    except (AttributeError, OSError):
+        # AttributeError: pre-3.7 ``reconfigure`` is missing (we're 3.12+
+        # so this branch is dead, but defensive); OSError: stream is
+        # closed or doesn't support reconfigure (e.g. captured by pytest's
+        # capsys, which monkey-patches stdout/stderr to non-text streams).
+        pass
 
 from nexus.commands.catalog import catalog
 from nexus.commands.collection import collection

--- a/tests/test_cli_registration.py
+++ b/tests/test_cli_registration.py
@@ -117,3 +117,23 @@ def test_catalog_mcp_tools_registered():
     }
     missing = expected - tools
     assert not missing, f"Missing catalog MCP tools: {missing}"
+
+
+def test_cli_import_enables_line_buffered_stdio():
+    """Issue #370: importing nexus.cli must reconfigure stdout/stderr
+    to line-buffered so long-running commands flush progress lines
+    in non-interactive contexts (background, piped, subprocess).
+
+    Python's default in non-TTY contexts is FULL buffering, which
+    swallows 10+ minutes of progress on large repo indexes.
+    """
+    import sys
+    # Re-import is a no-op if already imported, but the side effect
+    # (reconfigure) ran once at module load time.
+    import nexus.cli  # noqa: F401
+    assert sys.stdout.line_buffering, (
+        "nexus.cli import must enable line-buffering on stdout"
+    )
+    assert sys.stderr.line_buffering, (
+        "nexus.cli import must enable line-buffering on stderr"
+    )


### PR DESCRIPTION
## Summary

Closes **#370**. ``nx index repo`` running in non-interactive contexts (background process, piped output, subprocess) showed zero progress for 10+ minutes because Python's default stdout is FULLY buffered when not attached to a TTY.

## Fix

``sys.stdout.reconfigure(line_buffering=True)`` and the same for ``sys.stderr`` at the top of ``src/nexus/cli.py``. Same flush-on-newline behaviour as TTY mode regardless of terminal attachment. Defensive try/except (OSError, AttributeError) so test contexts that monkey-patch these streams don't crash the import.

## Test plan

- [x] ``test_cli_import_enables_line_buffered_stdio`` asserts both streams are ``line_buffering=True`` after ``import nexus.cli``.
- [x] Live smoke: ``import nexus.cli; print(sys.stdout.line_buffering)`` returns ``True``.
- [x] 581/581 plugin/CLI regression green.

Issue: GH #370