### PR TITLE
feat(t3): parallel-across-collections in nx t3 reidentify (nexus-qlm2)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -615,3 +615,4 @@
 {"id":"int-d289f6c0","kind":"field_change","created_at":"2026-05-09T22:16:10.321951Z","actor":"Hellblazer","issue_id":"nexus-z1mu","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-d95bef52","kind":"field_change","created_at":"2026-05-09T22:45:27.470488Z","actor":"Hellblazer","issue_id":"nexus-mmf5","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-776dcbd3","kind":"field_change","created_at":"2026-05-10T00:58:41.620029Z","actor":"Hellblazer","issue_id":"nexus-xy3b","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-d1b721f6","kind":"field_change","created_at":"2026-05-10T01:48:21.990082Z","actor":"Hellblazer","issue_id":"nexus-qlm2","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -616,3 +616,4 @@
 {"id":"int-d95bef52","kind":"field_change","created_at":"2026-05-09T22:45:27.470488Z","actor":"Hellblazer","issue_id":"nexus-mmf5","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-776dcbd3","kind":"field_change","created_at":"2026-05-10T00:58:41.620029Z","actor":"Hellblazer","issue_id":"nexus-xy3b","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-d1b721f6","kind":"field_change","created_at":"2026-05-10T01:48:21.990082Z","actor":"Hellblazer","issue_id":"nexus-qlm2","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-80f87d33","kind":"field_change","created_at":"2026-05-10T02:22:58.923364Z","actor":"Hellblazer","issue_id":"nexus-1ljk","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -775,10 +775,24 @@ def backfill_manifest_cmd(
     default=True,
     help="Report-only (default). Use --no-dry-run to perform the migration.",
 )
+@click.option(
+    "--max-workers",
+    type=int,
+    default=4,
+    show_default=True,
+    help=(
+        "Number of collections to process in parallel under "
+        "--all-collections. Each collection has an independent ID "
+        "namespace so concurrent execution is safe; ChromaDB Cloud "
+        "rate limits are the practical ceiling. Set to 1 for "
+        "deterministic serial output."
+    ),
+)
 def reidentify_cmd(
     collection: str,
     all_collections: bool,
     dry_run: bool,
+    max_workers: int,
 ) -> None:
     """Re-upsert T3 chunks under content-derived natural IDs (RDR-108 D1).
 
@@ -802,11 +816,24 @@ def reidentify_cmd(
         re-index that collection from source before running.
 
     \b
+    Performance (RDR-108 nexus-qlm2):
+      - --all-collections processes collections in parallel via a
+        ThreadPoolExecutor (--max-workers, default 4). Each collection
+        has an independent ID namespace so concurrent execution is
+        correctness-preserving; the practical ceiling is the operator's
+        ChromaDB Cloud rate limits, not local CPU.
+      - Per-collection completion order is non-deterministic under
+        max_workers > 1. Pass --max-workers 1 for serial dispatch and
+        operator-readable output.
+
+    \b
     Examples:
       nx t3 reidentify --collection code__nexus            # dry-run report
       nx t3 reidentify -c code__nexus --no-dry-run         # one collection
-      nx t3 reidentify --all-collections --no-dry-run      # full corpus
+      nx t3 reidentify --all-collections --no-dry-run      # full corpus, 4 workers
+      nx t3 reidentify --all-collections --max-workers 8   # higher concurrency
     """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
     from nexus.db.t3_reidentify import (  # noqa: PLC0415
         MissingChunkHashError,
         reidentify_collection,
@@ -817,6 +844,9 @@ def reidentify_cmd(
         raise click.UsageError(
             "Specify exactly one of --collection NAME or --all-collections."
         )
+
+    if max_workers < 1:
+        raise click.UsageError("--max-workers must be >= 1.")
 
     t3_db = _make_t3_for_backfill()
 
@@ -834,6 +864,29 @@ def reidentify_cmd(
             return
 
     total = len(collections_to_process)
+    # Single-collection invocations are inherently serial; skip the
+    # executor overhead and keep the per-collection progress line shape
+    # the operator already knows from --collection mode.
+    workers = min(max_workers, total) if total > 1 else 1
+
+    def _process_one(idx: int, coll_name: str) -> tuple[
+        int, str, "object | None", str | None
+    ]:
+        """Run reidentify_collection in a worker. Returns (idx, name,
+        result_or_None, error_or_None) so the main thread can render
+        output deterministically by index."""
+        print(
+            f"[{idx}/{total}] {coll_name}: processing ...",
+            file=sys.stderr,
+        )
+        try:
+            res = reidentify_collection(t3_db, coll_name, dry_run=dry_run)
+        except MissingChunkHashError as exc:
+            return idx, coll_name, None, str(exc)
+        except Exception as exc:
+            return idx, coll_name, None, f"{coll_name}: {exc}"
+        return idx, coll_name, res, None
+
     total_examined = 0
     total_migrated = 0
     total_already = 0
@@ -841,22 +894,28 @@ def reidentify_cmd(
     skipped_taxonomy = 0
     errors: list[str] = []
 
-    for idx, coll_name in enumerate(collections_to_process, start=1):
-        print(
-            f"[{idx}/{total}] {coll_name}: processing ...",
-            file=sys.stderr,
+    if workers == 1:
+        # Deterministic serial path: dispatch + render in input order.
+        results_iter = (
+            _process_one(i, n)
+            for i, n in enumerate(collections_to_process, start=1)
         )
+    else:
+        # Parallel dispatch; collect as completed (out-of-order render).
+        executor = ThreadPoolExecutor(max_workers=workers)
         try:
-            result = reidentify_collection(
-                t3_db, coll_name, dry_run=dry_run
-            )
-        except MissingChunkHashError as exc:
-            click.echo(f"ERROR: {exc}", err=True)
-            errors.append(str(exc))
-            continue
-        except Exception as exc:
-            click.echo(f"ERROR in {coll_name}: {exc}", err=True)
-            errors.append(f"{coll_name}: {exc}")
+            futures = [
+                executor.submit(_process_one, i, n)
+                for i, n in enumerate(collections_to_process, start=1)
+            ]
+            results_iter = (f.result() for f in as_completed(futures))
+        finally:
+            executor.shutdown(wait=False)
+
+    for _idx, coll_name, result, error in results_iter:
+        if error is not None:
+            click.echo(f"ERROR: {error}", err=True)
+            errors.append(error)
             continue
 
         if result.skipped_taxonomy:

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -515,6 +515,38 @@ class T3Database:
             for m in metadatas:
                 validate(m)
 
+        # RDR-108 D1 (nexus-fyfx): under content-derived natural IDs
+        # (``chunk_text_hash[:32]``), identical chunk text in the same
+        # batch produces duplicate IDs. ChromaDB's ``col.upsert``
+        # rejects batches with duplicate ids
+        # (``DuplicateIDError``). Drop duplicates here, keeping the
+        # first occurrence; the semantic is "identical content
+        # collapses to one row" per D1, and the dropped occurrences
+        # carry the same content + embedding + metadata so first-wins
+        # is content-equivalent to last-wins. Log when non-zero so
+        # operators can correlate with collection collapse rates.
+        seen_ids: set[str] = set()
+        unique_idx: list[int] = []
+        for i, cid in enumerate(ids):
+            if cid in seen_ids:
+                continue
+            seen_ids.add(cid)
+            unique_idx.append(i)
+        if len(unique_idx) < len(ids):
+            collapsed = len(ids) - len(unique_idx)
+            _log.info(
+                "write_batch_collapsed_duplicate_ids",
+                collection=collection_name,
+                received=len(ids),
+                kept=len(unique_idx),
+                collapsed=collapsed,
+            )
+            ids = [ids[i] for i in unique_idx]
+            documents = [documents[i] for i in unique_idx]
+            metadatas = [metadatas[i] for i in unique_idx]
+            if embeddings is not None:
+                embeddings = [embeddings[i] for i in unique_idx]
+
         size = QUOTAS.MAX_RECORDS_PER_WRITE
         with self._write_sem(collection_name):
             for start in range(0, len(ids), size):

--- a/tests/test_t3.py
+++ b/tests/test_t3.py
@@ -1011,6 +1011,53 @@ def test_upsert_chunks_with_embeddings_stores(mock_db):
     )
 
 
+def test_upsert_chunks_with_embeddings_dedupes_duplicate_ids(mock_db):
+    """RDR-108 D1 (nexus-1ljk): under content-derived natural IDs,
+    identical chunk text in the same batch produces duplicate IDs.
+    ChromaDB's ``col.upsert`` rejects batches with duplicate ids
+    (DuplicateIDError), so ``_write_batch`` must dedupe upstream
+    keeping the first occurrence (first-wins is content-equivalent
+    to last-wins under D1, since identical chunk_text yields
+    identical content + embedding + metadata)."""
+    db, mock_col, _ = mock_db
+    # Two distinct content + one duplicate of the first.
+    ids = ["a" * 32, "b" * 32, "a" * 32]
+    docs = ["alpha text", "beta text", "alpha text"]
+    embeddings = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.1, 0.2, 0.3]]
+    metas = [{"page_number": 1}, {"page_number": 2}, {"page_number": 1}]
+
+    db.upsert_chunks_with_embeddings(
+        collection_name="docs__corpus", ids=ids, documents=docs,
+        embeddings=embeddings, metadatas=metas,
+    )
+
+    # The duplicate is dropped before col.upsert is called.
+    call_kwargs = mock_col.upsert.call_args.kwargs
+    assert call_kwargs["ids"] == ["a" * 32, "b" * 32]
+    assert call_kwargs["documents"] == ["alpha text", "beta text"]
+    assert call_kwargs["embeddings"] == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+
+def test_upsert_chunks_with_embeddings_no_dedup_when_unique(mock_db):
+    """No collapse when all ids are distinct: the dedup path is a
+    no-op and the batch passes through unchanged."""
+    db, mock_col, _ = mock_db
+    ids = ["a" * 32, "b" * 32, "c" * 32]
+    docs = ["alpha", "beta", "gamma"]
+    embeddings = [[0.1, 0.0, 0.0], [0.0, 0.1, 0.0], [0.0, 0.0, 0.1]]
+    metas = [{"page_number": 1}, {"page_number": 2}, {"page_number": 3}]
+
+    db.upsert_chunks_with_embeddings(
+        collection_name="docs__corpus", ids=ids, documents=docs,
+        embeddings=embeddings, metadatas=metas,
+    )
+
+    call_kwargs = mock_col.upsert.call_args.kwargs
+    assert call_kwargs["ids"] == ids
+    assert call_kwargs["documents"] == docs
+    assert call_kwargs["embeddings"] == embeddings
+
+
 def test_upsert_chunks_with_embeddings_uses_get_or_create(mock_db):
     db, mock_col, mock_client = mock_db
     db.upsert_chunks_with_embeddings(

--- a/tests/test_t3_reidentify.py
+++ b/tests/test_t3_reidentify.py
@@ -688,6 +688,144 @@ class TestReidentifyCLI:
         assert result.exit_code != 0
         assert "exactly one" in result.output.lower()
 
+    def test_cli_all_collections_parallel_processes_concurrently(self, t3_db, runner):
+        """RDR-108 Phase 5 follow-up (nexus-qlm2): --all-collections
+        with --max-workers > 1 runs collection processing concurrently.
+
+        Each collection is independent (separate ID namespace), so
+        parallel execution is safe and gives N-x speedup bounded by the
+        operator's ChromaDB Cloud rate limits.
+
+        We verify three properties:
+          1. Every collection is processed (no skips beyond the
+             documented carve-outs).
+          2. Total counts in the summary match the per-collection
+             results regardless of completion order.
+          3. The reidentify_collection callable is dispatched within a
+             worker pool (the function call timestamps interleave),
+             not strictly sequentially.
+        """
+        import threading
+        import time
+        from collections import defaultdict
+        from unittest.mock import patch as _patch
+
+        # Seed three collections; each will need migration.
+        colls = [_unique_coll() for _ in range(3)]
+        for i, coll in enumerate(colls):
+            _seed_chunk(
+                t3_db, collection=coll, chunk_id=f"legacy-{i}",
+                content=f"content-{i}", chunk_text_hash=str(i) * 64,
+            )
+
+        # Wrap reidentify_collection so we can observe call timing.
+        from nexus.db import t3_reidentify as _ri
+        call_times: dict[str, tuple[float, float]] = {}
+        lock = threading.Lock()
+        original = _ri.reidentify_collection
+
+        def _timed(t3, coll_name, *, dry_run):
+            t0 = time.monotonic()
+            time.sleep(0.05)  # force overlap window
+            res = original(t3, coll_name, dry_run=dry_run)
+            t1 = time.monotonic()
+            with lock:
+                call_times[coll_name] = (t0, t1)
+            return res
+
+        with (
+            patch("nexus.commands.t3._make_t3_for_backfill", return_value=t3_db),
+            patch.object(
+                t3_db,
+                "list_collections",
+                return_value=[{"name": c, "count": 1} for c in colls],
+            ),
+            _patch(
+                "nexus.db.t3_reidentify.reidentify_collection",
+                side_effect=_timed,
+            ),
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "t3", "reidentify",
+                    "--all-collections",
+                    "--no-dry-run",
+                    "--max-workers", "3",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # All three collections were processed.
+        for c in colls:
+            assert c in call_times, (
+                f"collection {c} was never dispatched; got {list(call_times)}"
+            )
+        # Concurrency check: at least one pair of collections must have
+        # overlapping (start, end) windows under max_workers=3.
+        windows = sorted(call_times.values())
+        any_overlap = any(
+            windows[i][1] > windows[i + 1][0]  # later starts before earlier ends
+            for i in range(len(windows) - 1)
+        )
+        assert any_overlap, (
+            f"expected overlapping execution windows under max_workers=3; "
+            f"observed serial windows {windows}"
+        )
+        # Summary aggregates correctly.
+        assert "across 3 collection(s)" in result.output
+
+    def test_cli_max_workers_one_falls_back_to_serial(self, t3_db, runner):
+        """``--max-workers 1`` (or default in single-collection mode)
+        executes serially and produces deterministic per-collection
+        ordering, useful for debugging and operator-readable logs."""
+        import time
+        import threading
+
+        colls = [_unique_coll() for _ in range(2)]
+        for i, coll in enumerate(colls):
+            _seed_chunk(
+                t3_db, collection=coll, chunk_id=f"legacy-{i}",
+                content=f"content-{i}", chunk_text_hash=str(i + 5) * 64,
+            )
+
+        from nexus.db import t3_reidentify as _ri
+        call_order: list[str] = []
+        order_lock = threading.Lock()
+        original = _ri.reidentify_collection
+
+        def _ordered(t3, coll_name, *, dry_run):
+            with order_lock:
+                call_order.append(coll_name)
+            time.sleep(0.02)
+            return original(t3, coll_name, dry_run=dry_run)
+
+        with (
+            patch("nexus.commands.t3._make_t3_for_backfill", return_value=t3_db),
+            patch.object(
+                t3_db,
+                "list_collections",
+                return_value=[{"name": c, "count": 1} for c in colls],
+            ),
+            patch(
+                "nexus.db.t3_reidentify.reidentify_collection",
+                side_effect=_ordered,
+            ),
+        ):
+            result = runner.invoke(
+                main,
+                [
+                    "t3", "reidentify",
+                    "--all-collections",
+                    "--no-dry-run",
+                    "--max-workers", "1",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Strict serial dispatch order matches input order.
+        assert call_order == colls
+
     def test_cli_all_collections_continues_past_errors(self, t3_db, runner):
         """--all-collections accumulates errors and exits nonzero,
         but processes every collection in the iteration first.


### PR DESCRIPTION
## Summary

Stacked on #625. Two changes bundled:

1. **`nexus-qlm2`** (P2 perf): parallel-across-collections in `nx t3 reidentify` via `ThreadPoolExecutor` and a new `--max-workers N` flag (default 4). For 153 collections at ~200ms ChromaDB Cloud round-trip, drops dry-run wall-clock from ~10-30 min to ~3-7 min.

2. **`nexus-1ljk`** (P0 bug): fix `chromadb.errors.DuplicateIDError` from `T3Database._write_batch` when re-indexing real-world content. After `nexus-kmb6` retargeted indexer write paths to content-derived natural IDs, identical chunk text in the same batch produces duplicate IDs that ChromaDB rejects. Surfaced in production during the Phase 5 carve-out re-index.

## Bug context (nexus-1ljk)

Real-world repro: `nx index repo /path/to/scheme-evolution-research --force` crashed with `Expected IDs to be unique, found 13 duplicated IDs ... in upsert.` Boilerplate copyright headers and stock content blocks are the most common cause. The reidentify verb already handles this via `seen_new_ids` dedup (`t3_reidentify.py:218-224`); the bug was that the indexer write path didn't. Fix is centralized in `T3Database._write_batch` (single chokepoint for all 5 indexers + `T3Database.put`); first-wins is content-equivalent to last-wins under D1.

## Validation context (nexus-qlm2)

Discovered in-flight while running `nx t3 reidentify --all-collections --dry-run` against prod. Dry-run completed cleanly with one expected error (the documented RDR-108 RF-1 690-chunk carve-out for `docs__scheme-evolution-research-b7de0b63`). Operator wait was the motivator for the parallel speedup.

## Implementation

**`nexus-qlm2`**:
- New CLI flag `--max-workers N`, default 4, integer >= 1.
- `--max-workers 1` falls back to deterministic serial dispatch.
- Per-collection processing extracted into `_process_one(idx, name)`; worker threads return self-contained tuples; main thread aggregates.
- Single-collection invocations skip the executor entirely.
- Errors per collection do not abort others (same guarantee as the prior serial path).

**`nexus-1ljk`**:
- Dedup loop in `T3Database._write_batch` after the oversized-filter, before the chunked `col.upsert`.
- Logs at INFO with the dedup count so operators can correlate with collection collapse rates.

## Tests

- `test_cli_all_collections_parallel_processes_concurrently`: locks the parallel concurrency contract under `--max-workers 3`.
- `test_cli_max_workers_one_falls_back_to_serial`: locks the serial fallback for debugging.
- `test_upsert_chunks_with_embeddings_dedupes_duplicate_ids`: locks the collapse contract for within-batch duplicates.
- `test_upsert_chunks_with_embeddings_no_dedup_when_unique`: locks the no-op path when all ids are distinct.
- All 27 existing reidentify tests + 380 broader regression tests pass.

## Closes

- nexus-qlm2
- nexus-1ljk

## Test plan

- [x] Full `test_t3_reidentify` suite: 27 passed
- [x] Broader regression sweep (t3 / indexer / doc_indexer / pipeline / catalog_e2e / reidentify): 380 passed
- [ ] Operator validation: `nx index repo /path/to/scheme-evolution-research --force` succeeds without DuplicateIDError, then `nx t3 reidentify --all-collections --no-dry-run --max-workers 4` completes cleanly against prod.