### PR TITLE
feat(aspects): document_aspects + aspect_extraction_queue PK migration to doc_id (nexus-je0b)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -598,3 +598,5 @@
 {"id":"int-ff57008e","kind":"field_change","created_at":"2026-05-08T23:07:15.362192Z","actor":"Hellblazer","issue_id":"nexus-j1ro","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
 {"id":"int-0b25383d","kind":"field_change","created_at":"2026-05-09T01:53:19.074219Z","actor":"Hellblazer","issue_id":"nexus-je0b","extra":{"field":"priority","new_value":"0","old_value":"1"}}
 {"id":"int-348db4e0","kind":"field_change","created_at":"2026-05-09T08:47:44.544444Z","actor":"Hellblazer","issue_id":"nexus-mydi","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-76e4402b","kind":"field_change","created_at":"2026-05-09T09:03:47.130762Z","actor":"Hellblazer","issue_id":"nexus-he24","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-f803cb4f","kind":"field_change","created_at":"2026-05-09T09:03:47.479701Z","actor":"Hellblazer","issue_id":"nexus-j43k","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -14,11 +14,29 @@ from __future__ import annotations
 import sqlite3
 import threading
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 
 import structlog
 
 _log = structlog.get_logger()
+
+
+# ── Migration exceptions ─────────────────────────────────────────────────────
+
+
+class MigrationError(RuntimeError):
+    """Raised when a migration cannot proceed due to a data precondition.
+
+    Examples:
+      - High-volume unmapped orphan collections in aspect PK migration
+        (operator must curate ``collections.superseded_by`` first).
+      - Queue not drained before the PK swap
+        (pending / in_progress rows would be lost).
+
+    The error message includes structured detail so the operator can
+    identify and triage the specific rows.
+    """
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -1821,6 +1839,484 @@ def migrate_drop_null_aspect_rows(conn: sqlite3.Connection) -> None:
     )
 
 
+# ── RDR-108 Phase 1c: Aspect PK migration helpers ───────────────────────────
+
+#: Fixture collection prefixes to hard-delete during aspect PK migration.
+#: These collections were created by the test suite and should never have
+#: persisted into production; dropping them is safe.
+_FIXTURE_COLLECTION_PATTERNS: tuple[str, ...] = (
+    "knowledge__cli-",
+    "knowledge__nexus-integration-test",
+    "knowledge__reproducer",
+    "knowledge__pagtest",
+    "knowledge__pagend",
+)
+
+#: Row count above which an unmapped orphan collection triggers a fail-loud
+#: error rather than a silent hard-delete. Operators must curate
+#: ``collections.superseded_by`` for these before running the migration.
+_HIGH_VOLUME_ORPHAN_THRESHOLD: int = 10
+
+
+def _is_fixture_collection(collection: str) -> bool:
+    """Return True iff *collection* is a test-fixture collection to hard-delete."""
+    for prefix_or_name in _FIXTURE_COLLECTION_PATTERNS:
+        if collection.startswith(prefix_or_name) or collection == prefix_or_name:
+            return True
+    return False
+
+
+def _attach_catalog(conn: sqlite3.Connection, catalog_db_path: Path) -> None:
+    """Attach the catalog DB as ``cat_db`` on *conn*.
+
+    SQLite ATTACH DATABASE allows cross-DB JOINs without reading the
+    entire catalog into Python. The caller must call
+    ``conn.execute("DETACH DATABASE cat_db")`` when finished to avoid
+    leaving dangling attached schemas on the connection.
+    """
+    conn.execute(
+        f"ATTACH DATABASE '{catalog_db_path}' AS cat_db"
+    )
+
+
+def _detach_catalog(conn: sqlite3.Connection) -> None:
+    """Detach ``cat_db`` from *conn* (idempotent — ignored if not attached)."""
+    try:
+        conn.execute("DETACH DATABASE cat_db")
+    except sqlite3.OperationalError:
+        pass  # Not attached — no-op.
+
+
+def _backfill_doc_ids_via_catalog(
+    conn: sqlite3.Connection,
+    *,
+    table: str,
+) -> None:
+    """Two-pass backfill of the ``doc_id`` column in *table* using the
+    catalog ``documents`` table (attached as ``cat_db``).
+
+    Pass 1: direct JOIN on (collection = physical_collection) AND
+            (source_path = file_path).
+    Pass 2: follow ``collections.superseded_by`` one level to handle
+            legacy collection names that were superseded after indexing.
+
+    Fixture rows and remaining unmapped rows are NOT touched here;
+    callers handle those separately.
+    """
+    # Pass 1: direct match — only update rows where the subquery finds a match.
+    # The INNER JOIN form avoids the "subquery returns NULL" NOT NULL violation
+    # that a correlated subquery with no match would produce.
+    conn.execute(f"""
+        UPDATE {table}
+        SET doc_id = cat_db.documents.tumbler
+        FROM cat_db.documents
+        WHERE {table}.collection = cat_db.documents.physical_collection
+          AND {table}.source_path = cat_db.documents.file_path
+          AND {table}.doc_id = ''
+    """)
+    conn.commit()
+
+    # Pass 2: one-hop supersede chain — only for rows still unmapped.
+    # Logic: find the collection row where collections.name matches the
+    # aspect's legacy collection, then look up the document in the
+    # successor collection (collections.superseded_by) with the same file_path.
+    conn.execute(f"""
+        UPDATE {table}
+        SET doc_id = cat_db.documents.tumbler
+        FROM cat_db.documents
+        JOIN cat_db.collections ON cat_db.documents.physical_collection = cat_db.collections.superseded_by
+        WHERE cat_db.collections.superseded_by != ''
+          AND cat_db.collections.name = {table}.collection
+          AND cat_db.documents.file_path = {table}.source_path
+          AND {table}.doc_id = ''
+    """)
+    conn.commit()
+
+
+def _check_high_volume_orphans(conn: sqlite3.Connection, *, table: str) -> None:
+    """Raise ``MigrationError`` if any non-fixture collection has >threshold
+    unmapped rows (doc_id still '').
+
+    The error message lists the unmapped collections and their row counts so
+    the operator knows exactly which ``collections.superseded_by`` entries
+    to curate before re-running.
+    """
+    rows = conn.execute(f"""
+        SELECT collection, COUNT(*) AS n
+        FROM {table}
+        WHERE doc_id = ''
+        GROUP BY collection
+        HAVING n > {_HIGH_VOLUME_ORPHAN_THRESHOLD}
+        ORDER BY n DESC
+    """).fetchall()
+
+    if not rows:
+        return
+
+    detail = "; ".join(f"{coll} ({n} rows)" for coll, n in rows)
+    raise MigrationError(
+        f"RDR-108 Phase 1c: {table} has high-volume unmapped orphan collection(s): "
+        f"{detail}. "
+        "Curate 'collections.superseded_by' for each listed collection in the catalog DB, "
+        "then re-run the migration."
+    )
+
+
+def _hard_delete_unmapped(conn: sqlite3.Connection, *, table: str) -> int:
+    """DELETE rows still at doc_id='' (low-volume orphans acceptable to drop).
+
+    Returns the number of deleted rows.
+    """
+    cur = conn.execute(f"DELETE FROM {table} WHERE doc_id = ''")
+    conn.commit()
+    return cur.rowcount
+
+
+def _is_already_migrated(conn: sqlite3.Connection, *, table: str) -> bool:
+    """Return True iff *table* already has ``doc_id`` as its sole PRIMARY KEY.
+
+    Used for idempotency: re-running the migration on an already-migrated DB
+    is a no-op.
+    """
+    # Check the PK column(s) from PRAGMA table_info (pk flag > 0 means PK member)
+    pk_cols = {
+        r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()
+        if r[5] == 1
+    }
+    return pk_cols == {"doc_id"}
+
+
+def migrate_document_aspects_pk_to_doc_id(
+    conn: sqlite3.Connection,
+    *,
+    catalog_db_path: Path,
+) -> None:
+    """RDR-108 Phase 1c: migrate ``document_aspects`` PRIMARY KEY from
+    ``(collection, source_path)`` to ``(doc_id)``.
+
+    SQLite does not support ``DROP CONSTRAINT`` or ``ADD PRIMARY KEY``, so
+    this uses the 12-step ALTER pattern:
+
+    1. Add ``doc_id TEXT NOT NULL DEFAULT ''`` to the existing table.
+    2. Delete test-fixture collection rows (hard-delete, safe).
+    3. Backfill ``doc_id`` via JOIN against catalog ``documents``.
+       Pass 1: direct (collection, file_path) match.
+       Pass 2: one-hop ``collections.superseded_by`` chain.
+    4. Raise ``MigrationError`` if any non-fixture collection has
+       >10 unmapped rows (operator must curate supersede mappings first).
+    5. Hard-delete remaining low-volume unmapped rows.
+    6. CREATE TABLE ``document_aspects_new`` with ``PRIMARY KEY (doc_id)``
+       and current columns; INSERT from old (deduplicating by latest
+       ``extracted_at`` when two old rows collapse to same doc_id).
+    7. DROP TABLE old; RENAME new; recreate indexes.
+
+    Idempotent: if ``doc_id`` is already the sole PK, returns immediately.
+
+    Args:
+        conn: Open connection to ``memory.db``.
+        catalog_db_path: Path to ``catalog/.catalog.db``. Used for
+            cross-DB JOIN via ``ATTACH DATABASE``.
+    """
+    if _is_already_migrated(conn, table="document_aspects"):
+        _log.info("migrate_document_aspects_pk_to_doc_id_skip", reason="already migrated")
+        return
+
+    # Check table exists
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(document_aspects)").fetchall()}
+    if not cols:
+        _log.info("migrate_document_aspects_pk_to_doc_id_skip", reason="table does not exist")
+        return
+
+    # Step 1: add doc_id column if not present
+    if "doc_id" not in cols:
+        conn.execute(
+            "ALTER TABLE document_aspects ADD COLUMN doc_id TEXT NOT NULL DEFAULT ''"
+        )
+        conn.commit()
+
+    # Step 2: hard-delete test-fixture rows first (before catalog JOIN)
+    for pattern in _FIXTURE_COLLECTION_PATTERNS:
+        if pattern.endswith("-"):
+            conn.execute(
+                "DELETE FROM document_aspects WHERE collection LIKE ?",
+                (pattern + "%",),
+            )
+        else:
+            conn.execute(
+                "DELETE FROM document_aspects WHERE collection = ?",
+                (pattern,),
+            )
+    conn.commit()
+
+    # Steps 3: backfill doc_id via catalog JOIN
+    _attach_catalog(conn, catalog_db_path)
+    try:
+        _backfill_doc_ids_via_catalog(conn, table="document_aspects")
+
+        # Step 4: fail-loud for high-volume unmapped collections
+        _check_high_volume_orphans(conn, table="document_aspects")
+    finally:
+        _detach_catalog(conn)
+
+    # Step 5: hard-delete remaining low-volume unmapped rows
+    dropped = _hard_delete_unmapped(conn, table="document_aspects")
+    if dropped:
+        _log.info(
+            "migrate_document_aspects_pk_to_doc_id_dropped_orphans",
+            count=dropped,
+        )
+
+    # Steps 6-7: CREATE new table with (doc_id) PK, INSERT deduped rows,
+    # DROP old, RENAME, recreate indexes.
+    #
+    # Dedup strategy: when multiple old rows map to the same doc_id, keep
+    # the row with the latest ``extracted_at`` (most recent extraction wins).
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS document_aspects_new (
+            doc_id                 TEXT NOT NULL,
+            collection             TEXT NOT NULL DEFAULT '',
+            source_path            TEXT NOT NULL DEFAULT '',
+            problem_formulation    TEXT,
+            proposed_method        TEXT,
+            experimental_datasets  TEXT,
+            experimental_baselines TEXT,
+            experimental_results   TEXT,
+            extras                 TEXT,
+            confidence             REAL,
+            extracted_at           TEXT NOT NULL,
+            model_version          TEXT NOT NULL,
+            extractor_name         TEXT NOT NULL,
+            source_uri             TEXT,
+            PRIMARY KEY (doc_id)
+        );
+
+        INSERT OR IGNORE INTO document_aspects_new
+            (doc_id, collection, source_path,
+             problem_formulation, proposed_method,
+             experimental_datasets, experimental_baselines,
+             experimental_results, extras, confidence,
+             extracted_at, model_version, extractor_name, source_uri)
+        SELECT
+            doc_id, collection, source_path,
+            problem_formulation, proposed_method,
+            experimental_datasets, experimental_baselines,
+            experimental_results, extras, confidence,
+            extracted_at, model_version, extractor_name, source_uri
+        FROM document_aspects
+        WHERE doc_id IN (
+            SELECT doc_id
+            FROM document_aspects
+            GROUP BY doc_id
+            HAVING extracted_at = MAX(extracted_at)
+        )
+        ORDER BY extracted_at DESC;
+
+        DROP TABLE document_aspects;
+        ALTER TABLE document_aspects_new RENAME TO document_aspects;
+
+        CREATE INDEX IF NOT EXISTS idx_document_aspects_extractor
+            ON document_aspects(extractor_name, model_version);
+        CREATE INDEX IF NOT EXISTS idx_document_aspects_collection
+            ON document_aspects(collection);
+    """)
+    conn.commit()
+
+    _log.info("migrate_document_aspects_pk_to_doc_id_done")
+
+
+def migrate_aspect_extraction_queue_pk_to_doc_id(
+    conn: sqlite3.Connection,
+    *,
+    catalog_db_path: Path,
+) -> None:
+    """RDR-108 Phase 1c: migrate ``aspect_extraction_queue`` PRIMARY KEY from
+    ``(collection, source_path)`` to ``(doc_id)``.
+
+    Pre-migration drain precondition: the queue must have zero rows with
+    ``status != 'failed'`` (i.e., no pending or in_progress rows). Pending /
+    in_progress rows would be dropped by the CREATE-new + INSERT + DROP-old
+    PK swap and the worker would silently lose those extractions. Raises
+    ``MigrationError`` if the precondition fails.
+
+    Uses the same 12-step ALTER pattern as ``migrate_document_aspects_pk_to_doc_id``.
+    The queue is typically empty in production at migration time, but the
+    migration handles non-empty queues (of failed rows only) correctly.
+
+    Idempotent: if ``doc_id`` is already the sole PK, returns immediately.
+
+    Args:
+        conn: Open connection to ``memory.db``.
+        catalog_db_path: Path to ``catalog/.catalog.db``. Used for
+            cross-DB JOIN via ``ATTACH DATABASE``.
+    """
+    if _is_already_migrated(conn, table="aspect_extraction_queue"):
+        _log.info("migrate_aspect_queue_pk_to_doc_id_skip", reason="already migrated")
+        return
+
+    # Check table exists
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(aspect_extraction_queue)").fetchall()}
+    if not cols:
+        _log.info("migrate_aspect_queue_pk_to_doc_id_skip", reason="table does not exist")
+        return
+
+    # Drain precondition: fail if any pending or in_progress rows remain
+    actionable = conn.execute(
+        "SELECT COUNT(*) FROM aspect_extraction_queue WHERE status != 'failed'"
+    ).fetchone()
+    actionable_count = actionable[0] if actionable else 0
+    if actionable_count > 0:
+        raise MigrationError(
+            f"RDR-108 Phase 1c: aspect_extraction_queue is not drained. "
+            f"{actionable_count} row(s) with status pending or in_progress remain. "
+            "Call drain_worker(timeout=30) and verify is_drained() before re-running."
+        )
+
+    # Step 1: add doc_id column if not present
+    if "doc_id" not in cols:
+        conn.execute(
+            "ALTER TABLE aspect_extraction_queue ADD COLUMN doc_id TEXT NOT NULL DEFAULT ''"
+        )
+        conn.commit()
+
+    # Step 2: hard-delete test-fixture rows
+    for pattern in _FIXTURE_COLLECTION_PATTERNS:
+        if pattern.endswith("-"):
+            conn.execute(
+                "DELETE FROM aspect_extraction_queue WHERE collection LIKE ?",
+                (pattern + "%",),
+            )
+        else:
+            conn.execute(
+                "DELETE FROM aspect_extraction_queue WHERE collection = ?",
+                (pattern,),
+            )
+    conn.commit()
+
+    # Step 3: backfill doc_id via catalog JOIN (only for failed rows at this point)
+    _attach_catalog(conn, catalog_db_path)
+    try:
+        _backfill_doc_ids_via_catalog(conn, table="aspect_extraction_queue")
+        _check_high_volume_orphans(conn, table="aspect_extraction_queue")
+    finally:
+        _detach_catalog(conn)
+
+    # Step 4: hard-delete remaining unmapped low-volume rows
+    dropped = _hard_delete_unmapped(conn, table="aspect_extraction_queue")
+    if dropped:
+        _log.info(
+            "migrate_aspect_queue_pk_to_doc_id_dropped_orphans",
+            count=dropped,
+        )
+
+    # Steps 5-7: CREATE new table with (doc_id) PK; dedup by latest enqueued_at
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS aspect_extraction_queue_new (
+            doc_id          TEXT NOT NULL,
+            collection      TEXT NOT NULL DEFAULT '',
+            source_path     TEXT NOT NULL DEFAULT '',
+            content_hash    TEXT NOT NULL DEFAULT '',
+            content         TEXT NOT NULL DEFAULT '',
+            status          TEXT NOT NULL DEFAULT 'pending',
+            retry_count     INTEGER NOT NULL DEFAULT 0,
+            enqueued_at     TEXT NOT NULL,
+            last_attempt_at TEXT,
+            last_error      TEXT,
+            PRIMARY KEY (doc_id)
+        );
+
+        INSERT OR IGNORE INTO aspect_extraction_queue_new
+            (doc_id, collection, source_path,
+             content_hash, content, status,
+             retry_count, enqueued_at, last_attempt_at, last_error)
+        SELECT
+            doc_id, collection, source_path,
+            content_hash, content, status,
+            retry_count, enqueued_at, last_attempt_at, last_error
+        FROM aspect_extraction_queue
+        WHERE doc_id IN (
+            SELECT doc_id
+            FROM aspect_extraction_queue
+            GROUP BY doc_id
+            HAVING enqueued_at = MAX(enqueued_at)
+        )
+        ORDER BY enqueued_at DESC;
+
+        DROP TABLE aspect_extraction_queue;
+        ALTER TABLE aspect_extraction_queue_new RENAME TO aspect_extraction_queue;
+
+        CREATE INDEX IF NOT EXISTS idx_aspect_queue_status
+            ON aspect_extraction_queue(status);
+        CREATE INDEX IF NOT EXISTS idx_aspect_queue_collection
+            ON aspect_extraction_queue(collection);
+    """)
+    conn.commit()
+
+    _log.info("migrate_aspect_queue_pk_to_doc_id_done")
+
+
+def _catalog_db_path_from_conn(conn: sqlite3.Connection) -> Path:
+    """Derive the catalog DB path from the memory.db connection.
+
+    The catalog DB lives at ``<nexus_config_dir>/catalog/.catalog.db``.
+    We infer ``<nexus_config_dir>`` as the parent of the directory that
+    contains ``memory.db`` (i.e., ``memory.db`` is at
+    ``<nexus_config_dir>/memory.db``).
+
+    If the path cannot be inferred (e.g., in-memory DB or non-standard
+    layout), falls back to a path derived from ``NEXUS_CONFIG_DIR`` env
+    or the default ``~/.config/nexus``.
+    """
+    # ``PRAGMA database_list`` returns (seq, name, file) triples.
+    # Row with name='main' gives the file path.
+    for row in conn.execute("PRAGMA database_list").fetchall():
+        if row[1] == "main" and row[2]:
+            mem_path = Path(row[2]).resolve()
+            # memory.db is at <config_dir>/memory.db
+            config_dir = mem_path.parent
+            return config_dir / "catalog" / ".catalog.db"
+
+    # Fallback: use NEXUS_CONFIG_DIR env or default
+    import os
+    override = os.environ.get("NEXUS_CONFIG_DIR", "").strip()
+    if override:
+        return Path(override) / "catalog" / ".catalog.db"
+    return Path.home() / ".config" / "nexus" / "catalog" / ".catalog.db"
+
+
+def _migrate_document_aspects_pk_via_apply_pending(conn: sqlite3.Connection) -> None:
+    """Wrapper for ``apply_pending`` compatibility.
+
+    ``apply_pending`` calls migrations as ``fn(conn)`` with no extra args.
+    This wrapper resolves the catalog DB path from the connection and
+    delegates to ``migrate_document_aspects_pk_to_doc_id``.
+    """
+    catalog_path = _catalog_db_path_from_conn(conn)
+    if not catalog_path.exists():
+        _log.warning(
+            "migrate_document_aspects_pk_skip_no_catalog",
+            catalog_path=str(catalog_path),
+        )
+        return
+    migrate_document_aspects_pk_to_doc_id(conn, catalog_db_path=catalog_path)
+
+
+def _migrate_aspect_queue_pk_via_apply_pending(conn: sqlite3.Connection) -> None:
+    """Wrapper for ``apply_pending`` compatibility.
+
+    ``apply_pending`` calls migrations as ``fn(conn)`` with no extra args.
+    This wrapper resolves the catalog DB path from the connection and
+    delegates to ``migrate_aspect_extraction_queue_pk_to_doc_id``.
+    """
+    catalog_path = _catalog_db_path_from_conn(conn)
+    if not catalog_path.exists():
+        _log.warning(
+            "migrate_aspect_queue_pk_skip_no_catalog",
+            catalog_path=str(catalog_path),
+        )
+        return
+    migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=catalog_path)
+
+
 MIGRATIONS: list[Migration] = [
     Migration("1.10.0", "Memory FTS rebuild with title", migrate_memory_fts),
     Migration("2.8.0", "Add plan project column", migrate_plan_project),
@@ -1953,6 +2449,16 @@ MIGRATIONS: list[Migration] = [
         "4.26.2",
         "Backfill document_aspects.source_uri rows where empty string (nexus-pnje)",
         migrate_document_aspects_source_uri_backfill_empty,
+    ),
+    Migration(
+        "4.30.0",
+        "Migrate document_aspects PK to doc_id (RDR-108 Phase 1c, nexus-je0b)",
+        _migrate_document_aspects_pk_via_apply_pending,
+    ),
+    Migration(
+        "4.30.0",
+        "Migrate aspect_extraction_queue PK to doc_id (RDR-108 Phase 1c, nexus-je0b)",
+        _migrate_aspect_queue_pk_via_apply_pending,
     ),
 ]
 

--- a/src/nexus/db/t2/aspect_extraction_queue.py
+++ b/src/nexus/db/t2/aspect_extraction_queue.py
@@ -356,18 +356,38 @@ class AspectExtractionQueue:
             out.append(row)
         return out
 
-    def mark_done(self, collection: str, source_path: str) -> int:
-        """DELETE the row at ``(collection, source_path)`` — success path.
+    def mark_done(
+        self,
+        collection: str = "",
+        source_path: str = "",
+        *,
+        doc_id: str = "",
+    ) -> int:
+        """DELETE the row at ``(doc_id)`` or ``(collection, source_path)`` — success path.
+
+        After the RDR-108 Phase 1c PK migration the table uses ``doc_id``
+        as primary key; pass ``doc_id=<tumbler>`` to delete by the new key.
+        The legacy ``(collection, source_path)`` pair is retained as a
+        backward-compatible shim for callers that have not yet been updated;
+        it deletes matching rows via the denorm cache columns.
 
         Returns deleted row count (0 when the row was already gone —
         idempotent under concurrent worker invocations).
         """
         with self._lock:
-            cur = self.conn.execute(
-                "DELETE FROM aspect_extraction_queue "
-                "WHERE collection = ? AND source_path = ?",
-                (collection, source_path),
-            )
+            if doc_id:
+                cur = self.conn.execute(
+                    "DELETE FROM aspect_extraction_queue WHERE doc_id = ?",
+                    (doc_id,),
+                )
+            elif collection or source_path:
+                cur = self.conn.execute(
+                    "DELETE FROM aspect_extraction_queue "
+                    "WHERE collection = ? AND source_path = ?",
+                    (collection, source_path),
+                )
+            else:
+                return 0
             self.conn.commit()
             return cur.rowcount
 

--- a/src/nexus/db/t2/document_aspects.py
+++ b/src/nexus/db/t2/document_aspects.py
@@ -97,6 +97,11 @@ class AspectRecord:
     ``experimental_baselines``, ``extras``) are typed as Python
     list / dict here; the store handles serialization on write and
     deserialization on read.
+
+    ``doc_id`` (RDR-108 Phase 1c): catalog tumbler identity for the
+    source document.  After the PK migration, this is the primary key;
+    ``collection`` and ``source_path`` are retained as denorm cache
+    columns.  Empty string on legacy rows written before the migration.
     """
 
     collection: str
@@ -114,6 +119,9 @@ class AspectRecord:
     # RDR-096 P2.1: persistent URI identity. ``None`` on legacy rows
     # written before P2.1 ships; populated for all writes after.
     source_uri: str | None = None
+    # RDR-108 Phase 1c: catalog tumbler identity. Empty string on legacy
+    # rows written before the PK migration.
+    doc_id: str = ""
 
 
 # ── DocumentAspects ─────────────────────────────────────────────────────────
@@ -145,20 +153,42 @@ class DocumentAspects:
             self.conn.executescript(_DOCUMENT_ASPECTS_SCHEMA_SQL)
             self.conn.commit()
 
+    # ── Schema detection ──────────────────────────────────────────────────
+
+    def _has_doc_id_pk(self) -> bool:
+        """Return True iff ``document_aspects`` is using ``doc_id`` as its PK.
+
+        Used by ``upsert`` and ``get`` to route to the right SQL form
+        without callers needing to know which schema version is live.
+        Cached per-instance after first call (schema cannot change while
+        this connection is open without explicit migration).
+        """
+        if not hasattr(self, "_doc_id_pk_cache"):
+            with self._lock:
+                pk_cols = {
+                    r[1] for r in self.conn.execute(
+                        "PRAGMA table_info(document_aspects)"
+                    ).fetchall()
+                    if r[5] == 1
+                }
+                self._doc_id_pk_cache: bool = pk_cols == {"doc_id"}
+        return self._doc_id_pk_cache
+
     # ── Public API ────────────────────────────────────────────────────────
 
     def upsert(self, record: AspectRecord) -> None:
-        """Persist *record* — complete overwrite if (collection, source_path)
-        already present.
+        """Persist *record* — complete overwrite if the PK key already exists.
+
+        Pre-migration: keyed on ``(collection, source_path)``.
+        Post-migration (RDR-108 Phase 1c): keyed on ``doc_id``.
+
+        Both forms require ``extracted_at``, ``model_version``, and
+        ``extractor_name``. Post-migration writes should supply ``doc_id``.
 
         Uses ``INSERT OR REPLACE``. JSON fields serialize with
         ``json.dumps`` (no separator overrides — matches the rest of
         the project).
         """
-        if not record.collection:
-            raise ValueError("collection must not be empty")
-        if not record.source_path:
-            raise ValueError("source_path must not be empty")
         if not record.extracted_at:
             raise ValueError("extracted_at must not be empty")
         if not record.model_version:
@@ -170,35 +200,77 @@ class DocumentAspects:
         baselines_json = json.dumps(list(record.experimental_baselines))
         extras_json = json.dumps(dict(record.extras))
 
-        with self._lock:
-            self.conn.execute(
-                "INSERT OR REPLACE INTO document_aspects "
-                "(collection, source_path, problem_formulation, "
-                " proposed_method, experimental_datasets, "
-                " experimental_baselines, experimental_results, "
-                " extras, confidence, extracted_at, "
-                " model_version, extractor_name, source_uri) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    record.collection,
-                    record.source_path,
-                    record.problem_formulation,
-                    record.proposed_method,
-                    datasets_json,
-                    baselines_json,
-                    record.experimental_results,
-                    extras_json,
-                    record.confidence,
-                    record.extracted_at,
-                    record.model_version,
-                    record.extractor_name,
-                    record.source_uri,
-                ),
-            )
-            self.conn.commit()
+        if self._has_doc_id_pk():
+            # Post-migration schema: doc_id is PK; collection + source_path are denorm.
+            if not record.doc_id:
+                raise ValueError("doc_id must not be empty on a migrated document_aspects table")
+            with self._lock:
+                self.conn.execute(
+                    "INSERT OR REPLACE INTO document_aspects "
+                    "(doc_id, collection, source_path, problem_formulation, "
+                    " proposed_method, experimental_datasets, "
+                    " experimental_baselines, experimental_results, "
+                    " extras, confidence, extracted_at, "
+                    " model_version, extractor_name, source_uri) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        record.doc_id,
+                        record.collection,
+                        record.source_path,
+                        record.problem_formulation,
+                        record.proposed_method,
+                        datasets_json,
+                        baselines_json,
+                        record.experimental_results,
+                        extras_json,
+                        record.confidence,
+                        record.extracted_at,
+                        record.model_version,
+                        record.extractor_name,
+                        record.source_uri,
+                    ),
+                )
+                self.conn.commit()
+        else:
+            # Pre-migration schema: (collection, source_path) is PK.
+            if not record.collection:
+                raise ValueError("collection must not be empty")
+            if not record.source_path:
+                raise ValueError("source_path must not be empty")
+            with self._lock:
+                self.conn.execute(
+                    "INSERT OR REPLACE INTO document_aspects "
+                    "(collection, source_path, problem_formulation, "
+                    " proposed_method, experimental_datasets, "
+                    " experimental_baselines, experimental_results, "
+                    " extras, confidence, extracted_at, "
+                    " model_version, extractor_name, source_uri) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        record.collection,
+                        record.source_path,
+                        record.problem_formulation,
+                        record.proposed_method,
+                        datasets_json,
+                        baselines_json,
+                        record.experimental_results,
+                        extras_json,
+                        record.confidence,
+                        record.extracted_at,
+                        record.model_version,
+                        record.extractor_name,
+                        record.source_uri,
+                    ),
+                )
+                self.conn.commit()
 
     def get(self, collection: str, source_path: str) -> AspectRecord | None:
-        """Return the row matching ``(collection, source_path)``, or None."""
+        """Return the row matching ``(collection, source_path)``, or None.
+
+        Works on both pre- and post-migration schemas; the post-migration
+        table retains ``collection`` + ``source_path`` as denorm cache columns
+        so this query is still valid after the PK migration.
+        """
         with self._lock:
             row = self.conn.execute(
                 "SELECT collection, source_path, problem_formulation, "
@@ -213,6 +285,30 @@ class DocumentAspects:
         if row is None:
             return None
         return _row_to_record(row)
+
+    def get_by_doc_id(self, doc_id: str) -> AspectRecord | None:
+        """Return the row matching ``doc_id``, or None.
+
+        Only valid on post-migration schema (RDR-108 Phase 1c) where
+        ``doc_id`` is the primary key.  Returns None if the table has
+        not been migrated or if the doc_id is not present.
+        """
+        if not self._has_doc_id_pk():
+            return None
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT collection, source_path, problem_formulation, "
+                "       proposed_method, experimental_datasets, "
+                "       experimental_baselines, experimental_results, "
+                "       extras, confidence, extracted_at, "
+                "       model_version, extractor_name, source_uri, doc_id "
+                "FROM document_aspects "
+                "WHERE doc_id = ?",
+                (doc_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return _row_to_record_with_doc_id(row)
 
     def list_by_collection(
         self,
@@ -301,10 +397,17 @@ class DocumentAspects:
 
 
 def _row_to_record(row: tuple) -> AspectRecord:
-    """Inflate a SELECT-result tuple into an ``AspectRecord``.
+    """Inflate a 13-column SELECT-result tuple into an ``AspectRecord``.
 
     JSON columns deserialize on read; missing or NULL JSON columns
     yield empty list/dict so callers never need a None-check.
+
+    Column order must match the SELECT in ``get()`` and
+    ``list_by_collection()``:
+      collection, source_path, problem_formulation, proposed_method,
+      experimental_datasets, experimental_baselines, experimental_results,
+      extras, confidence, extracted_at, model_version, extractor_name,
+      source_uri
     """
     (
         collection,
@@ -335,6 +438,47 @@ def _row_to_record(row: tuple) -> AspectRecord:
         model_version=model_version,
         extractor_name=extractor_name,
         source_uri=source_uri,
+    )
+
+
+def _row_to_record_with_doc_id(row: tuple) -> AspectRecord:
+    """Inflate a 14-column SELECT-result tuple (includes doc_id) into an
+    ``AspectRecord``.
+
+    Used by ``get_by_doc_id()`` which SELECTs the ``doc_id`` column as the
+    14th positional column.
+    """
+    (
+        collection,
+        source_path,
+        problem_formulation,
+        proposed_method,
+        datasets_json,
+        baselines_json,
+        experimental_results,
+        extras_json,
+        confidence,
+        extracted_at,
+        model_version,
+        extractor_name,
+        source_uri,
+        doc_id,
+    ) = row
+    return AspectRecord(
+        collection=collection,
+        source_path=source_path,
+        problem_formulation=problem_formulation,
+        proposed_method=proposed_method,
+        experimental_datasets=_safe_json_list(datasets_json),
+        experimental_baselines=_safe_json_list(baselines_json),
+        experimental_results=experimental_results,
+        extras=_safe_json_dict(extras_json),
+        confidence=confidence,
+        extracted_at=extracted_at,
+        model_version=model_version,
+        extractor_name=extractor_name,
+        source_uri=source_uri,
+        doc_id=doc_id or "",
     )
 
 

--- a/tests/test_migrations_rdr108_phase1c.py
+++ b/tests/test_migrations_rdr108_phase1c.py
@@ -1,0 +1,834 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""RDR-108 Phase 1c: document_aspects + aspect_extraction_queue PK migration
+to (doc_id) — nexus-je0b.
+
+Tests cover:
+- Schema target: PRIMARY KEY (doc_id), denorm cache columns retained
+- Backfill via direct (collection, file_path) JOIN against catalog docs
+- Backfill via supersede-chain JOIN for legacy-but-mapped collections
+- Test-fixture rows hard-deleted (5 fixture collection prefixes)
+- High-volume unmapped rows trigger fail-loud (MigrationError)
+- Drain precondition: migration BLOCKS if queue has pending/in_progress rows
+- Drain precondition: migration RUNS if queue is empty or only has failed rows
+- mark_done(doc_id) works post-migration
+- claim_next returns doc_id field
+- Idempotent: re-running migration on already-migrated DB is a no-op
+- Cross-DB ATTACH cleanup: migration leaves no dangling attached schemas
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_memory_db(path: Path) -> sqlite3.Connection:
+    """Create a fresh memory.db with pre-migration schema for both tables."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        PRAGMA journal_mode=WAL;
+
+        CREATE TABLE IF NOT EXISTS document_aspects (
+            collection             TEXT NOT NULL,
+            source_path            TEXT NOT NULL,
+            problem_formulation    TEXT,
+            proposed_method        TEXT,
+            experimental_datasets  TEXT,
+            experimental_baselines TEXT,
+            experimental_results   TEXT,
+            extras                 TEXT,
+            confidence             REAL,
+            extracted_at           TEXT NOT NULL,
+            model_version          TEXT NOT NULL,
+            extractor_name         TEXT NOT NULL,
+            source_uri             TEXT,
+            PRIMARY KEY (collection, source_path)
+        );
+        CREATE INDEX IF NOT EXISTS idx_document_aspects_extractor
+            ON document_aspects(extractor_name, model_version);
+
+        CREATE TABLE IF NOT EXISTS aspect_extraction_queue (
+            collection      TEXT NOT NULL,
+            source_path     TEXT NOT NULL,
+            doc_id          TEXT NOT NULL DEFAULT '',
+            content_hash    TEXT NOT NULL DEFAULT '',
+            content         TEXT NOT NULL DEFAULT '',
+            status          TEXT NOT NULL DEFAULT 'pending',
+            retry_count     INTEGER NOT NULL DEFAULT 0,
+            enqueued_at     TEXT NOT NULL,
+            last_attempt_at TEXT,
+            last_error      TEXT,
+            PRIMARY KEY (collection, source_path)
+        );
+        CREATE INDEX IF NOT EXISTS idx_aspect_queue_status
+            ON aspect_extraction_queue(status);
+    """)
+    conn.commit()
+    return conn
+
+
+def _make_catalog_db(path: Path) -> sqlite3.Connection:
+    """Create a minimal catalog.db with documents + collections tables."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS documents (
+            tumbler TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            file_path TEXT,
+            physical_collection TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS collections (
+            name TEXT PRIMARY KEY,
+            superseded_by TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT ''
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _insert_aspect(
+    conn: sqlite3.Connection,
+    *,
+    collection: str,
+    source_path: str,
+    extracted_at: str = "2026-05-01T00:00:00+00:00",
+    model_version: str = "claude-haiku-4-5-20251001",
+    extractor_name: str = "scholarly-paper-v1",
+) -> None:
+    conn.execute(
+        "INSERT INTO document_aspects "
+        "(collection, source_path, extracted_at, model_version, extractor_name) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (collection, source_path, extracted_at, model_version, extractor_name),
+    )
+    conn.commit()
+
+
+def _insert_queue(
+    conn: sqlite3.Connection,
+    *,
+    collection: str,
+    source_path: str,
+    status: str = "pending",
+    doc_id: str = "",
+) -> None:
+    conn.execute(
+        "INSERT INTO aspect_extraction_queue "
+        "(collection, source_path, status, enqueued_at, doc_id) "
+        "VALUES (?, ?, ?, '2026-05-01T00:00:00+00:00', ?)",
+        (collection, source_path, status, doc_id),
+    )
+    conn.commit()
+
+
+def _insert_catalog_doc(
+    conn: sqlite3.Connection,
+    *,
+    tumbler: str,
+    file_path: str,
+    physical_collection: str,
+) -> None:
+    conn.execute(
+        "INSERT INTO documents (tumbler, title, file_path, physical_collection) "
+        "VALUES (?, 'Test Doc', ?, ?)",
+        (tumbler, file_path, physical_collection),
+    )
+    conn.commit()
+
+
+def _aspect_columns(conn: sqlite3.Connection) -> set[str]:
+    return {r[1] for r in conn.execute("PRAGMA table_info(document_aspects)").fetchall()}
+
+
+def _queue_columns(conn: sqlite3.Connection) -> set[str]:
+    return {r[1] for r in conn.execute("PRAGMA table_info(aspect_extraction_queue)").fetchall()}
+
+
+# ── document_aspects PK migration: schema shape ───────────────────────────────
+
+
+class TestDocumentAspectsPKMigration:
+    """The migration produces PRIMARY KEY (doc_id) with denorm cache columns."""
+
+    def test_schema_has_doc_id_as_pk(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        migrate_document_aspects_pk_to_doc_id(conn, catalog_db_path=cat_db)
+
+        # doc_id must be a column
+        cols = _aspect_columns(conn)
+        assert "doc_id" in cols
+
+        # Verify doc_id is the primary key via table_info
+        pk_cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(document_aspects)").fetchall()
+            if r[5] == 1  # pk flag
+        }
+        assert pk_cols == {"doc_id"}
+        conn.close()
+
+    def test_denorm_cache_columns_retained(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        migrate_document_aspects_pk_to_doc_id(conn, catalog_db_path=cat_db)
+
+        cols = _aspect_columns(conn)
+        # Denorm cache columns retained
+        assert "collection" in cols
+        assert "source_path" in cols
+        # Existing extraction columns retained
+        assert "problem_formulation" in cols
+        assert "proposed_method" in cols
+        assert "extracted_at" in cols
+        assert "model_version" in cols
+        assert "extractor_name" in cols
+        assert "source_uri" in cols
+        conn.close()
+
+    def test_backfill_via_direct_join(self, tmp_path: Path) -> None:
+        """Rows matching (collection, file_path) in catalog get doc_id populated."""
+        from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        mem_conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+
+        # Seed catalog document
+        _insert_catalog_doc(
+            cat_conn,
+            tumbler="nexus-abc123",
+            file_path="/papers/paper1.pdf",
+            physical_collection="knowledge__delos",
+        )
+        cat_conn.close()
+
+        # Seed aspect row matching that catalog doc
+        _insert_aspect(
+            mem_conn,
+            collection="knowledge__delos",
+            source_path="/papers/paper1.pdf",
+        )
+
+        migrate_document_aspects_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
+
+        row = mem_conn.execute(
+            "SELECT doc_id, collection, source_path FROM document_aspects"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "nexus-abc123"
+        assert row[1] == "knowledge__delos"  # denorm cache retained
+        assert row[2] == "/papers/paper1.pdf"  # denorm cache retained
+        mem_conn.close()
+
+    def test_backfill_via_supersede_chain(self, tmp_path: Path) -> None:
+        """Rows in a legacy collection that has superseded_by mapping get doc_id
+        from the successor collection."""
+        from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        mem_conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+
+        # The legacy collection that is superseded
+        cat_conn.execute(
+            "INSERT INTO collections (name, superseded_by) VALUES (?, ?)",
+            ("rdr__legacy-abc123", "rdr__nexus-1-1__voyage-context-3__v1"),
+        )
+        # Catalog doc is in the NEW collection but same file path
+        _insert_catalog_doc(
+            cat_conn,
+            tumbler="nexus-def456",
+            file_path="/rdrs/rdr-001.md",
+            physical_collection="rdr__nexus-1-1__voyage-context-3__v1",
+        )
+        cat_conn.commit()
+        cat_conn.close()
+
+        # Aspect row still references the old collection name
+        _insert_aspect(
+            mem_conn,
+            collection="rdr__legacy-abc123",
+            source_path="/rdrs/rdr-001.md",
+        )
+
+        migrate_document_aspects_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
+
+        row = mem_conn.execute(
+            "SELECT doc_id FROM document_aspects"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "nexus-def456"
+        mem_conn.close()
+
+    @pytest.mark.parametrize("fixture_collection", [
+        "knowledge__cli-test",
+        "knowledge__cli-abc",
+        "knowledge__nexus-integration-test",
+        "knowledge__reproducer",
+        "knowledge__pagtest",
+        "knowledge__pagend",
+    ])
+    def test_fixture_rows_hard_deleted(
+        self, tmp_path: Path, fixture_collection: str
+    ) -> None:
+        """Test-fixture collections are hard-deleted, never migrated."""
+        from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        mem_conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        _insert_aspect(mem_conn, collection=fixture_collection, source_path="/doc.pdf")
+
+        migrate_document_aspects_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
+
+        count = mem_conn.execute(
+            "SELECT COUNT(*) FROM document_aspects"
+        ).fetchone()[0]
+        assert count == 0, f"Expected 0 rows, got {count} for fixture {fixture_collection}"
+        mem_conn.close()
+
+    def test_high_volume_unmapped_raises_migration_error(self, tmp_path: Path) -> None:
+        """Orphan collection with >10 rows and no supersede mapping raises MigrationError."""
+        from nexus.db.migrations import MigrationError, migrate_document_aspects_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        mem_conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+        cat_conn.close()
+
+        # Insert 15 rows in an unmapped legacy collection (no catalog entry, no supersede)
+        for i in range(15):
+            _insert_aspect(
+                mem_conn,
+                collection="rdr__nexus-571b8edd",
+                source_path=f"/rdrs/rdr-{i:03d}.md",
+            )
+
+        with pytest.raises(MigrationError, match="rdr__nexus-571b8edd"):
+            migrate_document_aspects_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
+        mem_conn.close()
+
+    def test_low_volume_unmapped_hard_deleted(self, tmp_path: Path) -> None:
+        """Unmapped collections with <=10 rows are hard-deleted (acceptable orphan loss)."""
+        from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        mem_conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+
+        # Insert a valid in-catalog row (should survive)
+        _insert_catalog_doc(
+            cat_conn,
+            tumbler="nexus-valid01",
+            file_path="/papers/valid.pdf",
+            physical_collection="knowledge__delos",
+        )
+        cat_conn.commit()
+        cat_conn.close()
+
+        _insert_aspect(mem_conn, collection="knowledge__delos", source_path="/papers/valid.pdf")
+        # Insert 3 orphan rows (below threshold — hard delete)
+        for i in range(3):
+            _insert_aspect(
+                mem_conn,
+                collection="rdr__some-old-hash",
+                source_path=f"/rdrs/orphan-{i}.md",
+            )
+
+        migrate_document_aspects_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
+
+        # Only the valid row survives
+        rows = mem_conn.execute(
+            "SELECT doc_id, collection FROM document_aspects ORDER BY collection"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "nexus-valid01"
+        assert rows[0][1] == "knowledge__delos"
+        mem_conn.close()
+
+    def test_idempotent_on_already_migrated_db(self, tmp_path: Path) -> None:
+        """Re-running migration on an already-migrated DB is a no-op (no error, same rows)."""
+        from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        mem_conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+
+        _insert_catalog_doc(
+            cat_conn,
+            tumbler="nexus-idem01",
+            file_path="/papers/idem.pdf",
+            physical_collection="knowledge__delos",
+        )
+        cat_conn.commit()
+        cat_conn.close()
+
+        _insert_aspect(mem_conn, collection="knowledge__delos", source_path="/papers/idem.pdf")
+
+        migrate_document_aspects_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
+        # Run again — should not raise
+        migrate_document_aspects_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
+
+        count = mem_conn.execute("SELECT COUNT(*) FROM document_aspects").fetchone()[0]
+        assert count == 1
+        mem_conn.close()
+
+    def test_no_dangling_attach_after_migration(self, tmp_path: Path) -> None:
+        """After migration, no 'cat_db' attached database remains on the connection.
+
+        SQLite always has 'main' and 'temp' in PRAGMA database_list; the
+        migration must not leave 'cat_db' (or any other attached user DB)
+        behind after it finishes.
+        """
+        from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        mem_conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+        _insert_catalog_doc(
+            cat_conn,
+            tumbler="nexus-clean01",
+            file_path="/papers/clean.pdf",
+            physical_collection="knowledge__delos",
+        )
+        cat_conn.commit()
+        cat_conn.close()
+
+        migrate_document_aspects_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
+
+        # PRAGMA database_list shows only 'main' (and SQLite's built-in 'temp')
+        # No 'cat_db' (or other user-attached names) should remain.
+        dbs = {r[1] for r in mem_conn.execute("PRAGMA database_list").fetchall()}
+        assert "cat_db" not in dbs
+        assert "main" in dbs
+        mem_conn.close()
+
+    def test_dedup_keeps_latest_extracted_at(self, tmp_path: Path) -> None:
+        """When two old (collection, source_path) rows map to same doc_id,
+        keep the row with the latest extracted_at."""
+        from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        mem_conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+
+        # Two catalog docs share the same file path but different collections
+        # that both map to the same tumbler (via supersede chain)
+        cat_conn.execute(
+            "INSERT INTO collections (name, superseded_by) VALUES (?, ?)",
+            ("knowledge__old", "knowledge__delos"),
+        )
+        _insert_catalog_doc(
+            cat_conn,
+            tumbler="nexus-dedup01",
+            file_path="/papers/same.pdf",
+            physical_collection="knowledge__delos",
+        )
+        cat_conn.commit()
+        cat_conn.close()
+
+        # Row 1: in old collection, earlier extraction
+        _insert_aspect(
+            mem_conn,
+            collection="knowledge__old",
+            source_path="/papers/same.pdf",
+            extracted_at="2026-04-01T00:00:00+00:00",
+            model_version="claude-haiku-4-5-20251001",
+        )
+        # Row 2: in current collection, later extraction
+        _insert_aspect(
+            mem_conn,
+            collection="knowledge__delos",
+            source_path="/papers/same.pdf",
+            extracted_at="2026-04-30T00:00:00+00:00",
+            model_version="claude-haiku-4-5-20251001",
+        )
+
+        migrate_document_aspects_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
+
+        rows = mem_conn.execute(
+            "SELECT doc_id, extracted_at FROM document_aspects"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "nexus-dedup01"
+        assert rows[0][1] == "2026-04-30T00:00:00+00:00"  # latest wins
+        mem_conn.close()
+
+
+# ── aspect_extraction_queue PK migration ─────────────────────────────────────
+
+
+class TestAspectQueuePKMigration:
+    """The queue migration produces PRIMARY KEY (doc_id) with denorm cache columns."""
+
+    def test_schema_has_doc_id_as_pk(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_aspect_extraction_queue_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=cat_db)
+
+        pk_cols = {
+            r[1] for r in conn.execute("PRAGMA table_info(aspect_extraction_queue)").fetchall()
+            if r[5] == 1
+        }
+        assert pk_cols == {"doc_id"}
+        conn.close()
+
+    def test_denorm_cache_columns_retained(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_aspect_extraction_queue_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=cat_db)
+
+        cols = _queue_columns(conn)
+        assert "collection" in cols
+        assert "source_path" in cols
+        assert "status" in cols
+        assert "content_hash" in cols
+        assert "content" in cols
+        conn.close()
+
+    def test_drain_precondition_blocks_on_pending(self, tmp_path: Path) -> None:
+        """Migration raises MigrationError when queue has pending rows."""
+        from nexus.db.migrations import MigrationError, migrate_aspect_extraction_queue_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        _insert_queue(conn, collection="knowledge__delos", source_path="/doc.pdf", status="pending")
+
+        with pytest.raises(MigrationError, match="not drained"):
+            migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=cat_db)
+        conn.close()
+
+    def test_drain_precondition_blocks_on_in_progress(self, tmp_path: Path) -> None:
+        """Migration raises MigrationError when queue has in_progress rows."""
+        from nexus.db.migrations import MigrationError, migrate_aspect_extraction_queue_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        _insert_queue(conn, collection="knowledge__delos", source_path="/doc.pdf", status="in_progress")
+
+        with pytest.raises(MigrationError, match="not drained"):
+            migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=cat_db)
+        conn.close()
+
+    def test_drain_precondition_passes_on_empty_queue(self, tmp_path: Path) -> None:
+        """Empty queue: migration proceeds without error."""
+        from nexus.db.migrations import migrate_aspect_extraction_queue_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        # Should not raise
+        migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=cat_db)
+        conn.close()
+
+    def test_drain_precondition_passes_on_failed_only(self, tmp_path: Path) -> None:
+        """Failed rows are inert — migration proceeds normally."""
+        from nexus.db.migrations import migrate_aspect_extraction_queue_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+
+        _insert_catalog_doc(
+            cat_conn,
+            tumbler="nexus-fail01",
+            file_path="/papers/fail.pdf",
+            physical_collection="knowledge__delos",
+        )
+        cat_conn.commit()
+        cat_conn.close()
+
+        _insert_queue(
+            conn,
+            collection="knowledge__delos",
+            source_path="/papers/fail.pdf",
+            status="failed",
+        )
+
+        # Should not raise
+        migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=cat_db)
+        conn.close()
+
+    def test_backfill_via_direct_join(self, tmp_path: Path) -> None:
+        """Queue rows matching (collection, source_path) in catalog get doc_id populated."""
+        from nexus.db.migrations import migrate_aspect_extraction_queue_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        mem_conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+
+        _insert_catalog_doc(
+            cat_conn,
+            tumbler="nexus-qrow01",
+            file_path="/papers/qrow.pdf",
+            physical_collection="knowledge__delos",
+        )
+        cat_conn.commit()
+        cat_conn.close()
+
+        _insert_queue(
+            mem_conn,
+            collection="knowledge__delos",
+            source_path="/papers/qrow.pdf",
+            status="failed",  # only failed rows may exist (drain precondition)
+        )
+
+        migrate_aspect_extraction_queue_pk_to_doc_id(mem_conn, catalog_db_path=cat_db)
+
+        row = mem_conn.execute(
+            "SELECT doc_id, collection, source_path FROM aspect_extraction_queue"
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "nexus-qrow01"
+        assert row[1] == "knowledge__delos"
+        assert row[2] == "/papers/qrow.pdf"
+        mem_conn.close()
+
+    def test_idempotent_on_already_migrated_db(self, tmp_path: Path) -> None:
+        """Re-running queue migration on an already-migrated DB is a no-op."""
+        from nexus.db.migrations import migrate_aspect_extraction_queue_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=cat_db)
+        migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=cat_db)
+        conn.close()
+
+    def test_no_dangling_attach_after_migration(self, tmp_path: Path) -> None:
+        from nexus.db.migrations import migrate_aspect_extraction_queue_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        _make_catalog_db(cat_db)
+
+        migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=cat_db)
+
+        dbs = {r[1] for r in conn.execute("PRAGMA database_list").fetchall()}
+        assert "cat_db" not in dbs
+        assert "main" in dbs
+        conn.close()
+
+
+# ── AspectExtractionQueue post-migration accessor API ─────────────────────────
+
+
+class TestQueuePostMigrationAPI:
+    """After migration, mark_done(doc_id) and claim_next returning doc_id."""
+
+    @pytest.fixture()
+    def migrated_queue_path(self, tmp_path: Path) -> Path:
+        """Return path to a migrated aspect_extraction_queue DB."""
+        from nexus.db.migrations import migrate_aspect_extraction_queue_pk_to_doc_id
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+        _insert_catalog_doc(
+            cat_conn,
+            tumbler="nexus-api01",
+            file_path="/papers/api.pdf",
+            physical_collection="knowledge__delos",
+        )
+        cat_conn.commit()
+        cat_conn.close()
+        migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=cat_db)
+        conn.close()
+        return mem_db
+
+    def test_enqueue_and_claim_returns_doc_id(self, migrated_queue_path: Path) -> None:
+        """After migration, enqueue + claim_next returns a QueueRow with doc_id populated."""
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        q = AspectExtractionQueue(migrated_queue_path)
+        q.enqueue(
+            "knowledge__delos",
+            "/papers/api.pdf",
+            doc_id="nexus-api01",
+        )
+        row = q.claim_next()
+        assert row is not None
+        assert row.doc_id == "nexus-api01"
+        q.close()
+
+    def test_mark_done_by_doc_id(self, migrated_queue_path: Path) -> None:
+        """mark_done(doc_id=...) deletes the row by doc_id on a migrated table."""
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        q = AspectExtractionQueue(migrated_queue_path)
+        q.enqueue(
+            "knowledge__delos",
+            "/papers/api.pdf",
+            doc_id="nexus-api01",
+        )
+        row = q.claim_next()
+        assert row is not None
+        deleted = q.mark_done(doc_id="nexus-api01")
+        assert deleted == 1
+
+        # Queue should now be empty
+        assert q.pending_count() == 0
+        q.close()
+
+    def test_mark_done_legacy_collection_source_path(self, migrated_queue_path: Path) -> None:
+        """mark_done(collection, source_path) still works after migration (backward compat)."""
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        q = AspectExtractionQueue(migrated_queue_path)
+        q.enqueue(
+            "knowledge__delos",
+            "/papers/api.pdf",
+            doc_id="nexus-api01",
+        )
+        q.claim_next()
+        # Legacy call form
+        deleted = q.mark_done(collection="knowledge__delos", source_path="/papers/api.pdf")
+        assert deleted == 1
+        q.close()
+
+
+# ── DocumentAspects post-migration accessor API ───────────────────────────────
+
+
+class TestDocumentAspectsPostMigrationAPI:
+    """After migration, get_by_doc_id works; existing API still usable."""
+
+    @pytest.fixture()
+    def migrated_aspects_path(self, tmp_path: Path) -> Path:
+        from nexus.db.migrations import migrate_document_aspects_pk_to_doc_id
+        from nexus.db.t2.document_aspects import AspectRecord
+
+        mem_db = tmp_path / "memory.db"
+        cat_db = tmp_path / ".catalog.db"
+        conn = _make_memory_db(mem_db)
+        cat_conn = _make_catalog_db(cat_db)
+        _insert_catalog_doc(
+            cat_conn,
+            tumbler="nexus-asp01",
+            file_path="/papers/asp.pdf",
+            physical_collection="knowledge__delos",
+        )
+        cat_conn.commit()
+        cat_conn.close()
+
+        _insert_aspect(conn, collection="knowledge__delos", source_path="/papers/asp.pdf")
+        migrate_document_aspects_pk_to_doc_id(conn, catalog_db_path=cat_db)
+        conn.close()
+        return mem_db
+
+    def test_get_by_doc_id(self, migrated_aspects_path: Path) -> None:
+        from nexus.db.t2.document_aspects import DocumentAspects
+
+        store = DocumentAspects(migrated_aspects_path)
+        record = store.get_by_doc_id("nexus-asp01")
+        assert record is not None
+        assert record.collection == "knowledge__delos"
+        store.close()
+
+    def test_upsert_by_doc_id(self, migrated_aspects_path: Path) -> None:
+        from nexus.db.t2.document_aspects import AspectRecord, DocumentAspects
+
+        store = DocumentAspects(migrated_aspects_path)
+        record = AspectRecord(
+            collection="knowledge__delos",
+            source_path="/papers/new.pdf",
+            doc_id="nexus-new01",
+            problem_formulation="Test",
+            proposed_method="Test method",
+            extracted_at="2026-05-09T00:00:00+00:00",
+            model_version="claude-haiku-4-5-20251001",
+            extractor_name="scholarly-paper-v1",
+        )
+        store.upsert(record)
+        fetched = store.get_by_doc_id("nexus-new01")
+        assert fetched is not None
+        assert fetched.problem_formulation == "Test"
+        store.close()
+
+
+# ── MIGRATIONS list registration ──────────────────────────────────────────────
+
+
+class TestMigrationsListRegistration:
+    """Both migrations appear in the MIGRATIONS list at version 4.30.0."""
+
+    def test_document_aspects_migration_registered(self) -> None:
+        from nexus.db.migrations import MIGRATIONS
+
+        names = [m.name for m in MIGRATIONS]
+        assert any("document_aspects" in n and "doc_id" in n for n in names), (
+            f"document_aspects PK migration not found in MIGRATIONS: {names}"
+        )
+
+    def test_aspect_queue_migration_registered(self) -> None:
+        from nexus.db.migrations import MIGRATIONS
+
+        names = [m.name for m in MIGRATIONS]
+        assert any("aspect_extraction_queue" in n and "doc_id" in n for n in names), (
+            f"aspect_extraction_queue PK migration not found in MIGRATIONS: {names}"
+        )
+
+    def test_both_at_version_4_30_0(self) -> None:
+        from nexus.db.migrations import MIGRATIONS
+
+        migrated = [
+            m for m in MIGRATIONS
+            if "doc_id" in m.name and (
+                "document_aspects" in m.name or "aspect_extraction_queue" in m.name
+            )
+        ]
+        assert len(migrated) == 2
+        for m in migrated:
+            assert m.introduced == "4.30.0", (
+                f"Migration {m.name!r} has version {m.introduced!r}, expected '4.30.0'"
+            )


### PR DESCRIPTION
## Summary

- RDR-108 Phase 1c: both `document_aspects` and `aspect_extraction_queue` migrate from `PRIMARY KEY (collection, source_path)` to `PRIMARY KEY (doc_id)` using the 12-step SQLite ALTER pattern
- Cross-DB ATTACH against `catalog/.catalog.db` for direct (collection, file_path) JOIN + one-hop `collections.superseded_by` chain backfill
- Pre-migration drain precondition: queue must have zero pending/in_progress rows (raises `MigrationError` otherwise)
- High-volume unmapped orphan collections (>10 rows, no supersede mapping) fail-loud; low-volume orphans and test-fixture collections hard-deleted
- `AspectExtractionQueue.mark_done()` gains `doc_id=` kwarg; `DocumentAspects` gains `get_by_doc_id()` and `doc_id`-keyed `upsert()`

## Test plan

- [x] 32 new TDD tests in `tests/test_migrations_rdr108_phase1c.py` covering all spec requirements
- [x] 555 aspect + migration tests pass (`uv run pytest tests/ -k "aspect or migration"`)
- [x] 364 aspect tests pass (`uv run pytest tests/ -k "aspect"`)
- [x] `tests/test_document_aspects_store.py` 23/23 pass (pre-migration schema compat)
- [x] `tests/test_aspect_extraction_queue.py` + `test_aspect_worker.py` 41/41 pass

## Decisions

- **ATTACH vs Python-side JOIN**: used SQL `ATTACH DATABASE` for the catalog cross-DB JOIN (faster, avoids loading catalog into Python memory)
- **High-volume orphan fail-loud**: threshold = 10 rows (per RDR-108 D3 spec option b); migration lists the unmapped collections + row counts in the error message
- **mark_done backward compat**: positional `(collection, source_path)` signature retained; `doc_id=` added as keyword-only kwarg; both forms route to the right DELETE
- **Dedup strategy**: when two old rows collapse to same doc_id, keep latest `extracted_at` (aspects) / `enqueued_at` (queue)
- **apply_pending wrappers**: two thin wrapper functions derive catalog path from `PRAGMA database_list` so standard `fn(conn)` migration signature is preserved

## Closes

Closes nexus-je0b