### PR TITLE
fix(nx_answer): unwrap {output: ...} envelope from generate-terminal plans (#555)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -3031,6 +3031,47 @@ def _nx_answer_needs_operators(match: Any) -> bool:
     return _nx_answer_classify_plan(match) == "needs_operators"
 
 
+def _maybe_unwrap_output_envelope(text: str, *, max_depth: int = 3) -> str:
+    """GH #555: unwrap nested ``{"output": "..."}`` envelopes.
+
+    The ``operator_generate`` schema emits ``{"output": <prose>}``;
+    when an ``extract -> generate`` bundle's terminal step receives a
+    prior step's envelope as its ``context`` argument, claude -p has
+    been observed emitting a recursive ``{"output": "{\\"output\\":
+    \\"...\\"}"}`` shape (the model treats the envelope as raw text
+    and re-wraps). This helper repeatedly tries to JSON-parse *text*;
+    if the parse yields a single-key ``{"output": <str>}`` dict, it
+    pulls the inner string and tries again. Bounded by *max_depth*
+    so a malformed payload cannot infinite-loop.
+
+    Returns *text* unchanged when:
+      - it does not parse as JSON, OR
+      - the parse yields anything other than a single-key dict
+        whose only key is ``"output"`` and whose value is a string.
+
+    Cheap (single ``json.loads`` per depth) and safe (the strict
+    shape check guarantees no false unwraps on legitimate JSON).
+    """
+    current = text
+    for _ in range(max(0, max_depth)):
+        if not current or not current.lstrip().startswith("{"):
+            break
+        try:
+            parsed = json.loads(current)
+        except (json.JSONDecodeError, ValueError):
+            break
+        if (
+            isinstance(parsed, dict)
+            and len(parsed) == 1
+            and "output" in parsed
+            and isinstance(parsed["output"], str)
+        ):
+            current = parsed["output"]
+            continue
+        break
+    return current
+
+
 def _nx_answer_record_run(
     conn: Any,
     *,
@@ -3617,8 +3658,26 @@ async def nx_answer(
     # ── Step 5: extract final answer ─────────────────────────────────────
     elapsed_ms = int((time.monotonic() - start) * 1000)
     final_step = result.steps[-1] if result.steps else {}
-    text_key = next((k for k in ("text", "summary", "answer") if k in final_step), None)
+    # GH #555: include ``output`` (the operator_generate schema's
+    # terminal field) and ``comparison`` (operator_compare) in the
+    # text-key search so a generate-terminal plan returns its raw
+    # prose instead of the JSON-encoded envelope. Pre-fix the search
+    # ran ``("text", "summary", "answer")`` only; ``operator_generate``
+    # emits ``{"output": "..."}`` so the search missed and fell
+    # through to ``json.dumps(final_step)``, producing a wrapped
+    # ``'{"output": "..."}'`` final_text. Plus on extract -> generate
+    # bundles claude -p sometimes emits ``{"output": "<JSON-encoded
+    # {output: prose}>"}`` (the bundle prompt confuses the model into
+    # treating the prior step's envelope as its input string), so an
+    # additional one-level recursive unwrap on a string-valued ``output``
+    # that itself parses to ``{"output": ...}`` recovers the prose.
+    text_key = next(
+        (k for k in ("text", "summary", "answer", "output", "comparison")
+         if k in final_step),
+        None,
+    )
     final_text = str(final_step.get(text_key, "")) if text_key else json.dumps(final_step)
+    final_text = _maybe_unwrap_output_envelope(final_text)
 
     # RDR-086 Phase 3.3: harvest chunk refs from retrieval-op steps so the
     # envelope's ``chunks`` list carries id+chash+collection for every

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -1982,3 +1982,79 @@ class TestNxAnswerPlannerRetry:
         assert mock_dispatch.call_count == 1
         # First-attempt path uses the full 300s timeout.
         assert mock_dispatch.call_args.kwargs["timeout"] == 300.0
+
+
+# ── GH #555: final_text envelope unwrap ─────────────────────────────────────
+
+
+def test_maybe_unwrap_output_envelope_passthrough() -> None:
+    """Plain prose passes through unchanged. Empty string short-circuits."""
+    from nexus.mcp.core import _maybe_unwrap_output_envelope
+
+    assert _maybe_unwrap_output_envelope("plain prose") == "plain prose"
+    assert _maybe_unwrap_output_envelope("") == ""
+
+
+def test_maybe_unwrap_output_envelope_single_layer() -> None:
+    """One-layer ``{"output": "..."}`` envelope unwraps to the inner
+    string. The ``operator_generate`` schema produces this shape;
+    pre-fix the json.dumps fallback in nx_answer's text-key search
+    surfaced it as final_text verbatim.
+    """
+    import json
+    from nexus.mcp.core import _maybe_unwrap_output_envelope
+
+    payload = json.dumps({"output": "actual prose"})
+    assert _maybe_unwrap_output_envelope(payload) == "actual prose"
+
+
+def test_maybe_unwrap_output_envelope_double_wrap() -> None:
+    """GH #555: the extract -> generate bundle path can produce a
+    doubly-wrapped envelope when claude -p treats the prior step's
+    envelope as raw input. The unwrap descends into nested
+    string-valued ``output`` fields.
+    """
+    import json
+    from nexus.mcp.core import _maybe_unwrap_output_envelope
+
+    inner = json.dumps({"output": "deep prose"})
+    outer = json.dumps({"output": inner})
+    assert _maybe_unwrap_output_envelope(outer) == "deep prose"
+
+
+def test_maybe_unwrap_output_envelope_strict_shape_only() -> None:
+    """Multi-key dicts and non-string output values are NOT unwrapped.
+    Only the strict ``{"output": <str>}`` single-key shape triggers
+    descent so legitimate JSON payloads pass through intact.
+    """
+    import json
+    from nexus.mcp.core import _maybe_unwrap_output_envelope
+
+    # Multi-key dict: not unwrapped.
+    multi = json.dumps({"output": "x", "citations": []})
+    assert _maybe_unwrap_output_envelope(multi) == multi
+
+    # Non-string output: not unwrapped.
+    list_val = json.dumps({"output": [1, 2, 3]})
+    assert _maybe_unwrap_output_envelope(list_val) == list_val
+
+    # Different key: not unwrapped.
+    other = json.dumps({"text": "x"})
+    assert _maybe_unwrap_output_envelope(other) == other
+
+
+def test_maybe_unwrap_output_envelope_max_depth_bounded() -> None:
+    """A malformed deeply-recursive payload terminates after max_depth
+    iterations. Chosen so a 3-or-more-deep wrap (unobserved in the
+    wild) returns the partially-unwrapped state rather than looping.
+    """
+    import json
+    from nexus.mcp.core import _maybe_unwrap_output_envelope
+
+    # Build a 4-deep wrap; default max_depth is 3.
+    text = "core"
+    for _ in range(4):
+        text = json.dumps({"output": text})
+    out = _maybe_unwrap_output_envelope(text, max_depth=3)
+    # 3 unwraps from a 4-layer payload leaves one layer remaining.
+    assert "core" in out and out.startswith('{')


### PR DESCRIPTION
## Summary

GH #555: `nx_answer`'s `final_text` was double-JSON-wrapped when the plan's terminal step was a `generate` operator. The wrapped value landed in `nx_answer_runs.final_text` and in the `structured=True` envelope, breaking every skill that prints results as prose.

## Fix

1. Add `output` (and `comparison`) to the final-step text-key search so `operator_generate`'s `{output: <str>}` schema is surfaced directly instead of via `json.dumps` fallback.
2. Pass the extracted text through `_maybe_unwrap_output_envelope`, a strict-shape unwrap (only single-key `{"output": <str>}` triggers descent, multi-key dicts and non-string values pass through, bounded by `max_depth=3`).

## Closes

- Closes #555

## Test plan

- [x] `tests/test_nx_answer.py` +5 cases (passthrough, single-layer, double-layer, strict-shape guard, max_depth bound)
- [x] 241/241 nx_answer + plan_run + corpus suite green
- [ ] CI green