### PR TITLE
test(assertions): exact == replaces inequalities on deterministic fixtures (8g79.23 batch 2)

### DIFF
--- a/tests/test_ast_languages.py
+++ b/tests/test_ast_languages.py
@@ -11,7 +11,7 @@ def test_python_function_extraction():
     """chunk_file extracts Python function definitions with correct metadata."""
     src = "def hello(name: str) -> str:\n    return f'Hello {name}'\n\ndef goodbye():\n    pass\n"
     chunks = chunk_file(Path("example.py"), src)
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert chunks[0]["file_path"].endswith(".py")
     assert any("hello" in c["text"] for c in chunks)
 
@@ -27,7 +27,7 @@ def test_python_class_extraction():
         "        return f'Hi {self.name}'\n"
     )
     chunks = chunk_file(Path("greeter.py"), src)
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert any("Greeter" in c["text"] for c in chunks)
 
 
@@ -57,7 +57,7 @@ def test_javascript_function_extraction():
         "}\n"
     )
     chunks = chunk_file(Path("app.js"), src)
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert chunks[0]["file_path"].endswith(".js")
     assert any("greet" in c["text"] or "Animal" in c["text"] for c in chunks)
 
@@ -77,7 +77,7 @@ def test_typescript_function_extraction():
         "}\n"
     )
     chunks = chunk_file(Path("server.ts"), src)
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert chunks[0]["file_path"].endswith(".ts")
 
 
@@ -102,7 +102,7 @@ def test_go_function_extraction():
         "}\n"
     )
     chunks = chunk_file(Path("main.go"), src)
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert chunks[0]["file_path"].endswith(".go")
     assert any("Server" in c["text"] for c in chunks)
 
@@ -128,7 +128,7 @@ def test_rust_function_extraction():
         "}\n"
     )
     chunks = chunk_file(Path("main.rs"), src)
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert chunks[0]["file_path"].endswith(".rs")
 
 
@@ -151,7 +151,7 @@ def test_java_class_extraction():
         "}\n"
     )
     chunks = chunk_file(Path("Calculator.java"), src)
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert chunks[0]["file_path"].endswith(".java")
     assert any("Calculator" in c["text"] for c in chunks)
 

--- a/tests/test_catalog_e2e.py
+++ b/tests/test_catalog_e2e.py
@@ -173,7 +173,7 @@ class TestMCP:
     def test_search_returns_indexed_files(self, injected_catalog):
         from nexus.mcp_server import catalog_search
         results = catalog_search(query="ttl")
-        assert len(results) >= 1
+        assert len(results) == 3
         assert any("ttl" in r.get("title", "").lower() or "ttl" in r.get("file_path", "").lower()
                     for r in results)
 
@@ -183,7 +183,7 @@ class TestMCP:
         owner = cat._db.execute("SELECT tumbler_prefix FROM owners LIMIT 1").fetchone()
         assert owner is not None
         results = catalog_search(owner=owner[0])
-        assert len(results) >= 1 and "error" not in results[0]
+        assert len(results) == 5 and "error" not in results[0]
 
     def test_show_returns_full_entry(self, injected_catalog):
         from nexus.mcp_server import catalog_show
@@ -198,12 +198,12 @@ class TestMCP:
         cat, _ = injected_catalog
         owner = cat._db.execute("SELECT tumbler_prefix FROM owners LIMIT 1").fetchone()
         result = catalog_resolve(owner=owner[0])
-        assert len(result) >= 1 and any("__" in n for n in result)
+        assert len(result) == 3 and any("__" in n for n in result)
 
     def test_search_then_traverse_links(self, injected_catalog):
         from nexus.mcp_server import catalog_links, catalog_search
         results = catalog_search(query="ttl")
-        assert len(results) >= 1
+        assert len(results) == 3
         tumbler = results[0]["tumbler"]
         graph = catalog_links(tumbler=tumbler, depth=1)
         assert "nodes" in graph and "edges" in graph
@@ -220,7 +220,7 @@ class TestMCP:
     def test_link_audit_after_indexing(self, injected_catalog):
         from nexus.mcp_server import catalog_link_audit
         audit = catalog_link_audit()
-        assert "error" not in audit and audit["total"] >= 1
+        assert "error" not in audit and audit["total"] == 2
         assert audit["orphaned_count"] == 0
 
 

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -1332,7 +1332,8 @@ def test_index_threads_on_progress(indexer, sample_pdf, sample_md, monkeypatch, 
                 with patch("voyageai.Client", return_value=voyage_client):
                     chk_cls.return_value.chunk.return_value = [chunk]
                     result = index_markdown(path, corpus="docs", on_progress=lambda d, t: progress.append((d, t)))
-    assert result >= 1
+    # nexus-8g79.23: exact count — one mock chunk planted, one indexed.
+    assert result == 1
     assert progress
 
 

--- a/tests/test_local_mode.py
+++ b/tests/test_local_mode.py
@@ -123,7 +123,7 @@ class TestT3DatabaseLocalMode:
         )
         assert doc_id
         results = local_db.search("programming language", collection_names=["knowledge__test"])
-        assert len(results) >= 1
+        assert len(results) == 1
         assert any("Python" in r.get("content", "") for r in results)
 
     def test_local_mode_put_does_not_emit_source_path(
@@ -282,12 +282,12 @@ class TestLocalCollectionLifecycle:
         assert doc_id
 
         results = local_db.search("systems programming", collection_names=["knowledge__lifecycle"])
-        assert len(results) >= 1
+        assert len(results) == 1
         assert any("Rust" in r.get("content", "") for r in results)
 
         names = [c["name"] for c in local_db.list_collections()]
         assert "knowledge__lifecycle" in names
-        assert len(local_db.list_store("knowledge__lifecycle")) >= 1
+        assert len(local_db.list_store("knowledge__lifecycle")) == 1
         assert local_db.delete_by_id("knowledge__lifecycle", doc_id) is True
 
     def test_expire_ttl_entries(self, local_db: T3Database) -> None:
@@ -322,8 +322,8 @@ class TestLocalCollectionLifecycle:
             title="perm",
             ttl_days=0,
         )
-        assert local_db.expire() >= 1
-        assert len(local_db.search("permanent", collection_names=["knowledge__expire_test"])) >= 1
+        assert local_db.expire() == 1
+        assert len(local_db.search("permanent", collection_names=["knowledge__expire_test"])) == 1
 
 
 # ── Corpus model consistency ──────────────────────────────────────────────────

--- a/tests/test_md_chunker.py
+++ b/tests/test_md_chunker.py
@@ -48,7 +48,7 @@ def test_chunk_empty_text_returns_empty(chunker):
 
 def test_chunk_headings_create_separate_sections(chunker):
     chunks = chunker.chunk("# Introduction\n\nIntro content.\n\n## Background\n\nBG content.", {})
-    assert len(chunks) >= 2
+    assert len(chunks) == 2
 
 
 def test_chunk_header_path_in_metadata(chunker):
@@ -82,7 +82,7 @@ def test_chunk_pre_heading_content_is_not_dropped(chunker):
 
 def test_chunk_only_pre_heading_content(chunker):
     chunks = chunker.chunk("Just some plain content with no headings.\n\nAnother paragraph.", {})
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert "plain content" in " ".join(c.text for c in chunks)
 
 
@@ -93,7 +93,7 @@ def test_chunk_naive_fallback_without_markdown_it(monkeypatch):
     chunker = SemanticMarkdownChunker(chunk_size=50)
     chunker.md = None
     chunks = chunker.chunk("Some content here.\n\nMore content below.\n\nThird paragraph.", {})
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert all(c.text.strip() for c in chunks)
 
 
@@ -101,7 +101,7 @@ def test_chunk_semantic_exception_falls_back_to_naive():
     chunker = SemanticMarkdownChunker(chunk_size=512)
     chunker.md.parse = lambda text: (_ for _ in ()).throw(RuntimeError("boom"))
     chunks = chunker.chunk("Some plain text content.", {"source": "test"})
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert "plain text" in chunks[0].text
 
 
@@ -109,7 +109,7 @@ def test_chunk_semantic_exception_falls_back_to_naive():
 
 def test_semantic_chunk_offsets(chunker):
     chunks = chunker.chunk("# Alpha\n\nContent for alpha.\n\n# Beta\n\nContent for beta.", {})
-    assert len(chunks) >= 2
+    assert len(chunks) == 2
     for c in chunks:
         assert "chunk_start_char" in c.metadata
         assert "chunk_end_char" in c.metadata
@@ -129,7 +129,7 @@ def test_split_large_section_truncates_oversized_part():
         "content_parts": [{"type": "text", "content": "x" * 10000, "is_code_block": False}],
     }
     chunks = chunker._split_large_section(section, {}, start_index=0)
-    assert len(chunks) >= 1
+    assert len(chunks) == 2
     for chunk in chunks:
         assert len(chunk.text) <= chunker.max_chars + len("# Big Section") + 4
 
@@ -141,7 +141,7 @@ def test_split_large_section_truncation_with_overlap():
         "content_parts": [{"type": "text", "content": "x" * 10000, "is_code_block": False}],
     }
     chunks = chunker._split_large_section(section, {}, start_index=0)
-    assert len(chunks) >= 1
+    assert len(chunks) == 2
     budget = chunker.max_chars + len("# Big") + chunker.overlap_chars + 8
     for chunk in chunks:
         assert len(chunk.text) <= budget
@@ -180,6 +180,10 @@ def test_md_chunker_byte_cap_enforced(text):
     from nexus.db.chroma_quotas import SAFE_CHUNK_BYTES
     text = text.format(code="x" * 15_000)
     chunks = SemanticMarkdownChunker(preserve_code_blocks=True).chunk(text, {})
+    # Byte-cap contract: at least one chunk, every chunk under the cap.
+    # Exact count varies by parametrization (with-heading splits to 2;
+    # no-heading is 1) and the value-under-test is the size cap, not
+    # the chunk count.
     assert len(chunks) >= 1
     for c in chunks:
         assert len(c.text.encode()) <= SAFE_CHUNK_BYTES
@@ -210,7 +214,7 @@ def test_split_large_section_overlap():
         ],
     }
     chunks = chunker._split_large_section(section, {}, start_index=0)
-    assert len(chunks) >= 3
+    assert len(chunks) == 3
     _assert_overlap_at_start(chunks, chunker.overlap_chars)
 
 

--- a/tests/test_md_preservation.py
+++ b/tests/test_md_preservation.py
@@ -51,7 +51,7 @@ def test_heading_based_chunking():
     )
     chunker = SemanticMarkdownChunker(chunk_size=2048)
     chunks = chunker.chunk(md, {})
-    assert len(chunks) >= 2
+    assert len(chunks) == 3
     texts = [c.text for c in chunks]
     assert any("Introduction" in t for t in texts)
     assert any("Methods" in t or "Results" in t for t in texts)
@@ -67,7 +67,7 @@ def test_nested_heading_chunking():
     )
     chunker = SemanticMarkdownChunker(chunk_size=2048)
     chunks = chunker.chunk(md, {})
-    assert len(chunks) >= 2
+    assert len(chunks) == 4
 
 
 def test_code_block_preservation():
@@ -79,7 +79,7 @@ def test_code_block_preservation():
     )
     chunker = SemanticMarkdownChunker(chunk_size=2048)
     chunks = chunker.chunk(md, {})
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     combined = " ".join(c.text for c in chunks)
     assert "pip install nexus" in combined
     assert "nx --version" in combined
@@ -90,7 +90,7 @@ def test_no_heading_document():
     md = "Just plain text without any headings or structure.\n\nAnother paragraph.\n"
     chunker = SemanticMarkdownChunker(chunk_size=2048)
     chunks = chunker.chunk(md, {})
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     assert "plain text" in chunks[0].text
 
 
@@ -99,7 +99,7 @@ def test_chunk_metadata_includes_header_path():
     md = "## Parent\n\n### Child\n\nContent under child heading.\n"
     chunker = SemanticMarkdownChunker(chunk_size=2048)
     chunks = chunker.chunk(md, {})
-    assert len(chunks) >= 1
+    assert len(chunks) == 2
     # At least one chunk should have a header_path
     assert any(len(c.header_path) > 0 for c in chunks)
 

--- a/tests/test_minified_chunking.py
+++ b/tests/test_minified_chunking.py
@@ -28,7 +28,7 @@ def test_split_long_line_splits_at_semicolon() -> None:
     # Build a line with a semicolon near the end of the first segment
     line = "a" * 85 + ";rest" + "b" * 20
     result = _split_long_line(line, max_chars=100)
-    assert len(result) >= 2
+    assert len(result) == 2
     assert result[0].endswith(";")
 
 
@@ -36,7 +36,7 @@ def test_split_long_line_splits_at_brace() -> None:
     """Splits at closing brace when no semicolon available."""
     line = "a" * 85 + "}rest" + "b" * 20
     result = _split_long_line(line, max_chars=100)
-    assert len(result) >= 2
+    assert len(result) == 2
     assert result[0].endswith("}")
 
 
@@ -115,7 +115,7 @@ def test_chunk_file_normal_js_unchanged(tmp_path: Path) -> None:
     normal = "\n".join(f"var x{i} = {i};" for i in range(100))
     chunks = chunk_file(Path("normal.js"), normal)
 
-    assert len(chunks) >= 1
+    assert len(chunks) == 1
     # The ``ast_chunked`` discriminator was dropped in nexus-59j0 (cargo).
     # Contract here: chunker handles normal JS without crashing.
 


### PR DESCRIPTION
## Summary

Tier-4 audit cleanup, batch 2 of the inequality-assertion sweep (batch 1 shipped in 4.32.7 — \`test_chunker.py\` + \`test_indexer_modules.py\`). Hal's standing rule: 'inequalities are how silent-corruption tests pass'. Replaced \`>= N\` with \`== exact\` for assertions over deterministic fixture outputs.

## Files swept

| File | Exact | Kept (rationale) |
|---|---|---|
| test_md_chunker.py | 7 | 2 — byte-cap parametrized across two shapes |
| test_doc_indexer.py | 1 | 9 — contract-minimum invariants (no-singleton-tail, retry counts) |
| test_ast_languages.py | 7 | 1 — \`line_start >= 1\` real range check |
| test_md_preservation.py | 5 | 0 |
| test_minified_chunking.py | 3 | 0 |
| test_local_mode.py | 5 | 0 |
| test_catalog_e2e.py | 5 | 0 (MCP search/resolve/audit results against the 3-file + links-graph fixture) |

~33 patterns flipped to exact. ~144 remain across other files and are dominated by:

- **Contract-minimums** (CCE no-singleton-tail invariants, retry counts, checkpoint cadence) — inequalities ARE the contract.
- **Non-deterministic** (\`test_taxonomy.py\` / \`test_taxonomy_e2e.py\` HDBSCAN clustering depends on seed + min_cluster_size).
- **Timing assertions** (\`test_stage_timers.py\` wall-clock seconds).
- **Registry-growth bounds** (\`test_languages.py >= 27\` for language counts — registry grows, can't shrink).

## Tests

All seven touched files pass locally.

## Refs

- \`nexus-8g79.23\` (this is batch 2; bead stays in_progress for further sweeps of the qualifying remaining sites if any are flagged)