### PR TITLE
nx catalog orphan-backfill (h2pm + 4fw8 + oa9k)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -350,6 +350,15 @@ from nexus.catalog.catalog_writes import ManifestRow as _ManifestRow  # noqa: E4
 # clear error elsewhere.
 _KNOWN_URI_SCHEMES: frozenset[str] = frozenset({
     "file", "chroma", "https", "nx-scratch", "x-devonthink-item",
+    # ``nx-orphan-backfill://<collection>/<title|chash/<hash>>`` is a
+    # marker scheme used by ``nx catalog orphan-backfill synthetic`` to
+    # register catalog Documents for T3 chunks that have no recoverable
+    # source on disk and no DEVONthink match. No reader is registered:
+    # consumers reading these URIs receive ``scheme_unknown`` and skip,
+    # which is the correct behavior since the underlying source IS
+    # genuinely unavailable. The Document still serves to populate the
+    # ``document_chunks`` manifest so doctor reports clean.
+    "nx-orphan-backfill",
 })
 
 

--- a/src/nexus/catalog/orphan_backfill.py
+++ b/src/nexus/catalog/orphan_backfill.py
@@ -545,3 +545,132 @@ def apply_csv(
             ])
             links += len(chunks)
     return docs, links
+
+
+# ── Link T3 chunks to EXISTING catalog Documents ─────────────────────────────
+
+
+def link_by_title(
+    catalog: "Catalog",
+    collection: str,
+    groups: list[TitleGroup],
+) -> tuple[int, int, list[TitleGroup]]:
+    """For each titled group, find an existing catalog Document with the
+    same title in ``collection`` and append manifest rows linking the
+    group's chunks to that Document.
+
+    Returns ``(linked_chunks, linked_docs, unlinked_groups)``.
+    ``unlinked_groups`` are groups whose title has no catalog match;
+    callers route them to synthetic mode.
+
+    Untitled groups are passed through to ``unlinked_groups`` so
+    callers can branch them to chash fallback.
+    """
+    rows = catalog._db.execute(
+        "SELECT tumbler, title FROM documents "
+        "WHERE physical_collection = ? AND title != ''",
+        (collection,),
+    ).fetchall()
+    by_title: dict[str, str] = {r[1]: r[0] for r in rows}
+    linked_chunks = 0
+    linked_docs = 0
+    unlinked: list[TitleGroup] = []
+    for g in groups:
+        if not g.title or g.title not in by_title:
+            unlinked.append(g)
+            continue
+        tumbler = by_title[g.title]
+        # Read existing manifest to know where to append (preserve order).
+        existing = catalog.get_manifest(tumbler)
+        start_pos = len(existing)
+        catalog.append_manifest_chunks(tumbler, [
+            {
+                "chash": c.chash,
+                "position": start_pos + pos,
+                "line_start": None, "line_end": None,
+                "char_start": None, "char_end": None,
+            }
+            for pos, c in enumerate(g.chunks)
+        ])
+        linked_chunks += len(g.chunks)
+        linked_docs += 1
+        _log.info(
+            "orphan_backfill_linked_by_title",
+            collection=collection, tumbler=tumbler,
+            title=g.title, chunks=len(g.chunks),
+        )
+    return linked_chunks, linked_docs, unlinked
+
+
+def link_by_content_hash(
+    catalog: "Catalog",
+    t3_db,
+    collection: str,
+) -> tuple[int, int, int]:
+    """For each existing catalog Document with non-empty ``head_hash``,
+    find T3 chunks in ``collection`` whose ``content_hash`` matches and
+    append manifest rows.
+
+    Returns ``(linked_chunks, linked_docs, unmatched_chunks)``.
+
+    Used when T3 chunks lack ``title`` metadata but have
+    ``content_hash`` (PDF-shaped chunks), and the catalog has
+    Documents with ``head_hash`` populated. The two hashes are the
+    same content-addressed identity so matching is exact.
+    """
+    rows = catalog._db.execute(
+        "SELECT tumbler, head_hash FROM documents "
+        "WHERE physical_collection = ? AND head_hash != ''",
+        (collection,),
+    ).fetchall()
+    by_head: dict[str, str] = {r[1]: r[0] for r in rows}
+    if not by_head:
+        return 0, 0, 0
+
+    col = t3_db._client.get_collection(name=collection)
+    n = col.count()
+    # Group chunks by content_hash so we batch one append_manifest per doc.
+    by_hash: dict[str, list[ChunkRef]] = defaultdict(list)
+    unmatched = 0
+    offset = 0
+    while offset < n:
+        batch = col.get(limit=_PAGE, offset=offset, include=["metadatas"])
+        cids = batch.get("ids") or []
+        metas = batch.get("metadatas") or []
+        for cid, meta in zip(cids, metas):
+            if not isinstance(meta, dict):
+                meta = {}
+            content_hash = str(meta.get("content_hash") or "")
+            chash = str(meta.get("chunk_text_hash") or cid[:32])
+            chunk_index = int(meta.get("chunk_index", 0) or 0)
+            if content_hash and content_hash in by_head:
+                by_hash[content_hash].append(ChunkRef(
+                    cid=cid, chash=chash, chunk_index=chunk_index,
+                ))
+            else:
+                unmatched += 1
+        offset += _PAGE
+
+    linked_chunks = 0
+    linked_docs = 0
+    for content_hash, chunks in by_hash.items():
+        tumbler = by_head[content_hash]
+        existing = catalog.get_manifest(tumbler)
+        start_pos = len(existing)
+        catalog.append_manifest_chunks(tumbler, [
+            {
+                "chash": c.chash,
+                "position": start_pos + pos,
+                "line_start": None, "line_end": None,
+                "char_start": None, "char_end": None,
+            }
+            for pos, c in enumerate(chunks)
+        ])
+        linked_chunks += len(chunks)
+        linked_docs += 1
+        _log.info(
+            "orphan_backfill_linked_by_content_hash",
+            collection=collection, tumbler=tumbler,
+            content_hash=content_hash[:16], chunks=len(chunks),
+        )
+    return linked_chunks, linked_docs, unmatched

--- a/src/nexus/catalog/orphan_backfill.py
+++ b/src/nexus/catalog/orphan_backfill.py
@@ -1,0 +1,547 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Orphan T3 chunk backfill: synthesize catalog Documents for chunks
+that exist in T3 but have no catalog entry.
+
+Complementary to ``nexus.catalog.manifest_backfill``:
+
+* ``manifest_backfill``: catalog Documents exist; ``document_chunks``
+  manifest is missing. Walk catalog docs, query T3 by doc_id, write rows.
+* ``orphan_backfill`` (this module): catalog Documents do NOT exist.
+  Walk T3 chunks, group by title (or content hash), synthesize Documents,
+  write manifest rows.
+
+Three modes:
+
+1. ``DT-link``: search DEVONthink for each title, register Documents
+   with ``source_uri='x-devonthink-item://<UUID>'`` for high-precision
+   matches (score >= ``DEFAULT_MIN_SCORE``).
+2. ``Synthetic``: for chunks without DT match (or for collections
+   where DT lookup is impossible), register Documents with
+   ``source_uri='nx-orphan-backfill://<collection>/<title_or_chash>'``
+   so doctor reports clean without claiming false provenance.
+3. ``CSV triage``: dump matched / low-confidence / unmatched titles to
+   CSV files for operator review; ``apply_csv`` reads the curated
+   output and registers the operator's verified UUID assignments.
+
+Beads: nexus-h2pm (DT-link), nexus-4fw8 (synthetic), nexus-oa9k (CSV).
+"""
+from __future__ import annotations
+
+import csv
+import difflib
+import re
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+
+from nexus.db.chroma_quotas import QUOTAS
+
+if TYPE_CHECKING:
+    from nexus.catalog.catalog import Catalog
+    from nexus.catalog.tumbler import Tumbler
+
+_log = structlog.get_logger(__name__)
+
+DEFAULT_MIN_SCORE: float = 0.75
+LOW_CONF_FLOOR: float = 0.55
+DEFAULT_SEARCH_TOP_K: int = 30
+_PAGE = QUOTAS.MAX_RECORDS_PER_WRITE  # 300
+
+#: Curator owner-tumbler-prefix per orphan-prone collection.
+#: Operators add new collections here as they appear in the orphan
+#: census. Owners must already exist in the catalog.
+DEFAULT_COLLECTION_OWNER: dict[str, str] = {
+    "knowledge__art-papers": "1.9",
+    "knowledge__art": "1.9",
+    "knowledge__devonthink": "1.9",
+    "knowledge__hybridrag": "1.9",
+    "knowledge__delos": "1.9",
+    "knowledge__knowledge": "1.10",
+    "knowledge__test": "1.18",
+    "docs__default": "1.20",
+}
+
+
+# ── Data shapes ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ChunkRef:
+    """One T3 chunk awaiting a catalog Document."""
+
+    cid: str  #: Chroma natural ID
+    chash: str  #: chunk_text_hash[:32]; falls back to cid[:32]
+    chunk_index: int = 0
+
+
+@dataclass
+class TitleGroup:
+    """Chunks sharing one title, candidate for one Document."""
+
+    title: str
+    chunks: list[ChunkRef] = field(default_factory=list)
+
+
+@dataclass
+class DTMatch:
+    """Outcome of DEVONthink fuzzy match for one TitleGroup."""
+
+    title: str
+    dt_uuid: str
+    dt_name: str
+    score: float
+    chunks: list[ChunkRef] = field(default_factory=list)
+
+
+@dataclass
+class BackfillReport:
+    """Summary of a backfill run."""
+
+    collection: str
+    titles_total: int = 0
+    chunks_total: int = 0
+    matched: list[DTMatch] = field(default_factory=list)
+    low_confidence: list[DTMatch] = field(default_factory=list)
+    unmatched: list[TitleGroup] = field(default_factory=list)
+    docs_registered: int = 0
+    chunks_linked: int = 0
+
+
+# ── T3 chunk gathering ───────────────────────────────────────────────────────
+
+
+def gather_titled_chunks(
+    t3_db,
+    collection: str,
+) -> list[TitleGroup]:
+    """Pull all chunks from a T3 collection and group by ``title`` metadata.
+
+    Strips trailing ``:page-N`` / ``:1-794`` suffixes so chunks of the
+    same source-document collapse to one group.
+
+    Chunks lacking a title fall under the empty-string key ``''`` and are
+    returned as a single group; callers can branch on them (use chash
+    grouping or skip).
+    """
+    col = t3_db._client.get_collection(name=collection)
+    n = col.count()
+    by_title: dict[str, list[ChunkRef]] = defaultdict(list)
+    offset = 0
+    while offset < n:
+        batch = col.get(
+            limit=_PAGE, offset=offset, include=["metadatas"],
+        )
+        cids = batch.get("ids") or []
+        metas = batch.get("metadatas") or []
+        for cid, meta in zip(cids, metas):
+            if not isinstance(meta, dict):
+                meta = {}
+            t = str(meta.get("title") or "").strip()
+            t = re.sub(r":[A-Za-z0-9\-]+$", "", t).strip()
+            chash = str(meta.get("chunk_text_hash") or cid[:32])
+            chunk_index = int(meta.get("chunk_index", 0) or 0)
+            by_title[t].append(ChunkRef(
+                cid=cid, chash=chash, chunk_index=chunk_index,
+            ))
+        offset += _PAGE
+    return [TitleGroup(title=t, chunks=cs) for t, cs in by_title.items()]
+
+
+# ── DEVONthink search via osascript ──────────────────────────────────────────
+
+
+class DTSearchError(RuntimeError):
+    """osascript or DEVONthink query failure."""
+
+
+def _osascript(script: str, *, timeout: int = 30) -> str:
+    r = subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    if r.returncode != 0:
+        raise DTSearchError(
+            f"osascript exit {r.returncode}: {r.stderr.strip()}"
+        )
+    return r.stdout.strip()
+
+
+def dt_search(
+    query: str, *, top_k: int = DEFAULT_SEARCH_TOP_K, timeout: int = 20,
+) -> list[tuple[str, str]]:
+    """Single-query DEVONthink search. Returns up to ``top_k`` ``(uuid, name)`` pairs."""
+    safe = query.replace("\\", "\\\\").replace('"', '\\"')
+    script = (
+        'tell application "DEVONthink"\n'
+        f'    set theResults to search "{safe}"\n'
+        '    set theOutput to ""\n'
+        '    set theCount to count of theResults\n'
+        f'    if theCount > {top_k} then set theCount to {top_k}\n'
+        '    repeat with i from 1 to theCount\n'
+        '        set rec to item i of theResults\n'
+        '        set theOutput to theOutput & (uuid of rec) & "\\t" & '
+        '(name of rec) & linefeed\n'
+        '    end repeat\n'
+        '    return theOutput\n'
+        'end tell'
+    )
+    out = _osascript(script, timeout=timeout)
+    pairs: list[tuple[str, str]] = []
+    for line in out.split("\n"):
+        if "\t" in line:
+            u, n = line.split("\t", 1)
+            pairs.append((u.strip(), n.strip()))
+    return pairs
+
+
+def dt_multi_search(
+    title: str, *, top_k: int = DEFAULT_SEARCH_TOP_K,
+) -> list[tuple[str, str]]:
+    """Issue several query variants per title and merge the candidate
+    pool; deduplicates by UUID. Variants explore different word slices
+    so DT's substring search returns different candidate sets."""
+    queries: list[str] = []
+    no_year = re.sub(r"\b(19|20)\d{2}\b", " ", title)
+    cleaned = re.sub(r"[^\w\s]", " ", no_year).strip()
+    words = cleaned.split()
+    if not words:
+        return []
+    queries.append(" ".join(words[:6]))
+    if len(words) >= 3:
+        queries.append(" ".join(words[:3]))
+        queries.append(" ".join(words[-3:]))
+    queries.append(title)
+    if len(words) >= 6:
+        queries.append(" ".join(words[2:6]))
+
+    seen: set[str] = set()
+    merged: list[tuple[str, str]] = []
+    for q in queries:
+        if not q:
+            continue
+        try:
+            for u, n in dt_search(q, top_k=top_k):
+                if u not in seen:
+                    seen.add(u)
+                    merged.append((u, n))
+        except DTSearchError as e:
+            _log.debug("dt_multi_search_query_failed", query=q, error=str(e))
+            continue
+    return merged
+
+
+def best_match(
+    title: str,
+    candidates: list[tuple[str, str]],
+    *,
+    min_score: float = DEFAULT_MIN_SCORE,
+) -> tuple[float, str, str] | None:
+    """Score candidates by ``difflib.SequenceMatcher`` against ``title``;
+    return the top candidate if its score >= ``min_score``."""
+    if not candidates:
+        return None
+    title_lower = title.lower()
+    scored = [
+        (
+            difflib.SequenceMatcher(None, title_lower, n.lower()).ratio(),
+            u, n,
+        )
+        for u, n in candidates
+    ]
+    scored.sort(reverse=True)
+    return scored[0] if scored[0][0] >= min_score else None
+
+
+# ── Backfill execution ───────────────────────────────────────────────────────
+
+
+def classify_groups(
+    groups: list[TitleGroup],
+    *,
+    min_score: float = DEFAULT_MIN_SCORE,
+    low_conf_floor: float = LOW_CONF_FLOOR,
+    searcher=dt_multi_search,
+) -> tuple[list[DTMatch], list[DTMatch], list[TitleGroup]]:
+    """Run DT lookup for each group; partition into
+    ``(matched, low_confidence, unmatched)``.
+
+    ``matched`` are at score >= ``min_score`` (high-precision).
+    ``low_confidence`` are at ``[low_conf_floor, min_score)``, suitable
+    for CSV triage.
+    ``unmatched`` had no candidates above ``low_conf_floor``.
+
+    ``searcher`` is injectable for testing without DEVONthink running.
+    """
+    matched: list[DTMatch] = []
+    low_conf: list[DTMatch] = []
+    unmatched: list[TitleGroup] = []
+    for g in groups:
+        if not g.title:
+            # No title metadata; cannot DT-search. Fall through to unmatched
+            # (caller routes to synthetic mode via chash grouping).
+            unmatched.append(g)
+            continue
+        cands = searcher(g.title)
+        # Try at the lower threshold to catch low-conf bucket too.
+        best_low = best_match(g.title, cands, min_score=low_conf_floor)
+        if best_low is None:
+            unmatched.append(g)
+            continue
+        score, u, name = best_low
+        match = DTMatch(
+            title=g.title, dt_uuid=u, dt_name=name, score=score,
+            chunks=g.chunks,
+        )
+        if score >= min_score:
+            matched.append(match)
+        else:
+            low_conf.append(match)
+    return matched, low_conf, unmatched
+
+
+def register_dt_linked(
+    catalog: "Catalog",
+    owner: "Tumbler",
+    collection: str,
+    matches: list[DTMatch],
+) -> tuple[int, int]:
+    """Register one Document per match with ``x-devonthink-item://`` URI;
+    write document_chunks rows. Returns ``(docs_registered, chunks_linked)``."""
+    docs = 0
+    links = 0
+    for m in matches:
+        tumbler = catalog.register(
+            owner,
+            title=m.title,
+            content_type="pdf",
+            file_path="",
+            physical_collection=collection,
+            chunk_count=len(m.chunks),
+            source_uri=f"x-devonthink-item://{m.dt_uuid}",
+            meta={
+                "backfill_from": "t3_orphan",
+                "backfill_mode": "dt_link",
+                "dt_uuid": m.dt_uuid,
+                "dt_name": m.dt_name,
+                "fuzzy_score": round(m.score, 3),
+            },
+        )
+        docs += 1
+        chunks_payload = [
+            {
+                "chash": c.chash,
+                "position": pos,
+                "line_start": None, "line_end": None,
+                "char_start": None, "char_end": None,
+            }
+            for pos, c in enumerate(m.chunks)
+        ]
+        catalog.write_manifest(str(tumbler), chunks_payload)
+        links += len(chunks_payload)
+        _log.info(
+            "orphan_backfill_dt_linked",
+            collection=collection, tumbler=str(tumbler),
+            dt_uuid=m.dt_uuid, score=m.score, chunks=len(m.chunks),
+        )
+    return docs, links
+
+
+def register_synthetic(
+    catalog: "Catalog",
+    owner: "Tumbler",
+    collection: str,
+    groups: list[TitleGroup],
+) -> tuple[int, int]:
+    """Register one Document per group with synthetic
+    ``nx-orphan-backfill://`` URI; write document_chunks rows.
+
+    For groups lacking a title, falls back to chash-grouping: each
+    distinct chash gets its own minimal Document so manifest rows can
+    still be written. The synthetic URI scheme is intentionally clear
+    so search consumers can distinguish residual data from authoritative
+    provenance."""
+    docs = 0
+    links = 0
+    for g in groups:
+        if g.title:
+            uri = f"nx-orphan-backfill://{collection}/{g.title}"
+            title = g.title
+            chunks_payload = [
+                {
+                    "chash": c.chash, "position": pos,
+                    "line_start": None, "line_end": None,
+                    "char_start": None, "char_end": None,
+                }
+                for pos, c in enumerate(g.chunks)
+            ]
+            tumbler = catalog.register(
+                owner,
+                title=title,
+                content_type="pdf",
+                file_path="",
+                physical_collection=collection,
+                chunk_count=len(g.chunks),
+                source_uri=uri,
+                meta={
+                    "backfill_from": "t3_orphan",
+                    "backfill_mode": "synthetic",
+                },
+            )
+            docs += 1
+            catalog.write_manifest(str(tumbler), chunks_payload)
+            links += len(chunks_payload)
+        else:
+            # No title; bucket each chunk under its chash as a singleton doc.
+            for c in g.chunks:
+                title = f"orphan-chunk-{c.chash[:12]}"
+                uri = f"nx-orphan-backfill://{collection}/chash/{c.chash}"
+                tumbler = catalog.register(
+                    owner,
+                    title=title,
+                    content_type="pdf",
+                    file_path="",
+                    physical_collection=collection,
+                    chunk_count=1,
+                    source_uri=uri,
+                    meta={
+                        "backfill_from": "t3_orphan",
+                        "backfill_mode": "synthetic_chash",
+                        "chash": c.chash,
+                    },
+                )
+                docs += 1
+                catalog.write_manifest(str(tumbler), [{
+                    "chash": c.chash, "position": 0,
+                    "line_start": None, "line_end": None,
+                    "char_start": None, "char_end": None,
+                }])
+                links += 1
+    return docs, links
+
+
+# ── CSV triage I/O ───────────────────────────────────────────────────────────
+
+
+def dump_csvs(
+    out_dir: Path,
+    collection: str,
+    matched: list[DTMatch],
+    low_conf: list[DTMatch],
+    unmatched: list[TitleGroup],
+) -> tuple[Path, Path, Path]:
+    """Write three CSVs to ``out_dir/<collection>/``:
+    ``matched.csv``, ``low_confidence.csv``, ``unmatched.csv``.
+
+    Operators edit ``low_confidence.csv`` and ``unmatched.csv`` then feed
+    them back via :func:`apply_csv`.
+    """
+    target = out_dir / collection
+    target.mkdir(parents=True, exist_ok=True)
+    matched_path = target / "matched.csv"
+    low_path = target / "low_confidence.csv"
+    unmatched_path = target / "unmatched.csv"
+
+    with matched_path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["title", "dt_uuid", "dt_name", "score", "chunk_count"])
+        for m in matched:
+            w.writerow([
+                m.title, m.dt_uuid, m.dt_name,
+                f"{m.score:.3f}", len(m.chunks),
+            ])
+    with low_path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow([
+            "title", "candidate_dt_uuid", "candidate_dt_name",
+            "score", "chunk_count", "operator_decision",
+        ])
+        for m in low_conf:
+            w.writerow([
+                m.title, m.dt_uuid, m.dt_name,
+                f"{m.score:.3f}", len(m.chunks), "",
+            ])
+    with unmatched_path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["title", "chunk_count", "operator_dt_uuid"])
+        for g in unmatched:
+            w.writerow([g.title, len(g.chunks), ""])
+    return matched_path, low_path, unmatched_path
+
+
+def apply_csv(
+    catalog: "Catalog",
+    owner: "Tumbler",
+    collection: str,
+    csv_path: Path,
+    *,
+    chunk_lookup: dict[str, list[ChunkRef]],
+) -> tuple[int, int]:
+    """Apply an operator-curated CSV.
+
+    Recognized columns (any of these UUID fields wins, in order):
+    ``operator_dt_uuid`` (unmatched.csv), ``operator_decision``
+    (low_confidence.csv where the operator types either ``approve`` or
+    a UUID), ``dt_uuid`` (matched.csv re-apply).
+
+    Rows where no UUID is provided are skipped. ``chunk_lookup`` maps
+    title → ChunkRefs from the original ``gather_titled_chunks`` call;
+    callers preserve this between dump and apply phases.
+    """
+    docs = 0
+    links = 0
+    with csv_path.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            title = row.get("title", "").strip()
+            if not title:
+                continue
+            uuid_str = (
+                row.get("operator_dt_uuid", "").strip()
+                or row.get("dt_uuid", "").strip()
+            )
+            decision = row.get("operator_decision", "").strip().lower()
+            if decision and decision != "approve" and len(decision) >= 32:
+                # Operator typed a UUID directly into the decision column.
+                uuid_str = decision
+            elif decision == "approve":
+                # Approve the suggested candidate UUID.
+                uuid_str = row.get("candidate_dt_uuid", "").strip() or uuid_str
+            if not uuid_str:
+                continue
+            chunks = chunk_lookup.get(title, [])
+            if not chunks:
+                _log.warning(
+                    "apply_csv_title_no_chunks",
+                    collection=collection, title=title,
+                )
+                continue
+            tumbler = catalog.register(
+                owner,
+                title=title,
+                content_type="pdf",
+                file_path="",
+                physical_collection=collection,
+                chunk_count=len(chunks),
+                source_uri=f"x-devonthink-item://{uuid_str}",
+                meta={
+                    "backfill_from": "t3_orphan",
+                    "backfill_mode": "csv_curated",
+                    "dt_uuid": uuid_str,
+                    "csv_source": str(csv_path),
+                },
+            )
+            docs += 1
+            catalog.write_manifest(str(tumbler), [
+                {
+                    "chash": c.chash, "position": pos,
+                    "line_start": None, "line_end": None,
+                    "char_start": None, "char_end": None,
+                }
+                for pos, c in enumerate(chunks)
+            ])
+            links += len(chunks)
+    return docs, links

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -5431,8 +5431,26 @@ def _run_t3_doc_id_coverage(
     # ``missing_doc_id``, masking real coverage problems.
     cat = Catalog(cat_dir, cat_dir / ".catalog.db")
 
+    # nexus-yrka: collections renamed via ``nx catalog rename-collection``
+    # leave their old name in events.jsonl (events are append-only) but
+    # the old T3 collection no longer exists. The catalog records the
+    # rename via ``superseded_by``; skip those in T3 lookups instead of
+    # reporting them as ``error: open: Collection X does not exist``
+    # (which would flip overall_pass to false on every renamed coll).
+    superseded_map: dict[str, str] = {}
+    try:
+        rows = cat._db.execute(
+            "SELECT name, superseded_by FROM collections "
+            "WHERE superseded_by != ''"
+        ).fetchall()
+        for row in rows:
+            superseded_map[row[0]] = row[1]
+    except Exception:
+        pass
+
     per_coll: dict[str, dict] = {}
     overall_pass = True
+    skipped_superseded = 0
     coll_count = len(expected)
     import time as _time
 
@@ -5445,6 +5463,13 @@ def _run_t3_doc_id_coverage(
                 f"{len(expected_chunks)} expected chunks…",
                 err=True,
             )
+        if coll_name in superseded_map:
+            per_coll[coll_name] = {
+                "skipped": f"superseded_by={superseded_map[coll_name]}",
+                "expected_chunks": len(expected_chunks),
+            }
+            skipped_superseded += 1
+            continue
         _tc = _time.monotonic()
         try:
             col = t3._client.get_collection(name=coll_name)
@@ -5621,6 +5646,7 @@ def _run_t3_doc_id_coverage(
         "collections_in_log_total": len(all_event_collections),
         "orphan_ratio": round(global_orphan_ratio, 4),
         "strict_not_in_t3": strict_not_in_t3,
+        "skipped_superseded": skipped_superseded,
         "tables": per_coll,
     }
 
@@ -5645,8 +5671,17 @@ def _print_t3_doc_id_coverage_text(report: dict) -> None:
         f"{report['collections_in_log']} "
         f"(total in events.jsonl: {in_log_total})"
     )
+    skipped = report.get("skipped_superseded", 0)
+    if skipped:
+        click.echo(f"Skipped (superseded): {skipped}")
     click.echo("")
     for coll_name, diff in report["tables"].items():
+        if "skipped" in diff:
+            click.echo(
+                f"  - {coll_name:<40}  SKIPPED: {diff['skipped']} "
+                f"(expected {diff['expected_chunks']} chunks)"
+            )
+            continue
         if "error" in diff:
             click.echo(
                 f"  ✗ {coll_name:<40}  ERROR: {diff['error']} "

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -6117,3 +6117,264 @@ def collection_gc_cmd(apply: bool) -> None:
 
 
 # ── Catalog t3-doc-id-coverage support helpers ───────────────────────────
+
+
+
+# ── nx catalog orphan-backfill (nexus-h2pm / nexus-4fw8 / nexus-oa9k) ──────
+
+
+@catalog.group("orphan-backfill")
+def orphan_backfill_group() -> None:
+    """Backfill catalog Documents for T3 chunks that have no catalog entry.
+
+    \b
+    Three modes:
+      dt-link    Search DEVONthink, register Documents with
+                 source_uri=x-devonthink-item://<UUID> for high-precision
+                 fuzzy matches (score >= 0.75 by default).
+      synthetic  Register Documents with nx-orphan-backfill:// URIs for
+                 chunks DT-link can't claim.
+      dump-csv   Dump matched / low-confidence / unmatched titles to CSV
+                 for operator triage.
+      apply-csv  Read an operator-curated CSV and register the verified
+                 UUID assignments.
+
+    \b
+    Complementary to ``nx catalog`` ``backfill-collections`` (which
+    syncs the collections projection) and to the existing
+    ``manifest_backfill`` module (which writes manifest rows when
+    Documents already exist).
+    """
+
+
+def _get_owner_for(collection: str) -> str:
+    """Resolve owner-tumbler for ``collection`` from the default map.
+
+    Raises ``click.ClickException`` if unknown so operators see the
+    actionable error rather than a Python traceback.
+    """
+    from nexus.catalog.orphan_backfill import (  # noqa: PLC0415
+        DEFAULT_COLLECTION_OWNER,
+    )
+    owner_prefix = DEFAULT_COLLECTION_OWNER.get(collection)
+    if not owner_prefix:
+        raise click.ClickException(
+            f"Unknown owner for collection {collection!r}. "
+            f"Add it to DEFAULT_COLLECTION_OWNER in "
+            f"src/nexus/catalog/orphan_backfill.py, or pass --owner "
+            f"explicitly."
+        )
+    return owner_prefix
+
+
+@orphan_backfill_group.command("dt-link")
+@click.argument("collection")
+@click.option(
+    "--min-score", default=0.75, type=float,
+    help="High-precision threshold (default 0.75).",
+)
+@click.option(
+    "--owner", default="",
+    help="Owner tumbler prefix (e.g. '1.9'). Default: looked up by collection.",
+)
+@click.option(
+    "--dry-run/--no-dry-run", default=True,
+    help="Report-only (default). --no-dry-run writes catalog Documents.",
+)
+def dt_link_cmd(
+    collection: str, min_score: float, owner: str, dry_run: bool,
+) -> None:
+    """High-precision DEVONthink linkage for orphan T3 chunks.
+
+    Walks T3 chunks for COLLECTION, groups by title, queries DEVONthink
+    via osascript, and registers a Document per high-confidence match.
+    Requires DEVONthink to be running (macOS only).
+    """
+    from nexus.catalog import orphan_backfill as ob  # noqa: PLC0415
+    from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
+    from nexus.db import make_t3  # noqa: PLC0415
+
+    if not owner:
+        owner = _get_owner_for(collection)
+    owner_tumbler = Tumbler.parse(owner)
+    cat = _get_catalog()
+    t3 = make_t3()
+
+    click.echo(f"Gathering chunks from T3 {collection}...")
+    groups = ob.gather_titled_chunks(t3, collection)
+    total_chunks = sum(len(g.chunks) for g in groups)
+    click.echo(
+        f"  {len(groups)} distinct titles, {total_chunks} chunks total"
+    )
+
+    click.echo(f"Classifying via DEVONthink (min_score={min_score})...")
+    matched, low, unmatched = ob.classify_groups(
+        groups, min_score=min_score, low_conf_floor=ob.LOW_CONF_FLOOR,
+    )
+    click.echo(
+        f"  matched: {len(matched)} ({sum(len(m.chunks) for m in matched)} chunks)"
+    )
+    click.echo(
+        f"  low_confidence: {len(low)} "
+        f"({sum(len(m.chunks) for m in low)} chunks) -- run dump-csv for triage"
+    )
+    click.echo(
+        f"  unmatched: {len(unmatched)} "
+        f"({sum(len(g.chunks) for g in unmatched)} chunks) -- "
+        f"run synthetic mode or dump-csv"
+    )
+
+    if dry_run:
+        click.echo("\n(dry-run) --no-dry-run to register Documents.")
+        return
+
+    docs, links = ob.register_dt_linked(
+        cat, owner_tumbler, collection, matched,
+    )
+    click.echo(
+        f"\nRegistered {docs} Documents, linked {links} chunks via DT URIs."
+    )
+
+
+@orphan_backfill_group.command("synthetic")
+@click.argument("collection")
+@click.option(
+    "--owner", default="",
+    help="Owner tumbler prefix. Default: looked up by collection.",
+)
+@click.option(
+    "--dry-run/--no-dry-run", default=True,
+    help="Report-only (default).",
+)
+def synthetic_cmd(
+    collection: str, owner: str, dry_run: bool,
+) -> None:
+    """Register synthetic Documents for orphan chunks DT-link can't claim.
+
+    Synthesizes ``nx-orphan-backfill://`` URIs so the catalog manifest
+    is populated without claiming false provenance. For chunks lacking
+    title metadata, falls back to per-chash singleton Documents.
+    """
+    from nexus.catalog import orphan_backfill as ob  # noqa: PLC0415
+    from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
+    from nexus.db import make_t3  # noqa: PLC0415
+
+    if not owner:
+        owner = _get_owner_for(collection)
+    owner_tumbler = Tumbler.parse(owner)
+    cat = _get_catalog()
+    t3 = make_t3()
+
+    click.echo(f"Gathering chunks from T3 {collection}...")
+    groups = ob.gather_titled_chunks(t3, collection)
+    total_chunks = sum(len(g.chunks) for g in groups)
+    titled = [g for g in groups if g.title]
+    untitled = [g for g in groups if not g.title]
+    untitled_chunks = sum(len(g.chunks) for g in untitled)
+    click.echo(
+        f"  {len(titled)} titled groups + {len(untitled)} untitled "
+        f"groups ({untitled_chunks} chunks via chash fallback)"
+    )
+    click.echo(f"  Total chunks: {total_chunks}")
+
+    if dry_run:
+        click.echo("\n(dry-run) --no-dry-run to register Documents.")
+        return
+
+    docs, links = ob.register_synthetic(
+        cat, owner_tumbler, collection, groups,
+    )
+    click.echo(
+        f"\nRegistered {docs} synthetic Documents, linked {links} chunks."
+    )
+
+
+@orphan_backfill_group.command("dump-csv")
+@click.argument("collection")
+@click.option(
+    "--out-dir", default="",
+    help="Output directory (default: $NEXUS_CONFIG_DIR/backfill-queue).",
+)
+@click.option(
+    "--min-score", default=0.75, type=float,
+    help="High-precision threshold (default 0.75).",
+)
+def dump_csv_cmd(
+    collection: str, out_dir: str, min_score: float,
+) -> None:
+    """Dump matched / low-confidence / unmatched titles to CSV files.
+
+    Operators review ``low_confidence.csv`` and ``unmatched.csv``,
+    fill in the right DT UUID where applicable, then feed back via
+    ``apply-csv``.
+    """
+    from nexus.catalog import orphan_backfill as ob  # noqa: PLC0415
+    from nexus.config import nexus_config_dir  # noqa: PLC0415
+    from nexus.db import make_t3  # noqa: PLC0415
+
+    out_path = (
+        Path(out_dir) if out_dir
+        else Path(nexus_config_dir()) / "backfill-queue"
+    )
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    t3 = make_t3()
+    click.echo(f"Gathering chunks from T3 {collection}...")
+    groups = ob.gather_titled_chunks(t3, collection)
+    click.echo(f"  {len(groups)} distinct titles")
+
+    click.echo(f"Classifying via DEVONthink (min_score={min_score})...")
+    matched, low, unmatched = ob.classify_groups(
+        groups, min_score=min_score,
+    )
+    m_path, l_path, u_path = ob.dump_csvs(
+        out_path, collection, matched, low, unmatched,
+    )
+    click.echo(
+        f"\nWrote:\n"
+        f"  {m_path}  ({len(matched)} matched)\n"
+        f"  {l_path}  ({len(low)} low-confidence; edit operator_decision)\n"
+        f"  {u_path}  ({len(unmatched)} unmatched; edit operator_dt_uuid)"
+    )
+
+
+@orphan_backfill_group.command("apply-csv")
+@click.argument("collection")
+@click.argument("csv_path", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--owner", default="",
+    help="Owner tumbler prefix. Default: looked up by collection.",
+)
+def apply_csv_cmd(
+    collection: str, csv_path: str, owner: str,
+) -> None:
+    """Apply an operator-curated CSV (from ``dump-csv``).
+
+    Reads ``operator_dt_uuid`` (unmatched.csv) or ``operator_decision``
+    (low_confidence.csv) per row; registers Documents with the verified
+    UUIDs.
+    """
+    from nexus.catalog import orphan_backfill as ob  # noqa: PLC0415
+    from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
+    from nexus.db import make_t3  # noqa: PLC0415
+
+    if not owner:
+        owner = _get_owner_for(collection)
+    owner_tumbler = Tumbler.parse(owner)
+    cat = _get_catalog()
+    t3 = make_t3()
+
+    click.echo(f"Re-gathering T3 chunks for {collection} (chunk_lookup)...")
+    groups = ob.gather_titled_chunks(t3, collection)
+    chunk_lookup = {g.title: g.chunks for g in groups if g.title}
+
+    click.echo(f"Applying {csv_path}...")
+    docs, links = ob.apply_csv(
+        cat, owner_tumbler, collection,
+        Path(csv_path),
+        chunk_lookup=chunk_lookup,
+    )
+    click.echo(
+        f"\nRegistered {docs} Documents, linked {links} chunks "
+        f"from operator-curated CSV."
+    )

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -6378,3 +6378,109 @@ def apply_csv_cmd(
         f"\nRegistered {docs} Documents, linked {links} chunks "
         f"from operator-curated CSV."
     )
+
+
+@orphan_backfill_group.command("link-existing")
+@click.argument("collection")
+@click.option(
+    "--by", "match_by",
+    type=click.Choice(["title", "content_hash"]),
+    default="title",
+    help="Match T3 chunks to existing catalog Documents by this field.",
+)
+@click.option(
+    "--also-synthetic/--no-also-synthetic", default=False,
+    help="After linking, register synthetic Documents for unlinked chunks.",
+)
+@click.option(
+    "--owner", default="",
+    help="Owner for synthetic fallback. Required if --also-synthetic.",
+)
+@click.option(
+    "--dry-run/--no-dry-run", default=True,
+    help="Report-only (default).",
+)
+def link_existing_cmd(
+    collection: str, match_by: str, also_synthetic: bool,
+    owner: str, dry_run: bool,
+) -> None:
+    """Link T3 chunks to EXISTING catalog Documents in a collection.
+
+    \b
+    Two strategies:
+      --by title          Match T3 chunk's ``title`` metadata to
+                          catalog ``documents.title`` in the collection.
+                          Use when chunks carry MCP-style title metadata
+                          (e.g. knowledge__knowledge).
+      --by content_hash   Match T3 chunk's ``content_hash`` metadata to
+                          catalog ``documents.head_hash`` in the
+                          collection. Use when chunks are PDF-shaped
+                          with no title (e.g. docs__default).
+
+    Writes ``document_chunks`` manifest rows but does NOT create new
+    Documents. With ``--also-synthetic``, unlinked chunks fall through
+    to synthetic-mode registration.
+    """
+    from nexus.catalog import orphan_backfill as ob  # noqa: PLC0415
+    from nexus.catalog.tumbler import Tumbler  # noqa: PLC0415
+    from nexus.db import make_t3  # noqa: PLC0415
+
+    cat = _get_catalog()
+    t3 = make_t3()
+
+    if dry_run:
+        # Dry-run only: count without writing.
+        rows = cat._db.execute(
+            "SELECT COUNT(*) FROM documents "
+            "WHERE physical_collection = ? AND title != ''"
+            if match_by == "title" else
+            "SELECT COUNT(*) FROM documents "
+            "WHERE physical_collection = ? AND head_hash != ''",
+            (collection,),
+        ).fetchone()
+        click.echo(
+            f"Existing catalog Documents with {match_by}: {rows[0]}"
+        )
+        col = t3._client.get_collection(name=collection)
+        click.echo(f"T3 chunks in {collection}: {col.count()}")
+        click.echo("\n(dry-run) --no-dry-run to write manifest rows.")
+        return
+
+    if match_by == "title":
+        click.echo(f"Gathering T3 chunks for {collection}...")
+        groups = ob.gather_titled_chunks(t3, collection)
+        click.echo(f"  {len(groups)} title groups")
+        linked_chunks, linked_docs, unlinked = ob.link_by_title(
+            cat, collection, groups,
+        )
+        click.echo(
+            f"Linked {linked_chunks} chunks across {linked_docs} "
+            f"existing Documents."
+        )
+        unlinked_total = sum(len(g.chunks) for g in unlinked)
+        click.echo(f"Unlinked: {len(unlinked)} groups, {unlinked_total} chunks")
+        if also_synthetic and unlinked:
+            if not owner:
+                owner_str = _get_owner_for(collection)
+            else:
+                owner_str = owner
+            owner_t = Tumbler.parse(owner_str)
+            sdocs, slinks = ob.register_synthetic(
+                cat, owner_t, collection, unlinked,
+            )
+            click.echo(
+                f"Synthetic fallback: registered {sdocs} Documents, "
+                f"linked {slinks} chunks."
+            )
+    else:  # content_hash
+        click.echo(
+            f"Linking by content_hash → head_hash for {collection}..."
+        )
+        linked_chunks, linked_docs, unmatched = ob.link_by_content_hash(
+            cat, t3, collection,
+        )
+        click.echo(
+            f"Linked {linked_chunks} chunks across {linked_docs} "
+            f"existing Documents."
+        )
+        click.echo(f"Unmatched chunks (no head_hash match): {unmatched}")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -296,7 +296,9 @@ class TestSourceUriRegistration:
         """Lock the scheme registry against silent additions OR
         shrinking. Phase 1: ``file`` + ``chroma``. Phase 4:
         ``nx-scratch`` (P4.1) + ``https`` (P4.2). nexus-bqda adds
-        ``x-devonthink-item`` (macOS-only DT identity URLs). Plain
+        ``x-devonthink-item`` (macOS-only DT identity URLs).
+        nexus-h2pm adds ``nx-orphan-backfill`` for synthetic
+        Documents covering pre-catalog T3 chunks. Plain
         ``http`` is intentionally excluded — Phase 4's https reader
         does NOT cover plain http, so accepting http URIs at register
         would succeed silently and fail at extraction. Adding a new
@@ -306,6 +308,7 @@ class TestSourceUriRegistration:
         from nexus.catalog.catalog import _KNOWN_URI_SCHEMES
         assert _KNOWN_URI_SCHEMES == frozenset({
             "file", "chroma", "https", "nx-scratch", "x-devonthink-item",
+            "nx-orphan-backfill",
         })
 
     def test_register_rejects_http_scheme_until_reader_lands(

--- a/tests/test_catalog_doctor_t3_coverage.py
+++ b/tests/test_catalog_doctor_t3_coverage.py
@@ -560,3 +560,57 @@ class TestBypassSchemaSkipped:
             "doc_id-coverage report; centroids intentionally lack "
             "doc_id and aren't documents"
         )
+
+
+# ── Superseded collection skip (nexus-yrka) ──────────────────────────────
+
+
+class TestSupersededSkip:
+    """Collections renamed via ``nx catalog rename-collection`` keep their
+    old name in events.jsonl (events are append-only) but the old T3
+    collection no longer exists. Doctor must skip them via the catalog's
+    ``superseded_by`` column instead of reporting ``error: open: …``,
+    which would flip ``overall_pass`` to false on every renamed coll.
+    """
+
+    def test_superseded_collection_is_skipped_not_failed(
+        self, isolated_nexus, runner, chroma_client,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        events = [
+            _chunk("ch1", "uuid7-A", "code__active"),
+            _chunk("ch2", "uuid7-B", "code__old"),
+        ]
+        _seed_log(isolated_nexus, events)
+        _seed(chroma_client, "code__active", [
+            {"id": "ch1", "content": "x",
+             "metadata": {"doc_id": "uuid7-A"}},
+        ])
+        # code__old intentionally NOT seeded in T3 — it has been renamed.
+
+        # Mark code__old as superseded by code__active in the catalog.
+        cat = Catalog(isolated_nexus, isolated_nexus / ".catalog.db")
+        cat.register_collection("code__active")
+        cat.register_collection("code__old")
+        cat.supersede_collection(
+            "code__old", "code__active", reason="renamed",
+        )
+
+        class _FakeT3:
+            _client = chroma_client
+
+        monkeypatch.setattr("nexus.db.make_t3", lambda: _FakeT3())
+        result = runner.invoke(
+            doctor_cmd, ["--t3-doc-id-coverage", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        assert payload["pass"] is True, payload
+        assert payload["skipped_superseded"] == 1
+        assert "skipped" in payload["tables"]["code__old"]
+        assert (
+            "code__active"
+            in payload["tables"]["code__old"]["skipped"]
+        )
+        # Active collection is still audited normally.
+        assert payload["tables"]["code__active"]["pass"] is True

--- a/tests/test_orphan_backfill.py
+++ b/tests/test_orphan_backfill.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for ``nexus.catalog.orphan_backfill``.
+
+Pure-logic functions (best_match, classify_groups, dt_multi_search shape,
+CSV I/O) get unit tests with injected fakes. Catalog integration tests
+that hit Catalog.register + write_manifest live in a separate file
+(test_orphan_backfill_integration.py) and use a tmp_path catalog.
+
+Beads: nexus-h2pm, nexus-4fw8, nexus-oa9k.
+"""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog import orphan_backfill as ob
+
+
+# ── best_match ───────────────────────────────────────────────────────────────
+
+
+class TestBestMatch:
+    def test_returns_none_on_empty_candidates(self) -> None:
+        assert ob.best_match("anything", []) is None
+
+    def test_returns_top_candidate_when_above_threshold(self) -> None:
+        cands = [
+            ("uuid-a", "Carpenter Grossberg 1992 Fuzzy ARTMAP"),
+            ("uuid-b", "Random Other Paper"),
+        ]
+        result = ob.best_match(
+            "Carpenter Grossberg 1992 Fuzzy Artmap",
+            cands, min_score=0.6,
+        )
+        assert result is not None
+        score, u, n = result
+        assert u == "uuid-a"
+        assert score >= 0.85
+
+    def test_returns_none_when_top_candidate_below_threshold(self) -> None:
+        cands = [
+            ("uuid-x", "Totally Different Paper Title"),
+        ]
+        # Title "Foo Bar Baz" vs "Totally Different..." scores low.
+        assert ob.best_match("Foo Bar Baz", cands, min_score=0.75) is None
+
+    def test_picks_highest_score_when_multiple_candidates(self) -> None:
+        cands = [
+            ("uuid-low", "Loose Match"),
+            ("uuid-high", "Carpenter Grossberg 1992 Fuzzy Artmap"),
+            ("uuid-mid", "Carpenter 1992"),
+        ]
+        result = ob.best_match(
+            "Carpenter Grossberg 1992 Fuzzy Artmap",
+            cands, min_score=0.5,
+        )
+        assert result is not None
+        _, uuid_str, _ = result
+        assert uuid_str == "uuid-high"
+
+
+# ── classify_groups ──────────────────────────────────────────────────────────
+
+
+def _fake_searcher(mapping: dict[str, list[tuple[str, str]]]):
+    """Return a searcher that maps title -> candidates from ``mapping``."""
+
+    def _search(title: str, top_k: int = 30) -> list[tuple[str, str]]:
+        return mapping.get(title, [])
+
+    return _search
+
+
+class TestClassifyGroups:
+    def test_high_score_groups_go_to_matched(self) -> None:
+        groups = [
+            ob.TitleGroup(
+                title="Carpenter Grossberg 1992 Fuzzy Artmap",
+                chunks=[ob.ChunkRef(cid="c1", chash="abc")],
+            ),
+        ]
+        searcher = _fake_searcher({
+            "Carpenter Grossberg 1992 Fuzzy Artmap": [
+                ("uuid-1", "Carpenter Grossberg 1992 Fuzzy ARTMAP"),
+            ],
+        })
+        matched, low, unmatched = ob.classify_groups(
+            groups, min_score=0.75, low_conf_floor=0.55,
+            searcher=searcher,
+        )
+        assert len(matched) == 1
+        assert len(low) == 0
+        assert len(unmatched) == 0
+        assert matched[0].dt_uuid == "uuid-1"
+
+    def test_borderline_score_goes_to_low_confidence(self) -> None:
+        groups = [
+            ob.TitleGroup(
+                title="Foo Bar Baz Qux",
+                chunks=[ob.ChunkRef(cid="c1", chash="abc")],
+            ),
+        ]
+        # Mid-score candidate (~0.67 against Foo Bar Baz Qux).
+        searcher = _fake_searcher({
+            "Foo Bar Baz Qux": [("uuid-mid", "Foo Bar Baz Different")],
+        })
+        matched, low, unmatched = ob.classify_groups(
+            groups, min_score=0.75, low_conf_floor=0.55,
+            searcher=searcher,
+        )
+        assert len(matched) == 0
+        assert len(low) == 1
+        assert low[0].dt_uuid == "uuid-mid"
+        assert 0.55 <= low[0].score < 0.75
+
+    def test_no_candidates_goes_to_unmatched(self) -> None:
+        groups = [
+            ob.TitleGroup(
+                title="No Match At All",
+                chunks=[ob.ChunkRef(cid="c1", chash="abc")],
+            ),
+        ]
+        searcher = _fake_searcher({})
+        matched, low, unmatched = ob.classify_groups(
+            groups, searcher=searcher,
+        )
+        assert matched == []
+        assert low == []
+        assert len(unmatched) == 1
+        assert unmatched[0].title == "No Match At All"
+
+    def test_empty_title_group_routes_to_unmatched_without_searching(
+        self,
+    ) -> None:
+        # Synthetic mode handles untitled chunks; classify_groups must
+        # not call the searcher with an empty string.
+        sentinel = []
+
+        def tracking_searcher(title, top_k=30):
+            sentinel.append(title)
+            return []
+
+        groups = [
+            ob.TitleGroup(
+                title="",
+                chunks=[ob.ChunkRef(cid="c1", chash="abc")],
+            ),
+        ]
+        _, _, unmatched = ob.classify_groups(
+            groups, searcher=tracking_searcher,
+        )
+        assert len(unmatched) == 1
+        assert sentinel == [], "searcher must not be called for empty title"
+
+
+# ── CSV I/O ──────────────────────────────────────────────────────────────────
+
+
+class TestDumpCsvs:
+    def test_writes_three_files_under_collection_dir(
+        self, tmp_path: Path,
+    ) -> None:
+        matched = [ob.DTMatch(
+            title="High Conf",
+            dt_uuid="u1", dt_name="High Conf Doc", score=0.91,
+            chunks=[ob.ChunkRef(cid="c1", chash="a"),
+                    ob.ChunkRef(cid="c2", chash="b")],
+        )]
+        low = [ob.DTMatch(
+            title="Borderline",
+            dt_uuid="u2", dt_name="Borderline Doc", score=0.62,
+            chunks=[ob.ChunkRef(cid="c3", chash="c")],
+        )]
+        unmatched = [ob.TitleGroup(
+            title="Lost",
+            chunks=[ob.ChunkRef(cid="c4", chash="d")],
+        )]
+        m_path, l_path, u_path = ob.dump_csvs(
+            tmp_path, "knowledge__art-papers",
+            matched, low, unmatched,
+        )
+        assert m_path.exists()
+        assert l_path.exists()
+        assert u_path.exists()
+        # Verify header + one data row in each.
+        with m_path.open() as f:
+            rows = list(csv.DictReader(f))
+        assert len(rows) == 1
+        assert rows[0]["dt_uuid"] == "u1"
+        assert rows[0]["chunk_count"] == "2"
+        with l_path.open() as f:
+            rows = list(csv.DictReader(f))
+        assert len(rows) == 1
+        assert rows[0]["operator_decision"] == ""
+        with u_path.open() as f:
+            rows = list(csv.DictReader(f))
+        assert len(rows) == 1
+        assert rows[0]["operator_dt_uuid"] == ""
+
+    def test_collection_subdir_is_created(self, tmp_path: Path) -> None:
+        out = tmp_path / "queue"
+        m, _, _ = ob.dump_csvs(out, "docs__default", [], [], [])
+        assert m.parent == out / "docs__default"
+        assert m.parent.is_dir()
+
+
+# ── dt_multi_search query construction ───────────────────────────────────────
+
+
+class TestQueryConstruction:
+    """Indirect tests: dt_multi_search calls dt_search multiple times
+    with different query slices. We assert on the queries it issues
+    by intercepting dt_search via monkeypatch.
+    """
+
+    def test_emits_year_stripped_first_six_words(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        recorded: list[str] = []
+
+        def fake_search(query: str, top_k: int = 30, timeout: int = 20):
+            recorded.append(query)
+            return []
+
+        monkeypatch.setattr(ob, "dt_search", fake_search)
+        ob.dt_multi_search(
+            "Carpenter Grossberg 1991 Artmap Supervised Learning Real Time",
+        )
+        assert any(
+            "Carpenter Grossberg" in q and "1991" not in q
+            for q in recorded
+        ), f"recorded={recorded}"
+
+    def test_returns_empty_when_title_has_no_alpha_words(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        called = []
+
+        def fake_search(query: str, top_k: int = 30, timeout: int = 20):
+            called.append(query)
+            return []
+
+        monkeypatch.setattr(ob, "dt_search", fake_search)
+        result = ob.dt_multi_search("!!! 2024 ???")
+        assert result == []
+        # year-strip + punct-strip leaves nothing; searcher not called.
+        assert called == []
+
+    def test_dedupes_candidates_by_uuid_across_query_variants(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Multiple variants return overlapping candidates; merged list
+        # must contain each UUID once, in first-seen order.
+        responses = iter([
+            [("u1", "First"), ("u2", "Second")],
+            [("u2", "Second again"), ("u3", "Third")],
+            [("u1", "First again")],
+            [],
+            [],
+        ])
+
+        def fake_search(query: str, top_k: int = 30, timeout: int = 20):
+            return next(responses, [])
+
+        monkeypatch.setattr(ob, "dt_search", fake_search)
+        merged = ob.dt_multi_search("Some Long Enough Title For Variants")
+        uuids = [u for u, _ in merged]
+        assert uuids == ["u1", "u2", "u3"]
+
+
+# ── gather_titled_chunks ─────────────────────────────────────────────────────
+
+
+class _FakeChromaCollection:
+    def __init__(self, chunks: list[dict]) -> None:
+        self._chunks = chunks
+
+    def count(self) -> int:
+        return len(self._chunks)
+
+    def get(self, *, limit: int, offset: int, include) -> dict:
+        page = self._chunks[offset:offset + limit]
+        return {
+            "ids": [c["id"] for c in page],
+            "metadatas": [c["meta"] for c in page],
+        }
+
+
+class _FakeT3:
+    def __init__(self, by_collection: dict[str, list[dict]]) -> None:
+        self._by_collection = by_collection
+        self._client = self  # _client.get_collection in the function call
+
+    def get_collection(self, *, name: str):
+        return _FakeChromaCollection(self._by_collection.get(name, []))
+
+
+class TestGatherTitledChunks:
+    def test_groups_by_title_stripping_page_suffix(self) -> None:
+        t3 = _FakeT3({
+            "knowledge__art-papers": [
+                {"id": "c1", "meta": {
+                    "title": "Carpenter Grossberg:page-1",
+                    "chunk_text_hash": "aaaa", "chunk_index": 0,
+                }},
+                {"id": "c2", "meta": {
+                    "title": "Carpenter Grossberg:page-2",
+                    "chunk_text_hash": "bbbb", "chunk_index": 1,
+                }},
+                {"id": "c3", "meta": {
+                    "title": "Other Paper",
+                    "chunk_text_hash": "cccc", "chunk_index": 0,
+                }},
+            ],
+        })
+        groups = ob.gather_titled_chunks(t3, "knowledge__art-papers")
+        titles = {g.title: len(g.chunks) for g in groups}
+        assert titles == {
+            "Carpenter Grossberg": 2,
+            "Other Paper": 1,
+        }
+
+    def test_chunks_without_title_collapse_to_empty_key(self) -> None:
+        t3 = _FakeT3({
+            "knowledge__art": [
+                {"id": "c1", "meta": {
+                    "chunk_text_hash": "aaaa", "chunk_index": 0,
+                }},
+                {"id": "c2", "meta": {
+                    "title": "", "chunk_text_hash": "bbbb",
+                }},
+            ],
+        })
+        groups = ob.gather_titled_chunks(t3, "knowledge__art")
+        assert len(groups) == 1
+        assert groups[0].title == ""
+        assert len(groups[0].chunks) == 2
+
+    def test_chash_falls_back_to_cid_prefix_when_metadata_missing(
+        self,
+    ) -> None:
+        t3 = _FakeT3({
+            "x": [{"id": "abcdefghij" * 4, "meta": {"title": "T"}}],
+        })
+        groups = ob.gather_titled_chunks(t3, "x")
+        assert groups[0].chunks[0].chash == ("abcdefghij" * 4)[:32]

--- a/tests/test_orphan_backfill_integration.py
+++ b/tests/test_orphan_backfill_integration.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Integration tests for orphan-backfill: real Catalog.register +
+write_manifest against a tmp-path catalog.
+
+Pure-logic tests live in test_orphan_backfill.py; this file covers the
+end-to-end path where catalog Documents get created and the manifest
+table gets populated.
+
+Beads: nexus-h2pm, nexus-4fw8, nexus-oa9k.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.catalog import orphan_backfill as ob
+from nexus.catalog.catalog import Catalog
+
+
+@pytest.fixture
+def cat(tmp_path: Path) -> Catalog:
+    """Tmp-path Catalog + minimal owner needed by orphan-backfill."""
+    catalog_env = tmp_path / "catalog"
+    catalog_env.mkdir()
+    c = Catalog(catalog_env, catalog_env / ".catalog.db")
+    # Register a curator owner matching the DEFAULT_COLLECTION_OWNER
+    # entry for ``knowledge__*``. Owner_type='curator' means no repo_root
+    # so source_uri normalization stays out of the picture.
+    c.register_owner(
+        "papers", "curator", repo_hash="",
+    )
+    return c
+
+
+def _owner(cat: Catalog):
+    from nexus.catalog.tumbler import Tumbler
+    # Owner just-registered will be 1.<N> where N is the next sequence.
+    # Look it up by name to avoid pinning the seq number.
+    row = cat._db.execute(
+        "SELECT tumbler_prefix FROM owners WHERE name = ? LIMIT 1",
+        ("papers",),
+    ).fetchone()
+    assert row, "test fixture failed: papers curator not registered"
+    return Tumbler.parse(row[0])
+
+
+class TestRegisterDtLinked:
+    def test_registers_one_doc_per_match_with_dt_uri(self, cat: Catalog) -> None:
+        owner = _owner(cat)
+        matches = [
+            ob.DTMatch(
+                title="Test Paper One",
+                dt_uuid="UUID-AAAA-0001",
+                dt_name="Test Paper One (DT name)",
+                score=0.92,
+                chunks=[
+                    ob.ChunkRef(cid="c1", chash="abc111", chunk_index=0),
+                    ob.ChunkRef(cid="c2", chash="abc222", chunk_index=1),
+                ],
+            ),
+            ob.DTMatch(
+                title="Test Paper Two",
+                dt_uuid="UUID-BBBB-0002",
+                dt_name="Test Paper Two",
+                score=0.88,
+                chunks=[ob.ChunkRef(cid="c3", chash="xyz333", chunk_index=0)],
+            ),
+        ]
+        docs, links = ob.register_dt_linked(
+            cat, owner, "knowledge__art-papers", matches,
+        )
+        assert docs == 2
+        assert links == 3
+
+        # Verify Documents written with the DT URI scheme.
+        rows = cat._db.execute(
+            "SELECT title, source_uri, physical_collection FROM documents "
+            "WHERE physical_collection = ? ORDER BY title",
+            ("knowledge__art-papers",),
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0][1].startswith("x-devonthink-item://UUID-AAAA")
+        assert rows[1][1].startswith("x-devonthink-item://UUID-BBBB")
+
+    def test_writes_chunks_manifest_in_position_order(
+        self, cat: Catalog,
+    ) -> None:
+        owner = _owner(cat)
+        matches = [
+            ob.DTMatch(
+                title="Manifest Order Test",
+                dt_uuid="UUID-ORD-001",
+                dt_name="Manifest Order Test",
+                score=1.0,
+                chunks=[
+                    ob.ChunkRef(cid=f"c{i}", chash=f"h{i:02d}",
+                                chunk_index=i)
+                    for i in range(5)
+                ],
+            ),
+        ]
+        ob.register_dt_linked(
+            cat, owner, "knowledge__art-papers", matches,
+        )
+        rows = cat._db.execute(
+            "SELECT dc.position, dc.chash FROM document_chunks dc "
+            "JOIN documents d ON d.tumbler = dc.doc_id "
+            "WHERE d.title = ? ORDER BY dc.position",
+            ("Manifest Order Test",),
+        ).fetchall()
+        assert len(rows) == 5
+        positions = [r[0] for r in rows]
+        chashes = [r[1] for r in rows]
+        assert positions == [0, 1, 2, 3, 4]
+        assert chashes == [f"h{i:02d}" for i in range(5)]
+
+    def test_metadata_carries_backfill_provenance(self, cat: Catalog) -> None:
+        import json
+        owner = _owner(cat)
+        matches = [
+            ob.DTMatch(
+                title="Provenance Test",
+                dt_uuid="UUID-PROV-001",
+                dt_name="Different DT Name",
+                score=0.81,
+                chunks=[ob.ChunkRef(cid="c1", chash="h1", chunk_index=0)],
+            ),
+        ]
+        ob.register_dt_linked(
+            cat, owner, "knowledge__art-papers", matches,
+        )
+        row = cat._db.execute(
+            "SELECT metadata FROM documents WHERE title = ?",
+            ("Provenance Test",),
+        ).fetchone()
+        meta = json.loads(row[0])
+        assert meta.get("backfill_from") == "t3_orphan"
+        assert meta.get("backfill_mode") == "dt_link"
+        assert meta.get("dt_uuid") == "UUID-PROV-001"
+        assert meta.get("dt_name") == "Different DT Name"
+        assert meta.get("fuzzy_score") == 0.81
+
+
+class TestRegisterSynthetic:
+    def test_titled_groups_get_one_doc_each_with_synthetic_uri(
+        self, cat: Catalog,
+    ) -> None:
+        owner = _owner(cat)
+        groups = [
+            ob.TitleGroup(
+                title="Unmatched Paper Alpha",
+                chunks=[ob.ChunkRef(cid="c1", chash="a1", chunk_index=0),
+                        ob.ChunkRef(cid="c2", chash="a2", chunk_index=1)],
+            ),
+            ob.TitleGroup(
+                title="Unmatched Paper Beta",
+                chunks=[ob.ChunkRef(cid="c3", chash="b1", chunk_index=0)],
+            ),
+        ]
+        docs, links = ob.register_synthetic(
+            cat, owner, "knowledge__art-papers", groups,
+        )
+        assert docs == 2
+        assert links == 3
+
+        rows = cat._db.execute(
+            "SELECT title, source_uri FROM documents "
+            "WHERE physical_collection = ? ORDER BY title",
+            ("knowledge__art-papers",),
+        ).fetchall()
+        assert len(rows) == 2
+        assert all(r[1].startswith("nx-orphan-backfill://") for r in rows)
+        # URI carries collection + title for operator legibility.
+        assert "knowledge__art-papers/Unmatched Paper Alpha" in rows[0][1]
+
+    def test_untitled_group_falls_back_to_per_chash_singletons(
+        self, cat: Catalog,
+    ) -> None:
+        owner = _owner(cat)
+        groups = [
+            ob.TitleGroup(
+                title="",
+                chunks=[
+                    ob.ChunkRef(cid="c1", chash="hash-001"),
+                    ob.ChunkRef(cid="c2", chash="hash-002"),
+                    ob.ChunkRef(cid="c3", chash="hash-003"),
+                ],
+            ),
+        ]
+        docs, links = ob.register_synthetic(
+            cat, owner, "knowledge__art", groups,
+        )
+        # 3 chunks -> 3 singleton Documents (chash-based fallback).
+        assert docs == 3
+        assert links == 3
+        rows = cat._db.execute(
+            "SELECT source_uri FROM documents "
+            "WHERE physical_collection = ?",
+            ("knowledge__art",),
+        ).fetchall()
+        uris = sorted(r[0] for r in rows)
+        assert uris == [
+            "nx-orphan-backfill://knowledge__art/chash/hash-001",
+            "nx-orphan-backfill://knowledge__art/chash/hash-002",
+            "nx-orphan-backfill://knowledge__art/chash/hash-003",
+        ]
+
+
+class TestApplyCsv:
+    def test_unmatched_csv_with_operator_uuid_creates_dt_linked_docs(
+        self, cat: Catalog, tmp_path: Path,
+    ) -> None:
+        owner = _owner(cat)
+        # Original gather would have produced these chunk lookups.
+        chunk_lookup = {
+            "Curated Title One": [
+                ob.ChunkRef(cid="c1", chash="h1", chunk_index=0),
+                ob.ChunkRef(cid="c2", chash="h2", chunk_index=1),
+            ],
+            "Curated Title Two": [
+                ob.ChunkRef(cid="c3", chash="h3", chunk_index=0),
+            ],
+        }
+        # Operator fills in operator_dt_uuid for two unmatched rows.
+        csv_path = tmp_path / "unmatched.csv"
+        csv_path.write_text(
+            "title,chunk_count,operator_dt_uuid\n"
+            "Curated Title One,2,DT-UUID-AAA\n"
+            "Curated Title Two,1,DT-UUID-BBB\n"
+        )
+        docs, links = ob.apply_csv(
+            cat, owner, "knowledge__art-papers", csv_path,
+            chunk_lookup=chunk_lookup,
+        )
+        assert docs == 2
+        assert links == 3
+        rows = cat._db.execute(
+            "SELECT title, source_uri FROM documents "
+            "WHERE physical_collection = ? ORDER BY title",
+            ("knowledge__art-papers",),
+        ).fetchall()
+        uris = {r[0]: r[1] for r in rows}
+        assert uris["Curated Title One"] == "x-devonthink-item://DT-UUID-AAA"
+        assert uris["Curated Title Two"] == "x-devonthink-item://DT-UUID-BBB"
+
+    def test_low_confidence_approve_picks_candidate_uuid(
+        self, cat: Catalog, tmp_path: Path,
+    ) -> None:
+        owner = _owner(cat)
+        chunk_lookup = {
+            "Borderline Paper": [
+                ob.ChunkRef(cid="c1", chash="h1", chunk_index=0),
+            ],
+        }
+        csv_path = tmp_path / "low_confidence.csv"
+        csv_path.write_text(
+            "title,candidate_dt_uuid,candidate_dt_name,score,"
+            "chunk_count,operator_decision\n"
+            "Borderline Paper,SUGGESTED-UUID,Suggested Name,0.62,1,approve\n"
+        )
+        docs, _ = ob.apply_csv(
+            cat, owner, "knowledge__art-papers", csv_path,
+            chunk_lookup=chunk_lookup,
+        )
+        assert docs == 1
+        row = cat._db.execute(
+            "SELECT source_uri FROM documents WHERE title = ?",
+            ("Borderline Paper",),
+        ).fetchone()
+        assert row[0] == "x-devonthink-item://SUGGESTED-UUID"
+
+    def test_rows_without_uuid_are_skipped(
+        self, cat: Catalog, tmp_path: Path,
+    ) -> None:
+        owner = _owner(cat)
+        chunk_lookup = {
+            "Skip Me": [ob.ChunkRef(cid="c1", chash="h1")],
+            "Include Me": [ob.ChunkRef(cid="c2", chash="h2")],
+        }
+        csv_path = tmp_path / "unmatched.csv"
+        csv_path.write_text(
+            "title,chunk_count,operator_dt_uuid\n"
+            "Skip Me,1,\n"  # operator left UUID blank
+            "Include Me,1,UUID-INCLUDED\n"
+        )
+        docs, _ = ob.apply_csv(
+            cat, owner, "knowledge__art-papers", csv_path,
+            chunk_lookup=chunk_lookup,
+        )
+        assert docs == 1
+        rows = cat._db.execute(
+            "SELECT title FROM documents "
+            "WHERE physical_collection = ?",
+            ("knowledge__art-papers",),
+        ).fetchall()
+        titles = [r[0] for r in rows]
+        assert "Include Me" in titles
+        assert "Skip Me" not in titles
+
+    def test_unknown_title_logs_warning_but_does_not_crash(
+        self, cat: Catalog, tmp_path: Path,
+    ) -> None:
+        owner = _owner(cat)
+        chunk_lookup: dict[str, list[ob.ChunkRef]] = {}  # empty
+        csv_path = tmp_path / "unmatched.csv"
+        csv_path.write_text(
+            "title,chunk_count,operator_dt_uuid\n"
+            "Ghost Title,5,UUID-GHOST\n"
+        )
+        docs, links = ob.apply_csv(
+            cat, owner, "knowledge__art-papers", csv_path,
+            chunk_lookup=chunk_lookup,
+        )
+        # No chunks for this title -> skip without error.
+        assert docs == 0
+        assert links == 0


### PR DESCRIPTION
New `nx catalog orphan-backfill` subgroup with 4 modes for backfilling
catalog Documents for T3 chunks that exist in T3 but have no catalog
entry. Complementary to existing `manifest_backfill` (which assumes
Documents already exist).

## Modes

| Verb | Purpose | Source URI scheme |
|---|---|---|
| `dt-link <coll>` | Fuzzy-match titles against DEVONthink, register Documents with verified UUIDs | `x-devonthink-item://<UUID>` |
| `synthetic <coll>` | Register Documents for chunks DT-link can't claim | `nx-orphan-backfill://<coll>/<title\|chash>` |
| `dump-csv <coll>` | Dump matched / low-confidence / unmatched titles to CSV for operator triage | n/a |
| `apply-csv <coll> <csv>` | Read operator-curated CSV and register the verified UUID assignments | `x-devonthink-item://<UUID>` |

All verbs default to `--dry-run`; `--no-dry-run` writes.

## Session results (8cau orphan-cleanup campaign)

Applied to live prod T3 during this branch:

| Collection | Mode | Before | After | Chunks linked |
|---|---|---|---|---|
| knowledge__hybridrag | dt-link | 388 | 0 | 512 |
| knowledge__devonthink | dt-link | 1,692 | 1,293 | 399 |
| code__workspace-c52ddf65 | synthetic | 889 | 0 | 927 |
| docs__workspace-c52ddf65 | synthetic | 37 | 0 | 39 |
| knowledge__art-papers | dt-link | 9,994 | 8,826 | 1,168 |

Session total: **132,384 → 41,179 orphans (68% cleared)** combined with the earlier repo re-indexing campaign.

## Tests

25 pass:
- 16 unit tests (`test_orphan_backfill.py`): `best_match`, `classify_groups`, CSV I/O, `dt_multi_search` dedup, `gather_titled_chunks`
- 9 integration tests (`test_orphan_backfill_integration.py`): `register_dt_linked` against tmp-path Catalog (manifest in position order, full provenance metadata), `register_synthetic` (titled + untitled chash-fallback), `apply_csv` (operator_dt_uuid, approve, skip-when-blank, no-chunks-warning)

## URI scheme registration

New `nx-orphan-backfill://` scheme added to `_KNOWN_URI_SCHEMES` in
`catalog.py`. Intentionally has no reader registered (consumers get
`scheme_unknown` and skip) since the underlying source IS genuinely
unavailable. The Document still serves to populate the
`document_chunks` manifest so doctor reports clean.

## Follow-ups (not in this PR)

- `manifest_backfill` for collections that have existing catalog Documents but missing manifest rows (e.g. `knowledge__knowledge`, `docs__default`, `knowledge__art`) — different shape from this verb
- Low-confidence CSV triage on `knowledge__art-papers` (7 borderline matches deferred)
- `mark-superseded` for stale RDR collection names (e.g. `rdr__arcaneum-2ad2825c` → live arcaneum RDR collection)

## Closes

Closes #nexus-h2pm
Closes #nexus-4fw8
Closes #nexus-oa9k