### PR TITLE
fix(catalog): collapse DEVONthink URIs to one home; expose empty sentinel (nexus-n3md)

### DIFF
--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -2065,19 +2065,43 @@ def _home_matches_root(home: str, repo_root: str) -> bool:
     return real_home.startswith(real_root) or real_root.startswith(real_home)
 
 
+_EMPTY_HOME_KEY = ""
+_DEVONTHINK_HOME_KEY = "x-devonthink-item://"
+
+
 def _source_uri_home_key(uri: str) -> str:
     """Stable grouping key for source_uri "home" detection.
 
     For ``file://`` URIs, returns the first four path segments
     (e.g. ``/Users/hal.hildebrand/git/ART``) so two entries from the
-    same repo cluster regardless of the file inside that repo. For
-    other schemes returns ``<scheme>://<netloc>``. Empty URIs map to
-    ``""`` so missing-source-uri entries form their own bucket.
+    same repo cluster regardless of the file inside that repo.
+
+    For ``x-devonthink-item://`` URIs (RDR-099 DEVONthink integration),
+    returns a fixed sentinel ``x-devonthink-item://`` so every UUID-
+    netlocked DEVONthink reference collapses to ONE bucket. Pre-fix
+    this returned ``<scheme>://<uuid>`` per chunk, making every
+    DEVONthink import look like its own home. ``knowledge__art-
+    grossberg-papers`` reported 110+ homes when it has at most 4
+    logical roots; the audit's contamination signal was unreadable.
+
+    Other schemes return ``<scheme>://<netloc>``.
+
+    Empty URIs return :data:`_EMPTY_HOME_KEY` so the audit can
+    distinguish "no source_uri" rows from real "single home" rows;
+    callers that want a non-empty home count must filter the empty
+    bucket explicitly (the contamination signal is "≥2 distinct
+    NON-EMPTY homes", not just "≥2 distinct buckets"; a single self-
+    marker row was previously enough to flip a small clean
+    collection to "contaminated").
+
+    Constants ``_EMPTY_HOME_KEY`` and ``_DEVONTHINK_HOME_KEY`` are
+    exposed so consumers (audit-membership, doctor checks, tests)
+    can pattern-match on them without re-implementing the literals.
     """
     from urllib.parse import urlparse
 
     if not uri:
-        return ""
+        return _EMPTY_HOME_KEY
     p = urlparse(uri)
     if p.scheme == "file":
         # path = "/Users/hal.hildebrand/git/ART/docs/rdr/X.md"
@@ -2085,6 +2109,12 @@ def _source_uri_home_key(uri: str) -> str:
         # Take through the 5th component (the project root).
         parts = p.path.split("/")
         return "/".join(parts[:5]) if len(parts) >= 5 else p.path
+    if p.scheme == "x-devonthink-item":
+        # nexus-n3md: collapse all DEVONthink items to one bucket.
+        # Per RDR-099 the UUID netloc is an opaque doc handle, not a
+        # repo / namespace identifier; treating each as a distinct
+        # home produced 110+ false-positive homes per collection.
+        return _DEVONTHINK_HOME_KEY
     return f"{p.scheme}://{p.netloc}"
 
 

--- a/tests/test_source_uri_home_key.py
+++ b/tests/test_source_uri_home_key.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-n3md: ``_source_uri_home_key`` must collapse DEVONthink
+URIs (opaque UUID-netlocked handles per RDR-099) to a single bucket
+and keep empty URIs in a distinct bucket from real file homes.
+
+Pre-fix the function returned ``<scheme>://<uuid>`` per DEVONthink
+chunk, making every imported item look like its own home. The
+2026-05-08 audit reported 110+ homes for ``knowledge__art-
+grossberg-papers__voyage-context-3__v1`` when the collection has
+at most 4 logical roots.
+"""
+from __future__ import annotations
+
+from nexus.commands.catalog import (
+    _DEVONTHINK_HOME_KEY,
+    _EMPTY_HOME_KEY,
+    _source_uri_home_key,
+)
+
+
+class TestFileUri:
+    def test_file_uri_groups_by_first_four_path_segments(self) -> None:
+        """``file://``-rooted URIs at any depth under the same repo
+        return the same key, so an audit can count "homes per
+        collection" without inflating by per-file granularity.
+        """
+        a = "file:///Users/hal.hildebrand/git/ART/docs/rdr/X.md"
+        b = "file:///Users/hal.hildebrand/git/ART/docs/something/else/Y.md"
+        c = "file:///Users/hal.hildebrand/git/nexus/src/foo.py"
+        assert _source_uri_home_key(a) == _source_uri_home_key(b)
+        assert _source_uri_home_key(a) != _source_uri_home_key(c)
+
+
+class TestDevonthinkUri:
+    """nexus-n3md primary fix. Reverting the special-case for
+    ``scheme == 'x-devonthink-item'`` returns the per-UUID
+    ``<scheme>://<uuid>`` shape and these assertions fail.
+    """
+
+    def test_distinct_uuids_collapse_to_one_bucket(self) -> None:
+        """Two DEVONthink items with different UUIDs must map to
+        the same key. RDR-099 treats the UUID as opaque; the audit
+        must not count them as separate "homes".
+        """
+        u1 = "x-devonthink-item://CB1234AB-5678-90AB-CDEF-1234567890AB"
+        u2 = "x-devonthink-item://DC9876FE-3210-FEDC-BA98-76543210FEDC"
+        assert _source_uri_home_key(u1) == _source_uri_home_key(u2)
+        assert _source_uri_home_key(u1) == _DEVONTHINK_HOME_KEY
+
+    def test_devonthink_does_not_collide_with_file_or_empty(self) -> None:
+        """The DEVONthink bucket is its own; it must not match the
+        file:// home bucket or the empty bucket so the audit can
+        report DEVONthink contributions separately from file imports.
+        """
+        dt = _source_uri_home_key(
+            "x-devonthink-item://CB1234AB-5678-90AB-CDEF-1234567890AB"
+        )
+        file_home = _source_uri_home_key(
+            "file:///Users/hal.hildebrand/git/ART/X.md"
+        )
+        empty = _source_uri_home_key("")
+        assert dt != file_home
+        assert dt != empty
+
+
+class TestEmptySourceUri:
+    """nexus-n3md secondary fix. Empty source_uri rows (knowledge
+    notes with no source file) must form their OWN bucket so a
+    single self-marker row doesn't flip a small collection from
+    clean to contaminated.
+    """
+
+    def test_empty_uri_returns_empty_sentinel(self) -> None:
+        assert _source_uri_home_key("") == _EMPTY_HOME_KEY
+
+    def test_empty_uri_distinct_from_any_real_home(self) -> None:
+        """The empty bucket must not match a real file home. Audit
+        contamination logic (``≥ 2 distinct non-empty homes``) can
+        then filter the empty key explicitly.
+        """
+        empty = _source_uri_home_key("")
+        file_home = _source_uri_home_key(
+            "file:///Users/hal.hildebrand/git/ART/X.md"
+        )
+        assert empty != file_home
+
+
+class TestOtherSchemes:
+    def test_http_uri_keys_on_scheme_and_netloc(self) -> None:
+        """Non-file/non-DEVONthink URIs keep the prior
+        ``<scheme>://<netloc>`` shape so other curators (web
+        imports etc.) cluster by host.
+        """
+        a = _source_uri_home_key("https://arxiv.org/abs/1234.5678")
+        b = _source_uri_home_key("https://arxiv.org/abs/2345.6789")
+        c = _source_uri_home_key("https://example.com/page")
+        assert a == b == "https://arxiv.org"
+        assert a != c


### PR DESCRIPTION
## Summary

audit-membership reported false positives on ``_source_uri_home_key``: every ``x-devonthink-item://<uuid>`` looked like its own home (110+ for ``knowledge__art-grossberg-papers``), and empty source_uri rows bucketed with file-path rows (one self-marker row flipped a small collection to "contaminated").

## Fix

- DEVONthink: special-case to fixed sentinel ``_DEVONTHINK_HOME_KEY``.
- Empty: expose ``_EMPTY_HOME_KEY`` so audit can filter explicitly.

## Tests

6 new + 215 wider sweep clean.

## Closes

- nexus-n3md