### PR TITLE
fix(catalog-db): cap WAL growth via journal_size_limit (#437)

### DIFF
--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -237,6 +237,16 @@ class CatalogDB:
         # an indexing writer.
         self._conn.execute("PRAGMA busy_timeout=5000")
         self._conn.execute("PRAGMA journal_mode=WAL")
+        # Issue #437: cap WAL growth under long-lived MCP-server reader
+        # connections. SQLite's auto-checkpoint can run only as PASSIVE
+        # while readers hold pre-checkpoint snapshots; PASSIVE folds
+        # frames into the main DB but cannot truncate the WAL file.
+        # Without a journal_size_limit the WAL grows unbounded over a
+        # multi-hour session (12 MB observed on the reporter's install
+        # before manual ``PRAGMA wal_checkpoint(TRUNCATE)``). 64 MiB
+        # caps the steady-state size after each successful checkpoint;
+        # SQLite reuses the space rather than growing the file.
+        self._conn.execute("PRAGMA journal_size_limit=67108864")
         self._conn.executescript(_SCHEMA_SQL)
         # Migration: add repo_root column if missing (pre-RDR-060 databases)
         try:

--- a/tests/test_catalog_db.py
+++ b/tests/test_catalog_db.py
@@ -82,6 +82,21 @@ class TestSchemaCreation:
         mode = db._conn.execute("PRAGMA journal_mode").fetchone()[0]
         assert mode == "wal"
 
+    def test_journal_size_limit_set(self, tmp_path):
+        """Issue #437: journal_size_limit caps WAL growth under
+        long-lived MCP-server reader connections. SQLite's auto-
+        checkpoint runs only as PASSIVE while readers hold pre-
+        checkpoint snapshots; PASSIVE folds frames into the main DB
+        but cannot truncate the WAL file. Without journal_size_limit
+        the WAL grows unbounded over multi-hour sessions.
+        """
+        db = CatalogDB(tmp_path / ".catalog.db")
+        limit = db._conn.execute("PRAGMA journal_size_limit").fetchone()[0]
+        # 64 MiB cap from the issue's recommended value.
+        assert limit == 67108864, (
+            f"journal_size_limit should cap WAL at 64 MiB; got {limit}"
+        )
+
     def test_indexes_exist(self, tmp_path):
         db = CatalogDB(tmp_path / ".catalog.db")
         indexes = {


### PR DESCRIPTION
## Summary

Closes **#437**. Adds ``PRAGMA journal_size_limit=67108864`` (64 MiB) to ``CatalogDB`` so the WAL caps at a bounded steady-state size instead of growing unbounded under long-lived MCP-server reader connections. Reporter observed 12 MB WAL after a few hours; ``PRAGMA wal_checkpoint(TRUNCATE)`` immediately dropped it to 0, confirming the frames were checkpoint-eligible but blocked by reader snapshots.

This is the cheapest of the three options the reporter proposed.

## Test plan

- [x] ``test_journal_size_limit_set`` asserts ``PRAGMA journal_size_limit`` returns 67108864 after init.
- [x] Existing ``test_wal_mode`` still passes (no regression to journal mode).
- [x] 26/26 ``test_catalog_db.py`` regression green.

Issue: GH #437