### PR TITLE
feat(rdr): nx rdr lint + frontmatter quoting convention (nexus-u7ek)

### DIFF
--- a/docs/rdr/AGENTS.md
+++ b/docs/rdr/AGENTS.md
@@ -39,3 +39,25 @@ If you need to find an RDR by topic, prefer the index in `docs/rdr/README.md` ov
 Use the lifecycle skills: `/nx:rdr-create` → `/nx:rdr-research` → `/nx:rdr-gate` → `/nx:rdr-accept` → `/nx:rdr-close`. List existing with `/nx:rdr-list`; show one with `/nx:rdr-show NNN`.
 
 The numbering is monotonic; pick the next unused integer. The frontmatter shape is enforced by `/nx:rdr-audit`.
+
+## Frontmatter quoting — `#` is comment-start in YAML
+
+When listing PR / issue / bead refs in YAML frontmatter, **always quote them.** YAML treats `#` as comment-start at any token-start position, so an unquoted flow sequence like `prs: [#381, #382]` silently parses as an empty list followed by a comment that eats the closing `]`. The scanner then runs off the end of the frontmatter and raises `ScannerError: while parsing a flow sequence … got '<stream end>'`. The indexer marks the RDR `failed` (since nexus-qr9d) and skips it; before that fix it hung.
+
+```yaml
+# ❌ broken — # makes the rest of the line a comment
+references:
+  prs: [#381, #382, #383]
+
+# ✅ flow form, quoted
+references:
+  prs: ["#381", "#382", "#383"]
+
+# ✅ block form, quoted
+references:
+  prs:
+    - "#381"
+    - "#382"
+```
+
+Run `nx rdr lint` before committing to catch this hazard.

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -51,6 +51,7 @@ from nexus.commands.index import index
 from nexus.commands.memory import memory
 from nexus.commands.mineru import mineru_group
 from nexus.commands.plan import plan as plan_group
+from nexus.commands.rdr import rdr as rdr_group
 from nexus.commands.scratch import scratch
 from nexus.commands.search_cmd import search_cmd
 from nexus.commands.store import store
@@ -99,6 +100,7 @@ main.add_command(index)
 main.add_command(memory)
 main.add_command(mineru_group, name="mineru")
 main.add_command(plan_group, name="plan")
+main.add_command(rdr_group, name="rdr")
 main.add_command(scratch)
 main.add_command(search_cmd, name="search")
 main.add_command(store)

--- a/src/nexus/commands/rdr.py
+++ b/src/nexus/commands/rdr.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``nx rdr`` — RDR authoring helpers.
+
+Currently exposes a single subcommand, ``lint``, that scans RDR markdown
+files for frontmatter hazards that break downstream indexing. The first
+hazard it covers is ``nexus-u7ek``: YAML flow sequences containing
+unquoted ``#``-prefixed refs (``prs: [#381, #382]``) silently parse as an
+empty list + comment, scan past the closing ``]``, and run off the end
+of the frontmatter.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import click
+import yaml
+
+
+# Matches a flow-sequence opener followed by an unquoted ``#``-token.
+# ``\[`` opens the sequence; optional whitespace; then ``#`` directly
+# (i.e. *not* preceded by a quote). We rely on the regex being narrow
+# enough that legitimate ``#``-inside-a-quoted-string ("[\"#381\"]")
+# does not match.
+_HASH_REF_IN_FLOW_SEQ = re.compile(r":\s*\[\s*#")
+
+
+def _frontmatter_block(text: str) -> str | None:
+    """Return the frontmatter block (without delimiters) or None."""
+    if not text.startswith("---"):
+        return None
+    idx = text.find("\n---", 3)
+    if idx == -1:
+        return None
+    return text[3:idx]
+
+
+def _lint_one(path: Path) -> list[str]:
+    """Return a list of human-readable findings for *path* (empty if clean)."""
+    findings: list[str] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return [f"{path}: read failed ({type(exc).__name__}: {exc})"]
+
+    fm = _frontmatter_block(text)
+    if fm is None:
+        return findings
+
+    for lineno, line in enumerate(fm.splitlines(), start=2):  # +1 for opening ---
+        if _HASH_REF_IN_FLOW_SEQ.search(line):
+            findings.append(
+                f"{path}:{lineno}: unquoted #-ref in YAML flow sequence "
+                f"({line.strip()!r}); quote the refs: "
+                f'prs: ["#381", "#382"]'
+            )
+
+    try:
+        yaml.safe_load(fm)
+    except yaml.YAMLError as exc:
+        findings.append(f"{path}: frontmatter YAML parse error: {exc}")
+
+    return findings
+
+
+@click.group()
+def rdr() -> None:
+    """RDR authoring helpers."""
+
+
+@rdr.command("lint")
+@click.argument(
+    "paths",
+    nargs=-1,
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.option(
+    "--root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Scan this directory recursively for *.md (default: docs/rdr/ if it exists).",
+)
+def lint(paths: tuple[Path, ...], root: Path | None) -> None:
+    """Lint RDR frontmatter for parse hazards.
+
+    Checks each *.md for frontmatter that would fail downstream YAML
+    parsing — primarily the ``prs: [#NNN]`` flow-sequence hazard
+    (nexus-u7ek). Exits non-zero when any finding is reported.
+    """
+    targets: list[Path] = []
+    if paths:
+        for p in paths:
+            if p.is_dir():
+                targets.extend(sorted(p.rglob("*.md")))
+            else:
+                targets.append(p)
+    else:
+        scan_root = root or Path("docs/rdr")
+        if not scan_root.exists():
+            click.echo(
+                f"no paths given and {scan_root} not found; nothing to lint",
+                err=True,
+            )
+            sys.exit(2)
+        targets = sorted(scan_root.rglob("*.md"))
+
+    all_findings: list[str] = []
+    for path in targets:
+        all_findings.extend(_lint_one(path))
+
+    if all_findings:
+        for f in all_findings:
+            click.echo(f, err=True)
+        click.echo(
+            f"\n{len(all_findings)} finding(s) in {len(targets)} file(s)", err=True,
+        )
+        sys.exit(1)
+
+    click.echo(f"clean: {len(targets)} file(s) scanned")

--- a/tests/test_rdr_lint.py
+++ b/tests/test_rdr_lint.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-u7ek: lint catches the YAML #-flow-sequence hazard."""
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from nexus.commands.rdr import lint, rdr
+
+
+def test_lint_flags_unquoted_hash_in_flow_sequence(tmp_path: Path):
+    bad = tmp_path / "bad.md"
+    bad.write_text(
+        "---\nprs: [#381, #382, #383]\nstatus: post-mortem\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint", str(bad)])
+    assert result.exit_code == 1
+    assert "unquoted #-ref in YAML flow sequence" in result.output
+
+
+def test_lint_passes_quoted_refs(tmp_path: Path):
+    good = tmp_path / "good.md"
+    good.write_text(
+        '---\nprs: ["#381", "#382"]\nstatus: accepted\n---\n\nBody\n',
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint", str(good)])
+    assert result.exit_code == 0, result.output
+    assert "clean" in result.output
+
+
+def test_lint_passes_block_form(tmp_path: Path):
+    good = tmp_path / "good.md"
+    good.write_text(
+        '---\nprs:\n  - "#381"\n  - "#382"\nstatus: accepted\n---\n\nBody\n',
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint", str(good)])
+    assert result.exit_code == 0, result.output
+
+
+def test_lint_passes_file_without_frontmatter(tmp_path: Path):
+    plain = tmp_path / "plain.md"
+    plain.write_text("# Just a heading\n\nNo frontmatter here.\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint", str(plain)])
+    assert result.exit_code == 0, result.output
+
+
+def test_lint_recurses_into_directory(tmp_path: Path):
+    sub = tmp_path / "post-mortem"
+    sub.mkdir()
+    (sub / "bad.md").write_text(
+        "---\nprs: [#1, #2]\n---\n", encoding="utf-8",
+    )
+    (sub / "good.md").write_text(
+        "---\ntitle: ok\n---\n", encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "bad.md" in result.output
+    assert "good.md" not in result.output
+
+
+def test_lint_default_root_missing_exits_2(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint"])
+    assert result.exit_code == 2


### PR DESCRIPTION
## Summary
- `docs/rdr/AGENTS.md` documents the YAML `#`-comment hazard with paired ❌/✅ examples (flow + block form).
- New `nx rdr lint` command scans `docs/rdr/` (or given paths) for the `prs: [#NNN]` hazard and runs `yaml.safe_load` per file. Exits 1 on findings; 0 on clean.

Pairs with nexus-qr9d (graceful degradation downstream — PR #755).

## Test plan
- [x] `uv run pytest tests/test_rdr_lint.py` — 6 passed
- [x] `nx rdr lint` against live `docs/rdr/`: 156 files, 0 findings (the lone historical offender was fixed in PR #724)

Closes nexus-u7ek.