### PR TITLE
feat(rdr-110): four-consumer landing surface (Steps 8-12) (nexus-90pe)

### DIFF
--- a/docs/tuplespace-env.md
+++ b/docs/tuplespace-env.md
@@ -1,0 +1,69 @@
+# Tuplespace Environment Variables (RDR-110)
+
+Reference for the environment variables the tuple space consumer surface
+honours. The `nx tuplespace` CLI, the MCP tool surface, and the
+session-start banner all read these.
+
+## NX_STORAGE_MODE
+
+Values: unset (default), `direct`, `daemon`.
+
+When set to `daemon`, the daemon owns `tuples.db` and runs the single
+SQLite writer. The CLI then refuses mutating subcommands (`out`, `read`,
+`take`, `ack`, `nack`, `stats`) rather than opening a competing
+connection. Read-only introspection (`list-subspaces`, `show-schema`)
+remains available because it only loads the registry from YAML.
+
+In direct mode (the default), the CLI opens the SQLite file directly.
+
+## NX_TUPLES_DB
+
+Path override for `tuples.db`. Default is
+`<nexus_dir>/tuples.db`, where `nexus_dir` resolves from
+the config file (`~/.config/nexus` by default).
+
+Useful in tests to redirect to `tmp_path / "tuples.db"`. Honoured by the
+CLI; the MCP server uses the config-derived path only.
+
+## NX_TUPLESPACE_BUILTIN_DIR
+
+Path override for the bundled subspace YAML directory. Default is the
+repo's `nx/tuplespace/builtin/`. Tests use this to inject a fixture
+directory with stripped-down schemas.
+
+## NX_T1_HOST, NX_T1_PORT, NX_T1_ISOLATED
+
+T1 chroma server addressing. The tuple space does not consume T1
+directly, but the MCP tool layer that wraps it shares the same process,
+so misconfiguration here can starve the MCP server before tuple tools
+load. `NX_T1_ISOLATED=1` skips the per-session chroma spawn entirely.
+
+`NEXUS_SKIP_T1` is honoured as a deprecated alias for `NX_T1_ISOLATED`
+through the 4.27 to 4.28 cycle (RDR-105).
+
+## NX_BRIDGE_DISABLE
+
+Disables the hook-to-tuple bridge (RDR-111). When set, Claude Code hook
+events stop landing in the `events/hook` subspace. The bridge is the
+upstream feed for several event subscribers; with it disabled, those
+subscribers see no input and may appear stuck.
+
+## NX_HOOK_DEBUG, NX_TIMEOUT, BD_TIMEOUT
+
+Diagnostics for the session-start hook (`nx/hooks/scripts/session_start_hook.py`).
+`NX_HOOK_DEBUG=1` writes per-step traces to stderr. `NX_TIMEOUT` caps
+the `nx` subprocess calls (including the tuplespace banner read) at
+the given seconds; `BD_TIMEOUT` caps `bd` calls. Defaults are 10 s and
+5 s.
+
+## Quick reference
+
+| Variable | Default | Effect |
+|---|---|---|
+| `NX_STORAGE_MODE` | unset | `daemon` flips ownership of `tuples.db` |
+| `NX_TUPLES_DB` | `<nexus_dir>/tuples.db` | path override |
+| `NX_TUPLESPACE_BUILTIN_DIR` | `nx/tuplespace/builtin/` | subspace YAML directory |
+| `NX_T1_ISOLATED` | unset | skip T1 chroma session spawn |
+| `NX_BRIDGE_DISABLE` | unset | disables the hook-to-tuple bridge |
+| `NX_HOOK_DEBUG` | `0` | session-start hook debug trace |
+| `NX_TIMEOUT` | `10` | `nx` subprocess timeout for the session hook |

--- a/nx/hooks/scripts/session_start_hook.py
+++ b/nx/hooks/scripts/session_start_hook.py
@@ -104,6 +104,27 @@ def main() -> None:
     else:
         debug("bd command not found")
 
+    # --- Tuplespace summary (RDR-110, nexus-90pe) ---
+    # One-line consumer landing surface: "tuplespace: N subspaces, M tuples,
+    # K active claims". Defensive: must never crash the session-start hook,
+    # so we wrap the call and fall back silently on any failure.
+    if which('nx'):
+        ts_line = run_command(['nx', 'tuplespace', 'stats', '--json'], timeout=NX_TIMEOUT, cwd=cwd)
+        if ts_line:
+            try:
+                import json as _json
+                payload = _json.loads(ts_line)
+                summary = payload.get('summary') or payload
+                subs = summary.get('subspaces', 0)
+                tups = summary.get('tuples', 0)
+                claims = summary.get('active_claims', 0)
+                output_lines.append(
+                    f"tuplespace: {subs} subspaces, {tups} tuples, {claims} active claims"
+                )
+                output_lines.append("")
+            except (ValueError, AttributeError, TypeError) as e:
+                debug(f"tuplespace summary parse failed: {e}")
+
     # --- Capabilities summary (AI-optimized, minimal tokens) ---
     output_lines.append("## nx Capabilities")
     output_lines.append("")

--- a/nx/registry.yaml
+++ b/nx/registry.yaml
@@ -395,6 +395,55 @@ standalone_skills:
       - "understanding what RDRs relate to a file"
     tools: [Bash, Read]
 
+  tuplespace-tasks:
+    description: "Dispatch and claim work units via the tasks subspace (RDR-110 coordination)"
+    triggers:
+      - "post a task for any agent to claim"
+      - "claim the next work unit"
+    tools: [Bash, Read]
+
+  tuplespace-mailbox:
+    description: "Send a named message between specific agents via the mailbox subspace"
+    triggers:
+      - "send a message to a named agent"
+      - "agent-to-agent direct delivery"
+    tools: [Bash, Read]
+
+  tuplespace-lock:
+    description: "Mutual exclusion on a named resource via the locks subspace"
+    triggers:
+      - "acquire an exclusive lock on a resource"
+      - "release a lock"
+    tools: [Bash, Read]
+
+  tuplespace-events:
+    description: "Broadcast state changes via the events subspace (pub-sub)"
+    triggers:
+      - "publish a state-change event"
+      - "subscribe to broadcast events"
+    tools: [Bash, Read]
+
+  tuplespace-barriers:
+    description: "Fan-in synchronization for parallel agents via the barriers subspace"
+    triggers:
+      - "wait for N parallel agents to finish"
+      - "fan-in coordination barrier"
+    tools: [Bash, Read]
+
+  tuplespace-list:
+    description: "List registered subspaces and inspect their schemas"
+    triggers:
+      - "show all registered tuple-space subspaces"
+      - "inspect a subspace schema"
+    tools: [Bash, Read]
+
+  tuplespace-stats:
+    description: "Per-subspace tuple counts for triage and capacity checks"
+    triggers:
+      - "show tuple counts per subspace"
+      - "triage a stuck coordinator"
+    tools: [Bash, Read]
+
   nexus:
     description: "Nexus CLI reference for nx search, nx store, nx memory"
     triggers:

--- a/nx/skills/tuplespace-barriers/SKILL.md
+++ b/nx/skills/tuplespace-barriers/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: tuplespace-barriers
+description: Use when waiting for multiple parallel agents to complete before proceeding (fan-in synchronization via the barriers subspace)
+effort: low
+---
+
+# Tuplespace Barriers
+
+The barriers subspace is the fan-in synchronization primitive (RDR-110). Each participant posts an arrival tuple; the coordinator waits until the expected count has arrived. Once the barrier is satisfied, the coordinator proceeds.
+
+## When to use
+
+- N parallel agents must all finish before the next step.
+- You want a count-based gate, not a semantic one.
+- You need each participant's arrival to be observable individually (so debugging "who is late?" is possible).
+
+## Pattern
+
+Coordinator declares a barrier name. Participants each post an arrival tuple keyed to that name. Coordinator reads until the participant count reaches the expected value.
+
+### Participant posts arrival
+
+```
+tuplespace_out(
+    subspace="barriers/phase-1",
+    content="agent-impl-3 finished phase 1",
+    dimensions='{"barrier": "rdr-110-phase-1", "participant": "agent-impl-3", "status": "arrived"}',
+)
+```
+
+### Coordinator waits
+
+```
+arrivals = tuplespace_read(
+    subspace="barriers/phase-1",
+    query="",
+    where={"barrier": "rdr-110-phase-1", "status": "arrived"},
+    n=100,
+)
+if len(arrivals) >= expected_count:
+    # barrier satisfied
+    proceed()
+else:
+    # poll again after backoff
+    pass
+```
+
+## Cleanup
+
+After the barrier fires, the coordinator may `take` each arrival (when the schema enables take) or simply let `retention_seconds` reap them. Leaving them for retention is the simpler default.
+
+## Pitfalls
+
+- A late participant arrives after the coordinator has already proceeded. Decide whether the late arrival is a warning, an error, or ignored.
+- Without a stable `barrier` name, two runs of the same phase mix arrivals. Use a fresh barrier id (timestamp, run id) per fan-in episode.
+- Block-mode wait is not available in Phase 1 direct mode. Coordinators poll with backoff.
+
+## Related
+
+- `/nx:tuplespace-events` when subscribers act on each arrival independently rather than waiting for a count.
+- `/nx:tuplespace-tasks` for the unit of work itself; barriers gate the work, they are not the work.

--- a/nx/skills/tuplespace-events/SKILL.md
+++ b/nx/skills/tuplespace-events/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: tuplespace-events
+description: Use when broadcasting a state change that multiple subscribers may want to observe (pub-sub via the events subspace)
+effort: low
+---
+
+# Tuplespace Events
+
+The events subspace carries broadcast notifications (RDR-110). Unlike tasks or mailbox, events are read non-destructively, so many subscribers can observe the same tuple. `take` is typically disabled on the schema.
+
+## When to use
+
+- A state change happened that multiple agents may care about (file changed, RDR accepted, build finished).
+- You do not know in advance who is listening.
+- You want subscribers to filter on dimensions rather than carry a routing table.
+
+## Publishing
+
+```
+tuplespace_out(
+    subspace="events/rdr",
+    content="RDR-110 status flipped to accepted",
+    dimensions='{"kind": "rdr-accepted", "rdr_id": "RDR-110", "actor": "planner-1"}',
+)
+```
+
+Match the dimensions to whatever filters subscribers will use. If a `kind` field is universal across all event subspaces, keep that convention so the broker layer can route uniformly.
+
+## Subscribing
+
+Subscribers poll via `tuplespace_read` with a filter:
+
+```
+tuplespace_read(
+    subspace="events/rdr",
+    query="rdr accepted",
+    where={"kind": "rdr-accepted"},
+    n=20,
+)
+```
+
+`read` is non-destructive. Two subscribers calling read see the same tuples.
+
+## Subscription windowing
+
+Events accumulate. Each subscriber tracks its own watermark (highest `created_at` observed) and only acts on tuples newer than that. The watermark is subscriber-local state, not stored in the tuple.
+
+## Pitfalls
+
+- Do not call `take` on an events subspace. The schema typically has `take.enabled: false`; an attempt raises `TakeDisabledError`. If you need destructive consumption, you wanted tasks or mailbox.
+- Retention matters. Events are bounded by `retention_seconds`; a subscriber that wakes after a long sleep misses everything older than the retention window. Heartbeat or persist watermark to survive across restarts.
+- Two subscribers may receive the same event with different floors; tune your local filter to your needs.
+
+## Related
+
+- `/nx:tuplespace-barriers` when you need fan-in synchronization after a set of events.
+- `/nx:tuplespace-mailbox` for targeted delivery rather than broadcast.

--- a/nx/skills/tuplespace-list/SKILL.md
+++ b/nx/skills/tuplespace-list/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: tuplespace-list
+description: Use when surveying registered tuple-space subspaces, schemas, or active claims before posting or taking tuples
+effort: low
+---
+
+# Tuplespace List
+
+Introspection skill for the RDR-110 tuple space. Use this before posting or taking to confirm which subspaces exist and what dimensions they expect.
+
+## Commands
+
+List every registered subspace template:
+
+```
+nx tuplespace list-subspaces
+nx tuplespace list-subspaces --json
+```
+
+Show the resolved schema for a concrete or template subspace:
+
+```
+nx tuplespace show-schema tasks/nexus
+nx tuplespace show-schema locks/<resource> --json
+```
+
+The schema output includes `dimensions`, `embed_from`, `take` mode, `read` defaults, `retention_seconds`, and `tiers`.
+
+## When to use
+
+- A new agent does not know what subspaces are available.
+- You suspect a schema mismatch caused a `SubspaceSchemaError` and need to inspect the registered dimensions.
+- You want to verify that a custom subspace YAML loaded correctly via `NX_TUPLESPACE_BUILTIN_DIR`.
+
+## Pitfalls
+
+- Subspace names in the registry use template form (for example, `tasks/<project>`). When you post or take you supply a concrete name (`tasks/nexus`). `show-schema` accepts either form and resolves to the template.
+- An unknown subspace returns exit code 1 with a clear error rather than an empty schema.
+
+## Related
+
+- `/nx:tuplespace-stats` for per-subspace tuple counts.
+- `/nx:tuplespace-tasks`, `/nx:tuplespace-mailbox`, `/nx:tuplespace-lock`, `/nx:tuplespace-events`, `/nx:tuplespace-barriers` for the consumer patterns.

--- a/nx/skills/tuplespace-lock/SKILL.md
+++ b/nx/skills/tuplespace-lock/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: tuplespace-lock
+description: Use when an agent needs exclusive access to a named resource (mutual exclusion via the locks subspace)
+effort: low
+---
+
+# Tuplespace Lock
+
+The `locks/<resource>` subspace provides mutual exclusion over named resources (RDR-110). The schema uses `mode: exact` rather than semantic match, so the take operation is a pure SQL CAS on the `resource` dimension.
+
+## When to use
+
+- You need at-most-one-holder semantics over a named resource (a database, a file path, a build slot).
+- Optimistic semantic matching is wrong here. Use the `resource` key as a hard identity.
+
+## Acquiring a lock
+
+```
+tuplespace_out(
+    subspace="locks/build",
+    content="ci holds the build slot",
+    dimensions='{"resource": "build", "holder": "ci-runner-3"}',
+    ttl_seconds=300,
+)
+result = tuplespace_take(
+    subspace="locks/build",
+    query="",
+    claimant="ci-runner-3",
+    where={"resource": "build"},
+)
+```
+
+The pattern is: post a lock tuple with a TTL (so a crash auto-releases), then immediately take it. The `where` filter must include every `match_key` declared in the schema (here, just `resource`).
+
+## Releasing
+
+Use `tuplespace_ack(claim_id, claimant)` to release cleanly. The tuple transitions to `consumed`.
+
+If the holder crashes, the claim expires after `lease_seconds` and the resource becomes available again.
+
+## Detecting contention
+
+When `take` returns `None`, the lock is held by someone else. Poll, back off, or fail loud depending on the workload.
+
+## Pitfalls
+
+- Exact mode requires every `match_key` in the where filter. Omitting it raises `SubspaceSchemaError`.
+- A lock without a TTL on the underlying tuple persists forever in the table. Always set `ttl_seconds` or rely on `lease_seconds` to bound exposure.
+- The CAS guarantees one winner per row, not one holder per resource string. If two posters write tuples with the same `resource` value, both rows exist; only one take can succeed against any given row.
+
+## Related
+
+- `/nx:tuplespace-events` when you want "lock released" notifications.
+- `/nx:tuplespace-tasks` for cooperative work units rather than exclusive resources.

--- a/nx/skills/tuplespace-mailbox/SKILL.md
+++ b/nx/skills/tuplespace-mailbox/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: tuplespace-mailbox
+description: Use when sending a named message from one agent to another agent (point-to-point delivery via the mailbox subspace)
+effort: low
+---
+
+# Tuplespace Mailbox
+
+The mailbox subspace is the point-to-point delivery channel between named agents (RDR-110). Unlike tasks (anyone can claim) or events (broadcast), a mailbox tuple targets a specific `recipient`. The recipient takes by exact match on that dimension.
+
+## When to use
+
+- You know exactly which agent should receive the message.
+- You want a reply lane back to a specific sender.
+- Tasks is too open and events is too noisy.
+
+## Sending
+
+```
+tuplespace_out(
+    subspace="mailbox/nexus",
+    content="Patch ready for review on PR #786",
+    dimensions='{"sender": "agent-impl", "recipient": "agent-review", "kind": "review-request"}',
+)
+```
+
+The `recipient` dimension is the routing key. The sender field carries the reply-to identity.
+
+## Receiving
+
+```
+tuplespace_take(
+    subspace="mailbox/nexus",
+    query="review request",
+    claimant="agent-review",
+    where={"recipient": "agent-review"},
+)
+```
+
+Always filter by `recipient`. Otherwise an unrelated agent could semantically take a message addressed to someone else.
+
+## Replying
+
+A reply is just another mailbox tuple with sender and recipient swapped.
+
+```
+tuplespace_out(
+    subspace="mailbox/nexus",
+    content="LGTM, ready to merge",
+    dimensions='{"sender": "agent-review", "recipient": "agent-impl", "kind": "review-ack"}',
+)
+```
+
+## Pitfalls
+
+- Forgetting the `recipient` filter on take is the classic mailbox bug. The recipient may semantically match someone else's message and accidentally claim it.
+- Mailbox tuples do not auto-expire by default; configure TTL when you post if the message is time sensitive.
+- A nack returns the tuple to available; the original recipient can claim again.
+
+## Related
+
+- `/nx:tuplespace-tasks` for unsolicited work units.
+- `/nx:tuplespace-events` for broadcasts to all subscribers.

--- a/nx/skills/tuplespace-stats/SKILL.md
+++ b/nx/skills/tuplespace-stats/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: tuplespace-stats
+description: Use when inspecting per-subspace tuple counts (total, available, claimed, consumed) for triage or capacity checks
+effort: low
+---
+
+# Tuplespace Stats
+
+Counts and gauges for the RDR-110 tuple space. Use this to triage a stuck coordinator, confirm the queue is draining, or sanity-check that a `take` actually moved a tuple to `claimed`.
+
+## Commands
+
+Session-banner summary plus per-subspace breakdown:
+
+```
+nx tuplespace stats
+nx tuplespace stats --json
+```
+
+Single-subspace counts:
+
+```
+nx tuplespace stats tasks/nexus
+nx tuplespace stats locks/build --json
+```
+
+Each row reports four numbers:
+
+- `total` (rows in the subspace)
+- `available` (un-consumed, no active claim or expired claim)
+- `claimed` (active claim, lease not yet expired)
+- `consumed` (acked, terminal)
+
+## When to use
+
+- A coordinator says "no tasks available" and you want to know whether the queue is empty or every tuple is held.
+- A lock is stuck and you want to confirm the holder still has a live claim or whether the lease has expired.
+- Before re-driving a phase, verify the previous run drained to zero.
+
+## Session-start banner
+
+The session-start hook emits a one-line summary using the same data path:
+
+```
+tuplespace: <N> subspaces, <M> tuples, <K> active claims
+```
+
+This is the first signal in a session that the tuple space is healthy. Zero `active claims` plus non-zero `tuples` after a coordinator started usually means the coordinator never ran or the schema rejected its dimensions.
+
+## Pitfalls
+
+- In `NX_STORAGE_MODE=daemon`, stats refuses rather than racing the daemon writer. Query via the MCP tool surface instead.
+- A consumed tuple still counts in `total` until retention reaps it. To estimate live load, use `available + claimed`.
+
+## Related
+
+- `/nx:tuplespace-list` to see which subspaces exist before you query counts.
+- `/nx:tuplespace-tasks` and the other consumer skills for the actual posting / taking flows.

--- a/nx/skills/tuplespace-tasks/SKILL.md
+++ b/nx/skills/tuplespace-tasks/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: tuplespace-tasks
+description: Use when dispatching or claiming units of work via the tasks subspace, including coordinator handoff between agents
+effort: low
+---
+
+# Tuplespace Tasks
+
+The `tasks/<project>` subspace is the canonical work queue for agent coordination (RDR-110). One agent posts a tuple describing a work unit; another agent semantically takes it. The `take` operation is atomic (CAS under SQLite's single-writer lock), so two claimants cannot succeed on the same row.
+
+## When to use
+
+- Dispatching work that any capable agent can pick up.
+- Coordinator wants to fan out subtasks without naming a specific recipient.
+- Agent has finished its part and wants to surface the next step.
+
+Use the mailbox subspace instead when you have a named recipient. Use locks when you need mutual exclusion on a resource rather than a work item.
+
+## Schema (canonical defaults)
+
+- Dimensions: `status` (open / in_progress / done / cancelled), `priority` (P0..P4), `assignee` (optional), `created_by` (required).
+- `embed_from: content`, semantic take with floor 0.55 / margin 0.08.
+- Retention: 90 days.
+
+## Posting a task
+
+MCP tool (preferred for agents):
+
+```
+tuplespace_out(
+    subspace="tasks/nexus",
+    content="Ship the consumer landing surface for RDR-110",
+    dimensions='{"status": "open", "priority": "P1", "created_by": "planner-1"}',
+)
+```
+
+CLI smoke test:
+
+```
+nx tuplespace out tasks/nexus '{"status":"open","priority":"P1","created_by":"alice"}' \
+  --content "ship the landing surface"
+```
+
+`tuple_id` is deterministic over `(subspace, content, dimensions, match_text)`, so re-posting is idempotent.
+
+## Claiming a task
+
+```
+tuplespace_take(
+    subspace="tasks/nexus",
+    query="landing surface for tuple space",
+    claimant="agent-impl-3",
+)
+```
+
+Returns `(tuple_dict, claim_id)` or `None`. Default lease is 600 s. The claim expires automatically if you crash; another agent can then re-claim.
+
+## Acking and nacking
+
+When the work is complete, call `tuplespace_ack(claim_id, claimant)`. The tuple transitions to `consumed`.
+
+When you cannot complete the work (precondition failed, dependency missing), call `tuplespace_nack(claim_id, claimant)`. The tuple returns to `available` and another claimant can take it.
+
+## Inspecting the queue
+
+```
+nx tuplespace stats tasks/nexus
+nx tuplespace read tasks/nexus --query "your capability"
+```
+
+## Pitfalls
+
+- Re-claim by the same claimant returns the existing `claim_id`, not an error. Idempotent.
+- `block=True` is feature-flagged OFF in direct mode (Phase 1). Poll instead.
+- In `NX_STORAGE_MODE=daemon` the CLI refuses writes; agents must route through MCP tools.
+
+## Related
+
+- `/nx:tuplespace-mailbox` for direct sender-to-recipient handoff.
+- `/nx:tuplespace-lock` for mutual exclusion.
+- `/nx:tuplespace-stats` for queue introspection.

--- a/src/nexus/cli.py
+++ b/src/nexus/cli.py
@@ -62,6 +62,7 @@ from nexus.commands.tier_status import tier_status_cmd
 from nexus.commands.aspects import aspects_group
 from nexus.commands.upgrade import upgrade
 from nexus.commands.instances import instances_cmd
+from nexus.commands.tuplespace import tuplespace_group
 
 @click.group()
 @click.version_option(package_name="conexus", prog_name="nx")
@@ -175,3 +176,4 @@ main.add_command(tier_status_cmd, name="tier-status")
 main.add_command(aspects_group, name="aspects")
 main.add_command(upgrade)
 main.add_command(instances_cmd, name="instances")
+main.add_command(tuplespace_group, name="tuplespace")

--- a/src/nexus/commands/tuplespace.py
+++ b/src/nexus/commands/tuplespace.py
@@ -1,0 +1,494 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``nx tuplespace`` -- consumer CLI for the RDR-110 tuple space.
+
+Provides read, write, and introspection access to the registered
+coordination subspaces (tasks, mailbox, locks, events, barriers, hooks).
+The CLI mirrors the MCP tool surface in ``nexus.mcp.core`` so agents and
+humans use the same vocabulary.
+
+Daemon-mode (``NX_STORAGE_MODE=daemon``) is honoured: when the daemon owns
+``tuples.db``, this command refuses mutating subcommands rather than
+opening a competing SQLite connection. Read-only introspection
+(``list-subspaces``, ``show-schema``) is always safe because it touches
+the registry only.
+
+The ``out`` / ``read`` / ``take`` / ``ack`` / ``nack`` subcommands are a
+smoke-test surface intended for interactive debugging and shell scripts.
+Production agents use the MCP tools (``tuplespace_out`` etc.) so claim
+ownership and CAS atomicity remain process-local to the MCP server.
+"""
+from __future__ import annotations
+
+import json as _json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Storage helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_tuples_db_path() -> Path:
+    """Return the canonical tuples.db path, honouring ``NX_TUPLES_DB``."""
+    override = os.environ.get("NX_TUPLES_DB")
+    if override:
+        return Path(override).expanduser()
+    from nexus.config import load_config
+
+    cfg = load_config()
+    nexus_dir = cfg.get("nexus_dir", "~/.config/nexus")
+    return Path(os.path.expanduser(f"{nexus_dir}/tuples.db"))
+
+
+def _is_daemon_mode() -> bool:
+    return os.environ.get("NX_STORAGE_MODE", "").lower() == "daemon"
+
+
+def _load_registry():
+    """Return a loaded ``Registry``. Honours ``NX_TUPLESPACE_BUILTIN_DIR``."""
+    from nexus.tuplespace.registry import Registry, default_builtin_dir
+
+    override = os.environ.get("NX_TUPLESPACE_BUILTIN_DIR")
+    builtin_dir = Path(override).expanduser() if override else default_builtin_dir()
+    return Registry.load(builtin_dir)
+
+
+def _open_conn(db_path: Path) -> sqlite3.Connection:
+    """Open ``tuples.db`` for direct-mode operations."""
+    from nexus.tuplespace.store import open_tuples_db
+
+    conn = open_tuples_db(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _build_index(registry):
+    """Construct a ``TupleIndex`` rooted at the local chroma directory."""
+    import chromadb
+
+    from nexus.config import load_config
+    from nexus.tuplespace.index import TupleIndex
+
+    cfg = load_config()
+    nexus_dir = cfg.get("nexus_dir", "~/.config/nexus")
+    chroma_dir = os.path.expanduser(f"{nexus_dir}/chroma")
+    client = chromadb.PersistentClient(path=chroma_dir)
+    return TupleIndex.from_registry(registry, client)
+
+
+def _refuse_in_daemon_mode(action: str) -> None:
+    """Exit cleanly when a mutating subcommand is invoked in daemon mode."""
+    if _is_daemon_mode():
+        click.echo(
+            f"refusing to {action} in NX_STORAGE_MODE=daemon (daemon owns tuples.db). "
+            "Use the MCP tool surface instead.",
+            err=True,
+        )
+        sys.exit(2)
+
+
+# ---------------------------------------------------------------------------
+# Banner support (used by session_start_hook and `nx tuplespace stats`)
+# ---------------------------------------------------------------------------
+
+
+def banner_summary() -> dict[str, int]:
+    """Return a compact dict: ``{subspaces, tuples, active_claims}``.
+
+    Side effect free in daemon mode: returns counts of zero for ``tuples``
+    and ``active_claims`` because opening the SQLite file would race the
+    daemon's single writer. ``subspaces`` always reflects the registry,
+    which is loaded from YAML files only.
+    """
+    summary = {"subspaces": 0, "tuples": 0, "active_claims": 0}
+    try:
+        registry = _load_registry()
+        summary["subspaces"] = len(list(registry.schemas()))
+    except Exception as exc:
+        _log.warning("tuplespace_banner_registry_failed", error=str(exc))
+        return summary
+
+    if _is_daemon_mode():
+        return summary
+
+    db_path = _resolve_tuples_db_path()
+    if not db_path.exists():
+        return summary
+
+    try:
+        conn = _open_conn(db_path)
+        try:
+            total = conn.execute("SELECT COUNT(*) FROM tuples").fetchone()[0]
+            active = conn.execute(
+                "SELECT COUNT(*) FROM tuples "
+                "WHERE claim_state='claimed' AND claim_expires_at >= unixepoch()"
+            ).fetchone()[0]
+            summary["tuples"] = int(total or 0)
+            summary["active_claims"] = int(active or 0)
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        _log.warning("tuplespace_banner_sqlite_failed", error=str(exc))
+    return summary
+
+
+def banner_line() -> str:
+    """Return the one-line session-start banner string."""
+    s = banner_summary()
+    return (
+        f"tuplespace: {s['subspaces']} subspaces, "
+        f"{s['tuples']} tuples, {s['active_claims']} active claims"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+@click.group("tuplespace")
+def tuplespace_group() -> None:
+    """Inspect and exercise the RDR-110 tuple space.
+
+    Subcommands provide read-only introspection (``list-subspaces``,
+    ``show-schema``, ``stats``) and a smoke-test surface for
+    ``out`` / ``read`` / ``take`` / ``ack`` / ``nack``. Production agents
+    use the MCP tools; this CLI is for shell scripts and interactive
+    debugging.
+    """
+
+
+@tuplespace_group.command("list-subspaces")
+@click.option(
+    "--json", "json_out", is_flag=True, default=False,
+    help="Emit JSON instead of a plain list.",
+)
+def list_subspaces_cmd(json_out: bool) -> None:
+    """List every registered subspace template (e.g. ``tasks/<project>``)."""
+    registry = _load_registry()
+    names = sorted(s.name for s in registry.schemas())
+    if json_out:
+        click.echo(_json.dumps({"subspaces": names}, indent=2))
+        return
+    if not names:
+        click.echo("(no subspaces registered)")
+        return
+    for name in names:
+        click.echo(name)
+
+
+@tuplespace_group.command("show-schema")
+@click.argument("subspace")
+@click.option(
+    "--json", "json_out", is_flag=True, default=False,
+    help="Emit JSON instead of a human summary.",
+)
+def show_schema_cmd(subspace: str, json_out: bool) -> None:
+    """Print the resolved schema for a concrete or template subspace."""
+    from nexus.tuplespace.api import subspace_schema
+    from nexus.tuplespace.registry import UnknownSubspaceError
+
+    registry = _load_registry()
+    try:
+        schema = subspace_schema(registry=registry, subspace=subspace)
+    except UnknownSubspaceError as exc:
+        click.echo(f"unknown subspace: {exc}", err=True)
+        sys.exit(1)
+
+    if json_out:
+        click.echo(_json.dumps(schema, indent=2, sort_keys=True))
+        return
+
+    click.echo(f"name:             {schema['name']}")
+    click.echo(f"tier:             {schema['tier']}")
+    click.echo(f"content_type:     {schema['content_type']}")
+    click.echo(f"embed_from:       {schema['embed_from']}")
+    click.echo(f"retention_seconds: {schema['retention_seconds']}")
+    click.echo("dimensions:")
+    for k, v in (schema.get("dimensions") or {}).items():
+        click.echo(f"  {k}: {v}")
+    click.echo(f"take: {schema['take']}")
+    click.echo(f"read: {schema['read']}")
+
+
+@tuplespace_group.command("stats")
+@click.argument("subspace", required=False)
+@click.option(
+    "--json", "json_out", is_flag=True, default=False,
+    help="Emit JSON instead of a human table.",
+)
+def stats_cmd(subspace: str | None, json_out: bool) -> None:
+    """Show tuple counts (total, available, claimed, consumed).
+
+    With no SUBSPACE: prints the banner summary plus a per-subspace
+    breakdown across every concrete subspace observed in ``tuples.db``.
+    With a SUBSPACE argument: prints counts for that subspace only.
+    """
+    db_path = _resolve_tuples_db_path()
+    if _is_daemon_mode():
+        click.echo(
+            "stats unavailable in NX_STORAGE_MODE=daemon "
+            "(daemon owns tuples.db; query via MCP tools).",
+            err=True,
+        )
+        sys.exit(2)
+
+    if not db_path.exists():
+        if json_out:
+            click.echo(_json.dumps({"db_path": str(db_path), "exists": False, "summary": banner_summary()}))
+            return
+        click.echo(f"tuples.db not found at {db_path} (no tuples written yet)")
+        click.echo(banner_line())
+        return
+
+    conn = _open_conn(db_path)
+    try:
+        if subspace:
+            from nexus.tuplespace.api import subspace_stats
+
+            stats = subspace_stats(conn=conn, subspace=subspace)
+            if json_out:
+                click.echo(_json.dumps({"subspace": subspace, **stats}, indent=2))
+                return
+            click.echo(f"subspace:  {subspace}")
+            click.echo(f"total:     {stats['total']}")
+            click.echo(f"available: {stats['available']}")
+            click.echo(f"claimed:   {stats['claimed']}")
+            click.echo(f"consumed:  {stats['consumed']}")
+            return
+
+        rows = conn.execute(
+            "SELECT subspace, "
+            "  COUNT(*) AS total, "
+            "  SUM(CASE WHEN consumed_at IS NULL "
+            "           AND (claim_state IS NULL OR claim_expires_at < unixepoch()) "
+            "           THEN 1 ELSE 0 END) AS available, "
+            "  SUM(CASE WHEN claim_state='claimed' "
+            "           AND claim_expires_at >= unixepoch() THEN 1 ELSE 0 END) AS claimed, "
+            "  SUM(CASE WHEN consumed_at IS NOT NULL THEN 1 ELSE 0 END) AS consumed "
+            "FROM tuples GROUP BY subspace ORDER BY subspace"
+        ).fetchall()
+        summary = banner_summary()
+        per_subspace = [
+            {
+                "subspace": r[0],
+                "total": int(r[1] or 0),
+                "available": int(r[2] or 0),
+                "claimed": int(r[3] or 0),
+                "consumed": int(r[4] or 0),
+            }
+            for r in rows
+        ]
+        if json_out:
+            click.echo(_json.dumps({"summary": summary, "per_subspace": per_subspace}, indent=2))
+            return
+        click.echo(banner_line())
+        if not per_subspace:
+            click.echo("(no concrete subspaces have tuples yet)")
+            return
+        click.echo("")
+        click.echo(f"{'SUBSPACE':<40} {'TOTAL':>6} {'AVAIL':>6} {'CLAIM':>6} {'CONSU':>6}")
+        for row in per_subspace:
+            click.echo(
+                f"{row['subspace']:<40} {row['total']:>6} {row['available']:>6} "
+                f"{row['claimed']:>6} {row['consumed']:>6}"
+            )
+    finally:
+        conn.close()
+
+
+def _parse_json_arg(value: str, label: str) -> Any:
+    try:
+        return _json.loads(value)
+    except _json.JSONDecodeError as exc:
+        click.echo(f"invalid JSON for {label}: {exc}", err=True)
+        sys.exit(1)
+
+
+@tuplespace_group.command("out")
+@click.argument("subspace")
+@click.argument("dimensions_json")
+@click.option("--content", default="", help="Tuple body text.")
+@click.option("--match-text", default=None, help="Override for the embedding source.")
+@click.option("--ttl-seconds", type=float, default=None, help="TTL in seconds (default: no expiry).")
+def out_cmd(
+    subspace: str,
+    dimensions_json: str,
+    content: str,
+    match_text: str | None,
+    ttl_seconds: float | None,
+) -> None:
+    """Post a tuple to SUBSPACE. DIMENSIONS_JSON is a JSON object."""
+    _refuse_in_daemon_mode("write tuples")
+    from nexus.tuplespace.api import out
+
+    dims = _parse_json_arg(dimensions_json, "DIMENSIONS_JSON")
+    if not isinstance(dims, dict):
+        click.echo("DIMENSIONS_JSON must be a JSON object", err=True)
+        sys.exit(1)
+
+    registry = _load_registry()
+    db_path = _resolve_tuples_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = _open_conn(db_path)
+    index = _build_index(registry)
+    try:
+        tid = out(
+            conn=conn,
+            index=index,
+            registry=registry,
+            subspace=subspace,
+            content=content,
+            dimensions=dims,
+            match_text=match_text,
+            ttl_seconds=ttl_seconds,
+        )
+    finally:
+        conn.close()
+    click.echo(tid)
+
+
+@tuplespace_group.command("read")
+@click.argument("subspace")
+@click.option("--query", default="", help="Semantic query text.")
+@click.option("--where", "where_json", default=None, help="JSON filter dict.")
+@click.option("--floor", type=float, default=None, help="Minimum similarity.")
+@click.option("-n", "max_results", type=int, default=None, help="Max results.")
+def read_cmd(
+    subspace: str,
+    query: str,
+    where_json: str | None,
+    floor: float | None,
+    max_results: int | None,
+) -> None:
+    """Read tuples matching QUERY from SUBSPACE (non-destructive)."""
+    _refuse_in_daemon_mode("read tuples")
+    from nexus.tuplespace.api import read
+
+    where = _parse_json_arg(where_json, "--where") if where_json else None
+    registry = _load_registry()
+    db_path = _resolve_tuples_db_path()
+    if not db_path.exists():
+        click.echo(_json.dumps({"results": []}))
+        return
+    conn = _open_conn(db_path)
+    index = _build_index(registry)
+    try:
+        results = read(
+            conn=conn,
+            index=index,
+            registry=registry,
+            subspace=subspace,
+            query=query,
+            where=where,
+            floor=floor,
+            n=max_results,
+        )
+    finally:
+        conn.close()
+    click.echo(_json.dumps({"results": results}, indent=2, default=str))
+
+
+@tuplespace_group.command("take")
+@click.argument("subspace")
+@click.option("--query", default="", help="Semantic query text.")
+@click.option("--claimant", required=True, help="Identifier for the claiming agent.")
+@click.option("--where", "where_json", default=None, help="JSON filter dict.")
+@click.option("--floor", type=float, default=None, help="Minimum similarity.")
+@click.option("--lease-seconds", type=float, default=None, help="Claim lease seconds.")
+def take_cmd(
+    subspace: str,
+    query: str,
+    claimant: str,
+    where_json: str | None,
+    floor: float | None,
+    lease_seconds: float | None,
+) -> None:
+    """Atomically claim a tuple from SUBSPACE (destructive)."""
+    _refuse_in_daemon_mode("take tuples")
+    from nexus.tuplespace.api import take
+
+    where = _parse_json_arg(where_json, "--where") if where_json else None
+    registry = _load_registry()
+    db_path = _resolve_tuples_db_path()
+    if not db_path.exists():
+        click.echo(_json.dumps({"claimed": False, "reason": "tuples.db missing"}))
+        return
+    conn = _open_conn(db_path)
+    index = _build_index(registry)
+    try:
+        result = take(
+            conn=conn,
+            index=index,
+            registry=registry,
+            subspace=subspace,
+            query=query,
+            claimant=claimant,
+            where=where,
+            floor=floor,
+            lease_seconds=lease_seconds,
+        )
+    finally:
+        conn.close()
+    if result is None:
+        click.echo(_json.dumps({"claimed": False}))
+        return
+    tup, cid = result
+    click.echo(_json.dumps({"claimed": True, "claim_id": cid, "tuple": tup}, indent=2, default=str))
+
+
+@tuplespace_group.command("ack")
+@click.argument("claim_id")
+@click.option("--claimant", required=True, help="The claiming agent (must match take).")
+def ack_cmd(claim_id: str, claimant: str) -> None:
+    """Acknowledge a claim: mark the tuple consumed."""
+    _refuse_in_daemon_mode("ack claims")
+    from nexus.tuplespace.api import ack, ClaimNotFoundError, ClaimOwnershipError
+
+    db_path = _resolve_tuples_db_path()
+    if not db_path.exists():
+        click.echo("tuples.db missing", err=True)
+        sys.exit(1)
+    conn = _open_conn(db_path)
+    try:
+        try:
+            ack(conn=conn, claim_id=claim_id, claimant=claimant)
+        except (ClaimNotFoundError, ClaimOwnershipError) as exc:
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+    finally:
+        conn.close()
+    click.echo("ok")
+
+
+@tuplespace_group.command("nack")
+@click.argument("claim_id")
+@click.option("--claimant", required=True, help="The claiming agent (must match take).")
+def nack_cmd(claim_id: str, claimant: str) -> None:
+    """Negative-ack a claim: release it back to available."""
+    _refuse_in_daemon_mode("nack claims")
+    from nexus.tuplespace.api import nack, ClaimNotFoundError, ClaimOwnershipError
+
+    db_path = _resolve_tuples_db_path()
+    if not db_path.exists():
+        click.echo("tuples.db missing", err=True)
+        sys.exit(1)
+    conn = _open_conn(db_path)
+    try:
+        try:
+            nack(conn=conn, claim_id=claim_id, claimant=claimant)
+        except (ClaimNotFoundError, ClaimOwnershipError) as exc:
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+    finally:
+        conn.close()
+    click.echo("ok")

--- a/tests/commands/test_tuplespace_cli.py
+++ b/tests/commands/test_tuplespace_cli.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for ``nx tuplespace`` CLI (RDR-110 Step 11, nexus-90pe).
+
+Exercises every subcommand against a real ``tuples.db`` plus an
+``EphemeralClient`` chroma backend, with the registry pointed at the
+repo's bundled builtin subspace YAMLs (``nx/tuplespace/builtin/``).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import chromadb
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli import main
+from nexus.commands import tuplespace as ts_cmd
+
+
+_TASKS_YAML = """
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status:     { type: enum, values: [open, in_progress, done, cancelled], required: true }
+  priority:   { type: enum, values: [P0, P1, P2, P3, P4], required: true }
+  created_by: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.0
+  margin: 0.0
+  default_lease_seconds: 60
+read:
+  default_floor: 0.0
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+_LOCKS_YAML = """
+name: locks/<resource>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  resource: { type: string, required: true }
+  holder:   { type: string, required: true }
+take:
+  enabled: true
+  mode: exact
+  match_keys: [resource]
+  default_lease_seconds: 30
+read:
+  default_floor: 0.0
+  default_n: 1
+tiers: [project]
+retention_seconds: 3600
+"""
+
+
+@pytest.fixture
+def builtin_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "tasks.yml").write_text(_TASKS_YAML)
+    (d / "locks.yml").write_text(_LOCKS_YAML)
+    return d
+
+
+@pytest.fixture
+def env(tmp_path: Path, builtin_dir: Path, monkeypatch):
+    """Wire env vars + a chroma index so CLI commands hit a real backend."""
+    db_path = tmp_path / "tuples.db"
+    monkeypatch.setenv("NX_TUPLES_DB", str(db_path))
+    monkeypatch.setenv("NX_TUPLESPACE_BUILTIN_DIR", str(builtin_dir))
+    monkeypatch.delenv("NX_STORAGE_MODE", raising=False)
+
+    # Replace the persistent chroma builder with an in-process Ephemeral one
+    # so we don't write a real ``chroma/`` directory under the user's
+    # config. The shared-process state of EphemeralClient is fine here
+    # because each test gets a fresh client + chroma collections are
+    # name-scoped to the per-test ``tuples.db``.
+    client = chromadb.EphemeralClient()
+
+    def _build_index_test(registry):
+        from nexus.tuplespace.index import TupleIndex
+
+        return TupleIndex.from_registry(registry, client)
+
+    monkeypatch.setattr(ts_cmd, "_build_index", _build_index_test)
+    yield {"db_path": db_path, "client": client}
+
+    for coll in client.list_collections():
+        client.delete_collection(coll.name)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_list_subspaces_plain(runner: CliRunner, env) -> None:
+    result = runner.invoke(main, ["tuplespace", "list-subspaces"])
+    assert result.exit_code == 0, result.output
+    assert "tasks/<project>" in result.output
+    assert "locks/<resource>" in result.output
+
+
+def test_list_subspaces_json(runner: CliRunner, env) -> None:
+    result = runner.invoke(main, ["tuplespace", "list-subspaces", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "tasks/<project>" in payload["subspaces"]
+    assert "locks/<resource>" in payload["subspaces"]
+
+
+def test_show_schema_unknown(runner: CliRunner, env) -> None:
+    result = runner.invoke(main, ["tuplespace", "show-schema", "nope/whatever"])
+    assert result.exit_code == 1
+    assert "unknown subspace" in result.output.lower()
+
+
+def test_show_schema_known(runner: CliRunner, env) -> None:
+    result = runner.invoke(main, ["tuplespace", "show-schema", "tasks/demo", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["name"] == "tasks/<project>"
+    assert "status" in payload["dimensions"]
+
+
+def test_stats_empty(runner: CliRunner, env) -> None:
+    result = runner.invoke(main, ["tuplespace", "stats"])
+    assert result.exit_code == 0, result.output
+    assert "tuples.db not found" in result.output
+    assert "tuplespace:" in result.output
+    assert "2 subspaces" in result.output
+
+
+def test_out_then_stats(runner: CliRunner, env) -> None:
+    out_result = runner.invoke(
+        main,
+        [
+            "tuplespace", "out", "tasks/demo",
+            '{"status": "open", "priority": "P1", "created_by": "alice"}',
+            "--content", "ship the landing surface",
+        ],
+    )
+    assert out_result.exit_code == 0, out_result.output
+    tid = out_result.output.strip()
+    assert len(tid) == 32  # 32-hex tuple_id
+
+    stats_result = runner.invoke(main, ["tuplespace", "stats", "--json"])
+    assert stats_result.exit_code == 0, stats_result.output
+    payload = json.loads(stats_result.output)
+    assert payload["summary"]["tuples"] == 1
+    assert payload["per_subspace"][0]["subspace"] == "tasks/demo"
+    assert payload["per_subspace"][0]["total"] == 1
+
+
+def test_read_returns_tuple(runner: CliRunner, env) -> None:
+    runner.invoke(
+        main,
+        [
+            "tuplespace", "out", "tasks/demo",
+            '{"status": "open", "priority": "P1", "created_by": "alice"}',
+            "--content", "ship the landing surface",
+        ],
+    )
+    result = runner.invoke(
+        main,
+        ["tuplespace", "read", "tasks/demo", "--query", "ship", "-n", "5"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert len(payload["results"]) >= 1
+    assert payload["results"][0]["content"].startswith("ship")
+
+
+def test_take_ack_round_trip(runner: CliRunner, env) -> None:
+    runner.invoke(
+        main,
+        [
+            "tuplespace", "out", "locks/build",
+            '{"resource": "build", "holder": "ci"}',
+            "--content", "ci has build lock",
+        ],
+    )
+    take_result = runner.invoke(
+        main,
+        [
+            "tuplespace", "take", "locks/build",
+            "--claimant", "agent-1",
+            "--where", '{"resource": "build"}',
+        ],
+    )
+    assert take_result.exit_code == 0, take_result.output
+    payload = json.loads(take_result.output)
+    assert payload["claimed"] is True
+    claim_id = payload["claim_id"]
+
+    ack_result = runner.invoke(
+        main, ["tuplespace", "ack", claim_id, "--claimant", "agent-1"]
+    )
+    assert ack_result.exit_code == 0, ack_result.output
+    assert "ok" in ack_result.output
+
+
+def test_nack_returns_tuple_to_available(runner: CliRunner, env) -> None:
+    runner.invoke(
+        main,
+        [
+            "tuplespace", "out", "locks/db",
+            '{"resource": "db", "holder": "worker"}',
+            "--content", "db lock",
+        ],
+    )
+    take_result = runner.invoke(
+        main,
+        [
+            "tuplespace", "take", "locks/db",
+            "--claimant", "agent-x",
+            "--where", '{"resource": "db"}',
+        ],
+    )
+    claim_id = json.loads(take_result.output)["claim_id"]
+
+    nack_result = runner.invoke(
+        main, ["tuplespace", "nack", claim_id, "--claimant", "agent-x"]
+    )
+    assert nack_result.exit_code == 0, nack_result.output
+
+    # available count should be back to 1 (the nack released the claim)
+    stats_result = runner.invoke(main, ["tuplespace", "stats", "locks/db", "--json"])
+    payload = json.loads(stats_result.output)
+    assert payload["available"] == 1
+    assert payload["claimed"] == 0
+
+
+def test_daemon_mode_refuses_writes(runner: CliRunner, env, monkeypatch) -> None:
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+    result = runner.invoke(
+        main,
+        [
+            "tuplespace", "out", "tasks/demo",
+            '{"status": "open", "priority": "P1", "created_by": "alice"}',
+            "--content", "x",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "daemon" in result.output.lower()
+
+
+def test_daemon_mode_allows_list(runner: CliRunner, env, monkeypatch) -> None:
+    monkeypatch.setenv("NX_STORAGE_MODE", "daemon")
+    result = runner.invoke(main, ["tuplespace", "list-subspaces"])
+    assert result.exit_code == 0, result.output
+    assert "tasks/<project>" in result.output
+
+
+def test_banner_summary_no_db(env) -> None:
+    s = ts_cmd.banner_summary()
+    assert s["subspaces"] >= 2
+    assert s["tuples"] == 0
+    assert s["active_claims"] == 0
+    line = ts_cmd.banner_line()
+    assert "tuplespace:" in line
+    assert "subspaces" in line
+    assert "active claims" in line
+
+
+def test_banner_summary_with_tuples(runner: CliRunner, env) -> None:
+    runner.invoke(
+        main,
+        [
+            "tuplespace", "out", "tasks/demo",
+            '{"status": "open", "priority": "P1", "created_by": "alice"}',
+            "--content", "task A",
+        ],
+    )
+    runner.invoke(
+        main,
+        [
+            "tuplespace", "out", "tasks/demo",
+            '{"status": "open", "priority": "P2", "created_by": "bob"}',
+            "--content", "task B",
+        ],
+    )
+    s = ts_cmd.banner_summary()
+    assert s["tuples"] == 2
+    assert s["active_claims"] == 0
+    line = ts_cmd.banner_line()
+    assert "2 tuples" in line
+    assert "0 active claims" in line

--- a/tests/commands/test_tuplespace_cli.py
+++ b/tests/commands/test_tuplespace_cli.py
@@ -114,7 +114,7 @@ def test_list_subspaces_plain(runner: CliRunner, env) -> None:
 def test_list_subspaces_json(runner: CliRunner, env) -> None:
     result = runner.invoke(main, ["tuplespace", "list-subspaces", "--json"])
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert "tasks/<project>" in payload["subspaces"]
     assert "locks/<resource>" in payload["subspaces"]
 
@@ -128,7 +128,7 @@ def test_show_schema_unknown(runner: CliRunner, env) -> None:
 def test_show_schema_known(runner: CliRunner, env) -> None:
     result = runner.invoke(main, ["tuplespace", "show-schema", "tasks/demo", "--json"])
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["name"] == "tasks/<project>"
     assert "status" in payload["dimensions"]
 
@@ -176,7 +176,7 @@ def test_read_returns_tuple(runner: CliRunner, env) -> None:
         ["tuplespace", "read", "tasks/demo", "--query", "ship", "-n", "5"],
     )
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert len(payload["results"]) >= 1
     assert payload["results"][0]["content"].startswith("ship")
 

--- a/tests/test_plugin_structure.py
+++ b/tests/test_plugin_structure.py
@@ -39,6 +39,11 @@ _STANDALONE_SKILLS = {
     # RDR-078 verb skills — dispatch plan_match + plan_run directly, no agent relay
     "research", "review", "analyze", "debug", "document",
     "plan-author", "plan-inspect", "plan-promote", "plan-first",
+    # RDR-110 Step 8-10 tuple-space consumer skills (nexus-90pe) — pointer
+    # skills documenting the MCP / CLI surface; no agent dispatch.
+    "tuplespace-tasks", "tuplespace-mailbox", "tuplespace-lock",
+    "tuplespace-events", "tuplespace-barriers",
+    "tuplespace-list", "tuplespace-stats",
 }
 
 


### PR DESCRIPTION
## Summary

Ships the RDR-110 consumer landing surface (Steps 8-12) on top of the four canonical coordination subspaces and hook bridge already merged in PR #786 / nexus-y0nb. Today the substrate exists but no agent-facing surface lets a user consume it; this PR closes that gap.

- **Seven skills** under `nx/skills/`: tuplespace-tasks, tuplespace-mailbox, tuplespace-lock, tuplespace-events, tuplespace-barriers, tuplespace-list, tuplespace-stats. Registered as standalone skills in `nx/registry.yaml`. Pointer skills with no agent dispatch.
- **`nx tuplespace` CLI** at `src/nexus/commands/tuplespace.py`: list-subspaces, show-schema, stats, out, read, take, ack, nack. Mirrors the MCP tool vocabulary. Daemon-mode aware (refuses writes when `NX_STORAGE_MODE=daemon` so we never race the daemon's single writer).
- **Session-start banner extension** in `nx/hooks/scripts/session_start_hook.py`: one-line summary `tuplespace: N subspaces, M tuples, K active claims`. Sourced from the CLI so all three surfaces share one code path. Failure-tolerant (must never crash session start).
- **Env-var contract doc** at `docs/tuplespace-env.md`: every `NX_*` variable the consumer surface touches.

## Test plan

- [x] `uv run pytest tests/commands/ tests/tuplespace/ tests/test_plugin_structure.py -x` (760 passed, 33 skipped)
- [x] 13 CLI tests in `tests/commands/test_tuplespace_cli.py` cover every subcommand against a real `tuples.db` plus an EphemeralClient chroma backend, plus daemon-mode refusal and banner summary
- [x] Plugin-structure conventions enforced (frontmatter shape, registry parity, standalone-skill allowlist)

## Notes

- Steps already shipped (the four subspaces, hook bridge, `nx cockpit status`, `nx doctor --check-bridge`) are not re-touched here.
- Three sibling PRs (#787, #788, #789) modify `src/nexus/cockpit/`, `src/nexus/tuplespace/api.py`, `src/nexus/daemon/`. This PR avoids those files entirely; the CLI is read-only against the existing `nexus.tuplespace.api` surface.
- Banner reads via the same code path `_get_tuplespace` uses so daemon mode (post-#789) stays correct.

Part of epic nexus-hp9f.

Closes nexus-90pe