### PR TITLE
feat(index): nx index repo --corpus flag for prose routing (#451)

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -205,12 +205,30 @@ class _ETATicker:
                    "(chunking / embed / upload / retry). Silent without the "
                    "flag — nexus-7niu, vatx Gap 4b. Currently code files only; "
                    "prose + PDF stages instrumented in follow-up PRs.")
-def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, force_stale: bool, on_locked: str, no_taxonomy: bool, debug_timing: bool) -> None:
+@click.option(
+    "--corpus",
+    "corpus_choice",
+    type=click.Choice(["docs", "knowledge"]),
+    default="docs",
+    show_default=True,
+    help=(
+        "Route prose / PDF files to docs__<owner>__... (default; for "
+        "code-repo prose) or knowledge__<owner>__... (for curated "
+        "knowledge bases, ADR collections, doc sites). Code files always "
+        "go to code__. GH #451."
+    ),
+)
+def index_repo_cmd(
+    path: Path, frecency_only: bool, force: bool, monitor: bool,
+    force_stale: bool, on_locked: str, no_taxonomy: bool,
+    debug_timing: bool, corpus_choice: str,
+) -> None:
     """Register and immediately index a code repository at PATH.
 
     Classifies files by extension: code files get voyage-code-3 embeddings (code__),
-    prose and PDFs get voyage-context-3 embeddings (docs__), RDR documents are
-    auto-discovered and indexed into rdr__.
+    prose and PDFs get voyage-context-3 embeddings (docs__ or knowledge__ when
+    ``--corpus knowledge``), RDR documents are auto-discovered and indexed
+    into rdr__.
     """
     from nexus.indexer import index_repository
 
@@ -245,6 +263,26 @@ def index_repo_cmd(path: Path, frecency_only: bool, force: bool, monitor: bool, 
                 pass
         reg.add(path, cat=cat)
         click.echo(f"Registered {path}.")
+
+    # GH #451: when the operator opts into ``--corpus knowledge``,
+    # rewrite the registered ``docs_collection`` field to use the
+    # ``knowledge__`` prefix instead of ``docs__``. This single edit
+    # is enough for every downstream layer (index_repository,
+    # _index_prose_file, _index_pdf_file) to route prose at the new
+    # destination, since they all read the field directly from the
+    # registry. Idempotent on re-runs: the rewrite only fires when
+    # the registry currently holds the docs__ default. Code routing
+    # is unaffected (the rewrite touches only the docs_collection
+    # field, never code_collection).
+    if corpus_choice == "knowledge":
+        info = reg.get(path) or {}
+        existing_docs = info.get("docs_collection", "")
+        if existing_docs.startswith("docs__"):
+            new_docs = "knowledge__" + existing_docs.removeprefix("docs__")
+            reg.update(path, docs_collection=new_docs)
+            click.echo(
+                f"Routing prose to {new_docs} (--corpus knowledge)."
+            )
 
     if force:
         label = "Force-indexing"

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -444,3 +444,93 @@ def test_collections_from_registry_info_filters_excluded() -> None:
     out = _collections_from_registry_info(info)
     assert "code__myrepo__voyage-code-3__v1" in out
     assert "docs__myrepo__voyage-context-3__v1" in out
+
+
+# ── GH #451: --corpus flag for nx index repo ────────────────────────────────
+
+
+def test_index_repo_cmd_help_shows_corpus_flag(runner) -> None:
+    """GH #451: ``nx index repo --help`` advertises the new ``--corpus``
+    choice flag for routing prose to ``knowledge__`` instead of ``docs__``.
+    """
+    from nexus.commands.index import index_repo_cmd
+
+    result = runner.invoke(index_repo_cmd, ["--help"])
+    assert result.exit_code == 0
+    assert "--corpus" in result.output
+    assert "knowledge" in result.output
+
+
+def test_corpus_knowledge_rewrites_docs_collection(tmp_path, monkeypatch) -> None:
+    """GH #451: ``--corpus knowledge`` mutates the registry's
+    ``docs_collection`` field so the indexer routes prose to
+    ``knowledge__<owner>__...`` instead of ``docs__<owner>__...``.
+
+    Pure registry-level test; the indexer call is mocked so we
+    isolate the routing decision from the embed pipeline.
+    """
+    import json
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+    from nexus.commands.index import index_repo_cmd
+
+    # Set up an isolated config dir so the registry path is sandboxed.
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()  # so _git_ls_files won't crash; not strictly
+    (repo / "README.md").write_text("# repo\n")
+
+    runner = CliRunner()
+    with patch("nexus.indexer.index_repository", return_value={}) as _idx:
+        result = runner.invoke(
+            index_repo_cmd,
+            [str(repo), "--corpus", "knowledge", "--no-taxonomy"],
+            catch_exceptions=False,
+        )
+
+    # The registry should now hold a knowledge__ docs_collection.
+    repos_json = tmp_path / "repos.json"
+    assert repos_json.exists(), "registry never written"
+    data = json.loads(repos_json.read_text())
+    entry = data["repos"][str(repo.resolve())]
+    assert entry["docs_collection"].startswith("knowledge__"), (
+        f"--corpus knowledge did not rewrite docs_collection; "
+        f"registry holds {entry['docs_collection']!r}"
+    )
+    assert entry["code_collection"].startswith("code__"), (
+        "code_collection must NOT be touched by --corpus knowledge"
+    )
+    # Output mentions the routing decision.
+    assert "knowledge__" in result.output
+
+
+def test_corpus_default_keeps_docs_collection(tmp_path, monkeypatch) -> None:
+    """GH #451: omitting ``--corpus`` (or passing ``--corpus docs``)
+    is the default; prose continues to route to ``docs__``.
+    """
+    import json
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+    from nexus.commands.index import index_repo_cmd
+
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / "README.md").write_text("# repo\n")
+
+    runner = CliRunner()
+    with patch("nexus.indexer.index_repository", return_value={}):
+        runner.invoke(
+            index_repo_cmd, [str(repo), "--no-taxonomy"], catch_exceptions=False,
+        )
+
+    repos_json = tmp_path / "repos.json"
+    data = json.loads(repos_json.read_text())
+    entry = data["repos"][str(repo.resolve())]
+    assert entry["docs_collection"].startswith("docs__"), (
+        f"default routing changed; got {entry['docs_collection']!r}"
+    )


### PR DESCRIPTION
## Summary

GH #451: `nx index repo PATH` always routed prose / PDFs to `docs__<owner>__...`. The only escape for repos whose content IS curated synthesis (docs sites, ADR collections, internal knowledge bases) was renaming the collection after-the-fact, which drifted on every re-index.

## Fix

`--corpus { docs | knowledge }` flag (default `docs`, current behavior). When `--corpus knowledge` is supplied, mutate the registry's `docs_collection` field after `reg.add()` to use the `knowledge__` prefix. Every downstream layer reads the field directly, so this single edit is enough.

Code routing is unaffected. Sticky: subsequent runs without the flag keep the knowledge__ destination.

## Closes

- Closes #451

## Test plan

- [x] `tests/test_collection_cmd.py` +3 cases (--help shows flag, knowledge rewrites docs_collection without touching code_collection, default keeps docs__)
- [x] 122/122 collection_cmd + corpus + registry suite green
- [ ] CI green