### PR TITLE
fix(collection_audit): use get_collection to avoid zombie creation (nexus-8lbe P2)

### DIFF
--- a/src/nexus/collection_audit.py
+++ b/src/nexus/collection_audit.py
@@ -391,7 +391,14 @@ def compute_chash_coverage(collection: str) -> ChashCoverage | None:
 
         try:
             t3 = make_t3()
-            col = t3.get_or_create_collection(collection)
+            # nexus-8lbe (RDR-108 Phase 4 review CR-M3): use
+            # get_collection (not get_or_create_collection) so a
+            # missing T3 collection is reported as "unknown total"
+            # rather than minted as an empty zombie. The ks40 fix
+            # closed three indexer paths but missed this audit
+            # entry point — without this guard the audit ITSELF
+            # creates the zombies it then reports.
+            col = t3.get_collection(collection)
             total_chunks = col.count()
         except Exception:
             return ChashCoverage(

--- a/tests/test_collection_audit.py
+++ b/tests/test_collection_audit.py
@@ -422,6 +422,10 @@ class TestChashCoverageSection:
             def count(self): return 3
         class _FakeT3:
             def get_or_create_collection(self, _n): return _FakeCol()
+            # nexus-8lbe: compute_chash_coverage now uses get_collection
+            def get_collection(self, _n): return _FakeCol()
+            # nexus-8lbe: compute_chash_coverage now uses get_collection
+            def get_collection(self, _n): return _FakeCol()
 
         monkeypatch.setattr(
             "nexus.commands._helpers.default_db_path", lambda: db_path,
@@ -463,6 +467,10 @@ class TestChashCoverageSection:
                 }
         class _FakeT3:
             def get_or_create_collection(self, _n): return _FakeCol()
+            # nexus-8lbe: compute_chash_coverage now uses get_collection
+            def get_collection(self, _n): return _FakeCol()
+            # nexus-8lbe: compute_chash_coverage now uses get_collection
+            def get_collection(self, _n): return _FakeCol()
 
         monkeypatch.setattr(
             "nexus.commands._helpers.default_db_path", lambda: db_path,
@@ -492,6 +500,10 @@ class TestChashCoverageSection:
             def count(self): return 0
         class _FakeT3:
             def get_or_create_collection(self, _n): return _FakeCol()
+            # nexus-8lbe: compute_chash_coverage now uses get_collection
+            def get_collection(self, _n): return _FakeCol()
+            # nexus-8lbe: compute_chash_coverage now uses get_collection
+            def get_collection(self, _n): return _FakeCol()
 
         monkeypatch.setattr(
             "nexus.commands._helpers.default_db_path", lambda: db_path,
@@ -516,6 +528,56 @@ class TestChashCoverageSection:
         )
         cov = compute_chash_coverage("code__x")
         assert cov is None
+
+    def test_missing_t3_collection_does_not_create_zombie(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """nexus-8lbe (RDR-108 Phase 4 review CR-M3): the audit must
+        NOT speculatively create a T3 collection while computing
+        chash coverage. Pre-fix it called
+        ``get_or_create_collection`` and minted an empty zombie any
+        time the audit ran on a collection name that didn't yet
+        exist in T3 — the same leak ks40 fixed in three indexer
+        paths but missed in collection_audit.
+
+        Post-fix: ``get_collection`` raises NotFoundError; the
+        audit catches and returns total_chunks=None.
+        ``get_or_create_collection`` MUST NOT be called.
+        """
+        from chromadb.errors import NotFoundError as _ChromaNotFoundError
+
+        from nexus.collection_audit import compute_chash_coverage
+
+        db_path = tmp_path / "memory.db"
+        self._seed_chash_index(db_path, [])
+
+        get_or_create_calls: list[str] = []
+
+        class _FakeT3:
+            def get_or_create_collection(self, name):
+                get_or_create_calls.append(name)
+                class _C:
+                    def count(self_inner): return 0
+                return _C()
+
+            def get_collection(self, name):
+                raise _ChromaNotFoundError(f"Collection {name} not found")
+
+        monkeypatch.setattr(
+            "nexus.commands._helpers.default_db_path", lambda: db_path,
+        )
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        cov = compute_chash_coverage("code__never_created")
+
+        assert get_or_create_calls == [], (
+            "audit must NOT speculatively create T3 collection; "
+            f"get_or_create_collection was called with {get_or_create_calls!r}"
+        )
+        assert cov is not None
+        assert cov.total_chunks is None
+        assert cov.ratio is None
+        assert cov.missing_sample == []
 
 
 # ── CLI integration ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

P2 zombie-creation leak surfaced by nexus-izay (code-review-expert finding CR-M3).

ks40 fixed three indexer paths to use \`get_collection\` instead of \`get_or_create_collection\` so they don't speculatively mint empty T3 collections. \`collection_audit.compute_chash_coverage\` was the lone remaining leak: every audit of a collection name not yet in T3 created an empty zombie that ks40's \`collection-gc\` verb would then sweep on the next run.

The audit itself was creating the zombies it was supposed to report.

## Fix

Switch line 394 from \`get_or_create_collection\` to \`get_collection\`. The existing \`except Exception\` block already returns \`ChashCoverage(total_chunks=None, ...)\` so the NotFoundError case is handled cleanly.

## Tests

- All 3 existing TestChashCoverageSection tests' FakeT3 stubs updated to define both methods.
- New \`test_missing_t3_collection_does_not_create_zombie\` verifies the prevention contract.

## Test plan

- [x] \`uv run pytest tests/test_collection_audit.py\` (20 passed)
- [x] Em-dash audit clean
- [x] Branch off develop

## Closes

- nexus-8lbe