### PR TITLE
fix(cli): ThreadPoolExecutor lifecycle + collection-gc clean error handling (nexus-uv06 + nexus-pz24 P2)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -5467,11 +5467,19 @@ def collection_gc_cmd(apply: bool) -> None:
         click.echo(f"Failed to list T3 collections: {exc}", err=True)
         raise SystemExit(1)
 
-    projection_names = {r["name"] for r in cat.list_collections()}
-    doc_collection_rows = cat._db.execute(
-        "SELECT DISTINCT physical_collection FROM documents "
-        "WHERE physical_collection != ''"
-    ).fetchall()
+    # nexus-pz24 (RDR-108 Phase 4 review CR-M2): mirror the T3 path's
+    # error-handling shape so a SQLite failure (locked DB, schema
+    # mismatch, FS issue) surfaces a clean operator message rather
+    # than a raw Python traceback.
+    try:
+        projection_names = {r["name"] for r in cat.list_collections()}
+        doc_collection_rows = cat._db.execute(
+            "SELECT DISTINCT physical_collection FROM documents "
+            "WHERE physical_collection != ''"
+        ).fetchall()
+    except Exception as exc:
+        click.echo(f"Failed to query catalog: {exc}", err=True)
+        raise SystemExit(1)
     doc_collection_names = {r[0] for r in doc_collection_rows if r[0]}
 
     candidates: list[tuple[str, int]] = []

--- a/src/nexus/commands/t3.py
+++ b/src/nexus/commands/t3.py
@@ -919,52 +919,57 @@ def reidentify_cmd(
     skipped_taxonomy = 0
     errors: list[str] = []
 
+    def _render(results_iter):
+        nonlocal total_examined, total_migrated, total_already, total_deleted
+        nonlocal skipped_taxonomy
+        for _idx, coll_name, result, error in results_iter:
+            if error is not None:
+                click.echo(f"ERROR: {error}", err=True)
+                errors.append(error)
+                continue
+
+            if result.skipped_taxonomy:
+                click.echo(f"  {coll_name}: skipped (taxonomy carve-out)")
+                skipped_taxonomy += 1
+                continue
+
+            verb = "would migrate" if dry_run else "migrated"
+            delete_part = (
+                f", {result.chunks_deleted} old id(s) deleted"
+                if not dry_run and result.chunks_deleted
+                else ""
+            )
+            click.echo(
+                f"  {coll_name}: examined {result.chunks_examined} chunk(s), "
+                f"{verb} {result.chunks_migrated}, "
+                f"{result.chunks_already_migrated} already migrated"
+                + delete_part
+            )
+
+            total_examined += result.chunks_examined
+            total_migrated += result.chunks_migrated
+            total_already += result.chunks_already_migrated
+            total_deleted += result.chunks_deleted
+
     if workers == 1:
         # Deterministic serial path: dispatch + render in input order.
-        results_iter = (
+        _render(
             _process_one(i, n)
             for i, n in enumerate(collections_to_process, start=1)
         )
     else:
-        # Parallel dispatch; collect as completed (out-of-order render).
-        executor = ThreadPoolExecutor(max_workers=workers)
-        try:
+        # Parallel dispatch; collect + render INSIDE the executor's
+        # ``with`` block so __exit__ blocks until in-flight workers
+        # finish (nexus-uv06: prior code called executor.shutdown(
+        # wait=False) from a finally that fired BEFORE the lazy
+        # results_iter generator was consumed, leaking worker threads
+        # if the consumer raised or returned early).
+        with ThreadPoolExecutor(max_workers=workers) as executor:
             futures = [
                 executor.submit(_process_one, i, n)
                 for i, n in enumerate(collections_to_process, start=1)
             ]
-            results_iter = (f.result() for f in as_completed(futures))
-        finally:
-            executor.shutdown(wait=False)
-
-    for _idx, coll_name, result, error in results_iter:
-        if error is not None:
-            click.echo(f"ERROR: {error}", err=True)
-            errors.append(error)
-            continue
-
-        if result.skipped_taxonomy:
-            click.echo(f"  {coll_name}: skipped (taxonomy carve-out)")
-            skipped_taxonomy += 1
-            continue
-
-        verb = "would migrate" if dry_run else "migrated"
-        delete_part = (
-            f", {result.chunks_deleted} old id(s) deleted"
-            if not dry_run and result.chunks_deleted
-            else ""
-        )
-        click.echo(
-            f"  {coll_name}: examined {result.chunks_examined} chunk(s), "
-            f"{verb} {result.chunks_migrated}, "
-            f"{result.chunks_already_migrated} already migrated"
-            + delete_part
-        )
-
-        total_examined += result.chunks_examined
-        total_migrated += result.chunks_migrated
-        total_already += result.chunks_already_migrated
-        total_deleted += result.chunks_deleted
+            _render(f.result() for f in as_completed(futures))
 
     verb = "would migrate" if dry_run else "migrated"
     click.echo(

--- a/tests/test_collection_gc.py
+++ b/tests/test_collection_gc.py
@@ -247,3 +247,38 @@ class TestCollectionGCCli:
         names = {c["name"] for c in t3_db.list_collections()}
         assert "taxonomy__centroids" in names
         assert "rdr__zombie" not in names
+
+    def test_catalog_sqlite_error_exits_clean_not_traceback(
+        self, monkeypatch, runner, t3_db, catalog_env,
+    ) -> None:
+        """nexus-pz24 (RDR-108 Phase 4 review CR-M2): a SQLite error
+        on the catalog query (locked DB, schema mismatch, FS issue)
+        must surface a clean operator message, not a raw Python
+        traceback. The T3 query path already had this guard;
+        the catalog query path was the lone exception.
+        """
+        import sqlite3
+        from unittest.mock import MagicMock
+
+        # Stub _get_catalog to return a catalog whose _db.execute
+        # raises on the documents.physical_collection query.
+        fake_cat = MagicMock()
+        fake_cat.list_collections.return_value = []
+        fake_cat._db.execute.side_effect = sqlite3.OperationalError(
+            "database is locked"
+        )
+
+        monkeypatch.setattr(
+            "nexus.commands.catalog._get_catalog", lambda: fake_cat,
+        )
+        monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
+
+        result = runner.invoke(main, ["catalog", "collection-gc"])
+
+        assert result.exit_code != 0, (
+            "should exit nonzero on catalog failure"
+        )
+        assert "Failed to query catalog" in result.output, (
+            f"expected clean operator message, got: {result.output!r}"
+        )
+        assert "Traceback" not in result.output


### PR DESCRIPTION
## Summary

Two P2 CLI hardening fixes from nexus-izay code-review (findings CR-M1 + CR-M2). Bundled because both are CLI safety polish in the same source area.

### CR-M1 (nexus-uv06): ThreadPoolExecutor lifecycle

\`commands/t3.py:reidentify_command_parallel\` constructed an executor with \`try/finally: shutdown(wait=False)\`. The shutdown fired BEFORE the lazy \`results_iter\` generator was consumed (created inside try, consumed after finally). With \`wait=False\` and no \`cancel_futures\`, workers kept running; if the consumer raised early they leaked.

Fix: consume the generator INSIDE the executor's \`with\` block via a shared \`_render\` helper.

### CR-M2 (nexus-pz24): collection-gc clean error handling

\`commands/catalog.collection_gc_cmd\` queried \`cat._db.execute(...)\` without a try/except. Any SQLite error (locked DB, schema mismatch, FS issue) surfaced as a raw Python traceback. The T3 query path in the same function had proper error handling; the catalog path was the lone exception.

Fix: mirror the T3 path's \`except Exception -> click.echo + SystemExit(1)\` shape.

## Tests

- All 28 \`test_t3_reidentify.py\` CLI tests pass unchanged (executor refactor is behaviour-preserving).
- New \`test_catalog_sqlite_error_exits_clean_not_traceback\`: stubs \`_get_catalog\` with a fake whose \`_db.execute\` raises \`sqlite3.OperationalError\`; verifies clean exit + \`"Failed to query catalog"\` message + no traceback.

## Test plan

- [x] \`uv run pytest tests/test_collection_gc.py tests/test_t3_reidentify.py\` (35 passed)
- [x] Em-dash audit clean
- [x] Branch off develop

## Closes

- nexus-uv06
- nexus-pz24