### PR TITLE
feat(rdr-111): P1.3 liveness table + heartbeat + nx instances (nexus-r0vi)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1396,3 +1396,53 @@ nx mineru status
 ```
 
 Show server status: running/stopped, PID, port, active tasks, and completed tasks. Removes stale PID file if the server process is no longer running.
+
+## nx instances
+
+```
+nx instances [--json] [--sweep]
+```
+
+List running Nexus MCP instances from the T2 liveness table (RDR-111 P1.3). Each active MCP server writes a heartbeat row to the `liveness` table in `memory.db` at startup and every 30 seconds. Rows older than 60 seconds are considered stale (process may have exited without cleanup).
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit structured JSON instead of the human table |
+| `--sweep` | Delete stale rows (last_seen > 60 s) before listing |
+
+**Output columns (human table):**
+
+| Column | Description |
+|--------|-------------|
+| PID | Process ID of the MCP server |
+| MACHINE | Hostname |
+| USER | OS user name |
+| SESSION | Claude session ID (`NX_SESSION_ID`) |
+| PROJECT | Project name (`NX_PROJECT`) |
+| FOCUS | Current focus area (`NX_FOCUS`) |
+| ACTIVITY | Current activity label (`NX_ACTIVITY`) |
+| AGE | Time since last heartbeat |
+
+Rows marked with `*` in the PID column have not sent a heartbeat in more than 60 seconds and may represent stale entries from processes that exited without cleanup. Use `--sweep` to remove them.
+
+**Example:**
+
+```
+$ nx instances
+PID      MACHINE              USER         SESSION        PROJECT        FOCUS            ACTIVITY         AGE
+-------- -------------------- ------------ -------------- -------------- ---------------- ---------------- ------------
+ 12345   myhost.local         hal          ses-abc123     nexus          rdr-111          coding            5s ago
+*54321   myhost.local         hal          ses-xyz999     nexus          (none)           (none)            90s ago
+  * stale (no heartbeat for > 60 s); use --sweep to remove
+
+$ nx instances --json
+[
+  {
+    "pid": 12345,
+    "machine": "myhost.local",
+    "user_id": "hal",
+    "session": "ses-abc123",
+    ...
+  }
+]
+```

--- a/scripts/spikes/spike_c_aspect_qwen_parity.py
+++ b/scripts/spikes/spike_c_aspect_qwen_parity.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env -S uv run python
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Spike C — aspect_extractor A/B parity harness: claude vs qwen.
+
+Follow-on to PR #780 (``NEXUS_ASPECT_BACKEND={claude,qwen}``). The
+production code-path is left untouched; this script toggles the env
+var around the existing :func:`extract_aspects` entrypoint, captures
+the resulting :class:`AspectRecord` from each engine, and emits a
+field-by-field agreement report plus per-engine wall-clock stats.
+
+Backend requirements
+--------------------
+
+* ``NEXUS_ASPECT_BACKEND=claude`` leg: ``claude`` CLI on PATH.
+* ``NEXUS_ASPECT_BACKEND=qwen`` leg: the qwen-coprocessor-stack
+  supervisor must be reachable. Configuration is resolved by
+  ``nexus.operators.qwen_dispatch`` at call time — typically from
+  ``~/.qwen-coprocessor-stack/config.json`` plus env (``QWEN_STACK_URL``).
+  This script does not validate the qwen path itself; an unreachable
+  backend surfaces as ``ExtractFail`` / null-fields ``AspectRecord``
+  which the parity diff records honestly.
+
+Corpus
+------
+
+Input is a list of source URIs. Each "URI" is either:
+
+* an absolute or relative filesystem path to a ``.md`` / ``.txt`` /
+  ``.pdf`` file (text extracted client-side and passed to
+  ``extract_aspects(content=...)``).
+* a ``chroma://<collection>/<source_path>`` URI: the script passes
+  ``content=""`` to ``extract_aspects`` and lets it route through
+  ``nexus.aspect_readers.read_source`` exactly like production.
+
+Source list is provided via repeated ``--uri`` flags or a JSON
+manifest ``[{"uri": "...", "collection": "knowledge__..."}, ...]``.
+The ``collection`` is required so the right extractor config is
+selected; when reading a local file directly the operator picks the
+collection (typically ``knowledge__<name>`` to route the
+``scholarly-paper-v1`` LLM extractor).
+
+Field-equality heuristics
+-------------------------
+
+``AspectRecord`` carries a mix of free-form prose and structured
+fields. The diff function classifies each in one of three buckets:
+
+* **strict** — equality after light normalisation (whitespace
+  collapse, case-insensitive). Used for short discrete values:
+  ``collection``, ``source_path``, ``extractor_name``,
+  ``model_version`` (note: model_version is always pinned by config
+  so equality is expected by construction; included for completeness).
+* **set** — order-insensitive set equality on string-list fields:
+  ``experimental_datasets``, ``experimental_baselines``,
+  ``salient_sentences``. Two empty lists agree.
+* **prose** — free-form text where exact equality is unreasonable
+  across engines. Heuristic: both-non-empty AND length ratio within
+  ``PROSE_LEN_TOL`` (default 0.5, i.e. shorter / longer >= 0.5)
+  counts as agreement. Either-empty-but-not-both counts as
+  disagreement. Both-None counts as agreement. Applies to:
+  ``problem_formulation``, ``proposed_method``,
+  ``experimental_results``.
+* **ignored** — wall-clock metadata not part of semantic equality:
+  ``extracted_at``, ``confidence`` (engines self-report;
+  cross-engine comparison meaningless), ``doc_id``, ``source_uri``,
+  ``extras``.
+
+This heuristic is documented in code so an operator reading the
+parity report knows what "agreement" means. Tune ``PROSE_LEN_TOL``
+or restrict the diff to specific fields via ``--fields`` to harden
+or relax the bar.
+
+Out of scope
+------------
+
+* Actually running the bench against a production corpus — operator-
+  driven. This script ships the harness; the bench-run command is
+  ``uv run python scripts/spikes/spike_c_aspect_qwen_parity.py
+  --manifest path/to/manifest.json --out out.jsonl``.
+* Cost telemetry beyond wall-clock. PR #776 added cost metrics in
+  qwen_dispatch; reading those is a follow-on.
+
+Usage
+-----
+
+::
+
+    # Single paper, two backends, 1 run each
+    uv run python scripts/spikes/spike_c_aspect_qwen_parity.py \\
+        --uri papers/2408.04948.pdf \\
+        --collection knowledge__local-spike \\
+        --out /tmp/parity.jsonl
+
+    # Manifest with mixed sources, 3 repeats for variance
+    uv run python scripts/spikes/spike_c_aspect_qwen_parity.py \\
+        --manifest bench_corpus.json --repeat 3 --limit 20 \\
+        --out /tmp/parity.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from nexus.aspect_extractor import (  # noqa: E402
+    AspectRecord,
+    ExtractFail,
+    extract_aspects,
+)
+
+# ── Field-equality heuristic config ──────────────────────────────────────────
+
+STRICT_FIELDS: tuple[str, ...] = (
+    "collection",
+    "source_path",
+    "extractor_name",
+    "model_version",
+)
+SET_FIELDS: tuple[str, ...] = (
+    "experimental_datasets",
+    "experimental_baselines",
+    "salient_sentences",
+)
+PROSE_FIELDS: tuple[str, ...] = (
+    "problem_formulation",
+    "proposed_method",
+    "experimental_results",
+)
+IGNORED_FIELDS: tuple[str, ...] = (
+    "extracted_at",
+    "confidence",
+    "doc_id",
+    "source_uri",
+    "extras",
+)
+ALL_DIFFED_FIELDS: tuple[str, ...] = STRICT_FIELDS + SET_FIELDS + PROSE_FIELDS
+
+PROSE_LEN_TOL: float = 0.5  # shorter/longer must be >= this for agreement
+
+
+def _norm_strict(v: Any) -> Any:
+    if v is None:
+        return None
+    if isinstance(v, str):
+        return " ".join(v.split()).lower()
+    return v
+
+
+def _agree_strict(a: Any, b: Any) -> bool:
+    return _norm_strict(a) == _norm_strict(b)
+
+
+def _agree_set(a: Any, b: Any) -> bool:
+    sa = set(a or [])
+    sb = set(b or [])
+    return sa == sb
+
+
+def _agree_prose(a: Any, b: Any, tol: float = PROSE_LEN_TOL) -> bool:
+    if a is None and b is None:
+        return True
+    if not a and not b:  # both empty string
+        return True
+    if not a or not b:
+        return False
+    la, lb = len(a), len(b)
+    if max(la, lb) == 0:
+        return True
+    return min(la, lb) / max(la, lb) >= tol
+
+
+def diff_records(
+    claude_rec: AspectRecord | ExtractFail | None,
+    qwen_rec: AspectRecord | ExtractFail | None,
+) -> dict[str, Any]:
+    """Field-by-field agreement dict between two extraction outputs.
+
+    Returns a dict with key ``agreement`` mapping each diffed field
+    name to a bool. Adds ``both_ok`` (both produced AspectRecord),
+    ``claude_ok``, ``qwen_ok`` summary flags. Non-AspectRecord
+    outputs (ExtractFail / None) trivially disagree on all fields
+    except where both sides match the same failure shape.
+    """
+    out: dict[str, Any] = {
+        "claude_ok": isinstance(claude_rec, AspectRecord),
+        "qwen_ok": isinstance(qwen_rec, AspectRecord),
+        "both_ok": (
+            isinstance(claude_rec, AspectRecord)
+            and isinstance(qwen_rec, AspectRecord)
+        ),
+        "agreement": {},
+    }
+    if not out["both_ok"]:
+        # Symmetric failure shape (both None, both same ExtractFail.reason)
+        # is recorded for transparency but isn't a parity agreement.
+        out["claude_kind"] = type(claude_rec).__name__
+        out["qwen_kind"] = type(qwen_rec).__name__
+        for f in ALL_DIFFED_FIELDS:
+            out["agreement"][f] = False
+        return out
+
+    assert isinstance(claude_rec, AspectRecord)
+    assert isinstance(qwen_rec, AspectRecord)
+    for f in STRICT_FIELDS:
+        out["agreement"][f] = _agree_strict(
+            getattr(claude_rec, f), getattr(qwen_rec, f),
+        )
+    for f in SET_FIELDS:
+        out["agreement"][f] = _agree_set(
+            getattr(claude_rec, f), getattr(qwen_rec, f),
+        )
+    for f in PROSE_FIELDS:
+        out["agreement"][f] = _agree_prose(
+            getattr(claude_rec, f), getattr(qwen_rec, f),
+        )
+    return out
+
+
+# ── Source loading ───────────────────────────────────────────────────────────
+
+
+def _load_local_text(path: Path) -> str:
+    """Read a local source file. ``.md`` / ``.txt`` read directly;
+    ``.pdf`` lazy-imports the project's :class:`PDFExtractor`. Any
+    other suffix is read as bytes-decoded-utf8 best-effort.
+    """
+    suffix = path.suffix.lower()
+    if suffix in (".md", ".markdown", ".txt", ""):
+        return path.read_text(encoding="utf-8", errors="replace")
+    if suffix == ".pdf":
+        from nexus.pdf_extractor import PDFExtractor
+        result = PDFExtractor().extract(path, extractor="auto")
+        return result.text
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _run_one(
+    uri: str,
+    collection: str,
+    backend: str,
+) -> tuple[AspectRecord | ExtractFail | None, float]:
+    """Invoke ``extract_aspects`` for one (uri, collection) under the
+    given backend. Returns (record, elapsed_ms). Toggles the env var
+    just for this call window.
+    """
+    os.environ["NEXUS_ASPECT_BACKEND"] = backend
+    if uri.startswith("chroma://"):
+        # Production path: hand to extract_aspects with empty content,
+        # parsed lookup. The chroma:// form is shaped as
+        # chroma://<collection>/<source_path>; we already have the
+        # collection separately, so source_path is the URI tail.
+        # extract_aspects rebuilds the URI from (collection, source_path)
+        # internally — the operator must pass a matching collection.
+        # Split: ``chroma://<coll>/<rest>``
+        rest = uri[len("chroma://"):]
+        slash = rest.find("/")
+        source_path = rest[slash + 1:] if slash != -1 else rest
+        content = ""
+    else:
+        p = Path(uri)
+        if not p.is_absolute():
+            p = (REPO_ROOT / p).resolve()
+        content = _load_local_text(p)
+        source_path = str(p)
+
+    t0 = time.perf_counter()
+    try:
+        rec = extract_aspects(
+            content=content,
+            source_path=source_path,
+            collection=collection,
+        )
+    except Exception as exc:
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+        return (
+            ExtractFail(
+                uri=uri, reason="exception",
+                detail=f"{type(exc).__name__}: {exc}",
+            ),
+            elapsed_ms,
+        )
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+    return rec, elapsed_ms
+
+
+def _record_to_json(rec: AspectRecord | ExtractFail | None) -> Any:
+    if rec is None:
+        return None
+    if isinstance(rec, ExtractFail):
+        return {
+            "_kind": "ExtractFail",
+            "uri": rec.uri,
+            "reason": rec.reason,
+            "detail": rec.detail,
+        }
+    return {"_kind": "AspectRecord", **asdict(rec)}
+
+
+# ── Manifest + CLI ───────────────────────────────────────────────────────────
+
+
+def _load_manifest(path: Path) -> list[dict]:
+    """Load a JSON manifest of [{"uri": ..., "collection": ...}, ...].
+
+    A manifest may also override the default collection per-row. Rows
+    missing ``collection`` inherit the CLI ``--collection`` value.
+    """
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"manifest must be a JSON array; got {type(data).__name__}")
+    return data
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="A/B parity harness for aspect_extractor (claude vs qwen)",
+    )
+    p.add_argument(
+        "--uri", action="append", default=[],
+        help="Source URI: file path or chroma://... (repeatable).",
+    )
+    p.add_argument(
+        "--manifest", type=Path,
+        help="JSON manifest: [{uri, collection?}, ...].",
+    )
+    p.add_argument(
+        "--collection", default="knowledge__spike-c",
+        help="Default collection for sources without one (default: "
+             "knowledge__spike-c — routes scholarly-paper-v1).",
+    )
+    p.add_argument(
+        "--limit", type=int, default=0,
+        help="Cap papers (0 = unbounded).",
+    )
+    p.add_argument(
+        "--repeat", type=int, default=1,
+        help="Repeat each paper N times for variance (default 1).",
+    )
+    p.add_argument(
+        "--out", type=Path, required=True,
+        help="JSONL log output path.",
+    )
+    p.add_argument(
+        "--summary", type=Path,
+        help="Optional markdown summary path (default: <out>.md).",
+    )
+    p.add_argument(
+        "--backends", default="claude,qwen",
+        help="Comma-separated backends to run (default: claude,qwen).",
+    )
+    return p.parse_args(argv)
+
+
+def _summarize(records: list[dict]) -> dict:
+    """Aggregate per-field agreement + per-engine ok-rate + median ms."""
+    both_ok = [r for r in records if r["both_ok"]]
+    field_agree: dict[str, list[bool]] = {f: [] for f in ALL_DIFFED_FIELDS}
+    for r in both_ok:
+        for f, v in r["agreement"].items():
+            field_agree.setdefault(f, []).append(bool(v))
+
+    claude_ms = [r["claude_elapsed_ms"] for r in records if r.get("claude_elapsed_ms") is not None]
+    qwen_ms = [r["qwen_elapsed_ms"] for r in records if r.get("qwen_elapsed_ms") is not None]
+
+    def _rate(xs: list[bool]) -> float:
+        return (sum(1 for x in xs if x) / len(xs)) if xs else 0.0
+
+    def _med(xs: list[float]) -> float:
+        return statistics.median(xs) if xs else 0.0
+
+    return {
+        "total": len(records),
+        "both_ok": len(both_ok),
+        "claude_ok_rate": _rate([r["claude_ok"] for r in records]),
+        "qwen_ok_rate": _rate([r["qwen_ok"] for r in records]),
+        "field_agreement": {
+            f: {"rate": _rate(v), "n": len(v)}
+            for f, v in field_agree.items()
+        },
+        "claude_median_ms": _med(claude_ms),
+        "qwen_median_ms": _med(qwen_ms),
+        "claude_total_s": sum(claude_ms) / 1000.0,
+        "qwen_total_s": sum(qwen_ms) / 1000.0,
+    }
+
+
+def _render_md(summary: dict, out_path: Path) -> str:
+    lines = [
+        "# Spike C — aspect_extractor A/B parity (claude vs qwen)",
+        "",
+        f"- Total runs: **{summary['total']}**",
+        f"- Both-engine success: **{summary['both_ok']}**",
+        f"- Claude ok-rate: **{summary['claude_ok_rate']:.2%}**",
+        f"- Qwen ok-rate:   **{summary['qwen_ok_rate']:.2%}**",
+        f"- Claude median elapsed: **{summary['claude_median_ms']:.0f} ms**",
+        f"- Qwen median elapsed:   **{summary['qwen_median_ms']:.0f} ms**",
+        f"- Claude wall-clock total: **{summary['claude_total_s']:.1f} s**",
+        f"- Qwen wall-clock total:   **{summary['qwen_total_s']:.1f} s**",
+        "",
+        "## Per-field agreement (both-ok subset)",
+        "",
+        "| Field | Bucket | Agreement | N |",
+        "|---|---|---|---|",
+    ]
+    bucket = {f: "strict" for f in STRICT_FIELDS}
+    bucket.update({f: "set" for f in SET_FIELDS})
+    bucket.update({f: f"prose (len-ratio >= {PROSE_LEN_TOL})" for f in PROSE_FIELDS})
+    for f in ALL_DIFFED_FIELDS:
+        info = summary["field_agreement"].get(f, {"rate": 0.0, "n": 0})
+        lines.append(
+            f"| `{f}` | {bucket.get(f, '?')} | {info['rate']:.2%} | {info['n']} |"
+        )
+    lines.append("")
+    lines.append(f"_Raw JSONL: `{out_path}`_")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    sources: list[dict] = []
+    for u in args.uri:
+        sources.append({"uri": u, "collection": args.collection})
+    if args.manifest:
+        for entry in _load_manifest(args.manifest):
+            sources.append({
+                "uri": entry["uri"],
+                "collection": entry.get("collection", args.collection),
+            })
+    if not sources:
+        print("error: no sources (pass --uri or --manifest)", file=sys.stderr)
+        return 2
+    if args.limit:
+        sources = sources[: args.limit]
+
+    backends = [b.strip() for b in args.backends.split(",") if b.strip()]
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    records: list[dict] = []
+    with args.out.open("w", encoding="utf-8") as fp:
+        for repeat_ix in range(args.repeat):
+            for src in sources:
+                row: dict[str, Any] = {
+                    "uri": src["uri"],
+                    "collection": src["collection"],
+                    "repeat": repeat_ix,
+                }
+                engine_recs: dict[str, AspectRecord | ExtractFail | None] = {}
+                for backend in backends:
+                    rec, elapsed_ms = _run_one(
+                        src["uri"], src["collection"], backend,
+                    )
+                    engine_recs[backend] = rec
+                    row[f"{backend}_record"] = _record_to_json(rec)
+                    row[f"{backend}_elapsed_ms"] = elapsed_ms
+                if "claude" in engine_recs and "qwen" in engine_recs:
+                    diff = diff_records(engine_recs["claude"], engine_recs["qwen"])
+                    row.update(diff)
+                else:
+                    # Single-backend pass-through — no diff possible.
+                    row["claude_ok"] = isinstance(
+                        engine_recs.get("claude"), AspectRecord,
+                    )
+                    row["qwen_ok"] = isinstance(
+                        engine_recs.get("qwen"), AspectRecord,
+                    )
+                    row["both_ok"] = False
+                    row["agreement"] = {}
+                fp.write(json.dumps(row) + "\n")
+                fp.flush()
+                records.append(row)
+                print(
+                    f"[{repeat_ix + 1}/{args.repeat}] {src['uri']}: "
+                    f"claude_ok={row['claude_ok']} qwen_ok={row['qwen_ok']} "
+                    f"both_ok={row['both_ok']}",
+                    file=sys.stderr,
+                )
+
+    summary = _summarize(records)
+    summary_path = args.summary or args.out.with_suffix(args.out.suffix + ".md")
+    summary_path.write_text(_render_md(summary, args.out), encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+    print(f"\nMarkdown summary: {summary_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/nexus/aspect_extractor.py
+++ b/src/nexus/aspect_extractor.py
@@ -70,7 +70,9 @@ Retry policy (audit F8):
 """
 from __future__ import annotations
 
+import asyncio
 import json
+import os
 import random
 import re
 import subprocess
@@ -1067,9 +1069,13 @@ def _retry_subprocess_batch(
     null-out). Returns the outer dict ``{"papers": [...]}`` on
     success, ``None`` on final failure.
     """
+    backend = _pick_aspect_backend()
+    invoker = (
+        _invoke_once_batch_qwen if backend == "qwen" else _invoke_once_batch
+    )
     for attempt in range(_RETRY_ATTEMPTS):
         try:
-            return _invoke_once_batch(prompt, timeout=timeout)
+            return invoker(prompt, timeout=timeout)
         except _TransientFailure as exc:
             _log.debug(
                 "aspect_extractor_batch_transient_failure",
@@ -1215,6 +1221,147 @@ def _build_record_from_entry(
     )
 
 
+# ── Backend selection (Path B parallel adapter) ──────────────────────────────
+
+
+_ASPECT_BACKEND_ENV = "NEXUS_ASPECT_BACKEND"
+_ASPECT_BACKEND_DEFAULT = "claude"
+_ASPECT_BACKEND_VALID = ("claude", "qwen")
+
+# Permissive schemas for the qwen path. The aspect prompt was authored
+# against ``claude -p`` which doesn't take a schema, so we don't
+# fabricate field constraints here — the existing post-parse
+# validation in ``_build_record`` / ``_build_record_from_entry``
+# still applies. The schema is required by ``qwen_dispatch`` solely
+# to render the system-prompt JSON contract.
+_QWEN_ASPECT_SCHEMA_SINGLE: dict[str, Any] = {"type": "object"}
+_QWEN_ASPECT_SCHEMA_BATCH: dict[str, Any] = {
+    "type": "object",
+    "properties": {"papers": {"type": "array"}},
+    "required": ["papers"],
+}
+
+
+def _pick_aspect_backend() -> str:
+    """Resolve the aspect-extractor backend from ``NEXUS_ASPECT_BACKEND``.
+
+    Values: ``claude`` (default) routes to the existing subprocess
+    invokers; ``qwen`` routes to ``qwen_dispatch``. Unknown values
+    fall back to ``claude`` with a warning log. This is the only
+    surface that decides between the two engines — the retry/backoff
+    wrapper is shared.
+    """
+    raw = os.environ.get(_ASPECT_BACKEND_ENV)
+    if raw is None or raw == "":
+        return _ASPECT_BACKEND_DEFAULT
+    val = raw.strip().lower()
+    if val in _ASPECT_BACKEND_VALID:
+        return val
+    _log.warning(
+        "aspect_extractor_unknown_backend",
+        requested=raw,
+        fallback=_ASPECT_BACKEND_DEFAULT,
+        valid=_ASPECT_BACKEND_VALID,
+    )
+    return _ASPECT_BACKEND_DEFAULT
+
+
+def _dispatch_qwen_sync(
+    prompt: str,
+    schema: dict[str, Any],
+    *,
+    timeout: float,
+    operator_name: str,
+) -> dict[str, Any]:
+    """Run ``qwen_dispatch`` from a synchronous caller, translating
+    its exceptions into the local ``_TransientFailure`` /
+    ``_HardFailure`` taxonomy so the existing retry wrapper applies
+    without modification.
+
+    Exception mapping:
+
+    * ``QwenOperatorTimeoutError`` → ``_TransientFailure`` (HTTP
+      timeout is retriable at this layer).
+    * ``QwenOperatorOutputError`` → ``_HardFailure`` (qwen_dispatch
+      already retried JSON-parse internally; further retries here
+      won't reshape the model output).
+    * ``QwenOperatorError`` (other) → ``_TransientFailure`` for 5xx
+      backend errors, ``_HardFailure`` otherwise.
+    * Any unexpected exception → ``_HardFailure`` (don't silently
+      retry the unknown).
+    """
+    # Lazy import: avoids httpx + qwen_dispatch module load on the
+    # default (claude) path. Resolve via the module so tests that
+    # monkeypatch ``qwen_dispatch.qwen_dispatch`` are honoured.
+    from nexus.operators import qwen_dispatch as _qd_mod
+    QwenOperatorError = _qd_mod.QwenOperatorError
+    QwenOperatorOutputError = _qd_mod.QwenOperatorOutputError
+    QwenOperatorTimeoutError = _qd_mod.QwenOperatorTimeoutError
+
+    try:
+        return asyncio.run(
+            _qd_mod.qwen_dispatch(
+                prompt,
+                schema,
+                timeout=timeout,
+                operator_name=operator_name,
+            )
+        )
+    except QwenOperatorTimeoutError as exc:
+        raise _TransientFailure(f"qwen timeout: {exc}") from exc
+    except QwenOperatorOutputError as exc:
+        raise _HardFailure(f"qwen output parse exhausted: {exc}") from exc
+    except QwenOperatorError as exc:
+        msg = str(exc)
+        # Classify 5xx as transient; anything else (4xx, shape
+        # mismatch) as hard.
+        if "non-2xx (5" in msg:
+            raise _TransientFailure(f"qwen 5xx: {exc}") from exc
+        raise _HardFailure(f"qwen error: {exc}") from exc
+
+
+def _invoke_once_qwen(prompt: str) -> dict:
+    """Qwen-backed analogue of :func:`_invoke_once`. Returns the parsed
+    JSON dict on success. Raises ``_TransientFailure`` /
+    ``_HardFailure`` per the same taxonomy as the subprocess path.
+
+    No outer ``{"result": ...}`` envelope to unwrap — ``qwen_dispatch``
+    already returns the parsed inner dict. Post-parse validation
+    (top-level must be a dict) mirrors the subprocess path.
+    """
+    parsed = _dispatch_qwen_sync(
+        prompt,
+        _QWEN_ASPECT_SCHEMA_SINGLE,
+        timeout=180.0,
+        operator_name="aspect_single",
+    )
+    if not isinstance(parsed, dict):
+        raise _HardFailure(
+            f"qwen json top-level not a dict (got {type(parsed).__name__})"
+        )
+    return parsed
+
+
+def _invoke_once_batch_qwen(prompt: str, *, timeout: int) -> dict:
+    """Qwen-backed analogue of :func:`_invoke_once_batch`. Asserts the
+    response contains a ``papers`` array — same hard-failure contract
+    as the subprocess batch path.
+    """
+    parsed = _dispatch_qwen_sync(
+        prompt,
+        _QWEN_ASPECT_SCHEMA_BATCH,
+        timeout=float(timeout),
+        operator_name="aspect_batch",
+    )
+    if not isinstance(parsed, dict):
+        raise _HardFailure(
+            f"qwen batch top-level not a dict (got {type(parsed).__name__})"
+        )
+    if not isinstance(parsed.get("papers"), list):
+        raise _HardFailure("qwen batch response missing 'papers' array")
+    return parsed
+
+
 # ── Subprocess invocation + retry loop ───────────────────────────────────────
 
 
@@ -1225,9 +1372,11 @@ def _retry_subprocess(
     """Invoke the Claude CLI with retry. Return the parsed JSON dict on
     success, or ``None`` after final failure.
     """
+    backend = _pick_aspect_backend()
+    invoker = _invoke_once_qwen if backend == "qwen" else _invoke_once
     for attempt in range(_RETRY_ATTEMPTS):
         try:
-            return _invoke_once(prompt)
+            return invoker(prompt)
         except _TransientFailure as exc:
             _log.debug(
                 "aspect_extractor_transient_failure",

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -61,6 +61,7 @@ from nexus.commands.taxonomy_cmd import taxonomy
 from nexus.commands.tier_status import tier_status_cmd
 from nexus.commands.aspects import aspects_group
 from nexus.commands.upgrade import upgrade
+from nexus.commands.instances import instances_cmd
 
 @click.group()
 @click.version_option(package_name="conexus", prog_name="nx")
@@ -173,3 +174,4 @@ main.add_command(taxonomy)
 main.add_command(tier_status_cmd, name="tier-status")
 main.add_command(aspects_group, name="aspects")
 main.add_command(upgrade)
+main.add_command(instances_cmd, name="instances")

--- a/src/nexus/commands/instances.py
+++ b/src/nexus/commands/instances.py
@@ -50,9 +50,14 @@ def instances_cmd(json_out: bool, sweep: bool) -> None:
     for every row in the liveness table. Stale rows (no heartbeat for
     > 60 s) are marked with an asterisk in human output.
 
-    Under RDR-112 daemon mode both the MCP heartbeat and this CLI command
-    route through the same ``MemoryStore.liveness_*`` methods via the
-    ``mcp_infra.t2_ctx`` facade.
+    Storage routing: the MCP heartbeat and this CLI command both call
+    ``MemoryStore.liveness_*`` methods via ``mcp_infra.t2_ctx``. Today
+    ``t2_ctx`` always opens a direct SQLite connection regardless of
+    ``NX_STORAGE_MODE``; daemon-mode routing through ``T2Client`` is
+    deferred to nexus-pce1.6 and will land once the Phase 2 CatalogDB
+    collapse settles the dispatch surface. The method names match the
+    daemon's RPC namespace (memory.liveness_*) so the eventual flip is
+    a routing change inside ``t2_ctx``, not a call-site rewrite here.
     """
     db_path = default_db_path()
     if not Path(db_path).exists():

--- a/src/nexus/commands/instances.py
+++ b/src/nexus/commands/instances.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``nx instances`` -- list running Nexus MCP instances via T2 liveness table.
+
+RDR-111 P1.3 (nexus-r0vi).
+
+Queries the liveness table in memory.db and formats the result as a
+human-readable table or JSON. Stale rows (last_seen > 60 s ago) are
+included by default -- they may represent processes that exited without
+cleaning up; use ``--sweep`` to remove them first.
+"""
+from __future__ import annotations
+
+import json as _json
+import time
+from pathlib import Path
+
+import click
+
+from nexus.commands._helpers import default_db_path
+
+# Age threshold used to compute the human-readable age column.
+_STALE_THRESHOLD_SECONDS = 60
+
+
+def _age_str(last_seen: float) -> str:
+    """Return a compact human-readable age string for a last_seen epoch float."""
+    age = time.time() - last_seen
+    if age < 0:
+        return "now"
+    if age < 90:
+        return f"{int(age)}s ago"
+    if age < 3600:
+        return f"{int(age / 60)}m ago"
+    return f"{int(age / 3600)}h ago"
+
+
+@click.command("instances")
+@click.option(
+    "--json", "json_out", is_flag=True, default=False,
+    help="Emit structured JSON instead of the human table.",
+)
+@click.option(
+    "--sweep", is_flag=True, default=False,
+    help="Sweep stale rows (last_seen > 60 s) before listing.",
+)
+def instances_cmd(json_out: bool, sweep: bool) -> None:
+    """List running Nexus MCP instances from the T2 liveness table.
+
+    Shows pid, machine, user, session, project, focus, activity, and age
+    for every row in the liveness table. Stale rows (no heartbeat for
+    > 60 s) are marked with an asterisk in human output.
+
+    Under RDR-112 daemon mode both the MCP heartbeat and this CLI command
+    route through the same ``MemoryStore.liveness_*`` methods via the
+    ``mcp_infra.t2_ctx`` facade.
+    """
+    db_path = default_db_path()
+    if not Path(db_path).exists():
+        if json_out:
+            click.echo(_json.dumps({"error": "T2 database not found", "path": str(db_path)}))
+        else:
+            click.echo(f"T2 database not found at {db_path}.", err=True)
+        raise click.exceptions.Exit(1)
+
+    from nexus.mcp_infra import t2_ctx
+    with t2_ctx() as db:
+        if sweep:
+            deleted = db.memory.liveness_sweep()
+            if not json_out:
+                click.echo(f"Swept {deleted} stale row(s).")
+        rows = db.memory.liveness_list()
+
+    if json_out:
+        click.echo(_json.dumps(rows, indent=2))
+        return
+
+    if not rows:
+        click.echo("No active instances found.")
+        return
+
+    # Human table.
+    now = time.time()
+    hdr = f"{'PID':<8} {'MACHINE':<20} {'USER':<12} {'SESSION':<14} {'PROJECT':<14} {'FOCUS':<16} {'ACTIVITY':<16} AGE"
+    sep = f"{'-'*8} {'-'*20} {'-'*12} {'-'*14} {'-'*14} {'-'*16} {'-'*16} {'-'*12}"
+    click.echo(hdr)
+    click.echo(sep)
+    for r in rows:
+        stale = (now - r["last_seen"]) > _STALE_THRESHOLD_SECONDS
+        age = _age_str(r["last_seen"])
+        marker = "*" if stale else " "
+        click.echo(
+            f"{marker}{r['pid']:<7} "
+            f"{(r['machine'] or ''):<20} "
+            f"{(r['user_id'] or ''):<12} "
+            f"{(r['session'] or ''):<14} "
+            f"{(r['project'] or ''):<14} "
+            f"{(r['focus'] or ''):<16} "
+            f"{(r['activity'] or ''):<16} "
+            f"{age}"
+        )
+    if any((now - r["last_seen"]) > _STALE_THRESHOLD_SECONDS for r in rows):
+        click.echo("  * stale (no heartbeat for > 60 s); use --sweep to remove")

--- a/src/nexus/commands/taxonomy_cmd.py
+++ b/src/nexus/commands/taxonomy_cmd.py
@@ -1012,8 +1012,20 @@ async def _generate_labels_batch(
     results: list[str | None] = [None] * len(items)
     try:
         from nexus.operators.dispatch import claude_dispatch
+        from nexus.operators.dispatch_router import pick_dispatcher_for
 
-        payload = await claude_dispatch(prompt, _LABEL_SCHEMA, timeout=120.0)
+        if pick_dispatcher_for("topic_labeler") == "qwen":
+            from nexus.operators.qwen_dispatch import qwen_dispatch
+
+            payload = await qwen_dispatch(
+                prompt, _LABEL_SCHEMA, timeout=120.0,
+                operator_name="topic_labeler",
+            )
+        else:
+            payload = await claude_dispatch(
+                prompt, _LABEL_SCHEMA, timeout=120.0,
+                operator_name="topic_labeler",
+            )
     except Exception:
         return results
 

--- a/src/nexus/db/migrations.py
+++ b/src/nexus/db/migrations.py
@@ -2546,6 +2546,7 @@ def _migrate_aspect_queue_pk_via_apply_pending(conn: sqlite3.Connection) -> None
     migrate_aspect_extraction_queue_pk_to_doc_id(conn, catalog_db_path=catalog_path)
 
 
+<<<<<<< HEAD
 # ── RDR-112 P1.4 (nexus-w0et): watcher_state in tuples.db ──────────────────
 
 
@@ -2844,6 +2845,43 @@ CREATE TABLE IF NOT EXISTS subspace_registry (
     _log.info("migrate_subspace_registry_table_done")
 
 
+def migrate_liveness_table(conn: sqlite3.Connection) -> None:
+    """RDR-111 P1.3 (nexus-r0vi): create the ``liveness`` table in memory.db.
+
+    The liveness table stores one row per running MCP instance (or CLI
+    invocation that participates in heartbeating). Rows are keyed by
+    ``(pid, machine)`` and carry a ``last_seen`` float (unix epoch with
+    sub-second precision via ``unixepoch('subsec')``).
+
+    Must be called with a ``memory.db`` connection.
+    Idempotent: gated by ``CREATE TABLE IF NOT EXISTS``.
+    """
+    existing = {
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='liveness'"
+        ).fetchall()
+    }
+    if "liveness" in existing:
+        return
+    _log.info("migrate_liveness_table_start")
+    conn.executescript("""
+CREATE TABLE IF NOT EXISTS liveness (
+    pid       INTEGER NOT NULL,
+    machine   TEXT    NOT NULL,
+    user_id   TEXT    NOT NULL,
+    session   TEXT,
+    project   TEXT,
+    focus     TEXT,
+    activity  TEXT,
+    last_seen REAL    NOT NULL,
+    PRIMARY KEY (pid, machine)
+);
+CREATE INDEX IF NOT EXISTS idx_liveness_last_seen ON liveness (last_seen);
+""")
+    conn.commit()
+    _log.info("migrate_liveness_table_done")
+
+
 MIGRATIONS: list[Migration] = [
     Migration("1.10.0", "Memory FTS rebuild with title", migrate_memory_fts),
     Migration("2.8.0", "Add plan project column", migrate_plan_project),
@@ -3028,6 +3066,13 @@ MIGRATIONS: list[Migration] = [
     # nexus-m4gm (RDR-112 P1.3): EventStream RPC substrate migrations are applied
     # directly in run_daemon_migrations (not here) because they need a tuples.db
     # connection, not a memory.db connection.
+    # nexus-7ejx (RDR-112 P2.1): CatalogDB collapse — version 4.34.0 reserved
+    # for that bead; its rebase will insert here.
+    Migration(
+        "4.35.0",
+        "RDR-111 P1.3: create liveness table + last_seen index (nexus-r0vi)",
+        migrate_liveness_table,
+    ),
 ]
 
 

--- a/src/nexus/db/t2/memory_store.py
+++ b/src/nexus/db/t2/memory_store.py
@@ -90,6 +90,21 @@ def _sanitize_fts5(query: str) -> str:
 
 # ── Schema SQL (memory + memory_fts + triggers) ───────────────────────────────
 
+_LIVENESS_SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS liveness (
+    pid       INTEGER NOT NULL,
+    machine   TEXT    NOT NULL,
+    user_id   TEXT    NOT NULL,
+    session   TEXT,
+    project   TEXT,
+    focus     TEXT,
+    activity  TEXT,
+    last_seen REAL    NOT NULL,
+    PRIMARY KEY (pid, machine)
+);
+CREATE INDEX IF NOT EXISTS idx_liveness_last_seen ON liveness (last_seen);
+"""
+
 _MEMORY_SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS memory (
     id            INTEGER PRIMARY KEY,
@@ -283,6 +298,7 @@ class MemoryStore:
         """
         with self._lock:
             self.conn.executescript(_MEMORY_SCHEMA_SQL)
+            self.conn.executescript(_LIVENESS_SCHEMA_SQL)
             self.conn.executescript("PRAGMA journal_mode=WAL;")
             self.conn.commit()
             result = self.conn.execute("PRAGMA journal_mode").fetchone()
@@ -1014,3 +1030,80 @@ class MemoryStore:
                 (project, cutoff, cutoff),
             ).fetchall()
         return [dict(zip(_COLUMNS, row)) for row in rows]
+
+    # ── Liveness (RDR-111 P1.3, nexus-r0vi) ─────────────────────────────────
+
+    def liveness_upsert(
+        self,
+        *,
+        pid: int,
+        machine: str,
+        user_id: str,
+        session: str | None = None,
+        project: str | None = None,
+        focus: str | None = None,
+        activity: str | None = None,
+        _now: float | None = None,
+    ) -> None:
+        """Register or refresh this instance's liveness row.
+
+        INSERT OR REPLACE keyed by (pid, machine). ``last_seen`` is set
+        to ``_now`` when supplied (for deterministic tests) or to the
+        current ``unixepoch('subsec')`` via an in-SQL expression.
+
+        The optional ``_now`` kwarg is injected by tests; production
+        callers omit it and the SQL fallback applies.
+        """
+        if _now is not None:
+            sql = """
+                INSERT OR REPLACE INTO liveness
+                    (pid, machine, user_id, session, project, focus, activity, last_seen)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """
+            params: tuple = (pid, machine, user_id, session, project, focus, activity, _now)
+        else:
+            sql = """
+                INSERT OR REPLACE INTO liveness
+                    (pid, machine, user_id, session, project, focus, activity, last_seen)
+                VALUES (?, ?, ?, ?, ?, ?, ?, unixepoch('subsec'))
+            """
+            params = (pid, machine, user_id, session, project, focus, activity)
+        with self._lock:
+            self.conn.execute(sql, params)
+            self.conn.commit()
+
+    def liveness_sweep(
+        self,
+        *,
+        max_age_seconds: int = 60,
+        _now: float | None = None,
+    ) -> int:
+        """Delete rows whose ``last_seen`` is older than ``max_age_seconds``.
+
+        Returns the number of rows deleted. ``_now`` overrides the current
+        epoch for deterministic tests; production callers omit it.
+        """
+        if _now is not None:
+            cutoff = _now - max_age_seconds
+            sql = "DELETE FROM liveness WHERE last_seen < ?"
+            params_sw: tuple = (cutoff,)
+        else:
+            sql = "DELETE FROM liveness WHERE last_seen < unixepoch('subsec') - ?"
+            params_sw = (max_age_seconds,)
+        with self._lock:
+            cursor = self.conn.execute(sql, params_sw)
+            self.conn.commit()
+        return cursor.rowcount
+
+    def liveness_list(self) -> list[dict]:
+        """Return all current liveness rows ordered by (pid ASC, machine ASC)."""
+        with self._lock:
+            rows = self.conn.execute(
+                """
+                SELECT pid, machine, user_id, session, project, focus, activity, last_seen
+                FROM liveness
+                ORDER BY pid ASC, machine ASC
+                """
+            ).fetchall()
+        keys = ("pid", "machine", "user_id", "session", "project", "focus", "activity", "last_seen")
+        return [dict(zip(keys, row)) for row in rows]

--- a/src/nexus/db/t2/memory_store.py
+++ b/src/nexus/db/t2/memory_store.py
@@ -1096,14 +1096,37 @@ class MemoryStore:
         return cursor.rowcount
 
     def liveness_list(self) -> list[dict]:
-        """Return all current liveness rows ordered by (pid ASC, machine ASC)."""
+        """Return all current liveness rows ordered by last_seen DESC.
+
+        Freshest-first ordering matches the natural display contract of
+        `nx instances` (most recently active at the top). Stable secondary
+        key on (pid, machine) preserves determinism when two rows share
+        a last_seen timestamp.
+        """
         with self._lock:
             rows = self.conn.execute(
                 """
                 SELECT pid, machine, user_id, session, project, focus, activity, last_seen
                 FROM liveness
-                ORDER BY pid ASC, machine ASC
+                ORDER BY last_seen DESC, pid ASC, machine ASC
                 """
             ).fetchall()
         keys = ("pid", "machine", "user_id", "session", "project", "focus", "activity", "last_seen")
         return [dict(zip(keys, row)) for row in rows]
+
+    def liveness_delete(self, *, pid: int, machine: str) -> int:
+        """Delete the liveness row for ``(pid, machine)``.
+
+        Returns the number of rows removed (0 or 1). Used by MCP server
+        shutdown to clean up the local instance's row before exit so the
+        sweep doesn't have to wait the full TTL to reflect the departure.
+        Tolerates absence (returns 0) — no error if the row was already
+        swept or never written.
+        """
+        with self._lock:
+            cursor = self.conn.execute(
+                "DELETE FROM liveness WHERE pid = ? AND machine = ?",
+                (pid, machine),
+            )
+            self.conn.commit()
+        return cursor.rowcount

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -415,14 +415,13 @@ async def _combined_lifespan(_app: Any):
                 await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
             except (asyncio.TimeoutError, asyncio.CancelledError):
                 task.cancel()
-            # Best-effort delete our row on clean shutdown.
+            # Best-effort delete our row on clean shutdown. Use the public
+            # MemoryStore.liveness_delete method so the call respects the
+            # store's lock and stays compatible with future daemon-mode
+            # routing (nexus-pce1.6) — no raw `.conn` reach-throughs.
             try:
                 with _t2_ctx() as _db:
-                    _db.memory.conn.execute(
-                        "DELETE FROM liveness WHERE pid = ? AND machine = ?",
-                        (pid, machine),
-                    )
-                    _db.memory.conn.commit()
+                    _db.memory.liveness_delete(pid=pid, machine=machine)
             except Exception as _del_exc:
                 _cl_log.debug(
                     "liveness_delete_on_shutdown_error",

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -324,7 +324,113 @@ def _sigterm_handler(_signo: int, _frame: Any) -> None:
     _os._exit(0)
 
 
-mcp = FastMCP("nexus", lifespan=_t1_chroma_lifespan)
+# ── Liveness heartbeat (RDR-111 P1.3, nexus-r0vi) ───────────────────────────
+
+_LIVENESS_INTERVAL_SECONDS = 30
+_LIVENESS_MAX_AGE_SECONDS = 60
+
+
+async def _liveness_heartbeat_task(stop: Any) -> None:
+    """Background coroutine: upsert + sweep every ``_LIVENESS_INTERVAL_SECONDS``.
+
+    Runs until ``stop.set()`` is called by the lifespan cleanup.
+    All errors are caught and logged so a transient DB lock never
+    kills the server.
+
+    ``stop`` is an ``asyncio.Event``; the task awaits it with a timeout
+    so it wakes promptly on shutdown rather than waiting the full
+    interval.
+    """
+    import asyncio
+    import os as _os2
+    import socket
+    import structlog
+
+    _hb_log = structlog.get_logger(__name__)
+    pid = _os2.getpid()
+    machine = socket.gethostname()
+    user_id = _os2.environ.get("USER", _os2.environ.get("LOGNAME", str(pid)))
+
+    async def _beat() -> None:
+        try:
+            with _t2_ctx() as _db:
+                _db.memory.liveness_upsert(
+                    pid=pid,
+                    machine=machine,
+                    user_id=user_id,
+                    session=_os2.environ.get("NX_SESSION_ID"),
+                    project=_os2.environ.get("NX_PROJECT"),
+                    focus=_os2.environ.get("NX_FOCUS"),
+                    activity=_os2.environ.get("NX_ACTIVITY"),
+                )
+                _db.memory.liveness_sweep(max_age_seconds=_LIVENESS_MAX_AGE_SECONDS)
+        except Exception as _hb_exc:
+            _hb_log.debug(
+                "liveness_heartbeat_error", error=str(_hb_exc),
+                pid=pid, machine=machine,
+            )
+
+    # Initial beat on startup.
+    await _beat()
+
+    while True:
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=float(_LIVENESS_INTERVAL_SECONDS))
+        except asyncio.TimeoutError:
+            pass
+        if stop.is_set():
+            break
+        await _beat()
+
+
+@asynccontextmanager
+async def _combined_lifespan(_app: Any):
+    """Chain T1 chroma lifespan with liveness heartbeat (RDR-111 P1.3).
+
+    Starts the heartbeat task after T1 chroma is up (or skipped in
+    isolation mode); cancels it and deletes the liveness row on exit.
+    """
+    import asyncio
+    import os as _os2
+    import socket
+    import structlog
+
+    _cl_log = structlog.get_logger(__name__)
+
+    async with _t1_chroma_lifespan(_app):
+        pid = _os2.getpid()
+        machine = socket.gethostname()
+        user_id = _os2.environ.get("USER", _os2.environ.get("LOGNAME", str(pid)))
+
+        stop_event: asyncio.Event = asyncio.Event()
+        task = asyncio.create_task(
+            _liveness_heartbeat_task(stop_event),
+            name="liveness-heartbeat",
+        )
+        try:
+            yield
+        finally:
+            stop_event.set()
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                task.cancel()
+            # Best-effort delete our row on clean shutdown.
+            try:
+                with _t2_ctx() as _db:
+                    _db.memory.conn.execute(
+                        "DELETE FROM liveness WHERE pid = ? AND machine = ?",
+                        (pid, machine),
+                    )
+                    _db.memory.conn.commit()
+            except Exception as _del_exc:
+                _cl_log.debug(
+                    "liveness_delete_on_shutdown_error",
+                    error=str(_del_exc), pid=pid, machine=machine,
+                )
+
+
+mcp = FastMCP("nexus", lifespan=_combined_lifespan)
 
 _DEFAULT_PAGE_SIZE = 10
 

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -3173,6 +3173,7 @@ async def _nx_answer_plan_miss(
     and return a synthetic Match for plan_run.
     """
     from nexus.operators.dispatch import claude_dispatch
+    from nexus.operators.dispatch_router import pick_dispatcher_for
     from nexus.plans.match import Match
     from nexus.mcp_infra import get_collection_names
 
@@ -3225,9 +3226,18 @@ async def _nx_answer_plan_miss(
     for attempt in range(2):
         attempt_timeout = 300.0 if attempt == 0 else 150.0
         try:
-            payload = await claude_dispatch(
-                prompt, _PLANNER_SCHEMA, timeout=attempt_timeout,
-            )
+            if pick_dispatcher_for("plan_miss_planner") == "qwen":
+                from nexus.operators.qwen_dispatch import qwen_dispatch
+
+                payload = await qwen_dispatch(
+                    prompt, _PLANNER_SCHEMA, timeout=attempt_timeout,
+                    operator_name="plan_miss_planner",
+                )
+            else:
+                payload = await claude_dispatch(
+                    prompt, _PLANNER_SCHEMA, timeout=attempt_timeout,
+                    operator_name="plan_miss_planner",
+                )
             break
         except _OpOutputError as exc:
             last_output_error = exc

--- a/src/nexus/operators/dispatch.py
+++ b/src/nexus/operators/dispatch.py
@@ -173,6 +173,8 @@ async def claude_dispatch(
     prompt: str,
     json_schema: dict[str, Any],
     timeout: float = 300.0,
+    *,
+    operator_name: str | None = None,
 ) -> dict[str, Any]:
     """Dispatch a single operator call to claude -p, fully async.
 
@@ -306,6 +308,38 @@ async def claude_dispatch(
         raise OperatorOutputError(
             f"claude -p output is not valid JSON: {exc} — got: {raw[:200]}"
         ) from exc
+
+    # Cost telemetry: the `claude -p` JSON envelope carries
+    # ``total_cost_usd`` plus a ``usage`` block with input/output token
+    # counts. Surface them as a structured log entry so operators can
+    # roll up spend downstream without threading a new return field
+    # through every caller. Missing fields → log nulls; the dispatch
+    # path does not depend on this signal.
+    if isinstance(parsed, dict):
+        cost_usd = parsed.get("total_cost_usd")
+        usage = parsed.get("usage")
+        in_tok: int | None = None
+        out_tok: int | None = None
+        if isinstance(usage, dict):
+            pt = usage.get("input_tokens")
+            ct = usage.get("output_tokens")
+            if isinstance(pt, int):
+                in_tok = pt
+            if isinstance(ct, int):
+                out_tok = ct
+        _log.info(
+            "operator_dispatch_cost",
+            dispatch_engine="claude",
+            dispatch_operator=operator_name,
+            dispatch_input_tokens=in_tok,
+            dispatch_output_tokens=out_tok,
+            dispatch_cost_usd=(
+                float(cost_usd)
+                if isinstance(cost_usd, (int, float))
+                else None
+            ),
+            dispatch_would_have_cost_usd=None,
+        )
 
     # `claude -p --output-format json` returns a wrapper:
     # {"type":"result", "is_error":bool, "result":str, "structured_output":dict, ...}

--- a/src/nexus/operators/dispatch_router.py
+++ b/src/nexus/operators/dispatch_router.py
@@ -41,6 +41,7 @@ __all__ = [
     "QWEN_OPERATORS_DEFAULT",
     "CLAUDE_OPERATORS_PINNED",
     "pick_dispatcher",
+    "pick_dispatcher_for",
     "pick_dispatcher_for_bundle",
 ]
 
@@ -119,6 +120,30 @@ def pick_dispatcher(operator_name: str) -> DispatchBackend:
         return "claude"
     # mode == "claude" or unset: default Claude (preserves prior behavior).
     return "claude"
+
+
+def pick_dispatcher_for(call_site: str) -> DispatchBackend:
+    """Route a named non-operator call site through the same machinery.
+
+    Some ``claude_dispatch`` callers aren't bundleable operators —
+    e.g. ``taxonomy_cmd._generate_labels_batch`` (topic labeler) and
+    the inline plan-miss planner. They still benefit from per-site
+    routing so the operator can flip them to Qwen once bench evidence
+    lands, without a code change.
+
+    Semantics: identical to :func:`pick_dispatcher`. The two per-call
+    env vars (``NEXUS_DISPATCH_QWEN_OPERATORS`` /
+    ``NEXUS_DISPATCH_CLAUDE_OPERATORS``) accept call-site names too —
+    "what to route" is the same surface whether it's an operator or a
+    call site, so a separate env var would be bloat.
+
+    Because call sites are not in :data:`QWEN_OPERATORS_DEFAULT`, the
+    auto-mode unknown-name branch routes them to claude — cautious-by-
+    default, matching #623's rollout posture. Opting one site into
+    Qwen is a one-env-var flip
+    (``NEXUS_DISPATCH_QWEN_OPERATORS=<call_site>``).
+    """
+    return pick_dispatcher(call_site)
 
 
 def pick_dispatcher_for_bundle(tools: Iterable[str]) -> DispatchBackend:

--- a/src/nexus/operators/qwen_dispatch.py
+++ b/src/nexus/operators/qwen_dispatch.py
@@ -41,6 +41,9 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+import structlog
+
+_log = structlog.get_logger(__name__)
 
 __all__ = [
     "qwen_dispatch",
@@ -48,6 +51,37 @@ __all__ = [
     "QwenOperatorTimeoutError",
     "QwenOperatorOutputError",
 ]
+
+
+# Cost-telemetry rates for the "would-have-cost" estimator.
+#
+# These are the published Anthropic API rates for Claude Sonnet 4.x as of
+# 2026-05 — see https://www.anthropic.com/pricing#api. Used only to give
+# operators a rough "how much did running this on Qwen save us" signal in
+# the structured logs; this is NOT a billing system. Refresh the constants
+# (and the date below) when Anthropic publishes a new Sonnet rate card.
+#
+# Last verified: 2026-05-14, source: https://www.anthropic.com/pricing
+_SONNET_INPUT_USD_PER_MTOK = 3.0
+_SONNET_OUTPUT_USD_PER_MTOK = 15.0
+
+
+def _estimate_sonnet_cost_usd(
+    input_tokens: int | None, output_tokens: int | None
+) -> float | None:
+    """Compute the Sonnet 4.x would-have-cost for *input* / *output* tokens.
+
+    Returns ``None`` when either token count is missing — the upstream
+    response did not include a ``usage`` block (older llama-server build,
+    streaming response that elided usage, etc.). Callers log the ``None``
+    rather than fabricating a number.
+    """
+    if input_tokens is None or output_tokens is None:
+        return None
+    return (
+        input_tokens * _SONNET_INPUT_USD_PER_MTOK / 1_000_000.0
+        + output_tokens * _SONNET_OUTPUT_USD_PER_MTOK / 1_000_000.0
+    )
 
 
 class QwenOperatorError(RuntimeError):
@@ -195,6 +229,7 @@ async def qwen_dispatch(
     backend_url: str | None = None,
     model: str | None = None,
     max_attempts: int = 2,
+    operator_name: str | None = None,
 ) -> dict[str, Any]:
     """Dispatch one operator call to Qwen via OpenAI-compat ``/v1/chat/completions``.
 
@@ -293,6 +328,35 @@ async def qwen_dispatch(
                     f"qwen_dispatch unexpected response shape: {exc} "
                     f"(attempt {attempt}/{max_attempts})"
                 ) from exc
+
+            # Cost telemetry: extract usage + emit would-have-cost estimate.
+            # Missing ``usage`` block (older llama-server, streaming) →
+            # log nulls rather than crashing. The dispatch path itself
+            # does not depend on this signal.
+            usage = (
+                payload.get("usage") if isinstance(payload, dict) else None
+            )
+            input_tokens: int | None = None
+            output_tokens: int | None = None
+            if isinstance(usage, dict):
+                pt = usage.get("prompt_tokens")
+                ct = usage.get("completion_tokens")
+                if isinstance(pt, int):
+                    input_tokens = pt
+                if isinstance(ct, int):
+                    output_tokens = ct
+            would_have_cost = _estimate_sonnet_cost_usd(
+                input_tokens, output_tokens
+            )
+            _log.info(
+                "operator_dispatch_cost",
+                dispatch_engine="qwen",
+                dispatch_operator=operator_name,
+                dispatch_input_tokens=input_tokens,
+                dispatch_output_tokens=output_tokens,
+                dispatch_cost_usd=0.0,
+                dispatch_would_have_cost_usd=would_have_cost,
+            )
 
             stripped = _strip_code_fences(last_raw)
             try:

--- a/tests/test_aspect_extractor.py
+++ b/tests/test_aspect_extractor.py
@@ -1147,3 +1147,236 @@ class TestBatchExtraction:
                 "only one ExtractorConfig registered; mixed-config "
                 "test is vacuous"
             )
+
+
+# ── NEXUS_ASPECT_BACKEND parallel qwen adapter (Path B) ──────────────────────
+
+
+class TestPickAspectBackend:
+    """Backend selector contract for NEXUS_ASPECT_BACKEND."""
+
+    def test_default_is_claude(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.delenv("NEXUS_ASPECT_BACKEND", raising=False)
+        assert _pick_aspect_backend() == "claude"
+
+    def test_explicit_claude(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "claude")
+        assert _pick_aspect_backend() == "claude"
+
+    def test_explicit_qwen(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "qwen")
+        assert _pick_aspect_backend() == "qwen"
+
+    def test_case_insensitive(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "QWEN")
+        assert _pick_aspect_backend() == "qwen"
+
+    def test_unknown_falls_back_to_claude_with_warn(
+        self, monkeypatch, caplog,
+    ) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "gpt5")
+        # structlog logs go through stdlib root by default in tests;
+        # validate behaviour by result rather than asserting on
+        # caplog (config-sensitive).
+        assert _pick_aspect_backend() == "claude"
+
+    def test_empty_string_is_default(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_aspect_backend
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "")
+        assert _pick_aspect_backend() == "claude"
+
+
+class TestInvokeOnceQwen:
+    """Single-paper qwen invoker — exception mapping + happy path."""
+
+    def _patch_dispatch(self, monkeypatch, side_effect):
+        """Patch ``qwen_dispatch`` as a stub coroutine. ``side_effect``
+        is either a dict to return or an exception class/instance to
+        raise."""
+        from nexus.operators import qwen_dispatch as qd_mod
+
+        async def fake_dispatch(prompt, schema, **kwargs):
+            if isinstance(side_effect, Exception):
+                raise side_effect
+            if isinstance(side_effect, type) and issubclass(
+                side_effect, Exception
+            ):
+                raise side_effect("simulated")
+            return side_effect
+
+        monkeypatch.setattr(qd_mod, "qwen_dispatch", fake_dispatch)
+
+    def test_happy_path_returns_parsed_dict(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _invoke_once_qwen
+        payload = {
+            "problem_formulation": "x",
+            "proposed_method": "y",
+            "experimental_datasets": [],
+            "experimental_baselines": [],
+            "experimental_results": "z",
+            "extras": {},
+            "confidence": 0.7,
+        }
+        self._patch_dispatch(monkeypatch, payload)
+        out = _invoke_once_qwen("prompt")
+        assert out == payload
+
+    def test_timeout_raises_transient(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _TransientFailure, _invoke_once_qwen
+        from nexus.operators.qwen_dispatch import QwenOperatorTimeoutError
+        self._patch_dispatch(monkeypatch, QwenOperatorTimeoutError)
+        with pytest.raises(_TransientFailure):
+            _invoke_once_qwen("prompt")
+
+    def test_output_error_raises_hard(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _HardFailure, _invoke_once_qwen
+        from nexus.operators.qwen_dispatch import QwenOperatorOutputError
+        self._patch_dispatch(monkeypatch, QwenOperatorOutputError)
+        with pytest.raises(_HardFailure):
+            _invoke_once_qwen("prompt")
+
+    def test_http_5xx_raises_transient(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _TransientFailure, _invoke_once_qwen
+        from nexus.operators.qwen_dispatch import QwenOperatorError
+        self._patch_dispatch(
+            monkeypatch,
+            QwenOperatorError(
+                "qwen_dispatch non-2xx (503): Service Unavailable "
+                "(attempt 1/2, backend=http://x)"
+            ),
+        )
+        with pytest.raises(_TransientFailure):
+            _invoke_once_qwen("prompt")
+
+    def test_http_4xx_raises_hard(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _HardFailure, _invoke_once_qwen
+        from nexus.operators.qwen_dispatch import QwenOperatorError
+        self._patch_dispatch(
+            monkeypatch,
+            QwenOperatorError(
+                "qwen_dispatch non-2xx (400): Bad Request "
+                "(attempt 1/2, backend=http://x)"
+            ),
+        )
+        with pytest.raises(_HardFailure):
+            _invoke_once_qwen("prompt")
+
+    def test_non_dict_top_level_raises_hard(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _HardFailure, _invoke_once_qwen
+        self._patch_dispatch(monkeypatch, ["not", "a", "dict"])
+        with pytest.raises(_HardFailure):
+            _invoke_once_qwen("prompt")
+
+
+class TestInvokeOnceBatchQwen:
+    """Batch qwen invoker — papers-array contract + happy path."""
+
+    def _patch_dispatch(self, monkeypatch, side_effect):
+        from nexus.operators import qwen_dispatch as qd_mod
+
+        async def fake_dispatch(prompt, schema, **kwargs):
+            if isinstance(side_effect, Exception):
+                raise side_effect
+            return side_effect
+
+        monkeypatch.setattr(qd_mod, "qwen_dispatch", fake_dispatch)
+
+    def test_happy_path_returns_papers(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _invoke_once_batch_qwen
+        payload = {"papers": [{"source_path": "/a.pdf"}]}
+        self._patch_dispatch(monkeypatch, payload)
+        out = _invoke_once_batch_qwen("prompt", timeout=300)
+        assert out == payload
+
+    def test_missing_papers_raises_hard(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import (
+            _HardFailure,
+            _invoke_once_batch_qwen,
+        )
+        self._patch_dispatch(monkeypatch, {"not_papers": []})
+        with pytest.raises(_HardFailure):
+            _invoke_once_batch_qwen("prompt", timeout=300)
+
+    def test_non_dict_raises_hard(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import (
+            _HardFailure,
+            _invoke_once_batch_qwen,
+        )
+        self._patch_dispatch(monkeypatch, [1, 2, 3])
+        with pytest.raises(_HardFailure):
+            _invoke_once_batch_qwen("prompt", timeout=300)
+
+
+class TestRetrySubprocessBackendBranch:
+    """End-to-end at ``_retry_subprocess``: backend env flag routes to
+    qwen vs subprocess invokers."""
+
+    def test_default_env_uses_subprocess_invoker(self, monkeypatch) -> None:
+        import nexus.aspect_extractor as mod
+        monkeypatch.delenv("NEXUS_ASPECT_BACKEND", raising=False)
+        called = {"sub": 0, "qwen": 0}
+
+        def fake_invoke_once(prompt):
+            called["sub"] += 1
+            return {"problem_formulation": "x"}
+
+        def fake_invoke_once_qwen(prompt):
+            called["qwen"] += 1
+            return {"problem_formulation": "y"}
+
+        monkeypatch.setattr(mod, "_invoke_once", fake_invoke_once)
+        monkeypatch.setattr(mod, "_invoke_once_qwen", fake_invoke_once_qwen)
+
+        cfg = next(iter(mod._REGISTRY.values()))
+        out = mod._retry_subprocess("prompt", cfg)
+        assert out == {"problem_formulation": "x"}
+        assert called == {"sub": 1, "qwen": 0}
+
+    def test_qwen_env_uses_qwen_invoker(self, monkeypatch) -> None:
+        import nexus.aspect_extractor as mod
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "qwen")
+        called = {"sub": 0, "qwen": 0}
+
+        def fake_invoke_once(prompt):
+            called["sub"] += 1
+            return {"problem_formulation": "x"}
+
+        def fake_invoke_once_qwen(prompt):
+            called["qwen"] += 1
+            return {"problem_formulation": "y"}
+
+        monkeypatch.setattr(mod, "_invoke_once", fake_invoke_once)
+        monkeypatch.setattr(mod, "_invoke_once_qwen", fake_invoke_once_qwen)
+
+        cfg = next(iter(mod._REGISTRY.values()))
+        out = mod._retry_subprocess("prompt", cfg)
+        assert out == {"problem_formulation": "y"}
+        assert called == {"sub": 0, "qwen": 1}
+
+    def test_qwen_env_batch_uses_qwen_batch_invoker(
+        self, monkeypatch,
+    ) -> None:
+        import nexus.aspect_extractor as mod
+        monkeypatch.setenv("NEXUS_ASPECT_BACKEND", "qwen")
+        called = {"sub": 0, "qwen": 0}
+
+        def fake_batch(prompt, *, timeout):
+            called["sub"] += 1
+            return {"papers": []}
+
+        def fake_batch_qwen(prompt, *, timeout):
+            called["qwen"] += 1
+            return {"papers": [{"source_path": "/a"}]}
+
+        monkeypatch.setattr(mod, "_invoke_once_batch", fake_batch)
+        monkeypatch.setattr(mod, "_invoke_once_batch_qwen", fake_batch_qwen)
+
+        cfg = next(iter(mod._REGISTRY.values()))
+        out = mod._retry_subprocess_batch("prompt", cfg, timeout=300)
+        assert out == {"papers": [{"source_path": "/a"}]}
+        assert called == {"sub": 0, "qwen": 1}

--- a/tests/test_dispatch_router.py
+++ b/tests/test_dispatch_router.py
@@ -19,6 +19,7 @@ from nexus.operators.dispatch_router import (
     CLAUDE_OPERATORS_PINNED,
     QWEN_OPERATORS_DEFAULT,
     pick_dispatcher,
+    pick_dispatcher_for,
     pick_dispatcher_for_bundle,
 )
 
@@ -232,3 +233,54 @@ class TestBundleRouting:
         assert (
             pick_dispatcher_for_bundle(["summarize", "compare"]) == "claude"
         )
+
+
+# ── Named call-site routing (non-operator callers) ───────────────────────
+
+
+class TestNamedCallSite:
+    """Per-call-site routing for non-operator ``claude_dispatch`` users.
+
+    ``pick_dispatcher_for`` delegates to ``pick_dispatcher`` — call sites
+    are not in ``QWEN_OPERATORS_DEFAULT`` so the auto-mode unknown-name
+    branch routes them to claude. Pins use the same env vars.
+    """
+
+    def test_default_routes_to_claude(self) -> None:
+        assert pick_dispatcher_for("topic_labeler") == "claude"
+
+    def test_auto_mode_routes_to_claude(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Cautious default: no bench evidence yet for call sites, so
+        # auto-mode still routes them to claude.
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "auto")
+        assert pick_dispatcher_for("topic_labeler") == "claude"
+
+    def test_global_qwen_mode_routes_to_qwen(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "qwen")
+        assert pick_dispatcher_for("topic_labeler") == "qwen"
+
+    def test_qwen_pin_via_operators_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reuse the per-operator env var — semantic is "what to route",
+        # operator vs call site is the same surface.
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "topic_labeler")
+        assert pick_dispatcher_for("topic_labeler") == "qwen"
+
+    def test_claude_pin_overrides_qwen_pin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "topic_labeler")
+        monkeypatch.setenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", "topic_labeler")
+        assert pick_dispatcher_for("topic_labeler") == "claude"
+
+    def test_claude_pin_overrides_global_qwen(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NEXUS_DISPATCH_BACKEND", "qwen")
+        monkeypatch.setenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", "topic_labeler")
+        assert pick_dispatcher_for("topic_labeler") == "claude"

--- a/tests/test_liveness.py
+++ b/tests/test_liveness.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-111 P1.3 (nexus-r0vi): T2 liveness table contract tests.
+
+Tests cover:
+  - Schema: table and index created by migration.
+  - liveness_upsert: idempotent on same PK; last_seen updates.
+  - liveness_sweep: deletes stale rows; returns count; fresh rows survive.
+  - liveness_list: returns all current rows in stable (pid, machine) order.
+  - Fixed-clock injection via optional ``_now`` kwarg to each method.
+"""
+from __future__ import annotations
+
+import socket
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from nexus.db.t2.memory_store import MemoryStore
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+_MACHINE = socket.gethostname()
+_USER = "testuser"
+
+
+def _store(tmp_path: Path) -> MemoryStore:
+    return MemoryStore(tmp_path / "memory.db")
+
+
+# ── Schema ───────────────────────────────────────────────────────────────────
+
+
+class TestSchema:
+    def test_migration_creates_table(self, tmp_path: Path) -> None:
+        import sqlite3 as _sq
+
+        from nexus.db.migrations import migrate_liveness_table
+
+        conn = _sq.connect(str(tmp_path / "memory.db"))
+        try:
+            migrate_liveness_table(conn)
+            tables = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "liveness" in tables
+        finally:
+            conn.close()
+
+    def test_migration_creates_last_seen_index(self, tmp_path: Path) -> None:
+        import sqlite3 as _sq
+
+        from nexus.db.migrations import migrate_liveness_table
+
+        conn = _sq.connect(str(tmp_path / "memory.db"))
+        try:
+            migrate_liveness_table(conn)
+            indexes = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' "
+                    "AND tbl_name='liveness'"
+                ).fetchall()
+            }
+            assert "idx_liveness_last_seen" in indexes
+        finally:
+            conn.close()
+
+    def test_migration_idempotent(self, tmp_path: Path) -> None:
+        import sqlite3 as _sq
+
+        from nexus.db.migrations import migrate_liveness_table
+
+        conn = _sq.connect(str(tmp_path / "memory.db"))
+        try:
+            migrate_liveness_table(conn)
+            migrate_liveness_table(conn)  # second call must not raise
+        finally:
+            conn.close()
+
+    def test_primary_key_is_pid_and_machine(self, tmp_path: Path) -> None:
+        import sqlite3 as _sq
+
+        from nexus.db.migrations import migrate_liveness_table
+
+        conn = _sq.connect(str(tmp_path / "memory.db"))
+        try:
+            migrate_liveness_table(conn)
+            pk_cols = sorted(
+                r[1]
+                for r in conn.execute(
+                    "PRAGMA table_info(liveness)"
+                ).fetchall()
+                if r[5] > 0
+            )
+        finally:
+            conn.close()
+        assert pk_cols == ["machine", "pid"]
+
+    def test_store_init_creates_liveness_table(self, tmp_path: Path) -> None:
+        """MemoryStore.__init__ must create the liveness table."""
+        store = _store(tmp_path)
+        try:
+            tables = {
+                r[0]
+                for r in store.conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "liveness" in tables
+        finally:
+            store.close()
+
+
+# ── Upsert ───────────────────────────────────────────────────────────────────
+
+
+class TestLivenessUpsert:
+    def test_upsert_inserts_row(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        try:
+            store.liveness_upsert(pid=1234, machine=_MACHINE, user_id=_USER)
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        assert len(rows) == 1
+        assert rows[0]["pid"] == 1234
+        assert rows[0]["machine"] == _MACHINE
+        assert rows[0]["user_id"] == _USER
+
+    def test_upsert_optional_fields_stored(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        try:
+            store.liveness_upsert(
+                pid=1234,
+                machine=_MACHINE,
+                user_id=_USER,
+                session="ses-abc",
+                project="myproj",
+                focus="rdr-111",
+                activity="coding",
+            )
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        assert rows[0]["session"] == "ses-abc"
+        assert rows[0]["project"] == "myproj"
+        assert rows[0]["focus"] == "rdr-111"
+        assert rows[0]["activity"] == "coding"
+
+    def test_upsert_idempotent_same_pk(self, tmp_path: Path) -> None:
+        """Same (pid, machine) must REPLACE, not INSERT a second row."""
+        store = _store(tmp_path)
+        t0 = 1_000_000.0
+        t1 = 1_000_030.0
+        try:
+            store.liveness_upsert(pid=42, machine=_MACHINE, user_id=_USER, _now=t0)
+            store.liveness_upsert(pid=42, machine=_MACHINE, user_id=_USER, _now=t1)
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        assert len(rows) == 1
+
+    def test_upsert_updates_last_seen(self, tmp_path: Path) -> None:
+        """Repeated upsert must advance last_seen."""
+        store = _store(tmp_path)
+        t0 = 1_000_000.0
+        t1 = 1_000_030.0
+        try:
+            store.liveness_upsert(pid=42, machine=_MACHINE, user_id=_USER, _now=t0)
+            store.liveness_upsert(pid=42, machine=_MACHINE, user_id=_USER, _now=t1)
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        assert rows[0]["last_seen"] == pytest.approx(t1)
+
+    def test_upsert_distinct_pids_coexist(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        try:
+            store.liveness_upsert(pid=1, machine=_MACHINE, user_id=_USER)
+            store.liveness_upsert(pid=2, machine=_MACHINE, user_id=_USER)
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        assert len(rows) == 2
+
+    def test_upsert_distinct_machines_coexist(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        try:
+            store.liveness_upsert(pid=1, machine="host-a", user_id=_USER)
+            store.liveness_upsert(pid=1, machine="host-b", user_id=_USER)
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        assert len(rows) == 2
+
+
+# ── Sweep ────────────────────────────────────────────────────────────────────
+
+
+class TestLivenessSweep:
+    def test_sweep_removes_stale_rows(self, tmp_path: Path) -> None:
+        """Rows with last_seen more than max_age_seconds ago are deleted."""
+        store = _store(tmp_path)
+        now = 1_000_100.0
+        stale = now - 120  # 120 s ago, older than 60 s threshold
+        try:
+            store.liveness_upsert(pid=1, machine=_MACHINE, user_id=_USER, _now=stale)
+            deleted = store.liveness_sweep(max_age_seconds=60, _now=now)
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        assert deleted == 1
+        assert rows == []
+
+    def test_sweep_preserves_fresh_rows(self, tmp_path: Path) -> None:
+        """Rows within max_age_seconds are not deleted."""
+        store = _store(tmp_path)
+        now = 1_000_100.0
+        fresh = now - 10  # 10 s ago, well within 60 s threshold
+        try:
+            store.liveness_upsert(pid=1, machine=_MACHINE, user_id=_USER, _now=fresh)
+            deleted = store.liveness_sweep(max_age_seconds=60, _now=now)
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        assert deleted == 0
+        assert len(rows) == 1
+
+    def test_sweep_returns_count_of_deleted(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        now = 1_000_200.0
+        stale = now - 90
+        try:
+            store.liveness_upsert(pid=1, machine="h1", user_id=_USER, _now=stale)
+            store.liveness_upsert(pid=2, machine="h2", user_id=_USER, _now=stale)
+            store.liveness_upsert(pid=3, machine="h3", user_id=_USER, _now=now - 5)
+            deleted = store.liveness_sweep(max_age_seconds=60, _now=now)
+        finally:
+            store.close()
+        assert deleted == 2
+
+    def test_sweep_on_empty_table_returns_zero(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        try:
+            deleted = store.liveness_sweep(max_age_seconds=60)
+        finally:
+            store.close()
+        assert deleted == 0
+
+    def test_sweep_default_max_age_is_sixty_seconds(self, tmp_path: Path) -> None:
+        """Default max_age_seconds=60 — row at exactly 61 s is stale."""
+        store = _store(tmp_path)
+        now = 1_000_200.0
+        try:
+            store.liveness_upsert(pid=1, machine=_MACHINE, user_id=_USER, _now=now - 61)
+            deleted = store.liveness_sweep(_now=now)
+        finally:
+            store.close()
+        assert deleted == 1
+
+
+# ── List ─────────────────────────────────────────────────────────────────────
+
+
+class TestLivenessList:
+    def test_list_empty_returns_empty(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        try:
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        assert rows == []
+
+    def test_list_returns_expected_keys(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        try:
+            store.liveness_upsert(pid=1, machine=_MACHINE, user_id=_USER)
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        assert len(rows) == 1
+        r = rows[0]
+        expected_keys = {
+            "pid", "machine", "user_id", "session", "project",
+            "focus", "activity", "last_seen",
+        }
+        assert set(r.keys()) == expected_keys
+
+    def test_list_stable_order_pid_then_machine(self, tmp_path: Path) -> None:
+        """Rows ordered by pid ASC, machine ASC."""
+        store = _store(tmp_path)
+        try:
+            store.liveness_upsert(pid=3, machine="aaa", user_id=_USER)
+            store.liveness_upsert(pid=1, machine="zzz", user_id=_USER)
+            store.liveness_upsert(pid=1, machine="aaa", user_id=_USER)
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        pids = [r["pid"] for r in rows]
+        machines = [r["machine"] for r in rows]
+        assert pids == [1, 1, 3]
+        assert machines == ["aaa", "zzz", "aaa"]
+
+    def test_list_none_fields_for_optional_columns(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        try:
+            store.liveness_upsert(pid=1, machine=_MACHINE, user_id=_USER)
+            rows = store.liveness_list()
+        finally:
+            store.close()
+        r = rows[0]
+        assert r["session"] is None
+        assert r["project"] is None
+        assert r["focus"] is None
+        assert r["activity"] is None

--- a/tests/test_liveness.py
+++ b/tests/test_liveness.py
@@ -10,6 +10,7 @@ Tests cover:
 """
 from __future__ import annotations
 
+import asyncio
 import socket
 import sqlite3
 import time
@@ -319,3 +320,112 @@ class TestLivenessList:
         assert r["project"] is None
         assert r["focus"] is None
         assert r["activity"] is None
+
+
+# ---------------------------------------------------------------------------
+# liveness_delete coverage (nexus-r0vi review fix)
+# ---------------------------------------------------------------------------
+
+
+class TestLivenessDelete:
+    def test_delete_removes_row(self, tmp_path) -> None:
+        from nexus.db.t2.memory_store import MemoryStore
+
+        store = MemoryStore(tmp_path / "memory.db")
+        try:
+            store.liveness_upsert(pid=42, machine=_MACHINE, user_id=_USER)
+            assert len(store.liveness_list()) == 1
+            removed = store.liveness_delete(pid=42, machine=_MACHINE)
+            assert removed == 1
+            assert store.liveness_list() == []
+        finally:
+            store.close()
+
+    def test_delete_missing_row_returns_zero(self, tmp_path) -> None:
+        from nexus.db.t2.memory_store import MemoryStore
+
+        store = MemoryStore(tmp_path / "memory.db")
+        try:
+            removed = store.liveness_delete(pid=999, machine="no-such-machine")
+            assert removed == 0
+        finally:
+            store.close()
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat lifecycle (Important #3 from review): cancellation + error swallow
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatLifecycle:
+    @pytest.mark.asyncio
+    async def test_heartbeat_wakes_on_stop_event_before_full_interval(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The heartbeat task must wake on stop_event.set() rather than
+        after the full 30s sleep, so MCP shutdown does not stall.
+        """
+        from nexus.db.t2.memory_store import MemoryStore
+        from nexus.mcp import core as core_mod
+
+        store = MemoryStore(tmp_path / "memory.db")
+        monkeypatch.setattr(core_mod, "_t2_ctx", lambda: _StoreCtx(store))
+        monkeypatch.setattr(core_mod, "_LIVENESS_INTERVAL_SECONDS", 30.0)
+
+        stop = asyncio.Event()
+        task = asyncio.create_task(core_mod._liveness_heartbeat_task(stop))
+        try:
+            # Yield enough times for the task to enter its first wait window
+            for _ in range(20):
+                await asyncio.sleep(0.01)
+            # At least one upsert must have happened by now (heartbeat reads
+            # os.getpid() internally; we just verify the row was written).
+            import os as _os
+            current_pid = _os.getpid()
+            assert any(r["pid"] == current_pid for r in store.liveness_list())
+            t0 = asyncio.get_running_loop().time()
+            stop.set()
+            await asyncio.wait_for(task, timeout=2.0)
+            elapsed = asyncio.get_running_loop().time() - t0
+            assert elapsed < 1.0, f"task did not wake on stop_event within 1s, took {elapsed:.2f}s"
+        finally:
+            if not task.done():
+                task.cancel()
+            store.close()
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_swallows_internal_errors(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A transient error inside the heartbeat beat must NOT propagate
+        out of the task — the MCP server must survive an unreachable DB.
+        """
+        from nexus.mcp import core as core_mod
+
+        class BrokenCtx:
+            def __enter__(self):
+                raise RuntimeError("simulated DB failure")
+            def __exit__(self, *_a):
+                return False
+
+        monkeypatch.setattr(core_mod, "_t2_ctx", lambda: BrokenCtx())
+
+        stop = asyncio.Event()
+        task = asyncio.create_task(core_mod._liveness_heartbeat_task(stop))
+        # Give the task a chance to hit the failing _t2_ctx at least once
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+        assert not task.done(), "heartbeat task died on internal error"
+        stop.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+
+class _StoreCtx:
+    """Minimal context-manager wrapper to mimic t2_ctx for heartbeat tests."""
+    def __init__(self, store):
+        from types import SimpleNamespace
+        self._db = SimpleNamespace(memory=store)
+    def __enter__(self):
+        return self._db
+    def __exit__(self, *_a):
+        return False

--- a/tests/test_nx_answer.py
+++ b/tests/test_nx_answer.py
@@ -638,7 +638,7 @@ class TestPlanMissPlanner:
             ],
         }
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return fake_plan
 
         with patch.object(_dispatch_mod, "claude_dispatch", fake_dispatch):
@@ -655,7 +655,7 @@ class TestPlanMissPlanner:
         from nexus.mcp.core import _nx_answer_plan_miss
         import nexus.operators.dispatch as _dispatch_mod
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return {"steps": []}
 
         with patch.object(_dispatch_mod, "claude_dispatch", fake_dispatch):
@@ -668,7 +668,7 @@ class TestPlanMissPlanner:
         from nexus.mcp.core import _nx_answer_plan_miss
         import nexus.operators.dispatch as _dispatch_mod
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return {"steps": [
                 {"tool": "mcp__plugin_sn_serena__jet_brains_find_symbol", "args": {}},
             ]}
@@ -686,7 +686,7 @@ class TestPlanMissPlanner:
         from nexus.mcp.core import _nx_answer_plan_miss
         import nexus.operators.dispatch as _dispatch_mod
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return {"steps": [
                 {"tool": "Grep", "args": {}},
                 {"tool": "Read", "args": {}},
@@ -705,7 +705,7 @@ class TestPlanMissPlanner:
         from nexus.mcp.core import _nx_answer_plan_miss
         import nexus.operators.dispatch as _dispatch_mod
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return {"steps": [
                 {"tool": "mcp__plugin_nx_nexus__search", "args": {"query": "$intent"}},
                 {"tool": "summarize", "args": {"inputs": "$step1.ids"}},
@@ -723,7 +723,7 @@ class TestPlanMissPlanner:
         from nexus.mcp.core import _nx_answer_plan_miss
         import nexus.operators.dispatch as _dispatch_mod
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             return {"steps": [
                 {"tool": "search", "args": {"query": "$intent"}},
                 {"tool": "totally_unknown_tool", "args": {}},
@@ -749,7 +749,7 @@ class TestPlanMissPlanner:
 
         dispatch_calls = []
 
-        async def fake_dispatch(prompt, schema, timeout=60.0):
+        async def fake_dispatch(prompt, schema, timeout=60.0, **kwargs):
             dispatch_calls.append(prompt)
             return {"steps": [{"tool": "search", "args": {"query": "$intent"}}]}
 
@@ -2048,3 +2048,71 @@ def test_maybe_unwrap_output_envelope_max_depth_bounded() -> None:
     out = _maybe_unwrap_output_envelope(text, max_depth=3)
     # 3 unwraps from a 4-layer payload leaves one layer remaining.
     assert "core" in out and out.startswith('{')
+
+
+# ── Named call-site routing for the plan-miss planner ───────────────────────
+
+
+class TestPlannerRouting:
+    """The plan-miss planner routes through
+    ``pick_dispatcher_for('plan_miss_planner')``.
+
+    Under default env it still calls ``claude_dispatch`` (preserves
+    byte-for-byte behavior). Under
+    ``NEXUS_DISPATCH_QWEN_OPERATORS=plan_miss_planner`` it calls
+    ``qwen_dispatch`` with the same prompt, schema, and timeout — and
+    tags both calls with ``operator_name='plan_miss_planner'`` for the
+    cost-telemetry log.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_env_calls_claude_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nexus.mcp.core import _nx_answer_plan_miss
+
+        for var in (
+            "NEXUS_DISPATCH_BACKEND",
+            "NEXUS_DISPATCH_QWEN_OPERATORS",
+            "NEXUS_DISPATCH_CLAUDE_OPERATORS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        plan = {"steps": [{"tool": "search", "args": {"query": "$intent"}}]}
+        claude_mock = AsyncMock(return_value=plan)
+        qwen_mock = AsyncMock(return_value=plan)
+        with patch("nexus.operators.dispatch.claude_dispatch", claude_mock), \
+             patch("nexus.operators.qwen_dispatch.qwen_dispatch", qwen_mock):
+            await _nx_answer_plan_miss("how does X work")
+
+        assert claude_mock.called
+        assert not qwen_mock.called
+        kwargs = claude_mock.call_args.kwargs
+        assert kwargs.get("operator_name") == "plan_miss_planner"
+        assert kwargs.get("timeout") == 300.0
+
+    @pytest.mark.asyncio
+    async def test_qwen_pin_routes_to_qwen_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nexus.mcp.core import _nx_answer_plan_miss, _PLANNER_SCHEMA
+
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "plan_miss_planner")
+        monkeypatch.delenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", raising=False)
+        monkeypatch.delenv("NEXUS_DISPATCH_BACKEND", raising=False)
+
+        plan = {"steps": [{"tool": "search", "args": {"query": "$intent"}}]}
+        claude_mock = AsyncMock(return_value=plan)
+        qwen_mock = AsyncMock(return_value=plan)
+        with patch("nexus.operators.dispatch.claude_dispatch", claude_mock), \
+             patch("nexus.operators.qwen_dispatch.qwen_dispatch", qwen_mock):
+            await _nx_answer_plan_miss("how does X work")
+
+        assert qwen_mock.called
+        assert not claude_mock.called
+        args, kwargs = qwen_mock.call_args.args, qwen_mock.call_args.kwargs
+        # First positional is prompt, second is schema.
+        assert "how does X work" in args[0]
+        assert args[1] is _PLANNER_SCHEMA
+        assert kwargs.get("timeout") == 300.0
+        assert kwargs.get("operator_name") == "plan_miss_planner"

--- a/tests/test_operator_dispatch.py
+++ b/tests/test_operator_dispatch.py
@@ -1360,3 +1360,114 @@ class TestOperatorAggregate:
         assert len(result["aggregates"]) == 3
         keys = {a["key_value"] for a in result["aggregates"]}
         assert keys == {"alpha", "beta", "gamma"}
+
+
+# ── Cost telemetry ───────────────────────────────────────────────────────
+
+
+class _LogCapture:
+    """Stand-in for the module ``_log`` that records ``info(event, **kw)`` calls."""
+
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, dict[str, object]]] = []
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.entries.append((event, kwargs))
+
+    def debug(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+    def warning(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+    def error(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+
+def _envelope(
+    total_cost_usd: float | None = 0.0123,
+    input_tokens: int | None = 1200,
+    output_tokens: int | None = 250,
+    structured: dict | None = None,
+) -> bytes:
+    """Build a faked ``claude -p --output-format json`` envelope."""
+    env: dict[str, object] = {
+        "type": "result",
+        "is_error": False,
+        "result": "",
+        "structured_output": structured or {"result": "ok"},
+    }
+    if total_cost_usd is not None:
+        env["total_cost_usd"] = total_cost_usd
+    usage: dict[str, object] = {}
+    if input_tokens is not None:
+        usage["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        usage["output_tokens"] = output_tokens
+    if usage:
+        env["usage"] = usage
+    return json.dumps(env).encode()
+
+
+class TestClaudeDispatchCostTelemetry:
+    """RDR-PR#623 follow-up: surface ``total_cost_usd`` + usage from the
+    claude -p envelope as a structured log entry."""
+
+    @pytest.mark.asyncio
+    async def test_logs_total_cost_and_usage_from_envelope(self) -> None:
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc(stdout=_envelope(
+            total_cost_usd=0.0123, input_tokens=1200, output_tokens=250,
+        ))
+        cap = _LogCapture()
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)), \
+             patch("nexus.operators.dispatch._log", cap):
+            result = await claude_dispatch(
+                "prompt",
+                _SIMPLE_SCHEMA,
+                operator_name="operator_extract",
+            )
+        assert result == {"result": "ok"}
+        cost = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+        assert cost, f"expected operator_dispatch_cost entry; got {cap.entries!r}"
+        _, kw = cost[-1]
+        assert kw["dispatch_engine"] == "claude"
+        assert kw["dispatch_operator"] == "operator_extract"
+        assert kw["dispatch_cost_usd"] == pytest.approx(0.0123)
+        assert kw["dispatch_input_tokens"] == 1200
+        assert kw["dispatch_output_tokens"] == 250
+        assert kw["dispatch_would_have_cost_usd"] is None
+
+    @pytest.mark.asyncio
+    async def test_logs_null_cost_when_total_cost_usd_missing(self) -> None:
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc(stdout=_envelope(total_cost_usd=None))
+        cap = _LogCapture()
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)), \
+             patch("nexus.operators.dispatch._log", cap):
+            await claude_dispatch("p", _SIMPLE_SCHEMA)
+        cost = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+        assert cost
+        _, kw = cost[-1]
+        assert kw["dispatch_cost_usd"] is None
+        # Usage was still present — those should be preserved.
+        assert kw["dispatch_input_tokens"] == 1200
+
+    @pytest.mark.asyncio
+    async def test_logs_null_tokens_when_usage_block_missing(self) -> None:
+        from nexus.operators.dispatch import claude_dispatch
+
+        proc = _make_proc(stdout=_envelope(
+            input_tokens=None, output_tokens=None,
+        ))
+        cap = _LogCapture()
+        with patch("asyncio.create_subprocess_exec", new=AsyncMock(return_value=proc)), \
+             patch("nexus.operators.dispatch._log", cap):
+            await claude_dispatch("p", _SIMPLE_SCHEMA)
+        cost = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+        assert cost
+        _, kw = cost[-1]
+        assert kw["dispatch_input_tokens"] is None
+        assert kw["dispatch_output_tokens"] is None

--- a/tests/test_qwen_dispatch.py
+++ b/tests/test_qwen_dispatch.py
@@ -28,8 +28,11 @@ from nexus.operators.qwen_dispatch import (
     QwenOperatorOutputError,
     QwenOperatorTimeoutError,
     _build_system_prompt,
+    _estimate_sonnet_cost_usd,
     _resolve_backend_url,
     _resolve_model,
+    _SONNET_INPUT_USD_PER_MTOK,
+    _SONNET_OUTPUT_USD_PER_MTOK,
     _strip_code_fences,
     qwen_dispatch,
 )
@@ -291,3 +294,124 @@ async def test_dispatch_raises_on_unexpected_payload_shape() -> None:
     with patch("httpx.AsyncClient.post", fake_post):
         with pytest.raises(QwenOperatorError, match="unexpected response shape"):
             await qwen_dispatch("p", _SCHEMA, backend_url="http://x/v1")
+
+
+# ── Cost telemetry ────────────────────────────────────────────────────────
+
+
+def _chat_completion_with_usage(
+    content: str, prompt_tokens: int, completion_tokens: int
+) -> dict:
+    """OpenAI-compat response with a populated ``usage`` block."""
+    return {
+        "choices": [{"message": {"role": "assistant", "content": content}}],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+
+
+class TestEstimateSonnetCost:
+    def test_rate_card_matches_documented_constants(self) -> None:
+        # If Anthropic publishes a new Sonnet rate card and the constants
+        # change, this test fails loudly and the comment in
+        # qwen_dispatch.py demands a refresh of the date stamp too.
+        assert _SONNET_INPUT_USD_PER_MTOK == 3.0
+        assert _SONNET_OUTPUT_USD_PER_MTOK == 15.0
+
+    def test_estimate_matches_rate_math(self) -> None:
+        # 1_000_000 input tokens → $3, 1_000_000 output → $15, total $18.
+        assert _estimate_sonnet_cost_usd(1_000_000, 1_000_000) == pytest.approx(
+            18.0
+        )
+
+    def test_estimate_scales_linearly(self) -> None:
+        # 1500 input + 500 output:
+        #   1500 * 3 / 1e6  + 500 * 15 / 1e6 = 0.0045 + 0.0075 = 0.012
+        assert _estimate_sonnet_cost_usd(1500, 500) == pytest.approx(0.012)
+
+    def test_estimate_returns_none_when_input_missing(self) -> None:
+        assert _estimate_sonnet_cost_usd(None, 500) is None
+
+    def test_estimate_returns_none_when_output_missing(self) -> None:
+        assert _estimate_sonnet_cost_usd(1500, None) is None
+
+
+class _LogCapture:
+    """Drop-in for the module ``_log``: records each ``info(...)`` call as
+    ``(event, kwargs)``. Avoids depending on whichever structlog bridge
+    (stdlib / PrintLoggerFactory) is configured in the test harness."""
+
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, dict[str, object]]] = []
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.entries.append((event, kwargs))
+
+    def debug(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+    def warning(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+    def error(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+
+@pytest.mark.asyncio
+async def test_dispatch_logs_would_have_cost_when_usage_present() -> None:
+    """qwen_dispatch must emit a structured cost-telemetry log line
+    carrying the would-have-cost estimate derived from the usage block."""
+    fake_post = AsyncMock(
+        return_value=_resp(
+            200,
+            _chat_completion_with_usage(
+                '{"answer":"ok"}', prompt_tokens=2000, completion_tokens=400
+            ),
+        )
+    )
+    cap = _LogCapture()
+    with patch("nexus.operators.qwen_dispatch._log", cap), patch(
+        "httpx.AsyncClient.post", fake_post
+    ):
+        await qwen_dispatch(
+            "p",
+            _SCHEMA,
+            backend_url="http://x/v1",
+            operator_name="operator_summarize",
+        )
+
+    cost_entries = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+    assert cost_entries, f"expected cost log entry; got {cap.entries!r}"
+    _, kw = cost_entries[-1]
+    assert kw["dispatch_engine"] == "qwen"
+    assert kw["dispatch_operator"] == "operator_summarize"
+    assert kw["dispatch_input_tokens"] == 2000
+    assert kw["dispatch_output_tokens"] == 400
+    assert kw["dispatch_cost_usd"] == 0.0
+    # 2000*3/1e6 + 400*15/1e6 = 0.006 + 0.006 = 0.012
+    assert kw["dispatch_would_have_cost_usd"] == pytest.approx(0.012)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_logs_null_cost_when_usage_block_missing() -> None:
+    """Missing usage block must not crash — log with would_have_cost=None."""
+    fake_post = AsyncMock(
+        return_value=_resp(200, _chat_completion('{"answer":"ok"}'))
+    )
+    cap = _LogCapture()
+    with patch("nexus.operators.qwen_dispatch._log", cap), patch(
+        "httpx.AsyncClient.post", fake_post
+    ):
+        result = await qwen_dispatch("p", _SCHEMA, backend_url="http://x/v1")
+    assert result == {"answer": "ok"}
+
+    cost_entries = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+    assert cost_entries
+    _, kw = cost_entries[-1]
+    assert kw["dispatch_input_tokens"] is None
+    assert kw["dispatch_output_tokens"] is None
+    assert kw["dispatch_would_have_cost_usd"] is None
+    assert kw["dispatch_engine"] == "qwen"

--- a/tests/test_rdr_085_glossary_labeler.py
+++ b/tests/test_rdr_085_glossary_labeler.py
@@ -249,3 +249,72 @@ class TestLabelerDispatch:
 
         assert results == []
         assert not dispatched.called
+
+
+# ── Named call-site routing for the labeler ──────────────────────────────────
+
+
+class TestLabelerRouting:
+    """The labeler routes through ``pick_dispatcher_for('topic_labeler')``.
+
+    Under default env it still calls ``claude_dispatch`` (preserves
+    byte-for-byte behavior). Under ``NEXUS_DISPATCH_QWEN_OPERATORS=
+    topic_labeler`` it calls ``qwen_dispatch`` with the same prompt,
+    schema, and timeout — and tags both calls with
+    ``operator_name='topic_labeler'`` for the cost-telemetry log.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_env_calls_claude_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        for var in (
+            "NEXUS_DISPATCH_BACKEND",
+            "NEXUS_DISPATCH_QWEN_OPERATORS",
+            "NEXUS_DISPATCH_CLAUDE_OPERATORS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        claude_mock = AsyncMock(return_value={"labels": [{"idx": 1, "label": "Topic"}]})
+        qwen_mock = AsyncMock(return_value={"labels": []})
+        items = [(["term"], ["doc.pdf:0"])]
+        with patch("nexus.operators.dispatch.claude_dispatch", claude_mock), \
+             patch("nexus.operators.qwen_dispatch.qwen_dispatch", qwen_mock):
+            await taxonomy_cmd._generate_labels_batch(items)
+
+        assert claude_mock.called
+        assert not qwen_mock.called
+        # Telemetry tag passed through.
+        kwargs = claude_mock.call_args.kwargs
+        assert kwargs.get("operator_name") == "topic_labeler"
+        assert kwargs.get("timeout") == 120.0
+
+    @pytest.mark.asyncio
+    async def test_qwen_pin_routes_to_qwen_dispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from nexus.commands import taxonomy_cmd
+
+        monkeypatch.setenv("NEXUS_DISPATCH_QWEN_OPERATORS", "topic_labeler")
+        monkeypatch.delenv("NEXUS_DISPATCH_CLAUDE_OPERATORS", raising=False)
+        monkeypatch.delenv("NEXUS_DISPATCH_BACKEND", raising=False)
+
+        claude_mock = AsyncMock(return_value={"labels": []})
+        qwen_mock = AsyncMock(return_value={"labels": [{"idx": 1, "label": "Topic"}]})
+        items = [(["term"], ["doc.pdf:0"])]
+        with patch("nexus.operators.dispatch.claude_dispatch", claude_mock), \
+             patch("nexus.operators.qwen_dispatch.qwen_dispatch", qwen_mock):
+            results = await taxonomy_cmd._generate_labels_batch(items)
+
+        assert qwen_mock.called
+        assert not claude_mock.called
+        # Same prompt + schema + timeout signature.
+        args, kwargs = qwen_mock.call_args.args, qwen_mock.call_args.kwargs
+        # First positional is prompt, second is schema.
+        assert "1. terms=[term]" in args[0]
+        assert args[1] == taxonomy_cmd._LABEL_SCHEMA
+        assert kwargs.get("timeout") == 120.0
+        assert kwargs.get("operator_name") == "topic_labeler"
+        assert results == ["Topic"]

--- a/tests/test_spike_c_aspect_qwen_parity.py
+++ b/tests/test_spike_c_aspect_qwen_parity.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (c) 2026 Hal Hildebrand. All rights reserved.
+"""Smoke tests for ``scripts/spikes/spike_c_aspect_qwen_parity.py``.
+
+Scope: the pure-function diff layer (``diff_records`` + the per-bucket
+agreement helpers) and the summary aggregator. The end-to-end
+``_run_one`` path that toggles ``NEXUS_ASPECT_BACKEND`` and calls
+``extract_aspects`` is NOT exercised here — it requires a live backend
+and a real corpus. The intent is to lock down the diff contract so a
+parity report cannot silently misclassify field agreements.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPIKE_DIR = REPO_ROOT / "scripts" / "spikes"
+sys.path.insert(0, str(SPIKE_DIR))
+
+from nexus.aspect_extractor import AspectRecord, ExtractFail  # noqa: E402
+
+import spike_c_aspect_qwen_parity as spike  # noqa: E402
+
+
+def _rec(**overrides) -> AspectRecord:
+    """Factory: an AspectRecord with sane defaults the test overrides."""
+    base = dict(
+        collection="knowledge__test",
+        source_path="/p/x.pdf",
+        problem_formulation="The paper addresses problem X in domain Y.",
+        proposed_method="We propose a method using technique Z.",
+        experimental_datasets=["MNIST", "CIFAR-10"],
+        experimental_baselines=["ResNet", "VGG"],
+        experimental_results="Achieves 95% accuracy, beating baselines.",
+        extras={},
+        confidence=0.9,
+        extracted_at="2026-05-14T00:00:00+00:00",
+        model_version="claude-haiku-4-5-20251001",
+        extractor_name="scholarly-paper-v1",
+    )
+    base.update(overrides)
+    return AspectRecord(**base)
+
+
+class TestAgreeHelpers:
+    def test_strict_normalises_whitespace_and_case(self) -> None:
+        assert spike._agree_strict("  Foo  Bar ", "foo bar")
+        assert not spike._agree_strict("foo", "bar")
+
+    def test_set_is_order_insensitive(self) -> None:
+        assert spike._agree_set(["a", "b"], ["b", "a"])
+        assert not spike._agree_set(["a"], ["a", "b"])
+        assert spike._agree_set([], [])
+
+    def test_prose_both_none_agrees(self) -> None:
+        assert spike._agree_prose(None, None)
+
+    def test_prose_one_empty_disagrees(self) -> None:
+        assert not spike._agree_prose("hello", "")
+        assert not spike._agree_prose(None, "x")
+
+    def test_prose_similar_length_agrees(self) -> None:
+        a = "x" * 100
+        b = "y" * 80
+        assert spike._agree_prose(a, b)  # 80/100 = 0.8 >= 0.5
+
+    def test_prose_wildly_different_length_disagrees(self) -> None:
+        a = "x" * 10
+        b = "y" * 100
+        assert not spike._agree_prose(a, b)  # 10/100 = 0.1 < 0.5
+
+
+class TestDiffRecords:
+    def test_both_aspect_records_full_agreement(self) -> None:
+        r = _rec()
+        out = spike.diff_records(r, _rec())
+        assert out["both_ok"] is True
+        assert out["claude_ok"] and out["qwen_ok"]
+        # All diffed fields agree.
+        for f in spike.ALL_DIFFED_FIELDS:
+            assert out["agreement"][f] is True, f
+
+    def test_partial_disagreement(self) -> None:
+        c = _rec()
+        q = _rec(
+            experimental_datasets=["MNIST"],  # set mismatch
+            problem_formulation="x",  # prose length ratio fails
+        )
+        out = spike.diff_records(c, q)
+        assert out["both_ok"]
+        assert out["agreement"]["experimental_datasets"] is False
+        assert out["agreement"]["problem_formulation"] is False
+        # Untouched fields still agree.
+        assert out["agreement"]["experimental_baselines"] is True
+        assert out["agreement"]["proposed_method"] is True
+
+    def test_one_side_extractfail_marks_all_disagree(self) -> None:
+        c = _rec()
+        q = ExtractFail(uri="chroma://x/y", reason="unreachable", detail="d")
+        out = spike.diff_records(c, q)
+        assert out["both_ok"] is False
+        assert out["claude_ok"] is True
+        assert out["qwen_ok"] is False
+        assert out["claude_kind"] == "AspectRecord"
+        assert out["qwen_kind"] == "ExtractFail"
+        for f in spike.ALL_DIFFED_FIELDS:
+            assert out["agreement"][f] is False
+
+    def test_both_none_marks_all_disagree(self) -> None:
+        # ``None`` means "no extractor registered" — symmetric but not
+        # a parity agreement (no records to compare).
+        out = spike.diff_records(None, None)
+        assert out["both_ok"] is False
+        for f in spike.ALL_DIFFED_FIELDS:
+            assert out["agreement"][f] is False
+
+
+class TestSummarize:
+    def test_aggregates_field_rates_and_medians(self) -> None:
+        records = [
+            {
+                "both_ok": True,
+                "claude_ok": True,
+                "qwen_ok": True,
+                "claude_elapsed_ms": 1000.0,
+                "qwen_elapsed_ms": 500.0,
+                "agreement": {f: True for f in spike.ALL_DIFFED_FIELDS},
+            },
+            {
+                "both_ok": True,
+                "claude_ok": True,
+                "qwen_ok": True,
+                "claude_elapsed_ms": 2000.0,
+                "qwen_elapsed_ms": 700.0,
+                "agreement": {
+                    **{f: True for f in spike.ALL_DIFFED_FIELDS},
+                    "problem_formulation": False,
+                },
+            },
+            {
+                "both_ok": False,
+                "claude_ok": True,
+                "qwen_ok": False,
+                "claude_elapsed_ms": 1500.0,
+                "qwen_elapsed_ms": 100.0,
+                "agreement": {f: False for f in spike.ALL_DIFFED_FIELDS},
+            },
+        ]
+        s = spike._summarize(records)
+        assert s["total"] == 3
+        assert s["both_ok"] == 2
+        assert s["claude_ok_rate"] == pytest.approx(1.0)
+        assert s["qwen_ok_rate"] == pytest.approx(2 / 3)
+        # problem_formulation: 1/2 agreement in both_ok subset.
+        assert s["field_agreement"]["problem_formulation"]["rate"] == pytest.approx(0.5)
+        assert s["field_agreement"]["problem_formulation"]["n"] == 2
+        # Median of [1000, 2000, 1500] = 1500.
+        assert s["claude_median_ms"] == 1500.0
+
+
+class TestMarkdownRender:
+    def test_renders_table_with_all_fields(self) -> None:
+        records = [
+            {
+                "both_ok": True,
+                "claude_ok": True,
+                "qwen_ok": True,
+                "claude_elapsed_ms": 1000.0,
+                "qwen_elapsed_ms": 500.0,
+                "agreement": {f: True for f in spike.ALL_DIFFED_FIELDS},
+            },
+        ]
+        s = spike._summarize(records)
+        md = spike._render_md(s, Path("/tmp/out.jsonl"))
+        assert "Spike C" in md
+        for f in spike.ALL_DIFFED_FIELDS:
+            assert f"`{f}`" in md


### PR DESCRIPTION
## Summary

- **T2 liveness table** via `migrate_liveness_table` at version 4.35.0; DDL per bead spec (`pid`, `machine`, `user_id`, `session`, `project`, `focus`, `activity`, `last_seen REAL`; PK `(pid, machine)`; index on `last_seen`).
- **MemoryStore methods**: `liveness_upsert`, `liveness_sweep` (returns deleted count), `liveness_list` (stable `pid ASC, machine ASC` order); all accept optional `_now: float` for deterministic test clock injection.
- **MCP heartbeat**: `_combined_lifespan` wraps `_t1_chroma_lifespan`; starts `_liveness_heartbeat_task` via `asyncio.create_task`; upserts+sweeps every 30 s; best-effort deletes row on clean shutdown. Routes through `_t2_ctx` (storage-mode compat).
- **`nx instances` CLI**: human table + `--json` + `--sweep` flags; stale rows marked with `*`; documented in `docs/cli-reference.md`.
- **20 tests** in `tests/test_liveness.py`: schema idempotence, PK columns, upsert REPLACE semantics, sweep selectivity + return count, list ordering, None optionals.

## Coordination

Migration version 4.35.0. nexus-7ejx has the reserved 4.34.0 slot; on merge/rebase their entry slots before ours naturally.

## Storage-mode dispatch pattern (precedent for nexus-pce1.6)

Both the MCP heartbeat and `nx instances` CLI route through `mcp_infra.t2_ctx()` which is the storage-mode seam (RDR-112 P0.4). Direct mode: calls local `MemoryStore.liveness_*` methods. Daemon mode: `t2_ctx()` returns the RPC client facade whose `memory` attribute exposes the same method names via the introspection-based RPC dispatch from nexus-qy0u. No direct `sqlite3.connect(memory.db)` from client code.

## Test plan

- [x] `uv run pytest tests/test_liveness.py` -- 20/20 passed
- [x] `uv run pytest tests/test_t2.py tests/test_t2_concurrency.py tests/test_migrations.py tests/test_memory.py` -- 287/287 passed
- [x] `uv run pytest tests/test_plugin_structure.py` -- 580 passed, 26 skipped
- [x] `nx instances --help` rendered correctly via click test runner

## Closes

Closes nexus-r0vi