### PR TITLE
feat(catalog): nx catalog collection-gc + close zombie-collection leaks (nexus-ks40)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -622,3 +622,4 @@
 {"id":"int-1af8ddda","kind":"field_change","created_at":"2026-05-10T08:39:47.601313Z","actor":"Hellblazer","issue_id":"nexus-2exh","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-40908453","kind":"field_change","created_at":"2026-05-10T09:19:39.295619Z","actor":"Hellblazer","issue_id":"nexus-urj4","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-79e3b07e","kind":"field_change","created_at":"2026-05-10T10:07:15.103062Z","actor":"Hellblazer","issue_id":"nexus-w9vq","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-fa262d8c","kind":"field_change","created_at":"2026-05-10T13:26:26.955006Z","actor":"Hellblazer","issue_id":"nexus-ks40","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -5401,4 +5401,158 @@ def chash_reconcile_cmd(apply: bool) -> None:
         idx.close()
 
 
+# ── nx catalog collection-gc (nexus-ks40) ────────────────────────────────
+
+
+@catalog.command("collection-gc")
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Actually delete zombie T3 collections. Without this flag the "
+    "command is a dry-run report only.",
+)
+def collection_gc_cmd(apply: bool) -> None:
+    """Sweep zombie T3 collections (0 chunks, no catalog projection,
+    no document references).
+
+    \b
+    Targets the junkyard pattern flagged by
+    ``nx catalog doctor --collections-drift``: T3 collections that
+    accumulate from interrupted indexes, deleted worktrees, or any
+    indexer path that pre-creates a collection name (via
+    ``get_or_create_collection``) and then never writes a chunk.
+    Each one shows up in the doctor's "T3 collections without
+    projection rows" list and never gets cleaned up because no verb
+    targets them.
+
+    \b
+    Conservative deletion criteria. A T3 collection must satisfy ALL
+    of:
+
+      * 0 chunks (``col.count() == 0``);
+      * NOT registered in the catalog ``collections`` projection;
+      * NOT referenced by any ``documents.physical_collection`` row;
+      * NOT bypass-schema (``taxonomy__*`` is operator-managed and
+        out of scope).
+
+    \b
+    Default is dry-run: reports per-candidate deletion plan without
+    writing. Pass ``--apply`` to actually delete.
+
+    \b
+    Stale projection rows (catalog has the row, T3 collection is
+    gone) are NOT handled here: the catalog event log is
+    append-only, so removing a projection row requires
+    ``supersede_collection(<old>, <target>)`` against an explicit
+    operator-chosen target. Use the recipe printed by
+    ``nx catalog doctor --collections-drift`` for those cases.
+
+    \b
+    Examples:
+      nx catalog collection-gc          # dry-run report
+      nx catalog collection-gc --apply  # actually delete
+
+    \b
+    Filed under nexus-ks40 (catalog/T3 hygiene).
+    """
+    from nexus.db import make_t3
+    from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES
+
+    cat = _get_catalog()
+    try:
+        t3_db = make_t3()
+        t3_collections = t3_db.list_collections()
+    except Exception as exc:
+        click.echo(f"Failed to list T3 collections: {exc}", err=True)
+        raise SystemExit(1)
+
+    projection_names = {r["name"] for r in cat.list_collections()}
+    doc_collection_rows = cat._db.execute(
+        "SELECT DISTINCT physical_collection FROM documents "
+        "WHERE physical_collection != ''"
+    ).fetchall()
+    doc_collection_names = {r[0] for r in doc_collection_rows if r[0]}
+
+    candidates: list[tuple[str, int]] = []
+    skipped_referenced = 0
+    skipped_nonempty = 0
+    skipped_bypass = 0
+
+    for c in t3_collections:
+        name = c["name"]
+        count = c.get("count", 0)
+        if name.startswith(_BYPASS_SCHEMA_PREFIXES):
+            skipped_bypass += 1
+            continue
+        if name in projection_names or name in doc_collection_names:
+            skipped_referenced += 1
+            continue
+        if count > 0:
+            skipped_nonempty += 1
+            continue
+        candidates.append((name, count))
+
+    candidates.sort()
+
+    click.echo(
+        f"T3 collections: {len(t3_collections)} total"
+    )
+    click.echo(
+        f"  catalog projection: {len(projection_names)} entries"
+    )
+    click.echo(
+        f"  documents.physical_collection: {len(doc_collection_names)} entries"
+    )
+    click.echo(
+        f"  bypass-schema (excluded): {skipped_bypass}"
+    )
+    click.echo(
+        f"  referenced by catalog (kept): {skipped_referenced}"
+    )
+    click.echo(
+        f"  unreferenced but non-empty (kept, needs operator review): "
+        f"{skipped_nonempty}"
+    )
+    click.echo(
+        f"  unreferenced AND empty (zombie candidates): {len(candidates)}"
+    )
+
+    if not candidates:
+        click.echo("\nNothing to gc.")
+        return
+
+    verb = "would delete" if not apply else "deleted"
+    click.echo(f"\nZombie collections ({verb}):")
+    # Cap at 30 to keep output sane; the operator gets the count above.
+    for name, count in candidates[:30]:
+        click.echo(f"  {verb} {name} ({count} chunks)")
+    if len(candidates) > 30:
+        click.echo(f"  ... and {len(candidates) - 30} more")
+
+    if apply:
+        actually_deleted = 0
+        failures: list[tuple[str, str]] = []
+        for name, _ in candidates:
+            try:
+                t3_db.delete_collection(name)
+                actually_deleted += 1
+            except Exception as exc:
+                failures.append((name, str(exc)))
+        click.echo(
+            f"\nSummary: deleted {actually_deleted} zombie collection(s) "
+            f"of {len(candidates)} candidate(s)."
+        )
+        if failures:
+            click.echo(f"  {len(failures)} delete(s) failed:")
+            for name, err in failures[:10]:
+                click.echo(f"    {name}: {err}")
+            raise SystemExit(1)
+    else:
+        click.echo(
+            f"\nSummary: would delete {len(candidates)} zombie collection(s). "
+            "Re-run with --apply to actually delete."
+        )
+
+
 # ── Catalog t3-doc-id-coverage support helpers ───────────────────────────

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1006,8 +1006,15 @@ def _run_index_frecency_only(repo: Path, registry: "RepoRegistry") -> None:
     if docs_collection:
         collection_names.append(docs_collection)
 
+    # nexus-ks40: frecency_only is a read-update flow; if the
+    # collection has not yet been written, skip rather than mint an
+    # empty zombie via get_or_create_collection.
+    from chromadb.errors import NotFoundError as _ChromaNotFoundError  # noqa: PLC0415
     for collection_name in collection_names:
-        col = db.get_or_create_collection(collection_name)
+        try:
+            col = db.get_collection(collection_name)
+        except _ChromaNotFoundError:
+            continue
         for file, score in frecency_map.items():
             doc_id = file_to_doc_id.get(file, "")
             where = {"doc_id": doc_id} if doc_id else {"source_path": str(file)}
@@ -1532,10 +1539,25 @@ def _prune_misclassified(
     ~ceil(N / _CHROMA_PAGE_SIZE) queries per direction (~34 total for
     ART) — about a 300x reduction in roundtrips.
     """
+    from chromadb.errors import NotFoundError as _ChromaNotFoundError  # noqa: PLC0415
     from tqdm import tqdm
 
-    code_col = db.get_or_create_collection(code_collection)
-    docs_col = db.get_or_create_collection(docs_collection)
+    # nexus-ks40: read-only sweeps must NOT speculatively create T3
+    # collections. ``get_or_create_collection`` would mint an empty
+    # zombie T3 collection whenever this prune ran on a repo whose
+    # ``code__`` or ``docs__`` collection had not been written yet
+    # (fresh corpus, type-skewed corpus, post-housekeeping cleanup).
+    # Use ``get_collection`` and skip the matching sweep when the
+    # collection genuinely does not exist (there is nothing to
+    # misclassify against an absent target).
+    def _read_collection_or_none(name: str):
+        try:
+            return db.get_collection(name)
+        except _ChromaNotFoundError:
+            return None
+
+    code_col = _read_collection_or_none(code_collection)
+    docs_col = _read_collection_or_none(docs_collection)
     file_to_doc_id = file_to_doc_id or {}
 
     # Prose + PDF files should NOT have chunks in the code__ collection.
@@ -1552,15 +1574,17 @@ def _prune_misclassified(
         unit="sweep",
     )
     try:
-        pruned_chunks += _prune_misclassified_in_collection(
-            code_col, code_targets, file_to_doc_id, kind="code",
-        )
+        if code_col is not None:
+            pruned_chunks += _prune_misclassified_in_collection(
+                code_col, code_targets, file_to_doc_id, kind="code",
+            )
         bar.set_postfix_str(f"chunks={pruned_chunks}", refresh=False)
         bar.update(1)
 
-        pruned_chunks += _prune_misclassified_in_collection(
-            docs_col, docs_targets, file_to_doc_id, kind="docs",
-        )
+        if docs_col is not None:
+            pruned_chunks += _prune_misclassified_in_collection(
+                docs_col, docs_targets, file_to_doc_id, kind="docs",
+            )
         bar.set_postfix_str(f"chunks={pruned_chunks}", refresh=False)
         bar.update(1)
     finally:
@@ -1620,9 +1644,17 @@ def _prune_deleted_files(
     """
     if catalog is None:
         return
+    # nexus-ks40: read-only GC must use get_collection so an absent
+    # T3 collection is a clean skip, not a speculative empty creation
+    # (the latter is the leak that fed the doctor's "T3 collections
+    # without projection rows" zombie list).
+    from chromadb.errors import NotFoundError as _ChromaNotFoundError  # noqa: PLC0415
     for collection_name in (code_collection, docs_collection):
         referenced = catalog.chashes_for_collection(collection_name)
-        col = db.get_or_create_collection(collection_name)
+        try:
+            col = db.get_collection(collection_name)
+        except _ChromaNotFoundError:
+            continue
         all_chunks = _paginated_get(col, include=["metadatas"])
         if not all_chunks["ids"]:
             continue

--- a/tests/test_collection_gc.py
+++ b/tests/test_collection_gc.py
@@ -205,7 +205,7 @@ class TestCollectionGCCli:
         empty_referenced = "rdr__doc-referenced__voyage-context-3__v1"
         t3_db._client.get_or_create_collection(empty_referenced)
         # Direct insert into documents to skip the register flow.
-        catalog_env._db.execute(
+        catalog_env._db.execute(  # epsilon-allow: gc test fixture seeds an orphaned documents row to verify the document-reference protection guard
             "INSERT INTO documents "
             "(tumbler, title, author, year, content_type, file_path, "
             " corpus, physical_collection, chunk_count, head_hash, "

--- a/tests/test_collection_gc.py
+++ b/tests/test_collection_gc.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-ks40: ``nx catalog collection-gc`` verb.
+
+Sweeps zombie T3 collections (0 chunks, no catalog projection, no
+``documents.physical_collection`` reference). Targets the junkyard
+pattern flagged by ``nx catalog doctor --collections-drift``: empty
+T3 collections that accumulate from interrupted indexes, deleted
+worktrees, or any indexer path that pre-creates a collection name
+via ``get_or_create_collection`` and then never writes a chunk.
+
+Conservative: a non-empty unreferenced collection is preserved
+(operator review required); a referenced collection is preserved;
+``taxonomy__*`` bypass-schema collections are out of scope.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+from click.testing import CliRunner
+
+from nexus.catalog.catalog import Catalog
+from nexus.cli import main
+from nexus.db.t3 import T3Database
+
+
+class TestCollectionGCCli:
+    @pytest.fixture()
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    @pytest.fixture()
+    def t3_db(self) -> T3Database:
+        # Mirror test_chash_reconcile.py: clear collections on entry
+        # because EphemeralClient instances share an in-memory backend
+        # across the test session.
+        client = chromadb.EphemeralClient()
+        for c in list(client.list_collections()):
+            name = c if isinstance(c, str) else c.name
+            try:
+                client.delete_collection(name)
+            except Exception:
+                pass
+        return T3Database(
+            _client=client,
+            _ef_override=DefaultEmbeddingFunction(),
+        )
+
+    @pytest.fixture()
+    def catalog_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> Catalog:
+        catalog_dir = tmp_path / "catalog"
+        monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
+        Catalog.init(catalog_dir)
+        return Catalog(catalog_dir, catalog_dir / ".catalog.db")
+
+    def _seed(
+        self,
+        t3_db: T3Database,
+        catalog: Catalog,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        zombie_collections: list[str],
+        registered_collections: list[str],
+        unreferenced_with_chunks: list[str],
+    ) -> None:
+        """Wire env so the CLI sees ``t3_db`` + the seeded catalog,
+        then create the requested mixture of T3 collections.
+
+        ``zombie_collections``: empty T3 collections, NOT in catalog,
+        NOT in documents — should be deleted.
+
+        ``registered_collections``: empty T3 collections that ARE in
+        catalog projection — should be preserved.
+
+        ``unreferenced_with_chunks``: T3 collections with at least one
+        chunk, NOT in catalog — should be preserved (operator review).
+        """
+        for name in zombie_collections:
+            t3_db._client.get_or_create_collection(name)
+        for name in registered_collections:
+            t3_db._client.get_or_create_collection(name)
+            catalog.register_collection(name)
+        for name in unreferenced_with_chunks:
+            col = t3_db._client.get_or_create_collection(name)
+            col.upsert(
+                ids=["seed-1"], documents=["seed text"],
+                metadatas=[{"title": "seed.md"}],
+            )
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
+
+    def test_no_zombies_clean_summary(
+        self, monkeypatch, runner, t3_db, catalog_env,
+    ) -> None:
+        self._seed(
+            t3_db, catalog_env, monkeypatch,
+            zombie_collections=[],
+            registered_collections=["code__live"],
+            unreferenced_with_chunks=[],
+        )
+        result = runner.invoke(main, ["catalog", "collection-gc"])
+        assert result.exit_code == 0, result.output
+        assert "0" in result.output
+        assert "Nothing to gc" in result.output
+
+    def test_dry_run_lists_zombies_without_deleting(
+        self, monkeypatch, runner, t3_db, catalog_env,
+    ) -> None:
+        self._seed(
+            t3_db, catalog_env, monkeypatch,
+            zombie_collections=[
+                "rdr__zombie-1__voyage-context-3__v1",
+                "rdr__zombie-2__voyage-context-3__v1",
+                "code__zombie-leak",
+            ],
+            registered_collections=["code__live"],
+            unreferenced_with_chunks=[],
+        )
+
+        result = runner.invoke(main, ["catalog", "collection-gc"])
+
+        assert result.exit_code == 0, result.output
+        assert "zombie candidates): 3" in result.output
+        assert "would delete" in result.output
+        assert "rdr__zombie-1__voyage-context-3__v1" in result.output
+        assert "rdr__zombie-2__voyage-context-3__v1" in result.output
+        assert "code__zombie-leak" in result.output
+        assert "Re-run with --apply" in result.output
+
+        # T3 unchanged.
+        names = {c["name"] for c in t3_db.list_collections()}
+        assert {"rdr__zombie-1__voyage-context-3__v1",
+                "rdr__zombie-2__voyage-context-3__v1",
+                "code__zombie-leak",
+                "code__live"} <= names
+
+    def test_apply_deletes_only_zombies(
+        self, monkeypatch, runner, t3_db, catalog_env,
+    ) -> None:
+        """``--apply`` deletes the zombies but preserves registered
+        collections and unreferenced-but-non-empty collections.
+        """
+        self._seed(
+            t3_db, catalog_env, monkeypatch,
+            zombie_collections=[
+                "rdr__zombie-a__voyage-context-3__v1",
+                "docs__zombie-b",
+            ],
+            registered_collections=["code__live"],
+            unreferenced_with_chunks=[
+                "knowledge__operator-loaded",
+            ],
+        )
+
+        result = runner.invoke(main, ["catalog", "collection-gc", "--apply"])
+
+        assert result.exit_code == 0, result.output
+        assert "deleted 2 zombie collection(s)" in result.output
+
+        names = {c["name"] for c in t3_db.list_collections()}
+        # Zombies gone.
+        assert "rdr__zombie-a__voyage-context-3__v1" not in names
+        assert "docs__zombie-b" not in names
+        # Registered + non-empty preserved.
+        assert "code__live" in names
+        assert "knowledge__operator-loaded" in names
+
+    def test_unreferenced_with_chunks_is_kept_for_review(
+        self, monkeypatch, runner, t3_db, catalog_env,
+    ) -> None:
+        """A T3 collection NOT in catalog but with chunks may be
+        operator-loaded data not yet registered. The verb must NOT
+        delete it; it counts under "needs operator review".
+        """
+        self._seed(
+            t3_db, catalog_env, monkeypatch,
+            zombie_collections=[],
+            registered_collections=[],
+            unreferenced_with_chunks=["knowledge__operator-loaded"],
+        )
+
+        result = runner.invoke(main, ["catalog", "collection-gc", "--apply"])
+
+        assert result.exit_code == 0, result.output
+        assert "unreferenced but non-empty (kept" in result.output
+        assert "1" in result.output
+        # The non-empty unreferenced collection survives.
+        names = {c["name"] for c in t3_db.list_collections()}
+        assert "knowledge__operator-loaded" in names
+
+    def test_documents_physical_collection_reference_protects_from_delete(
+        self, monkeypatch, runner, t3_db, catalog_env,
+    ) -> None:
+        """A T3 collection that's referenced by ``documents.physical_collection``
+        must NOT be deleted even when empty in T3 (the document row is
+        the operator's intent — data may have been deleted out-of-band
+        and is being restored).
+        """
+        # Seed an empty T3 collection AND a documents row referencing it.
+        empty_referenced = "rdr__doc-referenced__voyage-context-3__v1"
+        t3_db._client.get_or_create_collection(empty_referenced)
+        # Direct insert into documents to skip the register flow.
+        catalog_env._db.execute(
+            "INSERT INTO documents "
+            "(tumbler, title, author, year, content_type, file_path, "
+            " corpus, physical_collection, chunk_count, head_hash, "
+            " indexed_at, source_uri, alias_of) "
+            "VALUES (?, '', '', 0, 'paper', '', '', ?, 0, '', '', '', '')",
+            ("9.9.9", empty_referenced),
+        )
+        catalog_env._db.commit()
+        monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
+
+        result = runner.invoke(main, ["catalog", "collection-gc", "--apply"])
+        assert result.exit_code == 0, result.output
+
+        names = {c["name"] for c in t3_db.list_collections()}
+        assert empty_referenced in names, (
+            "documents.physical_collection reference must protect the "
+            "T3 collection from gc-induced deletion"
+        )
+
+    def test_taxonomy_bypass_schema_excluded(
+        self, monkeypatch, runner, t3_db, catalog_env,
+    ) -> None:
+        """``taxonomy__*`` collections use bypass-schema (vector-only,
+        operator-managed) and must be excluded from gc consideration.
+        """
+        # Real chromadb would refuse to upsert into taxonomy__ without
+        # special metadata; just create the empty collection.
+        t3_db._client.get_or_create_collection(
+            "taxonomy__centroids", metadata={"hnsw:space": "cosine"},
+        )
+        # Plus one zombie that SHOULD be swept.
+        t3_db._client.get_or_create_collection("rdr__zombie")
+        monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
+
+        result = runner.invoke(main, ["catalog", "collection-gc", "--apply"])
+
+        assert result.exit_code == 0, result.output
+        assert "deleted 1 zombie" in result.output
+        names = {c["name"] for c in t3_db.list_collections()}
+        assert "taxonomy__centroids" in names
+        assert "rdr__zombie" not in names

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -46,6 +46,8 @@ def _tracking_db():
         ups.setdefault(collection_name, []).extend(metadatas)
     db = MagicMock()
     db.get_or_create_collection.side_effect = goc
+    db.get_collection.side_effect = goc
+    db.get_collection.side_effect = goc
     db.upsert_chunks_with_embeddings.side_effect = cap
     return db, ups, cols
 
@@ -53,6 +55,7 @@ def _tracking_db():
 def _mock_db():
     col = MagicMock(); col.get.return_value = {"metadatas": [], "ids": []}
     db = MagicMock(); db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
     return db, col
 
 
@@ -203,6 +206,7 @@ def test_run_index_reindexes_when_embedding_model_changed(tmp_path):
     col = MagicMock()
     col.get.return_value = {"metadatas": [{"content_hash": h, "embedding_model": "voyage-4"}], "ids": []}
     db = MagicMock(); db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
     with _patches(db, extra={"nexus.chunker.chunk_file": {"return_value": [_chunk()]},
                               "voyageai.Client": {"return_value": _voyage(1)}}):
         _run_index(repo, _reg())
@@ -218,6 +222,7 @@ def test_frecency_only_updates_frecency_score(tmp_path):
     old = {"frecency_score": 0.1, "source_path": str(src), "title": "main.py:1-1"}
     col = MagicMock(); col.get.return_value = {"ids": ["c1"], "metadatas": [old]}
     db = MagicMock(); db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
     with patch("nexus.frecency.batch_frecency", return_value={src: 0.75}), \
          patch("nexus.config.get_credential", return_value="fake-key"), \
          patch("nexus.db.make_t3", return_value=db):
@@ -244,6 +249,8 @@ def test_frecency_only_uses_doc_id_when_catalog_has_entry(tmp_path):
     col.get.return_value = {"ids": ["c1"], "metadatas": [old]}
     db = MagicMock()
     db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
+    db.get_collection.return_value = col
 
     # Mock the catalog map so the file resolves to a known doc_id.
     with patch(
@@ -275,6 +282,8 @@ def test_frecency_only_falls_back_to_source_path_when_no_catalog_entry(tmp_path)
     col.get.return_value = {"ids": ["c1"], "metadatas": [old]}
     db = MagicMock()
     db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
+    db.get_collection.return_value = col
     with patch(
         "nexus.indexer._build_frecency_doc_id_map",
         return_value={},
@@ -293,6 +302,7 @@ def test_frecency_only_skips_unindexed_files(tmp_path):
     src = repo / "new.py"; src.write_text("y = 2\n")
     col = MagicMock(); col.get.return_value = {"ids": [], "metadatas": []}
     db = MagicMock(); db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
     with patch("nexus.frecency.batch_frecency", return_value={src: 0.5}), \
          patch("nexus.config.get_credential", return_value="fake-key"), \
          patch("nexus.db.make_t3", return_value=db):
@@ -444,6 +454,7 @@ def _gc_db(per_collection_rows: dict[str, list[tuple[str, str]]]):
     returns a per-collection ``_gc_col``. Use when a test needs DIFFERENT
     chunks for the code and docs collections; the single-shared-col
     pattern (``db.get_or_create_collection.return_value = _gc_col(...)``)
+    db.get_collection.return_value = _gc_col(...)``)
     silently returns the same chunks for both collections, which would
     mask correctness bugs in any test that exercises non-empty
     references on both sides simultaneously (nexus-v7mn).
@@ -456,6 +467,10 @@ def _gc_db(per_collection_rows: dict[str, list[tuple[str, str]]]):
     }
     db = MagicMock()
     db.get_or_create_collection.side_effect = lambda name: cols[name]
+    db.get_collection.side_effect = lambda name: cols[name]
+    # nexus-ks40: read paths now use ``get_collection`` (raises when
+    # absent) so the mock must satisfy both name-resolution surfaces.
+    db.get_collection.side_effect = lambda name: cols[name]
     return db, cols
 
 
@@ -487,6 +502,7 @@ def test_prune_deleted_files_orphan_chunk_deleted(tmp_path):
     col = _gc_col([("live-id-synthetic", live_chash),
                    ("orphan-id-synthetic", orphan_chash)])
     db = MagicMock(); db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
     catalog = _gc_catalog({"code__repo": {live_chash[:32]}, "docs__repo": set()})
 
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
@@ -506,6 +522,7 @@ def test_prune_deleted_files_preserves_live_synthetic_id(tmp_path):
     synthetic_id = "0123456789abcdef" * 2  # 32 hex chars unrelated to chash
     col = _gc_col([(synthetic_id, chash)])
     db = MagicMock(); db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
     catalog = _gc_catalog({"code__repo": {chash[:32]}, "docs__repo": set()})
 
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
@@ -522,6 +539,7 @@ def test_prune_deleted_files_empty_manifest_deletes_all(tmp_path):
                    ("id-y", "y" * 64),
                    ("id-z", "z" * 64)])
     db = MagicMock(); db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
     catalog = _gc_catalog({"code__repo": set(), "docs__repo": set()})
 
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
@@ -541,6 +559,7 @@ def test_prune_deleted_files_chunk_without_chunk_text_hash_skipped(tmp_path):
     from nexus.indexer import _prune_deleted_files
     col = _gc_col([("ancient", ""), ("orphan", "b" * 64)])
     db = MagicMock(); db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
     catalog = _gc_catalog({"code__repo": {"a" * 32}, "docs__repo": set()})
 
     with capture_logs() as cap:
@@ -572,11 +591,13 @@ def test_prune_deleted_files_idempotent(tmp_path):
 
     col = _gc_col([("live-id", chash)])
     db = MagicMock(); db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
     assert col.delete.call_count == 0
 
     col2 = _gc_col([("live-id", chash)])
     db2 = MagicMock(); db2.get_or_create_collection.return_value = col2
+    db2.get_collection.return_value = col2
     _prune_deleted_files("code__repo", "docs__repo", db2, catalog=catalog)
     assert col2.delete.call_count == 0
 
@@ -587,11 +608,72 @@ def test_prune_deleted_files_no_catalog_is_noop(tmp_path):
     from nexus.indexer import _prune_deleted_files
     col = _gc_col([("x", "x" * 64)])
     db = MagicMock(); db.get_or_create_collection.return_value = col
+    db.get_collection.return_value = col
 
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=None)
 
     assert col.delete.call_count == 0
     db.get_or_create_collection.assert_not_called()
+
+
+def test_prune_deleted_files_does_not_create_zombie_collections(tmp_path):
+    """nexus-ks40 regression: an absent T3 collection must NOT be
+    speculatively created by the prune sweep. Pre-fix, prune called
+    ``db.get_or_create_collection`` which minted an empty zombie T3
+    collection whenever the GC ran on a corpus whose ``code__`` or
+    ``docs__`` collection had never been written. That zombie then
+    showed up in ``nx catalog doctor --collections-drift``'s "T3
+    collections without projection rows" list and never got cleaned
+    up. Post-fix, prune uses ``get_collection`` and silently skips
+    when the collection is absent.
+    """
+    from chromadb.errors import NotFoundError as _ChromaNotFoundError
+    from nexus.indexer import _prune_deleted_files
+
+    catalog = _gc_catalog({"code__repo": set(), "docs__repo": set()})
+
+    db = MagicMock()
+    db.get_collection.side_effect = _ChromaNotFoundError(
+        "Collection not found"
+    )
+
+    _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
+
+    # CRITICAL: get_or_create_collection must NOT have been called
+    # (the leak path). get_collection is the read-only correct path.
+    db.get_or_create_collection.assert_not_called()
+    # get_collection called once per collection (code, docs).
+    assert db.get_collection.call_count == 2
+
+
+def test_prune_misclassified_does_not_create_zombie_collections(tmp_path):
+    """nexus-ks40 regression for the misclassification sweep: same
+    contract as above. Absent T3 collections must NOT trip
+    speculative creation; the corresponding sweep is a no-op.
+    """
+    from chromadb.errors import NotFoundError as _ChromaNotFoundError
+    from nexus.indexer import _prune_misclassified
+
+    db = MagicMock()
+    db.get_collection.side_effect = _ChromaNotFoundError(
+        "Collection not found"
+    )
+
+    repo = tmp_path / "fresh-repo"
+    repo.mkdir()
+    (repo / "main.py").write_text("x = 1\n")
+
+    _prune_misclassified(
+        repo, "code__fresh", "docs__fresh",
+        code_files=[repo / "main.py"],
+        prose_files=[],
+        pdf_files=[],
+        db=db,
+        file_to_doc_id={},
+    )
+
+    db.get_or_create_collection.assert_not_called()
+    assert db.get_collection.call_count == 2
 
 
 def test_prune_deleted_files_per_collection_orphan_isolation(tmp_path):
@@ -713,6 +795,11 @@ def test_prune_deleted_files_round_trip_with_real_catalog(tmp_path):
         def get_or_create_collection(self, name):
             return chroma.get_or_create_collection(name)
 
+        # nexus-ks40: read-only GC paths now use ``get_collection``;
+        # forward to chroma so the integration test still wires through.
+        def get_collection(self, name):
+            return chroma.get_collection(name)
+
     # Delete the second document. FK CASCADE removes its manifest rows.
     cat._db.execute(  # epsilon-allow: integration fixture forces FK CASCADE
         "DELETE FROM documents WHERE tumbler = ?", ("1.1.2",),
@@ -731,6 +818,7 @@ def test_run_index_prune_misclassified(tmp_path):
     cc = MagicMock(); cc.get.return_value = {"ids": []}
     dc = MagicMock(); dc.get.return_value = {"ids": ["stale-1"]}
     db = MagicMock(); db.get_or_create_collection.side_effect = {"code__repo": cc, "docs__repo": dc}.get
+    db.get_collection.side_effect = {"code__repo": cc, "docs__repo": dc}.get
     _prune_misclassified(repo, "code__repo", "docs__repo", [repo/"main.py"], [repo/"README.md"], [], db)
     dc.delete.assert_called_once_with(ids=["stale-1"])
 
@@ -747,6 +835,7 @@ def test_registry_c2_fallback(tmp_path):
     names: list[str] = []
     col = MagicMock(); col.get.return_value = {"metadatas": [], "ids": []}
     db = MagicMock(); db.get_or_create_collection.side_effect = lambda n: (names.append(n), col)[1]
+    db.get_collection.side_effect = lambda n: (names.append(n), col)[1]
     with _patches(db): _run_index(repo, reg)
     assert expected in names
 
@@ -1167,6 +1256,8 @@ def test_prune_deleted_files_paginates(tmp_path):
         c = MagicMock(); c.get.side_effect = [p1, p2, p3]; return c
     db = MagicMock()
     db.get_or_create_collection.side_effect = lambda _: (mock_cols.append(mc()), mock_cols[-1])[1]
+    db.get_collection.side_effect = lambda _: (mock_cols.append(mc()), mock_cols[-1])[1]
+    db.get_collection.side_effect = lambda _: (mock_cols.append(mc()), mock_cols[-1])[1]
     catalog = _gc_catalog({"code__repo": live_chashes_32, "docs__repo": live_chashes_32})
 
     _prune_deleted_files("code__repo", "docs__repo", db, catalog=catalog)
@@ -1187,6 +1278,7 @@ def test_frecency_update_paginates(tmp_path):
     cc = MagicMock(); cc.get.side_effect = [p1, p2]
     dc = MagicMock(); dc.get.return_value = {"ids":[],"metadatas":[]}
     db = MagicMock(); db.get_or_create_collection.side_effect = {"code__repo":cc,"docs__repo":dc}.get
+    db.get_collection.side_effect = {"code__repo":cc,"docs__repo":dc}.get
     with patch("nexus.frecency.batch_frecency", return_value={src: 0.9}), \
          patch("nexus.config.get_credential", return_value="fake-key"), \
          patch("nexus.db.make_t3", return_value=db):
@@ -1202,6 +1294,7 @@ def test_prune_misclassified_paginates(tmp_path):
     cc = MagicMock(); cc.get.side_effect = [{"ids":[f"s-{i}" for i in range(300)]}, {"ids":[f"s-{i}" for i in range(300,310)]}]
     dc = MagicMock(); dc.get.return_value = {"ids":[]}
     db = MagicMock(); db.get_or_create_collection.side_effect = {"code__repo":cc,"docs__repo":dc}.get
+    db.get_collection.side_effect = {"code__repo":cc,"docs__repo":dc}.get
     _prune_misclassified(repo, "code__repo", "docs__repo", [], [bp], [], db)
     d = set()
     for c in cc.delete.call_args_list: d.update(c.kwargs.get("ids") or (c.args[0] if c.args else []))
@@ -1230,6 +1323,8 @@ def test_prune_misclassified_uses_doc_id_when_supplied(tmp_path):
     dc.get.return_value = {"ids": []}
     db = MagicMock()
     db.get_or_create_collection.side_effect = {"code__repo": cc, "docs__repo": dc}.get
+    db.get_collection.side_effect = {"code__repo": cc, "docs__repo": dc}.get
+    db.get_collection.side_effect = {"code__repo": cc, "docs__repo": dc}.get
     _prune_misclassified(
         repo, "code__repo", "docs__repo",
         [], [bp], [], db,
@@ -1256,6 +1351,8 @@ def test_prune_misclassified_falls_back_to_source_path_for_unmapped_files(tmp_pa
     dc.get.return_value = {"ids": []}
     db = MagicMock()
     db.get_or_create_collection.side_effect = {"code__repo": cc, "docs__repo": dc}.get
+    db.get_collection.side_effect = {"code__repo": cc, "docs__repo": dc}.get
+    db.get_collection.side_effect = {"code__repo": cc, "docs__repo": dc}.get
     _prune_misclassified(
         repo, "code__repo", "docs__repo",
         [], [bp], [], db,


### PR DESCRIPTION
## Summary

Two-part fix for the catalog/T3 hygiene drift the release-sandbox shakedown's step 11/11 (`nx catalog doctor --collections-drift`) keeps surfacing. RDR-108 closed the chunk-level identity gap; this closes the collection-level junkyard gap.

## Cleanup verb

`nx catalog collection-gc` — sweeps T3 collections that satisfy ALL of:
- 0 chunks
- not in catalog `collections` projection
- not referenced by any `documents.physical_collection`
- not bypass-schema (taxonomy__*)

Default dry-run; `--apply` deletes. **Verified against prod**: identified and removed 13 zombies in one shot (rdr__1-1, rdr__1-3, rdr__agent-* x3, rdr__nexus-rich0-* x2, code__alpha, code__main, code__fallback_live, docs__beta, docs__shakedown_4_16_1, docs__stale).

Stale projection rows (catalog has the entry, T3 collection is gone) are out of scope here — the catalog event log is append-only, so removing a projection row requires the operator to choose a supersede target. The doctor already prints that recipe.

## Prevention

Three indexer paths were minting empty zombie T3 collections every time they ran on a corpus where `code__` or `docs__` had not yet been written:

1. `_prune_misclassified` (type-skew sweep after every `nx index repo`).
2. `_prune_deleted_files` (manifest-orphan sweep after every `nx index repo`).
3. `_run_index_frecency_only` (frecency-only refresh).

All three flipped from `db.get_or_create_collection` to `db.get_collection` + silent skip on `NotFoundError`. The corresponding sweep is a no-op when the collection doesn't exist (which is the correct semantic: nothing to misclassify, prune, or refresh against an absent target).

## Tests

- `tests/test_collection_gc.py` (new): 6 cases covering dry-run, --apply, unreferenced-with-chunks-kept, document-reference protection, taxonomy bypass.
- `tests/test_indexer.py`: 2 regression tests that lock the prevention contract by asserting `db.get_or_create_collection.assert_not_called()` when the collection is absent.
- Updated existing prune / frecency mocks to satisfy both `get_or_create_collection` and `get_collection` (the read path flipped, the mocks need to mirror).

## Test plan

- [x] `uv run pytest tests/test_indexer.py tests/test_indexer_e2e.py tests/test_collection_gc.py tests/test_chash_reconcile.py tests/test_t3.py` (200 passed)
- [x] Real-world cleanup: `nx catalog collection-gc --apply` against prod deleted 13 zombies; before/after doctor output verified
- [x] Em-dash audit clean
- [x] Branch off develop (no stack dependencies)

## Closes

- nexus-ks40

## Follow-ups (not blocking)

- 7 prod T3 collections are non-empty but unregistered: `nx catalog backfill-collections` will register them. They were preserved by the gc's "needs operator review" guard.
- 1 prod stale projection (`docs__art-architecture`) needs operator to choose a supersede target. The doctor prints the recipe.
- Indexer paths in `_run_index` (lines 1945/1946) still pre-create code/docs collections at index start. Those are write-path creations (not zombies if writes happen) but worth a follow-up if we want to defer creation to the first chunk write.