### PR TITLE
feat(rdr-112): daemon-startup migration runner + watcher_state DDL (nexus-w0et)

### DIFF
--- a/src/nexus/daemon/t2_client.py
+++ b/src/nexus/daemon/t2_client.py
@@ -71,11 +71,30 @@ import structlog
 
 from nexus.daemon.t2_daemon import (
     DAEMON_PROTOCOL_VERSION,
+    DAEMON_SCHEMA_VERSION,
     t2_json_dumps,
     t2_json_loads,
 )
 
 _log = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Schema-version handshake constant (nexus-w0et RDR-112 P1.4)
+# ---------------------------------------------------------------------------
+
+#: Expected schema version from the daemon's hello_ack.
+#:
+#: The daemon includes ``schema_version: int`` in its hello_ack response.
+#: The client compares against this constant and raises ``T2DaemonError``
+#: with a directional instruction on mismatch:
+#:
+#: * ``client_version > daemon_version`` — daemon is older; restart it so
+#:   the migration runner applies the missing migrations automatically.
+#: * ``client_version < daemon_version`` — daemon is newer; upgrade the
+#:   client package.
+#:
+#: Mutable at module level so tests can monkey-patch it without subclassing.
+T2_SCHEMA_VERSION_EXPECTED: int = DAEMON_SCHEMA_VERSION
 
 # ---------------------------------------------------------------------------
 # Public exception
@@ -449,7 +468,10 @@ class T2Client:
     """
 
     # Constants
-    # nexus-w0et (P1.4 migration runner): add EXPECTED_SCHEMA_VERSION here.
+    # nexus-w0et (P1.4 migration runner): schema version handshake.
+    # Must match DAEMON_SCHEMA_VERSION in t2_daemon.py. Integer comparison
+    # avoids version-string ordering bugs. Mismatch raises T2DaemonError
+    # with a directional upgrade instruction before any RPC is issued.
 
     def __init__(
         self,
@@ -511,10 +533,36 @@ class T2Client:
             raise T2DaemonError(
                 f"expected hello_ack, got {ack.get('op')!r}"
             )
+
+        # --- Schema-version handshake (nexus-w0et RDR-112 P1.4) ---
+        daemon_sv = ack.get("schema_version")
+        if daemon_sv is not None:
+            # Read from the module-level constant so tests can monkey-patch it
+            # by assigning to nexus.daemon.t2_client.T2_SCHEMA_VERSION_EXPECTED.
+            import sys as _sys  # noqa: PLC0415
+            _mod = _sys.modules[__name__]
+            expected_sv: int = _mod.T2_SCHEMA_VERSION_EXPECTED
+            if expected_sv > daemon_sv:
+                sock.close()
+                raise T2DaemonError(
+                    f"Daemon schema version is older than this client expects "
+                    f"(daemon={daemon_sv}, client expects={expected_sv}). "
+                    "Run: nx daemon t2 stop && nx daemon t2 start "
+                    "(migration applies automatically)."
+                )
+            if expected_sv < daemon_sv:
+                sock.close()
+                raise T2DaemonError(
+                    f"Daemon schema version is newer than this client "
+                    f"(daemon={daemon_sv}, client expects={expected_sv}). "
+                    "Upgrade conexus: uv pip install -U conexus."
+                )
+
         _log.debug(
             "t2_client_connected",
             transport="uds" if self._uds_path else "tcp",
             daemon_version=ack.get("daemon_version"),
+            schema_version=daemon_sv,
         )
         return _SocketConnection(sock)
 

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -82,6 +82,15 @@ _log = structlog.get_logger(__name__)
 #: contract changes in a backward-incompatible way.
 DAEMON_PROTOCOL_VERSION: str = "1.0"
 
+#: Schema version for the T2 + tuples.db databases managed by this daemon.
+#: Represents the highest migration version in the MIGRATIONS registry that
+#: this daemon version applies. Clients compare their
+#: ``T2_SCHEMA_VERSION_EXPECTED`` against this value in the hello_ack to
+#: detect schema drift before issuing any RPC.
+#: Integer (monotonically increasing) to avoid version-string comparison bugs.
+#: nexus-w0et (RDR-112 P1.4): initial value = 1 (watcher_state era).
+DAEMON_SCHEMA_VERSION: int = 1
+
 #: Nexus package version embedded in discovery file and pong responses.
 try:
     from importlib.metadata import version as _pkg_version
@@ -433,13 +442,30 @@ class T2Daemon:
     async def start(self) -> None:
         """Bind both transports, write discovery file, announce to stdout.
 
+        Migration ownership (RDR-112 P1.4 / nexus-w0et): applies all pending
+        T2 migrations to both ``memory.db`` and ``tuples.db`` BEFORE binding
+        any socket. No client can connect to a partially-migrated daemon.
+
         Raises:
             RuntimeError: if the spawn lock is already held (another daemon
                 is running for this UID / config_dir).
+            MigrationError: if a data-precondition migration audit fails.
         """
         self._acquire_spawn_lock()
         self._ensure_dirs()
         self._start_time = datetime.now(timezone.utc).isoformat()
+
+        # --- Migration runner: BEFORE sockets are bound (RDR-112 P1.4) ---
+        from nexus.db.migrations import run_daemon_migrations  # noqa: PLC0415
+
+        memory_db_path = self._config_dir / "memory.db"
+        tuples_db_path = self._config_dir / "tuples.db"
+        from_ver, to_ver = run_daemon_migrations(memory_db_path, tuples_db_path)
+        _log.info(
+            "daemon/t2/lifecycle",
+            op="migration-applied",
+            **{"from": from_ver, "to": to_ver},
+        )
 
         uds_sock = self._bind_uds()
         tcp_sock = self._bind_tcp()
@@ -476,8 +502,13 @@ class T2Daemon:
                 except asyncio.TimeoutError:
                     _log.warning("t2_daemon_stop_timeout", which=repr(srv))
 
-        # Drain in-flight handlers
+        # Cancel and drain in-flight handlers.
+        # Without cancellation, handlers blocked in read_frame() (60-second
+        # timeout) would keep stop() waiting for up to 60 seconds after
+        # servers stop accepting. Cancelling lets the gather complete promptly.
         if self._active_handlers:
+            for task in list(self._active_handlers):
+                task.cancel()
             await asyncio.gather(*self._active_handlers, return_exceptions=True)
 
         self._unlink_discovery()
@@ -661,6 +692,7 @@ class T2Daemon:
                 "op": "hello_ack",
                 "daemon_protocol_version": DAEMON_PROTOCOL_VERSION,
                 "daemon_version": _NEXUS_VERSION,
+                "schema_version": DAEMON_SCHEMA_VERSION,
             },
         )
         await writer.drain()
@@ -709,6 +741,7 @@ class T2Daemon:
                     "pong": True,
                     "version": _NEXUS_VERSION,
                     "daemon_protocol_version": DAEMON_PROTOCOL_VERSION,
+                    "schema_version": DAEMON_SCHEMA_VERSION,
                     "start_time": self._start_time,
                     "pid": os.getpid(),
                 }

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -2546,6 +2546,68 @@ def _migrate_aspect_queue_pk_via_apply_pending(conn: sqlite3.Connection) -> None
     migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=catalog_path)
 
 
+# ── RDR-112 P1.4 (nexus-w0et): watcher_state in tuples.db ──────────────────
+
+
+def _tuples_db_path_from_conn(conn: sqlite3.Connection) -> Path:
+    """Derive the tuples.db path from a memory.db connection.
+
+    Mirrors the layout convention: tuples.db is a sibling of memory.db under
+    the same nexus config dir. Falls back to NEXUS_CONFIG_DIR env or the
+    default ``~/.config/nexus`` when the connection path is not resolvable
+    (e.g. in-memory DB in tests that don't need tuples.db).
+    """
+    for row in conn.execute("PRAGMA database_list").fetchall():
+        if row[1] == "main" and row[2]:
+            mem_path = Path(row[2]).resolve()
+            return mem_path.parent / "tuples.db"
+
+    import os as _os
+    override = _os.environ.get("NEXUS_CONFIG_DIR", "").strip()
+    if override:
+        return Path(override) / "tuples.db"
+    return Path.home() / ".config" / "nexus" / "tuples.db"
+
+
+def _migrate_watcher_state_in_tuples_db(conn: sqlite3.Connection) -> None:
+    """Create watcher_state (and other tuples.db tables) in the sibling tuples.db.
+
+    RDR-111 Phase 2 Step 6 / RDR-112 P1.4 (nexus-w0et).
+
+    watcher_state lives in tuples.db (not memory.db) for genuine atomicity
+    with cursor and tuple reads (RDR-111 lines 783-786). This migration
+    wrapper:
+
+    1. Derives the tuples.db path from the memory.db connection (the
+       standard nexus layout: both files share the same config dir).
+    2. Opens the tuples.db file with WAL mode (or creates it if absent).
+    3. Applies the full TUPLES_SCHEMA_DDL (idempotent via
+       ``CREATE TABLE IF NOT EXISTS`` / ``CREATE INDEX IF NOT EXISTS``).
+
+    Idempotent: the tuples schema DDL uses CREATE IF NOT EXISTS throughout,
+    so re-running on an already-initialised tuples.db is a guaranteed no-op.
+
+    This is registered in MIGRATIONS at "4.33.0" — the daemon is the sole
+    migration runner for both databases per RDR-112 §9.
+    """
+    from nexus.tuplespace.store import apply_tuples_schema  # noqa: PLC0415
+
+    tuples_path = _tuples_db_path_from_conn(conn)
+    tuples_path.parent.mkdir(parents=True, exist_ok=True)
+    tuples_conn = sqlite3.connect(str(tuples_path))
+    try:
+        tuples_conn.execute("PRAGMA journal_mode=WAL")
+        tuples_conn.execute("PRAGMA busy_timeout=5000")
+        tuples_conn.commit()
+        apply_tuples_schema(tuples_conn)
+        _log.info(
+            "migration_watcher_state_applied",
+            tuples_db=str(tuples_path),
+        )
+    finally:
+        tuples_conn.close()
+
+
 MIGRATIONS: list[Migration] = [
     Migration("1.10.0", "Memory FTS rebuild with title", migrate_memory_fts),
     Migration("2.8.0", "Add plan project column", migrate_plan_project),
@@ -2715,6 +2777,17 @@ MIGRATIONS: list[Migration] = [
         "4.32.1",
         "RDR-109 Phase 5: add document_aspects.salient_sentences column",
         lambda conn: _migrate_add_aspects_salient_sentences(conn),
+    ),
+    # nexus-w0et (RDR-112 P1.4): watcher_state table in tuples.db.
+    # watcher_state lives in tuples.db (not memory.db) for genuine atomicity
+    # with cursor and tuple reads (RDR-111 lines 783-786). This migration
+    # wrapper derives the tuples.db path from the memory.db connection and
+    # applies the full tuples schema (idempotent via CREATE IF NOT EXISTS).
+    # The daemon is the SOLE migration runner for both databases per RDR-112 §9.
+    Migration(
+        "4.33.0",
+        "Create watcher_state table in tuples.db (RDR-111 nexus-w0et)",
+        _migrate_watcher_state_in_tuples_db,
     ),
 ]
 
@@ -3181,3 +3254,101 @@ def _create_base_tables(conn: sqlite3.Connection) -> None:
     conn.executescript(_TAXONOMY_SCHEMA_SQL)
     conn.executescript(_TELEMETRY_SCHEMA_SQL)
     conn.commit()
+
+
+def run_daemon_migrations(
+    memory_db_path: Path,
+    tuples_db_path: Path,
+) -> tuple[str, str]:
+    """Apply all pending migrations for both T2 databases at daemon startup.
+
+    RDR-112 P1.4 (nexus-w0et): the daemon is the SOLE migration runner for
+    both ``memory.db`` and ``tuples.db`` per RDR-112 §9. This function is
+    the canonical entry point for daemon startup; it must be called BEFORE
+    sockets are bound so no client ever connects to a partially-migrated DB.
+
+    Steps:
+    1. Apply pending migrations to ``memory_db_path`` (the T2 main store)
+       via the versioned MIGRATIONS registry. Returns (from_version,
+       to_version) from the stored ``_nexus_version`` table.
+    2. Apply the full tuples.db schema to ``tuples_db_path`` via
+       ``apply_tuples_schema`` (idempotent, CREATE IF NOT EXISTS). This
+       guarantees ``watcher_state`` and all tuples-family tables are present
+       regardless of whether the MIGRATIONS registry step ran (same-version
+       edge case: the MIGRATIONS entry at "4.33.0" does not run on installs
+       whose stored version is already "4.33.0"; the direct schema apply
+       closes that gap).
+
+    Args:
+        memory_db_path: Path to ``memory.db`` (T2 main stores). Created if absent.
+        tuples_db_path: Path to ``tuples.db`` (tuplespace + watcher_state).
+                        Created if absent.
+
+    Returns:
+        ``(from_version, to_version)`` tuple — the stored ``_nexus_version``
+        value before and after applying migrations on ``memory.db``. Useful
+        for the daemon lifecycle log event.
+
+    Raises:
+        MigrationError: if a migration fails a data-precondition audit.
+        Exception: any other migration exception propagates; the daemon must
+            not bind sockets after an exception from this function.
+    """
+    import time as _time
+
+    from nexus.tuplespace.store import apply_tuples_schema  # noqa: PLC0415
+
+    # Step 1: memory.db migrations
+    memory_db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        current_version = _pkg_version_str()
+    except Exception:
+        current_version = "0.0.0"
+
+    memory_conn = sqlite3.connect(str(memory_db_path), check_same_thread=False)
+    try:
+        memory_conn.execute("PRAGMA busy_timeout=5000")
+        memory_conn.execute("PRAGMA journal_mode=WAL")
+        memory_conn.commit()
+
+        from_version = bootstrap_version(memory_conn)
+        apply_pending(memory_conn, current_version)
+        # Read version after migration (may not change on same-version runs)
+        row = memory_conn.execute(
+            "SELECT value FROM _nexus_version WHERE key='cli_version'"
+        ).fetchone()
+        to_version = row[0] if row else current_version
+    finally:
+        memory_conn.close()
+    # Ensure the argument-form key is also in _upgrade_done (mirrors run_if_needed fix)
+    try:
+        _upgrade_done.add(str(memory_db_path.resolve()))
+    except OSError:
+        _upgrade_done.add(str(memory_db_path))
+
+    # Step 2: tuples.db schema (unconditional — idempotent)
+    tuples_db_path.parent.mkdir(parents=True, exist_ok=True)
+    tuples_conn = sqlite3.connect(str(tuples_db_path), check_same_thread=False)
+    try:
+        tuples_conn.execute("PRAGMA busy_timeout=5000")
+        tuples_conn.execute("PRAGMA journal_mode=WAL")
+        tuples_conn.commit()
+        apply_tuples_schema(tuples_conn)
+    finally:
+        tuples_conn.close()
+
+    _log.info(
+        "run_daemon_migrations_complete",
+        memory_db=str(memory_db_path),
+        tuples_db=str(tuples_db_path),
+        from_version=from_version,
+        to_version=to_version,
+    )
+    return from_version, to_version
+
+
+def _pkg_version_str() -> str:
+    """Return the running ``conexus`` package version string."""
+    from importlib.metadata import version as _iv
+    return _iv("conexus")

--- a/src/nexus/tuplespace/store.py
+++ b/src/nexus/tuplespace/store.py
@@ -98,6 +98,18 @@ CREATE INDEX IF NOT EXISTS idx_claim_log_tuple
     ON tuple_claim_log (tuple_id, at);
 CREATE INDEX IF NOT EXISTS idx_claim_log_claimant
     ON tuple_claim_log (claimant, at);
+
+-- Watcher cursor state per (subspace, profile) pair (RDR-111 Phase 2 Step 6).
+-- Lives in tuples.db (not memory.db) so that cursor and tuple reads are in
+-- the same database for genuine atomicity (RDR-111 lines 783-786).
+-- Added by nexus-w0et (RDR-112 P1.4 daemon-startup migration runner).
+CREATE TABLE IF NOT EXISTS watcher_state (
+    subspace   TEXT NOT NULL,
+    profile    TEXT NOT NULL,
+    last_rowid INTEGER NOT NULL DEFAULT 0,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (subspace, profile)
+);
 """
 
 # ---------------------------------------------------------------------------

--- a/tests/daemon/test_migration_ownership.py
+++ b/tests/daemon/test_migration_ownership.py
@@ -313,3 +313,47 @@ def test_direct_and_daemon_paths_converge_on_same_tuples_schema(tmp_path):
         f"Direct: {[r[0] for r in direct_schema]}\n"
         f"Daemon: {[r[0] for r in daemon_schema]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test (f): second daemon start on same data dir is a no-op (idempotency)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_daemon_start_is_idempotent(tmp_path):
+    """A second daemon start against the same config_dir must be a no-op
+    (already at the current schema version). The tuples.db schema must
+    be byte-identical across both starts.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    tuples_path = config_dir / "tuples.db"
+
+    def _schema(path: Path) -> list[tuple[str, str]]:
+        c = sqlite3.connect(str(path))
+        try:
+            return sorted(
+                c.execute(
+                    "SELECT name, sql FROM sqlite_master "
+                    "WHERE sql IS NOT NULL ORDER BY name"
+                ).fetchall()
+            )
+        finally:
+            c.close()
+
+    daemon1 = T2Daemon(config_dir)
+    await daemon1.start()
+    schema_after_first = _schema(tuples_path)
+    await daemon1.stop()
+
+    # Second start on the same data dir — must not raise, must not change schema
+    daemon2 = T2Daemon(config_dir)
+    await daemon2.start()
+    schema_after_second = _schema(tuples_path)
+    await daemon2.stop()
+
+    assert schema_after_first == schema_after_second, (
+        "Second daemon start must produce identical schema "
+        "(CREATE TABLE IF NOT EXISTS idempotency)."
+    )

--- a/tests/daemon/test_migration_ownership.py
+++ b/tests/daemon/test_migration_ownership.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for daemon-startup migration runner (RDR-112 P1.4 / nexus-w0et).
+
+Contract:
+- T2Daemon.start() applies all pending migrations to memory.db AND
+  creates/applies the tuples.db schema BEFORE binding sockets.
+- watcher_state table exists in tuples.db after first daemon start.
+- Schema-version mismatch in hello_ack raises T2DaemonError with a
+  directional instruction message.
+- The lifecycle log event "daemon/t2/lifecycle" fires with
+  op="migration-applied", from, and to keys.
+"""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+import structlog
+import structlog.testing
+
+from nexus.daemon.t2_client import T2Client, T2DaemonError, T2_SCHEMA_VERSION_EXPECTED
+from nexus.daemon.t2_daemon import DAEMON_SCHEMA_VERSION, T2Daemon
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _start_daemon_sync(daemon: T2Daemon) -> None:
+    """Start *daemon* on the calling thread's new asyncio event loop."""
+    asyncio.run(daemon.start())
+
+
+def _get_watcher_state_info(db_path: Path) -> dict[str, Any]:
+    """Return PRAGMA table_info and index_list for watcher_state."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cols = {
+            row[1]: row
+            for row in conn.execute(
+                "PRAGMA table_info(watcher_state)"
+            ).fetchall()
+        }
+        indexes = conn.execute(
+            "PRAGMA index_list(watcher_state)"
+        ).fetchall()
+        return {"cols": cols, "indexes": indexes}
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test (a): startup applies pending migration before bind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watcher_state_exists_before_first_rpc(tmp_path):
+    """Start a fresh daemon; verify watcher_state exists in tuples.db
+    before any client RPC can succeed.
+
+    The table must be created by the migration runner in T2Daemon.start()
+    BEFORE the sockets are bound, so that the moment a client connects,
+    the schema is already in place.
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    daemon = T2Daemon(config_dir)
+    await daemon.start()
+
+    tuples_path = config_dir / "tuples.db"
+    assert tuples_path.exists(), "tuples.db must be created at daemon startup"
+
+    conn = sqlite3.connect(str(tuples_path))
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='watcher_state'"
+        ).fetchone()
+        assert row is not None, (
+            "watcher_state table must exist in tuples.db after daemon.start() "
+            "— migration runner must apply schema before bind"
+        )
+    finally:
+        conn.close()
+        await daemon.stop()
+
+
+# ---------------------------------------------------------------------------
+# Test (b): version handshake mismatch raises T2DaemonError with direction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schema_version_mismatch_raises_directional_error(tmp_path):
+    """Verify that the daemon's hello_ack carries schema_version, and that
+    T2Client raises T2DaemonError with directional instruction on mismatch.
+
+    Uses asyncio primitives (matching the existing transport test pattern)
+    to drive the handshake from within the daemon's event loop — avoids the
+    synchronous-socket-in-async-loop deadlock that T2Client.ping() would
+    cause when called on the event-loop thread.
+
+    Validates the client-side mismatch detection by calling _connect_once()
+    in a thread executor so both event-loop sides can progress concurrently.
+
+    Two sub-cases:
+      - client_version > daemon_version: "restart daemon" instruction
+      - client_version < daemon_version: "upgrade conexus" instruction
+    """
+    import nexus.daemon.t2_client as _client_mod
+    from nexus.daemon.t2_daemon import read_frame, write_frame, DAEMON_PROTOCOL_VERSION
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    daemon = T2Daemon(config_dir)
+    await daemon.start()
+
+    try:
+        # Sub-case A: verify daemon's hello_ack includes schema_version.
+        reader, writer = await asyncio.open_connection(
+            daemon.tcp_host, daemon.tcp_port
+        )
+        write_frame(writer, {"op": "hello", "protocol_version": DAEMON_PROTOCOL_VERSION})
+        await writer.drain()
+        ack = await read_frame(reader)
+        writer.close()
+        await writer.wait_closed()
+
+        assert "schema_version" in ack, (
+            f"hello_ack must include schema_version, got keys: {list(ack.keys())}"
+        )
+        daemon_sv = ack["schema_version"]
+        assert daemon_sv == DAEMON_SCHEMA_VERSION, (
+            f"schema_version in hello_ack must equal DAEMON_SCHEMA_VERSION "
+            f"({DAEMON_SCHEMA_VERSION}), got {daemon_sv}"
+        )
+
+        # Sub-case B: client expects NEWER schema → "restart daemon" message.
+        original = _client_mod.T2_SCHEMA_VERSION_EXPECTED
+        try:
+            _client_mod.T2_SCHEMA_VERSION_EXPECTED = DAEMON_SCHEMA_VERSION + 9999
+
+            def _client_connect_newer() -> None:
+                c = T2Client(tcp_addr=(daemon.tcp_host, daemon.tcp_port))
+                c.ping()
+
+            with pytest.raises(T2DaemonError) as exc_info:
+                await asyncio.to_thread(_client_connect_newer)
+
+            msg = str(exc_info.value)
+            assert "nx daemon t2 stop" in msg or "restart" in msg.lower(), (
+                f"Expected restart instruction, got: {msg!r}"
+            )
+
+            # Sub-case C: client expects OLDER schema → "upgrade" message.
+            _client_mod.T2_SCHEMA_VERSION_EXPECTED = DAEMON_SCHEMA_VERSION - 9999
+
+            def _client_connect_older() -> None:
+                c2 = T2Client(tcp_addr=(daemon.tcp_host, daemon.tcp_port))
+                c2.ping()
+
+            with pytest.raises(T2DaemonError) as exc_info2:
+                await asyncio.to_thread(_client_connect_older)
+
+            msg2 = str(exc_info2.value)
+            assert "upgrade" in msg2.lower() or "uv pip install" in msg2, (
+                f"Expected upgrade instruction, got: {msg2!r}"
+            )
+        finally:
+            _client_mod.T2_SCHEMA_VERSION_EXPECTED = original
+    finally:
+        await daemon.stop()
+
+
+# ---------------------------------------------------------------------------
+# Test (c): watcher_state has correct primary key shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_watcher_state_primary_key_shape(tmp_path):
+    """After first daemon start, watcher_state must have exactly
+    (subspace, profile) as PRIMARY KEY per RDR-111 line 864.
+
+    Checks:
+    - Column names: subspace, profile, last_rowid, updated_at
+    - PK columns: subspace (pk=1) AND profile (pk=2)
+    - At least one index (the autoindex for the PK)
+    """
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    daemon = T2Daemon(config_dir)
+    await daemon.start()
+    await daemon.stop()
+
+    tuples_path = config_dir / "tuples.db"
+    info = _get_watcher_state_info(tuples_path)
+
+    cols = info["cols"]
+    assert "subspace" in cols, "watcher_state must have 'subspace' column"
+    assert "profile" in cols, "watcher_state must have 'profile' column"
+    assert "last_rowid" in cols, "watcher_state must have 'last_rowid' column"
+    assert "updated_at" in cols, "watcher_state must have 'updated_at' column"
+
+    # pk flag: 0 = not PK; > 0 = PK member (value is position in composite PK)
+    pk_cols = {name for name, row in cols.items() if row[5] > 0}
+    assert pk_cols == {"subspace", "profile"}, (
+        f"PRIMARY KEY must be exactly (subspace, profile) per RDR-111, got: {pk_cols}"
+    )
+
+    # There must be at least one index (SQLite creates a unique index for
+    # composite PKs automatically: sqlite_autoindex_watcher_state_1)
+    assert len(info["indexes"]) >= 1, (
+        "watcher_state must have at least one index (auto-PK index)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test (d): lifecycle log event fires during daemon start
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_migration_applied_event(tmp_path):
+    """T2Daemon.start() must emit a structured log event:
+    event='daemon/t2/lifecycle' with op='migration-applied', 'from', 'to' keys.
+    """
+    import logging
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # Temporarily set structlog to DEBUG so INFO events are not filtered
+    # by the conftest's WARNING-level wrapper_class before reaching capture_logs.
+    saved_config = structlog.get_config()
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG),
+    )
+    try:
+        with structlog.testing.capture_logs() as captured:
+            daemon = T2Daemon(config_dir)
+            await daemon.start()
+            await daemon.stop()
+    finally:
+        structlog.configure(**saved_config)
+
+    # Look for the migration-applied event
+    migration_events = [
+        e for e in captured
+        if e.get("event") == "daemon/t2/lifecycle"
+        and e.get("op") == "migration-applied"
+    ]
+    assert len(migration_events) >= 1, (
+        "Expected at least one 'daemon/t2/lifecycle' event with op='migration-applied'. "
+        f"Got events: {[e.get('event') for e in captured]}"
+    )
+    evt = migration_events[0]
+    assert "from" in evt, f"Event must have 'from' key, got: {evt}"
+    assert "to" in evt, f"Event must have 'to' key, got: {evt}"
+
+
+# ---------------------------------------------------------------------------
+# Test (e): direct-mode and daemon paths converge on same tuples.db schema
+# ---------------------------------------------------------------------------
+
+
+def test_direct_and_daemon_paths_converge_on_same_tuples_schema(tmp_path):
+    """Both NX_STORAGE_MODE=direct (using open_tuples_db) and the daemon
+    startup path must produce the same tuples.db schema (same tables,
+    same indexes, same columns).
+    """
+    from nexus.tuplespace.store import open_tuples_db
+
+    # Direct path: open_tuples_db applies the full schema
+    direct_path = tmp_path / "tuples_direct.db"
+    conn_direct = open_tuples_db(direct_path)
+    conn_direct.close()
+
+    # Daemon path: daemon startup via run_daemon_migrations
+    daemon_path = tmp_path / "tuples_daemon.db"
+    memory_path = tmp_path / "memory_daemon.db"
+    from nexus.db.migrations import run_daemon_migrations
+    run_daemon_migrations(memory_path, daemon_path)
+
+    def _schema_rows(path: Path) -> list[tuple[str, str]]:
+        c = sqlite3.connect(str(path))
+        try:
+            return sorted(
+                c.execute(
+                    "SELECT name, sql FROM sqlite_master "
+                    "WHERE sql IS NOT NULL "
+                    "ORDER BY name"
+                ).fetchall()
+            )
+        finally:
+            c.close()
+
+    direct_schema = _schema_rows(direct_path)
+    daemon_schema = _schema_rows(daemon_path)
+
+    assert direct_schema == daemon_schema, (
+        "Direct-mode (open_tuples_db) and daemon-mode (run_daemon_migrations) "
+        "must produce identical tuples.db schemas.\n"
+        f"Direct: {[r[0] for r in direct_schema]}\n"
+        f"Daemon: {[r[0] for r in daemon_schema]}"
+    )


### PR DESCRIPTION
## Summary

- `run_daemon_migrations(memory_db_path, tuples_db_path)` is the daemon's exclusive migration entry point (RDR-112 §9 sole-runner contract); called in `T2Daemon.start()` BEFORE socket bind
- `watcher_state` DDL added to `TUPLES_SCHEMA_DDL` in `store.py` (lives in tuples.db per RDR-111 lines 783-786 for genuine atomicity with cursor reads); PRIMARY KEY (subspace, profile)
- `DAEMON_SCHEMA_VERSION: int = 1` + `T2_SCHEMA_VERSION_EXPECTED: int` module constants with directional schema-version mismatch errors on hello handshake
- `daemon/t2/lifecycle` structured log event with `op=migration-applied`, `from`, `to` keys emitted on every startup
- Versioned migration entry at "4.33.0" handles memory.db bookkeeping; tuples.db schema applied unconditionally via `apply_tuples_schema()`

## Test plan

- [ ] `test_watcher_state_exists_before_first_rpc` — watcher_state in tuples.db before any client RPC
- [ ] `test_schema_version_mismatch_raises_directional_error` — hello_ack carries schema_version; client raises T2DaemonError with restart/upgrade instruction
- [ ] `test_watcher_state_primary_key_shape` — columns (subspace, profile, last_rowid, updated_at) + composite PK
- [ ] `test_lifecycle_migration_applied_event` — structured log event fires on startup
- [ ] `test_direct_and_daemon_paths_converge_on_same_tuples_schema` — open_tuples_db vs run_daemon_migrations produce identical schema

All 5 pass locally; 94/94 daemon + db tests green.

## Closes

Closes nexus-w0et