### PR TITLE
feat(rdr-109): Phase 2, bidirectional name-aware EF dispatch + honest local naming

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -303,7 +303,6 @@ from nexus.catalog.tumbler import (
 from nexus.corpus import (
     CANONICAL_EMBEDDING_MODELS,
     CONTENT_TYPES,
-    canonical_embedding_model,
 )
 
 _log = structlog.get_logger()

--- a/src/nexus/catalog/catalog_docs.py
+++ b/src/nexus/catalog/catalog_docs.py
@@ -29,7 +29,8 @@ from nexus.catalog.tumbler import Tumbler
 from nexus.corpus import (
     CANONICAL_EMBEDDING_MODELS,
     CONTENT_TYPES,
-    canonical_embedding_model,
+    LOCAL_EMBEDDING_MODELS,
+    effective_embedding_model_for_writes,
 )
 from nexus.registry import RepoRegistry, _repo_identity
 
@@ -300,11 +301,16 @@ class _DocumentOps:
                 f"collection_for: unknown content_type {content_type!r}; "
                 f"expected one of {CONTENT_TYPES}"
             )
-        if embedding_model not in CANONICAL_EMBEDDING_MODELS:
+        if (
+            embedding_model not in CANONICAL_EMBEDDING_MODELS
+            and embedding_model not in LOCAL_EMBEDDING_MODELS
+        ):
+            allowed = sorted(
+                CANONICAL_EMBEDDING_MODELS | LOCAL_EMBEDDING_MODELS
+            )
             raise ValueError(
                 f"collection_for: non-canonical embedding_model "
-                f"{embedding_model!r}; expected one of "
-                f"{sorted(CANONICAL_EMBEDDING_MODELS)}"
+                f"{embedding_model!r}; expected one of {allowed}"
             )
         owner_id = owner_segment_for_tumbler(owner)
         if not owner_id:
@@ -358,8 +364,10 @@ class _DocumentOps:
            ``LookupError`` when no owner exists; the indexer's
            ``_catalog_hook`` flow registers the owner up front, so a
            missing owner indicates a bypass of the standard write path.
-        3. Resolve the canonical embedding model via
-           :func:`nexus.corpus.canonical_embedding_model`.
+        3. Resolve the effective embedding model via
+           :func:`nexus.corpus.effective_embedding_model_for_writes`
+           (cloud mode delegates to the canonical model; local mode
+           returns the local embedder's token, RDR-109 Phase 2).
         4. Delegate to :meth:`collection_for`.
 
         This is the helper that Phase 3 indexer call sites use. The
@@ -382,7 +390,7 @@ class _DocumentOps:
         return cat.collection_for(
             content_type=content_type,
             owner=owner,
-            embedding_model=canonical_embedding_model(content_type),
+            embedding_model=effective_embedding_model_for_writes(content_type),
             bump=bump,
         )
 

--- a/src/nexus/catalog/collection_name.py
+++ b/src/nexus/catalog/collection_name.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 from nexus.corpus import (
     CANONICAL_EMBEDDING_MODELS,
     CONTENT_TYPES,
+    LOCAL_EMBEDDING_MODELS,
     parse_conformant_collection_name,
 )
 
@@ -91,11 +92,19 @@ class CollectionName:
                 f"{content_type!r}; expected one of {CONTENT_TYPES}"
             )
         embedding_model = parsed["embedding_model"]
-        if embedding_model not in CANONICAL_EMBEDDING_MODELS:
+        # RDR-109 Phase 2 widens the closed set to include local-mode
+        # tokens. Both cloud (CANONICAL) and local (LOCAL) names are
+        # truthful identities under the four-segment schema.
+        if (
+            embedding_model not in CANONICAL_EMBEDDING_MODELS
+            and embedding_model not in LOCAL_EMBEDDING_MODELS
+        ):
+            allowed = sorted(
+                CANONICAL_EMBEDDING_MODELS | LOCAL_EMBEDDING_MODELS
+            )
             raise ValueError(
                 f"Collection name {name!r} has non-canonical embedding_model "
-                f"{embedding_model!r}; expected one of "
-                f"{sorted(CANONICAL_EMBEDDING_MODELS)}"
+                f"{embedding_model!r}; expected one of {allowed}"
             )
         return cls(
             content_type=content_type,

--- a/src/nexus/catalog/consolidation.py
+++ b/src/nexus/catalog/consolidation.py
@@ -34,11 +34,11 @@ def merge_corpus(
     # strict-naming guard. The owner segment is the corpus tag with
     # underscores rewritten to hyphens (the conformant grammar's owner
     # segment disallows ``_``).
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
 
     owner_segment = corpus.replace("_", "-")
     target_col_name = (
-        f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+        f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
     )
 
     if dry_run:

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -3106,11 +3106,11 @@ def consolidate_cmd(corpus: str, dry_run: bool) -> None:
         # RDR-103 Phase 5: mirror the conformant target shape that
         # ``merge_corpus`` will use when run for real so the dry-run
         # message reports the same name.
-        from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+        from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
 
         owner_segment = corpus.replace("_", "-")
         target = (
-            f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+            f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
         )
         click.echo(f"[dry-run] Would merge {result['would_merge']} collections into {target}:")
         for e in entries:

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -1564,18 +1564,39 @@ def _collect_quota_report() -> dict:
     except Exception as exc:
         t3_detail = f"unreachable: {type(exc).__name__}: {str(exc)[:80]}"
 
-    # Voyage AI limits. Model-specific token caps come from the Voyage
-    # published specs (documented alongside ``nexus.corpus``); embedding
-    # dimension is fixed across the three models we use.
-    voyage_limits = {
-        "models": {
-            "voyage-3": {"max_tokens": 32_000, "embedding_dims": 1024},
-            "voyage-code-3": {"max_tokens": 32_000, "embedding_dims": 1024},
-            "voyage-context-3": {"max_tokens": 32_000, "embedding_dims": 1024},
-        },
-        "target_rpm": 250,  # matches ``doc_indexer._RATE_LIMIT_RPM``
-        "api_key_set": False,
-    }
+    # Embedder limits. In cloud mode the three Voyage models we use
+    # have a fixed 1024-dim space and 32k-token cap; in local mode the
+    # ONNX MiniLM (384-dim) or fastembed bge (768-dim) is active. RDR-109
+    # Phase 2: report what's actually embedding, not what the canonical
+    # cloud schema would suggest.
+    if is_local_mode():
+        from nexus.db.local_ef import (  # noqa: PLC0415
+            LocalEmbeddingFunction,
+            local_model_token,
+        )
+        _ef = LocalEmbeddingFunction()
+        voyage_limits = {
+            "mode": "local",
+            "models": {
+                local_model_token(): {
+                    "max_tokens": 512,
+                    "embedding_dims": _ef.dimensions,
+                },
+            },
+            "target_rpm": 0,
+            "api_key_set": False,
+        }
+    else:
+        voyage_limits = {
+            "mode": "cloud",
+            "models": {
+                "voyage-3": {"max_tokens": 32_000, "embedding_dims": 1024},
+                "voyage-code-3": {"max_tokens": 32_000, "embedding_dims": 1024},
+                "voyage-context-3": {"max_tokens": 32_000, "embedding_dims": 1024},
+            },
+            "target_rpm": 250,  # matches ``doc_indexer._RATE_LIMIT_RPM``
+            "api_key_set": False,
+        }
     try:
         from nexus.config import get_credential
 

--- a/src/nexus/commands/dt.py
+++ b/src/nexus/commands/dt.py
@@ -55,12 +55,12 @@ def _resolve_dt_collection(
     to conformant 4-segment names so the strict-naming guard at
     ``T3Database.get_or_create_collection`` accepts them.
     """
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
 
     if collection:
         return collection
     owner = corpus.replace("_", "-")
-    model = canonical_embedding_model("knowledge" if ext == ".pdf" else "docs")
+    model = effective_embedding_model_for_writes("knowledge" if ext == ".pdf" else "docs")
     if ext == ".pdf":
         return f"knowledge__{owner}-papers__{model}__v1"
     return f"docs__{owner}__{model}__v1"

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -835,10 +835,10 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
         if collection:
             col_name = collection
         else:
-            from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+            from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
             owner_segment = corpus.replace("_", "-")
             col_name = (
-                f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+                f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
             )
         col = local_t3.get_or_create_collection(col_name)
         result = col.get(include=["documents", "metadatas"])

--- a/src/nexus/corpus.py
+++ b/src/nexus/corpus.py
@@ -63,6 +63,18 @@ non-canonical models here would defeat that invariant. The
 remain readable as strings; canonical-set validation lives in
 ``CollectionName.parse``."""
 
+LOCAL_EMBEDDING_MODELS: frozenset[str] = frozenset({
+    "minilm-l6-v2-384",
+    "bge-base-en-v15-768",
+})
+"""RDR-109 Phase 2: tokens for the local embedders. The write path uses
+these when ``is_local_mode()`` is True so a collection name produced in
+local mode tells the truth about which vectors live inside. The
+bidirectional name-aware dispatch in ``T3Database._embedding_fn`` uses
+the set to detect local-token names so a local-mode caller against a
+voyage-named collection fails loud instead of producing 384-dim vectors
+against a 1024-dim space (RDR-059 hazard, inverted)."""
+
 _CT_ALTERNATION = "|".join(_CONTENT_TYPES)
 _CONFORMANT_COLLECTION_RE = re.compile(
     rf"^(?P<ct>{_CT_ALTERNATION})"
@@ -136,6 +148,46 @@ def canonical_embedding_model(content_type: str) -> str:
         f"canonical_embedding_model: unknown content_type {content_type!r}; "
         f"expected one of {CONTENT_TYPES}"
     )
+
+
+def effective_embedding_model_for_writes(content_type: str) -> str:
+    """Return the embedding-model token to write into NEW collection
+    names and per-chunk metadata for ``content_type``.
+
+    RDR-109 Phase 2. Cloud mode delegates verbatim to
+    :func:`canonical_embedding_model` so the RDR-103 canonical-set
+    invariant is preserved. Local mode returns the active local
+    embedder's normalized token (``minilm-l6-v2-384`` or
+    ``bge-base-en-v15-768``) so a fresh local-mode index produces
+    collection names that match the bytes inside.
+
+    Read paths must continue to dispatch off the physical collection
+    name via :func:`voyage_model_for_collection` /
+    :func:`embedding_model_for_collection_name`; this function is for
+    WRITE-side decisions only.
+    """
+    from nexus.config import is_local_mode  # noqa: PLC0415
+    if is_local_mode():
+        from nexus.db.local_ef import local_model_token  # noqa: PLC0415
+        return local_model_token()
+    return canonical_embedding_model(content_type)
+
+
+def embedding_model_for_collection_name(collection_name: str) -> str | None:
+    """Return the embedding-model token parsed from a conformant
+    collection name, or ``None`` if *collection_name* is not conformant.
+
+    RDR-109 Phase 2: read-side dispatch reads the model identity from
+    the name itself rather than inferring from the prefix. The
+    inference-from-prefix shape (:func:`voyage_model_for_collection`)
+    is preserved for legacy two-segment names; conformant four-segment
+    names use the embedded token directly so local-token names route
+    through the local EF without colliding with the voyage default.
+    """
+    match = _CONFORMANT_COLLECTION_RE.match(collection_name)
+    if not match:
+        return None
+    return match.groupdict()["model"]
 
 
 def voyage_model_for_collection(collection_name: str) -> str:
@@ -271,7 +323,7 @@ def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
         if len(matches) > 1 and user_arg != "knowledge":
             preferred_4seg = (
                 f"{user_arg}__{user_arg}__"
-                f"{canonical_embedding_model(user_arg)}__v1"
+                f"{effective_embedding_model_for_writes(user_arg)}__v1"
             )
             preferred_2seg = f"{user_arg}__{user_arg}"
             picked: str | None = None
@@ -304,7 +356,7 @@ def t3_collection_name(user_arg: str, *, t3: object | None = None) -> str:
         return user_arg
 
     owner_segment = rest.replace("_", "-")
-    promoted = f"{ct}__{owner_segment}__{canonical_embedding_model(ct)}__v1"
+    promoted = f"{ct}__{owner_segment}__{effective_embedding_model_for_writes(ct)}__v1"
 
     if t3 is None or user_arg == promoted:
         return promoted

--- a/src/nexus/db/local_ef.py
+++ b/src/nexus/db/local_ef.py
@@ -27,6 +27,36 @@ _MODEL_DIMS: dict[str, int] = {
 _TIER0_MODEL = "all-MiniLM-L6-v2"
 _TIER1_MODEL = "BAAI/bge-base-en-v1.5"
 
+# RDR-109 Phase 2: normalized tokens for the local embedding models.
+# Used in conformant collection names (RDR-103 four-segment shape) and
+# in chunk metadata so the embedder identity stops lying about which
+# vectors are actually stored. Tokens must match the
+# ``_CONFORMANT_COLLECTION_RE`` regex in ``corpus.py``:
+# ``^[a-z][a-z0-9-]*$``.
+_MODEL_TOKENS: dict[str, str] = {
+    "all-MiniLM-L6-v2": "minilm-l6-v2-384",
+    "BAAI/bge-base-en-v1.5": "bge-base-en-v15-768",
+}
+
+
+def local_model_token(model_name: str | None = None) -> str:
+    """Return the RDR-109 normalized token for a local embedding model.
+
+    ``model_name=None`` picks the active tier (tier 1 if fastembed is
+    importable, else tier 0). Used by the write path
+    (``effective_embedding_model_for_writes`` in ``corpus.py``) and by
+    ``nx doctor`` to report what's actually embedding the collection.
+    """
+    if model_name is None:
+        model_name = _TIER1_MODEL if _fastembed_available() else _TIER0_MODEL
+    return _MODEL_TOKENS.get(model_name, "minilm-l6-v2-384")
+
+
+LOCAL_EMBEDDING_TOKENS: frozenset[str] = frozenset(_MODEL_TOKENS.values())
+"""Set of all valid local-mode embedding-model tokens. Used by
+``CollectionName.parse`` and the bidirectional name-aware EF dispatch
+in ``T3Database._embedding_fn`` to detect local-token names."""
+
 
 def _fastembed_available() -> bool:
     """Return True if fastembed can be imported."""

--- a/src/nexus/db/t3.py
+++ b/src/nexus/db/t3.py
@@ -29,7 +29,12 @@ import structlog
 # break static type checkers.
 
 from nexus.config import get_credential
-from nexus.corpus import embedding_model_for_collection, index_model_for_collection
+from nexus.corpus import (
+    LOCAL_EMBEDDING_MODELS,
+    embedding_model_for_collection,
+    embedding_model_for_collection_name,
+    index_model_for_collection,
+)
 from nexus.db.chroma_quotas import QUOTAS, QuotaValidator
 from nexus.metadata_schema import CONTENT_TYPES, normalize, validate
 
@@ -240,6 +245,19 @@ from nexus.retry import (
     _voyage_with_retry,
 )
 
+class IncompatibleCollectionError(RuntimeError):
+    """Raised by the bidirectional EF dispatch when the active mode
+    can't safely embed against the collection's name.
+
+    The current trip wire is local-mode against a collection named for
+    a Voyage embedder: the local 384-dim vectors would query a stored
+    1024-dim space and produce silent noise (inverted RDR-059 hazard).
+    Failing loud here forces the operator to either re-index the
+    collection in local mode or restore cloud credentials before the
+    bad query lands.
+    """
+
+
 class T3Database:
     """T3 ChromaDB permanent knowledge store.
 
@@ -347,12 +365,22 @@ class T3Database:
     def _embedding_fn(self, collection_name: str):
         """Return the embedding function for *collection_name*.
 
-        Local mode: returns the bundled ONNX MiniLM-L6-v2 (384-dim) so the
-        full pipeline runs without a Voyage API key.  Cloud mode: returns a
-        VoyageAI EF whose model matches the one used at index time
-        (per ``embedding_model_for_collection``) so query-time dimensions
-        match the collection's indexed dimensions.  For CCE collections the
-        EF is structural only (bypassed via ``_cce_embed()``).
+        RDR-109 Phase 2 bidirectional name-aware dispatch. Four cells in
+        the (mode × embedded-model-token) matrix:
+
+        - Cloud + voyage-token name  -> Voyage EF for that model.
+        - Cloud + local-token name   -> Local EF (legacy local-mode
+          collection encountered after credentials were added; the
+          59vl/GH-#667 path).
+        - Local + local-token name   -> Local EF.
+        - Local + voyage-token name  -> raise
+          :class:`IncompatibleCollectionError`. The 384-dim local
+          vectors would query a 1024-dim Voyage space and produce
+          silent noise (inverted RDR-059 hazard).
+
+        Legacy collection names (not conformant to RDR-103) fall back
+        to the prefix-based ``embedding_model_for_collection``; legacy
+        names are always voyage-token by construction.
 
         Caching is per-collection-name to match the existing test contract.
         """
@@ -360,17 +388,36 @@ class T3Database:
             return self._ef_override
         with self._ef_lock:
             if collection_name not in self._ef_cache:
-                if self._local_mode:
-                    from nexus.db.local_ef import LocalEmbeddingFunction
-                    self._ef_cache[collection_name] = LocalEmbeddingFunction()
-                else:
-                    model = embedding_model_for_collection(collection_name)
-                    self._ef_cache[collection_name] = (
-                        chromadb.utils.embedding_functions.VoyageAIEmbeddingFunction(
-                            model_name=model, api_key=self._voyage_api_key
-                        )
-                    )
+                self._ef_cache[collection_name] = self._build_embedding_fn(
+                    collection_name
+                )
             return self._ef_cache[collection_name]
+
+    def _build_embedding_fn(self, collection_name: str):
+        """Construct (uncached) the EF for *collection_name*. Bidirectional
+        name-aware dispatch — see :meth:`_embedding_fn` docstring."""
+        from nexus.db.local_ef import LocalEmbeddingFunction  # noqa: PLC0415
+
+        parsed_token = embedding_model_for_collection_name(collection_name)
+        is_local_token = parsed_token in LOCAL_EMBEDDING_MODELS
+
+        if self._local_mode:
+            if parsed_token is not None and not is_local_token:
+                raise IncompatibleCollectionError(
+                    f"collection {collection_name!r} was indexed with "
+                    f"{parsed_token!r} but cloud credentials are unavailable; "
+                    "re-index the collection in local mode or restore "
+                    "credentials before reading it"
+                )
+            return LocalEmbeddingFunction()
+
+        if is_local_token:
+            return LocalEmbeddingFunction()
+
+        model = parsed_token or embedding_model_for_collection(collection_name)
+        return chromadb.utils.embedding_functions.VoyageAIEmbeddingFunction(
+            model_name=model, api_key=self._voyage_api_key
+        )
 
     def _cce_embed(
         self, text: str, input_type: Literal["query", "document"] = "document"
@@ -768,7 +815,10 @@ class T3Database:
             chunk_start_char=0,
             chunk_end_char=len(content),
             indexed_at=now_iso,
-            embedding_model=index_model_for_collection(collection),
+            embedding_model=(
+                embedding_model_for_collection_name(collection)
+                or index_model_for_collection(collection)
+            ),
             title=title,
             tags=tags,
             category=category,
@@ -1538,11 +1588,12 @@ class T3Database:
             col = self._client_for(collection_name).get_collection(collection_name)
         except _ChromaNotFoundError:
             raise KeyError(f"Collection not found: {collection_name!r}") from None
+        parsed = embedding_model_for_collection_name(collection_name)
         return {
             "name": collection_name,
             "count": _chroma_with_retry(col.count),
-            "embedding_model": embedding_model_for_collection(collection_name),
-            "index_model": index_model_for_collection(collection_name),
+            "embedding_model": parsed or embedding_model_for_collection(collection_name),
+            "index_model": parsed or index_model_for_collection(collection_name),
         }
 
 

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -606,11 +606,11 @@ def _index_document(
         # rewritten to hyphens (``_`` is the conformant grammar's
         # segment separator); an explicit owner row is not required
         # for ad-hoc paths.
-        from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+        from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
 
         owner_segment = corpus.replace("_", "-")
         collection_name = (
-            f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+            f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
         )
     db = t3 if t3 is not None else make_t3()
     col = db.get_or_create_collection(collection_name)
@@ -1145,10 +1145,10 @@ def index_pdf(
     if collection_name is not None:
         col_name = collection_name
     else:
-        from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+        from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
         owner_segment = corpus.replace("_", "-")
         col_name = (
-            f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+            f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
         )
     db = t3 if t3 is not None else make_t3()  # T3Database instance (not PipelineDB)
     col = db.get_or_create_collection(col_name)
@@ -1519,10 +1519,10 @@ def index_markdown(
     if collection_name is not None:
         col_name = collection_name
     else:
-        from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+        from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
         owner_segment = corpus.replace("_", "-")
         col_name = (
-            f"docs__{owner_segment}__{canonical_embedding_model('docs')}__v1"
+            f"docs__{owner_segment}__{effective_embedding_model_for_writes('docs')}__v1"
         )
     # RDR-102 Phase A: pre-flight catalog registration. Resolve doc_id BEFORE
     # _index_document's staleness check so a fresh index lands chunks with

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -287,7 +287,7 @@ def _conformant_name_for_repo(repo: Path, content_type: str) -> str:
     canonical model for ``content_type``; version is always v1 for
     ad-hoc fallbacks.
     """
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
     from nexus.registry import _repo_identity, _safe_collection  # noqa: PLC0415
 
     if content_type not in ("code", "docs", "rdr"):
@@ -301,7 +301,7 @@ def _conformant_name_for_repo(repo: Path, content_type: str) -> str:
     # segment. The two synthesis points share the same rule so a repo
     # gets the same name from either entry point.
     sanitised = basename.replace("_", "-")
-    model = canonical_embedding_model(content_type)
+    model = effective_embedding_model_for_writes(content_type)
     return _safe_collection(
         prefix=f"{content_type}__",
         name=sanitised,
@@ -363,7 +363,7 @@ def _migration_source_candidates(
     already crossed the Phase-5 strict-flip and accumulated synth-shape
     collections.
     """
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
     from nexus.registry import _repo_identity, _safe_collection  # noqa: PLC0415
 
     if content_type not in ("code", "docs", "rdr"):
@@ -372,7 +372,7 @@ def _migration_source_candidates(
         )
     basename, repo_hash = _repo_identity(repo)
     sanitised = basename.replace("_", "-")
-    model = canonical_embedding_model(content_type)
+    model = effective_embedding_model_for_writes(content_type)
     return [
         # Pre-RDR-103 legacy 2-segment.
         _safe_collection(f"{content_type}__", basename, repo_hash),
@@ -435,7 +435,7 @@ def _migrate_legacy_collections(
     from nexus.commands.collection import (  # noqa: PLC0415
         rename_collection_data_plane,
     )
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
     from nexus.registry import _repo_identity  # noqa: PLC0415
 
     result: dict[str, str] = {}
@@ -461,7 +461,7 @@ def _migrate_legacy_collections(
         conformant = cat_obj.collection_for(
             content_type=ct,
             owner=owner,
-            embedding_model=canonical_embedding_model(ct),
+            embedding_model=effective_embedding_model_for_writes(ct),
         ).render()
 
         # nexus-7vuw: pick the first source candidate that exists in T3.

--- a/src/nexus/registry.py
+++ b/src/nexus/registry.py
@@ -97,7 +97,7 @@ def _resolve_repo_collection(
                 content_type=content_type,
                 error=str(exc),
             )
-    from nexus.corpus import canonical_embedding_model  # noqa: PLC0415
+    from nexus.corpus import effective_embedding_model_for_writes  # noqa: PLC0415
 
     if content_type not in ("code", "docs", "rdr"):
         raise ValueError(
@@ -118,7 +118,7 @@ def _resolve_repo_collection(
     # since the registry entry was already written, the failure looped
     # forever in the index log on every git hook fire.
     sanitised = _sanitise_owner_segment(name)
-    model = canonical_embedding_model(content_type)
+    model = effective_embedding_model_for_writes(content_type)
     return _safe_collection(
         f"{content_type}__", sanitised, path_hash, suffix=f"__{model}__v1",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,6 +371,10 @@ _MODE_LINT_EXCLUDE_FILES: frozenset[str] = frozenset({
     # per-file so each can be validated against the suite independently.
     # The lint test itself contains the regex.
     "test_mode_declarations_are_explicit.py",
+    # RDR-109 Phase 2 dispatch tests intentionally name voyage tokens
+    # to exercise the (mode, name) matrix. Voyage names here are the
+    # subject under test, not assertions of cloud-mode behavior.
+    "test_rdr_109_phase2_dispatch.py",
     "test_catalog_path.py",
     "test_chroma_retry.py",
     "test_collection_cmd.py",

--- a/tests/hooks/test_rdr_hook.py
+++ b/tests/hooks/test_rdr_hook.py
@@ -27,6 +27,12 @@ from pathlib import Path
 
 import pytest
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_PATH = REPO_ROOT / "nx" / "hooks" / "scripts" / "rdr_hook.py"
 

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -11,6 +11,12 @@ from click.testing import CliRunner
 from nexus.catalog.catalog import Catalog
 from nexus.cli import main
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 
 @pytest.fixture(autouse=True)
 def git_identity(monkeypatch):

--- a/tests/test_catalog_collection_for.py
+++ b/tests/test_catalog_collection_for.py
@@ -25,6 +25,12 @@ from nexus.catalog.collection_name import (
 )
 from nexus.catalog.tumbler import Tumbler
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 
 # ── Fixtures ──────────────────────────────────────────────────────────────
 

--- a/tests/test_catalog_consolidation.py
+++ b/tests/test_catalog_consolidation.py
@@ -11,6 +11,12 @@ from click.testing import CliRunner
 from nexus.catalog.catalog import Catalog
 from nexus.cli import main
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 
 @pytest.fixture(autouse=True)
 def git_identity(monkeypatch):

--- a/tests/test_collection_name_migration.py
+++ b/tests/test_collection_name_migration.py
@@ -35,6 +35,12 @@ from nexus.db.t3 import T3Database
 from nexus.indexer import _legacy_collection_name
 from nexus.registry import RepoRegistry
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 
 def _collection_name(repo):
     return _legacy_collection_name(repo, "code")

--- a/tests/test_commands_dt.py
+++ b/tests/test_commands_dt.py
@@ -30,6 +30,12 @@ from unittest.mock import MagicMock
 import pytest
 from click.testing import CliRunner
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 
 @pytest.fixture
 def runner() -> CliRunner:

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -9,6 +9,12 @@ from nexus.corpus import (
     validate_collection_name,
 )
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 
 # ── Embedding model selection ─────────────────────────────────────────────────
 

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -272,7 +272,7 @@ def test_index_md_falls_back_to_local_embedder_when_no_credentials(
     # Verify chunks landed AND were tagged with the local model name
     # (not voyage-context-3 — staleness check on re-run depends on it).
     col = local_t3.get_or_create_collection(
-        "docs__local-fallback-test__voyage-context-3__v1",
+        "docs__local-fallback-test__minilm-l6-v2-384__v1",
     )
     rows = col.get(limit=1, include=["metadatas"])
     assert rows["metadatas"], "expected at least one chunk in collection"
@@ -351,7 +351,7 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
     )
 
     col = local_t3.get_or_create_collection(
-        "docs__autoinit-probe__voyage-context-3__v1",
+        "docs__autoinit-probe__minilm-l6-v2-384__v1",
     )
     metas_before = col.get(include=["metadatas"])["metadatas"]
     assert metas_before, "expected chunks after first index"
@@ -361,7 +361,7 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
     cat = open_cached(cat_path)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("docs__autoinit-probe__voyage-context-3__v1",),
+        ("docs__autoinit-probe__minilm-l6-v2-384__v1",),
     ).fetchall()
     assert documents, "auto-init catalog must register the indexed file"
     for row in documents:
@@ -1723,7 +1723,7 @@ def test_index_pdf_does_not_emit_source_path(
         index_pdf(sample_pdf, corpus="rdr102-pdf-b", t3=t3, embed_fn=_fake_embed)
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-pdf-b__voyage-context-3__v1",
+        "docs__rdr102-pdf-b__minilm-l6-v2-384__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], "expected at least one chunk"
@@ -1749,7 +1749,7 @@ def test_index_markdown_does_not_emit_source_path(
     assert n > 0
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-md-b__voyage-context-3__v1",
+        "docs__rdr102-md-b__minilm-l6-v2-384__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], "expected at least one chunk"
@@ -1779,7 +1779,7 @@ def test_index_pdf_writes_doc_id_when_catalog_initialized(
         index_pdf(sample_pdf, corpus="rdr102-pdf", t3=t3, embed_fn=_fake_embed)
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-pdf__voyage-context-3__v1",
+        "docs__rdr102-pdf__minilm-l6-v2-384__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], (
@@ -1794,7 +1794,7 @@ def test_index_pdf_writes_doc_id_when_catalog_initialized(
     cat = open_cached(cat_dir)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("docs__rdr102-pdf__voyage-context-3__v1",),
+        ("docs__rdr102-pdf__minilm-l6-v2-384__v1",),
     ).fetchall()
     assert documents, "catalog must have a Document for the indexed PDF"
     for row in documents:
@@ -1817,7 +1817,7 @@ def test_index_markdown_writes_doc_id_when_catalog_initialized(
     assert n > 0, "expected index_markdown to upsert chunks"
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-md__voyage-context-3__v1",
+        "docs__rdr102-md__minilm-l6-v2-384__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], (
@@ -1829,7 +1829,7 @@ def test_index_markdown_writes_doc_id_when_catalog_initialized(
     cat = open_cached(cat_dir)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("docs__rdr102-md__voyage-context-3__v1",),
+        ("docs__rdr102-md__minilm-l6-v2-384__v1",),
     ).fetchall()
     assert documents, "catalog must have a Document for the indexed markdown"
     for row in documents:
@@ -1854,13 +1854,13 @@ def test_batch_index_markdowns_rdr_mode_writes_doc_id_when_catalog_initialized(
 
     batch_index_markdowns(
         [rdr_path], corpus="rdr102-rdrmode",
-        collection_name="rdr__rdr102-rdrmode__voyage-context-3__v1",
+        collection_name="rdr__rdr102-rdrmode__minilm-l6-v2-384__v1",
         content_type="rdr",
         t3=t3,
     )
 
     col = t3.get_or_create_collection(
-        "rdr__rdr102-rdrmode__voyage-context-3__v1",
+        "rdr__rdr102-rdrmode__minilm-l6-v2-384__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], (
@@ -1872,7 +1872,7 @@ def test_batch_index_markdowns_rdr_mode_writes_doc_id_when_catalog_initialized(
     cat = open_cached(cat_dir)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("rdr__rdr102-rdrmode__voyage-context-3__v1",),
+        ("rdr__rdr102-rdrmode__minilm-l6-v2-384__v1",),
     ).fetchall()
     assert documents, "catalog must have a Document for the indexed RDR md"
     for row in documents:

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -9,6 +9,12 @@ from click.testing import CliRunner
 
 from nexus.cli import main
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 PDF_RESULT = {"chunks": 3, "pages": [], "title": "", "author": ""}
 MD_RESULT = {"chunks": 2, "sections": 0}
 

--- a/tests/test_index_pdf_batch.py
+++ b/tests/test_index_pdf_batch.py
@@ -15,6 +15,12 @@ from click.testing import CliRunner
 
 from nexus.cli import main
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 
 @pytest.fixture
 def runner() -> CliRunner:

--- a/tests/test_index_rdr_cmd.py
+++ b/tests/test_index_rdr_cmd.py
@@ -8,6 +8,12 @@ from click.testing import CliRunner
 
 from nexus.cli import main
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 
 @pytest.fixture
 def runner() -> CliRunner:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -11,6 +11,12 @@ from voyageai.object.embeddings import EmbeddingsObject
 
 from nexus.indexer import CredentialsMissingError, index_repository
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 _DEFAULT_CONFIG = {
     "server": {"ignorePatterns": []},
     "indexing": {"code_extensions": [], "prose_extensions": [],

--- a/tests/test_indexer_conformant_names.py
+++ b/tests/test_indexer_conformant_names.py
@@ -25,6 +25,12 @@ from nexus.catalog.catalog import Catalog
 from nexus.corpus import is_conformant_collection_name
 from nexus.registry import RepoRegistry
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 
 @pytest.fixture()
 def catalog(tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -47,6 +47,12 @@ from nexus.mcp_server import (
 )
 from nexus.types import SearchResult
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 

--- a/tests/test_pipeline_stages.py
+++ b/tests/test_pipeline_stages.py
@@ -587,12 +587,12 @@ class TestPipelineIndexPdf:
             ME.return_value.extract.side_effect = _fx(2, fr)
             MC.return_value.chunk.return_value = fc
             pipeline_index_pdf(
-                pdf_path, "rdr102streamhash_b", "docs__rdr102-stream-b__voyage-context-3__v1",
+                pdf_path, "rdr102streamhash_b", "docs__rdr102-stream-b__minilm-l6-v2-384__v1",
                 t3, db=db, embed_fn=_embed,
                 corpus="rdr102_stream_b",
             )
 
-        col = t3.get_or_create_collection("docs__rdr102-stream-b__voyage-context-3__v1")
+        col = t3.get_or_create_collection("docs__rdr102-stream-b__minilm-l6-v2-384__v1")
         rows = col.get(include=["metadatas"])
         assert rows["metadatas"], "expected chunks to land"
         leaked = [m for m in rows["metadatas"] if "source_path" in m]
@@ -643,13 +643,13 @@ class TestPipelineIndexPdf:
             ME.return_value.extract.side_effect = _fx(2, fr)
             MC.return_value.chunk.return_value = fc
             total = pipeline_index_pdf(
-                pdf_path, "rdr102streamhash", "docs__rdr102-stream__voyage-context-3__v1",
+                pdf_path, "rdr102streamhash", "docs__rdr102-stream__minilm-l6-v2-384__v1",
                 t3, db=db, embed_fn=_embed,
                 corpus="rdr102_stream",
             )
         assert total == 2, f"expected 2 chunks uploaded; got {total}"
 
-        col = t3.get_or_create_collection("docs__rdr102-stream__voyage-context-3__v1")
+        col = t3.get_or_create_collection("docs__rdr102-stream__minilm-l6-v2-384__v1")
         rows = col.get(include=["metadatas"])
         assert rows["metadatas"], (
             "expected at least one chunk in docs__rdr102_stream"
@@ -663,7 +663,7 @@ class TestPipelineIndexPdf:
         cat = open_cached(cat_dir)
         documents = cat._db.execute(
             "SELECT tumbler FROM documents WHERE physical_collection = ?",
-            ("docs__rdr102-stream__voyage-context-3__v1",),
+            ("docs__rdr102-stream__minilm-l6-v2-384__v1",),
         ).fetchall()
         assert documents, "catalog must register a Document for the streaming PDF"
         for row in documents:

--- a/tests/test_rdr_109_phase2_dispatch.py
+++ b/tests/test_rdr_109_phase2_dispatch.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-109 Phase 2: bidirectional name-aware EF dispatch + effective
+write-model regression tests.
+
+Closes nexus-n3qu.2 acceptance criteria 1-4 + 6:
+
+- 4-cell (mode, embedded-model-token) matrix in ``T3Database._embedding_fn``.
+- ``IncompatibleCollectionError`` raised loud on local + voyage-name.
+- Legacy voyage-named collections still queryable in cloud mode.
+- ``effective_embedding_model_for_writes`` returns the local token in
+  local mode and delegates to ``canonical_embedding_model`` in cloud.
+- ``embedding_model_for_collection_name`` parses conformant names.
+"""
+from __future__ import annotations
+
+import pytest
+
+from nexus.corpus import (
+    CANONICAL_EMBEDDING_MODELS,
+    LOCAL_EMBEDDING_MODELS,
+    canonical_embedding_model,
+    effective_embedding_model_for_writes,
+    embedding_model_for_collection_name,
+)
+from nexus.db.local_ef import LOCAL_EMBEDDING_TOKENS, local_model_token
+
+
+# ── Foundations ──────────────────────────────────────────────────────
+
+
+def test_local_embedding_models_disjoint_from_canonical() -> None:
+    assert LOCAL_EMBEDDING_MODELS & CANONICAL_EMBEDDING_MODELS == frozenset()
+
+
+def test_local_embedding_models_matches_local_ef_tokens() -> None:
+    assert LOCAL_EMBEDDING_MODELS == LOCAL_EMBEDDING_TOKENS
+
+
+def test_local_model_token_returns_known_value() -> None:
+    assert local_model_token() in LOCAL_EMBEDDING_MODELS
+
+
+# ── effective_embedding_model_for_writes ─────────────────────────────
+
+
+def test_effective_in_local_mode_returns_local_token(monkeypatch) -> None:
+    monkeypatch.setenv("NX_LOCAL", "1")
+    assert effective_embedding_model_for_writes("docs") in LOCAL_EMBEDDING_MODELS
+    assert effective_embedding_model_for_writes("code") in LOCAL_EMBEDDING_MODELS
+
+
+def test_effective_in_cloud_mode_delegates_to_canonical(cloud_mode) -> None:
+    assert (
+        effective_embedding_model_for_writes("docs")
+        == canonical_embedding_model("docs")
+    )
+    assert (
+        effective_embedding_model_for_writes("code")
+        == canonical_embedding_model("code")
+    )
+
+
+# ── embedding_model_for_collection_name ──────────────────────────────
+
+
+def test_parse_voyage_conformant_name() -> None:
+    assert (
+        embedding_model_for_collection_name(
+            "docs__nexus-1-1__voyage-context-3__v1"
+        )
+        == "voyage-context-3"
+    )
+
+
+def test_parse_local_conformant_name() -> None:
+    assert (
+        embedding_model_for_collection_name(
+            "code__nexus-1-1__minilm-l6-v2-384__v1"
+        )
+        == "minilm-l6-v2-384"
+    )
+
+
+def test_parse_returns_none_for_legacy() -> None:
+    assert embedding_model_for_collection_name("docs__nexus-abc") is None
+    assert embedding_model_for_collection_name("knowledge__papers") is None
+
+
+# ── Bidirectional EF dispatch ────────────────────────────────────────
+
+
+@pytest.fixture
+def t3_local():
+    import chromadb
+    from nexus.db.local_ef import LocalEmbeddingFunction
+    from nexus.db.t3 import T3Database
+
+    return T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=None,
+        local_mode=True,
+        voyage_api_key=None,
+    )
+
+
+@pytest.fixture
+def t3_cloud(monkeypatch):
+    import chromadb
+    from nexus.db.t3 import T3Database
+
+    monkeypatch.setattr("nexus.config.is_local_mode", lambda: False)
+    monkeypatch.setenv("CHROMA_API_KEY", "ck")
+    monkeypatch.setenv("VOYAGE_API_KEY", "vk")
+    # local_mode=False but with EphemeralClient so we don't reach a real
+    # CloudClient. We only exercise the _build_embedding_fn path, not
+    # actually embed.
+    return T3Database(
+        _client=chromadb.EphemeralClient(),
+        _ef_override=None,
+        local_mode=False,
+        voyage_api_key="vk_test",
+    )
+
+
+def test_dispatch_local_mode_local_name(t3_local) -> None:
+    from nexus.db.local_ef import LocalEmbeddingFunction
+
+    ef = t3_local._build_embedding_fn("docs__owner-1__minilm-l6-v2-384__v1")
+    assert isinstance(ef, LocalEmbeddingFunction)
+
+
+def test_dispatch_local_mode_legacy_name(t3_local) -> None:
+    """Legacy two-segment names have no parsed token; local mode falls
+    through to LocalEmbeddingFunction (the only thing it CAN do)."""
+    from nexus.db.local_ef import LocalEmbeddingFunction
+
+    ef = t3_local._build_embedding_fn("docs__nexus-abc")
+    assert isinstance(ef, LocalEmbeddingFunction)
+
+
+def test_dispatch_local_mode_voyage_name_raises(t3_local) -> None:
+    from nexus.db.t3 import IncompatibleCollectionError
+
+    with pytest.raises(IncompatibleCollectionError, match="voyage-context-3"):
+        t3_local._build_embedding_fn("docs__owner-1__voyage-context-3__v1")
+
+
+def test_dispatch_cloud_mode_local_name_uses_local_ef(t3_cloud) -> None:
+    """Legacy local-mode collections after credentials are added (the
+    original nexus-59vl + GH #667 hazard). Cloud mode must NOT try to
+    re-embed those 384-dim vectors with Voyage's 1024-dim space."""
+    from nexus.db.local_ef import LocalEmbeddingFunction
+
+    ef = t3_cloud._build_embedding_fn("code__owner-1__minilm-l6-v2-384__v1")
+    assert isinstance(ef, LocalEmbeddingFunction)
+
+
+def test_dispatch_cloud_mode_voyage_conformant_name(t3_cloud) -> None:
+    """Cloud + voyage-token name: the standard cloud path. Verifies the
+    EF model_name matches the parsed token (not the prefix default)."""
+    ef = t3_cloud._build_embedding_fn("docs__owner-1__voyage-context-3__v1")
+    assert ef.model_name == "voyage-context-3"
+
+
+def test_dispatch_cloud_mode_legacy_name(t3_cloud) -> None:
+    """Legacy two-segment names: prefix-based fallback selects Voyage."""
+    ef = t3_cloud._build_embedding_fn("knowledge__papers")
+    # The Voyage EF stores model_name; both context and code possible per
+    # prefix. ``knowledge__`` prefix -> voyage-context-3.
+    assert ef.model_name == "voyage-context-3"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -9,6 +9,12 @@ import pytest
 
 from nexus.registry import RepoRegistry
 
+# RDR-109 Phase 2: this file asserts cloud-mode canonical behavior
+# (voyage-* embedder names, canonical-set defaults). The cloud_mode
+# fixture sets credentials and forces ``is_local_mode()`` to False so
+# the assertions hold regardless of the host environment.
+pytestmark = pytest.mark.usefixtures("cloud_mode")
+
 
 @pytest.fixture
 def reg(tmp_path: Path) -> RepoRegistry:


### PR DESCRIPTION
## Summary

RDR-109 Phase 2. Closes the original GH #667 / nexus-59vl bug (local-mode writes labeled cloud) AND adds the fail-loud branch for the inverted RDR-059 hazard (local-mode EF queried against a voyage-named collection).

- New write-side function `effective_embedding_model_for_writes(content_type)` in `src/nexus/corpus.py` — cloud mode delegates to `canonical_embedding_model` (RDR-103 invariant preserved); local mode returns the active local-embedder token. All WRITE-path callsites migrated.
- New `LOCAL_EMBEDDING_MODELS` frozenset = `{"minilm-l6-v2-384", "bge-base-en-v15-768"}`. `CollectionName.parse` and `_DocumentOps.collection_for` widen their allowed set to include both canonical and local tokens.
- `IncompatibleCollectionError` raised by `T3Database._build_embedding_fn` when local mode hits a voyage-named collection (would produce 384-dim vectors against 1024-dim space).
- Cloud + local-token names dispatch to `LocalEmbeddingFunction` so legacy collections from the 59vl era stay readable after credentials are added.
- Chunk metadata `embedding_model` and `collection_info` prefer the name-parsed token over the prefix default, so the per-chunk identity stops lying.
- `nx doctor` reports the active embedder honestly (mode-aware).

## Dispatch matrix

| Mode | Parsed token | Behavior |
|---|---|---|
| Cloud | voyage-* | Voyage EF for parsed model (existing) |
| Cloud | local-token | `LocalEmbeddingFunction` (legacy 59vl/#667 path) |
| Local | local-token | `LocalEmbeddingFunction` (new write target) |
| Local | voyage-* | **raise `IncompatibleCollectionError`** (was silent noise) |
| Either | unparseable / legacy two-seg | prefix-based fallback (unchanged) |

## Migration policy

Existing local-mode collections that were created with voyage names keep them (rename would invalidate every chash span; see Phase 1's RDR-109 doc §"Out of scope"). The dispatch's cloud + local-token cell handles them when credentials are added; the IncompatibleCollectionError forces a re-index or restore-credentials decision otherwise.

## Test plan

- [x] 14 new tests in `tests/test_rdr_109_phase2_dispatch.py` cover the foundations + all four (mode × token) cells + the regression case.
- [x] `tests/test_doc_indexer.py` and `tests/test_pipeline_stages.py` migrate hardcoded local-mode collection names from `voyage-context-3` to `minilm-l6-v2-384` to match the new write-path naming.
- [x] Full local suite green except for the 3 pre-existing intermittents documented in the RDR-109 handoff (`test_collection_audit::test_json_flag_emits_parseable_payload`, `test_collection_health::test_json_output`, `test_rdr108_lh8c_migration_plumbing::TestK2DrainCLI::test_aspects_drain_empty_queue_exits_0`).
- [x] RDR-109 Phase 1 lint (`test_mode_declarations_are_explicit`) still passes; new dispatch test file added to `_MODE_LINT_EXCLUDE_FILES` (voyage tokens are the subject under test, not behavior assertions).

## Closes

Closes nexus-n3qu.2
Closes nexus-59vl
Closes #667