### PR TITLE
fix(review): qr9d/u7ek/cxg9 review remediation

### DIFF
--- a/src/nexus/commands/rdr.py
+++ b/src/nexus/commands/rdr.py
@@ -18,12 +18,13 @@ import click
 import yaml
 
 
-# Matches a flow-sequence opener followed by an unquoted ``#``-token.
-# ``\[`` opens the sequence; optional whitespace; then ``#`` directly
-# (i.e. *not* preceded by a quote). We rely on the regex being narrow
-# enough that legitimate ``#``-inside-a-quoted-string ("[\"#381\"]")
-# does not match.
-_HASH_REF_IN_FLOW_SEQ = re.compile(r":\s*\[\s*#")
+# Matches a flow-sequence opener followed (eventually) by an unquoted
+# ``#`` before the closing ``]``. ``[^\]"']*?`` lets us span multiple
+# lines (PyYAML's multi-line flow sequences parse silently into empty
+# lists when ``#`` introduces comments mid-sequence — a true false
+# negative for the single-line regex). The ``"'`` exclusion keeps quoted
+# strings from being mis-flagged as the hazard.
+_HASH_REF_IN_FLOW_SEQ = re.compile(r":\s*\[[^\]\"']*?#", re.DOTALL)
 
 
 def _frontmatter_block(text: str) -> str | None:
@@ -48,13 +49,28 @@ def _lint_one(path: Path) -> list[str]:
     if fm is None:
         return findings
 
-    for lineno, line in enumerate(fm.splitlines(), start=2):  # +1 for opening ---
-        if _HASH_REF_IN_FLOW_SEQ.search(line):
-            findings.append(
-                f"{path}:{lineno}: unquoted #-ref in YAML flow sequence "
-                f"({line.strip()!r}); quote the refs: "
-                f'prs: ["#381", "#382"]'
-            )
+    # _frontmatter_block returns text starting at index 3 (right after the
+    # opening ``---``), which is typically the trailing ``\n`` of that line.
+    # Strip the leading newline so the first content line maps cleanly to
+    # file line 2 (file line 1 is the opening ``---``).
+    fm_body = fm.lstrip("\n")
+
+    for m in _HASH_REF_IN_FLOW_SEQ.finditer(fm_body):
+        # If the opener line is itself a YAML comment (``# note: [#381]``),
+        # the ``: [`` is inside a comment and the whole thing is benign.
+        # Find the start of the line containing the match opener and
+        # check the first non-whitespace char.
+        line_start = fm_body.rfind("\n", 0, m.start()) + 1
+        if fm_body[line_start:m.start()].lstrip().startswith("#"):
+            continue
+        # Line number within fm_body. +2 for the opening ``---`` line.
+        line_no = fm_body.count("\n", 0, m.start()) + 2
+        snippet = fm_body[m.start():m.end()].replace("\n", " ").strip()
+        findings.append(
+            f"{path}:{line_no}: unquoted #-ref in YAML flow sequence "
+            f"({snippet!r}); quote the refs: "
+            f'prs: ["#381", "#382"]'
+        )
 
     try:
         yaml.safe_load(fm)
@@ -106,14 +122,20 @@ def lint(paths: tuple[Path, ...], root: Path | None) -> None:
         targets = sorted(scan_root.rglob("*.md"))
 
     all_findings: list[str] = []
+    files_with_findings = 0
     for path in targets:
-        all_findings.extend(_lint_one(path))
+        per_file = _lint_one(path)
+        if per_file:
+            files_with_findings += 1
+            all_findings.extend(per_file)
 
     if all_findings:
         for f in all_findings:
             click.echo(f, err=True)
         click.echo(
-            f"\n{len(all_findings)} finding(s) in {len(targets)} file(s)", err=True,
+            f"\n{len(all_findings)} finding(s) in {files_with_findings} of "
+            f"{len(targets)} file(s)",
+            err=True,
         )
         sys.exit(1)
 

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1450,12 +1450,12 @@ def _discover_and_index_rdrs(
     indexed = sum(1 for s in results.values() if s == "indexed")
     skipped = sum(1 for s in results.values() if s == "skipped")
     failed = sum(1 for s in results.values() if s == "failed")
-    failed_paths = sorted(p for p, s in results.items() if s == "failed")
-    _log.info(
-        "RDR indexing complete",
-        indexed=indexed, current=skipped, failed=failed,
-        failed_paths=failed_paths,
-    )
+    log_kwargs: dict = {"indexed": indexed, "current": skipped, "failed": failed}
+    if failed:
+        log_kwargs["failed_paths"] = sorted(
+            p for p, s in results.items() if s == "failed"
+        )
+    _log.info("RDR indexing complete", **log_kwargs)
     return indexed, skipped, failed
 
 

--- a/src/nexus/md_chunker.py
+++ b/src/nexus/md_chunker.py
@@ -98,11 +98,25 @@ def parse_frontmatter(
 
     *source* is included in the warning log on parse failure so operators can
     locate the offending file (PyYAML's default ``<unicode string>`` is
-    useless when batch-indexing).
+    useless when batch-indexing). ``None`` (the default) logs
+    ``<unknown>``; pass ``""`` only if you genuinely want an empty
+    value rather than the sentinel.
 
-    *strict=True* re-raises ``yaml.YAMLError`` instead of swallowing it,
-    letting callers (e.g. the RDR post-pass) mark the file as failed and
-    skip rather than silently indexing the body without frontmatter.
+    *strict=True* re-raises ``yaml.YAMLError`` instead of swallowing it.
+
+    Caller policy
+    -------------
+    - **Authoritative content** (RDR documents) where missing frontmatter
+      means the index would carry empty metadata and search ranking would
+      degrade silently: pass ``strict=True``. The caller's existing
+      per-file ``except Exception`` (e.g. ``batch_index_markdowns``)
+      marks the file failed and skips it. Failure-mode rationale: the
+      indexer hang historically attributed to the YAML scanner was
+      avoided by *not reaching the embedding path with a broken-but-
+      partially-parsed file* — see nexus-qr9d.
+    - **Non-authoritative content** (prose, wiki, ad-hoc notes) where
+      indexing the body with empty metadata is preferable to dropping
+      the file: leave ``strict=False`` (the default).
     """
     if not text.startswith("---"):
         return {}, text
@@ -118,7 +132,7 @@ def parse_frontmatter(
     except yaml.YAMLError as exc:
         _log.warning(
             "frontmatter_parse_failed",
-            source=source or "<unknown>",
+            source=source if source is not None else "<unknown>",
             error=str(exc),
         )
         if strict:

--- a/src/nexus/registry.py
+++ b/src/nexus/registry.py
@@ -225,7 +225,14 @@ class RepoRegistry:
         with self._lock:
             self._data["repos"][key] = {
                 "name": name,
-                "collection": code_col,  # backward compat alias
+                # ``collection`` is a backward-compat alias for callers
+                # written before ``code_collection`` existed (e.g.
+                # indexer.py:1003,1893 still falls back to it). Read
+                # paths in the post-pass prefer ``code_collection`` and
+                # treat the alias as the legacy fallback only —
+                # nexus-cxg9. Don't remove the alias without auditing
+                # those call sites.
+                "collection": code_col,
                 "code_collection": code_col,
                 "docs_collection": docs_col,
                 "head_hash": "",

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -543,6 +543,45 @@ def test_collections_from_registry_info_dedupes() -> None:
     assert len(out) == len(set(out))
 
 
+def test_run_collection_postprocessing_does_not_pass_alias_through(monkeypatch):
+    """Review #757: prove the warning suppression end-to-end. The alias
+    must never reach ``_discover_taxonomy`` (which is where the
+    ``collection_not_found`` warning would fire). Patches
+    ``_discover_taxonomy`` to capture call args; asserts the legacy
+    non-conformant name never shows up."""
+    from unittest.mock import MagicMock
+    import nexus.commands.index as index_mod
+
+    captured: list[str] = []
+
+    def _capture(collection_name, taxonomy, chroma_client, *, force=False):
+        captured.append(collection_name)
+        return 0
+
+    monkeypatch.setattr(index_mod, "_discover_taxonomy", _capture)
+
+    fake_t3 = MagicMock()
+    fake_t3._client = MagicMock()
+    monkeypatch.setattr(index_mod, "make_t3", lambda: fake_t3, raising=False)
+    # make_t3 lives in nexus.db; patch at the import site used inside
+    # run_collection_postprocessing.
+    import nexus.db as _db_mod
+    monkeypatch.setattr(_db_mod, "make_t3", lambda: fake_t3)
+
+    info = {
+        "collection": "code__nexus-571b8edd",  # legacy non-conformant alias
+        "code_collection": "code__1-2188__voyage-code-3__v1",
+        "docs_collection": "docs__1-2188__voyage-context-3__v1",
+    }
+    collections = index_mod._collections_from_registry_info(info)
+    index_mod.run_collection_postprocessing(collections, repo_path=None, quiet=True)
+
+    assert "code__nexus-571b8edd" not in captured, (
+        "legacy non-conformant alias leaked to _discover_taxonomy — the "
+        "collection_not_found warning would fire on every post-pass"
+    )
+
+
 # ── GH #451: --corpus flag for nx index repo ────────────────────────────────
 
 

--- a/tests/test_md_chunker.py
+++ b/tests/test_md_chunker.py
@@ -63,6 +63,21 @@ def test_parse_frontmatter_strict_raises():
         parse_frontmatter(bad, source="x.md", strict=True)
 
 
+def test_parse_frontmatter_empty_source_is_distinct_from_none():
+    """Review #755 S-2: source="" must log as empty, not collapse to
+    the ``<unknown>`` sentinel that ``source=None`` uses."""
+    from structlog.testing import capture_logs
+
+    bad = "---\nprs: [#381]\n---\n\nBody\n"
+    with capture_logs() as cap:
+        parse_frontmatter(bad, source="")
+    fails = [e for e in cap if e["event"] == "frontmatter_parse_failed"]
+    assert len(fails) == 1
+    assert fails[0]["source"] == "", (
+        f"empty-string source must round-trip, got {fails[0]['source']!r}"
+    )
+
+
 # ── SemanticMarkdownChunker basics ───────────────────────────────────────────
 
 def test_chunk_empty_text_returns_empty(chunker):

--- a/tests/test_rdr_lint.py
+++ b/tests/test_rdr_lint.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from nexus.commands.rdr import lint, rdr
+from nexus.commands.rdr import rdr
+
+
+def _runner() -> CliRunner:
+    # Click 9+ separates stdout and stderr by default — ``result.stdout``
+    # and ``result.stderr`` are distinct streams. Findings go to stderr;
+    # the "clean" success line goes to stdout.
+    return CliRunner()
 
 
 def test_lint_flags_unquoted_hash_in_flow_sequence(tmp_path: Path):
@@ -13,10 +20,57 @@ def test_lint_flags_unquoted_hash_in_flow_sequence(tmp_path: Path):
         "---\nprs: [#381, #382, #383]\nstatus: post-mortem\n---\n\nBody\n",
         encoding="utf-8",
     )
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint", str(bad)])
+    result = _runner().invoke(rdr, ["lint", str(bad)])
     assert result.exit_code == 1
-    assert "unquoted #-ref in YAML flow sequence" in result.output
+    assert "unquoted #-ref in YAML flow sequence" in result.stderr
+
+
+def test_lint_reports_correct_line_number(tmp_path: Path):
+    """Review #756: the offender is on file line 2 (line 1 is ``---``);
+    the previous implementation reported line 3 because the leading ``\\n``
+    after the opening fence consumed an enumerate slot."""
+    bad = tmp_path / "bad.md"
+    bad.write_text(
+        "---\nprs: [#381, #382]\nstatus: x\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+    result = _runner().invoke(rdr, ["lint", str(bad)])
+    assert result.exit_code == 1
+    assert f"{bad}:2:" in result.stderr, (
+        f"expected offender at file line 2; stderr was:\n{result.stderr}"
+    )
+
+
+def test_lint_does_not_flag_yaml_comment_lines(tmp_path: Path):
+    """Review #756: ``# note: [#381]`` is a YAML comment, not the hazard.
+    The regex matches it, so the lint must skip lines whose first
+    non-whitespace char is ``#``."""
+    benign = tmp_path / "benign.md"
+    benign.write_text(
+        "---\n# note: [#381] is just a comment\ntitle: ok\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+    result = _runner().invoke(rdr, ["lint", str(benign)])
+    assert result.exit_code == 0, (
+        f"comment line falsely flagged; stderr was:\n{result.stderr}"
+    )
+
+
+def test_lint_catches_multiline_flow_sequence(tmp_path: Path):
+    """Review #756: multi-line flow sequences (``prs: [\\n  #381,\\n]``)
+    parse silently into empty lists in PyYAML — yaml.safe_load is not a
+    safety net for them. The regex must span lines so the hazard is
+    caught at the source."""
+    bad = tmp_path / "multiline.md"
+    bad.write_text(
+        "---\nprs: [\n  #381,\n  #382,\n]\nstatus: x\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+    result = _runner().invoke(rdr, ["lint", str(bad)])
+    assert result.exit_code == 1
+    assert "unquoted #-ref in YAML flow sequence" in result.stderr
+    # The opener `prs: [` is on file line 2.
+    assert f"{bad}:2:" in result.stderr
 
 
 def test_lint_passes_quoted_refs(tmp_path: Path):
@@ -25,10 +79,9 @@ def test_lint_passes_quoted_refs(tmp_path: Path):
         '---\nprs: ["#381", "#382"]\nstatus: accepted\n---\n\nBody\n',
         encoding="utf-8",
     )
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint", str(good)])
-    assert result.exit_code == 0, result.output
-    assert "clean" in result.output
+    result = _runner().invoke(rdr, ["lint", str(good)])
+    assert result.exit_code == 0, result.stderr
+    assert "clean" in result.stdout
 
 
 def test_lint_passes_block_form(tmp_path: Path):
@@ -37,17 +90,15 @@ def test_lint_passes_block_form(tmp_path: Path):
         '---\nprs:\n  - "#381"\n  - "#382"\nstatus: accepted\n---\n\nBody\n',
         encoding="utf-8",
     )
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint", str(good)])
-    assert result.exit_code == 0, result.output
+    result = _runner().invoke(rdr, ["lint", str(good)])
+    assert result.exit_code == 0, result.stderr
 
 
 def test_lint_passes_file_without_frontmatter(tmp_path: Path):
     plain = tmp_path / "plain.md"
     plain.write_text("# Just a heading\n\nNo frontmatter here.\n", encoding="utf-8")
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint", str(plain)])
-    assert result.exit_code == 0, result.output
+    result = _runner().invoke(rdr, ["lint", str(plain)])
+    assert result.exit_code == 0, result.stderr
 
 
 def test_lint_recurses_into_directory(tmp_path: Path):
@@ -59,15 +110,15 @@ def test_lint_recurses_into_directory(tmp_path: Path):
     (sub / "good.md").write_text(
         "---\ntitle: ok\n---\n", encoding="utf-8",
     )
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint", str(tmp_path)])
+    result = _runner().invoke(rdr, ["lint", str(tmp_path)])
     assert result.exit_code == 1
-    assert "bad.md" in result.output
-    assert "good.md" not in result.output
+    assert "bad.md" in result.stderr
+    assert "good.md" not in result.stderr
+    # Summary distinguishes files-with-findings from total scanned.
+    assert "1 of 2 file(s)" in result.stderr
 
 
 def test_lint_default_root_missing_exits_2(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint"])
+    result = _runner().invoke(rdr, ["lint"])
     assert result.exit_code == 2


### PR DESCRIPTION
Addresses review findings on PRs #755, #756, #757.

## #756 (u7ek) — `nx rdr lint`
- **Critical**: off-by-one in finding line numbers (frontmatter block leading `\n` consumed enumerate slot 2). Strip leading newline.
- **Important**: false positive on YAML comment lines (`# note: [#381]`). Skip matches whose opener is inside a `#`-prefixed line.
- **Important**: false negative on multi-line flow sequences (PyYAML silently parses `prs: [\n  #381,\n]` as `[]` — `yaml.safe_load` is NOT a safety net). Widen regex to span lines.
- Summary count now distinguishes files-with-findings from total.
- Tests: separate stdout/stderr; assert exact line number; cover comment-line + multi-line.

## #755 (qr9d) — `parse_frontmatter` strict mode
- Docstring states caller policy explicitly (RDR opts into `strict=True`; prose does not).
- `failed_paths` no longer logged when `failed == 0`.
- `source=""` no longer collapses to `<unknown>` sentinel.

## #757 (cxg9) — registry alias
- Document the alias's load-bearing fallback (`indexer.py:1003,1893`).
- Reviewer claimed `rdr_collection` was dead — actually written by RDR-103 Phase 4 supersede (`indexer.py:572`). Confirmed by inspecting the live registry. No code change needed.
- Integration test drives `run_collection_postprocessing` and asserts the legacy alias never reaches `_discover_taxonomy`.

## Test plan
- [x] `uv run pytest tests/test_md_chunker.py tests/test_md_preservation.py tests/test_silent_error_logging.py tests/test_doc_indexer.py tests/test_rdr_lint.py tests/test_collection_cmd.py` — 247 passed
- [x] `nx rdr lint` against live `docs/rdr/` — 156 files clean