### PR TITLE
fix(indexer): graceful degradation on malformed RDR frontmatter (nexus-qr9d)

### DIFF
--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -1034,7 +1034,7 @@ def _markdown_chunks(
         git_meta = detect_git_metadata(md_path)
 
     raw_text = md_path.read_text(encoding="utf-8")
-    frontmatter, body = parse_frontmatter(raw_text)
+    frontmatter, body = parse_frontmatter(raw_text, source=str(md_path), strict=True)
     frontmatter_len = len(raw_text) - len(body)
 
     # RDR-102 D2: source_path is no longer carried at any layer of the

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1450,7 +1450,12 @@ def _discover_and_index_rdrs(
     indexed = sum(1 for s in results.values() if s == "indexed")
     skipped = sum(1 for s in results.values() if s == "skipped")
     failed = sum(1 for s in results.values() if s == "failed")
-    _log.info("RDR indexing complete", indexed=indexed, current=skipped, failed=failed)
+    failed_paths = sorted(p for p, s in results.items() if s == "failed")
+    _log.info(
+        "RDR indexing complete",
+        indexed=indexed, current=skipped, failed=failed,
+        failed_paths=failed_paths,
+    )
     return indexed, skipped, failed
 
 

--- a/src/nexus/md_chunker.py
+++ b/src/nexus/md_chunker.py
@@ -85,11 +85,24 @@ class MarkdownChunk:
     header_path: list[str]
 
 
-def parse_frontmatter(text: str) -> tuple[dict, str]:
+def parse_frontmatter(
+    text: str,
+    *,
+    source: str | None = None,
+    strict: bool = False,
+) -> tuple[dict, str]:
     """Extract YAML frontmatter from *text*.
 
     Returns ``(metadata_dict, body)`` where *body* has the frontmatter block
     stripped.  Returns ``({}, text)`` when no frontmatter is detected.
+
+    *source* is included in the warning log on parse failure so operators can
+    locate the offending file (PyYAML's default ``<unicode string>`` is
+    useless when batch-indexing).
+
+    *strict=True* re-raises ``yaml.YAMLError`` instead of swallowing it,
+    letting callers (e.g. the RDR post-pass) mark the file as failed and
+    skip rather than silently indexing the body without frontmatter.
     """
     if not text.startswith("---"):
         return {}, text
@@ -103,7 +116,13 @@ def parse_frontmatter(text: str) -> tuple[dict, str]:
         if not isinstance(data, dict):
             data = {}
     except yaml.YAMLError as exc:
-        _log.warning("frontmatter_parse_failed", error=str(exc))
+        _log.warning(
+            "frontmatter_parse_failed",
+            source=source or "<unknown>",
+            error=str(exc),
+        )
+        if strict:
+            raise
         data = {}
     return data, rest
 

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -76,7 +76,7 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
     if ext in (".md", ".markdown"):
         # Markdown: use SemanticMarkdownChunker (M1: uses char offsets, not line numbers)
         with _stage("chunking"):
-            frontmatter, body = parse_frontmatter(content)
+            frontmatter, body = parse_frontmatter(content, source=str(file_path))
             frontmatter_len = len(content) - len(body)
             base_meta: dict = {"source_path": str(file_path), "corpus": ctx.corpus}
             chunks = SemanticMarkdownChunker().chunk(body, base_meta)

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -224,6 +224,54 @@ def test_identity_where_falls_back_when_corpus_owner_missing(tmp_path, monkeypat
     assert where == {"source_path": "/abs/path/x.pdf"}
 
 
+def test_batch_index_markdowns_skips_malformed_frontmatter_and_continues(
+    tmp_path, monkeypatch,
+):
+    """nexus-qr9d: malformed YAML frontmatter on one file must not abort
+    the batch or hang the post-pass. The offending file is marked
+    ``failed`` with its path; sibling files complete normally; the whole
+    call returns within a wall-clock bound."""
+    import chromadb
+    from nexus.catalog import reset_cache
+    from nexus.catalog.catalog import Catalog
+    from nexus.db.t3 import T3Database
+
+    cat_dir = tmp_path / "test-catalog"
+    Catalog.init(cat_dir)
+    reset_cache()
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+    monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "nexus.config._global_config_path", lambda: Path("/nonexistent"),
+    )
+
+    good = tmp_path / "good.md"
+    good.write_text(
+        "---\ntitle: Good\n---\n\n# Good\n\nContent here.\n",
+        encoding="utf-8",
+    )
+    # YAML flow sequence with unquoted #-refs — the exact hazard from the bead.
+    bad = tmp_path / "bad.md"
+    bad.write_text(
+        "---\nprs: [#381, #382]\nstatus: post-mortem\n---\n\n# Body\n\nText.\n",
+        encoding="utf-8",
+    )
+
+    client = chromadb.EphemeralClient()
+    t3 = T3Database(_client=client, local_mode=True)
+
+    t0 = time.monotonic()
+    results = batch_index_markdowns(
+        [bad, good], corpus="qr9d-test", t3=t3,
+        collection_name=f"rdr__qr9d-test__{_local_token()}__v1",
+        content_type="rdr",
+    )
+    elapsed = time.monotonic() - t0
+    assert elapsed < 30.0, f"batch hung or far too slow ({elapsed:.1f}s)"
+    assert results[str(bad)] == "failed"
+    assert results[str(good)] == "indexed"
+
+
 def test_index_md_falls_back_to_local_embedder_when_no_credentials(
     sample_md, tmp_path, monkeypatch,
 ):

--- a/tests/test_md_chunker.py
+++ b/tests/test_md_chunker.py
@@ -39,6 +39,30 @@ def test_parse_frontmatter_strips_delimiters():
     assert "---" not in rest
 
 
+def test_parse_frontmatter_warning_includes_source_path(caplog):
+    """nexus-qr9d: PyYAML's <unicode string> default is useless when batch-indexing;
+    the warning must surface the file path so operators can locate the offender."""
+    import structlog
+    from structlog.testing import capture_logs
+
+    bad = "---\nprs: [#381, #382]\nstatus: x\n---\n\nBody\n"
+    with capture_logs() as cap:
+        fm, _ = parse_frontmatter(bad, source="/path/to/rdr-bad.md")
+    assert fm == {}
+    fails = [e for e in cap if e["event"] == "frontmatter_parse_failed"]
+    assert len(fails) == 1
+    assert fails[0]["source"] == "/path/to/rdr-bad.md"
+
+
+def test_parse_frontmatter_strict_raises():
+    """nexus-qr9d: strict mode lets RDR pipeline mark file as failed and skip,
+    rather than silently indexing the body without frontmatter."""
+    import yaml as _yaml
+    bad = "---\nprs: [#381, #382]\nstatus: x\n---\n\nBody\n"
+    with pytest.raises(_yaml.YAMLError):
+        parse_frontmatter(bad, source="x.md", strict=True)
+
+
 # ── SemanticMarkdownChunker basics ───────────────────────────────────────────
 
 def test_chunk_empty_text_returns_empty(chunker):


### PR DESCRIPTION
## Summary
- `parse_frontmatter` gains `source` (path included in the parse-failure warning so the offender is locatable) and `strict` (re-raises `YAMLError`).
- `doc_indexer` opts into `strict`; `batch_index_markdowns`'s existing per-file try/except catches it and marks the file `failed` rather than silently indexing the body with empty metadata.
- `_discover_and_index_rdrs` surfaces failed paths in its summary log.

## Test plan
- [x] `uv run pytest tests/test_md_chunker.py tests/test_md_preservation.py tests/test_silent_error_logging.py tests/test_doc_indexer.py` — 199 passed
- [x] New regression: malformed `prs: [#…]` flow-sequence (the exact hazard from the bead) alongside a good RDR completes under 30s with one `failed`, one `indexed`.

Closes nexus-qr9d.