### PR TITLE
test(cite): pre-consume chash-fallback one-shot in JSON test (flake fix)

### DIFF
--- a/tests/test_phase5_doc_cite.py
+++ b/tests/test_phase5_doc_cite.py
@@ -241,6 +241,15 @@ class TestCiteTiedCandidatesNote:
 
     def test_tied_candidates_json_returns_all(self, cite_env):
         from nexus.commands.doc import cite_cmd
+        import nexus.catalog.catalog_spans as _spans
+
+        # nexus-8g79.* fix: the chash-fallback warning is one-shot
+        # per process and lands on stderr; when CliRunner merges
+        # stderr -> stdout in CI, the warning prefixes the JSON
+        # payload. Pre-consume the one-shot here so the warning has
+        # already fired before this test's JSON assertion runs,
+        # regardless of pytest collection order.
+        _spans._chash_fallback_warned = True
 
         cat, t3, chash_index, _ = cite_env
         c1, c2 = "a" * 64, "b" * 64


### PR DESCRIPTION
Order-dependent flake: catalog_spans._chash_fallback_warned is a one-shot. When test_tied_candidates_json_returns_all runs without an earlier test having tripped it, the structlog warning lands on stderr and CliRunner's stderr-merge in CI prefixes the JSON payload, breaking json.loads.

Pre-consume the one-shot at the top of the JSON test. Sibling test_tied_candidates_within_0_01_emit_note still exercises the warning path explicitly.

Caught while running the audit-PR queue: 3 of 7 PRs failed CI on this same test. Pre-existing, not caused by any audit PR.