### PR TITLE
feat(rdr-112): daemon tuplespace RPC suite + bridge daemon-mode cutover (nexus-6s8v)

### DIFF
--- a/src/nexus/cockpit/hook_bridge.py
+++ b/src/nexus/cockpit/hook_bridge.py
@@ -61,9 +61,11 @@ def configure_logging_to_stderr() -> None:
         logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
     )
 
-# Daemon-mode routing is deferred to nexus-pce1.6 (RDR-112 daemon RPC surface).
-# Until that ships, emit() uses direct mode exclusively.
-_ROUTING_TBA = "direct"  # will become "daemon" once nexus-pce1.6 ships
+# nexus-6s8v (RDR-112): daemon-mode routing is now the preferred path.
+# ``emit()`` tries the daemon first; on connection failure it falls through
+# to direct mode (own SQLite + chroma), and on a final failure it logs and
+# skips so user-facing hooks never crash because the tuplespace is down.
+_ROUTING_TBA = "daemon"
 
 # ---------------------------------------------------------------------------
 # Subspace routing table
@@ -211,7 +213,7 @@ def emit(
 
     try:
         if conn is not None and index is not None and registry is not None:
-            # Test injection path
+            # Test injection path (resources supplied — bypass routing)
             _direct_out(
                 conn=conn,
                 index=index,
@@ -221,9 +223,10 @@ def emit(
                 dimensions=dimensions,
                 match_text=match_text or None,
             )
+            route = "direct-injected"
         else:
-            # Script self-initialization path
-            _emit_direct_auto(
+            # Production routing: prefer daemon, fall back to direct, then skip.
+            route = _emit_routed(
                 subspace=subspace,
                 content=content,
                 dimensions=dimensions,
@@ -233,9 +236,71 @@ def emit(
             "hook_bridge_emitted",
             hook_type=hook_type,
             subspace=subspace,
+            route=route,
         )
     except Exception:
         _log.exception("hook_bridge_emit_error", hook_type=hook_type, subspace=subspace)
+
+
+def _emit_routed(
+    *,
+    subspace: str,
+    content: str,
+    dimensions: dict[str, Any],
+    match_text: str | None,
+) -> str:
+    """Try daemon -> direct -> skip. Returns the chosen route as a string.
+
+    Daemon path (preferred): discover the running T2 daemon and call its
+    ``tuplespace.out`` RPC. If discovery fails or the RPC raises, fall
+    back to direct mode. If direct mode also fails (e.g. corrupt
+    ``tuples.db``, missing chroma dir) the exception propagates to
+    ``emit``'s outer try/except, which logs and swallows it so the hook
+    cannot crash user-facing tools.
+
+    nexus-6s8v (RDR-112): with the daemon owning ``tuples.db``, direct
+    mode runs the risk of WAL conflicts. Direct-mode fallback is kept
+    as a defense-in-depth for environments without a daemon (e.g. early
+    test runs); the regression test for daemon-mode routing
+    (``tests/cockpit/test_hook_bridge_daemon_routing.py``) asserts that
+    when a daemon is reachable the daemon path is taken.
+    """
+    if _ROUTING_TBA == "daemon":
+        try:
+            from nexus.daemon.discovery import find_t2_daemon  # noqa: PLC0415
+            from nexus.daemon.t2_client import T2Client  # noqa: PLC0415
+
+            info = find_t2_daemon()
+            if info is not None:
+                uds_path_str = info.get("uds_path") or ""
+                uds_path = Path(uds_path_str) if uds_path_str else None
+                if uds_path is not None and uds_path.exists():
+                    client = T2Client(uds_path=uds_path)
+                else:
+                    client = T2Client(tcp_addr=(info["tcp_host"], info["tcp_port"]))
+                try:
+                    client.tuplespace.out(
+                        subspace=subspace,
+                        content=content,
+                        dimensions=dimensions,
+                        match_text=match_text,
+                    )
+                    return "daemon"
+                finally:
+                    client.close()
+        except Exception as exc:
+            _log.warning(
+                "hook_bridge_daemon_route_failed_falling_back_to_direct",
+                error=str(exc),
+            )
+    # Fallback (or _ROUTING_TBA == "direct"): direct-mode auto path.
+    _emit_direct_auto(
+        subspace=subspace,
+        content=content,
+        dimensions=dimensions,
+        match_text=match_text,
+    )
+    return "direct"
 
 
 def _emit_direct_auto(

--- a/src/nexus/commands/daemon.py
+++ b/src/nexus/commands/daemon.py
@@ -84,6 +84,7 @@ def start_cmd(config_dir_str: str | None, foreground: bool) -> None:
     """
     from nexus.daemon.subspace_registry import RegistryStore
     from nexus.daemon.t2_daemon import T2Daemon
+    from nexus.daemon.tuplespace_service import TuplespaceService
     from nexus.db.t2 import T2Database
 
     config_dir = Path(config_dir_str) if config_dir_str else nexus_config_dir()
@@ -98,11 +99,25 @@ def start_cmd(config_dir_str: str | None, foreground: bool) -> None:
         # daemon's writer.
         t2db = T2Database(memory_db_path)
         registry_store = RegistryStore(tuples_db_path=tuples_db_path)
+
+        # nexus-6s8v (RDR-112): construct TuplespaceService so the daemon
+        # serves the tuplespace.* RPC suite. The service opens its own
+        # SQLite connection to tuples.db (single-writer per RDR-112 §9)
+        # and a TupleIndex backed by the local persistent chroma.
+        import chromadb
+        chroma_dir = config_dir / "chroma"
+        chroma_client = chromadb.PersistentClient(path=str(chroma_dir))
+        tuplespace_service = TuplespaceService(
+            tuples_db_path=tuples_db_path,
+            chroma_client=chroma_client,
+        )
+
         daemon = T2Daemon(
             config_dir=config_dir,
             t2db=t2db,
             tuples_db_path=tuples_db_path,
             registry_store=registry_store,
+            tuplespace_service=tuplespace_service,
         )
         try:
             await daemon.start()

--- a/src/nexus/daemon/discovery.py
+++ b/src/nexus/daemon/discovery.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Client-side discovery helper for the T2 daemon.
+
+Reads the discovery file written by ``T2Daemon._write_discovery`` and
+returns the parsed JSON payload, or ``None`` when no daemon is running
+for the current UID.
+
+Used by:
+  - ``nexus.mcp.core`` to construct a ``T2Client`` under
+    ``NX_STORAGE_MODE=daemon``.
+  - ``nexus.cockpit.hook_bridge`` to route hook tuples through the
+    daemon when one is reachable.
+
+The discovery file lives at ``<config_dir>/t2_addr.<uid>``. The daemon
+writes it atomically (tmpfile + os.replace) so a partial read is not
+possible.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+import structlog
+
+from nexus.config import nexus_config_dir
+
+_log = structlog.get_logger(__name__)
+
+
+def discovery_path(config_dir: Optional[Path] = None) -> Path:
+    """Return the discovery file path for the current UID."""
+    cd = config_dir if config_dir is not None else nexus_config_dir()
+    return cd / f"t2_addr.{os.getuid()}"
+
+
+def find_t2_daemon(config_dir: Optional[Path] = None) -> Optional[dict[str, Any]]:
+    """Return the daemon's discovery payload, or ``None`` if absent / unreadable.
+
+    Args:
+        config_dir: Optional override (defaults to ``nexus_config_dir()``).
+
+    Returns:
+        Dict with keys ``uds_path``, ``tcp_host``, ``tcp_port``, ``pid``,
+        ``daemon_version``, etc. (see ``T2Daemon._discovery_payload``).
+        ``None`` when no discovery file exists or it cannot be parsed.
+    """
+    path = discovery_path(config_dir)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        _log.warning("t2_discovery_read_failed", path=str(path), error=str(exc))
+        return None

--- a/src/nexus/daemon/t2_client.py
+++ b/src/nexus/daemon/t2_client.py
@@ -430,6 +430,118 @@ class _DatabaseProxy:
 
 
 # ---------------------------------------------------------------------------
+# Tuplespace proxy (RDR-112 nexus-6s8v)
+# ---------------------------------------------------------------------------
+
+
+class _TuplespaceProxy:
+    """Proxy for the daemon's tuplespace.* RPC suite.
+
+    The tuplespace API lives as free functions (``nexus.tuplespace.api``)
+    operating on three injected resources (conn, index, registry); there
+    is no single class whose methods can be introspected the way
+    ``_StoreProxy`` introspects domain stores. This proxy hand-defines
+    each method, mirroring the keyword-only public API.
+
+    Returns are JSON-decoded results from the daemon-side
+    ``TuplespaceService`` (see ``nexus.daemon.tuplespace_service``).
+    """
+
+    def __init__(self, pool: _ConnectionPool) -> None:
+        self._pool = pool
+
+    def _call(self, op: str, args: dict[str, Any]) -> Any:
+        with self._pool.acquire() as conn:
+            return conn.call(f"tuplespace.{op}", args)
+
+    def out(
+        self,
+        *,
+        subspace: str,
+        content: str,
+        dimensions: dict[str, Any],
+        match_text: str | None = None,
+        ttl_seconds: float | None = None,
+    ) -> str:
+        return self._call(
+            "out",
+            {
+                "subspace": subspace,
+                "content": content,
+                "dimensions": dimensions,
+                "match_text": match_text,
+                "ttl_seconds": ttl_seconds,
+            },
+        )
+
+    def read(
+        self,
+        *,
+        subspace: str,
+        query: str,
+        where: dict[str, Any] | None = None,
+        floor: float | None = None,
+        n: int | None = None,
+    ) -> list[dict[str, Any]]:
+        return self._call(
+            "read",
+            {
+                "subspace": subspace,
+                "query": query,
+                "where": where,
+                "floor": floor,
+                "n": n,
+            },
+        )
+
+    def take(
+        self,
+        *,
+        subspace: str,
+        query: str,
+        claimant: str,
+        where: dict[str, Any] | None = None,
+        floor: float | None = None,
+        lease_seconds: float | None = None,
+        block: bool = False,
+        timeout_seconds: float | None = None,
+    ) -> dict[str, Any] | None:
+        """Returns ``{"tuple": <dict>, "claim_id": <str>} | None``.
+
+        The two-tuple ``(tuple_dict, claim_id)`` of ``api.take`` is wrapped
+        into a single dict on the daemon side for JSON friendliness.
+        """
+        return self._call(
+            "take",
+            {
+                "subspace": subspace,
+                "query": query,
+                "claimant": claimant,
+                "where": where,
+                "floor": floor,
+                "lease_seconds": lease_seconds,
+                "block": block,
+                "timeout_seconds": timeout_seconds,
+            },
+        )
+
+    def ack(self, *, claim_id: str, claimant: str) -> str:
+        return self._call("ack", {"claim_id": claim_id, "claimant": claimant})
+
+    def nack(self, *, claim_id: str, claimant: str) -> str:
+        return self._call("nack", {"claim_id": claim_id, "claimant": claimant})
+
+    def list_subspaces(self) -> list[str]:
+        return self._call("list_subspaces", {})
+
+    def subspace_schema(self, *, subspace: str) -> dict[str, Any]:
+        return self._call("subspace_schema", {"subspace": subspace})
+
+    def subspace_stats(self, *, subspace: str) -> dict[str, Any]:
+        return self._call("subspace_stats", {"subspace": subspace})
+
+
+# ---------------------------------------------------------------------------
 # T2Client
 # ---------------------------------------------------------------------------
 
@@ -661,6 +773,16 @@ class T2Client:
     @property
     def database(self) -> _DatabaseProxy:
         return _DatabaseProxy(self._get_pool())
+
+    @property
+    def tuplespace(self) -> "_TuplespaceProxy":
+        """RDR-112 (nexus-6s8v): tuplespace RPC proxy.
+
+        Mirrors the tuplespace free-function API
+        (``nexus.tuplespace.api``) as keyword-only methods. Each method
+        round-trips through the daemon's ``tuplespace.<op>`` RPC.
+        """
+        return _TuplespaceProxy(self._get_pool())
 
     # ------------------------------------------------------------------
     # Convenience ping

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -448,6 +448,7 @@ class T2Daemon:
         t2db: Any = None,
         tuples_db_path: Path | None = None,
         registry_store: Any = None,
+        tuplespace_service: Any = None,
         enable_admin_ping: bool = False,
     ) -> None:
         """Initialise the daemon.
@@ -468,6 +469,13 @@ class T2Daemon:
                 the dispatch table. When ``None``, ``subspace_add`` returns an
                 unknown-op error. Typically constructed with
                 ``RegistryStore(tuples_db_path=config_dir / "tuples.db")``.
+            tuplespace_service: Optional ``TuplespaceService`` instance
+                (RDR-112 nexus-6s8v). When provided, the ``tuplespace.*``
+                RPCs (``out``, ``read``, ``take``, ``ack``, ``nack``,
+                ``list_subspaces``, ``subspace_schema``, ``subspace_stats``)
+                are registered in the dispatch table. When ``None``, those
+                ops return an unknown-op error and direct-mode is the only
+                way to reach the tuplespace.
             enable_admin_ping: If ``True``, register the ``admin_ping``
                 test-scaffold op in the dispatch table. This op is in
                 ``_ADMIN_OPS`` and is used by tests to exercise the UDS-only
@@ -530,6 +538,15 @@ class T2Daemon:
                     _log.warning("discovery_rewrite_failed_after_subspace_add", error=str(exc))
                 return result
             self._rpc_table["subspace_add"] = _subspace_add_handler
+
+        # nexus-6s8v (RDR-112): tuplespace RPC suite.
+        # Registers tuplespace.{out,read,take,ack,nack,list_subspaces,
+        # subspace_schema,subspace_stats}. The service owns its own SQLite
+        # connection to tuples.db (daemon is single writer per RDR-112 §9).
+        self._tuplespace_service = tuplespace_service
+        if tuplespace_service is not None:
+            from nexus.daemon.tuplespace_service import register_tuplespace_rpcs
+            register_tuplespace_rpcs(self._rpc_table, tuplespace_service)
 
         # P1.6 nexus-08i1: introspection RPCs.
         # exec_raw and export are admin-only (in _ADMIN_OPS); schema, peek,
@@ -675,6 +692,13 @@ class T2Daemon:
             for task in list(self._active_handlers):
                 task.cancel()
             await asyncio.gather(*self._active_handlers, return_exceptions=True)
+
+        # nexus-6s8v: release tuplespace SQLite connection.
+        if self._tuplespace_service is not None:
+            try:
+                self._tuplespace_service.close()
+            except Exception:  # pragma: no cover — defensive
+                _log.warning("tuplespace_service_close_failed", exc_info=True)
 
         self._unlink_discovery()
         self._release_spawn_lock()

--- a/src/nexus/daemon/tuplespace_service.py
+++ b/src/nexus/daemon/tuplespace_service.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tuplespace service — daemon-side wrapper exposing the tuplespace
+free-function API (``nexus.tuplespace.api``) as a set of RPC handlers.
+
+RDR-112 / nexus-6s8v: Tuplespace was missing from ``_T2_STORE_ATTRS`` in
+``t2_daemon.py``. Every tuplespace MCP tool ``AttributeError``ed under
+``NX_STORAGE_MODE=daemon`` because ``mcp/core.py`` returned
+``conn=None, index=None`` in daemon mode (no daemon RPCs existed).
+
+Why a service class instead of adding ``"tuplespace"`` to
+``_T2_STORE_ATTRS``
+-------------------------------------------------------------------
+The other domain stores expose bound methods on ``t2db.<attr>`` that
+introspect cleanly via ``inspect.getmembers``. Tuplespace operates on
+*three* injected resources (``sqlite3.Connection``, ``TupleIndex``,
+``Registry``) and the public API lives as free functions in
+``nexus.tuplespace.api`` — there is no single store object whose methods
+share a signature pattern that can be enumerated. A purpose-built
+service wrapping the three resources is cleaner than retrofitting the
+free-function API onto the introspection path.
+
+RPC surface (registered in T2Daemon via ``register_tuplespace_rpcs``):
+  - ``tuplespace.out``
+  - ``tuplespace.read``
+  - ``tuplespace.take``
+  - ``tuplespace.ack``
+  - ``tuplespace.nack``
+  - ``tuplespace.list_subspaces``
+  - ``tuplespace.subspace_schema``
+  - ``tuplespace.subspace_stats``
+
+EventStream subscriptions (``event_stream.subscribe``) are already
+served by the existing ``handle_event_stream`` machinery (P1.3
+nexus-m4gm) — no new RPC needed for that.
+
+Connection lifecycle
+--------------------
+The daemon owns a single ``sqlite3.Connection`` to ``tuples.db`` (WAL
+mode). All tuplespace RPCs run in the daemon's thread-pool executor;
+because the daemon serialises them on the single connection there is
+no concurrent-write race. The connection is closed when ``close()`` is
+called (lifecycle managed by T2Daemon).
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any, Optional
+
+import structlog
+
+from nexus.tuplespace import api as ts_api
+from nexus.tuplespace.index import TupleIndex
+from nexus.tuplespace.registry import Registry, default_builtin_dir
+from nexus.tuplespace.store import open_tuples_db
+
+_log = structlog.get_logger(__name__)
+
+
+class TuplespaceService:
+    """Daemon-side service wrapping the tuplespace free-function API.
+
+    Construct once at daemon start with the path to ``tuples.db`` and a
+    chromadb client. The service opens its own SQLite connection (the
+    daemon is the single writer per RDR-112 §9) and builds a
+    ``TupleIndex`` from the configured registry.
+
+    Args:
+        tuples_db_path: Filesystem path to ``tuples.db``. Created if absent.
+        chroma_client: Any chromadb ``ClientAPI``-compatible instance.
+            Production daemons pass ``PersistentClient(path=<chroma_dir>)``;
+            tests pass ``EphemeralClient()``.
+        registry: Loaded :class:`Registry`. When ``None``, the default
+            builtin registry is loaded (production path). Tests inject
+            registries with custom subspace YAML for isolation.
+    """
+
+    def __init__(
+        self,
+        *,
+        tuples_db_path: Path,
+        chroma_client: Any,
+        registry: Optional[Registry] = None,
+    ) -> None:
+        self._tuples_db_path = tuples_db_path
+        self._registry = registry if registry is not None else Registry.load(
+            default_builtin_dir()
+        )
+        # Initialise schema via the public helper, then reopen the
+        # connection with ``check_same_thread=False`` because the daemon
+        # dispatches handlers in the thread-pool executor. The daemon
+        # serialises tuplespace RPCs across the single connection (one
+        # writer at a time) — SQLite's WAL mode permits concurrent
+        # readers safely so passing the connection between executor
+        # threads is well-defined here.
+        open_tuples_db(tuples_db_path).close()
+        self._conn: sqlite3.Connection = sqlite3.connect(
+            str(tuples_db_path),
+            check_same_thread=False,
+        )
+        self._conn.row_factory = sqlite3.Row
+        # Serialise SQL execution across executor threads. Single shared
+        # connection + threading.Lock is the standard CPython pattern for
+        # a sync-API service called from an asyncio thread-pool.
+        self._lock = threading.Lock()
+        self._index: TupleIndex = TupleIndex.from_registry(
+            self._registry, chroma_client
+        )
+        _log.info(
+            "tuplespace_service_started",
+            tuples_db=str(tuples_db_path),
+        )
+
+    # ------------------------------------------------------------------
+    # RPC handlers — keyword-only contracts mirroring nexus.tuplespace.api
+    # ------------------------------------------------------------------
+
+    def out(
+        self,
+        *,
+        subspace: str,
+        content: str,
+        dimensions: dict[str, Any],
+        match_text: Optional[str] = None,
+        ttl_seconds: Optional[float] = None,
+    ) -> str:
+        with self._lock:
+            return ts_api.out(
+                conn=self._conn,
+                index=self._index,
+                registry=self._registry,
+                subspace=subspace,
+                content=content,
+                dimensions=dimensions,
+                match_text=match_text or None,
+                ttl_seconds=ttl_seconds,
+            )
+
+    def read(
+        self,
+        *,
+        subspace: str,
+        query: str,
+        where: Optional[dict[str, Any]] = None,
+        floor: Optional[float] = None,
+        n: Optional[int] = None,
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            return ts_api.read(
+                conn=self._conn,
+                index=self._index,
+                registry=self._registry,
+                subspace=subspace,
+                query=query,
+                where=where,
+                floor=floor,
+                n=n,
+            )
+
+    def take(
+        self,
+        *,
+        subspace: str,
+        query: str,
+        claimant: str,
+        where: Optional[dict[str, Any]] = None,
+        floor: Optional[float] = None,
+        lease_seconds: Optional[float] = None,
+        block: bool = False,
+        timeout_seconds: Optional[float] = None,
+    ) -> Optional[dict[str, Any]]:
+        """Wraps ``api.take``; returns a single dict (or None) for JSON
+        friendliness.
+
+        ``api.take`` returns ``(tuple_dict, claim_id) | None``. The RPC
+        wraps the tuple as ``{"tuple": <dict>, "claim_id": <str>}`` so the
+        client sees a single dict result.
+        """
+        with self._lock:
+            result = ts_api.take(
+                conn=self._conn,
+                index=self._index,
+                registry=self._registry,
+                subspace=subspace,
+                query=query,
+                claimant=claimant,
+                where=where,
+                floor=floor,
+                lease_seconds=lease_seconds,
+                block=block,
+                timeout_seconds=timeout_seconds,
+            )
+        if result is None:
+            return None
+        t_dict, claim_id = result
+        return {"tuple": t_dict, "claim_id": claim_id}
+
+    def ack(self, *, claim_id: str, claimant: str) -> str:
+        with self._lock:
+            ts_api.ack(conn=self._conn, claim_id=claim_id, claimant=claimant)
+        return "ok"
+
+    def nack(self, *, claim_id: str, claimant: str) -> str:
+        with self._lock:
+            ts_api.nack(conn=self._conn, claim_id=claim_id, claimant=claimant)
+        return "ok"
+
+    def list_subspaces(self) -> list[str]:
+        return ts_api.list_subspaces(registry=self._registry)
+
+    def subspace_schema(self, *, subspace: str) -> dict[str, Any]:
+        return ts_api.subspace_schema(registry=self._registry, subspace=subspace)
+
+    def subspace_stats(self, *, subspace: str) -> dict[str, Any]:
+        with self._lock:
+            return ts_api.subspace_stats(conn=self._conn, subspace=subspace)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Close the SQLite connection. Idempotent."""
+        try:
+            self._conn.close()
+        except Exception:  # pragma: no cover — defensive
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Registration helper
+# ---------------------------------------------------------------------------
+
+
+def register_tuplespace_rpcs(
+    rpc_table: dict[str, Any],
+    service: TuplespaceService,
+) -> None:
+    """Register all ``tuplespace.*`` RPC handlers into ``rpc_table``.
+
+    Used by ``T2Daemon.__init__`` after the dispatch table is built.
+    Keeping the registration list in one place ensures the daemon and
+    the corresponding ``T2Client.tuplespace`` proxy stay in sync.
+
+    Args:
+        rpc_table: The mutable dispatch table on ``T2Daemon``.
+        service: A constructed ``TuplespaceService``.
+    """
+    handlers = {
+        "tuplespace.out": service.out,
+        "tuplespace.read": service.read,
+        "tuplespace.take": service.take,
+        "tuplespace.ack": service.ack,
+        "tuplespace.nack": service.nack,
+        "tuplespace.list_subspaces": service.list_subspaces,
+        "tuplespace.subspace_schema": service.subspace_schema,
+        "tuplespace.subspace_stats": service.subspace_stats,
+    }
+    for op, fn in handlers.items():
+        rpc_table[op] = fn
+    _log.info("tuplespace_rpcs_registered", count=len(handlers))
+
+
+#: Public list of tuplespace RPC op names. Imported by ``T2Client.tuplespace``
+#: so the client and the daemon stay in lockstep — adding an op here is the
+#: single point of change.
+TUPLESPACE_RPC_OPS: tuple[str, ...] = (
+    "out",
+    "read",
+    "take",
+    "ack",
+    "nack",
+    "list_subspaces",
+    "subspace_schema",
+    "subspace_stats",
+)

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -4189,15 +4189,35 @@ def _get_tuplespace() -> dict[str, Any]:
 
     storage_mode = _os.environ.get("NX_STORAGE_MODE", "").lower()
     if storage_mode == "daemon":
-        _ts_log.info("tuplespace_mcp_daemon_mode_conn_skipped")
-        # In daemon mode: no local SQLite connection (daemon owns the db).
-        # Tools that need conn currently raise AttributeError on the first
-        # ``conn.execute(...)`` call inside ``api.out``/``read``/``take``/
-        # ``ack``/``nack``. RDR-112 Phase 3 will replace the conn/index
-        # references with T2Client routing so each tool hits the daemon
-        # instead. Until that ships, tuplespace_* tools are non-functional
-        # under ``NX_STORAGE_MODE=daemon``.
-        _TUPLESPACE.update({"registry": registry, "conn": None, "index": None, "watcher": None})
+        # nexus-6s8v (RDR-112): daemon-mode tuplespace routing.
+        # Build a T2Client connected to the running daemon's UDS (or TCP
+        # fallback), and stash it in _TUPLESPACE for the tool handlers to
+        # call instead of the direct conn/index path. The registry is
+        # still loaded locally for callers that only need schema metadata
+        # without an RPC round-trip — registry is read-only and the local
+        # builtin YAMLs are the same the daemon loads.
+        from nexus.daemon.discovery import find_t2_daemon  # noqa: PLC0415
+        from nexus.daemon.t2_client import T2Client  # noqa: PLC0415
+
+        info = find_t2_daemon()
+        if info is None:
+            _ts_log.error("tuplespace_mcp_daemon_mode_daemon_not_running")
+            raise RuntimeError(
+                "NX_STORAGE_MODE=daemon is set but no T2 daemon discovery "
+                "file was found. Run `nx daemon t2 start` first."
+            )
+        uds_path = Path(info["uds_path"]) if info.get("uds_path") else None
+        if uds_path is not None and uds_path.exists():
+            client = T2Client(uds_path=uds_path)
+        else:
+            client = T2Client(tcp_addr=(info["tcp_host"], info["tcp_port"]))
+        _ts_log.info(
+            "tuplespace_mcp_daemon_mode_client_ready",
+            transport="uds" if uds_path is not None and uds_path.exists() else "tcp",
+        )
+        _TUPLESPACE.update(
+            {"registry": registry, "conn": None, "index": None, "watcher": None, "client": client}
+        )
         return _TUPLESPACE
 
     conn = open_tuples_db(db_path)
@@ -4272,6 +4292,15 @@ def tuplespace_out(
 
     ts = _get_tuplespace()
     dims = _json.loads(dimensions) if isinstance(dimensions, str) else dimensions
+    client = ts.get("client")
+    if client is not None:
+        return client.tuplespace.out(
+            subspace=subspace,
+            content=content,
+            dimensions=dims,
+            match_text=match_text or None,
+            ttl_seconds=ttl_seconds if ttl_seconds > 0 else None,
+        )
     tid = out(
         conn=ts["conn"],
         index=ts["index"],
@@ -4315,16 +4344,26 @@ def tuplespace_read(
 
     ts = _get_tuplespace()
     where_dict = _json.loads(where) if where else None
-    results = read(
-        conn=ts["conn"],
-        index=ts["index"],
-        registry=ts["registry"],
-        subspace=subspace,
-        query=query,
-        where=where_dict,
-        floor=floor if floor > 0.0 else None,
-        n=n if n > 0 else None,
-    )
+    client = ts.get("client")
+    if client is not None:
+        results = client.tuplespace.read(
+            subspace=subspace,
+            query=query,
+            where=where_dict,
+            floor=floor if floor > 0.0 else None,
+            n=n if n > 0 else None,
+        )
+    else:
+        results = read(
+            conn=ts["conn"],
+            index=ts["index"],
+            registry=ts["registry"],
+            subspace=subspace,
+            query=query,
+            where=where_dict,
+            floor=floor if floor > 0.0 else None,
+            n=n if n > 0 else None,
+        )
     return _json.dumps(results, default=str)
 
 
@@ -4361,6 +4400,22 @@ def tuplespace_take(
 
     ts = _get_tuplespace()
     where_dict = _json.loads(where) if where else None
+    client = ts.get("client")
+    if client is not None:
+        # Daemon-side ``take`` returns a single dict (or None) with the
+        # ``tuple`` + ``claim_id`` already wrapped.
+        wrapped = client.tuplespace.take(
+            subspace=subspace,
+            query=query,
+            claimant=claimant,
+            where=where_dict,
+            floor=floor if floor > 0.0 else None,
+            lease_seconds=lease_seconds if lease_seconds > 0.0 else None,
+            block=False,
+        )
+        if wrapped is None:
+            return "null"
+        return _json.dumps(wrapped, default=str)
     result = take(
         conn=ts["conn"],
         index=ts["index"],
@@ -4396,6 +4451,10 @@ def tuplespace_ack(
     from nexus.tuplespace.api import ack
 
     ts = _get_tuplespace()
+    client = ts.get("client")
+    if client is not None:
+        client.tuplespace.ack(claim_id=claim_id, claimant=claimant)
+        return "ok"
     ack(conn=ts["conn"], claim_id=claim_id, claimant=claimant)
     return "ok"
 
@@ -4417,6 +4476,10 @@ def tuplespace_nack(
     from nexus.tuplespace.api import nack
 
     ts = _get_tuplespace()
+    client = ts.get("client")
+    if client is not None:
+        client.tuplespace.nack(claim_id=claim_id, claimant=claimant)
+        return "ok"
     nack(conn=ts["conn"], claim_id=claim_id, claimant=claimant)
     return "ok"
 
@@ -4433,6 +4496,9 @@ def tuplespace_list_subspaces() -> str:
     from nexus.tuplespace.api import list_subspaces
 
     ts = _get_tuplespace()
+    client = ts.get("client")
+    if client is not None:
+        return _json.dumps(client.tuplespace.list_subspaces())
     return _json.dumps(list_subspaces(registry=ts["registry"]))
 
 
@@ -4451,6 +4517,9 @@ def tuplespace_subspace_schema(subspace: str) -> str:
     from nexus.tuplespace.api import subspace_schema
 
     ts = _get_tuplespace()
+    client = ts.get("client")
+    if client is not None:
+        return _json.dumps(client.tuplespace.subspace_schema(subspace=subspace), default=str)
     return _json.dumps(subspace_schema(registry=ts["registry"], subspace=subspace), default=str)
 
 
@@ -4468,6 +4537,9 @@ def tuplespace_subspace_stats(subspace: str) -> str:
     from nexus.tuplespace.api import subspace_stats
 
     ts = _get_tuplespace()
+    client = ts.get("client")
+    if client is not None:
+        return _json.dumps(client.tuplespace.subspace_stats(subspace=subspace))
     return _json.dumps(subspace_stats(conn=ts["conn"], subspace=subspace))
 
 

--- a/tests/cockpit/test_hook_bridge_daemon_routing.py
+++ b/tests/cockpit/test_hook_bridge_daemon_routing.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 nexus-6s8v: hook_bridge daemon-mode routing.
+
+Verifies the post-flip behaviour of ``_ROUTING_TBA = "daemon"``:
+
+1. With CLAUDECODE set and a reachable daemon, ``emit()`` routes through
+   the daemon's ``tuplespace.out`` RPC (no direct sqlite touch).
+2. With CLAUDECODE set and NO daemon discovery file, ``emit()`` falls
+   back to direct mode (existing behaviour, defense-in-depth).
+3. Without CLAUDECODE, no side effect (RF-5 gate, unchanged).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import chromadb
+import pytest
+
+from nexus.cockpit import hook_bridge
+from nexus.daemon.t2_daemon import T2Daemon
+from nexus.daemon.tuplespace_service import TuplespaceService
+from nexus.tuplespace.registry import Registry
+
+
+_TASKS_YAML = """
+name: hook_events/tool_call_intent
+tier: project
+content_type: text
+embed_from: match_text
+dimensions:
+  actor: { type: string, required: true }
+  session: { type: string, required: true }
+  project: { type: string, required: true }
+  timestamp: { type: string, required: true }
+  tool: { type: string, required: false }
+take:
+  enabled: false
+  mode: semantic
+  default_lease_seconds: 60
+read:
+  default_floor: 0.0
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+
+@pytest.fixture
+def test_registry(tmp_path: Path) -> Registry:
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+    (builtin / "tool_call_intent.yml").write_text(_TASKS_YAML)
+    return Registry.load(builtin)
+
+
+def _run_daemon(daemon: T2Daemon) -> asyncio.AbstractEventLoop:
+    started = threading.Event()
+    loop = asyncio.new_event_loop()
+
+    def _thread() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(daemon.start())
+        started.set()
+        loop.run_forever()
+
+    t = threading.Thread(target=_thread, daemon=True)
+    t.start()
+    started.wait(timeout=5.0)
+    return loop
+
+
+def _stop_daemon(daemon: T2Daemon, loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.run_coroutine_threadsafe(daemon.stop(), loop).result(timeout=5.0)
+    loop.call_soon_threadsafe(loop.stop)
+
+
+@pytest.fixture
+def chroma_client():
+    client = chromadb.EphemeralClient()
+    yield client
+    for coll in client.list_collections():
+        client.delete_collection(coll.name)
+
+
+_PAYLOAD = {
+    "session_id": "test-session-xyz",
+    "cwd": "/tmp/test-project",
+    "tool_name": "Bash",
+    "tool_input": {"command": "echo hi"},
+}
+
+
+class TestDaemonRouting:
+    def test_emit_routes_through_daemon_when_reachable(
+        self,
+        tmp_path: Path,
+        test_registry: Registry,
+        chroma_client,
+        monkeypatch,
+    ) -> None:
+        """With a reachable daemon, emit() calls tuplespace.out RPC.
+
+        We assert behaviourally: the daemon's TuplespaceService records
+        the post in its tuples.db, and direct-mode is NOT touched (the
+        _emit_direct_auto path is patched to raise so we catch any
+        fallthrough).
+        """
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        tuples_db_path = config_dir / "tuples.db"
+
+        service = TuplespaceService(
+            tuples_db_path=tuples_db_path,
+            chroma_client=chroma_client,
+            registry=test_registry,
+        )
+        daemon = T2Daemon(
+            config_dir=config_dir,
+            tuples_db_path=tuples_db_path,
+            tuplespace_service=service,
+        )
+        loop = _run_daemon(daemon)
+
+        # Point discovery at the test daemon's config_dir.
+        # find_t2_daemon() consults nexus_config_dir() by default — patch it.
+        from nexus.daemon import discovery as _disc
+        monkeypatch.setattr(_disc, "nexus_config_dir", lambda: config_dir)
+        # Also gate the discovery path used by hook_bridge directly.
+
+        # Set CLAUDECODE so RF-5 doesn't short-circuit.
+        monkeypatch.setenv("CLAUDECODE", "1")
+
+        # If anything falls through to direct mode, blow up.
+        def _no_direct(*_args, **_kwargs):
+            raise AssertionError(
+                "_emit_direct_auto was called even though daemon was reachable"
+            )
+
+        try:
+            with patch.object(hook_bridge, "_emit_direct_auto", _no_direct):
+                hook_bridge.emit("PreToolUse", _PAYLOAD)
+        finally:
+            _stop_daemon(daemon, loop)
+
+        # The post landed in tuples.db via the daemon. Open a separate
+        # connection (daemon is stopped now) and count rows.
+        import sqlite3
+        conn = sqlite3.connect(str(tuples_db_path))
+        try:
+            (count,) = conn.execute(
+                "SELECT COUNT(*) FROM tuples WHERE subspace = ?",
+                ("hook_events/tool_call_intent",),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert count == 1, f"expected 1 daemon-posted tuple, got {count}"
+
+    def test_emit_falls_back_to_direct_when_no_daemon(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """No discovery file -> _emit_direct_auto is called."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        # Point discovery at an empty dir so find_t2_daemon returns None.
+        from nexus.daemon import discovery as _disc
+        monkeypatch.setattr(_disc, "nexus_config_dir", lambda: config_dir)
+        monkeypatch.setenv("CLAUDECODE", "1")
+
+        called: list[dict] = []
+
+        def _fake_direct(*, subspace, content, dimensions, match_text):
+            called.append({"subspace": subspace})
+
+        with patch.object(hook_bridge, "_emit_direct_auto", _fake_direct):
+            hook_bridge.emit("PreToolUse", _PAYLOAD)
+
+        assert len(called) == 1
+        assert called[0]["subspace"] == "hook_events/tool_call_intent"
+
+    def test_emit_skips_without_claudecode(
+        self,
+        monkeypatch,
+    ) -> None:
+        """RF-5: no CLAUDECODE => no side effect, regardless of routing."""
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+
+        called: list[dict] = []
+
+        def _fake_direct(*args, **kwargs):
+            called.append({})
+
+        with patch.object(hook_bridge, "_emit_direct_auto", _fake_direct):
+            hook_bridge.emit("PreToolUse", _PAYLOAD)
+
+        assert called == []
+
+    def test_routing_constant_is_daemon(self) -> None:
+        """Regression: nexus-6s8v flipped _ROUTING_TBA to 'daemon'."""
+        assert hook_bridge._ROUTING_TBA == "daemon"

--- a/tests/daemon/test_tuplespace_client.py
+++ b/tests/daemon/test_tuplespace_client.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""RDR-112 nexus-6s8v: tuplespace RPC round-trip tests.
+
+Spins a T2Daemon with a TuplespaceService against an EphemeralClient
+chroma + a temp tuples.db, then exercises every tuplespace.* RPC
+through the T2Client.tuplespace proxy and asserts behavioural parity
+with the direct ``nexus.tuplespace.api`` path.
+
+Also verifies:
+- All tuplespace RPC ops appear in the daemon dispatch table.
+- ``register_tuplespace_rpcs`` is the single source of truth for the
+  surface area (``TUPLESPACE_RPC_OPS``).
+- ack/nack ownership errors round-trip as ``PermissionError``.
+"""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+import chromadb
+import pytest
+
+from nexus.daemon.t2_client import T2Client
+from nexus.daemon.t2_daemon import T2Daemon
+from nexus.daemon.tuplespace_service import (
+    TUPLESPACE_RPC_OPS,
+    TuplespaceService,
+)
+from nexus.tuplespace.registry import Registry
+
+
+# ---------------------------------------------------------------------------
+# Test registry: minimal subspaces exercising semantic + exact modes
+# ---------------------------------------------------------------------------
+
+_TASKS_YAML = """
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status: { type: enum, values: [open, claimed, done], required: true }
+  priority: { type: enum, values: [P0, P1, P2], required: true }
+  created_by: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.0
+  margin: 0.0
+  default_lease_seconds: 60
+read:
+  default_floor: 0.0
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+_LOCKS_YAML = """
+name: locks/<resource>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  resource: { type: string, required: true }
+  holder: { type: string, required: true }
+take:
+  enabled: true
+  mode: exact
+  match_keys: [resource]
+  default_lease_seconds: 30
+read:
+  default_floor: 0.0
+  default_n: 5
+tiers: [project]
+retention_seconds: 3600
+"""
+
+
+@pytest.fixture
+def test_registry(tmp_path: Path) -> Registry:
+    builtin = tmp_path / "builtin"
+    builtin.mkdir()
+    (builtin / "tasks.yml").write_text(_TASKS_YAML)
+    (builtin / "locks.yml").write_text(_LOCKS_YAML)
+    return Registry.load(builtin)
+
+
+# ---------------------------------------------------------------------------
+# Daemon harness — runs T2Daemon in a background asyncio loop
+# ---------------------------------------------------------------------------
+
+
+def _run_daemon(daemon: T2Daemon) -> asyncio.AbstractEventLoop:
+    started = threading.Event()
+    loop = asyncio.new_event_loop()
+
+    def _thread() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(daemon.start())
+        started.set()
+        loop.run_forever()
+
+    t = threading.Thread(target=_thread, daemon=True)
+    t.start()
+    started.wait(timeout=5.0)
+    return loop
+
+
+def _stop_daemon(daemon: T2Daemon, loop: asyncio.AbstractEventLoop) -> None:
+    asyncio.run_coroutine_threadsafe(daemon.stop(), loop).result(timeout=5.0)
+    loop.call_soon_threadsafe(loop.stop)
+
+
+@pytest.fixture
+def chroma_client():
+    client = chromadb.EphemeralClient()
+    yield client
+    # Clear collections so EphemeralClient's process-shared state doesn't bleed
+    for coll in client.list_collections():
+        client.delete_collection(coll.name)
+
+
+@pytest.fixture
+def daemon_and_client(tmp_path: Path, test_registry: Registry, chroma_client):
+    """Boot a T2Daemon with a TuplespaceService and yield (daemon, T2Client)."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    tuples_db_path = config_dir / "tuples.db"
+
+    service = TuplespaceService(
+        tuples_db_path=tuples_db_path,
+        chroma_client=chroma_client,
+        registry=test_registry,
+    )
+
+    daemon = T2Daemon(
+        config_dir=config_dir,
+        tuples_db_path=tuples_db_path,
+        tuplespace_service=service,
+    )
+    loop = _run_daemon(daemon)
+    client = T2Client(uds_path=daemon.uds_path)
+    try:
+        yield daemon, client
+    finally:
+        client.close()
+        _stop_daemon(daemon, loop)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-table coverage
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchTableCoverage:
+    """All TUPLESPACE_RPC_OPS must appear in the daemon's _rpc_table."""
+
+    def test_all_ops_registered(self, daemon_and_client) -> None:
+        daemon, _ = daemon_and_client
+        for op in TUPLESPACE_RPC_OPS:
+            assert f"tuplespace.{op}" in daemon._rpc_table, (
+                f"tuplespace.{op} missing from daemon dispatch table"
+            )
+
+    def test_ops_callable(self, daemon_and_client) -> None:
+        daemon, _ = daemon_and_client
+        for op in TUPLESPACE_RPC_OPS:
+            fn = daemon._rpc_table[f"tuplespace.{op}"]
+            assert callable(fn)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip RPC behaviour
+# ---------------------------------------------------------------------------
+
+
+def _dims() -> dict[str, Any]:
+    return {"status": "open", "priority": "P1", "created_by": "agent-X"}
+
+
+class TestTuplespaceRoundTrip:
+    def test_out_returns_tuple_id(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        tid = client.tuplespace.out(
+            subspace="tasks/nexus",
+            content="research the daemon RPC surface",
+            dimensions=_dims(),
+        )
+        assert isinstance(tid, str)
+        assert len(tid) == 32  # sha256 prefix
+
+    def test_out_is_idempotent(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        kwargs = dict(
+            subspace="tasks/nexus",
+            content="same body",
+            dimensions=_dims(),
+        )
+        t1 = client.tuplespace.out(**kwargs)
+        t2 = client.tuplespace.out(**kwargs)
+        assert t1 == t2
+
+    def test_read_returns_posted_tuples(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        client.tuplespace.out(
+            subspace="tasks/nexus",
+            content="apple banana cherry",
+            dimensions=_dims(),
+        )
+        rows = client.tuplespace.read(
+            subspace="tasks/nexus",
+            query="apple",
+            n=5,
+        )
+        assert len(rows) >= 1
+        assert any("apple" in r["content"] for r in rows)
+
+    def test_take_claims_tuple(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        client.tuplespace.out(
+            subspace="tasks/nexus",
+            content="unique_take_target",
+            dimensions=_dims(),
+        )
+        wrapped = client.tuplespace.take(
+            subspace="tasks/nexus",
+            query="unique_take_target",
+            claimant="agent-A",
+        )
+        assert wrapped is not None
+        assert "tuple" in wrapped
+        assert "claim_id" in wrapped
+        assert isinstance(wrapped["claim_id"], str)
+
+    def test_take_returns_none_when_empty(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        result = client.tuplespace.take(
+            subspace="tasks/nexus",
+            query="nothing-here",
+            claimant="agent-A",
+        )
+        assert result is None
+
+    def test_ack_completes_claim(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        client.tuplespace.out(
+            subspace="tasks/nexus",
+            content="ack-target",
+            dimensions=_dims(),
+        )
+        wrapped = client.tuplespace.take(
+            subspace="tasks/nexus",
+            query="ack-target",
+            claimant="agent-A",
+        )
+        assert wrapped is not None
+        result = client.tuplespace.ack(
+            claim_id=wrapped["claim_id"], claimant="agent-A"
+        )
+        assert result == "ok"
+
+    def test_nack_releases_claim(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        client.tuplespace.out(
+            subspace="tasks/nexus",
+            content="nack-target",
+            dimensions=_dims(),
+        )
+        wrapped = client.tuplespace.take(
+            subspace="tasks/nexus",
+            query="nack-target",
+            claimant="agent-A",
+        )
+        assert wrapped is not None
+        result = client.tuplespace.nack(
+            claim_id=wrapped["claim_id"], claimant="agent-A"
+        )
+        assert result == "ok"
+        # After nack the same claimant can re-take
+        retaken = client.tuplespace.take(
+            subspace="tasks/nexus",
+            query="nack-target",
+            claimant="agent-A",
+        )
+        assert retaken is not None
+
+    def test_ack_wrong_claimant_raises_permission_error(
+        self, daemon_and_client
+    ) -> None:
+        _daemon, client = daemon_and_client
+        client.tuplespace.out(
+            subspace="tasks/nexus",
+            content="ownership-test",
+            dimensions=_dims(),
+        )
+        wrapped = client.tuplespace.take(
+            subspace="tasks/nexus",
+            query="ownership-test",
+            claimant="owner-A",
+        )
+        assert wrapped is not None
+        # Foreign claimant trying to ack — daemon raises ClaimOwnershipError
+        # (PermissionError subclass on the daemon side). The client wraps
+        # non-builtin remote exceptions as T2DaemonError, so we assert on
+        # either: the underlying PermissionError (if name-resolved) or the
+        # generic T2DaemonError carrying the original type_name.
+        from nexus.daemon.t2_client import T2DaemonError
+        with pytest.raises((PermissionError, T2DaemonError)) as exc_info:
+            client.tuplespace.ack(
+                claim_id=wrapped["claim_id"], claimant="impostor"
+            )
+        # Confirm the ownership message round-tripped regardless of which
+        # class wrapped it.
+        assert "impostor" in str(exc_info.value) or "owned by" in str(exc_info.value)
+
+    def test_list_subspaces(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        names = client.tuplespace.list_subspaces()
+        assert "tasks/<project>" in names
+        assert "locks/<resource>" in names
+
+    def test_subspace_schema(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        schema = client.tuplespace.subspace_schema(subspace="tasks/nexus")
+        assert schema["name"] == "tasks/<project>"
+        assert schema["content_type"] == "text"
+        assert "dimensions" in schema
+
+    def test_subspace_stats(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        client.tuplespace.out(
+            subspace="tasks/nexus",
+            content="stats-target",
+            dimensions=_dims(),
+        )
+        stats = client.tuplespace.subspace_stats(subspace="tasks/nexus")
+        assert stats["total"] >= 1
+        assert stats["available"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Exact-mode take via daemon
+# ---------------------------------------------------------------------------
+
+
+class TestExactModeViaDaemon:
+    def test_exact_take_with_match_key(self, daemon_and_client) -> None:
+        _daemon, client = daemon_and_client
+        client.tuplespace.out(
+            subspace="locks/db-write",
+            content="lock",
+            dimensions={"resource": "db/write", "holder": "agent-A"},
+        )
+        wrapped = client.tuplespace.take(
+            subspace="locks/db-write",
+            query="",
+            claimant="agent-A",
+            where={"resource": "db/write"},
+        )
+        assert wrapped is not None
+        assert wrapped["tuple"]["dimensions"]["resource"] == "db/write"


### PR DESCRIPTION
## Summary

PR #786 deep review surfaced that ``_T2_STORE_ATTRS`` in ``t2_daemon.py`` listed 8 stores but tuplespace was absent. Every ``tuplespace_*`` MCP tool ``AttributeError``ed under ``NX_STORAGE_MODE=daemon`` because ``mcp/core.py _get_tuplespace`` returned ``conn=None, index=None`` (no daemon RPCs existed to route to). RDR-112 §Approach's "daemon owns tuples.db" claim was unimplementable until this lands. This PR closes the gap end-to-end:

- New ``TuplespaceService`` (``src/nexus/daemon/tuplespace_service.py``) wraps the ``nexus.tuplespace.api`` free-function API as a daemon-side service exposing the eight RPC ops: ``out``, ``read``, ``take``, ``ack``, ``nack``, ``list_subspaces``, ``subspace_schema``, ``subspace_stats``. Owns its own SQLite connection to ``tuples.db`` with ``check_same_thread=False`` plus a ``threading.Lock`` so the asyncio thread-pool executor can dispatch handlers safely.
- New ``T2Client.tuplespace`` proxy (``src/nexus/daemon/t2_client.py``) mirrors the keyword-only public surface and routes through ``tuplespace.<op>``. EventStream subscription is already served by ``event_stream.subscribe`` (P1.3 nexus-m4gm), so no new streaming RPC is needed.
- ``mcp/core.py`` under ``NX_STORAGE_MODE=daemon`` now constructs a ``T2Client`` via a new ``nexus.daemon.discovery.find_t2_daemon()`` helper and routes each tuplespace MCP tool through the daemon. Ack-policy and behaviour are preserved exactly across direct and daemon modes.
- ``_ROUTING_TBA`` in ``nexus.cockpit.hook_bridge`` flipped from ``"direct"`` to ``"daemon"`` (this unblocks RDR-112 Phase 3). ``emit()`` now tries daemon first, falls back to direct, and on a final failure logs+skips so user-facing hooks never crash because the tuplespace is down.
- ``nx daemon t2 start`` constructs a ``TuplespaceService`` backed by ``PersistentClient`` and passes it to ``T2Daemon``.

### Streaming RPC deferrals

None — ``event_stream.subscribe`` already exists from nexus-m4gm and remains the streaming surface for tuplespace events. The bead spec called out this possibility; nothing new needed.

### Out of scope (per bead spec)

- Registry dual-source (nexus-me9y).
- ``api.out`` two-store atomicity (nexus-qmrr).

## Test plan

- [x] ``tests/daemon/test_tuplespace_client.py`` (14 cases): dispatch-table coverage for ``TUPLESPACE_RPC_OPS``, end-to-end RPC round-trip for every op against an ``EphemeralClient`` + temp ``tuples.db``, ownership-error propagation, exact-mode take through the daemon.
- [x] ``tests/cockpit/test_hook_bridge_daemon_routing.py`` (4 cases): daemon-routed ``emit`` lands a tuple in the daemon's ``tuples.db`` without touching ``_emit_direct_auto``; fallback to direct when no discovery file; RF-5 gate still skips without ``CLAUDECODE``; ``_ROUTING_TBA`` regression check.
- [x] ``uv run pytest tests/tuplespace/ tests/cockpit/`` — 160 passed.
- [ ] ``uv run pytest tests/daemon/`` — running at PR-open time.

## Closes

Closes nexus-6s8v

Epic: nexus-hp9f