### PR TITLE
docs(rdr): RDR-111 (ORB) + RDR-112 (storage-as-service) drafts

### DIFF
--- a/docs/agentic-cockpit.md
+++ b/docs/agentic-cockpit.md
@@ -1,0 +1,883 @@
+# Agentic cockpit: tuple space common model + semantic events as integration
+
+A design exploration. **Not a workflow engine spec.** The workflow engine
+is handed off to the work-instance under a separate document set; here
+it is a free variable. We assume *some* workflow capability exists; we
+do not commit to which, at what level, or under whose execution model.
+What this doc commits to is the *substrate* the harness needs, and
+specifically two architectural moves.
+
+## The two moves
+
+**Move 1 — A semantic tuple space (RDR-110) is the common
+*coordination* model.**
+
+Nexus already has three retrieval surfaces that are structurally the
+same abstraction with different names (plans, T1 scratch, T2 memory).
+RDR-110 unifies them, adds Linda's atomic destructive read (`in`), and
+makes the registry of types/dimensions first-class. The proposal is
+accepted; this doc takes it as load-bearing.
+
+The move beyond RDR-110's stated scope: **everything that wants to
+coordinate uses the tuple space — but the tuple space is the
+switchboard, not the bandwidth.** Coordination, discovery,
+declaration, claims, bindings, layout state, profile state — these
+live as tuples. Actual high-bandwidth or low-latency dataflow does
+*not*. The bus is the store; the store is the switchboard. Writes are
+events *about* state; events are coordination handles. The actual
+data behind those handles flows over connections the tuple space
+helps establish but doesn't carry.
+
+**Move 2 — Semantic events are the local integration point.**
+
+The harness (Claude Code today, Cowork / VS Code / web variants
+ahead) has an existing event bus: hooks (`PreToolUse`, `PostToolUse`,
+`Stop`, `SubagentStop`, `SessionStart`, `SessionEnd`,
+`UserPromptSubmit`, `PreCompact`, `Notification`). These fire at
+well-defined points but are *code-only* surfaces today — a hook
+either runs a shell script or doesn't. The integration point we
+need is to *project* these events into the tuple space as
+semantically-typed tuples, so they become composable, queryable, and
+addressable by intent.
+
+Critically, semantic events are **milestones, not byte streams**.
+The PreToolUse hook firing produces *one* tuple per tool call, not
+a tuple per stdout line the tool emits. The workflow engine emitting
+"step N completed" produces one tuple per step, not one per stream
+chunk. Granularity matters. High-frequency dataflow stays on its
+own transport.
+
+Once both moves are made, most of what we want — composable C2
+surfaces, multi-agent coordination, cross-instance visibility,
+user-authored bindings — falls out structurally rather than needing
+to be invented.
+
+## The substrate is log-structured, per tier
+
+Before going further: the tuple space is not a key-value store with
+notifications bolted on. It is an **append-only event log per tier,
+with a materialised "current tuples" view as a fold over the log**.
+The four Linda-shaped primitives are operations on the log:
+
+- `out(t)` appends an `out` record at LSN N.
+- `in(template)` appends a `claim` record at LSN M, succeeding iff
+  the materialised view shows a matching unclaimed tuple in the same
+  transaction. The CAS is one SQLite tx; the log preserves who took
+  what when.
+- `rd(template)` reads the materialised view at the current LSN. Not
+  logged — reads don't change state.
+- Subscriptions ("notify") are **offset-tracking consumers**, Kafka /
+  Redis-Streams shaped, not callback registrations. A subscriber
+  holds an LSN cursor and advances it as it processes; restart =
+  resume from last committed offset; "at-least-once" is just
+  "subscriber hasn't advanced past LSN N yet." No callback to lose.
+
+On one machine this is essentially free: SQLite WAL already
+serialises writers through a single write lock, so the commit order
+**is** the global total order — no consensus, no extra coordination.
+The 1986-Linda and 1999-JavaSpaces literature paid total-ordering
+cost as if it were a distributed problem; for the local substrate it
+isn't.
+
+### Logs (plural), not log
+
+The three tiers have asymmetric lifetimes and scopes, and the
+log-structured discipline has to respect that.
+
+- **T2 is the canonical event log of the cockpit substrate.**
+  Everything coordination-shaped lives here: hook projections,
+  bindings, claims, manifests, liveness, mailboxes, layouts. One LSN
+  sequence per project (one SQLite file). Total order within the
+  project, across all processes touching it. Subscribers hold offset
+  cursors; resume-from-offset is the recovery story. Compaction =
+  snapshot at LSN N + prune below `min(consumer_offsets)`. When the
+  rest of this document says "the tuple space," T2 is the tier it is
+  load-bearing on.
+- **T1 is per-process working memory; its log is local to the
+  RDR-105 cohort.** "Local" here is wider than one agent: it is the
+  parent Claude process plus everything that resolves through its
+  `t1_addr.<pid>` discovery file — in-process `Agent`-tool subagents
+  (share the parent's MCP scratch directly), `Bash`-invoked
+  `nx scratch` calls in the same process (env passdown), and
+  `claude -p` subprocesses dispatched with `share_t1=True`. Sealed
+  off: default-`owned` `claude -p` workers, ephemeral one-shot
+  operators, and other Claude instances on the same machine. Total
+  order within a T1 instance is trivial (one chroma client, one
+  writer) and is used for in-session replay/debug — not for
+  cross-process coordination. If the process dies, the log dies;
+  anything that needs to survive belongs in T2.
+- **T3 is content-addressed knowledge — not a coordination log.**
+  Writes are curated and deliberate (`store_put`, `nx_tidy`,
+  `nx index`). Chashes are content-addressed; position is preserved
+  by the catalog manifest; consumers query by content/tumbler, not
+  by time. There is no "T3 event log" in the cockpit sense. When
+  something in T3 changes that the cockpit *should* react to (new
+  RDR indexed, knowledge consolidated, collection drifted), the
+  change is **mirrored as a T2 event** referencing the T3 artifact
+  (chash, tumbler). Subscribers watch T2; T3 just *is*.
+
+### Cross-tier ordering
+
+There is no global LSN across tiers, and we do not want one. Each
+tier serves a different lifetime/scope; pretending they share a
+clock would force coordination we do not need.
+
+- Within T2: total order, free, load-bearing.
+- T1 → T2 promotions (`--persist`, `memory_put`): logged as a T2
+  event. The promotion is an LSN'd row in T2's log.
+- T2 → T3 promotions (`nx_tidy`, knowledge consolidation): T3
+  catalog write **plus** a T2 mirror event referencing the resulting
+  chash/tumbler, so cockpit consumers can react without polling T3.
+- Cross-tier "what happened when" is wall-clock timestamps,
+  best-effort. Used for audit and debugging, not for correctness.
+
+The discipline this gives us: **subscribers reason about ordering
+within the tier they consume.** A binding watching for "hook fired
+AND claim acquired" reads both off T2's single sequence, so the
+causal relationship is preserved by construction. A binding that
+needs to know "T3 got a new RDR" reads a T2 mirror event, not T3
+itself — and the mirror event has an LSN like everything else on
+the bus.
+
+## Control plane / data plane — the discipline
+
+Nexus is the **control plane** and the **switchboard**. Real
+high-speed, specialized, point-to-point connections are the **data
+plane**. The discipline that keeps this clean:
+
+- **Tuples describe and broker connections; they do not carry the
+  payload.** A tuple may say "agent X is streaming tokens to surface
+  Y via endpoint Z, format F, lifetime L." The actual tokens flow
+  directly from X to Y via Z. Nexus knows the connection exists,
+  what type it is, who owns it, and when it should end. Nexus does
+  not see (and does not need to see) every token.
+- **Connections are first-class artifacts with explicit lifecycle.**
+  Manifest (declare the connection as a tuple), establish (peers
+  open the direct transport), use (data flows peer-to-peer),
+  heartbeat (the manifest tuple is refreshed; expired manifests
+  trigger teardown), tear down (release the tuple, close the
+  transport). This is the same shape as SIP signaling for an RTP
+  call, WebRTC signaling for a P2P data channel, Kubernetes service
+  discovery for a pod-to-pod connection. The pattern is well-trodden;
+  apply it.
+- **The transport is whatever fits.** Direct stdio pipe between
+  spawned processes. Unix socket. Named pipe. WebSocket from an
+  ext-apps iframe to its data-producing MCP server. SSE stream from
+  a workflow engine to a subscribed surface. File descriptor
+  passing. Shared memory. Audio device. The cockpit substrate does
+  not prescribe; the manifest declares the type and the peers
+  negotiate the rest.
+- **The line between control and data is bandwidth × frequency, not
+  semantics.** A user-click event going through the tuple space —
+  fine, low frequency, discrete. LLM tokens streaming at 50 t/s
+  through the tuple space — never; each token would be a tuple,
+  every consumer would index every token, the substrate would
+  collapse. Tool stdout flowing through the tuple space at line
+  granularity — also wrong; the workflow engine consumes the stream
+  and emits step milestones to the tuple space. Rule of thumb: if
+  it's a discrete observable event the user or another actor would
+  want to *react to as a unit*, it belongs as a tuple. If it's
+  fine-grained continuous data, it belongs on a direct connection
+  with a manifest.
+
+### What this means for the actors
+
+- **LLM agent**: the LLM API call is direct from harness to provider.
+  Tuples in the cockpit substrate carry agent *intent* (a tool call
+  was issued), *milestones* (an agent step completed), and *claims*
+  (agent holds a resource). Token streaming is not tupled.
+- **Workflow engine**: runs as a separate MCP server process. The
+  engine's *step events* are tupled (milestones); the engine's
+  *intra-step dataflow* (e.g., reading a 10MB blob from a downstream
+  MCP server and passing it to the next step) flows directly between
+  the engine and its peers. If a surface wants live progress of a
+  long-running step, the engine exposes a direct streaming endpoint
+  declared in a manifest tuple; the surface connects to it.
+- **Surfaces (ext-apps iframe, tmux pane, etc.)**: a surface's
+  *binding* is tupled — "this surface is wired to event stream E."
+  The actual data the surface displays may come from the tuple space
+  (low-frequency events match directly into the surface) or from a
+  direct connection declared in a manifest tuple (the iframe opens a
+  WebSocket to a server endpoint listed in the manifest). SEP-1865's
+  ext-apps model already supports this — the iframe is itself an MCP
+  client and can hold connections.
+- **Background workers**: their stdout streams to a log file or
+  named pipe; their *milestones* (started, completed, failed, claim
+  acquired) are tuples. The harness's `Monitor` tool streams the
+  pipe to the foreground agent when asked; it doesn't route every
+  byte through tuples.
+- **Inter-agent messaging**: discrete messages are tuples in a
+  mailbox. Streaming data between cooperating agents (e.g., agent
+  A producing JSON that agent B consumes step-by-step) opens a
+  direct pipe declared in a manifest tuple.
+
+### Connection manifest — concretely
+
+A manifest is a tuple type. Roughly:
+
+```
+connection_manifest {
+  id: <uuid>,
+  type: "stream" | "pipe" | "websocket" | "sse" | "file-fd" | ...
+  producer: <actor-id>,
+  consumer: <actor-id> | "any-subscriber",
+  endpoint: <transport-specific address>,
+  payload_type: <semantic type>,
+  lifetime: <TTL or "until-released">,
+  established_at: <ts>,
+  last_heartbeat: <ts>,
+}
+```
+
+The producer posts the manifest after the endpoint is ready. The
+consumer (or any subscriber matching the type) reads the manifest
+and connects directly to the endpoint. Heartbeats refresh the
+manifest. Release of the manifest tuple (via `in` or TTL expiry)
+signals teardown; the endpoint is closed.
+
+This is *one tuple type*. The cost in the substrate is small. The
+benefit is large: every direct connection in the system is visible
+in the control plane, debuggable, claim-able, revoke-able, without
+the substrate carrying any of the payload itself.
+
+## What the harness already provides (and why we mostly leverage)
+
+The agentic harness ships a remarkably complete coordination
+substrate. Surveyed concretely:
+
+| Capability | Mechanism | What it gives us |
+|---|---|---|
+| Hook bus | `PreToolUse`, `PostToolUse`, `Stop`, `SubagentStop`, `SessionStart`, `SessionEnd`, `UserPromptSubmit`, `PreCompact`, `Notification` | Process-level event channel at well-defined points |
+| Background supervision | `Bash(run_in_background)`, `Agent(run_in_background)` | Lifecycle for long-running tasks |
+| Push notifications | `Monitor` (stream-per-line), task completion notifications | Async push from background → main agent |
+| Inter-agent messaging | `SendMessage(to: agentId)` | Direct mailbox between agents |
+| Scheduled re-entry | `ScheduleWakeup`, `CronCreate` | Time-based triggers |
+| Isolation | `Agent(isolation: "worktree")` | Filesystem isolation for parallel agents |
+| Permission modes | `acceptEdits`, `bypassPermissions`, `plan`, `auto`, `default` | Lockdown discipline |
+| MCP server set | per-session, hot-reloadable | Pluggable capability inventory |
+| Plugins | commands + agents + skills + hooks + MCP servers bundled | Distribution unit |
+| Persistent tiers | T1 scratch, T2 memory, T3 store | Multi-scope state |
+| Issue tracking | beads + Dolt | Cross-session work queue |
+| Skills | invocable verbs with arguments | User- or agent-issued commands |
+
+That is — measured against any compositional dashboard / portal /
+addon framework — a near-complete starter kit *already in the
+runtime*. The two moves above turn the latent substrate into an
+explicit one.
+
+## Prior art that doesn't need reinventing
+
+Brief, anchored. Each is decades-old and well-validated; the question
+is which lessons port and which don't.
+
+- **Linda + tuple spaces** (Gelernter & Carriero, 1986). Coordination
+  as a separate concern from computation. `out` / `in` / `rd` / `eval`
+  as the four primitives. RDR-110 directly. Forty years of
+  distributed-systems theory says this is the right shape for
+  cooperating-process coordination.
+- **Blackboard architectures** (Hayes-Roth et al., Hearsay-II, 1970s).
+  Specialists post hypotheses to a shared knowledge base; other
+  specialists refine. The LLM is a specialist; the user is a
+  specialist; surfaces are specialists. Same pattern.
+- **Portal frameworks** (JSR-168/286, Plumtree, Liferay). Pluggable
+  components in a container with shared session, IPC events, user
+  customisation, saved layouts. The corporate-IT decade's worth of
+  evidence on what works (composability, themes) and what fails
+  (degeneration into siloed panels when IPC is too loose).
+- **Bakke, Karger & Miller — Automatic Layout of Structured
+  Hierarchical Reports** (InfoVis 2013). Schema-driven hybrid
+  layouts (nested table / multi-column form / outline) selected per
+  schema node and applied uniformly to every instance, with a
+  three-phase Measure / Auto-Style / Layout pipeline driven by a
+  schema-only stylesheet. Direct prior art for the cockpit's
+  automatic-layout discipline; the layout-engine section below
+  adapts it from static reports to the dynamic event-stream case.
+- **WoW addons + WeakAuras** (2004–). The richest consumer-grade
+  example of cooperating active surfaces over a shared world-state
+  API. WeakAuras specifically: a *scriptable display engine* with a
+  declarative trigger/display/action triple, user-authored without
+  code, importable as strings. Millions of users author auras
+  without being programmers. The existence proof that this pattern
+  is *learnable*, not just buildable.
+- **SCADA / DCS / mission control** (1960s–). Industrial command-and-
+  control. The lineage of HUDs, tag-based data models, alarm
+  systems, runbook integration. The dashboards that don't suck.
+- **Streamdeck / Loupedeck / TouchPortal**. Consumer C2: buttons,
+  pages, profiles, plugins. Per-app context auto-switching.
+- **LabVIEW / Pure Data / Node-RED**. Data-flow visual programming.
+  Architecture validates; UX (raw wiring) doesn't always.
+
+The lesson from this set, distilled: **the abstraction is the
+blackboard (typed shared state) plus the event bus (subscriptions
+on the blackboard) plus a binding language (declarative
+trigger→action), with the harness providing the rendering substrate.
+Don't reinvent the abstraction. Provide a runtime where the
+abstraction can actually be used.**
+
+## What "semantic event" means concretely
+
+A semantic event is a tuple posted to the tuple space that:
+
+1. **Carries a typed payload.** Not an opaque string. The type is
+   registered in the tuple-space dimension registry (RDR-110's
+   registry). Consumers can query by type.
+2. **Carries embeddable content.** The payload has a semantic-search
+   dimension — a description, a target, a domain, an intent. This is
+   what makes it *semantic* rather than just structured. A consumer
+   can `rd` by associative match ("any event indicating a build
+   failure in the catalog module") rather than only by exact type.
+3. **Carries structural metadata.** Timestamp, source actor
+   (`agent:abc123`, `user`, `tool:k8s.apply`), session, project,
+   correlation ID. The retrieval surface filters cheaply on these.
+4. **Is addressable for action.** If a consumer wants to *consume*
+   the event (claim it for a one-shot reaction), `in` takes it
+   atomically. If multiple consumers want to react in parallel, `rd`
+   reads non-destructively.
+5. **Is persistent at the tier appropriate to its lifecycle.** Some
+   events are session-scoped (T1); some are project-scoped (T2);
+   some are durable knowledge (T3). The tuple space tiers handle
+   this without callers caring.
+
+Examples of semantic events:
+
+- `tool_called(tool="k8s.apply", args={...}, actor="agent:abc",
+  session=S, intent="deploy frontend")` — emitted on PreToolUse hook.
+- `step_completed(workflow=W, step=N, output={...}, actor="engine",
+  duration_ms=124)` — emitted by the workflow engine.
+- `user_decision(checkpoint=C, choice="approve", workflow=W)` —
+  emitted when a user submits an iframe form.
+- `claim_acquired(resource="memory:plan_state", holder="agent:xyz",
+  ttl=300s)` — emitted on `in` of a coordination tuple.
+- `attention_request(reason="long-running tool may timeout",
+  surface="status-line", priority=low)` — emitted by a workflow that
+  wants to surface awareness without interrupting.
+
+The integration point is: **hooks fire → harness projects to tuple
+space as semantic events → bindings subscribe → actions trigger →
+surfaces render.** The hook bus is the producer; the tuple space is
+the substrate; bindings are the composition language; surfaces are
+the consumers.
+
+## What the tuple space carries beyond the three existing surfaces
+
+RDR-110's stated scope is unifying plans / scratch / memory. The
+substrate move extends this — but always within the control-plane
+discipline. The tuple space carries:
+
+- **Milestone event log.** Every hook firing, every workflow step
+  *completion*, every user action becomes a tuple. The audit log
+  *is* the tuple space, queried by time and actor. (Note: the
+  *stream* of stdout from a tool, the *stream* of LLM tokens, the
+  *stream* of step-internal IO — these do NOT become tuples. The
+  tool's *completion* with a result summary does. One tuple per
+  observable milestone, not one per byte.)
+- **Claims / leases.** Linda mutexes for shared resources. Active
+  claims are visible as tuples; the active-claims panel is a
+  workflow-as-app over `rd` of claim tuples.
+- **Bindings.** User-authored triggers ("when event X, do Y"). Each
+  binding is a tuple with trigger template + action descriptor +
+  surface descriptor. Bindings are queryable, editable, toggle-able.
+- **Connection manifests.** First-class declarations of direct peer-
+  to-peer streams as described above. Each open high-bandwidth
+  channel in the system has a manifest tuple; teardown is a tuple
+  release.
+- **Liveness / discovery.** Each active agent or instance posts a
+  heartbeat tuple. `nx instances` is `rd` of liveness tuples within
+  TTL. RDR-105's address-file discovery becomes tuple-space-native.
+- **Layout / profile state.** Saved layouts, active mission
+  contexts, per-context profile bindings — all tuples scoped by
+  user, project, time-window.
+- **Inter-agent mailboxes (small messages only).** `SendMessage`-
+  style discrete messages become tuples keyed by recipient. The
+  existing `SendMessage` tool remains the user-facing surface; the
+  transport is the tuple space *only when the messages are
+  small and discrete*. For agents that need to pipe data
+  continuously to each other, a connection manifest declares the
+  pipe and the agents communicate directly.
+- **Selection / focus.** Shared cross-surface state. When a user
+  clicks an item in one surface, the selection tuple updates; other
+  surfaces that `rd` selection update their view. (A user click is
+  one tuple, not 100Hz mouse-position.)
+
+In each case, the tuple space gives us *one query model, one
+persistence story, one debug surface, one access-control story* for
+the **coordination metadata**. Payload-heavy dataflow stays in its
+own appropriate transport, made visible to the substrate via
+manifest tuples.
+
+## The integration surface
+
+Three small pieces of glue, each independently shippable.
+
+**1. Hook → tuple bridge.** A single hook adapter that, on every
+configured hook event, emits a corresponding semantic event tuple.
+The mapping is mechanical:
+
+```
+PreToolUse{tool, args}     → tool_call_intent(...)
+PostToolUse{tool, result}  → tool_call_completed(...)
+SubagentStop{id, summary}  → agent_completed(...)
+Notification{...}          → harness_notification(...)
+UserPromptSubmit{prompt}   → user_prompt(...)
+SessionStart{}             → session_started(...)
+SessionEnd{}               → session_ended(...)
+PreCompact{...}            → compaction_pending(...)
+Stop{}                     → assistant_turn_ended(...)
+```
+
+Every hook becomes a tuple. The dimension registry registers the
+event types; consumers query by type, by actor, by content (semantic
+match on the payload), or by structural metadata.
+
+Estimated cost: a single hook handler that's a thin adapter over
+RDR-110's `out`. Maybe 100 LoC including the registry entries.
+
+**2. Tuple → surface fulfillment, with optional direct streaming.**
+When a binding fires and wants to render to a surface, the surface
+descriptor (`level: {notification, status-line, pane, iframe,
+full-screen}`, payload shape, optional CSS hints, optional direct
+stream endpoint) is fulfilled by whatever rendering substrate the
+harness has natively:
+
+- Terminal harness with tmux → spawn or update a pane (descriptor
+  becomes a tmux command).
+- GUI harness with ext-apps support → emit `ui://` resource, host
+  renders iframe.
+- Headless / autonomous → write to log file, optionally fire OS
+  notification.
+- Voice-first harness → text-to-speech of a short summary.
+
+**Static surfaces** render directly from the binding's tuple
+payload. One tuple → one render. Cheap, low-latency for discrete
+events.
+
+**Streaming surfaces** render from a direct connection declared
+via a manifest tuple. The binding's tuple says "this surface
+subscribes to event stream E with endpoint Z." The surface opens
+the direct connection to Z and consumes the stream at full
+bandwidth. The tuple space tracks the manifest's lifecycle but does
+not carry the stream. This is how a live-progress panel watches
+a workflow execute: not by polling the tuple space, not by
+receiving tuples at step-event granularity, but by holding a direct
+SSE / WebSocket / pipe connection to the workflow engine's emitter
+endpoint that the binding registered.
+
+The engine doesn't care about the host; the host doesn't care about
+the engine. The contract is the surface descriptor and (where
+needed) a connection manifest. This is what makes the substrate
+harness-agnostic without sacrificing the per-harness native
+experience or sacrificing bandwidth.
+
+Estimated cost: per-harness adapter. tmux adapter is small (~200
+LoC). ext-apps adapter is the work already covered in the handed-off
+workflow-engine doc. Manifest lifecycle is shared across adapters
+and is small once the tuple type is defined.
+
+**3. Bindings primitive + management panel.** Bindings are tuples.
+The trigger is a tuple template (or compound query); the action is
+a workflow invocation (or a tuple post, or a `SendMessage`); the
+surface is a descriptor. A binding is one row in the bindings table;
+the table is itself a tuple type in the tuple space.
+
+Authoring: an ext-apps form or tmux TUI lets the user fill in
+trigger/action/surface. The form is itself a workflow rendered as a
+surface. Bootstraps eats its own dog food.
+
+Management: a single panel lists all active bindings, lets the user
+toggle/edit/delete. Disabled bindings are kept (in case the user
+wants to reactivate). Bindings are profile-scoped — different
+mission contexts surface different bindings.
+
+Estimated cost: the primitive is a tuple type + a small CRUD path.
+The management panel is itself authored as a workflow-as-app. The
+authoring UX is a form; the form generator can be largely
+LLM-assisted ("user describes the trigger; LLM emits the tuple
+template").
+
+## The LLM and other actors on the bus
+
+The agent (LLM) is one specialist on the blackboard. So is the user.
+So is each surface. So is each background worker. So is each
+scheduled job.
+
+A critical discipline that has to be visible: **who acted, when,
+why.** The active-claims panel surfaces this. A claim is `in`-style
+acquisition of a coordination tuple — "I, agent xyz, am working on
+this; here's my TTL." The panel shows currently-active claims, what
+each actor is doing, and how long until TTL expiry. The user can
+see when an agent is about to time out; the agent can see what
+peers are working on adjacent things; the user can revoke a claim
+manually.
+
+Turn-taking happens at two levels:
+
+1. **Permission modes** as the existing lockdown discipline. The
+   harness already enforces this. `plan` mode = agent proposes,
+   user disposes. `acceptEdits` = agent acts freely. `auto` =
+   agent runs continuously. These map directly to the WoW
+   combat-lockdown analog: a posture the user picks for the
+   current mission context.
+2. **Claim-based coordination** as the fine-grained turn-taking. An
+   agent claims a resource (or a binding's action slot, or a
+   surface's render slot) before taking action; releases on
+   completion. Other agents see the claim and back off. The user
+   can break a claim manually. The atomic `in` makes this safe
+   under concurrent agents.
+
+Visualisation matters here. The substrate without visualisation is
+just plumbing. The active-claims panel + the recent-events stream
++ the active-bindings list are the *minimum* visible surfaces that
+turn the substrate into a comprehensible C2 cockpit. Without these
+three panels, the user has no situational awareness.
+
+## Cross-instance coordination
+
+Multiple Claude Code processes on the same machine, or multiple
+users in a shared project, or one user with foreground + N
+background agents — all the same problem. The tuple space's T2 tier
+(SQLite WAL) is multi-process safe, so the cross-process bus is
+free.
+
+Each instance posts a `liveness` tuple periodically with its PID,
+project, current focus, recent activity summary. A cross-instance
+panel `rd`s liveness tuples within TTL. The user sees what every
+instance is doing without context-switching.
+
+This is also where the existing `~/.config/nexus/t1_addr.<pid>`
+discovery mechanism (RDR-105) gets cleaned up: it remains for T1
+bootstrap, but everything else moves to T2 tuples. Cross-instance
+state becomes one query.
+
+Inter-instance messaging: post a tuple addressed to the recipient
+PID or by intent ("any instance handling project X"). The recipient
+`in`s it from its mailbox. The `SendMessage` user-facing tool can
+remain unchanged; its transport unifies to the tuple-space mailbox.
+
+## Workflows as a free variable
+
+Workflows in some form will exist. The form may be Parmar-style
+(JSON DSL, MCP Mediator, deterministic execution) — that's what the
+handed-off doc explores. Or it may be lighter (chained tool calls
+the agent re-issues), or richer (a Temporal-style code-first
+runtime). The substrate this doc proposes is *agnostic* to which.
+What it commits to is that:
+
+- A binding's action slot can hold a workflow reference, a single
+  tool call, a tuple post, or a `SendMessage`. The action is whatever
+  the harness can dispatch.
+- The workflow engine, if present, is a **peer specialist** on the
+  blackboard, running in its own process and connected to nexus via
+  MCP. It `in`s "run this workflow" tuples, emits step-completion
+  tuples back to the space, posts the final result tuple, and
+  optionally declares connection manifests for live step-progress
+  streams that subscribed surfaces consume directly.
+- Workflow execution does not happen in nexus. The workflow engine
+  is a separate MCP server process. Nexus coordinates; the workflow
+  engine executes. Intra-step dataflow (engine pulling a 10MB blob
+  from a downstream MCP server and feeding it into the next step's
+  input) is engine-internal, never tuple-routed.
+
+That last point matters: **the workflow engine is just another
+specialist** under this framing — and the *separation* is what
+keeps nexus as a switchboard rather than a bottleneck. If a project
+uses Parmar's engine for stateful workflows and direct tool calls
+for everything else, the substrate accommodates both with no extra
+work and no payload routing through nexus.
+
+## Surfaces — the C2 cockpit observation
+
+The harness already has rendering surfaces. The substrate doesn't
+need a new component model; it needs a *layout layer* and a few
+standard surface types.
+
+Surface levels (from least intrusive to most):
+
+- **Status line** — one-line ambient indicator. Maps to tmux
+  status-right, terminal status bar, or a small header element in
+  GUI hosts.
+- **Notification** — transient, dismissible. Maps to system notify,
+  terminal bell + log line, or in-chat toast.
+- **Panel** — persistent surface, takes a slot. Maps to tmux pane,
+  ext-apps iframe, VS Code webview, or artifact panel.
+- **Full-screen** — temporary takeover for a checkpoint or wizard.
+  Maps to tmux full-window mode, ext-apps fullscreen mode, or
+  modal in GUI.
+
+A *layout* is a named arrangement of slots, each slot bound to a
+surface descriptor produced by a binding. Layouts are tuples,
+profile-scoped. Switching layouts is `out`ting a "current_layout"
+tuple; subscribed surfaces react.
+
+Mission contexts are profiles in WoW's sense: a saved bundle of
+(active layout, active bindings, permission mode, recent-events
+filter). The user switches mission contexts by gesture; the LLM
+can suggest a switch. The harness handles the actual surface
+re-arrangement.
+
+### Layout is automatic — the binding-type registry is the stylesheet
+
+Hand-arranged dashboards rot. Every productivity tool that survived
+(Word, IDEs, Streamdeck profiles) defaults to automatic layout with
+user override as the escape hatch, not the entry point. The cockpit
+follows the same discipline.
+
+Bakke, Karger, and Miller's *Automatic Layout of Structured
+Hierarchical Reports* (InfoVis 2013) is the load-bearing prior art.
+Their algorithm composes three layout idioms (nested table,
+multi-column form, outline-style indented list) into hybrid layouts
+that fit a horizontally-constrained viewport by making **layout
+decisions per schema node, applied uniformly to every instance of
+that node**. Gestalt across siblings is what makes their reports
+legible at a glance. Our surface-level palette (`status-line`,
+`notification`, `panel`, `full-screen`) is the direct analog of
+their idiom palette; the same discipline applies — **pick a surface
+level per binding type, not per event instance**. Every
+`tool_call_completed` event renders the same way; every
+`claim_acquired` renders the same way; the user learns the cockpit
+*once*.
+
+The stylesheet sits on the schema, not on the data. In our terms
+that is **the RDR-110 dimension registry**, extended to carry layout
+disposition for each registered semantic-event type. When a new
+event type is registered, its default layout properties go on the
+registry entry; per-binding overrides ride on the binding tuple.
+Individual event tuples never carry layout properties — they carry
+payload, and the registry tells the layout engine how to render
+that payload-shape.
+
+### Measure → Auto-Style → Layout, online
+
+Bakke's three-phase algorithm maps cleanly, then needs three
+extensions for the dynamic case:
+
+- **Measure.** Traverse the active binding set. For each binding,
+  read off the registry: event type, typical event rate, payload
+  size profile, priority class, time-decay profile. For surfaces
+  already on-screen, measure observed render width / history depth.
+- **Auto-Style.** Heuristics over the binding set produce a
+  stylesheet — for each binding, which surface level it gets, which
+  slot allocation, which iconography, which on-screen TTL. The
+  heuristic respects the display budget (see below) and the active
+  mission-context profile. The stylesheet is a tuple, materialised
+  per mission context, regenerated whenever the binding set or the
+  display budget changes.
+- **Layout.** Apply the stylesheet to actual events: render the
+  status line from recent low-priority events, populate panels from
+  their bound queries, fire notifications from priority-tagged
+  events, raise full-screen modes for checkpoint/wizard events.
+
+The static-report assumptions in Bakke do not survive contact with a
+live event stream. Three extensions are mandatory:
+
+- **Online re-layout.** The Auto-Style phase is incremental, not
+  one-shot. Binding registrations, mission-context switches, and
+  display-budget changes (window resize, pane split, secondary
+  display attached) trigger a stylesheet regeneration. The
+  regeneration runs on the same totally-ordered T2 log as everything
+  else — it is one or two tuple operations, not a re-render of the
+  world.
+- **Temporal decay.** Bakke renders all data; the cockpit cannot.
+  Each event type carries a decay profile on its registry entry
+  (immediate-fade, last-N-on-status, persistent-until-acked,
+  persistent-until-superseded). The status line shows the last N
+  decayed events; the recent-events panel shows the last M
+  un-acked events; old tuples release their slot back to the layout
+  engine.
+- **Priority preemption.** A `priority=critical` event displaces a
+  lower-priority event already occupying its target surface level.
+  Bakke's algorithm has no notion of "this content must displace
+  lower-priority content"; the cockpit does. Preemption is a
+  property on the registry entry (`preempts: [...]`), enforced by
+  the layout engine when it allocates slots.
+
+### Horizontal-budget cascade — the demotion rule
+
+Bakke constrains horizontal width and refuses to scroll
+horizontally; everything cascades from there. Cockpit equivalent:
+the display budget (terminal pane width, monitor width, mobile
+width, voice-only audio "bandwidth") is fixed; vertical history
+scrolls; horizontal does not.
+
+When the budget shrinks (window resize, pane split, mission-context
+switch into a denser layout), the layout engine applies a
+**surface-level demotion cascade** to each binding, in priority
+order:
+
+```
+full-screen  →  panel  →  status-line  →  notification-only  →  suppressed
+```
+
+A binding with a `panel` disposition that no longer fits gets
+demoted to `status-line`; if the status line is full, it falls
+through to `notification-only` (events fire as transient
+notifications without occupying a slot); if even notifications would
+overwhelm, the binding is suppressed and a single
+`suppressed-bindings` indicator lights up on the status line.
+Per-binding minimums on the registry entry (`min-surface:
+status-line`) prevent critical bindings from being demoted past a
+floor.
+
+The user's manual override path stays available: any binding can be
+pinned to a specific surface level, in which case the cascade
+respects the pin and demotes other bindings around it. Manual
+layout authoring is the escape hatch; auto-layout from the binding
+set is the default.
+
+The cockpit metaphor is exact: cockpits have instruments (surfaces
+reading state), controls (surfaces issuing commands), modes (lockdown
+discipline), and checklists (workflows). The substrate provides each;
+the layout engine arranges them from the active bindings and the
+display budget; the user adjusts when the automatic arrangement
+needs nudging for the mission being flown.
+
+## What we build vs what we leverage
+
+The lever distinction matters because the cost picture changes
+radically when we count properly.
+
+**Build (small, novel):**
+- Hook → tuple bridge (~100 LoC).
+- Bindings primitive (~150 LoC: tuple type + CRUD path).
+- Auto-layout engine — Measure / Auto-Style / Layout phases with
+  online re-layout, temporal decay, priority preemption, and the
+  horizontal-budget demotion cascade. Built on top of the dimension
+  registry; per-harness adapters render the resulting slot
+  assignments. Layout disposition fields on registry entries are
+  ~50 LoC of registry plumbing; the engine itself is ~300 LoC of
+  heuristics plus per-harness adapter (~200 LoC tmux, more for GUI
+  hosts).
+- Active-claims panel (workflow-as-app on top of the substrate).
+- Active-bindings management panel (workflow-as-app).
+- Recent-events panel (workflow-as-app).
+- tmux fulfillment adapter (~200 LoC).
+- Cross-instance liveness tuple + `nx instances` (~50 LoC).
+- LLM-as-specialist turn-taking discipline (mostly documentation +
+  surfacing existing permission modes correctly).
+
+**Leverage (already in nexus):**
+- RDR-110 tuple space (in flight, accepted, load-bearing).
+- T1/T2/T3 tier discipline.
+- Plan library + plan_match.
+- nx CLI + skill ecosystem.
+- Beads for cross-session work tracking.
+- Catalog tumblers for content-addressed identity.
+
+**Leverage (already in the harness):**
+- Hook bus (every hook event type listed above).
+- Background process supervision.
+- Inter-agent SendMessage.
+- Scheduled wakeups and cron.
+- Worktrees for isolation.
+- Permission modes for lockdown.
+- MCP server set as capability inventory.
+- Plugin distribution.
+- tmux (terminal harness) — entire layout and multiplexing substrate.
+
+**Leverage (external prior art — patterns, not code):**
+- Linda's `out`/`in`/`rd`/`eval` semantics.
+- Blackboard architecture's specialist composition.
+- WeakAuras' trigger/display/action triple as the binding DSL shape.
+- Portal frameworks' lessons on IPC-versus-shared-state.
+- SCADA's tag-based data model.
+- LabVIEW's data-flow composition (architecture only; not the wiring UX).
+
+**Not building, intentionally:**
+- A new component / widget framework. The harness's native surfaces
+  are fine.
+- A new identity / auth layer. The harness owns identity.
+- A new persistence engine. RDR-110 tier model is sufficient.
+- A new IPC mechanism. SendMessage + tuple mailboxes are sufficient.
+- A wiring-style visual programming UX. Form-based binding authoring
+  is closer to what's been proven learnable.
+
+## The open questions (intentionally)
+
+These are *kept open*, not deferred:
+
+- **Where workflows fit.** Some bindings will want a multi-step
+  workflow as their action; others will want a one-shot tool call.
+  The substrate accepts both. Whether a project ships a workflow
+  engine as a peer MCP server, or inlines workflow-like logic in
+  the binding itself, or delegates to an external runtime — all
+  three are substrate-compatible. Don't commit yet.
+- **Binding authoring UX.** Form-based is the default. LLM-assisted
+  binding emission is natural. Visual wiring may eventually be
+  useful for advanced users but is not the starting point.
+- **Surface descriptor format.** Need to settle on a small, stable
+  shape (level + payload + optional layout hints). Earliest version
+  can be a JSON Schema; mature version maps to A2UI or similar
+  declarative component intent.
+- **Multi-user / collaborative shape.** Shared projects in Claude
+  Code already exist; the tuple-space-shared scope is the obvious
+  bridge, but the access-control and conflict-resolution stories
+  for multi-user editing of bindings / layouts / claims need
+  spec work.
+- **The voice-first / autonomous-headless cases.** The substrate
+  works without a display, but the binding/management UX needs
+  alternatives. Probably out of scope for early iterations.
+
+## Sketched ordering — what to do first
+
+Dependencies aside, the minimum-viable cockpit substrate ships in
+roughly this order:
+
+1. **RDR-110 implementation lands.** Tuple space common model with
+   `in` / `out` / `rd` / `eval` and the dimension registry. This is
+   the foundational primitive everything else hangs from.
+2. **Hook → tuple bridge.** Trivial to implement. Makes the
+   harness's existing event bus observable as data. Without this,
+   nothing in the substrate is composable.
+3. **Bindings primitive + management panel.** One tuple type, one
+   CRUD path, one workflow-as-app for management. Enables
+   user-authored composition.
+4. **Active-claims and recent-events panels.** Visualisation of the
+   substrate itself. Turns plumbing into a comprehensible cockpit.
+5. **tmux fulfillment adapter.** Lights up multi-pane situational
+   awareness for terminal users. Leverages the existing terminal
+   composition substrate.
+6. **Cross-instance liveness tuple.** Solves "what's running"
+   across multiple Claude Code processes. Cheap.
+7. **First end-to-end mission profile.** Pick a real workflow Hal
+   does often (RDR creation, incident response, build watching).
+   Author the bindings, the layout, the lockdown mode. Run it.
+   Measure what's awkward; iterate.
+
+Each step is bounded, builds on the prior, and leans on existing
+substrate rather than inventing.
+
+## Reframe
+
+The previous design conversation centered on a workflow engine
+extended with ext-apps. That doc is now shipped and handed off.
+
+This document centers on a different thing: **nexus as the
+coordinator and switchboard for an agentic cockpit. Tuple space as
+the control plane; direct peer-to-peer connections, brokered by
+manifest tuples, as the data plane. The harness's existing hook bus
+projected into the tuple space as semantic events. Workflows as one
+of many possible specialists, running in their own processes.**
+
+Nexus does not sit in the data path. It brokers, declares, claims,
+and tears down. The actual bandwidth flows where it needs to —
+between agents, between agent and surface, between engine and
+downstream MCP servers — over whatever direct transport fits.
+Manifests make every direct connection visible to the control plane
+without making the control plane responsible for the payload.
+
+The substrate is small. The leverage is enormous. Most of the work
+is naming what already exists and wiring it together; the
+genuinely-new code budget is in the low hundreds of LoC. The hard
+part is the discipline — making sure bindings, layouts, claims,
+manifests, and turn-taking are visible and comprehensible to both
+the user and the LLM, and that the line between control and data is
+respected so nexus never becomes a bottleneck.
+
+The metaphor that fits is the WoW addon ecosystem combined with
+SIP-style signaling: blackboard coordination at the substrate, real
+data paths between peers, both visible to a runtime that brokers but
+does not interpose.
+
+Workflow is a free variable in this design. Tuple space (as
+switchboard) and semantic events (as integration projection) are
+the load-bearing commitments. Connection manifests are the
+discipline that keeps the switchboard a switchboard.

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -133,6 +133,8 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-108](rdr-108-graph-identity-normalization.md) | Graph Identity Normalization: Catalog Holds the Tree, T3 is a Content-Addressed Blob Store | Architecture | Accepted | 2026-05-08 |
 | [RDR-109](rdr-109-honest-naming-and-cross-encoder-salience.md) | Honest Local-Mode Naming and Cross-Encoder Salience: Two Naming/Scoring Designs Touching the Same Test-Suite Mode-Default Surface | Architecture | Accepted | 2026-05-10 |
 | [RDR-110](rdr-110-semantic-tuple-space.md) | Semantic Tuple Space: Unified Coordination Primitive over ChromaDB + SQLite | Architecture | Accepted | 2026-05-09 |
+| [RDR-111](rdr-111-orb-agentic-cockpit-substrate.md) | The ORB: Observable Relay Bus — Hook Projection, Bindings, and C2 Cockpit Substrate | Architecture | Draft | 2026-05-11 |
+| [RDR-112](rdr-112-storage-as-service-container-boundary.md) | Storage-as-Service: T2/T3 Behind a Process Boundary, T1 Stays In-Container | Architecture | Draft | 2026-05-12 |
 
 ---
 

--- a/docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md
+++ b/docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md
@@ -1,0 +1,1049 @@
+---
+title: "The ORB: Observable Relay Bus — Hook Projection, Bindings, and C2 Cockpit Substrate"
+id: RDR-111
+type: Architecture
+status: draft
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-11
+related_issues: []
+related_rdrs: [RDR-105, RDR-110]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-111: The ORB: Observable Relay Bus — Hook Projection, Bindings, and C2 Cockpit Substrate
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+The agentic harness ships a remarkably complete coordination
+substrate — hooks at every lifecycle point (`PreToolUse`,
+`PostToolUse`, `Stop`, `SubagentStop`, `SessionStart`, `SessionEnd`,
+`UserPromptSubmit`, `PreCompact`, `Notification`), background
+supervision, inter-agent messaging, scheduled wakeups, worktree
+isolation, permission modes, and MCP server composition. But these
+capabilities are **opaque by default**. An agent runs; things happen;
+the user has no situational awareness unless they inspect tool output
+line by line. The hook bus fires but its events vanish. Coordination
+state — which agent holds what resource, what tasks are in flight,
+what just completed — is invisible unless each agent individually
+surfaces it, in ad-hoc ways, with no shared model.
+
+Three concrete gaps:
+
+### Gap 1: Hook events are fire-and-forget, not observable state
+
+`PreToolUse` and its siblings fire a shell script or nothing.
+There is no mechanism to observe these events as data — to query
+them, subscribe to them, aggregate them, or react to them
+declaratively. The hook bus is the right shape for an event
+backbone; it is wired to exactly one consumer (the script) and
+exposes nothing to other actors or surfaces.
+
+### Gap 2: No user-authored composition layer
+
+There is no way for a user — or an LLM acting on the user's behalf
+— to say "when event X happens, do Y and show Z." Reactions to
+events are hard-coded in hooks or in agent prompts. The composition
+is in code, not in data. Adding a new reaction requires a code
+change. Removing one requires finding it. There is no management
+surface, no toggle, no profile.
+
+### Gap 3: No situational awareness surface
+
+There is no panel, status line, or ambient display that answers
+"what is running right now, what does it hold, what just happened."
+The user context-switches between terminal windows, reads raw
+output, and loses track of what each background agent is doing.
+The cockpit metaphor is exactly right: this is a cockpit with no
+instruments.
+
+The ORB addresses all three gaps with minimal new mechanism,
+leveraging the semantic tuple space (RDR-110) as the backbone.
+
+## Context
+
+### The two architectural moves (from `docs/agentic-cockpit.md`)
+
+The design exploration in `docs/agentic-cockpit.md` identifies two
+load-bearing moves that turn the latent substrate into a C2 cockpit:
+
+**Move 1** — The RDR-110 semantic tuple space is the common
+coordination model. Everything that wants to coordinate uses it as a
+switchboard, not a bandwidth medium. Tuples describe state, declare
+connections, claim resources, and post milestones. Actual payload
+flows on direct peer-to-peer connections brokered by manifest tuples.
+
+**Move 2** — Hook events are projected into the tuple space as
+semantically-typed tuples (semantic events), making them composable,
+queryable, and addressable by intent. These are milestones —
+`PreToolUse` fires once per tool call, producing one tuple, not one
+per stdout byte. Granularity is the discipline.
+
+The ORB is the implementation of Move 2, built on the foundation of
+Move 1 (RDR-110). Three independently shippable pieces:
+
+1. **Hook → tuple bridge.** A hook adapter that projects each harness
+   lifecycle event into the tuple space as a typed semantic event.
+2. **Bindings primitive.** A tuple type that encodes a declarative
+   trigger/action/surface triple, plus CRUD management.
+3. **C2 cockpit surfaces.** Three minimal panels that make the
+   substrate visible: active claims, recent events, active bindings.
+
+### Prior art grounding
+
+- **Linda tuple spaces** (Gelernter & Carriero, 1986): `out`/`in`/`rd`
+  as the coordination primitives. RDR-110 provides these (as `out`/
+  `take`/`read`); the ORB uses `out` for event projection and `read`
+  for subscription.
+- **Blackboard architectures** (Hayes-Roth et al., Hearsay-II, 1970s):
+  specialists post hypotheses to a shared knowledge base; others
+  refine. Each actor in the system — LLM, user, surface, background
+  worker — is a specialist on the blackboard.
+- **WeakAuras** (WoW addons, 2004–): the richest consumer-grade example
+  of cooperating active surfaces over shared world-state. A
+  declarative trigger/display/action triple, user-authored without
+  code. The existence proof that this pattern is learnable.
+- **Bakke, Karger & Miller** (InfoVis 2013): automatic layout of
+  structured hierarchical reports via schema-driven hybrid layouts.
+  The binding-type registry is the stylesheet; layout decisions are
+  per schema node, applied uniformly to every instance.
+- **SCADA / DCS / mission control** (1960s–): tag-based data models,
+  alarm systems, runbook integration. The dashboards that don't suck.
+- **SIP/WebRTC signaling**: the connection manifest pattern —
+  signaling brokers connections without carrying the payload. Manifest
+  tuples declare direct peer-to-peer streams; nexus tracks the
+  lifecycle without seeing the data.
+
+### Relationship to RDR-110
+
+RDR-110 ships the tuple space primitive: `out`/`read`/`take`/`ack`/
+`nack`, the claim ledger, the subspace registry, five canonical
+subspaces, and the four-consumer landing surface. The ORB extends
+the subspace registry with seven new subspace types (semantic event
+types from the hook bus), adds the `bindings`, `layout_state`, and
+`connection_manifest` subspaces. The ORB's surfaces consume the tuple
+space via `read` queries; they do not require new storage.
+
+RDR-111 is **blocked on RDR-110 Phase 1 Step 4** (core API + MCP
+tools). The hook bridge needs `out`; the cockpit panels need `read`.
+
+**API name mapping** (Linda academic terms → RDR-110 concrete API):
+
+| Linda | RDR-110 | Notes |
+|-------|---------|-------|
+| `out` | `out` | identical |
+| `rd` / read-without-consuming | `read` | pattern-match query; tuple stays |
+| `in` / read-and-consume | `take` | atomic claim + consume |
+
+Linda terminology (`rd`, `in`) is used in prior-art and conceptual
+sections of this RDR. Implementation-facing sections use the RDR-110
+names (`read`, `take`).
+
+**RDR-110 coordination required (CA-9)**: The ORB's seven hook-event
+subspaces and `bindings/<profile>` subspace must be registered in
+RDR-110's subspace registry (the YAML subspace registry defined in
+RDR-110 Phase 1 Step 6). This RDR adds entries to that registry; the
+RDR-110 implementation must expose a registration mechanism for
+third-party subspaces (i.e., subspaces not defined in RDR-110 itself).
+This is a **definitive prerequisite** (CA-9), not a conditional: the
+RDR-110 implementor must be notified before Phase 1 Step 6 ships so
+that open registration is included in scope. Without this, the ORB's
+Phase 1 Step 1 (hook-event subspace schema registration) cannot proceed.
+
+## Research Findings
+
+### Investigation
+
+Structural analysis of the harness hook contract, the RDR-110 API
+surface, and the `docs/agentic-cockpit.md` design exploration. The
+findings below are verified against those sources.
+
+### Key Discoveries
+
+- **Verified** — The harness hook contract is stable and machine-
+  readable. Each hook fires with a well-defined JSON payload; the
+  mapping to a semantic event tuple is mechanical and ~100 LoC.
+  The hook adapter is additive — no existing hook handler changes.
+- **Verified** — A binding is a tuple type: trigger template (a
+  subspace query + optional structural filters), action descriptor
+  (tool call, tuple post, `SendMessage`, or workflow ref), surface
+  descriptor (level + payload shape + optional stream endpoint).
+  Bindings are managed via `out`/`take` on a `bindings/<profile>`
+  subspace. No new storage required.
+- **Verified** — The three minimum cockpit panels (active claims,
+  recent events, active bindings) are each a single `read` query over
+  the tuple space with a light formatting layer. No new primitives.
+  A tmux pane or ext-apps iframe rendering the query result is the
+  fulfillment layer.
+- **Verified** — Control plane / data plane separation is the load-
+  bearing discipline. Tuples describe and broker connections; they do
+  not carry payload. A `connection_manifest` tuple declares a direct
+  peer-to-peer stream (SSE, WebSocket, pipe, file-fd); the actual
+  bandwidth flows between peers without touching nexus. This keeps
+  nexus as a switchboard, never a bottleneck.
+- **Verified** — The auto-layout engine (Bakke's Measure /
+  Auto-Style / Layout pipeline, adapted for live event streams) sits
+  on the binding-type registry. Layout disposition is a property of
+  the registered event type, not of individual event tuples. Online
+  re-layout, temporal decay, priority preemption, and the
+  horizontal-budget demotion cascade are the four extensions the
+  static-report algorithm needs for the dynamic case.
+- **Revised** — Cross-instance liveness must use **T2 (SQLite),
+  not the tuple space**. The tuple space is scoped to a single
+  `nx-mcp` process (T1 or the process's local SQLite shard); a
+  tuple posted by one process is not visible to another process's
+  `read` query unless the tuple space itself has a cross-process
+  backend (which RDR-110 does not provide in Phase 1). Per RDR-105,
+  T2 (SQLite WAL mode) is the defined cross-process shared bus.
+  The correct implementation: a `liveness` table in the T2 SQLite
+  database with `(pid, machine, user, session, project,
+  focus, activity_summary, last_seen)`, upserted every 30s by
+  each `nx-mcp` process and swept by a background thread for rows
+  where `last_seen < now - 60s`. `nx instances` queries this
+  T2 table directly. This adds ~80 LoC (T2 schema migration +
+  upsert + sweep + CLI command), slightly more than the 50 LoC
+  originally estimated for the tuple-space approach.
+
+### Research Finding RF-1: Hook payload shapes — verified inventory
+
+Sourced from `nx/hooks/scripts/`, `tests/hooks/`, and the LangSmith Claude Agent SDK
+integration (`_hooks.py`). All fields below are verified against production code or
+test fixtures. Fields marked `[inferred]` are from community documentation and GitHub
+issues; no production hook in this repo reads them yet.
+
+**Common base fields** (present in all or most hook types):
+`session_id`, `hook_event_name`, `transcript_path` (path to JSONL), `cwd`
+
+| Hook type | Additional stdin fields | Output contract |
+|---|---|---|
+| `PreToolUse` | `tool_name`, `tool_input` (object with tool args, e.g. `command`, `file_path`) | **Required**: `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"\|"block", "additionalContext": "..."}}` — malformed output blocks tool calls |
+| `PostToolUse` | `tool_name`, `tool_input`, `tool_response` (tool output, any JSON type) | `{"hookSpecificOutput": {"hookEventName": "PostToolUse", "permissionDecision": "allow", "additionalContext": "..."}}` — advisory, never blocks |
+| `PermissionRequest` | `tool_name` | **Required**: `{"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": "allow"}}}` — malformed output blocks tool |
+| `Stop` | `stop_hook_active` (bool) | `{"decision": "approve", "reason": "..."}` — top-level `decision`, NOT `hookSpecificOutput` |
+| `StopFailure` | `error` (type string: rate_limit \| authentication_failed \| billing_error \| invalid_request \| server_error \| max_output_tokens \| unknown), `error_details` (string), `last_assistant_message` | Output **ignored** by harness; side-effects only |
+| `SubagentStart` | `task` (description), `prompt` (agent prompt text) | `{"hookSpecificOutput": {"hookEventName": "SubagentStart", "additionalContext": "..."}}` — injected into subagent context |
+| `SubagentStop` | `stop_hook_active` (bool), `permission_mode` [inferred] | `{"hookSpecificOutput": {"decision": {"behavior": "allow"\|"stop"}}}` [inferred] |
+| `SessionStart` | `claude_session_id` (UUID string) | Raw text/markdown — injected into Claude's context window |
+| `SessionEnd` | (no type-specific fields beyond base) | Output ignored; side-effects only |
+| `PostCompact` | `trigger` ("manual"\|"auto"), `compact_summary` (text), `permission_mode` | Raw text/markdown — injected into Claude's context window |
+| `PreCompact` | `trigger` ("manual"\|"auto"), `compact_summary`, `estimated_tokens`, `token_limit` [inferred] | Output ignored (`hooks.json` has empty `[]` for this type — not currently used) |
+| `UserPromptSubmit` | `prompt` (the user's message text) [inferred] | `{"hookSpecificOutput": {"decision": {"behavior": "allow"\|"stop"}}}` [inferred] |
+| `Notification` | `message`, `notification_type` [inferred] | Output ignored (informational only) |
+
+**Critical output divergence** (`Stop` vs `PreToolUse`): `Stop` uses top-level `{"decision":
+"approve"}` while `PreToolUse` uses `{"hookSpecificOutput": {"permissionDecision":
+"allow"}}`. These are **not interchangeable**. Each per-hook-type bridge script must
+emit exactly the contract for its hook type.
+
+**Gap note**: `SubagentStop`, `UserPromptSubmit`, `PreCompact`, and `Notification` payload
+shapes are partially inferred from community docs and GitHub issues (no production script
+in this repo reads them). CA-6 below gates on empirical verification before the bridge
+scripts for these types are written.
+
+**Implication for CA-2**: The hook payload shape is clear and already depended upon by
+multiple production hook scripts for the 9 verified types. CA-2 is substantially
+de-risked for those types; the bridge mapping table can be written today for them.
+
+### Research Finding RF-2: Hook output semantics vary by type — bridge must be transparent
+
+This is a critical design constraint not surfaced in the original draft.
+
+Hook scripts that respond with `hookSpecificOutput` JSON **affect Claude's behaviour**:
+
+- `PreToolUse` response: `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"|"block", "additionalContext": "..."}}`
+  — if the bridge outputs malformed JSON here, tool calls are blocked.
+- `PermissionRequest` response: same shape with `permissionDecision`.
+- `SubagentStart` response: `{"hookSpecificOutput": {"hookEventName": "SubagentStart", "additionalContext": "..."}}` — injects content into the subagent's initial context.
+- `Stop` / `StopFailure`: output and exit codes are **ignored** by the harness.
+- `SessionStart` / `SessionEnd`: output is injected as context; exit code matters.
+
+**Design correction**: The bridge cannot simply write to stdout for all hook types.
+For hooks with decision semantics (`PreToolUse`, `PermissionRequest`), the bridge must
+emit a permissive `hookSpecificOutput` JSON (pass-through allow) while posting the
+tuple as a side effect. For `SubagentStart`, it must either emit no stdout (to avoid
+interfering with the context-injection chain) or be registered *before* the existing
+hook so the existing hook's `additionalContext` arrives last. The safest shape:
+
+```python
+# For PreToolUse / PermissionRequest:
+import json, sys
+payload = json.loads(sys.stdin.read())
+out_to_tuple_space(payload)   # side effect only; errors caught and logged
+# emit transparent allow — never block on bridge failure
+print(json.dumps({"hookSpecificOutput": {
+    "hookEventName": payload.get("hookEventName", "PreToolUse"),
+    "permissionDecision": "allow"
+}}))
+sys.exit(0)
+
+# For Stop / StopFailure / SessionEnd:
+out_to_tuple_space(payload)
+sys.exit(0)  # no stdout needed
+```
+
+This constraint affects the bridge architecture: it is **not** a single handler
+for all hook types, but a **family of thin per-hook-type scripts**, each with the
+correct output contract, all sharing the `out` call.
+
+### Research Finding RF-3: Hook chaining is already in use — bridge is additive
+
+`nx/hooks/hooks.json` shows multiple hooks registered per event type (e.g.,
+`SessionStart` chains 6 commands). The bridge adds one more entry per type.
+Hook chaining has no ordering guarantee across entries at the same level, but
+output from all entries is collected. **The bridge must never be the last
+`PreToolUse` handler that determines the allow/block decision** — register it
+first in the chain, emit `allow`, and let the existing decision hooks follow.
+
+### Research Finding RF-4: No existing tmux surface integration — genuinely new territory
+
+Searching the codebase (`find + grep tmux`) shows tmux references only in:
+- E2E test runner scripts (`tests/e2e/*.sh`) — use tmux to drive test scenarios
+- Documentation (`docs/agentic-cockpit.md`, `rdr-111`) — design only
+
+There is no existing `status-right` update path, no pane management code, no
+tmux IPC in any Python source. The tmux fulfillment adapter is net-new code with
+no prior art to reuse within the repo. CA-4 (tmux refresh cadence) remains
+spike-gated and unverified.
+
+### Research Finding RF-5: `CLAUDECODE=1` env var gates production side-effects
+
+Existing hooks (`stop_failure_hook.py`) skip side-effects unless `CLAUDECODE=1`
+is set. The bridge should follow the same pattern: if `CLAUDECODE` is not set,
+skip the `out` call and exit 0 silently. This makes the bridge safe to invoke
+in test harnesses, linting, and local dev without polluting the tuple space.
+
+### Critical Assumptions
+
+| # | Assumption | Status | How to verify | Risk if wrong | Phase gate |
+|---|---|---|---|---|---|
+| CA-1 | RDR-110 Phase 1 Step 4 ships before this RDR begins implementation | Open | RDR-110 status check | Blocked; cannot proceed | P1 |
+| CA-2 | Hook payload JSON for the 9 verified hook types is stable across harness versions | **De-risked (RF-1)** | Schema validated against production scripts; 4 types (`SubagentStop`, `UserPromptSubmit`, `PreCompact`, `Notification`) still require empirical verification (CA-6) | Low for verified types; medium for inferred types | P1 |
+| CA-3 | `read` query latency over T2 is < 50ms at 10k tuples | Open | Benchmark after RDR-110 ships | Panel refresh sluggish; may need materialised view | **P2 gate** |
+| CA-4 | tmux `status-right` update at 1-2s cadence has no perceptible lag | Open | Manual test on target hardware | Increase to 5s cadence + stale indicator | **P3 gate** |
+| CA-5 | Binding reaction end-to-end < 200ms at 10 concurrent active bindings | Open | Benchmark after bridge + watcher ship | Move watcher to dedicated process | **P2 gate** |
+| CA-6 | `SubagentStop`, `UserPromptSubmit`, `PreCompact`, `Notification` payload shapes match inferred schemas | Open — **spike required before bridge scripts for these types are written** | Register a minimal logging hook for each type; capture real payload from a live session; compare against RF-1 table. Spike ≤ 2h. | Bridge scripts emit wrong field names → tuples have missing/null dimensions | P1 (bridge for these 4 types) |
+| CA-7 | The Bakke Measure/Auto-Style/Layout adaptation is ≤ 300 LoC and can be implemented by a single developer in < 1 week | Open — **novel work, no prior art in repo** | Prototype the three pipeline phases on a static binding set before committing to Phase 3 | Layout engine becomes the long pole; delays Phase 3 by 2–4 weeks | **P2 gate** |
+| CA-8 | Multi-`PreToolUse`-hook ordering: when two hooks are registered, the first-registered "allow" does not preempt subsequent hooks' ability to "block" | Open — **empirically unverified** | Run `tests/cc-validation/scenarios/` harness with two PreToolUse hooks: hook-A returns `allow`, hook-B returns `block`; observe which wins. See scenario 07 for PermissionRequest precedent. **Fallback design if first-wins confirmed**: the bridge cannot be registered first as an unconditional `allow` emitter without neutralising legitimate block hooks. Fallback: bridge registers as a *last* entry using a separate `PostToolUse`-adjacent hook that fires after the decision hooks have run, or bridge emits no `permissionDecision` key at all (only `additionalContext`) and relies on the harness's default allow. Fallback design must be documented before Phase 2. | Bridge registered first could silently neutralise a legitimate block hook; or a block hook registered first could stall the bridge chain | P1 (bridge registration ordering) |
+| CA-9 | RDR-110's subspace registry exposes a registration mechanism for third-party subspaces not defined in the canonical five | **Definitive prerequisite — must be flagged before RDR-110 Phase 1 Step 6 ships** | Coordinate with RDR-110 implementor: confirm that Step 6 ships with open registration (additional YAML dirs discoverable at startup), not a closed allow-list. If closed, an extension mechanism must be added to RDR-110 before the ORB's Phase 1 Step 1 can proceed. | Without this, the seven hook-event subspaces and `bindings/<profile>` cannot be registered; the tuple space bridge is blocked | P1 |
+| CA-10 | RDR-110's `tuples.db` migration includes the `watcher_state` table (see schema in Phase 2 Step 6) | **Coordination required before Phase 2 Step 6** | Notify RDR-110 implementor before the `tuples.db` migration is finalized; confirm `watcher_state` is included. Gate criterion: confirmed presence of `watcher_state` CREATE TABLE in the tuples.db migration file. If RDR-110 ships without it, the ORB must ship a tuples.db upgrade migration (with schema-version guard) before Phase 2. | Phase 2 Step 6 fails at first run with "no such table: watcher_state" | P2 |
+
+## Proposed Solution
+
+### The seven semantic event subspaces
+
+Seven new subspace YAML files in `nx/tuplespace/builtin/hooks/`:
+
+```
+hook_events/tool_call_intent      ← PreToolUse
+hook_events/tool_call_completed   ← PostToolUse
+hook_events/agent_completed       ← SubagentStop
+hook_events/assistant_turn_ended  ← Stop, StopFailure
+hook_events/user_prompt           ← UserPromptSubmit
+hook_events/session_lifecycle     ← SessionStart, SessionEnd
+hook_events/notification          ← Notification
+```
+
+Note: `PostCompact` is intentionally excluded — it fires after context is
+rebuilt and injecting a tuple at that point would be redundant (the compact
+summary is already injected into Claude's context window by the hook output).
+`PreCompact` is also excluded — its output is currently unused (empty `[]` in
+`hooks.json`). If either is needed in future, a new subspace can be added.
+`StopFailure` is merged into `assistant_turn_ended` (error variant) rather
+than given its own subspace, since both represent a session turn boundary.
+
+Each subspace schema carries:
+- Required dimensions: `actor`, `session`, `project`, `timestamp`
+- Optional dimensions: `tool`, `workflow`, `intent`, `priority`
+- `match_text` field: a short semantic description of the event
+  (e.g. "deployed frontend via k8s.apply") for associative query
+- Layout disposition: default surface level, decay profile,
+  priority class, `preempts` list
+
+### The hook → tuple bridge
+
+**Revised per RF-2**: not a single handler but a family of thin per-hook-type
+scripts in `nx/hooks/scripts/orb_bridge_*.py`, all sharing a common
+`src/nexus/cockpit/hook_bridge.py` library for the `out` call and
+mapping table.
+
+Each script:
+1. Reads hook payload JSON from stdin
+2. Maps to the appropriate subspace + dimensions + `match_text`
+3. Calls `out` on the tuple space (skipped if `CLAUDECODE` not set — RF-5)
+4. Emits the correct stdout for that hook type (RF-2):
+   - `PreToolUse` / `PermissionRequest`: emit transparent `allow` JSON
+   - `SubagentStart`: emit no stdout (bridge registered first; existing hook follows)
+   - `Stop` / `StopFailure` / `SessionEnd`: emit nothing
+5. Exits 0 unconditionally — bridge errors are logged to stderr, never propagated
+
+Registered in `nx/hooks/hooks.json` as the **first** entry for each hook type
+(before existing decision hooks) — **provisional pending CA-8 spike**. If the
+CA-8 spike (now gated before Step 2 — see Step 7a below) confirms first-wins
+semantics (i.e., the first hook's `allow` prevents subsequent hooks from
+blocking), registration must change to **last-in-chain** or the bridge must emit
+no `permissionDecision` key (only `additionalContext`). Step 2 implementation
+must use a feature flag or configuration entry for registration order so the
+CA-8 outcome can be applied without a code change. Default before CA-8 result:
+register first.
+
+Estimated: ~150 LoC in the shared library + ~20 LoC per hook-type script (7 types
+= ~140 LoC scripts). Total ~290 LoC. Larger than originally estimated due to
+per-type output contract requirements.
+
+### The bindings primitive
+
+A new subspace `bindings/<profile>` with schema:
+
+```yaml
+bindings:
+  dimensions:
+    - name: profile        # mission context name
+    - name: enabled        # true/false; default false during async creation
+    - name: status         # pending | active | failed (lifecycle for async binding_create)
+    - name: task_id        # UUID issued at binding_create time; used to poll creation progress
+    - name: priority       # integer, for demotion cascade ordering
+    - name: min_surface    # floor for demotion cascade
+  match_text_field: description
+  content_fields:
+    - trigger_subspace     # which subspace(s) to watch
+    - trigger_filters      # structural filter on the event tuple
+    - trigger_similarity   # optional semantic query for associative match
+    - action_type          # tool_call | tuple_out | send_message | workflow
+    - action_descriptor    # action-type-specific payload (must include idempotency_key)
+    - surface_level        # status-line | notification | panel | full-screen
+    - surface_payload      # how to render the event
+    - surface_stream       # optional: declare a connection_manifest instead
+```
+
+`task_id` is a registered dimension (not an MCP-layer side channel) so that callers can filter `binding_list(where={"task_id": "<uuid>"})` to check creation progress. `status` transitions: `pending` (background task running) → `active` (binding live, `_BindingWatcher` will match it) → `failed` (NLP parse or `out` call failed; error in `action_descriptor`). `enabled` starts `false` during async creation and is set to `true` atomically with the `pending → active` transition.
+
+CRUD operations: `out` to create/update, `take` to delete, `read` to list.
+A binding is enabled by setting `enabled=true`; disabled bindings are
+kept (tombstoned per RDR-106 pattern) rather than deleted.
+
+### The connection manifest subspace
+
+A new subspace `connection_manifest` for declaring direct peer-to-peer
+streams:
+
+```yaml
+connection_manifest:
+  dimensions:
+    - name: producer       # actor-id
+    - name: consumer       # actor-id or "any-subscriber"
+    - name: conn_type      # stream | pipe | websocket | sse | file-fd
+    - name: payload_type   # semantic type of the stream content
+    - name: ttl_seconds    # heartbeat interval; expired = teardown
+  content_fields:
+    - endpoint             # transport-specific address
+```
+
+Producer posts manifest after endpoint is ready. Consumer reads and
+connects directly. Heartbeats refresh the tuple's TTL via `out` with
+the same ID (idempotent). `take` or TTL expiry signals teardown.
+
+### The layout_state subspace
+
+A new subspace `layout_state/<profile>` for the auto-layout engine's
+stylesheet output. One tuple per binding-type (keyed by `event_type`
+and `profile`), written by the layout engine and read by all cockpit
+surfaces to know which slot and level to use for each event type.
+
+```yaml
+layout_state:
+  dimensions:
+    - name: profile        # mission context name
+    - name: event_type     # subspace path, e.g. hook_events/tool_call_intent
+  content_fields:
+    - surface_level        # status-line | notification | panel | full-screen
+    - demotion_level       # current effective level after cascade
+    - ttl_seconds          # on-screen display TTL for events of this type
+    - pinned               # bool; true = user override, skip auto-layout
+```
+
+The layout engine writes one `out` per event_type per profile per debounce
+window (250ms). Cockpit surfaces call `read(subspace="layout_state/<profile>")`
+to get the current stylesheet before rendering. Schema ships in Phase 1
+Step 1 alongside the hook-event subspace schemas (even though Step 11
+is Phase 3) so producers can register and write to it without waiting for
+the layout engine implementation.
+
+### The three minimum cockpit surfaces
+
+**Active-claims panel** — direct SQL query on `~/.config/nexus/tuples.db`
+(RDR-110's tuple-space database):
+
+```sql
+SELECT * FROM tuples
+WHERE claim_state = 'claimed'
+  AND claim_expires_at > unixepoch()
+ORDER BY claim_expires_at ASC;
+```
+
+Formatted as a table: actor (extracted via `json_extract(t.dimensions_json,
+'$.actor')` — `actor` is a registered dimension stored inside
+`dimensions_json`, not a top-level column on `tuples`), subspace, tuple
+summary, claimed_at (from `tuple_claim_log` via `JOIN tuple_claim_log tcl
+ON t.id = tcl.tuple_id WHERE tcl.transition = 'claim'`; `tuples` has no
+`claimed_at` column directly), TTL remaining
+(= `claim_expires_at - unixepoch()`). The expiry filter
+(`claim_expires_at > unixepoch()`) excludes expired leases not yet swept
+— without it, crashed-agent claims would appear as active until the next
+sweep. `claim_state` is an internal column on the `tuples` table (per
+RDR-110 claim ledger schema), not a registered dimension; it is not
+accessible via `read()` and must be queried directly. The cockpit surface
+is an internal component in the same process, so direct access to
+`tuples.db` is appropriate. Rendered as a tmux pane or ext-apps iframe.
+
+**Recent-events panel** — direct SQL query on `~/.config/nexus/tuples.db`
+for time-ordered display (RDR-110's `read()` has no `sort_by` or
+`since_cursor` parameter — time ordering requires direct SQL):
+
+```sql
+SELECT * FROM tuples
+WHERE subspace LIKE 'hook_events/%'
+  AND created_at > unixepoch() - ?   -- decay_window from subspace registry
+ORDER BY created_at DESC
+LIMIT 50;
+```
+
+With temporal decay: events older than their subspace `decay_profile`
+window are excluded by the `created_at` filter. Supports structural
+filtering by `actor`, `session`, `project` dimensions (additional WHERE
+clauses). For semantic filtering by intent, call `read()` on the
+subspace with a query string, then display results sorted client-side by
+the `timestamp` dimension (required on all hook-event subspaces — see
+schema above; `timestamp` is a registered dimension accessible in the
+`read()` response, unlike `created_at` which is an internal `tuples`
+table column not exposed by the API). This trades time-ordering guarantee
+for semantic relevance. The default display is SQL (time-ordered); semantic
+filter is an opt-in mode.
+
+**Active-bindings panel** — `read(subspace="bindings/<current_profile>",
+where={"enabled": "true"})`. Shows trigger, action, surface, enabled state.
+Toggle via `take` (remove) + `out` (re-post with `enabled` flipped). Edit
+via a form rendered in the panel itself.
+
+### The auto-layout engine
+
+A `src/nexus/cockpit/layout.py` module implementing the three phases:
+
+**Measure** — traverse the active binding set, read layout disposition
+from the subspace registry for each event type (surface level, decay
+profile, priority class, typical event rate).
+
+**Auto-Style** — produce a stylesheet tuple (one `out` to
+`layout_state/<profile>`): for each binding, which surface slot,
+which on-screen TTL, which demotion level. Respects the display budget
+(terminal width, active pane count) and mission-context profile.
+
+**Layout** — apply the stylesheet to actual events: render status line,
+populate panels, fire notifications, raise full-screen for checkpoints.
+
+The demotion cascade, applied when the display budget shrinks:
+```
+full-screen → panel → status-line → notification-only → suppressed
+```
+Per-binding `min_surface` prevents critical bindings from falling
+below their floor. Manual pin overrides auto-layout for that binding.
+
+**Write-storm guard**: the auto-layout engine must debounce its
+`layout_state/<profile>` tuple writes. Hook events may arrive in
+bursts (e.g., 10 `PostToolUse` events in < 100ms). A naive re-layout
+on every event would produce a write-per-event flood. The engine must
+batch events over a 250ms debounce window before re-running the
+Measure/Auto-Style/Layout pipeline. Only one `layout_state` write
+per debounce window is allowed.
+
+### Cross-instance liveness
+
+**Implementation: T2 table, not the tuple space.** Although project-tier
+T2 subspaces in RDR-110 are cross-process (SQLite WAL mode is multi-writer
+safe), raw T2 is the correct choice for liveness for three reasons: (a) no
+semantic matching is needed — liveness is a pure key-value keep-alive
+requiring only primary-key lookup by `(pid, machine)`; (b) no subspace
+schema registration overhead (liveness has no `match_text` or vector
+embedding); (c) no tombstone semantics — rows are hard-deleted on expiry,
+not soft-deleted with `data_version` ticks as required by the tuple space
+claim ledger. T2 (SQLite WAL, via `src/nexus/db/`) is the correct tier per
+RDR-105.
+
+T2 `liveness` table added via a new migration entry in
+`src/nexus/db/migrations.py` (actual migration number assigned at
+implementation time — add as the next integer after the current
+highest-numbered migration):
+
+```sql
+CREATE TABLE liveness (
+    pid          INTEGER NOT NULL,
+    machine      TEXT    NOT NULL,
+    user_id      TEXT    NOT NULL,
+    session      TEXT,
+    project      TEXT,
+    focus        TEXT,
+    activity     TEXT,
+    last_seen    REAL    NOT NULL,  -- epoch seconds
+    PRIMARY KEY (pid, machine)
+);
+```
+
+Each `nx-mcp` process upserts its row at startup and every 30s via the
+FastMCP lifespan background task (per RDR-094 pattern). A sweep thread
+deletes rows where `last_seen < epoch() - 60`. `nx instances` queries
+the T2 table directly and formats the result as a table.
+
+The `~/.config/nexus/t1_addr.<pid>` file mechanism (RDR-105) is
+retained for T1 bootstrap; `liveness` replaces it only for the
+cross-instance visibility use-case.
+
+## Alternatives Considered
+
+### A: Separate event store (not the tuple space)
+
+A dedicated SQLite table for hook events, separate from the tuple
+space. Rejected: the whole point is one query model for coordination
+metadata. A separate store means two mental models, two
+calibration stories, two debug surfaces. The tuple space is
+already the right shape.
+
+### B: Push notifications via the existing Notification hook
+
+Use `Notification` to push events to the user rather than projecting
+into the tuple space. Rejected: `Notification` is a one-way push to
+the current session. It has no queryability, no persistence, no
+subscription model. It is not composable. The ORB adds a composable
+layer; `Notification` remains a valid *sink* for a binding's action.
+
+### C: Separate binding engine process
+
+A dedicated process that watches the tuple space and dispatches
+binding reactions. Rejected for Phase 1: the hook bridge can dispatch
+binding reactions synchronously (or via a lightweight background
+thread) without a separate process. A separate process adds
+deployment complexity that isn't justified until binding volume or
+latency requirements force it.
+
+### D: Visual wiring UX (LabVIEW-style)
+
+A drag-and-drop wiring interface for bindings. Rejected as the entry
+point: form-based binding authoring is closer to what's been proven
+learnable (WeakAuras, Streamdeck plugins). Wiring may be useful for
+advanced users in a later phase but is not the starting point.
+
+## Trade-offs
+
+| Decision | Trade-off |
+|---|---|
+| Semantic events as tuples (not a separate event log) | One query model, one persistence story — but tuple space volume grows with hook frequency. Mitigated by per-subspace TTL/decay. |
+| Bindings dispatched in-process by the bridge | Simple, no extra process — but binding reaction latency is bounded by bridge execution time. A slow binding can delay the next hook. Mitigated by timeout on action dispatch. |
+| Auto-layout drives from the binding set, not from events | Layout is stable and predictable — but a binding with no recent events still occupies a layout slot. Mitigated by `decay_profile` on the registry entry. |
+| Connection manifests declared in the tuple space | Every direct connection is visible and debuggable — but manifest heartbeating adds a small overhead per active stream. Acceptable at expected connection counts. |
+| tmux as the first fulfillment target | Terminal users get the full cockpit immediately — but GUI (ext-apps iframe) and headless adapters are deferred. Each is ~200 LoC and independently shippable. |
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] RDR-110 Phase 1 Step 4 shipped (core API: `out`/`read`/`take`/
+      `ack`/`nack` as MCP tools, `data_version` watcher, `block`
+      support on `take`).
+- [ ] RDR-110 Phase 1 Step 5 shipped (periodic sweeps for TTL/tombstone
+      cleanup — required for liveness TTL and event decay to work).
+- [ ] RDR-110 Phase 1 Step 6 shipped (five canonical subspaces — the
+      `events/<topic>` and `locks/<resource>` patterns are prior art
+      for the new hook-event and bindings subspaces).
+
+### Phase 1: Hook bridge + seven event subspaces
+
+#### Step 1: Seven hook-event subspace schemas
+
+Add `nx/tuplespace/builtin/hooks/*.yml` with the seven hook-event subspace
+definitions, plus `nx/tuplespace/builtin/connection_manifest.yml` and
+`nx/tuplespace/builtin/layout_state.yml` (schema defined in Proposed
+Solution). Register layout disposition fields on each hook-event subspace
+(surface level, decay profile, priority class, `preempts` list).
+No code changes — schema-only. `layout_state` ships now so the layout
+engine (Step 11, Phase 3) can write to a registered subspace without a
+schema-migration step later.
+
+#### Step 1b: CA-8 spike (PreToolUse ordering — required before Step 2)
+
+Run the CA-8 multi-hook ordering experiment **before writing any bridge
+code**. Use the cc-validation harness pattern from
+`scenarios/07_perms_preempt_hook.sh`: register two PreToolUse hooks —
+bridge first (emits `allow`), then an existing decision hook (may emit
+`block`). Determine whether first-registered `allow` preempts the second
+hook's `block`, or all hooks run and the last `block` wins. Record the
+result in T2 (`111-ca8-spike-result`) and update Step 2's registration
+order accordingly before any bridge code is written. (≤ 1h)
+
+#### Step 2: Hook → tuple bridge
+
+`src/nexus/cockpit/hook_bridge.py`: reads hook payload from stdin,
+maps to subspace + dimensions + match_text, calls `out` via the
+MCP tool (or directly against the store if in-process), exits 0.
+Register in `nx/hooks/hooks.json` (the canonical hook registration
+location per RF-3) for the **seven projected hook types**: `PreToolUse`,
+`PostToolUse`, `Stop`/`StopFailure` (→ `assistant_turn_ended`),
+`SubagentStop`, `UserPromptSubmit`, `SessionStart`/`SessionEnd`
+(→ `session_lifecycle`), `Notification`. **Not registered**:
+`SubagentStart` (carries no semantic event worth projecting — the
+subagent's task description is already in the prompt),
+`PermissionRequest` (ephemeral permission handshake, no durable
+coordination state), `PreCompact` (output unused), and `PostCompact`
+(redundant with the compact summary already injected into context — see
+Proposed Solution, "The seven semantic event subspaces").
+
+Unit tests: mock `out`; assert correct subspace, dimensions, and
+match_text for each hook type. One test per hook type + one for
+malformed payload (must exit 0).
+
+#### Step 3: T2 liveness table + heartbeat
+
+Add `liveness` table via `src/nexus/db/migrations.py` migration (manages
+`~/.config/nexus/memory.db` — see schema above). Wire upsert into the
+`nx-mcp` FastMCP lifespan background task (startup upsert + 30s periodic
+upsert via `asyncio.create_task`, matching the pattern in RDR-094). Add
+sweep logic to delete stale rows (`last_seen < epoch() - 60`) in the
+same background task. Add `nx instances` CLI command: queries the
+`liveness` table in `memory.db` directly and formats as a table. No
+tuple-space subspace YAML required for liveness.
+
+Note: `watcher_state` (cursor table for `_BindingWatcher`) is added in
+`tuples.db` as part of the RDR-110 implementation (not here), so that the
+cursor and tuple reads are in the same database for genuine atomicity. See
+Phase 2 Step 6.
+
+### Phase 2: Bindings primitive
+
+#### Step 4: Bindings subspace schema
+
+Add `nx/tuplespace/builtin/bindings.yml`. Include all fields from
+the proposed solution above. Add `profile` as a first-class
+dimension so `read(subspace="bindings/<profile>")` is the query
+for the active profile's bindings.
+
+#### Step 5: Binding CRUD path + MCP tools
+
+`src/nexus/cockpit/bindings.py`: `binding_create`, `binding_list`,
+`binding_toggle`, `binding_delete`. Wire as four new MCP tools.
+`binding_create` **returns a `task_id` immediately** (async task
+pattern): it enqueues the binding creation work (NLP parse + `out` call)
+and returns `{"task_id": "<uuid>", "status": "pending"}` to the caller
+without waiting for completion. A background `asyncio.Task` does the
+actual work and updates the binding's `status` dimension from `pending`
+to `active` when done. This keeps `binding_create` non-blocking from
+the MCP caller's perspective. The LLM-assisted authoring path (calling
+`nx_answer` to parse a natural-language binding description into a
+structured tuple) runs inside this background task and is `await`-ed
+there. If `nx_answer` is currently synchronous, wrap it in
+`asyncio.run_in_executor` with a dedicated executor — do not block the
+MCP event loop. Callers poll status via `binding_list` filtering on
+`task_id` or register a binding-completion notification.
+
+#### Step 6: Binding reaction loop
+
+A `_BindingWatcher` background task (integrated with the FastMCP
+lifespan async task group per RDR-094; **must be `asyncio.create_task`,
+not `threading.Thread`** — the MCP server is async and thread-pool
+dispatch creates reentrancy risk) that polls for new events via **direct
+T2 SQL query** on the `tuples` table.
+
+**Retrieval mechanism — intentional internal bypass of `read()` API**:
+RDR-110's `read()` API has no ordered-retrieval or `since_cursor`
+parameter. `_BindingWatcher` is an internal component that runs in the
+same `nx-mcp` process as the tuple store and therefore has direct access
+to `~/.config/nexus/tuples.db` (RDR-110's tuple-space database —
+distinct from `~/.config/nexus/memory.db`). The correct retrieval
+pattern is:
+
+```sql
+-- against ~/.config/nexus/tuples.db
+SELECT rowid, * FROM tuples
+WHERE subspace = ?
+  AND rowid > ?    -- last-seen cursor
+ORDER BY rowid ASC
+LIMIT 100;
+```
+
+The `rowid` is SQLite's native monotonic row counter — it provides total
+ordering within the table, which is exactly what the watcher needs. This
+is *not* a semantic query and does not belong in the `read()` API surface.
+The intentional design boundary: `read()` is for external MCP callers doing
+associative or structural queries; the watcher is an internal subscriber
+that needs ordered streaming, and it accesses `tuples.db` directly.
+
+A `watcher_state` table records the per-subspace cursor (last-seen
+`rowid`). **Database placement**: `watcher_state` should live in
+`tuples.db` (not `memory.db`) so the cursor read and tuple read are in
+the same database, so that only one connection is needed for both reads
+and cursor updates (not transactional atomicity across dispatch and commit
+— dispatch is an async network call that cannot be inside a SQLite
+transaction; see pseudocode below). Add `watcher_state` as a CREATE TABLE in the RDR-110
+tuple-space migration (not in `src/nexus/db/migrations.py`, which manages
+`memory.db`):
+
+```sql
+-- in tuples.db migration (RDR-110 implementation)
+CREATE TABLE IF NOT EXISTS watcher_state (
+    subspace   TEXT NOT NULL,
+    profile    TEXT NOT NULL,
+    last_rowid INTEGER NOT NULL DEFAULT 0,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (subspace, profile)
+);
+```
+
+**Cursor persistence and restart semantics** (required for correctness):
+
+- The watcher's cursor position (`rowid` of the last processed tuple)
+  is persisted to `watcher_state` in `tuples.db` after every
+  successfully dispatched batch. The correct sequence is:
+
+  ```python
+  # 1. Fetch events (SELECT ... WHERE rowid > cursor ORDER BY rowid)
+  events = fetch_events(conn_tuples, subspace, cursor)
+
+  # 2. Dispatch action — OUTSIDE any SQLite transaction.
+  #    dispatch is an async network call (tool_call / out / send_message);
+  #    Python sqlite3 is synchronous — you cannot await inside an open
+  #    sqlite3 transaction without blocking the event loop.
+  await dispatch_action(event, idempotency_key=...)
+
+  # 3. Advance cursor — separate, committed after dispatch succeeds.
+  with conn_tuples:  # sqlite3 context manager = BEGIN/COMMIT
+      conn_tuples.execute(
+          "UPDATE watcher_state SET last_rowid=?, updated_at=?"
+          " WHERE subspace=? AND profile=?",
+          (event.rowid, time.time(), subspace, profile)
+      )
+  ```
+
+  Steps 2 and 3 are **not** in the same SQL transaction — they cannot
+  be: the dispatch is an async network call. The delivery guarantee is
+  **at-least-once**: if the process crashes between step 2 and step 3,
+  the event is replayed on restart. The `idempotency_key` mechanism in
+  the action descriptor handles duplicate deliveries.
+
+  `watcher_state` and `tuples` are in the same database (`tuples.db`),
+  which means only one database connection is needed; it does not imply
+  that dispatch and cursor-advance are in the same ACID transaction.
+- **Delivery guarantee: at-least-once.** The cursor advances only
+  after the action is dispatched (not before). Duplicate deliveries
+  are possible on crash-restart. Actions must therefore be idempotent:
+  the `action_descriptor` schema must include an `idempotency_key`
+  field (e.g. `sha256(binding_id + event_tuple_id)`); action handlers
+  must be no-ops if the key has been seen in a T2 dedup table within
+  the action's TTL window (default 5 minutes).
+- **At-most-once is not the guarantee.** Do not design actions that
+  must fire exactly once without a separate dedup mechanism.
+
+**Idempotency dedup table** (home: `memory.db`, added via
+`src/nexus/db/migrations.py`, same migration entry as `liveness`):
+
+```sql
+CREATE TABLE IF NOT EXISTS action_idempotency (
+    idempotency_key TEXT PRIMARY KEY,
+    expires_at      REAL NOT NULL   -- epoch seconds; TTL default 300s
+);
+```
+
+Action handlers check `SELECT 1 FROM action_idempotency WHERE
+idempotency_key = ?` before executing; if found, skip and return
+success. On first execution, insert the key. Sweep during the liveness
+sweep task: `DELETE FROM action_idempotency WHERE expires_at <
+unixepoch()`.
+
+Action dispatch: `tool_call` type dispatches via the MCP tool API
+(must be `await` — no `asyncio.run_in_executor` for tool calls);
+`tuple_out` calls `out` directly; `send_message` uses the harness
+`SendMessage` tool. All dispatch is bounded by a `action_timeout_s`
+field on the action descriptor (default 10s); timeout fires the next
+cursor advance regardless.
+
+**Watcher failure isolation**: any exception in dispatch is caught,
+logged via `structlog.get_logger(__name__)` (the watcher runs inside
+the `nx-mcp` process, so logs flow through the standard structured
+logging pipeline), and the cursor advances past the failed event to
+prevent livelock. A consecutive-failure counter is kept in T2 (small
+keyed table; resets on first successful dispatch) and triggers watcher
+pause after 5 consecutive failures on the same binding (indicating a
+broken binding); the binding is auto-disabled with an error annotation.
+
+#### Step 7: Phase 1 CA spikes (gate Phase 2)
+
+These spikes must complete before Phase 2 begins:
+
+- **CA-6**: Empirically capture real payload for `SubagentStop`,
+  `UserPromptSubmit`, `PreCompact`, `Notification` hooks by running
+  a logging hook in a live session. Update RF-1 table with verified
+  schemas. Write bridge scripts for these 4 types only after payloads
+  are confirmed. (≤ 2h)
+
+Note: **CA-8** (PreToolUse multi-hook ordering) was completed in Step 1b,
+before Step 2. Its result has already been applied to bridge registration
+order. It is not repeated here.
+
+#### Step 7b: Phase 2 CA spikes (gate Phase 3)
+
+- **CA-3**: Benchmark `read` query latency at 10k, 50k, 100k tuples.
+  If > 50ms, add a materialised view (SQLite view or summary table).
+- **CA-5**: Benchmark binding reaction end-to-end latency (hook fire →
+  action dispatch) at 10 concurrent active bindings. If > 200ms,
+  move binding watcher to a dedicated process.
+- **CA-7**: Prototype Bakke Measure/Auto-Style/Layout on a static
+  binding set. Estimate LoC and developer-days. If > 300 LoC or
+  > 1 week, scope Phase 3 accordingly or defer layout engine to a
+  follow-on RDR.
+
+#### Step 7c: Phase 3 CA spike (gate finalization)
+
+- **CA-4**: Measure tmux `status-right` update cadence on target
+  hardware. If noticeable lag, increase refresh interval to 5s and
+  add a stale indicator.
+
+### Phase 3: C2 cockpit surfaces
+
+#### Step 8: Active-claims panel
+
+`src/nexus/cockpit/surfaces/claims.py`: direct SQL on
+`~/.config/nexus/tuples.db` WHERE `claim_state = 'claimed' AND
+claim_expires_at > unixepoch()` (expiry filter required to exclude
+expired leases not yet swept — see Proposed Solution for full query and
+rationale). Formats as a table: actor, subspace, tuple summary,
+claimed_at, TTL remaining. tmux fulfillment: update a named pane on a
+2s cadence. ext-apps fulfillment: render as an iframe via `ui://claims`.
+
+#### Step 9: Recent-events panel
+
+`src/nexus/cockpit/surfaces/events.py`: direct SQL on
+`~/.config/nexus/tuples.db` for default time-ordered display (see
+Proposed Solution for full query). For semantic filtering, falls back
+to `read()` with client-side sort by the `timestamp` dimension (registered
+on all hook-event subspaces, present in the `read()` response — unlike
+`created_at`, which is an internal `tuples` table column not in the DTO).
+Supports structural params (`actor`, `session`, `project`) as additional
+WHERE clauses.
+tmux + ext-apps fulfillment as above.
+
+#### Step 10: Active-bindings management panel
+
+`src/nexus/cockpit/surfaces/bindings.py`: `read(subspace=
+"bindings/<profile>", where={"enabled": "true"})`. Toggle via
+`take` + `out` (remove then re-post with `enabled` flipped). Edit
+in-panel; the edit form is itself a binding-create form rendered inline.
+
+#### Step 11: Auto-layout engine
+
+`src/nexus/cockpit/layout.py`: Measure / Auto-Style / Layout
+pipeline. Reads the subspace registry for layout dispositions.
+Writes a `layout_state/<profile>` tuple. Triggers on:
+binding-set change, profile switch, display-budget change
+(terminal resize signal, pane count change). Implements the
+demotion cascade and `min_surface` floor.
+
+#### Step 12: First end-to-end mission profile
+
+Pick a real workflow (RDR creation, build watching, incident
+response). Author the bindings, the layout, the permission mode.
+Run it. Measure what's awkward. Iterate.
+
+### Connection manifest (Phase 4 — deferred)
+
+The `connection_manifest` subspace schema ships in Phase 1 (Step 1)
+so producers can use it. The fulfillment adapters that *consume*
+manifests to open direct streaming connections are deferred to
+Phase 4 (ext-apps iframe work, covered in the workflow-engine doc
+handed off separately).
+
+## Test Plan
+
+### Unit tests
+
+- Hook bridge: one test per hook type for correct subspace/dimensions
+  mapping. One test for malformed payload (must exit 0 and log).
+- Bindings CRUD: create / list / toggle / delete round-trip.
+- Binding reaction: mock event tuple → assert correct action dispatch.
+- Layout engine: given a binding set and display budget, assert
+  correct stylesheet tuple. Test demotion cascade at N bindings
+  exceeding budget.
+- Liveness: heartbeat emitted at startup; `nx instances` returns
+  the expected row; TTL expiry removes the row.
+
+### Integration tests
+
+- Bridge → tuple space end-to-end: fire a real hook, assert the
+  tuple appears in the `hook_events/*` subspace with correct fields.
+- Binding reaction end-to-end: register a binding; fire a hook;
+  assert the action was dispatched within 200ms.
+- Cockpit panel SQL queries (active-claims, recent-events) return
+  correct results at 1k, 10k event volumes against `tuples.db`.
+  Active-bindings panel `read()` returns correct results at 1k bindings.
+
+## Validation
+
+The ORB is validated when:
+
+1. A `PreToolUse` hook fires and the corresponding tuple appears in
+   `hook_events/tool_call_intent` within 100ms.
+2. A user-authored binding ("when a tool call completes, update the
+   status line with the tool name and duration") fires correctly
+   for 10 consecutive tool calls with no missed events.
+3. The active-claims panel accurately reflects all currently-claimed
+   tuples, updating within the refresh cadence.
+4. `nx instances` returns the correct set of live processes on a
+   machine running two `claude` sessions simultaneously.
+5. A mission profile (chosen in Step 12) runs end-to-end with all
+   three cockpit panels providing correct situational awareness,
+   and the user can toggle a binding on/off from the panel without
+   restarting any process.
+
+## Finalization Gate
+
+Phase-gated CA clearance:
+- [ ] **Before Phase 1 begins**: CA-9 cleared = RDR-110 Phase 1 Step 6 confirmed shipped with open-registry registration mechanism (or RDR-110 amended to add one), verified by checking the Step 6 implementation. Notification of the RDR-110 implementor is the action to take; a confirmed open-registry implementation is the gate criterion.
+- [ ] **Before Phase 1 Step 2**: CA-8 (PreToolUse multi-hook ordering determined; Step 2 registration order updated per result; fallback design implemented as feature flag).
+- [ ] **Before Phase 2**: CA-6 (4 inferred hook payload shapes verified empirically).
+- [ ] **Before Phase 2 Step 6**: CA-10 (`watcher_state` table confirmed in RDR-110 tuples.db migration).
+- [ ] **Before Phase 3**: CA-3 (`read` latency benchmark) + CA-5 (binding reaction latency benchmark) + CA-7 (Bakke layout engine LoC estimate).
+- [ ] **Before finalisation**: CA-4 (tmux cadence verified on target hardware) + CA-1 (RDR-110 prerequisite steps shipped).
+
+Other gates:
+- [ ] Unit + integration test suite passes.
+- [ ] First end-to-end mission profile runs cleanly (Step 12).
+- [ ] `docs/agentic-cockpit.md` updated to note implementation
+      status of each section.
+- [ ] `docs/cli-reference.md` updated with `nx instances` and
+      `nx bindings` commands.
+- [ ] RDR-110 implementor notified of subspace registry extension
+      requirement (per Relationship to RDR-110 section).
+
+## References
+
+- `docs/agentic-cockpit.md` — Design exploration; source for all
+  architectural decisions in this RDR.
+- `docs/rdr/rdr-110-semantic-tuple-space.md` — Foundation primitive.
+- `docs/rdr/rdr-105-t1-chroma-architecture-env-passdown.md` — T1/T2
+  tier discipline and process lifecycle patterns.
+- Gelernter & Carriero, "Linda in Context" (1992).
+- Bakke, Karger & Miller, "Automatic Layout of Structured Hierarchical
+  Reports" (InfoVis 2013).
+- WeakAuras project documentation (wago.io).
+
+## Revision History
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-05-11 | Hal Hildebrand | Initial draft |
+| 2026-05-11 | Hal Hildebrand | Post-gate revision: expanded RF-1 to complete verified payload inventory for all 13 hook types; revised liveness from tuple-space to T2 table (cross-process visibility requirement); added _BindingWatcher restart semantics, cursor persistence, at-least-once delivery + idempotency_key requirement; added CA-6 (inferred payload empirical spike), CA-7 (Bakke LoC estimate), CA-8 (PreToolUse ordering empirical spike); restructured CA phase gates to P1/P2/P3; added debounce to auto-layout engine; added binding_create async requirement; added RDR-110 subspace registry extension coordination note |
+| 2026-05-11 | Hal Hildebrand | Post-gate-2 revision (all gate-2 BLOCKED issues addressed): (C-NEW-1) _BindingWatcher retrieval mechanism changed from `rd()` with offset cursor to direct T2 SQL on `tuples` table by `rowid` — intentional internal bypass, RDR-110 `read()` has no ordered-retrieval parameter; (C-NEW-2) Active-claims panel changed from `rd(claim_state=claimed)` to direct T2 SQL — `claim_state` is an internal column not a registered dimension; (S1) T2 migration added to `src/nexus/db/migrations.py`, `watcher_state` table added to same migration as `liveness`; (S2) corrected false liveness rationale — project-tier T2 subspaces ARE cross-process, liveness uses raw T2 for semantic/schema/tombstone reasons; (S3) registry extension CA-9 added as definitive prerequisite, registry section changed from conditional "if" to CA-9; (S4) CA-8 fallback design documented (no-permissionDecision or last-in-chain if first-wins confirmed); (S5) `binding_create` changed to return `task_id` immediately with async task pattern |
+| 2026-05-11 | Hal Hildebrand | Post-gate-4 revision (all gate-4 BLOCKED issues addressed): (C-G4-1) corrected cursor-advance pseudocode — dispatch is now outside SQLite transaction (async dispatch cannot be wrapped in synchronous sqlite3 BEGIN/COMMIT); removed "genuinely atomic" claim; clarified same-database placement enables one connection, not transactional atomicity between dispatch and commit; (S-G4-1) switched recent-events semantic fallback sort from `tuple.created_at` (internal column not in read() DTO) to `timestamp` dimension (registered, accessible in read() response); (S-G4-2) removed CA-8 from Step 7 spike list — now only in Step 1b where it belongs; added cross-reference note; (S-G4-3) added CA-10 for `watcher_state` table coordination with RDR-110 implementor; added to Finalization Gate; (O-G4-2) fixed Step 2 registration path from `.claude/hooks/` to `nx/hooks/hooks.json` |
+| 2026-05-11 | Hal Hildebrand | Post-gate-5 revision (no criticals; 3 significant fixed pre-accept): (SIG-1) removed residual "enabling a genuine single-transaction cursor advance" claim from watcher_state rationale — replaced with accurate "one connection" language; (SIG-2) corrected Step 9 semantic fallback sort from `created_at` (internal column, not in read() DTO) to `timestamp` dimension; (SIG-3) added `action_idempotency` table schema, migration reference (memory.db), and sweep hook to Phase 2 Step 6 |
+| 2026-05-11 | Hal Hildebrand | Post-gate-6 revision (no criticals; all significant and observation issues addressed pre-accept): (SIG-A) replaced `rd`/`in` Linda aliases with `read`/`take` throughout all implementation-facing sections — Bindings CRUD, active-bindings panel, Step 10, Relationship to RDR-110 surfaces sentence, Key Discoveries (bindings, surfaces, cross-process), CA-3 across all references (assumption table, Step 7b spike, Finalization Gate), and the Linda bullet's "ORB uses" clause; added Linda→RDR-110 API name mapping table and usage rule to Relationship to RDR-110 section; (SIG-B) added `layout_state/<profile>` subspace schema block (dimensions: profile, event_type; content: surface_level, demotion_level, ttl_seconds, pinned) to Proposed Solution; added `layout_state.yml` and `connection_manifest.yml` to Step 1 file list; (OBS-1) added `tuple_claim_log` join note for `claimed_at` display field — `tuples` has no `claimed_at` column; (OBS-2) `connection_manifest.yml` now explicit in Step 1; (OBS-3) integration test 3 corrected to distinguish SQL-based panels (active-claims, recent-events) from `read()`-based panel (active-bindings); (OBS-4) Step 2 explicitly documents which hook types are projected (7) and which are excluded (SubagentStart, PermissionRequest) with rationale |
+| 2026-05-11 | Hal Hildebrand | Post-gate-3 revision (all gate-3 BLOCKED issues addressed): (C-G3-1) Added `task_id` (string) and `status` (enum: pending/active/failed) dimensions to bindings subspace schema YAML; documented enabled/status/task_id lifecycle; (S-G3-1) moved `watcher_state` table to `tuples.db` (not `memory.db`) for genuine single-transaction cursor atomicity; corrected "atomic" language; (S-G3-2) added `claim_expires_at > unixepoch()` filter to active-claims panel query in Proposed Solution and Step 8 to exclude expired leases; (S-G3-3) flagged Step 2 bridge registration order as provisional pending CA-8; moved CA-8 spike to new Step 1b (before Step 2); added feature-flag requirement for registration order; (S-G3-4) changed recent-events panel from `rd()` (no time ordering) to direct SQL on `tuples.db` ordered by `created_at DESC`; semantic filter noted as opt-in mode; (S-G3-5) replaced "direct T2 SQL via src/nexus/db/" with explicit `tuples.db` database references throughout; (O1) corrected "six" to "seven" subspaces; (O2) documented PostCompact/PreCompact exclusion with rationale; (O3) updated CA-9 gate condition to outcome-based (confirmed open-registry shipping) not action-based (notification sent) |
+| 2026-05-11 | Hal Hildebrand | Post-gate-7 revision (1 critical + 2 significant + 2 observations all addressed pre-accept): (C-G7-1) removed `PostCompact` from Step 2 bridge registration list — was contradicted by Proposed Solution's explicit exclusion; added `PreCompact` and `PostCompact` to the not-registered list with rationale cross-reference; (SIG-G7-1) replaced three residual `rd()` aliases with `read()` — Step 4 bindings dimension example, Step 6 `_BindingWatcher` rationale paragraph (header + two body references); (SIG-G7-2) corrected "six" → "seven" hook-event subspaces at four remaining sites (Relationship to RDR-110 summary, CA-9 description, CA-9 risk-if-wrong, Phase 1 section header); added `layout_state` to the Relationship-section subspace enumeration; (OBS-G7-1) active-claims display now explicitly extracts `actor` via `json_extract(t.dimensions_json, '$.actor')` — `actor` lives inside `dimensions_json`, not a top-level column; (OBS-G7-2) watcher failure isolation now logs via `structlog` (not "T2 scratch" — category error, scratch is T1); failure counter kept in T2 as before |

--- a/docs/rdr/rdr-112-storage-as-service-container-boundary.md
+++ b/docs/rdr/rdr-112-storage-as-service-container-boundary.md
@@ -1,0 +1,520 @@
+---
+title: "Storage-as-Service: T2/T3 Behind a Process Boundary, T1 Stays In-Container"
+id: RDR-112
+type: Architecture
+status: draft
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-12
+accepted_date:
+related_issues: []
+related_rdrs: [RDR-004, RDR-041, RDR-105, RDR-108, RDR-110, RDR-111]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-112: Storage-as-Service: T2/T3 Behind a Process Boundary, T1 Stays In-Container
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+Nexus's three storage tiers are accessed today as **library-mode
+file handles** — `sqlite3.connect(path)` for T2, `chromadb.PersistentClient(path)`
+for T3, `EphemeralClient()` or per-session HTTP for T1. That worked when
+the only consumer was a single `nx` CLI process plus its in-tree MCP
+server. It breaks the moment work runs **inside a sandbox container**
+(Claude Desktop's bundled MCP runtime, ext-app sandboxes, `claude -p`
+sub-processes with their own filesystem view, future agentic co-work
+peers running on the same host but in distinct containers).
+
+In a container, "open the file at `~/.nexus/t2.sqlite`" resolves to a
+*copy or an empty path*, not the host's database. The container gets
+its own sqlite, its own chroma collections, its own memory tier — and
+silently fragments knowledge across silos. T1 is fine in that world
+(per-session by design). T2 and T3 are not — they are the *cross-session,
+cross-instance* tiers, and their entire value proposition is that
+co-workers see the same state.
+
+### Enumerated gaps to close
+
+#### Gap 1: T2 and T3 leak the storage substrate as a file path
+
+`T2Database` and the T3 chroma client are opened by direct filesystem
+path. Any process with read access to the path is a peer writer. Inside
+a sandbox container that path either does not exist (silent fork to an
+empty DB) or resolves to a bind-mounted copy (silent fork to a stale
+DB). There is no enforced single-writer boundary, no liveness check,
+no version negotiation — just `open(path)` and hope.
+
+#### Gap 2: Multi-instance co-work fragments knowledge into silos
+
+When Claude Desktop, a `claude -p` sub-process, and a separate IDE
+agent all run on the same host, each opens its own T2/T3 handles. T2
+writes from one instance are invisible to the others until/unless they
+re-open the file (and even then, WAL behavior across containers is not
+guaranteed). Memory put in one cockpit is unreachable from another.
+This is the same fragmentation problem RDR-105 solved for T1 with env
+passdown — but T1 fragmentation is *desired* (per-process working
+memory), while T2/T3 fragmentation is *broken-by-design*.
+
+#### Gap 3: No lifecycle, liveness, or event hooks at the storage edge
+
+Because the storage layer is a file handle, there is nowhere to hang
+the things RDR-110 (tuple-space `in`/`out`/`rd`) and RDR-111 (ORB hook
+projection) actually need: a process owns the data; that process
+publishes events on write; clients subscribe; leases time out when
+holders die; barriers wake when N participants arrive. None of that
+is expressible against `sqlite3.connect(path)` — it needs a process
+that *owns* the data and mediates access.
+
+#### Gap 4: T1's existing service shape is the proof-of-concept, but it's not generalised
+
+RDR-105's `NX_T1_HOST`/`NX_T1_PORT` env passdown already establishes
+that nexus can run a tier as a host-process service and have container
+clients connect to it. That pattern exists for T1 but was deliberately
+*not* extended to T2/T3 because T1 had the unique problem (per-session
+isolation with sibling visibility). T2 and T3 have a *different* but
+equally clear service-shape problem: single writer, many readers,
+cross-container shared truth. The substrate is the same; only the
+sharing discipline differs.
+
+## Context
+
+### Background
+
+Three recent RDRs make this RDR's question unavoidable:
+
+- **RDR-105** moved T1 from on-disk session records to env-passdown of
+  a host-local chroma. Settled the "T1 is per-process working memory"
+  question and proved the host-service-plus-env-discovery pattern.
+- **RDR-110** named the unified abstraction over plan-match / T1 / T2
+  as a semantic tuple space and added Linda's atomic `in` operation.
+  Atomic destructive read requires a *single arbiter* — which a shared
+  file handle is not.
+- **RDR-111** projects hooks onto the tuple space as observable state
+  and adds a user-authored composition layer. Projection requires a
+  publishing point — which a file handle does not have.
+
+Both RDR-110 and RDR-111 land cleanly *if* there is a process that
+owns T2 and a process that owns T3 and they expose typed RPCs. They
+land messily otherwise: every reader has to poll, every writer has to
+trust filesystem locking, and `in` has to be implemented as advisory
+SQLite locks across containers — which does not work.
+
+Independently, Claude Desktop's container model and the proliferation
+of `claude -p` sub-processes and ext-app sandboxes have made the
+container-vs-host filesystem split a daily operational fact, not an
+edge case. Every "I can't see my memory" report from co-work
+configurations traces back to this gap.
+
+### Technical Environment
+
+- **T2**: SQLite + FTS5, seven domain stores behind `T2Database` facade.
+  WAL mode enabled. Currently opened by direct path; no daemon.
+- **T3 local mode**: `chromadb.PersistentClient(path)` + local ONNX
+  embedder. Currently opened by direct path; no daemon.
+- **T3 cloud mode**: `chromadb.CloudClient` — already service-shaped
+  by construction; nothing to change.
+- **T1**: `chromadb.EphemeralClient` in-process or per-session HTTP
+  via RDR-105 env passdown. Out of scope for this RDR.
+- **MCP boundary**: every nexus tool consumer talks to the database
+  through `nexus.mcp.*` handlers today; those handlers open T2/T3
+  directly. A service split would put a thin client there instead.
+
+## Research Findings
+
+### Investigation
+
+Conducted 2026-05-12 via deep-research-synthesizer (T2: 112-research-A1..A4).
+Primary sources: installed chromadb package, sqlite.org docs, nexus T1
+implementation (`src/nexus/db/t1.py`, `src/nexus/db/session.py`),
+T2 facade and stores (`src/nexus/db/t2/`, `src/nexus/db/memory_store.py`,
+`src/nexus/db/plan_library.py`, `src/nexus/db/chash_index.py`).
+
+### Key Discoveries
+
+- **Verified**: T2 daemon is *structurally required* for the
+  container case — Docker overlayfs blocks the `mmap` semantics SQLite
+  WAL requires, so a bind-mounted host path opened from inside a
+  container produces a separate WAL per process (or outright failure).
+  This is the silent silo failure mode the RDR set out to fix.
+- **Verified**: T1's existing service shape (chroma HTTP over loopback,
+  spawned at `session.py:494-504`, discovered via `~/.config/nexus/
+  t1_addr.<pid>` + PPID walk at `session.py:634-703`) is a live
+  production precedent for the T2/T3 daemon pattern.
+- **Documented**: `chroma run` is FastAPI + uvicorn with a configurable
+  thread pool (`chroma_server_thread_pool_size`, default 40). chromadb's
+  own "not for production" disclaimer attaches to `EphemeralClient` /
+  `PersistentClient`; `HttpClient` is explicitly the "recommended
+  production configuration" (`chromadb/__init__.py:326`).
+- **Refuted (partially)**: The RDR-105 PPID-walk + discovery-file
+  pattern *does not work* in PID-namespace-isolated containers — the
+  walk terminates at container init (PID 1) and `~/.config` is not
+  bind-mounted in typical sandbox configurations. The `NX_T2_ADDR` /
+  `NX_T3_ADDR` env-var override must be the *primary* path for
+  sandboxed consumers, not a fallback. Discovery protocol needs a
+  dual-primary design.
+- **Inconclusive**: RPC overhead is directionally acceptable —
+  T3 store ops are dominated by embedding latency (ONNX 10-50 ms,
+  Voyage 100-300 ms) and the hop disappears in noise; T2 `memory_get`
+  is the tightest case (0.5-2 ms direct, +10-25% over loopback) and
+  needs a spike with `timeit` against a real fixture to lock the
+  number. UDS will be faster than the loopback TCP T1 already uses.
+
+#### Dependency Source Verification
+
+| Dependency | Source Searched? | Key Findings |
+| --- | --- | --- |
+| chromadb (`chroma run`, FastAPI app) | Yes | uvicorn-backed; 40-thread pool; HttpClient is recommended prod config. T1 already uses this pattern. |
+| sqlite3 WAL | Yes (sqlite.org/wal.html + T2 stores) | WAL cannot use mmap across overlayfs bind mounts → container case broken. Same-host WAL fine. |
+| RDR-105 discovery (`session.py`) | Yes | PPID walk + `~/.config/nexus/t1_addr.<pid>` file. Works for host-native and `claude -p`; fails in PID-namespaced containers. |
+
+### Critical Assumptions
+
+- [x] **A1**: chromadb's bundled HTTP server (`chroma run`) is
+  production-quality enough to be our T3 service, not just a dev
+  convenience. — **Status**: Documented (High confidence) —
+  **Method**: Source Search — see T2 `112-research-A1`.
+- [x] **A2** (qualified): SQLite cross-process write concurrency under
+  WAL is *not* an acceptable substitute for a single-writer daemon —
+  **Verified for the container case** (overlayfs breaks WAL mmap);
+  **Inconclusive for same-host multi-process**, where WAL +
+  `busy_timeout` is the existing T2 design and works correctly. The
+  daemon is structurally required for containers, architecturally
+  necessary for RDR-110/111, and a discipline win same-host. —
+  **Method**: Source Search + sqlite.org/wal.html — see T2
+  `112-research-A2`.
+- [x] **A3**: A daemon-per-tier architecture imposes acceptable
+  latency overhead on the common-case read path. — **Status**:
+  **Verified** (High confidence) — **Method**: Spike
+  (`/tmp/rdr112_a3_spike.py`, 2000 iters on real `MemoryStore`).
+  Results in µs: direct p50=85 / p99=286; UDS p50=100 / p99=300
+  (+15 µs); TCP loopback p50=114 / p99=620 (+29 µs, doubled tail).
+  All sub-millisecond. **Design implication**: T2 daemon binds both
+  UDS and loopback TCP. Clients prefer UDS (faster, bypasses TCP
+  stack, free unix file permissions) but fall back to TCP whenever
+  the socket file is unreachable — Windows VM-based co-work,
+  containerised Claude Desktop, port-allow-listing sandboxes. The
+  ~14 µs gap between transports is well under budget so the fallback
+  is essentially free. T3 transport hop is below noise (embedding
+  dominates). See T2 `112-research-A3-spike`.
+- [x] **A4** (refuted): Discovery via per-host UID file (RDR-105
+  pattern) does **not** work universally — it fails in
+  PID-namespace-isolated containers where `/proc` and `ps` show only
+  container processes and `~/.config` is not bind-mounted. Mitigation:
+  promote `NX_T2_ADDR`/`NX_T3_ADDR` env-var to co-primary discovery
+  path, with daemon emitting its address on stdout for orchestrator
+  capture-and-inject. Proposed Solution will be revised to reflect
+  dual-primary discovery. — **Method**: Source Search of
+  `session.py:634-703` + container semantics — see T2 `112-research-A4`.
+
+## Proposed Solution
+
+### Approach (sketch — to be refined)
+
+1. **T2 service**: introduce `nx daemon t2` — a long-lived process
+   that owns the SQLite handle and exposes the seven domain-store
+   operations over **both UDS and loopback TCP** listeners. The
+   daemon always binds both. The **client** picks: UDS first (faster,
+   bypasses the TCP stack, gets unix file permissions for free), TCP
+   fallback when UDS is unreachable. UDS-unreachable is the expected
+   case for (a) Windows VM-based co-work, (b) containerised Claude
+   Desktop variants, (c) any orchestrator that allow-lists ports but
+   not socket files, and (d) ext-app sandboxes that can do network
+   policy but not bind mounts. A3 spike: UDS p50=100 µs, TCP p50=114
+   µs — both well under budget, so making TCP the fallback (not the
+   exclusion) costs us nothing and buys cross-environment reach.
+   Clients link `T2Client` instead of `T2Database`; the facade API
+   is unchanged.
+2. **T3 service**: run `chroma run` as a managed subprocess under
+   `nx daemon t3`. **Note**: chromadb 1.4.4's HTTP server is loopback
+   TCP, not UDS — we accept the TCP hop for T3 because (a) it's an
+   upstream constraint we don't control, and (b) T3 reads are
+   dominated by embedding latency (ONNX 10–50 ms, Voyage 100–300 ms)
+   so the transport hop is below noise. Local-mode T3 stops being
+   "open the directory directly" and becomes "connect to the managed
+   local server."
+3. **T1 stays put**: RDR-105's env passdown is already correct for T1.
+   No change.
+4. **Discovery (dual-primary)**: each daemon writes **both** its
+   UDS socket path and its TCP `host:port` to
+   `~/.config/nexus/<tier>_addr.<host_uid>` (single file, both
+   addresses) for host-native consumers with shared filesystem. For
+   sandboxed/containerised consumers where the discovery file is
+   unreachable (PID-namespaced containers per the A4 finding,
+   Windows-VM co-work, or containerised Claude Desktop), the
+   orchestrator injects `NX_T2_SOCK` and/or `NX_T2_ADDR` (and the T3
+   equivalents) into the container's environment. Daemon emits both
+   addresses on stdout at startup for orchestrator capture. **Client
+   transport selection**: if `NX_T2_SOCK` is set and the socket is
+   reachable → UDS. Else if `NX_T2_ADDR` is set → TCP. Else read the
+   discovery file and try UDS first, TCP second. Fail loud if neither
+   reaches a live daemon.
+5. **Lifecycle hooks**: the T2 daemon publishes change events to a
+   local pub-sub (RDR-110 tuple space surface), enabling RDR-111's
+   ORB projection without each client having to instrument writes.
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+| --- | --- | --- |
+| `nx daemon t2` | `nexus.db.t2_database.T2Database` | Extend — wrap existing facade in a socket server; do not rewrite store logic. |
+| `nx daemon t3` (local mode) | `nexus.db.t3_local.LocalT3Client` | Replace — direct PersistentClient becomes managed `chroma run` subprocess. |
+| Client-side `T2Client` | `nexus.db.t2_database.T2Database` | New — thin RPC client mirroring the facade signature, so call sites do not change. |
+| Discovery file | `~/.config/nexus/t1_addr.<claude_pid>` (RDR-105) | Extend pattern — same mechanism, different filenames per tier. |
+
+### Decision Rationale
+
+The discipline this RDR imposes — *no direct DB access outside the
+owning process* — is what unlocks RDR-110's atomic-take and RDR-111's
+event projection. It also closes a class of co-work bugs that today
+present as "memory I saved isn't there" and are diagnosed individually
+each time. The cost is a daemon to keep alive; the discovery+auto-spawn
+pattern from RDR-105 already shows that cost is tolerable.
+
+## Alternatives Considered
+
+### Alternative 1: Status quo — direct file access, hope WAL holds
+
+**Description**: Keep opening T2 and T3 by path; rely on SQLite WAL
+and chroma's filesystem locking to mediate cross-process access.
+
+**Pros**:
+
+- No new daemon to operate.
+- No discovery problem.
+
+**Cons**:
+
+- Does not work across container boundaries (the central problem).
+- No place to hang RDR-110 atomic-take or RDR-111 event projection.
+- Silent fork-into-empty-DB failure mode persists.
+
+**Reason for rejection**: Does not solve the stated problem.
+
+### Alternative 2: Single mega-daemon owning all three tiers
+
+**Description**: One `nx daemon` process owns T1+T2+T3.
+
+**Pros**:
+
+- One process to manage, one discovery file.
+
+**Cons**:
+
+- T1 must stay per-session — collapsing it into a shared daemon
+  breaks RDR-105's sibling-visibility model.
+- T2 and T3 have very different scaling and crash-isolation profiles;
+  a chroma OOM should not take down memory.
+
+**Reason for rejection**: Conflates tiers that RDR-105 deliberately
+separated.
+
+### Briefly Rejected
+
+- **Database-as-MCP-server only**: making the daemon a full MCP server
+  rather than a tier-internal RPC would conflate the storage boundary
+  with the tool boundary. The tool layer already exists; we want a
+  layer *below* it.
+- **Cloud-only T3**: would solve the boundary problem but reintroduces
+  the local-mode-required-for-air-gapped-work constraint.
+
+## Trade-offs
+
+### Consequences
+
+- (+) Closes the cross-container silo class of bugs structurally.
+- (+) Gives RDR-110 and RDR-111 a real publishing/arbitrating point.
+- (+) Forces discipline that future tiers (T4? cross-host?) will need
+  anyway.
+- (−) Two new long-lived processes to keep alive on every nexus install.
+- (−) Adds an RPC hop to every T2/T3 call — measurable but
+  presumably small on unix-domain sockets.
+- (−) Daemon ↔ client version handshake is a new operational concern.
+
+### Risks and Mitigations
+
+- **Risk**: Daemon crashes leave clients hanging.
+  **Mitigation**: Health-check + auto-respawn; clients fail loud with
+  recovery instructions rather than silent fallback to direct file.
+- **Risk**: Auto-spawn races between concurrent first-use clients.
+  **Mitigation**: Filesystem-lock-mediated spawn (the spawner takes
+  a lock on the discovery file before forking).
+- **Risk**: Sandbox containers with no host filesystem visibility at
+  all cannot read the discovery file.
+  **Mitigation**: `NX_T2_SOCK` / `NX_T2_ADDR` / `NX_T3_ADDR` env-var
+  injection is a co-primary discovery path per the A4 finding —
+  orchestrator captures the daemon's stdout-announced addresses and
+  passes them into the container at launch. T2 daemon binds both UDS
+  and loopback TCP so the orchestrator can pick whichever the
+  container can actually reach: bind-mount the UDS path for OCI
+  containers that allow mounts; rely on TCP for Windows-VM co-work,
+  containerised Claude Desktop, or sandboxes that allow-list ports
+  but not socket files. Cross-host co-work is still out of scope
+  (TCP listener is loopback-only by default; binding non-loopback
+  would require auth and is deferred to a future RDR).
+
+### Failure Modes
+
+- **Daemon down, client connects**: fail loud, suggest `nx daemon
+  start`. Do not silently degrade.
+- **Version mismatch**: client refuses to connect; report both versions.
+- **Daemon healthy, data corrupt**: same as today (SQLite/chroma
+  surface their own errors); the daemon does not mask them.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] RDR-110 accepted (defines the atomic-take primitive the T2
+  daemon must implement).
+- [ ] All Critical Assumptions verified.
+
+### Minimum Viable Validation
+
+A single end-to-end demo: two `claude -p` sub-processes on the same
+host, started in different working directories. One writes a memory
+via `memory_put`; the other reads it via `memory_get`. Today this
+fails (each gets its own T2). With this RDR, it succeeds.
+
+### Phase 1: Code Implementation
+
+To be expanded during `/nx:create-plan`.
+
+### Phase 2: Operational Activation
+
+To be expanded.
+
+### Day 2 Operations
+
+| Resource | List | Info | Delete | Verify | Backup |
+| --- | --- | --- | --- | --- | --- |
+| T2 daemon | `nx daemon list` | `nx daemon info t2` | `nx daemon stop t2` | health-check RPC | snapshot of underlying SQLite |
+| T3 daemon | `nx daemon list` | `nx daemon info t3` | `nx daemon stop t3` | health-check RPC | snapshot of underlying chroma dir |
+| Discovery files | `ls ~/.config/nexus/*_addr.*` | `cat <file>` | rm on daemon stop | daemon-startup writes | n/a (ephemeral) |
+
+### New Dependencies
+
+Probably none — stdlib `socketserver` / `multiprocessing.connection`
+for T2; chromadb itself for T3 (already a dep). To be confirmed.
+
+## Test Plan
+
+- **Scenario**: Two processes, distinct working dirs, same host —
+  memory_put in one, memory_get in the other. — **Verify**: value
+  is read back.
+- **Scenario**: Daemon killed mid-operation. — **Verify**: client
+  reports a clear error and does not silently fall back to direct
+  file.
+- **Scenario**: Two clients race to auto-spawn the daemon. —
+  **Verify**: exactly one daemon runs; the loser connects to the
+  winner.
+- **Scenario**: Client built against daemon version N+1 connects to
+  daemon version N. — **Verify**: handshake refuses with a clear
+  version message.
+- **Scenario**: RDR-110 atomic-take from two clients on the same
+  template. — **Verify**: exactly one wins; the other blocks or
+  fails per spec.
+
+## Validation
+
+### Testing Strategy
+
+1. **Scenario**: cross-process memory visibility (MVV).
+   **Expected**: visible.
+2. **Scenario**: cross-*container* memory visibility (Claude Desktop
+   ↔ host `nx` CLI).
+   **Expected**: visible.
+3. **Scenario**: daemon restart preserves data and notifies clients.
+   **Expected**: clients reconnect transparently or fail-loud per
+   policy.
+
+### Performance Expectations
+
+The RPC overhead on memory_get / search / store_get is the load-bearing
+performance question. Will measure empirically during Spike A3.
+
+## Finalization Gate
+
+> Complete each item with a written response before marking this RDR
+> as **Accepted**.
+
+### Contradiction Check
+
+To be filled at gate time.
+
+### Assumption Verification
+
+A1–A4 above; all currently Unverified.
+
+### Scope Verification
+
+Minimum Viable Validation (cross-process memory visibility) is in
+scope, not deferred.
+
+### Cross-Cutting Concerns
+
+- **Versioning**: daemon-client handshake required; encoded in discovery file.
+- **Build tool compatibility**: no new build-time deps anticipated.
+- **Licensing**: no new third-party libs anticipated.
+- **Deployment model**: daemons run on the host; clients run anywhere
+  with a route to the host's socket/loopback.
+- **IDE compatibility**: N/A.
+- **Incremental adoption**: rollout gates on a `NX_STORAGE_MODE=daemon|direct`
+  flag; default flips after MVV ships.
+- **Secret/credential lifecycle**: N/A (local daemons, no auth in v1;
+  see Open Questions below).
+- **Memory management**: daemon long-lived; needs a memory budget.
+
+### Proportionality
+
+Document is intentionally a thinking-through-decision draft, not a
+locked design. Right-size before gate.
+
+## Open Questions
+
+- **Authentication**: v1 assumes localhost-only and trusts every
+  local user. Is that the right call, or do we need a per-user UID
+  check on connect?
+- **Cross-host**: every assumption here is single-host. What's the
+  story when a co-worker runs nexus on a different machine? Out of
+  scope for this RDR but worth naming.
+- **Daemon-as-MCP**: should the T2 daemon eventually *be* the MCP
+  server, collapsing two layers? Or are they intentionally distinct?
+- **Migration**: how do existing on-disk T2/T3 stores get picked up
+  by the new daemons? Presumably "the daemon opens the same path the
+  old direct client did" — but worth being explicit.
+
+## References
+
+- RDR-004: Four-Store Architecture (the original tier definitions)
+- RDR-041: T1 Scratch Inter-Agent Context
+- RDR-105: T1 Chroma Architecture — Env Passdown (the proof-of-concept
+  for host-service-plus-discovery)
+- RDR-108: Graph Identity Normalization (relies on a single catalog
+  source-of-truth that this RDR's T2 daemon would arbitrate)
+- RDR-110: Semantic Tuple Space (needs an arbiter to implement `in`)
+- RDR-111: ORB — Observable Relay Bus (needs a publishing point at the
+  storage edge)
+
+## Revision History
+
+- 2026-05-12 — Initial draft. Hal.
+- 2026-05-12 — Research phase: A1 Documented (High), A2 Verified for
+  containers / Inconclusive same-host (High/Med), A3 Inconclusive
+  pending spike (Med), A4 Partially Refuted (High) — discovery needs
+  dual-primary design. Findings in T2 `nexus_rdr/112-research-A{1..4}`.
+- 2026-05-12 — A3 spike executed: UDS overhead +15 µs p50 on
+  `memory_get`, TCP loopback +29 µs p50 with doubled p99 tail.
+  A3 promoted to Verified.
+- 2026-05-12 — Design: T2 daemon binds **both UDS and loopback TCP**.
+  Client preference order is UDS → TCP. Reversed an earlier UDS-only
+  lock after considering Windows-VM co-work, containerised Claude
+  Desktop, and port-allow-listing sandboxes where UDS bind-mounts
+  aren't an option. The A3 spike's ~14 µs gap between transports
+  makes the fallback essentially free. T3 keeps loopback TCP
+  (upstream chromadb constraint). TCP listeners are loopback-only;
+  cross-host co-work is still a future RDR.

--- a/docs/workflow-engine-README.md
+++ b/docs/workflow-engine-README.md
@@ -1,0 +1,303 @@
+# Workflow engine + ext-apps — document set
+
+Four artifacts on disk, all gitignored, all indexed. Read them in the
+order below; each builds on the previous.
+
+## What this is
+
+A design exploration of a Parmar-style MCP workflow engine extended with
+ext-apps for human-in-the-loop, incremental cross-session durability,
+and explicit positioning against the broader workflow-orchestration
+landscape. The user has a working TypeScript first-cut of the engine;
+these documents are inputs to the next round of synthesis on it, not a
+greenfield design.
+
+Source paper: [Parmar 2026](https://arxiv.org/abs/2605.00827) —
+indexed locally as `knowledge__workflow-engine` (79 chunks).
+
+Canonical MCP + ext-apps reference material: `docs__mcp-protocol`
+(460 chunks). Includes the full SEP-1865 ext-apps spec
+(2026-01-26), SEP-1686 Tasks proposal with community thread, and
+MCP core spec for transports / lifecycle / resources / tools. Cite
+from this corpus when verifying any ext-apps or MCP-protocol claim
+in the design.
+
+## Reading order
+
+### 1. `workflow-engine-with-ext-apps.md` — the design doc
+
+The substantive design. ~1990 lines. Cuts across:
+
+- **Three combination patterns** — workflow-as-app, human-in-the-loop
+  checkpoints, blueprint authoring as an app.
+- **The blocking model and the yield alternative** — v1 ships blocking
+  RPC; v2 defaults to yield semantics.
+- **The 7 v1 shape constraints** — pure-data state, workflow IDs,
+  execution log shape, await-annotation branch, stateless UI-MCPs,
+  discriminated-union return schema, identity threading.
+- **Split storage commitment** — `ExecutionStore` (CAS snapshot) +
+  `AuditLog` (append-only). Atomic `park` / `resume` / `cancel`
+  transitions, not raw CRUD.
+- **Why isn't this just LangGraph?** — detailed comparison; the
+  recommendation is Tier C (steal patterns, no dep) primarily on
+  dependency-weight grounds.
+- **Recommended TS-engine architecture** — client-hosted in-process
+  by default; Mode B (HTTP+SSE + REST gateway) only when remote
+  access is required.
+- **ext-apps integration in detail** — protocol shape, lifecycle,
+  blueprint declarations, parent-iframe strategy for
+  `parallel { await_user; await_user }`.
+- **Async surface** — 14 enumerated issues sorted by when they bite.
+- **Adjacent workflow systems — hard-won lessons beyond LangGraph** —
+  landscape map (4 quadrants), ASL versioning, conditional-logic
+  escape, sub-workflow composition, saga gap, full HITL taxonomy
+  (blocking / task-token / awakeable / waitForEvent / yield).
+- **Substrate dependencies and pre-v1 experiments** — 4 substrate
+  questions (MCP Tasks SEP-1686, nx plan library, effect annotations,
+  ext-apps multi-iframe) + 5 bounded experiments.
+- **Design space kept open** — 8 angles not committed (effect-shadow
+  analysis, capability-aware blueprints, sub-workflows, OTel trees,
+  record/replay, semantic diff, blueprint mining, beyond-iframe UI),
+  plus the "no v2 durability ever" steelman.
+- **Decision posture** — consolidated decisions with alternatives
+  considered and reasons; v1 / v2 / substrate / experiments / deferred
+  lists; open architectural questions.
+
+Indexed: `docs__workflow-engine` (101 chunks).
+
+### 2. `workflow-engine-synthesis.md` — landscape position
+
+Cross-source synthesis (deep-research-synthesizer agent, May 2026).
+Reads the design through the lens of the broader landscape:
+
+- Positions the engine in the four-quadrant workflow-orchestration map.
+- Distills lessons from AWS Step Functions, Temporal, Restate,
+  Inngest, Argo, Tekton, LangGraph, Serverless Workflow Spec.
+- Full human-in-the-loop taxonomy (5 mechanically distinct shapes).
+- Convergent evidence where the design aligns with mature systems.
+- Genuine novelties (defensible) and gaps (table-stakes elsewhere).
+- 5 pre-commit experiments with bounded costs.
+- Citations to external sources (paper, MCP roadmap, ext-apps spec,
+  industry docs).
+
+Most of this is now folded into the main doc's "Adjacent workflow
+systems" section, but the synthesis remains the source-of-truth for
+the citation trail.
+
+Indexed: `docs__workflow-engine` (9 chunks).
+
+### 3. `workflow-engine-brainstorm.md` — adjacent design space
+
+Brainstorm pass (architect-planner agent, May 2026). 12 angles the
+design doc does not develop:
+
+1. nx plan library *is* the BlueprintStore
+2. Catalog tumblers as workflow-scoped identifiers
+3. Effect-shadow static analysis
+4. Semantic blueprint diff
+5. Workflow-as-test-fixture (record/replay)
+6. Cross-blueprint composition (`engine.run_workflow` as a tool)
+7. OpenTelemetry trace-tree by construction + cost roll-up
+8. Agent-side `describe_workflow` tool
+9. Capability-aware blueprints (workflow-as-privilege-bracket)
+10. UI surfaces beyond ext-apps (voice / Slack / mobile / email)
+11. Blueprint mining from observed agent traces
+12. The "no v2 durability ever" steelman
+
+Eight of the twelve are folded into the main doc's "Design space kept
+open" section with status and rationale. The brainstorm document
+retains the full sketches for reference.
+
+Indexed: `docs__workflow-engine` (14 chunks).
+
+### 4. (Reference) Parmar 2026 paper
+
+Source artifact. Indexed locally as `knowledge__workflow-engine`
+(79 chunks). Cite when verifying paper claims; do not paraphrase
+without checking the chunk text.
+
+## Provenance
+
+This document set was produced through:
+
+1. An initial design pass.
+2. Two rounds of substantive critique (against the doc itself, then
+   against the doc cross-referenced with the paper). Critiques
+   surfaced one critical factual inversion (~54k token attribution),
+   one silent extension (`collect` as a primitive), and structural
+   gaps in interpreter architecture grounding, `branch_id` schema,
+   identity threading, `WorkflowStore` interface, yield-vs-blocking
+   framing, and LangGraph Tier-B rejection rationale. All addressed
+   in the current main doc.
+3. A landscape synthesis pass and a brainstorm pass.
+4. A fold-up pass that integrated the synthesis and brainstorm
+   findings into the main doc's structure, with the standalone
+   companion documents retained as the source artifacts.
+5. A spec-grounding pass: the canonical SEP-1865 ext-apps spec,
+   SEP-1686 Tasks proposal (with community thread), and MCP core
+   spec (transports / lifecycle / resources / tools) were fetched
+   and indexed as `docs__mcp-protocol`. A deep-analyst verification
+   against that corpus surfaced three refuted claims and three
+   needing substantial correction in the doc's ext-apps section.
+   All nine resulting patches were applied: the PostMessage
+   protocol now uses actual SEP-1865 method names
+   (`ui/initialize`, `ui/notifications/tool-input` etc.); the
+   multi-iframe limitation is correctly attributed to host
+   implementations not the spec; the Sandbox-proxy hop on web
+   hosts is documented; the CSP defaults and four
+   `_meta.ui.csp.*` fields are spec-derived; SEP-1686 is
+   characterised as "accepted by Core maintainers, iterating to
+   final" rather than "experimental"; the spec's
+   `notifications/progress` lever for extending host tool-call
+   timeouts is named; Streamable HTTP (with `Last-Event-ID`
+   resumability) replaces "HTTP+SSE" throughout; the `ui/message`
+   fallback channel is added to progressive enhancement.
+
+## Reference material to (re-)index on the receiving instance
+
+The companion corpora cited throughout the design (`knowledge__workflow-engine`,
+`docs__mcp-protocol`) are indexed on the **originating** instance. On a
+different machine those collections won't exist; their tumbler-shaped
+collection names (e.g. `knowledge__workflow-engine__voyage-context-3__v1`,
+`docs__mcp-protocol__voyage-context-3__v1`) are project-local artifacts
+of the catalog/T3 layout per RDR-101/RDR-108 and may also be organized
+differently on the receiving instance (different corpus name, different
+tumbler scheme, different catalog conventions). Re-index from source,
+don't try to import-by-name.
+
+Fetch and index the following before relying on any spec-citation in the
+main doc. All URLs verified as of May 2026.
+
+### The source paper
+
+- **Parmar 2026** — "Separating Intelligence from Execution":
+  `https://arxiv.org/pdf/2605.00827v1` (PDF; 12 pages; the doc was indexed
+  with 16 pages via MinerU due to detected formulas).
+  Suggested local target: `knowledge__workflow-engine` (or the receiving
+  project's external-PDF convention).
+
+### MCP ext-apps spec (SEP-1865)
+
+GitHub repo: `modelcontextprotocol/ext-apps`. Fetch raw via
+`gh api repos/modelcontextprotocol/ext-apps/contents/<path>` and base64-decode.
+
+Files to grab:
+
+- `README.md` — entry-point overview
+- `specification/2026-01-26/apps.mdx` — the normative spec (1768 lines).
+  The load-bearing reference. If you only fetch one ext-apps file, this
+  is it.
+- `docs/overview.md` — high-level rationale
+- `docs/quickstart.md` — minimal working example
+- `docs/patterns.md` — interaction patterns, large-payload handling,
+  `ui/update-model-context` recipes
+- `docs/csp-cors.md` — security model details (short)
+- `docs/authorization.md` — auth scenarios
+- `docs/testing-mcp-apps.md` — testing harness
+- `docs/migrate_from_openai_apps.md` — useful as a reverse map: what
+  ChatGPT widgets do vs SEP-1865
+- `docs/agent-skills.md` — agent-skill integration
+
+Suggested local target: `docs__mcp-protocol` (or your equivalent).
+
+### MCP core spec — the load-bearing subset
+
+GitHub repo: `modelcontextprotocol/modelcontextprotocol`. Paths under
+`docs/specification/draft/`.
+
+- `basic/transports.mdx` — stdio, Streamable HTTP, resumability,
+  `Last-Event-ID`. Needed to ground the v1 transport claims.
+- `basic/lifecycle.mdx` — initialization handshake, timeouts (the
+  SHOULD-set-timeouts and MAY-reset-on-progress clauses are the
+  spec-sanctioned levers for long-running calls).
+- `server/resources.mdx` — `resources/list`, `resources/read`,
+  `notifications/resources/updated`.
+- `server/tools.mdx` — tool definition shape; how `_meta` fields are
+  carried.
+
+For a deeper dive, the same directory has `basic/authorization.mdx`,
+`server/prompts.mdx`, `server/utilities/`, `client/utilities/`,
+`changelog.mdx`. Not load-bearing for the design as written but useful
+when extending it.
+
+### MCP Tasks proposal (SEP-1686)
+
+Not a file — a GitHub issue with an extensive community thread.
+Fetch via `gh issue view 1686 --repo modelcontextprotocol/modelcontextprotocol
+--json title,body,state,comments`. Include the comments; the open issues
+(idempotency 2452/2451, deadlines 1956, polling 1955) are the gaps the
+design cites.
+
+Related open PRs worth checking the state of when revisiting:
+
+- SEP-2694: Resumable Task Event Streams —
+  `https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2694`
+- SEP-2679: Task streaming partial results —
+  `https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2679`
+- SEP-1905: Task Result Streaming and Immediate Result Acceptance —
+  `https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1905`
+- SEP-2575: Make MCP Stateless —
+  `https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575`
+
+### Bulk-index recipe (originating instance used this shape)
+
+```bash
+mkdir -p /tmp/mcp-refs && cd /tmp/mcp-refs
+
+# 1. ext-apps repo files
+for f in README.md docs/overview.md docs/quickstart.md docs/patterns.md \
+         docs/csp-cors.md docs/authorization.md docs/testing-mcp-apps.md \
+         docs/migrate_from_openai_apps.md docs/agent-skills.md \
+         specification/2026-01-26/apps.mdx; do
+  out="ext-apps-$(echo "$f" | tr '/' '-')"
+  gh api "repos/modelcontextprotocol/ext-apps/contents/$f" --jq '.content' \
+    | base64 -d > "${out%.mdx}.md"
+done
+
+# 2. MCP core spec
+for f in docs/specification/draft/basic/transports.mdx \
+         docs/specification/draft/basic/lifecycle.mdx \
+         docs/specification/draft/server/resources.mdx \
+         docs/specification/draft/server/tools.mdx; do
+  out="mcp-spec-$(basename "$f" .mdx).md"
+  gh api "repos/modelcontextprotocol/modelcontextprotocol/contents/$f" --jq '.content' \
+    | base64 -d > "$out"
+done
+
+# 3. SEP-1686 Tasks (issue + thread)
+gh issue view 1686 --repo modelcontextprotocol/modelcontextprotocol \
+  --json title,body,state,comments \
+  --jq '"# \(.title)\n\nState: \(.state)\n\n## Body\n\n\(.body)\n\n## Comments\n\n" +
+        ([.comments[] | "### @\(.author.login)\n\(.body)\n"] | join("\n---\n"))' \
+  > mcp-sep-1686-tasks.md
+
+# 4. Index into your local convention (this example uses nexus's `nx index md`)
+for f in *.md; do nx index md "$PWD/$f" --corpus mcp-protocol; done
+
+# 5. Parmar paper
+curl -sL https://arxiv.org/pdf/2605.00827v1 -o parmar-2026.pdf
+nx index pdf "$PWD/parmar-2026.pdf" --collection knowledge__workflow-engine
+```
+
+If your receiving environment uses a different indexing tool, the corpus
+names and tumbler shapes will differ — but the *content* to fetch is the
+same. The design doc cites these sources by name and quoted spec
+language, not by tumbler ID.
+
+## How to use this set
+
+For deeper reading: the main doc is self-contained. Synthesis and
+brainstorm are useful when verifying a claim's provenance or when
+considering an adjacent angle.
+
+For further synthesis: the four substrate questions and five pre-v1
+experiments in the main doc's Decision Posture are the highest-leverage
+unblocked surface. Experiments #1 (measure host stdio timeout) and #2
+(read the existing TS interpreter) are both bounded enough to run
+immediately and gate large pieces of the design.
+
+For implementation: the v1 shape constraints (7) + the split
+`ExecutionStore` / `AuditLog` interface + the parent-iframe ext-apps
+strategy are the load-bearing v1 commitments. Everything else is
+either deferred to v2 (additive) or kept open in the design-space
+section (genuinely undecided).

--- a/docs/workflow-engine-brainstorm.md
+++ b/docs/workflow-engine-brainstorm.md
@@ -1,0 +1,44 @@
+# Brainstorming brief — adjacent design space for the workflow engine
+
+12 angles surfaced by architect-planner agent (run abe8e36d) on the workflow-engine design doc, May 2026.
+
+## 1. nx plan library *is* the BlueprintStore
+Collapse `BlueprintStore` into nx plan library when engine ships inside nexus. T1→T2→T3 promotion maps onto draft→tested→battle-hardened blueprint maturity. `plan_match` becomes "did somebody already write this?" lookup. Cost: hard nx dependency; standalone-engine story weakens.
+
+## 2. Catalog tumblers as workflow-scoped identifiers
+Promote workflow runs to catalog Documents, steps as linkable entities, parent_step_id/branch_id as graph edges. Buys queryability through existing catalog APIs ("what workflows touched this file"). Cost: catalog write pressure during execution.
+
+## 3. Effect-shadow static analysis
+From blueprint + per-tool effect annotations, compute the effect shadow (tables touched, side effects, idempotency, parallel-branch conflicts) before execution. Buys CI-style production warnings, idempotency proofs, feeds capability-aware permissions. Cost: depends on MCP effect-annotation ecosystem that doesn't exist yet.
+
+## 4. Semantic blueprint diff
+Normalize step IDs by topological position, compute graph isomorphism on data-flow DAG. Buys meaningful PR review, safe auto-merge of equivalent blueprints. Cost: non-trivial; partial implementations mislead.
+
+## 5. Workflow-as-test-fixture (record/replay)
+Audit log becomes record/replay substrate. Capture (tool, params)→result during real runs, replay with shadowed calls. Buys regression tests, blueprint refactoring without re-spending tool budgets, reproducible bugs, v1→v2 migration test substrate. Cost: result-fidelity fragility (timestamps, UUIDs); needs canonicalization.
+
+## 6. Cross-blueprint composition (engine.run_workflow as tool)
+Blueprints become composable units. Hard part: recursion, cycle detection, naming/visibility across projects. Required machinery: call-stack depth limit, BlueprintStore cycle detection at save time. Buys real composition, library-of-blueprints culture. Cost: debugging across nested boundaries needs trace tree.
+
+## 7. OpenTelemetry trace-tree by construction + cost roll-up
+parent_step_id/branch_id already in audit log shape. Emit OTel spans natively → workflow becomes single trace tree by construction. Cost attribution rolls up free. Buys drop-in observability compatibility. Cost: OTel dep in hot path; audit-log-vs-trace overlap needs resolution (probably unify).
+
+## 8. Agent-side describe_workflow tool
+Workflows expose as tools to agents; can agent UNDERSTAND one before calling? describe_workflow returns plain-English explanation, effect shadow, human-touch points, expected duration. Buys better agent tool-selection, risk-aware execution, LLM-driven blueprint editing. Cost: derived descriptions can lie, cache-invalidation on edit.
+
+## 9. Capability-aware blueprints (workflow-as-privilege-bracket)
+Workflow is one tool that fans out to N tool calls — transitive permission expansion. Two design moves: (a) blueprints declare required capabilities, host gates run_workflow against union; (b) engine subject-shifts — workflow runs under blueprint's identity, not agent's, with separately-granted capability bundle (like sudo). Buys meaningful workflow-level permissions, grant agents access to outcomes without underlying tools.
+
+## 10. UI surfaces beyond ext-apps
+Voice (Twilio), Slack thread, mobile push, email all fit "deliver prompt → external system → return input → resume" shape. Forces yield over blocking for anything beyond seconds. Buys engine as interaction substrate, not just iframe substrate. Cost: v1 blocking model breaks; multi-channel routing logic.
+
+## 11. Blueprint mining from observed agent traces
+Inverse of authoring. Mine recurring tool-call sequences from prior agent traces, propose blueprints automatically. Buys cold-start solution, quantifies blueprint value via shadow execution, aligns with plan_match philosophy. Cost: trace privacy, false-positive blueprints. Constrains v1 audit-log schema (must be mineable).
+
+## 12. The "no v2 durability ever" steelman
+Never build v2. Constraints: every tool idempotent (or carries dedup key); long-human-time workflows use yield with agent re-issue; engine crash loses in-flight but blueprints durable so agent re-runs. Buys massive simplification (no ExecutionStore SQLite, no checkpoint serialization, no race conditions, no version-skew). Engine genuinely stateless, horizontal scaling trivial. Cost: idempotency-as-invariant is ecosystem tax; loses "park for 3 days" use case.
+
+## Cross-cutting themes
+- Yield wins on multiple independent vectors (HITL taxonomy, multi-channel UI, idempotent steelman)
+- Effect annotations on MCP tools are missing ecosystem piece for #3, #9, #11
+- MCP Tasks primitive + effect annotations + nx plan library = three external substrate questions that could simplify the doc

--- a/docs/workflow-engine-synthesis.md
+++ b/docs/workflow-engine-synthesis.md
@@ -1,0 +1,56 @@
+# Workflow Engine Landscape Synthesis
+
+Deep-research-synthesizer (run a78c5a1c) cross-source synthesis on workflow-engine design doc, May 2026.
+
+## Landscape position
+Sparse quadrant: declarative/data-first AND natively MCP-aware. Nobody else there.
+
+Four populated neighbors:
+- **Code-first durable**: Temporal, Restate, Inngest, Azure Durable Functions. Polyglot, production-grade, rich HITL. None MCP-aware.
+- **Code-first LLM**: LangGraph, CrewAI. First-class LLM nodes; not searchable/diffable.
+- **Data-first infrastructure**: AWS Step Functions/ASL, Argo, Tekton, Nextflow, Serverless Workflow Spec. Not LLM-authorable; expression languages bolted on.
+- **Data-first no-code**: n8n, Zapier, Prefect. Visual; not LLM-emittable.
+
+## Data-first prior-art lessons (every system learned these)
+1. **In-flight versioning is painful.** AWS shipped immutable versions+aliases in 2023 for this. Engine: what happens to parked workflow when its blueprint changes? No policy yet.
+2. **Conditional logic escapes the DSL.** ASL added intrinsic functions; jq-vs-JSONPath debate in Serverless Workflow Spec. Parmar's "re-engage design phase" is principled but breaks on data-driven conditionals.
+3. **Sub-workflow composition is table-stakes.** Step Functions, Argo, Temporal, BPMN all have it. 5-primitive DSL doesn't.
+4. **Saga/compensating transactions absent.** Continue-or-abort only.
+
+## HITL taxonomy — 5 mechanically distinct shapes
+| Shape | Example | Connection held? |
+|---|---|---|
+| Blocking RPC | Camunda BPMN sync; doc v1 | Yes |
+| Task token/callback | Step Functions .waitForTaskToken | No |
+| Durable promise/awakeable | Restate ctx.awakeable() | No |
+| waitForEvent | Inngest, Cloudflare Workflows | No (bus-bound) |
+| Yield/parking | Doc v2 default | No |
+
+Task-token and durable-promise are the same pattern at different infrastructure layers. Doc's engine.resume(workflow_id, checkpoint_id, payload) IS task-token-on-SQLite. **MCP Tasks primitive (SEP-1686, experimental)** is the protocol-level task-token. If matures (gaps: retry, expiry, idempotency), eliminates need for SQLite parking layer.
+
+## MCP ecosystem state (2026)
+- **2026 roadmap**: Streamable HTTP preferred; Tasks primitive experimental; no workflow orchestration in roadmap — engine doesn't duplicate.
+- **ext-apps spec (2026-01-26)**: Claude + ChatGPT support; VS Code + Goose joining; Java SDK not yet. Security via iframe sandbox + postMessage, no formal CSP spec.
+- **Mediator pattern in MCP space**: Parmar's framing doesn't appear in other published MCP work. Genuine novelty within MCP ecosystem.
+
+## Convergent evidence (where the design aligns with mature systems)
+- Snapshot+audit-log split is right (matches LangGraph, Temporal, every mature system)
+- Per-step timeout on human-approval is mandatory (universal)
+- ~300 LoC SQLite checkpointer estimate consistent with LangGraph's ~400 LoC Python
+
+## Genuine novelties (defensible claims)
+1. LLM-authored JSON workflow as first-class retrievable artifact (no prior system)
+2. MCP Mediator architecture (no other published MCP work frames it this way)
+3. plan_search/plan_match/plan_promote lifecycle (no traditional workflow system indexes its definitions)
+
+Novelty is "nobody else had this constraint" (LLMs + MCP standardization 2024-2025), not "nobody else would."
+
+## 5 pre-commit experiments
+1. **Measure Claude Code's stdio tool-call timeout.** One afternoon. Gates whether v1 blocking await_user is viable without HTTP+SSE.
+2. **Verify TS interpreter is flat-loop or recursive-descent.** Architectural question. Determines whether "state is data" is discipline or refactor.
+3. **Find JMESPath wall in 10 real blueprints.** The wall comes when templates need to CONSTRUCT new objects from parts of multiple prior outputs. Decide JSONata/intrinsics/re-engage from evidence.
+4. **Spike await_user on MCP Tasks (SEP-1686)** as alternative v2 path.
+5. **Prototype multi-iframe routing** for parallel { await_user; await_user }. Spec gap is real.
+
+## Sources cited
+Parmar 2026 paper; MCP 2026 roadmap; ext-apps spec; Restate/Inngest/Step Functions docs; LangGraph checkpointer code; Serverless Workflow Spec; Kai Waehner durable-execution survey; Temporal blog; Argo Workflows suspend/resume; Zigflow YAML-DSL-for-Temporal article.


### PR DESCRIPTION
## Summary

- **RDR-111** — *The ORB: Observable Relay Bus.* Hook event projection onto RDR-110's tuple space, user-authored composition layer, shared coordination model for the agentic cockpit. Draft.
- **RDR-112** — *Storage-as-Service.* T2/T3 move behind per-tier daemons so containerised consumers stop forking into per-container silos; T1 stays per-session per RDR-105. Draft, research phase complete.

## RDR-112 research outcomes

| # | Assumption | Verdict |
|---|---|---|
| A1 | `chroma run` is production-quality | **Documented** (uvicorn-backed, used for T1 already) |
| A2 | WAL not a substitute for daemon | **Verified** for containers (overlayfs blocks WAL mmap) |
| A3 | RPC overhead acceptable | **Verified** via spike — UDS +15 µs p50, TCP +29 µs p50, sub-ms |
| A4 | Per-host UID file works universally | **Partially Refuted** — needs env-var co-primary path |

Design locks: T2 daemon binds **both UDS and loopback TCP**; clients prefer UDS, fall back to TCP for Windows VM co-work, containerised Claude Desktop, and port-allow-list sandboxes. Discovery is dual-primary (file + env var). Cross-host co-work is explicitly out of scope.

## Adjacent prose

Also lands the working-notes design prose feeding RDR-111:

- `docs/agentic-cockpit.md` — tuple-space common model + semantic events
- `docs/workflow-engine-{README,brainstorm,synthesis}.md` — the workflow-engine "free variable" handoff document set RDR-111 deliberately leaves open

## Index hygiene

`docs/rdr/README.md` row for RDR-111 was missing; this PR adds both 111 and 112.

## Test plan

- [x] RDRs scaffolded from template; frontmatter parses
- [x] README index updated
- [ ] `/nx:rdr-gate 111` and `/nx:rdr-gate 112` are follow-ups, not blockers for this docs-only land