### PR TITLE
release(4.29.1): catalog destructive-verb safety + backup-before-delete

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.29.0"
+      "version": "4.29.1"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.29.0"
+      "version": "4.29.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,88 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.29.1] - 2026-05-08
+
+Patch release. Hardens the catalog's destructive-verb surface
+caught during the 4.29.0 prod shakeout: ``nx catalog prune-stale``
+narrowly misclassified 11,766 valid relative-path entries as
+stale because of a cwd-dependent ``Path.exists()`` check
+(nexus-6ims). Plus two adjacent safety regressions
+(``catalog gc`` deletes-by-default, ``link-bulk-delete`` no
+``--confirm``) and a backup-before-delete safety net
+(RDR-106 Option A).
+
+### Fixed
+
+- **``nx catalog prune-stale`` cwd-dependent classification**
+  (nexus-6ims P0): pre-fix logic used ``Path(fp).exists()`` to
+  classify entries as stale, which only worked for absolute
+  paths. Relative paths (most catalog entries store paths
+  relative to their owner's repo_root) resolved against the
+  running process's cwd; running the verb from any cwd other
+  than the entry's owning repo over-classified valid entries.
+  Caught 2026-05-08 during prod shakeout: a live catalog with
+  23,370 documents reported 11,837 "stale" entries when only
+  71 were actually stale. Post-fix: relative paths resolve
+  against ``owner.repo_root`` (RDR-060); owners without a
+  ``repo_root`` skip with a structured warning rather than
+  auto-classifying as stale.
+- **``nx t3 prune-stale`` cwd bug** (same root cause): chunk
+  ``source_path`` resolution now joins through the catalog to
+  pick up the owning document's ``owner.repo_root``. Owners
+  with no ``repo_root`` skip with the same fail-safe.
+  Critical because T3 chunk deletion is unrecoverable without
+  re-embedding (Voyage cost) and there's no event-log audit
+  trail like the catalog has.
+- **``nx catalog gc`` deletes-by-default** (nexus-tnz3 P1):
+  ``--dry-run`` was opt-in (default deletes). A typo or
+  forgotten flag silently dropped orphan entries. Inverted to
+  match ``prune-stale``: dry-run by default, ``--no-dry-run
+  --confirm`` required to actually delete.
+- **``nx catalog link-bulk-delete`` lacks ``--confirm``**
+  (nexus-9nim P2): hidden verb with the same delete-by-default
+  pattern. Hidden so casual usage was unlikely, but still on
+  the destructive-verb surface. Now matches the
+  ``prune-stale`` / ``gc`` shape.
+
+### Added
+
+- **Backup-before-delete safety net** (RDR-106 Option A):
+  every destructive catalog verb (``delete``, ``gc``,
+  ``prune-stale``, ``link-bulk-delete``) writes a JSONL
+  snapshot of the rows about to be deleted to
+  ``$NEXUS_CONFIG_DIR/catalog/.deleted-backups/`` BEFORE the
+  actual delete. The snapshot captures the full document row
+  + inbound and outbound links so an undelete can fully
+  reconstruct the document AND its position in the link
+  graph.
+- **``nx catalog undelete <backup-file>``**: restores the
+  documents and links from a backup snapshot via event-sourced
+  ``DocumentRegistered`` / ``LinkCreated`` events. Documents
+  are restored with their ORIGINAL tumblers; the tumbler
+  minting path is bypassed.
+- **``nx catalog list-backups``**: enumerates available
+  backup snapshots newest-first with verb, timestamp, row
+  count, and reason.
+- **``nx catalog vacuum-backups``**: drops backup files past
+  the retention window (default 30 days). Defaults to
+  dry-run; ``--no-dry-run`` to actually remove.
+
+### Filed for follow-up
+
+- **RDR-106** (draft): proper soft-delete via tombstone
+  columns on the catalog projection. The 4.29.1 backup
+  pattern is a recovery affordance; RDR-106 is the full
+  architectural answer with grace-window semantics, in-tree
+  state, and read-path filtering.
+
+### Closed
+
+- nexus-6ims (P0): catalog + t3 prune-stale cwd-dependent
+  classification
+- nexus-tnz3 (P1): catalog gc deletes-by-default
+- nexus-9nim (P2): link-bulk-delete missing --confirm
+
 ## [4.29.0] - 2026-05-08
 
 Minor release. Decomposes the 4434-LOC ``catalog.py`` god object into a

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -128,6 +128,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-103](rdr-103-catalog-collection-name-authority.md) | Catalog as Collection-Name Authority | Architecture | Closed | 2026-05-03 |
 | [RDR-104](rdr-104-incremental-catalog-projection-rebuild.md) | Incremental Catalog Projection Rebuild | Architecture | Closed | 2026-05-05 |
 | [RDR-105](rdr-105-t1-chroma-architecture-env-passdown.md) | T1 Chroma Architecture: Eliminate On-Disk Session Records via Env-Var Passdown | Architecture | Closed | 2026-05-07 |
+| [RDR-106](rdr-106-soft-delete-tombstone-column.md) | Soft-Delete via Tombstone Columns on Catalog Projection | Architecture | Draft | 2026-05-08 |
 
 ---
 

--- a/docs/rdr/rdr-106-soft-delete-tombstone-column.md
+++ b/docs/rdr/rdr-106-soft-delete-tombstone-column.md
@@ -1,0 +1,393 @@
+---
+title: "Soft-Delete via Tombstone Columns on Catalog Projection"
+id: RDR-106
+type: Architecture
+status: draft
+priority: high
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-08
+related_issues: [nexus-6ims, nexus-tnz3, nexus-9nim]
+---
+
+# RDR-106: Soft-Delete via Tombstone Columns on Catalog Projection
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+The catalog's destructive verbs (`nx catalog delete`, `gc`,
+`prune-stale`, `link-bulk-delete`; `nx t3 prune-stale`) physically
+drop rows from the projection (and chunks from T3) in a single
+transaction. Recovery requires a full rebuild from `events.jsonl`
+(catalog) or a re-index from source (T3, with re-embedding cost).
+The 2026-05-08 prod shakeout caught `nx catalog prune-stale`
+about to delete 11,766 valid catalog entries because of a
+cwd-dependent `Path(fp).exists()` classification bug
+(nexus-6ims). Only the user's intuition ("have we checked these
+aren't misclassified?") averted a hard-to-recover-from incident.
+
+The 4.29.1 release bundled a backup-before-delete safety net
+(JSONL snapshot to `.deleted-backups/`, `nx catalog undelete`
+verb) plus the cwd fix. That covers the immediate hazard but
+leaves the structural gap: physical delete is the only delete.
+There is no in-projection "trashed" state to filter or undo
+without an explicit recovery action. Reads of a deleted tumbler
+return `None`; the link graph silently loses the edges; UI
+surfaces show empty results. A second mistake on top of a backup
+(or after the backup TTL elapses) loses the data.
+
+### Enumerated gaps to close
+
+#### Gap 1: Reads can't distinguish "never existed" from "deleted"
+
+`Catalog.resolve(tumbler)` returns `None` for both
+"tumbler-never-registered" and "tumbler-deleted-via-prune-stale".
+Callers that need to know which case applies (audit tools, UI
+banners, link-graph repair) have no signal. A tombstone-aware
+read could surface the deleted state.
+
+#### Gap 2: Recovery requires explicit verb invocation
+
+Backup-before-delete (4.29.1) preserves the audit trail but
+recovery is operator-driven (`nx catalog undelete <backup>`).
+There is no automatic grace period; a deletion is functionally
+permanent at the moment the verb runs. A tombstone column makes
+"undelete within N days" a flag flip rather than a side-channel
+restore.
+
+#### Gap 3: Backup files are out-of-tree state
+
+`.deleted-backups/<verb>-<ts>.jsonl` files live alongside the
+catalog dir but are NOT tracked in git, NOT replicated by
+`nx catalog sync`, and NOT visible to `nx catalog stats` or
+`doctor`. A second machine pulling the catalog has no view of
+recent deletions. A tombstone column is in the canonical
+projection — visible everywhere the projection is.
+
+#### Gap 4: Link graph integrity during the grace window
+
+When a document is hard-deleted, the link graph loses BOTH the
+inbound and outbound edges. If the deletion was a mistake, the
+edges are lost too — the catalog can't rebuild them without the
+backup. With tombstone columns, edges remain in the graph but
+filter out by default; the relationship is recoverable atomic
+with the document.
+
+## Context
+
+### Background
+
+RDR-101 (event-sourced catalog) established events.jsonl as
+canonical truth; the SQLite projection is regenerated on demand.
+That model already provides "soft" history at the event-log
+level — a deleted document is still in the log. But the
+projection drops the row, and every read goes through the
+projection. The events.jsonl preserves the audit trail; it does
+not provide read-time filtering, undo, or grace-period semantics.
+
+The 4.29.1 backup-before-delete pattern (Option A in the
+2026-05-08 verb-safety review) is a recovery affordance bolted
+onto physical deletes. It works for "I deleted the wrong thing
+yesterday," but doesn't change the read semantics or provide a
+grace window. Tombstone columns are the proper architectural
+fix.
+
+### Technical Environment
+
+- `documents` SQLite table — currently no `deleted_at` column
+- `links` SQLite table — same
+- `collections` SQLite table — already has `superseded_by` /
+  `superseded_at` (a partial form of soft-delete via
+  supersession; the new tombstone columns generalize this)
+- `Projector.apply` verbs — currently `DocumentDeleted` does
+  `DELETE FROM documents WHERE tumbler = ?`; the new verb
+  `DocumentSoftDeleted` would `UPDATE documents SET
+  deleted_at = ?, deleted_reason = ?`
+- All read paths in `_DocumentOps` and `_LinkOps` need to filter
+  on `deleted_at IS NULL OR deleted_at = ''` by default
+
+## Research Findings
+
+### Investigation
+
+(to be filled during /nx:rdr-research)
+
+### Critical Assumptions
+
+- [ ] **Existing events.jsonl deletions can be coalesced into the
+  new schema without losing history** — Status: unverified.
+  Method: write a migration that walks `DocumentDeleted` events
+  and re-emits them as `DocumentSoftDeleted` with a synthetic
+  `deleted_at` from the original event timestamp, then a
+  follow-up `DocumentPurged` for the actual SQL DELETE. Replay
+  equality should hold.
+- [ ] **All read paths can be uniformly filtered** — Status:
+  needs audit. Some read paths (audit tooling, doctor checks)
+  legitimately want to see soft-deleted rows. The right
+  abstraction is a `include_deleted=False` parameter that
+  defaults to False but threads through.
+- [ ] **Performance: adding `WHERE deleted_at IS NULL` to every
+  query is acceptable** — Status: assumed safe based on the
+  existing `superseded_by` filter pattern, but should benchmark
+  against a 23K-document catalog.
+
+## Proposed Solution
+
+### Approach
+
+Add `deleted_at` (TEXT, ISO 8601) and `deleted_reason` (TEXT)
+columns to `documents` and `links`. Keep the existing
+`superseded_by` / `superseded_at` on `collections` (semantic
+overlap is acceptable; collections supersede, documents/links
+soft-delete). New projector verbs:
+
+- `DocumentSoftDeleted` — `UPDATE documents SET deleted_at = ?,
+  deleted_reason = ? WHERE tumbler = ?`
+- `LinkSoftDeleted` — same shape on links
+- `DocumentPurged` — `DELETE FROM documents WHERE tumbler = ?`
+  (the actual destructive op; only emitted by
+  `nx catalog purge` after the grace window)
+- `LinkPurged` — same shape on links
+
+The existing `DocumentDeleted` and `LinkDeleted` events stay in
+events.jsonl for back-compat; they project to soft-delete
+semantics post-migration (UPDATE rather than DELETE) so old
+events replay into the new schema correctly.
+
+New `nx catalog purge --older-than 30d` verb walks the
+soft-deleted rows and emits `*Purged` events for those past the
+grace window. Default grace period is 30 days.
+
+`Catalog.resolve(tumbler)` filters `deleted_at IS NULL` by
+default; `Catalog.resolve(tumbler, include_deleted=True)`
+surfaces it. Same parameter on `find`, `by_*`, link query
+methods.
+
+`nx catalog undelete <tumbler>` emits `DocumentUndeleted` event
+that clears the columns. Reversible while soft-deleted; not
+reversible after purge.
+
+### Technical Design
+
+(to be filled during /nx:rdr-research and /nx:create-plan)
+
+#### Phase 1: Schema migration
+
+- Add `deleted_at TEXT DEFAULT ''` and `deleted_reason TEXT
+  DEFAULT ''` to `documents` and `links` via T2 migration step
+  (idempotent; checks for column existence before adding).
+- Migration also walks events.jsonl: for every
+  `DocumentDeleted` / `LinkDeleted` event, emits a
+  corresponding `*Purged` event so the projection stays
+  consistent. Old events are NOT rewritten in place; the
+  projector handles both shapes.
+
+#### Phase 2: Projector verbs
+
+- `_v0_document_soft_deleted`, `_v0_document_purged`,
+  `_v0_document_undeleted` — all idempotent.
+- `_v0_link_soft_deleted`, `_v0_link_purged`,
+  `_v0_link_undeleted` — same.
+- Existing `_v0_document_deleted` and `_v0_link_deleted` rewire
+  to call the soft-delete projector internally (back-compat).
+
+#### Phase 3: Read-path filter
+
+- `_DocumentOps.resolve` / `find` / `by_*` /
+  `list_by_collection` / `all_documents` — add
+  `include_deleted=False` parameter, default False.
+- `_LinkOps.links_from` / `links_to` / `link_query` /
+  `bulk_unlink` — same.
+- SQL filter: `WHERE (deleted_at IS NULL OR deleted_at = '')`
+  appended to existing WHERE clauses.
+
+#### Phase 4: New verbs
+
+- `nx catalog undelete <tumbler>` — reversal within grace.
+- `nx catalog purge --older-than 30d` — physical delete after
+  grace.
+- `nx catalog list-deleted` — show soft-deleted entries with
+  age + reason (operator visibility).
+- Existing destructive verbs (`delete`, `gc`, `prune-stale`,
+  `link-bulk-delete`) rewire to emit `*SoftDeleted` events
+  instead of `*Deleted`. The 4.29.1 backup pattern stays as
+  belt-and-suspenders.
+
+#### Phase 5: Doctor + tests
+
+- `nx catalog doctor --soft-delete-health` — count
+  soft-deleted, age distribution, oldest entry.
+- Replay-equality must handle the new verbs.
+- Test coverage: per-verb soft-delete + undelete + purge cycle,
+  read-path filter (default + override), backwards-compat with
+  old `DocumentDeleted` events.
+
+### Decision Rationale
+
+(to be filled during /nx:rdr-research)
+
+## Alternatives Considered
+
+### Alternative A: Backup-before-delete only (4.29.1 Option A)
+
+Pure recovery layer; no schema change; no read-path changes.
+Pros: trivial, immediate. Cons: doesn't solve gap 1 (reads
+can't distinguish), gap 2 (recovery is operator-driven), gap 3
+(backup files are out-of-tree), gap 4 (link graph still loses
+edges atomically with the document). Adopted as the 4.29.1
+safety net but insufficient as the long-term answer.
+
+### Alternative B: Supersession-based soft-delete (Option C)
+
+Reuse the existing `supersede_collection` / `set_alias`
+mechanism. Set `superseded_by='__deleted__'` on documents /
+links. Pros: zero schema change. Cons: semantic conflation
+(supersession means "replaced by Y"; using it for "deleted, no
+replacement" muddies a clean abstraction). Read paths that
+already filter superseded would extend; many don't and need
+surgery anyway. Net surgery comparable to schema-add.
+
+### Alternative C: Trash table
+
+Move deleted rows to a parallel `trashed_documents` table.
+Pros: keeps the live table clean. Cons: every read that wants
+"include deleted" needs a UNION; the trash table needs its own
+indexes; schema duplication; doesn't generalize cleanly to
+links and collections.
+
+### Briefly Rejected
+
+- Per-row `is_deleted BOOL` instead of `deleted_at` — loses
+  age info needed for grace-window purge. Tombstone column with
+  timestamp is the canonical pattern.
+- Hard-delete with a `deleted_log` audit table — equivalent to
+  the 4.29.1 backup pattern at higher complexity. Adopted at
+  the file level (`.deleted-backups/`) instead.
+
+## Trade-offs
+
+### Consequences
+
+- **Read-path performance**: every catalog read filters on the
+  new column. SQLite handles this efficiently with an index on
+  `deleted_at`, but every WHERE clause grows by one predicate.
+  Benchmarks against the 23K-document prod catalog will measure
+  the actual cost.
+- **Replay-equality complexity**: the projector now has 6
+  document/link verbs (Registered, SoftDeleted, Undeleted,
+  Purged, Updated, plus the legacy Deleted that maps to
+  SoftDeleted). Replay-equality testing surface widens.
+- **Grace window operational discipline**: operators must run
+  `nx catalog purge` (or wait for an automatic schedule) to
+  reclaim space. Without it, soft-deleted rows accumulate.
+
+### Risks and Mitigations
+
+- **Risk**: Migration leaves projection inconsistent with
+  events.jsonl.
+  **Mitigation**: Migration is replay-equivalent — running
+  `nx catalog doctor --replay-equality` after migration must
+  pass (modulo the new `deleted_at` columns which are part of
+  both live and projected state).
+- **Risk**: `include_deleted=False` parameter forgotten on a
+  read path → soft-deleted rows leak.
+  **Mitigation**: All read methods on `_DocumentOps` /
+  `_LinkOps` get the parameter at extraction time; lint-style
+  test scans for any new read method that doesn't accept it.
+
+### Failure Modes
+
+- Soft-delete row count growing unboundedly without `purge`
+  cron → projection grows but reads stay correct (filtered).
+- Migration dry-run shows replay-equality divergence → block
+  release.
+
+## Implementation Plan
+
+### Prerequisites
+
+- 4.29.1 backup-before-delete shipped (Option A done).
+- Schema-migration framework supports column additions
+  (already exists; T2 migrations).
+
+### Phases
+
+P1: Schema migration + projector verbs (no read-path changes
+yet; events.jsonl still uses old verbs; projector translates).
+P2: Read-path filter on `_DocumentOps` and `_LinkOps`.
+P3: New verbs (undelete, purge, list-deleted).
+P4: Existing destructive verbs rewired to emit `*SoftDeleted`.
+P5: Doctor checks + backwards-compat smoke tests.
+
+### Minimum Viable Validation
+
+- Schema migration runs cleanly on the 23K-document prod
+  catalog (`nx catalog doctor --replay-equality` passes
+  post-migration).
+- `nx catalog delete <tumbler>` followed by
+  `nx catalog undelete <tumbler>` round-trips cleanly.
+- `nx catalog purge --older-than 30d` only deletes rows with
+  `deleted_at` older than 30 days.
+- Read paths return None for soft-deleted by default; surface
+  with `include_deleted=True`.
+
+## Test Plan
+
+(to be filled during /nx:rdr-research)
+
+## Validation
+
+### Testing Strategy
+
+(to be filled during /nx:rdr-research)
+
+## Finalization Gate
+
+> Complete each item with a written response before
+> marking this RDR as **Accepted**. Written responses
+> prevent rubber-stamping and produce a review record.
+
+### Contradiction Check
+
+(to be filled at gate time)
+
+### Assumption Verification
+
+(to be filled at gate time)
+
+### Scope Verification
+
+(to be filled at gate time)
+
+### Cross-Cutting Concerns
+
+- **Versioning**: schema bump (T2 migration); event-log
+  back-compat preserved.
+- **Build tool compatibility**: N/A
+- **Licensing**: N/A
+- **Deployment model**: ships in conexus wheel.
+- **Incremental adoption**: existing catalogs migrate on first
+  Catalog construction post-upgrade.
+- **Memory management**: N/A
+- **Secret/credential lifecycle**: N/A
+
+### Proportionality
+
+Right-sized: schema additions are minimal (2 columns × 2
+tables); the projector verb count grows from 2 to 6 per kind,
+but each verb is a one-line UPDATE/DELETE; read-path filter is
+a one-clause WHERE addition. Multi-week implementation
+matches the value: structural answer to the data-loss verb
+class identified in the 2026-05-08 review.
+
+## References
+
+- nexus-6ims (P0): catalog prune-stale + t3 prune-stale cwd bug
+- nexus-tnz3 (P1): catalog gc default-flip
+- nexus-9nim (P2): link-bulk-delete --confirm
+- 4.29.1 release: backup-before-delete (Option A)
+- RDR-101: event-sourced catalog (the substrate this builds on)
+- RDR-104: incremental projection rebuild (the substrate the
+  migration uses)

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.29.0",
+  "version": "4.29.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.29.1] - 2026-05-08
+
+Plugin version aligned with conexus 4.29.1. No plugin-side changes;
+the release ships in the conexus package: catalog destructive-verb
+hardening (cwd bug fix on ``prune-stale``, default-flips on ``gc``
+and ``link-bulk-delete``) plus a backup-before-delete safety net
+for recovery via the new ``nx catalog undelete`` /
+``list-backups`` / ``vacuum-backups`` verbs. RDR-106 filed as the
+proper soft-delete architectural answer (follow-up).
+See root ``CHANGELOG.md`` for the full breakdown.
+
 ## [4.29.0] - 2026-05-08
 
 Plugin version aligned with conexus 4.29.0. No plugin-side changes; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.29.0"
+version = "4.29.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.29.0",
+  "version": "4.29.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/catalog/catalog_backup.py
+++ b/src/nexus/catalog/catalog_backup.py
@@ -1,0 +1,430 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Backup-before-delete safety net for the catalog (4.29.1 / RDR-106
+Option A).
+
+Every destructive catalog verb (``delete``, ``gc``, ``prune-stale``,
+``link-bulk-delete``, ``t3 prune-stale``) snapshots the rows
+about to be deleted to JSONL under
+``$NEXUS_CONFIG_DIR/catalog/.deleted-backups/`` BEFORE the actual
+delete. ``nx catalog undelete <backup-file>`` re-registers them;
+``nx catalog vacuum-backups`` drops files older than the retention
+window (default 30 days).
+
+Pure recovery layer — no schema change, no projector change, no
+read-path filter. The backup files are out-of-tree (gitignored
+by the catalog dir's ``.gitignore``) and per-machine.
+
+Storage layout::
+
+    $NEXUS_CONFIG_DIR/catalog/.deleted-backups/
+        catalog-delete-2026-05-08T20-15-00-<short>.jsonl
+        catalog-gc-2026-05-08T21-30-00-<short>.jsonl
+        catalog-prune-stale-2026-05-08T22-00-00-<short>.jsonl
+        catalog-link-bulk-delete-2026-05-08T22-15-00-<short>.jsonl
+        t3-prune-stale-2026-05-08T22-30-00-<short>.jsonl
+
+Each file is JSONL with a header record (``kind="header"``) carrying
+the verb, timestamp, reason, and operator-supplied filter args, plus
+one record per deleted entity. The header is the first line so a
+``head -1`` quickly summarises what a backup contains.
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterable
+
+import structlog
+
+if TYPE_CHECKING:
+    from nexus.catalog.catalog import Catalog
+
+_log = structlog.get_logger(__name__)
+
+
+_BACKUP_DIRNAME: str = ".deleted-backups"
+_DEFAULT_RETENTION_DAYS: int = 30
+
+
+def _backup_dir(catalog: "Catalog") -> Path:
+    """Return the backup dir path; create it on demand."""
+    d = catalog._dir / _BACKUP_DIRNAME
+    d.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return d
+
+
+def _timestamp() -> str:
+    """ISO 8601 timestamp with hyphens (filesystem-safe)."""
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%S")
+
+
+def _short_id() -> str:
+    """4-byte hex tag; collision-resistant within one timestamp second."""
+    return secrets.token_hex(4)
+
+
+@dataclass(frozen=True)
+class BackupRecord:
+    """Metadata for a single backup file (the header line)."""
+
+    verb: str
+    timestamp: str
+    reason: str
+    args: dict
+    rows_count: int
+    path: Path
+
+    @classmethod
+    def from_file(cls, path: Path) -> "BackupRecord":
+        """Read the header line + count rows from a backup file."""
+        with path.open("r") as f:
+            header_line = f.readline()
+        header = json.loads(header_line)
+        rows = sum(1 for _ in path.open()) - 1  # subtract header
+        return cls(
+            verb=header.get("verb", ""),
+            timestamp=header.get("timestamp", ""),
+            reason=header.get("reason", ""),
+            args=header.get("args", {}),
+            rows_count=rows,
+            path=path,
+        )
+
+
+def snapshot_documents(
+    catalog: "Catalog",
+    tumblers: Iterable[str],
+    *,
+    verb: str,
+    reason: str = "",
+    args: dict | None = None,
+) -> Path | None:
+    """Write a JSONL snapshot of the documents about to be deleted.
+
+    Returns the backup file path, or ``None`` if no rows were
+    snapshotted (caller should still proceed with the delete; the
+    no-rows case is benign — there's nothing to back up).
+
+    Captures the full document row, plus its inbound and outbound
+    links, so an ``undelete`` can fully reconstruct the document
+    AND its position in the link graph.
+    """
+    tumbler_list = list(tumblers)
+    if not tumbler_list:
+        return None
+
+    backup_dir = _backup_dir(catalog)
+    fname = f"catalog-{verb}-{_timestamp()}-{_short_id()}.jsonl"
+    path = backup_dir / fname
+
+    placeholders = ",".join("?" * len(tumbler_list))
+    rows = catalog._db.execute(
+        f"SELECT tumbler, title, author, year, content_type, file_path, "
+        f"corpus, physical_collection, chunk_count, head_hash, "
+        f"indexed_at, metadata, source_mtime, alias_of, source_uri "
+        f"FROM documents WHERE tumbler IN ({placeholders})",
+        tumbler_list,
+    ).fetchall()
+    if not rows:
+        return None
+
+    # Inbound + outbound links per tumbler so undelete can recreate
+    # the link graph.
+    links_by_tumbler: dict[str, list[dict]] = {}
+    for t in tumbler_list:
+        from_rows = catalog._db.execute(
+            "SELECT from_tumbler, to_tumbler, link_type, from_span, "
+            "to_span, created_by, created_at, metadata FROM links "
+            "WHERE from_tumbler = ? OR to_tumbler = ?",
+            (t, t),
+        ).fetchall()
+        links_by_tumbler[t] = [
+            {
+                "from": fr[0], "to": fr[1], "link_type": fr[2],
+                "from_span": fr[3] or "", "to_span": fr[4] or "",
+                "created_by": fr[5], "created_at": fr[6] or "",
+                "meta": json.loads(fr[7]) if fr[7] else {},
+            }
+            for fr in from_rows
+        ]
+
+    with path.open("w") as f:
+        # Header.
+        header = {
+            "kind": "header",
+            "verb": verb,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "reason": reason,
+            "args": args or {},
+            "rows_count": len(rows),
+        }
+        f.write(json.dumps(header) + "\n")
+        # Rows.
+        for row in rows:
+            (tumbler, title, author, year, content_type, file_path,
+             corpus, physical_collection, chunk_count, head_hash,
+             indexed_at, metadata_json, source_mtime, alias_of,
+             source_uri) = row
+            rec = {
+                "kind": "document",
+                "tumbler": tumbler,
+                "title": title or "",
+                "author": author or "",
+                "year": year or 0,
+                "content_type": content_type or "",
+                "file_path": file_path or "",
+                "corpus": corpus or "",
+                "physical_collection": physical_collection or "",
+                "chunk_count": chunk_count or 0,
+                "head_hash": head_hash or "",
+                "indexed_at": indexed_at or "",
+                "metadata": (
+                    json.loads(metadata_json) if metadata_json else {}
+                ),
+                "source_mtime": source_mtime or 0.0,
+                "alias_of": alias_of or "",
+                "source_uri": source_uri or "",
+                "links": links_by_tumbler.get(tumbler, []),
+            }
+            f.write(json.dumps(rec) + "\n")
+
+    # Permissions: backup carries deleted content, owner-only read.
+    os.chmod(path, 0o600)
+    _log.info(
+        "catalog_backup_written",
+        verb=verb,
+        path=str(path),
+        rows=len(rows),
+    )
+    return path
+
+
+def snapshot_links(
+    catalog: "Catalog",
+    links: Iterable[dict],
+    *,
+    verb: str,
+    reason: str = "",
+    args: dict | None = None,
+) -> Path | None:
+    """JSONL snapshot of links about to be deleted.
+
+    Each link dict carries from_tumbler / to_tumbler / link_type /
+    spans / metadata so undelete can re-emit ``LinkCreated`` events.
+    """
+    link_list = list(links)
+    if not link_list:
+        return None
+
+    backup_dir = _backup_dir(catalog)
+    fname = f"catalog-{verb}-{_timestamp()}-{_short_id()}.jsonl"
+    path = backup_dir / fname
+
+    with path.open("w") as f:
+        header = {
+            "kind": "header",
+            "verb": verb,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "reason": reason,
+            "args": args or {},
+            "rows_count": len(link_list),
+        }
+        f.write(json.dumps(header) + "\n")
+        for link in link_list:
+            f.write(json.dumps({"kind": "link", **link}) + "\n")
+
+    os.chmod(path, 0o600)
+    _log.info(
+        "catalog_backup_written",
+        verb=verb,
+        path=str(path),
+        rows=len(link_list),
+    )
+    return path
+
+
+def list_backups(catalog: "Catalog") -> list[BackupRecord]:
+    """All backups, newest first."""
+    d = catalog._dir / _BACKUP_DIRNAME
+    if not d.exists():
+        return []
+    files = [
+        p for p in d.glob("*.jsonl")
+        if p.is_file() and p.stat().st_size > 0
+    ]
+    records = []
+    for p in sorted(files, key=lambda f: f.stat().st_mtime, reverse=True):
+        try:
+            records.append(BackupRecord.from_file(p))
+        except (OSError, json.JSONDecodeError) as exc:
+            _log.warning(
+                "catalog_backup_unreadable",
+                path=str(p), error=str(exc),
+            )
+    return records
+
+
+def restore_documents(
+    catalog: "Catalog", backup_path: Path,
+) -> tuple[int, int]:
+    """Re-register all documents from a backup file.
+
+    Returns ``(restored_documents, restored_links)``.
+
+    Documents are re-registered via ``Catalog.register`` (event-sourced;
+    DocumentRegistered event lands in events.jsonl). Links are
+    re-emitted via ``Catalog.link`` (LinkCreated event).
+
+    Idempotent: re-registering an already-existing tumbler is a
+    DocumentRegistered-on-existing, which the projector handles via
+    INSERT OR REPLACE. Re-emitting an already-existing link merges
+    into the existing row's metadata.
+    """
+    from nexus.catalog.tumbler import Tumbler
+
+    if not backup_path.exists():
+        raise FileNotFoundError(f"backup not found: {backup_path}")
+
+    restored_docs = 0
+    restored_links = 0
+    pending_links: list[dict] = []
+
+    with backup_path.open("r") as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError as exc:
+                _log.warning(
+                    "catalog_backup_skip_malformed",
+                    path=str(backup_path), lineno=lineno, error=str(exc),
+                )
+                continue
+            kind = rec.get("kind", "")
+            if kind == "header":
+                continue
+            if kind == "document":
+                # Re-register via catalog.register. Owner is derived
+                # from tumbler prefix: "1.5.233" → owner "1.5".
+                t_str = rec["tumbler"]
+                parts = t_str.split(".")
+                if len(parts) < 3:
+                    _log.warning(
+                        "catalog_backup_skip_no_owner",
+                        tumbler=t_str,
+                    )
+                    continue
+                owner = Tumbler.parse(".".join(parts[:2]))
+                # Best-effort restore: register with the original
+                # title, content_type, etc. Catalog.register normally
+                # mints a fresh tumbler; here we want the ORIGINAL
+                # tumbler back, which means using the lower-level
+                # event-emit path. Use Catalog._write_to_event_log
+                # directly with a DocumentRegistered payload.
+                from nexus.catalog.events import (
+                    DocumentRegisteredPayload as _DocPayload,
+                )
+                from nexus.catalog.catalog import _make_event
+                payload = _DocPayload(
+                    doc_id=t_str,
+                    owner_id=str(owner),
+                    content_type=rec.get("content_type", ""),
+                    source_uri=rec.get("source_uri", ""),
+                    coll_id=rec.get("physical_collection", ""),
+                    title=rec.get("title", ""),
+                    source_mtime=float(rec.get("source_mtime", 0.0)),
+                    indexed_at_doc=rec.get("indexed_at", ""),
+                    tumbler=t_str,
+                    author=rec.get("author", ""),
+                    year=int(rec.get("year", 0)),
+                    file_path=rec.get("file_path", ""),
+                    corpus=rec.get("corpus", ""),
+                    physical_collection=rec.get(
+                        "physical_collection", "",
+                    ),
+                    chunk_count=int(rec.get("chunk_count", 0)),
+                    head_hash=rec.get("head_hash", ""),
+                    indexed_at=rec.get("indexed_at", ""),
+                    alias_of=rec.get("alias_of", ""),
+                    meta=dict(rec.get("metadata", {})),
+                )
+                event = _make_event(payload, v=0)
+                dir_fd = catalog._acquire_lock()
+                try:
+                    catalog._write_to_event_log(event)
+                    catalog._projector.apply(event)
+                    catalog._db.commit()
+                finally:
+                    catalog._release_lock(dir_fd)
+                restored_docs += 1
+                # Defer link restoration until all docs are back so
+                # the link's endpoints exist.
+                for link in rec.get("links", []):
+                    pending_links.append(link)
+            elif kind == "link":
+                pending_links.append(rec)
+
+    # Re-emit links via catalog.link_if_absent (idempotent).
+    for link in pending_links:
+        try:
+            from_t = Tumbler.parse(link["from"])
+            to_t = Tumbler.parse(link["to"])
+            catalog.link_if_absent(
+                from_t, to_t, link["link_type"],
+                link.get("created_by", "undelete"),
+                from_span=link.get("from_span", ""),
+                to_span=link.get("to_span", ""),
+                allow_dangling=True,
+                **link.get("meta", {}),
+            )
+            restored_links += 1
+        except Exception as exc:
+            _log.warning(
+                "catalog_backup_link_restore_failed",
+                from_t=link.get("from", ""),
+                to_t=link.get("to", ""),
+                error=str(exc),
+            )
+
+    _log.info(
+        "catalog_backup_restored",
+        path=str(backup_path),
+        documents=restored_docs,
+        links=restored_links,
+    )
+    return restored_docs, restored_links
+
+
+def vacuum_old_backups(
+    catalog: "Catalog",
+    *,
+    older_than_days: int = _DEFAULT_RETENTION_DAYS,
+    dry_run: bool = False,
+) -> tuple[int, int]:
+    """Drop backup files older than the retention window.
+
+    Returns ``(removed_count, kept_count)``. With ``dry_run=True``
+    nothing is removed; the counts are what WOULD happen.
+    """
+    d = catalog._dir / _BACKUP_DIRNAME
+    if not d.exists():
+        return (0, 0)
+    cutoff = time.time() - (older_than_days * 86400)
+    removed = 0
+    kept = 0
+    for p in d.glob("*.jsonl"):
+        if p.stat().st_mtime < cutoff:
+            if not dry_run:
+                p.unlink()
+                _log.info("catalog_backup_vacuumed", path=str(p))
+            removed += 1
+        else:
+            kept += 1
+    return (removed, kept)

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -1122,7 +1122,23 @@ def delete_cmd(tumbler_or_title: str, yes: bool) -> None:
     if entry is None:
         raise click.ClickException(f"Not found: {tumbler_or_title}")
     if not yes:
-        click.confirm(f"Delete '{entry.title}' ({t})? Links will be preserved.", abort=True)
+        click.confirm(
+            f"Delete '{entry.title}' ({t})? Links will be preserved.",
+            abort=True,
+        )
+
+    # Backup snapshot before delete (RDR-106 Option A).
+    from nexus.catalog.catalog_backup import snapshot_documents
+    backup_path = snapshot_documents(
+        cat, [str(t)], verb="delete",
+        reason=f"single-document delete: {entry.title}",
+    )
+    if backup_path:
+        click.echo(
+            f"Backup snapshot: {backup_path.name}"
+            f"  (restore: nx catalog undelete {backup_path.name})"
+        )
+
     deleted = cat.delete_document(t)
     if deleted:
         click.echo(f"Deleted: {t} ({entry.title}). Links preserved.")
@@ -1336,22 +1352,87 @@ def links_cmd(
 @click.option("--type", "link_type", default="")
 @click.option("--created-by", default="")
 @click.option("--created-at-before", default="", help="ISO timestamp cutoff")
-@click.option("--dry-run", is_flag=True)
+@click.option(
+    "--dry-run/--no-dry-run", default=True,
+    help="Report-only (default). Use --no-dry-run to perform deletions.",
+)
+@click.option(
+    "--confirm", is_flag=True, default=False,
+    help="Required alongside --no-dry-run to actually delete links.",
+)
 def link_bulk_delete_cmd(
     from_t: str, to_t: str, link_type: str, created_by: str,
-    created_at_before: str, dry_run: bool,
+    created_at_before: str, dry_run: bool, confirm: bool,
 ) -> None:
-    """Bulk delete links matching filters."""
+    """Bulk delete links matching filters.
+
+    nexus-9nim: 4.29.1 inverted the default from "delete unless --dry-run"
+    to "report unless --no-dry-run --confirm" + writes a backup snapshot
+    before the actual delete. Recoverable via ``nx catalog undelete``.
+    """
+    will_delete = (not dry_run) and confirm
+    if (not dry_run) and not confirm:
+        click.echo(
+            "--no-dry-run alone is treated as report-only. "
+            "Add --confirm to actually delete links."
+        )
+
     cat = _get_catalog()
     resolved_from = str(_resolve_tumbler(cat, from_t)) if from_t else ""
     resolved_to = str(_resolve_tumbler(cat, to_t)) if to_t else ""
-    count = cat.bulk_unlink(
+
+    # First pass: dry-run to enumerate the matching links for the
+    # backup snapshot. The cat.bulk_unlink dry_run path returns the
+    # count; we need the actual rows for the snapshot, so query directly.
+    matching_links = cat.link_query(
         from_t=resolved_from, to_t=resolved_to,
         link_type=link_type, created_by=created_by,
-        created_at_before=created_at_before, dry_run=dry_run,
+        created_at_before=created_at_before,
+        limit=0,
     )
-    mode = "Would remove" if dry_run else "Removed"
-    click.echo(f"{mode} {count} link(s)")
+    count = len(matching_links)
+
+    if not will_delete:
+        click.echo(f"Would remove {count} link(s)")
+        return
+
+    # Backup snapshot before delete (RDR-106 Option A).
+    from nexus.catalog.catalog_backup import snapshot_links
+    backup_path = snapshot_links(
+        cat,
+        [
+            {
+                "from": str(lnk.from_tumbler),
+                "to": str(lnk.to_tumbler),
+                "link_type": lnk.link_type,
+                "from_span": lnk.from_span,
+                "to_span": lnk.to_span,
+                "created_by": lnk.created_by,
+                "created_at": lnk.created_at,
+                "meta": lnk.meta,
+            }
+            for lnk in matching_links
+        ],
+        verb="link-bulk-delete",
+        reason="bulk-unlink filters",
+        args={
+            "from_t": resolved_from, "to_t": resolved_to,
+            "link_type": link_type, "created_by": created_by,
+            "created_at_before": created_at_before,
+        },
+    )
+    if backup_path:
+        click.echo(
+            f"Backup snapshot written: {backup_path}\n"
+            f"  Restore with: nx catalog undelete {backup_path.name}"
+        )
+
+    actual = cat.bulk_unlink(
+        from_t=resolved_from, to_t=resolved_to,
+        link_type=link_type, created_by=created_by,
+        created_at_before=created_at_before, dry_run=False,
+    )
+    click.echo(f"Removed {actual} link(s)")
 
 
 @catalog.command("link-audit", hidden=True)
@@ -2311,19 +2392,38 @@ def session_summary_cmd(since: int) -> None:
 
 
 @catalog.command("gc")
-@click.option("--dry-run", is_flag=True, default=False, help="Show what would be deleted without deleting.")
-def gc_cmd(dry_run: bool) -> None:
+@click.option(
+    "--dry-run/--no-dry-run", default=True,
+    help="Report-only (default). Use --no-dry-run to perform deletions.",
+)
+@click.option(
+    "--confirm", is_flag=True, default=False,
+    help="Required alongside --no-dry-run to actually delete catalog rows.",
+)
+def gc_cmd(dry_run: bool, confirm: bool) -> None:
     """Remove orphan catalog entries that have miss_count >= 2.
 
     \b
     Orphans are entries that were absent in two or more consecutive index runs.
-    Use --dry-run to preview deletions without applying them.
+    Default is read-only (--dry-run is on). To actually delete:
+      nx catalog gc --no-dry-run --confirm
 
     \b
     Examples:
-      nx catalog gc              # delete orphan entries
-      nx catalog gc --dry-run   # preview without deleting
+      nx catalog gc                          # report (read-only)
+      nx catalog gc --no-dry-run --confirm  # actually delete
+
+    nexus-tnz3: 4.29.1 inverted the default from "delete unless --dry-run"
+    to "report unless --no-dry-run --confirm" so a forgotten flag no longer
+    silently destroys orphan entries.
     """
+    will_delete = (not dry_run) and confirm
+    if (not dry_run) and not confirm:
+        click.echo(
+            "--no-dry-run alone is treated as report-only. "
+            "Add --confirm to actually delete catalog rows."
+        )
+
     cat = _get_catalog()
 
     rows = cat._db.execute(
@@ -2340,19 +2440,46 @@ def gc_cmd(dry_run: bool) -> None:
         click.echo("No orphan entries found.")
         return
 
-    click.echo(f"Found {len(orphans)} orphan {'entry' if len(orphans) == 1 else 'entries'} (miss_count >= 2):")
-    for tumbler_str, title, file_path in orphans:
+    click.echo(
+        f"Found {len(orphans)} orphan "
+        f"{'entry' if len(orphans) == 1 else 'entries'} (miss_count >= 2):"
+    )
+    for tumbler_str, title, file_path in orphans[:20]:
         loc = f" ({file_path})" if file_path else ""
-        if dry_run:
-            click.echo(f"  [dry-run] would delete {tumbler_str}: {title}{loc}")
-        else:
-            cat.delete_document(Tumbler.parse(tumbler_str))
-            click.echo(f"  deleted {tumbler_str}: {title}{loc}")
+        click.echo(f"  {tumbler_str}: {title}{loc}")
+    if len(orphans) > 20:
+        click.echo(f"  ... ({len(orphans) - 20} more)")
 
-    if dry_run:
-        click.echo(f"\n{len(orphans)} {'entry' if len(orphans) == 1 else 'entries'} would be deleted. Run without --dry-run to apply.")
-    else:
-        click.echo(f"\nDeleted {len(orphans)} orphan {'entry' if len(orphans) == 1 else 'entries'}.")
+    if not will_delete:
+        click.echo(
+            f"\n{len(orphans)} {'entry' if len(orphans) == 1 else 'entries'} "
+            f"would be deleted. Run with --no-dry-run --confirm to apply."
+        )
+        return
+
+    # Backup before delete (RDR-106 Option A).
+    from nexus.catalog.catalog_backup import snapshot_documents
+    backup_path = snapshot_documents(
+        cat,
+        [t for t, _, _ in orphans],
+        verb="gc",
+        reason="miss_count >= 2",
+    )
+    if backup_path:
+        click.echo(
+            f"\nBackup snapshot written: {backup_path}"
+            f"\n  Restore with: nx catalog undelete {backup_path.name}"
+        )
+
+    n_deleted = 0
+    for tumbler_str, title, file_path in orphans:
+        if cat.delete_document(Tumbler.parse(tumbler_str)):
+            n_deleted += 1
+
+    click.echo(
+        f"\nDeleted {n_deleted} orphan "
+        f"{'entry' if n_deleted == 1 else 'entries'}."
+    )
 
 
 @catalog.command("coverage")
@@ -3792,16 +3919,47 @@ def prune_stale_cmd(
     else:
         entries = cat.all_documents()
 
+    # nexus-6ims: relative file_paths must resolve against the owner's
+    # repo_root (RDR-060), not against the running process's cwd. Pre-fix
+    # logic used ``Path(fp).exists()`` directly, which caught absolute
+    # paths fine but mass-misclassified relative paths whenever the
+    # operator ran the verb from a different repo (verified 2026-05-08:
+    # 11,766 valid entries reported as stale because cwd was nexus, not
+    # the entry's owning repo).
+    owner_roots = dict(cat._db.execute(
+        "SELECT tumbler_prefix, repo_root FROM owners WHERE repo_root != ''"
+    ))
+
     stale: list = []  # entries to delete
     skipped_replacement: list = []  # entries with RDR-prefix replacement
+    skipped_no_root: list = []  # owner has no repo_root — can't verify
     for entry in entries:
         fp = entry.file_path or ""
         if not fp:  # MCP-stored, no source file
             continue
         if "/" not in fp:  # basename-only — remediable
             continue
-        if Path(fp).exists():  # live, not stale
+
+        if fp.startswith("/"):
+            resolved = Path(fp)
+        else:
+            # Relative path — anchor at owner.repo_root.
+            t_str = str(entry.tumbler)
+            parts = t_str.split(".")
+            owner_id = ".".join(parts[:2]) if len(parts) >= 2 else ""
+            root = owner_roots.get(owner_id, "")
+            if not root:
+                # Owner has no repo_root (registered before RDR-060
+                # added the column). Cannot verify presence; refuse to
+                # delete — operator must repair owner.repo_root first
+                # via ``nx catalog dedupe-owners`` or manual update.
+                skipped_no_root.append(entry)
+                continue
+            resolved = Path(root) / fp
+
+        if resolved.exists():  # live, not stale
             continue
+
         # Stale candidate. If a same-prefix replacement exists, prefer
         # remediation: skip prune.
         if prefix_index:
@@ -3813,13 +3971,18 @@ def prune_stale_cmd(
 
     n_stale = len(stale)
     n_skipped = len(skipped_replacement)
-    click.echo(
-        f"{n_stale} stale entr{'y' if n_stale == 1 else 'ies'}"
-        + (
-            f" (skipped {n_skipped} with same-prefix replacement)"
-            if n_skipped else ""
+    n_no_root = len(skipped_no_root)
+    parts_msg = []
+    if n_skipped:
+        parts_msg.append(f"skipped {n_skipped} with same-prefix replacement")
+    if n_no_root:
+        parts_msg.append(
+            f"skipped {n_no_root} relative-path entries whose owner has "
+            f"no repo_root (cannot verify)"
         )
-        + "."
+    suffix = f" ({'; '.join(parts_msg)})" if parts_msg else ""
+    click.echo(
+        f"{n_stale} stale entr{'y' if n_stale == 1 else 'ies'}{suffix}."
     )
 
     if n_stale:
@@ -3834,6 +3997,25 @@ def prune_stale_cmd(
         if dry_run:
             click.echo("\n(dry-run — no catalog writes performed.)")
         return
+
+    # Backup snapshot before delete (RDR-106 Option A).
+    from nexus.catalog.catalog_backup import snapshot_documents
+    backup_path = snapshot_documents(
+        cat,
+        [str(e.tumbler) for e in stale],
+        verb="prune-stale",
+        reason="absolute path missing OR relative path missing under owner.repo_root",
+        args={
+            "collection": collection, "owner": owner,
+            "source_dir": str(source_dir_opt) if source_dir_opt else "",
+            "rdr_prefix_skip": rdr_prefix_skip,
+        },
+    )
+    if backup_path:
+        click.echo(
+            f"\nBackup snapshot written: {backup_path}"
+            f"\n  Restore with: nx catalog undelete {backup_path.name}"
+        )
 
     n_deleted = 0
     for entry in stale:
@@ -5003,6 +5185,100 @@ def _print_t3_doc_id_coverage_text(report: dict) -> None:
         click.echo(
             "See docs/rdr/post-mortem/101-event-sourced-catalog-migration.md "
             "for the arc record (verbs retired post Phase 5b)."
+        )
+
+
+# ── Backup-before-delete recovery surface (RDR-106 Option A) ─────────────
+
+
+@catalog.command("list-backups")
+def list_backups_cmd() -> None:
+    """List backup snapshots written by destructive catalog verbs.
+
+    Each destructive catalog verb (``delete``, ``gc``, ``prune-stale``,
+    ``link-bulk-delete``) writes a JSONL snapshot of the rows about
+    to be deleted under ``$NEXUS_CONFIG_DIR/catalog/.deleted-backups/``
+    BEFORE the actual delete. This verb shows what's recoverable
+    without inspecting the files manually.
+    """
+    from nexus.catalog.catalog_backup import list_backups
+    cat = _get_catalog()
+    records = list_backups(cat)
+    if not records:
+        click.echo("No backups found.")
+        return
+    click.echo(f"{len(records)} backup(s) (newest first):\n")
+    for rec in records:
+        click.echo(
+            f"  {rec.path.name}\n"
+            f"    verb={rec.verb}  ts={rec.timestamp}  "
+            f"rows={rec.rows_count}\n"
+            f"    reason={rec.reason or '<none>'}"
+        )
+
+
+@catalog.command("undelete")
+@click.argument("backup")
+def undelete_cmd(backup: str) -> None:
+    """Restore documents (and their links) from a backup snapshot.
+
+    BACKUP is either a filename inside ``.deleted-backups/`` or an
+    absolute path. Documents are re-emitted as DocumentRegistered
+    events in events.jsonl (event-sourced; full audit trail);
+    inbound and outbound links are re-emitted as LinkCreated events
+    via ``link_if_absent`` (idempotent).
+
+    Documents are restored with their ORIGINAL tumblers — the tumbler
+    minting path is bypassed. Re-running this on an already-restored
+    backup is a no-op (DocumentRegistered on existing tumbler is
+    idempotent via INSERT OR REPLACE).
+    """
+    from nexus.catalog.catalog_backup import restore_documents
+    cat = _get_catalog()
+    if backup.startswith("/"):
+        backup_path = Path(backup)
+    else:
+        backup_path = cat._dir / ".deleted-backups" / backup
+    if not backup_path.exists():
+        raise click.ClickException(f"Backup not found: {backup_path}")
+
+    docs, links = restore_documents(cat, backup_path)
+    click.echo(
+        f"Restored {docs} document(s) and {links} link(s) "
+        f"from {backup_path.name}."
+    )
+
+
+@catalog.command("vacuum-backups")
+@click.option(
+    "--older-than-days", default=30, show_default=True,
+    help="Drop backup files older than this many days.",
+)
+@click.option(
+    "--dry-run/--no-dry-run", default=True,
+    help="Report-only (default). Use --no-dry-run to delete.",
+)
+def vacuum_backups_cmd(older_than_days: int, dry_run: bool) -> None:
+    """Drop old backup snapshots past the retention window.
+
+    Default retention is 30 days. Removed files are gone for good —
+    after vacuum, the rows in those backups are no longer recoverable
+    via ``nx catalog undelete``.
+    """
+    from nexus.catalog.catalog_backup import vacuum_old_backups
+    cat = _get_catalog()
+    removed, kept = vacuum_old_backups(
+        cat, older_than_days=older_than_days, dry_run=dry_run,
+    )
+    if dry_run:
+        click.echo(
+            f"Would remove {removed} backup file(s) "
+            f"(keeping {kept}). "
+            f"Run with --no-dry-run to actually delete."
+        )
+    else:
+        click.echo(
+            f"Removed {removed} backup file(s); kept {kept}."
         )
 
 

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -168,6 +168,50 @@ def prune_stale_cmd(collection: str, dry_run: bool, confirm: bool) -> None:
     total_stale_chunks = 0
     affected_collections = 0
 
+    # nexus-6ims: relative source_paths must resolve against the
+    # owning catalog document's owner.repo_root, not against the
+    # running process's cwd. Open the catalog so we can join.
+    from nexus.catalog.catalog import Catalog
+    from nexus.config import catalog_path as _catalog_path
+    cat_dir = _catalog_path()
+    cat: Catalog | None = None
+    owner_roots: dict[str, str] = {}
+    if (cat_dir / "documents.jsonl").exists():
+        try:
+            cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+            owner_roots = dict(cat._db.execute(
+                "SELECT tumbler_prefix, repo_root FROM owners "
+                "WHERE repo_root != ''"
+            ))
+        except Exception as exc:
+            click.echo(f"WARN: catalog not available for owner lookup: {exc}")
+
+    def _resolve(path_str: str) -> Path | None:
+        """Resolve a chunk source_path. Absolute → as-is. Relative → look
+        up the owning document's owner.repo_root and prepend. Returns
+        None if no owner.repo_root anchor available."""
+        if path_str.startswith("/"):
+            return Path(path_str)
+        if not cat:
+            return None
+        # Find any catalog document with this file_path; take its owner.
+        row = cat._db.execute(
+            "SELECT tumbler FROM documents WHERE file_path = ? LIMIT 1",
+            (path_str,),
+        ).fetchone()
+        if not row:
+            return None
+        parts = row[0].split(".")
+        if len(parts) < 2:
+            return None
+        owner_id = ".".join(parts[:2])
+        root = owner_roots.get(owner_id)
+        if not root:
+            return None
+        return Path(root) / path_str
+
+    skipped_unverifiable = 0
+
     for coll_name in target_collections:
         try:
             unique_paths = t3_db.list_unique_source_paths(coll_name)
@@ -175,7 +219,17 @@ def prune_stale_cmd(collection: str, dry_run: bool, confirm: bool) -> None:
             click.echo(f"  {coll_name}: SKIP (list failed: {exc})")
             continue
 
-        stale_paths: list[str] = [p for p in unique_paths if not Path(p).exists()]
+        stale_paths: list[str] = []
+        for p in unique_paths:
+            resolved = _resolve(p)
+            if resolved is None:
+                # Relative path with no owner anchor — refuse to
+                # classify (would have falsely deleted under the
+                # nexus-6ims pre-fix logic).
+                skipped_unverifiable += 1
+                continue
+            if not resolved.exists():
+                stale_paths.append(p)
         if not stale_paths:
             continue
 
@@ -208,6 +262,12 @@ def prune_stale_cmd(collection: str, dry_run: bool, confirm: bool) -> None:
         f"across {total_stale_paths} stale path(s) "
         f"in {affected_collections} collection(s)."
     )
+    if skipped_unverifiable:
+        click.echo(
+            f"  Skipped {skipped_unverifiable} relative-path entries "
+            f"whose owning document has no owner.repo_root — cannot "
+            f"verify presence (nexus-6ims fail-safe)."
+        )
 
 
 @t3.command("gc")

--- a/tests/test_catalog_backup_and_safety.py
+++ b/tests/test_catalog_backup_and_safety.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""4.29.1 destructive-verb safety regression tests.
+
+Pins:
+
+- nexus-6ims P0: ``catalog prune-stale`` resolves relative paths
+  against ``owner.repo_root``, NOT cwd. The pre-fix logic
+  mass-misclassified valid relative-path entries as stale whenever
+  the verb was run from a different repo's cwd.
+- nexus-tnz3 P1: ``catalog gc`` defaults to dry-run; requires
+  ``--no-dry-run --confirm`` to actually delete.
+- nexus-9nim P2: ``catalog link-bulk-delete`` defaults to dry-run;
+  requires ``--no-dry-run --confirm`` to actually delete.
+- RDR-106 Option A: every destructive verb writes a JSONL backup
+  snapshot to ``$catalog_dir/.deleted-backups/`` BEFORE the actual
+  delete. ``nx catalog undelete`` re-emits the documents (and their
+  links) via event-sourced ``DocumentRegistered`` / ``LinkCreated``
+  events.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.tumbler import Tumbler
+from nexus.cli import main
+
+
+@pytest.fixture
+def catalog_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Initialised catalog with NEXUS_CATALOG_PATH pointed at it."""
+    cat_dir = tmp_path / "catalog"
+    Catalog.init(cat_dir)
+    monkeypatch.setenv("NEXUS_CATALOG_PATH", str(cat_dir))
+    return cat_dir
+
+
+@pytest.fixture
+def cat(catalog_env: Path) -> Catalog:
+    return Catalog(catalog_env, catalog_env / ".catalog.db")
+
+
+# ── nexus-6ims: prune-stale uses owner.repo_root for relative paths ────────
+
+
+def test_prune_stale_resolves_relative_paths_against_owner_root(
+    cat: Catalog, tmp_path: Path,
+) -> None:
+    """A relative file_path that exists under the owner's repo_root
+    must NOT be classified as stale, regardless of the cwd from
+    which the verb runs."""
+    # Owner with explicit repo_root.
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    src = repo / "src" / "main.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("print('hello')\n")
+
+    owner = cat.register_owner(
+        "myrepo", "repo", repo_hash="hash", repo_root=str(repo),
+    )
+    cat.register(
+        owner, "main.py", content_type="code",
+        file_path="src/main.py",  # RELATIVE to repo_root
+    )
+
+    runner = CliRunner()
+    # Run from a DIFFERENT cwd to expose the pre-fix bug.
+    different_cwd = tmp_path / "elsewhere"
+    different_cwd.mkdir()
+    cwd_save = os.getcwd()
+    os.chdir(different_cwd)
+    try:
+        result = runner.invoke(main, ["catalog", "prune-stale"])
+    finally:
+        os.chdir(cwd_save)
+
+    assert result.exit_code == 0, result.output
+    # The pre-fix bug would say "1 stale entry" because Path("src/main.py").exists()
+    # is False from /elsewhere. Post-fix: 0 stale.
+    assert "0 stale" in result.output, result.output
+
+
+def test_prune_stale_skips_relative_paths_when_owner_has_no_repo_root(
+    cat: Catalog, tmp_path: Path,
+) -> None:
+    """nexus-6ims fail-safe: owner.repo_root empty → refuse to
+    classify; skip with a structured warning. Better to leave a
+    real stale entry around than to mass-delete valid ones."""
+    # Curator-style owner: no repo_root.
+    owner = cat.register_owner("curator", "curator")
+    cat.register(
+        owner, "doc.md", content_type="prose",
+        file_path="some/relative/path.md",  # owner has NO repo_root
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["catalog", "prune-stale"])
+    assert result.exit_code == 0
+    # The verb refuses to classify; output reports the skip count.
+    assert "skipped" in result.output.lower()
+    assert "no repo_root" in result.output.lower()
+    assert "0 stale" in result.output
+
+
+def test_prune_stale_classifies_truly_missing_absolute_path_as_stale(
+    cat: Catalog, tmp_path: Path,
+) -> None:
+    """Absolute path that doesn't exist on disk → classified as stale
+    (the original happy-path of the verb still works)."""
+    owner = cat.register_owner("o", "repo", repo_hash="h")
+    cat.register(
+        owner, "gone.md", content_type="prose",
+        file_path="/var/folders/definitely-not-a-real-path-9d8f7a/file.md",
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["catalog", "prune-stale"])
+    assert result.exit_code == 0
+    assert "1 stale" in result.output
+
+
+# ── nexus-tnz3: catalog gc dry-run is the default ──────────────────────────
+
+
+def test_gc_default_is_dry_run(cat: Catalog) -> None:
+    """nexus-tnz3: 4.29.1 made dry-run the default. ``nx catalog gc``
+    with no flags must NOT delete."""
+    owner = cat.register_owner("repo", "repo", repo_hash="abc")
+    t = cat.register(owner, "old.py", content_type="code", file_path="src/old.py")
+    cat.update(t, meta={"miss_count": 2})
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["catalog", "gc"])
+    assert result.exit_code == 0
+    assert cat.resolve(t) is not None, (
+        "default `nx catalog gc` deleted entry — dry-run-default contract broken"
+    )
+    assert "would be deleted" in result.output
+
+
+def test_gc_no_dry_run_alone_is_still_report_only(cat: Catalog) -> None:
+    """``--no-dry-run`` without ``--confirm`` still report-only."""
+    owner = cat.register_owner("repo", "repo", repo_hash="abc")
+    t = cat.register(owner, "old.py", content_type="code", file_path="src/old.py")
+    cat.update(t, meta={"miss_count": 2})
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["catalog", "gc", "--no-dry-run"])
+    assert result.exit_code == 0
+    assert "treated as report-only" in result.output
+    assert cat.resolve(t) is not None
+
+
+def test_gc_no_dry_run_plus_confirm_actually_deletes(cat: Catalog) -> None:
+    """Both flags required: ``--no-dry-run --confirm``."""
+    owner = cat.register_owner("repo", "repo", repo_hash="abc")
+    t = cat.register(owner, "old.py", content_type="code", file_path="src/old.py")
+    cat.update(t, meta={"miss_count": 2})
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["catalog", "gc", "--no-dry-run", "--confirm"],
+    )
+    assert result.exit_code == 0
+    assert cat.resolve(t) is None
+    # Backup snapshot should have been written.
+    backup_dir = cat._dir / ".deleted-backups"
+    assert backup_dir.exists()
+    assert any(backup_dir.glob("catalog-gc-*.jsonl"))
+
+
+# ── nexus-9nim: link-bulk-delete --confirm safety rail ─────────────────────
+
+
+def test_link_bulk_delete_default_is_dry_run(cat: Catalog) -> None:
+    """nexus-9nim: 4.29.1 default flipped to dry-run."""
+    owner = cat.register_owner("o", "repo", repo_hash="h")
+    a = cat.register(owner, "A", content_type="prose", file_path="a.md")
+    b = cat.register(owner, "B", content_type="prose", file_path="b.md")
+    cat.link(a, b, "cites", created_by="t")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["catalog", "link-bulk-delete", "--type", "cites"],
+    )
+    assert result.exit_code == 0
+    # Default dry-run; link survives.
+    assert "Would remove 1 link(s)" in result.output
+    assert len(cat.links_from(a)) == 1
+
+
+def test_link_bulk_delete_no_confirm_is_still_report_only(
+    cat: Catalog,
+) -> None:
+    owner = cat.register_owner("o", "repo", repo_hash="h")
+    a = cat.register(owner, "A", content_type="prose", file_path="a.md")
+    b = cat.register(owner, "B", content_type="prose", file_path="b.md")
+    cat.link(a, b, "cites", created_by="t")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        "catalog", "link-bulk-delete", "--type", "cites", "--no-dry-run",
+    ])
+    assert result.exit_code == 0
+    assert len(cat.links_from(a)) == 1
+
+
+def test_link_bulk_delete_confirm_actually_removes(cat: Catalog) -> None:
+    owner = cat.register_owner("o", "repo", repo_hash="h")
+    a = cat.register(owner, "A", content_type="prose", file_path="a.md")
+    b = cat.register(owner, "B", content_type="prose", file_path="b.md")
+    cat.link(a, b, "cites", created_by="t")
+
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        "catalog", "link-bulk-delete", "--type", "cites",
+        "--no-dry-run", "--confirm",
+    ])
+    assert result.exit_code == 0
+    assert "Removed 1 link" in result.output
+    assert len(cat.links_from(a)) == 0
+    # Backup snapshot.
+    backup_dir = cat._dir / ".deleted-backups"
+    assert any(
+        p for p in backup_dir.glob("catalog-link-bulk-delete-*.jsonl")
+    )
+
+
+# ── RDR-106 Option A: backup-before-delete + undelete ──────────────────────
+
+
+def test_delete_writes_backup_before_deleting(
+    cat: Catalog,
+) -> None:
+    """``nx catalog delete <tumbler> --yes`` writes a JSONL snapshot
+    BEFORE calling delete_document."""
+    owner = cat.register_owner("o", "repo", repo_hash="h")
+    t = cat.register(
+        owner, "doomed.md", content_type="prose", file_path="doomed.md",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["catalog", "delete", str(t), "--yes"],
+    )
+    assert result.exit_code == 0, result.output
+    assert cat.resolve(t) is None
+    backup_dir = cat._dir / ".deleted-backups"
+    backups = list(backup_dir.glob("catalog-delete-*.jsonl"))
+    assert len(backups) == 1, "expected exactly one delete backup"
+    # Backup carries the deleted document.
+    with backups[0].open() as f:
+        lines = [json.loads(l) for l in f if l.strip()]
+    assert lines[0]["kind"] == "header"
+    assert lines[0]["verb"] == "delete"
+    assert any(
+        rec.get("kind") == "document" and rec.get("tumbler") == str(t)
+        for rec in lines
+    )
+
+
+def test_undelete_round_trips_document_via_event_log(
+    cat: Catalog,
+) -> None:
+    """delete + undelete round-trip preserves the document AND its links."""
+    owner = cat.register_owner("o", "repo", repo_hash="h")
+    a = cat.register(
+        owner, "alice.md", content_type="prose", file_path="alice.md",
+    )
+    b = cat.register(
+        owner, "bob.md", content_type="prose", file_path="bob.md",
+    )
+    cat.link(a, b, "cites", created_by="test")
+    cat.link(b, a, "relates", created_by="test")
+
+    # Delete A (writes backup).
+    runner = CliRunner()
+    result = runner.invoke(main, ["catalog", "delete", str(a), "--yes"])
+    assert result.exit_code == 0
+    assert cat.resolve(a) is None
+
+    # Find the backup file.
+    backup_dir = cat._dir / ".deleted-backups"
+    backups = list(backup_dir.glob("catalog-delete-*.jsonl"))
+    assert len(backups) == 1
+    backup_name = backups[0].name
+
+    # Restore.
+    result = runner.invoke(main, ["catalog", "undelete", backup_name])
+    assert result.exit_code == 0, result.output
+    assert "Restored 1 document" in result.output
+    # Document is back.
+    restored = cat.resolve(a)
+    assert restored is not None
+    assert restored.title == "alice.md"
+    # Links re-emitted.
+    out_links = cat.links_from(a)
+    in_links = cat.links_to(a)
+    assert any(l.link_type == "cites" for l in out_links)
+    assert any(l.link_type == "relates" for l in in_links)
+
+
+def test_list_backups_shows_recent_snapshots(cat: Catalog) -> None:
+    """``nx catalog list-backups`` enumerates JSONL files newest-first."""
+    owner = cat.register_owner("o", "repo", repo_hash="h")
+    t = cat.register(
+        owner, "doomed.md", content_type="prose", file_path="doomed.md",
+    )
+    runner = CliRunner()
+    runner.invoke(main, ["catalog", "delete", str(t), "--yes"])
+    result = runner.invoke(main, ["catalog", "list-backups"])
+    assert result.exit_code == 0, result.output
+    assert "catalog-delete-" in result.output
+    assert "verb=delete" in result.output
+    assert "rows=1" in result.output
+
+
+def test_vacuum_backups_dry_run_default(cat: Catalog) -> None:
+    """``nx catalog vacuum-backups`` defaults to dry-run."""
+    owner = cat.register_owner("o", "repo", repo_hash="h")
+    t = cat.register(
+        owner, "doomed.md", content_type="prose", file_path="doomed.md",
+    )
+    runner = CliRunner()
+    runner.invoke(main, ["catalog", "delete", str(t), "--yes"])
+
+    # Default dry-run; days = 30 means recent file is kept.
+    result = runner.invoke(main, ["catalog", "vacuum-backups"])
+    assert result.exit_code == 0
+    assert "Would remove 0 backup file" in result.output
+    backup_dir = cat._dir / ".deleted-backups"
+    assert any(backup_dir.glob("*.jsonl"))
+
+
+def test_vacuum_backups_actually_removes_old_files(
+    cat: Catalog,
+) -> None:
+    """Files older than the retention window are removed when
+    ``--no-dry-run`` is passed."""
+    owner = cat.register_owner("o", "repo", repo_hash="h")
+    t = cat.register(
+        owner, "doomed.md", content_type="prose", file_path="doomed.md",
+    )
+    runner = CliRunner()
+    runner.invoke(main, ["catalog", "delete", str(t), "--yes"])
+
+    backup_dir = cat._dir / ".deleted-backups"
+    backups = list(backup_dir.glob("*.jsonl"))
+    assert len(backups) == 1
+    # Backdate the file beyond retention.
+    old_time = backups[0].stat().st_mtime - (40 * 86400)
+    os.utime(backups[0], (old_time, old_time))
+
+    result = runner.invoke(
+        main, ["catalog", "vacuum-backups", "--no-dry-run"],
+    )
+    assert result.exit_code == 0
+    assert "Removed 1 backup" in result.output
+    assert not any(backup_dir.glob("*.jsonl"))
+
+
+def test_prune_stale_writes_backup_for_truly_stale(
+    cat: Catalog, tmp_path: Path,
+) -> None:
+    """When prune-stale --no-dry-run --confirm runs, it writes a
+    backup snapshot covering the deleted entries."""
+    owner = cat.register_owner("o", "repo", repo_hash="h")
+    cat.register(
+        owner, "gone.md", content_type="prose",
+        file_path="/definitely/missing/path-9876/gone.md",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, [
+        "catalog", "prune-stale", "--no-dry-run", "--confirm",
+    ])
+    assert result.exit_code == 0
+    assert "deleted 1" in result.output.lower()
+    backup_dir = cat._dir / ".deleted-backups"
+    assert any(backup_dir.glob("catalog-prune-stale-*.jsonl"))

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -1371,24 +1371,29 @@ class TestGcCommand:
         assert "No orphan" in result.output
 
     def test_gc_dry_run_does_not_delete(self, catalog_env):
-        runner = CliRunner()
-        cat = self._make_cat(catalog_env)
-        owner = cat.register_owner("repo", "repo", repo_hash="abc")
-        t = cat.register(owner, "old.py", content_type="code", file_path="src/old.py")
-        cat.update(t, meta={"miss_count": 2})
-        result = runner.invoke(main, ["catalog", "gc", "--dry-run"])
-        assert result.exit_code == 0
-        assert "[dry-run]" in result.output
-        # Entry still exists after dry run
-        assert cat.resolve(t) is not None
-
-    def test_gc_deletes_orphans(self, catalog_env):
+        """nexus-tnz3: 4.29.1 dry-run is the DEFAULT — no flags = report-only.
+        Entry must remain after a default invocation."""
         runner = CliRunner()
         cat = self._make_cat(catalog_env)
         owner = cat.register_owner("repo", "repo", repo_hash="abc")
         t = cat.register(owner, "old.py", content_type="code", file_path="src/old.py")
         cat.update(t, meta={"miss_count": 2})
         result = runner.invoke(main, ["catalog", "gc"])
+        assert result.exit_code == 0
+        # Default is dry-run; entry survives.
+        assert "would be deleted" in result.output
+        assert cat.resolve(t) is not None
+
+    def test_gc_deletes_orphans(self, catalog_env):
+        """4.29.1 requires --no-dry-run --confirm to actually delete."""
+        runner = CliRunner()
+        cat = self._make_cat(catalog_env)
+        owner = cat.register_owner("repo", "repo", repo_hash="abc")
+        t = cat.register(owner, "old.py", content_type="code", file_path="src/old.py")
+        cat.update(t, meta={"miss_count": 2})
+        result = runner.invoke(
+            main, ["catalog", "gc", "--no-dry-run", "--confirm"],
+        )
         assert result.exit_code == 0
         assert "Deleted 1" in result.output
         # Entry gone from catalog
@@ -1407,14 +1412,19 @@ class TestGcCommand:
         assert cat.resolve(t) is not None
 
     def test_gc_mixed_entries(self, catalog_env):
-        """Only entries with miss_count >= 2 are deleted; others survive."""
+        """Only entries with miss_count >= 2 are deleted; others survive.
+
+        4.29.1 default is dry-run; pass --no-dry-run --confirm to delete.
+        """
         runner = CliRunner()
         cat = self._make_cat(catalog_env)
         owner = cat.register_owner("repo", "repo", repo_hash="abc")
         t_keep = cat.register(owner, "keep.py", content_type="code", file_path="src/keep.py")
         t_del = cat.register(owner, "del.py", content_type="code", file_path="src/del.py")
         cat.update(t_del, meta={"miss_count": 3})
-        result = runner.invoke(main, ["catalog", "gc"])
+        result = runner.invoke(
+            main, ["catalog", "gc", "--no-dry-run", "--confirm"],
+        )
         assert result.exit_code == 0
         assert "Deleted 1" in result.output
         assert cat.resolve(t_keep) is not None

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.29.0"
+version = "4.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Patch release hardening the catalog's destructive-verb surface caught during the 4.29.0 prod shakeout. Three bug fixes (P0/P1/P2) + a backup-before-delete safety net (RDR-106 Option A) + RDR-106 draft filed as the architectural follow-up.

## Bug fixes

| ID | Severity | Issue |
|---|---|---|
| nexus-6ims | **P0** | `nx catalog prune-stale` and `nx t3 prune-stale` use cwd-dependent `Path.exists()` for stale classification. Relative paths (most catalog entries) over-classify when the verb runs from any cwd other than the entry's owning repo. **Caught 2026-05-08 prod shakeout: verb about to delete 11,766 valid entries; only 71 were actually stale.** |
| nexus-tnz3 | P1 | `nx catalog gc` had `--dry-run` as opt-in (default deletes). Typo or forgotten flag silently destroys data. |
| nexus-9nim | P2 | `nx catalog link-bulk-delete` (hidden verb) had the same delete-by-default pattern. |

**Fix shape:** `prune-stale` resolves relative paths against `owner.repo_root` (RDR-060); owners with no `repo_root` skip with a structured warning. `gc` and `link-bulk-delete` flipped to `--dry-run` default + require `--no-dry-run --confirm` to actually delete.

## Backup-before-delete (RDR-106 Option A)

Every destructive catalog verb writes a JSONL snapshot to `$NEXUS_CONFIG_DIR/catalog/.deleted-backups/` BEFORE the delete. Snapshot captures the full document row + inbound and outbound links so undelete can fully reconstruct the document AND its position in the link graph.

New CLI verbs:
- `nx catalog undelete <backup-file>` — restore via event-sourced `DocumentRegistered` / `LinkCreated` events; documents keep their ORIGINAL tumblers.
- `nx catalog list-backups` — enumerate snapshots newest-first.
- `nx catalog vacuum-backups` — drop files past retention (default 30d, dry-run by default).

Pure recovery layer — no schema change, no projector change, no read-path filter. Backup files are out-of-tree (per-machine, not synced via `nx catalog sync`).

## RDR-106 (draft) filed as architectural follow-up

Tombstone-column soft-delete: adds `deleted_at` / `deleted_reason` columns to `documents` and `links`, new projector verbs (`DocumentSoftDeleted` / `Purged` / `Undeleted`), read-path filter via `include_deleted` parameter, `nx catalog purge --older-than 30d` for grace-window enforcement. The proper architectural answer; the 4.29.1 backup pattern is the recovery affordance.

## Tests

- 15 new regression tests (`tests/test_catalog_backup_and_safety.py`) pin each bug fix + backup/undelete round-trip + retention-window vacuum
- 3 existing CLI tests updated for the new dry-run defaults

## Verification

- [x] `uv run pytest tests/test_catalog_backup_and_safety.py` — 15/15 pass
- [x] `uv run pytest tests/ -k "catalog or link or chash or span"` — 1298 passed, 0 failures
- [ ] `tests/e2e/release-sandbox.sh smoke` (will run after CI green)
- [ ] Local reinstall + `nx --version` (deferred — no `scripts/reinstall-tool.sh` from inside the live session per "no brain surgery on self")

## Closes

- nexus-6ims (P0)
- nexus-tnz3 (P1)
- nexus-9nim (P2)