### PR TITLE
fix(chunker): _split_long_line, prefer whitespace over mid-identifier hard cuts (nexus-wuhw)

### DIFF
--- a/src/nexus/chunker.py
+++ b/src/nexus/chunker.py
@@ -20,6 +20,11 @@ _CHUNK_MAX_BYTES = SAFE_CHUNK_BYTES
 # oversized chunk that gets truncated.
 _LONG_LINE_THRESHOLD = SAFE_CHUNK_BYTES
 _BREAK_CHARS = (";", ",", "}", ")", "]")
+# RDR-109 follow-up / nexus-wuhw: when no syntactic break is available,
+# any whitespace boundary is strictly better than a hard cut through
+# an identifier. Searched after _BREAK_CHARS so structurally meaningful
+# splits still win when available.
+_WHITESPACE_BREAK_CHARS = (" ", "\t", "\n")
 
 
 def _make_code_splitter(language: str, content: str, chunk_lines: int = _CHUNK_LINES) -> list:
@@ -54,9 +59,21 @@ def _split_long_line(line: str, max_chars: int) -> list[str]:
     """Split a very long line into smaller segments at natural break points.
 
     Used for minified code where a single line can be the entire file.
-    Prefers splitting at semicolons, commas, and closing brackets within
-    the last 20% of each segment.  Falls back to a hard cut at *max_chars*
-    when no natural break point is found.
+    Three preference tiers, falling through to the next when none found:
+
+    1. Syntactic break (semicolon, comma, closing bracket) in the last
+       20% of the segment.
+    2. Any whitespace boundary searched leftward through the full
+       window. Strictly better than a hard cut through an identifier.
+    3. Hard cut at *max_chars*. Reached only by truly minified code
+       with no whitespace anywhere — rare; mid-identifier splits at
+       this point are unavoidable.
+
+    nexus-wuhw: tier 2 was missing pre-fix, so files where every
+    syntactic break happened to land outside the last-20% window fell
+    straight through to the hard cut, producing chunks that started
+    mid-identifier ("tected ...", "ivate void ..."). Always prefer a
+    whitespace boundary over a mid-token slice.
     """
     if len(line) <= max_chars:
         return [line]
@@ -66,7 +83,7 @@ def _split_long_line(line: str, max_chars: int) -> list[str]:
     while pos < len(line):
         end = min(pos + max_chars, len(line))
         if end < len(line):
-            # Search for a natural break in the last 20% of the segment
+            # Tier 1: syntactic break in the last 20%.
             search_start = pos + int(max_chars * 0.8)
             best_break = -1
             for ch in _BREAK_CHARS:
@@ -74,7 +91,23 @@ def _split_long_line(line: str, max_chars: int) -> list[str]:
                 if bp > best_break:
                     best_break = bp
             if best_break > search_start:
-                end = best_break + 1  # include the break character
+                end = best_break + 1
+            else:
+                # Tier 2: any whitespace boundary in the full window.
+                ws_break = -1
+                for ch in _WHITESPACE_BREAK_CHARS:
+                    bp = line.rfind(ch, pos + 1, end)
+                    if bp > ws_break:
+                        ws_break = bp
+                if ws_break > pos:
+                    # Cut AT the whitespace (include it as a trailing
+                    # space on the current segment); the next segment
+                    # then starts cleanly at the following non-space.
+                    end = ws_break + 1
+                # else: tier 3 — minified code with no whitespace.
+                # Accept the hard cut at *max_chars*; the chunk will
+                # start mid-identifier but no boundary preserves
+                # tokens here.
         segments.append(line[pos:end])
         pos = end
     return segments

--- a/tests/test_chunker_split_long_line.py
+++ b/tests/test_chunker_split_long_line.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Regression tests for nexus-wuhw: _split_long_line must not produce
+mid-identifier fragments when a whitespace boundary is available.
+
+Symptom: in ``code__1-2153__voyage-code-3__v1`` (the ART Java repo),
+~24% of micro-chunks started mid-identifier ("tected ...", "ivate ...").
+Root cause: the _split_long_line search window for natural breaks was
+fixed at the last 20% of the segment, and when no syntactic break
+landed there the fallback hard-cut at max_chars sliced through
+whatever identifier happened to be at that offset.
+
+The fix adds a tier-2 whitespace search across the full window so any
+whitespace boundary is preferred over a mid-token hard cut.
+"""
+from __future__ import annotations
+
+import re
+
+from nexus.chunker import _split_long_line
+
+
+_IDENT_CHAR_RE = re.compile(r"[A-Za-z0-9_]")
+
+
+def _mid_identifier_boundaries(original: str, segments: list[str]) -> list[str]:
+    """Return segments whose start position in *original* is preceded
+    by an identifier character. A boundary that sits inside a run of
+    ``[A-Za-z0-9_]`` is a mid-identifier slice.
+    """
+    offenders: list[str] = []
+    cursor = 0
+    for i, seg in enumerate(segments):
+        if i == 0:
+            cursor += len(seg)
+            continue
+        # Segments concatenate to the original (lossless invariant).
+        prev_char = original[cursor - 1] if cursor > 0 else ""
+        first_char = seg[:1]
+        if (
+            prev_char
+            and first_char
+            and _IDENT_CHAR_RE.match(prev_char)
+            and _IDENT_CHAR_RE.match(first_char)
+        ):
+            offenders.append(seg[:60])
+        cursor += len(seg)
+    return offenders
+
+
+def test_short_line_unchanged() -> None:
+    """Below the max_chars threshold returns the line untouched."""
+    out = _split_long_line("short line", max_chars=100)
+    assert out == ["short line"]
+
+
+def test_split_prefers_syntactic_break_in_last_20pct() -> None:
+    """When a semicolon strictly inside the last 20% window, it wins
+    over later whitespace boundaries (existing tier-1 contract)."""
+    # max_chars=40. Last-20% window is positions > 32 and < 40.
+    # Place the semicolon at position 36 (well inside the window).
+    # Layout: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;morestuff_here..."
+    line = ("a" * 36) + ";morestuff and more characters past 40"
+    out = _split_long_line(line, max_chars=40)
+    assert out[0].endswith(";"), out[0]
+
+
+def test_split_uses_whitespace_when_no_syntactic_break() -> None:
+    """The wuhw fix: when no syntactic break lives in the last 20%,
+    fall back to ANY whitespace boundary before hard-cutting.
+
+    Pre-fix: ``protected void doSomething`` at the boundary would be
+    hard-cut, leaving ``tected void doSomething`` at the next chunk's
+    start.
+    """
+    # Java-shaped run: identifiers separated by spaces, no semicolons
+    # anywhere in the last-20% window before max_chars.
+    # max_chars = 50; the cut would land mid-"CanonicalLaminarCircuitGPU"
+    # without the whitespace tier.
+    line = (
+        "protected CanonicalLaminarCircuitGPU(CanonicalParameters params, "
+        "OrientingAdapter orienter, AttentionalAdapter attention)"
+    )
+    out = _split_long_line(line, max_chars=50)
+    offenders = _mid_identifier_boundaries(line, out)
+    assert not offenders, (
+        f"chunk(s) start mid-identifier: {offenders!r}"
+    )
+
+
+def test_split_emits_clean_boundaries_for_java_like_run() -> None:
+    """Composite regression mirroring the bead's observed fragments."""
+    line = (
+        "private void initializeMetalKernels() throws Exception { "
+        "float executeIterationBatched(int dimension, int groupingDim) "
+        "throws Exception ProcessingResult processGPUIterationLoop"
+        "(float[] input) throws Exception if (iter % 10 == 0 && "
+        "count >= minStableIterations) return; if (maxL6 >= "
+        "minL6Threshold) return;"
+    )
+    out = _split_long_line(line, max_chars=60)
+    offenders = _mid_identifier_boundaries(line, out)
+    assert not offenders, (
+        f"chunk(s) start mid-identifier: {offenders!r}"
+    )
+    # Every chunk should fit within the budget (allowing for trailing
+    # break char).
+    assert all(len(s) <= 60 + 1 for s in out)
+
+
+def test_split_falls_through_to_hard_cut_when_no_whitespace() -> None:
+    """Truly minified single-token input has no whitespace anywhere; the
+    splitter must still produce chunks (tier 3 hard cut is acceptable
+    here because no boundary preserves tokens)."""
+    line = "abcdefghij" * 20  # 200 chars, no whitespace
+    out = _split_long_line(line, max_chars=50)
+    assert sum(len(s) for s in out) == 200
+    assert all(len(s) <= 50 for s in out)
+
+
+def test_split_full_segment_concatenation_is_lossless() -> None:
+    """Concatenation invariant: joining the segments back gives the
+    original line (modulo whitespace cut at boundaries; the splitter
+    includes the break char so no characters are dropped)."""
+    line = (
+        "ProcessingResult processGPUIterationLoop(float[] input) "
+        "throws Exception { return new ProcessingResult(); }"
+    )
+    out = _split_long_line(line, max_chars=40)
+    assert "".join(out) == line


### PR DESCRIPTION
## Summary

The AST chunker's `_split_long_line` had two tiers — syntactic break in the last 20% of the segment, fall through to hard cut at `max_chars`. Java method-signature runs (no semicolons/commas/brackets in the last-20% window) routinely fell to the hard cut, slicing identifiers mid-token.

Fix: insert tier 2 — search for ANY whitespace boundary across the full segment window. Any whitespace boundary is strictly better than a mid-identifier slice. Tier 3 (hard cut) is reached only by truly minified code without whitespace.

## Symptoms (from fh3j audit, 2026-05-10)

23.9% of micro-chunks in `code__1-2153__voyage-code-3__v1` started mid-identifier:

- `tected CanonicalLaminarCircuitGPU(...`
- `ivate void initializeMetalKernels() throws Exception {`
- `ount >= minStableIterations) { ... `

All 1228 audited fragments came from this one collection. Other code collections had zero broken-split samples.

## Test plan

- [x] New regression test `tests/test_chunker_split_long_line.py` (6 tests) — boundary invariant: no chunk boundary sits inside a run of `[A-Za-z0-9_]` characters; tier-1 precedence still wins; lossless concatenation.
- [x] Regression suite green: 131 tests across `test_chunker`, `test_chunker_ast_languages`, `test_chunker_split_long_line`, `test_indexer`.
- [ ] Re-index `code__1-2153` post-merge and confirm broken-split count drops to zero (operator validation, not part of this PR).

## Closes

Closes nexus-wuhw