### PR TITLE
fix(dxly): aspect_readers fail-loud + scoring catalog chunk_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+Accumulating audit umbrella `nexus-58ui` slice work for the next
+release. RDR-108 Phase 3 dropped `chunk_index` / `chunk_count`
+from chunk metadata; the items below close the still-live call
+sites that read those fields.
+
+### Fixed (nexus-dxly)
+
+- `aspect_readers._gather_chroma_chunks_by_field`: post-Phase-3
+  chunks reassembled in chroma insertion order (chunk_text_hash
+  driven, not document order) when no `manifest_lookup` was wired
+  and chunks lacked `chunk_index`. Guard detects the corruption
+  fingerprint (identity_field == "doc_id" AND chash_position empty
+  AND >1 chunks AND every ci == 0) and returns
+  `ReadFail("unreachable")` so callers see the structural problem
+  instead of silently extracting scrambled text.
+  `_read_chroma_uri` propagates `unreachable` from the doc_id
+  gather path rather than falling through to the legacy probe
+  (which would mask the failure as `empty`).
+- `scoring.apply_hybrid_scoring`: file-size penalty for `code__`
+  results read `chunk_count` from chunk metadata and defaulted to
+  1 for every Phase-3 chunk, silently disabling the penalty.
+  New optional `catalog` kwarg batch-resolves chunk_count via
+  `SELECT tumbler, chunk_count FROM documents WHERE tumbler IN
+  (...)`. `commands/search_cmd` wires the catalog.
+
 ## [4.32.9] - 2026-05-12
 
 Patch on 4.32.8. Audit follow-up: RDR-096 P5.1 aspect_worker

--- a/src/nexus/aspect_readers.py
+++ b/src/nexus/aspect_readers.py
@@ -314,6 +314,30 @@ def _gather_chroma_chunks_by_field(
             reason="empty",
             detail=f"no chunks for {match_value!r} in {collection!r}",
         )
+    # nexus-dxly: post-RDR-108 Phase 3 chunks lack ``chunk_index``
+    # metadata. When the manifest lookup is unavailable (catalog gap
+    # for a Phase-3 doc) the fallback ``md.get("chunk_index", 0)``
+    # returns 0 for every chunk and multi-chunk docs reassemble in
+    # chroma insertion order (chunk_text_hash-driven, not document
+    # order). Fail loud so callers see the structural problem instead
+    # of silently extracting / scoring against a scrambled document.
+    if (
+        identity_field == "doc_id"
+        and not chash_position
+        and len(chunks) > 1
+        and {triple[0] for triple in chunks} == {0}
+    ):
+        return ReadFail(
+            reason="unreachable",
+            detail=(
+                f"Phase-3 reassembly unsafe for {match_value!r} in "
+                f"{collection!r}: manifest_lookup returned no rows and "
+                f"chunks lack chunk_index ordering. Cannot reassemble "
+                f"{len(chunks)} chunks deterministically. Initialize the "
+                f"catalog or re-index to populate the document_chunks "
+                f"manifest."
+            ),
+        )
     chunks.sort(key=lambda triple: (triple[0], triple[1]))
     text = "\n\n".join(doc for _, _, doc in chunks)
     return ReadOk(
@@ -421,6 +445,13 @@ def _read_chroma_uri(
             manifest_lookup=manifest_lookup,
         )
         if isinstance(result, ReadOk):
+            return result
+        # nexus-dxly: a structural reassembly failure (Phase-3 doc with
+        # no manifest_lookup, multi-chunk, no chunk_index) must propagate
+        # not silently fall through to legacy probe — the legacy probe
+        # would find nothing and the corruption stays hidden behind an
+        # ``empty`` report.
+        if result.reason == "unreachable":
             return result
         # doc_id mapped but T3 query returned empty: chunks predate
         # the Phase 4 doc_id write contract. Fall through to legacy

--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -408,12 +408,25 @@ def search_cmd(
                         rg_matched_lines.setdefault(fp, []).append(int(ln))
 
     # Hybrid scoring — pass tuning weights from config (honours per-repo .nexus.yml)
+    # nexus-dxly: pass catalog so the code__ file-size penalty can
+    # resolve chunk_count via documents.chunk_count for Phase-3 chunks
+    # (RDR-108 dropped chunk_count from chunk metadata).
+    from nexus.catalog import Catalog as _Catalog
+    from nexus.config import catalog_path as _catalog_path
+    _scoring_cat = None
+    try:
+        _scoring_cp = _catalog_path()
+        if _Catalog.is_initialized(_scoring_cp):
+            _scoring_cat = _Catalog(_scoring_cp, _scoring_cp / ".catalog.db")
+    except Exception:
+        _scoring_cat = None
     results = apply_hybrid_scoring(
         results,
         hybrid=hybrid,
         vector_weight=tuning.vector_weight,
         frecency_weight=tuning.frecency_weight,
         file_size_threshold=tuning.file_size_threshold,
+        catalog=_scoring_cat,
     )
 
     # RDR-055 E2: quality boost from bibliographic metadata (no-op when unenriched)

--- a/src/nexus/scoring.py
+++ b/src/nexus/scoring.py
@@ -71,6 +71,7 @@ def apply_hybrid_scoring(
     vector_weight: float = _VECTOR_WEIGHT,
     frecency_weight: float = _FRECENCY_WEIGHT,
     file_size_threshold: int = _FILE_SIZE_THRESHOLD,
+    catalog: Any | None = None,
 ) -> list[SearchResult]:
     """Compute hybrid scores for *results*.
 
@@ -80,7 +81,14 @@ def apply_hybrid_scoring(
 
     File-size penalty: applied to all code__ results unconditionally after the
     initial score is computed: ``score *= _file_size_factor(chunk_count)``.
-    When ``chunk_count`` is absent from metadata, defaults to 1 (no penalty).
+
+    nexus-dxly: post-RDR-108 Phase 3 chunks no longer carry the
+    ``chunk_count`` field in metadata. When *catalog* is provided, the
+    penalty resolves ``chunk_count`` via a batch SQL lookup against
+    ``documents.chunk_count`` keyed on the chunk's ``doc_id`` (== catalog
+    tumbler post-RDR-101). Falls back to metadata then ``1`` (no penalty)
+    when the catalog has no row or no catalog is supplied — preserves
+    behaviour for pre-Phase-3 corpora.
 
     If *hybrid* is True but no code__ collections appear in results, a warning
     is logged and all results use 1.0 * vector_norm.
@@ -109,6 +117,35 @@ def apply_hybrid_scoring(
         if r.collection.startswith("code__")
     ]
 
+    # nexus-dxly: batch-resolve documents.chunk_count for code__ results
+    # when a catalog is supplied; chunks lost the metadata field at
+    # RDR-108 Phase 3.
+    chunk_count_by_doc_id: dict[str, int] = {}
+    if catalog is not None:
+        code_doc_ids = {
+            r.metadata.get("doc_id", "")
+            for r in results
+            if r.collection.startswith("code__")
+        }
+        code_doc_ids.discard("")
+        if code_doc_ids:
+            try:
+                placeholders = ",".join("?" for _ in code_doc_ids)
+                rows = catalog._db.execute(
+                    f"SELECT tumbler, chunk_count FROM documents "
+                    f"WHERE tumbler IN ({placeholders})",
+                    list(code_doc_ids),
+                ).fetchall()
+                chunk_count_by_doc_id = {
+                    t: int(cc) for t, cc in rows if cc is not None
+                }
+            except Exception as exc:
+                _log.warning(
+                    "scoring_chunk_count_lookup_failed",
+                    error=str(exc),
+                    doc_id_count=len(code_doc_ids),
+                )
+
     for r in results:
         if r.collection == "rg__cache":
             r.hybrid_score = RG_FLOOR_SCORE
@@ -122,7 +159,10 @@ def apply_hybrid_scoring(
         else:
             r.hybrid_score = v_norm
         if r.collection.startswith("code__"):
-            chunk_count = int(r.metadata.get("chunk_count", 1))
+            doc_id = r.metadata.get("doc_id", "")
+            chunk_count = chunk_count_by_doc_id.get(doc_id) or int(
+                r.metadata.get("chunk_count", 1)
+            )
             r.hybrid_score *= _file_size_factor(chunk_count, file_size_threshold)
 
     return sorted(results, key=lambda r: r.hybrid_score, reverse=True)

--- a/tests/test_aspect_readers.py
+++ b/tests/test_aspect_readers.py
@@ -650,6 +650,78 @@ class TestReadChromaUriDocIdLookup:
             f"forbids 'empty' for documents that haven't been backfilled."
         )
 
+    def test_phase3_doc_without_manifest_fails_loud(self, t3_client):
+        """nexus-dxly: post-RDR-108 Phase-3 chunks lack ``chunk_index``
+        metadata. When the doc_id lookup resolves the tumbler but no
+        manifest_lookup is wired (catalog uninitialized, or doc absent
+        from document_chunks), every chunk falls to ``chunk_index=0`` and
+        the legacy reassembly sorts by chroma insertion order — which is
+        content-hash driven, not document order. The reader must fail
+        loud (``unreachable``) so callers see the corruption instead of
+        silently extracting scrambled text.
+        """
+        from nexus.aspect_readers import ReadFail, _read_chroma_uri
+
+        col_name = "knowledge__phase3"
+        try:
+            t3_client.delete_collection(col_name)
+        except Exception:
+            pass
+        coll = t3_client.get_or_create_collection(col_name)
+        # Phase-3 chunk shape: doc_id metadata only; NO chunk_index.
+        coll.add(
+            ids=["chunk-a", "chunk-b", "chunk-c"],
+            documents=["alpha", "bravo", "charlie"],
+            metadatas=[
+                {"doc_id": "ART-phase3", "chunk_text_hash": "a"},
+                {"doc_id": "ART-phase3", "chunk_text_hash": "b"},
+                {"doc_id": "ART-phase3", "chunk_text_hash": "c"},
+            ],
+        )
+
+        def lookup(_coll: str, _source_id: str) -> str:
+            return "ART-phase3"
+
+        # No manifest_lookup wired — simulates catalog gap.
+        result = _read_chroma_uri(
+            "chroma://knowledge__phase3//abs/path/paper.pdf",
+            t3=t3_client, doc_id_lookup=lookup,
+        )
+        assert isinstance(result, ReadFail)
+        assert result.reason == "unreachable"
+        assert "Phase-3 reassembly unsafe" in result.detail
+
+    def test_phase3_single_chunk_without_manifest_still_succeeds(
+        self, t3_client,
+    ):
+        """Single-chunk Phase-3 docs are unambiguous (no reassembly
+        order to get wrong). The fail-loud guard must NOT trip for
+        them — restrict to len(chunks) > 1.
+        """
+        from nexus.aspect_readers import ReadOk, _read_chroma_uri
+
+        col_name = "knowledge__phase3_single"
+        try:
+            t3_client.delete_collection(col_name)
+        except Exception:
+            pass
+        coll = t3_client.get_or_create_collection(col_name)
+        coll.add(
+            ids=["chunk-only"],
+            documents=["sole chunk"],
+            metadatas=[{"doc_id": "ART-single", "chunk_text_hash": "x"}],
+        )
+
+        def lookup(_coll: str, _source_id: str) -> str:
+            return "ART-single"
+
+        result = _read_chroma_uri(
+            "chroma://knowledge__phase3_single//abs/p.pdf",
+            t3=t3_client, doc_id_lookup=lookup,
+        )
+        assert isinstance(result, ReadOk)
+        assert result.text == "sole chunk"
+
     def test_no_doc_id_lookup_falls_back_to_legacy_probe(self, t3_client):
         """Back-compat: callers without catalog access (tests, ad-hoc
         CLI runs) call _read_chroma_uri without doc_id_lookup. The

--- a/tests/test_hybrid_boost.py
+++ b/tests/test_hybrid_boost.py
@@ -162,6 +162,68 @@ def test_hybrid_score_in_valid_range():
     assert 0.0 <= v_result.hybrid_score <= 1.0
 
 
+def test_file_size_penalty_uses_catalog_chunk_count_when_provided():
+    """nexus-dxly: post-RDR-108 Phase-3 chunks lack ``chunk_count`` in
+    metadata. When a catalog is supplied, the file-size penalty
+    resolves it via documents.chunk_count keyed on doc_id (tumbler).
+    Pre-fix, every Phase-3 chunk defaulted to chunk_count=1 (no penalty)
+    and large files outranked small ones on identical vector distance.
+    """
+    from nexus.scoring import apply_hybrid_scoring
+
+    class _FakeDB:
+        def execute(self, sql: str, params):
+            assert "documents" in sql
+            assert "chunk_count" in sql
+            rows = {"ART-small": 5, "ART-large": 5000}
+            return _FakeCursor([
+                (t, rows[t]) for t in params if t in rows
+            ])
+
+    class _FakeCursor:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def fetchall(self):
+            return self._rows
+
+    class _FakeCatalog:
+        _db = _FakeDB()
+
+    # Two code__ results, identical vector distance, no chunk_count
+    # in metadata (Phase-3 shape).  Only doc_id differs.
+    small = _sr(id="s", distance=0.3, collection="code__repo", doc_id="ART-small")
+    large = _sr(id="l", distance=0.3, collection="code__repo", doc_id="ART-large")
+    # Drop chunk_count from metadata to simulate Phase-3 chunk shape.
+    for r in (small, large):
+        r.metadata.pop("chunk_count", None)
+
+    results = apply_hybrid_scoring(
+        [small, large], hybrid=False, catalog=_FakeCatalog(),
+    )
+    score = {r.id: r.hybrid_score for r in results}
+    # Large file should score lower than small file due to penalty.
+    assert score["s"] > score["l"], (
+        f"small file (chunk_count=5) should outrank large file "
+        f"(chunk_count=5000) at equal vector distance; got {score!r}"
+    )
+
+
+def test_file_size_penalty_without_catalog_falls_back_to_metadata():
+    """Without a catalog the lookup is skipped and the legacy
+    ``metadata["chunk_count"]`` read still works (back-compat for
+    pre-Phase-3 chunks that still carry the field).
+    """
+    from nexus.scoring import apply_hybrid_scoring
+
+    small = _sr(id="s", distance=0.3, collection="code__repo", chunk_count=5)
+    large = _sr(id="l", distance=0.3, collection="code__repo", chunk_count=5000)
+
+    results = apply_hybrid_scoring([small, large], hybrid=False)
+    score = {r.id: r.hybrid_score for r in results}
+    assert score["s"] > score["l"]
+
+
 def test_non_hybrid_search_unaffected():
     from nexus.scoring import apply_hybrid_scoring
 


### PR DESCRIPTION
## Summary

Audit umbrella `nexus-58ui` slice 1: closes 2 of 3 still-live sub-findings of `nexus-dxly` (P0). RDR-108 Phase 3 dropped `chunk_index` / `chunk_count` from chunk metadata; two call sites still read those fields and silently produced wrong output.

## Fixed

### `aspect_readers._gather_chroma_chunks_by_field`

Post-Phase-3 chunks reassembled in chroma insertion order (chunk_text_hash driven, not document order) when no `manifest_lookup` was wired and chunks lacked `chunk_index`. Guard detects the corruption fingerprint (identity_field == \"doc_id\" AND chash_position empty AND >1 chunks AND every ci == 0) and returns `ReadFail(\"unreachable\")` so callers see the structural problem instead of silently extracting scrambled text. `_read_chroma_uri` propagates `unreachable` from the doc_id gather path rather than falling through to the legacy probe (which would mask the failure as `empty`).

### `scoring.apply_hybrid_scoring`

File-size penalty for `code__` results read `chunk_count` from chunk metadata and defaulted to 1 for every Phase-3 chunk, silently disabling the penalty (large monolithic files outranked small focused ones at equal vector distance). New optional `catalog` kwarg batch-resolves chunk_count via `SELECT tumbler, chunk_count FROM documents WHERE tumbler IN (...)`. `commands/search_cmd` wires the catalog.

## Third sub-finding

`aspect_extractor.py:785` from the audit description: file is already clean of `chunk_index`/`chunk_count` reads (closed by `nexus-8g79.2` work). No additional change needed.

## Tests

- `test_phase3_doc_without_manifest_fails_loud` — locks the aspect_readers guard
- `test_phase3_single_chunk_without_manifest_still_succeeds` — locks unambiguous single-chunk case is not affected
- `test_file_size_penalty_uses_catalog_chunk_count_when_provided` — locks catalog-resolved penalty
- `test_file_size_penalty_without_catalog_falls_back_to_metadata` — locks pre-Phase-3 back-compat

Local: 30 hybrid_boost + 67 aspect_readers + 108 search_cmd + 116 wider aspect suite all pass.

## Closes

- Refs #nexus-dxly (umbrella `nexus-58ui` slice 1; 3 P0/P1 audit fixes remain in the umbrella for follow-on patches)

## Test plan

- [x] Local touched-test suites pass
- [ ] CI green