### PR TITLE
fix(indexer): staleness cache resolves Phase-3 chunks via manifest (nexus-0ocy P3)

### DIFF
--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -282,7 +282,7 @@ def build_staleness_cache(col: object) -> StalenessCache:
     Pulls every chunk's ``include=["metadatas"]`` via the standard
     paginated helper. Calls per pull are ChromaDB Cloud's 300-record
     cap, so the total round-trip count is ``ceil(N / 300)`` where N is
-    the collection's chunk count — independent of the number of files
+    the collection's chunk count, independent of the number of files
     being indexed.
 
     Errors are tolerated: a build failure returns an empty cache and
@@ -300,7 +300,33 @@ def build_staleness_cache(col: object) -> StalenessCache:
     except Exception:
         return cache
 
+    # nexus-0ocy (RDR-108 Phase 4 review D-M4): when chunk metadata
+    # lacks ``doc_id`` (Phase-3 chunks) but carries ``chunk_text_hash``,
+    # resolve via the catalog ``document_chunks`` manifest in one
+    # batched call so by_doc_id stays useful for Phase-3 corpora.
+    # Empty fallback is a clean cache miss (the existing perf path
+    # for legacy chunks).
     metadatas = all_chunks.get("metadatas") or []
+    chash_to_doc: dict[str, str] = {}
+    needed_chashes = [
+        (m or {}).get("chunk_text_hash", "")
+        for m in metadatas
+        if m and not (m or {}).get("doc_id") and (m or {}).get("chunk_text_hash")
+    ]
+    if needed_chashes:
+        try:
+            from nexus.catalog import Catalog
+            from nexus.config import catalog_path
+            _cp = catalog_path()
+            if Catalog.is_initialized(_cp):
+                _cat = Catalog(_cp, _cp / ".catalog.db")
+                by_chash = _cat.docs_for_chashes(list(set(needed_chashes)))
+                for c, doc_ids in by_chash.items():
+                    if doc_ids:
+                        chash_to_doc[c] = sorted(doc_ids)[0]
+        except Exception:
+            pass
+
     for meta in metadatas:
         if not meta:
             continue
@@ -310,6 +336,10 @@ def build_staleness_cache(col: object) -> StalenessCache:
             continue
         value = (content_hash, model)
         doc_id = meta.get("doc_id", "")
+        if not doc_id:
+            chash = meta.get("chunk_text_hash", "")
+            if chash:
+                doc_id = chash_to_doc.get(chash, "")
         if doc_id:
             cache.by_doc_id[doc_id] = value
         source_path = meta.get("source_path", "")

--- a/tests/test_indexer_utils_repo.py
+++ b/tests/test_indexer_utils_repo.py
@@ -272,6 +272,40 @@ class TestStalenessCache:
             "legacy/old.py": ("hash-l", "voyage-code-3"),
         }
 
+    def test_build_resolves_phase3_chunks_via_catalog_manifest(self) -> None:
+        """nexus-0ocy (RDR-108 Phase 4 review D-M4): Phase-3 chunks
+        have no doc_id in metadata, only chunk_text_hash. The
+        staleness cache must batch-resolve chash -> doc_id via the
+        catalog manifest so by_doc_id stays useful for Phase-3
+        corpora; otherwise check_staleness falls through to the
+        per-file Chroma path and the build_staleness_cache perf
+        win evaporates.
+        """
+        chash = "a" * 64
+        col = MagicMock()
+        col.get.return_value = {
+            "ids": ["c1"],
+            "metadatas": [{
+                # Phase-3: chunk_text_hash but no doc_id.
+                "chunk_text_hash": chash,
+                "content_hash": "hash-a",
+                "embedding_model": "voyage-code-3",
+            }],
+        }
+
+        # Stub Catalog so the resolution finds the doc_id.
+        fake_cat = MagicMock()
+        fake_cat.docs_for_chashes.return_value = {chash: ["1.1.42"]}
+        import nexus.catalog as _cat_mod
+        with patch.object(
+            _cat_mod.Catalog, "is_initialized", return_value=True,
+        ), patch.object(_cat_mod, "Catalog", return_value=fake_cat):
+            cache = build_staleness_cache(col)
+
+        # by_doc_id resolved from the manifest, NOT from absent metadata.
+        assert cache.by_doc_id == {"1.1.42": ("hash-a", "voyage-code-3")}
+        fake_cat.docs_for_chashes.assert_called_once()
+
     def test_build_skips_chunks_missing_required_fields(self) -> None:
         """Chunks without content_hash or embedding_model (corrupted
         metadata, partial backfill) are skipped — the cache only holds


### PR DESCRIPTION
## Summary

P3 perf regression. \`build_staleness_cache\` indexed chunks via \`meta.get("doc_id", "")\`. RDR-108 Phase 3 removed doc_id from chunk metadata; for every Phase-3 chunk the by_doc_id index missed and \`check_staleness\` fell through to the per-file Chroma roundtrip path.

## Fix

Same shared-helper pattern as the other manifest-fallback fixes (rehf, hjd6, 7zcv, esrl, vn48): batch-resolve chash → doc_id via \`Catalog.docs_for_chashes\` in one pass per build.

## Tests

10 staleness-cache tests pass (9 existing + 1 new \`test_build_resolves_phase3_chunks_via_catalog_manifest\`).

## Test plan

- [x] \`uv run pytest tests/test_indexer_utils_repo.py -k TestStalenessCache\` (10 passed)
- [x] Em-dash audit clean
- [x] Branch off develop

## Closes

- nexus-0ocy