### PR TITLE
fix(t1): restore read_claude_session_id fallback in T1Database session_id chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **T1 cross-process session_id propagation regression in 4.27.0**
+  (PR pending, nexus-h8ge): RDR-105 P4 deletion of the legacy
+  session-record resolver removed the
+  ``read_claude_session_id()`` (~/.config/nexus/current_session)
+  fallback from ``T1Database._init_new_discovery``'s session_id
+  resolution chain. Every ``T1Database()`` call without an explicit
+  session_id arg or ``NX_SESSION_ID`` env minted a fresh ``uuid4()``
+  per process, so two processes in the same Claude session (the MCP
+  server and a Bash-tool sibling, or two shell ``nx scratch``
+  invocations) could not see each other's entries via the per-entry
+  session_id metadata filter. ``nx tier-status`` continued to use
+  the correct chain (``mcp/core.py:_record_tier_write``) so
+  telemetry attributed writes to the canonical session while the
+  data sat under fresh per-process UUIDs --- the audit log and the
+  T1 chunk store disagreed on attribution. Production hooks
+  reading T1 from the shell (``subagent-start.sh`` injecting T1 into
+  every sub-agent's seed prompt, ``post_compact_hook.sh``,
+  ``pre_close_verification_hook.sh``, ``divergence-language-guard.sh``)
+  silently saw "No scratch entries." regardless of T1 contents.
+  Fix: factor the resolution chain into ``_resolve_session_id`` and
+  call it from all four construction branches (Path A env, Path B
+  addr file, Path C isolation, client-injection) so the chain is a
+  single source of truth. ``read_claude_session_id`` /
+  ``write_claude_session_id`` now resolve ``NEXUS_CONFIG_DIR`` per
+  call instead of freezing the path at module import (consistency
+  with every other path helper in ``session.py``); the import-time
+  ``CLAUDE_SESSION_FILE`` constant remains for backward compat but
+  is no longer load-bearing. Regression coverage: 16 new unit tests
+  (``TestT1DatabaseSessionIdResolution``) parametrize the four
+  resolution scenarios across all four entry points; 1 new
+  integration test (``TestE2ESessionIdSharedAcrossProcesses``)
+  spawns two real subprocesses with no ``NX_SESSION_ID`` and
+  asserts both converge on the on-disk session_id and round-trip
+  T1 entries. The integration test is the missing invariant test
+  the 4.27.0 ship lacked: pre-fix it fails because each subprocess
+  mints its own UUID; post-fix it passes.
+
 ## [4.27.0] - 2026-05-07
 
 Minor release. RDR-105 retires the multi-writer T1 coordination layer

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -21,6 +21,7 @@ def _now_iso() -> str:
 from nexus.session import (
     _t1_isolated_env,
     find_immediate_claude_pid,
+    read_claude_session_id,
     read_t1_addr_for,
 )
 
@@ -143,6 +144,33 @@ class T1Database:
     the gate entirely.
     """
 
+    @staticmethod
+    def _resolve_session_id(arg: str | None) -> str:
+        """Resolve the session_id used as the per-entry metadata filter.
+
+        Chain: explicit ctor arg > ``NX_SESSION_ID`` env >
+        ``read_claude_session_id()`` (~/.config/nexus/current_session)
+        > new ``uuid4()``.
+
+        The ``read_claude_session_id()`` step is the load-bearing
+        fallback for cross-process T1 visibility (nexus-h8ge): the MCP
+        server, a Bash-tool sibling, and a hook subprocess all find
+        the same Claude session via the on-disk pointer and converge
+        on its UUID, so each side's session_id metadata filter sees
+        the others' entries. Pre-fix this step was missing in every
+        construction branch and every shell ``nx scratch`` invocation
+        orphaned its writes under a fresh per-process UUID,
+        breaking every nx-plugin hook that read T1 from the shell
+        (subagent-start, post_compact, pre_close_verification,
+        divergence-language-guard).
+        """
+        return (
+            arg
+            or os.environ.get("NX_SESSION_ID", "").strip()
+            or read_claude_session_id()
+            or str(uuid4())
+        )
+
     def _init_new_discovery(self, chromadb, session_id: str | None) -> None:
         """RDR-105 P2 (nexus-mj2o): four-branch fail-loud constructor.
 
@@ -177,11 +205,7 @@ class T1Database:
                     "not a valid integer."
                 ) from exc
             self._client = chromadb.HttpClient(host=host_env, port=port_int)
-            self._session_id = (
-                session_id
-                or os.environ.get("NX_SESSION_ID", "").strip()
-                or str(uuid4())
-            )
+            self._session_id = self._resolve_session_id(session_id)
             return
 
         claude_pid = find_immediate_claude_pid()
@@ -190,20 +214,12 @@ class T1Database:
             if addr is not None:
                 host, port = addr
                 self._client = chromadb.HttpClient(host=host, port=port)
-                self._session_id = (
-                    session_id
-                    or os.environ.get("NX_SESSION_ID", "").strip()
-                    or str(uuid4())
-                )
+                self._session_id = self._resolve_session_id(session_id)
                 return
 
         if _t1_isolated_env():
             self._client = chromadb.EphemeralClient()
-            self._session_id = (
-                session_id
-                or os.environ.get("NX_SESSION_ID", "").strip()
-                or str(uuid4())
-            )
+            self._session_id = self._resolve_session_id(session_id)
             return
 
         raise T1ServerNotFoundError(
@@ -230,7 +246,7 @@ class T1Database:
             # Used by the FastMCP lifespan to install a server-lifetime
             # EphemeralClient as the MCP-tool-side T1 store.
             self._client = client
-            self._session_id = session_id or str(uuid4())
+            self._session_id = self._resolve_session_id(session_id)
         else:
             # RDR-105 P4 (nexus-jnx7): the four-branch fail-loud gate is
             # the only resolution path. The legacy session-record

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -35,7 +35,23 @@ def _nexus_config_dir_at_import() -> Path:
     return Path.home() / ".config" / "nexus"
 
 
+#: Import-time snapshot kept for backward-compatibility with callers
+#: that import the constant directly. New code uses
+#: :func:`claude_session_file` (re-resolved per call so tests and
+#: subprocesses honour mid-process ``NEXUS_CONFIG_DIR`` flips). The
+#: read/write helpers below resolve the path per call so the constant
+#: is no longer load-bearing.
 CLAUDE_SESSION_FILE = _nexus_config_dir_at_import() / "current_session"
+
+
+def claude_session_file() -> Path:
+    """Return the path to ``current_session`` honouring the live
+    ``NEXUS_CONFIG_DIR`` env. Re-resolved per call so a subprocess
+    that inherits a different ``NEXUS_CONFIG_DIR`` (test isolation,
+    sandbox, sub-agent dispatch) sees its own config dir without
+    re-importing the module.
+    """
+    return _nexus_config_dir_at_import() / "current_session"
 
 
 def generate_session_id() -> str:
@@ -45,8 +61,9 @@ def generate_session_id() -> str:
 
 def write_claude_session_id(session_id: str) -> None:
     """Write the Claude session ID to the stable flat file (mode 0o600)."""
-    CLAUDE_SESSION_FILE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    fd = os.open(str(CLAUDE_SESSION_FILE), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    path = claude_session_file()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd = os.open(str(path), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
     try:
         os.write(fd, session_id.encode())
     finally:
@@ -56,7 +73,7 @@ def write_claude_session_id(session_id: str) -> None:
 def read_claude_session_id() -> str | None:
     """Read the Claude session ID from the flat file, or None if not set."""
     try:
-        text = CLAUDE_SESSION_FILE.read_text().strip()
+        text = claude_session_file().read_text().strip()
         return text or None
     except OSError:
         return None  # intentional: file not created yet, normal on first run

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -19,6 +19,7 @@ resolution surface. Verifies:
 """
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -541,6 +542,274 @@ class TestT1DatabaseFlagOnPrecedence:
             T1Database()
         # Should have used env-supplied 10.0.0.1:1111, not file-supplied 10.0.0.2:2222.
         fake_chromadb.HttpClient.assert_called_once_with(host="10.0.0.1", port=1111)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# session_id resolution chain (nexus-h8ge regression)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# The four-branch fail-loud constructor in
+# ``T1Database._init_new_discovery`` resolves the session_id used as the
+# ChromaDB metadata filter. All four branches MUST follow the same chain:
+#
+#     ctor session_id arg
+#         > NX_SESSION_ID env
+#         > read_claude_session_id() (~/.config/nexus/current_session)
+#         > new uuid4()
+#
+# The 4.27.0 ship omitted the ``read_claude_session_id()`` step in every
+# branch, so two ``T1Database()`` calls in the same Claude session (the
+# MCP server and a Bash-tool sibling) minted distinct UUIDs and could
+# not see each other's entries via the per-entry session_id metadata
+# filter. Production hooks that rely on shell ``nx scratch list``
+# (subagent-start, post_compact, pre_close_verification,
+# divergence-language-guard) silently saw "No scratch entries." even
+# when entries existed. See bead nexus-h8ge for the live shakeout
+# evidence.
+
+
+_PATH_IDS = ["env", "addr_file", "isolation", "client_injection"]
+
+
+def _setup_path(path_id: str, tmp_path, monkeypatch, fake_chromadb):
+    """Configure env + monkeypatches so the named branch fires.
+
+    Returns ``(extra_kwargs, expected_client_attr)`` for the
+    ``T1Database`` constructor call.
+
+    * ``env`` -- Path A (NX_T1_HOST + NX_T1_PORT).
+    * ``addr_file`` -- Path B (PPID walk + addr file).
+    * ``isolation`` -- Path C (NX_T1_ISOLATED=1 + no addr file).
+    * ``client_injection`` -- early branch with explicit client=.
+    """
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+    for var in ("NX_T1_HOST", "NX_T1_PORT", "NX_T1_ISOLATED", "NEXUS_SKIP_T1"):
+        monkeypatch.delenv(var, raising=False)
+
+    if path_id == "env":
+        monkeypatch.setenv("NX_T1_HOST", "127.0.0.1")
+        monkeypatch.setenv("NX_T1_PORT", "5555")
+        return {}, "HttpClient"
+    if path_id == "addr_file":
+        from nexus.session import write_t1_addr
+        write_t1_addr(33333, "127.0.0.1", 6666)
+        monkeypatch.setattr(
+            "nexus.db.t1.find_immediate_claude_pid",
+            lambda start_pid=None: 33333,
+        )
+        return {}, "HttpClient"
+    if path_id == "isolation":
+        monkeypatch.setenv("NX_T1_ISOLATED", "1")
+        monkeypatch.setattr(
+            "nexus.db.t1.find_immediate_claude_pid",
+            lambda start_pid=None: 0,
+        )
+        return {}, "EphemeralClient"
+    if path_id == "client_injection":
+        return {"client": fake_chromadb.EphemeralClient.return_value}, None
+    raise ValueError(path_id)
+
+
+def _write_current_session(tmp_path, sid: str) -> None:
+    (tmp_path / "current_session").write_text(sid)
+
+
+@pytest.fixture
+def fake_chromadb(monkeypatch):
+    from unittest.mock import MagicMock
+    fake = MagicMock()
+    fake.HttpClient.return_value = MagicMock()
+    fake.EphemeralClient.return_value = MagicMock()
+    monkeypatch.setitem(sys.modules, "chromadb", fake)
+    return fake
+
+
+class TestT1DatabaseSessionIdResolution:
+    """nexus-h8ge: session_id MUST follow the same four-step chain in
+    every branch (Path A/B/C + client-injection).
+
+    The chain is:
+        ctor arg > NX_SESSION_ID env > read_claude_session_id() > uuid4()
+
+    Pre-fix the ``read_claude_session_id()`` step was missing from every
+    branch, so two ``T1Database()`` calls in the same Claude session
+    minted distinct UUIDs and could not see each other's entries via
+    the per-entry session_id metadata filter.
+    """
+
+    @pytest.mark.parametrize("path_id", _PATH_IDS)
+    def test_explicit_arg_wins(self, path_id, tmp_path, monkeypatch, fake_chromadb):
+        kwargs, _ = _setup_path(path_id, tmp_path, monkeypatch, fake_chromadb)
+        monkeypatch.setenv("NX_SESSION_ID", "from-env")
+        _write_current_session(tmp_path, "from-file")
+
+        from nexus.db.t1 import T1Database
+        db = T1Database(session_id="from-arg", **kwargs)
+        assert db.session_id == "from-arg"
+
+    @pytest.mark.parametrize("path_id", _PATH_IDS)
+    def test_env_wins_over_current_session_file(
+        self, path_id, tmp_path, monkeypatch, fake_chromadb
+    ):
+        kwargs, _ = _setup_path(path_id, tmp_path, monkeypatch, fake_chromadb)
+        monkeypatch.setenv("NX_SESSION_ID", "from-env")
+        _write_current_session(tmp_path, "from-file")
+
+        from nexus.db.t1 import T1Database
+        db = T1Database(**kwargs)
+        assert db.session_id == "from-env"
+
+    @pytest.mark.parametrize("path_id", _PATH_IDS)
+    def test_current_session_file_wins_over_uuid_fallback(
+        self, path_id, tmp_path, monkeypatch, fake_chromadb
+    ):
+        """Regression: the missing fallback step.
+
+        With env unset and current_session populated, every branch must
+        resolve to the file's contents -- not mint a fresh UUID. This
+        is the load-bearing invariant for cross-process T1 visibility:
+        the MCP server and a Bash-tool sibling both find the same
+        Claude session via the on-disk pointer and converge on its
+        UUID, so each side's session_id metadata filter sees the
+        other's entries.
+        """
+        kwargs, _ = _setup_path(path_id, tmp_path, monkeypatch, fake_chromadb)
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        _write_current_session(tmp_path, "canonical-claude-uuid")
+
+        from nexus.db.t1 import T1Database
+        db = T1Database(**kwargs)
+        assert db.session_id == "canonical-claude-uuid"
+
+    @pytest.mark.parametrize("path_id", _PATH_IDS)
+    def test_uuid_fallback_when_nothing_set(
+        self, path_id, tmp_path, monkeypatch, fake_chromadb
+    ):
+        """Truly anonymous CLI (no env, no file) still gets a fresh
+        UUID -- preserves the pre-fix behaviour for callers running
+        outside any Claude session, e.g. ad-hoc scripting against an
+        explicit ephemeral.
+        """
+        kwargs, _ = _setup_path(path_id, tmp_path, monkeypatch, fake_chromadb)
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        # No current_session file written.
+
+        from nexus.db.t1 import T1Database
+        db = T1Database(**kwargs)
+        # uuid4() strings are 36 chars with four hyphens.
+        assert len(db.session_id) == 36
+        assert db.session_id.count("-") == 4
+
+
+@pytest.mark.integration
+class TestE2ESessionIdSharedAcrossProcesses:
+    """nexus-h8ge: two processes in the same Claude session must
+    converge on the canonical session_id via the on-disk pointer.
+
+    Boots a real chroma HTTP server. Spawns two subprocesses, each
+    with NEITHER ``NX_SESSION_ID`` nor explicit ctor arg set, both
+    pointed at the same ``NEXUS_CONFIG_DIR`` containing a populated
+    ``current_session`` file and an addr file naming the chroma. The
+    test asserts (a) both ``T1Database().session_id`` resolve to the
+    same canonical UUID, and (b) a put from process A is visible from
+    a list in process B.
+
+    This is the missing invariant test that 4.27.0 shipped without.
+    Pre-fix this test fails because each subprocess mints its own
+    UUID and the per-entry session_id metadata filter isolates them.
+    """
+
+    def test_two_subprocesses_share_session_id_via_current_session_file(
+        self, tmp_path
+    ):
+        import shutil
+
+        from nexus.session import (
+            stop_t1_server,
+            unlink_t1_addr,
+            write_claude_session_id,
+            write_t1_addr,
+        )
+
+        host, port, server_pid, chroma_tmpdir = _start_real_chroma()
+        own_pid = os.getpid()
+        canonical = "11111111-2222-3333-4444-555555555555"
+        try:
+            # Populate NEXUS_CONFIG_DIR with: current_session pointer +
+            # an addr file naming the chroma. NX_SESSION_ID stays UNSET
+            # in both subprocesses' env -- they must read the file.
+            env_overlay = {"NEXUS_CONFIG_DIR": str(tmp_path)}
+            for var in ("NX_T1_HOST", "NX_T1_PORT", "NX_SESSION_ID",
+                        "NX_T1_ISOLATED", "NEXUS_SKIP_T1"):
+                env_overlay[var] = ""  # blank-out below
+
+            base_env = {
+                k: v for k, v in os.environ.items()
+                if k not in {"NX_T1_HOST", "NX_T1_PORT", "NX_SESSION_ID",
+                             "NX_T1_ISOLATED", "NEXUS_SKIP_T1"}
+            }
+            base_env["NEXUS_CONFIG_DIR"] = str(tmp_path)
+
+            import nexus.session as _sess
+            real_dir_at_import = _sess._nexus_config_dir_at_import
+            try:
+                # Force the helpers in this test process to use tmp_path.
+                _sess._nexus_config_dir_at_import = (  # type: ignore[attr-defined]
+                    lambda: tmp_path
+                )
+                write_claude_session_id(canonical)
+                write_t1_addr(own_pid, host, port)
+            finally:
+                _sess._nexus_config_dir_at_import = real_dir_at_import
+
+            try:
+                child_code = (
+                    "import os, sys, json\n"
+                    "from nexus.db.t1 import T1Database\n"
+                    "import nexus.session as _sess\n"
+                    "import nexus.db.t1 as _t1\n"
+                    f"_sess.find_immediate_claude_pid = lambda start_pid=None: {own_pid}\n"
+                    f"_t1.find_immediate_claude_pid = lambda start_pid=None: {own_pid}\n"
+                    "action = sys.argv[1]\n"
+                    "db = T1Database()\n"
+                    "if action == 'put':\n"
+                    "    eid = db.put('hello-from-A', tags='shakeout')\n"
+                    "    print(json.dumps({'session_id': db.session_id, 'entry_id': eid}))\n"
+                    "elif action == 'list':\n"
+                    "    items = [e['content'] for e in db.list_entries()]\n"
+                    "    print(json.dumps({'session_id': db.session_id, 'items': items}))\n"
+                )
+
+                proc_a = subprocess.run(
+                    [sys.executable, "-c", child_code, "put"],
+                    capture_output=True, text=True, timeout=30, env=base_env,
+                )
+                assert proc_a.returncode == 0, (
+                    f"put-subprocess failed (rc={proc_a.returncode}): "
+                    f"stdout={proc_a.stdout!r} stderr={proc_a.stderr!r}"
+                )
+                a_result = json.loads(proc_a.stdout.strip())
+
+                proc_b = subprocess.run(
+                    [sys.executable, "-c", child_code, "list"],
+                    capture_output=True, text=True, timeout=30, env=base_env,
+                )
+                assert proc_b.returncode == 0, (
+                    f"list-subprocess failed (rc={proc_b.returncode}): "
+                    f"stdout={proc_b.stdout!r} stderr={proc_b.stderr!r}"
+                )
+                b_result = json.loads(proc_b.stdout.strip())
+
+                # (a) both processes converge on the canonical UUID.
+                assert a_result["session_id"] == canonical, a_result
+                assert b_result["session_id"] == canonical, b_result
+                # (b) put-from-A is visible from list-in-B.
+                assert "hello-from-A" in b_result["items"], b_result
+            finally:
+                unlink_t1_addr(own_pid)
+        finally:
+            stop_t1_server(server_pid)
+            shutil.rmtree(chroma_tmpdir, ignore_errors=True)
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- 4.27.0 shipped a regression: every shell ``nx scratch`` invocation orphans its writes under a fresh per-process UUID; `subagent-start.sh`, `post_compact_hook.sh`, `pre_close_verification_hook.sh`, and `divergence-language-guard.sh` all silently see "No scratch entries." regardless of T1 contents.
- Root cause: RDR-105 P4 deletion of the legacy session-record resolver removed the ``read_claude_session_id()`` fallback from ``T1Database._init_new_discovery``'s session_id chain. Every ``T1Database()`` call without an explicit arg or ``NX_SESSION_ID`` env mints a fresh ``uuid4()``.
- Fix: factor the chain into ``T1Database._resolve_session_id`` and call it from all four construction branches (Path A env, Path B addr file, Path C isolation, client-injection). Make ``read_claude_session_id`` / ``write_claude_session_id`` re-resolve ``NEXUS_CONFIG_DIR`` per call (the import-time ``CLAUDE_SESSION_FILE`` constant was a foot-gun that was masking the test scaffold).

## How it shipped past CI

`tests/test_t1_discovery.py::TestE2EParallelStress` (the "10-parallel stress" test) explicitly sets `NX_SESSION_ID` per worker so each subprocess gets its own scoped view by design. **No test covered "two processes with no NX_SESSION_ID, expects to share Claude session via the on-disk pointer".** The shakeout playbook describes the round-trip in prose but the pass criteria only check "completed without errors" — `nx scratch list` returning "No scratch entries." after a put exits 0, so it ticks green. The deletion-PR docstring claimed `read_claude_session_id()` was "preserved" — meaning in the codebase, not that any code path in `t1.py` actually called it. CI couldn't tell.

## Regression coverage

- ``TestT1DatabaseSessionIdResolution`` (16 unit tests): parametrizes the four resolution scenarios (``explicit-arg-wins``, ``env-wins``, ``file-wins``, ``uuid-fallback``) across all four entry points (``env`` / ``addr_file`` / ``isolation`` / ``client_injection``).
- ``TestE2ESessionIdSharedAcrossProcesses`` (1 integration test): spawns two real subprocesses with NO ``NX_SESSION_ID``, asserts both converge on the on-disk session_id and round-trip a T1 entry. Pre-fix this test fails (each subprocess mints its own UUID); post-fix it passes. This is the invariant test 4.27.0 lacked.

## Verification

- 56 ``test_t1_discovery.py`` unit tests pass; new integration test passes (real chroma round-trip in 6s).
- Adjacent ``test_t1.py`` / ``test_session.py`` / ``test_session_propagation_hypotheses.py`` / ``test_session_end_*.py`` all pass (60 tests).
- Full unit suite: 6595 passed, 33 skipped, 0 failures (10m36s).
- Live re-validation: after ``scripts/reinstall-tool.sh``, the original repro (``nx scratch put && nx scratch list``) now round-trips.

## Out of scope (separate findings from the same shakeout)

The shakeout also surfaced two adjacent issues that I am NOT fixing here:

1. **``NX_T1_ISOLATED=1`` is silently ignored when Path B can fire.** Four-branch order is A → B → C → raise; any shell sibling of a live Claude has a discoverable addr file → Path B wins → HTTP chroma. Operators cannot actually opt into ephemeral inside a session.
2. **``nx tier-status`` lies about T1 attribution.** It uses ``read_claude_session_id`` correctly so the audit log says "session=canonical wrote N scratch entries" — but pre-fix the chunks were under fresh per-process UUIDs. Post this PR they're under canonical too, so the lie evaporates as a side effect; but the underlying surface asymmetry is worth its own audit.

Both are tracked as follow-up notes on bead ``nexus-h8ge``.

## Closes

Fixes the production regression discovered in the live 4.27.0 shakeout (bead ``nexus-h8ge``).

## Test plan

- [x] ``uv run pytest tests/test_t1_discovery.py``
- [x] ``uv run pytest tests/test_t1_discovery.py -m integration``
- [x] ``uv run pytest`` (full unit suite)
- [x] Live re-validation: ``scripts/reinstall-tool.sh && nx scratch put X && nx scratch list``
- [ ] Reviewer to verify the existing ``test_env_wins_over_file`` precedence test still asserts what it intends (the new helper preserves the chain).