### PR TITLE
spike(tier-b): A/B parity harness for nx_enrich_beads / nx_tidy / nx_plan_audit

### DIFF
--- a/scripts/spikes/spike_d_tier_b_parity.py
+++ b/scripts/spikes/spike_d_tier_b_parity.py
@@ -1,0 +1,615 @@
+#!/usr/bin/env -S uv run python
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Spike D — tier-B tool-use A/B parity harness: claude_agent vs qwen_agent.
+
+Follow-on to PR #796 (``qwen_agent_dispatch`` + ``nx_enrich_beads``
+opt-in routing via ``NEXUS_TIER_B_DISPATCHER=qwen_agent``). Tier-B
+tools (``nx_tidy``, ``nx_enrich_beads``, ``nx_plan_audit``) differ
+structurally from operator-tier oneshot extractors: their prompts
+invite mid-loop MCP tool-use, so spike_c's prompt-in/JSON-out shape
+does not fit. This script ships the new harness.
+
+Routing reality
+---------------
+
+Per PR #796, only ``nx_enrich_beads`` honors
+``NEXUS_TIER_B_DISPATCHER``. The other two unconditionally call
+``claude_dispatch``. For those tools the bench records
+``qwen_agent_skipped: true`` on the qwen leg and runs only the claude
+leg; the structural-diff axis becomes vacuously self-equal, but the
+elapsed/ok-rate axis is still useful as a baseline. Routing for those
+two is the **follow-on PR** — spike_d ships the harness, not the
+routing.
+
+Three-axis metric
+-----------------
+
+* **Semantic** — prose fields (``summary``, ``verdict``,
+  ``enriched_description``). Length-ratio heuristic (>=0.5) mirrors
+  spike_c. LLM-judge generalisation is a separate follow-on script
+  (we already have ``judge_aspect_diffs.py`` for spike_c — it gets
+  generalised after this PR lands).
+* **Structural** — Jaccard overlap on canonical set fields per tool:
+    - ``nx_enrich_beads``: ``key_files``, ``test_commands``, ``constraints``
+    - ``nx_tidy``: ``actions`` (Jaccard on the JSON-serialised action dicts)
+    - ``nx_plan_audit``: ``findings`` (Jaccard on the JSON-serialised
+      finding dicts)
+* **Tool-call count** — only surfaced on the qwen leg via the
+  ``budget.tool_calls`` field PR #796 wired into qwen_oneshot's
+  return. Captured by monkey-patching ``_extract_oneshot_result`` to
+  stash the full payload, then reading ``budget.tool_calls`` off it
+  before the dispatcher discards everything except ``parsed``.
+
+Implementation notes
+--------------------
+
+The MCP tools (``nx_enrich_beads`` & friends) stringify their inner
+parsed dict before returning. To recover structural fields, the
+harness monkey-patches the two dispatchers — ``claude_dispatch`` and
+``qwen_agent_dispatch`` — with capture-wrappers that record the
+parsed dict before forwarding. This keeps the prompts/schemas
+exactly as production constructs them (no DRY duplication of prompt
+text in the harness), at the cost of a small in-process patch
+window.
+
+Manifest shape
+--------------
+
+Operator-supplied JSON list (no fixture corpus shipped with the PR)::
+
+    [
+      {
+        "name": "enrich-simple-bead",
+        "tool": "nx_enrich_beads",
+        "input": {
+          "bead_description": "Add SQLite-WAL backed cache for ...",
+          "context": ""
+        },
+        "tags": ["smoke"]
+      },
+      {
+        "name": "tidy-chroma-quotas",
+        "tool": "nx_tidy",
+        "input": {"topic": "chromadb quotas", "collection": "knowledge"}
+      },
+      {
+        "name": "audit-rdr-080-plan",
+        "tool": "nx_plan_audit",
+        "input": {"plan_json": "{...}"}
+      }
+    ]
+
+Out of scope
+------------
+
+* Routing for ``nx_tidy`` / ``nx_plan_audit`` — that's the follow-on
+  PR. spike_d *bench-skips* them on the qwen_agent leg.
+* Semantic-equivalence LLM judge — separate script.
+* Fixture corpus.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+# ── Per-tool config ──────────────────────────────────────────────────────────
+
+SUPPORTED_TOOLS: tuple[str, ...] = (
+    "nx_enrich_beads",
+    "nx_tidy",
+    "nx_plan_audit",
+)
+
+# Tools currently NOT wired to NEXUS_TIER_B_DISPATCHER opt-in. Both
+# legs of the bench run claude_dispatch for these; the qwen leg is
+# recorded as skipped so per-tool aggregates flag the gap.
+QWEN_AGENT_UNWIRED: frozenset[str] = frozenset({"nx_tidy", "nx_plan_audit"})
+
+# Per-tool structural fields used for Jaccard overlap.
+STRUCTURAL_FIELDS: dict[str, tuple[str, ...]] = {
+    "nx_enrich_beads": ("key_files", "test_commands", "constraints"),
+    "nx_tidy": ("actions",),
+    "nx_plan_audit": ("findings",),
+}
+
+# Per-tool prose fields used for length-ratio semantic agreement.
+PROSE_FIELDS: dict[str, tuple[str, ...]] = {
+    "nx_enrich_beads": ("enriched_description",),
+    "nx_tidy": ("summary",),
+    "nx_plan_audit": ("verdict", "summary"),
+}
+
+PROSE_LEN_TOL: float = 0.5
+
+
+# ── Agreement helpers ────────────────────────────────────────────────────────
+
+
+def _to_hashable(item: Any) -> str:
+    """Canonicalise a list element for Jaccard. Dicts → sorted-key JSON;
+    strings pass through; anything else → ``repr``."""
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        return json.dumps(item, sort_keys=True, ensure_ascii=False)
+    return repr(item)
+
+
+def _jaccard(a: Any, b: Any) -> float:
+    """Jaccard overlap between two iterables (after canonicalisation).
+    Two empty sets → 1.0 (vacuous agreement)."""
+    sa = {_to_hashable(x) for x in (a or [])}
+    sb = {_to_hashable(x) for x in (b or [])}
+    if not sa and not sb:
+        return 1.0
+    union = sa | sb
+    if not union:
+        return 1.0
+    return len(sa & sb) / len(union)
+
+
+def _prose_agree(a: Any, b: Any, tol: float = PROSE_LEN_TOL) -> bool:
+    if a is None and b is None:
+        return True
+    if not a and not b:
+        return True
+    if not a or not b:
+        return False
+    la, lb = len(a), len(b)
+    if max(la, lb) == 0:
+        return True
+    return min(la, lb) / max(la, lb) >= tol
+
+
+def diff_payloads(
+    tool: str,
+    claude_payload: dict | None,
+    qwen_payload: dict | None,
+) -> dict[str, Any]:
+    """Compute structural + prose agreement between two parsed payloads.
+
+    Returns dict with: ``claude_ok``, ``qwen_ok``, ``both_ok``,
+    ``structural`` (per-field Jaccard), ``prose`` (per-field bool).
+    """
+    out: dict[str, Any] = {
+        "claude_ok": isinstance(claude_payload, dict),
+        "qwen_ok": isinstance(qwen_payload, dict),
+        "both_ok": (
+            isinstance(claude_payload, dict)
+            and isinstance(qwen_payload, dict)
+        ),
+        "structural": {},
+        "prose": {},
+    }
+    if not out["both_ok"]:
+        for f in STRUCTURAL_FIELDS.get(tool, ()):
+            out["structural"][f] = 0.0
+        for f in PROSE_FIELDS.get(tool, ()):
+            out["prose"][f] = False
+        return out
+    for f in STRUCTURAL_FIELDS.get(tool, ()):
+        out["structural"][f] = _jaccard(
+            claude_payload.get(f), qwen_payload.get(f),
+        )
+    for f in PROSE_FIELDS.get(tool, ()):
+        out["prose"][f] = _prose_agree(
+            claude_payload.get(f), qwen_payload.get(f),
+        )
+    return out
+
+
+# ── Dispatch capture ─────────────────────────────────────────────────────────
+
+
+class _Capture:
+    """Module-level capture buffer for the last dispatched payload + budget.
+
+    Both ``claude_dispatch`` and ``qwen_agent_dispatch`` return the
+    *parsed* dict; ``qwen_agent_dispatch`` additionally has access to
+    the raw ``budget`` block but discards it after logging. We patch
+    each dispatcher with a thin wrapper that stashes the parsed dict
+    here, and for the qwen path we *also* patch
+    ``_extract_oneshot_result`` to stash the budget before its caller
+    moves on.
+    """
+
+    def __init__(self) -> None:
+        self.payload: dict | None = None
+        self.budget: dict | None = None
+
+    def reset(self) -> None:
+        self.payload = None
+        self.budget = None
+
+
+def _install_captures(capture: _Capture) -> list[Any]:
+    """Monkey-patch the two dispatchers + qwen oneshot extractor.
+
+    Returns a list of ``(module, attr, original)`` triples for
+    teardown. Caller invokes :func:`_uninstall_captures` after the
+    dispatch leg completes.
+    """
+    from nexus.operators import dispatch as _dispatch_mod
+    from nexus.operators import qwen_agent_dispatch as _qa_mod
+
+    originals: list[tuple[Any, str, Any]] = []
+
+    orig_claude = _dispatch_mod.claude_dispatch
+
+    async def _wrapped_claude(*args: Any, **kwargs: Any) -> Any:
+        result = await orig_claude(*args, **kwargs)
+        if isinstance(result, dict):
+            capture.payload = result
+        return result
+
+    _dispatch_mod.claude_dispatch = _wrapped_claude  # type: ignore[assignment]
+    originals.append((_dispatch_mod, "claude_dispatch", orig_claude))
+
+    orig_qa = _qa_mod.qwen_agent_dispatch
+
+    async def _wrapped_qa(*args: Any, **kwargs: Any) -> Any:
+        result = await orig_qa(*args, **kwargs)
+        if isinstance(result, dict):
+            capture.payload = result
+        return result
+
+    _qa_mod.qwen_agent_dispatch = _wrapped_qa  # type: ignore[assignment]
+    originals.append((_qa_mod, "qwen_agent_dispatch", orig_qa))
+
+    orig_extract = _qa_mod._extract_oneshot_result
+
+    def _wrapped_extract(call_result: Any) -> dict[str, Any]:
+        payload = orig_extract(call_result)
+        budget = payload.get("budget") if isinstance(payload, dict) else None
+        if isinstance(budget, dict):
+            capture.budget = budget
+        return payload
+
+    _qa_mod._extract_oneshot_result = _wrapped_extract  # type: ignore[assignment]
+    originals.append((_qa_mod, "_extract_oneshot_result", orig_extract))
+
+    return originals
+
+
+def _uninstall_captures(originals: list[Any]) -> None:
+    for mod, attr, orig in originals:
+        setattr(mod, attr, orig)
+
+
+# ── Tool invocation ──────────────────────────────────────────────────────────
+
+
+def _resolve_tool_fn(tool: str):
+    """Resolve the MCP tool's underlying async function (unwrap FastMCP)."""
+    from nexus.mcp import core
+
+    obj = getattr(core, tool)
+    return getattr(obj, "fn", obj)
+
+
+async def _run_one_leg(
+    tool: str,
+    inputs: dict[str, Any],
+    backend: str,
+) -> dict[str, Any]:
+    """Invoke *tool* under one backend leg. Returns a row fragment with
+    ``payload``, ``budget``, ``elapsed_ms``, ``error``, ``result_str``.
+    """
+    # Backend toggle. The 'claude_agent' label maps to the default
+    # (env unset / 'claude'); 'qwen_agent' sets the opt-in.
+    if backend == "claude_agent":
+        os.environ.pop("NEXUS_TIER_B_DISPATCHER", None)
+    elif backend == "qwen_agent":
+        os.environ["NEXUS_TIER_B_DISPATCHER"] = "qwen_agent"
+    else:
+        raise ValueError(f"unknown backend: {backend!r}")
+
+    capture = _Capture()
+    originals = _install_captures(capture)
+    fn = _resolve_tool_fn(tool)
+
+    t0 = time.perf_counter()
+    error: str | None = None
+    result_str: str | None = None
+    try:
+        result_str = await fn(**inputs)
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+    _uninstall_captures(originals)
+
+    tool_calls: int | None = None
+    if isinstance(capture.budget, dict):
+        tc = capture.budget.get("tool_calls")
+        if isinstance(tc, int):
+            tool_calls = tc
+
+    return {
+        "payload": capture.payload,
+        "budget": capture.budget,
+        "tool_calls": tool_calls,
+        "elapsed_ms": elapsed_ms,
+        "error": error,
+        "result_str": result_str,
+    }
+
+
+# ── Manifest + CLI ───────────────────────────────────────────────────────────
+
+
+def _load_cases(path: Path) -> list[dict]:
+    """Load + validate the per-case manifest. Raises on malformed entries."""
+    if not path.exists():
+        raise FileNotFoundError(f"cases manifest not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(
+            f"cases manifest must be a JSON array; got {type(data).__name__}"
+        )
+    for ix, case in enumerate(data):
+        if not isinstance(case, dict):
+            raise ValueError(f"case[{ix}] is not an object: {case!r}")
+        tool = case.get("tool")
+        if tool not in SUPPORTED_TOOLS:
+            raise ValueError(
+                f"case[{ix}] has unsupported / missing tool: {tool!r} "
+                f"(supported: {SUPPORTED_TOOLS})"
+            )
+        if not isinstance(case.get("input"), dict):
+            raise ValueError(
+                f"case[{ix}] missing 'input' dict (tool={tool!r})"
+            )
+        case.setdefault("name", f"case-{ix}")
+    return data
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="A/B parity harness for tier-B tool-use dispatch "
+                    "(claude_agent vs qwen_agent)",
+    )
+    p.add_argument("--cases", type=Path, required=True,
+                   help="JSON manifest of cases (see script docstring).")
+    p.add_argument("--out", type=Path, required=True,
+                   help="JSONL log output path.")
+    p.add_argument("--summary", type=Path,
+                   help="Optional markdown summary path (default: <out>.md).")
+    p.add_argument("--tool", choices=SUPPORTED_TOOLS,
+                   help="Filter to a single tool.")
+    p.add_argument("--case",
+                   help="Filter to a single case by name.")
+    p.add_argument("--limit", type=int, default=0,
+                   help="Cap cases (0 = unbounded).")
+    p.add_argument("--repeat", type=int, default=1,
+                   help="Repeat each case N times for variance (default 1).")
+    p.add_argument("--backends", default="claude_agent,qwen_agent",
+                   help="Comma-separated backends (default: "
+                        "claude_agent,qwen_agent).")
+    return p.parse_args(argv)
+
+
+# ── Aggregation ──────────────────────────────────────────────────────────────
+
+
+def _median(xs: list[float]) -> float:
+    return statistics.median(xs) if xs else 0.0
+
+
+def _rate(xs: list[bool]) -> float:
+    return (sum(1 for x in xs if x) / len(xs)) if xs else 0.0
+
+
+def _summarize(records: list[dict]) -> dict:
+    """Per-tool aggregation: ok-rate, medians, structural / prose agreement,
+    median + max tool-call count (qwen leg only)."""
+    by_tool: dict[str, list[dict]] = {}
+    for r in records:
+        by_tool.setdefault(r["tool"], []).append(r)
+
+    out: dict[str, Any] = {"total": len(records), "by_tool": {}}
+    for tool, rows in by_tool.items():
+        claude_ms = [r["claude_agent"]["elapsed_ms"] for r in rows
+                     if r.get("claude_agent")]
+        qwen_ms = [r["qwen_agent"]["elapsed_ms"] for r in rows
+                   if r.get("qwen_agent") and not r.get("qwen_agent_skipped")]
+        tool_calls = [r["qwen_agent"]["tool_calls"] for r in rows
+                      if r.get("qwen_agent")
+                      and not r.get("qwen_agent_skipped")
+                      and r["qwen_agent"].get("tool_calls") is not None]
+
+        both_ok = [r for r in rows if r.get("diff", {}).get("both_ok")]
+        struct_agg: dict[str, list[float]] = {}
+        prose_agg: dict[str, list[bool]] = {}
+        for r in both_ok:
+            for f, v in r["diff"].get("structural", {}).items():
+                struct_agg.setdefault(f, []).append(float(v))
+            for f, v in r["diff"].get("prose", {}).items():
+                prose_agg.setdefault(f, []).append(bool(v))
+
+        out["by_tool"][tool] = {
+            "n": len(rows),
+            "skipped_qwen_agent": sum(
+                1 for r in rows if r.get("qwen_agent_skipped")
+            ),
+            "claude_ok_rate": _rate([
+                bool(r.get("claude_agent") and not r["claude_agent"]["error"])
+                for r in rows
+            ]),
+            "qwen_ok_rate": _rate([
+                bool(r.get("qwen_agent") and not r["qwen_agent"]["error"])
+                for r in rows if not r.get("qwen_agent_skipped")
+            ]),
+            "claude_median_ms": _median(claude_ms),
+            "qwen_median_ms": _median(qwen_ms),
+            "tool_calls_median": _median(tool_calls) if tool_calls else 0.0,
+            "tool_calls_max": max(tool_calls) if tool_calls else 0,
+            "structural": {
+                f: {
+                    "mean_jaccard": (sum(v) / len(v)) if v else 0.0,
+                    "n": len(v),
+                }
+                for f, v in struct_agg.items()
+            },
+            "prose": {
+                f: {"agree_rate": _rate(v), "n": len(v)}
+                for f, v in prose_agg.items()
+            },
+        }
+    return out
+
+
+def _render_md(summary: dict, out_path: Path) -> str:
+    lines = [
+        "# Spike D — tier-B tool-use A/B parity (claude_agent vs qwen_agent)",
+        "",
+        f"- Total runs: **{summary['total']}**",
+        "",
+    ]
+    for tool, s in sorted(summary["by_tool"].items()):
+        lines += [
+            f"## `{tool}` (n={s['n']})",
+            "",
+            f"- Qwen-agent skipped (unwired): **{s['skipped_qwen_agent']}**",
+            f"- Claude ok-rate: **{s['claude_ok_rate']:.2%}**",
+            f"- Qwen ok-rate:   **{s['qwen_ok_rate']:.2%}**",
+            f"- Claude median elapsed: **{s['claude_median_ms']:.0f} ms**",
+            f"- Qwen median elapsed:   **{s['qwen_median_ms']:.0f} ms**",
+            f"- Qwen tool-calls (median / max): "
+            f"**{s['tool_calls_median']:.1f}** / **{s['tool_calls_max']}**",
+            "",
+            "### Structural agreement (Jaccard, both-ok subset)",
+            "",
+            "| Field | Mean Jaccard | N |",
+            "|---|---|---|",
+        ]
+        for f, info in sorted(s["structural"].items()):
+            lines.append(
+                f"| `{f}` | {info['mean_jaccard']:.2%} | {info['n']} |"
+            )
+        lines += [
+            "",
+            f"### Prose agreement (len-ratio >= {PROSE_LEN_TOL})",
+            "",
+            "| Field | Agree rate | N |",
+            "|---|---|---|",
+        ]
+        for f, info in sorted(s["prose"].items()):
+            lines.append(
+                f"| `{f}` | {info['agree_rate']:.2%} | {info['n']} |"
+            )
+        lines.append("")
+    lines.append(f"_Raw JSONL: `{out_path}`_")
+    return "\n".join(lines) + "\n"
+
+
+# ── Driver ───────────────────────────────────────────────────────────────────
+
+
+async def _run_case(
+    case: dict,
+    backends: list[str],
+) -> dict:
+    tool = case["tool"]
+    row: dict[str, Any] = {
+        "name": case["name"],
+        "tool": tool,
+        "tags": case.get("tags", []),
+        "input": case["input"],
+    }
+    for backend in backends:
+        if backend == "qwen_agent" and tool in QWEN_AGENT_UNWIRED:
+            row["qwen_agent_skipped"] = True
+            row["qwen_agent"] = None
+            continue
+        leg = await _run_one_leg(tool, case["input"], backend)
+        row[backend] = leg
+    # Diff only if both legs ran and both produced a payload.
+    claude_p = (row.get("claude_agent") or {}).get("payload")
+    qwen_p = (row.get("qwen_agent") or {}).get("payload") \
+        if not row.get("qwen_agent_skipped") else None
+    if claude_p is not None and qwen_p is not None:
+        row["diff"] = diff_payloads(tool, claude_p, qwen_p)
+    else:
+        row["diff"] = {
+            "claude_ok": claude_p is not None,
+            "qwen_ok": qwen_p is not None,
+            "both_ok": False,
+            "structural": {},
+            "prose": {},
+        }
+    return row
+
+
+async def _main_async(args: argparse.Namespace) -> int:
+    cases = _load_cases(args.cases)
+    if args.tool:
+        cases = [c for c in cases if c["tool"] == args.tool]
+    if args.case:
+        cases = [c for c in cases if c["name"] == args.case]
+    if args.limit:
+        cases = cases[: args.limit]
+    if not cases:
+        print("error: no cases after filtering", file=sys.stderr)
+        return 2
+
+    backends = [b.strip() for b in args.backends.split(",") if b.strip()]
+    for b in backends:
+        if b not in ("claude_agent", "qwen_agent"):
+            print(f"error: unknown backend {b!r}", file=sys.stderr)
+            return 2
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    records: list[dict] = []
+    with args.out.open("w", encoding="utf-8") as fp:
+        for repeat_ix in range(args.repeat):
+            for case in cases:
+                row = await _run_case(case, backends)
+                row["repeat"] = repeat_ix
+                fp.write(json.dumps(row, default=str) + "\n")
+                fp.flush()
+                records.append(row)
+                claude_ok = bool(
+                    row.get("claude_agent")
+                    and not row["claude_agent"]["error"]
+                )
+                if row.get("qwen_agent_skipped"):
+                    qwen_state = "skipped"
+                else:
+                    qwen_state = "ok" if (
+                        row.get("qwen_agent")
+                        and not row["qwen_agent"]["error"]
+                    ) else "fail"
+                print(
+                    f"[{repeat_ix + 1}/{args.repeat}] "
+                    f"{row['tool']}::{row['name']}: "
+                    f"claude={'ok' if claude_ok else 'fail'} "
+                    f"qwen={qwen_state}",
+                    file=sys.stderr,
+                )
+
+    summary = _summarize(records)
+    summary_path = args.summary or args.out.with_suffix(args.out.suffix + ".md")
+    summary_path.write_text(_render_md(summary, args.out), encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+    print(f"\nMarkdown summary: {summary_path}", file=sys.stderr)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return asyncio.run(_main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_spike_d_tier_b_parity.py
+++ b/tests/test_spike_d_tier_b_parity.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Smoke tests for ``scripts/spikes/spike_d_tier_b_parity.py``.
+
+Scope: pure-function diff + summary layer, manifest validation,
+backend env toggling, per-case routing to the correct tool function,
+and the ``qwen_agent_skipped`` behaviour for tools currently unwired
+to ``NEXUS_TIER_B_DISPATCHER``. The live-backend leg is NOT exercised
+— the dispatchers are patched.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPIKE_DIR = REPO_ROOT / "scripts" / "spikes"
+sys.path.insert(0, str(SPIKE_DIR))
+
+import spike_d_tier_b_parity as spike  # noqa: E402
+
+
+# ── Manifest validation ──────────────────────────────────────────────────────
+
+
+class TestLoadCases:
+    def test_missing_manifest_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            spike._load_cases(tmp_path / "nope.json")
+
+    def test_malformed_case_missing_tool_raises(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "m.json"
+        manifest.write_text(json.dumps([{"name": "x", "input": {}}]))
+        with pytest.raises(ValueError, match="unsupported / missing tool"):
+            spike._load_cases(manifest)
+
+    def test_malformed_case_missing_input_raises(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "m.json"
+        manifest.write_text(json.dumps([
+            {"name": "x", "tool": "nx_enrich_beads"}
+        ]))
+        with pytest.raises(ValueError, match="missing 'input' dict"):
+            spike._load_cases(manifest)
+
+    def test_non_array_manifest_raises(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "m.json"
+        manifest.write_text(json.dumps({"not": "a list"}))
+        with pytest.raises(ValueError, match="must be a JSON array"):
+            spike._load_cases(manifest)
+
+    def test_well_formed_manifest_loads(self, tmp_path: Path) -> None:
+        manifest = tmp_path / "m.json"
+        manifest.write_text(json.dumps([
+            {
+                "name": "c1",
+                "tool": "nx_enrich_beads",
+                "input": {"bead_description": "x"},
+            },
+        ]))
+        cases = spike._load_cases(manifest)
+        assert len(cases) == 1
+        assert cases[0]["name"] == "c1"
+
+
+# ── Diff math ────────────────────────────────────────────────────────────────
+
+
+class TestJaccard:
+    def test_identical_lists(self) -> None:
+        assert spike._jaccard(["a", "b"], ["b", "a"]) == 1.0
+
+    def test_partial_overlap(self) -> None:
+        # {a,b} ∩ {b,c} = {b}; union = {a,b,c}; 1/3.
+        assert spike._jaccard(["a", "b"], ["b", "c"]) == pytest.approx(1 / 3)
+
+    def test_disjoint(self) -> None:
+        assert spike._jaccard(["a"], ["b"]) == 0.0
+
+    def test_both_empty_vacuously_agrees(self) -> None:
+        assert spike._jaccard([], []) == 1.0
+
+    def test_dicts_canonicalised(self) -> None:
+        # Same content, different key order → still equal in the set.
+        a = [{"type": "merge", "id": 1}]
+        b = [{"id": 1, "type": "merge"}]
+        assert spike._jaccard(a, b) == 1.0
+
+
+class TestDiffPayloads:
+    def test_both_ok_full_agreement(self) -> None:
+        c = {"key_files": ["a", "b"], "test_commands": ["pytest"],
+             "constraints": [], "enriched_description": "x" * 50}
+        q = {"key_files": ["b", "a"], "test_commands": ["pytest"],
+             "constraints": [], "enriched_description": "y" * 50}
+        out = spike.diff_payloads("nx_enrich_beads", c, q)
+        assert out["both_ok"]
+        assert out["structural"]["key_files"] == 1.0
+        assert out["structural"]["test_commands"] == 1.0
+        assert out["prose"]["enriched_description"] is True
+
+    def test_one_side_none_marks_disagree(self) -> None:
+        out = spike.diff_payloads("nx_enrich_beads", None, {"x": 1})
+        assert not out["both_ok"]
+        assert out["structural"]["key_files"] == 0.0
+
+
+# ── Backend leg execution ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_claude_agent_leg_unsets_env_and_calls_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEXUS_TIER_B_DISPATCHER", "qwen_agent")  # stale
+    fake = AsyncMock(return_value={"enriched_description": "out",
+                                   "key_files": ["a.py"]})
+    # The claude_agent leg must clear the env so production code-path
+    # falls through to claude_dispatch.
+    seen_env: dict[str, str | None] = {}
+
+    async def _claude_dispatch(prompt, schema, timeout=600.0):
+        seen_env["v"] = os.environ.get("NEXUS_TIER_B_DISPATCHER")
+        return await fake(prompt, schema, timeout=timeout)
+
+    with patch("nexus.operators.dispatch.claude_dispatch", _claude_dispatch):
+        leg = await spike._run_one_leg(
+            "nx_enrich_beads",
+            {"bead_description": "a bead"},
+            "claude_agent",
+        )
+
+    assert seen_env["v"] is None  # env was popped for the claude leg
+    assert leg["payload"] == {"enriched_description": "out",
+                              "key_files": ["a.py"]}
+    assert leg["error"] is None
+    assert leg["elapsed_ms"] > 0
+
+
+@pytest.mark.asyncio
+async def test_qwen_agent_leg_sets_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
+    seen_env: dict[str, str | None] = {}
+
+    async def _qwen_dispatch(prompt, schema, **kwargs):
+        seen_env["v"] = os.environ.get("NEXUS_TIER_B_DISPATCHER")
+        return {"enriched_description": "qwen-out", "key_files": []}
+
+    with patch(
+        "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+        _qwen_dispatch,
+    ):
+        leg = await spike._run_one_leg(
+            "nx_enrich_beads",
+            {"bead_description": "a bead"},
+            "qwen_agent",
+        )
+
+    assert seen_env["v"] == "qwen_agent"
+    assert leg["payload"] == {"enriched_description": "qwen-out",
+                              "key_files": []}
+
+
+@pytest.mark.asyncio
+async def test_run_case_skips_qwen_for_unwired_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
+    fake_claude = AsyncMock(return_value={"summary": "s", "actions": []})
+    fake_qwen = AsyncMock(side_effect=AssertionError(
+        "qwen_agent must not run for nx_tidy until routing lands"
+    ))
+    with (
+        patch("nexus.operators.dispatch.claude_dispatch", fake_claude),
+        patch(
+            "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+            fake_qwen,
+        ),
+    ):
+        row = await spike._run_case(
+            {"name": "tidy-1", "tool": "nx_tidy",
+             "input": {"topic": "x", "collection": "knowledge"}},
+            ["claude_agent", "qwen_agent"],
+        )
+    assert row["qwen_agent_skipped"] is True
+    assert row["qwen_agent"] is None
+    assert row["claude_agent"]["payload"] == {"summary": "s", "actions": []}
+    fake_qwen.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_case_routes_enrich_beads_through_both_dispatchers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
+    fake_claude = AsyncMock(return_value={
+        "enriched_description": "c" * 40, "key_files": ["x.py"],
+        "test_commands": [], "constraints": [],
+    })
+    fake_qwen = AsyncMock(return_value={
+        "enriched_description": "q" * 40, "key_files": ["x.py"],
+        "test_commands": [], "constraints": [],
+    })
+    with (
+        patch("nexus.operators.dispatch.claude_dispatch", fake_claude),
+        patch(
+            "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+            fake_qwen,
+        ),
+    ):
+        row = await spike._run_case(
+            {"name": "e1", "tool": "nx_enrich_beads",
+             "input": {"bead_description": "fix the widget"}},
+            ["claude_agent", "qwen_agent"],
+        )
+    assert fake_claude.await_count == 1
+    assert fake_qwen.await_count == 1
+    # Bead description forwarded into the prompt (first positional arg).
+    claude_args, _ = fake_claude.call_args
+    assert "fix the widget" in claude_args[0]
+    qwen_args, _ = fake_qwen.call_args
+    assert "fix the widget" in qwen_args[0]
+    # Structural diff computed; identical key_files → 1.0 Jaccard.
+    assert row["diff"]["both_ok"] is True
+    assert row["diff"]["structural"]["key_files"] == 1.0
+
+
+# ── Aggregation ──────────────────────────────────────────────────────────────
+
+
+class TestSummarize:
+    def test_per_tool_aggregates(self) -> None:
+        records = [
+            {
+                "tool": "nx_enrich_beads",
+                "claude_agent": {"elapsed_ms": 1000.0, "error": None,
+                                 "tool_calls": None},
+                "qwen_agent": {"elapsed_ms": 500.0, "error": None,
+                               "tool_calls": 7},
+                "diff": {
+                    "both_ok": True,
+                    "structural": {"key_files": 1.0, "test_commands": 0.5,
+                                   "constraints": 1.0},
+                    "prose": {"enriched_description": True},
+                },
+            },
+            {
+                "tool": "nx_enrich_beads",
+                "claude_agent": {"elapsed_ms": 2000.0, "error": None,
+                                 "tool_calls": None},
+                "qwen_agent": {"elapsed_ms": 700.0, "error": None,
+                               "tool_calls": 12},
+                "diff": {
+                    "both_ok": True,
+                    "structural": {"key_files": 0.0, "test_commands": 0.5,
+                                   "constraints": 1.0},
+                    "prose": {"enriched_description": False},
+                },
+            },
+            {
+                "tool": "nx_tidy",
+                "claude_agent": {"elapsed_ms": 3000.0, "error": None,
+                                 "tool_calls": None},
+                "qwen_agent": None,
+                "qwen_agent_skipped": True,
+                "diff": {"both_ok": False, "structural": {}, "prose": {}},
+            },
+        ]
+        s = spike._summarize(records)
+        assert s["total"] == 3
+        # nx_enrich_beads aggregates.
+        eb = s["by_tool"]["nx_enrich_beads"]
+        assert eb["n"] == 2
+        assert eb["skipped_qwen_agent"] == 0
+        assert eb["claude_ok_rate"] == 1.0
+        assert eb["qwen_ok_rate"] == 1.0
+        assert eb["claude_median_ms"] == 1500.0
+        assert eb["qwen_median_ms"] == 600.0
+        assert eb["tool_calls_median"] == 9.5
+        assert eb["tool_calls_max"] == 12
+        # Mean Jaccard over key_files = (1.0 + 0.0) / 2 = 0.5.
+        assert eb["structural"]["key_files"]["mean_jaccard"] == 0.5
+        # Prose: 1 of 2 agree.
+        assert eb["prose"]["enriched_description"]["agree_rate"] == 0.5
+        # nx_tidy skipped on qwen leg.
+        td = s["by_tool"]["nx_tidy"]
+        assert td["skipped_qwen_agent"] == 1


### PR DESCRIPTION
## Summary

- Ships \`scripts/spikes/spike_d_tier_b_parity.py\` — tool-use dispatch parity bench, structural sibling to spike_c (PR #782 / #793).
- Three-axis metric: semantic length-ratio on prose fields, Jaccard on per-tool structural fields, qwen-leg tool-call count (from \`budget.tool_calls\` wired by #796).
- \`nx_enrich_beads\` runs full A/B; \`nx_tidy\` and \`nx_plan_audit\` are not yet wired to \`NEXUS_TIER_B_DISPATCHER\` — qwen leg is recorded as \`qwen_agent_skipped: true\` until the routing follow-on PR lands.

## Implementation notes

- **Per-tool input shapes** taken from \`src/nexus/mcp/core.py\`:
  - \`nx_enrich_beads\`: \`{bead_description, context?, timeout?}\`
  - \`nx_tidy\`: \`{topic, collection?, timeout?}\`
  - \`nx_plan_audit\`: \`{plan_json, context?, timeout?}\`
- **Backend toggling**: \`claude_agent\` leg pops \`NEXUS_TIER_B_DISPATCHER\`; \`qwen_agent\` leg sets it to \`qwen_agent\`. Tool is invoked via FastMCP \`.fn\` direct in-process call.
- **Structural field choice**:
  - \`nx_enrich_beads\`: \`key_files\`, \`test_commands\`, \`constraints\` (Jaccard on string lists)
  - \`nx_tidy\`: \`actions\` (Jaccard on JSON-serialised dicts, sorted keys)
  - \`nx_plan_audit\`: \`findings\` (Jaccard on JSON-serialised dicts)
- **Payload capture**: monkey-patches \`claude_dispatch\`, \`qwen_agent_dispatch\`, and \`_extract_oneshot_result\` to stash the parsed dict + qwen budget before the tool stringifies its return value. Keeps prompt/schema construction in production code (no harness-side duplication).
- **Skip behaviour**: \`QWEN_AGENT_UNWIRED = {nx_tidy, nx_plan_audit}\` short-circuits the qwen leg and records \`qwen_agent_skipped: true\`.

Script: 615 lines. Tests: 292 lines (17 tests).

## Test plan

- [x] \`pytest tests/test_spike_d_tier_b_parity.py\` — 17/17 pass
- [x] \`pytest tests/test_qwen_agent_dispatch.py tests/test_nx_enrich_beads_routing.py\` — 11/11 pass (no regressions)
- [x] \`pytest tests/test_spike_c_*.py\` — 17/17 pass

Coverage: manifest validation (5 tests), Jaccard math (5), diff payloads (2), backend env toggling (2), per-case routing + skip behaviour (2), aggregation (1).

## Out of scope

- Routing for \`nx_tidy\` / \`nx_plan_audit\` (follow-on PR).
- Semantic-equivalence LLM judge generalisation (\`judge_aspect_diffs.py\` from #793 will be generalised after this lands).
- Fixture corpus — operator-supplied via \`--cases\`.

Linked: #780, #790, #793, #796.