### PR TITLE
fix(lrhg): build_staleness_cache warn + EventLog unlocked variants

### DIFF
--- a/src/nexus/catalog/event_log.py
+++ b/src/nexus/catalog/event_log.py
@@ -75,6 +75,18 @@ class EventLog:
         The lock pattern matches ``Catalog._acquire_lock`` exactly so
         Phase 1 writers and the existing JSONL writers don't race.
 
+        Re-entrancy invariant (nexus-lrhg, RDR-108 audit finding 5):
+        callers MUST NOT already hold the catalog directory flock.
+        POSIX ``flock`` on the same file descriptor is re-entrant only
+        when the caller passes the same ``dir_fd``; ``acquire_directory_lock``
+        opens a fresh fd every call, so a holder calling ``append()``
+        produces a second flock acquisition that may deadlock under
+        some kernels (Linux ``flock`` LOCK_EX on a new fd against the
+        same path is non-reentrant). For writer code paths that already
+        hold the lock (e.g. ``Catalog`` mutators inside a single dir-fd
+        scope), use :meth:`append_unlocked` and let the caller manage
+        the flock around the whole atomic step.
+
         Raises ``TypeError`` if the event payload contains values
         ``json.dumps`` cannot serialize (e.g. ``datetime``, ``Path``,
         ``Decimal``). Earlier versions silently coerced these via
@@ -92,6 +104,23 @@ class EventLog:
         finally:
             release_lock(dir_fd)
 
+    def append_unlocked(self, event: Event) -> None:
+        """Append one event envelope WITHOUT acquiring the dir flock.
+
+        Caller is responsible for holding an exclusive lock on the
+        catalog directory for the whole atomic step. Use when the
+        write is part of a larger sequence already running under
+        ``acquire_directory_lock`` (e.g. a Catalog mutator that bundles
+        SQLite UPDATE + JSONL append + event log append under one
+        flock so the three projections converge or all fail together).
+
+        Same JSON-serialization contract as :meth:`append`.
+        """
+        line = json.dumps(event.to_dict(), separators=(",", ":"))
+        with self._path.open("a") as f:
+            f.write(line)
+            f.write("\n")
+
     def append_many(self, events: list[Event]) -> None:
         """Append a batch of events under a single flock acquisition.
 
@@ -99,6 +128,10 @@ class EventLog:
         catalog row produces multiple events (e.g. tombstoned row →
         ``DocumentRegistered`` + ``DocumentDeleted``). A single flock keeps
         the batch atomic with respect to other catalog writers.
+
+        Same re-entrancy invariant as :meth:`append`: callers must NOT
+        already hold the catalog directory flock; use
+        :meth:`append_many_unlocked` in that case.
 
         Like ``append``, raises ``TypeError`` on non-JSON-serializable
         payload values rather than silently coercing them.
@@ -117,6 +150,23 @@ class EventLog:
                     f.write("\n")
         finally:
             release_lock(dir_fd)
+
+    def append_many_unlocked(self, events: list[Event]) -> None:
+        """Append a batch of events WITHOUT acquiring the dir flock.
+
+        Caller-managed flock equivalent of :meth:`append_many`. See
+        :meth:`append_unlocked` for the invariant and use case.
+        """
+        if not events:
+            return
+        lines = [
+            json.dumps(e.to_dict(), separators=(",", ":"))
+            for e in events
+        ]
+        with self._path.open("a") as f:
+            for line in lines:
+                f.write(line)
+                f.write("\n")
 
     def replay(self) -> Iterator[Event]:
         """Yield events in append order. Skips malformed lines with a warning.

--- a/src/nexus/indexer_utils.py
+++ b/src/nexus/indexer_utils.py
@@ -298,6 +298,21 @@ def build_staleness_cache(col: object) -> StalenessCache:
 
         all_chunks = _paginated_get(col, include=["metadatas"])
     except Exception:
+        # nexus-lrhg (RDR-108 audit finding 6): pre-fix this swallowed
+        # ``_paginated_get`` failures with a bare ``except: pass`` and
+        # returned an empty cache. The caller fell back to the per-file
+        # Chroma probe, which on a Phase-3 corpus means re-embedding
+        # every chunk because the per-file cache misses are
+        # indistinguishable from genuine stale rows. WARNING log with
+        # the collection identity so a recurring outage (network blip,
+        # cloud throttle) surfaces in production logs instead of
+        # silently melting the embedder budget.
+        import structlog
+        structlog.get_logger(__name__).warning(
+            "build_staleness_cache_paginated_get_failed",
+            collection=getattr(col, "name", "<unknown>"),
+            exc_info=True,
+        )
         return cache
 
     # nexus-0ocy (RDR-108 Phase 4 review D-M4): when chunk metadata

--- a/tests/test_catalog_event_log.py
+++ b/tests/test_catalog_event_log.py
@@ -131,6 +131,46 @@ class TestAppendMany:
         assert [e.payload.doc_id for e in replayed] == ["a", "b", "c"]
 
 
+class TestAppendUnlocked:
+    """nexus-lrhg (RDR-108 audit finding 5): unlocked variants exist
+    for callers that already hold the catalog directory flock. The
+    write path matches the locked variants byte-for-byte; only the
+    flock acquisition is skipped."""
+
+    def test_append_unlocked_writes_one_line(self, event_log):
+        e = ev.make_event(ev.DocumentDeletedPayload(doc_id="x", reason="t"))
+        event_log.append_unlocked(e)
+        replayed = list(event_log.replay())
+        assert len(replayed) == 1
+        assert replayed[0].payload.doc_id == "x"
+
+    def test_append_many_unlocked_writes_batch(self, event_log):
+        events = [
+            ev.make_event(ev.DocumentDeletedPayload(doc_id=f"d{i}", reason="t"))
+            for i in range(3)
+        ]
+        event_log.append_many_unlocked(events)
+        replayed = list(event_log.replay())
+        assert [r.payload.doc_id for r in replayed] == ["d0", "d1", "d2"]
+
+    def test_append_many_unlocked_empty_is_noop(self, event_log):
+        event_log.append_many_unlocked([])
+        assert event_log.path.read_text() == ""
+
+    def test_unlocked_and_locked_interleave_correctly(self, event_log):
+        """A caller holding the dir flock can mix unlocked writes
+        with subsequent locked writes (after releasing) — the file
+        is append-only and replay sees all events in order."""
+        event_log.append_unlocked(
+            ev.make_event(ev.DocumentDeletedPayload(doc_id="u1", reason="t"))
+        )
+        event_log.append(
+            ev.make_event(ev.DocumentDeletedPayload(doc_id="l1", reason="t"))
+        )
+        replayed = list(event_log.replay())
+        assert [r.payload.doc_id for r in replayed] == ["u1", "l1"]
+
+
 class TestReplay:
     def test_empty_log_yields_nothing(self, event_log):
         assert list(event_log.replay()) == []

--- a/tests/test_indexer_utils_repo.py
+++ b/tests/test_indexer_utils_repo.py
@@ -341,6 +341,37 @@ class TestStalenessCache:
         assert cache.by_doc_id == {}
         assert cache.by_source_path == {}
 
+    def test_build_logs_warning_on_paginated_get_failure(self, caplog) -> None:
+        """nexus-lrhg (RDR-108 audit finding 6): pre-fix the bare
+        ``except: pass`` silently masked _paginated_get failures, which
+        for Phase-3 corpora forces a whole-collection re-embed when the
+        per-file fallback fires. The swallow must emit a structured
+        WARNING so operators can detect spurious re-index storms.
+        """
+        import logging
+
+        import structlog
+
+        col = MagicMock()
+        col.name = "code__sample"
+        col.get.side_effect = RuntimeError("chroma offline")
+
+        structlog.configure(
+            processors=[structlog.stdlib.render_to_log_kwargs],
+            wrapper_class=structlog.stdlib.BoundLogger,
+            logger_factory=structlog.stdlib.LoggerFactory(),
+        )
+        with caplog.at_level(logging.WARNING, logger="nexus.indexer_utils"):
+            cache = build_staleness_cache(col)
+
+        assert cache.by_doc_id == {}
+        events = [r.getMessage() for r in caplog.records] + [
+            getattr(r, "event", "") for r in caplog.records
+        ]
+        assert any(
+            "build_staleness_cache_paginated_get_failed" in e for e in events
+        ), f"expected structured warning, got {events!r}"
+
     def test_check_staleness_with_cache_hit_returns_true(self) -> None:
         """Cache hit + matching hash + matching model = stale (skip)."""
         cache = StalenessCache(


### PR DESCRIPTION
## Summary

Audit umbrella \`nexus-58ui\`, slice 2: closes 2 of 8 sub-findings in \`nexus-lrhg\` (P1) from the 2026-05-12 RDR-108 Phase-3 audit.

## Fixed

### Finding 6 — \`indexer_utils.build_staleness_cache\`

Bare \`except: pass\` swallowed \`_paginated_get\` failures and returned an empty cache. Per-file Chroma probe then re-embedded every chunk on a Phase-3 corpus (per-file misses indistinguishable from genuine stale rows). Add structured WARNING with collection identity so spurious re-index storms surface in production logs.

### Finding 5 — \`catalog.event_log.EventLog.append\`

\`append\` / \`append_many\` acquire the catalog dir flock unconditionally. Callers already holding the lock would re-acquire on a fresh fd; POSIX \`flock LOCK_EX\` on a new fd against the same path is non-reentrant on Linux and may deadlock. Add \`append_unlocked\` + \`append_many_unlocked\` for code paths that bundle SQLite UPDATE + JSONL append + event log append under one acquisition. Document the re-entrancy invariant on both locked variants.

## Deferred from this PR

- **Finding 4** (chash normalization to 32-char): attempted but reverted — breaks 15 tests across \`test_catalog_manifest_read_api\` that assert verbatim chash round-trip. Filed as \`nexus-gaa3\` (P2) to defer with proper test-fixture sweep.
- **Findings 1, 3, 7** (atomic_manifest_replace, FK orphan rebuild, resync_chunk_count_cache event-source bypass): bigger scope; future slices on this branch.
- **Finding 2** (Catalog.update chunk_count log on swallow): description notes already shipped post-zq79 F1.
- **Finding 8** (topic_links.link_count): already fixed via 4.32.4 F5.

## Tests

- 11 \`TestStalenessCache\` tests pass (1 new: \`test_build_logs_warning_on_paginated_get_failure\`)
- 28 \`event_log\` tests pass (4 new in \`TestAppendUnlocked\`)

## Refs

- \`nexus-lrhg\` (parent)
- \`nexus-gaa3\` (deferred finding 4)
- Umbrella: \`nexus-58ui\`

## Test plan

- [x] Local affected suites pass
- [ ] CI green