### PR TITLE
fix(corpus): skip multi-match pick for bare knowledge (nexus-0f3h regression)

### DIFF
--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -250,13 +250,25 @@ def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
         # ``{prefix}__*`` collections (e.g. ``code`` matching 22 repos),
         # falling through to the promotion branch produced
         # ``knowledge__code__voyage-context-3__v1`` -- the wrong
-        # namespace, silently. Pick deterministically when multi-match
-        # to avoid that misroute: prefer the conformant
-        # ``{prefix}__{prefix}__<canonical_model>__v1``, then the
-        # legacy 2-segment ``{prefix}__{prefix}``, then alphabetical
-        # first. Log a warning so the operator sees the choice and
-        # can pass a more specific name on subsequent calls.
-        if len(matches) > 1:
+        # namespace, silently.
+        #
+        # Multi-match pick is content-type-specific. For ``knowledge``,
+        # falling through is SAFE because the promotion branch produces
+        # the correct ``knowledge__knowledge__...`` namespace plus the
+        # ``knowledge__knowledge`` legacy fallback from #536 at the
+        # bottom of the function. The historical behaviour the test
+        # suite locks (``store_put(collection="knowledge")`` resolves
+        # to ``knowledge__knowledge``) lives in that fallthrough path.
+        #
+        # For ``code``/``docs``/``rdr``, falling through is the bug:
+        # the promotion produces ``knowledge__<x>__...``, the wrong
+        # namespace. Pick deterministically among the matches:
+        # prefer ``{prefix}__{prefix}__<canonical_model>__v1`` (the
+        # canonical default), then ``{prefix}__{prefix}`` (the legacy
+        # 2-seg default), then alphabetical first. Log a warning so
+        # the operator sees the choice and can pass a more specific
+        # name on subsequent calls.
+        if len(matches) > 1 and user_arg != "knowledge":
             preferred_4seg = (
                 f"{user_arg}__{user_arg}__"
                 f"{canonical_embedding_model(user_arg)}__v1"
@@ -277,8 +289,11 @@ def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
                 candidates=matches[:10],
             )
             return picked
-        # zero matches: fall through to the promotion branch so a
-        # greenfield install still gets the conformant target.
+        # zero matches OR bare ``knowledge``: fall through to the
+        # promotion branch. Greenfield installs still get the
+        # conformant target; ``knowledge`` keeps its
+        # ``knowledge__knowledge`` legacy bridge at the bottom of
+        # the function.
 
     if "__" in user_arg:
         ct, _, rest = user_arg.partition("__")

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -558,3 +558,23 @@ def test_t3_collection_name_bare_prefix_multi_match_picks_alphabetical_when_no_c
     assert out == "code__a__voyage-code-3__v1"
     # Anti-regression: must never land in the wrong knowledge__ namespace.
     assert not out.startswith("knowledge__"), out
+
+
+def test_t3_collection_name_bare_knowledge_falls_through_to_legacy_default() -> None:
+    """nexus-0f3h regression guard: bare ``knowledge`` on an install
+    with multiple ``knowledge__*`` collections (none of which is the
+    ``knowledge__knowledge`` 2-seg default) MUST NOT pick alphabetical
+    first. The historical contract — ``knowledge`` resolves to the
+    auto-promoted ``knowledge__knowledge__voyage-context-3__v1`` (or
+    the legacy 2-seg ``knowledge__knowledge`` if it exists) — is the
+    one the test suite + production tooling locks.
+    """
+    # Multiple knowledge__ matches, none is knowledge__knowledge.
+    t3 = _FakeT3({
+        "knowledge__art",
+        "knowledge__delos",
+        "knowledge__greenfield__voyage-context-3__v1",
+    })
+    out = t3_collection_name("knowledge", t3=t3)
+    # MUST be the auto-promoted shape (no knowledge__knowledge on disk).
+    assert out == "knowledge__knowledge__voyage-context-3__v1"


### PR DESCRIPTION
## Summary

PR #561 broke `tests/test_mcp_server.py::test_store_put` + `test_store_get_round_trip[metadata]` on CI. The tests lock that bare `knowledge` on a multi-collection install must resolve to `knowledge__knowledge` (the historical contract from #536). My multi-match path fired before the legacy fallback, picked alphabetical first, and returned `knowledge__ad58d0cc` instead.

## Fix

Multi-match pick is content-type-specific:
- `knowledge`: falling through is SAFE — the promotion branch produces `knowledge__knowledge__voyage-context-3__v1` plus the `knowledge__knowledge` legacy fallback from #536 handles it. Test suite + production tooling lock this path.
- `code`/`docs`/`rdr`: falling through is the bug from #563. Deterministic pick stays.

Gate the multi-match pick on `user_arg != "knowledge"` so the historical knowledge-default behaviour is preserved while the code/docs/rdr fix still fires.

## Closes

- Fixes regression introduced by PR #561 (does not close any issue)

## Test plan

- [x] `test_store_put` + `test_store_get_round_trip[metadata]` now pass
- [x] +1 regression test in `tests/test_corpus.py` locking the bare-knowledge fallthrough
- [x] 71/71 mcp_server + corpus suite green
- [ ] CI green