### PR TITLE
feat(operators): cost telemetry for claude_dispatch + qwen_dispatch

### DIFF
--- a/src/nexus/operators/dispatch.py
+++ b/src/nexus/operators/dispatch.py
@@ -173,6 +173,8 @@ async def claude_dispatch(
     prompt: str,
     json_schema: dict[str, Any],
     timeout: float = 300.0,
+    *,
+    operator_name: str | None = None,
 ) -> dict[str, Any]:
     """Dispatch a single operator call to claude -p, fully async.
 
@@ -306,6 +308,38 @@ async def claude_dispatch(
         raise OperatorOutputError(
             f"claude -p output is not valid JSON: {exc} — got: {raw[:200]}"
         ) from exc
+
+    # Cost telemetry: the `claude -p` JSON envelope carries
+    # ``total_cost_usd`` plus a ``usage`` block with input/output token
+    # counts. Surface them as a structured log entry so operators can
+    # roll up spend downstream without threading a new return field
+    # through every caller. Missing fields → log nulls; the dispatch
+    # path does not depend on this signal.
+    if isinstance(parsed, dict):
+        cost_usd = parsed.get("total_cost_usd")
+        usage = parsed.get("usage")
+        in_tok: int | None = None
+        out_tok: int | None = None
+        if isinstance(usage, dict):
+            pt = usage.get("input_tokens")
+            ct = usage.get("output_tokens")
+            if isinstance(pt, int):
+                in_tok = pt
+            if isinstance(ct, int):
+                out_tok = ct
+        _log.info(
+            "operator_dispatch_cost",
+            dispatch_engine="claude",
+            dispatch_operator=operator_name,
+            dispatch_input_tokens=in_tok,
+            dispatch_output_tokens=out_tok,
+            dispatch_cost_usd=(
+                float(cost_usd)
+                if isinstance(cost_usd, (int, float))
+                else None
+            ),
+            dispatch_would_have_cost_usd=None,
+        )
 
     # `claude -p --output-format json` returns a wrapper:
     # {"type":"result", "is_error":bool, "result":str, "structured_output":dict, ...}

--- a/src/nexus/operators/qwen_dispatch.py
+++ b/src/nexus/operators/qwen_dispatch.py
@@ -41,6 +41,9 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+import structlog
+
+_log = structlog.get_logger(__name__)
 
 __all__ = [
     "qwen_dispatch",
@@ -48,6 +51,37 @@ __all__ = [
     "QwenOperatorTimeoutError",
     "QwenOperatorOutputError",
 ]
+
+
+# Cost-telemetry rates for the "would-have-cost" estimator.
+#
+# These are the published Anthropic API rates for Claude Sonnet 4.x as of
+# 2026-05 — see https://www.anthropic.com/pricing#api. Used only to give
+# operators a rough "how much did running this on Qwen save us" signal in
+# the structured logs; this is NOT a billing system. Refresh the constants
+# (and the date below) when Anthropic publishes a new Sonnet rate card.
+#
+# Last verified: 2026-05-14, source: https://www.anthropic.com/pricing
+_SONNET_INPUT_USD_PER_MTOK = 3.0
+_SONNET_OUTPUT_USD_PER_MTOK = 15.0
+
+
+def _estimate_sonnet_cost_usd(
+    input_tokens: int | None, output_tokens: int | None
+) -> float | None:
+    """Compute the Sonnet 4.x would-have-cost for *input* / *output* tokens.
+
+    Returns ``None`` when either token count is missing — the upstream
+    response did not include a ``usage`` block (older llama-server build,
+    streaming response that elided usage, etc.). Callers log the ``None``
+    rather than fabricating a number.
+    """
+    if input_tokens is None or output_tokens is None:
+        return None
+    return (
+        input_tokens * _SONNET_INPUT_USD_PER_MTOK / 1_000_000.0
+        + output_tokens * _SONNET_OUTPUT_USD_PER_MTOK / 1_000_000.0
+    )
 
 
 class QwenOperatorError(RuntimeError):
@@ -195,6 +229,7 @@ async def qwen_dispatch(
     backend_url: str | None = None,
     model: str | None = None,
     max_attempts: int = 2,
+    operator_name: str | None = None,
 ) -> dict[str, Any]:
     """Dispatch one operator call to Qwen via OpenAI-compat ``/v1/chat/completions``.
 
@@ -293,6 +328,35 @@ async def qwen_dispatch(
                     f"qwen_dispatch unexpected response shape: {exc} "
                     f"(attempt {attempt}/{max_attempts})"
                 ) from exc
+
+            # Cost telemetry: extract usage + emit would-have-cost estimate.
+            # Missing ``usage`` block (older llama-server, streaming) →
+            # log nulls rather than crashing. The dispatch path itself
+            # does not depend on this signal.
+            usage = (
+                payload.get("usage") if isinstance(payload, dict) else None
+            )
+            input_tokens: int | None = None
+            output_tokens: int | None = None
+            if isinstance(usage, dict):
+                pt = usage.get("prompt_tokens")
+                ct = usage.get("completion_tokens")
+                if isinstance(pt, int):
+                    input_tokens = pt
+                if isinstance(ct, int):
+                    output_tokens = ct
+            would_have_cost = _estimate_sonnet_cost_usd(
+                input_tokens, output_tokens
+            )
+            _log.info(
+                "operator_dispatch_cost",
+                dispatch_engine="qwen",
+                dispatch_operator=operator_name,
+                dispatch_input_tokens=input_tokens,
+                dispatch_output_tokens=output_tokens,
+                dispatch_cost_usd=0.0,
+                dispatch_would_have_cost_usd=would_have_cost,
+            )
 
             stripped = _strip_code_fences(last_raw)
             try:

--- a/tests/test_operator_dispatch.py
+++ b/tests/test_operator_dispatch.py
@@ -1360,3 +1360,114 @@ class TestOperatorAggregate:
         assert len(result["aggregates"]) == 3
         keys = {a["key_value"] for a in result["aggregates"]}
         assert keys == {"alpha", "beta", "gamma"}
+
+
+# ── Cost telemetry ───────────────────────────────────────────────────────
+
+
+class _LogCapture:
+    """Stand-in for the module ``_log`` that records ``info(event, **kw)`` calls."""
+
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, dict[str, object]]] = []
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.entries.append((event, kwargs))
+
+    def debug(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+    def warning(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+    def error(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+
+def _envelope(
+    total_cost_usd: float | None = 0.0123,
+    input_tokens: int | None = 1200,
+    output_tokens: int | None = 250,
+    structured: dict | None = None,
+) -> bytes:
+    """Build a faked ``claude -p --output-format json`` envelope."""
+    env: dict[str, object] = {
+        "type": "result",
+        "is_error": False,
+        "result": "",
+        "structured_output": structured or {"result": "ok"},
+    }
+    if total_cost_usd is not None:
+        env["total_cost_usd"] = total_cost_usd
+    usage: dict[str, object] = {}
+    if input_tokens is not None:
+        usage["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        usage["output_tokens"] = output_tokens
+    if usage:
+        env["usage"] = usage
+    return json.dumps(env).encode()
+
+
+class TestClaudeDispatchCostTelemetry:
+    """RDR-PR#623 follow-up: surface ``total_cost_usd`` + usage from the
+    claude -p envelope as a structured log entry."""
+
+    @pytest.mark.asyncio
+    async def test_logs_total_cost_and_usage_from_envelope(self) -> None:
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc(stdout=_envelope(
+            total_cost_usd=0.0123, input_tokens=1200, output_tokens=250,
+        ))
+        cap = _LogCapture()
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)), \
+             patch("nexus.operators.dispatch._log", cap):
+            result = await claude_dispatch(
+                "prompt",
+                _SIMPLE_SCHEMA,
+                operator_name="operator_extract",
+            )
+        assert result == {"result": "ok"}
+        cost = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+        assert cost, f"expected operator_dispatch_cost entry; got {cap.entries!r}"
+        _, kw = cost[-1]
+        assert kw["dispatch_engine"] == "claude"
+        assert kw["dispatch_operator"] == "operator_extract"
+        assert kw["dispatch_cost_usd"] == pytest.approx(0.0123)
+        assert kw["dispatch_input_tokens"] == 1200
+        assert kw["dispatch_output_tokens"] == 250
+        assert kw["dispatch_would_have_cost_usd"] is None
+
+    @pytest.mark.asyncio
+    async def test_logs_null_cost_when_total_cost_usd_missing(self) -> None:
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc(stdout=_envelope(total_cost_usd=None))
+        cap = _LogCapture()
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)), \
+             patch("nexus.operators.dispatch._log", cap):
+            await claude_dispatch("p", _SIMPLE_SCHEMA)
+        cost = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+        assert cost
+        _, kw = cost[-1]
+        assert kw["dispatch_cost_usd"] is None
+        # Usage was still present — those should be preserved.
+        assert kw["dispatch_input_tokens"] == 1200
+
+    @pytest.mark.asyncio
+    async def test_logs_null_tokens_when_usage_block_missing(self) -> None:
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc(stdout=_envelope(
+            input_tokens=None, output_tokens=None,
+        ))
+        cap = _LogCapture()
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)), \
+             patch("nexus.operators.dispatch._log", cap):
+            await claude_dispatch("p", _SIMPLE_SCHEMA)
+        cost = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+        assert cost
+        _, kw = cost[-1]
+        assert kw["dispatch_input_tokens"] is None
+        assert kw["dispatch_output_tokens"] is None

--- a/tests/test_qwen_dispatch.py
+++ b/tests/test_qwen_dispatch.py
@@ -28,8 +28,11 @@ from nexus.operators.qwen_dispatch import (
     QwenOperatorOutputError,
     QwenOperatorTimeoutError,
     _build_system_prompt,
+    _estimate_sonnet_cost_usd,
     _resolve_backend_url,
     _resolve_model,
+    _SONNET_INPUT_USD_PER_MTOK,
+    _SONNET_OUTPUT_USD_PER_MTOK,
     _strip_code_fences,
     qwen_dispatch,
 )
@@ -291,3 +294,124 @@ async def test_dispatch_raises_on_unexpected_payload_shape() -> None:
     with patch("httpx.AsyncClient.post", fake_post):
         with pytest.raises(QwenOperatorError, match="unexpected response shape"):
             await qwen_dispatch("p", _SCHEMA, backend_url="http://x/v1")
+
+
+# ── Cost telemetry ────────────────────────────────────────────────────────
+
+
+def _chat_completion_with_usage(
+    content: str, prompt_tokens: int, completion_tokens: int
+) -> dict:
+    """OpenAI-compat response with a populated ``usage`` block."""
+    return {
+        "choices": [{"message": {"role": "assistant", "content": content}}],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+
+
+class TestEstimateSonnetCost:
+    def test_rate_card_matches_documented_constants(self) -> None:
+        # If Anthropic publishes a new Sonnet rate card and the constants
+        # change, this test fails loudly and the comment in
+        # qwen_dispatch.py demands a refresh of the date stamp too.
+        assert _SONNET_INPUT_USD_PER_MTOK == 3.0
+        assert _SONNET_OUTPUT_USD_PER_MTOK == 15.0
+
+    def test_estimate_matches_rate_math(self) -> None:
+        # 1_000_000 input tokens → $3, 1_000_000 output → $15, total $18.
+        assert _estimate_sonnet_cost_usd(1_000_000, 1_000_000) == pytest.approx(
+            18.0
+        )
+
+    def test_estimate_scales_linearly(self) -> None:
+        # 1500 input + 500 output:
+        #   1500 * 3 / 1e6  + 500 * 15 / 1e6 = 0.0045 + 0.0075 = 0.012
+        assert _estimate_sonnet_cost_usd(1500, 500) == pytest.approx(0.012)
+
+    def test_estimate_returns_none_when_input_missing(self) -> None:
+        assert _estimate_sonnet_cost_usd(None, 500) is None
+
+    def test_estimate_returns_none_when_output_missing(self) -> None:
+        assert _estimate_sonnet_cost_usd(1500, None) is None
+
+
+class _LogCapture:
+    """Drop-in for the module ``_log``: records each ``info(...)`` call as
+    ``(event, kwargs)``. Avoids depending on whichever structlog bridge
+    (stdlib / PrintLoggerFactory) is configured in the test harness."""
+
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, dict[str, object]]] = []
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.entries.append((event, kwargs))
+
+    def debug(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+    def warning(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+    def error(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+
+@pytest.mark.asyncio
+async def test_dispatch_logs_would_have_cost_when_usage_present() -> None:
+    """qwen_dispatch must emit a structured cost-telemetry log line
+    carrying the would-have-cost estimate derived from the usage block."""
+    fake_post = AsyncMock(
+        return_value=_resp(
+            200,
+            _chat_completion_with_usage(
+                '{"answer":"ok"}', prompt_tokens=2000, completion_tokens=400
+            ),
+        )
+    )
+    cap = _LogCapture()
+    with patch("nexus.operators.qwen_dispatch._log", cap), patch(
+        "httpx.AsyncClient.post", fake_post
+    ):
+        await qwen_dispatch(
+            "p",
+            _SCHEMA,
+            backend_url="http://x/v1",
+            operator_name="operator_summarize",
+        )
+
+    cost_entries = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+    assert cost_entries, f"expected cost log entry; got {cap.entries!r}"
+    _, kw = cost_entries[-1]
+    assert kw["dispatch_engine"] == "qwen"
+    assert kw["dispatch_operator"] == "operator_summarize"
+    assert kw["dispatch_input_tokens"] == 2000
+    assert kw["dispatch_output_tokens"] == 400
+    assert kw["dispatch_cost_usd"] == 0.0
+    # 2000*3/1e6 + 400*15/1e6 = 0.006 + 0.006 = 0.012
+    assert kw["dispatch_would_have_cost_usd"] == pytest.approx(0.012)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_logs_null_cost_when_usage_block_missing() -> None:
+    """Missing usage block must not crash — log with would_have_cost=None."""
+    fake_post = AsyncMock(
+        return_value=_resp(200, _chat_completion('{"answer":"ok"}'))
+    )
+    cap = _LogCapture()
+    with patch("nexus.operators.qwen_dispatch._log", cap), patch(
+        "httpx.AsyncClient.post", fake_post
+    ):
+        result = await qwen_dispatch("p", _SCHEMA, backend_url="http://x/v1")
+    assert result == {"answer": "ok"}
+
+    cost_entries = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+    assert cost_entries
+    _, kw = cost_entries[-1]
+    assert kw["dispatch_input_tokens"] is None
+    assert kw["dispatch_output_tokens"] is None
+    assert kw["dispatch_would_have_cost_usd"] is None
+    assert kw["dispatch_engine"] == "qwen"


### PR DESCRIPTION
## Summary

Follow-up to #623. Surfaces per-call cost data on both dispatchers as a structured `structlog` entry (`event=operator_dispatch_cost`) so operators can roll up spend and would-have-cost savings downstream without threading a new return-value field through every caller.

- `claude_dispatch`: extracts `total_cost_usd` plus `usage.input_tokens` / `usage.output_tokens` from the `claude -p --output-format json` envelope.
- `qwen_dispatch`: extracts `usage.prompt_tokens` / `completion_tokens` from the llama-server OpenAI-compat response and computes a Sonnet-4.x would-have-cost estimate (input \$3/MTok, output \$15/MTok). Rates live as module-level `_SONNET_INPUT_USD_PER_MTOK` / `_SONNET_OUTPUT_USD_PER_MTOK` constants with a comment citing source + last-verified date so future-us knows when to refresh.
- Both dispatchers gain an optional `operator_name` kwarg for log enrichment; existing callers are untouched (no breaking changes).

## Implementation notes

- Log-only for v1 — the deferred-from-#623 sketch explicitly avoids invasively threading a cost field through every caller. Aggregation happens downstream.
- Field naming is consistent across engines: `dispatch_engine`, `dispatch_operator`, `dispatch_input_tokens`, `dispatch_output_tokens`, `dispatch_cost_usd`, `dispatch_would_have_cost_usd`. Qwen always logs `dispatch_cost_usd=0.0` (local llama-server is free) and a populated would-have-cost; Claude always logs `dispatch_would_have_cost_usd=None`.
- Failures in the cost-extraction path cannot break dispatch: missing `total_cost_usd` or missing `usage` block both produce log entries with `None` for the missing field. Tests cover both edge cases.
- Constants are deliberately hardcoded rather than config-driven — this is a rough estimator, not a billing system.

## Test plan

- [x] `pytest tests/test_qwen_dispatch.py tests/test_operator_dispatch.py tests/test_dispatch_router.py` — 120 passed, 1 skipped
- [x] Broader sweep including `test_operator_pipelines_dispatch.py` + `test_rdr_109_phase2_dispatch.py` — 144 passed, 1 skipped
- [x] New tests cover: happy path with usage block, missing-usage edge case (qwen), happy path with `total_cost_usd`, missing-`total_cost_usd` edge case (claude), missing-usage edge case (claude), pure-function rate math + constants pin

## Out of scope

- Log-line aggregation / weekly cost rollup tooling
- Grammar-enforcement at llama-server for stricter token accounting
- Making the rate card config-driven

## Linked

- Parent: #623