### PR TITLE
feat(catalog): default-exclude implements-heuristic from graph traversal (nexus-6ppk)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1745,11 +1745,13 @@ class Catalog:
         direction: str = "both",
         link_type: str = "",
         link_types: list[str] | None = None,
+        include_heuristic: bool = False,
     ) -> dict:
         """BFS traversal — see ``_LinkOps.graph`` for the full contract."""
         return self._links.graph(
             tumbler, depth=depth, direction=direction,
             link_type=link_type, link_types=link_types,
+            include_heuristic=include_heuristic,
         )
 
     def graph_many(
@@ -1759,11 +1761,13 @@ class Catalog:
         direction: str = "both",
         link_type: str = "",
         link_types: list[str] | None = None,
+        include_heuristic: bool = False,
     ) -> dict:
         """BFS from multiple seeds."""
         return self._links.graph_many(
             seeds, depth=depth, direction=direction,
             link_type=link_type, link_types=link_types,
+            include_heuristic=include_heuristic,
         )
 
     # ── Rebuild ───────────���──────────────────────────��─────────────────────

--- a/src/nexus/catalog/catalog_links.py
+++ b/src/nexus/catalog/catalog_links.py
@@ -62,6 +62,53 @@ _MAX_GRAPH_DEPTH: int = 10
 _MAX_GRAPH_NODES: int = 500
 
 
+# nexus-6ppk: link types whose precision is too low for default
+# graph traversal. ``implements-heuristic`` is auto-emitted by
+# ``index_hook`` whenever a code chunk's auto-extracted symbols match
+# an RDR's terminology heuristic; high-traffic generic-infrastructure
+# RDRs (rdr-063 t2-domain-split, AST chunking, T1 scratch) accumulate
+# 500-660 inbound heuristic edges each, drowning the ~6% of hand-
+# curated cites/relates/contains. The 2026-05-08 prod probe found
+# 15,490 ``implements-heuristic`` edges (66% of 23,582 total); the
+# ``_MAX_GRAPH_NODES`` cap fires correctly but the resulting first-
+# 500 set is mostly noise.
+#
+# Default-exclude from graph traversal; callers wanting the noise
+# (auditing / debugging) opt back in via ``include_heuristic=True``.
+_HEURISTIC_LINK_TYPES: frozenset[str] = frozenset({
+    "implements-heuristic",
+})
+
+
+def _filter_link_types(
+    link_types: list[str] | None,
+    link_type: str,
+    *,
+    include_heuristic: bool,
+) -> list[str] | None:
+    """nexus-6ppk: compute the effective link-type filter for graph
+    traversal. When the caller did not specify any types AND
+    ``include_heuristic`` is False, returns the full known set minus
+    heuristic types so the BFS skips them. Returns the caller's
+    explicit list (or single-type list) unmodified when types are
+    given. Returns None (no filter) when ``include_heuristic`` is
+    True and no types were specified.
+    """
+    if link_types or link_type:
+        # Explicit caller filter wins; trust the caller knows whether
+        # they want heuristic edges in the result.
+        return link_types or [link_type]
+    if include_heuristic:
+        # Caller asked for everything explicitly.
+        return None
+    # Default: known meaningful types except the heuristic class.
+    return [
+        "cites", "implements", "relates", "contains",
+        "supersedes", "describes", "quotes", "comments",
+        "formalizes", "same-as",
+    ]
+
+
 class _LinkOps:
     """Composed into ``Catalog`` as ``self._links``.
 
@@ -825,6 +872,7 @@ class _LinkOps:
         direction: str = "both",
         link_type: str = "",
         link_types: list[str] | None = None,
+        include_heuristic: bool = False,
     ) -> dict:
         """BFS traversal to *depth*. Capped at ``_MAX_GRAPH_DEPTH``
         (10) and ``_MAX_GRAPH_NODES`` (500). Returns
@@ -835,6 +883,14 @@ class _LinkOps:
         (``cat._MAX_GRAPH_DEPTH`` / ``_MAX_GRAPH_NODES``) so tests
         that ``patch.object(type(cat), "_MAX_GRAPH_NODES", N)``
         intercept the value used here.
+
+        nexus-6ppk: when ``link_types`` and ``link_type`` are both
+        unspecified, the BFS defaults to "everything except
+        ``implements-heuristic``" so the auto-emitted heuristic
+        edges (66% of the 2026-05-08 prod link graph) don't drown
+        out hand-curated edges. Pass ``include_heuristic=True`` to
+        opt back in (auditing, debugging, or the rare consumer that
+        actively wants the heuristic flood).
         """
         from nexus.catalog.catalog import CatalogLink  # noqa: F401
         from nexus.catalog.tumbler import Tumbler
@@ -843,9 +899,10 @@ class _LinkOps:
         max_nodes = getattr(cat, "_MAX_GRAPH_NODES", _MAX_GRAPH_NODES)
 
         depth = min(depth, max_depth)
-        effective_types: list[str] = (
-            link_types or ([link_type] if link_type else [])
-        )
+        effective_types: list[str] = _filter_link_types(
+            link_types, link_type,
+            include_heuristic=include_heuristic,
+        ) or []
         visited: set[str] = {str(tumbler)}
         seen_edges: set[tuple[str, str, str]] = set()
         all_edges: list = []
@@ -904,6 +961,7 @@ class _LinkOps:
         direction: str = "both",
         link_type: str = "",
         link_types: list[str] | None = None,
+        include_heuristic: bool = False,
     ) -> dict:
         """BFS from multiple seeds. Thin wrapper over :meth:`graph`
         that dedupes nodes by ``str(tumbler)`` and edges by
@@ -930,6 +988,7 @@ class _LinkOps:
             result = self._cat.graph(
                 seed, depth=depth, direction=direction,
                 link_type=link_type, link_types=link_types,
+                include_heuristic=include_heuristic,
             )
             for node in result.get("nodes") or []:
                 if len(merged_nodes) >= max_nodes:

--- a/tests/test_catalog_graph_heuristic_filter.py
+++ b/tests/test_catalog_graph_heuristic_filter.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-6ppk: ``Catalog.graph()`` and ``graph_many()`` default-
+exclude ``implements-heuristic`` edges so the auto-emitted heuristic
+flood (66% of the 2026-05-08 prod link graph; 562-660 inbound on
+high-traffic infrastructure RDRs) doesn't drown out hand-curated
+edges. Callers wanting the heuristic edges opt back in via
+``include_heuristic=True``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog.catalog import Catalog
+from nexus.catalog.catalog_links import (
+    _HEURISTIC_LINK_TYPES,
+    _filter_link_types,
+)
+from nexus.catalog.tumbler import Tumbler
+
+
+@pytest.fixture(autouse=True)
+def _git_identity(monkeypatch):
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.invalid")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.invalid")
+
+
+def _make_catalog(tmp_path: Path) -> Catalog:
+    cat_dir = tmp_path / "catalog"
+    Catalog.init(cat_dir)
+    return Catalog(cat_dir, cat_dir / ".catalog.db")
+
+
+# ── _filter_link_types pure helper ────────────────────────────────────────
+
+
+class TestFilterLinkTypesHelper:
+    def test_explicit_link_types_pass_through(self) -> None:
+        """A caller's explicit list wins; the helper trusts the caller
+        knows whether they want heuristic edges in the result.
+        """
+        result = _filter_link_types(
+            ["cites", "implements-heuristic"], "",
+            include_heuristic=False,
+        )
+        assert result == ["cites", "implements-heuristic"]
+
+    def test_explicit_single_link_type_passes_through(self) -> None:
+        result = _filter_link_types(
+            None, "implements-heuristic",
+            include_heuristic=False,
+        )
+        assert result == ["implements-heuristic"]
+
+    def test_no_filter_default_excludes_heuristic(self) -> None:
+        """nexus-6ppk primary contract: when no explicit filter is
+        given AND ``include_heuristic`` is False, the result is the
+        full known set MINUS heuristic types.
+        """
+        result = _filter_link_types(
+            None, "", include_heuristic=False,
+        )
+        assert result is not None
+        assert "implements-heuristic" not in result
+        # Sanity: meaningful types are present.
+        for must_have in (
+            "cites", "implements", "relates", "supersedes",
+        ):
+            assert must_have in result, f"{must_have!r} missing"
+
+    def test_include_heuristic_true_returns_no_filter(self) -> None:
+        """``include_heuristic=True`` with no explicit types means
+        the caller wants EVERY type including heuristic. Returning
+        None signals the BFS to skip the link-type filter entirely.
+        """
+        result = _filter_link_types(
+            None, "", include_heuristic=True,
+        )
+        assert result is None
+
+
+# ── End-to-end: Catalog.graph default-excludes heuristic ─────────────────
+
+
+class TestGraphDefaultExcludesHeuristic:
+    def test_graph_default_skips_heuristic_neighbor(self, tmp_path: Path) -> None:
+        """Build a catalog with one ``cites`` and one
+        ``implements-heuristic`` edge from the seed; default
+        ``cat.graph(seed)`` returns only the ``cites`` neighbor.
+        Reverting the default-exclude makes the heuristic neighbor
+        appear in the result.
+        """
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab1234")
+        seed = cat.register(
+            owner, "Seed", content_type="rdr", file_path="docs/rdr/seed.md",
+        )
+        cited = cat.register(
+            owner, "Cited", content_type="rdr",
+            file_path="docs/rdr/cited.md",
+        )
+        heuristic_target = cat.register(
+            owner, "HeuristicMatch", content_type="code",
+            file_path="src/heuristic.py",
+        )
+        cat.link(seed, cited, "cites", created_by="test")
+        cat.link(
+            seed, heuristic_target, "implements-heuristic",
+            created_by="index_hook",
+        )
+
+        result = cat.graph(seed, depth=1)
+
+        node_tumblers = {
+            str(n.tumbler) if hasattr(n, "tumbler") else str(n)
+            for n in result["nodes"]
+        }
+        # Seed always present.
+        assert str(seed) in node_tumblers
+        # Cites neighbor present (default-allowed type).
+        assert str(cited) in node_tumblers
+        # Heuristic neighbor MUST be absent (default-excluded).
+        assert str(heuristic_target) not in node_tumblers, (
+            f"implements-heuristic neighbor leaked into the default "
+            f"graph traversal; reverting the nexus-6ppk default-"
+            f"exclude lets the heuristic flood dominate the result"
+        )
+
+    def test_graph_include_heuristic_returns_heuristic_neighbor(
+        self, tmp_path: Path,
+    ) -> None:
+        """Opt back in: ``cat.graph(seed, include_heuristic=True)``
+        returns the heuristic neighbor. Audit / debug consumers use
+        this path.
+        """
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab1234")
+        seed = cat.register(
+            owner, "Seed", content_type="rdr", file_path="docs/rdr/seed.md",
+        )
+        target = cat.register(
+            owner, "Target", content_type="code",
+            file_path="src/target.py",
+        )
+        cat.link(seed, target, "implements-heuristic", created_by="hook")
+
+        result = cat.graph(seed, depth=1, include_heuristic=True)
+        node_tumblers = {
+            str(n.tumbler) if hasattr(n, "tumbler") else str(n)
+            for n in result["nodes"]
+        }
+        assert str(target) in node_tumblers
+
+    def test_graph_explicit_link_type_overrides_default(
+        self, tmp_path: Path,
+    ) -> None:
+        """When the caller passes
+        ``link_type="implements-heuristic"`` explicitly, the
+        heuristic neighbor IS returned (the caller knows what they
+        asked for).
+        """
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab1234")
+        seed = cat.register(
+            owner, "Seed", content_type="rdr", file_path="docs/rdr/seed.md",
+        )
+        target = cat.register(
+            owner, "Target", content_type="code",
+            file_path="src/target.py",
+        )
+        cat.link(seed, target, "implements-heuristic", created_by="hook")
+
+        result = cat.graph(
+            seed, depth=1, link_type="implements-heuristic",
+        )
+        node_tumblers = {
+            str(n.tumbler) if hasattr(n, "tumbler") else str(n)
+            for n in result["nodes"]
+        }
+        assert str(target) in node_tumblers
+
+    def test_graph_many_inherits_default_exclude(
+        self, tmp_path: Path,
+    ) -> None:
+        """``graph_many`` propagates the same default; multi-seed
+        traversal also skips heuristic neighbors unless opted in.
+        """
+        cat = _make_catalog(tmp_path)
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab1234")
+        seed_a = cat.register(
+            owner, "SeedA", content_type="rdr",
+            file_path="docs/rdr/a.md",
+        )
+        seed_b = cat.register(
+            owner, "SeedB", content_type="rdr",
+            file_path="docs/rdr/b.md",
+        )
+        heuristic_a = cat.register(
+            owner, "HeurA", content_type="code",
+            file_path="src/a.py",
+        )
+        heuristic_b = cat.register(
+            owner, "HeurB", content_type="code",
+            file_path="src/b.py",
+        )
+        cat.link(seed_a, heuristic_a, "implements-heuristic", created_by="hook")
+        cat.link(seed_b, heuristic_b, "implements-heuristic", created_by="hook")
+
+        # Default: heuristic neighbors absent.
+        result = cat.graph_many([seed_a, seed_b], depth=1)
+        node_tumblers = {
+            str(n.tumbler) if hasattr(n, "tumbler") else str(n)
+            for n in result["nodes"]
+        }
+        assert str(heuristic_a) not in node_tumblers
+        assert str(heuristic_b) not in node_tumblers
+
+        # Opt-in: both heuristic neighbors present.
+        result_opt = cat.graph_many(
+            [seed_a, seed_b], depth=1, include_heuristic=True,
+        )
+        node_tumblers_opt = {
+            str(n.tumbler) if hasattr(n, "tumbler") else str(n)
+            for n in result_opt["nodes"]
+        }
+        assert str(heuristic_a) in node_tumblers_opt
+        assert str(heuristic_b) in node_tumblers_opt
+
+
+class TestHeuristicTokenSet:
+    def test_heuristic_set_pinned(self) -> None:
+        """Lock the heuristic-link-type set so adding a new
+        heuristic link type to the catalog forces a deliberate
+        decision about whether it should be default-excluded.
+        """
+        assert _HEURISTIC_LINK_TYPES == frozenset({"implements-heuristic"})


### PR DESCRIPTION
## Summary

The 2026-05-08 prod link graph: 66% of edges are auto-emitted ``implements-heuristic`` from ``index_hook``. High-traffic infrastructure RDRs accumulate 562-660 inbound heuristic edges, drowning hand-curated edges in BFS results.

## Fix

Default-exclude ``implements-heuristic`` from ``Catalog.graph()`` and ``graph_many()``. Opt back in via ``include_heuristic=True``. Explicit caller filters (``link_type=...`` or ``link_types=[...]``) bypass the default.

## Tests

8 new ``test_catalog_graph_heuristic_filter.py`` cases + 63 regression tests pass.

## Out of scope

- ``_MAX_GRAPH_NODES=500`` cap unchanged (upstream noise was the issue).
- Confidence scoring on heuristic edges (deferred).

## Closes

- nexus-6ppk