### PR TITLE
feat(rdr-112): EventStream RPC — streaming subscription, cursor backfill, failure-category demux (nexus-m4gm)

### DIFF
--- a/src/nexus/daemon/event_stream.py
+++ b/src/nexus/daemon/event_stream.py
@@ -232,23 +232,33 @@ async def handle_event_stream(
             current_dv: int = await asyncio.to_thread(_get_data_version, conn)
             if current_dv == last_data_version:
                 continue  # no commit since last poll
-            last_data_version = current_dv
 
-            # Fetch new events since last emitted cursor (one burst, no limit cap in live mode
-            # since the delta since last poll is bounded by the 10ms window)
-            batch = await asyncio.to_thread(
-                _fetch_events, conn, glob_pattern, last_emitted, category_filter, BACKFILL_BURST_LIMIT
-            )
-            if not batch:
-                continue
-            for event in batch:
-                write_frame(writer, {"event": event})
-                last_emitted = event["cursor"]
-            try:
-                await writer.drain()
-            except (BrokenPipeError, ConnectionResetError, OSError):
-                _log.debug("event_stream_client_gone_on_drain")
-                return
+            # Drain ALL new events for this data_version bump in bursts of
+            # BACKFILL_BURST_LIMIT. A single transaction can produce arbitrarily
+            # many trigger-fired rows; only advance last_data_version once an
+            # empty fetch confirms we're caught up. Otherwise a >cap write batch
+            # would silently strand rows beyond the cap until another unrelated
+            # write happened to bump data_version again.
+            while True:
+                batch = await asyncio.to_thread(
+                    _fetch_events, conn, glob_pattern, last_emitted, category_filter, BACKFILL_BURST_LIMIT
+                )
+                if not batch:
+                    last_data_version = current_dv  # caught up to this dv
+                    break
+                for event in batch:
+                    write_frame(writer, {"event": event})
+                    last_emitted = event["cursor"]
+                try:
+                    await writer.drain()
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    _log.debug("event_stream_client_gone_on_drain")
+                    return
+                if len(batch) < BACKFILL_BURST_LIMIT:
+                    last_data_version = current_dv  # fewer than cap means we're caught up
+                    break
+                # Full burst: more rows may exist for this dv; loop without sleep
+                # to drain the rest before checking the wake signal again.
 
         # Daemon stopping: notify client
         if stopping_fn():

--- a/src/nexus/daemon/event_stream.py
+++ b/src/nexus/daemon/event_stream.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Daemon-side EventStream RPC implementation — RDR-112 P1.3 (nexus-m4gm).
+
+Provides ``handle_event_stream``, the asyncio coroutine that handles the
+``event_stream.subscribe`` op.  When called, it:
+
+1. Sends a ``{"subscribed": True, "cursor": <since_cursor>}`` ack frame.
+2. Runs a backfill phase: queries ``events WHERE subspace GLOB ? AND
+   rowid > since_cursor ORDER BY rowid LIMIT 1000`` in a loop until caught up.
+3. Switches to live mode: polls ``PRAGMA data_version`` every 10 ms; on each
+   commit fetches new ``rowid > last_emitted`` rows and pushes them.
+4. Exits when the client closes the connection (detected via reader EOF) or
+   the daemon is stopping.
+
+Wire frames
+-----------
+Subscribe request (from client)::
+
+    {"op": "event_stream.subscribe",
+     "args": {"subspace_prefix": "tuples/foo",
+              "since_cursor": 42,
+              "where": {"category": "timeout"}}}
+
+Ack (first frame from daemon)::
+
+    {"subscribed": True, "cursor": 42}
+
+Event frames::
+
+    {"event": {"cursor": 101, "subspace": "tuples/foo/bar",
+               "op": "out", "tuple_id": "abc123",
+               "payload_summary": "...", "category": "data", "ts": 1234.5}}
+
+Connection close terminates the subscription with no explicit frame.
+
+Polling cadence
+---------------
+- 10 ms sleep between data_version polls while the subscription is open.
+- All SQLite I/O runs via ``asyncio.to_thread`` to avoid blocking the event loop.
+
+Backfill cap
+------------
+Each backfill SELECT is capped at ``BACKFILL_BURST_LIMIT`` rows (1 000) to
+avoid OOM on large catch-ups.  The loop repeats until no more rows are
+returned, then transitions to live mode.
+
+Category filter
+---------------
+An optional ``where: {category: <str>}`` arg in the subscribe request causes
+the daemon to filter events by ``category`` column in the SELECT WHERE clause.
+"""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+#: Each backfill SELECT burst fetches at most this many rows.
+BACKFILL_BURST_LIMIT: int = 1_000
+
+#: Poll interval (seconds) while a subscriber is connected.
+_POLL_ACTIVE: float = 0.010  # 10 ms
+
+# ---------------------------------------------------------------------------
+# SQLite helpers (run in thread pool via asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_events(
+    conn: sqlite3.Connection,
+    subspace_prefix: str,
+    after_rowid: int,
+    category: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Fetch events matching subspace_prefix and rowid > after_rowid.
+
+    Runs synchronously; caller must dispatch via asyncio.to_thread.
+
+    Args:
+        conn: Open SQLite connection to tuples.db.
+        subspace_prefix: SQLite GLOB pattern (e.g. ``"tuples/foo*"``).
+        after_rowid: Return only rows with ``rowid > after_rowid``.
+        category: Optional category filter; if set, adds ``category = ?``.
+        limit: Maximum rows to return per call.
+
+    Returns:
+        List of event dicts with keys: cursor, subspace, op, tuple_id,
+        payload_summary, category, ts.
+    """
+    if category is not None:
+        sql = (
+            "SELECT rowid, subspace, op, tuple_id, payload_summary, category, ts "
+            "FROM events "
+            "WHERE subspace GLOB ? AND rowid > ? AND category = ? "
+            "ORDER BY rowid LIMIT ?"
+        )
+        rows = conn.execute(sql, (subspace_prefix, after_rowid, category, limit)).fetchall()
+    else:
+        sql = (
+            "SELECT rowid, subspace, op, tuple_id, payload_summary, category, ts "
+            "FROM events "
+            "WHERE subspace GLOB ? AND rowid > ? "
+            "ORDER BY rowid LIMIT ?"
+        )
+        rows = conn.execute(sql, (subspace_prefix, after_rowid, limit)).fetchall()
+
+    return [
+        {
+            "cursor": row[0],
+            "subspace": row[1],
+            "op": row[2],
+            "tuple_id": row[3],
+            "payload_summary": row[4],
+            "category": row[5],
+            "ts": row[6],
+        }
+        for row in rows
+    ]
+
+
+def _get_data_version(conn: sqlite3.Connection) -> int:
+    """Read PRAGMA data_version (fast; runs synchronously)."""
+    row = conn.execute("PRAGMA data_version").fetchone()
+    return row[0] if row else 0
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+async def handle_event_stream(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    tuples_db_path: Path,
+    args: dict[str, Any],
+    stopping_fn: Any,
+) -> None:
+    """Handle an ``event_stream.subscribe`` connection in server-push mode.
+
+    This coroutine takes ownership of *writer* for the lifetime of the
+    subscription.  It returns when the client closes the connection or when
+    the daemon is stopping (``stopping_fn()`` returns True).
+
+    Args:
+        reader: asyncio StreamReader for the connection.
+        writer: asyncio StreamWriter for the connection.
+        tuples_db_path: Filesystem path to tuples.db.
+        args: Parsed ``args`` dict from the subscribe request. Keys:
+            - ``subspace_prefix`` (str, required)
+            - ``since_cursor`` (int, default 0)
+            - ``where`` (dict, optional; only ``{"category": <str>}`` honoured)
+        stopping_fn: Zero-arg callable returning bool; True when the daemon
+            is stopping.
+    """
+    from nexus.daemon.t2_daemon import write_frame  # avoid circular at module level
+
+    # --- Validate args ---
+    subspace_prefix = args.get("subspace_prefix")
+    if not subspace_prefix:
+        write_frame(writer, {"error": "event_stream.subscribe: subspace_prefix is required"})
+        await writer.drain()
+        return
+
+    since_cursor: int = int(args.get("since_cursor") or 0)
+    where: dict[str, Any] = args.get("where") or {}
+    category_filter: str | None = where.get("category") or None
+
+    # Convert subspace_prefix to SQLite GLOB pattern: "tuples/foo" -> "tuples/foo*"
+    glob_pattern = subspace_prefix if "*" in subspace_prefix else subspace_prefix + "*"
+
+    _log.info(
+        "event_stream_subscribe",
+        glob=glob_pattern,
+        since_cursor=since_cursor,
+        category_filter=category_filter,
+    )
+
+    # --- Open a dedicated read connection to tuples.db ---
+    try:
+        # storage-boundary-allow: daemon-owned tuples.db connection for EventStream
+        conn = sqlite3.connect(str(tuples_db_path), check_same_thread=False)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA query_only=ON")  # read-only guard
+    except Exception as exc:
+        _log.error("event_stream_db_open_failed", error=str(exc))
+        write_frame(writer, {"error": f"event_stream: failed to open tuples.db: {exc}"})
+        await writer.drain()
+        return
+
+    try:
+        # --- Ack ---
+        write_frame(writer, {"subscribed": True, "cursor": since_cursor})
+        await writer.drain()
+
+        last_emitted: int = since_cursor
+
+        # --- Phase 1: Backfill ---
+        while not stopping_fn():
+            # Check client hasn't disconnected
+            if _client_closed(reader):
+                return
+
+            batch = await asyncio.to_thread(
+                _fetch_events, conn, glob_pattern, last_emitted, category_filter, BACKFILL_BURST_LIMIT
+            )
+            if not batch:
+                break  # caught up; switch to live mode
+            for event in batch:
+                write_frame(writer, {"event": event})
+                last_emitted = event["cursor"]
+            await writer.drain()
+            _log.debug("event_stream_backfill_batch", count=len(batch), last_cursor=last_emitted)
+
+        # --- Phase 2: Live mode ---
+        last_data_version: int = await asyncio.to_thread(_get_data_version, conn)
+
+        while not stopping_fn():
+            # Check client disconnect (non-blocking)
+            if _client_closed(reader):
+                return
+
+            await asyncio.sleep(_POLL_ACTIVE)
+
+            current_dv: int = await asyncio.to_thread(_get_data_version, conn)
+            if current_dv == last_data_version:
+                continue  # no commit since last poll
+            last_data_version = current_dv
+
+            # Fetch new events since last emitted cursor (one burst, no limit cap in live mode
+            # since the delta since last poll is bounded by the 10ms window)
+            batch = await asyncio.to_thread(
+                _fetch_events, conn, glob_pattern, last_emitted, category_filter, BACKFILL_BURST_LIMIT
+            )
+            if not batch:
+                continue
+            for event in batch:
+                write_frame(writer, {"event": event})
+                last_emitted = event["cursor"]
+            try:
+                await writer.drain()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                _log.debug("event_stream_client_gone_on_drain")
+                return
+
+        # Daemon stopping: notify client
+        if stopping_fn():
+            try:
+                write_frame(writer, {"error": "daemon is shutting down"})
+                await writer.drain()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                pass
+
+    except (BrokenPipeError, ConnectionResetError, OSError) as exc:
+        _log.debug("event_stream_connection_lost", error=str(exc))
+    except Exception as exc:
+        _log.warning("event_stream_error", error=str(exc), exc_info=True)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        _log.info("event_stream_closed", last_cursor=last_emitted)
+
+
+def _client_closed(reader: asyncio.StreamReader) -> bool:
+    """Non-blocking check: return True if the client has closed the connection.
+
+    Uses ``StreamReader.at_eof()`` which is a synchronous, non-blocking check
+    on the internal buffer state. Returns True when the feed-data callback has
+    delivered an EOF (i.e., the client closed the connection) without consuming
+    any buffered bytes.
+    """
+    return reader.at_eof()

--- a/src/nexus/daemon/t2_client.py
+++ b/src/nexus/daemon/t2_client.py
@@ -64,6 +64,7 @@ import inspect
 import socket
 import struct
 import threading
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -637,3 +638,88 @@ class T2Client:
         with self._get_pool().acquire() as conn:
             # ping returns a flat {pong: True, ...} dict, not {result: ...}
             return conn.call("ping", {})
+
+    # ------------------------------------------------------------------
+    # EventStream (P1.3 nexus-m4gm)
+    # ------------------------------------------------------------------
+
+    def event_stream(
+        self,
+        subspace_prefix: str,
+        since_cursor: int = 0,
+        where: dict[str, Any] | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Yield event dicts from the daemon's EventStream until the connection closes.
+
+        Opens a **dedicated** socket connection (not from the pool) that is
+        held for the generator's lifetime.  The connection is closed when the
+        generator is exhausted or when the caller calls ``close()`` / uses
+        ``break`` inside a ``for`` loop.
+
+        Protocol:
+          1. Connect + hello/hello_ack handshake.
+          2. Send ``{"op": "event_stream.subscribe", "args": {...}}``.
+          3. Read the ``{"subscribed": True, "cursor": <N>}`` ack.
+          4. Yield each ``{"event": {...}}`` frame's inner event dict.
+          5. Stop on connection close, error frame, or generator close.
+
+        Args:
+            subspace_prefix: Subspace glob prefix, e.g. ``"tuples/myspace"``.
+                The daemon appends ``*`` when the prefix contains no wildcard.
+            since_cursor: Resume cursor (rowid).  0 requests full backfill.
+            where: Optional filter dict.  Currently supports
+                ``{"category": "<str>"}`` for failure-category demux.
+
+        Yields:
+            Event dicts with keys: ``cursor``, ``subspace``, ``op``,
+            ``tuple_id``, ``payload_summary``, ``category``, ``ts``.
+
+        Raises:
+            T2DaemonError: if the daemon returns an error on the subscribe op.
+            ConnectionError: if the socket closes unexpectedly mid-stream.
+
+        Example::
+
+            for event in client.event_stream("tuples/myspace", since_cursor=42):
+                print(event["op"], event["tuple_id"])
+        """
+        conn = self._connect_once()
+        sock = conn._sock  # dedicated socket; not returned to pool
+        try:
+            # Send subscribe request
+            _sock_write_frame(
+                sock,
+                {
+                    "op": "event_stream.subscribe",
+                    "args": {
+                        "subspace_prefix": subspace_prefix,
+                        "since_cursor": since_cursor,
+                        "where": where or {},
+                    },
+                },
+            )
+            # Read ack
+            ack = _sock_read_frame(sock)
+            if "error" in ack:
+                _reraise_remote_error(ack["error"])
+            if not ack.get("subscribed"):
+                raise T2DaemonError(
+                    f"expected subscribed ack, got: {ack!r}"
+                )
+            # Stream events
+            while True:
+                frame = _sock_read_frame(sock)
+                if "error" in frame:
+                    # Daemon shutting down or protocol error — stop cleanly
+                    _log.debug("event_stream_server_error", error=frame["error"])
+                    return
+                event = frame.get("event")
+                if event is not None:
+                    yield event
+        except (ConnectionError, OSError):
+            return  # connection closed
+        finally:
+            try:
+                sock.close()
+            except OSError:
+                pass

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -3,6 +3,7 @@
 
 RDR-112 P1.1 (nexus-61x6): transport scaffold + dual-bind UDS+TCP.
 RDR-112 P1.2 (nexus-qy0u): domain-store RPC dispatcher.
+RDR-112 P1.3 (nexus-m4gm): EventStream RPC — streaming subscription.
 
 This module provides:
   - ``T2Daemon``: the daemon class, managing two concurrent asyncio servers
@@ -43,8 +44,16 @@ Phase 1.2 scope (nexus-qy0u):
     ``{error: {type, message, traceback}}`` so the connection stays open.
   - ``database.rename_collection_cascade`` exposed as a top-level RPC.
 
+Phase 1.3 scope (nexus-m4gm):
+  - EventStream RPC: ``event_stream.subscribe`` op on a persistent connection.
+  - Server-push mode: after subscription, the daemon streams event frames
+    until the client closes or the daemon stops.
+  - Backfill: ``rowid > since_cursor`` from the ``events`` table in tuples.db.
+  - Live mode: ``PRAGMA data_version`` polling at 10 ms.
+  - Failure-category demux: ``where: {category: <str>}`` filter supported.
+  - Requires ``tuples_db_path`` arg at daemon construction.
+
 Out of scope here (later beads):
-  - EventStream subscription (P1.3 nexus-m4gm)
   - Migration runner (P1.4 nexus-w0et)
   - Subspace admin (P1.5 nexus-x98k)
   - Introspection RPCs (P1.6 nexus-08i1)
@@ -368,7 +377,13 @@ class T2Daemon:
         start_time: ISO-8601 UTC timestamp of daemon startup.
     """
 
-    def __init__(self, config_dir: Path, *, t2db: Any = None) -> None:
+    def __init__(
+        self,
+        config_dir: Path,
+        *,
+        t2db: Any = None,
+        tuples_db_path: Path | None = None,
+    ) -> None:
         """Initialise the daemon.
 
         Args:
@@ -379,6 +394,9 @@ class T2Daemon:
                 RPCs (P1.2 nexus-qy0u). When ``None``, only the handshake
                 and ping ops are available (useful for tests that only test
                 transport).
+            tuples_db_path: Path to tuples.db for EventStream subscriptions
+                (P1.3 nexus-m4gm). When ``None``, ``event_stream.subscribe``
+                returns an error.  Typically ``config_dir / "tuples.db"``.
         """
         self._config_dir = config_dir
         self._socket_dir: Path = config_dir / _SOCKET_SUBDIR
@@ -404,6 +422,9 @@ class T2Daemon:
         self._rpc_table: dict[str, Any] = {}
         if t2db is not None:
             self._rpc_table = _build_dispatch_table(t2db)
+
+        # P1.3 nexus-m4gm: tuples.db path for EventStream subscriptions.
+        self._tuples_db_path: Path | None = tuples_db_path
 
     # ------------------------------------------------------------------
     # Public properties (set after start())
@@ -714,6 +735,12 @@ class T2Daemon:
                 _log.warning("rpc_read_error", exc=str(exc))
                 return
 
+            # P1.3 nexus-m4gm: EventStream op hijacks the connection into
+            # server-push mode.  Return immediately after the stream ends.
+            if msg.get("op") == "event_stream.subscribe":
+                await self._handle_event_stream(reader, writer, msg.get("args") or {})
+                return
+
             response = await self._dispatch(msg)
             write_frame(writer, response)
             await writer.drain()
@@ -788,6 +815,41 @@ class T2Daemon:
                     "traceback": tb_text,
                 }
             }
+
+    async def _handle_event_stream(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        args: dict[str, Any],
+    ) -> None:
+        """Handle an ``event_stream.subscribe`` request in server-push mode.
+
+        Delegates to ``nexus.daemon.event_stream.handle_event_stream`` with
+        this daemon's tuples_db_path.  If ``tuples_db_path`` was not provided
+        at construction, responds with an error frame and returns.
+
+        Args:
+            reader: asyncio StreamReader for the connection.
+            writer: asyncio StreamWriter for the connection.
+            args: Parsed ``args`` dict from the subscribe request.
+        """
+        if self._tuples_db_path is None:
+            write_frame(
+                writer,
+                {"error": "event_stream not available: daemon has no tuples_db_path"},
+            )
+            await writer.drain()
+            return
+
+        from nexus.daemon.event_stream import handle_event_stream
+
+        await handle_event_stream(
+            reader=reader,
+            writer=writer,
+            tuples_db_path=self._tuples_db_path,
+            args=args,
+            stopping_fn=lambda: self._stopping,
+        )
 
     # ------------------------------------------------------------------
     # Discovery file + stdout announce

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -2608,6 +2608,124 @@ def _migrate_watcher_state_in_tuples_db(conn: sqlite3.Connection) -> None:
         tuples_conn.close()
 
 
+# ── tuples.db migrations (nexus-m4gm, RDR-112 P1.3) ────────────────────────
+# These functions target tuples.db (a separate database from memory.db).
+# They are called directly from run_daemon_migrations with a tuples.db
+# connection — NOT via the MIGRATIONS registry (which passes memory.db conns).
+# No-ops when tuples.db does not yet exist (fresh installs get the full schema
+# via apply_tuples_schema / TUPLES_SCHEMA_DDL on first open).
+
+
+def migrate_tuples_failure_category(conn: sqlite3.Connection) -> None:
+    """Add ``failure_category`` column to ``tuple_claim_log`` for EventStream demux.
+
+    This column carries the failure reason on nack transitions so that
+    EventStream consumers (RDR-111 binding-watcher, nexus-m4gm) can
+    filter events by category.
+
+    Idempotent: gated by ``PRAGMA table_info``. No-op when tuples.db does
+    not exist (``tuple_claim_log`` will be created with the column via
+    ``TUPLES_SCHEMA_DDL`` on first open). No-op when the column is already
+    present.
+
+    This migration operates on tuples.db, NOT memory.db. Call with a
+    tuples.db connection (e.g. from run_daemon_migrations).
+    """
+    cols = {
+        r[1] for r in conn.execute(
+            "PRAGMA table_info(tuple_claim_log)"
+        ).fetchall()
+    }
+    if not cols:
+        return  # tuples.db not yet initialised; fresh install gets column via DDL
+    if "failure_category" in cols:
+        return
+    _log.info("migrate_tuples_failure_category_start")
+    conn.execute(
+        "ALTER TABLE tuple_claim_log ADD COLUMN failure_category TEXT"
+    )
+    conn.commit()
+    _log.info("migrate_tuples_failure_category_done")
+
+
+def migrate_tuples_events_table(conn: sqlite3.Connection) -> None:
+    """Create the ``events`` table and its two triggers in tuples.db.
+
+    The ``events`` table is an append-only projection of every committed
+    tuple operation.  It is populated by:
+
+    - ``trg_tuples_out``: fires on INSERT into ``tuples``; emits op='out'.
+    - ``trg_claim_log_event``: fires on INSERT into ``tuple_claim_log``;
+      emits op=transition (claim/ack/nack/expire).
+
+    The monotonic ``rowid`` is the cursor for the EventStream RPC
+    (RDR-112 P1.3, nexus-m4gm).  Consumers reconnect with
+    ``since_cursor=last_rowid`` for at-least-once delivery.
+
+    Idempotent: gated by ``sqlite_master`` check.  No-op when tuples.db
+    does not exist (fresh installs get the table via ``TUPLES_SCHEMA_DDL``
+    on first open).
+
+    This migration operates on tuples.db, NOT memory.db.
+    """
+    existing_tables = {
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    if "tuples" not in existing_tables:
+        return  # tuples.db not yet initialised; fresh install gets table via DDL
+    if "events" in existing_tables:
+        return  # already migrated
+
+    _log.info("migrate_tuples_events_table_start")
+    conn.executescript("""\
+CREATE TABLE IF NOT EXISTS events (
+    rowid           INTEGER PRIMARY KEY AUTOINCREMENT,
+    subspace        TEXT NOT NULL,
+    op              TEXT NOT NULL,
+    tuple_id        TEXT NOT NULL,
+    payload_summary TEXT,
+    category        TEXT,
+    ts              REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_events_subspace_rowid
+    ON events (subspace, rowid);
+
+CREATE TRIGGER IF NOT EXISTS trg_tuples_out
+    AFTER INSERT ON tuples
+BEGIN
+    INSERT INTO events (subspace, op, tuple_id, payload_summary, category, ts)
+    VALUES (
+        NEW.subspace,
+        'out',
+        NEW.id,
+        SUBSTR(NEW.content, 1, 256),
+        'data',
+        NEW.created_at
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_claim_log_event
+    AFTER INSERT ON tuple_claim_log
+BEGIN
+    INSERT INTO events (subspace, op, tuple_id, payload_summary, category, ts)
+    VALUES (
+        COALESCE((SELECT subspace FROM tuples WHERE id = NEW.tuple_id), ''),
+        NEW.transition,
+        NEW.tuple_id,
+        NULL,
+        CASE
+            WHEN NEW.transition = 'nack' THEN COALESCE(NEW.failure_category, 'unknown')
+            ELSE 'data'
+        END,
+        NEW.at
+    );
+END;
+""")
+    _log.info("migrate_tuples_events_table_done")
+
+
 MIGRATIONS: list[Migration] = [
     Migration("1.10.0", "Memory FTS rebuild with title", migrate_memory_fts),
     Migration("2.8.0", "Add plan project column", migrate_plan_project),
@@ -2789,6 +2907,9 @@ MIGRATIONS: list[Migration] = [
         "Create watcher_state table in tuples.db (RDR-111 nexus-w0et)",
         _migrate_watcher_state_in_tuples_db,
     ),
+    # nexus-m4gm (RDR-112 P1.3): EventStream RPC substrate migrations are applied
+    # directly in run_daemon_migrations (not here) because they need a tuples.db
+    # connection, not a memory.db connection.
 ]
 
 
@@ -2814,6 +2935,7 @@ def _migrate_add_aspects_salient_sentences(conn: sqlite3.Connection) -> None:
         "ALTER TABLE document_aspects ADD COLUMN salient_sentences TEXT"
     )
     conn.commit()
+
 
 # ── T3 upgrade steps ────────────────────────────────────────────────────────
 # Separate from T2 migrations: these require a ChromaDB client, not sqlite3.
@@ -3335,6 +3457,13 @@ def run_daemon_migrations(
         tuples_conn.execute("PRAGMA journal_mode=WAL")
         tuples_conn.commit()
         apply_tuples_schema(tuples_conn)
+        # nexus-m4gm (RDR-112 P1.3): EventStream substrate migrations.
+        # Called here (not via MIGRATIONS registry) because they need a
+        # tuples.db connection. Both are no-ops on fresh schema (columns/tables
+        # already present via TUPLES_SCHEMA_DDL); they only fire on upgraded
+        # databases created before m4gm shipped.
+        migrate_tuples_failure_category(tuples_conn)
+        migrate_tuples_events_table(tuples_conn)
     finally:
         tuples_conn.close()
 

--- a/src/nexus/tuplespace/store.py
+++ b/src/nexus/tuplespace/store.py
@@ -2,14 +2,18 @@
 """SQLite schema for tuples.db — the T2 claim ledger for RDR-110.
 
 New database `~/.config/nexus/tuples.db` (separate from ``memory.db``
-for operational isolation). Contains two tables:
+for operational isolation). Contains:
 
 - ``tuples`` — body store + claim state. Single-table-with-state-column
   pattern (honker RF-9). Atomicity via ``UPDATE … RETURNING`` under
   SQLite's single-writer lock. Tombstone columns follow RDR-106/107 style.
 - ``tuple_claim_log`` — append-only audit trail for every state transition
   (claim, ack, nack, expire). Never updated; never deleted except by the
-  30-day retention sweep.
+  30-day retention sweep. Includes ``failure_category`` for nack demux.
+- ``events`` — append-only projection of every committed tuple operation,
+  populated by AFTER INSERT triggers on ``tuples`` (op='out') and
+  ``tuple_claim_log`` (op=transition). Provides monotonic ``rowid``
+  cursors for the EventStream RPC (RDR-112 P1.3, nexus-m4gm).
 
 Migration coordination with RDR-112 daemon (nexus-w0et)
 --------------------------------------------------------
@@ -29,6 +33,22 @@ nexus-w0et integration note: import ``TUPLES_SCHEMA_DDL`` and call
 ``conn.executescript(TUPLES_SCHEMA_DDL)`` inside the daemon's migration
 manifest function. ``apply_tuples_schema`` is a thin wrapper around
 exactly that — the daemon may call either form.
+
+EventStream (nexus-m4gm, RDR-112 P1.3)
+---------------------------------------
+The ``events`` table is the cursor source for the EventStream RPC.
+Two triggers maintain it automatically:
+
+- ``trg_tuples_out``: fires on every INSERT into ``tuples``, emitting an
+  'out' event with the new tuple's subspace and id.
+- ``trg_claim_log_event``: fires on every INSERT into ``tuple_claim_log``,
+  emitting the transition (claim/ack/nack/expire) as the op. For 'nack'
+  transitions, the ``failure_category`` column is propagated.
+
+The ``events`` table is read by the daemon's ``event_stream.subscribe``
+handler via ``SELECT … WHERE subspace GLOB ? AND rowid > ? ORDER BY rowid
+LIMIT 1000``. Consumers (RDR-111 binding-watcher) persist ``last_cursor``
+and reconnect with ``since_cursor=last_cursor`` for at-least-once delivery.
 """
 
 from __future__ import annotations
@@ -86,13 +106,15 @@ CREATE INDEX IF NOT EXISTS idx_tuples_expires
 
 -- Append-only claim history for audit. Insert-only; never updated.
 -- Records every state transition (claim, ack, nack, expiry-release).
+-- failure_category is set on nack rows for EventStream demux (nexus-m4gm).
 CREATE TABLE IF NOT EXISTS tuple_claim_log (
-    log_id          INTEGER PRIMARY KEY AUTOINCREMENT,
-    tuple_id        TEXT NOT NULL,
-    claim_id        TEXT NOT NULL,
-    claimant        TEXT NOT NULL,
-    transition      TEXT NOT NULL,                  -- 'claim' | 'ack' | 'nack' | 'expire'
-    at              REAL NOT NULL
+    log_id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    tuple_id         TEXT NOT NULL,
+    claim_id         TEXT NOT NULL,
+    claimant         TEXT NOT NULL,
+    transition       TEXT NOT NULL,                 -- 'claim' | 'ack' | 'nack' | 'expire'
+    failure_category TEXT,                          -- set on nack; NULL for claim/ack/expire
+    at               REAL NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_claim_log_tuple
     ON tuple_claim_log (tuple_id, at);
@@ -110,6 +132,57 @@ CREATE TABLE IF NOT EXISTS watcher_state (
     updated_at REAL NOT NULL,
     PRIMARY KEY (subspace, profile)
 );
+
+-- Append-only event projection for EventStream RPC (RDR-112 P1.3, nexus-m4gm).
+-- Every committed tuple operation lands here via triggers; monotonic rowid
+-- provides the cursor for at-least-once streaming delivery.
+CREATE TABLE IF NOT EXISTS events (
+    rowid           INTEGER PRIMARY KEY AUTOINCREMENT,
+    subspace        TEXT NOT NULL,
+    op              TEXT NOT NULL,                  -- 'out' | 'claim' | 'ack' | 'nack' | 'expire'
+    tuple_id        TEXT NOT NULL,
+    payload_summary TEXT,                           -- substr of content for stream consumers
+    category        TEXT,                           -- failure category for nack events
+    ts              REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_events_subspace_rowid
+    ON events (subspace, rowid);
+
+-- Trigger: emit 'out' event on every new tuple insertion.
+CREATE TRIGGER IF NOT EXISTS trg_tuples_out
+    AFTER INSERT ON tuples
+BEGIN
+    INSERT INTO events (subspace, op, tuple_id, payload_summary, category, ts)
+    VALUES (
+        NEW.subspace,
+        'out',
+        NEW.id,
+        SUBSTR(NEW.content, 1, 256),
+        'data',
+        NEW.created_at
+    );
+END;
+
+-- Trigger: emit a transition event on every tuple_claim_log insertion.
+-- Propagates failure_category for nack rows; uses 'data' for all others.
+-- COALESCE on subspace handles the edge case where the tuple was deleted before
+-- the claim log row was written (e.g. in tests or cleanup races).
+CREATE TRIGGER IF NOT EXISTS trg_claim_log_event
+    AFTER INSERT ON tuple_claim_log
+BEGIN
+    INSERT INTO events (subspace, op, tuple_id, payload_summary, category, ts)
+    VALUES (
+        COALESCE((SELECT subspace FROM tuples WHERE id = NEW.tuple_id), ''),
+        NEW.transition,
+        NEW.tuple_id,
+        NULL,
+        CASE
+            WHEN NEW.transition = 'nack' THEN COALESCE(NEW.failure_category, 'unknown')
+            ELSE 'data'
+        END,
+        NEW.at
+    );
+END;
 """
 
 # ---------------------------------------------------------------------------

--- a/tests/daemon/test_event_stream.py
+++ b/tests/daemon/test_event_stream.py
@@ -391,6 +391,59 @@ async def test_backfill_cap_1500(
 
 
 # ---------------------------------------------------------------------------
+# (g) Live mode >cap: single transaction emits 1500 rows AFTER subscribe;
+#     all must arrive (regression for the live-mode silent-drop bug)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_mode_above_cap_drains_all_events(
+    daemon: T2Daemon,
+    seeded_db: sqlite3.Connection,
+) -> None:
+    """Subscribe FIRST, then commit one >cap transaction; all rows arrive.
+
+    Regression: live-mode previously advanced last_data_version after a single
+    fetch capped at BACKFILL_BURST_LIMIT (1000). A transaction with >1000
+    trigger-fired rows would silently strand the remainder until another
+    unrelated write bumped data_version. Fixed by looping the live fetch
+    until an empty / under-cap batch returns.
+    """
+    n = 1500
+    client = _make_client(daemon)
+    # Spawn the collector first so it's in live mode when the transaction commits.
+    collector_task = asyncio.create_task(
+        _collect_n(client, "tuples/livecap", n, since_cursor=0, timeout=20.0)
+    )
+    # Yield enough times for the subscription to reach Phase 2 (live mode).
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+
+    # Single transaction, single commit -> single data_version bump -> 1500 trigger rows.
+    for i in range(n):
+        seeded_db.execute(
+            """\
+            INSERT INTO tuples
+                (id, subspace, template_name, content, dimensions_json, embed_text,
+                 created_at)
+            VALUES (?, 'tuples/livecap', 'test', 'x', '{}', 'x', ?)
+            """,
+            (f"livecap{i}", time.time()),
+        )
+    seeded_db.commit()
+
+    events = await collector_task
+    client.close()
+
+    assert len(events) == n, (
+        f"live mode dropped {n - len(events)} events under one data_version bump; "
+        "the per-poll fetch must drain in bursts until empty before advancing last_data_version"
+    )
+    cursors = [e["cursor"] for e in events]
+    assert cursors == sorted(set(cursors))
+
+
+# ---------------------------------------------------------------------------
 # Schema / migration smoke tests
 # ---------------------------------------------------------------------------
 

--- a/tests/daemon/test_event_stream.py
+++ b/tests/daemon/test_event_stream.py
@@ -1,0 +1,488 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for T2 daemon EventStream RPC — RDR-112 P1.3 (nexus-m4gm).
+
+Test matrix (all 6 from the bead acceptance criteria):
+  (a) Backfill correctness: out() N tuples, subscribe cursor=0, assert N events.
+  (b) Live streaming: subscribe, out() in another thread, assert events arrive.
+  (c) Cursor restart: receive 5 events, disconnect, reconnect cursor=5, no dups.
+  (d) Failure-category demux: nack with category='timeout', filter by category.
+  (e) Connection close cleanup: 10 open+close cycles, no leaked handlers.
+  (f) Backfill cap: out() 1500 tuples, cursor=0, first burst 1000 then 500 more.
+
+Helpers
+-------
+All tests use:
+  - ``tmp_path`` for tuples.db and config_dir isolation.
+  - ``port=0`` / UDS for transport.
+  - ``threading.Event`` for cross-thread synchronisation in live-streaming test.
+  - Direct sqlite3 inserts to seed tuples (bypassing the API layer) for speed.
+"""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from nexus.daemon.t2_client import T2Client
+from nexus.daemon.t2_daemon import T2Daemon
+from nexus.tuplespace.store import apply_tuples_schema
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _open_tuples_db(path: Path) -> sqlite3.Connection:
+    """Open (or create) a tuples.db at *path* with schema applied."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.commit()
+    apply_tuples_schema(conn)
+    return conn
+
+
+def _insert_tuple(
+    conn: sqlite3.Connection,
+    *,
+    tuple_id: str,
+    subspace: str = "tuples/test",
+    content: str = "hello",
+    created_at: float | None = None,
+) -> None:
+    """Insert a tuple row directly (triggers trg_tuples_out -> events)."""
+    if created_at is None:
+        created_at = time.time()
+    conn.execute(
+        """\
+        INSERT INTO tuples
+            (id, subspace, template_name, content, dimensions_json, embed_text,
+             created_at)
+        VALUES (?, ?, 'test', ?, '{}', ?, ?)
+        """,
+        (tuple_id, subspace, content, content, created_at),
+    )
+    conn.commit()
+
+
+def _insert_nack(
+    conn: sqlite3.Connection,
+    *,
+    tuple_id: str,
+    failure_category: str = "timeout",
+) -> None:
+    """Insert a nack row into tuple_claim_log (triggers trg_claim_log_event)."""
+    conn.execute(
+        """\
+        INSERT INTO tuple_claim_log
+            (tuple_id, claim_id, claimant, transition, failure_category, at)
+        VALUES (?, 'clm1', 'agent1', 'nack', ?, ?)
+        """,
+        (tuple_id, failure_category, time.time()),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def config_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "config"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture()
+def tuples_db_path(tmp_path: Path) -> Path:
+    return tmp_path / "tuples.db"
+
+
+@pytest.fixture()
+def seeded_db(tuples_db_path: Path) -> sqlite3.Connection:
+    """Open tuples.db with schema applied; caller closes."""
+    conn = _open_tuples_db(tuples_db_path)
+    yield conn
+    conn.close()
+
+
+@pytest_asyncio.fixture()
+async def daemon(config_dir: Path, tuples_db_path: Path):
+    """T2Daemon with tuples_db_path configured, started, yielded, stopped."""
+    d = T2Daemon(config_dir=config_dir, tuples_db_path=tuples_db_path)
+    await d.start()
+    yield d
+    await d.stop()
+
+
+def _make_client(daemon: T2Daemon) -> T2Client:
+    return T2Client(uds_path=daemon.uds_path)
+
+
+async def _collect_n(
+    client: T2Client,
+    subspace_prefix: str,
+    n: int,
+    *,
+    since_cursor: int = 0,
+    where: dict | None = None,
+    timeout: float = 5.0,
+) -> list[dict]:
+    """Collect exactly *n* events from event_stream then close the generator.
+
+    Runs the blocking generator in a thread pool executor so the asyncio
+    event loop remains free to serve the daemon during collection.
+    Raises ``TimeoutError`` if *n* events do not arrive within *timeout* seconds.
+    """
+    def _reader() -> list[dict]:
+        collected: list[dict] = []
+        gen = client.event_stream(subspace_prefix, since_cursor=since_cursor, where=where)
+        for event in gen:
+            collected.append(event)
+            if len(collected) >= n:
+                gen.close()
+                break
+        return collected
+
+    loop = asyncio.get_running_loop()
+    try:
+        return await asyncio.wait_for(
+            loop.run_in_executor(None, _reader),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError as exc:
+        raise TimeoutError(
+            f"_collect_n: did not receive {n} events within {timeout}s"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# (a) Backfill correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_correctness(
+    daemon: T2Daemon,
+    seeded_db: sqlite3.Connection,
+) -> None:
+    """Insert 10 tuples before subscribing; backfill must deliver all 10."""
+    n = 10
+    for i in range(n):
+        _insert_tuple(seeded_db, tuple_id=f"t{i}", subspace="tuples/backfill")
+
+    client = _make_client(daemon)
+    events = await _collect_n(client, "tuples/backfill", n, since_cursor=0)
+    client.close()
+
+    assert len(events) == n
+    # All should be 'out' ops (inserts into tuples)
+    assert all(e["op"] == "out" for e in events)
+    # Cursors must be monotonically increasing
+    cursors = [e["cursor"] for e in events]
+    assert cursors == sorted(cursors)
+    assert cursors == list(range(cursors[0], cursors[0] + n))
+
+
+# ---------------------------------------------------------------------------
+# (b) Live streaming
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_streaming(
+    daemon: T2Daemon,
+    tuples_db_path: Path,
+) -> None:
+    """Subscribe, then insert from a background thread; events must arrive."""
+    # Open the DB separately (the daemon does NOT hold a write connection
+    # in this test — we drive inserts from the test thread)
+    conn = _open_tuples_db(tuples_db_path)
+    try:
+        ready = threading.Event()
+        collected: list[dict[str, Any]] = []
+
+        client_holder: list[T2Client] = []
+
+        def _stream_reader() -> None:
+            client = _make_client(daemon)
+            client_holder.append(client)
+            try:
+                for event in client.event_stream("tuples/live", since_cursor=0):
+                    collected.append(event)
+                    ready.set()
+                    break  # one event is enough; gen.close() via context exits socket
+            finally:
+                client.close()
+
+        t = threading.Thread(target=_stream_reader, daemon=True)
+        t.start()
+
+        # Give subscriber time to connect
+        await asyncio.sleep(0.05)
+
+        # Insert a tuple from a thread (simulates out())
+        _insert_tuple(conn, tuple_id="live1", subspace="tuples/live")
+
+        # Wait for the event to arrive (max 1 second)
+        arrived = await asyncio.get_event_loop().run_in_executor(
+            None, lambda: ready.wait(timeout=2.0)
+        )
+        assert arrived, "live event did not arrive within 2 seconds"
+        # Join in executor so we don't block the event loop.
+        loop = asyncio.get_running_loop()
+        await asyncio.wait_for(
+            loop.run_in_executor(None, lambda: t.join(timeout=3.0)),
+            timeout=4.0,
+        )
+
+        assert len(collected) >= 1
+        assert collected[0]["tuple_id"] == "live1"
+        assert collected[0]["op"] == "out"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# (c) Cursor restart — no duplicates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cursor_restart_no_duplicates(
+    daemon: T2Daemon,
+    seeded_db: sqlite3.Connection,
+) -> None:
+    """Receive 5 events, disconnect, reconnect with cursor=last; assert no dups."""
+    # Insert 10 tuples
+    for i in range(10):
+        _insert_tuple(seeded_db, tuple_id=f"cr{i}", subspace="tuples/restart")
+
+    client = _make_client(daemon)
+    # Run in a thread to avoid blocking the asyncio event loop.
+    first_five = await _collect_n(client, "tuples/restart", 5, since_cursor=0)
+    client.close()
+
+    last_cursor = first_five[-1]["cursor"]
+
+    # Reconnect with since_cursor = last seen; collect the remaining 5.
+    client2 = _make_client(daemon)
+    remaining = await _collect_n(client2, "tuples/restart", 5, since_cursor=last_cursor)
+    client2.close()
+
+    assert len(remaining) == 5  # 10 total - 5 already seen
+    # No duplicates: all remaining cursors > last_cursor
+    assert all(e["cursor"] > last_cursor for e in remaining)
+    # Cursors monotonically increasing
+    cursors = [e["cursor"] for e in remaining]
+    assert cursors == sorted(cursors)
+
+
+# ---------------------------------------------------------------------------
+# (d) Failure-category demux
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failure_category_demux(
+    daemon: T2Daemon,
+    seeded_db: sqlite3.Connection,
+) -> None:
+    """Nack with category='timeout'; subscribe with where={category:'timeout'}."""
+    # Insert a tuple first (trg_tuples_out fires an 'out' event, category='data')
+    _insert_tuple(seeded_db, tuple_id="demux1", subspace="tuples/demux")
+    # Now insert a nack with category='timeout'
+    _insert_nack(seeded_db, tuple_id="demux1", failure_category="timeout")
+    # Insert another nack with category='disk_error'
+    _insert_nack(seeded_db, tuple_id="demux1", failure_category="disk_error")
+
+    client = _make_client(daemon)
+    # Subscribe with category filter = 'timeout'; collect the one matching event.
+    events = await _collect_n(
+        client,
+        "tuples/demux",
+        1,
+        since_cursor=0,
+        where={"category": "timeout"},
+    )
+    client.close()
+
+    # Only the nack with category='timeout' should appear
+    assert len(events) == 1
+    assert events[0]["op"] == "nack"
+    assert events[0]["category"] == "timeout"
+    assert events[0]["tuple_id"] == "demux1"
+
+
+# ---------------------------------------------------------------------------
+# (e) Connection close cleanup — no leaked handlers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connection_close_cleanup(
+    daemon: T2Daemon,
+    seeded_db: sqlite3.Connection,
+) -> None:
+    """Open and immediately close 10 event_stream subscriptions; no handler leaks."""
+    _insert_tuple(seeded_db, tuple_id="cl1", subspace="tuples/cleanup")
+
+    initial_handlers = len(daemon._active_handlers)
+
+    for _ in range(10):
+        client = _make_client(daemon)
+        # _collect_n runs the generator in a thread pool executor, reads 1 event,
+        # then closes the generator and socket — event loop stays free.
+        await _collect_n(client, "tuples/cleanup", 1, since_cursor=0)
+        client.close()
+
+    # Allow asyncio to clean up handler tasks
+    await asyncio.sleep(0.1)
+
+    # No more active handlers than before (they should have exited)
+    assert len(daemon._active_handlers) == initial_handlers
+
+
+# ---------------------------------------------------------------------------
+# (f) Backfill cap — 1500 tuples, burst 1000 then 500
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_cap_1500(
+    daemon: T2Daemon,
+    seeded_db: sqlite3.Connection,
+) -> None:
+    """Insert 1500 tuples; backfill delivers all via two bursts (1000 + 500)."""
+    n = 1500
+    for i in range(n):
+        # Batch inserts without triggering per-row commits to speed up the test
+        seeded_db.execute(
+            """\
+            INSERT INTO tuples
+                (id, subspace, template_name, content, dimensions_json, embed_text,
+                 created_at)
+            VALUES (?, 'tuples/bigbatch', 'test', 'x', '{}', 'x', ?)
+            """,
+            (f"big{i}", time.time()),
+        )
+    seeded_db.commit()  # Single commit triggers 1500 trigger-events atomically
+
+    client = _make_client(daemon)
+    events = await _collect_n(client, "tuples/bigbatch", n, since_cursor=0, timeout=15.0)
+    client.close()
+
+    assert len(events) == n
+    # Cursors must be monotonically increasing and gapless
+    cursors = [e["cursor"] for e in events]
+    assert cursors == sorted(set(cursors))
+    assert len(cursors) == n
+    # All are 'out' ops from the tuples trigger
+    assert all(e["op"] == "out" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Schema / migration smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_events_table_created_by_schema(tmp_path: Path) -> None:
+    """apply_tuples_schema creates the events table and both triggers."""
+    conn = _open_tuples_db(tmp_path / "t.db")
+    try:
+        tables = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "events" in tables
+
+        triggers = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='trigger'"
+            ).fetchall()
+        }
+        assert "trg_tuples_out" in triggers
+        assert "trg_claim_log_event" in triggers
+    finally:
+        conn.close()
+
+
+def test_failure_category_column_on_claim_log(tmp_path: Path) -> None:
+    """tuple_claim_log has failure_category column after schema apply."""
+    conn = _open_tuples_db(tmp_path / "t.db")
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(tuple_claim_log)").fetchall()}
+        assert "failure_category" in cols
+    finally:
+        conn.close()
+
+
+def test_out_trigger_inserts_event(tmp_path: Path) -> None:
+    """Inserting a tuple fires trg_tuples_out and creates an events row."""
+    conn = _open_tuples_db(tmp_path / "t.db")
+    try:
+        _insert_tuple(conn, tuple_id="trg1", subspace="tuples/trigger")
+        rows = conn.execute("SELECT op, subspace, tuple_id, category FROM events").fetchall()
+        assert len(rows) == 1
+        assert rows[0] == ("out", "tuples/trigger", "trg1", "data")
+    finally:
+        conn.close()
+
+
+def test_nack_trigger_inserts_event_with_category(tmp_path: Path) -> None:
+    """Nack insert fires trg_claim_log_event with correct failure_category."""
+    conn = _open_tuples_db(tmp_path / "t.db")
+    try:
+        _insert_tuple(conn, tuple_id="nk1", subspace="tuples/nack")
+        _insert_nack(conn, tuple_id="nk1", failure_category="disk_error")
+        rows = conn.execute(
+            "SELECT op, tuple_id, category FROM events ORDER BY rowid"
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0] == ("out", "nk1", "data")
+        assert rows[1] == ("nack", "nk1", "disk_error")
+    finally:
+        conn.close()
+
+
+def test_migrate_tuples_failure_category_idempotent(tmp_path: Path) -> None:
+    """migrate_tuples_failure_category is idempotent on a fresh schema."""
+    from nexus.db.migrations import migrate_tuples_failure_category
+
+    conn = _open_tuples_db(tmp_path / "t.db")
+    try:
+        # Should be a no-op (column already present via fresh schema)
+        migrate_tuples_failure_category(conn)
+        migrate_tuples_failure_category(conn)
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(tuple_claim_log)").fetchall()}
+        assert "failure_category" in cols
+    finally:
+        conn.close()
+
+
+def test_migrate_tuples_events_table_idempotent(tmp_path: Path) -> None:
+    """migrate_tuples_events_table is idempotent on a fresh schema."""
+    from nexus.db.migrations import migrate_tuples_events_table
+
+    conn = _open_tuples_db(tmp_path / "t.db")
+    try:
+        migrate_tuples_events_table(conn)
+        migrate_tuples_events_table(conn)
+        tables = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "events" in tables
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

- Implements `event_stream.subscribe` RPC (RDR-112 P1.3) — server-push streaming over a dedicated socket with backfill and live-mode polling
- Adds `events` table + two AFTER INSERT triggers to `TUPLES_SCHEMA_DDL`; `failure_category` column on `tuple_claim_log` for nack demux
- `T2Client.event_stream()` generator method for synchronous consumers; daemon-side `handle_event_stream` coroutine with `PRAGMA data_version` polling at 10 ms

## Key design decisions

- **Events table ownership**: option (b) — triggers on `tuples` (op='out') and `tuple_claim_log` (op=transition). DDL in `TUPLES_SCHEMA_DDL` so fresh installs get everything at first open.
- **Migration wiring**: `migrate_tuples_failure_category` + `migrate_tuples_events_table` called from `run_daemon_migrations` directly with the tuples.db connection. NOT in the `MIGRATIONS` registry (which passes memory.db connections).
- **EOF detection**: `StreamReader.at_eof()` synchronous check — avoids the `asyncio.wait_for(timeout=0)` hazard that can corrupt reader state.
- **`DAEMON_SCHEMA_VERSION`**: remains 1 (same as nexus-w0et). The events/failure_category schema is part of v1 in TUPLES_SCHEMA_DDL.
- **Rebase**: rebased onto develop post-w0et+qy0u merge. Conflict resolution kept both `watcher_state` (nexus-w0et) and `events` (nexus-m4gm) in `TUPLES_SCHEMA_DDL`.

## Test plan

- [x] `test_backfill_correctness` — 10 pre-inserted tuples delivered on subscribe
- [x] `test_live_streaming` — background insert visible via live mode polling
- [x] `test_cursor_restart_no_duplicates` — reconnect with last cursor, no dups
- [x] `test_failure_category_demux` — nack with category='timeout' filtered correctly
- [x] `test_connection_close_cleanup` — 10 open+close cycles, no leaked handlers
- [x] `test_backfill_cap_1500` — 1500 tuples in two bursts (1000+500)
- [x] 6 schema/migration smoke tests (trigger firing, idempotency)
- [x] All 212 tests in `tests/daemon/` + `tests/tuplespace/` pass

## Closes

Closes nexus-m4gm