### PR TITLE
refactor(aspect): RDR-096 P5.1 batch path migration (4.32.9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,13 +9,13 @@
       "name": "nx",
       "source": "./nx",
       "description": "Self-hosted three-tier knowledge management with 13 specialized agents, plan-centric retrieval via nx_answer, semantic search, and RDR decision tracking for Claude Code.",
-      "version": "4.32.8"
+      "version": "4.32.9"
     },
     {
       "name": "sn",
       "source": "./sn",
       "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
-      "version": "4.32.8"
+      "version": "4.32.9"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,62 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.32.9] - 2026-05-12
+
+Patch on 4.32.8. Audit follow-up: RDR-096 P5.1 aspect_worker
+batch path migration (nexus-8g79.34). Closes the RDR-096 P5
+deprecation cycle.
+
+### Refactored (nexus-8g79.34)
+
+- **``extract_aspects_batch`` return type widened** from
+  ``list[AspectRecord | None]`` to
+  ``list[AspectRecord | ExtractFail | None]``. Mirrors the
+  single-doc ``extract_aspects`` contract introduced in RDR-096
+  P1.2. Pre-fix, batch rows with un-sourceable content landed as
+  null-fields ``AspectRecord`` (polluting operator SQL fast paths);
+  post-fix they land as typed ``ExtractFail`` and the worker
+  ``mark_done``s without writing a row.
+- **Per-row URI-based content sourcing moved INTO
+  ``extract_aspects_batch``**. Empty-content rows now route through
+  :func:`nexus.aspect_readers.read_source` with a
+  ``chroma://<collection>/<source_path>`` URI — the same path
+  single-doc takes. Per-row ``doc_id_lookup`` built from the
+  queue-captured ``doc_id`` (nexus-tdgc) so chunk attribution stays
+  correct. New ``manifest_lookup`` kwarg passes through to the
+  chroma reader for canonical position ordering (4.32.5's
+  nexus-8g79.2 plumbing).
+- **Items tuple extended** to a 4-tuple
+  ``(collection, source_path, content, doc_id)``. Back-compat
+  preserved: 3-tuple callers continue to work (``doc_id`` defaults
+  to ``""``, falling back to source_path identity probe).
+- **``aspect_worker._process_batch`` rewritten**: deleted the
+  pre-fetch block (``_source_content_from_t3`` + disk fallback
+  dance, ~30 lines). Worker now passes raw queue rows in 4-tuple
+  form; ``extract_aspects_batch`` owns sourcing. ``ExtractFail``
+  rows handled with ``mark_done`` (mirrors ``_process_row``).
+- **``_source_content_from_t3`` shim deleted** from
+  ``aspect_extractor.py``. The ``warnings.warn(DeprecationWarning,
+  "Slated for removal in RDR-096 Phase 5")`` is gone. The
+  ``_T3_CONTENT_CAP_BYTES`` constant deleted with it.
+
+### Tests
+
+New regression test
+``test_batch_empty_content_uri_read_fail_yields_extract_fail``
+locks the new contract: empty-content row with ``read_source``
+returning ``ReadFail`` produces ``ExtractFail`` in the
+corresponding slot (not ``_empty_record``). Existing 3 batch
+tests' ``fake_batch`` shims extended to accept kwargs +
+``*_args``; existing 3-tuple input form preserved via the
+normalisation step.
+
+### Result
+
+The single-doc and batch aspect extraction paths now share the
+same content-sourcing contract. Behavioural divergence between
+the two is eliminated; deprecation cycle closes.
+
 ## [4.32.8] - 2026-05-12
 
 Patch on 4.32.7. Audit follow-up: layering violations

--- a/nx/.claude-plugin/plugin.json
+++ b/nx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nx",
-  "version": "4.32.8",
+  "version": "4.32.9",
   "description": "Self-hosted three-tier knowledge management with plan-centric retrieval (nx_answer), specialized agents, semantic search, and RDR decision tracking for Claude Code.",
   "author": {
     "name": "Hal Hildebrand",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "conexus"
-version = "4.32.8"
+version = "4.32.9"
 description = "Self-hosted semantic search and knowledge management for LLM-driven development"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.12,<3.14"

--- a/sn/.claude-plugin/plugin.json
+++ b/sn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sn",
-  "version": "4.32.8",
+  "version": "4.32.9",
   "description": "Injects Serena and Context7 MCP tool usage guidance into subagents via SubagentStart hook.",
   "author": {
     "name": "Hal Hildebrand",

--- a/src/nexus/aspect_extractor.py
+++ b/src/nexus/aspect_extractor.py
@@ -79,6 +79,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from urllib.parse import quote
 
 import structlog
@@ -698,131 +699,6 @@ _SCHOLARLY_SECTIONS = frozenset({
     "",
 })
 
-# Cap on the joined T3 content forwarded to the extractor. ~80 KB
-# accommodates a 14-page paper's relevant sections while leaving
-# generous headroom under the prompt budget. The extractor prompt
-# itself is now stdin-fed (see _invoke_once below) so this cap exists
-# for cost / latency / context-window reasons, not OS argv limits.
-_T3_CONTENT_CAP_BYTES = 80_000
-
-
-def _source_content_from_t3(collection: str, source_path: str) -> str:
-    """Reassemble the source document's text from T3 chunks, preferring
-    section-scoped chunks for scholarly papers.
-
-    .. deprecated:: RDR-096 P1.2 (2026-04-27)
-
-       ``extract_aspects`` no longer calls this function — it routes
-       through :func:`nexus.aspect_readers.read_source` with a
-       ``chroma://<collection>/<source_path>`` URI instead. The
-       function is retained as a deprecation shim for the worker's
-       batch-path pre-fetch (``aspect_worker._process_batch``) until
-       the worker migrates to ``read_source`` in a follow-up bead;
-       slated for removal in Phase 5 of RDR-096.
-
-    Returns an empty string on any failure (catalog lookup miss, T3
-    error, no chunks). Callers must treat the empty return as a signal
-    to fall back to disk read.
-
-    Routing notes:
-
-    * For ``knowledge__*`` collections the result is filtered to
-      :data:`_SCHOLARLY_SECTIONS` and capped at
-      :data:`_T3_CONTENT_CAP_BYTES`. This is the path that drove the
-      whole change: we previously slurped 14 pages of dense text into
-      argv.
-    * For other collections the full document is reassembled (no
-      filter). The cap still applies as a defensive bound.
-
-    The function is best-effort by design — every failure path returns
-    ``""`` and the caller falls back to the disk read. We don't want
-    the aspect extractor to crash because T3 is briefly unavailable.
-    """
-    import warnings  # noqa: PLC0415
-    warnings.warn(
-        "nexus.aspect_extractor._source_content_from_t3 is deprecated; "
-        "callers should migrate to nexus.aspect_readers.read_source with "
-        "a chroma:// URI. Slated for removal in RDR-096 Phase 5.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    try:
-        from nexus.db.t3 import T3Database  # noqa: PLC0415
-
-        # Bare constructor — credential fallback (chroma_tenant/database/api_key)
-        # comes from nexus.config via get_credential(); no positional args.
-        with T3Database() as t3:
-            try:
-                coll = t3.get_or_create_collection(collection)
-            except Exception:
-                # CloudClient raises on missing collection; treat as
-                # "no chunks" so the disk fallback can run.
-                return ""
-            from nexus.db.chroma_quotas import QUOTAS  # noqa: PLC0415
-
-            # Page through all chunks for this source. QUOTAS.MAX_QUERY_RESULTS
-            # caps the per-call limit; documents with more chunks than
-            # the cap are paginated. 300 (current cap) covers ~450 KB
-            # of chunked text per page — a single page suffices for
-            # all but the longest scholarly papers.
-            collected: list[tuple[int, str, str]] = []  # (chunk_index, section_type, text)
-            offset = 0
-            page_limit = QUOTAS.MAX_QUERY_RESULTS
-            while True:
-                got = coll.get(
-                    where={"source_path": source_path},
-                    include=["documents", "metadatas"],
-                    limit=page_limit,
-                    offset=offset,
-                )
-                docs = got.get("documents") or []
-                mds = got.get("metadatas") or []
-                if not docs:
-                    break
-                for md, doc in zip(mds, docs):
-                    if not doc:
-                        continue
-                    ci = md.get("chunk_index", 0) if isinstance(md, dict) else 0
-                    st = md.get("section_type", "") if isinstance(md, dict) else ""
-                    collected.append((int(ci), str(st), doc))
-                if len(docs) < page_limit:
-                    break
-                offset += page_limit
-
-            if not collected:
-                return ""
-
-            collected.sort(key=lambda x: x[0])
-            if collection.startswith("knowledge__"):
-                kept = [
-                    (ci, st, txt) for ci, st, txt in collected
-                    if st in _SCHOLARLY_SECTIONS
-                ]
-                # If section filtering nuked everything (heading detection
-                # failed entirely on this document), fall back to all
-                # chunks rather than returning "" — better degraded
-                # extraction than no extraction.
-                if not kept:
-                    kept = collected
-            else:
-                kept = collected
-
-            joined = "\n\n".join(txt for _, _, txt in kept)
-            if len(joined.encode("utf-8", errors="replace")) > _T3_CONTENT_CAP_BYTES:
-                # Truncate at byte boundary (decoded back with errors=ignore)
-                # so the cap isn't broken by a multi-byte UTF-8 split.
-                joined = joined.encode("utf-8", errors="replace")[:_T3_CONTENT_CAP_BYTES]\
-                    .decode("utf-8", errors="ignore")
-            return joined
-    except Exception:
-        _log.debug(
-            "aspect_extractor_t3_source_failed",
-            collection=collection,
-            source_path=source_path,
-            exc_info=True,
-        )
-        return ""
-
 
 # ── Extraction core ──────────────────────────────────────────────────────────
 
@@ -970,17 +846,31 @@ _BATCH_TIMEOUT_PER_EXTRA_PAPER_S = 60
 
 
 def extract_aspects_batch(
-    items: list[tuple[str, str, str]],
-) -> list[AspectRecord | None]:
+    items: list[tuple[str, str, str]] | list[tuple[str, str, str, str]],
+    *,
+    doc_id_lookup: Callable[[str, str], str] | None = None,
+    manifest_lookup: Callable[[str], list[Any]] | None = None,
+) -> list[AspectRecord | ExtractFail | None]:
     """Synchronously extract aspects for N papers in ONE Claude call.
 
-    Each input tuple is ``(collection, source_path, content)``. Returns
-    a list aligned with input order: ``AspectRecord`` per paper on
-    success, ``None`` for papers whose collection has no registered
-    extractor (the batch only covers a single registered config — see
-    grouping note below), or a null-fields ``AspectRecord`` for
-    papers whose individual extraction failed even though the batch
-    as a whole succeeded.
+    Each input tuple is ``(collection, source_path, content)`` or, with
+    RDR-096 P5.1 (nexus-8g79.34), the 4-tuple
+    ``(collection, source_path, content, doc_id)``. The 4-tuple form
+    captures the per-row catalog tumbler so empty-content rows can
+    route through URI-based reading with correct chunk attribution
+    (mirroring the single-doc ``extract_aspects`` path's contract).
+    Returns a list aligned with input order:
+
+    * ``AspectRecord`` — populated record on success, or null-fields
+      record on subprocess-side failure that the extractor already
+      retried up to 3 times internally.
+    * ``ExtractFail`` (RDR-096 P5.1) — typed read-failure sentinel
+      when an empty-content row could not be sourced via
+      ``chroma://`` URI. Mirrors the single-doc path's
+      ``ExtractFail`` contract so the worker can ``mark_done`` and
+      move on without writing a row.
+    * ``None`` — collection has no registered extractor (the caller
+      should not have included such items; preserved for back-compat).
 
     Cost amortisation: one ``claude -p`` call extracts N papers,
     sharing the model's per-call overhead (system prompt, response
@@ -997,13 +887,15 @@ def extract_aspects_batch(
     paper whose collection has no config (the caller should not
     have included such papers).
 
-    Empty-content fallback: papers with ``content=""`` are read
-    from disk by the worker before this function is called; this
-    function does NOT do its own source-path reading. If a paper's
-    ``content`` is empty when this runs, it lands in the null-
-    fields output without invoking the subprocess for that paper.
-    The single-paper ``extract_aspects`` (above) keeps the disk-
-    read fallback for the simpler call path.
+    Empty-content sourcing (RDR-096 P5.1, nexus-8g79.34): rows with
+    ``content=""`` route through
+    :func:`nexus.aspect_readers.read_source` with a
+    ``chroma://<collection>/<source_path>`` URI — the same path the
+    single-doc ``extract_aspects`` takes. Read failures land as
+    ``ExtractFail`` in the corresponding slot of the output list.
+    Pre-P5.1 the worker pre-fetched content via the deprecated
+    ``_source_content_from_t3`` + disk fallback dance; that shim is
+    deleted with this migration.
 
     Subprocess + retry semantics mirror the single-paper path:
     transient failures retry up to 3 times with exponential
@@ -1014,11 +906,23 @@ def extract_aspects_batch(
     if not items:
         return []
 
+    # Normalise to 4-tuple shape internally. Items passed as 3-tuples
+    # default doc_id to "" — the manifest_lookup path then bypasses
+    # the per-row catalog attribution and the read still works via
+    # source_path identity probe.
+    normalised: list[tuple[str, str, str, str]] = []
+    for item in items:
+        if len(item) == 3:
+            collection, source_path, content = item  # type: ignore[misc]
+            normalised.append((collection, source_path, content, ""))
+        else:
+            normalised.append(item)  # type: ignore[arg-type]
+
     # Group by ExtractorConfig (allows future multi-config batches; for
     # Phase D ships single-config support — multi-config raises).
     config = None
-    out: list[AspectRecord | None] = [None] * len(items)
-    for idx, (collection, _source_path, _content) in enumerate(items):
+    out: list[AspectRecord | ExtractFail | None] = [None] * len(normalised)
+    for idx, (collection, _source_path, _content, _doc_id) in enumerate(normalised):
         item_config = select_config(collection)
         if item_config is None:
             out[idx] = None
@@ -1035,36 +939,63 @@ def extract_aspects_batch(
         # Every item was unsupported.
         return out
 
-    # Filter to only items with a valid config; remember their original
-    # index so we can splice results back into the right slots.
-    indexed_inputs: list[tuple[int, str, str, str]] = [
-        (i, items[i][0], items[i][1], items[i][2])
-        for i in range(len(items))
-        if out[i] is not None or select_config(items[i][0]) is not None
-    ]
-    # The above simplifies to "all items where config is not None":
-    indexed_inputs = [
-        (i, items[i][0], items[i][1], items[i][2])
-        for i in range(len(items))
-        if select_config(items[i][0]) is not None
+    indexed_inputs: list[tuple[int, str, str, str, str]] = [
+        (i, normalised[i][0], normalised[i][1], normalised[i][2], normalised[i][3])
+        for i in range(len(normalised))
+        if select_config(normalised[i][0]) is not None
     ]
 
-    # Per-paper empty-content guard.
+    # nexus-8g79.34: per-row URI-based content sourcing for empty-
+    # content rows. Mirrors the single-doc path's pattern at
+    # extract_aspects:882-920.
     callable_inputs: list[tuple[int, str, str, str]] = []
-    for idx, collection, source_path, content in indexed_inputs:
+    t3_handle: Any = None  # lazy: only construct when we actually need to read
+    for idx, collection, source_path, content, queue_doc_id in indexed_inputs:
         if not content:
-            _log.warning(
-                "aspect_extractor_batch_empty_content",
-                source_path=source_path,
-                collection=collection,
-                detail=(
-                    "batch path received empty content; per-paper file "
-                    "read is the worker's responsibility before invoking "
-                    "this function. Recording null-fields and skipping."
-                ),
+            uri = f"chroma://{collection}/{quote(source_path, safe='/')}"
+            if t3_handle is None:
+                try:
+                    t3_handle = get_t3()
+                except Exception as exc:
+                    _log.warning(
+                        "aspect_extractor_batch_t3_unavailable",
+                        uri=uri,
+                        error=str(exc),
+                    )
+                    out[idx] = ExtractFail(
+                        uri=uri,
+                        reason="infra_unavailable",
+                        detail=f"get_t3 failed: {type(exc).__name__}: {exc}",
+                    )
+                    continue
+            # Per-row doc_id_lookup: prefer the queue-captured doc_id
+            # (nexus-tdgc) so the chroma reader routes to the doc_id-
+            # keyed chunk lookup without re-querying the catalog.
+            # Falls back to the caller-supplied lookup if no queue
+            # doc_id is present.
+            row_doc_id_lookup: Callable[[str, str], str] | None
+            if queue_doc_id:
+                row_doc_id_lookup = (lambda _coll, _sid, _d=queue_doc_id: _d)
+            else:
+                row_doc_id_lookup = doc_id_lookup
+            result = read_source(
+                uri, t3=t3_handle,
+                doc_id_lookup=row_doc_id_lookup,
+                manifest_lookup=manifest_lookup,
             )
-            out[idx] = _empty_record(source_path, collection, config)
-            continue
+            if isinstance(result, ReadFail):
+                _log.warning(
+                    "aspect_extractor_batch_source_unreadable",
+                    uri=uri,
+                    reason=result.reason,
+                    detail=result.detail,
+                )
+                out[idx] = ExtractFail(
+                    uri=uri, reason=result.reason, detail=result.detail,
+                )
+                continue
+            assert isinstance(result, ReadOk)
+            content = result.text
         # Defensive null-byte strip (matches single-paper path).
         content = content.replace("\x00", "")
         callable_inputs.append((idx, collection, source_path, content))

--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -285,19 +285,13 @@ class AspectExtractionWorker:
         """Run batch extraction on multiple queue rows in one
         Claude call. RDR-089 Phase D — cost-amortised drain.
 
-        Each row's content was captured at enqueue time when in scope.
-        CLI rows with empty content get a per-row source-path read
-        before the batch call (the batch extractor itself does NOT
-        do disk reads — that responsibility lives here so the
-        extractor stays a pure function of its inputs).
+        Each row's content was captured at enqueue time when in
+        scope. CLI rows with empty content are sourced via
+        ``chroma://`` URI inside ``extract_aspects_batch`` (RDR-096
+        P5.1 / nexus-8g79.34 — the batch path now mirrors the
+        single-doc extractor's read contract).
         """
-        from pathlib import Path
-
-        from nexus.aspect_extractor import (
-            _source_content_from_t3,
-            extract_aspects_batch,
-            select_config,
-        )
+        from nexus.aspect_extractor import select_config
         from nexus.mcp_infra import t2_ctx
 
         # extract_aspects_batch requires every input to share a single
@@ -316,42 +310,25 @@ class AspectExtractionWorker:
                 self._process_row(row)
             return
 
-        # Per-row content source: prefer queued content, fall back to
-        # T3 reassembly (same text we indexed; section-filtered for
-        # scholarly papers), then to disk read as last resort. Mirrors
-        # the single-doc path in extract_aspects so batch and single
-        # share the same sourcing precedence.
-        #
-        # TODO(RDR-096 P5.1): adopt URI-based read_source + ExtractFail
-        # in this batch path. The single-doc path migrated in P1.2;
-        # the batch path still uses the deprecated _source_content_from_t3
-        # + disk fallback because extract_aspects_batch returns
-        # _empty_record on missing content rather than ExtractFail.
-        # When the batch return type widens, this pre-fetch block can
-        # delete itself in favour of read_source per row.
-        items: list[tuple[str, str, str]] = []
-        for row in rows:
-            content = row.content
-            if not content:
-                content = _source_content_from_t3(row.collection, row.source_path)
-            if not content:
-                try:
-                    content = Path(row.source_path).read_text(
-                        encoding="utf-8", errors="replace",
-                    )
-                except (OSError, UnicodeDecodeError) as exc:
-                    _log.warning(
-                        "aspect_worker_batch_source_path_unreadable",
-                        source_path=row.source_path,
-                        error=str(exc),
-                    )
-                    # Push through with empty content; the batch
-                    # extractor will null-field this entry.
-                    content = ""
-            items.append((row.collection, row.source_path, content))
+        # nexus-8g79.34: build manifest_lookup once; pass queue-captured
+        # doc_id per row via the 4-tuple form (extract_aspects_batch
+        # uses it to construct the per-row doc_id_lookup, matching
+        # _process_row's pattern at lines 406-411).
+        manifest_lookup = None
+        try:
+            from nexus.commands.enrich import _build_catalog_manifest_lookup
+            manifest_lookup = _build_catalog_manifest_lookup()
+        except Exception:
+            pass
+
+        items: list[tuple[str, str, str, str]] = [
+            (row.collection, row.source_path, row.content,
+             getattr(row, "doc_id", "") or "")
+            for row in rows
+        ]
 
         try:
-            records = _extract_aspects_batch(items)
+            records = _extract_aspects_batch(items, manifest_lookup=manifest_lookup)
         except Exception as exc:
             _log.warning(
                 "aspect_worker_batch_extract_raised",
@@ -377,6 +354,23 @@ class AspectExtractionWorker:
                 for row, record in zip(rows, records):
                     if record is None:
                         # Unsupported collection — drop silently.
+                        t2.aspect_queue.mark_done(
+                            row.collection, row.source_path,
+                        )
+                        continue
+                    # nexus-8g79.34: ExtractFail per-row — typed read-
+                    # failure sentinel from URI-based reading. Mark
+                    # queue done so we don't retry an unreadable
+                    # source on every drain; operators re-enqueue
+                    # manually after fixing source identity (mirrors
+                    # _process_row's handling).
+                    if isinstance(record, ExtractFail):
+                        _log.info(
+                            "aspect_worker_batch_extract_skip",
+                            uri=record.uri,
+                            reason=record.reason,
+                            detail=record.detail,
+                        )
                         t2.aspect_queue.mark_done(
                             row.collection, row.source_path,
                         )

--- a/tests/test_aspect_extractor.py
+++ b/tests/test_aspect_extractor.py
@@ -987,6 +987,56 @@ class TestBatchExtraction:
         # /p2.pdf is fine
         assert records[1].problem_formulation == "P2"
 
+    def test_batch_empty_content_uri_read_fail_yields_extract_fail(
+        self, monkeypatch,
+    ) -> None:
+        """nexus-8g79.34 (RDR-096 P5.1): when a batch input has
+        ``content=""`` and the URI read fails, the slot returns
+        ``ExtractFail`` (not ``_empty_record``). Mirrors the single-doc
+        path's contract so the worker can ``mark_done`` and skip
+        retry on unreadable sources.
+        """
+        from nexus.aspect_extractor import (
+            ExtractFail,
+            extract_aspects_batch,
+        )
+        from nexus.aspect_readers import ReadFail
+
+        # Mock read_source to return ReadFail for the empty-content row.
+        # First row has content (subprocess path); second is empty
+        # (URI path → ReadFail → ExtractFail).
+        def fake_read(uri, **_kw):
+            return ReadFail(reason="unreachable", detail=f"mocked: {uri}")
+
+        # Mock get_t3 so the t3_handle init succeeds.
+        class _FakeT3:
+            def get_collection(self, _n):
+                raise AssertionError("read_source is mocked; chroma never called")
+
+        monkeypatch.setattr("nexus.aspect_extractor.read_source", fake_read)
+        monkeypatch.setattr(
+            "nexus.aspect_extractor.get_t3", lambda: _FakeT3(),
+        )
+        # subprocess.run must not fire — the empty-content row should
+        # short-circuit to ExtractFail before the subprocess prompt
+        # is built. (The first row would normally trigger subprocess,
+        # but we exercise the read-fail path on the second row only;
+        # use a single-input batch.)
+        monkeypatch.setattr(
+            "nexus.aspect_extractor.subprocess.run",
+            lambda *a, **kw: (_ for _ in ()).throw(
+                AssertionError("subprocess must not run when content is empty + read fails"),
+            ),
+        )
+
+        records = extract_aspects_batch([
+            ("knowledge__delos", "/missing.pdf", "", "1.99.1"),
+        ])
+        assert len(records) == 1
+        assert isinstance(records[0], ExtractFail)
+        assert records[0].reason == "unreachable"
+        assert "/missing.pdf" in records[0].uri
+
     def test_batch_empty_input_returns_empty(self, monkeypatch) -> None:
         from nexus.aspect_extractor import extract_aspects_batch
 

--- a/tests/test_aspect_worker.py
+++ b/tests/test_aspect_worker.py
@@ -508,7 +508,7 @@ class TestBatchPath:
         batch_calls: list[int] = []
         single_calls: list[int] = []
 
-        def fake_batch(items):
+        def fake_batch(items, *_args, **_kwargs):
             batch_calls.append(len(items))
             return [
                 AspectRecord(
@@ -523,7 +523,7 @@ class TestBatchPath:
                     model_version="claude-haiku-4-5-20251001",
                     extractor_name="scholarly-paper-v1",
                 )
-                for c, sp, _content in items
+                for c, sp, _content, *_ in items
             ]
 
         def fake_single(content, source_path, collection, **_kw):
@@ -573,7 +573,7 @@ class TestBatchPath:
         batch_calls: list[int] = []
         single_calls: list[str] = []
 
-        def fake_batch(items):
+        def fake_batch(items, *_args, **_kwargs):
             batch_calls.append(len(items))
             raise AssertionError("batch path should not fire for 1 row")
 
@@ -644,7 +644,7 @@ class TestBatchPath:
         batch_calls: list[int] = []
         single_calls: list[str] = []
 
-        def fake_batch(items):
+        def fake_batch(items, *_args, **_kwargs):
             batch_calls.append(len(items))
             raise AssertionError(
                 "batch path must NOT fire on heterogeneous configs"

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "conexus"
-version = "4.32.8"
+version = "4.32.9"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },


### PR DESCRIPTION
## Summary

Stacked on PR #708 (4.32.8 layering refactor). Closes \`nexus-8g79.34\` — the RDR-096 P5 deprecation cycle.

## What changed

The single-doc and batch aspect extraction paths now share the same content-sourcing contract. Pre-fix, the batch path used a deprecated multi-step T3-then-disk fallback chain (\`_source_content_from_t3\` shim); single-doc had migrated to URI-based reading in RDR-096 P1.2 but batch lagged. Now both paths route through \`aspect_readers.read_source\` with a \`chroma://\` URI.

## Refactored

- **\`extract_aspects_batch\` return widened** to \`list[AspectRecord | ExtractFail | None]\`. Per-row URI-based content sourcing moved INTO the function.
- **Items tuple extended** to 4-tuple \`(collection, source_path, content, doc_id)\` for per-row catalog attribution. 3-tuple back-compat preserved.
- **\`aspect_worker._process_batch\` rewritten** — deleted the pre-fetch block (\`_source_content_from_t3\` + disk fallback, ~30 lines). \`ExtractFail\` rows handled with \`mark_done\` (mirrors \`_process_row\`).
- **\`_source_content_from_t3\` shim deleted** from \`aspect_extractor.py\` (~120 lines). The \`DeprecationWarning\` is gone.

## Tests

- New regression test \`test_batch_empty_content_uri_read_fail_yields_extract_fail\` locks the new contract.
- 3 existing \`fake_batch\` shims extended for kwargs.
- 190 tests pass across aspect subsystem.

## Result

Behavioural divergence between batch and single-doc paths eliminated. RDR-096 P5 deprecation cycle closes.

## Closes

- Closes #nexus-8g79.34

## Test plan

- [x] 190 aspect-subsystem tests pass
- [ ] CI green
- [ ] Sandbox smoke before tag
- [ ] Merge after #708 (4.32.8 layering) lands