### PR TITLE
fix(catalog,indexer): close sandbox-shakeout bugs (qj1q + jm3z + vxz3)

### DIFF
--- a/src/nexus/catalog/events.py
+++ b/src/nexus/catalog/events.py
@@ -84,6 +84,7 @@ TYPE_OWNER_REGISTERED = "OwnerRegistered"
 TYPE_OWNER_DELETED = "OwnerDeleted"
 TYPE_COLLECTION_CREATED = "CollectionCreated"
 TYPE_COLLECTION_SUPERSEDED = "CollectionSuperseded"
+TYPE_COLLECTION_DELETED = "CollectionDeleted"
 TYPE_DOCUMENT_REGISTERED = "DocumentRegistered"
 TYPE_DOCUMENT_RENAMED = "DocumentRenamed"
 TYPE_DOCUMENT_ALIASED = "DocumentAliased"
@@ -215,6 +216,22 @@ class CollectionSupersededPayload:
     new_coll_id: str
     reason: str = ""
     superseded_at: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class CollectionDeletedPayload:
+    """A collection has been permanently removed.
+
+    nexus-vxz3 / nexus-jm3z: complements ``CollectionSuperseded`` (which
+    points the old collection at a replacement target). Use ``Deleted``
+    when there is no replacement — e.g. test detritus, an obsolete
+    embedding-model collection whose source content is gone. The
+    projector drops the collections projection row on apply.
+    """
+
+    coll_id: str
+    reason: str = ""
+    deleted_at: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -414,6 +431,7 @@ _PAYLOAD_CLASSES: dict[str, type] = {
     TYPE_OWNER_DELETED: OwnerDeletedPayload,
     TYPE_COLLECTION_CREATED: CollectionCreatedPayload,
     TYPE_COLLECTION_SUPERSEDED: CollectionSupersededPayload,
+    TYPE_COLLECTION_DELETED: CollectionDeletedPayload,
     TYPE_DOCUMENT_REGISTERED: DocumentRegisteredPayload,
     TYPE_DOCUMENT_RENAMED: DocumentRenamedPayload,
     TYPE_DOCUMENT_ALIASED: DocumentAliasedPayload,

--- a/src/nexus/catalog/projector.py
+++ b/src/nexus/catalog/projector.py
@@ -451,6 +451,22 @@ class Projector:
             (payload.new_coll_id, ts, payload.old_coll_id),
         )
 
+    def _v0_collection_deleted(self, payload: Any) -> None:
+        """Drop the collection's projection row.
+
+        nexus-vxz3 / nexus-jm3z: the cascade in
+        :func:`nexus.commands.collection.delete_cmd` emits this event
+        so replay produces SQLite state matching the live SQL DELETE.
+        Without it, replay-equality FAILed on collections after every
+        admin delete because there was no event to project.
+        """
+        if not getattr(payload, "coll_id", ""):
+            return
+        self._db.execute(
+            "DELETE FROM collections WHERE name = ?",
+            (payload.coll_id,),
+        )
+
     def _v0_chunk_indexed(self, payload: Any) -> None:
         # Phase 1 SQLite has no ``chunks`` table. The chunk count is
         # already on ``documents.chunk_count`` from
@@ -537,6 +553,7 @@ def _build_dispatch() -> dict[tuple[str, int], Any]:
         (ev.TYPE_OWNER_DELETED, 0):          Projector._v0_owner_deleted,
         (ev.TYPE_COLLECTION_CREATED, 0):     Projector._v0_collection_created,
         (ev.TYPE_COLLECTION_SUPERSEDED, 0):  Projector._v0_collection_superseded,
+        (ev.TYPE_COLLECTION_DELETED, 0):     Projector._v0_collection_deleted,
         (ev.TYPE_DOCUMENT_REGISTERED, 0):    Projector._v0_document_registered,
         (ev.TYPE_DOCUMENT_RENAMED, 0):       Projector._v0_document_renamed,
         (ev.TYPE_DOCUMENT_ALIASED, 0):       Projector._v0_document_aliased,
@@ -551,6 +568,7 @@ def _build_dispatch() -> dict[tuple[str, int], Any]:
         (ev.TYPE_OWNER_DELETED, 1):          Projector._v1_unsupported,
         (ev.TYPE_COLLECTION_CREATED, 1):     Projector._v1_unsupported,
         (ev.TYPE_COLLECTION_SUPERSEDED, 1):  Projector._v1_unsupported,
+        (ev.TYPE_COLLECTION_DELETED, 1):     Projector._v1_unsupported,
         (ev.TYPE_DOCUMENT_REGISTERED, 1):    Projector._v1_unsupported,
         (ev.TYPE_DOCUMENT_RENAMED, 1):       Projector._v1_unsupported,
         (ev.TYPE_DOCUMENT_ALIASED, 1):       Projector._v1_unsupported,

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -5189,11 +5189,24 @@ def _run_replay_equality() -> dict:
     # — a future schema migration that adds a column before ``id`` would
     # silently strip the wrong field under positional indexing).
     LINKS_EXCLUDE = ["id"]
+    # nexus-vxz3: documents.chunk_count is a denormalised cache populated
+    # by the post-store manifest-write batch hook (resync_chunk_count_cache),
+    # not by event-log events. The in-memory replay catalog has no
+    # document_chunks table to derive chunk_count from, so the projector's
+    # post-replay re-derive sees zero manifest rows and keeps the
+    # register-time chunk_count (typically 0). Live SQLite reflects the
+    # hook-driven value (typically 1+ for docs with at least one chunk).
+    # Exclude chunk_count from the comparison — it's intentionally
+    # non-event-sourced and the boundary is documented at
+    # mcp_infra.manifest_write_batch_hook.
+    DOCUMENTS_EXCLUDE = ["chunk_count"]
     live_uri = f"file:{live_db_path}?mode=ro"
     with closing(sqlite3.connect(live_uri, uri=True)) as live_conn:
         live_snap = {
             "owners": _snapshot_table(live_conn, "owners"),
-            "documents": _snapshot_table(live_conn, "documents"),
+            "documents": _snapshot_table(
+                live_conn, "documents", exclude_cols=DOCUMENTS_EXCLUDE,
+            ),
             "links": _snapshot_table(live_conn, "links", exclude_cols=LINKS_EXCLUDE),
             # RDR-101 Phase 6 prophylactic-review fix: include the
             # collections projection in replay-equality. Pre-fix this
@@ -5223,7 +5236,9 @@ def _run_replay_equality() -> dict:
         with closing(sqlite3.connect(str(projected_path))) as proj_conn:
             projected_snap = {
                 "owners": _snapshot_table(proj_conn, "owners"),
-                "documents": _snapshot_table(proj_conn, "documents"),
+                "documents": _snapshot_table(
+                    proj_conn, "documents", exclude_cols=DOCUMENTS_EXCLUDE,
+                ),
                 "links": _snapshot_table(proj_conn, "links", exclude_cols=LINKS_EXCLUDE),
                 "collections": _snapshot_table(proj_conn, "collections"),
             }

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -155,6 +155,73 @@ def delete_cmd(name: str, yes: bool) -> None:
     except Exception as exc:
         click.echo(f"warn: pipeline-state cleanup failed: {exc}", err=True)
 
+    # nexus-jm3z: cascade to catalog. Pre-fix, `nx collection delete`
+    # left catalog.documents rows whose physical_collection pointed at
+    # the now-gone collection, plus a stale catalog.collections
+    # projection row. Both surfaced as doctor FAILs (t3-vs-catalog +
+    # collections-drift) requiring per-tumbler manual cleanup. Run the
+    # cascade here so a single delete leaves the catalog clean.
+    catalog_docs_deleted = 0
+    catalog_projection_deleted = 0
+    try:
+        from nexus.catalog.catalog import Catalog
+        from nexus.config import catalog_path
+
+        cat_path = catalog_path()
+        if Catalog.is_initialized(cat_path):
+            cat = Catalog(cat_path, cat_path / ".catalog.db")
+            # Delete every document row pointing at the gone collection.
+            # Use the public delete_document so the event log + JSONL
+            # tombstone stay in sync with the SQLite projection.
+            orphan_tumblers = [
+                row[0]
+                for row in cat._db.execute(
+                    "SELECT tumbler FROM documents WHERE physical_collection = ?",
+                    (name,),
+                ).fetchall()
+            ]
+            for tumbler in orphan_tumblers:
+                try:
+                    if cat.delete_document(tumbler):
+                        catalog_docs_deleted += 1
+                except Exception:
+                    _log.debug(
+                        "collection_delete_cascade_document_failed",
+                        tumbler=tumbler, exc_info=True,
+                    )
+            # nexus-vxz3: emit CollectionDeleted event so replay
+            # produces SQLite state matching the live delete. The
+            # projector's _v0_collection_deleted handler drops the
+            # projection row.
+            from nexus.catalog.events import CollectionDeletedPayload
+            from nexus.catalog import catalog as _cat_mod
+
+            row_before = cat._db.execute(
+                "SELECT 1 FROM collections WHERE name = ?", (name,),
+            ).fetchone()
+            if row_before is not None:
+                event = _cat_mod._make_event(
+                    CollectionDeletedPayload(
+                        coll_id=name,
+                        reason="nx collection delete",
+                    ),
+                    v=0,
+                )
+                if cat._event_sourced_enabled:
+                    cat._write_to_event_log(event)
+                    cat._projector.apply(event)
+                    cat._db.commit()
+                else:
+                    cat._db.execute(
+                        "DELETE FROM collections WHERE name = ?",
+                        (name,),
+                    )
+                    cat._db.commit()
+                    cat._emit_shadow_event(event)
+                catalog_projection_deleted = 1
+    except Exception as exc:
+        click.echo(f"warn: catalog cascade failed: {exc}", err=True)
+
     parts: list[str] = []
     if taxonomy_counts and any(taxonomy_counts.values()):
         parts.append(
@@ -167,6 +234,10 @@ def delete_cmd(name: str, yes: bool) -> None:
         parts.append(f"{chash_deleted} chash rows")
     if pipeline_rows_deleted:
         parts.append(f"{pipeline_rows_deleted} pipeline rows")
+    if catalog_docs_deleted:
+        parts.append(f"{catalog_docs_deleted} catalog docs")
+    if catalog_projection_deleted:
+        parts.append(f"{catalog_projection_deleted} catalog projection row")
     if parts:
         click.echo(f"Deleted: {name} ({'; '.join(parts)})")
     else:

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1544,7 +1544,12 @@ def _prune_misclassified_in_collection(
         # the IDs that exist in this collection, so the cross-direction
         # check (a code file's chunks living in docs__) works without
         # any per-chunk metadata.
-        all_natural_ids: list[str] = []
+        # nexus-qj1q: dedupe via set so col.get(ids=batch_ids) sees
+        # unique IDs. Two docs may share a chunk (same file content
+        # vendored to two paths, shared boilerplate header, etc.); the
+        # same chash[:32] would otherwise appear multiple times in the
+        # batch and Chroma rejects with DuplicateIDError.
+        natural_id_set: set[str] = set()
         # nexus-8g79.4: bare ``continue`` on get_manifest failure silently
         # skipped doc_ids whose manifest lookup raised (catalog miss,
         # transient SQLite error). Those chunks were then never pruned
@@ -1567,7 +1572,8 @@ def _prune_misclassified_in_collection(
                 continue
             for row in manifest:
                 if row.chash:
-                    all_natural_ids.append(row.chash[:32])
+                    natural_id_set.add(row.chash[:32])
+        all_natural_ids: list[str] = list(natural_id_set)
         # Batched ``col.get`` to fetch the present subset, then batched
         # delete. _CHROMA_PAGE_SIZE caps the ids list per call.
         for i in range(0, len(all_natural_ids), _CHROMA_PAGE_SIZE):


### PR DESCRIPTION
## Summary

Sandbox shakeout (pristine \`NEXUS_CONFIG_DIR\` + \`NX_LOCAL=1\` + fresh chroma + index of \`~/git/ext-apps\`) surfaced three real bugs that were quietly hurting prod for a long time. Fixing them together so a fresh-index → delete-collection cycle leaves every doctor check PASSing.

## Closes

- Closes #nexus-qj1q (P1) — \`_prune_misclassified_in_collection\` DuplicateIDError
- Closes #nexus-jm3z (P1) — \`nx collection delete\` cascade gap
- Closes #nexus-vxz3 (P2) — doctor replay-equality false-positives

## Fixed

### qj1q — DuplicateIDError on shared chashes

\`all_natural_ids\` accumulated per-doc manifest chashes without deduping. When two docs share a chunk (common file content vendored to two paths, shared boilerplate header) the same \`chash[:32]\` appeared multiple times in \`col.get(ids=)\` and Chroma rejected the whole batch. The prune step silently skipped, leaving misclassified chunks in T3 indefinitely.

**Fix:** dedupe via \`set()\` before \`list()\`.

### jm3z — collection delete cascade

T3 delete + taxonomy + chash + pipeline cascades fired; catalog cascades did not. Every cleanup hit:
- \`catalog.documents\` rows whose \`physical_collection\` pointed at the gone collection survived as orphans (\`t3-vs-catalog\` FAIL).
- \`catalog.collections\` projection row survived as stale drift (\`collections-drift\` FAIL).

**Fix:** cascade in \`delete_cmd\` — \`Catalog.delete_document\` per orphan tumbler (event-sourced; cascades to \`document_chunks\`) then emit a \`CollectionDeleted\` event (new) so the projection row drops on apply.

### vxz3 — doctor replay-equality false-positives (two boundaries)

1. \`documents.chunk_count\` is populated by \`manifest_write_batch_hook\` post-store side-effect, not by the event log. The projector's in-memory replay has no \`document_chunks\` table to derive from. **Fix:** exclude \`chunk_count\` from the documents comparison (consistent with the existing \`LINKS_EXCLUDE\` pattern for the autoincrement id column).
2. Admin SQL DELETE on the collections projection bypassed the event log; replay produced more collections than live. **Fix:** new \`CollectionDeleted\` event type with \`_v0_collection_deleted\` handler. The cascade above emits it so the round-trip is clean.

## Sandbox verdict after this PR

| Scenario | Result |
|---|---|
| Fresh sandbox | all 6 doctor checks PASS |
| Index ext-apps | all 6 PASS (no DuplicateIDError) |
| Delete a collection | all 6 PASS (cascade clean) |

## Tests

320 pass across:
- \`test_indexer\`
- \`test_collection_cmd\`
- \`test_catalog\`
- \`test_catalog_event_log\`
- \`test_catalog_event_sourced_mutators\`
- \`test_catalog_doctor_replay_equality\`
- \`test_catalog_shadow_emit\`

## Test plan

- [x] Local touched-area suite passes (320 tests)
- [x] Sandbox shakeout: fresh + index + delete → all doctor checks PASS
- [ ] CI green