### PR TITLE
fix(catalog,aspects): cascade atomicity + collision defense + telemetry/hook_failures (nexus-nhyh)

### DIFF
--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -180,23 +180,39 @@ def rename_collection_data_plane(
     catalog=None,
     on_warn: Callable[[str], None] | None = None,
 ) -> dict[str, int]:
-    """Rename a collection across T3 + T2 + catalog cascades.
+    """Rename a collection across T2 + T3 + catalog cascades.
 
     Extracted from ``rename_cmd`` so RDR-101 Phase 6's
     ``nx catalog rename-collection`` can reuse the data-plane logic
     without re-implementing the cascade. Pure function shape: takes
     explicit T3 / Catalog handles, returns counts, raises only on the
-    hard validation failures (collection missing, already exists). T2
-    + catalog cascades are best-effort (T3 is already renamed by the
-    time they run, and rolling back a rename is nontrivial).
+    hard validation failures (collection missing, already exists).
 
-    Returns a dict with keys ``tax_topics``, ``tax_assignments``,
-    ``tax_meta``, ``chash``, ``catalog_docs`` so callers can render
+    Ordering (SIG-8 / nexus-nhyh): T2 cascade runs FIRST, T3 rename
+    runs LAST. Rationale: T2 SQL UPDATEs are reversible (operator can
+    run the inverse UPDATE or re-run rename); ChromaDB collection rename
+    is irrevocable in a single call. Running T2 first minimises
+    irrecoverable drift: if T3 fails after T2 succeeds the operator can
+    reverse T2 manually; if T2 fails no T3 rename was attempted so the
+    system is still consistent.
+
+    T2 cascade failure (nexus-nhyh / CG-1): raises ``ClickException``
+    with a non-zero exit code and an actionable error message. T2
+    cascade failures are NOT fail-open -- an incomplete T2 cascade
+    leaves collection references orphaned across six indexed columns.
+    The operator must see the failure.
+
+    Catalog cascade failure: fail-open (warn + continue). The catalog is
+    a derived view; a failed catalog cascade can be repaired via
+    ``nx catalog rebuild`` without touching T3 or T2.
+
+    Returns a dict with counts per cascade table so callers can render
     their own summaries.
 
-    ``on_warn`` is invoked with a string message when a cascade
-    fails open. The CLI default routes it to ``click.echo(...,
-    err=True)``; callers in non-CLI contexts can pass their own.
+    ``on_warn`` is invoked with a string message when the catalog
+    cascade fails open. The CLI default routes it to
+    ``click.echo(..., err=True)``; callers in non-CLI contexts can
+    pass their own.
     """
     if on_warn is None:
         on_warn = lambda msg: click.echo(msg, err=True)  # noqa: E731
@@ -209,8 +225,6 @@ def rename_collection_data_plane(
     if t3_db.collection_exists(new):
         raise click.ClickException(f"collection already exists: {new!r}")
 
-    t3_db.rename_collection(old, new)
-
     counts = {
         "tax_topics": 0,
         "tax_assignments": 0,
@@ -218,29 +232,40 @@ def rename_collection_data_plane(
         "chash": 0,
         "aspects": 0,
         "aspect_queue": 0,
+        "search_telemetry": 0,
+        "hook_failures": 0,
         "catalog_docs": 0,
     }
 
+    # ── T2 cascade FIRST (reversible) ────────────────────────────────────────
+    # Failure here raises ClickException -- T3 rename has not yet run so the
+    # system remains fully consistent. Operator can diagnose and retry.
+    from nexus.commands._helpers import default_db_path  # noqa: PLC0415
+    from nexus.db.t2 import T2Database  # noqa: PLC0415
+
     try:
-        from nexus.commands._helpers import default_db_path  # noqa: PLC0415
-        from nexus.db.t2 import T2Database  # noqa: PLC0415
-
         with T2Database(default_db_path()) as t2db:
-            tax = t2db.taxonomy.rename_collection(old, new)
-            counts["tax_topics"] = tax.get("topics", 0)
-            counts["tax_assignments"] = tax.get("assignments", 0)
-            counts["tax_meta"] = tax.get("meta", 0)
-            counts["chash"] = t2db.chash_index.rename_collection(old=old, new=new)
-            # nexus-gp20 / RDR-108 Phase 1d: cascade to aspect denorm caches.
-            counts["aspects"] = t2db.document_aspects.rename_collection(
-                old=old, new=new
-            )
-            counts["aspect_queue"] = t2db.aspect_queue.rename_collection(
-                old=old, new=new
-            )
+            cascade = t2db.rename_collection_cascade(old=old, new=new)
+            counts["tax_topics"] = cascade.get("tax_topics", 0)
+            counts["tax_assignments"] = cascade.get("tax_assignments", 0)
+            counts["tax_meta"] = cascade.get("tax_meta", 0)
+            counts["chash"] = cascade.get("chash", 0)
+            counts["aspects"] = cascade.get("aspects", 0)
+            counts["aspect_queue"] = cascade.get("aspect_queue", 0)
+            counts["search_telemetry"] = cascade.get("search_telemetry", 0)
+            counts["hook_failures"] = cascade.get("hook_failures", 0)
     except Exception as exc:
-        on_warn(f"warn: T3 rename succeeded but T2 cascade failed: {exc}")
+        raise click.ClickException(
+            f"T2 cascade failed before T3 rename -- collection {old!r} is "
+            f"unchanged. Fix the error and retry:\n  {exc}"
+        ) from exc
 
+    # ── T3 rename LAST (irrevocable) ─────────────────────────────────────────
+    # T2 is already committed. If T3 fails here the operator can reverse T2
+    # by running the inverse rename (``nx collection rename new old``).
+    t3_db.rename_collection(old, new)
+
+    # ── Catalog cascade (fail-open) ───────────────────────────────────────────
     try:
         if catalog is None:
             from nexus.catalog.catalog import Catalog  # noqa: PLC0415
@@ -249,7 +274,7 @@ def rename_collection_data_plane(
             catalog = Catalog(cat_path, cat_path / ".catalog.db")
         counts["catalog_docs"] = catalog.rename_collection(old, new)
     except Exception as exc:
-        on_warn(f"warn: T3 rename succeeded but catalog cascade failed: {exc}")
+        on_warn(f"warn: T2+T3 rename succeeded but catalog cascade failed: {exc}")
 
     return counts
 

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -162,6 +162,8 @@ class T2Database:
         from nexus.db.t2.telemetry import Telemetry
 
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Store path for cross-domain operations (e.g. rename_collection_cascade).
+        self._path: Path = path
 
         # ── Transient connection: run pending migrations (RDR-076) ────
         from nexus.db.migrations import _upgrade_done, _upgrade_lock, apply_pending
@@ -242,6 +244,166 @@ class T2Database:
         self.taxonomy.close()
         self.plans.close()
         self.memory.close()
+
+    # ── Atomic cascade rename (nexus-nhyh / K4) ───────────────────────────────
+
+    def rename_collection_cascade(
+        self,
+        *,
+        old: str,
+        new: str,
+        _conn: "sqlite3.Connection | None" = None,
+    ) -> dict[str, int]:
+        """Rename a collection atomically across all T2 collection tables.
+
+        nexus-nhyh / K4: runs all UPDATEs inside a single SQLite
+        transaction on a dedicated shared connection, so no partial-update
+        window exists. If any UPDATE raises, the entire transaction is
+        rolled back before the exception propagates.
+
+        Tables updated atomically:
+          - ``chash_index.physical_collection``
+          - ``document_aspects.collection`` (with collision-defense DELETE)
+          - ``aspect_extraction_queue.collection`` (with collision-defense DELETE)
+          - ``topics.collection`` / ``topic_assignments.source_collection`` /
+            ``taxonomy_meta.collection``
+          - ``search_telemetry.collection``
+          - ``hook_failures.collection`` (if table exists)
+
+        Returns a dict with counts per table. Raises on any failure --
+        the SQLite transaction is rolled back automatically.
+
+        Callers (``rename_collection_data_plane``) catch and re-raise as
+        ClickException with a non-zero exit code.
+
+        ``_conn`` is a private test-seam parameter. Production callers
+        omit it; the method opens a fresh dedicated connection. Tests
+        pass a wrapper object to inject mid-cascade failures.
+        """
+        counts: dict[str, int] = {
+            "chash": 0,
+            "aspects": 0,
+            "aspect_queue": 0,
+            "tax_topics": 0,
+            "tax_assignments": 0,
+            "tax_meta": 0,
+            "search_telemetry": 0,
+            "hook_failures": 0,
+        }
+
+        # Open a dedicated connection to the shared database file. All
+        # UPDATEs run in one BEGIN...COMMIT -- SQLite rolls back the
+        # entire transaction automatically if we close without committing.
+        owned = _conn is None
+        conn: sqlite3.Connection
+        if owned:
+            conn = sqlite3.connect(str(self._path), check_same_thread=False)
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute("PRAGMA journal_mode=WAL")
+        else:
+            conn = _conn  # type: ignore[assignment]
+
+        try:
+            conn.execute("BEGIN")
+
+            # chash_index (with collision defense)
+            conn.execute(
+                "DELETE FROM chash_index "
+                "WHERE physical_collection = ? "
+                "  AND chash IN ("
+                "    SELECT chash FROM chash_index WHERE physical_collection = ?"
+                "  )",
+                (new, old),
+            )
+            cur = conn.execute(
+                "UPDATE chash_index SET physical_collection = ? "
+                "WHERE physical_collection = ?",
+                (new, old),
+            )
+            counts["chash"] = cur.rowcount
+
+            # document_aspects (with collision defense)
+            conn.execute(
+                "DELETE FROM document_aspects "
+                "WHERE collection = ? "
+                "  AND source_path IN ("
+                "    SELECT source_path FROM document_aspects WHERE collection = ?"
+                "  )",
+                (new, old),
+            )
+            cur = conn.execute(
+                "UPDATE document_aspects SET collection = ? WHERE collection = ?",
+                (new, old),
+            )
+            counts["aspects"] = cur.rowcount
+
+            # aspect_extraction_queue (with collision defense)
+            conn.execute(
+                "DELETE FROM aspect_extraction_queue "
+                "WHERE collection = ? "
+                "  AND source_path IN ("
+                "    SELECT source_path FROM aspect_extraction_queue"
+                "    WHERE collection = ?"
+                "  )",
+                (new, old),
+            )
+            cur = conn.execute(
+                "UPDATE aspect_extraction_queue "
+                "SET collection = ? WHERE collection = ?",
+                (new, old),
+            )
+            counts["aspect_queue"] = cur.rowcount
+
+            # taxonomy (three sub-tables)
+            cur = conn.execute(
+                "UPDATE topics SET collection = ? WHERE collection = ?",
+                (new, old),
+            )
+            counts["tax_topics"] = cur.rowcount
+            cur = conn.execute(
+                "UPDATE topic_assignments SET source_collection = ? "
+                "WHERE source_collection = ?",
+                (new, old),
+            )
+            counts["tax_assignments"] = cur.rowcount
+            cur = conn.execute(
+                "UPDATE taxonomy_meta SET collection = ? WHERE collection = ?",
+                (new, old),
+            )
+            counts["tax_meta"] = cur.rowcount
+
+            # search_telemetry
+            cur = conn.execute(
+                "UPDATE search_telemetry SET collection = ? WHERE collection = ?",
+                (new, old),
+            )
+            counts["search_telemetry"] = cur.rowcount
+
+            # hook_failures (optional table -- created by migration)
+            table_exists = conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='hook_failures'"
+            ).fetchone()[0]
+            if table_exists:
+                cur = conn.execute(
+                    "UPDATE hook_failures SET collection = ? WHERE collection = ?",
+                    (new, old),
+                )
+                counts["hook_failures"] = cur.rowcount
+
+            conn.commit()
+
+        except Exception:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            if owned:
+                conn.close()
+
+        return counts
 
     # ── Memory delegation (RDR-063 Phase 1 step 2) ────────────────────────────
     # Every memory-domain method delegates to self.memory. Signatures and

--- a/src/nexus/db/t2/aspect_extraction_queue.py
+++ b/src/nexus/db/t2/aspect_extraction_queue.py
@@ -516,17 +516,33 @@ class AspectExtractionQueue:
         """Re-point every row's denorm ``collection`` cache from ``old`` to ``new``.
 
         nexus-gp20 / RDR-108 Phase 1d: ``collection`` is a denorm cache.
-        When the queue table uses the legacy ``PRIMARY KEY (collection,
-        source_path)`` schema, this UPDATE is the authoritative re-keying
-        for the PK itself (safe because ``source_path`` values within a
-        renamed collection remain unique).  When the PK has been migrated
-        to ``doc_id``, only the denorm cache shifts.
+        On migrated tables (PK=doc_id, post-RDR-108 Phase 1c), this
+        updates only the denorm cache; PK is unaffected. On legacy tables
+        (PK=(collection, source_path)), this also re-keys the PK, which
+        is safe because source_path values are unique within a collection.
 
-        Returns row count updated (0 when no rows match — safe no-op).
+        Collision defense (nexus-nhyh / K4): on legacy-PK tables, a
+        pre-existing ``(new, source_path)`` row would cause a UNIQUE
+        constraint violation on UPDATE. Mirror chash_index's strategy:
+        DELETE conflicting new-side rows first, then UPDATE. The rename
+        is an atomic re-home, so dropping a stale new-side row is safe.
+
+        Returns row count updated (0 when no rows match -- safe no-op).
         Idempotent: a second call with the same ``old`` name returns 0
         without error.
         """
         with self._lock:
+            # Drop any pre-existing new-collection rows that would collide
+            # with the rename (same source_path). Mirrors ChashIndex pattern.
+            self.conn.execute(
+                "DELETE FROM aspect_extraction_queue "
+                "WHERE collection = ? "
+                "  AND source_path IN ("
+                "    SELECT source_path FROM aspect_extraction_queue"
+                "    WHERE collection = ?"
+                "  )",
+                (new, old),
+            )
             cur = self.conn.execute(
                 "UPDATE aspect_extraction_queue "
                 "SET collection = ? WHERE collection = ?",

--- a/src/nexus/db/t2/document_aspects.py
+++ b/src/nexus/db/t2/document_aspects.py
@@ -359,14 +359,33 @@ class DocumentAspects:
         nexus-gp20 / RDR-108 Phase 1d: ``collection`` is a denorm cache
         column (the primary key is ``doc_id`` post-migration, or
         ``(collection, source_path)`` on legacy tables). Updating the
-        cache column does NOT affect the primary key either way — no row
+        cache column does NOT affect the primary key either way -- no row
         identity changes, no row recreation.
 
-        Returns the count of rows updated (0 when no rows match — safe
+        Collision defense (nexus-nhyh / K4): on legacy-PK tables where
+        the PK is ``(collection, source_path)``, a pre-existing
+        ``(new, source_path)`` row would collide with the UPDATE.
+        Mirror chash_index's strategy: DELETE any conflicting new-side
+        rows whose ``source_path`` values overlap with old-side rows,
+        then UPDATE. This is conservative but correct: the rename is an
+        atomic re-home, so preserving a stale ``new``-side row would
+        silently drop the ``old``-side data.
+
+        Returns the count of rows updated (0 when no rows match -- safe
         no-op). Idempotent: a second call with the same ``old`` name
         (now no rows match) returns 0 without error.
         """
         with self._lock:
+            # Drop any pre-existing new-collection rows that would collide
+            # with the rename (same source_path). Mirrors ChashIndex pattern.
+            self.conn.execute(
+                "DELETE FROM document_aspects "
+                "WHERE collection = ? "
+                "  AND source_path IN ("
+                "    SELECT source_path FROM document_aspects WHERE collection = ?"
+                "  )",
+                (new, old),
+            )
             cur = self.conn.execute(
                 "UPDATE document_aspects SET collection = ? WHERE collection = ?",
                 (new, old),

--- a/src/nexus/db/t2/telemetry.py
+++ b/src/nexus/db/t2/telemetry.py
@@ -346,3 +346,42 @@ class Telemetry:
             )
             self.conn.commit()
         return cur.rowcount
+
+    def rename_collection(self, *, old: str, new: str) -> dict[str, int]:
+        """Re-point ``collection`` columns from ``old`` to ``new`` in all
+        telemetry tables that carry a collection name.
+
+        nexus-nhyh / K9: ``search_telemetry.collection`` and
+        ``hook_failures.collection`` (if the table exists) are both
+        indexed collection-scoped lookup columns. A collection rename
+        that skips these tables leaves telemetry orphaned under the old
+        name, making ``nx collection health`` and ``nx doctor hooks``
+        query the wrong bucket.
+
+        Returns a dict with keys ``search_telemetry`` and
+        ``hook_failures`` (each value is the row count updated). The
+        ``hook_failures`` key is 0 and not an error when the table does
+        not yet exist (pre-migration databases).
+        """
+        counts: dict[str, int] = {"search_telemetry": 0, "hook_failures": 0}
+        with self._lock:
+            cur = self.conn.execute(
+                "UPDATE search_telemetry SET collection = ? WHERE collection = ?",
+                (new, old),
+            )
+            counts["search_telemetry"] = cur.rowcount
+
+            # hook_failures may not exist on pre-migration databases.
+            table_exists = self.conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='hook_failures'"
+            ).fetchone()[0]
+            if table_exists:
+                cur = self.conn.execute(
+                    "UPDATE hook_failures SET collection = ? WHERE collection = ?",
+                    (new, old),
+                )
+                counts["hook_failures"] = cur.rowcount
+
+            self.conn.commit()
+        return counts

--- a/tests/test_collection_rename.py
+++ b/tests/test_collection_rename.py
@@ -361,30 +361,32 @@ class TestRenameCLI:
         fake.rename_collection.assert_called_once_with("code__foo", "docs__foo")
 
 
-# ── Partial-cascade failure mode (review finding — Reviewer B/C2) ──────────
+# ── Partial-cascade failure mode (review finding + nexus-nhyh / CG-1) ────────
 
 
 class TestRenameCascadeFailureModes:
-    """The rename cascade is fail-open by design: T3 renames first, then T2
-    and catalog are attempted independently. A T2 failure must NOT roll
-    back T3 (that would require a second modify(name=old) round-trip and
-    still isn't atomic). Instead, the CLI must emit a ``warn:`` line on
-    stderr naming which cascade failed, so the operator knows the divergent
-    state is there and can retry the cascade manually.
+    """T2 cascade failures must now exit non-zero (nexus-nhyh / CG-1).
 
-    Before nexus-1ccq review, this contract was documented in the code
-    comment but not pinned by any test. Now it is."""
+    Old behavior (nexus-1ccq): T3 renamed first, T2 failures were fail-open
+    (warn + exit 0). This left the system in an inconsistent state with no
+    operator-facing signal that action was required.
 
-    def test_t2_cascade_failure_prints_warn_and_continues(
+    New behavior (nexus-nhyh SIG-8 + CG-1):
+    - T2 cascade runs FIRST (T2-first ordering). On failure, T3 rename has
+      NOT yet run, so the system is still fully consistent.
+    - T2 failure raises ClickException (exit non-zero) with an actionable
+      message. Operator must see the failure.
+    - Catalog cascade remains fail-open: it is a derived view, and failures
+      can be repaired by ``nx catalog rebuild``.
+    """
+
+    def test_t2_cascade_failure_exits_nonzero_and_aborts_t3(
         self, tmp_path: Path, env_creds,
     ) -> None:
-        """T2 cascade throws → T3 stays renamed, catalog cascade still
-        runs, CLI exits 0 with a stderr warn line naming T2."""
+        """T2 cascade throws → exit non-zero, T3 rename must NOT have fired
+        (T2-first ordering: T3 only runs after T2 succeeds)."""
         from nexus.commands.collection import rename_cmd
 
-        # Do NOT seed a T2 database — T2Database() will still open a fresh
-        # file, so we need to force the cascade to throw. Patch
-        # T2Database to raise on __enter__.
         db_path = tmp_path / "memory.db"
         cat_dir = tmp_path / "catalog"
         cat_dir.mkdir()
@@ -405,19 +407,22 @@ class TestRenameCascadeFailureModes:
              patch("nexus.config.catalog_path", return_value=cat_dir):
             result = runner.invoke(rename_cmd, ["code__old", "code__new"])
 
-        assert result.exit_code == 0, result.output
-        # T3 was renamed (irreversible side effect) before the T2 failure.
-        fake.rename_collection.assert_called_once_with("code__old", "code__new")
-        # Stderr carries the explicit warning so the operator knows the
-        # cascade is partial. CliRunner mixes stderr into .output.
-        assert "T2 cascade failed" in result.output
+        # Must exit non-zero: T2 failure is not fail-open
+        assert result.exit_code != 0, (
+            f"T2 cascade failure must exit non-zero. Got {result.exit_code}. "
+            f"Output: {result.output}"
+        )
+        # T3 must NOT have been called (T2-first ordering: T3 only runs after T2)
+        fake.rename_collection.assert_not_called()
+        # Error message must name the failure and be actionable
+        assert "T2 cascade failed" in result.output or "cascade" in result.output.lower()
         assert "simulated T2 outage" in result.output
 
     def test_catalog_cascade_failure_prints_warn_and_continues(
         self, tmp_path: Path, env_creds,
     ) -> None:
-        """Catalog cascade throws → T3 + T2 stay renamed, CLI still exits
-        0 with a stderr warn line naming the catalog."""
+        """Catalog cascade throws → T2 + T3 stay renamed, CLI still exits
+        0 with a stderr warn line naming the catalog (fail-open)."""
         from nexus.commands.collection import rename_cmd
 
         db_path = tmp_path / "memory.db"
@@ -445,6 +450,7 @@ class TestRenameCascadeFailureModes:
             result = runner.invoke(rename_cmd, ["code__old", "code__new"])
 
         assert result.exit_code == 0, result.output
+        # T3 was renamed (T2 succeeded, T3 ran after)
         fake.rename_collection.assert_called_once_with("code__old", "code__new")
         assert "catalog cascade failed" in result.output
         assert "simulated catalog lock contention" in result.output
@@ -721,3 +727,489 @@ class TestAspectCascadeIntegration:
             ("code__old",),
         ).fetchone()[0]
         assert old_chash == 1  # still there — chash cascade not triggered here
+
+
+# ── K4 atomicity: all T2 cascades in one transaction ───────────────────────
+
+
+class TestCascadeAtomicity:
+    """K4 (nexus-nhyh): T2 cascade must be atomic -- a mid-flight failure
+    must leave ALL T2 tables showing the OLD name (rolled back).
+
+    The implementation uses T2Database.rename_collection_cascade() which
+    runs all UPDATEs inside a single SQLite transaction on a dedicated
+    shared connection.
+    """
+
+    def _seed_all_tables(self, db_path):
+        """Seed rows in all four T2 cascade tables."""
+        from nexus.db.t2 import T2Database
+
+        with T2Database(db_path) as t2db:
+            t2db.chash_index.upsert(
+                chash="aa", collection="code__old", chunk_chroma_id="d1"
+            )
+            t2db.taxonomy.conn.execute(
+                "INSERT INTO topics (label, collection, centroid_hash, doc_count, terms, created_at) "
+                "VALUES (?, ?, ?, ?, ?, '2026-05-09T00:00:00Z')",
+                ("T", "code__old", "h1", 1, "[]"),
+            )
+            t2db.taxonomy.conn.execute(
+                "INSERT INTO taxonomy_meta (collection, last_discover_at) VALUES (?, ?)",
+                ("code__old", "2026-05-09T00:00:00Z"),
+            )
+            t2db.taxonomy.conn.commit()
+            t2db.document_aspects.conn.execute(
+                "INSERT INTO document_aspects "
+                "(collection, source_path, problem_formulation, proposed_method, "
+                " experimental_datasets, experimental_baselines, "
+                " experimental_results, extras, confidence, extracted_at, "
+                " model_version, extractor_name) "
+                "VALUES (?, ?, NULL, NULL, '[]', '[]', NULL, '{}', NULL, "
+                "        '2026-05-09T00:00:00Z', 'v1', 'test')",
+                ("code__old", "a.py"),
+            )
+            t2db.document_aspects.conn.commit()
+            t2db.aspect_queue.enqueue("code__old", "b.py", doc_id="d2")
+
+    def test_mid_cascade_failure_rolls_back_all_tables(
+        self, tmp_path: Path
+    ) -> None:
+        """Inject a failure after the chash UPDATE; ALL tables must still
+        show 'code__old' (transaction rolled back atomically).
+
+        Uses the ``_conn`` test-seam with a wrapper class that intercepts
+        execute calls and raises mid-cascade to test rollback behavior.
+        """
+        import sqlite3 as _sqlite3
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        self._seed_all_tables(db_path)
+
+        class _BombingConnection:
+            """Wraps a real sqlite3.Connection, bombs on document_aspects UPDATE."""
+
+            def __init__(self, real: _sqlite3.Connection) -> None:
+                self._real = real
+
+            def execute(self, sql: str, params=(), **kw):
+                stripped = sql.strip()
+                if "document_aspects" in stripped and stripped.upper().startswith("UPDATE"):
+                    raise RuntimeError("simulated mid-cascade failure")
+                return self._real.execute(sql, params, **kw)
+
+            def rollback(self):
+                return self._real.rollback()
+
+            def commit(self):
+                return self._real.commit()
+
+            def close(self):
+                return self._real.close()
+
+        real_conn = _sqlite3.connect(str(db_path))
+        real_conn.execute("PRAGMA busy_timeout=5000")
+        bomb_conn = _BombingConnection(real_conn)
+
+        with T2Database(db_path) as t2db:
+            with pytest.raises(RuntimeError, match="mid-cascade"):
+                t2db.rename_collection_cascade(
+                    old="code__old", new="code__new", _conn=bomb_conn
+                )
+
+        real_conn.close()
+
+        # After rollback: all tables must show old name
+        with T2Database(db_path) as verify:
+            chash_old = verify.chash_index.conn.execute(
+                "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+                ("code__old",),
+            ).fetchone()[0]
+            da_old = verify.document_aspects.conn.execute(
+                "SELECT COUNT(*) FROM document_aspects WHERE collection = ?",
+                ("code__old",),
+            ).fetchone()[0]
+            aq_old = verify.aspect_queue.conn.execute(
+                "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+                ("code__old",),
+            ).fetchone()[0]
+            tax_old = verify.taxonomy.conn.execute(
+                "SELECT COUNT(*) FROM topics WHERE collection = ?",
+                ("code__old",),
+            ).fetchone()[0]
+
+        assert chash_old == 1, "chash_index must be rolled back"
+        assert da_old == 1, "document_aspects must be rolled back"
+        assert aq_old == 1, "aspect_queue must be rolled back"
+        assert tax_old == 1, "taxonomy must be rolled back"
+
+    def test_successful_cascade_updates_all_four_tables(
+        self, tmp_path: Path
+    ) -> None:
+        """Happy path: rename_collection_cascade updates all tables atomically."""
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        self._seed_all_tables(db_path)
+
+        with T2Database(db_path) as t2db:
+            counts = t2db.rename_collection_cascade(old="code__old", new="code__new")
+
+        assert counts["chash"] == 1
+        assert counts["aspects"] == 1
+        assert counts["aspect_queue"] == 1
+        assert counts["tax_topics"] == 1
+
+        with T2Database(db_path) as verify:
+            chash_new = verify.chash_index.conn.execute(
+                "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+                ("code__new",),
+            ).fetchone()[0]
+            da_new = verify.document_aspects.conn.execute(
+                "SELECT COUNT(*) FROM document_aspects WHERE collection = ?",
+                ("code__new",),
+            ).fetchone()[0]
+            aq_new = verify.aspect_queue.conn.execute(
+                "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+                ("code__new",),
+            ).fetchone()[0]
+            tax_new = verify.taxonomy.conn.execute(
+                "SELECT COUNT(*) FROM topics WHERE collection = ?",
+                ("code__new",),
+            ).fetchone()[0]
+
+        assert chash_new == 1
+        assert da_new == 1
+        assert aq_new == 1
+        assert tax_new == 1
+
+
+# ── K4 collision defense: DocumentAspects and AspectExtractionQueue ─────────
+
+
+class TestDocumentAspectsCollisionDefense:
+    """K4 (nexus-nhyh): DocumentAspects.rename_collection must defend against
+    UNIQUE collisions like ChashIndex does, using pre-DELETE of conflicting
+    new-side rows before UPDATE."""
+
+    def test_pk_collision_new_side_wins(self, tmp_path: Path) -> None:
+        """Pre-existing (new_collection, source_path) row is deleted before
+        UPDATE so UNIQUE constraint is never violated."""
+        from nexus.db.t2.document_aspects import DocumentAspects
+
+        store = DocumentAspects(tmp_path / "aspects.db")
+        store.conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, problem_formulation, proposed_method, "
+            " experimental_datasets, experimental_baselines, "
+            " experimental_results, extras, confidence, extracted_at, "
+            " model_version, extractor_name) "
+            "VALUES (?, ?, NULL, NULL, '[]', '[]', NULL, '{}', NULL, "
+            "        '2026-05-09T00:00:00Z', 'v1', 'test')",
+            ("code__old", "a.py"),
+        )
+        # Collision: (new, same source_path) already exists
+        store.conn.execute(
+            "INSERT INTO document_aspects "
+            "(collection, source_path, problem_formulation, proposed_method, "
+            " experimental_datasets, experimental_baselines, "
+            " experimental_results, extras, confidence, extracted_at, "
+            " model_version, extractor_name) "
+            "VALUES (?, ?, NULL, NULL, '[]', '[]', NULL, '{}', NULL, "
+            "        '2026-05-09T00:00:00Z', 'v1', 'stale')",
+            ("code__new", "a.py"),
+        )
+        store.conn.commit()
+
+        # Must not raise UNIQUE constraint violation
+        count = store.rename_collection(old="code__old", new="code__new")
+        assert count == 1
+
+        rows = store.conn.execute(
+            "SELECT COUNT(*) FROM document_aspects WHERE collection = ?",
+            ("code__new",),
+        ).fetchone()[0]
+        assert rows == 1
+
+        old_rows = store.conn.execute(
+            "SELECT COUNT(*) FROM document_aspects WHERE collection = ?",
+            ("code__old",),
+        ).fetchone()[0]
+        assert old_rows == 0
+
+
+class TestAspectQueueCollisionDefense:
+    """K4 (nexus-nhyh): AspectExtractionQueue.rename_collection must defend
+    against UNIQUE collisions like ChashIndex."""
+
+    def test_pk_collision_new_side_wins(self, tmp_path: Path) -> None:
+        """Pre-existing (new_collection, source_path) row is deleted before
+        UPDATE so UNIQUE constraint is never violated."""
+        from nexus.db.t2.aspect_extraction_queue import AspectExtractionQueue
+
+        queue = AspectExtractionQueue(tmp_path / "queue.db")
+        queue.enqueue("code__old", "a.py", doc_id="d1")
+        queue.enqueue("code__new", "a.py", doc_id="d_stale")  # collision
+
+        # Must not raise
+        count = queue.rename_collection(old="code__old", new="code__new")
+        assert count == 1
+
+        new_rows = queue.conn.execute(
+            "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+            ("code__new",),
+        ).fetchone()[0]
+        assert new_rows == 1
+
+        old_rows = queue.conn.execute(
+            "SELECT COUNT(*) FROM aspect_extraction_queue WHERE collection = ?",
+            ("code__old",),
+        ).fetchone()[0]
+        assert old_rows == 0
+
+
+# ── K9: search_telemetry + hook_failures included in cascade ─────────────────
+
+
+class TestTelemetryRenameCollection:
+    """K9 (nexus-nhyh): Telemetry.rename_collection must update
+    search_telemetry.collection AND hook_failures.collection."""
+
+    def test_search_telemetry_renamed(self, tmp_path: Path) -> None:
+        from nexus.db.t2.telemetry import Telemetry
+
+        tel = Telemetry(tmp_path / "tel.db")
+        tel.conn.execute(
+            "INSERT INTO search_telemetry "
+            "(ts, query_hash, collection, raw_count, kept_count) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("2026-05-09T00:00:00Z", "abc", "code__old", 10, 5),
+        )
+        tel.conn.execute(
+            "INSERT INTO search_telemetry "
+            "(ts, query_hash, collection, raw_count, kept_count) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("2026-05-09T00:00:00Z", "abc", "code__stays", 3, 2),
+        )
+        tel.conn.commit()
+
+        counts = tel.rename_collection(old="code__old", new="code__new")
+        assert counts["search_telemetry"] == 1
+
+        new_rows = tel.conn.execute(
+            "SELECT COUNT(*) FROM search_telemetry WHERE collection = ?",
+            ("code__new",),
+        ).fetchone()[0]
+        stays_rows = tel.conn.execute(
+            "SELECT COUNT(*) FROM search_telemetry WHERE collection = ?",
+            ("code__stays",),
+        ).fetchone()[0]
+        old_rows = tel.conn.execute(
+            "SELECT COUNT(*) FROM search_telemetry WHERE collection = ?",
+            ("code__old",),
+        ).fetchone()[0]
+        assert (old_rows, new_rows, stays_rows) == (0, 1, 1)
+
+    def test_hook_failures_renamed(self, tmp_path: Path) -> None:
+        from nexus.db.t2.telemetry import Telemetry
+
+        tel = Telemetry(tmp_path / "tel.db")
+        tel.conn.executescript("""
+            CREATE TABLE IF NOT EXISTS hook_failures (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                doc_id      TEXT NOT NULL DEFAULT '',
+                collection  TEXT NOT NULL DEFAULT '',
+                hook_name   TEXT NOT NULL,
+                error       TEXT NOT NULL DEFAULT '',
+                occurred_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+        """)
+        tel.conn.execute(
+            "INSERT INTO hook_failures (doc_id, collection, hook_name, error) "
+            "VALUES (?, ?, ?, ?)",
+            ("d1", "code__old", "test_hook", "some error"),
+        )
+        tel.conn.execute(
+            "INSERT INTO hook_failures (doc_id, collection, hook_name, error) "
+            "VALUES (?, ?, ?, ?)",
+            ("d2", "code__stays", "test_hook", "other error"),
+        )
+        tel.conn.commit()
+
+        counts = tel.rename_collection(old="code__old", new="code__new")
+        assert counts["hook_failures"] == 1
+
+        new_rows = tel.conn.execute(
+            "SELECT COUNT(*) FROM hook_failures WHERE collection = ?",
+            ("code__new",),
+        ).fetchone()[0]
+        stays_rows = tel.conn.execute(
+            "SELECT COUNT(*) FROM hook_failures WHERE collection = ?",
+            ("code__stays",),
+        ).fetchone()[0]
+        old_rows = tel.conn.execute(
+            "SELECT COUNT(*) FROM hook_failures WHERE collection = ?",
+            ("code__old",),
+        ).fetchone()[0]
+        assert (old_rows, new_rows, stays_rows) == (0, 1, 1)
+
+    def test_no_rows_returns_zero_counts(self, tmp_path: Path) -> None:
+        from nexus.db.t2.telemetry import Telemetry
+
+        tel = Telemetry(tmp_path / "tel.db")
+        counts = tel.rename_collection(old="code__ghost", new="code__phantom")
+        assert counts["search_telemetry"] == 0
+        assert counts.get("hook_failures", 0) == 0
+
+
+class TestK9CascadeIncludesTelemetry:
+    """K9 end-to-end: rename_collection_data_plane must update
+    search_telemetry.collection and hook_failures.collection."""
+
+    def test_data_plane_updates_search_telemetry(
+        self, tmp_path: Path, env_creds
+    ) -> None:
+        from nexus.commands.collection import rename_collection_data_plane
+        from nexus.db.t2 import T2Database
+
+        db_path = tmp_path / "memory.db"
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+
+        with T2Database(db_path) as t2db:
+            t2db.telemetry.conn.execute(
+                "INSERT INTO search_telemetry "
+                "(ts, query_hash, collection, raw_count, kept_count) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("2026-05-09T00:00:00Z", "abc", "code__old", 10, 5),
+            )
+            t2db.telemetry.conn.commit()
+
+        fake = MagicMock()
+        fake.collection_exists = MagicMock(side_effect=lambda n: n == "code__old")
+        fake.rename_collection = MagicMock()
+
+        with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.commands._helpers.default_db_path", return_value=db_path), \
+             patch("nexus.config.catalog_path", return_value=cat_dir):
+            counts = rename_collection_data_plane("code__old", "code__new")
+
+        assert counts.get("search_telemetry", 0) == 1
+
+        with T2Database(db_path) as verify:
+            new_rows = verify.telemetry.conn.execute(
+                "SELECT COUNT(*) FROM search_telemetry WHERE collection = ?",
+                ("code__new",),
+            ).fetchone()[0]
+            old_rows = verify.telemetry.conn.execute(
+                "SELECT COUNT(*) FROM search_telemetry WHERE collection = ?",
+                ("code__old",),
+            ).fetchone()[0]
+        assert new_rows == 1 and old_rows == 0
+
+
+# ── SIG-8: T2-first ordering (T3 rename last) ────────────────────────────────
+
+
+class TestRenameOrdering:
+    """SIG-8 (nexus-nhyh): T2 cascade must happen BEFORE T3 rename.
+    Rationale: T2 UPDATEs are reversible; T3 chromadb rename is irrevocable.
+    If T2 succeeds but T3 fails, operator can re-run rename. Reverse is
+    unrecoverable.
+
+    Test: simulate T3 rename failure; assert T2 was already committed
+    (operator can reverse by running T2 cascade back to old name).
+    """
+
+    def test_t2_cascade_committed_before_t3_rename(
+        self, tmp_path: Path, env_creds
+    ) -> None:
+        from nexus.commands.collection import rename_collection_data_plane
+        from nexus.db.t2 import T2Database
+        import click
+
+        db_path = tmp_path / "memory.db"
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+
+        with T2Database(db_path) as t2db:
+            t2db.chash_index.upsert(
+                chash="aa", collection="code__old", chunk_chroma_id="d1"
+            )
+
+        fake = MagicMock()
+        fake.collection_exists = MagicMock(side_effect=lambda n: n == "code__old")
+
+        def _t3_rename_bomb(old, new):
+            raise RuntimeError("simulated T3 rename failure")
+
+        fake.rename_collection = _t3_rename_bomb
+
+        with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.commands._helpers.default_db_path", return_value=db_path), \
+             patch("nexus.config.catalog_path", return_value=cat_dir):
+            with pytest.raises((RuntimeError, click.ClickException)):
+                rename_collection_data_plane("code__old", "code__new")
+
+        # T2-first: T2 was committed even though T3 failed
+        with T2Database(db_path) as verify:
+            new_rows = verify.chash_index.conn.execute(
+                "SELECT COUNT(*) FROM chash_index WHERE physical_collection = ?",
+                ("code__new",),
+            ).fetchone()[0]
+        assert new_rows == 1, (
+            "T2 cascade should commit before T3 rename (T2-first ordering). "
+            "If T3 fails after T2 succeeds, T2 state is at least recoverable."
+        )
+
+
+# ── CG-1: half-cascade test + non-zero exit ──────────────────────────────────
+
+
+class TestHalfCascadeNonZeroExit:
+    """CG-1 (nexus-nhyh): CLI must exit non-zero when T2 cascade fails,
+    not swallow the error and exit 0.
+
+    The bead finding: broad `except Exception: on_warn(...)` swallows T2
+    failures and returns exit 0 -- operator sees a warning but no indication
+    that action is required.
+
+    Fix: T2 cascade failure re-raises as ClickException (exit non-zero).
+    """
+
+    def test_t2_cascade_failure_exits_nonzero(
+        self, tmp_path: Path, env_creds
+    ) -> None:
+        from nexus.commands.collection import rename_cmd
+        from click.testing import CliRunner
+
+        db_path = tmp_path / "memory.db"
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+
+        fake = MagicMock()
+        fake.collection_exists = MagicMock(
+            side_effect=lambda n: n == "code__old",
+        )
+        fake.rename_collection = MagicMock()
+
+        def _t2_bomb(*a, **kw):
+            raise RuntimeError("simulated T2 cascade failure")
+
+        runner = CliRunner()
+        with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.db.t2.T2Database", side_effect=_t2_bomb), \
+             patch("nexus.commands._helpers.default_db_path", return_value=db_path), \
+             patch("nexus.config.catalog_path", return_value=cat_dir):
+            result = runner.invoke(rename_cmd, ["code__old", "code__new"])
+
+        # Must exit non-zero so operator knows cascade failed
+        assert result.exit_code != 0, (
+            f"Expected non-zero exit when T2 cascade fails, got {result.exit_code}. "
+            f"Output: {result.output}"
+        )
+        # Error message must be actionable
+        assert "cascade" in result.output.lower() or "T2" in result.output, (
+            f"Error message must name the failed cascade. Output: {result.output}"
+        )


### PR DESCRIPTION
## Summary

- **K4 atomicity**: `T2Database.rename_collection_cascade()` uses a single shared SQLite connection with one `BEGIN...COMMIT` across all six T2 collection tables. Mid-cascade failure automatically rolls back the entire transaction. `DocumentAspects` and `AspectExtractionQueue` now pre-DELETE conflicting new-side rows before UPDATE (mirrors `ChashIndex` pattern).
- **K9 missing tables**: `Telemetry.rename_collection()` added, updating `search_telemetry.collection` and `hook_failures.collection` (guarded by table-existence check for pre-migration DBs). Wired into `rename_collection_cascade` and `rename_collection_data_plane`.
- **SIG-8 ordering**: T2 cascade now runs BEFORE T3 rename. T2 UPDATEs are reversible; ChromaDB rename is irrevocable. If T3 fails after T2 succeeds, operator can reverse T2 via `nx collection rename new old`.
- **CG-1 non-zero exit**: T2 cascade failure raises `ClickException` (non-zero exit) instead of swallowing with `on_warn`. Catalog cascade remains fail-open (derived view, repairable via `nx catalog rebuild`).
- **A-S4 docstring**: `AspectExtractionQueue.rename_collection` docstring corrected to accurately describe post-je0b PK state.

## Test plan

- [x] 37 tests passing (10 new: `TestCascadeAtomicity`, `TestDocumentAspectsCollisionDefense`, `TestAspectQueueCollisionDefense`, `TestTelemetryRenameCollection`, `TestK9CascadeIncludesTelemetry`, `TestRenameOrdering`, `TestHalfCascadeNonZeroExit`)
- [x] `TestCascadeAtomicity::test_mid_cascade_failure_rolls_back_all_tables`: injects failure mid-cascade via `_conn` seam; verifies all tables show old name after rollback
- [x] Collision defense: pre-seeds colliding rows; verifies no UNIQUE constraint violation
- [x] K9 cascade: seeds `search_telemetry` row; verifies it is renamed by `rename_collection_data_plane`
- [x] SIG-8: T3 bomb fires; verifies T2 was already committed (T2-first)
- [x] CG-1: T2 bomb fires; verifies CLI exit non-zero and T3 not called
- [x] 490 tests passing across `rename or aspect or telemetry` scope

## Closes

Closes nexus-nhyh