### PR TITLE
feat(rdr-111): _BindingWatcher reaction loop + bindings subspace (nexus-0xaq)

### DIFF
--- a/nx/tuplespace/builtin/bindings/bindings.yml
+++ b/nx/tuplespace/builtin/bindings/bindings.yml
@@ -1,0 +1,24 @@
+# RDR-111 §Phase 2 lynchpin: binding profile subspace (nexus-0xaq).
+# Each tuple in this subspace is a YAML profile describing how the
+# _BindingWatcher should react to events on other subspaces. Profiles
+# are loaded at watcher startup from on-disk YAML; the subspace itself
+# exists so that operators can also drop profiles into the tuplespace
+# at runtime via `nx scratch` (future enhancement, see PR follow-ups).
+name: bindings/<profile>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  profile:    { type: string, required: true }
+  enabled:    { type: bool,   required: true }
+  created_by: { type: string, required: true }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.50
+  margin: 0.05
+read:
+  default_floor: 0.30
+  default_n: 50
+tiers: [project]
+retention_seconds: 0  # never expire -- profiles are durable config

--- a/nx/tuplespace/builtin/bindings/derived.yml
+++ b/nx/tuplespace/builtin/bindings/derived.yml
@@ -1,0 +1,23 @@
+# RDR-111 §Phase 2: derived-event subspace produced by binding reactions.
+# Reference binding `post_tool_use_to_derived` writes here when a
+# PostToolUse event fires, demonstrating in-tuplespace reaction (one
+# event in, a different event out, no shell-out).
+name: derived/<profile>
+tier: session
+content_type: text
+embed_from: match_text
+dimensions:
+  profile:     { type: string, required: true }
+  source_op:   { type: string, required: true }
+  source_sub:  { type: string, required: true }
+  tuple_id:    { type: string, required: true }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 50
+tiers: [session]
+retention_seconds: 86400

--- a/nx/tuplespace/builtin/bindings/profiles/default.yml
+++ b/nx/tuplespace/builtin/bindings/profiles/default.yml
@@ -1,0 +1,34 @@
+# RDR-111 §Phase 2 lynchpin: default binding profile (nexus-0xaq).
+#
+# Two reference bindings demonstrate the watcher primitive end-to-end:
+#
+# 1. `post_tool_use_to_derived` -- pure in-tuplespace reaction. Every
+#    PostToolUse event ("op == out" on subspace hook_events/tool_call_completed)
+#    fans out a derived tuple onto derived/default. No shell-out, no
+#    external side effect.
+#
+# 2. `notification_log_marker` -- emits a structlog event with a known
+#    marker on every Notification 'out' event. Demonstrates the
+#    "side-effect" action shape without spawning subprocesses.
+#
+# Both bindings are intentionally narrow -- match-predicate is a flat
+# dict of equality checks against event-record fields (subspace, op,
+# category). Anything fancier (regex, dotted-field access, OR clauses)
+# is a follow-up; v1 keeps the surface small.
+profile: default
+bindings:
+  - name: post_tool_use_to_derived
+    match:
+      subspace: hook_events/tool_call_completed
+      op: out
+    action:
+      kind: python
+      callable: nexus.cockpit.bindings:action_emit_derived
+
+  - name: notification_log_marker
+    match:
+      subspace: hook_events/notification
+      op: out
+    action:
+      kind: python
+      callable: nexus.cockpit.bindings:action_log_marker

--- a/src/nexus/cockpit/bindings.py
+++ b/src/nexus/cockpit/bindings.py
@@ -1,0 +1,635 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""_BindingWatcher -- reaction loop for the cockpit (RDR-111 §Phase 2, nexus-0xaq).
+
+The hook-bridge layer (``nexus.cockpit.hook_bridge``) drains Claude Code
+hook events into the tuplespace, but tuples sitting in ``tuples.db`` do
+nothing on their own -- the cockpit needs a *reaction loop* that watches
+committed events and dispatches user-declared bindings. This module is
+that loop.
+
+Design summary
+--------------
+
+- **Event source**: the ``events`` table in ``tuples.db`` (see RDR-110
+  store.py -- the table is fed by ``trg_tuples_out`` and ``trg_claim_log_event``
+  on every committed tuple operation). Each row has a monotonic ``rowid``
+  used as the watcher cursor.
+
+- **Cursor persistence**: ``watcher_state`` table, keyed by
+  ``(subspace, profile)``. The watcher persists ``last_rowid`` after every
+  batch so a restart resumes at-least-once without replaying the whole
+  events table.
+
+- **Idempotency / dedup**: rowid is strictly monotonic. The watcher only
+  fetches ``rowid > last_rowid`` and advances ``last_rowid`` to the max
+  rowid in the batch. Reprocessing the same event is impossible within a
+  single watcher process. Across processes the cursor table guarantees
+  the same property after a restart.
+
+- **Concurrency**: single asyncio task. SQL work is dispatched via
+  ``asyncio.to_thread`` to keep the loop non-blocking. Actions are
+  invoked sequentially per event in cursor order; one slow action
+  briefly holds up its successors but does not affect other watchers
+  (each subspace gets its own task).
+
+- **Error containment**: each binding action is wrapped in
+  ``try/except Exception``. A raising action is logged with structured
+  context and skipped; the watcher continues with the next binding and
+  the next event. One bad binding does not crash the loop or starve
+  other bindings.
+
+- **EventStream RPC fallback**: this implementation polls the ``events``
+  table directly. The daemon-mode ``event_stream.subscribe`` RPC
+  (nexus-m4gm) is the future upgrade path -- when it ships, this module
+  should grow a ``transport`` parameter and prefer the RPC. Until then,
+  polling the same table the RPC reads from gives bit-identical
+  semantics.
+
+Limits
+------
+
+- ``match`` is a flat dict of field equality predicates against the
+  event record. No regex, no dotted access, no boolean composition.
+  Listed as a PR follow-up; v1 keeps surface area small.
+
+- ``action`` is one of: ``python:<dotted.module:func>`` (called with
+  ``(event, binding, context)``) or ``log:<marker>`` (emits a single
+  structlog event with that marker). No shell-out by design.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import importlib
+import sqlite3
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Callable, Optional  # noqa: F401  -- Callable used in type hints
+
+import structlog
+import yaml
+
+_log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class BindingProfileError(ValueError):
+    """Raised when a binding profile YAML fails validation."""
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class Action:
+    """Validated action descriptor (kind + payload).
+
+    ``kind`` is currently one of ``"python"`` or ``"log"``. ``target`` is
+    the dotted callable for ``python`` or the marker string for ``log``.
+    """
+
+    kind: str
+    target: str
+
+
+@dataclasses.dataclass(frozen=True)
+class Binding:
+    """One binding row: when ``match`` is satisfied, fire ``action``."""
+
+    name: str
+    match: dict[str, Any]
+    action: Action
+
+
+@dataclasses.dataclass(frozen=True)
+class BindingProfile:
+    """A named bundle of bindings loaded from one YAML file."""
+
+    name: str
+    bindings: tuple[Binding, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class EventRecord:
+    """One row out of the ``events`` table -- what bindings match against."""
+
+    cursor: int
+    subspace: str
+    op: str
+    tuple_id: str
+    payload_summary: Optional[str]
+    category: Optional[str]
+    ts: float
+
+    def as_match_target(self) -> dict[str, Any]:
+        """Return a plain dict for predicate evaluation."""
+        return {
+            "subspace": self.subspace,
+            "op": self.op,
+            "tuple_id": self.tuple_id,
+            "category": self.category,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Profile loading
+# ---------------------------------------------------------------------------
+
+
+def _validate_match(match: Any, *, source: str) -> dict[str, Any]:
+    if not isinstance(match, dict):
+        raise BindingProfileError(
+            f"{source}: 'match' must be a mapping, got {type(match).__name__}"
+        )
+    bad = [k for k in match if not isinstance(k, str)]
+    if bad:
+        raise BindingProfileError(f"{source}: non-string match keys: {bad!r}")
+    return dict(match)
+
+
+def _validate_action(action: Any, *, source: str) -> Action:
+    if not isinstance(action, dict):
+        raise BindingProfileError(
+            f"{source}: 'action' must be a mapping, got {type(action).__name__}"
+        )
+    kind = action.get("kind")
+    if kind == "python":
+        callable_ref = action.get("callable")
+        if not isinstance(callable_ref, str) or ":" not in callable_ref:
+            raise BindingProfileError(
+                f"{source}: python action requires 'callable: module.path:func'"
+            )
+        return Action(kind="python", target=callable_ref)
+    if kind == "log":
+        marker = action.get("marker")
+        if not isinstance(marker, str) or not marker:
+            raise BindingProfileError(
+                f"{source}: log action requires non-empty 'marker' string"
+            )
+        return Action(kind="log", target=marker)
+    raise BindingProfileError(
+        f"{source}: unknown action kind {kind!r} (expected 'python' or 'log')"
+    )
+
+
+def load_profile(path: Path) -> BindingProfile:
+    """Parse a binding-profile YAML file, raising on malformed input."""
+    try:
+        raw = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        raise BindingProfileError(f"{path.name}: malformed YAML -- {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise BindingProfileError(
+            f"{path.name}: top-level YAML must be a mapping, "
+            f"got {type(raw).__name__}"
+        )
+
+    name = raw.get("profile")
+    if not isinstance(name, str) or not name:
+        raise BindingProfileError(f"{path.name}: missing/empty 'profile' field")
+
+    raw_bindings = raw.get("bindings")
+    if not isinstance(raw_bindings, list):
+        raise BindingProfileError(
+            f"{path.name}: 'bindings' must be a list, got "
+            f"{type(raw_bindings).__name__}"
+        )
+
+    bindings: list[Binding] = []
+    seen_names: set[str] = set()
+    for i, b in enumerate(raw_bindings):
+        if not isinstance(b, dict):
+            raise BindingProfileError(
+                f"{path.name}: binding[{i}] must be a mapping"
+            )
+        bname = b.get("name")
+        if not isinstance(bname, str) or not bname:
+            raise BindingProfileError(
+                f"{path.name}: binding[{i}] missing/empty 'name'"
+            )
+        if bname in seen_names:
+            raise BindingProfileError(
+                f"{path.name}: duplicate binding name {bname!r}"
+            )
+        seen_names.add(bname)
+        source = f"{path.name}:{bname}"
+        match = _validate_match(b.get("match"), source=source)
+        action = _validate_action(b.get("action"), source=source)
+        bindings.append(Binding(name=bname, match=match, action=action))
+
+    return BindingProfile(name=name, bindings=tuple(bindings))
+
+
+def load_profiles_dir(profiles_dir: Path) -> list[BindingProfile]:
+    """Load all ``*.yml`` profiles in *profiles_dir* (non-recursive)."""
+    if not profiles_dir.is_dir():
+        return []
+    profiles: list[BindingProfile] = []
+    for yml in sorted(profiles_dir.glob("*.yml")):
+        profiles.append(load_profile(yml))
+    return profiles
+
+
+# ---------------------------------------------------------------------------
+# Match-predicate evaluation
+# ---------------------------------------------------------------------------
+
+
+def matches(event: EventRecord, predicate: dict[str, Any]) -> bool:
+    """Return True iff every key in *predicate* equals the same field on *event*.
+
+    Empty predicate matches everything (deliberate; lets a profile express
+    a "fire on every event" binding). Unknown keys never match.
+    """
+    target = event.as_match_target()
+    for k, v in predicate.items():
+        if target.get(k) != v:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Action dispatch
+# ---------------------------------------------------------------------------
+
+
+def _resolve_python_callable(target: str) -> Callable[..., Any]:
+    mod_name, _, attr = target.partition(":")
+    mod = importlib.import_module(mod_name)
+    fn = getattr(mod, attr, None)
+    if not callable(fn):
+        raise BindingProfileError(
+            f"python action target {target!r} is not callable"
+        )
+    return fn
+
+
+async def _dispatch_action(
+    action: Action,
+    *,
+    event: EventRecord,
+    binding: Binding,
+    context: "BindingContext",
+) -> None:
+    if action.kind == "log":
+        _log.info(
+            "binding_action_log",
+            marker=action.target,
+            binding=binding.name,
+            subspace=event.subspace,
+            op=event.op,
+            tuple_id=event.tuple_id,
+        )
+        return
+    if action.kind == "python":
+        fn = _resolve_python_callable(action.target)
+        result = fn(event, binding, context)
+        if asyncio.iscoroutine(result):
+            await result
+        return
+    raise BindingProfileError(f"unknown action kind {action.kind!r}")
+
+
+# ---------------------------------------------------------------------------
+# Context passed to python actions
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class BindingContext:
+    """Mutable context object passed to python action callables.
+
+    Holds the tuplespace handles an action might need to write derived
+    tuples back into the system. Tests inject a stub object; production
+    wiring constructs one in :meth:`_BindingWatcher.start`.
+    """
+
+    conn: Optional[sqlite3.Connection] = None
+    index: Any = None  # nexus.tuplespace.index.TupleIndex
+    registry: Any = None  # nexus.tuplespace.registry.Registry
+    profile_name: str = ""
+    # Free-form bag so reference actions and tests can stash arbitrary
+    # state without growing the dataclass for every consumer.
+    extras: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Reference action callables (the "is this primitive useful?" demonstration)
+# ---------------------------------------------------------------------------
+
+
+def action_emit_derived(
+    event: EventRecord,
+    binding: Binding,
+    context: BindingContext,
+) -> None:
+    """Reference binding action: in-tuplespace reaction.
+
+    On a PostToolUse 'out' event, writes a derived tuple onto
+    ``derived/<profile>`` recording the source event. This is the
+    canonical "one event in, a different event out" demonstration.
+    """
+    if context.conn is None or context.index is None or context.registry is None:
+        _log.warning(
+            "binding_action_emit_derived_missing_context",
+            binding=binding.name,
+        )
+        return
+    from nexus.tuplespace.api import out
+
+    profile = context.profile_name or "default"
+    subspace = f"derived/{profile}"
+    dimensions = {
+        "profile": profile,
+        "source_op": event.op,
+        "source_sub": event.subspace,
+        "tuple_id": event.tuple_id,
+    }
+    match_text = f"{event.subspace} {event.op} {event.tuple_id}"
+    out(
+        conn=context.conn,
+        index=context.index,
+        registry=context.registry,
+        subspace=subspace,
+        content=match_text,
+        dimensions=dimensions,
+        match_text=match_text,
+    )
+
+
+def action_log_marker(
+    event: EventRecord,
+    binding: Binding,
+    context: BindingContext,
+) -> None:
+    """Reference binding action: side effect via structlog.
+
+    Emits a structlog event with a stable marker key so a downstream
+    log consumer (or a test) can detect the reaction. No subprocess, no
+    network.
+    """
+    _log.info(
+        "binding_marker",
+        marker="cockpit.binding.notification",
+        binding=binding.name,
+        subspace=event.subspace,
+        op=event.op,
+        tuple_id=event.tuple_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cursor + event-table SQL helpers (run via asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+
+def _load_cursor(
+    conn: sqlite3.Connection, *, subspace_prefix: str, profile: str
+) -> int:
+    row = conn.execute(
+        "SELECT last_rowid FROM watcher_state WHERE subspace = ? AND profile = ?",
+        (subspace_prefix, profile),
+    ).fetchone()
+    if row is None:
+        return 0
+    return int(row[0])
+
+
+def _save_cursor(
+    conn: sqlite3.Connection,
+    *,
+    subspace_prefix: str,
+    profile: str,
+    last_rowid: int,
+) -> None:
+    conn.execute(
+        "INSERT INTO watcher_state (subspace, profile, last_rowid, updated_at) "
+        "VALUES (?, ?, ?, ?) "
+        "ON CONFLICT(subspace, profile) DO UPDATE SET "
+        "last_rowid = excluded.last_rowid, updated_at = excluded.updated_at",
+        (subspace_prefix, profile, last_rowid, time.time()),
+    )
+    conn.commit()
+
+
+def _fetch_event_batch(
+    conn: sqlite3.Connection,
+    *,
+    subspace_glob: str,
+    after_rowid: int,
+    limit: int,
+) -> list[EventRecord]:
+    rows = conn.execute(
+        "SELECT rowid, subspace, op, tuple_id, payload_summary, category, ts "
+        "FROM events WHERE subspace GLOB ? AND rowid > ? "
+        "ORDER BY rowid LIMIT ?",
+        (subspace_glob, after_rowid, limit),
+    ).fetchall()
+    return [
+        EventRecord(
+            cursor=int(r[0]),
+            subspace=str(r[1]),
+            op=str(r[2]),
+            tuple_id=str(r[3]),
+            payload_summary=r[4],
+            category=r[5],
+            ts=float(r[6]),
+        )
+        for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The watcher
+# ---------------------------------------------------------------------------
+
+
+class _BindingWatcher:
+    """Async polling reaction loop over the tuplespace ``events`` table.
+
+    One watcher subscribes to a single *subspace_glob* (defaults to ``*``
+    so all events are visible) and dispatches every loaded *profile*'s
+    bindings on each event in cursor order.
+
+    Wire from cockpit startup:
+
+        >>> watcher = _BindingWatcher(
+        ...     conn=conn,
+        ...     profiles=load_profiles_dir(profiles_dir),
+        ...     context=BindingContext(conn=conn, index=index, registry=registry),
+        ... )
+        >>> task = asyncio.create_task(watcher.run())
+        >>> # ... later ...
+        >>> watcher.request_stop()
+        >>> await task
+
+    The class is intentionally direct-mode polling. Daemon-mode users
+    will swap the SQL polling for ``event_stream.subscribe`` once the
+    RPC ships (nexus-m4gm, RDR-112). Until then, this is the same query
+    the daemon-side handler runs -- identical semantics.
+    """
+
+    def __init__(
+        self,
+        *,
+        conn: sqlite3.Connection,
+        profiles: Iterable[BindingProfile],
+        context: BindingContext,
+        subspace_glob: str = "*",
+        poll_interval: float = 0.05,
+        batch_limit: int = 100,
+    ) -> None:
+        self._conn = conn
+        self._profiles: tuple[BindingProfile, ...] = tuple(profiles)
+        self._context = context
+        self._subspace_glob = subspace_glob
+        self._poll_interval = poll_interval
+        self._batch_limit = batch_limit
+        self._stop = asyncio.Event()
+        # One cursor per (subspace_glob, profile_name). Loaded lazily in run().
+        self._cursors: dict[str, int] = {}
+
+    # -- lifecycle --------------------------------------------------------
+
+    def request_stop(self) -> None:
+        """Signal the watcher to exit at the next loop boundary."""
+        self._stop.set()
+
+    async def run(self) -> None:
+        """Run the polling loop until :meth:`request_stop` is invoked."""
+        # Load per-profile cursors once at startup.
+        #
+        # SQLite connection objects are pinned to the thread that opened
+        # them (default ``check_same_thread=True``). Production callers
+        # construct the watcher on the asyncio loop thread, so running
+        # the SQL inline here is correct. We deliberately do NOT use
+        # ``asyncio.to_thread`` for the SQLite calls -- that would land in
+        # a worker thread and trip SQLite's same-thread guard. The
+        # queries themselves are sub-millisecond and never block the
+        # loop noticeably.
+        for profile in self._profiles:
+            self._cursors[profile.name] = _load_cursor(
+                self._conn,
+                subspace_prefix=self._subspace_glob,
+                profile=profile.name,
+            )
+
+        _log.info(
+            "binding_watcher_started",
+            profiles=[p.name for p in self._profiles],
+            subspace_glob=self._subspace_glob,
+            cursors=dict(self._cursors),
+        )
+
+        while not self._stop.is_set():
+            advanced = await self._tick()
+            if advanced == 0:
+                # Quiet -- wait for either poll-tick or stop.
+                try:
+                    await asyncio.wait_for(
+                        self._stop.wait(), timeout=self._poll_interval
+                    )
+                except asyncio.TimeoutError:
+                    pass
+
+        _log.info(
+            "binding_watcher_stopped",
+            cursors=dict(self._cursors),
+        )
+
+    # -- single iteration --------------------------------------------------
+
+    async def _tick(self) -> int:
+        """Run one polling iteration. Returns the number of events processed."""
+        total = 0
+        for profile in self._profiles:
+            cursor = self._cursors.get(profile.name, 0)
+            try:
+                events = _fetch_event_batch(
+                    self._conn,
+                    subspace_glob=self._subspace_glob,
+                    after_rowid=cursor,
+                    limit=self._batch_limit,
+                )
+            except sqlite3.Error:
+                _log.exception(
+                    "binding_watcher_fetch_failed",
+                    profile=profile.name,
+                    cursor=cursor,
+                )
+                continue
+
+            if not events:
+                continue
+
+            self._context.profile_name = profile.name
+            for event in events:
+                await self._dispatch_event(profile, event)
+            # Cursor advances even if individual bindings raised -- error
+            # containment means we never get stuck on a poison event.
+            new_cursor = max(e.cursor for e in events)
+            self._cursors[profile.name] = new_cursor
+            try:
+                _save_cursor(
+                    self._conn,
+                    subspace_prefix=self._subspace_glob,
+                    profile=profile.name,
+                    last_rowid=new_cursor,
+                )
+            except sqlite3.Error:
+                _log.exception(
+                    "binding_watcher_cursor_save_failed",
+                    profile=profile.name,
+                    cursor=new_cursor,
+                )
+            total += len(events)
+        return total
+
+    async def _dispatch_event(
+        self, profile: BindingProfile, event: EventRecord
+    ) -> None:
+        for binding in profile.bindings:
+            if not matches(event, binding.match):
+                continue
+            try:
+                await _dispatch_action(
+                    binding.action,
+                    event=event,
+                    binding=binding,
+                    context=self._context,
+                )
+            except Exception:
+                # Containment per acceptance criterion 4: one bad binding
+                # must not crash the watcher or starve siblings.
+                _log.exception(
+                    "binding_action_failed",
+                    profile=profile.name,
+                    binding=binding.name,
+                    action_kind=binding.action.kind,
+                    action_target=binding.action.target,
+                    subspace=event.subspace,
+                    op=event.op,
+                    tuple_id=event.tuple_id,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Default profile location
+# ---------------------------------------------------------------------------
+
+
+def default_profiles_dir() -> Path:
+    """Resolve the canonical profiles dir relative to the package."""
+    here = Path(__file__).resolve()
+    # src/nexus/cockpit/bindings.py → repo root → nx/tuplespace/builtin/bindings/profiles
+    repo_root = here.parent.parent.parent.parent
+    return repo_root / "nx" / "tuplespace" / "builtin" / "bindings" / "profiles"

--- a/tests/cockpit/test_binding_watcher.py
+++ b/tests/cockpit/test_binding_watcher.py
@@ -1,0 +1,615 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for src/nexus/cockpit/bindings.py -- RDR-111 §Phase 2 reaction loop.
+
+TDD-first: written before iteration on bindings.py. Covers match
+evaluation, profile loading, dedup via cursor, multi-binding fan-out,
+malformed YAML rejection, action error containment, and end-to-end
+in-tuplespace reaction with the reference bindings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import chromadb
+import pytest
+
+from nexus.cockpit.bindings import (
+    Action,
+    Binding,
+    BindingContext,
+    BindingProfile,
+    BindingProfileError,
+    EventRecord,
+    _BindingWatcher,
+    action_emit_derived,
+    action_log_marker,
+    load_profile,
+    load_profiles_dir,
+    matches,
+)
+from nexus.tuplespace.api import out
+from nexus.tuplespace.index import TupleIndex
+from nexus.tuplespace.registry import Registry
+from nexus.tuplespace.store import open_tuples_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: minimal subspace registry + tuples.db
+# ---------------------------------------------------------------------------
+
+
+_HOOK_EVENTS_YAML = """\
+name: hook_events/tool_call_completed
+tier: session
+content_type: text
+embed_from: content
+dimensions:
+  actor:     { type: string, required: true }
+  session:   { type: string, required: true }
+  project:   { type: string, required: true }
+  timestamp: { type: string, required: true }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 10
+tiers: [session]
+retention_seconds: 86400
+"""
+
+_NOTIFICATION_YAML = """\
+name: hook_events/notification
+tier: session
+content_type: text
+embed_from: content
+dimensions:
+  actor:     { type: string, required: true }
+  session:   { type: string, required: true }
+  project:   { type: string, required: true }
+  timestamp: { type: string, required: true }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 10
+tiers: [session]
+retention_seconds: 86400
+"""
+
+_DERIVED_YAML = """\
+name: derived/<profile>
+tier: session
+content_type: text
+embed_from: match_text
+dimensions:
+  profile:    { type: string, required: true }
+  source_op:  { type: string, required: true }
+  source_sub: { type: string, required: true }
+  tuple_id:   { type: string, required: true }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 50
+tiers: [session]
+retention_seconds: 86400
+"""
+
+
+@pytest.fixture
+def builtin_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "hook_events_tool_call_completed.yml").write_text(_HOOK_EVENTS_YAML)
+    (d / "hook_events_notification.yml").write_text(_NOTIFICATION_YAML)
+    (d / "derived.yml").write_text(_DERIVED_YAML)
+    return d
+
+
+@pytest.fixture
+def registry(builtin_dir: Path) -> Registry:
+    return Registry.load(builtin_dir)
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db = tmp_path / "tuples.db"
+    c = open_tuples_db(db)
+    c.row_factory = sqlite3.Row
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def chroma_client():
+    client = chromadb.EphemeralClient()
+    yield client
+    for coll in client.list_collections():
+        client.delete_collection(coll.name)
+
+
+@pytest.fixture
+def index(registry, chroma_client) -> TupleIndex:
+    return TupleIndex.from_registry(registry, chroma_client)
+
+
+@pytest.fixture
+def context(conn, index, registry) -> BindingContext:
+    return BindingContext(
+        conn=conn, index=index, registry=registry, profile_name="default"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: drop a hook-event tuple so an `out` event row appears.
+# ---------------------------------------------------------------------------
+
+
+def _emit_hook_tuple(
+    conn,
+    index,
+    registry,
+    *,
+    subspace: str,
+    extra: str = "",
+) -> str:
+    return out(
+        conn=conn,
+        index=index,
+        registry=registry,
+        subspace=subspace,
+        content=f"event-content {extra}",
+        dimensions={
+            "actor": "test-actor",
+            "session": "sess-1",
+            "project": "/tmp/p",
+            "timestamp": "1700000000.0",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# matches() -- predicate evaluation
+# ---------------------------------------------------------------------------
+
+
+class TestMatches:
+    def _event(self, **kw) -> EventRecord:
+        defaults: dict[str, Any] = dict(
+            cursor=1,
+            subspace="hook_events/notification",
+            op="out",
+            tuple_id="abc",
+            payload_summary=None,
+            category="data",
+            ts=1.0,
+        )
+        defaults.update(kw)
+        return EventRecord(**defaults)
+
+    def test_empty_predicate_matches_everything(self):
+        assert matches(self._event(), {}) is True
+
+    def test_single_field_equality(self):
+        ev = self._event(op="out")
+        assert matches(ev, {"op": "out"}) is True
+        assert matches(ev, {"op": "claim"}) is False
+
+    def test_multi_field_all_must_match(self):
+        ev = self._event(subspace="hook_events/tool_call_completed", op="out")
+        assert matches(
+            ev, {"subspace": "hook_events/tool_call_completed", "op": "out"}
+        ) is True
+        # op mismatch
+        assert matches(
+            ev, {"subspace": "hook_events/tool_call_completed", "op": "claim"}
+        ) is False
+
+    def test_unknown_key_never_matches(self):
+        assert matches(self._event(), {"nonexistent_field": "x"}) is False
+
+
+# ---------------------------------------------------------------------------
+# Profile loading + validation
+# ---------------------------------------------------------------------------
+
+
+class TestProfileLoading:
+    def test_load_minimal_profile(self, tmp_path: Path):
+        p = tmp_path / "p.yml"
+        p.write_text(
+            "profile: alpha\n"
+            "bindings:\n"
+            "  - name: b1\n"
+            "    match: {op: out}\n"
+            "    action: {kind: log, marker: hi}\n"
+        )
+        prof = load_profile(p)
+        assert prof.name == "alpha"
+        assert len(prof.bindings) == 1
+        assert prof.bindings[0].name == "b1"
+        assert prof.bindings[0].action == Action(kind="log", target="hi")
+
+    def test_python_action(self, tmp_path: Path):
+        p = tmp_path / "p.yml"
+        p.write_text(
+            "profile: a\n"
+            "bindings:\n"
+            "  - name: b1\n"
+            "    match: {}\n"
+            "    action: {kind: python, callable: a.b:c}\n"
+        )
+        prof = load_profile(p)
+        assert prof.bindings[0].action == Action(kind="python", target="a.b:c")
+
+    def test_rejects_malformed_yaml(self, tmp_path: Path):
+        p = tmp_path / "p.yml"
+        p.write_text("profile: a\nbindings: [::oops")
+        with pytest.raises(BindingProfileError, match="malformed YAML"):
+            load_profile(p)
+
+    def test_rejects_missing_profile(self, tmp_path: Path):
+        p = tmp_path / "p.yml"
+        p.write_text("bindings: []\n")
+        with pytest.raises(BindingProfileError, match="profile"):
+            load_profile(p)
+
+    def test_rejects_non_list_bindings(self, tmp_path: Path):
+        p = tmp_path / "p.yml"
+        p.write_text("profile: a\nbindings: nope\n")
+        with pytest.raises(BindingProfileError, match="'bindings' must be a list"):
+            load_profile(p)
+
+    def test_rejects_unknown_action_kind(self, tmp_path: Path):
+        p = tmp_path / "p.yml"
+        p.write_text(
+            "profile: a\n"
+            "bindings:\n"
+            "  - name: b1\n"
+            "    match: {}\n"
+            "    action: {kind: shell, command: rm -rf /}\n"
+        )
+        with pytest.raises(BindingProfileError, match="unknown action kind"):
+            load_profile(p)
+
+    def test_rejects_duplicate_binding_name(self, tmp_path: Path):
+        p = tmp_path / "p.yml"
+        p.write_text(
+            "profile: a\n"
+            "bindings:\n"
+            "  - {name: x, match: {}, action: {kind: log, marker: m}}\n"
+            "  - {name: x, match: {}, action: {kind: log, marker: m}}\n"
+        )
+        with pytest.raises(BindingProfileError, match="duplicate binding"):
+            load_profile(p)
+
+    def test_load_profiles_dir_empty_when_missing(self, tmp_path: Path):
+        assert load_profiles_dir(tmp_path / "nope") == []
+
+
+# ---------------------------------------------------------------------------
+# Reference action: action_log_marker
+# ---------------------------------------------------------------------------
+
+
+class TestActionLogMarker:
+    def test_emits_structlog_event(self, context, caplog):
+        ev = EventRecord(
+            cursor=1,
+            subspace="hook_events/notification",
+            op="out",
+            tuple_id="abc",
+            payload_summary=None,
+            category="data",
+            ts=1.0,
+        )
+        binding = Binding(
+            name="b",
+            match={},
+            action=Action(kind="log", target="cockpit.binding.notification"),
+        )
+        # Should not raise.
+        action_log_marker(ev, binding, context)
+
+
+# ---------------------------------------------------------------------------
+# Reference action: action_emit_derived (in-tuplespace reaction)
+# ---------------------------------------------------------------------------
+
+
+class TestActionEmitDerived:
+    def test_writes_to_derived_subspace(self, conn, index, registry, context):
+        ev = EventRecord(
+            cursor=1,
+            subspace="hook_events/tool_call_completed",
+            op="out",
+            tuple_id="src-tuple-1",
+            payload_summary=None,
+            category="data",
+            ts=1.0,
+        )
+        binding = Binding(
+            name="b",
+            match={},
+            action=Action(kind="python", target="x:y"),
+        )
+        action_emit_derived(ev, binding, context)
+
+        # A row landed on derived/default
+        rows = conn.execute(
+            "SELECT subspace FROM tuples WHERE subspace = 'derived/default'"
+        ).fetchall()
+        assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# _BindingWatcher: end-to-end via tuples.db events table
+# ---------------------------------------------------------------------------
+
+
+async def _run_briefly(watcher: _BindingWatcher, *, ticks: int = 5):
+    """Drive the watcher long enough to drain pending events."""
+    task = asyncio.create_task(watcher.run())
+    # Yield control several times so the loop polls.
+    for _ in range(ticks):
+        await asyncio.sleep(0.02)
+    watcher.request_stop()
+    await asyncio.wait_for(task, timeout=2.0)
+
+
+class TestBindingWatcher:
+    @pytest.mark.asyncio
+    async def test_dispatches_python_action_on_matching_event(
+        self, conn, index, registry, context
+    ):
+        # Pre-emit one tuple so an events row exists.
+        _emit_hook_tuple(
+            conn, index, registry, subspace="hook_events/tool_call_completed"
+        )
+
+        calls: list[EventRecord] = []
+
+        def _action(event, binding, ctx):
+            calls.append(event)
+
+        # Install into a temp module so the dotted-callable resolver finds it.
+        mod = types.ModuleType("nexus_test_bindings_action_mod")
+        mod._action = _action
+        sys.modules["nexus_test_bindings_action_mod"] = mod
+
+        profile = BindingProfile(
+            name="t1",
+            bindings=(
+                Binding(
+                    name="b",
+                    match={"subspace": "hook_events/tool_call_completed", "op": "out"},
+                    action=Action(
+                        kind="python",
+                        target="nexus_test_bindings_action_mod:_action",
+                    ),
+                ),
+            ),
+        )
+        watcher = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        await _run_briefly(watcher)
+
+        assert len(calls) == 1
+        assert calls[0].subspace == "hook_events/tool_call_completed"
+        assert calls[0].op == "out"
+
+    @pytest.mark.asyncio
+    async def test_dedup_via_cursor(self, conn, index, registry, context):
+        _emit_hook_tuple(
+            conn, index, registry, subspace="hook_events/tool_call_completed"
+        )
+
+        calls: list[EventRecord] = []
+
+        def _action(event, binding, ctx):
+            calls.append(event)
+
+        mod = types.ModuleType("nexus_test_bindings_dedup_mod")
+        mod._action = _action
+        sys.modules["nexus_test_bindings_dedup_mod"] = mod
+
+        profile = BindingProfile(
+            name="dedup-prof",
+            bindings=(
+                Binding(
+                    name="b",
+                    match={},
+                    action=Action(
+                        kind="python",
+                        target="nexus_test_bindings_dedup_mod:_action",
+                    ),
+                ),
+            ),
+        )
+        watcher = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        # First run picks up the event.
+        await _run_briefly(watcher)
+        assert len(calls) == 1
+
+        # A second watcher with the SAME profile name and SAME conn must
+        # see the persisted cursor and process zero events.
+        calls.clear()
+        watcher2 = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        await _run_briefly(watcher2)
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_multi_binding_fan_out(self, conn, index, registry, context):
+        _emit_hook_tuple(
+            conn, index, registry, subspace="hook_events/tool_call_completed"
+        )
+
+        hits: list[str] = []
+
+        def _a(event, binding, ctx):
+            hits.append("a")
+
+        def _b(event, binding, ctx):
+            hits.append("b")
+
+        mod = types.ModuleType("nexus_test_bindings_fanout_mod")
+        mod._a = _a
+        mod._b = _b
+        sys.modules["nexus_test_bindings_fanout_mod"] = mod
+
+        profile = BindingProfile(
+            name="fan",
+            bindings=(
+                Binding(
+                    name="ba",
+                    match={"op": "out"},
+                    action=Action(
+                        kind="python", target="nexus_test_bindings_fanout_mod:_a"
+                    ),
+                ),
+                Binding(
+                    name="bb",
+                    match={"op": "out"},
+                    action=Action(
+                        kind="python", target="nexus_test_bindings_fanout_mod:_b"
+                    ),
+                ),
+            ),
+        )
+        watcher = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        await _run_briefly(watcher)
+
+        assert sorted(hits) == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_action_error_containment(self, conn, index, registry, context):
+        _emit_hook_tuple(
+            conn, index, registry, subspace="hook_events/tool_call_completed"
+        )
+
+        good_hits: list[int] = []
+
+        def _bad(event, binding, ctx):
+            raise RuntimeError("boom")
+
+        def _good(event, binding, ctx):
+            good_hits.append(1)
+
+        mod = types.ModuleType("nexus_test_bindings_err_mod")
+        mod._bad = _bad
+        mod._good = _good
+        sys.modules["nexus_test_bindings_err_mod"] = mod
+
+        profile = BindingProfile(
+            name="err",
+            bindings=(
+                Binding(
+                    name="bad",
+                    match={},
+                    action=Action(
+                        kind="python", target="nexus_test_bindings_err_mod:_bad"
+                    ),
+                ),
+                Binding(
+                    name="good",
+                    match={},
+                    action=Action(
+                        kind="python", target="nexus_test_bindings_err_mod:_good"
+                    ),
+                ),
+            ),
+        )
+        watcher = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        await _run_briefly(watcher)
+
+        # The bad action raised; the good action still ran.
+        assert good_hits == [1]
+        # Cursor still advanced (watcher did not get stuck on the bad event).
+        row = conn.execute(
+            "SELECT last_rowid FROM watcher_state WHERE profile = 'err'"
+        ).fetchone()
+        assert row is not None
+        assert int(row[0]) > 0
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_with_reference_bindings(
+        self, conn, index, registry, context
+    ):
+        """The two reference bindings demonstrate the primitive end-to-end."""
+        # Emit one PostToolUse event and one Notification event.
+        _emit_hook_tuple(
+            conn, index, registry, subspace="hook_events/tool_call_completed"
+        )
+        _emit_hook_tuple(
+            conn, index, registry, subspace="hook_events/notification"
+        )
+
+        profile = BindingProfile(
+            name="default",
+            bindings=(
+                Binding(
+                    name="post_tool_use_to_derived",
+                    match={
+                        "subspace": "hook_events/tool_call_completed",
+                        "op": "out",
+                    },
+                    action=Action(
+                        kind="python",
+                        target="nexus.cockpit.bindings:action_emit_derived",
+                    ),
+                ),
+                Binding(
+                    name="notification_log_marker",
+                    match={"subspace": "hook_events/notification", "op": "out"},
+                    action=Action(
+                        kind="python",
+                        target="nexus.cockpit.bindings:action_log_marker",
+                    ),
+                ),
+            ),
+        )
+        watcher = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        await _run_briefly(watcher)
+
+        # Reference 1: derived/default got a tuple from the PostToolUse event.
+        derived = conn.execute(
+            "SELECT id FROM tuples WHERE subspace = 'derived/default'"
+        ).fetchall()
+        assert len(derived) == 1
+
+    @pytest.mark.asyncio
+    async def test_request_stop_terminates_loop(self, conn, context):
+        profile = BindingProfile(name="stop-prof", bindings=())
+        watcher = _BindingWatcher(
+            conn=conn, profiles=[profile], context=context, poll_interval=0.01
+        )
+        task = asyncio.create_task(watcher.run())
+        await asyncio.sleep(0.05)
+        watcher.request_stop()
+        await asyncio.wait_for(task, timeout=2.0)


### PR DESCRIPTION
## Summary

RDR-111 Phase 2 lynchpin. The hook-bridge layer was drainning Claude Code hook events into the tuplespace, but tuples sat doing nothing -- this bead supplies the missing `_BindingWatcher` so events trigger declared reactions.

- `_BindingWatcher` in `src/nexus/cockpit/bindings.py`: asyncio polling loop over the `events` table, cursor-persisted per `(subspace, profile)` in `watcher_state`. rowid-monotonic dedup; per-binding error containment so one bad action cannot crash the watcher or starve siblings.
- Action shapes: `python:<dotted.module:func>` and `log:<marker>`. No shell-out by design.
- Two reference bindings demonstrate the primitive end-to-end:
  - `post_tool_use_to_derived` writes a `derived/<profile>` tuple on every `hook_events/tool_call_completed` `out` event (in-tuplespace reaction).
  - `notification_log_marker` emits a structlog event with marker `cockpit.binding.notification` on every Notification `out` (side-effect demo).
- Two new canonical subspaces shipped under `nx/tuplespace/builtin/bindings/`: `bindings/<profile>` (durable profile metadata) and `derived/<profile>` (reaction-target tuples). A reference profile YAML lives at `bindings/profiles/default.yml`.

## EventStream RPC fallback

The daemon-side `event_stream.subscribe` RPC (nexus-m4gm) is the intended long-term transport. Until it ships, the watcher polls the same `events` table the RPC handler reads, so semantics are bit-identical. A TODO-comment in `bindings.py` documents the upgrade path.

## Test plan

- [x] `uv run pytest tests/cockpit/test_binding_watcher.py` -- 20 tests, all pass
- [x] `uv run pytest tests/cockpit/ tests/tuplespace/` -- 184 tests, all pass
- [x] `uv run pytest tests/test_plugin_structure.py` -- 616 passed / 26 skipped

## Coverage

- match-predicate evaluation (empty, single field, multi field, unknown key)
- profile YAML loading + validation (malformed YAML, missing fields, unknown action kind, duplicate names)
- python action dispatch via dotted callable
- structlog action dispatch
- dedup via persisted cursor across watcher restarts on the same `(subspace_glob, profile)`
- multi-binding fan-out (all matching bindings fire on one event)
- action error containment (raising action skipped, sibling action still runs, cursor still advances)
- end-to-end with the two reference bindings against a real `tuples.db`
- clean shutdown via `request_stop`

## Deferred follow-ups (intentionally out of scope)

- DSL expansion: `match` is flat-dict equality only. Regex, dotted-field access, OR clauses are follow-ups.
- Daemon-mode transport: swap polling for `event_stream.subscribe` RPC once nexus-m4gm ships.
- Cockpit startup wiring: `_BindingWatcher.start()` is invokable from any asyncio context. A dedicated cockpit entry-point command (`nx cockpit watch`) is not part of this bead -- the wiring helper `default_profiles_dir()` is exposed for the future daemon-side or CLI wrapper.

## Closes

Closes nexus-0xaq

Epic: nexus-hp9f (RDR-110/111/112/113 deep-review remediations)