### PR TITLE
fix(catalog): auto-bootstrap leaves created_at empty for replay-equality (nexus-33xm)

### DIFF
--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -549,8 +549,26 @@ class CatalogDB:
                 ).fetchall()
             }
             if candidates:
-                from datetime import UTC, datetime as _datetime  # noqa: PLC0415
-                _now = _datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+                # nexus-33xm: created_at is INTENTIONALLY left empty
+                # here. The companion ``_emit_backfilled_collection_events``
+                # (catalog.py) emits CollectionCreated events with
+                # ``created_at=""`` for these same names; the projector
+                # handler does ``INSERT OR REPLACE ... COALESCE((SELECT
+                # created_at FROM collections WHERE name = ?), ?)``. If
+                # this auto-bootstrap stamps ``NOW()``, the COALESCE
+                # preserves the synthetic stamp on event apply but a
+                # fresh ``--replay-equality`` replay (which starts from
+                # an empty table) takes the ``""`` from the event
+                # payload, producing a permanent drift between live
+                # and projected. Empty here keeps the two paths
+                # bit-equal.
+                #
+                # SIG-7 (nexus-872w) audit-distinction goal: the prior
+                # NOW() stamp was meant to let audit tools distinguish
+                # auto-bootstrapped rows from event-derived rows. That
+                # distinction now lives in the synthetic event itself
+                # (``payload.created_at == ""`` marks a backfilled row);
+                # the SQLite row no longer needs to carry it.
                 with self._conn:
                     self._conn.execute(
                         "INSERT OR IGNORE INTO collections "
@@ -558,11 +576,10 @@ class CatalogDB:
                         " model_version, display_name, legacy_grandfathered, "
                         " superseded_by, superseded_at, created_at) "
                         "SELECT DISTINCT physical_collection, '', '', '', '', '', "
-                        "  1, '', '', ? "
+                        "  1, '', '', '' "
                         "FROM documents "
                         "WHERE physical_collection IS NOT NULL "
                         "  AND physical_collection != ''",
-                        (_now,),
                     )
                 self._backfilled_collections = candidates
 

--- a/tests/test_catalog_doctor_replay_equality.py
+++ b/tests/test_catalog_doctor_replay_equality.py
@@ -207,3 +207,46 @@ class TestReplayEqualityFails:
         assert docs_diff["equal"] is False
         assert docs_diff["live_count"] == 0
         assert docs_diff["projected_count"] >= 1
+
+
+class TestAutoBootstrapReplayEquality:
+    """nexus-33xm: when documents reference a physical_collection that
+    has no matching ``collections`` row, ``CatalogDB.__init__`` auto-
+    bootstraps the row and ``Catalog._emit_backfilled_collection_events``
+    appends a synthetic ``CollectionCreated`` event with
+    ``payload.created_at == ""``. The auto-bootstrap and the synthetic
+    event must agree on ``created_at``, otherwise ``--replay-equality``
+    permanently flags collections as drifted.
+
+    Pre-fix: auto-bootstrap stamped ``NOW()`` but the synthetic event
+    carried ``""``; live SQLite kept the NOW stamp via the projector's
+    COALESCE, but a fresh replay from the event log started empty and
+    took the synthetic ``""``. The drift was reproducible on every
+    catalog open with auto-bootstrapped rows.
+    """
+
+    def test_replay_equality_holds_for_auto_bootstrapped_collection(
+        self, isolated_nexus, runner,
+    ):
+        cat_dir = isolated_nexus
+        Catalog.init(cat_dir)
+        cat = Catalog(cat_dir, cat_dir / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        # Register with a physical_collection that has no CollectionCreated
+        # event of its own; on next open the auto-bootstrap will fire.
+        cat.register(
+            owner, "doc.md", content_type="prose", file_path="doc.md",
+            physical_collection="docs__autobackfill_33xm",
+        )
+        cat._db.close()
+
+        # Re-open: triggers CatalogDB.__init__ auto-bootstrap +
+        # Catalog._emit_backfilled_collection_events.
+        cat2 = Catalog(cat_dir, cat_dir / ".catalog.db")
+        cat2._db.close()
+
+        result = runner.invoke(doctor_cmd, ["--replay-equality"])
+        assert result.exit_code == 0, (
+            f"replay-equality must hold for auto-bootstrapped "
+            f"collections; got exit {result.exit_code}\n{result.output}"
+        )

--- a/tests/test_rdr108_phase1_remediation.py
+++ b/tests/test_rdr108_phase1_remediation.py
@@ -383,23 +383,44 @@ class TestSIG6ProgressOutput:
             assert result2.exit_code == 0, result2.output
 
 
-# ── SIG-7: created_at='' on backfilled collections rows ──────────────────────
+# ── nexus-33xm: created_at='' on auto-bootstrapped collections rows ─────────
 
 
-class TestSIG7CreatedAtTimestamp:
-    """SIG-7: collections backfill in catalog_db must set a real ISO timestamp
-    for created_at, not the empty string ''."""
+class TestAutoBootstrapCreatedAtEmpty:
+    """nexus-33xm (replaces SIG-7 / nexus-872w):
 
-    def test_backfilled_collections_have_real_created_at(self, tmp_path):
-        """The collections backfill (catalog_db.py __init__ INSERT INTO collections)
-        must emit a real ISO timestamp, not empty string."""
+    The auto-bootstrap that populates ``collections`` from
+    ``documents.physical_collection`` (catalog_db.py __init__) MUST
+    leave ``created_at`` empty.
+
+    Why: ``_emit_backfilled_collection_events`` (catalog.py) emits
+    a companion ``CollectionCreated`` event with
+    ``payload.created_at = ""`` for each auto-bootstrapped name. The
+    projector handler does ``INSERT OR REPLACE ... COALESCE((SELECT
+    created_at FROM collections WHERE name = ?), payload.created_at)``.
+
+    If the auto-bootstrap stamps ``NOW()``, the COALESCE preserves
+    that synthetic stamp on event apply, but a fresh
+    ``--replay-equality`` replay (which starts from an empty table)
+    takes ``""`` from the event payload, producing a permanent
+    drift between live and projected created_at columns.
+
+    Empty here keeps the two paths bit-equal. The audit-distinction
+    goal that drove SIG-7 (NOW() so audit tools could tell
+    backfilled from event-derived rows) now lives in the synthetic
+    event itself: ``payload.created_at == ""`` is the marker.
+    """
+
+    def test_backfilled_collections_have_empty_created_at(self, tmp_path):
+        """Auto-bootstrap must NOT stamp ``created_at = NOW()`` or
+        ``--replay-equality`` will permanently drift on the column.
+        Reverting the empty-string stamp to ``NOW()`` makes this
+        test fail with a non-empty timestamp.
+        """
         from nexus.catalog.catalog_db import CatalogDB
 
         db_path = tmp_path / "catalog.db"
         db = CatalogDB(db_path)
-
-        # Manually insert a documents row with a physical_collection not in
-        # the collections table, to trigger the backfill path
         db.execute(
             "INSERT OR IGNORE INTO documents "
             "(tumbler, title, author, year, content_type, file_path, "
@@ -408,28 +429,25 @@ class TestSIG7CreatedAtTimestamp:
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 "1.1.1", "Test doc", "", 0, "code", "/tmp/test.py",
-                "", "code__test_backfill_sig7", 0, "", "", "{}", 0.0, "", "",
+                "", "code__test_backfill_33xm", 0, "", "", "{}", 0.0, "", "",
             ),
         )
         db.commit()
         db.close()
 
-        # Re-open: the __init__ backfill path should fire and populate created_at
         db2 = CatalogDB(db_path)
         row = db2._conn.execute(
             "SELECT created_at FROM collections WHERE name = ?",
-            ("code__test_backfill_sig7",),
+            ("code__test_backfill_33xm",),
         ).fetchone()
         db2.close()
 
         assert row is not None, "collections row was not inserted"
-        created_at = row[0]
-        assert created_at not in ("", None), (
-            f"created_at must be a real timestamp, got {created_at!r}"
-        )
-        # Validate it's ISO format (basic check)
-        assert "T" in created_at or len(created_at) >= 10, (
-            f"created_at does not look like an ISO timestamp: {created_at!r}"
+        assert row[0] == "", (
+            f"auto-bootstrap must leave created_at empty so the "
+            f"synthetic CollectionCreated event with "
+            f"``payload.created_at == ''`` matches under "
+            f"--replay-equality; got {row[0]!r}"
         )
 
 


### PR DESCRIPTION
## Summary

Permanent ``--replay-equality`` drift on ``collections.created_at``. Two-write-path bug: ``CatalogDB.__init__`` auto-bootstrap stamped ``NOW()``, but the synthetic ``CollectionCreated`` event from ``Catalog._emit_backfilled_collection_events`` carried ``""``. Live SQLite kept NOW (COALESCE preserved), fresh replay took ``""`` (no existing row). Doctor flagged every auto-bootstrapped collection on every prod open.

## Fix

Auto-bootstrap now stamps ``''`` to match the synthetic event. SIG-7 audit-distinction goal lives in the event payload now (``payload.created_at == ''`` marks a backfilled row).

## Tests

- 158 catalog tests pass (rdr108_phase1, doctor_replay_equality, catalog_projector, catalog).
- ``TestSIG7CreatedAtTimestamp`` -> ``TestAutoBootstrapCreatedAtEmpty`` (inverted contract).
- New ``TestAutoBootstrapReplayEquality::test_replay_equality_holds_for_auto_bootstrapped_collection``.

## Test plan

- [x] ``uv run pytest tests/test_rdr108_phase1_remediation.py tests/test_catalog_doctor_replay_equality.py tests/test_catalog_projector.py tests/test_catalog.py`` (158 passed)
- [x] Em-dash audit clean
- [x] Branch off develop

## Closes

- nexus-33xm