### PR TITLE
feat(daemon): cross-platform peer-cred accessor (nexus-dsxd, RDR-113 P1)

### DIFF
--- a/src/nexus/daemon/__init__.py
+++ b/src/nexus/daemon/__init__.py
@@ -1,0 +1,5 @@
+"""nexus daemon — single-writer process owning T2 SQLite + chromadb.
+
+See docs/rdr/rdr-112-storage-as-service-container-boundary.md and
+docs/rdr/rdr-113-host-trust-model.md for the substrate design.
+"""

--- a/src/nexus/daemon/peer.py
+++ b/src/nexus/daemon/peer.py
@@ -1,0 +1,141 @@
+"""Cross-platform peer-credential accessor for UDS sockets.
+
+RDR-113 §Host-Trust Model: the daemon accepts connections only from
+peer processes whose effective UID matches the daemon's UID. This module
+isolates the platform-specific `getsockopt` dance behind a single
+``read_peer_credentials`` entry point.
+
+Linux ``SO_PEERCRED`` returns ``struct ucred = {pid, uid, gid}`` as three
+32-bit ints (12 bytes). macOS ``LOCAL_PEERCRED`` returns ``struct xucred``
+(76 bytes, natural-alignment) — no PID, but ``cr_uid`` plus a 16-slot
+group array; ``cr_groups[0]`` is the effective GID.
+
+Failures are loud: unsupported platform → ``NotImplementedError``;
+non-UDS socket → ``ValueError``; ``cr_version != XUCRED_VERSION`` → ``OSError``.
+No "accept with warning" fallback (RDR-113 §Failure Modes).
+"""
+
+from __future__ import annotations
+
+import socket
+import struct
+import sys
+from typing import NamedTuple
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+
+class PeerCredentials(NamedTuple):
+    """Peer process identity over a UDS socket.
+
+    ``pid`` is ``-1`` on macOS — ``xucred`` does not carry it. Callers
+    that need PID-level identity must use Linux or solicit it over the
+    application protocol.
+    """
+
+    pid: int
+    uid: int
+    gid: int
+
+
+# Linux struct ucred = {pid_t pid, uid_t uid, gid_t gid}: signed pid (can be
+# negative in odd corner cases), unsigned uid/gid (UIDs above 2^31 unpack as
+# negative if we read them as signed — see nobody on some distros).
+_LINUX_UCRED_FMT = "=iII"
+_LINUX_UCRED_SIZE = struct.calcsize(_LINUX_UCRED_FMT)
+
+# macOS struct xucred (sys/ucred.h, NGROUPS_MAX-ish flattened to 16):
+#   u_int  cr_version;          // 4 bytes
+#   uid_t  cr_uid;              // 4 bytes
+#   short  cr_ngroups;          // 2 bytes + 2 pad
+#   gid_t  cr_groups[16];       // 64 bytes
+# Total: 76 bytes, native alignment, no struct padding beyond the explicit 2x.
+_DARWIN_XUCRED_FMT = "=IIH2x16I"
+_DARWIN_XUCRED_SIZE = struct.calcsize(_DARWIN_XUCRED_FMT)
+
+# CPython does not expose SOL_LOCAL / LOCAL_PEERCRED in the socket module
+# on macOS; fall back to the kernel ABI numbers from <sys/un.h>.
+_DARWIN_SOL_LOCAL = getattr(socket, "SOL_LOCAL", 0)
+_DARWIN_LOCAL_PEERCRED = getattr(socket, "LOCAL_PEERCRED", 0x001)
+
+# Likewise SO_PEERCRED is absent on macOS-built CPython; use the Linux ABI
+# value (17) so tests on either platform can patch sys.platform freely.
+_LINUX_SO_PEERCRED = getattr(socket, "SO_PEERCRED", 17)
+
+_XUCRED_VERSION = 0
+
+
+def read_peer_credentials(sock: socket.socket) -> PeerCredentials:
+    """Read the peer process credentials from a connected AF_UNIX socket.
+
+    Args:
+        sock: A connected ``AF_UNIX`` socket (one end of an accepted UDS
+            connection or a ``socketpair`` half).
+
+    Returns:
+        ``PeerCredentials(pid, uid, gid)``. ``pid`` is ``-1`` on macOS.
+
+    Raises:
+        ValueError: ``sock`` is not an ``AF_UNIX`` socket.
+        NotImplementedError: Running on a platform other than Linux or
+            macOS.
+        OSError: The kernel returned a peer-cred payload that fails the
+            integrity check (e.g. macOS ``cr_version`` mismatch).
+    """
+    family = getattr(sock, "family", None)
+    if family != socket.AF_UNIX:
+        raise ValueError(
+            "peer credentials only available on UDS (AF_UNIX) sockets; "
+            f"got family={family!r}"
+        )
+
+    platform = sys.platform
+    if platform.startswith("linux"):
+        return _read_linux(sock)
+    if platform == "darwin":
+        return _read_darwin(sock)
+    raise NotImplementedError(
+        f"peer credentials not supported on platform {platform!r}; "
+        "Linux and macOS only in v1"
+    )
+
+
+def _read_linux(sock: socket.socket) -> PeerCredentials:
+    raw = sock.getsockopt(socket.SOL_SOCKET, _LINUX_SO_PEERCRED, _LINUX_UCRED_SIZE)
+    pid, uid, gid = struct.unpack(_LINUX_UCRED_FMT, raw[:_LINUX_UCRED_SIZE])
+    _log.info("peer_cred_read", platform="linux", pid=pid, uid=uid, gid=gid)
+    return PeerCredentials(pid=pid, uid=uid, gid=gid)
+
+
+def _read_darwin(sock: socket.socket) -> PeerCredentials:
+    raw = sock.getsockopt(
+        _DARWIN_SOL_LOCAL, _DARWIN_LOCAL_PEERCRED, _DARWIN_XUCRED_SIZE
+    )
+    if len(raw) < _DARWIN_XUCRED_SIZE:
+        raise OSError(
+            f"xucred payload too short: got {len(raw)} bytes, "
+            f"expected {_DARWIN_XUCRED_SIZE}"
+        )
+    unpacked = struct.unpack(_DARWIN_XUCRED_FMT, raw[:_DARWIN_XUCRED_SIZE])
+    version, uid, ngroups, *groups = unpacked
+    if version != _XUCRED_VERSION:
+        raise OSError(
+            f"unexpected xucred version: got {version}, "
+            f"expected {_XUCRED_VERSION}"
+        )
+    if ngroups < 1:
+        raise OSError(
+            f"xucred reports no groups (ngroups={ngroups}); "
+            "cannot derive peer gid"
+        )
+    gid = groups[0]
+    _log.info(
+        "peer_cred_read",
+        platform="darwin",
+        uid=uid,
+        gid=gid,
+        ngroups=ngroups,
+    )
+    return PeerCredentials(pid=-1, uid=uid, gid=gid)

--- a/tests/daemon/test_peer_credentials.py
+++ b/tests/daemon/test_peer_credentials.py
@@ -1,0 +1,219 @@
+"""Tests for nexus.daemon.peer — cross-platform peer-credential accessor.
+
+RDR-113 §Risks mitigation. Linux SO_PEERCRED returns `struct ucred` (3i).
+macOS LOCAL_PEERCRED returns `struct xucred` (cr_version, cr_uid,
+cr_ngroups, cr_groups[16]) = 76 bytes with natural alignment.
+
+Fail-loud on all error paths — no fallback (RDR-113 §Failure Modes).
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+# -- Linux path -------------------------------------------------------------
+
+
+def test_linux_parses_ucred_struct():
+    """Linux SO_PEERCRED returns three 32-bit ints (pid, uid, gid)."""
+    from nexus.daemon import peer
+
+    packed = struct.pack("3i", 12345, 1001, 1001)
+    fake_sock = _make_uds_sock_mock(packed)
+
+    with patch.object(sys, "platform", "linux"):
+        creds = peer.read_peer_credentials(fake_sock)
+
+    assert creds.pid == 12345
+    assert creds.uid == 1001
+    assert creds.gid == 1001
+
+
+def test_linux_uses_so_peercred_constants():
+    """Linux path must use SOL_SOCKET + SO_PEERCRED."""
+    from nexus.daemon import peer
+
+    packed = struct.pack("3i", 1, 2, 3)
+    fake_sock = _make_uds_sock_mock(packed, capture=True)
+
+    with patch.object(sys, "platform", "linux"):
+        peer.read_peer_credentials(fake_sock)
+
+    level, optname, _ = fake_sock.last_getsockopt
+    assert level == socket.SOL_SOCKET
+    assert optname == getattr(socket, "SO_PEERCRED", 17)
+
+
+# -- macOS path -------------------------------------------------------------
+
+
+def _pack_xucred(uid: int, version: int = 0, ngroups: int = 1, gid: int = 20) -> bytes:
+    """Pack a minimal valid xucred byte string (76 bytes)."""
+    groups = [gid] + [0] * 15
+    return struct.pack("=IIH2x16I", version, uid, ngroups, *groups)
+
+
+def test_macos_parses_xucred_struct():
+    """macOS LOCAL_PEERCRED returns xucred (76 bytes); extract uid + gid."""
+    from nexus.daemon import peer
+
+    packed = _pack_xucred(uid=501, ngroups=1, gid=20)
+    fake_sock = _make_uds_sock_mock(packed)
+
+    with patch.object(sys, "platform", "darwin"):
+        creds = peer.read_peer_credentials(fake_sock)
+
+    # macOS xucred does NOT carry pid; pid field is -1 sentinel.
+    assert creds.pid == -1
+    assert creds.uid == 501
+    assert creds.gid == 20
+
+
+def test_macos_rejects_bad_xucred_version():
+    """cr_version != XUCRED_VERSION (0) must fail loud."""
+    from nexus.daemon import peer
+
+    packed = _pack_xucred(uid=501, version=99)
+    fake_sock = _make_uds_sock_mock(packed)
+
+    with patch.object(sys, "platform", "darwin"):
+        with pytest.raises(OSError, match="xucred version"):
+            peer.read_peer_credentials(fake_sock)
+
+
+def test_macos_short_payload_raises():
+    """xucred payload shorter than 76 bytes must fail loud."""
+    from nexus.daemon import peer
+
+    fake_sock = _make_uds_sock_mock(b"\x00" * 10)
+
+    with patch.object(sys, "platform", "darwin"):
+        with pytest.raises(OSError, match="too short"):
+            peer.read_peer_credentials(fake_sock)
+
+
+def test_macos_zero_ngroups_raises():
+    """xucred with ngroups=0 cannot derive gid; fail loud per RDR-113."""
+    from nexus.daemon import peer
+
+    packed = _pack_xucred(uid=501, ngroups=0, gid=0)
+    fake_sock = _make_uds_sock_mock(packed)
+
+    with patch.object(sys, "platform", "darwin"):
+        with pytest.raises(OSError, match="ngroups"):
+            peer.read_peer_credentials(fake_sock)
+
+
+def test_linux_parses_large_uid_above_signed_int_max():
+    """UIDs > 2^31 (e.g. nobody=4294967294) must not unpack as negative."""
+    from nexus.daemon import peer
+
+    packed = struct.pack("=iII", 12345, 4294967294, 4294967294)
+    fake_sock = _make_uds_sock_mock(packed)
+
+    with patch.object(sys, "platform", "linux"):
+        creds = peer.read_peer_credentials(fake_sock)
+
+    assert creds.uid == 4294967294
+    assert creds.gid == 4294967294
+
+
+def test_macos_uses_local_peercred_constants():
+    """macOS path uses SOL_LOCAL=0 + LOCAL_PEERCRED=0x001 (numeric fallback)."""
+    from nexus.daemon import peer
+
+    packed = _pack_xucred(uid=501)
+    fake_sock = _make_uds_sock_mock(packed, capture=True)
+
+    with patch.object(sys, "platform", "darwin"):
+        peer.read_peer_credentials(fake_sock)
+
+    level, optname, _ = fake_sock.last_getsockopt
+    assert level == getattr(socket, "SOL_LOCAL", 0)
+    assert optname == getattr(socket, "LOCAL_PEERCRED", 0x001)
+
+
+# -- Error paths ------------------------------------------------------------
+
+
+def test_tcp_socket_rejected():
+    """Non-UDS sockets must raise ValueError."""
+    from nexus.daemon import peer
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as tcp_sock:
+        with pytest.raises(ValueError, match="UDS"):
+            peer.read_peer_credentials(tcp_sock)
+
+
+def test_unsupported_platform_raises():
+    """Unsupported platforms fail loud, no fallback."""
+    from nexus.daemon import peer
+
+    fake_sock = _make_uds_sock_mock(b"")
+
+    with patch.object(sys, "platform", "win32"):
+        with pytest.raises(NotImplementedError, match="win32"):
+            peer.read_peer_credentials(fake_sock)
+
+
+def test_freebsd_unsupported():
+    """BSD variants also unsupported in v1."""
+    from nexus.daemon import peer
+
+    fake_sock = _make_uds_sock_mock(b"")
+
+    with patch.object(sys, "platform", "freebsd13"):
+        with pytest.raises(NotImplementedError):
+            peer.read_peer_credentials(fake_sock)
+
+
+# -- Integration (real UDS socketpair) -------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.platform not in ("linux", "darwin"),
+    reason="peer-cred only supported on Linux/macOS",
+)
+def test_integration_real_uds_socketpair_returns_real_uid():
+    """End-to-end on a real AF_UNIX socketpair: returned UID matches geteuid."""
+    from nexus.daemon import peer
+
+    a, b = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        creds = peer.read_peer_credentials(a)
+        assert creds.uid == os.geteuid()
+        # On Linux pid is the peer pid; on macOS pid is -1 sentinel.
+        if sys.platform == "linux":
+            assert creds.pid == os.getpid()
+    finally:
+        a.close()
+        b.close()
+
+
+# -- Helpers ----------------------------------------------------------------
+
+
+class _SockMock:
+    """Minimal duck-typed UDS socket for tests."""
+
+    def __init__(self, payload: bytes, capture: bool = False):
+        self._payload = payload
+        self._capture = capture
+        self.last_getsockopt: tuple[int, int, int] | None = None
+        self.family = socket.AF_UNIX
+
+    def getsockopt(self, level: int, optname: int, buflen: int) -> bytes:
+        if self._capture:
+            self.last_getsockopt = (level, optname, buflen)
+        return self._payload
+
+
+def _make_uds_sock_mock(payload: bytes, capture: bool = False) -> _SockMock:
+    return _SockMock(payload, capture=capture)


### PR DESCRIPTION
## Summary

Substrate for the RDR-112 daemon scaffold (nexus-61x6). New module `src/nexus/daemon/peer.py` exposing `read_peer_credentials(sock) -> PeerCredentials(pid, uid, gid)`, dispatching Linux `SO_PEERCRED` and macOS `LOCAL_PEERCRED` (xucred). Fail-loud on every error path per RDR-113 §Failure Modes.

- Linux: `=iII` (signed pid, unsigned uid/gid) — handles UIDs above 2^31 correctly.
- macOS: `=IIH2x16I` (xucred, 76 bytes); cr_uid + cr_groups[0]; pid is `-1` sentinel.
- Integrity guards: `cr_version != 0` and `ngroups < 1` both raise OSError.
- `socket.SO_PEERCRED`, `SOL_LOCAL`, `LOCAL_PEERCRED` fall back to kernel ABI values when CPython does not expose them (macOS-built CPython lacks `SO_PEERCRED` entirely).
- AF_UNIX check on the socket → non-UDS raises `ValueError`.
- Unsupported platforms raise `NotImplementedError`.

## Test plan

12 tests, all green on darwin:

- [x] Linux happy path (parses ucred, asserts SOL_SOCKET + SO_PEERCRED)
- [x] Linux large UID (4_294_967_294) — regression for `3i` vs `=iII`
- [x] macOS happy path (parses xucred, asserts SOL_LOCAL + LOCAL_PEERCRED)
- [x] macOS bad version (cr_version=99) → OSError
- [x] macOS short payload (10 bytes) → OSError
- [x] macOS ngroups=0 → OSError
- [x] TCP socket → ValueError
- [x] win32 → NotImplementedError
- [x] freebsd13 → NotImplementedError
- [x] Real `socket.socketpair(AF_UNIX)` integration → `os.geteuid()` round-trip

## Closes

Bead: nexus-dsxd
RDR: docs/rdr/rdr-113-host-trust-model.md §Risks (peer-cred mitigation)