### PR TITLE
fix(rdr): quote '#'-prefixed PR refs in post-mortem frontmatter (nexus-u7ek)

### DIFF
--- a/docs/rdr/post-mortem/nexus-3e4s-catalog-t3-drift.md
+++ b/docs/rdr/post-mortem/nexus-3e4s-catalog-t3-drift.md
@@ -4,7 +4,7 @@ date: 2026-04-30
 references:
   rdr: RDR-101
   beads: [ART-lhk1, nexus-3e4s, nexus-p03z, nexus-v9az]
-  prs: [#381, #382, #383, #385, #386, #388, #389]
+  prs: ["#381", "#382", "#383", "#385", "#386", "#388", "#389"]
 status: post-mortem
 ---
 


### PR DESCRIPTION
## Summary

One-line YAML fix to `docs/rdr/post-mortem/nexus-3e4s-catalog-t3-drift.md` line 7. Quoting the `#`-prefixed PR references in the flow sequence so YAML's scanner doesn't interpret them as comment-start tokens.

```diff
-  prs: [#381, #382, #383, #385, #386, #388, #389]
+  prs: ["#381", "#382", "#383", "#385", "#386", "#388", "#389"]
```

## Why

YAML's flow-sequence scanner treats `#` as comment-start at the first character of a token. The original line was parsed as `[` followed by a comment that consumed the rest of the line — including the closing `]`. The flow sequence then ran off the end of the frontmatter:

```
expected ',' or ']', but got '<stream end>'
```

The author's eye reads a perfectly valid list of GitHub PR references; YAML disagrees silently.

## Concrete impact

`nx index repo .` hung on this file during the `[post] Discovering and indexing RDR markdown files` pass — the parser emitted a `frontmatter_parse_failed` warning and then the indexer never returned. Quoting the refs unblocks the indexer; production session 2026-05-13 completed cleanly post-fix:

```
[post] RDR indexing done — 0 indexed, 154 current, 0 failed (62.1s)
```

## What this is NOT

This commit is the minimum needed to unblock indexing. Two related defects are tracked separately and are out of scope here:

- **nexus-qr9d**: The indexer hanging on the parse failure instead of skipping + continuing. Graceful degradation gap; should be fixed regardless of how clean the corpus is.
- **nexus-u7ek**: The class-level hazard — `prs: [#NNN, ...]` is a natural pattern that any new RDR author will reach for. Needs documented quoting convention (or block-sequence migration) and ideally a pre-write lint at `/nx:rdr-create` time.

## Test plan

- [x] `nx index repo .` ran clean (783 files, 1427 chunks, RDR post-pass 154 current / 0 failed)
- [x] Verified frontmatter parses via `yaml.safe_load`: `prs = ['#381', '#382', '#383', '#385', '#386', '#388', '#389']`
- [x] No other RDRs match the offender pattern at time of filing (`grep 'prs: \[#' docs/rdr/` → empty after this fix)

Closes nexus-u7ek (partial — convention work remains; this commit only addresses the in-corpus offender).