### PR TITLE
fix(search): --max-file-chunks via post-query manifest filter, not removed metadata (nexus-oo4f D-M2 P2)

### DIFF
--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -259,12 +259,14 @@ def search_cmd(
     except click.BadParameter as exc:
         raise click.ClickException(str(exc)) from exc
 
-    if max_file_chunks is not None:
-        size_filter: dict = {"chunk_count": {"$lte": max_file_chunks}}
-        if where_filter is None:
-            where_filter = size_filter
-        else:
-            where_filter = {"$and": [size_filter, where_filter]}
+    # nexus-oo4f (RDR-108 Phase 4 review D-M2): pre-Phase-3 chunks
+    # carried ``chunk_count`` in metadata so a chroma ``where``
+    # filter at query time worked. RDR-108 Phase 3 (nexus-bdag)
+    # removed that field; the chroma filter then matched zero
+    # Phase-3 chunks and ``--max-file-chunks`` silently returned no
+    # results. The filter is now applied as a post-query pass
+    # against the catalog manifest length (D2 authoritative source);
+    # the query no longer carries ``chunk_count`` to chroma.
 
     db = _t3()
     all_collections = [c["name"] for c in db.list_collections()]
@@ -342,6 +344,50 @@ def search_cmd(
             if (r.metadata.get("_display_path") or "").startswith(resolved)
             or r.metadata.get("file_path", "").startswith(resolved)
             or r.metadata.get("source_path", "").startswith(resolved)
+        ]
+        if not results:
+            click.echo("No results.")
+            return
+
+    # nexus-oo4f post-query filter: --max-file-chunks against the
+    # catalog manifest length. Phase-3 chunks no longer carry
+    # chunk_count metadata, so the chroma where-filter (above) has
+    # been removed. We resolve each result's doc_id (already
+    # populated by search_engine._attach_doc_ids_from_catalog from
+    # nexus-rehf), then look up the doc's manifest length once.
+    # Chunks whose doc has more than N manifest rows are dropped.
+    # Pre-Phase-3 chunks that still carry chunk_count fall back to
+    # the metadata read so the legacy contract still works.
+    if max_file_chunks is not None:
+        from nexus.catalog import Catalog
+        from nexus.config import catalog_path
+        _cp = catalog_path()
+        _cat = (
+            Catalog(_cp, _cp / ".catalog.db")
+            if Catalog.is_initialized(_cp)
+            else None
+        )
+        chunk_count_cache: dict[str, int] = {}
+
+        def _doc_chunk_count(r: SearchResult) -> int | None:
+            doc_id = r.metadata.get("doc_id", "")
+            if doc_id and _cat is not None:
+                if doc_id not in chunk_count_cache:
+                    try:
+                        chunk_count_cache[doc_id] = len(_cat.get_manifest(doc_id))
+                    except Exception:
+                        chunk_count_cache[doc_id] = 0
+                if chunk_count_cache[doc_id] > 0:
+                    return chunk_count_cache[doc_id]
+            # Legacy fallback: pre-Phase-3 chunks still have it.
+            legacy = r.metadata.get("chunk_count")
+            if isinstance(legacy, int) and legacy > 0:
+                return legacy
+            return None  # unknown; keep the chunk
+
+        results = [
+            r for r in results
+            if (cnt := _doc_chunk_count(r)) is None or cnt <= max_file_chunks
         ]
         if not results:
             click.echo("No results.")

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -425,22 +425,45 @@ def test_parse_where_empty_value_with_operator_raises() -> None:
 # ── --max-file-chunks ───────────────────────────────────────────────────────
 
 
-def test_max_file_chunks_builds_chunk_count_filter(runner: CliRunner, code_search_ctx) -> None:
+def test_max_file_chunks_does_not_route_through_chroma_where(
+    runner: CliRunner, code_search_ctx,
+) -> None:
+    """nexus-oo4f (RDR-108 Phase 4 review D-M2): --max-file-chunks
+    used to build a chroma where={"chunk_count": {"$lte": N}} filter.
+    RDR-108 Phase 3 removed chunk_count from chunk metadata; the
+    chroma where matched zero Phase-3 chunks and --max-file-chunks
+    silently returned no results.
+
+    Post-fix: --max-file-chunks is a post-query filter (against the
+    catalog manifest length), so the chroma where must NOT carry
+    chunk_count. Reverting the fix routes chunk_count through chroma
+    again and makes Phase-3 chunks invisible.
+    """
     _, captured = code_search_ctx
     runner.invoke(main, ["search", "query", "--corpus", "code", "--max-file-chunks", "17"])
-    assert captured[0] == {"chunk_count": {"$lte": 17}}
+    # No where filter at all when --max-file-chunks is the only filter.
+    assert captured[0] is None, (
+        f"chunk_count must NOT be routed through chroma where; got {captured[0]!r}"
+    )
 
 
-def test_max_file_chunks_and_where_merged_with_and(runner: CliRunner, code_search_ctx) -> None:
+def test_max_file_chunks_does_not_pollute_where_when_combined(
+    runner: CliRunner, code_search_ctx,
+) -> None:
+    """When combined with --where, only the --where pairs reach
+    chroma; the size filter is a post-query pass.
+    """
     _, captured = code_search_ctx
     runner.invoke(main, [
         "search", "query", "--corpus", "code",
         "--max-file-chunks", "17", "--where", "lang=python",
     ])
     w = captured[0]
-    assert "$and" in w
-    assert {"chunk_count": {"$lte": 17}} in w["$and"]
-    assert {"lang": "python"} in w["$and"]
+    # Only --where pairs route through chroma now.
+    assert w == {"lang": "python"}, (
+        f"where filter must contain only --where pairs, not chunk_count; "
+        f"got {w!r}"
+    )
 
 
 # ── corpus warning ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

P2 silent-feature regression from the nexus-izay review (D-M2 of the 4-bug nexus-oo4f bundle).

\`nx search --max-file-chunks\` built a chroma \`where={"chunk_count": {"$lte": N}}\` filter at query time. RDR-108 Phase 3 removed \`chunk_count\` from chunk metadata; the chroma where matched zero Phase-3 chunks. \`--max-file-chunks\` silently returned no results.

## Fix

- Drop the chroma where; chunk_count no longer routes through the query.
- After search returns, post-filter against the catalog manifest: resolve doc_id (already populated by \`search_engine._attach_doc_ids_from_catalog\` from #639) → get manifest length → drop chunks whose doc has more than N rows.
- Pre-Phase-3 chunks that still carry chunk_count fall back to the metadata read.

## Scope

This PR ships ONLY the D-M2 fix. The other 3 D-M items had diverging fix shapes and were split into separate P3 beads:
- nexus-vn48 (D-M1): collection.reindex_cmd sourceless misclassification.
- nexus-esrl (D-M3): catalog doctor --t3-doc-id-coverage.
- nexus-0ocy (D-M4): indexer_utils.build_staleness_cache by_doc_id perf.

All 3 linked under the nexus-veb5 umbrella for follow-up.

## Tests

2 existing tests updated to lock the new contract.

## Test plan

- [x] \`uv run pytest tests/test_search_cmd.py\` (60 passed)
- [x] Em-dash audit clean
- [x] Branch off develop

## Closes

- nexus-oo4f