### PR TITLE
fix(catalog): collapse link-generate alias into generate-links (nexus-2297 partial)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -2992,17 +2992,33 @@ def generate_links_cmd(citations: bool, filepath: bool, dry_run: bool) -> None:
         click.echo(f"Total links generated: {total}")
 
 
-@catalog.command("link-generate")
+@catalog.command("link-generate", hidden=True)
 @click.option("--dry-run", is_flag=True, default=False, help="Show what would be done without writing")
-def link_generate_cmd(dry_run: bool) -> None:
-    """Run all link generators over the full catalog (batch scan)."""
-    cat = _get_catalog()
-    if dry_run:
-        click.echo("[dry-run] Would run full link generation scan")
-        return
-    from nexus.catalog.link_generator import generate_rdr_filepath_links
-    count = generate_rdr_filepath_links(cat)
-    click.echo(f"Generated {count} filepath links.")
+@click.pass_context
+def link_generate_cmd(ctx: click.Context, dry_run: bool) -> None:
+    """Deprecated alias for ``nx catalog generate-links`` (nexus-2297).
+
+    Pre-fix this verb generated only the RDR filepath links and emitted
+    a different message. To converge on the verb-noun convention used
+    by ``nx catalog link`` / ``unlink`` / ``links``, the canonical name
+    is now ``generate-links`` -- this alias emits a deprecation warning
+    and delegates to it. The alias will be removed in a future release.
+    """
+    click.echo(
+        "WARNING: 'nx catalog link-generate' is deprecated and will be "
+        "removed in a future release. Use 'nx catalog generate-links' "
+        "instead.",
+        err=True,
+    )
+    # Preserve the historical behaviour: filepath links only,
+    # no citations. Operators who want both should switch to the
+    # canonical ``generate-links`` verb.
+    ctx.invoke(
+        generate_links_cmd,
+        citations=False,
+        filepath=True,
+        dry_run=dry_run,
+    )
 
 
 def _make_t3():

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -1171,14 +1171,23 @@ class TestLinkDensity:
 
 
 class TestLinkGenerate:
-    """Tests for `nx catalog link-generate` command."""
+    """Tests for `nx catalog link-generate` deprecation alias (nexus-2297).
+
+    The canonical verb is now ``generate-links``; ``link-generate``
+    delegates to it and emits a deprecation warning. Tests verify the
+    delegation works end-to-end (dry-run path, empty-catalog path,
+    idempotent path) and that the deprecation warning fires.
+    """
 
     def test_link_generate_dry_run(self, initialized_catalog, catalog_env):
         """--dry-run outputs a message and exits cleanly without writing."""
         runner = CliRunner()
         result = runner.invoke(main, ["catalog", "link-generate", "--dry-run"])
         assert result.exit_code == 0
-        assert "dry-run" in result.output.lower()
+        # Deprecation warning fires from the alias.
+        assert "deprecated" in result.output.lower()
+        # The canonical command's dry-run message lands.
+        assert "would generate" in result.output.lower()
 
     def test_link_generate_empty_catalog(self, initialized_catalog, catalog_env):
         """Running on a catalog with no entries produces 0 links."""
@@ -1193,7 +1202,25 @@ class TestLinkGenerate:
         result = runner.invoke(main, ["catalog", "link-generate"])
         result = runner.invoke(main, ["catalog", "link-generate"])
         assert result.exit_code == 0
-        assert "0 filepath" in result.output
+        # Canonical generate_links_cmd phrases the count as
+        # "RDR filepath links created: 0" (was "Generated 0 filepath links."
+        # in the pre-deprecation impl).
+        assert "filepath links created: 0" in result.output
+
+
+class TestLinkGenerateDeprecation:
+    """nexus-2297: alias must emit the deprecation warning on stderr."""
+
+    def test_link_generate_alias_emits_deprecation_warning(
+        self, initialized_catalog, catalog_env,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "link-generate"])
+        assert result.exit_code == 0
+        assert "link-generate" in result.output
+        assert "deprecated" in result.output.lower()
+        # Points the operator at the canonical name.
+        assert "generate-links" in result.output
 
 
 class TestAgentIntegration:


### PR DESCRIPTION
## Summary

Scope A from nexus-2297: synonym collapse of two near-equivalent catalog verbs (`generate-links` and `link-generate`) that confused operators with no semantic distinction.

## Fix

`link-generate` becomes a hidden, deprecated alias that emits a stderr warning and delegates to `generate_links_cmd` with `citations=False, filepath=True` to preserve historical behaviour. Operators see the warning and migrate to the canonical `generate-links`.

## Out of scope

Scope B (folding diagnostic verbs into `nx doctor`) requires a deprecation cycle on user-facing commands and a more careful design review than this single-alias collapse. Tracked separately.

## Closes

- Closes nexus-2297 (partial — Scope A only)

## Test plan

- [x] `TestLinkGenerate` retitled + tests updated for the new delegation message format
- [x] +1 new `TestLinkGenerateDeprecation` class verifying the warning + pointer
- [x] 85/85 `test_catalog_cli` green
- [ ] CI green