### PR TITLE
feat(nx_enrich_beads): tighten prompt + raise qwen tool-call budget (spike_d follow-on)

### DIFF
--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -3969,6 +3969,18 @@ async def nx_enrich_beads(
     )
     if context:
         prompt += f"\n\nAdditional context:\n{context}"
+    # Schema-conformance directive (spike_d follow-on). Tier-B qwen
+    # reliably emits "Now I have..." narrative at finalization in
+    # tool-use loops instead of json_schema output; an explicit
+    # "JSON only" trailer fixes that. Applied to both legs — claude
+    # is tolerant of the looser prompt but the tighter directive is
+    # a no-op there and guards against future qwen-flavored
+    # regressions on the claude path.
+    prompt += (
+        "\n\nRespond with ONLY a JSON object conforming to the schema "
+        "above. No prose, no commentary, no prefix, no markdown fences. "
+        "Begin your response with `{` and end with `}`."
+    )
 
     # Tier-B dispatcher selection (RDR follow-on to operator-level qwen
     # offload). Default ``claude`` preserves prior behavior; setting
@@ -3984,7 +3996,12 @@ async def nx_enrich_beads(
             schema,
             timeout=timeout,
             extensions=["nx"],
-            max_tool_calls=20,
+            # spike_d bench (3 cases) observed qwen self-terminating at
+            # 14/17/19 tool calls; the prior cap of 20 was aborting every
+            # exploration at exactly 21 (cap+1). 50 = 2.5× the max
+            # observed, giving headroom for harder cases without being
+            # unbounded.
+            max_tool_calls=50,
             operator_name="nx_enrich_beads",
         )
     else:

--- a/tests/test_nx_enrich_beads_routing.py
+++ b/tests/test_nx_enrich_beads_routing.py
@@ -62,7 +62,7 @@ async def test_qwen_agent_env_routes_to_qwen_agent(
     _, kwargs = fake_qwen.call_args
     assert kwargs.get("extensions") == ["nx"]
     assert kwargs.get("operator_name") == "nx_enrich_beads"
-    assert kwargs.get("max_tool_calls") == 20
+    assert kwargs.get("max_tool_calls") == 50
     # Prompt forwarded positionally; schema is the second positional arg.
     args, _ = fake_qwen.call_args
     assert "parsing widgets" in args[0]


### PR DESCRIPTION
## Summary

Two coupled fixes for the tier-B qwen offload path, both surfaced by spike_d bench (#797) against `nx_enrich_beads`:

- Raise `max_tool_calls` from 20 → 50 in the `nx_enrich_beads` qwen_agent dispatch branch (per-call-site; dispatcher default unchanged).
- Append an explicit "JSON only" schema-conformance directive to the `nx_enrich_beads` prompt, applied to BOTH legs (claude + qwen).

## Bench evidence (spike_d, 3 cases, qwen leg)

| Case | Tool calls | Output |
|------|------------|--------|
| 1    | 19         | prose ("Now I have...") → fail |
| 2    | 14         | prose → fail |
| 3    | 17         | schema-valid, 8 key files extracted → ok |

- Max self-termination = 19 tool calls. The prior cap of 20 was aborting every exploration at exactly 21 (cap+1). New value 50 = 2.5× max observed.
- Case 3 proves qwen *can* emit conforming structured output; cases 1/2 show it doesn't reliably without an explicit "JSON only" directive (same failure mode as scholarly-paper-v2).

## Test plan

- [x] `tests/test_nx_enrich_beads_routing.py` budget assertion bumped 20 → 50 — 2/2 pass
- [x] `tests/test_qwen_agent_dispatch.py` — 9/9 pass (unchanged)
- [x] Adjacent sweep `tests/test_spike_d_tier_b_parity.py` + `tests/test_mcp_package.py` — 28/28 pass

## Out of scope

- `nx_tidy` / `nx_plan_audit` routing — still claude-only; separate PR.
- spike_d bench harness changes — not touched.
- Semantic-equivalence judge generalization for tier-B — separate.

## Linked

- #796 (introduced the call site)
- #797 (bench harness that produced the evidence)
- #798 (wire-shape fix from the same bench session)