### PR TITLE
chore(rdr): close RDR-105 + clear deferred T1 follow-ups (-7m8i, -9nbk)

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -127,7 +127,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-102](rdr-102-phase4-completion.md) | RDR-101 Phase 4 Completion — doc_indexer Wiring, Write-Side source_path Retirement, Doctor Visibility | Architecture | Closed | 2026-05-02 |
 | [RDR-103](rdr-103-catalog-collection-name-authority.md) | Catalog as Collection-Name Authority | Architecture | Closed | 2026-05-03 |
 | [RDR-104](rdr-104-incremental-catalog-projection-rebuild.md) | Incremental Catalog Projection Rebuild | Architecture | Closed | 2026-05-05 |
-| [RDR-105](rdr-105-t1-chroma-architecture-env-passdown.md) | T1 Chroma Architecture: Eliminate On-Disk Session Records via Env-Var Passdown | Architecture | Accepted | 2026-05-07 |
+| [RDR-105](rdr-105-t1-chroma-architecture-env-passdown.md) | T1 Chroma Architecture: Eliminate On-Disk Session Records via Env-Var Passdown | Architecture | Closed | 2026-05-07 |
 
 ---
 

--- a/docs/rdr/rdr-105-t1-chroma-architecture-env-passdown.md
+++ b/docs/rdr/rdr-105-t1-chroma-architecture-env-passdown.md
@@ -2,13 +2,31 @@
 title: "T1 Chroma Architecture: Eliminate On-Disk Session Records via Env-Var Passdown"
 id: RDR-105
 type: Architecture
-status: accepted
+status: closed
 priority: high
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-05-07
 accepted_date: 2026-05-07
-related_issues: [nexus-lqp7, "GH-579", "GH-567", "GH-572", "GH-575", "GH-576"]
+closed_date: 2026-05-08
+close_reason: implemented
+related_issues: [nexus-lqp7, nexus-d73b, nexus-h8ge, "GH-579", "GH-567", "GH-572", "GH-575", "GH-576"]
+gap_closure:
+  - gap: 1
+    title: "Discovery-via-on-disk-record is inherently racy"
+    pointer: src/nexus/mcp/_t1_state.py:22
+  - gap: 2
+    title: "Cross-process idempotency is unenforceable in-process"
+    pointer: src/nexus/mcp/core.py:139
+  - gap: 3
+    title: "Silent ephemeral fallback is the data-loss generator"
+    pointer: src/nexus/db/t1.py:226
+  - gap: 4
+    title: "The watchdog's role is muddled"
+    pointer: src/nexus/session.py:813
+  - gap: 5
+    title: "Sub-agent dispatch sharing is implicit, not contractual"
+    pointer: src/nexus/operators/dispatch.py:44
 ---
 
 # RDR-105: T1 Chroma Architecture: Eliminate On-Disk Session Records via Env-Var Passdown
@@ -473,3 +491,47 @@ Stdlib-only (just typing). Imported by both the lifespan (writer) and the dispat
 - `src/nexus/t1_watchdog.py`, `src/nexus/mcp/core.py`, `src/nexus/db/t1.py`, `src/nexus/session.py`, `src/nexus/hooks.py`, source files this RDR rewrites.
 - `tests/test_t1_invariants.py`, `tests/test_t1_watchdog.py`, `tests/test_mcp_chroma_lifecycle.py`, `tests/test_session.py`, current scaffolding (will be replaced).
 - `docs/architecture.md`, three-tier T1/T2/T3 design context.
+
+## Close — 2026-05-08
+
+### Implementation shipped
+
+Five-phase epic `nexus-d73b` (closed 2026-05-07) shipped in **conexus 4.27.0**:
+
+- **Phase 1** (`nexus-4fek`, PR #581): design lock + hybrid-discovery spike, feature-flagged behind `NX_T1_NEW_DISCOVERY=1`.
+- **Phase 2** (`nexus-9fu7`, PR #582): constructor gate + dispatcher (4-branch `__init__`, `find_immediate_claude_pid`, lifespan publish, 3-mode dispatcher, new `_t1_state` module).
+- **Phase 3** (`nexus-xf5r`, PR #583): default flip + sandbox shakeout (six T1 cases + 10-parallel stress).
+- **Phase 4** (`nexus-jnx7`, PR #585): deletion of watchdog + record machinery + reconcile + sweep + `_OWNED_CHROMA` legacy migration; added periodic orphan reaper.
+- **Phase 5** (`nexus-s368`, PR #586 + release commit `7dc59e84`): release 4.27.0 (CHANGELOG, `NEXUS_SKIP_T1` deprecation alias for `NX_T1_ISOLATED=1`, `nx doctor --check-t1`).
+
+Net deletion: ~5000 LOC removed from production code, plus the corresponding test scaffolding for the deleted machinery.
+
+### Gap closure pointers
+
+| Gap | Title | Pointer |
+|---|---|---|
+| 1 | Discovery-via-on-disk-record is inherently racy | `src/nexus/mcp/_t1_state.py:22` (single-writer `T1_ADDR` module replacing the multi-writer record system) |
+| 2 | Cross-process idempotency is unenforceable in-process | `src/nexus/mcp/core.py:139` (env-discovery branch — eliminates the need for cross-process idempotency) |
+| 3 | Silent ephemeral fallback is the data-loss generator | `src/nexus/db/t1.py:226` (fail-loud `T1ServerNotFoundError` raise; no fallback path) |
+| 4 | The watchdog's role is muddled | `src/nexus/session.py:813` (`sweep_orphan_t1_addr_files`, periodic best-effort orphan reaper replacing the conflated watchdog) |
+| 5 | Sub-agent dispatch sharing is implicit, not contractual | `src/nexus/operators/dispatch.py:44` (`share_t1` / `ephemeral` explicit dispatcher contract) |
+
+### Production validation
+
+- **`nexus-h8ge`** (closed 2026-05-08): live shakeout against shipped 4.27.0 binary. PR #590 landed; 56 T1 unit tests pass; new e2e test `TestE2ESessionIdSharedAcrossProcesses` passes (real chroma 6 s); full unit suite 6595 passed / 33 skipped / 0 failures. Live shell `put` + `list` round-trips after reinstall.
+- **Post-release fixes already shipped**: `nexus-svpq` (PR #596 — `NX_T1_ISOLATED=1` outranks env+addr-file discovery), `nexus-9h1s` (PR #598 — orphan multiprocessing tracker reaping at MCP startup). Six-bug class structurally eliminated; the seven T1 manifestations between #567 and #579 have not recurred.
+
+### Deferred follow-ups (cleared at close)
+
+Both surfaced during P4 review and originally deferred; resolved alongside the close:
+
+- **`nexus-7m8i`** (closed 2026-05-08): emit `t1_chroma_init_owned` info log on happy-path spawn. The pre-RDR-105 `_t1_chroma_init_if_owner` was silent on success; the same gap survived through P4's rewrite at `src/nexus/mcp/core.py:200-230` (only the no-claude-pid warning fired). Now emits one structured `info` per owner spawn with `host` / `port` / `server_pid` / `claude_pid` / `tmpdir`. Two regression tests in `TestLifespanNewDiscoveryGenerator` lock the behaviour.
+- **`nexus-9nbk`** (closed 2026-05-08): delete legacy `getsid`-keyed session helpers (`_stable_pid`, `session_file_path`, `write_session_file`, `read_session_id`). The pre-RDR-094 PID-keyed scheme survived P4 because `memory_store.py` still fell back through it for direct-CLI session resolution. Migrated to `read_claude_session_id`; the four legacy functions and their tests are removed.
+
+### Test coverage post-RDR-105
+
+- `tests/test_t1_discovery.py` — 56 unit tests covering the four `__init__` branches, env-passdown, addr-file discovery, isolation, and ephemeral mode.
+- `tests/integration/test_e2e_session_id_shared_across_processes.py` — real-chroma e2e for the dispatcher's `share_t1=True` contract.
+- `tests/test_session_propagation_hypotheses.py`, `tests/test_ppid_chain_hypothesis.py`, `tests/test_session_sweep_orphan_trackers.py` — supporting hypothesis + sweep coverage.
+
+No post-mortem: shipped declared scope across five phases, with the structural-bug-class elimination thesis confirmed by the absence of seventh-instance manifestations through 4.27.x → 4.28.0.

--- a/src/nexus/db/t2/memory_store.py
+++ b/src/nexus/db/t2/memory_store.py
@@ -38,7 +38,7 @@ from typing import Any, Literal
 
 import structlog
 
-from nexus.session import read_session_id as _read_session_id
+from nexus.session import read_claude_session_id as _read_session_id
 
 _log = structlog.get_logger()
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1424,7 +1424,7 @@ def memory_put(
         if not content:
             return "Error: content is required"
         # Translate empty strings to None so MemoryStore.put's
-        # fall-back chain (NX_AGENT env, _read_session_id) takes
+        # fall-back chain (NX_AGENT env, read_claude_session_id) takes
         # over rather than persisting literal empty strings.
         agent_arg = agent if agent else None
         # Resolve session at the MCP layer so NX_SESSION_ID env wins

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -211,6 +211,9 @@ async def _t1_chroma_lifespan(_app: Any):
         from nexus.mcp import _t1_state
         from nexus.session import find_immediate_claude_pid, write_t1_addr
 
+        import structlog
+        _spawn_log = structlog.get_logger()
+
         claude_pid = find_immediate_claude_pid()
         if claude_pid > 0:
             # Invariant: ``_t1_state.T1_ADDR`` and
@@ -220,9 +223,22 @@ async def _t1_chroma_lifespan(_app: Any):
             write_t1_addr(claude_pid, host, port)
             _t1_state.T1_ADDR = (host, port)
             _OWNED_CHROMA["t1_addr_claude_pid"] = claude_pid
+            # nexus-7m8i: happy-path observability. Pre-RDR-105 the
+            # equivalent code emitted only on the exception branches
+            # (minted, reconciled), leaving operators unable to
+            # distinguish "MCP started cleanly" from "MCP never reached
+            # the spawn step" by reading the log alone. One ``info``
+            # per owner spawn closes the gap.
+            _spawn_log.info(
+                "t1_chroma_init_owned",
+                host=host,
+                port=port,
+                server_pid=server_pid,
+                claude_pid=claude_pid,
+                tmpdir=str(tmpdir),
+            )
         else:
-            import structlog
-            structlog.get_logger().warning(
+            _spawn_log.warning(
                 "t1_addr_publish_skipped_no_claude_pid",
                 host=host,
                 port=port,

--- a/src/nexus/session.py
+++ b/src/nexus/session.py
@@ -122,52 +122,6 @@ def resolve_active_session_id(arg: str | None = None) -> str | None:
     return None
 
 
-def _stable_pid() -> int:
-    """Return a stable process-group anchor for legacy session file naming.
-
-    Lookup order:
-    1. ``NX_SESSION_PID`` env var — allows callers to pin a specific PID.
-    2. Process session leader (``os.getsid(0)``).
-
-    Note: os.getsid(0) is unreliable across Claude Code Bash subprocesses.
-    New code should use read_claude_session_id() / write_claude_session_id()
-    instead of session_file_path() / write_session_file() / read_session_id().
-    """
-    if raw := os.environ.get("NX_SESSION_PID"):
-        try:
-            return int(raw)
-        except ValueError:
-            pass  # intentional: invalid NX_SESSION_PID env var, fall through to os.getsid(0)
-    return os.getsid(0)
-
-
-def session_file_path(ppid: int | None = None) -> Path:
-    """Return the legacy getsid-keyed session file path."""
-    pid = ppid if ppid is not None else _stable_pid()
-    return _nexus_config_dir_at_import() / "sessions" / f"{pid}.session"
-
-
-def write_session_file(session_id: str, ppid: int | None = None) -> Path:
-    """Write *session_id* to the legacy getsid-keyed session file."""
-    path = session_file_path(ppid)
-    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    fd = os.open(str(path), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
-    try:
-        os.write(fd, session_id.encode())
-    finally:
-        os.close(fd)
-    return path
-
-
-def read_session_id(ppid: int | None = None) -> str | None:
-    """Read and return the session ID from the legacy getsid-keyed file, or None."""
-    try:
-        text = session_file_path(ppid).read_text().strip()
-        return text or None
-    except OSError:
-        return None  # intentional: session file not created yet, normal on first run
-
-
 # ── T1 server session management (RDR-010) ────────────────────────────────────
 
 _T1_SERVER_HOST: str = "127.0.0.1"

--- a/tests/test_config_dir_isolation.py
+++ b/tests/test_config_dir_isolation.py
@@ -28,10 +28,11 @@ def sandbox_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
     # Reload modules that resolve their path constants at import time so
     # the new env var takes effect within the test scope. Also reload
-    # nexus.db.t2.memory_store because it imports ``read_session_id``
-    # from nexus.session by name — a bare reload of nexus.session would
-    # leave memory_store pointing at the old function object and break
-    # the identity-check assertion in tests/test_memory.py.
+    # nexus.db.t2.memory_store because it imports
+    # ``read_claude_session_id`` from nexus.session by name — a bare
+    # reload of nexus.session would leave memory_store pointing at the
+    # old function object and break the identity-check assertion in
+    # tests/test_memory.py.
     import nexus.session
     import nexus.context
     import nexus.checkpoint
@@ -118,12 +119,6 @@ class TestSessionIsolatedUnderOverride:
 
         assert CLAUDE_SESSION_FILE == sandbox_dir / "current_session"
 
-
-
-    def test_session_file_path_redirects(self, sandbox_dir: Path):
-        from nexus.session import session_file_path
-
-        assert session_file_path(1234) == sandbox_dir / "sessions" / "1234.session"
 
 
 class TestCheckpointAndBufferRedirects:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -165,7 +165,7 @@ def test_t2_uses_session_module_for_session_id(db: T2Database) -> None:
     # moved with them. Patch the new location to verify the wiring.
     import nexus.db.t2.memory_store as mem_mod
     import nexus.session as sess_mod
-    assert mem_mod._read_session_id is sess_mod.read_session_id
+    assert mem_mod._read_session_id is sess_mod.read_claude_session_id
     with patch("nexus.db.t2.memory_store._read_session_id", return_value="test-sid-xyz"):
         row_id = db.put(project="p", title="t.md", content="x")
     assert db.get(id=row_id)["session"] == "test-sid-xyz"

--- a/tests/test_memory_put_attribution.py
+++ b/tests/test_memory_put_attribution.py
@@ -43,12 +43,15 @@ def isolated_t2(
     monkeypatch.setattr(infra, "default_db_path", lambda: db)
     monkeypatch.delenv("NX_AGENT", raising=False)
     monkeypatch.delenv("NX_SESSION_ID", raising=False)
-    # Default: no claude session file present (prevents legacy session
-    # file from leaking into MemoryStore.put's session resolution).
-    import nexus.session
-    monkeypatch.setattr(
-        nexus.session, "read_session_id", lambda ppid=None: None,
-    )
+    # Default: no claude session file present (prevents the real
+    # ``~/.config/nexus/current_session`` from leaking into
+    # MemoryStore.put's session resolution). Patches the alias binding
+    # inside memory_store directly because ``from X import Y as Z`` in
+    # memory_store captures the function object at import time;
+    # patching ``nexus.session.read_claude_session_id`` after that
+    # would not propagate.
+    import nexus.db.t2.memory_store as _ms
+    monkeypatch.setattr(_ms, "_read_session_id", lambda: None)
     return db
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,19 +1,20 @@
-"""AC1: Session ID is a valid UUID4, written to and readable from a PID-scoped file."""
-import json
+"""Session-id generator and Claude-session flat-file behaviours.
+
+The legacy getsid-keyed session-file scheme (``_stable_pid``,
+``session_file_path``, ``write_session_file``, ``read_session_id``)
+was deleted as the RDR-105 P4 follow-up tracked by ``nexus-9nbk``.
+Current callers use ``read_claude_session_id`` /
+``write_claude_session_id`` against the flat
+``~/.config/nexus/current_session`` file.
+"""
 import os
 import re
 import time
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
-from nexus.session import (
-    _stable_pid,
-    generate_session_id,
-    read_session_id,
-    write_session_file,
-)
+from nexus.session import generate_session_id
 
 
 def test_generate_session_id_is_uuid4() -> None:
@@ -23,63 +24,6 @@ def test_generate_session_id_is_uuid4() -> None:
 
 def test_generate_session_id_unique() -> None:
     assert generate_session_id() != generate_session_id()
-
-
-def test_write_and_read_session_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
-    sid = generate_session_id()
-
-    path = write_session_file(sid, ppid=99999)
-    assert path.exists()
-    assert path.read_text() == sid
-
-    recovered = read_session_id(ppid=99999)
-    assert recovered == sid
-
-
-def test_read_session_id_missing_returns_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
-    assert read_session_id(ppid=99998) is None
-
-
-def test_session_file_is_pid_scoped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
-    write_session_file("session-a", ppid=1001)
-    write_session_file("session-b", ppid=1002)
-
-    assert read_session_id(ppid=1001) == "session-a"
-    assert read_session_id(ppid=1002) == "session-b"
-
-
-# ── Behavior 1: _stable_pid() env var path ────────────────────────────────────
-
-def test_stable_pid_env_var_takes_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When NX_SESSION_PID is set, _stable_pid() returns that value and ignores getsid(0)."""
-    monkeypatch.setenv("NX_SESSION_PID", "77777")
-    with patch("nexus.session.os.getsid", return_value=99999):
-        result = _stable_pid()
-    assert result == 77777
-
-
-# ── Behavior 2: _stable_pid() getsid fallback ────────────────────────────────
-
-def test_stable_pid_falls_back_to_getsid(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When NX_SESSION_PID is unset, _stable_pid() returns os.getsid(0)."""
-    monkeypatch.delenv("NX_SESSION_PID", raising=False)
-    with patch("nexus.session.os.getsid", return_value=55555) as mock_getsid:
-        result = _stable_pid()
-    assert result == 55555
-    mock_getsid.assert_called_once_with(0)
-
-
-# ── Behavior 3: _stable_pid() invalid env var falls back ─────────────────────
-
-def test_stable_pid_invalid_env_var_falls_back_to_getsid(monkeypatch: pytest.MonkeyPatch) -> None:
-    """When NX_SESSION_PID is non-integer, _stable_pid() silently falls back to getsid(0)."""
-    monkeypatch.setenv("NX_SESSION_PID", "not-a-number")
-    with patch("nexus.session.os.getsid", return_value=44444):
-        result = _stable_pid()
-    assert result == 44444
 
 
 # ── write_session_record ──────────────────────────────────────────────────────

--- a/tests/test_t1_discovery.py
+++ b/tests/test_t1_discovery.py
@@ -1112,6 +1112,115 @@ class TestLifespanNewDiscoveryGenerator:
         finally:
             _t1_state.T1_ADDR = prev_addr
 
+    def test_branch3_emits_t1_chroma_init_owned_log(self, tmp_path, monkeypatch):
+        """nexus-7m8i: happy-path spawn emits exactly one
+        ``t1_chroma_init_owned`` info log with host/port/server_pid/
+        claude_pid/tmpdir. The no-claude-pid path emits the warning
+        instead (covered indirectly by the absence of the info)."""
+        import asyncio
+        import logging
+
+        import structlog
+        from structlog.testing import capture_logs
+
+        from nexus.mcp import _t1_state, core as mcp_core
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("NX_T1_HOST", raising=False)
+        monkeypatch.delenv("NX_T1_PORT", raising=False)
+        monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
+        monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+
+        # The default structlog wrapper filters at WARNING in test
+        # context; lower to INFO so capture_logs sees the happy-path
+        # event. Restored in the finally below.
+        prev_wrapper = structlog.get_config().get("wrapper_class")
+        structlog.configure(
+            wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        )
+        prev_addr = _t1_state.T1_ADDR
+        _t1_state.T1_ADDR = None
+        try:
+            with patch("nexus.session.start_t1_server",
+                       return_value=("127.0.0.1", 51515, 88888,
+                                     str(tmp_path / "chroma_tmpdir"))), \
+                 patch("nexus.session.stop_t1_server"), \
+                 patch("nexus.session.find_immediate_claude_pid",
+                       return_value=12321):
+                with capture_logs() as cap:
+                    async def _run():
+                        async with mcp_core._t1_chroma_lifespan(None):
+                            pass
+                    asyncio.run(_run())
+
+            owned_events = [
+                e for e in cap if e.get("event") == "t1_chroma_init_owned"
+            ]
+            assert len(owned_events) == 1, (
+                f"expected exactly one t1_chroma_init_owned event, "
+                f"got {len(owned_events)}: {owned_events}"
+            )
+            ev = owned_events[0]
+            assert ev["log_level"] == "info"
+            assert ev["host"] == "127.0.0.1"
+            assert ev["port"] == 51515
+            assert ev["server_pid"] == 88888
+            assert ev["claude_pid"] == 12321
+            assert ev["tmpdir"] == str(tmp_path / "chroma_tmpdir")
+
+            # The warning path must NOT fire on the happy branch.
+            warnings = [
+                e for e in cap
+                if e.get("event") == "t1_addr_publish_skipped_no_claude_pid"
+            ]
+            assert warnings == []
+        finally:
+            _t1_state.T1_ADDR = prev_addr
+            if prev_wrapper is not None:
+                structlog.configure(wrapper_class=prev_wrapper)
+
+    def test_branch3_no_claude_pid_emits_warning_not_info(
+        self, tmp_path, monkeypatch,
+    ):
+        """When ``find_immediate_claude_pid`` returns 0, the warning
+        fires and the happy-path info does NOT (nexus-7m8i symmetry)."""
+        import asyncio
+        from structlog.testing import capture_logs
+
+        from nexus.mcp import _t1_state, core as mcp_core
+
+        monkeypatch.setenv("NEXUS_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("NX_T1_HOST", raising=False)
+        monkeypatch.delenv("NX_T1_PORT", raising=False)
+        monkeypatch.delenv("NX_T1_ISOLATED", raising=False)
+        monkeypatch.delenv("NEXUS_SKIP_T1", raising=False)
+
+        prev_addr = _t1_state.T1_ADDR
+        _t1_state.T1_ADDR = None
+        try:
+            with patch("nexus.session.start_t1_server",
+                       return_value=("127.0.0.1", 51515, 88888,
+                                     str(tmp_path / "chroma_tmpdir"))), \
+                 patch("nexus.session.stop_t1_server"), \
+                 patch("nexus.session.find_immediate_claude_pid",
+                       return_value=0):
+                with capture_logs() as cap:
+                    async def _run():
+                        async with mcp_core._t1_chroma_lifespan(None):
+                            pass
+                    asyncio.run(_run())
+
+            owned = [e for e in cap if e.get("event") == "t1_chroma_init_owned"]
+            warned = [
+                e for e in cap
+                if e.get("event") == "t1_addr_publish_skipped_no_claude_pid"
+            ]
+            assert owned == []
+            assert len(warned) == 1
+            assert warned[0]["log_level"] == "warning"
+        finally:
+            _t1_state.T1_ADDR = prev_addr
+
     def test_branch3_no_claude_pid_skips_publish_but_keeps_chroma(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Summary

Closes RDR-105 (T1 chroma architecture: eliminate on-disk session records via env-var passdown) and clears the two deferred follow-ups surfaced during P4 review:

- **nexus-7m8i**: emit `t1_chroma_init_owned` info log on happy-path spawn. The pre-RDR-105 `_t1_chroma_init_if_owner` was silent on success; the same gap survived through P4 at `mcp/core.py:200-230`. Now emits one structured `info` per owner spawn with `host` / `port` / `server_pid` / `claude_pid` / `tmpdir`. Two regression tests added.
- **nexus-9nbk**: delete legacy `getsid`-keyed session helpers (`_stable_pid`, `session_file_path`, `write_session_file`, `read_session_id`). Migrated `memory_store.py` to `read_claude_session_id()`; the four legacy functions and their tests are removed (-104 lines net).

## RDR-105 close

- Implementation shipped via 5-phase epic `nexus-d73b` (closed) in conexus 4.27.0.
- ~5000 LOC removed; six-bug class structurally eliminated; no seventh-instance manifestations through 4.27.x → 4.28.0.
- Production validation: `nexus-h8ge` closed (PR #590 + e2e + full suite green); post-release fixes shipped via `nexus-svpq` (PR #596) and `nexus-9h1s` (PR #598).

Gap closure pointers (verified at close):
- Gap 1 (multi-writer record race) → `src/nexus/mcp/_t1_state.py:22`
- Gap 2 (cross-process idempotency) → `src/nexus/mcp/core.py:139`
- Gap 3 (silent ephemeral fallback) → `src/nexus/db/t1.py:226`
- Gap 4 (watchdog role conflation) → `src/nexus/session.py:813`
- Gap 5 (sub-agent sharing contract) → `src/nexus/operators/dispatch.py:44`

## Closes

- nexus-h8ge (closed via `bd close` 2026-05-08)
- nexus-7m8i (closed via `bd close` 2026-05-08)
- nexus-9nbk (closed via `bd close` 2026-05-08)
- RDR-105 (closed via `/nx:rdr-close` 2026-05-08)

## Test plan

- [x] `uv run pytest tests/test_t1_discovery.py` — 62 passed (incl. 2 new for nexus-7m8i)
- [x] `uv run pytest tests/test_session.py tests/test_memory.py tests/test_memory_put_attribution.py tests/test_config_dir_isolation.py` — 75 passed
- [x] `uv run pytest tests/ -k "t1 or session or memory or mcp"` — 555 passed, no regressions