### PR TITLE
feat(doctor): add nx doctor --check-t1 + document T1 sub-agent contract (nexus-s368)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,17 @@ Three storage tiers, by lifetime:
 - **T2** — SQLite + FTS5, seven domain stores behind a `T2Database` facade. Persistent notes, plans, taxonomy, telemetry, chash, aspects, aspect queue.
 - **T3** — `chromadb.PersistentClient` + local ONNX (local mode) **or** `chromadb.CloudClient` + Voyage (cloud mode). Permanent knowledge (`nx store`, `nx search`).
 
+### T1 sub-agent contract (RDR-105)
+
+T1 is the per-MCP-process "working memory" tier. T2 is the cross-process shared bus. Discovery is hybrid: env passdown for MCP-dispatched subprocesses, single-writer `~/.config/nexus/t1_addr.<claude_pid>` for Claude-Code-spawned siblings.
+
+- **Agent-tool sub-agents** (in-process Task dispatches) share T1 with their parent via the parent's MCP scratch tool. No separate T1 instance.
+- **`claude -p` sub-processes default to `owned`** mode: their MCP spawns its own session-scoped chroma + writes its own `~/.config/nexus/t1_addr.<own_claude_pid>` file. Sealed from the parent; internally consistent for the subprocess's own Bash tools and sub-agents.
+- **`claude -p` sub-processes that genuinely need parent-T1 visibility** opt in via `share_t1=True` at dispatch time. Subprocess inherits `NX_T1_HOST` / `NX_T1_PORT` and connects to the parent's chroma via HTTP.
+- **Stateless one-shot operators** (`ephemeral=True`) get an in-process `EphemeralClient` only (no chroma spawn). The operator-dispatch default (`nx_answer`, `nx_tidy`, plan-runner inline planning).
+- **Cross-process findings between sibling sub-processes go to T2** (`memory_put`). T1 is process-local by design; T2 is the shared bus (SQLite + WAL is multi-process-safe).
+- **Deprecated env name:** `NEXUS_SKIP_T1=1` is honoured as an alias for `NX_T1_ISOLATED=1` for the 4.27 -> 4.28 deprecation cycle. Removed in 5.0.
+
 Collection prefixes coexist in one T3 database. Always `__` (double underscore) as separator (colons are invalid in ChromaDB collection names). Conformant collection-name shape (RDR-103) is `<content_type>__<owner_id>__<embedding_model>__v<n>`, e.g. `code__nexus-1-1__voyage-code-3__v1`:
 
 | Prefix | Embedder | Document identity (catalog) | Chunk join key |

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -1050,6 +1050,17 @@ def _run_check_mineru() -> None:
          "error. nexus-1pfq.",
 )
 @click.option(
+    "--check-t1",
+    "check_t1",
+    is_flag=True,
+    default=False,
+    help="Diagnose T1 addr-file presence + reachability. Detects "
+         "the 'no t1_addr.<claude_pid> when Claude Code is parent' "
+         "case and the exec -a / wrapper-rename residual. RDR-105 "
+         "P5 / nexus-ssdg. Exits 1 when Claude is in the chain "
+         "but the addr file is missing or unreachable.",
+)
+@click.option(
     "--days",
     "days",
     default=30,
@@ -1069,6 +1080,7 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                trim_telemetry: bool, days: int,
                check_post_store_hooks: bool,
                check_aspect_queue: bool,
+               check_t1: bool,
                check_tier_discipline: bool) -> None:
     """Verify that all required services and credentials are available."""
     if check_schema:
@@ -1118,6 +1130,10 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if check_aspect_queue:
         _run_check_aspect_queue()
+        return
+
+    if check_t1:
+        _run_check_t1()
         return
 
     if check_tier_discipline:
@@ -1307,6 +1323,116 @@ def _run_check_resources() -> None:
         err=True,
     )
     raise click.exceptions.Exit(2)
+
+
+# ── --check-t1 (RDR-105 P5 / nexus-ssdg) ─────────────────────────────────────
+
+
+def _run_check_t1() -> None:
+    """Diagnostic: T1 addr-file presence + reachability.
+
+    .. note::
+       Imports ``_tcp_probe_alive`` lazily from ``nexus.mcp.core`` to
+       avoid pulling FastMCP / chromadb / corpus into the doctor's
+       cold-start path.
+
+    Three outcomes:
+
+    * **Healthy.** A live ``claude*`` ancestor is reachable via the
+      PPID walk and ``~/.config/nexus/t1_addr.<claude_pid>`` exists
+      AND its host:port responds to a TCP probe.
+    * **Missing addr file under live Claude.** A ``claude*`` ancestor
+      is reachable but the addr file is absent. Two common causes:
+      (a) the MCP server crashed before the lifespan wrote the file,
+      (b) the operator launched Claude Code via ``exec -a`` or a
+      custom wrapper whose process name does not start with
+      ``claude``, defeating the PPID walk's match.
+    * **No Claude in chain.** The current process has no ``claude*``
+      ancestor; ``nx scratch`` from this shell will fail-loud unless
+      the operator opts in via ``NX_T1_ISOLATED=1``.
+
+    Exit code:
+      * 0: healthy or "no Claude in chain" (informational).
+      * 1: Claude in chain but addr file absent or unreachable.
+    """
+    import os as _os
+
+    from nexus.mcp.core import _tcp_probe_alive
+    from nexus.session import (
+        _command_name_of,
+        find_immediate_claude_pid,
+        read_t1_addr_for,
+        t1_addr_path,
+    )
+
+    own_pid = _os.getpid()
+    claude_pid = find_immediate_claude_pid(start_pid=own_pid)
+
+    if claude_pid <= 0:
+        click.echo("[ ] T1: no claude ancestor in PPID chain")
+        click.echo(
+            "    This is informational. ``nx scratch`` from this shell "
+            "will fail-loud unless you opt into per-process ephemeral "
+            "T1 via ``NX_T1_ISOLATED=1``."
+        )
+        return
+
+    comm = _command_name_of(claude_pid)
+    is_claude = comm.lower().startswith("claude")
+    if not is_claude:
+        # find_immediate_claude_pid returned the immediate-PPID
+        # fallback because no ancestor's comm starts with "claude".
+        # Likely an exec -a / wrapper rename.
+        click.echo(
+            f"[!] T1: ancestor PID {claude_pid} (comm={comm!r}) is not "
+            "named 'claude*'; likely launched via exec -a or a "
+            "wrapper. Falling back to the immediate-PPID."
+        )
+        click.echo(
+            "    If you launched Claude Code via ``exec -a`` or a "
+            "custom wrapper, ensure the process name starts with "
+            "``claude`` so the PPID walk can find it."
+        )
+        raise click.exceptions.Exit(1)
+
+    addr_path = t1_addr_path(claude_pid)
+    addr = read_t1_addr_for(claude_pid)
+    if addr is None:
+        click.echo(
+            f"[✗] T1: claude ancestor PID {claude_pid} ({comm!r}) "
+            f"is alive but {addr_path} is missing or unreadable."
+        )
+        click.echo(
+            "    The MCP server's lifespan should have written this "
+            "file at session start. Causes:\n"
+            "      - The MCP server crashed before the lifespan "
+            "completed (check ~/.config/nexus/logs/mcp.log).\n"
+            "      - The MCP server is still booting; retry shortly.\n"
+            "      - The Claude Code binary was launched via "
+            "``exec -a`` with a different process name (the PPID walk "
+            "found the right PID but the comm-prefix check missed)."
+        )
+        raise click.exceptions.Exit(1)
+
+    host, port = addr
+    if _tcp_probe_alive(host, port, timeout=1.0):
+        click.echo(
+            f"[✓] T1: addr file {addr_path.name} -> "
+            f"{host}:{port} (chroma reachable)"
+        )
+        return
+
+    click.echo(
+        f"[✗] T1: addr file {addr_path.name} -> {host}:{port} "
+        "but TCP probe failed."
+    )
+    click.echo(
+        "    The addr file points at a chroma that is not listening. "
+        "The MCP server may have died ungracefully. Restart Claude "
+        "Code; the next MCP startup will sweep this stale addr file "
+        "and spawn a fresh chroma."
+    )
+    raise click.exceptions.Exit(1)
 
 
 # ── --check-quotas (nexus-c590) ──────────────────────────────────────────────

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -783,3 +783,82 @@ class TestCheckTmpdirs:
         assert len(payload["candidates"]) == 1
         assert payload["candidates"][0]["path"].endswith("nx_t1_x")
         assert payload["reaped"] == 0
+
+
+# ── --check-t1 (RDR-105 P5 / nexus-ssdg) ─────────────────────────────────────
+
+
+class TestCheckT1:
+    """Diagnostic: T1 addr-file presence + reachability."""
+
+    def test_no_claude_ancestor_is_informational(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        from unittest.mock import patch
+        with patch("nexus.session.find_immediate_claude_pid", return_value=0):
+            result = runner.invoke(main, ["doctor", "--check-t1"])
+        assert result.exit_code == 0, result.output
+        assert "no claude ancestor" in result.output.lower()
+
+    def test_exec_a_wrapper_rename_warns(
+        self, runner: CliRunner, tmp_path: Path,
+    ) -> None:
+        """find_immediate_claude_pid returns the immediate-PPID
+        fallback when no ancestor's comm starts with 'claude'."""
+        from unittest.mock import patch
+        with (
+            patch("nexus.session.find_immediate_claude_pid", return_value=4242),
+            patch("nexus.session._command_name_of", return_value="bash"),
+        ):
+            result = runner.invoke(main, ["doctor", "--check-t1"])
+        assert result.exit_code == 1, result.output
+        assert "exec -a" in result.output
+
+    def test_addr_file_missing_under_live_claude(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from unittest.mock import patch
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        with (
+            patch("nexus.session.find_immediate_claude_pid", return_value=4242),
+            patch("nexus.session._command_name_of", return_value="claude"),
+        ):
+            result = runner.invoke(main, ["doctor", "--check-t1"])
+        assert result.exit_code == 1, result.output
+        assert "missing or unreadable" in result.output
+
+    def test_addr_file_present_but_unreachable(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from unittest.mock import patch
+
+        from nexus.session import write_t1_addr
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        write_t1_addr(4242, "127.0.0.1", 1)
+        with (
+            patch("nexus.session.find_immediate_claude_pid", return_value=4242),
+            patch("nexus.session._command_name_of", return_value="claude"),
+            patch("nexus.mcp.core._tcp_probe_alive", return_value=False),
+        ):
+            result = runner.invoke(main, ["doctor", "--check-t1"])
+        assert result.exit_code == 1, result.output
+        assert "TCP probe failed" in result.output
+
+    def test_healthy(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch,
+    ) -> None:
+        from unittest.mock import patch
+
+        from nexus.session import write_t1_addr
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        write_t1_addr(4242, "127.0.0.1", 12345)
+        with (
+            patch("nexus.session.find_immediate_claude_pid", return_value=4242),
+            patch("nexus.session._command_name_of", return_value="claude"),
+            patch("nexus.mcp.core._tcp_probe_alive", return_value=True),
+        ):
+            result = runner.invoke(main, ["doctor", "--check-t1"])
+        assert result.exit_code == 0, result.output
+        assert "chroma reachable" in result.output


### PR DESCRIPTION
## Summary

Pre-release prep for conexus 4.27.0 (RDR-105 P5). The doctor
diagnostic + sub-agent contract docs go in via this feature PR;
the version bump + CHANGELOG entries ship in the
``chore(release): conexus 4.27.0`` commit on main.

## Contents

- **`nx doctor --check-t1`** (P5.1 / nexus-ssdg). Diagnoses T1 addr
  file presence + reachability. Distinguishes five outcomes:
  - No claude ancestor in the PPID chain (informational, exit 0).
  - Ancestor found but comm does not start with ``claude*`` (likely
    ``exec -a`` / wrapper rename, exit 1).
  - Claude is the parent but addr file is missing (MCP crashed,
    still booting, or wrapper rename, exit 1).
  - Addr file present but TCP probe fails (stale; restart Claude,
    exit 1).
  - Healthy (exit 0).
- **T1 sub-agent contract** documented in ``AGENTS.md`` (P5.4 /
  nexus-qirr). Captures the post-RDR-105 tier semantics so future
  contributors do not re-discover the rules: agent-tool sub-agents
  share via parent's MCP, ``claude -p`` defaults to ``owned`` mode,
  ``share_t1=True`` opts into parent T1, ``ephemeral=True`` skips
  chroma; cross-process findings go to T2.
- 5 unit tests in ``tests/test_doctor_cmd.py::TestCheckT1`` covering
  all outcomes.

## Verification

- 94 unit tests in ``test_doctor_cmd`` + ``test_t1_discovery`` green.
- Smoke-tested ``nx doctor --check-t1`` in this repo: correctly
  identifies the addr file as missing in the current environment
  (the live Claude session lost its MCP earlier today via GH #579).

## Out of scope (release commit)

- Version bump in 4 manifests (4.26.8 -> 4.27.0).
- ``CHANGELOG.md`` + ``nx/CHANGELOG.md`` entries.
- ``uv.lock`` refresh.

These ship as the documented direct-to-main ``chore(release): conexus
4.27.0`` commit after this feature PR merges into develop and
develop fast-forwards to main.

## Refs

- Bead: nexus-s368 (and children nexus-ssdg, nexus-qirr)
- Epic: nexus-d73b
- RDR: ``docs/rdr/rdr-105-t1-chroma-architecture-env-passdown.md``
- Predecessor PRs: #581 (P1), #582 (P2), #583 (P3), #584 (shakeout
  doc), #585 (P4 deletion). All merged into develop.