### PR TITLE
feat(rdr-111): hook-to-tuple bridge + 7 per-hook-type scripts (nexus-y0nb)

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -719,3 +719,11 @@
 {"id":"int-51a935be","kind":"field_change","created_at":"2026-05-15T01:27:17.712002Z","actor":"Hellblazer","issue_id":"nexus-pce1.1","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-a2ea45d4","kind":"field_change","created_at":"2026-05-15T01:28:33.774721Z","actor":"Hellblazer","issue_id":"nexus-x98k","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-8580fc36","kind":"field_change","created_at":"2026-05-15T01:28:34.331862Z","actor":"Hellblazer","issue_id":"nexus-08i1","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-ef896e09","kind":"field_change","created_at":"2026-05-15T01:38:52.286005Z","actor":"Hellblazer","issue_id":"nexus-x98k","extra":{"field":"status","new_value":"closed","old_value":"in_progress"}}
+{"id":"int-2f2fec66","kind":"field_change","created_at":"2026-05-15T01:59:00.126601Z","actor":"Hellblazer","issue_id":"nexus-08i1","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-4b1b3c69","kind":"field_change","created_at":"2026-05-15T02:04:15.880751Z","actor":"Hellblazer","issue_id":"nexus-52lb","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-7385a2b5","kind":"field_change","created_at":"2026-05-15T02:17:20.885518Z","actor":"Hellblazer","issue_id":"nexus-52lb","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-9b79b1ee","kind":"field_change","created_at":"2026-05-15T03:17:01.542457Z","actor":"Hellblazer","issue_id":"nexus-5krl","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-9e06d326","kind":"field_change","created_at":"2026-05-15T03:40:14.642602Z","actor":"Hellblazer","issue_id":"nexus-7ejx","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-3021c53c","kind":"field_change","created_at":"2026-05-15T03:40:15.28046Z","actor":"Hellblazer","issue_id":"nexus-r0vi","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
+{"id":"int-9425d5bb","kind":"field_change","created_at":"2026-05-15T03:40:15.892444Z","actor":"Hellblazer","issue_id":"nexus-y0nb","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md
+++ b/docs/rdr/rdr-111-orb-agentic-cockpit-substrate.md
@@ -268,7 +268,7 @@ issues; no production hook in this repo reads them yet.
 |---|---|---|
 | `PreToolUse` | `tool_name`, `tool_input` (object with tool args, e.g. `command`, `file_path`) | **Required**: `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"\|"block", "additionalContext": "..."}}` — malformed output blocks tool calls |
 | `PostToolUse` | `tool_name`, `tool_input`, `tool_response` (tool output, any JSON type) | `{"hookSpecificOutput": {"hookEventName": "PostToolUse", "permissionDecision": "allow", "additionalContext": "..."}}` — advisory, never blocks |
-| `PermissionRequest` | `tool_name` | **Required**: `{"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": "allow"}}}` — malformed output blocks tool |
+| `PermissionRequest` | `tool_name` | **Required**: `{"hookSpecificOutput": {"hookEventName": "PermissionRequest", "permissionDecision": "allow"}}` — malformed output blocks tool. (Earlier draft used `decision.behavior`; `permissionDecision` is consistent with the §Required-response lines further down and matches CC 2.1.x runtime behaviour.) |
 | `Stop` | `stop_hook_active` (bool) | `{"decision": "approve", "reason": "..."}` — top-level `decision`, NOT `hookSpecificOutput` |
 | `StopFailure` | `error` (type string: rate_limit \| authentication_failed \| billing_error \| invalid_request \| server_error \| max_output_tokens \| unknown), `error_details` (string), `last_assistant_message` | Output **ignored** by harness; side-effects only |
 | `SubagentStart` | `task` (description), `prompt` (agent prompt text) | `{"hookSpecificOutput": {"hookEventName": "SubagentStart", "additionalContext": "..."}}` — injected into subagent context |
@@ -421,7 +421,10 @@ Each script:
 2. Maps to the appropriate subspace + dimensions + `match_text`
 3. Calls `out` on the tuple space (skipped if `CLAUDECODE` not set — RF-5)
 4. Emits the correct stdout for that hook type (RF-2):
-   - `PreToolUse` / `PermissionRequest`: emit transparent `allow` JSON
+   - `PermissionRequest`: emit transparent `allow` JSON (`permissionDecision: allow`)
+   - `PreToolUse`: emit nothing (observe-only — CA-8 spike resolved 2026-05-14:
+     allow-wins regardless of ordering, so the bridge stays silent to avoid
+     locking in a stance)
    - `SubagentStart`: emit no stdout (bridge registered first; existing hook follows)
    - `Stop` / `StopFailure` / `SessionEnd`: emit nothing
 5. Exits 0 unconditionally — bridge errors are logged to stderr, never propagated

--- a/nx/hooks/hooks.json
+++ b/nx/hooks/hooks.json
@@ -2,11 +2,21 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/orb_bridge_session.py SessionStart",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
             "type": "command",
-            "command": "nx upgrade --auto 2>/dev/null || echo 'nx plugin requires conexus >= 4.2.0 — run: uv tool upgrade conexus' >&2",
+            "command": "nx upgrade --auto 2>/dev/null || echo 'nx plugin requires conexus >= 4.2.0 -- run: uv tool upgrade conexus' >&2",
             "timeout": 30
           },
           {
@@ -43,6 +53,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/orb_bridge_session.py SessionEnd",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
             "command": "nx-session-end-launcher",
             "timeout": 3
           }
@@ -68,6 +88,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/orb_bridge_stop.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
             "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/stop_failure_hook.py",
             "timeout": 5
           }
@@ -86,7 +116,29 @@
         ]
       }
     ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/orb_bridge_subagent_stop.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/orb_bridge_stop.py",
+            "timeout": 5
+          }
+        ]
+      },
       {
         "matcher": "",
         "hooks": [
@@ -100,6 +152,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/orb_bridge_pretooluse.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
@@ -112,12 +174,46 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/orb_bridge_posttooluse.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit",
         "hooks": [
           {
             "type": "command",
             "command": "bash $CLAUDE_PLUGIN_ROOT/hooks/scripts/divergence-language-guard.sh",
             "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/orb_bridge_user_prompt_submit.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PLUGIN_ROOT/hooks/scripts/_run_python_hook.sh $CLAUDE_PLUGIN_ROOT/hooks/scripts/orb_bridge_notification.py",
+            "timeout": 5
           }
         ]
       }

--- a/nx/hooks/scripts/orb_bridge_notification.py
+++ b/nx/hooks/scripts/orb_bridge_notification.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""ORB bridge: Notification -> hook_events/notification (RDR-111 §Step 2).
+
+CA-6 spike (2026-05-14): verified payload -- message, notification_type,
+session_id, cwd, hook_event_name. Reliable trigger is idle-wait (~60-90s),
+NOT permission prompts (CC 2.1.x auto-allows safe tools). The bridge uses
+the message text as match_text for semantic search.
+
+Output is ignored by Claude Code for Notification hooks.
+
+RF-5: all tuplespace side-effects are skipped when CLAUDECODE is not set.
+Errors are logged to stderr only; the script always exits 0.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx hook bridge requires Python 3.12+, got {sys.version.split()[0]}\n"
+    )
+    sys.exit(0)
+
+_HOOK_TYPE = "Notification"
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"[orb-bridge-notification] malformed JSON: {exc}\n")
+        payload = {}
+
+    try:
+        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+
+        configure_logging_to_stderr()
+        emit(_HOOK_TYPE, payload)
+
+        out = output_for_hook(_HOOK_TYPE)
+        if out is not None:
+            sys.stdout.write(out)
+            sys.stdout.flush()
+    except Exception as exc:
+        sys.stderr.write(f"[orb-bridge-notification] error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/nx/hooks/scripts/orb_bridge_posttooluse.py
+++ b/nx/hooks/scripts/orb_bridge_posttooluse.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""ORB bridge: PostToolUse -> hook_events/tool_call_completed (RDR-111 §Step 2).
+
+Observe-only. Output is ignored by Claude Code; the bridge writes its tuple
+as a side effect.
+
+RF-5: all tuplespace side-effects are skipped when CLAUDECODE is not set.
+Errors are logged to stderr only; the script always exits 0.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx hook bridge requires Python 3.12+, got {sys.version.split()[0]}\n"
+    )
+    sys.exit(0)
+
+_HOOK_TYPE = "PostToolUse"
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"[orb-bridge-posttooluse] malformed JSON: {exc}\n")
+        payload = {}
+
+    try:
+        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+
+        configure_logging_to_stderr()
+        emit(_HOOK_TYPE, payload)
+
+        out = output_for_hook(_HOOK_TYPE)
+        if out is not None:
+            sys.stdout.write(out)
+            sys.stdout.flush()
+    except Exception as exc:
+        sys.stderr.write(f"[orb-bridge-posttooluse] error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/nx/hooks/scripts/orb_bridge_pretooluse.py
+++ b/nx/hooks/scripts/orb_bridge_pretooluse.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""ORB bridge: PreToolUse -> hook_events/tool_call_intent (RDR-111 §Step 2).
+
+Observe-only per CA-8 spike (2026-05-14): both hooks fire on every invocation
+regardless of registration order; allow-wins. The bridge writes its tuple as
+a side effect and emits no stdout, leaving permission decisions to the user's
+allowlist and other installed hooks.
+
+RF-5: all tuplespace side-effects are skipped when CLAUDECODE is not set.
+Errors are logged to stderr only; the script always exits 0.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx hook bridge requires Python 3.12+, got {sys.version.split()[0]}\n"
+    )
+    sys.exit(0)  # always exit 0
+
+_HOOK_TYPE = "PreToolUse"
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"[orb-bridge-pretooluse] malformed JSON: {exc}\n")
+        payload = {}
+
+    try:
+        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+
+        configure_logging_to_stderr()
+        emit(_HOOK_TYPE, payload)
+
+        out = output_for_hook(_HOOK_TYPE)
+        if out is not None:
+            sys.stdout.write(out)
+            sys.stdout.flush()
+    except Exception as exc:
+        sys.stderr.write(f"[orb-bridge-pretooluse] error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/nx/hooks/scripts/orb_bridge_session.py
+++ b/nx/hooks/scripts/orb_bridge_session.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""ORB bridge: SessionStart + SessionEnd -> hook_events/session_lifecycle (RDR-111 §Step 2).
+
+Handles both SessionStart and SessionEnd hook types (both map to
+session_lifecycle, per RDR-111 §Step 2 rationale: both represent a session
+turn boundary).
+
+The hook_type is inferred from the payload's ``hook_event_name`` field,
+with a fallback to the argv[1] (hook-type arg from hooks.json).
+
+SessionEnd emits no stdout (output ignored by Claude Code).
+SessionStart also emits no stdout (observe-only).
+
+RF-5: all tuplespace side-effects are skipped when CLAUDECODE is not set.
+Errors are logged to stderr only; the script always exits 0.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx hook bridge requires Python 3.12+, got {sys.version.split()[0]}\n"
+    )
+    sys.exit(0)
+
+_SUPPORTED = frozenset({"SessionStart", "SessionEnd"})
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"[orb-bridge-session] malformed JSON: {exc}\n")
+        payload = {}
+
+    # Infer hook type from payload or argv[1]
+    hook_type = payload.get("hook_event_name", "")
+    if hook_type not in _SUPPORTED and len(sys.argv) > 1:
+        hook_type = sys.argv[1]
+    if hook_type not in _SUPPORTED:
+        hook_type = "SessionStart"
+
+    try:
+        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+
+        configure_logging_to_stderr()
+        emit(hook_type, payload)
+
+        out = output_for_hook(hook_type)
+        if out is not None:
+            sys.stdout.write(out)
+            sys.stdout.flush()
+    except Exception as exc:
+        sys.stderr.write(f"[orb-bridge-session] error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/nx/hooks/scripts/orb_bridge_stop.py
+++ b/nx/hooks/scripts/orb_bridge_stop.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""ORB bridge: Stop + StopFailure -> hook_events/assistant_turn_ended (RDR-111 §Step 2).
+
+Handles both Stop and StopFailure hook types (both map to assistant_turn_ended).
+Output is ignored by Claude Code for Stop/StopFailure; the bridge writes its
+tuple as a side effect.
+
+The hook_type is inferred from the payload's ``hook_event_name`` field.
+
+RF-5: all tuplespace side-effects are skipped when CLAUDECODE is not set.
+Errors are logged to stderr only; the script always exits 0.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx hook bridge requires Python 3.12+, got {sys.version.split()[0]}\n"
+    )
+    sys.exit(0)
+
+_SUPPORTED = frozenset({"Stop", "StopFailure"})
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"[orb-bridge-stop] malformed JSON: {exc}\n")
+        payload = {}
+
+    hook_type = payload.get("hook_event_name", "Stop")
+    if hook_type not in _SUPPORTED:
+        hook_type = "Stop"
+
+    try:
+        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+
+        configure_logging_to_stderr()
+        emit(hook_type, payload)
+
+        out = output_for_hook(hook_type)
+        if out is not None:
+            sys.stdout.write(out)
+            sys.stdout.flush()
+    except Exception as exc:
+        sys.stderr.write(f"[orb-bridge-stop] error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/nx/hooks/scripts/orb_bridge_subagent_stop.py
+++ b/nx/hooks/scripts/orb_bridge_subagent_stop.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""ORB bridge: SubagentStop -> hook_events/agent_completed (RDR-111 §Step 2).
+
+CA-6 spike (2026-05-14): SubagentStop payload is significantly richer than
+the original RF-1 inference -- includes agent_id, agent_type, effort.level,
+last_assistant_message, agent_transcript_path. The bridge uses
+last_assistant_message as match_text for semantic search.
+
+RF-5: all tuplespace side-effects are skipped when CLAUDECODE is not set.
+Errors are logged to stderr only; the script always exits 0.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx hook bridge requires Python 3.12+, got {sys.version.split()[0]}\n"
+    )
+    sys.exit(0)
+
+_HOOK_TYPE = "SubagentStop"
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"[orb-bridge-subagent-stop] malformed JSON: {exc}\n")
+        payload = {}
+
+    try:
+        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+
+        configure_logging_to_stderr()
+        emit(_HOOK_TYPE, payload)
+
+        out = output_for_hook(_HOOK_TYPE)
+        if out is not None:
+            sys.stdout.write(out)
+            sys.stdout.flush()
+    except Exception as exc:
+        sys.stderr.write(f"[orb-bridge-subagent-stop] error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/nx/hooks/scripts/orb_bridge_user_prompt_submit.py
+++ b/nx/hooks/scripts/orb_bridge_user_prompt_submit.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""ORB bridge: UserPromptSubmit -> hook_events/user_prompt (RDR-111 §Step 2).
+
+CA-6 spike (2026-05-14): verified payload shape -- prompt, session_id, cwd,
+permission_mode, hook_event_name. The bridge uses the prompt text as match_text
+for semantic search.
+
+Observe-only: bridge emits no output, leaving UserPromptSubmit's optional
+additionalContext injection to other hooks.
+
+RF-5: all tuplespace side-effects are skipped when CLAUDECODE is not set.
+Errors are logged to stderr only; the script always exits 0.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+if sys.version_info < (3, 12):
+    sys.stderr.write(
+        f"ERROR: nx hook bridge requires Python 3.12+, got {sys.version.split()[0]}\n"
+    )
+    sys.exit(0)
+
+_HOOK_TYPE = "UserPromptSubmit"
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"[orb-bridge-user-prompt-submit] malformed JSON: {exc}\n")
+        payload = {}
+
+    try:
+        from nexus.cockpit.hook_bridge import configure_logging_to_stderr, emit, output_for_hook
+
+        configure_logging_to_stderr()
+        emit(_HOOK_TYPE, payload)
+
+        out = output_for_hook(_HOOK_TYPE)
+        if out is not None:
+            sys.stdout.write(out)
+            sys.stdout.flush()
+    except Exception as exc:
+        sys.stderr.write(f"[orb-bridge-user-prompt-submit] error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/nx/tuplespace/builtin/hooks/hook_events_agent_completed.yml
+++ b/nx/tuplespace/builtin/hooks/hook_events_agent_completed.yml
@@ -1,0 +1,23 @@
+# RDR-111 hook-event subspace: SubagentStop -> agent_completed
+# Registered via nexus-78mh (CA-9 coordination).
+# Bridge: nx/hooks/scripts/orb_bridge_subagent_stop.py
+name: hook_events/agent_completed
+tier: session
+content_type: text
+embed_from: match_text
+dimensions:
+  actor:     { type: string, required: true }
+  session:   { type: string, required: true }
+  project:   { type: string, required: true }
+  timestamp: { type: string, required: true }
+  workflow:  { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 20
+tiers: [session]
+retention_seconds: 86400

--- a/nx/tuplespace/builtin/hooks/hook_events_assistant_turn_ended.yml
+++ b/nx/tuplespace/builtin/hooks/hook_events_assistant_turn_ended.yml
@@ -1,0 +1,23 @@
+# RDR-111 hook-event subspace: Stop + StopFailure -> assistant_turn_ended
+# Registered via nexus-78mh (CA-9 coordination).
+# Bridge: nx/hooks/scripts/orb_bridge_stop.py
+name: hook_events/assistant_turn_ended
+tier: session
+content_type: text
+embed_from: match_text
+dimensions:
+  actor:     { type: string, required: true }
+  session:   { type: string, required: true }
+  project:   { type: string, required: true }
+  timestamp: { type: string, required: true }
+  intent:    { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 20
+tiers: [session]
+retention_seconds: 86400

--- a/nx/tuplespace/builtin/hooks/hook_events_notification.yml
+++ b/nx/tuplespace/builtin/hooks/hook_events_notification.yml
@@ -1,0 +1,23 @@
+# RDR-111 hook-event subspace: Notification -> notification
+# Registered via nexus-78mh (CA-9 coordination).
+# Bridge: nx/hooks/scripts/orb_bridge_notification.py
+name: hook_events/notification
+tier: session
+content_type: text
+embed_from: match_text
+dimensions:
+  actor:     { type: string, required: true }
+  session:   { type: string, required: true }
+  project:   { type: string, required: true }
+  timestamp: { type: string, required: true }
+  intent:    { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 20
+tiers: [session]
+retention_seconds: 86400

--- a/nx/tuplespace/builtin/hooks/hook_events_session_lifecycle.yml
+++ b/nx/tuplespace/builtin/hooks/hook_events_session_lifecycle.yml
@@ -1,0 +1,23 @@
+# RDR-111 hook-event subspace: SessionStart + SessionEnd -> session_lifecycle
+# Registered via nexus-78mh (CA-9 coordination).
+# Bridge: nx/hooks/scripts/orb_bridge_session.py
+name: hook_events/session_lifecycle
+tier: session
+content_type: text
+embed_from: match_text
+dimensions:
+  actor:     { type: string, required: true }
+  session:   { type: string, required: true }
+  project:   { type: string, required: true }
+  timestamp: { type: string, required: true }
+  workflow:  { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 20
+tiers: [session]
+retention_seconds: 86400

--- a/nx/tuplespace/builtin/hooks/hook_events_tool_call_completed.yml
+++ b/nx/tuplespace/builtin/hooks/hook_events_tool_call_completed.yml
@@ -1,0 +1,23 @@
+# RDR-111 hook-event subspace: PostToolUse -> tool_call_completed
+# Registered via nexus-78mh (CA-9 coordination).
+# Bridge: nx/hooks/scripts/orb_bridge_posttooluse.py
+name: hook_events/tool_call_completed
+tier: session
+content_type: text
+embed_from: match_text
+dimensions:
+  actor:     { type: string, required: true }
+  session:   { type: string, required: true }
+  project:   { type: string, required: true }
+  timestamp: { type: string, required: true }
+  tool:      { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 20
+tiers: [session]
+retention_seconds: 86400

--- a/nx/tuplespace/builtin/hooks/hook_events_tool_call_intent.yml
+++ b/nx/tuplespace/builtin/hooks/hook_events_tool_call_intent.yml
@@ -1,0 +1,23 @@
+# RDR-111 hook-event subspace: PreToolUse -> tool_call_intent
+# Registered via nexus-78mh (CA-9 coordination).
+# Bridge: nx/hooks/scripts/orb_bridge_pretooluse.py
+name: hook_events/tool_call_intent
+tier: session
+content_type: text
+embed_from: match_text
+dimensions:
+  actor:     { type: string, required: true }
+  session:   { type: string, required: true }
+  project:   { type: string, required: true }
+  timestamp: { type: string, required: true }
+  tool:      { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 20
+tiers: [session]
+retention_seconds: 86400

--- a/nx/tuplespace/builtin/hooks/hook_events_user_prompt.yml
+++ b/nx/tuplespace/builtin/hooks/hook_events_user_prompt.yml
@@ -1,0 +1,23 @@
+# RDR-111 hook-event subspace: UserPromptSubmit -> user_prompt
+# Registered via nexus-78mh (CA-9 coordination).
+# Bridge: nx/hooks/scripts/orb_bridge_user_prompt_submit.py
+name: hook_events/user_prompt
+tier: session
+content_type: text
+embed_from: match_text
+dimensions:
+  actor:     { type: string, required: true }
+  session:   { type: string, required: true }
+  project:   { type: string, required: true }
+  timestamp: { type: string, required: true }
+  priority:  { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 20
+tiers: [session]
+retention_seconds: 86400

--- a/src/nexus/cockpit/__init__.py
+++ b/src/nexus/cockpit/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Nexus cockpit — observability bridge for Claude Code hook events (RDR-111)."""

--- a/src/nexus/cockpit/hook_bridge.py
+++ b/src/nexus/cockpit/hook_bridge.py
@@ -290,33 +290,16 @@ def _emit_direct_auto(
 
 
 def _load_registry_with_hooks(builtin_dir: Path) -> "Registry":
-    """Load the registry, merging in hook-event YAMLs from a ``hooks`` subdir.
+    """Load the registry, including the hook-event subdir.
 
-    The main registry only globs ``*.yml`` from its top-level dir. The
-    hook-event schemas (nexus-78mh) land in ``<builtin_dir>/hooks/``. This
-    helper merges them in without modifying the main registry loader.
+    Delegates to ``Registry.load(builtin_dir, subdirs=("hooks",))`` so the
+    hook-event YAMLs in ``<builtin_dir>/hooks/`` participate in the same
+    duplicate-name guard and ``_compile_template`` flow as top-level YAMLs.
+    No private-attribute access.
     """
-    from nexus.tuplespace.registry import Registry, _load_one
+    from nexus.tuplespace.registry import Registry
 
-    registry = Registry.load(builtin_dir)
-
-    hooks_subdir = builtin_dir / "hooks"
-    if hooks_subdir.is_dir():
-        for yml_path in sorted(hooks_subdir.glob("*.yml")):
-            try:
-                schema = _load_one(yml_path)
-                if schema.name not in registry._by_template:
-                    from nexus.tuplespace.registry import _compile_template
-                    registry._by_template[schema.name] = schema
-                    registry._matchers.append((_compile_template(schema.name), schema))
-            except Exception as exc:
-                _log.warning(
-                    "hook_bridge_hooks_yaml_load_error",
-                    path=str(yml_path),
-                    error=str(exc),
-                )
-
-    return registry
+    return Registry.load(builtin_dir, subdirs=("hooks",))
 
 
 def _direct_out(

--- a/src/nexus/cockpit/hook_bridge.py
+++ b/src/nexus/cockpit/hook_bridge.py
@@ -1,0 +1,432 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Hook-to-tuple bridge: shared library for the seven orb_bridge_*.py scripts.
+
+Implements RDR-111 §Step 2. Each Claude Code hook type maps to a distinct
+tuplespace subspace. Hook scripts call ``emit()`` to post an event tuple and
+``output_for_hook()`` to get the correct stdout for that hook type.
+
+Key design decisions (backed by RDR-111 spike results):
+
+- **PreToolUse is observe-only** (CA-8 spike, 2026-05-14): emitting
+  ``permissionDecision`` is not needed — allow-wins regardless of hook
+  registration order. The bridge writes its tuple as a side effect and
+  emits no stdout, leaving permission decisions to the user's allowlist
+  and other installed hooks.
+
+- **PermissionRequest needs explicit allow**: unlike PreToolUse, a
+  PermissionRequest hook that emits no output may be treated as a block.
+  The bridge emits a transparent allow for PermissionRequest.
+
+- **Daemon-mode routing deferred** (nexus-pce1.6): ``emit()`` currently
+  dispatches in ``direct`` mode only (opens tuples.db directly via
+  ``api.out``). When the RDR-112 daemon ships a ``tuplespace.out`` RPC
+  the bridge can route through ``T2Client.call("tuplespace.out", ...)``
+  instead. The ``_ROUTING_TBA`` constant documents this deferral.
+
+- **RF-5 gate**: all tuplespace side-effects are skipped when the
+  ``CLAUDECODE`` environment variable is absent. The hook scripts still
+  produce correct stdout (transparent allow where applicable) regardless
+  of the gate -- RF-5 is about not contaminating non-Claude environments
+  with tuples, not about silencing the output that Claude Code relies on.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+import structlog
+
+if TYPE_CHECKING:
+    from nexus.tuplespace.index import TupleIndex
+    from nexus.tuplespace.registry import Registry
+
+_log = structlog.get_logger(__name__)
+
+
+def configure_logging_to_stderr() -> None:
+    """Redirect structlog output to stderr.
+
+    Hook scripts must call this before any logging so that structlog's output
+    does not contaminate the stdout channel that Claude Code reads for hook
+    decisions. Call once at script startup, before importing from
+    nexus.cockpit.hook_bridge (or after -- structlog reconfigures lazily).
+    """
+    structlog.configure(
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+    )
+
+# Daemon-mode routing is deferred to nexus-pce1.6 (RDR-112 daemon RPC surface).
+# Until that ships, emit() uses direct mode exclusively.
+_ROUTING_TBA = "direct"  # will become "daemon" once nexus-pce1.6 ships
+
+# ---------------------------------------------------------------------------
+# Subspace routing table
+# Canonical names from RDR-111 lines 387-393.
+# ---------------------------------------------------------------------------
+
+_SUBSPACE_MAP: dict[str, str] = {
+    "PreToolUse": "hook_events/tool_call_intent",
+    "PostToolUse": "hook_events/tool_call_completed",
+    "SubagentStop": "hook_events/agent_completed",
+    "Stop": "hook_events/assistant_turn_ended",
+    "StopFailure": "hook_events/assistant_turn_ended",
+    "UserPromptSubmit": "hook_events/user_prompt",
+    "SessionStart": "hook_events/session_lifecycle",
+    "SessionEnd": "hook_events/session_lifecycle",
+    "Notification": "hook_events/notification",
+    # PreCompact / PostCompact / SubagentStart intentionally excluded (RDR-111 §400)
+}
+
+# ---------------------------------------------------------------------------
+# Transparent-allow output shapes (RF-2)
+# ---------------------------------------------------------------------------
+
+_PERMISSIONREQUEST_ALLOW = json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PermissionRequest",
+        "permissionDecision": "allow",
+    }
+})
+
+# Hooks with no stdout output (None means: don't write anything to stdout)
+_NO_OUTPUT: frozenset[str] = frozenset({
+    "PreToolUse",       # observe-only per CA-8 spike
+    "PostToolUse",
+    "Stop",
+    "StopFailure",
+    "SubagentStop",
+    "UserPromptSubmit",
+    "SessionStart",
+    "SessionEnd",
+    "Notification",
+})
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def route_payload(
+    hook_type: str,
+    payload: dict[str, Any],
+) -> tuple[str, dict[str, Any], str] | None:
+    """Map a hook payload to ``(subspace, dimensions, match_text)``.
+
+    Returns ``None`` for hook types the bridge does not handle (PreCompact,
+    PostCompact, SubagentStart, or any unknown type). The caller should
+    silently skip emission in that case.
+
+    The four required dimensions -- ``actor``, ``session``, ``project``,
+    ``timestamp`` -- are always populated. Optional dimensions (``tool``,
+    ``workflow``, ``intent``, ``priority``) are populated when the payload
+    provides the relevant field.
+
+    Args:
+        hook_type: The CC hook type string (e.g. ``"PreToolUse"``).
+        payload: The JSON object read from the hook's stdin.
+
+    Returns:
+        A 3-tuple ``(subspace, dimensions, match_text)`` or ``None``.
+    """
+    subspace = _SUBSPACE_MAP.get(hook_type)
+    if subspace is None:
+        return None
+
+    dims = _build_dimensions(hook_type, payload)
+    match_text = _build_match_text(hook_type, payload)
+    return subspace, dims, match_text
+
+
+def output_for_hook(hook_type: str) -> str | None:
+    """Return the stdout string for a hook type, or None for silent hooks.
+
+    Pure function -- not gated on CLAUDECODE. Callers (bridge scripts) are
+    responsible for writing the returned string to stdout.
+
+    Per CA-8 spike, PreToolUse is observe-only (no permissionDecision emitted).
+    PermissionRequest emits transparent allow because silent output may block.
+
+    Args:
+        hook_type: The CC hook type string.
+
+    Returns:
+        A JSON string to write to stdout, or ``None`` for silent hooks.
+    """
+    if hook_type == "PermissionRequest":
+        return _PERMISSIONREQUEST_ALLOW
+    # All other hook types (including PreToolUse -- observe-only) emit nothing
+    return None
+
+
+def emit(
+    hook_type: str,
+    payload: dict[str, Any],
+    *,
+    conn: "sqlite3.Connection | None" = None,
+    index: "TupleIndex | None" = None,
+    registry: "Registry | None" = None,
+) -> None:
+    """Post a hook-event tuple to the tuplespace (if CLAUDECODE is set).
+
+    RF-5: skips all side-effects when ``CLAUDECODE`` is not in the environment.
+    This prevents the bridge from contaminating non-Claude shell sessions.
+
+    When ``conn``, ``index``, and ``registry`` are all ``None`` (the default
+    for bridge scripts), ``emit`` opens the tuplespace in direct mode using
+    the default nexus config paths. This is the standard hook-script call path.
+
+    When all three are provided (the test call path), the caller-supplied
+    resources are used directly; no file-system or ChromaDB connections are
+    opened.
+
+    Daemon-mode routing (nexus-pce1.6 / _ROUTING_TBA): currently routes
+    through direct mode only. When the RDR-112 ``tuplespace.out`` daemon RPC
+    ships, this function will detect the daemon and route accordingly.
+
+    Args:
+        hook_type: The CC hook type string.
+        payload: The JSON object read from the hook's stdin.
+        conn: Open SQLite connection to tuples.db (test injection; None to auto-open).
+        index: TupleIndex wrapping ChromaDB (test injection; None to auto-open).
+        registry: Loaded Registry of subspace schemas (test injection; None to auto-load).
+    """
+    if not os.environ.get("CLAUDECODE"):
+        _log.debug("hook_bridge_skip_no_claudecode", hook_type=hook_type)
+        return
+
+    routed = route_payload(hook_type, payload)
+    if routed is None:
+        _log.debug("hook_bridge_skip_unrouted", hook_type=hook_type)
+        return
+
+    subspace, dimensions, match_text = routed
+    content = _build_content(hook_type, payload)
+
+    try:
+        if conn is not None and index is not None and registry is not None:
+            # Test injection path
+            _direct_out(
+                conn=conn,
+                index=index,
+                registry=registry,
+                subspace=subspace,
+                content=content,
+                dimensions=dimensions,
+                match_text=match_text or None,
+            )
+        else:
+            # Script self-initialization path
+            _emit_direct_auto(
+                subspace=subspace,
+                content=content,
+                dimensions=dimensions,
+                match_text=match_text or None,
+            )
+        _log.debug(
+            "hook_bridge_emitted",
+            hook_type=hook_type,
+            subspace=subspace,
+        )
+    except Exception:
+        _log.exception("hook_bridge_emit_error", hook_type=hook_type, subspace=subspace)
+
+
+def _emit_direct_auto(
+    *,
+    subspace: str,
+    content: str,
+    dimensions: dict[str, Any],
+    match_text: str | None,
+) -> None:
+    """Open tuplespace resources from default config paths and call out().
+
+    This is the production path for bridge scripts. Opens tuples.db and
+    ChromaDB directly (no daemon) using the nexus config. The registry
+    is loaded from the default builtin dir, augmented with any hook-event
+    YAML schemas in ``nx/tuplespace/builtin/hooks/`` if they exist.
+    """
+    import chromadb as _chromadb
+
+    from nexus.config import load_config
+    from nexus.tuplespace.index import TupleIndex
+    from nexus.tuplespace.registry import Registry, default_builtin_dir
+    from nexus.tuplespace.store import open_tuples_db
+
+    cfg = load_config()
+    nexus_dir = cfg.get("nexus_dir", "~/.config/nexus")
+    db_path = Path(os.path.expanduser(f"{nexus_dir}/tuples.db"))
+    chroma_dir = Path(os.path.expanduser(f"{nexus_dir}/chroma"))
+
+    # Load registry from default builtin dir; also try the hooks subdir
+    # where nexus-78mh will place the seven hook-event YAMLs.
+    builtin = default_builtin_dir()
+    registry = _load_registry_with_hooks(builtin)
+
+    conn = open_tuples_db(db_path)
+    conn.row_factory = sqlite3.Row
+
+    chroma_client = _chromadb.PersistentClient(path=str(chroma_dir))
+    index = TupleIndex.from_registry(registry, chroma_client)
+
+    try:
+        _direct_out(
+            conn=conn,
+            index=index,
+            registry=registry,
+            subspace=subspace,
+            content=content,
+            dimensions=dimensions,
+            match_text=match_text,
+        )
+    finally:
+        conn.close()
+
+
+def _load_registry_with_hooks(builtin_dir: Path) -> "Registry":
+    """Load the registry, merging in hook-event YAMLs from a ``hooks`` subdir.
+
+    The main registry only globs ``*.yml`` from its top-level dir. The
+    hook-event schemas (nexus-78mh) land in ``<builtin_dir>/hooks/``. This
+    helper merges them in without modifying the main registry loader.
+    """
+    from nexus.tuplespace.registry import Registry, _load_one
+
+    registry = Registry.load(builtin_dir)
+
+    hooks_subdir = builtin_dir / "hooks"
+    if hooks_subdir.is_dir():
+        for yml_path in sorted(hooks_subdir.glob("*.yml")):
+            try:
+                schema = _load_one(yml_path)
+                if schema.name not in registry._by_template:
+                    from nexus.tuplespace.registry import _compile_template
+                    registry._by_template[schema.name] = schema
+                    registry._matchers.append((_compile_template(schema.name), schema))
+            except Exception as exc:
+                _log.warning(
+                    "hook_bridge_hooks_yaml_load_error",
+                    path=str(yml_path),
+                    error=str(exc),
+                )
+
+    return registry
+
+
+def _direct_out(
+    *,
+    conn: sqlite3.Connection,
+    index: "TupleIndex",
+    registry: "Registry",
+    subspace: str,
+    content: str,
+    dimensions: dict[str, Any],
+    match_text: str | None = None,
+    ttl_seconds: float | None = None,
+) -> str:
+    """Thin wrapper around api.out for easy mocking in tests."""
+    from nexus.tuplespace.api import out
+
+    return out(
+        conn=conn,
+        index=index,
+        registry=registry,
+        subspace=subspace,
+        content=content,
+        dimensions=dimensions,
+        match_text=match_text,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_dimensions(hook_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Construct the dimension dict for a hook event tuple.
+
+    Required dimensions: actor, session, project, timestamp.
+    Optional: tool, workflow, intent, priority (only when non-empty).
+    """
+    session_id = payload.get("session_id", "unknown")
+    cwd = payload.get("cwd", os.environ.get("CLAUDE_PROJECT_DIR", ""))
+    # "actor" is the process/agent identifier -- use session_id as a stable key
+    actor = session_id
+    timestamp = str(time.time())
+
+    dims: dict[str, Any] = {
+        "actor": actor,
+        "session": session_id,
+        "project": cwd,
+        "timestamp": timestamp,
+    }
+
+    # Optional dimensions -- populated per hook type
+    tool_name = payload.get("tool_name")
+    if tool_name and hook_type in ("PreToolUse", "PostToolUse"):
+        dims["tool"] = tool_name
+
+    # No additional optional dims for the other types at this stage
+    # (workflow, intent, priority are reserved for future enrichment)
+
+    return dims
+
+
+def _build_match_text(hook_type: str, payload: dict[str, Any]) -> str:
+    """Extract the semantic match text for a hook event tuple.
+
+    The match text is what gets embedded for semantic search. Each hook
+    type uses the most semantically rich field available.
+    """
+    match hook_type:
+        case "PreToolUse":
+            tool = payload.get("tool_name", "")
+            tool_input = payload.get("tool_input", {})
+            if isinstance(tool_input, dict):
+                input_summary = " ".join(str(v) for v in tool_input.values())
+            else:
+                input_summary = str(tool_input)
+            return f"{tool} {input_summary}".strip()
+
+        case "PostToolUse":
+            tool = payload.get("tool_name", "")
+            response = payload.get("tool_response", "")
+            return f"{tool} {response}"[:512].strip()
+
+        case "SubagentStop":
+            return payload.get("last_assistant_message", "")
+
+        case "UserPromptSubmit":
+            return payload.get("prompt", "")
+
+        case "Notification":
+            return payload.get("message", "")
+
+        case "Stop" | "StopFailure":
+            return hook_type
+
+        case "SessionStart" | "SessionEnd":
+            cwd = payload.get("cwd", "")
+            return f"{hook_type} {cwd}".strip()
+
+        case _:
+            return ""
+
+
+def _build_content(hook_type: str, payload: dict[str, Any]) -> str:
+    """Build the tuple content field (stored verbatim, not embedded).
+
+    Serialises the raw payload as JSON, capped to a safe chunk size to
+    stay within ChromaDB's MAX_DOCUMENT_BYTES limit.
+    """
+    raw = json.dumps(payload, ensure_ascii=False)
+    # Stay well within SAFE_CHUNK_BYTES = 12288
+    return raw[:12000]

--- a/src/nexus/tuplespace/registry.py
+++ b/src/nexus/tuplespace/registry.py
@@ -15,6 +15,7 @@ RDR-112 ``nexus-x98k`` in Phase 2.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, TypedDict
@@ -224,8 +225,13 @@ class Registry:
     _matchers: list[tuple[re.Pattern[str], SubspaceSchema]] = field(default_factory=list)
 
     @classmethod
-    def load(cls, builtin_dir: Path) -> "Registry":
-        """Load + validate every ``*.yml`` under *builtin_dir*.
+    def load(cls, builtin_dir: Path, *, subdirs: Iterable[str] = ()) -> "Registry":
+        """Load + validate every ``*.yml`` under *builtin_dir* and *subdirs*.
+
+        *builtin_dir* is globbed at the top level; each name in *subdirs* is
+        appended as a relative path under *builtin_dir* and globbed in turn
+        (e.g. ``subdirs=("hooks",)`` includes ``builtin_dir/hooks/*.yml``).
+        Subdirs not present on disk are silently skipped.
 
         Raises:
             RegistryLoadError: a file fails YAML parse, JSON Schema
@@ -239,20 +245,28 @@ class Registry:
             )
 
         registry = cls()
-        for yml_path in sorted(builtin_dir.glob("*.yml")):
-            schema = _load_one(yml_path)
-            if schema.name in registry._by_template:
-                raise RegistryLoadError(
-                    f"{yml_path.name}: duplicate subspace name "
-                    f"{schema.name!r} (also in "
-                    f"{registry._by_template[schema.name].source_path})"
-                )
-            registry._by_template[schema.name] = schema
-            registry._matchers.append((_compile_template(schema.name), schema))
+        search_dirs: list[Path] = [builtin_dir]
+        for sub in subdirs:
+            sub_path = builtin_dir / sub
+            if sub_path.is_dir():
+                search_dirs.append(sub_path)
+
+        for d in search_dirs:
+            for yml_path in sorted(d.glob("*.yml")):
+                schema = _load_one(yml_path)
+                if schema.name in registry._by_template:
+                    raise RegistryLoadError(
+                        f"{yml_path.name}: duplicate subspace name "
+                        f"{schema.name!r} (also in "
+                        f"{registry._by_template[schema.name].source_path})"
+                    )
+                registry._by_template[schema.name] = schema
+                registry._matchers.append((_compile_template(schema.name), schema))
 
         _log.info(
             "tuplespace_registry_loaded",
             builtin_dir=str(builtin_dir),
+            subdirs=tuple(subdirs),
             count=len(registry._by_template),
         )
         return registry

--- a/tests/cockpit/__init__.py
+++ b/tests/cockpit/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tests/cockpit/test_hook_bridge.py
+++ b/tests/cockpit/test_hook_bridge.py
@@ -1,0 +1,802 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for src/nexus/cockpit/hook_bridge.py — hook-to-tuple bridge.
+
+TDD-first: these tests define the contract for the bridge library and the
+seven per-hook-type scripts. Written before implementation per project TDD
+conventions.
+
+Coverage:
+- route_payload: one test per hook type asserting (subspace, dimensions, match_text)
+- output_for_hook: one test per hook type asserting correct output contract
+- Script exit-0 on malformed JSON
+- CLAUDECODE-unset skips emission but still produces transparent-allow output
+- api.out call shape for PreToolUse, Stop, Notification
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import chromadb
+import pytest
+
+# ---------------------------------------------------------------------------
+# Inline subspace YAML stubs for the seven hook-event subspaces.
+# These match the canonical names from RDR-111 lines 387-393.
+# ---------------------------------------------------------------------------
+
+_TOOL_CALL_INTENT_YAML = """
+name: hook_events/tool_call_intent
+tier: session
+content_type: text
+embed_from: content
+dimensions:
+  actor:      { type: string, required: true }
+  session:    { type: string, required: true }
+  project:    { type: string, required: true }
+  timestamp:  { type: string, required: true }
+  tool:       { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 10
+tiers: [session]
+retention_seconds: 86400
+"""
+
+_TOOL_CALL_COMPLETED_YAML = """
+name: hook_events/tool_call_completed
+tier: session
+content_type: text
+embed_from: content
+dimensions:
+  actor:      { type: string, required: true }
+  session:    { type: string, required: true }
+  project:    { type: string, required: true }
+  timestamp:  { type: string, required: true }
+  tool:       { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 10
+tiers: [session]
+retention_seconds: 86400
+"""
+
+_AGENT_COMPLETED_YAML = """
+name: hook_events/agent_completed
+tier: session
+content_type: text
+embed_from: content
+dimensions:
+  actor:      { type: string, required: true }
+  session:    { type: string, required: true }
+  project:    { type: string, required: true }
+  timestamp:  { type: string, required: true }
+  workflow:   { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 10
+tiers: [session]
+retention_seconds: 86400
+"""
+
+_ASSISTANT_TURN_ENDED_YAML = """
+name: hook_events/assistant_turn_ended
+tier: session
+content_type: text
+embed_from: content
+dimensions:
+  actor:      { type: string, required: true }
+  session:    { type: string, required: true }
+  project:    { type: string, required: true }
+  timestamp:  { type: string, required: true }
+  intent:     { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 10
+tiers: [session]
+retention_seconds: 86400
+"""
+
+_USER_PROMPT_YAML = """
+name: hook_events/user_prompt
+tier: session
+content_type: text
+embed_from: content
+dimensions:
+  actor:      { type: string, required: true }
+  session:    { type: string, required: true }
+  project:    { type: string, required: true }
+  timestamp:  { type: string, required: true }
+  priority:   { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 10
+tiers: [session]
+retention_seconds: 86400
+"""
+
+_SESSION_LIFECYCLE_YAML = """
+name: hook_events/session_lifecycle
+tier: session
+content_type: text
+embed_from: content
+dimensions:
+  actor:      { type: string, required: true }
+  session:    { type: string, required: true }
+  project:    { type: string, required: true }
+  timestamp:  { type: string, required: true }
+  workflow:   { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 10
+tiers: [session]
+retention_seconds: 86400
+"""
+
+_NOTIFICATION_YAML = """
+name: hook_events/notification
+tier: session
+content_type: text
+embed_from: content
+dimensions:
+  actor:      { type: string, required: true }
+  session:    { type: string, required: true }
+  project:    { type: string, required: true }
+  timestamp:  { type: string, required: true }
+  intent:     { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 10
+tiers: [session]
+retention_seconds: 86400
+"""
+
+_ALL_HOOK_YAMLS = [
+    ("hook_events_tool_call_intent.yml", _TOOL_CALL_INTENT_YAML),
+    ("hook_events_tool_call_completed.yml", _TOOL_CALL_COMPLETED_YAML),
+    ("hook_events_agent_completed.yml", _AGENT_COMPLETED_YAML),
+    ("hook_events_assistant_turn_ended.yml", _ASSISTANT_TURN_ENDED_YAML),
+    ("hook_events_user_prompt.yml", _USER_PROMPT_YAML),
+    ("hook_events_session_lifecycle.yml", _SESSION_LIFECYCLE_YAML),
+    ("hook_events_notification.yml", _NOTIFICATION_YAML),
+]
+
+
+@pytest.fixture
+def hook_builtin_dir(tmp_path: Path) -> Path:
+    """Write hook-event subspace YAMLs into a tmp builtin dir for tests."""
+    d = tmp_path / "builtin"
+    d.mkdir()
+    for fname, content in _ALL_HOOK_YAMLS:
+        (d / fname).write_text(content)
+    return d
+
+
+@pytest.fixture
+def hook_registry(hook_builtin_dir: Path):
+    from nexus.tuplespace.registry import Registry
+
+    return Registry.load(hook_builtin_dir)
+
+
+@pytest.fixture
+def db_conn(tmp_path: Path) -> sqlite3.Connection:
+    from nexus.tuplespace.store import open_tuples_db
+
+    db_path = tmp_path / "tuples.db"
+    conn = open_tuples_db(db_path)
+    conn.row_factory = sqlite3.Row
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def chroma_client():
+    client = chromadb.EphemeralClient()
+    yield client
+    for coll in client.list_collections():
+        client.delete_collection(coll.name)
+
+
+@pytest.fixture
+def hook_index(hook_registry, chroma_client):
+    from nexus.tuplespace.index import TupleIndex
+
+    return TupleIndex.from_registry(hook_registry, chroma_client)
+
+
+# ---------------------------------------------------------------------------
+# Sample payloads matching the verified spike shapes (CA-6 + RDR-111 §RF-1)
+# ---------------------------------------------------------------------------
+
+_BASE_ENV = {
+    "session_id": "test-session-abc",
+    "transcript_path": "/tmp/test.jsonl",
+    "cwd": "/projects/nexus",
+    "permission_mode": "bypassPermissions",
+}
+
+PRETOOLUSE_PAYLOAD: dict[str, Any] = {
+    **_BASE_ENV,
+    "hook_event_name": "PreToolUse",
+    "tool_name": "Bash",
+    "tool_input": {"command": "ls -la"},
+}
+
+POSTTOOLUSE_PAYLOAD: dict[str, Any] = {
+    **_BASE_ENV,
+    "hook_event_name": "PostToolUse",
+    "tool_name": "Bash",
+    "tool_input": {"command": "ls -la"},
+    "tool_response": "file1.py\nfile2.py\n",
+}
+
+STOP_PAYLOAD: dict[str, Any] = {
+    **_BASE_ENV,
+    "hook_event_name": "Stop",
+    "stop_hook_active": False,
+}
+
+STOPFAILURE_PAYLOAD: dict[str, Any] = {
+    **_BASE_ENV,
+    "hook_event_name": "StopFailure",
+    "stop_hook_active": False,
+}
+
+SUBAGENT_STOP_PAYLOAD: dict[str, Any] = {
+    **_BASE_ENV,
+    "hook_event_name": "SubagentStop",
+    "agent_id": "agent-abc123",
+    "agent_type": "general-purpose",
+    "effort": {"level": "xhigh"},
+    "stop_hook_active": False,
+    "agent_transcript_path": "/tmp/subagents/agent-abc123.jsonl",
+    "last_assistant_message": "Task complete. All tests pass.",
+}
+
+USER_PROMPT_PAYLOAD: dict[str, Any] = {
+    **_BASE_ENV,
+    "hook_event_name": "UserPromptSubmit",
+    "prompt": "Please run the tests and summarise the results.",
+}
+
+SESSION_START_PAYLOAD: dict[str, Any] = {
+    **_BASE_ENV,
+    "hook_event_name": "SessionStart",
+}
+
+SESSION_END_PAYLOAD: dict[str, Any] = {
+    **_BASE_ENV,
+    "hook_event_name": "SessionEnd",
+}
+
+NOTIFICATION_PAYLOAD: dict[str, Any] = {
+    **_BASE_ENV,
+    "hook_event_name": "Notification",
+    "message": "Claude is waiting for your input",
+    "notification_type": "idle_prompt",
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests: route_payload — (subspace, dimensions, match_text) shape
+# ---------------------------------------------------------------------------
+
+
+class TestRoutePayload:
+    """route_payload returns (subspace, dimensions, match_text) or None."""
+
+    def test_pretooluse_routes_to_tool_call_intent(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        result = route_payload("PreToolUse", PRETOOLUSE_PAYLOAD)
+        assert result is not None
+        subspace, dims, match_text = result
+        assert subspace == "hook_events/tool_call_intent"
+        assert dims["session"] == "test-session-abc"
+        assert dims["project"] == "/projects/nexus"
+        assert "actor" in dims
+        assert "timestamp" in dims
+        assert dims.get("tool") == "Bash"
+        assert isinstance(match_text, str)
+
+    def test_posttooluse_routes_to_tool_call_completed(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        result = route_payload("PostToolUse", POSTTOOLUSE_PAYLOAD)
+        assert result is not None
+        subspace, dims, match_text = result
+        assert subspace == "hook_events/tool_call_completed"
+        assert dims["session"] == "test-session-abc"
+        assert dims.get("tool") == "Bash"
+        assert isinstance(match_text, str)
+
+    def test_stop_routes_to_assistant_turn_ended(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        result = route_payload("Stop", STOP_PAYLOAD)
+        assert result is not None
+        subspace, dims, match_text = result
+        assert subspace == "hook_events/assistant_turn_ended"
+        assert dims["session"] == "test-session-abc"
+        assert isinstance(match_text, str)
+
+    def test_stopfailure_routes_to_assistant_turn_ended(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        result = route_payload("StopFailure", STOPFAILURE_PAYLOAD)
+        assert result is not None
+        subspace, dims, match_text = result
+        assert subspace == "hook_events/assistant_turn_ended"
+
+    def test_subagent_stop_routes_to_agent_completed(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        result = route_payload("SubagentStop", SUBAGENT_STOP_PAYLOAD)
+        assert result is not None
+        subspace, dims, match_text = result
+        assert subspace == "hook_events/agent_completed"
+        assert dims["session"] == "test-session-abc"
+        assert isinstance(match_text, str)
+        # match_text is the last assistant message for SubagentStop
+        assert "Task complete" in match_text
+
+    def test_user_prompt_routes_to_user_prompt(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        result = route_payload("UserPromptSubmit", USER_PROMPT_PAYLOAD)
+        assert result is not None
+        subspace, dims, match_text = result
+        assert subspace == "hook_events/user_prompt"
+        assert dims["session"] == "test-session-abc"
+        assert "Please run the tests" in match_text
+
+    def test_session_start_routes_to_session_lifecycle(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        result = route_payload("SessionStart", SESSION_START_PAYLOAD)
+        assert result is not None
+        subspace, dims, match_text = result
+        assert subspace == "hook_events/session_lifecycle"
+        assert dims["session"] == "test-session-abc"
+
+    def test_session_end_routes_to_session_lifecycle(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        result = route_payload("SessionEnd", SESSION_END_PAYLOAD)
+        assert result is not None
+        subspace, dims, match_text = result
+        assert subspace == "hook_events/session_lifecycle"
+
+    def test_notification_routes_to_notification(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        result = route_payload("Notification", NOTIFICATION_PAYLOAD)
+        assert result is not None
+        subspace, dims, match_text = result
+        assert subspace == "hook_events/notification"
+        assert dims["session"] == "test-session-abc"
+        assert "waiting" in match_text
+
+    def test_unknown_hook_type_returns_none(self) -> None:
+        from nexus.cockpit.hook_bridge import route_payload
+
+        result = route_payload("UnknownHookType", {"session_id": "x"})
+        assert result is None
+
+    def test_required_dimensions_present(self) -> None:
+        """actor, session, project, timestamp always present."""
+        from nexus.cockpit.hook_bridge import route_payload
+
+        for hook_type, payload in [
+            ("PreToolUse", PRETOOLUSE_PAYLOAD),
+            ("PostToolUse", POSTTOOLUSE_PAYLOAD),
+            ("Stop", STOP_PAYLOAD),
+            ("SubagentStop", SUBAGENT_STOP_PAYLOAD),
+            ("UserPromptSubmit", USER_PROMPT_PAYLOAD),
+            ("SessionStart", SESSION_START_PAYLOAD),
+            ("Notification", NOTIFICATION_PAYLOAD),
+        ]:
+            result = route_payload(hook_type, payload)
+            assert result is not None, f"route_payload returned None for {hook_type}"
+            _, dims, _ = result
+            for req in ("actor", "session", "project", "timestamp"):
+                assert req in dims, f"Missing required dim {req!r} for {hook_type}"
+                assert dims[req] != "", f"Required dim {req!r} is empty for {hook_type}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: output_for_hook — stdout contract
+# ---------------------------------------------------------------------------
+
+
+class TestOutputForHook:
+    """output_for_hook returns a string or None depending on hook type."""
+
+    def test_pretooluse_emits_none_observe_only(self) -> None:
+        """CA-8 spike result: bridge is observe-only, no permissionDecision."""
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("PreToolUse")
+        # observe-only: emit nothing to avoid interfering with other hooks
+        assert out is None
+
+    def test_permissionrequest_emits_transparent_allow(self) -> None:
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("PermissionRequest")
+        assert out is not None
+        parsed = json.loads(out)
+        # PermissionRequest needs explicit allow
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+    def test_posttooluse_emits_none(self) -> None:
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("PostToolUse")
+        assert out is None
+
+    def test_stop_emits_none(self) -> None:
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("Stop")
+        assert out is None
+
+    def test_stopfailure_emits_none(self) -> None:
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("StopFailure")
+        assert out is None
+
+    def test_session_end_emits_none(self) -> None:
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("SessionEnd")
+        assert out is None
+
+    def test_session_start_emits_none(self) -> None:
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("SessionStart")
+        assert out is None
+
+    def test_subagent_stop_emits_none(self) -> None:
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("SubagentStop")
+        assert out is None
+
+    def test_user_prompt_emits_none(self) -> None:
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("UserPromptSubmit")
+        assert out is None
+
+    def test_notification_emits_none(self) -> None:
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("Notification")
+        assert out is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: emit — calls api.out with correct args (mock tuplespace)
+# ---------------------------------------------------------------------------
+
+
+class TestEmit:
+    """emit() calls api.out with the correct args in direct mode."""
+
+    def _make_mock_tuplespace(self):
+        """Return a mock that satisfies the api.out call signature."""
+        mock_out = MagicMock(return_value="abc123")
+        return mock_out
+
+    def test_pretooluse_emit_calls_out(
+        self, db_conn, hook_index, hook_registry, tmp_path
+    ) -> None:
+        from nexus.cockpit import hook_bridge
+
+        called_args: list[dict] = []
+
+        def _fake_out(*, conn, index, registry, subspace, content, dimensions, match_text=None, ttl_seconds=None):
+            called_args.append({
+                "subspace": subspace,
+                "content": content,
+                "dimensions": dimensions,
+                "match_text": match_text,
+            })
+            return "fake-tuple-id"
+
+        with patch("nexus.cockpit.hook_bridge._direct_out", _fake_out):
+            hook_bridge.emit(
+                "PreToolUse",
+                PRETOOLUSE_PAYLOAD,
+                conn=db_conn,
+                index=hook_index,
+                registry=hook_registry,
+            )
+
+        assert len(called_args) == 1
+        assert called_args[0]["subspace"] == "hook_events/tool_call_intent"
+        dims = called_args[0]["dimensions"]
+        assert dims["session"] == "test-session-abc"
+        assert dims["tool"] == "Bash"
+
+    def test_stop_emit_calls_out(
+        self, db_conn, hook_index, hook_registry
+    ) -> None:
+        from nexus.cockpit import hook_bridge
+
+        called_args: list[dict] = []
+
+        def _fake_out(*, conn, index, registry, subspace, content, dimensions, match_text=None, ttl_seconds=None):
+            called_args.append({"subspace": subspace, "dimensions": dimensions})
+            return "fake-id"
+
+        with patch("nexus.cockpit.hook_bridge._direct_out", _fake_out):
+            hook_bridge.emit(
+                "Stop",
+                STOP_PAYLOAD,
+                conn=db_conn,
+                index=hook_index,
+                registry=hook_registry,
+            )
+
+        assert len(called_args) == 1
+        assert called_args[0]["subspace"] == "hook_events/assistant_turn_ended"
+
+    def test_notification_emit_calls_out(
+        self, db_conn, hook_index, hook_registry
+    ) -> None:
+        from nexus.cockpit import hook_bridge
+
+        called_args: list[dict] = []
+
+        def _fake_out(*, conn, index, registry, subspace, content, dimensions, match_text=None, ttl_seconds=None):
+            called_args.append({
+                "subspace": subspace,
+                "match_text": match_text,
+            })
+            return "fake-id"
+
+        with patch("nexus.cockpit.hook_bridge._direct_out", _fake_out):
+            hook_bridge.emit(
+                "Notification",
+                NOTIFICATION_PAYLOAD,
+                conn=db_conn,
+                index=hook_index,
+                registry=hook_registry,
+            )
+
+        assert len(called_args) == 1
+        assert called_args[0]["subspace"] == "hook_events/notification"
+        assert "waiting" in (called_args[0]["match_text"] or "")
+
+    def test_emit_unknown_hook_type_no_call(
+        self, db_conn, hook_index, hook_registry
+    ) -> None:
+        """Unknown hook types produce no api.out call (route_payload returns None)."""
+        from nexus.cockpit import hook_bridge
+
+        called = []
+
+        def _fake_out(**kwargs):
+            called.append(kwargs)
+            return "id"
+
+        with patch("nexus.cockpit.hook_bridge._direct_out", _fake_out):
+            hook_bridge.emit(
+                "PreCompact",
+                {"session_id": "x", "trigger": "manual", "cwd": "/tmp"},
+                conn=db_conn,
+                index=hook_index,
+                registry=hook_registry,
+            )
+
+        assert called == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLAUDECODE-unset skips emission but still emits correct stdout
+# ---------------------------------------------------------------------------
+
+
+class TestClaudecodeGate:
+    """RF-5: side effects skipped when CLAUDECODE not set in environment."""
+
+    def test_emit_skips_out_when_claudecode_unset(
+        self, db_conn, hook_index, hook_registry
+    ) -> None:
+        from nexus.cockpit import hook_bridge
+
+        called = []
+
+        def _fake_out(**kwargs):
+            called.append(kwargs)
+            return "id"
+
+        env_without_claudecode = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        with patch("nexus.cockpit.hook_bridge._direct_out", _fake_out):
+            with patch.dict(os.environ, env_without_claudecode, clear=True):
+                hook_bridge.emit(
+                    "PreToolUse",
+                    PRETOOLUSE_PAYLOAD,
+                    conn=db_conn,
+                    index=hook_index,
+                    registry=hook_registry,
+                )
+
+        assert called == [], "api.out must not be called when CLAUDECODE is not set"
+
+    def test_permissionrequest_output_still_emits_when_claudecode_unset(self) -> None:
+        """Even without CLAUDECODE, PermissionRequest must output transparent allow."""
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        # output_for_hook is pure — not gated on CLAUDECODE
+        out = output_for_hook("PermissionRequest")
+        assert out is not None
+        parsed = json.loads(out)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Tests: script exit-0 on malformed JSON
+# ---------------------------------------------------------------------------
+
+# Find the scripts directory relative to this test file
+_SCRIPTS_DIR = (
+    Path(__file__).resolve().parent.parent.parent / "nx" / "hooks" / "scripts"
+)
+
+_SCRIPT_NAMES = [
+    "orb_bridge_pretooluse.py",
+    "orb_bridge_posttooluse.py",
+    "orb_bridge_stop.py",
+    "orb_bridge_subagent_stop.py",
+    "orb_bridge_user_prompt_submit.py",
+    "orb_bridge_session.py",
+    "orb_bridge_notification.py",
+]
+
+
+def _run_script(
+    script_name: str,
+    stdin_data: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Run a bridge script with given stdin, return CompletedProcess."""
+    script_path = _SCRIPTS_DIR / script_name
+    run_env = dict(os.environ)
+    if env is not None:
+        run_env.update(env)
+    return subprocess.run(
+        [sys.executable, str(script_path)],
+        input=stdin_data,
+        capture_output=True,
+        text=True,
+        env=run_env,
+        timeout=10,
+    )
+
+
+class TestScriptMalformedJson:
+    """Each script exits 0 even on malformed JSON input."""
+
+    @pytest.mark.parametrize("script_name", _SCRIPT_NAMES)
+    def test_exits_0_on_malformed_json(self, script_name: str) -> None:
+        result = _run_script(script_name, "NOT VALID JSON {{{")
+        assert result.returncode == 0, (
+            f"{script_name} exited {result.returncode} on malformed JSON.\n"
+            f"stderr: {result.stderr}"
+        )
+
+    @pytest.mark.parametrize("script_name", _SCRIPT_NAMES)
+    def test_exits_0_on_empty_stdin(self, script_name: str) -> None:
+        result = _run_script(script_name, "")
+        assert result.returncode == 0, (
+            f"{script_name} exited {result.returncode} on empty stdin.\n"
+            f"stderr: {result.stderr}"
+        )
+
+
+class TestScriptClaudecodeGate:
+    """Scripts skip side-effects when CLAUDECODE is not in environment."""
+
+    def test_pretooluse_observe_only_no_stdout_when_claudecode_unset(self) -> None:
+        """PreToolUse is observe-only: no output even with CLAUDECODE unset."""
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        result = _run_script(
+            "orb_bridge_pretooluse.py",
+            json.dumps(PRETOOLUSE_PAYLOAD),
+            env=env,
+        )
+        assert result.returncode == 0
+        # observe-only: no stdout
+        assert result.stdout.strip() == ""
+
+    def test_permissionrequest_not_a_script_but_output_for_hook_is_pure(self) -> None:
+        """output_for_hook is pure Python, not gated on env; PermissionRequest always allows."""
+        from nexus.cockpit.hook_bridge import output_for_hook
+
+        out = output_for_hook("PermissionRequest")
+        assert out is not None
+        assert "allow" in out
+
+
+class TestScriptCorrectOutput:
+    """Scripts produce correct stdout for their hook type."""
+
+    def test_pretooluse_script_no_stdout_observe_only(self) -> None:
+        """CA-8 spike: observe-only, no stdout from PreToolUse bridge."""
+        result = _run_script(
+            "orb_bridge_pretooluse.py",
+            json.dumps(PRETOOLUSE_PAYLOAD),
+            env={"CLAUDECODE": "1", "CLAUDE_PROJECT_DIR": "/projects/nexus"},
+        )
+        assert result.returncode == 0
+        # observe-only: no stdout
+        assert result.stdout.strip() == ""
+
+    def test_stop_script_no_stdout(self) -> None:
+        result = _run_script(
+            "orb_bridge_stop.py",
+            json.dumps(STOP_PAYLOAD),
+            env={"CLAUDECODE": "1", "CLAUDE_PROJECT_DIR": "/projects/nexus"},
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_notification_script_no_stdout(self) -> None:
+        result = _run_script(
+            "orb_bridge_notification.py",
+            json.dumps(NOTIFICATION_PAYLOAD),
+            env={"CLAUDECODE": "1", "CLAUDE_PROJECT_DIR": "/projects/nexus"},
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary

- Implements RDR-111 §Step 2: `src/nexus/cockpit/hook_bridge.py` shared library with `route_payload()`, `output_for_hook()`, `emit()`, and `configure_logging_to_stderr()`
- Seven per-hook-type scripts under `nx/hooks/scripts/orb_bridge_*.py` — each reads stdin JSON, calls emit(), exits 0 unconditionally
- Seven hook-event subspace YAML schemas in `nx/tuplespace/builtin/hooks/` (loaded via `_load_registry_with_hooks()` which merges the hooks/ subdir into the main registry)
- `nx/hooks/hooks.json` updated to register all 7 scripts; bridge entries placed FIRST per `ORB_BRIDGE_REGISTER_FIRST=true` default
- 46 TDD tests in `tests/cockpit/test_hook_bridge.py`

## Key design decisions

- PreToolUse is **observe-only** (no permissionDecision emitted) per CA-8 spike: allow-wins regardless of registration order
- PermissionRequest emits transparent allow (needed to avoid silent block)
- RF-5 gate: `CLAUDECODE` env must be set for any tuplespace side-effects
- Daemon-mode routing deferred to nexus-pce1.6 (`_ROUTING_TBA = "direct"` documented in source)
- Subspace names from RDR-111 lines 387-393 (canonical, not CA-6 spike memo variants)

## Routing-TBA note (daemon mode)

`emit()` currently routes in direct mode only (opens `tuples.db` + ChromaDB directly). When the RDR-112 daemon ships a `tuplespace.out` RPC (nexus-pce1.6), the bridge can detect `NX_STORAGE_MODE=daemon` and route through `T2Client.call("tuplespace.out", ...)`. The `_ROUTING_TBA = "direct"` constant in `hook_bridge.py` marks the deferral point.

## Hook-event YAML schemas

The seven YAMLs live in `nx/tuplespace/builtin/hooks/`. The main registry's `load()` only globs `*.yml` from the top-level builtin dir. The bridge uses `_load_registry_with_hooks()` which merges the hooks/ subdir. When nexus-78mh ships, the daemon registers these via `subspace_add` from the same YAML files.

## Test plan

- [x] `uv run pytest tests/cockpit/ tests/tuplespace/ -q` -- 156 passed
- [x] `uv run pytest tests/test_plugin_structure.py -q` -- 616 passed, 26 skipped
- [x] Scripts actually write to real `~/.config/nexus/tuples.db` when CLAUDECODE=1 (confirmed via test stdout inspection during debug)

## Closes

Closes nexus-y0nb