### PR TITLE
feat(tuplespace): subspace registry (nexus-rugy, RDR-110 P1.1)

### DIFF
--- a/nx/tuplespace/builtin/tasks.yml
+++ b/nx/tuplespace/builtin/tasks.yml
@@ -1,0 +1,23 @@
+# RDR-110 canonical subspace: project-scoped task tuples.
+# Agents drop tasks into tasks/<project> with status/priority dimensions;
+# coordinators take items by semantic relevance to their capability.
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status:     { type: enum, values: [open, in_progress, done, cancelled], required: true }
+  priority:   { type: enum, values: [P0, P1, P2, P3, P4], required: true }
+  assignee:   { type: string, required: false }
+  created_by: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.55
+  margin: 0.08
+  default_lease_seconds: 600
+read:
+  default_floor: 0.40
+  default_n: 5
+tiers: [project]
+retention_seconds: 7776000  # 90 days

--- a/src/nexus/tuplespace/__init__.py
+++ b/src/nexus/tuplespace/__init__.py
@@ -1,0 +1,26 @@
+"""nexus.tuplespace — semantic tuple-space primitives (RDR-110).
+
+Phase 1 lands the substrate: the subspace registry (this module's
+``registry``), the SQLite schema, the core MCP tools, and a direct-mode
+watcher. Daemon-mode integration ships in RDR-112 follow-up beads.
+
+This package is intentionally substrate-only — no SQLite, no HTTP, no
+embedder. The registry validates YAML schemas; downstream beads supply
+the storage and the network plane.
+"""
+
+from nexus.tuplespace.registry import (
+    Registry,
+    RegistryLoadError,
+    SubspaceSchema,
+    UnknownSubspaceError,
+    default_builtin_dir,
+)
+
+__all__ = [
+    "Registry",
+    "RegistryLoadError",
+    "SubspaceSchema",
+    "UnknownSubspaceError",
+    "default_builtin_dir",
+]

--- a/src/nexus/tuplespace/registry.py
+++ b/src/nexus/tuplespace/registry.py
@@ -190,6 +190,13 @@ class SubspaceSchema:
 # broken matcher that silently never matches.
 _PARAM_PATTERN = re.compile(r"<([a-zA-Z_][a-zA-Z0-9_]*)>")
 
+# Used by ``_load_one`` to enumerate every angle-bracketed token in a
+# template name (valid or invalid). ``[^>]*`` (zero-or-more) deliberately
+# catches the empty-brackets case ``<>`` so the load-time guard rejects
+# it; the captured tokens are then filtered against ``_PARAM_PATTERN``
+# to identify syntactically invalid identifiers.
+_ANGLE_TOKEN = re.compile(r"<([^>]*)>")
+
 
 def _compile_template(template_name: str) -> re.Pattern[str]:
     """Compile a template like ``tasks/<project>`` into a regex.
@@ -298,10 +305,12 @@ def _load_one(yml_path: Path) -> SubspaceSchema:
 
     # Reject malformed param names at load — Python's named-group syntax
     # disallows dashes (``(?P<a-b>...)`` is a regex error). A YAML author
-    # writing ``mailbox/<agent-name>`` would otherwise ship a template
-    # whose ``<agent-name>`` placeholder is treated as a literal,
+    # writing ``mailbox/<agent-name>`` or ``mailbox/<>`` would otherwise
+    # ship a template whose placeholder is treated as a literal,
     # producing an opaque UnknownSubspaceError on first ``take``.
-    _ANGLE_TOKEN = re.compile(r"<([^>]+)>")
+    # ``_ANGLE_TOKEN`` uses ``[^>]*`` so empty ``<>`` is captured as the
+    # empty string and filtered through ``_PARAM_PATTERN`` (which
+    # requires at least one identifier char) into ``bad_params``.
     bad_params = [
         token
         for token in _ANGLE_TOKEN.findall(raw["name"])

--- a/src/nexus/tuplespace/registry.py
+++ b/src/nexus/tuplespace/registry.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, TypedDict
 
 import structlog
 import yaml
@@ -118,6 +118,38 @@ REGISTRY_FORMAT_SCHEMA: dict[str, Any] = {
 _VALIDATOR = Draft202012Validator(REGISTRY_FORMAT_SCHEMA)
 
 
+# -- Typed sub-shapes --------------------------------------------------------
+
+
+TakeMode = Literal["semantic", "exact"]
+
+
+class TakeConfig(TypedDict, total=False):
+    """Type for the ``take`` block on a subspace schema.
+
+    Mirrors RDR-110 §Step 1 and the JSON-Schema validation. ``total=False``
+    because optional keys (``floor``, ``margin``, ``match_keys``,
+    ``default_lease_seconds``) are conditional on ``mode``: ``floor`` and
+    ``margin`` apply to semantic mode; ``match_keys`` applies to exact
+    mode. Loader validation in ``_load_one`` enforces the
+    mode-conditional invariants.
+    """
+
+    enabled: bool
+    mode: TakeMode
+    floor: float
+    margin: float
+    match_keys: list[str]
+    default_lease_seconds: int
+
+
+class ReadConfig(TypedDict):
+    """Type for the ``read`` block on a subspace schema (RDR-110 §Step 1)."""
+
+    default_floor: float
+    default_n: int
+
+
 # -- Schema dataclass --------------------------------------------------------
 
 
@@ -128,6 +160,11 @@ class SubspaceSchema:
     ``name`` may include ``<param>`` placeholders (single-segment) that
     ``Registry.get_schema_for`` resolves against concrete subspace
     strings at lookup time.
+
+    ``take`` and ``read`` are ``TypedDict``s rather than plain ``dict[str, Any]``
+    so downstream consumers (RDR-110 nexus-8q4v Core API) get static-checker
+    affordance without forcing a stringly-keyed access pattern across the
+    codebase. The dict values themselves remain JSON-deserialised.
     """
 
     name: str
@@ -135,8 +172,10 @@ class SubspaceSchema:
     content_type: str
     embed_from: str
     dimensions: dict[str, dict[str, Any]] = field(default_factory=dict)
-    take: dict[str, Any] = field(default_factory=dict)
-    read: dict[str, Any] = field(default_factory=dict)
+    take: TakeConfig = field(default_factory=lambda: TakeConfig())  # type: ignore[misc]
+    read: ReadConfig = field(  # type: ignore[assignment]
+        default_factory=lambda: ReadConfig(default_floor=0.0, default_n=1)
+    )
     tiers: list[str] = field(default_factory=list)
     retention_seconds: int = 0
     source_path: Path | None = None
@@ -256,6 +295,24 @@ def _load_one(yml_path: Path) -> SubspaceSchema:
         raise RegistryLoadError(
             f"{yml_path.name}: schema validation failed at {path}: {exc.message}"
         ) from exc
+
+    # Reject malformed param names at load — Python's named-group syntax
+    # disallows dashes (``(?P<a-b>...)`` is a regex error). A YAML author
+    # writing ``mailbox/<agent-name>`` would otherwise ship a template
+    # whose ``<agent-name>`` placeholder is treated as a literal,
+    # producing an opaque UnknownSubspaceError on first ``take``.
+    _ANGLE_TOKEN = re.compile(r"<([^>]+)>")
+    bad_params = [
+        token
+        for token in _ANGLE_TOKEN.findall(raw["name"])
+        if _PARAM_PATTERN.fullmatch(f"<{token}>") is None
+    ]
+    if bad_params:
+        raise RegistryLoadError(
+            f"{yml_path.name}: invalid param identifier(s) {bad_params!r} "
+            f"in name {raw['name']!r}; params must match "
+            f"[a-zA-Z_][a-zA-Z0-9_]* (Python named-group syntax — no dashes)"
+        )
 
     take = raw["take"]
     if take.get("mode") == "exact":

--- a/src/nexus/tuplespace/registry.py
+++ b/src/nexus/tuplespace/registry.py
@@ -1,0 +1,299 @@
+"""Subspace registry: YAML loader + JSON Schema validation (RDR-110 P1.1).
+
+Loads ``nx/tuplespace/builtin/*.yml`` at MCP/CLI startup, validates each
+file against an inline JSON Schema for the registry format itself, and
+exposes ``Registry.get_schema_for(subspace)`` with single-segment
+parameterised matching (``tasks/<project>`` matches concrete
+``tasks/nexus`` but NOT ``tasks/a/b``).
+
+Phase 1.1 is purely client-side substrate — no SQLite, no daemon. The
+daemon-side admin RPC for third-party subspace registration ships under
+RDR-112 ``nexus-x98k`` in Phase 2.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import structlog
+import yaml
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+_log = structlog.get_logger(__name__)
+
+
+# -- Errors -------------------------------------------------------------------
+
+
+class RegistryError(Exception):
+    """Base for all registry errors."""
+
+
+class RegistryLoadError(RegistryError):
+    """A YAML file failed to parse or did not satisfy the registry schema."""
+
+
+class UnknownSubspaceError(RegistryError):
+    """``get_schema_for`` was called with a subspace that no template matches."""
+
+
+# -- Registry-format JSON Schema ---------------------------------------------
+
+
+_DIMENSION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "enum": ["string", "int", "float", "bool", "enum"]},
+        "values": {"type": "array", "items": {"type": "string"}},
+        "required": {"type": "boolean"},
+    },
+    "required": ["type"],
+    "additionalProperties": True,
+}
+
+
+_TAKE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "enabled": {"type": "boolean"},
+        "mode": {"type": "string", "enum": ["semantic", "exact"]},
+        "floor": {"type": "number"},
+        "margin": {"type": "number"},
+        "match_keys": {"type": "array", "items": {"type": "string"}},
+        "default_lease_seconds": {"type": "integer", "minimum": 0},
+    },
+    "required": ["enabled", "mode"],
+    "additionalProperties": True,
+}
+
+
+_READ_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "default_floor": {"type": "number"},
+        "default_n": {"type": "integer", "minimum": 1},
+    },
+    "required": ["default_floor", "default_n"],
+    "additionalProperties": True,
+}
+
+
+REGISTRY_FORMAT_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "RDR-110 subspace registry entry",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "tier": {"type": "string", "minLength": 1},
+        "content_type": {"type": "string", "enum": ["text", "json"]},
+        "embed_from": {"type": "string", "minLength": 1},
+        "dimensions": {
+            "type": "object",
+            "additionalProperties": _DIMENSION_SCHEMA,
+        },
+        "take": _TAKE_SCHEMA,
+        "read": _READ_SCHEMA,
+        "tiers": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+        "retention_seconds": {"type": "integer", "minimum": 0},
+    },
+    "required": [
+        "name",
+        "tier",
+        "content_type",
+        "embed_from",
+        "dimensions",
+        "take",
+        "read",
+        "tiers",
+        "retention_seconds",
+    ],
+    "additionalProperties": True,
+}
+
+
+_VALIDATOR = Draft202012Validator(REGISTRY_FORMAT_SCHEMA)
+
+
+# -- Schema dataclass --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SubspaceSchema:
+    """Parsed registry entry for one subspace template.
+
+    ``name`` may include ``<param>`` placeholders (single-segment) that
+    ``Registry.get_schema_for`` resolves against concrete subspace
+    strings at lookup time.
+    """
+
+    name: str
+    tier: str
+    content_type: str
+    embed_from: str
+    dimensions: dict[str, dict[str, Any]] = field(default_factory=dict)
+    take: dict[str, Any] = field(default_factory=dict)
+    read: dict[str, Any] = field(default_factory=dict)
+    tiers: list[str] = field(default_factory=list)
+    retention_seconds: int = 0
+    source_path: Path | None = None
+
+
+# -- Param matching ----------------------------------------------------------
+
+
+# Param identifiers follow Python regex named-group rules — no dashes
+# (CPython rejects ``(?P<a-b>...)``). Mirror that constraint here so a
+# typo in a template name fails at YAML load rather than producing a
+# broken matcher that silently never matches.
+_PARAM_PATTERN = re.compile(r"<([a-zA-Z_][a-zA-Z0-9_]*)>")
+
+
+def _compile_template(template_name: str) -> re.Pattern[str]:
+    """Compile a template like ``tasks/<project>`` into a regex.
+
+    Each ``<param>`` matches a single path segment (one or more chars
+    other than ``/``). The whole template is anchored.
+    """
+    escaped = re.escape(template_name)
+    # ``re.escape`` escapes the angle brackets too — restore them so the
+    # param substitution below works on the original character class.
+    escaped = escaped.replace(r"\<", "<").replace(r"\>", ">")
+    pattern = _PARAM_PATTERN.sub(r"(?P<\1>[^/]+)", escaped)
+    return re.compile(rf"^{pattern}$")
+
+
+# -- Registry ----------------------------------------------------------------
+
+
+@dataclass
+class Registry:
+    """In-memory collection of validated subspace schemas."""
+
+    _by_template: dict[str, SubspaceSchema] = field(default_factory=dict)
+    _matchers: list[tuple[re.Pattern[str], SubspaceSchema]] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, builtin_dir: Path) -> "Registry":
+        """Load + validate every ``*.yml`` under *builtin_dir*.
+
+        Raises:
+            RegistryLoadError: a file fails YAML parse, JSON Schema
+                validation, additional load-time invariants
+                (``mode=exact`` requires non-empty ``match_keys``), or a
+                subspace name collides with one already loaded.
+        """
+        if not builtin_dir.is_dir():
+            raise RegistryLoadError(
+                f"builtin dir does not exist or is not a directory: {builtin_dir}"
+            )
+
+        registry = cls()
+        for yml_path in sorted(builtin_dir.glob("*.yml")):
+            schema = _load_one(yml_path)
+            if schema.name in registry._by_template:
+                raise RegistryLoadError(
+                    f"{yml_path.name}: duplicate subspace name "
+                    f"{schema.name!r} (also in "
+                    f"{registry._by_template[schema.name].source_path})"
+                )
+            registry._by_template[schema.name] = schema
+            registry._matchers.append((_compile_template(schema.name), schema))
+
+        _log.info(
+            "tuplespace_registry_loaded",
+            builtin_dir=str(builtin_dir),
+            count=len(registry._by_template),
+        )
+        return registry
+
+    def get_schema_for(self, subspace: str) -> SubspaceSchema:
+        """Return the template that matches *subspace* (concrete or templated).
+
+        Raises:
+            UnknownSubspaceError: no loaded template matches.
+        """
+        if not subspace:
+            raise UnknownSubspaceError("empty subspace")
+
+        # Fast path: literal name match (no params).
+        literal = self._by_template.get(subspace)
+        if literal is not None:
+            return literal
+
+        for matcher, schema in self._matchers:
+            if matcher.fullmatch(subspace) is not None:
+                return schema
+        raise UnknownSubspaceError(
+            f"no registered template matches subspace {subspace!r}"
+        )
+
+    def schemas(self) -> list[SubspaceSchema]:
+        """All loaded schemas in load order."""
+        return list(self._by_template.values())
+
+
+def _load_one(yml_path: Path) -> SubspaceSchema:
+    """Parse, validate, and convert one YAML file into a ``SubspaceSchema``."""
+    try:
+        raw = yaml.safe_load(yml_path.read_text())
+    except yaml.YAMLError as exc:
+        raise RegistryLoadError(f"{yml_path.name}: malformed YAML — {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise RegistryLoadError(
+            f"{yml_path.name}: top-level YAML must be a mapping, got {type(raw).__name__}"
+        )
+
+    try:
+        _VALIDATOR.validate(raw)
+    except ValidationError as exc:
+        # Surface the JSON-pointer path so debugging is precise.
+        path = "/".join(str(p) for p in exc.absolute_path) or "<root>"
+        raise RegistryLoadError(
+            f"{yml_path.name}: schema validation failed at {path}: {exc.message}"
+        ) from exc
+
+    take = raw["take"]
+    if take.get("mode") == "exact":
+        keys = take.get("match_keys") or []
+        if not keys:
+            raise RegistryLoadError(
+                f"{yml_path.name}: take.mode='exact' requires non-empty "
+                "match_keys (RDR-110 §C2)"
+            )
+
+    return SubspaceSchema(
+        name=raw["name"],
+        tier=raw["tier"],
+        content_type=raw["content_type"],
+        embed_from=raw["embed_from"],
+        dimensions=dict(raw.get("dimensions", {})),
+        take=dict(take),
+        read=dict(raw["read"]),
+        tiers=list(raw["tiers"]),
+        retention_seconds=int(raw["retention_seconds"]),
+        source_path=yml_path,
+    )
+
+
+# -- Default builtin location ------------------------------------------------
+
+
+def default_builtin_dir() -> Path:
+    """Return the repo's canonical ``nx/tuplespace/builtin/`` directory.
+
+    Resolves relative to the running package: walks up from this file
+    to the repo root and then into ``nx/tuplespace/builtin/``. Works
+    for editable installs (``uv sync``) and source checkouts; for wheel
+    installs the path may not exist and callers can pass an explicit
+    directory to ``Registry.load`` instead.
+    """
+    here = Path(__file__).resolve()
+    # src/nexus/tuplespace/registry.py — four parent hops reach the repo
+    # root: tuplespace → nexus → src → repo.
+    repo_root = here.parent.parent.parent.parent
+    return repo_root / "nx" / "tuplespace" / "builtin"

--- a/tests/tuplespace/test_registry.py
+++ b/tests/tuplespace/test_registry.py
@@ -1,0 +1,306 @@
+"""Tests for nexus.tuplespace.registry — YAML loader + JSON Schema validation.
+
+RDR-110 P1.1 (nexus-rugy). The registry loads ``nx/tuplespace/builtin/*.yml``,
+validates each against an inline JSON Schema for the registry format,
+and exposes ``get_schema_for(subspace)`` with single-segment
+parameterised matching (``tasks/<project>`` matches ``tasks/nexus``).
+
+This bead has NO SQLite, NO daemon — pure YAML + JSON Schema (RDR-110
+§Implementation Plan Step 1, §Storage-boundary in the bead).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+_VALID_TASKS_YAML = """
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status:    { type: enum, values: [open, in_progress, done, cancelled], required: true }
+  priority:  { type: enum, values: [P0, P1, P2, P3, P4], required: true }
+  assignee:  { type: string, required: false }
+  created_by: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.55
+  margin: 0.08
+  default_lease_seconds: 600
+read:
+  default_floor: 0.40
+  default_n: 5
+tiers: [project]
+retention_seconds: 7776000
+"""
+
+
+_VALID_LOCKS_YAML = """
+name: locks/<resource>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  resource: { type: string, required: true }
+  holder:   { type: string, required: true }
+take:
+  enabled: true
+  mode: exact
+  match_keys: [resource]
+  default_lease_seconds: 30
+read:
+  default_floor: 0.0
+  default_n: 1
+tiers: [project]
+retention_seconds: 86400
+"""
+
+
+@pytest.fixture
+def builtin_dir(tmp_path: Path) -> Path:
+    """Build a synthetic ``nx/tuplespace/builtin/`` directory."""
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "tasks.yml").write_text(_VALID_TASKS_YAML)
+    (d / "locks.yml").write_text(_VALID_LOCKS_YAML)
+    return d
+
+
+# -- Happy-path loading ------------------------------------------------------
+
+
+def test_registry_loads_valid_yaml_files(builtin_dir):
+    from nexus.tuplespace.registry import Registry
+
+    reg = Registry.load(builtin_dir)
+
+    names = {s.name for s in reg.schemas()}
+    assert names == {"tasks/<project>", "locks/<resource>"}
+
+
+def test_subspace_schema_fields_are_populated(builtin_dir):
+    from nexus.tuplespace.registry import Registry
+
+    reg = Registry.load(builtin_dir)
+    schema = reg.get_schema_for("tasks/nexus")
+
+    assert schema.name == "tasks/<project>"
+    assert schema.tier == "project"
+    assert schema.content_type == "text"
+    assert schema.embed_from == "content"
+    assert schema.tiers == ["project"]
+    assert schema.retention_seconds == 7776000
+    assert schema.dimensions["status"]["type"] == "enum"
+    assert schema.dimensions["status"]["required"] is True
+    assert schema.take["mode"] == "semantic"
+    assert schema.take["floor"] == 0.55
+
+
+# -- Parameterised matching --------------------------------------------------
+
+
+def test_parameterised_template_matches_concrete_subspace(builtin_dir):
+    from nexus.tuplespace.registry import Registry
+
+    reg = Registry.load(builtin_dir)
+
+    assert reg.get_schema_for("tasks/nexus").name == "tasks/<project>"
+    assert reg.get_schema_for("tasks/another-project").name == "tasks/<project>"
+    assert reg.get_schema_for("locks/db-write").name == "locks/<resource>"
+
+
+def test_parameterised_param_matches_single_segment_only(builtin_dir):
+    """``tasks/<project>`` MUST NOT match ``tasks/a/b`` — params are
+    single-segment by RDR-110 §Step 1.
+    """
+    from nexus.tuplespace.registry import Registry, UnknownSubspaceError
+
+    reg = Registry.load(builtin_dir)
+
+    with pytest.raises(UnknownSubspaceError):
+        reg.get_schema_for("tasks/a/b")
+
+
+def test_unknown_subspace_raises(builtin_dir):
+    from nexus.tuplespace.registry import Registry, UnknownSubspaceError
+
+    reg = Registry.load(builtin_dir)
+
+    with pytest.raises(UnknownSubspaceError, match="mailbox/anyone"):
+        reg.get_schema_for("mailbox/anyone")
+
+
+def test_multi_param_template_matches(tmp_path):
+    """Templates with two single-segment params resolve correctly."""
+    from nexus.tuplespace.registry import Registry
+
+    yml = yaml.safe_dump(
+        {
+            "name": "mailbox/<agent>/<inbox>",
+            "tier": "project",
+            "content_type": "text",
+            "embed_from": "content",
+            "dimensions": {"sender": {"type": "string", "required": True}},
+            "take": {"enabled": True, "mode": "semantic"},
+            "read": {"default_floor": 0.4, "default_n": 5},
+            "tiers": ["project"],
+            "retention_seconds": 3600,
+        }
+    )
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "mailbox.yml").write_text(yml)
+
+    reg = Registry.load(d)
+    schema = reg.get_schema_for("mailbox/alice/primary")
+    assert schema.name == "mailbox/<agent>/<inbox>"
+
+
+def test_dashed_param_name_is_rejected_as_literal(tmp_path):
+    """Param identifiers follow Python named-group rules (no dashes).
+
+    ``mailbox/<agent-name>`` would compile to an invalid named group at
+    runtime; the loader treats the placeholder as a literal so the
+    template only ever matches itself, surfacing the bad name on first
+    use rather than producing a silently-broken matcher.
+    """
+    from nexus.tuplespace.registry import Registry, UnknownSubspaceError
+
+    yml = yaml.safe_dump(
+        {
+            "name": "mailbox/<agent-name>",
+            "tier": "project",
+            "content_type": "text",
+            "embed_from": "content",
+            "dimensions": {},
+            "take": {"enabled": True, "mode": "semantic"},
+            "read": {"default_floor": 0.4, "default_n": 5},
+            "tiers": ["project"],
+            "retention_seconds": 3600,
+        }
+    )
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "bad.yml").write_text(yml)
+
+    reg = Registry.load(d)
+    # The literal template name resolves (fast-path), but no concrete
+    # mailbox/<X> matches because the placeholder was not substituted.
+    assert reg.get_schema_for("mailbox/<agent-name>").name == "mailbox/<agent-name>"
+    with pytest.raises(UnknownSubspaceError):
+        reg.get_schema_for("mailbox/alice")
+
+
+def test_empty_subspace_raises(builtin_dir):
+    from nexus.tuplespace.registry import Registry, UnknownSubspaceError
+
+    reg = Registry.load(builtin_dir)
+
+    with pytest.raises(UnknownSubspaceError):
+        reg.get_schema_for("")
+
+
+# -- Validation errors -------------------------------------------------------
+
+
+def test_malformed_yaml_raises_at_load(tmp_path):
+    from nexus.tuplespace.registry import Registry, RegistryLoadError
+
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "bad.yml").write_text("name: tasks/<x>\n: : bad\n")
+
+    with pytest.raises(RegistryLoadError, match="bad.yml"):
+        Registry.load(d)
+
+
+def test_schema_violation_yaml_raises_at_load(tmp_path):
+    """Missing required top-level field (e.g. ``tier``) fails validation."""
+    from nexus.tuplespace.registry import Registry, RegistryLoadError
+
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "incomplete.yml").write_text("name: tasks/<project>\n")
+
+    with pytest.raises(RegistryLoadError, match="incomplete.yml"):
+        Registry.load(d)
+
+
+def test_invalid_take_mode_raises(tmp_path):
+    """``take.mode`` must be 'semantic' or 'exact' per the JSON schema."""
+    from nexus.tuplespace.registry import Registry, RegistryLoadError
+
+    bad_yaml = yaml.safe_dump(
+        {
+            "name": "things/<x>",
+            "tier": "project",
+            "content_type": "text",
+            "embed_from": "content",
+            "dimensions": {},
+            "take": {"enabled": True, "mode": "lol-fuzzy"},
+            "read": {"default_floor": 0.4, "default_n": 5},
+            "tiers": ["project"],
+            "retention_seconds": 3600,
+        }
+    )
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "bad-mode.yml").write_text(bad_yaml)
+
+    with pytest.raises(RegistryLoadError, match="bad-mode.yml"):
+        Registry.load(d)
+
+
+def test_exact_mode_without_match_keys_raises(tmp_path):
+    """``take.mode=exact`` requires non-empty ``match_keys`` (RDR-110 §C2)."""
+    from nexus.tuplespace.registry import Registry, RegistryLoadError
+
+    bad_yaml = yaml.safe_dump(
+        {
+            "name": "things/<x>",
+            "tier": "project",
+            "content_type": "text",
+            "embed_from": "content",
+            "dimensions": {"x": {"type": "string", "required": True}},
+            "take": {"enabled": True, "mode": "exact", "match_keys": []},
+            "read": {"default_floor": 0.4, "default_n": 5},
+            "tiers": ["project"],
+            "retention_seconds": 3600,
+        }
+    )
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "exact-no-keys.yml").write_text(bad_yaml)
+
+    with pytest.raises(RegistryLoadError, match="exact-no-keys.yml"):
+        Registry.load(d)
+
+
+def test_duplicate_subspace_names_raise(tmp_path):
+    """Two YAML files declaring the same subspace name must fail loudly."""
+    from nexus.tuplespace.registry import Registry, RegistryLoadError
+
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "a.yml").write_text(_VALID_TASKS_YAML)
+    (d / "b.yml").write_text(_VALID_TASKS_YAML)
+
+    with pytest.raises(RegistryLoadError, match="duplicate"):
+        Registry.load(d)
+
+
+# -- Production builtin dir --------------------------------------------------
+
+
+def test_real_builtin_dir_loads_cleanly():
+    """The ``nx/tuplespace/builtin/`` shipped with the repo must load."""
+    from nexus.tuplespace.registry import Registry, default_builtin_dir
+
+    reg = Registry.load(default_builtin_dir())
+    assert len(list(reg.schemas())) >= 1

--- a/tests/tuplespace/test_registry.py
+++ b/tests/tuplespace/test_registry.py
@@ -162,15 +162,15 @@ def test_multi_param_template_matches(tmp_path):
     assert schema.name == "mailbox/<agent>/<inbox>"
 
 
-def test_dashed_param_name_is_rejected_as_literal(tmp_path):
-    """Param identifiers follow Python named-group rules (no dashes).
+def test_dashed_param_name_raises_at_load(tmp_path):
+    """Param identifiers must match Python named-group syntax (no dashes).
 
     ``mailbox/<agent-name>`` would compile to an invalid named group at
-    runtime; the loader treats the placeholder as a literal so the
-    template only ever matches itself, surfacing the bad name on first
-    use rather than producing a silently-broken matcher.
+    runtime. The loader rejects this at load time so a YAML author sees
+    the failure immediately rather than discovering it on first ``take``
+    via an opaque ``UnknownSubspaceError``.
     """
-    from nexus.tuplespace.registry import Registry, UnknownSubspaceError
+    from nexus.tuplespace.registry import Registry, RegistryLoadError
 
     yml = yaml.safe_dump(
         {
@@ -189,12 +189,41 @@ def test_dashed_param_name_is_rejected_as_literal(tmp_path):
     d.mkdir()
     (d / "bad.yml").write_text(yml)
 
+    with pytest.raises(RegistryLoadError, match="agent-name"):
+        Registry.load(d)
+
+
+def test_empty_segment_rejected_in_multi_param_match(tmp_path):
+    """``mailbox/<agent>/<inbox>`` must not match ``mailbox//primary``.
+
+    The ``[^/]+`` quantifier rejects empty segments; pinning this here
+    guards against a future refactor of ``_compile_template`` that
+    switched the quantifier to ``*``.
+    """
+    from nexus.tuplespace.registry import Registry, UnknownSubspaceError
+
+    yml = yaml.safe_dump(
+        {
+            "name": "mailbox/<agent>/<inbox>",
+            "tier": "project",
+            "content_type": "text",
+            "embed_from": "content",
+            "dimensions": {"sender": {"type": "string", "required": True}},
+            "take": {"enabled": True, "mode": "semantic"},
+            "read": {"default_floor": 0.4, "default_n": 5},
+            "tiers": ["project"],
+            "retention_seconds": 3600,
+        }
+    )
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "mailbox.yml").write_text(yml)
+
     reg = Registry.load(d)
-    # The literal template name resolves (fast-path), but no concrete
-    # mailbox/<X> matches because the placeholder was not substituted.
-    assert reg.get_schema_for("mailbox/<agent-name>").name == "mailbox/<agent-name>"
     with pytest.raises(UnknownSubspaceError):
-        reg.get_schema_for("mailbox/alice")
+        reg.get_schema_for("mailbox//primary")
+    with pytest.raises(UnknownSubspaceError):
+        reg.get_schema_for("mailbox/alice/")
 
 
 def test_empty_subspace_raises(builtin_dir):

--- a/tests/tuplespace/test_registry.py
+++ b/tests/tuplespace/test_registry.py
@@ -193,6 +193,38 @@ def test_dashed_param_name_raises_at_load(tmp_path):
         Registry.load(d)
 
 
+def test_empty_angle_brackets_raise_at_load(tmp_path):
+    """``mailbox/<>`` is the dashed-param sibling: empty identifier.
+
+    Round-2 critic catch: the original ``_ANGLE_TOKEN`` regex used
+    ``[^>]+`` (one-or-more), so empty brackets produced zero captures
+    and slipped through the bad-param filter. The widened ``[^>]*``
+    regex captures the empty string, which ``_PARAM_PATTERN`` then
+    rejects.
+    """
+    from nexus.tuplespace.registry import Registry, RegistryLoadError
+
+    yml = yaml.safe_dump(
+        {
+            "name": "mailbox/<>",
+            "tier": "project",
+            "content_type": "text",
+            "embed_from": "content",
+            "dimensions": {},
+            "take": {"enabled": True, "mode": "semantic"},
+            "read": {"default_floor": 0.4, "default_n": 5},
+            "tiers": ["project"],
+            "retention_seconds": 3600,
+        }
+    )
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "bad.yml").write_text(yml)
+
+    with pytest.raises(RegistryLoadError, match="invalid param"):
+        Registry.load(d)
+
+
 def test_empty_segment_rejected_in_multi_param_match(tmp_path):
     """``mailbox/<agent>/<inbox>`` must not match ``mailbox//primary``.
 


### PR DESCRIPTION
## Summary

First Phase-1 substrate bead for RDR-110 — the subspace registry. Loads \`nx/tuplespace/builtin/*.yml\` at MCP/CLI startup, validates each file against an inline Draft-2020-12 JSON Schema, and exposes \`get_schema_for(subspace)\` with single-segment parameterised matching.

Pure substrate — no SQLite, no daemon, no HTTP. Daemon-side admin RPC for third-party registration ships under RDR-112 \`nexus-x98k\` in Phase 2.

- \`SubspaceSchema\` frozen dataclass with the 9 RDR-110 §Step 1 fields.
- \`Registry.load(builtin_dir)\` validates each YAML, detects duplicate names, sorts for determinism.
- \`get_schema_for(subspace)\` fast-paths on literal lookup, regex-matches on templates. Unknown raises \`UnknownSubspaceError\`.
- \`REGISTRY_FORMAT_SCHEMA\` enforces required keys, \`take.mode ∈ {semantic, exact}\`, \`content_type ∈ {text, json}\`. \`additionalProperties: true\` so downstream beads extend without bumping a registry version.
- Hand-coded post-validation: \`take.mode='exact'\` requires non-empty \`match_keys\` (§C2). Cleaner as imperative than JSON Schema \`if/then\`.
- \`_PARAM_PATTERN\` mirrors Python's named-group identifier rules — no dashes — so a typo like \`<agent-name>\` fails fast instead of compiling to a silently-broken matcher.

First built-in shipped: \`tasks/<project>\` with semantic take and standard \`status\`/\`priority\`/\`assignee\`/\`created_by\` dimensions. Locks/mailbox/events/barriers ship in follow-up beads.

## Test plan

14 tests, all green:

- [x] Valid YAML load + field population
- [x] Single-param template (\`tasks/<project>\`)
- [x] Multi-param template (\`mailbox/<agent>/<inbox>\`)
- [x] Single-segment param boundary (\`tasks/<project>\` does NOT match \`tasks/a/b\`)
- [x] Unknown / empty subspace → \`UnknownSubspaceError\`
- [x] Malformed YAML, schema-violation YAML → \`RegistryLoadError\` with filename + JSON-pointer
- [x] Invalid \`take.mode\` → \`RegistryLoadError\`
- [x] \`take.mode=exact\` with empty \`match_keys\` → \`RegistryLoadError\`
- [x] Duplicate subspace names across files → \`RegistryLoadError\`
- [x] Dashed-param regression (code-review catch)
- [x] Real \`nx/tuplespace/builtin/\` loads cleanly

## Closes

Bead: nexus-rugy
RDR: docs/rdr/rdr-110-semantic-tuple-space.md §Step 1