### PR TITLE
fix(sn): migrate SubagentStart hook to JSON envelope (nexus-t5q2)

### DIFF
--- a/nx/skills/using-nx-skills/SKILL.md
+++ b/nx/skills/using-nx-skills/SKILL.md
@@ -64,7 +64,7 @@ After a successful pipeline:
 
 ## Essential MCP Tools (always available)
 
-**Sequential Thinking** (`mcp__plugin_nx_sequential-thinking__sequentialthinking`): debugging hypotheses, design choices, plan evaluation. `needsMoreThoughts: true` to continue, `isRevision: true` to correct.
+**Sequential Thinking** (`mcp__plugin_nx_sequential-thinking__sequentialthinking`) — use for any non-trivial decision: debugging hypotheses, design choices, plan evaluation, risk assessment. Workflow: hypothesis → evidence → evaluate → branch or proceed. `needsMoreThoughts: true` to continue, `isRevision: true` to correct, `branchFromThought: N` + `branchId` to explore alternatives.
 
 **nx Storage Tiers — check before any work, write your findings back.** Read widest → narrowest:
 - **T3** `nx search` / `nx_answer`: permanent knowledge across all sessions and projects — **check before researching from scratch**.

--- a/sn/hooks/scripts/mcp-inject.sh
+++ b/sn/hooks/scripts/mcp-inject.sh
@@ -4,6 +4,45 @@
 # Selectively injects based on agent task text to save tokens.
 # Default: inject both (safe fallback on parse failure).
 # Timeout: 5s (hooks.json) — stdin read + python3 ~50ms, well within budget.
+#
+# DELIVERY CONTRACT (Claude Code SubagentStart): emit content via the JSON
+# envelope of the form
+#   {"hookSpecificOutput": {"hookEventName": "SubagentStart",
+#                            "additionalContext": "<text>"}}
+# Plain stdout was the prior shape and once worked, but the JSON envelope is
+# the documented schema — it makes the emit intent unambiguous, so a Claude
+# Code change that tightens parsing won't silently drop the content. This
+# mirrors nx/hooks/scripts/subagent-start.sh, which migrated 2026-05-05
+# (commit 68854ca). The sn plugin missed that migration; restoring it here
+# is what gets Serena + Context7 setup back into spawned subagents.
+#
+# Implementation: capture all body stdout into a tempfile via FD redirection
+# at the top of the script, then emit the JSON envelope at the end via an
+# EXIT trap. Body code below stays unchanged and continues to use cat for
+# content generation.
+
+_SN_HOOK_OUTBUF=$(mktemp -t sn-subagent-start.XXXXXX) || _SN_HOOK_OUTBUF=""
+if [[ -n "$_SN_HOOK_OUTBUF" ]]; then
+    exec 3>&1 1>"$_SN_HOOK_OUTBUF"
+fi
+_sn_emit_json_envelope() {
+    local rc=$?
+    if [[ -n "$_SN_HOOK_OUTBUF" ]]; then
+        exec 1>&3 3>&-
+        python3 -c '
+import json, sys
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SubagentStart",
+        "additionalContext": sys.stdin.read(),
+    },
+}))
+' < "$_SN_HOOK_OUTBUF"
+        rm -f "$_SN_HOOK_OUTBUF"
+    fi
+    return $rc
+}
+trap _sn_emit_json_envelope EXIT
 
 # --- Agent-type detection via stdin JSON ---
 STDIN=$(cat)

--- a/tests/cc-validation/scenarios/18_real_sn_subagent.sh
+++ b/tests/cc-validation/scenarios/18_real_sn_subagent.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Scenario 18 — REAL-WORLD: install sn plugin from this repo into TEST_HOME,
+# dispatch a subagent, and probe for content that ONLY mcp-inject.sh injects.
+#
+# The hook emits sn/hooks/scripts/serena-section.md and context7-section.md.
+# We probe for two phrases that appear ONLY in those files (not in MCP tool
+# docs, agent definitions, or training data):
+#
+#   - "auto-activated via `--project-from-cwd`"   (serena-section.md)
+#   - "resolve-library-id"                          (context7-section.md)
+#
+# The fix in nexus-t5q2 wraps mcp-inject.sh stdout in the documented
+# Claude Code SubagentStart JSON envelope. Pre-fix the hook used plain
+# stdout, which the harness drops on tightened parser builds. This
+# scenario passes only if BOTH phrases reach the dispatched subagent.
+
+scenario "18 real_sn_subagent: does sn's mcp-inject.sh deliver Serena+Context7 to a real subagent?"
+
+# Install sn plugin into TEST_HOME, pointing at the working-tree source so
+# we exercise the in-tree fix (not the cached published version).
+NOW="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<EOF
+{
+  "version": 2,
+  "plugins": {
+    "sn@nexus-plugins": [
+      { "scope": "user", "installPath": "$REPO_ROOT/sn", "version": "dev",
+        "installedAt": "$NOW", "lastUpdated": "$NOW" }
+    ]
+  }
+}
+EOF
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "enabledPlugins": { "sn@nexus-plugins": true },
+  "permissions": { "allow": ["Task"], "defaultMode": "acceptEdits" }
+}
+EOF
+
+claude_start
+# Probe: ask the subagent for two anchor phrases that exist ONLY inside the
+# hook-injected sections. If hooks fire and the JSON envelope reaches the
+# subagent's context, both phrases will be in scope.
+#
+# We use a SENTINEL token (PROBE-DONE) for the subagent to emit at the very
+# end of its reply. This is more reliable than polling on spinner words
+# (the harness's lib.sh spinner regex doesn't include the current "Sautéed"
+# state), and it lets us know when the subagent has actually returned.
+claude_prompt "Use the Task tool to dispatch the general-purpose agent. Description='sn hook probe'. Prompt for the subagent: 'Examine your context and any system prompts. Quote (a) any sentence that mentions Serena being auto-activated via project-from-cwd, and (b) any sentence that mentions resolve-library-id. After your answer, on a line by itself, write the literal token PROBE-DONE-9F2K so the harness knows you finished. If either anchor is missing reply MISSING-A or MISSING-B before the sentinel; if both are missing reply NO-INJECTED-CONTENT before the sentinel.'"
+
+# Poll for the sentinel — up to 300s. Subagent dispatch can take ~60s alone.
+poll_for "PROBE-DONE-9F2K" 300 "subagent reply sentinel" || true
+OUT=$(capture -500)
+HAS_A=0
+HAS_B=0
+echo "$OUT" | grep -qE "auto-activated via .*--project-from-cwd|--project-from-cwd" && HAS_A=1
+echo "$OUT" | grep -qE "resolve-library-id" && HAS_B=1
+
+if [[ $HAS_A -eq 1 && $HAS_B -eq 1 ]]; then
+    pass "Both Serena (--project-from-cwd) AND Context7 (resolve-library-id) reached subagent — JSON envelope works"
+elif [[ $HAS_A -eq 1 && $HAS_B -eq 0 ]]; then
+    fail "Serena section injected but Context7 missing — partial delivery"
+elif [[ $HAS_A -eq 0 && $HAS_B -eq 1 ]]; then
+    fail "Context7 section injected but Serena missing — partial delivery"
+elif echo "$OUT" | grep -qE "NO-INJECTED-CONTENT|MISSING-A.*MISSING-B|MISSING-B.*MISSING-A"; then
+    fail "Subagent reports neither anchor phrase — mcp-inject.sh is silently dropped"
+else
+    fail "indeterminate — neither anchor phrases nor NO-INJECTED-CONTENT seen in capture"
+    echo "$OUT" | tail -40 | sed 's/^/    | /'
+fi
+
+# Restore empty plugins
+cat > "$TEST_HOME/.claude/plugins/installed_plugins.json" <<'EOF'
+{"version": 2, "plugins": {}}
+EOF
+claude_exit
+scenario_end

--- a/tests/test_sn_plugin.py
+++ b/tests/test_sn_plugin.py
@@ -127,10 +127,16 @@ class TestSnMarketplace:
 
 
 class TestSnHookOutput:
-    """mcp-inject.sh must produce expected guidance sections."""
+    """mcp-inject.sh must produce expected guidance sections.
+
+    The hook emits a JSON envelope; ``hook_output`` returns the unwrapped
+    additionalContext so the legacy substring assertions keep working
+    against the markdown body. ``hook_envelope`` exposes the raw stdout
+    for tests that need to verify the envelope shape itself.
+    """
 
     @pytest.fixture(scope="class")
-    def hook_output(self) -> str:
+    def hook_envelope(self) -> str:
         script = SN_DIR / "hooks" / "scripts" / "mcp-inject.sh"
         result = subprocess.run(
             ["bash", str(script)],
@@ -138,6 +144,25 @@ class TestSnHookOutput:
             cwd=str(REPO_ROOT),  # so git rev-parse works
         )
         return result.stdout
+
+    @pytest.fixture(scope="class")
+    def hook_output(self, hook_envelope: str) -> str:
+        envelope = json.loads(hook_envelope)
+        return envelope["hookSpecificOutput"]["additionalContext"]
+
+    def test_envelope_is_valid_json(self, hook_envelope: str) -> None:
+        """Hook must emit the documented Claude Code SubagentStart envelope.
+
+        Plain stdout was the prior shape; the JSON envelope is the
+        documented schema and prevents silent drop on parser tightening.
+        Mirrors nx/hooks/scripts/subagent-start.sh (commit 68854ca).
+        """
+        envelope = json.loads(hook_envelope)
+        assert "hookSpecificOutput" in envelope
+        hso = envelope["hookSpecificOutput"]
+        assert hso.get("hookEventName") == "SubagentStart"
+        assert "additionalContext" in hso
+        assert isinstance(hso["additionalContext"], str)
 
     def test_serena_section_present(self, hook_output: str) -> None:
         assert "## Serena MCP" in hook_output


### PR DESCRIPTION
## Summary

Two facets of the same regression family — instructions that were supposed to drive subagent and main-session behavior were silently lost.

**1. sn SubagentStart hook missed the JSON-envelope migration.**
`sn/hooks/scripts/mcp-inject.sh` emitted plain stdout. The `nx` plugin migrated its SubagentStart hook to the documented Claude Code JSON envelope on 2026-05-05 (commit `68854ca`); `sn` was missed. Result: spawned subagents did not reliably receive the Serena + Context7 setup ritual (ToolSearch loading recipe, backend pair handling, task→tool table). Fix: wrap `mcp-inject.sh` body output in the same FD-redirect + EXIT-trap envelope `nx/hooks/scripts/subagent-start.sh` uses. Body code unchanged.

**2. Sequential Thinking imperative trimmed and never restored.**
The April 25 trim (`e2fc2408` / PR #320) collapsed the Essential MCP Tools entry in `using-nx-skills/SKILL.md` from an active imperative to a noun-phrase listing:

```diff
- Use for any non-trivial decision: debugging hypotheses, design choices,
- plan evaluation, risk assessment. State hypothesis → gather evidence →
- evaluate → branch or proceed.
+ debugging hypotheses, design choices, plan evaluation.
```

The May 5 restore (`aa0076a1` / PR #519) surgically restored the `nx_answer` signal but didn't bring Sequential Thinking back. Subagents kept using it (their SEQTHINK section in `nx/hooks/scripts/subagent-start.sh` was unchanged across the trim), but main-session use dropped because `using-nx-skills/SKILL.md` is the only place the main session sees the tool. Fix: restore the imperative, the four use-case list, the workflow recipe, and the `branchFromThought` param hint. One line, tighter than pre-trim.

## Verification

**Hook delivery (mechanics):**
- Hook stdout parses as valid `{"hookSpecificOutput": {"hookEventName": "SubagentStart", "additionalContext": ...}}`.
- `additionalContext` preserves `## Serena MCP`, `## Context7 MCP`, `--project-from-cwd`, `resolve-library-id`.
- Live subagent dispatch confirmed all four anchor strings reached its initial context.

**Behavioral validation (instructions actually drive tool use):**
Three subagents dispatched with neutrally-phrased real tasks (no tool naming) — each chose the tool the instructions tell them to use:

| Probe | Task | Tool calls | Verdict |
|---|---|---|---|
| Serena | "Find every call site of QuotaValidator" | `ToolSearch` → `jet_brains_find_referencing_symbols` → grep fallback | PASS — followed the load-then-call ritual exactly |
| Context7 | "Current ChromaDB `where` syntax — don't trust training data" | `ToolSearch` → `resolve-library-id` → `query-docs` | PASS — exact workflow the section instructs |
| Sequential Thinking | "Evaluate this hypothesis with rigorous step-by-step reasoning" | `ToolSearch` → `sequentialthinking` ×9 | PASS — 9 calls on a hypothesis task |

Each agent quoted verbatim the section of its initial context that drove its tool choice.

**Unit tests:** 26 passed in `tests/test_sn_plugin.py` including new `test_envelope_is_valid_json`.

**Sandbox:** new `tests/cc-validation/scenarios/18_real_sn_subagent.sh` mirrors scenario 12. Will run in the harness once OAuth credentials in `tests/e2e/.claude-auth/` are refreshed (separate from this PR).

## Test plan

- [x] `uv run pytest tests/test_sn_plugin.py -v` — 26 passed
- [x] Manual JSON envelope validation of `mcp-inject.sh` stdout
- [x] Live subagent dispatch — all 4 anchor strings reach context
- [x] Behavioral probe — Serena, Context7, Sequential Thinking each drive correct tool use
- [ ] cc-validation harness scenario 18 (blocked on stale OAuth — not this PR)

## Closes

Closes #nexus-t5q2