### PR TITLE
feat(operators): named call-site routing + topic_labeler

### DIFF
--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -1058,8 +1058,20 @@ async def _generate_labels_batch(
     results: list[str | None] = [None] * len(items)
     try:
         from nexus.operators.dispatch import claude_dispatch
+        from nexus.operators.dispatch_router import pick_dispatcher_for
 
-        payload = await claude_dispatch(prompt, _LABEL_SCHEMA, timeout=120.0)
+        if pick_dispatcher_for("topic_labeler") == "qwen":
+            from nexus.operators.qwen_dispatch import qwen_dispatch
+
+            payload = await qwen_dispatch(
+                prompt, _LABEL_SCHEMA, timeout=120.0,
+                operator_name="topic_labeler",
+            )
+        else:
+            payload = await claude_dispatch(
+                prompt, _LABEL_SCHEMA, timeout=120.0,
+                operator_name="topic_labeler",
+            )
     except Exception:
         return results
 

--- a/src/nexus/operators/dispatch_router.py
+++ b/src/nexus/operators/dispatch_router.py
@@ -41,6 +41,7 @@ __all__ = [
     "QWEN_OPERATORS_DEFAULT",
     "CLAUDE_OPERATORS_PINNED",
     "pick_dispatcher",
+    "pick_dispatcher_for",
     "pick_dispatcher_for_bundle",
 ]
 
@@ -119,6 +120,30 @@ def pick_dispatcher(operator_name: str) -> DispatchBackend:
         return "claude"
     # mode == "claude" or unset: default Claude (preserves prior behavior).
     return "claude"
+
+
+def pick_dispatcher_for(call_site: str) -> DispatchBackend:
+    """Route a named non-operator call site through the same machinery.
+
+    Some ``claude_dispatch`` callers aren't bundleable operators —
+    e.g. ``taxonomy_cmd._generate_labels_batch`` (topic labeler) and
+    the inline plan-miss planner. They still benefit from per-site
+    routing so the operator can flip them to Qwen once bench evidence
+    lands, without a code change.
+
+    Semantics: identical to :func:`pick_dispatcher`. The two per-call
+    env vars (``NEXUS_DISPATCH_QWEN_OPERATORS`` /
+    ``NEXUS_DISPATCH_CLAUDE_OPERATORS``) accept call-site names too —
+    "what to route" is the same surface whether it's an operator or a
+    call site, so a separate env var would be bloat.
+
+    Because call sites are not in :data:`QWEN_OPERATORS_DEFAULT`, the
+    auto-mode unknown-name branch routes them to claude — cautious-by-
+    default, matching #623's rollout posture. Opting one site into
+    Qwen is a one-env-var flip
+    (``NEXUS_DISPATCH_QWEN_OPERATORS=<call_site>``).
+    """
+    return pick_dispatcher(call_site)
 
 
 def pick_dispatcher_for_bundle(tools: Iterable[str]) -> DispatchBackend:

--- a/tests/test_dispatch_router.py
+++ b/tests/test_dispatch_router.py
@@ -19,6 +19,7 @@ from nexus.operators.dispatch_router import (
     CLAUDE_OPERATORS_PINNED,
     QWEN_OPERATORS_DEFAULT,
     pick_dispatcher,
+    pick_dispatcher_for,
     pick_dispatcher_for_bundle,
 )
 
@@ -232,3 +233,54 @@ class TestBundleRouting:
         assert (
             pick_dispatcher_for_bundle(["summarize", "compare"]) == "claude"
         )
+
+
+# ── Named call-site routing (non-operator callers) ───────────────────────
+
+
+class TestNamedCallSite:
+    """Per-call-site routing for non-operator ``claude_dispatch`` users.
+
+    ``pick_dispatcher_for`` delegates to ``pick_dispatcher`` — call sites
+    are not in ``QWEN_OPERATORS_DEFAULT`` so the auto-mode unknown-name
+    branch routes them to claude. Pins use the same env vars.
+    """
+
+    def test_default_routes_to_claude(self) -> None:
+        assert pick_dispatcher_for("topic_labeler") == "claude"
+
+    def test_auto_mode_routes_to_claude(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Cautious default: no bench evidence yet for call sites, so
+        # auto-mode still routes them to claude.
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "auto")
+        assert pick_dispatcher_for("topic_labeler") == "claude"
+
+    def test_global_qwen_mode_routes_to_qwen(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "qwen")
+        assert pick_dispatcher_for("topic_labeler") == "qwen"
+
+    def test_qwen_pin_via_operators_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reuse the per-operator env var — semantic is "what to route",
+        # operator vs call site is the same surface.
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "topic_labeler")
+        assert pick_dispatcher_for("topic_labeler") == "qwen"
+
+    def test_claude_pin_overrides_qwen_pin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "topic_labeler")
+        monkeypatch.setenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", "topic_labeler")
+        assert pick_dispatcher_for("topic_labeler") == "claude"
+
+    def test_claude_pin_overrides_global_qwen(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "qwen")
+        monkeypatch.setenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", "topic_labeler")
+        assert pick_dispatcher_for("topic_labeler") == "claude"

--- a/tests/test_rdr_085_glossary_labeler.py
+++ b/tests/test_rdr_085_glossary_labeler.py
@@ -249,3 +249,72 @@ class TestLabelerDispatch:
 
         assert results == []
         assert not dispatched.called
+
+
+# ── Named call-site routing for the labeler ──────────────────────────────────
+
+
+class TestLabelerRouting:
+    """The labeler routes through ``pick_dispatcher_for('topic_labeler')``.
+
+    Under default env it still calls ``claude_dispatch`` (preserves
+    byte-for-byte behavior). Under ``NEXUS_DISPATCH_QWEN_OPERATORS=
+    topic_labeler`` it calls ``qwen_dispatch`` with the same prompt,
+    schema, and timeout — and tags both calls with
+    ``operator_name='topic_labeler'`` for the cost-telemetry log.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_env_calls_claude_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        for var in (
+            "NEXUS_DISPATCH_BACKEND",
+            "NEXUS_DISPATCH_QWEN_OPERATORS",
+            "NEXUS_DISPATCH_CLAUDE_OPERATORS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        claude_mock = AsyncMock(return_value={"labels": [{"idx": 1, "label": "Topic"}]})
+        qwen_mock = AsyncMock(return_value={"labels": []})
+        items = [(["term"], ["doc.pdf:0"])]
+        with patch("nexus.operators.dispatch.claude_dispatch", claude_mock), \
+             patch("nexus.operators.qwen_dispatch.qwen_dispatch", qwen_mock):
+            await taxonomy_cmd._generate_labels_batch(items)
+
+        assert claude_mock.called
+        assert not qwen_mock.called
+        # Telemetry tag passed through.
+        kwargs = claude_mock.call_args.kwargs
+        assert kwargs.get("operator_name") == "topic_labeler"
+        assert kwargs.get("timeout") == 120.0
+
+    @pytest.mark.asyncio
+    async def test_qwen_pin_routes_to_qwen_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "topic_labeler")
+        monkeypatch.delenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", raising=False)
+        monkeypatch.delenv("NEXUS_DISPATCH_BACKEND", raising=False)
+
+        claude_mock = AsyncMock(return_value={"labels": []})
+        qwen_mock = AsyncMock(return_value={"labels": [{"idx": 1, "label": "Topic"}]})
+        items = [(["term"], ["doc.pdf:0"])]
+        with patch("nexus.operators.dispatch.claude_dispatch", claude_mock), \
+             patch("nexus.operators.qwen_dispatch.qwen_dispatch", qwen_mock):
+            results = await taxonomy_cmd._generate_labels_batch(items)
+
+        assert qwen_mock.called
+        assert not claude_mock.called
+        # Same prompt + schema + timeout signature.
+        args, kwargs = qwen_mock.call_args.args, qwen_mock.call_args.kwargs
+        # First positional is prompt, second is schema.
+        assert "1. terms=[term]" in args[0]
+        assert args[1] == taxonomy_cmd._LABEL_SCHEMA
+        assert kwargs.get("timeout") == 120.0
+        assert kwargs.get("operator_name") == "topic_labeler"
+        assert results == ["Topic"]


### PR DESCRIPTION
## Summary

Extends per-operator dispatch routing (#623/#626/#776) to non-operator
`claude_dispatch` call sites. Step 1 of 3 from the qwen-offload audit
(`docs/integrations/qwen-offload-audit-2026-05-14.md`) — proves the
named-call-site pattern with the lowest-risk caller, the topic labeler.

## Implementation

- **Router seam.** New `pick_dispatcher_for(call_site)` in
  `src/nexus/operators/dispatch_router.py` (~20 LOC including
  docstring). Delegates to the existing `pick_dispatcher` — same env
  vars (`NEXUS_DISPATCH_BACKEND`, `NEXUS_DISPATCH_QWEN_OPERATORS`,
  `NEXUS_DISPATCH_CLAUDE_OPERATORS`), same resolution order. Because
  call-site names are not in `QWEN_OPERATORS_DEFAULT`, auto-mode's
  unknown-name branch routes them to claude — cautious-by-default,
  matching #623. No new env var introduced; "what to route" is the
  same surface for operators and call sites.

- **topic_labeler migration.** `_generate_labels_batch` in
  `src/nexus/commands/taxonomy_cmd.py` now picks the engine via
  `pick_dispatcher_for("topic_labeler")` and calls `qwen_dispatch` or
  `claude_dispatch` with the same prompt/schema/timeout. Both paths
  tag the dispatch with `operator_name="topic_labeler"` for PR #776
  cost telemetry.

- **No behavior change under default env.** All existing labeler
  tests pass unchanged.

## Test plan

- [x] `pytest tests/test_dispatch_router.py tests/test_rdr_085_glossary_labeler.py` — 53 passed, 1 skipped (pre-existing `CLAUDE_OPERATORS_PINNED` empty-set skip).
- [x] Broader sweep: `pytest tests/ -k "dispatch or taxonomy or labeler"` — 390 passed, no regressions.
- New tests:
  - `TestNamedCallSite` × 6 in `test_dispatch_router.py` (default, auto, global-qwen, qwen pin, claude-pin-overrides-qwen-pin, claude-pin-overrides-global-qwen).
  - `TestLabelerRouting` × 2 in `test_rdr_085_glossary_labeler.py` (default env → claude_dispatch with `operator_name`; `NEXUS_DISPATCH_QWEN_OPERATORS=topic_labeler` → qwen_dispatch with same prompt+schema+timeout).

## Out of scope

- **Plan-miss planner** (`_nx_answer_plan_miss` at `src/nexus/mcp/core.py:3228`) — step 2 of the sequence.
- **aspect_extractor** — step 3.
- Bench evidence for `topic_labeler` to promote it into the auto-mode default set — separate work once we have a labeling oracle.

## Linked

- Builds on #623 (`pick_dispatcher`), #626 (bundle routing), #776 (cost telemetry / `operator_name` kwarg).
- Audit: `docs/integrations/qwen-offload-audit-2026-05-14.md` (commit 090b213).