### PR TITLE
test(collection_audit): clear EphemeralClient collections (CI flake fix)

### DIFF
--- a/tests/test_collection_audit.py
+++ b/tests/test_collection_audit.py
@@ -15,6 +15,25 @@ import pytest
 from click.testing import CliRunner
 
 
+def _clean_ephemeral_client():
+    """Return a chromadb.EphemeralClient with all collections cleared.
+
+    chromadb.EphemeralClient() instances share an in-memory backend
+    across the process, so a hardcoded ``create_collection(name=...)``
+    in test N collides with a leftover from test N-1 when both ran in
+    the same suite. Clearing collections at entry guarantees per-test
+    isolation. See project memory: chromadb_ephemeral_shared_state.
+    """
+    import chromadb  # noqa: PLC0415
+    client = chromadb.EphemeralClient()
+    for col in list(client.list_collections()):
+        try:
+            client.delete_collection(col.name)
+        except Exception:
+            pass
+    return client
+
+
 @pytest.fixture
 def runner() -> CliRunner:
     return CliRunner()
@@ -273,7 +292,7 @@ class TestLiveDistanceProbe:
         import chromadb
         from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
 
-        client = chromadb.EphemeralClient()
+        client = _clean_ephemeral_client()
         ef = DefaultEmbeddingFunction()
         col = client.create_collection(name=name, embedding_function=ef)
         col.add(
@@ -328,7 +347,7 @@ class TestLiveDistanceProbe:
         import chromadb
         from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
 
-        client = chromadb.EphemeralClient()
+        client = _clean_ephemeral_client()
         ef = DefaultEmbeddingFunction()
         empty = client.create_collection(name="code__empty", embedding_function=ef)
 
@@ -662,7 +681,7 @@ class TestCollectionAuditCli:
         )
 
         # Seed an EphemeralClient collection the --live probe can sample.
-        client = chromadb.EphemeralClient()
+        client = _clean_ephemeral_client()
         ef = DefaultEmbeddingFunction()
         col = client.create_collection(name="code__live_cli", embedding_function=ef)
         col.add(


### PR DESCRIPTION
## Summary

\`chromadb.EphemeralClient()\` instances share an in-memory backend
across the process. The three inline call sites in
\`test_collection_audit.py\` create collections with hardcoded names
(\`code__live_mark\`, \`code__empty\`, \`code__live_cli\`) and previously
collided with leftover state from preceding tests in the suite.

Symptom: \`InternalError: Collection [code__empty] already exists\`
under suite ordering; tests pass in isolation. Surfaced as a flake
on PRs #674, #675, #676, #677.

Reproduced locally with:

\`\`\`
pytest tests/test_resolve_chash.py tests/test_search_engine.py \\
       tests/test_collection_audit.py tests/test_collection_health.py
\`\`\`

## Fix

Add a \`_clean_ephemeral_client()\` helper that lists + deletes any
existing collections before returning the client. Route the three
inline sites through it. The pattern matches the fixture in
\`test_catalog_doctor_t3_coverage.py\` from PR #674.

## Test plan

- [x] Order-reproducer: 108/108 pass with the fix
- [x] Each affected file passes in isolation
- [ ] CI green Python 3.12 + 3.13