### PR TITLE
feat(catalog): nx catalog chash-reconcile verb (nexus-w9vq)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -620,3 +620,4 @@
 {"id":"int-a7e127c1","kind":"field_change","created_at":"2026-05-10T03:28:26.996308Z","actor":"Hellblazer","issue_id":"nexus-o9an","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-08242c45","kind":"field_change","created_at":"2026-05-10T07:59:59.446469Z","actor":"Hellblazer","issue_id":"nexus-6l9p","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-1af8ddda","kind":"field_change","created_at":"2026-05-10T08:39:47.601313Z","actor":"Hellblazer","issue_id":"nexus-2exh","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-79e3b07e","kind":"field_change","created_at":"2026-05-10T10:07:15.103062Z","actor":"Hellblazer","issue_id":"nexus-w9vq","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -5282,4 +5282,123 @@ def vacuum_backups_cmd(older_than_days: int, dry_run: bool) -> None:
         )
 
 
+@catalog.command("chash-reconcile")
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Actually delete ghost rows. Without this flag the command "
+    "is a dry-run report only.",
+)
+def chash_reconcile_cmd(apply: bool) -> None:
+    """Sweep stale ``chash_index`` rows pointing at deleted T3 collections.
+
+    \b
+    The T2 ``chash_index`` is the routing table that resolves
+    ``chash:<hex>`` link spans to the (collection, chunk) they live
+    in. Rows accumulate over time: when a collection is deleted from
+    T3 (``nx collection delete`` or operator-driven cleanup), the
+    chash_index rows for that collection are NOT cascaded today, so
+    they remain as ghosts pointing at a non-existent collection.
+
+    \b
+    ``Catalog.resolve_chash`` self-heals on access (drops a stale row
+    when it tries to look up a chash and finds the collection
+    missing in T3), but that's a per-access correction, not a sweep.
+    This verb is the bulk equivalent.
+
+    \b
+    Default is dry-run: reports per-collection ghost counts without
+    writing. Pass ``--apply`` to actually delete.
+
+    \b
+    Examples:
+      nx catalog chash-reconcile         # dry-run report
+      nx catalog chash-reconcile --apply # actually delete
+
+    \b
+    Filed under nexus-w9vq (RDR-108 Phase 5 follow-up).
+    """
+    from nexus.commands._helpers import default_db_path
+    from nexus.db import make_t3
+    from nexus.db.t2.chash_index import ChashIndex
+
+    db_path = default_db_path()
+    if not db_path.exists():
+        click.echo(
+            f"No T2 db at {db_path}. Nothing to reconcile.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    try:
+        t3 = make_t3()
+        live_collections = {c.name for c in t3._client.list_collections()}
+    except Exception as exc:
+        click.echo(f"Failed to list T3 collections: {exc}", err=True)
+        raise SystemExit(1)
+
+    idx = ChashIndex(db_path)
+    try:
+        indexed_collections = idx.distinct_collections()
+        ghost_collections = sorted(indexed_collections - live_collections)
+        live_in_index = indexed_collections & live_collections
+        unindexed_in_t3 = sorted(live_collections - indexed_collections)
+
+        if not ghost_collections:
+            click.echo(
+                f"chash_index: {len(indexed_collections)} distinct "
+                f"collection(s); 0 ghost(s). Nothing to reconcile."
+            )
+            if unindexed_in_t3:
+                click.echo(
+                    f"  Note: {len(unindexed_in_t3)} T3 collection(s) "
+                    f"have no chash_index rows (likely empty or never "
+                    f"backfilled)."
+                )
+            return
+
+        # Per-collection ghost row counts (read-only).
+        ghost_counts: list[tuple[str, int]] = []
+        for coll_name in ghost_collections:
+            n = idx.count_for_collection(coll_name)
+            ghost_counts.append((coll_name, n))
+        total_ghost_rows = sum(n for _, n in ghost_counts)
+
+        verb = "would delete" if not apply else "deleted"
+        click.echo(
+            f"chash_index: {len(indexed_collections)} distinct "
+            f"collection(s); {len(ghost_collections)} ghost(s) "
+            f"({total_ghost_rows} row(s) total)"
+        )
+        click.echo(f"  live (in both T3 and index): {len(live_in_index)}")
+        if unindexed_in_t3:
+            click.echo(
+                f"  unindexed (in T3 but not index): {len(unindexed_in_t3)}"
+            )
+
+        # Per-ghost-collection breakdown (capped at 20 to keep output sane).
+        for coll_name, n in ghost_counts[:20]:
+            click.echo(f"  {verb} {n:>6} row(s) from ghost: {coll_name}")
+        if len(ghost_counts) > 20:
+            click.echo(f"  ... and {len(ghost_counts) - 20} more ghost collection(s)")
+
+        if apply:
+            actually_deleted = 0
+            for coll_name in ghost_collections:
+                actually_deleted += idx.delete_collection(coll_name)
+            click.echo(
+                f"\nSummary: deleted {actually_deleted} row(s) across "
+                f"{len(ghost_collections)} ghost collection(s)."
+            )
+        else:
+            click.echo(
+                f"\nSummary: would delete {total_ghost_rows} row(s) "
+                f"across {len(ghost_collections)} ghost collection(s). "
+                f"Re-run with --apply to actually delete."
+            )
+    finally:
+        idx.close()
+
+
 # ── Catalog t3-doc-id-coverage support helpers ───────────────────────────

--- a/src/nexus/db/t2/chash_index.py
+++ b/src/nexus/db/t2/chash_index.py
@@ -199,6 +199,19 @@ class ChashIndex:
             self.conn.commit()
             return cur.rowcount
 
+    def distinct_collections(self) -> set[str]:
+        """Return every distinct ``physical_collection`` value in the
+        index (RDR-108 Phase 5 / nexus-w9vq).
+
+        Used by ``nx catalog chash-reconcile`` to identify ghost
+        collections (rows whose collection no longer exists in T3).
+        """
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT DISTINCT physical_collection FROM chash_index"
+            ).fetchall()
+        return {r[0] for r in rows}
+
     def rename_collection(self, *, old: str, new: str) -> int:
         """Re-point every row from ``old`` → ``new``. Returns row count updated.
 

--- a/tests/test_chash_reconcile.py
+++ b/tests/test_chash_reconcile.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-w9vq: ``nx catalog chash-reconcile`` verb.
+
+The T2 ``chash_index`` is a routing table mapping ``chash`` to
+``physical_collection``. When a collection is deleted from T3, the
+chash_index rows for that collection are NOT cascaded today; they
+remain as ghosts pointing at a non-existent collection. The Phase 5
+verification probe (2026-05-10) found 1682 ghost rows (1824 distinct
+collections in chash_index vs 153 in T3).
+
+These tests pin the contract for ``ChashIndex.distinct_collections``
+and the ``nx catalog chash-reconcile`` CLI verb.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.db.t2.chash_index import ChashIndex
+from nexus.db.t3 import T3Database
+
+
+# ── ChashIndex.distinct_collections ────────────────────────────────────────
+
+
+class TestChashIndexDistinctCollections:
+    def test_empty_returns_empty_set(self, tmp_path: Path) -> None:
+        store = ChashIndex(tmp_path / "t2.db")
+        try:
+            assert store.distinct_collections() == set()
+        finally:
+            store.close()
+
+    def test_returns_distinct_collection_names(self, tmp_path: Path) -> None:
+        store = ChashIndex(tmp_path / "t2.db")
+        try:
+            store.upsert(chash="a" * 64, collection="code__one")
+            store.upsert(chash="b" * 64, collection="code__one")
+            store.upsert(chash="c" * 64, collection="code__two")
+            store.upsert(chash="d" * 64, collection="docs__three")
+            assert store.distinct_collections() == {
+                "code__one", "code__two", "docs__three",
+            }
+        finally:
+            store.close()
+
+
+# ── nx catalog chash-reconcile CLI ─────────────────────────────────────────
+
+
+class TestChashReconcileCLI:
+    @pytest.fixture()
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    @pytest.fixture()
+    def t3_db(self) -> T3Database:
+        return T3Database(
+            _client=chromadb.EphemeralClient(),
+            _ef_override=DefaultEmbeddingFunction(),
+        )
+
+    def _setup_env(
+        self, tmp_path: Path, monkeypatch, t3_db: T3Database,
+        *,
+        live_collections: list[str],
+        indexed_collections: list[tuple[str, list[str]]],
+    ) -> Path:
+        """Configure env so the CLI sees this T3 + a tmp t2 db.
+
+        ``live_collections``: collection names to create in T3.
+        ``indexed_collections``: per-collection (name, [chashes]) to seed
+        in the chash_index. Pass ghost names that aren't in
+        live_collections to simulate stale rows.
+        """
+        for name in live_collections:
+            t3_db._client.get_or_create_collection(name)
+
+        mem_db = tmp_path / "memory.db"
+        idx = ChashIndex(mem_db)
+        try:
+            for name, chashes in indexed_collections:
+                for c in chashes:
+                    idx.upsert(chash=c, collection=name)
+        finally:
+            idx.close()
+
+        import nexus.commands._helpers as h
+        monkeypatch.setattr(h, "default_db_path", lambda: mem_db)
+        monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
+        return mem_db
+
+    def test_no_ghosts_clean_summary(
+        self, tmp_path: Path, monkeypatch, runner, t3_db,
+    ) -> None:
+        self._setup_env(
+            tmp_path, monkeypatch, t3_db,
+            live_collections=["code__live"],
+            indexed_collections=[("code__live", ["a" * 64])],
+        )
+        result = runner.invoke(main, ["catalog", "chash-reconcile"])
+        assert result.exit_code == 0, result.output
+        assert "0 ghost" in result.output
+        assert "Nothing to reconcile" in result.output
+
+    def test_dry_run_default_reports_without_deleting(
+        self, tmp_path: Path, monkeypatch, runner, t3_db,
+    ) -> None:
+        mem_db = self._setup_env(
+            tmp_path, monkeypatch, t3_db,
+            live_collections=["code__live"],
+            indexed_collections=[
+                ("code__live", ["a" * 64]),
+                ("code__ghost1", ["b" * 64, "c" * 64]),  # 2 rows
+                ("code__ghost2", ["d" * 64]),             # 1 row
+            ],
+        )
+
+        result = runner.invoke(main, ["catalog", "chash-reconcile"])
+
+        assert result.exit_code == 0, result.output
+        assert "2 ghost" in result.output  # 2 ghost collections
+        assert "3 row(s) total" in result.output
+        assert "would delete" in result.output
+        assert "Re-run with --apply" in result.output
+
+        # Verify nothing was actually deleted.
+        idx = ChashIndex(mem_db)
+        try:
+            assert idx.distinct_collections() == {
+                "code__live", "code__ghost1", "code__ghost2",
+            }
+            assert idx.count_for_collection("code__ghost1") == 2
+        finally:
+            idx.close()
+
+    def test_apply_deletes_ghost_rows(
+        self, tmp_path: Path, monkeypatch, runner, t3_db,
+    ) -> None:
+        mem_db = self._setup_env(
+            tmp_path, monkeypatch, t3_db,
+            live_collections=["code__live"],
+            indexed_collections=[
+                ("code__live", ["a" * 64, "b" * 64]),
+                ("code__ghost1", ["c" * 64, "d" * 64]),
+                ("code__ghost2", ["e" * 64]),
+            ],
+        )
+
+        result = runner.invoke(main, ["catalog", "chash-reconcile", "--apply"])
+
+        assert result.exit_code == 0, result.output
+        assert "deleted 3 row(s)" in result.output
+        assert "2 ghost collection(s)" in result.output
+
+        idx = ChashIndex(mem_db)
+        try:
+            # Live collection rows preserved; ghost rows gone.
+            assert idx.distinct_collections() == {"code__live"}
+            assert idx.count_for_collection("code__live") == 2
+            assert idx.count_for_collection("code__ghost1") == 0
+            assert idx.count_for_collection("code__ghost2") == 0
+        finally:
+            idx.close()
+
+    def test_apply_idempotent_after_first_run(
+        self, tmp_path: Path, monkeypatch, runner, t3_db,
+    ) -> None:
+        """A second --apply on a clean state finds 0 ghosts."""
+        self._setup_env(
+            tmp_path, monkeypatch, t3_db,
+            live_collections=["code__live"],
+            indexed_collections=[
+                ("code__live", ["a" * 64]),
+                ("code__ghost", ["b" * 64]),
+            ],
+        )
+
+        runner.invoke(main, ["catalog", "chash-reconcile", "--apply"])
+        result = runner.invoke(main, ["catalog", "chash-reconcile", "--apply"])
+
+        assert result.exit_code == 0, result.output
+        assert "0 ghost" in result.output
+
+    def test_unindexed_t3_collections_reported_not_deleted(
+        self, tmp_path: Path, monkeypatch, runner, t3_db,
+    ) -> None:
+        """T3 collections that have NO chash_index rows are reported
+        as 'unindexed' but are NOT classified as ghosts (they're the
+        opposite direction: live in T3, missing from index)."""
+        self._setup_env(
+            tmp_path, monkeypatch, t3_db,
+            live_collections=[
+                "code__live",
+                "code__no_index1",
+                "code__no_index2",
+            ],
+            indexed_collections=[("code__live", ["a" * 64])],
+        )
+
+        result = runner.invoke(main, ["catalog", "chash-reconcile"])
+
+        assert result.exit_code == 0, result.output
+        assert "0 ghost" in result.output
+        assert "2 T3 collection(s)" in result.output  # unindexed count
+        assert "no chash_index rows" in result.output
+
+    def test_no_t2_db_exits_nonzero(
+        self, tmp_path: Path, monkeypatch, runner,
+    ) -> None:
+        absent_db = tmp_path / "absent" / "memory.db"
+        import nexus.commands._helpers as h
+        monkeypatch.setattr(h, "default_db_path", lambda: absent_db)
+
+        result = runner.invoke(main, ["catalog", "chash-reconcile"])
+        assert result.exit_code != 0
+        assert "No T2 db" in result.output
+
+    def test_truncates_long_ghost_list(
+        self, tmp_path: Path, monkeypatch, runner, t3_db,
+    ) -> None:
+        """When there are >20 ghost collections, the per-collection
+        breakdown caps at 20 and reports the remainder count."""
+        ghost_names = [f"code__ghost_{i:03d}" for i in range(25)]
+        self._setup_env(
+            tmp_path, monkeypatch, t3_db,
+            live_collections=["code__live"],
+            indexed_collections=[("code__live", ["a" * 64])] + [
+                (n, [f"{i:064x}"]) for i, n in enumerate(ghost_names)
+            ],
+        )
+
+        result = runner.invoke(main, ["catalog", "chash-reconcile"])
+
+        assert result.exit_code == 0, result.output
+        assert "25 ghost" in result.output
+        assert "and 5 more ghost collection(s)" in result.output


### PR DESCRIPTION
## Summary

Stacked on #632. Ships the bulk-sweep verb for the 1682 ghost chash_index rows surfaced in the Phase 5 verification probe (2026-05-10).

## Background

The T2 \`chash_index\` is a routing table mapping \`chash\` to \`physical_collection\`. When a collection is deleted from T3 (\`nx collection delete\` or operator-driven cleanup), the chash_index rows for that collection are NOT cascaded today. They remain as ghosts pointing at non-existent collections.

\`Catalog.resolve_chash\` already self-heals on access, but that's a per-access correction, not a sweep. Phase 5 probe found:
- 1824 distinct collections in chash_index
- 153 in T3
- 1682 ghost rows (mostly ephemeral test fixtures, legacy RDR-101 names)

This was originally proposed in \`nexus-mmf5\`'s bead description (the 2026-05-08 prod shakeout finding) but deferred when that bead was repurposed for the chunk_chroma_id column drop. This PR ships the deferred work.

## API

- \`ChashIndex.distinct_collections() -> set[str]\`: returns every distinct \`physical_collection\` value in the index.

## CLI

\`nx catalog chash-reconcile [--apply]\`

- Default: dry-run; reports per-collection ghost counts + live/unindexed breakdown.
- \`--apply\`: actually deletes ghost rows via the existing \`delete_collection\` method (uses \`idx_chash_index_collection\` for fast bulk DELETE).
- Per-collection breakdown capped at 20 lines + remainder count (output stays sane on the 1682-ghost prod state).
- Exits non-zero with a helpful message if the T2 db is absent.

## Tests

9 new tests in \`tests/test_chash_reconcile.py\`:
- 2 \`TestChashIndexDistinctCollections\`: empty + multi-collection contracts.
- 7 \`TestChashReconcileCLI\`: clean (no ghosts), dry-run reports, \`--apply\` deletes only ghosts, idempotent re-run, unindexed T3 collections reported (not deleted), no-T2-db exits non-zero, long-ghost-list truncation.

94 broader regression tests pass.

## Closes

- nexus-w9vq

## Operator runbook (post-merge)

\`\`\`bash
nx catalog chash-reconcile          # dry-run; expect ~1682 ghost rows
nx catalog chash-reconcile --apply  # actually delete
\`\`\`

The verb is idempotent and safe to schedule periodically.

## Test plan

- [x] 9 new tests pass
- [x] Broader sweep: 94 passed
- [ ] Operator validation: \`nx catalog chash-reconcile\` against prod reports the expected ~1682 ghost rows; \`--apply\` reduces ghost count to 0.