### PR TITLE
test(conftest): isolate NEXUS_CONFIG_DIR per test (nexus-mrmq)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,47 @@ def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.fixture(autouse=True)
+def _isolate_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect NEXUS_CONFIG_DIR so child processes write under tmp_path.
+
+    nexus-mrmq: integration tests that dispatch ``claude -p`` subprocesses
+    (the operator dispatch path, plan-runner, nx_answer equivalence
+    suite) inherit the parent's ``os.environ``. Without this fixture
+    the child resolves ``nexus_config_dir()`` to the user's real
+    ``~/.config/nexus/`` and writes ``current_session`` /
+    ``t1_addr.<claude_pid>`` files there. Reproduced 2026-05-08 during
+    4.27.1 shakeout: a transient ``claude_dispatch -p`` subprocess
+    rewrote the live MCP's session file and unlinked its addr file
+    mid-session.
+
+    Setting ``NEXUS_CONFIG_DIR`` here is read at call time inside
+    ``nexus.config.nexus_config_dir()`` and propagates to children
+    via ``os.environ`` inheritance, so every spawned subprocess
+    (regardless of operator-dispatch mode) writes its config files
+    under the per-test tmp dir.
+
+    Tests that need to assert the default path (``Path.home() /
+    .config / nexus``) explicitly ``monkeypatch.delenv`` first; that
+    still works because this fixture's ``monkeypatch.setenv`` is
+    overridden by any later test-local ``setenv`` / ``delenv`` call.
+
+    Path layout mirrors the natural ``~/.config/nexus`` relative
+    layout (``tmp_path/.config/nexus``) so per-test fixtures that
+    set ``HOME=tmp_path`` and write into ``tmp_path/.config/nexus/``
+    (e.g. ``test_scratch_cmd.fake_home``) land at the same path
+    ``read_claude_session_id`` resolves to via ``NEXUS_CONFIG_DIR``.
+
+    The directory itself is *not* pre-created — write helpers
+    (``write_claude_session_id``, ``write_t1_addr``, etc.) all do
+    ``parents=True, exist_ok=True`` themselves, and tests that
+    explicitly call ``mkdir(parents=True)`` without ``exist_ok``
+    on the same path would otherwise hit ``FileExistsError``.
+    """
+    config_dir = tmp_path / ".config" / "nexus"
+    monkeypatch.setenv("NEXUS_CONFIG_DIR", str(config_dir))
+
+
+@pytest.fixture(autouse=True)
 def _isolate_catalog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Redirect NEXUS_CATALOG_PATH so tests never pollute the real user catalog.
 

--- a/tests/test_config_dir_isolation.py
+++ b/tests/test_config_dir_isolation.py
@@ -74,6 +74,102 @@ class TestCanonicalHelper:
         assert nexus_config_dir() == tmp_path
 
 
+class TestAutouseConfigDirIsolation:
+    """nexus-mrmq regression: the autouse ``_isolate_config_dir`` fixture
+    must redirect ``NEXUS_CONFIG_DIR`` to a tmp dir so child processes
+    spawned by integration tests (``claude_dispatch -p``, plan-runner,
+    nx_answer equivalence suite) inherit the redirect via
+    ``os.environ`` and write ``current_session`` /
+    ``t1_addr.<claude_pid>`` files under tmp instead of the user's
+    real ``~/.config/nexus/``.
+
+    These tests intentionally do NOT delenv ``NEXUS_CONFIG_DIR`` —
+    they assert the autouse fixture's effect.
+    """
+
+    def test_env_var_set_to_non_home_path(self):
+        env_path = os.environ.get("NEXUS_CONFIG_DIR", "")
+        assert env_path, (
+            "NEXUS_CONFIG_DIR is unset — the autouse _isolate_config_dir "
+            "fixture in tests/conftest.py is missing or has been disabled. "
+            "This is the guardrail that prevents integration-test "
+            "subprocesses from rewriting the user's real "
+            "~/.config/nexus/current_session and t1_addr.<pid> files."
+        )
+        real_config = Path.home() / ".config" / "nexus"
+        assert Path(env_path) != real_config, (
+            "NEXUS_CONFIG_DIR resolves to the user's real config "
+            "directory; integration-test isolation is broken."
+        )
+
+    def test_config_dir_resolves_under_tmp(self):
+        """``nexus_config_dir()`` follows the autouse redirect."""
+        from nexus.config import nexus_config_dir
+
+        resolved = nexus_config_dir()
+        real_config = Path.home() / ".config" / "nexus"
+        assert resolved != real_config
+
+    def test_subprocess_inherits_redirected_path(self):
+        """A subprocess that imports nexus and reads
+        ``nexus_config_dir()`` must resolve to the autouse tmp dir,
+        not the user's home. This is the actual leak path: a child
+        process inheriting ``os.environ`` from pytest must see the
+        override.
+        """
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [
+                sys.executable, "-c",
+                "from nexus.config import nexus_config_dir; "
+                "print(nexus_config_dir())",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        child_path = result.stdout.strip()
+        real_config = str(Path.home() / ".config" / "nexus")
+        assert child_path != real_config, (
+            f"Child subprocess resolved nexus_config_dir() to "
+            f"{child_path!r}, the user's real home. The autouse "
+            "fixture's NEXUS_CONFIG_DIR did not propagate via "
+            "os.environ inheritance."
+        )
+
+    def test_user_real_config_untouched_by_leak_pattern(self, tmp_path):
+        """End-to-end: simulate the leak pattern (a child process
+        writing ``current_session``) and verify it lands under tmp,
+        not under the user's home."""
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [
+                sys.executable, "-c",
+                "from nexus.session import write_claude_session_id; "
+                "write_claude_session_id('test-leak-uuid'); "
+                "from nexus.session import claude_session_file; "
+                "print(claude_session_file())",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        written_path = Path(result.stdout.strip())
+        real_session_file = Path.home() / ".config" / "nexus" / "current_session"
+        assert written_path != real_session_file, (
+            f"Child wrote current_session to {written_path!r}, the "
+            "user's real session file. Integration-test isolation is "
+            "broken."
+        )
+        # Confirm the autouse tmp dir actually received the write.
+        assert written_path.exists()
+        assert written_path.read_text().strip() == "test-leak-uuid"
+
+
 class TestT2IsolatedUnderOverride:
     def test_default_db_path_redirects(self, sandbox_dir: Path):
         from nexus.commands._helpers import default_db_path


### PR DESCRIPTION
## Summary

Adds an autouse fixture in `tests/conftest.py` that redirects `NEXUS_CONFIG_DIR` to `tmp_path/.config/nexus` for every test. The env var propagates to children via `os.environ` inheritance, so every spawned subprocess (operator dispatch, plan-runner, nx_answer equivalence, `claude_dispatch -p`) writes its config files under the per-test tmp dir instead of the user's real `~/.config/nexus/`.

## Why

Reproduced 2026-05-08 during 4.27.1 shakeout: `uv run pytest -m integration` rewrote the live MCP's `~/.config/nexus/current_session` from the canonical session UUID to one minted by a transient `claude_dispatch -p` subprocess, and unlinked the live `t1_addr.<claude_pid>` file. Integration tests dispatch child `claude -p` that fork their own MCP lifespans; without `NEXUS_CONFIG_DIR` set, the child resolves to the user's real `~/.config/nexus/` and writes there.

## Path layout

The autouse fixture uses `tmp_path/.config/nexus` (the natural `~/.config/nexus` relative layout) so per-test fixtures that set `HOME=tmp_path` and write into `tmp_path/.config/nexus/` (e.g. `test_scratch_cmd.fake_home`) land at the same path `read_claude_session_id` resolves to via `NEXUS_CONFIG_DIR`. The directory is not pre-created so tests that call `mkdir(parents=True)` without `exist_ok` keep working.

## Coverage

New `TestAutouseConfigDirIsolation` class in `test_config_dir_isolation.py`:

- Fixture sets the env var to a non-home path.
- `nexus_config_dir()` follows the redirect.
- Child Python subprocess inherits the redirect via `os.environ`.
- Child writing `current_session` lands under tmp, not the user's real `~/.config/nexus/current_session` — the literal leak the bead recorded.

## Closes

- nexus-mrmq

## Test plan

- [x] `uv run pytest tests/test_config_dir_isolation.py` — 28 passed
- [x] `uv run pytest tests/test_config.py tests/test_config_cmd.py tests/test_context.py tests/test_tuning_config.py tests/test_scratch_cmd.py tests/test_mineru_cmd.py` — 148 passed (no regressions in tests that touch config / HOME)
- [x] `uv run pytest tests/ -q --ignore=tests/integration` — 6635 passed, 33 skipped, 0 failures