### PR TITLE
feat(catalog): document_chunks manifest + collections backfill (nexus-mydi)

### DIFF
--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -216,6 +216,34 @@ CREATE INDEX IF NOT EXISTS idx_collections_tuple
 -- live in the post-migration block in __init__: the legacy-DB upgrade
 -- path has to ALTER TABLE the bib columns into existence before the
 -- partial-index CREATE can reference them.
+
+-- RDR-108 D2 (nexus-mydi): document_chunks manifest. The catalog is
+-- the authoritative source of truth for doc->chunk ordering (the
+-- "tree" layer of the git/IPFS-style blob+tree split). T3 chunks are
+-- content-addressed blobs keyed on chunk_text_hash[:32]; this table
+-- records the ordered (doc_id, position) -> chash references that
+-- compose each Document. The same chash can appear at multiple
+-- (doc_id, position) rows: the manifest preserves position; T3
+-- stores content once. Optional positional columns (line_start /
+-- line_end / char_start / char_end) carry display-friendly span
+-- coordinates so retrieval doesn't have to re-derive them from the
+-- source file. chunk_index is the chunker-assigned ordinal at index
+-- time, retained for reference; position is the canonical ordering
+-- key from this RDR onward.
+CREATE TABLE IF NOT EXISTS document_chunks (
+    doc_id      TEXT NOT NULL REFERENCES documents(tumbler),
+    position    INTEGER NOT NULL,
+    chash       TEXT NOT NULL,
+    chunk_index INTEGER,
+    line_start  INTEGER,
+    line_end    INTEGER,
+    char_start  INTEGER,
+    char_end    INTEGER,
+    PRIMARY KEY (doc_id, position)
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_chunks_chash
+    ON document_chunks(chash);
 """
 
 
@@ -237,6 +265,13 @@ class CatalogDB:
         # an indexing writer.
         self._conn.execute("PRAGMA busy_timeout=5000")
         self._conn.execute("PRAGMA journal_mode=WAL")
+        # RDR-108 D2 + D5 (nexus-mydi): enable foreign-key enforcement
+        # so the document_chunks manifest cannot reference a deleted
+        # Document, and future cascade-on-rename machinery (D5
+        # chash_index FK) works as advertised. SQLite enforces FK
+        # constraints only when this PRAGMA is ON; declared REFERENCES
+        # clauses in the schema are otherwise advisory.
+        self._conn.execute("PRAGMA foreign_keys=ON")
         # Issue #437: cap WAL growth under long-lived MCP-server reader
         # connections. SQLite's auto-checkpoint can run only as PASSIVE
         # while readers hold pre-checkpoint snapshots; PASSIVE folds
@@ -387,6 +422,45 @@ class CatalogDB:
                 "ON documents(bib_openalex_id) "
                 "WHERE bib_openalex_id != ''"
             )
+
+        # RDR-108 D2 (nexus-mydi): backfill collections rows for any
+        # documents.physical_collection value that has no matching
+        # collections.name row. Pre-RDR-108 catalogs accumulated docs
+        # whose physical_collection was a free-form string, never
+        # registered in the collections projection — surfaced as the
+        # 11.3x chash_index drift and 76% document_aspects orphan rate
+        # in the 2026-05-08 prod-shakeout. This backfill is structural
+        # prep for FK enforcement on documents.physical_collection
+        # (deferred to a follow-up migration that recreates the
+        # documents table per SQLite's 12-step ALTER pattern).
+        # Idempotent: the SELECT-then-INSERT pattern with a
+        # collections.name PK on the target side is a no-op when the
+        # row already exists.
+        # Probe-guarded: stripped-down legacy schemas (e.g. the
+        # alias_of migration test fixture) may lack the
+        # physical_collection column entirely; skip the backfill in
+        # that case rather than raise.
+        try:
+            self._conn.execute(
+                "SELECT physical_collection FROM documents LIMIT 0"
+            )
+        except sqlite3.OperationalError:
+            pass
+        else:
+            with self._conn:
+                self._conn.execute(
+                    "INSERT INTO collections "
+                    "(name, content_type, owner_id, embedding_model, "
+                    " model_version, display_name, legacy_grandfathered, "
+                    " superseded_by, superseded_at, created_at) "
+                    "SELECT DISTINCT physical_collection, '', '', '', '', '', "
+                    "  1, '', '', '' "
+                    "FROM documents "
+                    "WHERE physical_collection IS NOT NULL "
+                    "  AND physical_collection != '' "
+                    "  AND physical_collection NOT IN "
+                    "      (SELECT name FROM collections)"
+                )
 
     def rebuild(
         self,

--- a/tests/test_catalog_db.py
+++ b/tests/test_catalog_db.py
@@ -485,3 +485,210 @@ class TestNexus7vuwOwnerNameUniqueRelaxation:
         assert db._conn.execute(
             "SELECT COUNT(*) FROM owners WHERE name = 'nexus'"
         ).fetchone()[0] == 2
+
+
+class TestRDR108Phase1aManifest:
+    """RDR-108 Phase 1a (nexus-mydi): document_chunks manifest table +
+    collections backfill + FK enforcement.
+
+    The catalog becomes the authoritative source of truth for
+    doc -> chunk ordering (the "tree" layer of the git/IPFS-style
+    blob+tree split). T3 chunks are content-addressed blobs;
+    document_chunks records each (doc_id, position) -> chash reference.
+    """
+
+    def test_document_chunks_table_exists(self, tmp_path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        tables = {
+            row[0]
+            for row in db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "document_chunks" in tables
+
+    def test_document_chunks_columns(self, tmp_path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        cols = {
+            row[1]
+            for row in db._conn.execute(
+                "PRAGMA table_info(document_chunks)"
+            ).fetchall()
+        }
+        assert {"doc_id", "position", "chash", "chunk_index",
+                "line_start", "line_end", "char_start", "char_end"} <= cols
+
+    def test_document_chunks_pk_is_doc_id_position(self, tmp_path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        pk_cols = [
+            row[1]
+            for row in db._conn.execute(
+                "PRAGMA table_info(document_chunks)"
+            ).fetchall()
+            if row[5] > 0
+        ]
+        # SQLite PRAGMA pk column ordering: 1 = first PK col, 2 = second, etc.
+        assert pk_cols == ["doc_id", "position"]
+
+    def test_idx_document_chunks_chash_exists(self, tmp_path):
+        db = CatalogDB(tmp_path / ".catalog.db")
+        indexes = {
+            row[0]
+            for row in db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            ).fetchall()
+        }
+        assert "idx_document_chunks_chash" in indexes
+
+    def test_foreign_keys_pragma_enabled(self, tmp_path):
+        """RDR-108 D2 + D5 require FK enforcement so cascades work and
+        manifest entries cannot point at deleted documents. SQLite FK
+        enforcement is per-connection: PRAGMA foreign_keys=ON must be
+        set on the CatalogDB connection.
+        """
+        db = CatalogDB(tmp_path / ".catalog.db")
+        on = db._conn.execute("PRAGMA foreign_keys").fetchone()[0]
+        assert on == 1
+
+    def test_document_chunks_fk_rejects_unknown_doc_id(self, tmp_path):
+        """Manifest entries must reference an existing Document. Insert
+        with a doc_id that has no matching documents.tumbler row should
+        raise IntegrityError when foreign_keys=ON.
+        """
+        db = CatalogDB(tmp_path / ".catalog.db")
+        with pytest.raises(sqlite3.IntegrityError):
+            db._conn.execute(
+                "INSERT INTO document_chunks "
+                "(doc_id, position, chash) VALUES (?, ?, ?)",
+                ("1.999.999", 0, "a" * 64),
+            )
+
+    def test_document_chunks_fk_accepts_known_doc_id(self, tmp_path):
+        """Sanity: a manifest entry for a real document succeeds."""
+        db = CatalogDB(tmp_path / ".catalog.db")
+        # Insert a Document row first (use raw SQL to keep the test
+        # independent of the rebuild path).
+        db._conn.execute(
+            "INSERT INTO documents (tumbler, title) VALUES (?, ?)",
+            ("1.1.1", "test.py"),
+        )
+        # Then a manifest entry referencing it.
+        db._conn.execute(
+            "INSERT INTO document_chunks "
+            "(doc_id, position, chash) VALUES (?, ?, ?)",
+            ("1.1.1", 0, "f" * 64),
+        )
+        db._conn.commit()
+        rows = db._conn.execute(
+            "SELECT doc_id, position, chash FROM document_chunks"
+        ).fetchall()
+        assert rows == [("1.1.1", 0, "f" * 64)]
+
+    def test_collections_backfill_creates_missing_rows(self, tmp_path):
+        """Pre-existing documents.physical_collection values that have
+        no matching collections.name row must be backfilled at CatalogDB
+        construction time. This is the structural prep step for FK
+        enforcement on documents.physical_collection (RDR-108 D2 ->
+        future migration).
+        """
+        # Seed a fresh DB and inject documents pointing at an unregistered
+        # collection name (mimics pre-RDR-108 state).
+        db = CatalogDB(tmp_path / ".catalog.db")
+        db._conn.execute(
+            "INSERT INTO documents (tumbler, title, physical_collection) "
+            "VALUES (?, ?, ?)",
+            ("1.1.1", "doc1", "code__legacy-no-row"),
+        )
+        db._conn.execute(
+            "INSERT INTO documents (tumbler, title, physical_collection) "
+            "VALUES (?, ?, ?)",
+            ("1.1.2", "doc2", "code__legacy-no-row"),
+        )
+        db._conn.commit()
+        db.close()
+
+        # Re-open: backfill must create the missing collections row
+        # (idempotent on re-open of an already-backfilled DB).
+        db2 = CatalogDB(tmp_path / ".catalog.db")
+        names = {
+            row[0]
+            for row in db2._conn.execute(
+                "SELECT name FROM collections"
+            ).fetchall()
+        }
+        assert "code__legacy-no-row" in names
+
+    def test_collections_backfill_idempotent(self, tmp_path):
+        """Re-opening a DB whose backfill already ran must not raise
+        nor duplicate collections rows.
+        """
+        db = CatalogDB(tmp_path / ".catalog.db")
+        db._conn.execute(
+            "INSERT INTO documents (tumbler, title, physical_collection) "
+            "VALUES (?, ?, ?)",
+            ("1.1.1", "doc1", "code__legacy"),
+        )
+        db._conn.commit()
+        db.close()
+
+        # Two re-opens: backfill runs twice, must converge.
+        CatalogDB(tmp_path / ".catalog.db").close()
+        db3 = CatalogDB(tmp_path / ".catalog.db")
+        count = db3._conn.execute(
+            "SELECT COUNT(*) FROM collections WHERE name = ?",
+            ("code__legacy",),
+        ).fetchone()[0]
+        assert count == 1
+
+    def test_collections_backfill_skips_empty_physical_collection(self, tmp_path):
+        """Documents with empty physical_collection must NOT generate a
+        backfill row (an empty string is not a valid collection name).
+        """
+        db = CatalogDB(tmp_path / ".catalog.db")
+        db._conn.execute(
+            "INSERT INTO documents (tumbler, title, physical_collection) "
+            "VALUES (?, ?, ?)",
+            ("1.1.1", "doc1", ""),
+        )
+        db._conn.commit()
+        db.close()
+
+        db2 = CatalogDB(tmp_path / ".catalog.db")
+        names = {
+            row[0]
+            for row in db2._conn.execute(
+                "SELECT name FROM collections"
+            ).fetchall()
+        }
+        assert "" not in names
+
+    def test_collections_backfill_skips_existing_rows(self, tmp_path):
+        """If a collections row already exists for a physical_collection
+        value, the backfill must not OVERWRITE its existing fields
+        (legacy_grandfathered, content_type, owner_id, etc.).
+        """
+        db = CatalogDB(tmp_path / ".catalog.db")
+        db._conn.execute(
+            "INSERT INTO collections "
+            "(name, content_type, owner_id, embedding_model, "
+            " legacy_grandfathered, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("code__pre-existing", "code", "1.1", "voyage-code-3",
+             0, "2026-04-01T00:00:00Z"),
+        )
+        db._conn.execute(
+            "INSERT INTO documents (tumbler, title, physical_collection) "
+            "VALUES (?, ?, ?)",
+            ("1.1.1", "doc", "code__pre-existing"),
+        )
+        db._conn.commit()
+        db.close()
+
+        db2 = CatalogDB(tmp_path / ".catalog.db")
+        row = db2._conn.execute(
+            "SELECT content_type, owner_id, legacy_grandfathered "
+            "FROM collections WHERE name = ?",
+            ("code__pre-existing",),
+        ).fetchone()
+        # Pre-existing row preserved.
+        assert row == ("code", "1.1", 0)


### PR DESCRIPTION
## Summary

RDR-108 Phase 1a (D2). Catalog gains the manifest layer.

- New table: `document_chunks (doc_id, position, chash, chunk_index, line_start, line_end, char_start, char_end)` with PK `(doc_id, position)` and `idx_document_chunks_chash`.
- `PRAGMA foreign_keys=ON` so REFERENCES clauses in the schema are actually enforced (D2 manifest integrity, D5 chash_index FK in follow-up beads).
- Backfill: every CatalogDB open creates `collections` rows for any `documents.physical_collection` value that has no matching `collections.name` row (`legacy_grandfathered=1`, all other fields empty). Idempotent. Probe-guarded against the legacy-schema test fixture that lacks `physical_collection`.

FK enforcement on `documents.physical_collection` itself is deferred to a follow-up migration that recreates the `documents` table per SQLite's 12-step ALTER pattern. The backfill here is the structural prep step.

## Why

RDR-108 establishes the git/IPFS-style blob+tree split: T3 = content-addressed chunks, catalog = graph + manifest. This PR lands the manifest table; subsequent Phase 1 beads backfill it from existing T3 metadata (nexus-j43k) and migrate aspect-table PKs (nexus-je0b).

## Tests

- 11 new `TestRDR108Phase1aManifest` cases (table presence, columns, PK shape, index, FK on/off, FK rejects unknown doc_id, FK accepts known doc_id, backfill creates/idempotent/skips-empty/skips-existing-rows).
- `tests/test_catalog_db.py`: 37/37 passed.
- Wider catalog regression: 1053 passed, 0 failed.

## Branch discipline

Per Hal direction 2026-05-09: feature branch off `develop`, PR targets `develop`. main only receives RDR docs + completed-and-reviewed develop merges via develop→main PR (pattern: PR #589).

## Closes

nexus-mydi (RDR-108 Phase 1a)

## Refs

- RDR-108 § Phase 1 Step 1a
- Epic: nexus-4bws
- Next bead in chain: nexus-j43k (manifest backfill from existing T3 metadata) and nexus-he24 (S1 drain protocol) — both depend on this PR landing.