### PR TITLE
test(phase5-doc-cite): tolerate leading log lines in JSON-parsed stdout

### DIFF
--- a/tests/test_phase5_doc_cite.py
+++ b/tests/test_phase5_doc_cite.py
@@ -24,6 +24,26 @@ import pytest
 from click.testing import CliRunner
 
 
+def _parse_json_payload(stdout: str) -> dict:
+    """JSON-load `stdout`, tolerating leading structlog warning lines.
+
+    Under CliRunner in CI, stderr is merged into stdout. Process-scoped
+    one-shot WARNINGs (e.g. ``_chash_fallback_warned``,
+    ``migrate_document_aspects_pk_skip_no_catalog``) can fire on the
+    first test that triggers them — and that test is order-dependent,
+    so robust JSON-parsing here is cheaper than chasing every new
+    one-shot through pre-consumption.
+
+    Strategy: find the first ``{`` (the JSON payload always starts with
+    an object) and parse from there.
+    """
+    idx = stdout.find("{")
+    if idx == -1:
+        # No JSON object — let json.loads raise the standard error.
+        return json.loads(stdout)
+    return json.loads(stdout[idx:])
+
+
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 
 
@@ -154,7 +174,7 @@ class TestCiteJsonSchema:
             )
 
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.stdout)
+        payload = _parse_json_payload(result.stdout)
         assert "candidates" in payload
         assert "query" in payload
         assert "threshold_met" in payload
@@ -283,5 +303,5 @@ class TestCiteTiedCandidatesNote:
             )
 
         assert result.exit_code == 0, result.output
-        payload = json.loads(result.stdout)
+        payload = _parse_json_payload(result.stdout)
         assert len(payload["candidates"]) == 2


### PR DESCRIPTION
## Summary

CI run 25809392645 (post-#733) hit:

\`\`\`
FAILED tests/test_phase5_doc_cite.py::TestCiteTiedCandidatesNote::test_tied_candidates_json_returns_all
  json.decoder.JSONDecodeError: Extra data: line 1 column 5 (char 4)
\`\`\`

Cause: CliRunner merges stderr into stdout under CI. A structlog WARNING (\`migrate_document_aspects_pk_skip_no_catalog\`) fires on whichever test first triggers a T2 open against a missing catalog DB. Order-dependent; this run happened to fire the warning during the cite-tied-candidates test, prefixing the JSON output and breaking \`json.loads\`.

The test file already pre-consumes \`_chash_fallback_warned\` to dodge one specific one-shot leak. Chasing every new warning that gets added would be a treadmill.

## Fix

Add a small \`_parse_json_payload(stdout)\` helper that locates the first \`{\` (the JSON payload is always an object) and parses from there. Both \`json.loads(result.stdout)\` call sites in the file now go through it. No production-code change.

## Verification

\`\`\`
tests/test_phase5_doc_cite.py        6/6 PASS
\`\`\`

## Root cause unrelated to PR #733

The migration warning fires from \`src/nexus/db/migrations.py:2500\`, not from any code path the catalog-delete-cascade fix in #733 touched. The previous CI run (RDR-111 gate PR, before #733) had this test passing only because the earlier ε-lint failure prevented later tests from running long enough to surface the order-dependent leak. Post-#733, the suite progresses further and the flake becomes visible.