### PR TITLE
fix(plans): verb-synonym carve-out in dimension filter (nexus-qi8t)

### DIFF
--- a/src/nexus/plans/matcher.py
+++ b/src/nexus/plans/matcher.py
@@ -156,9 +156,69 @@ class PlanCache(Protocol):
         ...
 
 
+#: nexus-qi8t: verb-synonym equivalence classes for the dimension
+#: filter. The historical strict-equality gate at :func:`_superset`
+#: rejected high-confidence cosine matches whenever the caller's
+#: inferred verb (``query``) and the plan's declared verb
+#: (``research``) used different vocabulary for what is semantically
+#: the same intent. Live repro 2026-05-06: ``nx_answer`` with
+#: question 'Find papers by Grossberg about ART resonance' and
+#: ``dimensions={"verb":"research"}`` did NOT match the builtin
+#: ``find-by-author`` plan (verb=research) because the inline planner
+#: classified the question as ``verb=query`` and the strict filter
+#: dropped the cosine hit before it reached scoring.
+#:
+#: Each class lists verb names that should be treated as
+#: interchangeable for filter purposes; verbs not in any class only
+#: match themselves (strict-equality preserved). Classes are
+#: deliberately conservative -- ``debug`` (failure investigation),
+#: ``document`` (gap-finding), and ``plan-*`` (plan lifecycle ops)
+#: all stay isolated since swapping them with a research-verb plan
+#: would produce wrong answers.
+_VERB_SYNONYMS: tuple[frozenset[str], ...] = (
+    # Information-retrieval intents -- "tell me about X", "how does X
+    # work", "find papers by Y". The user's question shape rarely
+    # disambiguates between these and the plan-author's verb choice
+    # is similarly fuzzy in practice.
+    frozenset({"query", "research", "lookup"}),
+    # Critique / synthesis intents -- "what tradeoffs", "compare X
+    # across projects", "review this design".
+    frozenset({"analyze", "review", "compare"}),
+)
+
+
+def _verbs_compatible(plan_verb: Any, filter_verb: Any) -> bool:
+    """Return True when *plan_verb* and *filter_verb* should be
+    treated as equivalent under the synonym map. Falls back to
+    strict equality when either verb is empty or neither appears in
+    any class.
+    """
+    if plan_verb == filter_verb:
+        return True
+    if not plan_verb or not filter_verb:
+        return False
+    for klass in _VERB_SYNONYMS:
+        if plan_verb in klass and filter_verb in klass:
+            return True
+    return False
+
+
 def _superset(plan_dims: dict[str, Any], filter_dims: dict[str, Any]) -> bool:
-    """Return True when ``plan_dims ⊇ filter_dims`` by equality."""
-    return all(plan_dims.get(k) == v for k, v in filter_dims.items())
+    """Return True when ``plan_dims ⊇ filter_dims`` (nexus-qi8t).
+
+    The ``verb`` dimension uses the synonym-class equality at
+    :func:`_verbs_compatible`; other dimensions (scope, strategy,
+    taxonomy_domain, ...) keep strict equality so cross-domain plans
+    cannot accidentally match.
+    """
+    for k, v in filter_dims.items():
+        plan_v = plan_dims.get(k)
+        if k == "verb":
+            if not _verbs_compatible(plan_v, v):
+                return False
+        elif plan_v != v:
+            return False
+    return True
 
 
 def plan_match(

--- a/tests/test_plan_match.py
+++ b/tests/test_plan_match.py
@@ -942,3 +942,70 @@ class TestRdr092Canaries:
             f"attractor ratio telemetry: {max_single}/{total} "
             f"(= {ratio:.2f}) across {len(landings)} distinct plans"
         )
+
+
+# ── nexus-qi8t: verb-synonym equivalence in dimension filter ───────────────
+
+
+def test_superset_verbs_research_query_lookup_are_compatible() -> None:
+    """nexus-qi8t: a plan with verb=research must match a filter with
+    verb=query (or lookup) since these are all retrieval intents.
+    Pre-fix the strict-equality gate dropped the match at the dimension
+    filter stage, even when the cosine confidence was high.
+    """
+    from nexus.plans.matcher import _superset
+
+    plan_dims = {"verb": "research"}
+    assert _superset(plan_dims, {"verb": "query"}) is True
+    assert _superset(plan_dims, {"verb": "lookup"}) is True
+    assert _superset(plan_dims, {"verb": "research"}) is True
+
+
+def test_superset_verbs_analyze_review_compare_are_compatible() -> None:
+    """nexus-qi8t: critique / synthesis intents share a class."""
+    from nexus.plans.matcher import _superset
+
+    plan_dims = {"verb": "analyze"}
+    assert _superset(plan_dims, {"verb": "review"}) is True
+    assert _superset(plan_dims, {"verb": "compare"}) is True
+
+
+def test_superset_verbs_isolated_classes_stay_strict() -> None:
+    """nexus-qi8t: ``debug`` / ``document`` / ``plan-*`` are isolated.
+    Swapping them with a research-verb plan would produce wrong
+    answers, so they must NOT match.
+    """
+    from nexus.plans.matcher import _superset
+
+    plan_dims = {"verb": "debug"}
+    assert _superset(plan_dims, {"verb": "research"}) is False
+    assert _superset(plan_dims, {"verb": "document"}) is False
+
+    plan_dims = {"verb": "document"}
+    assert _superset(plan_dims, {"verb": "research"}) is False
+
+
+def test_superset_non_verb_dimensions_stay_strict() -> None:
+    """nexus-qi8t: only the verb dimension carves out synonyms.
+    ``scope``, ``strategy``, ``taxonomy_domain`` etc. keep strict
+    equality so cross-domain plans cannot accidentally match.
+    """
+    from nexus.plans.matcher import _superset
+
+    plan_dims = {"verb": "research", "scope": "global"}
+    assert _superset(plan_dims, {"verb": "query", "scope": "global"}) is True
+    # Same verb-synonym match but scope differs => reject.
+    assert _superset(plan_dims, {"verb": "query", "scope": "project"}) is False
+
+
+def test_superset_empty_verb_falls_back_to_strict_equality() -> None:
+    """A missing verb (None / "") falls back to strict equality so a
+    legacy NULL-verb plan cannot accidentally match a verb-tagged
+    filter.
+    """
+    from nexus.plans.matcher import _superset
+
+    plan_dims: dict = {"verb": ""}
+    assert _superset(plan_dims, {"verb": "research"}) is False
+    plan_dims = {"verb": None}
+    assert _superset(plan_dims, {"verb": "research"}) is False


### PR DESCRIPTION
## Summary

`plan_match`'s `_superset` enforced strict equality on every dimension. A common-shape question (e.g. 'Find papers by Grossberg') gets verb=`query` from the inline planner but a builtin plan declares verb=`research` — strict-equality drops the match before scoring sees it. Routes to inline-planner instead (~80s vs ~1s for a cached plan).

## Fix

Carve out the verb dimension. Equivalence classes:
- `{query, research, lookup}` — retrieval intents
- `{analyze, review, compare}` — critique / synthesis intents

Isolated verbs (`debug`, `document`, `plan-*`) stay strict. Other dimensions (`scope`, `strategy`, `taxonomy_domain`) keep strict equality.

## Closes

- Closes nexus-qi8t

## Test plan

- [x] +5 cases (synonym acceptance, isolated-class strict, non-verb-dim strict, empty-verb strict)
- [x] 43/43 test_plan_match green
- [ ] CI green