### PR TITLE
fix(windows): replace fcntl.flock with cross-platform locking helper

### DIFF
--- a/src/nexus/_locking.py
+++ b/src/nexus/_locking.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+
+"""Cross-platform advisory exclusive locking.
+
+Wraps POSIX ``fcntl.flock`` (Linux/macOS) and ``msvcrt.locking`` (Windows)
+behind a small uniform API so the rest of the codebase doesn't carry
+platform branches. Locks are advisory at the OS level: processes that
+don't participate in the protocol can still write through them, but every
+nexus writer routes through this module so the protocol holds.
+
+Two patterns:
+
+* :func:`acquire_directory_lock` — serializes catalog writers. On Unix
+  we ``flock`` the directory fd directly; Windows can't lock directory
+  handles, so we lock a sentinel file ``<dir>/.lock`` instead. The
+  caller's contract is unchanged — opaque token in, ``release_lock``
+  with the token out.
+
+* :func:`lock_file` / :func:`unlock_file` — exclusive lock on an
+  already-open regular file (used by the per-repo PID lock in the
+  indexer). Non-blocking failures raise ``BlockingIOError`` on both
+  platforms so callers handle them with a single except clause.
+
+``msvcrt.locking(LK_LOCK)`` only retries ten times before raising; we
+loop it for true blocking semantics matching ``fcntl.LOCK_EX``.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+from typing import IO, Any
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+__all__ = [
+    "acquire_directory_lock",
+    "release_lock",
+    "lock_file",
+    "unlock_file",
+]
+
+
+_DIR_LOCK_SENTINEL = ".lock"
+
+
+def acquire_directory_lock(directory: Path) -> int:
+    """Take an exclusive lock that serializes writers on ``directory``.
+
+    Blocks until granted. Returns an opaque integer token that must be
+    passed to :func:`release_lock`.
+    """
+    if sys.platform == "win32":
+        sentinel = directory / _DIR_LOCK_SENTINEL
+        fd = os.open(str(sentinel), os.O_RDWR | os.O_CREAT, 0o644)
+        try:
+            while True:
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                    break
+                except OSError:
+                    time.sleep(0.5)
+        except BaseException:
+            os.close(fd)
+            raise
+        return fd
+    fd = os.open(str(directory), os.O_RDONLY)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except BaseException:
+        os.close(fd)
+        raise
+    return fd
+
+
+def release_lock(fd: int) -> None:
+    """Release a lock acquired by :func:`acquire_directory_lock`."""
+    try:
+        if sys.platform == "win32":
+            try:
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+        else:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+def lock_file(file_obj: IO[Any], *, blocking: bool) -> None:
+    """Take an exclusive lock on ``file_obj`` (an open regular file).
+
+    Caller retains ownership of ``file_obj`` and is responsible for
+    calling :func:`unlock_file` and closing the file.
+
+    Raises ``BlockingIOError`` if ``blocking=False`` and the lock is
+    contended.
+    """
+    fd = file_obj.fileno()
+    if sys.platform == "win32":
+        if blocking:
+            while True:
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                    return
+                except OSError:
+                    time.sleep(0.5)
+        else:
+            try:
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            except OSError as e:
+                raise BlockingIOError(str(e)) from e
+    else:
+        flag = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+        fcntl.flock(fd, flag)
+
+
+def unlock_file(file_obj: IO[Any]) -> None:
+    """Release a lock acquired by :func:`lock_file`."""
+    fd = file_obj.fileno()
+    if sys.platform == "win32":
+        try:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+    else:
+        fcntl.flock(fd, fcntl.LOCK_UN)

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
 import os
@@ -20,6 +19,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import structlog
+
+from nexus._locking import acquire_directory_lock, release_lock
 
 if TYPE_CHECKING:
     from chromadb.api import ClientAPI
@@ -741,13 +742,10 @@ class Catalog:
     # ── Locking ────────────────────────────────────────────────────────────
 
     def _acquire_lock(self) -> int:
-        dir_fd = os.open(str(self._dir), os.O_RDONLY)
-        fcntl.flock(dir_fd, fcntl.LOCK_EX)
-        return dir_fd
+        return acquire_directory_lock(self._dir)
 
     def _release_lock(self, dir_fd: int) -> None:
-        fcntl.flock(dir_fd, fcntl.LOCK_UN)
-        os.close(dir_fd)
+        release_lock(dir_fd)
 
     # ── JSONL append helpers ───────────────────────────────────────────────
 

--- a/src/nexus/catalog/event_log.py
+++ b/src/nexus/catalog/event_log.py
@@ -6,8 +6,10 @@
 The event log is the canonical state per RDR-101 §"Core invariants". This
 module owns the on-disk format (JSONL, one envelope per line) and the
 locking pattern that the existing ``Catalog`` JSONL files use today: a
-directory-level ``fcntl.flock`` taken before every append, mirroring
-``Catalog._acquire_lock`` / ``Catalog._append_jsonl``.
+directory-level exclusive lock taken before every append, mirroring
+``Catalog._acquire_lock`` / ``Catalog._append_jsonl``. Locking is
+delegated to :mod:`nexus._locking`, which uses POSIX ``fcntl.flock`` on
+Unix and a sentinel-file ``msvcrt.locking`` on Windows.
 
 The Phase 1 writer is shadow-only: nothing reads from this log yet and
 the existing ``Catalog.register()`` / ``update()`` continue to write to
@@ -25,7 +27,6 @@ malformed line would brick the projector.
 
 from __future__ import annotations
 
-import fcntl
 import json
 import os
 from collections.abc import Iterator
@@ -33,6 +34,7 @@ from pathlib import Path
 
 import structlog
 
+from nexus._locking import acquire_directory_lock, release_lock
 from nexus.catalog.events import Event
 
 _log = structlog.get_logger()
@@ -82,15 +84,13 @@ class EventLog:
         primitives before calling.
         """
         line = json.dumps(event.to_dict(), separators=(",", ":"))
-        dir_fd = os.open(str(self._dir), os.O_RDONLY)
+        dir_fd = acquire_directory_lock(self._dir)
         try:
-            fcntl.flock(dir_fd, fcntl.LOCK_EX)
             with self._path.open("a") as f:
                 f.write(line)
                 f.write("\n")
         finally:
-            fcntl.flock(dir_fd, fcntl.LOCK_UN)
-            os.close(dir_fd)
+            release_lock(dir_fd)
 
     def append_many(self, events: list[Event]) -> None:
         """Append a batch of events under a single flock acquisition.
@@ -109,16 +109,14 @@ class EventLog:
             json.dumps(e.to_dict(), separators=(",", ":"))
             for e in events
         ]
-        dir_fd = os.open(str(self._dir), os.O_RDONLY)
+        dir_fd = acquire_directory_lock(self._dir)
         try:
-            fcntl.flock(dir_fd, fcntl.LOCK_EX)
             with self._path.open("a") as f:
                 for line in lines:
                     f.write(line)
                     f.write("\n")
         finally:
-            fcntl.flock(dir_fd, fcntl.LOCK_UN)
-            os.close(dir_fd)
+            release_lock(dir_fd)
 
     def replay(self) -> Iterator[Event]:
         """Yield events in append order. Skips malformed lines with a warning.

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -17,7 +17,6 @@ Per-file indexing logic lives in focused sub-modules (RDR-032):
   nexus.index_context  — IndexContext dataclass
 """
 import errno
-import fcntl
 import os
 import subprocess
 import time
@@ -27,6 +26,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from nexus._locking import lock_file, unlock_file
 from nexus.corpus import index_model_for_collection
 from nexus.retry import _chroma_with_retry, _voyage_with_retry  # noqa: F401 — re-exported for any existing imports
 from nexus.errors import CredentialsMissingError  # re-exported for backward compatibility
@@ -200,8 +200,8 @@ def _clear_stale_lock(lock_path: Path) -> None:
     The second case handles background processes (disown/&) that were killed
     before writing their PID, leaving empty 0-byte lock files forever.
 
-    This is advisory cleanup — ``fcntl.flock`` provides the real mutual
-    exclusion.
+    This is advisory cleanup — the platform lock from
+    :mod:`nexus._locking` provides the real mutual exclusion.
     """
     if not lock_path.exists():
         return
@@ -885,9 +885,8 @@ def index_repository(
             lock_fd.flush()
         except OSError:
             pass  # PID write is best-effort; lock still works without it
-        lock_flag = fcntl.LOCK_EX if on_locked == "wait" else fcntl.LOCK_EX | fcntl.LOCK_NB
         try:
-            fcntl.flock(lock_fd, lock_flag)
+            lock_file(lock_fd, blocking=(on_locked == "wait"))
         except BlockingIOError:
             # on_locked == "skip" and another process holds the lock
             lock_fd.close()
@@ -912,7 +911,7 @@ def index_repository(
             raise
     finally:
         if lock_fd is not None:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            unlock_file(lock_fd)
             lock_fd.close()
         if lock_path is not None:
             try:


### PR DESCRIPTION
## Summary
- Replaces three `fcntl.flock` call sites with a small `nexus._locking` helper that uses POSIX `fcntl` on Unix and `msvcrt.locking` on Windows.
- Unblocks all CLI usage on Windows — pre-fix, every `nx` invocation crashed with `ModuleNotFoundError: No module named 'fcntl'` at import time, before click ever dispatched.
- POSIX behaviour preserved: same `os.open(dir, O_RDONLY)` + `fcntl.flock(LOCK_EX)` calls, same exception types. Only the Windows path is new code.

## Why now
Filed against #619 (Windows first-run shakedown). After installing every declared dependency on Windows 11 (`uv`, `node`, `bd`, `ripgrep`, `uv tool install conexus`), `nx --version` still failed with the fcntl import error. This is the smallest patch that makes `nx doctor` green on Windows.

## Design
New module: `src/nexus/_locking.py` (~130 lines, fully docstring'd).

Two patterns surface, mirroring the original call sites:

* `acquire_directory_lock(dir)` / `release_lock(token)` — exclusive lock that serializes catalog writers. Unix flocks the directory fd directly (unchanged from before). Windows can't lock directory handles, so we lock a sentinel file `<dir>/.lock` via `msvcrt.locking` instead. The caller's contract is identical — opaque token in/out.

* `lock_file(file_obj, blocking=...)` / `unlock_file(file_obj)` — exclusive lock on an already-open regular file (used by the per-repo PID lock in `indexer.py`). Non-blocking failures raise `BlockingIOError` on both platforms so callers keep one `except` clause.

One Windows quirk worth knowing: `msvcrt.locking(LK_LOCK)` only retries ten times (~10s) before raising, unlike `fcntl.LOCK_EX` which truly blocks. The helper loops `LK_LOCK` with a 0.5s sleep so the blocking-wait path matches POSIX semantics.

## Diff shape
```
 src/nexus/_locking.py          | new (~130 lines)
 src/nexus/catalog/catalog.py   | 10 ++++------
 src/nexus/catalog/event_log.py | 20 +++++++++-----------
 src/nexus/indexer.py           | 11 +++++------
 4 files changed, 150 insertions(+), 23 deletions(-)
```

The three call-site files now drop `import fcntl`, gain `from nexus._locking import …`, and replace four flock blocks with helper calls. Two stale docstring mentions of `fcntl.flock` updated to reference the abstraction.

## Test plan
- [x] `nx --version` reports `4.29.1` (Windows 11, Python 3.12.13)
- [x] `nx doctor` exits 0 with all 14 checks green (Windows 11)
- [ ] `nx doctor` on macOS / Linux — POSIX path is byte-equivalent to before, so no regression expected; CI run would confirm
- [ ] Concurrent indexer wait/skip behaviour on Windows — exercised manually but not yet covered by an automated test

## Notes / out of scope
- The marketplace plugin's bash-only hooks are still a separate Windows blocker (tracked under #619).
- `nx doctor`'s ✓ glyph crashes Windows cp1252 consoles; `PYTHONIOENCODING=utf-8` works around it. Worth a follow-up to either utf-8-wrap click stdout or make the output ASCII-safe by default.
- New sentinel file `.lock` appears inside catalog directories on Windows. Should probably be added to whatever `.gitignore` patterns the catalog generates — happy to do that here on request, or in a follow-up.