### PR TITLE
fix(reidentify): use canonical normalize for over-quota chunks (nexus-6l9p)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -619,3 +619,4 @@
 {"id":"int-80f87d33","kind":"field_change","created_at":"2026-05-10T02:22:58.923364Z","actor":"Hellblazer","issue_id":"nexus-1ljk","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-a7e127c1","kind":"field_change","created_at":"2026-05-10T03:28:26.996308Z","actor":"Hellblazer","issue_id":"nexus-o9an","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-08242c45","kind":"field_change","created_at":"2026-05-10T07:59:59.446469Z","actor":"Hellblazer","issue_id":"nexus-6l9p","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-1af8ddda","kind":"field_change","created_at":"2026-05-10T08:39:47.601313Z","actor":"Hellblazer","issue_id":"nexus-2exh","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -618,3 +618,4 @@
 {"id":"int-d1b721f6","kind":"field_change","created_at":"2026-05-10T01:48:21.990082Z","actor":"Hellblazer","issue_id":"nexus-qlm2","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-80f87d33","kind":"field_change","created_at":"2026-05-10T02:22:58.923364Z","actor":"Hellblazer","issue_id":"nexus-1ljk","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-a7e127c1","kind":"field_change","created_at":"2026-05-10T03:28:26.996308Z","actor":"Hellblazer","issue_id":"nexus-o9an","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-08242c45","kind":"field_change","created_at":"2026-05-10T07:59:59.446469Z","actor":"Hellblazer","issue_id":"nexus-6l9p","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,6 +148,25 @@ Properties:
 
 **ChashIndex (T2 routing table)**: `chash_index` maps `(chash, physical_collection)` to enable global `chash:<hex>` link resolution without scanning every collection. Post-RDR-108 it is a pure routing table (chash + collection + created_at, no denormalized chunk_chroma_id). Stale rows (collection no longer exists in T3) are self-healed by `Catalog.resolve_chash` on access. A bulk reconcile sweep is on the post-Phase-4 follow-up backlog.
 
+### Migration runbook (RDR-108 Phase 4 -> Phase 5)
+
+For operators upgrading an existing nexus deployment to the post-RDR-108 storage shape:
+
+1. **Deploy the new code + restart the MCP server** so the indexer / GC / retrieval paths use the manifest-aware code paths.
+2. **`nx collection backfill-hash --all`** . Adds `chunk_text_hash` to any chunk that lacks it (pre-RDR-053 collections). Two-pass walk: pass 1 collects ids with a lightweight `include=[]` payload, pass 2 fetches by exact id and re-upserts with canonical-schema-normalized metadata. The two-pass design sidesteps ChromaDB Cloud's offset-pagination instability (a naive offset+update loop misses chunks); the canonical-normalize step drops legacy cargo so chunks with 32+ metadata keys land back under the per-row `NumMetadataKeys` quota. Idempotent; chunks that already have the hash short-circuit.
+3. **`nx t3 reidentify --all-collections --dry-run --max-workers 4`** . Preview what will migrate. Should return `0 error(s)`. Errors at this stage typically mean a collection still has chunks without `chunk_text_hash`; re-run step 2 on the named collection or re-index from source.
+4. **`nx t3 reidentify --all-collections --no-dry-run --max-workers 4`** . Actual migration. Each collection is re-upserted under content-derived natural IDs (`chunk_text_hash[:32]`); old IDs are batch-deleted. The `--max-workers` flag parallelizes across collections (default 4); each collection has an independent ID namespace so concurrent execution is safe. Bound by ChromaDB Cloud rate limits, not local CPU.
+5. **Verify**: rerun the dry-run from step 3; expect `would migrate 0` corpus-wide. Spot-check `(source_path, chunk_index)` dupe-key count on a previously-affected collection (was 1,630 in `code__1-2188` before migration; should be 0 after, since the positional fields no longer exist).
+
+Properties of the verbs:
+- **Idempotent**: re-running on a fully-migrated collection performs zero writes.
+- **Crash-resumable**: re-invoking after an interrupted run safely sweeps un-deleted old IDs.
+- **Carve-outs surface as structured errors**: `taxonomy__*` collections are auto-skipped (centroids use `centroid_hash`, not `chunk_text_hash`). Pre-RDR-053 chunks missing `chunk_text_hash` raise `MissingChunkHashError` rather than silently dropping; the message names the collection and tells the operator to re-index from source.
+
+Pre-existing drift surfaced during Phase 5 verification (filed as separate beads):
+- `chash_index` may carry rows for collections that no longer exist in T3 (`Catalog.resolve_chash` self-heals on access; bulk sweep tracked in `nexus-w9vq`).
+- `document_aspects` may carry rows whose `source_uri` no longer matches a catalog Document (FK CASCADE + optional one-shot GC tracked in `nexus-urj4`).
+
 **Tumbler ordering**: Comparison operators (`<`, `<=`, `>`, `>=`) use -1 sentinel padding for cross-depth ordering -- parent tumblers sort before their children. `Tumbler.spans_overlap()` detects positional span overlap using these operators.
 
 **Two graph views**: `catalog_links` returns only links between live documents (deleted nodes excluded).

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -657,8 +657,12 @@ def _backfill_chunk_text_hash(
     # Pass 1: collect every chunk id. Lightweight payload (no metadata,
     # no documents, no embeddings); offset is stable because pass 1 only
     # reads. ChromaDB Cloud's offset semantics are order-unstable across
-    # the longer pass-2 walk, but pass 1 completes fast enough that the
-    # collection state stays consistent for this iteration.
+    # long walks, but pass 1 (read-only, ids only) completes fast enough
+    # for the single-operator scenario that the collection state stays
+    # consistent. Best-effort only: concurrent indexer writes during
+    # pass 1 may produce incomplete coverage on this iteration. The verb
+    # is idempotent, so re-running picks up any chunks the previous pass
+    # missed. nexus-2exh review caveat #4.
     all_ids: list[str] = []
     offset = 0
     while True:

--- a/src/nexus/db/t3_reidentify.py
+++ b/src/nexus/db/t3_reidentify.py
@@ -53,7 +53,6 @@ _log = structlog.get_logger(__name__)
 
 _TAXONOMY_PREFIX = "taxonomy__"
 _PAGE_SIZE = QUOTAS.MAX_RECORDS_PER_WRITE  # 300
-_STRIPPED_META_FIELDS = frozenset({"doc_id", "chunk_index", "chunk_count"})
 
 
 class MissingChunkHashError(ValueError):
@@ -223,10 +222,18 @@ def reidentify_collection(
                 continue
             seen_new_ids.add(new_id)
 
-            new_meta = {
-                k: v for k, v in meta.items()
-                if k not in _STRIPPED_META_FIELDS
-            }
+            # Use the canonical schema funnel (RDR-108 nexus-6l9p)
+            # rather than a narrow strip set. ``_normalize_for_write``
+            # drops the 3 RDR-108 Phase 3 fields (doc_id, chunk_index,
+            # chunk_count) plus all pre-RDR-101-Phase-5c cargo (corpus,
+            # store_type, expires_at, extraction_method, etc) and
+            # bib_* placeholders. Surfaced during the Phase 5 prod
+            # migration: 2 of 153 collections held legacy chunks with
+            # 33+ metadata keys; the prior narrow-strip path produced
+            # NumMetadataKeys quota errors on the upsert. The canonical
+            # funnel brings these chunks back under the per-row quota.
+            from nexus.db.t3 import _normalize_for_write
+            new_meta = _normalize_for_write(meta, collection_name)
             ids_to_upsert.append(new_id)
             docs_to_upsert.append(doc)
             embs_to_upsert.append(emb)

--- a/tests/test_t3_reidentify.py
+++ b/tests/test_t3_reidentify.py
@@ -122,8 +122,13 @@ class TestReidentifyCollection:
         assert "a" * 32 in _ids_in(t3_db, coll)
         assert "legacy-id-1" not in _ids_in(t3_db, coll)
 
-    def test_strips_doc_level_metadata_fields(self, t3_db):
-        """doc_id, chunk_index, chunk_count are removed from metadata at re-upsert."""
+    def test_normalizes_metadata_to_canonical_schema(self, t3_db):
+        """RDR-108 nexus-6l9p: reidentify routes metadata through the
+        canonical schema funnel (``_normalize_for_write``), dropping
+        all cargo not in ``ALLOWED_TOP_LEVEL`` rather than just the
+        3-field RDR-108 Phase 3 set. This sidesteps the per-row
+        ``NumMetadataKeys`` quota error that fires when legacy chunks
+        carry 32+ keys."""
         from nexus.db.t3_reidentify import reidentify_collection
 
         coll = _unique_coll()
@@ -131,7 +136,14 @@ class TestReidentifyCollection:
             t3_db, collection=coll, chunk_id="legacy-id-1",
             content="hello", chunk_text_hash="b" * 64,
             doc_id="1.1.1", chunk_index=2, chunk_count=5,
-            extra_meta={"source_path": "/tmp/foo.py", "line_start": 0},
+            extra_meta={
+                # Pre-RDR-102 D2: source_path was canonical, now cargo.
+                "source_path": "/tmp/foo.py",
+                # Canonical fields that survive normalize.
+                "line_start": 0,
+                "title": "foo.py:0-5",
+                "content_type": "code",
+            },
         )
 
         reidentify_collection(t3_db, coll, dry_run=False)
@@ -139,13 +151,73 @@ class TestReidentifyCollection:
         col = t3_db._client.get_or_create_collection(coll)
         result = col.get(ids=["b" * 32], include=["metadatas"])
         meta = result["metadatas"][0]
+        # RDR-108 Phase 3 fields dropped (the original strip target).
         assert "doc_id" not in meta
         assert "chunk_index" not in meta
         assert "chunk_count" not in meta
-        # Non-stripped fields preserved
-        assert meta.get("source_path") == "/tmp/foo.py"
+        # RDR-102 D2 cargo dropped by canonical normalize.
+        assert "source_path" not in meta
+        # Canonical fields preserved.
         assert meta.get("line_start") == 0
+        assert meta.get("title") == "foo.py:0-5"
         assert meta.get("chunk_text_hash") == "b" * 64
+
+    def test_normalize_drops_legacy_cargo_for_over_quota_chunks(self, t3_db):
+        """RDR-108 nexus-6l9p regression: a chunk seeded with 33 metadata
+        keys (legacy cargo + pre-RDR-108 fields) must reidentify cleanly,
+        producing a normalized payload under the per-row quota.
+
+        Pre-fix path used a 3-field strip; the resulting upsert merged
+        with the chunk's existing cargo and tripped Cloud's
+        ``NumMetadataKeys`` quota at 33 > 32. The canonical funnel drops
+        cargo so the upsert lands under quota."""
+        from nexus.db.t3_reidentify import reidentify_collection
+
+        coll = _unique_coll(prefix="docs")
+        _seed_chunk(
+            t3_db, collection=coll, chunk_id="legacy-cargo-1",
+            content="paper text body", chunk_text_hash="c" * 64,
+            doc_id="1.1.1", chunk_index=0, chunk_count=50,
+            extra_meta={
+                "title": "old-paper",
+                "content_type": "pdf",
+                "content_hash": "abc",
+                "indexed_at": "2024-01-01T00:00:00",
+                "source_path": "/papers/old.pdf",
+                # Cargo that the canonical schema drops:
+                "corpus": "knowledge",
+                "store_type": "knowledge",
+                "expires_at": "",
+                "extraction_method": "docling",
+                "format": "markdown",
+                "is_image_pdf": False,
+                "has_formulas": False,
+                "page_count": 12,
+                "chunk_type": "text",
+            },
+        )
+
+        reidentify_collection(t3_db, coll, dry_run=False)
+
+        col = t3_db._client.get_or_create_collection(coll)
+        result = col.get(ids=["c" * 32], include=["metadatas"])
+        meta = result["metadatas"][0]
+        # The hash is preserved (the chunk migrated).
+        assert meta["chunk_text_hash"] == "c" * 64
+        # Cargo dropped by canonical normalize.
+        for cargo_key in (
+            "corpus", "store_type", "expires_at", "extraction_method",
+            "format", "is_image_pdf", "has_formulas", "page_count",
+            "chunk_type", "source_path",
+            "doc_id", "chunk_index", "chunk_count",
+        ):
+            assert cargo_key not in meta, (
+                f"{cargo_key!r} should be stripped by canonical "
+                f"normalize, got meta={sorted(meta)}"
+            )
+        # Canonical fields preserved.
+        assert meta.get("title") == "old-paper"
+        assert meta.get("content_type") == "pdf"
 
     def test_idempotent_on_fully_migrated_collection(self, t3_db):
         """Re-running on a fully-migrated collection performs zero writes."""

--- a/tests/test_t3_reidentify.py
+++ b/tests/test_t3_reidentify.py
@@ -218,6 +218,18 @@ class TestReidentifyCollection:
         # Canonical fields preserved.
         assert meta.get("title") == "old-paper"
         assert meta.get("content_type") == "pdf"
+        # nexus-2exh review caveat #3: lock the per-row metadata
+        # quota bound. ChromaDB Cloud rejects records whose metadata
+        # has more than 32 keys (NumMetadataKeys quota); the canonical
+        # normalize must produce a payload that respects it. The
+        # MAX_SAFE_TOP_LEVEL_KEYS constant in metadata_schema is the
+        # canonical bound (32).
+        from nexus.metadata_schema import MAX_SAFE_TOP_LEVEL_KEYS
+        assert len(meta) <= MAX_SAFE_TOP_LEVEL_KEYS, (
+            f"normalized metadata must fit under the per-row key "
+            f"quota ({MAX_SAFE_TOP_LEVEL_KEYS}); got {len(meta)} "
+            f"keys: {sorted(meta)}"
+        )
 
     def test_idempotent_on_fully_migrated_collection(self, t3_db):
         """Re-running on a fully-migrated collection performs zero writes."""


### PR DESCRIPTION
## Summary

Stacked on #628. Surfaced during the RDR-108 Phase 5 prod migration: 2 of 153 collections failed reidentify with \`NumMetadataKeys\` quota errors:

\`\`\`
ERROR: docs__1-7__voyage-context-3__v1: Quota exceeded ... usage of 33 exceeds limit of 32.
ERROR: knowledge__art-grossberg-papers__voyage-context-3__v1: Quota exceeded ... usage of 37 exceeds limit of 32.
\`\`\`

## Root cause

\`reidentify_collection\` stripped a 3-field set
(\`_STRIPPED_META_FIELDS = {doc_id, chunk_index, chunk_count}\`) before upserting under the new natural ID. Many legacy chunks carry far more cargo: \`corpus\`, \`store_type\`, \`expires_at\`, \`extraction_method\`, \`format\`, \`is_image_pdf\`, \`has_formulas\`, \`page_count\`, \`source_path\`, \`bib_*\` placeholders. The narrow strip left these in the upsert payload; ChromaDB Cloud's per-row metadata semantics then tripped the 32-key quota.

The canonical schema funnel \`_normalize_for_write\` (\`db/t3.py:132\`) already drops every cargo class plus the RDR-108 Phase 3 fields plus \`bib_*\` placeholders. The indexer write path uses this funnel; backfill-hash uses it (nexus-o9an); reidentify was the outlier.

## Fix

Replace the narrow strip with \`_normalize_for_write\`. Drop the now-redundant \`_STRIPPED_META_FIELDS\` constant.

## Tests

- \`test_strips_doc_level_metadata_fields\` renamed to \`test_normalizes_metadata_to_canonical_schema\`; assertions updated to expect the broader strip set (also drops \`source_path\` per RDR-102 D2).
- New \`test_normalize_drops_legacy_cargo_for_over_quota_chunks\` seeds a 33-key chunk with the exact cargo fingerprint from the prod failure; locks the contract that reidentify produces a normalized payload that survives the per-row quota.
- 28 reidentify tests pass (was 27, +1); 224 broader regression tests pass.

## Closes

- nexus-6l9p

## Test plan

- [x] Full \`test_t3_reidentify\` suite: 28 passed
- [x] Broader regression sweep: 224 passed
- [ ] Operator validation: re-run \`nx t3 reidentify --collection docs__1-7__voyage-context-3__v1 --no-dry-run\` and \`nx t3 reidentify --collection knowledge__art-grossberg-papers__voyage-context-3__v1 --no-dry-run\` — should complete without quota errors. Then verify those 2 collections converge to the post-D1 state.