### PR TITLE
feat(operators): route nx_answer plan-miss planner through pick_dispatcher_for

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -3177,6 +3177,7 @@ async def _nx_answer_plan_miss(
     and return a synthetic Match for plan_run.
     """
     from nexus.operators.dispatch import claude_dispatch
+    from nexus.operators.dispatch_router import pick_dispatcher_for
     from nexus.plans.match import Match
     from nexus.mcp_infra import get_collection_names
 
@@ -3229,9 +3230,18 @@ async def _nx_answer_plan_miss(
     for attempt in range(2):
         attempt_timeout = 300.0 if attempt == 0 else 150.0
         try:
-            payload = await claude_dispatch(
-                prompt, _PLANNER_SCHEMA, timeout=attempt_timeout,
-            )
+            if pick_dispatcher_for("plan_miss_planner") == "qwen":
+                from nexus.operators.qwen_dispatch import qwen_dispatch
+
+                payload = await qwen_dispatch(
+                    prompt, _PLANNER_SCHEMA, timeout=attempt_timeout,
+                    operator_name="plan_miss_planner",
+                )
+            else:
+                payload = await claude_dispatch(
+                    prompt, _PLANNER_SCHEMA, timeout=attempt_timeout,
+                    operator_name="plan_miss_planner",
+                )
             break
         except _OpOutputError as exc:
             last_output_error = exc

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -647,7 +647,7 @@ class TestPlanMissPlanner:
             ],
         }
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return fake_plan
 
         with patch.object(_dispatch_mod, "claude_dispatch", fake_dispatch):
@@ -664,7 +664,7 @@ class TestPlanMissPlanner:
         from nexus.mcp.core import _nx_answer_plan_miss
         import nexus.operators.dispatch as _dispatch_mod
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return {"steps": []}
 
         with patch.object(_dispatch_mod, "claude_dispatch", fake_dispatch):
@@ -677,7 +677,7 @@ class TestPlanMissPlanner:
         from nexus.mcp.core import _nx_answer_plan_miss
         import nexus.operators.dispatch as _dispatch_mod
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return {"steps": [
                 {"tool": "mcp__plugin_sn_serena__jet_brains_find_symbol", "args": {}},
             ]}
@@ -695,7 +695,7 @@ class TestPlanMissPlanner:
         from nexus.mcp.core import _nx_answer_plan_miss
         import nexus.operators.dispatch as _dispatch_mod
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return {"steps": [
                 {"tool": "Grep", "args": {}},
                 {"tool": "Read", "args": {}},
@@ -714,7 +714,7 @@ class TestPlanMissPlanner:
         from nexus.mcp.core import _nx_answer_plan_miss
         import nexus.operators.dispatch as _dispatch_mod
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return {"steps": [
                 {"tool": "mcp__plugin_nx_nexus__search", "args": {"query": "$intent"}},
                 {"tool": "summarize", "args": {"inputs": "$step1.ids"}},
@@ -732,7 +732,7 @@ class TestPlanMissPlanner:
         from nexus.mcp.core import _nx_answer_plan_miss
         import nexus.operators.dispatch as _dispatch_mod
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return {"steps": [
                 {"tool": "search", "args": {"query": "$intent"}},
                 {"tool": "totally_unknown_tool", "args": {}},
@@ -758,7 +758,7 @@ class TestPlanMissPlanner:
 
         dispatch_calls = []
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             dispatch_calls.append(prompt)
             return {"steps": [{"tool": "search", "args": {"query": "$intent"}}]}
 
@@ -2058,3 +2058,71 @@ def test_maybe_unwrap_output_envelope_max_depth_bounded() -> None:
     out = _maybe_unwrap_output_envelope(text, max_depth=3)
     # 3 unwraps from a 4-layer payload leaves one layer remaining.
     assert "core" in out and out.startswith('{')
+
+
+# ── Named call-site routing for the plan-miss planner ───────────────────────
+
+
+class TestPlannerRouting:
+    """The plan-miss planner routes through
+    ``pick_dispatcher_for('plan_miss_planner')``.
+
+    Under default env it still calls ``claude_dispatch`` (preserves
+    byte-for-byte behavior). Under
+    ``NEXUS_DISPATCH_QWEN_OPERATORS=plan_miss_planner`` it calls
+    ``qwen_dispatch`` with the same prompt, schema, and timeout — and
+    tags both calls with ``operator_name='plan_miss_planner'`` for the
+    cost-telemetry log.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_env_calls_claude_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nexus.mcp.core import _nx_answer_plan_miss
+
+        for var in (
+            "NEXUS_DISPATCH_BACKEND",
+            "NEXUS_DISPATCH_QWEN_OPERATORS",
+            "NEXUS_DISPATCH_CLAUDE_OPERATORS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        plan = {"steps": [{"tool": "search", "args": {"query": "$intent"}}]}
+        claude_mock = AsyncMock(return_value=plan)
+        qwen_mock = AsyncMock(return_value=plan)
+        with patch("nexus.operators.dispatch.claude_dispatch", claude_mock), \
+             patch("nexus.operators.qwen_dispatch.qwen_dispatch", qwen_mock):
+            await _nx_answer_plan_miss("how does X work")
+
+        assert claude_mock.called
+        assert not qwen_mock.called
+        kwargs = claude_mock.call_args.kwargs
+        assert kwargs.get("operator_name") == "plan_miss_planner"
+        assert kwargs.get("timeout") == 300.0
+
+    @pytest.mark.asyncio
+    async def test_qwen_pin_routes_to_qwen_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nexus.mcp.core import _nx_answer_plan_miss, _PLANNER_SCHEMA
+
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "plan_miss_planner")
+        monkeypatch.delenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", raising=False)
+        monkeypatch.delenv("NEXUS_DISPATCH_BACKEND", raising=False)
+
+        plan = {"steps": [{"tool": "search", "args": {"query": "$intent"}}]}
+        claude_mock = AsyncMock(return_value=plan)
+        qwen_mock = AsyncMock(return_value=plan)
+        with patch("nexus.operators.dispatch.claude_dispatch", claude_mock), \
+             patch("nexus.operators.qwen_dispatch.qwen_dispatch", qwen_mock):
+            await _nx_answer_plan_miss("how does X work")
+
+        assert qwen_mock.called
+        assert not claude_mock.called
+        args, kwargs = qwen_mock.call_args.args, qwen_mock.call_args.kwargs
+        # First positional is prompt, second is schema.
+        assert "how does X work" in args[0]
+        assert args[1] is _PLANNER_SCHEMA
+        assert kwargs.get("timeout") == 300.0
+        assert kwargs.get("operator_name") == "plan_miss_planner"


### PR DESCRIPTION
## Summary

Step 2 of the named call-site routing rollout. Migrates `_nx_answer_plan_miss` (`src/nexus/mcp/core.py`) onto the `pick_dispatcher_for(call_site)` seam shipped in #778. Default env keeps calling `claude_dispatch` byte-for-byte; `NEXUS_DISPATCH_QWEN_OPERATORS=plan_miss_planner` flips it to `qwen_dispatch` with the same prompt, schema, and timeout (300s primary / 150s retry). Both dispatchers tag the call with `operator_name=\"plan_miss_planner\"` so PR #776's cost telemetry attributes spend.

No dedicated bench. The planner is structurally identical to the bundleable operators already covered by the bench harness — oneshot, schema-bounded, with host-validated emitted tool names via `_ALLOWED_TOOLS` — so existing evidence covers the regime. Env-var rollback (`NEXUS_DISPATCH_CLAUDE_OPERATORS=plan_miss_planner`) is the v1 mitigation if behavior drifts under the qwen pin.

- `src/nexus/mcp/core.py`: +14/-2 — import `pick_dispatcher_for`, fork inside the existing retry loop on `pick_dispatcher_for(\"plan_miss_planner\") == \"qwen\"`, pass `operator_name=` to both legs.
- `tests/test_nx_answer.py`: +74/-7 — new `TestPlannerRouting` mirroring `TestLabelerRouting` from #778 (default → claude, qwen pin → qwen with same prompt/schema/timeout and telemetry tag asserted both legs). Existing `TestPlanMissPlanner` fakes widened with `**kwargs` to accept the new `operator_name=` kwarg; runtime behavior unchanged.

## Out of scope

- `aspect_extractor` (step 3 — needs a Path-B adapter, not a route-flip).

## Test plan

- [x] `pytest tests/test_nx_answer.py tests/test_dispatch_router.py tests/test_qwen_dispatch.py` → 169 passed, 1 skipped.
- [x] `TestPlannerRouting` default-env case verifies `claude_dispatch` called with `operator_name=\"plan_miss_planner\"` and `timeout=300.0`; `qwen_dispatch` not called.
- [x] `TestPlannerRouting` qwen-pin case verifies `qwen_dispatch` called with matching prompt/schema/timeout/operator_name; `claude_dispatch` not called.

Linked: #778