### PR TITLE
docs(rdr): 5x5 alignment pass on RDR-110 wrt 111/112/113

### DIFF
--- a/docs/rdr/rdr-110-semantic-tuple-space.md
+++ b/docs/rdr/rdr-110-semantic-tuple-space.md
@@ -9,7 +9,7 @@ reviewed-by: self
 created: 2026-05-09
 accepted_date: 2026-05-09
 related_issues: []
-related_rdrs: [RDR-004, RDR-041, RDR-077, RDR-078, RDR-079, RDR-087, RDR-092, RDR-105, RDR-106, RDR-107, RDR-108, RDR-112]
+related_rdrs: [RDR-004, RDR-041, RDR-077, RDR-078, RDR-079, RDR-087, RDR-092, RDR-105, RDR-106, RDR-107, RDR-108, RDR-112, RDR-113]
 related_tests: []
 implementation_notes: ""
 ---
@@ -1022,14 +1022,25 @@ two-statement read-then-update because the simpler pattern
 above conflates same-claimant retake with foreign-claimant
 contention. Documented; not in the pseudocode for clarity.
 
-**`data_version` polling thread**: a single `_TupleSpaceWatcher`
-thread per `tuples.db` connection runs `PRAGMA data_version`
-every 1ms, fires `wake_event` on increment. Started at MCP
-lifespan start (per RDR-094), stopped at lifespan finally.
-CPU cost: one integer read per millisecond per database. All
-blocking `take` calls share the same wake_event; spurious wakes
-(commits not relevant to this caller's subspace) cost one
-extra UPDATE attempt that returns no row.
+**`data_version` polling thread** (`NX_STORAGE_MODE=direct` only):
+a single `_TupleSpaceWatcher` thread per `tuples.db` connection
+runs `PRAGMA data_version` every 1ms, fires `wake_event` on
+increment. Started at MCP lifespan start (per RDR-094), stopped
+at lifespan finally. CPU cost: one integer read per millisecond
+per database. All blocking `take` calls share the same wake_event;
+spurious wakes (commits not relevant to this caller's subspace)
+cost one extra UPDATE attempt that returns no row.
+
+**Under `NX_STORAGE_MODE=daemon` (RDR-112)**, the watcher is
+*daemon-internal* — the daemon owns the single `tuples.db`
+connection (one process, one lock, one `data_version`) and exposes
+client-side waiting via the **blocking-take RPC** and the
+**`EventStream(subspace_prefix, since_cursor) → Stream<Event>`
+RPC** (RDR-112 Approach §7). Clients never hold a `tuples.db`
+connection in daemon mode; doing so would fork the WAL (RDR-112
+§A2) and is forbidden by the `nx doctor --check-storage-boundary`
+lint (RDR-112 §5). The in-process watcher described above is the
+direct-mode path only.
 
 **Tier routing:**
 
@@ -1362,6 +1373,25 @@ algorithm) on any increment. Started at MCP lifespan start
 (per RDR-094 / RDR-105 lifecycle pattern), stopped at lifespan
 finally. Honker's production cadence is the reference (1-2ms
 median wake latency).
+
+**Mode split — daemon vs direct (RDR-112)**: the watcher described
+above is the **`NX_STORAGE_MODE=direct`** path only (same-host,
+single-filesystem deployments). Under
+**`NX_STORAGE_MODE=daemon`**, the MCP server is a client of the T2
+daemon (RDR-112 D1) and does **not** hold a `tuples.db`
+connection — the watcher runs daemon-side, owned by the single
+process that owns the SQLite file. Client-side `block=True`
+calls into `take` route through the daemon's **blocking-take
+RPC**; client-side observers (RDR-111's `_BindingWatcher`,
+cockpit panels) subscribe via the daemon's
+**`EventStream(subspace_prefix, since_cursor)`** RPC (RDR-112
+Approach §7). Holding a client-side `tuples.db` connection
+under daemon mode is forbidden by the
+`nx doctor --check-storage-boundary` lint (RDR-112 §5) and would
+fork the WAL across the overlayfs boundary (RDR-112 §A2).
+`block=True` ships feature-flagged in Step 4 and is enabled when
+daemon mode is the default, per the sequencing constraint in
+the Revision-History "Further-revised scope (2026-05-13)" block.
 
 #### Step 5: Periodic sweeps
 
@@ -1785,7 +1815,14 @@ work-stealing harness) is in scope and bundled into Phase 1 Step 7._
 - **Incremental adoption**: v1 ships alongside existing surfaces;
   no callers forced to migrate. v2 wraps existing surfaces
   behavior-preservingly. v3 deprecates parallel APIs.
-- **Secret/credential lifecycle**: N/A.
+- **Secret/credential lifecycle**: N/A in the tuple-space layer
+  itself. The trust boundary for agent-private subspaces (notably
+  `mailbox/<agent>`) is inherited from the storage substrate: under
+  `NX_STORAGE_MODE=daemon`, **RDR-113** (host-trust model — UDS
+  `chmod 0600` + peer-credential check, single-user v1) ensures
+  only the daemon-owner UID can read/write any subspace through the
+  daemon. Under `direct` mode, host filesystem permissions on
+  `tuples.db` are the gate (same-host single-user assumption).
 - **Memory management**: Per-template chroma collections at T2 are
   bounded by `retention_seconds`. Tombstone sweep enforces ceiling.
   Claim ledger is bounded by lease expiry + sweep cadence.
@@ -2094,3 +2131,40 @@ container-vs-daemon boundary determines correctness.
 **No changes to RDR-110's design surface.** `related_rdrs`
 frontmatter includes RDR-112; this revision-history note
 records the cross-reference and the full sequencing constraint.
+
+### 5x5 alignment pass 2026-05-13
+
+After RDR-111 (PASSED R9), RDR-112 (PASSED light re-gate), and
+RDR-113 (PASSED R1) all completed their gates, a focused
+critic alignment check (`a25b97d1aac1d8523`) flagged one
+significant + three observations against RDR-110. Closeouts in
+this revision (no design-surface change; record-keeping only):
+
+- **S** (significant): Technical Design `data_version` polling
+  thread description (lines ~1025) and Implementation Plan
+  Step 4 watcher description (lines ~1368) said the
+  `_TupleSpaceWatcher` runs in-process against `tuples.db` —
+  correct in `NX_STORAGE_MODE=direct`, but under
+  `NX_STORAGE_MODE=daemon` (RDR-112) the watcher is
+  daemon-internal and clients subscribe via the daemon's
+  `EventStream` / blocking-take RPCs. Holding a client-side
+  `tuples.db` connection in daemon mode is forbidden by
+  `nx doctor --check-storage-boundary` (RDR-112 §5 lint).
+  Both sites now carry a "Mode split — daemon vs direct"
+  note pointing at RDR-112 Approach §7 and §A2. The
+  in-process watcher path remains correct as the direct-mode
+  implementation; daemon-mode adds the RPC indirection.
+- **O1**: Frontmatter `related_rdrs` did not include RDR-113.
+  Added.
+- **O2**: Body prose had no cite for RDR-113's host-trust
+  model on `mailbox/<agent>` and other agent-private
+  subspaces. Added a paragraph in §Cross-Cutting Concerns
+  §Secret/credential lifecycle naming RDR-113 as the trust
+  boundary under daemon mode.
+- **O3**: (RDR-111 Proposed Solution panel descriptions had
+  stale "same process, direct SQL appropriate" justification
+  — fixed in RDR-111 alongside this RDR's edits, not in
+  RDR-110.)
+
+No re-gate required — these are documentation-tracking
+corrections, not design changes.

--- a/docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md
+++ b/docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md
@@ -540,9 +540,15 @@ ON t.id = tcl.tuple_id WHERE tcl.transition = 'claim'`; `tuples` has no
 — without it, crashed-agent claims would appear as active until the next
 sweep. `claim_state` is an internal column on the `tuples` table (per
 RDR-110 claim ledger schema), not a registered dimension; it is not
-accessible via `read()` and must be queried directly. The cockpit surface
-is an internal component in the same process, so direct access to
-`tuples.db` is appropriate. Rendered as a tmux pane or ext-apps iframe.
+accessible via `read()` and must be queried directly. **Routing under
+RDR-112**: under `NX_STORAGE_MODE=daemon` (the supported deployment),
+the cockpit surface is a *client* of the T2 daemon — direct
+`sqlite3.connect(tuples.db)` from the cockpit client process is
+**forbidden** (RDR-112 §5 lint). The query shape above runs daemon-side
+via a dedicated read RPC or via `nx daemon t2 exec --raw` (RDR-112
+§Nexus-in-its-own-container introspection surface). See Implementation
+Plan Step 8 for the concrete call form. Rendered as a tmux pane or
+ext-apps iframe.
 
 **Recent-events panel** — direct SQL query on `~/.config/nexus/tuples.db`
 for time-ordered display (RDR-110's `read()` has no `sort_by` or
@@ -566,7 +572,12 @@ schema above; `timestamp` is a registered dimension accessible in the
 `read()` response, unlike `created_at` which is an internal `tuples`
 table column not exposed by the API). This trades time-ordering guarantee
 for semantic relevance. The default display is SQL (time-ordered); semantic
-filter is an opt-in mode.
+filter is an opt-in mode. **Routing under RDR-112**: same as the
+active-claims panel above — under daemon mode the cockpit is a daemon
+client; the query runs via a daemon read RPC or `nx daemon t2 exec
+--raw`. Direct `sqlite3.connect(tuples.db)` from the client process is
+forbidden (RDR-112 §5 lint). See Implementation Plan Step 9 for the
+concrete call form.
 
 **Active-bindings panel** — `read(subspace="bindings/<current_profile>",
 where={"enabled": "true"})`. Shows trigger, action, surface, enabled state.
@@ -1174,3 +1185,4 @@ Other gates:
 | 2026-05-11 | Hal Hildebrand | Post-gate-7 revision (1 critical + 2 significant + 2 observations all addressed pre-accept): (C-G7-1) removed `PostCompact` from Step 2 bridge registration list — was contradicted by Proposed Solution's explicit exclusion; added `PreCompact` and `PostCompact` to the not-registered list with rationale cross-reference; (SIG-G7-1) replaced three residual `rd()` aliases with `read()` — Step 4 bindings dimension example, Step 6 `_BindingWatcher` rationale paragraph (header + two body references); (SIG-G7-2) corrected "six" → "seven" hook-event subspaces at four remaining sites (Relationship to RDR-110 summary, CA-9 description, CA-9 risk-if-wrong, Phase 1 section header); added `layout_state` to the Relationship-section subspace enumeration; (OBS-G7-1) active-claims display now explicitly extracts `actor` via `json_extract(t.dimensions_json, '$.actor')` — `actor` lives inside `dimensions_json`, not a top-level column; (OBS-G7-2) watcher failure isolation now logs via `structlog` (not "T2 scratch" — category error, scratch is T1); failure counter kept in T2 as before |
 | 2026-05-13 | Hal Hildebrand | **Triad rework (RDR-110/111/112 composition gaps, deep-analyst `a56172936d63fd480`)**: added §Relationship to RDR-112; rewrote §Step 6 binding-watcher to consume RDR-112 `EventStream(subspace_prefix, since_cursor)` RPC instead of direct SQL on `tuples.db` (cursor protocol and at-least-once semantics preserved verbatim; only transport changes); rewrote §Step 6 Watcher failure isolation to distinguish action / substrate / schema failure categories so daemon hiccups do not silently auto-disable user bindings (closes G5); updated `watcher_state` placement to record that the table is daemon-owned and read/written via dedicated RPCs (closes G4 wrt RDR-111 dependency); `related_rdrs` frontmatter extended to include RDR-112 and RDR-113. RDR-111 is now blocked on RDR-112 Phase 1 for the binding-watcher; query-only cockpit surfaces unaffected. |
 | 2026-05-13 | Hal Hildebrand | **Gate round 8 closeout** (substantive-critic `a3da714a7d21b75ee`, 1C/2S/2O on the triad-rework PR): (C-G8-1) Steps 8 + 9 cockpit panels rewritten to route through T2 daemon read RPCs (`t2_client.active_claims()`, `t2_client.recent_events()`) or `nx daemon t2 exec --raw` introspection; explicit ban on direct `sqlite3.connect(tuples.db)` from cockpit client process. The §Relationship to RDR-112 subsection had committed this; Steps 8/9 prose now matches. (S-G8-1) CA-10 description and gate criterion updated to reference the T2 daemon migration manifest (RDR-112 Approach §9), not RDR-110 migration file — the migration owner moved daemon-side and the criterion has to point there. (S-G8-2) CA-9 extended with the second-half coordination: ORB Phase 1 Step 1 also gates on the RDR-112 daemon `subspace add` admin RPC existing, not just RDR-110 shipping open-registry. (OBS-G8-1) Step 6 cursor-persistence pseudocode rewritten to use `t2_client.watcher_state_set` / `watcher_state_get` RPCs and `t2_client.event_stream` async-for loop, removing the bare `conn_tuples.execute(UPDATE watcher_state ...)` that contradicted the surrounding prose. (OBS-G8-2) Watcher failure isolation disambiguates the two uses of "category" — RDR-112 event `category ∈ {data, schema, substrate}` published by the daemon is independent of the watcher-side action/substrate/schema failure classification. |
+| 2026-05-13 | Hal Hildebrand | **5x5 alignment pass (alignment check `a25b97d1aac1d8523`)**: Proposed Solution panel descriptions (Active-claims, Recent-events) carried a pre-rework justification ("internal component in the same process, so direct access to `tuples.db` is appropriate") that contradicts Implementation Plan Steps 8 + 9 (which were corrected in the round-8 closeout to route through daemon RPCs). Added "Routing under RDR-112" notes to both Proposed Solution panel paragraphs pointing at Steps 8 + 9 and the RDR-112 §5 lint, closing the internal inconsistency. No design change. |


### PR DESCRIPTION
## Summary

After the triad gate cycle finished (RDR-111 PASSED R9, RDR-112 PASSED light re-gate, RDR-113 PASSED R1), ran a focused alignment check on RDR-110 — does its body still hold up against what 111/112/113 *committed* to since 110 was accepted? Critic \`a25b97d1aac1d8523\` returned **0 critical, 1 significant, 3 observations**. All four closed in this PR.

## Closeouts

**S — RDR-110 watcher description carried direct-mode-only assumptions**: §Technical Design \`data_version\` polling thread paragraph and §Implementation Plan Step 4 both described the \`_TupleSpaceWatcher\` running in-process against \`tuples.db\`. Correct in \`NX_STORAGE_MODE=direct\` only; under daemon mode (RDR-112) the watcher is daemon-internal and clients subscribe via \`EventStream\` / blocking-take RPCs. Both sites now carry a "Mode split — daemon vs direct" note pointing at RDR-112 §7 (EventStream) and §A2 (overlayfs WAL). **Importance**: without this note, a planner reading Step 4 would implement an in-process \`tuples.db\` connection and trip the \`nx doctor --check-storage-boundary\` lint (RDR-112 §5) the moment daemon mode activates.

**O1 — RDR-110 frontmatter \`related_rdrs\` += RDR-113**.

**O2 — RDR-110 body prose cite for RDR-113**: §Cross-Cutting Concerns §Secret/credential lifecycle now names RDR-113 as the trust boundary for \`mailbox/<agent>\` and other agent-private subspaces under daemon mode.

**O3 — RDR-111 Proposed Solution panel descriptions**: Active-claims and Recent-events panels still had the pre-rework "internal component in the same process, so direct access to \`tuples.db\` is appropriate" justification that contradicts the corrected Implementation Plan Steps 8 + 9. Added "Routing under RDR-112" notes pointing at the corrected steps + the §5 lint.

## What this PR is not

- **Not a re-gate.** RDR-110 stays Accepted; RDR-111 stays PASSED R9. These are documentation-tracking corrections, not design changes.
- **Not a 112/113 amendment.** Both already PASSED their (re-)gates and were correct.

## After merge

Triad gate cycle complete and 5x5:

| RDR | Status | Gate | Body in sync with siblings? |
|---|---|---|---|
| 110 | Accepted | (revision-history-only updates) | ✓ after this PR |
| 111 | Draft | PASSED R9 | ✓ after this PR |
| 112 | Draft | PASSED light re-gate | ✓ |
| 113 | Draft | PASSED R1 | ✓ |

Three drafts ready for \`/nx:rdr-accept\` in any order.

## Test plan

- [x] Alignment check by substantive-critic returned 0 critical
- [x] All 4 closeouts applied in this PR
- [x] No design surface change in any RDR