### PR TITLE
refactor(memory_store): record_hook_failure encapsulates hook_failures writes (nexus-xmu5, RDR-112 P0.2)

### DIFF
--- a/src/nexus/db/t2/memory_store.py
+++ b/src/nexus/db/t2/memory_store.py
@@ -36,6 +36,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal
 
+HookFailureChain = Literal["single", "batch", "document"]
+
 import structlog
 
 from nexus.session import read_claude_session_id as _read_session_id
@@ -713,7 +715,7 @@ class MemoryStore:
         collection: str,
         hook_name: str,
         error: str,
-        chain: str = "single",
+        chain: HookFailureChain = "single",
         batch_doc_ids: list[str] | None = None,
     ) -> None:
         """Persist a post-store hook failure to T2 ``hook_failures``.
@@ -731,10 +733,14 @@ class MemoryStore:
             hook_name: hook callable name (for triage).
             error: free-text error message; truncated to 2000 chars.
             chain: ``single`` | ``batch`` | ``document`` per RDR-089
-                4.14.2 schema.
+                4.14.2 schema. Typed as ``HookFailureChain`` so the
+                Phase-1 RPC freeze does not pin a free-text string.
             batch_doc_ids: full doc-id list for ``chain='batch'``;
                 serialised as JSON into the ``batch_doc_ids`` column
-                and ``is_batch=1`` is set. Ignored for other chains.
+                and ``is_batch=1`` is set. **Must be non-empty when
+                chain='batch'**; ``None`` or ``[]`` raises ValueError
+                (a row with ``is_batch=1`` and no recoverable identity
+                is worse than a loud failure). Ignored for other chains.
 
         Schema fallback: on a pre-4.14.2 DB the ``chain`` column is
         absent; on a pre-4.14.1 DB ``batch_doc_ids``/``is_batch`` are
@@ -745,11 +751,14 @@ class MemoryStore:
         ``mcp_infra`` can log + swallow.
         """
         import json
-        import sqlite3
 
-        if chain == "batch" and batch_doc_ids is None:
+        if chain == "batch" and not batch_doc_ids:
+            # Reject both ``None`` and empty list — the daemon-RPC path
+            # in Phase 1 will serialise this kwarg, so a None-or-[] from
+            # a misbehaving client must not silently produce an
+            # ``is_batch=1`` row with no recoverable identity.
             raise ValueError(
-                "batch_doc_ids must be provided when chain='batch'"
+                "batch_doc_ids must be a non-empty list when chain='batch'"
             )
 
         truncated = error[: self.HOOK_FAILURE_ERROR_MAX]

--- a/src/nexus/db/t2/memory_store.py
+++ b/src/nexus/db/t2/memory_store.py
@@ -698,6 +698,120 @@ class MemoryStore:
             self.conn.commit()
         return cursor.rowcount > 0
 
+    # ── Cross-cutting hook_failures owner (RDR-112 P0.2 / nexus-xmu5) ─────
+
+    #: Cap on the ``error`` column's persisted length. Long stack traces
+    #: blow up storage and never carry signal past the first ~2 KB; the
+    #: cap is shared by all three call paths and validated in the
+    #: truncation test.
+    HOOK_FAILURE_ERROR_MAX = 2000
+
+    def record_hook_failure(
+        self,
+        *,
+        doc_id: str,
+        collection: str,
+        hook_name: str,
+        error: str,
+        chain: str = "single",
+        batch_doc_ids: list[str] | None = None,
+    ) -> None:
+        """Persist a post-store hook failure to T2 ``hook_failures``.
+
+        RDR-112 P0.2 (nexus-xmu5): the canonical writer for the cross-
+        cutting ``hook_failures`` table. Replaces three raw INSERTs
+        scattered across ``mcp_infra.py`` that reached through
+        ``t2.taxonomy.conn``.
+
+        Args:
+            doc_id: subject of failure — a scalar doc id for ``single``
+                and ``document`` chains, a representative id (first of
+                the batch) for ``batch``.
+            collection: collection name the hook fired on.
+            hook_name: hook callable name (for triage).
+            error: free-text error message; truncated to 2000 chars.
+            chain: ``single`` | ``batch`` | ``document`` per RDR-089
+                4.14.2 schema.
+            batch_doc_ids: full doc-id list for ``chain='batch'``;
+                serialised as JSON into the ``batch_doc_ids`` column
+                and ``is_batch=1`` is set. Ignored for other chains.
+
+        Schema fallback: on a pre-4.14.2 DB the ``chain`` column is
+        absent; on a pre-4.14.1 DB ``batch_doc_ids``/``is_batch`` are
+        also absent. The method retries with progressively fewer
+        columns so mixed-version operator scenarios still persist.
+        Persistence is best-effort at the caller level — secondary
+        write failures should propagate so the outer guard in
+        ``mcp_infra`` can log + swallow.
+        """
+        import json
+        import sqlite3
+
+        if chain == "batch" and batch_doc_ids is None:
+            raise ValueError(
+                "batch_doc_ids must be provided when chain='batch'"
+            )
+
+        truncated = error[: self.HOOK_FAILURE_ERROR_MAX]
+
+        with self._lock:
+            if chain == "batch":
+                payload = json.dumps(batch_doc_ids or [])
+                try:
+                    # 4.14.2: full shape — chain + is_batch + batch_doc_ids.
+                    self.conn.execute(
+                        "INSERT INTO hook_failures "
+                        "(doc_id, collection, hook_name, error, "
+                        " batch_doc_ids, is_batch, chain) "
+                        "VALUES (?, ?, ?, ?, ?, 1, 'batch')",
+                        (doc_id, collection, hook_name, truncated, payload),
+                    )
+                except sqlite3.OperationalError as exc:
+                    msg = str(exc)
+                    if "no column named" not in msg and "no such column" not in msg:
+                        raise
+                    try:
+                        # 4.14.1: is_batch + batch_doc_ids without chain.
+                        self.conn.execute(
+                            "INSERT INTO hook_failures "
+                            "(doc_id, collection, hook_name, error, "
+                            " batch_doc_ids, is_batch) "
+                            "VALUES (?, ?, ?, ?, ?, 1)",
+                            (doc_id, collection, hook_name, truncated, payload),
+                        )
+                    except sqlite3.OperationalError as exc2:
+                        msg2 = str(exc2)
+                        if "no column named" not in msg2 and "no such column" not in msg2:
+                            raise
+                        # 4.14.0: scalar-only.
+                        self.conn.execute(
+                            "INSERT INTO hook_failures "
+                            "(doc_id, collection, hook_name, error) "
+                            "VALUES (?, ?, ?, ?)",
+                            (doc_id, collection, hook_name, truncated),
+                        )
+            else:
+                try:
+                    # 4.14.2: chain column present.
+                    self.conn.execute(
+                        "INSERT INTO hook_failures "
+                        "(doc_id, collection, hook_name, error, chain) "
+                        "VALUES (?, ?, ?, ?, ?)",
+                        (doc_id, collection, hook_name, truncated, chain),
+                    )
+                except sqlite3.OperationalError as exc:
+                    msg = str(exc)
+                    if "no column named" not in msg and "no such column" not in msg:
+                        raise
+                    # Pre-4.14.2: chain column absent. Drop the marker.
+                    self.conn.execute(
+                        "INSERT INTO hook_failures "
+                        "(doc_id, collection, hook_name, error) "
+                        "VALUES (?, ?, ?, ?)",
+                        (doc_id, collection, hook_name, truncated),
+                    )
+            self.conn.commit()
+
     # ── Housekeeping ──────────────────────────────────────────────────────
 
     def expire(self) -> list[int]:

--- a/src/nexus/db/t2/memory_store.py
+++ b/src/nexus/db/t2/memory_store.py
@@ -752,6 +752,17 @@ class MemoryStore:
         """
         import json
 
+        # ``HookFailureChain = Literal[...]`` is a static-checker hint
+        # only; the interpreter accepts any string. Phase 1's daemon-RPC
+        # deserialiser does not yet exist, so enforce at runtime now to
+        # close the gap a misbehaving caller (test stub, future RPC
+        # client, raw Python) could exploit by writing an unrecognised
+        # chain value.
+        if chain not in ("single", "batch", "document"):
+            raise ValueError(
+                f"chain must be one of 'single' | 'batch' | 'document'; got {chain!r}"
+            )
+
         if chain == "batch" and not batch_doc_ids:
             # Reject both ``None`` and empty list — the daemon-RPC path
             # in Phase 1 will serialise this kwarg, so a None-or-[] from

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -442,33 +442,12 @@ def _record_hook_failure(
     the second failure (the primary warning already reached structlog)
     rather than mask the original hook exception.
     """
-    import sqlite3
-    truncated = error[:2000]
     try:
         with t2_ctx() as t2:
-            # ``hook_failures`` is cross-cutting — any domain's connection
-            # points at the same SQLite file. Use the taxonomy conn because
-            # the status line that surfaces these rows already reads there.
-            conn = t2.taxonomy.conn
-            with t2.taxonomy._lock:
-                try:
-                    conn.execute(
-                        "INSERT INTO hook_failures "
-                        "(doc_id, collection, hook_name, error, chain) "
-                        "VALUES (?, ?, ?, ?, 'single')",
-                        (doc_id, collection, hook_name, truncated),
-                    )
-                except sqlite3.OperationalError as exc:
-                    msg = str(exc)
-                    if "no column named" not in msg and "no such column" not in msg:
-                        raise
-                    # Pre-4.14.2 schema: chain column absent.
-                    conn.execute(
-                        "INSERT INTO hook_failures "
-                        "(doc_id, collection, hook_name, error) VALUES (?, ?, ?, ?)",
-                        (doc_id, collection, hook_name, truncated),
-                    )
-                conn.commit()
+            t2.memory.record_hook_failure(
+                doc_id=doc_id, collection=collection,
+                hook_name=hook_name, error=error, chain="single",
+            )
     except Exception:
         import structlog
         structlog.get_logger().debug(
@@ -612,54 +591,14 @@ def _record_batch_hook_failure(
     semantics as ``_record_hook_failure``: persistence failure cannot
     break ingest.
     """
-    import json
-    import sqlite3
     representative = doc_ids[0] if doc_ids else ""
-    payload = json.dumps(doc_ids)
-    truncated = error[:2000]
     try:
         with t2_ctx() as t2:
-            conn = t2.taxonomy.conn
-            with t2.taxonomy._lock:
-                try:
-                    # 4.14.2 schema: dual-write chain alongside is_batch
-                    # so RDR-089 readers can classify rows by chain while
-                    # legacy readers still see is_batch=1.
-                    conn.execute(
-                        "INSERT INTO hook_failures "
-                        "(doc_id, collection, hook_name, error, "
-                        " batch_doc_ids, is_batch, chain) "
-                        "VALUES (?, ?, ?, ?, ?, 1, 'batch')",
-                        (representative, collection, hook_name, truncated, payload),
-                    )
-                except sqlite3.OperationalError as exc:
-                    # Pre-4.14.x schema: chain and/or batch columns may be
-                    # absent. Narrow catch to schema errors so transient
-                    # lock or I/O failures bubble up to the outer guard
-                    # rather than silently degrading the captured row.
-                    msg = str(exc)
-                    if "no column named" not in msg and "no such column" not in msg:
-                        raise
-                    # Try the 4.14.1 shape (is_batch + batch_doc_ids, no chain)
-                    # before falling back to scalar-only.
-                    try:
-                        conn.execute(
-                            "INSERT INTO hook_failures "
-                            "(doc_id, collection, hook_name, error, "
-                            " batch_doc_ids, is_batch) VALUES (?, ?, ?, ?, ?, 1)",
-                            (representative, collection, hook_name, truncated, payload),
-                        )
-                    except sqlite3.OperationalError as exc2:
-                        msg2 = str(exc2)
-                        if "no column named" not in msg2 and "no such column" not in msg2:
-                            raise
-                        conn.execute(
-                            "INSERT INTO hook_failures "
-                            "(doc_id, collection, hook_name, error) "
-                            "VALUES (?, ?, ?, ?)",
-                            (representative, collection, hook_name, truncated),
-                        )
-                conn.commit()
+            t2.memory.record_hook_failure(
+                doc_id=representative, collection=collection,
+                hook_name=hook_name, error=error,
+                chain="batch", batch_doc_ids=list(doc_ids),
+            )
     except Exception:
         import structlog
         structlog.get_logger().debug(
@@ -1118,33 +1057,14 @@ def _record_document_hook_failure(
     intermediate 4.14.1-shape schema to handle — the row either has
     ``chain`` (post-4.14.2) or it does not (pre-4.14.2 generic shape).
     """
-    import sqlite3
-    truncated = error[:2000]
     try:
         with t2_ctx() as t2:
-            conn = t2.taxonomy.conn
-            with t2.taxonomy._lock:
-                try:
-                    conn.execute(
-                        "INSERT INTO hook_failures "
-                        "(doc_id, collection, hook_name, error, chain) "
-                        "VALUES (?, ?, ?, ?, 'document')",
-                        (source_path, collection, hook_name, truncated),
-                    )
-                except sqlite3.OperationalError as exc:
-                    msg = str(exc)
-                    if "no column named" not in msg and "no such column" not in msg:
-                        raise
-                    # Pre-4.14.2 schema: chain column absent. Persist
-                    # without the chain marker — the row is still useful
-                    # for triage even if it cannot be classified by chain.
-                    conn.execute(
-                        "INSERT INTO hook_failures "
-                        "(doc_id, collection, hook_name, error) "
-                        "VALUES (?, ?, ?, ?)",
-                        (source_path, collection, hook_name, truncated),
-                    )
-                conn.commit()
+            # ``source_path`` lands in the ``doc_id`` column — the column
+            # carries 'subject of failure' regardless of chain shape.
+            t2.memory.record_hook_failure(
+                doc_id=source_path, collection=collection,
+                hook_name=hook_name, error=error, chain="document",
+            )
     except Exception:
         import structlog
         structlog.get_logger().debug(

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -591,7 +591,12 @@ def _record_batch_hook_failure(
     semantics as ``_record_hook_failure``: persistence failure cannot
     break ingest.
     """
-    representative = doc_ids[0] if doc_ids else ""
+    if not doc_ids:
+        # Empty batch -> no identity to persist; nothing to record.
+        # record_hook_failure also rejects empty batch_doc_ids so this
+        # early-return skips the t2_ctx round-trip cleanly.
+        return
+    representative = doc_ids[0]
     try:
         with t2_ctx() as t2:
             t2.memory.record_hook_failure(

--- a/tests/test_memory_store_hook_failures.py
+++ b/tests/test_memory_store_hook_failures.py
@@ -89,6 +89,20 @@ def test_record_hook_failure_truncates_error_to_cap(mem_db: T2Database) -> None:
     assert len(rows[0][3]) == MemoryStore.HOOK_FAILURE_ERROR_MAX
 
 
+def test_record_hook_failure_invalid_chain_raises(mem_db: T2Database) -> None:
+    """An unrecognised ``chain`` value is a contract bug, not silently stored.
+
+    ``HookFailureChain = Literal[...]`` is a static-checker hint only;
+    the runtime guard catches typos a misbehaving caller might smuggle
+    in (test stub, future RPC client, raw Python).
+    """
+    with pytest.raises(ValueError, match="single.*batch.*document"):
+        mem_db.memory.record_hook_failure(
+            doc_id="d", collection="c", hook_name="h", error="e",
+            chain="singleton",  # type: ignore[arg-type]
+        )
+
+
 def test_record_hook_failure_batch_without_doc_ids_raises(mem_db: T2Database) -> None:
     """Explicit ``chain='batch'`` with no ``batch_doc_ids`` is a contract bug."""
     with pytest.raises(ValueError, match="non-empty"):

--- a/tests/test_memory_store_hook_failures.py
+++ b/tests/test_memory_store_hook_failures.py
@@ -91,10 +91,24 @@ def test_record_hook_failure_truncates_error_to_cap(mem_db: T2Database) -> None:
 
 def test_record_hook_failure_batch_without_doc_ids_raises(mem_db: T2Database) -> None:
     """Explicit ``chain='batch'`` with no ``batch_doc_ids`` is a contract bug."""
-    with pytest.raises(ValueError, match="batch_doc_ids"):
+    with pytest.raises(ValueError, match="non-empty"):
         mem_db.memory.record_hook_failure(
             doc_id="rep", collection="c", hook_name="h", error="e",
             chain="batch",
+        )
+
+
+def test_record_hook_failure_batch_empty_doc_ids_raises(mem_db: T2Database) -> None:
+    """Explicit ``chain='batch'`` with empty ``batch_doc_ids`` is also rejected.
+
+    Catches a row with ``is_batch=1`` and no recoverable identity — a
+    daemon-RPC client passing ``[]`` (vs ``None``) would otherwise slip
+    through.
+    """
+    with pytest.raises(ValueError, match="non-empty"):
+        mem_db.memory.record_hook_failure(
+            doc_id="rep", collection="c", hook_name="h", error="e",
+            chain="batch", batch_doc_ids=[],
         )
 
 

--- a/tests/test_memory_store_hook_failures.py
+++ b/tests/test_memory_store_hook_failures.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for MemoryStore.record_hook_failure (RDR-112 P0.2 / nexus-xmu5).
+
+The method is the domain owner for the ``hook_failures`` table; three
+``mcp_infra`` raw-INSERT reach-throughs collapse into one call. Schema
+fallback is internal so the daemon-mode swap in Phase 1 sees a single
+RPC, not three subtly different ones.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from pathlib import Path
+
+import pytest
+
+from nexus.db.t2 import T2Database
+
+
+@pytest.fixture
+def mem_db(tmp_path: Path):
+    db = T2Database(tmp_path / "hf.db")
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _hook_failure_rows(db: T2Database) -> list[tuple]:
+    return db.memory.conn.execute(
+        "SELECT doc_id, collection, hook_name, error, chain, is_batch, batch_doc_ids "
+        "FROM hook_failures ORDER BY id"
+    ).fetchall()
+
+
+# -- Happy paths -------------------------------------------------------------
+
+
+def test_record_hook_failure_single(mem_db: T2Database) -> None:
+    mem_db.memory.record_hook_failure(
+        doc_id="doc-1", collection="code__x", hook_name="h1", error="boom",
+    )
+
+    rows = _hook_failure_rows(mem_db)
+    assert len(rows) == 1
+    doc_id, coll, hook, err, chain, is_batch, batch_ids = rows[0]
+    assert (doc_id, coll, hook, err) == ("doc-1", "code__x", "h1", "boom")
+    assert chain == "single"
+    assert (is_batch or 0) == 0
+    assert batch_ids is None
+
+
+def test_record_hook_failure_document(mem_db: T2Database) -> None:
+    mem_db.memory.record_hook_failure(
+        doc_id="/abs/x.md", collection="knowledge__d", hook_name="h2",
+        error="splat", chain="document",
+    )
+
+    rows = _hook_failure_rows(mem_db)
+    assert len(rows) == 1
+    assert rows[0][0] == "/abs/x.md"
+    assert rows[0][4] == "document"
+
+
+def test_record_hook_failure_batch_sets_marker_and_payload(mem_db: T2Database) -> None:
+    mem_db.memory.record_hook_failure(
+        doc_id="rep", collection="docs__x", hook_name="h3", error="oops",
+        chain="batch", batch_doc_ids=["a", "b", "c"],
+    )
+
+    rows = _hook_failure_rows(mem_db)
+    assert len(rows) == 1
+    doc_id, coll, hook, err, chain, is_batch, batch_ids = rows[0]
+    assert chain == "batch"
+    assert is_batch == 1
+    assert json.loads(batch_ids) == ["a", "b", "c"]
+
+
+def test_record_hook_failure_truncates_error_to_cap(mem_db: T2Database) -> None:
+    from nexus.db.t2.memory_store import MemoryStore
+
+    mem_db.memory.record_hook_failure(
+        doc_id="d", collection="c", hook_name="h",
+        error="x" * (MemoryStore.HOOK_FAILURE_ERROR_MAX + 3000),
+    )
+    rows = _hook_failure_rows(mem_db)
+    assert len(rows[0][3]) == MemoryStore.HOOK_FAILURE_ERROR_MAX
+
+
+def test_record_hook_failure_batch_without_doc_ids_raises(mem_db: T2Database) -> None:
+    """Explicit ``chain='batch'`` with no ``batch_doc_ids`` is a contract bug."""
+    with pytest.raises(ValueError, match="batch_doc_ids"):
+        mem_db.memory.record_hook_failure(
+            doc_id="rep", collection="c", hook_name="h", error="e",
+            chain="batch",
+        )
+
+
+# -- Schema fallback (pre-4.14.2 + pre-4.14.1) -------------------------------
+
+
+def _build_pre_4_14_2_db(path: Path) -> sqlite3.Connection:
+    """Construct a hook_failures schema at the 4.14.1 level (no chain column)."""
+    from nexus.db.migrations import (
+        migrate_hook_failures,
+        migrate_hook_failures_batch_columns,
+    )
+
+    raw = sqlite3.connect(str(path), isolation_level=None)
+    migrate_hook_failures(raw)
+    migrate_hook_failures_batch_columns(raw)
+    return raw
+
+
+def _build_pre_4_14_1_db(path: Path) -> sqlite3.Connection:
+    """Construct a hook_failures schema at the 4.14.0 level (scalar-only)."""
+    from nexus.db.migrations import migrate_hook_failures
+
+    raw = sqlite3.connect(str(path), isolation_level=None)
+    migrate_hook_failures(raw)
+    return raw
+
+
+def test_record_hook_failure_falls_back_when_chain_column_absent(tmp_path: Path) -> None:
+    """Pre-4.14.2 schema: chain column missing — must still persist."""
+    from nexus.db.t2.memory_store import MemoryStore
+
+    db_path = tmp_path / "pre_4_14_2.db"
+    raw = _build_pre_4_14_2_db(db_path)
+    raw.close()
+
+    store = MemoryStore.__new__(MemoryStore)
+    store.conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    store._lock = threading.Lock()
+
+    try:
+        store.record_hook_failure(
+            doc_id="d", collection="c", hook_name="h", error="e",
+            chain="document",
+        )
+        rows = store.conn.execute(
+            "SELECT doc_id, collection, hook_name, error FROM hook_failures"
+        ).fetchall()
+    finally:
+        store.conn.close()
+
+    assert rows == [("d", "c", "h", "e")]
+
+
+def test_record_hook_failure_falls_back_when_batch_columns_absent(tmp_path: Path) -> None:
+    """Pre-4.14.1 schema: chain AND batch columns missing — must still persist."""
+    from nexus.db.t2.memory_store import MemoryStore
+
+    db_path = tmp_path / "pre_4_14_1.db"
+    raw = _build_pre_4_14_1_db(db_path)
+    raw.close()
+
+    store = MemoryStore.__new__(MemoryStore)
+    store.conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    store._lock = threading.Lock()
+
+    try:
+        store.record_hook_failure(
+            doc_id="rep", collection="c", hook_name="h", error="e",
+            chain="batch", batch_doc_ids=["a", "b"],
+        )
+        rows = store.conn.execute(
+            "SELECT doc_id, collection, hook_name, error FROM hook_failures"
+        ).fetchall()
+    finally:
+        store.conn.close()
+
+    assert rows == [("rep", "c", "h", "e")]
+
+
+# -- Concurrency -------------------------------------------------------------
+
+
+def test_record_hook_failure_concurrent_writes(mem_db: T2Database) -> None:
+    """Many threads each record one row; all rows land, no exceptions."""
+    barrier = threading.Barrier(8)
+
+    def worker(i: int):
+        barrier.wait()
+        mem_db.memory.record_hook_failure(
+            doc_id=f"d{i}", collection="c", hook_name="h", error=f"err-{i}",
+        )
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    count = mem_db.memory.conn.execute(
+        "SELECT COUNT(*) FROM hook_failures"
+    ).fetchone()[0]
+    assert count == 8

--- a/tests/test_post_document_hooks.py
+++ b/tests/test_post_document_hooks.py
@@ -296,14 +296,23 @@ def test_fire_post_document_hooks_falls_back_to_scalar_when_chain_column_absent(
         "pre-condition: hook_failures must lack the chain column"
     )
 
+    from nexus.db.t2.memory_store import MemoryStore
+
     class _FakeTaxonomy:
         def __init__(self, conn: sqlite3.Connection) -> None:
             self.conn = conn
             self._lock = threading.RLock()
 
+    def _fake_memory(conn: sqlite3.Connection) -> MemoryStore:
+        store = MemoryStore.__new__(MemoryStore)
+        store.conn = conn
+        store._lock = threading.Lock()
+        return store
+
     class _FakeT2:
         def __init__(self, conn: sqlite3.Connection) -> None:
             self.taxonomy = _FakeTaxonomy(conn)
+            self.memory = _fake_memory(conn)
         def __enter__(self) -> "_FakeT2":
             return self
         def __exit__(self, *_: object) -> None:
@@ -562,14 +571,23 @@ def test_record_hook_failure_falls_back_when_chain_column_absent(
         "pre-condition: hook_failures must lack the chain column"
     )
 
+    from nexus.db.t2.memory_store import MemoryStore
+
     class _FakeTaxonomy:
         def __init__(self, conn: sqlite3.Connection) -> None:
             self.conn = conn
             self._lock = threading.RLock()
 
+    def _fake_memory(conn: sqlite3.Connection) -> MemoryStore:
+        store = MemoryStore.__new__(MemoryStore)
+        store.conn = conn
+        store._lock = threading.Lock()
+        return store
+
     class _FakeT2:
         def __init__(self, conn: sqlite3.Connection) -> None:
             self.taxonomy = _FakeTaxonomy(conn)
+            self.memory = _fake_memory(conn)
         def __enter__(self) -> "_FakeT2":
             return self
         def __exit__(self, *_: object) -> None:

--- a/tests/test_post_store_hook.py
+++ b/tests/test_post_store_hook.py
@@ -362,14 +362,23 @@ def test_fire_post_store_batch_hooks_falls_back_to_scalar_when_columns_absent(
         "pre-condition: hook_failures must lack batch_doc_ids before the test runs"
     )
 
+    from nexus.db.t2.memory_store import MemoryStore
+
     class _FakeTaxonomy:
         def __init__(self, conn: sqlite3.Connection) -> None:
             self.conn = conn
             self._lock = threading.RLock()
 
+    def _fake_memory(conn: sqlite3.Connection) -> MemoryStore:
+        store = MemoryStore.__new__(MemoryStore)
+        store.conn = conn
+        store._lock = threading.Lock()
+        return store
+
     class _FakeT2:
         def __init__(self, conn: sqlite3.Connection) -> None:
             self.taxonomy = _FakeTaxonomy(conn)
+            self.memory = _fake_memory(conn)
         def __enter__(self) -> "_FakeT2":
             return self
         def __exit__(self, *_: object) -> None:


### PR DESCRIPTION
## Summary

Phase 0 structural blocker #4: three raw INSERTs into \`hook_failures\` in \`mcp_infra.py\` reached through \`t2.taxonomy.conn\`. The first site's inline comment ("cross-cutting — any domain's connection points at the same SQLite file") signaled the table needs its own home; daemon mode (Phase 1) makes the reach-through impossible because no client-side conn exists.

- \`MemoryStore.record_hook_failure(*, doc_id, collection, hook_name, error, chain='single', batch_doc_ids=None)\` is the canonical writer.
- Internal 3-tier schema fallback: 4.14.2 (chain column) → 4.14.1 (batch columns) → 4.14.0 (scalar-only). Single/document need only 2 tiers; batch uses the full 3.
- \`HOOK_FAILURE_ERROR_MAX = 2000\` is a module constant (was magic 2000 duplicated at three sites).
- \`chain='batch'\` + \`batch_doc_ids=None\` now raises \`ValueError\` (code-review catch — once Phase 1's RPC boundary exists, a None slipping through serialization would silently write \`is_batch=1\` with an empty payload).
- Three \`_record_*_hook_failure\` helpers in \`mcp_infra\` collapse to single-line delegates wrapped in the existing outer best-effort try/except.

MemoryStore was the recommended owner per the bead (vs. a new \`HookFailureStore\`); the method does not touch the \`memory\` table — it only uses \`self.conn\`/\`self._lock\`, exactly the two resources it needs.

## Test plan

9 new contract tests + 3 mock updates, all green; full unit suite 7260 pass + 1 pre-existing environmental failure (stale aspect_worker lock).

- [x] single / document / batch happy paths
- [x] error truncation at \`HOOK_FAILURE_ERROR_MAX\`
- [x] \`chain='batch'\` + None → ValueError (code-review catch)
- [x] pre-4.14.2 fallback (chain column absent)
- [x] pre-4.14.1 fallback (chain + batch cols absent)
- [x] concurrent writes via \`self._lock\`
- [x] Existing \`test_post_document_hooks.py\` + \`test_post_store_hook.py\` fakes updated to expose \`.memory\` shim

## Closes

Bead: nexus-xmu5
RDR: docs/rdr/rdr-112-storage-as-service-container-boundary.md §Phase 0