### PR TITLE
fix(catalog): chunk_count + manifest cache invalidation post-RDR-108 P3 (4.32.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.32.3"
+      "version": "4.32.4"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.32.3"
+      "version": "4.32.4"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,92 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.32.4] - 2026-05-12
+
+Patch on 4.32.3. Stops the silent data-correctness regression from
+RDR-108 Phase 3 (PR #618, fd09a7f4): fresh indexes were shipping
+with empty catalog manifests and ``chunk_count=0`` despite chunks
+correctly landing in T3. Catalog-aware retrieval (tumbler→chunks
+resolution) was silently broken for every doc indexed since 4.32.0.
+
+### Fixed
+
+- **``documents.chunk_count`` cache never re-derived** (nexus-zq79):
+  Post-Phase-3, ``chunk_count`` is a denormalised cache of
+  ``COUNT(*) FROM document_chunks``. The catalog-register hook
+  seeds it to 0 (runs BEFORE per-file indexing) and nothing
+  re-derived it for code/prose indexers. New Catalog public APIs
+  ``resync_chunk_count_cache(doc_id)`` and
+  ``purge_manifest_for_doc(doc_id)`` keep the cache and manifest
+  consistent through ``manifest_write_batch_hook``.
+- **Shrink-reindex orphan rows** (nexus-zq79 F3):
+  ``append_manifest_chunks`` UPSERTs by ``(doc_id, position)``;
+  re-indexing with fewer chunks left orphan rows at higher
+  positions, inflating ``chunk_count``. The hook now purges the
+  doc's prior manifest rows when a batch contains position 0.
+- **First-time PDF/markdown batch ingest silently never wrote
+  manifest** (nexus-zq79 F2): the doc-indexer batch paths used
+  ``_lookup_existing_doc_id`` (read-only), which returned ``""``
+  for a fresh document; post-Phase-3 chunks have no ``doc_id``
+  fallback so the manifest hook short-circuited. Three call
+  sites in ``doc_indexer.py`` switched to
+  ``_register_or_lookup_doc_id``.
+- **``Catalog.update()`` emitted stale ``chunk_count``** (nexus-zq79
+  F4): ``DocumentRegistered`` event payload used the resolve-time
+  snapshot; event-replay projected stale zero. ``update()`` now
+  re-derives ``chunk_count`` when the caller omits it;
+  caller-supplied values still win. Previously-silent
+  ``except Exception: pass`` now logs at debug (F1).
+- **``documents.indexed_at`` never refreshed on re-index**
+  (nexus-zq79 F7): ``Catalog.update(head_hash=...)`` now
+  refreshes ``indexed_at`` so ``nx catalog show`` last_indexed
+  and ``collection_health`` advance.
+- **``topics.doc_count`` cache stale until next discover rebuild**
+  (nexus-n41p): ``CatalogTaxonomy.assign_topic`` re-derives
+  ``doc_count`` from ``topic_assignments`` after every assign.
+- **``topic_links.link_count`` stale on incremental indexing**
+  (nexus-zq79 F5): ``assign_topic`` resyncs all ``topic_links``
+  rows touching the assigned topic, materialising new pairs.
+  ``link_count`` re-derived atomically via correlated subquery.
+- **``manifest_write_batch_hook`` failure logged at debug** —
+  bumped to WARNING since post-Phase-3 the hook is load-bearing.
+
+### Backfill on upgrade
+
+The fix corrects the *write path*; documents indexed before this
+release retain stale caches. A migration step is filed for a
+follow-up patch; in the interim apply directly:
+
+```sql
+-- catalog SQLite (.catalog.db)
+UPDATE documents SET chunk_count = (
+  SELECT COUNT(*) FROM document_chunks dc WHERE dc.doc_id = documents.tumbler
+) WHERE chunk_count = 0 AND EXISTS (
+  SELECT 1 FROM document_chunks dc WHERE dc.doc_id = documents.tumbler
+);
+
+-- memory.db (taxonomy)
+UPDATE topics SET doc_count = (
+  SELECT COUNT(*) FROM topic_assignments WHERE topic_id = topics.id
+);
+```
+
+### Known follow-ups
+
+Deep audit surfaced additional silent regressions filed for the
+next patch:
+
+- ``nexus-dxly`` (P0) — ``scoring.py``, ``aspect_readers.py``,
+  ``aspect_extractor.py`` still read dropped chunk metadata
+  fields with bad defaults (ranking degrades, multi-chunk
+  aspect ordering wrong).
+- ``nexus-w5zv`` (P1) — ``manifest_backfill.py`` /
+  ``orphan_backfill.py`` write Phase-3 chunks at position 0.
+- ``nexus-lrhg`` (P1) — atomicity wrap of manifest hook, chash
+  32/64-char normalisation, ``DocumentDeleted`` replay orphan
+  cleanup, ``event_log.py`` flock re-entrancy, staleness-cache
+  silent-fail.
+
 ## [4.32.3] - 2026-05-11
 
 Patch on 4.32.2. Stops the auto-restart-writes-ephemeral-port-to-

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.32.3",
+  "version": "4.32.4",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.32.3"
+version = "4.32.4"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.32.3",
+  "version": "4.32.4",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1529,6 +1529,16 @@ class Catalog:
         :meth:`_WriteOps.append_manifest_chunks` for the contract."""
         return self._writes.append_manifest_chunks(doc_id, chunks)
 
+    def resync_chunk_count_cache(self, doc_id: str) -> None:
+        """nexus-zq79: re-derive ``documents.chunk_count`` cache. See
+        :meth:`_WriteOps.resync_chunk_count_cache`."""
+        return self._writes.resync_chunk_count_cache(doc_id)
+
+    def purge_manifest_for_doc(self, doc_id: str) -> None:
+        """nexus-zq79 F3: clear all manifest rows for ``doc_id``. See
+        :meth:`_WriteOps.purge_manifest_for_doc`."""
+        return self._writes.purge_manifest_for_doc(doc_id)
+
     def get_manifest(self, doc_id: str) -> list[_ManifestRow]:
         """Return ordered manifest rows for ``doc_id`` (nexus-572g K6)."""
         return self._writes.get_manifest(doc_id)

--- a/src/nexus/catalog/catalog_writes.py
+++ b/src/nexus/catalog/catalog_writes.py
@@ -470,6 +470,45 @@ class _WriteOps:
             cat._check_source_uri_in_repo_root(
                 owner_addr, rec_dict["source_uri"],
             )
+            # nexus-zq79 F4: re-derive chunk_count from the current
+            # document_chunks count so the emitted DocumentRegistered event
+            # carries fresh state, not the resolve()-time snapshot. Without
+            # this, an `nx catalog rebuild` from events.jsonl projects a
+            # stale 0 whenever update() ran before the manifest_write_hook
+            # converged the cache. Live SQLite is already correct via the
+            # zq79 hook; this closes the event-replay side.
+            #
+            # Only re-derive when the caller did not explicitly supply
+            # chunk_count — callers that do (e.g. orphan-backfill paths)
+            # are signalling intent and their value wins.
+            if "chunk_count" not in fields:
+                try:
+                    cnt_row = cat._db.execute(
+                        "SELECT COUNT(*) FROM document_chunks WHERE doc_id = ?",
+                        (rec_dict["tumbler"],),
+                    ).fetchone()
+                    if cnt_row is not None:
+                        rec_dict["chunk_count"] = int(cnt_row[0])
+                except Exception:
+                    # nexus-zq79 F1: silent pass would invisibly revert the
+                    # F4 chunk_count re-derive to the broken pre-fix
+                    # behaviour. Surface failures at debug+ so they're
+                    # discoverable via `nx doctor` and structured-log
+                    # tooling. We still don't propagate — the public
+                    # update() contract must remain best-effort here.
+                    import structlog
+                    structlog.get_logger(__name__).debug(
+                        "chunk_count_rederive_failed",
+                        tumbler=rec_dict["tumbler"],
+                        exc_info=True,
+                    )
+            # nexus-zq79 F7: refresh indexed_at when the caller signals a
+            # genuine re-index (new head_hash or source_mtime). Without
+            # this, indexed_at remains the register-time stamp forever,
+            # so `nx catalog show` / collection_health "last_indexed"
+            # never advance on re-indexed docs.
+            if "head_hash" in fields or "source_mtime" in fields:
+                rec_dict["indexed_at"] = datetime.now(UTC).isoformat()
             event = _cat_mod._make_event(
                 _DocumentRegisteredPayload(
                     doc_id=rec_dict["tumbler"],
@@ -771,6 +810,48 @@ class _WriteOps:
                         )
                     ],
                 )
+
+    def resync_chunk_count_cache(self, doc_id: str) -> None:
+        """nexus-zq79: re-derive ``documents.chunk_count`` from current
+        ``document_chunks`` count.
+
+        ``chunk_count`` is a denormalised cache; the catalog-register
+        hook seeds it to 0 (it runs BEFORE per-file indexing for tumbler
+        injection). Post-store hooks call this method once manifest
+        writes have converged so consumers gated on
+        ``chunk_count > 0`` (e.g. catalog-aware retrieval, drift
+        checks) see fresh state.
+
+        Direct SQL (not via ``update()``) — ``chunk_count`` is a
+        projection of the manifest, not an event-sourced field. Routing
+        via ``update()`` would emit a redundant ``DocumentRegistered``
+        event per converge.
+        """
+        cat = self._cat
+        cat._db.execute(
+            "UPDATE documents SET chunk_count = "
+            "(SELECT COUNT(*) FROM document_chunks WHERE doc_id = ?) "
+            "WHERE tumbler = ?",
+            (doc_id, doc_id),
+        )
+        cat._db.commit()
+
+    def purge_manifest_for_doc(self, doc_id: str) -> None:
+        """nexus-zq79 F3: purge ALL manifest rows for ``doc_id``.
+
+        Called from the manifest-write batch hook when a re-index
+        begins (first batch contains chunk position 0) so the new
+        write defines the final shape rather than leaving orphans
+        from the previous index at higher positions. UPSERT alone
+        cannot handle shrink (fewer chunks than before) because it
+        keys on ``(doc_id, position)``.
+        """
+        cat = self._cat
+        cat._db.execute(
+            "DELETE FROM document_chunks WHERE doc_id = ?",
+            (doc_id,),
+        )
+        cat._db.commit()
 
     def append_manifest_chunks(self, doc_id: str, chunks: list[dict]) -> None:
         """UPSERT manifest rows for one document without deleting prior rows

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -737,6 +737,17 @@ class CatalogTaxonomy:
                     """,
                     (doc_id, topic_id, similarity, ts, source_collection),
                 )
+                # nexus-n41p: topics.doc_count is a denormalised cache of
+                # COUNT(*) FROM topic_assignments WHERE topic_id = ?. Resync
+                # after every UPSERT so taxonomy stats / ORDER BY doc_count
+                # stay accurate without waiting for the next discover rebuild.
+                self.conn.execute(
+                    "UPDATE topics SET doc_count = "
+                    "(SELECT COUNT(*) FROM topic_assignments WHERE topic_id = ?) "
+                    "WHERE id = ?",
+                    (topic_id, topic_id),
+                )
+                self._resync_topic_links_for(doc_id, topic_id)
                 self.conn.commit()
             return
 
@@ -746,7 +757,66 @@ class CatalogTaxonomy:
                 "(doc_id, topic_id, assigned_by) VALUES (?, ?, ?)",
                 (doc_id, topic_id, assigned_by),
             )
+            # nexus-n41p: see comment in the projection branch above.
+            self.conn.execute(
+                "UPDATE topics SET doc_count = "
+                "(SELECT COUNT(*) FROM topic_assignments WHERE topic_id = ?) "
+                "WHERE id = ?",
+                (topic_id, topic_id),
+            )
+            self._resync_topic_links_for(doc_id, topic_id)
             self.conn.commit()
+
+    def _resync_topic_links_for(self, doc_id: str, topic_id: int) -> None:
+        """nexus-zq79 F5: re-derive ``topic_links.link_count`` for every
+        pair touching ``topic_id`` after a new ``topic_assignments`` row
+        for ``(doc_id, topic_id)``.
+
+        Pre-fix, ``assign_topic`` updated ``topics.doc_count`` (n41p) but
+        left ``topic_links.link_count`` stale until the next
+        ``refresh_projection_links`` / ``generate_cooccurrence_links``
+        full rebuild. Symptoms: ``links`` view under-reports co-occurrence
+        counts, hubs ranking drifts.
+
+        Cost: bounded by the number of links involving ``topic_id``,
+        which is small for normal taxonomies. Atomic single-statement
+        UPDATE; idempotent under concurrent calls (the same write
+        recomputes the same value).
+
+        New pairs (first co-occurrence of two topics for any doc) are
+        materialised here too — without this, the row stays absent and
+        the count never appears until full discover.
+        """
+        # Materialise any new pairs (topic_id, other) that don't yet
+        # have a topic_links row. INSERT OR IGNORE; link_count is set
+        # to 0 here and corrected by the UPDATE below in the same tx.
+        self.conn.execute(
+            """
+            INSERT OR IGNORE INTO topic_links
+                (from_topic_id, to_topic_id, link_count, link_types)
+            SELECT
+                MIN(other.topic_id, ?), MAX(other.topic_id, ?),
+                0, '["incremental"]'
+            FROM topic_assignments other
+            WHERE other.doc_id = ? AND other.topic_id != ?
+            """,
+            (topic_id, topic_id, doc_id, topic_id),
+        )
+        # Atomic re-derive: any topic_links row touching topic_id gets
+        # its link_count recomputed from current topic_assignments.
+        self.conn.execute(
+            """
+            UPDATE topic_links SET link_count = (
+                SELECT COUNT(*)
+                FROM topic_assignments a
+                JOIN topic_assignments b ON a.doc_id = b.doc_id
+                WHERE a.topic_id = topic_links.from_topic_id
+                  AND b.topic_id = topic_links.to_topic_id
+            )
+            WHERE from_topic_id = ? OR to_topic_id = ?
+            """,
+            (topic_id, topic_id),
+        )
 
     def get_topic_docs(
         self,

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -670,7 +670,17 @@ def _index_document(
         fire_post_store_batch_hooks,
         fire_post_store_hooks,
     )
-    _catalog_doc_id_for_batch = _lookup_existing_doc_id(sp, corpus)
+    # nexus-zq79 F2: use _register_or_lookup_doc_id, NOT _lookup_existing_doc_id.
+    # The read-only lookup returns "" for first-time indexes; post-Phase-3
+    # chunks have no doc_id fallback so the manifest hook short-circuits and
+    # the catalog document ships with chunk_count=0 / empty manifest. Routing
+    # via the register-or-lookup path closes the gap idempotently.
+    _ct_for_register = (metadatas[0].get("content_type") if metadatas else "") or "prose"
+    _catalog_doc_id_for_batch = _register_or_lookup_doc_id(
+        file_path, corpus,
+        content_type=_ct_for_register,
+        physical_collection=collection_name,
+    )
     fire_post_store_batch_hooks(
         ids, collection_name, documents, embeddings, metadatas,
         catalog_doc_id=_catalog_doc_id_for_batch,
@@ -782,7 +792,14 @@ def _index_pdf_incremental(
     # Resolve catalog doc_id once outside the per-batch loop (RDR-108
     # Phase 3: chunk metadata no longer carries it; manifest hook reads
     # via the fire_post_store_batch_hooks kwarg).
-    _catalog_doc_id_for_batch = _lookup_existing_doc_id(str(file_path), corpus)
+    # nexus-zq79 F2: register-or-lookup, not pure lookup (see _index_document
+    # for the rationale — fresh indexes returned "" pre-fix).
+    _ct_for_register = (metadatas_all[0].get("content_type") if metadatas_all else "") or "pdf"
+    _catalog_doc_id_for_batch = _register_or_lookup_doc_id(
+        Path(file_path), corpus,
+        content_type=_ct_for_register,
+        physical_collection=collection_name,
+    )
 
     for batch_start in range(start_offset, total, _INCREMENTAL_BATCH_SIZE):
         batch_end = min(batch_start + _INCREMENTAL_BATCH_SIZE, total)
@@ -1322,7 +1339,13 @@ def index_pdf(
         fire_post_store_batch_hooks,
         fire_post_store_hooks,
     )
-    _catalog_doc_id_for_batch = _lookup_existing_doc_id(str(pdf_path), corpus)
+    # nexus-zq79 F2: register-or-lookup (fresh indexes returned "" pre-fix).
+    _ct_for_register = (metadatas_list[0].get("content_type") if metadatas_list else "") or "pdf"
+    _catalog_doc_id_for_batch = _register_or_lookup_doc_id(
+        pdf_path, corpus,
+        content_type=_ct_for_register,
+        physical_collection=col_name,
+    )
     fire_post_store_batch_hooks(
         ids, col_name, documents, embeddings, metadatas_list,
         catalog_doc_id=_catalog_doc_id_for_batch,

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -901,10 +901,33 @@ def manifest_write_batch_hook(
         if all(not c["chash"] for c in chunks):
             continue
         try:
+            # nexus-zq79 F3: shrink-reindex orphan cleanup. UPSERT keyed on
+            # (doc_id, position) leaves orphan rows when a file re-indexes
+            # with fewer chunks than before. When the batch contains
+            # position 0 (the start of a file's chunks), wipe the doc's
+            # prior manifest rows first so the new write defines the
+            # complete shape. Multi-batch writes never include position 0
+            # in batches other than the first, so this is safe across the
+            # streaming PDF / doc_indexer paths.
+            if any(c["position"] == 0 for c in chunks):
+                cat.purge_manifest_for_doc(doc_id)
             cat.append_manifest_chunks(doc_id, chunks)
+            # nexus-zq79: documents.chunk_count is a denormalised cache of
+            # COUNT(*) document_chunks. The catalog-register hook runs BEFORE
+            # per-file indexing (tumbler injection requires it), so chunk_count
+            # is initialised to 0; nothing else updates it for code/prose
+            # indexers post-Phase-3. Routed via Catalog public API to satisfy
+            # the projector-only-writes invariant (RDR-101 Phase 3 ε).
+            cat.resync_chunk_count_cache(doc_id)
         except Exception:
+            # Post-Phase-3 the manifest hook is load-bearing: a failure
+            # leaves the catalog manifest empty and chunk_count=0 for
+            # this doc (silent data-correctness bug). The contract still
+            # requires non-propagation (best-effort hook) but the log
+            # severity is WARNING so failures are discoverable in
+            # production log streams without DEBUG enabled. nexus-zq79.
             import structlog
-            structlog.get_logger().debug(
+            structlog.get_logger().warning(
                 "manifest_write_hook_failed", doc_id=doc_id, exc_info=True
             )
 

--- a/tests/test_catalog_event_sourced_mutators.py
+++ b/tests/test_catalog_event_sourced_mutators.py
@@ -67,6 +67,118 @@ class TestUpdateEventSourced:
         ).fetchone()
         assert row == (42, "updated")
 
+    def test_update_re_derives_chunk_count_from_manifest_when_omitted(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """nexus-zq79 F4: when caller omits chunk_count, cat.update() must
+        re-derive it from the current document_chunks count so the emitted
+        event payload is fresh (not the resolve-time stale snapshot).
+        Event replay would otherwise project the old 0.
+        """
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "doc.md", content_type="prose",
+            file_path="doc.md", chunk_count=0,
+        )
+        # Simulate the post-store manifest write writing 5 chunk rows but
+        # NOT touching documents.chunk_count (the pre-zq79 bug shape).
+        # Use the catalog public API to satisfy the projector-only-writes
+        # invariant (RDR-101 Phase 3 ε).
+        cat.append_manifest_chunks(
+            str(tumbler),
+            [
+                {
+                    "position": pos,
+                    "chash": f"chash{pos}",
+                    "chunk_index": pos,
+                    "line_start": None,
+                    "line_end": None,
+                    "char_start": None,
+                    "char_end": None,
+                }
+                for pos in range(5)
+            ],
+        )
+        # Update with head_hash only — no chunk_count in fields.
+        cat.update(tumbler, head_hash="updated")
+        log = EventLog(d)
+        events = list(log.replay())
+        # Last event must carry re-derived chunk_count=5, not the
+        # stale 0 from resolve().
+        assert events[-1].type == ev.TYPE_DOCUMENT_REGISTERED
+        assert events[-1].payload.chunk_count == 5, (
+            f"expected re-derived chunk_count=5, got "
+            f"{events[-1].payload.chunk_count}"
+        )
+
+    def test_update_respects_caller_supplied_chunk_count(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """nexus-zq79 F4: caller intent wins — when chunk_count is passed
+        explicitly (e.g. orphan-backfill paths), use the caller's value
+        without re-derivation.
+        """
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "doc.md", content_type="prose",
+            file_path="doc.md", chunk_count=0,
+        )
+        # 3 manifest rows present, but caller wants to assert 99.
+        cat.append_manifest_chunks(
+            str(tumbler),
+            [
+                {
+                    "position": pos,
+                    "chash": f"chash{pos}",
+                    "chunk_index": pos,
+                    "line_start": None,
+                    "line_end": None,
+                    "char_start": None,
+                    "char_end": None,
+                }
+                for pos in range(3)
+            ],
+        )
+        cat.update(tumbler, chunk_count=99)
+        log = EventLog(d)
+        events = list(log.replay())
+        assert events[-1].payload.chunk_count == 99
+
+    def test_update_refreshes_indexed_at_when_head_hash_changes(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """nexus-zq79 F7: cat.update(head_hash=...) must refresh
+        documents.indexed_at to now. Pre-fix, indexed_at stayed at the
+        original register stamp forever; `nx catalog show` last_indexed
+        never advanced on re-indexed files.
+        """
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(
+            owner, "doc.md", content_type="prose",
+            file_path="doc.md", chunk_count=0,
+        )
+        original_at = cat.resolve(tumbler).indexed_at
+        import time
+        time.sleep(0.01)
+        cat.update(tumbler, head_hash="rev2")
+        refreshed_at = cat.resolve(tumbler).indexed_at
+        assert refreshed_at != original_at, (
+            f"indexed_at must advance on re-index; "
+            f"original={original_at!r} refreshed={refreshed_at!r}"
+        )
+
 
 # ── delete_document ──────────────────────────────────────────────────────
 

--- a/tests/test_catalog_manifest_read_api.py
+++ b/tests/test_catalog_manifest_read_api.py
@@ -902,6 +902,105 @@ class TestManifestWriteBatchHook:
         assert rows[0][1] == "a" * 64
         assert rows[4][1] == "e" * 64
 
+    def test_manifest_write_batch_hook_updates_chunk_count_cache(self, tmp_path):
+        """nexus-zq79: documents.chunk_count must track manifest size after
+        the hook fires. Pre-fix, catalog-register seeded chunk_count=0 and
+        nothing else re-derived it for code/prose indexers — catalog-aware
+        retrieval gated on chunk_count was silently disabled for fresh
+        indexes.
+        """
+        from unittest.mock import patch
+        from nexus.mcp_infra import manifest_write_batch_hook
+
+        cat = _make_catalog(tmp_path)
+        _insert_doc(cat, "1.1.1", "code__test")
+        # Sanity: register-time chunk_count is 0.
+        assert cat._db.execute(
+            "SELECT chunk_count FROM documents WHERE tumbler=?", ("1.1.1",),
+        ).fetchone()[0] == 0
+
+        metadatas = [
+            {"chunk_index": 0, "chunk_text_hash": "a" * 64},
+            {"chunk_index": 1, "chunk_text_hash": "b" * 64},
+            {"chunk_index": 2, "chunk_text_hash": "c" * 64},
+        ]
+        with patch("nexus.mcp_infra.get_catalog", return_value=cat):
+            manifest_write_batch_hook(
+                doc_ids=["c-0", "c-1", "c-2"],
+                collection="code__test",
+                contents=["x", "y", "z"],
+                embeddings=None,
+                metadatas=metadatas,
+                catalog_doc_id="1.1.1",
+            )
+
+        chunk_count = cat._db.execute(
+            "SELECT chunk_count FROM documents WHERE tumbler=?", ("1.1.1",),
+        ).fetchone()[0]
+        manifest_size = len(cat.get_manifest("1.1.1"))
+        assert chunk_count == manifest_size == 3, (
+            f"chunk_count={chunk_count} != manifest_size={manifest_size}"
+        )
+
+    def test_manifest_write_batch_hook_shrink_reindex_purges_orphans(self, tmp_path):
+        """nexus-zq79 F3: re-indexing a doc with fewer chunks than before
+        must purge orphan rows at higher positions. UPSERT keyed on
+        ``(doc_id, position)`` alone leaves the old tail in place; the
+        zq79 fix DELETEs the doc's prior manifest rows when a batch
+        contains position 0 (the start of a re-write). Without this,
+        chunk_count and the manifest both inflate.
+        """
+        from unittest.mock import patch
+        from nexus.mcp_infra import manifest_write_batch_hook
+
+        cat = _make_catalog(tmp_path)
+        _insert_doc(cat, "1.1.1", "code__test")
+
+        # First index: 5 chunks at positions 0..4.
+        first = [
+            {"chunk_index": i, "chunk_text_hash": chr(ord("a") + i) * 64}
+            for i in range(5)
+        ]
+        with patch("nexus.mcp_infra.get_catalog", return_value=cat):
+            manifest_write_batch_hook(
+                doc_ids=[f"c-{i}" for i in range(5)],
+                collection="code__test",
+                contents=["x"] * 5,
+                embeddings=None,
+                metadatas=first,
+                catalog_doc_id="1.1.1",
+            )
+        assert len(cat.get_manifest("1.1.1")) == 5
+
+        # Re-index: 3 chunks at positions 0..2 (file got smaller).
+        second = [
+            {"chunk_index": i, "chunk_text_hash": chr(ord("p") + i) * 64}
+            for i in range(3)
+        ]
+        with patch("nexus.mcp_infra.get_catalog", return_value=cat):
+            manifest_write_batch_hook(
+                doc_ids=[f"d-{i}" for i in range(3)],
+                collection="code__test",
+                contents=["x"] * 3,
+                embeddings=None,
+                metadatas=second,
+                catalog_doc_id="1.1.1",
+            )
+
+        rows = cat.get_manifest("1.1.1")
+        assert len(rows) == 3, (
+            f"shrink-reindex must purge orphan rows; got {len(rows)} rows: "
+            f"{[(r.position, r.chash[:1]) for r in rows]}"
+        )
+        # New chashes wholly replace the old ones.
+        assert rows[0].chash == "p" * 64
+        assert rows[2].chash == "r" * 64
+        # And the chunk_count cache reflects the new shape.
+        chunk_count = cat._db.execute(
+            "SELECT chunk_count FROM documents WHERE tumbler=?", ("1.1.1",),
+        ).fetchone()[0]
+        assert chunk_count == 3
+
 
 # ── nexus-oe2i (RDR-108 Phase 4 review TV-low): manifest-authoritative ──────
 

--- a/tests/test_code_indexer_doc_id.py
+++ b/tests/test_code_indexer_doc_id.py
@@ -177,6 +177,12 @@ def test_code_indexer_writes_manifest_rows_for_each_document(
             f"manifest_write_batch_hook must populate document_chunks "
             f"for doc_id={tumbler!r} (file_path={file_path!r})"
         )
+        # nexus-zq79: documents.chunk_count cache must track manifest size.
+        entry = cat.resolve(Tumbler.parse(tumbler))
+        assert entry is not None and entry.chunk_count == len(manifest_rows), (
+            f"chunk_count={entry.chunk_count if entry else None} != "
+            f"manifest_size={len(manifest_rows)} for doc_id={tumbler!r}"
+        )
 
 
 def test_code_indexer_doc_id_absent_when_catalog_uninitialized(

--- a/tests/test_pdf_indexer_doc_id.py
+++ b/tests/test_pdf_indexer_doc_id.py
@@ -182,6 +182,12 @@ def test_pdf_indexer_registers_catalog_and_writes_manifest(
         f"manifest_write_batch_hook must populate document_chunks for "
         f"PDF doc_id={pdf_entry.tumbler!r}"
     )
+    # nexus-zq79: documents.chunk_count cache must track manifest size.
+    fresh = cat.resolve(pdf_entry.tumbler)
+    assert fresh is not None and fresh.chunk_count == len(manifest_rows), (
+        f"chunk_count={fresh.chunk_count if fresh else None} != "
+        f"manifest_size={len(manifest_rows)} for PDF doc_id={pdf_entry.tumbler!r}"
+    )
 
 
 def test_pdf_indexer_doc_id_absent_when_catalog_uninitialized(

--- a/tests/test_prose_indexer_doc_id.py
+++ b/tests/test_prose_indexer_doc_id.py
@@ -185,6 +185,14 @@ def test_prose_indexer_writes_manifest_rows_for_each_document(
             f"manifest_write_batch_hook must populate document_chunks "
             f"for doc_id={tumbler!r} (file_path={file_path!r})"
         )
+        # nexus-zq79: documents.chunk_count must stay in sync with
+        # the manifest (it's a denormalised cache; cache-invalidation
+        # bug regression test).
+        entry = cat.resolve(Tumbler.parse(tumbler))
+        assert entry is not None and entry.chunk_count == len(manifest_rows), (
+            f"chunk_count={entry.chunk_count if entry else None} != "
+            f"manifest_size={len(manifest_rows)} for doc_id={tumbler!r}"
+        )
         if file_path.endswith(".md"):
             md_seen = True
         if file_path.endswith(".rst"):

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -131,6 +131,126 @@ def test_assign_topic_idempotent(db: T2Database) -> None:
     assert count == 1
 
 
+def test_assign_topic_updates_doc_count_cache(db: T2Database) -> None:
+    """nexus-n41p: topics.doc_count must track COUNT(*) topic_assignments.
+
+    Cache-invalidation regression test. Pre-fix, doc_count stayed at its
+    register-time default (0) after assign_topic() inserted into
+    topic_assignments. Stats consumers (`nx taxonomy stats`, ORDER BY
+    doc_count) silently under-reported.
+    """
+    db.taxonomy.conn.execute(
+        "INSERT INTO topics (label, collection, doc_count, created_at) VALUES (?, ?, ?, ?)",
+        ("test-topic", "proj", 0, "2026-01-01T00:00:00Z"),
+    )
+    db.taxonomy.conn.commit()
+    topic_id = db.taxonomy.conn.execute("SELECT id FROM topics LIMIT 1").fetchone()[0]
+
+    # HDBSCAN path (default assigned_by)
+    db.taxonomy.assign_topic("doc-a", topic_id, assigned_by="hdbscan")
+    db.taxonomy.assign_topic("doc-b", topic_id, assigned_by="hdbscan")
+    cached = db.taxonomy.conn.execute(
+        "SELECT doc_count FROM topics WHERE id = ?", (topic_id,)
+    ).fetchone()[0]
+    derived = db.taxonomy.conn.execute(
+        "SELECT COUNT(*) FROM topic_assignments WHERE topic_id = ?", (topic_id,)
+    ).fetchone()[0]
+    assert cached == derived == 2, f"cached={cached} derived={derived}"
+
+    # Projection (UPSERT) path
+    db.taxonomy.assign_topic(
+        "doc-c",
+        topic_id,
+        assigned_by="projection",
+        similarity=0.9,
+        source_collection="proj",
+    )
+    cached = db.taxonomy.conn.execute(
+        "SELECT doc_count FROM topics WHERE id = ?", (topic_id,)
+    ).fetchone()[0]
+    derived = db.taxonomy.conn.execute(
+        "SELECT COUNT(*) FROM topic_assignments WHERE topic_id = ?", (topic_id,)
+    ).fetchone()[0]
+    assert cached == derived == 3, f"cached={cached} derived={derived}"
+
+    # Re-assigning same doc via projection UPSERT must not double-count.
+    db.taxonomy.assign_topic(
+        "doc-c",
+        topic_id,
+        assigned_by="projection",
+        similarity=0.95,
+        source_collection="proj",
+    )
+    cached = db.taxonomy.conn.execute(
+        "SELECT doc_count FROM topics WHERE id = ?", (topic_id,)
+    ).fetchone()[0]
+    derived = db.taxonomy.conn.execute(
+        "SELECT COUNT(*) FROM topic_assignments WHERE topic_id = ?", (topic_id,)
+    ).fetchone()[0]
+    assert cached == derived == 3, f"cached={cached} derived={derived}"
+
+
+def test_assign_topic_resyncs_topic_links_link_count(db: T2Database) -> None:
+    """nexus-zq79 F5: topic_links.link_count must track co-occurrence
+    count after every assign_topic, not stay stale until the next full
+    refresh_projection_links / generate_cooccurrence_links rebuild.
+    """
+    # Two topics in different collections so co-occurrence is meaningful.
+    db.taxonomy.conn.executemany(
+        "INSERT INTO topics (label, collection, doc_count, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        [
+            ("topic-a", "proj-a", 0, "2026-01-01T00:00:00Z"),
+            ("topic-b", "proj-b", 0, "2026-01-01T00:00:00Z"),
+        ],
+    )
+    db.taxonomy.conn.commit()
+    ids = [
+        row[0]
+        for row in db.taxonomy.conn.execute(
+            "SELECT id FROM topics ORDER BY id"
+        ).fetchall()
+    ]
+    a_id, b_id = ids[0], ids[1]
+
+    # Doc X in topic A, then X in topic B — co-occurrence 1.
+    db.taxonomy.assign_topic("doc-x", a_id, assigned_by="hdbscan")
+    db.taxonomy.assign_topic("doc-x", b_id, assigned_by="hdbscan")
+    link = db.taxonomy.conn.execute(
+        "SELECT link_count FROM topic_links "
+        "WHERE from_topic_id = ? AND to_topic_id = ?",
+        (min(a_id, b_id), max(a_id, b_id)),
+    ).fetchone()
+    assert link is not None and link[0] == 1, (
+        f"expected link_count=1 after first co-occurrence, got "
+        f"{link[0] if link else None}"
+    )
+
+    # Doc Y also in both topics — co-occurrence 2.
+    db.taxonomy.assign_topic("doc-y", a_id, assigned_by="hdbscan")
+    db.taxonomy.assign_topic("doc-y", b_id, assigned_by="hdbscan")
+    link = db.taxonomy.conn.execute(
+        "SELECT link_count FROM topic_links "
+        "WHERE from_topic_id = ? AND to_topic_id = ?",
+        (min(a_id, b_id), max(a_id, b_id)),
+    ).fetchone()
+    assert link[0] == 2, (
+        f"expected link_count=2 after second co-occurrence, got {link[0]}"
+    )
+
+    # Re-assigning the same (doc, topic) must not inflate.
+    db.taxonomy.assign_topic("doc-y", a_id, assigned_by="hdbscan")
+    link = db.taxonomy.conn.execute(
+        "SELECT link_count FROM topic_links "
+        "WHERE from_topic_id = ? AND to_topic_id = ?",
+        (min(a_id, b_id), max(a_id, b_id)),
+    ).fetchone()
+    assert link[0] == 2, (
+        f"INSERT OR IGNORE on duplicate must not increment link_count; "
+        f"got {link[0]}"
+    )
+
+
 def test_rebuild_taxonomy_clears_and_rediscovers(
     db: T2Database, chroma_client: chromadb.ClientAPI,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.32.3"
+version = "4.32.4"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Stops the silent data-correctness regression introduced by RDR-108 Phase 3 (PR #618, fd09a7f4 — merged 2026-05-09). Fresh `nx index repo` runs were shipping with **empty catalog manifests** and `chunk_count=0` despite chunks correctly landing in T3. **Catalog-aware retrieval was silently broken for every doc indexed since 4.32.0.**

Reproducer: `nx index repo /Users/hal.hildebrand/git/ext-apps` showed 138 catalog entries all with `chunk_count: 0`, while T3 chroma collections held 2087 + 575 chunks. Manifest never joined back to document_chunks for the new docs.

## Root causes (deep audit by 3 specialised review agents)

- **`documents.chunk_count`** — denormalised cache of `COUNT(*) document_chunks`. Catalog-register seeds it to 0 (must, for tumbler injection); nothing re-derived it for code/prose indexers post-Phase-3.
- **First-time batch PDF/markdown** — used `_lookup_existing_doc_id` (read-only); fresh docs returned `""` → manifest hook short-circuited → silent data loss.
- **Shrink-reindex** — `append_manifest_chunks` UPSERTs by `(doc_id, position)`; fewer-chunks re-index left orphan rows.
- **`Catalog.update()`** — captured `chunk_count` at resolve-time; event-replay projected stale zero.
- **`topics.doc_count` / `topic_links.link_count`** — same cache-stale shape, taxonomy stats undercount.
- **`documents.indexed_at`** — never refreshed; `nx catalog show` last_indexed stayed at register time forever.

## What's fixed

### New Catalog public API
- `Catalog.resync_chunk_count_cache(doc_id)` — atomic re-derive
- `Catalog.purge_manifest_for_doc(doc_id)` — shrink-reindex orphan cleanup
- (Maintains RDR-101 Phase 3 ε projector-only-writes invariant)

### Cache invalidation
- `manifest_write_batch_hook`: purge prior rows on first-batch (position 0), append, resync `chunk_count`. Failures bumped to WARNING (load-bearing hook).
- `doc_indexer.py`: 3 sites switched from `_lookup_existing_doc_id` → `_register_or_lookup_doc_id`.
- `Catalog.update()`: re-derives `chunk_count` when caller omits it; refreshes `indexed_at` on `head_hash`/`source_mtime`; silent `except` now logs at debug.
- `CatalogTaxonomy.assign_topic`: re-derives `topics.doc_count` + new `_resync_topic_links_for()` resyncs every link row touching the assigned topic.

### Tests
313 tests across 8 touched suites pass:
- `test_catalog_manifest_read_api`: chunk_count==manifest_size + shrink-reindex purge
- `test_catalog_event_sourced_mutators`: F4 re-derive, caller-supplied wins, F7 indexed_at
- `test_{prose,code,pdf}_indexer_doc_id`: end-to-end chunk_count cache discipline
- `test_taxonomy`: doc_count + link_count resync on every assign
- `test_no_direct_catalog_writes_outside_projector`: lint gate clean

### Backfill
On-machine backfill: 2995 damaged documents + 1638 damaged topics → 0. SQL one-liners documented in CHANGELOG for users. Migration step deferred to follow-up patch.

## Closes

- Closes #nexus-zq79 (P0 — chunk_count regression)
- Closes #nexus-n41p (P1 — topics.doc_count cache)

## Known follow-ups filed (NOT in this PR)

Deep audit surfaced more silent regressions for the next patch:
- `nexus-dxly` (P0) — `scoring.py`, `aspect_readers.py`, `aspect_extractor.py` still read dropped chunk metadata (ranking/aspect ordering degrades).
- `nexus-w5zv` (P1) — `manifest_backfill.py`/`orphan_backfill.py` write Phase-3 chunks at position 0.
- `nexus-lrhg` (P1) — atomicity wrap of manifest hook, chash 32/64-char normalisation, `DocumentDeleted` replay orphan cleanup, `event_log` flock re-entrancy, staleness-cache silent-fail.

## Test plan

- [x] Lint gate (`test_no_direct_catalog_writes_outside_projector`) passes
- [x] All catalog mutator regression tests pass (313/313 in touched suites)
- [x] End-to-end re-index of `~/git/ext-apps` shows correct `chunk_count` per doc (verified)
- [x] Host backfill SQL verified (2995 + 1638 → 0)
- [ ] CI suite green
- [ ] Sandbox smoke (`tests/e2e/release-sandbox.sh smoke`) — pending