### PR TITLE
fix(corpus): deterministic pick on multi-match bare prefix (nexus-0f3h)

### DIFF
--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -5,6 +5,8 @@ import re
 
 import structlog
 
+_log = structlog.get_logger(__name__)
+
 # ChromaDB collection name constraints:
 # - 3–63 characters
 # - Must start and end with an alphanumeric character
@@ -243,11 +245,40 @@ def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
             matches = []
         if len(matches) == 1:
             return matches[0]
-        # zero or many: fall through to the promotion branch so a
-        # greenfield install still gets the conformant target and a
-        # multi-collection install still goes through the existing
-        # paths (the existing ``knowledge`` fallback will then catch
-        # ``knowledge__knowledge`` on installs that have it).
+        # nexus-0f3h: GH #545 follow-up. The original 4.26.3 fix only
+        # handled the unique-match case. On installs with MANY
+        # ``{prefix}__*`` collections (e.g. ``code`` matching 22 repos),
+        # falling through to the promotion branch produced
+        # ``knowledge__code__voyage-context-3__v1`` -- the wrong
+        # namespace, silently. Pick deterministically when multi-match
+        # to avoid that misroute: prefer the conformant
+        # ``{prefix}__{prefix}__<canonical_model>__v1``, then the
+        # legacy 2-segment ``{prefix}__{prefix}``, then alphabetical
+        # first. Log a warning so the operator sees the choice and
+        # can pass a more specific name on subsequent calls.
+        if len(matches) > 1:
+            preferred_4seg = (
+                f"{user_arg}__{user_arg}__"
+                f"{canonical_embedding_model(user_arg)}__v1"
+            )
+            preferred_2seg = f"{user_arg}__{user_arg}"
+            picked: str | None = None
+            if preferred_4seg in matches:
+                picked = preferred_4seg
+            elif preferred_2seg in matches:
+                picked = preferred_2seg
+            else:
+                picked = sorted(matches)[0]
+            _log.warning(
+                "t3_collection_name_bare_prefix_ambiguous",
+                user_arg=user_arg,
+                match_count=len(matches),
+                picked=picked,
+                candidates=matches[:10],
+            )
+            return picked
+        # zero matches: fall through to the promotion branch so a
+        # greenfield install still gets the conformant target.
 
     if "__" in user_arg:
         ct, _, rest = user_arg.partition("__")

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -493,3 +493,68 @@ def test_cce_index_query_model_invariant() -> None:
             f"{prefix}: index model ({idx}) must match query model ({qry}). "
             f"Mismatched models produce random noise. See RDR-059."
         )
+
+
+def test_t3_collection_name_bare_prefix_multi_match_picks_4seg() -> None:
+    """nexus-0f3h: when multiple ``{prefix}__*`` collections exist AND the
+    conformant ``{prefix}__{prefix}__<canonical_model>__v1`` is among
+    them, pick that one. This honours the RDR-103 conformant default
+    and avoids the wrong-namespace fall-through that the 4.26.3 partial
+    fix produced for the multi-match case.
+    """
+    t3 = _FakeT3({
+        "code__nexus-1__voyage-code-3__v1",
+        "code__myrepo__voyage-code-3__v1",
+        "code__code__voyage-code-3__v1",  # the conformant default
+    })
+    assert (
+        t3_collection_name("code", t3=t3)
+        == "code__code__voyage-code-3__v1"
+    )
+
+
+def test_t3_collection_name_bare_prefix_multi_match_picks_2seg_legacy() -> None:
+    """nexus-0f3h: when no conformant default exists but the legacy
+    2-segment ``{prefix}__{prefix}`` does, pick that. Mirrors the
+    nexus-6mr0 fallback for the unique-match path.
+    """
+    t3 = _FakeT3({
+        "code__nexus-1__voyage-code-3__v1",
+        "code__myrepo__voyage-code-3__v1",
+        "code__code",  # legacy 2-segment default
+    })
+    assert t3_collection_name("code", t3=t3) == "code__code"
+
+
+def test_t3_collection_name_bare_prefix_multi_match_picks_alphabetical_first() -> None:
+    """nexus-0f3h: when no canonical default exists, fall back to
+    alphabetical first. Deterministic so callers get a stable choice
+    across runs and the warning log gives the operator the candidate
+    list for disambiguation on subsequent calls.
+    """
+    t3 = _FakeT3({
+        "code__myrepo-bbb__voyage-code-3__v1",
+        "code__myrepo-aaa__voyage-code-3__v1",
+        "code__myrepo-ccc__voyage-code-3__v1",
+    })
+    assert (
+        t3_collection_name("code", t3=t3)
+        == "code__myrepo-aaa__voyage-code-3__v1"
+    )
+
+
+def test_t3_collection_name_bare_prefix_multi_match_picks_alphabetical_when_no_canonical() -> None:
+    """nexus-0f3h: 2 matches, neither is the canonical default; pick
+    alphabetical first deterministically. Pre-fix this fell through to
+    promotion and produced ``knowledge__code__voyage-context-3__v1``
+    (wrong namespace) — the load-bearing assertion is that we land on
+    a real ``code__*`` instead.
+    """
+    t3 = _FakeT3({
+        "code__b__voyage-code-3__v1",
+        "code__a__voyage-code-3__v1",
+    })
+    out = t3_collection_name("code", t3=t3)
+    assert out == "code__a__voyage-code-3__v1"
+    # Anti-regression: must never land in the wrong knowledge__ namespace.
+    assert not out.startswith("knowledge__"), out


### PR DESCRIPTION
## Summary

Follow-up to #550 (4.26.3). The original fix only handled the unique-match case; multi-match still fell through to the wrong-namespace promotion branch (`nx store list -c code` resolved to `knowledge__code__voyage-context-3__v1`).

## Fix

Pick deterministically when 2+ matches found:
1. Conformant `{prefix}__{prefix}__<canonical_model>__v1` if present
2. Legacy 2-segment `{prefix}__{prefix}` if present
3. Alphabetical first

Log `t3_collection_name_bare_prefix_ambiguous` warning so the operator sees the choice.

## Closes

- Closes nexus-0f3h

## Test plan

- [x] +3 cases (4-seg conformant preferred, 2-seg legacy fallback, alphabetical first) plus anti-regression
- [x] 69/69 test_corpus green
- [ ] CI green