### PR TITLE
docs(rdr-112): light re-gate PASSED post-triad-rework — lint enforcement committed

### DIFF
--- a/docs/rdr/rdr-112-storage-as-service-container-boundary.md
+++ b/docs/rdr/rdr-112-storage-as-service-container-boundary.md
@@ -285,9 +285,27 @@ T2 facade and stores (`src/nexus/db/t2/`, `src/nexus/db/memory_store.py`,
 5. **Any future persistent store** is added as a domain inside an
    existing daemon (preferred) or as a new daemon (only if a
    first-class operational separation is needed). Direct
-   `sqlite3.connect()` / `chromadb.PersistentClient()` outside a
-   daemon process becomes a lint-checked anti-pattern, enforced by
-   `nx doctor` or a CI rule.
+   `sqlite3.connect()` / `chromadb.PersistentClient()` outside
+   `src/nexus/db/` daemon-internal code becomes a lint-checked
+   anti-pattern. **Enforcement (committed)**:
+   - **Tool**: `nx doctor --check-storage-boundary` — an AST-based
+     scan modelled on the existing
+     `tests/test_no_direct_catalog_writes_outside_projector.py`
+     ε-lint (RDR-101 Phase 3 ε). The implementation lives at
+     `src/nexus/commands/doctor.py` (a new check function) and
+     scans `src/nexus/` for `sqlite3.connect(...)` and
+     `chromadb.PersistentClient(...)` call sites outside the
+     allowlisted prefix `src/nexus/db/`.
+   - **Trigger**: `nx doctor` runs the check as part of its
+     default audit pass; CI invokes `nx doctor
+     --check-storage-boundary --fail-on-violation` as a
+     dedicated step in the existing pytest workflow.
+   - **Surfacing**: violations are listed by `file:line` with the
+     offending call shape, mirroring the ε-lint output format.
+     Exit code 1 from CI fails the build.
+   - **Escape hatch**: a `# storage-boundary-allow: <reason>`
+     line marker, ≥8-char reason, parallels the
+     `# epsilon-allow:` mechanism already in the catalog lint.
 6. **Discovery (dual-primary)**: each daemon writes **both** its
    UDS socket path and its TCP `host:port` to
    `~/.config/nexus/<tier>_addr.<host_uid>` (single file, both
@@ -749,8 +767,10 @@ single end-to-end proof and ships with the daemon.
   indefinitely for debugging but is not the recommended path
   post-cutover.
 - **Secret/credential lifecycle**: N/A in v1 — local daemons,
-  UDS uses unix file permissions, TCP listeners are
-  loopback-only. Future cross-host RDR will introduce auth.
+  UDS uses unix file permissions (`chmod 0600` + peer-credential
+  check on accept; see **RDR-113** for the v1 host-trust model),
+  TCP listeners are loopback-only. Future cross-host RDR will
+  introduce token-based auth.
 - **Memory management**: daemon long-lived; needs a memory
   budget (to be set during planning based on expected concurrent
   client count and result-set sizes).
@@ -911,3 +931,21 @@ the planner's job, not this RDR's.
   trust / UDS auth (closing G6). G7 closes via a one-line
   forward-reference in `docs/workflow-engine-synthesis.md`. G9
   (cross-triad integration test) becomes a planning-time bead.
+- 2026-05-13 — **Light re-gate post-triad-rework PASSED**
+  (substantive-critic `abbc3adfbe8d94ca2`, 0C/1S/1O). Critic
+  confirmed §7-§10 integrate cleanly with §1-§6; cross-RDR
+  consistency with RDR-111 (EventStream signature, CA-9, CA-10)
+  solid; R3 PASSED items intact. Closeouts in this revision:
+  - S1 (Approach §5 lint-rule enforcement was an unresolved
+    disjunction predating the rework): committed to
+    `nx doctor --check-storage-boundary` as the concrete tool,
+    AST-scan modelled on the existing RDR-101 Phase 3 ε-lint at
+    `tests/test_no_direct_catalog_writes_outside_projector.py`.
+    Trigger (CI step + `nx doctor` default audit), surfacing
+    (file:line + exit 1), and escape hatch
+    (`# storage-boundary-allow: <reason>`, ≥8-char) all named.
+  - O1 (RDR-113 forward-reference lived only in revision
+    history + frontmatter): added a body-prose cite in
+    Cross-Cutting Concerns §Secret/credential lifecycle so the
+    cross-reference is navigable without a revision-history
+    dig.


### PR DESCRIPTION
## Summary

Light re-gate on RDR-112 after the triad rework (#730), RDR-113 cross-ref (#732), and CI fixes (#733, #734) landed. Substantive-critic \`abbc3adfbe8d94ca2\` returned **0 critical, 1 significant, 1 observation** — both closed in-revision.

## Gate trail (cumulative)

| Round | C | S | O | Outcome |
|---|---|---|---|---|
| R1 (pre-rework) | 2 | 3 | 3 | BLOCKED |
| R2 (pre-rework) | 1 | 1 | 3 | BLOCKED |
| R3 (pre-rework) | 0 | 0 | 3 | **PASSED** |
| Light re-gate (post-rework) | 0 | 1 | 1 | **PASSED** (closeouts in this PR) |

## Closeouts this PR

**S1 — Lint-rule enforcement (predated rework, finally pinned)**: Approach §5 used to say "enforced by \`nx doctor\` or a CI rule". The disjunction was aspirational. Committed to:
- **Tool**: \`nx doctor --check-storage-boundary\` — AST scan modelled on the existing RDR-101 Phase 3 ε-lint (\`tests/test_no_direct_catalog_writes_outside_projector.py\`)
- **Trigger**: \`nx doctor\` default audit + dedicated CI step with \`--fail-on-violation\`
- **Surfacing**: \`file:line\` offender format + exit 1
- **Escape hatch**: \`# storage-boundary-allow: <reason>\` (≥8-char), parallels the existing \`# epsilon-allow:\`

**O1 — RDR-113 forward-reference**: was claimed in revision history but never actually appeared in body prose. Added inline cite in Cross-Cutting Concerns §Secret/credential lifecycle.

## Critic-verified intact from R3 PASSED

- §Decision Rationale "Sequencing constraint vs RDR-110" subsection
- §Finalization Gate contradiction check + assumption verification
- §Nexus-in-its-own-container introspection commitment (\`exec --raw\`)
- Cross-RDR consistency: RDR-111 §Step 6 / CA-9 / CA-10 align with RDR-112 §7 / §8 / §9 verbatim

## T2

\`nexus_rdr/112-gate-latest\` → PASSED.

## Next

**Not auto-merged.** Per standing pause-between-gate-and-accept rule. After merge + review, \`/nx:rdr-accept 112\`.

## Test plan

- [x] Re-gate by substantive-critic returned 0 critical
- [x] R3 PASSED items verified intact
- [x] Cross-RDR consistency confirmed against RDR-111 (PASSED R9) and RDR-113 (PASSED R1)
- [ ] \`/nx:rdr-accept 112\` is a follow-up after user review