### PR TITLE
fix(mcp): post-spawn reconciliation when current_session drifts (#572)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -197,17 +197,131 @@ def _t1_chroma_init_if_owner() -> None:
         mcp_pid=_os.getpid(),  # FM-NEW-1: dual-watch
     ) if claude_root_pid else 0
 
+    # GH #572: post-spawn reconciliation. The SessionStart hook may
+    # race with this lifespan and write a DIFFERENT canonical session
+    # id to ``current_session`` AFTER we read it. Live trace from the
+    # reporter:
+    #
+    #   1. Prior session ended; sessions/ empty; current_session left
+    #      pointing at the prior id (7c5f5331)
+    #   2. New conversation starts. MCP lifespan reads pointer ->
+    #      7c5f5331 (stale but indistinguishable from a fresh
+    #      pre-SessionStart pointer at this point)
+    #   3. We spawn chroma + write sessions/7c5f5331.session
+    #   4. SessionStart fires (after our read), writes
+    #      current_session=b314324c (the canonical conversation id)
+    #   5. Every later T1Database() reads b314324c, looks for
+    #      sessions/b314324c.session, fails -> entire conversation's
+    #      T1 broken
+    #
+    # Reconcile by re-reading the pointer AFTER our record write. If
+    # it differs from own_id, rename the record file + pointer the
+    # _OWNED_CHROMA snapshot at the canonical id. The chroma server
+    # itself doesn't care about the file name; the file is the
+    # discovery surface that ``find_session_by_id`` reads.
     write_session_record_by_id(
         SESSIONS_DIR, own_id, host, port, server_pid, tmpdir,
         claude_root_pid=claude_root_pid,
         watchdog_pid=watchdog_pid,
     )
+
     _OWNED_CHROMA.update({
         "session_id": own_id,
         "server_pid": server_pid,
         "tmpdir": str(tmpdir),
         "session_file": str(session_file),
     })
+
+    # Run a first reconcile pass immediately after spawn. Catches the
+    # case where SessionStart fired between our pointer read and our
+    # spawn (the closest race window). The full reconcile -- which
+    # also catches SessionStart firing AFTER spawn but before the
+    # first tool call -- runs from get_t1 via reconcile_owned_chroma.
+    if not inherited:
+        reconcile_owned_chroma()
+
+
+def reconcile_owned_chroma() -> bool:
+    """GH #572: rename ``_OWNED_CHROMA``'s session record file to
+    match the current ``current_session`` pointer when they've
+    drifted. Idempotent.
+
+    The lifespan spawn path can race with the SessionStart hook:
+
+      1. Prior session ended; ``sessions/`` empty; ``current_session``
+         left pointing at the prior id (call it ``X``).
+      2. New conversation starts. MCP lifespan reads pointer -> ``X``,
+         spawns chroma + writes ``sessions/X.session``.
+      3. SessionStart fires, writes ``current_session=Y`` (the
+         canonical conversation id).
+      4. Every later ``T1Database()`` reads ``Y``, looks for
+         ``sessions/Y.session``, fails -- the conversation's T1 is
+         broken until manual recovery.
+
+    This reconcile pass re-reads ``current_session``. If it differs
+    from ``_OWNED_CHROMA["session_id"]``, rename the record file so
+    discovery via the canonical pointer succeeds. The chroma server
+    itself doesn't care about the file name; it's a discovery
+    surface only.
+
+    Called from two sites:
+      - ``_t1_chroma_init_if_owner`` post-spawn (catches the closest
+        race window: SessionStart fired between pointer read + spawn)
+      - ``get_t1`` first tool call (catches the wider race window:
+        SessionStart fired AFTER spawn but BEFORE first tool call;
+        tool dispatch is sequenced after SessionStart by Claude Code,
+        so by tool-call time the pointer is canonical)
+
+    Returns True when a rename was performed; False when no action
+    was needed.
+    """
+    if not _OWNED_CHROMA:
+        return False
+    if _OWNED_CHROMA.get("nested") or _OWNED_CHROMA.get("reused"):
+        # Subagent path or shared-server path: not our record to rename.
+        return False
+    if _os.environ.get("NX_SESSION_ID", "").strip():
+        # Subagent inheritance: parent owns the record key.
+        return False
+
+    current_id = _OWNED_CHROMA.get("session_id", "")
+    canonical = _resolve_top_level_session_id()
+    if not canonical or canonical == current_id:
+        return False
+
+    from nexus.db.t1 import SESSIONS_DIR
+
+    old_path_str = _OWNED_CHROMA.get("session_file", "")
+    if not old_path_str:
+        return False
+    from pathlib import Path
+    old_path = Path(old_path_str)
+    new_path = SESSIONS_DIR / f"{canonical}.session"
+
+    if not old_path.exists():
+        # Already renamed by a sibling reconcile, or reaped externally.
+        return False
+
+    try:
+        old_path.replace(new_path)
+    except OSError as exc:
+        import structlog
+        structlog.get_logger().warning(
+            "t1_chroma_reconcile_rename_failed",
+            from_id=current_id, to_id=canonical, error=str(exc),
+        )
+        return False
+
+    _OWNED_CHROMA["session_id"] = canonical
+    _OWNED_CHROMA["session_file"] = str(new_path)
+    import structlog
+    structlog.get_logger().info(
+        "t1_chroma_reconciled_session_id",
+        from_id=current_id,
+        to_id=canonical,
+        reason="current_session_pointer_diverged",
+    )
+    return True
 
 
 def _resolve_top_level_session_id() -> str | None:

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -131,8 +131,20 @@ def get_t1():
                 # T1Database() probes for it. Idempotent: returns
                 # immediately when _OWNED_CHROMA already set.
                 try:
-                    from nexus.mcp.core import _t1_chroma_init_if_owner
+                    from nexus.mcp.core import (
+                        _t1_chroma_init_if_owner,
+                        reconcile_owned_chroma,
+                    )
                     _t1_chroma_init_if_owner()
+                    # GH #572: reconcile session record file vs the
+                    # current_session pointer. SessionStart can fire
+                    # AFTER our spawn (between lifespan boot and the
+                    # first tool call); the rename here makes the
+                    # record discoverable via the canonical pointer.
+                    # Tool dispatch is sequenced after SessionStart
+                    # by Claude Code, so by this call the pointer is
+                    # canonical. Idempotent: no-op when no drift.
+                    reconcile_owned_chroma()
                 except Exception:
                     # Spawn failure already logs as 't1_chroma_spawn_failed';
                     # let T1Database raise its T1ServerNotFoundError below

--- a/tests/test_mcp_chroma_lifecycle.py
+++ b/tests/test_mcp_chroma_lifecycle.py
@@ -523,3 +523,115 @@ def test_t1_chroma_init_self_mints_session_id_when_pointer_missing(
     # _OWNED_CHROMA reflects the spawn.
     assert _OWNED_CHROMA.get("session_id") == minted_uuid
     _OWNED_CHROMA.clear()  # cleanup
+
+
+# ── GH #572: post-spawn pointer reconciliation ──────────────────────────────
+
+
+class TestReconcileOwnedChroma:
+    """GH #572: SessionStart can fire AFTER the lifespan spawn.
+    ``reconcile_owned_chroma`` renames the session record file when
+    the canonical pointer drifts post-spawn so discovery via
+    ``find_session_by_id`` succeeds.
+    """
+
+    def test_reconcile_renames_when_pointer_drifts_after_spawn(
+        self, tmp_path, monkeypatch,
+    ):
+        from nexus.mcp import core as core_mod
+
+        # Set up a synthetic _OWNED_CHROMA + session record on disk.
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        old_id = "old-uuid-aaaa-bbbb-cccc-dddddddddddd"
+        new_id = "new-uuid-aaaa-bbbb-cccc-dddddddddddd"
+        old_record = sessions_dir / f"{old_id}.session"
+        old_record.write_text('{"session_id": "old"}')
+
+        pointer = tmp_path / "current_session"
+        pointer.write_text(new_id)
+
+        monkeypatch.setattr("nexus.db.t1.SESSIONS_DIR", sessions_dir)
+        monkeypatch.setattr("nexus.session.CLAUDE_SESSION_FILE", pointer)
+
+        # Reset module state.
+        core_mod._OWNED_CHROMA.clear()
+        core_mod._OWNED_CHROMA.update({
+            "session_id": old_id,
+            "server_pid": 99999,
+            "tmpdir": str(tmp_path / "tmp"),
+            "session_file": str(old_record),
+        })
+
+        # Drive the reconcile.
+        renamed = core_mod.reconcile_owned_chroma()
+
+        assert renamed, "expected reconcile to fire"
+        assert not old_record.exists(), "old record must be moved"
+        new_record = sessions_dir / f"{new_id}.session"
+        assert new_record.exists(), "new record must be present"
+        assert core_mod._OWNED_CHROMA["session_id"] == new_id
+        assert core_mod._OWNED_CHROMA["session_file"] == str(new_record)
+
+        core_mod._OWNED_CHROMA.clear()
+
+    def test_reconcile_noop_when_pointer_matches(
+        self, tmp_path, monkeypatch,
+    ):
+        """Steady-state: pointer already matches our record. No-op."""
+        from nexus.mcp import core as core_mod
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        sid = "stable-uuid-xxxx"
+        record = sessions_dir / f"{sid}.session"
+        record.write_text("{}")
+        pointer = tmp_path / "current_session"
+        pointer.write_text(sid)
+
+        monkeypatch.setattr("nexus.db.t1.SESSIONS_DIR", sessions_dir)
+        monkeypatch.setattr("nexus.session.CLAUDE_SESSION_FILE", pointer)
+
+        core_mod._OWNED_CHROMA.clear()
+        core_mod._OWNED_CHROMA.update({
+            "session_id": sid,
+            "server_pid": 99999,
+            "tmpdir": str(tmp_path / "tmp"),
+            "session_file": str(record),
+        })
+
+        assert core_mod.reconcile_owned_chroma() is False
+        assert record.exists()  # unchanged
+
+        core_mod._OWNED_CHROMA.clear()
+
+    def test_reconcile_noop_for_subagent_path(
+        self, tmp_path, monkeypatch,
+    ):
+        """Subagent (NX_SESSION_ID set) MUST NOT rename the parent's
+        session record. The subagent inherits the parent's record key.
+        """
+        from nexus.mcp import core as core_mod
+
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        parent_id = "parent-uuid"
+        record = sessions_dir / f"{parent_id}.session"
+        record.write_text("{}")
+        pointer = tmp_path / "current_session"
+        pointer.write_text("different-uuid")  # would normally trigger
+
+        monkeypatch.setattr("nexus.db.t1.SESSIONS_DIR", sessions_dir)
+        monkeypatch.setattr("nexus.session.CLAUDE_SESSION_FILE", pointer)
+        monkeypatch.setenv("NX_SESSION_ID", parent_id)
+
+        core_mod._OWNED_CHROMA.clear()
+        core_mod._OWNED_CHROMA.update({
+            "session_id": parent_id,
+            "session_file": str(record),
+        })
+
+        assert core_mod.reconcile_owned_chroma() is False
+        assert record.exists(), "subagent must not rename parent record"
+
+        core_mod._OWNED_CHROMA.clear()


### PR DESCRIPTION
## Summary

GH #572 — follow-up to #567 + #571. The reporter caught a real race that my earlier empty-pointer self-heal didn't cover:

1. Prior session ended; chroma reaped; `sessions/` empty; but `current_session` left pointing at the prior id.
2. New conversation starts. MCP lifespan + SessionStart race.
3. `_t1_chroma_init_if_owner` reads stale pointer, `find_session_by_id` returns None. #571's self-heal only fires on EMPTY pointer, not stale-but-missing-record. Lifespan trusts the stale id, spawns chroma + writes `sessions/<stale>.session`.
4. SessionStart fires, writes `current_session=<canonical>`.
5. Every later `T1Database()` reads `<canonical>`, looks for `sessions/<canonical>.session`, fails → entire conversation's T1 broken until manual recovery (`NX_SESSION_ID=<record-key> nx scratch ...`).

## Fix

Post-spawn reconciliation. After writing the session record, re-read `current_session`. If it drifted, rename `sessions/<old>.session` → `sessions/<canonical>.session` and update `_OWNED_CHROMA`.

Wired at two sites:
- `_t1_chroma_init_if_owner` post-spawn (closest race window)
- `get_t1` first tool call (wider window — tool dispatch sequenced after SessionStart so pointer is canonical by then)

Subagent + reused/nested chroma paths opt out (not their record to rename).

## Closes

- Closes #572

## Test plan

- [x] +3 cases (rename-on-drift, no-op-on-match, no-op-for-subagent)
- [x] 134/134 chroma + t1 + scratch + hooks suite green
- [ ] CI green