### PR TITLE
fix(indexer): pre-classification file-size guard (#371, #436)

### DIFF
--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1710,6 +1710,25 @@ def _run_index(
         _log.warning("falling back to rglob file walk", repo=str(repo))
         candidate_files = sorted(p for p in repo.rglob("*") if p.is_file() and not p.is_symlink())
 
+    # GH #371 + #436: skip files larger than MAX_INDEXABLE_FILE_BYTES
+    # before classification. Pre-fix, a single huge file (vendored
+    # minified JS, generated bundle, large JSON config) would be
+    # classified as CODE / PROSE on extension alone and then passed
+    # to ``read_text(encoding="utf-8")`` in the per-file indexer,
+    # which loads the entire content into memory before any check.
+    # Observed symptoms:
+    # - #371: parent process OOM-killed at 3GB+ RSS on a repo with a
+    #   single 2GB+ vendored bundle.
+    # - #436: progress bar stalls at file N where file N+1 is the
+    #   huge file (read_text blocks while allocating the full buffer
+    #   under ext4 + low memory pressure; CPU at 0%).
+    # Cap at 5 MiB by default; configurable per repo via
+    # ``[indexing] max_file_bytes`` so monorepos with legitimately
+    # large indexable files can opt up. Emit a structured warning per
+    # skipped file so the operator can see what got dropped.
+    max_file_bytes = int(indexing_config.get("max_file_bytes", 5 * 1024 * 1024))
+    skipped_oversize: list[tuple[Path, int]] = []
+
     for path in candidate_files:
         if not path.is_file():
             continue  # git ls-files may list deleted files not yet committed
@@ -1723,6 +1742,15 @@ def _run_index(
         # Skip files under RDR paths — they go to rdr__ separately
         resolved = path.resolve()
         if any(resolved == rdr or _is_under(resolved, rdr) for rdr in rdr_abs_paths):
+            continue
+
+        # GH #371 + #436: oversize guard. Cheap stat() before any read.
+        try:
+            file_size = path.stat().st_size
+        except OSError:
+            continue  # broken symlink / permissions — defer to per-file path
+        if file_size > max_file_bytes:
+            skipped_oversize.append((path, file_size))
             continue
 
         score = frecency_map.get(path, 0.0)
@@ -1746,6 +1774,28 @@ def _run_index(
     prose_files.sort(key=lambda x: x[0], reverse=True)
     pdf_files.sort(key=lambda x: x[0], reverse=True)
     all_text_scored.sort(key=lambda x: x[0], reverse=True)
+
+    # GH #371 + #436: surface the oversize-skip set so the operator
+    # knows what got dropped. Single structured log + on_phase line
+    # so it's visible in non-TTY runs (CI, hooks, nohup).
+    if skipped_oversize:
+        _log.warning(
+            "indexer_oversize_skip",
+            count=len(skipped_oversize),
+            max_file_bytes=max_file_bytes,
+            sample=[
+                {"path": str(p.relative_to(repo)), "size": s}
+                for p, s in skipped_oversize[:5]
+            ],
+        )
+        if on_phase is not None:
+            largest = max(skipped_oversize, key=lambda x: x[1])
+            on_phase(
+                f"Skipped {len(skipped_oversize)} oversized file(s) "
+                f"(> {max_file_bytes // (1024 * 1024)} MiB). Largest: "
+                f"{largest[0].relative_to(repo)} at {largest[1] // (1024 * 1024)} MiB. "
+                f"Configure indexing.max_file_bytes to opt up."
+            )
 
     # Fire on_start with total non-RDR file count.
     # Note: this fires before the credential check below.  Phase 2 (CLI) must

--- a/tests/test_indexer_modules.py
+++ b/tests/test_indexer_modules.py
@@ -413,3 +413,70 @@ def test_index_prose_file_line_chunk_does_not_emit_source_path(
         f"source_path from the make_chunk_metadata call at "
         f"prose_indexer.py:183."
     )
+
+
+# ── GH #371 + #436: oversize file guard ─────────────────────────────────────
+
+
+def test_indexer_oversize_guard_skips_huge_files(tmp_path, monkeypatch) -> None:
+    """GH #371 + #436: a file larger than ``indexing.max_file_bytes``
+    must be skipped BEFORE classification + read_text. Pre-fix, a
+    single huge file (vendored bundle, generated payload) loaded its
+    full content into memory in ``read_text`` -- causing the parent
+    to OOM (#371) or the per-file loop to stall while the buffer
+    allocated under memory pressure (#436).
+
+    Uses the ``include_untracked=True`` path so we can exercise the
+    walker without committing files to git, keeping the test unit-fast.
+    """
+    import subprocess
+
+    from nexus.indexer import index_repository
+    from nexus.registry import RepoRegistry
+
+    repo = tmp_path / "test-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@x.io"], cwd=repo, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "test"], cwd=repo, check=True,
+    )
+    (repo / "small.py").write_text("def f():\n    return 1\n")
+    huge = repo / "vendor.min.js"
+    huge.write_bytes(b"x" * (6 * 1024 * 1024))  # 6 MiB
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "init"], cwd=repo, check=True,
+    )
+
+    phases: list[str] = []
+    def on_phase(msg: str) -> None:
+        phases.append(msg)
+
+    # Sandbox config so the registry doesn't pollute the operator's
+    # real ~/.config/nexus.
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(cfg_dir))
+    monkeypatch.setenv("NEXUS_SKIP_T1", "1")
+    monkeypatch.setenv("NX_LOCAL", "1")  # local mode, no Voyage credentials
+
+    reg = RepoRegistry(cfg_dir / "repos.json")
+    reg.add(repo)
+    try:
+        index_repository(repo, reg, on_phase=on_phase)
+    except Exception:
+        # The indexer may bail on missing credentials or on the
+        # local-only path's pipeline. The oversize guard fires
+        # BEFORE any of that, so the on_phase notice still lands.
+        pass
+
+    oversize_msgs = [p for p in phases if "oversized" in p.lower()]
+    assert oversize_msgs, (
+        f"expected an 'oversized file' phase message; got: {phases}"
+    )
+    assert any("vendor.min.js" in p for p in oversize_msgs), (
+        f"oversize message should name the file; got: {oversize_msgs}"
+    )


### PR DESCRIPTION
## Summary

Both #371 (OOM) and #436 (progress halt) share the same root cause: no file-size check anywhere in the classification or per-file index path. A repo with a single multi-megabyte text file (vendored minified bundle, generated payload, large JSON config) hits this:

1. `classify_file` routes by extension only → returns `CODE` / `PROSE`
2. `index_code_file` (or `index_prose_file`) calls `read_text(encoding='utf-8')` — loads entire content into memory before any decode-error check
3. A 2GB+ file allocates 2GB+ RSS

Observed:
- **#371**: parent OOM-killed at 3GB+ RSS on a repo with one large vendored file
- **#436**: progress bar stalls at file N (file N+1 is the huge file); CPU 0% while `read_text` blocks allocating the buffer under memory pressure

## Fix

`stat()` each candidate file BEFORE classification + read. Files larger than `indexing.max_file_bytes` (default 5 MiB, configurable per repo) get added to a `skipped_oversize` list and emit a single structured warning + `on_phase` notice naming the largest skipped file. Cheap (single stat per candidate) and runs before any embedding work.

## Closes

- Closes #371
- Closes #436

## Test plan

- [x] `tests/test_indexer_modules.py` +1 case (6 MiB `vendor.min.js` + small Python; assert `on_phase` 'oversized' notice fires)
- [x] 163/163 indexer suite green
- [ ] CI green