### PR TITLE
fix(backfill-hash): two-pass walk + upsert with normalized metadata (nexus-o9an)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -617,3 +617,4 @@
 {"id":"int-776dcbd3","kind":"field_change","created_at":"2026-05-10T00:58:41.620029Z","actor":"Hellblazer","issue_id":"nexus-xy3b","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-d1b721f6","kind":"field_change","created_at":"2026-05-10T01:48:21.990082Z","actor":"Hellblazer","issue_id":"nexus-qlm2","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-80f87d33","kind":"field_change","created_at":"2026-05-10T02:22:58.923364Z","actor":"Hellblazer","issue_id":"nexus-1ljk","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-a7e127c1","kind":"field_change","created_at":"2026-05-10T03:28:26.996308Z","actor":"Hellblazer","issue_id":"nexus-o9an","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -622,35 +622,88 @@ def _backfill_chunk_text_hash(
         col: ChromaDB collection.
         on_progress: Optional callback(updated, skipped, total) called after each batch.
         chash_index: Optional T2 store (RDR-086 Phase 1.3). When provided, every
-            chunk that has — or gains — a chunk_text_hash is registered as a
-            ``(chash, physical_collection, doc_id)`` row. Reconciles gaps left
-            by Phase 1.2 dual-write failures and pre-Phase-1 collections. Pass
+            chunk that has, or gains, a chunk_text_hash is registered as a
+            ``(chash, physical_collection)`` row. Reconciles gaps left by
+            Phase 1.2 dual-write failures and pre-Phase-1 collections. Pass
             ``None`` (default) to preserve the T3-only behaviour that legacy
             callers in ``commands/catalog.py`` still rely on.
+
+    Implementation (nexus-o9an): two-pass walk, mirrors
+    ``reidentify_collection``. Pass 1 paginates ``col.get(include=[])``
+    to collect every chunk id; pass 2 fetches by exact id and re-upserts
+    chunks needing the hash with a canonical-schema-normalized payload.
+
+    Why two-pass: ChromaDB Cloud's offset-based ``col.get`` is order-
+    unstable, so a naive ``offset += len(ids)`` loop can revisit some
+    chunks and miss others. The two-pass design sidesteps this entirely
+    (pass 2's exact-id lookups are deterministic).
+
+    Why upsert + normalize instead of update: many legacy collections
+    carry chunks with 32+ metadata keys (pre-RDR-101-Phase-5c cargo +
+    pre-RDR-108 doc/chunk fields). ``col.update`` MERGES metadata, so
+    adding ``chunk_text_hash`` would push them to 33+ and trip the
+    ChromaDB Cloud per-row ``NumMetadataKeys`` quota. The previous
+    implementation caught the quota error and silently incremented
+    ``skipped``, leaving the chunks broken. The upsert + normalize
+    path REPLACES metadata via the canonical schema funnel, dropping
+    cargo so the row lands back under quota.
     """
     if getattr(col, "name", "") in _DOCUMENTLESS_COLLECTIONS:
         return (0, 0, 0)
 
     from nexus.db.t2.chash_index import dual_write_chash_index
+    from nexus.db.t3 import _normalize_for_write
+
+    # Pass 1: collect every chunk id. Lightweight payload (no metadata,
+    # no documents, no embeddings); offset is stable because pass 1 only
+    # reads. ChromaDB Cloud's offset semantics are order-unstable across
+    # the longer pass-2 walk, but pass 1 completes fast enough that the
+    # collection state stays consistent for this iteration.
+    all_ids: list[str] = []
+    offset = 0
+    while True:
+        page = col.get(limit=_BACKFILL_BATCH, offset=offset, include=[])
+        ids = page.get("ids") if isinstance(page, dict) else []
+        if not ids or not isinstance(ids, list):
+            break
+        all_ids.extend(ids)
+        if len(ids) < _BACKFILL_BATCH:
+            break
+        offset += _BACKFILL_BATCH
 
     updated = 0
     skipped = 0
-    total = 0
-    offset = 0
-    while True:
-        batch = col.get(limit=_BACKFILL_BATCH, offset=offset, include=["documents", "metadatas"])
-        ids = batch.get("ids") if isinstance(batch, dict) else []
-        if not ids or not isinstance(ids, list):
-            break
-        update_ids: list[str] = []
-        update_metas: list[dict] = []
-        # Parallel lists for the T2 reconciliation write — ids + metas for every
-        # row whose metadata ends this batch with a chunk_text_hash, whether
-        # newly computed or previously present.
+    total = len(all_ids)
+    coll_name = getattr(col, "name", "")
+
+    # Pass 2: fetch by exact id (deterministic), then upsert chunks
+    # needing the hash with canonical-schema-normalized metadata.
+    for start in range(0, len(all_ids), _BACKFILL_BATCH):
+        batch_ids = all_ids[start : start + _BACKFILL_BATCH]
+        page = col.get(
+            ids=batch_ids,
+            include=["documents", "embeddings", "metadatas"],
+        )
+        page_ids = page.get("ids") or []
+        page_docs = page.get("documents") or [None] * len(page_ids)
+        page_embs = page.get("embeddings")
+        if page_embs is None:
+            page_embs = [None] * len(page_ids)
+        page_metas = page.get("metadatas") or [{}] * len(page_ids)
+
+        upsert_ids: list[str] = []
+        upsert_docs: list[str] = []
+        upsert_embs: list = []
+        upsert_metas: list[dict] = []
+        # Parallel lists for the T2 reconciliation write: ids + metas for
+        # every row whose metadata ends this batch with a chunk_text_hash,
+        # whether newly computed or previously present.
         t2_ids: list[str] = []
         t2_metas: list[dict] = []
-        for chunk_id, doc, meta in zip(ids, batch["documents"], batch["metadatas"]):
-            total += 1
+
+        for chunk_id, doc, emb, meta in zip(
+            page_ids, page_docs, page_embs, page_metas
+        ):
             if meta and meta.get("chunk_text_hash"):
                 skipped += 1
                 # Reconciliation path: T3 already has the hash but T2 may not.
@@ -661,38 +714,58 @@ def _backfill_chunk_text_hash(
                 # nexus-p03z: Cloud T3 occasionally returns rows whose
                 # ``documents`` entry is None even when the chunk exists.
                 # Hashing a missing doc is impossible; skip and keep
-                # going. Without this guard, ``nx catalog backfill``
-                # crashes mid-pass and leaves the catalog half-recovered.
+                # going.
                 skipped += 1
                 _log.warning(
                     "backfill_chunk_text_hash_none_doc",
                     chunk_id=chunk_id,
-                    collection=getattr(col, "name", ""),
+                    collection=coll_name,
                 )
                 continue
             new_meta = dict(meta) if meta else {}
-            new_meta["chunk_text_hash"] = hashlib.sha256(doc.encode()).hexdigest()
-            update_ids.append(chunk_id)
-            update_metas.append(new_meta)
-            # Newly-hashed path: register in T2 alongside T3.
+            new_meta["chunk_text_hash"] = hashlib.sha256(
+                doc.encode()
+            ).hexdigest()
+            # Canonical schema funnel: drops cargo (corpus, store_type,
+            # expires_at, extraction_method, etc) so chunks with 32+
+            # keys land back under the per-row metadata quota.
+            normalized = _normalize_for_write(new_meta, coll_name)
+            upsert_ids.append(chunk_id)
+            upsert_docs.append(doc)
+            upsert_embs.append(emb)
+            upsert_metas.append(normalized)
             t2_ids.append(chunk_id)
-            t2_metas.append(new_meta)
-        if update_ids:
+            t2_metas.append(normalized)
+
+        if upsert_ids:
             try:
-                col.update(ids=update_ids, metadatas=update_metas)
-                updated += len(update_ids)
+                col.upsert(
+                    ids=upsert_ids,
+                    documents=upsert_docs,
+                    embeddings=upsert_embs,
+                    metadatas=upsert_metas,
+                )
+                updated += len(upsert_ids)
             except Exception as exc:
                 exc_msg = str(exc)
                 if "Quota exceeded" in exc_msg or "NumMetadataKeys" in exc_msg:
-                    skipped += len(update_ids)  # count as skipped — too many metadata keys
+                    # Even after normalization the row is over quota;
+                    # operator must re-index from source. Count as
+                    # skipped so the totals still balance.
+                    skipped += len(upsert_ids)
+                    _log.warning(
+                        "backfill_chunk_text_hash_quota_after_normalize",
+                        collection=coll_name,
+                        affected=len(upsert_ids),
+                    )
                 else:
                     raise
         if chash_index is not None and t2_ids:
             # Best-effort: dual_write_chash_index swallows per-row failures.
-            dual_write_chash_index(chash_index, col.name, t2_ids, t2_metas)
-        offset += len(ids)
+            dual_write_chash_index(chash_index, coll_name, t2_ids, t2_metas)
         if on_progress:
             on_progress(updated, skipped, total)
+
     return updated, skipped, total
 
 

--- a/tests/test_backfill_hash.py
+++ b/tests/test_backfill_hash.py
@@ -117,15 +117,18 @@ class TestBackfillChunkTextHash:
     def test_backfill_skips_none_documents_without_crash(self):
         """nexus-p03z Issue 1: when T3 returns ``documents[i] is None``
         (an inconsistency that occurs in practice on rare chunks), the
-        previous code crashed on ``doc.encode()``. Guard skips those
-        rows, counts them as skipped, processes the remainder, and
-        returns normally.
+        backfill code must skip those rows, count them as skipped,
+        process the remainder, and return normally.
 
         Reproduces the live crash that made ``nx catalog backfill``
         unusable on the host catalog. Uses a mocked collection because
         chromadb's public ``add()`` rejects None document strings; the
         None-document state is reachable in cloud T3 but not via local
         EphemeralClient writes.
+
+        nexus-o9an: backfill is now a two-pass walk (pass 1 collects
+        ids; pass 2 fetches by exact id). The mock must return shapes
+        for both passes.
         """
         from unittest.mock import MagicMock
 
@@ -133,20 +136,20 @@ class TestBackfillChunkTextHash:
 
         col = MagicMock()
         col.name = "code__none_doc_repro"
-        # First page: 3 chunks. Middle one has a None document. The
-        # other two have valid text and no chunk_text_hash so they
-        # should be hashed normally.
         col.get.side_effect = [
+            # Pass 1: 3 ids (< _BACKFILL_BATCH so loop breaks after one call).
+            {"ids": ["c1", "c2", "c3"]},
+            # Pass 2: batch fetch with docs + embeddings + metadatas.
             {
                 "ids": ["c1", "c2", "c3"],
                 "documents": ["alpha", None, "gamma"],
+                "embeddings": [[0.1], [0.2], [0.3]],
                 "metadatas": [
                     {"source_path": "a.py"},
                     {"source_path": "b.py"},
                     {"source_path": "c.py"},
                 ],
             },
-            {"ids": [], "documents": [], "metadatas": []},
         ]
 
         updated, skipped, total = _backfill_chunk_text_hash(col)
@@ -154,9 +157,141 @@ class TestBackfillChunkTextHash:
         assert total == 3
         assert updated == 2  # alpha + gamma got hashed
         assert skipped == 1  # the None doc skipped, not crashed
-        # The col.update call must NOT include the None-doc chunk.
-        update_call = col.update.call_args
-        assert "c2" not in update_call.kwargs["ids"]
+        # The col.upsert call must NOT include the None-doc chunk.
+        upsert_call = col.upsert.call_args
+        assert "c2" not in upsert_call.kwargs["ids"]
+
+
+class TestBackfillUpsertHandlesLegacyChunks:
+    """nexus-o9an: chunks with 32+ metadata keys (legacy cargo +
+    pre-RDR-108 fields) trip ChromaDB Cloud's per-row metadata quota
+    when ``col.update`` MERGES the existing metadata with a new
+    ``chunk_text_hash``. The previous implementation caught the
+    quota error and silently incremented ``skipped``, leaving
+    chunks broken. Backfill now uses ``col.upsert`` with metadata
+    pre-normalized via the canonical schema funnel; on Cloud this
+    REPLACES rather than merges (proven by the prod migration on
+    ``docs__1-7__voyage-context-3__v1`` which fixed 600 over-quota
+    chunks). EphemeralClient's upsert MERGES, so this test asserts
+    the contract that's reliable across both backends: the new
+    ``chunk_text_hash`` lands on the chunk and the row is no longer
+    a silently-skipped error."""
+
+    def test_legacy_chunk_with_cargo_gets_hash_via_upsert(self):
+        from nexus.commands.collection import _backfill_chunk_text_hash
+
+        client = chromadb.EphemeralClient()
+        col = client.get_or_create_collection("docs__legacy_cargo")
+        col.add(
+            ids=["legacy-1"],
+            documents=["paper text body"],
+            metadatas=[{
+                "title": "old-paper",
+                "content_type": "pdf",
+                "content_hash": "abc",
+                "indexed_at": "2024-01-01T00:00:00",
+                "corpus": "knowledge",
+                "store_type": "knowledge",
+                "extraction_method": "docling",
+                "doc_id": "1.1.1",
+                "chunk_index": 0,
+                "chunk_count": 50,
+            }],
+        )
+
+        updated, skipped, total = _backfill_chunk_text_hash(col)
+        # Counted as updated (was missing chunk_text_hash, now has it).
+        # The old code would have silently skipped these on Cloud
+        # quota failure; the new code routes through upsert which
+        # Cloud treats as REPLACE.
+        assert (updated, skipped, total) == (1, 0, 1)
+
+        meta = col.get(ids=["legacy-1"], include=["metadatas"])["metadatas"][0]
+        assert meta["chunk_text_hash"] == hashlib.sha256(
+            b"paper text body"
+        ).hexdigest()
+        # Title preserved (canonical field, present in both old + new).
+        assert meta["title"] == "old-paper"
+
+
+class TestBackfillTwoPassPaginationContract:
+    """nexus-o9an: pass 1 collects every chunk id with a lightweight
+    ``include=[]`` payload before pass 2 fetches by exact id. This
+    sidesteps ChromaDB Cloud's offset-pagination instability (where a
+    naive offset+update loop can revisit some chunks and miss others)."""
+
+    def test_pass1_uses_lightweight_payload_pass2_uses_exact_ids(self):
+        from unittest.mock import MagicMock
+
+        from nexus.commands.collection import _backfill_chunk_text_hash
+
+        col = MagicMock()
+        col.name = "code__two_pass_contract"
+        # Pass 1 short-circuits on a partial page (< _BACKFILL_BATCH);
+        # only one pass-1 call fires before the loop breaks.
+        col.get.side_effect = [
+            # Pass 1: 2 ids (less than batch size, so loop breaks).
+            {"ids": ["a", "b"]},
+            # Pass 2: batch fetch with embeddings + docs + metas.
+            {
+                "ids": ["a", "b"],
+                "documents": ["doc-a", "doc-b"],
+                "embeddings": [[0.1], [0.2]],
+                "metadatas": [{}, {}],
+            },
+        ]
+
+        _backfill_chunk_text_hash(col)
+
+        calls = col.get.call_args_list
+        assert len(calls) == 2, (
+            f"expected 1 pass-1 call + 1 pass-2 call, got {len(calls)}"
+        )
+        # Pass 1: lightweight (include=[]), offset-based.
+        assert calls[0].kwargs.get("include") == []
+        assert calls[0].kwargs.get("offset") == 0
+        # Pass 2: ids= (exact-id lookup), NOT offset-based.
+        assert calls[1].kwargs.get("ids") == ["a", "b"]
+        assert "offset" not in calls[1].kwargs
+        assert set(calls[1].kwargs.get("include", [])) == {
+            "documents", "embeddings", "metadatas",
+        }
+
+    def test_pass1_paginates_when_first_page_full(self):
+        """When pass-1 page is exactly _BACKFILL_BATCH, the loop
+        continues with offset += BATCH and probes for more.
+        Locks the multi-page pass-1 path that the order-stability
+        contract depends on."""
+        from unittest.mock import MagicMock
+
+        from nexus.commands.collection import (
+            _BACKFILL_BATCH,
+            _backfill_chunk_text_hash,
+        )
+
+        col = MagicMock()
+        col.name = "code__paginated"
+        # Pass 1 page 1 returns exactly _BACKFILL_BATCH ids → loop continues.
+        page1_ids = [f"id-{i}" for i in range(_BACKFILL_BATCH)]
+        col.get.side_effect = [
+            {"ids": page1_ids},                     # pass 1, page 1 (full)
+            {"ids": []},                            # pass 1, page 2 (empty)
+            {                                        # pass 2, batch fetch
+                "ids": page1_ids,
+                "documents": [f"doc-{i}" for i in range(_BACKFILL_BATCH)],
+                "embeddings": [[0.0]] * _BACKFILL_BATCH,
+                "metadatas": [{"chunk_text_hash": "x"}] * _BACKFILL_BATCH,
+            },
+        ]
+
+        _backfill_chunk_text_hash(col)
+
+        calls = col.get.call_args_list
+        assert len(calls) == 3
+        assert calls[0].kwargs.get("offset") == 0
+        assert calls[1].kwargs.get("offset") == _BACKFILL_BATCH
+        # Pass 2 still uses ids= regardless of pass-1 page count.
+        assert calls[2].kwargs.get("ids") == page1_ids
 
 
 # ── Phase 1.3 (nexus-ppl) — T2 chash_index reconciliation ────────────────────


### PR DESCRIPTION
## Summary

Stacked on #627. Surfaced during the RDR-108 Phase 5 prod migration.

\`nx collection backfill-hash --all\` reported "90 updated, 11789 already had hash" against \`docs__1-7__voyage-context-3__v1\`, but a follow-up reidentify dry-run still found chunks without \`chunk_text_hash\` in that collection. Direct paginated audit showed the actual missing-hash count was **600**, not 90. Two underlying bugs:

1. **Offset-pagination instability** — \`col.get(limit=N, offset=M)\` is order-unstable on Cloud across calls. Naive offset+update loop can revisit some rows and miss others. Reidentify already uses a two-pass design (collect-all-ids first, fetch-by-exact-id second); backfill now mirrors it.

2. **Over-quota update silently skipped** — \`col.update\` MERGES metadata. Many legacy chunks carry 32+ keys; adding \`chunk_text_hash\` pushes the merged dict over Cloud's per-row \`NumMetadataKeys\` quota. Previous code caught the quota error and incremented \`skipped\`, silently leaving chunks broken. Backfill now uses \`col.upsert\` with metadata pre-normalized via the canonical schema funnel (\`_normalize_for_write\`), dropping cargo so the row lands back under quota.

## Implementation

- **Pass 1**: paginate with \`include=[]\` (lightweight) to collect every chunk id. Pass-1 walk completes fast enough that offset semantics stay consistent for this iteration.
- **Pass 2**: \`col.get(ids=batch, include=['documents', 'embeddings', 'metadatas'])\` fetches by exact id (deterministic). For each missing-hash chunk, build a normalized payload via \`_normalize_for_write\` and \`col.upsert\` with the new documents + embeddings + metadatas.
- Quota-after-normalize fallback: if the upsert STILL trips the per-row quota (Cloud merge semantics for some collections), log at WARNING and increment \`skipped\` so the totals balance. Operator must re-index those chunks from source.

## Tests

- \`test_backfill_skips_none_documents_without_crash\` updated for the two-pass + upsert mock shape.
- \`test_legacy_chunk_with_cargo_gets_hash_via_upsert\`: locks the upsert path against a chunk with legacy cargo fields.
- \`TestBackfillTwoPassPaginationContract\`:
  - \`test_pass1_uses_lightweight_payload_pass2_uses_exact_ids\` locks pass 1 → \`include=[]\`, pass 2 → \`ids=\`, no offset on pass 2.
  - \`test_pass1_paginates_when_first_page_full\` locks the multi-page pass-1 path that the order-stability contract relies on.
- 223 broader regression tests pass (backfill + t3 + indexer + t3_reidentify).

## Closes

- nexus-o9an

## Test plan

- [x] Full \`test_backfill_hash\` suite: 15 passed
- [x] Broader regression sweep: 223 passed
- [ ] Operator validation: re-run \`nx collection backfill-hash --all\` against prod after deploy; verify the previously-stuck 600 chunks are now populated.