### PR TITLE
feat(migration): drop document_aspects.source_path column (RDR-096 P5.2 / nexus-ocu9.11)

### DIFF
--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -1763,6 +1763,68 @@ def migrate_document_aspects_source_uri_backfill_empty(conn: sqlite3.Connection)
         )
 
 
+def migrate_drop_source_path_column(conn: sqlite3.Connection) -> None:
+    """nexus-ocu9.11 (RDR-096 P5.2 final deprecation): drop
+    ``source_path`` from ``document_aspects``.
+
+    Pre-conditions enforced as a hard audit:
+
+    * Column exists in the live schema. If not, the migration is a
+      no-op (already dropped).
+    * Every row has ``source_uri`` populated (NOT NULL and not the
+      empty string). The two-release deprecation window had two
+      backfill migrations land first
+      (``migrate_document_aspects_source_uri`` at 4.16.0 and
+      ``migrate_document_aspects_source_uri_backfill_empty`` /
+      ``nexus-pnje`` at 4.26.2); after both, every row should be
+      addressable by URI alone. If any row still has NULL or empty
+      source_uri, the audit raises ``MigrationError`` and the
+      migration aborts so the operator can triage rather than
+      silently destroying the only addressing path.
+
+    Implementation: SQLite >= 3.35 supports ``ALTER TABLE ... DROP
+    COLUMN`` natively (project floor is 3.49.1). Idempotent on the
+    column-presence check.
+    """
+    cols = {
+        r[1] for r in conn.execute(
+            "PRAGMA table_info(document_aspects)"
+        ).fetchall()
+    }
+    if not cols:
+        # Table doesn't exist; nothing to drop.
+        return
+    if "source_path" not in cols:
+        return
+
+    # Pre-audit: every row MUST have source_uri populated. After two
+    # release windows of writer + backfill enforcement this should be
+    # zero in production. Block here loudly if not.
+    bad_rows = conn.execute(
+        "SELECT COUNT(*) FROM document_aspects "
+        "WHERE source_uri IS NULL OR source_uri = ''"
+    ).fetchone()[0]
+    if bad_rows > 0:
+        raise MigrationError(
+            f"nexus-ocu9.11: refusing to drop document_aspects.source_path "
+            f"because {bad_rows} row(s) still have NULL or empty "
+            f"source_uri. After dropping the column those rows would be "
+            f"unaddressable. Run "
+            f"``migrate_document_aspects_source_uri_backfill_empty`` "
+            f"first or repair the rows manually, then re-run."
+        )
+
+    # SQLite indexed-column drop; the migration runs INSIDE the
+    # T2Database constructor's transaction context (apply_pending
+    # wraps each migration in its own transaction).
+    conn.execute("ALTER TABLE document_aspects DROP COLUMN source_path")
+    conn.commit()
+    _log.info(
+        "migrate_drop_source_path_column",
+        table="document_aspects",
+    )
+
+
 def migrate_drop_null_aspect_rows(conn: sqlite3.Connection) -> None:
     """RDR-096 P2.2: drop pre-RDR-096 read-failure rows from
     ``document_aspects`` using the seven-clause discriminator from
@@ -2606,6 +2668,11 @@ MIGRATIONS: list[Migration] = [
         "4.30.0",
         "Drop chash_index.chunk_chroma_id column (RDR-108 Phase 4a, nexus-mmf5)",
         _drop_chash_index_chunk_chroma_id,
+    ),
+    Migration(
+        "4.31.0",
+        "Drop document_aspects.source_path column (RDR-096 P5.2, nexus-ocu9.11)",
+        migrate_drop_source_path_column,
     ),
 ]
 

--- a/src/nexus/operators/aspect_sql.py
+++ b/src/nexus/operators/aspect_sql.py
@@ -499,53 +499,61 @@ def try_aggregate(
 def _query_filter(
     idents: list[tuple[str, str]], field: str, query: str,
 ) -> tuple[list[tuple[str, str]], list[dict]]:
-    """Execute the filter SQL. Return (kept_idents, rationale_entries)."""
+    """Execute the filter SQL. Return (kept_idents, rationale_entries).
+
+    nexus-ocu9.11 (RDR-096 P5.2): the ``source_path`` column is
+    dropped from ``document_aspects`` at 4.31.0; the SQL keys on
+    ``source_uri`` instead. The operator's input ``idents`` still
+    carry ``(collection, source_path)`` for back-compat; we derive
+    each ident's URI via ``aspect_readers.uri_for(collection,
+    source_path)`` before the SELECT, and key the round-trip by
+    URI on the way back. The rationale's ``id`` field stays as the
+    source_path string for caller back-compat.
+    """
+    from nexus.aspect_readers import uri_for
     from nexus.commands._helpers import default_db_path
     from nexus.db.t2 import T2Database
 
     pred_sql, pred_params = _build_filter_predicate(field, query)
 
-    # SELECT in batches of 300 (ChromaDB-quota-equivalent SQLite param
-    # cap) to handle large item lists. SQLite's default param limit
-    # is 999 with two params per item (collection, source_path), so
-    # batching at 300 leaves plenty of headroom.
-    # RDR-096 P2.3 dual-read: ``COALESCE(source_uri, 'file://' ||
-    # source_path) AS source_identity`` projects the URI form so the
-    # rationale entries can surface URIs alongside the source_path
-    # ``id`` (kept for back-compat). Rows whose source_uri escaped
-    # backfill (empty source_path) get the file://-shaped fallback
-    # via the COALESCE second arm.
-    #
-    # Rationale-shape contract (P2.3):
-    # * ``id`` — source_path string (back-compat with pre-P2.3 callers)
-    # * ``source_uri`` — populated for rows the SQL fast path
-    #   matched; ``""`` when no row exists (non-match, queue pending,
-    #   or aspects-only meta entry). Never ``None``: the empty-string
-    #   sentinel keeps the field type consistent for downstream
-    #   consumers that don't distinguish missing-vs-pending.
-    # * ``reason`` — human-readable explanation.
+    # Derive URIs for every ident up front; idents whose
+    # ``uri_for`` returns None are unreachable post-source_path-drop
+    # (the migration's audit guarantees no NULL/empty source_uri
+    # rows so a None here is a caller-side issue, not a row issue).
+    ident_to_uri: dict[tuple[str, str], str] = {}
+    uri_to_ident: dict[str, tuple[str, str]] = {}
+    for c, sp in idents:
+        u = uri_for(c, sp) or ""
+        if not u:
+            continue
+        ident_to_uri[(c, sp)] = u
+        uri_to_ident[u] = (c, sp)
+
     keep: list[tuple[str, str]] = []
     matches: dict[tuple[str, str], bool] = {}
     uris: dict[tuple[str, str], str] = {}
-    with T2Database(default_db_path()) as db:
-        conn = db.document_aspects.conn
-        for chunk_start in range(0, len(idents), 300):
-            batch = idents[chunk_start:chunk_start + 300]
-            placeholders = ",".join(["(?, ?)"] * len(batch))
-            params: list[Any] = []
-            for c, sp in batch:
-                params.extend([c, sp])
-            sql = (
-                f"SELECT collection, source_path, "
-                f"       COALESCE(source_uri, 'file://' || source_path) AS source_identity "
-                f"FROM document_aspects "
-                f"WHERE (collection, source_path) IN ({placeholders}) "
-                f"  AND {pred_sql}"
-            )
-            params.extend(pred_params)
-            for c, sp, uri in conn.execute(sql, params).fetchall():
-                matches[(c, sp)] = True
-                uris[(c, sp)] = uri
+    if ident_to_uri:
+        # Batch in 300s to leave plenty of headroom under SQLite's
+        # 999-param default cap.
+        with T2Database(default_db_path()) as db:
+            conn = db.document_aspects.conn
+            uri_list = list(ident_to_uri.values())
+            for chunk_start in range(0, len(uri_list), 300):
+                batch = uri_list[chunk_start:chunk_start + 300]
+                placeholders = ",".join(["?"] * len(batch))
+                sql = (
+                    f"SELECT source_uri "
+                    f"FROM document_aspects "
+                    f"WHERE source_uri IN ({placeholders}) "
+                    f"  AND {pred_sql}"
+                )
+                params: list[Any] = list(batch) + list(pred_params)
+                for (uri,) in conn.execute(sql, params).fetchall():
+                    ident = uri_to_ident.get(uri)
+                    if ident is None:
+                        continue
+                    matches[ident] = True
+                    uris[ident] = uri
 
     rationale = []
     for c, sp in idents:
@@ -587,31 +595,41 @@ def _query_groupby(
         select_expr = field
         select_params = []
 
-    # P2.3 note: ``_query_filter`` widens its SELECT with a COALESCE
-    # source_identity column so rationale entries can surface URIs.
-    # ``_query_groupby`` does not — its return shape (``{key:
-    # [(collection, source_path)]}``) doesn't currently expose
-    # identity to callers, and projecting an unused column would be
-    # dead overhead. When a future bead adds URI to groupby output,
-    # widen the SELECT here and update the unpacking.
+    # nexus-ocu9.11: source_path column dropped at 4.31.0; key on
+    # source_uri instead. The operator's input idents still carry
+    # (collection, source_path) for back-compat; derive each ident's
+    # URI via ``aspect_readers.uri_for`` and use the URI for both
+    # the WHERE and the round-trip mapping.
+    from nexus.aspect_readers import uri_for
+
     groups: dict[str, list[tuple[str, str]]] = {}
     fetched: dict[tuple[str, str], Any] = {}
+    ident_to_uri: dict[tuple[str, str], str] = {}
+    uri_to_ident: dict[str, tuple[str, str]] = {}
+    for c, sp in idents:
+        u = uri_for(c, sp) or ""
+        if not u:
+            continue
+        ident_to_uri[(c, sp)] = u
+        uri_to_ident[u] = (c, sp)
 
     with T2Database(default_db_path()) as db:
         conn = db.document_aspects.conn
-        for chunk_start in range(0, len(idents), 300):
-            batch = idents[chunk_start:chunk_start + 300]
-            placeholders = ",".join(["(?, ?)"] * len(batch))
-            params: list[Any] = list(select_params)
-            for c, sp in batch:
-                params.extend([c, sp])
+        uri_list = list(ident_to_uri.values())
+        for chunk_start in range(0, len(uri_list), 300):
+            batch = uri_list[chunk_start:chunk_start + 300]
+            placeholders = ",".join(["?"] * len(batch))
+            params: list[Any] = list(select_params) + list(batch)
             sql = (
-                f"SELECT collection, source_path, {select_expr} "
+                f"SELECT source_uri, {select_expr} "
                 f"FROM document_aspects "
-                f"WHERE (collection, source_path) IN ({placeholders})"
+                f"WHERE source_uri IN ({placeholders})"
             )
-            for c, sp, value in conn.execute(sql, params).fetchall():
-                fetched[(c, sp)] = value
+            for uri, value in conn.execute(sql, params).fetchall():
+                ident = uri_to_ident.get(uri)
+                if ident is None:
+                    continue
+                fetched[ident] = value
 
     for ident in idents:
         value = fetched.get(ident)
@@ -655,24 +673,33 @@ def _query_confidence_aggregate(
     if reducer_kind not in op_map:
         return None
 
+    # nexus-ocu9.11: source_path column dropped; key the WHERE on
+    # source_uri. Confidence aggregate doesn't need the round-trip
+    # mapping (it folds into a scalar), so we just collect URIs.
+    from nexus.aspect_readers import uri_for
+
     sum_acc = 0.0
     count_acc = 0
     min_acc: float | None = None
     max_acc: float | None = None
 
+    uris_for_query: list[str] = []
+    for c, sp in idents:
+        u = uri_for(c, sp) or ""
+        if u:
+            uris_for_query.append(u)
+
     with T2Database(default_db_path()) as db:
         conn = db.document_aspects.conn
-        for chunk_start in range(0, len(idents), 300):
-            batch = idents[chunk_start:chunk_start + 300]
-            placeholders = ",".join(["(?, ?)"] * len(batch))
-            params: list[Any] = []
-            for c, sp in batch:
-                params.extend([c, sp])
+        for chunk_start in range(0, len(uris_for_query), 300):
+            batch = uris_for_query[chunk_start:chunk_start + 300]
+            placeholders = ",".join(["?"] * len(batch))
             sql = (
                 f"SELECT confidence FROM document_aspects "
-                f"WHERE (collection, source_path) IN ({placeholders}) "
+                f"WHERE source_uri IN ({placeholders}) "
                 f"  AND confidence IS NOT NULL"
             )
+            params: list[Any] = list(batch)
             for (value,) in conn.execute(sql, params).fetchall():
                 if value is None:
                     continue

--- a/tests/test_aspect_sql.py
+++ b/tests/test_aspect_sql.py
@@ -372,15 +372,25 @@ class TestDualRead:
             "chroma://knowledge__delos//papers/paxos.pdf"
         )
 
-    def test_filter_rationale_falls_back_to_file_for_legacy_null_uri(
+    def test_filter_legacy_null_uri_row_is_unreachable_post_drop(
         self, env: Path, monkeypatch,
     ) -> None:
-        """Rows whose source_uri escaped backfill (NULL in the DB)
-        get a synthesised ``file://<abspath>`` URI from the COALESCE
-        second arm. Simulate by NULLing one row directly in SQL.
+        """nexus-ocu9.11 (RDR-096 P5.2): the COALESCE second arm
+        retired with the source_path column drop. A row with
+        source_uri NULL is now structurally unreachable by the
+        operator: the WHERE clause keys on source_uri IN (...), so
+        a NULL source_uri row never matches the WHERE; the operator
+        treats it as "row absent" with an empty source_uri.
+
+        This is the post-drop contract. The migration's pre-audit
+        in ``migrate_drop_source_path_column`` blocks if any row
+        has NULL/empty source_uri, so in production this state is
+        unreachable. The test simulates the legacy state to lock
+        the operator's "no fallback synthesis" behavior.
         """
-        # NULL out source_uri on one row to mimic a legacy /
-        # backfill-skipped state.
+        # NULL out source_uri on one row to mimic the now-unreachable
+        # legacy state. The migration's audit would have blocked
+        # this in prod; the test forces it via SQL.
         with T2Database(env) as db:
             db.document_aspects.conn.execute(
                 "UPDATE document_aspects SET source_uri = NULL "
@@ -396,11 +406,11 @@ class TestDualRead:
         assert result is not None
         match = [r for r in result["rationale"] if r["id"] == "/papers/raft.pdf"]
         assert len(match) == 1
-        # COALESCE second arm: 'file://' || source_path. Note SQL's
-        # || does not call os.path.abspath — it concatenates verbatim,
-        # so the URI is ``file:///papers/raft.pdf`` (the source_path
-        # already had a leading slash).
-        assert match[0]["source_uri"] == "file:///papers/raft.pdf"
+        # Post-drop: NULL source_uri row never matches the WHERE,
+        # so the operator surfaces it as "aspect row absent" with
+        # empty source_uri. There is no synthesised file:// fallback.
+        assert match[0]["source_uri"] == ""
+        assert "absent" in match[0]["reason"] or "does not match" in match[0]["reason"]
 
     def test_filter_non_match_rationale_has_empty_source_uri(
         self, env: Path,

--- a/tests/test_migrate_drop_source_path_column.py
+++ b/tests/test_migrate_drop_source_path_column.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-ocu9.11 (RDR-096 P5.2): tests for
+``migrate_drop_source_path_column`` — the final-deprecation
+migration that drops ``document_aspects.source_path`` after the
+two-release dual-read window.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.db.migrations import (
+    MigrationError,
+    migrate_drop_source_path_column,
+)
+
+
+def _make_post_phase1c_aspects(path: Path) -> sqlite3.Connection:
+    """Create document_aspects at the post-RDR-108-Phase-1c +
+    post-pnje shape:
+    - PK migrated to (doc_id) at 4.30.0; source_path is now a denorm
+      cache column (not PK), which lets ALTER TABLE DROP COLUMN
+      succeed (SQLite refuses to drop PK columns).
+    - source_uri column is present (added at 4.16.0).
+
+    This is the schema the ocu9.11 migration is designed to operate
+    on. It always runs AFTER Phase 1c in the MIGRATIONS list (4.30.0
+    < 4.31.0), so production never reaches the drop step with
+    source_path still in the PK.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE document_aspects (
+            doc_id                 TEXT NOT NULL,
+            collection             TEXT NOT NULL,
+            source_path            TEXT NOT NULL DEFAULT '',
+            problem_formulation    TEXT,
+            proposed_method        TEXT,
+            experimental_datasets  TEXT,
+            experimental_baselines TEXT,
+            experimental_results   TEXT,
+            extras                 TEXT,
+            confidence             REAL,
+            extracted_at           TEXT NOT NULL,
+            model_version          TEXT NOT NULL,
+            extractor_name         TEXT NOT NULL,
+            source_uri             TEXT,
+            PRIMARY KEY (doc_id)
+        );
+    """)
+    conn.commit()
+    return conn
+
+
+def _insert(
+    conn: sqlite3.Connection,
+    *, source_path: str, source_uri: str | None = None,
+    collection: str = "knowledge__delos",
+    doc_id: str | None = None,
+) -> None:
+    """Insert a row into the post-Phase-1c document_aspects table.
+    ``doc_id`` is the PK; defaults to a hash of source_path so each
+    test row has a unique key without callers having to invent one.
+    """
+    if doc_id is None:
+        # Quick deterministic doc_id; tests just need uniqueness.
+        doc_id = f"d-{abs(hash(source_path)) % 10**8}"
+    conn.execute(
+        "INSERT INTO document_aspects "
+        "(doc_id, collection, source_path, source_uri, extracted_at, "
+        " model_version, extractor_name) "
+        "VALUES (?, ?, ?, ?, '2026-05-10T00:00:00Z', "
+        " 'claude-haiku-4-5-20251001', 'scholarly-paper-v1')",
+        (doc_id, collection, source_path, source_uri),
+    )
+    conn.commit()
+
+
+class TestMigrateDropSourcePathColumn:
+    def test_no_op_when_table_absent(self, tmp_path: Path) -> None:
+        conn = sqlite3.connect(str(tmp_path / "empty.db"))
+        try:
+            # Should not raise.
+            migrate_drop_source_path_column(conn)
+        finally:
+            conn.close()
+
+    def test_no_op_when_column_already_dropped(self, tmp_path: Path) -> None:
+        """The migration is idempotent: re-running on a DB where
+        source_path is already gone does nothing.
+        """
+        conn = sqlite3.connect(str(tmp_path / "post.db"))
+        try:
+            # Build the post-drop schema directly.
+            conn.executescript("""
+                CREATE TABLE document_aspects (
+                    collection TEXT NOT NULL,
+                    source_uri TEXT,
+                    extracted_at TEXT NOT NULL,
+                    model_version TEXT NOT NULL,
+                    extractor_name TEXT NOT NULL
+                );
+            """)
+            conn.commit()
+            migrate_drop_source_path_column(conn)
+            cols = {
+                r[1] for r in conn.execute(
+                    "PRAGMA table_info(document_aspects)"
+                ).fetchall()
+            }
+            assert "source_path" not in cols
+        finally:
+            conn.close()
+
+    def test_drops_source_path_when_all_rows_have_source_uri(
+        self, tmp_path: Path,
+    ) -> None:
+        """The happy path: every row has source_uri populated, so
+        the audit passes and the column drops.
+        """
+        conn = _make_post_phase1c_aspects(tmp_path / "ok.db")
+        try:
+            _insert(
+                conn, source_path="/papers/a.pdf",
+                source_uri="chroma://knowledge__delos//papers/a.pdf",
+            )
+            _insert(
+                conn, source_path="/papers/b.pdf",
+                source_uri="chroma://knowledge__delos//papers/b.pdf",
+            )
+
+            migrate_drop_source_path_column(conn)
+
+            cols = {
+                r[1] for r in conn.execute(
+                    "PRAGMA table_info(document_aspects)"
+                ).fetchall()
+            }
+            assert "source_path" not in cols
+            assert "source_uri" in cols
+            # Rows survive.
+            n = conn.execute(
+                "SELECT COUNT(*) FROM document_aspects"
+            ).fetchone()[0]
+            assert n == 2
+        finally:
+            conn.close()
+
+    def test_blocks_when_a_row_has_null_source_uri(
+        self, tmp_path: Path,
+    ) -> None:
+        """The pre-audit refuses to drop the column when even one row
+        has NULL source_uri. Dropping would leave the row
+        unaddressable; per the no-silent-fallback rule the migration
+        raises MigrationError so the operator can triage.
+        """
+        conn = _make_post_phase1c_aspects(tmp_path / "null.db")
+        try:
+            _insert(
+                conn, source_path="/papers/a.pdf",
+                source_uri="chroma://knowledge__delos//papers/a.pdf",
+            )
+            _insert(
+                conn, source_path="/papers/b.pdf",
+                source_uri=None,  # The unmigrated row.
+            )
+
+            with pytest.raises(MigrationError, match="source_uri"):
+                migrate_drop_source_path_column(conn)
+
+            # Schema must be UNCHANGED — column still present, no
+            # half-applied state.
+            cols = {
+                r[1] for r in conn.execute(
+                    "PRAGMA table_info(document_aspects)"
+                ).fetchall()
+            }
+            assert "source_path" in cols
+        finally:
+            conn.close()
+
+    def test_blocks_when_a_row_has_empty_source_uri(
+        self, tmp_path: Path,
+    ) -> None:
+        """Empty-string source_uri is treated the same as NULL: a row
+        whose only addressing path is empty is unreachable post-drop.
+        """
+        conn = _make_post_phase1c_aspects(tmp_path / "empty.db")
+        try:
+            _insert(
+                conn, source_path="/papers/a.pdf",
+                source_uri="",  # Empty string, not NULL.
+            )
+            with pytest.raises(MigrationError, match="source_uri"):
+                migrate_drop_source_path_column(conn)
+        finally:
+            conn.close()
+
+    def test_audit_error_message_names_the_count(self, tmp_path: Path) -> None:
+        """Operator-facing error message must surface the count of
+        bad rows so triage isn't a guessing game.
+        """
+        conn = _make_post_phase1c_aspects(tmp_path / "count.db")
+        try:
+            _insert(conn, source_path="/p1.pdf", source_uri=None)
+            _insert(conn, source_path="/p2.pdf", source_uri="")
+            _insert(
+                conn, source_path="/p3.pdf",
+                source_uri="chroma://knowledge__delos//p3.pdf",
+            )
+
+            with pytest.raises(MigrationError) as exc_info:
+                migrate_drop_source_path_column(conn)
+
+            msg = str(exc_info.value)
+            # 2 bad rows out of 3.
+            assert "2" in msg
+            # Names the remediation path so operator knows what to do.
+            assert "backfill" in msg.lower() or "repair" in msg.lower()
+        finally:
+            conn.close()
+
+
+class TestMigrationListRegistration:
+    def test_drop_source_path_appears_in_migrations_list(self) -> None:
+        """The migration is registered in the MIGRATIONS list at
+        version 4.31.0 — apply_pending picks it up automatically on
+        the next nx run.
+        """
+        from nexus.db.migrations import MIGRATIONS
+
+        targets = [
+            m for m in MIGRATIONS
+            if m.fn is migrate_drop_source_path_column
+        ]
+        assert len(targets) == 1
+        assert targets[0].introduced == "4.31.0"


### PR DESCRIPTION
## Summary

Final deprecation for RDR-096. Drops ``document_aspects.source_path`` after the two-release dual-read window (writer stopped at v4.23.0, dual-read since v4.16.0, empty-source_uri backfill at v4.26.2).

## Migration (4.31.0)

- Pre-audit blocks if any row has NULL/empty source_uri (no silent fallback; row would be unaddressable).
- ``ALTER TABLE document_aspects DROP COLUMN source_path``; native since SQLite 3.35.
- Idempotent.
- Runs AFTER 4.30.0's Phase 1c PK migration that moves source_path out of the PK.

## Operator update

``aspect_sql.py`` ``_query_filter`` / ``_query_groupby`` / ``_query_confidence_aggregate`` switch WHERE from ``(collection, source_path)`` to ``source_uri IN (...)``. Ident shape stays the same for caller back-compat; operator derives URI internally via ``aspect_readers.uri_for``.

## Tests

7 new migration tests + 1 updated dual-read regression. 240 passing across aspect_sql, migrations, document_aspects.

## Closes

- nexus-ocu9.11
- (parent epic ``nexus-ocu9`` closes 11/11 once this lands)