### PR TITLE
spike(aspect_extractor): A/B parity harness (claude vs qwen)

### DIFF
--- a/scripts/spikes/spike_c_aspect_qwen_parity.py
+++ b/scripts/spikes/spike_c_aspect_qwen_parity.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env -S uv run python
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Spike C — aspect_extractor A/B parity harness: claude vs qwen.
+
+Follow-on to PR #780 (``NEXUS_ASPECT_BACKEND={claude,qwen}``). The
+production code-path is left untouched; this script toggles the env
+var around the existing :func:`extract_aspects` entrypoint, captures
+the resulting :class:`AspectRecord` from each engine, and emits a
+field-by-field agreement report plus per-engine wall-clock stats.
+
+Backend requirements
+--------------------
+
+* ``NEXUS_ASPECT_BACKEND=claude`` leg: ``claude`` CLI on PATH.
+* ``NEXUS_ASPECT_BACKEND=qwen`` leg: the qwen-coprocessor-stack
+  supervisor must be reachable. Configuration is resolved by
+  ``nexus.operators.qwen_dispatch`` at call time — typically from
+  ``~/.qwen-coprocessor-stack/config.json`` plus env (``QWEN_STACK_URL``).
+  This script does not validate the qwen path itself; an unreachable
+  backend surfaces as ``ExtractFail`` / null-fields ``AspectRecord``
+  which the parity diff records honestly.
+
+Corpus
+------
+
+Input is a list of source URIs. Each "URI" is either:
+
+* an absolute or relative filesystem path to a ``.md`` / ``.txt`` /
+  ``.pdf`` file (text extracted client-side and passed to
+  ``extract_aspects(content=...)``).
+* a ``chroma://<collection>/<source_path>`` URI: the script passes
+  ``content=""`` to ``extract_aspects`` and lets it route through
+  ``nexus.aspect_readers.read_source`` exactly like production.
+
+Source list is provided via repeated ``--uri`` flags or a JSON
+manifest ``[{"uri": "...", "collection": "knowledge__..."}, ...]``.
+The ``collection`` is required so the right extractor config is
+selected; when reading a local file directly the operator picks the
+collection (typically ``knowledge__<name>`` to route the
+``scholarly-paper-v1`` LLM extractor).
+
+Field-equality heuristics
+-------------------------
+
+``AspectRecord`` carries a mix of free-form prose and structured
+fields. The diff function classifies each in one of three buckets:
+
+* **strict** — equality after light normalisation (whitespace
+  collapse, case-insensitive). Used for short discrete values:
+  ``collection``, ``source_path``, ``extractor_name``,
+  ``model_version`` (note: model_version is always pinned by config
+  so equality is expected by construction; included for completeness).
+* **set** — order-insensitive set equality on string-list fields:
+  ``experimental_datasets``, ``experimental_baselines``,
+  ``salient_sentences``. Two empty lists agree.
+* **prose** — free-form text where exact equality is unreasonable
+  across engines. Heuristic: both-non-empty AND length ratio within
+  ``PROSE_LEN_TOL`` (default 0.5, i.e. shorter / longer >= 0.5)
+  counts as agreement. Either-empty-but-not-both counts as
+  disagreement. Both-None counts as agreement. Applies to:
+  ``problem_formulation``, ``proposed_method``,
+  ``experimental_results``.
+* **ignored** — wall-clock metadata not part of semantic equality:
+  ``extracted_at``, ``confidence`` (engines self-report;
+  cross-engine comparison meaningless), ``doc_id``, ``source_uri``,
+  ``extras``.
+
+This heuristic is documented in code so an operator reading the
+parity report knows what "agreement" means. Tune ``PROSE_LEN_TOL``
+or restrict the diff to specific fields via ``--fields`` to harden
+or relax the bar.
+
+Out of scope
+------------
+
+* Actually running the bench against a production corpus — operator-
+  driven. This script ships the harness; the bench-run command is
+  ``uv run python scripts/spikes/spike_c_aspect_qwen_parity.py
+  --manifest path/to/manifest.json --out out.jsonl``.
+* Cost telemetry beyond wall-clock. PR #776 added cost metrics in
+  qwen_dispatch; reading those is a follow-on.
+
+Usage
+-----
+
+::
+
+    # Single paper, two backends, 1 run each
+    uv run python scripts/spikes/spike_c_aspect_qwen_parity.py \\
+        --uri papers/2408.04948.pdf \\
+        --collection knowledge__local-spike \\
+        --out /tmp/parity.jsonl
+
+    # Manifest with mixed sources, 3 repeats for variance
+    uv run python scripts/spikes/spike_c_aspect_qwen_parity.py \\
+        --manifest bench_corpus.json --repeat 3 --limit 20 \\
+        --out /tmp/parity.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from nexus.aspect_extractor import (  # noqa: E402
+    AspectRecord,
+    ExtractFail,
+    extract_aspects,
+)
+
+# ── Field-equality heuristic config ──────────────────────────────────────────
+
+STRICT_FIELDS: tuple[str, ...] = (
+    "collection",
+    "source_path",
+    "extractor_name",
+    "model_version",
+)
+SET_FIELDS: tuple[str, ...] = (
+    "experimental_datasets",
+    "experimental_baselines",
+    "salient_sentences",
+)
+PROSE_FIELDS: tuple[str, ...] = (
+    "problem_formulation",
+    "proposed_method",
+    "experimental_results",
+)
+IGNORED_FIELDS: tuple[str, ...] = (
+    "extracted_at",
+    "confidence",
+    "doc_id",
+    "source_uri",
+    "extras",
+)
+ALL_DIFFED_FIELDS: tuple[str, ...] = STRICT_FIELDS + SET_FIELDS + PROSE_FIELDS
+
+PROSE_LEN_TOL: float = 0.5  # shorter/longer must be >= this for agreement
+
+
+def _norm_strict(v: Any) -> Any:
+    if v is None:
+        return None
+    if isinstance(v, str):
+        return " ".join(v.split()).lower()
+    return v
+
+
+def _agree_strict(a: Any, b: Any) -> bool:
+    return _norm_strict(a) == _norm_strict(b)
+
+
+def _agree_set(a: Any, b: Any) -> bool:
+    sa = set(a or [])
+    sb = set(b or [])
+    return sa == sb
+
+
+def _agree_prose(a: Any, b: Any, tol: float = PROSE_LEN_TOL) -> bool:
+    if a is None and b is None:
+        return True
+    if not a and not b:  # both empty string
+        return True
+    if not a or not b:
+        return False
+    la, lb = len(a), len(b)
+    if max(la, lb) == 0:
+        return True
+    return min(la, lb) / max(la, lb) >= tol
+
+
+def diff_records(
+    claude_rec: AspectRecord | ExtractFail | None,
+    qwen_rec: AspectRecord | ExtractFail | None,
+) -> dict[str, Any]:
+    """Field-by-field agreement dict between two extraction outputs.
+
+    Returns a dict with key ``agreement`` mapping each diffed field
+    name to a bool. Adds ``both_ok`` (both produced AspectRecord),
+    ``claude_ok``, ``qwen_ok`` summary flags. Non-AspectRecord
+    outputs (ExtractFail / None) trivially disagree on all fields
+    except where both sides match the same failure shape.
+    """
+    out: dict[str, Any] = {
+        "claude_ok": isinstance(claude_rec, AspectRecord),
+        "qwen_ok": isinstance(qwen_rec, AspectRecord),
+        "both_ok": (
+            isinstance(claude_rec, AspectRecord)
+            and isinstance(qwen_rec, AspectRecord)
+        ),
+        "agreement": {},
+    }
+    if not out["both_ok"]:
+        # Symmetric failure shape (both None, both same ExtractFail.reason)
+        # is recorded for transparency but isn't a parity agreement.
+        out["claude_kind"] = type(claude_rec).__name__
+        out["qwen_kind"] = type(qwen_rec).__name__
+        for f in ALL_DIFFED_FIELDS:
+            out["agreement"][f] = False
+        return out
+
+    assert isinstance(claude_rec, AspectRecord)
+    assert isinstance(qwen_rec, AspectRecord)
+    for f in STRICT_FIELDS:
+        out["agreement"][f] = _agree_strict(
+            getattr(claude_rec, f), getattr(qwen_rec, f),
+        )
+    for f in SET_FIELDS:
+        out["agreement"][f] = _agree_set(
+            getattr(claude_rec, f), getattr(qwen_rec, f),
+        )
+    for f in PROSE_FIELDS:
+        out["agreement"][f] = _agree_prose(
+            getattr(claude_rec, f), getattr(qwen_rec, f),
+        )
+    return out
+
+
+# ── Source loading ───────────────────────────────────────────────────────────
+
+
+def _load_local_text(path: Path) -> str:
+    """Read a local source file. ``.md`` / ``.txt`` read directly;
+    ``.pdf`` lazy-imports the project's :class:`PDFExtractor`. Any
+    other suffix is read as bytes-decoded-utf8 best-effort.
+    """
+    suffix = path.suffix.lower()
+    if suffix in (".md", ".markdown", ".txt", ""):
+        return path.read_text(encoding="utf-8", errors="replace")
+    if suffix == ".pdf":
+        from nexus.pdf_extractor import PDFExtractor
+        result = PDFExtractor().extract(path, extractor="auto")
+        return result.text
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _run_one(
+    uri: str,
+    collection: str,
+    backend: str,
+) -> tuple[AspectRecord | ExtractFail | None, float]:
+    """Invoke ``extract_aspects`` for one (uri, collection) under the
+    given backend. Returns (record, elapsed_ms). Toggles the env var
+    just for this call window.
+    """
+    os.environ["NEXUS_ASPECT_BACKEND"] = backend
+    if uri.startswith("chroma://"):
+        # Production path: hand to extract_aspects with empty content,
+        # parsed lookup. The chroma:// form is shaped as
+        # chroma://<collection>/<source_path>; we already have the
+        # collection separately, so source_path is the URI tail.
+        # extract_aspects rebuilds the URI from (collection, source_path)
+        # internally — the operator must pass a matching collection.
+        # Split: ``chroma://<coll>/<rest>``
+        rest = uri[len("chroma://"):]
+        slash = rest.find("/")
+        source_path = rest[slash + 1:] if slash != -1 else rest
+        content = ""
+    else:
+        p = Path(uri)
+        if not p.is_absolute():
+            p = (REPO_ROOT / p).resolve()
+        content = _load_local_text(p)
+        source_path = str(p)
+
+    t0 = time.perf_counter()
+    try:
+        rec = extract_aspects(
+            content=content,
+            source_path=source_path,
+            collection=collection,
+        )
+    except Exception as exc:
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+        return (
+            ExtractFail(
+                uri=uri, reason="exception",
+                detail=f"{type(exc).__name__}: {exc}",
+            ),
+            elapsed_ms,
+        )
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+    return rec, elapsed_ms
+
+
+def _record_to_json(rec: AspectRecord | ExtractFail | None) -> Any:
+    if rec is None:
+        return None
+    if isinstance(rec, ExtractFail):
+        return {
+            "_kind": "ExtractFail",
+            "uri": rec.uri,
+            "reason": rec.reason,
+            "detail": rec.detail,
+        }
+    return {"_kind": "AspectRecord", **asdict(rec)}
+
+
+# ── Manifest + CLI ───────────────────────────────────────────────────────────
+
+
+def _load_manifest(path: Path) -> list[dict]:
+    """Load a JSON manifest of [{"uri": ..., "collection": ...}, ...].
+
+    A manifest may also override the default collection per-row. Rows
+    missing ``collection`` inherit the CLI ``--collection`` value.
+    """
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"manifest must be a JSON array; got {type(data).__name__}")
+    return data
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="A/B parity harness for aspect_extractor (claude vs qwen)",
+    )
+    p.add_argument(
+        "--uri", action="append", default=[],
+        help="Source URI: file path or chroma://... (repeatable).",
+    )
+    p.add_argument(
+        "--manifest", type=Path,
+        help="JSON manifest: [{uri, collection?}, ...].",
+    )
+    p.add_argument(
+        "--collection", default="knowledge__spike-c",
+        help="Default collection for sources without one (default: "
+             "knowledge__spike-c — routes scholarly-paper-v1).",
+    )
+    p.add_argument(
+        "--limit", type=int, default=0,
+        help="Cap papers (0 = unbounded).",
+    )
+    p.add_argument(
+        "--repeat", type=int, default=1,
+        help="Repeat each paper N times for variance (default 1).",
+    )
+    p.add_argument(
+        "--out", type=Path, required=True,
+        help="JSONL log output path.",
+    )
+    p.add_argument(
+        "--summary", type=Path,
+        help="Optional markdown summary path (default: <out>.md).",
+    )
+    p.add_argument(
+        "--backends", default="claude,qwen",
+        help="Comma-separated backends to run (default: claude,qwen).",
+    )
+    return p.parse_args(argv)
+
+
+def _summarize(records: list[dict]) -> dict:
+    """Aggregate per-field agreement + per-engine ok-rate + median ms."""
+    both_ok = [r for r in records if r["both_ok"]]
+    field_agree: dict[str, list[bool]] = {f: [] for f in ALL_DIFFED_FIELDS}
+    for r in both_ok:
+        for f, v in r["agreement"].items():
+            field_agree.setdefault(f, []).append(bool(v))
+
+    claude_ms = [r["claude_elapsed_ms"] for r in records if r.get("claude_elapsed_ms") is not None]
+    qwen_ms = [r["qwen_elapsed_ms"] for r in records if r.get("qwen_elapsed_ms") is not None]
+
+    def _rate(xs: list[bool]) -> float:
+        return (sum(1 for x in xs if x) / len(xs)) if xs else 0.0
+
+    def _med(xs: list[float]) -> float:
+        return statistics.median(xs) if xs else 0.0
+
+    return {
+        "total": len(records),
+        "both_ok": len(both_ok),
+        "claude_ok_rate": _rate([r["claude_ok"] for r in records]),
+        "qwen_ok_rate": _rate([r["qwen_ok"] for r in records]),
+        "field_agreement": {
+            f: {"rate": _rate(v), "n": len(v)}
+            for f, v in field_agree.items()
+        },
+        "claude_median_ms": _med(claude_ms),
+        "qwen_median_ms": _med(qwen_ms),
+        "claude_total_s": sum(claude_ms) / 1000.0,
+        "qwen_total_s": sum(qwen_ms) / 1000.0,
+    }
+
+
+def _render_md(summary: dict, out_path: Path) -> str:
+    lines = [
+        "# Spike C — aspect_extractor A/B parity (claude vs qwen)",
+        "",
+        f"- Total runs: **{summary['total']}**",
+        f"- Both-engine success: **{summary['both_ok']}**",
+        f"- Claude ok-rate: **{summary['claude_ok_rate']:.2%}**",
+        f"- Qwen ok-rate:   **{summary['qwen_ok_rate']:.2%}**",
+        f"- Claude median elapsed: **{summary['claude_median_ms']:.0f} ms**",
+        f"- Qwen median elapsed:   **{summary['qwen_median_ms']:.0f} ms**",
+        f"- Claude wall-clock total: **{summary['claude_total_s']:.1f} s**",
+        f"- Qwen wall-clock total:   **{summary['qwen_total_s']:.1f} s**",
+        "",
+        "## Per-field agreement (both-ok subset)",
+        "",
+        "| Field | Bucket | Agreement | N |",
+        "|---|---|---|---|",
+    ]
+    bucket = {f: "strict" for f in STRICT_FIELDS}
+    bucket.update({f: "set" for f in SET_FIELDS})
+    bucket.update({f: f"prose (len-ratio >= {PROSE_LEN_TOL})" for f in PROSE_FIELDS})
+    for f in ALL_DIFFED_FIELDS:
+        info = summary["field_agreement"].get(f, {"rate": 0.0, "n": 0})
+        lines.append(
+            f"| `{f}` | {bucket.get(f, '?')} | {info['rate']:.2%} | {info['n']} |"
+        )
+    lines.append("")
+    lines.append(f"_Raw JSONL: `{out_path}`_")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    sources: list[dict] = []
+    for u in args.uri:
+        sources.append({"uri": u, "collection": args.collection})
+    if args.manifest:
+        for entry in _load_manifest(args.manifest):
+            sources.append({
+                "uri": entry["uri"],
+                "collection": entry.get("collection", args.collection),
+            })
+    if not sources:
+        print("error: no sources (pass --uri or --manifest)", file=sys.stderr)
+        return 2
+    if args.limit:
+        sources = sources[: args.limit]
+
+    backends = [b.strip() for b in args.backends.split(",") if b.strip()]
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    records: list[dict] = []
+    with args.out.open("w", encoding="utf-8") as fp:
+        for repeat_ix in range(args.repeat):
+            for src in sources:
+                row: dict[str, Any] = {
+                    "uri": src["uri"],
+                    "collection": src["collection"],
+                    "repeat": repeat_ix,
+                }
+                engine_recs: dict[str, AspectRecord | ExtractFail | None] = {}
+                for backend in backends:
+                    rec, elapsed_ms = _run_one(
+                        src["uri"], src["collection"], backend,
+                    )
+                    engine_recs[backend] = rec
+                    row[f"{backend}_record"] = _record_to_json(rec)
+                    row[f"{backend}_elapsed_ms"] = elapsed_ms
+                if "claude" in engine_recs and "qwen" in engine_recs:
+                    diff = diff_records(engine_recs["claude"], engine_recs["qwen"])
+                    row.update(diff)
+                else:
+                    # Single-backend pass-through — no diff possible.
+                    row["claude_ok"] = isinstance(
+                        engine_recs.get("claude"), AspectRecord,
+                    )
+                    row["qwen_ok"] = isinstance(
+                        engine_recs.get("qwen"), AspectRecord,
+                    )
+                    row["both_ok"] = False
+                    row["agreement"] = {}
+                fp.write(json.dumps(row) + "\n")
+                fp.flush()
+                records.append(row)
+                print(
+                    f"[{repeat_ix + 1}/{args.repeat}] {src['uri']}: "
+                    f"claude_ok={row['claude_ok']} qwen_ok={row['qwen_ok']} "
+                    f"both_ok={row['both_ok']}",
+                    file=sys.stderr,
+                )
+
+    summary = _summarize(records)
+    summary_path = args.summary or args.out.with_suffix(args.out.suffix + ".md")
+    summary_path.write_text(_render_md(summary, args.out), encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+    print(f"\nMarkdown summary: {summary_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_spike_c_aspect_qwen_parity.py
+++ b/tests/test_spike_c_aspect_qwen_parity.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Smoke tests for ``scripts/spikes/spike_c_aspect_qwen_parity.py``.
+
+Scope: the pure-function diff layer (``diff_records`` + the per-bucket
+agreement helpers) and the summary aggregator. The end-to-end
+``_run_one`` path that toggles ``NEXUS_ASPECT_BACKEND`` and calls
+``extract_aspects`` is NOT exercised here — it requires a live backend
+and a real corpus. The intent is to lock down the diff contract so a
+parity report cannot silently misclassify field agreements.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPIKE_DIR = REPO_ROOT / "scripts" / "spikes"
+sys.path.insert(0, str(SPIKE_DIR))
+
+from nexus.aspect_extractor import AspectRecord, ExtractFail  # noqa: E402
+
+import spike_c_aspect_qwen_parity as spike  # noqa: E402
+
+
+def _rec(**overrides) -> AspectRecord:
+    """Factory: an AspectRecord with sane defaults the test overrides."""
+    base = dict(
+        collection="knowledge__test",
+        source_path="/p/x.pdf",
+        problem_formulation="The paper addresses problem X in domain Y.",
+        proposed_method="We propose a method using technique Z.",
+        experimental_datasets=["MNIST", "CIFAR-10"],
+        experimental_baselines=["ResNet", "VGG"],
+        experimental_results="Achieves 95% accuracy, beating baselines.",
+        extras={},
+        confidence=0.9,
+        extracted_at="2026-05-14T00:00:00+00:00",
+        model_version="claude-haiku-4-5-20251001",
+        extractor_name="scholarly-paper-v1",
+    )
+    base.update(overrides)
+    return AspectRecord(**base)
+
+
+class TestAgreeHelpers:
+    def test_strict_normalises_whitespace_and_case(self) -> None:
+        assert spike._agree_strict("  Foo  Bar ", "foo bar")
+        assert not spike._agree_strict("foo", "bar")
+
+    def test_set_is_order_insensitive(self) -> None:
+        assert spike._agree_set(["a", "b"], ["b", "a"])
+        assert not spike._agree_set(["a"], ["a", "b"])
+        assert spike._agree_set([], [])
+
+    def test_prose_both_none_agrees(self) -> None:
+        assert spike._agree_prose(None, None)
+
+    def test_prose_one_empty_disagrees(self) -> None:
+        assert not spike._agree_prose("hello", "")
+        assert not spike._agree_prose(None, "x")
+
+    def test_prose_similar_length_agrees(self) -> None:
+        a = "x" * 100
+        b = "y" * 80
+        assert spike._agree_prose(a, b)  # 80/100 = 0.8 >= 0.5
+
+    def test_prose_wildly_different_length_disagrees(self) -> None:
+        a = "x" * 10
+        b = "y" * 100
+        assert not spike._agree_prose(a, b)  # 10/100 = 0.1 < 0.5
+
+
+class TestDiffRecords:
+    def test_both_aspect_records_full_agreement(self) -> None:
+        r = _rec()
+        out = spike.diff_records(r, _rec())
+        assert out["both_ok"] is True
+        assert out["claude_ok"] and out["qwen_ok"]
+        # All diffed fields agree.
+        for f in spike.ALL_DIFFED_FIELDS:
+            assert out["agreement"][f] is True, f
+
+    def test_partial_disagreement(self) -> None:
+        c = _rec()
+        q = _rec(
+            experimental_datasets=["MNIST"],  # set mismatch
+            problem_formulation="x",  # prose length ratio fails
+        )
+        out = spike.diff_records(c, q)
+        assert out["both_ok"]
+        assert out["agreement"]["experimental_datasets"] is False
+        assert out["agreement"]["problem_formulation"] is False
+        # Untouched fields still agree.
+        assert out["agreement"]["experimental_baselines"] is True
+        assert out["agreement"]["proposed_method"] is True
+
+    def test_one_side_extractfail_marks_all_disagree(self) -> None:
+        c = _rec()
+        q = ExtractFail(uri="chroma://x/y", reason="unreachable", detail="d")
+        out = spike.diff_records(c, q)
+        assert out["both_ok"] is False
+        assert out["claude_ok"] is True
+        assert out["qwen_ok"] is False
+        assert out["claude_kind"] == "AspectRecord"
+        assert out["qwen_kind"] == "ExtractFail"
+        for f in spike.ALL_DIFFED_FIELDS:
+            assert out["agreement"][f] is False
+
+    def test_both_none_marks_all_disagree(self) -> None:
+        # ``None`` means "no extractor registered" — symmetric but not
+        # a parity agreement (no records to compare).
+        out = spike.diff_records(None, None)
+        assert out["both_ok"] is False
+        for f in spike.ALL_DIFFED_FIELDS:
+            assert out["agreement"][f] is False
+
+
+class TestSummarize:
+    def test_aggregates_field_rates_and_medians(self) -> None:
+        records = [
+            {
+                "both_ok": True,
+                "claude_ok": True,
+                "qwen_ok": True,
+                "claude_elapsed_ms": 1000.0,
+                "qwen_elapsed_ms": 500.0,
+                "agreement": {f: True for f in spike.ALL_DIFFED_FIELDS},
+            },
+            {
+                "both_ok": True,
+                "claude_ok": True,
+                "qwen_ok": True,
+                "claude_elapsed_ms": 2000.0,
+                "qwen_elapsed_ms": 700.0,
+                "agreement": {
+                    **{f: True for f in spike.ALL_DIFFED_FIELDS},
+                    "problem_formulation": False,
+                },
+            },
+            {
+                "both_ok": False,
+                "claude_ok": True,
+                "qwen_ok": False,
+                "claude_elapsed_ms": 1500.0,
+                "qwen_elapsed_ms": 100.0,
+                "agreement": {f: False for f in spike.ALL_DIFFED_FIELDS},
+            },
+        ]
+        s = spike._summarize(records)
+        assert s["total"] == 3
+        assert s["both_ok"] == 2
+        assert s["claude_ok_rate"] == pytest.approx(1.0)
+        assert s["qwen_ok_rate"] == pytest.approx(2 / 3)
+        # problem_formulation: 1/2 agreement in both_ok subset.
+        assert s["field_agreement"]["problem_formulation"]["rate"] == pytest.approx(0.5)
+        assert s["field_agreement"]["problem_formulation"]["n"] == 2
+        # Median of [1000, 2000, 1500] = 1500.
+        assert s["claude_median_ms"] == 1500.0
+
+
+class TestMarkdownRender:
+    def test_renders_table_with_all_fields(self) -> None:
+        records = [
+            {
+                "both_ok": True,
+                "claude_ok": True,
+                "qwen_ok": True,
+                "claude_elapsed_ms": 1000.0,
+                "qwen_elapsed_ms": 500.0,
+                "agreement": {f: True for f in spike.ALL_DIFFED_FIELDS},
+            },
+        ]
+        s = spike._summarize(records)
+        md = spike._render_md(s, Path("/tmp/out.jsonl"))
+        assert "Spike C" in md
+        for f in spike.ALL_DIFFED_FIELDS:
+            assert f"`{f}`" in md


### PR DESCRIPTION
## Summary

Follow-on to #780, which added `NEXUS_ASPECT_BACKEND={claude,qwen}` for `aspect_extractor`. This PR ships the operator-driven A/B parity harness as a spike script — production code is untouched.

- `scripts/spikes/spike_c_aspect_qwen_parity.py`: CLI that runs each source through `extract_aspects` once per backend (toggling the env var around the call), captures both `AspectRecord` outputs, and emits a JSONL log + markdown summary with per-field agreement rates, per-engine ok-rates, median elapsed ms, and total wall-clock seconds.
- `tests/test_spike_c_aspect_qwen_parity.py`: 12 smoke tests over the pure-function diff layer (`diff_records`, `_agree_*` helpers, `_summarize`, `_render_md`). The end-to-end live-backend path is operator-driven.

### Field-equality heuristic (documented in module docstring)

`AspectRecord` fields are bucketed three ways:

- **strict** (whitespace + case normalised equality): `collection`, `source_path`, `extractor_name`, `model_version`
- **set** (order-insensitive): `experimental_datasets`, `experimental_baselines`, `salient_sentences`
- **prose** (both-non-empty AND len-ratio >= 0.5): `problem_formulation`, `proposed_method`, `experimental_results`
- **ignored** (metadata or self-reported, cross-engine comparison meaningless): `extracted_at`, `confidence`, `doc_id`, `source_uri`, `extras`

`PROSE_LEN_TOL` is a module constant so the operator can tighten/loosen the prose bar without code edits to the diff function.

### Input shape

Sources are absolute/relative file paths (`.md` / `.txt` read directly; `.pdf` via the project's `PDFExtractor`) or `chroma://<collection>/<source_path>` URIs (production read path through `aspect_readers.read_source`). Either repeat `--uri` or pass a JSON manifest `[{uri, collection?}, ...]`.

## Test plan

- [x] `pytest tests/test_spike_c_aspect_qwen_parity.py -v` — 12 passed
- [x] `pytest tests/test_aspect_extractor.py` — 55 passed (production tests unaffected)
- [ ] Operator-driven: point `--manifest` at a real corpus of `knowledge__*` papers and inspect the markdown summary; tune `PROSE_LEN_TOL` if prose agreement looks systematically harsh/lax.

## Out of scope

- Actually running the bench against a production corpus — operator-driven follow-up.
- Cost telemetry beyond wall-clock (PR #776 added qwen_dispatch cost metrics; surfacing them is another follow-on).

Linked: #780.