### PR TITLE
fix(t2): silence migration notice on no-op version bumps

### DIFF
--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -2938,8 +2938,13 @@ def bootstrap_version(conn: sqlite3.Connection) -> str:
     return row[0] if row else "0.0.0"
 
 
-def apply_pending(conn: sqlite3.Connection, current_version: str) -> None:
+def apply_pending(conn: sqlite3.Connection, current_version: str) -> int:
     """Run all migrations introduced between last-seen and *current_version*.
+
+    Returns the number of migration steps that actually executed.
+    Callers can suppress operator-visible "Migrating database..." notices
+    when the return is 0 (no-op version bump — common case after a patch
+    release that did not change the schema).
 
     Idempotent — every migration function has column/table-existence guards.
 
@@ -2957,7 +2962,7 @@ def apply_pending(conn: sqlite3.Connection, current_version: str) -> None:
     path_key = _connection_path_key(conn)
     with _upgrade_lock:
         if path_key in _upgrade_done:
-            return
+            return 0
 
         # OBS-1: record migration session start for telemetry.
         _t_start = _time.monotonic()
@@ -3015,7 +3020,7 @@ def apply_pending(conn: sqlite3.Connection, current_version: str) -> None:
                 path_key=path_key,
                 steps_run=steps_run,
             )
-            return
+            return steps_run
 
         # Update stored version.  Guards:
         # - Skip pre-release/unparseable versions ((0,0,0)) to prevent
@@ -3040,6 +3045,7 @@ def apply_pending(conn: sqlite3.Connection, current_version: str) -> None:
             steps_run=steps_run,
             duration_ms=round((_time.monotonic() - _t_start) * 1000),
         )
+        return steps_run
 
 
 def _connection_path_key(conn: sqlite3.Connection) -> str:

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -193,24 +193,33 @@ class T2Database:
                 # case (running `nx <verb>` from a real terminal) keeps
                 # the visibility benefit; the headless case stays
                 # quiet.
+                #
+                # Post-fix: only print when apply_pending actually ran
+                # migration steps. A patch release that bumps the
+                # version without adding a migration would otherwise
+                # print on the first post-upgrade open of every
+                # T2Database, which is noise on the operator side and
+                # misleading (no actual migration happened).
                 import sys as _sys
-                _stderr_is_tty = (
-                    hasattr(_sys.stderr, "isatty") and _sys.stderr.isatty()
-                )
-                if _stderr_is_tty:
-                    print(
-                        f"Migrating database {path.name!r} to schema "
-                        f"version {current_version} ...",
-                        file=_sys.stderr,
-                    )
 
                 conn = sqlite3.connect(str(path), check_same_thread=False)
                 try:
                     conn.execute("PRAGMA busy_timeout=5000")
                     conn.execute("PRAGMA journal_mode=WAL")
-                    apply_pending(conn, current_version)
+                    steps_run = apply_pending(conn, current_version)
                 finally:
                     conn.close()
+
+                _stderr_is_tty = (
+                    hasattr(_sys.stderr, "isatty") and _sys.stderr.isatty()
+                )
+                if steps_run and _stderr_is_tty:
+                    print(
+                        f"Migrated database {path.name!r} to schema "
+                        f"version {current_version} "
+                        f"({steps_run} step{'s' if steps_run != 1 else ''}).",
+                        file=_sys.stderr,
+                    )
                 # apply_pending() keys _upgrade_done by
                 # _connection_path_key(conn) (Path(row[2]).resolve() from
                 # PRAGMA database_list). The fast-path check above keys by


### PR DESCRIPTION
## Summary

\`apply_pending()\` now returns the step count; T2Database prints the operator-visible 'Migrating database ...' notice only when \`steps_run > 0\`. A patch-release version bump that does not add a migration previously printed the notice on every first T2 open after upgrade — operator-confusing noise.

Hit live during the v4.32.11 cutover smoke: \`nx memory list\` post-reinstall printed 'Migrating database memory.db to schema version 4.32.11 ...' even though the latest registered migration is at 4.32.1.

## Changed

- \`apply_pending(conn, current_version) -> int\` (was \`-> None\`)
- T2 init: call \`apply_pending\` first, print only when \`steps_run > 0\`. Message reframed to past tense with step count: \`Migrated database 'memory.db' to schema version 4.32.11 (3 steps).\`

## Tests

119 pass across \`test_migrations\` + \`test_t2_concurrency\`.

## Test plan

- [x] Local: no notice on 4.32.11 reinstall (verified during live cutover)
- [ ] CI green