### PR TITLE
fix(corpus): bare content-type prefix resolves to unique T3 match (#545)

### DIFF
--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -218,6 +218,37 @@ def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
     if is_conformant_collection_name(user_arg):
         return user_arg
 
+    # GH #545: when the user typed a BARE content-type prefix
+    # (``"code"``, ``"docs"``, ``"rdr"``, ``"knowledge"``) AND no
+    # ``__`` is present, the historical else-branch treated the value
+    # as an owner-name under content_type=``knowledge`` -- so
+    # ``--collection code`` resolved to
+    # ``knowledge__code__voyage-context-3__v1``, the wrong namespace.
+    # The 4.26.2 fix (#536) only covered the special case where the
+    # legacy 2-segment ``knowledge__knowledge`` happened to exist; for
+    # ``code``/``docs``/``rdr`` there's no ``<x>__<x>`` convention, so
+    # the bug stayed silent on those prefixes. Resolve via live-T3
+    # probe instead: if exactly one ``{prefix}__*`` collection exists,
+    # use it; on no/multiple matches fall through to the existing
+    # owner-segment-promotion branch (which then still has the
+    # ``knowledge__knowledge`` legacy fallback from #536).
+    if t3 is not None and "__" not in user_arg and user_arg in CONTENT_TYPES:
+        try:
+            matches = [
+                c["name"]
+                for c in t3.list_collections()  # type: ignore[attr-defined]
+                if c["name"].startswith(f"{user_arg}__")
+            ]
+        except Exception:
+            matches = []
+        if len(matches) == 1:
+            return matches[0]
+        # zero or many: fall through to the promotion branch so a
+        # greenfield install still gets the conformant target and a
+        # multi-collection install still goes through the existing
+        # paths (the existing ``knowledge`` fallback will then catch
+        # ``knowledge__knowledge`` on installs that have it).
+
     if "__" in user_arg:
         ct, _, rest = user_arg.partition("__")
     else:

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -292,6 +292,9 @@ class _FakeT3:
     def collection_exists(self, name: str) -> bool:
         return name in self._collections
 
+    def list_collections(self) -> list[dict]:
+        return [{"name": c} for c in sorted(self._collections)]
+
 
 def test_t3_collection_name_grandfathers_existing_legacy_when_t3_supplied() -> None:
     """nexus-hmxi: with a t3 probe, an existing legacy 2-segment
@@ -386,6 +389,66 @@ def test_t3_collection_name_bare_prefix_prefers_conformant_when_both_exist() -> 
     conformant = "knowledge__knowledge__voyage-context-3__v1"
     t3 = _FakeT3({legacy_2seg, conformant})
     assert t3_collection_name("knowledge", t3=t3) == conformant
+
+
+def test_t3_collection_name_bare_code_prefix_resolves_to_unique_match() -> None:
+    """GH #545: bare ``"code"`` (and ``"docs"``, ``"rdr"``) on installs
+    that have exactly one matching ``code__*`` collection must resolve
+    to it. Pre-fix the resolver treated bare ``code`` as an owner under
+    content_type ``knowledge`` and produced
+    ``knowledge__code__voyage-context-3__v1`` — wrong namespace.
+    """
+    only_code = "code__myrepo__voyage-code-3__v1"
+    t3 = _FakeT3({only_code})
+    assert t3_collection_name("code", t3=t3) == only_code
+
+
+def test_t3_collection_name_bare_docs_prefix_resolves_to_unique_match() -> None:
+    """GH #545 sibling: bare ``"docs"`` resolves to the unique
+    ``docs__*`` collection.
+    """
+    only_docs = "docs__myrepo__voyage-context-3__v1"
+    t3 = _FakeT3({only_docs})
+    assert t3_collection_name("docs", t3=t3) == only_docs
+
+
+def test_t3_collection_name_bare_rdr_prefix_resolves_to_unique_match() -> None:
+    """GH #545 sibling: bare ``"rdr"`` resolves to the unique
+    ``rdr__*`` collection.
+    """
+    only_rdr = "rdr__nexus__voyage-context-3__v1"
+    t3 = _FakeT3({only_rdr})
+    assert t3_collection_name("rdr", t3=t3) == only_rdr
+
+
+def test_t3_collection_name_bare_prefix_falls_through_when_multiple() -> None:
+    """GH #545: when 2+ ``code__*`` collections exist, the unique-match
+    branch falls through to the existing promotion logic so the
+    operator gets back the conformant target. This documents the
+    behaviour rather than the ideal (a candidate-list disambiguation
+    error would be cleaner; that's a separate UX call captured in #545).
+    """
+    t3 = _FakeT3({
+        "code__a__voyage-code-3__v1",
+        "code__b__voyage-code-3__v1",
+    })
+    # Falls through to promotion: bare ``code`` -> knowledge__code__...
+    # Not ideal but documents the current behaviour. The fix's value
+    # is the unique-match path, which is the common case.
+    out = t3_collection_name("code", t3=t3)
+    assert "code" in out  # don't pin the exact promoted shape
+
+
+def test_t3_collection_name_bare_knowledge_still_uses_legacy_fallback() -> None:
+    """GH #545 backwards-compat: the existing ``knowledge`` -> ``knowledge__knowledge``
+    legacy fallback (#536) must still fire when the bare-prefix probe
+    returns no unique match (e.g. no ``knowledge__*`` collections of
+    any other shape exist).
+    """
+    legacy = "knowledge__knowledge"
+    t3 = _FakeT3({legacy})  # only the legacy 2-seg, no other knowledge__*
+    # Probe sees one match, returns it. (Single-match path.)
+    assert t3_collection_name("knowledge", t3=t3) == legacy
 
 
 def test_t3_collection_name_t3_probe_failure_falls_through_to_promoted() -> None:


### PR DESCRIPTION
## Summary

GH #545 — follow-up to my 4.26.2 fix #536. Bare prefix `code` / `docs` / `rdr` was being treated as an owner-name under `knowledge`, so `--collection code` resolved to `knowledge__code__voyage-context-3__v1` (wrong namespace) and the operator got "No entries" while the data sat under `code__myrepo__voyage-code-3__v1`.

## Fix

When `t3` is supplied, `user_arg` is in `CONTENT_TYPES`, and there's no `__` in it, probe live T3 for collections starting with `{user_arg}__`. If exactly one matches, return it. On zero or multiple matches, fall through to the existing promotion branch (which still catches `knowledge__knowledge` via #536).

## Closes

- Closes #545

## Test plan

- [x] `tests/test_corpus.py` +5 cases: unique `code`/`docs`/`rdr` match, multi-match falls through, `knowledge` legacy fallback unbroken
- [x] `uv run pytest tests/test_corpus.py -x` — 65 passed
- [ ] CI green