### PR TITLE
feat(operators): qwen_agent_dispatch + nx_enrich_beads opt-in routing

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -3970,7 +3970,25 @@ async def nx_enrich_beads(
     if context:
         prompt += f"\n\nAdditional context:\n{context}"
 
-    payload = await claude_dispatch(prompt, schema, timeout=timeout)
+    # Tier-B dispatcher selection (RDR follow-on to operator-level qwen
+    # offload). Default ``claude`` preserves prior behavior; setting
+    # ``NEXUS_TIER_B_DISPATCHER=qwen_agent`` routes through the
+    # qwen-coprocessor-stack supervisor with the ``nx`` extension wired
+    # in so the spawned qwen session can use search/query tools mid-loop.
+    tier_b = _os.environ.get("NEXUS_TIER_B_DISPATCHER", "claude").lower()
+    if tier_b == "qwen_agent":
+        from nexus.operators.qwen_agent_dispatch import qwen_agent_dispatch
+
+        payload = await qwen_agent_dispatch(
+            prompt,
+            schema,
+            timeout=timeout,
+            extensions=["nx"],
+            max_tool_calls=20,
+            operator_name="nx_enrich_beads",
+        )
+    else:
+        payload = await claude_dispatch(prompt, schema, timeout=timeout)
     return (
         payload.get("enriched_description", "")
         if isinstance(payload, dict) else str(payload)

--- a/src/nexus/operators/qwen_agent_dispatch.py
+++ b/src/nexus/operators/qwen_agent_dispatch.py
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Async qwen-agent dispatch — Qwen-backed alternative to ``claude_dispatch``
+for *tier-B* operator tools whose prompts invite mid-loop tool-use.
+
+Where :func:`nexus.operators.qwen_dispatch.qwen_dispatch` is a pure HTTP
+oneshot against llama-server's OpenAI-compat endpoint (no tools), this
+module talks to the **qwen-coprocessor-stack supervisor** over MCP-stdio
+and invokes its ``qwen_oneshot`` tool. The supervisor spawns a qwen CLI
+session with configured MCP extensions (e.g. the ``nx`` extension that
+exposes nexus's own search/query tools), runs the prompt with tool-use
+available, parses JSON against the supplied schema, then stops the
+session. Return shape mirrors ``claude_dispatch``'s parsed-dict contract.
+
+Supervisor source:
+    https://github.com/Hellblazer/qwen-coprocessor-stack
+    mcp-bridges/qwen-agent-server/src/server.ts  (qwen_oneshot tool)
+
+Resolution chain for the supervisor binary command-line:
+
+* explicit ``supervisor_binary=`` arg (a shell-style command string)
+* ``QWEN_AGENT_SUPERVISOR`` env (e.g. ``"node /path/to/dist/server.js"``)
+* ``~/.qwen-coprocessor-stack/config.json`` field ``supervisor_binary``
+  (or the ``QWEN_CONFIG_DIR`` override path)
+* hardcoded developer-machine default — see ``_DEFAULT_SUPERVISOR_CMD``
+
+The hardcoded default is intentionally developer-machine-specific. In
+production deployments the operator MUST set ``QWEN_AGENT_SUPERVISOR``
+or the config-file field; the default exists only so the test suite and
+local dev box don't need extra wiring.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shlex
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+_log = structlog.get_logger(__name__)
+
+__all__ = [
+    "qwen_agent_dispatch",
+    "QwenAgentOperatorError",
+    "QwenAgentOperatorTimeoutError",
+    "QwenAgentOperatorOutputError",
+]
+
+
+class QwenAgentOperatorError(RuntimeError):
+    """Raised when the supervisor returns an unexpected payload, the MCP
+    transport fails, or the ``qwen_oneshot`` tool returns
+    ``{ok: False}`` with a non-timeout / non-parse error code."""
+
+
+class QwenAgentOperatorTimeoutError(asyncio.TimeoutError):
+    """Raised when the supervisor reports
+    ``{ok: False, error: {code: "timeout"}}`` or when the MCP-side
+    asyncio wait exceeds *timeout* with a generous slack."""
+
+
+class QwenAgentOperatorOutputError(QwenAgentOperatorError):
+    """Raised when the supervisor reports
+    ``{ok: False, error: {code: "validation_failed"}}`` after retries —
+    i.e. the model produced non-JSON / schema-non-conforming output on
+    every attempt."""
+
+
+# Module-level concurrency cap mirrors qwen_dispatch's design: a single
+# llama-server serves one session at a time. Multiple supervisor sessions
+# queue at the backend with no benefit. Default 1; raise via env when a
+# multi-backend pool is configured upstream.
+_QWEN_AGENT_CONCURRENCY = max(
+    1, int(os.environ.get("NEXUS_QWEN_AGENT_CONCURRENCY", "1"))
+)
+_QWEN_AGENT_SEMAPHORE: asyncio.Semaphore | None = None
+
+
+def _semaphore() -> asyncio.Semaphore:
+    """Lazy-init the module semaphore so it binds to the running loop."""
+    global _QWEN_AGENT_SEMAPHORE
+    if _QWEN_AGENT_SEMAPHORE is None:
+        _QWEN_AGENT_SEMAPHORE = asyncio.Semaphore(_QWEN_AGENT_CONCURRENCY)
+    return _QWEN_AGENT_SEMAPHORE
+
+
+# Developer-machine default. Operators MUST override in prod via
+# QWEN_AGENT_SUPERVISOR or ``supervisor_binary`` config-file field.
+_DEFAULT_SUPERVISOR_CMD = (
+    "node /Volumes/Transcend Hell/git/qwen-coprocessor-stack/"
+    "mcp-bridges/qwen-agent-server/dist/server.js"
+)
+
+
+def _read_qwen_stack_config() -> dict[str, Any] | None:
+    """Read ``~/.qwen-coprocessor-stack/config.json`` if present.
+
+    Same file qwen_dispatch reads. Failures (missing, invalid JSON, OS
+    error) return ``None`` so resolution falls through to the default.
+    """
+    override = os.environ.get("QWEN_CONFIG_DIR")
+    cfg_path = (
+        Path(override) / "config.json"
+        if override
+        else Path.home() / ".qwen-coprocessor-stack" / "config.json"
+    )
+    try:
+        return json.loads(cfg_path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _resolve_supervisor_cmd(explicit: str | None) -> list[str]:
+    """Resolve the supervisor command into argv form (split via shlex)."""
+    if explicit:
+        return shlex.split(explicit)
+    env = os.environ.get("QWEN_AGENT_SUPERVISOR")
+    if env:
+        return shlex.split(env)
+    cfg = _read_qwen_stack_config()
+    if cfg:
+        sb = cfg.get("supervisor_binary")
+        if isinstance(sb, str) and sb:
+            return shlex.split(sb)
+    return shlex.split(_DEFAULT_SUPERVISOR_CMD)
+
+
+def _extract_oneshot_result(call_result: Any) -> dict[str, Any]:
+    """Pull the ``qwen_oneshot`` JSON return value out of an MCP CallToolResult.
+
+    MCP tool returns surface as ``CallToolResult`` with a ``content``
+    list of typed parts. For ``qwen_oneshot`` we expect a single
+    text-part whose body is the JSON-encoded ``OneshotResult``. We are
+    defensive: also accept ``structuredContent`` when the server emits
+    it, and pull the first text-part if there are multiple.
+    """
+    # structuredContent path (newer MCP servers)
+    structured = getattr(call_result, "structuredContent", None)
+    if isinstance(structured, dict):
+        return structured
+
+    content = getattr(call_result, "content", None) or []
+    for part in content:
+        text = getattr(part, "text", None)
+        if isinstance(text, str) and text:
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                continue
+
+    raise QwenAgentOperatorError(
+        f"qwen_oneshot returned no parseable content: {call_result!r}"
+    )
+
+
+async def qwen_agent_dispatch(
+    prompt: str,
+    json_schema: dict[str, Any],
+    *,
+    timeout: float = 600.0,
+    extensions: list[str] | None = None,
+    max_tool_calls: int = 20,
+    max_attempts: int = 2,
+    operator_name: str | None = None,
+    supervisor_binary: str | None = None,
+) -> dict[str, Any]:
+    """Dispatch a prompt to qwen via the qwen-agent-server supervisor.
+
+    Opens an MCP-stdio client to the supervisor binary, calls the
+    ``qwen_oneshot`` tool with the supplied prompt, schema, and
+    extension loadout, and returns the parsed JSON dict (same shape
+    as ``claude_dispatch``).
+
+    Args:
+        prompt: The task prompt forwarded to qwen.
+        json_schema: JSON Schema the response must conform to.
+        timeout: Hard timeout in seconds. Forwarded to ``qwen_oneshot``
+            as ``timeout_ms``; the python-side asyncio wait gets a
+            small slack to allow the supervisor to surface its own
+            timeout error cleanly. Default 600 s (parity with tier-B
+            tools' 600 s claude_dispatch ceiling).
+        extensions: Optional list of qwen-agent extension names to
+            enable for the spawned session. ``None`` lets the supervisor
+            use its ``default_extensions`` config field.
+        max_tool_calls: Cap on tool-use turns inside the session.
+        max_attempts: Retry budget for JSON parse / schema failures.
+        operator_name: Tag attached to the structured cost log line.
+        supervisor_binary: Override the supervisor command resolution.
+
+    Returns:
+        Parsed JSON dict from the model response.
+
+    Raises:
+        QwenAgentOperatorTimeoutError: supervisor reported a timeout
+            or the python-side wait exceeded *timeout* plus slack.
+        QwenAgentOperatorOutputError: supervisor reported
+            ``validation_failed`` after exhausting retries.
+        QwenAgentOperatorError: transport / session / other failure.
+    """
+    # Late-import the mcp client so import of this module does not
+    # incur the cost (or the failure mode) of pulling in anyio /
+    # mcp transports unless dispatch is actually invoked.
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    argv = _resolve_supervisor_cmd(supervisor_binary)
+    if not argv:
+        raise QwenAgentOperatorError(
+            "qwen_agent_dispatch: empty supervisor command after resolution"
+        )
+
+    server_params = StdioServerParameters(command=argv[0], args=argv[1:])
+
+    opts: dict[str, Any] = {
+        "json_schema": json_schema,
+        "max_tool_calls": max_tool_calls,
+        "timeout_ms": int(timeout * 1000),
+        "max_attempts": max_attempts,
+    }
+    if extensions is not None:
+        opts["extensions"] = extensions
+
+    # Generous slack so the supervisor's own timeout fires first and
+    # we get its structured error rather than a python-side cancel.
+    wait_timeout = timeout + 30.0
+
+    async with _semaphore():
+        try:
+            async with asyncio.timeout(wait_timeout):
+                async with stdio_client(server_params) as (read, write):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        call_result = await session.call_tool(
+                            "qwen_oneshot",
+                            arguments={"task": prompt, "opts": opts},
+                        )
+        except TimeoutError as exc:
+            raise QwenAgentOperatorTimeoutError(
+                f"qwen_agent_dispatch python-side wait exceeded "
+                f"{wait_timeout}s (supervisor did not surface its own "
+                f"timeout in time)"
+            ) from exc
+        except (QwenAgentOperatorError, QwenAgentOperatorTimeoutError):
+            raise
+        except Exception as exc:
+            raise QwenAgentOperatorError(
+                f"qwen_agent_dispatch MCP transport error: {exc}"
+            ) from exc
+
+    payload = _extract_oneshot_result(call_result)
+
+    # Cost telemetry — emit the same ``operator_dispatch_cost`` event
+    # PR #776 added for claude / qwen, so downstream rollups don't need
+    # a new engine-aware path. The supervisor's ``budget`` block carries
+    # tool_calls + (when available on the OpenAI/Anthropic envelope)
+    # input/output token counts; missing fields log as nulls.
+    budget = payload.get("budget") if isinstance(payload, dict) else None
+    in_tok: int | None = None
+    out_tok: int | None = None
+    tool_calls: int | None = None
+    if isinstance(budget, dict):
+        for src_key, dst in (
+            ("input_tokens", "in_tok"),
+            ("output_tokens", "out_tok"),
+            ("tool_calls", "tool_calls"),
+        ):
+            v = budget.get(src_key)
+            if isinstance(v, int):
+                if dst == "in_tok":
+                    in_tok = v
+                elif dst == "out_tok":
+                    out_tok = v
+                else:
+                    tool_calls = v
+    _log.info(
+        "operator_dispatch_cost",
+        dispatch_engine="qwen_agent",
+        dispatch_operator=operator_name,
+        dispatch_input_tokens=in_tok,
+        dispatch_output_tokens=out_tok,
+        dispatch_tool_calls=tool_calls,
+        dispatch_cost_usd=0.0,
+        dispatch_would_have_cost_usd=None,
+    )
+
+    if payload.get("ok") is True:
+        parsed = payload.get("parsed")
+        if not isinstance(parsed, dict):
+            raise QwenAgentOperatorOutputError(
+                f"qwen_oneshot returned ok=True but parsed is not a dict: "
+                f"{type(parsed).__name__}"
+            )
+        return parsed
+
+    err = payload.get("error") if isinstance(payload, dict) else None
+    code = err.get("code") if isinstance(err, dict) else None
+    msg = err.get("message", "") if isinstance(err, dict) else ""
+
+    if code == "timeout":
+        raise QwenAgentOperatorTimeoutError(
+            f"qwen_oneshot timeout: {msg}"
+        )
+    if code == "validation_failed":
+        raise QwenAgentOperatorOutputError(
+            f"qwen_oneshot validation_failed after retries: {msg}"
+        )
+    raise QwenAgentOperatorError(
+        f"qwen_oneshot failed (code={code!r}): {msg}"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,6 +226,17 @@ def _isolate_dispatch_routing(monkeypatch: pytest.MonkeyPatch) -> None:
         # prompt body, masking v1-shaped assertions.
         "NEXUS_ASPECT_BACKEND",
         "NEXUS_SCHOLARLY_PAPER_VERSION",
+        # Tier-B dispatcher routing (qwen_agent_dispatch). A shell that
+        # exports ``NEXUS_TIER_B_DISPATCHER=qwen_agent`` for an operator
+        # session would otherwise silently flip every nx_enrich_beads
+        # test off the default claude path. Same isolation reasoning as
+        # NEXUS_DISPATCH_BACKEND above.
+        "NEXUS_TIER_B_DISPATCHER",
+        # Supervisor-binary override for the qwen-agent transport — kept
+        # out of band so tests that exercise resolution can ``setenv`` it
+        # explicitly without inheriting an operator's real supervisor
+        # path.
+        "QWEN_AGENT_SUPERVISOR",
     ):
         monkeypatch.delenv(var, raising=False)
 

--- a/tests/test_nx_enrich_beads_routing.py
+++ b/tests/test_nx_enrich_beads_routing.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tier-B dispatcher routing for ``nx_enrich_beads``.
+
+Asserts that:
+
+* Default env → calls ``claude_dispatch`` (preserves prior behavior).
+* ``NEXUS_TIER_B_DISPATCHER=qwen_agent`` → calls ``qwen_agent_dispatch``
+  with ``extensions=["nx"]``, ``operator_name="nx_enrich_beads"``,
+  and the bead's enrichment prompt.
+
+Both dispatchers are mocked; no real backend is exercised.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_default_env_routes_to_claude(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
+    fake = AsyncMock(return_value={"enriched_description": "out"})
+    with (
+        patch("nexus.operators.dispatch.claude_dispatch", fake),
+        patch(
+            "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+            new=AsyncMock(side_effect=AssertionError("qwen_agent must not run")),
+        ),
+    ):
+        from nexus.mcp.core import nx_enrich_beads
+        # The FastMCP @mcp.tool() decorator wraps the function; reach
+        # the original async via .fn (FastMCP convention).
+        impl = getattr(nx_enrich_beads, "fn", nx_enrich_beads)
+        result = await impl("a bead about parsing widgets")
+    assert result == "out"
+    assert fake.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_qwen_agent_env_routes_to_qwen_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEXUS_TIER_B_DISPATCHER", "qwen_agent")
+    fake_qwen = AsyncMock(return_value={"enriched_description": "qwen-out"})
+    fake_claude = AsyncMock(side_effect=AssertionError("claude must not run"))
+    with (
+        patch(
+            "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+            fake_qwen,
+        ),
+        patch("nexus.operators.dispatch.claude_dispatch", fake_claude),
+    ):
+        from nexus.mcp.core import nx_enrich_beads
+        impl = getattr(nx_enrich_beads, "fn", nx_enrich_beads)
+        result = await impl("a bead about parsing widgets")
+
+    assert result == "qwen-out"
+    assert fake_qwen.await_count == 1
+    _, kwargs = fake_qwen.call_args
+    assert kwargs.get("extensions") == ["nx"]
+    assert kwargs.get("operator_name") == "nx_enrich_beads"
+    assert kwargs.get("max_tool_calls") == 20
+    # Prompt forwarded positionally; schema is the second positional arg.
+    args, _ = fake_qwen.call_args
+    assert "parsing widgets" in args[0]
+    assert isinstance(args[1], dict)
+    assert "enriched_description" in args[1].get("properties", {})

--- a/tests/test_qwen_agent_dispatch.py
+++ b/tests/test_qwen_agent_dispatch.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for ``nexus.operators.qwen_agent_dispatch``.
+
+The MCP stdio transport is not exercised end-to-end — we mock the
+``stdio_client`` / ``ClientSession`` surface to return synthetic
+``qwen_oneshot`` payloads. This keeps the test independent of the
+qwen-coprocessor-stack supervisor binary and runs offline.
+
+Coverage:
+  * Supervisor-command resolution: explicit > env > config > default
+  * Happy path → parsed dict returned, cost telemetry emitted
+  * ``error.code == "timeout"`` → QwenAgentOperatorTimeoutError
+  * ``error.code == "validation_failed"`` → QwenAgentOperatorOutputError
+  * Other error codes → QwenAgentOperatorError
+"""
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nexus.operators import qwen_agent_dispatch as mod
+from nexus.operators.qwen_agent_dispatch import (
+    QwenAgentOperatorError,
+    QwenAgentOperatorOutputError,
+    QwenAgentOperatorTimeoutError,
+    _resolve_supervisor_cmd,
+    qwen_agent_dispatch,
+)
+
+
+class _LogCapture:
+    """Drop-in for the module ``_log``: records each ``info(...)`` call as
+    ``(event, kwargs)``. Avoids depending on the harness's structlog
+    bridge — mirrors the same helper in ``test_qwen_dispatch.py``."""
+
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, dict[str, object]]] = []
+
+    def info(self, event: str, **kwargs: object) -> None:
+        self.entries.append((event, kwargs))
+
+    def debug(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+    def warning(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+    def error(self, *a: object, **kw: object) -> None:  # pragma: no cover
+        pass
+
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"answer": {"type": "string"}},
+    "required": ["answer"],
+}
+
+
+# ── Env isolation ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    for var in (
+        "QWEN_AGENT_SUPERVISOR",
+        "NEXUS_QWEN_AGENT_CONCURRENCY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # Empty tmpdir → no config.json → resolver falls through to the
+    # hardcoded developer-machine default.
+    monkeypatch.setenv("QWEN_CONFIG_DIR", str(tmp_path))
+
+
+# ── Supervisor-command resolution ─────────────────────────────────────────
+
+
+class TestResolveSupervisor:
+    def test_explicit_arg_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("QWEN_AGENT_SUPERVISOR", "node /env/server.js")
+        argv = _resolve_supervisor_cmd("node /explicit/server.js --flag")
+        assert argv == ["node", "/explicit/server.js", "--flag"]
+
+    def test_env_beats_config_and_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        (tmp_path / "config.json").write_text(
+            json.dumps({"supervisor_binary": "node /cfg/server.js"})
+        )
+        monkeypatch.setenv("QWEN_AGENT_SUPERVISOR", "node /env/server.js")
+        argv = _resolve_supervisor_cmd(None)
+        assert argv == ["node", "/env/server.js"]
+
+    def test_config_file_used_when_no_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        (tmp_path / "config.json").write_text(
+            json.dumps({"supervisor_binary": "node /cfg/server.js"})
+        )
+        monkeypatch.delenv("QWEN_AGENT_SUPERVISOR", raising=False)
+        argv = _resolve_supervisor_cmd(None)
+        assert argv == ["node", "/cfg/server.js"]
+
+    def test_falls_through_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("QWEN_AGENT_SUPERVISOR", raising=False)
+        argv = _resolve_supervisor_cmd(None)
+        # Default is developer-machine-specific but always begins with
+        # ``node`` and points at a ``server.js``.
+        assert argv[0] == "node"
+        assert argv[-1].endswith("server.js")
+
+
+# ── Mock MCP client harness ───────────────────────────────────────────────
+
+
+def _call_result(payload: dict) -> SimpleNamespace:
+    """Synthesize a CallToolResult-shaped object whose single content
+    part carries ``payload`` as JSON text."""
+    text_part = SimpleNamespace(text=json.dumps(payload))
+    return SimpleNamespace(content=[text_part], structuredContent=None)
+
+
+@asynccontextmanager
+async def _fake_stdio_client(server_params):
+    yield (object(), object())
+
+
+class _FakeSession:
+    """Minimal stand-in for ``mcp.ClientSession``.
+
+    Captures the ``call_tool`` invocation kwargs so tests can assert on
+    them, and returns a synthetic ``qwen_oneshot`` payload supplied at
+    construction time.
+    """
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self.initialize = AsyncMock(return_value=None)
+        self.call_tool = AsyncMock(return_value=_call_result(payload))
+        self.last_args: dict | None = None
+
+        async def _capture(name, arguments=None):
+            self.last_args = {"name": name, "arguments": arguments}
+            return _call_result(self._payload)
+
+        self.call_tool.side_effect = _capture
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _patch_mcp(monkeypatch, session: _FakeSession):
+    """Patch the lazy mcp imports inside qwen_agent_dispatch."""
+    import mcp
+    import mcp.client.stdio
+
+    def _client_factory(*a, **kw):
+        return _fake_stdio_client(None)
+
+    monkeypatch.setattr(mcp.client.stdio, "stdio_client", _client_factory)
+    monkeypatch.setattr(
+        mcp, "ClientSession", lambda *a, **kw: session
+    )
+    # Identity StdioServerParameters — we don't use it beyond construction.
+    monkeypatch.setattr(
+        mcp,
+        "StdioServerParameters",
+        lambda **kw: SimpleNamespace(**kw),
+    )
+
+
+# ── Behavioural tests ─────────────────────────────────────────────────────
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_parsed_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = _FakeSession({
+            "ok": True,
+            "parsed": {"answer": "42"},
+            "budget": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "tool_calls": 3,
+            },
+        })
+        _patch_mcp(monkeypatch, session)
+
+        result = await qwen_agent_dispatch(
+            "what is the answer",
+            _SCHEMA,
+            timeout=10.0,
+            extensions=["nx"],
+            operator_name="test_op",
+            supervisor_binary="node /fake/server.js",
+        )
+        assert result == {"answer": "42"}
+
+        # Forwarded args: opts.timeout_ms = timeout * 1000, schema + ext.
+        assert session.last_args is not None
+        args = session.last_args["arguments"]
+        assert session.last_args["name"] == "qwen_oneshot"
+        assert args["task"] == "what is the answer"
+        assert args["opts"]["json_schema"] == _SCHEMA
+        assert args["opts"]["extensions"] == ["nx"]
+        assert args["opts"]["timeout_ms"] == 10000
+
+    @pytest.mark.asyncio
+    async def test_cost_telemetry_emitted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = _FakeSession({
+            "ok": True,
+            "parsed": {"answer": "ok"},
+            "budget": {
+                "input_tokens": 200,
+                "output_tokens": 75,
+                "tool_calls": 5,
+            },
+        })
+        _patch_mcp(monkeypatch, session)
+
+        cap = _LogCapture()
+        with patch("nexus.operators.qwen_agent_dispatch._log", cap):
+            await qwen_agent_dispatch(
+                "prompt",
+                _SCHEMA,
+                operator_name="nx_enrich_beads",
+                supervisor_binary="node /fake/server.js",
+            )
+
+        cost_entries = [e for e in cap.entries if e[0] == "operator_dispatch_cost"]
+        assert cost_entries, f"expected cost log entry; got {cap.entries!r}"
+        _, kw = cost_entries[-1]
+        assert kw["dispatch_engine"] == "qwen_agent"
+        assert kw["dispatch_operator"] == "nx_enrich_beads"
+        assert kw["dispatch_input_tokens"] == 200
+        assert kw["dispatch_output_tokens"] == 75
+        assert kw["dispatch_tool_calls"] == 5
+        assert kw["dispatch_cost_usd"] == 0.0
+
+
+class TestErrorMapping:
+    @pytest.mark.asyncio
+    async def test_timeout_code_maps_to_timeout_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = _FakeSession({
+            "ok": False,
+            "error": {"code": "timeout", "message": "oneshot timed out"},
+        })
+        _patch_mcp(monkeypatch, session)
+        with pytest.raises(QwenAgentOperatorTimeoutError):
+            await qwen_agent_dispatch(
+                "p", _SCHEMA, supervisor_binary="node /fake/s.js",
+            )
+
+    @pytest.mark.asyncio
+    async def test_validation_failed_maps_to_output_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = _FakeSession({
+            "ok": False,
+            "error": {"code": "validation_failed", "message": "JSON.parse failed"},
+        })
+        _patch_mcp(monkeypatch, session)
+        with pytest.raises(QwenAgentOperatorOutputError):
+            await qwen_agent_dispatch(
+                "p", _SCHEMA, supervisor_binary="node /fake/s.js",
+            )
+
+    @pytest.mark.asyncio
+    async def test_other_error_maps_to_generic_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = _FakeSession({
+            "ok": False,
+            "error": {"code": "session_error", "message": "spawn ENOENT"},
+        })
+        _patch_mcp(monkeypatch, session)
+        with pytest.raises(QwenAgentOperatorError) as exc_info:
+            await qwen_agent_dispatch(
+                "p", _SCHEMA, supervisor_binary="node /fake/s.js",
+            )
+        # NOT the timeout/output subclasses.
+        assert not isinstance(exc_info.value, QwenAgentOperatorTimeoutError)
+        assert not isinstance(exc_info.value, QwenAgentOperatorOutputError)
+
+
+# Reset the module semaphore between tests so concurrency state doesn't
+# leak across the suite (matches the qwen_dispatch test convention).
+@pytest.fixture(autouse=True)
+def _reset_semaphore() -> None:
+    mod._QWEN_AGENT_SEMAPHORE = None
+    yield
+    mod._QWEN_AGENT_SEMAPHORE = None


### PR DESCRIPTION
## Summary

Tier-B dispatch substrate for routing operator prompts through the
qwen-coprocessor-stack supervisor's ``qwen_oneshot`` MCP tool. Enables
Qwen-backed dispatch for the three tier-B operators (``nx_tidy``,
``nx_enrich_beads``, ``nx_plan_audit``) whose prompts invite mid-loop
tool-use that pure-HTTP ``qwen_dispatch`` cannot serve.

This PR ships the substrate plus routing for ``nx_enrich_beads`` only,
behind an opt-in env flag. ``nx_tidy`` / ``nx_plan_audit`` routing and
the bench harness are explicit follow-ons.

## Changes

- ``src/nexus/operators/qwen_agent_dispatch.py`` (new, ~310 lines):
  MCP-stdio client to the supervisor, calls ``qwen_oneshot``, mirrors
  ``qwen_dispatch``'s exception/semaphore/telemetry shape.
- ``src/nexus/mcp/core.py``: ``nx_enrich_beads`` checks
  ``NEXUS_TIER_B_DISPATCHER``; default routes to ``claude_dispatch`` (no
  behavior change), ``qwen_agent`` routes to ``qwen_agent_dispatch`` with
  ``extensions=["nx"]``.
- ``tests/conftest.py``: env-isolates ``NEXUS_TIER_B_DISPATCHER`` and
  ``QWEN_AGENT_SUPERVISOR`` (mirrors the ``NEXUS_DISPATCH_*`` pattern from
  #626).
- ``tests/test_qwen_agent_dispatch.py`` (9 tests): supervisor-command
  resolution chain, happy path with arg-forwarding assertion, cost
  telemetry, error-code mapping (timeout / validation_failed / other).
- ``tests/test_nx_enrich_beads_routing.py`` (2 tests): default routes to
  claude, ``qwen_agent`` routes to qwen with the right kwargs.

## Wire-shape notes

- Supervisor error codes are ``timeout`` / ``validation_failed`` /
  ``session_error`` / ``no_result`` (NOT ``parse_failure`` as the spec
  guessed) — verified against
  ``mcp-bridges/qwen-agent-server/src/server.ts`` qwen_oneshot handler.
- Budget block (``SessionBudgetStats``) carries ``tool_calls`` always
  and ``input_tokens`` / ``output_tokens`` when the Anthropic/OpenAI
  envelope surfaces them; missing fields log as nulls.
- Extension names are lowercased ``config.name`` strings; ``"nx"`` is the
  expected name for the nexus extension that exposes search/query tools.

## Dependencies

- ``mcp>=1.0`` is already declared in ``pyproject.toml`` (used by
  ``nexus.mcp.core`` for the FastMCP server). No new dependency added;
  the Python client surface is imported lazily inside
  ``qwen_agent_dispatch`` so module-import cost is paid only on use.

## Supervisor-binary resolution

Order (left to right):
1. Explicit ``supervisor_binary=`` arg
2. ``QWEN_AGENT_SUPERVISOR`` env (full command string)
3. ``~/.qwen-coprocessor-stack/config.json`` ``supervisor_binary`` field
   (honors ``QWEN_CONFIG_DIR`` override)
4. Hardcoded developer-machine default (commented as such; prod operators
   must set the env or config-file field).

## Bench evidence

**NONE in this PR by design.** This ships the substrate; the bench
harness (``spike_d``) is the follow-on that will compare claude vs.
qwen_agent on the tier-B operators against real beads / plans.

## Out of scope

- ``nx_tidy`` and ``nx_plan_audit`` routing (subsequent PRs once bench
  evidence justifies the routing decision per-operator).
- ``spike_d`` bench harness.
- Any changes to ``claude_dispatch`` or ``qwen_dispatch``.

## Linked

#780, #790, #793.

## Test plan

- [x] ``pytest tests/test_qwen_agent_dispatch.py tests/test_nx_enrich_beads_routing.py`` — 11 passed
- [x] ``pytest tests/test_qwen_dispatch.py tests/test_dispatch_router.py`` — 68 passed, 1 skipped
- [x] ``pytest tests/ -k "dispatch or enrich_beads or operator"`` — 284 passed, 1 skipped
- [ ] Manual smoke against a real supervisor binary (deferred to spike_d)