### PR TITLE
fix(rdr-111): api.out atomicity + embed_from fail-loud (nexus-qmrr nexus-zm2n)

### DIFF
--- a/src/nexus/tuplespace/api.py
+++ b/src/nexus/tuplespace/api.py
@@ -204,7 +204,18 @@ def _resolve_embed_text(
     if embed_from == "content":
         return content
     if embed_from == "match_text":
-        return match_text or content
+        # nexus-zm2n: fail loud. An empty/None match_text on an
+        # embed_from=match_text schema is a caller misconfiguration; silently
+        # substituting content would index against the wrong text and degrade
+        # semantic recall without any visible signal
+        # (feedback_no_silent_fallbacks_for_correctness.md).
+        if not match_text:
+            raise SubspaceSchemaError(
+                "embed_from='match_text' requires a non-empty match_text argument; "
+                "got empty value. Either pass match_text=<query> or change the "
+                "subspace schema's embed_from to 'content'."
+            )
+        return match_text
     if embed_from.startswith("dimensions:"):
         key = embed_from[len("dimensions:"):]
         return str(dimensions[key])
@@ -378,7 +389,16 @@ def out(
 
     mt = match_text or ""
     tid = _tuple_id(subspace, content, dimensions, mt)
-    embed_text = _resolve_embed_text(schema.embed_from, content, match_text, dimensions)
+    try:
+        embed_text = _resolve_embed_text(
+            schema.embed_from, content, match_text, dimensions
+        )
+    except SubspaceSchemaError as exc:
+        # nexus-zm2n: re-raise with subspace + schema context so the caller
+        # can identify which write was misconfigured.
+        raise SubspaceSchemaError(
+            f"subspace={subspace!r} (schema={schema.name!r}): {exc}"
+        ) from exc
     dims_json = json.dumps(dimensions, sort_keys=True)
     now = time.time()
     # Resolve effective TTL: explicit ttl_seconds wins; otherwise fall back
@@ -392,17 +412,16 @@ def out(
             effective_ttl = float(ret)
     expires_at = now + effective_ttl if effective_ttl is not None else None
 
-    # Upsert into SQLite (INSERT OR IGNORE for idempotency — same tid = same content)
-    conn.execute(
-        "INSERT OR IGNORE INTO tuples "
-        "(id, subspace, template_name, content, dimensions_json, embed_text, "
-        " match_text, created_at, expires_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        (tid, subspace, schema.name, content, dims_json, embed_text, mt or None, now, expires_at),
-    )
-    conn.commit()
-
-    # Upsert into ChromaDB (idempotent by design)
+    # Two-store atomicity (nexus-qmrr): write Chroma FIRST, then commit
+    # SQLite.  Invariant: a SQLite row's existence implies the Chroma
+    # record exists.  If the Chroma upsert fails (or this process is
+    # killed mid-flight, e.g. the cockpit-hook 5s SIGTERM), no SQLite row
+    # is committed.  Worst case is an orphan Chroma record from a prior
+    # partial write of the same tuple_id; Chroma upserts are idempotent
+    # so it is reclaimed on retry, and the retention sweeper picks up any
+    # stragglers.  This ordering mirrors (asymmetrically) the retention
+    # sweeper (nexus-kk9h) which deletes Chroma first then SQLite, so a
+    # crash there leaves recoverable SQLite orphans.
     meta: dict[str, Any] = {"subspace": subspace}
     for k, v in dimensions.items():
         # ChromaDB metadata values must be str/int/float/bool
@@ -415,6 +434,16 @@ def out(
         payload=embed_text,
         metadata=meta,
     )
+
+    # SQLite second.  INSERT OR IGNORE for idempotency (same tid = same content).
+    conn.execute(
+        "INSERT OR IGNORE INTO tuples "
+        "(id, subspace, template_name, content, dimensions_json, embed_text, "
+        " match_text, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (tid, subspace, schema.name, content, dims_json, embed_text, mt or None, now, expires_at),
+    )
+    conn.commit()
 
     _log.debug("tuplespace_out_complete", subspace=subspace, tuple_id=tid)
     return tid

--- a/tests/tuplespace/test_api_atomicity.py
+++ b/tests/tuplespace/test_api_atomicity.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Atomicity tests for api.out — nexus-qmrr (RDR-111).
+
+Invariant: SQLite presence implies Chroma presence. If the Chroma upsert
+fails, no SQLite row exists for that tuple_id. Achieved by ordering the
+Chroma write before the SQLite commit (mirrors the retention sweeper's
+asymmetric ordering, which deletes from Chroma first so a crash leaves
+recoverable SQLite orphans).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import chromadb
+import pytest
+
+
+_TASKS_YAML = """
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status:     { type: enum, values: [open, in_progress, done, cancelled], required: true }
+  priority:   { type: enum, values: [P0, P1, P2, P3, P4], required: true }
+  created_by: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+  default_lease_seconds: 60
+read:
+  default_floor: 0.20
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+
+@pytest.fixture
+def builtin_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "tasks.yml").write_text(_TASKS_YAML)
+    return d
+
+
+@pytest.fixture
+def registry(builtin_dir: Path):
+    from nexus.tuplespace.registry import Registry
+    return Registry.load(builtin_dir)
+
+
+@pytest.fixture
+def db_conn(tmp_path: Path) -> sqlite3.Connection:
+    from nexus.tuplespace.store import open_tuples_db
+    conn = open_tuples_db(tmp_path / "tuples.db")
+    conn.row_factory = sqlite3.Row
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def chroma_client():
+    client = chromadb.EphemeralClient()
+    yield client
+    for coll in client.list_collections():
+        client.delete_collection(coll.name)
+
+
+@pytest.fixture
+def index(registry, chroma_client):
+    from nexus.tuplespace.index import TupleIndex
+    return TupleIndex.from_registry(registry, chroma_client)
+
+
+def _valid_task_dims() -> dict[str, Any]:
+    return {"status": "open", "priority": "P1", "created_by": "agent-X"}
+
+
+class TestOutAtomicity:
+    """nexus-qmrr: api.out must not commit SQLite if Chroma write fails."""
+
+    def test_happy_path_writes_both_stores(self, db_conn, index, registry):
+        """Sanity: successful out() leaves both SQLite row and Chroma record."""
+        from nexus.tuplespace.api import out
+
+        tid = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus",
+            content="hello",
+            dimensions=_valid_task_dims(),
+        )
+
+        row = db_conn.execute(
+            "SELECT id FROM tuples WHERE id = ?", (tid,)
+        ).fetchone()
+        assert row is not None, "SQLite row must exist on success"
+
+        chroma_results = index.read(
+            template_name="tasks/<project>",
+            subspace="tasks/nexus",
+            query="hello",
+            n_results=5,
+        )
+        assert any(r["id"] == tid for r in chroma_results), \
+            "Chroma record must exist on success"
+
+    def test_chroma_failure_leaves_no_sqlite_row(
+        self, db_conn, index, registry, monkeypatch
+    ):
+        """If Chroma upsert raises, SQLite must have no row for that tuple_id."""
+        from nexus.tuplespace.api import out
+
+        def boom(**_kwargs):
+            raise RuntimeError("simulated chroma outage")
+
+        monkeypatch.setattr(index, "out", boom)
+
+        with pytest.raises(RuntimeError, match="simulated chroma outage"):
+            out(
+                conn=db_conn, index=index, registry=registry,
+                subspace="tasks/nexus",
+                content="failed write",
+                dimensions=_valid_task_dims(),
+            )
+
+        # The whole point of nexus-qmrr: SQLite must not have the row.
+        rows = db_conn.execute(
+            "SELECT id FROM tuples WHERE content = ?", ("failed write",)
+        ).fetchall()
+        assert rows == [], (
+            "Two-store invariant violated: SQLite row exists but Chroma "
+            "write failed. nexus-qmrr regression."
+        )

--- a/tests/tuplespace/test_api_embed_from.py
+++ b/tests/tuplespace/test_api_embed_from.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+"""embed_from fail-loud tests — nexus-zm2n (RDR-111).
+
+When a subspace declares ``embed_from: match_text``, callers MUST supply
+a non-empty ``match_text``. Silently falling back to ``content`` violates
+the project rule "no silent fallbacks for data-correctness problems"
+(feedback_no_silent_fallbacks_for_correctness.md): downstream semantic
+retrieval would index against the wrong text and silently degrade recall.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import chromadb
+import pytest
+
+
+_PLANS_YAML = """
+name: plans
+tier: project
+content_type: text
+embed_from: match_text
+dimensions:
+  query_hash: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+  default_lease_seconds: 60
+read:
+  default_floor: 0.20
+  default_n: 3
+tiers: [project]
+retention_seconds: 86400
+"""
+
+_TASKS_YAML = """
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status:     { type: enum, values: [open, in_progress, done, cancelled], required: true }
+  priority:   { type: enum, values: [P0, P1, P2, P3, P4], required: true }
+  created_by: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+  default_lease_seconds: 60
+read:
+  default_floor: 0.20
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+
+@pytest.fixture
+def builtin_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "builtin"
+    d.mkdir()
+    (d / "plans.yml").write_text(_PLANS_YAML)
+    (d / "tasks.yml").write_text(_TASKS_YAML)
+    return d
+
+
+@pytest.fixture
+def registry(builtin_dir: Path):
+    from nexus.tuplespace.registry import Registry
+    return Registry.load(builtin_dir)
+
+
+@pytest.fixture
+def db_conn(tmp_path: Path) -> sqlite3.Connection:
+    from nexus.tuplespace.store import open_tuples_db
+    conn = open_tuples_db(tmp_path / "tuples.db")
+    conn.row_factory = sqlite3.Row
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def chroma_client():
+    client = chromadb.EphemeralClient()
+    yield client
+    for coll in client.list_collections():
+        client.delete_collection(coll.name)
+
+
+@pytest.fixture
+def index(registry, chroma_client):
+    from nexus.tuplespace.index import TupleIndex
+    return TupleIndex.from_registry(registry, chroma_client)
+
+
+class TestEmbedFromFailLoud:
+    """nexus-zm2n: empty match_text on embed_from=match_text must raise."""
+
+    def test_empty_match_text_raises_on_match_text_schema(
+        self, db_conn, index, registry
+    ):
+        """match_text=None when schema says embed_from=match_text -> raise."""
+        from nexus.tuplespace.api import SubspaceSchemaError, out
+
+        with pytest.raises(SubspaceSchemaError) as excinfo:
+            out(
+                conn=db_conn, index=index, registry=registry,
+                subspace="plans",
+                content="plan body content",
+                dimensions={"query_hash": "abc123"},
+                match_text=None,
+            )
+
+        msg = str(excinfo.value)
+        assert "plans" in msg, "error must name the subspace"
+        assert "match_text" in msg, "error must name the misconfigured field"
+
+    def test_blank_match_text_raises_on_match_text_schema(
+        self, db_conn, index, registry
+    ):
+        """Empty-string match_text is just as bad as None."""
+        from nexus.tuplespace.api import SubspaceSchemaError, out
+
+        with pytest.raises(SubspaceSchemaError, match="match_text"):
+            out(
+                conn=db_conn, index=index, registry=registry,
+                subspace="plans",
+                content="plan body content",
+                dimensions={"query_hash": "abc123"},
+                match_text="",
+            )
+
+    def test_nonempty_match_text_succeeds_on_match_text_schema(
+        self, db_conn, index, registry
+    ):
+        """Happy path: a real match_text embeds normally."""
+        from nexus.tuplespace.api import out
+
+        tid = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="plans",
+            content="plan body",
+            dimensions={"query_hash": "abc123"},
+            match_text="search query for semantic retrieval",
+        )
+        assert isinstance(tid, str)
+
+    def test_embed_from_content_does_not_require_match_text(
+        self, db_conn, index, registry
+    ):
+        """embed_from=content schemas never look at match_text — must still work."""
+        from nexus.tuplespace.api import out
+
+        tid = out(
+            conn=db_conn, index=index, registry=registry,
+            subspace="tasks/nexus",
+            content="some task body",
+            dimensions={
+                "status": "open",
+                "priority": "P1",
+                "created_by": "agent-X",
+            },
+            match_text=None,
+        )
+        assert isinstance(tid, str)


### PR DESCRIPTION
## Summary

Two bundled P1 RDR-111 correctness fixes in `src/nexus/tuplespace/api.py`. Parent epic: nexus-hp9f.

### nexus-qmrr: two-store atomicity in `api.out`

Previously `api.out` committed the SQLite row first, then upserted the Chroma record. A SIGTERM between the two (e.g. the cockpit-hook 5s timeout) or any Chroma exception left a SQLite row with no embedding, invisible to `read`/`take`.

Fix: reorder so the Chroma upsert runs first, then the SQLite commit. New invariant: **SQLite presence implies Chroma presence**. If Chroma fails, no SQLite row is committed; worst case is an orphan Chroma record (idempotent on retry, swept by retention).

This mirrors the retention sweeper's (nexus-kk9h) asymmetric ordering: sweeper deletes Chroma first then SQLite (crash leaves recoverable SQLite orphans); `out` writes Chroma first then SQLite (crash leaves recoverable Chroma orphans). The invariant is documented inline with an nexus-qmrr reference.

### nexus-zm2n: `embed_from=match_text` fail-loud

`_resolve_embed_text` previously silently substituted `content` when `embed_from='match_text'` but the caller passed an empty/None `match_text`. This violates `feedback_no_silent_fallbacks_for_correctness.md`: downstream semantic retrieval would index against the wrong text and silently degrade recall.

Fix: raise `SubspaceSchemaError` (existing exception class). The wrapping `out()` catches and re-raises with subspace + schema name in the message.

## Test plan

- [x] `tests/tuplespace/test_api_atomicity.py` — new file. Crash injection (monkeypatched `index.out` raises) asserts no SQLite row; sanity test confirms happy path writes both stores.
- [x] `tests/tuplespace/test_api_embed_from.py` — new file. Asserts raise on `match_text=None` and `match_text=''` for `embed_from=match_text` schemas; confirms non-empty `match_text` and `embed_from=content` schemas still work; error message names the subspace and the misconfigured field.
- [x] `uv run pytest tests/tuplespace/ tests/cockpit/` — 193 passed, 1 deselected. The deselected test (`test_emit_routes_through_daemon_when_reachable`) fails on plain `develop` too and is unrelated to this PR.

## Closes

Closes nexus-qmrr
Closes nexus-zm2n
Refs nexus-hp9f