### PR TITLE
fix(catalog): atomic_manifest_replace + rebuild orphan chunk purge (lrhg #1, #3)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1546,6 +1546,13 @@ class Catalog:
         :meth:`_WriteOps.purge_manifest_for_doc`."""
         return self._writes.purge_manifest_for_doc(doc_id)
 
+    def atomic_manifest_replace(
+        self, doc_id: str, chunks: list[dict],
+    ) -> None:
+        """nexus-lrhg: atomic DELETE + INSERT + chunk_count UPDATE for one
+        document's manifest. See :meth:`_WriteOps.atomic_manifest_replace`."""
+        return self._writes.atomic_manifest_replace(doc_id, chunks)
+
     def get_manifest(self, doc_id: str) -> list[_ManifestRow]:
         """Return ordered manifest rows for ``doc_id`` (nexus-572g K6)."""
         return self._writes.get_manifest(doc_id)

--- a/src/nexus/catalog/catalog_db.py
+++ b/src/nexus/catalog/catalog_db.py
@@ -625,6 +625,31 @@ class CatalogDB:
         self._conn.execute("PRAGMA foreign_keys=OFF")
         try:
             self._rebuild_inner(owners, documents, links, consistency_mtime=consistency_mtime)
+            # nexus-lrhg #3: with FK enforcement disabled the DELETE FROM
+            # documents above did NOT cascade-delete the
+            # ``document_chunks`` manifest. Any rows whose ``doc_id``
+            # references a tombstoned document (DocumentDeleted in the
+            # legacy log that this rebuild replays) survive the wipe and
+            # become orphans: they reference a doc_id that the new
+            # documents INSERT loop did not restore. PRAGMA foreign_keys
+            # =ON below only enforces new writes, not existing rows, so
+            # the orphan rows persist silently forever. Wipe them
+            # explicitly before re-enabling FK so the post-rebuild state
+            # is FK-clean.
+            orphan_count = self._conn.execute(
+                "SELECT COUNT(*) FROM document_chunks "
+                "WHERE doc_id NOT IN (SELECT tumbler FROM documents)"
+            ).fetchone()[0]
+            if orphan_count:
+                self._conn.execute(
+                    "DELETE FROM document_chunks "
+                    "WHERE doc_id NOT IN (SELECT tumbler FROM documents)"
+                )
+                self._conn.commit()
+                _log.info(
+                    "catalog_db_rebuild_orphan_chunks_purged",
+                    count=orphan_count,
+                )
         finally:
             self._conn.execute("PRAGMA foreign_keys=ON")
 

--- a/src/nexus/catalog/catalog_writes.py
+++ b/src/nexus/catalog/catalog_writes.py
@@ -862,6 +862,69 @@ class _WriteOps:
         )
         cat._db.commit()
 
+    def atomic_manifest_replace(
+        self, doc_id: str, chunks: list[dict],
+    ) -> None:
+        """Replace the manifest for ``doc_id`` atomically — single txn
+        for DELETE + UPSERT + ``documents.chunk_count`` UPDATE.
+
+        nexus-lrhg (RDR-108 audit finding 1): the per-batch hook
+        sequence (``purge_manifest_for_doc`` → ``append_manifest_chunks``
+        → ``resync_chunk_count_cache``) ran each step in its own
+        transaction. A partial failure (sqlite lock contention, FK
+        violation, disk error) between the DELETE and the INSERT left
+        the catalog with zero chunks for the doc while the documents
+        row claimed N. Subsequent reads via ``get_manifest`` returned
+        an empty list and the chunk_count remained desynced until the
+        next full re-index.
+
+        Wrapping all three steps in one txn means either the whole
+        replacement lands or none of it does — the catalog never
+        observes a torn state. Idempotent: re-running with the same
+        chunks list produces identical rows.
+
+        For shrink-reindex (fewer chunks than before): the DELETE
+        clears every row; the INSERT writes the new shape; the UPDATE
+        re-derives chunk_count from the post-INSERT row count.
+        """
+        cat = self._cat
+        with cat._db.transaction():
+            cat._db.execute(
+                "DELETE FROM document_chunks WHERE doc_id = ?",
+                (doc_id,),
+            )
+            if chunks:
+                _batch = 300
+                for i in range(0, len(chunks), _batch):
+                    batch = chunks[i : i + _batch]
+                    cat._db.execute(
+                        "INSERT INTO document_chunks "
+                        "(doc_id, position, chash, chunk_index, "
+                        " line_start, line_end, char_start, char_end) "
+                        "VALUES "
+                        + ", ".join(["(?, ?, ?, ?, ?, ?, ?, ?)"] * len(batch)),
+                        [
+                            val
+                            for c in batch
+                            for val in (
+                                doc_id,
+                                c["position"],
+                                c["chash"],
+                                c.get("chunk_index"),
+                                c.get("line_start"),
+                                c.get("line_end"),
+                                c.get("char_start"),
+                                c.get("char_end"),
+                            )
+                        ],
+                    )
+            cat._db.execute(
+                "UPDATE documents SET chunk_count = ("
+                "SELECT COUNT(*) FROM document_chunks WHERE doc_id = ?"
+                ") WHERE tumbler = ?",
+                (doc_id, doc_id),
+            )
+
     def append_manifest_chunks(self, doc_id: str, chunks: list[dict]) -> None:
         """UPSERT manifest rows for one document without deleting prior rows
         (RDR-108 Phase 3, nexus-bdag).

--- a/src/nexus/catalog/catalog_writes.py
+++ b/src/nexus/catalog/catalog_writes.py
@@ -909,7 +909,10 @@ class _WriteOps:
                             for val in (
                                 doc_id,
                                 c["position"],
-                                c["chash"],
+                                # nexus-gaa3: chash stored as 32-char
+                                # for uniformity with write_manifest /
+                                # append_manifest_chunks.
+                                (c["chash"] or "")[:32],
                                 c.get("chunk_index"),
                                 c.get("line_start"),
                                 c.get("line_end"),

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -901,24 +901,28 @@ def manifest_write_batch_hook(
         if all(not c["chash"] for c in chunks):
             continue
         try:
-            # nexus-zq79 F3: shrink-reindex orphan cleanup. UPSERT keyed on
-            # (doc_id, position) leaves orphan rows when a file re-indexes
-            # with fewer chunks than before. When the batch contains
-            # position 0 (the start of a file's chunks), wipe the doc's
-            # prior manifest rows first so the new write defines the
-            # complete shape. Multi-batch writes never include position 0
-            # in batches other than the first, so this is safe across the
+            # nexus-zq79 F3 / nexus-lrhg #1: shrink-reindex orphan cleanup.
+            # UPSERT keyed on (doc_id, position) leaves orphan rows when a
+            # file re-indexes with fewer chunks than before. When the batch
+            # contains position 0 (the start of a file's chunks), wrap the
+            # DELETE + INSERT + chunk_count UPDATE in one transaction via
+            # ``atomic_manifest_replace`` so a partial-failure crash
+            # between the purge and the new write cannot leave the catalog
+            # with zero chunks for a doc the documents row still claims N.
+            # Multi-batch writes never include position 0 in batches other
+            # than the first, so the atomic-replace path is safe for the
             # streaming PDF / doc_indexer paths.
             if any(c["position"] == 0 for c in chunks):
-                cat.purge_manifest_for_doc(doc_id)
-            cat.append_manifest_chunks(doc_id, chunks)
-            # nexus-zq79: documents.chunk_count is a denormalised cache of
-            # COUNT(*) document_chunks. The catalog-register hook runs BEFORE
-            # per-file indexing (tumbler injection requires it), so chunk_count
-            # is initialised to 0; nothing else updates it for code/prose
-            # indexers post-Phase-3. Routed via Catalog public API to satisfy
-            # the projector-only-writes invariant (RDR-101 Phase 3 ε).
-            cat.resync_chunk_count_cache(doc_id)
+                cat.atomic_manifest_replace(doc_id, chunks)
+            else:
+                cat.append_manifest_chunks(doc_id, chunks)
+                # nexus-zq79: documents.chunk_count is a denormalised cache of
+                # COUNT(*) document_chunks. The catalog-register hook runs BEFORE
+                # per-file indexing (tumbler injection requires it), so chunk_count
+                # is initialised to 0; nothing else updates it for code/prose
+                # indexers post-Phase-3. Routed via Catalog public API to satisfy
+                # the projector-only-writes invariant (RDR-101 Phase 3 ε).
+                cat.resync_chunk_count_cache(doc_id)
         except Exception:
             # Post-Phase-3 the manifest hook is load-bearing: a failure
             # leaves the catalog manifest empty and chunk_count=0 for

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -834,6 +834,53 @@ class TestRebuild:
         cat2.rebuild()
         assert cat2.resolve(doc) is None
 
+    def test_rebuild_purges_orphan_document_chunks_for_tombstoned_docs(
+        self, cat_with_owner,
+    ):
+        """nexus-lrhg #3: rebuild runs with FK enforcement disabled so
+        the DELETE FROM documents does not cascade to document_chunks.
+        Manifest rows referencing a tombstoned doc_id that the JSONL
+        replay does not re-INSERT must be purged explicitly before
+        FK=ON is re-enabled, else they survive forever as silent orphans
+        (PRAGMA foreign_keys=ON only enforces new writes, not existing
+        rows).
+        """
+        cat, owner = cat_with_owner
+        doc = cat.register(owner, "ghost.py", content_type="code", file_path="ghost.py")
+        # Plant a manifest row for the doc.
+        cat._db.execute(
+            "INSERT INTO document_chunks "
+            "(doc_id, position, chash, chunk_index, "
+            " line_start, line_end, char_start, char_end) "
+            "VALUES (?, 0, ?, 0, NULL, NULL, NULL, NULL)",
+            (str(doc), "a" * 32),
+        )
+        cat._db.commit()
+        # Tombstone the doc via JSONL append (the post-RDR-101 deletion
+        # contract — replay sees the DocumentDeleted shape).
+        tombstone = {"tumbler": str(doc), "_deleted": True, "title": "",
+                     "author": "", "year": 0, "content_type": "",
+                     "file_path": "ghost.py", "corpus": "",
+                     "physical_collection": "", "chunk_count": 0,
+                     "head_hash": "", "indexed_at": "", "meta": {}}
+        with (cat._dir / "documents.jsonl").open("a") as f:
+            f.write(json.dumps(tombstone) + "\n")
+
+        cat2 = Catalog(cat._dir, cat._dir / ".catalog.db2")
+        cat2.rebuild()
+
+        # Doc is gone from the documents projection.
+        assert cat2.resolve(doc) is None
+        # Manifest rows referencing it must also be gone (no orphans).
+        rows = cat2._db.execute(
+            "SELECT COUNT(*) FROM document_chunks WHERE doc_id = ?",
+            (str(doc),),
+        ).fetchone()[0]
+        assert rows == 0, (
+            f"expected zero orphan document_chunks for tombstoned doc, "
+            f"got {rows}"
+        )
+
 
 class TestEnsureConsistentDegradedFlag:
     def test_degraded_false_on_success(self, cat):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -848,7 +848,7 @@ class TestRebuild:
         cat, owner = cat_with_owner
         doc = cat.register(owner, "ghost.py", content_type="code", file_path="ghost.py")
         # Plant a manifest row for the doc.
-        cat._db.execute(
+        cat._db.execute(  # epsilon-allow: test seeds an orphan document_chunks row to verify post-rebuild cascade purge — the whole point is the row pre-exists outside Catalog public API
             "INSERT INTO document_chunks "
             "(doc_id, position, chash, chunk_index, "
             " line_start, line_end, char_start, char_end) "

--- a/tests/test_catalog_manifest_backfill.py
+++ b/tests/test_catalog_manifest_backfill.py
@@ -295,6 +295,125 @@ class TestWriteManifest:
 # ── Integration tests: backfill_manifest_for_collection ─────────────────────
 
 
+class TestAtomicManifestReplace:
+    """nexus-lrhg #1: atomic_manifest_replace bundles DELETE +
+    INSERT + chunk_count UPDATE in one transaction so a partial
+    failure cannot leave the catalog with zero chunks while
+    documents.chunk_count still claims N.
+    """
+
+    def test_replace_writes_chunks_and_updates_chunk_count(self, catalog):
+        coll = _unique_coll()
+        _insert_doc(catalog, "1.1.1", coll)
+        chunks = [
+            {"chash": "a" * 64, "position": 0, "line_start": None,
+             "line_end": None, "char_start": None, "char_end": None},
+            {"chash": "b" * 64, "position": 1, "line_start": None,
+             "line_end": None, "char_start": None, "char_end": None},
+        ]
+        catalog.atomic_manifest_replace("1.1.1", chunks)
+
+        rows = catalog._db.execute(
+            "SELECT position, chash FROM document_chunks "
+            "WHERE doc_id = ? ORDER BY position",
+            ("1.1.1",),
+        ).fetchall()
+        assert rows == [(0, "a" * 64), (1, "b" * 64)]
+
+        cc = catalog._db.execute(
+            "SELECT chunk_count FROM documents WHERE tumbler = ?",
+            ("1.1.1",),
+        ).fetchone()[0]
+        assert cc == 2
+
+    def test_replace_shrinks_manifest_and_chunk_count(self, catalog):
+        """Shrink-reindex: replace 3-chunk manifest with 1-chunk.
+        DELETE clears the prior 3; INSERT writes the new 1; chunk_count
+        re-derives to 1. No orphan rows survive."""
+        coll = _unique_coll()
+        _insert_doc(catalog, "1.1.1", coll)
+
+        catalog.atomic_manifest_replace("1.1.1", [
+            {"chash": x * 64, "position": p, "line_start": None,
+             "line_end": None, "char_start": None, "char_end": None}
+            for p, x in enumerate(("a", "b", "c"))
+        ])
+        cc_before = catalog._db.execute(
+            "SELECT chunk_count FROM documents WHERE tumbler = ?",
+            ("1.1.1",),
+        ).fetchone()[0]
+        assert cc_before == 3
+
+        catalog.atomic_manifest_replace("1.1.1", [
+            {"chash": "z" * 64, "position": 0, "line_start": None,
+             "line_end": None, "char_start": None, "char_end": None}
+        ])
+        rows = catalog._db.execute(
+            "SELECT chash FROM document_chunks WHERE doc_id = ?",
+            ("1.1.1",),
+        ).fetchall()
+        assert rows == [("z" * 64,)]
+        cc_after = catalog._db.execute(
+            "SELECT chunk_count FROM documents WHERE tumbler = ?",
+            ("1.1.1",),
+        ).fetchone()[0]
+        assert cc_after == 1
+
+    def test_replace_empty_chunks_clears_and_zeros_count(self, catalog):
+        """Replace with empty list: DELETE clears, no INSERT, count
+        re-derives to 0. Valid representation for a doc with no
+        manifested chunks."""
+        coll = _unique_coll()
+        _insert_doc(catalog, "1.1.1", coll)
+        catalog.atomic_manifest_replace("1.1.1", [
+            {"chash": "a" * 64, "position": 0, "line_start": None,
+             "line_end": None, "char_start": None, "char_end": None}
+        ])
+
+        catalog.atomic_manifest_replace("1.1.1", [])
+        rows = catalog._db.execute(
+            "SELECT COUNT(*) FROM document_chunks WHERE doc_id = ?",
+            ("1.1.1",),
+        ).fetchone()[0]
+        assert rows == 0
+        cc = catalog._db.execute(
+            "SELECT chunk_count FROM documents WHERE tumbler = ?",
+            ("1.1.1",),
+        ).fetchone()[0]
+        assert cc == 0
+
+    def test_replace_is_atomic_on_insert_failure(self, catalog):
+        """Force an INSERT failure mid-replace and confirm the prior
+        manifest survives (no torn state)."""
+        coll = _unique_coll()
+        _insert_doc(catalog, "1.1.1", coll)
+        # Seed an initial valid manifest.
+        catalog.atomic_manifest_replace("1.1.1", [
+            {"chash": "a" * 64, "position": 0, "line_start": None,
+             "line_end": None, "char_start": None, "char_end": None}
+        ])
+
+        # Pass duplicate positions to trigger a PK violation INSIDE the
+        # batched INSERT. The transaction must roll back, leaving the
+        # original "a" * 64 row intact.
+        bad_chunks = [
+            {"chash": "b" * 64, "position": 0, "line_start": None,
+             "line_end": None, "char_start": None, "char_end": None},
+            {"chash": "c" * 64, "position": 0, "line_start": None,
+             "line_end": None, "char_start": None, "char_end": None},
+        ]
+        with pytest.raises(Exception):
+            catalog.atomic_manifest_replace("1.1.1", bad_chunks)
+
+        rows = catalog._db.execute(
+            "SELECT chash FROM document_chunks WHERE doc_id = ?",
+            ("1.1.1",),
+        ).fetchall()
+        assert rows == [("a" * 64,)], (
+            f"prior manifest must survive a mid-replace failure; got {rows!r}"
+        )
+
+
 class TestBackfillManifestForCollection:
     """Tests for the core backfill function that reads T3 and writes manifests."""
 

--- a/tests/test_catalog_manifest_backfill.py
+++ b/tests/test_catalog_manifest_backfill.py
@@ -306,9 +306,9 @@ class TestAtomicManifestReplace:
         coll = _unique_coll()
         _insert_doc(catalog, "1.1.1", coll)
         chunks = [
-            {"chash": "a" * 64, "position": 0, "line_start": None,
+            {"chash": "a" * 32, "position": 0, "line_start": None,
              "line_end": None, "char_start": None, "char_end": None},
-            {"chash": "b" * 64, "position": 1, "line_start": None,
+            {"chash": "b" * 32, "position": 1, "line_start": None,
              "line_end": None, "char_start": None, "char_end": None},
         ]
         catalog.atomic_manifest_replace("1.1.1", chunks)
@@ -318,7 +318,7 @@ class TestAtomicManifestReplace:
             "WHERE doc_id = ? ORDER BY position",
             ("1.1.1",),
         ).fetchall()
-        assert rows == [(0, "a" * 64), (1, "b" * 64)]
+        assert rows == [(0, "a" * 32), (1, "b" * 32)]
 
         cc = catalog._db.execute(
             "SELECT chunk_count FROM documents WHERE tumbler = ?",
@@ -334,7 +334,7 @@ class TestAtomicManifestReplace:
         _insert_doc(catalog, "1.1.1", coll)
 
         catalog.atomic_manifest_replace("1.1.1", [
-            {"chash": x * 64, "position": p, "line_start": None,
+            {"chash": x * 32, "position": p, "line_start": None,
              "line_end": None, "char_start": None, "char_end": None}
             for p, x in enumerate(("a", "b", "c"))
         ])
@@ -345,14 +345,14 @@ class TestAtomicManifestReplace:
         assert cc_before == 3
 
         catalog.atomic_manifest_replace("1.1.1", [
-            {"chash": "z" * 64, "position": 0, "line_start": None,
+            {"chash": "z" * 32, "position": 0, "line_start": None,
              "line_end": None, "char_start": None, "char_end": None}
         ])
         rows = catalog._db.execute(
             "SELECT chash FROM document_chunks WHERE doc_id = ?",
             ("1.1.1",),
         ).fetchall()
-        assert rows == [("z" * 64,)]
+        assert rows == [("z" * 32,)]
         cc_after = catalog._db.execute(
             "SELECT chunk_count FROM documents WHERE tumbler = ?",
             ("1.1.1",),
@@ -366,7 +366,7 @@ class TestAtomicManifestReplace:
         coll = _unique_coll()
         _insert_doc(catalog, "1.1.1", coll)
         catalog.atomic_manifest_replace("1.1.1", [
-            {"chash": "a" * 64, "position": 0, "line_start": None,
+            {"chash": "a" * 32, "position": 0, "line_start": None,
              "line_end": None, "char_start": None, "char_end": None}
         ])
 
@@ -389,17 +389,17 @@ class TestAtomicManifestReplace:
         _insert_doc(catalog, "1.1.1", coll)
         # Seed an initial valid manifest.
         catalog.atomic_manifest_replace("1.1.1", [
-            {"chash": "a" * 64, "position": 0, "line_start": None,
+            {"chash": "a" * 32, "position": 0, "line_start": None,
              "line_end": None, "char_start": None, "char_end": None}
         ])
 
         # Pass duplicate positions to trigger a PK violation INSIDE the
         # batched INSERT. The transaction must roll back, leaving the
-        # original "a" * 64 row intact.
+        # original "a" * 32 row intact.
         bad_chunks = [
-            {"chash": "b" * 64, "position": 0, "line_start": None,
+            {"chash": "b" * 32, "position": 0, "line_start": None,
              "line_end": None, "char_start": None, "char_end": None},
-            {"chash": "c" * 64, "position": 0, "line_start": None,
+            {"chash": "c" * 32, "position": 0, "line_start": None,
              "line_end": None, "char_start": None, "char_end": None},
         ]
         with pytest.raises(Exception):
@@ -409,7 +409,7 @@ class TestAtomicManifestReplace:
             "SELECT chash FROM document_chunks WHERE doc_id = ?",
             ("1.1.1",),
         ).fetchall()
-        assert rows == [("a" * 64,)], (
+        assert rows == [("a" * 32,)], (
             f"prior manifest must survive a mid-replace failure; got {rows!r}"
         )
 

--- a/tests/test_catalog_manifest_read_api.py
+++ b/tests/test_catalog_manifest_read_api.py
@@ -853,9 +853,16 @@ class TestManifestWriteBatchHook:
         metadatas = [
             {"chunk_index": 0, "chunk_text_hash": "a" * 32},
         ]
-        # Force append_manifest_chunks to raise.
+        # nexus-lrhg: the hook routes to atomic_manifest_replace when
+        # the batch contains position 0 (first batch of a re-index) and
+        # to append_manifest_chunks otherwise. Patch both so the
+        # warning-on-exception contract is exercised regardless of
+        # which branch fires.
         with patch.object(
             type(cat), "append_manifest_chunks",
+            side_effect=RuntimeError("induced manifest failure"),
+        ), patch.object(
+            type(cat), "atomic_manifest_replace",
             side_effect=RuntimeError("induced manifest failure"),
         ), patch("nexus.mcp_infra.get_catalog", return_value=cat), \
                 capture_logs() as cap:


### PR DESCRIPTION
## Summary

Closes the remaining 2 of 8 findings in \`nexus-lrhg\` (P1 RDR-108 audit umbrella).

## Fixed

### Finding 1 — \`manifest_write_batch_hook\` torn-state window

The per-batch hook ran \`purge_manifest_for_doc\` → \`append_manifest_chunks\` → \`resync_chunk_count_cache\` as three separate transactions. A failure between the DELETE and the INSERT left the catalog with zero chunks for the doc while \`documents.chunk_count\` still claimed N — a silent data-correctness bug surviving until the next full re-index.

New \`_WriteOps.atomic_manifest_replace\` bundles DELETE + INSERT + \`chunk_count\` UPDATE under one \`CatalogDB.transaction\`. \`Catalog.atomic_manifest_replace\` facade exposes it. The hook calls it on first-batch (position 0 present) so shrink-reindex is now all-or-nothing; multi-batch streaming continues to use \`append_manifest_chunks\` + \`resync_chunk_count_cache\` (separate transactions are fine when there is no DELETE phase to make atomic).

### Finding 3 — DocumentDeleted replay leaves orphan document_chunks

\`CatalogDB.rebuild\` runs with \`PRAGMA foreign_keys=OFF\` (RDR-108 Phase 3 bdag) so \`DELETE FROM documents\` does not cascade-wipe the manifest the post-store batch hook owns. INSERTs restore valid references. But manifest rows whose \`doc_id\` was tombstoned (replay sees a \`DocumentDeleted\`) and not re-INSERTed survive as orphans — \`PRAGMA foreign_keys=ON\` only checks new writes, not existing rows.

After \`_rebuild_inner\` and before \`PRAGMA foreign_keys=ON\`, run \`DELETE FROM document_chunks WHERE doc_id NOT IN (SELECT tumbler FROM documents)\`. Structured INFO log records the purge count so an operator sees the cleanup.

## Tests

- \`TestAtomicManifestReplace\` (4 tests): writes + chunk_count update, shrink-reindex, empty replace, atomicity on insert failure
- \`test_rebuild_purges_orphan_document_chunks_for_tombstoned_docs\` locks the rebuild guard
- 194 tests pass across catalog + catalog_manifest_backfill + catalog_event_sourced_mutators + post_store_hook + post_document_hooks

## Closes

- Closes #nexus-lrhg (finishes the bundle alongside PR #711)
- Umbrella: \`nexus-58ui\` (this is the last bead in the umbrella)

## Test plan

- [x] Local affected suites pass
- [ ] CI green