### PR TITLE
test(infra): fail session when fixture cache files leak into ~/.config/nexus/ (nexus-nifd)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,100 @@ def pytest_configure(config):
     )
 
 
+# nexus-nifd: prefixes that the indexer's repo cache uses for
+# pytest fixture-named test repos. Files at
+# ``~/.config/nexus/<prefix>-*-<repo_hash>.cache`` matching one of
+# these are evidence that a test bypassed the autouse
+# ``_isolate_config_dir`` fixture (e.g. a subprocess that didn't
+# inherit ``NEXUS_CONFIG_DIR``, or a test that explicitly
+# ``monkeypatch.delenv("NEXUS_CONFIG_DIR")``). Update this list when
+# adding a new fixture-named test repo.
+_FIXTURE_CACHE_PREFIXES: tuple[str, ...] = (
+    "nexus-rich0",
+    "nexus-mini0",
+    "code-repo",
+    "prose-repo",
+    "pdf-repo",
+    "stage-b-repo",
+    "sentinel-repo",
+    "test-repo",
+    "nx-shakeout-",
+)
+
+
+def _scan_fixture_cache_files() -> set[Path]:
+    """Return the set of *.cache files in the REAL ~/.config/nexus/
+    whose basename starts with a fixture-cache prefix. Empty when
+    the directory doesn't exist.
+
+    Uses Path.home() rather than ``nexus_config_dir()`` to bypass
+    any test-time NEXUS_CONFIG_DIR override; the leak we're guarding
+    against is precisely tests that hit the REAL config dir.
+    """
+    real_config = Path.home() / ".config" / "nexus"
+    if not real_config.exists():
+        return set()
+    return {
+        p for p in real_config.glob("*.cache")
+        if p.name.startswith(_FIXTURE_CACHE_PREFIXES)
+    }
+
+
+_fixture_cache_baseline: set[Path] = set()
+
+
+def pytest_sessionstart(session):
+    """Snapshot fixture cache files in ~/.config/nexus/ at session
+    start so ``pytest_sessionfinish`` can detect leaks introduced
+    during the session (nexus-nifd).
+    """
+    global _fixture_cache_baseline
+    _fixture_cache_baseline = _scan_fixture_cache_files()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """nexus-nifd: fail the session when any new test-fixture cache
+    file appears in the REAL ~/.config/nexus/ during the session.
+
+    Background: 2026-05-08 prod shakeout found 1,707 leaked
+    test-fixture cache files (~121.5 MB) accumulated over weeks.
+    The autouse ``_isolate_config_dir`` fixture (PR #601 / nexus-
+    mrmq) prevents future leakage for tests that USE it, but a
+    test that bypasses the fixture or spawns a subprocess without
+    propagating ``NEXUS_CONFIG_DIR`` could re-introduce the leak
+    silently. This guard catches that class.
+
+    Best-effort cleanup: any newly-leaked file is unlinked before
+    the failure surfaces so the next run starts from a clean
+    baseline. The session is still failed so the offending test
+    is visible in CI.
+    """
+    after = _scan_fixture_cache_files()
+    leaked = after - _fixture_cache_baseline
+    if not leaked:
+        return
+    # Surface and clean up.
+    leaked_sorted = sorted(leaked)
+    for path in leaked_sorted:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+    names = ", ".join(p.name for p in leaked_sorted[:5])
+    suffix = "" if len(leaked_sorted) <= 5 else f" (+{len(leaked_sorted) - 5} more)"
+    session.exitstatus = 1
+    print(
+        f"\n\nFAIL: nexus-nifd cache-leak guard caught "
+        f"{len(leaked_sorted)} fixture-cache file(s) leaked into "
+        f"~/.config/nexus/: {names}{suffix}\n"
+        f"  Cause: a test bypassed the autouse `_isolate_config_dir` "
+        f"fixture or spawned a subprocess without inheriting "
+        f"NEXUS_CONFIG_DIR.\n"
+        f"  Cleanup: leaked files removed; failing the session.\n",
+        flush=True,
+    )
+
+
 @pytest.fixture(autouse=True)
 def _restore_structlog_after_test():
     """Save and restore structlog config around every test so any test

--- a/tests/test_fixture_cache_leak_guard.py
+++ b/tests/test_fixture_cache_leak_guard.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-nifd: tests for the fixture-cache leak guard hooks added
+to ``tests/conftest.py``.
+
+The guard runs at session start (snapshots leaked-file baseline) and
+session finish (computes delta + fails if any new fixture-cache
+file landed in the REAL ``~/.config/nexus/``). Direct testing of
+``pytest_sessionfinish`` requires running pytest inside pytest;
+instead we test the helper functions and the prefix list.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from tests.conftest import (
+    _FIXTURE_CACHE_PREFIXES,
+    _scan_fixture_cache_files,
+)
+
+
+class TestFixtureCachePrefixes:
+    def test_prefix_list_covers_known_fixture_repos(self) -> None:
+        """The prefix list must contain every fixture name the
+        2026-05-08 leak audit identified. Adding a new fixture
+        without updating the list is a soft regression: the new
+        fixture's cache files would leak silently.
+        """
+        # Sourced from the bead's description (2026-05-08 audit
+        # of 1,707 leaked files in ~/.config/nexus/).
+        from_audit = {
+            "nexus-rich0", "nexus-mini0", "code-repo", "prose-repo",
+            "pdf-repo", "stage-b-repo", "sentinel-repo", "test-repo",
+            "nx-shakeout-",
+        }
+        assert from_audit.issubset(set(_FIXTURE_CACHE_PREFIXES))
+
+
+class TestScanFixtureCacheFiles:
+    def test_returns_empty_when_real_dir_missing(self, tmp_path: Path) -> None:
+        """When ``~/.config/nexus/`` doesn't exist (CI sandbox), the
+        scan returns empty rather than raising — keeps the guard
+        non-fatal in environments without an existing config dir.
+        """
+        with patch.object(Path, "home", return_value=tmp_path):
+            assert _scan_fixture_cache_files() == set()
+
+    def test_picks_up_files_with_fixture_prefix(self, tmp_path: Path) -> None:
+        """A file matching one of ``_FIXTURE_CACHE_PREFIXES`` is
+        flagged. A file with an unmatched prefix is not.
+        """
+        cfg = tmp_path / ".config" / "nexus"
+        cfg.mkdir(parents=True)
+        match = cfg / "code-repo-deadbeef.cache"
+        match.write_text("payload")
+        no_match = cfg / "real-user-project-cafef00d.cache"
+        no_match.write_text("payload")
+        not_cache = cfg / "code-repo-deadbeef.txt"
+        not_cache.write_text("payload")
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            found = _scan_fixture_cache_files()
+        assert match in found
+        assert no_match not in found
+        assert not_cache not in found
+
+    def test_picks_up_all_known_prefixes(self, tmp_path: Path) -> None:
+        """Every prefix in the allow-list actually triggers the
+        scan; reverting any prefix removal would re-allow that
+        leakage class. Lock the contract by seeding one file per
+        prefix.
+        """
+        cfg = tmp_path / ".config" / "nexus"
+        cfg.mkdir(parents=True)
+        for prefix in _FIXTURE_CACHE_PREFIXES:
+            (cfg / f"{prefix}-abcd1234.cache").write_text("x")
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            found = _scan_fixture_cache_files()
+        # One per prefix.
+        assert len(found) == len(_FIXTURE_CACHE_PREFIXES), (
+            f"expected {len(_FIXTURE_CACHE_PREFIXES)} flagged files, "
+            f"got {len(found)}: {sorted(p.name for p in found)}"
+        )


### PR DESCRIPTION
## Summary

2026-05-08 prod shakeout found 1,707 leaked test-fixture cache files (~121.5 MB) in ``~/.config/nexus/``. The autouse ``_isolate_config_dir`` fixture prevents future leakage for tests that USE it; this PR adds a session-scoped guard that fails the session if a fixture-named cache file lands in the REAL config dir (catches subprocess-spawning tests + tests that bypass the fixture).

## Tests

4 new helper-function tests + 226 wider sweep clean.

## Closes

- nexus-nifd