### PR TITLE
feat(catalog): prose + pdf auto-link generators wired into bulk ingest (nexus-sob9)

### DIFF
--- a/src/nexus/catalog/AGENTS.md
+++ b/src/nexus/catalog/AGENTS.md
@@ -11,7 +11,7 @@ The catalog is a Xanadu-inspired document registry that tracks *what* is indexed
 
 ## Three link-creation paths
 
-1. **Post-hoc** (batch, after indexing) — `link_generator.py`: `generate_citation_links()`, `generate_code_rdr_links()`, `generate_rdr_filepath_links()`. Run when a corpus is fully indexed.
+1. **Post-hoc** (batch, after indexing): `link_generator.py` exposes `generate_citation_links()`, `generate_rdr_filepath_links()`, `generate_prose_filepath_links()`, `generate_pdf_corpus_links()`. Run when a corpus is fully indexed.
 2. **Auto-linker** — `auto_linker.py` fires on every `store_put` MCP call. Reads `link-context` from T1 scratch (tag `link-context`), creates links to seeded targets. Skills seed before dispatch; agents self-seed from their task prompt.
 3. **Agent-direct** — agents call the `catalog_link` MCP tool during work for precise typed links.
 
@@ -30,7 +30,7 @@ The `query` MCP tool has catalog-aware routing: `author`, `content_type`, `subtr
 | `catalog_db.py` | SQLite schema, FTS5 tables, UNIQUE link constraint, `descendants()` SQL helper. |
 | `tumbler.py` | `Tumbler` dataclass + `parse`, hierarchy helpers, JSONL readers with resilience (truncated rows, bad JSON). |
 | `auto_linker.py` | Storage-boundary auto-linking from T1 scratch link-context. Hook firing site is `mcp/core.py`. |
-| `link_generator.py` | Post-hoc batch linkers (citation, code↔RDR heuristic, RDR↔file-path). |
+| `link_generator.py` | Post-hoc batch linkers (citation, RDR↔file-path, prose↔file-path, pdf same-as via shared head_hash). |
 | `consolidation.py` | Merges per-paper `knowledge__<paper>` collections into corpus-level `knowledge__<corpus>`. |
 
 ## Adding a new source-URI scheme

--- a/src/nexus/catalog/link_generator.py
+++ b/src/nexus/catalog/link_generator.py
@@ -76,6 +76,24 @@ _FILE_PATH_RE = re.compile(
 )
 
 
+# nexus-sob9: prose-side regex. RDR file_path matching anchors on a
+# source-root prefix (``src/`` etc) because RDR text is dense with
+# fully-qualified paths; the anchor disambiguates against common
+# prose like "the algorithm runs in O(n log n)". Prose docs use a
+# wider path vocabulary (``docs/`` runbooks, ``nx/`` plugin trees,
+# ``.claude/`` profiles) that the RDR anchor list misses entirely.
+# The prose regex requires AT LEAST ONE ``/`` (so a bare
+# ``foo.py`` mention doesn't match) plus a recognised source
+# extension. The match is then checked against catalog code
+# entries by exact ``file_path`` so non-existent-in-catalog
+# strings fall through silently.
+_PROSE_PATH_RE = re.compile(
+    r"(?:[\w.-]+/)+"                              # at least one dir segment
+    r"[\w.-]+"                                    # filename
+    r"\.(?:py|java|go|rs|ts|tsx|js|jsx|c|cpp|h|rb|php|swift|kt|scala|md)"
+)
+
+
 def generate_rdr_filepath_links(cat: Catalog, *, new_tumblers: list[Tumbler] | None = None) -> int:
     """Extract file paths from RDR content and link to matching code entries.
 
@@ -136,6 +154,171 @@ def generate_rdr_filepath_links(cat: Catalog, *, new_tumblers: list[Tumbler] | N
                     "rdr_filepath_link_created",
                     rdr=str(rdr.tumbler), code=str(code_tumbler),
                     path=fpath,
+                )
+
+    return count
+
+
+def generate_prose_filepath_links(
+    cat: Catalog, *, new_tumblers: list[Tumbler] | None = None,
+) -> int:
+    """nexus-sob9: extract file paths from prose / markdown content
+    and link to matching code entries.
+
+    Same shape as ``generate_rdr_filepath_links`` but with two
+    contracts widened so prose docs (the original RDR-only filter
+    excluded them) get linked to code:
+
+    - Source-side filter: ``content_type in {"prose", "markdown",
+      "docs"}`` instead of ``"rdr"``.
+    - Path regex: ``_PROSE_PATH_RE`` requires at least one ``/``
+      and a recognised source extension, but does NOT require a
+      ``src/`` / ``tests/`` source-root anchor. ``docs/`` runbooks,
+      ``nx/`` plugin trees, and ``.claude/`` profiles all match.
+      Disambiguates against bare-filename mentions in prose by
+      requiring the directory segment.
+
+    Match is then checked against catalog code entries by exact
+    ``file_path`` so non-existent strings fall through silently.
+    Creates ``implements`` links (prose -> code) with
+    ``created_by="filepath_extractor"`` for parity with the RDR
+    linker.
+
+    Closes prose=0.1% catalog auto-link coverage gap from the
+    2026-05-08 prod shakeout (4.29.0: 23,378 docs / 23,575 links).
+    """
+    if new_tumblers is not None and len(new_tumblers) == 0:
+        return 0
+
+    entries = _all_entries(cat)
+    prose_entries = [
+        e for e in entries
+        if e.content_type in ("prose", "markdown", "docs") and e.file_path
+    ]
+    code_entries = [
+        e for e in entries if e.content_type == "code" and e.file_path
+    ]
+
+    if new_tumblers is not None:
+        new_set = {str(t) for t in new_tumblers}
+        prose_entries = [
+            e for e in prose_entries if str(e.tumbler) in new_set
+        ]
+
+    path_to_code: dict[str, Tumbler] = {
+        code.file_path: code.tumbler for code in code_entries
+    }
+
+    count = 0
+    for prose in prose_entries:
+        resolved = cat.resolve_path(prose.tumbler)
+        if resolved is None or not resolved.is_file():
+            continue
+        try:
+            text = resolved.read_text(errors="replace")
+        except OSError:
+            continue
+
+        seen_targets: set[str] = set()
+        for match in _PROSE_PATH_RE.finditer(text):
+            fpath = match.group(0)
+            if fpath in seen_targets:
+                continue
+            seen_targets.add(fpath)
+            code_tumbler = path_to_code.get(fpath)
+            if code_tumbler is None:
+                continue
+            try:
+                created = cat.link_if_absent(
+                    prose.tumbler, code_tumbler, "implements",
+                    created_by="filepath_extractor",
+                )
+            except ValueError:
+                continue
+            if created:
+                count += 1
+                _log.debug(
+                    "prose_filepath_link_created",
+                    prose=str(prose.tumbler),
+                    code=str(code_tumbler),
+                    path=fpath,
+                )
+
+    return count
+
+
+def generate_pdf_corpus_links(
+    cat: Catalog, *, new_tumblers: list[Tumbler] | None = None,
+) -> int:
+    """nexus-sob9: link PDFs that share a content_hash via ``same-as``.
+
+    Two PDFs in different physical_collections with the same
+    ``head_hash`` are the same source paper indexed twice (e.g. a
+    PDF imported into both ``knowledge__delos`` and
+    ``knowledge__art-grossberg-papers``). The catalog should
+    surface that fact so cross-corpus retrieval can collapse them
+    to one logical document.
+
+    Algorithm:
+    1. Group catalog PDF entries (``content_type in {"pdf",
+       "paper"}``) by ``head_hash`` (the catalog's stored
+       file-content hash; populated at register time).
+    2. For each group with >= 2 entries, create ``same-as`` links
+       from every member to the lexicographically-first member
+       (the canonical anchor). Avoids O(N^2) pairwise links;
+       everyone links to one anchor and traversal goes through it.
+
+    Idempotent via ``link_if_absent``. Incremental when
+    ``new_tumblers`` is supplied: only the new pdf entries emit
+    links FROM them; the anchor side may be a pre-existing
+    tumbler (that's the desired join point).
+
+    Closes pdf=0% catalog auto-link coverage gap from the
+    2026-05-08 prod shakeout.
+    """
+    if new_tumblers is not None and len(new_tumblers) == 0:
+        return 0
+
+    entries = _all_entries(cat)
+    pdf_entries = [
+        e for e in entries
+        if e.content_type in ("pdf", "paper") and e.head_hash
+    ]
+
+    by_hash: dict[str, list[CatalogEntry]] = {}
+    for e in pdf_entries:
+        by_hash.setdefault(e.head_hash, []).append(e)
+
+    new_set: set[str] | None
+    if new_tumblers is not None:
+        new_set = {str(t) for t in new_tumblers}
+    else:
+        new_set = None
+
+    count = 0
+    for hash_value, group in by_hash.items():
+        if len(group) < 2:
+            continue
+        anchor = min(group, key=lambda e: str(e.tumbler))
+        for member in group:
+            if member.tumbler == anchor.tumbler:
+                continue
+            if new_set is not None and str(member.tumbler) not in new_set:
+                continue
+            try:
+                created = cat.link_if_absent(
+                    member.tumbler, anchor.tumbler, "same-as",
+                    created_by="content_hash_dedup",
+                )
+            except ValueError:
+                continue
+            if created:
+                count += 1
+                _log.debug(
+                    "pdf_same_as_link_created",
+                    member=str(member.tumbler),
+                    anchor=str(anchor.tumbler),
+                    head_hash=hash_value[:16],
                 )
 
     return count

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -735,11 +735,28 @@ def _catalog_hook(
         if new_tumblers:
             _progress(f"  Catalog: linking {len(new_tumblers)} new entries…\r")
         try:
-            from nexus.catalog.link_generator import generate_rdr_filepath_links
+            from nexus.catalog.link_generator import (
+                generate_pdf_corpus_links,
+                generate_prose_filepath_links,
+                generate_rdr_filepath_links,
+            )
             fp_count = generate_rdr_filepath_links(cat, new_tumblers=new_tumblers)
-            links_created = fp_count
+            # nexus-sob9: prose + pdf coverage. Run with the same
+            # incremental scope so a single bulk-index pass closes
+            # the prose/pdf 0% gap from the 2026-05-08 prod shakeout.
+            prose_count = generate_prose_filepath_links(
+                cat, new_tumblers=new_tumblers,
+            )
+            pdf_count = generate_pdf_corpus_links(
+                cat, new_tumblers=new_tumblers,
+            )
+            links_created = fp_count + prose_count + pdf_count
             if links_created:
-                _log.info("catalog_links_generated", filepath=fp_count, repo=repo_name)
+                _log.info(
+                    "catalog_links_generated",
+                    filepath=fp_count, prose=prose_count, pdf=pdf_count,
+                    repo=repo_name,
+                )
         except Exception:
             _log.debug("catalog_link_generation_failed", exc_info=True)
 

--- a/tests/test_link_generator.py
+++ b/tests/test_link_generator.py
@@ -7,7 +7,12 @@ from pathlib import Path
 import pytest
 
 from nexus.catalog.catalog import Catalog
-from nexus.catalog.link_generator import generate_citation_links, generate_rdr_filepath_links
+from nexus.catalog.link_generator import (
+    generate_citation_links,
+    generate_pdf_corpus_links,
+    generate_prose_filepath_links,
+    generate_rdr_filepath_links,
+)
 
 
 class TestRdrFilepathLinks:
@@ -200,3 +205,255 @@ class TestCitationLinksNoneMeta:
         with patch.object(cat, "all_documents", return_value=[legacy]):
             count = generate_citation_links(cat)
         assert count == 0
+
+
+# ── nexus-sob9: prose filepath linker ─────────────────────────────────────
+
+
+class TestProseFilepathLinks:
+    """generate_prose_filepath_links closes the prose=0.1% catalog
+    auto-link coverage gap by scanning prose/markdown content for
+    code file paths and creating ``implements`` links. Same shape
+    as the RDR linker but with a wider source-side filter (content_type
+    in {prose, markdown, docs}) and a relaxed regex (no source-root
+    anchor; ``docs/`` and ``nx/`` paths match).
+    """
+
+    def _make_catalog(self, tmp_path: Path) -> Catalog:
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        (cat_dir / "owners.jsonl").touch()
+        (cat_dir / "documents.jsonl").touch()
+        (cat_dir / "links.jsonl").touch()
+        return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+    def test_prose_doc_in_docs_dir_links_to_code(self, tmp_path: Path) -> None:
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        docs_dir = repo / "docs"
+        docs_dir.mkdir()
+        # The prose doc mentions a file under ``docs/runbook.md`` and
+        # ``src/nexus/foo.py``. The RDR linker would only catch the
+        # second (source-root anchored). The prose linker catches both
+        # if both are registered as code; here only foo.py is.
+        prose_file = docs_dir / "runbook.md"
+        prose_file.write_text(
+            "# Runbook\n\n"
+            "See ``src/nexus/foo.py`` for the impl. "
+            "Also ``docs/legacy.md`` for context.\n"
+        )
+
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner(
+            "myrepo", "repo", repo_hash="abc12345", repo_root=str(repo),
+        )
+        prose_tumbler = cat.register(
+            owner, "Runbook", content_type="prose",
+            file_path="docs/runbook.md",
+        )
+        code_tumbler = cat.register(
+            owner, "foo.py", content_type="code",
+            file_path="src/nexus/foo.py",
+        )
+
+        count = generate_prose_filepath_links(cat)
+        assert count == 1
+
+        links = cat.links_from(prose_tumbler)
+        assert len(links) == 1
+        assert str(links[0].to_tumbler) == str(code_tumbler)
+        assert links[0].link_type == "implements"
+
+    def test_prose_doc_in_non_source_root_dir_links(self, tmp_path: Path) -> None:
+        """nexus-sob9 widening contract: a docs/ -> nx/ reference (no
+        ``src/`` anchor) MUST link. Pre-fix the RDR regex required a
+        source-root prefix; ``nx/`` plugin paths never matched.
+        Reverting the relaxed prose regex makes this test fail.
+        """
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        prose_file = repo / "docs" / "guide.md"
+        prose_file.parent.mkdir(parents=True)
+        prose_file.write_text("See ``nx/skills/foo.md`` for usage.\n")
+
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner(
+            "myrepo", "repo", repo_hash="abc12345", repo_root=str(repo),
+        )
+        prose_tumbler = cat.register(
+            owner, "Guide", content_type="prose",
+            file_path="docs/guide.md",
+        )
+        code_tumbler = cat.register(
+            owner, "foo.md", content_type="code",
+            file_path="nx/skills/foo.md",
+        )
+
+        count = generate_prose_filepath_links(cat)
+        assert count == 1
+        links = cat.links_from(prose_tumbler)
+        assert len(links) == 1
+        assert str(links[0].to_tumbler) == str(code_tumbler)
+
+    def test_bare_filename_does_not_match(self, tmp_path: Path) -> None:
+        """A prose mention of bare ``foo.py`` (no directory segment)
+        must NOT match (too noisy). The regex requires at least one
+        ``/`` to disambiguate against generic mentions.
+        """
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        prose_file = repo / "docs" / "loose.md"
+        prose_file.parent.mkdir(parents=True)
+        prose_file.write_text("Run ``foo.py`` to start.\n")
+
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner(
+            "myrepo", "repo", repo_hash="abc12345", repo_root=str(repo),
+        )
+        prose_tumbler = cat.register(
+            owner, "Loose", content_type="prose",
+            file_path="docs/loose.md",
+        )
+        cat.register(
+            owner, "foo.py", content_type="code",
+            file_path="foo.py",
+        )
+
+        count = generate_prose_filepath_links(cat)
+        assert count == 0
+        assert len(cat.links_from(prose_tumbler)) == 0
+
+    def test_incremental_only_scans_new_prose(self, tmp_path: Path) -> None:
+        """When ``new_tumblers`` lists only the new prose entry, only
+        that one is scanned (mirrors RDR linker incremental contract).
+        """
+        repo = tmp_path / "myrepo"
+        repo.mkdir()
+        for name in ("a.md", "b.md"):
+            f = repo / "docs" / name
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(f"See ``src/nexus/{name.replace('.md', '.py')}``.\n")
+
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner(
+            "myrepo", "repo", repo_hash="abc12345", repo_root=str(repo),
+        )
+        # Register both prose docs + their code targets.
+        prose_a = cat.register(
+            owner, "a", content_type="prose", file_path="docs/a.md",
+        )
+        prose_b = cat.register(
+            owner, "b", content_type="prose", file_path="docs/b.md",
+        )
+        cat.register(
+            owner, "a.py", content_type="code", file_path="src/nexus/a.py",
+        )
+        cat.register(
+            owner, "b.py", content_type="code", file_path="src/nexus/b.py",
+        )
+
+        count = generate_prose_filepath_links(cat, new_tumblers=[prose_a])
+        assert count == 1
+        # Only prose_a got linked.
+        assert len(cat.links_from(prose_a)) == 1
+        assert len(cat.links_from(prose_b)) == 0
+
+
+# ── nexus-sob9: pdf-content-hash linker ───────────────────────────────────
+
+
+class TestPdfCorpusLinks:
+    """generate_pdf_corpus_links closes the pdf=0% catalog auto-link
+    coverage gap by linking PDFs that share head_hash via ``same-as``.
+    Group anchors are lexicographically-first tumbler in each hash
+    group (stable across runs).
+    """
+
+    def _make_catalog(self, tmp_path: Path) -> Catalog:
+        cat_dir = tmp_path / "catalog"
+        cat_dir.mkdir()
+        (cat_dir / "owners.jsonl").touch()
+        (cat_dir / "documents.jsonl").touch()
+        (cat_dir / "links.jsonl").touch()
+        return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+    def test_two_pdfs_with_same_hash_get_linked(self, tmp_path: Path) -> None:
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        a = cat.register(
+            owner, "Paper1", content_type="paper",
+            head_hash="abc123", physical_collection="knowledge__delos",
+        )
+        b = cat.register(
+            owner, "Paper2", content_type="paper",
+            head_hash="abc123", physical_collection="knowledge__art-papers",
+        )
+
+        count = generate_pdf_corpus_links(cat)
+        assert count == 1
+
+        # Anchor is the lexicographically-first tumbler.
+        anchor = a if str(a) < str(b) else b
+        member = b if anchor == a else a
+        links = cat.links_from(member)
+        assert len(links) == 1
+        assert str(links[0].to_tumbler) == str(anchor)
+        assert links[0].link_type == "same-as"
+
+    def test_no_link_when_hash_unique(self, tmp_path: Path) -> None:
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        a = cat.register(
+            owner, "Unique", content_type="paper",
+            head_hash="unique-hash", physical_collection="knowledge__delos",
+        )
+        count = generate_pdf_corpus_links(cat)
+        assert count == 0
+        assert len(cat.links_from(a)) == 0
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        cat.register(
+            owner, "P1", content_type="paper",
+            head_hash="h1", physical_collection="knowledge__delos",
+        )
+        cat.register(
+            owner, "P2", content_type="paper",
+            head_hash="h1", physical_collection="knowledge__art-papers",
+        )
+        first = generate_pdf_corpus_links(cat)
+        second = generate_pdf_corpus_links(cat)
+        assert first == 1
+        # Re-running creates zero new links (link_if_absent).
+        assert second == 0
+
+    def test_pdfs_without_head_hash_skipped(self, tmp_path: Path) -> None:
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        cat.register(
+            owner, "NoHash1", content_type="paper",
+            head_hash="", physical_collection="knowledge__delos",
+        )
+        cat.register(
+            owner, "NoHash2", content_type="paper",
+            head_hash="", physical_collection="knowledge__art-papers",
+        )
+        count = generate_pdf_corpus_links(cat)
+        assert count == 0
+
+    def test_three_pdfs_one_anchor(self, tmp_path: Path) -> None:
+        """Three PDFs sharing a hash: two ``same-as`` links emitted
+        (member -> anchor), not three (no self-link, no pairwise
+        explosion).
+        """
+        cat = self._make_catalog(tmp_path)
+        owner = cat.register_owner("papers", "curator")
+        for i, coll in enumerate(("delos", "art-papers", "rag-papers"), start=1):
+            cat.register(
+                owner, f"P{i}", content_type="paper",
+                head_hash="trio-hash",
+                physical_collection=f"knowledge__{coll}",
+            )
+        count = generate_pdf_corpus_links(cat)
+        assert count == 2


### PR DESCRIPTION
## Summary

Closes the prose=0.1% / pdf=0% catalog auto-link coverage gap from the 2026-05-08 prod shakeout.

## Two new generators

- ``generate_prose_filepath_links``: scans ``content_type in {prose, markdown, docs}`` for code refs; relaxed regex (no source-root anchor) catches ``docs/`` + ``nx/`` paths.
- ``generate_pdf_corpus_links``: groups PDFs by ``head_hash``; emits ``same-as`` from members to a stable canonical anchor.

Both wired into ``src/nexus/indexer.py:737`` next to the existing RDR linker; both idempotent + incremental.

## Tests

9 new + 8 existing link_generator tests pass.

## Closes

- nexus-sob9