### PR TITLE
test(infra): RDR-109 Phase 1, local-mode default + cloud_mode fixture + lint

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,43 @@
+# tests/AGENTS.md
+
+Test-suite conventions for AI coding agents. `CLAUDE.md` is not a symlink here; the project-root `AGENTS.md` covers global conventions.
+
+## Mode defaults (RDR-109 Phase 1)
+
+The suite runs in **local mode by default** — no API keys, ONNX MiniLM embedding function via `chromadb.DefaultEmbeddingFunction`. This matches CI (which has no credentials) and reproduces a clean-install developer environment.
+
+Tests that exercise **cloud-mode behavior** (real Voyage calls, `CloudClient` routing, `_has_credentials()`-gated code paths, `voyage-context-3` / `voyage-code-3` embedder assertions) **opt in** by depending on the `cloud_mode` fixture:
+
+```python
+def test_something(cloud_mode, ...):
+    ...
+```
+
+Or at module / class scope:
+
+```python
+import pytest
+
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+```
+
+The `cloud_mode` fixture lives in `tests/conftest.py`. It sets `CHROMA_API_KEY`, `VOYAGE_API_KEY`, `CHROMA_TENANT`, `CHROMA_DATABASE` to test sentinels and monkeypatches `nexus.config.is_local_mode` to return `False`.
+
+## Lint guard
+
+`tests/test_mode_declarations_are_explicit.py` enforces the convention. For every collected test whose source contains the regex `voyage-(context|code)-3`, it requires one of:
+
+- The test depends on `cloud_mode` (directly, via class `pytestmark`, or via module `pytestmark`).
+- The test's file is in `_MODE_LINT_EXCLUDE_FILES` (uniformly mode-independent).
+- The test's nodeid is in `_MODE_LINT_EXCLUDE_NODEIDS` (per-test exclusion for mixed files).
+
+Exclusion categories are documented in `tests/conftest.py` above each set.
+
+## When you add a new test that references voyage embedder names
+
+Decide:
+
+1. **Is the voyage token a schema-canonical name** (e.g. `corpus.canonical_embedding_model("code")`, a collection-name parse / render round-trip, RDR-103 four-segment shape)? → mode-independent. Add the test's file to `_MODE_LINT_EXCLUDE_FILES` (if the whole file is schema-only) or its nodeid to `_MODE_LINT_EXCLUDE_NODEIDS`.
+2. **Does the test actually exercise cloud-mode behavior** (real Voyage embedder, `_has_credentials()` gated path, `CloudClient` routing)? → add `cloud_mode` to the test's fixture list, or `pytestmark = pytest.mark.usefixtures("cloud_mode")` at module scope.
+
+If the lint fails on a CI run after your edit, the failure message lists the offending nodeids and the two options above.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,6 +311,140 @@ def set_credentials(monkeypatch) -> None:
     monkeypatch.setenv("CHROMA_DATABASE", "db")
 
 
+# RDR-109 Phase 1: cloud-mode opt-in fixture.
+#
+# Default test mode is local (no API keys, ONNX MiniLM EF). Tests that
+# assert cloud-mode behavior — voyage-context-3 / voyage-code-3 embedder
+# names, _has_credentials() gated paths, CloudClient routing — opt in via
+# this fixture (or class-level
+# ``pytestmark = pytest.mark.usefixtures("cloud_mode")``).
+#
+# The lint test ``test_mode_declarations_are_explicit`` enforces that any
+# test function whose source contains ``voyage-(context|code)-3`` either
+# depends on ``cloud_mode`` or is listed in ``_MODE_LINT_EXCLUDE`` below.
+@pytest.fixture
+def cloud_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Activate cloud mode: set Voyage/Chroma credentials and force
+    ``nexus.config.is_local_mode`` to return False.
+
+    Callers that do ``from nexus.config import is_local_mode`` inside a
+    function body (the established pattern in this codebase — see all
+    callsites under ``src/nexus/``) pick up the patch on next call.
+    """
+    set_credentials(monkeypatch)
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: False)
+
+
+# Tests whose source matches the voyage-token regex but legitimately do
+# NOT need cloud_mode. Two granularities:
+#   * ``_MODE_LINT_EXCLUDE_FILES`` — every test in the file is exempt.
+#     Use for files whose tests are uniformly schema / name-shape /
+#     canonical-set tests where the voyage token is a label, not a
+#     behavior assertion.
+#   * ``_MODE_LINT_EXCLUDE_NODEIDS`` — individual ``file.py::test_x``
+#     entries for mixed files.
+#
+# Exclusion reasons fall into:
+#   - "canonical-set": tests of ``corpus.canonical_embedding_model``
+#     or ``CollectionName`` schema constants; the token is the schema's
+#     canonical embedder name, not a behavior assertion.
+#   - "string-literal-as-name": the test builds a conformant collection
+#     name string and asserts on the *name shape* (RDR-103
+#     ``<content_type>__<owner>__<model>__v<n>``), not on the embedder
+#     that actually ran. The name is canonical regardless of mode.
+#   - "parametrize-label": the voyage token appears only in a
+#     ``pytest.mark.parametrize`` data tuple or test id.
+#   - "docstring-or-comment": the voyage token appears only in a
+#     docstring or comment, not in executable code.
+#   - "mode-self-test": the test asserts local-mode behavior itself
+#     (``test_local_mode.py``); cloud_mode would invert what it tests.
+#
+# Files that primarily exercise cloud-mode behavior (real Voyage calls,
+# CloudClient routing, ``_has_credentials()`` gated paths) do NOT appear
+# here; they declare ``pytestmark = pytest.mark.usefixtures("cloud_mode")``
+# at module scope instead. See ``docs/contributing.md`` and
+# ``tests/AGENTS.md``.
+_MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
+    # Cloud-behavior files — Phase 1 ships the lint mechanism with these
+    # excluded; subsequent PRs promote each to module-level
+    # ``pytestmark = pytest.mark.usefixtures("cloud_mode")``. Promotion is
+    # per-file so each can be validated against the suite independently.
+    # The lint test itself contains the regex.
+    "test_mode_declarations_are_explicit.py",
+    "test_catalog_path.py",
+    "test_chroma_retry.py",
+    "test_collection_cmd.py",
+    "test_doc_indexer.py",
+    "test_exporter.py",
+    "test_index_cmd.py",
+    "test_index_pdf_batch.py",
+    "test_index_rdr_cmd.py",
+    "test_indexer.py",
+    "test_indexer_e2e.py",
+    "test_integration.py",
+    "test_mcp_server.py",
+    "test_pdf_chunks_no_silent_zero.py",
+    "test_pdf_e2e.py",
+    "test_pdf_extractor.py",
+    "test_pdf_subsystem.py",
+    "test_pipeline_stages.py",
+    "test_store_cmd.py",
+    "test_voyage_retry.py",
+    # Schema / canonical-set / collection-name shape — mode-independent.
+    "test_backfill_hash.py",
+    "test_catalog_backfill_collections.py",
+    "test_catalog_cli.py",
+    "test_catalog_collection_for.py",
+    "test_catalog_collection_name.py",
+    "test_catalog_collections.py",
+    "test_catalog_collections_rebuild.py",
+    "test_catalog_concurrent_writer_lock.py",
+    "test_catalog_consolidation.py",
+    "test_catalog_db.py",
+    "test_catalog_doctor_collections_drift.py",
+    "test_catalog_incremental_rebuild.py",
+    "test_catalog_manifest_backfill.py",
+    "test_catalog_migrate_fallback.py",
+    "test_catalog_papers_curator_isolation.py",
+    "test_catalog_rename_collection.py",
+    "test_catalog_spans_chunk_char.py",
+    "test_checkpoint.py",
+    "test_collection_gc.py",
+    "test_collection_name_migration.py",
+    "test_commands_dt.py",
+    "test_corpus.py",
+    "test_doc_indexer_hash_sync.py",
+    "test_doctor_cmd.py",
+    "test_doctor_integrity.py",
+    "test_doctor_search.py",
+    "test_indexer_conformant_names.py",
+    "test_indexer_duplicate_content.py",
+    "test_indexer_modules.py",
+    "test_indexer_utils_repo.py",
+    "test_memory.py",
+    "test_metadata_consistency.py",
+    "test_metadata_schema.py",
+    "test_migrations_rdr108_phase1c.py",
+    "test_plan_run.py",
+    "test_rdr_hook.py",  # tests/hooks/ — collection-name shape only
+    "test_registry.py",
+    "test_source_uri_home_key.py",
+    "test_store_enrich_doc_id.py",
+    "test_store_put_cli_parity.py",
+    "test_t3_strict_collection_naming.py",
+    "test_t3.py",
+    "test_tuning_config.py",
+    # Mode-self-tests — these assert local-mode behavior; cloud_mode
+    # would invert what they test.
+    "test_local_mode.py",
+})
+
+_MODE_LINT_EXCLUDE_NODEIDS: frozenset[str] = frozenset({
+    # Reserved for individual mixed-file exclusions. Format:
+    # "tests/test_file.py::test_func"  (no parametrize suffix).
+})
+
+
 @pytest.fixture
 def db(tmp_path: Path) -> T2Database:
     """Provide a T2Database backed by a temporary SQLite file."""

--- a/tests/test_mode_declarations_are_explicit.py
+++ b/tests/test_mode_declarations_are_explicit.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""RDR-109 Phase 1 lint: tests that reference cloud-mode embedder names
+must opt in to the ``cloud_mode`` fixture (or be in the exclusion list).
+
+The default test mode is local (no API keys, ONNX MiniLM EF). Without
+this guard, a test that asserts ``embedding_model == "voyage-context-3"``
+would silently pass in CI iff some prior PR happened to leak cloud-mode
+state into the session, and fail otherwise. The lint forces the choice
+to be explicit.
+
+Implementation: grep + ``request.fixturenames`` introspection. AST-shape
+analysis is out of scope (RDR-109 §Phase 1, step 4).
+"""
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+from tests.conftest import (
+    _MODE_LINT_EXCLUDE_FILES,
+    _MODE_LINT_EXCLUDE_NODEIDS,
+)
+
+VOYAGE_RE = re.compile(r"voyage-(context|code)-3")
+
+
+def test_mode_declarations_are_explicit(request: pytest.FixtureRequest) -> None:
+    offenders: list[str] = []
+    for item in request.session.items:
+        func = getattr(item, "function", None)
+        if func is None:
+            continue
+        try:
+            src = inspect.getsource(func)
+        except (OSError, TypeError):
+            continue
+        if not VOYAGE_RE.search(src):
+            continue
+        # File-level exclusion (every test in the file is exempt).
+        # ``item.nodeid`` is e.g. ``tests/test_x.py::test_func[param]``.
+        nodeid = item.nodeid
+        file_part = nodeid.split("::", 1)[0]
+        file_basename = file_part.rsplit("/", 1)[-1]
+        if file_basename in _MODE_LINT_EXCLUDE_FILES:
+            continue
+        # Per-test exclusion (strip parametrize suffix).
+        base_nodeid = nodeid.split("[", 1)[0]
+        if base_nodeid in _MODE_LINT_EXCLUDE_NODEIDS:
+            continue
+        fixturenames = set(getattr(item, "fixturenames", ()))
+        if "cloud_mode" in fixturenames:
+            continue
+        offenders.append(nodeid)
+
+    if offenders:
+        sample = "\n  ".join(offenders[:20])
+        suffix = (
+            f"\n  ... (+{len(offenders) - 20} more)"
+            if len(offenders) > 20
+            else ""
+        )
+        pytest.fail(
+            "RDR-109 Phase 1: the following tests reference voyage-"
+            "(context|code)-3 but do not opt in to the `cloud_mode` "
+            "fixture and are not listed in `_MODE_LINT_EXCLUDE`:\n  "
+            + sample
+            + suffix
+            + "\n\nFix: add `cloud_mode` to the test's fixture list "
+            "(or `pytestmark = pytest.mark.usefixtures(\"cloud_mode\")` "
+            "at module/class scope) if the test asserts cloud-mode "
+            "behavior; or add the nodeid to `_MODE_LINT_EXCLUDE` in "
+            "tests/conftest.py with a documented reason."
+        )


### PR DESCRIPTION
## Summary

RDR-109 Phase 1 foundation: makes local mode the test-suite default and forces cloud-mode behavior tests to opt in via a `cloud_mode` fixture, with a lint test that fails CI on unmarked voyage-token references.

- `cloud_mode` fixture in `tests/conftest.py` monkeypatches `nexus.config.is_local_mode` to `False` and sets four credential sentinels via the existing `set_credentials` helper.
- `tests/test_mode_declarations_are_explicit.py` walks `session.items`; every collected test whose source matches `voyage-(context|code)-3` must depend on `cloud_mode` or appear in `_MODE_LINT_EXCLUDE_FILES` / `_MODE_LINT_EXCLUDE_NODEIDS`.
- `_MODE_LINT_EXCLUDE_FILES` enumerates files whose voyage references are schema-canonical names, collection-name shape assertions, or mode-self tests; reasons documented inline.
- Cloud-behavior files (test_doc_indexer, test_pdf_subsystem, test_voyage_retry, etc.) are listed as placeholders pending per-file `pytestmark` promotion in follow-on PRs, executed one file at a time under the lint's protection.
- `tests/AGENTS.md` documents the convention plus the exclude-vs-promote decision tree.

## Why now

Phase 2 (`nexus-n3qu.2` / closes GH #667 / nexus-59vl) is the user-visible mode-aware write-path change. Reviewers can isolate the test-infra change here from the production change in Phase 2.

## Test plan

- [x] Lint test passes against full local suite (one fixed self-reference regression caught by full run; lint test file now in `_MODE_LINT_EXCLUDE_FILES`).
- [x] Deliberate violation (test asserting `voyage-context-3` without `cloud_mode`) fails lint with descriptive message.
- [x] `cloud_mode` fixture itself verified: `is_local_mode()` returns False, `VOYAGE_API_KEY == "vk_test"`.
- [x] Targeted suites green: `test_mode_declarations_are_explicit`, `test_doc_indexer`, `test_corpus`, `test_local_mode`, `test_catalog_collection_for`, `test_rdr_hook`, `test_retrieval_ndcg`.
- [x] Full local suite: 7113 passed, 4 failed (the 3 pre-existing intermittents documented in the handoff: `test_collection_health::test_json_output`, `test_projection_quality::test_assign_single_returns_namedtuple`, `test_rdr108_lh8c_migration_plumbing::TestK2DrainCLI::test_aspects_drain_empty_queue_exits_0`; the self-reference regression in the lint, fixed in this same PR).

## Closes

Closes nexus-n3qu.1