### PR TITLE
fix(catalog): unbreak CI — route delete-cascade through Catalog API (RDR-101 Phase 3 ε)

### DIFF
--- a/src/nexus/catalog/catalog.py
+++ b/src/nexus/catalog/catalog.py
@@ -1399,6 +1399,50 @@ class Catalog:
         finally:
             self._release_lock(dir_fd)
 
+    def delete_collection_projection(self, name: str, *, reason: str) -> bool:
+        """Drop the ``collections`` projection row for ``name``.
+
+        Returns ``True`` if a row was deleted, ``False`` if there was
+        nothing to delete. Honors the ``_event_sourced_enabled`` split
+        used by every other catalog mutator: in event-sourced mode the
+        ``CollectionDeleted`` event is canonical and the projector
+        applies it; in legacy mode SQLite is written directly and the
+        event is shadow-emitted.
+
+        This method exists so callers outside ``src/nexus/catalog/``
+        (e.g. ``commands/collection.py``'s delete cascade) do not have
+        to reach into ``self._db`` directly — RDR-101 Phase 3 ε lints
+        forbid catalog writes outside the projector module. Cascade
+        callers stay clean by routing through this verb.
+        """
+        from nexus.catalog.events import CollectionDeletedPayload  # noqa: PLC0415
+
+        dir_fd = self._acquire_lock()
+        try:
+            row_before = self._db.execute(
+                "SELECT 1 FROM collections WHERE name = ?", (name,),
+            ).fetchone()
+            if row_before is None:
+                return False
+            event = _make_event(
+                CollectionDeletedPayload(coll_id=name, reason=reason),
+                v=0,
+            )
+            if self._event_sourced_enabled:
+                self._write_to_event_log(event)
+                self._projector.apply(event)
+                self._db.commit()
+            else:
+                self._db.execute(
+                    "DELETE FROM collections WHERE name = ?",
+                    (name,),
+                )
+                self._db.commit()
+                self._emit_shadow_event(event)
+            return True
+        finally:
+            self._release_lock(dir_fd)
+
     def list_collections(self) -> list[dict]:
         """Delegates to ``_DocumentOps.list_collections`` (nexus-mbm)."""
         return self._docs.list_collections()

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -192,32 +192,13 @@ def delete_cmd(name: str, yes: bool) -> None:
             # nexus-vxz3: emit CollectionDeleted event so replay
             # produces SQLite state matching the live delete. The
             # projector's _v0_collection_deleted handler drops the
-            # projection row.
-            from nexus.catalog.events import CollectionDeletedPayload
-            from nexus.catalog import catalog as _cat_mod
-
-            row_before = cat._db.execute(
-                "SELECT 1 FROM collections WHERE name = ?", (name,),
-            ).fetchone()
-            if row_before is not None:
-                event = _cat_mod._make_event(
-                    CollectionDeletedPayload(
-                        coll_id=name,
-                        reason="nx collection delete",
-                    ),
-                    v=0,
-                )
-                if cat._event_sourced_enabled:
-                    cat._write_to_event_log(event)
-                    cat._projector.apply(event)
-                    cat._db.commit()
-                else:
-                    cat._db.execute(
-                        "DELETE FROM collections WHERE name = ?",
-                        (name,),
-                    )
-                    cat._db.commit()
-                    cat._emit_shadow_event(event)
+            # projection row. Routed through Catalog.delete_collection_projection
+            # so the SQL stays inside src/nexus/catalog/ — RDR-101
+            # Phase 3 ε lint gate forbids direct catalog writes from
+            # outside the projector module.
+            if cat.delete_collection_projection(
+                name, reason="nx collection delete"
+            ):
                 catalog_projection_deleted = 1
     except Exception as exc:
         click.echo(f"warn: catalog cascade failed: {exc}", err=True)


### PR DESCRIPTION
## Summary

CI has been red on \`main\` since 2026-05-12 (PR #722) because the delete-cascade in \`src/nexus/commands/collection.py\` reaches into \`cat._db.execute("DELETE FROM collections ...")\` directly, which violates the RDR-101 Phase 3 ε lint gate (\`tests/test_no_direct_catalog_writes_outside_projector.py\`).

## Fix

- Add \`Catalog.delete_collection_projection(name, *, reason)\` to \`src/nexus/catalog/catalog.py\`, modeled on the existing \`register_collection\` shape:
  - acquires the catalog lock
  - short-circuits if the row doesn't exist (returns \`False\`)
  - dispatches on \`_event_sourced_enabled\`: ES path = \`write_to_event_log\` → \`projector.apply\` → commit; legacy path = direct DELETE → commit → \`_emit_shadow_event\`
  - returns \`True\` if a row was deleted
- \`commands/collection.py\` cascade calls the new verb. ES/non-ES split moves into the catalog module where the SQL is allowed; cascade caller stays clean.

## Verification

\`\`\`
tests/test_no_direct_catalog_writes_outside_projector.py        17/17 PASS
tests/test_collection_cmd.py                                    *
tests/test_catalog.py                                           *
tests/test_catalog_event_log.py                                 *
tests/test_catalog_event_sourced_mutators.py                    *
tests/test_catalog_doctor_replay_equality.py                    *
tests/test_catalog_shadow_emit.py                               *
                                                          229/229 PASS
\`\`\`

## Root cause

PR #722's description claimed "320 tests pass across test_indexer + test_collection_cmd + test_catalog + test_catalog_event_log + test_catalog_event_sourced_mutators + test_catalog_doctor_replay_equality + test_catalog_shadow_emit" — but the ε-lint test wasn't in the cited list, so the violation slipped past the suite the author ran.

## Test plan

- [x] Lint gate green (17/17)
- [x] Catalog functional tests green (229/229)
- [ ] CI full suite green after merge (this is the goal)