### PR TITLE
feat(indexer): defer T3 collection creation until first chunk write (nexus-27u7)

### DIFF
--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -2097,20 +2097,46 @@ def _run_index(
         # collection names so the indexing run still completes.
         _log.warning("phase4_migration_failed", exc_info=True)
 
-    _log.debug("creating collections", code=code_collection, docs=docs_collection)
-    code_col = db.get_or_create_collection(code_collection)
-    docs_col = db.get_or_create_collection(docs_collection)
+    # nexus-27u7: defer T3 collection creation to the per-content-type
+    # branches that actually have files. Pre-fix the indexer
+    # unconditionally created both ``code__`` and ``docs__`` collections
+    # at the start of every ``nx index repo`` run; a code-only repo
+    # (no .md / .rst) accumulated an empty ``docs__`` zombie that
+    # ``nx catalog collection-gc`` had to sweep later. Symmetric for
+    # docs-only corpora.
+    #
+    # Downstream call sites already handle ``code_col is None`` /
+    # ``docs_col is None`` (frecency reads at indexer.py:1676,
+    # build_staleness_cache below, stamp_collection_version below);
+    # the missing piece was the gate here.
+    have_code_files = bool(code_files)
+    have_docs_files = bool(prose_files or pdf_files)
+    _log.debug(
+        "creating collections",
+        code=code_collection if have_code_files else "(deferred; no files)",
+        docs=docs_collection if have_docs_files else "(deferred; no files)",
+    )
+    code_col = (
+        db.get_or_create_collection(code_collection)
+        if have_code_files else None
+    )
+    docs_col = (
+        db.get_or_create_collection(docs_collection)
+        if have_docs_files else None
+    )
     _log.debug("collections ready")
 
     # Check pipeline version staleness (informational warning only)
-    check_pipeline_staleness(code_col, code_collection)
-    check_pipeline_staleness(docs_col, docs_collection)
+    if code_col is not None:
+        check_pipeline_staleness(code_col, code_collection)
+    if docs_col is not None:
+        check_pipeline_staleness(docs_col, docs_collection)
 
     # --force-stale: escalate to force if any collection is stale
     if force_stale:
         any_stale = (
-            get_collection_pipeline_version(code_col) not in (None, PIPELINE_VERSION)
-            or get_collection_pipeline_version(docs_col) not in (None, PIPELINE_VERSION)
+            (code_col is not None and get_collection_pipeline_version(code_col) not in (None, PIPELINE_VERSION))
+            or (docs_col is not None and get_collection_pipeline_version(docs_col) not in (None, PIPELINE_VERSION))
         )
         if any_stale:
             _log.info("force_stale_escalating", reason="stale collection detected")
@@ -2185,8 +2211,19 @@ def _run_index(
     if on_phase is not None:
         on_phase("Building staleness caches…")
     _staleness_t0 = time.monotonic()
-    code_staleness = build_staleness_cache(code_col)
-    docs_staleness = build_staleness_cache(docs_col)
+    # nexus-27u7: empty StalenessCache when the collection wasn't
+    # created (no files of that content_type). Caller-side
+    # ``check_staleness(cache=…)`` falls through to the per-file path,
+    # which itself short-circuits on a missing collection.
+    from nexus.indexer_utils import StalenessCache  # noqa: PLC0415
+    code_staleness = (
+        build_staleness_cache(code_col) if code_col is not None
+        else StalenessCache()
+    )
+    docs_staleness = (
+        build_staleness_cache(docs_col) if docs_col is not None
+        else StalenessCache()
+    )
     _log.info(
         "staleness_caches_built",
         code_doc_ids=len(code_staleness.by_doc_id),
@@ -2354,8 +2391,11 @@ def _run_index(
         # a state that should never have existed.
         _phase("Stamping pipeline version…")
         _t = time.monotonic()
-        stamp_collection_version(code_col)
-        stamp_collection_version(docs_col)
+        # nexus-27u7: stamp only when the collection was created.
+        if code_col is not None:
+            stamp_collection_version(code_col)
+        if docs_col is not None:
+            stamp_collection_version(docs_col)
         if rdr_indexed > 0:
             # RDR-103 Phase 3a: catalog-first resolution; legacy
             # fallback retained for catalog-absent test paths.

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1568,3 +1568,104 @@ def test_prose_indexer_non_markdown_metadata(tmp_path):
         h = x["chunk_text_hash"]; assert len(h) == 64
         assert h == hashlib.sha256(doc.encode()).hexdigest()
         assert x.get("section_type") == ""
+
+
+# ── nexus-27u7: lazy collection creation ─────────────────────────────────
+
+
+def test_run_index_skips_docs_collection_for_code_only_repo(tmp_path):
+    """nexus-27u7: a code-only repo MUST NOT create the docs__
+    collection at the start of ``_run_index``. Pre-fix the indexer
+    pre-created BOTH ``code__`` and ``docs__`` regardless of file
+    composition; a code-only repo accumulated an empty zombie
+    ``docs__`` that ``nx catalog collection-gc`` had to sweep later.
+
+    Reverting the lazy-creation gate (re-introducing
+    ``code_col = db.get_or_create_collection(code_collection);
+    docs_col = db.get_or_create_collection(docs_collection)``)
+    makes this test fail because the docs name appears in the
+    get_or_create_collection call list.
+    """
+    from nexus.indexer import _run_index
+    repo = tmp_path / "repo"; repo.mkdir()
+    (repo / "main.py").write_text("x = 1\n")  # code only
+    db, col = _mock_db()
+    v = _voyage(1)
+    with _patches(db, extra={
+        "nexus.chunker.chunk_file": {"return_value": [_chunk()]},
+        "voyageai.Client": {"return_value": v},
+    }):
+        _run_index(repo, _reg())
+
+    # Inspect every collection name passed to get_or_create_collection.
+    created = [
+        call.args[0] if call.args else call.kwargs.get("name", "")
+        for call in db.get_or_create_collection.call_args_list
+    ]
+    docs_created = [n for n in created if n.startswith("docs__")]
+    assert not docs_created, (
+        f"docs collection should NOT have been created for code-only "
+        f"repo (nexus-27u7); got created: {docs_created!r}"
+    )
+
+
+def test_run_index_skips_code_collection_for_docs_only_repo(tmp_path):
+    """nexus-27u7 symmetric case: a docs-only repo (.md files only)
+    MUST NOT create the code__ collection.
+    """
+    from nexus.indexer import _run_index
+    repo = tmp_path / "repo"; repo.mkdir()
+    (repo / "README.md").write_text("# Title\n\nSome prose.\n")  # docs only
+    db, col = _mock_db()
+    with _patches(db, extra={
+        "nexus.doc_indexer._embed_with_fallback": {
+            "return_value": ([[0.1]*10], "voyage-context-3"),
+        },
+    }):
+        _run_index(repo, _reg())
+
+    created = [
+        call.args[0] if call.args else call.kwargs.get("name", "")
+        for call in db.get_or_create_collection.call_args_list
+    ]
+    code_created = [n for n in created if n.startswith("code__")]
+    assert not code_created, (
+        f"code collection should NOT have been created for docs-only "
+        f"repo (nexus-27u7); got created: {code_created!r}"
+    )
+
+
+def test_run_index_creates_both_for_mixed_repo(tmp_path):
+    """nexus-27u7 regression guard: a mixed repo (code + docs)
+    creates BOTH collections. Lazy-creation must not regress the
+    happy path.
+    """
+    from nexus.indexer import _run_index
+    repo = tmp_path / "repo"; repo.mkdir()
+    (repo / "main.py").write_text("x = 1\n")
+    (repo / "README.md").write_text("# Title\n\nProse.\n")
+    db, col = _mock_db()
+    v = _voyage(1)
+    with _patches(db, extra={
+        "nexus.chunker.chunk_file": {"return_value": [_chunk()]},
+        "voyageai.Client": {"return_value": v},
+        "nexus.doc_indexer._embed_with_fallback": {
+            "return_value": ([[0.1]*10], "voyage-context-3"),
+        },
+    }):
+        _run_index(repo, _reg())
+
+    created = [
+        call.args[0] if call.args else call.kwargs.get("name", "")
+        for call in db.get_or_create_collection.call_args_list
+    ]
+    code_created = [n for n in created if n.startswith("code__")]
+    docs_created = [n for n in created if n.startswith("docs__")]
+    assert code_created, (
+        "mixed repo must create code__ collection; "
+        "lazy-creation gate is over-eager"
+    )
+    assert docs_created, (
+        "mixed repo must create docs__ collection; "
+        "lazy-creation gate is over-eager"
+    )


### PR DESCRIPTION
## Summary

Stop pre-creating ``code__`` and ``docs__`` T3 collections unconditionally at the start of ``nx index repo``. Gate on whether files of that content type were classified; guard the downstream call sites to handle the ``None`` case.

## Tests

3 new regression cases (code-only skip, docs-only skip, mixed-repo positive guard) + 88 existing pass. 91 total.

## Closes

- nexus-27u7