### PR TITLE
fix(t1): raise loudly when no server + cleanup stale pointer (#567)

### DIFF
--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -159,6 +159,24 @@ def _find_promote_overlap_candidates(
     return [cand for _, cand in hits]
 
 
+class T1ServerNotFoundError(RuntimeError):
+    """Raised when ``T1Database()`` cannot resolve a live T1 server and the
+    caller did not explicitly opt into ephemeral semantics.
+
+    GH #567: pre-fix the constructor silently fell back to a per-process
+    ``EphemeralClient`` whenever no session record was found. CLI
+    ``nx scratch put`` writes landed in that store and vanished at
+    process exit; the next ``nx scratch list`` invocation spawned a
+    fresh ``EphemeralClient`` and saw nothing.
+
+    Opt-in paths (no exception raised):
+      - ``T1Database(client=...)`` — caller injects the chroma client
+        (tests, MCP server lifespan)
+      - ``NEXUS_SKIP_T1=1`` env var — operator subprocess path that
+        explicitly acknowledges ephemeral semantics
+    """
+
+
 class T1Database:
     """T1 ChromaDB session scratch — shared across all agents in a session tree.
 
@@ -186,7 +204,10 @@ class T1Database:
         self._dead: bool = False
 
         if client is not None:
-            # Test-injection path: use provided client as-is.
+            # Test-injection / MCP-server path: caller supplies a client
+            # explicitly (EphemeralClient, mock, or its own HttpClient).
+            # Used by the FastMCP lifespan to install a server-lifetime
+            # EphemeralClient as the MCP-tool-side T1 store.
             self._client = client
             self._session_id = session_id or str(uuid4())
         else:
@@ -220,19 +241,56 @@ class T1Database:
                     port=record["server_port"],
                 )
                 self._session_id = record["session_id"]
-            else:
-                if not skip_t1:
-                    # Only warn when the absence of a T1 server is unexpected.
-                    # Skip-T1 is the stateless-operator path; the EphemeralClient
-                    # fallback is the documented intended behaviour there.
-                    warnings.warn(
-                        "No T1 server found; falling back to local EphemeralClient. "
-                        "Cross-agent scratch sharing is unavailable for this session.",
-                        stacklevel=2,
-                    )
+            elif skip_t1:
+                # Operator subprocess path: NEXUS_SKIP_T1=1 acknowledges
+                # the ephemeral semantics. Use EphemeralClient.
                 from nexus.session import read_claude_session_id
                 self._client = chromadb.EphemeralClient()
                 self._session_id = session_id or read_claude_session_id() or str(uuid4())
+            else:
+                # GH #567: NO live T1 server, NO opt-in via NEXUS_SKIP_T1,
+                # NO injected client. Pre-fix the constructor silently
+                # fell back to a per-process EphemeralClient. CLI
+                # ``nx scratch put`` writes would land in that ephemeral
+                # store and vanish when the process exited; subsequent
+                # ``nx scratch list`` invocations spawned a fresh
+                # EphemeralClient and saw nothing. The user reported
+                # this as silent data loss.
+                #
+                # Fail loud instead. Callers that want ephemeral
+                # semantics opt in explicitly:
+                #
+                #   - ``T1Database(client=chromadb.EphemeralClient())``
+                #     (tests, MCP-server lifespan)
+                #   - ``NEXUS_SKIP_T1=1`` env var (operator subprocess)
+                #
+                # Detect + clear the stale ``current_session`` pointer
+                # at the same time so the next invocation gets a clean
+                # baseline; structured-log the cleanup so the operator
+                # can correlate.
+                from nexus.session import read_claude_session_id
+                stale_uuid = read_claude_session_id()
+                if stale_uuid:
+                    from nexus.session import CLAUDE_SESSION_FILE
+                    try:
+                        CLAUDE_SESSION_FILE.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                    _log.warning(
+                        "t1_stale_current_session_pointer_cleared",
+                        stale_uuid=stale_uuid,
+                        sessions_dir=str(SESSIONS_DIR),
+                    )
+                raise T1ServerNotFoundError(
+                    f"No T1 server found in {SESSIONS_DIR} and no in-process "
+                    f"client supplied. T1 scratch requires either:\n"
+                    f"  - an active Claude Code session (which spawns the MCP "
+                    f"server + chroma via FastMCP lifespan), OR\n"
+                    f"  - NEXUS_SKIP_T1=1 to acknowledge ephemeral per-process "
+                    f"semantics (writes will not persist across invocations).\n"
+                    f"Pre-fix this fell through to a silent EphemeralClient "
+                    f"that lost every write at process exit (GH #567)."
+                )
 
         self._col = self._client.get_or_create_collection(_COLLECTION)
 

--- a/src/nexus/t1_watchdog.py
+++ b/src/nexus/t1_watchdog.py
@@ -148,6 +148,13 @@ def main(argv: list[str] | None = None) -> int:
     log = structlog.get_logger("nexus.t1_watchdog")
 
     session_file = Path(args.session_file) if args.session_file else None
+    # GH #567: snapshot whether the session file was present when the
+    # watchdog started. The poll loop's session-file-removed exit only
+    # fires when the file existed at startup -- avoids breaking
+    # callers (tests, legacy) that pass a path that never gets created.
+    session_file_existed_at_start = (
+        session_file is not None and session_file.exists()
+    )
     tmpdir = Path(args.tmpdir) if args.tmpdir else None
     dual_watch = args.mcp_pid > 0
 
@@ -177,6 +184,32 @@ def main(argv: list[str] | None = None) -> int:
                 "watchdog_exiting",
                 reason="chroma_died_externally",
                 chroma_pid=args.chroma_pid,
+            )
+            return 0
+        # GH #567: session-file disappearance trigger. The session
+        # record may be removed by sweep_stale_sessions (uuid-mismatch
+        # arm at session.py:286) when the same Claude process rolls to
+        # a new conversation UUID via /clear or /resume. Pre-fix, the
+        # watchdog kept polling on its old session's chroma_pid and
+        # leaked until that PID died -- the reporter saw a stale
+        # watchdog for a session whose .session file was gone. Exit
+        # cleanly when our session file disappears so the kept-alive
+        # chroma server we were watching can be reaped by whatever
+        # path replaced our session record.
+        #
+        # Only fire when the file EXISTED at watchdog startup; tests
+        # and legacy callers may pass ``--session-file`` paths that
+        # never get created, and the existing behaviour there is to
+        # rely on PID liveness alone.
+        if (
+            session_file_existed_at_start
+            and session_file is not None
+            and not session_file.exists()
+        ):
+            log.info(
+                "watchdog_exiting",
+                reason="session_file_removed",
+                session_file=str(session_file),
             )
             return 0
         # Dual-watch mode (RDR-094 FM-NEW-1): MCP server died without

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,14 @@ def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setattr("nexus.db.t1.SESSIONS_DIR", sessions)
     monkeypatch.setattr("nexus.hooks.SESSIONS_DIR", sessions)
+    # GH #567: T1Database() now raises T1ServerNotFoundError when no
+    # record is found and no client is injected, to prevent the silent
+    # CLI write-loss bug. Tests that previously relied on the implicit
+    # EphemeralClient fallback opt in via NEXUS_SKIP_T1=1, the same
+    # env var the operator subprocess path uses. Test fixtures that
+    # want to share a chroma client across two T1Database instances
+    # (e.g. ``two_sessions``) still pass ``client=...`` explicitly.
+    monkeypatch.setenv("NEXUS_SKIP_T1", "1")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_t1.py
+++ b/tests/test_t1.py
@@ -15,6 +15,22 @@ import pytest
 from nexus.db.t1 import T1Database
 
 
+@pytest.fixture(autouse=True)
+def _allow_t1_record_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GH #567: tests in this file exercise T1Database's record-
+    resolution + raise-loud paths directly. The conftest's autouse
+    ``_isolate_t1_sessions`` fixture sets ``NEXUS_SKIP_T1=1`` to keep
+    other test files using ephemeral fallback semantics; here we
+    UNSET it so tests reach the post-fix behaviour:
+      - constructor raises ``T1ServerNotFoundError`` when no record
+      - finds a record when one is written
+      - exercises the resolver-retry loop
+    Tests that explicitly want ``NEXUS_SKIP_T1=1`` opt back in
+    locally via ``monkeypatch.setenv`` inside the test body.
+    """
+    monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+
+
 def _ephemeral_t1(session_id: str | None = None) -> T1Database:
     return T1Database(session_id=session_id or str(uuid4()), client=chromadb.EphemeralClient())
 
@@ -41,15 +57,33 @@ class TestT1DatabaseConstructor:
         assert t1._session_id == "parent-session-uuid"
         assert t1._client is mock_http
 
-    def test_falls_back_to_ephemeral_when_no_record(self) -> None:
+    def test_raises_when_no_record_and_no_opt_in(self) -> None:
+        """GH #567: pre-fix the constructor silently fell back to
+        EphemeralClient. That broke ``nx scratch put`` -> ``nx scratch
+        list`` across CLI invocations because each CLI process got its
+        own EphemeralClient and lost every prior write at exit. Post-
+        fix the constructor raises so the silent loss is impossible.
+        """
+        from nexus.db.t1 import T1ServerNotFoundError
+
         with patch("nexus.db.t1._resolve_session_record_with_retry", return_value=None), \
-             patch("nexus.db.t1.find_ancestor_session", return_value=None), \
-             warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+             patch("nexus.db.t1.find_ancestor_session", return_value=None):
+            with pytest.raises(T1ServerNotFoundError, match="No T1 server found"):
+                T1Database(session_id="fallback-id")
+
+    def test_falls_back_to_ephemeral_when_skip_t1_env_set(
+        self, monkeypatch,
+    ) -> None:
+        """GH #567 opt-in path: ``NEXUS_SKIP_T1=1`` explicitly
+        acknowledges ephemeral semantics so the operator subprocess
+        path keeps working. EphemeralClient, no exception.
+        """
+        monkeypatch.setenv("NEXUS_SKIP_T1", "1")
+        with patch("nexus.db.t1._resolve_session_record_with_retry", return_value=None), \
+             patch("nexus.db.t1.find_ancestor_session", return_value=None):
             t1 = T1Database(session_id="fallback-id")
         assert t1._session_id == "fallback-id"
         assert not hasattr(t1._client, "_api_url")
-        assert any("EphemeralClient" in str(x.message) for x in w)
 
     def test_explicit_client_injection_bypasses_chain(self) -> None:
         client = chromadb.EphemeralClient()

--- a/tests/test_t1_watchdog.py
+++ b/tests/test_t1_watchdog.py
@@ -487,3 +487,91 @@ class TestWatchdogLogConfiguration:
         body = log_file.read_text()
         assert "watchdog_started" in body
         assert "claude_pid=1" in body
+
+
+# ── GH #567: session-file disappearance trigger ─────────────────────────────
+
+
+class TestSessionFileRemovedExit:
+    """GH #567: when the session file existed at watchdog startup but
+    is later removed (sweep_stale_sessions uuid-mismatch arm at
+    session.py:286), the watchdog must exit cleanly. Pre-fix it kept
+    polling and leaked until its watched PIDs died.
+    """
+
+    def test_session_file_removed_after_start_triggers_exit(
+        self, tmp_path, monkeypatch, captured_events,
+    ):
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(
+            t1_watchdog, "_is_alive", lambda _pid: True,  # everything alive
+        )
+
+        session_file = tmp_path / "s"
+        session_file.write_text("{}")  # exists at startup
+
+        # Remove the file on the FIRST tick so we exercise the
+        # disappearance trigger.
+        original_sleep = t1_watchdog.time.sleep
+        ticks = [0]
+
+        def _tick_then_remove(_s):
+            ticks[0] += 1
+            if ticks[0] == 1:
+                session_file.unlink()
+            return original_sleep(_s)
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", _tick_then_remove)
+
+        with patch.object(t1_watchdog, "_cleanup"):
+            t1_watchdog.main([
+                "--claude-pid", "100",
+                "--chroma-pid", "200",
+                "--session-file", str(session_file),
+                "--tmpdir", str(tmp_path / "td"),
+            ])
+
+        events = [
+            e for e in captured_events
+            if e.get("reason") == "session_file_removed"
+        ]
+        assert events, (
+            f"expected watchdog_exiting with reason=session_file_removed; "
+            f"got events: {[e.get('event') for e in captured_events]}"
+        )
+
+    def test_session_file_never_existed_does_not_trigger(
+        self, tmp_path, monkeypatch, captured_events,
+    ):
+        """Tests / legacy callers that pass a path that never gets
+        created must NOT see the new exit. The PID-liveness paths
+        keep ownership.
+        """
+        from nexus import t1_watchdog
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+
+        # claude dies on first tick so the loop exits via the
+        # claude_pid_disappeared arm; if our new check fired
+        # incorrectly it would beat that path.
+        def _alive(pid: int) -> bool:
+            return pid != 100
+
+        monkeypatch.setattr(t1_watchdog, "_is_alive", _alive)
+        with patch.object(t1_watchdog, "_cleanup"), \
+             patch.object(t1_watchdog, "_signal_then_kill"):
+            t1_watchdog.main([
+                "--claude-pid", "100",
+                "--chroma-pid", "200",
+                "--session-file", str(tmp_path / "never-created"),
+                "--tmpdir", str(tmp_path / "td"),
+            ])
+
+        # claude_pid_disappeared should be the load-bearing event,
+        # NOT session_file_removed.
+        names = [e.get("event") for e in captured_events]
+        reasons = [e.get("reason") for e in captured_events]
+        assert "claude_pid_disappeared" in names
+        assert "session_file_removed" not in reasons


### PR DESCRIPTION
## Summary

GH #567 (4.26.4 shake-out): `nx scratch` CLI silently fell back to `EphemeralClient` when `~/.config/nexus/current_session` pointed at a UUID with no backing `.session` file. Each CLI invocation spawned its own `EphemeralClient` — writes lost between invocations. The user saw `nx scratch put` return `Stored: <uuid>`, then `nx scratch list` report `No scratch entries.`

`/nx:*` skills invoking `nx scratch` from a Bash tool (sibling-agent coordination) silently stored nothing.

## Fix

1. **`T1Database` constructor RAISES `T1ServerNotFoundError`** when no record is found AND no client injected AND `NEXUS_SKIP_T1` not set. Pre-fix it warned + fell through, making silent data loss the default.
2. **Stale `current_session` pointer cleanup**: when the constructor detects the pointer points at a non-existent record, it structured-logs and unlinks the pointer so subsequent invocations start clean.
3. **`t1_watchdog` self-exits** when its `--session-file` disappears (only when file existed at startup; tests that pass never-created paths still work).

## Opt-in paths (no exception)

- `T1Database(client=...)` — MCP-server lifespan, tests
- `NEXUS_SKIP_T1=1` env var — operator subprocess path

## Closes

- Closes #567

## Test plan

- [x] `test_t1.py` constructor tests rewritten for raise-loud + per-file autouse to unset `NEXUS_SKIP_T1`
- [x] `conftest.py` autouse sets `NEXUS_SKIP_T1=1` for the test suite (covers the pre-existing fallback assumption)
- [x] `test_t1_watchdog.py` +2 cases (file-removed-after-start triggers exit; never-existed does not trigger)
- [x] 211/211 t1 + scratch + watchdog regression green
- [ ] CI green