### PR TITLE
fix(catalog): docs_for_chashes accepts both 32-char and 64-char chashes (nexus-f8c3 P2)

### DIFF
--- a/src/nexus/catalog/catalog_writes.py
+++ b/src/nexus/catalog/catalog_writes.py
@@ -899,6 +899,20 @@ class _WriteOps:
         whose manifest contains that chash. Chashes with no manifest
         entries are omitted from the result.
 
+        Accepts EITHER full 64-char ``chunk_text_hash`` (legacy callers,
+        e.g. ``mcp/core.py:868``) OR 32-char ``chash[:32]``
+        (RDR-108 D1 natural-id form, used by post-Phase-4 helpers
+        such as ``search_engine._attach_doc_ids_from_catalog``). The
+        SQL match normalizes to 32-char via ``substr(chash,1,32)``,
+        matching ``chashes_for_collection``'s contract (nexus-f8c3
+        review S2: closes the latent normalization-contract
+        divergence between the two manifest read APIs).
+
+        Returned keys preserve the INPUT form so callers don't have
+        to re-normalize: a caller that passed full 64-char chashes
+        gets full-chash keys back; a caller that passed 32-char
+        gets 32-char keys back. Mixed input is supported.
+
         Used by Phase 4 retrieval doc-grouping (mcp/core.py:847 path)
         to reconstruct the document context for a set of chunk hashes
         returned by a T3 query.
@@ -911,20 +925,37 @@ class _WriteOps:
         if not chashes:
             return {}
         cat = self._cat
-        result: dict[str, list[str]] = defaultdict(list)
+        # Map chash[:32] -> the input form(s) that asked for it. A
+        # single 32-char prefix may correspond to multiple 64-char
+        # input variants (when the caller mixes representations);
+        # all such input forms get the same doc list back.
+        prefix_to_inputs: dict[str, list[str]] = defaultdict(list)
+        for c in chashes:
+            if c:
+                prefix_to_inputs[c[:32]].append(c)
+        if not prefix_to_inputs:
+            return {}
+        prefix_to_docs: dict[str, list[str]] = defaultdict(list)
+        unique_prefixes = list(prefix_to_inputs.keys())
         _BATCH = 500
-        for i in range(0, len(chashes), _BATCH):
-            batch = chashes[i : i + _BATCH]
+        for i in range(0, len(unique_prefixes), _BATCH):
+            batch = unique_prefixes[i : i + _BATCH]
             placeholders = ", ".join(["?"] * len(batch))
             rows = cat._db.execute(
-                f"SELECT chash, doc_id FROM document_chunks "
-                f"WHERE chash IN ({placeholders})",
+                f"SELECT substr(chash, 1, 32), doc_id FROM document_chunks "
+                f"WHERE substr(chash, 1, 32) IN ({placeholders})",
                 batch,
             ).fetchall()
-            for chash, doc_id in rows:
-                if doc_id not in result[chash]:
-                    result[chash].append(doc_id)
-        return dict(result)
+            for prefix, doc_id in rows:
+                if doc_id not in prefix_to_docs[prefix]:
+                    prefix_to_docs[prefix].append(doc_id)
+        # Build the response keyed on the caller's input form so
+        # callers don't have to re-normalize their lookup keys.
+        result: dict[str, list[str]] = {}
+        for prefix, doc_ids in prefix_to_docs.items():
+            for input_form in prefix_to_inputs[prefix]:
+                result[input_form] = list(doc_ids)
+        return result
 
     def delete_document(self, tumbler: Tumbler) -> bool:
         """Soft-delete a document: tombstone in JSONL, DELETE from SQLite.

--- a/tests/test_catalog_manifest_read_api.py
+++ b/tests/test_catalog_manifest_read_api.py
@@ -265,6 +265,67 @@ class TestDocsForChashes:
         assert result["a" * 64] == ["1.1.1"]
         assert result["b" * 64] == ["1.1.1"]
 
+    def test_docs_for_chashes_accepts_32_char_chash_form(self, tmp_path):
+        """nexus-f8c3 (RDR-108 Phase 4 review S2): a caller passing
+        32-char chash[:32] (the RDR-108 D1 natural-id form) must
+        get the same lookup result as a caller passing the full
+        64-char form. Pre-fix the WHERE clause was a literal string
+        match, so 32-char input silently returned an empty result.
+        """
+        cat = _make_catalog(tmp_path)
+        _insert_doc(cat, "1.1.1", "code__test")
+        full_chash = "a" * 64
+        cat.write_manifest("1.1.1", [_make_chunk(full_chash, 0)])
+
+        # 32-char form (RDR-108 D1 natural id).
+        result = cat.docs_for_chashes([full_chash[:32]])
+        assert result[full_chash[:32]] == ["1.1.1"], (
+            "32-char chash[:32] form must resolve to the same doc_id "
+            "as the 64-char form (S2 normalization-contract fix)."
+        )
+
+    def test_docs_for_chashes_preserves_input_form_in_keys(self, tmp_path):
+        """Backward-compat: callers that pass full 64-char chashes
+        must get full 64-char keys back (not chash[:32] keys).
+        Otherwise the lookup pattern ``result[r.metadata['chunk_text_hash']]``
+        in mcp/core.py:868 silently returns nothing. The fix
+        normalizes for SQL but rebuilds the response keyed on the
+        caller's input form.
+        """
+        cat = _make_catalog(tmp_path)
+        _insert_doc(cat, "1.1.1", "code__test")
+        full_chash = "b" * 64
+        cat.write_manifest("1.1.1", [_make_chunk(full_chash, 0)])
+
+        result = cat.docs_for_chashes([full_chash])
+        # Key is the input form (64-char), not the truncated form.
+        assert full_chash in result
+        assert full_chash[:32] not in result, (
+            "result keys must mirror input form, not internal "
+            "normalization (preserves backward compat with mcp/core.py)"
+        )
+        assert result[full_chash] == ["1.1.1"]
+
+    def test_docs_for_chashes_mixed_input_forms(self, tmp_path):
+        """A caller may mix 64-char and 32-char inputs in one call
+        (e.g. legacy + new chunks in one search response). Each
+        input form must resolve correctly in the response.
+        """
+        cat = _make_catalog(tmp_path)
+        _insert_doc(cat, "1.1.1", "code__test")
+        _insert_doc(cat, "1.1.2", "code__test")
+        legacy_chash = "c" * 64
+        new_chash = "d" * 64
+        cat.write_manifest("1.1.1", [_make_chunk(legacy_chash, 0)])
+        cat.write_manifest("1.1.2", [_make_chunk(new_chash, 0)])
+
+        result = cat.docs_for_chashes([
+            legacy_chash,             # 64-char
+            new_chash[:32],           # 32-char
+        ])
+        assert result[legacy_chash] == ["1.1.1"]
+        assert result[new_chash[:32]] == ["1.1.2"]
+
 
 # ── RDR-108 Phase 4b / nexus-kosc: get_chunk_chashes ─────────────────────────
 


### PR DESCRIPTION
## Summary

P2 latent normalization-contract divergence between the two manifest read APIs:

- \`chashes_for_collection\` normalized via \`substr(chash, 1, 32)\` and returned chash[:32].
- \`docs_for_chashes\` did literal \`WHERE chash IN (?)\` and returned full-chash keys.

The manifest write hook stores full 64-char \`chunk_text_hash\`. Current callers pass full 64-char and the round-trip worked. But D1 says the natural ID is \`chash[:32]\`; any future caller following D1 conventions silently got an empty result.

## Fix

Normalize for SQL via \`substr\` (matches the sibling API); preserve the caller's input form in the response keys so existing 64-char callers don't break. Mixed-form input is supported.

## Tests

- All 6 existing TestDocsForChashes tests pass unchanged (backward compat verified).
- 3 new tests: \`accepts_32_char_chash_form\`, \`preserves_input_form_in_keys\`, \`mixed_input_forms\`.

## Test plan

- [x] \`uv run pytest tests/test_catalog_manifest_read_api.py tests/test_search_engine.py tests/test_catalog_e2e.py tests/test_mcp_server.py\` (193 passed)
- [x] Em-dash audit clean
- [x] Branch off develop

## Closes

- nexus-f8c3