### PR TITLE
fix(collection): reindex resolves Phase-3 chunks via catalog manifest (nexus-vn48 P3)

### DIFF
--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -359,16 +359,56 @@ def reindex_cmd(name: str, force: bool) -> None:
     # source_path from chunk metadata, doc_id is the only signal; the
     # catalog row pointed to by doc_id holds the file_path used for
     # the actual reindex.
+    #
+    # nexus-vn48 (RDR-108 Phase 4 review D-M1): RDR-108 Phase 3
+    # (nexus-bdag) removed doc_id from chunk metadata too. For
+    # Phase-3 chunks both source_path and doc_id are gone; the
+    # only remaining signal is ``chunk_text_hash``. Resolve via
+    # the catalog's chash -> doc_id manifest reverse-lookup, then
+    # fall through to the existing _doc_id_to_file_path helper.
     col = db.get_or_create_collection(name)
     sourceless: list[str] = []
     source_paths: set[str] = set()
     offset = 0
+    # Build a one-shot catalog handle for the manifest fallback.
+    _cat = None
+    try:
+        from nexus.catalog import Catalog
+        from nexus.config import catalog_path
+        _cp = catalog_path()
+        if Catalog.is_initialized(_cp):
+            _cat = Catalog(_cp, _cp / ".catalog.db")
+    except Exception:
+        pass
     while True:
         batch = col.get(limit=300, offset=offset, include=["metadatas"])
+        # nexus-vn48: page-batch chash -> doc_id resolution to amortise
+        # SQLite calls across the page rather than per-chunk.
+        page_chashes = [
+            (m or {}).get("chunk_text_hash", "")
+            for m in (batch["metadatas"] or [])
+        ]
+        page_chashes_nonempty = [c for c in page_chashes if c]
+        chash_to_doc: dict[str, str] = {}
+        if _cat is not None and page_chashes_nonempty:
+            try:
+                by_chash = _cat.docs_for_chashes(page_chashes_nonempty)
+            except Exception:
+                by_chash = {}
+            for c, doc_ids in by_chash.items():
+                if doc_ids:
+                    chash_to_doc[c] = sorted(doc_ids)[0]
+
         for mid, meta in zip(batch["ids"], batch["metadatas"] or []):
             meta = meta or {}
             sp = meta.get("source_path", "")
             did = meta.get("doc_id", "")
+            # Phase-3 fallback: resolve via manifest when metadata
+            # lacks doc_id but carries chunk_text_hash.
+            if not did:
+                chash = meta.get("chunk_text_hash", "")
+                if chash:
+                    did = chash_to_doc.get(chash, "")
             if sp:
                 source_paths.add(sp)
             elif did:

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -305,6 +305,62 @@ def test_reindex_treats_doc_id_only_chunk_as_reindexable(
     mock_db.delete_collection.assert_called_once_with("docs__test")
 
 
+def test_reindex_treats_phase3_chunk_with_chash_only_as_reindexable(
+    runner, env_creds, mock_db, tmp_path,
+) -> None:
+    """nexus-vn48 (RDR-108 Phase 4 review D-M1): RDR-108 Phase 3
+    chunks have neither source_path NOR doc_id in metadata, only
+    chunk_text_hash. The safety check must resolve chash -> doc_id
+    via the catalog manifest then use the existing doc_id branch.
+    Pre-fix the chunk landed in ``sourceless`` and triggered the
+    all-sourceless refuse path on every Phase-3 corpus.
+    """
+    doc_file = tmp_path / "doc.md"
+    doc_file.write_text("# Doc\ncontent")
+
+    mock_db.collection_info.return_value = {"count": 1, "metadata": {}}
+    mock_col = MagicMock()
+    chash = "a" * 64
+    # Phase-3 chunk: only chunk_text_hash; no source_path or doc_id.
+    mock_col.get.return_value = {
+        "ids": ["chunk-phase3"],
+        "metadatas": [{"chunk_text_hash": chash}],
+    }
+    mock_db.get_or_create_collection.return_value = mock_col
+    from nexus.db.t3 import VerifyResult
+    mock_db.delete_collection.return_value = None
+    after_col = MagicMock()
+    after_col.count.return_value = 1
+    mock_db.get_or_create_collection.side_effect = [mock_col, after_col]
+    vr = VerifyResult(status="healthy", doc_count=1, probe_doc_id="x", distance=0.05, metric="l2")
+
+    # Stub Catalog.docs_for_chashes to return the manifest mapping.
+    # Catalog is lazy-imported inside reindex_cmd (`from nexus.catalog
+    # import Catalog`); patch the source module's attribute so the
+    # lazy import resolves to our stub.
+    fake_cat = MagicMock()
+    fake_cat.docs_for_chashes.return_value = {chash: ["ART-PHASE3"]}
+
+    import nexus.catalog as _cat_mod
+    with patch(
+        "nexus.commands.collection._doc_id_to_file_path",
+        return_value=str(doc_file),
+    ), \
+         patch("nexus.commands.collection._t3", return_value=mock_db), \
+         patch.object(_cat_mod.Catalog, "is_initialized", return_value=True), \
+         patch.object(_cat_mod, "Catalog", return_value=fake_cat), \
+         patch("nexus.doc_indexer.index_markdown", return_value=1), \
+         patch("nexus.db.t3.verify_collection_deep", return_value=vr):
+        result = runner.invoke(
+            main, ["collection", "reindex", "docs__test", "--force"],
+        )
+    # Must NOT hit the all-sourceless refuse branch.
+    assert "refusing to reindex" not in result.output.lower(), result.output
+    mock_db.delete_collection.assert_called_once_with("docs__test")
+    # Verify the manifest path actually fired.
+    fake_cat.docs_for_chashes.assert_called_once()
+
+
 def test_reindex_treats_doc_id_with_no_catalog_entry_as_sourceless(
     runner, env_creds, mock_db,
 ) -> None:


### PR DESCRIPTION
## Summary

P3 silent-feature regression. RDR-108 Phase 3 removed doc_id from chunk metadata. \`nx collection reindex\`'s sourceless safety check reads source_path + doc_id; for Phase-3 chunks both are absent and the all-sourceless refuse branch fires on every Phase-3 corpus.

## Fix

Same shared-helper pattern as the other manifest-fallback fixes (rehf, hjd6, 7zcv, esrl): batch-resolve chash → doc_id via \`Catalog.docs_for_chashes()\` per page, then fall through to the existing \`_doc_id_to_file_path\` branch.

## Tests

10 reindex tests pass (9 existing + 1 new \`test_reindex_treats_phase3_chunk_with_chash_only_as_reindexable\`).

## Test plan

- [x] \`uv run pytest tests/test_collection_cmd.py -k reindex\` (10 passed)
- [x] Em-dash audit clean
- [x] Branch off develop

## Closes

- nexus-vn48