### PR TITLE
refactor(taxonomy): encapsulate taxonomy_cmd reach-throughs (nexus-49bw, RDR-112 P0.5)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -695,3 +695,4 @@
 {"id":"int-db31f4fc","kind":"field_change","created_at":"2026-05-12T16:08:32.151086Z","actor":"Hellblazer","issue_id":"nexus-8g79.16","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-73a57147","kind":"field_change","created_at":"2026-05-12T16:31:07.573737Z","actor":"Hellblazer","issue_id":"nexus-8g79.18","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-a75c42ab","kind":"field_change","created_at":"2026-05-12T16:37:31.910235Z","actor":"Hellblazer","issue_id":"nexus-8g79.35","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-4fad911c","kind":"field_change","created_at":"2026-05-13T23:05:04.911918Z","actor":"Hellblazer","issue_id":"nexus-1tyq","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -185,13 +185,7 @@ def status_cmd(collection: str, limit: int, summary: bool, needs_review: bool) -
         # Storage review I-1: every .conn access goes through the
         # domain-store lock. These are read-only queries but the lock
         # protects against a concurrent writer on the same connection.
-        with db.taxonomy._lock:
-            all_topics = db.taxonomy.conn.execute(
-                "SELECT collection, COUNT(*), SUM(doc_count), "
-                "SUM(CASE WHEN review_status = 'pending' THEN 1 ELSE 0 END), "
-                "SUM(CASE WHEN review_status = 'accepted' THEN 1 ELSE 0 END) "
-                "FROM topics GROUP BY collection ORDER BY SUM(doc_count) DESC"
-            ).fetchall()
+        all_topics = db.taxonomy.get_collection_topic_stats()
 
         if not all_topics:
             click.echo("No taxonomy data. Run `nx index repo` or `nx taxonomy discover`.")
@@ -214,10 +208,7 @@ def status_cmd(collection: str, limit: int, summary: bool, needs_review: bool) -
             if n_topics > 0 and projection_counts.get(coll, 0) == 0
         ]
 
-        with db.taxonomy._lock:
-            link_count = db.taxonomy.conn.execute(
-                "SELECT COUNT(*) FROM topic_links"
-            ).fetchone()[0]
+        link_count = db.taxonomy.count_topic_links()
 
         # Apply filters
         rows = all_topics
@@ -234,12 +225,7 @@ def status_cmd(collection: str, limit: int, summary: bool, needs_review: bool) -
         if not summary:
             click.echo("Taxonomy Status\n")
             for coll, n_topics, n_docs, n_pending, n_accepted in rows:
-                with db.taxonomy._lock:
-                    meta = db.taxonomy.conn.execute(
-                        "SELECT last_discover_doc_count, last_discover_at "
-                        "FROM taxonomy_meta WHERE collection = ?",
-                        (coll,),
-                    ).fetchone()
+                meta = db.taxonomy.get_taxonomy_meta(coll)
 
                 rebal = ""
                 if meta:
@@ -282,27 +268,11 @@ def status_cmd(collection: str, limit: int, summary: bool, needs_review: bool) -
         # exceed the row count. Reading is best-effort: pre-4.9.10 DBs
         # have no table; pre-4.14.1 DBs have no batch columns. Each path
         # falls back without crashing.
-        rows: list[tuple[str, int, int, str | None]] = []
         try:
-            with db.taxonomy._lock:
-                try:
-                    rows = db.taxonomy.conn.execute(
-                        "SELECT hook_name, is_batch, "
-                        "       COALESCE(batch_doc_ids, '') "
-                        "FROM hook_failures "
-                        "WHERE occurred_at >= datetime('now', '-1 day')"
-                    ).fetchall()
-                    rows = [(r[0], 1, r[1], r[2]) for r in rows]
-                except Exception:
-                    # Pre-4.14.1 schema: batch columns absent. Read with
-                    # legacy shape and treat every row as scalar.
-                    legacy = db.taxonomy.conn.execute(
-                        "SELECT hook_name FROM hook_failures "
-                        "WHERE occurred_at >= datetime('now', '-1 day')"
-                    ).fetchall()
-                    rows = [(r[0], 1, 0, None) for r in legacy]
+            failure_rows = db.taxonomy.get_recent_hook_failures()
         except Exception:
-            rows = []
+            failure_rows = []
+        rows = [(name, 1, is_batch, payload) for name, is_batch, payload in failure_rows]
 
         if rows:
             import json as _json
@@ -350,12 +320,7 @@ def list_cmd(collection: str, depth: int) -> None:
         tree = get_topic_tree(db, collection, max_depth=depth)
         # Count docs with no topic assignment (noise / uncategorized).
         # Lock taken per storage review I-1.
-        with db.taxonomy._lock:
-            total_assigned = db.taxonomy.conn.execute(
-                "SELECT COUNT(DISTINCT doc_id) FROM topic_assignments"
-                + (" WHERE topic_id IN (SELECT id FROM topics WHERE collection = ?)" if collection else ""),
-                (collection,) if collection else (),
-            ).fetchone()[0]
+        total_assigned = db.taxonomy.count_assigned_docs(collection)
     if not tree:
         click.echo("No topics found. Run `nx taxonomy discover --collection <name>` first.")
         return
@@ -434,12 +399,12 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
     t3 = make_t3()
 
     if discover_all:
-        colls = t3._client.list_collections()
+        colls = t3.list_collections()
         targets = [
-            c.name for c in colls
-            if c.count() >= 5
-            and not any(fnmatch(c.name, pat) for pat in exclude)
-            and not c.name.startswith("taxonomy__")
+            c["name"] for c in colls
+            if c["count"] >= 5
+            and not any(fnmatch(c["name"], pat) for pat in exclude)
+            and not c["name"].startswith("taxonomy__")
         ]
         if not targets:
             click.echo("No eligible collections found.")
@@ -945,27 +910,7 @@ def links_cmd(collection: str, refresh: bool) -> None:
 
         # Display all rows in topic_links, joined with topic labels.
         # Lock taken per storage review I-1.
-        with db.taxonomy._lock:
-            if collection:
-                rows = db.taxonomy.conn.execute(
-                    "SELECT t1.label, t1.collection, t2.label, t2.collection, "
-                    "       tl.link_count, tl.link_types "
-                    "FROM topic_links tl "
-                    "JOIN topics t1 ON tl.from_topic_id = t1.id "
-                    "JOIN topics t2 ON tl.to_topic_id = t2.id "
-                    "WHERE t1.collection = ? OR t2.collection = ? "
-                    "ORDER BY tl.link_count DESC",
-                    (collection, collection),
-                ).fetchall()
-            else:
-                rows = db.taxonomy.conn.execute(
-                    "SELECT t1.label, t1.collection, t2.label, t2.collection, "
-                    "       tl.link_count, tl.link_types "
-                    "FROM topic_links tl "
-                    "JOIN topics t1 ON tl.from_topic_id = t1.id "
-                    "JOIN topics t2 ON tl.to_topic_id = t2.id "
-                    "ORDER BY tl.link_count DESC"
-                ).fetchall()
+        rows = db.taxonomy.list_topic_link_rows_with_labels(collection=collection)
 
         if not rows:
             click.echo("No topic links found.")

--- a/src/nexus/db/t2/catalog_taxonomy.py
+++ b/src/nexus/db/t2/catalog_taxonomy.py
@@ -1262,6 +1262,134 @@ class CatalogTaxonomy:
             ).fetchall()
         return [r[0] for r in rows]
 
+    # ── command-layer domain methods (RDR-112 P0.5, nexus-49bw) ─────────────
+    #
+    # The following methods encapsulate SQL previously executed via
+    # ``db.taxonomy.conn.execute`` from ``nexus.commands.taxonomy_cmd``.
+    # Daemon-mode (RDR-112 P1) turns those reach-throughs into errors;
+    # this surface is the supported replacement.
+
+    def get_collection_topic_stats(
+        self,
+    ) -> list[tuple[str, int, int, int, int]]:
+        """Per-collection topic counts for ``nx taxonomy status``.
+
+        Returns rows of ``(collection, n_topics, total_docs, n_pending,
+        n_accepted)`` ordered by ``total_docs`` descending.
+        """
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT collection, COUNT(*), SUM(doc_count), "
+                "SUM(CASE WHEN review_status = 'pending' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN review_status = 'accepted' THEN 1 ELSE 0 END) "
+                "FROM topics GROUP BY collection ORDER BY SUM(doc_count) DESC"
+            ).fetchall()
+        return [(r[0], r[1], r[2] or 0, r[3] or 0, r[4] or 0) for r in rows]
+
+    def count_topic_links(self) -> int:
+        """Return total row count from ``topic_links``."""
+        with self._lock:
+            return self.conn.execute(
+                "SELECT COUNT(*) FROM topic_links"
+            ).fetchone()[0]
+
+    def get_taxonomy_meta(
+        self, collection: str,
+    ) -> tuple[int | None, str | None] | None:
+        """Return ``(last_discover_doc_count, last_discover_at)`` or None."""
+        with self._lock:
+            return self.conn.execute(
+                "SELECT last_discover_doc_count, last_discover_at "
+                "FROM taxonomy_meta WHERE collection = ?",
+                (collection,),
+            ).fetchone()
+
+    def count_assigned_docs(self, collection: str = "") -> int:
+        """Distinct ``doc_id`` count in ``topic_assignments``.
+
+        When ``collection`` is non-empty, restrict to topics whose
+        ``collection`` field matches.
+        """
+        with self._lock:
+            if collection:
+                return self.conn.execute(
+                    "SELECT COUNT(DISTINCT doc_id) FROM topic_assignments "
+                    "WHERE topic_id IN (SELECT id FROM topics WHERE collection = ?)",
+                    (collection,),
+                ).fetchone()[0]
+            return self.conn.execute(
+                "SELECT COUNT(DISTINCT doc_id) FROM topic_assignments"
+            ).fetchone()[0]
+
+    def get_recent_hook_failures(
+        self, *, since: str = "-1 day",
+    ) -> list[tuple[str, int, str | None]]:
+        """Recent rows from ``hook_failures``.
+
+        Each row is ``(hook_name, is_batch, batch_doc_ids)``. ``is_batch``
+        is 1 for batch-shape rows and 0 for legacy scalar rows.
+        ``batch_doc_ids`` is the JSON-encoded list payload (or None).
+
+        Returns ``[]`` when the table does not exist (pre-4.9.10 DBs).
+        Falls back to the pre-4.14.1 column shape when batch columns are
+        absent — those rows are reported as scalar (``is_batch=0``,
+        ``batch_doc_ids=None``).
+
+        ``since`` is a SQLite modifier passed to ``datetime('now', ?)``.
+        """
+        with self._lock:
+            try:
+                rows = self.conn.execute(
+                    "SELECT hook_name, is_batch, COALESCE(batch_doc_ids, '') "
+                    "FROM hook_failures "
+                    "WHERE occurred_at >= datetime('now', ?)",
+                    (since,),
+                ).fetchall()
+                return [(r[0], int(r[1] or 0), r[2] or None) for r in rows]
+            except sqlite3.OperationalError:
+                try:
+                    legacy = self.conn.execute(
+                        "SELECT hook_name FROM hook_failures "
+                        "WHERE occurred_at >= datetime('now', ?)",
+                        (since,),
+                    ).fetchall()
+                    return [(r[0], 0, None) for r in legacy]
+                except sqlite3.OperationalError:
+                    return []
+
+    def list_topic_link_rows_with_labels(
+        self, *, collection: str = "",
+    ) -> list[tuple[str, str, str, str, int, str]]:
+        """Joined ``topic_links`` rows for ``nx taxonomy links`` display.
+
+        Returns ``(from_label, from_collection, to_label, to_collection,
+        link_count, link_types)`` ordered by ``link_count`` descending.
+        When ``collection`` is provided, only rows where either endpoint
+        matches are returned.
+        """
+        with self._lock:
+            if collection:
+                rows = self.conn.execute(
+                    "SELECT t1.label, t1.collection, t2.label, t2.collection, "
+                    "       tl.link_count, tl.link_types "
+                    "FROM topic_links tl "
+                    "JOIN topics t1 ON tl.from_topic_id = t1.id "
+                    "JOIN topics t2 ON tl.to_topic_id = t2.id "
+                    "WHERE t1.collection = ? OR t2.collection = ? "
+                    "ORDER BY tl.link_count DESC",
+                    (collection, collection),
+                ).fetchall()
+            else:
+                rows = self.conn.execute(
+                    "SELECT t1.label, t1.collection, t2.label, t2.collection, "
+                    "       tl.link_count, tl.link_types "
+                    "FROM topic_links tl "
+                    "JOIN topics t1 ON tl.from_topic_id = t1.id "
+                    "JOIN topics t2 ON tl.to_topic_id = t2.id "
+                    "ORDER BY tl.link_count DESC"
+                ).fetchall()
+        return [tuple(r) for r in rows]
+
     def get_topics_for_collection(
         self,
         collection: str,

--- a/tests/test_taxonomy_domain_methods.py
+++ b/tests/test_taxonomy_domain_methods.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for CatalogTaxonomy command-layer domain methods (RDR-112 P0.5, nexus-49bw).
+
+Each method here replaces a previous ``db.taxonomy.conn.execute``
+reach-through from ``src/nexus/commands/taxonomy_cmd.py``. The tests
+seed rows directly via the underlying connection so behaviour is
+verified independently of the discovery / projection pipelines.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nexus.db.t2 import T2Database
+
+
+def _seed_topic(
+    db: T2Database, *, label: str, collection: str,
+    doc_count: int = 0, review_status: str = "pending",
+) -> int:
+    cur = db.taxonomy.conn.execute(
+        "INSERT INTO topics (label, collection, doc_count, review_status, terms, created_at) "
+        "VALUES (?, ?, ?, ?, '[]', datetime('now'))",
+        (label, collection, doc_count, review_status),
+    )
+    db.taxonomy.conn.commit()
+    return cur.lastrowid
+
+
+# ── get_collection_topic_stats ─────────────────────────────────────────────
+
+
+def test_collection_topic_stats_empty(db: T2Database) -> None:
+    assert db.taxonomy.get_collection_topic_stats() == []
+
+
+def test_collection_topic_stats_grouped_and_ordered(db: T2Database) -> None:
+    _seed_topic(db, label="a", collection="docs", doc_count=10, review_status="accepted")
+    _seed_topic(db, label="b", collection="docs", doc_count=5, review_status="pending")
+    _seed_topic(db, label="c", collection="code", doc_count=20, review_status="pending")
+    rows = db.taxonomy.get_collection_topic_stats()
+    # code has 20 docs, docs has 15 — code should come first.
+    assert rows[0] == ("code", 1, 20, 1, 0)
+    assert rows[1] == ("docs", 2, 15, 1, 1)
+
+
+# ── count_topic_links ──────────────────────────────────────────────────────
+
+
+def test_count_topic_links_zero(db: T2Database) -> None:
+    assert db.taxonomy.count_topic_links() == 0
+
+
+def test_count_topic_links_nonzero(db: T2Database) -> None:
+    a = _seed_topic(db, label="a", collection="x")
+    b = _seed_topic(db, label="b", collection="x")
+    db.taxonomy.conn.execute(
+        "INSERT INTO topic_links (from_topic_id, to_topic_id, link_count, link_types) "
+        "VALUES (?, ?, ?, ?)",
+        (a, b, 3, json.dumps(["projection"])),
+    )
+    db.taxonomy.conn.commit()
+    assert db.taxonomy.count_topic_links() == 1
+
+
+# ── get_taxonomy_meta ──────────────────────────────────────────────────────
+
+
+def test_get_taxonomy_meta_missing(db: T2Database) -> None:
+    assert db.taxonomy.get_taxonomy_meta("never-seen") is None
+
+
+def test_get_taxonomy_meta_present(db: T2Database) -> None:
+    db.taxonomy.conn.execute(
+        "INSERT INTO taxonomy_meta (collection, last_discover_doc_count, last_discover_at) "
+        "VALUES (?, ?, ?)",
+        ("docs", 42, "2026-05-14T00:00:00"),
+    )
+    db.taxonomy.conn.commit()
+    assert db.taxonomy.get_taxonomy_meta("docs") == (42, "2026-05-14T00:00:00")
+
+
+# ── count_assigned_docs ────────────────────────────────────────────────────
+
+
+def test_count_assigned_docs_empty(db: T2Database) -> None:
+    assert db.taxonomy.count_assigned_docs() == 0
+    assert db.taxonomy.count_assigned_docs("docs") == 0
+
+
+def test_count_assigned_docs_total_and_filtered(db: T2Database) -> None:
+    a = _seed_topic(db, label="a", collection="docs")
+    b = _seed_topic(db, label="b", collection="code")
+    for tid, doc in [(a, "d1"), (a, "d2"), (b, "d3"), (b, "d3")]:
+        db.taxonomy.conn.execute(
+            "INSERT OR IGNORE INTO topic_assignments (topic_id, doc_id) VALUES (?, ?)",
+            (tid, doc),
+        )
+    db.taxonomy.conn.commit()
+    assert db.taxonomy.count_assigned_docs() == 3
+    assert db.taxonomy.count_assigned_docs("docs") == 2
+    assert db.taxonomy.count_assigned_docs("code") == 1
+
+
+# ── get_recent_hook_failures ───────────────────────────────────────────────
+
+
+def test_get_recent_hook_failures_empty(db: T2Database) -> None:
+    assert db.taxonomy.get_recent_hook_failures() == []
+
+
+def test_get_recent_hook_failures_modern_schema(db: T2Database) -> None:
+    db.taxonomy.conn.execute(
+        "INSERT INTO hook_failures (hook_name, is_batch, batch_doc_ids) VALUES (?, ?, ?)",
+        ("topic_assign", 1, json.dumps(["d1", "d2"])),
+    )
+    db.taxonomy.conn.execute(
+        "INSERT INTO hook_failures (hook_name, is_batch) VALUES (?, ?)",
+        ("centroid_update", 0),
+    )
+    db.taxonomy.conn.commit()
+    rows = db.taxonomy.get_recent_hook_failures()
+    assert len(rows) == 2
+    by_name = {r[0]: r for r in rows}
+    assert by_name["topic_assign"][1] == 1
+    assert json.loads(by_name["topic_assign"][2]) == ["d1", "d2"]
+    assert by_name["centroid_update"] == ("centroid_update", 0, None)
+
+
+def test_get_recent_hook_failures_outside_window(db: T2Database) -> None:
+    db.taxonomy.conn.execute(
+        "INSERT INTO hook_failures (hook_name, occurred_at) "
+        "VALUES (?, datetime('now', '-5 days'))",
+        ("ancient",),
+    )
+    db.taxonomy.conn.commit()
+    assert db.taxonomy.get_recent_hook_failures() == []
+
+
+def test_get_recent_hook_failures_no_table(db: T2Database) -> None:
+    db.taxonomy.conn.execute("DROP TABLE hook_failures")
+    db.taxonomy.conn.commit()
+    assert db.taxonomy.get_recent_hook_failures() == []
+
+
+# ── list_topic_link_rows_with_labels ───────────────────────────────────────
+
+
+def test_list_topic_link_rows_with_labels_filtered_and_unfiltered(db: T2Database) -> None:
+    a = _seed_topic(db, label="alpha", collection="docs")
+    b = _seed_topic(db, label="beta", collection="code")
+    c = _seed_topic(db, label="gamma", collection="docs")
+    for f, t, n in [(a, b, 7), (a, c, 3)]:
+        db.taxonomy.conn.execute(
+            "INSERT INTO topic_links (from_topic_id, to_topic_id, link_count, link_types) "
+            "VALUES (?, ?, ?, ?)",
+            (f, t, n, json.dumps(["projection"])),
+        )
+    db.taxonomy.conn.commit()
+
+    all_rows = db.taxonomy.list_topic_link_rows_with_labels()
+    assert len(all_rows) == 2
+    # Order: descending by link_count.
+    assert all_rows[0][:5] == ("alpha", "docs", "beta", "code", 7)
+    assert all_rows[1][:5] == ("alpha", "docs", "gamma", "docs", 3)
+
+    code_only = db.taxonomy.list_topic_link_rows_with_labels(collection="code")
+    assert len(code_only) == 1
+    assert code_only[0][:5] == ("alpha", "docs", "beta", "code", 7)


### PR DESCRIPTION
## Summary

Closes the largest single reach-through cluster from the 2026-05-13 RDR-112 P0.5 review: 8 ``db.taxonomy.conn.execute`` sites + 1 ``t3._client.list_collections`` site in ``src/nexus/commands/taxonomy_cmd.py``. Daemon-mode (RDR-112 P1, ``nexus-507q``) makes those reach-throughs impossible to flip in place; this PR adds the supported domain surface and migrates every caller.

## What changed

Six new methods on ``CatalogTaxonomy`` (each TDD-covered in ``tests/test_taxonomy_domain_methods.py``):

- ``get_collection_topic_stats()`` — per-collection topic counts for ``nx taxonomy status``
- ``count_topic_links()`` — total ``topic_links`` row count
- ``get_taxonomy_meta(collection)`` — last-discover metadata
- ``count_assigned_docs(collection='')`` — distinct-doc count, optional collection filter
- ``get_recent_hook_failures(since='-1 day')`` — encapsulates the modern + legacy-schema + missing-table fallback chain
- ``list_topic_link_rows_with_labels(collection='')`` — joined ``topic_links`` rows for ``nx taxonomy links``

The ``discover_cmd`` ``--all`` branch swaps ``t3._client.list_collections()`` for the existing ``t3.list_collections()`` wrapper that returns ``{name, count}`` dicts.

## Predicate ACs (per the bead)

```
git grep 'db.taxonomy.conn.' -- src/nexus/commands/             → zero
git grep 't3._client.list_collections' -- src/nexus/commands/taxonomy_cmd.py → zero
```

The remaining ``t3._client.*`` site in ``src/nexus/commands/catalog.py`` is in scope for ``nexus-siva``, not this bead.

## Test plan

- [x] ``uv run pytest tests/test_taxonomy_domain_methods.py`` — 13 new tests pass
- [x] ``uv run pytest tests/test_taxonomy.py tests/test_taxonomy_e2e.py tests/test_taxonomy_backfill.py tests/test_index_taxonomy.py`` — 153 + dependents pass
- [x] ``uv run pytest tests/test_tier_status_cli.py tests/test_catalog_cli.py tests/test_cli_registration.py`` — 105 pass
- [ ] CI green on develop

## Closes

Part of ``nexus-j6bi`` epic; closes ``nexus-49bw``.