### PR TITLE
feat(doctor): add Windows winget hints to install Fix-line block (nexus-njmg)

### DIFF
--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -99,9 +99,10 @@ def _check_python() -> list[HealthResult]:
     )
     if not ok:
         r.fix_suggestions = [
+            "brew install python@3.12                                 (macOS)",
+            "apt install python3.12                                   (Ubuntu/Debian)",
+            "winget install --id Python.Python.3.12 --scope user      (Windows)",
             "https://www.python.org/downloads/",
-            "brew install python@3.12         (macOS)",
-            "apt install python3.12           (Ubuntu/Debian)",
         ]
     return [r]
 
@@ -379,9 +380,12 @@ def _check_tools() -> list[HealthResult]:
         fatal=True,
     )
     if not rg_path:
+        # nexus-njmg (GH #622): winget --scope user avoids UAC-prompt
+        # failures during unattended install on Windows.
         r.fix_suggestions = [
-            "brew install ripgrep                      (macOS)",
-            "apt install ripgrep                       (Ubuntu/Debian)",
+            "brew install ripgrep                                          (macOS)",
+            "apt install ripgrep                                           (Ubuntu/Debian)",
+            "winget install --id BurntSushi.ripgrep.MSVC --scope user      (Windows)",
             "https://github.com/BurntSushi/ripgrep#installation",
         ]
     results.append(r)
@@ -396,8 +400,9 @@ def _check_tools() -> list[HealthResult]:
     )
     if not git_path:
         r.fix_suggestions = [
-            "brew install git                          (macOS)",
-            "apt install git                           (Ubuntu/Debian)",
+            "brew install git                                              (macOS)",
+            "apt install git                                               (Ubuntu/Debian)",
+            "winget install --id Git.Git --scope user                      (Windows)",
             "https://git-scm.com/downloads",
         ]
     results.append(r)
@@ -407,11 +412,15 @@ def _check_tools() -> list[HealthResult]:
     if bd_path:
         results.append(HealthResult(label="bd (beads, optional)", ok=True, detail=bd_path))
     else:
+        # bd has no winget package (verified 2026-05-10); upstream releases
+        # ship as a GitHub release zip operators install manually.
         results.append(HealthResult(
             label="bd (beads, optional)",
             ok=True,
             detail="not found — task tracking unavailable",
-            fix_suggestions=["https://github.com/BeadsProject/beads"],
+            fix_suggestions=[
+                "https://github.com/BeadsProject/beads/releases   (download for your OS)",
+            ],
         ))
 
     # npx (Node.js, plugin-only)
@@ -430,9 +439,10 @@ def _check_tools() -> list[HealthResult]:
             ok=True,
             detail="not found — plugin MCP servers (sequential-thinking, context7) will fail",
             fix_suggestions=[
-                "brew install node                         (macOS)",
-                "apt install nodejs npm                    (Ubuntu/Debian)",
-                "https://nodejs.org/                       (other platforms)",
+                "brew install node                                              (macOS)",
+                "apt install nodejs npm                                         (Ubuntu/Debian)",
+                "winget install --id OpenJS.NodeJS.LTS --scope user             (Windows)",
+                "https://nodejs.org/                                            (other platforms)",
             ],
         ))
 

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -133,6 +133,47 @@ def test_doctor_missing_rg_shows_platform_hints(runner, mock_reg):
     assert "BurntSushi/ripgrep" in result.output
 
 
+def test_doctor_missing_rg_includes_winget_hint(runner, mock_reg):
+    """nexus-njmg (GH #622): the Fix-line block for ripgrep must
+    include a Windows winget command. Operators on Windows had no
+    actionable install line and had to leave the terminal to figure
+    out the path manually. ``--scope user`` is mandatory to avoid
+    UAC-prompt failures during unattended install.
+    """
+    result = _invoke(runner, mock_reg, which=lambda _: None)
+    assert "winget install --id BurntSushi.ripgrep.MSVC" in result.output
+    assert "--scope user" in result.output
+
+
+def test_doctor_missing_git_includes_winget_hint(runner, mock_reg):
+    """nexus-njmg: git Fix-line must include winget."""
+    def which_side(name):
+        return None if name == "git" else f"/usr/bin/{name}"
+    result = _invoke(runner, mock_reg, which=which_side)
+    assert "winget install --id Git.Git --scope user" in result.output
+
+
+def test_doctor_missing_npx_includes_winget_hint(runner, mock_reg):
+    """nexus-njmg: Node.js (npx) Fix-line must include winget so
+    Windows plugin users can install the MCP-server runtime.
+    """
+    def which_side(name):
+        return None if name == "npx" else f"/usr/bin/{name}"
+    result = _invoke(runner, mock_reg, which=which_side)
+    assert "winget install --id OpenJS.NodeJS.LTS --scope user" in result.output
+
+
+def test_doctor_missing_bd_includes_release_zip_hint(runner, mock_reg):
+    """nexus-njmg: bd has no winget package; the Fix-line must point
+    at the GitHub releases page so Windows users can find the right
+    binary.
+    """
+    def which_side(name):
+        return None if name == "bd" else f"/usr/bin/{name}"
+    result = _invoke(runner, mock_reg, which=which_side)
+    assert "github.com/BeadsProject/beads/releases" in result.output
+
+
 @pytest.mark.parametrize("tool,exit_code", [("bd", 0), ("uv", 0)])
 def test_doctor_missing_optional_tool(runner, mock_reg, tool, exit_code):
     def which_side(name):


### PR DESCRIPTION
## Summary

Closes GH #622. Pre-fix the doctor's Fix-line block showed brew/apt commands but no Windows install. Operators on Windows had to leave the terminal to figure out the right path manually.

## Fix

Append a winget line for each installable tool: ripgrep, git, Node.js (npx), Python. ``--scope user`` avoids UAC-prompt failures during unattended install. ``bd`` has no winget package; points at GitHub release zip instead.

## Tests

4 new ``test_doctor_missing_*_includes_winget_hint`` cases. 58/58 doctor tests pass.

## Closes

- nexus-njmg
- Closes #622