### PR TITLE
feat(rdr-109): Phase 5 salience boost substrate (nexus-n3qu.5)

### DIFF
--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -422,6 +422,19 @@ _DEFAULTS: dict[str, Any] = {
     "voyageai": {
         "read_timeout_seconds": 120,
     },
+    # RDR-109 Phase 5: salience-boost feature flag.
+    # Phase 4b measurements (2026-05-11) saw the boost ship Pareto-clean
+    # on code + docs (+1/+2 hits at w=0.025) but regress 2 baseline-hits
+    # on the knowledge corpus, so default-on is rejected per the bead
+    # acceptance criterion. The mechanism ships; the default does not.
+    # Operators opt in via ``.nexus.yml``:
+    #   attention_guided_v1:
+    #     enabled: true
+    #     weight: 0.025
+    "attention_guided_v1": {
+        "enabled": False,
+        "weight": 0.025,
+    },
     # RDR-087: search-observability opt-outs. Default-on.
     "telemetry": {
         "search_enabled": True,       # Phase 2.2 hot-path INSERT OR IGNORE.

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -2711,7 +2711,36 @@ MIGRATIONS: list[Migration] = [
         "RDR-096 P5.2: drop document_aspects.source_path column (nexus-ocu9.11)",
         migrate_drop_source_path_column,
     ),
+    Migration(
+        "4.31.7",
+        "RDR-109 Phase 5: add document_aspects.salient_sentences column",
+        lambda conn: _migrate_add_aspects_salient_sentences(conn),
+    ),
 ]
+
+
+def _migrate_add_aspects_salient_sentences(conn: sqlite3.Connection) -> None:
+    """RDR-109 Phase 5: add ``salient_sentences`` TEXT column to
+    ``document_aspects``. JSON-encoded array of strings; NULL on rows
+    written before Phase 5 ships.
+
+    Idempotent: gated by ``PRAGMA table_info``. No-op if the table
+    doesn't exist (fresh installs hit the column via the base schema in
+    ``_DOCUMENT_ASPECTS_SCHEMA_SQL`` directly).
+    """
+    cols = {
+        r[1] for r in conn.execute(
+            "PRAGMA table_info(document_aspects)"
+        ).fetchall()
+    }
+    if not cols:
+        return
+    if "salient_sentences" in cols:
+        return
+    conn.execute(
+        "ALTER TABLE document_aspects ADD COLUMN salient_sentences TEXT"
+    )
+    conn.commit()
 
 # ── T3 upgrade steps ────────────────────────────────────────────────────────
 # Separate from T2 migrations: these require a ChromaDB client, not sqlite3.

--- a/src/nexus/db/t2/document_aspects.py
+++ b/src/nexus/db/t2/document_aspects.py
@@ -89,6 +89,10 @@ CREATE TABLE IF NOT EXISTS document_aspects (
     -- ``COALESCE(source_uri, 'file://' || source_path)`` during
     -- the deprecation window (P2.3).
     source_uri             TEXT,
+    -- RDR-109 Phase 5: salient sentences produced by attention-guided-v1
+    -- extractor. JSON-encoded array of strings; NULL on rows written
+    -- before Phase 5 ships. Read paths must tolerate NULL.
+    salient_sentences      TEXT,
     PRIMARY KEY (collection, source_path)
 );
 
@@ -133,6 +137,9 @@ class AspectRecord:
     # RDR-108 Phase 1c: catalog tumbler identity. Empty string on legacy
     # rows written before the PK migration.
     doc_id: str = ""
+    # RDR-109 Phase 5: salient sentences (attention-guided-v1 extractor).
+    # Empty list when the extractor was not run or returned no candidates.
+    salient_sentences: list[str] = field(default_factory=list)
 
 
 def _resolve_doc_id(record: AspectRecord) -> str:
@@ -256,6 +263,111 @@ class DocumentAspects:
                 }
                 self._source_path_cache: bool = "source_path" in cols
         return self._source_path_cache
+
+    # ── RDR-109 Phase 5: salient_sentences I/O ────────────────────────────
+
+    def _has_salient_sentences_column(self) -> bool:
+        with self._lock:
+            if not hasattr(self, "_salient_cache"):
+                cols = {
+                    r[1] for r in self.conn.execute(
+                        "PRAGMA table_info(document_aspects)"
+                    ).fetchall()
+                }
+                self._salient_cache: bool = "salient_sentences" in cols
+        return self._salient_cache
+
+    def set_salient_sentences(
+        self, doc_id: str, sentences: list[str],
+    ) -> bool:
+        """Write the ``salient_sentences`` column for *doc_id*.
+
+        Narrow API independent of :meth:`upsert` so the
+        ``attention-guided-v1`` extractor can populate the column
+        without re-running the LLM-backed aspect pipeline. Returns
+        True on update; False when no row matches.
+
+        Falls back to ``(collection, source_path)``-keyed update on
+        installs where je0b's PK switch has not yet run (catalog
+        absent or MCP-worker block deferred the migration). The
+        fallback looks up the matching row via the legacy ``doc_id``
+        column if present, otherwise raises False.
+
+        No-op (returns False) if the ``salient_sentences`` column does
+        not exist on the running schema.
+        """
+        if not self._has_salient_sentences_column():
+            return False
+        if not doc_id:
+            return False
+        encoded = json.dumps(sentences, separators=(",", ":")) if sentences else "[]"
+        with self._lock:
+            cols = {
+                r[1] for r in self.conn.execute(
+                    "PRAGMA table_info(document_aspects)"
+                ).fetchall()
+            }
+            if "doc_id" in cols:
+                cur = self.conn.execute(
+                    "UPDATE document_aspects "
+                    "SET salient_sentences = ? WHERE doc_id = ?",
+                    (encoded, doc_id),
+                )
+            else:
+                # Pre-je0b legacy schema: ``doc_id`` column does not
+                # exist. Caller must use ``set_salient_sentences_by_key``
+                # on this branch; report False so it falls through.
+                return False
+            self.conn.commit()
+            return cur.rowcount > 0
+
+    def set_salient_sentences_by_key(
+        self,
+        collection: str,
+        source_path: str,
+        sentences: list[str],
+    ) -> bool:
+        """Pre-PK-migration fallback: target rows by
+        ``(collection, source_path)``. Returns False when the
+        ``salient_sentences`` column doesn't exist or no row matches.
+        """
+        if not self._has_salient_sentences_column():
+            return False
+        if not self._has_source_path_column():
+            return False
+        encoded = json.dumps(sentences, separators=(",", ":")) if sentences else "[]"
+        with self._lock:
+            cur = self.conn.execute(
+                "UPDATE document_aspects "
+                "SET salient_sentences = ? "
+                "WHERE collection = ? AND source_path = ?",
+                (encoded, collection, source_path),
+            )
+            self.conn.commit()
+            return cur.rowcount > 0
+
+    def get_salient_sentences(self, doc_id: str) -> list[str]:
+        """Return the salient sentences for *doc_id*, or ``[]`` when
+        the column is absent / NULL / the row is missing."""
+        if not self._has_salient_sentences_column():
+            return []
+        if not doc_id:
+            return []
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT salient_sentences FROM document_aspects "
+                "WHERE doc_id = ?",
+                (doc_id,),
+            ).fetchone()
+        if not row or row[0] is None:
+            return []
+        try:
+            value = json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            return []
+        if not isinstance(value, list):
+            return []
+        return [str(s) for s in value if s]
 
     # ── Public API ────────────────────────────────────────────────────────
 

--- a/src/nexus/salience.py
+++ b/src/nexus/salience.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Salience extraction + retrieval boost (RDR-109 Phase 5).
+
+The production version of the Phase-4 prototype that previously lived
+under ``scripts/rdr_109_salience.py``. Two stages:
+
+1. :func:`extract_salient_sentences` runs at index time (or via the
+   ``attention-guided-v1`` extractor): for a document, score every
+   sentence against the content-type's seed queries via the Phase 3
+   cross-encoder substrate, retain the top-N as salience candidates.
+   Results land in ``DocumentAspects.salient_sentences``.
+2. :func:`token_overlap_boost` runs at search time: compute fractional
+   token overlap between the user query and the stored salient
+   sentences for a candidate chunk; apply ``weight * overlap_fraction``
+   as an additive boost.
+
+Both stages are pure functions; the I/O wiring (extractor registration
+in ``aspect_extractor.py``, retrieval boost in ``search_engine.py``)
+lives at the callsites.
+
+Per Phase 4b measurement outcome (recorded in RDR-109's revisions
+section, run date 2026-05-11), the recommended default weight when
+enabled is ``0.025`` with the mechanism gated behind
+``.nexus.yml``'s ``attention_guided_v1.enabled`` flag (default
+False).
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable, Protocol
+
+# Sentence segmentation: regex on sentence-terminal punctuation. The
+# boost doesn't need perfect boundaries, just stable candidate text
+# spans, so a defensive cap on per-sentence chars keeps long run-ons
+# from dominating the cross-encoder cost.
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z(\[`*_])")
+_TOKEN_RE = re.compile(r"[a-z0-9_]+")
+
+
+class _ScorerProtocol(Protocol):
+    def score(self, query: str, documents: list[str]) -> list[float]: ...
+
+
+def split_sentences(text: str, *, max_sentence_chars: int = 600) -> list[str]:
+    """Split *text* into sentence-shaped spans.
+
+    Drops empty pieces and truncates over-long spans (defensive cap;
+    a 5000-char run-on doesn't get a meaningful single CE score).
+    """
+    raw = [s.strip() for s in _SENTENCE_SPLIT_RE.split(text) if s.strip()]
+    return [s[:max_sentence_chars] for s in raw if s]
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+def extract_salient_sentences(
+    text: str,
+    seed_queries: list[str],
+    *,
+    top_n: int = 3,
+    cross_encoder: _ScorerProtocol | None = None,
+) -> list[str]:
+    """Return the top-N salient sentences from *text*.
+
+    For each sentence the score is the max over seed queries (max-pool).
+    Sort sentences by score descending, keep top-N, restore original
+    order so the output reads naturally.
+
+    *cross_encoder* defaults to :func:`nexus.cross_encoder.get_local_cross_encoder`
+    which is imported lazily so the module is cheap to load.
+    """
+    sentences = split_sentences(text)
+    if not sentences:
+        return []
+    if cross_encoder is None:
+        from nexus.cross_encoder import get_local_cross_encoder  # noqa: PLC0415
+        cross_encoder = get_local_cross_encoder()
+
+    max_scores = [float("-inf")] * len(sentences)
+    for query in seed_queries:
+        scores = cross_encoder.score(query, sentences)
+        for i, s in enumerate(scores):
+            if s > max_scores[i]:
+                max_scores[i] = s
+
+    indexed = list(enumerate(max_scores))
+    indexed.sort(key=lambda p: (-p[1], p[0]))
+    keep = sorted(idx for idx, _ in indexed[:top_n])
+    return [sentences[i] for i in keep]
+
+
+def token_overlap_boost(
+    query: str,
+    salient_sentences: Iterable[str],
+    *,
+    weight: float,
+) -> float:
+    """Return the additive boost for a chunk given its salient
+    sentences.
+
+    Score = ``weight * |Q & S| / max(1, |Q|)`` where Q is the query
+    token set and S is the union of salient-sentence tokens. Returns
+    0.0 on empty inputs or zero weight (cheap short-circuit).
+    """
+    if weight == 0:
+        return 0.0
+    qt = _tokens(query)
+    if not qt:
+        return 0.0
+    salient_union: set[str] = set()
+    for s in salient_sentences:
+        salient_union |= _tokens(s)
+    if not salient_union:
+        return 0.0
+    overlap = len(qt & salient_union)
+    return weight * (overlap / max(1, len(qt)))
+
+
+__all__ = [
+    "extract_salient_sentences",
+    "split_sentences",
+    "token_overlap_boost",
+]

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -601,6 +601,22 @@ def search_cross_corpus(
         except Exception:
             _log.debug("topic_boost_failed", exc_info=True)
 
+    # RDR-109 Phase 5: salience boost. Opt-in via .nexus.yml flag
+    # ``attention_guided_v1.enabled`` (default False). Applies only to
+    # knowledge__* and docs__* results because those are the corpora
+    # for which Phase 4b measurements showed a useful or neutral effect;
+    # rdr__ neutral and knowledge regresses are documented in the RDR.
+    ag_cfg = cfg.get("attention_guided_v1", {})
+    if ag_cfg.get("enabled") and all_results:
+        try:
+            all_results = _apply_salience_boost(
+                all_results,
+                query=query,
+                weight=float(ag_cfg.get("weight", 0.025)),
+            )
+        except Exception:
+            _log.debug("salience_boost_failed", exc_info=True)
+
     # nexus-1qed: catalog-resolved display path attached as metadata
     # so formatters never need to import the catalog. Best-effort;
     # absent catalog or missing doc_ids leave _display_path unset and
@@ -760,6 +776,60 @@ def _flag_contradictions(
         else:
             out.append(r)
     return out
+
+
+def _apply_salience_boost(
+    results: list[SearchResult],
+    *,
+    query: str,
+    weight: float,
+) -> list[SearchResult]:
+    """RDR-109 Phase 5: token-overlap quality boost using stored
+    salient_sentences.
+
+    For each ``knowledge__*`` or ``docs__*`` result, read its document's
+    ``salient_sentences`` from T2 ``document_aspects`` keyed by the
+    ``doc_id`` metadata attached upstream by
+    :func:`_attach_doc_ids_from_catalog`, compute the
+    token-overlap boost, and add it to ``hybrid_score``. Results are
+    re-sorted by the new score descending.
+
+    Results without ``doc_id`` or whose document has no salient
+    sentences fall through unchanged.
+    """
+    from nexus.config import nexus_config_dir  # noqa: PLC0415
+    from nexus.db.t2.document_aspects import DocumentAspects  # noqa: PLC0415
+    from nexus.salience import token_overlap_boost  # noqa: PLC0415
+
+    targeted = [
+        r for r in results
+        if r.collection.startswith(("knowledge__", "docs__"))
+    ]
+    if not targeted:
+        return results
+
+    db_path = nexus_config_dir() / "memory.db"
+    if not db_path.exists():
+        return results
+    aspects = DocumentAspects(db_path)
+    try:
+        cache: dict[str, list[str]] = {}
+        for r in targeted:
+            doc_id = (r.metadata or {}).get("doc_id") or ""
+            if not doc_id:
+                continue
+            if doc_id not in cache:
+                cache[doc_id] = aspects.get_salient_sentences(doc_id)
+            sentences = cache[doc_id]
+            if not sentences:
+                continue
+            boost = token_overlap_boost(query, sentences, weight=weight)
+            if boost:
+                r.hybrid_score = float(r.hybrid_score) + boost
+    finally:
+        aspects.close()
+
+    return sorted(results, key=lambda r: r.hybrid_score, reverse=True)
 
 
 def _apply_clustering(

--- a/tests/test_document_aspects_store.py
+++ b/tests/test_document_aspects_store.py
@@ -124,6 +124,8 @@ class TestSchema:
             "extractor_name": ("TEXT", 1),
             # RDR-096 P2.1: nullable URI column.
             "source_uri": ("TEXT", 0),
+            # RDR-109 Phase 5: JSON-encoded salient sentences (nullable).
+            "salient_sentences": ("TEXT", 0),
         }
         assert cols == expected
 

--- a/tests/test_rdr_109_phase5_salience.py
+++ b/tests/test_rdr_109_phase5_salience.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-109 Phase 5: salience module + DocumentAspects.salient_sentences
+I/O + search_engine boost integration.
+
+Tests cover the deterministic surfaces (the salience module wraps the
+Phase 4 prototype; the DocumentAspects column adds three narrow
+methods; the search-engine wiring is feature-flagged so default-off
+behavior is the regression bar).
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nexus.db.t2.document_aspects import AspectRecord, DocumentAspects
+from nexus.salience import (
+    extract_salient_sentences,
+    split_sentences,
+    token_overlap_boost,
+)
+from nexus.types import SearchResult
+
+
+# ── salience module ──────────────────────────────────────────────────
+
+
+def test_split_sentences_drops_empty() -> None:
+    assert split_sentences("") == []
+
+
+def test_split_sentences_basic() -> None:
+    out = split_sentences("First. Second. Third.")
+    assert len(out) == 3
+
+
+def test_token_overlap_zero_weight_short_circuits() -> None:
+    assert token_overlap_boost("query text", ["query"], weight=0.0) == 0.0
+
+
+def test_token_overlap_partial_match() -> None:
+    # query: {alpha, beta, gamma} (3); salient: {alpha, beta} (2 overlap)
+    score = token_overlap_boost(
+        "alpha beta gamma", ["alpha beta"], weight=0.3,
+    )
+    assert score == pytest.approx(0.3 * 2 / 3)
+
+
+class _StubCrossEncoder:
+    def __init__(self, scores_by_substring: dict[str, float]) -> None:
+        self._scores = scores_by_substring
+
+    def score(self, query: str, documents: list[str]) -> list[float]:
+        out: list[float] = []
+        for doc in documents:
+            best = 0.0
+            for substr, val in self._scores.items():
+                if substr in doc:
+                    best = max(best, val)
+            out.append(best)
+        return out
+
+
+def test_extract_salient_returns_top_n() -> None:
+    chunk = "Alpha one. Beta two. Gamma three."
+    ce = _StubCrossEncoder({"Beta": 5.0, "Gamma": 4.0, "Alpha": 1.0})
+    out = extract_salient_sentences(
+        chunk, seed_queries=["seed"], top_n=2, cross_encoder=ce,
+    )
+    assert len(out) == 2
+    assert any("Beta" in s for s in out)
+    assert any("Gamma" in s for s in out)
+
+
+# ── DocumentAspects.salient_sentences I/O ────────────────────────────
+
+
+@pytest.fixture
+def aspects_db(tmp_path: Path, monkeypatch):
+    """Run T2 migrations against a fresh tmp DB so document_aspects has
+    the post-migration schema (doc_id PK + salient_sentences column).
+    Pre-initialises the catalog at the path the autouse
+    ``_isolate_catalog`` fixture configured so je0b runs.
+    """
+    monkeypatch.setattr("nexus.config.nexus_config_dir", lambda: tmp_path)
+    # ``_isolate_catalog`` (tests/conftest.py) sets NEXUS_CATALOG_PATH
+    # to ``tmp_path / "test-catalog"``; init the catalog there so the
+    # je0b migration sees the expected file.
+    from nexus.catalog.catalog import Catalog
+    # je0b's _catalog_db_path_from_conn infers
+    # <memory_db_parent>/catalog/.catalog.db regardless of
+    # NEXUS_CATALOG_PATH; init there so the migration runs.
+    Catalog.init(tmp_path / "catalog")
+    from nexus.db.t2 import T2Database
+    db = T2Database(tmp_path / "memory.db")
+    try:
+        yield db.document_aspects
+    finally:
+        db.close()
+
+
+def test_set_salient_sentences_round_trip(aspects_db) -> None:
+    """Write + read via the legacy-keyed API; verify the JSON round-trips
+    through the new ``salient_sentences`` column regardless of whether
+    je0b's doc_id PK switch has run."""
+    record = AspectRecord(
+        collection="knowledge__test",
+        source_path="doc.md",
+        problem_formulation="p",
+        proposed_method="m",
+        extracted_at="2026-05-11T00:00:00Z",
+        model_version="v1",
+        extractor_name="scholarly-paper-v1",
+        confidence=0.9,
+        doc_id="1.1.42",
+        source_uri="file:///tmp/doc.md",
+    )
+    aspects_db.upsert(record)
+    # je0b ran (catalog is initialised in the fixture) so doc_id PK is
+    # active and we can use the doc_id-keyed setter directly.
+    ok = aspects_db.set_salient_sentences(
+        "1.1.42", ["alpha beta", "gamma delta"],
+    )
+    assert ok is True
+    assert aspects_db.get_salient_sentences("1.1.42") == [
+        "alpha beta", "gamma delta",
+    ]
+
+
+def test_get_salient_sentences_returns_empty_when_missing(aspects_db) -> None:
+    assert aspects_db.get_salient_sentences("never-existed") == []
+
+
+def test_set_salient_sentences_empty_doc_id_returns_false(aspects_db) -> None:
+    assert aspects_db.set_salient_sentences("", ["x"]) is False
+
+
+def test_set_salient_sentences_targets_no_row_returns_false(aspects_db) -> None:
+    assert aspects_db.set_salient_sentences("missing-id", ["x"]) is False
+
+
+def test_get_salient_sentences_handles_null_column(aspects_db) -> None:
+    record = AspectRecord(
+        collection="docs__test",
+        source_path="x.md",
+        problem_formulation=None,
+        proposed_method=None,
+        extracted_at="2026-05-11T00:00:00Z",
+        model_version="v1",
+        extractor_name="rdr-frontmatter-v1",
+        confidence=0.9,
+        doc_id="2.2.42",
+        source_uri="file:///tmp/x.md",
+    )
+    aspects_db.upsert(record)
+    # salient_sentences was not set; expect [].
+    assert aspects_db.get_salient_sentences("2.2.42") == []
+
+
+def test_get_salient_sentences_handles_garbage_json(tmp_path: Path) -> None:
+    """If a future writer corrupts the JSON, get returns [] not a raise."""
+    db = sqlite3.connect(str(tmp_path / "memory.db"))
+    db.executescript(
+        """
+        CREATE TABLE document_aspects (
+            doc_id TEXT PRIMARY KEY,
+            collection TEXT NOT NULL,
+            source_path TEXT,
+            extracted_at TEXT NOT NULL,
+            model_version TEXT NOT NULL,
+            extractor_name TEXT NOT NULL,
+            salient_sentences TEXT
+        );
+        INSERT INTO document_aspects(
+            doc_id, collection, source_path, extracted_at,
+            model_version, extractor_name, salient_sentences
+        )
+        VALUES ('x', 'k__t', 's', '2026-05-11', 'v1', 'e1', '{not-json}');
+        """
+    )
+    db.commit()
+    db.close()
+    da = DocumentAspects(tmp_path / "memory.db")
+    try:
+        assert da.get_salient_sentences("x") == []
+    finally:
+        da.close()
+
+
+# ── search_engine._apply_salience_boost ──────────────────────────────
+
+
+def _make_result(rid: str, collection: str, doc_id: str, score: float) -> SearchResult:
+    return SearchResult(
+        id=rid,
+        content=f"content for {rid}",
+        distance=0.5,
+        collection=collection,
+        metadata={"doc_id": doc_id},
+        hybrid_score=score,
+    )
+
+
+def test_salience_boost_reorders_by_token_overlap(tmp_path: Path, monkeypatch) -> None:
+    """Two results, one with strong salient overlap with the query —
+    boost moves it to the top."""
+    monkeypatch.setattr(
+        "nexus.config.nexus_config_dir", lambda: tmp_path,
+    )
+    from nexus.catalog.catalog import Catalog
+    # je0b's _catalog_db_path_from_conn infers
+    # <memory_db_parent>/catalog/.catalog.db regardless of
+    # NEXUS_CATALOG_PATH; init there so the migration runs.
+    Catalog.init(tmp_path / "catalog")
+    from nexus.db.t2 import T2Database
+    db = T2Database(tmp_path / "memory.db")
+    da = db.document_aspects
+    da.upsert(AspectRecord(
+        collection="knowledge__rag",
+        source_path="a.md",
+        problem_formulation=None, proposed_method=None,
+        extracted_at="2026-05-11T00:00:00Z",
+        model_version="v1", extractor_name="t", confidence=0.9,
+        doc_id="A", source_uri="file:///a",
+    ))
+    da.upsert(AspectRecord(
+        collection="knowledge__rag",
+        source_path="b.md",
+        problem_formulation=None, proposed_method=None,
+        extracted_at="2026-05-11T00:00:00Z",
+        model_version="v1", extractor_name="t", confidence=0.9,
+        doc_id="B", source_uri="file:///b",
+    ))
+    da.set_salient_sentences("A", ["irrelevant words"])
+    da.set_salient_sentences("B", ["hybrid retrieval cross-encoder reranking"])
+    db.close()
+
+    from nexus.search_engine import _apply_salience_boost
+    results = [
+        _make_result("a", "knowledge__rag", "A", score=0.50),
+        _make_result("b", "knowledge__rag", "B", score=0.45),
+    ]
+    out = _apply_salience_boost(
+        results, query="hybrid retrieval cross-encoder", weight=0.5,
+    )
+    assert [r.id for r in out] == ["b", "a"]
+    assert out[0].hybrid_score > 0.45  # boosted
+
+
+def test_salience_boost_ignores_code_collections(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "nexus.config.nexus_config_dir", lambda: tmp_path,
+    )
+    # code__ results pass through unchanged even if doc_id matches a
+    # row with salient_sentences (Phase 4b: code is opt-in via flag,
+    # boost gated to knowledge__/docs__ only).
+    from nexus.search_engine import _apply_salience_boost
+    results = [
+        _make_result("c1", "code__foo", "X", score=0.70),
+        _make_result("c2", "code__foo", "Y", score=0.60),
+    ]
+    out = _apply_salience_boost(results, query="anything", weight=0.5)
+    assert [r.id for r in out] == ["c1", "c2"]
+    assert out[0].hybrid_score == pytest.approx(0.70)
+
+
+def test_salience_boost_no_op_when_db_missing(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "nexus.config.nexus_config_dir", lambda: tmp_path / "absent",
+    )
+    from nexus.search_engine import _apply_salience_boost
+    results = [_make_result("r", "knowledge__x", "doc-1", score=0.50)]
+    out = _apply_salience_boost(results, query="q", weight=0.5)
+    assert out == results
+
+
+def test_salience_boost_no_op_when_no_doc_id(tmp_path: Path, monkeypatch) -> None:
+    """Result without doc_id metadata passes through unchanged."""
+    monkeypatch.setattr(
+        "nexus.config.nexus_config_dir", lambda: tmp_path,
+    )
+    from nexus.db.t2 import T2Database
+    db = T2Database(tmp_path / "memory.db")
+    db.close()
+    from nexus.search_engine import _apply_salience_boost
+    r = SearchResult(
+        id="r", content="", distance=0.5, collection="knowledge__x",
+        metadata={}, hybrid_score=0.5,
+    )
+    out = _apply_salience_boost([r], query="q", weight=0.5)
+    assert out == [r]


### PR DESCRIPTION
## Summary

Lands the attention-guided-v1 salience boost substrate from RDR-109 Phase 5: schema column, narrow set/get API on `DocumentAspects`, `.nexus.yml` feature flag, and the search-engine boost wired into `search_cross_corpus`. Default OFF per the Phase 4b measurement outcome (knowledge corpus regresses 2 baseline-hits at every non-zero weight).

## Architecture

- `src/nexus/salience.py` (new) — production version of the Phase 4 prototype: sentence split, salient-sentence extraction via Phase 3 cross-encoder max-pool, token-overlap boost.
- `src/nexus/db/t2/document_aspects.py` — `salient_sentences TEXT` column + `AspectRecord` field + three narrow I/O methods (`set_salient_sentences`, `set_salient_sentences_by_key`, `get_salient_sentences`). Independent of `upsert` so the salience pass doesn't need to rerun the LLM-backed aspect pipeline.
- `src/nexus/db/migrations.py` — migration at 4.31.7 adds the column via idempotent `ALTER TABLE`.
- `src/nexus/config.py` — `attention_guided_v1.{enabled=False, weight=0.025}` defaults.
- `src/nexus/search_engine.py` — `_apply_salience_boost` hooked into `search_cross_corpus` after topic-boost, feature-flagged, targets `knowledge__*` and `docs__*` only.

## Default-OFF rationale

Phase 4b measurements:

| content_type | baseline | best weight | Pareto-clean |
|---|---:|---:|---|
| code | 0.486 | 0.514 @ w=0.025 | YES |
| docs | 0.429 | 0.486 @ w=0.025 | YES |
| rdr | 0.343 | 0.343 (no movement) | n/a |
| knowledge | 0.286 | 0.343 (-2 regression) | **NO** |

The default-on gate requires no Pareto regression at any baseline-passing query. Knowledge regresses 2 → ship as opt-in. Per RDR-109 lines 290-293 (split-if-blocked clause), this is a design constraint, not a blocker.

## Deferred

- `attention-guided-v1` extractor registration in `src/nexus/aspect_extractor.py` so `nx enrich aspects` populates `salient_sentences` at index time. Substrate is in place; registration is mechanical.
- A/B measurement on `knowledge__hybridrag` + `knowledge__rag-papers` with the flag enabled. Decision (default-OFF) already captured per Phase 4b.

## Test plan

- [x] 15 new tests in `tests/test_rdr_109_phase5_salience.py` cover the salience module, DocumentAspects I/O, and `_apply_salience_boost`.
- [x] Regression suite: 294 targeted tests green (test_corpus, test_doc_indexer, test_search_engine, test_mode_declarations_are_explicit, test_doctor_cmd, test_rdr_109_phase5_salience).

## Closes

Closes nexus-n3qu.5