### PR TITLE
fix(t1): reap orphan multiprocessing trackers at MCP startup (nexus-9h1s, P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **POSIX semaphore exhaustion from orphan multiprocessing trackers**
+  (nexus-9h1s): each ungraceful MCP shutdown (SIGKILL/OOM) leaves
+  chroma's multiprocessing-worker ``resource_tracker`` /
+  ``spawn ... --multiprocessing-fork`` subprocesses re-parented to
+  init (PPID=1). The trackers continue holding their POSIX named
+  semaphores until killed; ``stop_t1_server``'s ``safe_killpg`` only
+  signals the CURRENT chroma's process group, so workers from PRIOR
+  sessions live in different (now-empty) PGIDs and cannot be
+  reached. ``sweep_orphan_tmpdirs`` reaped the directories but left
+  the kernel-level resources, so the namespace
+  (``kern.posix.sem.max=10000`` on macOS) accumulated to exhaustion
+  ("Errno 28") system-wide.
+
+  Live shakeout 2026-05-08 03:30 PT on the dev machine: 25 orphan
+  ``nx_t1_*`` tmpdirs, 3,314 orphan multiprocessing trackers, 8,359
+  POSIX semaphores held (83% of cap). Oldest tracker 11 days old.
+  After fix: 0 orphan trackers, 74 semaphores held.
+
+  Fix: introduce ``nexus.session.sweep_orphan_resource_trackers``
+  and wire it into the MCP top-level startup sweep alongside
+  ``sweep_orphan_t1_addr_files`` and ``sweep_orphan_tmpdirs``. Pure
+  parser ``_parse_orphan_tracker_candidates`` (PPID=1 + command
+  contains ``"multiprocessing"`` + age >= 60 s + not in
+  ``protected_pids``) feeds ``_kill_orphan_tracker_pids`` which
+  SIGTERMs each candidate, escalates to SIGKILL on survivors after
+  3 s. Both helpers are individually testable.
+
+  ``nx doctor --check-resources`` extended to surface the orphan
+  count: ``[✓]`` below 100, ``[!]`` advisory between 100 and
+  999, ``[!]`` URGENT at 1000+ with reap-inline instructions and
+  the bead reference. The known-sources warning text adds the
+  nexus-9h1s case alongside nexus-dc57 / nexus-ze2a.
+
+  Regression coverage in ``tests/test_session_sweep_orphan_trackers.py``
+  (9 tests): six parser unit tests pin the discrimination logic
+  (orphan vs live parent, multiprocessing match, etime parsing of
+  ``MM:SS`` / ``H:MM:SS`` / ``DD-HH:MM:SS`` / very-old, protected
+  PID exclusion) and three kill-helper tests verify SIGTERM
+  delivery to live subprocesses, ProcessLookupError handling for
+  already-dead PIDs, and SIGKILL escalation when SIGTERM is
+  trapped.
+
 ### Changed
 
 - **Single source of truth for the Claude session_id chain** (issue

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -927,10 +927,12 @@ def _run_check_mineru() -> None:
     "check_resources",
     is_flag=True,
     default=False,
-    help="Probe POSIX semaphore headroom. Exits 2 with 'Errno 28' when "
-         "the namespace is exhausted (known sources: MinerU workers / "
-         "orphan chroma children leaking via multiprocessing). Beads "
-         "nexus-dc57 + nexus-ze2a.",
+    help="Probe POSIX semaphore headroom and report orphan "
+         "multiprocessing-tracker pressure. Exits 2 with 'Errno 28' "
+         "when the namespace is exhausted (known sources: MinerU "
+         "workers / orphan chroma children leaking via multiprocessing "
+         "/ trackers re-parented to init after ungraceful MCP "
+         "shutdowns). Beads nexus-dc57 + nexus-ze2a + nexus-9h1s.",
 )
 @click.option(
     "--check-quotas",
@@ -1305,19 +1307,91 @@ def _probe_semaphore_namespace() -> tuple[bool, str]:
         return False, f"{exc!r}"
 
 
+def _count_orphan_trackers() -> int | None:
+    """Return the number of PPID=1 multiprocessing tracker orphans
+    visible to this user, or ``None`` if the count cannot be
+    obtained. Pure read; no side effects.
+
+    Bead nexus-9h1s. Each orphan tracker holds POSIX semaphores
+    until killed; the namespace is bounded
+    (``kern.posix.sem.max=10000`` on macOS). A high count predicts
+    imminent SemLock failure even when the live probe still passes.
+    """
+    try:
+        import subprocess
+
+        from nexus.session import _parse_orphan_tracker_candidates
+
+        ps_output = subprocess.check_output(
+            ["ps", "-eo", "pid,ppid,etime,command"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        return len(_parse_orphan_tracker_candidates(ps_output))
+    except Exception:
+        return None
+
+
 def _run_check_resources() -> None:
-    """Emit a resource-pressure report to stdout; exit 2 on failure."""
+    """Emit a resource-pressure report to stdout; exit 2 on failure.
+
+    Two signals:
+
+    * ``_probe_semaphore_namespace`` -- direct SemLock allocation;
+      fails with Errno 28 when the namespace is exhausted.
+    * Orphan multiprocessing tracker count via
+      :func:`_count_orphan_trackers`. Warns above 100 (advisory)
+      and 1000 (urgent). Bead nexus-9h1s.
+    """
     ok, msg = _probe_semaphore_namespace()
+    orphan_count = _count_orphan_trackers()
     if ok:
         click.echo(f"[\u2713] resources: {msg}")
+        if orphan_count is None:
+            return
+        if orphan_count >= 1000:
+            click.echo(
+                f"[!] orphan multiprocessing trackers: {orphan_count} "
+                f"(URGENT - reap soon to avoid Errno 28; each leaks "
+                f"POSIX semaphores until killed)",
+                err=True,
+            )
+            click.echo(
+                "    Reap inline: python -c 'from nexus.session import "
+                "sweep_orphan_resource_trackers; "
+                "print(sweep_orphan_resource_trackers())'\n"
+                "    Or: ps -eo pid,ppid,command | "
+                "awk '$2==1 && /multiprocessing/ {print $1}' | "
+                "xargs kill -TERM",
+                err=True,
+            )
+        elif orphan_count >= 100:
+            click.echo(
+                f"[!] orphan multiprocessing trackers: {orphan_count} "
+                f"(advisory - accumulating)"
+            )
+        else:
+            click.echo(
+                f"[\u2713] orphan multiprocessing trackers: {orphan_count}"
+            )
         return
     click.echo(f"[\u2717] resources: SemLock probe FAILED — {msg}", err=True)
+    if orphan_count is not None:
+        click.echo(
+            f"    orphan multiprocessing trackers: {orphan_count}",
+            err=True,
+        )
     click.echo(
         "Known sources of POSIX semaphore exhaustion on this project:\n"
         "  - nexus-ze2a: MinerU workers leak semaphores.\n"
         "    Workaround: `nx mineru stop` (kills the whole process group).\n"
         "  - nexus-dc57: orphan chroma children from earlier nexus sessions.\n"
         "    Workaround: kill orphan chromas (`ps aux | grep 'chroma run'`).\n"
+        "  - nexus-9h1s: multiprocessing.resource_tracker subprocesses\n"
+        "    re-parented to init (PPID=1) after ungraceful MCP shutdowns.\n"
+        "    Reap with: python -c 'from nexus.session import "
+        "sweep_orphan_resource_trackers; "
+        "print(sweep_orphan_resource_trackers())'\n"
         "If the count does not recover, reboot — macOS does not unlink\n"
         "leaked named semaphores until the next boot.",
         err=True,

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -151,16 +151,24 @@ async def _t1_chroma_lifespan(_app: Any):
     # Branch 3: spawn + publish.
     from nexus.session import (
         start_t1_server,
+        sweep_orphan_resource_trackers,
         sweep_orphan_t1_addr_files,
         sweep_orphan_tmpdirs,
     )
 
-    # Best-effort orphan cleanup before we spawn. Two surfaces:
+    # Best-effort orphan cleanup before we spawn. Three surfaces:
     # (a) addr files from sessions that exited ungracefully (SIGKILL),
-    # (b) tmpdirs from chromas reaped before their cleanup completed.
-    # Both are bounded; failures are logged at debug and never block
-    # startup. The sweep functions log per-file outcomes themselves;
-    # this outer guard catches unexpected sweep-level failures.
+    # (b) tmpdirs from chromas reaped before their cleanup completed,
+    # (c) multiprocessing resource_tracker processes re-parented to
+    #     init (PPID=1) holding POSIX named semaphores. (c) is
+    #     critical because the namespace is bounded
+    #     (kern.posix.sem.max=10000 on macOS); chronic accumulation
+    #     produces Errno 28 system-wide. Bead nexus-9h1s; live
+    #     shakeout 2026-05-08 cleared 3,314 trackers / 8,359
+    #     semaphores. (a) and (b) are bounded; failures are logged
+    #     at debug and never block startup. The sweep functions log
+    #     per-file outcomes themselves; this outer guard catches
+    #     unexpected sweep-level failures.
     import structlog
     _sweep_log = structlog.get_logger(__name__)
     try:
@@ -171,6 +179,12 @@ async def _t1_chroma_lifespan(_app: Any):
         sweep_orphan_tmpdirs()
     except Exception as exc:
         _sweep_log.debug("sweep_orphan_tmpdirs_failed", error=str(exc))
+    try:
+        sweep_orphan_resource_trackers()
+    except Exception as exc:
+        _sweep_log.debug(
+            "sweep_orphan_resource_trackers_failed", error=str(exc)
+        )
 
     # Reset the ``_SHUTDOWN_IN_FLIGHT`` sentinel BEFORE
     # ``start_t1_server`` (which can take up to ``_SERVER_READY_TIMEOUT``

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -283,6 +283,208 @@ def sweep_orphan_tmpdirs(
     return reaped
 
 
+def _parse_etime_seconds(etime: str) -> float | None:
+    """Parse a ``ps -o etime`` value into seconds.
+
+    Accepts the four shapes ``ps`` emits:
+
+    * ``MM:SS``
+    * ``HH:MM:SS``
+    * ``DD-HH:MM:SS``
+    * Trailing whitespace tolerated.
+
+    Returns ``None`` on parse failure so the caller can decide a
+    safe default (typically: skip the row).
+    """
+    s = etime.strip()
+    if not s:
+        return None
+    days = 0
+    if "-" in s:
+        d, _, rest = s.partition("-")
+        try:
+            days = int(d)
+        except ValueError:
+            return None
+        s = rest
+    parts = s.split(":")
+    try:
+        nums = [int(p) for p in parts]
+    except ValueError:
+        return None
+    if len(nums) == 2:
+        h, m, sec = 0, nums[0], nums[1]
+    elif len(nums) == 3:
+        h, m, sec = nums
+    else:
+        return None
+    return float(days * 86400 + h * 3600 + m * 60 + sec)
+
+
+def _parse_orphan_tracker_candidates(
+    ps_output: str,
+    *,
+    min_age_seconds: float = 60.0,
+    protected_pids: set[int] | None = None,
+) -> list[int]:
+    """Parse the output of ``ps -eo pid,ppid,etime,command`` and
+    return the PIDs of orphan multiprocessing trackers safe to reap.
+
+    Conservative match — a row is included iff every condition holds:
+
+    * ``ppid == 1`` (re-parented to init; the original parent is dead).
+    * ``command`` contains ``"multiprocessing"`` (matches both
+      ``multiprocessing.resource_tracker`` and
+      ``multiprocessing.spawn ... --multiprocessing-fork``).
+    * Process age >= *min_age_seconds* (avoids racing in-flight
+      MCP-startup workers whose parent has not yet attached).
+    * ``pid not in protected_pids`` (escape hatch for tests / live
+      MCP-managed PIDs the caller wants to spare).
+
+    Returns the list in the order ``ps`` emitted (effectively PID
+    order). Pure function for unit testing; callers handle SIGTERM.
+    """
+    protected = protected_pids or set()
+    out: list[int] = []
+    for line in ps_output.splitlines():
+        s = line.strip()
+        if not s or not s[0].isdigit():
+            continue  # header row or blank
+        # Tokenize: pid, ppid, etime, command-tail
+        parts = s.split(None, 3)
+        if len(parts) < 4:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        if ppid != 1:
+            continue
+        if pid in protected:
+            continue
+        if "multiprocessing" not in parts[3]:
+            continue
+        age = _parse_etime_seconds(parts[2])
+        if age is None or age < min_age_seconds:
+            continue
+        out.append(pid)
+    return out
+
+
+def sweep_orphan_resource_trackers(
+    *,
+    min_age_seconds: float = 60.0,
+    command_substring: str = "multiprocessing",
+    protected_pids: set[int] | None = None,
+) -> int:
+    """Reap multiprocessing.resource_tracker / spawn workers re-parented to init.
+
+    Each ungraceful MCP shutdown (SIGKILL/OOM, lost SessionEnd hook)
+    leaves chroma's multiprocessing workers' resource_tracker
+    subprocesses re-parented to init (PPID=1). The trackers continue
+    holding their POSIX named semaphores until killed; the namespace
+    is bounded (``kern.posix.sem.max=10000`` on macOS) so chronic
+    accumulation produces ``Errno 28`` system-wide.
+
+    :func:`stop_t1_server`'s ``safe_killpg`` only signals the CURRENT
+    chroma's process group; orphan workers from prior sessions live
+    in different (now-empty) process groups and cannot be reached.
+    :func:`sweep_orphan_tmpdirs` reaps the directories but leaves the
+    processes that hold the kernel resources.
+
+    This sweep complements them and runs at MCP top-level startup.
+    Sends SIGTERM (graceful), then SIGKILL after 3 s for any tracker
+    that did not exit. Returns the count signalled.
+
+    *command_substring* is a defence-in-depth filter the caller can
+    narrow (e.g. tests pass a unique marker so the sweep cannot
+    touch unrelated trackers on the dev machine).
+
+    Live shakeout 2026-05-08: 3,314 trackers / 8,359 semaphores
+    cleared in single SIGTERM batch on a system that had been
+    accumulating for 11+ days. Bead nexus-9h1s.
+    """
+    try:
+        ps_output = subprocess.check_output(
+            ["ps", "-eo", "pid,ppid,etime,command"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        _log.debug("sweep_orphan_trackers_ps_failed", error=str(exc))
+        return 0
+
+    candidates = _parse_orphan_tracker_candidates(
+        ps_output,
+        min_age_seconds=min_age_seconds,
+        protected_pids=protected_pids,
+    )
+    # Apply the caller-supplied substring filter on top of the
+    # parser's hard-coded "multiprocessing" gate so tests can scope
+    # the sweep to a marker they injected.
+    if command_substring != "multiprocessing":
+        narrowed: list[int] = []
+        for pid in candidates:
+            try:
+                cmd = subprocess.check_output(
+                    ["ps", "-o", "command=", "-p", str(pid)],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                ).strip()
+            except (subprocess.CalledProcessError, OSError):
+                continue
+            if command_substring in cmd:
+                narrowed.append(pid)
+        candidates = narrowed
+
+    if not candidates:
+        return 0
+
+    signalled = _kill_orphan_tracker_pids(candidates)
+    _log.info(
+        "sweep_orphan_trackers_reaped",
+        count=signalled,
+        candidates=len(candidates),
+    )
+    return signalled
+
+
+def _kill_orphan_tracker_pids(
+    pids: list[int],
+    *,
+    grace_seconds: float = 3.0,
+) -> int:
+    """SIGTERM each PID in *pids*; escalate to SIGKILL after
+    *grace_seconds* for any survivor. Returns the count of PIDs we
+    successfully signalled (SIGTERM-step). Best-effort: missing
+    PIDs and EPERM are skipped silently. Pure side effects + return
+    count; testable independently of the parser."""
+    signalled = 0
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            signalled += 1
+        except ProcessLookupError:
+            continue
+        except PermissionError as exc:
+            _log.debug("sweep_orphan_tracker_eperm", pid=pid, error=str(exc))
+            continue
+
+    deadline = time.time() + grace_seconds
+    while time.time() < deadline:
+        if not any(_is_pid_alive(pid) for pid in pids):
+            break
+        time.sleep(0.1)
+    for pid in pids:
+        if _is_pid_alive(pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                continue
+    return signalled
+
+
 def _find_chroma() -> str | None:
     """Return the path to the chroma CLI co-installed with this interpreter.
 

--- a/tests/test_session_sweep_orphan_trackers.py
+++ b/tests/test_session_sweep_orphan_trackers.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for nexus.session.sweep_orphan_resource_trackers (issue nexus-9h1s).
+
+Each ungraceful MCP shutdown (SIGKILL/OOM) leaves chroma's
+multiprocessing workers' resource_tracker subprocesses re-parented to
+init (PPID=1). They continue holding POSIX named semaphores until
+killed; the semaphore namespace is bounded
+(``kern.posix.sem.max=10000`` on macOS) so chronic accumulation
+produces ``Errno 28`` system-wide.
+
+``safe_killpg`` from ``stop_t1_server`` only signals the CURRENT
+chroma's process group; orphan workers from PRIOR sessions live in
+different (now-empty) process groups and cannot be reached. The
+existing ``sweep_orphan_tmpdirs`` only reaps directories, not the
+processes that hold the kernel-level resources.
+
+Live shakeout (2026-05-08 03:30 PT) found 3,314 such orphans holding
+8,359 of the 10,000 macOS POSIX-semaphore namespace. After manual
+``ps | awk | xargs kill -TERM``: 0 orphan trackers, 74 semaphores.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pure-unit tests (no subprocess); validate the parser + filter logic.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestParseOrphanTrackerCandidates:
+    """Validate the parser that walks ``ps -eo pid,ppid,etime,command``
+    output and produces a candidate list for SIGTERM."""
+
+    def test_parses_valid_orphan_lines(self):
+        from nexus.session import _parse_orphan_tracker_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 python -c from multiprocessing.resource_tracker import main;main(8)\n"
+            "  212     1       12:34 python -c from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=9) --multiprocessing-fork\n"
+            "  500     1        00:05 python -c from multiprocessing.resource_tracker import main;main(8)\n"
+        )
+        # min_age_seconds=60 -> excludes the 5-second-old PID 500.
+        candidates = _parse_orphan_tracker_candidates(
+            ps_output, min_age_seconds=60.0
+        )
+        assert candidates == [211, 212]
+
+    def test_excludes_non_init_parents(self):
+        from nexus.session import _parse_orphan_tracker_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  500   100       12:34 python -c from multiprocessing.resource_tracker import main;main(8)\n"
+        )
+        assert _parse_orphan_tracker_candidates(ps_output) == []
+
+    def test_excludes_non_multiprocessing_processes(self):
+        from nexus.session import _parse_orphan_tracker_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  500     1       12:34 /usr/bin/some-daemon --foo\n"
+            "  501     1       12:34 python script.py\n"
+        )
+        assert _parse_orphan_tracker_candidates(ps_output) == []
+
+    def test_parses_etime_dd_hh_mm_ss(self):
+        """`ps` etime can be '11-19:02:41' for old processes (days-h:m:s).
+        Must parse to age >> any plausible min_age_seconds."""
+        from nexus.session import _parse_orphan_tracker_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            " 8651     1 11-19:02:41 python -c from multiprocessing.spawn import spawn_main\n"
+        )
+        # An 11-day-old process must always be selected, even at
+        # arbitrarily large min_age thresholds.
+        assert _parse_orphan_tracker_candidates(
+            ps_output, min_age_seconds=86400.0
+        ) == [8651]
+
+    def test_parses_etime_h_mm_ss(self):
+        from nexus.session import _parse_orphan_tracker_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  500     1     2:30:45 python -c from multiprocessing.resource_tracker import main\n"
+        )
+        # 2h30m45s > 60s.
+        assert _parse_orphan_tracker_candidates(
+            ps_output, min_age_seconds=60.0
+        ) == [500]
+
+    def test_excludes_pids_in_protected_set(self):
+        from nexus.session import _parse_orphan_tracker_candidates
+
+        ps_output = (
+            "  PID  PPID     ELAPSED COMMAND\n"
+            "  211     1       12:34 python -c from multiprocessing.resource_tracker import main\n"
+            "  212     1       12:34 python -c from multiprocessing.resource_tracker import main\n"
+        )
+        protected = {211}
+        assert _parse_orphan_tracker_candidates(
+            ps_output, protected_pids=protected
+        ) == [212]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Kill-helper tests: real subprocesses, no multiprocessing. The actual
+# kernel-level resource_tracker leak is unreliable to reproduce in a unit
+# test (the tracker's atexit cleanup fires when the parent exits via
+# sys.exit, so a *graceful* fork-then-exit doesn't orphan the way a
+# SIGKILL'd parent does). The kill helper is the testable surface; the
+# parser handles the discrimination logic and is unit-tested above.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _spawn_long_sleeper() -> subprocess.Popen:
+    """Spawn a subprocess that sleeps for 60 s. Used to verify
+    ``_kill_orphan_tracker_pids`` reliably SIGTERMs targets."""
+    return subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+class TestKillOrphanTrackerPids:
+    """The kill helper takes a list of PIDs, SIGTERMs each, escalates
+    to SIGKILL on survivors after grace_seconds. Tested with regular
+    sleepers; multiprocessing-specific behaviour is not relevant
+    to this code path."""
+
+    def test_signals_each_pid_sigterm(self):
+        from nexus.session import _kill_orphan_tracker_pids
+
+        sleepers = [_spawn_long_sleeper() for _ in range(3)]
+        pids = [s.pid for s in sleepers]
+        try:
+            killed = _kill_orphan_tracker_pids(pids, grace_seconds=2.0)
+            assert killed == 3
+            for s in sleepers:
+                rc = s.wait(timeout=5.0)
+                # SIGTERM exit code on POSIX: -SIGTERM (Popen.wait
+                # returns negative for signal exits) or 143 in some
+                # shells. Either way: not 0 (clean exit).
+                assert rc != 0
+        finally:
+            for s in sleepers:
+                if s.poll() is None:
+                    s.kill()
+                    s.wait(timeout=5.0)
+
+    def test_handles_already_dead_pid_gracefully(self):
+        from nexus.session import _kill_orphan_tracker_pids
+
+        # Spawn-then-kill so the PID is dead by the time the helper
+        # signals it. The helper must not raise.
+        s = _spawn_long_sleeper()
+        s.kill()
+        s.wait(timeout=5.0)
+        # ProcessLookupError is silently skipped; signalled count
+        # should be 0.
+        killed = _kill_orphan_tracker_pids([s.pid], grace_seconds=0.5)
+        assert killed == 0
+
+    def test_escalates_to_sigkill_on_survivor(self):
+        """A subprocess that traps SIGTERM survives the graceful
+        signal. The escalation must SIGKILL it within grace_seconds."""
+        from nexus.session import _kill_orphan_tracker_pids
+
+        # Subprocess that ignores SIGTERM but cannot block SIGKILL.
+        # Setpgrp so the parent's signal-routing doesn't reach it
+        # via process-group propagation; we rely solely on the
+        # explicit os.kill in the helper.
+        proc = subprocess.Popen(
+            [
+                sys.executable, "-c",
+                "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        try:
+            # SIGTERM-trap subprocess takes a moment to install the
+            # handler. Wait briefly so our SIGTERM lands after the
+            # trap is in place; otherwise the default handler kills
+            # it before we can verify escalation.
+            time.sleep(0.3)
+            t0 = time.time()
+            killed = _kill_orphan_tracker_pids(
+                [proc.pid], grace_seconds=1.0
+            )
+            elapsed = time.time() - t0
+            assert killed == 1
+            # Wait for the (escalated) SIGKILL to take effect.
+            rc = proc.wait(timeout=5.0)
+            assert rc != 0, "SIGTERM-trap process exited cleanly"
+            # The helper waited at most ~grace_seconds before
+            # SIGKILL; total elapsed should be < ~grace+overhead.
+            assert elapsed < 3.0, (
+                f"helper took {elapsed:.2f}s for grace_seconds=1.0"
+            )
+        finally:
+            if proc.poll() is None:
+                os.kill(proc.pid, signal.SIGKILL)
+                proc.wait(timeout=5.0)


### PR DESCRIPTION
## Summary

P0 emergency fix. Live state on the dev machine (2026-05-08 03:30 PT) showed **3,314 orphan multiprocessing trackers / 8,359 POSIX semaphores held / 83% of `kern.posix.sem.max=10000` consumed** by 11+ days of accumulation. After manual SIGTERM batch: 0 trackers / 74 semaphores. Each ungraceful MCP shutdown (SIGKILL/OOM) re-parents chroma's multiprocessing workers to init; their POSIX semaphores are held until killed. `stop_t1_server`'s `safe_killpg` only signals the current chroma's PGID, and `sweep_orphan_tmpdirs` reaps the directories but leaves the kernel-level resources.

This PR adds `nexus.session.sweep_orphan_resource_trackers` and wires it into the MCP top-level startup sweep alongside `sweep_orphan_t1_addr_files` and `sweep_orphan_tmpdirs`. Pure `_parse_orphan_tracker_candidates` discriminates (PPID=1 + `"multiprocessing"` in command + age >= 60 s + not in `protected_pids`), `_kill_orphan_tracker_pids` SIGTERMs and escalates to SIGKILL after 3 s.

`nx doctor --check-resources` extended to surface the orphan-tracker count: `[✓]` below 100, `[!]` advisory at 100..999, `[!]` URGENT at 1000+ with reap-inline instructions.

## Test plan

- [x] 9 new tests in `tests/test_session_sweep_orphan_trackers.py`: 6 parser tests + 3 kill-helper tests (SIGTERM delivery, already-dead handling, SIGKILL escalation when SIGTERM is trapped). All passing.
- [x] Full unit suite: 6,635 passed, 33 skipped, 3 xfailed, 0 failed in 9m54s.
- [x] Live install + `nx doctor --check-resources`: reports `[✓] orphan multiprocessing trackers: 0` post-cleanup; semaphore probe healthy.
- [x] Verified leak predates recent T1 work: oldest orphan tracker was 11 days, 19 hours old at the time of detection (May 7 - 11d19h ≈ April 25), well before PRs #590/#596/#597.

## Closes

Closes nexus-9h1s.