### PR TITLE
fix(collection,index): reindex runs same post-processing chain (#369)

### DIFF
--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -469,6 +469,44 @@ def reindex_cmd(name: str, force: bool) -> None:
         except Exception as exc:
             click.echo(f"Verify failed: {exc}", err=True)
 
+    # GH #369: run the same post-processing chain ``nx index repo``
+    # runs after a successful index — taxonomy discover, Claude
+    # labeling, cross-collection projection, cooccurrence links,
+    # topic-link compute, L1 context refresh. Pre-fix the chain only
+    # fired from index_repo_cmd, so a bulk reindex (e.g. after an
+    # embedding-model upgrade) left the catalog/taxonomy/links stale
+    # and the operator had to know to re-run ``nx index repo`` per
+    # repo. ``run_collection_postprocessing`` is now the shared entry
+    # point.
+    if indexed > 0:
+        try:
+            from nexus.commands.index import run_collection_postprocessing
+            # Resolve repo_path from the registry when available so the
+            # L1 context refresh fires; falls back to ``None`` for
+            # collections with no registered owner (the L1 step is the
+            # only thing in the chain that requires a path, and it
+            # short-circuits cleanly when ``repo_path`` is ``None``).
+            repo_path: Path | None = None
+            try:
+                from nexus.indexer import RepoRegistry
+                from nexus.commands._helpers import default_db_path  # noqa: F401
+                from nexus.config import nexus_config_dir
+                reg = RepoRegistry(nexus_config_dir() / "repos.json")
+                for rp_str, info in reg.all_info().items():
+                    coll = info.get("collection") or info.get("docs_collection")
+                    if coll == name or info.get("docs_collection") == name:
+                        repo_path = Path(rp_str)
+                        break
+            except Exception:
+                pass  # repo-path resolution is best-effort
+            run_collection_postprocessing([name], repo_path=repo_path)
+        except Exception as exc:
+            click.echo(
+                f"Note: post-processing (taxonomy / links / context) "
+                f"failed: {exc}. Run `nx index repo <path>` to retry.",
+                err=True,
+            )
+
 
 @collection.command("verify")
 @click.argument("name")

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -389,41 +389,109 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
             if rdr_failed:
                 parts.append(f"{rdr_failed} failed")
             click.echo(f"  RDR documents: {', '.join(parts)} (collection rdr__)")
-    # Auto-discover taxonomy topics (RDR-070, nexus-0bg)
+    # Auto-discover taxonomy topics (RDR-070, nexus-0bg).
+    # GH #369: this chain (taxonomy + project + topic-links + L1) used
+    # to live inline here so reindex_cmd silently skipped it after
+    # bulk re-embeds. Extracted into ``run_collection_postprocessing``
+    # so both ``nx index repo`` and ``nx collection reindex`` walk the
+    # same path.
     if not frecency_only and not no_taxonomy and stats:
+        info = reg.get(path) or {}
+        collections = _collections_from_registry_info(info)
+        run_collection_postprocessing(collections, repo_path=path)
+
+    if not frecency_only:
         try:
-            from fnmatch import fnmatch
-
-            from nexus.config import is_local_mode, load_config as _load_cfg
-            from nexus.db import make_t3
-            from nexus.db.t2 import T2Database
-            from nexus.commands._helpers import default_db_path
-
-            t3 = make_t3()
-            info = reg.get(path) or {}
-            cfg = _load_cfg()
-            exclude_patterns = (
-                cfg.get("taxonomy", {}).get("local_exclude_collections", [])
-                if is_local_mode() else []
+            from nexus.commands.hooks import SENTINEL_BEGIN, _effective_hooks_dir
+            hdir = _effective_hooks_dir(path)
+            hook_names = ("post-commit", "post-merge", "post-rewrite")
+            any_managed = any(
+                SENTINEL_BEGIN in (hdir / n).read_text()
+                for n in hook_names
+                if (hdir / n).exists()
             )
-            collections = []
-            for key in ("collection", "docs_collection"):
-                col = info.get(key)
-                if col and not any(fnmatch(col, pat) for pat in exclude_patterns):
-                    collections.append(col)
+            if not any_managed:
+                click.echo("Tip: run `nx hooks install` to auto-index this repo on every commit.")
+        except Exception as exc:
+            _log.debug("hook_detection_failed", error=str(exc))  # Don't let hook detection break indexing
 
-            total_topics = 0
-            with T2Database(default_db_path()) as db:
-                for col_name in collections:
-                    try:
-                        n = _discover_taxonomy(col_name, db.taxonomy, t3._client)
-                        total_topics += n
-                    except Exception:
-                        _log.debug("taxonomy_discover_failed", collection=col_name, exc_info=True)
+    # Retry summary now emitted from the `finally` block around
+    # index_repository (see `_emit_retry_summary`) so it fires on both
+    # success and exception paths — Reviewer A/I-2.
+    click.echo("Done.")
+
+
+def _collections_from_registry_info(info: dict) -> list[str]:
+    """Return the registry's tracked collection names for taxonomy +
+    projection post-processing, filtered by
+    ``taxonomy.local_exclude_collections``. Empty list when
+    *info* is ``{}`` or carries no collection keys.
+    """
+    from fnmatch import fnmatch
+
+    from nexus.config import is_local_mode, load_config as _load_cfg
+
+    cfg = _load_cfg()
+    exclude_patterns = (
+        cfg.get("taxonomy", {}).get("local_exclude_collections", [])
+        if is_local_mode() else []
+    )
+    collections: list[str] = []
+    for key in ("collection", "docs_collection"):
+        col = info.get(key)
+        if col and not any(fnmatch(col, pat) for pat in exclude_patterns):
+            collections.append(col)
+    return collections
+
+
+def run_collection_postprocessing(
+    collections: list[str],
+    *,
+    repo_path: Path | None = None,
+    quiet: bool = False,
+) -> None:
+    """Run the post-index taxonomy + projection + topic-link chain
+    against *collections* and refresh the L1 context cache.
+
+    Extracted from :func:`index_repo_cmd` (GH #369) so
+    :func:`nexus.commands.collection.reindex_cmd` can call the same
+    chain after a bulk re-embed; previously reindex left the catalog,
+    taxonomy, and links stale because only ``nx index repo`` ran the
+    full pipeline. Each step is wrapped so a non-fatal failure (e.g.
+    cloud quota, missing optional dep) doesn't take down the chain.
+
+    *repo_path* enables the L1 context cache refresh (the only step
+    that needs the originating repo path); reindex callers pass it
+    when the registry resolves a path for the collection.
+
+    *quiet* suppresses the human-facing ``click.echo`` lines so
+    callers can drive the chain without operator output.
+    """
+    if not collections:
+        return
+
+    from nexus.config import load_config as _load_cfg
+    from nexus.db import make_t3
+    from nexus.db.t2 import T2Database
+    from nexus.commands._helpers import default_db_path
+
+    def _say(msg: str) -> None:
+        if not quiet:
+            click.echo(msg)
+
+    cfg = _load_cfg()
+    try:
+        t3 = make_t3()
+        total_topics = 0
+        with T2Database(default_db_path()) as db:
+            for col_name in collections:
+                try:
+                    n = _discover_taxonomy(col_name, db.taxonomy, t3._client)
+                    total_topics += n
+                except Exception:
+                    _log.debug("taxonomy_discover_failed", collection=col_name, exc_info=True)
             if total_topics:
-                click.echo(
-                    f"  Taxonomy: {total_topics} topics across {len(collections)} collections."
-                )
+                _say(f"  Taxonomy: {total_topics} topics across {len(collections)} collections.")
                 # Auto-label with Claude if available and enabled
                 auto_label = cfg.get("taxonomy", {}).get("auto_label", True)
                 if auto_label:
@@ -436,14 +504,14 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
                                     db.taxonomy, collection=col_name, only_pending=True,
                                 )
                             if labeled:
-                                click.echo(f"  Labels:   {labeled} topics labeled by Claude haiku.")
+                                _say(f"  Labels:   {labeled} topics labeled by Claude haiku.")
                     except Exception:
                         _log.debug("taxonomy_label_failed", exc_info=True)
 
                 # Count remaining unreviewed
                 unreviewed = len(db.taxonomy.get_unreviewed_topics())
                 if unreviewed:
-                    click.echo(
+                    _say(
                         f"  Review:   {unreviewed} topics pending. "
                         f"Run `nx taxonomy review` to curate."
                     )
@@ -462,7 +530,7 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
                                 _persist_assignments(db.taxonomy, assignments, quiet=True)
                                 proj_total += len(assignments)
                     if proj_total:
-                        click.echo(f"  Project:  {proj_total} cross-collection assignments.")
+                        _say(f"  Project:  {proj_total} cross-collection assignments.")
                 except Exception:
                     _log.debug("taxonomy_projection_failed", exc_info=True)
 
@@ -486,33 +554,14 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
                 except Exception:
                     pass  # Non-fatal
                 # Refresh L1 context cache
-                try:
-                    from nexus.context import generate_context_l1
-                    generate_context_l1(db.taxonomy, repo_path=path)
-                except Exception:
-                    pass  # Non-fatal
-        except Exception:
-            _log.debug("taxonomy_discover_failed", exc_info=True)
-
-    if not frecency_only:
-        try:
-            from nexus.commands.hooks import SENTINEL_BEGIN, _effective_hooks_dir
-            hdir = _effective_hooks_dir(path)
-            hook_names = ("post-commit", "post-merge", "post-rewrite")
-            any_managed = any(
-                SENTINEL_BEGIN in (hdir / n).read_text()
-                for n in hook_names
-                if (hdir / n).exists()
-            )
-            if not any_managed:
-                click.echo("Tip: run `nx hooks install` to auto-index this repo on every commit.")
-        except Exception as exc:
-            _log.debug("hook_detection_failed", error=str(exc))  # Don't let hook detection break indexing
-
-    # Retry summary now emitted from the `finally` block around
-    # index_repository (see `_emit_retry_summary`) so it fires on both
-    # success and exception paths — Reviewer A/I-2.
-    click.echo("Done.")
+                if repo_path is not None:
+                    try:
+                        from nexus.context import generate_context_l1
+                        generate_context_l1(db.taxonomy, repo_path=repo_path)
+                    except Exception:
+                        pass  # Non-fatal
+    except Exception:
+        _log.debug("taxonomy_discover_failed", exc_info=True)
 
 
 @index.command("pdf")

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -394,3 +394,53 @@ def test_reindex_warns_on_missing_source_files(runner, env_creds, mock_db) -> No
         result = runner.invoke(main, ["collection", "reindex", "docs__corpus"])
     assert result.exit_code == 0, result.output
     assert any(w in result.output.lower() for w in ("not found", "missing", "warning"))
+
+
+# ── GH #369: reindex post-processing ────────────────────────────────────────
+
+
+def test_run_collection_postprocessing_skips_empty_collection_list() -> None:
+    """The helper is a no-op on empty input so callers can route
+    unconditionally without an outer ``if collections:`` guard.
+    """
+    from nexus.commands.index import run_collection_postprocessing
+
+    # Should not raise, even without any T2/T3 access setup.
+    run_collection_postprocessing([], repo_path=None, quiet=True)
+
+
+def test_run_collection_postprocessing_swallows_t2_t3_errors() -> None:
+    """The chain's outer try/except wraps T3/T2 setup so a missing
+    SQLite path (e.g. fresh install with no memory.db yet) is logged
+    and silently skipped rather than killing the caller.
+    """
+    from unittest.mock import patch
+
+    from nexus.commands.index import run_collection_postprocessing
+
+    with patch("nexus.db.make_t3", side_effect=RuntimeError("boom")):
+        # Must NOT raise; the chain logs and falls through.
+        run_collection_postprocessing(
+            ["docs__regression"], repo_path=None, quiet=True,
+        )
+
+
+def test_collections_from_registry_info_filters_excluded() -> None:
+    """``taxonomy.local_exclude_collections`` patterns hide registry
+    collections from the post-processing chain. Empty registry
+    info returns ``[]``.
+    """
+    from nexus.commands.index import _collections_from_registry_info
+
+    # Empty info -> empty list.
+    assert _collections_from_registry_info({}) == []
+
+    # A typical post-RDR-103 registry entry returns its
+    # collection + docs_collection pair.
+    info = {
+        "collection": "code__myrepo__voyage-code-3__v1",
+        "docs_collection": "docs__myrepo__voyage-context-3__v1",
+    }
+    out = _collections_from_registry_info(info)
+    assert "code__myrepo__voyage-code-3__v1" in out
+    assert "docs__myrepo__voyage-context-3__v1" in out


### PR DESCRIPTION
## Summary

GH #369: `nx collection reindex` re-embedded chunks but did NOT run any post-index pipeline. After a bulk reindex (e.g. embedding-model upgrade), catalog/taxonomy/links went stale and the operator had to know to re-run `nx index repo` per repo to recover.

## Fix

Extracted `run_collection_postprocessing(collections, *, repo_path, quiet)` from `index_repo_cmd` to module level. Both `index_repo_cmd` and `reindex_cmd` now call the same chain (taxonomy discover → Claude label → cross-collection projection → cooccurrence links → topic-link compute → L1 context refresh).

`reindex_cmd` resolves the repo_path via `RepoRegistry` on best-effort. Guarded by `indexed > 0` so a refused-all-sourceless reindex still exits cleanly.

## Closes

- Closes #369

## Test plan

- [x] `tests/test_collection_cmd.py` +3 cases (empty-input no-op, T3-error swallowing, registry-info filtering)
- [x] `uv run pytest tests/test_collection_cmd.py tests/test_corpus.py tests/test_registry.py -x` — 116 passed
- [ ] CI green