### PR TITLE
docs(agents): codify develop-as-integration + batch-PR-per-logical-unit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ Pagination over a large collection: `limit ≤ 300` per call, `offset += 300` in
 
 - **Never `print()` in library code.** Use `structlog.get_logger(__name__).info(event=..., **fields)`.
 - **Never push directly to `main`.** Open a PR. The only exception is the version-bump commit during a release (`docs/contributing.md` § Release Process).
+- **PRs target `develop`, not `main`.** `develop` is the integration branch; `main` only receives release commits and the periodic `develop → main` reconciliation. Branch off `develop`, target `develop`, merge to `develop`. Hotfix exception: red-on-prod fixes may PR to `main`, then `main → develop` after. State the exception in the PR body.
+- **Batch commits into one PR per logical unit.** CI run ≈ 13–16 minutes per push; opening five PRs for one logical change wastes 65–80 minutes of CI for work that could validate in one run. Stack commits locally (each well-scoped and reviewable), then push a single PR per gate-round / RDR / sweep. One gate-round closeout = one PR; one RDR accept + planning chain output = one PR; one bead-enrichment sweep = one PR. CI-breaking fixes ship alone (fast revert path). See `feedback_develop_is_integration_branch.md` for the batching heuristics.
 - **Never `git add -A` or `git add .`.** Stage by explicit path so untracked drafts don't sneak in.
 - **Never include AI attribution in commits.** No "Generated with Claude", no `Co-Authored-By: Claude`. Bead references and `Closes #N` only.
 - **Never delete RDR files.** Closing an RDR is a frontmatter `status: closed` flip — the file stays. See [`docs/rdr/AGENTS.md`](docs/rdr/AGENTS.md).


### PR DESCRIPTION
## Summary

Codify two CI-discipline rules in AGENTS.md (Hot Rules section):

1. **PRs target \`develop\`, not \`main\`.** \`develop\` is the integration branch; \`main\` only receives release commits and the periodic \`develop → main\` reconciliation.
2. **Batch commits into ONE PR per logical unit.** Minimise CI runs — one gate-round closeout = one PR; one RDR accept + planning chain output = one PR; one bead-enrichment sweep = one PR.

## Why now

The 2026-05-13 RDR-110/111/112/113 triad cycle merged **13 PRs to main** when they should have gone to develop. \`origin/main\` is now 15 commits ahead of \`origin/develop\`; reconciliation via the existing \`chore/merge-main-into-develop\` branch is pending. This PR + the companion memory note ensure the discipline holds going forward.

## What's in this PR

- \`AGENTS.md\` — two new Hot Rules added under the existing \"Never push directly to main\" rule

## What's in the memory companion (not in this PR — lives in user's memory)

- \`~/.claude/projects/-Users-hal-hildebrand-git-nexus/memory/feedback_develop_is_integration_branch.md\` — the batching heuristics, anti-patterns, and the historical record of 2026-05-13's mistake

## This PR eats its own dog food

Targets \`develop\`. Single commit. Single PR.

## Test plan

- [x] AGENTS.md grep shows the two new rules at lines 84-85
- [x] No code changes
- [x] PR targets \`develop\`, not \`main\` (the new rule)