### PR TITLE
feat(t3): nx t3 gc CLI uses manifest path (nexus-e5aw)

### DIFF
--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -351,18 +351,25 @@ def gc_cmd(
     dry_run: bool,
     yes: bool,
 ) -> None:
-    """Garbage-collect orphaned T3 chunks (RDR-101 Phase 6).
+    """Garbage-collect orphaned T3 chunks via the catalog manifest (RDR-108 Phase 4).
 
     \b
     A chunk is an orphan when:
-      - its ``doc_id`` metadata is not in the catalog projection's
-        alive set for ``--collection``, AND
+      - its ``meta.chunk_text_hash[:32]`` is NOT referenced by any
+        manifest entry in the catalog ``document_chunks`` table for
+        ``--collection``, AND
       - its ``indexed_at`` predates ``--orphan-window`` (default 30d).
 
     \b
-    Per RF-101-3, ``nx t3 gc`` is the SOLE post-Phase-3 emitter of
-    ``ChunkOrphaned`` events and the SOLE path that physically deletes
-    T3 chunks. The strict order on each candidate is:
+    The manifest path matches what ``indexer._prune_deleted_files``
+    (run at the end of ``nx index``) does. Both paths are now
+    semantically equivalent; this CLI is the operator-driven one with
+    explicit dry-run + --yes confirmation, plus ``ChunkOrphaned``
+    event emission for audit trail.
+
+    \b
+    Per RF-101-3, ``nx t3 gc`` is the SOLE emitter of ``ChunkOrphaned``
+    events. The strict order on each candidate is:
 
         1. Append ``ChunkOrphaned(chunk_id, reason)`` to the event log.
         2. Call ``T3Database.delete_by_chunk_ids`` for that chunk.
@@ -375,15 +382,10 @@ def gc_cmd(
     replay-equality.
 
     \b
-    Chunks missing ``doc_id`` (legacy pre-Phase-2 backfill) are
-    UNDECIDABLE here and skipped: operators must run a maintenance
-    backfill verb, not GC, to address them.
-
-    \b
-    NOTE (RDR-108 Phase 4): post-Phase-3 chunks have no ``doc_id`` in
-    metadata and so are skipped here. The manifest-based GC inside
-    ``nx index`` (``indexer._prune_deleted_files``) handles them.
-    Reconciliation of the two paths is tracked in nexus-e5aw.
+    Chunks missing ``chunk_text_hash`` (pre-RDR-053 relics) are
+    UNDECIDABLE here and skipped with a warning: re-index the source
+    or run ``nx t3 reidentify`` to populate the field. Same carve-out
+    as the indexer's manifest GC.
 
     \b
     Examples:
@@ -413,30 +415,40 @@ def gc_cmd(
     cat = _make_catalog()
 
     try:
-        alive = {e.tumbler for e in cat.list_by_collection(collection)}
+        # Manifest path (RDR-108 nexus-e5aw): the catalog
+        # document_chunks table is the authoritative source of truth
+        # for which chashes belong to which collection. A chunk is
+        # orphan when its content hash is not referenced by any
+        # manifest row for this collection's documents. Same SQL the
+        # indexer's _prune_deleted_files uses.
+        referenced = cat.chashes_for_collection(collection)
     except Exception as exc:
-        click.echo(f"Failed to read catalog: {exc}")
+        click.echo(f"Failed to read catalog manifest: {exc}")
         raise click.exceptions.Exit(1)
-    alive_str = {str(t) for t in alive}
 
-    candidates: list[tuple[str, str]] = []
-    skipped_no_doc_id = 0
+    candidates: list[tuple[str, str]] = []  # (chunk_id, chash)
+    skipped_no_chash = 0
     skipped_no_indexed_at = 0
     skipped_within_window = 0
 
     try:
-        chunks = list(t3_db.list_chunks_with_metadata(collection))
+        chunks = list(t3_db.list_chunks_with_metadata(
+            collection, fields=("chunk_text_hash", "indexed_at"),
+        ))
     except Exception as exc:
         click.echo(f"Failed to list chunks for {collection}: {exc}")
         raise click.exceptions.Exit(1)
 
     for chunk_id, meta in chunks:
-        doc_id = meta.get("doc_id", "")
-        if not doc_id:
-            skipped_no_doc_id += 1
+        chash = (meta.get("chunk_text_hash") or "")[:32]
+        if not chash:
+            # Pre-RDR-053 relic: no content hash to compare against
+            # the manifest. Skip with operator-visible count. Same
+            # carve-out semantics as indexer._prune_deleted_files.
+            skipped_no_chash += 1
             continue
-        if doc_id in alive_str:
-            continue
+        if chash in referenced:
+            continue  # live: manifest still references this chunk
         indexed_at = meta.get("indexed_at", "")
         if not indexed_at:
             skipped_no_indexed_at += 1
@@ -449,14 +461,17 @@ def gc_cmd(
         if indexed_dt > cutoff:
             skipped_within_window += 1
             continue
-        candidates.append((chunk_id, doc_id))
+        candidates.append((chunk_id, chash))
 
     click.echo(
         f"{collection}: {len(candidates)} orphan chunk(s) eligible "
         f"(window={orphan_window})"
     )
-    if skipped_no_doc_id:
-        click.echo(f"  skipped {skipped_no_doc_id} chunk(s) with no doc_id")
+    if skipped_no_chash:
+        click.echo(
+            f"  skipped {skipped_no_chash} chunk(s) with no chunk_text_hash "
+            f"(pre-RDR-053 relics; re-index source or run 'nx t3 reidentify')"
+        )
     if skipped_no_indexed_at:
         click.echo(
             f"  skipped {skipped_no_indexed_at} chunk(s) with no/bad indexed_at"
@@ -466,8 +481,8 @@ def gc_cmd(
             f"  skipped {skipped_within_window} chunk(s) inside the orphan window"
         )
 
-    for chunk_id, doc_id in candidates:
-        click.echo(f"  {chunk_id}  ->  doc_id={doc_id}")
+    for chunk_id, chash in candidates:
+        click.echo(f"  {chunk_id}  ->  chash={chash}")
 
     if not candidates:
         click.echo("\nSummary: 0 orphan(s); nothing to do.")
@@ -487,19 +502,23 @@ def gc_cmd(
     # consistent with T3 (events present, all chunks still in T3); the
     # next gc run idempotently re-emits and retries the batch.
     #
-    # NOTE on the alive snapshot: ``alive_str`` was sampled at the top
-    # of this command. A doc registered concurrently between snapshot
-    # and execution would not appear in the alive set, so its chunks
-    # could be GC'd despite the doc being live again. Operators
-    # SHOULD NOT run gc concurrently with active indexing. The window
-    # is single-operator-driven and acceptably small in practice.
+    # NOTE on the manifest snapshot: ``referenced`` was sampled at the
+    # top of this command. A doc registered concurrently between
+    # snapshot and execution would not appear in the referenced set,
+    # so its chunks could be GC'd despite the doc being live again.
+    # Operators SHOULD NOT run gc concurrently with active indexing.
+    # The window is single-operator-driven and acceptably small in
+    # practice.
     event_log = EventLog(cat._dir)
     pending_chunk_ids: list[str] = []
-    for chunk_id, doc_id in candidates:
+    for chunk_id, chash in candidates:
         event = make_event(
             ChunkOrphanedPayload(
                 chunk_id=chunk_id,
-                reason=f"doc_id {doc_id} no longer alive in {collection}",
+                reason=(
+                    f"chash {chash} not referenced by any manifest entry "
+                    f"in {collection}"
+                ),
             )
         )
         event_log.append(event)

--- a/tests/test_t3_gc.py
+++ b/tests/test_t3_gc.py
@@ -69,16 +69,24 @@ def _seed_chunk(
     collection: str,
     chunk_id: str,
     content: str,
-    doc_id: str,
     indexed_at: str,
+    chunk_text_hash: str | None = None,
+    doc_id: str | None = None,
 ) -> None:
-    """Insert one chunk with the metadata GC reads."""
+    """Insert one chunk with the metadata GC reads.
+
+    nexus-e5aw: GC now reads ``chunk_text_hash`` (not ``doc_id``) to
+    decide orphan status, matching the indexer's manifest-based GC.
+    ``doc_id`` is retained as an optional kwarg for back-compat with
+    legacy tests, but the new GC ignores it.
+    """
+    meta: dict = {"indexed_at": indexed_at}
+    if chunk_text_hash is not None:
+        meta["chunk_text_hash"] = chunk_text_hash
+    if doc_id is not None:
+        meta["doc_id"] = doc_id
     col = t3_db._client.get_or_create_collection(collection)
-    col.add(
-        ids=[chunk_id],
-        documents=[content],
-        metadatas=[{"doc_id": doc_id, "indexed_at": indexed_at}],
-    )
+    col.add(ids=[chunk_id], documents=[content], metadatas=[meta])
 
 
 def _iso(dt: datetime) -> str:
@@ -143,12 +151,19 @@ def test_delete_by_chunk_ids_empty_list(t3_db):
 # ── nx t3 gc CLI ─────────────────────────────────────────────────────────
 
 
-def _register_doc(catalog: Catalog, *, tumbler: str, collection: str) -> None:
-    """Seed a document row directly so ``list_by_collection`` returns it.
+def _register_doc(
+    catalog: Catalog,
+    *,
+    tumbler: str,
+    collection: str,
+    chashes: list[str] | None = None,
+) -> None:
+    """Seed a document row directly so the catalog manifest references it.
 
     Bypasses ``Catalog.register`` (which mints its own tumbler off an
-    owner prefix). GC only cares that ``list_by_collection`` reports
-    alive doc_ids, and the SQLite projection is the read path.
+    owner prefix). nexus-e5aw: also writes manifest rows for the given
+    ``chashes`` so ``Catalog.chashes_for_collection`` returns them as
+    referenced (live).
     """
     catalog._db.execute(  # epsilon-allow: GC alive_set fixture; Catalog.register would mint its own tumbler instead of pinning to the test value
         "INSERT INTO documents "
@@ -162,20 +177,28 @@ def _register_doc(catalog: Catalog, *, tumbler: str, collection: str) -> None:
         ),
     )
     catalog._db.commit()
+    if chashes:
+        catalog.write_manifest(tumbler, [
+            {"chash": c, "position": i} for i, c in enumerate(chashes)
+        ])
 
 
 def test_gc_dry_run_reports_orphans_no_mutation(t3_db, catalog, tmp_path, runner):
     """Default dry-run prints orphan candidates but does not delete or emit."""
     coll = "knowledge__test_gc_dryrun"
     long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
-    _register_doc(catalog, tumbler="1.1.1", collection=coll)  # alive
+    live_chash = "a" * 64
+    orphan_chash = "b" * 64
+    _register_doc(
+        catalog, tumbler="1.1.1", collection=coll, chashes=[live_chash],
+    )
     _seed_chunk(
         t3_db, collection=coll, chunk_id="alive1", content="a",
-        doc_id="1.1.1", indexed_at=long_ago,
+        chunk_text_hash=live_chash, indexed_at=long_ago,
     )
-    _seed_chunk(  # orphan: doc 1.1.99 not registered
+    _seed_chunk(  # orphan: chash not in any manifest entry
         t3_db, collection=coll, chunk_id="orphan1", content="o",
-        doc_id="1.1.99", indexed_at=long_ago,
+        chunk_text_hash=orphan_chash, indexed_at=long_ago,
     )
 
     with patch("nexus.db.make_t3", return_value=t3_db), \
@@ -211,18 +234,21 @@ def test_gc_emits_chunk_orphaned_event_before_delete(
     """
     coll = "knowledge__test_gc_emit"
     long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
-    _register_doc(catalog, tumbler="1.1.1", collection=coll)
+    live_chash = "a" * 64
+    _register_doc(
+        catalog, tumbler="1.1.1", collection=coll, chashes=[live_chash],
+    )
     _seed_chunk(
         t3_db, collection=coll, chunk_id="alive1", content="a",
-        doc_id="1.1.1", indexed_at=long_ago,
+        chunk_text_hash=live_chash, indexed_at=long_ago,
     )
     _seed_chunk(
         t3_db, collection=coll, chunk_id="orphan1", content="o",
-        doc_id="1.1.99", indexed_at=long_ago,
+        chunk_text_hash="b" * 64, indexed_at=long_ago,
     )
     _seed_chunk(
         t3_db, collection=coll, chunk_id="orphan2", content="o2",
-        doc_id="1.1.99", indexed_at=long_ago,
+        chunk_text_hash="c" * 64, indexed_at=long_ago,
     )
 
     with patch("nexus.db.make_t3", return_value=t3_db), \
@@ -248,10 +274,10 @@ def test_gc_emits_chunk_orphaned_event_before_delete(
 
 def test_gc_orphan_window_excludes_recent(t3_db, catalog, tmp_path, runner):
     """Chunks whose ``indexed_at`` is within the orphan window are not GC'd
-    even if their ``doc_id`` is dead.
+    even if their chash is not in the manifest.
 
     Rationale: a fresh re-index might briefly leave chunks orphaned
-    while the catalog projection catches up. The window is the grace
+    while the manifest projection catches up. The window is the grace
     period.
     """
     coll = "knowledge__test_gc_window"
@@ -259,11 +285,11 @@ def test_gc_orphan_window_excludes_recent(t3_db, catalog, tmp_path, runner):
     long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
     _seed_chunk(  # orphan but recent: protected
         t3_db, collection=coll, chunk_id="recent_orphan", content="r",
-        doc_id="1.1.99", indexed_at=recent,
+        chunk_text_hash="b" * 64, indexed_at=recent,
     )
     _seed_chunk(  # orphan and old: eligible
         t3_db, collection=coll, chunk_id="old_orphan", content="o",
-        doc_id="1.1.99", indexed_at=long_ago,
+        chunk_text_hash="c" * 64, indexed_at=long_ago,
     )
 
     with patch("nexus.db.make_t3", return_value=t3_db), \
@@ -289,11 +315,11 @@ def test_gc_default_window_is_30_days(t3_db, catalog, tmp_path, runner):
     forty_days = _iso(datetime.now(UTC) - timedelta(days=40))
     _seed_chunk(
         t3_db, collection=coll, chunk_id="within_window", content="w",
-        doc_id="1.1.99", indexed_at=twenty_days,
+        chunk_text_hash="b" * 64, indexed_at=twenty_days,
     )
     _seed_chunk(
         t3_db, collection=coll, chunk_id="past_window", content="p",
-        doc_id="1.1.99", indexed_at=forty_days,
+        chunk_text_hash="c" * 64, indexed_at=forty_days,
     )
 
     with patch("nexus.db.make_t3", return_value=t3_db), \
@@ -309,13 +335,16 @@ def test_gc_default_window_is_30_days(t3_db, catalog, tmp_path, runner):
 
 
 def test_gc_no_orphans_clean_summary(t3_db, catalog, runner):
-    """Every chunk's doc_id alive → 0/0 summary, no events."""
+    """Every chunk's chash referenced in the manifest → 0 orphans, no events."""
     coll = "knowledge__test_gc_clean"
     long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
-    _register_doc(catalog, tumbler="1.1.1", collection=coll)
+    live_chash = "a" * 64
+    _register_doc(
+        catalog, tumbler="1.1.1", collection=coll, chashes=[live_chash],
+    )
     _seed_chunk(
         t3_db, collection=coll, chunk_id="c1", content="x",
-        doc_id="1.1.1", indexed_at=long_ago,
+        chunk_text_hash=live_chash, indexed_at=long_ago,
     )
 
     with patch("nexus.db.make_t3", return_value=t3_db), \
@@ -331,22 +360,19 @@ def test_gc_no_orphans_clean_summary(t3_db, catalog, runner):
         assert events == []
 
 
-def test_gc_chunk_with_missing_doc_id_skipped(
+def test_gc_chunk_with_missing_chunk_text_hash_skipped(
     t3_db, catalog, tmp_path, runner,
 ):
-    """Chunk metadata without ``doc_id`` is undecidable, skipped not GC'd.
-
-    Legacy chunks pre-Phase-2-backfill may not carry ``doc_id``. They
-    must NOT be silently deleted; a maintenance backfill verb is the
-    right path, not GC.
-    """
-    coll = "knowledge__test_gc_no_doc_id"
+    """nexus-e5aw: pre-RDR-053 chunks without ``chunk_text_hash`` are
+    undecidable under the manifest path and skipped with a warning,
+    not GC'd. Same carve-out as ``indexer._prune_deleted_files``."""
+    coll = "knowledge__test_gc_no_chash"
     long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
     col = t3_db._client.get_or_create_collection(coll)
     col.add(
         ids=["legacy_chunk"],
         documents=["x"],
-        metadatas=[{"indexed_at": long_ago}],  # no doc_id
+        metadatas=[{"indexed_at": long_ago}],  # no chunk_text_hash
     )
 
     with patch("nexus.db.make_t3", return_value=t3_db), \
@@ -356,8 +382,12 @@ def test_gc_chunk_with_missing_doc_id_skipped(
             ["t3", "gc", "-c", coll, "--no-dry-run", "--yes"],
         )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
+    # Carve-out chunk preserved.
     assert t3_db._client.get_collection(coll).count() == 1
+    # Operator-visible warning surfaces.
+    assert "no chunk_text_hash" in result.output
+    assert "pre-RDR-053" in result.output
 
 
 def test_gc_aborts_on_uninitialized_catalog(t3_db, tmp_path, runner, monkeypatch):
@@ -402,7 +432,10 @@ def test_gc_malformed_indexed_at_is_skipped(t3_db, catalog, tmp_path, runner):
     col.add(
         ids=["bad_chunk"],
         documents=["x"],
-        metadatas=[{"doc_id": "1.1.99", "indexed_at": "not-an-iso-timestamp"}],
+        metadatas=[{
+            "chunk_text_hash": "b" * 64,
+            "indexed_at": "not-an-iso-timestamp",
+        }],
     )
 
     with patch("nexus.db.make_t3", return_value=t3_db), \
@@ -432,8 +465,11 @@ def test_gc_paginates_above_300_chunk_boundary(
         ids=[f"orphan_{i:04d}" for i in range(chunk_count)],
         documents=[f"chunk {i}" for i in range(chunk_count)],
         metadatas=[
-            {"doc_id": "1.1.99", "indexed_at": long_ago}
-            for _ in range(chunk_count)
+            {
+                "chunk_text_hash": f"{i:064x}",  # unique chash per chunk
+                "indexed_at": long_ago,
+            }
+            for i in range(chunk_count)
         ],
     )
 
@@ -449,52 +485,37 @@ def test_gc_paginates_above_300_chunk_boundary(
     assert t3_db._client.get_collection(coll).count() == 0
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "nexus-krhr contract lock: today GC builds alive_set from "
-        "CatalogEntry.tumbler only (commands/t3.py:302). When Phase 3 "
-        "ships native UUID7 doc_id writes to T3 chunk metadata while "
-        "the catalog still keys documents by tumbler, the alive_set "
-        "intersection misses every UUID7-keyed chunk and GC silently "
-        "sweeps live data after the orphan window. The fix unions both "
-        "tumbler and uuid7 columns when constructing alive_set. This "
-        "test fails today (UUID7 chunks classified as orphans, deleted) "
-        "and starts passing once the union lands. The strict=True flag "
-        "ensures CI fails when the fix is in place but the marker has "
-        "not been removed, forcing the contract lock to ratchet forward."
-    ),
-)
-def test_gc_uuid7_keyed_chunks_with_alive_catalog_entry_must_survive(
+def test_gc_chunk_id_shape_irrelevant_under_manifest_path(
     t3_db, catalog, tmp_path, runner,
 ):
-    """nexus-krhr forward-proof: when chunk doc_id is a UUID7 string
-    that the catalog's projection treats as alive (under whatever
-    schema extension lands), GC must not classify the chunk as an
-    orphan.
-
-    Today's behaviour: alive_set = {tumbler}; chunk doc_id (UUID7) not
-    in alive_set; chunk swept after orphan window. This test fails.
-
-    Future behaviour: alive_set = {tumbler} | {uuid7}; chunk doc_id
-    matches; chunk survives. This test passes; remove the xfail marker.
-    """
-    coll = "knowledge__test_gc_uuid7"
+    """nexus-e5aw replaces the legacy nexus-krhr xfail. Under the
+    manifest path, the chunk's natural-ID shape (UUID7, content-derived
+    chash[:32], legacy synthetic hash) is irrelevant for orphan
+    classification: the only thing that matters is whether the chunk's
+    ``meta.chunk_text_hash[:32]`` is in the manifest's referenced set.
+    A UUID7-keyed chunk whose chash IS referenced survives; a content-
+    derived-keyed chunk whose chash is NOT referenced is GC'd."""
+    coll = "knowledge__test_gc_chunk_id_shape"
     long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
+    live_chash = "a" * 64
 
-    # The catalog has the document keyed by tumbler "1.1.1" today.
-    # In a future native-UUID7-writes world, the SAME document would
-    # ALSO carry the UUID7. Simulate that future by stuffing the UUID7
-    # into a synthetic field; the GC fix must read it.
-    uuid7 = "01900000-0000-7000-8000-000000000000"
-    _register_doc(catalog, tumbler="1.1.1", collection=coll)
+    _register_doc(
+        catalog, tumbler="1.1.1", collection=coll, chashes=[live_chash],
+    )
 
-    # Seed a T3 chunk whose doc_id is the UUID7 (the Phase 3 native
-    # write shape). Today's GC, walking alive = {tumbler}, classifies
-    # this as an orphan because UUID7 != "1.1.1".
+    # UUID7-keyed chunk whose chash IS in the manifest. Survives.
     _seed_chunk(
-        t3_db, collection=coll, chunk_id="alive-uuid7", content="x",
-        doc_id=uuid7, indexed_at=long_ago,
+        t3_db, collection=coll,
+        chunk_id="01900000-0000-7000-8000-000000000000",
+        content="live",
+        chunk_text_hash=live_chash, indexed_at=long_ago,
+    )
+    # Content-derived-keyed chunk whose chash is NOT referenced. GC'd.
+    _seed_chunk(
+        t3_db, collection=coll,
+        chunk_id=("b" * 64)[:32],
+        content="orphan",
+        chunk_text_hash="b" * 64, indexed_at=long_ago,
     )
 
     with patch("nexus.db.make_t3", return_value=t3_db), \
@@ -505,17 +526,9 @@ def test_gc_uuid7_keyed_chunks_with_alive_catalog_entry_must_survive(
         )
 
     assert result.exit_code == 0, result.output
-
-    # Future contract: the UUID7-keyed chunk must survive because the
-    # catalog projection treats it as alive. Today this assertion fails
-    # (the chunk was deleted as an orphan).
-    surviving = t3_db._client.get_collection(coll).get()["ids"]
-    assert "alive-uuid7" in surviving, (
-        f"UUID7-keyed chunk was swept; alive_set construction in "
-        f"commands/t3.py:302 only reads e.tumbler. Fix: union with "
-        f"the future uuid7 column when it lands. Surviving ids: "
-        f"{surviving!r}."
-    )
+    surviving = set(t3_db._client.get_collection(coll).get()["ids"])
+    assert "01900000-0000-7000-8000-000000000000" in surviving
+    assert ("b" * 64)[:32] not in surviving
 
 
 def test_gc_no_yes_flag_reports_only(t3_db, catalog, tmp_path, runner):
@@ -524,7 +537,7 @@ def test_gc_no_yes_flag_reports_only(t3_db, catalog, tmp_path, runner):
     long_ago = _iso(datetime.now(UTC) - timedelta(days=60))
     _seed_chunk(
         t3_db, collection=coll, chunk_id="orphan1", content="o",
-        doc_id="1.1.99", indexed_at=long_ago,
+        chunk_text_hash="b" * 64, indexed_at=long_ago,
     )
 
     with patch("nexus.db.make_t3", return_value=t3_db), \


### PR DESCRIPTION
## Summary

Stacked on #629. Resolves the dual-GC-paths problem the Phase 4 cross-cutting review (nexus-2exh) flagged.

Pre-fix:
- \`indexer._prune_deleted_files\` (auto, runs at end of \`nx index\`) uses the manifest path: \`meta.chunk_text_hash[:32]\` vs \`Catalog.chashes_for_collection\`.
- \`nx t3 gc\` CLI (operator-driven) used the legacy \`doc_id\`-vs-alive path. Post-Phase-3 chunks have no \`doc_id\`, so this CLI silently skipped them and reported zero candidates, even though \`nx index\` would sweep them on the next run.

Post-fix:
- Both paths use the same SQL (\`Catalog.chashes_for_collection\`), the same per-chunk \`meta.chunk_text_hash[:32]\` keying, and the same pre-RDR-053 carve-out.

## Preserved

- \`--dry-run\` / \`--no-dry-run\` / \`--yes\` confirmation UX.
- \`--orphan-window\` grace period (unchanged; protects against deleting chunks the indexer just wrote but the manifest hasn't projected).
- \`ChunkOrphaned\` event emission per RF-101-3 'SOLE-emitter' contract (reason text now mentions chash, not doc_id).
- Strict ordering: event before delete, batch-delete after all events emitted, crash-safe.

## Carve-outs

- Pre-RDR-053 chunks without \`chunk_text_hash\`: skipped with operator-visible warning, NOT deleted. Same as \`_prune_deleted_files\`.

## Tests

The existing \`test_t3_gc\` suite was rewritten:
- \`_seed_chunk\` takes \`chunk_text_hash\` kwarg (\`doc_id\` retained for back-compat with the T3Database direct-API tests).
- \`_register_doc\` writes manifest rows via the new \`chashes\` kwarg.
- \`test_gc_chunk_with_missing_doc_id_skipped\` renamed to \`test_gc_chunk_with_missing_chunk_text_hash_skipped\`; verifies the 'pre-RDR-053' warning surfaces.
- \`nexus-krhr\` xfail (UUID7-keyed alive-chunk) replaced by \`test_gc_chunk_id_shape_irrelevant_under_manifest_path\`: under the manifest path, chunk-id shape is irrelevant; only \`meta.chunk_text_hash\` matters.
- 17 gc tests pass; 294 broader regression tests pass.

## Closes

- nexus-e5aw

## Test plan

- [x] Full \`test_t3_gc\` suite: 17 passed
- [x] Broader regression sweep: 294 passed
- [ ] Operator validation: \`nx t3 gc -c <some-collection> --dry-run\` against prod returns the same orphan count that \`indexer._prune_deleted_files\` would (or close to it; the orphan-window may exclude some recent chunks).