### PR TITLE
docs(rdr): triad rework — close 110/111/112 composition gaps; introduce RDR-113

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -135,6 +135,7 @@ An RDR (Research-Design-Review) is a short document that records a technical dec
 | [RDR-110](rdr-110-semantic-tuple-space.md) | Semantic Tuple Space: Unified Coordination Primitive over ChromaDB + SQLite | Architecture | Accepted | 2026-05-09 |
 | [RDR-111](rdr-111-orb-agentic-cockpit-substrate.md) | The ORB: Observable Relay Bus — Hook Projection, Bindings, and C2 Cockpit Substrate | Architecture | Draft | 2026-05-11 |
 | [RDR-112](rdr-112-storage-as-service-container-boundary.md) | Storage-as-Service: Every Persistent Shared-State Store Behind a Daemon, T1 Stays In-Container | Architecture | Draft | 2026-05-12 |
+| [RDR-113](rdr-113-host-trust-model.md) | Host-Trust Model for nexus Daemons: UDS Permissions, Peer Credentials, Single-User v1 | Architecture | Draft | 2026-05-13 |
 
 ---
 

--- a/docs/rdr/rdr-110-semantic-tuple-space.md
+++ b/docs/rdr/rdr-110-semantic-tuple-space.md
@@ -2048,31 +2048,49 @@ has two ordering options.
 CAS primitive is independent of where it runs; the daemon is a
 transport wrapper, not a redesign.
 
-**Revised preference (2026-05-13, RDR-112 gate round 2)**: **a
-hybrid is required for the `block=True` path.** RDR-112 gate
+**Revised preference (2026-05-13, RDR-112 gate round 2)**: a
+hybrid is required for the `block=True` path. RDR-112 gate
 round 1 surfaced that the `data_version`-polling mechanism in
 §RF-9 / §CA #6 — which underwrites `block=True` cross-process
 wake — depends on the same `mmap` semantics that RDR-112 §A2
 verified are broken across container overlayfs bind mounts.
-`data_version` works same-host; it does *not* propagate from
-container to container against an overlayfs-mounted SQLite.
-`block=True` against direct-file T2 from inside a sandbox
-container would silently wedge or miss wakes.
 
-**Concrete revised ordering**:
+**Further-revised scope (2026-05-13, RDR-110/111/112 triad
+analysis)**: the round-2 carve-out was too narrow. The overlayfs
+`mmap` failure is a **class** of bug, not specifically about
+`data_version`. SQLite's single-writer lock — the foundation of
+*every* RDR-110 operation, including the `block=False` CAS at
+§RF-9 — relies on the same `mmap` semantics. Across overlayfs
+bind mounts, two containers each open their own SQLite handle
+that resolves to a forked WAL with its own single-writer lock.
+**Two `block=False` claimants in different containers can both
+win the CAS.** Sweeps (`sweep_expired_claims`,
+`sweep_tombstones`) run against each container's forked WAL and
+produce inconsistent tombstones. The `tuple_claim_log` audit
+captures only its container's view.
 
-- `block=False` (polling, non-blocking) — unaffected; ships in
-  RDR-110 Phase 1 Step 4 as designed. Same-host and containers
-  both correct.
-- `block=True` (cross-process wake via `data_version`) — ships
-  only after the T2 daemon's blocking-take RPC is in place
-  (RDR-112), gated behind `NX_STORAGE_MODE=daemon`. RDR-110
-  Phase 1 Step 4 lands the call sites and the same-host
-  watcher implementation; the path is feature-flagged off until
-  the substrate supports it.
+**Definitive ordering (D3 from the triad rework)**:
 
-The CAS primitive itself is unchanged in either path.
+- **Single-host, single-filesystem** (no container boundaries):
+  direct-file T2 access is correct for both `block=False` and
+  `block=True`. CA #1, CA #2, CA #5, CA #6 hold as Verified for
+  this scope only.
+- **Multi-container or any deployment that crosses an overlayfs
+  bind mount**: all RDR-110 operations require
+  `NX_STORAGE_MODE=daemon`. The daemon owns the single SQLite
+  handle (single lock, single WAL, single `data_version`), and
+  clients call atomic-take / sweep / audit via RPC. `block=True`
+  is implemented daemon-side as a blocking-take RPC.
+- **Phase 1 Step 4** ships the CAS implementation and the
+  same-host watcher as designed. The `block=True` call sites
+  land feature-flagged off until `NX_STORAGE_MODE=daemon` is
+  available; `block=False` ships unconditionally and is correct
+  same-host. **Multi-container deployments must run in daemon
+  mode regardless of `block` value.**
+
+The CAS primitive itself is unchanged in any path; only the
+container-vs-daemon boundary determines correctness.
 
 **No changes to RDR-110's design surface.** `related_rdrs`
-frontmatter updated to include RDR-112; this revision-history note
-records the cross-reference and the sequencing constraint.
+frontmatter includes RDR-112; this revision-history note
+records the cross-reference and the full sequencing constraint.

--- a/docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md
+++ b/docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md
@@ -8,7 +8,7 @@ author: Hal Hildebrand
 reviewed-by: self
 created: 2026-05-11
 related_issues: []
-related_rdrs: [RDR-105, RDR-110]
+related_rdrs: [RDR-105, RDR-110, RDR-112, RDR-113]
 related_tests: []
 implementation_notes: ""
 ---
@@ -154,6 +154,50 @@ This is a **definitive prerequisite** (CA-9), not a conditional: the
 RDR-110 implementor must be notified before Phase 1 Step 6 ships so
 that open registration is included in scope. Without this, the ORB's
 Phase 1 Step 1 (hook-event subspace schema registration) cannot proceed.
+
+### Relationship to RDR-112
+
+RDR-112 ships the storage-as-service daemons that own `tuples.db`,
+`memory.db`, the T3 chroma store, and CatalogDB. Under RDR-112 the
+MCP server is a **client** of the daemons, not the daemon itself —
+the ORB's `_BindingWatcher` and cockpit surface code all run in the
+client process and reach storage exclusively through daemon RPCs.
+
+Specific RDR-112 surfaces RDR-111 consumes:
+
+- **`EventStream(subspace_prefix, since_cursor)`** streaming RPC
+  (RDR-112 Approach §7) — `_BindingWatcher` consumes
+  `tuples/<subspace>` events instead of the direct-SQL `rowid > N`
+  query the pre-rework draft used. The `rowid` cursor protocol is
+  preserved as the wire-level cursor; only the transport changes.
+- **Failure-category demux** on the event stream (`category ∈
+  {data, schema, substrate}`, per RDR-112 §7) — `_BindingWatcher`'s
+  failure-isolation logic depends on this to avoid auto-disabling
+  user bindings when the daemon hiccups (see §Step 6 Watcher
+  failure isolation).
+- **Subspace registry validation is daemon-side** (RDR-112 Approach
+  §8) — the ORB-supplied subspaces (per CA-9) land via
+  `nx daemon t2 subspace add <yaml>` rather than client-side
+  runtime registration.
+- **Migration ownership is daemon-side** (RDR-112 Approach §9) —
+  the `watcher_state` table and the `action_idempotency` table are
+  applied by the daemon at startup, not by the MCP client (CA-10
+  language adjusted accordingly in the gate revision).
+- **Cockpit panel direct-SQL queries** (Steps 8 + 9 + the
+  active-claims and recent-events surfaces) — under RDR-112 these
+  re-route through daemon read RPCs (or the introspection surface
+  `nx daemon t2 exec --raw` for ad-hoc analytical queries; see
+  RDR-112 §Nexus-in-its-own-container). The query shapes are
+  unchanged; only the substrate boundary moves.
+- **Host-trust model** is inherited from RDR-113 (UDS chmod, peer
+  credentials, single-user v1). Cockpit projections respect the
+  same trust boundary as every other daemon client — only the
+  daemon-owner UID sees other-agent tuples and mailbox traffic.
+
+RDR-111 is **blocked on RDR-112 Phase 1** (T2 daemon with
+EventStream RPC) for the binding-watcher pieces. The cockpit
+surfaces that only query (not subscribe) can ship earlier against
+the daemon's read RPCs.
 
 ## Research Findings
 
@@ -751,45 +795,45 @@ MCP event loop. Callers poll status via `binding_list` filtering on
 A `_BindingWatcher` background task (integrated with the FastMCP
 lifespan async task group per RDR-094; **must be `asyncio.create_task`,
 not `threading.Thread`** — the MCP server is async and thread-pool
-dispatch creates reentrancy risk) that polls for new events via **direct
-T2 SQL query** on the `tuples` table.
+dispatch creates reentrancy risk) that consumes new events via the
+**RDR-112 daemon `EventStream` RPC** on the `tuples/<subspace>`
+namespace.
 
-**Retrieval mechanism — intentional internal bypass of `read()` API**:
-RDR-110's `read()` API has no ordered-retrieval or `since_cursor`
-parameter. `_BindingWatcher` is an internal component that runs in the
-same `nx-mcp` process as the tuple store and therefore has direct access
-to `~/.config/nexus/tuples.db` (RDR-110's tuple-space database —
-distinct from `~/.config/nexus/memory.db`). The correct retrieval
-pattern is:
+**Retrieval mechanism — RDR-112 EventStream RPC**: under RDR-112 the
+T2 daemon owns the SQLite handle for `tuples.db`; the MCP server is a
+*client* of the daemon (RDR-112 §Proposed Solution §1 + Approach §7).
+Direct SQL access from inside `nx-mcp` is daemon-internal-only and
+forbidden to clients. The watcher subscribes via:
 
-```sql
--- against ~/.config/nexus/tuples.db
-SELECT rowid, * FROM tuples
-WHERE subspace = ?
-  AND rowid > ?    -- last-seen cursor
-ORDER BY rowid ASC
-LIMIT 100;
+```python
+# Pseudocode — verify signature during implementation.
+async for event in t2_client.event_stream(
+    subspace_prefix="tuples/<subspace>",
+    since_cursor=last_rowid,   # 0 on first connect; persisted across restarts
+):
+    # event = {cursor: rowid, subspace, op, payload_summary, category, ts}
+    ...
 ```
 
-The `rowid` is SQLite's native monotonic row counter — it provides total
-ordering within the table, which is exactly what the watcher needs. This
-is *not* a semantic query and does not belong in the `read()` API surface.
-The intentional design boundary: `read()` is for external MCP callers doing
-associative or structural queries; the watcher is an internal subscriber
-that needs ordered streaming, and it accesses `tuples.db` directly.
+The daemon's EventStream RPC carries the same monotonic `rowid` cursor
+the original direct-SQL pattern used, so the at-least-once semantics
+(below) survive verbatim — only the transport changes. On disconnect,
+the watcher reconnects from its last-acked cursor. `EventStream` is the
+*only* way clients observe tuple changes; the RDR-110 `read()` API
+remains the surface for associative / structural queries by external
+callers.
 
 A `watcher_state` table records the per-subspace cursor (last-seen
-`rowid`). **Database placement**: `watcher_state` should live in
-`tuples.db` (not `memory.db`) so the cursor read and tuple read are in
-the same database, so that only one connection is needed for both reads
-and cursor updates (not transactional atomicity across dispatch and commit
-— dispatch is an async network call that cannot be inside a SQLite
-transaction; see pseudocode below). Add `watcher_state` as a CREATE TABLE in the RDR-110
-tuple-space migration (not in `src/nexus/db/migrations.py`, which manages
-`memory.db`):
+`rowid`). **Database placement**: `watcher_state` lives in `tuples.db`
+alongside the tuple data. Under RDR-112, this table is owned by the T2
+daemon (single SQLite handle); the client-side watcher reads and writes
+its cursor via a dedicated daemon RPC pair (`watcher_state.get`,
+`watcher_state.set`) rather than direct SQL. The schema (owned by
+RDR-110's tuple-space migration, applied daemon-side per RDR-112
+Approach §9):
 
 ```sql
--- in tuples.db migration (RDR-110 implementation)
+-- in tuples.db migration (RDR-110 implementation, daemon-applied)
 CREATE TABLE IF NOT EXISTS watcher_state (
     subspace   TEXT NOT NULL,
     profile    TEXT NOT NULL,
@@ -866,14 +910,32 @@ Action dispatch: `tool_call` type dispatches via the MCP tool API
 field on the action descriptor (default 10s); timeout fires the next
 cursor advance regardless.
 
-**Watcher failure isolation**: any exception in dispatch is caught,
-logged via `structlog.get_logger(__name__)` (the watcher runs inside
-the `nx-mcp` process, so logs flow through the standard structured
-logging pipeline), and the cursor advances past the failed event to
-prevent livelock. A consecutive-failure counter is kept in T2 (small
-keyed table; resets on first successful dispatch) and triggers watcher
-pause after 5 consecutive failures on the same binding (indicating a
-broken binding); the binding is auto-disabled with an error annotation.
+**Watcher failure isolation** — must distinguish failure categories
+to compose correctly with the RDR-112 daemon:
+
+- **Action failure** (the dispatched tool call / `out` / send_message
+  raised). Caught, logged via `structlog.get_logger(__name__)`, cursor
+  advances past the failed event to prevent livelock. Consecutive-
+  failure counter (kept in T2 via `memory_put`) increments; after 5
+  consecutive failures on the same binding the binding is
+  auto-disabled with an error annotation. This is "the user's binding
+  is broken" — the original failure-isolation path, unchanged.
+- **Substrate failure** (RDR-112 daemon down, EventStream RPC
+  disconnect, transient transport error). Logged at WARN; cursor does
+  **not** advance; consecutive-failure counter does **not** increment
+  toward auto-disable. The watcher reconnects with exponential
+  back-off (capped at 30s) and resumes from the last-acked cursor.
+  Substrate hiccups must not silently auto-disable user bindings.
+- **Schema failure** (event payload doesn't match the binding's
+  expected shape — e.g. a registry version mismatch). Logged at ERROR
+  with the binding ID, cursor advances, counter increments. Treated
+  as an action failure: the binding is wrong relative to the current
+  schema and the user needs to fix it.
+
+The EventStream event record carries an optional `category` field
+(per RDR-112 Approach §7); for transport-level errors the watcher
+classifies directly from the exception type without needing daemon
+cooperation.
 
 #### Step 7: Phase 1 CA spikes (gate Phase 2)
 
@@ -1047,3 +1109,4 @@ Other gates:
 | 2026-05-11 | Hal Hildebrand | Post-gate-6 revision (no criticals; all significant and observation issues addressed pre-accept): (SIG-A) replaced `rd`/`in` Linda aliases with `read`/`take` throughout all implementation-facing sections — Bindings CRUD, active-bindings panel, Step 10, Relationship to RDR-110 surfaces sentence, Key Discoveries (bindings, surfaces, cross-process), CA-3 across all references (assumption table, Step 7b spike, Finalization Gate), and the Linda bullet's "ORB uses" clause; added Linda→RDR-110 API name mapping table and usage rule to Relationship to RDR-110 section; (SIG-B) added `layout_state/<profile>` subspace schema block (dimensions: profile, event_type; content: surface_level, demotion_level, ttl_seconds, pinned) to Proposed Solution; added `layout_state.yml` and `connection_manifest.yml` to Step 1 file list; (OBS-1) added `tuple_claim_log` join note for `claimed_at` display field — `tuples` has no `claimed_at` column; (OBS-2) `connection_manifest.yml` now explicit in Step 1; (OBS-3) integration test 3 corrected to distinguish SQL-based panels (active-claims, recent-events) from `read()`-based panel (active-bindings); (OBS-4) Step 2 explicitly documents which hook types are projected (7) and which are excluded (SubagentStart, PermissionRequest) with rationale |
 | 2026-05-11 | Hal Hildebrand | Post-gate-3 revision (all gate-3 BLOCKED issues addressed): (C-G3-1) Added `task_id` (string) and `status` (enum: pending/active/failed) dimensions to bindings subspace schema YAML; documented enabled/status/task_id lifecycle; (S-G3-1) moved `watcher_state` table to `tuples.db` (not `memory.db`) for genuine single-transaction cursor atomicity; corrected "atomic" language; (S-G3-2) added `claim_expires_at > unixepoch()` filter to active-claims panel query in Proposed Solution and Step 8 to exclude expired leases; (S-G3-3) flagged Step 2 bridge registration order as provisional pending CA-8; moved CA-8 spike to new Step 1b (before Step 2); added feature-flag requirement for registration order; (S-G3-4) changed recent-events panel from `rd()` (no time ordering) to direct SQL on `tuples.db` ordered by `created_at DESC`; semantic filter noted as opt-in mode; (S-G3-5) replaced "direct T2 SQL via src/nexus/db/" with explicit `tuples.db` database references throughout; (O1) corrected "six" to "seven" subspaces; (O2) documented PostCompact/PreCompact exclusion with rationale; (O3) updated CA-9 gate condition to outcome-based (confirmed open-registry shipping) not action-based (notification sent) |
 | 2026-05-11 | Hal Hildebrand | Post-gate-7 revision (1 critical + 2 significant + 2 observations all addressed pre-accept): (C-G7-1) removed `PostCompact` from Step 2 bridge registration list — was contradicted by Proposed Solution's explicit exclusion; added `PreCompact` and `PostCompact` to the not-registered list with rationale cross-reference; (SIG-G7-1) replaced three residual `rd()` aliases with `read()` — Step 4 bindings dimension example, Step 6 `_BindingWatcher` rationale paragraph (header + two body references); (SIG-G7-2) corrected "six" → "seven" hook-event subspaces at four remaining sites (Relationship to RDR-110 summary, CA-9 description, CA-9 risk-if-wrong, Phase 1 section header); added `layout_state` to the Relationship-section subspace enumeration; (OBS-G7-1) active-claims display now explicitly extracts `actor` via `json_extract(t.dimensions_json, '$.actor')` — `actor` lives inside `dimensions_json`, not a top-level column; (OBS-G7-2) watcher failure isolation now logs via `structlog` (not "T2 scratch" — category error, scratch is T1); failure counter kept in T2 as before |
+| 2026-05-13 | Hal Hildebrand | **Triad rework (RDR-110/111/112 composition gaps, deep-analyst `a56172936d63fd480`)**: added §Relationship to RDR-112; rewrote §Step 6 binding-watcher to consume RDR-112 `EventStream(subspace_prefix, since_cursor)` RPC instead of direct SQL on `tuples.db` (cursor protocol and at-least-once semantics preserved verbatim; only transport changes); rewrote §Step 6 Watcher failure isolation to distinguish action / substrate / schema failure categories so daemon hiccups do not silently auto-disable user bindings (closes G5); updated `watcher_state` placement to record that the table is daemon-owned and read/written via dedicated RPCs (closes G4 wrt RDR-111 dependency); `related_rdrs` frontmatter extended to include RDR-112 and RDR-113. RDR-111 is now blocked on RDR-112 Phase 1 for the binding-watcher; query-only cockpit surfaces unaffected. |

--- a/docs/rdr/rdr-112-storage-as-service-container-boundary.md
+++ b/docs/rdr/rdr-112-storage-as-service-container-boundary.md
@@ -9,7 +9,7 @@ reviewed-by: self
 created: 2026-05-12
 accepted_date:
 related_issues: []
-related_rdrs: [RDR-004, RDR-041, RDR-105, RDR-108, RDR-110, RDR-111]
+related_rdrs: [RDR-004, RDR-041, RDR-105, RDR-108, RDR-110, RDR-111, RDR-113]
 related_tests: []
 implementation_notes: ""
 ---
@@ -302,10 +302,61 @@ T2 facade and stores (`src/nexus/db/t2/`, `src/nexus/db/memory_store.py`,
    and the socket is reachable → UDS. Else if `NX_T2_ADDR` is set →
    TCP. Else read the discovery file and try UDS first, TCP second.
    Fail loud if neither reaches a live daemon.
-7. **Lifecycle hooks**: each daemon publishes change events to a
-   local pub-sub (RDR-110 tuple space surface), enabling RDR-111's
-   ORB projection without each client having to instrument writes.
-   T2, CatalogDB, and T3 all participate.
+7. **Event stream (wire contract)**: each daemon exposes a
+   streaming RPC `EventStream(subspace_prefix, since_cursor) →
+   Stream<Event>` over the same UDS/TCP transport as the regular
+   RPCs. Event records carry `{cursor: rowid, subspace, op,
+   payload_summary, ts}`. Cursor is monotonic `rowid > N` within
+   a subspace; consumers persist their last-acked cursor and
+   reconnect from there after a disconnect (at-least-once
+   delivery). Subspace-prefix matching is glob-style (e.g.
+   `tuples/*`, `daemon/*/lifecycle`). The stream is the **only**
+   way clients observe change — direct SQL polling on the
+   underlying SQLite is daemon-internal and forbidden to clients.
+
+   **Reserved subspaces**:
+   - `tuples/<subspace>` — tuple-space change events (RDR-110
+     consumers; the projection RDR-111 §Step 6 watcher consumes).
+   - `daemon/<name>/lifecycle` — substrate operational events
+     (started, stopping, migration-applied, client-connected,
+     client-disconnected, sweep-fired). First-class so a cockpit
+     binding "show me when the daemon restarts" is expressible
+     on the same bus as any other observation.
+
+   **Failure-category demux**: events carry an optional
+   `category ∈ {data, schema, substrate}` field. Consumers
+   distinguish substrate failures (transport/daemon faults) from
+   action failures (their own dispatch errors) — RDR-111
+   §Watcher failure isolation depends on this demux to avoid
+   auto-disabling user bindings when the daemon hiccups.
+
+8. **Subspace registry — daemon validates**: tuple-space
+   subspace schemas (RDR-110 §Subspace registry) ship with each
+   daemon and are validated daemon-side at startup, not in the
+   MCP client. The daemon-client version handshake carries a
+   subspace-schema digest; client refuses to connect on
+   mismatch. Rationale: the daemon owns the data and must
+   enforce its own invariants regardless of which client
+   connects. RDR-111's plugin-supplied subspaces (RDR-111 CA-9)
+   land via the daemon's `nx daemon t2 subspace add <yaml>`
+   admin RPC, not by the client registering at runtime.
+
+9. **Schema migration ownership**: the daemon is the **sole
+   migration runner**. On startup the daemon checks its own
+   schema version and applies pending migrations against its
+   single SQLite handle before accepting client connections.
+   Clients carry an expected-schema-version constant; on
+   connect, the handshake compares and fails loud if the daemon
+   is behind (instruct user to `nx daemon t2 migrate`) or ahead
+   (instruct user to upgrade the client). The MCP server stops
+   driving migrations entirely (per RDR-110 Phase 1 Step 2 needs
+   updating).
+
+10. **Original "Lifecycle hooks" promise**: superseded by items
+    7–9 above, which spell out the event-stream protocol,
+    failure demux, registry validation, and migration ownership
+    explicitly. T2, CatalogDB, and T3 all participate in the
+    EventStream RPC; same wire contract per daemon.
 
 ### Existing Infrastructure Audit
 
@@ -835,3 +886,28 @@ the planner's job, not this RDR's.
   - All round-1 closeouts (C2/S1/S2/S3/O1/O2/O3) verified clean
     by round-2 critic; no regressions introduced by round-1
     edits.
+- 2026-05-13 — **Triad rework (110/111/112 composition gaps)**:
+  deep-analyst pass `a56172936d63fd480` surfaced 10 gaps between
+  the three RDRs that local gates couldn't see. User chose deep
+  rework (option D). Three load-bearing decisions:
+  - **D1**: MCP server is a **client** of the daemon, not the
+    daemon itself. Recorded here; closes G10. RDR-110/111
+    watcher placement updates follow.
+  - **D2**: Event bus is the `EventStream(subspace_prefix,
+    since_cursor)` streaming RPC on the daemon (new Approach
+    §7 above). Closes G2 (RDR-111 watcher subscription protocol)
+    and G8 (daemon lifecycle events first-class on same bus).
+  - **D3**: Under `NX_STORAGE_MODE=daemon`, **no client ever
+    touches the SQLite file**. Direct-file mode is single-host
+    single-filesystem only. Recorded in RDR-110 revision-history
+    "Further-revised scope" block. Closes G1 (overlayfs
+    correctness extends past `data_version` to the entire CAS
+    primitive, sweeps, audit).
+  This revision also adds Approach §8 (subspace registry —
+  daemon validates, closing G3), Approach §9 (daemon is sole
+  migration runner, closing G4), failure-category demux on the
+  event stream (closing G5 with the matching consumer-side
+  change in RDR-111), and forward-references RDR-113 for host
+  trust / UDS auth (closing G6). G7 closes via a one-line
+  forward-reference in `docs/workflow-engine-synthesis.md`. G9
+  (cross-triad integration test) becomes a planning-time bead.

--- a/docs/rdr/rdr-113-host-trust-model.md
+++ b/docs/rdr/rdr-113-host-trust-model.md
@@ -1,0 +1,398 @@
+---
+title: "Host-Trust Model for nexus Daemons: UDS Permissions, Peer Credentials, Single-User v1"
+id: RDR-113
+type: Architecture
+status: draft
+priority: medium
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-05-13
+accepted_date:
+related_issues: []
+related_rdrs: [RDR-105, RDR-110, RDR-111, RDR-112]
+related_tests: []
+implementation_notes: ""
+---
+
+# RDR-113: Host-Trust Model for nexus Daemons: UDS Permissions, Peer Credentials, Single-User v1
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+RDR-112 puts T2, T3, and CatalogDB behind daemons that accept
+connections over a unix-domain socket (UDS-primary) or loopback
+TCP (fallback). The v1 framing in RDR-112 §Cross-Cutting Concerns
+says "no auth in v1 — local daemons, UDS uses unix file
+permissions, TCP listeners are loopback-only." That sentence is
+load-bearing for cross-RDR safety claims but no concrete trust
+model is committed: the UDS `chmod` value is unspecified, the
+TCP listener's bind address is not pinned, and there is no
+explicit answer to "who can attach to my daemon?"
+
+RDR-111's ORB cockpit raises the stakes. Its panels project
+*every host agent's state* — running tools, pending bindings,
+hook events. RDR-110's tuple space carries `mailbox/<agent>`
+subspaces (agent-to-agent direct messaging). If a second user
+on the same host can attach to the daemon, that user can read
+every memory entry, every in-flight tuple, every hook event,
+and every mailbox — and can post messages impersonating any
+agent.
+
+For nexus's actual deployment model — single-user developer
+laptops, occasionally a shared dev VM — the threat is small but
+real. For the daemon model to be defensible at all, the trust
+boundary needs to be named and enforced, not assumed.
+
+### Enumerated gaps to close
+
+#### Gap 1: UDS socket file mode is unspecified
+
+RDR-112 references "unix file permissions" but never commits to
+a value. The default umask on most systems is `0022`, which
+would create the socket as `0755` (world-readable, owner-write).
+Any local user could `connect()` to the daemon. The fix is a
+specific `chmod` value, applied by the daemon at bind time
+before announcing the address.
+
+#### Gap 2: TCP fallback bind address is not pinned
+
+RDR-112 says "TCP listeners are loopback-only" in prose but
+does not commit to `127.0.0.1` (vs `0.0.0.0`) in the design
+artefact. Future planning could read the prose as advisory and
+bind a routable interface. A binding-time commitment prevents
+the silent regression.
+
+#### Gap 3: No peer-credential check on connect
+
+UDS supports `SO_PEERCRED` (Linux) and `LOCAL_PEERCRED` (macOS),
+which return the connecting peer's UID. The daemon currently
+performs no check. On a multi-user host (rare but real for dev
+VMs), file permissions alone may be circumventable — for
+instance, if the socket path traverses a directory the second
+user controls. A peer-UID check at accept time is cheap and
+closes the residual gap.
+
+#### Gap 4: No commitment on what v1 *does not* protect against
+
+"Single-user v1" needs a written boundary. Threats RDR-113
+explicitly does *not* address: a malicious local process
+running as the same user (it can read the SQLite file directly
+if the daemon is down, and can connect to the UDS regardless);
+a compromised parent process injecting `NX_T2_ADDR` env vars;
+cross-host attacks (out of scope per RDR-112). Naming the
+boundary prevents over-claiming.
+
+## Context
+
+### Background
+
+This RDR was spun out of the RDR-110/111/112 triad rework
+(2026-05-13) as the closure for gap G6. The triad analysis
+flagged that RDR-112's auth deferral was vague enough that
+"no auth in v1" could be read as "we'll get to it later," when
+the actual stance — for the daemon model to compose safely with
+RDR-110's mailbox tuples and RDR-111's cockpit projection —
+needs to be "v1 enforces single-user host trust via UDS
+permissions and peer credentials." That stance is small enough
+to land in a mini-RDR, large enough to deserve its own gate.
+
+### Technical Environment
+
+- **UDS sockets**: stdlib `socketserver` / `multiprocessing.connection`.
+  `socket.bind()` creates the path with current umask; daemon
+  must `os.chmod()` after bind to set the desired mode.
+- **TCP fallback**: stdlib `socketserver` with `server_address =
+  ('127.0.0.1', 0)` for explicit loopback bind.
+- **Peer credentials**: `socket.SO_PEERCRED` (Linux), via
+  `getsockopt(SOL_SOCKET, SO_PEERCRED, ...)`; `LOCAL_PEERCRED`
+  (macOS), via `getsockopt(SOL_LOCAL, LOCAL_PEERCRED, ...)`.
+  Both available without third-party deps.
+
+## Research Findings
+
+### Investigation
+
+- **Inherited pattern from RDR-105**: The T1 chroma server
+  spawned at `session.py:494-504` is a similar host-local
+  daemon. Inspecting its current bind-time behaviour: TCP only,
+  port 0 (dynamic), bound to whatever interface chromadb's HTTP
+  server defaults to (loopback in practice, but not enforced).
+  RDR-113 tightens this pattern rather than inventing one from
+  scratch.
+- **Docker socket precedent**: `/var/run/docker.sock` ships
+  `0660` with `root:docker` ownership; users in the `docker`
+  group connect. nexus's analogue: `0600` with the running
+  user's UID; no group ACL in v1.
+- **PostgreSQL UDS precedent**: peer authentication via
+  `pg_hba.conf` checks `SO_PEERCRED` UID against database role.
+  nexus v1 is simpler: peer UID must equal the daemon's UID, no
+  multi-user mapping.
+
+### Key Discoveries
+
+- **Verified**: `os.chmod(socket_path, 0o600)` after
+  `socket.bind()` is the standard way to restrict UDS access to
+  the owner. Verified against stdlib docs and a quick spike.
+- **Documented**: `SO_PEERCRED` returns `(pid, uid, gid)` on
+  Linux; `LOCAL_PEERCRED` returns `xucred` on macOS. Both work
+  without setting any flag on the listening socket beforehand.
+- **Assumed**: TCP loopback peers cannot be reliably identified.
+  `SO_PEERCRED` does not apply to TCP. The v1 stance accepts
+  this — TCP fallback is for orchestrator-injected access
+  (containers, VMs), where the orchestrator is the trust
+  boundary, not the daemon.
+
+### Critical Assumptions
+
+- [ ] **A1**: `os.chmod(0o600)` on the UDS path is honored
+  before any client `connect()` attempt — i.e., there is no
+  race window between `bind()` and `chmod()` where a fast peer
+  could attach with default-umask permissions.
+  — **Status**: Unverified — **Method**: Spike or source-search
+  Python `socketserver` internals to confirm a clean ordering.
+- [ ] **A2**: `SO_PEERCRED` / `LOCAL_PEERCRED` reliably return
+  the *originator* of the connection, not a forwarding proxy
+  (relevant if the user later puts the daemon behind a
+  socket-relay).
+  — **Status**: Unverified — **Method**: Docs Only is
+  sufficient for v1; revisit if proxying is introduced.
+
+## Proposed Solution
+
+### Approach
+
+**v1 trust model: single-user host, daemon owner == client owner.**
+
+1. **UDS bind discipline** (T2, T3, CatalogDB daemons):
+   - `socket.bind(path)` followed immediately by
+     `os.chmod(path, 0o600)`.
+   - Daemon refuses to start if `os.geteuid() != os.stat(path).st_uid`
+     after chmod (sanity check).
+   - Socket directory (`~/.config/nexus/sockets/` or similar)
+     created with `0o700` if not present.
+
+2. **TCP bind discipline**:
+   - `server_address = ('127.0.0.1', port)`. Hard-coded
+     loopback; never `0.0.0.0`, never the host's external IP,
+     never a `--bind-host` flag in v1.
+   - `port=0` for dynamic allocation; actual port goes into
+     discovery file and stdout announcement.
+
+3. **Peer-UID check on accept**:
+   - For UDS connections: read `SO_PEERCRED` / `LOCAL_PEERCRED`;
+     reject with a clear error if peer UID ≠ daemon UID.
+   - For TCP connections: no UID check (loopback only; trust
+     boundary is the orchestrator).
+   - Rejection is logged at INFO with peer PID + UID for audit.
+
+4. **No in-protocol auth in v1**:
+   - No tokens, no challenge/response, no TLS. The UDS/TCP
+     bind discipline plus peer-cred check is the entire trust
+     mechanism.
+   - Future RDR will add token-based auth for cross-host /
+     multi-user / federated deployments.
+
+5. **Explicit non-goals (named in §Threat Model below)**:
+   - Same-user malicious processes (they own the socket and the
+     SQLite file directly; defence against this is outside
+     nexus's trust boundary).
+   - Compromised parent processes injecting `NX_T2_ADDR`.
+   - Cross-host attacks (RDR-112 out of scope).
+
+### Threat Model
+
+| Threat | Mitigation | Residual risk |
+| --- | --- | --- |
+| Second user on host attaches to my UDS | `chmod 0600` + peer-UID check | None (v1) |
+| Second user crafts TCP connection to my daemon | Loopback bind + peer cannot reach loopback as another user | None (single-host) |
+| Same-user malicious process | **Not addressed in v1** | Accepted — user owns the data |
+| Daemon impersonation (rogue process binds the path first) | Discovery file carries PID + start time; client verifies via `/proc` or `ps` | Spike needed (A1-adjacent) |
+| Cross-host attacker | **Not addressed in v1** | RDR-112 out of scope |
+| TCP listener reaches the network | Hard-coded `127.0.0.1` bind, no flag to override | None (v1) |
+
+### Decision Rationale
+
+Minimum-viable trust model that closes the visible gap (G6)
+without inventing auth code we don't yet need. The threat model
+matches nexus's actual deployment (single-user developer
+laptop), names the cases it explicitly doesn't protect against,
+and leaves a clean seam for a future auth RDR if/when the
+threat model expands.
+
+## Alternatives Considered
+
+### Alternative 1: Token-based auth in v1
+
+**Description**: Daemon generates a token at startup, writes it
+to the discovery file alongside the socket address; clients
+must present the token on every RPC.
+
+**Pros**:
+- Closes the same-user-malicious-process threat (process needs
+  read access to the discovery file *and* the socket).
+- Forward-compatible with cross-host auth.
+
+**Cons**:
+- The discovery file is in the same place the malicious process
+  would already have read access to. Net protection is small.
+- Adds RPC overhead and token-rotation lifecycle for marginal
+  benefit at v1 scale.
+
+**Reason for rejection**: Cost-benefit doesn't justify v1.
+Token auth lands when the threat model justifies it (multi-user
+or cross-host).
+
+### Briefly Rejected
+
+- **mTLS**: Heavy; appropriate for cross-host, not single-host.
+- **Group-based UDS ACLs** (`chmod 0660` + group): unnecessary
+  generalisation for single-user v1; can land later if shared
+  dev VMs become a supported deployment.
+
+## Trade-offs
+
+### Consequences
+
+- (+) Closes G6 (multi-user host exposure) at full v1 scope.
+- (+) Threat model written down — over-claiming prevented.
+- (−) Same-user malicious process is explicitly out of scope;
+  if a user's threat model includes that, RDR-113 doesn't help.
+- (−) Peer-cred check adds one `getsockopt()` per accept;
+  negligible.
+
+### Risks and Mitigations
+
+- **Risk**: Race window between `bind()` and `chmod()`.
+  **Mitigation**: A1 spike confirms ordering; if a race exists,
+  bind to a temp path with `0o700` parent dir and atomic-rename
+  in place of in-place chmod.
+- **Risk**: macOS `LOCAL_PEERCRED` quirks (different struct
+  shape from Linux `SO_PEERCRED`).
+  **Mitigation**: platform-specific accessor in `nexus.daemon.peer`;
+  unit tests on both OS.
+
+### Failure Modes
+
+- **UDS chmod fails** (e.g., filesystem doesn't support it):
+  daemon fails to start with a clear error. No silent fallback.
+- **Peer-cred rejection**: client sees a `PermissionDenied`
+  RPC error with a message naming the daemon's expected UID and
+  the peer's actual UID. Logged daemon-side.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] RDR-112 accepted (this RDR layers onto its daemon model).
+- [ ] A1 verified (no `bind()`-to-`chmod()` race).
+
+### Minimum Viable Validation
+
+Two users on the same host. User A starts `nx daemon t2`. User
+B tries to `nx memory get` against User A's socket path. The
+attempt must fail loud with a peer-UID rejection message — not
+hang, not silently fall back, not return a stale read.
+
+### Phase 1: Daemon-side enforcement
+
+To be expanded during `/nx:create-plan`.
+
+### Day 2 Operations
+
+| Resource | List | Info | Delete | Verify | Backup |
+| --- | --- | --- | --- | --- | --- |
+| UDS socket file | `ls -la <path>` | `stat <path>` | daemon stop | `stat` mode == `0600` | n/a |
+| TCP bind address | `ss -tlnp | grep nx-daemon` | discovery file | daemon stop | bind == `127.0.0.1:N` | n/a |
+
+### New Dependencies
+
+None. Stdlib `socket`, `os`, `getsockopt`.
+
+## Test Plan
+
+- **Scenario**: Daemon binds UDS; check `os.stat(path).st_mode & 0o777 == 0o600`. — **Verify**: passes.
+- **Scenario**: User B (different UID) connects to User A's UDS. — **Verify**: connect fails or accept rejects with clear message.
+- **Scenario**: Daemon TCP bind. — **Verify**: `ss -tln` shows `127.0.0.1:N`, not `0.0.0.0:N`.
+- **Scenario**: `LOCAL_PEERCRED` path on macOS. — **Verify**: peer UID parsed correctly.
+- **Scenario**: Race between `bind()` and `chmod()`. — **Verify**: no window where a different-UID peer can connect (A1).
+
+## Validation
+
+### Testing Strategy
+
+1. Unit tests for the peer-cred accessor on Linux + macOS.
+2. Integration test: two-user MVV scenario (CI uses sudo or
+   `unshare -U` to fake a second UID).
+3. Negative test: TCP bind never exposes a non-loopback
+   interface.
+
+### Performance Expectations
+
+`getsockopt(SO_PEERCRED)` is a single syscall on accept;
+negligible. No measurable overhead expected.
+
+## Finalization Gate
+
+> Complete each item with a written response before marking
+> this RDR as **Accepted**.
+
+### Contradiction Check
+
+To be filled at gate time. Pre-check: this RDR layers cleanly
+on RDR-112 (no contradiction); RDR-110 and RDR-111 inherit the
+trust boundary without changes (they observe via the daemon,
+which now performs the peer check).
+
+### Assumption Verification
+
+A1 and A2 above; both Unverified at draft. A1 needs a small
+spike before accept.
+
+### Scope Verification
+
+MVV (cross-user rejection) is in scope, not deferred. Single
+end-to-end test using two host UIDs.
+
+### Cross-Cutting Concerns
+
+- **Versioning**: trust model is invariant across daemon
+  versions; no handshake field needed.
+- **Build tool compatibility**: stdlib only.
+- **Licensing**: N/A.
+- **Deployment model**: single-user host (named explicitly).
+- **IDE compatibility**: N/A.
+- **Incremental adoption**: enforced from daemon v1; no flag.
+- **Secret/credential lifecycle**: N/A (no secrets in v1).
+- **Memory management**: N/A.
+
+### Proportionality
+
+Mini-RDR; right-sized for a single closure of G6.
+
+## Open Questions
+
+- **Future auth surface**: when the threat model expands
+  (cross-host, multi-user, federated), token-based auth lands
+  in a follow-on RDR. RDR-113's discipline survives that change
+  as the host-local v1 path.
+- **`docker:docker` group analogue**: if shared dev VMs become
+  supported, RDR-113 v2 may add group-based ACLs (`chmod 0660`).
+  Deferred.
+
+## References
+
+- RDR-105: T1 Chroma Architecture — Env Passdown (the
+  precedent for host-local daemon spawning).
+- RDR-110: Semantic Tuple Space (mailbox subspaces inherit the
+  trust boundary).
+- RDR-111: ORB Observable Relay Bus (cockpit projection
+  inherits the trust boundary).
+- RDR-112: Storage-as-Service (this RDR closes its G6 gap).
+- POSIX `socket(7)`, `unix(7)`, `SO_PEERCRED` Linux man page.
+
+## Revision History
+
+- 2026-05-13 — Initial draft. Spun out of RDR-110/111/112 triad
+  rework as the closure for gap G6.

--- a/docs/workflow-engine-synthesis.md
+++ b/docs/workflow-engine-synthesis.md
@@ -54,3 +54,16 @@ Novelty is "nobody else had this constraint" (LLMs + MCP standardization 2024-20
 
 ## Sources cited
 Parmar 2026 paper; MCP 2026 roadmap; ext-apps spec; Restate/Inngest/Step Functions docs; LangGraph checkpointer code; Serverless Workflow Spec; Kai Waehner durable-execution survey; Temporal blog; Argo Workflows suspend/resume; Zigflow YAML-DSL-for-Temporal article.
+
+## RDR-110/111/112 triad relationship (2026-05-13)
+
+The workflow engine slots in as another consumer of the RDR-110 tuple
+space, the RDR-111 ORB bus, and the RDR-112 daemons — no retrofit
+required on any of the three. One load-bearing constraint: cross-
+container coordination (workflow steps that span sandbox boundaries)
+is gated on `NX_STORAGE_MODE=daemon` per the RDR-112 sequencing
+decision. Same-host single-FS deployments can use direct-file mode
+for early prototyping; any deployment that crosses an overlayfs bind
+mount must run the T2 daemon. Checkpointer surfaces compose as
+tuple-space subspaces; durable-execution wake semantics land on the
+RDR-112 `EventStream` RPC. Host trust inherited from RDR-113.


### PR DESCRIPTION
## Summary

Deep-analyst pass on the RDR-110/111/112 triad surfaced 10 composition gaps local per-RDR gates couldn't see. Architect-planner produced a phased rework. This PR executes Phase B (the document edits).

## Three load-bearing decisions

- **D1** — MCP server is a **client** of the daemon, not the daemon itself. (G10)
- **D2** — Event bus is \`EventStream(subspace_prefix, since_cursor)\` streaming RPC on each daemon; cursor = \`rowid > N\`; reserved subspaces \`tuples/*\` (data) and \`daemon/*/lifecycle\` (substrate ops). (G2, G8)
- **D3** — Under \`NX_STORAGE_MODE=daemon\` no client ever touches the SQLite file. Direct-file mode is single-host-single-FS only. (G1 at full scope — overlayfs \`mmap\` breaks the entire CAS, not just \`data_version\`.)

## Gap coverage

| Gap | Closure |
|---|---|
| G1 | RDR-110 revision history "Further-revised scope" — overlayfs carve-out extended to all RDR-110 ops |
| G2 | RDR-112 Approach §7 EventStream RPC + RDR-111 §Step 6 rewrite consuming it |
| G3 | RDR-112 Approach §8 — daemon validates subspace registry |
| G4 | RDR-112 Approach §9 — daemon is sole migration runner |
| G5 | RDR-111 §Step 6 Watcher failure isolation distinguishes action/substrate/schema |
| G6 | **New RDR-113** — host-trust model (UDS 0600, peer-cred, single-user v1) |
| G7 | One-paragraph forward-reference in docs/workflow-engine-synthesis.md |
| G8 | RDR-112 §7 reserves \`daemon/*/lifecycle\` subspace |
| G9 | Planning-time bead (deferred per plan) |
| G10 | D1 above, recorded in RDR-112 revision history |

## Files

- \`docs/rdr/rdr-110-semantic-tuple-space.md\` — amend revision history, no design surface change
- \`docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md\` — §Relationship to RDR-112 added; §Step 6 rewritten; failure-isolation rewritten
- \`docs/rdr/rdr-112-storage-as-service-container-boundary.md\` — Approach §7–§10, related_rdrs +RDR-113, revision history
- \`docs/rdr/rdr-113-host-trust-model.md\` — **new** mini-RDR
- \`docs/rdr/README.md\` — RDR-113 row
- \`docs/workflow-engine-synthesis.md\` — triad relationship section

## Next (post-merge, per plan)

- Gate cycle: \`/nx:rdr-gate 113\` → pause → accept; \`/nx:rdr-gate 112\` light re-gate (G1/G2 verification) → pause → accept; \`/nx:rdr-gate 111\` full re-gate (Step 6 is structural) → pause → accept.
- G9 cross-triad integration test → planning-time bead.
- RDR-110 in-flight bead audit for container-correctness references.

T2 plan persisted: \`nexus/rework-plan-rdr-110-111-112-triad.md\` (id 1239).

## Test plan

- [x] All four files build (RDRs are pure markdown)
- [x] README index row for RDR-113 added
- [x] frontmatter related_rdrs cross-references consistent: 111↔112, 111↔113, 112↔113
- [ ] Gate cycle runs are follow-up PRs, not bundled here