### PR TITLE
fix(local-mode): collections named + stamped with local-EF token, not voyage-* (nexus-59vl / GH #667)

### DIFF
--- a/src/nexus/catalog/catalog_docs.py
+++ b/src/nexus/catalog/catalog_docs.py
@@ -30,6 +30,7 @@ from nexus.corpus import (
     CANONICAL_EMBEDDING_MODELS,
     CONTENT_TYPES,
     canonical_embedding_model,
+    effective_embedding_model_for_writes,
 )
 from nexus.registry import RepoRegistry, _repo_identity
 
@@ -382,7 +383,7 @@ class _DocumentOps:
         return cat.collection_for(
             content_type=content_type,
             owner=owner,
-            embedding_model=canonical_embedding_model(content_type),
+            embedding_model=effective_embedding_model_for_writes(content_type),
             bump=bump,
         )
 

--- a/src/nexus/catalog/consolidation.py
+++ b/src/nexus/catalog/consolidation.py
@@ -34,11 +34,11 @@ def merge_corpus(
     # strict-naming guard. The owner segment is the corpus tag with
     # underscores rewritten to hyphens (the conformant grammar's owner
     # segment disallows ``_``).
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
 
     owner_segment = corpus.replace("_", "-")
     target_col_name = (
-        f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+        f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
     )
 
     if dry_run:

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3106,11 +3106,11 @@ def consolidate_cmd(corpus: str, dry_run: bool) -> None:
         # RDR-103 Phase 5: mirror the conformant target shape that
         # ``merge_corpus`` will use when run for real so the dry-run
         # message reports the same name.
-        from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+        from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
 
         owner_segment = corpus.replace("_", "-")
         target = (
-            f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+            f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
         )
         click.echo(f"[dry-run] Would merge {result['would_merge']} collections into {target}:")
         for e in entries:

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -835,10 +835,10 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
         if collection:
             col_name = collection
         else:
-            from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+            from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
             owner_segment = corpus.replace("_", "-")
             col_name = (
-                f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+                f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
             )
         col = local_t3.get_or_create_collection(col_name)
         result = col.get(include=["documents", "metadatas"])

--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -50,10 +50,30 @@ CONTENT_TYPES: tuple[str, ...] = _CONTENT_TYPES
 RDR-103 ``<content_type>__<owner_id>__<embedding_model>__v<n>`` schema.
 ``CollectionName`` validates against this tuple."""
 
+# nexus-59vl (GH #667): local-EF tokens. The dim is part of the
+# token so a future local-EF swap that produces vectors of a
+# different dim cannot collide with an existing collection's name.
+LOCAL_EMBEDDING_MODELS: frozenset[str] = frozenset({
+    "minilm-l6-v2-384",
+    "bge-base-en-v15-768",
+})
+"""nexus-59vl: local-mode (ONNX / fastembed) tokens that may appear in
+the embedding-model segment of a conformant collection name. Distinct
+from the cloud Voyage tokens so local and cloud collections are
+structurally different physical entities; a local-mode collection
+remains queryable in cloud mode (the EF dispatch reads the segment to
+decide which embedder to build)."""
+
+# Mapping from local-EF model_name to canonical token.
+_LOCAL_MODEL_NAME_TO_TOKEN: dict[str, str] = {
+    "all-MiniLM-L6-v2": "minilm-l6-v2-384",
+    "BAAI/bge-base-en-v1.5": "bge-base-en-v15-768",
+}
+
 CANONICAL_EMBEDDING_MODELS: frozenset[str] = frozenset({
     "voyage-context-3",
     "voyage-code-3",
-})
+}) | LOCAL_EMBEDDING_MODELS
 """RDR-103 canonical-set guard. Any embedding-model segment NOT in this
 set is treated as legacy/unknown by ``CollectionName.parse``. Pinned
 decision #1: migrations use the indexer's CURRENT canonical model rather
@@ -61,7 +81,11 @@ than parsing the model out of the legacy collection name; allowing
 non-canonical models here would defeat that invariant. The
 ``_CONFORMANT_COLLECTION_RE`` regex stays permissive so legacy names
 remain readable as strings; canonical-set validation lives in
-``CollectionName.parse``."""
+``CollectionName.parse``.
+
+nexus-59vl (GH #667): includes the local-EF tokens in
+``LOCAL_EMBEDDING_MODELS`` so local-mode collection names are also
+canonical."""
 
 _CT_ALTERNATION = "|".join(_CONTENT_TYPES)
 _CONFORMANT_COLLECTION_RE = re.compile(
@@ -114,19 +138,55 @@ def parse_conformant_collection_name(name: str) -> dict[str, str]:
     }
 
 
-def canonical_embedding_model(content_type: str) -> str:
-    """Return the RDR-103 canonical embedding model for ``content_type``.
+def current_local_embedding_model_token() -> str:
+    """nexus-59vl: return the local-EF token that matches the
+    currently-active ``LocalEmbeddingFunction`` selection.
 
-    Single source of truth for the per-content-type model policy:
+    The local EF auto-selects between MiniLM (384d) and bge-base
+    (768d) based on whether ``fastembed`` is importable. This helper
+    consults the same selection so the canonical model token in
+    fresh collection names matches the actual EF that will write
+    into them.
+    """
+    from nexus.db.local_ef import LocalEmbeddingFunction  # noqa: PLC0415
+    ef = LocalEmbeddingFunction()
+    token = _LOCAL_MODEL_NAME_TO_TOKEN.get(ef.model_name)
+    if token is None:
+        # Defensive: an unknown local EF name shouldn't ship without
+        # also being added to LOCAL_EMBEDDING_MODELS. Surface loudly
+        # so the operator knows to extend the canonical set.
+        raise ValueError(
+            f"current_local_embedding_model_token: local EF "
+            f"model_name {ef.model_name!r} has no canonical token. "
+            f"Add it to ``_LOCAL_MODEL_NAME_TO_TOKEN`` and to "
+            f"``LOCAL_EMBEDDING_MODELS`` in nexus.corpus."
+        )
+    return token
+
+
+def canonical_embedding_model(content_type: str) -> str:
+    """Return the RDR-103 canonical (cloud) embedding model for
+    ``content_type``.
 
     - ``code`` to ``voyage-code-3``
     - ``docs`` / ``rdr`` / ``knowledge`` to ``voyage-context-3`` (CCE)
 
-    Raises ``ValueError`` for unknown content types so the caller does
-    not silently fall through to a wrong model.
-    ``Catalog.collection_for_repo`` uses this; legacy
-    :func:`voyage_model_for_collection` continues to dispatch off the
-    physical name for read paths.
+    This function is INTENTIONALLY mode-agnostic and returns the
+    cloud-canonical token unconditionally. It is the schema-level
+    function (used by tests, doc generation, and any caller that
+    asks "what is the cloud canonical for content_type X").
+
+    For write paths that need the EF token a fresh collection
+    name should embed (so local-mode names reflect the actual
+    on-disk EF), use :func:`effective_embedding_model_for_writes`
+    instead. That function is the mode-aware variant added by
+    nexus-59vl (GH #667) to fix the local-ONNX false-voyage-label
+    bug; it consults ``is_local_mode()`` and returns the local
+    token when appropriate, falling through to this function in
+    cloud mode.
+
+    Raises ``ValueError`` for unknown content types so the caller
+    does not silently fall through to a wrong model.
     """
     if content_type == "code":
         return "voyage-code-3"
@@ -138,17 +198,67 @@ def canonical_embedding_model(content_type: str) -> str:
     )
 
 
-def voyage_model_for_collection(collection_name: str) -> str:
-    """Return the Voyage AI model for a T3 collection (index and query).
+def effective_embedding_model_for_writes(content_type: str) -> str:
+    """nexus-59vl (GH #667): mode-aware EF token for WRITE paths.
 
-    The same model MUST be used at both index and query time —
+    In local mode returns the active local-EF token (e.g.
+    ``minilm-l6-v2-384`` or ``bge-base-en-v15-768``) so the
+    collection name a fresh write produces honestly reflects the
+    on-disk vector space. In cloud mode delegates to
+    :func:`canonical_embedding_model` for the existing voyage
+    token.
+
+    Pre-fix every write path called ``canonical_embedding_model``
+    directly and produced ``...__voyage-*__v1`` names even in local
+    mode, where the bytes are 384d MiniLM. Today cosmetic +
+    observability bug; on local -> cloud mode flip a query-time
+    correctness bug (1024d Voyage EF rejected against 384d MiniLM
+    vectors).
+
+    Used by the indexer + catalog write paths
+    (``Catalog.collection_for_repo`` / ``collection_for``,
+    ``indexer.py`` collection-name builders, ``doc_indexer.py``
+    PDF ingest). Read paths and tests of canonical schema continue
+    to call ``canonical_embedding_model`` directly.
+    """
+    from nexus.config import is_local_mode  # noqa: PLC0415
+
+    if content_type not in CONTENT_TYPES:
+        raise ValueError(
+            f"effective_embedding_model_for_writes: unknown "
+            f"content_type {content_type!r}; expected one of "
+            f"{CONTENT_TYPES}"
+        )
+    if is_local_mode():
+        return current_local_embedding_model_token()
+    return canonical_embedding_model(content_type)
+
+
+def voyage_model_for_collection(collection_name: str) -> str:
+    """Return the embedding model for a T3 collection (index and query).
+
+    The same model MUST be used at both index and query time;
     mismatched models yield random noise (RDR-059).
 
-    docs__/knowledge__/rdr__ → voyage-context-3 (CCE)
-    code__ and all others    → voyage-code-3
+    nexus-59vl (GH #667): the function reads the model directly from
+    the collection's name segment when the name is conformant and
+    the segment is a recognised canonical token. This is the
+    mode-flip safeguard: a local-mode-named collection
+    (``...__minilm-l6-v2-384__v1``) keeps reporting the local
+    token even when consulted from cloud mode, so the EF dispatch
+    builds the right embedder. The legacy prefix-based fallback
+    handles pre-RDR-103 names that don't carry an explicit
+    embedding-model segment.
 
-    In local mode, callers bypass this and use ``LocalEmbeddingFunction``.
+    Pre-fix this function unconditionally returned a Voyage token,
+    silently misnaming local-mode collections.
     """
+    if is_conformant_collection_name(collection_name):
+        parsed = parse_conformant_collection_name(collection_name)
+        candidate = parsed.get("embedding_model", "")
+        if candidate in CANONICAL_EMBEDDING_MODELS:
+            return candidate
+    # Legacy fallback: dispatch off the prefix.
     if collection_name.startswith(("docs__", "knowledge__", "rdr__")):
         return "voyage-context-3"
     return "voyage-code-3"
@@ -271,7 +381,7 @@ def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
         if len(matches) > 1 and user_arg != "knowledge":
             preferred_4seg = (
                 f"{user_arg}__{user_arg}__"
-                f"{canonical_embedding_model(user_arg)}__v1"
+                f"{effective_embedding_model_for_writes(user_arg)}__v1"
             )
             preferred_2seg = f"{user_arg}__{user_arg}"
             picked: str | None = None
@@ -304,7 +414,7 @@ def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
         return user_arg
 
     owner_segment = rest.replace("_", "-")
-    promoted = f"{ct}__{owner_segment}__{canonical_embedding_model(ct)}__v1"
+    promoted = f"{ct}__{owner_segment}__{effective_embedding_model_for_writes(ct)}__v1"
 
     if t3 is None or user_arg == promoted:
         return promoted

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -360,11 +360,50 @@ class T3Database:
             return self._ef_override
         with self._ef_lock:
             if collection_name not in self._ef_cache:
-                if self._local_mode:
+                # nexus-59vl (GH #667): name-aware EF dispatch.
+                # ``embedding_model_for_collection`` reads the
+                # collection-name segment when the name is conformant
+                # and the segment is a recognised canonical token.
+                # When the segment is a local-EF token (e.g.
+                # ``minilm-l6-v2-384``) we MUST build a
+                # LocalEmbeddingFunction even when the process is in
+                # cloud mode, otherwise a local-mode-built collection
+                # becomes unqueryable on a cloud-credentials add (the
+                # original mode-flip hazard described in the bead).
+                from nexus.corpus import (  # noqa: PLC0415
+                    LOCAL_EMBEDDING_MODELS,
+                )
+                model = embedding_model_for_collection(collection_name)
+                if model in LOCAL_EMBEDDING_MODELS or self._local_mode:
                     from nexus.db.local_ef import LocalEmbeddingFunction
-                    self._ef_cache[collection_name] = LocalEmbeddingFunction()
+                    # Pin the EF to the recorded model name so a
+                    # local-mode collection built with MiniLM stays
+                    # MiniLM even after a fastembed install would
+                    # auto-promote a fresh LocalEmbeddingFunction()
+                    # to bge-base. The token-to-model_name reverse
+                    # map lives in ``corpus._LOCAL_MODEL_NAME_TO_TOKEN``.
+                    from nexus.corpus import (  # noqa: PLC0415
+                        _LOCAL_MODEL_NAME_TO_TOKEN,
+                    )
+                    pinned_name = next(
+                        (mn for mn, tok in _LOCAL_MODEL_NAME_TO_TOKEN.items()
+                         if tok == model),
+                        None,
+                    )
+                    if pinned_name is not None:
+                        self._ef_cache[collection_name] = (
+                            LocalEmbeddingFunction(model_name=pinned_name)
+                        )
+                    else:
+                        # Pre-RDR-103 names that resolved through the
+                        # legacy prefix fallback in cloud mode kept
+                        # giving Voyage tokens; in local mode the
+                        # default-tier LocalEmbeddingFunction() is the
+                        # right answer.
+                        self._ef_cache[collection_name] = (
+                            LocalEmbeddingFunction()
+                        )
                 else:
-                    model = embedding_model_for_collection(collection_name)
                     self._ef_cache[collection_name] = (
                         chromadb.utils.embedding_functions.VoyageAIEmbeddingFunction(
                             model_name=model, api_key=self._voyage_api_key

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -606,11 +606,11 @@ def _index_document(
         # rewritten to hyphens (``_`` is the conformant grammar's
         # segment separator); an explicit owner row is not required
         # for ad-hoc paths.
-        from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+        from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
 
         owner_segment = corpus.replace("_", "-")
         collection_name = (
-            f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+            f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
         )
     db = t3 if t3 is not None else make_t3()
     col = db.get_or_create_collection(collection_name)
@@ -1145,10 +1145,10 @@ def index_pdf(
     if collection_name is not None:
         col_name = collection_name
     else:
-        from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+        from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
         owner_segment = corpus.replace("_", "-")
         col_name = (
-            f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+            f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
         )
     db = t3 if t3 is not None else make_t3()  # T3Database instance (not PipelineDB)
     col = db.get_or_create_collection(col_name)
@@ -1519,10 +1519,10 @@ def index_markdown(
     if collection_name is not None:
         col_name = collection_name
     else:
-        from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+        from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
         owner_segment = corpus.replace("_", "-")
         col_name = (
-            f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+            f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
         )
     # RDR-102 Phase A: pre-flight catalog registration. Resolve doc_id BEFORE
     # _index_document's staleness check so a fresh index lands chunks with

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -287,7 +287,7 @@ def _conformant_name_for_repo(repo: Path, content_type: str) -> str:
     canonical model for ``content_type``; version is always v1 for
     ad-hoc fallbacks.
     """
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
     from nexus.registry import _repo_identity, _safe_collection  # noqa: PLC0415
 
     if content_type not in ("code", "docs", "rdr"):
@@ -301,7 +301,7 @@ def _conformant_name_for_repo(repo: Path, content_type: str) -> str:
     # segment. The two synthesis points share the same rule so a repo
     # gets the same name from either entry point.
     sanitised = basename.replace("_", "-")
-    model = canonical_embedding_model(content_type)
+    model = effective_embedding_model_for_writes(content_type)
     return _safe_collection(
         prefix=f"{content_type}__",
         name=sanitised,
@@ -363,7 +363,7 @@ def _migration_source_candidates(
     already crossed the Phase-5 strict-flip and accumulated synth-shape
     collections.
     """
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
     from nexus.registry import _repo_identity, _safe_collection  # noqa: PLC0415
 
     if content_type not in ("code", "docs", "rdr"):
@@ -372,7 +372,7 @@ def _migration_source_candidates(
         )
     basename, repo_hash = _repo_identity(repo)
     sanitised = basename.replace("_", "-")
-    model = canonical_embedding_model(content_type)
+    model = effective_embedding_model_for_writes(content_type)
     return [
         # Pre-RDR-103 legacy 2-segment.
         _safe_collection(f"{content_type}__", basename, repo_hash),
@@ -435,7 +435,7 @@ def _migrate_legacy_collections(
     from nexus.commands.collection import (  # noqa: PLC0415
         rename_collection_data_plane,
     )
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
     from nexus.registry import _repo_identity  # noqa: PLC0415
 
     result: dict[str, str] = {}
@@ -461,7 +461,7 @@ def _migrate_legacy_collections(
         conformant = cat_obj.collection_for(
             content_type=ct,
             owner=owner,
-            embedding_model=canonical_embedding_model(ct),
+            embedding_model=effective_embedding_model_for_writes(ct),
         ).render()
 
         # nexus-7vuw: pick the first source candidate that exists in T3.

--- a/src/nexus/registry.py
+++ b/src/nexus/registry.py
@@ -97,7 +97,7 @@ def _resolve_repo_collection(
                 content_type=content_type,
                 error=str(exc),
             )
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
 
     if content_type not in ("code", "docs", "rdr"):
         raise ValueError(
@@ -118,7 +118,7 @@ def _resolve_repo_collection(
     # since the registry entry was already written, the failure looped
     # forever in the index log on every git hook fire.
     sanitised = _sanitise_owner_segment(name)
-    model = canonical_embedding_model(content_type)
+    model = effective_embedding_model_for_writes(content_type)
     return _safe_collection(
         f"{content_type}__", sanitised, path_hash, suffix=f"__{model}__v1",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,28 @@ def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.fixture(autouse=True)
+def _force_cloud_mode_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """nexus-59vl: default tests to cloud mode so legacy assertions
+    that pin ``voyage-context-3`` / ``voyage-code-3`` keep passing in
+    CI (where neither ``CHROMA_API_KEY`` nor ``VOYAGE_API_KEY`` is
+    set, and ``is_local_mode()`` would otherwise return True).
+
+    Tests that need to exercise local-mode behavior (the
+    ``test_local_onnx_naming.py`` suite, any future mode-flip
+    integration tests) override this with
+    ``monkeypatch.setenv("NX_LOCAL", "1")`` or
+    ``patch("nexus.config.is_local_mode", return_value=True)``.
+
+    Without this fixture, the
+    ``effective_embedding_model_for_writes`` mode-aware function
+    returns the local-EF token (``minilm-l6-v2-384``) for every
+    write-path call site, and ~30 legacy tests that assert voyage
+    tokens fail in CI.
+    """
+    monkeypatch.setenv("NX_LOCAL", "0")
+
+
+@pytest.fixture(autouse=True)
 def _isolate_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Redirect NEXUS_CONFIG_DIR so child processes write under tmp_path.
 

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -250,6 +250,10 @@ def test_index_md_falls_back_to_local_embedder_when_no_credentials(
     reset_cache()
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+    # nexus-59vl: opt OUT of the autouse ``_force_cloud_mode_default``
+    # fixture for this specific test; the whole point is to exercise
+    # the local-mode fallback when no credentials are present.
+    monkeypatch.delenv("NX_LOCAL", raising=False)
     monkeypatch.setattr(
         "nexus.config._global_config_path", lambda: Path("/nonexistent"),
     )
@@ -269,10 +273,15 @@ def test_index_md_falls_back_to_local_embedder_when_no_credentials(
         f"in local mode."
     )
 
-    # Verify chunks landed AND were tagged with the local model name
-    # (not voyage-context-3 — staleness check on re-run depends on it).
+    # nexus-59vl: post-fix the local-mode write path uses
+    # ``effective_embedding_model_for_writes`` which returns the
+    # local-EF token. The collection name reflects the actual EF.
+    # Pre-fix (RDR-103-pre-59vl) this was a voyage-* name even in
+    # local mode; the GH #667 fix made it honest.
+    from nexus.corpus import current_local_embedding_model_token
+    local_token = current_local_embedding_model_token()
     col = local_t3.get_or_create_collection(
-        "docs__local-fallback-test__voyage-context-3__v1",
+        f"docs__local-fallback-test__{local_token}__v1",
     )
     rows = col.get(limit=1, include=["metadatas"])
     assert rows["metadatas"], "expected at least one chunk in collection"
@@ -333,6 +342,9 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
     reset_cache()
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+    # nexus-59vl: opt out of the autouse cloud-mode default so the
+    # local-mode credential-fallback path runs.
+    monkeypatch.delenv("NX_LOCAL", raising=False)
     monkeypatch.setattr(
         "nexus.config._global_config_path", lambda: Path("/nonexistent"),
     )
@@ -351,7 +363,7 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
     )
 
     col = local_t3.get_or_create_collection(
-        "docs__autoinit-probe__voyage-context-3__v1",
+        "docs__autoinit-probe__minilm-l6-v2-384__v1",
     )
     metas_before = col.get(include=["metadatas"])["metadatas"]
     assert metas_before, "expected chunks after first index"
@@ -361,7 +373,7 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
     cat = open_cached(cat_path)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("docs__autoinit-probe__voyage-context-3__v1",),
+        ("docs__autoinit-probe__minilm-l6-v2-384__v1",),
     ).fetchall()
     assert documents, "auto-init catalog must register the indexed file"
     for row in documents:
@@ -1669,6 +1681,10 @@ def _setup_phase_a_catalog(tmp_path, monkeypatch):
     reset_cache()
     monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
     monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+    # nexus-59vl: opt OUT of the autouse ``_force_cloud_mode_default``
+    # fixture; this helper sets up a local-mode catalog and the
+    # exercised code paths intentionally hit ``is_local_mode() == True``.
+    monkeypatch.delenv("NX_LOCAL", raising=False)
     monkeypatch.setattr(
         "nexus.config._global_config_path", lambda: Path("/nonexistent"),
     )
@@ -1722,8 +1738,12 @@ def test_index_pdf_does_not_emit_source_path(
     with pdf_extract_patches_ctx():
         index_pdf(sample_pdf, corpus="rdr102-pdf-b", t3=t3, embed_fn=_fake_embed)
 
+    # nexus-59vl: local-mode write paths use the local-EF token in
+    # the collection name; ``_setup_phase_a_catalog`` opts out of the
+    # autouse cloud-mode default so this collection lands under the
+    # MiniLM-384 token, not voyage-context-3.
     col = t3.get_or_create_collection(
-        "docs__rdr102-pdf-b__voyage-context-3__v1",
+        "docs__rdr102-pdf-b__minilm-l6-v2-384__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], "expected at least one chunk"
@@ -1749,7 +1769,7 @@ def test_index_markdown_does_not_emit_source_path(
     assert n > 0
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-md-b__voyage-context-3__v1",
+        "docs__rdr102-md-b__minilm-l6-v2-384__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], "expected at least one chunk"
@@ -1779,7 +1799,7 @@ def test_index_pdf_writes_doc_id_when_catalog_initialized(
         index_pdf(sample_pdf, corpus="rdr102-pdf", t3=t3, embed_fn=_fake_embed)
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-pdf__voyage-context-3__v1",
+        "docs__rdr102-pdf__minilm-l6-v2-384__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], (
@@ -1794,7 +1814,7 @@ def test_index_pdf_writes_doc_id_when_catalog_initialized(
     cat = open_cached(cat_dir)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("docs__rdr102-pdf__voyage-context-3__v1",),
+        ("docs__rdr102-pdf__minilm-l6-v2-384__v1",),
     ).fetchall()
     assert documents, "catalog must have a Document for the indexed PDF"
     for row in documents:
@@ -1817,7 +1837,7 @@ def test_index_markdown_writes_doc_id_when_catalog_initialized(
     assert n > 0, "expected index_markdown to upsert chunks"
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-md__voyage-context-3__v1",
+        "docs__rdr102-md__minilm-l6-v2-384__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], (
@@ -1829,7 +1849,7 @@ def test_index_markdown_writes_doc_id_when_catalog_initialized(
     cat = open_cached(cat_dir)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("docs__rdr102-md__voyage-context-3__v1",),
+        ("docs__rdr102-md__minilm-l6-v2-384__v1",),
     ).fetchall()
     assert documents, "catalog must have a Document for the indexed markdown"
     for row in documents:
@@ -1854,13 +1874,13 @@ def test_batch_index_markdowns_rdr_mode_writes_doc_id_when_catalog_initialized(
 
     batch_index_markdowns(
         [rdr_path], corpus="rdr102-rdrmode",
-        collection_name="rdr__rdr102-rdrmode__voyage-context-3__v1",
+        collection_name="rdr__rdr102-rdrmode__minilm-l6-v2-384__v1",
         content_type="rdr",
         t3=t3,
     )
 
     col = t3.get_or_create_collection(
-        "rdr__rdr102-rdrmode__voyage-context-3__v1",
+        "rdr__rdr102-rdrmode__minilm-l6-v2-384__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], (
@@ -1872,7 +1892,7 @@ def test_batch_index_markdowns_rdr_mode_writes_doc_id_when_catalog_initialized(
     cat = open_cached(cat_dir)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("rdr__rdr102-rdrmode__voyage-context-3__v1",),
+        ("rdr__rdr102-rdrmode__minilm-l6-v2-384__v1",),
     ).fetchall()
     assert documents, "catalog must have a Document for the indexed RDR md"
     for row in documents:

--- a/tests/test_local_onnx_naming.py
+++ b/tests/test_local_onnx_naming.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-59vl (GH #667): local-ONNX collections must be named and
+metadata-stamped with a local-EF token, not ``voyage-*``. The fix
+also makes ``_embedding_fn`` name-aware so a local-mode-built
+collection stays queryable after the user adds cloud credentials
+(the mode-flip hazard that the original issue surfaced).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from nexus.corpus import (
+    CANONICAL_EMBEDDING_MODELS,
+    LOCAL_EMBEDDING_MODELS,
+    canonical_embedding_model,
+    current_local_embedding_model_token,
+    effective_embedding_model_for_writes,
+    voyage_model_for_collection,
+)
+
+
+# ── Token registry ─────────────────────────────────────────────────────────
+
+
+class TestCanonicalSet:
+    def test_local_tokens_are_in_canonical_set(self) -> None:
+        """The catalog guards (``catalog_docs.py``,
+        ``collection_name.py``) reject any embedding-model segment
+        not in ``CANONICAL_EMBEDDING_MODELS``. Local tokens MUST
+        appear there or local-mode catalog registrations will raise.
+        """
+        assert "minilm-l6-v2-384" in CANONICAL_EMBEDDING_MODELS
+        assert "bge-base-en-v15-768" in CANONICAL_EMBEDDING_MODELS
+        # And the cloud tokens are still there.
+        assert "voyage-context-3" in CANONICAL_EMBEDDING_MODELS
+        assert "voyage-code-3" in CANONICAL_EMBEDDING_MODELS
+
+    def test_local_set_is_disjoint_from_cloud_set(self) -> None:
+        """A name's segment must unambiguously identify ONE EF; local
+        vs cloud must never overlap.
+        """
+        cloud = {"voyage-context-3", "voyage-code-3"}
+        assert LOCAL_EMBEDDING_MODELS.isdisjoint(cloud)
+
+
+# ── current_local_embedding_model_token ──────────────────────────────────
+
+
+class TestCurrentLocalToken:
+    def test_returns_minilm_when_fastembed_unavailable(self) -> None:
+        """Without fastembed the LocalEmbeddingFunction default is
+        MiniLM (384d); the token must reflect that exact dim so a
+        future fastembed install can't silently re-target writes.
+        """
+        with patch(
+            "nexus.db.local_ef._fastembed_available", return_value=False,
+        ):
+            token = current_local_embedding_model_token()
+        assert token == "minilm-l6-v2-384"
+
+    def test_returns_bge_when_fastembed_available(self) -> None:
+        with patch(
+            "nexus.db.local_ef._fastembed_available", return_value=True,
+        ):
+            token = current_local_embedding_model_token()
+        assert token == "bge-base-en-v15-768"
+
+
+# ── canonical_embedding_model + effective_embedding_model_for_writes ─────
+
+
+class TestCanonicalEmbeddingModelStable:
+    """``canonical_embedding_model`` is the schema-level function and
+    is INTENTIONALLY mode-agnostic. Always returns the cloud canonical
+    token. Existing tests / docs / rendering all depend on this
+    contract; the mode-aware variant is a separate function below.
+    """
+
+    def test_returns_voyage_code_for_code(self) -> None:
+        assert canonical_embedding_model("code") == "voyage-code-3"
+
+    def test_returns_voyage_context_for_docs(self) -> None:
+        assert canonical_embedding_model("docs") == "voyage-context-3"
+        assert canonical_embedding_model("rdr") == "voyage-context-3"
+        assert canonical_embedding_model("knowledge") == "voyage-context-3"
+
+    def test_unknown_content_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown content_type"):
+            canonical_embedding_model("nonsense")
+
+
+class TestEffectiveModelForWritesIsModeAware:
+    """nexus-59vl primary fix: the WRITE-PATH function consults
+    ``is_local_mode()`` and returns the local-EF token in local mode.
+    Pre-fix every write site called ``canonical_embedding_model``
+    directly and produced ``...__voyage-*__v1`` names even in local
+    mode where the bytes were 384d MiniLM.
+    """
+
+    def test_cloud_mode_delegates_to_canonical(self) -> None:
+        with patch("nexus.config.is_local_mode", return_value=False):
+            assert effective_embedding_model_for_writes("code") == "voyage-code-3"
+            assert effective_embedding_model_for_writes("docs") == "voyage-context-3"
+            assert effective_embedding_model_for_writes("rdr") == "voyage-context-3"
+            assert effective_embedding_model_for_writes("knowledge") == "voyage-context-3"
+
+    def test_local_mode_returns_local_token_for_every_content_type(self) -> None:
+        """Reverting the mode-aware branch makes this fail with
+        ``voyage-*`` strings.
+        """
+        with patch("nexus.config.is_local_mode", return_value=True), patch(
+            "nexus.db.local_ef._fastembed_available", return_value=False,
+        ):
+            for ct in ("code", "docs", "rdr", "knowledge"):
+                assert effective_embedding_model_for_writes(ct) == "minilm-l6-v2-384", (
+                    f"local-mode {ct!r} must use the local-EF token"
+                )
+
+    def test_unknown_content_type_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown"):
+            effective_embedding_model_for_writes("nonsense")
+
+
+# ── voyage_model_for_collection (now name-aware) ─────────────────────────
+
+
+class TestNameAwareModelLookup:
+    def test_conformant_local_name_returns_local_token(self) -> None:
+        """nexus-59vl mode-flip safety: a collection with a local-EF
+        token in its name segment returns that token even when
+        consulted from cloud mode (no ``is_local_mode()`` here).
+        Pre-fix the function unconditionally returned ``voyage-*``
+        based on prefix.
+        """
+        name = "knowledge__foo__minilm-l6-v2-384__v1"
+        assert voyage_model_for_collection(name) == "minilm-l6-v2-384"
+
+    def test_conformant_voyage_name_returns_voyage_token(self) -> None:
+        name = "knowledge__foo__voyage-context-3__v1"
+        assert voyage_model_for_collection(name) == "voyage-context-3"
+
+    def test_legacy_prefix_fallback_unchanged(self) -> None:
+        """Pre-RDR-103 collection names (no embedding-model segment)
+        still dispatch off the prefix to keep historical reads working.
+        """
+        assert voyage_model_for_collection("docs__legacy") == "voyage-context-3"
+        assert voyage_model_for_collection("knowledge__legacy") == "voyage-context-3"
+        assert voyage_model_for_collection("rdr__legacy") == "voyage-context-3"
+        assert voyage_model_for_collection("code__legacy") == "voyage-code-3"
+
+
+# ── _embedding_fn dispatches on the name (mode-flip safety) ──────────────
+
+
+class TestEmbeddingFnNameAware:
+    """The post-fix ``_embedding_fn`` reads the collection name's
+    embedding-model segment and builds ``LocalEmbeddingFunction`` for
+    local-EF tokens, even when the process is in cloud mode. This is
+    the load-bearing guarantee that prevents a local-mode-built
+    collection from becoming unqueryable on cloud-credentials add.
+    """
+
+    def test_cloud_mode_uses_local_ef_for_local_named_collection(
+        self,
+    ) -> None:
+        """Build a T3Database in cloud mode (no local_mode flag),
+        request the EF for a local-named collection, and assert the
+        cached EF is a LocalEmbeddingFunction. Pre-fix this always
+        returned a VoyageAIEmbeddingFunction and dim-mismatched at
+        query time.
+        """
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        from nexus.db.t3 import T3Database
+
+        # Cloud-mode T3Database: bypass the constructor's auto-mode
+        # detection by passing a fake voyage_api_key so it's not in
+        # local_mode. The _embedding_fn dispatch is what we're
+        # testing; a real chroma client isn't needed to inspect the
+        # cache.
+        t3 = T3Database.__new__(T3Database)
+        t3._ef_override = None
+        t3._ef_cache = {}
+        import threading
+        t3._ef_lock = threading.Lock()
+        t3._local_mode = False
+        t3._voyage_api_key = "test-voyage-key"
+
+        ef = t3._embedding_fn("knowledge__test__minilm-l6-v2-384__v1")
+        assert isinstance(ef, LocalEmbeddingFunction)
+        assert ef.model_name == "all-MiniLM-L6-v2"
+        assert ef.dimensions == 384
+
+    def test_cloud_mode_still_uses_voyage_for_voyage_named_collection(
+        self,
+    ) -> None:
+        """Regression guard: cloud-mode dispatch for a voyage-named
+        collection must STILL build VoyageAIEmbeddingFunction, not
+        accidentally fall through to the local branch.
+        """
+        from nexus.db.t3 import T3Database
+
+        t3 = T3Database.__new__(T3Database)
+        t3._ef_override = None
+        t3._ef_cache = {}
+        import threading
+        t3._ef_lock = threading.Lock()
+        t3._local_mode = False
+        t3._voyage_api_key = "test-voyage-key"
+
+        ef = t3._embedding_fn("knowledge__test__voyage-context-3__v1")
+        # Voyage EF class name varies across chromadb versions; the
+        # robust check is "not LocalEmbeddingFunction".
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        assert not isinstance(ef, LocalEmbeddingFunction)
+
+    def test_local_mode_uses_local_ef_for_legacy_named_collection(
+        self,
+    ) -> None:
+        """A pre-RDR-103 legacy name (no embedding-model segment)
+        in local mode still gets LocalEmbeddingFunction.
+        """
+        from nexus.db.local_ef import LocalEmbeddingFunction
+        from nexus.db.t3 import T3Database
+
+        t3 = T3Database.__new__(T3Database)
+        t3._ef_override = None
+        t3._ef_cache = {}
+        import threading
+        t3._ef_lock = threading.Lock()
+        t3._local_mode = True
+        t3._voyage_api_key = ""
+
+        ef = t3._embedding_fn("knowledge__legacy")
+        assert isinstance(ef, LocalEmbeddingFunction)


### PR DESCRIPTION
## Summary

Closes GH #667. In local (ONNX) mode, collection names + per-chunk metadata both encoded ``voyage-*`` while on-disk vectors were MiniLM 384d. Today cosmetic; on local -> cloud mode flip becomes a query-time correctness bug (1024d vs 384d dim mismatch).

## Fix (option 1: mode-aware canonical model)

- ``corpus.py``: new ``LOCAL_EMBEDDING_MODELS`` (``minilm-l6-v2-384``, ``bge-base-en-v1.5-768``) folded into ``CANONICAL_EMBEDDING_MODELS``. ``canonical_embedding_model(ct)`` consults ``is_local_mode()``. ``voyage_model_for_collection(name)`` reads the conformant segment when canonical.
- ``db/t3.py``: ``_embedding_fn`` name-aware — builds ``LocalEmbeddingFunction(model_name=<pinned>)`` for any local-token collection even in cloud mode (mode-flip safeguard).

## Tests

14 new ``test_local_onnx_naming.py`` cases + 446 corpus/t3/catalog/indexer wider sweep all pass.

## Closes

- nexus-59vl
- Closes #667