### PR TITLE
feat(catalog): re-expose synthesize-log CLI verb (nexus-hh1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`nx catalog synthesize-log` CLI verb** (issue #591, nexus-hh1b):
+  in-place lossless recovery for catalogs in bootstrap-fallback mode.
+  The `synthesize_from_jsonl` synthesizer code has always been present
+  in `src/nexus/catalog/synthesizer.py`; only the CLI handler was
+  retired post Phase 5b (nexus-iftc). The previous `nx catalog doctor`
+  warning told operators to delete the catalog directory and re-run
+  `nx catalog setup`, which is destructive: setup bootstraps owners
+  and documents from current T3 state but cannot reconstruct user-
+  authored typed links (`relates`, `cites`, `implements`,
+  `supersedes`) because T3 stores chunks, not the catalog graph. On a
+  real-world catalog (15,853 docs / 533 links / 41 owners) this
+  produced 99% link loss in field reports.
+
+  Re-exposing the synthesizer behind a CLI handler restores the
+  zero-loss recovery path. Flags: `--check` (detect fallback, exit 1
+  if active), `--dry-run` (print event counts, write nothing),
+  `--no-verify` (skip post-write replay-equality check), `--force`
+  (synthesize on a healthy catalog, harvesting and preserving the
+  existing event-log `tumbler->doc_id` map so T3 chunk metadata
+  stays valid). Default invocation snapshots the entire catalog
+  directory to a sibling `<catalog>.synth-snapshot-<ts>/` before
+  writing, performs an atomic write of `events.jsonl`, runs the
+  doctor's `--replay-equality` check, and on FAIL rotates the
+  failed live state aside and restores the catalog from the snapshot
+  via `copytree` so all three artifacts (pristine snapshot, failed
+  state, restored catalog) are retained for forensics. `nx catalog
+  doctor` warning text updated to direct operators at the new verb
+  and label the destructive `setup` path as a lossy fallback.
+
 ## [4.27.1] - 2026-05-08
 
 Patch release. Closes a critical T1 regression introduced by RDR-105

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3844,6 +3844,200 @@ def prune_stale_cmd(
                f"{'y' if n_deleted == 1 else 'ies'}.")
 
 
+# ── RDR-101 Phase 2: synthesize-log (in-place fallback recovery) ─────────
+
+
+@catalog.command("synthesize-log")
+@click.option(
+    "--check", is_flag=True,
+    help=(
+        "Detect bootstrap-fallback mode without writing. Exit 0 when not "
+        "in fallback, exit 1 when fallback is active."
+    ),
+)
+@click.option(
+    "--dry-run", is_flag=True,
+    help="Print event counts that would be synthesized; write nothing.",
+)
+@click.option(
+    "--no-verify", is_flag=True,
+    help=(
+        "Skip the post-write replay-equality verification. Use only when "
+        "you have already verified the catalog independently."
+    ),
+)
+@click.option(
+    "--force", is_flag=True,
+    help=(
+        "Synthesize even when the catalog is not in bootstrap-fallback. "
+        "Existing event-log doc_ids are harvested and preserved so that "
+        "T3 chunk metadata referencing them does not become stale."
+    ),
+)
+def synthesize_log_cmd(
+    check: bool, dry_run: bool, no_verify: bool, force: bool
+) -> None:
+    """Rebuild ``events.jsonl`` from the catalog's JSONL state in place.
+
+    Companion to ``nx catalog doctor`` for catalogs in bootstrap-fallback
+    mode. Calls ``nexus.catalog.synthesizer.synthesize_from_jsonl`` with
+    ``mint_doc_id=True`` and writes the resulting envelope stream to
+    ``events.jsonl`` atomically. Snapshots the entire catalog directory
+    before touching it; on a verify FAIL, rolls the snapshot back into
+    place and retains both copies for forensics.
+
+    Lossless alternative to ``rm -rf catalog && nx catalog setup``, which
+    discards user-authored typed links and owner registrations because
+    those are not reconstructible from T3 alone.
+    """
+    import dataclasses
+    import shutil
+    import time
+    from datetime import datetime, timezone
+
+    from nexus.config import catalog_path
+    from nexus.catalog import events as ev
+    from nexus.catalog.synthesizer import synthesize_from_jsonl
+
+    cat_path = catalog_path()
+    if not Catalog.is_initialized(cat_path):
+        raise click.ClickException(
+            f"Catalog at {cat_path} is not initialized. "
+            "Run 'nx catalog setup' first."
+        )
+
+    bootstrap_status = _check_bootstrap_status()
+    fallback_active = bool(bootstrap_status.get("fallback_active"))
+
+    if check:
+        if fallback_active:
+            click.echo(
+                "fallback-active: events.jsonl is sparse vs documents.jsonl. "
+                "Run 'nx catalog synthesize-log' to repair in place.",
+                err=True,
+            )
+            raise click.exceptions.Exit(1)
+        click.echo("not-in-fallback: events.jsonl matches documents.jsonl.")
+        return
+
+    if not fallback_active and not force:
+        click.echo(
+            "no-op: catalog is not in bootstrap-fallback mode. "
+            "Pass --force to synthesize anyway."
+        )
+        return
+
+    # --force on a healthy catalog: harvest existing tumbler->doc_id from
+    # events.jsonl so re-synthesis preserves T3-side doc_id references.
+    preserve_doc_ids: dict[str, str] = {}
+    events_path = cat_path / "events.jsonl"
+    if force and events_path.exists():
+        with events_path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("type") != ev.TYPE_DOCUMENT_REGISTERED:
+                    continue
+                payload = obj.get("payload") or {}
+                tumbler = payload.get("tumbler")
+                doc_id = payload.get("doc_id")
+                if tumbler and doc_id:
+                    preserve_doc_ids[tumbler] = doc_id
+
+    # Synthesize the full event stream into memory and tally per-type.
+    events_list = list(
+        synthesize_from_jsonl(
+            cat_path,
+            mint_doc_id=True,
+            preserve_doc_ids=preserve_doc_ids or None,
+        )
+    )
+    counts: dict[str, int] = {}
+    for e in events_list:
+        counts[e.type] = counts.get(e.type, 0) + 1
+    total = sum(counts.values())
+
+    click.echo("== synthesizing events ==")
+    for type_name in sorted(counts):
+        click.echo(f"  {type_name:<28} {counts[type_name]:>6}")
+    click.echo(f"  {'TOTAL':<28} {total:>6}")
+
+    if dry_run:
+        click.echo("(dry-run: no files written)")
+        return
+
+    # Snapshot the entire catalog directory to a sibling. Forensic
+    # retention: this command never deletes the snapshot, even on PASS.
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    snapshot_dir = cat_path.parent / f"{cat_path.name}.synth-snapshot-{ts}"
+    if snapshot_dir.exists():
+        # Disambiguate when a prior run within the same second exists.
+        snapshot_dir = cat_path.parent / (
+            f"{cat_path.name}.synth-snapshot-{ts}-{int(time.time() * 1000) % 1000}"
+        )
+    shutil.copytree(cat_path, snapshot_dir)
+    click.echo(f"snapshot: {snapshot_dir}")
+
+    # Atomic write: serialize to events.jsonl.tmp, fsync, rename.
+    tmp_path = events_path.with_suffix(".jsonl.tmp")
+    with tmp_path.open("w") as f:
+        for e in events_list:
+            line = json.dumps(
+                {
+                    "type": e.type,
+                    "v": e.v,
+                    "payload": dataclasses.asdict(e.payload),
+                    "ts": e.ts,
+                },
+                separators=(",", ":"),
+            )
+            f.write(line)
+            f.write("\n")
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, events_path)
+    click.echo(f"wrote: {events_path} ({total} events)")
+
+    if no_verify:
+        click.echo("PASS (verify skipped via --no-verify)")
+        return
+
+    # Verify by re-running the doctor's replay-equality check against
+    # the freshly-written log. _run_replay_equality reads catalog_path()
+    # so it picks up the new state automatically.
+    report = _run_replay_equality()
+    if report.get("pass"):
+        click.echo("PASS: replay-equality verified against fresh log.")
+        click.echo(f"snapshot retained for forensics: {snapshot_dir}")
+        return
+
+    # Verify FAIL: rotate the failed live state aside, restore from the
+    # snapshot via copytree. Snapshot is left pristine so the operator
+    # has three artifacts for forensics: the pristine pre-synthesis
+    # snapshot, the failed live state, and the restored live catalog.
+    failed_dir = cat_path.parent / f"{cat_path.name}.synth-failed-{ts}"
+    if failed_dir.exists():
+        failed_dir = cat_path.parent / (
+            f"{cat_path.name}.synth-failed-{ts}-{int(time.time() * 1000) % 1000}"
+        )
+    os.rename(cat_path, failed_dir)
+    shutil.copytree(snapshot_dir, cat_path)
+
+    click.echo(
+        f"FAIL: replay-equality verification did not pass: {report}",
+        err=True,
+    )
+    click.echo(f"failed-state retained: {failed_dir}", err=True)
+    click.echo(f"snapshot retained: {snapshot_dir}", err=True)
+    click.echo(f"catalog restored from snapshot at: {cat_path}", err=True)
+    raise click.exceptions.Exit(1)
+
+
 # ── RDR-101 Phase 1: doctor --replay-equality ────────────────────────────
 
 
@@ -3954,10 +4148,14 @@ def doctor_cmd(
                 "  events.jsonl is non-empty but sparse vs documents.jsonl;\n"
                 "  ES writes are landing in the log but reads come from\n"
                 "  legacy JSONL; replay equality is silently broken.\n"
-                "  The synthesize-log + t3-backfill-doc-id remediation\n"
-                "  verbs were retired post Phase 5b (nexus-iftc). Restore\n"
-                "  by deleting the catalog directory and re-running\n"
-                "  'nx catalog setup' to bootstrap from current T3 state.\n",
+                "\n"
+                "  Restore in place with:\n"
+                "    nx catalog synthesize-log\n"
+                "\n"
+                "  This rebuilds events.jsonl from the JSONL state with\n"
+                "  zero data loss. 'nx catalog setup' from a clean state\n"
+                "  is a lossy fallback - it cannot reconstruct user-\n"
+                "  authored typed links or owner registrations from T3.\n",
                 err=True,
             )
         overall_pass = False

--- a/tests/test_catalog_synthesize_log.py
+++ b/tests/test_catalog_synthesize_log.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for `nx catalog synthesize-log` (issue #591 / nexus-hh1b).
+
+Covers:
+- --check exit codes (0 when not in fallback, 1 when fallback active)
+- --dry-run prints event counts and writes nothing
+- happy-path round-trip: fallback catalog -> synthesize-log -> fallback cleared
+- no-op when not in fallback (without --force)
+- --force re-synthesizes and preserves existing doc_ids
+- snapshot is created and retained on PASS
+- --no-verify skips post-write verification
+- auto-restore on verify FAIL (snapshot rotated back into place)
+- doctor warning text directs to synthesize-log
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.cli import main
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _write_event_line(events_path: Path, payload_dict: dict) -> None:
+    """Append one JSONL event envelope. Mirrors the helper in
+    tests/test_catalog_mcp_bootstrap_fallback.py."""
+    events_path.parent.mkdir(parents=True, exist_ok=True)
+    with events_path.open("a") as f:
+        f.write(json.dumps(payload_dict, separators=(",", ":")))
+        f.write("\n")
+
+
+@pytest.fixture(autouse=True)
+def git_identity(monkeypatch):
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
+
+@pytest.fixture
+def catalog_env(tmp_path, monkeypatch):
+    catalog_dir = tmp_path / "catalog"
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+    return catalog_dir
+
+
+@pytest.fixture
+def healthy_catalog(catalog_env, monkeypatch):
+    """A catalog with parity between events.jsonl and documents.jsonl."""
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    Catalog.init(catalog_env)
+    cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab1234")
+    for i in range(3):
+        cat.register(
+            owner, f"doc-{i}.md",
+            content_type="prose",
+            file_path=f"doc-{i}.md",
+        )
+    cat._db.close()
+    return catalog_env
+
+
+@pytest.fixture
+def fallback_catalog(catalog_env, monkeypatch):
+    """A catalog wedged into bootstrap-fallback state.
+
+    10 legacy DocumentRegistered rows in documents.jsonl, only one stray
+    event in events.jsonl - sparse enough to trip the 95% guardrail.
+    """
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "0")
+    Catalog.init(catalog_env)
+    cat = Catalog(catalog_env, catalog_env / ".catalog.db")
+    owner = cat.register_owner("nexus", "repo", repo_hash="abab1234")
+    for i in range(10):
+        cat.register(
+            owner, f"doc-{i}.md",
+            content_type="prose",
+            file_path=f"doc-{i}.md",
+        )
+    cat._db.close()
+
+    events_path = catalog_env / "events.jsonl"
+    _write_event_line(events_path, {
+        "type": "DocumentRegistered", "v": 0,
+        "payload": {
+            "doc_id": "1.1.99", "owner_id": "1.1",
+            "content_type": "prose", "source_uri": "",
+            "coll_id": "", "title": "stray.md", "tumbler": "1.1.99",
+            "author": "", "year": 0, "file_path": "stray.md",
+            "corpus": "", "physical_collection": "",
+            "chunk_count": 0, "head_hash": "", "indexed_at": "",
+            "alias_of": "", "meta": {}, "source_mtime": 0.0,
+            "indexed_at_doc": "",
+        },
+        "ts": "2026-05-01T00:00:00+00:00",
+    })
+
+    monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+    return catalog_env
+
+
+# ─────────────────────────────────────────────────────────────────────
+# --check
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestCheckMode:
+    def test_check_returns_0_when_not_in_fallback(self, healthy_catalog):
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "synthesize-log", "--check"])
+        assert result.exit_code == 0, result.output
+        assert "fallback" in result.output.lower()
+
+    def test_check_returns_1_when_fallback_active(self, fallback_catalog):
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "synthesize-log", "--check"])
+        assert result.exit_code == 1
+        assert "fallback" in result.output.lower()
+
+    def test_check_does_not_write(self, fallback_catalog):
+        events_path = fallback_catalog / "events.jsonl"
+        before = events_path.read_bytes()
+        runner = CliRunner()
+        runner.invoke(main, ["catalog", "synthesize-log", "--check"])
+        after = events_path.read_bytes()
+        assert before == after
+
+
+# ─────────────────────────────────────────────────────────────────────
+# --dry-run
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestDryRun:
+    def test_dry_run_prints_event_counts(self, fallback_catalog):
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "synthesize-log", "--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "DocumentRegistered" in result.output
+        assert "OwnerRegistered" in result.output
+        assert "TOTAL" in result.output
+
+    def test_dry_run_does_not_modify_events_log(self, fallback_catalog):
+        events_path = fallback_catalog / "events.jsonl"
+        before = events_path.read_bytes()
+        runner = CliRunner()
+        runner.invoke(main, ["catalog", "synthesize-log", "--dry-run"])
+        after = events_path.read_bytes()
+        assert before == after
+
+    def test_dry_run_creates_no_snapshot(self, fallback_catalog):
+        runner = CliRunner()
+        runner.invoke(main, ["catalog", "synthesize-log", "--dry-run"])
+        siblings = list(fallback_catalog.parent.iterdir())
+        snapshots = [p for p in siblings if "synth-snapshot" in p.name]
+        assert snapshots == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Happy path
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestHappyPath:
+    def test_synthesize_clears_fallback(self, fallback_catalog):
+        from nexus.commands.catalog import _check_bootstrap_status
+
+        assert _check_bootstrap_status()["fallback_active"] is True
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "synthesize-log"])
+        assert result.exit_code == 0, result.output
+
+        post = _check_bootstrap_status()
+        assert post["fallback_active"] is False, post
+
+    def test_synthesize_retains_snapshot_on_pass(self, fallback_catalog):
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "synthesize-log"])
+        assert result.exit_code == 0, result.output
+
+        siblings = list(fallback_catalog.parent.iterdir())
+        snapshots = [p for p in siblings if "synth-snapshot" in p.name]
+        assert len(snapshots) == 1, [p.name for p in siblings]
+        assert (snapshots[0] / "events.jsonl").exists()
+
+    def test_synthesize_replay_equality_passes_after(self, fallback_catalog):
+        from nexus.commands.catalog import _run_replay_equality
+
+        runner = CliRunner()
+        runner.invoke(main, ["catalog", "synthesize-log"])
+
+        report = _run_replay_equality()
+        assert report["pass"] is True, report
+
+    def test_no_op_when_not_in_fallback(self, healthy_catalog):
+        events_path = healthy_catalog / "events.jsonl"
+        before = events_path.read_bytes()
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "synthesize-log"])
+        assert result.exit_code == 0
+        assert "no-op" in result.output.lower() or "not in fallback" in result.output.lower()
+
+        assert events_path.read_bytes() == before
+
+
+# ─────────────────────────────────────────────────────────────────────
+# --force
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestForce:
+    def _doc_id_map(self, events_path: Path) -> dict[str, str]:
+        out: dict[str, str] = {}
+        with events_path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if obj.get("type") != "DocumentRegistered":
+                    continue
+                payload = obj.get("payload") or {}
+                tumbler = payload.get("tumbler")
+                doc_id = payload.get("doc_id")
+                if tumbler and doc_id:
+                    out[tumbler] = doc_id
+        return out
+
+    def test_force_synthesizes_when_not_in_fallback(self, healthy_catalog):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["catalog", "synthesize-log", "--force"]
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_force_preserves_doc_ids_across_runs(self, fallback_catalog):
+        runner = CliRunner()
+        # First synthesis: fallback -> healthy.
+        r1 = runner.invoke(main, ["catalog", "synthesize-log"])
+        assert r1.exit_code == 0, r1.output
+        first_map = self._doc_id_map(fallback_catalog / "events.jsonl")
+        assert first_map, "first synthesis produced no doc_id mappings"
+
+        # Second synthesis with --force: doc_ids must round-trip.
+        r2 = runner.invoke(main, ["catalog", "synthesize-log", "--force"])
+        assert r2.exit_code == 0, r2.output
+        second_map = self._doc_id_map(fallback_catalog / "events.jsonl")
+
+        assert second_map == first_map, (
+            "doc_ids drifted across --force re-synthesis "
+            "(would invalidate downstream T3 metadata)"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# --no-verify
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestNoVerify:
+    def test_no_verify_skips_replay_equality(self, fallback_catalog, monkeypatch):
+        called = {"flag": False}
+
+        def _spy():
+            called["flag"] = True
+            return {"pass": True}
+
+        monkeypatch.setattr(
+            "nexus.commands.catalog._run_replay_equality", _spy
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["catalog", "synthesize-log", "--no-verify"]
+        )
+        assert result.exit_code == 0, result.output
+        assert called["flag"] is False, "verify ran despite --no-verify"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Auto-restore
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestAutoRestore:
+    def test_verify_failure_restores_snapshot(self, fallback_catalog, monkeypatch):
+        events_path = fallback_catalog / "events.jsonl"
+        pre = events_path.read_bytes()
+
+        def _failing_verify():
+            return {"pass": False, "reason": "synthetic test failure"}
+
+        monkeypatch.setattr(
+            "nexus.commands.catalog._run_replay_equality", _failing_verify
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["catalog", "synthesize-log"])
+        assert result.exit_code == 1
+
+        # Live catalog content matches pre-synthesis exactly.
+        assert events_path.read_bytes() == pre
+
+        siblings = list(fallback_catalog.parent.iterdir())
+        snapshots = [p for p in siblings if "synth-snapshot" in p.name]
+        failed = [p for p in siblings if "synth-failed" in p.name]
+        assert len(snapshots) == 1, (
+            f"expected snapshot retained, got: {[p.name for p in siblings]}"
+        )
+        assert len(failed) == 1, (
+            f"expected failed-state retained, got: {[p.name for p in siblings]}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Doctor warning text update
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestDoctorWarningText:
+    def test_warning_points_to_synthesize_log(self, fallback_catalog):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["catalog", "doctor", "--replay-equality"]
+        )
+        # Doctor warning is emitted on stderr; CliRunner merges by default.
+        combined = (result.output or "") + (result.stderr or "" if result.stderr_bytes is not None else "")
+        assert "synthesize-log" in combined, combined
+        assert "delete the catalog directory" not in combined.lower(), (
+            "stale lossy guidance still present"
+        )


### PR DESCRIPTION
## Summary

- Re-expose `nexus.catalog.synthesizer.synthesize_from_jsonl` as `nx catalog synthesize-log`. Synthesizer code has always existed; only the CLI handler was retired post Phase 5b. Lossless alternative to the destructive `rm catalog && nx catalog setup` path that the doctor warning previously recommended.
- Flags: `--check`, `--dry-run`, `--no-verify`, `--force`. Default invocation snapshots the catalog directory, atomic-writes `events.jsonl`, verifies via the doctor's `_run_replay_equality`, and on FAIL rotates the failed live state aside and `copytree`s the snapshot back into place. Snapshot remains pristine for forensics.
- `nx catalog doctor` bootstrap-fallback warning text rewritten to direct operators at the new verb and label the destructive setup path as a lossy fallback.

## Test plan

- [x] 15 new tests in `tests/test_catalog_synthesize_log.py`: --check/--dry-run/happy-path/--force/--no-verify/auto-restore/doctor-warning-text. All passing.
- [x] Neighbouring catalog test files unaffected: `test_catalog_doctor_replay_equality.py`, `test_catalog_mcp_bootstrap_fallback.py`, `test_catalog_cli.py` (98 tests passing).
- [x] Local install + smoke against live ~/.config/nexus/catalog (23k docs, not in fallback): `--check` reports `not-in-fallback`, default invocation no-ops with exit 0.

## Closes

Closes #591