### PR TITLE
fix(audit): tier-1 silent-fail discipline pass (4.32.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.32.4"
+      "version": "4.32.5"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.32.4"
+      "version": "4.32.5"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.32.5"
+      "version": "4.32.6"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.32.5"
+      "version": "4.32.6"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,77 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.32.6] - 2026-05-12
+
+Patch on 4.32.5. Tier-1 silent-fail discipline pass surfaced by the
+2026-05-12 multi-agent audit. None of these are data-loss class — they
+are silent degradations where a recurring error returns "safe-looking"
+state (empty set, False, b"", default value) so the broken behaviour is
+indistinguishable from healthy in logs.
+
+### Fixed
+
+- **``catalog_spans.py:290`` no longer wipes the chash index on T3
+  transient** (nexus-8g79.3): the pre-fix
+  ``except: live = set()`` made every row look stale and the
+  self-heal loop deleted them all. Now logs at WARNING, treats every
+  row as a provisional survivor, and skips the self-heal pass.
+- **``Catalog.delete_document`` cascades to ``document_chunks``**
+  (nexus-8g79.7): pre-fix only ``DELETE FROM documents`` ran, leaving
+  orphan manifest rows that survived even after event-sourced replay
+  (no FK cascade in the schema). Both the projector's
+  ``_v0_document_deleted`` and the legacy write path now
+  ``DELETE FROM document_chunks WHERE doc_id = ?`` first.
+- **``indexer.py:1547`` prune-misclassified no longer silently
+  accumulates T3 orphans** (nexus-8g79.4): the bare ``continue`` on
+  ``get_manifest`` failure left chunks un-pruned indefinitely. Both
+  the manifest-lookup and the ``col.get`` paths now log at WARNING
+  with doc_id / batch size + ``exc_info``.
+- **``catalog.py:_needs_compaction`` exception surfaces at WARNING**
+  (nexus-8g79.5): pre-fix the bare ``except: pass`` silently disabled
+  JSONL compaction whenever the threshold check raised, letting the
+  files grow unbounded.
+- **``catalog_sync.py:_should_use_event_sourced_rebuild`` exception
+  surfaces at WARNING** (nexus-8g79.6): pre-fix the silent return-False
+  downgraded every startup to legacy rebuild on a persistent error,
+  with no operator signal.
+- **``pipeline_buffer.update_progress`` quotes column identifiers**
+  (nexus-8g79.9): defense-in-depth — allowlist-check still gates today,
+  but a future allowlist entry that includes a SQL keyword (``order``)
+  would break or inject without explicit ``"col" = ?`` quoting.
+- **8 silent-fail patterns logged correctly** (nexus-8g79.8):
+  ``indexer_utils.py:317`` (WARNING — docs_for_chashes failure
+  silently broke catalog-aware retrieval),
+  ``context.py:71/78`` (DEBUG inner + WARNING outer — L1 context
+  collection-discovery),
+  ``operators/dispatch.py:128`` (DEBUG — pipe read failure was
+  invisible),
+  ``plans/matcher.py:298`` (DEBUG — cache eviction failure with
+  plan_id),
+  ``doc_indexer.py:1434`` (DEBUG — frontmatter parse failure left
+  catalog title/year unset),
+  ``collection_audit.py:186`` (WARNING + failed-count — per-embedding
+  query failure produced sparse-looking histograms indistinguishable
+  from genuinely sparse collections).
+
+### Tests
+
+Two new regression tests in ``test_catalog_event_sourced_mutators.py``
+assert ``delete_document`` cascades to ``document_chunks`` on both
+the event-sourced and legacy paths. 532 tests pass across touched
+suites.
+
+### Known follow-ups (from the audit epic ``nexus-8g79``)
+
+Tier-2 architectural cleanup (7 layering violations + consolidation
+T3-write bypass + dead-code sweep) plans into 4.33. Tier-3 external
+dep upgrades (``llama-index-core``, ``cryptography``,
+``tree-sitter-language-pack``, ``mineru[all]`` surface reduction,
+``chromadb`` timeout-patch fragility) plan as separate beads. Tier-4
+test discipline (155 inequality assertions, ``manifest_write_batch_hook``
+exception coverage, ``time.sleep`` → threading.Event in 8 files)
+plans as a sweep.
+
 ## [4.32.5] - 2026-05-12
 
 Patch on 4.32.4. Closes the remaining Tier-0 same-class regressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,18 +53,47 @@ with the identical bug shape and closes the event-replay invariant.
   ``aspect_extractor`` direct-chroma paths still need wiring to
   the manifest — filed as follow-ups.
 
-### Known follow-ups
+### Additional fixes (nexus-8g79.1, nexus-8g79.2)
 
-- ``nexus-dxly`` (P0) — ``aspect_readers`` and ``aspect_extractor``
-  direct-chroma reassembly still needs manifest-based ordering.
+- **``nx memory promote`` now registers in catalog before T3 put**
+  (nexus-8g79.1): the T2→T3 promotion path pre-registers via the
+  shared ``_catalog_store_hook`` so chunks land with the catalog
+  tumbler as ``doc_id`` and the manifest hook populates
+  ``document_chunks`` + ``chunk_count`` correctly. Same fix pattern
+  as ``nx store put`` in this release.
+- **``nx store import`` (exporter) now groups by doc_id**
+  (nexus-8g79.1): batched chunk imports group records by
+  ``meta["doc_id"]`` and fire ``fire_store_chains`` per group with
+  the group key as ``catalog_doc_id``. Pre-Phase-3 exports carrying
+  ``doc_id`` per chunk attribute correctly; post-Phase-3 exports
+  without ``doc_id`` retain the existing graceful-degradation
+  behaviour (manifest hook short-circuits for that group) until the
+  export format extension carries a catalog manifest sidecar.
+- **aspect_readers + aspect_extractor manifest-ordered reassembly**
+  (nexus-8g79.2): the chroma reader's ``_gather_chroma_chunks_by_field``
+  accepts a ``manifest_lookup(doc_id) -> list[ManifestRow]`` callable
+  and, when ``identity_field == 'doc_id'``, orders chunks by the
+  catalog manifest's canonical position keyed on
+  ``chunk_text_hash``. Post-Phase-3 chunks have no ``chunk_index``
+  in metadata so the legacy ``md.get('chunk_index', 0)`` ordering
+  collapsed to insertion-sequence — wrong for multi-chunk docs.
+  Threaded through ``read_source`` → ``_read_chroma_uri`` and the
+  three callers (``enrich.py`` aspects/dry-run paths,
+  ``aspect_worker.py``, ``aspect_extractor.extract_aspects``) via a
+  new ``_build_catalog_manifest_lookup`` factory in
+  ``commands/enrich.py``.
+
+### Known follow-ups (deferred)
+
 - ``nexus-w5zv`` (P1) — backfill paths write Phase-3 chunks at
   position 0.
 - ``nexus-lrhg`` (P1) — atomicity wrap of manifest hook, chash
   32/64-char normalisation, ``DocumentDeleted`` replay orphan
   cleanup, ``event_log.py`` flock re-entrancy, staleness-cache
   silent-fail.
-- ``nexus-lf8f`` (this bead, partial — store_put + projector
-  shipped, ``memory promote`` + ``store import`` deferred).
+- Post-Phase-3 export format extension (``nx store import``):
+  carry a catalog manifest sidecar so post-Phase-3 imports can
+  reconstruct ``document_chunks``. Filed in nexus-8g79.1 notes.
 
 ## [4.32.4] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,66 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.32.5] - 2026-05-12
+
+Patch on 4.32.4. Closes the remaining Tier-0 same-class regressions
+surfaced by the post-4.32.4 multi-agent audit (6 specialised agents
+ran in parallel across architecture, error handling, test quality,
+external deps, design contracts, deferment inventory). 4.32.4 fixed
+the ``nx index repo`` path; 4.32.5 fixes the rest of the surface
+with the identical bug shape and closes the event-replay invariant.
+
+### Fixed
+
+- **``fire_store_chains`` missing ``catalog_doc_id``** (nexus-lf8f):
+  the consolidated hook-firing helper used by MCP ``store_put``,
+  ``nx store put``, ``nx memory promote``, and ``nx store import``
+  didn't pass ``catalog_doc_id`` through to
+  ``fire_post_store_batch_hooks``. Post-Phase-3 chunks have no
+  ``doc_id`` fallback in metadata, so the manifest hook short-
+  circuited and the catalog row shipped with ``chunk_count=0`` and
+  an empty manifest — the same regression class as nexus-zq79,
+  different code path. ``fire_store_chains`` now accepts
+  ``catalog_doc_id`` kwarg and threads it through; ``nx store put``
+  wires it explicitly from ``_catalog_store_hook``. The
+  ``nx memory promote`` and ``nx store import`` paths still need
+  catalog registration plumbing — filed as follow-ups.
+- **``Projector.apply_all`` event-replay re-derives
+  ``documents.chunk_count``** (nexus-lf8f): the resync hook writes
+  directly to SQLite (chunk_count is a denormalised cache, not an
+  event-sourced field). Without a post-replay re-derivation,
+  ``nx catalog rebuild`` from ``events.jsonl`` would project
+  ``chunk_count=0`` forever — the ``DocumentRegistered`` events
+  carry the register-time snapshot only. The projector now runs
+  a single set-based ``UPDATE documents SET chunk_count = (SELECT
+  COUNT(*) FROM document_chunks WHERE doc_id = tumbler)`` after
+  every replay, guarded by ``WHERE EXISTS`` so caller-supplied
+  values via ``Catalog.update(chunk_count=N)`` still survive.
+- **Search results now carry catalog-derived ``chunk_count`` and
+  ``chunk_index``** (nexus-dxly, partial): post-Phase-3 chunk
+  metadata dropped both fields; ``scoring.py:125`` defaulted
+  ``chunk_count=1`` (file-size penalty silently disabled);
+  ``aspect_readers.py:266`` defaulted ``chunk_index=0`` (multi-
+  chunk doc reassembly wrong). The
+  ``_attach_doc_ids_from_catalog`` helper now batches the
+  manifest fetch and stamps both fields onto every result that
+  resolves to a catalog doc. ``aspect_readers`` and
+  ``aspect_extractor`` direct-chroma paths still need wiring to
+  the manifest — filed as follow-ups.
+
+### Known follow-ups
+
+- ``nexus-dxly`` (P0) — ``aspect_readers`` and ``aspect_extractor``
+  direct-chroma reassembly still needs manifest-based ordering.
+- ``nexus-w5zv`` (P1) — backfill paths write Phase-3 chunks at
+  position 0.
+- ``nexus-lrhg`` (P1) — atomicity wrap of manifest hook, chash
+  32/64-char normalisation, ``DocumentDeleted`` replay orphan
+  cleanup, ``event_log.py`` flock re-entrancy, staleness-cache
+  silent-fail.
+- ``nexus-lf8f`` (this bead, partial — store_put + projector
+  shipped, ``memory promote`` + ``store import`` deferred).
+
 ## [4.32.4] - 2026-05-12
 
 Patch on 4.32.3. Stops the silent data-correctness regression from

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.32.4",
+  "version": "4.32.5",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.32.5",
+  "version": "4.32.6",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.32.4"
+version = "4.32.5"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.32.5"
+version = "4.32.6"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.32.5",
+  "version": "4.32.6",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sn",
-  "version": "4.32.4",
+  "version": "4.32.5",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook."
 }

--- a/src/nexus/aspect_extractor.py
+++ b/src/nexus/aspect_extractor.py
@@ -834,6 +834,7 @@ def extract_aspects(
     *,
     lookup_path: str = "",
     doc_id_lookup: Callable[[str, str], str] | None = None,
+    manifest_lookup: Callable[[str], list[Any]] | None = None,
 ) -> AspectRecord | ExtractFail | None:
     """Synchronously extract aspects from ``content`` and return either
     a populated ``AspectRecord``, an :class:`ExtractFail` sentinel
@@ -902,7 +903,11 @@ def extract_aspects(
                 reason="infra_unavailable",
                 detail=f"get_t3 failed: {type(exc).__name__}: {exc}",
             )
-        result = read_source(uri, t3=t3, doc_id_lookup=doc_id_lookup)
+        result = read_source(
+            uri, t3=t3,
+            doc_id_lookup=doc_id_lookup,
+            manifest_lookup=manifest_lookup,
+        )
         if isinstance(result, ReadFail):
             _log.warning(
                 "aspect_extractor_source_unreadable",

--- a/src/nexus/aspect_readers.py
+++ b/src/nexus/aspect_readers.py
@@ -237,17 +237,42 @@ def _gather_chroma_chunks_by_field(
     source_id: str,
     identity_field: str,
     match_value: str,
+    manifest_lookup: Callable[[str], list[Any]] | None = None,
 ) -> ReadResult:
     """Page through ``coll.get(where={identity_field: match_value})`` and
-    return a ``ReadOk`` with chunks reassembled in ``chunk_index`` order
-    (insertion-sequence tiebreaker). ``ReadFail(reason='empty')`` when
-    no chunks match. Shared between the doc_id-keyed primary path
-    and the legacy multi-field probe.
+    return a ``ReadOk`` with chunks reassembled in canonical order.
+
+    nexus-8g79.2: When ``manifest_lookup`` is provided and
+    ``identity_field == 'doc_id'`` (so ``match_value`` is the catalog
+    tumbler), the canonical chunk order comes from
+    ``cat.get_manifest(doc_id)`` keyed by ``chash``. Post-RDR-108
+    Phase 3, chunk metadata no longer carries ``chunk_index``, so the
+    legacy ``md.get("chunk_index", 0)`` ordering collapses to position
+    zero for every chunk and only the insertion-sequence tiebreaker
+    survives — which is wrong for multi-chunk docs. The manifest is
+    authoritative; fall back to ``chunk_index`` (then to insertion
+    sequence) only when no manifest is available.
     """
     chunks: list[tuple[int, int, str]] = []
     seq = 0
     offset = 0
     page_limit = QUOTAS.MAX_QUERY_RESULTS
+    # Build chash → manifest position map when available.
+    chash_position: dict[str, int] = {}
+    if manifest_lookup is not None and identity_field == "doc_id":
+        try:
+            rows = manifest_lookup(match_value)
+        except Exception:
+            rows = []
+        for row in rows or []:
+            chash = getattr(row, "chash", None) or (
+                row.get("chash") if isinstance(row, dict) else None
+            )
+            position = getattr(row, "position", None)
+            if position is None and isinstance(row, dict):
+                position = row.get("position")
+            if chash and position is not None:
+                chash_position[chash] = int(position)
     try:
         while True:
             page = coll.get(
@@ -263,8 +288,15 @@ def _gather_chroma_chunks_by_field(
             for md, doc in zip(mds, docs):
                 if not doc:
                     continue
-                ci = md.get("chunk_index", 0) if isinstance(md, dict) else 0
-                chunks.append((int(ci), seq, doc))
+                if isinstance(md, dict):
+                    chash = md.get("chunk_text_hash", "")
+                    if chash_position and chash in chash_position:
+                        ci = chash_position[chash]
+                    else:
+                        ci = int(md.get("chunk_index", 0) or 0)
+                else:
+                    ci = 0
+                chunks.append((ci, seq, doc))
                 seq += 1
             if len(docs) < page_limit:
                 break
@@ -292,6 +324,7 @@ def _gather_chroma_chunks_by_field(
             "source_id": source_id,
             "identity_field": identity_field,
             "chunk_count": len(chunks),
+            "manifest_ordered": bool(chash_position),
         },
     )
 
@@ -301,6 +334,7 @@ def _read_chroma_uri(
     *,
     t3: Any = None,
     doc_id_lookup: Callable[[str, str], str] | None = None,
+    manifest_lookup: Callable[[str], list[Any]] | None = None,
     **_kw: Any,
 ) -> ReadResult:
     """Reassemble a document from chroma chunks.
@@ -384,6 +418,7 @@ def _read_chroma_uri(
         result = _gather_chroma_chunks_by_field(
             coll=coll, collection=collection, source_id=source_id,
             identity_field="doc_id", match_value=doc_id,
+            manifest_lookup=manifest_lookup,
         )
         if isinstance(result, ReadOk):
             return result
@@ -739,6 +774,7 @@ def read_source(
     t3: Any = None,
     scratch: Any = None,
     doc_id_lookup: Callable[[str, str], str] | None = None,
+    manifest_lookup: Callable[[str], list[Any]] | None = None,
 ) -> ReadResult:
     """Dispatch ``uri`` to its registered reader by scheme.
 
@@ -749,7 +785,11 @@ def read_source(
 
     ``doc_id_lookup`` (RDR-101 Phase 4 / nexus-o6aa.10.1) is forwarded
     to the chroma reader as the source-identifier → ``doc_id``
-    projection. Other readers ignore it.
+    projection. ``manifest_lookup`` (nexus-8g79.2) is forwarded as the
+    ``doc_id -> list[ManifestRow]`` projection so the chroma reader can
+    order multi-chunk docs by the catalog manifest's canonical
+    position rather than the dropped ``chunk_index`` metadata field.
+    Other readers ignore both.
     """
     if not uri:
         return ReadFail(reason="unreachable", detail="empty uri")
@@ -763,4 +803,8 @@ def read_source(
             reason="scheme_unknown",
             detail=f"no reader for scheme {scheme!r}",
         )
-    return reader(uri, t3=t3, scratch=scratch, doc_id_lookup=doc_id_lookup)
+    return reader(
+        uri, t3=t3, scratch=scratch,
+        doc_id_lookup=doc_id_lookup,
+        manifest_lookup=manifest_lookup,
+    )

--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -409,11 +409,21 @@ class AspectExtractionWorker:
                 if queued_doc_id
                 else None
             )
+            # nexus-8g79.2: manifest lookup gives the chroma reader the
+            # canonical chunk-order from document_chunks instead of the
+            # dropped chunk_index metadata field.
+            manifest_lookup = None
+            try:
+                from nexus.commands.enrich import _build_catalog_manifest_lookup
+                manifest_lookup = _build_catalog_manifest_lookup()
+            except Exception:
+                pass
             record = _extract_aspects(
                 content=row.content,
                 source_path=row.source_path,
                 collection=row.collection,
                 doc_id_lookup=doc_id_lookup,
+                manifest_lookup=manifest_lookup,
             )
         except Exception as exc:
             _log.warning(

--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -785,7 +785,14 @@ class Catalog:
                 if live_count > 0 and total_lines / live_count >= ratio:
                     return True
         except Exception:
-            pass
+            # nexus-8g79.5: pre-fix the bare ``except: pass`` silently
+            # disabled JSONL compaction whenever an exception fired
+            # (transient read error, permissions hiccup). The next call
+            # would re-try and might succeed, but a persistent error
+            # silently let the JSONL grow unbounded. Surface at WARNING
+            # so operators see the disablement; still return False so
+            # the sync path doesn't crash on a corrupt JSONL.
+            _log.warning("needs_compaction_check_failed", exc_info=True)
         return False
 
     def sync(self, message: str = "catalog update") -> None:

--- a/src/nexus/catalog/catalog_spans.py
+++ b/src/nexus/catalog/catalog_spans.py
@@ -287,13 +287,38 @@ def resolve_chash_globally(
     # ── T2 path ─────────────────────────────────────────────────────
     rows = chash_index.lookup(hex_chash)
     if rows:
+        # nexus-8g79.3: when T3 list_collections() fails transiently
+        # (network blip, quota, timeout) the pre-fix code defaulted
+        # ``live`` to the empty set, then the self-heal loop below
+        # treated EVERY row as stale and deleted them all — silently
+        # wiping the chash index across the whole prefix. The guarded
+        # delete_stale calls succeeded so no exception surfaced;
+        # subsequent span resolution then fell through to the full-
+        # collection scan fallback. Fail-loud-and-skip-cleanup is
+        # strictly safer than fail-quiet-and-purge: log at WARNING
+        # and return without touching the index.
         try:
             live = {c.name for c in t3.list_collections()}
+            list_failed = False
         except Exception:
+            _log.warning(
+                "chash_index_selfheal_skipped_list_collections_failed",
+                chash_prefix=hex_chash[:16],
+                exc_info=True,
+            )
+            # Skip self-heal this pass; treat every row as a survivor
+            # so span resolution still proceeds. A future call with a
+            # working T3 will reconcile. Pre-fix the bare
+            # ``except: live = set()`` purged every row from the chash
+            # index — catastrophic on a transient.
             live = set()
+            list_failed = True
         survivors: list[dict] = []
         for row in rows:
-            if row["collection"] in live:
+            if list_failed or row["collection"] in live:
+                # nexus-8g79.3: when list_collections() failed above
+                # we cannot tell stale from live, so every row is a
+                # provisional survivor and self-heal is skipped.
                 survivors.append(row)
             else:
                 # Go through the locked public API — this must not race
@@ -304,7 +329,7 @@ def resolve_chash_globally(
                         chash=hex_chash, collection=row["collection"],
                     )
                 except Exception:
-                    _log.debug(
+                    _log.warning(
                         "chash_index_selfheal_delete_failed",
                         chash_prefix=hex_chash[:16],
                         collection=row["collection"],

--- a/src/nexus/catalog/catalog_sync.py
+++ b/src/nexus/catalog/catalog_sync.py
@@ -705,6 +705,14 @@ class _SyncOps:
         except Exception:
             # On any unexpected failure, refuse the event-sourced
             # rebuild (safer to fall through to legacy than to wipe).
+            # nexus-8g79.6: surface at WARNING — pre-fix this returned
+            # False with no log, so a persistent error silently
+            # downgraded every startup to the slower legacy rebuild
+            # with no operator signal.
+            _log.warning(
+                "should_use_event_sourced_rebuild_failed",
+                exc_info=True,
+            )
             return False
 
     def rebuild(self) -> None:

--- a/src/nexus/catalog/catalog_writes.py
+++ b/src/nexus/catalog/catalog_writes.py
@@ -1081,6 +1081,13 @@ class _WriteOps:
                 cat._append_jsonl(cat._documents_path, tombstone)
             else:
                 cat._append_jsonl(cat._documents_path, tombstone)
+                # nexus-8g79.7: cascade-delete the manifest rows.
+                # Mirrors the event-sourced path in projector
+                # ``_v0_document_deleted``.
+                cat._db.execute(
+                    "DELETE FROM document_chunks WHERE doc_id = ?",
+                    (str(tumbler),),
+                )
                 cat._db.execute(
                     "DELETE FROM documents WHERE tumbler = ?",
                     (str(tumbler),),

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -336,6 +336,15 @@ class Projector:
         tumbler = payload.tumbler or payload.doc_id
         if not tumbler:
             return
+        # nexus-8g79.7: cascade-delete the document_chunks manifest
+        # rows. Pre-fix, deleting a document left orphan manifest rows
+        # forever (the schema has no FK with ON DELETE CASCADE; under
+        # FK=OFF replay the orphans then survived into the rebuilt
+        # SQLite). Manifest is keyed on doc_id == tumbler.
+        self._db.execute(
+            "DELETE FROM document_chunks WHERE doc_id = ?",
+            (tumbler,),
+        )
         self._db.execute(
             "DELETE FROM documents WHERE tumbler = ?",
             (tumbler,),

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -108,11 +108,34 @@ class Projector:
         outer ``with`` block commits or rolls back atomically and a
         nested commit would finalize the transaction prematurely,
         defeating the rollback fence.
+
+        Post-replay (nexus-lf8f): re-derive ``documents.chunk_count``
+        from ``document_chunks`` for every row. ``chunk_count`` is a
+        denormalised cache, not an event-sourced field — the
+        ``DocumentRegistered`` events carry the register-time snapshot
+        (typically ``0``) and would project as-is forever without this
+        re-derivation. Equivalent to running
+        ``Catalog.resync_chunk_count_cache(doc_id)`` for each document
+        in one set-based UPDATE.
         """
         applied = 0
         for event in events:
             self.apply(event)
             applied += 1
+        # nexus-lf8f: bulk chunk_count resync from document_chunks.
+        # Idempotent; safe to run even on a partial replay. Only
+        # touches rows that actually have manifest entries — docs
+        # without manifest rows keep whatever ``DocumentRegistered``
+        # carried (which lets callers set ``chunk_count`` explicitly
+        # via ``Catalog.update(chunk_count=N)`` and have replay honour
+        # that value).
+        self._db.execute(
+            "UPDATE documents SET chunk_count = ("
+            "SELECT COUNT(*) FROM document_chunks dc "
+            "WHERE dc.doc_id = documents.tumbler) "
+            "WHERE EXISTS (SELECT 1 FROM document_chunks dc "
+            "WHERE dc.doc_id = documents.tumbler)"
+        )
         if commit:
             self._db.commit()
         return applied

--- a/src/nexus/collection_audit.py
+++ b/src/nexus/collection_audit.py
@@ -182,17 +182,35 @@ def sample_live_distances(
     embeddings = embeddings_raw
 
     distances: list[float] = []
+    # nexus-8g79.8: pre-fix the bare ``continue`` silently dropped any
+    # query failure — operators saw a sparse/short histogram that
+    # looked identical to "healthy sparse collection". Count failures
+    # so they surface in the structured log + audit-result summary.
+    failed = 0
     for emb in embeddings:
         try:
             res = col.query(
                 query_embeddings=[emb], n_results=2, include=["distances"],
             )
         except Exception:
+            failed += 1
+            _log.debug(
+                "sample_live_distances_query_failed",
+                collection=collection, exc_info=True,
+            )
             continue
         d_rows = res.get("distances") or [[]]
         if not d_rows or not d_rows[0] or len(d_rows[0]) < 2:
             continue
         distances.append(float(d_rows[0][1]))
+    if failed > 0:
+        _log.warning(
+            "sample_live_distances_partial_failure",
+            collection=collection,
+            failed=failed,
+            sampled=len(embeddings),
+            surviving_distances=len(distances),
+        )
     return distances
 
 

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -23,6 +23,37 @@ import structlog
 _log = structlog.get_logger(__name__)
 
 
+def _build_catalog_manifest_lookup() -> Callable[[str], list[Any]] | None:
+    """nexus-8g79.2: build a ``manifest_lookup(doc_id) -> list[ManifestRow]``
+    callable backed by ``Catalog.get_manifest``.
+
+    The aspect/enrich chroma readers use this to reassemble chunks in
+    canonical position order via the catalog ``document_chunks`` table
+    rather than the dropped ``chunk_index`` chunk-metadata field.
+    Returns ``None`` when the catalog is uninitialized; the reader
+    falls back to ``chunk_index`` (post-Phase-3 this collapses to
+    insertion order, the pre-fix behaviour).
+    """
+    try:
+        from nexus.catalog import Catalog, open_cached
+        from nexus.config import catalog_path
+
+        cat_path = catalog_path()
+        if not Catalog.is_initialized(cat_path):
+            return None
+        cat = open_cached(cat_path)
+    except Exception:
+        return None
+
+    def _lookup(doc_id: str) -> list[Any]:
+        try:
+            return cat.get_manifest(doc_id)
+        except Exception:
+            return []
+
+    return _lookup
+
+
 def _build_catalog_doc_id_lookup() -> Callable[[str, str], str] | None:
     """Build a ``doc_id_lookup(collection, source_id) -> doc_id``
     callable backed by the catalog's ``physical_collection`` +
@@ -773,6 +804,9 @@ def _dry_run_predict_skips(
     # this projection so the dry-run reflects post-prune behavior. ``None``
     # falls back to the legacy probe (catalog absent / pre-Phase-3).
     doc_id_lookup = _build_catalog_doc_id_lookup()
+    # nexus-8g79.2: catalog manifest is authoritative for chunk position
+    # post-RDR-108 Phase 3 (chunk_index dropped from metadata).
+    manifest_lookup = _build_catalog_manifest_lookup()
 
     planned: dict[str, int] = {}
     skip_lines: list[str] = []
@@ -783,7 +817,11 @@ def _dry_run_predict_skips(
             continue
         uri = f"chroma://{collection}/{quote(sp, safe='/')}"
         try:
-            result = read_source(uri, t3=t3, doc_id_lookup=doc_id_lookup)
+            result = read_source(
+                uri, t3=t3,
+                doc_id_lookup=doc_id_lookup,
+                manifest_lookup=manifest_lookup,
+            )
         except Exception as exc:
             # Per-entry transient failure shouldn't abort the whole
             # prediction loop. Bucket under a synthetic ``read_error``
@@ -928,6 +966,8 @@ def _run_extraction(
     # in this collection. Built once outside the loop because the SQL
     # connection inside the helper is cheap-but-not-free per-call.
     doc_id_lookup = _build_catalog_doc_id_lookup()
+    # nexus-8g79.2: same — manifest_lookup is process-cached.
+    manifest_lookup = _build_catalog_manifest_lookup()
 
     db_path = default_db_path()
     with T2Database(db_path) as db:
@@ -951,6 +991,7 @@ def _run_extraction(
                 collection=collection,
                 lookup_path=_chroma_source_id_for_entry(entry),
                 doc_id_lookup=doc_id_lookup,
+                manifest_lookup=manifest_lookup,
             )
             if record is None:
                 # Defensive — select_config already passed at the parent

--- a/src/nexus/commands/memory.py
+++ b/src/nexus/commands/memory.py
@@ -229,6 +229,21 @@ def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None
         else:
             expires_at = ""  # permanent
 
+        # nexus-8g79.1: pre-register the catalog entry so the T3 chunk
+        # carries the resulting tumbler as ``doc_id`` at write-time and
+        # the manifest hook in fire_store_chains populates document_chunks
+        # + documents.chunk_count for this promotion. Without this, the
+        # promoted entry lands in T3 with no catalog identity — same
+        # regression class as nexus-zq79 / nexus-lf8f.
+        import hashlib
+        from nexus.commands.store import _catalog_store_hook
+        chunk_chroma_id = hashlib.sha256(entry["content"].encode()).hexdigest()[:32]
+        catalog_doc_id = _catalog_store_hook(
+            title=entry["title"],
+            doc_id=chunk_chroma_id,
+            collection_name=collection,
+        )
+
         with make_t3() as t3:
             doc_id = t3.put(
                 collection=collection,
@@ -237,13 +252,19 @@ def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None
                 tags=merged_tags,
                 ttl_days=ttl_days,
                 expires_at=expires_at,
+                catalog_doc_id=catalog_doc_id,
             )
 
         # nexus-9099: fire post-store chains so the promoted T3 row
         # reaches chash_index / taxonomy / aspect queue. RDR-095
         # symmetric-fire; this path was missed by the original commit.
+        # nexus-8g79.1: thread catalog_doc_id through so the manifest
+        # hook can populate document_chunks + chunk_count.
         from nexus.mcp_infra import fire_store_chains
-        fire_store_chains([doc_id], collection, [entry["content"]])
+        fire_store_chains(
+            [doc_id], collection, [entry["content"]],
+            catalog_doc_id=catalog_doc_id,
+        )
 
         if remove:
             db.delete(entry["project"], entry["title"])

--- a/src/nexus/commands/store.py
+++ b/src/nexus/commands/store.py
@@ -134,7 +134,16 @@ def put_cmd(
     # the original commit. doc_id is the source identity here (no
     # on-disk file at the CLI boundary, mirroring MCP store_put).
     from nexus.mcp_infra import fire_store_chains
-    fire_store_chains([doc_id], col_name, [content])
+    # nexus-lf8f: pass catalog_doc_id through to fire_store_chains so the
+    # manifest-write batch hook can populate document_chunks and
+    # documents.chunk_count for this CLI store path. Without it the
+    # hook short-circuits and the catalog row ships with chunk_count=0
+    # (the same regression class as nexus-zq79 / 4.32.4 fixed for
+    # `nx index repo`).
+    fire_store_chains(
+        [doc_id], col_name, [content],
+        catalog_doc_id=catalog_doc_id,
+    )
 
 
 def _catalog_store_hook(title: str, doc_id: str, collection_name: str) -> str:

--- a/src/nexus/context.py
+++ b/src/nexus/context.py
@@ -73,9 +73,25 @@ def _repo_collections(repo_path: Path | None) -> set[str] | None:
 
             colls.add(_repo_collection_or_legacy(repo_path, "rdr"))
         except Exception:
-            pass
+            # nexus-8g79.8: inner — recoverable, the rdr collection
+            # may legitimately not exist. DEBUG-with-exc_info so
+            # debugging surfaces it without flooding production logs.
+            import structlog
+            structlog.get_logger(__name__).debug(
+                "repo_collection_or_legacy_failed",
+                repo_path=str(repo_path),
+                exc_info=True,
+            )
         return colls if colls else None
     except Exception:
+        # nexus-8g79.8: outer — degrades the entire L1 context
+        # (taxonomy + collections) silently. WARNING because a
+        # recurring failure produces wrong LLM prompts with no signal.
+        import structlog
+        structlog.get_logger(__name__).warning(
+            "discover_repo_collections_failed",
+            exc_info=True,
+        )
         return None
 
 

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -1432,7 +1432,15 @@ def _catalog_markdown_hook(
                             year = int(dm.group(1))
                             break
         except Exception:
-            pass
+            # nexus-8g79.8: silent pass leaves title/year unset for the
+            # whole catalog entry — `nx catalog show` shows "" / 0.
+            # DEBUG-with-exc_info + path so a recurring permissions or
+            # encoding issue surfaces without aborting indexing.
+            import structlog
+            structlog.get_logger(__name__).debug(
+                "catalog_markdown_frontmatter_parse_failed",
+                path=str(md_path), exc_info=True,
+            )
 
         owner_name = corpus if corpus else "standalone-docs"
         # Curator-only lookup — see _register_or_lookup_doc_id for

--- a/src/nexus/exporter.py
+++ b/src/nexus/exporter.py
@@ -91,6 +91,53 @@ def _apply_remap(source_path: str, remaps: list[tuple[str, str]]) -> str:
     return source_path
 
 
+def _fire_store_chains_grouped_by_doc(
+    ids: list[str],
+    collection_name: str,
+    documents: list[str],
+    embeddings: list[list[float]],
+    metadatas: list[dict],
+) -> None:
+    """nexus-8g79.1: fire post-store chains per-doc so the manifest
+    hook can attribute chunks to the right catalog tumbler.
+
+    Pre-RDR-108-Phase-3 exports carry ``meta["doc_id"]`` per chunk
+    (the tumbler string was stored in chunk metadata at write-time).
+    Post-Phase-3 exports do NOT carry it; for those chunks the group
+    key is the empty string and the manifest hook short-circuits —
+    accepted limitation until export-format extension carries the
+    catalog manifest sidecar. The grouping handles the legacy path
+    correctly and degrades to the existing no-doc_id behaviour for
+    Phase-3 exports.
+
+    Records are partitioned by ``meta.get("doc_id", "")``; each group
+    fires its own ``fire_store_chains`` call with that group key as
+    ``catalog_doc_id`` so the manifest hook attributes the chunks
+    correctly. Insertion order within each group is preserved so
+    ``chunk_index`` re-injection sees a stable position.
+    """
+    from collections import defaultdict
+    from nexus.mcp_infra import fire_store_chains
+
+    groups: dict[str, list[int]] = defaultdict(list)
+    for i, m in enumerate(metadatas):
+        groups[(m or {}).get("doc_id", "")].append(i)
+
+    for doc_id_key, indices in groups.items():
+        sub_ids = [ids[i] for i in indices]
+        sub_docs = [documents[i] for i in indices]
+        sub_embs = [embeddings[i] for i in indices] if embeddings else None
+        sub_metas = [metadatas[i] for i in indices]
+        sub_paths = [(metadatas[i] or {}).get("source_path", "") for i in indices]
+        fire_store_chains(
+            sub_ids, collection_name, sub_docs,
+            source_paths=sub_paths,
+            embeddings=sub_embs,
+            metadatas=sub_metas,
+            catalog_doc_id=doc_id_key,
+        )
+
+
 def export_collection(
     db: "T3Database",
     collection_name: str,
@@ -381,16 +428,9 @@ def import_collection(
                         embeddings=embeddings,
                         metadatas=metadatas,
                     )
-                    # nexus-9099: fire post-store chains for the imported
-                    # batch (RDR-095 symmetric-fire; missed by the original
-                    # commit). source_path comes from the export metadata
-                    # so the document chain sees the original on-disk path.
-                    from nexus.mcp_infra import fire_store_chains
-                    fire_store_chains(
+                    _fire_store_chains_grouped_by_doc(
                         ids, collection_name, documents,
-                        source_paths=[m.get("source_path", "") for m in metadatas],
-                        embeddings=embeddings,
-                        metadatas=metadatas,
+                        embeddings, metadatas,
                     )
                     imported_count += len(ids)
                     _log.debug("import_batch_written", count=len(ids), total_so_far=imported_count)
@@ -405,12 +445,8 @@ def import_collection(
             embeddings=embeddings,
             metadatas=metadatas,
         )
-        from nexus.mcp_infra import fire_store_chains
-        fire_store_chains(
-            ids, collection_name, documents,
-            source_paths=[m.get("source_path", "") for m in metadatas],
-            embeddings=embeddings,
-            metadatas=metadatas,
+        _fire_store_chains_grouped_by_doc(
+            ids, collection_name, documents, embeddings, metadatas,
         )
         imported_count += len(ids)
 

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1542,10 +1542,25 @@ def _prune_misclassified_in_collection(
         # check (a code file's chunks living in docs__) works without
         # any per-chunk metadata.
         all_natural_ids: list[str] = []
+        # nexus-8g79.4: bare ``continue`` on get_manifest failure silently
+        # skipped doc_ids whose manifest lookup raised (catalog miss,
+        # transient SQLite error). Those chunks were then never pruned
+        # from T3 — over successive runs T3 grew with unreachable orphan
+        # chunks. Log at WARNING with the doc_id so operators see the
+        # affected scope; count for the post-run summary.
+        skipped_doc_ids: dict[str, str] = {}
         for did in doc_ids:
             try:
                 manifest = catalog.get_manifest(did)
-            except Exception:
+            except Exception as exc:
+                skipped_doc_ids[did] = f"{type(exc).__name__}: {exc}"
+                _log.warning(
+                    "prune_misclassified_manifest_lookup_failed",
+                    doc_id=did,
+                    collection=getattr(col, "name", "?"),
+                    kind=kind,
+                    exc_info=True,
+                )
                 continue
             for row in manifest:
                 if row.chash:
@@ -1559,6 +1574,16 @@ def _prune_misclassified_in_collection(
             try:
                 present = col.get(ids=batch_ids, include=[])
             except Exception:
+                # nexus-8g79.4: same class — log so a recurring chroma
+                # outage during prune doesn't hide silently behind a
+                # bare ``continue``.
+                _log.warning(
+                    "prune_misclassified_chroma_get_failed",
+                    collection=getattr(col, "name", "?"),
+                    kind=kind,
+                    batch_size=len(batch_ids),
+                    exc_info=True,
+                )
                 continue
             present_ids = present.get("ids") or []
             if present_ids:

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -325,7 +325,17 @@ def build_staleness_cache(col: object) -> StalenessCache:
                     if doc_ids:
                         chash_to_doc[c] = sorted(doc_ids)[0]
         except Exception:
-            pass
+            # nexus-8g79.8: pre-fix this swallowed the whole chash→doc_id
+            # resolution silently, leaving every result without doc_id
+            # in metadata (catalog-aware retrieval gated on doc_id then
+            # no-ops). WARNING with the chash count so a recurring
+            # catalog outage surfaces in production logs.
+            import structlog
+            structlog.get_logger(__name__).warning(
+                "docs_for_chashes_failed",
+                chash_count=len(needed_chashes),
+                exc_info=True,
+            )
 
     for meta in metadatas:
         if not meta:

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -1138,6 +1138,7 @@ def fire_store_chains(
     source_paths: list[str] | None = None,
     embeddings: list[list[float]] | None = None,
     metadatas: list[dict] | None = None,
+    catalog_doc_id: str = "",
 ) -> None:
     """Fire all three post-store hook chains for a batch of just-stored docs.
 
@@ -1165,11 +1166,25 @@ def fire_store_chains(
     metadatas:
         Optional metadata dicts per doc; forwarded to the batch chain.
         ``chash_dual_write_batch_hook`` reads from this.
+    catalog_doc_id:
+        nexus-lf8f: the catalog ``Document.tumbler`` for these chunks
+        (RDR-108 Phase 3). Post-Phase-3, chunk metadata no longer
+        carries ``doc_id`` so the manifest-write hook needs the tumbler
+        passed explicitly via this kwarg or it short-circuits silently
+        (the exact symptom nexus-zq79 fixed for the indexer paths in
+        4.32.4; this kwarg closes the same gap for the store-path
+        callers — MCP ``store_put``, ``nx store put``,
+        ``nx memory promote``, ``nx store import``). Default ``""``
+        preserves the legacy "no catalog identity" shape for callers
+        that genuinely have no tumbler (raw scratch writes pre-catalog
+        registration); those callers' chunks remain catalog-orphaned by
+        design.
     """
     n = len(doc_ids)
-    assert len(contents) == n, (
-        f"contents length {len(contents)} != doc_ids length {n}"
-    )
+    if len(contents) != n:
+        raise ValueError(
+            f"contents length {len(contents)} != doc_ids length {n}"
+        )
     if source_paths is None:
         source_paths = list(doc_ids)
     elif len(source_paths) != n:
@@ -1185,6 +1200,7 @@ def fire_store_chains(
     fire_post_store_batch_hooks(
         doc_ids, collection, contents,
         embeddings=embeddings, metadatas=metadatas,
+        catalog_doc_id=catalog_doc_id,
     )
 
     # Document-grain chain — once per (source_path, content).

--- a/src/nexus/operators/dispatch.py
+++ b/src/nexus/operators/dispatch.py
@@ -128,6 +128,15 @@ async def _drain_pipe(pipe: asyncio.StreamReader | None) -> bytes:
     try:
         return await pipe.read()
     except Exception:
+        # nexus-8g79.8: empty bytes is the right return shape (caller
+        # treats it as "no output"), but the silent swallow hides
+        # subprocess pipe failures (OOM kill, fd exhaustion, broken
+        # pipe). DEBUG-with-exc_info preserves the API contract while
+        # making the cause discoverable.
+        import structlog
+        structlog.get_logger(__name__).debug(
+            "operator_pipe_read_failed", exc_info=True,
+        )
         return b""
 
 

--- a/src/nexus/pipeline_buffer.py
+++ b/src/nexus/pipeline_buffer.py
@@ -210,7 +210,11 @@ class PipelineDB:
         if not fields:
             return
 
-        sets = ", ".join(f"{k} = ?" for k in fields)
+        # nexus-8g79.9: defense-in-depth — quote identifiers even though
+        # the allowlist already prevents injection today. Future allowlist
+        # additions that include a SQL keyword (e.g. ``order``) would
+        # break or inject without the explicit quoting.
+        sets = ", ".join(f'"{k}" = ?' for k in fields)
         vals = list(fields.values())
         vals.append(_now())
         vals.append(content_hash)

--- a/src/nexus/plans/matcher.py
+++ b/src/nexus/plans/matcher.py
@@ -298,7 +298,15 @@ def plan_match(
                 try:
                     cache.remove(plan_id)
                 except Exception:
-                    pass
+                    # nexus-8g79.8: a recurring removal failure causes
+                    # the stale row to be re-evicted on every match
+                    # call. DEBUG-with-exc_info + plan_id so the
+                    # repeat-offender is identifiable.
+                    import structlog
+                    structlog.get_logger(__name__).debug(
+                        "plan_cache_eviction_failed",
+                        plan_id=plan_id, exc_info=True,
+                    )
                 continue
             confidence = max(0.0, 1.0 - float(distance))
             if confidence < min_confidence:

--- a/src/nexus/search_engine.py
+++ b/src/nexus/search_engine.py
@@ -102,6 +102,16 @@ def _attach_doc_ids_from_catalog(
         return
     if not chash_to_docs:
         return
+    # nexus-lf8f: also stamp chunk_count + chunk_index from the catalog
+    # manifest. Post-Phase-3 chunk metadata no longer carries these
+    # fields; consumers (scoring.py file-size penalty, aspect_readers
+    # / aspect_extractor chunk reassembly) read them with stale defaults
+    # (chunk_count=1 means "no penalty", chunk_index=0 means "all
+    # chunks at position 0") leading to wrong rankings and wrong
+    # multi-chunk reassembly order. Batch-fetch manifests for every
+    # distinct doc_id so each search hit pays one catalog query
+    # amortised, not one per result.
+    resolved_doc_ids: dict[str, str] = {}  # chash -> doc_id
     for r, chash in zip(results, chashes):
         if not chash:
             continue
@@ -110,6 +120,7 @@ def _attach_doc_ids_from_catalog(
         # The manifest lookup is the FALLBACK for chunks where the
         # field is absent, not an override.
         if r.metadata.get("doc_id"):
+            resolved_doc_ids[chash] = r.metadata["doc_id"]
             continue
         docs = chash_to_docs.get(chash, [])
         if docs:
@@ -118,6 +129,37 @@ def _attach_doc_ids_from_catalog(
             # the first deterministically; downstream consumers that
             # need finer disambiguation can re-query the manifest.
             r.metadata["doc_id"] = docs[0]
+            resolved_doc_ids[chash] = docs[0]
+
+    # Per-doc manifest cache so multi-chunk docs only fetch once.
+    manifest_cache: dict[str, list[Any]] = {}
+    for r, chash in zip(results, chashes):
+        if not chash:
+            continue
+        doc_id = resolved_doc_ids.get(chash) or r.metadata.get("doc_id", "")
+        if not doc_id:
+            continue
+        manifest = manifest_cache.get(doc_id)
+        if manifest is None:
+            try:
+                manifest = catalog.get_manifest(doc_id)
+            except Exception:
+                _log.debug(
+                    "attach_chunk_count_lookup_failed",
+                    doc_id=doc_id, exc_info=True,
+                )
+                manifest = []
+            manifest_cache[doc_id] = manifest
+        if not manifest:
+            continue
+        # Only inject when absent (legacy chunks may have these).
+        if "chunk_count" not in r.metadata:
+            r.metadata["chunk_count"] = len(manifest)
+        if "chunk_index" not in r.metadata:
+            for row in manifest:
+                if getattr(row, "chash", "") == chash:
+                    r.metadata["chunk_index"] = int(getattr(row, "position", 0))
+                    break
 
 
 def _attach_display_paths(

--- a/tests/test_aspect_readers.py
+++ b/tests/test_aspect_readers.py
@@ -281,6 +281,66 @@ class TestReadChromaUri:
         assert result.text == "first\n\nsecond\n\nthird"
         assert result.metadata["chunk_count"] == 3
 
+    def test_manifest_lookup_overrides_chunk_index_for_phase3_chunks(self, t3_client):
+        """nexus-8g79.2: post-RDR-108 P3 chunks have no chunk_index in
+        metadata (cargo-filtered) so md.get('chunk_index', 0) collapses
+        every chunk to position 0 and only the insertion-sequence
+        tiebreaker survives. When manifest_lookup is provided the
+        reader must use catalog manifest positions (keyed on chash)
+        instead, so multi-chunk docs reassemble in canonical order even
+        when chunk_index is absent.
+        """
+        from nexus.aspect_readers import ReadOk, _read_chroma_uri
+
+        # Seed three chunks with NO chunk_index (Phase-3 shape), and
+        # chunk_text_hash values that the manifest_lookup will map to
+        # canonical positions. Insert in reversed order so the
+        # insertion-sequence tiebreaker would yield the wrong text if
+        # the manifest weren't authoritative.
+        col_name = "code__phase3-manifest"
+        col = t3_client.get_or_create_collection(col_name)
+        col.upsert(
+            ids=["c-x", "c-y", "c-z"],
+            documents=["third", "second", "first"],
+            metadatas=[
+                {"doc_id": "1.99.1", "chunk_text_hash": "zzz" + "0" * 61},
+                {"doc_id": "1.99.1", "chunk_text_hash": "yyy" + "0" * 61},
+                {"doc_id": "1.99.1", "chunk_text_hash": "xxx" + "0" * 61},
+            ],
+        )
+
+        # Fake manifest_lookup: chash -> position (canonical).
+        from dataclasses import dataclass
+
+        @dataclass
+        class _Row:
+            chash: str
+            position: int
+
+        def manifest_lookup(doc_id: str) -> list[_Row]:
+            assert doc_id == "1.99.1"
+            return [
+                _Row(chash="xxx" + "0" * 61, position=0),
+                _Row(chash="yyy" + "0" * 61, position=1),
+                _Row(chash="zzz" + "0" * 61, position=2),
+            ]
+
+        def doc_id_lookup(_coll: str, _sid: str) -> str:
+            return "1.99.1"
+
+        result = _read_chroma_uri(
+            f"chroma://{col_name}/anything",
+            t3=t3_client,
+            doc_id_lookup=doc_id_lookup,
+            manifest_lookup=manifest_lookup,
+        )
+        assert isinstance(result, ReadOk), result
+        # Manifest-ordered: positions 0,1,2 → first,second,third.
+        # Without the fix, insertion-sequence tiebreaker would yield
+        # 'third\n\nsecond\n\nfirst' (insertion order with all ci=0).
+        assert result.text == "first\n\nsecond\n\nthird"
+        assert result.metadata["manifest_ordered"] is True
+
     def test_no_matching_chunks_returns_read_fail_empty(self, t3_client):
         from nexus.aspect_readers import ReadFail, _read_chroma_uri
 

--- a/tests/test_catalog_event_sourced_mutators.py
+++ b/tests/test_catalog_event_sourced_mutators.py
@@ -209,6 +209,79 @@ class TestDeleteDocumentEventSourced:
         ).fetchone()
         assert rows[0] == 0
 
+    def test_delete_cascades_to_document_chunks(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """nexus-8g79.7: deleting a document must purge its
+        document_chunks manifest rows in the same write — pre-fix the
+        manifest was left as FK orphans because the schema has no
+        ON DELETE CASCADE and the projector handler only DELETEd from
+        documents.
+        """
+        monkeypatch.setenv("NEXUS_EVENT_SOURCED", "1")
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(owner, "doc.md", content_type="prose")
+        # Plant 3 manifest rows via the public API.
+        cat.append_manifest_chunks(
+            str(tumbler),
+            [
+                {
+                    "position": i, "chash": f"ch{i}",
+                    "chunk_index": i,
+                    "line_start": None, "line_end": None,
+                    "char_start": None, "char_end": None,
+                }
+                for i in range(3)
+            ],
+        )
+        assert len(cat.get_manifest(str(tumbler))) == 3
+
+        assert cat.delete_document(tumbler) is True
+
+        # documents row gone AND document_chunks rows gone.
+        doc_count = cat._db.execute(
+            "SELECT count(*) FROM documents WHERE tumbler = ?",
+            (str(tumbler),),
+        ).fetchone()[0]
+        chunk_count = cat._db.execute(
+            "SELECT count(*) FROM document_chunks WHERE doc_id = ?",
+            (str(tumbler),),
+        ).fetchone()[0]
+        assert doc_count == 0
+        assert chunk_count == 0, (
+            "delete_document must cascade-purge document_chunks; pre-fix "
+            f"this left {chunk_count} orphan rows."
+        )
+
+    def test_delete_cascades_to_document_chunks_legacy_path(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """nexus-8g79.7: same cascade for the non-event-sourced path."""
+        monkeypatch.delenv("NEXUS_EVENT_SOURCED", raising=False)
+        d = tmp_path / "catalog"
+        d.mkdir()
+        cat = Catalog(d, d / ".catalog.db")
+        owner = cat.register_owner("nexus", "repo", repo_hash="abab")
+        tumbler = cat.register(owner, "doc.md", content_type="prose")
+        cat.append_manifest_chunks(
+            str(tumbler),
+            [{"position": 0, "chash": "ch0", "chunk_index": 0,
+              "line_start": None, "line_end": None,
+              "char_start": None, "char_end": None}],
+        )
+        assert len(cat.get_manifest(str(tumbler))) == 1
+
+        assert cat.delete_document(tumbler) is True
+
+        chunk_count = cat._db.execute(
+            "SELECT count(*) FROM document_chunks WHERE doc_id = ?",
+            (str(tumbler),),
+        ).fetchone()[0]
+        assert chunk_count == 0
+
 
 # ── set_alias ────────────────────────────────────────────────────────────
 

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.32.5"
+version = "4.32.6"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.32.4"
+version = "4.32.5"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Closes the 7 Tier-1 silent-fail findings from the 2026-05-12 multi-agent audit. **None are data-loss class** — every one is a silent degradation where a recurring error returns safe-looking state (empty set / False / b\"\" / default) so the broken behaviour is indistinguishable from healthy in logs.

Stacked on PR #701 (4.32.5). Merge after 4.32.5 lands; the diff against main will include both releases' commits.

## What's fixed

### Bugs
- **`catalog_spans.py:290`** (`nexus-8g79.3`): pre-fix `except: live = set()` on T3 `list_collections` failure made every row look stale; the self-heal loop then DELETEd them all from the chash index. Now logs at WARNING and skips self-heal entirely on transient — every row stays a provisional survivor.
- **`Catalog.delete_document` FK cascade** (`nexus-8g79.7`): pre-fix only `DELETE FROM documents` ran, leaving orphan `document_chunks` rows that survived even after event-sourced replay. Both projector and legacy paths now cascade.
- **`indexer.py:1547` prune-misclassified** (`nexus-8g79.4`): pre-fix bare `continue` on `get_manifest` failure left T3 chunks un-pruned indefinitely. WARNING on both the manifest-lookup and `col.get` failure paths.
- **`catalog.py:_needs_compaction`** (`nexus-8g79.5`): pre-fix silent return-False disabled JSONL compaction forever on persistent error. WARNING + exc_info.
- **`catalog_sync.py:_should_use_event_sourced_rebuild`** (`nexus-8g79.6`): same shape — silent return-False downgraded every startup to legacy rebuild without operator signal. WARNING + exc_info.
- **`pipeline_buffer.update_progress`** (`nexus-8g79.9`): defense-in-depth `\"col\" = ?` identifier quoting against future allowlist entries that collide with SQL keywords (e.g. `order`).

### Discipline pass (`nexus-8g79.8`) — 8 silent-fail sites
| File:line | Level | Why |
|---|---|---|
| `indexer_utils.py:317` | WARNING | `docs_for_chashes` failure silently broke catalog-aware retrieval |
| `context.py:71/78` | DEBUG inner + WARNING outer | L1 context collection-discovery |
| `operators/dispatch.py:128` | DEBUG | subprocess pipe-read failure invisible |
| `plans/matcher.py:298` | DEBUG + plan_id | plan-cache eviction failure |
| `doc_indexer.py:1434` | DEBUG + path | frontmatter parse failure left title/year unset |
| `collection_audit.py:186` | WARNING + failed-count | partial NN query failures produced sparse-looking histograms |

## Tests
**532 pass** across touched suites. Two new regression tests in `test_catalog_event_sourced_mutators.py` assert `delete_document` cascades to `document_chunks` on both event-sourced and legacy paths.

## Closes

- Closes #nexus-8g79.3 — catalog_spans wipe
- Closes #nexus-8g79.4 — indexer prune orphan
- Closes #nexus-8g79.5 — _needs_compaction silent disable
- Closes #nexus-8g79.6 — rebuild refusal silent
- Closes #nexus-8g79.7 — delete_document FK cascade
- Closes #nexus-8g79.8 — 10 silent-fail patterns
- Closes #nexus-8g79.9 — SQL column quoting defense-in-depth

## Test plan

- [x] 532 touched-suite tests pass
- [x] Lint gate (`test_no_direct_catalog_writes_outside_projector`) clean
- [ ] CI green on PR
- [ ] Sandbox smoke before tag
- [ ] Merge after 4.32.5 lands