### PR TITLE
chore: merge nexus-84a6 CI flake fix into main

### DIFF
--- a/tests/test_catalog_audit_membership.py
+++ b/tests/test_catalog_audit_membership.py
@@ -120,7 +120,7 @@ class TestMultiHome:
             catalog, ["audit-membership", "rdr__myproject", "--json"],
         )
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert data["collection"] == "rdr__myproject"
         assert data["total_entries"] == 8
         assert data["distinct_homes"] == 2
@@ -320,7 +320,7 @@ class TestAllCollections:
             catalog, ["audit-membership", "--all-collections", "--json"],
         )
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert data["total_collections"] == 2
         assert data["contaminated_count"] == 1
         assert data["clean_count"] == 1
@@ -437,7 +437,7 @@ class TestAllCollectionsOwnerAware:
             catalog, ["audit-membership", "--all-collections", "--json"],
         )
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         rec = next(r for r in data["collections"] if r["collection"] == wrong_col)
         assert rec["wrong_home"] is True
         assert rec["contaminated_entries"] == rec["total_entries"] == 3
@@ -455,7 +455,7 @@ class TestAllCollectionsOwnerAware:
             catalog, ["audit-membership", "--all-collections", "--json"],
         )
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         rec = next(r for r in data["collections"] if r["collection"] == clean_col)
         assert rec["wrong_home"] is False
         assert rec["contaminated_entries"] == 0
@@ -481,7 +481,7 @@ class TestAllCollectionsOwnerAware:
             catalog, ["audit-membership", "--all-collections", "--json"],
         )
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         rec = next(
             r for r in data["collections"]
             if r["collection"] == "docs__hal_papers"

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -96,7 +96,7 @@ class TestRegisterAndShow:
         ])
         result = runner.invoke(main, ["catalog", "show", "1.1.1", "--json"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert data["title"] == "Test Paper"
 
     def test_register_with_explicit_source_uri(
@@ -169,7 +169,7 @@ class TestListCommand:
         runner.invoke(main, ["catalog", "register", "--title", "A", "--owner", "1.1"])
         result = runner.invoke(main, ["catalog", "list", "--json"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert isinstance(data, list)
         assert len(data) >= 1
 
@@ -347,7 +347,7 @@ class TestLinksFilterCommand:
         runner.invoke(main, ["catalog", "link", "1.1.1", "1.1.2", "--type", "cites"])
         result = runner.invoke(main, ["catalog", "links", "--type", "cites", "--json"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert isinstance(data, list)
         assert len(data) == 1
 
@@ -556,7 +556,7 @@ class TestLinkAuditCommand:
         runner.invoke(main, ["catalog", "link", "1.1.1", "1.1.2", "--type", "cites"])
         result = runner.invoke(main, ["catalog", "link-audit", "--json"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert data["total"] == 1
 
 
@@ -850,7 +850,7 @@ class TestStatsCommand:
         runner = CliRunner()
         result = runner.invoke(main, ["catalog", "stats", "--json"])
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert data["taxonomy"]["topics"] == 2
         assert data["taxonomy"]["projection_by_source"] == {"knowledge__a": 5}
 
@@ -1028,7 +1028,7 @@ class TestVerifyCommand:
         result = runner.invoke(main, ["catalog", "verify", "--json"])
 
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert "knowledge__x" in data
         assert data["knowledge__x"][0]["doc_id"] == "ffff666666666666"
         assert data["knowledge__x"][0]["title"] == "Ghost"

--- a/tests/test_catalog_dedupe.py
+++ b/tests/test_catalog_dedupe.py
@@ -247,7 +247,7 @@ class TestDedupeCLI:
         runner = CliRunner()
         result = runner.invoke(main, ["catalog", "dedupe-owners", "--json"])
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert payload["dry_run"] is True
         assert payload["summary"]["remove"] == 1
         assert payload["summary"]["skip"] == 1

--- a/tests/test_catalog_doctor_collections_drift.py
+++ b/tests/test_catalog_doctor_collections_drift.py
@@ -202,7 +202,7 @@ def test_doctor_collections_drift_json_payload(t3_db, catalog, runner):
             main, ["catalog", "doctor", "--collections-drift", "--json"],
         )
     assert result.exit_code != 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert "collections_drift" in payload
     drift = payload["collections_drift"]
     assert drift["pass"] is False

--- a/tests/test_catalog_doctor_new_checks.py
+++ b/tests/test_catalog_doctor_new_checks.py
@@ -113,7 +113,7 @@ class TestChunkSizeDistribution:
             doctor_cmd, ["--chunk-size-distribution", "--json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)["chunk_size_distribution"]
+        payload = json.loads(result.stdout)["chunk_size_distribution"]
         assert payload["pass"] is True
         t = payload["tables"]["code__ok"]
         assert t["total_chunks"] == 10
@@ -148,7 +148,7 @@ class TestChunkSizeDistribution:
         )
         # Micros are WARN, not FAIL.
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)["chunk_size_distribution"]
+        payload = json.loads(result.stdout)["chunk_size_distribution"]
         t = payload["tables"]["code__micros"]
         assert t["micro_count"] == 2
         assert t["warn"] is True
@@ -179,7 +179,7 @@ class TestChunkSizeDistribution:
             doctor_cmd, ["--chunk-size-distribution", "--json"],
         )
         assert result.exit_code == 1
-        payload = json.loads(result.output)["chunk_size_distribution"]
+        payload = json.loads(result.stdout)["chunk_size_distribution"]
         assert payload["pass"] is False
         t = payload["tables"]["code__big"]
         assert t["over_quota_count"] == 1
@@ -207,7 +207,7 @@ class TestChunkSizeDistribution:
             doctor_cmd, ["--chunk-size-distribution", "--json"],
         )
         assert result.exit_code == 0
-        payload = json.loads(result.output)["chunk_size_distribution"]
+        payload = json.loads(result.stdout)["chunk_size_distribution"]
         assert "taxonomy__centroids" not in payload["tables"]
 
 
@@ -235,7 +235,7 @@ class TestChunkTextDedup:
             doctor_cmd, ["--chunk-text-dedup", "--json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)["chunk_text_dedup"]
+        payload = json.loads(result.stdout)["chunk_text_dedup"]
         assert payload["pass"] is True
         assert payload["within"]["code__cleanup"]["dupe_chunks"] == 0
         assert payload["cross_dupe_chunk_count"] == 0
@@ -269,7 +269,7 @@ class TestChunkTextDedup:
         )
         # WARN, not FAIL; overall pass is True unless an exception fires.
         assert result.exit_code == 0
-        payload = json.loads(result.output)["chunk_text_dedup"]
+        payload = json.loads(result.stdout)["chunk_text_dedup"]
         t = payload["within"]["code__bug"]
         assert t["dupe_chunks"] == 2
         assert t["warn"] is True
@@ -300,7 +300,7 @@ class TestChunkTextDedup:
             doctor_cmd, ["--chunk-text-dedup", "--json"],
         )
         assert result.exit_code == 0
-        payload = json.loads(result.output)["chunk_text_dedup"]
+        payload = json.loads(result.stdout)["chunk_text_dedup"]
         assert payload["cross_dupe_chunk_count"] == 1
         sample = payload["cross_sample"][0]
         assert sample["chash"].startswith("shared-1234")
@@ -343,7 +343,7 @@ class TestT3VsCatalog:
             doctor_cmd, ["--t3-vs-catalog", "--json"],
         )
         assert result.exit_code == 0
-        payload = json.loads(result.output)["t3_vs_catalog"]
+        payload = json.loads(result.stdout)["t3_vs_catalog"]
         assert payload["pass"] is True
         assert payload["t3_orphans"] == []
         assert payload["zombies"] == []
@@ -374,7 +374,7 @@ class TestT3VsCatalog:
             doctor_cmd, ["--t3-vs-catalog", "--json"],
         )
         assert result.exit_code == 1
-        payload = json.loads(result.output)["t3_vs_catalog"]
+        payload = json.loads(result.stdout)["t3_vs_catalog"]
         assert payload["pass"] is False
         assert len(payload["t3_orphans"]) == 1
         assert payload["t3_orphans"][0]["name"] == "code__orphan"
@@ -410,7 +410,7 @@ class TestT3VsCatalog:
             doctor_cmd, ["--t3-vs-catalog", "--json"],
         )
         assert result.exit_code == 1
-        payload = json.loads(result.output)["t3_vs_catalog"]
+        payload = json.loads(result.stdout)["t3_vs_catalog"]
         assert payload["pass"] is False
         missing = payload["docs_pointing_at_missing_t3"]
         assert len(missing) == 1

--- a/tests/test_catalog_doctor_replay_equality.py
+++ b/tests/test_catalog_doctor_replay_equality.py
@@ -109,7 +109,7 @@ class TestReplayEqualityPasses:
         assert result.exit_code == 0
         # Phase 2 PR δ wraps each check's payload under its flag name so
         # multiple checks can be invoked in one run.
-        payload = json.loads(result.output)["replay_equality"]
+        payload = json.loads(result.stdout)["replay_equality"]
         assert payload["pass"] is True
         assert payload["events_applied"] >= 3  # 1 owner + 2 documents
         assert "tables" in payload
@@ -200,7 +200,7 @@ class TestReplayEqualityFails:
         result = runner.invoke(doctor_cmd, ["--replay-equality", "--json"])
         assert result.exit_code == 1
         # Phase 2 PR δ wraps each check's payload under its flag name.
-        payload = json.loads(result.output)["replay_equality"]
+        payload = json.loads(result.stdout)["replay_equality"]
         assert payload["pass"] is False
         # Documents table is the source of the disagreement
         docs_diff = payload["tables"]["documents"]

--- a/tests/test_catalog_doctor_t3_coverage.py
+++ b/tests/test_catalog_doctor_t3_coverage.py
@@ -118,7 +118,7 @@ class TestCoveragePasses:
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        payload = json.loads(result.stdout)["t3_doc_id_coverage"]
         assert payload["pass"] is True
         assert payload["tables"]["code__test"]["coverage"] == 1.0
 
@@ -144,7 +144,7 @@ class TestCoveragePasses:
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        payload = json.loads(result.stdout)["t3_doc_id_coverage"]
         assert payload["pass"] is True
         coll = payload["tables"]["code__test"]
         assert coll["expected_orphans"] == 1
@@ -174,7 +174,7 @@ class TestCoverageFails:
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
         assert result.exit_code == 1
-        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        payload = json.loads(result.stdout)["t3_doc_id_coverage"]
         assert payload["pass"] is False
         coll = payload["tables"]["code__test"]
         assert "ch1" in coll["missing_doc_id_sample"]
@@ -200,7 +200,7 @@ class TestCoverageFails:
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
         assert result.exit_code == 1
-        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        payload = json.loads(result.stdout)["t3_doc_id_coverage"]
         coll = payload["tables"]["code__test"]
         assert coll["mismatched_doc_id_count"] == 1
         m = coll["mismatched_doc_id_sample"][0]
@@ -235,7 +235,7 @@ class TestCoverageFails:
             ["--t3-doc-id-coverage", "--strict-not-in-t3", "--json"],
         )
         assert result.exit_code == 1
-        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        payload = json.loads(result.stdout)["t3_doc_id_coverage"]
         coll = payload["tables"]["code__test"]
         assert coll["not_in_t3_count"] == 1
         assert "missing-from-t3" in coll["not_in_t3_sample"]
@@ -277,7 +277,7 @@ class TestCombined:
         # Replay equality may or may not pass depending on whether the
         # synthesized log matches the live SQLite — what we care about
         # here is that both checks ran and got a payload.
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert "replay_equality" in payload
         assert "t3_doc_id_coverage" in payload
         assert payload["t3_doc_id_coverage"]["pass"] is True
@@ -504,7 +504,7 @@ class TestPhase3ManifestFallback:
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        payload = json.loads(result.stdout)["t3_doc_id_coverage"]
         assert payload["pass"] is True, (
             f"Phase-3 chunk should register as covered via manifest; "
             f"got {payload!r}"
@@ -553,7 +553,7 @@ class TestBypassSchemaSkipped:
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        payload = json.loads(result.stdout)["t3_doc_id_coverage"]
         assert payload["pass"] is True
         assert "taxonomy__centroids" not in payload["tables"], (
             "bypass-schema collection should be excluded from the "
@@ -604,7 +604,7 @@ class TestSupersededSkip:
             doctor_cmd, ["--t3-doc-id-coverage", "--json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)["t3_doc_id_coverage"]
+        payload = json.loads(result.stdout)["t3_doc_id_coverage"]
         assert payload["pass"] is True, payload
         assert payload["skipped_superseded"] == 1
         assert "skipped" in payload["tables"]["code__old"]

--- a/tests/test_cli_runner_output_invariant.py
+++ b/tests/test_cli_runner_output_invariant.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-84a6: source-level guard preventing the
+``json.loads(result.output)`` anti-pattern from reappearing.
+
+Click 8.2 changed semantics: ``result.output`` is now stdout + stderr
+interleaved, not just stdout. JSON-parsing the merged stream fails
+non-deterministically on Linux CI when a structlog/warn line lands
+before the JSON payload — surfaces as ``JSONDecodeError`` with
+either ``Extra data`` or ``Expecting value`` (empty if the log
+flushes after stdout was captured).
+
+The fix: parse ``result.stdout`` instead. This test file enforces
+the rule across the whole test tree so the rot can't sneak back in
+via a copy-paste.
+
+Allow-list: this file legitimately mentions the anti-pattern in a
+docstring; it's filtered out before the assertion.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_PATTERN = re.compile(r"json\.loads\(\s*result\.output\s*\)")
+
+
+def test_no_json_loads_on_result_output() -> None:
+    """Every CliRunner-based test that JSON-parses the result must
+    use ``result.stdout`` (clean), not ``result.output`` (stdout +
+    stderr interleaved). See nexus-84a6 and Click 8.2 release notes.
+    """
+    tests_dir = Path(__file__).parent
+    offenders: list[tuple[Path, int, str]] = []
+    for path in tests_dir.rglob("test_*.py"):
+        if path.name == Path(__file__).name:
+            continue
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if _PATTERN.search(line):
+                offenders.append((path.relative_to(tests_dir), lineno, line.strip()))
+
+    if offenders:
+        sample = "\n  ".join(
+            f"{p}:{n}  {l!r}" for p, n, l in offenders[:10]
+        )
+        suffix = (
+            f"\n  ... (+{len(offenders) - 10} more)"
+            if len(offenders) > 10
+            else ""
+        )
+        raise AssertionError(
+            "nexus-84a6: tests use json.loads(result.output) which "
+            "parses stdout+stderr interleaved (Click 8.2+ change). "
+            "Switch to json.loads(result.stdout):\n  "
+            + sample
+            + suffix
+        )

--- a/tests/test_collection_audit.py
+++ b/tests/test_collection_audit.py
@@ -652,7 +652,7 @@ class TestCollectionAuditCli:
             main, ["collection", "audit", "code__main", "--format", "json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert payload["collection"] == "code__main"
         assert "distance_histogram" in payload
         assert "cross_projections" in payload
@@ -704,6 +704,6 @@ class TestCollectionAuditCli:
                 ],
             )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert payload["distance_histogram"]["source"] == "live"
         assert payload["distance_histogram"]["sample_size"] == 4

--- a/tests/test_collection_health.py
+++ b/tests/test_collection_health.py
@@ -494,7 +494,7 @@ class TestCollectionHealthCli:
         self._stub(monkeypatch)
         result = runner.invoke(main, ["collection", "health", "--format", "json"])
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert "collections" in payload
 
     def test_sort_flag(self, runner, monkeypatch) -> None:

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -2020,7 +2020,7 @@ def test_preflight_registration_idempotent_on_staleness_skip(
         f"doctor --replay-equality exited {result.exit_code}: "
         f"{result.output[:500]}"
     )
-    payload = _json.loads(result.output)["replay_equality"]
+    payload = _json.loads(result.stdout)["replay_equality"]
     assert payload["pass"] is True, (
         f"replay-equality flagged drift after pre-flight registration + "
         f"staleness skip; the projector must accept a "

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -605,7 +605,7 @@ class TestCheckQuotas:
                 main, ["doctor", "--check-quotas", "--json"]
             )
         assert result.exit_code == 0, result.output
-        data = _json.loads(result.output)
+        data = _json.loads(result.stdout)
         assert set(data.keys()) == {
             "chromadb", "voyage", "cross_encoder", "retry",
         }
@@ -821,7 +821,7 @@ class TestCheckTmpdirs:
                 main, ["doctor", "--check-tmpdirs", "--json"],
             )
         assert result.exit_code == 0, result.output
-        payload = _json.loads(result.output)
+        payload = _json.loads(result.stdout)
         assert payload["cutoff_hours"] == 24.0
         assert len(payload["candidates"]) == 1
         assert payload["candidates"][0]["path"].endswith("nx_t1_x")

--- a/tests/test_doctor_search.py
+++ b/tests/test_doctor_search.py
@@ -216,7 +216,7 @@ class TestDoctorCheckSearchCli:
         result = runner.invoke(main, ["doctor", "--check-search", "--json"])
         # exit_code == 2 because the seeded set includes 'raises-name';
         # JSON payload is still emitted on regression.
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert isinstance(payload, dict)
         assert "probes" in payload and len(payload["probes"]) == 2
         probe_names = [p["probe"] for p in payload["probes"]]

--- a/tests/test_enrich_aspects.py
+++ b/tests/test_enrich_aspects.py
@@ -893,7 +893,7 @@ class TestDay2Ops:
             enrich, ["info", "knowledge__delos", "/p1.pdf"],
         )
         assert result.exit_code == 0, result.output
-        parsed = json.loads(result.output)
+        parsed = json.loads(result.stdout)
         assert parsed["collection"] == "knowledge__delos"
         assert parsed["source_path"] == "/p1.pdf"
         assert parsed["problem_formulation"] == "P"
@@ -1012,7 +1012,7 @@ class TestDay2Ops:
             enrich, ["info", "knowledge__delos", "/papers/aleph.pdf"],
         )
         assert result.exit_code == 0, result.output
-        parsed = json.loads(result.output)
+        parsed = json.loads(result.stdout)
         assert parsed["source_uri"].startswith("chroma://knowledge__delos/")
         assert parsed["scheme"] == "chroma"
 

--- a/tests/test_enrich_aspects_read.py
+++ b/tests/test_enrich_aspects_read.py
@@ -124,7 +124,7 @@ class TestAspectsShow:
         runner = CliRunner()
         result = runner.invoke(enrich, ["aspects-show", tumbler, "--json"])
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert data["collection"] == "knowledge__myrepo-papers"
         assert data["problem_formulation"].startswith("Stale-reads")
         assert data["experimental_datasets"] == ["YCSB-A", "TPC-C"]
@@ -295,7 +295,7 @@ class TestAspectsList:
             "--json",
         ])
         assert result.exit_code == 0, result.output
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert isinstance(data, list)
         assert len(data) == 2
         assert {d["source_path"] for d in data} == {

--- a/tests/test_hybrid_boost.py
+++ b/tests/test_hybrid_boost.py
@@ -249,7 +249,7 @@ def test_boost_ranks_matching_file_higher(cli_env, mock_t3, test_id):
         cache_lines="/repo/match.py:10:hello\n",
     )
     assert result.exit_code == 0, result.output
-    data = json.loads(result.output)
+    data = json.loads(result.stdout)
     match_idx = next(i for i, r in enumerate(data) if r.get("source_path") == "/repo/match.py")
     nomatch_idx = next(i for i, r in enumerate(data) if r.get("source_path") == "/repo/other.py")
     assert match_idx < nomatch_idx
@@ -270,7 +270,7 @@ def test_rg_signal_filtered_from_output(cli_env, mock_t3):
         config_extra={"search": {"hybrid_default": False}},
     )
     assert result.exit_code == 0, result.output
-    data = json.loads(result.output)
+    data = json.loads(result.stdout)
     assert len(data) == 1
     assert data[0].get("collection") == "code__repo-abcd1234"
 
@@ -334,7 +334,7 @@ def test_multiple_rg_hits_same_file_boost_once(cli_env, mock_t3):
         config_extra={"search": {"hybrid_default": False}},
     )
     assert result.exit_code == 0, result.output
-    data = json.loads(result.output)
+    data = json.loads(result.stdout)
     assert len(data) == 1
     assert data[0].get("source_path") == "/repo/match.py"
 
@@ -384,7 +384,7 @@ def test_rg_only_files_promoted_with_penalty(cli_env, mock_t3):
         config_extra={"search": {"hybrid_default": False}},
     )
     assert result.exit_code == 0, result.output
-    data = json.loads(result.output)
+    data = json.loads(result.stdout)
     paths = [r.get("source_path", r.get("file_path")) for r in data]
     assert "/repo/rg_only.py" in paths
     assert "/repo/vector_file.py" in paths
@@ -424,6 +424,6 @@ def test_boosted_result_has_rg_matched_lines(cli_env, mock_t3):
         config_extra={"search": {"hybrid_default": False}},
     )
     assert result.exit_code == 0, result.output
-    data = json.loads(result.output)
+    data = json.loads(result.stdout)
     assert len(data) == 1
     assert data[0].get("rg_matched_lines") == [10, 25]

--- a/tests/test_merge_candidates.py
+++ b/tests/test_merge_candidates.py
@@ -240,7 +240,7 @@ class TestMergeCandidatesCli:
              "--min-shared", "1", "--format", "json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert "candidates" in payload
         assert len(payload["candidates"]) >= 1
 
@@ -262,7 +262,7 @@ class TestMergeCandidatesCli:
              "--format", "json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         pairs = {(c["a"], c["b"]) for c in payload["candidates"]}
         # Hub-only pair suppressed.
         assert ("code__a", "code__c") not in pairs

--- a/tests/test_phase5_doc_cite.py
+++ b/tests/test_phase5_doc_cite.py
@@ -154,7 +154,7 @@ class TestCiteJsonSchema:
             )
 
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert "candidates" in payload
         assert "query" in payload
         assert "threshold_met" in payload
@@ -274,5 +274,5 @@ class TestCiteTiedCandidatesNote:
             )
 
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert len(payload["candidates"]) == 2

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -257,7 +257,7 @@ class TestPlanList:
         ):
             result = runner.invoke(main, ["plan", "list", "--json"])
         assert result.exit_code == 0
-        data = _json.loads(result.output)
+        data = _json.loads(result.stdout)
         assert isinstance(data, list)
         assert len(data) == 1
         assert data[0]["name"] == "some-plan"

--- a/tests/test_store_cmd.py
+++ b/tests/test_store_cmd.py
@@ -399,7 +399,7 @@ def test_store_get_json_output(runner, mock_store):
         "title": "doc.md", "tags": "test", "indexed_at": "2026-03-09"}
     result = runner.invoke(main, ["store", "get", "abcdef1234567890", "--json"])
     assert result.exit_code == 0, result.output
-    data = json.loads(result.output)
+    data = json.loads(result.stdout)
     assert data["id"] == "abcdef1234567890"
     assert data["content"] == "test content"
 

--- a/tests/test_tier_status_cli.py
+++ b/tests/test_tier_status_cli.py
@@ -138,7 +138,7 @@ class TestExplicitFlags:
             tier_status_cmd, ["--session", "sess-J", "--json"],
         )
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
+        payload = json.loads(result.stdout)
         assert payload["session_id"] == "sess-J"
         assert payload["total_writes"] == 2
         assert payload["by_tier"]["T2"] == 1


### PR DESCRIPTION
Test-only change. json.loads(result.output) -> json.loads(result.stdout) across 20 test files plus a source-level regression guard. Resolves the recurring Linux CI JSONDecodeError flake class. No production code change; no version bump needed.

Closes nexus-84a6 (already merged to develop via PR #698).