### PR TITLE
fix(mcp): lazy chroma init + self-mint UUID on lifespan-vs-hook race

### DIFF
--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -264,23 +264,15 @@ class T1Database:
                 #     (tests, MCP-server lifespan)
                 #   - ``NEXUS_SKIP_T1=1`` env var (operator subprocess)
                 #
-                # Detect + clear the stale ``current_session`` pointer
-                # at the same time so the next invocation gets a clean
-                # baseline; structured-log the cleanup so the operator
-                # can correlate.
-                from nexus.session import read_claude_session_id
-                stale_uuid = read_claude_session_id()
-                if stale_uuid:
-                    from nexus.session import CLAUDE_SESSION_FILE
-                    try:
-                        CLAUDE_SESSION_FILE.unlink(missing_ok=True)
-                    except OSError:
-                        pass
-                    _log.warning(
-                        "t1_stale_current_session_pointer_cleared",
-                        stale_uuid=stale_uuid,
-                        sessions_dir=str(SESSIONS_DIR),
-                    )
+                # NOTE: do NOT clear current_session here. An earlier
+                # iteration of this fix unlinked the pointer when no
+                # ``.session`` matched it, but that's racy: the MCP
+                # server's ``_t1_chroma_init_if_owner`` reads the same
+                # pointer to decide what session_id to spawn chroma
+                # under. Nuking it from a CLI invocation defeats an
+                # MCP server that's about to spawn its chroma.
+                # ``_t1_chroma_init_if_owner`` self-mints a UUID when
+                # the pointer is missing (mcp/core.py post-#567 fix).
                 raise T1ServerNotFoundError(
                     f"No T1 server found in {SESSIONS_DIR} and no in-process "
                     f"client supplied. T1 scratch requires either:\n"

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -144,8 +144,25 @@ def _t1_chroma_init_if_owner() -> None:
 
     own_id = inherited or _resolve_top_level_session_id()
     if not own_id:
-        # No session id resolvable: skip; T1 falls back to EphemeralClient.
-        return
+        # GH #567 follow-up: no current_session pointer at the time
+        # the lifespan / first-tool-call fires. Pre-fix the function
+        # returned silently and chroma never spawned -- the silent-
+        # data-loss fingerprint #567 reported. The SessionStart hook
+        # may simply not have fired yet (race vs lifespan boot), or
+        # an earlier stale-cleanup pass nuked the pointer. Self-heal:
+        # mint a fresh UUID, write it to current_session as the canonical
+        # pointer, and use it as our session id. SessionStart on the
+        # NEXT boot reads this same pointer and won't overwrite.
+        from uuid import uuid4
+        from nexus.session import write_claude_session_id
+        own_id = str(uuid4())
+        write_claude_session_id(own_id)
+        import structlog
+        structlog.get_logger().info(
+            "t1_chroma_init_minted_session_id",
+            session_id=own_id,
+            reason="no_current_session_at_lifespan_boot",
+        )
 
     # FM-NEW-2: TCP-probe an existing record before spawning. If the
     # prior chroma is still listening, reuse it.

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -97,11 +97,47 @@ def clear_search_traces() -> None:
 
 
 def get_t1():
-    """Return (T1Database, is_isolated) — lazy init on first call."""
+    """Return (T1Database, is_isolated) — lazy init on first call.
+
+    GH #567 + chroma-spawn-race follow-up: the FastMCP lifespan that
+    used to own ``_t1_chroma_init_if_owner`` could fire BEFORE the
+    Claude Code SessionStart hook wrote ``current_session``. When that
+    happened, ``_resolve_top_level_session_id`` returned None,
+    ``_t1_chroma_init_if_owner`` returned silently, no chroma was
+    spawned, and no ``.session`` file was written. CLI tools then had
+    no record to find -- the silent-data-loss fingerprint that #567
+    reported. Live trace 2026-05-06 (mcp.log boot at 14:29:40 had no
+    chroma_init log; current_session was nuked by an earlier stale-
+    cleanup pass; lifespan ran with empty pointer).
+
+    Fix: call ``_t1_chroma_init_if_owner`` from ``get_t1`` BEFORE
+    constructing T1Database. By the time any MCP tool fires, the
+    SessionStart hook has run (Claude Code sequences SessionStart
+    before tool dispatch). The lifespan still calls
+    ``_t1_chroma_init_if_owner`` -- whichever fires first wins
+    (the function is idempotent via the ``if _OWNED_CHROMA: return``
+    guard at its head). This makes chroma spawn robust to lifespan
+    vs SessionStart ordering races.
+
+    The function is also called from ``mcp/catalog.py`` so the
+    catalog-side MCP server's first tool call gets the same robust
+    behaviour.
+    """
     global _t1_instance, _t1_isolated
     if _t1_instance is None:
         with _t1_lock:
             if _t1_instance is None:
+                # Ensure chroma is up + .session record written before
+                # T1Database() probes for it. Idempotent: returns
+                # immediately when _OWNED_CHROMA already set.
+                try:
+                    from nexus.mcp.core import _t1_chroma_init_if_owner
+                    _t1_chroma_init_if_owner()
+                except Exception:
+                    # Spawn failure already logs as 't1_chroma_spawn_failed';
+                    # let T1Database raise its T1ServerNotFoundError below
+                    # if no record landed.
+                    pass
                 with warnings.catch_warnings(record=True) as caught:
                     warnings.simplefilter("always")
                     from nexus.db.t1 import T1Database

--- a/tests/test_mcp_chroma_lifecycle.py
+++ b/tests/test_mcp_chroma_lifecycle.py
@@ -460,3 +460,66 @@ class TestLifespanWiring:
         assert not hasattr(core_mod, "_flag_enabled"), (
             "_flag_enabled was removed with the gate"
         )
+
+
+# ── GH #567 follow-up: lifespan-vs-SessionStart race ─────────────────────────
+
+
+def test_t1_chroma_init_self_mints_session_id_when_pointer_missing(
+    tmp_path, monkeypatch,
+) -> None:
+    """GH #567 follow-up: lifespan boots before SessionStart writes
+    current_session pointer (race observed locally on 4.26.4, mcp.log
+    boot at 14:29:40 had no chroma_init log because the pointer was
+    empty). Pre-fix _t1_chroma_init_if_owner returned silently on
+    'no own_id'; chroma never spawned; .session never written. Post-
+    fix it self-mints a UUID and writes current_session so the lazy
+    chroma comes up regardless of hook order.
+
+    Mocks start_t1_server so the test does not actually spawn chroma.
+    """
+    from unittest.mock import patch
+
+    from nexus.mcp.core import _t1_chroma_init_if_owner, _OWNED_CHROMA
+
+    # Sandbox config dir so we don't touch the operator's real
+    # current_session.
+    pointer = tmp_path / "current_session"
+    monkeypatch.setattr("nexus.session.CLAUDE_SESSION_FILE", pointer)
+
+    # Confirm pointer is absent at start.
+    assert not pointer.exists()
+
+    # Reset _OWNED_CHROMA singleton between tests.
+    _OWNED_CHROMA.clear()
+
+    fake_record_writes: list[tuple] = []
+
+    def _fake_start():
+        return ("127.0.0.1", 54321, 99999, str(tmp_path / "fake-tmpdir"))
+
+    def _fake_write_record(sessions_dir, session_id, host, port, server_pid, tmpdir, **kwargs):
+        fake_record_writes.append((session_id, host, port))
+
+    with patch("nexus.session.start_t1_server", side_effect=_fake_start), \
+         patch("nexus.session.write_session_record_by_id", side_effect=_fake_write_record), \
+         patch("nexus.session.find_claude_root_pid", return_value=None), \
+         patch("nexus.session.spawn_t1_watchdog", return_value=0):
+        _t1_chroma_init_if_owner()
+
+    # Self-minted UUID written to current_session.
+    assert pointer.exists(), "current_session pointer must be written"
+    minted_uuid = pointer.read_text().strip()
+    assert len(minted_uuid) == 36, f"expected UUID, got {minted_uuid!r}"
+
+    # Chroma spawn fired with that UUID.
+    assert fake_record_writes, "no record write fired"
+    session_id, host, port = fake_record_writes[0]
+    assert session_id == minted_uuid, (
+        f"record session_id {session_id!r} must match minted UUID {minted_uuid!r}"
+    )
+    assert host == "127.0.0.1"
+
+    # _OWNED_CHROMA reflects the spawn.
+    assert _OWNED_CHROMA.get("session_id") == minted_uuid
+    _OWNED_CHROMA.clear()  # cleanup


### PR DESCRIPTION
## Summary

GH #567 deeper root cause. The FastMCP lifespan calls `_t1_chroma_init_if_owner` BEFORE Claude Code's SessionStart hook writes `~/.config/nexus/current_session` in some boot orderings. When that race fires, `_resolve_top_level_session_id` returns None, the init function returns silently, **no chroma spawns**, **no `.session` file gets written**.

Live trace 2026-05-06: mcp.log boot at 14:29:40 had ZERO chroma_init events. `~/.config/nexus/sessions/` was empty. MCP tools worked because in-process get_t1 fell back to ephemeral; CLI `nx scratch` raised.

## Fix

Three changes:

1. **`mcp_infra.get_t1` calls `_t1_chroma_init_if_owner` BEFORE constructing T1Database** — by first-tool-call time, SessionStart has run.
2. **`_t1_chroma_init_if_owner` self-mints a UUID** when `current_session` is absent and writes it as the canonical pointer. MCP server becomes self-sufficient: first tool call lazily spawns chroma even when SessionStart hasn't fired.
3. **T1Database constructor no longer unlinks `current_session` on the raise path** (was racy — a CLI invocation could nuke the pointer a concurrently-booting MCP server was about to read).

## Closes

Closes the architectural gap behind GH #567. PR #569 covered the silent-loss surface (raise loud); this PR makes the happy-path spawn robust to ordering races so the raise stays rare.

## Test plan

- [x] `+1 case` mocks `start_t1_server` / `write_session_record_by_id`, asserts self-mint + pointer write + chroma spawn fires
- [x] `153/153` chroma + t1 + scratch + hooks + watchdog suite green
- [ ] CI green