### PR TITLE
fix(backfill): refuse Phase-3 multi-chunk docs without chunk_index; stable-sort orphan paths

### DIFF
--- a/src/nexus/catalog/manifest_backfill.py
+++ b/src/nexus/catalog/manifest_backfill.py
@@ -58,6 +58,35 @@ class MissingChunkHashError(ValueError):
         )
 
 
+class Phase3ChunkIndexMissingError(ValueError):
+    """Raised when a multi-chunk doc's T3 chunks lack ``chunk_index``.
+
+    nexus-w5zv: post-RDR-108 Phase 3 chunks dropped ``chunk_index`` from
+    metadata. Pre-fix, the backfill read ``meta.get("chunk_index", 0)``
+    and every chunk landed at position=0; ``ON CONFLICT(doc_id, position)``
+    in the manifest UPSERT kept only one row. The resulting manifest was
+    silently wrong (a single chunk where the doc had many).
+
+    Backfill cannot determine canonical position for a Phase-3 corpus
+    without re-running the indexer; the only safe action is to fail loud
+    and force a re-index. Single-chunk docs (no ordering ambiguity)
+    bypass this guard.
+    """
+
+    def __init__(self, doc_id: str, collection: str, chunk_count: int) -> None:
+        self.doc_id = doc_id
+        self.collection = collection
+        self.chunk_count = chunk_count
+        super().__init__(
+            f"Document {doc_id!r} in collection {collection!r} has "
+            f"{chunk_count} chunks but none carry chunk_index metadata "
+            f"(post-RDR-108 Phase 3 shape). Backfill cannot reconstruct "
+            f"canonical chunk order from this state; re-index the "
+            f"collection so the indexer writes the manifest at write "
+            f"time, or carve out this doc."
+        )
+
+
 @dataclass
 class BackfillResult:
     """Summary of one backfill run over a single collection."""
@@ -66,6 +95,10 @@ class BackfillResult:
     docs_processed: int = 0
     chunks_written: int = 0
     docs_skipped_no_t3: int = 0
+    # nexus-w5zv: count Phase-3 docs that couldn't be backfilled because
+    # chunk_index is missing from metadata (multi-chunk only). Operator
+    # action: re-index the affected collection.
+    docs_skipped_phase3_no_index: int = 0
     skipped_taxonomy: bool = False
 
 
@@ -84,6 +117,7 @@ def _iter_chunks_for_doc(
     from chromadb import Collection  # noqa: PLC0415 — defer heavy import
 
     chunks: list[dict] = []
+    chunk_index_seen = 0
     offset = 0
     while True:
         result = col.get(
@@ -102,6 +136,11 @@ def _iter_chunks_for_doc(
             chash = meta.get("chunk_text_hash") or ""
             if not chash:
                 raise MissingChunkHashError(chunk_id=cid, collection=collection)
+            # nexus-w5zv: track explicit chunk_index presence so multi-chunk
+            # Phase-3 docs (where chunk_index was dropped from metadata) fail
+            # loud rather than collapse every chunk to position=0.
+            if "chunk_index" in meta:
+                chunk_index_seen += 1
             chunk_index = int(meta.get("chunk_index", 0) or 0)
             chunks.append({
                 "chash": chash,
@@ -114,6 +153,10 @@ def _iter_chunks_for_doc(
         if len(page_ids) < _PAGE_SIZE:
             break
         offset += _PAGE_SIZE
+    if len(chunks) > 1 and chunk_index_seen == 0:
+        raise Phase3ChunkIndexMissingError(
+            doc_id=doc_id, collection=collection, chunk_count=len(chunks),
+        )
     return chunks
 
 
@@ -183,7 +226,19 @@ def backfill_manifest_for_collection(
             )
             continue
 
-        chunks = _iter_chunks_for_doc(col, doc_id, collection_name)
+        try:
+            chunks = _iter_chunks_for_doc(col, doc_id, collection_name)
+        except Phase3ChunkIndexMissingError:
+            # nexus-w5zv: Phase-3 multi-chunk doc has no recoverable
+            # position metadata. Skip rather than silently collapse to
+            # position=0. Operator must re-index.
+            result.docs_skipped_phase3_no_index += 1
+            _log.warning(
+                "manifest_backfill_doc_skipped_phase3_no_chunk_index",
+                collection=collection_name,
+                doc_id=doc_id,
+            )
+            continue
         chunks.sort(key=lambda c: c["position"])
 
         if not dry_run:

--- a/src/nexus/catalog/orphan_backfill.py
+++ b/src/nexus/catalog/orphan_backfill.py
@@ -331,6 +331,11 @@ def register_dt_linked(
             },
         )
         docs += 1
+        # nexus-w5zv: stable-sort by chunk_index so pre-Phase-3 chunks
+        # land in document order; Phase-3 chunks (all chunk_index == 0)
+        # preserve chroma insertion order (the only signal we have when
+        # the indexer dropped the field).
+        ordered_chunks = sorted(m.chunks, key=lambda c: c.chunk_index)
         chunks_payload = [
             {
                 "chash": c.chash,
@@ -338,7 +343,7 @@ def register_dt_linked(
                 "line_start": None, "line_end": None,
                 "char_start": None, "char_end": None,
             }
-            for pos, c in enumerate(m.chunks)
+            for pos, c in enumerate(ordered_chunks)
         ]
         catalog.write_manifest(str(tumbler), chunks_payload)
         links += len(chunks_payload)
@@ -370,13 +375,16 @@ def register_synthetic(
         if g.title:
             uri = f"nx-orphan-backfill://{collection}/{g.title}"
             title = g.title
+            # nexus-w5zv: stable sort by chunk_index (same rationale as
+            # register_dt_linked above).
+            ordered_chunks = sorted(g.chunks, key=lambda c: c.chunk_index)
             chunks_payload = [
                 {
                     "chash": c.chash, "position": pos,
                     "line_start": None, "line_end": None,
                     "char_start": None, "char_end": None,
                 }
-                for pos, c in enumerate(g.chunks)
+                for pos, c in enumerate(ordered_chunks)
             ]
             tumbler = catalog.register(
                 owner,
@@ -535,13 +543,15 @@ def apply_csv(
                 },
             )
             docs += 1
+            # nexus-w5zv: stable sort by chunk_index (see register_dt_linked).
+            ordered_chunks = sorted(chunks, key=lambda c: c.chunk_index)
             catalog.write_manifest(str(tumbler), [
                 {
                     "chash": c.chash, "position": pos,
                     "line_start": None, "line_end": None,
                     "char_start": None, "char_end": None,
                 }
-                for pos, c in enumerate(chunks)
+                for pos, c in enumerate(ordered_chunks)
             ])
             links += len(chunks)
     return docs, links
@@ -583,6 +593,8 @@ def link_by_title(
         # Read existing manifest to know where to append (preserve order).
         existing = catalog.get_manifest(tumbler)
         start_pos = len(existing)
+        # nexus-w5zv: stable sort by chunk_index (see register_dt_linked).
+        ordered_chunks = sorted(g.chunks, key=lambda c: c.chunk_index)
         catalog.append_manifest_chunks(tumbler, [
             {
                 "chash": c.chash,
@@ -590,7 +602,7 @@ def link_by_title(
                 "line_start": None, "line_end": None,
                 "char_start": None, "char_end": None,
             }
-            for pos, c in enumerate(g.chunks)
+            for pos, c in enumerate(ordered_chunks)
         ])
         linked_chunks += len(g.chunks)
         linked_docs += 1
@@ -657,6 +669,8 @@ def link_by_content_hash(
         tumbler = by_head[content_hash]
         existing = catalog.get_manifest(tumbler)
         start_pos = len(existing)
+        # nexus-w5zv: stable sort by chunk_index (see register_dt_linked).
+        ordered_chunks = sorted(chunks, key=lambda c: c.chunk_index)
         catalog.append_manifest_chunks(tumbler, [
             {
                 "chash": c.chash,
@@ -664,7 +678,7 @@ def link_by_content_hash(
                 "line_start": None, "line_end": None,
                 "char_start": None, "char_end": None,
             }
-            for pos, c in enumerate(chunks)
+            for pos, c in enumerate(ordered_chunks)
         ])
         linked_chunks += len(chunks)
         linked_docs += 1

--- a/tests/test_catalog_manifest_backfill.py
+++ b/tests/test_catalog_manifest_backfill.py
@@ -414,6 +414,72 @@ class TestBackfillManifestForCollection:
         assert f"legacy-{coll}" in str(exc_info.value)
         assert coll in str(exc_info.value)
 
+    def test_backfill_skips_phase3_multi_chunk_doc_without_chunk_index(
+        self, catalog, t3_db,
+    ):
+        """nexus-w5zv: post-RDR-108 Phase 3 chunks lack chunk_index.
+        Pre-fix the backfill defaulted every chunk to position=0 and the
+        manifest UPSERT ON CONFLICT(doc_id, position) silently kept one
+        row. Multi-chunk docs must skip with a structured warning so the
+        operator re-indexes; single-chunk docs are unambiguous and pass.
+        """
+        from nexus.catalog.manifest_backfill import (
+            backfill_manifest_for_collection,
+        )
+
+        coll = _unique_coll()
+        _insert_doc(catalog, "1.1.1", coll)
+        # Plant Phase-3 multi-chunk shape: no chunk_index in metadata.
+        col = t3_db._client.get_or_create_collection(coll)
+        col.add(
+            ids=[f"a-{coll}", f"b-{coll}"],
+            documents=["alpha", "bravo"],
+            metadatas=[
+                {"doc_id": "1.1.1", "chunk_text_hash": "a" * 64},
+                {"doc_id": "1.1.1", "chunk_text_hash": "b" * 64},
+            ],
+        )
+
+        result = backfill_manifest_for_collection(
+            catalog, t3_db, coll, dry_run=False,
+        )
+        assert result.docs_skipped_phase3_no_index == 1
+        assert result.docs_processed == 0
+        assert result.chunks_written == 0
+        count = catalog._db.execute(
+            "SELECT COUNT(*) FROM document_chunks WHERE doc_id = ?",
+            ("1.1.1",),
+        ).fetchone()[0]
+        assert count == 0
+
+    def test_backfill_phase3_single_chunk_doc_still_writes(
+        self, catalog, t3_db,
+    ):
+        """nexus-w5zv: single-chunk Phase-3 docs have no ordering
+        ambiguity (position=0 is correct), so the guard must not trip.
+        """
+        from nexus.catalog.manifest_backfill import (
+            backfill_manifest_for_collection,
+        )
+
+        coll = _unique_coll()
+        _insert_doc(catalog, "1.1.1", coll)
+        col = t3_db._client.get_or_create_collection(coll)
+        col.add(
+            ids=[f"only-{coll}"],
+            documents=["sole chunk"],
+            metadatas=[
+                {"doc_id": "1.1.1", "chunk_text_hash": "a" * 64},
+            ],
+        )
+
+        result = backfill_manifest_for_collection(
+            catalog, t3_db, coll, dry_run=False,
+        )
+        assert result.docs_processed == 1
+        assert result.chunks_written == 1
+        assert result.docs_skipped_phase3_no_index == 0
+
     def test_backfill_dry_run_does_not_write(self, catalog, t3_db):
         """--dry-run reports but does not write manifest rows."""
         from nexus.catalog.manifest_backfill import backfill_manifest_for_collection


### PR DESCRIPTION
## Summary

Audit umbrella \`nexus-58ui\` slice 3: closes \`nexus-w5zv\` (P1). RDR-108 Phase 3 dropped \`chunk_index\` from chunk metadata. Pre-fix, the backfill paths read \`meta.get(\"chunk_index\", 0)\` and Phase-3 chunks all landed at position=0, producing either a hard PK violation (manifest_backfill, PK = doc_id+position) or chroma-insertion-order placement (orphan_backfill, which already uses \`enumerate\` for position).

## Fixed

### manifest_backfill

Track explicit \`chunk_index\` presence per doc. New \`Phase3ChunkIndexMissingError\` raised when a doc has >1 chunks AND zero of them carry the field. Orchestrator catches, increments a new \`docs_skipped_phase3_no_index\` counter on \`BackfillResult\`, emits a structured WARNING, and continues. Single-chunk docs pass through unchanged.

### orphan_backfill

The four manifest-write paths (register_dt_linked, register_synthetic, apply_csv DT-linked, link_by_title, link_by_content_hash) already assign position via \`enumerate\`, so no PK collapse. Add a stable sort by \`chunk_index\` before \`enumerate\` so pre-Phase-3 chunks land in document order and Phase-3 chunks (all chunk_index == 0) preserve chroma insertion order (best available signal for orphan recovery).

## Tests

- \`test_backfill_skips_phase3_multi_chunk_doc_without_chunk_index\` locks the multi-chunk guard
- \`test_backfill_phase3_single_chunk_doc_still_writes\` locks single-chunk passthrough
- 50 tests pass across catalog_manifest_backfill + orphan_backfill + orphan_backfill_integration

## Closes

- Closes #nexus-w5zv
- Umbrella: \`nexus-58ui\`

## Test plan

- [x] Local affected suites pass
- [ ] CI green