### PR TITLE
fix(plans): pre-embed intent in session_cache.query (#554)

### DIFF
--- a/src/nexus/plans/session_cache.py
+++ b/src/nexus/plans/session_cache.py
@@ -77,12 +77,30 @@ class PlanSessionCache:
         return self._available and self._col is not None
 
     def query(self, intent: str, n: int) -> list[tuple[int, float]]:
-        """Return ``(plan_id, distance)`` pairs ordered closest-first."""
+        """Return ``(plan_id, distance)`` pairs ordered closest-first.
+
+        GH #554: pre-embed the intent here and pass
+        ``query_embeddings=`` to chromadb. Pre-fix this called
+        ``query_texts=[intent]`` which routes through chromadb 1.5.9's
+        text-side path; that path unconditionally calls
+        ``convert_np_embeddings_to_list`` on the post-embed result and
+        crashes when the embedding function returns ``list[list[float]]``
+        (every conexus install: LocalEmbeddingFunction returns plain
+        Python lists, not numpy arrays). The crash was caught by the
+        outer ``except`` and silently disabled session-level plan
+        caching on every ``nx_answer`` invocation.
+
+        Routing the embed call through ``LocalEmbeddingFunction``
+        directly bypasses chromadb's text-side adapter and keeps the
+        cache live.
+        """
         if not self.is_available or not intent:
             return []
         try:
+            ef = LocalEmbeddingFunction()
+            query_emb = ef([intent])  # list[list[float]] of length 1
             result = self._col.query(
-                query_texts=[intent],
+                query_embeddings=query_emb,
                 n_results=min(n, 300),
                 where={"session_id": self._session_id},
                 include=["metadatas", "distances"],

--- a/tests/test_plan_session_cache_query.py
+++ b/tests/test_plan_session_cache_query.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""GH #554: PlanSessionCache.query must use query_embeddings, not query_texts.
+
+Pre-fix the query went through chromadb 1.5.9's text-side path which
+crashed in convert_np_embeddings_to_list when the embedding function
+returned plain Python lists. This test verifies the call goes through
+query_embeddings and returns results without crashing.
+"""
+from __future__ import annotations
+
+import chromadb
+import pytest
+
+from nexus.plans.session_cache import PlanSessionCache
+
+
+def test_query_uses_query_embeddings_not_query_texts() -> None:
+    """GH #554: pre-fix the query routed via query_texts and crashed
+    inside chromadb 1.5.9. Post-fix it pre-embeds the intent and
+    passes query_embeddings, bypassing the text-side adapter.
+
+    Verifies: a query against this session returns [] cleanly when
+    no rows match (no exception caught + warning, which was the
+    pre-fix symptom).
+    """
+    # MEMORY: chromadb EphemeralClient shares process state across
+    # test instances; scope the where-filter to a unique session_id
+    # so other tests' rows don't leak into this query.
+    cache = PlanSessionCache(
+        client=chromadb.EphemeralClient(),
+        session_id="test-554-empty-session",
+    )
+
+    out = cache.query("how does X work", n=5)
+    assert out == []
+
+
+def test_query_does_not_warn_on_chromadb_text_path(caplog) -> None:
+    """GH #554 belt-and-suspenders: ensure the warning event the
+    pre-fix path emitted (``plan_session_cache_query_failed``) does
+    NOT fire on a plain query against an empty collection.
+
+    Pre-fix, every ``query()`` call emitted this warning because
+    chromadb 1.5.9's text-side adapter crashed on plain-list
+    embedding return values. Post-fix, the adapter is bypassed and
+    the warning never fires.
+    """
+    import logging
+
+    cache = PlanSessionCache(
+        client=chromadb.EphemeralClient(),
+        session_id="test-554-no-warn-session",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        out = cache.query("any prose query", n=5)
+
+    assert out == []
+    failure_records = [
+        r for r in caplog.records
+        if "plan_session_cache_query_failed" in r.getMessage()
+    ]
+    assert not failure_records, (
+        f"unexpected warning emitted: {[r.getMessage() for r in failure_records]}"
+    )


### PR DESCRIPTION
## Summary

GH #554: every `nx_answer` call on 4.26.2 logged `plan_session_cache_query_failed` and silently fell back to the un-cached path. Crash was inside chromadb 1.5.9 — `convert_np_embeddings_to_list` iterates and calls `.tolist()` on each item, fails when `LocalEmbeddingFunction` returns plain Python lists. Every conexus install hit it.

## Fix

Pre-embed the intent via `LocalEmbeddingFunction` directly and pass `query_embeddings=` to chromadb. Bypasses the text-side adapter and the `convert_np_embeddings_to_list` landmine entirely.

## Closes

- Closes #554

## Test plan

- [x] `tests/test_plan_session_cache_query.py` +2 cases (empty-collection [], no warning event)
- [x] Full plan suite: 95 passed
- [ ] CI green