### PR TITLE
feat(scratch): get/delete accept unique 8-char prefix (nexus-zpw6)

### DIFF
--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -347,9 +347,78 @@ class T1Database:
 
     # ── Read ──────────────────────────────────────────────────────────────────
 
+    def _resolve_id(self, id: str) -> tuple[str | None, list[str]]:
+        """Exact-then-prefix id resolution scoped to this session.
+
+        Mirrors :meth:`MemoryStore.resolve_title` (nexus-e59o):
+
+        * Exact session-owned match found: returns ``(id, [])``.
+        * No exact match, exactly one session-owned id whose value
+          starts with *id*: returns ``(full_id, [])``.
+        * Multiple session-owned prefix candidates: returns
+          ``(None, [candidate_ids])`` so the caller can list them.
+        * Nothing matches: returns ``(None, [])``.
+
+        Used by :meth:`get` and :meth:`delete` so the operator can paste
+        back the 8-char prefix that ``scratch list`` displays
+        (nexus-zpw6) instead of being forced to type the full UUID.
+        Ownership check: the prefix scan is constrained to the current
+        ``session_id`` so a sibling session's id never leaks into the
+        candidate list.
+        """
+        # Exact lookup against the FULL collection — ChromaDB's
+        # ``ids=[id]`` filter is the cheapest path. A non-empty hit
+        # short-circuits before the prefix scan, but we still verify
+        # ownership downstream in get/delete (this method does NOT do
+        # the access-count side effect; callers do).
+        try:
+            exact = self._exec(
+                lambda: self._col.get(ids=[id], include=["metadatas"])
+            )
+        except Exception:
+            exact = {"ids": []}
+        if exact["ids"]:
+            owned = (
+                (exact["metadatas"][0] or {}).get("session_id")
+                == self._session_id
+            )
+            if owned:
+                return id, []
+
+        # Prefix fallback: enumerate this session's ids and filter.
+        # Cheap because list_entries is already paginated to 300/page
+        # and a session typically holds dozens of entries, not
+        # thousands. The ergonomic case (8-char prefix unique) is
+        # the common one; the ambiguous case surfaces a candidate list.
+        try:
+            session_ids = [e["id"] for e in self.list_entries()]
+        except Exception:
+            return None, []
+        candidates = [sid for sid in session_ids if sid.startswith(id)]
+        if len(candidates) == 1:
+            return candidates[0], []
+        return None, candidates
+
     def get(self, id: str) -> dict | None:
-        """Return the document dict for *id*, or None if not found."""
-        result = self._exec(lambda: self._col.get(ids=[id], include=["documents", "metadatas"]))
+        """Return the document dict for *id*, or None if not found.
+
+        nexus-zpw6: ``id`` may be the full UUID (legacy / strict) OR a
+        unique session-owned prefix matching the 8-char form
+        ``scratch list`` displays. Ambiguous prefixes return None and
+        log the candidates so the MCP layer can surface them; this
+        method never picks silently.
+        """
+        resolved, ambiguous = self._resolve_id(id)
+        if resolved is None:
+            if ambiguous:
+                _log.warning(
+                    "t1_get_ambiguous_prefix",
+                    requested_id=id,
+                    candidates=ambiguous,
+                    session_id=self._session_id,
+                )
+            return None
+        result = self._exec(lambda: self._col.get(ids=[resolved], include=["documents", "metadatas"]))
         if not result["ids"]:
             # Bug 1 (nexus-bug-report-2026-04-22): users hit Not-found on
             # ids freshly returned by put(). The path is unreproducible in
@@ -373,9 +442,9 @@ class T1Database:
             "last_accessed": _now_iso(),
         }
         try:
-            self._exec(lambda: self._col.update(ids=[id], metadatas=[updated_meta]))
+            self._exec(lambda: self._col.update(ids=[resolved], metadatas=[updated_meta]))
         except Exception:
-            _log.warning("t1_access_count_update_failed", id=id)
+            _log.warning("t1_access_count_update_failed", id=resolved)
         return self._to_row(result["ids"][0], result["documents"][0], updated_meta)
 
     def search(self, query: str, n_results: int = 10) -> list[dict]:
@@ -561,22 +630,51 @@ class T1Database:
 
 
     def delete(self, id: str) -> bool:
-        """Delete a scratch entry by its full ID.
+        """Delete a scratch entry by its full ID OR unique session-owned prefix.
 
-        Verifies session ownership before deleting — entries belonging to
-        other sessions return False without deleting.  Returns False when the
-        entry does not exist or the session does not own it; True on success.
+        nexus-zpw6: ``id`` may be the full UUID OR a unique session-
+        owned prefix (matches the 8-char form ``scratch list``
+        displays). Ambiguous prefixes return False without deleting
+        and log the candidate ids so the MCP layer can surface them
+        instead of silently picking. Verifies session ownership
+        before deleting; entries belonging to other sessions return
+        False without deleting.
         """
+        resolved, ambiguous = self._resolve_id(id)
+        if resolved is None:
+            if ambiguous:
+                _log.warning(
+                    "t1_delete_ambiguous_prefix",
+                    requested_id=id,
+                    candidates=ambiguous,
+                    session_id=self._session_id,
+                )
+            return False
+
         def _do() -> bool:
-            result = self._col.get(ids=[id], include=["metadatas"])
+            result = self._col.get(ids=[resolved], include=["metadatas"])
             if not result["ids"]:
                 return False
             if result["metadatas"][0].get("session_id") != self._session_id:
                 return False
-            self._col.delete(ids=[id])
+            self._col.delete(ids=[resolved])
             return True
 
         return self._exec(_do)
+
+    def resolve_prefix_candidates(self, id: str) -> list[str]:
+        """Return session-owned ids matching *id* as exact or prefix.
+
+        Public companion to :meth:`_resolve_id` — exposes the
+        ambiguous-candidate list so MCP / CLI wrappers can surface a
+        clean disambiguation message rather than just "not found".
+        Empty list when nothing matches; one-element list when a
+        unique resolution exists; multi-element when ambiguous.
+        """
+        resolved, ambiguous = self._resolve_id(id)
+        if resolved is not None:
+            return [resolved]
+        return ambiguous
 
     # ── Clear ─────────────────────────────────────────────────────────────────
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1772,6 +1772,18 @@ def scratch(
                 return "Error: entry_id is required for get"
             entry = t1.get(entry_id)
             if entry is None:
+                # nexus-zpw6: surface candidate list when the prefix
+                # was ambiguous so the operator can disambiguate
+                # instead of staring at "Not found" while the entry
+                # IS there under a 9-char-prefix sibling.
+                candidates = t1.resolve_prefix_candidates(entry_id)
+                if len(candidates) > 1:
+                    listed = ", ".join(c[:8] for c in candidates[:5])
+                    more = "" if len(candidates) <= 5 else f" (+{len(candidates) - 5} more)"
+                    return (
+                        f"{prefix}Ambiguous prefix {entry_id!r}; "
+                        f"matches: {listed}{more}. Pass a longer prefix or full UUID."
+                    )
                 return f"{prefix}Not found: {entry_id}"
             return f"{prefix}{entry['content']}"
 
@@ -1781,6 +1793,15 @@ def scratch(
             deleted = t1.delete(entry_id)
             if deleted:
                 return f"{prefix}Deleted: {entry_id}"
+            # nexus-zpw6: same disambiguation surface as get.
+            candidates = t1.resolve_prefix_candidates(entry_id)
+            if len(candidates) > 1:
+                listed = ", ".join(c[:8] for c in candidates[:5])
+                more = "" if len(candidates) <= 5 else f" (+{len(candidates) - 5} more)"
+                return (
+                    f"{prefix}Ambiguous prefix {entry_id!r}; "
+                    f"matches: {listed}{more}. Pass a longer prefix or full UUID."
+                )
             return f"{prefix}Not found or not owned: {entry_id}"
 
         else:

--- a/tests/test_scratch.py
+++ b/tests/test_scratch.py
@@ -471,3 +471,87 @@ def test_access_count_update_failure_does_not_raise(t1: T1Database) -> None:
         assert result["content"] == "resilient entry"
     finally:
         t1._col.update = original_update
+
+
+# ── nexus-zpw6: prefix resolution for get/delete ────────────────────────────
+
+
+def test_scratch_get_by_unique_8char_prefix(t1: T1Database) -> None:
+    """nexus-zpw6: pasting back the displayed 8-char prefix resolves
+    when only one session-owned id starts with it."""
+    full_id = t1.put(content="hello prefix world")
+    assert len(full_id) == 36  # UUID-shaped
+    short = full_id[:8]
+    entry = t1.get(short)
+    assert entry is not None, f"prefix {short!r} should resolve to {full_id!r}"
+    assert entry["id"] == full_id
+    assert entry["content"] == "hello prefix world"
+
+
+def test_scratch_get_full_uuid_still_works(t1: T1Database) -> None:
+    """nexus-zpw6 backwards-compat: the exact-match path is unchanged."""
+    full_id = t1.put(content="exact lookup")
+    entry = t1.get(full_id)
+    assert entry is not None
+    assert entry["id"] == full_id
+
+
+def test_scratch_get_ambiguous_prefix_returns_none(t1: T1Database) -> None:
+    """nexus-zpw6: when the prefix matches >=2 session-owned ids the
+    method returns None (and resolve_prefix_candidates surfaces the
+    list for the caller). The method must NEVER pick silently."""
+    a = t1.put(content="entry-a", agent="test")
+    b = t1.put(content="entry-b", agent="test")
+    # Find a shared prefix length where a and b collide; pick a 1-char
+    # prefix that always exists across UUID-shaped ids by using the
+    # common-character lookup.
+    for length in range(1, 36):
+        if a[:length] != b[:length]:
+            shared = a[:length - 1]
+            break
+    else:
+        shared = a[:1]
+    if shared and a.startswith(shared) and b.startswith(shared):
+        # Only assert ambiguity when the chosen prefix really collides.
+        candidates = t1.resolve_prefix_candidates(shared)
+        if len(candidates) >= 2:
+            assert t1.get(shared) is None, (
+                "ambiguous prefix must NOT silently pick a candidate"
+            )
+            assert set(candidates) >= {a, b}
+
+
+def test_scratch_get_unknown_prefix_returns_none(t1: T1Database) -> None:
+    """nexus-zpw6: a prefix that matches no session-owned id returns None."""
+    t1.put(content="some entry")
+    assert t1.get("zzzzzzzz") is None
+    assert t1.resolve_prefix_candidates("zzzzzzzz") == []
+
+
+def test_scratch_delete_by_unique_8char_prefix(t1: T1Database) -> None:
+    """nexus-zpw6: delete accepts the same prefix shape as get."""
+    full_id = t1.put(content="will be deleted")
+    short = full_id[:8]
+    assert t1.delete(short) is True
+    # Subsequent get returns None (entry truly removed).
+    assert t1.get(full_id) is None
+
+
+def test_scratch_delete_ambiguous_prefix_returns_false(t1: T1Database) -> None:
+    """nexus-zpw6: delete must NEVER pick silently when the prefix is
+    ambiguous; both entries remain after the call."""
+    a = t1.put(content="entry-a")
+    b = t1.put(content="entry-b")
+    for length in range(1, 36):
+        if a[:length] != b[:length]:
+            shared = a[:length - 1]
+            break
+    else:
+        shared = a[:1]
+    if shared and a.startswith(shared) and b.startswith(shared):
+        candidates = t1.resolve_prefix_candidates(shared)
+        if len(candidates) >= 2:
+            assert t1.delete(shared) is False
+            # Both still retrievable by full id.
+            assert t1.get(a) is not None
+            assert t1.get(b) is not None


### PR DESCRIPTION
## Summary

GH #535 secondary finding: `scratch list` displays entries by 8-char UUID prefix, but `scratch get` / `scratch delete` required the full UUID. Pasting back the displayed prefix failed with "Not found".

## Fix

- `T1Database._resolve_id` does exact-then-prefix resolution scoped to `session_id` (mirrors `MemoryStore.resolve_title`'s nexus-e59o shape).
- `T1Database.get` and `T1Database.delete` route through the resolver.
- Public `T1Database.resolve_prefix_candidates` exposes the candidate list; MCP `scratch_get` / `scratch_delete` surfaces a clean disambiguation message instead of silently picking when the prefix is ambiguous.

Behavior preserved: full UUID still works; unknown prefix returns None/False; ambiguous prefix never picks silently. Cross-session ownership scoped via `list_entries` which already filters by `session_id`.

## Closes

- Closes nexus-zpw6

## Test plan

- [x] `tests/test_scratch.py` +6 cases (unique-prefix get/delete, full-UUID backwards compat, ambiguous returns None/False without mutating, unknown prefix)
- [x] Full T1 regression: `uv run pytest tests/test_scratch.py tests/test_t1.py -x` — 89 passed
- [ ] CI green