### PR TITLE
feat(t3): pipeline pass-2 fetch with prior-batch upsert in reidentify (nexus-zpnq)

### DIFF
--- a/src/nexus/db/t3_reidentify.py
+++ b/src/nexus/db/t3_reidentify.py
@@ -37,6 +37,7 @@ Edge-case contracts:
 """
 from __future__ import annotations
 
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -180,75 +181,109 @@ def reidentify_collection(
     seen_old_ids: set[str] = set()
     seen_new_ids: set[str] = set()
 
-    for start in range(0, len(all_cids), _PAGE_SIZE):
-        cid_batch = all_cids[start : start + _PAGE_SIZE]
-        page = _chroma_with_retry(
+    # nexus-zpnq: pipeline pass-2 fetches one batch ahead of the
+    # processing+upsert of the prior batch. ChromaDB allows up to 10
+    # concurrent reads + 10 concurrent writes per collection
+    # (chroma_quotas.MAX_CONCURRENT_READS/WRITES); a 1-batch
+    # look-ahead is well within budget. Order is preserved: the main
+    # thread still processes batches in cid-list order, and the
+    # ``seen_old_ids`` / ``seen_new_ids`` dedupe sets are only ever
+    # touched from the main thread, so the per-collection state
+    # machine stays correct under the overlap. Theoretical speedup:
+    # up to 2x for I/O-bound collections; in practice modest because
+    # processing time per batch is non-zero.
+    cid_batches = [
+        all_cids[i : i + _PAGE_SIZE]
+        for i in range(0, len(all_cids), _PAGE_SIZE)
+    ]
+
+    def _fetch(batch: list[str]) -> dict:
+        return _chroma_with_retry(
             col.get,
-            ids=cid_batch,
+            ids=batch,
             include=["documents", "embeddings", "metadatas"],
         )
-        page_ids = page.get("ids") or []
-        page_docs = page.get("documents") or [None] * len(page_ids)
-        page_embs = page.get("embeddings")
-        if page_embs is None:
-            page_embs = [None] * len(page_ids)
-        page_metas = page.get("metadatas") or [{}] * len(page_ids)
 
-        ids_to_upsert: list[str] = []
-        docs_to_upsert: list[str] = []
-        embs_to_upsert: list = []
-        metas_to_upsert: list[dict] = []
+    pending_future: Future[dict] | None = None
+    with ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="reidentify-fetch",
+    ) as executor:
+        if cid_batches:
+            pending_future = executor.submit(_fetch, cid_batches[0])
 
-        for cid, doc, emb, meta in zip(
-            page_ids, page_docs, page_embs, page_metas
-        ):
-            result.chunks_examined += 1
-            meta = meta if isinstance(meta, dict) else {}
-            chash = meta.get("chunk_text_hash") or ""
-            if not chash:
-                raise MissingChunkHashError(
-                    chunk_id=cid, collection=collection_name
+        for i, cid_batch in enumerate(cid_batches):
+            assert pending_future is not None
+            page = pending_future.result()
+            # Kick off the NEXT fetch before processing this batch so
+            # the network round-trip overlaps with the upsert below.
+            if i + 1 < len(cid_batches):
+                pending_future = executor.submit(
+                    _fetch, cid_batches[i + 1],
                 )
-            new_id = chash[:32]
-            if cid == new_id:
-                result.chunks_already_migrated += 1
-                continue
+            else:
+                pending_future = None
+            page_ids = page.get("ids") or []
+            page_docs = page.get("documents") or [None] * len(page_ids)
+            page_embs = page.get("embeddings")
+            if page_embs is None:
+                page_embs = [None] * len(page_ids)
+            page_metas = page.get("metadatas") or [{}] * len(page_ids)
 
-            seen_old_ids.add(cid)
-            if new_id in seen_new_ids:
-                # Identical-text collapse (within-batch or cross-batch):
-                # still need to delete the old cid, but skip the
-                # redundant upsert so chromadb doesn't reject a duplicate.
-                continue
-            seen_new_ids.add(new_id)
+            ids_to_upsert: list[str] = []
+            docs_to_upsert: list[str] = []
+            embs_to_upsert: list = []
+            metas_to_upsert: list[dict] = []
 
-            # Use the canonical schema funnel (RDR-108 nexus-6l9p)
-            # rather than a narrow strip set. ``_normalize_for_write``
-            # drops the 3 RDR-108 Phase 3 fields (doc_id, chunk_index,
-            # chunk_count) plus all pre-RDR-101-Phase-5c cargo (corpus,
-            # store_type, expires_at, extraction_method, etc) and
-            # bib_* placeholders. Surfaced during the Phase 5 prod
-            # migration: 2 of 153 collections held legacy chunks with
-            # 33+ metadata keys; the prior narrow-strip path produced
-            # NumMetadataKeys quota errors on the upsert. The canonical
-            # funnel brings these chunks back under the per-row quota.
-            from nexus.db.t3 import _normalize_for_write
-            new_meta = _normalize_for_write(meta, collection_name)
-            ids_to_upsert.append(new_id)
-            docs_to_upsert.append(doc)
-            embs_to_upsert.append(emb)
-            metas_to_upsert.append(new_meta)
+            for cid, doc, emb, meta in zip(
+                page_ids, page_docs, page_embs, page_metas
+            ):
+                result.chunks_examined += 1
+                meta = meta if isinstance(meta, dict) else {}
+                chash = meta.get("chunk_text_hash") or ""
+                if not chash:
+                    raise MissingChunkHashError(
+                        chunk_id=cid, collection=collection_name
+                    )
+                new_id = chash[:32]
+                if cid == new_id:
+                    result.chunks_already_migrated += 1
+                    continue
 
-        if ids_to_upsert and not dry_run:
-            _chroma_with_retry(
-                col.upsert,
-                ids=ids_to_upsert,
-                documents=docs_to_upsert,
-                embeddings=embs_to_upsert,
-                metadatas=metas_to_upsert,
-            )
+                seen_old_ids.add(cid)
+                if new_id in seen_new_ids:
+                    # Identical-text collapse (within-batch or cross-batch):
+                    # still need to delete the old cid, but skip the
+                    # redundant upsert so chromadb doesn't reject a duplicate.
+                    continue
+                seen_new_ids.add(new_id)
 
-        result.chunks_migrated += len(ids_to_upsert)
+                # Use the canonical schema funnel (RDR-108 nexus-6l9p)
+                # rather than a narrow strip set. ``_normalize_for_write``
+                # drops the 3 RDR-108 Phase 3 fields (doc_id, chunk_index,
+                # chunk_count) plus all pre-RDR-101-Phase-5c cargo (corpus,
+                # store_type, expires_at, extraction_method, etc) and
+                # bib_* placeholders. Surfaced during the Phase 5 prod
+                # migration: 2 of 153 collections held legacy chunks with
+                # 33+ metadata keys; the prior narrow-strip path produced
+                # NumMetadataKeys quota errors on the upsert. The canonical
+                # funnel brings these chunks back under the per-row quota.
+                from nexus.db.t3 import _normalize_for_write
+                new_meta = _normalize_for_write(meta, collection_name)
+                ids_to_upsert.append(new_id)
+                docs_to_upsert.append(doc)
+                embs_to_upsert.append(emb)
+                metas_to_upsert.append(new_meta)
+
+            if ids_to_upsert and not dry_run:
+                _chroma_with_retry(
+                    col.upsert,
+                    ids=ids_to_upsert,
+                    documents=docs_to_upsert,
+                    embeddings=embs_to_upsert,
+                    metadatas=metas_to_upsert,
+                )
+
+            result.chunks_migrated += len(ids_to_upsert)
 
     if not dry_run and seen_old_ids:
         old_ids_list = list(seen_old_ids)

--- a/tests/test_t3_reidentify.py
+++ b/tests/test_t3_reidentify.py
@@ -624,6 +624,148 @@ class TestReidentifyPagination:
             )
 
 
+# ── nexus-zpnq: pass-2 fetch / upsert pipelining ─────────────────────────────
+
+
+class TestReidentifyPipelining:
+    """nexus-zpnq: pass-2 must fetch batch N+1 in parallel with the
+    processing+upsert of batch N. Reverting the pipelining (back to
+    sequential ``col.get -> col.upsert -> col.get -> col.upsert``)
+    fails the timing-overlap test below.
+    """
+
+    def test_pass2_fetch_overlaps_with_upsert(self, t3_db, monkeypatch):
+        """The look-ahead fetch (executor thread) must run
+        concurrently with the prior batch's upsert (main thread).
+        Test asserts that a fetch is in flight at the same wall-
+        clock moment as an upsert; reverting to a fully-sequential
+        ``fetch -> upsert -> fetch -> upsert`` loop fails this.
+        """
+        import threading
+        import time
+
+        coll_name = _unique_coll()
+        col = t3_db._client.get_or_create_collection(coll_name)
+
+        # Seed 3 pages worth of chunks. _PAGE_SIZE is monkeypatched
+        # down so the test runs fast (production _PAGE_SIZE=300).
+        from nexus.db import t3_reidentify as rmod
+        monkeypatch.setattr(rmod, "_PAGE_SIZE", 3)
+
+        ids = [f"old-{i}" for i in range(7)]  # 3 pages of 3 + 1
+        col.add(
+            ids=ids,
+            documents=[f"text-{i}" for i in range(7)],
+            metadatas=[
+                {"chunk_text_hash": f"h{i:062d}aa"}
+                for i in range(7)
+            ],
+            embeddings=[[0.1] * 3 for _ in range(7)],
+        )
+
+        # Track whether a get and an upsert are EVER concurrently
+        # in flight (the pipelining contract).
+        get_in_flight = False
+        upsert_in_flight = False
+        observed_overlap = False
+        lock = threading.Lock()
+
+        target_col = t3_db._client.get_collection(coll_name)
+        real_get = target_col.get
+        real_upsert = target_col.upsert
+
+        def _slow_get(*args, **kwargs):
+            nonlocal get_in_flight, observed_overlap
+            with lock:
+                get_in_flight = True
+                if upsert_in_flight:
+                    observed_overlap = True
+            try:
+                # ids= calls are pass-2 batches; offset= calls are
+                # pass-1 id discovery (no upsert in flight then,
+                # so they don't trigger the overlap signal anyway).
+                time.sleep(0.05)
+                return real_get(*args, **kwargs)
+            finally:
+                with lock:
+                    get_in_flight = False
+
+        def _slow_upsert(*args, **kwargs):
+            nonlocal upsert_in_flight, observed_overlap
+            with lock:
+                upsert_in_flight = True
+                if get_in_flight:
+                    observed_overlap = True
+            try:
+                time.sleep(0.05)
+                return real_upsert(*args, **kwargs)
+            finally:
+                with lock:
+                    upsert_in_flight = False
+
+        monkeypatch.setattr(target_col, "get", _slow_get)
+        monkeypatch.setattr(target_col, "upsert", _slow_upsert)
+        monkeypatch.setattr(
+            t3_db, "_client_for",
+            lambda _name: type(
+                "X", (), {"get_collection": lambda self, n: target_col},
+            )(),
+        )
+
+        rmod.reidentify_collection(t3_db, coll_name, dry_run=False)
+
+        assert observed_overlap, (
+            "pass-2 must overlap a look-ahead fetch with the prior "
+            "batch's upsert (zpnq pipelining contract). Reverting to "
+            "sequential fetch->upsert keeps the two strictly "
+            "alternating and observed_overlap stays False."
+        )
+
+    def test_pipelining_preserves_dedupe_semantics(self, t3_db, monkeypatch):
+        """The seen_new_ids dedupe set is touched only from the main
+        thread; pipelining the fetch must not introduce concurrent
+        writes to it. Two batches whose chunks all share the same
+        chash must collapse to a single upsert in total (one new id,
+        rest skipped as identical-text-collapse).
+        """
+        from nexus.db import t3_reidentify as rmod
+        monkeypatch.setattr(rmod, "_PAGE_SIZE", 2)
+
+        coll_name = _unique_coll()
+        col = t3_db._client.get_or_create_collection(coll_name)
+
+        # 4 chunks, 2 unique chashes -> 2 batches of 2; under
+        # pipelining, batch 2 is being fetched while batch 1 upsert
+        # is processing. The dedupe set must still correctly skip
+        # cross-batch duplicates.
+        chash_a = "a" * 64
+        chash_b = "b" * 64
+        col.add(
+            ids=["c1", "c2", "c3", "c4"],
+            documents=["a-text", "a-dup", "b-text", "b-dup"],
+            metadatas=[
+                {"chunk_text_hash": chash_a},
+                {"chunk_text_hash": chash_a},
+                {"chunk_text_hash": chash_b},
+                {"chunk_text_hash": chash_b},
+            ],
+            embeddings=[[0.1] * 3 for _ in range(4)],
+        )
+
+        result = rmod.reidentify_collection(
+            t3_db, coll_name, dry_run=False,
+        )
+        assert result.chunks_examined == 4
+        # Two unique chashes -> two upserts under the new ids.
+        assert result.chunks_migrated == 2, (
+            f"identical-text collapse broken under pipelining: "
+            f"expected 2 unique migrations, got {result.chunks_migrated}"
+        )
+        # All 4 old ids deleted (the 2 collapsed dupes still get the
+        # old-cid delete; only the upsert is skipped).
+        assert result.chunks_deleted == 4
+
+
 # ── CLI tests: nx t3 reidentify ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Within-collection parallelism on top of nexus-qlm2 (cross-collection). Pre-fix the pass-2 loop in ``reidentify_collection`` was strictly sequential: ``fetch -> process -> upsert -> fetch -> process -> upsert -> ...``. Now a 1-batch look-ahead via ``ThreadPoolExecutor(max_workers=1)`` submits the next batch's ``col.get`` BEFORE the main thread starts processing the current batch, so the look-ahead fetch overlaps in wall-clock time with the current batch's processing + upsert.

## Correctness invariants preserved

- **Order**: batches still processed in cid-list order.
- **Dedupe**: ``seen_old_ids`` / ``seen_new_ids`` touched only from main thread.
- **Crash-resumable**: two-pass design unchanged.
- **Quota**: still <=300 records per get/upsert; concurrency well within ChromaDB's MAX_CONCURRENT_READS/WRITES (10 each).

## Speedup

Theoretical: up to 2x for I/O-bound collections. Practical estimate: 1.3-1.7x.

## Tests

- 28 existing reidentify tests pass.
- 2 new ``TestReidentifyPipelining`` tests:
  - Asserts get+upsert ever concurrently in flight (catches revert).
  - Asserts dedupe semantics survive cross-batch with pipelining.

## Closes

- nexus-zpnq