### PR TITLE
feat(t3): chunk re-upsert with content-derived natural IDs (nexus-jc63)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -700,6 +700,22 @@ Default is report-only; both `--no-dry-run` AND `--yes` are required to actually
 
 `--orphan-window` accepts `s`, `m`, `h`, `d`, `w` suffixes (e.g. `30d`, `12h`, `2w`); a bare integer is rejected so a typo cannot silently mean 30 seconds.
 
+### nx t3 reidentify
+
+```
+nx t3 reidentify (-c COLLECTION | --all-collections) [--no-dry-run]
+```
+
+Re-upsert T3 chunks under content-derived natural IDs `chunk_text_hash[:32]` (RDR-108 D1 / nexus-jc63). Per collection the verb paginates T3 chunks (300/op), computes the new natural ID for each chunk, re-upserts under the new ID using the existing embedding (no Voyage call), and batch-deletes the old chunk IDs after the get-loop completes. Document-level metadata fields (`doc_id`, `chunk_index`, `chunk_count`) are stripped at re-upsert; the `document_chunks` manifest table is now authoritative for those.
+
+The verb is idempotent: re-running on a fully-migrated collection performs zero writes. It is also crash-resumable: re-invoking after an interrupted run safely sweeps the un-deleted old IDs.
+
+Default is `--dry-run` (report-only). Use `--no-dry-run` to perform the migration.
+
+Carve-outs:
+- `taxonomy__*` collections are skipped (centroids use `centroid_hash` from the `topics` table, not `chunk_text_hash`).
+- Pre-RDR-053 chunks lacking `chunk_text_hash` raise a structured error; re-index that collection from source before running.
+
 ---
 
 ## nx taxonomy

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -748,3 +748,146 @@ def backfill_manifest_cmd(
 
     if errors:
         raise SystemExit(1)
+
+
+@t3.command("reidentify")
+@click.option(
+    "--collection",
+    "-c",
+    default="",
+    help="Limit to one collection. Mutually exclusive with --all-collections.",
+)
+@click.option(
+    "--all-collections",
+    "all_collections",
+    is_flag=True,
+    default=False,
+    help="Re-identify every T3 collection. Mutually exclusive with --collection.",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    help="Report-only (default). Use --no-dry-run to perform the migration.",
+)
+def reidentify_cmd(
+    collection: str,
+    all_collections: bool,
+    dry_run: bool,
+) -> None:
+    """Re-upsert T3 chunks under content-derived natural IDs (RDR-108 D1).
+
+    \b
+    Per collection, paginates T3 chunks (300/op), computes a new natural
+    ID from chunk_text_hash[:32], and re-upserts each chunk under the new
+    ID using the existing embedding (no Voyage call). Document-level
+    metadata fields (doc_id, chunk_index, chunk_count) are stripped at
+    re-upsert; the catalog manifest table is now authoritative for those.
+    Old chunk IDs are batch-deleted after the get-loop completes.
+
+    \b
+    The command is idempotent: re-running on a fully-migrated collection
+    is a zero-write no-op. It is also crash-resumable: re-invoking after
+    an interrupted run safely sweeps the un-deleted old IDs.
+
+    \b
+    Carve-outs:
+      - taxonomy__* collections are skipped (centroids use centroid_hash).
+      - Pre-RDR-053 chunks missing chunk_text_hash raise an error;
+        re-index that collection from source before running.
+
+    \b
+    Examples:
+      nx t3 reidentify --collection code__nexus            # dry-run report
+      nx t3 reidentify -c code__nexus --no-dry-run         # one collection
+      nx t3 reidentify --all-collections --no-dry-run      # full corpus
+    """
+    from nexus.db.t3_reidentify import (  # noqa: PLC0415
+        MissingChunkHashError,
+        reidentify_collection,
+    )
+
+    if not collection and not all_collections:
+        raise click.UsageError(
+            "Specify either --collection NAME or --all-collections."
+        )
+    if collection and all_collections:
+        raise click.UsageError(
+            "--collection and --all-collections are mutually exclusive."
+        )
+
+    t3_db = _make_t3_for_backfill()
+
+    if dry_run:
+        click.echo("(dry-run: no T3 writes or deletes will be performed)")
+
+    if collection:
+        collections_to_process = [collection]
+    else:
+        collections_to_process = [
+            c["name"] for c in t3_db.list_collections()
+        ]
+        if not collections_to_process:
+            click.echo("No T3 collections found; nothing to do.")
+            return
+
+    total = len(collections_to_process)
+    total_examined = 0
+    total_migrated = 0
+    total_already = 0
+    total_deleted = 0
+    skipped_taxonomy = 0
+    errors: list[str] = []
+
+    for idx, coll_name in enumerate(collections_to_process, start=1):
+        print(
+            f"[{idx}/{total}] {coll_name}: processing ...",
+            file=sys.stderr,
+        )
+        try:
+            result = reidentify_collection(
+                t3_db, coll_name, dry_run=dry_run
+            )
+        except MissingChunkHashError as exc:
+            click.echo(f"ERROR: {exc}", err=True)
+            errors.append(str(exc))
+            continue
+        except Exception as exc:
+            click.echo(f"ERROR in {coll_name}: {exc}", err=True)
+            errors.append(f"{coll_name}: {exc}")
+            continue
+
+        if result.skipped_taxonomy:
+            click.echo(f"  {coll_name}: skipped (taxonomy carve-out)")
+            skipped_taxonomy += 1
+            continue
+
+        verb = "would migrate" if dry_run else "migrated"
+        delete_part = (
+            f", {result.chunks_deleted} old id(s) deleted"
+            if not dry_run and result.chunks_deleted
+            else ""
+        )
+        click.echo(
+            f"  {coll_name}: examined {result.chunks_examined} chunk(s), "
+            f"{verb} {result.chunks_migrated}, "
+            f"{result.chunks_already_migrated} already migrated"
+            + delete_part
+        )
+
+        total_examined += result.chunks_examined
+        total_migrated += result.chunks_migrated
+        total_already += result.chunks_already_migrated
+        total_deleted += result.chunks_deleted
+
+    verb = "would migrate" if dry_run else "migrated"
+    click.echo(
+        f"\nSummary: examined {total_examined} chunk(s) across "
+        f"{total} collection(s); {verb} {total_migrated}, "
+        f"{total_already} already migrated, "
+        f"{total_deleted} old id(s) deleted"
+        + (f", skipped {skipped_taxonomy} taxonomy" if skipped_taxonomy else "")
+        + (f", {len(errors)} error(s)" if errors else "")
+    )
+
+    if errors:
+        raise SystemExit(1)

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -806,13 +806,10 @@ def reidentify_cmd(
         reidentify_collection,
     )
 
-    if not collection and not all_collections:
+    # XOR: exactly one of --collection / --all-collections must be set.
+    if bool(collection) == bool(all_collections):
         raise click.UsageError(
-            "Specify either --collection NAME or --all-collections."
-        )
-    if collection and all_collections:
-        raise click.UsageError(
-            "--collection and --all-collections are mutually exclusive."
+            "Specify exactly one of --collection NAME or --all-collections."
         )
 
     t3_db = _make_t3_for_backfill()

--- a/src/nexus/db/t3_reidentify.py
+++ b/src/nexus/db/t3_reidentify.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-108 Phase 2 (nexus-jc63): T3 chunk re-identification.
+
+Re-upserts every T3 chunk under a content-derived natural ID
+(``chunk_text_hash[:32]``), reusing the chunk's existing embedding so
+the migration is free of Voyage calls. After all chunks for a
+collection have been re-upserted, the old chunk IDs are batch-deleted
+in groups of 300 (the ChromaDB write quota).
+
+The loop is idempotent (re-running on a fully-migrated collection is
+a zero-write no-op) and crash-resumable (a partial run can be
+re-invoked safely; the filter naturally skips already-migrated chunks
+and the un-deleted old IDs from the prior crash get re-collected on
+resume).
+
+Edge-case contracts:
+  - ``taxonomy__*`` collections are skipped: centroids use
+    ``centroid_hash`` from the ``topics`` table, not
+    ``chunk_text_hash``. Detected by collection-name prefix.
+  - Pre-RDR-053 chunks lacking ``chunk_text_hash``: FAIL LOUD with
+    :class:`MissingChunkHashError` (per RDR-108 re-gate S3). Operator
+    must re-index that collection or carve it out.
+  - Quota compliance: paginates T3 at <=300 records per ``col.get()``
+    call; ``col.delete()`` batches at <=300 ids per call.
+  - Embedding reuse: ``col.upsert(..., embeddings=...)`` accepts a
+    pre-computed vector and bypasses the embedding function (RF-2).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import structlog
+from chromadb.errors import NotFoundError as _ChromaNotFoundError
+
+from nexus.db.chroma_quotas import QUOTAS
+from nexus.retry import _chroma_with_retry
+
+if TYPE_CHECKING:
+    from nexus.db.t3 import T3Database
+
+_log = structlog.get_logger(__name__)
+
+_TAXONOMY_PREFIX = "taxonomy__"
+_PAGE_SIZE = QUOTAS.MAX_RECORDS_PER_WRITE  # 300
+_STRIPPED_META_FIELDS = frozenset({"doc_id", "chunk_index", "chunk_count"})
+
+
+class MissingChunkHashError(ValueError):
+    """Raised when a T3 chunk lacks ``chunk_text_hash``.
+
+    Phase 2 cannot derive a natural ID without this field. Per the
+    RDR-108 re-gate S3 finding, pre-RDR-053 chunks must FAIL LOUD so
+    the operator knows to re-index the collection rather than silently
+    losing data through a degraded fallback.
+    """
+
+    def __init__(self, chunk_id: str, collection: str) -> None:
+        self.chunk_id = chunk_id
+        self.collection = collection
+        super().__init__(
+            f"Chunk {chunk_id!r} in collection {collection!r} has no "
+            f"chunk_text_hash. Re-index this collection from source "
+            f"before running 'nx t3 reidentify', or explicitly carve "
+            f"it out."
+        )
+
+
+@dataclass
+class ReidentifyResult:
+    """Summary of one re-identification run over a single collection."""
+
+    collection: str
+    chunks_examined: int = 0
+    chunks_migrated: int = 0
+    chunks_already_migrated: int = 0
+    chunks_deleted: int = 0
+    skipped_taxonomy: bool = False
+
+
+def reidentify_collection(
+    t3: "T3Database",
+    collection_name: str,
+    *,
+    dry_run: bool = True,
+) -> ReidentifyResult:
+    """Re-upsert every chunk in ``collection_name`` under chunk_text_hash[:32].
+
+    Per-collection paginated loop following RDR-108 RF-6:
+
+      1. ``col.get(limit=300, offset=N, include=[documents, embeddings, metadatas])``
+      2. For each chunk, compute ``new_id = meta["chunk_text_hash"][:32]``.
+         Skip silently if ``cid == new_id`` (already migrated).
+      3. Strip ``doc_id`` / ``chunk_index`` / ``chunk_count`` from metadata
+         (the catalog manifest is now authoritative for those fields).
+      4. ``col.upsert(ids=new, documents=..., embeddings=..., metadatas=...)``
+         — pre-computed embeddings bypass the embedding function (no Voyage
+         call).
+      5. After the get-loop completes, batch-delete the collected old IDs
+         in groups of 300.
+
+    Args:
+        t3: T3Database for ChromaDB access.
+        collection_name: Name of the T3 collection to re-identify.
+        dry_run: If True, count what would change but do not write or delete.
+
+    Returns:
+        :class:`ReidentifyResult` with counts.
+
+    Raises:
+        :class:`MissingChunkHashError`: if any chunk lacks ``chunk_text_hash``.
+    """
+    result = ReidentifyResult(collection=collection_name)
+
+    if collection_name.startswith(_TAXONOMY_PREFIX):
+        _log.info(
+            "reidentify_skipped_taxonomy",
+            collection=collection_name,
+        )
+        result.skipped_taxonomy = True
+        return result
+
+    try:
+        col = t3._client_for(collection_name).get_collection(collection_name)
+    except _ChromaNotFoundError:
+        _log.info(
+            "reidentify_collection_absent",
+            collection=collection_name,
+        )
+        return result
+
+    seen_old_ids: set[str] = set()
+    offset = 0
+    while True:
+        page = _chroma_with_retry(
+            col.get,
+            limit=_PAGE_SIZE,
+            offset=offset,
+            include=["documents", "embeddings", "metadatas"],
+        )
+        page_ids: list[str] = page.get("ids") or []
+        if not page_ids:
+            break
+
+        page_docs = page.get("documents") or [None] * len(page_ids)
+        page_embs = page.get("embeddings")
+        if page_embs is None:
+            page_embs = [None] * len(page_ids)
+        page_metas = page.get("metadatas") or [{}] * len(page_ids)
+
+        ids_to_upsert: list[str] = []
+        docs_to_upsert: list[str] = []
+        embs_to_upsert: list = []
+        metas_to_upsert: list[dict] = []
+        # Dedupe within-page identical-text collisions: chromadb.upsert
+        # rejects duplicate IDs within a single call. Two chunks in the
+        # same page sharing chunk_text_hash[:32] mean identical text, so
+        # the second upsert would carry the same content anyway.
+        seen_new_ids_in_page: set[str] = set()
+
+        for cid, doc, emb, meta in zip(
+            page_ids, page_docs, page_embs, page_metas
+        ):
+            result.chunks_examined += 1
+            meta = meta if isinstance(meta, dict) else {}
+            chash = meta.get("chunk_text_hash") or ""
+            if not chash:
+                raise MissingChunkHashError(
+                    chunk_id=cid, collection=collection_name
+                )
+            new_id = chash[:32]
+            if cid == new_id:
+                result.chunks_already_migrated += 1
+                continue
+
+            seen_old_ids.add(cid)
+            if new_id in seen_new_ids_in_page:
+                # Identical-text collapse: still need to delete the old
+                # cid, but skip the redundant upsert.
+                continue
+            seen_new_ids_in_page.add(new_id)
+
+            new_meta = {
+                k: v for k, v in meta.items()
+                if k not in _STRIPPED_META_FIELDS
+            }
+            ids_to_upsert.append(new_id)
+            docs_to_upsert.append(doc)
+            embs_to_upsert.append(emb)
+            metas_to_upsert.append(new_meta)
+
+        if ids_to_upsert and not dry_run:
+            _chroma_with_retry(
+                col.upsert,
+                ids=ids_to_upsert,
+                documents=docs_to_upsert,
+                embeddings=embs_to_upsert,
+                metadatas=metas_to_upsert,
+            )
+
+        result.chunks_migrated += len(ids_to_upsert)
+
+        if len(page_ids) < _PAGE_SIZE:
+            break
+        offset += _PAGE_SIZE
+
+    if not dry_run and seen_old_ids:
+        old_ids_list = list(seen_old_ids)
+        for start in range(0, len(old_ids_list), _PAGE_SIZE):
+            batch = old_ids_list[start : start + _PAGE_SIZE]
+            _chroma_with_retry(col.delete, ids=batch)
+            result.chunks_deleted += len(batch)
+
+    _log.info(
+        "reidentify_collection_complete",
+        collection=collection_name,
+        chunks_examined=result.chunks_examined,
+        chunks_migrated=result.chunks_migrated,
+        chunks_already_migrated=result.chunks_already_migrated,
+        chunks_deleted=result.chunks_deleted,
+        dry_run=dry_run,
+    )
+
+    return result

--- a/src/nexus/db/t3_reidentify.py
+++ b/src/nexus/db/t3_reidentify.py
@@ -7,6 +7,16 @@ the migration is free of Voyage calls. After all chunks for a
 collection have been re-upserted, the old chunk IDs are batch-deleted
 in groups of 300 (the ChromaDB write quota).
 
+The implementation uses a two-pass design (divergence from the RDR-108
+RF-6 pseudocode, which prescribed a single loop interleaving
+``col.get(offset)`` and ``col.upsert``). Pass 1 paginates by offset to
+collect every original chunk id with NO writes; pass 2 processes the
+collected ids in batches via exact-id ``col.get(ids=batch)`` lookups,
+which are immune to in-loop collection mutation. The naive single-pass
+form is unsafe because mid-loop upserts add records that shift
+offset-pagination semantics, causing later pages to either re-visit or
+skip chunks (see ``test_multi_page_iteration_migrates_all_chunks``).
+
 The loop is idempotent (re-running on a fully-migrated collection is
 a zero-write no-op) and crash-resumable (a partial run can be
 re-invoked safely; the filter naturally skips already-migrated chunks
@@ -86,18 +96,28 @@ def reidentify_collection(
 ) -> ReidentifyResult:
     """Re-upsert every chunk in ``collection_name`` under chunk_text_hash[:32].
 
-    Per-collection paginated loop following RDR-108 RF-6:
+    Two-pass per-collection loop:
 
-      1. ``col.get(limit=300, offset=N, include=[documents, embeddings, metadatas])``
-      2. For each chunk, compute ``new_id = meta["chunk_text_hash"][:32]``.
-         Skip silently if ``cid == new_id`` (already migrated).
-      3. Strip ``doc_id`` / ``chunk_index`` / ``chunk_count`` from metadata
-         (the catalog manifest is now authoritative for those fields).
-      4. ``col.upsert(ids=new, documents=..., embeddings=..., metadatas=...)``
-         — pre-computed embeddings bypass the embedding function (no Voyage
-         call).
-      5. After the get-loop completes, batch-delete the collected old IDs
-         in groups of 300.
+      Pass 1 (id discovery): paginate ``col.get(limit=300, offset=N, include=[])``
+      until exhaustion, collecting every original chunk id. No writes.
+
+      Pass 2 (process): for each batch of <=300 collected ids,
+        a. ``col.get(ids=batch, include=[documents, embeddings, metadatas])``
+        b. Compute ``new_id = meta["chunk_text_hash"][:32]`` per chunk.
+           Skip silently if ``cid == new_id`` (already migrated).
+        c. Strip ``doc_id`` / ``chunk_index`` / ``chunk_count`` from
+           metadata (catalog manifest is authoritative for those).
+        d. ``col.upsert(ids=new, documents=..., embeddings=..., metadatas=...)``
+           — pre-computed embeddings bypass the embedding function
+           (no Voyage call).
+
+      Phase 2b (cleanup): batch-delete the collected old ids in groups
+      of 300.
+
+    The two-pass form sidesteps the offset-instability that plagues the
+    naive single-pass loop (in-loop upserts add records, shifting offset
+    semantics for later pages). Exact-id lookups in pass 2 are immune to
+    collection mutation.
 
     Args:
         t3: T3Database for ChromaDB access.
@@ -129,19 +149,46 @@ def reidentify_collection(
         )
         return result
 
-    seen_old_ids: set[str] = set()
+    # Two-pass design:
+    #
+    #   Pass 1: paginate by offset, collecting only the cid list. No writes
+    #           happen during pass 1, so offset semantics stay valid.
+    #
+    #   Pass 2: process in batches of <=_PAGE_SIZE, fetching each batch via
+    #           col.get(ids=batch) (exact-id lookup, not offset-based). New
+    #           upserts during pass 2 don't disturb iteration because we
+    #           already know the full original cid set.
+    #
+    # The naive "paginate-and-upsert in one loop" pattern from RDR-108 RF-6
+    # is unsafe: in-loop upserts add records to the collection, shifting
+    # offset semantics so later pages either re-visit migrated chunks or
+    # skip un-migrated ones. The two-pass form is correctness-preserving
+    # and equally idempotent / resumable.
+    all_cids: list[str] = []
     offset = 0
     while True:
         page = _chroma_with_retry(
-            col.get,
-            limit=_PAGE_SIZE,
-            offset=offset,
-            include=["documents", "embeddings", "metadatas"],
+            col.get, limit=_PAGE_SIZE, offset=offset, include=[]
         )
         page_ids: list[str] = page.get("ids") or []
         if not page_ids:
             break
+        all_cids.extend(page_ids)
+        if len(page_ids) < _PAGE_SIZE:
+            break
+        offset += _PAGE_SIZE
 
+    seen_old_ids: set[str] = set()
+    seen_new_ids: set[str] = set()
+
+    for start in range(0, len(all_cids), _PAGE_SIZE):
+        cid_batch = all_cids[start : start + _PAGE_SIZE]
+        page = _chroma_with_retry(
+            col.get,
+            ids=cid_batch,
+            include=["documents", "embeddings", "metadatas"],
+        )
+        page_ids = page.get("ids") or []
         page_docs = page.get("documents") or [None] * len(page_ids)
         page_embs = page.get("embeddings")
         if page_embs is None:
@@ -152,11 +199,6 @@ def reidentify_collection(
         docs_to_upsert: list[str] = []
         embs_to_upsert: list = []
         metas_to_upsert: list[dict] = []
-        # Dedupe within-page identical-text collisions: chromadb.upsert
-        # rejects duplicate IDs within a single call. Two chunks in the
-        # same page sharing chunk_text_hash[:32] mean identical text, so
-        # the second upsert would carry the same content anyway.
-        seen_new_ids_in_page: set[str] = set()
 
         for cid, doc, emb, meta in zip(
             page_ids, page_docs, page_embs, page_metas
@@ -174,11 +216,12 @@ def reidentify_collection(
                 continue
 
             seen_old_ids.add(cid)
-            if new_id in seen_new_ids_in_page:
-                # Identical-text collapse: still need to delete the old
-                # cid, but skip the redundant upsert.
+            if new_id in seen_new_ids:
+                # Identical-text collapse (within-batch or cross-batch):
+                # still need to delete the old cid, but skip the
+                # redundant upsert so chromadb doesn't reject a duplicate.
                 continue
-            seen_new_ids_in_page.add(new_id)
+            seen_new_ids.add(new_id)
 
             new_meta = {
                 k: v for k, v in meta.items()
@@ -199,10 +242,6 @@ def reidentify_collection(
             )
 
         result.chunks_migrated += len(ids_to_upsert)
-
-        if len(page_ids) < _PAGE_SIZE:
-            break
-        offset += _PAGE_SIZE
 
     if not dry_run and seen_old_ids:
         old_ids_list = list(seen_old_ids)

--- a/tests/test_t3_reidentify.py
+++ b/tests/test_t3_reidentify.py
@@ -271,7 +271,12 @@ class TestReidentifyCollection:
         assert coll in str(exc_info.value)
 
     def test_within_collection_identical_chunks_collapse(self, t3_db):
-        """Identical chunk text in the same collection collapses to one T3 record."""
+        """Identical chunk text in the same collection collapses to one T3 record.
+
+        Both old cids must still be deleted: the second duplicate is dropped
+        from the upsert batch (chromadb rejects duplicate ids in one call)
+        but its cid is added to seen_old_ids and Phase 2b deletes it.
+        """
         from nexus.db.t3_reidentify import reidentify_collection
 
         coll = _unique_coll()
@@ -284,10 +289,12 @@ class TestReidentifyCollection:
             content="identical text", chunk_text_hash="1" * 64,
         )
 
-        reidentify_collection(t3_db, coll, dry_run=False)
+        result = reidentify_collection(t3_db, coll, dry_run=False)
 
         ids = _ids_in(t3_db, coll)
         assert ids == {"1" * 32}
+        # Both old cids deleted (collapse-path doesn't skip cleanup).
+        assert result.chunks_deleted == 2
 
     def test_cross_collection_chash_dedup_independent(self, t3_db):
         """Same chunk text in two collections produces independent records.
@@ -351,6 +358,41 @@ class TestReidentifyCollection:
 
 class TestReidentifyPagination:
     """Verify quota compliance: page size <= 300, batch deletes <= 300."""
+
+    def test_multi_page_iteration_migrates_all_chunks(self, t3_db):
+        """Multi-page pagination correctly walks past page 1.
+
+        Patches _PAGE_SIZE to 3 so seven seeded chunks span three pages
+        (3 + 3 + 1). The chunk_text_hash values are constructed so each
+        chunk's first 32 chars are unique (variation in the high nibbles,
+        not the low ones).
+        """
+        from nexus.db import t3_reidentify
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        # Hashes vary in the FIRST 32 chars so chunk_text_hash[:32] is
+        # distinct per chunk. Pattern: digit i repeated 32 times, then
+        # zeros to pad to 64 chars.
+        new_ids_expected = []
+        for i in range(7):
+            chash = (str(i) * 32) + ("0" * 32)
+            new_ids_expected.append(chash[:32])
+            _seed_chunk(
+                t3_db, collection=coll, chunk_id=f"legacy-{i}",
+                content=f"content-{i}", chunk_text_hash=chash,
+            )
+
+        with patch.object(t3_reidentify, "_PAGE_SIZE", 3):
+            result = reidentify_collection(t3_db, coll, dry_run=False)
+
+        assert result.chunks_examined == 7
+        assert result.chunks_migrated == 7
+        assert result.chunks_deleted == 7
+        ids = _ids_in(t3_db, coll)
+        for i, new_id in enumerate(new_ids_expected):
+            assert f"legacy-{i}" not in ids
+            assert new_id in ids
 
     def test_get_page_size_never_exceeds_300(self, t3_db):
         """col.get is called with limit <= 300."""

--- a/tests/test_t3_reidentify.py
+++ b/tests/test_t3_reidentify.py
@@ -1,0 +1,555 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-jc63: T3 chunk re-identification (RDR-108 Phase 2).
+
+Re-upserts every T3 chunk under a content-derived natural ID
+(``chunk_text_hash[:32]``), reusing the chunk's existing embedding
+so the migration is free of Voyage calls. After re-upsert, the
+old chunk IDs are batch-deleted.
+
+Tests cover:
+  - basic happy path: chunks migrate from old IDs to ``chunk_text_hash[:32]``
+  - idempotent: re-running on a fully-migrated collection performs zero writes
+  - resumable: a partial run can be re-invoked safely (un-deleted old IDs swept)
+  - embedding reuse: byte-identical embeddings before and after migration
+  - metadata strip: doc_id, chunk_index, chunk_count removed at re-upsert
+  - taxonomy carve-out: ``taxonomy__*`` collections skipped by default
+  - missing chunk_text_hash raises a structured error (not KeyError)
+  - cross-collection chash dedup: same chunk text in two collections stays
+    independent (chromadb natural IDs are per-collection)
+  - within-collection identical chunks collapse to one T3 record
+  - dry-run: no writes, no deletes
+  - quota compliance: page size <= 300, batch deletes <= 300
+  - CLI: --collection, --dry-run, --no-dry-run, --all-collections flags
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.db.t3 import T3Database
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _unique_coll(prefix: str = "code") -> str:
+    """Return a unique collection name per call.
+
+    chromadb.EphemeralClient instances share an in-memory backend singleton;
+    data seeded in one test is visible to subsequent tests unless collection
+    names are isolated per call.
+    """
+    return f"{prefix}__{uuid.uuid4().hex[:12]}"
+
+
+def _seed_chunk(
+    t3_db: T3Database,
+    *,
+    collection: str,
+    chunk_id: str,
+    content: str,
+    chunk_text_hash: str,
+    doc_id: str | None = None,
+    chunk_index: int | None = None,
+    chunk_count: int | None = None,
+    extra_meta: dict[str, Any] | None = None,
+) -> None:
+    """Insert one chunk with the metadata that re-identify reads."""
+    col = t3_db._client.get_or_create_collection(collection)
+    meta: dict[str, Any] = {"chunk_text_hash": chunk_text_hash}
+    if doc_id is not None:
+        meta["doc_id"] = doc_id
+    if chunk_index is not None:
+        meta["chunk_index"] = chunk_index
+    if chunk_count is not None:
+        meta["chunk_count"] = chunk_count
+    if extra_meta:
+        meta.update(extra_meta)
+    col.add(ids=[chunk_id], documents=[content], metadatas=[meta])
+
+
+def _ids_in(t3_db: T3Database, collection: str) -> set[str]:
+    """Return the full set of chunk IDs currently in a collection."""
+    col = t3_db._client.get_or_create_collection(collection)
+    return set(col.get()["ids"])
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def t3_db():
+    """Real T3Database backed by an ephemeral local Chroma."""
+    return T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── Unit tests: reidentify_collection ────────────────────────────────────────
+
+
+class TestReidentifyCollection:
+    """Tests for the core re-identification function."""
+
+    def test_migrates_to_chunk_text_hash_prefix(self, t3_db):
+        """Chunks are re-upserted under chunk_text_hash[:32] natural IDs."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-id-1",
+            content="hello world", chunk_text_hash="a" * 64,
+            doc_id="1.1.1", chunk_index=0, chunk_count=1,
+        )
+
+        result = reidentify_collection(t3_db, coll, dry_run=False)
+
+        assert result.chunks_migrated == 1
+        assert result.chunks_deleted == 1
+        assert "a" * 32 in _ids_in(t3_db, coll)
+        assert "legacy-id-1" not in _ids_in(t3_db, coll)
+
+    def test_strips_doc_level_metadata_fields(self, t3_db):
+        """doc_id, chunk_index, chunk_count are removed from metadata at re-upsert."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-id-1",
+            content="hello", chunk_text_hash="b" * 64,
+            doc_id="1.1.1", chunk_index=2, chunk_count=5,
+            extra_meta={"source_path": "/tmp/foo.py", "line_start": 0},
+        )
+
+        reidentify_collection(t3_db, coll, dry_run=False)
+
+        col = t3_db._client.get_or_create_collection(coll)
+        result = col.get(ids=["b" * 32], include=["metadatas"])
+        meta = result["metadatas"][0]
+        assert "doc_id" not in meta
+        assert "chunk_index" not in meta
+        assert "chunk_count" not in meta
+        # Non-stripped fields preserved
+        assert meta.get("source_path") == "/tmp/foo.py"
+        assert meta.get("line_start") == 0
+        assert meta.get("chunk_text_hash") == "b" * 64
+
+    def test_idempotent_on_fully_migrated_collection(self, t3_db):
+        """Re-running on a fully-migrated collection performs zero writes."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-id-1",
+            content="hello", chunk_text_hash="c" * 64,
+            doc_id="1.1.1", chunk_index=0,
+        )
+
+        # First run migrates.
+        reidentify_collection(t3_db, coll, dry_run=False)
+        ids_after_first = _ids_in(t3_db, coll)
+        assert ids_after_first == {"c" * 32}
+
+        # Second run is a no-op.
+        result2 = reidentify_collection(t3_db, coll, dry_run=False)
+        assert result2.chunks_migrated == 0
+        assert result2.chunks_deleted == 0
+        assert result2.chunks_already_migrated == 1
+        assert _ids_in(t3_db, coll) == ids_after_first
+
+    def test_resume_after_partial_migration(self, t3_db):
+        """A crashed mid-collection run can be re-invoked safely.
+
+        Simulates a partial migration by manually upserting two chunks
+        under their new IDs without deleting their old IDs. Re-running
+        the migration must sweep the un-deleted old IDs without
+        damaging the already-migrated new IDs.
+        """
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-1",
+            content="hello", chunk_text_hash="d" * 64,
+        )
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-2",
+            content="world", chunk_text_hash="e" * 64,
+        )
+        # Simulate the partial state: new IDs already added, old IDs
+        # still present (a crash before Phase 2b delete fires).
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="d" * 32,
+            content="hello", chunk_text_hash="d" * 64,
+        )
+
+        result = reidentify_collection(t3_db, coll, dry_run=False)
+
+        # legacy-1 collected as old (its new_id "ddd...32" already exists,
+        # idempotent overwrite). legacy-2 fully migrated.
+        assert "d" * 32 in _ids_in(t3_db, coll)
+        assert "e" * 32 in _ids_in(t3_db, coll)
+        assert "legacy-1" not in _ids_in(t3_db, coll)
+        assert "legacy-2" not in _ids_in(t3_db, coll)
+        # Both old IDs collected and deleted.
+        assert result.chunks_deleted == 2
+
+    def test_embedding_round_trip_byte_identical(self, t3_db):
+        """Byte-identical embeddings before and after migration (no Voyage call)."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-1",
+            content="rendezvous embedding", chunk_text_hash="f" * 64,
+        )
+
+        col = t3_db._client.get_or_create_collection(coll)
+        before = col.get(
+            ids=["legacy-1"], include=["embeddings"]
+        )["embeddings"][0]
+
+        reidentify_collection(t3_db, coll, dry_run=False)
+
+        after = col.get(
+            ids=["f" * 32], include=["embeddings"]
+        )["embeddings"][0]
+
+        # numpy-array equality at the byte level. Voyage was never called;
+        # the original embedding was reused on re-upsert.
+        assert list(before) == list(after)
+
+    def test_taxonomy_collection_skipped(self, t3_db):
+        """taxonomy__* collections are skipped by default."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll(prefix="taxonomy")
+        col = t3_db._client.get_or_create_collection(coll)
+        col.add(
+            ids=["centroid-1"],
+            documents=["centroid content"],
+            metadatas=[{"centroid_hash": "abc123"}],
+        )
+
+        result = reidentify_collection(t3_db, coll, dry_run=False)
+
+        assert result.skipped_taxonomy is True
+        assert result.chunks_migrated == 0
+        assert "centroid-1" in _ids_in(t3_db, coll)
+
+    def test_missing_chunk_text_hash_raises_structured_error(self, t3_db):
+        """Chunks without chunk_text_hash raise MissingChunkHashError, not KeyError."""
+        from nexus.db.t3_reidentify import (
+            MissingChunkHashError,
+            reidentify_collection,
+        )
+
+        coll = _unique_coll()
+        col = t3_db._client.get_or_create_collection(coll)
+        col.add(
+            ids=["legacy-noh"],
+            documents=["pre-RDR-053 chunk"],
+            metadatas=[{"doc_id": "1.1.1", "chunk_index": 0}],  # no chunk_text_hash
+        )
+
+        with pytest.raises(MissingChunkHashError) as exc_info:
+            reidentify_collection(t3_db, coll, dry_run=False)
+        assert "legacy-noh" in str(exc_info.value)
+        assert coll in str(exc_info.value)
+
+    def test_within_collection_identical_chunks_collapse(self, t3_db):
+        """Identical chunk text in the same collection collapses to one T3 record."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-1",
+            content="identical text", chunk_text_hash="1" * 64,
+        )
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-2",
+            content="identical text", chunk_text_hash="1" * 64,
+        )
+
+        reidentify_collection(t3_db, coll, dry_run=False)
+
+        ids = _ids_in(t3_db, coll)
+        assert ids == {"1" * 32}
+
+    def test_cross_collection_chash_dedup_independent(self, t3_db):
+        """Same chunk text in two collections produces independent records.
+
+        ChromaDB natural IDs are per-collection, so the two collections
+        each end up with one chunk under the same string ID, but
+        they're separate records.
+        """
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll_a = _unique_coll()
+        coll_b = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll_a, chunk_id="legacy-A",
+            content="shared text", chunk_text_hash="2" * 64,
+        )
+        _seed_chunk(
+            t3_db, collection=coll_b, chunk_id="legacy-B",
+            content="shared text", chunk_text_hash="2" * 64,
+        )
+
+        reidentify_collection(t3_db, coll_a, dry_run=False)
+        reidentify_collection(t3_db, coll_b, dry_run=False)
+
+        assert "2" * 32 in _ids_in(t3_db, coll_a)
+        assert "2" * 32 in _ids_in(t3_db, coll_b)
+
+        # Documents stay independent.
+        col_a = t3_db._client.get_or_create_collection(coll_a)
+        col_b = t3_db._client.get_or_create_collection(coll_b)
+        assert col_a.get(ids=["2" * 32])["documents"] == ["shared text"]
+        assert col_b.get(ids=["2" * 32])["documents"] == ["shared text"]
+
+    def test_dry_run_does_not_write_or_delete(self, t3_db):
+        """--dry-run does not write new IDs and does not delete old IDs."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-1",
+            content="hello", chunk_text_hash="3" * 64,
+        )
+
+        result = reidentify_collection(t3_db, coll, dry_run=True)
+
+        # Counts what WOULD migrate
+        assert result.chunks_migrated == 1
+        # But actually nothing was written or deleted
+        ids = _ids_in(t3_db, coll)
+        assert "legacy-1" in ids
+        assert "3" * 32 not in ids
+
+    def test_absent_collection_returns_empty_result(self, t3_db):
+        """An unknown T3 collection returns an empty result, not an error."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        result = reidentify_collection(t3_db, "code__no_such_coll_xyz", dry_run=False)
+        assert result.chunks_migrated == 0
+        assert result.chunks_deleted == 0
+
+
+class TestReidentifyPagination:
+    """Verify quota compliance: page size <= 300, batch deletes <= 300."""
+
+    def test_get_page_size_never_exceeds_300(self, t3_db):
+        """col.get is called with limit <= 300."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-1",
+            content="x", chunk_text_hash="4" * 64,
+        )
+
+        col = t3_db._client.get_or_create_collection(coll)
+        original_get = col.get
+        get_calls: list[dict] = []
+
+        def _tracking_get(**kwargs):
+            get_calls.append(kwargs)
+            return original_get(**kwargs)
+
+        with (
+            patch.object(col, "get", side_effect=_tracking_get),
+            patch.object(t3_db._client, "get_collection", return_value=col),
+        ):
+            reidentify_collection(t3_db, coll, dry_run=False)
+
+        assert get_calls
+        for call in get_calls:
+            limit = call.get("limit")
+            if limit is not None:
+                assert limit <= 300, (
+                    f"col.get called with limit={limit} > 300 (quota violation)"
+                )
+
+    def test_delete_batch_size_never_exceeds_300(self, t3_db):
+        """col.delete is called with batches of <= 300 IDs."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        # Seed 5 chunks (well under 300) and assert delete batches are bounded.
+        for i in range(5):
+            _seed_chunk(
+                t3_db, collection=coll, chunk_id=f"legacy-{i}",
+                content=f"content-{i}",
+                chunk_text_hash=f"{i:064x}",
+            )
+
+        col = t3_db._client.get_or_create_collection(coll)
+        original_delete = col.delete
+        delete_calls: list[dict] = []
+
+        def _tracking_delete(**kwargs):
+            delete_calls.append(kwargs)
+            return original_delete(**kwargs)
+
+        with (
+            patch.object(col, "delete", side_effect=_tracking_delete),
+            patch.object(t3_db._client, "get_collection", return_value=col),
+        ):
+            reidentify_collection(t3_db, coll, dry_run=False)
+
+        for call in delete_calls:
+            ids = call.get("ids", [])
+            assert len(ids) <= 300, (
+                f"col.delete called with {len(ids)} ids > 300 (quota violation)"
+            )
+
+
+# ── CLI tests: nx t3 reidentify ──────────────────────────────────────────────
+
+
+class TestReidentifyCLI:
+    """Tests for ``nx t3 reidentify`` CLI command."""
+
+    def test_cli_dry_run_default_writes_nothing(self, t3_db, runner):
+        """--dry-run is the default (defensive); nothing written or deleted."""
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-1",
+            content="hello", chunk_text_hash="5" * 64,
+        )
+
+        with patch(
+            "nexus.commands.t3._make_t3_for_backfill", return_value=t3_db
+        ):
+            result = runner.invoke(
+                main,
+                ["t3", "reidentify", "--collection", coll],
+            )
+        assert result.exit_code == 0, result.output
+        # default is dry-run — old ID still present, new ID absent
+        ids = _ids_in(t3_db, coll)
+        assert "legacy-1" in ids
+        assert "5" * 32 not in ids
+
+    def test_cli_no_dry_run_migrates(self, t3_db, runner):
+        """--no-dry-run actually migrates chunks."""
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-1",
+            content="hello", chunk_text_hash="6" * 64,
+        )
+
+        with patch(
+            "nexus.commands.t3._make_t3_for_backfill", return_value=t3_db
+        ):
+            result = runner.invoke(
+                main,
+                ["t3", "reidentify", "--collection", coll, "--no-dry-run"],
+            )
+        assert result.exit_code == 0, result.output
+        ids = _ids_in(t3_db, coll)
+        assert "legacy-1" not in ids
+        assert "6" * 32 in ids
+
+    def test_cli_all_collections_iterates(self, t3_db, runner):
+        """--all-collections iterates every T3 collection.
+
+        We narrow the CLI's view via a mocked list_collections() so the
+        test isn't polluted by ephemeral-client state shared with sibling
+        tests (project memory: chromadb.EphemeralClient instances share
+        an in-memory backend singleton).
+        """
+        coll_a = _unique_coll()
+        coll_b = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll_a, chunk_id="legacy-A",
+            content="a", chunk_text_hash="7" * 64,
+        )
+        _seed_chunk(
+            t3_db, collection=coll_b, chunk_id="legacy-B",
+            content="b", chunk_text_hash="8" * 64,
+        )
+
+        with (
+            patch(
+                "nexus.commands.t3._make_t3_for_backfill", return_value=t3_db
+            ),
+            patch.object(
+                t3_db,
+                "list_collections",
+                return_value=[
+                    {"name": coll_a, "count": 1},
+                    {"name": coll_b, "count": 1},
+                ],
+            ),
+        ):
+            result = runner.invoke(
+                main,
+                ["t3", "reidentify", "--all-collections", "--no-dry-run"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "7" * 32 in _ids_in(t3_db, coll_a)
+        assert "8" * 32 in _ids_in(t3_db, coll_b)
+
+    def test_cli_taxonomy_skipped_in_output(self, t3_db, runner):
+        """taxonomy__* collections are reported as skipped in output."""
+        coll = _unique_coll(prefix="taxonomy")
+        col = t3_db._client.get_or_create_collection(coll)
+        col.add(
+            ids=["centroid-1"],
+            documents=["centroid"],
+            metadatas=[{"centroid_hash": "abc"}],
+        )
+
+        with patch(
+            "nexus.commands.t3._make_t3_for_backfill", return_value=t3_db
+        ):
+            result = runner.invoke(
+                main,
+                ["t3", "reidentify", "--collection", coll, "--no-dry-run"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "skip" in result.output.lower()
+
+    def test_cli_missing_hash_exits_nonzero(self, t3_db, runner):
+        """Missing chunk_text_hash causes the CLI to exit with non-zero status."""
+        coll = _unique_coll()
+        col = t3_db._client.get_or_create_collection(coll)
+        col.add(
+            ids=["legacy-noh"],
+            documents=["pre-RDR-053"],
+            metadatas=[{"doc_id": "1.1.1", "chunk_index": 0}],
+        )
+
+        with patch(
+            "nexus.commands.t3._make_t3_for_backfill", return_value=t3_db
+        ):
+            result = runner.invoke(
+                main,
+                ["t3", "reidentify", "--collection", coll, "--no-dry-run"],
+            )
+        assert result.exit_code != 0
+        assert "chunk_text_hash" in result.output.lower()
+
+    def test_cli_requires_collection_or_all(self, t3_db, runner):
+        """Either --collection or --all-collections must be specified."""
+        with patch(
+            "nexus.commands.t3._make_t3_for_backfill", return_value=t3_db
+        ):
+            result = runner.invoke(main, ["t3", "reidentify"])
+        # Either a non-zero exit or an explanatory message
+        assert result.exit_code != 0 or "collection" in result.output.lower()

--- a/tests/test_t3_reidentify.py
+++ b/tests/test_t3_reidentify.py
@@ -355,6 +355,86 @@ class TestReidentifyCollection:
         assert result.chunks_migrated == 0
         assert result.chunks_deleted == 0
 
+    def test_cross_batch_collapse_dedupes_correctly(self, t3_db):
+        """Identical chunk_text_hash across pass-2 batches still collapses.
+
+        The seen_new_ids set is initialized outside the batch loop so the
+        collapse path works across batch boundaries. With page_size=2 and
+        three duplicates, the first batch upserts the new id; the second
+        and third batches see new_id in seen_new_ids and skip the upsert
+        but still add their cids to seen_old_ids for deletion.
+        """
+        from nexus.db import t3_reidentify
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll()
+        for i in range(3):
+            _seed_chunk(
+                t3_db, collection=coll, chunk_id=f"legacy-{i}",
+                content="duplicate", chunk_text_hash="d" * 64,
+            )
+
+        with patch.object(t3_reidentify, "_PAGE_SIZE", 2):
+            result = reidentify_collection(t3_db, coll, dry_run=False)
+
+        ids = _ids_in(t3_db, coll)
+        assert ids == {"d" * 32}
+        # All three old cids deleted, even though only one upsert fired.
+        assert result.chunks_deleted == 3
+        assert result.chunks_migrated == 1
+
+    def test_missing_hash_in_non_first_batch_propagates(self, t3_db):
+        """MissingChunkHashError raises from any batch, not only batch 1.
+
+        Patches _PAGE_SIZE=1 and seeds two chunks with the bad chunk
+        second so the error fires from pass-2 iteration after a
+        successful first batch.
+        """
+        from nexus.db import t3_reidentify
+        from nexus.db.t3_reidentify import (
+            MissingChunkHashError,
+            reidentify_collection,
+        )
+
+        coll = _unique_coll()
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-good",
+            content="ok", chunk_text_hash="a" * 64,
+        )
+        col = t3_db._client.get_or_create_collection(coll)
+        col.add(
+            ids=["legacy-bad"],
+            documents=["pre-RDR-053"],
+            metadatas=[{"doc_id": "1.1.1"}],  # no chunk_text_hash
+        )
+
+        with patch.object(t3_reidentify, "_PAGE_SIZE", 1):
+            with pytest.raises(MissingChunkHashError) as exc_info:
+                reidentify_collection(t3_db, coll, dry_run=False)
+        assert "legacy-bad" in str(exc_info.value)
+
+    def test_missing_hash_raises_in_dry_run(self, t3_db):
+        """Dry-run does not suppress the missing-hash error.
+
+        The fail-loud contract (re-gate S3) must hold even when no
+        writes are scheduled. The error fires before the dry-run guard.
+        """
+        from nexus.db.t3_reidentify import (
+            MissingChunkHashError,
+            reidentify_collection,
+        )
+
+        coll = _unique_coll()
+        col = t3_db._client.get_or_create_collection(coll)
+        col.add(
+            ids=["legacy-noh"],
+            documents=["pre-RDR-053"],
+            metadatas=[{"doc_id": "1.1.1"}],
+        )
+
+        with pytest.raises(MissingChunkHashError):
+            reidentify_collection(t3_db, coll, dry_run=True)
+
 
 class TestReidentifyPagination:
     """Verify quota compliance: page size <= 300, batch deletes <= 300."""
@@ -593,5 +673,74 @@ class TestReidentifyCLI:
             "nexus.commands.t3._make_t3_for_backfill", return_value=t3_db
         ):
             result = runner.invoke(main, ["t3", "reidentify"])
-        # Either a non-zero exit or an explanatory message
-        assert result.exit_code != 0 or "collection" in result.output.lower()
+        assert result.exit_code != 0
+        assert "collection" in result.output.lower()
+
+    def test_cli_rejects_both_collection_and_all(self, t3_db, runner):
+        """--collection and --all-collections together raise UsageError."""
+        with patch(
+            "nexus.commands.t3._make_t3_for_backfill", return_value=t3_db
+        ):
+            result = runner.invoke(
+                main,
+                ["t3", "reidentify", "--collection", "x", "--all-collections"],
+            )
+        assert result.exit_code != 0
+        assert "exactly one" in result.output.lower()
+
+    def test_cli_all_collections_continues_past_errors(self, t3_db, runner):
+        """--all-collections accumulates errors and exits nonzero,
+        but processes every collection in the iteration first.
+
+        Mixes a taxonomy carve-out, a valid collection, and a hashless
+        collection. The valid one must migrate, the taxonomy one must
+        be reported skipped, and the hashless one must surface the
+        structured error and force exit_code != 0.
+        """
+        coll_valid = _unique_coll()
+        coll_tax = _unique_coll(prefix="taxonomy")
+        coll_bad = _unique_coll()
+
+        _seed_chunk(
+            t3_db, collection=coll_valid, chunk_id="legacy-valid",
+            content="hello", chunk_text_hash="9" * 64,
+        )
+        col_tax = t3_db._client.get_or_create_collection(coll_tax)
+        col_tax.add(
+            ids=["centroid-1"],
+            documents=["centroid"],
+            metadatas=[{"centroid_hash": "abc"}],
+        )
+        col_bad = t3_db._client.get_or_create_collection(coll_bad)
+        col_bad.add(
+            ids=["legacy-noh"],
+            documents=["pre-RDR-053"],
+            metadatas=[{"doc_id": "1.1.1"}],
+        )
+
+        with (
+            patch(
+                "nexus.commands.t3._make_t3_for_backfill", return_value=t3_db
+            ),
+            patch.object(
+                t3_db,
+                "list_collections",
+                return_value=[
+                    {"name": coll_valid, "count": 1},
+                    {"name": coll_tax, "count": 1},
+                    {"name": coll_bad, "count": 1},
+                ],
+            ),
+        ):
+            result = runner.invoke(
+                main,
+                ["t3", "reidentify", "--all-collections", "--no-dry-run"],
+            )
+
+        assert result.exit_code != 0  # error present
+        # Valid collection migrated despite the bad one's error
+        assert "9" * 32 in _ids_in(t3_db, coll_valid)
+        # Taxonomy reported skipped
+        assert "skip" in result.output.lower()
+        # Bad collection surfaced the structured error
+        assert "chunk_text_hash" in result.output.lower()


### PR DESCRIPTION
RDR-108 Phase 2 — re-identify every T3 chunk under `chunk_text_hash[:32]` as its natural ID.

## Summary

- New module `src/nexus/db/t3_reidentify.py` with `reidentify_collection()` + `MissingChunkHashError` + `ReidentifyResult`.
- New verb `nx t3 reidentify (-c COLLECTION | --all-collections) [--no-dry-run]` in `src/nexus/commands/t3.py`.
- Per-collection paginated loop following RDR-108 RF-6: paginate T3 (300/op), compute `new_id = meta["chunk_text_hash"][:32]`, re-upsert under new id with the existing embedding (RF-2: no Voyage call), strip `doc_id`/`chunk_index`/`chunk_count` from metadata, batch-delete old ids in groups of 300.
- Idempotent (zero-write on fully-migrated collection) and crash-resumable.
- Carve-outs: `taxonomy__*` skipped by name prefix; missing `chunk_text_hash` raises `MissingChunkHashError` (re-gate S3 contract).
- Within-page identical-text collapse handled: chromadb upsert rejects duplicate ids in a single call, so the second occurrence is dropped from the upsert batch but its old id still gets collected and deleted.

## Test plan

- [x] Unit: 13 tests cover happy path, idempotency, partial-resume, byte-identical embedding round-trip, metadata strip, taxonomy skip, missing-hash error, cross-collection independence, within-collection collapse, dry-run, absent-collection.
- [x] Pagination: 2 tests verify `col.get(limit=…)` <= 300 and `col.delete(ids=…)` batch <= 300.
- [x] CLI: 6 tests cover `--collection`, `--all-collections`, default-dry-run, `--no-dry-run`, taxonomy skip output, missing-hash exit-nonzero, mutual-exclusion of flags.
- [x] Regression sweep `uv run pytest tests/ -k "t3 or catalog"`: 1360 passed, 1 skipped, 1 xfailed (no new failures).
- [x] Plugin structure tests: 576 passed, 26 skipped.
- [x] CLI help (`nx t3 reidentify --help`) renders correctly.

## Closes

Closes nexus-jc63