### PR TITLE
fix(t3,bib): defensive guards against malformed external data

### DIFF
--- a/src/nexus/bib_enricher_openalex.py
+++ b/src/nexus/bib_enricher_openalex.py
@@ -170,6 +170,17 @@ def _titles_compatible(source: str, returned: str) -> bool:
     if len(intersection) >= _TITLE_MIN_INTERSECTION_FOR_AUTO_ACCEPT:
         return True
     if len(intersection) == 1:
+        # nexus-5cez: the short-source relaxation was designed for
+        # filename-derived 2-token titles like "Pbeegees" matching
+        # "pBeeGees: A Prudent Approach to ...", not for genuinely
+        # 1-token source titles ("Survey", "Methods", "Notes") where
+        # any OpenAlex paper that happens to mention the word would
+        # auto-accept. Require BOTH sides to have at least 2
+        # substantive tokens before the relaxation applies; 1-token
+        # sides fall through to reject so the caller takes the fuzzy-
+        # search path instead of stamping a coincidence.
+        if len(a) < 2 or len(b) < 2:
+            return False
         return min(len(a), len(b)) <= _TITLE_MAX_SHORT_SET_SIZE
     return False
 

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -939,6 +939,28 @@ class T3Database:
                 qr["metadatas"][0],
                 qr["distances"][0],
             ):
+                # GH #373: ChromaDB can return None metadata entries for
+                # corrupted or upsert-without-meta rows. The bare ``**meta``
+                # then raises ``TypeError: 'NoneType' object is not a
+                # mapping`` and kills the entire query, even though the
+                # other rows in the result set are valid. Defensively
+                # coerce + log so the row still surfaces with empty
+                # metadata fields.
+                if meta is None:
+                    _log.warning(
+                        "t3_query_meta_none",
+                        doc_id=doc_id,
+                        collection=name,
+                    )
+                    meta = {}
+                elif not isinstance(meta, dict):
+                    _log.warning(
+                        "t3_query_meta_corrupt",
+                        doc_id=doc_id,
+                        collection=name,
+                        meta_type=type(meta).__name__,
+                    )
+                    meta = {}
                 results.append({"id": doc_id, "content": doc, "distance": dist, **meta})
         return sorted(results, key=lambda r: r["distance"])
 
@@ -1025,8 +1047,10 @@ class T3Database:
             result = _chroma_with_retry(
                 col.get, include=["metadatas"], limit=clamped, offset=offset,
             )
+        # GH #373 mirror: same None-meta defence as the query path; a
+        # single corrupted row should not blank the whole listing.
         return [
-            {"id": doc_id, **meta}
+            {"id": doc_id, **(meta if isinstance(meta, dict) else {})}
             for doc_id, meta in zip(result["ids"], result["metadatas"])
         ]
 

--- a/tests/test_bib_enricher_openalex.py
+++ b/tests/test_bib_enricher_openalex.py
@@ -399,6 +399,46 @@ def test_titles_compatible_single_overlap_in_long_titles_rejects():
     )
 
 
+def test_titles_compatible_single_token_source_rejects():
+    """nexus-5cez: a 1-token source title (e.g. "Survey", "Methods")
+    must NOT auto-accept on common-word coincidence. The short-source
+    relaxation (2026-04-21) was designed for 2-token cases like
+    "Pbeegees" matching "pBeeGees: A Prudent Approach to ...", not
+    for genuinely single-substantive-token titles where any OpenAlex
+    paper that mentions the word would auto-accept.
+
+    Both ``a < 2`` and ``b < 2`` must reject so the caller falls
+    through to fuzzy search instead of stamping the coincidence.
+    """
+    from nexus.bib_enricher_openalex import _titles_compatible
+
+    # 1-token source ("Survey", post-tokenize) vs unrelated long
+    # title that happens to mention "survey" must reject.
+    assert not _titles_compatible(
+        "Survey",
+        "A Survey of Distributed Consensus Algorithms in Practice",
+    )
+
+    # Symmetric: 1-token returned title that coincidentally shares
+    # one word with a multi-token source must also reject.
+    assert not _titles_compatible(
+        "Distributed Consensus Algorithms in Practice",
+        "Algorithms",
+    )
+
+    # Both single-token: 100% intersection of single shared word
+    # is still a coincidence reject.
+    assert not _titles_compatible("Methods", "Methods")
+
+    # Existing 2-token case (filename-derived "Pbeegees") still
+    # accepts: the relaxation gate is "≥2 substantive tokens BOTH
+    # sides", not "≥2 in either".
+    assert _titles_compatible(
+        "Pbeegees Consensus",
+        "pBeeGees A Prudent Approach Consensus",
+    )
+
+
 def test_titles_compatible_helper_basics():
     """The helper is exported so callers (commands/enrich._resolve_bib_for_title)
     can validate title shapes outside the OpenAlex backend too. Source-paper


### PR DESCRIPTION
## Summary

Two unrelated defensive fixes against malformed external data, batched into one PR.

- **GH #373** — `t3.py:942` + `t3.py:1051` crashed on `None` metadata returned by ChromaDB (corrupted / upsert-without-meta rows). Now coerces to `{}` with a structlog warning so the row surfaces with empty metadata and the failure leaves a footprint instead of an opaque `TypeError`.
- **nexus-5cez** — `bib_enricher_openalex._titles_compatible` auto-accepted single-token coincidences. The short-source relaxation (designed for 2-token filenames like `Pbeegees` → `pBeeGees: A Prudent Approach…`) was firing on 1-token sources (`Survey`, `Methods`) where any OpenAlex paper that mentions the word would over-accept and stamp the wrong bib. Now requires both sides ≥2 substantive tokens before relaxation applies.

## Closes

- Closes #373
- Closes nexus-5cez

## Test plan

- [x] `uv run pytest tests/test_bib_enricher_openalex.py -k "single_token_source or single_overlap" -xvs` — 2 passed (1 new + 1 regression)
- [x] `uv run pytest tests/test_t3.py -k "list_store_multiple or test_search_returns" -xvs` — 2 passed (defensive guard sites stay green)
- [ ] CI green