### PR TITLE
fix(mineru): PID file is canonical for server URL (nexus-oa7r)

### DIFF
--- a/src/nexus/commands/mineru.py
+++ b/src/nexus/commands/mineru.py
@@ -211,10 +211,11 @@ def start(port: int) -> None:
             pass
         raise click.exceptions.Exit(1)
 
-    # Persist the server URL to config so pdf_extractor can discover it
-    from nexus.config import set_config_value
-    set_config_value("pdf.mineru_server_url", f"http://127.0.0.1:{port}")
-
+    # nexus-oa7r: do NOT write the port to persistent config. The PID
+    # file is the canonical source of truth; ``get_mineru_server_url``
+    # reads it at call time. Persisting an ephemeral port to config
+    # caused drift across reboots — the dead port survived as a
+    # config record while the server didn't.
     _log.info("mineru_started", pid=proc.pid, port=port)
     click.echo(f"MinerU server started (PID {proc.pid}, port {port})")
 

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -193,7 +193,58 @@ def get_telemetry_config(
 def get_pdf_extractor(repo_root: Path | None = None) -> str:
     return get_pdf_config(repo_root).extractor
 
+def _read_live_mineru_port() -> int | None:
+    """Return the port of the currently-alive MinerU server, or None.
+
+    Source of truth is the PID file written by ``nx mineru start`` /
+    ``_restart_mineru_server`` at ``~/.config/nexus/mineru.pid``. The
+    file persists across the spawning process tree's lifetime but is
+    cleaned up by ``nx mineru stop``; ``_is_process_alive`` guards
+    against stale rows when the server crashes without cleanup.
+
+    nexus-oa7r: previously the live port was written to
+    ``~/.config/nexus/config.yml``'s ``pdf.mineru_server_url``. That
+    persistent record drifted across reboots: when the server died,
+    the config still pointed at the dead port, and every subsequent
+    session silently fell through to the OOM-prone in-process
+    subprocess. PID file is the canonical source — it's correct by
+    construction (only present when the server is up).
+    """
+    try:
+        from nexus.commands.mineru import (  # noqa: PLC0415
+            _is_process_alive,
+            _read_pid_file,
+        )
+    except Exception:
+        return None
+    info = _read_pid_file()
+    if not info:
+        return None
+    pid = info.get("pid")
+    port = info.get("port")
+    if not isinstance(pid, int) or not isinstance(port, int):
+        return None
+    if not _is_process_alive(pid):
+        return None
+    return port
+
+
 def get_mineru_server_url(repo_root: Path | None = None) -> str:
+    """Return the URL of the live MinerU server, falling back to the
+    configured default when no live server is found.
+
+    Resolution order:
+    1. Live PID file (``~/.config/nexus/mineru.pid``) — the canonical
+       source of truth when a server is running. Validated via
+       ``_is_process_alive``.
+    2. Configured ``pdf.mineru_server_url`` — the static fallback for
+       installs where the operator manages the server out-of-band
+       (e.g. a launchctl service on a fixed port).
+    3. Built-in default ``http://127.0.0.1:8010``.
+    """
+    live = _read_live_mineru_port()
+    if live is not None:
+        return f"http://127.0.0.1:{live}"
     return get_pdf_config(repo_root).mineru_server_url
 
 def get_mineru_table_enable(repo_root: Path | None = None) -> bool:

--- a/src/nexus/pdf_extractor.py
+++ b/src/nexus/pdf_extractor.py
@@ -748,8 +748,6 @@ class PDFExtractor:
             _mineru_output_root,
             _server_env,
         )
-        from nexus.config import set_config_value
-
         port = _find_free_port()
         cmd = ["mineru-api", "--host", "127.0.0.1", "--port", str(port)]
         # nexus-2fyb code-review C-sec-1: previously called _server_env() with
@@ -787,7 +785,11 @@ class PDFExtractor:
             _log.warning("mineru_restart_failed", reason="health timeout")
             return False
 
-        # Write PID file and update config
+        # Write PID file only (canonical source of truth). nexus-oa7r:
+        # do NOT write the port to persistent config — the PID-file
+        # lookup in ``get_mineru_server_url`` discovers the live port
+        # at every call. Persisting ephemeral ports drifted across
+        # reboots.
         import json as _json
         from datetime import datetime, timezone
         pid_path = _pid_file_path()
@@ -796,7 +798,6 @@ class PDFExtractor:
             "pid": proc.pid, "port": port,
             "started_at": datetime.now(timezone.utc).isoformat(),
         }))
-        set_config_value("pdf.mineru_server_url", f"http://127.0.0.1:{port}")
 
         # Reset availability cache
         self._mineru_server_checked = True

--- a/tests/test_mineru_config_drift.py
+++ b/tests/test_mineru_config_drift.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-oa7r: PID-file-as-source-of-truth for MinerU server URL.
+
+Pre-fix: ``_restart_mineru_server`` and ``nx mineru start`` wrote
+the live port to ``~/.config/nexus/config.yml``'s
+``pdf.mineru_server_url``. The port was ephemeral but the config
+was persistent; when the server later died, the URL drifted to a
+dead port and every subsequent session silently fell through to
+the OOM-prone in-process subprocess.
+
+Post-fix: PID file at ``~/.config/nexus/mineru.pid`` is canonical.
+``get_mineru_server_url`` reads it at call time. Neither startup
+path writes the live port to config any more.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ── _read_live_mineru_port ───────────────────────────────────────────
+
+
+def test_live_port_returns_port_when_pid_alive(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("nexus.config.nexus_config_dir", lambda: tmp_path)
+    pid_path = tmp_path / "mineru.pid"
+    pid_path.write_text(json.dumps({
+        "pid": os.getpid(),  # this test process is alive
+        "port": 49353,
+    }))
+    from nexus.config import _read_live_mineru_port
+    assert _read_live_mineru_port() == 49353
+
+
+def test_live_port_returns_none_when_pid_dead(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("nexus.config.nexus_config_dir", lambda: tmp_path)
+    pid_path = tmp_path / "mineru.pid"
+    # PID 1 is init on macOS/Linux; safe to use a clearly-not-our-pid
+    # value that we then patch _is_process_alive to claim is dead.
+    pid_path.write_text(json.dumps({"pid": 999999, "port": 49353}))
+    with patch(
+        "nexus.commands.mineru._is_process_alive", return_value=False,
+    ):
+        from nexus.config import _read_live_mineru_port
+        assert _read_live_mineru_port() is None
+
+
+def test_live_port_returns_none_when_no_pid_file(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("nexus.config.nexus_config_dir", lambda: tmp_path)
+    from nexus.config import _read_live_mineru_port
+    assert _read_live_mineru_port() is None
+
+
+def test_live_port_returns_none_when_malformed_json(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("nexus.config.nexus_config_dir", lambda: tmp_path)
+    (tmp_path / "mineru.pid").write_text("{not-json}")
+    from nexus.config import _read_live_mineru_port
+    assert _read_live_mineru_port() is None
+
+
+# ── get_mineru_server_url ────────────────────────────────────────────
+
+
+def test_url_prefers_live_pid_file_over_config(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("nexus.config.nexus_config_dir", lambda: tmp_path)
+    # Config says dead port; PID file says live port — PID wins.
+    pid_path = tmp_path / "mineru.pid"
+    pid_path.write_text(json.dumps({
+        "pid": os.getpid(),
+        "port": 49353,
+    }))
+    with patch(
+        "nexus.config.get_pdf_config",
+        return_value=type("X", (), {
+            "mineru_server_url": "http://127.0.0.1:9999",
+        })(),
+    ):
+        from nexus.config import get_mineru_server_url
+        assert get_mineru_server_url() == "http://127.0.0.1:49353"
+
+
+def test_url_falls_back_to_config_when_no_live_pid(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("nexus.config.nexus_config_dir", lambda: tmp_path)
+    with patch(
+        "nexus.config.get_pdf_config",
+        return_value=type("X", (), {
+            "mineru_server_url": "http://127.0.0.1:8010",
+        })(),
+    ):
+        from nexus.config import get_mineru_server_url
+        assert get_mineru_server_url() == "http://127.0.0.1:8010"
+
+
+def test_url_falls_back_to_config_when_pid_stale(tmp_path: Path, monkeypatch) -> None:
+    """Stale PID file (server died without cleanup) — fall back to config."""
+    monkeypatch.setattr("nexus.config.nexus_config_dir", lambda: tmp_path)
+    pid_path = tmp_path / "mineru.pid"
+    pid_path.write_text(json.dumps({"pid": 999999, "port": 49353}))
+    with patch(
+        "nexus.commands.mineru._is_process_alive", return_value=False,
+    ), patch(
+        "nexus.config.get_pdf_config",
+        return_value=type("X", (), {
+            "mineru_server_url": "http://127.0.0.1:8010",
+        })(),
+    ):
+        from nexus.config import get_mineru_server_url
+        assert get_mineru_server_url() == "http://127.0.0.1:8010"
+
+
+# ── Startup paths must not write config ──────────────────────────────
+
+
+def test_nx_mineru_start_does_not_set_config(monkeypatch) -> None:
+    """``nx mineru start`` must not write ``pdf.mineru_server_url``.
+    Reading the module source is the cheap regression for this
+    contract — exercising the full start flow needs a real
+    mineru-api binary."""
+    import nexus.commands.mineru as mineru_mod
+    src = Path(mineru_mod.__file__).read_text()
+    assert "set_config_value(\"pdf.mineru_server_url\"" not in src, (
+        "nx mineru start re-introduced the config write; the PID file "
+        "is the canonical source of truth — see nexus-oa7r."
+    )
+
+
+def test_restart_mineru_server_does_not_set_config(monkeypatch) -> None:
+    """``_restart_mineru_server`` in pdf_extractor must not write
+    ``pdf.mineru_server_url`` either."""
+    import nexus.pdf_extractor as ext_mod
+    src = Path(ext_mod.__file__).read_text()
+    assert "set_config_value(\"pdf.mineru_server_url\"" not in src, (
+        "_restart_mineru_server re-introduced the config write; "
+        "the PID file is canonical (nexus-oa7r)."
+    )


### PR DESCRIPTION
## Summary

Removes the auto-restart-writes-ephemeral-port-to-persistent-config drift caught during the 4.32.1 / 4.32.2 shakeout. PID file is now canonical; config write is gone from both startup paths.

## Before

\`_restart_mineru_server\` + \`nx mineru start\` both wrote the live port to \`~/.config/nexus/config.yml\`. Ephemeral data, persistent storage → drift across reboots → silent fallback to OOM-prone subprocess.

## After

\`~/.config/nexus/mineru.pid\` is the source of truth. \`get_mineru_server_url\` reads it at every call (\`_is_process_alive\`-validated). Config retains a static fallback for out-of-band server management (launchctl etc.).

Resolution order: live PID file → configured \`pdf.mineru_server_url\` → default \`http://127.0.0.1:8010\`.

## Test plan

- [x] 9 new tests cover PID-file lookup states + URL resolution precedence + source-level regression guards on both startup paths.
- [x] 160-test regression green across mineru, pdf_extractor, doctor, config.
- [x] Live verified: my dev box's stale \`config.yml\` (\`mineru_server_url: http://127.0.0.1:62485\`) no longer affects resolution — the PID file's port wins.

## Closes

Closes nexus-oa7r