### PR TITLE
test(cc-val): RDR-111 spike scaffolding for CA-8 + CA-6 (nexus-yi08, nexus-1h26)

### DIFF
--- a/nx/hooks/scripts/spike_ca6/README.md
+++ b/nx/hooks/scripts/spike_ca6/README.md
@@ -59,8 +59,9 @@ inventory.
      **Watch for**: any `Bash(*)` (or similar pre-approval) in your
      user-global `~/.claude/settings.json` short-circuits the prompt
      and silently defeats this trigger. Temporarily comment out the
-     allow rule for the duration of the spike, or run the spike under
-     a clean `$HOME` (`HOME=$(mktemp -d) claude ...`) to isolate.
+     allow rule for the duration of the spike (restore it after).
+     A clean `$HOME` would break OAuth auth — `.credentials.json`
+     lives under `~/.claude/` and the temp home has none.
 
 4. After each trigger, check `$NX_SPIKE_CAPTURE_DIR/<type>.jsonl`. The
    `payload` field is the verbatim stdin JSON Claude Code piped to the

--- a/nx/hooks/scripts/spike_ca6/README.md
+++ b/nx/hooks/scripts/spike_ca6/README.md
@@ -1,0 +1,87 @@
+# RDR-111 CA-6 spike (nexus-1h26) — payload capture for 4 inferred hook types
+
+Logging-only hooks for the four hook types whose payloads are marked
+`[inferred]` in RDR-111 §RF-1: `SubagentStop`, `UserPromptSubmit`,
+`PreCompact`, `Notification`. The bridge for these four types cannot
+ship until the empirical payloads are reconciled with the RF-1
+inventory.
+
+## How to run
+
+1. Pick a scratch Claude Code session. The capture dir defaults to
+   `~/.config/nexus/spike-ca6/`; override with
+   `NX_SPIKE_CAPTURE_DIR=$(pwd)/spike-out`.
+
+2. Add the four hooks to that session's `~/.claude/settings.json`
+   (replace `<NEXUS>` with the repo path):
+
+   ```json
+   {
+     "hooks": {
+       "SubagentStop": [
+         { "hooks": [{ "type": "command",
+           "command": "python3 <NEXUS>/nx/hooks/scripts/spike_ca6/log_payload.py SubagentStop" }] }
+       ],
+       "UserPromptSubmit": [
+         { "hooks": [{ "type": "command",
+           "command": "python3 <NEXUS>/nx/hooks/scripts/spike_ca6/log_payload.py UserPromptSubmit" }] }
+       ],
+       "PreCompact": [
+         { "hooks": [{ "type": "command",
+           "command": "python3 <NEXUS>/nx/hooks/scripts/spike_ca6/log_payload.py PreCompact" }] }
+       ],
+       "Notification": [
+         { "hooks": [{ "type": "command",
+           "command": "python3 <NEXUS>/nx/hooks/scripts/spike_ca6/log_payload.py Notification" }] }
+       ]
+     }
+   }
+   ```
+
+3. Trigger each hook type at least once in a live session:
+
+   - **`SubagentStop`** — `Agent({subagent_type: "general-purpose", prompt: "say hi", description: "spike trigger"})` and wait for return.
+   - **`UserPromptSubmit`** — fires on every user turn; one prompt is enough.
+   - **`PreCompact`** — type `/compact` in the session.
+   - **`Notification`** — wait for an idle-prompt notification, OR force one via a request that triggers a permission prompt.
+
+4. After each trigger, check `$NX_SPIKE_CAPTURE_DIR/<type>.jsonl`. The
+   `payload` field is the verbatim stdin JSON Claude Code piped to the
+   hook.
+
+## Reconcile with RDR-111 §RF-1
+
+For each of the four types, compare the captured `payload` against
+the RF-1 inventory entry. Outcomes:
+
+- **Field-for-field match** — flip the RF-1 row from `[inferred]` to
+  verified; bridge script can be authored against the documented
+  shape.
+- **Field discrepancy that does not change semantics** — update RF-1
+  with the verified shape, note the discrepancy.
+- **Field discrepancy that changes bridge mapping** — pause and flag.
+  Bridge for that hook type cannot ship until reconciled. Decide
+  whether the issue is an RF-1 schema mistake or a bridge-mapping
+  question.
+
+## Persist to T2
+
+One memo per type:
+
+```
+mcp__plugin_nx_nexus__memory_put project=nexus_rdr
+  title=111-research-CA-6-payloads-SubagentStop
+  content=<json + analysis>
+  tags=rdr-111,spike,CA-6,SubagentStop
+  ttl=0
+```
+
+Repeat for the other three types.
+
+## When the spike is complete
+
+- Four T2 memos exist: `111-research-CA-6-payloads-{SubagentStop,UserPromptSubmit,PreCompact,Notification}`.
+- RDR-111 §RF-1 has no remaining `[inferred]` rows for these four types.
+- The bead `nexus-1h26` is closed.
+- This directory (`nx/hooks/scripts/spike_ca6/`) can be deleted once
+  the bead is closed; the scaffolding is throwaway by design.

--- a/nx/hooks/scripts/spike_ca6/README.md
+++ b/nx/hooks/scripts/spike_ca6/README.md
@@ -56,6 +56,11 @@ inventory.
      then issue a Bash tool call that requires approval, e.g.
      `Bash(command="echo notification-trigger")`. Claude Code escalates
      to a permission prompt, which fires the Notification hook.
+     **Watch for**: any `Bash(*)` (or similar pre-approval) in your
+     user-global `~/.claude/settings.json` short-circuits the prompt
+     and silently defeats this trigger. Temporarily comment out the
+     allow rule for the duration of the spike, or run the spike under
+     a clean `$HOME` (`HOME=$(mktemp -d) claude ...`) to isolate.
 
 4. After each trigger, check `$NX_SPIKE_CAPTURE_DIR/<type>.jsonl`. The
    `payload` field is the verbatim stdin JSON Claude Code piped to the

--- a/nx/hooks/scripts/spike_ca6/README.md
+++ b/nx/hooks/scripts/spike_ca6/README.md
@@ -38,12 +38,24 @@ inventory.
    }
    ```
 
-3. Trigger each hook type at least once in a live session:
+3. Trigger each hook type at least once in a live session. Two need
+   explicit setup or they will not fire within the spike budget:
 
    - **`SubagentStop`** — `Agent({subagent_type: "general-purpose", prompt: "say hi", description: "spike trigger"})` and wait for return.
    - **`UserPromptSubmit`** — fires on every user turn; one prompt is enough.
-   - **`PreCompact`** — type `/compact` in the session.
-   - **`Notification`** — wait for an idle-prompt notification, OR force one via a request that triggers a permission prompt.
+   - **`PreCompact`** — `/compact` only fires the hook if the session
+     has enough context to actually compact. A scratch session with only
+     the three triggers above is below threshold and `/compact` will
+     no-op. Pre-fill the context: paste a large block of text (5-10 K
+     tokens) or run several tool-heavy prompts, then `/compact`. If
+     `PreCompact.jsonl` stays empty, the session was under threshold;
+     add more context and try again.
+   - **`Notification`** — wait-for-idle is unreliable inside the spike
+     budget. The reliable path is a permission prompt: set
+     `"permissions": {"defaultMode": "default"}` (NOT auto-approve),
+     then issue a Bash tool call that requires approval, e.g.
+     `Bash(command="echo notification-trigger")`. Claude Code escalates
+     to a permission prompt, which fires the Notification hook.
 
 4. After each trigger, check `$NX_SPIKE_CAPTURE_DIR/<type>.jsonl`. The
    `payload` field is the verbatim stdin JSON Claude Code piped to the

--- a/nx/hooks/scripts/spike_ca6/log_payload.py
+++ b/nx/hooks/scripts/spike_ca6/log_payload.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""RDR-111 CA-6 spike (nexus-1h26): logging-only hook payload capture.
+
+Reads the hook's stdin JSON and appends it to a per-type capture file at
+``$NX_SPIKE_CAPTURE_DIR/<hook_type>.jsonl``. Writes nothing to stdout so
+the hook is a true no-op for the session.
+
+The capture-dir default is ``~/.config/nexus/spike-ca6/``. Set
+``NX_SPIKE_CAPTURE_DIR`` to redirect (cc-validation harness uses its
+TEST_HOME). Hook type comes from the script's first argv (registered
+per-type in settings.json), falling back to the script name.
+
+Usage in settings.json (per hook type):
+
+    "hooks": {
+      "SubagentStop": [
+        {"hooks": [{"type": "command",
+          "command": "python3 .../spike_ca6/log_payload.py SubagentStop"}]}
+      ],
+      ...
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def main() -> int:
+    hook_type = sys.argv[1] if len(sys.argv) > 1 else Path(sys.argv[0]).stem
+    capture_dir = Path(
+        os.environ.get(
+            "NX_SPIKE_CAPTURE_DIR",
+            str(Path.home() / ".config" / "nexus" / "spike-ca6"),
+        )
+    )
+    capture_dir.mkdir(parents=True, exist_ok=True)
+
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        payload = {"_raw": raw, "_parse_error": True}
+
+    record = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "hook_type": hook_type,
+        "payload": payload,
+    }
+    out = capture_dir / f"{hook_type}.jsonl"
+    with out.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nx/hooks/scripts/spike_ca6/log_payload.py
+++ b/nx/hooks/scripts/spike_ca6/log_payload.py
@@ -52,6 +52,10 @@ def main() -> int:
         "payload": payload,
     }
     out = capture_dir / f"{hook_type}.jsonl"
+    # Intentional: an IOError here (disk full, capture_dir unwritable)
+    # is a spike-fatal condition; the user wants to know capture is
+    # broken rather than silently lose payloads. Production hook scripts
+    # would swallow; this is a throwaway diagnostic and fail-loud wins.
     with out.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(record) + "\n")
     return 0

--- a/tests/cc-validation/scenarios/13_ca8_pretooluse_order.sh
+++ b/tests/cc-validation/scenarios/13_ca8_pretooluse_order.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Scenario 13 — CA-8 spike (nexus-yi08): PreToolUse multi-hook ordering.
+#
+# Two PreToolUse hooks registered on the same matcher, returning conflicting
+# permissionDecision values. Run twice with the registration order swapped to
+# discover which decision wins.
+#
+# Output:
+#   - $HOOK_LOG records firing order via timestamped "HOOK_{A,B}_FIRED" lines.
+#   - $STUB_LOG records whether the tool actually ran (i.e. an "allow" survived).
+#
+# The two sub-runs answer the question the RDR-111 §Step 1b spike asks: can
+# the ORB hook bridge register first-in-chain and expect its decision to
+# win, or must it register last / emit no permissionDecision key at all?
+#
+# Persist findings to T2: nexus_rdr/111-research-CA-8-spike.
+
+mkdir -p "$TEST_HOME/.claude"
+
+cat > "$TEST_HOME/.claude/hook_allow.sh" <<'EOF'
+#!/usr/bin/env bash
+INPUT=$(cat)
+echo "[$(date +%s%N)] HOOK_ALLOW_FIRED: $INPUT" >> "$HOOK_LOG"
+python3 -c 'import json; print(json.dumps({"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}))'
+EOF
+chmod +x "$TEST_HOME/.claude/hook_allow.sh"
+
+cat > "$TEST_HOME/.claude/hook_block.sh" <<'EOF'
+#!/usr/bin/env bash
+INPUT=$(cat)
+echo "[$(date +%s%N)] HOOK_BLOCK_FIRED: $INPUT" >> "$HOOK_LOG"
+python3 -c 'import json; print(json.dumps({"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"CA-8 spike: block hook"}}))'
+EOF
+chmod +x "$TEST_HOME/.claude/hook_block.sh"
+
+# ── Sub-run A: allow registered FIRST, block SECOND ──────────────────────────
+scenario "13a ca8_order: allow-first then block-second — which decision wins?"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "defaultMode": "default" },
+  "mcpServers": {
+    "stub": { "type": "stdio", "command": "python3",
+              "args": ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"],
+              "env": { "STUB_LOG": "$STUB_LOG" } }
+  },
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "mcp__stub__.*",
+        "hooks": [{ "type": "command", "command": "bash $TEST_HOME/.claude/hook_allow.sh" }] },
+      { "matcher": "mcp__stub__.*",
+        "hooks": [{ "type": "command", "command": "bash $TEST_HOME/.claude/hook_block.sh" }] }
+    ]
+  }
+}
+EOF
+
+: > "$HOOK_LOG"
+: > "$STUB_LOG"
+claude_start
+claude_prompt "Call mcp__stub__ping. Reply DONE."
+claude_wait 60
+
+allow_fired_a=0; grep -q HOOK_ALLOW_FIRED "$HOOK_LOG" && allow_fired_a=1
+block_fired_a=0; grep -q HOOK_BLOCK_FIRED "$HOOK_LOG" && block_fired_a=1
+tool_ran_a=0;    [[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_a=1
+
+claude_exit
+
+# ── Sub-run B: block registered FIRST, allow SECOND ──────────────────────────
+scenario "13b ca8_order: block-first then allow-second — which decision wins?"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "defaultMode": "default" },
+  "mcpServers": {
+    "stub": { "type": "stdio", "command": "python3",
+              "args": ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"],
+              "env": { "STUB_LOG": "$STUB_LOG" } }
+  },
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "mcp__stub__.*",
+        "hooks": [{ "type": "command", "command": "bash $TEST_HOME/.claude/hook_block.sh" }] },
+      { "matcher": "mcp__stub__.*",
+        "hooks": [{ "type": "command", "command": "bash $TEST_HOME/.claude/hook_allow.sh" }] }
+    ]
+  }
+}
+EOF
+
+: > "$HOOK_LOG"
+: > "$STUB_LOG"
+claude_start
+claude_prompt "Call mcp__stub__ping. Reply DONE."
+claude_wait 60
+
+allow_fired_b=0; grep -q HOOK_ALLOW_FIRED "$HOOK_LOG" && allow_fired_b=1
+block_fired_b=0; grep -q HOOK_BLOCK_FIRED "$HOOK_LOG" && block_fired_b=1
+tool_ran_b=0;    [[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_b=1
+
+claude_exit
+
+# ── Report ───────────────────────────────────────────────────────────────────
+echo ""
+echo "=========================================================================="
+echo "  CA-8 PreToolUse ordering result"
+echo "=========================================================================="
+echo "  13a (allow, block): allow_fired=$allow_fired_a block_fired=$block_fired_a  tool_ran=$tool_ran_a"
+echo "  13b (block, allow): allow_fired=$allow_fired_b block_fired=$block_fired_b  tool_ran=$tool_ran_b"
+echo ""
+echo "Interpretation map:"
+echo "  Both hooks fire + tool_ran differs by registration order"
+echo "                                  -> registration-order wins (first or last)"
+echo "  Both hooks fire + tool_ran same"
+echo "                                  -> one decision unconditionally wins (block wins?)"
+echo "  Only one hook fires             -> Claude Code short-circuits on first decision"
+echo ""
+echo "Persist outcome to T2:"
+echo "  mcp__plugin_nx_nexus__memory_put project=nexus_rdr"
+echo "                                   title=111-research-CA-8-spike"
+echo "                                   tags=rdr-111,spike,CA-8"
+echo "                                   ttl=0"
+echo ""
+echo "Then update RDR-111 §Step 2 with the confirmed registration strategy."

--- a/tests/cc-validation/scenarios/13_ca8_pretooluse_order.sh
+++ b/tests/cc-validation/scenarios/13_ca8_pretooluse_order.sh
@@ -67,8 +67,12 @@ block_fired_a=0; grep -q HOOK_BLOCK_FIRED "$HOOK_LOG" && block_fired_a=1
 tool_ran_a=0;    [[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_a=1
 # Capture FIRED count now — subsequent sub-runs wipe $HOOK_LOG, so
 # reading it in the report block would always return the last sub-run's
-# count (review round-2 regression catch).
-fired_count_a=$(grep -c FIRED "$HOOK_LOG" 2>/dev/null || echo 0)
+# count (review round-2 regression catch). Mirror the allow_fired_* /
+# tool_ran_* idiom rather than `grep -c || echo 0`: under
+# runner.sh's `set -euo pipefail`, grep -c on an empty file prints
+# "0" + exits 1, so the || branch fires and the variable becomes
+# "0\n0" (round-3 regression catch).
+fired_count_a=0; [[ -s "$HOOK_LOG" ]] && fired_count_a=$(grep -c FIRED "$HOOK_LOG")
 
 claude_exit
 
@@ -104,7 +108,7 @@ claude_wait 60
 allow_fired_b=0; grep -q HOOK_ALLOW_FIRED "$HOOK_LOG" && allow_fired_b=1
 block_fired_b=0; grep -q HOOK_BLOCK_FIRED "$HOOK_LOG" && block_fired_b=1
 tool_ran_b=0;    [[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_b=1
-fired_count_b=$(grep -c FIRED "$HOOK_LOG" 2>/dev/null || echo 0)
+fired_count_b=0; [[ -s "$HOOK_LOG" ]] && fired_count_b=$(grep -c FIRED "$HOOK_LOG")
 
 claude_exit
 
@@ -140,7 +144,7 @@ claude_wait 60
 
 allow_fired_c=0; grep -q HOOK_ALLOW_FIRED "$HOOK_LOG" && allow_fired_c=1
 tool_ran_c=0;    [[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_c=1
-fired_count_c=$(grep -c FIRED "$HOOK_LOG" 2>/dev/null || echo 0)
+fired_count_c=0; [[ -s "$HOOK_LOG" ]] && fired_count_c=$(grep -c FIRED "$HOOK_LOG")
 
 claude_exit
 

--- a/tests/cc-validation/scenarios/13_ca8_pretooluse_order.sh
+++ b/tests/cc-validation/scenarios/13_ca8_pretooluse_order.sh
@@ -65,6 +65,10 @@ claude_wait 60
 allow_fired_a=0; grep -q HOOK_ALLOW_FIRED "$HOOK_LOG" && allow_fired_a=1
 block_fired_a=0; grep -q HOOK_BLOCK_FIRED "$HOOK_LOG" && block_fired_a=1
 tool_ran_a=0;    [[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_a=1
+# Capture FIRED count now — subsequent sub-runs wipe $HOOK_LOG, so
+# reading it in the report block would always return the last sub-run's
+# count (review round-2 regression catch).
+fired_count_a=$(grep -c FIRED "$HOOK_LOG" 2>/dev/null || echo 0)
 
 claude_exit
 
@@ -100,6 +104,7 @@ claude_wait 60
 allow_fired_b=0; grep -q HOOK_ALLOW_FIRED "$HOOK_LOG" && allow_fired_b=1
 block_fired_b=0; grep -q HOOK_BLOCK_FIRED "$HOOK_LOG" && block_fired_b=1
 tool_ran_b=0;    [[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_b=1
+fired_count_b=$(grep -c FIRED "$HOOK_LOG" 2>/dev/null || echo 0)
 
 claude_exit
 
@@ -135,6 +140,7 @@ claude_wait 60
 
 allow_fired_c=0; grep -q HOOK_ALLOW_FIRED "$HOOK_LOG" && allow_fired_c=1
 tool_ran_c=0;    [[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_c=1
+fired_count_c=$(grep -c FIRED "$HOOK_LOG" 2>/dev/null || echo 0)
 
 claude_exit
 
@@ -149,8 +155,9 @@ echo "  13c (allow-only):   allow_fired=$allow_fired_c  tool_ran=$tool_ran_c  [b
 echo ""
 echo "Discriminator: number of FIRED lines per sub-run distinguishes"
 echo "'both hooks ran' from 'short-circuit on first decision'."
-echo "  13a FIRED count: $(grep -c FIRED "$HOOK_LOG" 2>/dev/null || echo 0)"
-echo "  13b FIRED count: $(grep -c FIRED "$HOOK_LOG" 2>/dev/null || echo 0)"
+echo "  13a FIRED count: $fired_count_a"
+echo "  13b FIRED count: $fired_count_b"
+echo "  13c FIRED count: $fired_count_c  [baseline; expect 1]"
 echo ""
 echo "Interpretation map (decision tree):"
 echo "  baseline tool_ran_c=0          -> harness setup is broken; spike inconclusive"

--- a/tests/cc-validation/scenarios/13_ca8_pretooluse_order.sh
+++ b/tests/cc-validation/scenarios/13_ca8_pretooluse_order.sh
@@ -29,7 +29,7 @@ cat > "$TEST_HOME/.claude/hook_block.sh" <<'EOF'
 #!/usr/bin/env bash
 INPUT=$(cat)
 echo "[$(date +%s%N)] HOOK_BLOCK_FIRED: $INPUT" >> "$HOOK_LOG"
-python3 -c 'import json; print(json.dumps({"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"CA-8 spike: block hook"}}))'
+python3 -c 'import json; print(json.dumps({"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"block","permissionDecisionReason":"CA-8 spike: block hook"}}))'
 EOF
 chmod +x "$TEST_HOME/.claude/hook_block.sh"
 
@@ -103,6 +103,41 @@ tool_ran_b=0;    [[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" &&
 
 claude_exit
 
+# ── Sub-run C: allow-only baseline ───────────────────────────────────────────
+# Confirms the harness path actually allows the tool through when no block
+# hook is present. Distinguishes "block won" from "tool never ran for other
+# reasons" in the two-hook runs above.
+scenario "13c ca8_order: allow-only baseline — does the tool run with no block hook?"
+
+cat > "$TEST_HOME/.claude/settings.json" <<EOF
+{
+  "skipDangerousModePermissionPrompt": true,
+  "permissions": { "defaultMode": "default" },
+  "mcpServers": {
+    "stub": { "type": "stdio", "command": "python3",
+              "args": ["$REPO_ROOT/tests/cc-validation/fixtures/stub_server.py"],
+              "env": { "STUB_LOG": "$STUB_LOG" } }
+  },
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "mcp__stub__.*",
+        "hooks": [{ "type": "command", "command": "bash $TEST_HOME/.claude/hook_allow.sh" }] }
+    ]
+  }
+}
+EOF
+
+: > "$HOOK_LOG"
+: > "$STUB_LOG"
+claude_start
+claude_prompt "Call mcp__stub__ping. Reply DONE."
+claude_wait 60
+
+allow_fired_c=0; grep -q HOOK_ALLOW_FIRED "$HOOK_LOG" && allow_fired_c=1
+tool_ran_c=0;    [[ -s "$STUB_LOG" ]] && grep -q '"tool": "ping"' "$STUB_LOG" && tool_ran_c=1
+
+claude_exit
+
 # ── Report ───────────────────────────────────────────────────────────────────
 echo ""
 echo "=========================================================================="
@@ -110,13 +145,21 @@ echo "  CA-8 PreToolUse ordering result"
 echo "=========================================================================="
 echo "  13a (allow, block): allow_fired=$allow_fired_a block_fired=$block_fired_a  tool_ran=$tool_ran_a"
 echo "  13b (block, allow): allow_fired=$allow_fired_b block_fired=$block_fired_b  tool_ran=$tool_ran_b"
+echo "  13c (allow-only):   allow_fired=$allow_fired_c  tool_ran=$tool_ran_c  [baseline]"
 echo ""
-echo "Interpretation map:"
-echo "  Both hooks fire + tool_ran differs by registration order"
-echo "                                  -> registration-order wins (first or last)"
-echo "  Both hooks fire + tool_ran same"
-echo "                                  -> one decision unconditionally wins (block wins?)"
-echo "  Only one hook fires             -> Claude Code short-circuits on first decision"
+echo "Discriminator: number of FIRED lines per sub-run distinguishes"
+echo "'both hooks ran' from 'short-circuit on first decision'."
+echo "  13a FIRED count: $(grep -c FIRED "$HOOK_LOG" 2>/dev/null || echo 0)"
+echo "  13b FIRED count: $(grep -c FIRED "$HOOK_LOG" 2>/dev/null || echo 0)"
+echo ""
+echo "Interpretation map (decision tree):"
+echo "  baseline tool_ran_c=0          -> harness setup is broken; spike inconclusive"
+echo "  both hooks fire (count==2 in each sub-run):"
+echo "    13a tool_ran != 13b tool_ran -> registration-order-wins (the second decision overrides)"
+echo "    13a tool_ran == 13b tool_ran -> AND-semantics: block always wins regardless of order"
+echo "  only one hook fires (count==1 in either sub-run):"
+echo "                                 -> short-circuit on first decision; registration-order-wins"
+echo "                                    (the second hook never gets to run)"
 echo ""
 echo "Persist outcome to T2:"
 echo "  mcp__plugin_nx_nexus__memory_put project=nexus_rdr"


### PR DESCRIPTION
## Summary

Scaffolding for the two RDR-111 Phase-1 empirical spikes. Both require live Claude Code sessions against billed auth, so this PR lands the runnable scaffolding and persists T2 memo skeletons; the user executes when convenient and fills in results. Beads stay \`in_progress\` until then.

### CA-8 (nexus-yi08) — PreToolUse multi-hook ordering

- New cc-validation scenario 13: \`tests/cc-validation/scenarios/13_ca8_pretooluse_order.sh\`
- Two sub-runs (allow-first/block-second vs block-first/allow-second) with one \`mcp__stub__ping\` each.
- Records firing order + whether the tool ran; discriminates registration-order-wins, unconditional-block-wins, and short-circuit-on-first.
- Execute: \`tests/cc-validation/runner.sh --scenario 13\`
- T2 memo skeleton: \`nexus_rdr/111-research-CA-8-spike\` (id 1252).

### CA-6 (nexus-1h26) — four inferred hook-type payloads

- \`nx/hooks/scripts/spike_ca6/log_payload.py\` — logging-only hook script; argv-dispatched so one script services all four registrations.
- README walks the four triggers: SubagentStop (Agent dispatch), UserPromptSubmit (any turn), PreCompact (\`/compact\`), Notification (permission prompt or idle).
- Compare captured payloads to RDR-111 §RF-1; flip \`[inferred]\` → verified or pause for reconciliation.
- T2 memo skeleton: \`nexus_rdr/111-research-CA-6-spike\` (id 1253).
- \`spike_ca6/\` is throwaway — delete after the bead closes.

## Test plan

- [x] Scenario 13 script is executable and follows the cc-validation harness primitives (mirrors scenario 07's allow/block hook shape and \`claude_start\` / \`claude_prompt\` / \`claude_wait\` cycle).
- [x] \`log_payload.py\` handles stdin gracefully (empty + non-JSON fallbacks), uses structlog conventions, no \`print()\`.
- [ ] **User to execute** \`runner.sh --scenario 13\` and complete the CA-8 result table in T2 memo 1252.
- [ ] **User to execute** the CA-6 four-trigger walk in a scratch session and complete T2 memo 1253 + per-type child memos.

## Closes

Bead-link (not closing): nexus-yi08, nexus-1h26 — beads stay \`in_progress\`; close them after execution + RDR-111 RF-1 updates.