### PR TITLE
fix(operators,plans): graceful degrade on OperatorError + capture timeout output

### DIFF
--- a/src/nexus/operators/dispatch.py
+++ b/src/nexus/operators/dispatch.py
@@ -39,6 +39,52 @@ class OperatorOutputError(OperatorError):
     """Raised when stdout cannot be parsed as JSON."""
 
 
+async def _drain_pipe(pipe: asyncio.StreamReader | None) -> bytes:
+    """Read whatever bytes are currently buffered in *pipe*.
+
+    Used by the timeout path (nexus-1at5) AFTER the subprocess has
+    been killed and reaped. The writer is dead, so ``read()`` returns
+    EOF immediately for whatever was buffered without blocking.
+    Returns an empty ``bytes`` on any error so the caller can still
+    raise the timeout exception cleanly.
+    """
+    if pipe is None:
+        return b""
+    try:
+        return await pipe.read()
+    except Exception:
+        return b""
+
+
+def _persist_timeout_log(
+    timeout: float, stdout: bytes, stderr: bytes,
+) -> str:
+    """Persist partial subprocess output to a timestamped log file.
+
+    Returns the file path as a string for inclusion in the timeout
+    exception message. Failures to write the log are swallowed so
+    that the timeout exception (the load-bearing signal) always
+    surfaces; the absent log is a soft loss.
+    """
+    from datetime import datetime, timezone
+    from nexus.config import nexus_config_dir
+
+    try:
+        logs_dir = nexus_config_dir() / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        path = logs_dir / f"operator-timeout-{ts}.log"
+        path.write_bytes(
+            f"[operator-timeout {timeout}s] {ts}Z\n".encode()
+            + b"--- stdout ---\n" + stdout + b"\n"
+            + b"--- stderr ---\n" + stderr + b"\n"
+        )
+        return str(path)
+    except Exception as exc:
+        _log.warning("operator_timeout_log_failed", error=str(exc))
+        return "(log write failed)"
+
+
 async def claude_dispatch(
     prompt: str,
     json_schema: dict[str, Any],
@@ -134,8 +180,22 @@ async def claude_dispatch(
             await proc.wait()
         except Exception:
             pass
+        # nexus-1at5: drain whatever bytes already landed in the pipe
+        # buffers BEFORE raising. ``communicate()`` was cancelled mid-
+        # await so its return value is gone, but the kernel-side pipe
+        # still holds whatever the subprocess wrote. After kill+wait
+        # the writer is dead, so the read drains cleanly without
+        # blocking. Persist to a per-call log file so the operator can
+        # see what claude was producing when the timeout fired -
+        # otherwise a 5-minute timeout discards 5 minutes of analytical
+        # output and the next debugging session starts from zero.
+        partial_stdout = await _drain_pipe(proc.stdout)
+        partial_stderr = await _drain_pipe(proc.stderr)
+        log_path = _persist_timeout_log(timeout, partial_stdout, partial_stderr)
         raise OperatorTimeoutError(
-            f"claude -p timed out after {timeout}s"
+            f"claude -p timed out after {timeout}s; "
+            f"partial output ({len(partial_stdout)}B stdout, "
+            f"{len(partial_stderr)}B stderr) logged to {log_path}"
         )
 
     if proc.returncode != 0:

--- a/src/nexus/plans/runner.py
+++ b/src/nexus/plans/runner.py
@@ -310,6 +310,33 @@ _STEPREF_RE = re.compile(r"^\$step(\d+)\.([A-Za-z_][A-Za-z0-9_]*)$")
 #: :mod:`nexus.plans.bundle` (``DEFERRED_REF_KEY``) so a rename or typo
 #: on either side can't silently drop the sentinel (substantive-critic C2).
 from nexus.plans.bundle import DEFERRED_REF_KEY as _DEFERRED_REF_KEY  # noqa: E402
+from nexus.operators.dispatch import OperatorError as _OperatorError  # noqa: E402
+
+
+# nexus-l0yh: sentinel that replaces a step's output when the
+# operator dispatch raised :class:`OperatorError`. The runner stays
+# alive, downstream ``$stepN.<field>`` references resolve to ``""``
+# via the dict fall-through (no KeyError), and the final result
+# carries enough breadcrumbs for the operator to triage in the
+# logs. Mirrors the retrieval-tool short-circuit shape (e.g.
+# catalog_not_initialized => ``{ids:[], error:...}``).
+_OPERATOR_FAILED_SENTINEL_KEYS = ("error", "status", "tool", "step_index")
+def _operator_failed_sentinel(
+    *, tool: str, step_index: int, message: str,
+) -> dict[str, Any]:
+    return {
+        "error": message,
+        "status": "failed",
+        "tool": tool,
+        "step_index": step_index,
+        # Common downstream fields tools usually return; substituting
+        # empty values lets ``$stepN.text`` / ``$stepN.summary`` /
+        # ``$stepN.aggregates`` style refs resolve to a falsy value
+        # instead of raising PlanRunStepRefError.
+        "text": "",
+        "summary": "",
+        "aggregates": [],
+    }
 
 
 def _resolve_value(
@@ -1118,11 +1145,28 @@ async def plan_run(
                         b_raw_args, bindings=merged,
                         step_outputs=step_outputs,
                     )
-                    raw = dispatch(btool, b_resolved)
-                    if inspect.iscoroutine(raw):
-                        result = await raw
-                    else:
-                        result = raw
+                    try:
+                        raw = dispatch(btool, b_resolved)
+                        if inspect.iscoroutine(raw):
+                            result = await raw
+                        else:
+                            result = raw
+                    except _OperatorError as exc:
+                        # nexus-l0yh: graceful degrade — substitute
+                        # sentinel, log, continue. Bundle fallback
+                        # path: each step gets its own sentinel so the
+                        # plan can still surface partial results.
+                        _log.warning(
+                            "operator_step_failed",
+                            kind="bundle_fallback",
+                            step_index=bi,
+                            tool=btool,
+                            error=str(exc),
+                        )
+                        step_outputs.append(_operator_failed_sentinel(
+                            tool=btool, step_index=bi, message=str(exc),
+                        ))
+                        continue
                     if not isinstance(result, dict):
                         raise PlanRunStepRefError(
                             ref=f"step{bi + 1}",
@@ -1142,7 +1186,28 @@ async def plan_run(
                 )
                 continue
 
-            bundle_result = await dispatch_bundle(bundle)
+            try:
+                bundle_result = await dispatch_bundle(bundle)
+            except _OperatorError as exc:
+                # nexus-l0yh: bundle dispatch covers every plan_index
+                # in the segment, so on failure push one sentinel per
+                # index. Downstream refs to the terminal slot now
+                # resolve to the failed-sentinel; the planner sees
+                # ``status: failed`` if it inspects step output, or
+                # falls through to empty fields for $stepN.<field>.
+                _log.warning(
+                    "operator_step_failed",
+                    kind="bundle",
+                    step_indices=list(seg.plan_indices),
+                    error=str(exc),
+                )
+                for bi in seg.plan_indices:
+                    step_outputs.append(_operator_failed_sentinel(
+                        tool=_extract_tool(steps[bi]),
+                        step_index=bi,
+                        message=str(exc),
+                    ))
+                continue
             # Intermediate slots: sentinel. Terminal slot: the real
             # output. Downstream $stepN.<field> refs to an intermediate
             # raise a specific "inside a bundle" error via
@@ -1206,11 +1271,26 @@ async def plan_run(
         # (legacy test fixtures + any caller that prefers the simpler
         # contract). Detect a returned coroutine and await it; treat a
         # returned dict/mapping as the direct result.
-        raw = dispatch(tool, resolved)
-        if inspect.iscoroutine(raw):
-            result = await raw
-        else:
-            result = raw
+        try:
+            raw = dispatch(tool, resolved)
+            if inspect.iscoroutine(raw):
+                result = await raw
+            else:
+                result = raw
+        except _OperatorError as exc:
+            # nexus-l0yh: graceful degrade for the isolated-step path.
+            # Substitute sentinel, log, continue with the next step.
+            _log.warning(
+                "operator_step_failed",
+                kind="isolated",
+                step_index=index,
+                tool=tool,
+                error=str(exc),
+            )
+            step_outputs.append(_operator_failed_sentinel(
+                tool=tool, step_index=index, message=str(exc),
+            ))
+            continue
         if not isinstance(result, dict):
             # Tool authors must follow the documented output contract;
             # surface non-dict returns explicitly rather than letting

--- a/tests/test_plan_run.py
+++ b/tests/test_plan_run.py
@@ -1762,3 +1762,62 @@ class TestPlanRunStepProgressLogs:
         assert isinstance(ev["elapsed_ms"], int)
         assert ev["elapsed_ms"] >= 0
         assert ev["kind"] == "isolated"
+
+
+# ── nexus-l0yh: OperatorError graceful fallback ────────────────────────────
+
+
+class _OperatorFailingDispatcher:
+    """Dispatcher that raises ``OperatorError`` on any operator step.
+
+    Retrieval steps return a stub dict so step-output binding still
+    works for downstream refs. Used to verify the runner's graceful
+    degradation behavior (nexus-l0yh).
+    """
+
+    def __init__(self, message: str = "claude -p exited 1") -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._message = message
+
+    async def __call__(self, tool: str, args: dict) -> dict:
+        from nexus.operators.dispatch import OperatorError
+        self.calls.append((tool, args))
+        if tool.startswith("operator_"):
+            raise OperatorError(self._message)
+        return {"text": f"{tool}(stub)", "ids": [], "tumblers": []}
+
+
+@pytest.mark.asyncio
+async def test_run_substitutes_sentinel_on_operator_error_isolated() -> None:
+    """nexus-l0yh: an isolated operator step that raises OperatorError
+    must NOT propagate; the runner substitutes a failure sentinel into
+    step_outputs and continues with the next step.
+    """
+    from nexus.plans.runner import plan_run
+
+    plan = {
+        "steps": [
+            {"tool": "search", "args": {"query": "x"}},
+            {"tool": "operator_summarize", "args": {"text": "$step1.text"}},
+            {"tool": "search", "args": {"query": "y"}},
+        ],
+    }
+    disp = _OperatorFailingDispatcher("simulated dispatch failure")
+    result = await plan_run(_match(plan), {}, dispatcher=disp)
+
+    # All three steps must have run — failure on step 2 must NOT
+    # short-circuit step 3.
+    assert len(disp.calls) == 3
+    assert disp.calls[0][0] == "search"
+    assert disp.calls[1][0] == "operator_summarize"
+    assert disp.calls[2][0] == "search"
+
+    # step 2's output is the sentinel.
+    s2 = result.steps[1]
+    assert s2["status"] == "failed"
+    assert s2["tool"] == "operator_summarize"
+    assert s2["step_index"] == 1
+    assert "simulated dispatch failure" in s2["error"]
+    # Empty downstream-ref fields so $stepN.<field> resolves to "" not raises.
+    assert s2["text"] == ""
+    assert s2["summary"] == ""


### PR DESCRIPTION
## Summary

Two related fixes for plan-runner robustness under operator failures.

- **nexus-l0yh** — when an operator step (a tool that dispatches via `claude -p`) raises `OperatorError`, the runner now substitutes a sentinel `{ error, status: failed, tool, step_index, text: '', summary: '', aggregates: [] }` into step_outputs and continues. Previously the exception propagated and killed the entire `plan_run` / `nx_answer` call. Three call sites patched: bundle dispatch, bundle-fallback per-step, isolated step.
- **nexus-1at5** — when `claude_dispatch` times out, the partial stdout/stderr in the pipe buffers was discarded. After SIGKILL+reap, `_drain_pipe` collects whatever was produced and persists it to `~/.config/nexus/logs/operator-timeout-<ts>.log`. The exception message includes the log path.

## Closes

- Closes nexus-l0yh
- Closes nexus-1at5

## Test plan

- [x] New `test_run_substitutes_sentinel_on_operator_error_isolated` with `_OperatorFailingDispatcher` fixture covering 3-step plan: `search → operator_summarize (fails) → search`. All 3 calls dispatched, step 2 sentinel populated.
- [x] `uv run pytest tests/test_plan_run.py tests/test_nx_answer.py tests/test_operator_dispatch.py -x` — 227 passed
- [ ] CI green