### PR TITLE
fix(t1): close data-loss class — six-phase fix for #575 + #576

### DIFF
--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from collections.abc import Callable
 from typing import TypeVar
 from uuid import uuid4
@@ -291,10 +290,24 @@ class T1Database:
     def _reconnect(self) -> None:
         """Re-resolve the T1 server connection after a connectivity failure.
 
-        Walks the PPID chain for a (possibly restarted) server record.
-        Falls back to EphemeralClient when no record is found — but this
-        loses all prior scratch entries including flagged ones (nexus-uhch).
-        Sets ``_dead=True`` immediately to prevent cascading reconnect loops.
+        Uses the same UUID-keyed resolution chain as the constructor
+        (``_resolve_session_record_with_retry`` then legacy
+        ``find_ancestor_session`` for pre-v4.13 records). On miss,
+        raises :class:`T1ServerNotFoundError` — symmetric with the
+        constructor's PR #569 fail-loud contract (GH #576).
+
+        Pre-fix this path silently fell back to a per-process
+        EphemeralClient, which dropped every prior scratch entry under
+        a single misleading WARNING. Live trace 2026-05-06 (issue
+        #576): ``nx_answer`` plan-runner subprocess SessionStart fired
+        ``sweep_stale_sessions`` against the parent's record before
+        Phase B/C landed; main MCP's next reconnect found no record
+        and silently switched to ephemeral. After Phase A, the same
+        sequence raises and the user sees the failure immediately
+        instead of after they've lost data.
+
+        Sets ``_dead=True`` immediately to prevent cascading reconnect
+        loops on re-entry.
         """
         import chromadb
 
@@ -303,13 +316,23 @@ class T1Database:
         self._dead = True  # set before any I/O to prevent loops on re-entry
 
         prior_session_id = self._session_id
-        record = find_ancestor_session(SESSIONS_DIR)
+        # Use the same UUID-keyed chain as the constructor (GH #576):
+        # legacy ``find_ancestor_session`` (PID-keyed) cannot find
+        # records written by post-v4.13 ``write_session_record_by_id``,
+        # so reconnect was effectively guaranteed to miss in any
+        # current install. The retry helper additionally covers the
+        # CA-2 race where reconnect lands inside a respawn window.
+        record = (
+            _resolve_session_record_with_retry(SESSIONS_DIR)
+            or find_ancestor_session(SESSIONS_DIR)
+        )
         if record is not None:
             self._client = chromadb.HttpClient(
                 host=record["server_host"],
                 port=record["server_port"],
             )
             self._session_id = record["session_id"]
+            self._dead = False  # successful reconnect — re-arm
             _log.warning(
                 "t1_reconnect_to_different_server",
                 prior_session_id=prior_session_id,
@@ -317,18 +340,26 @@ class T1Database:
                 new_host=record["server_host"],
                 new_port=record["server_port"],
             )
-        else:
-            warnings.warn(
-                "T1 reconnect falling back to EphemeralClient — "
-                "all prior scratch entries (including flagged ones) are lost.",
-                stacklevel=2,
-            )
-            _log.warning("t1_reconnect_ephemeral_fallback_data_lost",
-                         session_id=self._session_id)
-            self._client = chromadb.EphemeralClient()
-            # session_id intentionally preserved from original construction.
+            self._col = self._client.get_or_create_collection(_COLLECTION)
+            return
 
-        self._col = self._client.get_or_create_collection(_COLLECTION)
+        # No record. Fail loud — match constructor's PR #569 contract.
+        # The ``_dead=True`` flag set above prevents cascading reconnect
+        # loops; subsequent ``_exec`` calls will re-raise the original
+        # connection error rather than retrying.
+        _log.warning(
+            "t1_reconnect_no_record_raising",
+            session_id=self._session_id,
+        )
+        raise T1ServerNotFoundError(
+            f"T1 reconnect failed: no session record in {SESSIONS_DIR} "
+            f"for session_id={self._session_id}. The chroma server may "
+            f"have been reaped (sweep_stale_sessions, /clear, /resume) "
+            f"or the session record was unlinked by another process. "
+            f"Pre-fix this path silently fell back to EphemeralClient "
+            f"and lost every scratch entry written before the reconnect "
+            f"(GH #576)."
+        )
 
     @property
     def session_id(self) -> str:

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -107,10 +107,23 @@ def session_start(claude_session_id: str | None = None) -> str:
 
     Returns the output string to be printed.
     """
-    # Sweep orphaned server processes from previous crashed sessions. Also
-    # handles the migration: legacy numeric-stem session files written by
-    # the old PID-keyed scheme are reaped unconditionally here.
-    sweep_stale_sessions(SESSIONS_DIR)
+    # GH #576 Phase F: sweep_stale_sessions runs against the parent's
+    # SESSIONS_DIR. When this SessionStart fires inside a subprocess
+    # spawned by claude_dispatch (NX_SESSION_ID set), the parent owns
+    # all session-record lifecycle decisions and the subprocess must
+    # not touch them. Pre-fix the unconditional sweep would scan the
+    # parent's records and reap any with sweep-arm matches (age,
+    # server_dead probe race, anchor_dead, uuid_stale) — directly
+    # causing the silent T1 data loss in #576. Phase C closes the
+    # uuid_stale arm by switching to filename-stem comparison; Phase F
+    # is defense-in-depth against the other arms.
+    inherited_session = os.environ.get("NX_SESSION_ID", "").strip()
+    if not inherited_session:
+        # Sweep orphaned server processes from previous crashed sessions.
+        # Also handles the migration: legacy numeric-stem session files
+        # written by the old PID-keyed scheme are reaped unconditionally
+        # here.
+        sweep_stale_sessions(SESSIONS_DIR)
 
     # Issue #435: remove the pre-v4.13.0 ``session.lock`` PID file if
     # it survived from an older install. v4.13.0 (RDR-094 Phase F /
@@ -128,11 +141,15 @@ def session_start(claude_session_id: str | None = None) -> str:
     # in-flight tmpdirs (mkdtemp -> write_session_record_by_id has a
     # small window; legitimate tmpdirs from active sessions never reach
     # the cutoff because their record reaches the filter first).
-    try:
-        from nexus.session import sweep_orphan_tmpdirs
-        sweep_orphan_tmpdirs(SESSIONS_DIR)
-    except Exception as exc:
-        _log.debug("sweep_orphan_tmpdirs_failed", error=str(exc))
+    # Phase F: subprocess SessionStart skips tmpdir sweep — same
+    # rationale as the session-record sweep above (parent owns
+    # lifecycle).
+    if not inherited_session:
+        try:
+            from nexus.session import sweep_orphan_tmpdirs
+            sweep_orphan_tmpdirs(SESSIONS_DIR)
+        except Exception as exc:
+            _log.debug("sweep_orphan_tmpdirs_failed", error=str(exc))
 
     # Resolve session_id with this precedence:
     #   1. ``NX_SESSION_ID`` env  — we're a nested subprocess our parent

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -130,17 +130,41 @@ def _t1_chroma_init_if_owner() -> None:
         write_session_record_by_id,
     )
 
-    # Subagent: a nested MCP server (claude_dispatch sets NX_SESSION_ID
-    # on the child env) inherits the parent's chroma via PPID walk. The
-    # T1 client handles the lookup; we just must not spawn a sibling.
+    # GH #576 Phase D: subprocess HARD READ-ONLY init. When
+    # ``NX_SESSION_ID`` (subagent inheritance from claude_dispatch) OR
+    # ``NEXUS_SKIP_T1=1`` (operator-subprocess opt-in) is set, this
+    # process is NEVER the chroma owner and must never spawn a sibling
+    # chroma, write a session record, or unlink anything on shutdown.
+    #
+    # Pre-fix the function had a probe-driven branch (lines 137-143):
+    # if the parent's TCP probe failed (0.5s timeout under load) the
+    # nested guard would miss and control fell through to the spawn
+    # path at line 178, which started a fresh chroma at the inherited
+    # UUID and overwrote ``sessions/<inherited>.session`` with the
+    # subprocess's own server_pid. The subprocess's
+    # ``_t1_chroma_shutdown`` then unlinked the file because
+    # ``_OWNED_CHROMA["nested"]`` was never set. This is the silent
+    # spawn-and-overwrite path the deep-analyst flagged as the
+    # fifth invariant violation.
     inherited = _os.environ.get("NX_SESSION_ID", "").strip()
-    if inherited:
-        ancestor = find_session_by_id(SESSIONS_DIR, inherited)
-        if ancestor and _tcp_probe_alive(
-            ancestor.get("server_host", ""), int(ancestor.get("server_port", 0)),
-        ):
-            _OWNED_CHROMA["nested"] = True
-            return
+    skip_t1 = _os.environ.get(
+        "NEXUS_SKIP_T1", ""
+    ).strip().lower() in ("1", "true", "yes")
+    if inherited or skip_t1:
+        if inherited:
+            ancestor = find_session_by_id(SESSIONS_DIR, inherited)
+            if ancestor and _tcp_probe_alive(
+                ancestor.get("server_host", ""),
+                int(ancestor.get("server_port", 0)),
+            ):
+                _OWNED_CHROMA["nested"] = True
+                return
+        # Probe failed (or no inherited UUID): leave _OWNED_CHROMA
+        # empty. T1Database with NEXUS_SKIP_T1=1 will use
+        # EphemeralClient (operator-subprocess semantics); without
+        # NEXUS_SKIP_T1 the constructor will raise T1ServerNotFoundError
+        # — explicit failure, not a silent record overwrite.
+        return
 
     own_id = inherited or _resolve_top_level_session_id()
     if not own_id:
@@ -311,6 +335,38 @@ def reconcile_owned_chroma() -> bool:
             from_id=current_id, to_id=canonical, error=str(exc),
         )
         return False
+
+    # GH #576 Phase B: rewrite the JSON content's session_id field to
+    # match the new (canonical) filename. Pre-fix ``Path.replace`` only
+    # renamed the file; the JSON content kept the pre-reconcile UUID,
+    # which then triggered ``sweep_stale_sessions.uuid_stale`` (the
+    # JSON-content-vs-current_session comparison at session.py:286)
+    # in any subsequent SessionStart fire — including the plan-runner
+    # subprocess SessionStart. The sweep would unlink the canonical
+    # record, leading to the silent T1 data loss reported in #576.
+    # The atomic write below uses the same shape as
+    # ``write_session_record_by_id`` (O_TRUNC + os.write).
+    import json
+    try:
+        record = json.loads(new_path.read_text())
+        record["session_id"] = canonical
+        fd = _os.open(
+            str(new_path), _os.O_CREAT | _os.O_WRONLY | _os.O_TRUNC, 0o600,
+        )
+        try:
+            _os.write(fd, json.dumps(record).encode())
+        finally:
+            _os.close(fd)
+    except (json.JSONDecodeError, OSError) as exc:
+        import structlog
+        structlog.get_logger().warning(
+            "t1_chroma_reconcile_json_rewrite_failed",
+            from_id=current_id, to_id=canonical, error=str(exc),
+        )
+        # Filename rename succeeded — record is still discoverable via
+        # ``find_session_by_id`` (UUID-keyed lookup). Phase C
+        # (sweep filename-stem comparison) prevents the uuid_stale
+        # arm from firing even with stale JSON content. Continue.
 
     _OWNED_CHROMA["session_id"] = canonical
     _OWNED_CHROMA["session_file"] = str(new_path)

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -282,7 +282,18 @@ def sweep_stale_sessions(
             # fires. Requires claude_root_pid to be alive — otherwise the
             # anchor_dead arm owns the reap and reports the more specific
             # reason.
-            record_uuid = record.get("session_id", "")
+            #
+            # GH #576 Phase C: compare ``f.stem`` (the canonical
+            # filename, kept in sync with the conversation UUID by
+            # ``reconcile_owned_chroma``'s rename) against
+            # ``current_session``. Pre-fix this read ``record["session_id"]``
+            # from JSON content, which ``Path.replace`` did NOT rewrite
+            # — leading to a uuid_stale=True false positive on every
+            # subprocess SessionStart fire post-reconcile, which then
+            # unlinked the parent's canonical record (the silent T1
+            # data-loss trigger). Filename-stem is canonical; JSON
+            # content is incidental metadata.
+            record_uuid = f.stem
             uuid_stale = bool(
                 current_uuid
                 and record_uuid

--- a/src/nexus/t1_watchdog.py
+++ b/src/nexus/t1_watchdog.py
@@ -58,6 +58,52 @@ def _is_alive(pid: int) -> bool:
     return True
 
 
+def _find_record_by_chroma_pid(
+    sessions_dir: Path, chroma_pid: int,
+) -> Path | None:
+    """Find the session record file whose JSON ``server_pid`` matches.
+
+    GH #575 Phase E: pre-fix the watchdog tracked a CLI-arg
+    ``--session-file`` path captured at spawn time. When
+    ``reconcile_owned_chroma`` renamed the file (the canonical
+    lifespan-then-SessionStart flow), the watchdog's snapshot path
+    became stale and the sticky ``session_file_has_existed`` flag
+    never flipped True — the ``session_file_removed`` exit branch
+    (PR #574) was unreachable for the rest of the watchdog's life.
+
+    The chroma server_pid is invariant across reconcile renames and
+    /resume rolls. Looking up the record by ``server_pid`` is the
+    canonical "is our session still alive" check, robust to any
+    filename change.
+
+    Returns the matching :class:`pathlib.Path` or None. Corrupt /
+    unreadable session files are skipped silently — the watchdog's
+    job is to detect deletion of OUR record, not to validate
+    other processes' records.
+    """
+    import json
+
+    if not sessions_dir.exists():
+        return None
+    try:
+        candidates = list(sessions_dir.glob("*.session"))
+    except OSError:
+        return None
+    for f in candidates:
+        try:
+            rec = json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(rec, dict):
+            continue
+        try:
+            if int(rec.get("server_pid", 0)) == chroma_pid:
+                return f
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
 def _cleanup(
     *, chroma_pid: int, session_file: Path | None, tmpdir: Path | None,
 ) -> None:
@@ -148,17 +194,20 @@ def main(argv: list[str] | None = None) -> int:
     log = structlog.get_logger("nexus.t1_watchdog")
 
     session_file = Path(args.session_file) if args.session_file else None
-    # GH #567 + #572 follow-up: track whether the session file has EVER
-    # existed during this watchdog's lifetime, not just at startup.
-    # ``_t1_chroma_init_if_owner`` spawns the watchdog BEFORE writing
-    # the record (so the watchdog can be PID-watched even if the
-    # record write fails); using a startup-only snapshot meant
-    # ``session_file_existed_at_start`` was always False and the
-    # session-file-removed exit never fired. Sticky flag: once True,
-    # stays True; the file-removed exit only fires after we've
-    # observed the file exist at least once.
+    # GH #575 Phase E: track via ``server_pid`` JSON match instead of
+    # the CLI-arg path. Pre-fix the sticky flag was bound to
+    # ``args.session_file`` (captured at spawn time); any rename of
+    # the canonical record by ``reconcile_owned_chroma`` left the
+    # watchdog watching a path that was already gone before its first
+    # poll, so the sticky flag never flipped True and PR #574's
+    # ``session_file_removed`` exit was unreachable in the canonical
+    # lifespan-then-SessionStart flow. ``server_pid`` is invariant
+    # across reconcile renames and /resume rolls.
+    # Lazy import: keeps the watchdog cold-start cost negligible
+    # (the rest of this file is stdlib-only).
+    from nexus.db.t1 import SESSIONS_DIR as sessions_dir
     session_file_has_existed = (
-        session_file is not None and session_file.exists()
+        _find_record_by_chroma_pid(sessions_dir, args.chroma_pid) is not None
     )
     tmpdir = Path(args.tmpdir) if args.tmpdir else None
     dual_watch = args.mcp_pid > 0
@@ -191,32 +240,22 @@ def main(argv: list[str] | None = None) -> int:
                 chroma_pid=args.chroma_pid,
             )
             return 0
-        # GH #567: session-file disappearance trigger. The session
-        # record may be removed by sweep_stale_sessions (uuid-mismatch
-        # arm at session.py:286) when the same Claude process rolls to
-        # a new conversation UUID via /clear or /resume. Pre-fix, the
-        # watchdog kept polling on its old session's chroma_pid and
-        # leaked until that PID died -- the reporter saw a stale
-        # watchdog for a session whose .session file was gone. Exit
-        # cleanly when our session file disappears so the kept-alive
-        # chroma server we were watching can be reaped by whatever
-        # path replaced our session record.
-        #
-        # Only fire when the file has EVER existed in this watchdog's
-        # lifetime (sticky flag). Tests and legacy callers that pass
-        # a path that never gets created continue to rely on
-        # PID liveness alone.
-        if session_file is not None and session_file.exists():
+        # GH #567/#575: session-record disappearance trigger. Resolved
+        # via ``server_pid`` JSON match each poll (Phase E) — robust
+        # to filename rename by ``reconcile_owned_chroma`` (GH #572)
+        # and to /clear or /resume rolling the conversation UUID
+        # (nexus-886w). Sticky flag: once True, stays True; the
+        # exit only fires after we've observed our record exist at
+        # least once. Tests and legacy callers that don't write a
+        # record continue to rely on PID liveness alone.
+        record_path = _find_record_by_chroma_pid(sessions_dir, args.chroma_pid)
+        if record_path is not None:
             session_file_has_existed = True
-        if (
-            session_file_has_existed
-            and session_file is not None
-            and not session_file.exists()
-        ):
+        if session_file_has_existed and record_path is None:
             log.info(
                 "watchdog_exiting",
                 reason="session_file_removed",
-                session_file=str(session_file),
+                chroma_pid=args.chroma_pid,
             )
             return 0
         # Dual-watch mode (RDR-094 FM-NEW-1): MCP server died without
@@ -237,10 +276,16 @@ def main(argv: list[str] | None = None) -> int:
                 _signal_then_kill(args.mcp_pid)
             break
 
+    # GH #575 Phase E: at cleanup time, prefer the canonical record
+    # path (resolved via server_pid JSON match) over the CLI-arg
+    # ``--session-file`` snapshot. ``reconcile_owned_chroma`` may have
+    # renamed the file post-spawn; unlinking the CLI-arg path would
+    # miss the canonical record and leak it until the next sweep.
     log.info("chroma_cleanup_started", chroma_pid=args.chroma_pid)
+    canonical_record = _find_record_by_chroma_pid(sessions_dir, args.chroma_pid)
     _cleanup(
         chroma_pid=args.chroma_pid,
-        session_file=session_file,
+        session_file=canonical_record or session_file,
         tmpdir=tmpdir,
     )
     log.info("chroma_cleanup_complete", chroma_pid=args.chroma_pid)

--- a/tests/test_mcp_chroma_lifecycle.py
+++ b/tests/test_mcp_chroma_lifecycle.py
@@ -15,6 +15,7 @@ spike harness.
 """
 from __future__ import annotations
 
+import os
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
@@ -105,6 +106,94 @@ class TestInitIfOwner:
             assert core_mod._OWNED_CHROMA.get("nested") is True
             mock_start.assert_not_called()
 
+    def test_subprocess_with_nx_session_id_never_spawns_when_probe_fails(
+        self, monkeypatch,
+    ):
+        """GH #576 Phase D — invariant I1+I5: subprocess MCPs (those
+        with NX_SESSION_ID set) must NEVER spawn their own chroma,
+        even when the parent's probe fails. Pre-fix the function fell
+        through to the spawn path (line 178) and overwrote
+        ``sessions/<inherited>.session`` with the subprocess's own
+        server_pid — the deep-analyst's "fifth bug" (silent
+        spawn-and-overwrite under inherited UUID).
+
+        Two failure modes feed the spawn fall-through:
+          1. ``find_session_by_id`` returns None (parent's record was
+             swept by an earlier subprocess SessionStart).
+          2. TCP probe to parent times out under load.
+
+        Phase D's hard read-only gate kills both modes at the same
+        check: when NX_SESSION_ID is set, never spawn. Period.
+        """
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            monkeypatch.setenv("NX_SESSION_ID", "parent-uuid")
+            monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+            # Parent record gone (sweep raced) → find returns None.
+            with patch(
+                "nexus.session.find_session_by_id", return_value=None,
+            ), patch(
+                "nexus.session.start_t1_server",
+            ) as mock_start, patch(
+                "nexus.session.write_session_record_by_id",
+            ) as mock_write, patch(
+                "nexus.session.spawn_t1_watchdog",
+            ) as mock_spawn:
+                core_mod._t1_chroma_init_if_owner()
+
+            mock_start.assert_not_called()
+            mock_write.assert_not_called()
+            mock_spawn.assert_not_called()
+            # _OWNED_CHROMA stays empty: subprocess T1Database falls
+            # back to its NEXUS_SKIP_T1 / EphemeralClient or raises
+            # T1ServerNotFoundError. No silent record overwrite.
+            assert core_mod._OWNED_CHROMA == {}
+
+    def test_subprocess_with_nx_session_id_never_spawns_when_probe_succeeds_no_record(
+        self, monkeypatch,
+    ):
+        """Variant of the above: probe succeeds (parent chroma is
+        reachable in some other guise) but find_session_by_id returns
+        None — still no spawn, no record write."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            monkeypatch.setenv("NX_SESSION_ID", "parent-uuid")
+            monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+            with patch(
+                "nexus.session.find_session_by_id", return_value=None,
+            ), patch.object(
+                core_mod, "_tcp_probe_alive", return_value=True,
+            ), patch(
+                "nexus.session.start_t1_server",
+            ) as mock_start:
+                core_mod._t1_chroma_init_if_owner()
+            mock_start.assert_not_called()
+            assert core_mod._OWNED_CHROMA.get("nested") is not True
+
+    def test_subprocess_with_nexus_skip_t1_never_spawns(
+        self, monkeypatch,
+    ):
+        """Phase D: NEXUS_SKIP_T1=1 (operator-subprocess opt-in from
+        ``claude_dispatch``) is also a hard read-only gate. The conftest
+        sets it autouse; this test relies on that default rather than
+        opting out."""
+        from nexus.mcp import core as core_mod
+
+        with _clean_owned_chroma():
+            monkeypatch.delenv("NX_SESSION_ID", raising=False)
+            # NEXUS_SKIP_T1 is set autouse by conftest._isolate_t1_sessions.
+            assert os.environ.get("NEXUS_SKIP_T1") == "1"
+            with patch(
+                "nexus.session.start_t1_server",
+            ) as mock_start, patch(
+                "nexus.session.write_session_record_by_id",
+            ) as mock_write:
+                core_mod._t1_chroma_init_if_owner()
+            mock_start.assert_not_called()
+            mock_write.assert_not_called()
+
     def test_reuse_path_when_existing_record_reachable(self, monkeypatch):
         """FM-NEW-2: existing record for own session_id is reachable,
         so reuse instead of spawning. _OWNED_CHROMA is marked reused
@@ -113,6 +202,10 @@ class TestInitIfOwner:
 
         with _clean_owned_chroma():
             monkeypatch.delenv("NX_SESSION_ID", raising=False)
+            # Phase D: NEXUS_SKIP_T1=1 short-circuits to read-only
+            # subprocess mode. The conftest sets it autouse for ALL
+            # tests; top-level-MCP scenarios must opt out explicitly.
+            monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
             existing = {"server_host": "127.0.0.1", "server_port": 22222}
             with patch.object(
                 core_mod, "_resolve_top_level_session_id", return_value="own-id",
@@ -136,6 +229,7 @@ class TestInitIfOwner:
 
         with _clean_owned_chroma():
             monkeypatch.delenv("NX_SESSION_ID", raising=False)
+            monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
             spawn_calls: dict = {}
 
             def _fake_spawn_watchdog(**kwargs):
@@ -175,6 +269,7 @@ class TestInitIfOwner:
 
         with _clean_owned_chroma():
             monkeypatch.delenv("NX_SESSION_ID", raising=False)
+            monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
             with patch.object(
                 core_mod, "_resolve_top_level_session_id",
                 return_value="x",
@@ -487,6 +582,12 @@ def test_t1_chroma_init_self_mints_session_id_when_pointer_missing(
     pointer = tmp_path / "current_session"
     monkeypatch.setattr("nexus.session.CLAUDE_SESSION_FILE", pointer)
 
+    # Phase D: NEXUS_SKIP_T1=1 short-circuits to read-only subprocess
+    # mode. The conftest sets it autouse for ALL tests; top-level-MCP
+    # scenarios (this self-mint test) must opt out explicitly.
+    monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
+
     # Confirm pointer is absent at start.
     assert not pointer.exists()
 
@@ -546,7 +647,10 @@ class TestReconcileOwnedChroma:
         old_id = "old-uuid-aaaa-bbbb-cccc-dddddddddddd"
         new_id = "new-uuid-aaaa-bbbb-cccc-dddddddddddd"
         old_record = sessions_dir / f"{old_id}.session"
-        old_record.write_text('{"session_id": "old"}')
+        old_record.write_text(
+            '{"session_id": "' + old_id + '", "server_pid": 99999, '
+            '"server_host": "127.0.0.1", "server_port": 12345}'
+        )
 
         pointer = tmp_path / "current_session"
         pointer.write_text(new_id)
@@ -572,6 +676,24 @@ class TestReconcileOwnedChroma:
         assert new_record.exists(), "new record must be present"
         assert core_mod._OWNED_CHROMA["session_id"] == new_id
         assert core_mod._OWNED_CHROMA["session_file"] == str(new_record)
+
+        # GH #576 Phase B: JSON content must be rewritten too — the
+        # filename rename was historically NOT followed by a content
+        # rewrite, leaving the JSON's ``session_id`` field stale. That
+        # stale field then triggered ``sweep_stale_sessions.uuid_stale``
+        # in any subsequent SessionStart fire (including the plan-runner
+        # subprocess SessionStart from claude_dispatch), which unlinked
+        # the canonical record and caused the silent T1 data loss
+        # reported in #576.
+        import json
+        content = json.loads(new_record.read_text())
+        assert content["session_id"] == new_id, (
+            f"JSON content session_id must be rewritten to canonical; "
+            f"got {content.get('session_id')!r}"
+        )
+        # Other fields preserved.
+        assert content["server_pid"] == 99999
+        assert content["server_host"] == "127.0.0.1"
 
         core_mod._OWNED_CHROMA.clear()
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -89,6 +89,79 @@ def test_session_start_outputs_session_id(
     assert "Nexus ready" in result.output
 
 
+# ── GH #576 Phase F: subprocess SessionStart skip-sweep ─────────────────────
+
+
+def test_subprocess_session_start_skips_sweep_when_inherited(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GH #576 Phase F: when SessionStart fires inside a subprocess
+    spawned by ``claude_dispatch`` (NX_SESSION_ID set on env), the
+    parent owns all session-record lifecycle decisions and the
+    subprocess must NOT sweep the parent's records.
+
+    Pre-fix the unconditional sweep at hooks.py:113 ran inside every
+    plan-runner subprocess SessionStart. With Phase C in place
+    (filename-stem comparison) the sweep's uuid_stale arm no longer
+    fires for healthy parent records — but Phase F is defense-in-depth
+    against the other arms (age_expired, server_dead probe race,
+    anchor_dead). The combined effect: parent's record is never
+    touched by subprocess-side housekeeping.
+    """
+    from nexus.hooks import session_start
+
+    monkeypatch.setenv("NX_SESSION_ID", "parent-uuid")
+    swept: list[bool] = []
+    tmpdir_swept: list[bool] = []
+
+    def _fake_sweep(*args, **kwargs):
+        swept.append(True)
+
+    def _fake_tmpdir_sweep(*args, **kwargs):
+        tmpdir_swept.append(True)
+
+    with patch("nexus.hooks.sweep_stale_sessions", side_effect=_fake_sweep), \
+         patch("nexus.session.sweep_orphan_tmpdirs", side_effect=_fake_tmpdir_sweep):
+        session_start()
+
+    assert swept == [], (
+        "subprocess SessionStart (NX_SESSION_ID set) must NOT call "
+        "sweep_stale_sessions on the parent's SESSIONS_DIR"
+    )
+    assert tmpdir_swept == [], (
+        "subprocess SessionStart must NOT call sweep_orphan_tmpdirs"
+    )
+
+
+def test_top_level_session_start_runs_sweep(
+    fake_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Counterpart: top-level SessionStart (NX_SESSION_ID NOT set)
+    still runs both sweeps — the conventional bootstrap path."""
+    from nexus.hooks import session_start
+
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
+    swept: list[bool] = []
+    tmpdir_swept: list[bool] = []
+
+    def _fake_sweep(*args, **kwargs):
+        swept.append(True)
+
+    def _fake_tmpdir_sweep(*args, **kwargs):
+        tmpdir_swept.append(True)
+
+    with patch("nexus.hooks.sweep_stale_sessions", side_effect=_fake_sweep), \
+         patch("nexus.session.sweep_orphan_tmpdirs", side_effect=_fake_tmpdir_sweep):
+        session_start()
+
+    assert swept == [True], (
+        "top-level SessionStart must call sweep_stale_sessions"
+    )
+    assert tmpdir_swept == [True], (
+        "top-level SessionStart must call sweep_orphan_tmpdirs"
+    )
+
+
 # ── AC5: SessionEnd flush + expire ────────────────────────────────────────────
 
 def test_session_end_flushes_flagged_t1_entries(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -431,6 +431,57 @@ def test_sweep_reaps_on_uuid_mismatch_with_live_claude(
     )
 
 
+def test_sweep_uses_filename_stem_not_json_session_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GH #576 Phase C: when ``reconcile_owned_chroma`` renames a
+    session record file (lifespan A → canonical B), only the filename
+    stem ends up at B; the JSON content's ``session_id`` field stays
+    at A unless Phase B's content rewrite is also in place.
+
+    Pre-fix the sweep's ``uuid_stale`` arm compared
+    ``record["session_id"]`` (JSON content, stale → 'A') against
+    ``current_session`` (canonical → 'B'). They mismatched, the arm
+    fired, and the canonical record was unlinked — the immediate
+    trigger for the silent T1 data loss in #576 (sweep ran inside
+    every plan-runner subprocess SessionStart).
+
+    Phase C closes this by comparing ``f.stem`` (filename, kept in
+    sync with the conversation UUID by reconcile's rename) instead.
+    Even if JSON content is stale (Phase B not in place yet, or
+    Phase B's atomic rewrite raced), the sweep no longer reaps a
+    canonical record under a healthy parent.
+    """
+    sessions = tmp_path / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+
+    own = os.getpid()
+    monkeypatch.setattr("nexus.session._is_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        "nexus.session.read_claude_session_id",
+        lambda: "canonical-uuid",
+    )
+
+    # Simulate the post-reconcile state: filename = canonical, JSON
+    # content's session_id = pre-reconcile (rename without rewrite).
+    record = sessions / "canonical-uuid.session"
+    record.write_text(json.dumps({
+        "session_id": "lifespan-uuid",  # STALE
+        "server_host": "127.0.0.1",
+        "server_port": 12345,
+        "server_pid": own,
+        "claude_root_pid": own,
+        "created_at": time.time(),
+    }))
+
+    sweep_stale_sessions(sessions_dir=sessions)
+    assert record.exists(), (
+        "canonical record (filename matches current_session) must "
+        "survive sweep even when JSON content's session_id is stale; "
+        "filename-stem is canonical, JSON is incidental metadata"
+    )
+
+
 def test_sweep_keeps_record_matching_current_session(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_t1.py
+++ b/tests/test_t1.py
@@ -295,29 +295,67 @@ class TestT1DatabaseReconnect:
                 t1._exec(lambda: (_ for _ in ()).throw(ValueError("unrelated")))
         mock.assert_not_called()
 
-    def test_reconnect_falls_back_to_ephemeral_when_no_record(self) -> None:
+    def test_reconnect_raises_when_no_record_no_silent_ephemeral_fallback(
+        self,
+    ) -> None:
+        """GH #576 Phase A invariant I3+I7: reconnect must match the
+        constructor's PR #569 fail-loud contract. Pre-fix this path
+        fell back to EphemeralClient with a single warning, silently
+        dropping every prior scratch entry under a misleading
+        ``t1_reconnect_ephemeral_fallback_data_lost`` log line.
+        """
+        from nexus.db.t1 import T1ServerNotFoundError
+
         record = {"session_id": "orig-session", "server_host": "127.0.0.1", "server_port": 54321}
         mock_http = MagicMock()
         mock_http.get_or_create_collection.return_value = MagicMock()
-        with patch("nexus.db.t1.find_ancestor_session", return_value=record), \
+        with patch("nexus.db.t1._resolve_session_record_with_retry", return_value=record), \
              patch("chromadb.HttpClient", return_value=mock_http):
             t1 = T1Database()
         assert t1._client is mock_http
-        with patch("nexus.db.t1.find_ancestor_session", return_value=None):
-            t1._reconnect()
-        assert t1._dead is True and t1._client is not mock_http
-
-    def test_reconnect_sets_dead_flag(self) -> None:
-        t1 = _ephemeral_t1()
-        with patch("nexus.db.t1.find_ancestor_session", return_value=None):
-            t1._reconnect()
+        with patch("nexus.db.t1._resolve_session_record_with_retry", return_value=None), \
+             patch("nexus.db.t1.find_ancestor_session", return_value=None):
+            with pytest.raises(T1ServerNotFoundError):
+                t1._reconnect()
         assert t1._dead is True
+        # _client untouched — no silent EphemeralClient swap.
+        assert t1._client is mock_http
+
+    def test_reconnect_uses_uuid_keyed_resolution(self) -> None:
+        """GH #576 Phase A invariant I7: reconnect must use the same
+        UUID-keyed resolution chain as the constructor. Pre-fix
+        ``_reconnect`` called ``find_ancestor_session`` (legacy
+        PID-keyed PPID walker) which never finds records written by
+        post-v4.13 ``write_session_record_by_id`` — so reconnect was
+        effectively guaranteed to miss in any current install.
+        """
+        # Initial record (constructor-time).
+        rec_a = {"session_id": "sess-a", "server_host": "127.0.0.1", "server_port": 11111}
+        # Post-reconnect record (only resolvable via UUID-keyed
+        # ``_resolve_session_record_with_retry``, NOT via legacy
+        # ``find_ancestor_session``).
+        rec_b = {"session_id": "sess-b", "server_host": "127.0.0.1", "server_port": 22222}
+        mock_http_a = MagicMock(); mock_http_a.get_or_create_collection.return_value = MagicMock()
+        mock_http_b = MagicMock(); mock_http_b.get_or_create_collection.return_value = MagicMock()
+        with patch("nexus.db.t1._resolve_session_record_with_retry", return_value=rec_a), \
+             patch("chromadb.HttpClient", return_value=mock_http_a):
+            t1 = T1Database()
+        # Reconnect: UUID-keyed lookup returns rec_b, PID-keyed returns
+        # None. Pre-fix t1._reconnect would have ignored rec_b and hit
+        # the EphemeralClient fallback.
+        with patch("nexus.db.t1._resolve_session_record_with_retry", return_value=rec_b), \
+             patch("nexus.db.t1.find_ancestor_session", return_value=None), \
+             patch("chromadb.HttpClient", return_value=mock_http_b):
+            t1._reconnect()
+        assert t1._client is mock_http_b
+        assert t1._session_id == "sess-b"
+        assert t1._dead is False  # successful reconnect re-arms
 
     def test_reconnect_noop_when_already_dead(self) -> None:
         t1 = _ephemeral_t1()
         t1._dead = True
         original = t1._client
-        with patch("nexus.db.t1.find_ancestor_session") as mock:
+        with patch("nexus.db.t1._resolve_session_record_with_retry") as mock:
             t1._reconnect()
         mock.assert_not_called()
         assert t1._client is original

--- a/tests/test_t1_invariants.py
+++ b/tests/test_t1_invariants.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Regression scaffolding for the T1 lifecycle data-loss class.
+
+Background — the fix-loop pattern: ``#567 → #569 → #572 → #573 →
+#574 → #575/#576``. Each fix patched a witnessed instance of a
+class-of-bugs; the class re-instantiated at the next code path that
+wasn't audited. The unified fix in PR for ``nexus-gxq5`` closes the
+class — these tests encode the invariants the class violated, so any
+future patch that re-introduces the same shape fails CI before merge.
+
+The deep-analyst's brief (T1 scratch ``f9125457``, ``fef6153a``) is
+the source of truth for the invariant set.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / "src" / "nexus"
+
+
+# ── Invariant: no silent EphemeralClient fallback ──────────────────────────
+
+
+# The two production paths where EphemeralClient is allowed:
+#
+#   1. ``T1Database.__init__`` skip_t1 branch in ``src/nexus/db/t1.py``
+#      — explicit opt-in via ``NEXUS_SKIP_T1=1``; operator subprocesses
+#      from ``claude_dispatch`` use this.
+#   2. ``cloud-mode local_t3`` in ``src/nexus/commands/index.py`` —
+#      explicit opt-in for the wheel's local-only fallback when no
+#      Voyage credentials are configured. Different concern from T1.
+#
+# Anything else is a regression.
+_EPHEMERAL_ALLOWLIST = {
+    ("src/nexus/db/t1.py", "skip_t1 branch"),
+    ("src/nexus/commands/index.py", "cloud-mode local_t3"),
+}
+
+
+def test_no_silent_ephemeral_client_outside_allowlist() -> None:
+    """Invariant: ``chromadb.EphemeralClient(`` constructions are
+    confined to the explicit opt-in paths.
+
+    PR #569 fixed site 1 (constructor's no-record-no-skip-t1 branch).
+    Issue #576 surfaced site 2 (``_reconnect`` fallback) and Phase A
+    fixed it. This test prevents site 3 from appearing silently.
+
+    If you NEED to add a new EphemeralClient construction, update the
+    ``_EPHEMERAL_ALLOWLIST`` and document the explicit opt-in
+    contract in the same commit.
+    """
+    pat = re.compile(r"chromadb\.EphemeralClient\s*\(")
+    findings: list[tuple[str, int, str]] = []
+    for f in sorted(SRC_ROOT.rglob("*.py")):
+        rel = f.relative_to(REPO_ROOT)
+        try:
+            text = f.read_text()
+        except OSError:
+            continue
+        for i, line in enumerate(text.splitlines(), 1):
+            if pat.search(line) and "#" not in line.split("EphemeralClient")[0]:
+                findings.append((str(rel), i, line.strip()))
+
+    # Filter out doc/comment-only lines (the regex already requires
+    # "(" so docstring examples that say "EphemeralClient" without
+    # the open-paren are excluded; but allow the comment-marker check
+    # for paranoia).
+    real = [
+        (rel, lineno, src) for (rel, lineno, src) in findings
+        if not src.lstrip().startswith("#")
+    ]
+
+    expected_files = {p for (p, _) in _EPHEMERAL_ALLOWLIST}
+    found_files = {rel for (rel, _, _) in real}
+    unexpected = found_files - expected_files
+    assert not unexpected, (
+        f"chromadb.EphemeralClient() construction in non-allow-listed "
+        f"file(s): {sorted(unexpected)}.\n"
+        f"All findings: {real}\n"
+        f"Expected only: {sorted(expected_files)}.\n"
+        f"If this is intentional, update _EPHEMERAL_ALLOWLIST in "
+        f"tests/test_t1_invariants.py and document the explicit "
+        f"opt-in contract in the same commit."
+    )
+
+
+# ── Invariant: _reconnect uses same resolution chain as constructor ────────
+
+
+def test_reconnect_uses_same_resolution_chain_as_constructor() -> None:
+    """Invariant I7: when T1Database loses connectivity and reconnects,
+    the reconnected instance's behaviour must be identical to a fresh
+    ``T1Database()`` — same fail-loud contract, same lookup semantics.
+
+    Pre-fix the constructor used UUID-keyed
+    ``_resolve_session_record_with_retry`` while ``_reconnect`` used
+    legacy ``find_ancestor_session`` (PID-keyed PPID walker). The
+    asymmetry meant reconnect ALWAYS missed UUID-keyed records — the
+    direct mechanism behind the silent EphemeralClient fallback in
+    GH #576.
+
+    AST-style audit: both paths must mention
+    ``_resolve_session_record_with_retry`` in their bodies.
+    """
+    text = (SRC_ROOT / "db" / "t1.py").read_text()
+    # Find the bodies of __init__ (constructor) and _reconnect.
+    # Simple grep approach: the function names must appear at module
+    # level near the resolver.
+    ctor_body = _extract_function_body(text, "def __init__")
+    recon_body = _extract_function_body(text, "def _reconnect")
+    assert "_resolve_session_record_with_retry" in ctor_body, (
+        "constructor expected to use _resolve_session_record_with_retry"
+    )
+    assert "_resolve_session_record_with_retry" in recon_body, (
+        "_reconnect MUST use the same UUID-keyed resolver as the "
+        "constructor (GH #576 invariant I7). Pre-fix it called "
+        "find_ancestor_session (PID-keyed legacy walker) which "
+        "could not find UUID-keyed records."
+    )
+
+
+def _extract_function_body(text: str, def_marker: str) -> str:
+    """Crude function-body extractor: returns the source from the
+    ``def_marker`` line through the next dedent at module indent (4
+    spaces). Sufficient for the symbol-presence assertions above.
+    """
+    lines = text.splitlines()
+    out: list[str] = []
+    in_func = False
+    base_indent = -1
+    for line in lines:
+        if not in_func:
+            if def_marker in line:
+                in_func = True
+                base_indent = len(line) - len(line.lstrip())
+                out.append(line)
+            continue
+        if line.strip() == "":
+            out.append(line)
+            continue
+        cur_indent = len(line) - len(line.lstrip())
+        if cur_indent <= base_indent and line.strip():
+            break
+        out.append(line)
+    return "\n".join(out)
+
+
+# ── Invariant: reconcile rewrites JSON content, not just filename ──────────
+
+
+def test_reconcile_rewrites_json_content_not_just_filename() -> None:
+    """Invariant: ``reconcile_owned_chroma`` must keep the JSON
+    content's ``session_id`` field aligned with the filename. Phase B.
+
+    Pre-fix ``Path.replace`` only renamed the file; the JSON content
+    kept the pre-reconcile UUID. ``sweep_stale_sessions`` (pre-Phase
+    C) compared JSON content against ``current_session`` and reaped
+    every healthy parent record on subprocess SessionStart. Even
+    after Phase C makes sweep filename-stem-based, JSON content
+    consistency is still load-bearing for any future code that reads
+    ``record["session_id"]`` (e.g. console watchers, telemetry).
+    """
+    text = (SRC_ROOT / "mcp" / "core.py").read_text()
+    func = _extract_function_body(text, "def reconcile_owned_chroma")
+    # The function body must contain BOTH the filename rename AND a
+    # JSON content rewrite. The rewrite uses ``json.dumps`` + atomic
+    # write via ``os.O_TRUNC``.
+    assert "old_path.replace" in func or ".replace(new_path)" in func, (
+        "reconcile_owned_chroma must perform the filename rename"
+    )
+    assert "json.dumps" in func, (
+        "reconcile_owned_chroma must rewrite JSON content (Phase B). "
+        "Pre-fix the filename rename left JSON's session_id field "
+        "stale; sweep then reaped the canonical record on next fire."
+    )
+
+
+# ── Invariant: subprocess SessionStart never sweeps parent's records ───────
+
+
+def test_full_576_chain_no_data_loss_under_subprocess_sessionstart(
+    tmp_path, monkeypatch,
+) -> None:
+    """End-to-end #576 reproduction (no Claude Code, no real chroma).
+
+    Walks the full data-loss chain from issue #576 and asserts that
+    after Phases A through F land, the chain is broken at multiple
+    points:
+
+      1. Lifespan writes ``sessions/<lifespan>.session`` (JSON + name
+         both at lifespan UUID).
+      2. SessionStart hook writes ``current_session=<canonical>``.
+      3. ``reconcile_owned_chroma`` renames the file AND rewrites
+         JSON content (Phase B).
+      4. Plan-runner spawns ``claude -p`` with NX_SESSION_ID=<canonical>.
+         That subprocess fires its OWN nexus SessionStart hook
+         (``nexus.hooks.session_start``).
+      5. Phase F: subprocess SessionStart skips ``sweep_stale_sessions``
+         entirely. Even if it did sweep, Phase C (filename-stem
+         comparison) means the canonical record is not uuid_stale.
+      6. After subprocess returns, the canonical record MUST still
+         exist on disk — pre-fix it would have been unlinked, leading
+         to T1 reconnect → silent EphemeralClient fallback (Phase A
+         closes that as a final safety net).
+    """
+    import json
+    import os
+
+    from nexus.mcp import core as core_mod
+    from nexus.session import write_session_record_by_id
+
+    # ─── Phase 1+2: lifespan + SessionStart drift ───────────────────────
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    pointer = tmp_path / "current_session"
+    monkeypatch.setattr("nexus.db.t1.SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr("nexus.hooks.SESSIONS_DIR", sessions_dir)
+    monkeypatch.setattr("nexus.session.CLAUDE_SESSION_FILE", pointer)
+
+    lifespan_uuid = "lifespan-uuid-aaaa-bbbb-cccc-aaaaaaaaaaaa"
+    canonical_uuid = "canonical-uuid-bbbb-cccc-dddd-bbbbbbbbbbbb"
+
+    record = write_session_record_by_id(
+        sessions_dir, lifespan_uuid,
+        host="127.0.0.1", port=12345, server_pid=os.getpid(),
+        claude_root_pid=os.getpid(),
+    )
+    assert record.exists()
+
+    pointer.write_text(canonical_uuid)
+
+    # ─── Phase 3: reconcile renames file + rewrites JSON ────────────────
+    core_mod._OWNED_CHROMA.clear()
+    core_mod._OWNED_CHROMA.update({
+        "session_id": lifespan_uuid,
+        "server_pid": os.getpid(),
+        "session_file": str(record),
+        "tmpdir": str(tmp_path / "tmp"),
+    })
+    monkeypatch.delenv("NX_SESSION_ID", raising=False)
+    assert core_mod.reconcile_owned_chroma() is True
+
+    canonical_record = sessions_dir / f"{canonical_uuid}.session"
+    assert canonical_record.exists(), "Phase 3: file must be at canonical name"
+    assert not record.exists(), "Phase 3: lifespan-name file must be gone"
+    body = json.loads(canonical_record.read_text())
+    assert body["session_id"] == canonical_uuid, (
+        "Phase B: JSON content must be rewritten to canonical UUID"
+    )
+    assert body["server_pid"] == os.getpid(), (
+        "Phase B: other JSON fields must survive rewrite"
+    )
+    core_mod._OWNED_CHROMA.clear()
+
+    # ─── Phases 4+5: plan-runner subprocess SessionStart ────────────────
+    # Simulate the subprocess by setting NX_SESSION_ID + calling
+    # nexus.hooks.session_start directly. ``stop_t1_server`` is patched
+    # because if Phase C/F regressed and sweep fired, the test would
+    # otherwise try to send SIGTERM to the test's own pid.
+    monkeypatch.setenv("NX_SESSION_ID", canonical_uuid)
+    monkeypatch.setattr("nexus.session.stop_t1_server", lambda _pid: None)
+    monkeypatch.setattr("nexus.session._is_pid_alive", lambda _pid: True)
+
+    from nexus.hooks import session_start
+    session_start()
+
+    # ─── Phase 6: canonical record SURVIVES the subprocess SessionStart ─
+    assert canonical_record.exists(), (
+        "GH #576: canonical session record must survive subprocess "
+        "SessionStart fire. Phase F (skip sweep when NX_SESSION_ID set) "
+        "is the primary defense; Phase C (filename-stem comparison) is "
+        "the secondary. Pre-fix this assertion fails because the "
+        "subprocess sweep ran uuid_stale=True (JSON content stale, "
+        "filename was canonical) and unlinked the parent's record."
+    )
+    body_after = json.loads(canonical_record.read_text())
+    assert body_after["session_id"] == canonical_uuid
+
+
+def test_session_start_subprocess_skip_sweep_present() -> None:
+    """Invariant: when ``NX_SESSION_ID`` is set in the environment,
+    ``session_start`` must NOT call ``sweep_stale_sessions`` against
+    the parent's SESSIONS_DIR. Phase F.
+
+    AST audit: the function body must have a guard branching on
+    ``NX_SESSION_ID`` BEFORE the sweep_stale_sessions call.
+    """
+    text = (SRC_ROOT / "hooks.py").read_text()
+    func = _extract_function_body(text, "def session_start")
+    # Find the position of the inherited-session check and the sweep
+    # call. The check must come first.
+    sweep_idx = func.find("sweep_stale_sessions(SESSIONS_DIR)")
+    inherited_idx = func.find("NX_SESSION_ID")
+    assert sweep_idx > 0, "session_start must call sweep_stale_sessions"
+    assert inherited_idx > 0, (
+        "session_start must check NX_SESSION_ID before sweep (Phase F)"
+    )
+    assert inherited_idx < sweep_idx, (
+        "Phase F: NX_SESSION_ID guard must be evaluated BEFORE "
+        "sweep_stale_sessions. Subprocess SessionStart firing in a "
+        "plan-runner ``claude -p`` must not touch the parent's "
+        "SESSIONS_DIR (GH #576)."
+    )

--- a/tests/test_t1_watchdog.py
+++ b/tests/test_t1_watchdog.py
@@ -493,24 +493,40 @@ class TestWatchdogLogConfiguration:
 
 
 class TestSessionFileRemovedExit:
-    """GH #567: when the session file existed at watchdog startup but
-    is later removed (sweep_stale_sessions uuid-mismatch arm at
-    session.py:286), the watchdog must exit cleanly. Pre-fix it kept
-    polling and leaked until its watched PIDs died.
+    """GH #567 / #575: when the watchdog's chroma server's session
+    record disappears (sweep_stale_sessions, /clear, /resume, or any
+    other reaper), the watchdog must exit cleanly.
+
+    Phase E: lookup is by ``server_pid`` JSON match instead of the
+    CLI-arg ``--session-file`` path. Pre-fix the existence check was
+    bound to a path captured at spawn time, which became stale 88ms
+    after spawn when ``reconcile_owned_chroma`` renamed the file —
+    the sticky flag never flipped True and the exit branch was
+    unreachable in the canonical lifespan-then-SessionStart flow.
     """
 
-    def test_session_file_removed_after_start_triggers_exit(
+    @staticmethod
+    def _write_record(sessions_dir, session_id, server_pid):
+        import json
+        f = sessions_dir / f"{session_id}.session"
+        f.write_text(json.dumps({
+            "session_id": session_id, "server_pid": server_pid,
+            "server_host": "127.0.0.1", "server_port": 11111,
+        }))
+        return f
+
+    def test_session_record_removed_after_start_triggers_exit(
         self, tmp_path, monkeypatch, captured_events,
     ):
         from nexus import t1_watchdog
+        from nexus.db.t1 import SESSIONS_DIR
 
         monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
         monkeypatch.setattr(
             t1_watchdog, "_is_alive", lambda _pid: True,  # everything alive
         )
 
-        session_file = tmp_path / "s"
-        session_file.write_text("{}")  # exists at startup
+        record = self._write_record(SESSIONS_DIR, "abc", server_pid=200)
 
         # Remove the file on the FIRST tick so we exercise the
         # disappearance trigger.
@@ -520,7 +536,7 @@ class TestSessionFileRemovedExit:
         def _tick_then_remove(_s):
             ticks[0] += 1
             if ticks[0] == 1:
-                session_file.unlink()
+                record.unlink()
             return original_sleep(_s)
 
         monkeypatch.setattr(t1_watchdog.time, "sleep", _tick_then_remove)
@@ -529,7 +545,7 @@ class TestSessionFileRemovedExit:
             t1_watchdog.main([
                 "--claude-pid", "100",
                 "--chroma-pid", "200",
-                "--session-file", str(session_file),
+                "--session-file", str(record),
                 "--tmpdir", str(tmp_path / "td"),
             ])
 
@@ -540,6 +556,64 @@ class TestSessionFileRemovedExit:
         assert events, (
             f"expected watchdog_exiting with reason=session_file_removed; "
             f"got events: {[e.get('event') for e in captured_events]}"
+        )
+        assert events[0]["chroma_pid"] == 200
+
+    def test_session_record_renamed_then_removed_triggers_exit(
+        self, tmp_path, monkeypatch, captured_events,
+    ):
+        """GH #575 Phase E: reconcile renames the record file post-
+        spawn (sessions/<lifespan-uuid>.session →
+        sessions/<canonical>.session). The watchdog must track via
+        server_pid (not filename) so the renamed record is still
+        recognised; when the canonical record is later unlinked
+        (e.g. /clear), the exit fires.
+
+        Pre-fix this scenario was the load-bearing #575 reproducer:
+        sticky flag never flipped True because the watchdog's CLI-arg
+        path snapshot was the pre-rename filename, which was already
+        gone by the first poll.
+        """
+        from nexus import t1_watchdog
+        from nexus.db.t1 import SESSIONS_DIR
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(t1_watchdog, "_is_alive", lambda _pid: True)
+
+        lifespan_record = self._write_record(
+            SESSIONS_DIR, "lifespan-uuid", server_pid=200,
+        )
+        canonical_record = SESSIONS_DIR / "canonical-uuid.session"
+
+        original_sleep = t1_watchdog.time.sleep
+        ticks = [0]
+
+        def _tick(_s):
+            ticks[0] += 1
+            if ticks[0] == 1:
+                lifespan_record.replace(canonical_record)
+            elif ticks[0] == 3:
+                canonical_record.unlink()
+            return original_sleep(_s)
+
+        monkeypatch.setattr(t1_watchdog.time, "sleep", _tick)
+
+        with patch.object(t1_watchdog, "_cleanup"):
+            t1_watchdog.main([
+                "--claude-pid", "100",
+                "--chroma-pid", "200",
+                "--session-file", str(lifespan_record),
+                "--tmpdir", str(tmp_path / "td"),
+            ])
+
+        events = [
+            e for e in captured_events
+            if e.get("reason") == "session_file_removed"
+        ]
+        assert events, (
+            f"expected exit reason=session_file_removed after rename + "
+            f"unlink; got events: "
+            f"{[(e.get('event'), e.get('reason')) for e in captured_events]}"
         )
 
     def test_session_file_never_existed_does_not_trigger(


### PR DESCRIPTION
## Summary

P0 unified fix for the T1 data-loss class that escaped three rounds of patches (#567/#572/#574 in 4.26.4–4.26.6). The fix-loop kept repeating because each patch closed a witnessed instance of a class-of-bugs while the class re-instantiated at the next un-audited code path. Root-cause analysis (debugger + deep-analyst) identified five invariant violations across six call sites; this PR closes them all.

## Phases

- **Phase A** — `db/t1.py` `_reconnect`: UUID-keyed lookup symmetry with constructor + raise instead of silent EphemeralClient (PR #569 contract parity).
- **Phase B** — `mcp/core.py` `reconcile_owned_chroma`: rewrite JSON content after rename. Pre-fix the rename left JSON's `session_id` stale, the trigger for the silent T1 data loss in #576.
- **Phase C** — `session.py` `sweep_stale_sessions`: compare filename-stem (canonical post-reconcile) instead of JSON content (incidental metadata).
- **Phase D** — `mcp/core.py` `_t1_chroma_init_if_owner`: subprocess hard read-only when `NX_SESSION_ID` or `NEXUS_SKIP_T1=1` is set. Closes the deep-analyst's "fifth bug" — silent spawn-and-overwrite under inherited UUID when probe races.
- **Phase E** — `t1_watchdog.py`: find record by `chroma_pid` JSON match each poll. Robust to reconcile rename, `/clear`, `/resume`. Closes #575.
- **Phase F** — `hooks.py` `session_start`: skip `sweep_stale_sessions` + `sweep_orphan_tmpdirs` when `NX_SESSION_ID` is set (subprocess inheritance). Defense-in-depth complementing Phase C.

## Regression scaffolding (`tests/test_t1_invariants.py`)

Encodes the invariants as test assertions so future patches that re-introduce the same bug class fail CI before merge:

- `_EPHEMERAL_ALLOWLIST` grep test (any new `chromadb.EphemeralClient(` outside the two opt-in paths fails CI)
- AST-style audits for resolver symmetry, JSON rewrite, subprocess sweep gate
- End-to-end #576 chain reproduction (walks lifespan→SessionStart→reconcile→subprocess SessionStart→assert no record loss)

## Test plan

- [x] Unit suite: 6661/6669 pass. Eight failures are pre-existing PDF subsystem (docling module not installed locally), unrelated to T1.
- [x] Sandbox smoke + doctor checks pass (`tests/e2e/release-sandbox.sh smoke`).
- [x] All five invariant tests pass including the chained #576 reproduction.
- [ ] Live tmux verification in sandbox (run `tests/e2e/release-sandbox.sh tmux` and exercise: scratch put → nx_answer with verb=research → scratch list; expect prior entries still present, no `t1_reconnect_ephemeral_fallback_data_lost` in logs).

## Closes

Closes #575
Closes #576

## Beads

nexus-gxq5