### PR TITLE
fix(rdr-112): denormalize subspace + validate subspace_prefix (m4gm follow-ups)

### DIFF
--- a/src/nexus/daemon/event_stream.py
+++ b/src/nexus/daemon/event_stream.py
@@ -52,6 +52,7 @@ the daemon to filter events by ``category`` column in the SELECT WHERE clause.
 from __future__ import annotations
 
 import asyncio
+import re
 import sqlite3
 import time
 from pathlib import Path
@@ -66,6 +67,36 @@ BACKFILL_BURST_LIMIT: int = 1_000
 
 #: Poll interval (seconds) while a subscriber is connected.
 _POLL_ACTIVE: float = 0.010  # 10 ms
+
+#: Allowed character set for the non-wildcard part of subspace_prefix. The
+#: subspace name is path-shaped (e.g. ``tuples/tasks/coordinator``) so we
+#: accept alphanumerics, slash, dash, underscore, and dot. The only allowed
+#: GLOB metacharacter is a single trailing ``*``.
+_SUBSPACE_PREFIX_BODY = re.compile(r"^[A-Za-z0-9_./-]+$")
+
+
+def _validate_subspace_prefix(prefix: str) -> str | None:
+    """Return None if *prefix* is safe to expand to a GLOB pattern, else an error string.
+
+    Rejects:
+    - GLOB metacharacters other than a single trailing ``*`` (``?`` matches any
+      single character; ``[...]`` is a character class).
+    - ``*`` appearing anywhere except as the final character.
+    - Characters outside the path-safe set.
+    """
+    if "?" in prefix:
+        return "subspace_prefix may not contain '?' (GLOB single-char wildcard)"
+    if "[" in prefix or "]" in prefix:
+        return "subspace_prefix may not contain '[' or ']' (GLOB bracket-class)"
+    star_count = prefix.count("*")
+    if star_count > 1:
+        return "subspace_prefix may contain at most one '*' (as trailing wildcard)"
+    if star_count == 1 and not prefix.endswith("*"):
+        return "subspace_prefix '*' is only allowed as the trailing character"
+    body = prefix[:-1] if prefix.endswith("*") else prefix
+    if not _SUBSPACE_PREFIX_BODY.match(body):
+        return "subspace_prefix contains characters outside [A-Za-z0-9_./-]"
+    return None
 
 # ---------------------------------------------------------------------------
 # SQLite helpers (run in thread pool via asyncio.to_thread)
@@ -169,12 +200,23 @@ async def handle_event_stream(
         await writer.drain()
         return
 
+    # nexus-pce1.5: reject GLOB metacharacters other than a single trailing '*'.
+    # Without this, "tuples/foo?" would expand to "tuples/foo?*" where '?' is a
+    # GLOB wildcard matching any single character — broader than the caller
+    # likely intended. Also reject bracket-classes and '*' in non-terminal
+    # position. Allowed character set is the path-safe subset.
+    validation_error = _validate_subspace_prefix(subspace_prefix)
+    if validation_error is not None:
+        write_frame(writer, {"error": f"event_stream.subscribe: {validation_error}"})
+        await writer.drain()
+        return
+
     since_cursor: int = int(args.get("since_cursor") or 0)
     where: dict[str, Any] = args.get("where") or {}
     category_filter: str | None = where.get("category") or None
 
     # Convert subspace_prefix to SQLite GLOB pattern: "tuples/foo" -> "tuples/foo*"
-    glob_pattern = subspace_prefix if "*" in subspace_prefix else subspace_prefix + "*"
+    glob_pattern = subspace_prefix if subspace_prefix.endswith("*") else subspace_prefix + "*"
 
     _log.info(
         "event_stream_subscribe",

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -2711,7 +2711,7 @@ CREATE TRIGGER IF NOT EXISTS trg_claim_log_event
 BEGIN
     INSERT INTO events (subspace, op, tuple_id, payload_summary, category, ts)
     VALUES (
-        COALESCE((SELECT subspace FROM tuples WHERE id = NEW.tuple_id), ''),
+        NEW.subspace,
         NEW.transition,
         NEW.tuple_id,
         NULL,
@@ -2724,6 +2724,73 @@ BEGIN
 END;
 """)
     _log.info("migrate_tuples_events_table_done")
+
+
+def migrate_tuples_claim_log_subspace(conn: sqlite3.Connection) -> None:
+    """Denormalize ``subspace`` into ``tuple_claim_log`` (nexus-pce1.4).
+
+    The original ``trg_claim_log_event`` trigger used a COALESCE-on-JOIN to
+    fetch subspace from the parent tuple, falling back to empty string when
+    the tuple had been hard-deleted (e.g., retention sweep racing a slow
+    nack). Empty-string subspace events were invisible to all GLOB-pattern
+    subscribers, silently dropping legitimate nack signals.
+
+    This migration:
+      1. Adds ``subspace TEXT NOT NULL DEFAULT ''`` column to tuple_claim_log
+         (legacy rows get '' which preserves prior behaviour — they were
+         already silently dropped).
+      2. Backfills existing rows from tuples via JOIN where possible.
+      3. Drops + recreates ``trg_claim_log_event`` using ``NEW.subspace``
+         directly, eliminating the JOIN and the empty-string fallback.
+
+    Idempotent: gated by ``PRAGMA table_info``. No-op when tuples.db does
+    not exist (fresh installs get the column via TUPLES_SCHEMA_DDL).
+    """
+    cols = {
+        r[1] for r in conn.execute(
+            "PRAGMA table_info(tuple_claim_log)"
+        ).fetchall()
+    }
+    if not cols:
+        return  # tuples.db not yet initialised
+    if "subspace" in cols:
+        return
+
+    _log.info("migrate_tuples_claim_log_subspace_start")
+    # SQLite ALTER TABLE ADD COLUMN with NOT NULL requires a default.
+    conn.execute(
+        "ALTER TABLE tuple_claim_log ADD COLUMN subspace TEXT NOT NULL DEFAULT ''"
+    )
+    # Backfill from the parent tuple where it still exists.
+    conn.execute(
+        "UPDATE tuple_claim_log "
+        "SET subspace = (SELECT t.subspace FROM tuples t WHERE t.id = tuple_claim_log.tuple_id) "
+        "WHERE subspace = '' "
+        "  AND EXISTS (SELECT 1 FROM tuples t WHERE t.id = tuple_claim_log.tuple_id)"
+    )
+    # Replace the trigger body — DROP + CREATE since CREATE TRIGGER IF NOT EXISTS
+    # won't overwrite an existing definition.
+    conn.executescript("""\
+DROP TRIGGER IF EXISTS trg_claim_log_event;
+CREATE TRIGGER trg_claim_log_event
+    AFTER INSERT ON tuple_claim_log
+BEGIN
+    INSERT INTO events (subspace, op, tuple_id, payload_summary, category, ts)
+    VALUES (
+        NEW.subspace,
+        NEW.transition,
+        NEW.tuple_id,
+        NULL,
+        CASE
+            WHEN NEW.transition = 'nack' THEN COALESCE(NEW.failure_category, 'unknown')
+            ELSE 'data'
+        END,
+        NEW.at
+    );
+END;
+""")
+    conn.commit()
+    _log.info("migrate_tuples_claim_log_subspace_done")
 
 
 MIGRATIONS: list[Migration] = [
@@ -3464,6 +3531,9 @@ def run_daemon_migrations(
         # databases created before m4gm shipped.
         migrate_tuples_failure_category(tuples_conn)
         migrate_tuples_events_table(tuples_conn)
+        # nexus-pce1.4: denormalize subspace into tuple_claim_log to remove
+        # the COALESCE-on-deleted-tuple silent-drop in the EventStream trigger.
+        migrate_tuples_claim_log_subspace(tuples_conn)
     finally:
         tuples_conn.close()
 

--- a/src/nexus/tuplespace/api.py
+++ b/src/nexus/tuplespace/api.py
@@ -691,9 +691,9 @@ def take(
         return None
 
     conn.execute(
-        "INSERT INTO tuple_claim_log (tuple_id, claim_id, claimant, transition, at) "
-        "VALUES (?, ?, ?, 'claim', ?)",
-        (row[0], cid, claimant, now),
+        "INSERT INTO tuple_claim_log (tuple_id, subspace, claim_id, claimant, transition, at) "
+        "VALUES (?, ?, ?, ?, 'claim', ?)",
+        (row[0], subspace, cid, claimant, now),
     )
     conn.commit()
 
@@ -726,7 +726,7 @@ def ack(
         ClaimOwnershipError: *claimant* does not own the claim.
     """
     row = conn.execute(
-        "SELECT id, claimant FROM tuples WHERE claim_id = ? AND claim_state = 'claimed'",
+        "SELECT id, claimant, subspace FROM tuples WHERE claim_id = ? AND claim_state = 'claimed'",
         (claim_id,),
     ).fetchone()
 
@@ -748,9 +748,9 @@ def ack(
         (now, claimant, claim_id),
     )
     conn.execute(
-        "INSERT INTO tuple_claim_log (tuple_id, claim_id, claimant, transition, at) "
-        "VALUES (?, ?, ?, 'ack', ?)",
-        (row[0], claim_id, claimant, now),
+        "INSERT INTO tuple_claim_log (tuple_id, subspace, claim_id, claimant, transition, at) "
+        "VALUES (?, ?, ?, ?, 'ack', ?)",
+        (row[0], row[2], claim_id, claimant, now),
     )
     conn.commit()
     _log.debug("tuplespace_ack", tuple_id=row[0], claim_id=claim_id, claimant=claimant)
@@ -774,7 +774,7 @@ def nack(
         ClaimOwnershipError: *claimant* does not own the claim.
     """
     row = conn.execute(
-        "SELECT id, claimant FROM tuples WHERE claim_id = ? AND claim_state = 'claimed'",
+        "SELECT id, claimant, subspace FROM tuples WHERE claim_id = ? AND claim_state = 'claimed'",
         (claim_id,),
     ).fetchone()
 
@@ -796,9 +796,9 @@ def nack(
         (claim_id,),
     )
     conn.execute(
-        "INSERT INTO tuple_claim_log (tuple_id, claim_id, claimant, transition, at) "
-        "VALUES (?, ?, ?, 'nack', ?)",
-        (row[0], claim_id, claimant, now),
+        "INSERT INTO tuple_claim_log (tuple_id, subspace, claim_id, claimant, transition, at) "
+        "VALUES (?, ?, ?, ?, 'nack', ?)",
+        (row[0], row[2], claim_id, claimant, now),
     )
     conn.commit()
     _log.debug("tuplespace_nack", tuple_id=row[0], claim_id=claim_id, claimant=claimant)

--- a/src/nexus/tuplespace/store.py
+++ b/src/nexus/tuplespace/store.py
@@ -110,6 +110,7 @@ CREATE INDEX IF NOT EXISTS idx_tuples_expires
 CREATE TABLE IF NOT EXISTS tuple_claim_log (
     log_id           INTEGER PRIMARY KEY AUTOINCREMENT,
     tuple_id         TEXT NOT NULL,
+    subspace         TEXT NOT NULL,                 -- denormalized from tuples.subspace (nexus-pce1.4)
     claim_id         TEXT NOT NULL,
     claimant         TEXT NOT NULL,
     transition       TEXT NOT NULL,                 -- 'claim' | 'ack' | 'nack' | 'expire'
@@ -165,14 +166,15 @@ END;
 
 -- Trigger: emit a transition event on every tuple_claim_log insertion.
 -- Propagates failure_category for nack rows; uses 'data' for all others.
--- COALESCE on subspace handles the edge case where the tuple was deleted before
--- the claim log row was written (e.g. in tests or cleanup races).
+-- Uses NEW.subspace directly (denormalized at insert time) so the event
+-- survives even when the source tuple has been hard-deleted (e.g. by a
+-- retention sweep that races a slow nack). nexus-pce1.4.
 CREATE TRIGGER IF NOT EXISTS trg_claim_log_event
     AFTER INSERT ON tuple_claim_log
 BEGIN
     INSERT INTO events (subspace, op, tuple_id, payload_summary, category, ts)
     VALUES (
-        COALESCE((SELECT subspace FROM tuples WHERE id = NEW.tuple_id), ''),
+        NEW.subspace,
         NEW.transition,
         NEW.tuple_id,
         NULL,

--- a/tests/daemon/test_event_stream.py
+++ b/tests/daemon/test_event_stream.py
@@ -76,16 +76,17 @@ def _insert_nack(
     conn: sqlite3.Connection,
     *,
     tuple_id: str,
+    subspace: str = "tuples/test",
     failure_category: str = "timeout",
 ) -> None:
     """Insert a nack row into tuple_claim_log (triggers trg_claim_log_event)."""
     conn.execute(
         """\
         INSERT INTO tuple_claim_log
-            (tuple_id, claim_id, claimant, transition, failure_category, at)
-        VALUES (?, 'clm1', 'agent1', 'nack', ?, ?)
+            (tuple_id, subspace, claim_id, claimant, transition, failure_category, at)
+        VALUES (?, ?, 'clm1', 'agent1', 'nack', ?, ?)
         """,
-        (tuple_id, failure_category, time.time()),
+        (tuple_id, subspace, failure_category, time.time()),
     )
     conn.commit()
 
@@ -301,9 +302,9 @@ async def test_failure_category_demux(
     # Insert a tuple first (trg_tuples_out fires an 'out' event, category='data')
     _insert_tuple(seeded_db, tuple_id="demux1", subspace="tuples/demux")
     # Now insert a nack with category='timeout'
-    _insert_nack(seeded_db, tuple_id="demux1", failure_category="timeout")
+    _insert_nack(seeded_db, tuple_id="demux1", subspace="tuples/demux", failure_category="timeout")
     # Insert another nack with category='disk_error'
-    _insert_nack(seeded_db, tuple_id="demux1", failure_category="disk_error")
+    _insert_nack(seeded_db, tuple_id="demux1", subspace="tuples/demux", failure_category="disk_error")
 
     client = _make_client(daemon)
     # Subscribe with category filter = 'timeout'; collect the one matching event.
@@ -497,7 +498,7 @@ def test_nack_trigger_inserts_event_with_category(tmp_path: Path) -> None:
     conn = _open_tuples_db(tmp_path / "t.db")
     try:
         _insert_tuple(conn, tuple_id="nk1", subspace="tuples/nack")
-        _insert_nack(conn, tuple_id="nk1", failure_category="disk_error")
+        _insert_nack(conn, tuple_id="nk1", subspace="tuples/nack", failure_category="disk_error")
         rows = conn.execute(
             "SELECT op, tuple_id, category FROM events ORDER BY rowid"
         ).fetchall()
@@ -539,3 +540,87 @@ def test_migrate_tuples_events_table_idempotent(tmp_path: Path) -> None:
         assert "events" in tables
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# (g) nexus-pce1.4: nack-after-tuple-delete still delivers event to subscriber
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nack_after_tuple_deleted_still_delivered(
+    daemon: T2Daemon,
+    seeded_db: sqlite3.Connection,
+) -> None:
+    """Retention-sweep simulation: delete the tuple, then write the nack.
+
+    Pre-pce1.4 trg_claim_log_event used COALESCE-on-JOIN with empty-string
+    fallback, which left no subspace-matched subscriber able to see the
+    event. With subspace denormalized into tuple_claim_log, the trigger
+    uses NEW.subspace directly and the event reaches subscribers.
+    """
+    subspace = "tuples/retention"
+    _insert_tuple(seeded_db, tuple_id="rt1", subspace=subspace)
+    # Hard-delete the tuple BEFORE the nack lands (retention sweep race).
+    seeded_db.execute("DELETE FROM tuples WHERE id = 'rt1'")
+    seeded_db.commit()
+    # Now write the nack — subspace must be supplied because the parent row is gone.
+    _insert_nack(seeded_db, tuple_id="rt1", subspace=subspace, failure_category="late-nack")
+
+    client = _make_client(daemon)
+    # We expect two events for this subspace: the 'out' and the 'nack'.
+    events = await _collect_n(client, subspace, 2, since_cursor=0, timeout=5.0)
+    client.close()
+
+    ops = sorted(e["op"] for e in events)
+    assert ops == ["nack", "out"]
+    nack_event = next(e for e in events if e["op"] == "nack")
+    assert nack_event["subspace"] == subspace
+    assert nack_event["category"] == "late-nack"
+
+
+# ---------------------------------------------------------------------------
+# (h) nexus-pce1.5: subspace_prefix GLOB injection rejected
+# ---------------------------------------------------------------------------
+
+
+def test_validate_subspace_prefix_accepts_safe_inputs() -> None:
+    from nexus.daemon.event_stream import _validate_subspace_prefix
+
+    assert _validate_subspace_prefix("tuples/tasks") is None
+    assert _validate_subspace_prefix("tuples/tasks*") is None
+    assert _validate_subspace_prefix("tuples/tasks/coordinator") is None
+    assert _validate_subspace_prefix("tuples/v1.2") is None
+    assert _validate_subspace_prefix("tuples/with-dash") is None
+    assert _validate_subspace_prefix("tuples/with_underscore") is None
+
+
+def test_validate_subspace_prefix_rejects_glob_metachars() -> None:
+    from nexus.daemon.event_stream import _validate_subspace_prefix
+
+    assert "'?'" in (_validate_subspace_prefix("tuples/foo?") or "")
+    assert "[" in (_validate_subspace_prefix("tuples/[abc]") or "")
+    assert "]" in (_validate_subspace_prefix("tuples/abc]") or "")
+
+
+def test_validate_subspace_prefix_rejects_non_terminal_star() -> None:
+    from nexus.daemon.event_stream import _validate_subspace_prefix
+
+    err = _validate_subspace_prefix("tuples/*/foo")
+    assert err is not None
+    assert "trailing" in err or "at most one" in err
+
+
+def test_validate_subspace_prefix_rejects_multiple_stars() -> None:
+    from nexus.daemon.event_stream import _validate_subspace_prefix
+
+    err = _validate_subspace_prefix("tuples/*/*")
+    assert err is not None
+
+
+def test_validate_subspace_prefix_rejects_disallowed_chars() -> None:
+    from nexus.daemon.event_stream import _validate_subspace_prefix
+
+    assert _validate_subspace_prefix("tuples/foo bar") is not None  # space
+    assert _validate_subspace_prefix("tuples/foo;DROP") is not None  # semicolon
+    assert _validate_subspace_prefix("tuples/foo'") is not None  # quote

--- a/tests/tuplespace/test_store.py
+++ b/tests/tuplespace/test_store.py
@@ -295,8 +295,8 @@ class TestPartialIndexCorrectness:
 
         # Insert a log row so the planner has a populated table.
         conn.execute(
-            "INSERT INTO tuple_claim_log (tuple_id, claim_id, claimant, transition, at) "
-            "VALUES ('t1', 'c1', 'agent', 'claim', ?)",
+            "INSERT INTO tuple_claim_log (tuple_id, subspace, claim_id, claimant, transition, at) "
+            "VALUES ('t1', 'tuples/test', 'c1', 'agent', 'claim', ?)",
             (now,),
         )
         conn.commit()


### PR DESCRIPTION
Two PR #771 review follow-ups bundled.

## Closes

- Closes #nexus-pce1.4 — Denormalize subspace into tuple_claim_log (eliminate COALESCE empty-subspace silent-drop)
- Closes #nexus-pce1.5 — Validate subspace_prefix to prevent GLOB wildcard injection

## Summary

**pce1.4** — The trg_claim_log_event trigger used COALESCE on a JOIN against tuples; when a tuple was hard-deleted before its nack landed (retention-sweep race), the event was emitted with subspace='' and invisible to all GLOB subscribers. Fix: denormalize subspace into tuple_claim_log so the trigger uses NEW.subspace directly. Migration backfills legacy rows via JOIN; trigger is DROP+CREATE so the old body is replaced.

**pce1.5** — The '*'-only check let 'tuples/foo?' expand to a broader-than-intended GLOB. New _validate_subspace_prefix rejects '?', '[', ']', non-terminal '*', multiple '*', and non-path-safe characters. Server returns a clear error frame.

## Test plan

- [x] 224 tests pass across tests/daemon/ + tests/db/ + tests/tuplespace/
- [x] New regression test: nack after tuple-deletion still reaches subscriber (pce1.4)
- [x] New unit tests: 5 invalid prefix shapes + 6 valid (pce1.5)