### PR TITLE
refactor(session): unify session_id resolution chain (nexus-9e9a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Single source of truth for the Claude session_id chain** (issue
+  #594, nexus-9e9a): introduce ``nexus.session.resolve_active_session_id``
+  and route the three open-coded callsites
+  (``T1Database._resolve_session_id``, ``mcp/core._record_tier_write``,
+  ``_session_end_launcher._print_tier_status_summary``) through it.
+  Pre-PR each site implemented ``NX_SESSION_ID env >
+  read_claude_session_id() > <fallback>`` independently with three
+  divergent fallbacks: ``uuid4()`` (T1), ``"unknown"``
+  (``_record_tier_write``), and no fallback (launcher). The drift
+  between the first two was the exact bug class that produced PR #590
+  / nexus-h8ge -- the audit log and the T1 chunk store disagreed on
+  attribution because each site mutated its chain independently.
+
+  ``T1Database`` and ``_record_tier_write`` now both fall back to
+  ``"unknown"`` so the audit log and the T1 chunk store agree on
+  attribution: rows under ``"unknown"`` are exactly the rows from
+  processes that did not bind to a Claude session, grep-able for
+  forensics. Behaviour change: T1 no longer mints a per-process
+  ``uuid4()`` for an anonymous CLI run -- the existing
+  ``test_uuid_fallback_when_nothing_set`` regression test (now
+  ``test_unknown_fallback_when_nothing_set``) was locking in the
+  drift-prone behaviour. The launcher still short-circuits when the
+  resolver returns ``None`` (no useful per-session summary without a
+  bound session; querying ``WHERE session_id = "unknown"`` would leak
+  rows from unrelated invocations into the user-facing summary).
+
+  Regression coverage in ``tests/test_session_resolver.py`` (12 tests):
+  six chain-semantics tests pin the resolver's behaviour, six callsite
+  tests assert each of the three sites routes through the helper and
+  applies its documented fallback. Future changes to the chain happen
+  in one place or surface here.
+
 ### Fixed
 
 - **`NX_T1_ISOLATED=1` precedence inside Claude sessions** (issue #593,

--- a/src/nexus/_session_end_launcher.py
+++ b/src/nexus/_session_end_launcher.py
@@ -133,21 +133,25 @@ def _print_tier_status_summary() -> None:
     printing for a transactional session that didn't intend to
     persist anything).
 
-    Resolution: NX_SESSION_ID env, then read_claude_session_id from
-    the session file. Mirrors the same chain ``nx tier-status``
-    uses so the two surfaces agree.
+    Resolution: delegates to
+    :func:`nexus.session.resolve_active_session_id`. Short-circuits
+    when no session is bound -- a per-session summary makes no sense
+    without a session, and querying ``WHERE session_id = "unknown"``
+    would leak rows from unrelated invocations into the user-facing
+    summary.
+
+    Issue #594 / nexus-9e9a: this site shares the resolution chain
+    with the T1 chunk store and the tier-write audit log, so the
+    three surfaces never disagree on attribution.
     """
     try:
         import sqlite3
         from pathlib import Path
 
         from nexus.commands._helpers import default_db_path
-        from nexus.session import read_claude_session_id
+        from nexus.session import resolve_active_session_id
 
-        session_id = (
-            os.environ.get("NX_SESSION_ID", "").strip()
-            or read_claude_session_id()
-        )
+        session_id = resolve_active_session_id()
         if not session_id:
             return
         db_path = default_db_path()

--- a/src/nexus/db/t1.py
+++ b/src/nexus/db/t1.py
@@ -21,8 +21,8 @@ def _now_iso() -> str:
 from nexus.session import (
     _t1_isolated_env,
     find_immediate_claude_pid,
-    read_claude_session_id,
     read_t1_addr_for,
+    resolve_active_session_id,
 )
 
 _T = TypeVar("_T")
@@ -148,28 +148,25 @@ class T1Database:
     def _resolve_session_id(arg: str | None) -> str:
         """Resolve the session_id used as the per-entry metadata filter.
 
-        Chain: explicit ctor arg > ``NX_SESSION_ID`` env >
-        ``read_claude_session_id()`` (~/.config/nexus/current_session)
-        > new ``uuid4()``.
+        Delegates to :func:`nexus.session.resolve_active_session_id` and
+        substitutes ``"unknown"`` when the chain returns ``None``.
 
-        The ``read_claude_session_id()`` step is the load-bearing
-        fallback for cross-process T1 visibility (nexus-h8ge): the MCP
-        server, a Bash-tool sibling, and a hook subprocess all find
-        the same Claude session via the on-disk pointer and converge
-        on its UUID, so each side's session_id metadata filter sees
-        the others' entries. Pre-fix this step was missing in every
-        construction branch and every shell ``nx scratch`` invocation
-        orphaned its writes under a fresh per-process UUID,
-        breaking every nx-plugin hook that read T1 from the shell
-        (subagent-start, post_compact, pre_close_verification,
-        divergence-language-guard).
+        The per-entry session_id is the metadata filter key on every
+        chunk; it must never be empty. ``"unknown"`` is the canonical
+        sentinel: when no session is bound, the audit log
+        (``mcp/core._record_tier_write``) and the T1 chunk store agree
+        on attribution and operators can grep for "unknown" to find
+        rows that did not bind to a Claude session.
+
+        Pre-issue-#594 this method open-coded the chain and used
+        ``uuid4()`` as the fallback, which made T1 writes impossible to
+        correlate with the audit log when the on-disk pointer was
+        missing -- the exact failure mode that PR #590 was supposed to
+        close. Issue #594 / nexus-9e9a unifies the chain and the
+        fallback so the three drift-prone sites
+        (T1 / tier-write / launcher) have one source of truth.
         """
-        return (
-            arg
-            or os.environ.get("NX_SESSION_ID", "").strip()
-            or read_claude_session_id()
-            or str(uuid4())
-        )
+        return resolve_active_session_id(arg) or "unknown"
 
     def _init_new_discovery(self, chromadb, session_id: str | None) -> None:
         """RDR-105 P2 (nexus-mj2o): four-branch fail-loud constructor.

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -339,30 +339,29 @@ def _record_tier_write(
     """Append one row to ``tier_writes`` recording a tier-write call.
 
     Best-effort: any exception is swallowed. Telemetry must NEVER break
-    the hot path of the calling tool. ``session_id`` resolves from
-    ``NX_SESSION_ID`` env, then ``read_claude_session_id()``, then
-    ``"unknown"`` as a last-resort sentinel so rows are never lost.
+    the hot path of the calling tool. ``session_id`` is resolved by
+    :func:`nexus.session.resolve_active_session_id`; rows from a process
+    with no bound Claude session are attributed to ``"unknown"`` so
+    operators can grep for the sentinel and rows are never lost.
 
     Phase 1A of the tier-discipline restoration initiative
-    (memory: tier-discipline-audit-2026-05-06).
+    (memory: tier-discipline-audit-2026-05-06). Issue #594 / nexus-9e9a
+    routed the resolution chain through ``resolve_active_session_id``
+    so this site agrees with the T1 chunk store and the SessionEnd
+    launcher on attribution.
 
     Lazy imports inside this function so monkey-patches of
     ``nexus.mcp_infra.t2_ctx`` in tests are picked up at call time
     rather than frozen at module-import time.
     """
     try:
-        import os
         from datetime import datetime, timezone
 
         from nexus.db.migrations import migrate_tier_writes
         from nexus.mcp_infra import t2_ctx
-        from nexus.session import read_claude_session_id
+        from nexus.session import resolve_active_session_id
 
-        session_id = (
-            os.environ.get("NX_SESSION_ID", "").strip()
-            or read_claude_session_id()
-            or "unknown"
-        )
+        session_id = resolve_active_session_id() or "unknown"
         ts = datetime.now(timezone.utc).isoformat()
         with t2_ctx() as t2:
             # Any domain conn points at the same SQLite file; reuse the

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -79,6 +79,49 @@ def read_claude_session_id() -> str | None:
         return None  # intentional: file not created yet, normal on first run
 
 
+def resolve_active_session_id(arg: str | None = None) -> str | None:
+    """Single source of truth for the active Claude session_id.
+
+    Resolution chain (highest priority first):
+
+    1. Explicit ``arg`` (caller-supplied; non-empty after strip).
+    2. ``NX_SESSION_ID`` env var (non-empty after strip).
+    3. ``~/.config/nexus/current_session`` via ``read_claude_session_id``.
+    4. ``None``.
+
+    Returns ``None`` when nothing in the chain resolves. Callers choose
+    their own fallback at the call site:
+
+    * ``T1Database._resolve_session_id`` and ``mcp/core._record_tier_write``
+      substitute ``"unknown"`` so the per-entry / per-row session_id is
+      never empty and the audit log and the T1 chunk store agree on
+      attribution. Pre-PR T1 fell back to ``uuid4()`` while tier-write
+      fell back to ``"unknown"`` -- the divergence that produced the
+      nexus-h8ge bug class even after PR #590 lifted the chain into
+      ``T1Database._resolve_session_id``: each open-coded copy could
+      drift independently.
+    * ``_session_end_launcher._print_tier_status_summary`` short-circuits
+      on ``None`` (no useful per-session summary without a bound session
+      -- querying ``WHERE session_id = "unknown"`` would leak rows from
+      unrelated invocations into the user-facing summary).
+
+    Issue #594 / nexus-9e9a: this helper is the structural fix for the
+    three-site drift class. Any future change to the chain happens here
+    once.
+    """
+    if arg:
+        stripped = arg.strip()
+        if stripped:
+            return stripped
+    env = os.environ.get("NX_SESSION_ID", "").strip()
+    if env:
+        return env
+    file_id = read_claude_session_id()
+    if file_id:
+        return file_id
+    return None
+
+
 def _stable_pid() -> int:
     """Return a stable process-group anchor for legacy session file naming.
 

--- a/tests/test_session_resolver.py
+++ b/tests/test_session_resolver.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for nexus.session.resolve_active_session_id (issue #594, nexus-9e9a).
+
+The session_id resolution chain (NX_SESSION_ID env -> read_claude_session_id ->
+fallback) must live in exactly one place and be reused by all three callsites:
+
+  1. T1Database._init_new_discovery       (every Path A/B/C/client branch)
+  2. _record_tier_write (mcp/core.py)     (telemetry insert)
+  3. _print_tier_status_summary (_session_end_launcher.py)
+                                          (session-end summary)
+
+Pre-PR these were three open-coded copies with three divergent fallbacks
+(uuid4(), "unknown", and no fallback respectively). The drift class that
+produced PR #590 (nexus-h8ge) was a divergence between two of these copies.
+This file's tests exist so any future change to the chain has to be made
+in exactly one place or it surfaces here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: write the on-disk current_session pointer.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _write_current_session(tmp_path: Path, sid: str) -> None:
+    target = tmp_path / "current_session"
+    target.write_text(sid)
+    target.chmod(0o600)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# resolve_active_session_id chain semantics
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestResolveActiveSessionIdChain:
+    """The chain: arg > NX_SESSION_ID env > read_claude_session_id() > None."""
+
+    def test_explicit_arg_wins_over_env_and_file(self, tmp_path, monkeypatch):
+        from nexus.session import resolve_active_session_id
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("NX_SESSION_ID", "from-env")
+        _write_current_session(tmp_path, "from-file")
+
+        assert resolve_active_session_id("from-arg") == "from-arg"
+
+    def test_env_wins_over_file(self, tmp_path, monkeypatch):
+        from nexus.session import resolve_active_session_id
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("NX_SESSION_ID", "from-env")
+        _write_current_session(tmp_path, "from-file")
+
+        assert resolve_active_session_id() == "from-env"
+
+    def test_file_wins_when_env_empty(self, tmp_path, monkeypatch):
+        from nexus.session import resolve_active_session_id
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        _write_current_session(tmp_path, "canonical-uuid")
+
+        assert resolve_active_session_id() == "canonical-uuid"
+
+    def test_returns_none_when_nothing_resolves(self, tmp_path, monkeypatch):
+        from nexus.session import resolve_active_session_id
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        # No current_session file written.
+
+        assert resolve_active_session_id() is None
+
+    def test_blank_env_treated_as_unset(self, tmp_path, monkeypatch):
+        """Whitespace-only NX_SESSION_ID falls through, matching the
+        pre-PR behaviour every callsite implemented via .strip()."""
+        from nexus.session import resolve_active_session_id
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("NX_SESSION_ID", "   ")
+        _write_current_session(tmp_path, "from-file")
+
+        assert resolve_active_session_id() == "from-file"
+
+    def test_blank_arg_falls_through(self, tmp_path, monkeypatch):
+        """Empty string arg behaves the same as None: chain continues."""
+        from nexus.session import resolve_active_session_id
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("NX_SESSION_ID", "from-env")
+        _write_current_session(tmp_path, "from-file")
+
+        assert resolve_active_session_id("") == "from-env"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Callsite unification: each of the three sites routes through the helper.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestT1DatabaseRoutesThroughHelper:
+    """T1Database._resolve_session_id MUST delegate to
+    nexus.session.resolve_active_session_id with the explicit ctor arg."""
+
+    def test_t1_propagates_helper_value(self, tmp_path, monkeypatch):
+        from nexus.db.t1 import T1Database
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        # Patch the helper to return a recognisable sentinel.
+        monkeypatch.setattr(
+            "nexus.session.resolve_active_session_id",
+            lambda arg=None: "HELPER-SENTINEL-1234",
+        )
+        # Also patch the alias in nexus.db.t1's import namespace, since
+        # `from nexus.session import resolve_active_session_id` would
+        # bind the symbol at import time.
+        monkeypatch.setattr(
+            "nexus.db.t1.resolve_active_session_id",
+            lambda arg=None: "HELPER-SENTINEL-1234",
+            raising=False,
+        )
+        assert T1Database._resolve_session_id(None) == "HELPER-SENTINEL-1234"
+
+    def test_t1_uses_unknown_fallback_when_helper_returns_none(
+        self, tmp_path, monkeypatch
+    ):
+        """Per-entry T1 metadata can never be empty (it's the filter
+        key). When the helper returns None, T1 must substitute
+        ``"unknown"`` so the audit log and chunk store agree on
+        attribution."""
+        from nexus.db.t1 import T1Database
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        # No current_session file -> helper returns None -> T1 uses "unknown".
+        assert T1Database._resolve_session_id(None) == "unknown"
+
+
+class TestRecordTierWriteRoutesThroughHelper:
+    """_record_tier_write MUST delegate to resolve_active_session_id and
+    use ``"unknown"`` as the per-row last-resort sentinel."""
+
+    def test_tier_write_uses_helper(self, tmp_path, monkeypatch):
+        """Patch the helper, invoke the function, assert the row landed
+        with the helper's value as session_id."""
+        from nexus.mcp.core import _record_tier_write
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "nexus.session.resolve_active_session_id",
+            lambda arg=None: "HELPER-SENTINEL-9876",
+        )
+
+        observed: dict[str, str] = {}
+
+        class _FakeTaxonomyConn:
+            def execute(self, sql, params):
+                if "INSERT INTO tier_writes" in sql:
+                    observed["session_id"] = params[0]
+                return self
+
+            def commit(self):
+                pass
+
+        class _FakeTaxonomy:
+            def __init__(self):
+                self.conn = _FakeTaxonomyConn()
+                self._lock = _NullLock()
+
+        class _NullLock:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        class _FakeT2:
+            def __init__(self):
+                self.taxonomy = _FakeTaxonomy()
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _fake_t2_ctx():
+            yield _FakeT2()
+
+        monkeypatch.setattr("nexus.mcp_infra.t2_ctx", _fake_t2_ctx)
+        monkeypatch.setattr(
+            "nexus.db.migrations.migrate_tier_writes", lambda conn: None
+        )
+
+        _record_tier_write(tool="t", tier="T1")
+        assert observed.get("session_id") == "HELPER-SENTINEL-9876"
+
+    def test_tier_write_unknown_fallback_when_helper_returns_none(
+        self, tmp_path, monkeypatch
+    ):
+        from nexus.mcp.core import _record_tier_write
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        # No file -> helper returns None -> tier-write uses "unknown".
+
+        observed: dict[str, str] = {}
+
+        class _FakeTaxonomyConn:
+            def execute(self, sql, params):
+                if "INSERT INTO tier_writes" in sql:
+                    observed["session_id"] = params[0]
+                return self
+
+            def commit(self):
+                pass
+
+        class _NullLock:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        class _FakeTaxonomy:
+            def __init__(self):
+                self.conn = _FakeTaxonomyConn()
+                self._lock = _NullLock()
+
+        class _FakeT2:
+            def __init__(self):
+                self.taxonomy = _FakeTaxonomy()
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _fake_t2_ctx():
+            yield _FakeT2()
+
+        monkeypatch.setattr("nexus.mcp_infra.t2_ctx", _fake_t2_ctx)
+        monkeypatch.setattr(
+            "nexus.db.migrations.migrate_tier_writes", lambda conn: None
+        )
+
+        _record_tier_write(tool="t", tier="T1")
+        assert observed.get("session_id") == "unknown"
+
+
+class TestSessionEndLauncherRoutesThroughHelper:
+    """_print_tier_status_summary MUST delegate to resolve_active_session_id and
+    short-circuit when the helper returns None (no useful summary
+    without a bound session)."""
+
+    def test_launcher_short_circuits_when_helper_returns_none(
+        self, tmp_path, monkeypatch
+    ):
+        """If the helper returns None the launcher must NOT query for
+        ``WHERE session_id = "unknown"`` (that would leak rows from
+        unrelated invocations into the user-facing summary)."""
+        from nexus._session_end_launcher import _print_tier_status_summary
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("NX_SESSION_ID", raising=False)
+        monkeypatch.setattr(
+            "nexus.session.resolve_active_session_id",
+            lambda arg=None: None,
+        )
+        # Also patch the launcher's import alias if applicable.
+        monkeypatch.setattr(
+            "nexus._session_end_launcher.resolve_active_session_id",
+            lambda arg=None: None,
+            raising=False,
+        )
+
+        # Should return without raising and without attempting any DB
+        # connect. We assert this by ensuring sqlite3.connect is NOT
+        # called.
+        called = {"connect": False}
+
+        def _spy_connect(*a, **kw):
+            called["connect"] = True
+            raise AssertionError("launcher must short-circuit")
+
+        monkeypatch.setattr("sqlite3.connect", _spy_connect)
+        _print_tier_status_summary()
+        assert called["connect"] is False
+
+    def test_launcher_uses_helper_value_for_query(
+        self, tmp_path, monkeypatch
+    ):
+        """When the helper returns a session_id, the launcher must use
+        it as the WHERE-clause value verbatim."""
+        import sqlite3
+
+        from nexus._session_end_launcher import _print_tier_status_summary
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "nexus.session.resolve_active_session_id",
+            lambda arg=None: "LAUNCHER-SENTINEL",
+        )
+        monkeypatch.setattr(
+            "nexus._session_end_launcher.resolve_active_session_id",
+            lambda arg=None: "LAUNCHER-SENTINEL",
+            raising=False,
+        )
+
+        # Build a minimal SQLite db with the tier_writes table + a row.
+        db_path = tmp_path / "t2.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE tier_writes "
+            "(session_id TEXT, ts TEXT, tool TEXT, tier TEXT, "
+            "agent TEXT, project TEXT, target_title TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO tier_writes VALUES "
+            "('LAUNCHER-SENTINEL', '2026-05-08T00:00:00', 't', 'T1', "
+            "'', '', '')"
+        )
+        conn.execute(
+            "INSERT INTO tier_writes VALUES "
+            "('OTHER-SESSION', '2026-05-08T00:00:00', 't', 'T1', "
+            "'', '', '')"
+        )
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: str(db_path)
+        )
+
+        # Capture stderr so we can assert the launcher only counted the
+        # one row matching LAUNCHER-SENTINEL, not the OTHER-SESSION row.
+        import io
+        import sys
+
+        buf = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", buf)
+        _print_tier_status_summary()
+        out = buf.getvalue()
+        assert "total=1" in out, out
+        assert "LAUNCHER" in out  # truncated session_id[:8] in the line

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -782,13 +782,22 @@ class TestT1DatabaseSessionIdResolution:
         assert db.session_id == "canonical-claude-uuid"
 
     @pytest.mark.parametrize("path_id", _PATH_IDS)
-    def test_uuid_fallback_when_nothing_set(
+    def test_unknown_fallback_when_nothing_set(
         self, path_id, tmp_path, monkeypatch, fake_chromadb
     ):
-        """Truly anonymous CLI (no env, no file) still gets a fresh
-        UUID -- preserves the pre-fix behaviour for callers running
-        outside any Claude session, e.g. ad-hoc scripting against an
-        explicit ephemeral.
+        """Truly anonymous CLI (no env, no file) attributes its T1
+        writes to the canonical ``"unknown"`` sentinel.
+
+        Pre-issue-#594 the fallback was ``uuid4()`` -- a per-process
+        random string that made T1 writes impossible to correlate with
+        the audit log when the on-disk pointer was missing, the exact
+        failure mode PR #590 was supposed to close. Issue #594 /
+        nexus-9e9a unifies the chain through
+        ``nexus.session.resolve_active_session_id`` and uses
+        ``"unknown"`` as the per-row last-resort sentinel, so the
+        T1 chunk store and the tier-write audit log agree on
+        attribution: rows under ``"unknown"`` are exactly the rows
+        from processes that did not bind to a Claude session.
         """
         kwargs, _ = _setup_path(path_id, tmp_path, monkeypatch, fake_chromadb)
         monkeypatch.delenv("NX_SESSION_ID", raising=False)
@@ -796,9 +805,7 @@ class TestT1DatabaseSessionIdResolution:
 
         from nexus.db.t1 import T1Database
         db = T1Database(**kwargs)
-        # uuid4() strings are 36 chars with four hyphens.
-        assert len(db.session_id) == 36
-        assert db.session_id.count("-") == 4
+        assert db.session_id == "unknown"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- Introduce `nexus.session.resolve_active_session_id` as the single source of truth for the Claude session_id chain (`NX_SESSION_ID` env > `read_claude_session_id()` > `None`). Route the three open-coded callsites through it: `T1Database._resolve_session_id`, `mcp/core._record_tier_write`, and `_session_end_launcher._print_tier_status_summary`. Pre-PR each site implemented the chain independently with three divergent fallbacks (`uuid4()`, `"unknown"`, none); the drift between the first two was the exact bug class that produced PR #590 / nexus-h8ge.
- T1 and `_record_tier_write` now both fall back to `"unknown"` so the audit log and the chunk store agree on attribution (rows under `"unknown"` are exactly the rows from processes that did not bind to a Claude session, grep-able for forensics). `uuid4()` in T1 was the failure mode PR #590 was supposed to close. The launcher still short-circuits on `None` (per-session summary makes no sense without a bound session).

## Test plan

- [x] 12 new tests in `tests/test_session_resolver.py`: 6 chain-semantics tests pin the resolver, 6 callsite tests assert each of the three sites routes through the helper and applies its documented fallback. All passing.
- [x] Updated `tests/test_t1_discovery.py::test_uuid_fallback_when_nothing_set` -> `test_unknown_fallback_when_nothing_set` to assert the new sentinel; remaining 16 session-id resolution tests still pass across all four construction branches.
- [x] Full unit suite: 6626 passed, 33 skipped, 3 xfailed, 0 failed in 10 min.
- [x] Local install + live shakeout: shell `nx scratch put` + `nx scratch list` round-trips through the live MCP T1 inside a Claude session; `nx tier-status` reports the canonical session UUID.

## Closes

Closes #594