### PR TITLE
fix(aspects): drop NULL or sub-floor confidence rows at upsert (nexus-17wf)

### DIFF
--- a/src/nexus/db/t2/document_aspects.py
+++ b/src/nexus/db/t2/document_aspects.py
@@ -55,6 +55,17 @@ import structlog
 _log = structlog.get_logger()
 
 
+# nexus-17wf: minimum confidence for an aspect record to be persisted.
+# Records with confidence None or below this floor are dropped at
+# upsert time with a structured warning, since they signal extractor
+# failures (LLM returned malformed JSON, retry-loop exhausted, etc.).
+# 2026-05-08 prod probe: 125 of 753 rows (16.6%) had NULL or zero
+# confidence; downstream consumers treated them as authoritative.
+# 0.3 is conservative: the same probe showed avg=0.823 across
+# non-NULL rows, so a real extraction clears the floor comfortably.
+_MIN_CONFIDENCE: float = 0.3
+
+
 # ── Schema SQL ──────────────────────────────────────────────────────────────
 
 _DOCUMENT_ASPECTS_SCHEMA_SQL = """\
@@ -176,7 +187,7 @@ class DocumentAspects:
 
     # ── Public API ────────────────────────────────────────────────────────
 
-    def upsert(self, record: AspectRecord) -> None:
+    def upsert(self, record: AspectRecord) -> bool:
         """Persist *record* — complete overwrite if the PK key already exists.
 
         Pre-migration: keyed on ``(collection, source_path)``.
@@ -188,6 +199,19 @@ class DocumentAspects:
         Uses ``INSERT OR REPLACE``. JSON fields serialize with
         ``json.dumps`` (no separator overrides — matches the rest of
         the project).
+
+        nexus-17wf: silently DROPS records with ``confidence is None``
+        or ``confidence < _MIN_CONFIDENCE`` (no row written, structured
+        warning logged). The 2026-05-08 prod probe found 125 of 753
+        rows (16.6%) committed with NULL or zero confidence, signaling
+        extractor failures that downstream consumers (``nx aspects
+        show``, retrieval ranking, telemetry) treated as authoritative.
+        Per the project's no-silent-fallback principle for
+        data-correctness problems, the right shape is reject + log so
+        the data store stays clean. Returns True if the row was
+        written, False if dropped on the confidence floor; callers
+        that need to mark a queue row done either way ignore the
+        return value.
         """
         if not record.extracted_at:
             raise ValueError("extracted_at must not be empty")
@@ -195,6 +219,23 @@ class DocumentAspects:
             raise ValueError("model_version must not be empty")
         if not record.extractor_name:
             raise ValueError("extractor_name must not be empty")
+
+        # nexus-17wf: drop low-quality extractions before they pollute
+        # the aspects table. The threshold is conservative; a real
+        # extraction should clear it comfortably (2026-05-08 probe:
+        # min=0, max=1.0, avg=0.823 across non-NULL rows).
+        if record.confidence is None or record.confidence < _MIN_CONFIDENCE:
+            _log.warning(
+                "document_aspects_upsert_dropped_low_confidence",
+                doc_id=record.doc_id,
+                collection=record.collection,
+                source_path=record.source_path,
+                extractor_name=record.extractor_name,
+                model_version=record.model_version,
+                confidence=record.confidence,
+                threshold=_MIN_CONFIDENCE,
+            )
+            return False
 
         datasets_json = json.dumps(list(record.experimental_datasets))
         baselines_json = json.dumps(list(record.experimental_baselines))
@@ -263,6 +304,7 @@ class DocumentAspects:
                     ),
                 )
                 self.conn.commit()
+        return True
 
     def get(self, collection: str, source_path: str) -> AspectRecord | None:
         """Return the row matching ``(collection, source_path)``, or None.

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -135,13 +135,23 @@ class TestWorkerDrain:
             rec = db.document_aspects.get("code__nexus", "/p1.py")
         assert rec is None
 
-    def test_worker_null_fields_record_persists_without_retry(
+    def test_worker_null_confidence_record_dropped_without_retry(
         self, _isolate_t2: Path,
     ) -> None:
-        """If extract_aspects returned a null-fields record, the
-        extractor's internal 3-retry budget is exhausted. The worker
-        writes the null record + drops the queue row (no retry —
-        retrying would re-attempt 3× more for no benefit)."""
+        """nexus-17wf: a null-fields record (the failure shape that
+        the extractor's internal 3-retry budget produces) carries
+        ``confidence=None``. The DocumentAspects upsert must DROP
+        it (no row written) so downstream consumers don't treat
+        a failed extraction as authoritative; the worker still
+        marks the queue row done (no worker-level retry, since
+        retrying would re-attempt 3 more times for no benefit).
+
+        Pre-fix: the null record was persisted, polluting 16.6%
+        of the table per 2026-05-08 prod probe. Reverting the
+        confidence-floor check in DocumentAspects.upsert lands
+        the row again and this test fails on the ``rec is None``
+        assertion below.
+        """
         from nexus.aspect_extractor import AspectRecord
         from nexus.aspect_worker import AspectExtractionWorker
 
@@ -179,11 +189,14 @@ class TestWorkerDrain:
 
         # extract_aspects called exactly once — no worker-level retry.
         assert call_count[0] == 1
+        # The null-confidence record must NOT be persisted (nexus-17wf).
         with T2Database(_isolate_t2) as db:
             rec = db.document_aspects.get("knowledge__delos", "/p1.pdf")
-        assert rec is not None
-        assert rec.problem_formulation is None
-        assert rec.extractor_name == "scholarly-paper-v1"
+        assert rec is None, (
+            "nexus-17wf: confidence=None record must be dropped at "
+            "upsert (was committed pre-fix, polluting downstream "
+            "consumers); reverting the floor check fails this assert"
+        )
 
     def test_mcp_path_content_survives_the_queue(
         self, _isolate_t2: Path,

--- a/tests/test_document_aspects_store.py
+++ b/tests/test_document_aspects_store.py
@@ -221,6 +221,96 @@ class TestUpsertGet:
         assert json.loads(row[2]) == {"venue": "VLDB", "year": 2023}
 
 
+class TestConfidenceFloor:
+    """nexus-17wf: rows with NULL or sub-floor confidence must be
+    DROPPED at upsert (no row written, structured warning logged,
+    upsert returns False). The 2026-05-08 prod probe found 125 of
+    753 rows (16.6%) committed with NULL or zero confidence,
+    polluting downstream consumers (``nx aspects show``, retrieval
+    ranking, telemetry) that treated them as authoritative. Per
+    the project's no-silent-fallback principle, the right shape is
+    reject + log.
+    """
+
+    def test_null_confidence_is_dropped(self, tmp_path: Path) -> None:
+        from nexus.db.t2.document_aspects import DocumentAspects
+
+        store = DocumentAspects(tmp_path / "t2.db")
+        try:
+            written = store.upsert(_make_record(confidence=None))
+            assert written is False
+            assert store.get(
+                "knowledge__delos", "/papers/p1.pdf"
+            ) is None
+        finally:
+            store.close()
+
+    def test_zero_confidence_is_dropped(self, tmp_path: Path) -> None:
+        from nexus.db.t2.document_aspects import DocumentAspects
+
+        store = DocumentAspects(tmp_path / "t2.db")
+        try:
+            written = store.upsert(_make_record(confidence=0.0))
+            assert written is False
+            assert store.get(
+                "knowledge__delos", "/papers/p1.pdf"
+            ) is None
+        finally:
+            store.close()
+
+    def test_confidence_at_floor_is_persisted(self, tmp_path: Path) -> None:
+        """A confidence equal to the floor (0.3) is accepted; only
+        STRICTLY-below values are dropped. Lock the boundary so a
+        future tightening of the floor surfaces as a deliberate
+        diff rather than a silent drop.
+        """
+        from nexus.db.t2.document_aspects import (
+            DocumentAspects, _MIN_CONFIDENCE,
+        )
+        assert _MIN_CONFIDENCE == 0.3
+        store = DocumentAspects(tmp_path / "t2.db")
+        try:
+            written = store.upsert(_make_record(confidence=0.3))
+            assert written is True
+            assert store.get(
+                "knowledge__delos", "/papers/p1.pdf"
+            ) is not None
+        finally:
+            store.close()
+
+    def test_confidence_just_below_floor_is_dropped(
+        self, tmp_path: Path,
+    ) -> None:
+        from nexus.db.t2.document_aspects import DocumentAspects
+
+        store = DocumentAspects(tmp_path / "t2.db")
+        try:
+            written = store.upsert(_make_record(confidence=0.29))
+            assert written is False
+            assert store.get(
+                "knowledge__delos", "/papers/p1.pdf"
+            ) is None
+        finally:
+            store.close()
+
+    def test_high_confidence_unaffected(self, tmp_path: Path) -> None:
+        """Real extractions (avg confidence 0.823 in the 2026-05-08
+        probe) clear the floor comfortably. Lock the contract so a
+        future change that accidentally tightens the floor too high
+        surfaces in the test diff.
+        """
+        from nexus.db.t2.document_aspects import DocumentAspects
+
+        store = DocumentAspects(tmp_path / "t2.db")
+        try:
+            assert store.upsert(_make_record(confidence=0.823)) is True
+            got = store.get("knowledge__delos", "/papers/p1.pdf")
+            assert got is not None
+            assert got.confidence == 0.823
+        finally:
+            store.close()
+
+
 # ── Idempotent overwrite (RDR Upsert Semantics — load-bearing) ───────────────
 
 

--- a/tests/test_migrations_rdr096.py
+++ b/tests/test_migrations_rdr096.py
@@ -748,11 +748,16 @@ class TestAspectRecordSourceUriRoundTrip:
 
         store = DocumentAspects(tmp_path / "rt.db")
         try:
+            # nexus-17wf: confidence is now floor-gated (>=0.3); pass
+            # an explicit value above the floor so the upsert lands.
+            # The test exercises source_uri round-trip, not confidence
+            # semantics.
             store.upsert(AspectRecord(
                 collection="knowledge__delos",
                 source_path="/Users/me/aleph-bft.pdf",
                 problem_formulation="problem",
                 proposed_method="method",
+                confidence=0.9,
                 extracted_at=datetime.now(UTC).isoformat(),
                 model_version="claude-haiku-4-5-20251001",
                 extractor_name="scholarly-paper-v1",

--- a/tests/test_migrations_rdr108_phase1c.py
+++ b/tests/test_migrations_rdr108_phase1c.py
@@ -785,6 +785,10 @@ class TestDocumentAspectsPostMigrationAPI:
             doc_id="nexus-new01",
             problem_formulation="Test",
             proposed_method="Test method",
+            # nexus-17wf: confidence floor-gated (>=0.3); pass an
+            # explicit value so the upsert lands. Test exercises
+            # doc_id PK round-trip, not confidence semantics.
+            confidence=0.9,
             extracted_at="2026-05-09T00:00:00+00:00",
             model_version="claude-haiku-4-5-20251001",
             extractor_name="scholarly-paper-v1",


### PR DESCRIPTION
## Summary

2026-05-08 prod probe found 125 of 753 ``document_aspects`` rows (16.6%) with NULL or zero confidence — the extractor's 3-retry-budget-exhausted shape. Pre-fix these were persisted and treated as authoritative by downstream consumers.

## Fix

Per the project's no-silent-fallback principle: ``DocumentAspects.upsert`` now drops rows where ``confidence is None`` or ``< 0.3``, logs ``document_aspects_upsert_dropped_low_confidence``, and returns False. The 0.3 floor is conservative (probe avg = 0.823).

## Existing rows

Future writes only. The 125 historical rows need a separate operator sweep.

## Tests

- 5 new ``TestConfidenceFloor`` cases lock the boundary.
- ``test_worker_null_confidence_record_dropped_without_retry`` (inverted from the prior ``_persists_`` form).
- 212 aspect tests pass.

## Closes

- nexus-17wf