### PR TITLE
fix(registry): sanitize all non-alnum chars in owner segment (#551)

### DIFF
--- a/src/nexus/registry.py
+++ b/src/nexus/registry.py
@@ -104,14 +104,48 @@ def _resolve_repo_collection(
             f"_resolve_repo_collection: unknown content_type {content_type!r}"
         )
     name, path_hash = _repo_identity(repo)
-    # The conformant collection-name grammar disallows ``_`` inside the
-    # owner segment (it is the segment separator). Sanitise the basename
-    # so repos like ``my_special_repo`` still produce a parseable name.
-    sanitised = name.replace("_", "-")
+    # The conformant collection-name grammar accepts only alphanumerics
+    # and hyphens inside the owner segment. Sanitise the basename so
+    # repos with ``_`` (segment separator) AND repos like
+    # ``com.conductor.sys.monitoring`` (Java reverse-domain naming) or
+    # other non-alnum characters in the basename still produce a name
+    # ``validate_collection_name`` accepts.
+    #
+    # GH #551: pre-fix, only ``_`` was replaced; dots and other chars
+    # passed through verbatim, so the registry persisted a name like
+    # ``code__com.conductor.sys.monitoring-b25083f0`` that subsequent
+    # ``get_or_create_collection`` calls then failed to validate -- and
+    # since the registry entry was already written, the failure looped
+    # forever in the index log on every git hook fire.
+    sanitised = _sanitise_owner_segment(name)
     model = canonical_embedding_model(content_type)
     return _safe_collection(
         f"{content_type}__", sanitised, path_hash, suffix=f"__{model}__v1",
     )
+
+
+def _sanitise_owner_segment(name: str) -> str:
+    """Return *name* with any character that ``validate_collection_name``
+    would reject collapsed to ``-``.
+
+    Conformant grammar (RDR-103): owner segment must contain only
+    alphanumerics and hyphens. ``_`` is the segment separator and must
+    not appear inside the segment. Dots, slashes, spaces, and any other
+    glyph map to ``-``. Repeated hyphens collapse to a single hyphen
+    and leading / trailing hyphens are stripped so the resulting
+    segment also satisfies the start-and-end-with-alphanumeric guard
+    in ``validate_collection_name``.
+    """
+    out_chars: list[str] = []
+    for ch in name:
+        if ch.isalnum():
+            out_chars.append(ch)
+        else:
+            out_chars.append("-")
+    collapsed = "".join(out_chars)
+    while "--" in collapsed:
+        collapsed = collapsed.replace("--", "-")
+    return collapsed.strip("-")
 
 
 def list_sibling_collections(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -263,3 +263,62 @@ def test_truncated_names_still_unique() -> None:
         _resolve_repo_collection(Path("/tmp/" + "a" * 60), "code")
         != _resolve_repo_collection(Path("/other/" + "a" * 60), "code")
     )
+
+
+# ── GH #551: dotted basename sanitization ──────────────────────────────────
+
+
+def test_sanitise_owner_segment_replaces_dots() -> None:
+    """GH #551: Java reverse-domain repo names (``com.foo.bar``) must
+    be sanitised so the conformant collection name passes
+    validate_collection_name. Pre-fix only ``_`` was replaced."""
+    from nexus.registry import _sanitise_owner_segment
+
+    assert _sanitise_owner_segment("com.conductor.sys.monitoring") == \
+        "com-conductor-sys-monitoring"
+
+
+def test_sanitise_owner_segment_collapses_multi_separators() -> None:
+    """Adjacent rejected chars collapse to a single hyphen so the
+    output stays compact and avoids ``--`` runs that look ugly in
+    operator output (e.g. ``foo..bar`` -> ``foo-bar`` not ``foo--bar``)."""
+    from nexus.registry import _sanitise_owner_segment
+
+    assert _sanitise_owner_segment("foo..bar") == "foo-bar"
+    assert _sanitise_owner_segment("foo_._bar") == "foo-bar"
+    assert _sanitise_owner_segment("a/b/c") == "a-b-c"
+
+
+def test_sanitise_owner_segment_strips_leading_trailing_hyphens() -> None:
+    """validate_collection_name requires alphanumeric start AND end.
+    A basename like ``.foo-bar.`` must come back as ``foo-bar``."""
+    from nexus.registry import _sanitise_owner_segment
+
+    assert _sanitise_owner_segment(".foo-bar.") == "foo-bar"
+    assert _sanitise_owner_segment("__foo__") == "foo"
+
+
+def test_sanitise_owner_segment_preserves_alnum_and_hyphens() -> None:
+    """Already-clean inputs pass through unchanged."""
+    from nexus.registry import _sanitise_owner_segment
+
+    assert _sanitise_owner_segment("clean-repo-123") == "clean-repo-123"
+    assert _sanitise_owner_segment("FooBar123") == "FooBar123"
+
+
+def test_resolve_repo_collection_dotted_basename_passes_validation() -> None:
+    """GH #551 end-to-end: the conformant name produced for a dotted
+    basename must pass validate_collection_name (the regex enforced by
+    ChromaDB on get_or_create). Pre-fix this raised because the dot
+    survived sanitisation; the registry then persisted an invalid
+    name and every subsequent index attempt crashed."""
+    from nexus.corpus import validate_collection_name
+    from nexus.registry import _resolve_repo_collection
+
+    repo = Path("/Users/hal/git/com.conductor.sys.monitoring")
+    for ct in ("code", "docs", "rdr"):
+        name = _resolve_repo_collection(repo, ct)
+        # Must start with ``ct__``, must validate, must NOT contain dots.
+        assert name.startswith(f"{ct}__")
+        validate_collection_name(name)
+        assert "." not in name


### PR DESCRIPTION
## Summary

GH #551: `nx index repo` on a path like `/git/com.conductor.sys.monitoring` persisted the basename verbatim into the registry, including the dots. The resulting collection name (`code__com.conductor.sys.monitoring-b25083f0`) failed `validate_collection_name` on every subsequent index attempt — and since the registry entry was already written, the failure looped forever in the index log on every git-hook fire.

## Root cause

`_resolve_repo_collection` ran `name.replace('_', '-')` only. That caught the segment-separator case but let dots, slashes, spaces, and any other non-alnum/non-hyphen char pass through verbatim.

## Fix

Extracted `_sanitise_owner_segment` helper that replaces every non-alnum char with a hyphen, collapses adjacent hyphens, and strips leading/trailing hyphens. Output always satisfies the conformant grammar.

## Closes

- Closes #551 issue 1 (sanitization).
- Issue 2 (suffix-length budget) in the report was based on a mis-arithmetic; `_safe_collection` already accounts for `prefix + 1 + hash + suffix` and truncates to 63 chars. The end-to-end test verifies all three content types validate cleanly for the reporter's repo shape.

## Test plan

- [x] `tests/test_registry.py` +5 cases (dot replacement, adjacent collapse, leading/trailing strip, alnum passthrough, end-to-end validate)
- [x] `uv run pytest tests/test_registry.py -x` — 27 passed
- [ ] CI green