### PR TITLE
feat(aspect_extractor): qwen-backed adapter behind NEXUS_ASPECT_BACKEND env

### DIFF
--- a/src/nexus/aspect_extractor.py
+++ b/src/nexus/aspect_extractor.py
@@ -70,7 +70,9 @@ Retry policy (audit F8):
 """
 from __future__ import annotations
 
+import asyncio
 import json
+import os
 import random
 import re
 import subprocess
@@ -1067,9 +1069,13 @@ def _retry_subprocess_batch(
     null-out). Returns the outer dict ``{"papers": [...]}`` on
     success, ``None`` on final failure.
     """
+    backend = _pick_aspect_backend()
+    invoker = (
+        _invoke_once_batch_qwen if backend == "qwen" else _invoke_once_batch
+    )
     for attempt in range(_RETRY_ATTEMPTS):
         try:
-            return _invoke_once_batch(prompt, timeout=timeout)
+            return invoker(prompt, timeout=timeout)
         except _TransientFailure as exc:
             _log.debug(
                 "aspect_extractor_batch_transient_failure",
@@ -1215,6 +1221,147 @@ def _build_record_from_entry(
     )
 
 
+# ── Backend selection (Path B parallel adapter) ──────────────────────────────
+
+
+_ASPECT_BACKEND_ENV = "NEXUS_ASPECT_BACKEND"
+_ASPECT_BACKEND_DEFAULT = "claude"
+_ASPECT_BACKEND_VALID = ("claude", "qwen")
+
+# Permissive schemas for the qwen path. The aspect prompt was authored
+# against ``claude -p`` which doesn't take a schema, so we don't
+# fabricate field constraints here — the existing post-parse
+# validation in ``_build_record`` / ``_build_record_from_entry``
+# still applies. The schema is required by ``qwen_dispatch`` solely
+# to render the system-prompt JSON contract.
+_QWEN_ASPECT_SCHEMA_SINGLE: dict[str, Any] = {"type": "object"}
+_QWEN_ASPECT_SCHEMA_BATCH: dict[str, Any] = {
+    "type": "object",
+    "properties": {"papers": {"type": "array"}},
+    "required": ["papers"],
+}
+
+
+def _pick_aspect_backend() -> str:
+    """Resolve the aspect-extractor backend from ``NEXUS_ASPECT_BACKEND``.
+
+    Values: ``claude`` (default) routes to the existing subprocess
+    invokers; ``qwen`` routes to ``qwen_dispatch``. Unknown values
+    fall back to ``claude`` with a warning log. This is the only
+    surface that decides between the two engines — the retry/backoff
+    wrapper is shared.
+    """
+    raw = os.environ.get(_ASPECT_BACKEND_ENV)
+    if raw is None or raw == "":
+        return _ASPECT_BACKEND_DEFAULT
+    val = raw.strip().lower()
+    if val in _ASPECT_BACKEND_VALID:
+        return val
+    _log.warning(
+        "aspect_extractor_unknown_backend",
+        requested=raw,
+        fallback=_ASPECT_BACKEND_DEFAULT,
+        valid=_ASPECT_BACKEND_VALID,
+    )
+    return _ASPECT_BACKEND_DEFAULT
+
+
+def _dispatch_qwen_sync(
+    prompt: str,
+    schema: dict[str, Any],
+    *,
+    timeout: float,
+    operator_name: str,
+) -> dict[str, Any]:
+    """Run ``qwen_dispatch`` from a synchronous caller, translating
+    its exceptions into the local ``_TransientFailure`` /
+    ``_HardFailure`` taxonomy so the existing retry wrapper applies
+    without modification.
+
+    Exception mapping:
+
+    * ``QwenOperatorTimeoutError`` → ``_TransientFailure`` (HTTP
+      timeout is retriable at this layer).
+    * ``QwenOperatorOutputError`` → ``_HardFailure`` (qwen_dispatch
+      already retried JSON-parse internally; further retries here
+      won't reshape the model output).
+    * ``QwenOperatorError`` (other) → ``_TransientFailure`` for 5xx
+      backend errors, ``_HardFailure`` otherwise.
+    * Any unexpected exception → ``_HardFailure`` (don't silently
+      retry the unknown).
+    """
+    # Lazy import: avoids httpx + qwen_dispatch module load on the
+    # default (claude) path. Resolve via the module so tests that
+    # monkeypatch ``qwen_dispatch.qwen_dispatch`` are honoured.
+    from nexus.operators import qwen_dispatch as _qd_mod
+    QwenOperatorError = _qd_mod.QwenOperatorError
+    QwenOperatorOutputError = _qd_mod.QwenOperatorOutputError
+    QwenOperatorTimeoutError = _qd_mod.QwenOperatorTimeoutError
+
+    try:
+        return asyncio.run(
+            _qd_mod.qwen_dispatch(
+                prompt,
+                schema,
+                timeout=timeout,
+                operator_name=operator_name,
+            )
+        )
+    except QwenOperatorTimeoutError as exc:
+        raise _TransientFailure(f"qwen timeout: {exc}") from exc
+    except QwenOperatorOutputError as exc:
+        raise _HardFailure(f"qwen output parse exhausted: {exc}") from exc
+    except QwenOperatorError as exc:
+        msg = str(exc)
+        # Classify 5xx as transient; anything else (4xx, shape
+        # mismatch) as hard.
+        if "non-2xx (5" in msg:
+            raise _TransientFailure(f"qwen 5xx: {exc}") from exc
+        raise _HardFailure(f"qwen error: {exc}") from exc
+
+
+def _invoke_once_qwen(prompt: str) -> dict:
+    """Qwen-backed analogue of :func:`_invoke_once`. Returns the parsed
+    JSON dict on success. Raises ``_TransientFailure`` /
+    ``_HardFailure`` per the same taxonomy as the subprocess path.
+
+    No outer ``{"result": ...}`` envelope to unwrap — ``qwen_dispatch``
+    already returns the parsed inner dict. Post-parse validation
+    (top-level must be a dict) mirrors the subprocess path.
+    """
+    parsed = _dispatch_qwen_sync(
+        prompt,
+        _QWEN_ASPECT_SCHEMA_SINGLE,
+        timeout=180.0,
+        operator_name="aspect_single",
+    )
+    if not isinstance(parsed, dict):
+        raise _HardFailure(
+            f"qwen json top-level not a dict (got {type(parsed).__name__})"
+        )
+    return parsed
+
+
+def _invoke_once_batch_qwen(prompt: str, *, timeout: int) -> dict:
+    """Qwen-backed analogue of :func:`_invoke_once_batch`. Asserts the
+    response contains a ``papers`` array — same hard-failure contract
+    as the subprocess batch path.
+    """
+    parsed = _dispatch_qwen_sync(
+        prompt,
+        _QWEN_ASPECT_SCHEMA_BATCH,
+        timeout=float(timeout),
+        operator_name="aspect_batch",
+    )
+    if not isinstance(parsed, dict):
+        raise _HardFailure(
+            f"qwen batch top-level not a dict (got {type(parsed).__name__})"
+        )
+    if not isinstance(parsed.get("papers"), list):
+        raise _HardFailure("qwen batch response missing 'papers' array")
+    return parsed
+
+
 # ── Subprocess invocation + retry loop ───────────────────────────────────────
 
 
@@ -1225,9 +1372,11 @@ def _retry_subprocess(
     """Invoke the Claude CLI with retry. Return the parsed JSON dict on
     success, or ``None`` after final failure.
     """
+    backend = _pick_aspect_backend()
+    invoker = _invoke_once_qwen if backend == "qwen" else _invoke_once
     for attempt in range(_RETRY_ATTEMPTS):
         try:
-            return _invoke_once(prompt)
+            return invoker(prompt)
         except _TransientFailure as exc:
             _log.debug(
                 "aspect_extractor_transient_failure",

--- a/tests/test_aspect_extractor.py
+++ b/tests/test_aspect_extractor.py
@@ -1147,3 +1147,236 @@ class TestBatchExtraction:
                 "only one ExtractorConfig registered; mixed-config "
                 "test is vacuous"
             )
+
+
+# ── NEXUS_ASPECT_BACKEND parallel qwen adapter (Path B) ──────────────────────
+
+
+class TestPickAspectBackend:
+    """Backend selector contract for NEXUS_ASPECT_BACKEND."""
+
+    def test_default_is_claude(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.delenv("NEXUS_ASPECT_BACKEND", raising=False)
+        assert _pick_aspect_backend() == "claude"
+
+    def test_explicit_claude(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "claude")
+        assert _pick_aspect_backend() == "claude"
+
+    def test_explicit_qwen(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "qwen")
+        assert _pick_aspect_backend() == "qwen"
+
+    def test_case_insensitive(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "QWEN")
+        assert _pick_aspect_backend() == "qwen"
+
+    def test_unknown_falls_back_to_claude_with_warn(
+        self, monkeypatch, caplog,
+    ) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "gpt5")
+        # structlog logs go through stdlib root by default in tests;
+        # validate behaviour by result rather than asserting on
+        # caplog (config-sensitive).
+        assert _pick_aspect_backend() == "claude"
+
+    def test_empty_string_is_default(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "")
+        assert _pick_aspect_backend() == "claude"
+
+
+class TestInvokeOnceQwen:
+    """Single-paper qwen invoker — exception mapping + happy path."""
+
+    def _patch_dispatch(self, monkeypatch, side_effect):
+        """Patch ``qwen_dispatch`` as a stub coroutine. ``side_effect``
+        is either a dict to return or an exception class/instance to
+        raise."""
+        from nexus.operators import qwen_dispatch as qd_mod
+
+        async def fake_dispatch(prompt, schema, **kwargs):
+            if isinstance(side_effect, Exception):
+                raise side_effect
+            if isinstance(side_effect, type) and issubclass(
+                side_effect, Exception
+            ):
+                raise side_effect("simulated")
+            return side_effect
+
+        monkeypatch.setattr(qd_mod, "qwen_dispatch", fake_dispatch)
+
+    def test_happy_path_returns_parsed_dict(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _invoke_once_qwen
+        payload = {
+            "problem_formulation": "x",
+            "proposed_method": "y",
+            "experimental_datasets": [],
+            "experimental_baselines": [],
+            "experimental_results": "z",
+            "extras": {},
+            "confidence": 0.7,
+        }
+        self._patch_dispatch(monkeypatch, payload)
+        out = _invoke_once_qwen("prompt")
+        assert out == payload
+
+    def test_timeout_raises_transient(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _TransientFailure, _invoke_once_qwen
+        from nexus.operators.qwen_dispatch import QwenOperatorTimeoutError
+        self._patch_dispatch(monkeypatch, QwenOperatorTimeoutError)
+        with pytest.raises(_TransientFailure):
+            _invoke_once_qwen("prompt")
+
+    def test_output_error_raises_hard(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _HardFailure, _invoke_once_qwen
+        from nexus.operators.qwen_dispatch import QwenOperatorOutputError
+        self._patch_dispatch(monkeypatch, QwenOperatorOutputError)
+        with pytest.raises(_HardFailure):
+            _invoke_once_qwen("prompt")
+
+    def test_http_5xx_raises_transient(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _TransientFailure, _invoke_once_qwen
+        from nexus.operators.qwen_dispatch import QwenOperatorError
+        self._patch_dispatch(
+            monkeypatch,
+            QwenOperatorError(
+                "qwen_dispatch non-2xx (503): Service Unavailable "
+                "(attempt 1/2, backend=http://x)"
+            ),
+        )
+        with pytest.raises(_TransientFailure):
+            _invoke_once_qwen("prompt")
+
+    def test_http_4xx_raises_hard(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _HardFailure, _invoke_once_qwen
+        from nexus.operators.qwen_dispatch import QwenOperatorError
+        self._patch_dispatch(
+            monkeypatch,
+            QwenOperatorError(
+                "qwen_dispatch non-2xx (400): Bad Request "
+                "(attempt 1/2, backend=http://x)"
+            ),
+        )
+        with pytest.raises(_HardFailure):
+            _invoke_once_qwen("prompt")
+
+    def test_non_dict_top_level_raises_hard(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _HardFailure, _invoke_once_qwen
+        self._patch_dispatch(monkeypatch, ["not", "a", "dict"])
+        with pytest.raises(_HardFailure):
+            _invoke_once_qwen("prompt")
+
+
+class TestInvokeOnceBatchQwen:
+    """Batch qwen invoker — papers-array contract + happy path."""
+
+    def _patch_dispatch(self, monkeypatch, side_effect):
+        from nexus.operators import qwen_dispatch as qd_mod
+
+        async def fake_dispatch(prompt, schema, **kwargs):
+            if isinstance(side_effect, Exception):
+                raise side_effect
+            return side_effect
+
+        monkeypatch.setattr(qd_mod, "qwen_dispatch", fake_dispatch)
+
+    def test_happy_path_returns_papers(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _invoke_once_batch_qwen
+        payload = {"papers": [{"source_path": "/a.pdf"}]}
+        self._patch_dispatch(monkeypatch, payload)
+        out = _invoke_once_batch_qwen("prompt", timeout=300)
+        assert out == payload
+
+    def test_missing_papers_raises_hard(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import (
+            _HardFailure,
+            _invoke_once_batch_qwen,
+        )
+        self._patch_dispatch(monkeypatch, {"not_papers": []})
+        with pytest.raises(_HardFailure):
+            _invoke_once_batch_qwen("prompt", timeout=300)
+
+    def test_non_dict_raises_hard(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import (
+            _HardFailure,
+            _invoke_once_batch_qwen,
+        )
+        self._patch_dispatch(monkeypatch, [1, 2, 3])
+        with pytest.raises(_HardFailure):
+            _invoke_once_batch_qwen("prompt", timeout=300)
+
+
+class TestRetrySubprocessBackendBranch:
+    """End-to-end at ``_retry_subprocess``: backend env flag routes to
+    qwen vs subprocess invokers."""
+
+    def test_default_env_uses_subprocess_invoker(self, monkeypatch) -> None:
+        import nexus.aspect_extractor as mod
+        monkeypatch.delenv("NEXUS_ASPECT_BACKEND", raising=False)
+        called = {"sub": 0, "qwen": 0}
+
+        def fake_invoke_once(prompt):
+            called["sub"] += 1
+            return {"problem_formulation": "x"}
+
+        def fake_invoke_once_qwen(prompt):
+            called["qwen"] += 1
+            return {"problem_formulation": "y"}
+
+        monkeypatch.setattr(mod, "_invoke_once", fake_invoke_once)
+        monkeypatch.setattr(mod, "_invoke_once_qwen", fake_invoke_once_qwen)
+
+        cfg = next(iter(mod._REGISTRY.values()))
+        out = mod._retry_subprocess("prompt", cfg)
+        assert out == {"problem_formulation": "x"}
+        assert called == {"sub": 1, "qwen": 0}
+
+    def test_qwen_env_uses_qwen_invoker(self, monkeypatch) -> None:
+        import nexus.aspect_extractor as mod
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "qwen")
+        called = {"sub": 0, "qwen": 0}
+
+        def fake_invoke_once(prompt):
+            called["sub"] += 1
+            return {"problem_formulation": "x"}
+
+        def fake_invoke_once_qwen(prompt):
+            called["qwen"] += 1
+            return {"problem_formulation": "y"}
+
+        monkeypatch.setattr(mod, "_invoke_once", fake_invoke_once)
+        monkeypatch.setattr(mod, "_invoke_once_qwen", fake_invoke_once_qwen)
+
+        cfg = next(iter(mod._REGISTRY.values()))
+        out = mod._retry_subprocess("prompt", cfg)
+        assert out == {"problem_formulation": "y"}
+        assert called == {"sub": 0, "qwen": 1}
+
+    def test_qwen_env_batch_uses_qwen_batch_invoker(
+        self, monkeypatch,
+    ) -> None:
+        import nexus.aspect_extractor as mod
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "qwen")
+        called = {"sub": 0, "qwen": 0}
+
+        def fake_batch(prompt, *, timeout):
+            called["sub"] += 1
+            return {"papers": []}
+
+        def fake_batch_qwen(prompt, *, timeout):
+            called["qwen"] += 1
+            return {"papers": [{"source_path": "/a"}]}
+
+        monkeypatch.setattr(mod, "_invoke_once_batch", fake_batch)
+        monkeypatch.setattr(mod, "_invoke_once_batch_qwen", fake_batch_qwen)
+
+        cfg = next(iter(mod._REGISTRY.values()))
+        out = mod._retry_subprocess_batch("prompt", cfg, timeout=300)
+        assert out == {"papers": [{"source_path": "/a"}]}
+        assert called == {"sub": 0, "qwen": 1}


### PR DESCRIPTION
## Summary

- Path B parallel qwen adapter for `nexus/aspect_extractor.py` — the biggest-volume Claude call site in the codebase (per-document on every ingest, per the v0.7 delegation report). Pure A/B opt-in behind `NEXUS_ASPECT_BACKEND={claude,qwen}`. Default `claude`; existing subprocess path is byte-for-byte unchanged.
- New `_invoke_once_qwen` / `_invoke_once_batch_qwen` mirror the subprocess invokers' shape and feed into the same `_TransientFailure` / `_HardFailure` retry taxonomy so the existing `_retry_subprocess{,_batch}` wrappers stay shared. Branch point lives at the top of those wrappers.
- Exception mapping: `QwenOperatorTimeoutError` -> transient; `QwenOperatorOutputError` -> hard (qwen_dispatch already retried internally); `QwenOperatorError` -> transient on 5xx (matched against `non-2xx (5*)` message format from `qwen_dispatch`), hard otherwise.
- Permissive JSON schemas: `{type:object}` single, `{papers:array,required}` batch — the existing prompt was authored without `--json-schema`; post-parse validation in `_build_record` / `_build_record_from_entry` still applies. `operator_name` set to `aspect_single` / `aspect_batch` for cost telemetry.
- Lazy import of `qwen_dispatch` so the claude-default path doesn't pull `httpx` at module load.

## Out of scope

- Production-traffic A/B bench against a real paper corpus (follow-on; this PR ships the substrate the bench needs).
- Refactoring the existing subprocess path onto `claude_dispatch`.
- Wiring aspect extractor through `dispatch_router.pick_dispatcher_for` — Path B is explicitly parallel, not unified.

## Test plan

- [x] `pytest tests/test_aspect_extractor.py -v` — 55 passing (32 pre-existing + 23 new: `_pick_aspect_backend` (6), single-paper invoker incl. happy/timeout/parse-exhaustion/5xx/4xx/non-dict (7), batch variant (3), end-to-end branching at the retry wrappers (3))
- [x] `pytest tests/test_qwen_dispatch.py tests/test_dispatch_router.py` — 67 pass, 1 skip (pre-existing)
- [x] Broader sanity: `tests/test_aspect_worker.py`, `tests/test_aspect_drain_protocol.py`, `tests/test_aspect_extraction_queue.py`, `tests/test_enrich_aspects.py` — 150 total pass
- [ ] Follow-on: A/B bench on real ingest corpus (separate PR)

## Refs

- Issue: nexus-cn4o
- Prior art: #623 (delegation report), #776 (cost telemetry), #778 (topic_labeler), #779 (plan_miss_planner)