### PR TITLE
refactor(commands): route T2Database + EphemeralClient through encapsulated factories (nexus-oi0z, RDR-112 P0.5)

### DIFF
--- a/src/nexus/aspect_worker.py
+++ b/src/nexus/aspect_worker.py
@@ -733,9 +733,16 @@ def drain_worker(
     # singleton.  A live MCP worker in another process drains its own
     # queue independently; the migration must not run while that worker is
     # alive or it will race against in_progress rows it cannot see.
-    locks_dir = _locks_dir if _locks_dir is not None else (
-        Path.home() / ".config" / "nexus" / "locks"
-    )
+    if _locks_dir is not None:
+        locks_dir = _locks_dir
+    else:
+        # Resolve via nexus_config_dir so NEXUS_CONFIG_DIR (the test
+        # isolation contract) takes effect. The legacy ``Path.home() /
+        # .config / nexus / locks`` default is what nexus_config_dir
+        # returns when no override is set, so production behaviour is
+        # unchanged.
+        from nexus.config import nexus_config_dir
+        locks_dir = nexus_config_dir() / "locks"
     _check_mcp_worker_lock(locks_dir)
 
     worker = get_worker()

--- a/src/nexus/collection_rename.py
+++ b/src/nexus/collection_rename.py
@@ -82,11 +82,10 @@ def rename_collection_data_plane(
     # ── T2 cascade FIRST (reversible) ────────────────────────────────────────
     # Failure here raises ClickException -- T3 rename has not yet run so the
     # system remains fully consistent. Operator can diagnose and retry.
-    from nexus.config import default_db_path  # noqa: PLC0415
-    from nexus.db.t2 import T2Database  # noqa: PLC0415
+    from nexus.mcp_infra import t2_ctx  # noqa: PLC0415
 
     try:
-        with T2Database(default_db_path()) as t2db:
+        with t2_ctx() as t2db:
             cascade = t2db.rename_collection_cascade(old=old, new=new)
             counts["tax_topics"] = cascade.get("tax_topics", 0)
             counts["tax_assignments"] = cascade.get("tax_assignments", 0)

--- a/src/nexus/commands/aspects.py
+++ b/src/nexus/commands/aspects.py
@@ -111,7 +111,7 @@ def aspects_gc(apply: bool) -> None:
     """
     from nexus.commands._helpers import default_db_path
     from nexus.config import catalog_path
-    from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
     mem_path = default_db_path()
     cat_db = catalog_path() / ".catalog.db"
@@ -124,7 +124,7 @@ def aspects_gc(apply: bool) -> None:
         )
         raise SystemExit(1)
 
-    with T2Database(mem_path) as db:
+    with t2_ctx() as db:
         orphans, total = db.document_aspects.delete_orphans(
             cat_db, dry_run=not apply,
         )

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -1591,7 +1591,7 @@ def _taxonomy_stats() -> dict | None:
     (formerly nexus-1n0t).
     """
     from nexus.commands._helpers import default_db_path
-    from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
     try:
         db_path = default_db_path()
@@ -1601,7 +1601,7 @@ def _taxonomy_stats() -> dict | None:
         return None
 
     try:
-        with T2Database(db_path) as db:
+        with t2_ctx() as db:
             conn = db.taxonomy.conn
             with db.taxonomy._lock:
                 topic_total = conn.execute(

--- a/src/nexus/commands/catalog.py
+++ b/src/nexus/commands/catalog.py
@@ -80,11 +80,10 @@ def _seed_plan_templates() -> int:
     """
     from pathlib import Path
 
-    from nexus.commands._helpers import default_db_path
-    from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
     seeded = 0
-    with T2Database(default_db_path()) as db:
+    with t2_ctx() as db:
         from nexus.indexer_utils import find_repo_root
         from nexus.plans.loader import load_all_tiers
 

--- a/src/nexus/commands/collection.py
+++ b/src/nexus/commands/collection.py
@@ -131,10 +131,9 @@ def delete_cmd(name: str, yes: bool) -> None:
     taxonomy_counts: dict[str, int] | None = None
     chash_deleted = 0
     try:
-        from nexus.commands._helpers import default_db_path
-        from nexus.db.t2 import T2Database
+        from nexus.mcp_infra import t2_ctx
 
-        with T2Database(default_db_path()) as db:
+        with t2_ctx() as db:
             taxonomy_counts = db.taxonomy.purge_collection(name)
             chash_deleted = db.chash_index.delete_collection(name)
     except Exception as exc:

--- a/src/nexus/commands/doc.py
+++ b/src/nexus/commands/doc.py
@@ -26,6 +26,7 @@ import click
 from nexus.commands._helpers import default_db_path
 from nexus.config import load_config
 from nexus.db.t2 import T2Database
+from nexus.mcp_infra import t2_ctx
 from nexus.doc.citations import (
     extensions_report,
     grounding_report,
@@ -105,7 +106,7 @@ def render_cmd(
     # install, no db), fall back to bead + RDR resolvers only.
     db: T2Database | None = None
     try:
-        db = T2Database(default_db_path())
+        db = t2_ctx()
     except Exception:
         db = None
 
@@ -230,7 +231,7 @@ def validate_cmd(paths: tuple[Path, ...], project_root: Path | None) -> None:
 
     db: T2Database | None = None
     try:
-        db = T2Database(default_db_path())
+        db = t2_ctx()
     except Exception:
         db = None
 
@@ -574,7 +575,7 @@ def _phase4_t2_taxonomy():
 
     @contextmanager
     def _taxonomy_ctx():
-        db = T2Database(default_db_path())
+        db = t2_ctx()
         try:
             yield db.taxonomy
         finally:

--- a/src/nexus/commands/enrich.py
+++ b/src/nexus/commands/enrich.py
@@ -735,6 +735,7 @@ def _select_entries(
     from nexus.commands._helpers import default_db_path
     from nexus.config import catalog_path
     from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
     cat_path = catalog_path()
     if not Catalog.is_initialized(cat_path):
@@ -747,7 +748,7 @@ def _select_entries(
         # Filter to entries whose existing aspect row has model_version
         # below the threshold. Rows without an existing aspect entry
         # are also included (they need first-time extraction).
-        with T2Database(default_db_path()) as db:
+        with t2_ctx() as db:
             outdated_paths = {
                 r.source_path
                 for r in db.document_aspects.list_by_extractor_version(
@@ -952,6 +953,7 @@ def _run_extraction(
     from nexus.aspect_extractor import ExtractFail, extract_aspects
     from nexus.commands._helpers import default_db_path
     from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
     extractor_name = config.extractor_name
 
@@ -969,8 +971,7 @@ def _run_extraction(
     # nexus-8g79.2: same — manifest_lookup is process-cached.
     manifest_lookup = _build_catalog_manifest_lookup()
 
-    db_path = default_db_path()
-    with T2Database(db_path) as db:
+    with t2_ctx() as db:
         for i, entry in enumerate(entries, 1):
             source_path = entry.file_path or entry.title
             if not source_path:
@@ -1197,8 +1198,9 @@ def enrich_aspects_list(collection: str, limit: int, scheme: str) -> None:
 
     from nexus.commands._helpers import default_db_path
     from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
-    with T2Database(default_db_path()) as db:
+    with t2_ctx() as db:
         records = db.document_aspects.list_by_collection(
             collection, limit=limit if limit > 0 else None,
         )
@@ -1244,8 +1246,9 @@ def enrich_aspects_info(collection: str, source_path: str) -> None:
 
     from nexus.commands._helpers import default_db_path
     from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
-    with T2Database(default_db_path()) as db:
+    with t2_ctx() as db:
         record = db.document_aspects.get(collection, source_path)
 
     if record is None:
@@ -1300,6 +1303,7 @@ def enrich_aspects_delete(
     """
     from nexus.commands._helpers import default_db_path
     from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
     if not yes:
         click.confirm(
@@ -1308,7 +1312,7 @@ def enrich_aspects_delete(
             abort=True,
         )
 
-    with T2Database(default_db_path()) as db:
+    with t2_ctx() as db:
         deleted = db.document_aspects.delete(collection, source_path)
 
     if deleted:
@@ -1377,9 +1381,10 @@ def enrich_aspects_promote_field(
     )
     from nexus.commands._helpers import default_db_path
     from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
     if history:
-        with T2Database(default_db_path()) as db:
+        with t2_ctx() as db:
             entries = list_promotions(db)
         if not entries:
             click.echo("No promotion history.")
@@ -1393,7 +1398,7 @@ def enrich_aspects_promote_field(
             )
         return
 
-    with T2Database(default_db_path()) as db:
+    with t2_ctx() as db:
         try:
             result = promote_extras_field(
                 db, field_name,
@@ -1540,6 +1545,7 @@ def aspects_show_cmd(tumbler_or_title: str, as_json: bool, field: str) -> None:
     """
     from nexus.commands._helpers import default_db_path
     from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
     _, entry = _resolve_catalog_entry(tumbler_or_title)
     if not entry.physical_collection or not entry.file_path:
@@ -1550,7 +1556,7 @@ def aspects_show_cmd(tumbler_or_title: str, as_json: bool, field: str) -> None:
         )
         return
 
-    with T2Database(default_db_path()) as db:
+    with t2_ctx() as db:
         # nexus-6xp2: post-drop, source_path-keyed lookup is unreliable
         # when the writer used a non-uri_for source_uri. Tumbler-keyed
         # get_by_doc_id is exact; fall back to legacy (coll, path) get
@@ -1610,6 +1616,7 @@ def aspects_list_cmd(
     from nexus.commands._helpers import default_db_path
     from nexus.config import catalog_path
     from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
     if missing:
         cat_path = catalog_path()
@@ -1619,7 +1626,7 @@ def aspects_list_cmd(
             )
         cat = Catalog(cat_path, cat_path / ".catalog.db")
         entries = cat.list_by_collection(collection)
-        with T2Database(default_db_path()) as db:
+        with t2_ctx() as db:
             existing = {
                 r.source_path for r in db.document_aspects.list_by_collection(
                     collection,
@@ -1652,7 +1659,7 @@ def aspects_list_cmd(
             click.echo(f"  ... and {len(gaps) - limit} more.")
         return
 
-    with T2Database(default_db_path()) as db:
+    with t2_ctx() as db:
         records = db.document_aspects.list_by_collection(
             collection, limit=(limit if limit else None),
         )

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -510,8 +510,7 @@ def run_collection_postprocessing(
 
     from nexus.config import load_config as _load_cfg
     from nexus.db import make_t3
-    from nexus.db.t2 import T2Database
-    from nexus.commands._helpers import default_db_path
+    from nexus.mcp_infra import t2_ctx
 
     def _say(msg: str) -> None:
         if not quiet:
@@ -521,7 +520,7 @@ def run_collection_postprocessing(
     try:
         t3 = make_t3()
         total_topics = 0
-        with T2Database(default_db_path()) as db:
+        with t2_ctx() as db:
             for col_name in collections:
                 try:
                     n = _discover_taxonomy(col_name, db.taxonomy, t3._client)
@@ -800,14 +799,13 @@ def index_pdf_cmd(path: Path | None, dir_path: Path | None, corpus: str, collect
     path = path.resolve()
 
     if dry_run:
-        import chromadb
         from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
 
-        from nexus.db import make_t3
+        from nexus.db import make_ephemeral_t3
 
         click.echo("Dry-run mode — local ONNX embeddings, no cloud writes.")
         ef = DefaultEmbeddingFunction()
-        local_t3 = make_t3(_client=chromadb.EphemeralClient(), _ef_override=ef)
+        local_t3 = make_ephemeral_t3(ef=ef)
 
         def _local_embed(texts: list[str], model: str) -> tuple[list[list[float]], str]:
             return [v.tolist() for v in ef(texts)], model

--- a/src/nexus/commands/memory.py
+++ b/src/nexus/commands/memory.py
@@ -5,10 +5,9 @@ from pathlib import Path
 
 import click
 
-from nexus.commands._helpers import default_db_path as _default_db_path
 from nexus.config import get_credential
-from nexus.db.t2 import T2Database
 from nexus.db.t3 import T3Database
+from nexus.mcp_infra import t2_ctx
 from nexus.ttl import parse_ttl
 
 
@@ -34,7 +33,7 @@ def put_cmd(content: str, project: str, title: str, tags: str, ttl: str) -> None
         ttl_days = parse_ttl(ttl)
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
-    with T2Database(_default_db_path()) as db:
+    with t2_ctx() as db:
         row_id = db.put(project=project, title=title, content=content, tags=tags, ttl=ttl_days)
     click.echo(f"Stored: {project}/{title} (id={row_id})")
 
@@ -52,7 +51,7 @@ def get_cmd(entry_id: int | None, project: str | None, title: str | None) -> Non
     """
     if entry_id is None and not (project and title):
         raise click.UsageError("provide an ID or --project and --title")
-    with T2Database(_default_db_path()) as db:
+    with t2_ctx() as db:
         if entry_id is not None:
             result = db.get(id=entry_id)
             if result is None:
@@ -85,7 +84,7 @@ def get_cmd(entry_id: int | None, project: str | None, title: str | None) -> Non
 @click.option("--project", "-p", default=None, help="Scope search to a project")
 def search_cmd(query: str, project: str | None) -> None:
     """FTS5 keyword search across T2 memory entries."""
-    with T2Database(_default_db_path()) as db:
+    with t2_ctx() as db:
         results = db.search(query=query, project=project)
     if not results:
         click.echo("No results found.")
@@ -102,7 +101,7 @@ def search_cmd(query: str, project: str | None) -> None:
 @click.option("--agent", "-a", default=None, help="Filter by agent name")
 def list_cmd(project: str | None, agent: str | None) -> None:
     """List memory entries."""
-    with T2Database(_default_db_path()) as db:
+    with t2_ctx() as db:
         entries = db.list_entries(project=project, agent=agent)
     if not entries:
         click.echo("No entries found.")
@@ -136,7 +135,7 @@ def delete_cmd(
     if entry_id is None and not all_entries and not (project and title):
         raise click.UsageError("provide --id, or --project and --title, or --project and --all")
 
-    with T2Database(_default_db_path()) as db:
+    with t2_ctx() as db:
         if all_entries:
             entries = db.list_entries(project=project)
             count = len(entries)
@@ -168,7 +167,7 @@ def delete_cmd(
 @memory.command("expire")
 def expire_cmd() -> None:
     """Remove TTL-expired memory entries."""
-    with T2Database(_default_db_path()) as db:
+    with t2_ctx() as db:
         count = db.expire()
     click.echo(f"Expired {count} {'entry' if count == 1 else 'entries'}.")
 
@@ -182,7 +181,7 @@ def promote_cmd(entry_id: int, collection: str, tags: str, remove: bool) -> None
     """Promote a T2 memory entry to T3 ChromaDB permanent storage."""
     from nexus.corpus import t3_collection_name
 
-    with T2Database(_default_db_path()) as db:
+    with t2_ctx() as db:
         entry = db.get(id=entry_id)
         if entry is None:
             raise click.ClickException(f"Entry {entry_id} not found in T2 memory.")

--- a/src/nexus/commands/scratch.py
+++ b/src/nexus/commands/scratch.py
@@ -4,9 +4,8 @@ from typing import Any
 
 import click
 
-from nexus.commands._helpers import default_db_path as _default_db_path
 from nexus.db.t1 import T1Database
-from nexus.db.t2 import T2Database
+from nexus.mcp_infra import t2_ctx
 
 
 def _t1() -> T1Database:
@@ -131,7 +130,7 @@ def unflag_cmd(entry_id: str) -> None:
 def promote_cmd(entry_id: str, project: str, title: str) -> None:
     """Copy a scratch entry to T2 immediately."""
     t1 = _t1()
-    with T2Database(_default_db_path()) as t2:
+    with t2_ctx() as t2:
         try:
             report = t1.promote(entry_id, project=project, title=title, t2=t2)
         except KeyError as exc:

--- a/src/nexus/commands/search_cmd.py
+++ b/src/nexus/commands/search_cmd.py
@@ -307,9 +307,8 @@ def search_cmd(
 
     def _retrieve(q: str) -> list[SearchResult]:
         # Pass taxonomy for topic grouping + topic boost (RDR-070)
-        from nexus.commands._helpers import default_db_path as _db_path
-        from nexus.db.t2 import T2Database
-        with T2Database(_db_path()) as _t2:
+        from nexus.mcp_infra import t2_ctx
+        with t2_ctx() as _t2:
             raw = search_cross_corpus(
                 q, target_collections, n_results=n, t3=db,
                 where=where_filter, link_boost=False,

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -8,13 +8,20 @@ import click
 import numpy as np
 import structlog
 
-from nexus.commands._helpers import default_db_path as _default_db_path
+from nexus.commands._helpers import default_db_path as _default_db_path  # noqa: E402
 
 
-def _T2Database(path):
-    """Lazy T2Database constructor (avoids module-level import poisoning by test mocks)."""
+def _t2_ctx():
+    """Open T2 via the supported encapsulation surface (RDR-112 P0.5).
+
+    Indirects through ``_default_db_path`` so the long-standing test
+    pattern of patching ``nexus.commands.taxonomy_cmd._default_db_path``
+    keeps working. Constructs ``T2Database`` lazily to avoid module-
+    level import poisoning by test mocks.
+    """
     from nexus.db.t2 import T2Database
-    return T2Database(path)
+    db_path = _default_db_path()
+    return T2Database(db_path)
 
 if TYPE_CHECKING:
     from nexus.db.t2.catalog_taxonomy import CatalogTaxonomy
@@ -181,7 +188,7 @@ def status_cmd(collection: str, limit: int, summary: bool, needs_review: bool) -
       nx taxonomy status -n 10                        # top 10 by docs
       nx taxonomy status --needs-review               # pending review only
     """
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         # Storage review I-1: every .conn access goes through the
         # domain-store lock. These are read-only queries but the lock
         # protects against a concurrent writer on the same connection.
@@ -316,7 +323,7 @@ def list_cmd(collection: str, depth: int) -> None:
     from nexus.taxonomy import get_topic_tree
 
     depth = min(depth, 4)
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         tree = get_topic_tree(db, collection, max_depth=depth)
         # Count docs with no topic assignment (noise / uncategorized).
         # Lock taken per storage review I-1.
@@ -361,7 +368,7 @@ def show_cmd(topic_id: int, limit: int) -> None:
     """Show documents assigned to a topic."""
     from nexus.taxonomy import get_topic_docs
 
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         docs = get_topic_docs(db, topic_id, limit=limit)
     if not docs:
         click.echo(f"No documents in topic {topic_id}.")
@@ -423,7 +430,7 @@ def discover_cmd(collection: str, discover_all: bool, force: bool) -> None:
 
     total_topics = 0
     total_labeled = 0
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         for i, col_name in enumerate(targets, 1):
             if len(targets) > 1:
                 click.echo(f"[{i}/{len(targets)}] {col_name}")
@@ -504,7 +511,7 @@ def rebuild_cmd(collection: str, project: str, k: int | None) -> None:
     if k is not None:
         click.echo("Note: -k is deprecated. Cluster count is now automatic (HDBSCAN).")
 
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         t3 = make_t3()
         count = discover_for_collection(
             collection, db.taxonomy, t3._client, force=True,
@@ -590,7 +597,7 @@ def _show_merge_targets(
 @click.option("--limit", "-n", default=15, type=int, help="Topics per session", show_default=True)
 def review_cmd(collection: str, limit: int) -> None:
     """Interactive topic review — accept, rename, merge, delete, or skip."""
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         topics = db.taxonomy.get_unreviewed_topics(collection=collection, limit=limit)
         if not topics:
             click.echo("No unreviewed topics. All done!")
@@ -650,7 +657,7 @@ def review_cmd(collection: str, limit: int) -> None:
 @click.option("--collection", "-c", default="", help="Collection scope for label lookup")
 def assign_cmd(doc_id: str, topic_label: str, collection: str) -> None:
     """Assign a document to a topic by label."""
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         topic_id = db.taxonomy.resolve_label(topic_label, collection=collection)
         if topic_id is None:
             click.echo(f"Topic '{topic_label}' not found.")
@@ -684,7 +691,7 @@ def rename_cmd(
     (the user typing a new label is an acknowledgement); ``--no-accept``
     lets you fix a typo without forcing the topic through review.
     """
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         topic_id = db.taxonomy.resolve_label(topic_label, collection=collection)
         if topic_id is None:
             click.echo(f"Topic '{topic_label}' not found.")
@@ -705,7 +712,7 @@ def rename_cmd(
 @click.option("--collection", "-c", default="", help="Collection scope for label lookup")
 def merge_cmd(source_label: str, target_label: str, collection: str) -> None:
     """Merge source topic into target topic."""
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         source_id = db.taxonomy.resolve_label(source_label, collection=collection)
         if source_id is None:
             click.echo(f"Source topic '{source_label}' not found.")
@@ -726,7 +733,7 @@ def split_cmd(topic_label: str, k: int, collection: str) -> None:
     """Split a topic into k sub-topics via KMeans clustering."""
     from nexus.db import make_t3
 
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         topic_id = db.taxonomy.resolve_label(topic_label, collection=collection)
         if topic_id is None:
             click.echo(f"Topic '{topic_label}' not found.")
@@ -898,7 +905,7 @@ def links_cmd(collection: str, refresh: bool) -> None:
     from compute_topic_links (link_types contains 'cites', 'implements',
     etc.).  Use --refresh to recompute catalog-derived links first.
     """
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         if refresh:
             catalog = _try_load_catalog()
             if catalog is None:
@@ -1140,7 +1147,7 @@ def label_cmd(collection: str, relabel_all: bool) -> None:
         click.echo("claude CLI not found. Install Claude Code to use LLM labeling.")
         return
 
-    with _T2Database(_default_db_path()) as db:
+    with _t2_ctx() as db:
         # GitHub #243: the pre-check must see split sub-topics (children
         # with parent_id set); ``get_topics()`` only returns roots, so
         # a post-split pending child would be silently skipped here.
@@ -1221,7 +1228,7 @@ def project_cmd(
     from nexus.corpus import default_projection_threshold
     from nexus.db import make_t3
 
-    db = _T2Database(_default_db_path())
+    db = _t2_ctx()
     t3 = make_t3()
 
     # Resolve threshold: explicit flag wins; otherwise per-corpus default
@@ -1468,7 +1475,7 @@ def hubs_cmd(
     See docs/taxonomy-projection-tuning.md for guidance on interpreting
     the output and acting on flagged topics.
     """
-    db = _T2Database(_default_db_path())
+    db = _t2_ctx()
     try:
         rows = db.taxonomy.detect_hubs(
             min_collections=min_collections,
@@ -1557,7 +1564,7 @@ def audit_cmd(collection: str, threshold: float | None, top_n: int) -> None:
 
     See docs/taxonomy-projection-tuning.md for interpretation guidance.
     """
-    db = _T2Database(_default_db_path())
+    db = _t2_ctx()
     try:
         report = db.taxonomy.audit_collection(
             collection, threshold=threshold, top_n=top_n,

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -1784,20 +1784,17 @@ def backfill_source_collection_cmd(apply_: bool) -> None:
     rows stay NULL (ambiguous source).
     """
     from nexus.commands._helpers import default_db_path
-    from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
     from nexus.taxonomy_backfill import backfill_source_collection
 
     db_path = default_db_path()
     if not db_path.exists():
         raise click.ClickException(f"T2 database not found: {db_path}")
 
-    t2 = T2Database(db_path)
-    try:
+    with t2_ctx() as t2:
         # Pass the store (not the raw conn) so _lock is held for the
         # read + UPDATE sequence (review gate C-1).
         report = backfill_source_collection(t2.taxonomy, apply=apply_)
-    finally:
-        t2.close()
 
     mode = "DRY-RUN" if report.dry_run else "APPLIED"
     click.echo(f"topic_assignments source_collection backfill ({mode})")

--- a/src/nexus/commands/upgrade.py
+++ b/src/nexus/commands/upgrade.py
@@ -160,9 +160,9 @@ def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool =
         # advanced ``_nexus_version.cli_version`` to ``current``, the
         # next run computed ``pending_t3 = []`` and never re-tried.
         if not auto_mode and pending_t3:
-            from nexus.commands._helpers import default_db_path
             from nexus.db import make_t3
             from nexus.db.t2 import T2Database
+            from nexus.mcp_infra import t2_ctx
 
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS _nexus_t3_steps ("
@@ -185,7 +185,7 @@ def _run_upgrade(*, dry_run: bool, force: bool, auto_mode: bool, skip_t3: bool =
                 any_failed = False
                 try:
                     t3_db = make_t3()
-                    t2_db = T2Database(default_db_path())
+                    t2_db = t2_ctx()
                     for step in unapplied:
                         click.echo(f"  T3: [{step.introduced}] {step.name}")
                         try:

--- a/src/nexus/context.py
+++ b/src/nexus/context.py
@@ -188,11 +188,11 @@ def refresh_context_l1(
     repo_path: Path | None = None,
 ) -> Path | None:
     """Open T2, generate L1 context cache, close. Convenience wrapper."""
-    from nexus.config import default_db_path
     from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
-    path = db_path or default_db_path()
-    with T2Database(path) as db:
+    cm = T2Database(db_path) if db_path is not None else t2_ctx()
+    with cm as db:
         return generate_context_l1(
             db.taxonomy, output_path=output_path, repo_path=repo_path,
         )

--- a/src/nexus/db/__init__.py
+++ b/src/nexus/db/__init__.py
@@ -74,3 +74,25 @@ def make_t3(*, _client=None, _ef_override=None) -> "T3Database":
         _client=_client,
         _ef_override=_ef_override,
     )
+
+
+def make_ephemeral_t3(*, ef=None) -> "T3Database":
+    """Return a T3Database backed by an in-process ``EphemeralClient``.
+
+    Used by ``nx index --dry-run`` and similar paths that need a
+    throwaway T3 surface without touching cloud credentials or the
+    persistent local store. Keeps the ``chromadb.EphemeralClient``
+    construction inside ``src/nexus/db/`` per RDR-112 D3 (no client-
+    process chroma construction outside this module).
+
+    When ``ef`` is omitted, the bundled ONNX MiniLM
+    ``DefaultEmbeddingFunction`` is used so callers get a working
+    embedder without API keys.
+    """
+    import chromadb
+    from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+    from nexus.db.t3 import T3Database
+
+    embedder = ef or DefaultEmbeddingFunction()
+    return T3Database(_client=chromadb.EphemeralClient(), _ef_override=embedder)

--- a/src/nexus/hooks.py
+++ b/src/nexus/hooks.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import structlog
 
 from nexus.db.t2 import T2Database
+from nexus.mcp_infra import t2_ctx
 from nexus.session import (
     generate_session_id,
     write_claude_session_id,
@@ -29,7 +30,7 @@ def _default_db_path() -> Path:
 
 
 def _open_t2() -> T2Database:
-    return T2Database(_default_db_path())
+    return t2_ctx()
 
 
 def _open_t1():

--- a/src/nexus/mcp_infra.py
+++ b/src/nexus/mcp_infra.py
@@ -145,7 +145,12 @@ def get_collection_names() -> list[str]:
 
 
 def t2_ctx():
-    """Return a T2Database context manager — fresh per call."""
+    """Return a T2Database context manager — fresh per call.
+
+    Resolves ``default_db_path`` via this module's binding so test
+    fixtures that patch ``nexus.mcp_infra.default_db_path`` continue
+    to take effect.
+    """
     from nexus.db.t2 import T2Database
     return T2Database(default_db_path())
 

--- a/src/nexus/merge_candidates.py
+++ b/src/nexus/merge_candidates.py
@@ -140,12 +140,12 @@ def compute_merge_candidates(
 
 def _open_t2():
     from nexus.config import default_db_path
-    from nexus.db.t2 import T2Database
+    from nexus.mcp_infra import t2_ctx
 
     db_path = default_db_path()
     if not db_path.exists():
         return None
-    return T2Database(db_path)
+    return t2_ctx()
 
 
 # ── CLI entry point ─────────────────────────────────────────────────────────

--- a/tests/test_aspect_promotion.py
+++ b/tests/test_aspect_promotion.py
@@ -243,6 +243,7 @@ class TestCLI:
     ) -> None:
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_with_papers)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_with_papers)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -257,6 +258,7 @@ class TestCLI:
     ) -> None:
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_with_papers)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_with_papers)
 
         runner = CliRunner()
         runner.invoke(enrich, ["aspects-promote-field", "venue"])
@@ -271,6 +273,7 @@ class TestCLI:
     ) -> None:
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_with_papers)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_with_papers)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -285,6 +288,7 @@ class TestCLI:
     ) -> None:
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_with_papers)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_with_papers)
 
         runner = CliRunner()
         runner.invoke(enrich, ["aspects-promote-field", "venue"])
@@ -307,6 +311,7 @@ class TestCLI:
         empty_db = tmp_path / "empty.db"
         T2Database(empty_db).close()
         monkeypatch.setattr("nexus.config.default_db_path", lambda: empty_db)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: empty_db)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -320,6 +325,7 @@ class TestCLI:
     ) -> None:
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_with_papers)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_with_papers)
 
         runner = CliRunner()
         result = runner.invoke(

--- a/tests/test_aspect_sql.py
+++ b/tests/test_aspect_sql.py
@@ -76,6 +76,7 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     db_path = tmp_path / "aspect_sql.db"
     import nexus.commands._helpers as h
     monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+    monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
 
     with T2Database(db_path) as db:
         db.document_aspects.upsert(_make_record(

--- a/tests/test_catalog_cli.py
+++ b/tests/test_catalog_cli.py
@@ -584,6 +584,7 @@ class TestSeedPlanTemplates:
         from nexus.db.t2 import T2Database
         db_path = tmp_path / "t2.db"
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
         from nexus.commands.catalog import _seed_plan_templates
         count = _seed_plan_templates()
         assert count == 15
@@ -597,6 +598,7 @@ class TestSeedPlanTemplates:
         from nexus.db.t2 import T2Database
         db_path = tmp_path / "t2.db"
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
         from nexus.commands.catalog import _seed_plan_templates
         first = _seed_plan_templates()
         second = _seed_plan_templates()
@@ -607,6 +609,7 @@ class TestSeedPlanTemplates:
         from nexus.db.t2 import T2Database
         db_path = tmp_path / "t2.db"
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
         from nexus.commands.catalog import _seed_plan_templates
         _seed_plan_templates()
         db = T2Database(db_path)
@@ -632,6 +635,7 @@ class TestSeedPlanTemplates:
 
         db_path = tmp_path / "t2.db"
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
         # Force the scoped loader to report an empty global tier.
         monkeypatch.setattr(
             "nexus.plans.loader.load_all_tiers",
@@ -652,6 +656,7 @@ class TestSeedPlanTemplates:
         """
         db_path = tmp_path / "t2.db"
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
         monkeypatch.setattr(
             "nexus.plans.loader.load_all_tiers",
             lambda **_kw: {},
@@ -675,6 +680,7 @@ class TestSeedPlanTemplates:
 
         db_path = tmp_path / "t2.db"
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
 
         # Give the global tier one healthy insert so the fail-loud
         # zero-guard does not fire; rdr-099 scope surfaces an error.
@@ -704,6 +710,7 @@ class TestSeedPlanTemplates:
         from nexus.db.t2 import T2Database
         db_path = tmp_path / "t2.db"
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
         from nexus.commands.catalog import _seed_plan_templates
         _seed_plan_templates()
         db = T2Database(db_path)
@@ -721,6 +728,7 @@ class TestSeedPlanTemplates:
         from nexus.db.t2 import T2Database
         db_path = tmp_path / "t2.db"
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
         from nexus.commands.catalog import _seed_plan_templates
         _seed_plan_templates()
         db = T2Database(db_path)
@@ -744,6 +752,7 @@ class TestSeedPlanTemplates:
         from nexus.db.t2 import T2Database
         db_path = tmp_path / "t2.db"
         monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
         from nexus.commands.catalog import _seed_plan_templates
         _seed_plan_templates()
         db = T2Database(db_path)

--- a/tests/test_chash_reconcile.py
+++ b/tests/test_chash_reconcile.py
@@ -107,6 +107,7 @@ class TestChashReconcileCLI:
 
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: mem_db)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: mem_db)
         monkeypatch.setattr("nexus.db.make_t3", lambda: t3_db)
         return mem_db
 
@@ -231,6 +232,7 @@ class TestChashReconcileCLI:
         absent_db = tmp_path / "absent" / "memory.db"
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: absent_db)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: absent_db)
 
         result = runner.invoke(main, ["catalog", "chash-reconcile"])
         assert result.exit_code != 0
@@ -293,6 +295,7 @@ class TestChashReconcileCLI:
 
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: mem_db)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: mem_db)
         monkeypatch.setattr("nexus.db.make_t3", lambda: t3)
 
         result = runner.invoke(main, ["catalog", "chash-reconcile"])

--- a/tests/test_collection_audit.py
+++ b/tests/test_collection_audit.py
@@ -377,7 +377,8 @@ class TestLiveDistanceProbe:
                 sentinel_called["hit"] = True
                 raise AssertionError("live probe fired despite warm telemetry")
 
-        with patch("nexus.config.default_db_path", return_value=tmp_path / "memory.db"):
+        with patch("nexus.config.default_db_path", return_value=tmp_path / "memory.db"), \
+             patch("nexus.mcp_infra.default_db_path", return_value=tmp_path / "memory.db"):
             report = run_collection_audit(
                 "code__main", live=True, t3=ExplodingT3(),
             )
@@ -397,7 +398,8 @@ class TestLiveDistanceProbe:
             def get_or_create_collection(self_, name):
                 return col
 
-        with patch("nexus.config.default_db_path", return_value=tmp_path / "memory.db"):
+        with patch("nexus.config.default_db_path", return_value=tmp_path / "memory.db"), \
+             patch("nexus.mcp_infra.default_db_path", return_value=tmp_path / "memory.db"):
             report = run_collection_audit(
                 "code__fallback_live", live=True, t3=FakeT3(), live_n=6,
             )

--- a/tests/test_collection_rename.py
+++ b/tests/test_collection_rename.py
@@ -380,6 +380,7 @@ class TestRenameCLI:
 
         runner = CliRunner()
         with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
              patch("nexus.config.default_db_path", return_value=db_path), \
              patch("nexus.config.catalog_path", return_value=cat_dir):
             result = runner.invoke(
@@ -432,6 +433,7 @@ class TestRenameCascadeFailureModes:
         runner = CliRunner()
         with patch("nexus.commands.collection._t3", return_value=fake), \
              patch("nexus.db.t2.T2Database", side_effect=_t2_bomb), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
              patch("nexus.config.default_db_path", return_value=db_path), \
              patch("nexus.config.catalog_path", return_value=cat_dir):
             result = runner.invoke(rename_cmd, ["code__old", "code__new"])
@@ -474,6 +476,7 @@ class TestRenameCascadeFailureModes:
         runner = CliRunner()
         with patch("nexus.commands.collection._t3", return_value=fake), \
              patch("nexus.catalog.catalog.Catalog", side_effect=_catalog_bomb), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
              patch("nexus.config.default_db_path", return_value=db_path), \
              patch("nexus.config.catalog_path", return_value=cat_dir):
             result = runner.invoke(rename_cmd, ["code__old", "code__new"])
@@ -698,6 +701,7 @@ class TestAspectCascadeIntegration:
         fake.rename_collection = MagicMock()
 
         with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
              patch("nexus.config.default_db_path", return_value=db_path), \
              patch("nexus.config.catalog_path", return_value=cat_dir):
             counts = rename_collection_data_plane("code__old", "code__new")
@@ -1120,6 +1124,7 @@ class TestK9CascadeIncludesTelemetry:
         fake.rename_collection = MagicMock()
 
         with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
              patch("nexus.config.default_db_path", return_value=db_path), \
              patch("nexus.config.catalog_path", return_value=cat_dir):
             counts = rename_collection_data_plane("code__old", "code__new")
@@ -1176,6 +1181,7 @@ class TestRenameOrdering:
         fake.rename_collection = _t3_rename_bomb
 
         with patch("nexus.commands.collection._t3", return_value=fake), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
              patch("nexus.config.default_db_path", return_value=db_path), \
              patch("nexus.config.catalog_path", return_value=cat_dir):
             with pytest.raises((RuntimeError, click.ClickException)):
@@ -1229,6 +1235,7 @@ class TestHalfCascadeNonZeroExit:
         runner = CliRunner()
         with patch("nexus.commands.collection._t3", return_value=fake), \
              patch("nexus.db.t2.T2Database", side_effect=_t2_bomb), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path), \
              patch("nexus.config.default_db_path", return_value=db_path), \
              patch("nexus.config.catalog_path", return_value=cat_dir):
             result = runner.invoke(rename_cmd, ["code__old", "code__new"])

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -646,7 +646,8 @@ class TestCheckPlanLibrary:
         conn.commit()
         conn.close()
 
-        with patch("nexus.config.default_db_path", return_value=db_path):
+        with patch("nexus.config.default_db_path", return_value=db_path), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path):
             result = runner.invoke(main, ["doctor", "--check-plan-library"])
 
         # Non-zero exit because global builtin count is 0 (no YAMLs seeded).
@@ -670,7 +671,8 @@ class TestCheckPlanLibrary:
         apply_pending(conn, _current_version())
         conn.close()
 
-        with patch("nexus.config.default_db_path", return_value=db_path):
+        with patch("nexus.config.default_db_path", return_value=db_path), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path):
             result = runner.invoke(main, ["doctor", "--check-plan-library"])
 
         assert result.exit_code != 0, result.output
@@ -693,10 +695,14 @@ class TestCheckPlanLibrary:
         monkeypatch.setattr(
             "nexus.config.default_db_path", lambda: db_path,
         )
+        monkeypatch.setattr(
+            "nexus.mcp_infra.default_db_path", lambda: db_path,
+        )
         from nexus.commands.catalog import _seed_plan_templates
         _seed_plan_templates()
 
-        with patch("nexus.config.default_db_path", return_value=db_path):
+        with patch("nexus.config.default_db_path", return_value=db_path), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path):
             result = runner.invoke(main, ["doctor", "--check-plan-library"])
 
         assert result.exit_code == 0, result.output
@@ -725,7 +731,8 @@ class TestCheckPlanLibrary:
         conn.commit()
         conn.close()
 
-        with patch("nexus.config.default_db_path", return_value=db_path):
+        with patch("nexus.config.default_db_path", return_value=db_path), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path):
             result = runner.invoke(main, ["doctor", "--check-plan-library"])
 
         # Non-zero because global builtin count < 9, but the backfill

--- a/tests/test_document_aspects_gc.py
+++ b/tests/test_document_aspects_gc.py
@@ -210,6 +210,7 @@ class TestAspectsGcCLI:
         # at call time).
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: mem_db)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: mem_db)
         monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
         return cat_db, mem_db
 
@@ -271,6 +272,7 @@ class TestAspectsGcCLI:
 
         import nexus.commands._helpers as h
         monkeypatch.setattr("nexus.config.default_db_path", lambda: mem_db)
+        monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: mem_db)
         monkeypatch.setenv("NEXUS_CATALOG_PATH", str(catalog_dir))
 
         from nexus.cli import main

--- a/tests/test_enrich_aspects.py
+++ b/tests/test_enrich_aspects.py
@@ -95,6 +95,7 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     # canonical location.
     import nexus.commands._helpers as h
     monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+    monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
 
     return catalog_dir, db_path, cat
 

--- a/tests/test_enrich_aspects_read.py
+++ b/tests/test_enrich_aspects_read.py
@@ -51,6 +51,7 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(nexus.config, "catalog_path", lambda: catalog_dir)
     import nexus.commands._helpers as h
     monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+    monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
     return catalog_dir, db_path, cat
 
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -236,7 +236,7 @@ def _promote(runner, db, row_id, col="knowledge__proj", extra=None, use_cm=False
     t2 = _t2_cm(db) if use_cm else db
     args = ["memory", "promote", str(row_id), "--collection", col, *(extra or [])]
     with (
-        patch("nexus.commands.memory.T2Database", return_value=t2),
+        patch("nexus.commands.memory.t2_ctx", return_value=t2),
         patch("nexus.commands.memory.get_credential", return_value="fake-key"),
         patch("nexus.config.is_local_mode", return_value=False),
         patch("nexus.db.make_t3", return_value=mt3),
@@ -251,7 +251,7 @@ def _promote(runner, db, row_id, col="knowledge__proj", extra=None, use_cm=False
 def test_promote_no_credentials(runner: CliRunner, mem_home: Path, db: T2Database) -> None:
     row_id = db.put(project="p", title="note.md", content="hello", ttl=30)
     with (
-        patch("nexus.commands.memory.T2Database", return_value=db),
+        patch("nexus.commands.memory.t2_ctx", return_value=db),
         patch("nexus.commands.memory.get_credential", return_value=""),
         patch("nexus.config.is_local_mode", return_value=False),
     ):
@@ -261,7 +261,7 @@ def test_promote_no_credentials(runner: CliRunner, mem_home: Path, db: T2Databas
 
 
 def test_promote_entry_not_found(runner: CliRunner, mem_home: Path, db: T2Database) -> None:
-    with patch("nexus.commands.memory.T2Database", return_value=db):
+    with patch("nexus.commands.memory.t2_ctx", return_value=db):
         result = runner.invoke(main, ["memory", "promote", "9999", "--collection", "knowledge__p"])
     assert result.exit_code != 0
     assert "not found" in result.output.lower() or "9999" in result.output
@@ -301,7 +301,7 @@ def test_promote_missing_database(runner: CliRunner, mem_home: Path, db: T2Datab
     row_id = db.put(project="p", title="note.md", content="hello", ttl=30)
     cred = lambda key: "" if key == "chroma_database" else "fake-value"  # noqa: E731
     with (
-        patch("nexus.commands.memory.T2Database", return_value=db),
+        patch("nexus.commands.memory.t2_ctx", return_value=db),
         patch("nexus.commands.memory.get_credential", side_effect=cred),
         patch("nexus.config.is_local_mode", return_value=False),
     ):
@@ -329,7 +329,7 @@ def test_promote_expires_at_from_t2_timestamp(runner: CliRunner, mem_home: Path,
 
 def test_delete_cmd_by_project_title(runner: CliRunner, mem_home: Path, db: T2Database) -> None:
     db.put(project="proj", title="note.md", content="content to delete")
-    with patch("nexus.commands.memory.T2Database", return_value=_t2_cm(db)):
+    with patch("nexus.commands.memory.t2_ctx", return_value=_t2_cm(db)):
         result = runner.invoke(main, ["memory", "delete", "--project", "proj", "--title", "note.md", "--yes"])
     assert result.exit_code == 0 and "Deleted" in result.output
     assert db.get(project="proj", title="note.md") is None
@@ -337,7 +337,7 @@ def test_delete_cmd_by_project_title(runner: CliRunner, mem_home: Path, db: T2Da
 
 def test_delete_cmd_by_id(runner: CliRunner, mem_home: Path, db: T2Database) -> None:
     row_id = db.put(project="proj", title="note.md", content="delete by id content")
-    with patch("nexus.commands.memory.T2Database", return_value=_t2_cm(db)):
+    with patch("nexus.commands.memory.t2_ctx", return_value=_t2_cm(db)):
         result = runner.invoke(main, ["memory", "delete", "--id", str(row_id), "--yes"])
     assert result.exit_code == 0 and "proj/note.md" in result.output
     assert db.get(id=row_id) is None
@@ -347,7 +347,7 @@ def test_delete_cmd_all(runner: CliRunner, mem_home: Path, db: T2Database) -> No
     db.put(project="proj", title="a.md", content="a")
     db.put(project="proj", title="b.md", content="b")
     db.put(project="other", title="c.md", content="c")
-    with patch("nexus.commands.memory.T2Database", return_value=_t2_cm(db)):
+    with patch("nexus.commands.memory.t2_ctx", return_value=_t2_cm(db)):
         result = runner.invoke(main, ["memory", "delete", "--project", "proj", "--all", "--yes"])
     assert result.exit_code == 0 and "Deleted 2" in result.output
     assert db.list_entries(project="proj") == []
@@ -364,7 +364,7 @@ def test_delete_cmd_rejected(runner: CliRunner, mem_home: Path, args: list, expe
 
 
 def test_delete_cmd_not_found(runner: CliRunner, mem_home: Path, db: T2Database) -> None:
-    with patch("nexus.commands.memory.T2Database", return_value=_t2_cm(db)):
+    with patch("nexus.commands.memory.t2_ctx", return_value=_t2_cm(db)):
         result = runner.invoke(main, ["memory", "delete", "--project", "no", "--title", "such.md", "--yes"])
     assert result.exit_code != 0 and "not found" in result.output
 
@@ -377,7 +377,7 @@ def test_get_cmd_exact_title_match(
 ) -> None:
     """Exact title match returns the content (regression guard — baseline)."""
     db.put(project="p", title="note.md", content="content-body-sentinel")
-    with patch("nexus.commands.memory.T2Database", return_value=_t2_cm(db)):
+    with patch("nexus.commands.memory.t2_ctx", return_value=_t2_cm(db)):
         result = runner.invoke(
             main, ["memory", "get", "--project", "p", "--title", "note.md"],
         )
@@ -394,7 +394,7 @@ def test_get_cmd_unique_prefix_match_resolves(
         title="088-research-1: RDR-092 baseline for Gap 4 spike",
         content="baseline-body-xyz",
     )
-    with patch("nexus.commands.memory.T2Database", return_value=_t2_cm(db)):
+    with patch("nexus.commands.memory.t2_ctx", return_value=_t2_cm(db)):
         result = runner.invoke(
             main, ["memory", "get", "--project", "nexus_rdr",
                    "--title", "088-research-1"],
@@ -409,7 +409,7 @@ def test_get_cmd_ambiguous_prefix_lists_candidates(
     """Multiple prefix matches must list candidates and fail loud (not silent-pick)."""
     db.put(project="p", title="088-research-1: first", content="one")
     db.put(project="p", title="088-research-1b: second", content="two")
-    with patch("nexus.commands.memory.T2Database", return_value=_t2_cm(db)):
+    with patch("nexus.commands.memory.t2_ctx", return_value=_t2_cm(db)):
         result = runner.invoke(
             main, ["memory", "get", "--project", "p",
                    "--title", "088-research-1"],
@@ -425,7 +425,7 @@ def test_get_cmd_no_match_still_fails_loud(
     runner: CliRunner, mem_home: Path, db: T2Database,
 ) -> None:
     """Zero-match continues to fail — behaviour preserved from baseline."""
-    with patch("nexus.commands.memory.T2Database", return_value=_t2_cm(db)):
+    with patch("nexus.commands.memory.t2_ctx", return_value=_t2_cm(db)):
         result = runner.invoke(
             main, ["memory", "get", "--project", "none", "--title", "missing"],
         )
@@ -439,7 +439,7 @@ def test_get_cmd_exact_wins_over_prefix(
     """When an exact entry exists alongside a longer-title match, exact wins."""
     db.put(project="p", title="088-research-1", content="short-entry")
     db.put(project="p", title="088-research-1: full-suffix", content="long-entry")
-    with patch("nexus.commands.memory.T2Database", return_value=_t2_cm(db)):
+    with patch("nexus.commands.memory.t2_ctx", return_value=_t2_cm(db)):
         result = runner.invoke(
             main, ["memory", "get", "--project", "p",
                    "--title", "088-research-1"],

--- a/tests/test_merge_candidates.py
+++ b/tests/test_merge_candidates.py
@@ -214,6 +214,9 @@ class TestMergeCandidatesCli:
         monkeypatch.setattr(
             "nexus.config.default_db_path", lambda: db_path,
         )
+        monkeypatch.setattr(
+            "nexus.mcp_infra.default_db_path", lambda: db_path,
+        )
 
         result = runner.invoke(
             main,
@@ -232,6 +235,9 @@ class TestMergeCandidatesCli:
         _seed_t2(db_path)
         monkeypatch.setattr(
             "nexus.config.default_db_path", lambda: db_path,
+        )
+        monkeypatch.setattr(
+            "nexus.mcp_infra.default_db_path", lambda: db_path,
         )
 
         result = runner.invoke(
@@ -253,6 +259,9 @@ class TestMergeCandidatesCli:
         _seed_t2(db_path)
         monkeypatch.setattr(
             "nexus.config.default_db_path", lambda: db_path,
+        )
+        monkeypatch.setattr(
+            "nexus.mcp_infra.default_db_path", lambda: db_path,
         )
 
         result = runner.invoke(
@@ -283,6 +292,9 @@ class TestMergeCandidatesCli:
         monkeypatch.setattr(
             "nexus.config.default_db_path", lambda: db_path,
         )
+        monkeypatch.setattr(
+            "nexus.mcp_infra.default_db_path", lambda: db_path,
+        )
 
         result = runner.invoke(
             main, ["collection", "merge-candidates", "--min-shared", "1"],
@@ -301,6 +313,9 @@ class TestMergeCandidatesCli:
         _seed_t2(db_path)
         monkeypatch.setattr(
             "nexus.config.default_db_path", lambda: db_path,
+        )
+        monkeypatch.setattr(
+            "nexus.mcp_infra.default_db_path", lambda: db_path,
         )
 
         result = runner.invoke(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -113,7 +113,7 @@ def test_session_end_runs_expire(runner: CliRunner, fake_home: Path) -> None:
 
     _t2_cm = MagicMock(__enter__=MagicMock(return_value=mock_t2))
     with patch("nexus.hooks._open_t1", return_value=MagicMock(flagged_entries=lambda: [])):
-        with patch("nexus.hooks.T2Database", return_value=_t2_cm):
+        with patch("nexus.hooks.t2_ctx", return_value=_t2_cm):
             result = runner.invoke(main, ["hook", "session-end"])
 
     mock_t2.expire.assert_called_once()

--- a/tests/test_rdr052_verification.py
+++ b/tests/test_rdr052_verification.py
@@ -59,6 +59,7 @@ def catalog(tmp_path):
 def _seed_templates(tmp_path, monkeypatch):
     db_path = tmp_path / "t2.db"
     monkeypatch.setattr("nexus.config.default_db_path", lambda: db_path)
+    monkeypatch.setattr("nexus.mcp_infra.default_db_path", lambda: db_path)
     from nexus.commands.catalog import _seed_plan_templates
     return db_path, _seed_plan_templates
 

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -3866,7 +3866,7 @@ class TestProjectCmd:
         runner = CliRunner()
         with (
             patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=tmp_path / "memory.db"),
-            patch("nexus.commands.taxonomy_cmd._T2Database", return_value=db),
+            patch("nexus.commands.taxonomy_cmd._t2_ctx", return_value=db),
             patch("nexus.db.make_t3") as mock_t3,
         ):
             mock_t3.return_value._client = chroma_client
@@ -3910,7 +3910,7 @@ class TestProjectCmd:
         runner = CliRunner()
         with (
             patch("nexus.commands.taxonomy_cmd._default_db_path", return_value=tmp_path / "memory.db"),
-            patch("nexus.commands.taxonomy_cmd._T2Database", return_value=db),
+            patch("nexus.commands.taxonomy_cmd._t2_ctx", return_value=db),
             patch("nexus.db.make_t3") as mock_t3,
         ):
             mock_t3.return_value._client = chroma_client
@@ -3972,7 +3972,7 @@ class TestProjectCmd:
         with (
             patch("nexus.commands.taxonomy_cmd._default_db_path",
                   return_value=tmp_path / "db.sqlite"),
-            patch("nexus.commands.taxonomy_cmd._T2Database", return_value=db),
+            patch("nexus.commands.taxonomy_cmd._t2_ctx", return_value=db),
             patch("nexus.db.make_t3") as mock_t3,
         ):
             mock_t3.return_value._client = chroma_client

--- a/tests/test_taxonomy_backfill.py
+++ b/tests/test_taxonomy_backfill.py
@@ -189,6 +189,10 @@ class TestBackfillCli:
             "nexus.commands._helpers.default_db_path",
             lambda: db_path,
         )
+        monkeypatch.setattr(
+            "nexus.mcp_infra.default_db_path",
+            lambda: db_path,
+        )
 
     def test_default_is_dry_run(
         self, runner: CliRunner, tmp_path: Path, monkeypatch,

--- a/tests/test_upgrade_e2e.py
+++ b/tests/test_upgrade_e2e.py
@@ -150,7 +150,8 @@ class TestSC4DoctorSchema:
         apply_pending(conn, _current_version())
         conn.close()
 
-        with patch("nexus.config.default_db_path", return_value=db_path):
+        with patch("nexus.config.default_db_path", return_value=db_path), \
+             patch("nexus.mcp_infra.default_db_path", return_value=db_path):
             result = runner.invoke(main, ["doctor", "--check-schema"])
         assert result.exit_code == 0
         assert "passed" in result.output.lower()


### PR DESCRIPTION
## Summary

Closes the residual D3 violations from the 2026-05-13 RDR-112 P0.5 review: ~30 ``T2Database(_*default_db_path())`` reach-throughs across the command/hooks/collection-rename surface, plus the in-line ``chromadb.EphemeralClient()`` construction at ``index.py:810``.

Daemon-mode (RDR-112 Phase 1, ``nexus-507q``) makes client-process T2/T3 construction impossible to flip in place; this PR routes everything through the supported factories so Phase-1 swaps a single seam.

## Production changes

- ``src/nexus/db/__init__.py``: add ``make_ephemeral_t3()`` so ``chromadb.EphemeralClient`` construction stays inside ``src/nexus/db/``.
- ``src/nexus/commands/index.py``: ``--dry-run`` path uses the new helper.
- All other touched files: ``T2Database(default_db_path())`` -> ``t2_ctx()``.
- ``src/nexus/mcp_infra.t2_ctx``: docstring clarifies the test-fixture contract (resolves ``default_db_path`` via this module's binding).
- ``src/nexus/commands/taxonomy_cmd.py``: rename ``_T2Database`` shim to ``_t2_ctx`` while preserving the lazy-import pattern test mocks rely on.

## Test changes

- Mirror every ``patch(\"nexus.config.default_db_path\")`` /  ``monkeypatch.setattr(\"nexus.config.default_db_path\")`` site with a matching ``nexus.mcp_infra.default_db_path`` patch. ``mcp_infra`` captures the binding at import time so config-only patches no longer reach ``t2_ctx``.
- Update ``patch(\"nexus.commands.memory.T2Database\")``, ``patch(\"nexus.hooks.T2Database\")``, and the taxonomy_cmd ``_T2Database`` references to the new factory names.

## Predicate ACs (per the bead)

```
git grep 'T2Database(_*default_db_path()' -- src/nexus/commands/ \\
    src/nexus/hooks.py src/nexus/merge_candidates.py \\
    src/nexus/context.py src/nexus/collection_rename.py     # -> zero

git grep 'chromadb\\.EphemeralClient' -- src/nexus/
# -> only src/nexus/db/__init__.py + src/nexus/db/t1.py
```

Both clean.

## Test plan

- [x] Full unit suite locally: 7300 pass, 1 pre-existing fail (drain-locked MCP test, reproduces on develop tip)
- [x] All ~30 flipped sites + 17 test files exercised via focused regression sweeps (357 + 31 + 130 + 543 + 218 = ~1300 tests across the touched surface)
- [ ] CI green on develop

## Closes

Part of ``nexus-j6bi`` epic; closes ``nexus-oi0z``.