### PR TITLE
docs(rdr): cross-reference 110↔112; anticipate nexus-in-a-container ops

### DIFF
--- a/docs/rdr/rdr-110-semantic-tuple-space.md
+++ b/docs/rdr/rdr-110-semantic-tuple-space.md
@@ -9,7 +9,7 @@ reviewed-by: self
 created: 2026-05-09
 accepted_date: 2026-05-09
 related_issues: []
-related_rdrs: [RDR-004, RDR-041, RDR-077, RDR-078, RDR-079, RDR-087, RDR-092, RDR-105, RDR-106, RDR-107, RDR-108]
+related_rdrs: [RDR-004, RDR-041, RDR-077, RDR-078, RDR-079, RDR-087, RDR-092, RDR-105, RDR-106, RDR-107, RDR-108, RDR-112]
 related_tests: []
 implementation_notes: ""
 ---
@@ -2011,3 +2011,42 @@ anywhere in the document. End-to-end coherence across all four
 revision rounds verified. Total findings closed across four
 passes: 16 (3 critical → 0; 7 significant → 0; 6 observations →
 0). RDR-110 ready for `/nx:rdr-accept`.
+
+### Post-acceptance cross-reference 2026-05-12 — RDR-112 (Storage-as-Service)
+
+RDR-110's atomic-take primitive is built on SQLite WAL multi-process
+safety (Critical Assumptions #1 and #2, both Verified for the
+same-host POSIX-filesystem case). RDR-112 (draft 2026-05-12) found
+this guarantee **does not extend across container overlayfs bind
+mounts** — WAL requires `mmap` semantics that overlayfs blocks, so
+a SQLite handle opened from inside a container against a host-mounted
+path forks into a per-container WAL. The Linda `in` primitive
+would silently break (or worse, silently double-claim) in that
+configuration.
+
+**This does not invalidate RDR-110.** The atomic-take CAS primitive
+itself is correct; only its *call site* shifts. Under RDR-112, T2 is
+owned by `nx daemon t2` (single process, single SQLite handle,
+single WAL — exactly the configuration RDR-110's CAs assume).
+Containerised clients call atomic-take via UDS/TCP RPC to the
+daemon; the daemon executes the same
+`UPDATE … RETURNING … WHERE id = (SELECT id … LIMIT 1)`
+pattern against its local handle. The CAS is unchanged.
+
+**Sequencing implication for planning**: RDR-110's planning chain
+has two ordering options.
+
+1. **Ship 110 first against direct-file T2** (current `T2Database`
+   facade). Same-host atomic-take works immediately. RDR-112's
+   daemon later wraps the existing CAS as an RPC; call sites
+   move from `T2Database.take(...)` to `T2Client.take(...)` with
+   no semantic change.
+2. **Sequence 112's daemon before 110's atomic-take call sites**
+   so the call sites are written once.
+
+Option 1 is preferred. The CAS primitive is independent of where it
+runs; the daemon is a transport wrapper, not a redesign.
+
+**No changes to RDR-110's design surface.** `related_rdrs`
+frontmatter updated to include RDR-112; this revision-history note
+records the cross-reference.

--- a/docs/rdr/rdr-112-storage-as-service-container-boundary.md
+++ b/docs/rdr/rdr-112-storage-as-service-container-boundary.md
@@ -330,10 +330,80 @@ separated.
 - (+) Gives RDR-110 and RDR-111 a real publishing/arbitrating point.
 - (+) Forces discipline that future tiers (T4? cross-host?) will need
   anyway.
+- (+) Multi-user host isolation is free (UDS filesystem permissions);
+  no in-process auth code in v1.
 - (−) Two new long-lived processes to keep alive on every nexus install.
-- (−) Adds an RPC hop to every T2/T3 call — measurable but
-  presumably small on unix-domain sockets.
+- (−) Adds an RPC hop to every T2/T3 call — measured at +15 µs p50
+  (UDS) / +29 µs p50 (TCP loopback) in the A3 spike; both sub-ms.
 - (−) Daemon ↔ client version handshake is a new operational concern.
+- (−) Containerised consumers require an orchestration step (UDS
+  bind-mount or TCP port allow-list + env-var injection) at
+  container launch. Documented in Day 2 Ops.
+- (−) Cross-host co-work is explicitly *not* addressed; a future RDR
+  layers federation on top of the local daemon.
+- (−) **Ad-hoc DB access disappears when nexus runs inside its own
+  container** — see "Nexus-in-its-own-container" subsection below.
+
+### Nexus-in-its-own-container — interaction model shift
+
+One deployment mode RDR-112 enables (and which the agentic-cockpit
+roadmap anticipates) is **packaging nexus itself as a container** —
+daemons, MCP server, CLI, and config inside a single OCI image that
+consumers attach to via UDS bind-mount or TCP. In that configuration
+**no out-of-band process on the host can reach the underlying SQLite
+file or chroma directory**: `sqlite3 ~/.nexus/t2.db`, `chroma utils
+info`, DBeaver, Datasette, ad-hoc `SELECT ... FROM memory WHERE ...`
+are all unavailable without `docker exec`-ing into the nexus
+container and even then constrained by what the image ships.
+
+Today these out-of-band paths are heavily used. Debugging a stuck
+indexer, sampling raw memory rows, inspecting a chroma collection,
+running one-off analytical SQL across the seven domain stores — all
+happen against the file directly. Containerising nexus closes those
+paths by design. The daemon-as-arbiter discipline is the whole
+point, but it means the daemon must **expose first-class
+introspection surfaces** to replace what ad-hoc DB access provides
+today.
+
+**Anticipated surfaces** (to be specified during planning, not
+locked here):
+
+- `nx daemon t2 exec <SQL>` — execute a parameterised read-only
+  query via RPC, output as JSON or table. Read-only by default;
+  explicit `--write` flag for destructive ops gated on a
+  confirmation prompt. Replaces `sqlite3 <file>` for the 90% case.
+- `nx daemon t3 peek <collection>` — paged inspection of a
+  collection's documents / metadata / embeddings. Replaces
+  `chromadb` CLI inspection.
+- `nx daemon t2 schema` / `nx daemon t3 schema` — print live schema
+  (T2 tables, T3 collection metadata) so external tooling can be
+  code-generated against the current shape.
+- `nx daemon t2 export [--table N] [--format jsonl|csv|sqlite]` —
+  snapshot dump to a path the daemon writes (mounted volume in
+  container mode). Replaces sqlite3's `.dump`.
+- `nx daemon t2 import` — reverse operation; required for backup
+  restore parity.
+- **Streaming event log** — RDR-111's ORB projection of T2 change
+  events is the principled answer to "tail -f the database":
+  subscribe to `T2.changed` events filtered by table/project,
+  rendered in the cockpit UI or via `nx daemon t2 events --follow`.
+- **Read-only side-channel socket** — optional second UDS bound to
+  a `readonly` group, exposing only the read surface. Lets external
+  tooling (Grafana, DataDog SQL exporter, custom dashboards) attach
+  without write capability or in-daemon auth code.
+
+**What this RDR commits to**: the introspection surface must be
+**at least as expressive as `sqlite3 <file>` is today for read
+paths** before nexus-in-a-container ships as a supported deployment
+mode. Without that commitment, containerising nexus regresses
+operational visibility — the opposite of what this RDR exists to
+do.
+
+**What this RDR explicitly defers**: an *interactive REPL* surface
+(`nx daemon t2 repl` for a sqlite3-like prompt) is nice-to-have for
+power users but not required for correctness. Planning picks it up
+if cheap; otherwise it falls to a follow-on RDR. The pipe-friendly
+`exec` subcommand is sufficient for scripted workflows.
 
 ### Risks and Mitigations
 
@@ -487,6 +557,17 @@ locked design. Right-size before gate.
 - **Migration**: how do existing on-disk T2/T3 stores get picked up
   by the new daemons? Presumably "the daemon opens the same path the
   old direct client did" — but worth being explicit.
+- **Introspection-surface completeness**: the "at least as expressive
+  as `sqlite3 <file>` for reads" bar is correct for the 90% case;
+  the long tail (recursive CTEs against arbitrary user-supplied SQL,
+  EXPLAIN QUERY PLAN, ATTACH DATABASE for cross-DB joins) needs an
+  explicit decision during planning — accept the regression, ship
+  an escape hatch (`nx daemon t2 exec --raw`), or keep direct-file
+  access as a separately gated "debug" mode.
+- **Container image surface**: if nexus ships as a container, which
+  external paths must remain available — `/tmp` for downloads, the
+  user's git repos for indexing, an output volume for `export`? The
+  container's filesystem contract is part of the introspection story.
 
 ## References
 
@@ -518,3 +599,12 @@ locked design. Right-size before gate.
   makes the fallback essentially free. T3 keeps loopback TCP
   (upstream chromadb constraint). TCP listeners are loopback-only;
   cross-host co-work is still a future RDR.
+- 2026-05-12 — Added **Nexus-in-its-own-container** trade-off
+  subsection anticipating the deployment mode where nexus itself is
+  the container. Ad-hoc DB access (`sqlite3 <file>`, DBeaver, etc.)
+  becomes unavailable; the daemon must therefore expose first-class
+  introspection surfaces (`exec`, `peek`, `schema`, `export`,
+  streaming events, optional read-only side socket) that are at
+  least as expressive as direct-file reads. Cross-references RDR-110
+  (atomic-take CAS unchanged — same SQLite handle, single process,
+  daemon hosts it) and RDR-111 (event-streaming surface).


### PR DESCRIPTION
## Summary

- **RDR-110** — add RDR-112 to `related_rdrs`, append post-acceptance revision note. The atomic-take CAS primitive is unchanged under RDR-112; only its call site moves from direct-file `T2Database` to `T2Client` RPC. WAL multi-process safety remains correct for same-host POSIX; container overlayfs is RDR-112's problem. Sequencing preferred: ship 110 against direct-file first, port to daemon RPC when 112 lands.
- **RDR-112** — add **Nexus-in-its-own-container** trade-off subsection. The daemon-only access pattern doesn't just close off *other* containers from the DB; it closes off the *user* too. `sqlite3 ~/.nexus/t2.db`, DBeaver, ad-hoc SELECT, `chroma utils info` all disappear when nexus ships as its own OCI image. The daemon must therefore expose first-class introspection surfaces (`exec`, `peek`, `schema`, `export`, streaming events, optional read-only side socket) at least as expressive as direct-file reads before container-mode ships as supported. Two new Open Questions added (introspection-surface completeness, container filesystem contract).

## Why now

RDR-110 was Accepted 2026-05-09 before RDR-112 existed and explicitly claims WAL multi-process safety (CAs #1 + #2 Verified). That claim holds for same-host; RDR-112's A2 finding (overlayfs blocks WAL mmap) names the case 110 didn't address. Cross-ref now so 110's planning chain doesn't get blindsided.

The introspection point came up while reviewing 112: today's debugging workflows assume direct file access. Containerising nexus closes that path *by design* — anticipate it now rather than discover it at planning time.

## Test plan

- [x] RDR frontmatter valid (related_rdrs updated)
- [x] No design surface changes in RDR-110 — only revision history + cross-ref
- [x] RDR-112 stays a draft; this is research-phase expansion