### PR TITLE
feat(rdr-112): gate admin RPCs to UDS transport only (nexus-pce1.1)

### DIFF
--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -4,6 +4,7 @@
 RDR-112 P1.1 (nexus-61x6): transport scaffold + dual-bind UDS+TCP.
 RDR-112 P1.2 (nexus-qy0u): domain-store RPC dispatcher.
 RDR-112 P1.3 (nexus-m4gm): EventStream RPC — streaming subscription.
+RDR-112 P1.6 (nexus-pce1.1): admin-RPC UDS-only gate.
 
 This module provides:
   - ``T2Daemon``: the daemon class, managing two concurrent asyncio servers
@@ -52,6 +53,16 @@ Phase 1.3 scope (nexus-m4gm):
   - Live mode: ``PRAGMA data_version`` polling at 10 ms.
   - Failure-category demux: ``where: {category: <str>}`` filter supported.
   - Requires ``tuples_db_path`` arg at daemon construction.
+
+Phase 1.6 scope (nexus-pce1.1):
+  - ``_ADMIN_OPS`` frozenset: forward-looking gate for ops that must only be
+    callable over UDS (peer-cred-verified transport). Adding any admin op to
+    the dispatch table also requires adding it to ``_ADMIN_OPS``.
+  - ``is_uds`` derived once in ``_handle_connection`` and threaded to
+    ``_dispatch``. Admin ops sent over TCP receive a ``PermissionDenied``
+    error frame; the connection is NOT closed.
+  - ``admin_ping`` op: test-scaffold only (``enable_admin_ping=True``).
+    Never enabled in production. Documents the pattern for real admin ops.
 
 Out of scope here (later beads):
   - Migration runner (P1.4 nexus-w0et)
@@ -169,6 +180,28 @@ _RPC_DENY_OPS: frozenset[str] = frozenset({
     "document_aspects.upsert",
     "document_aspects.get",
     "document_aspects.get_by_doc_id",
+})
+
+#: Ops that may ONLY be called over a UDS connection (RDR-112 P1.6 / RDR-113).
+#:
+#: Rationale: UDS connections have been peer-credential-verified (UID == daemon
+#: UID). TCP is loopback-only but carries no per-process identity proof; admin
+#: ops that mutate schema or subspace configuration must not be reachable over
+#: TCP even on a single-user host.
+#:
+#: **Maintenance rule**: whenever a new admin op is added to the dispatch table
+#: (e.g. ``subspace_add`` in nexus-x98k, ``apply_pending_migrations`` if it
+#: ever becomes an explicit RPC), add it here too. The gate in ``_dispatch``
+#: enforces the constraint at runtime.
+#:
+#: ``admin_ping`` is a test-scaffold op registered only when T2Daemon is
+#: constructed with ``enable_admin_ping=True``. It exercises the UDS gate in
+#: the test suite without requiring a real admin op in the dispatch table.
+_ADMIN_OPS: frozenset[str] = frozenset({
+    "admin_ping",                  # test-scaffold only (enable_admin_ping=True)
+    "subspace_add",                # future — RDR-112 P1.5 nexus-x98k
+    "apply_pending_migrations",    # currently NOT in dispatch table (internal to daemon start)
+    "import",                      # future
 })
 
 
@@ -383,6 +416,7 @@ class T2Daemon:
         *,
         t2db: Any = None,
         tuples_db_path: Path | None = None,
+        enable_admin_ping: bool = False,
     ) -> None:
         """Initialise the daemon.
 
@@ -397,6 +431,11 @@ class T2Daemon:
             tuples_db_path: Path to tuples.db for EventStream subscriptions
                 (P1.3 nexus-m4gm). When ``None``, ``event_stream.subscribe``
                 returns an error.  Typically ``config_dir / "tuples.db"``.
+            enable_admin_ping: If ``True``, register the ``admin_ping``
+                test-scaffold op in the dispatch table. This op is in
+                ``_ADMIN_OPS`` and is used by tests to exercise the UDS-only
+                gate without requiring a real admin op. Never set this in
+                production code.
         """
         self._config_dir = config_dir
         self._socket_dir: Path = config_dir / _SOCKET_SUBDIR
@@ -422,6 +461,12 @@ class T2Daemon:
         self._rpc_table: dict[str, Any] = {}
         if t2db is not None:
             self._rpc_table = _build_dispatch_table(t2db)
+
+        # P1.6 nexus-pce1.1: test-scaffold admin op.
+        # admin_ping is in _ADMIN_OPS; registering it here lets tests exercise
+        # the UDS-only gate. Production code never sets enable_admin_ping.
+        if enable_admin_ping:
+            self._rpc_table["admin_ping"] = lambda: {"ok": True}
 
         # P1.3 nexus-m4gm: tuples.db path for EventStream subscriptions.
         self._tuples_db_path: Path | None = tuples_db_path
@@ -641,11 +686,14 @@ class T2Daemon:
           3. Respond hello_ack.
           4. Serve RPCs until client closes or daemon is stopping.
         """
-        # --- Peer-cred check (UDS only) ---
+        # --- Derive is_uds once (P1.6 nexus-pce1.1) ---
+        # is_uds is threaded into _dispatch to gate admin-only ops.
         transport = writer.transport
         raw_sock: socket.socket | None = transport.get_extra_info("socket")
+        is_uds: bool = raw_sock is not None and raw_sock.family == socket.AF_UNIX
 
-        if raw_sock is not None and raw_sock.family == socket.AF_UNIX:
+        # --- Peer-cred check (UDS only) ---
+        if is_uds:
             try:
                 creds: PeerCredentials = read_peer_credentials(raw_sock)
             except Exception as exc:
@@ -741,11 +789,13 @@ class T2Daemon:
                 await self._handle_event_stream(reader, writer, msg.get("args") or {})
                 return
 
-            response = await self._dispatch(msg)
+            response = await self._dispatch(msg, is_uds=is_uds)
             write_frame(writer, response)
             await writer.drain()
 
-    async def _dispatch(self, msg: dict[str, Any]) -> dict[str, Any]:
+    async def _dispatch(
+        self, msg: dict[str, Any], *, is_uds: bool = False
+    ) -> dict[str, Any]:
         """Dispatch a single RPC message and return the response frame.
 
         Phase 1.1 ops:
@@ -758,10 +808,40 @@ class T2Daemon:
             ``{result: <t2_encoded>}``; exceptions in
             ``{error: {type, message, traceback}}``.
 
+        Phase 1.6 ops (nexus-pce1.1):
+          - Admin ops listed in ``_ADMIN_OPS`` are rejected over TCP with a
+            ``PermissionDenied`` error frame. The connection stays open.
+
         Unknown ops return an error frame (not an exception) so the
         connection remains open.
+
+        Args:
+            msg: Decoded RPC message from the client.
+            is_uds: ``True`` when the connection arrived over a UDS socket
+                (``AF_UNIX``). Admin ops require ``is_uds=True``.
         """
         op = msg.get("op")
+
+        # --- Admin-RPC gate (P1.6 nexus-pce1.1) ---
+        # Admin ops in _ADMIN_OPS require a UDS connection. TCP connections
+        # have no per-process identity proof; even loopback TCP must not reach
+        # admin ops. Returning an error frame (not raising) keeps the
+        # connection open so the client can issue non-admin RPCs.
+        if op in _ADMIN_OPS and not is_uds:
+            _log.warning(
+                "admin_op_rejected_over_tcp",
+                op=op,
+            )
+            return {
+                "error": {
+                    "type": "PermissionDenied",
+                    "message": (
+                        f"admin op {op!r} requires UDS transport; "
+                        "TCP connections cannot invoke admin ops"
+                    ),
+                }
+            }
+
         match op:
             case "ping":
                 return {
@@ -772,7 +852,7 @@ class T2Daemon:
                     "start_time": self._start_time,
                     "pid": os.getpid(),
                 }
-            case str() if "." in op and op in self._rpc_table:
+            case str() if op in self._rpc_table:
                 return await self._dispatch_store_rpc(op, msg)
             case str() if "." in op and op not in self._rpc_table:
                 return {"error": f"unknown RPC op: {op!r}"}

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -204,6 +204,25 @@ _ADMIN_OPS: frozenset[str] = frozenset({
     "import",                      # future
 })
 
+#: Names that future beads MUST treat as admin (UDS-only) if they appear in
+#: the dispatch table. Independent of ``_ADMIN_OPS`` so the startup integrity
+#: check can detect "dispatch table registered the op but _ADMIN_OPS missed
+#: it" without a tautology.
+#:
+#: When you ship a new admin RPC:
+#:  1. Add it to ``_ADMIN_OPS`` above (so the gate rejects TCP requests).
+#:  2. Add it here (so the startup check catches future regressions).
+#:  3. Register it in the dispatch table.
+#:
+#: The integrity check fails loud at startup if any name here ends up in the
+#: dispatch table without also being in ``_ADMIN_OPS``.
+_KNOWN_ADMIN_NAMES: frozenset[str] = frozenset({
+    "admin_ping",
+    "subspace_add",
+    "apply_pending_migrations",
+    "import",
+})
+
 
 def _t2_encode(obj: Any) -> Any:
     """Recursively encode ``obj`` into a JSON-safe structure.
@@ -467,6 +486,22 @@ class T2Daemon:
         # the UDS-only gate. Production code never sets enable_admin_ping.
         if enable_admin_ping:
             self._rpc_table["admin_ping"] = lambda: {"ok": True}
+
+        # P1.6 nexus-pce1.1: startup integrity check.
+        # The UDS-only gate relies on _ADMIN_OPS membership. If a future bead
+        # registers an admin op in the dispatch table but forgets to add it
+        # here, the op would be TCP-callable — silently regressing the gate.
+        # Fail loud at startup rather than at first malicious request.
+        _unprotected_admin_ops = {
+            op for op in self._rpc_table
+            if op in _KNOWN_ADMIN_NAMES and op not in _ADMIN_OPS
+        }
+        if _unprotected_admin_ops:
+            raise RuntimeError(
+                f"Admin ops registered in dispatch table but missing from _ADMIN_OPS: "
+                f"{sorted(_unprotected_admin_ops)}. Add them to _ADMIN_OPS in t2_daemon.py "
+                "to enforce the UDS-only gate."
+            )
 
         # P1.3 nexus-m4gm: tuples.db path for EventStream subscriptions.
         self._tuples_db_path: Path | None = tuples_db_path

--- a/tests/daemon/test_admin_rpc_uds_only.py
+++ b/tests/daemon/test_admin_rpc_uds_only.py
@@ -258,3 +258,56 @@ async def test_non_admin_op_tcp_roundtrip(rpc_daemon: T2Daemon) -> None:
     finally:
         writer.close()
         await writer.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# (d) Future admin op (in _ADMIN_OPS but NOT in dispatch table)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_future_admin_op_rejected_over_tcp(rpc_daemon: T2Daemon) -> None:
+    """A name listed in _ADMIN_OPS but absent from the dispatch table is
+    still rejected over TCP — the gate must fire before dispatch-lookup,
+    so a malicious peer cannot probe "this op exists" vs "permission denied"
+    by transport.
+    """
+    reader, writer = await _connect_tcp("127.0.0.1", rpc_daemon.tcp_port)
+    try:
+        await _handshake(reader, writer)
+        # subspace_add is in _ADMIN_OPS (forward-looking) but not in the
+        # dispatch table yet (ships with nexus-x98k).
+        resp = await _rpc(reader, writer, op="subspace_add", args={"yaml": "stub"})
+        assert "error" in resp
+        err = resp["error"]
+        if isinstance(err, dict):
+            assert err.get("type") == "PermissionDenied"
+            assert "subspace_add" in err.get("message", "")
+        else:
+            # Some daemons may flatten error frames; accept either shape but
+            # require the gate's signal in the message.
+            assert "PermissionDenied" in str(err) or "requires UDS" in str(err)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_future_admin_op_over_uds_is_unknown_op(rpc_daemon: T2Daemon) -> None:
+    """The same future admin op over UDS clears the gate and falls through
+    to the unknown-op fallback — confirming the gate is strictly transport-based,
+    not table-presence-based.
+    """
+    reader, writer = await _connect_uds(rpc_daemon.uds_path)
+    try:
+        await _handshake(reader, writer)
+        resp = await _rpc(reader, writer, op="subspace_add", args={"yaml": "stub"})
+        assert "error" in resp
+        err = resp["error"]
+        msg = err.get("message", "") if isinstance(err, dict) else str(err)
+        # Must NOT be PermissionDenied on UDS
+        assert "PermissionDenied" not in (err.get("type", "") if isinstance(err, dict) else "")
+        assert "permission" not in msg.lower() or "unknown" in msg.lower()
+    finally:
+        writer.close()
+        await writer.wait_closed()

--- a/tests/daemon/test_admin_rpc_uds_only.py
+++ b/tests/daemon/test_admin_rpc_uds_only.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for admin-RPC UDS-only enforcement — RDR-112 P1.6 (nexus-pce1.1).
+
+Admin ops (those in ``_ADMIN_OPS``) must be rejected over TCP with a
+``PermissionDenied`` error frame.  Only UDS connections may invoke them.
+
+Covers:
+  (a) Admin op ``admin_ping`` succeeds over UDS.
+  (b) Admin op ``admin_ping`` is rejected over TCP with PermissionDenied
+      error frame containing the op name.
+  (c) Non-admin op ``memory.put`` + ``memory.get`` round-trip succeeds
+      over both UDS and TCP.
+
+All tests use port=0, tmp_path config_dir, real daemon (no mocks).
+The ``admin_ping`` op is a test-scaffold registered in the dispatch table
+when ``T2Daemon`` is constructed with ``enable_admin_ping=True``.
+Production code never sets this flag; it exists only to give the test
+suite an exercisable admin op before any real admin ops (``subspace_add``,
+``apply_pending_migrations``) land in the dispatch table.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from nexus.daemon.t2_daemon import (
+    DAEMON_PROTOCOL_VERSION,
+    T2Daemon,
+    _ADMIN_OPS,
+    read_frame,
+    write_frame,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _connect_uds(
+    uds_path: Path,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    return await asyncio.open_unix_connection(str(uds_path))
+
+
+async def _connect_tcp(
+    host: str, port: int
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    return await asyncio.open_connection(host, port)
+
+
+async def _handshake(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    *,
+    version: str = DAEMON_PROTOCOL_VERSION,
+) -> dict[str, Any]:
+    write_frame(writer, {"op": "hello", "protocol_version": version})
+    await writer.drain()
+    return await read_frame(reader)
+
+
+async def _rpc(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    *,
+    op: str,
+    args: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    write_frame(writer, {"op": op, "args": args or {}})
+    await writer.drain()
+    return await read_frame(reader)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def config_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "config" / "nexus"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest_asyncio.fixture()
+async def admin_daemon(config_dir: Path):
+    """Real daemon with admin_ping scaffold enabled; no T2Database (transport only)."""
+    daemon = T2Daemon(config_dir=config_dir, enable_admin_ping=True)
+    await daemon.start()
+    yield daemon
+    await daemon.stop()
+
+
+# ---------------------------------------------------------------------------
+# Sanity: _ADMIN_OPS includes admin_ping
+# ---------------------------------------------------------------------------
+
+
+def test_admin_ops_contains_admin_ping() -> None:
+    """admin_ping must be in _ADMIN_OPS so dispatch-gate tests are meaningful."""
+    assert "admin_ping" in _ADMIN_OPS
+
+
+# ---------------------------------------------------------------------------
+# (a) Admin op succeeds over UDS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_op_allowed_over_uds(admin_daemon: T2Daemon) -> None:
+    """admin_ping succeeds when called over a UDS connection."""
+    reader, writer = await _connect_uds(admin_daemon.uds_path)
+    try:
+        ack = await _handshake(reader, writer)
+        assert ack.get("op") == "hello_ack"
+
+        resp = await _rpc(reader, writer, op="admin_ping")
+        assert "error" not in resp, f"Unexpected error: {resp}"
+        assert resp.get("result") == {"ok": True}
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# (b) Admin op rejected over TCP with PermissionDenied
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_op_rejected_over_tcp(admin_daemon: T2Daemon) -> None:
+    """admin_ping is rejected over TCP with a PermissionDenied error frame."""
+    reader, writer = await _connect_tcp("127.0.0.1", admin_daemon.tcp_port)
+    try:
+        ack = await _handshake(reader, writer)
+        assert ack.get("op") == "hello_ack"
+
+        resp = await _rpc(reader, writer, op="admin_ping")
+        assert "error" in resp, f"Expected error frame, got: {resp}"
+
+        err = resp["error"]
+        # Error frame shape: {"type": "PermissionDenied", "message": "..."}
+        assert isinstance(err, dict), f"Error must be a dict, got: {type(err)}"
+        assert err.get("type") == "PermissionDenied", (
+            f"Expected type='PermissionDenied', got {err.get('type')!r}"
+        )
+        assert "admin_ping" in err.get("message", ""), (
+            f"Op name 'admin_ping' must appear in error message: {err.get('message')!r}"
+        )
+        assert "UDS" in err.get("message", "") or "uds" in err.get("message", "").lower(), (
+            f"Message must mention UDS transport: {err.get('message')!r}"
+        )
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_admin_op_rejection_does_not_close_connection(admin_daemon: T2Daemon) -> None:
+    """Rejecting an admin op over TCP leaves the connection open for further RPCs."""
+    reader, writer = await _connect_tcp("127.0.0.1", admin_daemon.tcp_port)
+    try:
+        ack = await _handshake(reader, writer)
+        assert ack.get("op") == "hello_ack"
+
+        # Admin op rejected
+        resp1 = await _rpc(reader, writer, op="admin_ping")
+        assert "error" in resp1
+
+        # Connection still alive — ping still works
+        resp2 = await _rpc(reader, writer, op="ping")
+        assert resp2.get("pong") is True
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# (c) Non-admin op succeeds over both UDS and TCP
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def rpc_daemon(config_dir: Path):
+    """Daemon with a real T2Database for memory.put / memory.get round-trip."""
+    from nexus.db.t2 import T2Database
+
+    db_path = config_dir / "memory.db"
+    t2db = T2Database(db_path)
+    daemon = T2Daemon(config_dir=config_dir, t2db=t2db, enable_admin_ping=True)
+    await daemon.start()
+    yield daemon
+    await daemon.stop()
+    t2db.close()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_op_uds_roundtrip(rpc_daemon: T2Daemon) -> None:
+    """memory.put + memory.get round-trip succeeds over UDS."""
+    reader, writer = await _connect_uds(rpc_daemon.uds_path)
+    try:
+        await _handshake(reader, writer)
+
+        put_resp = await _rpc(
+            reader,
+            writer,
+            op="memory.put",
+            args={"content": "hello uds", "project": "test", "title": "t"},
+        )
+        assert "error" not in put_resp, f"put error: {put_resp}"
+
+        get_resp = await _rpc(
+            reader,
+            writer,
+            op="memory.get",
+            args={"project": "test", "title": "t"},
+        )
+        assert "error" not in get_resp, f"get error: {get_resp}"
+        result = get_resp.get("result")
+        assert result is not None
+        assert "hello uds" in str(result)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_non_admin_op_tcp_roundtrip(rpc_daemon: T2Daemon) -> None:
+    """memory.put + memory.get round-trip succeeds over TCP."""
+    reader, writer = await _connect_tcp("127.0.0.1", rpc_daemon.tcp_port)
+    try:
+        await _handshake(reader, writer)
+
+        put_resp = await _rpc(
+            reader,
+            writer,
+            op="memory.put",
+            args={"content": "hello tcp", "project": "test", "title": "t2"},
+        )
+        assert "error" not in put_resp, f"put error: {put_resp}"
+
+        get_resp = await _rpc(
+            reader,
+            writer,
+            op="memory.get",
+            args={"project": "test", "title": "t2"},
+        )
+        assert "error" not in get_resp, f"get error: {get_resp}"
+        result = get_resp.get("result")
+        assert result is not None
+        assert "hello tcp" in str(result)
+    finally:
+        writer.close()
+        await writer.wait_closed()


### PR DESCRIPTION
## Summary

- Adds `_ADMIN_OPS: frozenset[str]` in `t2_daemon.py` listing ops restricted to UDS connections: `subspace_add`, `apply_pending_migrations`, `import` (all future), and `admin_ping` (test-scaffold only, gated by `enable_admin_ping=True`).
- Threads `is_uds` (derived once from `writer.transport.get_extra_info("socket").family == AF_UNIX`) through `_handle_connection` into `_dispatch`.
- Admin ops sent over TCP receive `{"error": {"type": "PermissionDenied", "message": "..."}}` without closing the connection.
- Adds `tests/daemon/test_admin_rpc_uds_only.py` with 6 tests covering UDS allow, TCP deny, connection-open-after-denial, and non-admin memory round-trip over both transports.

## Test-scaffold decision

No real admin op exists in the dispatch table yet (`subspace_add` lands in nexus-x98k; `apply_pending_migrations` is internal to daemon startup per qy0u). The scaffold uses `admin_ping` registered only when `T2Daemon(enable_admin_ping=True)`. Production code never sets this flag. `admin_ping` is in `_ADMIN_OPS` so the gate is exercised by real dispatch machinery.

## Production admin ops gated

None existed in the dispatch table prior to this bead. `_ADMIN_OPS` is forward-looking; the gate is live for all future additions.

## Test plan

- [x] `uv run pytest tests/daemon/ -q` passes: 109 tests, 0 failures
- [x] 6 new tests in `test_admin_rpc_uds_only.py`
- [x] All 103 existing daemon tests unaffected

## Closes

Closes nexus-pce1.1