### PR TITLE
release: conexus 4.32.1 — fix salient_sentences migration for upgraders (nexus-m3dp)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.32.0"
+      "version": "4.32.1"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.32.0"
+      "version": "4.32.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.32.1] - 2026-05-11
+
+Patch on 4.32.0. Fixes a 4.32.0 release bug (nexus-m3dp): the
+RDR-109 Phase 5 ``salient_sentences`` migration was registered at
+version 4.31.7. ``apply_pending`` requires ``m_ver > last_seen_t``,
+so users upgrading from 4.31.7 to 4.32.0 had the migration skipped —
+the column was never added. Fresh installs got the column via the
+base CREATE TABLE; only upgraders were affected.
+
+Re-registering the migration at 4.32.1 forces re-evaluation against
+every install. The migration body is idempotent
+(``PRAGMA table_info`` guards the ALTER), so installs that already
+have the column from a fresh-install path no-op cleanly.
+
+Live-confirmed by 4.32.0 shakeout: local memory.db at stored
+version 4.32.0 was missing ``salient_sentences``.
+
+### Fixed
+
+- **``salient_sentences`` migration unreachable for upgraders**
+  (nexus-m3dp). Migration registration bumped from 4.31.7 to 4.32.1.
+
 ## [4.32.0] - 2026-05-11
 
 Minor release. **Headline**: RDR-109 ships in five phases — local

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.32.0",
+  "version": "4.32.1",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.32.1] - 2026-05-11
+
+Plugin version aligned with conexus 4.32.1. No plugin-side changes;
+the release fixes a 4.32.0 migration-registration bug (nexus-m3dp)
+that left the RDR-109 Phase 5 ``salient_sentences`` column missing
+for users upgrading from 4.31.7. See root ``CHANGELOG.md``.
+
 ## [4.32.0] - 2026-05-11
 
 Plugin version aligned with conexus 4.32.0. No plugin-side changes;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.32.0"
+version = "4.32.1"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.32.0",
+  "version": "4.32.1",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -2712,7 +2712,7 @@ MIGRATIONS: list[Migration] = [
         migrate_drop_source_path_column,
     ),
     Migration(
-        "4.31.7",
+        "4.32.1",
         "RDR-109 Phase 5: add document_aspects.salient_sentences column",
         lambda conn: _migrate_add_aspects_salient_sentences(conn),
     ),

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.32.0"
+version = "4.32.1"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Patch on 4.32.0. Fixes a 4.32.0 release bug caught by live shakeout: the RDR-109 Phase 5 \`salient_sentences\` migration was registered at \`4.31.7\`, so \`apply_pending\`'s \`m_ver > last_seen_t\` check skipped it for users upgrading from 4.31.7 → 4.32.0. The column was never added on those installs.

Fresh installs got the column via the base \`CREATE TABLE\` in \`document_aspects.py\`; only upgraders were affected.

## Fix

Re-register the migration at \`4.32.1\`. Forces re-evaluation against every install. Body is idempotent (\`PRAGMA table_info\` guards the \`ALTER\`), so installs that already have the column no-op cleanly.

## Verification

- ✓ Reset local stored version to \`4.32.0\`, opened T2 → migration ran, column now present.
- ✓ Sandbox smoke PASS.

## Closes

Closes nexus-m3dp