### PR TITLE
feat(operators): promote extract to qwen-default + isolate dispatch env in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ tests/fixtures/*.pdf
 .serena/
 blog/
 output/
+
+# Local exploration / scratch — never committed
+notes/

--- a/src/nexus/operators/dispatch_router.py
+++ b/src/nexus/operators/dispatch_router.py
@@ -17,10 +17,16 @@ Per-operator overrides apply in **all** modes (most-granular wins):
 Bake-in defaults are grounded in measurement —
 ``qwen-coprocessor-stack/scripts/bench/`` (run 2026-05-09) covered all
 ten bundleable operator types with 10/10 schema-conforming output on
-both engines and content-tied or near-tied on 9/10 cases. Only
-``extract`` showed a clear Qwen content loss (heuristically filtered
-underscore-prefixed identifiers despite an "every top-level function"
-prompt) and stays pinned to Claude.
+both engines and content-tied or near-tied on 9/10 cases.
+
+Initial routing pinned ``extract`` to Claude based on a single bench
+sample where Qwen filtered an underscore-prefixed function. A follow-
+up bench (2026-05-09 evening, 4 extract case shapes × 5 repeats = 20
+dispatches) returned 20/20 oracle-match — including the original
+``_normalize``-miss case at 5/5. The miss was sampling variance, not
+a precision floor. ``extract`` is now in ``QWEN_OPERATORS_DEFAULT``;
+``CLAUDE_OPERATORS_PINNED`` remains as an empty placeholder so future
+bench-driven pins have a home without re-introducing the symbol.
 
 Operator-chooses pattern: defaults reflect bench evidence, the operator
 flips to ``auto`` (or pins per-operator) when ready, no flag day.
@@ -43,26 +49,25 @@ DispatchBackend = Literal["qwen", "claude"]
 
 
 #: Operators routed to Qwen when ``NEXUS_DISPATCH_BACKEND=auto``.
-#: Bench: 10/10 schema-conforming; content tied or near-tied. Filter
-#: showed minor formatting drift (kept input enum prefix) but content
-#: was correct — operator preference is to favor Qwen pipelines for
-#: filter (cleaner), so it lives here despite the cosmetic note.
+#: Bench: 10/10 schema-conforming; content tied or near-tied. ``extract``
+#: was previously Claude-pinned on a single-sample miss, then validated
+#: at 20/20 oracle-match (4 case shapes × 5 repeats including URL-
+#: from-prose, ISO-date-from-log, CLI-flag-from-help, function-name-
+#: from-code) and promoted to default. ``filter`` showed minor
+#: formatting drift (kept input enum prefix) but content was correct;
+#: operator preference is to favor Qwen pipelines for filter (cleaner)
+#: so it lives here despite the cosmetic note.
 QWEN_OPERATORS_DEFAULT: frozenset[str] = frozenset({
     "summarize", "compare", "rank", "filter",
     "aggregate", "groupby", "verify", "check", "generate",
-})
-
-#: Operators where Qwen lost precision in the bench. Pinned to Claude
-#: in ``auto`` mode until a tighter prompt or grammar enforcement
-#: closes the gap.
-#:   extract: Qwen heuristically filtered "private-looking" identifiers
-#:     (underscore-prefix) despite the prompt asking for *every*
-#:     top-level function. Precision loss matters more here than on
-#:     other operators because extract typically heads a pipeline:
-#:     downstream rank / compare / summarize all consume its output.
-CLAUDE_OPERATORS_PINNED: frozenset[str] = frozenset({
     "extract",
 })
+
+#: Operators where Qwen has measurably lost precision in the bench.
+#: Currently empty — the original ``extract`` pin was retired after a
+#: 20/20 oracle-match validation. Kept as a placeholder so future
+#: bench-driven pins can land without re-introducing the symbol.
+CLAUDE_OPERATORS_PINNED: frozenset[str] = frozenset()
 
 
 def _bare(tool: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,29 @@ def _restore_structlog_after_test():
 
 
 @pytest.fixture(autouse=True)
+def _isolate_dispatch_routing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip NEXUS_DISPATCH_* env so tests don't inherit operator mode.
+
+    The dispatch router consults ``NEXUS_DISPATCH_BACKEND`` and the
+    ``NEXUS_DISPATCH_{QWEN,CLAUDE}_OPERATORS`` env sets at every call.
+    If the test runner inherits ``NEXUS_DISPATCH_BACKEND=auto`` from a
+    shell where the operator activated qwen routing, every bundle test
+    that mocks ``claude_dispatch`` silently switches to the qwen path
+    and the assertion ``patch.object(..., 'claude_dispatch', fake)``
+    never fires. The pre-existing shell env can leak the operator's
+    production routing into the suite. Strip them at session start;
+    individual tests that exercise routing opt in via
+    ``monkeypatch.setenv`` as they already do.
+    """
+    for var in (
+        "NEXUS_DISPATCH_BACKEND",
+        "NEXUS_DISPATCH_QWEN_OPERATORS",
+        "NEXUS_DISPATCH_CLAUDE_OPERATORS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Force tests onto the explicit-isolation T1 path.
 

--- a/tests/test_dispatch_router.py
+++ b/tests/test_dispatch_router.py
@@ -95,6 +95,11 @@ class TestAutoMode:
     def test_qwen_default_operators_route_to_qwen(self, op: str) -> None:
         assert pick_dispatcher(op) == "qwen"
 
+    @pytest.mark.skipif(
+        not CLAUDE_OPERATORS_PINNED,
+        reason="CLAUDE_OPERATORS_PINNED is empty after extract was promoted to "
+        "qwen-default; placeholder remains for future bench-driven pins",
+    )
     @pytest.mark.parametrize("op", sorted(CLAUDE_OPERATORS_PINNED))
     def test_claude_pinned_operators_route_to_claude(self, op: str) -> None:
         assert pick_dispatcher(op) == "claude"
@@ -180,10 +185,12 @@ class TestBundleRouting:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "auto")
-        # extract is Claude-pinned; the bundle includes it → all Claude
-        # so the bundle stays a single subprocess.
+        # Pin one operator to Claude via env. The bundle then contains
+        # one Claude-routed step; conservative routing pulls the whole
+        # bundle to Claude so it stays a single subprocess.
+        monkeypatch.setenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", "verify")
         assert (
-            pick_dispatcher_for_bundle(["extract", "rank", "summarize"])
+            pick_dispatcher_for_bundle(["verify", "rank", "summarize"])
             == "claude"
         )
 
@@ -197,10 +204,8 @@ class TestBundleRouting:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "qwen")
-        # Even bundles that include extract (normally Claude-pinned)
-        # go to qwen when the global override is qwen.
         assert (
-            pick_dispatcher_for_bundle(["extract", "summarize"]) == "qwen"
+            pick_dispatcher_for_bundle(["summarize", "compare"]) == "qwen"
         )
 
     def test_empty_bundle_defaults_to_claude(self) -> None:


### PR DESCRIPTION
## Summary

Two changes that should land together:

1. **Promote `extract` from `CLAUDE_OPERATORS_PINNED` to `QWEN_OPERATORS_DEFAULT`.** The original pin was based on a single bench sample where Qwen filtered an underscore-prefixed function. Follow-up benching showed the miss was sampling variance.
2. **Add a conftest autouse fixture** that strips `NEXUS_DISPATCH_*` env at every test start. The feature branch was developed in a shell where the operator had exported `NEXUS_DISPATCH_BACKEND=auto` for live testing; the leak silently switched mocked-claude tests onto the qwen path.

## Bench evidence for the promotion

A dedicated extract-precision bench (4 case shapes × 5 repeats = 20 dispatches via `nexus.operators.qwen_dispatch` against real qwentescence) returned **20/20 oracle-match**:

| Case | Match rate |
|---|---|
| `extract-function-names` (the original miss case) | **5/5** |
| `extract-urls-from-prose` (parenthesized URLs, trailing punct) | **5/5** |
| `extract-iso-dates-from-log` (non-date noise lines) | **5/5** |
| `extract-cli-long-flags` (short/long flag pairing) | **5/5** |

Bench harness + cases live in `qwen-coprocessor-stack/scripts/bench/` (supports `--repeat N` and per-case `oracle` field with set/exact match). Each oracle is hand-curated set-equality on the extracted array.

## Why this matters in practice

The pre-promotion routing was naturally narrow because nexus's inline planner generates `extract` as the head of nearly every analytical plan. The conservative bundle-routing pulled extract-containing bundles entirely to Claude. Live `/nx:query` traffic on the prior PR showed `[extract, compare]` / `[extract, generate]` bundles consistently landing all-Claude.

Promoting extract closes that gap. The eight other qwen-default operators now actually fire on production traffic instead of being shadowed by extract's bundle pin.

## Conftest env isolation

`_isolate_dispatch_routing` strips `NEXUS_DISPATCH_BACKEND`, `NEXUS_DISPATCH_QWEN_OPERATORS`, `NEXUS_DISPATCH_CLAUDE_OPERATORS` at every test start. Tests that exercise routing opt back in via `monkeypatch.setenv` exactly as they already do.

This is a real test-suite bug fix — the suite was previously shell-agnostic for every other env knob (T1, config_dir, catalog) but not for the dispatch routing vars. Fixing it independently of the extract promotion would also be defensible.

Notable side effect: the previously-flaky `tests/test_t2.py::test_migration_guard_sequential_construction` passes under the conftest fix. The env leak was likely contributing — different routing means different dispatch paths means different ordering interactions.

## Test changes

- `test_dispatch_router::TestAutoMode::test_claude_pinned_operators_route_to_claude` is now `skipif`-marked when `CLAUDE_OPERATORS_PINNED` is empty (with a reason explaining the placeholder).
- `test_dispatch_router::TestBundleRouting::test_any_claude_step_pulls_whole_bundle_to_claude` uses `NEXUS_DISPATCH_CLAUDE_OPERATORS=verify` to synthesize a Claude-pinned step, rather than relying on extract's now-retired pin. Asserts the same conservative-routing semantic.

## Migration

**No code change required for current users.** Under default mode (`NEXUS_DISPATCH_BACKEND` unset or `=claude`), routing is unchanged.

After merging + setting `NEXUS_DISPATCH_BACKEND=auto`:
- All 10 bundleable operators now route to Qwen by default.
- `CLAUDE_OPERATORS_PINNED` is empty; future precision-driven pins land cleanly.
- Reversible per-operator via `NEXUS_DISPATCH_CLAUDE_OPERATORS=extract` if the production sample shows regressions.

## Test plan

- [x] **119 passed, 1 skipped** in `tests/test_dispatch_router.py + tests/test_qwen_dispatch.py + tests/test_plan_bundle.py` (the skip is the conditional empty-pin test).
- [x] **6715 passed, 34 skipped, 0 failed** in the full unit suite.

## Out of scope

- Re-running the full 10-case bench (`scripts/bench/`) — already done in the prior PR; promoting extract doesn't change the other operators' behavior.
- Splitting bundles at extract boundaries — moot now that extract is qwen-default. Bundle amortization preserved as-is.
- Running `/nx:query` against a representative production sample to measure cost-saving — operator-side measurement, captured in `notes/bench_qwen_dispatch.py` for re-running.

## Linked
- Prior PR (initial qwen_dispatch + router + bench): #623
- Bench harness: https://github.com/Hellblazer/qwen-coprocessor-stack