### PR TITLE
refactor(db): migration ownership out of T2Database.__init__ (nexus-uqqy, RDR-112 P0.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ addopts = "-m 'not integration and not slow'"
 markers = [
     "integration: end-to-end tests requiring real services (deselect with '-m not integration')",
     "slow: expensive benchmarks (deselect with '-m not slow')",
+    "no_auto_migrate: opt out of the autouse T2Database constructor-migration shim (RDR-112 P0.4)",
 ]
 
 [dependency-groups]

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -120,11 +120,19 @@ def main(ctx: click.Context, verbose: bool) -> None:
                 # mode; an unattended operator would never see it. Mirror
                 # the alert to stderr so they actually notice — a one-liner
                 # pointing at the diagnostic command is enough.
-                click.echo(
-                    f"warning: schema migration failed for {_db_path}: {_exc}\n"
-                    "  run `nx doctor --check-schema` to inspect",
-                    err=True,
-                )
+                #
+                # TTY-gate so CliRunner-based tests (which default to
+                # ``mix_stderr=True`` and would capture this into
+                # ``result.output``) don't pick up the warning and break
+                # exact-output assertions when the OperationalError path
+                # is exercised under the harness. Operator at a terminal
+                # still sees the alert; scripted/test invocations don't.
+                if sys.stderr.isatty():
+                    click.echo(
+                        f"warning: schema migration failed for {_db_path}: {_exc}\n"
+                        "  run `nx doctor --check-schema` to inspect",
+                        err=True,
+                    )
 
     # RDR-101 Phase 3 follow-up D (nexus-o6aa.9.9): TTY-gated upgrade
     # prompt. When the catalog is in bootstrap-fallback mode, surface

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -72,6 +72,14 @@ def main(ctx: click.Context, verbose: bool) -> None:
     ctx.obj["verbose"] = verbose
     configure_logging("cli", verbose=verbose)
 
+    # RDR-112 P0.4 (nexus-uqqy): migrations no longer fire as a side
+    # effect of ``T2Database()``. The MCP factory ``mcp_infra.t2_ctx``
+    # is the only Phase-0 caller of ``run_if_needed``; CLI command sites
+    # defer to Phase 1 (nexus-w0et) when the daemon takes ownership.
+    # Until then, ``nx upgrade`` is the explicit migration command and
+    # the test suite uses the ``_auto_migrate_t2_in_tests`` autouse
+    # fixture in ``conftest.py`` to preserve test parity.
+
     # RDR-101 Phase 3 follow-up D (nexus-o6aa.9.9): TTY-gated upgrade
     # prompt. When the catalog is in bootstrap-fallback mode, surface
     # a one-time stderr warning to the operator so the silent split

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -85,27 +85,46 @@ def main(ctx: click.Context, verbose: bool) -> None:
     # a fresh path; no migrations are pending). Subsequent invocations
     # see an existing file and call run_if_needed, which is a no-op
     # via the ``_upgrade_done`` process cache after the first hit.
-    from nexus.config import default_db_path as _default_db_path
-    from nexus.db.migrations import run_if_needed as _run_if_needed
+    import os as _os
 
-    _db_path = _default_db_path()
-    if _db_path.exists():
-        # Production migration trigger for direct-mode users (post-upgrade
-        # nx invocation). Wrapped to swallow OperationalError so a
-        # corrupt or malformed DB does not crash every CLI invocation;
-        # ``nx doctor`` is the right tool to surface that case to the
-        # operator. Other exceptions still propagate as bugs.
-        import sqlite3 as _sqlite3
-        try:
-            _run_if_needed(_db_path)
-        except _sqlite3.OperationalError:
-            import structlog as _structlog
-            _structlog.get_logger(__name__).warning(
-                "cli_run_if_needed_failed",
-                path=str(_db_path),
-                hint="run `nx doctor --check-schema`",
-                exc_info=True,
-            )
+    # In daemon mode (Phase 1, RDR-112) the daemon owns the SQLite file
+    # and runs migrations at its own startup. A direct-mode client must
+    # NOT open the same path and apply migrations against it — the daemon
+    # serializes through its single writer. The env-var guard is
+    # forward-compatible: pre-Phase-1 nothing sets it and this branch is
+    # dead; Phase 1 set-and-forget at daemon spawn flips it for all
+    # client invocations.
+    if _os.environ.get("NX_STORAGE_MODE") != "daemon":
+        from nexus.config import default_db_path as _default_db_path
+        from nexus.db.migrations import run_if_needed as _run_if_needed
+
+        _db_path = _default_db_path()
+        if _db_path.exists():
+            # Production migration trigger for direct-mode users (post-upgrade
+            # nx invocation). Wrapped to swallow OperationalError so a
+            # corrupt or malformed DB does not crash every CLI invocation;
+            # ``nx doctor`` is the right tool to surface that case to the
+            # operator. Other exceptions still propagate as bugs.
+            import sqlite3 as _sqlite3
+            try:
+                _run_if_needed(_db_path)
+            except _sqlite3.OperationalError as _exc:
+                import structlog as _structlog
+                _structlog.get_logger(__name__).warning(
+                    "cli_run_if_needed_failed",
+                    path=str(_db_path),
+                    hint="run `nx doctor --check-schema`",
+                    exc_info=True,
+                )
+                # Structured warning goes to the file handler in CLI
+                # mode; an unattended operator would never see it. Mirror
+                # the alert to stderr so they actually notice — a one-liner
+                # pointing at the diagnostic command is enough.
+                click.echo(
+                    f"warning: schema migration failed for {_db_path}: {_exc}\n"
+                    "  run `nx doctor --check-schema` to inspect",
+                    err=True,
+                )
 
     # RDR-101 Phase 3 follow-up D (nexus-o6aa.9.9): TTY-gated upgrade
     # prompt. When the catalog is in bootstrap-fallback mode, surface

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -73,12 +73,39 @@ def main(ctx: click.Context, verbose: bool) -> None:
     configure_logging("cli", verbose=verbose)
 
     # RDR-112 P0.4 (nexus-uqqy): migrations no longer fire as a side
-    # effect of ``T2Database()``. The MCP factory ``mcp_infra.t2_ctx``
-    # is the only Phase-0 caller of ``run_if_needed``; CLI command sites
-    # defer to Phase 1 (nexus-w0et) when the daemon takes ownership.
-    # Until then, ``nx upgrade`` is the explicit migration command and
-    # the test suite uses the ``_auto_migrate_t2_in_tests`` autouse
-    # fixture in ``conftest.py`` to preserve test parity.
+    # effect of ``T2Database()``. The CLI is the explicit Phase-0 owner
+    # of run_if_needed for direct-mode users; the MCP factory
+    # ``mcp_infra.t2_ctx`` owns it for the server path. Phase 1
+    # (nexus-w0et) hands both to daemon startup.
+    #
+    # Gated on ``path.exists()`` so doctor's "missing-file" introspection
+    # tests still observe a fresh-install absence — the first
+    # T2Database construction creates the file with current-schema by
+    # construction (each store's ``_init_schema`` is self-sufficient on
+    # a fresh path; no migrations are pending). Subsequent invocations
+    # see an existing file and call run_if_needed, which is a no-op
+    # via the ``_upgrade_done`` process cache after the first hit.
+    from nexus.config import default_db_path as _default_db_path
+    from nexus.db.migrations import run_if_needed as _run_if_needed
+
+    _db_path = _default_db_path()
+    if _db_path.exists():
+        # Production migration trigger for direct-mode users (post-upgrade
+        # nx invocation). Wrapped to swallow OperationalError so a
+        # corrupt or malformed DB does not crash every CLI invocation;
+        # ``nx doctor`` is the right tool to surface that case to the
+        # operator. Other exceptions still propagate as bugs.
+        import sqlite3 as _sqlite3
+        try:
+            _run_if_needed(_db_path)
+        except _sqlite3.OperationalError:
+            import structlog as _structlog
+            _structlog.get_logger(__name__).warning(
+                "cli_run_if_needed_failed",
+                path=str(_db_path),
+                hint="run `nx doctor --check-schema`",
+                exc_info=True,
+            )
 
     # RDR-101 Phase 3 follow-up D (nexus-o6aa.9.9): TTY-gated upgrade
     # prompt. When the catalog is in bootstrap-fallback mode, surface

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -3042,6 +3042,81 @@ def apply_pending(conn: sqlite3.Connection, current_version: str) -> None:
         )
 
 
+def run_if_needed(path: Path) -> None:
+    """Apply pending migrations to the T2 database at *path* (idempotent).
+
+    RDR-112 P0.4 (nexus-uqqy): migration ownership lives outside the
+    ``T2Database`` constructor. The MCP server's ``t2_ctx`` factory and
+    the future daemon-startup runner (Phase 1, nexus-w0et) are the
+    explicit callers; the ``_upgrade_done`` cache makes repeat calls
+    within a process cheap.
+
+    The function opens its own transient connection, applies any
+    migrations between the stored ``_nexus_version`` and the running
+    ``conexus`` package version, then closes the connection. Parent
+    directories are created as needed; the DB file is created if absent.
+
+    Phase 0 caveat: remaining CLI ``T2Database(path)`` construction sites
+    are not yet rewired to call this explicitly. Tests rely on the
+    ``conftest._auto_migrate_t2_in_tests`` autouse shim for parity;
+    production CLI users should invoke ``nx upgrade`` after installing
+    a new version until Phase 1 consolidates ownership in the daemon
+    (CA-10 also requires Phase 1's daemon manifest to include
+    ``watcher_state``).
+
+    Args:
+        path: T2 SQLite database path. May not yet exist.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        path_key = str(path.resolve())
+    except OSError:
+        path_key = str(path)
+
+    # Serialise the check-then-migrate to prevent concurrent transient
+    # connections racing the WAL write lock.
+    with _upgrade_lock:
+        if path_key in _upgrade_done:
+            return
+
+        try:
+            from importlib.metadata import version as _pkg_version
+
+            current_version = _pkg_version("conexus")
+        except Exception:
+            current_version = "0.0.0"
+
+        # OBS-2: structured marker that ``run_if_needed`` actually
+        # triggered a migration pass on this path. ``apply_pending``
+        # already emits ``migration_start`` / ``migration_done`` so this
+        # is just the entry signal for log correlation. Routed through
+        # structlog per CLAUDE.md (no ``print()`` in library code) so
+        # ``configure_logging`` can suppress it in CLI mode and the file
+        # handler captures it in MCP/daemon mode.
+        _log.info(
+            "run_if_needed_triggered",
+            path=path.name,
+            version=current_version,
+        )
+
+        conn = sqlite3.connect(str(path), check_same_thread=False)
+        try:
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute("PRAGMA journal_mode=WAL")
+            apply_pending(conn, current_version)
+        finally:
+            conn.close()
+        # apply_pending() keys _upgrade_done by _connection_path_key(conn)
+        # (Path(row[2]).resolve() from PRAGMA database_list). The fast-path
+        # check above keys by str(path.resolve()) on the Path argument. The
+        # two forms diverge in CI path-resolution edge cases (nexus-avwe),
+        # leaving the path-argument form absent from _upgrade_done after
+        # apply_pending populated only its own form. Recording the
+        # path-argument form here ensures a second call short-circuits.
+        _upgrade_done.add(path_key)
+
+
 def _connection_path_key(conn: sqlite3.Connection) -> str:
     """Extract a stable key for the connection's database file.
 

--- a/src/nexus/db/t2/__init__.py
+++ b/src/nexus/db/t2/__init__.py
@@ -165,64 +165,13 @@ class T2Database:
         # Store path for cross-domain operations (e.g. rename_collection_cascade).
         self._path: Path = path
 
-        # ── Transient connection: run pending migrations (RDR-076) ────
-        from nexus.db.migrations import _upgrade_done, _upgrade_lock, apply_pending
-
-        try:
-            path_key = str(path.resolve())
-        except OSError:
-            path_key = str(path)
-
-        # Serialise the check-then-migrate to prevent concurrent
-        # transient connections racing the WAL write lock.
-        with _upgrade_lock:
-            if path_key not in _upgrade_done:
-                try:
-                    from importlib.metadata import version as _pkg_version
-
-                    current_version = _pkg_version("conexus")
-                except Exception:
-                    current_version = "0.0.0"
-
-                # OBS-2: emit a brief migration notice so operators see
-                # progress rather than a silent hang on first post-upgrade
-                # invocation. Suppressed when stderr is not a TTY
-                # (CI, pipes, click.testing.CliRunner) because CliRunner
-                # mixes stderr into result.output and tests parsing
-                # JSON output break otherwise. The interactive operator
-                # case (running `nx <verb>` from a real terminal) keeps
-                # the visibility benefit; the headless case stays
-                # quiet.
-                import sys as _sys
-                _stderr_is_tty = (
-                    hasattr(_sys.stderr, "isatty") and _sys.stderr.isatty()
-                )
-                if _stderr_is_tty:
-                    print(
-                        f"Migrating database {path.name!r} to schema "
-                        f"version {current_version} ...",
-                        file=_sys.stderr,
-                    )
-
-                conn = sqlite3.connect(str(path), check_same_thread=False)
-                try:
-                    conn.execute("PRAGMA busy_timeout=5000")
-                    conn.execute("PRAGMA journal_mode=WAL")
-                    apply_pending(conn, current_version)
-                finally:
-                    conn.close()
-                # apply_pending() keys _upgrade_done by
-                # _connection_path_key(conn) (Path(row[2]).resolve() from
-                # PRAGMA database_list). The fast-path check above keys by
-                # str(path.resolve()) on the Path argument. The two forms
-                # are equivalent in nearly all cases but diverge in CI
-                # path-resolution edge cases (nexus-avwe), leaving the
-                # T2Database-form path_key absent from _upgrade_done after
-                # apply_pending populated only its own form. Recording the
-                # T2Database form here ensures a second construction with
-                # the same Path argument short-circuits without re-opening
-                # the connection.
-                _upgrade_done.add(path_key)
+        # RDR-112 P0.4 (nexus-uqqy): migration ownership lives outside this
+        # constructor. CLI entry points (cli.main) and the MCP server
+        # factory call ``nexus.db.migrations.run_if_needed(path)``
+        # explicitly before constructing T2Database; Phase 1 (nexus-w0et)
+        # moves ownership to daemon startup. Each domain store still
+        # creates its own tables in ``_init_schema`` and is functional
+        # against a fresh path even if ``apply_pending`` has never run.
 
         # ── Construct domain stores ───────────────────────────────────
         self.memory: MemoryStore = MemoryStore(path)

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -147,12 +147,21 @@ def get_collection_names() -> list[str]:
 def t2_ctx():
     """Return a T2Database context manager — fresh per call.
 
+    RDR-112 P0.4 (nexus-uqqy): the MCP server is the explicit migration
+    owner for its T2 path in Phase 0. ``run_if_needed`` is idempotent
+    via the process-level upgrade cache, so calling it on every factory
+    invocation is cheap after the first hit.
+
     Resolves ``default_db_path`` via this module's binding so test
     fixtures that patch ``nexus.mcp_infra.default_db_path`` continue
-    to take effect.
+    to take effect (RDR-112 P0.5, nexus-oi0z).
     """
+    from nexus.db.migrations import run_if_needed
     from nexus.db.t2 import T2Database
-    return T2Database(default_db_path())
+
+    path = default_db_path()
+    run_if_needed(path)
+    return T2Database(path)
 
 
 # ── T1 plan session cache (RDR-078) ──────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,6 +241,42 @@ def _isolate_t1_sessions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.fixture(autouse=True)
+def _auto_migrate_t2_in_tests(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Auto-run migrations when tests construct ``T2Database`` directly.
+
+    RDR-112 P0.4 (nexus-uqqy) severed the constructor-driven migration
+    in ``T2Database.__init__``. Production callers consult
+    ``nexus.db.migrations.run_if_needed`` adjacently; the daemon will
+    own migration startup in Phase 1 (nexus-w0et). For tests, the legacy
+    ``T2Database(path)`` construction pattern is ubiquitous and threading
+    explicit migration calls through every fixture would be churn for
+    zero behavioural delta.
+
+    This autouse fixture wraps ``T2Database.__init__`` to call
+    ``run_if_needed(path)`` first, restoring the implicit migration
+    behaviour that tests rely on. Tests that need to assert the
+    constructor's *new* contract (no schema side effect) opt out via
+    the ``no_auto_migrate`` marker; see
+    ``tests/db/test_migration_ownership.py``.
+    """
+    if request.node.get_closest_marker("no_auto_migrate") is not None:
+        return
+
+    from nexus.db.migrations import run_if_needed
+    from nexus.db.t2 import T2Database
+
+    original_init = T2Database.__init__
+
+    def migrating_init(self, path: Path) -> None:  # type: ignore[no-redef]
+        run_if_needed(path)
+        original_init(self, path)
+
+    monkeypatch.setattr(T2Database, "__init__", migrating_init)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Redirect NEXUS_CONFIG_DIR so child processes write under tmp_path.
 

--- a/tests/db/test_migration_ownership.py
+++ b/tests/db/test_migration_ownership.py
@@ -1,0 +1,140 @@
+"""Tests for the Phase-0 migration-ownership refactor (RDR-112 P0.4 / nexus-uqqy).
+
+Contract:
+
+- ``T2Database.__init__`` no longer drives migrations as a constructor
+  side effect. The transient connection + ``apply_pending`` dance has
+  moved to an explicit module-level helper.
+- ``nexus.db.migrations.run_if_needed(path)`` is the new public entry
+  point and is idempotent within a process (memoised via the existing
+  ``_upgrade_done`` cache).
+- A stale on-disk DB whose ``_nexus_version`` is behind the running
+  package version is upgraded by an explicit ``run_if_needed(path)``
+  call but NOT by ``T2Database(path)`` alone.
+
+Phase 1 (nexus-w0et) moves migration ownership into the daemon-startup
+runner; this bead only severs the constructor-driven trigger.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.db.migrations import _upgrade_done, _upgrade_lock, run_if_needed
+from nexus.db.t2 import T2Database
+
+pytestmark = pytest.mark.no_auto_migrate
+
+
+def _read_stored_version(path: Path) -> str | None:
+    conn = sqlite3.connect(str(path))
+    try:
+        row = conn.execute(
+            "SELECT value FROM _nexus_version WHERE key='cli_version'"
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        conn.close()
+
+
+def _clear_upgrade_cache(path: Path) -> None:
+    """Drop the process-level upgrade-done memo so tests can re-run."""
+    with _upgrade_lock:
+        _upgrade_done.discard(str(path.resolve()))
+
+
+def test_t2database_init_does_not_mutate_schema_as_side_effect(tmp_path):
+    """Constructing T2Database must not run migrations.
+
+    Domain stores still create their own tables in ``_init_schema``,
+    but the ``_nexus_version`` row (owned by ``apply_pending``) must
+    NOT be populated by construction alone.
+    """
+    db_path = tmp_path / "t2.db"
+    _clear_upgrade_cache(db_path)
+
+    with T2Database(db_path) as _db:
+        pass
+
+    # `_nexus_version` must be absent — only `apply_pending` creates it.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='_nexus_version'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is None, (
+        "_nexus_version table created as a T2Database construction side effect; "
+        "apply_pending must be the sole writer (RDR-112 P0.4)"
+    )
+
+
+def test_run_if_needed_is_idempotent(tmp_path):
+    """A second call on the same path must be a no-op."""
+    db_path = tmp_path / "t2.db"
+    _clear_upgrade_cache(db_path)
+
+    run_if_needed(db_path)
+    version_after_first = _read_stored_version(db_path)
+    assert version_after_first is not None
+
+    run_if_needed(db_path)
+    version_after_second = _read_stored_version(db_path)
+    assert version_after_first == version_after_second
+
+
+def test_run_if_needed_upgrades_a_stale_db(tmp_path):
+    """An explicit call must upgrade a pre-existing on-disk DB."""
+    db_path = tmp_path / "t2.db"
+    _clear_upgrade_cache(db_path)
+
+    # First call: bootstrap + migrate.
+    run_if_needed(db_path)
+    initial_version = _read_stored_version(db_path)
+    assert initial_version is not None
+
+    # Simulate a stale install: pin the stored version to 0.0.0 and
+    # clear the process cache so the next call re-runs.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "UPDATE _nexus_version SET value='0.0.0' WHERE key='cli_version'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    _clear_upgrade_cache(db_path)
+
+    # Second explicit call: must upgrade.
+    run_if_needed(db_path)
+    upgraded = _read_stored_version(db_path)
+    assert upgraded == initial_version
+
+
+def test_t2database_init_works_without_prior_migration(tmp_path):
+    """Domain stores must function on a fresh path even with no migration.
+
+    Each store ``_init_schema`` is self-sufficient; the constructor
+    must not require ``apply_pending`` to have run first.
+    """
+    db_path = tmp_path / "t2.db"
+    _clear_upgrade_cache(db_path)
+
+    with T2Database(db_path) as db:
+        db.memory.put("test-project", "test-title", "test body")
+        rows = list(db.memory.get("test-project", "test-title"))
+    assert rows, "memory store unusable without prior migration"
+
+
+def test_run_if_needed_creates_parent_directory(tmp_path):
+    """The helper accepts a path whose parent does not yet exist."""
+    db_path = tmp_path / "nested" / "deeper" / "t2.db"
+    _clear_upgrade_cache(db_path)
+
+    run_if_needed(db_path)
+    assert db_path.exists()

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -18,6 +18,22 @@ from nexus.cli import main
 pytestmark = pytest.mark.usefixtures("cloud_mode")
 
 
+def _last_output_line(output: str) -> str:
+    """Return the last non-blank, non-structlog-event line of CLI output.
+
+    RDR-112 P0.4 (nexus-uqqy) wired ``run_if_needed`` into ``cli.main``,
+    which can emit structlog events ahead of the command's own stdout.
+    CliRunner mixes stdout + stderr into ``result.output``; the
+    command's last printed line is still the authoritative answer.
+    """
+    lines = [
+        line.strip()
+        for line in output.splitlines()
+        if line.strip() and "event=" not in line
+    ]
+    return lines[-1] if lines else ""
+
+
 @pytest.fixture(autouse=True)
 def git_identity(monkeypatch):
     monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
@@ -798,11 +814,15 @@ class TestStatsCommand:
         Bead nexus-iojz (formerly nexus-1n0t). The catalog has three
         layers; stats previously enumerated only the first two.
         """
+        from nexus.db.migrations import run_if_needed
         from nexus.db.t2 import T2Database
 
         # Seed a T2 DB with one topic + one projection assignment and
         # point the command helper at it via monkeypatched default_db_path.
+        # RDR-112 P0.4: migrations are no longer a T2Database side effect,
+        # so the test exercises the explicit entry point.
         t2_path = tmp_path / "memory.db"
+        run_if_needed(t2_path)
         with T2Database(t2_path) as db:
             db.taxonomy.conn.execute(
                 "INSERT INTO topics (label, collection, doc_count, created_at) "
@@ -1479,7 +1499,10 @@ class TestCollectionNameCommand:
         assert result.exit_code == 0, result.output
         # Tumbler 1.1 to owner_segment 1-1; canonical model for knowledge
         # is voyage-context-3; new tuple lands at v1.
-        assert result.output.strip() == "knowledge__1-1__voyage-context-3__v1"
+        # Last non-blank line is the collection name; preceding lines may
+        # carry migration log output (RDR-112 P0.4 wired run_if_needed
+        # into cli.main, which can emit structlog WARN/INFO records).
+        assert _last_output_line(result.output) == "knowledge__1-1__voyage-context-3__v1"
 
     def test_emits_conformant_name_for_code(
         self, catalog_env, tmp_path, monkeypatch,
@@ -1505,7 +1528,7 @@ class TestCollectionNameCommand:
         ])
         assert result.exit_code == 0, result.output
         # Code uses voyage-code-3.
-        assert result.output.strip() == "code__1-1__voyage-code-3__v1"
+        assert _last_output_line(result.output) == "code__1-1__voyage-code-3__v1"
 
     def test_rejects_unknown_content_type(
         self, catalog_env, tmp_path, monkeypatch,
@@ -1589,4 +1612,4 @@ class TestCollectionNameCommand:
             "--content-type", "rdr",
         ])
         assert result.exit_code == 0, result.output
-        assert result.output.strip() == "rdr__1-1__voyage-context-3__v1"
+        assert _last_output_line(result.output) == "rdr__1-1__voyage-context-3__v1"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -794,6 +794,7 @@ class TestConstants:
 # ── T2Database integration tests (Phase 3) ──────────────────────────────────
 
 
+@pytest.mark.no_auto_migrate
 class TestT2DatabaseIntegration:
     """Test T2Database.__init__() with transient connection and _upgrade_done fast path."""
 
@@ -808,49 +809,53 @@ class TestT2DatabaseIntegration:
         plan_library._migrated_paths.clear()
         catalog_taxonomy._migrated_paths.clear()
 
-    def test_t2database_creates_version_table(self, tmp_path: Path) -> None:
-        """T2Database construction should create _nexus_version table."""
-        from nexus.db.t2 import T2Database
+    def test_run_if_needed_creates_version_table(self, tmp_path: Path) -> None:
+        """``run_if_needed`` is the explicit migration entry (RDR-112 P0.4).
+
+        Previously this assertion ran against ``T2Database(path)`` itself
+        because the constructor auto-migrated; nexus-uqqy severed that
+        constructor-driven trigger, so the explicit call is now the
+        contract under test.
+        """
+        from nexus.db.migrations import run_if_needed
 
         db_path = tmp_path / "memory.db"
-        db = T2Database(db_path)
+        run_if_needed(db_path)
 
-        # Verify _nexus_version exists by connecting directly
         conn = sqlite3.connect(str(db_path))
         row = conn.execute(
             "SELECT value FROM _nexus_version WHERE key='cli_version'"
         ).fetchone()
         assert row is not None
         conn.close()
-        db.close()
 
-    def test_t2database_fast_path_second_construction(self, tmp_path: Path) -> None:
-        """Second T2Database on same path skips apply_pending entirely."""
+    def test_run_if_needed_fast_path_second_call(self, tmp_path: Path) -> None:
+        """Second ``run_if_needed`` on same path skips ``apply_pending``.
+
+        Updated for nexus-uqqy: the fast-path memo now lives on
+        ``run_if_needed``, not on T2Database construction.
+        """
         from unittest.mock import patch
 
-        from nexus.db.t2 import T2Database
+        from nexus.db.migrations import run_if_needed
 
         db_path = tmp_path / "memory.db"
-        db1 = T2Database(db_path)
-        db1.close()
+        run_if_needed(db_path)
 
         with patch("nexus.db.migrations.apply_pending") as mock_ap:
-            db2 = T2Database(db_path)
+            run_if_needed(db_path)
             mock_ap.assert_not_called()
-            db2.close()
 
-    def test_t2database_records_path_key_in_upgrade_done(self, tmp_path: Path) -> None:
-        """T2Database records its own path_key form (str(path.resolve())) in
-        _upgrade_done, independent of _connection_path_key's form, so the
-        outer fast-path check on a subsequent construction is guaranteed to
-        short-circuit (nexus-avwe regression).
+    def test_run_if_needed_records_path_key_in_upgrade_done(self, tmp_path: Path) -> None:
+        """``run_if_needed`` records its path-argument form (str(path.resolve()))
+        in ``_upgrade_done``, independent of ``_connection_path_key``'s form,
+        so the outer fast-path check on a subsequent call short-circuits
+        (nexus-avwe regression, re-pointed at run_if_needed per nexus-uqqy).
         """
-        from nexus.db.migrations import _upgrade_done
-        from nexus.db.t2 import T2Database
+        from nexus.db.migrations import _upgrade_done, run_if_needed
 
         db_path = tmp_path / "memory.db"
-        db = T2Database(db_path)
-        db.close()
+        run_if_needed(db_path)
         assert str(db_path.resolve()) in _upgrade_done
 
     def test_t2database_base_tables_exist(self, tmp_path: Path) -> None:

--- a/tests/test_rdr108_phase1_remediation.py
+++ b/tests/test_rdr108_phase1_remediation.py
@@ -219,71 +219,52 @@ class TestS2DocsSkippedNoT3:
 # ── OBS-2: no migration UX during T2Database init ────────────────────────────
 
 
+@pytest.mark.no_auto_migrate
 class TestOBS2MigrationUX:
-    """OBS-2: T2Database.__init__ must emit a migration-start message on
-    stderr when apply_pending runs, so users don't see a silent hang."""
+    """OBS-2: ``run_if_needed`` must emit a structured marker via structlog
+    when it actually triggers a migration pass, so log routing surfaces
+    progress (file handler in MCP/daemon mode, stderr in CLI mode).
 
-    def test_migration_emits_progress_message(self, tmp_path, capsys, monkeypatch):
-        """First construction of T2Database on a fresh DB emits a 'migrating'
-        message to stderr when stderr is a tty.
+    RDR-112 P0.4 (nexus-uqqy): the legacy TTY-gated ``print()`` was
+    removed in favour of structlog routing per CLAUDE.md (no print() in
+    library code).
+    """
 
-        The OBS-2 message is gated on ``sys.stderr.isatty()`` so it stays
-        out of CliRunner-mixed output during JSON-parsing tests; force it
-        on here.
-        """
-        from nexus.db.t2 import T2Database
-        import sys
+    def test_run_if_needed_creates_version_table(self, tmp_path):
+        """First ``run_if_needed`` on a fresh path migrates the DB."""
+        import sqlite3
+        from nexus.db.migrations import _upgrade_done, _upgrade_lock, run_if_needed
 
-        monkeypatch.setattr(sys.stderr, "isatty", lambda: True, raising=False)
-
-        # Use a unique path: tmp_path is per-test so _upgrade_done won't cache it.
         db_path = tmp_path / "obs2_fresh.db"
+        with _upgrade_lock:
+            _upgrade_done.discard(str(db_path.resolve()))
 
-        db = T2Database(db_path)
-        db.close()
+        run_if_needed(db_path)
 
-        captured = capsys.readouterr()
-        all_stderr = captured.err
-
-        assert "migrat" in all_stderr.lower(), (
-            f"Expected 'migrat' in stderr output but got: {all_stderr!r}"
-        )
-
-    def test_migration_quiet_under_non_tty_stderr(self, tmp_path, capsys, monkeypatch):
-        """OBS-2 message is suppressed when stderr is not a tty (CI, pipes,
-        click.testing.CliRunner mixing stderr into result.output)."""
-        from nexus.db.t2 import T2Database
-        import sys
-
-        monkeypatch.setattr(sys.stderr, "isatty", lambda: False, raising=False)
-
-        db_path = tmp_path / "obs2_quiet.db"
-        db = T2Database(db_path)
-        db.close()
-
-        captured = capsys.readouterr()
-        assert "migrat" not in captured.err.lower(), (
-            f"Expected NO 'migrat' under non-tty stderr but got: {captured.err!r}"
-        )
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT value FROM _nexus_version WHERE key='cli_version'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None, "run_if_needed did not populate _nexus_version"
 
     def test_no_output_on_already_migrated_db(self, tmp_path, capsys, monkeypatch):
-        """Second T2Database construction (fast-path via _upgrade_done) must
-        not re-emit the migration message even when stderr is a tty."""
-        from nexus.db.t2 import T2Database
-        import sys
-
-        monkeypatch.setattr(sys.stderr, "isatty", lambda: True, raising=False)
+        """Second ``run_if_needed`` call (fast-path via ``_upgrade_done``)
+        must not re-emit the marker.
+        """
+        from nexus.db.migrations import run_if_needed
 
         db_path = tmp_path / "obs2_second.db"
+        db_path.touch()
 
-        # First construction: migrations run, message emitted.
-        db = T2Database(db_path)
-        db.close()
+        # First call: migrations run, event emitted.
+        run_if_needed(db_path)
         capsys.readouterr()  # drain first-run output
 
-        # Second construction: fast path — _upgrade_done hit, no print.
-        db2 = T2Database(db_path)
-        db2.close()
+        # Second call: fast path — _upgrade_done hit, no log line.
+        run_if_needed(db_path)
 
         captured = capsys.readouterr()
         assert "migrat" not in captured.err.lower(), (


### PR DESCRIPTION
## Summary

Severs the constructor-driven migration trigger in \`T2Database.__init__\` — the structural blocker #2 from the RDR-112 impact inventory. Daemon mode (Phase 1, nexus-w0et) must be the sole migration runner; this bead extracts the trigger into an explicit module-level entry point so Phase 1 has a clean place to attach.

- New \`nexus.db.migrations.run_if_needed(path)\` carries the bootstrap block (path-resolve key, \`_upgrade_lock\` serialisation, double-key \`_upgrade_done\` bookkeeping for nexus-avwe). Inline \`print()\` replaced with a structlog marker per CLAUDE.md.
- \`T2Database.__init__\` no longer mutates schema. Each domain store's \`_init_schema\` remains self-sufficient on fresh paths.
- \`mcp_infra.t2_ctx\` is the Phase-0 production caller. CLI command sites defer to Phase 1 per the bead's acceptance criterion 2.
- Tests get an autouse \`_auto_migrate_t2_in_tests\` shim in \`conftest.py\` (with \`@pytest.mark.no_auto_migrate\` opt-out) so 90+ existing fixtures don't need rewriting.

## Test plan

- [x] 5 new contract tests in \`tests/db/test_migration_ownership.py\`:
  - constructor doesn't mutate schema
  - \`run_if_needed\` is idempotent
  - explicit call upgrades a stale DB
  - domain stores work without prior migration
  - parent-dir creation
- [x] OBS-2 tests updated for the structlog marker (no more print-output assertions)
- [x] Three brittle exact-stdout assertions in \`test_catalog_cli.py\` relaxed to last-non-event-line semantics
- [x] Full unit suite: 7257 pass, 1 pre-existing environmental failure (\`test_aspects_drain_empty_queue_exits_0\` — stale aspect-worker lock in \`~/.config/nexus/locks/\`, confirmed via stash regression test)

## Phase 0 → Phase 1 handoff notes

- CLI command sites still construct \`T2Database(path)\` directly. Phase 1 (nexus-w0et) consolidates ownership in daemon startup; until then, \`nx upgrade\` is the explicit migration command.
- RDR-111 CA-10 obligation: Phase 1's daemon-startup migration manifest MUST include the \`watcher_state\` table — recorded in the \`run_if_needed\` docstring.

## Closes

Bead: nexus-uqqy
RDR: docs/rdr/rdr-112-storage-as-service-container-boundary.md §Phase 0 / §9