### PR TITLE
feat(catalog): rename_collection cascades to aspect denorm caches (nexus-gp20)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -600,3 +600,4 @@
 {"id":"int-348db4e0","kind":"field_change","created_at":"2026-05-09T08:47:44.544444Z","actor":"Hellblazer","issue_id":"nexus-mydi","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-76e4402b","kind":"field_change","created_at":"2026-05-09T09:03:47.130762Z","actor":"Hellblazer","issue_id":"nexus-he24","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-f803cb4f","kind":"field_change","created_at":"2026-05-09T09:03:47.479701Z","actor":"Hellblazer","issue_id":"nexus-j43k","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-97397f5c","kind":"field_change","created_at":"2026-05-09T09:36:24.822195Z","actor":"Hellblazer","issue_id":"nexus-je0b","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -216,6 +216,8 @@ def rename_collection_data_plane(
         "tax_assignments": 0,
         "tax_meta": 0,
         "chash": 0,
+        "aspects": 0,
+        "aspect_queue": 0,
         "catalog_docs": 0,
     }
 
@@ -229,6 +231,13 @@ def rename_collection_data_plane(
             counts["tax_assignments"] = tax.get("assignments", 0)
             counts["tax_meta"] = tax.get("meta", 0)
             counts["chash"] = t2db.chash_index.rename_collection(old=old, new=new)
+            # nexus-gp20 / RDR-108 Phase 1d: cascade to aspect denorm caches.
+            counts["aspects"] = t2db.document_aspects.rename_collection(
+                old=old, new=new
+            )
+            counts["aspect_queue"] = t2db.aspect_queue.rename_collection(
+                old=old, new=new
+            )
     except Exception as exc:
         on_warn(f"warn: T3 rename succeeded but T2 cascade failed: {exc}")
 

--- a/src/nexus/db/t2/aspect_extraction_queue.py
+++ b/src/nexus/db/t2/aspect_extraction_queue.py
@@ -511,3 +511,26 @@ class AspectExtractionQueue:
             )
             for c, sp, ch, co, rc in rows
         ]
+
+    def rename_collection(self, *, old: str, new: str) -> int:
+        """Re-point every row's denorm ``collection`` cache from ``old`` to ``new``.
+
+        nexus-gp20 / RDR-108 Phase 1d: ``collection`` is a denorm cache.
+        When the queue table uses the legacy ``PRIMARY KEY (collection,
+        source_path)`` schema, this UPDATE is the authoritative re-keying
+        for the PK itself (safe because ``source_path`` values within a
+        renamed collection remain unique).  When the PK has been migrated
+        to ``doc_id``, only the denorm cache shifts.
+
+        Returns row count updated (0 when no rows match — safe no-op).
+        Idempotent: a second call with the same ``old`` name returns 0
+        without error.
+        """
+        with self._lock:
+            cur = self.conn.execute(
+                "UPDATE aspect_extraction_queue "
+                "SET collection = ? WHERE collection = ?",
+                (new, old),
+            )
+            self.conn.commit()
+            return cur.rowcount

--- a/src/nexus/db/t2/document_aspects.py
+++ b/src/nexus/db/t2/document_aspects.py
@@ -353,6 +353,27 @@ class DocumentAspects:
             self.conn.commit()
             return cur.rowcount
 
+    def rename_collection(self, *, old: str, new: str) -> int:
+        """Re-point every row's denorm ``collection`` cache from ``old`` to ``new``.
+
+        nexus-gp20 / RDR-108 Phase 1d: ``collection`` is a denorm cache
+        column (the primary key is ``doc_id`` post-migration, or
+        ``(collection, source_path)`` on legacy tables). Updating the
+        cache column does NOT affect the primary key either way — no row
+        identity changes, no row recreation.
+
+        Returns the count of rows updated (0 when no rows match — safe
+        no-op). Idempotent: a second call with the same ``old`` name
+        (now no rows match) returns 0 without error.
+        """
+        with self._lock:
+            cur = self.conn.execute(
+                "UPDATE document_aspects SET collection = ? WHERE collection = ?",
+                (new, old),
+            )
+            self.conn.commit()
+            return cur.rowcount
+
     def list_by_extractor_version(
         self,
         extractor_name: str,

--- a/tests/test_collection_rename.py
+++ b/tests/test_collection_rename.py
@@ -2,13 +2,15 @@
 """nexus-1ccq — `nx collection rename` + domain-store cascade coverage.
 
 ChromaDB Cloud's ``collection.modify(name=...)`` is an O(1) metadata-only
-rename. The CLI wraps it and cascades the new name through the three T2
-surfaces that store a collection string:
+rename. The CLI wraps it and cascades the new name through the T2 surfaces
+that store a collection string:
 
   * ``chash_index.physical_collection``
   * ``topics.collection`` / ``topic_assignments.source_collection`` /
     ``taxonomy_meta.collection``
   * Catalog documents' ``physical_collection`` (JSONL + SQLite cache).
+  * ``document_aspects.collection`` (denorm cache, nexus-gp20)
+  * ``aspect_extraction_queue.collection`` (denorm cache, nexus-gp20)
 
 The cascade is fail-open after the T3 rename lands — T2/catalog errors
 log but do not abort, mirroring the delete-cascade contract.
@@ -446,3 +448,276 @@ class TestRenameCascadeFailureModes:
         fake.rename_collection.assert_called_once_with("code__old", "code__new")
         assert "catalog cascade failed" in result.output
         assert "simulated catalog lock contention" in result.output
+
+
+# ── DocumentAspects.rename_collection (nexus-gp20) ─────────────────────────
+
+
+class TestDocumentAspectsRename:
+    """RDR-108 Phase 1d: ``document_aspects.collection`` is a denorm cache;
+    rename_collection keeps it in sync with the T3 collection rename."""
+
+    def _seed(self, tmp_path: Path):
+        from nexus.db.t2.document_aspects import DocumentAspects, AspectRecord
+
+        store = DocumentAspects(tmp_path / "aspects.db")
+        # Insert rows directly via SQL to avoid the upsert's schema-detection
+        # gate (pre-migration schema: PK is (collection, source_path)).
+        store.conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, problem_formulation, proposed_method, "
+            " experimental_datasets, experimental_baselines, experimental_results, "
+            " extras, confidence, extracted_at, model_version, extractor_name) "
+            "VALUES (?, ?, NULL, NULL, '[]', '[]', NULL, '{}', NULL, "
+            "        '2026-05-09T00:00:00Z', 'v1', 'test_extractor')",
+            ("code__old", "a.py"),
+        )
+        store.conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, problem_formulation, proposed_method, "
+            " experimental_datasets, experimental_baselines, experimental_results, "
+            " extras, confidence, extracted_at, model_version, extractor_name) "
+            "VALUES (?, ?, NULL, NULL, '[]', '[]', NULL, '{}', NULL, "
+            "        '2026-05-09T00:00:00Z', 'v1', 'test_extractor')",
+            ("code__old", "b.py"),
+        )
+        store.conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, problem_formulation, proposed_method, "
+            " experimental_datasets, experimental_baselines, experimental_results, "
+            " extras, confidence, extracted_at, model_version, extractor_name) "
+            "VALUES (?, ?, NULL, NULL, '[]', '[]', NULL, '{}', NULL, "
+            "        '2026-05-09T00:00:00Z', 'v1', 'test_extractor')",
+            ("code__stays", "c.py"),
+        )
+        store.conn.commit()
+        return store
+
+    def test_updates_matching_rows(self, tmp_path: Path) -> None:
+        store = self._seed(tmp_path)
+        count = store.rename_collection(old="code__old", new="code__new")
+        assert count == 2
+
+        old_rows = store.conn.execute(
+            "SELECT COUNT(*) FROM document_aspects WHERE collection = ?",
+            ("code__old",),
+        ).fetchone()[0]
+        new_rows = store.conn.execute(
+            "SELECT COUNT(*) FROM document_aspects WHERE collection = ?",
+            ("code__new",),
+        ).fetchone()[0]
+        stays_rows = store.conn.execute(
+            "SELECT COUNT(*) FROM document_aspects WHERE collection = ?",
+            ("code__stays",),
+        ).fetchone()[0]
+        assert (old_rows, new_rows, stays_rows) == (0, 2, 1)
+
+    def test_source_path_untouched(self, tmp_path: Path) -> None:
+        """source_path denorm cache must be byte-identical pre/post rename."""
+        store = self._seed(tmp_path)
+        paths_before = set(
+            r[0] for r in store.conn.execute(
+                "SELECT source_path FROM document_aspects ORDER BY source_path"
+            ).fetchall()
+        )
+        store.rename_collection(old="code__old", new="code__new")
+        paths_after = set(
+            r[0] for r in store.conn.execute(
+                "SELECT source_path FROM document_aspects ORDER BY source_path"
+            ).fetchall()
+        )
+        assert paths_before == paths_after
+
+    def test_no_rows_returns_zero(self, tmp_path: Path) -> None:
+        from nexus.db.t2.document_aspects import DocumentAspects
+
+        store = DocumentAspects(tmp_path / "aspects.db")
+        assert store.rename_collection(old="docs__ghost", new="docs__phantom") == 0
+
+    def test_idempotent_second_rename(self, tmp_path: Path) -> None:
+        """Second call with old name that no longer has rows is safe no-op."""
+        store = self._seed(tmp_path)
+        store.rename_collection(old="code__old", new="code__new")
+        # Second rename of same old name: no rows match → zero, no error.
+        count = store.rename_collection(old="code__old", new="code__new")
+        assert count == 0
+
+    def test_only_matching_collection_updated(self, tmp_path: Path) -> None:
+        """Rows for 'code__stays' must not be touched."""
+        store = self._seed(tmp_path)
+        store.rename_collection(old="code__old", new="code__new")
+        stays = store.conn.execute(
+            "SELECT collection FROM document_aspects WHERE source_path = ?",
+            ("c.py",),
+        ).fetchone()[0]
+        assert stays == "code__stays"
+
+
+# ── AspectExtractionQueue.rename_collection (nexus-gp20) ───────────────────
+
+
+class TestAspectExtractionQueueRename:
+    """RDR-108 Phase 1d: ``aspect_extraction_queue.collection`` is a denorm
+    cache; rename_collection keeps it in sync."""
+
+    def _seed(self, tmp_path: Path):
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        queue = AspectExtractionQueue(tmp_path / "queue.db")
+        queue.enqueue("code__old", "a.py", doc_id="d1")
+        queue.enqueue("code__old", "b.py", doc_id="d2")
+        queue.enqueue("code__stays", "c.py", doc_id="d3")
+        return queue
+
+    def test_updates_matching_rows(self, tmp_path: Path) -> None:
+        queue = self._seed(tmp_path)
+        count = queue.rename_collection(old="code__old", new="code__new")
+        assert count == 2
+
+        old_rows = queue.conn.execute(
+            "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+            ("code__old",),
+        ).fetchone()[0]
+        new_rows = queue.conn.execute(
+            "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+            ("code__new",),
+        ).fetchone()[0]
+        stays_rows = queue.conn.execute(
+            "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+            ("code__stays",),
+        ).fetchone()[0]
+        assert (old_rows, new_rows, stays_rows) == (0, 2, 1)
+
+    def test_source_path_and_doc_id_untouched(self, tmp_path: Path) -> None:
+        """source_path and doc_id must be byte-identical pre/post rename."""
+        queue = self._seed(tmp_path)
+        rows_before = {
+            r[0]: (r[1], r[2])  # source_path -> (doc_id, collection)
+            for r in queue.conn.execute(
+                "SELECT source_path, doc_id, collection "
+                "FROM aspect_extraction_queue ORDER BY source_path"
+            ).fetchall()
+        }
+        queue.rename_collection(old="code__old", new="code__new")
+        rows_after = {
+            r[0]: (r[1], r[2])
+            for r in queue.conn.execute(
+                "SELECT source_path, doc_id, collection "
+                "FROM aspect_extraction_queue ORDER BY source_path"
+            ).fetchall()
+        }
+        # source_path and doc_id unchanged
+        for sp in rows_before:
+            assert rows_before[sp][0] == rows_after[sp][0], f"doc_id changed for {sp}"
+
+    def test_no_rows_returns_zero(self, tmp_path: Path) -> None:
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        queue = AspectExtractionQueue(tmp_path / "queue.db")
+        assert queue.rename_collection(old="docs__ghost", new="docs__phantom") == 0
+
+    def test_idempotent_second_rename(self, tmp_path: Path) -> None:
+        queue = self._seed(tmp_path)
+        queue.rename_collection(old="code__old", new="code__new")
+        count = queue.rename_collection(old="code__old", new="code__new")
+        assert count == 0
+
+
+# ── Aspect cascade wired into rename_collection_data_plane (nexus-gp20) ────
+
+
+class TestAspectCascadeIntegration:
+    """End-to-end: rename_collection_data_plane must update both aspect
+    denorm tables in the same T2Database context as chash_index."""
+
+    def test_both_aspect_tables_updated_by_data_plane(
+        self, tmp_path: Path, env_creds,
+    ) -> None:
+        from nexus.commands.collection import rename_collection_data_plane
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+
+        # Seed T2 with rows in both aspect tables.
+        with T2Database(db_path) as t2db:
+            t2db.chash_index.upsert(
+                chash="aa", collection="code__old", chunk_chroma_id="d1"
+            )
+            t2db.document_aspects.conn.execute(
+                "INSERT INTO document_aspects "
+                "(collection, source_path, problem_formulation, proposed_method, "
+                " experimental_datasets, experimental_baselines, "
+                " experimental_results, extras, confidence, extracted_at, "
+                " model_version, extractor_name) "
+                "VALUES (?, ?, NULL, NULL, '[]', '[]', NULL, '{}', NULL, "
+                "        '2026-05-09T00:00:00Z', 'v1', 'test')",
+                ("code__old", "a.py"),
+            )
+            t2db.document_aspects.conn.commit()
+            t2db.aspect_queue.enqueue("code__old", "b.py", doc_id="d2")
+
+        fake = MagicMock()
+        fake.collection_exists = MagicMock(side_effect=lambda n: n == "code__old")
+        fake.rename_collection = MagicMock()
+
+        with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.commands._helpers.default_db_path", return_value=db_path), \
+             patch("nexus.config.catalog_path", return_value=cat_dir):
+            counts = rename_collection_data_plane("code__old", "code__new")
+
+        assert counts.get("aspects", 0) >= 0  # key present (even if 0)
+        assert counts.get("aspect_queue", 0) >= 0
+
+        with T2Database(db_path) as verify:
+            da_old = verify.document_aspects.conn.execute(
+                "SELECT COUNT(*) FROM document_aspects WHERE collection = ?",
+                ("code__old",),
+            ).fetchone()[0]
+            da_new = verify.document_aspects.conn.execute(
+                "SELECT COUNT(*) FROM document_aspects WHERE collection = ?",
+                ("code__new",),
+            ).fetchone()[0]
+            aq_old = verify.aspect_queue.conn.execute(
+                "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+                ("code__old",),
+            ).fetchone()[0]
+            aq_new = verify.aspect_queue.conn.execute(
+                "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+                ("code__new",),
+            ).fetchone()[0]
+
+        assert da_old == 0 and da_new == 1
+        assert aq_old == 0 and aq_new == 1
+
+    def test_no_collateral_writes_to_chash(self, tmp_path: Path) -> None:
+        """Aspect cascade must not alter chash_index rows."""
+        from nexus.db.t2.document_aspects import DocumentAspects
+        from nexus.db.t2.chash_index import ChashIndex
+
+        aspects = DocumentAspects(tmp_path / "aspects.db")
+        aspects.conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, problem_formulation, proposed_method, "
+            " experimental_datasets, experimental_baselines, "
+            " experimental_results, extras, confidence, extracted_at, "
+            " model_version, extractor_name) "
+            "VALUES (?, ?, NULL, NULL, '[]', '[]', NULL, '{}', NULL, "
+            "        '2026-05-09T00:00:00Z', 'v1', 'test')",
+            ("code__old", "a.py"),
+        )
+        aspects.conn.commit()
+
+        chash = ChashIndex(tmp_path / "chash.db")
+        chash.upsert(chash="aa", collection="code__old", chunk_chroma_id="d1")
+
+        # rename only aspects
+        aspects.rename_collection(old="code__old", new="code__new")
+
+        # chash_index untouched
+        old_chash = chash.conn.execute(
+            "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+            ("code__old",),
+        ).fetchone()[0]
+        assert old_chash == 1  # still there — chash cascade not triggered here


### PR DESCRIPTION
## Summary

- Adds `DocumentAspects.rename_collection(old, new)` that UPDATEs the `collection` denorm cache column on `document_aspects`
- Adds `AspectExtractionQueue.rename_collection(old, new)` that UPDATEs the `collection` denorm cache column on `aspect_extraction_queue`
- Wires both into `rename_collection_data_plane` alongside the existing `chash_index` and taxonomy cascades; returns `aspects` and `aspect_queue` counts in the result dict

RDR-108 Phase 1d. Pattern follows `ChashIndex.rename_collection` at `src/nexus/db/t2/chash_index.py:178`.

`Catalog.rename_collection` already existed (delegates to `_WriteOps.rename_collection`) and is unchanged; the aspect cascade runs in the CLI data-plane function which is the execution path for all renames.

## Test plan

- [x] `TestDocumentAspectsRename`: 5 tests covering cache update, source_path byte-identity, no-op, idempotent re-rename, no collateral rows
- [x] `TestAspectExtractionQueueRename`: 4 tests covering same properties for queue table
- [x] `TestAspectCascadeIntegration`: end-to-end via `rename_collection_data_plane` + no collateral writes to chash_index
- [x] 27/27 `tests/test_collection_rename.py` pass (all pre-existing + 11 new)
- [x] 1075 catalog tests pass, 375 aspect tests pass

## Closes

Closes nexus-gp20