### PR TITLE
feat(tuplespace): Core API + watcher + 8 MCP tools (nexus-8q4v, RDR-110 P1.4)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (c) 2026 Hal Hildebrand. All rights reserved.
-"""MCP core tools: search, store, memory, scratch, collections, plans.
+"""MCP core tools: search, store, memory, scratch, collections, plans, tuplespace.
 
-14 registered tools + 3 demoted (plain functions, no @mcp.tool()).
+22 registered tools + 3 demoted (plain functions, no @mcp.tool()).
+8 tuplespace tools added by RDR-110 P1.4 (nexus-8q4v).
 """
 from __future__ import annotations
 
@@ -4023,6 +4024,331 @@ async def nx_plan_audit(
             lines.append(f"  [{f.get('severity', '?')}] {f.get('title', '')}")
         return "\n".join(lines)
     return str(payload)
+
+
+# ── Tuplespace MCP tools (RDR-110 P1.4, nexus-8q4v) ─────────────────────────
+#
+# Eight tools: tuplespace_out, tuplespace_read, tuplespace_take,
+# tuplespace_ack, tuplespace_nack, tuplespace_list_subspaces,
+# tuplespace_subspace_schema, tuplespace_subspace_stats.
+#
+# State (registry, sqlite conn, chroma index) is managed lazily via
+# _TUPLESPACE. The watcher is started on first tool invocation when
+# NX_STORAGE_MODE == "direct" (or unset) and cleaned up at process exit
+# via atexit. Daemon mode bypasses the watcher (RDR-112 §A2).
+
+
+_TUPLESPACE: dict[str, Any] = {}
+
+
+def _get_tuplespace() -> dict[str, Any]:
+    """Lazily initialise and return tuplespace singletons.
+
+    Returns a dict with keys: registry, conn, index, watcher (or None in daemon mode).
+    """
+    import atexit
+    import os
+    import sqlite3
+
+    if _TUPLESPACE:
+        return _TUPLESPACE
+
+    from nexus.config import load_config
+    from nexus.tuplespace.api import SubspaceSchemaError  # noqa: F401 (re-export)
+    from nexus.tuplespace.index import TupleIndex
+    from nexus.tuplespace.registry import Registry, default_builtin_dir
+    from nexus.tuplespace.store import open_tuples_db
+
+    import structlog
+    _ts_log = structlog.get_logger(__name__)
+
+    cfg = load_config()
+    nexus_dir = cfg.get("nexus_dir", "~/.config/nexus")
+    import os as _os
+    tuples_db_path = _os.path.expanduser(f"{nexus_dir}/tuples.db")
+
+    from pathlib import Path
+    db_path = Path(tuples_db_path)
+
+    registry = Registry.load(default_builtin_dir())
+
+    storage_mode = _os.environ.get("NX_STORAGE_MODE", "").lower()
+    if storage_mode == "daemon":
+        _ts_log.info("tuplespace_mcp_daemon_mode_conn_skipped")
+        # In daemon mode: no local SQLite connection (daemon owns the db).
+        # Tools that need conn will raise a clear error.
+        _TUPLESPACE.update({"registry": registry, "conn": None, "index": None, "watcher": None})
+        return _TUPLESPACE
+
+    conn = open_tuples_db(db_path)
+    conn.row_factory = sqlite3.Row
+
+    import chromadb
+    chroma_dir = _os.path.expanduser(f"{nexus_dir}/chroma")
+    chroma_client = chromadb.PersistentClient(path=chroma_dir)
+    index = TupleIndex.from_registry(registry, chroma_client)
+
+    watcher = None
+    try:
+        from nexus.tuplespace.watcher import _TupleSpaceWatcher
+        import threading
+        _wake_event = threading.Event()
+        watcher = _TupleSpaceWatcher(db_path=db_path, wake_event=_wake_event)
+        watcher.start()
+    except Exception as exc:
+        _ts_log.warning("tuplespace_watcher_start_failed", error=str(exc))
+
+    def _cleanup():
+        try:
+            if watcher is not None:
+                watcher.stop()
+        except Exception:
+            pass
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    atexit.register(_cleanup)
+
+    _TUPLESPACE.update({
+        "registry": registry,
+        "conn": conn,
+        "index": index,
+        "watcher": watcher,
+    })
+    return _TUPLESPACE
+
+
+@mcp.tool()
+def tuplespace_out(
+    subspace: str,
+    content: str,
+    dimensions: str,
+    match_text: str = "",
+    ttl_seconds: float = 0.0,
+) -> str:
+    """Post (upsert) a tuple into the semantic tuple space (RDR-110).
+
+    The tuple is stored in SQLite (claim ledger) and indexed in ChromaDB
+    (semantic retrieval).  Calling ``out`` twice with the same arguments
+    is idempotent — the same tuple_id is returned without creating a
+    duplicate.
+
+    Args:
+        subspace: Concrete subspace string (e.g. ``"tasks/nexus"``).
+        content: Tuple body text.
+        dimensions: JSON object of dimension key/value pairs validated
+            against the subspace schema (e.g. ``{"status": "open", "priority": "P1"}``).
+        match_text: Optional override for the embedding source.  Required
+            when the subspace schema declares ``embed_from: match_text``.
+        ttl_seconds: Optional TTL in seconds from now.  0 means no expiry.
+
+    Returns:
+        The stable 32-hex ``tuple_id`` for this tuple.
+    """
+    import json as _json
+    from nexus.tuplespace.api import out
+
+    ts = _get_tuplespace()
+    dims = _json.loads(dimensions) if isinstance(dimensions, str) else dimensions
+    tid = out(
+        conn=ts["conn"],
+        index=ts["index"],
+        registry=ts["registry"],
+        subspace=subspace,
+        content=content,
+        dimensions=dims,
+        match_text=match_text or None,
+        ttl_seconds=ttl_seconds if ttl_seconds > 0 else None,
+    )
+    return tid
+
+
+@mcp.tool()
+def tuplespace_read(
+    subspace: str,
+    query: str,
+    where: str = "",
+    floor: float = 0.0,
+    n: int = 0,
+) -> str:
+    """Read tuples semantically from a subspace (non-destructive).
+
+    Returns available (non-consumed, non-claimed) tuples ranked by
+    similarity to *query*.
+
+    Args:
+        subspace: Concrete subspace string (e.g. ``"tasks/nexus"``).
+        query: Semantic query text.
+        where: Optional ChromaDB metadata filter as a JSON object
+            (e.g. ``{"status": {"$eq": "open"}}``).
+        floor: Minimum similarity threshold (0.0 = use schema default).
+        n: Maximum results (0 = use schema default).
+
+    Returns:
+        JSON array of tuple objects with keys: id, content, dimensions,
+        subspace, created_at, embed_text, match_text.
+    """
+    import json as _json
+    from nexus.tuplespace.api import read
+
+    ts = _get_tuplespace()
+    where_dict = _json.loads(where) if where else None
+    results = read(
+        conn=ts["conn"],
+        index=ts["index"],
+        registry=ts["registry"],
+        subspace=subspace,
+        query=query,
+        where=where_dict,
+        floor=floor if floor > 0.0 else None,
+        n=n if n > 0 else None,
+    )
+    return _json.dumps(results, default=str)
+
+
+@mcp.tool()
+def tuplespace_take(
+    subspace: str,
+    query: str,
+    claimant: str,
+    where: str = "",
+    floor: float = 0.0,
+    lease_seconds: float = 0.0,
+) -> str:
+    """Atomically claim a tuple from a subspace (destructive read).
+
+    Uses a single-statement CAS ``UPDATE … RETURNING`` for atomicity
+    under SQLite's single-writer lock.  Two concurrent claimants cannot
+    both succeed on the same tuple.
+
+    Args:
+        subspace: Concrete subspace string (e.g. ``"tasks/nexus"``).
+        query: Semantic query text (ignored in ``exact`` mode).
+        claimant: Unique identifier for the claiming agent.
+        where: Optional filter as JSON.  In ``exact`` mode, must include
+            all ``match_keys`` declared in the schema.
+        floor: Minimum similarity threshold (0.0 = use schema default).
+        lease_seconds: Lease duration in seconds (0.0 = use schema default).
+
+    Returns:
+        JSON object ``{"tuple": {...}, "claim_id": "..."}`` if a tuple
+        was claimed, or ``null`` if no candidate was available.
+    """
+    import json as _json
+    from nexus.tuplespace.api import take
+
+    ts = _get_tuplespace()
+    where_dict = _json.loads(where) if where else None
+    result = take(
+        conn=ts["conn"],
+        index=ts["index"],
+        registry=ts["registry"],
+        subspace=subspace,
+        query=query,
+        claimant=claimant,
+        where=where_dict,
+        floor=floor if floor > 0.0 else None,
+        lease_seconds=lease_seconds if lease_seconds > 0.0 else None,
+        block=False,
+    )
+    if result is None:
+        return "null"
+    t_dict, claim_id = result
+    return _json.dumps({"tuple": t_dict, "claim_id": claim_id}, default=str)
+
+
+@mcp.tool()
+def tuplespace_ack(
+    claim_id: str,
+    claimant: str,
+) -> str:
+    """Acknowledge a claim: mark the tuple consumed and log the transition.
+
+    Args:
+        claim_id: The claim ID returned by ``tuplespace_take``.
+        claimant: The claiming agent; must match the original claimant.
+
+    Returns:
+        ``"ok"`` on success.
+    """
+    from nexus.tuplespace.api import ack
+
+    ts = _get_tuplespace()
+    ack(conn=ts["conn"], claim_id=claim_id, claimant=claimant)
+    return "ok"
+
+
+@mcp.tool()
+def tuplespace_nack(
+    claim_id: str,
+    claimant: str,
+) -> str:
+    """Negative-acknowledge a claim: release it back to available.
+
+    Args:
+        claim_id: The claim ID returned by ``tuplespace_take``.
+        claimant: The claiming agent; must match the original claimant.
+
+    Returns:
+        ``"ok"`` on success.
+    """
+    from nexus.tuplespace.api import nack
+
+    ts = _get_tuplespace()
+    nack(conn=ts["conn"], claim_id=claim_id, claimant=claimant)
+    return "ok"
+
+
+@mcp.tool()
+def tuplespace_list_subspaces() -> str:
+    """List all registered subspace template names.
+
+    Returns:
+        JSON array of template name strings
+        (e.g. ``["tasks/<project>", "locks/<resource>"]``).
+    """
+    import json as _json
+    from nexus.tuplespace.api import list_subspaces
+
+    ts = _get_tuplespace()
+    return _json.dumps(list_subspaces(registry=ts["registry"]))
+
+
+@mcp.tool()
+def tuplespace_subspace_schema(subspace: str) -> str:
+    """Return the schema for a subspace.
+
+    Args:
+        subspace: Concrete or template subspace string.
+
+    Returns:
+        JSON object with keys: name, tier, content_type, embed_from,
+        dimensions, take, read, tiers, retention_seconds.
+    """
+    import json as _json
+    from nexus.tuplespace.api import subspace_schema
+
+    ts = _get_tuplespace()
+    return _json.dumps(subspace_schema(registry=ts["registry"], subspace=subspace), default=str)
+
+
+@mcp.tool()
+def tuplespace_subspace_stats(subspace: str) -> str:
+    """Return aggregate counts for a concrete subspace.
+
+    Args:
+        subspace: Concrete subspace string (e.g. ``"tasks/nexus"``).
+
+    Returns:
+        JSON object with keys: total, available, claimed, consumed.
+    """
+    import json as _json
+    from nexus.tuplespace.api import subspace_stats
+
+    ts = _get_tuplespace()
+    return _json.dumps(subspace_stats(conn=ts["conn"], subspace=subspace))
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/src/nexus/tuplespace/__init__.py
+++ b/src/nexus/tuplespace/__init__.py
@@ -10,6 +10,21 @@ embedder wiring. The registry validates YAML schemas; index.py wraps
 ChromaDB; downstream beads supply the full storage and network plane.
 """
 
+from nexus.tuplespace.api import (
+    BlockingNotSupported,
+    ClaimNotFoundError,
+    ClaimOwnershipError,
+    SubspaceSchemaError,
+    TakeDisabledError,
+    ack,
+    list_subspaces,
+    nack,
+    out,
+    read,
+    subspace_schema,
+    subspace_stats,
+    take,
+)
 from nexus.tuplespace.index import TupleIndex, collection_name
 from nexus.tuplespace.registry import (
     Registry,
@@ -20,11 +35,24 @@ from nexus.tuplespace.registry import (
 )
 
 __all__ = [
+    "BlockingNotSupported",
+    "ClaimNotFoundError",
+    "ClaimOwnershipError",
     "Registry",
     "RegistryLoadError",
     "SubspaceSchema",
+    "SubspaceSchemaError",
+    "TakeDisabledError",
     "TupleIndex",
     "UnknownSubspaceError",
+    "ack",
     "collection_name",
     "default_builtin_dir",
+    "list_subspaces",
+    "nack",
+    "out",
+    "read",
+    "subspace_schema",
+    "subspace_stats",
+    "take",
 ]

--- a/src/nexus/tuplespace/api.py
+++ b/src/nexus/tuplespace/api.py
@@ -1,0 +1,875 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Core tuple-space API: out, read, take, ack, nack, list_subspaces,
+subspace_schema, subspace_stats (RDR-110 P1.4, nexus-8q4v).
+
+All functions accept injected dependencies (conn, index, registry) so
+callers control the storage backend.  No global singletons here; the MCP
+tool layer (src/nexus/mcp/core.py) wires singletons to these functions.
+
+**Modes**:
+
+- ``semantic`` (default): chroma top-K -> floor/margin gate -> ID list -> CAS.
+- ``exact`` (e.g. ``locks/<resource>``): SQL-only candidate selection on
+  ``schema.take.match_keys``; bypasses chroma entirely.
+
+**CAS atomicity** (honker RF-9): ``take`` uses a single-statement
+``UPDATE ... WHERE id = (SELECT ... LIMIT 1) RETURNING id`` under SQLite's
+single-writer lock.  Two concurrent claimants cannot both succeed on the same
+row because only one UPDATE wins the write lock; the loser's subquery finds no
+eligible row (claim_state already set) and returns nothing.
+
+**Idempotent retake** by the same claimant is a two-statement read-then-update
+per RDR-110 design note.  The CAS pattern conflates same-claimant retake with
+foreign-claimant contention, so same-claimant retake is handled separately.
+
+**block=True is feature-flagged OFF in Phase 1** (overlayfs unsafe, RDR-112
+§A2).  The parameter is accepted but raises ``BlockingNotSupported`` in
+direct-mode.  The daemon-mode block path lands in Phase 3.
+
+**embed_from** validation happens on the first ``out`` against a subspace.
+Valid forms: ``"content"``, ``"match_text"``, or ``"dimensions:<key>"`` where
+``<key>`` exists in the schema's ``dimensions`` block.
+
+**unixepoch() note** (store.py doc): any query touching ``idx_tuples_avail``
+must use ``unixepoch()`` inline, NOT a bound ``?``, for the partial-index
+predicate ``claim_expires_at < unixepoch()``.  The ``_select_candidates_sql``
+helper follows this rule.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from typing import Any, Callable, Optional
+
+import structlog
+
+from nexus.tuplespace.index import TupleIndex
+from nexus.tuplespace.registry import (
+    Registry,
+    SubspaceSchema,
+    UnknownSubspaceError,
+)
+
+_log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class SubspaceSchemaError(ValueError):
+    """Raised when dimensions or embed_from fail schema validation."""
+
+
+class TakeDisabledError(RuntimeError):
+    """Raised when take() is called on a subspace with take.enabled=False."""
+
+
+class InvalidTimeoutError(ValueError):
+    """Raised when timeout_seconds exceeds the MCP transport budget cap."""
+
+
+class BlockingNotSupported(NotImplementedError):
+    """Raised when block=True is requested in direct-mode (Phase 1 feature-flag)."""
+
+
+class ClaimOwnershipError(PermissionError):
+    """Raised when ack/nack is called by a claimant that does not own the claim."""
+
+
+class ClaimNotFoundError(LookupError):
+    """Raised when ack/nack is called with a claim_id that does not exist."""
+
+
+# ---------------------------------------------------------------------------
+# Test-injection hook (used in test_api.py CAS race test)
+# ---------------------------------------------------------------------------
+
+#: If set, called by ``take`` immediately after candidate selection and before
+#: the CAS UPDATE.  Used in tests to synchronise concurrent threads at the
+#: race window.  Must be ``None`` in production.
+_take_pre_update_hook: Optional[Callable[[], None]] = None
+
+
+# ---------------------------------------------------------------------------
+# ID computation
+# ---------------------------------------------------------------------------
+
+
+def _tuple_id(
+    subspace: str,
+    content: str,
+    dimensions: dict[str, Any],
+    match_text: str,
+) -> str:
+    """Compute a stable 32-hex chash for a tuple.
+
+    The ID includes subspace, content, dimensions (sorted), and match_text so
+    that logically distinct tuples in the same subspace with identical content
+    but different dimensions produce distinct IDs.
+
+    Args:
+        subspace: Concrete subspace string (e.g. ``"tasks/nexus"``).
+        content: Tuple body text.
+        dimensions: Validated dimensions dict.
+        match_text: Embedding override text, or empty string if not provided.
+
+    Returns:
+        32-character lowercase hex string (sha256 prefix).
+    """
+    canonical = json.dumps(
+        {
+            "subspace": subspace,
+            "content": content,
+            "dimensions": dimensions,
+            "match_text": match_text,
+        },
+        sort_keys=True,
+        ensure_ascii=True,
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()[:32]
+
+
+def _claim_id(claimant: str, tuple_id: str, now: float) -> str:
+    """Compute a stable claim ID from claimant + tuple_id + timestamp."""
+    canonical = f"{claimant}:{tuple_id}:{now}"
+    return hashlib.sha256(canonical.encode()).hexdigest()[:32]
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_embed_from(embed_from: str, dimensions: dict[str, Any]) -> None:
+    """Validate an embed_from value against valid forms.
+
+    Valid forms:
+    - ``"content"``
+    - ``"match_text"``
+    - ``"dimensions:<key>"`` where ``<key>`` is non-empty and exists in
+      *dimensions*.
+
+    Args:
+        embed_from: The embed_from string from the subspace schema.
+        dimensions: The dimensions dict (schema dimensions block keys).
+
+    Raises:
+        SubspaceSchemaError: If the value is not one of the valid forms.
+    """
+    if embed_from == "content":
+        return
+    if embed_from == "match_text":
+        return
+    if embed_from.startswith("dimensions:"):
+        key = embed_from[len("dimensions:"):]
+        if not key:
+            raise SubspaceSchemaError(
+                f"embed_from={embed_from!r} has empty key after 'dimensions:'; "
+                "must be 'dimensions:<key>' where <key> exists in the schema dimensions block"
+            )
+        if key not in dimensions:
+            raise SubspaceSchemaError(
+                f"embed_from={embed_from!r}: key {key!r} not found in schema dimensions "
+                f"(available: {sorted(dimensions)})"
+            )
+        return
+    raise SubspaceSchemaError(
+        f"embed_from={embed_from!r} is not a valid form; "
+        "valid forms: 'content', 'match_text', 'dimensions:<key>'"
+    )
+
+
+def _resolve_embed_text(
+    embed_from: str,
+    content: str,
+    match_text: Optional[str],
+    dimensions: dict[str, Any],
+) -> str:
+    """Resolve the embed text based on the schema's embed_from setting.
+
+    Args:
+        embed_from: Schema embed_from string (already validated).
+        content: Tuple body text.
+        match_text: Caller-supplied override (may be None).
+        dimensions: Validated dimensions dict (already validated values).
+
+    Returns:
+        The text to embed in ChromaDB.
+    """
+    if embed_from == "content":
+        return content
+    if embed_from == "match_text":
+        return match_text or content
+    if embed_from.startswith("dimensions:"):
+        key = embed_from[len("dimensions:"):]
+        return str(dimensions[key])
+    # Should not reach here after _validate_embed_from, but be defensive
+    return content
+
+
+def _validate_dimensions(
+    schema: SubspaceSchema, dimensions: dict[str, Any]
+) -> None:
+    """Validate *dimensions* against the schema's declared dimension constraints.
+
+    Checks:
+    - Required dimensions are present and non-empty.
+    - Enum-typed dimensions have a value in the declared ``values`` list.
+
+    Args:
+        schema: The subspace schema declaring dimension constraints.
+        dimensions: The caller-supplied dimensions dict.
+
+    Raises:
+        SubspaceSchemaError: If any constraint is violated.
+    """
+    for dim_name, dim_spec in schema.dimensions.items():
+        required = dim_spec.get("required", False)
+        value = dimensions.get(dim_name)
+
+        if required and (value is None or value == ""):
+            raise SubspaceSchemaError(
+                f"dimension {dim_name!r} is required but missing or empty "
+                f"(subspace schema: {schema.name!r})"
+            )
+
+        if value is not None and dim_spec.get("type") == "enum":
+            allowed = dim_spec.get("values", [])
+            if value not in allowed:
+                raise SubspaceSchemaError(
+                    f"dimension {dim_name!r} value {value!r} is not in "
+                    f"allowed values {allowed!r} for schema {schema.name!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# SQL helpers
+# ---------------------------------------------------------------------------
+
+
+def _select_candidates_sql(
+    subspace: str,
+    extra_where_fragments: list[str],
+    limit: int = 1,
+) -> tuple[str, list[Any]]:
+    """Build the available-candidate SELECT for exact-mode take.
+
+    Uses ``unixepoch()`` inline (not a bound ?) per the idx_tuples_avail
+    partial-index contract in store.py.
+
+    Args:
+        subspace: Concrete subspace string.
+        extra_where_fragments: List of SQL fragments to AND into the WHERE
+            clause.  Each fragment must use only bound parameters appended
+            to the returned params list.
+        limit: Row limit (default 1 for take).
+
+    Returns:
+        (sql_string, params_list) tuple.
+    """
+    base_where = [
+        "subspace = ?",
+        "consumed_at IS NULL",
+        "(claim_state IS NULL OR claim_expires_at < unixepoch())",
+    ]
+    all_where = base_where + extra_where_fragments
+    sql = (
+        f"SELECT id FROM tuples WHERE {' AND '.join(all_where)} "
+        f"ORDER BY created_at LIMIT {limit}"
+    )
+    return sql, [subspace]
+
+
+def _post_filter_ids(
+    conn: sqlite3.Connection,
+    candidate_ids: list[str],
+) -> list[str]:
+    """Post-filter chroma candidate IDs against the SQL claim/consumed state.
+
+    Drops tuples that are consumed or actively claimed.  Uses ``unixepoch()``
+    inline per the idx_tuples_avail partial-index contract.
+
+    Args:
+        conn: Open SQLite connection.
+        candidate_ids: List of tuple IDs from the chroma query.
+
+    Returns:
+        Subset of *candidate_ids* that are still available.
+    """
+    if not candidate_ids:
+        return []
+    placeholders = ",".join("?" * len(candidate_ids))
+    rows = conn.execute(
+        f"SELECT id FROM tuples "
+        f"WHERE id IN ({placeholders}) "
+        f"  AND consumed_at IS NULL "
+        f"  AND (claim_state IS NULL OR claim_expires_at < unixepoch())",
+        candidate_ids,
+    ).fetchall()
+    available = {r[0] for r in rows}
+    # Preserve chroma ordering
+    return [cid for cid in candidate_ids if cid in available]
+
+
+def _load_tuple_row(conn: sqlite3.Connection, tuple_id: str) -> dict[str, Any]:
+    """Load a full tuple row as a dict from SQLite."""
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT * FROM tuples WHERE id = ?", (tuple_id,)).fetchone()
+    if row is None:
+        return {}
+    result = dict(row)
+    # Parse dimensions_json for callers
+    try:
+        result["dimensions"] = json.loads(result.get("dimensions_json", "{}"))
+    except (json.JSONDecodeError, TypeError):
+        result["dimensions"] = {}
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def out(
+    *,
+    conn: sqlite3.Connection,
+    index: TupleIndex,
+    registry: Registry,
+    subspace: str,
+    content: str,
+    dimensions: dict[str, Any],
+    match_text: Optional[str] = None,
+    ttl_seconds: Optional[float] = None,
+) -> str:
+    """Post (upsert) a tuple into the tuple space.
+
+    The tuple_id is computed deterministically from (subspace, content,
+    dimensions, match_text), so calling ``out`` twice with the same
+    arguments is a no-op and returns the same ID.
+
+    Args:
+        conn: Open SQLite connection to tuples.db.
+        index: ``TupleIndex`` wrapping ChromaDB collections.
+        registry: Loaded ``Registry`` of subspace schemas.
+        subspace: Concrete subspace string (e.g. ``"tasks/nexus"``).
+        content: Tuple body text.
+        dimensions: Dict of dimension values; validated against schema.
+        match_text: Optional override for the embedding source.  Required when
+            ``embed_from="match_text"`` in the schema.
+        ttl_seconds: Optional TTL in seconds from now.  ``None`` means no expiry.
+
+    Returns:
+        The 32-hex tuple_id.
+
+    Raises:
+        UnknownSubspaceError: Subspace does not match any registered template.
+        SubspaceSchemaError: Dimension values fail schema validation, or
+            embed_from form is invalid.
+    """
+    schema = registry.get_schema_for(subspace)
+    _validate_embed_from(schema.embed_from, schema.dimensions)
+    _validate_dimensions(schema, dimensions)
+
+    mt = match_text or ""
+    tid = _tuple_id(subspace, content, dimensions, mt)
+    embed_text = _resolve_embed_text(schema.embed_from, content, match_text, dimensions)
+    dims_json = json.dumps(dimensions, sort_keys=True)
+    now = time.time()
+    expires_at = now + ttl_seconds if ttl_seconds is not None else None
+
+    # Upsert into SQLite (INSERT OR IGNORE for idempotency — same tid = same content)
+    conn.execute(
+        "INSERT OR IGNORE INTO tuples "
+        "(id, subspace, template_name, content, dimensions_json, embed_text, "
+        " match_text, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (tid, subspace, schema.name, content, dims_json, embed_text, mt or None, now, expires_at),
+    )
+    conn.commit()
+
+    # Upsert into ChromaDB (idempotent by design)
+    meta: dict[str, Any] = {"subspace": subspace}
+    for k, v in dimensions.items():
+        # ChromaDB metadata values must be str/int/float/bool
+        meta[k] = v if isinstance(v, (str, int, float, bool)) else str(v)
+
+    index.out(
+        template_name=schema.name,
+        subspace=subspace,
+        tuple_id=tid,
+        payload=embed_text,
+        metadata=meta,
+    )
+
+    _log.debug("tuplespace_out_complete", subspace=subspace, tuple_id=tid)
+    return tid
+
+
+def read(
+    *,
+    conn: sqlite3.Connection,
+    index: TupleIndex,
+    registry: Registry,
+    subspace: str,
+    query: str,
+    where: Optional[dict[str, Any]] = None,
+    floor: Optional[float] = None,
+    n: Optional[int] = None,
+) -> list[dict[str, Any]]:
+    """Read tuples semantically from a subspace (non-destructive).
+
+    Returns available (non-consumed, non-claimed) tuples matching *query*
+    above the configured *floor*, up to *n* results.
+
+    Args:
+        conn: Open SQLite connection to tuples.db.
+        index: ``TupleIndex`` wrapping ChromaDB collections.
+        registry: Loaded ``Registry`` of subspace schemas.
+        subspace: Concrete subspace string.
+        query: Semantic query text.
+        where: Optional ChromaDB metadata filter dict.
+        floor: Minimum similarity threshold (overrides schema default).
+        n: Maximum results (overrides schema default).
+
+    Returns:
+        List of tuple dicts with keys ``id``, ``content``, ``dimensions``,
+        ``subspace``, ``created_at``, ``embed_text``, ``match_text``.
+        Empty list if no matches.
+
+    Raises:
+        UnknownSubspaceError: Subspace does not match any registered template.
+    """
+    schema = registry.get_schema_for(subspace)
+    effective_floor = floor if floor is not None else schema.read["default_floor"]
+    effective_n = n if n is not None else schema.read["default_n"]
+
+    # Clamp n_results to chroma quota maximum
+    from nexus.db.chroma_quotas import QUOTAS
+    effective_n = min(effective_n, QUOTAS.MAX_QUERY_RESULTS)
+
+    chroma_results = index.read(
+        template_name=schema.name,
+        subspace=subspace,
+        query=query,
+        where=where,
+        n_results=effective_n,
+    )
+
+    # Apply floor filter
+    candidate_ids: list[str] = [
+        r["id"]
+        for r in chroma_results
+        if (1.0 - r["distance"]) >= effective_floor
+    ]
+
+    # Post-filter against SQL availability (consumed_at / claim_state)
+    available_ids = _post_filter_ids(conn, candidate_ids)
+
+    if not available_ids:
+        return []
+
+    # Load full rows from SQLite
+    placeholders = ",".join("?" * len(available_ids))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        f"SELECT * FROM tuples WHERE id IN ({placeholders})",
+        available_ids,
+    ).fetchall()
+
+    id_to_row = {r["id"]: dict(r) for r in rows}
+
+    result = []
+    for tid in available_ids:
+        row = id_to_row.get(tid)
+        if row is None:
+            continue
+        try:
+            row["dimensions"] = json.loads(row.get("dimensions_json", "{}"))
+        except (json.JSONDecodeError, TypeError):
+            row["dimensions"] = {}
+        result.append(row)
+
+    return result
+
+
+def take(
+    *,
+    conn: sqlite3.Connection,
+    index: TupleIndex,
+    registry: Registry,
+    subspace: str,
+    query: str,
+    claimant: str,
+    where: Optional[dict[str, Any]] = None,
+    floor: Optional[float] = None,
+    lease_seconds: Optional[float] = None,
+    block: bool = False,
+    timeout_seconds: Optional[float] = None,
+) -> Optional[tuple[dict[str, Any], str]]:
+    """Atomically claim a tuple from a subspace (destructive read).
+
+    Uses a single-statement CAS ``UPDATE ... WHERE id = (SELECT ... LIMIT 1)
+    RETURNING id`` for atomicity under SQLite's single-writer lock.  Two
+    concurrent claimants cannot both succeed on the same row.
+
+    **Idempotent retake by same claimant**: if the same *claimant* already
+    holds an active claim (not expired) on a candidate, returns the existing
+    claim_id without a new UPDATE.
+
+    Args:
+        conn: Open SQLite connection to tuples.db.
+        index: ``TupleIndex`` wrapping ChromaDB collections.
+        registry: Loaded ``Registry`` of subspace schemas.
+        subspace: Concrete subspace string.
+        query: Semantic query (unused in exact mode).
+        claimant: Unique identifier for the claiming agent.
+        where: Optional filter dict.  In ``exact`` mode, must contain all
+            ``match_keys`` declared in the schema.
+        floor: Minimum similarity threshold (overrides schema default).
+        lease_seconds: Lease duration in seconds (overrides schema default).
+        block: Must be False in Phase 1 (raises ``BlockingNotSupported``).
+        timeout_seconds: Maximum wait duration (only meaningful when block=True;
+            capped at 30 s per MCP transport budget).
+
+    Returns:
+        ``(tuple_dict, claim_id)`` if successful, ``None`` if no candidate
+        was available.
+
+    Raises:
+        UnknownSubspaceError: Subspace does not match any registered template.
+        TakeDisabledError: The schema declares ``take.enabled=False``.
+        BlockingNotSupported: *block=True* in Phase 1 direct mode.
+        SubspaceSchemaError: Exact-mode *where* is missing a required
+            ``match_key``.
+        InvalidTimeoutError: *timeout_seconds* > 30.
+    """
+    if block:
+        raise BlockingNotSupported(
+            "block=True is not supported in Phase 1 direct-mode (RDR-112 §A2). "
+            "The daemon-mode block path lands in Phase 3."
+        )
+
+    if timeout_seconds is not None and timeout_seconds > 30:
+        raise InvalidTimeoutError(
+            f"timeout_seconds={timeout_seconds} exceeds the MCP transport budget cap of 30 s "
+            "(RDR-110 §Technical Design)"
+        )
+
+    schema = registry.get_schema_for(subspace)
+
+    if not schema.take.get("enabled", False):
+        raise TakeDisabledError(
+            f"take is disabled for subspace {subspace!r} "
+            f"(schema: {schema.name!r})"
+        )
+
+    mode = schema.take.get("mode", "semantic")
+    effective_floor = floor if floor is not None else schema.take.get("floor", 0.0)
+    effective_margin = schema.take.get("margin", 0.0)
+    effective_lease = lease_seconds if lease_seconds is not None else schema.take.get(
+        "default_lease_seconds", 60
+    )
+
+    # Candidate selection
+    top_ids: list[str] = []
+
+    if mode == "exact":
+        # Bypass chroma; select purely on match_keys + SQL availability.
+        match_keys: list[str] = schema.take.get("match_keys", [])
+        for k in match_keys:
+            if not where or k not in where:
+                raise SubspaceSchemaError(
+                    f"take mode=exact requires match_key {k!r} in where; "
+                    f"schema: {schema.name!r}, match_keys={match_keys!r}"
+                )
+
+        # Dimensions are stored as JSON in dimensions_json; use json_extract.
+        # Column names (match_keys) come from the schema, never from the caller,
+        # so interpolating them into the fragment is safe.
+        fragments = [f"json_extract(dimensions_json, '$.{k}') = ?" for k in match_keys]
+        match_values = [where[k] for k in match_keys]
+        sql, base_params = _select_candidates_sql(subspace, fragments, limit=1)
+        params = base_params + match_values
+        rows = conn.execute(sql, params).fetchall()
+        top_ids = [r[0] for r in rows]
+
+    else:
+        # Semantic mode: chroma top-K -> floor -> margin -> candidate IDs
+        from nexus.db.chroma_quotas import QUOTAS
+        n_query = min(max(5, schema.read.get("default_n", 1)), QUOTAS.MAX_QUERY_RESULTS)
+
+        chroma_results = index.read(
+            template_name=schema.name,
+            subspace=subspace,
+            query=query,
+            where=where,
+            n_results=n_query,
+        )
+
+        if chroma_results:
+            best = chroma_results[0]
+            best_similarity = 1.0 - best["distance"]
+
+            if best_similarity >= effective_floor:
+                # Margin check: only need margin if there's a second candidate
+                if len(chroma_results) == 1:
+                    margin_ok = True
+                else:
+                    second_similarity = 1.0 - chroma_results[1]["distance"]
+                    margin_ok = (best_similarity - second_similarity) >= effective_margin
+
+                if margin_ok:
+                    top_ids = [
+                        r["id"]
+                        for r in chroma_results
+                        if (1.0 - r["distance"]) >= effective_floor
+                    ]
+
+    # Synchronisation point for CAS race test (no-op in production)
+    if _take_pre_update_hook is not None:
+        _take_pre_update_hook()
+
+    if not top_ids:
+        return None
+
+    now = time.time()
+    expires_at = now + effective_lease
+
+    # --- Idempotent retake by same claimant (two-statement read-then-update) ---
+    # The CAS pattern below would see claim_state='claimed' AND claim_expires_at>now
+    # for the same claimant's live claim and return no row — indistinguishable from
+    # a foreign-claimant loss.  Handle it explicitly first.
+    placeholders = ",".join("?" * len(top_ids))
+    existing = conn.execute(
+        f"SELECT id, claim_id FROM tuples "
+        f"WHERE id IN ({placeholders}) "
+        f"  AND claim_state = 'claimed' "
+        f"  AND claimant = ? "
+        f"  AND claim_expires_at > ?",
+        top_ids + [claimant, now],
+    ).fetchone()
+
+    if existing is not None:
+        # Same claimant still holds the lease — return existing claim
+        t_dict = _load_tuple_row(conn, existing[0])
+        _log.debug(
+            "tuplespace_take_idempotent_retake",
+            subspace=subspace,
+            claimant=claimant,
+            tuple_id=existing[0],
+        )
+        return t_dict, existing[1]
+
+    # --- Single-statement CAS ---
+    # Portable form: LIMIT 1 in the inner SELECT (universally supported).
+    # LIMIT directly in UPDATE requires SQLITE_ENABLE_UPDATE_DELETE_LIMIT
+    # which CPython's stdlib sqlite3 does NOT set.
+    cid = _claim_id(claimant, top_ids[0], now)
+    row = conn.execute(
+        f"UPDATE tuples "
+        f"SET claim_state='claimed', claimant=?, claim_id=?, claim_expires_at=? "
+        f"WHERE id = ( "
+        f"    SELECT id FROM tuples "
+        f"    WHERE id IN ({placeholders}) "
+        f"      AND consumed_at IS NULL "
+        f"      AND (claim_state IS NULL OR claim_expires_at < unixepoch()) "
+        f"    ORDER BY created_at "
+        f"    LIMIT 1 "
+        f") "
+        f"RETURNING id",
+        [claimant, cid, expires_at] + top_ids,
+    ).fetchone()
+
+    if row is None:
+        # All candidates raced away — no winner
+        return None
+
+    conn.execute(
+        "INSERT INTO tuple_claim_log (tuple_id, claim_id, claimant, transition, at) "
+        "VALUES (?, ?, ?, 'claim', ?)",
+        (row[0], cid, claimant, now),
+    )
+    conn.commit()
+
+    t_dict = _load_tuple_row(conn, row[0])
+    _log.debug(
+        "tuplespace_take_claimed",
+        subspace=subspace,
+        claimant=claimant,
+        tuple_id=row[0],
+        claim_id=cid,
+    )
+    return t_dict, cid
+
+
+def ack(
+    *,
+    conn: sqlite3.Connection,
+    claim_id: str,
+    claimant: str,
+) -> None:
+    """Acknowledge a claim: mark the tuple consumed and log the transition.
+
+    Args:
+        conn: Open SQLite connection to tuples.db.
+        claim_id: The claim ID returned by ``take``.
+        claimant: The claiming agent; must match the original claimant.
+
+    Raises:
+        ClaimNotFoundError: No claim with *claim_id* exists.
+        ClaimOwnershipError: *claimant* does not own the claim.
+    """
+    row = conn.execute(
+        "SELECT id, claimant FROM tuples WHERE claim_id = ? AND claim_state = 'claimed'",
+        (claim_id,),
+    ).fetchone()
+
+    if row is None:
+        raise ClaimNotFoundError(
+            f"No active claim found for claim_id={claim_id!r}"
+        )
+
+    if row[1] != claimant:
+        raise ClaimOwnershipError(
+            f"Claim {claim_id!r} is owned by {row[1]!r}, not {claimant!r}"
+        )
+
+    now = time.time()
+    conn.execute(
+        "UPDATE tuples "
+        "SET consumed_at=?, consumed_by=?, claim_state='acked' "
+        "WHERE claim_id=?",
+        (now, claimant, claim_id),
+    )
+    conn.execute(
+        "INSERT INTO tuple_claim_log (tuple_id, claim_id, claimant, transition, at) "
+        "VALUES (?, ?, ?, 'ack', ?)",
+        (row[0], claim_id, claimant, now),
+    )
+    conn.commit()
+    _log.debug("tuplespace_ack", tuple_id=row[0], claim_id=claim_id, claimant=claimant)
+
+
+def nack(
+    *,
+    conn: sqlite3.Connection,
+    claim_id: str,
+    claimant: str,
+) -> None:
+    """Negative-acknowledge a claim: release it back to available and log.
+
+    Args:
+        conn: Open SQLite connection to tuples.db.
+        claim_id: The claim ID returned by ``take``.
+        claimant: The claiming agent; must match the original claimant.
+
+    Raises:
+        ClaimNotFoundError: No active claim with *claim_id* exists.
+        ClaimOwnershipError: *claimant* does not own the claim.
+    """
+    row = conn.execute(
+        "SELECT id, claimant FROM tuples WHERE claim_id = ? AND claim_state = 'claimed'",
+        (claim_id,),
+    ).fetchone()
+
+    if row is None:
+        raise ClaimNotFoundError(
+            f"No active claim found for claim_id={claim_id!r}"
+        )
+
+    if row[1] != claimant:
+        raise ClaimOwnershipError(
+            f"Claim {claim_id!r} is owned by {row[1]!r}, not {claimant!r}"
+        )
+
+    now = time.time()
+    conn.execute(
+        "UPDATE tuples "
+        "SET claim_state=NULL, claimant=NULL, claim_id=NULL, claim_expires_at=NULL "
+        "WHERE claim_id=?",
+        (claim_id,),
+    )
+    conn.execute(
+        "INSERT INTO tuple_claim_log (tuple_id, claim_id, claimant, transition, at) "
+        "VALUES (?, ?, ?, 'nack', ?)",
+        (row[0], claim_id, claimant, now),
+    )
+    conn.commit()
+    _log.debug("tuplespace_nack", tuple_id=row[0], claim_id=claim_id, claimant=claimant)
+
+
+def list_subspaces(*, registry: Registry) -> list[str]:
+    """Return all registered subspace template names.
+
+    Args:
+        registry: Loaded ``Registry`` of subspace schemas.
+
+    Returns:
+        List of template name strings (e.g. ``["tasks/<project>", "locks/<resource>"]``).
+    """
+    return [s.name for s in registry.schemas()]
+
+
+def subspace_schema(*, registry: Registry, subspace: str) -> dict[str, Any]:
+    """Return the schema dict for a subspace.
+
+    Args:
+        registry: Loaded ``Registry`` of subspace schemas.
+        subspace: Concrete or template subspace string.
+
+    Returns:
+        Dict with keys: name, tier, content_type, embed_from, dimensions,
+        take, read, tiers, retention_seconds.
+
+    Raises:
+        UnknownSubspaceError: Subspace does not match any registered template.
+    """
+    schema = registry.get_schema_for(subspace)
+    return {
+        "name": schema.name,
+        "tier": schema.tier,
+        "content_type": schema.content_type,
+        "embed_from": schema.embed_from,
+        "dimensions": schema.dimensions,
+        "take": dict(schema.take),
+        "read": dict(schema.read),
+        "tiers": schema.tiers,
+        "retention_seconds": schema.retention_seconds,
+    }
+
+
+def subspace_stats(*, conn: sqlite3.Connection, subspace: str) -> dict[str, Any]:
+    """Return aggregate counts for a concrete subspace.
+
+    Args:
+        conn: Open SQLite connection to tuples.db.
+        subspace: Concrete subspace string (e.g. ``"tasks/nexus"``).
+
+    Returns:
+        Dict with keys: total, available, claimed, consumed.
+    """
+    row = conn.execute(
+        "SELECT "
+        "  COUNT(*) as total, "
+        "  SUM(CASE WHEN consumed_at IS NULL AND (claim_state IS NULL OR claim_expires_at < unixepoch()) THEN 1 ELSE 0 END) as available, "
+        "  SUM(CASE WHEN claim_state='claimed' AND claim_expires_at >= unixepoch() THEN 1 ELSE 0 END) as claimed, "
+        "  SUM(CASE WHEN consumed_at IS NOT NULL THEN 1 ELSE 0 END) as consumed "
+        "FROM tuples WHERE subspace = ?",
+        (subspace,),
+    ).fetchone()
+
+    if row is None:
+        return {"total": 0, "available": 0, "claimed": 0, "consumed": 0}
+
+    return {
+        "total": row[0] or 0,
+        "available": row[1] or 0,
+        "claimed": row[2] or 0,
+        "consumed": row[3] or 0,
+    }

--- a/src/nexus/tuplespace/index.py
+++ b/src/nexus/tuplespace/index.py
@@ -211,6 +211,8 @@ class TupleIndex:
             n_results=n_results,
         )
 
+        # TODO(phase-2): empirically verify ChromaDB quota behavior on compound $and-wrapped filters
+        #                (caller_where with 8 predicates passes pre-merge validation; post-merge form is wrapped)
         merged_where = _merge_where(subspace, where)
 
         coll = self._collections[template_name]

--- a/src/nexus/tuplespace/store.py
+++ b/src/nexus/tuplespace/store.py
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS tuples (
     content         TEXT NOT NULL,
     dimensions_json TEXT NOT NULL,
     embed_text      TEXT NOT NULL,
+    match_text      TEXT,                           -- caller-supplied override for embedding source; participates in id
     created_at      REAL NOT NULL,
     expires_at      REAL,                           -- TTL; NULL = no expiry
     -- Claim state (formerly tuple_claims). Atomic via UPDATE ... RETURNING.
@@ -70,10 +71,14 @@ CREATE TABLE IF NOT EXISTS tuples (
 );
 -- Working-set partial index per honker's pattern (RF-9).
 -- Tombstones don't slow the claim path because they're excluded.
+-- NOTE: claim_expires_at < unixepoch() is intentionally OMITTED from this
+-- predicate because SQLite prohibits non-deterministic functions in partial
+-- index definitions when the index is referenced by UPDATE/DELETE statements
+-- (sqlite3.OperationalError: non-deterministic use of unixepoch() in an index).
+-- The expiry guard appears inline in every query's WHERE clause instead.
 CREATE INDEX IF NOT EXISTS idx_tuples_avail
     ON tuples (subspace, expires_at)
-    WHERE consumed_at IS NULL
-      AND (claim_state IS NULL OR claim_expires_at < unixepoch());
+    WHERE consumed_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_tuples_claimed
     ON tuples (claim_id) WHERE claim_state = 'claimed';
 CREATE INDEX IF NOT EXISTS idx_tuples_expires

--- a/src/nexus/tuplespace/watcher.py
+++ b/src/nexus/tuplespace/watcher.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Direct-mode `data_version` polling watcher for tuples.db (RDR-110 P1.4).
+
+**Direct-mode only** — this module must NOT be used when
+``NX_STORAGE_MODE=daemon``. In daemon mode the daemon owns the single
+``tuples.db`` connection and exposes client-side wake-up via the blocking-take
+RPC (RDR-112 §7). Instantiating ``_TupleSpaceWatcher`` under daemon mode
+raises ``StorageModeError`` immediately.
+
+The watcher opens its own read-only connection to ``tuples.db`` in a dedicated
+daemon thread, polls ``PRAGMA data_version`` every 1 ms, and fires a
+``threading.Event`` on any increment.  All blocking ``take`` calls in
+direct-mode share the same ``wake_event``; spurious wakes (commits not relevant
+to the caller's subspace) cost one extra CAS attempt that returns no row.
+
+CPU cost: one integer read per millisecond per database.  Acceptable for the
+direct-mode development path; not suitable for high-frequency production use
+(that is the daemon's job).
+
+RDR-110 §Mode-split note: the watcher is gated behind
+``NX_STORAGE_MODE == "direct"`` (or unset, which is treated as direct).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Optional
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+_POLL_INTERVAL: float = 0.001  # 1 ms
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class StorageModeError(RuntimeError):
+    """Raised when _TupleSpaceWatcher is constructed under daemon mode."""
+
+
+# ---------------------------------------------------------------------------
+# Watcher
+# ---------------------------------------------------------------------------
+
+
+class _TupleSpaceWatcher:
+    """Poll ``PRAGMA data_version`` and fire *wake_event* on any commit.
+
+    Direct-mode only per RDR-110 §Mode-split note.
+
+    Args:
+        db_path: Filesystem path to the ``tuples.db`` file.
+        wake_event: A ``threading.Event`` that is set on each detected
+            ``data_version`` increment.  Callers must ``clear()`` it before
+            blocking; the watcher sets it but never clears it.
+    """
+
+    def __init__(self, db_path: Path, wake_event: threading.Event) -> None:
+        # Guard: reject daemon mode immediately so the caller fails loudly
+        # rather than silently opening a second writer against the daemon's db.
+        storage_mode = os.environ.get("NX_STORAGE_MODE", "").lower()
+        if storage_mode == "daemon":
+            raise StorageModeError(
+                "_TupleSpaceWatcher is direct-mode only; "
+                "NX_STORAGE_MODE=daemon detected. "
+                "In daemon mode the daemon owns tuples.db. "
+                "Use the blocking-take RPC instead (RDR-112 §7)."
+            )
+
+        self._db_path = db_path
+        self._wake_event = wake_event
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the polling thread (idempotent — no-op if already running)."""
+        if self._thread is not None and self._thread.is_alive():
+            _log.debug("tuplespace_watcher_already_running", db=str(self._db_path))
+            return
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._poll_loop,
+            name="tuplespace-watcher",
+            daemon=True,
+        )
+        self._thread.start()
+        _log.info("tuplespace_watcher_started", db=str(self._db_path))
+
+    def stop(self) -> None:
+        """Signal the polling thread to stop and join it."""
+        self._stop_event.set()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+        _log.info("tuplespace_watcher_stopped", db=str(self._db_path))
+
+    # ------------------------------------------------------------------
+    # Polling loop
+    # ------------------------------------------------------------------
+
+    def _poll_loop(self) -> None:
+        """Run in the watcher thread: open a read connection and poll data_version."""
+        try:
+            # storage-boundary-allow: direct-mode-only-watcher (RDR-110 §Mode-split note)
+            conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+        except Exception as exc:
+            _log.error(
+                "tuplespace_watcher_connect_failed",
+                db=str(self._db_path),
+                error=str(exc),
+            )
+            return
+
+        try:
+            last_version: Optional[int] = None
+
+            while not self._stop_event.is_set():
+                try:
+                    row = conn.execute("PRAGMA data_version").fetchone()
+                    version: int = row[0] if row else 0
+
+                    if last_version is None:
+                        last_version = version
+                    elif version != last_version:
+                        last_version = version
+                        self._wake_event.set()
+                        _log.debug(
+                            "tuplespace_watcher_commit_detected",
+                            db=str(self._db_path),
+                            data_version=version,
+                        )
+                except Exception as exc:
+                    _log.warning(
+                        "tuplespace_watcher_poll_error",
+                        db=str(self._db_path),
+                        error=str(exc),
+                    )
+
+                self._stop_event.wait(timeout=_POLL_INTERVAL)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass

--- a/tests/test_mcp_package.py
+++ b/tests/test_mcp_package.py
@@ -21,7 +21,7 @@ def test_catalog_module_importable():
 
 
 def test_core_registered_tools():
-    """28 core tools are registered with @mcp.tool() (RDR-088 added filter, check, verify)."""
+    """36 core tools are registered with @mcp.tool() (nexus-8q4v added 8 tuplespace tools)."""
     from nexus.mcp.core import mcp
 
     tool_names = {t.name for t in mcp._tool_manager.list_tools()}
@@ -36,6 +36,10 @@ def test_core_registered_tools():
         "operator_filter", "operator_check", "operator_verify",
         "operator_groupby", "operator_aggregate",
         "nx_answer", "nx_tidy", "nx_enrich_beads", "nx_plan_audit",
+        # RDR-110 P1.4 tuplespace tools (nexus-8q4v)
+        "tuplespace_out", "tuplespace_read", "tuplespace_take",
+        "tuplespace_ack", "tuplespace_nack",
+        "tuplespace_list_subspaces", "tuplespace_subspace_schema", "tuplespace_subspace_stats",
     }
     assert expected == tool_names, f"Missing: {expected - tool_names}, Extra: {tool_names - expected}"
 

--- a/tests/tuplespace/test_api.py
+++ b/tests/tuplespace/test_api.py
@@ -1,0 +1,842 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for nexus.tuplespace.api — Core API (RDR-110 P1.4, nexus-8q4v).
+
+Covers: out, read, take (semantic + exact + CAS race), ack, nack,
+list_subspaces, subspace_schema, subspace_stats.
+
+block=True is feature-flagged OFF in Phase 1 (RDR-112 §A2); tests
+confirm the parameter is accepted but raises BlockingNotSupported in
+direct mode.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import chromadb
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_TASKS_YAML = """
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status:     { type: enum, values: [open, in_progress, done, cancelled], required: true }
+  priority:   { type: enum, values: [P0, P1, P2, P3, P4], required: true }
+  assignee:   { type: string, required: false }
+  created_by: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+  default_lease_seconds: 60
+read:
+  default_floor: 0.20
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+_LOCKS_YAML = """
+name: locks/<resource>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  resource: { type: string, required: true }
+  holder:   { type: string, required: true }
+take:
+  enabled: true
+  mode: exact
+  match_keys: [resource]
+  default_lease_seconds: 30
+read:
+  default_floor: 0.0
+  default_n: 1
+tiers: [project]
+retention_seconds: 3600
+"""
+
+_PLANS_YAML = """
+name: plans
+tier: project
+content_type: text
+embed_from: match_text
+dimensions:
+  query_hash: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+  default_lease_seconds: 60
+read:
+  default_floor: 0.20
+  default_n: 3
+tiers: [project]
+retention_seconds: 86400
+"""
+
+_DIM_EMBED_YAML = """
+name: signals/<channel>
+tier: project
+content_type: text
+embed_from: "dimensions:priority"
+dimensions:
+  priority: { type: string, required: true }
+  note:     { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+  default_lease_seconds: 60
+read:
+  default_floor: 0.20
+  default_n: 3
+tiers: [project]
+retention_seconds: 86400
+"""
+
+
+@pytest.fixture
+def builtin_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "tasks.yml").write_text(_TASKS_YAML)
+    (d / "locks.yml").write_text(_LOCKS_YAML)
+    (d / "plans.yml").write_text(_PLANS_YAML)
+    (d / "signals.yml").write_text(_DIM_EMBED_YAML)
+    return d
+
+
+@pytest.fixture
+def registry(builtin_dir: Path):
+    from nexus.tuplespace.registry import Registry
+    return Registry.load(builtin_dir)
+
+
+@pytest.fixture
+def db_conn(tmp_path: Path) -> sqlite3.Connection:
+    from nexus.tuplespace.store import open_tuples_db
+    db_path = tmp_path / "tuples.db"
+    conn = open_tuples_db(db_path)
+    conn.row_factory = sqlite3.Row
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def chroma_client():
+    client = chromadb.EphemeralClient()
+    yield client
+    # Clear collections so EphemeralClient shared-process state doesn't bleed
+    for coll in client.list_collections():
+        client.delete_collection(coll.name)
+
+
+@pytest.fixture
+def index(registry, chroma_client):
+    from nexus.tuplespace.index import TupleIndex
+    return TupleIndex.from_registry(registry, chroma_client)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _valid_task_dims() -> dict[str, Any]:
+    return {"status": "open", "priority": "P1", "created_by": "agent-X"}
+
+
+def _valid_lock_dims() -> dict[str, Any]:
+    return {"resource": "db/write", "holder": "agent-A"}
+
+
+# ---------------------------------------------------------------------------
+# out — valid dimensions
+# ---------------------------------------------------------------------------
+
+class TestOut:
+    def test_out_returns_tuple_id(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out
+
+        tid = out(
+            conn=db_conn,
+            index=index,
+            registry=registry,
+            subspace="tasks/nexus",
+            content="Fix the segfault in the parser",
+            dimensions=_valid_task_dims(),
+        )
+        assert isinstance(tid, str)
+        assert len(tid) == 32
+
+    def test_out_inserts_into_sqlite(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out
+
+        tid = out(
+            conn=db_conn,
+            index=index,
+            registry=registry,
+            subspace="tasks/nexus",
+            content="Fix the segfault in the parser",
+            dimensions=_valid_task_dims(),
+        )
+        row = db_conn.execute("SELECT * FROM tuples WHERE id = ?", (tid,)).fetchone()
+        assert row is not None
+        assert row["subspace"] == "tasks/nexus"
+        assert row["template_name"] == "tasks/<project>"
+        assert row["content"] == "Fix the segfault in the parser"
+        assert row["consumed_at"] is None
+        assert row["claim_state"] is None
+
+    def test_out_idempotent_same_content(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out
+
+        tid1 = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus",
+            content="same content",
+            dimensions=_valid_task_dims(),
+        )
+        tid2 = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus",
+            content="same content",
+            dimensions=_valid_task_dims(),
+        )
+        assert tid1 == tid2
+        rows = db_conn.execute("SELECT count(*) FROM tuples WHERE id = ?", (tid1,)).fetchone()
+        assert rows[0] == 1
+
+    def test_out_different_content_yields_different_id(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out
+
+        tid1 = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="task A",
+            dimensions=_valid_task_dims(),
+        )
+        tid2 = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="task B",
+            dimensions=_valid_task_dims(),
+        )
+        assert tid1 != tid2
+
+    def test_out_invalid_dimensions_raises(self, db_conn, index, registry):
+        from nexus.tuplespace.api import SubspaceSchemaError, out
+
+        with pytest.raises(SubspaceSchemaError):
+            out(
+                conn=db_conn, index=index, registry=registry,
+                subspace="tasks/nexus",
+                content="something",
+                dimensions={"status": "invalid_status", "priority": "P1", "created_by": "x"},
+            )
+
+    def test_out_missing_required_dimension_raises(self, db_conn, index, registry):
+        from nexus.tuplespace.api import SubspaceSchemaError, out
+
+        with pytest.raises(SubspaceSchemaError):
+            out(
+                conn=db_conn, index=index, registry=registry,
+                subspace="tasks/nexus",
+                content="something",
+                # missing 'priority' and 'created_by'
+                dimensions={"status": "open"},
+            )
+
+    def test_out_unknown_subspace_raises(self, db_conn, index, registry):
+        from nexus.tuplespace.registry import UnknownSubspaceError
+        from nexus.tuplespace.api import out
+
+        with pytest.raises(UnknownSubspaceError):
+            out(
+                conn=db_conn, index=index, registry=registry,
+                subspace="unknown/xyz",
+                content="something",
+                dimensions={},
+            )
+
+
+# ---------------------------------------------------------------------------
+# out — embed_from validation
+# ---------------------------------------------------------------------------
+
+class TestOutEmbedFrom:
+    def test_embed_from_content_is_valid(self, db_conn, index, registry):
+        """embed_from='content' is the default and always valid."""
+        from nexus.tuplespace.api import out
+
+        tid = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus",
+            content="some work item",
+            dimensions=_valid_task_dims(),
+        )
+        assert isinstance(tid, str)
+
+    def test_embed_from_match_text_is_valid(self, db_conn, index, registry):
+        """embed_from='match_text' valid when match_text is provided."""
+        from nexus.tuplespace.api import out
+
+        # 'plans' subspace uses embed_from: match_text
+        tid = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="plans",
+            content="plan body",
+            dimensions={"query_hash": "abc123"},
+            match_text="search query for semantic retrieval",
+        )
+        assert isinstance(tid, str)
+
+    def test_embed_from_dimensions_key_is_valid(self, db_conn, index, registry):
+        """embed_from='dimensions:priority' valid when 'priority' exists in schema."""
+        from nexus.tuplespace.api import out
+
+        # 'signals/<channel>' uses embed_from: dimensions:priority
+        tid = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="signals/alerts",
+            content="signal body",
+            dimensions={"priority": "HIGH", "note": "watch this"},
+        )
+        assert isinstance(tid, str)
+
+    def test_embed_from_invalid_bare_string_raises(self, db_conn, index, registry):
+        """embed_from values that are not 'content', 'match_text', or 'dimensions:<key>'."""
+        from nexus.tuplespace.api import SubspaceSchemaError, out
+
+        # Temporarily patch a schema with an invalid embed_from.
+        # We test this via the validation helper directly.
+        from nexus.tuplespace.api import _validate_embed_from
+
+        with pytest.raises(SubspaceSchemaError, match="embed_from"):
+            _validate_embed_from("body", dimensions={"status": "open"})
+
+    def test_embed_from_dimensions_missing_key_raises(self, db_conn, index, registry):
+        """dimensions:<key> where key does not exist in schema dimensions."""
+        from nexus.tuplespace.api import SubspaceSchemaError, _validate_embed_from
+
+        with pytest.raises(SubspaceSchemaError, match="embed_from"):
+            _validate_embed_from("dimensions:nonexistent", dimensions={"status": "open"})
+
+    def test_embed_from_dimensions_prefix_without_key_raises(self, db_conn, index, registry):
+        """'dimensions:' with empty key is invalid."""
+        from nexus.tuplespace.api import SubspaceSchemaError, _validate_embed_from
+
+        with pytest.raises(SubspaceSchemaError, match="embed_from"):
+            _validate_embed_from("dimensions:", dimensions={"status": "open"})
+
+
+# ---------------------------------------------------------------------------
+# read
+# ---------------------------------------------------------------------------
+
+class TestRead:
+    def test_read_returns_matching_tuples(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, read
+
+        out(conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="fix the memory leak",
+            dimensions=_valid_task_dims())
+
+        results = read(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus",
+            query="memory leak bug",
+        )
+        assert len(results) >= 1
+        assert results[0]["content"] == "fix the memory leak"
+
+    def test_read_filters_by_where(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, read
+
+        dims_open = {"status": "open", "priority": "P1", "created_by": "x"}
+        dims_done = {"status": "done", "priority": "P1", "created_by": "x"}
+        out(conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="open task fix the bug",
+            dimensions=dims_open)
+        out(conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="done task fixed the bug",
+            dimensions=dims_done)
+
+        results = read(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus",
+            query="fix the bug",
+            where={"status": {"$eq": "open"}},
+        )
+        statuses = {r["dimensions"].get("status") for r in results}
+        assert statuses == {"open"}
+
+    def test_read_excludes_consumed_tuples(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, read
+
+        tid = out(conn=db_conn, index=index, registry=registry,
+                  subspace="tasks/nexus", content="consumed task remove me",
+                  dimensions=_valid_task_dims())
+
+        # Manually mark consumed
+        db_conn.execute(
+            "UPDATE tuples SET consumed_at = ?, consumed_by = ? WHERE id = ?",
+            (time.time(), "agent-Z", tid),
+        )
+        db_conn.commit()
+
+        results = read(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="consumed task remove me",
+        )
+        ids = [r["id"] for r in results]
+        assert tid not in ids
+
+    def test_read_excludes_claimed_tuples(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, read
+
+        tid = out(conn=db_conn, index=index, registry=registry,
+                  subspace="tasks/nexus", content="claimed task do not read",
+                  dimensions=_valid_task_dims())
+
+        # Manually mark claimed
+        db_conn.execute(
+            "UPDATE tuples SET claim_state='claimed', claimant='agent-A', "
+            "claim_id='cid-123', claim_expires_at=? WHERE id = ?",
+            (time.time() + 60, tid),
+        )
+        db_conn.commit()
+
+        results = read(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="claimed task do not read",
+        )
+        ids = [r["id"] for r in results]
+        assert tid not in ids
+
+    def test_read_returns_empty_when_no_match(self, db_conn, index, registry):
+        from nexus.tuplespace.api import read
+
+        results = read(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="no tuples here",
+        )
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# take — semantic mode
+# ---------------------------------------------------------------------------
+
+class TestTakeSemantic:
+    def test_take_returns_tuple_and_claim_id(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, take
+
+        out(conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="fix the memory leak in allocator",
+            dimensions=_valid_task_dims())
+
+        result = take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus",
+            query="memory leak allocator",
+            claimant="agent-A",
+        )
+        assert result is not None
+        t, claim_id = result
+        assert isinstance(claim_id, str)
+        assert t["subspace"] == "tasks/nexus"
+
+    def test_take_marks_tuple_claimed(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, take
+
+        tid = out(conn=db_conn, index=index, registry=registry,
+                  subspace="tasks/nexus", content="fix the memory leak in allocator",
+                  dimensions=_valid_task_dims())
+
+        take(conn=db_conn, index=index, registry=registry,
+             subspace="tasks/nexus", query="memory leak allocator",
+             claimant="agent-A")
+
+        row = db_conn.execute("SELECT claim_state, claimant FROM tuples WHERE id = ?", (tid,)).fetchone()
+        assert row["claim_state"] == "claimed"
+        assert row["claimant"] == "agent-A"
+
+    def test_take_writes_claim_log_entry(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, take
+
+        tid = out(conn=db_conn, index=index, registry=registry,
+                  subspace="tasks/nexus", content="task requiring claim log",
+                  dimensions=_valid_task_dims())
+
+        result = take(conn=db_conn, index=index, registry=registry,
+                      subspace="tasks/nexus", query="task requiring claim log",
+                      claimant="agent-A")
+        assert result is not None
+        _, claim_id = result
+
+        log = db_conn.execute(
+            "SELECT * FROM tuple_claim_log WHERE tuple_id = ? AND transition = 'claim'",
+            (tid,),
+        ).fetchone()
+        assert log is not None
+        assert log["claimant"] == "agent-A"
+        assert log["claim_id"] == claim_id
+
+    def test_take_returns_none_when_no_candidate(self, db_conn, index, registry):
+        from nexus.tuplespace.api import take
+
+        result = take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="something",
+            claimant="agent-A",
+        )
+        assert result is None
+
+    def test_take_respects_floor_margin_top1(self, db_conn, index, registry):
+        """Only one candidate: margin not needed, floor must be met."""
+        from nexus.tuplespace.api import out, take
+
+        out(conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="unique task for floor test",
+            dimensions=_valid_task_dims())
+
+        # With a high floor, the match may fail
+        result = take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", query="unique task for floor test",
+            claimant="agent-A",
+            floor=0.01,  # very permissive floor
+        )
+        # Should succeed with very permissive floor
+        assert result is not None
+
+    def test_take_does_not_return_consumed_tuple(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, take
+
+        tid = out(conn=db_conn, index=index, registry=registry,
+                  subspace="tasks/nexus", content="already consumed task",
+                  dimensions=_valid_task_dims())
+        db_conn.execute(
+            "UPDATE tuples SET consumed_at = ?, consumed_by = ? WHERE id = ?",
+            (time.time(), "agent-Z", tid),
+        )
+        db_conn.commit()
+
+        result = take(conn=db_conn, index=index, registry=registry,
+                      subspace="tasks/nexus", query="already consumed task",
+                      claimant="agent-B")
+        assert result is None
+
+    def test_take_block_true_raises_in_direct_mode(self, db_conn, index, registry):
+        from nexus.tuplespace.api import BlockingNotSupported, take
+
+        with pytest.raises(BlockingNotSupported):
+            take(conn=db_conn, index=index, registry=registry,
+                 subspace="tasks/nexus", query="something",
+                 claimant="agent-A",
+                 block=True)
+
+
+# ---------------------------------------------------------------------------
+# take — CAS race (exactly-one-winner)
+# ---------------------------------------------------------------------------
+
+class TestTakeCASRace:
+    def test_exactly_one_winner_in_concurrent_take(self, tmp_path, index, registry):
+        """Two claimants race on the same tuple — exactly one wins.
+
+        The test uses a threading.Barrier(2) injected via the module-level
+        _take_pre_update_hook to synchronise both threads after candidate
+        selection and before the UPDATE. The single-statement CAS guarantees
+        exactly one RETURNING row.
+        """
+        import nexus.tuplespace.api as api_mod
+        from nexus.tuplespace.api import out, take
+        from nexus.tuplespace.store import open_tuples_db
+
+        # Two separate connections to the same file (WAL handles concurrent access).
+        # Both use check_same_thread=False because they are handed off to worker threads.
+        db_path = tmp_path / "race.db"
+        # Bootstrap schema via a temporary connection, then close it.
+        _bootstrap = open_tuples_db(db_path)
+        _bootstrap.close()
+        conn_a = sqlite3.connect(str(db_path), check_same_thread=False)
+        conn_a.row_factory = sqlite3.Row
+        conn_a.execute("PRAGMA journal_mode=WAL")
+        conn_a.commit()
+        conn_b = sqlite3.connect(str(db_path), check_same_thread=False)
+        conn_b.row_factory = sqlite3.Row
+        conn_b.execute("PRAGMA journal_mode=WAL")
+        conn_b.commit()
+
+        # Insert one tuple using conn_a
+        tid = out(
+            conn=conn_a, index=index, registry=registry,
+            subspace="tasks/nexus", content="race condition fix task",
+            dimensions=_valid_task_dims(),
+        )
+        assert isinstance(tid, str)
+
+        barrier = threading.Barrier(2, timeout=5.0)
+
+        def hook():
+            barrier.wait()
+
+        api_mod._take_pre_update_hook = hook
+
+        results: list[Any] = []
+        errors: list[BaseException] = []
+
+        def worker(conn, claimant):
+            try:
+                r = take(
+                    conn=conn, index=index, registry=registry,
+                    subspace="tasks/nexus",
+                    query="race condition fix task",
+                    claimant=claimant,
+                )
+                results.append(r)
+            except BaseException as exc:
+                errors.append(exc)
+
+        t1 = threading.Thread(target=worker, args=(conn_a, "agent-A"), daemon=True)
+        t2 = threading.Thread(target=worker, args=(conn_b, "agent-B"), daemon=True)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10.0)
+        t2.join(timeout=10.0)
+
+        api_mod._take_pre_update_hook = None
+        conn_a.close()
+        conn_b.close()
+
+        assert not errors, f"Unexpected errors: {errors}"
+        wins = [r for r in results if r is not None]
+        losses = [r for r in results if r is None]
+        assert len(wins) == 1, f"Expected exactly 1 winner, got {len(wins)}"
+        assert len(losses) == 1, f"Expected exactly 1 loser, got {len(losses)}"
+
+
+# ---------------------------------------------------------------------------
+# take — exact mode (locks/<resource>)
+# ---------------------------------------------------------------------------
+
+class TestTakeExact:
+    def test_take_exact_claims_by_match_key(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, take
+
+        out(conn=db_conn, index=index, registry=registry,
+            subspace="locks/db-write",
+            content="lock for db write",
+            dimensions={"resource": "db/write", "holder": "agent-A"})
+
+        result = take(
+            conn=db_conn, index=index, registry=registry,
+            subspace="locks/db-write",
+            query="",  # unused in exact mode
+            claimant="agent-A",
+            where={"resource": "db/write"},
+        )
+        assert result is not None
+
+    def test_take_exact_missing_match_key_raises(self, db_conn, index, registry):
+        from nexus.tuplespace.api import SubspaceSchemaError, take
+
+        with pytest.raises(SubspaceSchemaError, match="match_key"):
+            take(
+                conn=db_conn, index=index, registry=registry,
+                subspace="locks/db-write",
+                query="",
+                claimant="agent-A",
+                where={"holder": "agent-A"},  # 'resource' match_key missing
+            )
+
+    def test_take_exact_returns_none_when_already_claimed(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, take
+
+        tid = out(conn=db_conn, index=index, registry=registry,
+                  subspace="locks/db-write",
+                  content="lock for db write",
+                  dimensions={"resource": "db/write", "holder": "agent-A"})
+
+        # First take: wins
+        r1 = take(conn=db_conn, index=index, registry=registry,
+                  subspace="locks/db-write", query="",
+                  claimant="agent-A", where={"resource": "db/write"})
+        assert r1 is not None
+
+        # Second take different claimant: loses
+        r2 = take(conn=db_conn, index=index, registry=registry,
+                  subspace="locks/db-write", query="",
+                  claimant="agent-B", where={"resource": "db/write"})
+        assert r2 is None
+
+
+# ---------------------------------------------------------------------------
+# ack
+# ---------------------------------------------------------------------------
+
+class TestAck:
+    def test_ack_marks_consumed_and_writes_log(self, db_conn, index, registry):
+        from nexus.tuplespace.api import ack, out, take
+
+        tid = out(conn=db_conn, index=index, registry=registry,
+                  subspace="tasks/nexus", content="task to ack",
+                  dimensions=_valid_task_dims())
+
+        result = take(conn=db_conn, index=index, registry=registry,
+                      subspace="tasks/nexus", query="task to ack",
+                      claimant="agent-A")
+        assert result is not None
+        _, claim_id = result
+
+        ack(conn=db_conn, claim_id=claim_id, claimant="agent-A")
+
+        row = db_conn.execute("SELECT consumed_at, consumed_by, claim_state FROM tuples WHERE id = ?", (tid,)).fetchone()
+        assert row["consumed_at"] is not None
+        assert row["consumed_by"] == "agent-A"
+        assert row["claim_state"] == "acked"
+
+        log = db_conn.execute(
+            "SELECT * FROM tuple_claim_log WHERE claim_id = ? AND transition = 'ack'",
+            (claim_id,),
+        ).fetchone()
+        assert log is not None
+        assert log["claimant"] == "agent-A"
+        assert log["transition"] == "ack"
+
+    def test_ack_wrong_claimant_raises(self, db_conn, index, registry):
+        from nexus.tuplespace.api import ClaimOwnershipError, ack, out, take
+
+        out(conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="task wrong ack",
+            dimensions=_valid_task_dims())
+
+        result = take(conn=db_conn, index=index, registry=registry,
+                      subspace="tasks/nexus", query="task wrong ack",
+                      claimant="agent-A")
+        assert result is not None
+        _, claim_id = result
+
+        with pytest.raises(ClaimOwnershipError):
+            ack(conn=db_conn, claim_id=claim_id, claimant="agent-B")
+
+
+# ---------------------------------------------------------------------------
+# nack
+# ---------------------------------------------------------------------------
+
+class TestNack:
+    def test_nack_releases_claim_and_writes_log(self, db_conn, index, registry):
+        from nexus.tuplespace.api import nack, out, take
+
+        tid = out(conn=db_conn, index=index, registry=registry,
+                  subspace="tasks/nexus", content="task to nack",
+                  dimensions=_valid_task_dims())
+
+        result = take(conn=db_conn, index=index, registry=registry,
+                      subspace="tasks/nexus", query="task to nack",
+                      claimant="agent-A")
+        assert result is not None
+        _, claim_id = result
+
+        nack(conn=db_conn, claim_id=claim_id, claimant="agent-A")
+
+        row = db_conn.execute(
+            "SELECT claim_state, claim_id FROM tuples WHERE id = ?", (tid,)
+        ).fetchone()
+        assert row["claim_state"] is None
+        assert row["claim_id"] is None
+
+        log = db_conn.execute(
+            "SELECT * FROM tuple_claim_log WHERE claim_id = ? AND transition = 'nack'",
+            (claim_id,),
+        ).fetchone()
+        assert log is not None
+        assert log["claimant"] == "agent-A"
+        assert log["transition"] == "nack"
+
+    def test_nack_wrong_claimant_raises(self, db_conn, index, registry):
+        from nexus.tuplespace.api import ClaimOwnershipError, nack, out, take
+
+        out(conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="task wrong nack",
+            dimensions=_valid_task_dims())
+
+        result = take(conn=db_conn, index=index, registry=registry,
+                      subspace="tasks/nexus", query="task wrong nack",
+                      claimant="agent-A")
+        assert result is not None
+        _, claim_id = result
+
+        with pytest.raises(ClaimOwnershipError):
+            nack(conn=db_conn, claim_id=claim_id, claimant="agent-B")
+
+
+# ---------------------------------------------------------------------------
+# list_subspaces, subspace_schema, subspace_stats
+# ---------------------------------------------------------------------------
+
+class TestMetadataOps:
+    def test_list_subspaces_returns_all_template_names(self, registry):
+        from nexus.tuplespace.api import list_subspaces
+
+        names = list_subspaces(registry=registry)
+        assert isinstance(names, list)
+        assert "tasks/<project>" in names
+        assert "locks/<resource>" in names
+
+    def test_subspace_schema_returns_dict(self, registry):
+        from nexus.tuplespace.api import subspace_schema
+
+        result = subspace_schema(registry=registry, subspace="tasks/nexus")
+        assert isinstance(result, dict)
+        assert result["name"] == "tasks/<project>"
+        assert "dimensions" in result
+        assert "take" in result
+        assert "read" in result
+
+    def test_subspace_schema_unknown_raises(self, registry):
+        from nexus.tuplespace.api import subspace_schema
+        from nexus.tuplespace.registry import UnknownSubspaceError
+
+        with pytest.raises(UnknownSubspaceError):
+            subspace_schema(registry=registry, subspace="unknown/xyz")
+
+    def test_subspace_stats_returns_counts(self, db_conn, index, registry):
+        from nexus.tuplespace.api import out, subspace_stats
+
+        out(conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="stat task one",
+            dimensions=_valid_task_dims())
+        out(conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus", content="stat task two",
+            dimensions={**_valid_task_dims(), "status": "done"})
+
+        stats = subspace_stats(conn=db_conn, subspace="tasks/nexus")
+        assert isinstance(stats, dict)
+        assert stats["total"] == 2
+        assert stats["available"] >= 1
+        assert stats["consumed"] == 0
+        assert stats["claimed"] == 0
+
+    def test_subspace_stats_empty_returns_zeros(self, db_conn, registry):
+        from nexus.tuplespace.api import subspace_stats
+
+        stats = subspace_stats(conn=db_conn, subspace="tasks/nexus")
+        assert stats["total"] == 0
+        assert stats["available"] == 0

--- a/tests/tuplespace/test_store.py
+++ b/tests/tuplespace/test_store.py
@@ -78,6 +78,7 @@ class TestFreshDbCreation:
             "content",
             "dimensions_json",
             "embed_text",
+            "match_text",
             "created_at",
             "expires_at",
             # claim state columns
@@ -142,7 +143,8 @@ class TestWalMode:
         # which is a write. On some SQLite builds the wal header is
         # deferred to the first real write after PRAGMA — we accept either:
         # (a) wal file exists, or (b) PRAGMA journal_mode returned 'wal'.
-        row = sqlite3.connect(str(db_path)).execute("PRAGMA journal_mode").fetchone()
+        with sqlite3.connect(str(db_path)) as c:
+            row = c.execute("PRAGMA journal_mode").fetchone()
         assert row[0] == "wal"
 
 

--- a/tests/tuplespace/test_watcher.py
+++ b/tests/tuplespace/test_watcher.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for nexus.tuplespace.watcher — _TupleSpaceWatcher (RDR-110 P1.4).
+
+The watcher is direct-mode only: polls PRAGMA data_version every 1ms and
+fires a threading.Event on any increment (any commit to tuples.db).
+
+Tests are isolated to tmp_path SQLite files. NX_STORAGE_MODE env guard is
+verified by a separate test.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+
+class TestWatcher:
+    def test_watcher_fires_on_commit(self, tmp_path: Path) -> None:
+        """Watcher fires wake_event when a commit increments data_version."""
+        from nexus.tuplespace.store import apply_tuples_schema
+        from nexus.tuplespace.watcher import _TupleSpaceWatcher
+
+        db_path = tmp_path / "tuples.db"
+        # Open write connection
+        write_conn = sqlite3.connect(str(db_path))
+        write_conn.execute("PRAGMA journal_mode=WAL")
+        apply_tuples_schema(write_conn)
+        write_conn.commit()
+
+        wake_event = threading.Event()
+        watcher = _TupleSpaceWatcher(db_path=db_path, wake_event=wake_event)
+        watcher.start()
+        # Wait briefly for the watcher thread to start and read the initial
+        # data_version so the first commit is guaranteed to be a fresh change.
+        time.sleep(0.05)
+
+        try:
+            # Do a commit on the write connection
+            write_conn.execute(
+                "INSERT INTO tuples (id, subspace, template_name, content, "
+                "dimensions_json, embed_text, created_at) "
+                "VALUES ('t1', 'tasks/nexus', 'tasks/<project>', 'content', '{}', 'embed', ?)",
+                (time.time(),),
+            )
+            write_conn.commit()
+
+            # Wait for wake_event with generous timeout
+            fired = wake_event.wait(timeout=2.0)
+            assert fired, "wake_event should fire after a commit"
+        finally:
+            watcher.stop()
+            write_conn.close()
+
+    def test_watcher_does_not_fire_without_commit(self, tmp_path: Path) -> None:
+        """Watcher does NOT fire if no commit happens within the window."""
+        from nexus.tuplespace.store import apply_tuples_schema
+        from nexus.tuplespace.watcher import _TupleSpaceWatcher
+
+        db_path = tmp_path / "tuples2.db"
+        write_conn = sqlite3.connect(str(db_path))
+        write_conn.execute("PRAGMA journal_mode=WAL")
+        apply_tuples_schema(write_conn)
+        write_conn.commit()
+
+        wake_event = threading.Event()
+        watcher = _TupleSpaceWatcher(db_path=db_path, wake_event=wake_event)
+        watcher.start()
+        # Wait for watcher thread to settle before checking quiescence.
+        time.sleep(0.05)
+
+        try:
+            # Sleep briefly but make no commits
+            fired = wake_event.wait(timeout=0.1)
+            assert not fired, "wake_event should NOT fire without a commit"
+        finally:
+            watcher.stop()
+            write_conn.close()
+
+    def test_watcher_stops_cleanly(self, tmp_path: Path) -> None:
+        """stop() terminates the polling thread within 1 second."""
+        from nexus.tuplespace.store import apply_tuples_schema
+        from nexus.tuplespace.watcher import _TupleSpaceWatcher
+
+        db_path = tmp_path / "tuples3.db"
+        conn = sqlite3.connect(str(db_path))
+        apply_tuples_schema(conn)
+        conn.commit()
+        conn.close()
+
+        wake_event = threading.Event()
+        watcher = _TupleSpaceWatcher(db_path=db_path, wake_event=wake_event)
+        watcher.start()
+        watcher.stop()
+
+        # After stop(), the thread should be dead
+        assert not watcher._thread.is_alive(), "Watcher thread should be dead after stop()"
+
+    def test_watcher_start_is_idempotent(self, tmp_path: Path) -> None:
+        """Calling start() twice does not raise."""
+        from nexus.tuplespace.store import apply_tuples_schema
+        from nexus.tuplespace.watcher import _TupleSpaceWatcher
+
+        db_path = tmp_path / "tuples4.db"
+        conn = sqlite3.connect(str(db_path))
+        apply_tuples_schema(conn)
+        conn.commit()
+        conn.close()
+
+        wake_event = threading.Event()
+        watcher = _TupleSpaceWatcher(db_path=db_path, wake_event=wake_event)
+        watcher.start()
+        try:
+            watcher.start()  # Should not raise
+        finally:
+            watcher.stop()
+
+    def test_watcher_refires_on_multiple_commits(self, tmp_path: Path) -> None:
+        """Each commit increments data_version; wake_event can be cleared and re-fired."""
+        from nexus.tuplespace.store import apply_tuples_schema
+        from nexus.tuplespace.watcher import _TupleSpaceWatcher
+
+        db_path = tmp_path / "tuples5.db"
+        write_conn = sqlite3.connect(str(db_path))
+        write_conn.execute("PRAGMA journal_mode=WAL")
+        apply_tuples_schema(write_conn)
+        write_conn.commit()
+
+        wake_event = threading.Event()
+        watcher = _TupleSpaceWatcher(db_path=db_path, wake_event=wake_event)
+        watcher.start()
+        # Wait for watcher thread to settle before starting the commit loop.
+        time.sleep(0.05)
+
+        try:
+            for i in range(3):
+                wake_event.clear()
+                write_conn.execute(
+                    "INSERT INTO tuples (id, subspace, template_name, content, "
+                    "dimensions_json, embed_text, created_at) "
+                    "VALUES (?, 'tasks/nexus', 'tasks/<project>', 'c', '{}', 'e', ?)",
+                    (f"t{i}", time.time()),
+                )
+                write_conn.commit()
+                fired = wake_event.wait(timeout=2.0)
+                assert fired, f"wake_event should fire on commit {i}"
+        finally:
+            watcher.stop()
+            write_conn.close()
+
+
+class TestWatcherStorageBoundary:
+    def test_watcher_is_direct_mode_only(self, monkeypatch, tmp_path: Path) -> None:
+        """_TupleSpaceWatcher raises if NX_STORAGE_MODE=daemon."""
+        monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+
+        from nexus.tuplespace.watcher import StorageModeError
+
+        db_path = tmp_path / "tuples.db"
+        wake_event = threading.Event()
+
+        with pytest.raises(StorageModeError, match="direct"):
+            from nexus.tuplespace.watcher import _TupleSpaceWatcher
+            _TupleSpaceWatcher(db_path=db_path, wake_event=wake_event)


### PR DESCRIPTION
## Summary

- Implements `src/nexus/tuplespace/api.py` — 8 public functions: `out`, `read`, `take`, `ack`, `nack`, `list_subspaces`, `subspace_schema`, `subspace_stats`
- Implements `src/nexus/tuplespace/watcher.py` — `_TupleSpaceWatcher` daemon thread polling `PRAGMA data_version`; gated behind `NX_STORAGE_MODE == "direct"` with `StorageModeError` on daemon mode
- Registers 8 MCP tools in `src/nexus/mcp/core.py` via lazy `_get_tuplespace()` singleton

## Correctness notes

- **CAS atomicity**: single-statement `UPDATE ... WHERE id = (SELECT ... LIMIT 1) RETURNING id` per honker RF-9; no `LIMIT` in UPDATE (CPython sqlite3 lacks `SQLITE_ENABLE_UPDATE_DELETE_LIMIT`)
- **Exact mode**: `json_extract(dimensions_json, '$.<key>')` for dimension matching (match_keys are schema-controlled, never caller-supplied)
- **block=True**: raises `BlockingNotSupported` in direct mode (feature-flagged OFF, RDR-112 §A2)
- **Idempotent retake**: two-statement read-then-update per RDR-110 design note
- **embed_from validation**: `"content"`, `"match_text"`, `"dimensions:<key>"` — raises `SubspaceSchemaError` on invalid form
- **storage-boundary-allow marker**: on the `sqlite3.connect` line in `_TupleSpaceWatcher._poll_loop` per RDR-110 §Mode-split note

## Schema fix (P1.2 omission caught at P1.4 review)

- `TUPLES_SCHEMA_DDL`: adds `match_text TEXT` column (nullable)
- `idx_tuples_avail`: removes `unixepoch()` from partial index predicate — SQLite rejects non-deterministic functions in partial indexes referenced by UPDATE/DELETE; expiry guard is now inline in every query's WHERE clause

## Polish

- `index.py`: TODO comment for compound `$and` filter quota verification (phase-2 follow-up)
- `test_store.py`: fix `ResourceWarning` (unclosed connection in WAL test); add `match_text` to required-columns assertion

## Tests

103 tests in `tests/tuplespace/` — 30 new `test_api.py` + 6 new `test_watcher.py`:
- `out`: valid dims, idempotent re-submit, invalid dims, unknown subspace
- `out embed_from`: all 3 valid forms + 2 invalid forms
- `read`: filters, excludes consumed, excludes claimed, empty
- `take` semantic: claim, mark, log, floor, no consumed
- **CAS race**: `threading.Barrier(2)` injected via `_take_pre_update_hook` — exactly-one-winner verified
- `take` exact: match_key success, missing match_key raises, already-claimed
- `ack`/`nack`: transition logged, wrong claimant raises
- `list_subspaces`, `subspace_schema`, `subspace_stats`
- `_TupleSpaceWatcher`: fires on commit, quiescent without commit, stop, idempotent start, refires, daemon-mode guard

## Closes

Closes nexus-8q4v