### PR TITLE
feat(operators): qwen_dispatch + per-operator routing

### DIFF
--- a/src/nexus/operators/dispatch_router.py
+++ b/src/nexus/operators/dispatch_router.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Per-operator routing between Qwen and Claude dispatch backends.
+
+Three modes of operation, controlled by ``NEXUS_DISPATCH_BACKEND``:
+
+* ``claude`` (default when unset): all bundles route to ``claude_dispatch``.
+  Preserves existing behavior — no surprise dispatch flips on a fresh
+  install.
+* ``qwen``: all bundles route to ``qwen_dispatch``.
+* ``auto``: per-operator routing per the bench-grounded table below.
+
+Per-operator overrides apply in **all** modes (most-granular wins):
+
+* ``NEXUS_DISPATCH_QWEN_OPERATORS=op1,op2,…``  — pin to qwen
+* ``NEXUS_DISPATCH_CLAUDE_OPERATORS=op1,op2,…`` — pin to claude
+
+Bake-in defaults are grounded in measurement —
+``qwen-coprocessor-stack/scripts/bench/`` (run 2026-05-09) covered all
+ten bundleable operator types with 10/10 schema-conforming output on
+both engines and content-tied or near-tied on 9/10 cases. Only
+``extract`` showed a clear Qwen content loss (heuristically filtered
+underscore-prefixed identifiers despite an "every top-level function"
+prompt) and stays pinned to Claude.
+
+Operator-chooses pattern: defaults reflect bench evidence, the operator
+flips to ``auto`` (or pins per-operator) when ready, no flag day.
+"""
+from __future__ import annotations
+
+import os
+from typing import Iterable, Literal
+
+__all__ = [
+    "DispatchBackend",
+    "QWEN_OPERATORS_DEFAULT",
+    "CLAUDE_OPERATORS_PINNED",
+    "pick_dispatcher",
+    "pick_dispatcher_for_bundle",
+]
+
+
+DispatchBackend = Literal["qwen", "claude"]
+
+
+#: Operators routed to Qwen when ``NEXUS_DISPATCH_BACKEND=auto``.
+#: Bench: 10/10 schema-conforming; content tied or near-tied. Filter
+#: showed minor formatting drift (kept input enum prefix) but content
+#: was correct — operator preference is to favor Qwen pipelines for
+#: filter (cleaner), so it lives here despite the cosmetic note.
+QWEN_OPERATORS_DEFAULT: frozenset[str] = frozenset({
+    "summarize", "compare", "rank", "filter",
+    "aggregate", "groupby", "verify", "check", "generate",
+})
+
+#: Operators where Qwen lost precision in the bench. Pinned to Claude
+#: in ``auto`` mode until a tighter prompt or grammar enforcement
+#: closes the gap.
+#:   extract: Qwen heuristically filtered "private-looking" identifiers
+#:     (underscore-prefix) despite the prompt asking for *every*
+#:     top-level function. Precision loss matters more here than on
+#:     other operators because extract typically heads a pipeline:
+#:     downstream rank / compare / summarize all consume its output.
+CLAUDE_OPERATORS_PINNED: frozenset[str] = frozenset({
+    "extract",
+})
+
+
+def _bare(tool: str) -> str:
+    """Strip the optional ``operator_`` prefix nexus uses on some plan YAMLs."""
+    return tool.removeprefix("operator_")
+
+
+def _parse_env_set(name: str) -> frozenset[str]:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return frozenset()
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+def pick_dispatcher(operator_name: str) -> DispatchBackend:
+    """Route a single operator to its dispatcher.
+
+    Resolution order (highest priority first):
+
+    1. ``NEXUS_DISPATCH_CLAUDE_OPERATORS`` env contains this operator → claude
+    2. ``NEXUS_DISPATCH_QWEN_OPERATORS`` env contains this operator → qwen
+    3. ``NEXUS_DISPATCH_BACKEND=qwen`` → qwen
+    4. ``NEXUS_DISPATCH_BACKEND=auto`` → bake-in routing table
+       (``CLAUDE_OPERATORS_PINNED`` then ``QWEN_OPERATORS_DEFAULT``)
+    5. ``NEXUS_DISPATCH_BACKEND=claude`` or unset → claude
+
+    Per-operator pins always win — they're the most granular surface
+    and let the operator opt one operator into qwen on an otherwise-
+    claude environment, or force one back to claude when ``auto`` is
+    on.
+    """
+    bare = _bare(operator_name)
+
+    # Per-operator pins win regardless of mode.
+    if bare in _parse_env_set("NEXUS_DISPATCH_CLAUDE_OPERATORS"):
+        return "claude"
+    if bare in _parse_env_set("NEXUS_DISPATCH_QWEN_OPERATORS"):
+        return "qwen"
+
+    mode = os.environ.get("NEXUS_DISPATCH_BACKEND", "").strip().lower()
+    if mode == "qwen":
+        return "qwen"
+    if mode == "auto":
+        if bare in CLAUDE_OPERATORS_PINNED:
+            return "claude"
+        if bare in QWEN_OPERATORS_DEFAULT:
+            return "qwen"
+        # Unknown operator under auto-mode: conservative.
+        return "claude"
+    # mode == "claude" or unset: default Claude (preserves prior behavior).
+    return "claude"
+
+
+def pick_dispatcher_for_bundle(tools: Iterable[str]) -> DispatchBackend:
+    """Route an entire bundle.
+
+    Conservative semantics: if **any** step in the bundle would route
+    to Claude, the whole bundle goes to Claude. This preserves bundle
+    amortization (one HTTP/subprocess call per N operators) without
+    risking a Qwen-handled extract step in an otherwise-Qwen bundle.
+
+    Empty input → claude (defensive — should not happen in practice
+    since bundles must have ≥2 steps to exist).
+    """
+    seen = False
+    for tool in tools:
+        seen = True
+        if pick_dispatcher(tool) == "claude":
+            return "claude"
+    return "qwen" if seen else "claude"

--- a/src/nexus/operators/qwen_dispatch.py
+++ b/src/nexus/operators/qwen_dispatch.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Async Qwen dispatch — drop-in alternative to ``claude_dispatch``.
+
+Single responsibility: deliver one schema-bounded synthesis call to a
+locally-hosted llama.cpp / OpenAI-compat backend, return parsed JSON.
+
+The qwen-coprocessor-stack supervisor
+(https://github.com/Hellblazer/qwen-coprocessor-stack) defined the
+SpawnOpts surface this dispatch mirrors: ``thinking_mode`` disabled by
+default (Qwen3.6's chain-of-thought adds ~6× output token bloat per
+Artificial Analysis 2026-04, impractical for synthesis), JSON Schema
+rendered into the system prompt as a directive, defensive markdown
+fence stripping post-response.
+
+No grammar enforcement (yet); relies on Qwen3.6's instruction-following
+on JSON output. Bench measurement against the seed cases at
+qwen-coprocessor-stack/scripts/bench/ shows 10/10 schema-conforming
+output. Retry-on-parse-failure is bounded by ``max_attempts``.
+
+Resolution chain for backend URL/model (all optional, fall through
+left-to-right):
+
+* explicit args (``backend_url=``, ``model=``)
+* ``QWEN_BACKEND_URL`` / ``QWEN_MODEL`` env vars
+* first backend in ``~/.qwen-coprocessor-stack/config.json`` (or the
+  ``QWEN_CONFIG_DIR`` override path)
+* hardcoded default (``http://localhost:8080/v1``,
+  ``qwen3.6-35b-a3b``)
+
+Same operator-chooses pattern as ``claude_dispatch``'s auth: the
+operator declares intent at the system level; nexus consumes whatever
+is configured.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+__all__ = [
+    "qwen_dispatch",
+    "QwenOperatorError",
+    "QwenOperatorTimeoutError",
+    "QwenOperatorOutputError",
+]
+
+
+class QwenOperatorError(RuntimeError):
+    """Raised when llama-server returns a non-2xx response or the body
+    payload doesn't match the OpenAI chat-completions shape."""
+
+
+class QwenOperatorTimeoutError(asyncio.TimeoutError):
+    """Raised when the dispatch HTTP request exceeds *timeout*."""
+
+
+class QwenOperatorOutputError(QwenOperatorError):
+    """Raised when the response is not valid JSON after fence-stripping
+    on every attempt — i.e. the model emitted prose despite the system
+    prompt + retry."""
+
+
+# Module-level concurrency cap. llama-server serves one request at a
+# time; if nexus parallelizes plan execution across sessions, multiple
+# dispatches would queue at the backend with no benefit. Default 1
+# matches single-server reality. Operator can raise via env when a
+# multi-backend pool is configured upstream.
+_QWEN_CONCURRENCY = max(1, int(os.environ.get("NEXUS_QWEN_CONCURRENCY", "1")))
+_QWEN_SEMAPHORE: asyncio.Semaphore | None = None
+
+
+def _semaphore() -> asyncio.Semaphore:
+    """Lazy-init the module semaphore so it binds to the running loop.
+
+    Creating an ``asyncio.Semaphore`` at module-import time bound it to
+    whatever loop existed when the import ran — which in test harnesses
+    is often a different loop than the one running the dispatch. Lazy
+    creation defers binding to first use.
+    """
+    global _QWEN_SEMAPHORE
+    if _QWEN_SEMAPHORE is None:
+        _QWEN_SEMAPHORE = asyncio.Semaphore(_QWEN_CONCURRENCY)
+    return _QWEN_SEMAPHORE
+
+
+_DEFAULT_BACKEND_URL = "http://localhost:8080/v1"
+_DEFAULT_MODEL = "qwen3.6-35b-a3b"
+
+
+def _read_qwen_stack_config() -> dict[str, Any] | None:
+    """Read the operator's qwen-coprocessor-stack config when present.
+
+    Same path the qwen-stack supervisor reads. We don't import from that
+    package — keeping nexus free of a runtime dep on a TypeScript repo.
+    Failures (file missing, JSON invalid, OS error) all return ``None``
+    so callers fall through to env / hardcoded.
+    """
+    override = os.environ.get("QWEN_CONFIG_DIR")
+    cfg_path = (
+        Path(override) / "config.json"
+        if override
+        else Path.home() / ".qwen-coprocessor-stack" / "config.json"
+    )
+    try:
+        return json.loads(cfg_path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _resolve_backend_url(explicit: str | None) -> str:
+    if explicit:
+        return explicit.rstrip("/")
+    env = os.environ.get("QWEN_BACKEND_URL")
+    if env:
+        return env.rstrip("/")
+    cfg = _read_qwen_stack_config()
+    if cfg and isinstance(cfg.get("backends"), list) and cfg["backends"]:
+        url = cfg["backends"][0].get("url")
+        if isinstance(url, str) and url:
+            return url.rstrip("/")
+    return _DEFAULT_BACKEND_URL
+
+
+def _resolve_model(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    env = os.environ.get("QWEN_MODEL")
+    if env:
+        return env
+    cfg = _read_qwen_stack_config()
+    if cfg and isinstance(cfg.get("backends"), list) and cfg["backends"]:
+        model = cfg["backends"][0].get("model")
+        if isinstance(model, str) and model:
+            return model
+    return _DEFAULT_MODEL
+
+
+# Mirror of ``stripCodeFences`` in qwen-coprocessor-stack/src/server.ts.
+# Anchored at both ends so mid-prose fenced blocks are NOT stripped —
+# we only undress responses where the model wrapped its entire JSON
+# output in ```json ... ```.
+_FENCE_RE = re.compile(r"^```(?:json|JSON)?\s*\n([\s\S]*?)\n?```$")
+
+
+def _strip_code_fences(raw: str) -> str:
+    """Strip surrounding markdown code fences from a candidate JSON string.
+
+    Qwen3.6 frequently wraps schema-conforming JSON in `````json
+    ... ````` despite a system-prompt directive forbidding
+    fences. The content is right; defending against the jacket is cheaper
+    than fighting the model. Returns input unchanged if no fences are
+    detected — JSON.loads then runs on the original.
+    """
+    trimmed = raw.strip()
+    m = _FENCE_RE.match(trimmed)
+    if m:
+        return m.group(1).strip()
+    return raw
+
+
+def _build_system_prompt(json_schema: dict[str, Any]) -> str:
+    """Render the schema-as-system-prompt directive used by qwen-stack v0.8.
+
+    Positive framing ("begin with ``{`` or ``[``") performs better than
+    negative directives ("no fences") on Qwen3.6's instruction-following.
+    The closing fallback for unrecoverable inputs gives the model a
+    schema-shaped escape hatch instead of free-text apology.
+    """
+    return (
+        "You are operating as a coprocessor under a supervisor that runs you "
+        "in single-turn mode for schema-bounded synthesis.\n\n"
+        "[Output contract — JSON only]\n"
+        "Your final assistant message must START with `{` or `[` and END\n"
+        "with `}` or `]`. No preamble, no closing remarks, no explanatory\n"
+        "text. ABSOLUTELY no markdown code fences (no triple backticks,\n"
+        "no ```json wrappers). The very first character of your response\n"
+        "must be `{` or `[`.\n\n"
+        "The JSON must conform to this JSON Schema:\n\n"
+        + json.dumps(json_schema, indent=2)
+        + "\n\nIf the task cannot be completed, return a JSON object with\n"
+        '`{"error": "<one-line explanation>"}` rather than free text.'
+    )
+
+
+async def qwen_dispatch(
+    prompt: str,
+    json_schema: dict[str, Any],
+    *,
+    timeout: float = 300.0,
+    backend_url: str | None = None,
+    model: str | None = None,
+    max_attempts: int = 2,
+) -> dict[str, Any]:
+    """Dispatch one operator call to Qwen via OpenAI-compat ``/v1/chat/completions``.
+
+    Mirrors :func:`nexus.operators.dispatch.claude_dispatch`'s signature:
+    takes prompt + JSON Schema, returns parsed dict.
+
+    Differences from ``claude_dispatch``:
+
+    * No subprocess. Uses ``httpx`` against llama-server's OpenAI-compat
+      endpoint. Saves ~5 s of subprocess-spawn overhead per call.
+    * No ``--json-schema`` enforcement at the server side (yet) —
+      Qwen3.6's instruction-following plus :func:`_strip_code_fences`
+      is reliable enough on the bench seed cases. Grammar enforcement
+      via llama.cpp ``--grammar`` is a future option if measurement
+      justifies it.
+    * Retries on JSON parse failure, bounded by *max_attempts* (default
+      2). The retry uses a tightened user message that names the prior
+      parse error.
+
+    Args:
+        prompt: Full prompt text.
+        json_schema: JSON Schema the response must conform to.
+        timeout: Hard timeout per HTTP attempt (default 300 s).
+        backend_url: Override the resolved backend URL.
+        model: Override the resolved model name.
+        max_attempts: Cap on retry-on-parse-failure (default 2).
+
+    Returns:
+        Parsed JSON dict from the model response.
+
+    Raises:
+        QwenOperatorTimeoutError: HTTP request exceeded *timeout*.
+        QwenOperatorError: Non-2xx response or unexpected payload shape.
+        QwenOperatorOutputError: All attempts produced non-JSON output.
+    """
+    backend = _resolve_backend_url(backend_url)
+    model_id = _resolve_model(model)
+    system = _build_system_prompt(json_schema)
+    user = f"/no_think\n\n{prompt}"
+
+    last_raw: str | None = None
+    last_parse_err: str | None = None
+
+    async with _semaphore():
+        for attempt in range(1, max_attempts + 1):
+            messages: list[dict[str, str]] = [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ]
+            if attempt > 1 and last_parse_err is not None:
+                # Retry — name the prior failure so the model has
+                # something to fix, not just a re-roll.
+                messages.append({
+                    "role": "user",
+                    "content": (
+                        "/no_think\n\n"
+                        f"Your previous response was not valid JSON ({last_parse_err}). "
+                        "Try again. Begin with `{` or `[`. No preamble. No code fences."
+                    ),
+                })
+
+            try:
+                async with httpx.AsyncClient(timeout=timeout) as client:
+                    resp = await client.post(
+                        f"{backend}/chat/completions",
+                        json={
+                            "model": model_id,
+                            "messages": messages,
+                            "temperature": 0.2,
+                            "stream": False,
+                        },
+                    )
+            except httpx.TimeoutException as exc:
+                raise QwenOperatorTimeoutError(
+                    f"qwen_dispatch timed out after {timeout}s "
+                    f"(attempt {attempt}/{max_attempts}, backend={backend})"
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise QwenOperatorError(
+                    f"qwen_dispatch HTTP error: {exc} "
+                    f"(attempt {attempt}/{max_attempts}, backend={backend})"
+                ) from exc
+
+            if resp.status_code != 200:
+                snippet = resp.text[:300]
+                raise QwenOperatorError(
+                    f"qwen_dispatch non-2xx ({resp.status_code}): {snippet} "
+                    f"(attempt {attempt}/{max_attempts}, backend={backend})"
+                )
+
+            try:
+                payload = resp.json()
+                last_raw = payload["choices"][0]["message"]["content"]
+            except (KeyError, IndexError, json.JSONDecodeError, ValueError) as exc:
+                raise QwenOperatorError(
+                    f"qwen_dispatch unexpected response shape: {exc} "
+                    f"(attempt {attempt}/{max_attempts})"
+                ) from exc
+
+            stripped = _strip_code_fences(last_raw)
+            try:
+                return json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                last_parse_err = str(exc)
+                # fall through to retry (if attempts remain)
+
+    raise QwenOperatorOutputError(
+        f"qwen_dispatch produced non-JSON output after {max_attempts} attempts "
+        f"(last error: {last_parse_err}); last raw: {(last_raw or '')[:300]}"
+    )

--- a/src/nexus/plans/bundle.py
+++ b/src/nexus/plans/bundle.py
@@ -734,12 +734,28 @@ async def dispatch_bundle(
     *,
     timeout: float = 300.0,
 ) -> dict[str, Any]:
-    """Issue a single ``claude_dispatch`` for the whole bundle.
+    """Issue a single dispatch (claude or qwen) for the whole bundle.
 
     Returns the terminal step's output dict — the caller stamps it at the
     bundle's ``end_index`` slot in ``step_outputs``.
+
+    Routing: per-operator via :mod:`nexus.operators.dispatch_router`,
+    consulting the bundle's step tools. Default is ``claude_dispatch``
+    (preserves prior behavior); operator opts into Qwen routing via
+    ``NEXUS_DISPATCH_BACKEND={qwen,auto}`` or per-operator
+    ``NEXUS_DISPATCH_QWEN_OPERATORS`` env. See the router module
+    docstring for the resolution order and bench-grounded defaults.
     """
-    from nexus.operators.dispatch import claude_dispatch
+    from nexus.operators.dispatch_router import pick_dispatcher_for_bundle
 
     prompt, schema = compose_bundle_prompt(bundle)
+    backend = pick_dispatcher_for_bundle(step.tool for step in bundle.steps)
+
+    if backend == "qwen":
+        from nexus.operators.qwen_dispatch import qwen_dispatch
+
+        return await qwen_dispatch(prompt, schema, timeout=timeout)
+
+    from nexus.operators.dispatch import claude_dispatch
+
     return await claude_dispatch(prompt, schema, timeout=timeout)

--- a/tests/test_dispatch_router.py
+++ b/tests/test_dispatch_router.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the per-operator dispatch router.
+
+The router is pure-logic + env-introspection; no mocking required
+beyond ``monkeypatch`` for env vars. Tests cover:
+
+  * Default mode (no env): always Claude
+  * NEXUS_DISPATCH_BACKEND=qwen / claude / auto
+  * Per-operator pins (NEXUS_DISPATCH_{QWEN,CLAUDE}_OPERATORS) win in
+    every mode
+  * operator_X / X equivalence (the optional ``operator_`` prefix)
+  * Bundle-level conservative routing: any-claude → all-claude
+"""
+from __future__ import annotations
+
+import pytest
+
+from nexus.operators.dispatch_router import (
+    CLAUDE_OPERATORS_PINNED,
+    QWEN_OPERATORS_DEFAULT,
+    pick_dispatcher,
+    pick_dispatcher_for_bundle,
+)
+
+
+# ── Fixture: clean env per test ───────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "NEXUS_DISPATCH_BACKEND",
+        "NEXUS_DISPATCH_QWEN_OPERATORS",
+        "NEXUS_DISPATCH_CLAUDE_OPERATORS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ── Default mode: preserves prior behavior ────────────────────────────────
+
+
+class TestDefaultMode:
+    def test_no_env_routes_everything_to_claude(self) -> None:
+        for op in QWEN_OPERATORS_DEFAULT | CLAUDE_OPERATORS_PINNED:
+            assert pick_dispatcher(op) == "claude", f"unexpected route for {op}"
+
+    def test_unknown_operator_defaults_to_claude(self) -> None:
+        assert pick_dispatcher("nonsense_operator") == "claude"
+
+    def test_operator_prefix_doesnt_change_default(self) -> None:
+        assert pick_dispatcher("operator_summarize") == "claude"
+        assert pick_dispatcher("operator_extract") == "claude"
+
+
+# ── NEXUS_DISPATCH_BACKEND global override ────────────────────────────────
+
+
+class TestGlobalOverride:
+    def test_backend_qwen_routes_everything_to_qwen(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "qwen")
+        for op in QWEN_OPERATORS_DEFAULT | CLAUDE_OPERATORS_PINNED:
+            assert pick_dispatcher(op) == "qwen", f"unexpected route for {op}"
+
+    def test_backend_claude_routes_everything_to_claude(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "claude")
+        for op in QWEN_OPERATORS_DEFAULT | CLAUDE_OPERATORS_PINNED:
+            assert pick_dispatcher(op) == "claude"
+
+    def test_backend_value_is_case_insensitive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "QwEn")
+        assert pick_dispatcher("summarize") == "qwen"
+
+    def test_unrecognized_value_falls_back_to_claude(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "gibberish")
+        assert pick_dispatcher("summarize") == "claude"
+
+
+# ── auto mode: bench-grounded routing table ───────────────────────────────
+
+
+class TestAutoMode:
+    @pytest.fixture(autouse=True)
+    def _auto(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "auto")
+
+    @pytest.mark.parametrize("op", sorted(QWEN_OPERATORS_DEFAULT))
+    def test_qwen_default_operators_route_to_qwen(self, op: str) -> None:
+        assert pick_dispatcher(op) == "qwen"
+
+    @pytest.mark.parametrize("op", sorted(CLAUDE_OPERATORS_PINNED))
+    def test_claude_pinned_operators_route_to_claude(self, op: str) -> None:
+        assert pick_dispatcher(op) == "claude"
+
+    def test_operator_prefix_treated_equivalently(self) -> None:
+        for op in QWEN_OPERATORS_DEFAULT:
+            assert pick_dispatcher(f"operator_{op}") == "qwen"
+        for op in CLAUDE_OPERATORS_PINNED:
+            assert pick_dispatcher(f"operator_{op}") == "claude"
+
+    def test_unknown_operator_routes_to_claude(self) -> None:
+        # Conservative — never silently route an unknown operator to
+        # qwen even in auto mode.
+        assert pick_dispatcher("brand_new_op") == "claude"
+
+
+# ── Per-operator env pins win in every mode ───────────────────────────────
+
+
+class TestPerOperatorPins:
+    def test_qwen_pin_wins_over_default_claude(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Default mode = all-claude. Per-op pin to qwen overrides.
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "summarize,filter")
+        assert pick_dispatcher("summarize") == "qwen"
+        assert pick_dispatcher("filter") == "qwen"
+        # Unspecified operator stays on the default.
+        assert pick_dispatcher("compare") == "claude"
+
+    def test_claude_pin_wins_over_qwen_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force-all-qwen mode. Per-op pin pulls one back to Claude.
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "qwen")
+        monkeypatch.setenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", "summarize")
+        assert pick_dispatcher("summarize") == "claude"
+        assert pick_dispatcher("compare") == "qwen"
+
+    def test_claude_pin_wins_over_auto_mode_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "auto")
+        monkeypatch.setenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", "summarize")
+        assert pick_dispatcher("summarize") == "claude"
+        # Other QWEN_OPERATORS_DEFAULT entries still go to qwen.
+        assert pick_dispatcher("compare") == "qwen"
+
+    def test_claude_pin_takes_priority_over_qwen_pin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Documented order: Claude pin checked first → Claude wins
+        # when an operator appears in both env sets (operator error,
+        # but be predictable).
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "compare")
+        monkeypatch.setenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", "compare")
+        assert pick_dispatcher("compare") == "claude"
+
+    def test_pin_handles_whitespace_and_empty_segments(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "NEXUS_DISPATCH_QWEN_OPERATORS", " summarize , , filter ,"
+        )
+        assert pick_dispatcher("summarize") == "qwen"
+        assert pick_dispatcher("filter") == "qwen"
+
+
+# ── Bundle-level routing ──────────────────────────────────────────────────
+
+
+class TestBundleRouting:
+    def test_all_qwen_steps_routes_bundle_to_qwen(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "auto")
+        assert (
+            pick_dispatcher_for_bundle(["summarize", "compare", "rank"])
+            == "qwen"
+        )
+
+    def test_any_claude_step_pulls_whole_bundle_to_claude(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "auto")
+        # extract is Claude-pinned; the bundle includes it → all Claude
+        # so the bundle stays a single subprocess.
+        assert (
+            pick_dispatcher_for_bundle(["extract", "rank", "summarize"])
+            == "claude"
+        )
+
+    def test_default_mode_bundles_route_to_claude(self) -> None:
+        # No env set → all-claude default → bundle goes to Claude.
+        assert (
+            pick_dispatcher_for_bundle(["summarize", "compare"]) == "claude"
+        )
+
+    def test_force_qwen_mode_routes_bundle_to_qwen(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "qwen")
+        # Even bundles that include extract (normally Claude-pinned)
+        # go to qwen when the global override is qwen.
+        assert (
+            pick_dispatcher_for_bundle(["extract", "summarize"]) == "qwen"
+        )
+
+    def test_empty_bundle_defaults_to_claude(self) -> None:
+        assert pick_dispatcher_for_bundle([]) == "claude"
+
+    def test_per_op_pin_in_bundle(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # In default mode, pin one operator to qwen — the bundle still
+        # contains other (default-claude) operators so it goes to claude.
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "summarize")
+        assert (
+            pick_dispatcher_for_bundle(["summarize", "compare"]) == "claude"
+        )

--- a/tests/test_qwen_dispatch.py
+++ b/tests/test_qwen_dispatch.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for ``nexus.operators.qwen_dispatch``.
+
+httpx is mocked via the standard ``respx``-style approach; we patch
+``httpx.AsyncClient.post`` to return fake ``httpx.Response`` objects.
+This keeps the test independent of any real backend at qwentescence
+and runs offline.
+
+Coverage:
+  * Happy path — schema-conforming JSON → parsed dict
+  * Markdown fence-wrapping → stripped + parsed
+  * Parse-failure retry → second attempt succeeds
+  * Parse-failure exhausts attempts → QwenOperatorOutputError
+  * Non-2xx HTTP response → QwenOperatorError
+  * Timeout → QwenOperatorTimeoutError
+  * Backend URL / model resolution: explicit > env > config > default
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from nexus.operators.qwen_dispatch import (
+    QwenOperatorError,
+    QwenOperatorOutputError,
+    QwenOperatorTimeoutError,
+    _build_system_prompt,
+    _resolve_backend_url,
+    _resolve_model,
+    _strip_code_fences,
+    qwen_dispatch,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _resp(status: int, body: str | dict) -> httpx.Response:
+    """Build an httpx.Response carrying *body* as either text or JSON dict."""
+    if isinstance(body, dict):
+        return httpx.Response(status, json=body)
+    return httpx.Response(status, text=body)
+
+
+def _chat_completion(content: str) -> dict:
+    """OpenAI-compat chat-completions response shape with one choice."""
+    return {
+        "choices": [{"message": {"role": "assistant", "content": content}}],
+    }
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"answer": {"type": "string"}},
+    "required": ["answer"],
+}
+
+
+# ── Env isolation ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Strip env vars that would otherwise pollute resolution and
+    semaphore size; also point QWEN_CONFIG_DIR at a fresh tmpdir so
+    the resolver does NOT fall through to the operator's real
+    ``~/.qwen-coprocessor-stack/config.json`` and pick up qwentescence
+    coordinates that would mask test assertions on the hardcoded
+    default."""
+    for var in ("QWEN_BACKEND_URL", "QWEN_MODEL", "NEXUS_QWEN_CONCURRENCY"):
+        monkeypatch.delenv(var, raising=False)
+    # Empty tmpdir → no config.json → resolver falls through to default.
+    monkeypatch.setenv("QWEN_CONFIG_DIR", str(tmp_path))
+
+
+# ── Pure-function helpers ─────────────────────────────────────────────────
+
+
+class TestStripCodeFences:
+    """Mirror of qwen-coprocessor-stack/tests/server.test.ts coverage."""
+
+    def test_strips_json_fenced_block(self) -> None:
+        assert _strip_code_fences('```json\n{"a":1}\n```') == '{"a":1}'
+
+    def test_strips_plain_fenced_block(self) -> None:
+        assert _strip_code_fences('```\n{"a":1}\n```') == '{"a":1}'
+
+    def test_tolerates_outer_whitespace(self) -> None:
+        assert _strip_code_fences('  ```json\n{"a":1}\n```  ') == '{"a":1}'
+
+    def test_does_not_strip_when_no_fences(self) -> None:
+        assert _strip_code_fences('{"a":1}') == '{"a":1}'
+
+    def test_does_not_strip_mid_prose_fences(self) -> None:
+        s = 'here:\n```json\n{"a":1}\n```\nnice'
+        assert _strip_code_fences(s) == s
+
+
+class TestSystemPromptShape:
+    def test_includes_schema_json(self) -> None:
+        sp = _build_system_prompt(_SCHEMA)
+        assert '"answer"' in sp
+        assert '"required"' in sp
+
+    def test_includes_no_fences_directive(self) -> None:
+        sp = _build_system_prompt(_SCHEMA)
+        # Positive framing is the load-bearing part.
+        assert "must START with `{` or `[`" in sp
+
+
+# ── Resolution chain (env > config > default) ─────────────────────────────
+
+
+class TestBackendUrlResolution:
+    def test_explicit_arg_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("QWEN_BACKEND_URL", "http://from-env:1234/v1")
+        assert (
+            _resolve_backend_url("http://explicit:9999/v1")
+            == "http://explicit:9999/v1"
+        )
+
+    def test_env_wins_over_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("QWEN_BACKEND_URL", "http://from-env:1234/v1/")
+        # Trailing slash is stripped.
+        assert _resolve_backend_url(None) == "http://from-env:1234/v1"
+
+    def test_falls_through_to_default(self) -> None:
+        assert _resolve_backend_url(None) == "http://localhost:8080/v1"
+
+
+class TestModelResolution:
+    def test_explicit_arg_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("QWEN_MODEL", "from-env")
+        assert _resolve_model("explicit") == "explicit"
+
+    def test_env_wins_over_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("QWEN_MODEL", "qwen3.6-test")
+        assert _resolve_model(None) == "qwen3.6-test"
+
+    def test_falls_through_to_default(self) -> None:
+        assert _resolve_model(None) == "qwen3.6-35b-a3b"
+
+
+# ── Happy path ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_returns_parsed_json_on_clean_response() -> None:
+    fake_post = AsyncMock(
+        return_value=_resp(200, _chat_completion('{"answer":"hello"}'))
+    )
+    with patch("httpx.AsyncClient.post", fake_post):
+        result = await qwen_dispatch(
+            "What is hello?",
+            _SCHEMA,
+            backend_url="http://test:1234/v1",
+            model="qwen-test",
+        )
+    assert result == {"answer": "hello"}
+    fake_post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_strips_markdown_fences_before_parse() -> None:
+    fake_post = AsyncMock(
+        return_value=_resp(
+            200,
+            _chat_completion('```json\n{"answer":"fenced"}\n```'),
+        )
+    )
+    with patch("httpx.AsyncClient.post", fake_post):
+        result = await qwen_dispatch(
+            "fenced", _SCHEMA, backend_url="http://test:1234/v1"
+        )
+    assert result == {"answer": "fenced"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sends_no_think_prefix_in_user_message() -> None:
+    """Qwen3.6 thinking mode is disabled via /no_think on user turns."""
+    fake_post = AsyncMock(
+        return_value=_resp(200, _chat_completion('{"answer":"x"}'))
+    )
+    with patch("httpx.AsyncClient.post", fake_post):
+        await qwen_dispatch("test prompt", _SCHEMA, backend_url="http://x/v1")
+    sent_body = fake_post.await_args.kwargs["json"]
+    user_msg = next(m for m in sent_body["messages"] if m["role"] == "user")
+    assert user_msg["content"].startswith("/no_think\n\n")
+    assert "test prompt" in user_msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sends_schema_in_system_prompt() -> None:
+    fake_post = AsyncMock(
+        return_value=_resp(200, _chat_completion('{"answer":"x"}'))
+    )
+    with patch("httpx.AsyncClient.post", fake_post):
+        await qwen_dispatch("p", _SCHEMA, backend_url="http://x/v1")
+    sent_body = fake_post.await_args.kwargs["json"]
+    sys_msg = next(m for m in sent_body["messages"] if m["role"] == "system")
+    assert '"answer"' in sys_msg["content"]
+    assert "must START" in sys_msg["content"]
+
+
+# ── Retry on parse failure ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_retries_on_json_parse_failure() -> None:
+    # First call returns prose; second returns valid JSON.
+    fake_post = AsyncMock(
+        side_effect=[
+            _resp(200, _chat_completion("Sorry, I cannot do that.")),
+            _resp(200, _chat_completion('{"answer":"on retry"}')),
+        ]
+    )
+    with patch("httpx.AsyncClient.post", fake_post):
+        result = await qwen_dispatch(
+            "p", _SCHEMA, backend_url="http://x/v1", max_attempts=2
+        )
+    assert result == {"answer": "on retry"}
+    assert fake_post.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_dispatch_raises_after_max_attempts_of_parse_failure() -> None:
+    fake_post = AsyncMock(
+        return_value=_resp(200, _chat_completion("definitely not json"))
+    )
+    with patch("httpx.AsyncClient.post", fake_post):
+        with pytest.raises(QwenOperatorOutputError, match="non-JSON output"):
+            await qwen_dispatch(
+                "p", _SCHEMA, backend_url="http://x/v1", max_attempts=2
+            )
+    assert fake_post.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_user_message_names_prior_parse_error() -> None:
+    """Retry isn't a blind reroll — it tells the model what failed."""
+    fake_post = AsyncMock(
+        side_effect=[
+            _resp(200, _chat_completion("not json")),
+            _resp(200, _chat_completion('{"answer":"ok"}')),
+        ]
+    )
+    with patch("httpx.AsyncClient.post", fake_post):
+        await qwen_dispatch(
+            "p", _SCHEMA, backend_url="http://x/v1", max_attempts=2
+        )
+    second_body = fake_post.await_args_list[1].kwargs["json"]
+    # The second call should include an extra user message naming the
+    # parse failure.
+    user_msgs = [m for m in second_body["messages"] if m["role"] == "user"]
+    assert len(user_msgs) == 2
+    assert "previous response was not valid JSON" in user_msgs[1]["content"]
+
+
+# ── Error paths ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_raises_on_non_2xx() -> None:
+    fake_post = AsyncMock(return_value=_resp(500, "internal server error"))
+    with patch("httpx.AsyncClient.post", fake_post):
+        with pytest.raises(QwenOperatorError, match=r"non-2xx \(500\)"):
+            await qwen_dispatch("p", _SCHEMA, backend_url="http://x/v1")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_raises_on_timeout() -> None:
+    fake_post = AsyncMock(side_effect=httpx.ConnectTimeout("connect timeout"))
+    with patch("httpx.AsyncClient.post", fake_post):
+        with pytest.raises(QwenOperatorTimeoutError, match="timed out"):
+            await qwen_dispatch("p", _SCHEMA, backend_url="http://x/v1")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_raises_on_unexpected_payload_shape() -> None:
+    # Missing "choices" → KeyError → QwenOperatorError surfaces it.
+    fake_post = AsyncMock(return_value=_resp(200, {"weird": "shape"}))
+    with patch("httpx.AsyncClient.post", fake_post):
+        with pytest.raises(QwenOperatorError, match="unexpected response shape"):
+            await qwen_dispatch("p", _SCHEMA, backend_url="http://x/v1")


### PR DESCRIPTION
## Summary

- Adds `nexus.operators.qwen_dispatch` — async httpx call to a locally-hosted llama.cpp / OpenAI-compat backend, drop-in shape for `claude_dispatch`. ~80 lines + helpers.
- Adds `nexus.operators.dispatch_router` — three-mode global switch (`NEXUS_DISPATCH_BACKEND={claude,qwen,auto}`) plus always-applied per-operator pins (`NEXUS_DISPATCH_{QWEN,CLAUDE}_OPERATORS`).
- Modifies `nexus.plans.bundle.dispatch_bundle` to consult the router. Bundle amortization preserved; conservative any-claude-pulls-bundle-to-claude semantic.
- **Default behavior is unchanged** — `claude` is the default mode. Operator opts in by flipping the env.

## Bench evidence

The qwen-coprocessor-stack supervisor (separate repo) ships a bench harness that exercises both engines on identical prompt+schema pairs covering all 10 bundleable operator types. Run 2026-05-09:

| Engine | ok | json_valid | median | ratio |
|---|---|---|---|---|
| claude | 10/10 | 10/10 | 15.0s | 1.0× |
| qwen | 10/10 | 10/10 | 20.4s | 1.36× |

Content tied or near-tied on 9/10 cases. Only `extract` showed a clear Qwen content miss (heuristically filtered an underscore-prefixed function despite a "every top-level function" prompt) — pinned to Claude in the bake-in table. `filter` showed minor formatting drift but content correctness; operator preference is to favor Qwen pipelines for filter (cleaner).

## Bake-in routing table (active under `NEXUS_DISPATCH_BACKEND=auto`)

```python
QWEN_OPERATORS_DEFAULT  = {summarize, compare, rank, filter,
                           aggregate, groupby, verify, check, generate}
CLAUDE_OPERATORS_PINNED = {extract}
```

`extract` is the head of the operator pipeline (downstream rank / compare / summarize all consume its output), so precision losses there compound. Keeping it on Claude under `auto` is the conservative call.

## Per-operator pins

Always win (compose with global mode for granular control):

```bash
NEXUS_DISPATCH_QWEN_OPERATORS=summarize,compare    # opt these in
NEXUS_DISPATCH_CLAUDE_OPERATORS=verify             # pull this back
```

Order: claude pins → qwen pins → global mode. Resolution implemented in `pick_dispatcher`.

## Migration

No code change required for current users; default routing preserves prior behavior. To activate:

```bash
NEXUS_DISPATCH_BACKEND=auto              # bench-grounded routing
NEXUS_DISPATCH_BACKEND=qwen              # force all to Qwen
NEXUS_DISPATCH_QWEN_OPERATORS=summarize  # per-operator opt-in
```

Reversible at every step.

## Backend resolution

```
explicit args > QWEN_BACKEND_URL / QWEN_MODEL env
              > first backend in ~/.qwen-coprocessor-stack/config.json
                (or QWEN_CONFIG_DIR override)
              > hardcoded default (http://localhost:8080/v1, qwen3.6-35b-a3b)
```

Same operator-chooses pattern as the rest of nexus's config surface. No new config file.

## qwen_dispatch implementation notes

- **Schema as system prompt** — directive uses positive framing ("begin with `{` or `[`") which Qwen3.6 follows more reliably than negative directives.
- **`/no_think` prefix on user turns** — disables Qwen3.6 thinking mode (Artificial Analysis 2026-04 measured ~6× output bloat with thinking on).
- **Markdown fence stripping post-response** — Qwen3.6 occasionally wraps schema-conforming JSON in `\`\`\`json ... \`\`\`` despite the directive. Defensive regex anchored at both ends; refuses mid-prose stripping.
- **Retry on parse failure**, bounded by `max_attempts=2` with a tightened user message naming the prior error. No retry on HTTP errors / timeouts (real failures, retry is expensive).
- **Module-level `asyncio.Semaphore`** (default 1, configurable via `NEXUS_QWEN_CONCURRENCY`) — llama-server serves one request at a time, so concurrent dispatches would queue at the backend regardless. Lazy-init binds to the running loop, not import-time.
- **No grammar enforcement** — bench shows fence-stripping is sufficient on the seed cases. GBNF / `response_format: json_schema` plumbing is deferred until a measurement justifies it.

## Test plan

- [x] `tests/test_dispatch_router.py` — 30 cases: default mode preserves prior behavior; global override; auto mode parametrized over the bake-in pin sets; per-operator pins win over both modes; claude pin takes priority over qwen pin when both set; whitespace tolerance; bundle-level conservative routing (any-claude → all-claude).
- [x] `tests/test_qwen_dispatch.py` — 23 cases: pure-function helpers (fence stripper, schema directive); resolution chain (explicit > env > default with `QWEN_CONFIG_DIR` pointed at empty tmpdir); happy path; fence-wrapped JSON recovered; `/no_think` prefix in user message; schema appears in system prompt; retry on parse failure; retry's user message names prior error; exhausted attempts → `QwenOperatorOutputError`; non-2xx → `QwenOperatorError`; timeout → `QwenOperatorTimeoutError`; unexpected payload shape → `QwenOperatorError`.
- [x] **53/53 new tests pass.**
- [x] Existing dispatch-related tests untouched: `test_operator_dispatch.py`, `test_plan_bundle.py`, `test_plan_run.py`, `test_nx_answer.py` — **298/298 pass.**
- [x] Full unit suite: **6714 passed**, 33 skipped, 3 xfailed.
- [x] One pre-existing flaky test surfaces under full-suite ordering: `tests/test_t2.py::test_migration_guard_sequential_construction`. **Passes in isolation on both `main` and this branch.** T2 migration semantics are unrelated to dispatch routing; flake reproduces on `main`. Not introduced by this change.

## Out of scope

- llama.cpp grammar enforcement (GBNF / `response_format`) — bench shows the fence-strip + retry path is sufficient on the seed cases. Defer until a measurement justifies the harder plumbing.
- Replacing `claude_dispatch` on non-bundle paths (plan-miss inline planner in `nx_answer`, ad-hoc operator dispatches). Bundle dispatch is the volume case and what the bench measured. Other paths have different precision needs and remain on Claude.
- Cost telemetry (would-have-been Claude cost tracking) — out of v1 scope; can stack on top later.

## Linked
- Bench harness + supervisor primitives: https://github.com/Hellblazer/qwen-coprocessor-stack (v0.8.1+)