### PR TITLE
fix(catalog): resolve chunk:char span via document_chunks manifest (nexus-hjd6 P1)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1726,7 +1726,13 @@ class Catalog:
         if entry is None:
             return None
         from nexus.catalog import catalog_spans
-        return catalog_spans.resolve_span_text_for_entry(entry, span)
+        # nexus-hjd6: pass self so the chunk:char branch can use the
+        # document_chunks manifest (RDR-108 Phase 3 removed the
+        # chunk_index/doc_id metadata that the legacy where-filter
+        # depended on).
+        return catalog_spans.resolve_span_text_for_entry(
+            entry, span, catalog=self,
+        )
 
     def link_audit(self, *, t3: "ClientAPI | None" = None) -> dict:
         """Audit the links table."""

--- a/src/nexus/catalog/catalog_spans.py
+++ b/src/nexus/catalog/catalog_spans.py
@@ -340,7 +340,7 @@ def resolve_chash_globally(
 
 
 def resolve_span_text_for_entry(
-    entry: "CatalogEntry", span: str,
+    entry: "CatalogEntry", span: str, *, catalog: "Catalog | None" = None,
 ) -> str | None:
     """Resolve a span to text given an already-resolved CatalogEntry.
 
@@ -354,6 +354,17 @@ def resolve_span_text_for_entry(
     span, retrieve the exact passage. ``Catalog.resolve_span_text``
     is the public entry point that performs the tumbler→entry
     resolution before calling here.
+
+    *catalog* (nexus-hjd6 / RDR-108 Phase 4 review D-H3): the
+    chunk:char branch uses the catalog ``document_chunks`` manifest
+    to map a position-indexed chunk (``3:100-250``) to its content
+    hash. RDR-108 Phase 3 removed ``chunk_index`` and ``doc_id``
+    from chunk metadata so the legacy ``where`` filter has nothing
+    to match against; without the catalog the chunk:char branch
+    silently returns ``None`` for every Phase-3 chunk. The
+    ``Catalog.resolve_span_text`` entry point passes ``self``;
+    ad-hoc callers without a catalog fall back to the legacy
+    metadata path (correct for pre-Phase-3 chunks only).
     """
     if not span:
         return None
@@ -398,11 +409,41 @@ def resolve_span_text_for_entry(
             from nexus.db import make_t3
             t3 = make_t3()
             col = t3.get_or_create_collection(entry.physical_collection)
-            # nexus-dcym: chunk identity is the catalog ``doc_id``,
-            # not the legacy ``source_path``. ``doc_id`` is stored by
-            # the projector under ``meta.doc_id``; older entries fall
-            # back to ``str(entry.tumbler)`` (Phase 1's stand-in).
             doc_id = entry.meta.get("doc_id") or str(entry.tumbler)
+
+            # nexus-hjd6 (RDR-108 Phase 4 review D-H3): prefer the
+            # catalog manifest because RDR-108 Phase 3 removed
+            # chunk_index / doc_id from T3 chunk metadata. The
+            # manifest stores (doc_id, position, chash) so we can
+            # resolve position chunk_idx -> chash, then look up the
+            # chunk in T3 by its content-addressed natural id
+            # (chash[:32]). The legacy where-filter path stays as a
+            # fallback for environments that have a chunk:char span
+            # but no catalog manifest yet (transition window).
+            if catalog is not None:
+                manifest = catalog.get_manifest(doc_id)
+                # Manifest is ordered by position; index by `chunk_idx`
+                # but defensively look it up by .position to tolerate
+                # any future gap or reorder.
+                row = next(
+                    (r for r in manifest if r.position == chunk_idx),
+                    None,
+                )
+                if row is not None and row.chash:
+                    natural_id = row.chash[:32]
+                    fetched = col.get(
+                        ids=[natural_id],
+                        include=["documents"],
+                    )
+                    docs = fetched.get("documents", [])
+                    if docs:
+                        text = docs[0]
+                        return text[char_start:char_end]
+
+            # Legacy fallback: ``where`` on chunk_index + doc_id.
+            # Returns nothing for post-Phase-3 chunks (the metadata
+            # fields are gone). Kept so pre-Phase-3 corpora and
+            # ad-hoc callers without a catalog still resolve.
             where_filter: dict = {
                 "chunk_index": chunk_idx,
                 "doc_id": doc_id,

--- a/tests/test_catalog_spans_chunk_char.py
+++ b/tests/test_catalog_spans_chunk_char.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-hjd6 (RDR-108 Phase 4 review D-H3): catalog_spans.resolve_span_text_for_entry's
+chunk:char branch must use the catalog document_chunks manifest, not the
+removed chunk_index/doc_id metadata fields.
+
+Pre-fix the branch read where={chunk_index, doc_id} from T3 chunk
+metadata. RDR-108 Phase 3 removed both fields; the where-filter
+matched nothing for Phase-3 chunks and the function silently returned
+None. Post-fix: the catalog manifest stores (doc_id, position, chash)
+so we resolve position -> chash, then look up the chunk in T3 by its
+content-addressed natural id (chash[:32]).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import chromadb
+import pytest
+from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.tumbler import Tumbler
+from nexus.db.t3 import T3Database
+
+
+@pytest.fixture()
+def t3_db() -> T3Database:
+    """T3Database backed by a fresh EphemeralClient. Mirrors the
+    test_chash_reconcile.py / test_collection_gc.py pattern of
+    clearing collections on entry to defend against the chromadb
+    in-memory backend's session-shared state."""
+    client = chromadb.EphemeralClient()
+    for c in list(client.list_collections()):
+        name = c if isinstance(c, str) else c.name
+        try:
+            client.delete_collection(name)
+        except Exception:
+            pass
+    return T3Database(
+        _client=client,
+        _ef_override=DefaultEmbeddingFunction(),
+    )
+
+
+@pytest.fixture()
+def catalog(tmp_path: Path) -> Catalog:
+    catalog_dir = tmp_path / "catalog"
+    Catalog.init(catalog_dir)
+    return Catalog(catalog_dir, catalog_dir / ".catalog.db")
+
+
+def test_chunk_char_span_resolves_via_manifest(t3_db, catalog) -> None:
+    """nexus-hjd6 contract: a chunk:char span on a Phase-3 chunk
+    (no chunk_index/doc_id in metadata) must resolve to the correct
+    text slice via the manifest. Reverting the manifest lookup makes
+    this test fail (legacy where-filter returns nothing).
+    """
+    import hashlib as _hl
+
+    # Seed: one Document with two chunks. Phase-3 metadata: only
+    # chunk_text_hash (no chunk_index, no doc_id). The chunks are
+    # written with chash[:32] as the chroma natural id (RDR-108 D1).
+    coll_name = "docs__hjd6-test__voyage-context-3__v1"
+    chunk_a_text = "alpha alpha alpha alpha alpha alpha"
+    chunk_b_text = "beta beta beta beta beta beta beta beta"
+    chash_a = _hl.sha256(chunk_a_text.encode()).hexdigest()
+    chash_b = _hl.sha256(chunk_b_text.encode()).hexdigest()
+
+    col = t3_db._client.get_or_create_collection(coll_name)
+    col.upsert(
+        ids=[chash_a[:32], chash_b[:32]],
+        documents=[chunk_a_text, chunk_b_text],
+        metadatas=[
+            {"chunk_text_hash": chash_a},
+            {"chunk_text_hash": chash_b},
+        ],
+    )
+
+    # Register a Document and write its manifest. Position 0 -> chash_a;
+    # position 1 -> chash_b. (Plain register_owner + register would
+    # work but we want a deterministic tumbler for the test.)
+    owner = catalog.register_owner("test-corpus", "corpus")
+    tumbler = catalog.register(
+        owner,
+        title="hjd6.md",
+        content_type="paper",
+        file_path="hjd6.md",
+        physical_collection=coll_name,
+        chunk_count=2,
+    )
+    catalog.write_manifest(
+        str(tumbler),
+        [
+            {"chash": chash_a, "position": 0, "line_start": 1, "line_end": 1,
+             "char_start": 0, "char_end": len(chunk_a_text)},
+            {"chash": chash_b, "position": 1, "line_start": 2, "line_end": 2,
+             "char_start": 0, "char_end": len(chunk_b_text)},
+        ],
+    )
+
+    # Patch make_t3 to return our test instance (the chunk:char branch
+    # constructs T3 internally to read chroma).
+    from unittest.mock import patch
+
+    with patch("nexus.db.make_t3", return_value=t3_db):
+        # chunk 0, chars 0-5 -> "alpha"
+        text = catalog.resolve_span_text(tumbler, "0:0-5")
+        assert text == "alpha", (
+            f"chunk:char resolution must return slice; got {text!r}. "
+            "Manifest lookup or chash[:32] T3 read regressed."
+        )
+
+        # chunk 1, chars 0-4 -> "beta"
+        text2 = catalog.resolve_span_text(tumbler, "1:0-4")
+        assert text2 == "beta", (
+            f"second chunk:char resolution failed; got {text2!r}"
+        )
+
+        # chunk 1, full span (manifest reports char_end > 4) -> full text
+        text3 = catalog.resolve_span_text(tumbler, "1:0-9999")
+        assert text3 == chunk_b_text
+
+
+def test_chunk_char_span_returns_none_when_position_out_of_range(
+    t3_db, catalog,
+) -> None:
+    """A chunk:char span pointing at a position the manifest
+    doesn't have must return None (not crash, not return wrong text).
+    Defensive guard against operator-supplied span typos.
+    """
+    import hashlib as _hl
+    from unittest.mock import patch
+
+    coll_name = "docs__hjd6-oob__voyage-context-3__v1"
+    chunk_text = "the only chunk"
+    chash = _hl.sha256(chunk_text.encode()).hexdigest()
+    col = t3_db._client.get_or_create_collection(coll_name)
+    col.upsert(
+        ids=[chash[:32]], documents=[chunk_text],
+        metadatas=[{"chunk_text_hash": chash}],
+    )
+
+    owner = catalog.register_owner("oob-corpus", "corpus")
+    tumbler = catalog.register(
+        owner, title="oob.md", content_type="paper", file_path="oob.md",
+        physical_collection=coll_name, chunk_count=1,
+    )
+    catalog.write_manifest(
+        str(tumbler),
+        [{"chash": chash, "position": 0, "char_start": 0,
+          "char_end": len(chunk_text)}],
+    )
+
+    with patch("nexus.db.make_t3", return_value=t3_db):
+        # Position 99 doesn't exist in the manifest.
+        result = catalog.resolve_span_text(tumbler, "99:0-5")
+        assert result is None, (
+            f"out-of-range position must return None; got {result!r}"
+        )


### PR DESCRIPTION
## Summary

P1 silent-feature-regression class fix surfaced by the nexus-izay review pass (deep-analyst finding D-H3).

\`catalog_spans.resolve_span_text_for_entry\`'s chunk:char branch built a \`where={chunk_index, doc_id}\` chroma filter against fields RDR-108 Phase 3 (nexus-bdag) removed. For every Phase-3 chunk the filter matched nothing; the function silently returned None.

Symptom: \`chash:<hex>:<start>-<end>\` link spans no longer resolved their underlying quote text on Phase-3 chunks.

## Fix

Thread the catalog through so the chunk:char branch can use the \`document_chunks\` manifest:

1. \`catalog.get_manifest(doc_id)\` returns ordered \`(position, chash)\` rows.
2. Find the row whose \`.position == chunk_idx\`.
3. Look up \`chash[:32]\` in T3 directly (RDR-108 D1 natural id).
4. Apply \`char_start:char_end\` to the document text.

Legacy where-filter path retained as a fallback for catalog-absent callers (correct only for pre-Phase-3 chunks; explicit fallback rather than silent failure).

## Tests

- \`test_chunk_char_span_resolves_via_manifest\`: end-to-end with real EphemeralClient + Catalog; seeds two Phase-3 chunks (only \`chunk_text_hash\` in metadata) and a manifest; asserts \`"0:0-5"\` and \`"1:0-4"\` resolve to the right slices.
- \`test_chunk_char_span_returns_none_when_position_out_of_range\`: defensive guard for span typos.

## Test plan

- [x] \`uv run pytest tests/test_catalog_e2e.py tests/test_catalog_spans_chunk_char.py\` (31 passed)
- [x] Em-dash audit clean
- [x] Branch off develop (no stack dependencies)

## Closes

- nexus-hjd6