### PR TITLE
feat(rdr-112): introspection RPC surface — exec_raw, schema, peek, stats, export (nexus-08i1)

### DIFF
--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -256,3 +256,378 @@ def subspace_add_cmd(yaml_path: Path, config_dir_str: str | None) -> None:
 
     click.echo(f"Registered: {result.get('name')}")
     click.echo(f"Digest:     {result.get('digest')}")
+# Helpers shared by introspection subcommands
+# ---------------------------------------------------------------------------
+
+
+def _nexus_config_dir() -> Path:
+    from nexus.config import nexus_config_dir as _ncd
+    return _ncd()
+
+
+def _client_from_disc(disc_data: dict) -> "T2Client":  # noqa: F821
+    from nexus.daemon.t2_client import T2Client
+    uds = disc_data.get("uds_path")
+    tcp = disc_data.get("tcp_addr")
+    if uds:
+        return T2Client(uds_path=Path(uds))
+    if tcp:
+        host, port_str = tcp.split(":")
+        return T2Client(tcp_addr=(host, int(port_str)))
+    raise RuntimeError("Discovery file missing both uds_path and tcp_addr.")
+
+
+def _uds_client_from_disc(disc_data: dict) -> "T2Client":  # noqa: F821
+    """Return a UDS-only client; exit if not available (admin ops require UDS)."""
+    from nexus.daemon.t2_client import T2Client
+    uds = disc_data.get("uds_path")
+    if not uds:
+        click.echo("Discovery file missing uds_path. Admin ops require UDS.", err=True)
+        sys.exit(1)
+    return T2Client(uds_path=Path(uds))
+
+
+def _load_disc(config_dir_str: str | None) -> dict:
+    config_dir = Path(config_dir_str) if config_dir_str else _nexus_config_dir()
+    disc = _discovery_path(config_dir)
+    if not disc.exists():
+        click.echo("No T2 daemon discovery file found.", err=True)
+        sys.exit(1)
+    try:
+        return json.loads(disc.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        click.echo(f"Failed to read discovery file: {exc}", err=True)
+        sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# nx daemon t2 exec  (admin -- UDS only)
+# ---------------------------------------------------------------------------
+
+
+@t2_group.command("exec")
+@click.option("--config-dir", "config_dir_str", default=None, help="Config directory override.")
+@click.option(
+    "--raw",
+    "sql",
+    required=True,
+    metavar="SQL",
+    help="SQL string to execute (read-only; mode=ro enforced by daemon).",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
+def exec_cmd(config_dir_str: str | None, sql: str, as_json: bool) -> None:
+    """Execute read-only SQL on the T2 database via the daemon (admin, UDS only).
+
+    Writes are rejected by SQLite mode=ro on the daemon side.
+
+    Example:
+      nx daemon t2 exec --raw "SELECT COUNT(*) FROM memory"
+    """
+    from nexus.daemon.t2_client import T2Client, T2DaemonError  # noqa: F401
+
+    disc = _load_disc(config_dir_str)
+    client = _uds_client_from_disc(disc)
+    try:
+        result = client.call("exec_raw", {"sql": sql})
+    except T2DaemonError as exc:
+        click.echo(f"Daemon error: {exc}", err=True)
+        sys.exit(1)
+    except (ConnectionError, OSError) as exc:
+        click.echo(f"Connection error: {exc}", err=True)
+        sys.exit(1)
+    finally:
+        client.close()
+
+    if as_json:
+        click.echo(json.dumps(result, indent=2))
+        return
+    if not result:
+        click.echo("(no rows)")
+        return
+    headers = list(result[0].keys())
+    widths = [
+        max(len(h), max((len(str(row.get(h, ""))) for row in result), default=0))
+        for h in headers
+    ]
+    click.echo("  ".join(h.ljust(w) for h, w in zip(headers, widths)))
+    click.echo("-" * (sum(widths) + 2 * (len(widths) - 1)))
+    for row in result:
+        click.echo("  ".join(str(row.get(h, "")).ljust(w) for h, w in zip(headers, widths)))
+
+
+# ---------------------------------------------------------------------------
+# nx daemon t2 schema
+# ---------------------------------------------------------------------------
+
+
+@t2_group.command("schema")
+@click.option("--config-dir", "config_dir_str", default=None, help="Config directory override.")
+@click.option("--tables", "tables_filter", default=None, help="Filter to a specific table name.")
+@click.option("--indexes", "indexes", is_flag=True, default=False, help="Include indexes.")
+@click.option("--fts", "fts", is_flag=True, default=False, help="Include FTS5 virtual tables.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
+def schema_cmd(
+    config_dir_str: str | None,
+    tables_filter: str | None,
+    indexes: bool,
+    fts: bool,
+    as_json: bool,
+) -> None:
+    """Print T2 database schema.
+
+    With no flags, returns all tables. Use --tables NAME, --indexes, --fts
+    to restrict output. Safe over TCP.
+    """
+    from nexus.daemon.t2_client import T2Client, T2DaemonError  # noqa: F401
+
+    disc = _load_disc(config_dir_str)
+    client = _client_from_disc(disc)
+
+    filters: dict = {}
+    if tables_filter is not None:
+        filters["tables"] = tables_filter
+    if indexes:
+        filters["indexes"] = True
+    if fts:
+        filters["fts"] = True
+
+    try:
+        result = client.call("schema", {"filters": filters if filters else None})
+    except T2DaemonError as exc:
+        click.echo(f"Daemon error: {exc}", err=True)
+        sys.exit(1)
+    finally:
+        client.close()
+
+    if as_json:
+        click.echo(json.dumps(result, indent=2))
+        return
+    if "tables" in result:
+        click.echo(f"Tables ({len(result['tables'])}):")
+        for t in result["tables"]:
+            click.echo(f"  {t['name']}")
+            for col in t.get("columns", []):
+                click.echo(f"    {col['name']} {col['type']}")
+    if "indexes" in result:
+        click.echo(f"Indexes ({len(result['indexes'])}):")
+        for idx in result["indexes"]:
+            click.echo(f"  {idx['name']} on {idx['table']}")
+    if "fts" in result:
+        click.echo(f"FTS5 tables ({len(result['fts'])}):")
+        for t in result["fts"]:
+            click.echo(f"  {t['name']}")
+
+
+# ---------------------------------------------------------------------------
+# nx daemon t2 peek
+# ---------------------------------------------------------------------------
+
+
+@t2_group.command("peek")
+@click.option("--config-dir", "config_dir_str", default=None, help="Config directory override.")
+@click.argument("table")
+@click.option("--offset", default=0, show_default=True, help="Row offset.")
+@click.option("--limit", default=20, show_default=True, help="Rows to return (max 300).")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
+def peek_cmd(
+    config_dir_str: str | None,
+    table: str,
+    offset: int,
+    limit: int,
+    as_json: bool,
+) -> None:
+    """Show rows from a T2 table (paged, max 300 per call). Safe over TCP.
+
+    Example:
+      nx daemon t2 peek memory --limit 10
+    """
+    from nexus.daemon.t2_client import T2Client, T2DaemonError  # noqa: F401
+
+    disc = _load_disc(config_dir_str)
+    client = _client_from_disc(disc)
+    try:
+        result = client.call("peek", {"table": table, "offset": offset, "limit": limit})
+    except T2DaemonError as exc:
+        click.echo(f"Daemon error: {exc}", err=True)
+        sys.exit(1)
+    finally:
+        client.close()
+
+    if as_json:
+        click.echo(json.dumps(result, indent=2))
+        return
+    rows = result.get("rows", [])
+    total = result.get("total", 0)
+    eff_limit = result.get("limit", limit)
+    click.echo(f"Table: {table}  total={total}  offset={offset}  limit={eff_limit}")
+    if not rows:
+        click.echo("(no rows)")
+        return
+    headers = list(rows[0].keys())
+    widths = [
+        max(len(h), max((len(str(row.get(h, ""))) for row in rows), default=0))
+        for h in headers
+    ]
+    click.echo("  ".join(h.ljust(w) for h, w in zip(headers, widths)))
+    click.echo("-" * (sum(widths) + 2 * (len(widths) - 1)))
+    for row in rows:
+        click.echo("  ".join(str(row.get(h, "")).ljust(w) for h, w in zip(headers, widths)))
+
+
+# ---------------------------------------------------------------------------
+# nx daemon t2 stats
+# ---------------------------------------------------------------------------
+
+
+@t2_group.command("stats")
+@click.option("--config-dir", "config_dir_str", default=None, help="Config directory override.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
+def stats_cmd(config_dir_str: str | None, as_json: bool) -> None:
+    """Print T2 database statistics (row counts, file sizes). Safe over TCP."""
+    from nexus.daemon.t2_client import T2Client, T2DaemonError  # noqa: F401
+
+    disc = _load_disc(config_dir_str)
+    client = _client_from_disc(disc)
+    try:
+        result = client.call("stats", {})
+    except T2DaemonError as exc:
+        click.echo(f"Daemon error: {exc}", err=True)
+        sys.exit(1)
+    finally:
+        client.close()
+
+    if as_json:
+        click.echo(json.dumps(result, indent=2))
+        return
+    click.echo("T2 Stats")
+    click.echo("-" * 40)
+    tables = result.get("tables", {})
+    if tables:
+        click.echo("Row counts:")
+        for tname, count in sorted(tables.items()):
+            click.echo(f"  {tname}: {count}")
+    click.echo(f"memory_db: {result.get('memory_db_bytes', 0):,} bytes")
+    click.echo(f"memory_db WAL: {result.get('memory_db_wal_bytes', 0):,} bytes")
+    click.echo(f"tuples_db: {result.get('tuples_db_bytes', 0):,} bytes")
+    click.echo(f"tuples_db WAL: {result.get('tuples_db_wal_bytes', 0):,} bytes")
+
+
+# ---------------------------------------------------------------------------
+# nx daemon t2 export  (admin -- UDS only)
+# ---------------------------------------------------------------------------
+
+
+@t2_group.command("export")
+@click.option("--config-dir", "config_dir_str", default=None, help="Config directory override.")
+@click.option("--table", "table", default=None, help="Table to export (omit for all tables).")
+@click.option(
+    "--format",
+    "fmt",
+    default="jsonl",
+    show_default=True,
+    type=click.Choice(["jsonl", "csv", "sqlite"]),
+    help="Output format.",
+)
+@click.argument("dest")
+def export_cmd(config_dir_str: str | None, table: str | None, fmt: str, dest: str) -> None:
+    """Export a T2 table (or all tables) to DEST on the daemon host (admin, UDS only).
+
+    Examples:
+      nx daemon t2 export --table memory --format jsonl /tmp/memory.jsonl
+      nx daemon t2 export --format sqlite /tmp/backup.db
+    """
+    from nexus.daemon.t2_client import T2Client, T2DaemonError  # noqa: F401
+
+    disc = _load_disc(config_dir_str)
+    client = _uds_client_from_disc(disc)
+    try:
+        result = client.call("export", {"table": table, "format": fmt, "dest_path": dest})
+    except T2DaemonError as exc:
+        click.echo(f"Daemon error: {exc}", err=True)
+        sys.exit(1)
+    except (ConnectionError, OSError) as exc:
+        click.echo(f"Connection error: {exc}", err=True)
+        sys.exit(1)
+    finally:
+        client.close()
+
+    click.echo(
+        f"Export complete: {result.get('rows', '?')} rows, "
+        f"{result.get('bytes_written', 0):,} bytes -> {result.get('path', dest)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# nx daemon t2 subspace  (P1.5 nexus-x98k)
+# ---------------------------------------------------------------------------
+
+
+@t2_group.group("subspace")
+def subspace_group() -> None:
+    """Manage registered subspace schemas (admin; UDS only)."""
+
+
+@subspace_group.command("add")
+@click.argument("yaml_path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--config-dir",
+    "config_dir_str",
+    default=None,
+    help="Config directory override.",
+)
+def subspace_add_cmd(yaml_path: Path, config_dir_str: str | None) -> None:
+    """Register a subspace schema from a YAML file.
+
+    Reads YAML_PATH, sends it to the running T2 daemon via the UDS-only
+    ``subspace_add`` admin RPC, and prints the registered name + digest.
+
+    The daemon validates the schema (JSON Schema + reserved-prefix check)
+    and persists it to tuples.db. Duplicate names are rejected.
+
+    Requires a running daemon (``nx daemon t2 start``) and must be invoked
+    as the same user that owns the daemon (UDS peer-cred gate).
+    """
+    from nexus.daemon.t2_client import T2Client, T2DaemonError
+
+    config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
+    disc = _discovery_path(config_dir)
+    if not disc.exists():
+        click.echo("No T2 daemon discovery file found — is the daemon running?", err=True)
+        import sys
+        sys.exit(1)
+
+    try:
+        data = json.loads(disc.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        click.echo(f"Failed to read discovery file: {exc}", err=True)
+        import sys
+        sys.exit(1)
+
+    uds_path_str = data.get("uds_path")
+    if not uds_path_str:
+        click.echo("Discovery file missing 'uds_path'. Cannot use admin RPC over TCP.", err=True)
+        import sys
+        sys.exit(1)
+
+    try:
+        yaml_text = yaml_path.read_text()
+    except OSError as exc:
+        click.echo(f"Failed to read YAML file: {exc}", err=True)
+        import sys
+        sys.exit(1)
+
+    try:
+        with T2Client(uds_path=Path(uds_path_str)) as client:
+            with client._get_pool().acquire() as conn:
+                result = conn.call("subspace_add", {"yaml": yaml_text})
+    except T2DaemonError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        import sys
+        sys.exit(1)
+    except OSError as exc:
+        click.echo(f"Connection error: {exc}", err=True)
+        import sys
+        sys.exit(1)
+
+    click.echo(f"Registered: {result.get('name')}")
+    click.echo(f"Digest:     {result.get('digest')}")

--- a/src/nexus/daemon/introspection.py
+++ b/src/nexus/daemon/introspection.py
@@ -1,0 +1,570 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Introspection RPC surface for the T2 daemon — RDR-112 P1.6 (nexus-08i1).
+
+Provides ``IntrospectionService`` with five verbs:
+
+- ``exec_raw``  -- arbitrary read-only SQL via ``sqlite3 URI mode=ro``.
+- ``schema``    -- sqlite_master enumeration with optional filters.
+- ``peek``      -- paged SELECT * with limit clamped to MAX_QUERY_RESULTS=300.
+- ``stats``     -- row counts per table, DB file size, WAL size.
+- ``export``    -- daemon-side streaming write (jsonl, csv, or sqlite backup).
+
+Security model
+--------------
+``exec_raw`` and ``export`` are admin-only (UDS-gated via ``_ADMIN_OPS`` in
+``t2_daemon.py``). ``schema``, ``peek``, and ``stats`` are read-only metadata
+and safe over TCP.
+
+``exec_raw`` opens a ``sqlite3.connect("file:<path>?mode=ro", uri=True)``
+connection per call. The read-only constraint is enforced by SQLite's URI
+flag, NOT by SQL pattern matching (which is unreliable).
+
+Audit logging
+-------------
+Every ``exec_raw`` invocation emits a ``daemon/t2/lifecycle`` log event with
+``op=raw-exec`` and ``sql_hash=sha256(sql)[:16]``. The full SQL is never
+logged (may contain PII).
+"""
+from __future__ import annotations
+
+import csv
+import hashlib
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any, Generator
+
+import structlog
+
+from nexus.db.chroma_quotas import QUOTAS
+
+_log = structlog.get_logger(__name__)
+
+# Maximum rows per peek call (hard cap from chroma quota constant for consistency).
+_PEEK_MAX: int = QUOTAS.MAX_QUERY_RESULTS  # 300
+
+#: Hard cap for ``exec_raw`` result rows. Above this the daemon raises rather
+#: than materialising the result set into a Python list. Admin-only op but a
+#: misbehaving caller should not be able to crash the daemon on a large table.
+_EXEC_RAW_MAX_ROWS: int = 50_000
+
+
+class IntrospectionService:
+    """Read-only introspection over the T2 SQLite stores.
+
+    Owns no persistent connections. ``exec_raw``, ``schema``, ``peek``,
+    and ``stats`` each open a fresh ``mode=ro`` connection and close it in
+    a ``finally`` block. ``export`` streams rows via a generator to avoid
+    materialising the full result set in memory.
+
+    Constructor injection only — no global state.
+
+    Args:
+        memory_db_path: Path to the T2 memory/plans/taxonomy/etc. SQLite DB.
+        tuples_db_path: Path to the tuples.db (watcher_state, events, etc.).
+    """
+
+    def __init__(
+        self,
+        memory_db_path: Path,
+        tuples_db_path: Path,
+        export_root: Path | None = None,
+    ) -> None:
+        self._memory_db_path: Path = memory_db_path
+        self._tuples_db_path: Path = tuples_db_path
+        # Export destinations must resolve inside this root. Default is the
+        # config dir parent (the db files' parent dir) so a fresh container
+        # mount works without extra wiring. Operators with a dedicated export
+        # volume should pass export_root explicitly.
+        self._export_root: Path = (
+            export_root.resolve()
+            if export_root is not None
+            else memory_db_path.parent.resolve()
+        )
+
+    def _validate_export_path(self, dest_path: str) -> Path:
+        """Resolve ``dest_path`` and reject anything outside ``_export_root``.
+
+        Defends against path-traversal (``../../etc/cron.d/...``) under an
+        admin caller. Admin gate restricts who can call ``export``; this
+        restricts where they can write to.
+        """
+        try:
+            dest = Path(dest_path).resolve()
+        except OSError as exc:
+            raise ValueError(f"export dest_path could not be resolved: {exc}") from exc
+        root = self._export_root
+        try:
+            dest.relative_to(root)
+        except ValueError:
+            raise ValueError(
+                f"export dest_path {str(dest)!r} is outside the configured "
+                f"export root {str(root)!r}. Daemon writes are restricted to "
+                "the export root to prevent path-traversal."
+            ) from None
+        return dest
+
+    # ------------------------------------------------------------------
+    # exec_raw
+    # ------------------------------------------------------------------
+
+    def exec_raw(self, sql: str) -> list[dict[str, Any]]:
+        """Execute ``sql`` against the memory DB and return rows as dicts.
+
+        Opens a fresh ``sqlite3.connect("file:<path>?mode=ro", uri=True)``
+        connection per call. The read-only constraint is enforced by SQLite's
+        URI ``mode=ro`` flag — NOT by SQL pattern matching.
+
+        Audit: emits ``daemon/t2/lifecycle`` with ``op=raw-exec`` and
+        ``sql_hash=sha256(sql)[:16]``. The full SQL is never logged.
+
+        Args:
+            sql: Arbitrary SQL string. Must be read-only or SQLite will raise
+                ``sqlite3.OperationalError`` (attempt to write a readonly db).
+
+        Returns:
+            List of dicts keyed by column name.
+
+        Raises:
+            sqlite3.OperationalError: If the SQL attempts a write, or on any
+                other SQLite error.
+        """
+        sql_hash = hashlib.sha256(sql.encode()).hexdigest()[:16]
+
+        uri = f"file:{self._memory_db_path}?mode=ro"
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = sqlite3.connect(uri, uri=True)
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(sql)
+            # Cap result size to avoid OOM on unbounded SELECTs over large
+            # tables. Admin-only op, but a misbehaving admin should not be
+            # able to crash the daemon process by querying a 50M-row table.
+            rows: list[dict[str, Any]] = []
+            for row in cursor:
+                if len(rows) >= _EXEC_RAW_MAX_ROWS:
+                    raise ValueError(
+                        f"exec_raw result exceeded {_EXEC_RAW_MAX_ROWS} rows; "
+                        "add a LIMIT clause or use export for full table dumps"
+                    )
+                rows.append(dict(row))
+            # Audit after successful execution — pre-execution logging would
+            # record failed/rejected attempts as DoS noise.
+            _log.info(
+                "daemon/t2/lifecycle",
+                op="raw-exec",
+                sql_hash=sql_hash,
+                row_count=len(rows),
+            )
+            return rows
+        finally:
+            if conn is not None:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # schema
+    # ------------------------------------------------------------------
+
+    def schema(self, filters: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Return schema information from ``sqlite_master``.
+
+        Args:
+            filters: Optional dict controlling which sections to include.
+                - ``"tables"`` (str | True): include table list. If a string,
+                  filter to only that table name. If True, include all tables.
+                - ``"indexes"`` (bool): include index list.
+                - ``"fts"`` (bool): include FTS5 virtual tables.
+                When ``filters`` is None, all sections are included.
+
+        Returns:
+            Dict with keys ``"tables"``, ``"indexes"``, ``"fts"`` (each a
+            list of dicts). Absent keys indicate the section was filtered out.
+        """
+        f = filters or {}
+        include_tables = "tables" in f or not f
+        include_indexes = "indexes" in f or not f
+        include_fts = "fts" in f or not f
+
+        table_name_filter: str | None = None
+        if "tables" in f and isinstance(f["tables"], str):
+            table_name_filter = f["tables"]
+
+        uri = f"file:{self._memory_db_path}?mode=ro"
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = sqlite3.connect(uri, uri=True)
+            result: dict[str, Any] = {}
+
+            if include_tables:
+                if table_name_filter is not None:
+                    rows = conn.execute(
+                        "SELECT name, sql FROM sqlite_master WHERE type='table' AND name=?",
+                        (table_name_filter,),
+                    ).fetchall()
+                else:
+                    rows = conn.execute(
+                        "SELECT name, sql FROM sqlite_master WHERE type='table' "
+                        "AND name NOT LIKE 'sqlite_%'",
+                    ).fetchall()
+
+                tables = []
+                for name, ddl in rows:
+                    cols = _get_columns(conn, name)
+                    tables.append({"name": name, "ddl": ddl, "columns": cols})
+                result["tables"] = tables
+
+            if include_indexes:
+                idx_rows = conn.execute(
+                    "SELECT name, tbl_name, sql FROM sqlite_master WHERE type='index' "
+                    "AND name NOT LIKE 'sqlite_%'",
+                ).fetchall()
+                result["indexes"] = [
+                    {"name": n, "table": t, "ddl": s} for n, t, s in idx_rows
+                ]
+
+            if include_fts:
+                fts_rows = conn.execute(
+                    "SELECT name, sql FROM sqlite_master "
+                    "WHERE type='table' AND sql LIKE '%USING fts5%'",
+                ).fetchall()
+                result["fts"] = [{"name": n, "ddl": s} for n, s in fts_rows]
+
+            return result
+        finally:
+            if conn is not None:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # peek
+    # ------------------------------------------------------------------
+
+    def peek(
+        self,
+        table: str,
+        offset: int = 0,
+        limit: int = _PEEK_MAX,
+    ) -> dict[str, Any]:
+        """Return a paged slice of ``table``.
+
+        ``limit`` is silently clamped to ``MAX_QUERY_RESULTS`` (300).
+        ``limit <= 0`` raises ``ValueError`` (a zero-result silent-success is
+        indistinguishable from an empty table and is a usability foot-gun).
+        ``offset < 0`` likewise raises.
+
+        Args:
+            table: Table name to inspect (must be an existing table).
+            offset: Number of rows to skip (default 0). Must be >= 0.
+            limit: Maximum rows to return; must be > 0; clamped to 300.
+
+        Returns:
+            Dict with keys ``rows`` (list of dicts), ``total`` (int),
+            ``offset`` (int), ``limit`` (int — the effective clamped value).
+        """
+        if limit <= 0:
+            raise ValueError(f"peek limit must be positive, got {limit!r}")
+        if offset < 0:
+            raise ValueError(f"peek offset must be non-negative, got {offset!r}")
+        effective_limit = min(limit, _PEEK_MAX)
+
+        uri = f"file:{self._memory_db_path}?mode=ro"
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = sqlite3.connect(uri, uri=True)
+            conn.row_factory = sqlite3.Row
+
+            total: int = conn.execute(
+                f"SELECT COUNT(*) FROM \"{_quote_id(table)}\""  # noqa: S608
+            ).fetchone()[0]
+
+            cursor = conn.execute(
+                f"SELECT * FROM \"{_quote_id(table)}\" LIMIT ? OFFSET ?",  # noqa: S608
+                (effective_limit, offset),
+            )
+            rows = [dict(row) for row in cursor.fetchall()]
+
+            return {
+                "rows": rows,
+                "total": total,
+                "offset": offset,
+                "limit": effective_limit,
+            }
+        finally:
+            if conn is not None:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # stats
+    # ------------------------------------------------------------------
+
+    def stats(self) -> dict[str, Any]:
+        """Return row counts per table plus DB file sizes.
+
+        Returns:
+            Dict with keys:
+            - ``"tables"``: mapping of table_name -> row_count.
+            - ``"memory_db_bytes"``: file size of memory_db_path (0 if missing).
+            - ``"memory_db_wal_bytes"``: WAL file size (0 if missing).
+            - ``"tuples_db_bytes"``: file size of tuples_db_path (0 if missing).
+            - ``"tuples_db_wal_bytes"``: WAL file size (0 if missing).
+        """
+        uri = f"file:{self._memory_db_path}?mode=ro"
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = sqlite3.connect(uri, uri=True)
+
+            table_names: list[str] = [
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name NOT LIKE 'sqlite_%'"
+                ).fetchall()
+            ]
+
+            counts: dict[str, int] = {}
+            for tname in table_names:
+                row = conn.execute(
+                    f"SELECT COUNT(*) FROM \"{_quote_id(tname)}\""  # noqa: S608
+                ).fetchone()
+                counts[tname] = row[0] if row else 0
+
+            return {
+                "tables": counts,
+                "memory_db_bytes": _file_size(self._memory_db_path),
+                "memory_db_wal_bytes": _file_size(
+                    self._memory_db_path.parent / (self._memory_db_path.name + "-wal")
+                ),
+                "tuples_db_bytes": _file_size(self._tuples_db_path),
+                "tuples_db_wal_bytes": _file_size(
+                    self._tuples_db_path.parent / (self._tuples_db_path.name + "-wal")
+                ),
+            }
+        finally:
+            if conn is not None:
+                conn.close()
+
+    # ------------------------------------------------------------------
+    # export
+    # ------------------------------------------------------------------
+
+    def export(
+        self,
+        table: str | None,
+        format: str,
+        dest_path: str,
+    ) -> dict[str, Any]:
+        """Export table(s) to ``dest_path`` in the requested format.
+
+        Streams rows via a generator; never materialises the full result in
+        memory. For ``format="sqlite"`` uses the SQLite Backup API
+        (``sqlite3.Connection.backup()``).
+
+        Args:
+            table: Table name to export, or ``None`` to export all tables.
+            format: One of ``"jsonl"``, ``"csv"``, ``"sqlite"``.
+            dest_path: Destination file path (daemon-side write). For
+                ``format="jsonl"``/``"csv"`` with ``table=None``, this is
+                treated as a directory and one file per table is created.
+
+        Returns:
+            Dict with keys ``"path"`` (str), ``"bytes_written"`` (int),
+            ``"rows"`` (int).
+
+        Raises:
+            ValueError: If ``format`` is not one of the supported values.
+        """
+        if format not in {"jsonl", "csv", "sqlite"}:
+            raise ValueError(f"Unsupported export format: {format!r}. Use jsonl, csv, or sqlite.")
+
+        dest = self._validate_export_path(dest_path)
+
+        if format == "sqlite":
+            return self._export_sqlite(dest)
+
+        if table is None:
+            return self._export_all_tables(dest, format)
+
+        return self._export_single_table(table, dest, format)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _export_sqlite(self, dest: Path) -> dict[str, Any]:
+        """Export a full SQLite backup using the Backup API."""
+        src_uri = f"file:{self._memory_db_path}?mode=ro"
+        src_conn: sqlite3.Connection | None = None
+        dst_conn: sqlite3.Connection | None = None
+        try:
+            src_conn = sqlite3.connect(src_uri, uri=True)
+            dst_conn = sqlite3.connect(str(dest))
+            src_conn.backup(dst_conn)
+            dst_conn.close()
+            dst_conn = None
+
+            # Count total rows across all tables for reporting
+            verify_conn = sqlite3.connect(str(dest))
+            try:
+                table_names = [
+                    r[0]
+                    for r in verify_conn.execute(
+                        "SELECT name FROM sqlite_master WHERE type='table' "
+                        "AND name NOT LIKE 'sqlite_%'"
+                    ).fetchall()
+                ]
+                total = sum(
+                    verify_conn.execute(
+                        f"SELECT COUNT(*) FROM \"{_quote_id(t)}\""  # noqa: S608
+                    ).fetchone()[0]
+                    for t in table_names
+                )
+            finally:
+                verify_conn.close()
+
+            return {
+                "path": str(dest),
+                "bytes_written": dest.stat().st_size,
+                "rows": total,
+            }
+        finally:
+            if src_conn is not None:
+                src_conn.close()
+            if dst_conn is not None:
+                dst_conn.close()
+
+    def _export_all_tables(self, dest: Path, format: str) -> dict[str, Any]:
+        """Export all tables to a directory, one file per table."""
+        dest.mkdir(parents=True, exist_ok=True)
+
+        uri = f"file:{self._memory_db_path}?mode=ro"
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = sqlite3.connect(uri, uri=True)
+            table_names = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name NOT LIKE 'sqlite_%'"
+                ).fetchall()
+            ]
+        finally:
+            if conn is not None:
+                conn.close()
+
+        total_rows = 0
+        total_bytes = 0
+        for tname in table_names:
+            ext = "jsonl" if format == "jsonl" else "csv"
+            tfile = dest / f"{tname}.{ext}"
+            result = self._export_single_table(tname, tfile, format)
+            total_rows += result["rows"]
+            total_bytes += result["bytes_written"]
+
+        return {
+            "path": str(dest),
+            "bytes_written": total_bytes,
+            "rows": total_rows,
+        }
+
+    def _export_single_table(
+        self, table: str, dest: Path, format: str
+    ) -> dict[str, Any]:
+        """Export a single table to ``dest`` in the given format."""
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        rows_written = 0
+        bytes_written = 0
+
+        if format == "jsonl":
+            with dest.open("w", encoding="utf-8") as out:
+                for row in self._stream_table(table):
+                    line = json_encode_row(row) + "\n"
+                    out.write(line)
+                    bytes_written += len(line.encode("utf-8"))
+                    rows_written += 1
+        elif format == "csv":
+            first = True
+            writer_obj: csv.DictWriter | None = None
+            with dest.open("w", encoding="utf-8", newline="") as out:
+                for row in self._stream_table(table):
+                    if first:
+                        writer_obj = csv.DictWriter(out, fieldnames=list(row.keys()))
+                        writer_obj.writeheader()
+                        first = False
+                    writer_obj.writerow(row)  # type: ignore[union-attr]
+                    rows_written += 1
+            bytes_written = dest.stat().st_size if dest.exists() else 0
+        else:
+            raise ValueError(f"Unsupported format: {format!r}")
+
+        return {
+            "path": str(dest),
+            "bytes_written": bytes_written,
+            "rows": rows_written,
+        }
+
+    def _stream_table(self, table: str) -> Generator[dict[str, Any], None, None]:
+        """Yield rows from ``table`` one at a time (streaming, no full materialisation)."""
+        uri = f"file:{self._memory_db_path}?mode=ro"
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = sqlite3.connect(uri, uri=True)
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                f"SELECT * FROM \"{_quote_id(table)}\""  # noqa: S608
+            )
+            while True:
+                rows = cursor.fetchmany(256)
+                if not rows:
+                    break
+                for row in rows:
+                    yield dict(row)
+        finally:
+            if conn is not None:
+                conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _quote_id(name: str) -> str:
+    """Escape a SQLite identifier by doubling internal double-quotes."""
+    return name.replace('"', '""')
+
+
+def _file_size(path: Path) -> int:
+    """Return file size in bytes, or 0 if the file does not exist."""
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+
+def _get_columns(conn: sqlite3.Connection, table: str) -> list[dict[str, Any]]:
+    """Return column info for ``table`` via PRAGMA table_info."""
+    rows = conn.execute(f"PRAGMA table_info(\"{_quote_id(table)}\")").fetchall()
+    return [
+        {
+            "cid": r[0],
+            "name": r[1],
+            "type": r[2],
+            "notnull": bool(r[3]),
+            "default": r[4],
+            "pk": bool(r[5]),
+        }
+        for r in rows
+    ]
+
+
+def json_encode_row(row: dict[str, Any]) -> str:
+    """JSON-encode a row dict, handling bytes as base64 and non-serialisable types."""
+    import base64
+    import json as _json
+
+    def _default(obj: Any) -> Any:
+        if isinstance(obj, (bytes, bytearray)):
+            return {"__bytes__": base64.b64encode(obj).decode()}
+        raise TypeError(f"Not JSON serialisable: {type(obj)!r}")
+
+    return _json.dumps(row, default=_default)

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -202,6 +202,8 @@ _ADMIN_OPS: frozenset[str] = frozenset({
     "subspace_add",                # RDR-112 P1.5 nexus-x98k
     "apply_pending_migrations",    # currently NOT in dispatch table (internal to daemon start)
     "import",                      # future
+    "exec_raw",                    # RDR-112 P1.6 nexus-08i1 — arbitrary read-only SQL
+    "export",                      # RDR-112 P1.6 nexus-08i1 — daemon-side file write
 })
 
 #: Names that future beads MUST treat as admin (UDS-only) if they appear in
@@ -221,6 +223,8 @@ _KNOWN_ADMIN_NAMES: frozenset[str] = frozenset({
     "subspace_add",
     "apply_pending_migrations",
     "import",
+    "exec_raw",
+    "export",
 })
 
 
@@ -504,6 +508,24 @@ class T2Daemon:
             self._rpc_table["subspace_add"] = (
                 lambda yaml: registry_store.add(yaml_str=yaml)  # noqa: A006
             )
+
+        # P1.6 nexus-08i1: introspection RPCs.
+        # exec_raw and export are admin-only (in _ADMIN_OPS); schema, peek,
+        # stats are read-only metadata and safe over TCP.
+        if t2db is not None:
+            from nexus.daemon.introspection import IntrospectionService
+            _intr = IntrospectionService(
+                memory_db_path=t2db._path,
+                tuples_db_path=(
+                    tuples_db_path if tuples_db_path is not None
+                    else config_dir / "tuples.db"
+                ),
+            )
+            self._rpc_table["exec_raw"] = _intr.exec_raw
+            self._rpc_table["schema"] = _intr.schema
+            self._rpc_table["peek"] = _intr.peek
+            self._rpc_table["stats"] = _intr.stats
+            self._rpc_table["export"] = _intr.export
 
         # P1.6 nexus-pce1.1: startup integrity check.
         # The UDS-only gate relies on _ADMIN_OPS membership. If a future bead

--- a/tests/daemon/test_introspection_rpcs.py
+++ b/tests/daemon/test_introspection_rpcs.py
@@ -1,0 +1,657 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for introspection RPC surface — RDR-112 P1.6 (nexus-08i1).
+
+Covers:
+  (a) exec_raw round-trips a SELECT.
+  (b) exec_raw rejects writes — mode=ro enforcement via sqlite3.OperationalError.
+  (c) schema output matches sqlite_master.
+  (d) peek pagination — 500 rows, offset/limit clamping.
+  (e) export round-trips via re-import (jsonl format).
+  (f) exec_raw over TCP is rejected (admin-gated).
+  (g) exec_raw audit-log emits sql_hash (not full SQL).
+
+All tests use tmp_path SQLite databases and real IntrospectionService.
+Daemon tests use port=0, tmp_path config_dir, real T2Daemon.
+"""
+from __future__ import annotations
+
+import asyncio
+import csv
+import hashlib
+import io
+import json
+import logging
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+import structlog
+
+from nexus.daemon.introspection import IntrospectionService
+from nexus.daemon.t2_daemon import (
+    DAEMON_PROTOCOL_VERSION,
+    T2Daemon,
+    read_frame,
+    write_frame,
+)
+from nexus.db.t2 import T2Database
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_memory_db(path: Path) -> sqlite3.Connection:
+    """Open a fresh writable SQLite DB, create a test table, return conn."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS test_items (id INTEGER PRIMARY KEY, name TEXT, value INTEGER)"
+    )
+    conn.commit()
+    return conn
+
+
+def _insert_rows(conn: sqlite3.Connection, table: str, rows: list[dict]) -> None:
+    for row in rows:
+        cols = ", ".join(row.keys())
+        placeholders = ", ".join("?" for _ in row)
+        conn.execute(f"INSERT INTO {table} ({cols}) VALUES ({placeholders})", list(row.values()))
+    conn.commit()
+
+
+def _run_daemon(daemon: T2Daemon) -> asyncio.AbstractEventLoop:
+    """Start daemon on a background event loop; return loop."""
+    started = threading.Event()
+    loop = asyncio.new_event_loop()
+
+    def _thread() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(daemon.start())
+        started.set()
+        loop.run_forever()
+
+    t = threading.Thread(target=_thread, daemon=True)
+    t.start()
+    started.wait(timeout=5.0)
+    return loop
+
+
+async def _tcp_rpc(
+    host: str,
+    port: int,
+    *,
+    op: str,
+    args: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    reader, writer = await asyncio.open_connection(host, port)
+    try:
+        write_frame(writer, {"op": "hello", "protocol_version": DAEMON_PROTOCOL_VERSION})
+        await writer.drain()
+        await read_frame(reader)  # hello_ack
+        write_frame(writer, {"op": op, "args": args or {}})
+        await writer.drain()
+        return await read_frame(reader)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def memory_db_path(tmp_path: Path) -> Path:
+    return tmp_path / "memory.db"
+
+
+@pytest.fixture
+def tuples_db_path(tmp_path: Path) -> Path:
+    return tmp_path / "tuples.db"
+
+
+@pytest.fixture
+def service(
+    tmp_path: Path,
+    memory_db_path: Path,
+    tuples_db_path: Path,
+) -> IntrospectionService:
+    """IntrospectionService wired to tmp_path databases.
+
+    ``export_root`` is the same tmp_path so export-path-traversal tests can
+    target an exports/ subdir under the same tree.
+    """
+    return IntrospectionService(
+        memory_db_path=memory_db_path,
+        tuples_db_path=tuples_db_path,
+        export_root=tmp_path,
+    )
+
+
+@pytest.fixture
+def populated_db(memory_db_path: Path) -> sqlite3.Connection:
+    """Create and return a writable connection to the test DB."""
+    conn = _make_memory_db(memory_db_path)
+    return conn
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "config" / "nexus"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture
+def t2db(memory_db_path: Path) -> T2Database:
+    database = T2Database(memory_db_path)
+    yield database
+    database.close()
+
+
+# ---------------------------------------------------------------------------
+# (a) exec_raw round-trips a SELECT
+# ---------------------------------------------------------------------------
+
+
+def test_exec_raw_select_roundtrip(service: IntrospectionService, populated_db: sqlite3.Connection, memory_db_path: Path) -> None:
+    """exec_raw SELECT retrieves rows inserted directly into the DB."""
+    _insert_rows(populated_db, "test_items", [
+        {"name": "alpha", "value": 1},
+        {"name": "beta", "value": 2},
+    ])
+    populated_db.close()
+
+    rows = service.exec_raw("SELECT name, value FROM test_items ORDER BY id")
+    assert len(rows) == 2
+    assert rows[0] == {"name": "alpha", "value": 1}
+    assert rows[1] == {"name": "beta", "value": 2}
+
+
+def test_exec_raw_returns_dicts_with_column_keys(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """exec_raw rows are dicts keyed by column name (not positional tuples)."""
+    _insert_rows(populated_db, "test_items", [{"name": "gamma", "value": 42}])
+    populated_db.close()
+
+    rows = service.exec_raw("SELECT id, name, value FROM test_items")
+    assert isinstance(rows[0], dict)
+    assert "name" in rows[0]
+    assert "value" in rows[0]
+    assert rows[0]["name"] == "gamma"
+    assert rows[0]["value"] == 42
+
+
+# ---------------------------------------------------------------------------
+# (b) exec_raw rejects writes — mode=ro enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_exec_raw_rejects_insert_via_mode_ro(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """exec_raw raises sqlite3.OperationalError for INSERT — mode=ro enforcement.
+
+    The test does NOT pattern-match the SQL. The rejection comes from SQLite's
+    URI mode=ro flag, which makes the file read-only at the OS level.
+    """
+    populated_db.close()
+
+    with pytest.raises(sqlite3.OperationalError):
+        service.exec_raw("INSERT INTO test_items (name, value) VALUES ('x', 99)")
+
+
+def test_exec_raw_rejects_create_table_via_mode_ro(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """exec_raw raises sqlite3.OperationalError for CREATE TABLE — mode=ro."""
+    populated_db.close()
+
+    with pytest.raises(sqlite3.OperationalError):
+        service.exec_raw("CREATE TABLE forbidden (x INTEGER)")
+
+
+def test_exec_raw_rejects_delete_via_mode_ro(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """exec_raw raises sqlite3.OperationalError for DELETE — mode=ro."""
+    _insert_rows(sqlite3.connect(str(service._memory_db_path)), "test_items", [
+        {"name": "to_delete", "value": 7}
+    ])
+
+    with pytest.raises(sqlite3.OperationalError):
+        service.exec_raw("DELETE FROM test_items")
+
+
+# ---------------------------------------------------------------------------
+# (c) schema output matches sqlite_master
+# ---------------------------------------------------------------------------
+
+
+def test_schema_tables_present(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """schema() tables list includes our created table."""
+    populated_db.close()
+
+    result = service.schema()
+    assert "tables" in result
+    table_names = [t["name"] for t in result["tables"]]
+    assert "test_items" in table_names
+
+
+def test_schema_tables_filter_by_name(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """schema(filters={'tables': 'test_items'}) returns only the matching table."""
+    populated_db.close()
+
+    result = service.schema(filters={"tables": "test_items"})
+    table_names = [t["name"] for t in result["tables"]]
+    assert "test_items" in table_names
+    # Other internal sqlite_ tables should not be present if filter is applied
+    assert all(n == "test_items" for n in table_names)
+
+
+def test_schema_indexes_present(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """schema() includes indexes when --indexes filter is used."""
+    # Create an index
+    populated_db.execute("CREATE INDEX idx_name ON test_items(name)")
+    populated_db.commit()
+    populated_db.close()
+
+    result = service.schema(filters={"indexes": True})
+    assert "indexes" in result
+    index_names = [i["name"] for i in result["indexes"]]
+    assert "idx_name" in index_names
+
+
+def test_schema_fts_present(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """schema() includes FTS5 tables under 'fts' key."""
+    # FTS5 column spec does not accept a type token; just the column name.
+    populated_db.execute("CREATE VIRTUAL TABLE search_fts USING fts5(content)")
+    populated_db.commit()
+    populated_db.close()
+
+    result = service.schema(filters={"fts": True})
+    assert "fts" in result
+    fts_names = [t["name"] for t in result["fts"]]
+    assert "search_fts" in fts_names
+
+
+def test_schema_column_shape_present(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """schema() tables include column information."""
+    populated_db.close()
+
+    result = service.schema()
+    test_table = next(t for t in result["tables"] if t["name"] == "test_items")
+    assert "columns" in test_table
+    col_names = [c["name"] for c in test_table["columns"]]
+    assert "id" in col_names
+    assert "name" in col_names
+    assert "value" in col_names
+
+
+# ---------------------------------------------------------------------------
+# (d) peek pagination
+# ---------------------------------------------------------------------------
+
+
+def test_peek_first_page(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """peek with offset=0, limit=300 returns 300 rows from 500-row table."""
+    rows_data = [{"name": f"item_{i}", "value": i} for i in range(500)]
+    _insert_rows(populated_db, "test_items", rows_data)
+    populated_db.close()
+
+    result = service.peek("test_items", offset=0, limit=300)
+    assert result["offset"] == 0
+    assert result["limit"] == 300
+    assert result["total"] == 500
+    assert len(result["rows"]) == 300
+
+
+def test_peek_second_page(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """peek with offset=300 returns the remaining 200 rows."""
+    rows_data = [{"name": f"item_{i}", "value": i} for i in range(500)]
+    _insert_rows(populated_db, "test_items", rows_data)
+    populated_db.close()
+
+    result = service.peek("test_items", offset=300, limit=300)
+    assert result["offset"] == 300
+    assert len(result["rows"]) == 200
+
+
+def test_peek_clamps_limit_to_300(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """peek with limit=400 is clamped to 300 (MAX_QUERY_RESULTS)."""
+    rows_data = [{"name": f"item_{i}", "value": i} for i in range(500)]
+    _insert_rows(populated_db, "test_items", rows_data)
+    populated_db.close()
+
+    result = service.peek("test_items", offset=0, limit=400)
+    assert result["limit"] == 300
+    assert len(result["rows"]) == 300
+
+
+def test_peek_returns_dicts(service: IntrospectionService, populated_db: sqlite3.Connection) -> None:
+    """peek rows are dicts keyed by column name."""
+    _insert_rows(populated_db, "test_items", [{"name": "z", "value": 99}])
+    populated_db.close()
+
+    result = service.peek("test_items", offset=0, limit=10)
+    assert len(result["rows"]) >= 1
+    row = result["rows"][0]
+    assert isinstance(row, dict)
+    assert "name" in row
+
+
+# ---------------------------------------------------------------------------
+# (e) export round-trips via re-import
+# ---------------------------------------------------------------------------
+
+
+def test_export_jsonl_roundtrip(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """export jsonl then re-read matches original row count and content."""
+    rows_data = [{"name": f"item_{i}", "value": i} for i in range(10)]
+    _insert_rows(populated_db, "test_items", rows_data)
+    populated_db.close()
+
+    dest = tmp_path / "export.jsonl"
+    result = service.export(table="test_items", format="jsonl", dest_path=str(dest))
+
+    assert result["rows"] == 10
+    assert result["bytes_written"] > 0
+    assert Path(result["path"]) == dest
+
+    # Re-import
+    loaded = []
+    with dest.open() as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                loaded.append(json.loads(line))
+
+    assert len(loaded) == 10
+    names = {r["name"] for r in loaded}
+    assert names == {f"item_{i}" for i in range(10)}
+
+
+def test_export_csv_roundtrip(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """export csv then re-read matches original row count."""
+    rows_data = [{"name": f"row_{i}", "value": i * 2} for i in range(5)]
+    _insert_rows(populated_db, "test_items", rows_data)
+    populated_db.close()
+
+    dest = tmp_path / "export.csv"
+    result = service.export(table="test_items", format="csv", dest_path=str(dest))
+    assert result["rows"] == 5
+
+    with dest.open() as f:
+        reader = csv.DictReader(f)
+        loaded = list(reader)
+
+    assert len(loaded) == 5
+
+
+def test_export_sqlite_roundtrip(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """export sqlite backup then open the copy and verify row count."""
+    rows_data = [{"name": f"s_{i}", "value": i} for i in range(7)]
+    _insert_rows(populated_db, "test_items", rows_data)
+    populated_db.close()
+
+    dest = tmp_path / "backup.db"
+    result = service.export(table=None, format="sqlite", dest_path=str(dest))
+    # SQLite backup copies every row including any internal tables; assert
+    # at least our 7 test rows arrived (exact total depends on schema state).
+    assert result["rows"] == 7
+
+    backup_conn = sqlite3.connect(str(dest))
+    rows = backup_conn.execute("SELECT COUNT(*) FROM test_items").fetchone()[0]
+    backup_conn.close()
+    assert rows == 7
+
+
+def test_export_all_tables_jsonl(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """export with table=None exports all tables into dest_path directory."""
+    _insert_rows(populated_db, "test_items", [{"name": "a", "value": 1}])
+    populated_db.close()
+
+    dest = tmp_path / "all_tables"
+    result = service.export(table=None, format="jsonl", dest_path=str(dest))
+    assert result["rows"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# (f) exec_raw over TCP is rejected (admin-gated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exec_raw_rejected_over_tcp(config_dir: Path, t2db: T2Database) -> None:
+    """exec_raw is in _ADMIN_OPS; calling it over TCP returns PermissionDenied."""
+    daemon = T2Daemon(config_dir=config_dir, t2db=t2db)
+    loop = _run_daemon(daemon)
+    try:
+        resp = await _tcp_rpc(
+            "127.0.0.1",
+            daemon.tcp_port,
+            op="exec_raw",
+            args={"sql": "SELECT 1"},
+        )
+        assert "error" in resp, f"Expected error frame, got: {resp}"
+        err = resp["error"]
+        assert isinstance(err, dict)
+        assert err.get("type") == "PermissionDenied"
+        assert "exec_raw" in err.get("message", "") or "UDS" in err.get("message", "")
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        await asyncio.sleep(0)  # yield to event loop
+
+
+@pytest.mark.asyncio
+async def test_export_rejected_over_tcp(config_dir: Path, t2db: T2Database, tmp_path: Path) -> None:
+    """export is in _ADMIN_OPS; calling it over TCP returns PermissionDenied."""
+    daemon = T2Daemon(config_dir=config_dir, t2db=t2db)
+    loop = _run_daemon(daemon)
+    try:
+        resp = await _tcp_rpc(
+            "127.0.0.1",
+            daemon.tcp_port,
+            op="export",
+            args={"table": "memory", "format": "jsonl", "dest_path": str(tmp_path / "x.jsonl")},
+        )
+        assert "error" in resp
+        err = resp["error"]
+        assert isinstance(err, dict)
+        assert err.get("type") == "PermissionDenied"
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        await asyncio.sleep(0)
+
+
+# ---------------------------------------------------------------------------
+# (g) exec_raw audit-log emits sql_hash (not full SQL)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_raw_audit_log_emits_sql_hash(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """exec_raw audit log emits sql_hash (16-char SHA256 prefix), not the full SQL."""
+    import structlog as _structlog
+
+    _insert_rows(populated_db, "test_items", [{"name": "audit_test", "value": 5}])
+    populated_db.close()
+
+    sql = "SELECT name FROM test_items"
+    expected_hash = hashlib.sha256(sql.encode()).hexdigest()[:16]
+
+    # Reconfigure structlog to emit through stdlib logging so caplog catches it.
+    _structlog.configure(
+        processors=[_structlog.stdlib.render_to_log_kwargs],
+        wrapper_class=_structlog.stdlib.BoundLogger,
+        logger_factory=_structlog.stdlib.LoggerFactory(),
+    )
+
+    with caplog.at_level(logging.INFO, logger="nexus.daemon.introspection"):
+        service.exec_raw(sql)
+
+    # render_to_log_kwargs puts extra fields as LogRecord attributes.
+    # The event is getMessage(); extra fields are on the record object.
+    found_hash = False
+    for record in caplog.records:
+        if getattr(record, "sql_hash", None) == expected_hash:
+            found_hash = True
+            break
+    assert found_hash, (
+        f"Expected sql_hash={expected_hash!r} as a log record attribute. "
+        f"Records: {[(r.getMessage(), vars(r)) for r in caplog.records]!r}"
+    )
+
+    # The full SQL must NOT appear in any record field
+    for record in caplog.records:
+        record_str = str(vars(record))
+        assert sql not in record_str, (
+            f"Full SQL must not appear in audit log record: {record_str!r}"
+        )
+
+
+def test_exec_raw_audit_log_does_not_emit_full_sql(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """exec_raw audit log never contains the full SQL string."""
+    import structlog as _structlog
+
+    _insert_rows(populated_db, "test_items", [{"name": "secret_name", "value": 123}])
+    populated_db.close()
+
+    # Reconfigure structlog to emit through stdlib logging so caplog catches it.
+    _structlog.configure(
+        processors=[_structlog.stdlib.render_to_log_kwargs],
+        wrapper_class=_structlog.stdlib.BoundLogger,
+        logger_factory=_structlog.stdlib.LoggerFactory(),
+    )
+
+    # Use SQL with PII-like content that must not leak into logs
+    sql = "SELECT name FROM test_items WHERE name = 'secret_name'"
+
+    with caplog.at_level(logging.DEBUG, logger="nexus.daemon.introspection"):
+        service.exec_raw(sql)
+
+    # Check ALL record attributes, not just getMessage()
+    for record in caplog.records:
+        record_str = str(vars(record))
+        assert "secret_name" not in record_str, (
+            f"PII from SQL must not appear in audit log: {record_str!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: IntrospectionService registered in daemon dispatch table
+# ---------------------------------------------------------------------------
+
+
+def test_introspection_ops_in_dispatch_table(config_dir: Path, t2db: T2Database) -> None:
+    """schema, peek, stats are registered in the daemon RPC table (non-admin)."""
+    daemon = T2Daemon(config_dir=config_dir, t2db=t2db)
+    assert "schema" in daemon._rpc_table
+    assert "peek" in daemon._rpc_table
+    assert "stats" in daemon._rpc_table
+
+
+def test_admin_introspection_ops_in_admin_set(config_dir: Path, t2db: T2Database) -> None:
+    """exec_raw and export are in _ADMIN_OPS."""
+    from nexus.daemon.t2_daemon import _ADMIN_OPS
+    assert "exec_raw" in _ADMIN_OPS
+    assert "export" in _ADMIN_OPS
+
+
+def test_non_admin_introspection_ops_not_in_admin_set() -> None:
+    """schema, peek, stats are NOT in _ADMIN_OPS (safe over TCP)."""
+    from nexus.daemon.t2_daemon import _ADMIN_OPS
+    assert "schema" not in _ADMIN_OPS
+    assert "peek" not in _ADMIN_OPS
+    assert "stats" not in _ADMIN_OPS
+
+
+# ---------------------------------------------------------------------------
+# Review-driven additions (PR #775 review)
+# ---------------------------------------------------------------------------
+
+
+def test_peek_rejects_zero_limit(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+) -> None:
+    """peek with limit=0 must raise ValueError (silent empty is a foot-gun)."""
+    populated_db.close()
+    with pytest.raises(ValueError, match="positive"):
+        service.peek(table="test_items", limit=0)
+
+
+def test_peek_rejects_negative_limit(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+) -> None:
+    populated_db.close()
+    with pytest.raises(ValueError, match="positive"):
+        service.peek(table="test_items", limit=-5)
+
+
+def test_peek_rejects_negative_offset(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+) -> None:
+    populated_db.close()
+    with pytest.raises(ValueError, match="non-negative"):
+        service.peek(table="test_items", offset=-1, limit=10)
+
+
+def test_export_rejects_path_traversal(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+    tmp_path: Path,
+) -> None:
+    """export must reject dest_path outside the configured export root."""
+    populated_db.close()
+    # Path traversal: try to write outside tmp_path (the export root).
+    traversal = "/tmp/escape-test-nexus-pce11.jsonl"
+    with pytest.raises(ValueError, match="outside the configured export root"):
+        service.export(table="test_items", format="jsonl", dest_path=traversal)
+
+
+def test_exec_raw_audit_log_fires_after_execution(
+    service: IntrospectionService,
+    populated_db: sqlite3.Connection,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """exec_raw must NOT emit an audit event when the SQL fails (DoS noise)."""
+    populated_db.close()
+    import logging as _logging
+    caplog.set_level(_logging.INFO)
+    # Invalid SQL — execution fails. Pre-execution logging would record the
+    # attempt regardless of validity, creating DoS-friendly audit churn.
+    with pytest.raises(Exception):
+        service.exec_raw("SELECT * FROM no_such_table_xyz")
+    # No "raw-exec" event should appear in caplog records for the failed call.
+    raw_exec_events = [
+        r for r in caplog.records
+        if "raw-exec" in r.getMessage() or getattr(r, "op", None) == "raw-exec"
+    ]
+    assert raw_exec_events == [], (
+        f"audit must fire only on success; got {len(raw_exec_events)} event(s) "
+        "for a failed exec_raw"
+    )


### PR DESCRIPTION
## Summary

- Adds `IntrospectionService` (`src/nexus/daemon/introspection.py`) with five verbs: `exec_raw`, `schema`, `peek`, `stats`, `export`
- `exec_raw` and `export` added to `_ADMIN_OPS` + `_KNOWN_ADMIN_NAMES` (UDS-only gate)
- `schema`, `peek`, `stats` are TCP-safe read-only metadata ops
- 5 new CLI subcommands under `nx daemon t2`: `exec`, `schema`, `peek`, `stats`, `export`
- 25 new tests covering all 7 acceptance criteria from nexus-08i1

## Admin-only classification

- **`exec_raw`**: arbitrary SQL read access; blast radius = full T2 read surface. UDS-only.
- **`export`**: daemon-side file write to arbitrary path. UDS-only.
- **`schema`, `peek`, `stats`**: read-only metadata. TCP-safe.

## Export streaming implementation

`export` uses a generator + `cursor.fetchmany(256)` for jsonl/csv (no full materialisation). SQLite format uses `sqlite3.Connection.backup()` (Backup API). The result dict carries `rows` (total row count) and `bytes_written`.

## `exec_raw` write enforcement

Write rejection is via `sqlite3.connect("file:<path>?mode=ro", uri=True)`. No SQL pattern matching. Tests confirm `INSERT`, `DELETE`, `CREATE TABLE` all raise `sqlite3.OperationalError`.

## Cross-bead conflict

No conflict. `commands/daemon.py` additions are appended at the bottom (after `info_cmd`). `t2_daemon.py` additions are a contiguous block in `__init__` (before the startup integrity check) plus 2 lines in each of `_ADMIN_OPS` and `_KNOWN_ADMIN_NAMES`. nexus-x98k (`subspace_add`) is in a separate worktree and adds non-overlapping lines.

## Test plan

- [x] `tests/daemon/test_introspection_rpcs.py` — 25 tests, 142 daemon tests total pass
- [x] `tests/test_plugin_structure.py` — 580 passed, 26 skipped
- [x] No AI attribution in commit

## Closes

Closes nexus-08i1