### PR TITLE
fix(qwen_agent_dispatch): wrap extensions list as {only: [...]} per qwen_oneshot schema

### DIFF
--- a/src/nexus/operators/qwen_agent_dispatch.py
+++ b/src/nexus/operators/qwen_agent_dispatch.py
@@ -220,7 +220,13 @@ async def qwen_agent_dispatch(
         "max_attempts": max_attempts,
     }
     if extensions is not None:
-        opts["extensions"] = extensions
+        # qwen_oneshot's ``opts.extensions`` is an object with
+        # ``enable`` / ``disable`` / ``only`` array fields — not a
+        # bare list. Treat the list arg as "only these extensions"
+        # (the most restrictive / predictable semantic for tier-B
+        # dispatch). If a future caller needs enable/disable
+        # subsets, widen the arg type at that point.
+        opts["extensions"] = {"only": list(extensions)}
 
     # Generous slack so the supervisor's own timeout fires first and
     # we get its structured error rather than a python-side cancel.

--- a/tests/test_qwen_agent_dispatch.py
+++ b/tests/test_qwen_agent_dispatch.py
@@ -212,7 +212,7 @@ class TestHappyPath:
         assert session.last_args["name"] == "qwen_oneshot"
         assert args["task"] == "what is the answer"
         assert args["opts"]["json_schema"] == _SCHEMA
-        assert args["opts"]["extensions"] == ["nx"]
+        assert args["opts"]["extensions"] == {"only": ["nx"]}
         assert args["opts"]["timeout_ms"] == 10000
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

PR #796 shipped \`qwen_agent_dispatch\` but passed \`extensions\` to the supervisor as a bare array. The supervisor's \`qwen_oneshot\` tool schema defines \`opts.extensions\` as an object with optional \`enable\` / \`disable\` / \`only\` array fields, not as a bare list. Runtime calls failed with:

\`\`\`
MCP error -32602: Input validation error: Invalid arguments for tool qwen_oneshot:
  path: ["opts", "extensions"]
  expected: "object"
  received: "array"
\`\`\`

## Fix

\`qwen_agent_dispatch\` now wraps the list as \`{"only": [...]}\` — the most restrictive / predictable semantic for tier-B dispatch where the caller knows the exact extension loadout they need.

## Discovery

Found when running spike_d (#797) end-to-end against the qwen-agent-server with the \`nx\` Qwen Code extension installed. Claude leg succeeded fully; qwen leg failed with the validation error above. Surfaced now (and not in #796) because the unit tests asserted the bare-array shape rather than checking against the supervisor's actual zod schema.

If a future caller needs enable/disable subsets, widen the arg type at that point.

## Test plan

- [x] Updated \`test_qwen_agent_dispatch::test_extensions_forwarded\` (or equivalent) to assert the \`{"only": [...]}\` wrap.
- [x] \`test_qwen_agent_dispatch.py\` + \`test_nx_enrich_beads_routing.py\` — 11/11 pass.

## Linked

- #796 (introduced the bug)
- #797 (discovered the bug via end-to-end run)
- qwen-coprocessor-stack#1 (companion pino-to-stderr fix needed alongside this one)