### PR TITLE
release: conexus 4.32.2 — MinerU server visibility (nexus-h1jk)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.32.1"
+      "version": "4.32.2"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.32.1"
+      "version": "4.32.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.32.2] - 2026-05-11
+
+Patch on 4.32.1. Surfaces MinerU server reachability state in the
+default ``nx doctor`` flow and adds a warn-on-fallback in
+``PDFExtractor._mineru_server_available`` so operators see when math-
+PDF indexing silently degrades to the in-process subprocess path
+(where Grossberg-class math papers OOM-kill the worker at ~p23).
+
+Caught during the 4.32.1 live shakeout: a stale
+``mineru_server_url`` in ``~/.config/nexus/config.yml`` (written by a
+prior ``_restart_mineru_server`` cycle to a now-dead port) silently
+redirected every PDF index to the OOM-prone fallback. Three Grossberg
+papers (cohen-1997 18p / grossberg-1975 34p / GroSchmajuk1987 46p)
+that failed on 2026-05-08 indexed cleanly (129 + 445 + 351 = 925
+chunks) once the config was corrected and the server was running.
+
+### Fixed
+
+- **MinerU server unreachable now surfaces in ``nx doctor``**
+  (nexus-h1jk). New ``_check_mineru_server`` in ``nexus/health.py``
+  wired into the default health-check flow. Reports ``✓ MinerU
+  server: reachable at <url>`` on the happy path; ``✗ MinerU server:
+  <url> unreachable`` with remediation hints (``nx mineru start`` /
+  inspect config.yml) on miss.
+- **``PDFExtractor._mineru_server_available`` warns on fallback** —
+  structured ``mineru_server_unreachable`` / ``mineru_server_unhealthy``
+  log events plus an inline ``_progress`` line naming the URL and
+  recommending ``nx mineru start``. The silent fallback to the
+  in-process subprocess (slower, OOM-risk on math PDFs) was the
+  proximate cause of operator confusion.
+
+### Known follow-up
+
+- The auto-restart-writes-ephemeral-port-to-persistent-config drift
+  itself is not fixed by this release — visibility only. Tracked as
+  ``nexus-oa7r``.
+
 ## [4.32.1] - 2026-05-11
 
 Patch on 4.32.0. Fixes a 4.32.0 release bug (nexus-m3dp): the

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.32.1",
+  "version": "4.32.2",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/CHANGELOG.md
+++ b/nx/CHANGELOG.md
@@ -6,6 +6,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.32.2] - 2026-05-11
+
+Plugin version aligned with conexus 4.32.2. No plugin-side changes;
+the release surfaces MinerU server unreachable state in ``nx doctor``
++ warn-on-fallback in pdf_extractor (nexus-h1jk). See root
+``CHANGELOG.md``.
+
 ## [4.32.1] - 2026-05-11
 
 Plugin version aligned with conexus 4.32.1. No plugin-side changes;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.32.1"
+version = "4.32.2"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.32.1",
+  "version": "4.32.2",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/health.py
+++ b/src/nexus/health.py
@@ -635,6 +635,62 @@ def _check_orphan_pipelines() -> list[HealthResult]:
     )]
 
 
+def _check_mineru_server() -> list[HealthResult]:
+    """nexus-h1jk: surface MinerU server reachability in the default
+    doctor flow.
+
+    Math-heavy PDFs (papers with dense formula notation) accumulate per-
+    page tensor state in MinerU's formula-detection pass and routinely
+    OOM-kill the in-process subprocess fallback. The HTTP server avoids
+    that by running MinerU as a long-lived dedicated worker. The
+    configured URL silently goes stale: ``_restart_mineru_server`` in
+    ``pdf_extractor.py`` writes the live port to
+    ``~/.config/nexus/config.yml`` after a mid-run recovery, but if
+    that server later dies the URL points at a dead port across every
+    subsequent session. ``nx doctor`` is the natural place to surface
+    that drift.
+    """
+    from nexus.config import get_mineru_server_url
+    import httpx as _httpx
+
+    try:
+        url = get_mineru_server_url()
+    except Exception:
+        return []
+    if not url:
+        return []
+
+    health_url = f"{url}/health"
+    try:
+        resp = _httpx.get(health_url, timeout=2.0)
+    except (_httpx.ConnectError, _httpx.TimeoutException) as exc:
+        return [HealthResult(
+            label="MinerU server",
+            ok=False,
+            detail=(
+                f"{url} unreachable ({type(exc).__name__}); falling back to "
+                "in-process subprocess on math PDFs (OOM-risk)"
+            ),
+            fix_suggestions=[
+                "Start the server: nx mineru start",
+                f"Or confirm the URL in ~/.config/nexus/config.yml "
+                f"(currently: {url})",
+            ],
+        )]
+    if resp.status_code != 200:
+        return [HealthResult(
+            label="MinerU server",
+            ok=False,
+            detail=f"{url} returned HTTP {resp.status_code}",
+            fix_suggestions=["Restart the server: nx mineru stop && nx mineru start"],
+        )]
+    return [HealthResult(
+        label="MinerU server",
+        ok=True,
+        detail=f"reachable at {url}",
+    )]
+
+
 def _check_t2_integrity() -> list[HealthResult]:
     db_path = default_db_path()
     if not db_path.exists():
@@ -760,6 +816,7 @@ def run_health_checks() -> tuple[list[HealthResult], bool]:
     results.extend(_check_orphan_t1())
     results.extend(_check_orphan_checkpoints())
     results.extend(_check_orphan_pipelines())
+    results.extend(_check_mineru_server())
     results.extend(_check_t2_integrity())
 
     # ChromaDB pagination audit (cloud only)

--- a/src/nexus/pdf_extractor.py
+++ b/src/nexus/pdf_extractor.py
@@ -615,6 +615,14 @@ class PDFExtractor:
 
         Result cached for the lifetime of this PDFExtractor instance —
         a False result is never retried. Create a new instance to re-check.
+
+        nexus-h1jk: when the configured URL is unreachable, emit a
+        structured warning + ``_progress`` line so the operator knows
+        the run is silently degrading to the in-process subprocess
+        path (where math-heavy / large PDFs OOM-kill the worker).
+        The auto-restart machinery writes the live port back to
+        ``~/.config/nexus/config.yml``, so a stale URL persists across
+        sessions when the server is later killed.
         """
         if self._mineru_server_checked:
             return self._mineru_server_up
@@ -624,8 +632,27 @@ class PDFExtractor:
         try:
             resp = httpx.get(url, timeout=2)
             self._mineru_server_up = resp.status_code == 200
-        except (httpx.ConnectError, httpx.TimeoutException):
+            if not self._mineru_server_up:
+                _log.warning(
+                    "mineru_server_unhealthy",
+                    url=url, http_status=resp.status_code,
+                )
+                _progress(
+                    f"  warn: MinerU server at {url} returned HTTP "
+                    f"{resp.status_code}; falling back to in-process subprocess. "
+                    f"Run `nx mineru start` to enable server mode."
+                )
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
             self._mineru_server_up = False
+            _log.warning(
+                "mineru_server_unreachable",
+                url=url, error=f"{type(exc).__name__}: {exc}",
+            )
+            _progress(
+                f"  warn: MinerU server at {url} unreachable; falling back "
+                f"to in-process subprocess (slower, OOM-risk on large math PDFs). "
+                f"Run `nx mineru start` to enable server mode."
+            )
 
         self._mineru_server_checked = True
         return self._mineru_server_up

--- a/tests/test_mineru_server_supervision.py
+++ b/tests/test_mineru_server_supervision.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-h1jk: MinerU server supervision (visibility in doctor +
+warn-on-fallback in pdf_extractor).
+
+Tests the visibility layer only. Auto-spawn is deferred to a separate
+bead; the focused fixes here are:
+
+1. ``nx doctor`` reports MinerU server reachability in the default
+   health-check flow (always-on, not gated behind ``--check-mineru``).
+2. ``PDFExtractor._mineru_server_available`` emits a structured WARN
+   when the configured URL is unreachable, so the operator sees the
+   silent fallback to the in-process subprocess (which OOMs on
+   large math papers).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from nexus.health import _check_mineru_server
+
+
+# ── doctor: _check_mineru_server ─────────────────────────────────────
+
+
+def test_check_mineru_server_pass_when_reachable() -> None:
+    fake_resp = MagicMock(status_code=200)
+    with patch(
+        "nexus.config.get_mineru_server_url",
+        return_value="http://127.0.0.1:8010",
+    ), patch("httpx.get", return_value=fake_resp):
+        results = _check_mineru_server()
+    assert len(results) == 1
+    assert results[0].ok is True
+    assert "8010" in results[0].detail
+
+
+def test_check_mineru_server_fail_when_unreachable() -> None:
+    with patch(
+        "nexus.config.get_mineru_server_url",
+        return_value="http://127.0.0.1:49353",
+    ), patch(
+        "httpx.get",
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
+        results = _check_mineru_server()
+    assert len(results) == 1
+    assert results[0].ok is False
+    assert "49353" in results[0].detail
+    assert any("mineru start" in s for s in results[0].fix_suggestions)
+    assert any("config.yml" in s for s in results[0].fix_suggestions)
+
+
+def test_check_mineru_server_fail_on_non_200() -> None:
+    fake_resp = MagicMock(status_code=503)
+    with patch(
+        "nexus.config.get_mineru_server_url",
+        return_value="http://127.0.0.1:8010",
+    ), patch("httpx.get", return_value=fake_resp):
+        results = _check_mineru_server()
+    assert len(results) == 1
+    assert results[0].ok is False
+    assert "503" in results[0].detail
+
+
+def test_check_mineru_server_no_op_when_url_missing() -> None:
+    with patch("nexus.config.get_mineru_server_url", return_value=""):
+        results = _check_mineru_server()
+    assert results == []
+
+
+# ── pdf_extractor: warn-on-fallback ──────────────────────────────────
+
+
+def test_mineru_server_available_warns_on_unreachable(caplog) -> None:
+    from nexus.pdf_extractor import PDFExtractor
+
+    ex = PDFExtractor()
+    with patch(
+        "nexus.config.get_mineru_server_url",
+        return_value="http://127.0.0.1:49353",
+    ), patch(
+        "httpx.get",
+        side_effect=httpx.ConnectError("refused"),
+    ):
+        assert ex._mineru_server_available() is False
+    # Second call returns the cached False without re-probing — locks in
+    # the contract that the warning fires exactly once per extractor.
+    with patch("httpx.get") as mock_get:
+        assert ex._mineru_server_available() is False
+        mock_get.assert_not_called()
+
+
+def test_mineru_server_available_warns_on_non_200(caplog) -> None:
+    from nexus.pdf_extractor import PDFExtractor
+
+    ex = PDFExtractor()
+    fake_resp = MagicMock(status_code=503)
+    with patch(
+        "nexus.config.get_mineru_server_url",
+        return_value="http://127.0.0.1:8010",
+    ), patch("httpx.get", return_value=fake_resp):
+        assert ex._mineru_server_available() is False
+
+
+def test_mineru_server_available_caches_success() -> None:
+    from nexus.pdf_extractor import PDFExtractor
+
+    ex = PDFExtractor()
+    fake_resp = MagicMock(status_code=200)
+    with patch(
+        "nexus.config.get_mineru_server_url",
+        return_value="http://127.0.0.1:8010",
+    ), patch("httpx.get", return_value=fake_resp) as mock_get:
+        assert ex._mineru_server_available() is True
+        assert ex._mineru_server_available() is True  # cache hit
+        mock_get.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.32.1"
+version = "4.32.2"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Patch on 4.32.1. Ships the MinerU server unreachable visibility fix caught during 4.32.1 live shakeout.

- ``nx doctor`` now reports MinerU server reachability in the default flow (was behind ``--check-mineru`` only).
- ``PDFExtractor._mineru_server_available`` emits a structured warn + inline ``_progress`` line when the configured URL is unreachable, naming the URL and recommending ``nx mineru start``.

7 new tests guard the behavior. Sandbox smoke green.

## Caveat

Visibility only — the underlying auto-restart-writes-ephemeral-port-to-persistent-config drift is unchanged and tracked as ``nexus-oa7r``.

## Closes

Closes nexus-h1jk (already merged via PR #693; this packages it as a release)