### PR TITLE
fix(doctor): t3-doc-id-coverage falls back to manifest for Phase-3 chunks (nexus-esrl P3)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -4909,6 +4909,15 @@ def _run_t3_doc_id_coverage(
             f"Failed to open T3 client: {exc}. Check ChromaDB credentials."
         )
 
+    # nexus-esrl (RDR-108 Phase 4 review D-M3): the audit reads
+    # ``meta.get("doc_id", "")`` from chunk metadata to compare
+    # against the event-log expected value. RDR-108 Phase 3
+    # (nexus-bdag) removed doc_id from chunk metadata; the read
+    # returns "" for every Phase-3 chunk. Without manifest
+    # resolution the audit unconditionally reports near-100%
+    # ``missing_doc_id``, masking real coverage problems.
+    cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+
     per_coll: dict[str, dict] = {}
     overall_pass = True
     coll_count = len(expected)
@@ -4956,11 +4965,34 @@ def _run_t3_doc_id_coverage(
             metas = page.get("metadatas") or []
             if not ids:
                 break
+            # nexus-esrl: resolve actual doc_id via the catalog
+            # manifest for this page's chashes when chunk metadata
+            # lacks doc_id (Phase-3 chunks). One batched lookup per
+            # page; the per-chunk resolution below tries metadata
+            # first, falls through to the manifest map.
+            page_chashes = [
+                (m or {}).get("chunk_text_hash", "") for m in metas
+            ]
+            page_chashes_nonempty = [c for c in page_chashes if c]
+            chash_to_doc_for_page: dict[str, str] = {}
+            if page_chashes_nonempty:
+                try:
+                    by_chash = cat.docs_for_chashes(page_chashes_nonempty)
+                except Exception:
+                    by_chash = {}
+                for c, doc_ids in by_chash.items():
+                    if doc_ids:
+                        chash_to_doc_for_page[c] = sorted(doc_ids)[0]
             for cid, meta in zip(ids, metas):
                 meta = meta or {}
                 total += 1
                 seen.add(cid)
                 actual = meta.get("doc_id", "") or ""
+                # Manifest fallback when metadata lacks doc_id.
+                if not actual:
+                    chash = meta.get("chunk_text_hash", "")
+                    if chash:
+                        actual = chash_to_doc_for_page.get(chash, "")
                 expected_doc_id = expected_chunks.get(cid, "")
                 is_orphan = cid in expected_orphans.get(coll_name, set())
                 if actual:

--- a/tests/test_catalog_doctor_t3_coverage.py
+++ b/tests/test_catalog_doctor_t3_coverage.py
@@ -443,3 +443,75 @@ class TestOrphanRatioSurface:
         assert "WARN" not in runner.invoke(
             doctor_cmd, ["--t3-doc-id-coverage"],
         ).output
+
+
+# ── nexus-esrl (RDR-108 Phase 4 review D-M3): manifest-fallback ─────────────
+
+
+class TestPhase3ManifestFallback:
+    """nexus-esrl: under RDR-108 Phase 3 (nexus-bdag) chunk metadata
+    no longer carries doc_id. The audit must fall back to the
+    catalog ``document_chunks`` manifest (resolve via
+    ``Catalog.docs_for_chashes(chash)``) so Phase-3 chunks register
+    as covered when the manifest knows their doc_id. Pre-fix, every
+    Phase-3 chunk reported as missing_doc_id and the audit failed
+    unconditionally on any post-Phase-3 corpus.
+    """
+
+    def test_phase3_chunks_resolve_via_manifest(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A Phase-3 chunk (no doc_id in metadata, only chunk_text_hash)
+        must register as covered when the catalog manifest has the
+        chash -> doc_id mapping. Reverting the manifest-fallback
+        path makes this test fail with missing_doc_id_count >= 1.
+        """
+        events = [_chunk("ch1", "uuid7-PHASE3", "code__phase3")]
+        _seed_log(isolated_nexus, events)
+
+        # Phase-3 chunk: only chunk_text_hash in metadata, no doc_id.
+        chash = "a" * 64
+        _seed(chroma_client, "code__phase3", [
+            {"id": "ch1", "content": "x",
+             "metadata": {"chunk_text_hash": chash}},
+        ])
+
+        # Seed the catalog manifest so chash -> doc_id resolves.
+        cat = Catalog(isolated_nexus, isolated_nexus / ".catalog.db")
+        cat._db.execute(  # epsilon-allow: test fixture seeds documents row
+            "INSERT OR IGNORE INTO documents "
+            "(tumbler, title, author, year, content_type, file_path, "
+            "corpus, physical_collection, chunk_count, head_hash, "
+            "indexed_at, metadata, source_mtime, alias_of, source_uri) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("uuid7-PHASE3", "doc", "", 0, "code", "/tmp/x.py",
+             "", "code__phase3", 1, "", "", "{}", 0.0, "", ""),
+        )
+        cat._db.commit()
+        cat.write_manifest("uuid7-PHASE3", [
+            {"chash": chash, "position": 0,
+             "chunk_index": None, "line_start": None, "line_end": None,
+             "char_start": None, "char_end": None},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+
+        result = runner.invoke(
+            doctor_cmd, ["--t3-doc-id-coverage", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        assert payload["pass"] is True, (
+            f"Phase-3 chunk should register as covered via manifest; "
+            f"got {payload!r}"
+        )
+        coll = payload["tables"]["code__phase3"]
+        assert coll["with_doc_id"] == 1
+        assert coll["missing_doc_id_count"] == 0, (
+            "Phase-3 chunk should NOT be reported as missing doc_id "
+            "when catalog manifest has the chash -> doc_id mapping"
+        )


### PR DESCRIPTION
## Summary

P3 silent-audit-fail. \`nx catalog doctor --t3-doc-id-coverage\` read \`meta.get("doc_id", "")\` from chunk metadata. RDR-108 Phase 3 removed doc_id; the audit unconditionally reported near-100% missing_doc_id on Phase-3 corpora.

## Fix

When chunk metadata lacks doc_id, batch-resolve chash → doc_id via \`Catalog.docs_for_chashes()\` per page. One batched lookup per \`col.get()\` page; per-chunk resolution falls through to the manifest map when metadata is empty.

## Tests

- All 13 existing tests pass unchanged.
- New \`test_phase3_chunks_resolve_via_manifest\`: a Phase-3 chunk (only chunk_text_hash in metadata) with manifest mapping registers as covered. Reverting the fallback regresses this test.

## Test plan

- [x] \`uv run pytest tests/test_catalog_doctor_t3_coverage.py\` (14 passed)
- [x] Em-dash audit clean
- [x] Branch off develop

## Closes

- nexus-esrl