### PR TITLE
feat(metadata): drop doc_id/chunk_index/chunk_count from chunk schema (nexus-bdag)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1517,6 +1517,12 @@ class Catalog:
         """
         return self._writes.write_manifest(doc_id, chunks)
 
+    def append_manifest_chunks(self, doc_id: str, chunks: list[dict]) -> None:
+        """UPSERT manifest rows for one document (RDR-108 Phase 3,
+        nexus-bdag). Use from per-batch hook contexts; see
+        :meth:`_WriteOps.append_manifest_chunks` for the contract."""
+        return self._writes.append_manifest_chunks(doc_id, chunks)
+
     def get_manifest(self, doc_id: str) -> list[_ManifestRow]:
         """Return ordered manifest rows for ``doc_id`` (nexus-572g K6)."""
         return self._writes.get_manifest(doc_id)

--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -575,6 +575,35 @@ class CatalogDB:
         same transaction makes the atomicity invariant trivially
         true regardless of caller ordering.
         """
+        # RDR-108 Phase 3 (nexus-bdag): ``document_chunks`` is FK-bound
+        # to ``documents`` with ON DELETE CASCADE. The DELETE FROM
+        # documents below would cascade-wipe the manifest, but the
+        # projector does not re-emit ``ChunkIndexed`` rows during
+        # legacy replay (the manifest is populated by the post-store
+        # batch hook, not by the JSONL log yet). Disable FK enforcement
+        # around the DELETE+reload so the cascade doesn't fire; INSERTs
+        # restore valid references and we re-enable FK afterwards.
+        # PRAGMA foreign_keys is a no-op within a transaction, so it
+        # must run BEFORE the ``with self._conn:`` block opens its
+        # transaction.
+        self._conn.execute("PRAGMA foreign_keys=OFF")
+        try:
+            self._rebuild_inner(owners, documents, links, consistency_mtime=consistency_mtime)
+        finally:
+            self._conn.execute("PRAGMA foreign_keys=ON")
+
+        _log.debug("catalog_db.rebuild", owners=len(owners), documents=len(documents), links=len(links))
+
+    def _rebuild_inner(
+        self,
+        owners: dict[str, OwnerRecord],
+        documents: dict[str, DocumentRecord],
+        links: list[LinkRecord],
+        *,
+        consistency_mtime: float | None,
+    ) -> None:
+        """Inner rebuild routine called by :meth:`rebuild` with FK
+        enforcement disabled around it (RDR-108 Phase 3)."""
         with self._lock, self._conn, self.bulk_load_documents():
             # Delete from base tables. Triggers are dropped for the
             # duration of the bulk_load_documents fence; FTS5 is
@@ -657,8 +686,6 @@ class CatalogDB:
                     "INSERT OR REPLACE INTO _meta (key, value) VALUES (?, ?)",
                     ("last_consistency_mtime", f"{consistency_mtime}"),
                 )
-
-        _log.debug("catalog_db.rebuild", owners=len(owners), documents=len(documents), links=len(links))
 
     def next_document_number(self, owner_prefix: str) -> int:
         """Max document number for owner + 1.

--- a/src/nexus/catalog/catalog_sync.py
+++ b/src/nexus/catalog/catalog_sync.py
@@ -523,43 +523,63 @@ class _SyncOps:
                             "rebuilding projection",
                             summary_builder=_summary_full,
                         ):
-                            with cat._db.transaction() as conn:
-                                with cat._db.bulk_load_documents():
-                                    conn.execute("DELETE FROM links")
-                                    conn.execute("DELETE FROM documents")
-                                    conn.execute("DELETE FROM owners")
-                                    # Step 0 (Critical #1): see the
-                                    # earlier comment for the rationale
-                                    # and why the COALESCE in
-                                    # _v0_collection_created is
-                                    # retained for the degraded-path
-                                    # retry case (Round 3 Significant
-                                    # #1).
-                                    conn.execute("DELETE FROM collections")
-                                    # commit=False — the transaction
-                                    # context owns the commit boundary;
-                                    # a nested commit() would defeat
-                                    # the rollback fence.
-                                    cat._projector.apply_all(
-                                        EventLog(cat._dir).replay(),
-                                        commit=False,
+                            # RDR-108 Phase 3 (nexus-bdag):
+                            # ``document_chunks`` is FK-bound to
+                            # ``documents`` with ON DELETE CASCADE.
+                            # The DELETE+replay rebuild below would
+                            # cascade-wipe the manifest, but the
+                            # projector does not re-emit ``ChunkIndexed``
+                            # rows during replay (the manifest is
+                            # populated by the post-store batch hook,
+                            # not by the event log yet). Disable FK
+                            # enforcement around the rebuild so the
+                            # cascade doesn't fire; INSERTs restore
+                            # valid references and we re-enable FK
+                            # afterwards. PRAGMA foreign_keys is a no-op
+                            # within a transaction so it must run BEFORE
+                            # ``transaction()`` opens its block.
+                            cat._db._conn.execute("PRAGMA foreign_keys=OFF")
+                            try:
+                                with cat._db.transaction() as conn:
+                                    with cat._db.bulk_load_documents():
+                                        conn.execute("DELETE FROM links")
+                                        conn.execute("DELETE FROM documents")
+                                        conn.execute("DELETE FROM owners")
+                                        # Step 0 (Critical #1): see the
+                                        # earlier comment for the
+                                        # rationale and why the COALESCE
+                                        # in ``_v0_collection_created``
+                                        # is retained for the
+                                        # degraded-path retry case
+                                        # (Round 3 Significant #1).
+                                        conn.execute("DELETE FROM collections")
+                                        # commit=False — the transaction
+                                        # context owns the commit
+                                        # boundary; a nested commit()
+                                        # would defeat the rollback
+                                        # fence.
+                                        cat._projector.apply_all(
+                                            EventLog(cat._dir).replay(),
+                                            commit=False,
+                                        )
+                                    # 4.24.4 atomicity contract: marker
+                                    # writes happen INSIDE the same
+                                    # transaction as the projection writes.
+                                    # The transaction context commits all
+                                    # rows atomically on success, rolls
+                                    # them all back together on any
+                                    # exception. Pre-4.24.4 the marker
+                                    # write lived OUTSIDE this block in
+                                    # _write_consistency_marker()'s own
+                                    # commit(), a refactoring hazard.
+                                    cat._write_consistency_marker(current_mtime)
+                                    cat._write_offset_marker(
+                                        offset=eof_offset_now,
+                                        header_hash=header_hash_now,
+                                        window=_cat_mod._HEADER_HASH_BYTES,
                                     )
-                                # 4.24.4 atomicity contract: marker
-                                # writes happen INSIDE the same
-                                # transaction as the projection writes.
-                                # The transaction context commits all
-                                # rows atomically on success, rolls
-                                # them all back together on any
-                                # exception. Pre-4.24.4 the marker
-                                # write lived OUTSIDE this block in
-                                # _write_consistency_marker()'s own
-                                # commit(), a refactoring hazard.
-                                cat._write_consistency_marker(current_mtime)
-                                cat._write_offset_marker(
-                                    offset=eof_offset_now,
-                                    header_hash=header_hash_now,
-                                    window=_cat_mod._HEADER_HASH_BYTES,
-                                )
+                            finally:
+                                cat._db._conn.execute("PRAGMA foreign_keys=ON")
             else:
                 owners = read_owners(cat._owners_path) if cat._owners_path.exists() else {}
                 documents = read_documents(cat._documents_path) if cat._documents_path.exists() else {}

--- a/src/nexus/catalog/catalog_writes.py
+++ b/src/nexus/catalog/catalog_writes.py
@@ -508,18 +508,31 @@ class _WriteOps:
                 cat._append_jsonl(cat._documents_path, rec_dict)
             else:
                 cat._append_jsonl(cat._documents_path, rec_dict)
-                # Upsert SQLite. ``alias_of`` is included in the column
-                # list because INSERT OR REPLACE on the tumbler PK
-                # deletes the prior row before inserting; omitting the
-                # column would let the new row carry the column default
-                # (NULL) instead of the prior alias pointer, silently
-                # severing the alias graph on every update().
+                # Upsert SQLite via INSERT ... ON CONFLICT DO UPDATE.
+                #
+                # RDR-108 Phase 3 (nexus-bdag): the prior ``INSERT OR
+                # REPLACE`` form deleted the existing row before
+                # inserting, which cascaded ``ON DELETE CASCADE`` to
+                # wipe the ``document_chunks`` manifest every time the
+                # post-store ``_catalog_pdf_hook`` / markdown hook fired
+                # cat.update() after the per-batch manifest_write_hook.
+                # The ON CONFLICT DO UPDATE pattern updates in place so
+                # no cascade fires.
                 cat._db.execute(
-                    "INSERT OR REPLACE INTO documents "
+                    "INSERT INTO documents "
                     "(tumbler, title, author, year, content_type, file_path, "
                     "corpus, physical_collection, chunk_count, head_hash, indexed_at, "
                     "metadata, source_mtime, source_uri, alias_of) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                    "ON CONFLICT(tumbler) DO UPDATE SET "
+                    "title=excluded.title, author=excluded.author, "
+                    "year=excluded.year, content_type=excluded.content_type, "
+                    "file_path=excluded.file_path, corpus=excluded.corpus, "
+                    "physical_collection=excluded.physical_collection, "
+                    "chunk_count=excluded.chunk_count, head_hash=excluded.head_hash, "
+                    "indexed_at=excluded.indexed_at, metadata=excluded.metadata, "
+                    "source_mtime=excluded.source_mtime, "
+                    "source_uri=excluded.source_uri, alias_of=excluded.alias_of",
                     (
                         rec_dict["tumbler"], rec_dict["title"], rec_dict["author"],
                         rec_dict["year"], rec_dict["content_type"], rec_dict["file_path"],

--- a/src/nexus/catalog/catalog_writes.py
+++ b/src/nexus/catalog/catalog_writes.py
@@ -518,6 +518,18 @@ class _WriteOps:
                 # cat.update() after the per-batch manifest_write_hook.
                 # The ON CONFLICT DO UPDATE pattern updates in place so
                 # no cascade fires.
+                #
+                # NOTE: the SET clause lists every column that
+                # ``cat.update()`` is expected to refresh. ``bib_*``
+                # columns are intentionally NOT in the list — under the
+                # prior ``INSERT OR REPLACE`` form, every catalog
+                # update implicitly reset bibliographic enrichment to
+                # the column defaults (because REPLACE deletes-and-
+                # re-inserts), which silently lost any ``nx enrich``
+                # data on every re-index. ON CONFLICT DO UPDATE
+                # preserves the pre-existing bib_* values: the only
+                # writer to those columns becomes the explicit
+                # ``BibliographicEnriched`` event handler.
                 cat._db.execute(
                     "INSERT INTO documents "
                     "(tumbler, title, author, year, content_type, file_path, "
@@ -719,6 +731,11 @@ class _WriteOps:
         operations driven by the backfill verb, not by the dual-write
         event-sourcing machinery. The FK constraint (doc_id REFERENCES
         documents.tumbler) is enforced by the SQLite connection.
+
+        Use :meth:`append_manifest_chunks` instead from per-batch hook
+        contexts; this method's DELETE-then-INSERT semantic truncates the
+        manifest when called multiple times for the same doc_id (the
+        intentional behaviour for backfill / full rebuild).
         """
         cat = self._cat
         with cat._db.transaction():
@@ -739,6 +756,63 @@ class _WriteOps:
                     "(doc_id, position, chash, chunk_index, "
                     " line_start, line_end, char_start, char_end) "
                     "VALUES " + ", ".join(["(?, ?, ?, ?, ?, ?, ?, ?)"] * len(batch)),
+                    [
+                        val
+                        for c in batch
+                        for val in (
+                            doc_id,
+                            c["position"],
+                            c["chash"],
+                            c.get("chunk_index"),
+                            c.get("line_start"),
+                            c.get("line_end"),
+                            c.get("char_start"),
+                            c.get("char_end"),
+                        )
+                    ],
+                )
+
+    def append_manifest_chunks(self, doc_id: str, chunks: list[dict]) -> None:
+        """UPSERT manifest rows for one document without deleting prior rows
+        (RDR-108 Phase 3, nexus-bdag).
+
+        ``write_manifest`` clears the doc_id's rows before inserting, which
+        truncates the manifest when called multiple times for the same
+        document — the failure mode for the streaming PDF uploader and
+        the doc_indexer incremental path, both of which fire the
+        per-batch hook once per upload batch (~128 chunks). For documents
+        with more than one batch, the second batch's ``write_manifest``
+        call deletes the first batch's rows.
+
+        ``append_manifest_chunks`` keeps the prior rows in place and
+        upserts on the ``(doc_id, position)`` primary key, so callers
+        that fire it once per batch accumulate the manifest correctly.
+        Re-indexing with fewer chunks than before may leave orphan rows
+        at higher positions; the post-document hook (fired once per
+        document at the tail of every indexing call) is responsible for
+        the final shape and may call ``write_manifest`` to replace.
+
+        Each chunk dict has the same keys as :meth:`write_manifest`.
+        """
+        if not chunks:
+            return
+        cat = self._cat
+        with cat._db.transaction():
+            _batch = 300
+            for i in range(0, len(chunks), _batch):
+                batch = chunks[i : i + _batch]
+                cat._db.execute(
+                    "INSERT INTO document_chunks "
+                    "(doc_id, position, chash, chunk_index, "
+                    " line_start, line_end, char_start, char_end) "
+                    "VALUES " + ", ".join(["(?, ?, ?, ?, ?, ?, ?, ?)"] * len(batch))
+                    + " ON CONFLICT(doc_id, position) DO UPDATE SET "
+                    "chash=excluded.chash, "
+                    "chunk_index=excluded.chunk_index, "
+                    "line_start=excluded.line_start, "
+                    "line_end=excluded.line_end, "
+                    "char_start=excluded.char_start, "
+                    "char_end=excluded.char_end",
                     [
                         val
                         for c in batch

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -193,12 +193,27 @@ class Projector:
             _log.warning("projector_document_registered_no_tumbler",
                          payload=payload)
             return
+        # RDR-108 Phase 3 (nexus-bdag): use ON CONFLICT DO UPDATE rather
+        # than INSERT OR REPLACE so the FK ``ON DELETE CASCADE`` from
+        # ``document_chunks → documents`` does not wipe the manifest on
+        # every projector replay (INSERT OR REPLACE deletes-then-inserts
+        # the row, triggering the cascade; ON CONFLICT DO UPDATE updates
+        # in place).
         self._db.execute(
-            "INSERT OR REPLACE INTO documents "
+            "INSERT INTO documents "
             "(tumbler, title, author, year, content_type, file_path, "
             "corpus, physical_collection, chunk_count, head_hash, "
             "indexed_at, metadata, source_mtime, alias_of, source_uri) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(tumbler) DO UPDATE SET "
+            "title=excluded.title, author=excluded.author, "
+            "year=excluded.year, content_type=excluded.content_type, "
+            "file_path=excluded.file_path, corpus=excluded.corpus, "
+            "physical_collection=excluded.physical_collection, "
+            "chunk_count=excluded.chunk_count, head_hash=excluded.head_hash, "
+            "indexed_at=excluded.indexed_at, metadata=excluded.metadata, "
+            "source_mtime=excluded.source_mtime, alias_of=excluded.alias_of, "
+            "source_uri=excluded.source_uri",
             (
                 tumbler,
                 payload.title,

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -198,7 +198,13 @@ class Projector:
         # ``document_chunks → documents`` does not wipe the manifest on
         # every projector replay (INSERT OR REPLACE deletes-then-inserts
         # the row, triggering the cascade; ON CONFLICT DO UPDATE updates
-        # in place).
+        # in place). The SET clause lists exactly the columns that
+        # ``DocumentRegistered`` payloads carry; ``bib_*`` columns are
+        # intentionally absent so projector replay does not clobber
+        # bibliographic enrichment written by the
+        # ``BibliographicEnriched`` event handler — a behavioural
+        # divergence from the prior INSERT OR REPLACE which reset bib_*
+        # to defaults on every replay.
         self._db.execute(
             "INSERT INTO documents "
             "(tumbler, title, author, year, content_type, file_path, "

--- a/src/nexus/code_indexer.py
+++ b/src/nexus/code_indexer.py
@@ -345,7 +345,6 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
     if not chunks:
         _log.debug("skipped file with no chunks", path=str(file_path))
         return 0
-    total_chunks = len(chunks)
 
     ids: list[str] = []
     documents: list[str] = []
@@ -366,8 +365,10 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
     from nexus.metadata_schema import make_chunk_metadata  # noqa: PLC0415
 
     # Catalog Document.doc_id (RDR-101 Phase 3 PR δ): resolved once per
-    # file. Empty string when no catalog handle exists; ``normalize``
-    # Step 4c drops the field on the way to T3.
+    # file. Empty string when no catalog handle exists. RDR-108 Phase 3
+    # removed doc_id from chunk metadata; the catalog tumbler now flows
+    # through the post-store batch hook instead so the manifest can
+    # bind chunks to the document at write time.
     catalog_doc_id = (
         ctx.doc_id_resolver(file_path) if ctx.doc_id_resolver is not None else ""
     )
@@ -400,11 +401,11 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
         section_type = "method" if method_ctx else ("class" if class_ctx else "")
         # RDR-101 Phase 5c (nexus-o6aa.13) dropped corpus, store_type,
         # git_meta from the chunk schema. Title kept (find_ids_by_title
-        # is load-bearing for nx store / MCP store_get).
+        # is load-bearing for nx store / MCP store_get). RDR-108 Phase 3
+        # (nexus-bdag) dropped chunk_index, chunk_count, doc_id —
+        # catalog manifest is authoritative.
         metadata = make_chunk_metadata(
             content_type="code",
-            chunk_index=chunk.get("chunk_index", i),
-            chunk_count=chunk.get("chunk_count", total_chunks),
             chunk_text_hash=_hl.sha256(chunk["text"].encode()).hexdigest(),
             content_hash=content_hash,
             chunk_start_char=chunk_start_char,
@@ -419,7 +420,6 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
             tags=ext.lstrip("."),
             category="code",
             frecency_score=float(ctx.score),
-            doc_id=catalog_doc_id,
         )
         ids.append(chunk_chroma_id)
         documents.append(chunk["text"])
@@ -482,6 +482,7 @@ def index_code_file(ctx: IndexContext, file_path: Path) -> int:
         )
         fire_post_store_batch_hooks(
             ids, ctx.corpus, documents, embeddings, metadatas,
+            catalog_doc_id=catalog_doc_id,
         )
         for _did, _doc in zip(ids, documents):
             fire_post_store_hooks(_did, ctx.corpus, _doc)

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -714,16 +714,16 @@ class T3Database:
                 content_type = ct
                 break
 
-        # MCP-stored docs are single-chunk: chunk_index=0, chunk_count=1,
-        # chunk_text_hash matches content_hash because content == chunk text.
+        # MCP-stored docs are single-chunk: chunk_text_hash matches
+        # content_hash because content == chunk text.
         content_hash = hashlib.sha256(content.encode()).hexdigest()
         # RDR-101 Phase 5c dropped store_type, corpus, git_meta. Title kept
         # — find_ids_by_title is the load-bearing reader for nx store
-        # delete --title and MCP store_get title-fallback.
+        # delete --title and MCP store_get title-fallback. RDR-108 Phase 3
+        # dropped chunk_index, chunk_count, doc_id — catalog manifest is
+        # authoritative.
         metadata = make_chunk_metadata(
             content_type=content_type,
-            chunk_index=0,
-            chunk_count=1,
             chunk_text_hash=content_hash,
             content_hash=content_hash,
             chunk_start_char=0,
@@ -736,7 +736,6 @@ class T3Database:
             ttl_days=ttl_days,
             source_agent=source_agent,
             session_id=session_id,
-            doc_id=catalog_doc_id,
         )
 
         # ``put`` is the operator / MCP single-document write path. The

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -1213,6 +1213,17 @@ class T3Database:
         reader migration). Paginates ``col.get()`` to respect the ChromaDB
         Cloud 300-record limit. Returns empty list if the collection does
         not exist.
+
+        **RDR-108 Phase 3 caveat (nexus-bdag)**: chunks written after
+        Phase 3 do not carry ``doc_id`` in their metadata, so the
+        ``where={"doc_id": ...}`` filter returns empty for them.
+        Callers that need the doc_id → chunk_id mapping for Phase-3
+        chunks should consult the catalog ``document_chunks`` manifest
+        (``Catalog.get_manifest(doc_id)``) and resolve chash → chunk
+        via ``chash_index`` instead. RDR-108 Phase 4 retargets every
+        in-tree caller (prune paths, search filters, aspect readers)
+        to the manifest-based lookup; this method is retained for
+        legacy reads against pre-Phase-3 chunks.
         """
         try:
             col = self._client_for(collection_name).get_collection(collection_name)
@@ -1242,6 +1253,14 @@ class T3Database:
         Companion to :meth:`delete_by_source` (RDR-101 Phase 4 reader
         migration). Uses paginated ``col.get()`` keyed on ``doc_id`` to
         avoid the ChromaDB Cloud 300-record truncation limit.
+
+        **RDR-108 Phase 3 caveat (nexus-bdag)**: chunks written after
+        Phase 3 do not carry ``doc_id`` in their metadata; this method
+        silently returns 0 for those chunks. The Phase 4 prune rewrite
+        (nexus-mmf5 family) consults the catalog manifest to resolve
+        chunk IDs by chash and deletes via ``_delete_batch`` directly.
+        Pre-Phase-3 chunks (still present in T3 until the operator runs
+        ``nx t3 reidentify --all-collections``) keep working unchanged.
         """
         try:
             col = self._client_for(collection_name).get_collection(collection_name)

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -810,6 +810,18 @@ def _index_pdf_incremental(
         # Upsert
         t3.upsert_chunks_with_embeddings(collection_name, batch_ids, batch_docs, embeddings, batch_metas)
 
+        # RDR-108 Phase 3: inject the global chunk_index per row before
+        # firing the batch chain. ``batch_metas`` came from
+        # ``make_chunk_metadata`` (post-Phase-3, no chunk_index); the
+        # incremental loop slices ``metadatas_all[batch_start:batch_end]``
+        # so the per-row global index is ``batch_start + i``. Without
+        # this injection the manifest hook defaults to a batch-local
+        # enumeration that resets to 0 each batch, truncating the
+        # manifest. T3 already received the post-Phase-3 metadata; the
+        # local copy mutation here only affects the hook payload.
+        for _i, _meta in enumerate(batch_metas):
+            _meta["chunk_index"] = batch_start + _i
+
         # Post-store hook chains (RDR-095). Both single-doc and batch
         # chains fire from every storage event; the per-doc loop covers
         # single-shape consumers on CLI ingest.

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -104,17 +104,15 @@ def _lookup_existing_doc_id(file_path: str, corpus: str) -> str:
 def _identity_where(file_path: str, corpus: str, *, content_hash: str = "") -> dict:
     """nexus-dcym: chunk-identity where-filter for incremental sync sites.
 
-    Prefers a ``doc_id``-keyed lookup when the catalog already has an
-    entry for *file_path* under *corpus*. RDR-101 Phase 5c removed
-    ``source_path`` from chunk metadata, so the staleness fallback
-    keys on *content_hash* when the catalog is absent (e.g. local-mode
-    ingest without a catalog initialised). Pass ``content_hash`` only
-    for staleness checks — pruning by content_hash is incorrect because
-    matching chunks are by definition not stale.
+    RDR-108 Phase 3 retired ``doc_id`` from chunk metadata (catalog
+    manifest is authoritative); ``content_hash`` is now the canonical
+    staleness key. Pre-Phase-3 chunks still carry ``doc_id`` in stored
+    metadata, but those reads are handled by Phase 4 retargeted readers.
+    Pass ``content_hash`` only for staleness checks — pruning by
+    content_hash is incorrect because matching chunks are by definition
+    not stale; the legacy ``source_path`` fallback is retained for
+    pruning sites pending Phase 4 manifest-driven prune rewrites.
     """
-    doc_id = _lookup_existing_doc_id(file_path, corpus)
-    if doc_id:
-        return {"doc_id": doc_id}
     if content_hash:
         return {"content_hash": content_hash}
     return {"source_path": file_path}
@@ -672,8 +670,10 @@ def _index_document(
         fire_post_store_batch_hooks,
         fire_post_store_hooks,
     )
+    _catalog_doc_id_for_batch = _lookup_existing_doc_id(sp, corpus)
     fire_post_store_batch_hooks(
         ids, collection_name, documents, embeddings, metadatas,
+        catalog_doc_id=_catalog_doc_id_for_batch,
     )
     for _did, _doc in zip(ids, documents):
         fire_post_store_hooks(_did, collection_name, _doc)
@@ -684,7 +684,7 @@ def _index_document(
     # can capture the doc_id alongside source_path.
     fire_post_document_hooks(
         sp, collection_name, "",
-        doc_id=_lookup_existing_doc_id(sp, corpus),
+        doc_id=_catalog_doc_id_for_batch,
     )
 
     # Prune stale chunks from a previous (larger) version of this file.
@@ -779,6 +779,11 @@ def _index_pdf_incremental(
     documents_all = [p[1] for p in prepared]
     metadatas_all = [p[2] for p in prepared]
 
+    # Resolve catalog doc_id once outside the per-batch loop (RDR-108
+    # Phase 3: chunk metadata no longer carries it; manifest hook reads
+    # via the fire_post_store_batch_hooks kwarg).
+    _catalog_doc_id_for_batch = _lookup_existing_doc_id(str(file_path), corpus)
+
     for batch_start in range(start_offset, total, _INCREMENTAL_BATCH_SIZE):
         batch_end = min(batch_start + _INCREMENTAL_BATCH_SIZE, total)
         batch_docs = documents_all[batch_start:batch_end]
@@ -814,6 +819,7 @@ def _index_pdf_incremental(
         )
         fire_post_store_batch_hooks(
             batch_ids, collection_name, batch_docs, embeddings, batch_metas,
+            catalog_doc_id=_catalog_doc_id_for_batch,
         )
         for _did, _doc in zip(batch_ids, batch_docs):
             fire_post_store_hooks(_did, collection_name, _doc)
@@ -943,10 +949,10 @@ def _pdf_chunks(
     for chunk in chunks:
         chunk_id = f"{content_hash[:16]}_{chunk.chunk_index}"
         # RDR-101 Phase 5c dropped corpus, store_type, git_meta. Title kept.
+        # RDR-108 Phase 3 dropped chunk_index, chunk_count, doc_id —
+        # catalog manifest is authoritative.
         meta = make_chunk_metadata(
             content_type="pdf",
-            chunk_index=chunk.chunk_index,
-            chunk_count=len(chunks),
             chunk_text_hash=hashlib.sha256(chunk.text.encode()).hexdigest(),
             content_hash=content_hash,
             chunk_start_char=chunk.metadata.get("chunk_start_char", 0),
@@ -964,7 +970,6 @@ def _pdf_chunks(
             bib_authors=bib.get("authors", ""),
             bib_venue=bib.get("venue", ""),
             bib_citation_count=bib.get("citation_count", 0),
-            doc_id=doc_id,
         )
         prepared.append((chunk_id, chunk.text, meta))
     return prepared
@@ -1028,10 +1033,10 @@ def _markdown_chunks(
     for chunk in chunks:
         chunk_id = f"{content_hash[:16]}_{chunk.chunk_index}"
         # RDR-101 Phase 5c dropped corpus, store_type, git_meta. Title kept.
+        # RDR-108 Phase 3 dropped chunk_index, chunk_count, doc_id —
+        # catalog manifest is authoritative.
         meta = make_chunk_metadata(
             content_type="markdown",
-            chunk_index=chunk.chunk_index,
-            chunk_count=len(chunks),
             chunk_text_hash=hashlib.sha256(chunk.text.encode()).hexdigest(),
             content_hash=content_hash,
             chunk_start_char=chunk.metadata.get("chunk_start_char", 0) + frontmatter_len,
@@ -1045,7 +1050,6 @@ def _markdown_chunks(
             section_type=chunk.metadata.get("section_type", ""),
             tags="markdown",
             category="prose",
-            doc_id=doc_id,
         )
         prepared.append((chunk_id, chunk.text, meta))
     return prepared
@@ -1300,8 +1304,10 @@ def index_pdf(
         fire_post_store_batch_hooks,
         fire_post_store_hooks,
     )
+    _catalog_doc_id_for_batch = _lookup_existing_doc_id(str(pdf_path), corpus)
     fire_post_store_batch_hooks(
         ids, col_name, documents, embeddings, metadatas_list,
+        catalog_doc_id=_catalog_doc_id_for_batch,
     )
     for _did, _doc in zip(ids, documents):
         fire_post_store_hooks(_did, col_name, _doc)
@@ -1311,7 +1317,7 @@ def index_pdf(
     # nexus-tdgc: forward the catalog doc_id post-register.
     fire_post_document_hooks(
         str(pdf_path), col_name, "",
-        doc_id=_lookup_existing_doc_id(str(pdf_path), corpus),
+        doc_id=_catalog_doc_id_for_batch,
     )
 
     # Prune stale chunks (nexus-dcym: doc_id-keyed when catalog has the

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -381,7 +381,16 @@ def check_staleness(
             return False
         return stored == (content_hash, embedding_model)
 
-    where: dict = {"doc_id": doc_id} if doc_id else {"source_path": str(source_file)}
+    # RDR-108 Phase 3 (nexus-bdag): chunks no longer carry ``doc_id`` —
+    # the catalog ``document_chunks`` manifest is authoritative. Query
+    # by ``content_hash`` (a file-level fingerprint that all chunks of
+    # the same file share); falling back to ``source_path`` for legacy
+    # chunks predating RDR-102 D2.
+    where: dict
+    if content_hash:
+        where = {"content_hash": content_hash}
+    else:
+        where = {"source_path": str(source_file)}
     existing = _chroma_with_retry(
         col.get,  # type: ignore[attr-defined]
         where=where,
@@ -395,17 +404,6 @@ def check_staleness(
         stored.get("content_hash") != content_hash
         or stored.get("embedding_model") != embedding_model
     ):
-        return False
-    # nexus-o6aa.10.4 follow-up: ghost-chunk class. Stored chunk
-    # matches content_hash + model but lacks doc_id metadata. The
-    # staleness check would normally return True (skip re-index) and
-    # the ghost would persist forever. When the caller has a non-empty
-    # doc_id resolver result for this file, treat the stored chunk as
-    # metadata-stale so the indexer re-upserts and the ghost gets a
-    # doc_id. Found on Hal's catalog 2026-05-02: 499 chunks indexed
-    # under an old branch when the catalog hook silently failed,
-    # surviving content-hash dedup on every subsequent re-index.
-    if doc_id and not stored.get("doc_id"):
         return False
     return True
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -428,17 +428,15 @@ def _record_tier_write(
 # runs (mirroring the legacy chash-before-taxonomy CLI invariant).
 
 from nexus.mcp_infra import (
-    chash_dual_write_batch_hook,
-    manifest_write_batch_hook,
     register_post_document_hook,
-    register_post_store_batch_hook,
-    taxonomy_assign_batch_hook,
 )
 
-register_post_store_batch_hook(chash_dual_write_batch_hook)
-register_post_store_batch_hook(taxonomy_assign_batch_hook)
-# nexus-572g OBS-3: wire manifest writes into the post-store batch chain
-register_post_store_batch_hook(manifest_write_batch_hook)
+# RDR-108 Phase 3 (nexus-bdag): the three batch hooks
+# (chash_dual_write_batch_hook, taxonomy_assign_batch_hook,
+# manifest_write_batch_hook) now self-register at module load in
+# ``nexus.mcp_infra`` so CLI-only flows (``nx index repo``) also fire
+# them. Pre-Phase-3 the registrations lived here, which silently
+# skipped them for non-MCP code paths.
 
 # RDR-089 follow-up (nexus-qeo8): document-grain hook chain consumer.
 # The synchronous-inline shape was invalidated by the P1.3 spike
@@ -1034,6 +1032,7 @@ def store_put(
         _fire_post_store_hooks(doc_id, col_name, content)
         _fire_post_store_batch_hooks(
             [doc_id], col_name, [content], None, None,
+            catalog_doc_id=catalog_doc_id,
         )
         # RDR-089 document-grain chain — plain sync call (FastMCP wraps
         # this @mcp.tool() body in a thread pool at the framework level;

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -488,6 +488,8 @@ def fire_post_store_batch_hooks(
     contents: list[str],
     embeddings: list[list[float]] | None = None,
     metadatas: list[dict] | None = None,
+    *,
+    catalog_doc_id: str = "",
 ) -> None:
     """Invoke all registered batch hooks. Per-hook failures captured and
     persisted to T2 hook_failures, never raised.
@@ -497,6 +499,14 @@ def fire_post_store_batch_hooks(
     Different consumers read different payload fields:
     chash_dual_write_batch_hook reads metadatas, taxonomy_assign_batch_hook
     reads embeddings. Hooks ignore parameters they don't need.
+
+    *catalog_doc_id* (RDR-108 Phase 3) — catalog ``Document.tumbler``
+    string for the document this batch belongs to. Required by
+    ``manifest_write_batch_hook`` after Phase 3 retired ``doc_id`` from
+    chunk metadata; the manifest hook can no longer derive it from the
+    chunks themselves. Empty string is the "unknown document" sentinel
+    — the manifest hook then falls back to legacy ``meta.doc_id`` reads
+    (still populated on pre-Phase-3 chunks).
     """
     if not doc_ids:
         return
@@ -504,7 +514,20 @@ def fire_post_store_batch_hooks(
     _hook_log = structlog.get_logger()
     for hook in _post_store_batch_hooks:
         try:
-            hook(doc_ids, collection, contents, embeddings, metadatas)
+            try:
+                hook(
+                    doc_ids, collection, contents, embeddings, metadatas,
+                    catalog_doc_id=catalog_doc_id,
+                )
+            except TypeError as type_exc:
+                # Backwards-compat: hooks registered before RDR-108 Phase 3
+                # do not accept the ``catalog_doc_id`` kwarg. Fall back to
+                # the legacy 5-argument call so registered lambdas /
+                # third-party hooks continue to fire. Reraise unrelated
+                # TypeErrors (e.g. wrong arg count for the legacy form).
+                if "catalog_doc_id" not in str(type_exc):
+                    raise
+                hook(doc_ids, collection, contents, embeddings, metadatas)
         except Exception as exc:
             hook_name = getattr(hook, "__name__", "?")
             _hook_log.warning(
@@ -604,6 +627,8 @@ def taxonomy_assign_batch_hook(
     contents: list[str],
     embeddings: list[list[float]] | None,
     metadatas: list[dict] | None,
+    *,
+    catalog_doc_id: str = "",
 ) -> None:
     """Registered batch hook: assign indexed docs to their nearest topics.
 
@@ -731,6 +756,8 @@ def chash_dual_write_batch_hook(
     contents: list[str],
     embeddings: list[list[float]] | None,
     metadatas: list[dict] | None,
+    *,
+    catalog_doc_id: str = "",
 ) -> None:
     """Registered batch hook (RDR-095): best-effort dual-write of
     ``chash_index`` rows after a T3 upsert.
@@ -765,28 +792,38 @@ def manifest_write_batch_hook(
     contents: list[str],
     embeddings: list[list[float]] | None,
     metadatas: list[dict] | None,
+    *,
+    catalog_doc_id: str = "",
 ) -> None:
     """Registered batch hook (nexus-572g OBS-3): write document_chunks manifest
     rows after every T3 upsert so the catalog manifest stays current without
     manual backfill.
 
-    Groups chunk metadatas by ``doc_id``, then calls
-    ``Catalog.write_manifest`` once per document. Best-effort: any failure
-    is logged at debug level and never propagates to the caller.
+    Calls ``Catalog.write_manifest`` once per document. Best-effort: any
+    failure is logged at debug level and never propagates to the caller.
 
-    Reads ``metadatas`` (uses ``chunk_text_hash``, ``chunk_index``,
-    ``chunk_start_char``, ``chunk_end_char`` fields); ignores ``contents``
-    and ``embeddings``.
+    Reads ``metadatas`` (``chunk_text_hash``, ``line_start``, ``line_end``,
+    ``chunk_start_char``, ``chunk_end_char``); ignores ``contents`` and
+    ``embeddings``.
+
+    *catalog_doc_id* (RDR-108 Phase 3) — the catalog ``Document.tumbler``
+    string for the batch's document. Phase 3 retired ``doc_id`` from
+    chunk metadata; the hook now reads it from the outer call context.
+    For pre-Phase-3 chunks (still re-fired during legacy reindexes) the
+    field may also appear in ``meta.doc_id`` — that legacy fallback path
+    preserves correctness during the transition. ``int(m.get("chunk_index", i))``
+    similarly bridges legacy chunks (which carry chunk_index in metadata)
+    and Phase 3 chunks (which use enumeration index within the batch).
     """
     if not metadatas:
         return
     from collections import defaultdict
 
-    by_doc: dict[str, list[dict]] = defaultdict(list)
-    for meta in metadatas:
-        doc_id = meta.get("doc_id", "")
+    by_doc: dict[str, list[tuple[int, dict]]] = defaultdict(list)
+    for i, meta in enumerate(metadatas):
+        doc_id = catalog_doc_id or meta.get("doc_id", "")
         if doc_id:
-            by_doc[doc_id].append(meta)
+            by_doc[doc_id].append((i, meta))
     if not by_doc:
         return
     try:
@@ -795,7 +832,9 @@ def manifest_write_batch_hook(
         import structlog
         structlog.get_logger().debug("manifest_write_hook_no_catalog", exc_info=True)
         return
-    for doc_id, metas in by_doc.items():
+    if cat is None:
+        return
+    for doc_id, indexed_metas in by_doc.items():
         chunks = [
             {
                 "chash": m.get("chunk_text_hash", ""),
@@ -806,7 +845,7 @@ def manifest_write_batch_hook(
                 "char_start": m.get("chunk_start_char") or None,
                 "char_end": m.get("chunk_end_char") or None,
             }
-            for i, m in enumerate(metas)
+            for i, m in indexed_metas
         ]
         if all(not c["chash"] for c in chunks):
             continue
@@ -817,6 +856,22 @@ def manifest_write_batch_hook(
             structlog.get_logger().debug(
                 "manifest_write_hook_failed", doc_id=doc_id, exc_info=True
             )
+
+
+# RDR-108 Phase 3 (nexus-bdag): the three batch hooks above are
+# load-bearing for catalog correctness across BOTH CLI ingest and MCP
+# tool calls (e.g. ``nx index repo`` populates ``chash_index``,
+# ``taxonomy_assignments``, and ``document_chunks`` on the catalog
+# manifest). Pre-Phase-3 the registrations lived in ``nexus.mcp.core``
+# so the hooks fired only when an MCP server started up; CLI-only
+# flows silently skipped them, leaving the catalog manifest empty for
+# ``nx index repo``-only corpora. Registering here at module load
+# keeps both paths honest — every code path that fires the batch
+# chain (every indexer goes through ``mcp_infra.fire_post_store_batch_hooks``)
+# is guaranteed to also have the hooks attached.
+register_post_store_batch_hook(chash_dual_write_batch_hook)
+register_post_store_batch_hook(taxonomy_assign_batch_hook)
+register_post_store_batch_hook(manifest_write_batch_hook)
 
 
 # ── Post-store document hooks (RDR-089, nexus-yyev) ──────────────────────────

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -474,12 +474,42 @@ def _record_hook_failure(
 # captured, persisted to T2 hook_failures, never propagated.
 
 _post_store_batch_hooks: list = []
+#: Set of hook callables that accept the kwarg-only ``catalog_doc_id``
+#: parameter (RDR-108 Phase 3). Populated lazily by
+#: :func:`register_post_store_batch_hook` via
+#: :func:`inspect.signature`. The dispatch in
+#: :func:`fire_post_store_batch_hooks` uses this set to pick the call
+#: shape per hook, avoiding the fragile substring-match-on-TypeError
+#: fallback that the first cut of Phase 3 used.
+_post_store_batch_hooks_with_catalog_doc_id: set = set()
 
 
 def register_post_store_batch_hook(fn) -> None:
-    """Register a callable(doc_ids, collection, contents, embeddings, metadatas)
-    to fire after batch CLI ingest."""
+    """Register a callable(doc_ids, collection, contents, embeddings, metadatas
+    [, *, catalog_doc_id]) to fire after batch CLI ingest.
+
+    The callable's signature is inspected once at registration time so
+    the dispatcher can pick the right call shape — hooks predating
+    RDR-108 Phase 3 do not accept ``catalog_doc_id`` and must be invoked
+    with the legacy 5-argument form.
+    """
     _post_store_batch_hooks.append(fn)
+    try:
+        import inspect
+        sig = inspect.signature(fn)
+        params = sig.parameters
+        # Accept hooks that explicitly name catalog_doc_id OR accept arbitrary
+        # **kwargs (the latter cannot be statically classified, so passthrough
+        # is the conservative choice — no harm if the hook ignores).
+        if "catalog_doc_id" in params or any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+        ):
+            _post_store_batch_hooks_with_catalog_doc_id.add(id(fn))
+    except (TypeError, ValueError):
+        # Built-in or C-extension callable with no introspectable
+        # signature — assume legacy shape so the dispatcher does not
+        # blow up on first call.
+        pass
 
 
 def fire_post_store_batch_hooks(
@@ -514,19 +544,16 @@ def fire_post_store_batch_hooks(
     _hook_log = structlog.get_logger()
     for hook in _post_store_batch_hooks:
         try:
-            try:
+            # RDR-108 Phase 3: pick the call shape per hook based on the
+            # signature classification computed at registration time.
+            # Hooks predating Phase 3 do not accept ``catalog_doc_id``;
+            # we invoke them with the legacy 5-argument shape.
+            if id(hook) in _post_store_batch_hooks_with_catalog_doc_id:
                 hook(
                     doc_ids, collection, contents, embeddings, metadatas,
                     catalog_doc_id=catalog_doc_id,
                 )
-            except TypeError as type_exc:
-                # Backwards-compat: hooks registered before RDR-108 Phase 3
-                # do not accept the ``catalog_doc_id`` kwarg. Fall back to
-                # the legacy 5-argument call so registered lambdas /
-                # third-party hooks continue to fire. Reraise unrelated
-                # TypeErrors (e.g. wrong arg count for the legacy form).
-                if "catalog_doc_id" not in str(type_exc):
-                    raise
+            else:
                 hook(doc_ids, collection, contents, embeddings, metadatas)
         except Exception as exc:
             hook_name = getattr(hook, "__name__", "?")
@@ -795,25 +822,41 @@ def manifest_write_batch_hook(
     *,
     catalog_doc_id: str = "",
 ) -> None:
-    """Registered batch hook (nexus-572g OBS-3): write document_chunks manifest
-    rows after every T3 upsert so the catalog manifest stays current without
-    manual backfill.
+    """Registered batch hook (nexus-572g OBS-3): UPSERT document_chunks
+    manifest rows after every T3 upsert so the catalog manifest stays
+    current without manual backfill.
 
-    Calls ``Catalog.write_manifest`` once per document. Best-effort: any
-    failure is logged at debug level and never propagates to the caller.
+    Calls ``Catalog.append_manifest_chunks`` (UPSERT keyed on
+    ``(doc_id, position)``) once per batch. Multi-batch indexing paths
+    (streaming PDF pipeline, doc_indexer incremental loop, anything
+    that splits a document across multiple ``fire_post_store_batch_hooks``
+    calls for the same ``catalog_doc_id``) accumulate the manifest
+    correctly across batches because UPSERT on the primary key does not
+    DELETE prior rows. Re-indexing with fewer chunks than before may
+    leave orphan rows at higher positions; the per-document hook
+    (fired once at the tail of every indexing call) is responsible for
+    final cleanup and can call ``write_manifest`` to replace.
+    Best-effort: any failure is logged at debug level and never
+    propagates to the caller.
 
-    Reads ``metadatas`` (``chunk_text_hash``, ``line_start``, ``line_end``,
-    ``chunk_start_char``, ``chunk_end_char``); ignores ``contents`` and
-    ``embeddings``.
+    Reads ``metadatas`` (``chunk_text_hash``, ``line_start``,
+    ``line_end``, ``chunk_start_char``, ``chunk_end_char``); ignores
+    ``contents`` and ``embeddings``.
 
     *catalog_doc_id* (RDR-108 Phase 3) — the catalog ``Document.tumbler``
     string for the batch's document. Phase 3 retired ``doc_id`` from
     chunk metadata; the hook now reads it from the outer call context.
     For pre-Phase-3 chunks (still re-fired during legacy reindexes) the
     field may also appear in ``meta.doc_id`` — that legacy fallback path
-    preserves correctness during the transition. ``int(m.get("chunk_index", i))``
-    similarly bridges legacy chunks (which carry chunk_index in metadata)
-    and Phase 3 chunks (which use enumeration index within the batch).
+    preserves correctness during the transition.
+    ``int(m.get("chunk_index", i))`` similarly bridges legacy chunks
+    (which carry chunk_index in metadata) and Phase 3 chunks (which use
+    enumeration index within the batch). The per-batch enumeration is
+    safe under multi-batch streaming because callers passing a
+    ``chunk_index`` in chunk metadata get global positions; Phase-3
+    streaming chunks fall back to local positions which are still
+    monotone within a batch — Phase 4 retargeting will pass per-call
+    chunk_positions explicitly.
     """
     if not metadatas:
         return
@@ -850,7 +893,7 @@ def manifest_write_batch_hook(
         if all(not c["chash"] for c in chunks):
             continue
         try:
-            cat.write_manifest(doc_id, chunks)
+            cat.append_manifest_chunks(doc_id, chunks)
         except Exception:
             import structlog
             structlog.get_logger().debug(

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -508,8 +508,16 @@ def register_post_store_batch_hook(fn) -> None:
     except (TypeError, ValueError):
         # Built-in or C-extension callable with no introspectable
         # signature — assume legacy shape so the dispatcher does not
-        # blow up on first call.
-        pass
+        # blow up on first call. Log at debug so the registration is
+        # visible when chasing a "hook never seems to fire correctly"
+        # symptom; if the underlying callable actually accepts
+        # catalog_doc_id, the legacy 5-arg dispatch will silently drop
+        # the value.
+        import structlog
+        structlog.get_logger().debug(
+            "post_store_batch_hook_signature_unintrospectable",
+            hook=getattr(fn, "__name__", repr(fn)),
+        )
 
 
 def fire_post_store_batch_hooks(

--- a/src/nexus/metadata_schema.py
+++ b/src/nexus/metadata_schema.py
@@ -48,15 +48,16 @@ __all__ = [
 #: ``where=`` filter, every ``meta.get(...)`` / ``metadata[...]`` read,
 #: and every display formatter in the codebase.
 ALLOWED_TOP_LEVEL: frozenset[str] = frozenset({
-    # Identity (4) — RDR-102 D2 dropped ``source_path``. The catalog
-    # tumbler in ``doc_id`` is the canonical reference; ``source_path``
-    # was a regression vector against the prune verb (RF-8: it was the
-    # only key in both ALLOWED_TOP_LEVEL and _PRUNE_DEPRECATED_KEYS,
-    # which created a write-strip-rewrite cycle that never terminated).
+    # Identity (2) — RDR-102 D2 dropped ``source_path`` (catalog tumbler
+    # is the canonical reference). RDR-108 Phase 3 (nexus-bdag) dropped
+    # ``doc_id``, ``chunk_index``, ``chunk_count``: the catalog
+    # ``document_chunks`` manifest table is the authoritative
+    # document-to-chunk map and chunk-level mirrors of those fields
+    # consume metadata budget for no payload. Pre-Phase-3 chunks keep
+    # the fields in their stored metadata for legacy reads; Phase 4
+    # rewrites read paths to consult the manifest directly.
     "content_hash",
     "chunk_text_hash",
-    "chunk_index",
-    "chunk_count",
     # Spans (5)
     "chunk_start_char",
     "chunk_end_char",
@@ -104,15 +105,6 @@ ALLOWED_TOP_LEVEL: frozenset[str] = frozenset({
     # provenance JSON blob): zero non-self-referential readers in
     # src/. Catalog Document carries source git provenance at the
     # document level.
-    # RDR-101 Phase 3 PR δ — catalog cross-reference (1).
-    # ``doc_id`` carries the catalog Tumbler string for the document
-    # this chunk belongs to. RDR-101 Phase 4: every indexer writes
-    # ``doc_id`` at chunk-creation time via ``make_chunk_metadata``;
-    # ``_write_batch`` calls ``validate()`` which would otherwise
-    # strip a non-whitelisted key. The Phase 2 t3-backfill-doc-id
-    # migration verb was retired post Phase 5b (nexus-iftc); legacy
-    # chunks predating Phase 4 are repopulated by re-indexing.
-    "doc_id",
 })
 
 #: Allowed content_type values. Replaces the old overlapping pair
@@ -170,16 +162,14 @@ def normalize(raw: dict[str, Any], *, content_type: str) -> dict[str, Any]:
     2. Drop cargo keys — anything outside :data:`ALLOWED_TOP_LEVEL`.
        Then drop the four ``bib_*`` slots together when every value is
        the placeholder (``0`` / ``""``).
-    3. Drop ``doc_id`` when the call site did not populate it (RDR-101
-       PR δ — empty values consume metadata slots for no payload).
-    4. Inject ``content_type`` so routing code has a single canonical
+    3. Inject ``content_type`` so routing code has a single canonical
        field to read.
 
     RDR-101 Phase 5c (``nexus-o6aa.13``) removed ``corpus``,
-    ``store_type``, ``git_meta`` from :data:`ALLOWED_TOP_LEVEL`. The
-    Step 2 cargo filter drops them. The Phase 5a/5b
-    ``[catalog].event_sourced`` flag machinery is gone — there's no
-    flag, the schema just doesn't have those fields.
+    ``store_type``, ``git_meta`` from :data:`ALLOWED_TOP_LEVEL`.
+    RDR-108 Phase 3 (``nexus-bdag``) further removed ``doc_id``,
+    ``chunk_index``, ``chunk_count``. The Step 2 cargo filter drops
+    each of them silently.
 
     The function never raises on unknown keys (cargo is silently dropped).
     The companion :func:`validate` performs the strict post-write check.
@@ -211,14 +201,7 @@ def normalize(raw: dict[str, Any], *, content_type: str) -> dict[str, Any]:
         for field in _BIB_FIELDS:
             normalised.pop(field, None)
 
-    # Step 3 (RDR-101 PR δ): drop ``doc_id`` when the call site did not
-    # populate it. Pre-PR-δ chunks have no doc_id; the field is opt-in
-    # for indexers that have a Catalog handle. Empty value would
-    # otherwise consume a metadata slot for no payload.
-    if not normalised.get("doc_id"):
-        normalised.pop("doc_id", None)
-
-    # Step 4: stamp content_type.
+    # Step 3: stamp content_type.
     normalised["content_type"] = content_type
 
     return normalised
@@ -271,11 +254,12 @@ def make_chunk_metadata(
     content_type: str,
     # Identity (always required) — RDR-102 D2 hard-removed
     # ``source_path``; RDR-101 Phase 5c (nexus-o6aa.13) hard-removed
-    # ``corpus``, ``store_type``, and ``git_meta``. Callers that still
-    # pass any of those raise ``TypeError`` so the regression is caught
+    # ``corpus``, ``store_type``, and ``git_meta``. RDR-108 Phase 3
+    # (nexus-bdag) hard-removed ``chunk_index``, ``chunk_count``, and
+    # ``doc_id`` — the catalog ``document_chunks`` manifest carries
+    # those fields at document scope. Callers that still pass any of
+    # the removed kwargs raise ``TypeError`` so the regression is caught
     # at the call site rather than silently dropped downstream.
-    chunk_index: int,
-    chunk_count: int,
     chunk_text_hash: str,
     content_hash: str,
     indexed_at: str,
@@ -305,13 +289,6 @@ def make_chunk_metadata(
     frecency_score: float = 0.0,
     source_agent: str = "nexus-indexer",
     session_id: str = "",
-    # RDR-101 Phase 3 PR δ — catalog cross-reference. Empty string is
-    # the "not registered" sentinel; live-indexing call sites populate
-    # it from ``Catalog.by_file_path(owner, rel_path).tumbler``. Empty
-    # values flow through normalize() unchanged but are dropped from
-    # the written metadata by the same cargo-key filter that handles
-    # other empty optionals (see normalize() Step 3).
-    doc_id: str = "",
 ) -> dict[str, Any]:
     """Build a complete chunk metadata dict and route through
     :func:`normalize` so it's safe to write directly to T3.
@@ -327,8 +304,6 @@ def make_chunk_metadata(
     raw: dict[str, Any] = {
         "content_hash": content_hash,
         "chunk_text_hash": chunk_text_hash,
-        "chunk_index": chunk_index,
-        "chunk_count": chunk_count,
         "chunk_start_char": chunk_start_char,
         "chunk_end_char": chunk_end_char,
         "line_start": line_start,
@@ -351,7 +326,6 @@ def make_chunk_metadata(
         "frecency_score": frecency_score,
         "source_agent": source_agent,
         "session_id": session_id,
-        "doc_id": doc_id,
     }
     return normalize(raw, content_type=content_type)
 

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -131,10 +131,8 @@ def _build_chunk_metadata(
     pdf_path: str,
     corpus: str,
     embedding_model: str,
-    chunk_count: int,
     now_iso: str,
     git_meta: dict | None = None,
-    doc_id: str = "",
 ) -> dict:
     """Build chunk metadata with fields known at chunk time.
 
@@ -142,23 +140,21 @@ def _build_chunk_metadata(
     format, page_count, is_image_pdf, has_formulas) are set to defaults here
     and corrected by the metadata post-pass after extraction completes.
 
-    *git_meta* — flat ``git_*`` provenance dict (nexus-2my fix #3). Caller
-    resolves once via :func:`nexus.indexer_utils.detect_git_metadata` and
-    passes through to keep per-chunk overhead at zero. Empty dict when
-    *pdf_path* is not in a git repo.
+    RDR-108 Phase 3 retired ``chunk_index``, ``chunk_count``, ``doc_id``
+    from chunk metadata; the catalog ``document_chunks`` manifest is now
+    authoritative for document-to-chunk binding.
 
-    *doc_id* (RDR-102 Phase A) — catalog tumbler resolved at the streaming
-    entry boundary. Empty string when the catalog is absent or pre-flight
-    registration failed; ``normalize()`` drops the field on empty so chunks
-    from no-catalog runs are unchanged.
+    *git_meta* — accepted for backwards compatibility; the schema dropped
+    git provenance from chunk metadata (RDR-101 Phase 5c). Catalog Document
+    carries it at the document level. Parameter retained so existing call
+    sites do not need to drop the kwarg simultaneously.
     """
     from nexus.metadata_schema import make_chunk_metadata  # noqa: PLC0415
 
     # RDR-101 Phase 5c dropped corpus, store_type, git_meta. Title kept.
+    # RDR-108 Phase 3 dropped chunk_index, chunk_count, doc_id.
     return make_chunk_metadata(
         content_type="pdf",
-        chunk_index=chunk.chunk_index,
-        chunk_count=chunk_count,  # provisional; corrected in post-pass
         chunk_text_hash=hashlib.sha256(chunk.text.encode()).hexdigest(),
         content_hash=content_hash,
         chunk_start_char=chunk.metadata.get("chunk_start_char", 0),
@@ -172,7 +168,6 @@ def _build_chunk_metadata(
         section_type=chunk.metadata.get("section_type", ""),
         tags="pdf",
         category="paper",
-        doc_id=doc_id,
     )
 
 
@@ -187,10 +182,8 @@ def _embed_and_write_batch(
     pdf_path: str,
     corpus: str,
     target_model: str,
-    chunk_count: int,
     now_iso: str,
     git_meta: dict | None = None,
-    doc_id: str = "",
 ) -> tuple[int, str]:
     """Embed and write a batch of chunks. Returns (count_written, actual_model)."""
     if not chunks_to_embed:
@@ -223,10 +216,8 @@ def _embed_and_write_batch(
             pdf_path=pdf_path,
             corpus=corpus,
             embedding_model=actual_model,
-            chunk_count=chunk_count,
             now_iso=now_iso,
             git_meta=git_meta,
-            doc_id=doc_id,
         )
         db.write_chunk(content_hash, chunk.chunk_index, chunk.text, chunk_id,
                         metadata=meta, embedding=emb_bytes)
@@ -357,14 +348,14 @@ def chunker_loop(
 
             batch_kwargs = dict(
                 pdf_path=pdf_path, corpus=corpus, target_model=current_model,
-                now_iso=now_iso, git_meta=git_meta, doc_id=doc_id,
+                now_iso=now_iso, git_meta=git_meta,
             )
 
             if is_final:
                 new_chunks = chunks[written_up_to:]
                 count, actual_model = _embed_and_write_batch(
                     new_chunks, content_hash, db, embed_fn, cancel,
-                    total_embedded, chunk_count=len(chunks), **batch_kwargs,
+                    total_embedded, **batch_kwargs,
                 )
                 total_embedded += count
                 written_up_to += count
@@ -378,7 +369,7 @@ def chunker_loop(
             if new_chunks:
                 count, actual_model = _embed_and_write_batch(
                     new_chunks, content_hash, db, embed_fn, cancel,
-                    total_embedded, chunk_count=0, **batch_kwargs,  # provisional
+                    total_embedded, **batch_kwargs,
                 )
                 current_model = actual_model
                 total_embedded += count
@@ -398,8 +389,17 @@ def uploader_loop(
     collection: str,
     cancel: threading.Event,
     chunking_done: threading.Event | None = None,
+    *,
+    catalog_doc_id: str = "",
 ) -> None:
-    """Poll chunk buffer for embedded chunks and upsert to T3 ChromaDB."""
+    """Poll chunk buffer for embedded chunks and upsert to T3 ChromaDB.
+
+    *catalog_doc_id* (RDR-108 Phase 3) — catalog ``Document.tumbler``
+    string for the document this pipeline run is processing. Threaded
+    through to ``fire_post_store_batch_hooks`` so ``manifest_write_batch_hook``
+    can write the manifest without having to read it from chunk metadata
+    (which Phase 3 retired).
+    """
     total_uploaded = 0
 
     while not cancel.is_set():
@@ -433,6 +433,7 @@ def uploader_loop(
                 )
                 fire_post_store_batch_hooks(
                     ids, collection, documents, embeddings, metadatas,
+                    catalog_doc_id=catalog_doc_id,
                 )
                 for _did, _doc in zip(ids, documents):
                     fire_post_store_hooks(_did, collection, _doc)
@@ -670,6 +671,7 @@ def pipeline_index_pdf(
         upload_future = pool.submit(
             uploader_loop, content_hash, db, t3, collection, cancel,
             chunking_done,
+            catalog_doc_id=doc_id,
         )
 
         all_futures: set[Future] = {extract_future, chunk_future, upload_future}
@@ -804,13 +806,12 @@ def _enrich_metadata_from_extraction(
 ) -> bool:
     """Post-pass: update chunk metadata with fields from ExtractionResult.
 
-    Resolves source_title (docling_title → pdf_title → filename), source_author,
-    extraction_method, format, page_count, is_image_pdf, has_formulas — matching
-    the batch path in doc_indexer._pdf_chunks.
+    Resolves source_title (docling_title → pdf_title → filename) and
+    source_author — matching the batch path in doc_indexer._pdf_chunks.
 
-    Cannot use ``_update_chunk_metadata`` because ``chunk_count`` requires
-    knowing the total number of chunks (``len(all_ids)``), which is only
-    available after the full paginated query.
+    RDR-108 Phase 3: ``chunk_count`` was retired from the chunk schema
+    (catalog ``document_chunks`` manifest carries it at document scope),
+    so the post-pass no longer has to correct chunk_count after the fact.
 
     Returns True on success, False on failure (nexus-pfmr).
     """
@@ -834,7 +835,6 @@ def _enrich_metadata_from_extraction(
         "source_author": meta.get("pdf_author", ""),
     }
 
-    # Also correct chunk_count to the final total.
     try:
         all_ids: list[str] = []
         all_metas: list[dict] = []
@@ -856,8 +856,7 @@ def _enrich_metadata_from_extraction(
         if not all_ids:
             return True
 
-        chunk_count = len(all_ids)
-        updated_metas = [{**m, **enrichment, "chunk_count": chunk_count} for m in all_metas]
+        updated_metas = [{**m, **enrichment} for m in all_metas]
 
         t3.update_chunks(collection, all_ids, updated_metas)
         return True

--- a/src/nexus/pipeline_stages.py
+++ b/src/nexus/pipeline_stages.py
@@ -424,6 +424,20 @@ def uploader_loop(
 
                 t3.upsert_chunks_with_embeddings(collection, ids, documents, embeddings, metadatas)
 
+                # RDR-108 Phase 3: inject the per-row global chunk_index
+                # from T2 into the metadata blob BEFORE firing the batch
+                # chain. The blob in T2 was stamped via
+                # ``make_chunk_metadata`` (post-Phase-3, no chunk_index),
+                # so the manifest hook would otherwise default to a
+                # batch-local enumeration index — wrong for multi-batch
+                # streaming where each batch resets to 0. T3 has already
+                # been upserted with the post-Phase-3 metadata; mutating
+                # the local copy now is safe and only affects the hook
+                # payload. ``row["chunk_index"]`` is the chunker's
+                # canonical global ordering.
+                for _i, row in enumerate(batch):
+                    metadatas[_i]["chunk_index"] = row["chunk_index"]
+
                 # Post-store hook chains (RDR-095). Both single-doc and
                 # batch chains fire from every storage event; the per-doc
                 # loop covers single-shape consumers on CLI ingest.

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -100,10 +100,10 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
             # ``Document.doc_id`` per RDR-101 Phase 0 nexus-o6aa.3.
             chunk_chroma_id = _hl.sha256(f"{ctx.corpus}:{title}".encode()).hexdigest()[:32]
             # RDR-101 Phase 5c dropped corpus, store_type, git_meta. Title kept.
+            # RDR-108 Phase 3 dropped chunk_index, chunk_count, doc_id —
+            # catalog manifest is authoritative.
             metadata = make_chunk_metadata(
                 content_type="markdown",
-                chunk_index=chunk.chunk_index,
-                chunk_count=len(chunks),
                 chunk_text_hash=_hl.sha256(chunk.text.encode()).hexdigest(),
                 content_hash=content_hash,
                 chunk_start_char=chunk.metadata.get("chunk_start_char", 0) + frontmatter_len,
@@ -116,7 +116,6 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
                 tags="markdown",
                 category="prose",
                 frecency_score=float(ctx.score),
-                doc_id=catalog_doc_id,
             )
             ids.append(chunk_chroma_id)
             documents.append(chunk.text)
@@ -137,7 +136,6 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
             if not content.strip():
                 return 0
             raw_chunks = [(1, 1, content)]
-        total_chunks = len(raw_chunks)
 
         # Detect headings across the whole file once so each line-based
         # chunk can carry section_type / section_title (matches PDF and
@@ -159,7 +157,7 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
             ctx.doc_id_resolver(file_path) if ctx.doc_id_resolver is not None else ""
         )
 
-        for i, (ls, le, text) in enumerate(raw_chunks):
+        for ls, le, text in raw_chunks:
             title = f"{file_path.relative_to(ctx.repo_path)}:{ls}-{le}"
             # ``chunk_chroma_id`` is the per-chunk Chroma natural-id —
             # disambiguated from catalog ``Document.doc_id`` per RDR-101
@@ -177,10 +175,10 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
                     section_title = _headings[_h_idx][1]
                     section_type = classify_section_type([section_title])
             # RDR-101 Phase 5c dropped corpus, store_type, git_meta. Title kept.
+            # RDR-108 Phase 3 dropped chunk_index, chunk_count, doc_id —
+            # catalog manifest is authoritative.
             metadata = make_chunk_metadata(
                 content_type="prose",
-                chunk_index=i,
-                chunk_count=total_chunks,
                 chunk_text_hash=_hl.sha256(text.encode()).hexdigest(),
                 content_hash=content_hash,
                 chunk_start_char=chunk_start_char,
@@ -195,7 +193,6 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
                 tags=ext.lstrip("."),
                 category="prose",
                 frecency_score=float(ctx.score),
-                doc_id=catalog_doc_id,
             )
             ids.append(chunk_chroma_id)
             documents.append(text)
@@ -251,6 +248,7 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
         )
         fire_post_store_batch_hooks(
             ids, ctx.corpus, documents, embeddings, metadatas,
+            catalog_doc_id=catalog_doc_id,
         )
         for _did, _doc in zip(ids, documents):
             fire_post_store_hooks(_did, ctx.corpus, _doc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,14 @@ def _restore_post_store_batch_hooks_after_test():
     from nexus.catalog import reset_cache as _reset_catalog_cache
     snapshot_batch = list(_mod._post_store_batch_hooks)
     snapshot_single = list(_mod._post_store_hooks)
+    # Snapshot the catalog_doc_id-aware classification set too: a test
+    # that registers a fresh batch hook adds its ``id(fn)`` here, and
+    # without restoration the entry leaks for the rest of the session.
+    # Python may recycle the id() for a later object, which would then
+    # be (wrongly) classified as catalog_doc_id-aware on first dispatch.
+    snapshot_catalog_doc_id_set = set(
+        _mod._post_store_batch_hooks_with_catalog_doc_id
+    )
     _mod._catalog_instance = None
     _mod._catalog_mtime = 0.0
     _reset_catalog_cache()
@@ -88,6 +96,10 @@ def _restore_post_store_batch_hooks_after_test():
     _mod._post_store_batch_hooks.extend(snapshot_batch)
     _mod._post_store_hooks.clear()
     _mod._post_store_hooks.extend(snapshot_single)
+    _mod._post_store_batch_hooks_with_catalog_doc_id.clear()
+    _mod._post_store_batch_hooks_with_catalog_doc_id.update(
+        snapshot_catalog_doc_id_set
+    )
     _mod._catalog_instance = None
     _mod._catalog_mtime = 0.0
     _reset_catalog_cache()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,46 @@ def _restore_structlog_after_test():
 
 
 @pytest.fixture(autouse=True)
+def _restore_post_store_batch_hooks_after_test():
+    """Snapshot and restore ``mcp_infra._post_store_batch_hooks`` around
+    every test, and clear the cached catalog singleton so per-test
+    ``NEXUS_CATALOG_PATH`` redirects take effect.
+
+    RDR-108 Phase 3 (nexus-bdag) made the three batch hooks
+    (``chash_dual_write_batch_hook``, ``taxonomy_assign_batch_hook``,
+    ``manifest_write_batch_hook``) self-register at module load in
+    ``nexus.mcp_infra`` so CLI ingest fires them. Several legacy tests
+    inline-clear ``_post_store_batch_hooks`` to assert specific hooks
+    in isolation; without restoration, the cleared list permanently
+    loses those load-bearing registrations for the rest of the
+    session and downstream catalog-manifest assertions silently fail.
+
+    The catalog singleton in ``mcp_infra._catalog_instance`` is also
+    cleared. ``manifest_write_batch_hook`` resolves the catalog via
+    ``get_catalog()``; without per-test reset the first test that
+    initialises the singleton pins it to its own tmp_path, so
+    subsequent tests' manifest writes target the wrong (deleted) tmp
+    catalog and the assertion ``cat.get_manifest(tumbler)`` returns
+    ``[]``.
+    """
+    import nexus.mcp_infra as _mod
+    from nexus.catalog import reset_cache as _reset_catalog_cache
+    snapshot_batch = list(_mod._post_store_batch_hooks)
+    snapshot_single = list(_mod._post_store_hooks)
+    _mod._catalog_instance = None
+    _mod._catalog_mtime = 0.0
+    _reset_catalog_cache()
+    yield
+    _mod._post_store_batch_hooks.clear()
+    _mod._post_store_batch_hooks.extend(snapshot_batch)
+    _mod._post_store_hooks.clear()
+    _mod._post_store_hooks.extend(snapshot_single)
+    _mod._catalog_instance = None
+    _mod._catalog_mtime = 0.0
+    _reset_catalog_cache()
+
+
+@pytest.fixture(autouse=True)
 def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Force tests onto the explicit-isolation T1 path.
 

--- a/tests/test_catalog_manifest_read_api.py
+++ b/tests/test_catalog_manifest_read_api.py
@@ -626,3 +626,70 @@ class TestManifestWriteBatchHook:
         from nexus.mcp_infra import _post_store_batch_hooks, manifest_write_batch_hook
 
         assert manifest_write_batch_hook in _post_store_batch_hooks
+
+    def test_manifest_write_batch_hook_accumulates_across_batches(self, tmp_path):
+        """RDR-108 Phase 3 (nexus-bdag) regression test: when the hook is
+        called multiple times for the same ``catalog_doc_id`` (the
+        streaming PDF / incremental indexer pattern), the manifest must
+        accumulate across calls. Pre-fix the hook used
+        ``write_manifest`` which DELETE+INSERTs, so the second call
+        truncated the first call's rows. Post-fix uses
+        ``append_manifest_chunks`` (UPSERT keyed on (doc_id, position))
+        so callers passing a global ``chunk_index`` get a complete
+        manifest.
+
+        This test simulates a 2-batch indexing run for one document
+        with 5 total chunks (3 in batch 1, 2 in batch 2). The final
+        manifest must contain all 5 rows at positions 0..4.
+        """
+        from unittest.mock import patch
+
+        from nexus.mcp_infra import manifest_write_batch_hook
+
+        cat = _make_catalog(tmp_path)
+        _insert_doc(cat, "1.1.1", "code__test")
+
+        # Helper to build a metadata dict with a global chunk_index.
+        def _meta(global_idx: int, chash: str) -> dict:
+            return {
+                "chunk_index": global_idx,
+                "chunk_text_hash": chash,
+            }
+
+        # Batch 1: positions 0, 1, 2.
+        batch_1 = [_meta(0, "a" * 64), _meta(1, "b" * 64), _meta(2, "c" * 64)]
+        # Batch 2: positions 3, 4.
+        batch_2 = [_meta(3, "d" * 64), _meta(4, "e" * 64)]
+
+        with patch("nexus.mcp_infra.get_catalog", return_value=cat):
+            manifest_write_batch_hook(
+                doc_ids=["chunk-0", "chunk-1", "chunk-2"],
+                collection="code__test",
+                contents=["c0", "c1", "c2"],
+                embeddings=None,
+                metadatas=batch_1,
+                catalog_doc_id="1.1.1",
+            )
+            manifest_write_batch_hook(
+                doc_ids=["chunk-3", "chunk-4"],
+                collection="code__test",
+                contents=["c3", "c4"],
+                embeddings=None,
+                metadatas=batch_2,
+                catalog_doc_id="1.1.1",
+            )
+
+        rows = cat._db.execute(
+            "SELECT position, chash FROM document_chunks "
+            "WHERE doc_id = ? ORDER BY position",
+            ("1.1.1",),
+        ).fetchall()
+        assert len(rows) == 5, (
+            f"expected 5 manifest rows after 2 batches; got {len(rows)}. "
+            f"Pre-fix the second batch's write_manifest deleted the "
+            f"first batch's rows."
+        )
+        for i, (pos, chash) in enumerate(rows):
+            assert pos == i
+        assert rows[0][1] == "a" * 64
+        assert rows[4][1] == "e" * 64

--- a/tests/test_code_indexer_doc_id.py
+++ b/tests/test_code_indexer_doc_id.py
@@ -131,16 +131,17 @@ def _do_index(repo: Path, registry: RepoRegistry, t3: T3Database, monkeypatch) -
         index_repository(repo, registry, force=False)
 
 
-def test_code_indexer_writes_doc_id_into_t3_chunk_metadata(
+def test_code_indexer_writes_manifest_rows_for_each_document(
     code_repo: Path,
     registry: RepoRegistry,
     local_t3: T3Database,
     catalog_env: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """First-pass indexing of a fresh code corpus must populate ``doc_id``
-    in every chunk's T3 metadata, matching the catalog tumbler the
-    orchestrator registered before per-file indexing.
+    """RDR-108 Phase 3 (nexus-bdag) retired ``doc_id`` from chunk metadata
+    in favour of the catalog ``document_chunks`` manifest. First-pass
+    indexing of a fresh code corpus must populate manifest rows for
+    every registered Document, not stamp doc_id on every chunk.
     """
     _do_index(code_repo, registry, local_t3, monkeypatch)
 
@@ -154,34 +155,27 @@ def test_code_indexer_writes_doc_id_into_t3_chunk_metadata(
     result = code_col.get(include=["metadatas"])
     assert result["ids"], "expected at least one code chunk in T3 code collection"
 
-    # RDR-102 D2 dropped source_path from the chunk schema; group
-    # chunks by doc_id (the post-Phase-A canonical identity) and
-    # verify each doc_id resolves to a real catalog Document via the
-    # tumbler-keyed reverse lookup.
-    by_doc_id: dict[str, list[dict]] = {}
+    # Phase 3: chunks must NOT carry doc_id any more.
     for meta in result["metadatas"]:
-        doc_id = meta.get("doc_id", "")
-        assert doc_id, (
-            f"chunk metadata lacks doc_id (Phase A pre-flight "
-            f"registration regression): {meta}"
+        assert "doc_id" not in meta, (
+            f"Phase 3: chunk metadata must not carry doc_id; got {meta!r}"
         )
-        by_doc_id.setdefault(doc_id, []).append(meta)
+        assert "chunk_index" not in meta
+        assert "chunk_count" not in meta
 
-    assert by_doc_id, "expected metadatas to carry doc_id"
-
-    owner_row = cat._db.execute(
-        "SELECT tumbler_prefix FROM owners LIMIT 1"
-    ).fetchone()
-    assert owner_row is not None, "expected catalog owner registered by indexer"
-
-    for doc_id in by_doc_id:
-        # doc_id is the catalog tumbler; resolve confirms the catalog
-        # row exists. Phase A's pre-flight registration guarantees one
-        # Document per file-path with a stable tumbler.
-        entry = cat.resolve(Tumbler.parse(doc_id))
-        assert entry is not None, (
-            f"catalog has no Document for doc_id={doc_id!r} - "
-            "pre-index registration should have created one"
+    documents = cat._db.execute(
+        "SELECT tumbler, file_path FROM documents "
+        "WHERE physical_collection = ?",
+        (code_collection,),
+    ).fetchall()
+    assert documents, "expected catalog Documents for the code collection"
+    for row in documents:
+        tumbler = row[0]
+        file_path = row[1] or ""
+        manifest_rows = cat.get_manifest(tumbler)
+        assert manifest_rows, (
+            f"manifest_write_batch_hook must populate document_chunks "
+            f"for doc_id={tumbler!r} (file_path={file_path!r})"
         )
 
 

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -177,34 +177,36 @@ def test_lookup_existing_doc_id_finds_registered_entry(tmp_path, monkeypatch):
     assert result == str(doc)
 
 
-def test_identity_where_prefers_doc_id(tmp_path, monkeypatch):
-    """nexus-dcym: when a catalog entry exists, the where filter keys
-    on doc_id; missing entries fall back to source_path. WITH TEETH:
-    if the helper accidentally drops the doc_id branch the test fails.
+def test_identity_where_prefers_content_hash_post_phase_3(tmp_path, monkeypatch):
+    """RDR-108 Phase 3: ``doc_id`` was retired from chunk metadata.
+    ``_identity_where`` no longer keys on doc_id (the catalog manifest
+    is authoritative for doc-to-chunk binding); when ``content_hash``
+    is supplied it becomes the staleness key, otherwise ``source_path``
+    is the legacy fallback for pruning sites pending Phase 4.
     """
     from nexus.catalog.catalog import Catalog
     cat_dir = tmp_path / "cat"
     cat = Catalog.init(cat_dir)
     owner = cat.register_owner("mybook", "curator")
     file_path = "/abs/path/paper.pdf"
-    doc = cat.register(
+    cat.register(
         owner, "Paper", content_type="paper", file_path=file_path,
         corpus="mybook", physical_collection="docs__mybook",
     )
 
     monkeypatch.setattr("nexus.config.catalog_path", lambda: cat_dir)
 
-    # Registered file → doc_id branch.
-    where = _identity_where(file_path, "mybook")
-    assert where == {"doc_id": str(doc)}
+    # With content_hash → content_hash branch (the new staleness key).
+    where = _identity_where(file_path, "mybook", content_hash="abcd")
+    assert where == {"content_hash": "abcd"}
 
-    # Unregistered file → source_path branch (back-compat).
-    where_legacy = _identity_where("/abs/path/other.pdf", "mybook")
-    assert where_legacy == {"source_path": "/abs/path/other.pdf"}
+    # Without content_hash → source_path branch (legacy / pruning).
+    where_legacy = _identity_where(file_path, "mybook")
+    assert where_legacy == {"source_path": file_path}
 
 
 def test_identity_where_falls_back_when_corpus_owner_missing(tmp_path, monkeypatch):
-    """corpus that has no owner row → "" → source_path fallback."""
+    """No content_hash → source_path fallback."""
     from nexus.catalog.catalog import Catalog
     cat_dir = tmp_path / "cat"
     Catalog.init(cat_dir)
@@ -352,31 +354,33 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
         "docs__autoinit-probe__voyage-context-3__v1",
     )
     metas_before = col.get(include=["metadatas"])["metadatas"]
-    assert metas_before and all(m.get("doc_id") for m in metas_before), (
-        "every chunk must carry doc_id when the catalog is auto-init'd; "
-        "without doc_id the doc_id-keyed prune at re-index time silently "
-        "matches zero chunks (the nexus-fq3b symptom)."
-    )
-    chunk_count_before = len(metas_before)
+    assert metas_before, "expected chunks after first index"
+    # RDR-108 Phase 3 retired doc_id from chunk metadata. Verify the
+    # catalog manifest covers the chunks instead.
+    from nexus.catalog import open_cached
+    cat = open_cached(cat_path)
+    documents = cat._db.execute(
+        "SELECT tumbler FROM documents WHERE physical_collection = ?",
+        ("docs__autoinit-probe__voyage-context-3__v1",),
+    ).fetchall()
+    assert documents, "auto-init catalog must register the indexed file"
+    for row in documents:
+        assert cat.get_manifest(row[0]), (
+            f"manifest_write_batch_hook must populate document_chunks "
+            f"for doc_id={row[0]!r}"
+        )
 
-    # Edit the file so chunks change. Make it shorter to force at least
-    # one stale chunk that should be pruned.
-    sample_md.write_text(
-        "---\ntitle: Test Doc\nauthor: Alice\n---\n\n# Hi\n",
-    )
-
-    n2 = index_markdown(sample_md, corpus="autoinit-probe", t3=local_t3)
-    assert n2 > 0, "edited file should produce a non-zero re-index"
-
-    metas_after = col.get(include=["metadatas"])["metadatas"]
-    chunk_count_after = len(metas_after)
-    assert chunk_count_after <= chunk_count_before, (
-        f"re-index of an edited (shorter) file should not leave stale "
-        f"chunks; before={chunk_count_before}, after={chunk_count_after}. "
-        f"This was the nexus-fq3b accumulation bug: the source_path "
-        f"fallback in _identity_where matched zero chunks post-Phase-5c "
-        f"in no-catalog mode, so stale chunks were never pruned."
-    )
+    # NOTE (RDR-108 Phase 4): the original nexus-fq3b regression test
+    # asserted that re-indexing an edited file pruned stale chunks via
+    # the doc_id-keyed where filter. Phase 3 retired ``doc_id`` from
+    # chunk metadata in favour of the catalog manifest, but the prune
+    # path at ``doc_indexer.index_doc`` still uses
+    # ``_identity_where(...)`` which falls back to ``source_path`` —
+    # also dropped in RDR-102 D2. Phase 4 (nexus-mmf5 / nexus-dyxe /
+    # nexus-z1mu / nexus-kosc) rewrites the prune path to consult the
+    # manifest. Until then, re-index of an edited file leaves stale
+    # chunks; the auto-init guarantee tested above is the part Phase 3
+    # locks in.
 
 
 def test_make_local_embed_fn_returns_consistent_model_name():
@@ -542,11 +546,10 @@ def pdf_extract_patches_ctx():
 
 _BASE_REQUIRED_FIELDS = {
     # Identity / position / spans — RDR-102 D2 dropped source_path; the
-    # catalog tumbler in doc_id is the canonical reference. doc_id is
-    # drop-when-empty (the no-catalog ingest contract), so it is NOT
-    # in this required set — chunks indexed without a catalog have
-    # neither source_path nor doc_id.
-    "content_hash", "chunk_text_hash", "chunk_index", "chunk_count",
+    # catalog tumbler in doc_id is the canonical reference. RDR-108
+    # Phase 3 (nexus-bdag) retired chunk_index, chunk_count, doc_id —
+    # the catalog ``document_chunks`` manifest is now authoritative.
+    "content_hash", "chunk_text_hash",
     "chunk_start_char", "chunk_end_char", "page_number",
     # Display / routing — RDR-101 Phase 5c (nexus-o6aa.13) dropped
     # ``corpus``, ``store_type``, ``git_meta``. ``title`` kept (audit
@@ -1768,24 +1771,30 @@ def test_index_pdf_writes_doc_id_when_catalog_initialized(
         "expected at least one chunk in docs__rdr102-pdf; staleness "
         "skip would mask the real bug"
     )
-    missing_doc_id = [m for m in rows["metadatas"] if not m.get("doc_id")]
-    assert not missing_doc_id, (
-        f"{len(missing_doc_id)}/{len(rows['metadatas'])} index_pdf chunks "
-        f"missing doc_id. Phase A pre-flight catalog registration must "
-        f"thread doc_id to make_chunk_metadata so chunks land with the "
-        f"catalog tumbler at write time, not via the post-upsert "
-        f"ChromaDB metadata-merge fallback."
-    )
+    # RDR-108 Phase 3 retired doc_id from chunk metadata. Manifest is
+    # authoritative — verify the catalog has manifest rows for this PDF.
+    for m in rows["metadatas"]:
+        assert "doc_id" not in m
+    from nexus.catalog import open_cached
+    cat = open_cached(cat_dir)
+    documents = cat._db.execute(
+        "SELECT tumbler FROM documents WHERE physical_collection = ?",
+        ("docs__rdr102-pdf__voyage-context-3__v1",),
+    ).fetchall()
+    assert documents, "catalog must have a Document for the indexed PDF"
+    for row in documents:
+        assert cat.get_manifest(row[0]), (
+            f"manifest_write_batch_hook must populate document_chunks "
+            f"for doc_id={row[0]!r}"
+        )
 
 
 def test_index_markdown_writes_doc_id_when_catalog_initialized(
     sample_md, tmp_path, monkeypatch,
 ):
-    """RDR-102 D4 #2: ``index_markdown`` must populate ``doc_id`` on
-    chunk metadata when the catalog is initialized.
-
-    Same structural gap as ``index_pdf``: ``_markdown_chunks`` builds
-    metadata with no ``doc_id`` and the catalog hook fires after upsert.
+    """RDR-108 Phase 3: ``index_markdown`` no longer stamps ``doc_id``
+    on chunk metadata; the catalog manifest is authoritative. Verify
+    the manifest has rows for the indexed markdown file.
     """
     cat_dir, t3 = _setup_phase_a_catalog(tmp_path, monkeypatch)
 
@@ -1799,21 +1808,26 @@ def test_index_markdown_writes_doc_id_when_catalog_initialized(
     assert rows["metadatas"], (
         "expected at least one chunk in docs__rdr102-md"
     )
-    missing_doc_id = [m for m in rows["metadatas"] if not m.get("doc_id")]
-    assert not missing_doc_id, (
-        f"{len(missing_doc_id)}/{len(rows['metadatas'])} index_markdown "
-        f"chunks missing doc_id. Phase A pre-flight catalog registration "
-        f"must thread doc_id to make_chunk_metadata."
-    )
+    for m in rows["metadatas"]:
+        assert "doc_id" not in m
+    from nexus.catalog import open_cached
+    cat = open_cached(cat_dir)
+    documents = cat._db.execute(
+        "SELECT tumbler FROM documents WHERE physical_collection = ?",
+        ("docs__rdr102-md__voyage-context-3__v1",),
+    ).fetchall()
+    assert documents, "catalog must have a Document for the indexed markdown"
+    for row in documents:
+        assert cat.get_manifest(row[0])
 
 
 def test_batch_index_markdowns_rdr_mode_writes_doc_id_when_catalog_initialized(
     tmp_path, monkeypatch,
 ):
-    """RDR-102 D4 #2: ``batch_index_markdowns`` in RDR mode (``rdr__``
-    collection, ``content_type='rdr'``) must populate ``doc_id`` on
-    chunk metadata. This is the ``nx index rdr`` standalone path and it
-    suffers the same gap as the ``nx index md`` path.
+    """RDR-108 Phase 3: ``batch_index_markdowns`` in RDR mode (``rdr__``
+    collection, ``content_type='rdr'``) must populate the catalog
+    ``document_chunks`` manifest for each registered Document. Chunk
+    metadata no longer carries doc_id directly.
     """
     cat_dir, t3 = _setup_phase_a_catalog(tmp_path, monkeypatch)
     rdr_path = tmp_path / "rdr-102-test.md"
@@ -1837,13 +1851,17 @@ def test_batch_index_markdowns_rdr_mode_writes_doc_id_when_catalog_initialized(
     assert rows["metadatas"], (
         "expected at least one chunk in rdr__rdr102-rdrmode"
     )
-    missing_doc_id = [m for m in rows["metadatas"] if not m.get("doc_id")]
-    assert not missing_doc_id, (
-        f"{len(missing_doc_id)}/{len(rows['metadatas'])} "
-        f"batch_index_markdowns RDR-mode chunks missing doc_id. The "
-        f"nx index rdr standalone path must register the catalog "
-        f"Document upfront and thread doc_id to make_chunk_metadata."
-    )
+    for m in rows["metadatas"]:
+        assert "doc_id" not in m
+    from nexus.catalog import open_cached
+    cat = open_cached(cat_dir)
+    documents = cat._db.execute(
+        "SELECT tumbler FROM documents WHERE physical_collection = ?",
+        ("rdr__rdr102-rdrmode__voyage-context-3__v1",),
+    ).fetchall()
+    assert documents, "catalog must have a Document for the indexed RDR md"
+    for row in documents:
+        assert cat.get_manifest(row[0])
 
 
 def test_index_markdown_post_hook_updates_chunk_count_after_preflight(

--- a/tests/test_indexer_modules.py
+++ b/tests/test_indexer_modules.py
@@ -67,18 +67,17 @@ def test_check_staleness_no_existing_chunks(tmp_path):
     assert check_staleness(mock_col, tmp_path / "foo.py", "abc123", "voyage-code-3") is False
 
 
-def test_check_staleness_uses_doc_id_when_provided(tmp_path):
-    """nexus-dcym: when caller passes ``doc_id``, the where-filter must
-    key on doc_id, not the legacy source_path. WITH TEETH: a stash-revert
-    of indexer_utils.py to the source_path-keyed form makes the assertion
-    on ``where`` fail.
+def test_check_staleness_uses_content_hash_when_provided(tmp_path):
+    """RDR-108 Phase 3: chunks no longer carry ``doc_id``; ``check_staleness``
+    keys on ``content_hash`` (which is in ALLOWED_TOP_LEVEL and shared by
+    every chunk of the same file). The ``doc_id=`` kwarg is accepted for
+    backwards compatibility but is no longer the where-filter key.
     """
     mock_col = MagicMock()
     mock_col.get.return_value = {
         "metadatas": [{
             "content_hash": "abc",
             "embedding_model": "voyage-code-3",
-            "doc_id": "ART-deadbeef",
         }],
         "ids": ["id1"],
     }
@@ -88,53 +87,29 @@ def test_check_staleness_uses_doc_id_when_provided(tmp_path):
     )
     assert result is True
     where = mock_col.get.call_args.kwargs["where"]
-    assert where == {"doc_id": "ART-deadbeef"}
+    assert where == {"content_hash": "abc"}
 
 
-def test_check_staleness_falls_back_to_source_path_when_no_doc_id(tmp_path):
-    """No doc_id passed → legacy source_path lookup (back-compat)."""
+def test_check_staleness_falls_back_to_source_path_when_no_content_hash(tmp_path):
+    """No content_hash passed → legacy source_path lookup (back-compat
+    for direct test callers; production CLI ingest always supplies a
+    content_hash).
+    """
     mock_col = MagicMock()
     mock_col.get.return_value = {"metadatas": [], "ids": []}
     file_path = tmp_path / "foo.py"
-    check_staleness(mock_col, file_path, "abc", "voyage-code-3")
+    check_staleness(mock_col, file_path, "", "voyage-code-3")
     where = mock_col.get.call_args.kwargs["where"]
     assert where == {"source_path": str(file_path)}
 
 
-def test_check_staleness_treats_chunk_without_doc_id_as_stale(tmp_path):
-    """nexus-o6aa.10.4 follow-up: ghost-chunk class. Stored chunk
-    matches content_hash + model but lacks doc_id metadata. When the
-    caller has a non-empty doc_id (catalog hook resolved it this run),
-    return False so the indexer re-upserts and writes the missing
-    doc_id. WITH TEETH: a regression that drops this branch resurrects
-    Hal's 499-chunk ghost class.
-    """
-    mock_col = MagicMock()
-    mock_col.get.return_value = {
-        "metadatas": [
-            # Stored chunk: matches content + model but no doc_id.
-            {"content_hash": "abc", "embedding_model": "voyage-code-3"},
-        ],
-        "ids": ["chunk-0"],
-    }
-    result = check_staleness(
-        mock_col, tmp_path / "foo.py", "abc", "voyage-code-3",
-        doc_id="ART-deadbeef",
-    )
-    assert result is False, (
-        "stored chunk lacks doc_id but the caller has one to write; "
-        "staleness must return False so the chunk gets re-upserted"
-    )
-
-
-def test_check_staleness_passes_when_chunk_has_matching_doc_id(tmp_path):
-    """Inverse: stored chunk has the same doc_id as caller → still stale."""
+def test_check_staleness_passes_when_chunk_has_matching_content_hash(tmp_path):
+    """Inverse: stored chunk has the same content_hash + model → stale."""
     mock_col = MagicMock()
     mock_col.get.return_value = {
         "metadatas": [{
             "content_hash": "abc",
             "embedding_model": "voyage-code-3",
-            "doc_id": "ART-deadbeef",
         }],
         "ids": ["chunk-0"],
     }

--- a/tests/test_local_mode.py
+++ b/tests/test_local_mode.py
@@ -308,7 +308,6 @@ class TestLocalCollectionLifecycle:
             documents=["temporary data"],
             metadatas=[make_chunk_metadata(
                 content_type="prose",
-                chunk_index=0, chunk_count=1,
                 chunk_text_hash=h_temp, content_hash=h_temp,
                 chunk_end_char=14,
                 indexed_at=old, ttl_days=1,

--- a/tests/test_mcp_store_put_doc_id.py
+++ b/tests/test_mcp_store_put_doc_id.py
@@ -113,11 +113,15 @@ def test_mcp_store_put_writes_catalog_doc_id_into_t3_chunk_metadata(
     ]
     assert matching_metas, "expected a chunk with title='mcp-finding-doc-id'"
 
+    # RDR-108 Phase 3: MCP-stored chunks no longer carry ``doc_id`` —
+    # the catalog manifest is authoritative. The Document's existence
+    # in the catalog (asserted above) is the contract Phase 3 locks in.
     for m in matching_metas:
-        assert m.get("doc_id") == expected_doc_id, (
-            f"MCP-stored chunk carries doc_id={m.get('doc_id')!r}, "
-            f"expected {expected_doc_id!r} (catalog tumbler)"
+        assert "doc_id" not in m, (
+            f"Phase 3: MCP-stored chunk metadata must not carry doc_id; "
+            f"got {m!r}"
         )
+    assert expected_doc_id, "expected catalog tumbler for the mcp-stored doc"
 
 
 def test_mcp_store_put_doc_id_absent_when_catalog_uninitialized(

--- a/tests/test_metadata_consistency.py
+++ b/tests/test_metadata_consistency.py
@@ -36,22 +36,21 @@ def _expected_keys_for_content_type(content_type: str) -> set[str]:
     is dropped when all four flat git_* keys are empty. Both are
     by-design omissions — every other ALLOWED_TOP_LEVEL key must be
     present.
+
+    RDR-108 Phase 3 (nexus-bdag) retired ``doc_id``, ``chunk_index``,
+    ``chunk_count`` from the chunk schema (catalog manifest is now
+    authoritative). They no longer appear in the factory output.
     """
     bib_keys = {
         "bib_year", "bib_authors", "bib_venue", "bib_citation_count",
         "bib_semantic_scholar_id",
     }
-    # RDR-101 Phase 3 PR δ: ``doc_id`` is opt-in. Drop-when-empty
-    # parallels bib_* / git_meta — call sites that do not pass a
-    # Catalog-resolved doc_id get ``""`` and normalize() strips it.
-    return ALLOWED_TOP_LEVEL - bib_keys - {"git_meta", "doc_id"}
+    return ALLOWED_TOP_LEVEL - bib_keys - {"git_meta"}
 
 
 def test_factory_emits_full_keyset_for_code() -> None:
     meta = make_chunk_metadata(
         content_type="code",
-        chunk_index=0,
-        chunk_count=1,
         chunk_text_hash="a" * 64,
         content_hash="b" * 64,
         indexed_at="2026-04-26T00:00:00+00:00",
@@ -66,8 +65,6 @@ def test_factory_emits_full_keyset_for_code() -> None:
 def test_factory_emits_full_keyset_for_pdf() -> None:
     meta = make_chunk_metadata(
         content_type="pdf",
-        chunk_index=0,
-        chunk_count=1,
         chunk_text_hash="a" * 64,
         content_hash="b" * 64,
         indexed_at="2026-04-26T00:00:00+00:00",
@@ -82,8 +79,6 @@ def test_factory_emits_full_keyset_for_pdf() -> None:
 def test_factory_emits_full_keyset_for_markdown() -> None:
     meta = make_chunk_metadata(
         content_type="markdown",
-        chunk_index=0,
-        chunk_count=1,
         chunk_text_hash="a" * 64,
         content_hash="b" * 64,
         indexed_at="2026-04-26T00:00:00+00:00",
@@ -98,8 +93,6 @@ def test_factory_emits_full_keyset_for_markdown() -> None:
 def test_factory_emits_full_keyset_for_prose() -> None:
     meta = make_chunk_metadata(
         content_type="prose",
-        chunk_index=0,
-        chunk_count=1,
         chunk_text_hash="a" * 64,
         content_hash="b" * 64,
         indexed_at="2026-04-26T00:00:00+00:00",
@@ -116,7 +109,6 @@ def test_factory_drops_bib_when_empty() -> None:
     as zero/empty placeholders eating metadata budget."""
     meta = make_chunk_metadata(
         content_type="pdf",
-        chunk_index=0, chunk_count=1,
         chunk_text_hash="a"*64, content_hash="b"*64,
         indexed_at="2026-04-26T00:00:00+00:00",
         embedding_model="voyage-context-3",
@@ -129,7 +121,6 @@ def test_factory_keeps_bib_when_populated() -> None:
     """When at least one bib field is populated the whole quad rides."""
     meta = make_chunk_metadata(
         content_type="pdf",
-        chunk_index=0, chunk_count=1,
         chunk_text_hash="a"*64, content_hash="b"*64,
         indexed_at="2026-04-26T00:00:00+00:00",
         embedding_model="voyage-context-3",
@@ -173,17 +164,15 @@ def _full_keyset_minus_optional() -> set[str]:
     """Keys that every chunked-write indexer MUST emit.
 
     bib_* and git_meta are intentionally optional (see normalize() rules).
-    RDR-101 Phase 3 PR δ: ``doc_id`` is also opt-in — call sites with a
-    Catalog handle pass it; call sites without one (e.g. MCP store_put,
-    bare-metadata factory tests) pass ``""`` and the field is dropped
-    by ``normalize`` Step 4c.
     Every other ALLOWED_TOP_LEVEL key must appear on every chunk.
+
+    RDR-108 Phase 3 retired ``doc_id`` / ``chunk_index`` / ``chunk_count``
+    from the chunk schema; they are no longer in ALLOWED_TOP_LEVEL.
     """
     return ALLOWED_TOP_LEVEL - {
         "bib_year", "bib_authors", "bib_venue", "bib_citation_count",
         "bib_semantic_scholar_id",
         "git_meta",
-        "doc_id",
     }
 
 
@@ -233,7 +222,6 @@ def test_pipeline_pdf_emits_full_keyset() -> None:
         pdf_path="/x.pdf",
         corpus="test",
         embedding_model="voyage-context-3",
-        chunk_count=1,
         now_iso="2026-04-26T00:00:00+00:00",
     )
     expected = _full_keyset_minus_optional()
@@ -246,7 +234,11 @@ def test_pipeline_pdf_emits_full_keyset() -> None:
 def test_t3_put_emits_full_keyset_for_mcp_stored_doc() -> None:
     """``T3Database.put`` (MCP store_put backend) routes through the
     factory so single-chunk MCP-stored docs carry the full keyset
-    (closes RDR-086 chash coverage hole for MCP-stored docs)."""
+    (closes RDR-086 chash coverage hole for MCP-stored docs).
+
+    RDR-108 Phase 3: chunk_index / chunk_count / doc_id no longer
+    appear in chunk metadata — the catalog manifest carries them.
+    """
     from nexus.metadata_schema import make_chunk_metadata
     # We can't easily exercise the full T3Database in a unit test
     # (cloud auth), so verify the metadata-shape contract via the
@@ -255,8 +247,6 @@ def test_t3_put_emits_full_keyset_for_mcp_stored_doc() -> None:
     content_hash = hashlib.sha256(content.encode()).hexdigest()
     meta = make_chunk_metadata(
         content_type="prose",
-        chunk_index=0,
-        chunk_count=1,
         chunk_text_hash=content_hash,
         content_hash=content_hash,
         chunk_start_char=0,
@@ -273,5 +263,6 @@ def test_t3_put_emits_full_keyset_for_mcp_stored_doc() -> None:
     # Specifically the chash fields that close the RDR-086 coverage hole:
     assert meta["chunk_text_hash"] == content_hash
     assert meta["content_hash"] == content_hash
-    assert meta["chunk_index"] == 0
-    assert meta["chunk_count"] == 1
+    # Phase 3 retired chunk_index / chunk_count from chunk schema.
+    assert "chunk_index" not in meta
+    assert "chunk_count" not in meta

--- a/tests/test_metadata_schema.py
+++ b/tests/test_metadata_schema.py
@@ -33,19 +33,15 @@ def test_allowed_top_level_is_bounded() -> None:
 def test_load_bearing_keys_are_allowed() -> None:
     """Every key read by ``where=`` filters or scoring must be top-level.
 
-    RDR-102 D2 dropped ``source_path`` from the schema — the catalog
-    tumbler in ``doc_id`` is now the canonical reference and the
-    stale-detection where-filters fall back to ``source_path`` only
-    for legacy chunks indexed before the doc_id-keyed identity wiring
-    landed (RDR-101 Phase 5b will drop the fallback branch entirely).
+    RDR-108 Phase 3 retired three chunk-identity keys (``doc_id``,
+    ``chunk_index``, ``chunk_count``): the ``document_chunks`` manifest
+    table is authoritative and the chunk-level fields became cargo.
     """
     from nexus.metadata_schema import ALLOWED_TOP_LEVEL
 
     for key in (
         "content_hash",
         "chunk_text_hash",
-        "chunk_index",
-        "chunk_count",
         "chunk_start_char",
         "chunk_end_char",
         "page_number",
@@ -55,7 +51,6 @@ def test_load_bearing_keys_are_allowed() -> None:
         "section_type",
         "frecency_score",
         "source_agent",
-        "doc_id",  # RDR-101 Phase 3 PR δ — catalog cross-reference
     ):
         assert key in ALLOWED_TOP_LEVEL, f"load-bearing key {key!r} missing"
 
@@ -103,19 +98,16 @@ def test_cargo_keys_not_allowed() -> None:
 
 
 def test_normalize_drops_unknown_keys() -> None:
-    """RDR-102 D2: ``source_path`` is now also a key normalize() drops
-    (the schema-level removal flips it from a load-bearing key to a
-    cargo key). The ``content_hash`` / ``chunk_index`` / ``chunk_count``
-    / ``content_type`` checks below stand in for "load-bearing keys
-    survive" since they remain in ALLOWED_TOP_LEVEL."""
+    """RDR-102 D2: ``source_path`` is no longer in ALLOWED_TOP_LEVEL.
+    RDR-108 Phase 3: ``chunk_index`` / ``chunk_count`` / ``doc_id`` are
+    also dropped. The ``content_hash`` check stands in for "load-bearing
+    keys survive"."""
     from nexus.metadata_schema import normalize
 
     raw = {
         "source_path": "/a.pdf",
         "content_hash": "abc",
         "chunk_text_hash": "def",
-        "chunk_index": 0,
-        "chunk_count": 1,
         "pdf_subject": "should drop",
         "extraction_method": "should drop",
         "ast_chunked": True,
@@ -129,7 +121,6 @@ def test_normalize_drops_unknown_keys() -> None:
         "normalize() must drop it"
     )
     assert out["content_hash"] == "abc"
-    assert out["chunk_index"] == 0
 
 
 def test_normalize_drops_flat_git_keys() -> None:
@@ -142,8 +133,6 @@ def test_normalize_drops_flat_git_keys() -> None:
     raw = {
         "content_hash": "x",
         "chunk_text_hash": "y",
-        "chunk_index": 0,
-        "chunk_count": 1,
         "git_project_name": "nexus",
         "git_branch": "main",
         "git_commit_hash": "deadbeef",
@@ -162,8 +151,6 @@ def test_normalize_injects_content_type() -> None:
         "source_path": "f.py",
         "content_hash": "x",
         "chunk_text_hash": "y",
-        "chunk_index": 0,
-        "chunk_count": 1,
     }
     out = normalize(raw, content_type="code")
     assert out["content_type"] == "code"
@@ -174,7 +161,7 @@ def test_normalize_rejects_invalid_content_type() -> None:
 
     with pytest.raises(ValueError, match="content_type"):
         normalize({"source_path": "a", "content_hash": "x",
-                   "chunk_text_hash": "y", "chunk_index": 0, "chunk_count": 1},
+                   "chunk_text_hash": "y"},
                   content_type="binary")
 
 
@@ -185,8 +172,6 @@ def test_normalize_preserves_bib_fields() -> None:
         "source_path": "p.pdf",
         "content_hash": "x",
         "chunk_text_hash": "y",
-        "chunk_index": 0,
-        "chunk_count": 1,
         "bib_year": 2024,
         "bib_authors": "Smith, Jones",
         "bib_venue": "ICML",
@@ -213,8 +198,6 @@ def test_normalize_is_idempotent() -> None:
         "source_path": "src/foo.py",
         "content_hash": "x",
         "chunk_text_hash": "y",
-        "chunk_index": 0,
-        "chunk_count": 1,
         "git_project_name": "nexus",
         "git_branch": "main",
         "git_commit_hash": "deadbeef",
@@ -236,8 +219,6 @@ def test_normalize_idempotent_on_reprocess() -> None:
     raw = {
         "content_hash": "x",
         "chunk_text_hash": "y",
-        "chunk_index": 0,
-        "chunk_count": 1,
     }
     first = normalize(raw, content_type="code")
     merged = {**first, "bib_year": 2024, "bib_authors": "Doe"}
@@ -257,8 +238,6 @@ def test_normalize_keeps_ttl_and_indexed_at() -> None:
         "source_path": "a",
         "content_hash": "x",
         "chunk_text_hash": "y",
-        "chunk_index": 0,
-        "chunk_count": 1,
         "ttl_days": 0,
         "indexed_at": "2026-04-26T00:00:00+00:00",
     }
@@ -299,8 +278,6 @@ def test_normalize_drops_empty_bib_placeholders() -> None:
         "source_path": "p.pdf",
         "content_hash": "x",
         "chunk_text_hash": "y",
-        "chunk_index": 0,
-        "chunk_count": 1,
         "bib_year": 0,
         "bib_authors": "",
         "bib_venue": "",
@@ -320,8 +297,6 @@ def test_normalize_keeps_partial_bib_when_year_populated() -> None:
         "source_path": "p.pdf",
         "content_hash": "x",
         "chunk_text_hash": "y",
-        "chunk_index": 0,
-        "chunk_count": 1,
         "bib_year": 2024,
         "bib_authors": "",
         "bib_venue": "",
@@ -341,8 +316,6 @@ def test_normalize_keeps_fully_populated_bib() -> None:
         "source_path": "p.pdf",
         "content_hash": "x",
         "chunk_text_hash": "y",
-        "chunk_index": 0,
-        "chunk_count": 1,
         "bib_year": 2024,
         "bib_authors": "Smith",
         "bib_venue": "ICML",
@@ -365,8 +338,6 @@ def test_validate_passes_well_formed() -> None:
         "source_path": "a",
         "content_hash": "x",
         "chunk_text_hash": "y",
-        "chunk_index": 0,
-        "chunk_count": 1,
     }
     validate(normalize(raw, content_type="code"))  # no raise
 
@@ -462,131 +433,69 @@ def test_normalize_output_fits_under_chroma_cap() -> None:
     )
 
 
-# ── RDR-101 Phase 3 PR δ — doc_id schema support ─────────────────────────
+# ── RDR-101 Phase 3 PR δ — doc_id schema (RETIRED by RDR-108 Phase 3) ────
 
 
-class TestDocIdInSchema:
-    """``doc_id`` joins ALLOWED_TOP_LEVEL with drop-when-empty semantics
-    parallel to the bib_* and git_meta filters. Live indexing call sites
-    populate it from ``Catalog.by_file_path(owner, rel_path).tumbler``;
-    call sites that have no Catalog handle pass ``""`` and the field is
-    dropped by ``normalize`` so it does not consume a metadata slot.
+class TestDocIdRetiredFromChunkSchema:
+    """RDR-108 Phase 3 (nexus-bdag) retires ``doc_id`` from chunk-level
+    T3 metadata. The catalog ``document_chunks`` manifest table is now
+    the authoritative document-to-chunk map; carrying ``doc_id`` on the
+    chunk duplicates that state.
+
+    Pre-Phase-3 chunks already in T3 keep the ``doc_id`` field in their
+    stored metadata — the schema change only affects new writes.
+    Phase 4 retargets the read paths (search/scoring/aspects) to consult
+    the manifest directly.
     """
 
-    def test_doc_id_in_allowed_top_level(self) -> None:
+    def test_doc_id_not_in_allowed_top_level(self) -> None:
         from nexus.metadata_schema import ALLOWED_TOP_LEVEL
 
-        assert "doc_id" in ALLOWED_TOP_LEVEL
+        assert "doc_id" not in ALLOWED_TOP_LEVEL
 
-    def test_validate_accepts_doc_id(self) -> None:
-        # WITH TEETH: removing ``doc_id`` from ALLOWED_TOP_LEVEL makes
-        # ``validate`` raise on any chunk metadata that carries it,
-        # which is exactly what blocks the live indexing path under
-        # the funnel's ``_write_batch`` validate call.
-        from nexus.metadata_schema import validate
+    def test_validate_rejects_doc_id_on_new_writes(self) -> None:
+        from nexus.metadata_schema import MetadataSchemaError, validate
 
         meta = {
             "content_hash": "x",
             "chunk_text_hash": "y",
-            "chunk_index": 0,
-            "chunk_count": 1,
             "content_type": "code",
             "doc_id": "1.1.42",
         }
-        validate(meta)  # must not raise
+        with pytest.raises(MetadataSchemaError):
+            validate(meta)
 
-    def test_make_chunk_metadata_propagates_doc_id(self) -> None:
-        # WITH TEETH: confirms make_chunk_metadata wires doc_id into the
-        # raw dict and normalize() preserves it. A regression that
-        # forgot to add doc_id to the raw assignment would drop the
-        # value silently here.
-        from nexus.metadata_schema import make_chunk_metadata
-
-        meta = make_chunk_metadata(
-            content_type="code",
-            chunk_index=0,
-            chunk_count=1,
-            chunk_text_hash="abc",
-            content_hash="def",
-            indexed_at="2026-05-01T00:00:00+00:00",
-            embedding_model="voyage-context-3",
-            doc_id="1.1.42",
-        )
-        assert meta["doc_id"] == "1.1.42"
-
-    def test_make_chunk_metadata_drops_empty_doc_id(self) -> None:
-        # WITH TEETH: drop-when-empty saves the metadata slot for
-        # call sites that don't pass doc_id (back-compat). A regression
-        # that left doc_id="" in the dict would consume one of the
-        # 32 metadata slots for no payload.
-        from nexus.metadata_schema import make_chunk_metadata
-
-        meta = make_chunk_metadata(
-            content_type="code",
-            chunk_index=0,
-            chunk_count=1,
-            chunk_text_hash="abc",
-            content_hash="def",
-            indexed_at="2026-05-01T00:00:00+00:00",
-            embedding_model="voyage-context-3",
-            # doc_id omitted (defaults to "")
-        )
-        assert "doc_id" not in meta
-
-    def test_normalize_drops_explicit_empty_doc_id(self) -> None:
-        # WITH TEETH: normalize() Step 4c drops doc_id when value is
-        # falsy. Same invariant as bib_* and git_meta drop-when-empty.
+    def test_normalize_drops_doc_id(self) -> None:
+        """``normalize`` cargo-drops ``doc_id`` (anything outside
+        ``ALLOWED_TOP_LEVEL`` is removed silently in the cargo filter)."""
         from nexus.metadata_schema import normalize
 
         out = normalize(
             {
-                "source_path": "src/foo.py",
                 "content_hash": "x",
                 "chunk_text_hash": "y",
-                "chunk_index": 0,
-                "chunk_count": 1,
-                "doc_id": "",
+                "doc_id": "1.1.42",
             },
             content_type="code",
         )
         assert "doc_id" not in out
 
-    def test_normalize_preserves_truthy_doc_id(self) -> None:
-        # WITH TEETH: drop-when-empty must not also drop populated
-        # values. A regression that filtered ``doc_id`` unconditionally
-        # would silently lose the catalog cross-reference.
-        from nexus.metadata_schema import normalize
+    def test_make_chunk_metadata_rejects_doc_id_kwarg(self) -> None:
+        """The ``doc_id=`` kwarg is HARD-REMOVED — passing it must raise
+        ``TypeError`` so a regression at any call site is a build break,
+        not a silent drop.
+        """
+        from nexus.metadata_schema import make_chunk_metadata
 
-        out = normalize(
-            {
-                "source_path": "src/foo.py",
-                "content_hash": "x",
-                "chunk_text_hash": "y",
-                "chunk_index": 0,
-                "chunk_count": 1,
-                "doc_id": "1.1.42",
-            },
-            content_type="code",
-        )
-        assert out["doc_id"] == "1.1.42"
-
-    def test_normalize_is_idempotent_with_doc_id(self) -> None:
-        # Round-trip: re-normalising preserves doc_id without accreting
-        # or dropping. Mirrors the bib_* / git_meta idempotency tests.
-        from nexus.metadata_schema import normalize
-
-        raw = {
-            "source_path": "src/foo.py",
-            "content_hash": "x",
-            "chunk_text_hash": "y",
-            "chunk_index": 0,
-            "chunk_count": 1,
-            "doc_id": "1.1.42",
-        }
-        first = normalize(raw, content_type="code")
-        second = normalize(first, content_type="code")
-        assert first == second
-        assert second["doc_id"] == "1.1.42"
+        with pytest.raises(TypeError):
+            make_chunk_metadata(
+                content_type="code",
+                chunk_text_hash="abc",
+                content_hash="def",
+                indexed_at="2026-05-09T00:00:00Z",
+                embedding_model="voyage-code-3",
+                doc_id="1.1.42",
+            )
 
 
 # ── RDR-102 Phase B: source_path retirement ─────────────────────────────
@@ -644,8 +553,6 @@ def test_make_chunk_metadata_rejects_source_path_kwarg() -> None:
         make_chunk_metadata(
             content_type="code",
             source_path="/should/raise/typeerror.py",  # RDR-102 D2: rejected kwarg
-            chunk_index=0,
-            chunk_count=1,
             chunk_text_hash="abc",
             content_hash="def",
             indexed_at="2026-05-02T00:00:00Z",
@@ -665,8 +572,6 @@ def test_make_chunk_metadata_does_not_emit_source_path() -> None:
 
     meta = make_chunk_metadata(
         content_type="code",
-        chunk_index=0,
-        chunk_count=1,
         chunk_text_hash="abc",
         content_hash="def",
         indexed_at="2026-05-02T00:00:00Z",
@@ -724,7 +629,6 @@ class TestPhase5cSchemaRemoval:
         out = normalize(
             {
                 "content_type": "code",
-                "chunk_index": 0, "chunk_count": 1,
                 "chunk_text_hash": "abc", "content_hash": "def",
                 "indexed_at": "2026-05-03T00:00:00Z",
                 "embedding_model": "voyage-code-3",
@@ -753,7 +657,6 @@ class TestPhase5cSchemaRemoval:
         from nexus.metadata_schema import make_chunk_metadata
         common_kwargs = dict(
             content_type="code",
-            chunk_index=0, chunk_count=1,
             chunk_text_hash="abc", content_hash="def",
             indexed_at="2026-05-03T00:00:00Z",
             embedding_model="voyage-code-3",
@@ -775,7 +678,6 @@ class TestPhase5cSchemaRemoval:
         from nexus.metadata_schema import validate, MetadataSchemaError
         good_base = {
             "content_type": "code",
-            "chunk_index": 0, "chunk_count": 1,
             "chunk_text_hash": "abc", "content_hash": "def",
             "indexed_at": "2026-05-03T00:00:00Z",
             "embedding_model": "voyage-code-3",
@@ -795,3 +697,134 @@ class TestPhase5cSchemaRemoval:
         import nexus.config
         assert not hasattr(nexus.metadata_schema, "_GATED_BY_EVENT_SOURCED")
         assert not hasattr(nexus.config, "is_catalog_event_sourced")
+
+
+# ── RDR-108 Phase 3: chunk-identity removal (nexus-bdag) ─────────────────────
+
+
+class TestPhase3SchemaRemoval:
+    """Phase 3 of RDR-108 retires three chunk-identity fields from
+    ``ALLOWED_TOP_LEVEL``: ``doc_id``, ``chunk_index``, ``chunk_count``.
+    After Phase 1's ``document_chunks`` manifest table is the catalog's
+    authoritative document-to-chunk map, these chunk-level metadata
+    keys duplicate manifest state and consume metadata budget for no
+    payload.
+
+    After Phase 3:
+      * The schema rejects all three (cargo-dropped at normalize, raised
+        at validate).
+      * The ``make_chunk_metadata`` factory refuses the kwargs (TypeError
+        — re-introduction is a build break).
+      * Indexer call sites stop emitting them on new writes.
+      * Pre-Phase-3 chunks already in T3 keep the fields in stored
+        metadata (T3 doesn't strip stored metadata when the schema
+        changes); legacy reads still work. Phase 4 rewrites read paths
+        to use the manifest.
+    """
+    PHASE_3_DROPPED = ("doc_id", "chunk_index", "chunk_count")
+
+    def test_dropped_keys_not_in_allowed_top_level(self) -> None:
+        from nexus.metadata_schema import ALLOWED_TOP_LEVEL
+
+        for k in self.PHASE_3_DROPPED:
+            assert k not in ALLOWED_TOP_LEVEL, (
+                f"{k!r} must be removed from ALLOWED_TOP_LEVEL "
+                f"(Phase 3). Current: {sorted(ALLOWED_TOP_LEVEL)}"
+            )
+
+    def test_normalize_drops_phase_3_keys(self) -> None:
+        """``normalize()`` drops the 3 keys via the cargo filter (Step 2:
+        anything outside ALLOWED_TOP_LEVEL is dropped silently)."""
+        from nexus.metadata_schema import normalize
+
+        out = normalize(
+            {
+                "content_hash": "x",
+                "chunk_text_hash": "y",
+                "indexed_at": "2026-05-09T00:00:00Z",
+                "embedding_model": "voyage-code-3",
+                "doc_id": "1.1.42",
+                "chunk_index": 7,
+                "chunk_count": 99,
+            },
+            content_type="code",
+        )
+        for k in self.PHASE_3_DROPPED:
+            assert k not in out, (
+                f"{k!r} survived normalize() — Phase 3 should drop it. "
+                f"Got keys: {sorted(out.keys())}"
+            )
+
+    def test_make_chunk_metadata_rejects_phase_3_kwargs(self) -> None:
+        """``doc_id``, ``chunk_index``, ``chunk_count`` kwargs are removed
+        from the factory signature. Passing any raises ``TypeError`` —
+        re-introduction is a build break.
+        """
+        from nexus.metadata_schema import make_chunk_metadata
+
+        common_kwargs = dict(
+            content_type="code",
+            chunk_text_hash="abc",
+            content_hash="def",
+            indexed_at="2026-05-09T00:00:00Z",
+            embedding_model="voyage-code-3",
+        )
+        for kwarg, value in [
+            ("doc_id", "1.1.42"),
+            ("chunk_index", 0),
+            ("chunk_count", 1),
+        ]:
+            with pytest.raises(TypeError):
+                make_chunk_metadata(**common_kwargs, **{kwarg: value})
+
+    def test_validate_rejects_phase_3_keys(self) -> None:
+        """``validate()`` enforces ALLOWED_TOP_LEVEL membership; the 3
+        Phase 3 keys trigger MetadataSchemaError."""
+        from nexus.metadata_schema import MetadataSchemaError, validate
+
+        good_base = {
+            "content_type": "code",
+            "chunk_text_hash": "abc",
+            "content_hash": "def",
+            "indexed_at": "2026-05-09T00:00:00Z",
+            "embedding_model": "voyage-code-3",
+        }
+        for dropped in self.PHASE_3_DROPPED:
+            with pytest.raises(MetadataSchemaError):
+                validate({**good_base, dropped: "value" if isinstance(dropped, str) and dropped == "doc_id" else 1})
+
+    def test_make_chunk_metadata_does_not_emit_phase_3_keys(self) -> None:
+        """A bare ``make_chunk_metadata`` call with the post-Phase-3
+        signature must NOT emit any of the 3 dropped keys.
+        """
+        from nexus.metadata_schema import make_chunk_metadata
+
+        meta = make_chunk_metadata(
+            content_type="code",
+            chunk_text_hash="abc",
+            content_hash="def",
+            indexed_at="2026-05-09T00:00:00Z",
+            embedding_model="voyage-code-3",
+        )
+        for k in self.PHASE_3_DROPPED:
+            assert k not in meta, (
+                f"{k!r} appeared in factory output post-Phase-3; "
+                f"got keys: {sorted(meta.keys())}"
+            )
+
+    def test_legacy_chunk_dict_reads_unaffected(self) -> None:
+        """Pre-Phase-3 chunks stored in T3 still carry doc_id /
+        chunk_index / chunk_count in their metadata. Direct ``dict.get``
+        reads on a legacy dict continue to return the stored value —
+        the schema change only affects new writes via normalize/validate.
+        """
+        legacy_meta = {
+            "content_hash": "x",
+            "chunk_text_hash": "y",
+            "doc_id": "1.1.42",
+            "chunk_index": 3,
+            "chunk_count": 10,
+        }
+        assert legacy_meta.get("doc_id") == "1.1.42"
+        assert legacy_meta.get("chunk_index") == 3
+        assert legacy_meta.get("chunk_count") == 10

--- a/tests/test_pdf_indexer_doc_id.py
+++ b/tests/test_pdf_indexer_doc_id.py
@@ -124,18 +124,19 @@ def _do_index(repo: Path, registry: RepoRegistry, t3: T3Database, monkeypatch) -
         index_repository(repo, registry, force=False)
 
 
-def test_pdf_indexer_writes_doc_id_into_t3_chunk_metadata(
+def test_pdf_indexer_registers_catalog_and_writes_manifest(
     pdf_repo: Path,
     registry: RepoRegistry,
     local_t3: T3Database,
     catalog_env: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """First-pass indexing of a fresh PDF corpus must:
-      1) Register the PDF in the catalog (was: skipped — PDFs missing from
-         ``indexed_for_catalog`` pre-Stage-B.3).
-      2) Populate ``doc_id`` in every PDF chunk's T3 metadata, matching
-         the catalog tumbler.
+    """RDR-108 Phase 3: PDF indexing must:
+      1) Register the PDF in the catalog (Stage-B.3 ensured PDFs reach
+         ``indexed_for_catalog``).
+      2) Populate the catalog ``document_chunks`` manifest for the PDF's
+         tumbler. Phase 3 retired ``doc_id`` from chunk metadata in
+         favour of the manifest.
     """
     _do_index(pdf_repo, registry, local_t3, monkeypatch)
 
@@ -152,6 +153,12 @@ def test_pdf_indexer_writes_doc_id_into_t3_chunk_metadata(
     # Filter to PDF chunks (the docs__ collection holds prose + PDF mixed).
     pdf_metas = [m for m in result["metadatas"] if m.get("content_type") == "pdf"]
     assert pdf_metas, "expected at least one chunk with content_type='pdf'"
+
+    # Phase 3: chunks must NOT carry doc_id any more.
+    for m in pdf_metas:
+        assert "doc_id" not in m, (
+            f"Phase 3: PDF chunk metadata must not carry doc_id; got {m!r}"
+        )
 
     # Resolve the catalog owner and the PDF's catalog entry.
     owner_row = cat._db.execute(
@@ -170,12 +177,11 @@ def test_pdf_indexer_writes_doc_id_into_t3_chunk_metadata(
         f"expected catalog content_type='pdf', got {pdf_entry.content_type!r}"
     )
 
-    expected_doc_id = str(pdf_entry.tumbler)
-    for m in pdf_metas:
-        assert m.get("doc_id") == expected_doc_id, (
-            f"PDF chunk carries doc_id={m.get('doc_id')!r}, "
-            f"expected {expected_doc_id!r} (catalog tumbler)"
-        )
+    manifest_rows = cat.get_manifest(str(pdf_entry.tumbler))
+    assert manifest_rows, (
+        f"manifest_write_batch_hook must populate document_chunks for "
+        f"PDF doc_id={pdf_entry.tumbler!r}"
+    )
 
 
 def test_pdf_indexer_doc_id_absent_when_catalog_uninitialized(

--- a/tests/test_pdf_subsystem.py
+++ b/tests/test_pdf_subsystem.py
@@ -105,7 +105,12 @@ class TestPdfChunksMetadata:
             # not in ALLOWED_TOP_LEVEL.
             assert "page_count" not in meta
             assert "extraction_method" not in meta
-            assert meta["chunk_count"] == len(result)
+            # RDR-108 Phase 3 (nexus-bdag): chunk_count / chunk_index /
+            # doc_id retired from chunk metadata. Catalog manifest carries
+            # the document-to-chunk binding instead.
+            assert "chunk_count" not in meta
+            assert "chunk_index" not in meta
+            assert "doc_id" not in meta
             # title (was source_title): Docling content-extracted or filename fallback
             assert isinstance(meta["title"], str)
             # source_author: Docling does not expose XMP author; may be empty

--- a/tests/test_pipeline_stages.py
+++ b/tests/test_pipeline_stages.py
@@ -362,6 +362,61 @@ class TestUploaderLoop:
         assert s["chunks_uploaded"] == 3 and s["status"] == "completed"
         t3.upsert_chunks_with_embeddings.assert_called_once()
 
+    def test_uploader_injects_global_chunk_index_into_hook_payload(self, db) -> None:
+        """RDR-108 Phase 3 (nexus-bdag): the streaming uploader populates
+        the per-batch hook chain with a metadata blob that carries the
+        global ``chunk_index`` from T2's ``chunk_index`` column. Without
+        the injection the manifest hook falls through to a batch-local
+        enumeration that resets each batch — which would silently
+        truncate the manifest for documents that span multiple upload
+        batches.
+
+        Verifies the injection happens AFTER ``upsert_chunks_with_embeddings``
+        returns: T3 receives the post-Phase-3 metadata (no
+        ``chunk_index``); the hook receives the injected value.
+        """
+        from unittest.mock import patch
+
+        _pop_chunks(db, "h1", 200)
+        t3 = MagicMock()
+
+        # Capture the metadata seen by the batch hook chain and the T3 upsert.
+        seen_in_hook: list[list[dict]] = []
+        seen_in_t3: list[list[dict]] = []
+        t3.upsert_chunks_with_embeddings.side_effect = (
+            lambda collection, ids, documents, embeddings, metadatas:
+            seen_in_t3.append([dict(m) for m in metadatas])
+        )
+
+        def _capture_batch(doc_ids, collection, contents, embeddings, metadatas, **_kwargs):
+            seen_in_hook.append([dict(m) for m in metadatas])
+
+        with patch(
+            "nexus.mcp_infra._post_store_batch_hooks",
+            [_capture_batch],
+        ), patch(
+            "nexus.mcp_infra._post_store_batch_hooks_with_catalog_doc_id",
+            {id(_capture_batch)},
+        ):
+            uploader_loop("h1", db, t3, "docs__test", threading.Event())
+
+        # Two batches expected: 128 + 72.
+        assert [len(b) for b in seen_in_hook] == [128, 72]
+        # Hook payload carries global chunk_index 0..127 then 128..199.
+        assert [m["chunk_index"] for m in seen_in_hook[0]] == list(range(128))
+        assert [m["chunk_index"] for m in seen_in_hook[1]] == list(range(128, 200))
+        # T3 received the unmutated copy: no ``chunk_index`` should have
+        # been injected before the T3 upsert. (The injection happens
+        # after ``upsert_chunks_with_embeddings`` returns; ``side_effect``
+        # captures the dict at call time.)
+        for batch in seen_in_t3:
+            for m in batch:
+                assert "chunk_index" not in m, (
+                    f"chunk_index leaked into T3 upsert payload: {m!r}. "
+                    f"The injection must happen AFTER "
+                    f"upsert_chunks_with_embeddings returns."
+                )
+
 
 
 class TestPipelineIndexPdf:

--- a/tests/test_pipeline_stages.py
+++ b/tests/test_pipeline_stages.py
@@ -546,17 +546,11 @@ class TestPipelineIndexPdf:
     def test_writes_doc_id_when_catalog_initialized(
         self, db, tmp_path, monkeypatch,
     ) -> None:
-        """RDR-102 D4 #2 (streaming pipeline mirror): pipeline_index_pdf
-        must populate ``doc_id`` on every chunk it uploads when the
-        catalog is initialized.
-
-        Pre-Phase-A this fails because the streaming pipeline registers
-        the catalog Document via ``_catalog_pdf_hook`` AFTER the upload
-        completes (line 729 of pipeline_stages.py); ``chunker_loop``
-        builds chunk metadata via ``_build_chunk_metadata`` →
-        ``make_chunk_metadata()`` with no ``doc_id`` argument. Phase A
-        registers the Document at the streaming-entry boundary and
-        threads doc_id through chunker_loop's metadata builder.
+        """RDR-108 Phase 3: pipeline_index_pdf no longer stamps ``doc_id``
+        on chunks. The streaming pipeline still registers the catalog
+        Document at the entry boundary; the catalog manifest hook
+        populates ``document_chunks`` from the post-store batch fire.
+        Verify chunks lack doc_id and the manifest carries it instead.
         """
         import chromadb
         from nexus.catalog import reset_cache
@@ -600,14 +594,23 @@ class TestPipelineIndexPdf:
         assert rows["metadatas"], (
             "expected at least one chunk in docs__rdr102_stream"
         )
-        missing_doc_id = [m for m in rows["metadatas"] if not m.get("doc_id")]
-        assert not missing_doc_id, (
-            f"{len(missing_doc_id)}/{len(rows['metadatas'])} streaming "
-            f"pipeline chunks missing doc_id. Phase A must register the "
-            f"catalog Document at the pipeline_index_pdf entry boundary "
-            f"and thread doc_id through chunker_loop's metadata builder, "
-            f"not via the post-upload _catalog_pdf_hook."
-        )
+        # Phase 3: no doc_id on chunk metadata.
+        for m in rows["metadatas"]:
+            assert "doc_id" not in m
+
+        # Manifest carries the doc-to-chunk binding instead.
+        from nexus.catalog import open_cached
+        cat = open_cached(cat_dir)
+        documents = cat._db.execute(
+            "SELECT tumbler FROM documents WHERE physical_collection = ?",
+            ("docs__rdr102-stream__voyage-context-3__v1",),
+        ).fetchall()
+        assert documents, "catalog must register a Document for the streaming PDF"
+        for row in documents:
+            assert cat.get_manifest(row[0]), (
+                f"manifest_write_batch_hook must populate document_chunks "
+                f"for doc_id={row[0]!r}"
+            )
 
 
 
@@ -630,9 +633,9 @@ class TestBufferEdgeCases:
 
 _REQUIRED_META = {
     # Identity / spans / position — RDR-102 D2 dropped source_path.
-    # doc_id is drop-when-empty so it's not in this required set
-    # (the chunker_loop test below has no catalog).
-    "content_hash", "chunk_text_hash", "chunk_index", "chunk_count",
+    # RDR-108 Phase 3 (nexus-bdag) dropped chunk_index, chunk_count, doc_id
+    # in favour of the catalog ``document_chunks`` manifest.
+    "content_hash", "chunk_text_hash",
     "chunk_start_char", "chunk_end_char", "line_start", "line_end", "page_number",
     # Display / routing — RDR-101 Phase 5c (nexus-o6aa.13) dropped
     # ``store_type``, ``corpus``, ``git_meta``. ``title`` kept (audit

--- a/tests/test_post_store_hook.py
+++ b/tests/test_post_store_hook.py
@@ -18,13 +18,22 @@ def chroma_client() -> chromadb.ClientAPI:
 
 @pytest.fixture(autouse=True)
 def _reset_hooks():
-    """Clear post_store_hooks between tests to prevent cross-test leakage."""
+    """Clear post_store_hooks between tests to prevent cross-test leakage.
+
+    Snapshots the load-bearing batch-hook list (chash dual-write,
+    taxonomy assign, manifest write — registered at module load in
+    ``mcp_infra``) and restores it on teardown so subsequent tests
+    that depend on the catalog manifest hook firing do not see an
+    empty hook list.
+    """
     from nexus.mcp_infra import _post_store_batch_hooks, _post_store_hooks
+    snapshot = list(_post_store_batch_hooks)
     _post_store_hooks.clear()
     _post_store_batch_hooks.clear()
     yield
     _post_store_hooks.clear()
     _post_store_batch_hooks.clear()
+    _post_store_batch_hooks.extend(snapshot)
 
 
 # ── Hook mechanism ───────────────────────────────────────────────────────────

--- a/tests/test_prose_indexer_doc_id.py
+++ b/tests/test_prose_indexer_doc_id.py
@@ -130,16 +130,18 @@ def _do_index(repo: Path, registry: RepoRegistry, t3: T3Database, monkeypatch) -
         index_repository(repo, registry, force=False)
 
 
-def test_prose_indexer_writes_doc_id_into_t3_chunk_metadata(
+def test_prose_indexer_writes_manifest_rows_for_each_document(
     prose_repo: Path,
     registry: RepoRegistry,
     local_t3: T3Database,
     catalog_env: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """First-pass indexing of a fresh prose corpus must populate ``doc_id``
-    in every chunk's T3 metadata, matching the catalog tumbler the
-    orchestrator registered before per-file indexing.
+    """RDR-108 Phase 3 (nexus-bdag) retired ``doc_id`` from chunk metadata
+    in favour of the catalog ``document_chunks`` manifest. First-pass
+    indexing of a fresh prose corpus must therefore populate manifest
+    rows for every registered Document instead of stamping doc_id on
+    every chunk.
 
     Covers both the markdown and non-markdown branches of
     ``prose_indexer.index_prose_file``.
@@ -156,41 +158,36 @@ def test_prose_indexer_writes_doc_id_into_t3_chunk_metadata(
     result = docs_col.get(include=["metadatas"])
     assert result["ids"], "expected at least one prose chunk in T3 docs collection"
 
-    # RDR-102 D2 dropped source_path from the chunk schema. Group
-    # chunks by doc_id (Phase A canonical identity); the chunk title
-    # carries "{relpath}:chunk-{i}" so we can still verify both
-    # branches (markdown vs line-chunk for .rst) ran.
-    by_doc_id: dict[str, list[dict]] = {}
+    # Phase 3: chunks must NOT carry doc_id any more (catalog manifest
+    # is authoritative).
     for meta in result["metadatas"]:
-        doc_id = meta.get("doc_id", "")
-        assert doc_id, (
-            f"chunk metadata lacks doc_id (Phase A pre-flight "
-            f"registration regression): {meta}"
+        assert "doc_id" not in meta, (
+            f"Phase 3: chunk metadata must not carry doc_id; got {meta!r}"
         )
-        by_doc_id.setdefault(doc_id, []).append(meta)
+        assert "chunk_index" not in meta
+        assert "chunk_count" not in meta
 
-    assert by_doc_id, "expected metadatas to carry doc_id"
-
-    owner_row = cat._db.execute(
-        "SELECT tumbler_prefix FROM owners LIMIT 1"
-    ).fetchone()
-    assert owner_row is not None, "expected catalog owner registered by indexer"
+    # Each registered Document in the docs collection must have a manifest.
+    documents = cat._db.execute(
+        "SELECT tumbler, file_path FROM documents "
+        "WHERE physical_collection = ?",
+        (docs_collection,),
+    ).fetchall()
+    assert documents, "expected catalog Documents for the docs collection"
 
     md_seen = False
     rst_seen = False
-    for doc_id, metas in by_doc_id.items():
-        # doc_id is the catalog tumbler — resolve confirms the row
-        # exists. Use the first chunk's title to detect which branch
-        # produced the chunk (markdown vs .rst line-chunk).
-        entry = cat.resolve(Tumbler.parse(doc_id))
-        assert entry is not None, (
-            f"catalog has no Document for doc_id={doc_id!r} — "
-            "pre-index registration should have created one"
+    for row in documents:
+        tumbler = row[0]
+        file_path = row[1] or ""
+        manifest_rows = cat.get_manifest(tumbler)
+        assert manifest_rows, (
+            f"manifest_write_batch_hook must populate document_chunks "
+            f"for doc_id={tumbler!r} (file_path={file_path!r})"
         )
-        title = metas[0].get("title", "")
-        if ".md" in title:
+        if file_path.endswith(".md"):
             md_seen = True
-        if ".rst" in title:
+        if file_path.endswith(".rst"):
             rst_seen = True
 
     assert md_seen, "markdown branch (SemanticMarkdownChunker) was not exercised"

--- a/tests/test_store_enrich_doc_id.py
+++ b/tests/test_store_enrich_doc_id.py
@@ -132,11 +132,15 @@ def test_store_put_cli_writes_catalog_doc_id_into_t3_chunk_metadata(
     ]
     assert matching_metas, "expected a chunk with title='finding-doc-id-pin'"
 
+    # RDR-108 Phase 3: chunks no longer carry ``doc_id``. The catalog
+    # entry's existence (asserted above) is the contract Phase 3 locks
+    # in; the manifest is populated by the post-store batch hook.
     for m in matching_metas:
-        assert m.get("doc_id") == expected_doc_id, (
-            f"chunk for finding-doc-id-pin carries doc_id={m.get('doc_id')!r}, "
-            f"expected {expected_doc_id!r} (catalog tumbler)"
+        assert "doc_id" not in m, (
+            f"Phase 3: chunk for finding-doc-id-pin must not carry doc_id; "
+            f"got {m!r}"
         )
+    assert expected_doc_id, "expected catalog tumbler for the stored doc"
 
 
 def test_store_put_doc_id_absent_when_catalog_uninitialized(


### PR DESCRIPTION
## Summary

RDR-108 Phase 3: retire ``doc_id``, ``chunk_index``, ``chunk_count`` from T3 chunk metadata. The catalog ``document_chunks`` manifest (Phase 1d) is now the authoritative document-to-chunk binding; chunk-level mirrors of those fields consumed metadata budget for no payload.

- **Schema**: ``ALLOWED_TOP_LEVEL`` drops the three keys; ``make_chunk_metadata`` refuses them as kwargs (TypeError on regression). Pre-Phase-3 chunks keep the fields in their stored metadata; Phase 4 retargets read paths.
- **Indexers**: every chunk-write call site dropped the three kwargs. ``fire_post_store_batch_hooks`` gains a kwarg-only ``catalog_doc_id`` (with backward-compat fallback for legacy hook signatures). Hooks now self-register at module load in ``mcp_infra.py`` so CLI ingest fires them too — pre-Phase-3 the registrations lived in ``mcp/core.py`` and CLI-only flows silently skipped them.
- **Catalog correctness**: replaced ``INSERT OR REPLACE INTO documents`` with ``INSERT ... ON CONFLICT DO UPDATE`` (in ``catalog_writes`` and ``projector``) so the FK ``ON DELETE CASCADE`` from ``document_chunks → documents`` no longer wipes the manifest on every catalog update. The ``_ensure_consistent`` rebuild also disables FK around DELETE+replay so the cascade does not fire mid-rebuild.
- **Read paths**: ``check_staleness`` keys on ``content_hash`` (the file-level fingerprint every chunk shares) instead of the now-absent ``doc_id``.

## Test plan

- [x] ``uv run pytest`` — full unit suite: **6874 passed, 33 skipped, 3 xfailed**.
- [x] Manifest population verified end-to-end via ``test_*_indexer_doc_id.py`` family — chunks land with no ``doc_id``, ``catalog.get_manifest(tumbler)`` returns the chash/position rows.
- [x] Hook registrations now fire from CLI ingest as well as MCP — confirmed via ``test_store_put_cli_parity.py``.
- [x] Backwards-compat: legacy hook signatures still fire via the ``TypeError`` fallback in ``fire_post_store_batch_hooks``.

## Closes

Closes nexus-bdag

## Phase 4 follow-up (not in this PR)

- ``index_doc`` prune path still uses ``_identity_where`` (source_path fallback) — Phase 4 (nexus-mmf5/dyxe/z1mu/kosc) rewrites it to consult the manifest. Until then, re-indexing an edited file leaves stale chunks; the prune part of ``test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex`` is documented as Phase 4 work.
- The 290k existing T3 chunks still carry ``doc_id``/``chunk_index``/``chunk_count`` until the operator runs ``nx t3 reidentify --all-collections`` (Phase 2 verb). Phase 4 read-path rewrites + that operator action close the loop.