### PR TITLE
refactor(plan_library): delete_by_tag + plans_mtime encapsulation (nexus-j07g, RDR-112 P0.1)

### DIFF
--- a/src/nexus/commands/plan.py
+++ b/src/nexus/commands/plan.py
@@ -477,13 +477,7 @@ def reseed_cmd(force: bool) -> None:
     if force:
         lib = PlanLibrary(path=db_path)
         try:
-            with lib._lock:
-                cursor = lib.conn.execute(
-                    "DELETE FROM plans "
-                    "WHERE (',' || tags || ',') LIKE '%,builtin-template,%'"
-                )
-                lib.conn.commit()
-                removed = cursor.rowcount
+            removed = lib.delete_by_tag("builtin-template")
         finally:
             lib.close()
         click.echo(f"--force: removed {removed} builtin row(s).")

--- a/src/nexus/db/t2/plan_library.py
+++ b/src/nexus/db/t2/plan_library.py
@@ -406,6 +406,43 @@ class PlanLibrary:
             ).fetchone()
         return _row_to_dict(row) if row else None
 
+    def delete_by_tag(self, tag: str) -> int:
+        """Delete every plan whose ``tags`` column contains *tag* as a token.
+
+        RDR-112 P0.1 (nexus-j07g): closes the ``commands/plan.py`` reach-
+        through that ran ``DELETE`` directly via ``lib.conn``. Token
+        matching uses the ``',' || tags || ','`` LIKE pattern with an
+        explicit ESCAPE so a tag containing SQL wildcards (``%`` or
+        ``_``) cannot widen the match.
+
+        Returns the SQLite ``rowcount`` (number of rows removed).
+        """
+        escaped_tag = tag.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        like_pattern = f"%,{escaped_tag},%"
+        with self._lock:
+            cursor = self.conn.execute(
+                "DELETE FROM plans "
+                "WHERE (',' || tags || ',') LIKE ? ESCAPE '\\'",
+                (like_pattern,),
+            )
+            self.conn.commit()
+            return cursor.rowcount
+
+    def plans_mtime(self) -> float | None:
+        """Return the SQLite file's ``st_mtime`` for cache-staleness checks.
+
+        RDR-112 P0.1 (nexus-j07g): closes the ``mcp_infra`` reach-through
+        that called ``library.path.stat().st_mtime`` directly. Returns
+        ``None`` when the file is absent so callers can detect "no DB
+        yet" without an ``OSError`` round-trip.
+        """
+        try:
+            return self.path.stat().st_mtime
+        except FileNotFoundError:
+            return None
+        except OSError:
+            return None
+
     def delete_plan(self, plan_id: int) -> int:
         """Delete the plan with *plan_id*. Returns the row count removed.
 

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -175,11 +175,20 @@ _plan_cache_mtime: float = 0.0
 def _plan_library_mtime(library) -> float:
     """Return the SQLite file mtime for *library*, or 0.0 when unknown.
 
-    Falls back to 0.0 when the library does not expose a ``path``
-    attribute (in-memory or test-stub libraries) or when the file is
-    missing — both produce a stable repopulate-never-runs fallback that
-    matches the legacy single-populate contract.
+    RDR-112 P0.1 (nexus-j07g): delegates to ``library.plans_mtime()``
+    when present so daemon-mode swaps (Phase 1) can supply the watermark
+    without exposing a ``path`` attribute. Test stubs / in-memory
+    libraries that expose neither method nor ``path`` get the
+    legacy 0.0 fallback (repopulate-never-runs).
     """
+    mtime_fn = getattr(library, "plans_mtime", None)
+    if callable(mtime_fn):
+        try:
+            mtime = mtime_fn()
+        except OSError:
+            mtime = None
+        return float(mtime) if mtime is not None else 0.0
+    # Legacy fallback: pre-encapsulation stubs without plans_mtime().
     path = getattr(library, "path", None)
     if path is None:
         return 0.0

--- a/tests/test_plan_library.py
+++ b/tests/test_plan_library.py
@@ -915,3 +915,96 @@ def test_search_plans_still_matches_raw_description(
     results = plan_db.search_plans("semantic")
     assert results, "description tokens still FTS-hit via match_text"
     assert "semantic" in results[0]["query"]
+
+
+# ── delete_by_tag + plans_mtime (RDR-112 P0.1 / nexus-j07g) ──────────────────
+
+
+def test_delete_by_tag_removes_matching_rows(plan_db: T2Database) -> None:
+    """``delete_by_tag`` removes only rows whose ``tags`` includes the tag."""
+    plan_db.save_plan(query="builtin-a", plan_json="{}", tags="builtin-template,other")
+    plan_db.save_plan(query="builtin-b", plan_json="{}", tags="builtin-template")
+    plan_db.save_plan(query="user-c", plan_json="{}", tags="custom")
+
+    removed = plan_db.plans.delete_by_tag("builtin-template")
+    assert removed == 2
+
+    rows = plan_db.plans.conn.execute("SELECT query FROM plans").fetchall()
+    assert [r[0] for r in rows] == ["user-c"]
+
+
+def test_delete_by_tag_zero_when_unknown(plan_db: T2Database) -> None:
+    """No matching rows → 0 returned, no errors."""
+    plan_db.save_plan(query="solo", plan_json="{}", tags="custom")
+
+    assert plan_db.plans.delete_by_tag("nope") == 0
+    assert plan_db.plans.conn.execute("SELECT COUNT(*) FROM plans").fetchone()[0] == 1
+
+
+def test_delete_by_tag_substring_safe(plan_db: T2Database) -> None:
+    """Match a whole comma-delimited token, not a substring."""
+    plan_db.save_plan(query="prefixed", plan_json="{}", tags="builtin-template-extra")
+    plan_db.save_plan(query="exact", plan_json="{}", tags="builtin-template")
+
+    removed = plan_db.plans.delete_by_tag("builtin-template")
+    assert removed == 1
+    remaining = plan_db.plans.conn.execute("SELECT query FROM plans").fetchall()
+    assert [r[0] for r in remaining] == ["prefixed"]
+
+
+def test_delete_by_tag_escapes_sql_wildcards(plan_db: T2Database) -> None:
+    """A tag containing ``%`` or ``_`` must not widen the match.
+
+    Pre-ESCAPE the pattern ``%,1_x,%`` would match any tag with
+    ``1<anychar>x``, hitting ``1Ax`` rows by accident.
+    """
+    plan_db.save_plan(query="exact", plan_json="{}", tags="1_x")
+    plan_db.save_plan(query="wildcarded", plan_json="{}", tags="1Ax")
+
+    removed = plan_db.plans.delete_by_tag("1_x")
+    assert removed == 1
+    remaining = plan_db.plans.conn.execute("SELECT query FROM plans").fetchall()
+    assert [r[0] for r in remaining] == ["wildcarded"]
+
+
+def test_plans_mtime_returns_float_when_db_exists(plan_db: T2Database) -> None:
+    """``plans_mtime`` returns a stat-derived float on a real SQLite file."""
+    mtime = plan_db.plans.plans_mtime()
+    assert isinstance(mtime, float)
+    assert mtime > 0.0
+
+
+def test_plans_mtime_advances_after_write(plan_db: T2Database) -> None:
+    """A write to the plans table moves the file mtime forward."""
+    import time
+
+    before = plan_db.plans.plans_mtime()
+    assert before is not None
+
+    # 50ms clears any sub-second mtime resolution on tmp_path filesystems.
+    time.sleep(0.05)
+    plan_db.save_plan(query="post-write", plan_json="{}", tags="x")
+
+    after = plan_db.plans.plans_mtime()
+    assert after is not None
+    assert after >= before
+
+
+def test_plans_mtime_returns_none_when_path_missing(tmp_path) -> None:
+    """``plans_mtime`` returns ``None`` when the SQLite file is absent."""
+    from nexus.db.t2.plan_library import PlanLibrary
+
+    path = tmp_path / "plans.db"
+    lib = PlanLibrary(path=path)
+    try:
+        lib.close()
+        # Wipe the SQLite file and any sidecars so the next stat misses.
+        for suffix in ("", "-wal", "-shm", "-journal"):
+            sidecar = path.with_name(path.name + suffix)
+            sidecar.unlink(missing_ok=True)
+        assert lib.plans_mtime() is None
+    finally:
+        try:
+            lib.close()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

Closes Phase-0 structural blocker #3 from the RDR-112 impact inventory: two reach-throughs into \`PlanLibrary\`'s public \`conn\`/\`path\` from outside the class. After Phase 1's daemon flip these become impossible (connection lives daemon-side), so close them while each is still independently PR-able.

- \`PlanLibrary.delete_by_tag(tag) -> int\` takes \`self._lock\` internally; LIKE ESCAPE protects against SQL wildcards in the tag string.
- \`PlanLibrary.plans_mtime() -> float | None\` returns \`None\` on \`FileNotFoundError\` / \`OSError\` so callers can detect "no DB yet" without a stat round-trip.
- \`commands/plan.py\` reseed-cmd flips its private \`with lib._lock: lib.conn.execute(DELETE…)\` block to one \`lib.delete_by_tag("builtin-template")\` call.
- \`mcp_infra._plan_library_mtime\` prefers \`library.plans_mtime()\` when callable; legacy path-stat fallback retained for test stubs.

\`PlanLibrary.conn\` and \`PlanLibrary.path\` stay public (deprecation lint is RDR-112 Phase 6 / nexus-1u5v).

## Test plan

7 new tests, all green:

- [x] \`delete_by_tag\` removes only matching rows (rowcount)
- [x] Zero rows when tag unknown
- [x] Token boundary: \`builtin-template\` ≠ \`builtin-template-extra\`
- [x] LIKE ESCAPE: tag \`1_x\` does not match \`1Ax\` (code-review catch)
- [x] \`plans_mtime\` returns a float on a live DB
- [x] mtime advances after a write
- [x] Returns \`None\` when path absent

Adjacent suites pass: 135 plan-library/cmd/match/cache tests.

## Closes

Bead: nexus-j07g
RDR: docs/rdr/rdr-112-storage-as-service-container-boundary.md §Phase 0