### PR TITLE
fix(doctor): t3-doc-id-coverage skips bypass-schema collections (nexus-wszt)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -4884,6 +4884,13 @@ def _run_t3_doc_id_coverage(
             "bootstrap from current T3 state."
         )
 
+    # nexus-wszt: bypass-schema collections (taxonomy__*) carry their
+    # own metadata vocabulary and intentionally have no doc_id (they
+    # are BERTopic centroids / embedding anchors, not document chunks).
+    # The doc_id-coverage audit must skip them or it reports 100%
+    # orphan ratio on every centroid set (false positive class).
+    from nexus.db.t3 import _BYPASS_SCHEMA_PREFIXES  # noqa: PLC0415
+
     # Build expected (coll_id, chunk_id) → doc_id; track orphans.
     # RDR-102 D3: also track every coll_id that appears in events.jsonl
     # (whether non-orphan or orphan-only) so the orphan-ratio surface
@@ -4895,6 +4902,8 @@ def _run_t3_doc_id_coverage(
         if event.type != ev.TYPE_CHUNK_INDEXED:
             continue
         coll = event.payload.coll_id
+        if coll.startswith(_BYPASS_SCHEMA_PREFIXES):
+            continue
         cid = event.payload.chunk_id
         all_event_collections.add(coll)
         if event.payload.synthesized_orphan:

--- a/tests/test_catalog_doctor_t3_coverage.py
+++ b/tests/test_catalog_doctor_t3_coverage.py
@@ -515,3 +515,48 @@ class TestPhase3ManifestFallback:
             "Phase-3 chunk should NOT be reported as missing doc_id "
             "when catalog manifest has the chash -> doc_id mapping"
         )
+
+
+class TestBypassSchemaSkipped:
+    """nexus-wszt: bypass-schema collections (taxonomy__*) carry their
+    own metadata vocabulary and intentionally lack doc_id (they are
+    BERTopic centroids / embedding anchors, not document chunks). The
+    doc_id-coverage audit must skip them or it reports 100% orphan
+    ratio on every centroid set (false positive class). Confirmed
+    via 2026-05-08 prod probe: ``taxonomy__centroids`` showed 2014
+    orphans where the schema is ``{collection, doc_count, label,
+    topic_id}`` (no doc_id by design).
+    """
+
+    def test_taxonomy_collection_excluded_from_audit(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A ``taxonomy__*`` collection with chunks that lack doc_id
+        must NOT cause the audit to fail; the collection should be
+        absent from the report tables entirely.
+        """
+        # Seed an event referencing taxonomy__centroids; the audit
+        # would normally treat this as expected -> needing doc_id.
+        events = [_chunk("topic-1", "uuid7-IRRELEVANT", "taxonomy__centroids")]
+        _seed_log(isolated_nexus, events)
+        _seed(chroma_client, "taxonomy__centroids", [
+            {"id": "topic-1", "content": "x",
+             "metadata": {"label": "foo bar", "topic_id": 1, "doc_count": 5}},
+        ])
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        result = runner.invoke(
+            doctor_cmd, ["--t3-doc-id-coverage", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        assert payload["pass"] is True
+        assert "taxonomy__centroids" not in payload["tables"], (
+            "bypass-schema collection should be excluded from the "
+            "doc_id-coverage report; centroids intentionally lack "
+            "doc_id and aren't documents"
+        )


### PR DESCRIPTION
## Summary

False positive class. ``taxonomy__*`` collections (BERTopic centroids per RDR-070) intentionally lack doc_id — they aren't documents. The doc_id-coverage audit was reporting 100% orphan ratio on ``taxonomy__centroids`` (2014 chunks) on every prod run.

## Fix

Skip events whose ``coll_id`` starts with ``_BYPASS_SCHEMA_PREFIXES`` (currently ``taxonomy__``) when building the expected map. Bypass-schema collections then appear in neither ``expected`` nor the report tables.

## Tests

15 doc_id-coverage tests pass (14 existing + 1 new ``test_taxonomy_collection_excluded_from_audit``).

## Test plan

- [x] ``uv run pytest tests/test_catalog_doctor_t3_coverage.py -v`` (15 passed)
- [x] Em-dash audit clean
- [x] Branch off develop

## Closes

- nexus-wszt