### PR TITLE
feat(rdr-109): Phase 3, local cross-encoder substrate (nexus-n3qu.3)

### DIFF
--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -1609,6 +1609,14 @@ def _collect_quota_report() -> dict:
     # error.
     retry = dict(get_retry_stats())
 
+    # RDR-109 Phase 3: cross-encoder substrate availability + active backend.
+    from nexus.cross_encoder import cross_encoder_available  # noqa: PLC0415
+    cross_encoder_info = {
+        "available": cross_encoder_available(),
+        "backend": "voyage-rerank-2.5" if not is_local_mode() else "onnx-local",
+        "default_local_model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    }
+
     return {
         "chromadb": {
             "limits": chromadb_limits,
@@ -1616,6 +1624,7 @@ def _collect_quota_report() -> dict:
             "detail": t3_detail,
         },
         "voyage": voyage_limits,
+        "cross_encoder": cross_encoder_info,
         "retry": retry,
     }
 
@@ -1647,6 +1656,19 @@ def _format_quota_report(report: dict) -> str:
             f"dims={caps['embedding_dims']}"
         )
     lines.append("")
+
+    # ── Cross-encoder (RDR-109 Phase 3) ──────────────────────────────────
+    ce = report.get("cross_encoder", {})
+    if ce:
+        ce_status = _CHECK if ce.get("available") else _WARN
+        lines.append(
+            f"  {ce_status} Cross-encoder backend: {ce.get('backend', 'unknown')}"
+        )
+        if ce.get("backend") == "onnx-local":
+            lines.append(
+                f"    default local model: {ce.get('default_local_model', '')}"
+            )
+        lines.append("")
 
     # ── Retry accumulator ────────────────────────────────────────────────
     r = report["retry"]

--- a/src/nexus/cross_encoder.py
+++ b/src/nexus/cross_encoder.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Local cross-encoder substrate for RDR-109 Phase 3.
+
+Provides ``LocalCrossEncoder`` — an ONNX-runtime cross-encoder for
+(query, document) salience scoring without PyTorch. Used by
+:mod:`nexus.scoring` for the local-mode rerank path and reserved for
+RDR-109 Phase 4 (salience calibration, nexus-2wc1).
+
+Stack:
+
+- ``onnxruntime``    runtime (already a core dep via chromadb's bundled
+  ONNX MiniLM EF).
+- ``tokenizers``     HuggingFace Rust tokenizer (already a core dep).
+- ``huggingface_hub``  pulls the ONNX + tokenizer.json artifacts on
+  first call. Already a core dep via chromadb / docling.
+
+Default model: ``cross-encoder/ms-marco-MiniLM-L-6-v2`` (~80MB). The
+download is lazy; importing this module does not touch the network.
+
+RDR-109 Phase 3, step 1 resolved fastembed FIRST: fastembed 0.8.0 has
+no Reranker / CrossEncoder class (only TextEmbedding, SparseTextEmbedding,
+ImageEmbedding, late-interaction). Falling back to onnxruntime-direct
+keeps RDR-038 F-03 intact (no PyTorch) and reuses deps already pulled
+by ``LocalEmbeddingFunction``.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+# Default model: small (~80MB), well-known, well-trained on MS-MARCO.
+# Override via ``LocalCrossEncoder(model_id=...)`` for experimentation.
+_DEFAULT_MODEL_ID = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+# HF hub filenames under the model repo. ``onnx/model.onnx`` is the
+# canonical layout for the ``optimum``-exported variants.
+_MODEL_FILENAME_CANDIDATES = ("model.onnx", "onnx/model.onnx")
+_TOKENIZER_FILENAME = "tokenizer.json"
+
+
+class LocalCrossEncoder:
+    """ONNX cross-encoder. Lazy model download + lazy session init.
+
+    Thread-safe init via a per-instance lock so concurrent ``score()``
+    callers don't race on the first hub download.
+    """
+
+    def __init__(self, model_id: str = _DEFAULT_MODEL_ID, *, cache_dir: Path | None = None) -> None:
+        self._model_id = model_id
+        self._cache_dir = cache_dir
+        self._session: Any = None
+        self._tokenizer: Any = None
+        self._init_lock = threading.Lock()
+
+    @property
+    def model_id(self) -> str:
+        return self._model_id
+
+    def _resolve_model_path(self) -> Path:
+        """Locate ``model.onnx`` for *model_id* on the HF hub. Tries the
+        flat layout first, then the ``onnx/`` subfolder.
+
+        Raises ``RuntimeError`` if neither path exists in the repo.
+        """
+        from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError
+
+        last_exc: Exception | None = None
+        for candidate in _MODEL_FILENAME_CANDIDATES:
+            try:
+                return Path(
+                    hf_hub_download(
+                        repo_id=self._model_id,
+                        filename=candidate,
+                        cache_dir=str(self._cache_dir) if self._cache_dir else None,
+                    )
+                )
+            except EntryNotFoundError as exc:
+                last_exc = exc
+                continue
+        raise RuntimeError(
+            f"LocalCrossEncoder: no ONNX model file found for "
+            f"{self._model_id!r}. Tried {_MODEL_FILENAME_CANDIDATES}."
+        ) from last_exc
+
+    def _resolve_tokenizer_path(self) -> Path:
+        from huggingface_hub import hf_hub_download
+
+        return Path(
+            hf_hub_download(
+                repo_id=self._model_id,
+                filename=_TOKENIZER_FILENAME,
+                cache_dir=str(self._cache_dir) if self._cache_dir else None,
+            )
+        )
+
+    def _init(self) -> None:
+        """Lazy session + tokenizer initialisation.
+
+        Imports onnxruntime / tokenizers inside the function so the
+        module is cheap to import (matches ``LocalEmbeddingFunction``
+        in ``nexus.db.local_ef``).
+        """
+        if self._session is not None:
+            return
+        with self._init_lock:
+            if self._session is not None:
+                return
+            import onnxruntime as ort
+            from tokenizers import Tokenizer
+
+            model_path = self._resolve_model_path()
+            tokenizer_path = self._resolve_tokenizer_path()
+            self._session = ort.InferenceSession(
+                str(model_path),
+                providers=["CPUExecutionProvider"],
+            )
+            self._tokenizer = Tokenizer.from_file(str(tokenizer_path))
+            _log.debug(
+                "local_cross_encoder_initialised",
+                model=self._model_id,
+                providers=self._session.get_providers(),
+            )
+
+    def score(self, query: str, documents: list[str]) -> list[float]:
+        """Return one relevance score per document for *query*.
+
+        Higher score = more relevant. Scores are the raw logit from the
+        cross-encoder head (typical range roughly -10 to +10 for MS-MARCO
+        trained models); callers that need probabilities should apply
+        their own sigmoid.
+
+        Empty ``documents`` returns ``[]`` without initialising the
+        session (cheap no-op).
+        """
+        if not documents:
+            return []
+        self._init()
+        assert self._tokenizer is not None
+        assert self._session is not None
+
+        # ``tokenizers`` encode_batch returns one ``Encoding`` per item.
+        # Pair encoding: tuple of (query, doc) per row.
+        encodings = self._tokenizer.encode_batch(
+            [(query, doc) for doc in documents]
+        )
+        # Build padded numpy arrays for onnxruntime.
+        import numpy as np
+
+        max_len = max(len(e.ids) for e in encodings)
+        input_ids = np.zeros((len(encodings), max_len), dtype=np.int64)
+        attention_mask = np.zeros((len(encodings), max_len), dtype=np.int64)
+        token_type_ids = np.zeros((len(encodings), max_len), dtype=np.int64)
+        for i, enc in enumerate(encodings):
+            n = len(enc.ids)
+            input_ids[i, :n] = enc.ids
+            attention_mask[i, :n] = enc.attention_mask
+            token_type_ids[i, :n] = enc.type_ids
+
+        feeds: dict[str, Any] = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+        }
+        # token_type_ids is required by BERT-style cross-encoders but
+        # not by every architecture; only feed it if the session
+        # expects it.
+        expected_inputs = {inp.name for inp in self._session.get_inputs()}
+        if "token_type_ids" in expected_inputs:
+            feeds["token_type_ids"] = token_type_ids
+
+        outputs = self._session.run(None, feeds)
+        # MS-MARCO cross-encoder exports as a 2D ``logits`` tensor
+        # shaped (batch, 1) or (batch,). Flatten and return as floats.
+        logits = np.asarray(outputs[0]).reshape(-1)
+        return [float(v) for v in logits]
+
+
+_singleton_lock = threading.Lock()
+_singleton: LocalCrossEncoder | None = None
+
+
+def get_local_cross_encoder(model_id: str = _DEFAULT_MODEL_ID) -> LocalCrossEncoder:
+    """Return a process-wide cached :class:`LocalCrossEncoder`.
+
+    Single-singleton-per-model is the common case; tests that need a
+    fresh instance construct one directly.
+    """
+    global _singleton
+    if _singleton is not None and _singleton.model_id == model_id:
+        return _singleton
+    with _singleton_lock:
+        if _singleton is None or _singleton.model_id != model_id:
+            _singleton = LocalCrossEncoder(model_id=model_id)
+    return _singleton
+
+
+def _reset_singleton() -> None:
+    """Test hook: drop the cached singleton."""
+    global _singleton
+    with _singleton_lock:
+        _singleton = None
+
+
+def cross_encoder_available() -> bool:
+    """Return True if the local cross-encoder substrate can plausibly
+    initialise. Checks importability of ``onnxruntime``, ``tokenizers``,
+    and ``huggingface_hub``; does NOT download the model.
+
+    Used by ``nx doctor`` to differentiate ``not installed`` from
+    ``model not downloaded yet``.
+    """
+    for mod in ("onnxruntime", "tokenizers", "huggingface_hub"):
+        try:
+            __import__(mod)
+        except ImportError:
+            return False
+    return True

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -363,18 +363,43 @@ def rerank_results(
     model: str = _RERANK_MODEL,
     top_k: int | None = None,
 ) -> list[SearchResult]:
-    """Rerank *results* using Voyage AI reranker.
+    """Rerank *results* by cross-encoder relevance for *query*.
 
-    Returns results sorted by relevance_score descending.
+    RDR-109 Phase 3 mode-aware dispatch:
 
-    Note: Mutates ``hybrid_score`` on each SearchResult in place before
-    returning the sorted list.
+    - Cloud mode: Voyage AI reranker (``rerank-2.5``).
+    - Local mode: ONNX cross-encoder via
+      :class:`nexus.cross_encoder.LocalCrossEncoder` (default
+      ``cross-encoder/ms-marco-MiniLM-L-6-v2``, ~80MB lazy download).
+
+    Returns results sorted by relevance score descending. Mutates
+    ``hybrid_score`` on each SearchResult in place. On any failure
+    (network, missing model, exception during scoring) falls back to
+    the input order, truncated to *top_k* if supplied. Failure is
+    logged at WARN; reranking is best-effort.
     """
     if not results:
         return results
 
     n = top_k or len(results)
     documents = [r.content for r in results]
+
+    from nexus.config import is_local_mode  # noqa: PLC0415
+
+    if is_local_mode():
+        return _rerank_local(results, query, documents, n)
+    return _rerank_cloud(results, query, documents, model, n)
+
+
+def _rerank_cloud(
+    results: list[SearchResult],
+    query: str,
+    documents: list[str],
+    model: str,
+    top_n: int,
+) -> list[SearchResult]:
+    """Cloud reranker via Voyage AI. Best-effort: any exception falls
+    back to the original order truncated to *top_n*."""
     client = _voyage_client()
     try:
         rerank_response = _voyage_with_retry(
@@ -382,15 +407,45 @@ def rerank_results(
             query=query,
             documents=documents,
             model=model,
-            top_k=n,
+            top_k=top_n,
         )
     except Exception as exc:
         _log.warning("rerank failed, returning original order", error=str(exc))
-        return results[:n]
+        return results[:top_n]
     reranked: list[SearchResult] = []
     for item in rerank_response.results:
         r = results[item.index]
         r.hybrid_score = float(item.relevance_score)
+        reranked.append(r)
+    return reranked
+
+
+def _rerank_local(
+    results: list[SearchResult],
+    query: str,
+    documents: list[str],
+    top_n: int,
+) -> list[SearchResult]:
+    """Local reranker via ONNX cross-encoder. Best-effort: model
+    download failures or missing optional deps fall back to the
+    original order."""
+    try:
+        from nexus.cross_encoder import get_local_cross_encoder  # noqa: PLC0415
+        scores = get_local_cross_encoder().score(query, documents)
+    except Exception as exc:
+        _log.warning(
+            "local rerank failed, returning original order",
+            error=str(exc),
+        )
+        return results[:top_n]
+    pairs = sorted(
+        zip(results, scores, strict=True),
+        key=lambda p: p[1],
+        reverse=True,
+    )
+    reranked: list[SearchResult] = []
+    for r, s in pairs[:top_n]:
+        r.hybrid_score = float(s)
         reranked.append(r)
     return reranked
 

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-109 Phase 3: local cross-encoder substrate + mode-aware rerank.
+
+Tests cover the public surface without hitting the network or running
+ONNX inference (the model download is ~80MB and the inference is
+upstream-tested). The dispatch and fallback paths are the things that
+can regress.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from nexus.cross_encoder import (
+    LocalCrossEncoder,
+    _reset_singleton,
+    cross_encoder_available,
+    get_local_cross_encoder,
+)
+from nexus.types import SearchResult
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    _reset_singleton()
+    yield
+    _reset_singleton()
+
+
+# ── Surface ──────────────────────────────────────────────────────────
+
+
+def test_singleton_is_cached_per_model() -> None:
+    a = get_local_cross_encoder("model-a")
+    b = get_local_cross_encoder("model-a")
+    assert a is b
+
+
+def test_singleton_swaps_when_model_id_changes() -> None:
+    a = get_local_cross_encoder("model-a")
+    b = get_local_cross_encoder("model-b")
+    assert a is not b
+    assert b.model_id == "model-b"
+
+
+def test_cross_encoder_available_true_when_deps_present() -> None:
+    # onnxruntime / tokenizers / huggingface_hub are core deps already
+    # (chromadb's bundled ONNX MiniLM path pulls them).
+    assert cross_encoder_available() is True
+
+
+def test_cross_encoder_available_false_when_dep_missing(monkeypatch) -> None:
+    import builtins
+    real_import = builtins.__import__
+
+    def _fail(name, *args, **kwargs):
+        if name == "onnxruntime":
+            raise ImportError("simulated missing dep")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fail)
+    assert cross_encoder_available() is False
+
+
+def test_score_returns_empty_for_empty_documents() -> None:
+    # Empty documents must short-circuit before touching the session,
+    # so the test does not need to mock the model download.
+    ce = LocalCrossEncoder()
+    assert ce.score("query", []) == []
+
+
+# ── Mode-aware rerank dispatch ───────────────────────────────────────
+
+
+def _make_result(i: int, content: str) -> SearchResult:
+    return SearchResult(
+        id=f"r{i}",
+        content=content,
+        distance=0.0,
+        collection="docs__owner__voyage-context-3__v1",
+        metadata={},
+        hybrid_score=0.0,
+    )
+
+
+def test_rerank_routes_to_local_in_local_mode(monkeypatch) -> None:
+    monkeypatch.setenv("NX_LOCAL", "1")
+    from nexus import scoring
+
+    results = [_make_result(i, f"doc {i}") for i in range(3)]
+
+    calls: dict[str, object] = {}
+
+    def fake_score(self, query, documents):
+        calls["query"] = query
+        calls["docs"] = list(documents)
+        return [0.1, 0.9, 0.5]  # doc-1 wins
+
+    with patch.object(LocalCrossEncoder, "score", fake_score):
+        out = scoring.rerank_results(results, query="q")
+
+    assert [r.id for r in out] == ["r1", "r2", "r0"]
+    assert calls["query"] == "q"
+    assert calls["docs"] == ["doc 0", "doc 1", "doc 2"]
+
+
+def test_rerank_local_failure_falls_back_to_original_order(monkeypatch) -> None:
+    monkeypatch.setenv("NX_LOCAL", "1")
+    from nexus import scoring
+
+    results = [_make_result(i, f"doc {i}") for i in range(3)]
+
+    def boom(self, query, documents):
+        raise RuntimeError("simulated model load failure")
+
+    with patch.object(LocalCrossEncoder, "score", boom):
+        out = scoring.rerank_results(results, query="q", top_k=2)
+
+    assert [r.id for r in out] == ["r0", "r1"]
+
+
+def test_rerank_routes_to_cloud_in_cloud_mode(cloud_mode, monkeypatch) -> None:
+    """Cloud mode preserves the existing Voyage path."""
+    from nexus import scoring
+
+    results = [_make_result(i, f"doc {i}") for i in range(3)]
+
+    class _RerankItem:
+        def __init__(self, index: int, relevance_score: float) -> None:
+            self.index = index
+            self.relevance_score = relevance_score
+
+    class _RerankResp:
+        def __init__(self, items) -> None:
+            self.results = items
+
+    captured: dict[str, object] = {}
+
+    def fake_rerank(query, documents, model, top_k):
+        captured["query"] = query
+        captured["documents"] = list(documents)
+        captured["model"] = model
+        return _RerankResp([
+            _RerankItem(2, 0.9),
+            _RerankItem(0, 0.5),
+            _RerankItem(1, 0.1),
+        ])
+
+    class _FakeClient:
+        def rerank(self, **kw):
+            return fake_rerank(**kw)
+
+    monkeypatch.setattr("nexus.scoring._voyage_client", lambda: _FakeClient())
+
+    out = scoring.rerank_results(results, query="q")
+    assert [r.id for r in out] == ["r2", "r0", "r1"]
+    assert captured["model"] == "rerank-2.5"
+
+
+def test_rerank_returns_empty_when_input_empty(monkeypatch) -> None:
+    from nexus import scoring
+
+    monkeypatch.setenv("NX_LOCAL", "1")
+    assert scoring.rerank_results([], "q") == []

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -20,6 +20,15 @@ from nexus.doc_indexer import (
 from tests.conftest import set_credentials
 
 
+# RDR-109 Phase 2: local-token in test collection names varies by whether
+# fastembed is installed (tier 1: bge-base-en-v15-768, else tier 0:
+# minilm-l6-v2-384). Resolve at runtime so the suite is deterministic on
+# CI (no fastembed) and dev machines (fastembed pulled by experiments).
+def _local_token() -> str:
+    from nexus.db.local_ef import local_model_token
+    return local_model_token()
+
+
 def _add_cce_mock(mock_voyage_client: MagicMock) -> None:
     def _fake_cce(inputs, model, input_type):
         batch = inputs[0]
@@ -272,7 +281,7 @@ def test_index_md_falls_back_to_local_embedder_when_no_credentials(
     # Verify chunks landed AND were tagged with the local model name
     # (not voyage-context-3 — staleness check on re-run depends on it).
     col = local_t3.get_or_create_collection(
-        "docs__local-fallback-test__minilm-l6-v2-384__v1",
+        f"docs__local-fallback-test__{_local_token()}__v1",
     )
     rows = col.get(limit=1, include=["metadatas"])
     assert rows["metadatas"], "expected at least one chunk in collection"
@@ -351,7 +360,7 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
     )
 
     col = local_t3.get_or_create_collection(
-        "docs__autoinit-probe__minilm-l6-v2-384__v1",
+        f"docs__autoinit-probe__{_local_token()}__v1",
     )
     metas_before = col.get(include=["metadatas"])["metadatas"]
     assert metas_before, "expected chunks after first index"
@@ -361,7 +370,7 @@ def test_index_markdown_auto_inits_catalog_when_absent_and_prunes_on_reindex(
     cat = open_cached(cat_path)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("docs__autoinit-probe__minilm-l6-v2-384__v1",),
+        (f"docs__autoinit-probe__{_local_token()}__v1",),
     ).fetchall()
     assert documents, "auto-init catalog must register the indexed file"
     for row in documents:
@@ -1723,7 +1732,7 @@ def test_index_pdf_does_not_emit_source_path(
         index_pdf(sample_pdf, corpus="rdr102-pdf-b", t3=t3, embed_fn=_fake_embed)
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-pdf-b__minilm-l6-v2-384__v1",
+        f"docs__rdr102-pdf-b__{_local_token()}__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], "expected at least one chunk"
@@ -1749,7 +1758,7 @@ def test_index_markdown_does_not_emit_source_path(
     assert n > 0
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-md-b__minilm-l6-v2-384__v1",
+        f"docs__rdr102-md-b__{_local_token()}__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], "expected at least one chunk"
@@ -1779,7 +1788,7 @@ def test_index_pdf_writes_doc_id_when_catalog_initialized(
         index_pdf(sample_pdf, corpus="rdr102-pdf", t3=t3, embed_fn=_fake_embed)
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-pdf__minilm-l6-v2-384__v1",
+        f"docs__rdr102-pdf__{_local_token()}__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], (
@@ -1794,7 +1803,7 @@ def test_index_pdf_writes_doc_id_when_catalog_initialized(
     cat = open_cached(cat_dir)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("docs__rdr102-pdf__minilm-l6-v2-384__v1",),
+        (f"docs__rdr102-pdf__{_local_token()}__v1",),
     ).fetchall()
     assert documents, "catalog must have a Document for the indexed PDF"
     for row in documents:
@@ -1817,7 +1826,7 @@ def test_index_markdown_writes_doc_id_when_catalog_initialized(
     assert n > 0, "expected index_markdown to upsert chunks"
 
     col = t3.get_or_create_collection(
-        "docs__rdr102-md__minilm-l6-v2-384__v1",
+        f"docs__rdr102-md__{_local_token()}__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], (
@@ -1829,7 +1838,7 @@ def test_index_markdown_writes_doc_id_when_catalog_initialized(
     cat = open_cached(cat_dir)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("docs__rdr102-md__minilm-l6-v2-384__v1",),
+        (f"docs__rdr102-md__{_local_token()}__v1",),
     ).fetchall()
     assert documents, "catalog must have a Document for the indexed markdown"
     for row in documents:
@@ -1854,13 +1863,13 @@ def test_batch_index_markdowns_rdr_mode_writes_doc_id_when_catalog_initialized(
 
     batch_index_markdowns(
         [rdr_path], corpus="rdr102-rdrmode",
-        collection_name="rdr__rdr102-rdrmode__minilm-l6-v2-384__v1",
+        collection_name=f"rdr__rdr102-rdrmode__{_local_token()}__v1",
         content_type="rdr",
         t3=t3,
     )
 
     col = t3.get_or_create_collection(
-        "rdr__rdr102-rdrmode__minilm-l6-v2-384__v1",
+        f"rdr__rdr102-rdrmode__{_local_token()}__v1",
     )
     rows = col.get(include=["metadatas"])
     assert rows["metadatas"], (
@@ -1872,7 +1881,7 @@ def test_batch_index_markdowns_rdr_mode_writes_doc_id_when_catalog_initialized(
     cat = open_cached(cat_dir)
     documents = cat._db.execute(
         "SELECT tumbler FROM documents WHERE physical_collection = ?",
-        ("rdr__rdr102-rdrmode__minilm-l6-v2-384__v1",),
+        (f"rdr__rdr102-rdrmode__{_local_token()}__v1",),
     ).fetchall()
     assert documents, "catalog must have a Document for the indexed RDR md"
     for row in documents:

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -606,7 +606,9 @@ class TestCheckQuotas:
             )
         assert result.exit_code == 0, result.output
         data = _json.loads(result.output)
-        assert set(data.keys()) == {"chromadb", "voyage", "retry"}
+        assert set(data.keys()) == {
+            "chromadb", "voyage", "cross_encoder", "retry",
+        }
         assert data["chromadb"]["reachable"] is True
         assert data["chromadb"]["limits"]["max_records_per_write"] == 300
         assert "voyage-code-3" in data["voyage"]["models"]

--- a/tests/test_pipeline_stages.py
+++ b/tests/test_pipeline_stages.py
@@ -25,6 +25,15 @@ from nexus.pipeline_stages import (
     uploader_loop,
 )
 
+
+# RDR-109 Phase 2: local-token in test collection names varies by whether
+# fastembed is installed (tier 1: bge-base-en-v15-768, else tier 0:
+# minilm-l6-v2-384). Resolve at runtime so the suite is deterministic on
+# CI (no fastembed) and dev machines (fastembed pulled by experiments).
+def _local_token() -> str:
+    from nexus.db.local_ef import local_model_token
+    return local_model_token()
+
 _P_EXT = "nexus.pipeline_stages.PDFExtractor"
 _P_CHK = "nexus.pipeline_stages.PDFChunker"
 
@@ -587,12 +596,12 @@ class TestPipelineIndexPdf:
             ME.return_value.extract.side_effect = _fx(2, fr)
             MC.return_value.chunk.return_value = fc
             pipeline_index_pdf(
-                pdf_path, "rdr102streamhash_b", "docs__rdr102-stream-b__minilm-l6-v2-384__v1",
+                pdf_path, "rdr102streamhash_b", f"docs__rdr102-stream-b__{_local_token()}__v1",
                 t3, db=db, embed_fn=_embed,
                 corpus="rdr102_stream_b",
             )
 
-        col = t3.get_or_create_collection("docs__rdr102-stream-b__minilm-l6-v2-384__v1")
+        col = t3.get_or_create_collection(f"docs__rdr102-stream-b__{_local_token()}__v1")
         rows = col.get(include=["metadatas"])
         assert rows["metadatas"], "expected chunks to land"
         leaked = [m for m in rows["metadatas"] if "source_path" in m]
@@ -643,13 +652,13 @@ class TestPipelineIndexPdf:
             ME.return_value.extract.side_effect = _fx(2, fr)
             MC.return_value.chunk.return_value = fc
             total = pipeline_index_pdf(
-                pdf_path, "rdr102streamhash", "docs__rdr102-stream__minilm-l6-v2-384__v1",
+                pdf_path, "rdr102streamhash", f"docs__rdr102-stream__{_local_token()}__v1",
                 t3, db=db, embed_fn=_embed,
                 corpus="rdr102_stream",
             )
         assert total == 2, f"expected 2 chunks uploaded; got {total}"
 
-        col = t3.get_or_create_collection("docs__rdr102-stream__minilm-l6-v2-384__v1")
+        col = t3.get_or_create_collection(f"docs__rdr102-stream__{_local_token()}__v1")
         rows = col.get(include=["metadatas"])
         assert rows["metadatas"], (
             "expected at least one chunk in docs__rdr102_stream"
@@ -663,7 +672,7 @@ class TestPipelineIndexPdf:
         cat = open_cached(cat_dir)
         documents = cat._db.execute(
             "SELECT tumbler FROM documents WHERE physical_collection = ?",
-            ("docs__rdr102-stream__minilm-l6-v2-384__v1",),
+            (f"docs__rdr102-stream__{_local_token()}__v1",),
         ).fetchall()
         assert documents, "catalog must register a Document for the streaming PDF"
         for row in documents:

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -80,8 +80,13 @@ def test_hybrid_mixed_corpus_no_warning(capsys):
 
 # ── AC3: Cross-corpus reranking ───────────────────────────────────────────────
 
-def test_rerank_results_returns_unified_ranking():
-    """rerank_results reorders results using the reranker model."""
+def test_rerank_results_returns_unified_ranking(cloud_mode):
+    """rerank_results reorders results using the reranker model.
+
+    RDR-109 Phase 3: rerank_results dispatches by mode. This test
+    asserts the cloud (Voyage) path; the local path is exercised in
+    ``tests/test_cross_encoder.py``.
+    """
     results = [
         SearchResult(id="1", content="alpha", distance=0.5, collection="code__r", metadata={}),
         SearchResult(id="2", content="beta", distance=0.2, collection="docs__d", metadata={}),


### PR DESCRIPTION
## Summary

RDR-109 Phase 3. Substrate for the salience-rerank work in Phase 4 (`nexus-2wc1`). Cloud mode keeps Voyage `rerank-2.5`; local mode routes to a new `LocalCrossEncoder` backed by `onnxruntime` + HF `tokenizers` (default model `cross-encoder/ms-marco-MiniLM-L-6-v2`, ~80MB lazy download).

## Step 1 research outcome

fastembed 0.8.0 has no Reranker / CrossEncoder class — only `TextEmbedding`, `SparseTextEmbedding`, `ImageEmbedding`, and late-interaction. Falling back to onnxruntime-direct reuses deps already pulled by `LocalEmbeddingFunction` (`onnxruntime`, `tokenizers`, `huggingface_hub` are core deps via chromadb's bundled ONNX path), so:

- No new `conexus[cross-encoder]` optional extra is needed; the substrate works on any install.
- RDR-038 F-03 (no PyTorch) stays intact.

## API surface

- `nexus.cross_encoder.LocalCrossEncoder(model_id=...)` — lazy ONNX cross-encoder. `score(query, documents) -> list[float]` returns one raw logit per doc.
- `nexus.cross_encoder.get_local_cross_encoder()` — process-wide singleton keyed by `model_id`.
- `nexus.cross_encoder.cross_encoder_available()` — predicate for `nx doctor`.
- `nexus.scoring.rerank_results` — mode-aware dispatch. Public signature unchanged.

## Test plan

- [x] 9 new tests in `tests/test_cross_encoder.py` cover singleton caching, dep predicate, empty-doc short-circuit, local + cloud dispatch (mocked).
- [x] `nx doctor --check-quotas --json` schema includes new `cross_encoder` key (test updated).
- [x] Pre-existing `test_doc_indexer.py` / `test_pipeline_stages.py` tests migrated from hardcoded `minilm-l6-v2-384` to runtime `_local_token()` so the suite is deterministic on machines that have fastembed installed (which selects tier 1 `bge-base-en-v15-768`).
- [x] Full local suite green except for pre-existing intermittents documented in handoff.

## Closes

Closes nexus-n3qu.3