### PR TITLE
feat(tuplespace): Chroma collection layout per template (RDR-110 P1.3)

### DIFF
--- a/src/nexus/tuplespace/__init__.py
+++ b/src/nexus/tuplespace/__init__.py
@@ -1,14 +1,16 @@
 """nexus.tuplespace — semantic tuple-space primitives (RDR-110).
 
 Phase 1 lands the substrate: the subspace registry (this module's
-``registry``), the SQLite schema, the core MCP tools, and a direct-mode
-watcher. Daemon-mode integration ships in RDR-112 follow-up beads.
+``registry``), the Chroma collection layout (``index``), the SQLite schema,
+the core MCP tools, and a direct-mode watcher. Daemon-mode integration ships
+in RDR-112 follow-up beads.
 
-This package is intentionally substrate-only — no SQLite, no HTTP, no
-embedder. The registry validates YAML schemas; downstream beads supply
-the storage and the network plane.
+This package is intentionally substrate-only — no daemon HTTP, no
+embedder wiring. The registry validates YAML schemas; index.py wraps
+ChromaDB; downstream beads supply the full storage and network plane.
 """
 
+from nexus.tuplespace.index import TupleIndex, collection_name
 from nexus.tuplespace.registry import (
     Registry,
     RegistryLoadError,
@@ -21,6 +23,8 @@ __all__ = [
     "Registry",
     "RegistryLoadError",
     "SubspaceSchema",
+    "TupleIndex",
     "UnknownSubspaceError",
+    "collection_name",
     "default_builtin_dir",
 ]

--- a/src/nexus/tuplespace/index.py
+++ b/src/nexus/tuplespace/index.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Chroma collection layout for the semantic tuple space (RDR-110 P1.3).
+
+Project-tier storage: one persistent local ChromaDB collection per registered
+template, named ``tuples__<template_slug>``.  The slug strips ``<`` and ``>``
+from parameterised segments and replaces ``/`` with ``_`` so that collection
+names are valid ChromaDB identifiers (no colons; ``__`` separator is the
+project convention from CLAUDE.md).
+
+**Client choice**: production code passes a ``chromadb.PersistentClient``
+pointed at the project data directory (``~/.config/nexus/``).  Tests inject
+a ``chromadb.EphemeralClient`` so no filesystem side-effects occur.  The
+``TupleIndex`` class accepts any ``chromadb.ClientAPI``-compatible object
+(constructor injection; no singletons).
+
+**Embedding**: collections are created without an explicit embedding function,
+so ChromaDB uses its bundled all-MiniLM-L6-v2 embedder when documents are
+passed.  Explicit embedding-function injection is deferred to P1.4/Phase 2.
+
+**API consumers (P1.4 api.py) do not touch ChromaDB directly** — they call
+``out()`` and ``read()`` on this class only.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import structlog
+
+from nexus.db.chroma_quotas import QUOTAS, QuotaValidator
+
+_log = structlog.get_logger(__name__)
+
+# Matches < and > individually so both brackets are removed.
+_ANGLE_RE = re.compile(r"[<>]")
+
+_VALIDATOR = QuotaValidator(QUOTAS)
+
+
+def _template_slug(name: str) -> str:
+    """Convert a template name to a ChromaDB-safe slug.
+
+    Strips ``<`` and ``>`` from parameterised segments, then replaces
+    ``/`` with ``_``.  Examples::
+
+        "tasks/<project>"  -> "tasks_project"
+        "locks/<resource>" -> "locks_resource"
+        "plans"            -> "plans"
+        "a/<b>/c/<d>"      -> "a_b_c_d"
+    """
+    return _ANGLE_RE.sub("", name).replace("/", "_")
+
+
+def collection_name(template_name: str) -> str:
+    """Return the ChromaDB collection name for *template_name*.
+
+    Format: ``tuples__<slug>`` where slug is produced by
+    :func:`_template_slug`.
+
+    Examples::
+
+        collection_name("tasks/<project>") == "tuples__tasks_project"
+        collection_name("plans")           == "tuples__plans"
+    """
+    return f"tuples__{_template_slug(template_name)}"
+
+
+class TupleIndex:
+    """Thin ChromaDB wrapper for tuple-space per-template collections.
+
+    One collection per registered template; created at instantiation via
+    ``get_or_create_collection`` (idempotent).  The collection stores tuple
+    documents with metadata containing ``subspace`` plus the validated
+    dimensions declared in the template's YAML schema.
+
+    Args:
+        collections: Mapping from template name to ChromaDB collection.
+    """
+
+    def __init__(
+        self,
+        collections: dict[str, Any],  # dict[str, chromadb.Collection]
+    ) -> None:
+        self._collections = collections
+
+    @classmethod
+    def from_registry(cls, registry: Any, client: Any) -> "TupleIndex":
+        """Create a ``TupleIndex`` from a loaded :class:`Registry`.
+
+        Iterates ``registry.schemas()`` and calls
+        ``client.get_or_create_collection`` for each template, using
+        :func:`collection_name` to derive the name.  Safe to call multiple
+        times on the same client (idempotent).
+
+        Args:
+            registry: A :class:`nexus.tuplespace.registry.Registry` instance.
+            client: Any ``chromadb.ClientAPI``-compatible object
+                (``PersistentClient`` in production, ``EphemeralClient`` in
+                tests).
+
+        Returns:
+            A fully initialised ``TupleIndex``.
+        """
+        collections: dict[str, Any] = {}
+        for schema in registry.schemas():
+            coll_name = collection_name(schema.name)
+            coll = client.get_or_create_collection(coll_name)
+            collections[schema.name] = coll
+            _log.debug(
+                "tuplespace_collection_ready",
+                template=schema.name,
+                collection=coll_name,
+            )
+        _log.info(
+            "tuplespace_index_created",
+            count=len(collections),
+        )
+        return cls(collections)
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    def out(
+        self,
+        *,
+        template_name: str,
+        subspace: str,
+        tuple_id: str,
+        payload: str,
+        metadata: dict[str, Any],
+    ) -> None:
+        """Write (upsert) one tuple into the template's collection.
+
+        Args:
+            template_name: The template key as registered (e.g. ``"tasks/<project>"``).
+            subspace: Concrete subspace string (e.g. ``"tasks/nexus"``).
+            tuple_id: Stable identifier for this tuple (used as the ChromaDB
+                record ID).  Upsert semantics: calling ``out`` twice with the
+                same ``tuple_id`` is a no-op.
+            payload: Document text indexed for semantic retrieval.
+            metadata: Record metadata dict.  Must include ``subspace`` and any
+                validated dimensions.  Validated against ChromaDB quota limits
+                before the write.
+
+        Raises:
+            KeyError: *template_name* is not in this index.
+            RecordTooLarge: *payload* exceeds ``MAX_DOCUMENT_BYTES`` (16 384 bytes).
+            NameTooLong: *tuple_id* exceeds ``MAX_ID_BYTES`` (128 bytes).
+        """
+        _VALIDATOR.validate_record(
+            id=tuple_id,
+            document=payload,
+            embedding=None,
+            metadata=metadata,
+        )
+        coll = self._collections[template_name]
+        coll.upsert(
+            ids=[tuple_id],
+            documents=[payload],
+            metadatas=[metadata],
+        )
+        _log.debug(
+            "tuplespace_out",
+            template=template_name,
+            subspace=subspace,
+            tuple_id=tuple_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def read(
+        self,
+        *,
+        template_name: str,
+        subspace: str,
+        query: str,
+        where: dict[str, Any] | None = None,
+        n_results: int = 1,
+    ) -> list[dict[str, Any]]:
+        """Query tuples semantically from the template's collection.
+
+        The *subspace* filter is always merged into the ``where`` predicate
+        so that only tuples from the requested concrete subspace are returned.
+
+        Args:
+            template_name: The template key (e.g. ``"tasks/<project>"``).
+            subspace: Concrete subspace to filter on.
+            query: Semantic query text.  Must be <= 256 chars.
+            where: Optional caller-supplied ChromaDB metadata filter dict.
+                Must have <= 8 top-level keys (quota limit).
+            n_results: Maximum results to return.  Must be <= 300.
+
+        Returns:
+            List of dicts with keys ``id``, ``document``, ``metadata``,
+            ``distance``.  Empty list if no matches.
+
+        Raises:
+            KeyError: *template_name* is not in this index.
+            ResultsExceedLimit: *n_results* > 300.
+            QueryStringTooLong: *query* > 256 chars.
+            TooManyPredicates: caller *where* has > 8 top-level keys.
+        """
+        # Validate quota limits before touching ChromaDB.
+        _VALIDATOR.validate_query(
+            query_text=query,
+            where=where,
+            n_results=n_results,
+        )
+
+        merged_where = _merge_where(subspace, where)
+
+        coll = self._collections[template_name]
+        raw = coll.query(
+            query_texts=[query],
+            where=merged_where,
+            n_results=n_results,
+        )
+
+        # ChromaDB returns nested lists (one per query text).  Unwrap the
+        # single-query outer list.
+        ids = raw["ids"][0] if raw["ids"] else []
+        documents = raw["documents"][0] if raw["documents"] else []
+        metadatas = raw["metadatas"][0] if raw["metadatas"] else []
+        distances = raw["distances"][0] if raw["distances"] else []
+
+        results = [
+            {
+                "id": id_,
+                "document": doc,
+                "metadata": meta,
+                "distance": dist,
+            }
+            for id_, doc, meta, dist in zip(ids, documents, metadatas, distances)
+        ]
+        _log.debug(
+            "tuplespace_read",
+            template=template_name,
+            subspace=subspace,
+            n_results=n_results,
+            hits=len(results),
+        )
+        return results
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _merge_where(
+    subspace: str,
+    caller_where: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the merged ChromaDB ``where`` filter.
+
+    Always injects a ``subspace`` equality filter.  If the caller supplied
+    additional predicates, wraps both in a ``$and`` compound filter.
+
+    Args:
+        subspace: The concrete subspace string to filter on.
+        caller_where: Optional caller-supplied filter dict (may be ``None``).
+
+    Returns:
+        A single ChromaDB-compatible ``where`` dict.
+    """
+    subspace_filter: dict[str, Any] = {"subspace": {"$eq": subspace}}
+
+    if not caller_where:
+        return subspace_filter
+
+    # Wrap subspace filter and caller filter in $and.
+    return {"$and": [subspace_filter, caller_where]}

--- a/tests/tuplespace/test_index.py
+++ b/tests/tuplespace/test_index.py
@@ -1,0 +1,480 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for nexus.tuplespace.index — Chroma collection layout (project tier).
+
+RDR-110 P1.3 (nexus-78hx). Covers:
+- Slug generation for literal and parameterised template names.
+- Collection creation per registered template at from_registry time.
+- out() writes a document with correct metadata.
+- read() queries the correct collection with subspace filter merged.
+- Subspace isolation: read() only returns tuples from the requested subspace.
+- Caller where-predicate filter is forwarded.
+- Quota enforcement: n_results limit, document size, query length, where count.
+- Upsert idempotence: duplicate tuple_id does not raise.
+
+TDD: this file was written before index.py existed.
+Integration over mocks: real chromadb.EphemeralClient throughout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test YAML fixtures (minimal valid schemas)
+# ---------------------------------------------------------------------------
+
+_TASKS_YAML = """\
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status:    { type: enum, values: [open, in_progress, done, cancelled], required: true }
+  priority:  { type: enum, values: [P0, P1, P2, P3, P4], required: true }
+  assignee:  { type: string, required: false }
+  created_by: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.55
+  margin: 0.08
+  default_lease_seconds: 600
+read:
+  default_floor: 0.40
+  default_n: 5
+tiers: [project]
+retention_seconds: 7776000
+"""
+
+_LOCKS_YAML = """\
+name: locks/<resource>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  resource: { type: string, required: true }
+  holder:   { type: string, required: true }
+take:
+  enabled: true
+  mode: exact
+  match_keys: [resource]
+  default_lease_seconds: 30
+read:
+  default_floor: 0.0
+  default_n: 1
+tiers: [project]
+retention_seconds: 86400
+"""
+
+_PLANS_YAML = """\
+name: plans
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  verb: { type: string, required: true }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.40
+  margin: 0.05
+  default_lease_seconds: 0
+read:
+  default_floor: 0.40
+  default_n: 5
+tiers: [project]
+retention_seconds: 0
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def builtin_dir(tmp_path: Path) -> Path:
+    """Synthetic builtin/ directory with two parameterised templates."""
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "tasks.yml").write_text(_TASKS_YAML)
+    (d / "locks.yml").write_text(_LOCKS_YAML)
+    return d
+
+
+@pytest.fixture()
+def builtin_dir_with_literal(tmp_path: Path) -> Path:
+    """Synthetic builtin/ directory including a literal (non-parameterised) template."""
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "tasks.yml").write_text(_TASKS_YAML)
+    (d / "plans.yml").write_text(_PLANS_YAML)
+    return d
+
+
+@pytest.fixture()
+def registry(builtin_dir: Path):
+    from nexus.tuplespace.registry import Registry
+
+    return Registry.load(builtin_dir)
+
+
+@pytest.fixture()
+def chroma_client():
+    """Fresh EphemeralClient per test — collections accumulate in-process memory."""
+    import chromadb
+
+    return chromadb.EphemeralClient()
+
+
+@pytest.fixture()
+def index(registry, chroma_client):
+    from nexus.tuplespace.index import TupleIndex
+
+    return TupleIndex.from_registry(registry, chroma_client)
+
+
+# ---------------------------------------------------------------------------
+# Slug generation
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateSlug:
+    """Unit tests for the internal slug function."""
+
+    def _slug(self, name: str) -> str:
+        from nexus.tuplespace.index import _template_slug
+
+        return _template_slug(name)
+
+    def test_literal_name_unchanged(self):
+        assert self._slug("plans") == "plans"
+
+    def test_single_param_segment(self):
+        assert self._slug("tasks/<project>") == "tasks_project"
+
+    def test_param_in_second_segment(self):
+        assert self._slug("locks/<resource>") == "locks_resource"
+
+    def test_param_with_underscore_in_name(self):
+        assert self._slug("barriers/<barrier_id>") == "barriers_barrier_id"
+
+    def test_multi_param_segments(self):
+        # Hypothetical multi-param template (not shipped in v1 but valid slug logic).
+        assert self._slug("a/<b>/c/<d>") == "a_b_c_d"
+
+    def test_no_slash_no_param(self):
+        assert self._slug("scratch") == "scratch"
+
+    def test_angle_brackets_stripped(self):
+        # Ensures < and > are removed, not the content between them.
+        assert "<" not in self._slug("tasks/<project>")
+        assert ">" not in self._slug("tasks/<project>")
+
+
+# ---------------------------------------------------------------------------
+# Collection name
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionName:
+    """Unit tests for the public collection-name helper."""
+
+    def _name(self, template_name: str) -> str:
+        from nexus.tuplespace.index import collection_name
+
+        return collection_name(template_name)
+
+    def test_prefixed_with_tuples_double_underscore(self):
+        assert self._name("tasks/<project>").startswith("tuples__")
+
+    def test_tasks_collection_name(self):
+        assert self._name("tasks/<project>") == "tuples__tasks_project"
+
+    def test_locks_collection_name(self):
+        assert self._name("locks/<resource>") == "tuples__locks_resource"
+
+    def test_barriers_collection_name(self):
+        assert self._name("barriers/<barrier_id>") == "tuples__barriers_barrier_id"
+
+    def test_literal_collection_name(self):
+        assert self._name("plans") == "tuples__plans"
+
+    def test_mailbox_collection_name(self):
+        assert self._name("mailbox/<agent>") == "tuples__mailbox_agent"
+
+    def test_events_collection_name(self):
+        assert self._name("events/<topic>") == "tuples__events_topic"
+
+
+# ---------------------------------------------------------------------------
+# from_registry creates collections
+# ---------------------------------------------------------------------------
+
+
+class TestFromRegistry:
+    def test_creates_collection_for_each_template(self, index, chroma_client):
+        """Both registered templates get a collection."""
+        from nexus.tuplespace.index import collection_name
+
+        existing = {c.name for c in chroma_client.list_collections()}
+        assert collection_name("tasks/<project>") in existing
+        assert collection_name("locks/<resource>") in existing
+
+    def test_no_extra_collections_created(self, index, chroma_client):
+        """Exactly the registered templates' collections are present (plus any pre-existing)."""
+        from nexus.tuplespace.index import collection_name
+
+        created = {
+            collection_name("tasks/<project>"),
+            collection_name("locks/<resource>"),
+        }
+        existing = {c.name for c in chroma_client.list_collections()}
+        assert created.issubset(existing)
+
+    def test_from_registry_idempotent(self, registry, chroma_client):
+        """Calling from_registry twice does not raise (get_or_create semantics)."""
+        from nexus.tuplespace.index import TupleIndex
+
+        TupleIndex.from_registry(registry, chroma_client)
+        TupleIndex.from_registry(registry, chroma_client)  # no exception
+
+    def test_literal_template_collection(self, tmp_path, chroma_client):
+        """Literal (non-parameterised) template name produces correct collection."""
+        from nexus.tuplespace.index import TupleIndex, collection_name
+        from nexus.tuplespace.registry import Registry
+
+        d = tmp_path / "builtin"
+        d.mkdir()
+        (d / "plans.yml").write_text(_PLANS_YAML)
+        registry = Registry.load(d)
+        TupleIndex.from_registry(registry, chroma_client)
+
+        existing = {c.name for c in chroma_client.list_collections()}
+        assert collection_name("plans") in existing
+
+
+# ---------------------------------------------------------------------------
+# out — write a tuple
+# ---------------------------------------------------------------------------
+
+
+class TestOut:
+    def test_out_writes_document(self, index, chroma_client):
+        """out() adds a retrievable document to the template's collection."""
+        from nexus.tuplespace.index import collection_name
+
+        index.out(
+            template_name="tasks/<project>",
+            subspace="tasks/nexus",
+            tuple_id="t-001",
+            payload="fix the bug in core",
+            metadata={"subspace": "tasks/nexus", "status": "open", "priority": "P1",
+                      "created_by": "alice"},
+        )
+
+        coll = chroma_client.get_collection(collection_name("tasks/<project>"))
+        result = coll.get(ids=["t-001"])
+        assert result["ids"] == ["t-001"]
+        assert result["documents"] == ["fix the bug in core"]
+        assert result["metadatas"][0]["subspace"] == "tasks/nexus"
+        assert result["metadatas"][0]["status"] == "open"
+
+    def test_out_upsert_is_idempotent(self, index):
+        """Calling out() twice with the same tuple_id must not raise."""
+        kwargs: dict[str, Any] = dict(
+            template_name="tasks/<project>",
+            subspace="tasks/nexus",
+            tuple_id="t-idempotent",
+            payload="initial content",
+            metadata={"subspace": "tasks/nexus", "status": "open", "priority": "P0",
+                      "created_by": "bob"},
+        )
+        index.out(**kwargs)
+        index.out(**kwargs)  # second call — should not raise
+
+    def test_out_metadata_includes_subspace(self, index, chroma_client):
+        """Metadata stored always includes the subspace field."""
+        from nexus.tuplespace.index import collection_name
+
+        index.out(
+            template_name="locks/<resource>",
+            subspace="locks/db",
+            tuple_id="l-001",
+            payload="hold the db lock",
+            metadata={"subspace": "locks/db", "resource": "db", "holder": "worker-1"},
+        )
+
+        coll = chroma_client.get_collection(collection_name("locks/<resource>"))
+        result = coll.get(ids=["l-001"])
+        assert result["metadatas"][0]["subspace"] == "locks/db"
+
+
+# ---------------------------------------------------------------------------
+# Quota enforcement — out
+# ---------------------------------------------------------------------------
+
+
+class TestOutQuota:
+    def test_document_too_large_raises(self, index):
+        """Payload > MAX_DOCUMENT_BYTES (16384) raises RecordTooLarge."""
+        from nexus.db.chroma_quotas import RecordTooLarge
+
+        big_payload = "x" * (16_384 + 1)
+        with pytest.raises(RecordTooLarge):
+            index.out(
+                template_name="tasks/<project>",
+                subspace="tasks/nexus",
+                tuple_id="t-big",
+                payload=big_payload,
+                metadata={"subspace": "tasks/nexus", "status": "open", "priority": "P1",
+                          "created_by": "alice"},
+            )
+
+
+# ---------------------------------------------------------------------------
+# read — query tuples
+# ---------------------------------------------------------------------------
+
+
+class TestRead:
+    def _populate(self, index: Any) -> None:
+        """Insert a few tuples into the tasks template for use in read tests."""
+        index.out(
+            template_name="tasks/<project>",
+            subspace="tasks/nexus",
+            tuple_id="read-t-001",
+            payload="implement caching layer for faster retrieval",
+            metadata={"subspace": "tasks/nexus", "status": "open", "priority": "P1",
+                      "created_by": "alice"},
+        )
+        index.out(
+            template_name="tasks/<project>",
+            subspace="tasks/nexus",
+            tuple_id="read-t-002",
+            payload="fix the authentication bug in login flow",
+            metadata={"subspace": "tasks/nexus", "status": "open", "priority": "P0",
+                      "created_by": "bob"},
+        )
+        # Different subspace — must not appear in tasks/nexus reads.
+        index.out(
+            template_name="tasks/<project>",
+            subspace="tasks/other",
+            tuple_id="read-t-003",
+            payload="unrelated task in another project",
+            metadata={"subspace": "tasks/other", "status": "open", "priority": "P2",
+                      "created_by": "carol"},
+        )
+
+    def test_read_returns_list(self, index):
+        """read() always returns a list."""
+        self._populate(index)
+        results = index.read(
+            template_name="tasks/<project>",
+            subspace="tasks/nexus",
+            query="caching",
+            n_results=1,
+        )
+        assert isinstance(results, list)
+
+    def test_read_result_has_expected_keys(self, index):
+        """Each result dict has id, document, metadata, distance keys."""
+        self._populate(index)
+        results = index.read(
+            template_name="tasks/<project>",
+            subspace="tasks/nexus",
+            query="caching layer",
+            n_results=1,
+        )
+        assert len(results) >= 1
+        r = results[0]
+        assert "id" in r
+        assert "document" in r
+        assert "metadata" in r
+        assert "distance" in r
+
+    def test_read_subspace_filter_isolates_results(self, index):
+        """read() only returns tuples from the requested subspace."""
+        self._populate(index)
+        results = index.read(
+            template_name="tasks/<project>",
+            subspace="tasks/nexus",
+            query="task project work",
+            n_results=10,
+        )
+        for r in results:
+            assert r["metadata"]["subspace"] == "tasks/nexus", (
+                f"Unexpected subspace in result: {r['metadata']['subspace']}"
+            )
+
+    def test_read_where_filter_applied(self, index):
+        """Caller where-predicate is forwarded to the chroma query."""
+        self._populate(index)
+        results = index.read(
+            template_name="tasks/<project>",
+            subspace="tasks/nexus",
+            query="bug fix authentication",
+            where={"priority": {"$eq": "P0"}},
+            n_results=5,
+        )
+        for r in results:
+            assert r["metadata"]["priority"] == "P0"
+
+    def test_read_empty_where_is_ok(self, index):
+        """read() with where=None works without error."""
+        self._populate(index)
+        results = index.read(
+            template_name="tasks/<project>",
+            subspace="tasks/nexus",
+            query="caching",
+        )
+        assert isinstance(results, list)
+
+
+# ---------------------------------------------------------------------------
+# Quota enforcement — read
+# ---------------------------------------------------------------------------
+
+
+class TestReadQuota:
+    def test_n_results_too_large_raises(self, index):
+        """n_results > 300 raises ResultsExceedLimit."""
+        from nexus.db.chroma_quotas import ResultsExceedLimit
+
+        with pytest.raises(ResultsExceedLimit):
+            index.read(
+                template_name="tasks/<project>",
+                subspace="tasks/nexus",
+                query="anything",
+                n_results=301,
+            )
+
+    def test_query_string_too_long_raises(self, index):
+        """query > 256 chars raises QueryStringTooLong."""
+        from nexus.db.chroma_quotas import QueryStringTooLong
+
+        long_query = "a" * 257
+        with pytest.raises(QueryStringTooLong):
+            index.read(
+                template_name="tasks/<project>",
+                subspace="tasks/nexus",
+                query=long_query,
+            )
+
+    def test_where_too_many_predicates_raises(self, index):
+        """where with > 8 top-level keys raises TooManyPredicates."""
+        from nexus.db.chroma_quotas import TooManyPredicates
+
+        # 9 top-level keys in caller's where dict exceeds the 8-predicate limit.
+        big_where = {f"key{i}": {"$eq": f"val{i}"} for i in range(9)}
+        with pytest.raises(TooManyPredicates):
+            index.read(
+                template_name="tasks/<project>",
+                subspace="tasks/nexus",
+                query="anything",
+                where=big_where,
+            )


### PR DESCRIPTION
## Summary

- Adds `src/nexus/tuplespace/index.py` with `TupleIndex`: one persistent local ChromaDB collection per registered template, named `tuples__<template_slug>`
- Slug generation strips `<>` from parameterised segments and replaces `/` with `_` (e.g. `tasks/<project>` -> `tuples__tasks_project`)
- `out()` upserts tuple documents with `{subspace, ...dimensions}` metadata using ChromaDB upsert semantics
- `read()` queries with automatically-merged subspace filter plus caller `where` predicates via `$and`
- Quota enforcement via `QuotaValidator` before every ChromaDB call: n_results <= 300, document <= 16384 bytes, query <= 256 chars, where predicates <= 8
- `from_registry()` classmethod creates all template collections at startup (idempotent via `get_or_create_collection`)
- `collection_name()` public helper for deterministic slug-to-name mapping
- Updates `__init__.py` to export `TupleIndex` and `collection_name`

## Test plan

- [x] 30 TDD tests in `tests/tuplespace/test_index.py` using real `chromadb.EphemeralClient` (no mocks)
- [x] Slug correctness: literal names, single params, multi-segment params, underscore-in-param-name
- [x] Collection creation per template, idempotence, literal template names
- [x] `out()` write verification via `coll.get(ids=[...])`, upsert idempotence
- [x] `read()` result structure, subspace isolation, where-predicate forwarding
- [x] Quota enforcement: each limit individually triggers expected `QuotaViolation` subtype
- [x] `uv run pytest tests/tuplespace/ tests/test_plugin_structure.py`: 626 passed, 26 skipped

## Closes

Closes nexus-78hx