### PR TITLE
feat(migrations): reland RDR-108 Phase 1c PK migrations (nexus-4s2o)

### DIFF
--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -2684,17 +2684,22 @@ MIGRATIONS: list[Migration] = [
         "Drop chash_index.chunk_chroma_id column (RDR-108 Phase 4a, nexus-mmf5)",
         _drop_chash_index_chunk_chroma_id,
     ),
-    # The RDR-108 Phase 1c PK migrations (``nexus-je0b``: document_aspects
-    # and aspect_extraction_queue PK switch to doc_id) and ``nexus-ocu9.11``
-    # (drop document_aspects.source_path) stay deferred from the
-    # registry. The 4.31.4 reland attempt surfaced cascading test
-    # surgery: collection-rename / aspect-worker direct INSERTs need
-    # doc_id threading; the empty-catalog fast path violates the
-    # K11/CG2 "no-catalog → no-cache" contract; the high-volume
-    # orphan check needs to stay MigrationError (test contract). The
-    # ``_resolve_doc_id`` substrate in DocumentAspects.upsert ships
-    # in 4.31.5 so the eventual reland is a one-line registry change
-    # plus targeted test updates. Function definitions stay in place.
+    # nexus-4s2o reland of nexus-je0b: RDR-108 Phase 1c PK switch to
+    # doc_id for document_aspects + aspect_extraction_queue. The
+    # ``_resolve_doc_id`` substrate in DocumentAspects.upsert (4.31.5)
+    # plus the test surgery in this commit unblock the reland.
+    # ``nexus-ocu9.11`` (drop document_aspects.source_path) stays
+    # deferred — separate follow-up.
+    Migration(
+        "4.30.0",
+        "RDR-108 Phase 1c: PK switch document_aspects to doc_id (nexus-je0b)",
+        _migrate_document_aspects_pk_via_apply_pending,
+    ),
+    Migration(
+        "4.30.0",
+        "RDR-108 Phase 1c: PK switch aspect_extraction_queue to doc_id (nexus-je0b)",
+        _migrate_aspect_queue_pk_via_apply_pending,
+    ),
 ]
 
 # ── T3 upgrade steps ────────────────────────────────────────────────────────

--- a/tests/test_migrations_rdr108_phase1c.py
+++ b/tests/test_migrations_rdr108_phase1c.py
@@ -804,35 +804,35 @@ class TestDocumentAspectsPostMigrationAPI:
 
 
 class TestMigrationsListRegistration:
-    """je0b migrations are intentionally deferred from MIGRATIONS in 4.31.5+.
+    """je0b migrations registered in MIGRATIONS at 4.30.0 (nexus-4s2o reland).
 
-    The companion ``_resolve_doc_id`` substrate ships in
-    ``DocumentAspects.upsert``; the registry change is the last
-    one-line step plus targeted test surgery (see bead nexus-4s2o).
-    Function definitions stay in place so re-enable is trivial.
+    The companion ``_resolve_doc_id`` substrate in
+    ``DocumentAspects.upsert`` (4.31.5) and the targeted test surgery
+    in nexus-4s2o together unblock registration. Both migrations sit
+    at version ``4.30.0`` so existing T2 DBs upgrade through them.
     """
 
-    def test_document_aspects_migration_deferred(self) -> None:
+    def test_document_aspects_migration_registered(self) -> None:
         from nexus.db.migrations import MIGRATIONS
 
         names = [m.name for m in MIGRATIONS]
-        assert not any(
+        assert any(
             "document_aspects" in n and "doc_id" in n for n in names
         ), (
-            "document_aspects PK migration must stay deferred until "
-            "the test surgery in nexus-4s2o lands; got: "
+            "document_aspects PK migration must be registered in "
+            "MIGRATIONS post-reland; got: "
             f"{[n for n in names if 'document_aspects' in n]}"
         )
 
-    def test_aspect_queue_migration_deferred(self) -> None:
+    def test_aspect_queue_migration_registered(self) -> None:
         from nexus.db.migrations import MIGRATIONS
 
         names = [m.name for m in MIGRATIONS]
-        assert not any(
+        assert any(
             "aspect_extraction_queue" in n and "doc_id" in n for n in names
         ), (
-            "aspect_extraction_queue PK migration must stay deferred "
-            "until nexus-4s2o lands; got: "
+            "aspect_extraction_queue PK migration must be registered "
+            "in MIGRATIONS post-reland; got: "
             f"{[n for n in names if 'aspect_extraction_queue' in n]}"
         )
 

--- a/tests/test_phase5_integration.py
+++ b/tests/test_phase5_integration.py
@@ -275,9 +275,14 @@ class TestDoctorCheckSchema:
         assert "not found" in result.output.lower()
 
     def test_healthy_schema(self, runner: CliRunner, tmp_path: Path) -> None:
+        from nexus.catalog.catalog import Catalog
         from nexus.commands.upgrade import _current_version
         from nexus.db.migrations import apply_pending
 
+        # nexus-4s2o: je0b PK migrations skip via MigrationRetry when
+        # the catalog is absent, leaving the stored version unbumped.
+        # Initialize the catalog so apply_pending completes cleanly.
+        Catalog.init(tmp_path / "catalog")
         db_path = tmp_path / "memory.db"
         conn = sqlite3.connect(str(db_path))
         apply_pending(conn, _current_version())

--- a/tests/test_rdr108_lh8c_migration_plumbing.py
+++ b/tests/test_rdr108_lh8c_migration_plumbing.py
@@ -561,10 +561,6 @@ def _je0b_registered() -> bool:
     )
 
 
-@pytest.mark.skipif(
-    not _je0b_registered(),
-    reason="je0b deferred from MIGRATIONS in 4.31.5 (see CHANGELOG)",
-)
 class TestK11SkipNotCached:
     """K11: apply_pending must NOT add path to _upgrade_done when catalog is absent."""
 
@@ -632,10 +628,6 @@ class TestK11SkipNotCached:
 # ── CG-2: apply_pending no-catalog-path ──────────────────────────────────────
 
 
-@pytest.mark.skipif(
-    not _je0b_registered(),
-    reason="je0b deferred from MIGRATIONS in 4.31.5 (see CHANGELOG)",
-)
 class TestCG2NoCatalog:
     """CG-2: apply_pending with absent catalog must be no-op AND retry-able."""
 

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -209,8 +209,17 @@ def test_reverse_flag_reverses_output_order(runner: CliRunner, cloud_env) -> Non
         )
     assert normal.exit_code == 0
     assert reversed_.exit_code == 0
-    normal_lines = [ln for ln in normal.output.splitlines() if ln.strip()]
-    reversed_lines = [ln for ln in reversed_.output.splitlines() if ln.strip()]
+    # nexus-4s2o: filter out structlog warning lines (e.g.
+    # ``migrate_*_pk_skip_no_catalog`` emitted when je0b skips
+    # because the test fixture leaves the catalog uninitialized).
+    def _result_lines(out: str) -> list[str]:
+        return [
+            ln for ln in out.splitlines()
+            if ln.strip() and not ln.startswith("event=")
+            and "migration_" not in ln and "migrate_" not in ln
+        ]
+    normal_lines = _result_lines(normal.output)
+    reversed_lines = _result_lines(reversed_.output)
     assert normal_lines != reversed_lines
     assert normal_lines == list(reversed(reversed_lines))
 

--- a/tests/test_upgrade_e2e.py
+++ b/tests/test_upgrade_e2e.py
@@ -139,9 +139,12 @@ class TestSC3UpgradeFlags:
 
 class TestSC4DoctorSchema:
     def test_healthy_db_passes(self, runner: CliRunner, tmp_path: Path) -> None:
+        from nexus.catalog.catalog import Catalog
         from nexus.commands.upgrade import _current_version
         from nexus.db.migrations import apply_pending
 
+        # nexus-4s2o: je0b PK migrations require a catalog to complete.
+        Catalog.init(tmp_path / "catalog")
         db_path = tmp_path / "memory.db"
         conn = sqlite3.connect(str(db_path))
         apply_pending(conn, _current_version())


### PR DESCRIPTION
## Summary

Reland of nexus-je0b (RDR-108 Phase 1c PK migrations: document_aspects +
aspect_extraction_queue switch to doc_id PK), unblocked by the
\`_resolve_doc_id\` substrate in \`DocumentAspects.upsert\` (shipped 4.31.5)
plus targeted test surgery in this PR.

The 4.31.4 reland attempt failed on cascading test issues; this PR
addresses each:

- Re-register both migrations at version 4.30.0
- Invert two MIGRATIONS-list-deferred assertions to registered-asserts
- Drop \`@pytest.mark.skipif\` on TestK11SkipNotCached / TestCG2NoCatalog
- Init catalog in two doctor --check-schema test fixtures so
  \`apply_pending\` completes (otherwise je0b raises MigrationRetry,
  version stays at 0.0.0, and doctor reports 35 pending migrations)
- Filter structlog warning lines in test_reverse_flag_reverses_output_order
  (migration warnings leak into stdout when je0b skips)

## Test plan

- [x] Targeted: \`uv run pytest\` on the 6 affected test files — 40/40 pass
- [x] Full suite: \`uv run pytest -q\` — 7113 pass; 3 pre-existing
      intermittents unchanged (2 chromadb EphemeralClient shared-state,
      1 K2DrainCLI MCP-worker env conflict)
- [ ] CI green on Python 3.12 + 3.13

## Prod gotcha

High-volume orphan collections must be marked superseded BEFORE the next
\`nx upgrade\` or je0b will raise MigrationError:

- \`rdr__nexus-571b8edd\` (224 orphans)
- \`rdr__ART-8c2e74c0\` (94 orphans)

Add to release notes when this PR ships in a tagged version.

## Out of scope

- nexus-ocu9.11 (drop \`document_aspects.source_path\` column) — separate
  follow-up.

## Closes

Closes nexus-4s2o.