### PR TITLE
chore: reconcile main → develop — qr9d/u7ek/cxg9 bead sweep

### DIFF
--- a/docs/rdr/AGENTS.md
+++ b/docs/rdr/AGENTS.md
@@ -39,3 +39,25 @@ If you need to find an RDR by topic, prefer the index in `docs/rdr/README.md` ov
 Use the lifecycle skills: `/nx:rdr-create` → `/nx:rdr-research` → `/nx:rdr-gate` → `/nx:rdr-accept` → `/nx:rdr-close`. List existing with `/nx:rdr-list`; show one with `/nx:rdr-show NNN`.
 
 The numbering is monotonic; pick the next unused integer. The frontmatter shape is enforced by `/nx:rdr-audit`.
+
+## Frontmatter quoting — `#` is comment-start in YAML
+
+When listing PR / issue / bead refs in YAML frontmatter, **always quote them.** YAML treats `#` as comment-start at any token-start position, so an unquoted flow sequence like `prs: [#381, #382]` silently parses as an empty list followed by a comment that eats the closing `]`. The scanner then runs off the end of the frontmatter and raises `ScannerError: while parsing a flow sequence … got '<stream end>'`. The indexer marks the RDR `failed` (since nexus-qr9d) and skips it; before that fix it hung.
+
+```yaml
+# ❌ broken — # makes the rest of the line a comment
+references:
+  prs: [#381, #382, #383]
+
+# ✅ flow form, quoted
+references:
+  prs: ["#381", "#382", "#383"]
+
+# ✅ block form, quoted
+references:
+  prs:
+    - "#381"
+    - "#382"
+```
+
+Run `nx rdr lint` before committing to catch this hazard.

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -51,6 +51,7 @@ from nexus.commands.index import index
 from nexus.commands.memory import memory
 from nexus.commands.mineru import mineru_group
 from nexus.commands.plan import plan as plan_group
+from nexus.commands.rdr import rdr as rdr_group
 from nexus.commands.scratch import scratch
 from nexus.commands.search_cmd import search_cmd
 from nexus.commands.store import store
@@ -99,6 +100,7 @@ main.add_command(index)
 main.add_command(memory)
 main.add_command(mineru_group, name="mineru")
 main.add_command(plan_group, name="plan")
+main.add_command(rdr_group, name="rdr")
 main.add_command(scratch)
 main.add_command(search_cmd, name="search")
 main.add_command(store)

--- a/src/nexus/commands/index.py
+++ b/src/nexus/commands/index.py
@@ -464,6 +464,17 @@ def _collections_from_registry_info(info: dict) -> list[str]:
     projection post-processing, filtered by
     ``taxonomy.local_exclude_collections``. Empty list when
     *info* is ``{}`` or carries no collection keys.
+
+    nexus-cxg9: prefer the conformant ``code_collection`` /
+    ``docs_collection`` / ``rdr_collection`` over the legacy
+    ``collection`` alias. The alias was kept in
+    ``RepoRegistry.add`` for backward compat (line 228) but for
+    repos registered before RDR-103 it still holds the
+    non-conformant ``code__<basename>-<hash8>`` shape (no
+    embedding_model / version segments), which does not exist in
+    T3 and emits ``collection_not_found`` every post-pass. Skipping
+    the alias when the conformant ``code_collection`` is present
+    silences the false warning without touching real data.
     """
     from fnmatch import fnmatch
 
@@ -474,11 +485,21 @@ def _collections_from_registry_info(info: dict) -> list[str]:
         cfg.get("taxonomy", {}).get("local_exclude_collections", [])
         if is_local_mode() else []
     )
+    code_col = info.get("code_collection") or info.get("collection")
+    candidates = [
+        code_col,
+        info.get("docs_collection"),
+        info.get("rdr_collection"),
+    ]
     collections: list[str] = []
-    for key in ("collection", "docs_collection"):
-        col = info.get(key)
-        if col and not any(fnmatch(col, pat) for pat in exclude_patterns):
-            collections.append(col)
+    seen: set[str] = set()
+    for col in candidates:
+        if not col or col in seen:
+            continue
+        if any(fnmatch(col, pat) for pat in exclude_patterns):
+            continue
+        seen.add(col)
+        collections.append(col)
     return collections
 
 

--- a/src/nexus/commands/rdr.py
+++ b/src/nexus/commands/rdr.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``nx rdr`` — RDR authoring helpers.
+
+Currently exposes a single subcommand, ``lint``, that scans RDR markdown
+files for frontmatter hazards that break downstream indexing. The first
+hazard it covers is ``nexus-u7ek``: YAML flow sequences containing
+unquoted ``#``-prefixed refs (``prs: [#381, #382]``) silently parse as an
+empty list + comment, scan past the closing ``]``, and run off the end
+of the frontmatter.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import click
+import yaml
+
+
+# Matches a flow-sequence opener followed by an unquoted ``#``-token.
+# ``\[`` opens the sequence; optional whitespace; then ``#`` directly
+# (i.e. *not* preceded by a quote). We rely on the regex being narrow
+# enough that legitimate ``#``-inside-a-quoted-string ("[\"#381\"]")
+# does not match.
+_HASH_REF_IN_FLOW_SEQ = re.compile(r":\s*\[\s*#")
+
+
+def _frontmatter_block(text: str) -> str | None:
+    """Return the frontmatter block (without delimiters) or None."""
+    if not text.startswith("---"):
+        return None
+    idx = text.find("\n---", 3)
+    if idx == -1:
+        return None
+    return text[3:idx]
+
+
+def _lint_one(path: Path) -> list[str]:
+    """Return a list of human-readable findings for *path* (empty if clean)."""
+    findings: list[str] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return [f"{path}: read failed ({type(exc).__name__}: {exc})"]
+
+    fm = _frontmatter_block(text)
+    if fm is None:
+        return findings
+
+    for lineno, line in enumerate(fm.splitlines(), start=2):  # +1 for opening ---
+        if _HASH_REF_IN_FLOW_SEQ.search(line):
+            findings.append(
+                f"{path}:{lineno}: unquoted #-ref in YAML flow sequence "
+                f"({line.strip()!r}); quote the refs: "
+                f'prs: ["#381", "#382"]'
+            )
+
+    try:
+        yaml.safe_load(fm)
+    except yaml.YAMLError as exc:
+        findings.append(f"{path}: frontmatter YAML parse error: {exc}")
+
+    return findings
+
+
+@click.group()
+def rdr() -> None:
+    """RDR authoring helpers."""
+
+
+@rdr.command("lint")
+@click.argument(
+    "paths",
+    nargs=-1,
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.option(
+    "--root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Scan this directory recursively for *.md (default: docs/rdr/ if it exists).",
+)
+def lint(paths: tuple[Path, ...], root: Path | None) -> None:
+    """Lint RDR frontmatter for parse hazards.
+
+    Checks each *.md for frontmatter that would fail downstream YAML
+    parsing — primarily the ``prs: [#NNN]`` flow-sequence hazard
+    (nexus-u7ek). Exits non-zero when any finding is reported.
+    """
+    targets: list[Path] = []
+    if paths:
+        for p in paths:
+            if p.is_dir():
+                targets.extend(sorted(p.rglob("*.md")))
+            else:
+                targets.append(p)
+    else:
+        scan_root = root or Path("docs/rdr")
+        if not scan_root.exists():
+            click.echo(
+                f"no paths given and {scan_root} not found; nothing to lint",
+                err=True,
+            )
+            sys.exit(2)
+        targets = sorted(scan_root.rglob("*.md"))
+
+    all_findings: list[str] = []
+    for path in targets:
+        all_findings.extend(_lint_one(path))
+
+    if all_findings:
+        for f in all_findings:
+            click.echo(f, err=True)
+        click.echo(
+            f"\n{len(all_findings)} finding(s) in {len(targets)} file(s)", err=True,
+        )
+        sys.exit(1)
+
+    click.echo(f"clean: {len(targets)} file(s) scanned")

--- a/src/nexus/commands/rdr.py
+++ b/src/nexus/commands/rdr.py
@@ -18,12 +18,13 @@ import click
 import yaml
 
 
-# Matches a flow-sequence opener followed by an unquoted ``#``-token.
-# ``\[`` opens the sequence; optional whitespace; then ``#`` directly
-# (i.e. *not* preceded by a quote). We rely on the regex being narrow
-# enough that legitimate ``#``-inside-a-quoted-string ("[\"#381\"]")
-# does not match.
-_HASH_REF_IN_FLOW_SEQ = re.compile(r":\s*\[\s*#")
+# Matches a flow-sequence opener followed (eventually) by an unquoted
+# ``#`` before the closing ``]``. ``[^\]"']*?`` lets us span multiple
+# lines (PyYAML's multi-line flow sequences parse silently into empty
+# lists when ``#`` introduces comments mid-sequence — a true false
+# negative for the single-line regex). The ``"'`` exclusion keeps quoted
+# strings from being mis-flagged as the hazard.
+_HASH_REF_IN_FLOW_SEQ = re.compile(r":\s*\[[^\]\"']*?#", re.DOTALL)
 
 
 def _frontmatter_block(text: str) -> str | None:
@@ -48,13 +49,28 @@ def _lint_one(path: Path) -> list[str]:
     if fm is None:
         return findings
 
-    for lineno, line in enumerate(fm.splitlines(), start=2):  # +1 for opening ---
-        if _HASH_REF_IN_FLOW_SEQ.search(line):
-            findings.append(
-                f"{path}:{lineno}: unquoted #-ref in YAML flow sequence "
-                f"({line.strip()!r}); quote the refs: "
-                f'prs: ["#381", "#382"]'
-            )
+    # _frontmatter_block returns text starting at index 3 (right after the
+    # opening ``---``), which is typically the trailing ``\n`` of that line.
+    # Strip the leading newline so the first content line maps cleanly to
+    # file line 2 (file line 1 is the opening ``---``).
+    fm_body = fm.lstrip("\n")
+
+    for m in _HASH_REF_IN_FLOW_SEQ.finditer(fm_body):
+        # If the opener line is itself a YAML comment (``# note: [#381]``),
+        # the ``: [`` is inside a comment and the whole thing is benign.
+        # Find the start of the line containing the match opener and
+        # check the first non-whitespace char.
+        line_start = fm_body.rfind("\n", 0, m.start()) + 1
+        if fm_body[line_start:m.start()].lstrip().startswith("#"):
+            continue
+        # Line number within fm_body. +2 for the opening ``---`` line.
+        line_no = fm_body.count("\n", 0, m.start()) + 2
+        snippet = fm_body[m.start():m.end()].replace("\n", " ").strip()
+        findings.append(
+            f"{path}:{line_no}: unquoted #-ref in YAML flow sequence "
+            f"({snippet!r}); quote the refs: "
+            f'prs: ["#381", "#382"]'
+        )
 
     try:
         yaml.safe_load(fm)
@@ -106,14 +122,20 @@ def lint(paths: tuple[Path, ...], root: Path | None) -> None:
         targets = sorted(scan_root.rglob("*.md"))
 
     all_findings: list[str] = []
+    files_with_findings = 0
     for path in targets:
-        all_findings.extend(_lint_one(path))
+        per_file = _lint_one(path)
+        if per_file:
+            files_with_findings += 1
+            all_findings.extend(per_file)
 
     if all_findings:
         for f in all_findings:
             click.echo(f, err=True)
         click.echo(
-            f"\n{len(all_findings)} finding(s) in {len(targets)} file(s)", err=True,
+            f"\n{len(all_findings)} finding(s) in {files_with_findings} of "
+            f"{len(targets)} file(s)",
+            err=True,
         )
         sys.exit(1)
 

--- a/src/nexus/doc_indexer.py
+++ b/src/nexus/doc_indexer.py
@@ -1034,7 +1034,7 @@ def _markdown_chunks(
         git_meta = detect_git_metadata(md_path)
 
     raw_text = md_path.read_text(encoding="utf-8")
-    frontmatter, body = parse_frontmatter(raw_text)
+    frontmatter, body = parse_frontmatter(raw_text, source=str(md_path), strict=True)
     frontmatter_len = len(raw_text) - len(body)
 
     # RDR-102 D2: source_path is no longer carried at any layer of the

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1450,12 +1450,12 @@ def _discover_and_index_rdrs(
     indexed = sum(1 for s in results.values() if s == "indexed")
     skipped = sum(1 for s in results.values() if s == "skipped")
     failed = sum(1 for s in results.values() if s == "failed")
-    failed_paths = sorted(p for p, s in results.items() if s == "failed")
-    _log.info(
-        "RDR indexing complete",
-        indexed=indexed, current=skipped, failed=failed,
-        failed_paths=failed_paths,
-    )
+    log_kwargs: dict = {"indexed": indexed, "current": skipped, "failed": failed}
+    if failed:
+        log_kwargs["failed_paths"] = sorted(
+            p for p, s in results.items() if s == "failed"
+        )
+    _log.info("RDR indexing complete", **log_kwargs)
     return indexed, skipped, failed
 
 

--- a/src/nexus/indexer.py
+++ b/src/nexus/indexer.py
@@ -1450,7 +1450,12 @@ def _discover_and_index_rdrs(
     indexed = sum(1 for s in results.values() if s == "indexed")
     skipped = sum(1 for s in results.values() if s == "skipped")
     failed = sum(1 for s in results.values() if s == "failed")
-    _log.info("RDR indexing complete", indexed=indexed, current=skipped, failed=failed)
+    failed_paths = sorted(p for p, s in results.items() if s == "failed")
+    _log.info(
+        "RDR indexing complete",
+        indexed=indexed, current=skipped, failed=failed,
+        failed_paths=failed_paths,
+    )
     return indexed, skipped, failed
 
 

--- a/src/nexus/md_chunker.py
+++ b/src/nexus/md_chunker.py
@@ -85,11 +85,24 @@ class MarkdownChunk:
     header_path: list[str]
 
 
-def parse_frontmatter(text: str) -> tuple[dict, str]:
+def parse_frontmatter(
+    text: str,
+    *,
+    source: str | None = None,
+    strict: bool = False,
+) -> tuple[dict, str]:
     """Extract YAML frontmatter from *text*.
 
     Returns ``(metadata_dict, body)`` where *body* has the frontmatter block
     stripped.  Returns ``({}, text)`` when no frontmatter is detected.
+
+    *source* is included in the warning log on parse failure so operators can
+    locate the offending file (PyYAML's default ``<unicode string>`` is
+    useless when batch-indexing).
+
+    *strict=True* re-raises ``yaml.YAMLError`` instead of swallowing it,
+    letting callers (e.g. the RDR post-pass) mark the file as failed and
+    skip rather than silently indexing the body without frontmatter.
     """
     if not text.startswith("---"):
         return {}, text
@@ -103,7 +116,13 @@ def parse_frontmatter(text: str) -> tuple[dict, str]:
         if not isinstance(data, dict):
             data = {}
     except yaml.YAMLError as exc:
-        _log.warning("frontmatter_parse_failed", error=str(exc))
+        _log.warning(
+            "frontmatter_parse_failed",
+            source=source or "<unknown>",
+            error=str(exc),
+        )
+        if strict:
+            raise
         data = {}
     return data, rest
 

--- a/src/nexus/md_chunker.py
+++ b/src/nexus/md_chunker.py
@@ -98,11 +98,25 @@ def parse_frontmatter(
 
     *source* is included in the warning log on parse failure so operators can
     locate the offending file (PyYAML's default ``<unicode string>`` is
-    useless when batch-indexing).
+    useless when batch-indexing). ``None`` (the default) logs
+    ``<unknown>``; pass ``""`` only if you genuinely want an empty
+    value rather than the sentinel.
 
-    *strict=True* re-raises ``yaml.YAMLError`` instead of swallowing it,
-    letting callers (e.g. the RDR post-pass) mark the file as failed and
-    skip rather than silently indexing the body without frontmatter.
+    *strict=True* re-raises ``yaml.YAMLError`` instead of swallowing it.
+
+    Caller policy
+    -------------
+    - **Authoritative content** (RDR documents) where missing frontmatter
+      means the index would carry empty metadata and search ranking would
+      degrade silently: pass ``strict=True``. The caller's existing
+      per-file ``except Exception`` (e.g. ``batch_index_markdowns``)
+      marks the file failed and skips it. Failure-mode rationale: the
+      indexer hang historically attributed to the YAML scanner was
+      avoided by *not reaching the embedding path with a broken-but-
+      partially-parsed file* — see nexus-qr9d.
+    - **Non-authoritative content** (prose, wiki, ad-hoc notes) where
+      indexing the body with empty metadata is preferable to dropping
+      the file: leave ``strict=False`` (the default).
     """
     if not text.startswith("---"):
         return {}, text
@@ -118,7 +132,7 @@ def parse_frontmatter(
     except yaml.YAMLError as exc:
         _log.warning(
             "frontmatter_parse_failed",
-            source=source or "<unknown>",
+            source=source if source is not None else "<unknown>",
             error=str(exc),
         )
         if strict:

--- a/src/nexus/prose_indexer.py
+++ b/src/nexus/prose_indexer.py
@@ -76,7 +76,7 @@ def index_prose_file(ctx: IndexContext, file_path: Path) -> int:
     if ext in (".md", ".markdown"):
         # Markdown: use SemanticMarkdownChunker (M1: uses char offsets, not line numbers)
         with _stage("chunking"):
-            frontmatter, body = parse_frontmatter(content)
+            frontmatter, body = parse_frontmatter(content, source=str(file_path))
             frontmatter_len = len(content) - len(body)
             base_meta: dict = {"source_path": str(file_path), "corpus": ctx.corpus}
             chunks = SemanticMarkdownChunker().chunk(body, base_meta)

--- a/src/nexus/registry.py
+++ b/src/nexus/registry.py
@@ -225,7 +225,14 @@ class RepoRegistry:
         with self._lock:
             self._data["repos"][key] = {
                 "name": name,
-                "collection": code_col,  # backward compat alias
+                # ``collection`` is a backward-compat alias for callers
+                # written before ``code_collection`` existed (e.g.
+                # indexer.py:1003,1893 still falls back to it). Read
+                # paths in the post-pass prefer ``code_collection`` and
+                # treat the alias as the legacy fallback only —
+                # nexus-cxg9. Don't remove the alias without auditing
+                # those call sites.
+                "collection": code_col,
                 "code_collection": code_col,
                 "docs_collection": docs_col,
                 "head_hash": "",

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -543,6 +543,45 @@ def test_collections_from_registry_info_dedupes() -> None:
     assert len(out) == len(set(out))
 
 
+def test_run_collection_postprocessing_does_not_pass_alias_through(monkeypatch):
+    """Review #757: prove the warning suppression end-to-end. The alias
+    must never reach ``_discover_taxonomy`` (which is where the
+    ``collection_not_found`` warning would fire). Patches
+    ``_discover_taxonomy`` to capture call args; asserts the legacy
+    non-conformant name never shows up."""
+    from unittest.mock import MagicMock
+    import nexus.commands.index as index_mod
+
+    captured: list[str] = []
+
+    def _capture(collection_name, taxonomy, chroma_client, *, force=False):
+        captured.append(collection_name)
+        return 0
+
+    monkeypatch.setattr(index_mod, "_discover_taxonomy", _capture)
+
+    fake_t3 = MagicMock()
+    fake_t3._client = MagicMock()
+    monkeypatch.setattr(index_mod, "make_t3", lambda: fake_t3, raising=False)
+    # make_t3 lives in nexus.db; patch at the import site used inside
+    # run_collection_postprocessing.
+    import nexus.db as _db_mod
+    monkeypatch.setattr(_db_mod, "make_t3", lambda: fake_t3)
+
+    info = {
+        "collection": "code__nexus-571b8edd",  # legacy non-conformant alias
+        "code_collection": "code__1-2188__voyage-code-3__v1",
+        "docs_collection": "docs__1-2188__voyage-context-3__v1",
+    }
+    collections = index_mod._collections_from_registry_info(info)
+    index_mod.run_collection_postprocessing(collections, repo_path=None, quiet=True)
+
+    assert "code__nexus-571b8edd" not in captured, (
+        "legacy non-conformant alias leaked to _discover_taxonomy — the "
+        "collection_not_found warning would fire on every post-pass"
+    )
+
+
 # ── GH #451: --corpus flag for nx index repo ────────────────────────────────
 
 

--- a/tests/test_collection_cmd.py
+++ b/tests/test_collection_cmd.py
@@ -505,6 +505,44 @@ def test_collections_from_registry_info_filters_excluded() -> None:
     assert "docs__myrepo__voyage-context-3__v1" in out
 
 
+def test_collections_from_registry_info_prefers_conformant_code_collection() -> None:
+    """nexus-cxg9: pre-RDR-103 entries keep the legacy non-conformant
+    ``collection`` alias even after the conformant ``code_collection``
+    is set. The post-pass must enumerate the conformant name only —
+    enumerating the alias triggers ``collection_not_found`` every run.
+    """
+    from nexus.commands.index import _collections_from_registry_info
+
+    info = {
+        "collection": "code__nexus-571b8edd",  # legacy alias, no T3 collection
+        "code_collection": "code__1-2188__voyage-code-3__v1",
+        "docs_collection": "docs__1-2188__voyage-context-3__v1",
+        "rdr_collection": "rdr__1-2188__voyage-context-3__v1",
+    }
+    out = _collections_from_registry_info(info)
+    assert "code__nexus-571b8edd" not in out, (
+        "legacy non-conformant alias must not be enumerated when a "
+        "conformant code_collection is present"
+    )
+    # Cloud-mode passthrough: rdr/docs always; code__ filtered in local mode only.
+    assert "docs__1-2188__voyage-context-3__v1" in out
+    assert "rdr__1-2188__voyage-context-3__v1" in out
+
+
+def test_collections_from_registry_info_dedupes() -> None:
+    """nexus-cxg9: when the legacy ``collection`` field happens to equal
+    ``code_collection`` (post-RDR-103 fresh registrations), the result
+    must not contain duplicates.
+    """
+    from nexus.commands.index import _collections_from_registry_info
+
+    name = "code__myrepo__voyage-code-3__v1"
+    info = {"collection": name, "code_collection": name,
+            "docs_collection": "docs__myrepo__voyage-context-3__v1"}
+    out = _collections_from_registry_info(info)
+    assert len(out) == len(set(out))
+
+
 # ── GH #451: --corpus flag for nx index repo ────────────────────────────────
 
 

--- a/tests/test_doc_indexer.py
+++ b/tests/test_doc_indexer.py
@@ -224,6 +224,54 @@ def test_identity_where_falls_back_when_corpus_owner_missing(tmp_path, monkeypat
     assert where == {"source_path": "/abs/path/x.pdf"}
 
 
+def test_batch_index_markdowns_skips_malformed_frontmatter_and_continues(
+    tmp_path, monkeypatch,
+):
+    """nexus-qr9d: malformed YAML frontmatter on one file must not abort
+    the batch or hang the post-pass. The offending file is marked
+    ``failed`` with its path; sibling files complete normally; the whole
+    call returns within a wall-clock bound."""
+    import chromadb
+    from nexus.catalog import reset_cache
+    from nexus.catalog.catalog import Catalog
+    from nexus.db.t3 import T3Database
+
+    cat_dir = tmp_path / "test-catalog"
+    Catalog.init(cat_dir)
+    reset_cache()
+    monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+    monkeypatch.delenv("CHROMA_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "nexus.config._global_config_path", lambda: Path("/nonexistent"),
+    )
+
+    good = tmp_path / "good.md"
+    good.write_text(
+        "---\ntitle: Good\n---\n\n# Good\n\nContent here.\n",
+        encoding="utf-8",
+    )
+    # YAML flow sequence with unquoted #-refs — the exact hazard from the bead.
+    bad = tmp_path / "bad.md"
+    bad.write_text(
+        "---\nprs: [#381, #382]\nstatus: post-mortem\n---\n\n# Body\n\nText.\n",
+        encoding="utf-8",
+    )
+
+    client = chromadb.EphemeralClient()
+    t3 = T3Database(_client=client, local_mode=True)
+
+    t0 = time.monotonic()
+    results = batch_index_markdowns(
+        [bad, good], corpus="qr9d-test", t3=t3,
+        collection_name=f"rdr__qr9d-test__{_local_token()}__v1",
+        content_type="rdr",
+    )
+    elapsed = time.monotonic() - t0
+    assert elapsed < 30.0, f"batch hung or far too slow ({elapsed:.1f}s)"
+    assert results[str(bad)] == "failed"
+    assert results[str(good)] == "indexed"
+
+
 def test_index_md_falls_back_to_local_embedder_when_no_credentials(
     sample_md, tmp_path, monkeypatch,
 ):

--- a/tests/test_md_chunker.py
+++ b/tests/test_md_chunker.py
@@ -39,6 +39,30 @@ def test_parse_frontmatter_strips_delimiters():
     assert "---" not in rest
 
 
+def test_parse_frontmatter_warning_includes_source_path(caplog):
+    """nexus-qr9d: PyYAML's <unicode string> default is useless when batch-indexing;
+    the warning must surface the file path so operators can locate the offender."""
+    import structlog
+    from structlog.testing import capture_logs
+
+    bad = "---\nprs: [#381, #382]\nstatus: x\n---\n\nBody\n"
+    with capture_logs() as cap:
+        fm, _ = parse_frontmatter(bad, source="/path/to/rdr-bad.md")
+    assert fm == {}
+    fails = [e for e in cap if e["event"] == "frontmatter_parse_failed"]
+    assert len(fails) == 1
+    assert fails[0]["source"] == "/path/to/rdr-bad.md"
+
+
+def test_parse_frontmatter_strict_raises():
+    """nexus-qr9d: strict mode lets RDR pipeline mark file as failed and skip,
+    rather than silently indexing the body without frontmatter."""
+    import yaml as _yaml
+    bad = "---\nprs: [#381, #382]\nstatus: x\n---\n\nBody\n"
+    with pytest.raises(_yaml.YAMLError):
+        parse_frontmatter(bad, source="x.md", strict=True)
+
+
 # ── SemanticMarkdownChunker basics ───────────────────────────────────────────
 
 def test_chunk_empty_text_returns_empty(chunker):

--- a/tests/test_md_chunker.py
+++ b/tests/test_md_chunker.py
@@ -63,6 +63,21 @@ def test_parse_frontmatter_strict_raises():
         parse_frontmatter(bad, source="x.md", strict=True)
 
 
+def test_parse_frontmatter_empty_source_is_distinct_from_none():
+    """Review #755 S-2: source="" must log as empty, not collapse to
+    the ``<unknown>`` sentinel that ``source=None`` uses."""
+    from structlog.testing import capture_logs
+
+    bad = "---\nprs: [#381]\n---\n\nBody\n"
+    with capture_logs() as cap:
+        parse_frontmatter(bad, source="")
+    fails = [e for e in cap if e["event"] == "frontmatter_parse_failed"]
+    assert len(fails) == 1
+    assert fails[0]["source"] == "", (
+        f"empty-string source must round-trip, got {fails[0]['source']!r}"
+    )
+
+
 # ── SemanticMarkdownChunker basics ───────────────────────────────────────────
 
 def test_chunk_empty_text_returns_empty(chunker):

--- a/tests/test_rdr_lint.py
+++ b/tests/test_rdr_lint.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from nexus.commands.rdr import lint, rdr
+from nexus.commands.rdr import rdr
+
+
+def _runner() -> CliRunner:
+    # Click 9+ separates stdout and stderr by default — ``result.stdout``
+    # and ``result.stderr`` are distinct streams. Findings go to stderr;
+    # the "clean" success line goes to stdout.
+    return CliRunner()
 
 
 def test_lint_flags_unquoted_hash_in_flow_sequence(tmp_path: Path):
@@ -13,10 +20,57 @@ def test_lint_flags_unquoted_hash_in_flow_sequence(tmp_path: Path):
         "---\nprs: [#381, #382, #383]\nstatus: post-mortem\n---\n\nBody\n",
         encoding="utf-8",
     )
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint", str(bad)])
+    result = _runner().invoke(rdr, ["lint", str(bad)])
     assert result.exit_code == 1
-    assert "unquoted #-ref in YAML flow sequence" in result.output
+    assert "unquoted #-ref in YAML flow sequence" in result.stderr
+
+
+def test_lint_reports_correct_line_number(tmp_path: Path):
+    """Review #756: the offender is on file line 2 (line 1 is ``---``);
+    the previous implementation reported line 3 because the leading ``\\n``
+    after the opening fence consumed an enumerate slot."""
+    bad = tmp_path / "bad.md"
+    bad.write_text(
+        "---\nprs: [#381, #382]\nstatus: x\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+    result = _runner().invoke(rdr, ["lint", str(bad)])
+    assert result.exit_code == 1
+    assert f"{bad}:2:" in result.stderr, (
+        f"expected offender at file line 2; stderr was:\n{result.stderr}"
+    )
+
+
+def test_lint_does_not_flag_yaml_comment_lines(tmp_path: Path):
+    """Review #756: ``# note: [#381]`` is a YAML comment, not the hazard.
+    The regex matches it, so the lint must skip lines whose first
+    non-whitespace char is ``#``."""
+    benign = tmp_path / "benign.md"
+    benign.write_text(
+        "---\n# note: [#381] is just a comment\ntitle: ok\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+    result = _runner().invoke(rdr, ["lint", str(benign)])
+    assert result.exit_code == 0, (
+        f"comment line falsely flagged; stderr was:\n{result.stderr}"
+    )
+
+
+def test_lint_catches_multiline_flow_sequence(tmp_path: Path):
+    """Review #756: multi-line flow sequences (``prs: [\\n  #381,\\n]``)
+    parse silently into empty lists in PyYAML — yaml.safe_load is not a
+    safety net for them. The regex must span lines so the hazard is
+    caught at the source."""
+    bad = tmp_path / "multiline.md"
+    bad.write_text(
+        "---\nprs: [\n  #381,\n  #382,\n]\nstatus: x\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+    result = _runner().invoke(rdr, ["lint", str(bad)])
+    assert result.exit_code == 1
+    assert "unquoted #-ref in YAML flow sequence" in result.stderr
+    # The opener `prs: [` is on file line 2.
+    assert f"{bad}:2:" in result.stderr
 
 
 def test_lint_passes_quoted_refs(tmp_path: Path):
@@ -25,10 +79,9 @@ def test_lint_passes_quoted_refs(tmp_path: Path):
         '---\nprs: ["#381", "#382"]\nstatus: accepted\n---\n\nBody\n',
         encoding="utf-8",
     )
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint", str(good)])
-    assert result.exit_code == 0, result.output
-    assert "clean" in result.output
+    result = _runner().invoke(rdr, ["lint", str(good)])
+    assert result.exit_code == 0, result.stderr
+    assert "clean" in result.stdout
 
 
 def test_lint_passes_block_form(tmp_path: Path):
@@ -37,17 +90,15 @@ def test_lint_passes_block_form(tmp_path: Path):
         '---\nprs:\n  - "#381"\n  - "#382"\nstatus: accepted\n---\n\nBody\n',
         encoding="utf-8",
     )
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint", str(good)])
-    assert result.exit_code == 0, result.output
+    result = _runner().invoke(rdr, ["lint", str(good)])
+    assert result.exit_code == 0, result.stderr
 
 
 def test_lint_passes_file_without_frontmatter(tmp_path: Path):
     plain = tmp_path / "plain.md"
     plain.write_text("# Just a heading\n\nNo frontmatter here.\n", encoding="utf-8")
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint", str(plain)])
-    assert result.exit_code == 0, result.output
+    result = _runner().invoke(rdr, ["lint", str(plain)])
+    assert result.exit_code == 0, result.stderr
 
 
 def test_lint_recurses_into_directory(tmp_path: Path):
@@ -59,15 +110,15 @@ def test_lint_recurses_into_directory(tmp_path: Path):
     (sub / "good.md").write_text(
         "---\ntitle: ok\n---\n", encoding="utf-8",
     )
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint", str(tmp_path)])
+    result = _runner().invoke(rdr, ["lint", str(tmp_path)])
     assert result.exit_code == 1
-    assert "bad.md" in result.output
-    assert "good.md" not in result.output
+    assert "bad.md" in result.stderr
+    assert "good.md" not in result.stderr
+    # Summary distinguishes files-with-findings from total scanned.
+    assert "1 of 2 file(s)" in result.stderr
 
 
 def test_lint_default_root_missing_exits_2(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    runner = CliRunner()
-    result = runner.invoke(rdr, ["lint"])
+    result = _runner().invoke(rdr, ["lint"])
     assert result.exit_code == 2

--- a/tests/test_rdr_lint.py
+++ b/tests/test_rdr_lint.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""nexus-u7ek: lint catches the YAML #-flow-sequence hazard."""
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from nexus.commands.rdr import lint, rdr
+
+
+def test_lint_flags_unquoted_hash_in_flow_sequence(tmp_path: Path):
+    bad = tmp_path / "bad.md"
+    bad.write_text(
+        "---\nprs: [#381, #382, #383]\nstatus: post-mortem\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint", str(bad)])
+    assert result.exit_code == 1
+    assert "unquoted #-ref in YAML flow sequence" in result.output
+
+
+def test_lint_passes_quoted_refs(tmp_path: Path):
+    good = tmp_path / "good.md"
+    good.write_text(
+        '---\nprs: ["#381", "#382"]\nstatus: accepted\n---\n\nBody\n',
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint", str(good)])
+    assert result.exit_code == 0, result.output
+    assert "clean" in result.output
+
+
+def test_lint_passes_block_form(tmp_path: Path):
+    good = tmp_path / "good.md"
+    good.write_text(
+        '---\nprs:\n  - "#381"\n  - "#382"\nstatus: accepted\n---\n\nBody\n',
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint", str(good)])
+    assert result.exit_code == 0, result.output
+
+
+def test_lint_passes_file_without_frontmatter(tmp_path: Path):
+    plain = tmp_path / "plain.md"
+    plain.write_text("# Just a heading\n\nNo frontmatter here.\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint", str(plain)])
+    assert result.exit_code == 0, result.output
+
+
+def test_lint_recurses_into_directory(tmp_path: Path):
+    sub = tmp_path / "post-mortem"
+    sub.mkdir()
+    (sub / "bad.md").write_text(
+        "---\nprs: [#1, #2]\n---\n", encoding="utf-8",
+    )
+    (sub / "good.md").write_text(
+        "---\ntitle: ok\n---\n", encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "bad.md" in result.output
+    assert "good.md" not in result.output
+
+
+def test_lint_default_root_missing_exits_2(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(rdr, ["lint"])
+    assert result.exit_code == 2


### PR DESCRIPTION
## Summary
Reconciles four commits that landed on \`main\` instead of \`develop\` (process error — see AGENTS.md "PRs target develop" hot rule, codified in #739).

- #755 nexus-qr9d — graceful degradation on malformed RDR frontmatter
- #756 nexus-u7ek — \`nx rdr lint\` + quoting convention
- #757 nexus-cxg9 — prefer conformant code_collection over legacy alias
- #758 — review remediation across all three (off-by-one, comment-line FP, multi-line FN, alias documentation)

## Process note
These four should have been one batched PR per the "one PR per logical unit" rule. Memory saved (\`feedback_develop_is_integration_branch.md\`) so the next session catches it before push.

## Test plan
- [x] All four PRs were green on main before this reconcile.
- CI re-runs on develop will validate the merged state.