### PR TITLE
fix(catalog-cli): push --type filter into SQL (#568)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -3427,16 +3427,32 @@ class Catalog:
         row = self._db.execute("SELECT COUNT(*) FROM documents").fetchone()
         return row[0] if row else 0
 
-    def all_documents(self, limit: int = 0) -> list[CatalogEntry]:
-        """Return all catalog entries. limit=0 means unlimited."""
+    def all_documents(
+        self, limit: int = 0, *, content_type: str = "",
+    ) -> list[CatalogEntry]:
+        """Return all catalog entries. limit=0 means unlimited.
+
+        GH #568: ``content_type`` pushes the filter into the SQL
+        ``WHERE`` clause so pagination works correctly when the
+        requested content_type is small-cardinality. Pre-fix the
+        CLI ``nx catalog list --type rdr`` filtered Python-side
+        AFTER ``LIMIT/OFFSET`` and returned empty whenever the
+        pre-LIMIT slice held no matching rows -- e.g. 15K-entry
+        catalog with only 2 rdr rows: ``--type rdr -n 3`` got 0.
+        Mirrors PR #533's fix for the MCP ``catalog_list`` surface.
+        """
         sql = (
             "SELECT tumbler, title, author, year, content_type, file_path, "
             "corpus, physical_collection, chunk_count, head_hash, indexed_at, metadata, source_mtime, source_uri "
             "FROM documents"
         )
+        params: tuple = ()
+        if content_type:
+            sql += " WHERE content_type = ?"
+            params = (content_type,)
         if limit > 0:
             sql += f" LIMIT {limit}"
-        rows = self._db.execute(sql).fetchall()
+        rows = self._db.execute(sql, params).fetchall()
         return [
             CatalogEntry(
                 tumbler=Tumbler.parse(r[0]), title=r[1], author=r[2], year=r[3],

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -859,10 +859,20 @@ def list_cmd(owner: str, content_type: str, limit: int, offset: int, as_json: bo
                 )
             owner_tumbler = matches[0]
         entries = cat.by_owner(owner_tumbler)
+        # GH #568: --owner path is by-owner-then-Python-filter (the
+        # owner cardinality is naturally small so the post-filter is
+        # safe). Apply the type filter here too if provided.
+        if content_type:
+            entries = [e for e in entries if e.content_type == content_type]
     else:
-        entries = cat.all_documents(limit=limit + offset + 1)
-    if content_type:
-        entries = [e for e in entries if e.content_type == content_type]
+        # GH #568: push --type into SQL so pagination on a small-
+        # cardinality content_type doesn't return empty. Pre-fix the
+        # filter ran Python-side AFTER LIMIT/OFFSET; a 15K-entry
+        # catalog with only 2 rdr rows had ``--type rdr -n 3`` return
+        # 0. Mirrors PR #533's fix for the MCP catalog_list surface.
+        entries = cat.all_documents(
+            limit=limit + offset + 1, content_type=content_type,
+        )
     total = len(entries)
     entries = entries[offset:offset + limit]
 

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -192,6 +192,68 @@ class TestListCommand:
         assert "A" in result.output
         assert "B" in result.output
 
+    def test_list_type_filter_pushed_to_sql(
+        self, initialized_catalog, catalog_env,
+    ):
+        """GH #568: --type filter must be pushed into the SQL WHERE
+        clause. Pre-fix, the CLI fetched LIMIT+OFFSET rows then
+        Python-filtered, so a small-cardinality content_type (rdr in
+        a code/docs-heavy catalog) returned empty even when matching
+        rows existed.
+
+        Construct the worst case: register many code rows + 2 rdr rows.
+        Without the SQL push, ``--type rdr -n 3`` returns 0 because
+        the first 51 rows fetched are all code.
+        """
+        runner = CliRunner()
+        # Register 20 code rows.
+        for i in range(20):
+            runner.invoke(main, [
+                "catalog", "register", "--title", f"code-{i}",
+                "--owner", "1.1", "--type", "code",
+            ])
+        # Register 2 rdr rows.
+        runner.invoke(main, [
+            "catalog", "register", "--title", "rdr-A",
+            "--owner", "1.1", "--type", "rdr",
+        ])
+        runner.invoke(main, [
+            "catalog", "register", "--title", "rdr-B",
+            "--owner", "1.1", "--type", "rdr",
+        ])
+        # Crucially, fetch -n 3 (smaller than the code-row prefix).
+        result = runner.invoke(main, [
+            "catalog", "list", "--type", "rdr", "-n", "3",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "rdr-A" in result.output, result.output
+        assert "rdr-B" in result.output, result.output
+        # And no code rows leaked.
+        assert "code-" not in result.output, result.output
+
+    def test_list_type_filter_with_owner(
+        self, initialized_catalog, catalog_env,
+    ):
+        """GH #568 sanity: --owner + --type combined still works.
+        The owner path applies the type filter Python-side (small
+        cardinality per owner makes that safe).
+        """
+        runner = CliRunner()
+        runner.invoke(main, [
+            "catalog", "register", "--title", "owner-code",
+            "--owner", "1.1", "--type", "code",
+        ])
+        runner.invoke(main, [
+            "catalog", "register", "--title", "owner-rdr",
+            "--owner", "1.1", "--type", "rdr",
+        ])
+        result = runner.invoke(main, [
+            "catalog", "list", "--owner", "test-repo", "--type", "rdr",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "owner-rdr" in result.output
+        assert "owner-code" not in result.output
+
     def test_list_owner_unknown_emits_clean_error(
         self, initialized_catalog, catalog_env,
     ):


### PR DESCRIPTION
## Summary

GH #568: `nx catalog list --type rdr` returned empty on a 15K-entry catalog with only 2 rdr rows. Same shape as #538 (4.26.1, PR #533) which fixed the MCP `catalog_list` surface but missed the CLI path.

## Root cause

`commands/catalog.py:list_cmd`:
```python
entries = cat.all_documents(limit=limit + offset + 1)
if content_type:
    entries = [e for e in entries if e.content_type == content_type]
```

Python-side filter ran AFTER SQL LIMIT, so `--type rdr -n 3` fetched 51 rows (all code in a code-heavy catalog) and produced 0 matches.

## Fix

Extend `Catalog.all_documents` with a `content_type` kwarg that pushes `WHERE content_type = ?` into the SQL. CLI's no-owner branch passes it through. Owner-path keeps the Python-side filter (small cardinality per owner makes that safe).

## Closes

- Closes #568

## Test plan

- [x] +2 cases: push-down (20 code + 2 rdr, `-n 3 --type rdr` returns rdr rows) and `--owner + --type` combined
- [x] 87/87 catalog_cli green
- [ ] CI green