### PR TITLE
fix(index): prefer conformant code_collection over legacy alias (nexus-cxg9)

### DIFF
--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -464,6 +464,17 @@ def _collections_from_registry_info(info: dict) -> list[str]:
     projection post-processing, filtered by
     ``taxonomy.local_exclude_collections``. Empty list when
     *info* is ``{}`` or carries no collection keys.
+
+    nexus-cxg9: prefer the conformant ``code_collection`` /
+    ``docs_collection`` / ``rdr_collection`` over the legacy
+    ``collection`` alias. The alias was kept in
+    ``RepoRegistry.add`` for backward compat (line 228) but for
+    repos registered before RDR-103 it still holds the
+    non-conformant ``code__<basename>-<hash8>`` shape (no
+    embedding_model / version segments), which does not exist in
+    T3 and emits ``collection_not_found`` every post-pass. Skipping
+    the alias when the conformant ``code_collection`` is present
+    silences the false warning without touching real data.
     """
     from fnmatch import fnmatch
 
@@ -474,11 +485,21 @@ def _collections_from_registry_info(info: dict) -> list[str]:
         cfg.get("taxonomy", {}).get("local_exclude_collections", [])
         if is_local_mode() else []
     )
+    code_col = info.get("code_collection") or info.get("collection")
+    candidates = [
+        code_col,
+        info.get("docs_collection"),
+        info.get("rdr_collection"),
+    ]
     collections: list[str] = []
-    for key in ("collection", "docs_collection"):
-        col = info.get(key)
-        if col and not any(fnmatch(col, pat) for pat in exclude_patterns):
-            collections.append(col)
+    seen: set[str] = set()
+    for col in candidates:
+        if not col or col in seen:
+            continue
+        if any(fnmatch(col, pat) for pat in exclude_patterns):
+            continue
+        seen.add(col)
+        collections.append(col)
     return collections
 
 

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -505,6 +505,44 @@ def test_collections_from_registry_info_filters_excluded() -> None:
     assert "docs__myrepo__voyage-context-3__v1" in out
 
 
+def test_collections_from_registry_info_prefers_conformant_code_collection() -> None:
+    """nexus-cxg9: pre-RDR-103 entries keep the legacy non-conformant
+    ``collection`` alias even after the conformant ``code_collection``
+    is set. The post-pass must enumerate the conformant name only —
+    enumerating the alias triggers ``collection_not_found`` every run.
+    """
+    from nexus.commands.index import _collections_from_registry_info
+
+    info = {
+        "collection": "code__nexus-571b8edd",  # legacy alias, no T3 collection
+        "code_collection": "code__1-2188__voyage-code-3__v1",
+        "docs_collection": "docs__1-2188__voyage-context-3__v1",
+        "rdr_collection": "rdr__1-2188__voyage-context-3__v1",
+    }
+    out = _collections_from_registry_info(info)
+    assert "code__nexus-571b8edd" not in out, (
+        "legacy non-conformant alias must not be enumerated when a "
+        "conformant code_collection is present"
+    )
+    # Cloud-mode passthrough: rdr/docs always; code__ filtered in local mode only.
+    assert "docs__1-2188__voyage-context-3__v1" in out
+    assert "rdr__1-2188__voyage-context-3__v1" in out
+
+
+def test_collections_from_registry_info_dedupes() -> None:
+    """nexus-cxg9: when the legacy ``collection`` field happens to equal
+    ``code_collection`` (post-RDR-103 fresh registrations), the result
+    must not contain duplicates.
+    """
+    from nexus.commands.index import _collections_from_registry_info
+
+    name = "code__myrepo__voyage-code-3__v1"
+    info = {"collection": name, "code_collection": name,
+            "docs_collection": "docs__myrepo__voyage-context-3__v1"}
+    out = _collections_from_registry_info(info)
+    assert len(out) == len(set(out))
+
+
 # ── GH #451: --corpus flag for nx index repo ────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Root cause: `_collections_from_registry_info` enumerated the legacy backward-compat `collection` alias unconditionally, even when the conformant `code_collection` was present alongside it. For repos registered before RDR-103, the alias holds a non-conformant `code__<basename>-<hash8>` name that doesn't exist in T3 → `collection_not_found` every run.
- Fix: prefer `code_collection` over `collection`; also enumerate the previously-ignored `rdr_collection`; de-dupe.

## Live evidence
The reporter's own registry against `~/git/nexus`:

```
collection:       code__nexus-571b8edd            ← orphan, the warning
code_collection:  code__1-2188__voyage-code-3__v1 ← real, in T3
docs_collection:  docs__1-2188__voyage-context-3__v1
rdr_collection:   rdr__1-2188__voyage-context-3__v1
```

The bead's second observed warning (`docs__1-2188__voyage-context-3__v1`) no longer reproduces — that collection now exists in T3. Likely transient (T3 created mid-run on the original capture).

## Test plan
- [x] `uv run pytest tests/test_collection_cmd.py` — 37 passed (2 new: alias-collision regression, dedupe)
- Registry left alone — the alias is harmless once not enumerated.

Closes nexus-cxg9.