### PR TITLE
docs: chunk vs document metadata semantics + T3 health & audit-membership runbooks (nexus-gndj)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,27 @@ and scoping semantic search to relevant collections instead of searching everyth
 
 Content-hash spans reference chunks by `chunk_text_hash` metadata (SHA-256 of stored chunk text). All 5 indexers (code, prose, doc PDF, doc markdown, streaming PDF pipeline) emit `chunk_text_hash` alongside the existing file-level `content_hash`. For existing collections, `nx catalog setup` or `nx collection backfill-hash` adds the field without re-embedding. `link_audit()` verifies chash spans resolve in T3.
 
+### Metadata field semantics (chunk vs document level)
+
+Two hash fields look similar but mean very different things. Confusing them produces false-positive panic findings (e.g. "94% redundancy across the corpus" turns out to be 94% of chunks share a doc-level hash, which is correct: every chunk of one paper has the same `content_hash`). The table below locks the contract; consult before drawing conclusions from a metadata distribution.
+
+| Metadata field | Level | Keyed on | Set by | Used for |
+|---|---|---|---|---|
+| `content_hash` | document | `sha256(file_bytes)` | every indexer at register time (`indexer.py:1198`) | document-level dedup; staleness comparison; backup-snapshot identity |
+| `chunk_text_hash` | chunk | `sha256(chunk_text)` (full 64 chars) | every indexer per chunk; backfilled by `nx collection backfill-hash` | content-addressed link spans (`chash:<hex>`); `nx t3 reidentify` natural-ID source (first 32 chars); cross-collection chunk dedup |
+| `chunk_text_hash[:32]` | chunk | first 32 chars of the SHA | `nx t3 reidentify` upsert (RDR-108 Phase 2) | Chroma natural ID for the chunk; the join key from `document_chunks.chash` |
+| `source_uri` | document | `file://...` or `x-devonthink-item://<uuid>` etc. | indexer / MCP write paths | persistent URI identity; aspect-extraction routing; audit-membership home detection |
+| `source_path` | document | absolute or repo-relative file path | indexer | display + grep targets; legacy path predating `source_uri` |
+| `chunk_start_char` / `chunk_end_char` | chunk | char offsets in the source file | indexer per chunk | `chunk:char` span resolution; UI highlight |
+| `section_title` / `section_type` | chunk | tree-sitter / Markdown section header | code/prose chunkers | search-time filtering (`section_type!=references`) |
+| `embedding_model` | document | model id string | every write through `T3Database` | `voyage-code-3` vs `voyage-context-3` routing; quota validation |
+
+`doc_id`, `chunk_index`, and `chunk_count` were ALSO chunk-level metadata pre-RDR-108. RDR-108 Phase 3 retired them; the catalog `document_chunks` manifest is the single source of truth for chunk position within a document. Read paths that need chunk order consult `Catalog.get_manifest(doc_id)` (see `_attach_doc_ids_from_catalog` in `search_engine.py` for the standard fallback).
+
+Legacy fields (`corpus`, `store_type`, `extraction_method`, `expires_at`) were dropped in RDR-101 Phase 5c. They are not present in current writes; older collections still carry them as cargo until `nx t3 reidentify` runs the canonical-schema funnel and normalizes them away.
+
+For operator runbooks built on this vocabulary see [`docs/operations/t3-health.md`](operations/t3-health.md) (when `nx catalog doctor` reports X) and [`docs/operations/audit-membership-interpretation.md`](operations/audit-membership-interpretation.md) (the 3 contamination axes).
+
 ### Catalog manifest as authoritative doc structure (RDR-108)
 
 The catalog `document_chunks` table is the authoritative graph layer of the git/IPFS-style blob+tree split that addresses document identity:

--- a/docs/operations/audit-membership-interpretation.md
+++ b/docs/operations/audit-membership-interpretation.md
@@ -1,0 +1,63 @@
+# Interpreting `nx catalog audit-membership` output
+
+`audit-membership` reports per-collection contamination signals: how many distinct "homes" the collection's documents come from. A clean collection has one home (one repo, one curator import directory, one DEVONthink database). A contaminated collection has 2+, and the verb flags it.
+
+But "contamination" lumps together three structurally different situations. Knowing which axis you're on tells you whether to act, and how.
+
+## The three axes
+
+### Axis 1: true cross-project leak
+
+A document genuinely registered in the wrong collection. The 2026-05-08 prod probe's canonical example: tumbler `1.653.2` (`SOVEREIGN2-Grossberg2019.pdf`, content_type=paper, owner=papers curator) registered into `knowledge__knowledge` instead of `knowledge__art-grossberg-papers__voyage-context-3__v1`. `knowledge__knowledge` is reserved for MCP-stored knowledge notes (content_type=knowledge); a paper row there violates the content-type-vs-collection invariant.
+
+**Detection signal**: a single document whose `physical_collection` doesn't match the curator's owned collection. The audit shows the collection as having 2+ homes when "homes" is computed at the source-URI / repo-root level.
+
+**Action**: `nx catalog show <tumbler>` to confirm; `nx catalog delete <tumbler>` (4.29.1 backup-before-delete makes this reversible); re-index the source into the right collection. Add a regression test asserting the invariant (e.g. `tests/test_catalog_papers_curator_isolation.py` for the papers/knowledge case).
+
+### Axis 2: self-marker noise
+
+A collection-creation artifact row with `chunk_count=0` and empty `source_uri`. These are placeholder documents that the indexer or operator created when the collection was first registered, and they never received any actual chunks. They flip the audit's "distinct homes" count from 1 to 2 because the empty-URI bucket counts as its own home.
+
+**Detection signal**: the second home is the empty-URI bucket; the document has `chunk_count=0`. There are usually 1-3 of these per affected collection.
+
+**Action**: `nx catalog delete <tumbler>` to sweep. The 2026-05-08 shakeout cleaned 13 such rows under bead `nexus-4yfr` (all `chunk_count=0`, all confirmed safe via the bead's pre-audit). Reversible via `nx catalog undelete`.
+
+### Axis 3: multi-source corpus
+
+A collection that is intentionally fed from more than one home. Common shapes:
+
+- A `knowledge__art-grossberg-papers` collection that imports from BOTH a DEVONthink database AND a `~/git/ART/SOVEREIGN-papers/` directory; both are legitimate "homes" for the curator.
+- A `code__workspace-XXX` collection that scans multiple repo roots under one workspace umbrella.
+
+**Detection signal**: 2+ homes, all of them legitimate (real source URIs, real `chunk_count > 0`); none match the cross-project-leak shape (wrong content_type, wrong owner).
+
+**Action**: ignore. Optionally suppress by adding the collection to an allow-list once the audit verb supports one (not yet shipped; track under future operator UX work).
+
+## How to triage in practice
+
+For each collection the audit flags:
+
+1. Open the collection's documents:
+   ```
+   nx catalog list --collection <name>
+   ```
+2. Check the home of each: count distinct `source_uri` after collapsing DEVONthink UUIDs (per `nexus-n3md` the `_DEVONTHINK_HOME_KEY` sentinel does this) and excluding the empty-URI bucket.
+3. If any document has `chunk_count=0` AND empty `source_uri`: axis 2, delete it.
+4. If any document's `content_type` doesn't match the curator's expectation (e.g. content_type=paper in knowledge__knowledge): axis 1, delete + re-index into the right collection.
+5. Anything left over with 2+ legitimate non-empty homes and `chunk_count > 0`: axis 3, fine.
+
+## Worked example: 2026-05-08 shakeout
+
+The verb flagged 15 collections as contaminated. After applying the three-axis decomposition:
+
+- **Axis 1 (true leak)**: 1 collection (`knowledge__knowledge`, the SOVEREIGN2 misregister). Filed `nexus-frai`, prod data fix run 2026-05-10, regression test added.
+- **Axis 2 (self-marker)**: 13 collections, 13 rows total. Filed `nexus-4yfr`, swept 2026-05-10.
+- **Axis 3 (multi-source)**: 2 collections (`knowledge__art-grossberg-papers`, `knowledge__rag-papers`). Pre-fix the audit reported 110+ homes for the first because every DEVONthink UUID was a distinct home; `nexus-n3md` (PR #662) collapsed them so the audit now reports the 4 logical roots.
+
+Net: the audit went from "15 contaminated" to "0 contaminated" once each axis was handled with the right verb.
+
+## Cross-references
+
+- [`t3-health.md`](t3-health.md) for the `nx catalog doctor` runbook.
+- [`../architecture.md`](../architecture.md) § Metadata field semantics for `content_hash` vs `chunk_text_hash`, `source_uri` vs `source_path`.
+- Beads: `nexus-frai` (axis 1 example + regression test), `nexus-4yfr` (axis 2 sweep), `nexus-n3md` (DEVONthink home-key fix), `nexus-fntl` (axis 3 partially-resolved).

--- a/docs/operations/t3-health.md
+++ b/docs/operations/t3-health.md
@@ -1,0 +1,71 @@
+# T3 health runbook
+
+When `nx catalog doctor` reports something concerning, this page tells you whether the report is a real problem or a known false-positive class. Each section starts with the symptom (what the doctor says) and ends with the action (do this, or ignore and add `# noise` to the noise list).
+
+The doctor is intentionally conservative: it favors WARN over silent pass. Several reported classes are operationally fine, OR are surfacing pre-existing data drift that the architecture has since obviated. Knowing which is which saves 30 minutes of forensics per investigation.
+
+## `--collections-drift`
+
+### Symptom: `T3 collections without projection rows (N)`
+
+T3 has a collection that the catalog `collections` projection table doesn't know about.
+
+**Cause**: indexer or MCP write created the T3 collection, but the catalog hook either failed silently or hasn't run yet.
+
+**Action**: `nx catalog backfill-collections --no-dry-run`. Idempotent; safe to run any time. After the verb the projection has one row per T3 collection, drift count drops to 0.
+
+### Symptom: `Projection rows whose T3 collection is gone and not superseded (N)`
+
+The catalog has a collection row, but T3 doesn't have a matching collection.
+
+**Cause**: a T3 collection was deleted (manual `nx collection delete`, or chromadb-side housekeeping) without going through `Catalog.supersede_collection`.
+
+**Action**: operator decision. If the documents that referenced this collection are still real, re-create the T3 collection by re-indexing the source files. If they're stale, either delete the catalog rows (`nx catalog delete <tumbler>`) or supersede the collection projection row to a known target via the manual Python snippet the doctor prints. There is no automated fix for this class because the right answer depends on whether the source data still exists.
+
+## `--t3-doc-id-coverage`
+
+### Symptom: `WARN: <collection> orphan_ratio=100.00%` for every collection
+
+Most collections show 100% orphan ratio.
+
+**Cause**: post-RDR-108 architecture removed `doc_id` from chunk metadata; the catalog `document_chunks` manifest is the authoritative position record. Collections where chunks lack `doc_id` AND lack a manifest entry are the genuine orphan class. The 100% ratios you see are usually historical synthesized-orphan events from the retired Phase 5b verb, not live drift.
+
+**Action**: ignore unless `--strict-not-in-t3` flips the check to FAIL. The doctor's manifest-fallback path (`nexus-esrl`) resolves chunks via `chash -> doc_id` from the catalog manifest, so a chunk that has `chunk_text_hash` AND a manifest row counts as covered.
+
+### Symptom: `taxonomy__centroids` reports a high orphan count
+
+**Cause**: `taxonomy__*` collections are bypass-schema. Centroids carry `{topic_id, label, doc_count, collection}` metadata; there is no `doc_id` by design (centroids are not documents; they're embedding-space anchors per RDR-070).
+
+**Action**: ignore. As of `nexus-wszt` (PR #653) the doctor skips bypass-schema collections from this audit. If you see them in current output, your `nx` is older than 4.30; upgrade.
+
+## `--replay-equality`
+
+### Symptom: `collections live=N projected=M` with timestamp diffs in the diff section
+
+`created_at` differs between live SQLite and the projected replay.
+
+**Cause**: pre-`nexus-33xm` (PR #654) the auto-bootstrap stamped `created_at = NOW()` while the synthetic `CollectionCreated` event carried `created_at = ""`. The projector's COALESCE preserved the NOW stamp on live but the replay started empty and took the synthetic empty string. Persistent drift on every run.
+
+**Action**: upgrade to 4.30+. The fix lands `created_at = ""` on both sides; `--replay-equality` then PASSes for auto-bootstrapped collections.
+
+### Symptom: `events_applied: <huge>` followed by tabletype-specific FAIL
+
+A specific table type (owners / documents / links / collections) shows a count or row mismatch.
+
+**Cause**: real data drift. Either a direct SQLite write bypassed the projector chain (filed under epsilon-allow review), or a projector handler version is stale.
+
+**Action**: `--json` for the structured payload, share with maintainers. Do NOT run `--rebuild` until the source of the divergence is identified; rebuilding from the event log silently overwrites whichever side was wrong.
+
+## False-positive classes the doctor knows about
+
+The doctor pre-skips these:
+
+- **`taxonomy__*` collections**: bypass-schema (RDR-070 centroids). Excluded from `--t3-doc-id-coverage`, `--collections-drift` projection scan, and `nx catalog backfill-collections`.
+- **`x-devonthink-item://` source URIs**: collapsed to a single home bucket (`nexus-n3md` PR #662). Pre-fix every UUID-netlocked DEVONthink import looked like its own home; post-fix the audit treats them as one logical curator.
+- **Empty `source_uri` rows**: knowledge notes (MCP-stored, no source file) bucket separately so they can't flip a small clean collection to "contaminated" via a single self-marker row.
+
+## Useful follow-ups
+
+- For the audit-membership three-axis interpretation: [`audit-membership-interpretation.md`](audit-membership-interpretation.md).
+- For the post-Phase-3 metadata field semantics (chunk vs document level, `content_hash` vs `chunk_text_hash`): [`../architecture.md`](../architecture.md) § Metadata field semantics.
+- Beads referenced above: `nexus-wszt`, `nexus-33xm`, `nexus-esrl`, `nexus-n3md`. Each carries the full prod-probe context from the 2026-05-08 shakeout.


### PR DESCRIPTION
## Summary

Three doc additions saving 30 minutes of forensics per investigator:

1. ``docs/architecture.md`` § Metadata field semantics — locks ``content_hash`` (document-level) vs ``chunk_text_hash`` (chunk-level) plus 7 other commonly-confused fields.
2. ``docs/operations/t3-health.md`` (new) — ``nx catalog doctor`` runbook by symptom -> cause -> action.
3. ``docs/operations/audit-membership-interpretation.md`` (new) — the 3 contamination axes (true leak / self-marker / multi-source) with the 2026-05-08 worked example.

## Closes

- nexus-gndj