### PR TITLE
feat(aspect_extractor): scholarly-paper-v2 prompt (opt-in via NEXUS_SCHOLARLY_PAPER_VERSION)

### DIFF
--- a/src/nexus/aspect_extractor.py
+++ b/src/nexus/aspect_extractor.py
@@ -235,6 +235,152 @@ its ``source_path`` line.
 """
 
 
+# v2 prompt — feature/scholarly-paper-v2. Tightened
+# ``experimental_datasets`` and ``experimental_baselines`` definitions
+# vs. v1; problem/method/results/extras/confidence unchanged. Verbatim
+# copy of /tmp/aspect-prompt-v4.txt validated against the Grossberg-lab
+# 10-paper bench corpus (v1: 46% / 64% semantic agreement on datasets /
+# baselines; v4: 100% / 93%).
+_SCHOLARLY_PAPER_V2_PROMPT = """\
+You are extracting structured aspects from a scholarly paper. Read the
+paper text below and return a JSON object with EXACTLY the following
+fields:
+
+  problem_formulation:    string — one or two sentences naming the
+                          problem the paper addresses.
+  proposed_method:        string — one to three sentences naming the
+                          paper's proposed approach.
+  experimental_datasets:  array of strings — empirical datasets the
+                          paper DIRECTLY USES or GENERATES in its own
+                          experiments. NOT data merely cited in
+                          related-work or background discussion.
+
+                          CRITICAL — return [] when:
+                          - The paper proposes a theoretical model
+                            and the candidate "datasets" are task
+                            paradigms, behavioral findings, or
+                            empirical results reported by CITED prior
+                            work (i.e. the paper references the data
+                            but does not run experiments on it).
+                          - The paper is a review, survey, or
+                            position paper with no experiments of
+                            its own.
+                          - The paper's only quantitative content is
+                            symbolic/mathematical analysis of a
+                            proposed model against analytical
+                            predictions, not against an empirical
+                            dataset.
+
+                          Examples of CORRECT extraction:
+                          - ML paper that trains on MNIST and reports
+                            accuracy: ["MNIST"]
+                          - Theoretical neuroscience paper that cites
+                            Bizzi et al. (1984) arm-movement data but
+                            does not run its own experiments on that
+                            data: []
+                          - Paper that introduces and uses its own
+                            new corpus of 535 English words rated on
+                            Mechanical Turk: ["535-word MTurk
+                            attribute rating corpus"]
+
+                          Each entry: SHORT NAME ONLY, max 12 words,
+                          no parenthetical citation suffix
+                          (e.g. "MNIST" not "MNIST (LeCun 1998)"),
+                          no aggregation phrases ("various", "other",
+                          "etc.").
+
+  experimental_baselines: array of strings — DISTINCT prior models or
+                          methods (from OTHER authors / prior work)
+                          that the paper QUANTITATIVELY COMPARES
+                          AGAINST in its own reported experiments.
+
+                          IMPORTANT — do NOT list:
+                          - Internal ablation variants of the paper's
+                            own proposed model (e.g. "ProposedModel
+                            without component X"). The proposed model
+                            itself and its ablation variants are
+                            collectively the paper's contribution,
+                            not baselines.
+                          - Models merely reviewed, discussed, or
+                            surveyed without quantitative comparison.
+
+                          Each entry: model/method NAME ONLY, max 8
+                          words, no parenthetical citation suffix
+                          ("HILLARY" not "HILLARY (Iba et al. 1988)"),
+                          no aggregation phrases. Empty array is the
+                          correct answer when the paper runs no
+                          quantitative comparison against prior
+                          external models.
+
+  experimental_results:   string — one to two sentences summarizing
+                          the headline experimental result.
+  extras:                 JSON object — any other useful structured
+                          fields (e.g. venue, ablations_present,
+                          code_release). May be empty.
+  confidence:             number in [0, 1] — your confidence that
+                          the extraction is faithful to the paper.
+
+Respond with ONLY the JSON object (no Markdown, no commentary).
+
+Paper text follows:
+
+---
+
+{content}
+"""
+
+
+# v2 batch header — the v1 batch header (above) deliberately punts
+# field semantics to the single-paper prompt, listing field names only.
+# The per-paper definitional tightening in v2 is single-paper-resident;
+# the batch wrapper inherits semantics via the per-paper-rendered
+# response shape it asks for. We add a brief reminder block here so
+# operators reading the wire prompt see that the same dataset /
+# baseline rules apply in batch mode. The outer ``{papers: [...]}``
+# JSON shape is unchanged.
+_SCHOLARLY_BATCH_PROMPT_HEADER_V2 = """\
+You are extracting structured aspects from N scholarly papers in one
+pass. Each paper carries a ``source_path`` identifier; you must echo
+that identifier back in each output entry so the caller can match
+extractions to inputs.
+
+Return a JSON object with this exact shape:
+
+  {{
+    "papers": [
+      {{
+        "source_path": "<verbatim from input>",
+        "problem_formulation": string — one or two sentences,
+        "proposed_method": string — one to three sentences,
+        "experimental_datasets": array of strings (empty if none),
+        "experimental_baselines": array of strings (empty if none),
+        "experimental_results": string — one to two sentences,
+        "extras": JSON object (may be empty),
+        "confidence": number in [0, 1]
+      }},
+      ...
+    ]
+  }}
+
+Field-definition reminders (apply per paper):
+  * experimental_datasets — ONLY empirical datasets the paper directly
+    uses or generates in its own experiments. Return [] for theoretical
+    / review / symbolic-analysis papers that merely cite prior data.
+    Short name only, max 12 words, no citation suffix, no aggregation.
+  * experimental_baselines — DISTINCT prior models (from OTHER authors /
+    prior work) that the paper QUANTITATIVELY COMPARES AGAINST. Do NOT
+    list internal ablation variants of the paper's own proposed model.
+    Name only, max 8 words, no citation suffix, no aggregation.
+
+The ``papers`` array must have EXACTLY one entry per input paper, in
+the same order. Echo each paper's ``source_path`` verbatim. Respond
+with ONLY the JSON object (no Markdown, no commentary).
+
+The papers follow, separated by ``=====``. Each paper is preceded by
+its ``source_path`` line.
+"""
+
+
 _SCHOLARLY_PAPER_CONFIG = ExtractorConfig(
     extractor_name="scholarly-paper-v1",
     # The model is pinned at config; the actual Claude CLI may
@@ -255,7 +401,84 @@ _SCHOLARLY_PAPER_CONFIG = ExtractorConfig(
 )
 
 
+# v2 mirror config. Same required_fields and model_version as v1 —
+# the schema and pinned model are unchanged; only the prompt body and
+# the extractor_name (for downstream model_version + extractor_name
+# rows on document_aspects) differ. Bench evidence: see PR body and
+# the harness in #782.
+_SCHOLARLY_PAPER_V2_CONFIG = ExtractorConfig(
+    extractor_name="scholarly-paper-v2",
+    model_version="claude-haiku-4-5-20251001",
+    prompt_template=_SCHOLARLY_PAPER_V2_PROMPT,
+    required_fields=(
+        "problem_formulation",
+        "proposed_method",
+        "experimental_datasets",
+        "experimental_baselines",
+        "experimental_results",
+    ),
+)
+
+
+# ── Scholarly-paper prompt version switch ────────────────────────────────────
+#
+# Opt-in v2 prompt selection. v1 remains the default; setting
+# ``NEXUS_SCHOLARLY_PAPER_VERSION=v2`` routes ``knowledge__*``
+# collections through ``_SCHOLARLY_PAPER_V2_CONFIG`` (and its batch
+# header analogue ``_SCHOLARLY_BATCH_PROMPT_HEADER_V2``). Unknown
+# values fall back to v1 with a warning log.
+#
+# Resolution is **lookup-time**, not module-import-time. Tests can
+# ``monkeypatch.setenv`` per-test without re-importing the module;
+# operators can flip the env per-shell or per-systemd-unit without
+# restarting long-running processes that share the import.
+#
+# This is intentionally a coarse global toggle, not a per-collection
+# routing system. Per-collection routing is a future enhancement if
+# more than two prompt revisions ever ship simultaneously.
+
+_SCHOLARLY_PAPER_VERSION_ENV = "NEXUS_SCHOLARLY_PAPER_VERSION"
+_SCHOLARLY_PAPER_VERSION_DEFAULT = "v1"
+_SCHOLARLY_PAPER_VERSION_VALID = ("v1", "v2")
+
+
+def _pick_scholarly_paper_version() -> str:
+    """Resolve the scholarly-paper prompt version from env.
+
+    Returns ``"v1"`` or ``"v2"``. Default is ``"v1"``. Unknown values
+    log a warning and fall back to ``"v1"``. Case-insensitive on the
+    value side.
+    """
+    raw = os.environ.get(_SCHOLARLY_PAPER_VERSION_ENV)
+    if raw is None or raw == "":
+        return _SCHOLARLY_PAPER_VERSION_DEFAULT
+    val = raw.strip().lower()
+    if val in _SCHOLARLY_PAPER_VERSION_VALID:
+        return val
+    _log.warning(
+        "aspect_extractor_unknown_scholarly_version",
+        requested=raw,
+        fallback=_SCHOLARLY_PAPER_VERSION_DEFAULT,
+        valid=_SCHOLARLY_PAPER_VERSION_VALID,
+    )
+    return _SCHOLARLY_PAPER_VERSION_DEFAULT
+
+
+def _pick_scholarly_paper_config() -> ExtractorConfig:
+    """Return the active scholarly-paper ``ExtractorConfig`` for the
+    current ``NEXUS_SCHOLARLY_PAPER_VERSION`` setting."""
+    if _pick_scholarly_paper_version() == "v2":
+        return _SCHOLARLY_PAPER_V2_CONFIG
+    return _SCHOLARLY_PAPER_CONFIG
+
+
 _REGISTRY: dict[str, ExtractorConfig] = {
+    # ``knowledge__`` entry is the default (v1). The actual resolved
+    # config for ``knowledge__*`` lookups goes through
+    # ``_pick_scholarly_paper_config`` inside ``select_config`` so the
+    # env toggle is honoured at call time. The dict entry remains for
+    # back-compat with tests / callers that iterate ``_REGISTRY``
+    # directly.
     "knowledge__": _SCHOLARLY_PAPER_CONFIG,
     # docs__* — NOT registered (nexus-z70w reverted #377). docs__<repo>
     # is populated by `nx index repo`, which sweeps any prose file in
@@ -639,6 +862,12 @@ def select_config(collection: str) -> ExtractorConfig | None:
     """
     for prefix, config in _REGISTRY.items():
         if collection.startswith(prefix):
+            # ``knowledge__`` honours the NEXUS_SCHOLARLY_PAPER_VERSION
+            # env toggle at call time so operators can flip v1↔v2 per
+            # shell / systemd-unit without restarting long-running
+            # processes. Other prefixes (``rdr__``) are not versioned.
+            if prefix == "knowledge__":
+                return _pick_scholarly_paper_config()
             return config
     return None
 
@@ -1049,7 +1278,14 @@ def _build_batch_prompt(
     ``source_path`` line followed by its content, separated from
     other papers by a ``=====`` divider.
     """
-    parts = [_SCHOLARLY_BATCH_PROMPT_HEADER]
+    # Pick the v2 batch header when the active config is the v2 one;
+    # otherwise use v1. Keyed off the config object identity so the
+    # batch path matches whatever single-paper would have used.
+    if config is _SCHOLARLY_PAPER_V2_CONFIG:
+        header = _SCHOLARLY_BATCH_PROMPT_HEADER_V2
+    else:
+        header = _SCHOLARLY_BATCH_PROMPT_HEADER
+    parts = [header]
     for _idx, _collection, source_path, content in callable_inputs:
         parts.append("\n=====\n")
         parts.append(f"source_path: {source_path}\n\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,14 @@ def _isolate_dispatch_routing(monkeypatch: pytest.MonkeyPatch) -> None:
         "NEXUS_DISPATCH_BACKEND",
         "NEXUS_DISPATCH_QWEN_OPERATORS",
         "NEXUS_DISPATCH_CLAUDE_OPERATORS",
+        # Aspect-extractor backend (PR #780) and scholarly-paper prompt
+        # version (feature/scholarly-paper-v2): both are read at every
+        # call into ``aspect_extractor``. A shell that has the
+        # ``v2`` toggle exported for an operator session would
+        # otherwise silently flip every aspect test off the default
+        # prompt body, masking v1-shaped assertions.
+        "NEXUS_ASPECT_BACKEND",
+        "NEXUS_SCHOLARLY_PAPER_VERSION",
     ):
         monkeypatch.delenv(var, raising=False)
 

--- a/tests/test_aspect_extractor.py
+++ b/tests/test_aspect_extractor.py
@@ -1380,3 +1380,209 @@ class TestRetrySubprocessBackendBranch:
         out = mod._retry_subprocess_batch("prompt", cfg, timeout=300)
         assert out == {"papers": [{"source_path": "/a"}]}
         assert called == {"sub": 0, "qwen": 1}
+
+
+# ── NEXUS_SCHOLARLY_PAPER_VERSION (v1 default / v2 opt-in) ───────────────────
+
+
+class TestPickScholarlyPaperVersion:
+    """Version selector contract for NEXUS_SCHOLARLY_PAPER_VERSION."""
+
+    def test_unset_env_is_v1(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_scholarly_paper_version
+        monkeypatch.delenv("NEXUS_SCHOLARLY_PAPER_VERSION", raising=False)
+        assert _pick_scholarly_paper_version() == "v1"
+
+    def test_explicit_v1(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_scholarly_paper_version
+        monkeypatch.setenv("NEXUS_SCHOLARLY_PAPER_VERSION", "v1")
+        assert _pick_scholarly_paper_version() == "v1"
+
+    def test_explicit_v2(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_scholarly_paper_version
+        monkeypatch.setenv("NEXUS_SCHOLARLY_PAPER_VERSION", "v2")
+        assert _pick_scholarly_paper_version() == "v2"
+
+    def test_case_insensitive_v2(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_scholarly_paper_version
+        monkeypatch.setenv("NEXUS_SCHOLARLY_PAPER_VERSION", "V2")
+        assert _pick_scholarly_paper_version() == "v2"
+
+    def test_unknown_falls_back_to_v1(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_scholarly_paper_version
+        monkeypatch.setenv("NEXUS_SCHOLARLY_PAPER_VERSION", "v99")
+        assert _pick_scholarly_paper_version() == "v1"
+
+    def test_empty_string_is_default(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import _pick_scholarly_paper_version
+        monkeypatch.setenv("NEXUS_SCHOLARLY_PAPER_VERSION", "")
+        assert _pick_scholarly_paper_version() == "v1"
+
+
+class TestPickScholarlyPaperConfig:
+    """Config resolver routes between v1 and v2 ExtractorConfig."""
+
+    def test_default_resolves_to_v1(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import (
+            _SCHOLARLY_PAPER_CONFIG,
+            _pick_scholarly_paper_config,
+        )
+        monkeypatch.delenv("NEXUS_SCHOLARLY_PAPER_VERSION", raising=False)
+        assert _pick_scholarly_paper_config() is _SCHOLARLY_PAPER_CONFIG
+
+    def test_v2_resolves_to_v2(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import (
+            _SCHOLARLY_PAPER_V2_CONFIG,
+            _pick_scholarly_paper_config,
+        )
+        monkeypatch.setenv("NEXUS_SCHOLARLY_PAPER_VERSION", "v2")
+        assert _pick_scholarly_paper_config() is _SCHOLARLY_PAPER_V2_CONFIG
+
+    def test_select_config_knowledge_default_v1(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import (
+            _SCHOLARLY_PAPER_CONFIG,
+            select_config,
+        )
+        monkeypatch.delenv("NEXUS_SCHOLARLY_PAPER_VERSION", raising=False)
+        cfg = select_config("knowledge__delos")
+        assert cfg is _SCHOLARLY_PAPER_CONFIG
+
+    def test_select_config_knowledge_v2(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import (
+            _SCHOLARLY_PAPER_V2_CONFIG,
+            select_config,
+        )
+        monkeypatch.setenv("NEXUS_SCHOLARLY_PAPER_VERSION", "v2")
+        cfg = select_config("knowledge__delos")
+        assert cfg is _SCHOLARLY_PAPER_V2_CONFIG
+        assert cfg.extractor_name == "scholarly-paper-v2"
+
+    def test_select_config_rdr_unaffected_by_version(self, monkeypatch) -> None:
+        from nexus.aspect_extractor import select_config
+        monkeypatch.setenv("NEXUS_SCHOLARLY_PAPER_VERSION", "v2")
+        cfg = select_config("rdr__nexus")
+        assert cfg is not None
+        # rdr__* always routes to the deterministic frontmatter parser,
+        # regardless of the scholarly-paper version toggle.
+        assert cfg.extractor_name == "rdr-frontmatter-v1"
+
+
+class TestScholarlyV2PromptBody:
+    """v2 prompt body carries the tightening markers and is wired
+    through ``extract_aspects`` when the env opts in."""
+
+    def test_v2_prompt_contains_tightening_markers(self) -> None:
+        from nexus.aspect_extractor import _SCHOLARLY_PAPER_V2_PROMPT
+        # Marker phrases unique to v2's tightened field definitions.
+        assert "DISTINCT prior models" in _SCHOLARLY_PAPER_V2_PROMPT
+        assert "ablation variants" in _SCHOLARLY_PAPER_V2_PROMPT
+        assert "max 12 words" in _SCHOLARLY_PAPER_V2_PROMPT
+
+    def test_v1_prompt_lacks_v2_markers(self) -> None:
+        from nexus.aspect_extractor import _SCHOLARLY_PAPER_PROMPT
+        # v1 is the loose definition — the tightening phrases are
+        # specifically what v2 introduces.
+        assert "DISTINCT prior models" not in _SCHOLARLY_PAPER_PROMPT
+        assert "ablation variants" not in _SCHOLARLY_PAPER_PROMPT
+
+    def test_v2_config_required_fields_match_v1(self) -> None:
+        from nexus.aspect_extractor import (
+            _SCHOLARLY_PAPER_CONFIG,
+            _SCHOLARLY_PAPER_V2_CONFIG,
+        )
+        assert (
+            _SCHOLARLY_PAPER_V2_CONFIG.required_fields
+            == _SCHOLARLY_PAPER_CONFIG.required_fields
+        )
+        assert (
+            _SCHOLARLY_PAPER_V2_CONFIG.model_version
+            == _SCHOLARLY_PAPER_CONFIG.model_version
+        )
+
+    def test_extract_aspects_under_v2_uses_v2_prompt(self, monkeypatch) -> None:
+        """Round-trip: with v2 env set, the prompt fed to the invoker
+        contains v2-only marker text."""
+        import nexus.aspect_extractor as mod
+        monkeypatch.setenv("NEXUS_SCHOLARLY_PAPER_VERSION", "v2")
+        monkeypatch.delenv("NEXUS_ASPECT_BACKEND", raising=False)
+
+        seen: dict[str, str] = {}
+
+        def fake_invoke_once(prompt: str) -> dict:
+            seen["prompt"] = prompt
+            return {
+                "problem_formulation": "p",
+                "proposed_method": "m",
+                "experimental_datasets": [],
+                "experimental_baselines": [],
+                "experimental_results": "r",
+                "extras": {},
+                "confidence": 0.9,
+            }
+
+        monkeypatch.setattr(mod, "_invoke_once", fake_invoke_once)
+        out = mod.extract_aspects(
+            content="paper body",
+            source_path="/tmp/x.pdf",
+            collection="knowledge__delos",
+        )
+        assert out is not None
+        assert "DISTINCT prior models" in seen["prompt"]
+        assert "ablation variants" in seen["prompt"]
+        # And the record carries the v2 extractor_name.
+        from nexus.db.t2.document_aspects import AspectRecord
+        assert isinstance(out, AspectRecord)
+        assert out.extractor_name == "scholarly-paper-v2"
+
+    def test_extract_aspects_default_uses_v1_prompt(self, monkeypatch) -> None:
+        import nexus.aspect_extractor as mod
+        monkeypatch.delenv("NEXUS_SCHOLARLY_PAPER_VERSION", raising=False)
+        monkeypatch.delenv("NEXUS_ASPECT_BACKEND", raising=False)
+
+        seen: dict[str, str] = {}
+
+        def fake_invoke_once(prompt: str) -> dict:
+            seen["prompt"] = prompt
+            return {
+                "problem_formulation": "p",
+                "proposed_method": "m",
+                "experimental_datasets": [],
+                "experimental_baselines": [],
+                "experimental_results": "r",
+                "extras": {},
+                "confidence": 0.9,
+            }
+
+        monkeypatch.setattr(mod, "_invoke_once", fake_invoke_once)
+        out = mod.extract_aspects(
+            content="paper body",
+            source_path="/tmp/x.pdf",
+            collection="knowledge__delos",
+        )
+        assert out is not None
+        # Default leg: v2-only markers absent.
+        assert "DISTINCT prior models" not in seen["prompt"]
+        from nexus.db.t2.document_aspects import AspectRecord
+        assert isinstance(out, AspectRecord)
+        assert out.extractor_name == "scholarly-paper-v1"
+
+    def test_batch_prompt_uses_v2_header_under_v2(self, monkeypatch) -> None:
+        import nexus.aspect_extractor as mod
+        monkeypatch.setenv("NEXUS_SCHOLARLY_PAPER_VERSION", "v2")
+        cfg = mod._pick_scholarly_paper_config()
+        prompt = mod._build_batch_prompt(
+            [(0, "knowledge__delos", "/tmp/a.pdf", "paper a body")],
+            cfg,
+        )
+        assert "DISTINCT prior models" in prompt
+        assert "ablation variants" in prompt
+
+    def test_batch_prompt_uses_v1_header_by_default(self, monkeypatch) -> None:
+        import nexus.aspect_extractor as mod
+        monkeypatch.delenv("NEXUS_SCHOLARLY_PAPER_VERSION", raising=False)
+        cfg = mod._pick_scholarly_paper_config()
+        prompt = mod._build_batch_prompt(
+            [(0, "knowledge__delos", "/tmp/a.pdf", "paper a body")],
+            cfg,
+        )
+        assert "DISTINCT prior models" not in prompt


### PR DESCRIPTION
## Summary

Adds a tightened scholarly-paper prompt revision as an **opt-in v2 recipe**, selectable per-process via `NEXUS_SCHOLARLY_PAPER_VERSION={v1,v2}`. v1 remains the default. v2 routes `knowledge__*` collections through `_SCHOLARLY_PAPER_V2_CONFIG` (`extractor_name=scholarly-paper-v2`, same `model_version` and `required_fields` as v1).

## Implementation

- `_SCHOLARLY_PAPER_V2_PROMPT` — verbatim v4 prompt body from the bench iteration.
- `_SCHOLARLY_PAPER_V2_CONFIG` — mirrors v1 (same model + schema), only `extractor_name` + `prompt_template` differ.
- `_SCHOLARLY_BATCH_PROMPT_HEADER_V2` — batch header mirror with a brief reminder block restating the tightened dataset / baseline rules. Outer `{papers: [...]}` JSON shape unchanged. (v1 batch header punts field semantics to single-paper; we lift the two changed rules here so the wire prompt is self-describing.)
- `_pick_scholarly_paper_version()` / `_pick_scholarly_paper_config()` — env resolver; unknown values log a warning and fall back to v1.
- Resolution is **lookup-time** (inside `select_config`), not module-import-time. Operators can flip the env per shell or systemd-unit without restarting long-running imports; tests can `monkeypatch.setenv` without re-importing. Documented in code.
- `_build_batch_prompt` picks the v2 header by config-object identity.
- `_REGISTRY["knowledge__"]` still points at the v1 config for back-compat with callers that iterate the registry directly; `select_config` overlays the version toggle for `knowledge__`.
- `tests/conftest.py::_isolate_dispatch_routing` extended to strip `NEXUS_ASPECT_BACKEND` and `NEXUS_SCHOLARLY_PAPER_VERSION` at every test (PR #626 pattern).

Tightening (v1 → v2):

1. **`experimental_datasets`**: return `[]` for theoretical / review / symbolic-analysis papers that cite prior empirical data without running their own experiments; three worked examples; short name only, max 12 words, no citation suffix, no aggregation phrases.
2. **`experimental_baselines`**: distinct prior models from other authors / prior work that the paper *quantitatively compares against*; explicit "do NOT list internal ablation variants of the paper's own proposed model"; max 8 words, no citation suffix.
3. Unchanged: `problem_formulation` / `proposed_method` / `experimental_results` / `extras` / `confidence`.

## Test plan

- [x] `pytest tests/test_aspect_extractor.py tests/test_dispatch_router.py tests/test_qwen_dispatch.py` — 140 passed, 1 skipped.
- [x] Sanity sweep on ingest-adjacent suites (`test_aspect_drain_protocol`, `test_aspect_extraction_queue`, `test_aspect_worker`, `test_aspect_readers`, `test_aspect_sql`, `test_aspect_promotion`) — clean (one pre-existing thread-timing flake unrelated to this change; passes in isolation).
- New tests cover:
  - `_pick_scholarly_paper_version`: unset → v1, `v1` → v1, `v2` → v2, `V2` (case) → v2, unknown → v1, `""` → v1.
  - `_pick_scholarly_paper_config`: routes v1 / v2 `ExtractorConfig`.
  - `select_config("knowledge__delos")` honours env; `rdr__*` unaffected.
  - Prompt-body markers: `DISTINCT prior models` + `ablation variants` present in v2, absent in v1.
  - `_SCHOLARLY_PAPER_V2_CONFIG.required_fields == _SCHOLARLY_PAPER_CONFIG.required_fields` and same `model_version`.
  - **Round-trip**: under v2 env, `extract_aspects(content, …, "knowledge__delos")` feeds the v2 prompt body to `_invoke_once` and the record carries `extractor_name=scholarly-paper-v2`. Default leg uses v1.
  - Batch prompt picks v2 header under v2; v1 header by default.

## Bench evidence

10-paper Grossberg-lab corpus A/B (parity harness from #782, LLM-judge semantic equivalence via the `judge_aspect_diffs.py` spike — not shipped here):

| Field                  | v1 strict / sem | v4 (this) strict / sem |
|------------------------|-----------------|------------------------|
| experimental_datasets  | 20% / 46%       | 80% / 100%             |
| experimental_baselines | 40% / 64%       | 80% / 93%              |

All three prompt iterations (v2 / v3 / v4) were measured against the same corpus; v4 reached 100% / 93% semantic agreement on the two most-divergent fields. Note these deltas are corpus-specific — the Grossberg cognitive-modeling literature is unusually theoretical (lots of papers cite prior empirical data without running their own experiments), so v1's looseness hurt it disproportionately. ML / empirical corpora are expected to show smaller deltas.

## Out of scope

- **Flipping the default** to v2 — separate decision once a broader corpus has been validated.
- **Per-collection routing** — coarse global toggle is sufficient for v1 → v2; future enhancement if more than two revisions ever ship.
- **Harness improvements** — `--prompt-override` flag, `judge_aspect_diffs.py` — follow-on PR.
- **No bench artefacts** in this PR (paths are local-only; harness lives in #782).

## Linked

- #780 — `NEXUS_ASPECT_BACKEND` aspect adapter (the underlying claude/qwen switch).
- #782 — parity harness used to produce the bench numbers.
- #623 / #626 — substrate (extractor + conftest env-isolation pattern).