### PR TITLE
fix(t1): NX_T1_ISOLATED=1 outranks discovery (nexus-svpq)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`NX_T1_ISOLATED=1` precedence inside Claude sessions** (issue #593,
+  nexus-svpq): pre-fix, ``T1Database._init_new_discovery``'s four-branch
+  gate ran in order Path A (env-pair) -> Path B (addr file) -> Path C
+  (isolation flag) -> raise. Inside an active Claude session, Path B
+  always resolved a sibling MCP T1 via ``find_immediate_claude_pid()`` +
+  ``read_t1_addr_for(pid)`` and short-circuited before the
+  ``_t1_isolated_env()`` check fired. Operators who ran
+  ``NX_T1_ISOLATED=1 nx scratch ...`` from a sibling shell expected an
+  in-process ``EphemeralClient`` sealed from the live MCP T1; they got
+  an ``HttpClient`` against the live T1 instead. The 4.27.0 CHANGELOG
+  line "Operators who want ephemeral semantics opt in via
+  ``NX_T1_ISOLATED=1``" was true only outside a Claude session.
+
+  Fix: hoist Path C above Paths A and B so an explicit operator opt-in
+  outranks env-pair and addr-file auto-discovery. ``NX_T1_HOST`` /
+  ``NX_T1_PORT`` and the ``~/.config/nexus/t1_addr.<pid>`` file are
+  inheritance / discovery signals; ``NX_T1_ISOLATED=1`` is a deliberate
+  operator action, and opt-ins outrank discovery (consistent with the
+  pre-4.27 ``NEXUS_SKIP_T1=1`` semantics that the env-rename preserved).
+  Regression coverage in
+  ``tests/test_t1_discovery.py::TestT1DatabaseIsolatedOverridesDiscovery``
+  asserts isolated wins over env-pair, over addr-file, and over both
+  simultaneously, plus that the deprecated ``NEXUS_SKIP_T1=1`` alias
+  retains the same override semantics through the deprecation cycle.
+
 ### Added
 
 - **`nx catalog synthesize-log` CLI verb** (issue #591, nexus-hh1b):

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -174,26 +174,35 @@ class T1Database:
     def _init_new_discovery(self, chromadb, session_id: str | None) -> None:
         """RDR-105 P2 (nexus-mj2o): four-branch fail-loud constructor.
 
-        Branch order (signal hierarchy mirrors the lifespan):
+        Branch order (opt-in outranks discovery):
 
-        Path A
-            ``NX_T1_HOST`` + ``NX_T1_PORT`` in env -> ``HttpClient``.
-            Used by MCP-dispatched subprocesses (``claude -p`` shared).
-        Path B
-            ``find_immediate_claude_pid`` resolves to a live addr file
-            at ``~/.config/nexus/t1_addr.<pid>`` -> ``HttpClient``.
-            Used by Claude-Code-spawned siblings (Bash tool, hooks).
-        Path C
+        Path C (operator opt-in, highest priority)
             ``NX_T1_ISOLATED=1`` (or its legacy ``NEXUS_SKIP_T1=1``
             alias) -> ``EphemeralClient``. The only place
             ``EphemeralClient`` may be constructed in this code path.
-        Path D
+            nexus-svpq / GH #593: this branch is consulted FIRST so an
+            explicit operator opt-in to ephemeral semantics is not
+            silently overridden by env-pair or addr-file auto-discovery
+            inside an active Claude session.
+        Path A (env-pair discovery)
+            ``NX_T1_HOST`` + ``NX_T1_PORT`` in env -> ``HttpClient``.
+            Used by MCP-dispatched subprocesses (``claude -p`` shared).
+        Path B (addr-file discovery)
+            ``find_immediate_claude_pid`` resolves to a live addr file
+            at ``~/.config/nexus/t1_addr.<pid>`` -> ``HttpClient``.
+            Used by Claude-Code-spawned siblings (Bash tool, hooks).
+        Path D (failure)
             None of the above -> raise :class:`T1ServerNotFoundError`.
 
         The flag-on path does NOT fall through to the legacy resolver.
         Per the RDR §'Phase 2 flag-isolation contract', flag-on and
         flag-off paths are mutually exclusive per process.
         """
+        if _t1_isolated_env():
+            self._client = chromadb.EphemeralClient()
+            self._session_id = self._resolve_session_id(session_id)
+            return
+
         host_env = os.environ.get("NX_T1_HOST", "").strip()
         port_env = os.environ.get("NX_T1_PORT", "").strip()
         if host_env and port_env:
@@ -216,11 +225,6 @@ class T1Database:
                 self._client = chromadb.HttpClient(host=host, port=port)
                 self._session_id = self._resolve_session_id(session_id)
                 return
-
-        if _t1_isolated_env():
-            self._client = chromadb.EphemeralClient()
-            self._session_id = self._resolve_session_id(session_id)
-            return
 
         raise T1ServerNotFoundError(
             "T1 not configured for this process. Either inherit "

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -544,6 +544,106 @@ class TestT1DatabaseFlagOnPrecedence:
         fake_chromadb.HttpClient.assert_called_once_with(host="10.0.0.1", port=1111)
 
 
+class TestT1DatabaseIsolatedOverridesDiscovery:
+    """nexus-svpq / GH #593: ``NX_T1_ISOLATED=1`` is an explicit operator
+    opt-in and must outrank both env-pair (Path A) and addr-file (Path B)
+    auto-discovery. Pre-fix, Path C only fired when Paths A and B both
+    missed, so an operator setting the flag from inside a Claude session
+    silently wrote into the live MCP-owned T1 instead of a sealed
+    EphemeralClient.
+    """
+
+    def test_isolated_wins_over_env_pair(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        fake_chromadb = MagicMock()
+        fake_chromadb.HttpClient.return_value = MagicMock()
+        fake_chromadb.EphemeralClient.return_value = MagicMock()
+        monkeypatch.setitem(sys.modules, "chromadb", fake_chromadb)
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("NX_T1_HOST", "10.0.0.1")
+        monkeypatch.setenv("NX_T1_PORT", "1111")
+        monkeypatch.setenv("NX_T1_ISOLATED", "1")
+        monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+
+        from nexus.db.t1 import T1Database
+        T1Database()
+
+        fake_chromadb.EphemeralClient.assert_called_once()
+        fake_chromadb.HttpClient.assert_not_called()
+
+    def test_isolated_wins_over_addr_file(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        fake_chromadb = MagicMock()
+        fake_chromadb.HttpClient.return_value = MagicMock()
+        fake_chromadb.EphemeralClient.return_value = MagicMock()
+        monkeypatch.setitem(sys.modules, "chromadb", fake_chromadb)
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        for var in ("NX_T1_HOST", "NX_T1_PORT", "NEXUS_SKIP_T1"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("NX_T1_ISOLATED", "1")
+
+        from nexus.session import write_t1_addr
+        write_t1_addr(44444, "10.0.0.2", 2222)
+
+        with patch("nexus.db.t1.find_immediate_claude_pid", return_value=44444):
+            from nexus.db.t1 import T1Database
+            T1Database()
+
+        fake_chromadb.EphemeralClient.assert_called_once()
+        fake_chromadb.HttpClient.assert_not_called()
+
+    def test_isolated_wins_over_env_pair_and_addr_file(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        fake_chromadb = MagicMock()
+        fake_chromadb.HttpClient.return_value = MagicMock()
+        fake_chromadb.EphemeralClient.return_value = MagicMock()
+        monkeypatch.setitem(sys.modules, "chromadb", fake_chromadb)
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("NX_T1_HOST", "10.0.0.1")
+        monkeypatch.setenv("NX_T1_PORT", "1111")
+        monkeypatch.setenv("NX_T1_ISOLATED", "1")
+        monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+
+        from nexus.session import write_t1_addr
+        write_t1_addr(55555, "10.0.0.3", 3333)
+
+        with patch("nexus.db.t1.find_immediate_claude_pid", return_value=55555):
+            from nexus.db.t1 import T1Database
+            T1Database()
+
+        fake_chromadb.EphemeralClient.assert_called_once()
+        fake_chromadb.HttpClient.assert_not_called()
+
+    def test_legacy_skip_t1_alias_still_overrides_discovery(self, tmp_path, monkeypatch):
+        """``NEXUS_SKIP_T1=1`` is honoured as a deprecated alias for the
+        4.27 -> 4.28 cycle (per CLAUDE.md / RDR-105). The override must
+        apply through the alias path too."""
+        from unittest.mock import MagicMock
+
+        fake_chromadb = MagicMock()
+        fake_chromadb.HttpClient.return_value = MagicMock()
+        fake_chromadb.EphemeralClient.return_value = MagicMock()
+        monkeypatch.setitem(sys.modules, "chromadb", fake_chromadb)
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("NX_T1_HOST", "10.0.0.1")
+        monkeypatch.setenv("NX_T1_PORT", "1111")
+        monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
+        monkeypatch.setenv("NEXUS_SKIP_T1", "1")
+
+        from nexus.db.t1 import T1Database
+        T1Database()
+
+        fake_chromadb.EphemeralClient.assert_called_once()
+        fake_chromadb.HttpClient.assert_not_called()
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # session_id resolution chain (nexus-h8ge regression)
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Hoist the `_t1_isolated_env()` check above Path A (env-pair) and Path B (addr-file) in `T1Database._init_new_discovery`. Explicit operator opt-ins (`NX_T1_ISOLATED=1` and the deprecated `NEXUS_SKIP_T1=1` alias) now outrank auto-discovery so `NX_T1_ISOLATED=1 nx scratch ...` from a Claude-session sibling produces a sealed in-process `EphemeralClient`, not an `HttpClient` against the live MCP T1.
- Restores the pre-4.27 semantics that the env rename was supposed to preserve. Listed as "Known issue, deferred" in the 4.27.1 CHANGELOG.

## Test plan

- [x] 4 new unit tests in `tests/test_t1_discovery.py::TestT1DatabaseIsolatedOverridesDiscovery`: isolated wins over env, over addr-file, over both simultaneously, and the legacy `NEXUS_SKIP_T1=1` alias retains override semantics. All four fail pre-fix and pass post-fix.
- [x] Full T1 sweep (74 tests, `tests/test_t1.py` + `tests/test_t1_discovery.py`) passing.
- [x] Local install + live shakeout: `NX_T1_ISOLATED=1 nx scratch put` is invisible to a sibling `nx scratch list`; non-isolated `nx scratch put` still round-trips through the live MCP T1 unchanged.

## Closes

Closes #593