### PR TITLE
feat(collection): add in-place re-embed verb (bw65)

### DIFF
--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -820,6 +820,177 @@ def backfill_hash_cmd(name: str | None, all_collections: bool) -> None:
         chash_index.close()
 
 
+_REEMBED_SUPPORTED_MODELS = ("voyage-3", "voyage-code-3")
+
+
+def _reembed_collection(
+    db,
+    col_name: str,
+    target_model: str,
+    *,
+    dry_run: bool,
+    on_progress=None,
+) -> tuple[int, int]:
+    """Re-embed every chunk in *col_name* with *target_model*.
+
+    Preserves chunk id, document text, and metadata. Only the embedding
+    vector changes. Returns ``(processed, skipped)``.
+
+    nexus-bw65: in-place re-embed for non-CCE Voyage models. CCE
+    (``voyage-context-3``) requires sliding-window context across chunks
+    and is intentionally out of scope; the CLI rejects it up front.
+    """
+    from nexus.db.chroma_quotas import QUOTAS
+    from nexus.retry import _voyage_with_retry
+
+    try:
+        col = db._client.get_collection(col_name)
+    except Exception as exc:
+        raise click.ClickException(
+            f"collection {col_name!r}: {type(exc).__name__}: {exc}"
+        )
+
+    total = col.count()
+    if total == 0:
+        return 0, 0
+
+    voyage_client = None
+    if not dry_run:
+        from nexus.config import get_credential
+
+        key = get_credential("voyage_api_key")
+        if not key:
+            raise click.ClickException(
+                "VOYAGE_API_KEY not set; cannot re-embed without it. "
+                "(Dry-run only requires read access.)"
+            )
+        import voyageai  # noqa: PLC0415
+
+        voyage_client = voyageai.Client(api_key=key)
+
+    processed = 0
+    skipped = 0
+    page = QUOTAS.MAX_QUERY_RESULTS  # 300
+    voyage_batch = 128  # Voyage embed API batch limit
+    offset = 0
+    while offset < total:
+        page_rows = col.get(
+            limit=page, offset=offset,
+            include=["documents", "metadatas"],
+        )
+        ids = page_rows.get("ids") or []
+        documents = page_rows.get("documents") or []
+        metadatas = page_rows.get("metadatas") or []
+        if not ids:
+            break
+
+        valid_idx = [
+            i for i, d in enumerate(documents)
+            if isinstance(d, str) and d.strip()
+        ]
+        skipped += len(ids) - len(valid_idx)
+        if not valid_idx:
+            offset += page
+            continue
+
+        v_ids = [ids[i] for i in valid_idx]
+        v_docs = [documents[i] for i in valid_idx]
+        v_metas = [metadatas[i] for i in valid_idx]
+
+        if not dry_run:
+            embeddings: list[list[float]] = []
+            for batch_start in range(0, len(v_docs), voyage_batch):
+                batch = v_docs[batch_start : batch_start + voyage_batch]
+                result = _voyage_with_retry(
+                    voyage_client.embed,
+                    texts=batch,
+                    model=target_model,
+                    input_type="document",
+                )
+                embeddings.extend(result.embeddings)
+            # Stamp the new model on metadata so check_staleness reads
+            # right post-re-embed; otherwise next index pass would treat
+            # every chunk as stale and re-embed twice.
+            for m in v_metas:
+                if isinstance(m, dict):
+                    m["embedding_model"] = target_model
+            db.upsert_chunks_with_embeddings(
+                collection_name=col_name,
+                ids=v_ids,
+                documents=v_docs,
+                embeddings=embeddings,
+                metadatas=v_metas,
+            )
+
+        processed += len(v_ids)
+        if on_progress is not None:
+            on_progress(processed, total)
+        offset += page
+
+    return processed, skipped
+
+
+@collection.command("re-embed")
+@click.argument("name")
+@click.option(
+    "--to", "target_model", required=True,
+    type=click.Choice(_REEMBED_SUPPORTED_MODELS),
+    help="Target embedding model (CCE models like voyage-context-3 are "
+         "intentionally not supported — see nexus-bw65).",
+)
+@click.option("--dry-run/--no-dry-run", default=True,
+              help="Default dry-run. Pass --no-dry-run to actually write.")
+@click.option("--yes", is_flag=True, default=False,
+              help="Skip the destructive-action confirmation prompt.")
+def reembed_cmd(
+    name: str, target_model: str, dry_run: bool, yes: bool,
+) -> None:
+    """In-place re-embed: preserve content, swap embedding model.
+
+    nexus-bw65: rebuild embeddings for every chunk in NAME using
+    --to MODEL. Chunk ids, document text, and metadata are
+    preserved; only the vector changes.
+
+    Use case: an embedding-model upgrade on a sourceless collection
+    (store_put-only / MCP-promoted notes). For source-backed
+    collections prefer ``nx collection reindex`` so the indexer
+    re-derives chunk boundaries with the new chunker contract.
+
+    Limitations:
+      - Only non-CCE Voyage models are supported. Contextualized
+        Chunk Embeddings (voyage-context-3) require sliding-window
+        context across chunks and need a different pipeline.
+      - The collection's name often encodes the embedding model
+        (RDR-103 / nexus-1-1__voyage-code-3__v1). This command does
+        NOT rename the collection; run ``nx collection rename`` if
+        the name needs to track the new model.
+    """
+    if not dry_run and not yes:
+        click.confirm(
+            f"Re-embed {name!r} with {target_model!r}? This rewrites "
+            f"every chunk's vector in place.",
+            abort=True,
+        )
+
+    db = _t3()
+    if dry_run:
+        col = db._client.get_collection(name)
+        n = col.count()
+        click.echo(
+            f"dry-run: would re-embed {n} chunk(s) in {name!r} with "
+            f"{target_model!r}. Pass --no-dry-run --yes to apply."
+        )
+        return
+
+    processed, skipped = _reembed_collection(
+        db, name, target_model, dry_run=False,
+    )
+    click.echo(
+        f"re-embedded {processed} chunk(s) in {name!r} with "
+        f"{target_model!r}; skipped {skipped} empty-document row(s)."
+    )
+
+
 @collection.command("rewrite-metadata")
 @click.argument("name", required=False, default=None)
 @click.option("--all", "all_collections", is_flag=True,

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -921,6 +921,25 @@ def _reembed_collection(
                 embeddings=embeddings,
                 metadatas=v_metas,
             )
+            # nexus-bw65 / nexus-9099: fire post-store chains so the
+            # invariant 'every CLI T3 write also fires the chain'
+            # (test_every_cli_t3_write_function_fires_store_chains)
+            # holds. Re-embed preserves doc_id / chash / manifest
+            # position, so the chain's hooks (chash_dual_write,
+            # taxonomy_assign, manifest_write) re-touch existing rows
+            # idempotently.
+            from nexus.mcp_infra import fire_store_chains
+
+            fire_store_chains(
+                v_ids, col_name, v_docs,
+                source_paths=[
+                    (m.get("source_path", "") if isinstance(m, dict) else "")
+                    for m in v_metas
+                ],
+                embeddings=embeddings,
+                metadatas=v_metas,
+                catalog_doc_id="",
+            )
 
         processed += len(v_ids)
         if on_progress is not None:

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -593,3 +593,143 @@ def test_corpus_default_keeps_docs_collection(tmp_path, monkeypatch) -> None:
     assert entry["docs_collection"].startswith("docs__"), (
         f"default routing changed; got {entry['docs_collection']!r}"
     )
+
+
+# ── re-embed (nexus-bw65) ──────────────────────────────────────────────────
+
+
+def test_reembed_dry_run_reports_count(runner, env_creds, tmp_path) -> None:
+    """nexus-bw65: --dry-run (default) reports the chunk count that
+    would be re-embedded without making any writes. No Voyage call."""
+    import chromadb
+    import uuid
+
+    coll_name = f"knowledge__rem_{uuid.uuid4().hex[:12]}"
+    client = chromadb.EphemeralClient()
+    col = client.get_or_create_collection(coll_name)
+    col.add(
+        ids=["c1", "c2"], documents=["doc one", "doc two"],
+        metadatas=[
+            {"content_hash": "h1", "embedding_model": "voyage-3"},
+            {"content_hash": "h2", "embedding_model": "voyage-3"},
+        ],
+    )
+
+    fake_db = MagicMock()
+    fake_db._client = client
+
+    result = _invoke(
+        runner, fake_db,
+        ["re-embed", coll_name, "--to", "voyage-code-3"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "dry-run" in result.output
+    assert "2" in result.output
+
+
+def test_reembed_no_dry_run_writes_via_voyage(
+    runner, env_creds, tmp_path, monkeypatch,
+) -> None:
+    """nexus-bw65: --no-dry-run --yes embeds via Voyage and upserts the
+    new vectors. Chunk ids + document text + metadata preserved;
+    metadata.embedding_model stamped to the target model.
+    """
+    import chromadb
+    import uuid
+
+    coll_name = f"knowledge__rem_{uuid.uuid4().hex[:12]}"
+    client = chromadb.EphemeralClient()
+    col = client.get_or_create_collection(coll_name)
+    col.add(
+        ids=["c1", "c2"], documents=["doc one", "doc two"],
+        metadatas=[
+            {"content_hash": "h1", "embedding_model": "voyage-3"},
+            {"content_hash": "h2", "embedding_model": "voyage-3"},
+        ],
+    )
+
+    fake_db = MagicMock()
+    fake_db._client = client
+
+    upsert_calls: list[dict] = []
+
+    def _capture_upsert(**kw):
+        upsert_calls.append(kw)
+
+    fake_db.upsert_chunks_with_embeddings.side_effect = _capture_upsert
+
+    fake_embed_result = MagicMock()
+    fake_embed_result.embeddings = [[0.5] * 1024, [0.7] * 1024]
+    fake_voyage_client = MagicMock()
+    fake_voyage_client.embed.return_value = fake_embed_result
+
+    with patch("voyageai.Client", return_value=fake_voyage_client):
+        result = _invoke(
+            runner, fake_db,
+            ["re-embed", coll_name, "--to", "voyage-code-3",
+             "--no-dry-run", "--yes"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "re-embedded 2" in result.output
+    assert len(upsert_calls) == 1
+    call = upsert_calls[0]
+    assert call["collection_name"] == coll_name
+    assert call["ids"] == ["c1", "c2"]
+    assert call["documents"] == ["doc one", "doc two"]
+    # embedding_model stamped to target model on every row.
+    assert all(
+        m["embedding_model"] == "voyage-code-3" for m in call["metadatas"]
+    )
+    # Voyage embed called with target model.
+    fake_voyage_client.embed.assert_called_once()
+    assert fake_voyage_client.embed.call_args.kwargs["model"] == "voyage-code-3"
+
+
+def test_reembed_rejects_cce_model(runner, env_creds) -> None:
+    """nexus-bw65: voyage-context-3 (CCE) is not supported; click.Choice
+    rejects at parse time."""
+    result = _invoke(
+        runner, MagicMock(),
+        ["re-embed", "knowledge__any", "--to", "voyage-context-3"],
+    )
+    assert result.exit_code != 0
+    assert "voyage-context-3" in result.output or "Invalid value" in result.output
+
+
+def test_reembed_skips_empty_documents(
+    runner, env_creds, monkeypatch,
+) -> None:
+    """nexus-bw65: chunks with empty / whitespace-only document text are
+    skipped (Voyage rejects empty strings). Counted under ``skipped``."""
+    import chromadb
+    import uuid
+
+    coll_name = f"knowledge__rem_{uuid.uuid4().hex[:12]}"
+    client = chromadb.EphemeralClient()
+    col = client.get_or_create_collection(coll_name)
+    col.add(
+        ids=["good", "blank"],
+        documents=["real content", "   "],
+        metadatas=[
+            {"content_hash": "h1", "embedding_model": "voyage-3"},
+            {"content_hash": "h2", "embedding_model": "voyage-3"},
+        ],
+    )
+
+    fake_db = MagicMock()
+    fake_db._client = client
+
+    fake_embed_result = MagicMock()
+    fake_embed_result.embeddings = [[0.5] * 1024]
+    fake_voyage_client = MagicMock()
+    fake_voyage_client.embed.return_value = fake_embed_result
+
+    with patch("voyageai.Client", return_value=fake_voyage_client):
+        result = _invoke(
+            runner, fake_db,
+            ["re-embed", coll_name, "--to", "voyage-3",
+             "--no-dry-run", "--yes"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "re-embedded 1" in result.output
+    assert "skipped 1" in result.output


### PR DESCRIPTION
## Summary

Closes \`nexus-bw65\`. CHANGELOG.md:2328 cited 'in-place re-embedding is the user's underlying need and is filed as a follow-up' for the embedding-model-upgrade use case on sourceless collections (store_put-only / MCP-promoted notes). \`nx collection reindex\` refuses unconditionally on all-sourceless collections (correct, it would delete data with nothing to re-index from). Operators needed a non-destructive path.

## Added

New \`nx collection re-embed NAME --to MODEL\` subcommand. Reads every chunk's document text, embeds with target model via Voyage, upserts the new vector in place. Chunk ids, document text, and metadata are preserved; \`metadata.embedding_model\` is stamped to the target model so subsequent \`check_staleness\` sees the new model and does not re-embed everything a second time.

## Scope

- Non-CCE Voyage models only (\`voyage-3\`, \`voyage-code-3\`). CCE (\`voyage-context-3\`) needs sliding-window context across chunks and a different pipeline; click.Choice rejects it at parse time with a clear error.
- Default \`--dry-run\` reports the chunk count without making any Voyage call (no credentials required). \`--no-dry-run --yes\` applies the rewrite.
- Empty / whitespace-only documents are skipped (Voyage rejects empty strings); reported under \`skipped\` in the summary line.
- Collection NAME is preserved. RDR-103 names embed the model (\`code__owner__voyage-code-3__v1\`); this verb does not rename. Operators handle catalog renames via \`nx collection rename\`.

## Batching

- Page T3 reads at \`QUOTAS.MAX_QUERY_RESULTS\` (300).
- Voyage embed at 128 inputs per batch.
- \`_voyage_with_retry\` handles transient errors.

## Tests

- \`test_reembed_dry_run_reports_count\` locks dry-run output without Voyage credentials.
- \`test_reembed_no_dry_run_writes_via_voyage\` locks the upsert call: ids + documents preserved, metadata.embedding_model stamped, Voyage embed called with target model.
- \`test_reembed_rejects_cce_model\` locks the parse-time guard.
- \`test_reembed_skips_empty_documents\` locks the empty-doc skip contract.
- 35 collection_cmd tests pass.

## Closes

- Closes #nexus-bw65

## Test plan

- [x] Local affected suite passes
- [ ] CI green