### PR TITLE
feat(classifier): skip minified bundles by default (nexus-haet)

### DIFF
--- a/src/nexus/classifier.py
+++ b/src/nexus/classifier.py
@@ -43,6 +43,36 @@ _SKIP_EXTENSIONS: frozenset[str] = frozenset({
     ".txt", ".csv", ".tsv", ".dat", ".log",
 })
 
+# nexus-haet (GH issue surfaced 2026-05-08): minified bundle filenames
+# (``htmx.min.js``, ``react.min.css``, ``vendor.min.mjs``) are
+# extension-wise indexable code, but the bytes are unreadable for
+# semantic search: mangled identifiers, no whitespace, no comments.
+# Embedding them wastes Voyage budget AND historically produced
+# oversized chunks (the 2026-05-08 audit found 84 chunks > Voyage
+# MAX_DOCUMENT_BYTES, all from a single ``htmx.min.js`` at 50,917
+# bytes each, blocking re-embed). The T3.put MAX_DOCUMENT_BYTES guard
+# (``db/t3.py:460``) drops oversized chunks defensively, but skipping
+# the file at classification time avoids the chunker churn entirely.
+#
+# Operators with a legitimate need to index minified files (e.g.
+# auditing a vendored bundle for known patterns) opt back in via
+# ``indexing_config["index_minified"] = True``.
+_MINIFIED_BASENAME_PATTERNS: tuple[str, ...] = (
+    ".min.js", ".min.mjs", ".min.cjs",
+    ".min.css",
+    ".bundle.js", ".bundle.mjs",  # Webpack / Rollup output convention.
+)
+
+
+def _is_minified_basename(basename: str) -> bool:
+    """Return True when ``basename`` matches a known minified-bundle
+    naming convention. Case-insensitive; handles double extensions
+    (e.g. ``htmx.min.js``) which a bare ``Path.suffix`` check would
+    miss (it returns ``.js``).
+    """
+    lower = basename.lower()
+    return any(lower.endswith(suffix) for suffix in _MINIFIED_BASENAME_PATTERNS)
+
 
 def _has_shebang(path: Path) -> bool:
     """Return True if *path* starts with a shebang (#!)."""
@@ -63,11 +93,14 @@ def classify_file(
 
     Priority order:
     1. PDF (always PDF)
-    2. prose_extensions config override (wins over all)
-    3. Effective code set (defaults + code_extensions config)
-    4. _SKIP_EXTENSIONS (known-noise file types)
-    5. Extensionless files: shebang → CODE, else → SKIP
-    6. Everything else → PROSE
+    2. nexus-haet: minified bundles (basename matches
+       ``_MINIFIED_BASENAME_PATTERNS``) -> SKIP, unless
+       ``indexing_config["index_minified"] = True``
+    3. prose_extensions config override (wins over all)
+    4. Effective code set (defaults + code_extensions config)
+    5. _SKIP_EXTENSIONS (known-noise file types)
+    6. Extensionless files: shebang → CODE, else → SKIP
+    7. Everything else → PROSE
     """
     ext = path.suffix.lower()
 
@@ -75,6 +108,15 @@ def classify_file(
         return ContentClass.PDF
 
     cfg = indexing_config or {}
+
+    # nexus-haet: minified-bundle skip. Runs BEFORE the code-extension
+    # check so ``htmx.min.js`` (extension ``.js``) doesn't reach the
+    # CODE branch. Operators can opt back in via
+    # ``indexing_config["index_minified"] = True``.
+    if not cfg.get("index_minified", False):
+        if _is_minified_basename(path.name):
+            return ContentClass.SKIP
+
     prose_overrides = set(cfg.get("prose_extensions", []))
     code_additions = set(cfg.get("code_extensions", []))
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -160,3 +160,89 @@ def test_case_insensitive_extension():
     from nexus.classifier import classify_file, ContentClass
     assert classify_file(Path("Main.PY")) == ContentClass.CODE
     assert classify_file(Path("Doc.PDF")) == ContentClass.PDF
+
+
+# ── nexus-haet: minified-bundle skip ─────────────────────────────────────
+
+
+class TestMinifiedBundleSkip:
+    """nexus-haet (2026-05-08 chunk-size audit): minified bundle
+    filenames (``htmx.min.js``, ``react.min.css``) are extension-wise
+    indexable code but produce ~zero search signal (mangled
+    identifiers, no whitespace) and historically generated chunks
+    larger than Voyage MAX_DOCUMENT_BYTES. Default classify as SKIP;
+    operators opt back in via ``index_minified``.
+    """
+
+    def test_min_js_classified_as_skip(self):
+        from nexus.classifier import classify_file, ContentClass
+        assert (
+            classify_file(Path("htmx.min.js"))
+            == ContentClass.SKIP
+        )
+
+    def test_min_mjs_classified_as_skip(self):
+        from nexus.classifier import classify_file, ContentClass
+        assert (
+            classify_file(Path("vendor.min.mjs"))
+            == ContentClass.SKIP
+        )
+
+    def test_min_cjs_classified_as_skip(self):
+        from nexus.classifier import classify_file, ContentClass
+        assert (
+            classify_file(Path("lib.min.cjs"))
+            == ContentClass.SKIP
+        )
+
+    def test_min_css_classified_as_skip(self):
+        from nexus.classifier import classify_file, ContentClass
+        # .css is already in _SKIP_EXTENSIONS but lock the
+        # min-pattern path explicitly so a future .css removal from
+        # the skip list (e.g. promoting CSS to prose) doesn't
+        # silently re-enable .min.css indexing.
+        assert (
+            classify_file(Path("react.min.css"))
+            == ContentClass.SKIP
+        )
+
+    def test_bundle_js_classified_as_skip(self):
+        """Webpack / Rollup produce ``vendor.bundle.js``-shape names;
+        same ~zero-signal class as min.js.
+        """
+        from nexus.classifier import classify_file, ContentClass
+        assert (
+            classify_file(Path("vendor.bundle.js"))
+            == ContentClass.SKIP
+        )
+
+    def test_non_minified_js_still_classified_as_code(self):
+        """Regression guard: a regular ``.js`` file is NOT swept up
+        by the minified-pattern check.
+        """
+        from nexus.classifier import classify_file, ContentClass
+        assert classify_file(Path("app.js")) == ContentClass.CODE
+        assert classify_file(Path("src/lib/util.js")) == ContentClass.CODE
+
+    def test_index_minified_opt_in(self):
+        """``indexing_config["index_minified"] = True`` opts back into
+        indexing minified files. The file then routes through normal
+        extension-based classification (``.min.js`` -> CODE because
+        ``.js`` is in ``_CODE_EXTENSIONS``).
+        """
+        from nexus.classifier import classify_file, ContentClass
+        cfg = {"index_minified": True}
+        assert (
+            classify_file(Path("htmx.min.js"), indexing_config=cfg)
+            == ContentClass.CODE
+        )
+
+    def test_case_insensitive_minified_match(self):
+        """Operators sometimes have ``HTMX.MIN.JS`` (case-insensitive
+        repos / Windows-derived names). Match on lowercase.
+        """
+        from nexus.classifier import classify_file, ContentClass
+        assert (
+            classify_file(Path("HTMX.MIN.JS"))
+            == ContentClass.SKIP
+        )


### PR DESCRIPTION
## Summary

Classify ``*.min.js`` / ``*.min.css`` / ``*.bundle.js`` etc as SKIP at the classifier boundary. Avoids embedding-budget waste on zero-signal mangled-identifier chunks. Operators opt back in via ``indexing_config["index_minified"] = True``.

## Audit finding

The 2026-05-08 84-oversized-chunks claim is stale; 2026-05-10 re-audit shows 0 oversized chunks (RDR-108 reidentify cleaned them). The T3 MAX_DOCUMENT_BYTES guard remains as defense-in-depth; this PR is upstream prevention.

## Tests

8 new ``TestMinifiedBundleSkip`` cases + 89 regression tests pass.

## Closes

- nexus-haet