### PR TITLE
fix(rdr-112): collapse daemon registry dual source-of-truth (nexus-me9y)

### DIFF
--- a/src/nexus/daemon/subspace_registry.py
+++ b/src/nexus/daemon/subspace_registry.py
@@ -1,11 +1,20 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Daemon-side subspace registry with SQLite persistence (RDR-112 P1.5 nexus-x98k).
 
-``RegistryStore`` accepts third-party subspace YAML schemas via the
-``subspace_add`` admin RPC, validates them using
-``nexus.tuplespace.registry.SubspaceSchema``, enforces reserved-prefix rules,
-and persists accepted schemas to the ``subspace_registry`` table in
-``tuples.db``.
+``RegistryStore`` is the single source of truth for subspace schemas inside a
+running daemon. Two structurally distinct entry points populate it:
+
+* ``seed_from_builtin_dir(path)`` -- called once at daemon startup, before any
+  socket binds. Idempotently upserts every YAML under
+  ``nx/tuplespace/builtin/`` (and its conventional subdirs). Bypasses the
+  reserved-prefix gate because the builtin subspaces *define* the reserved
+  prefixes.
+* ``add(yaml_str)`` -- third-party admission via the ``subspace_add`` admin
+  RPC. Enforces the reserved-prefix gate so external callers cannot mint a
+  schema that shadows a builtin namespace.
+
+The split is structural (two methods) not just a runtime flag, so the
+distinction shows up at the call site (RDR-112 nexus-me9y).
 
 Design decisions:
 - Persistence: ``tuples.db`` (same SQLite file as tuple stores) to keep the
@@ -13,18 +22,13 @@ Design decisions:
   future phases.
 - Validation: reuses the JSON Schema validator and parameter-pattern regexes
   from ``nexus.tuplespace.registry`` (``_VALIDATOR``, ``_ANGLE_TOKEN``,
-  ``_PARAM_PATTERN``) so the daemon and the loader stay in lockstep. We do
-  not call ``_load_one`` directly because that function takes a ``Path``;
-  the registry admin RPC accepts a YAML string in-memory, so the parse
-  pipeline is mirrored here (yaml.safe_load + the same checks). When the
-  loader gains a new rule, mirror it here.
+  ``_PARAM_PATTERN``) so the daemon and the loader stay in lockstep.
 - Digest: sha256 over ``json.dumps({name: schema_digest}, sort_keys=True,
   separators=(",", ":"))`` where ``schema_digest`` is sha256 of the raw
-  YAML bytes. ``sort_keys=True`` gives a canonical key ordering;
-  ``separators=(",", ":")`` removes whitespace variability. The overall
-  digest is cached and invalidated on every ``add()``.
-- Reserved prefixes: ``tuples/`` (RDR-110 namespace) and ``daemon/``
-  (RDR-112 lifecycle) are rejected.
+  YAML bytes. The overall digest is cached and invalidated on every write.
+- Reserved prefixes: see ``_RESERVED_PREFIXES`` below. Every canonical
+  builtin namespace plus the daemon lifecycle prefix is reserved. Builtins
+  enter via ``seed_from_builtin_dir``; third parties cannot mint into them.
 """
 from __future__ import annotations
 
@@ -43,18 +47,55 @@ from nexus.tuplespace.registry import (
     _ANGLE_TOKEN,
     _PARAM_PATTERN,
     _VALIDATOR,
+    Registry,
     SubspaceSchema,
 )
 
 _log = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
-# Reserved name prefixes (RDR-112 §8, RDR-110 §Subspace registry)
+# Reserved name prefixes (RDR-112 §8, RDR-110 §Subspace registry, nexus-me9y)
 # ---------------------------------------------------------------------------
 
-#: Subspace name prefixes that are reserved for the daemon's own internal
-#: event channels. Third-party YAML schemas must not use these prefixes.
-_RESERVED_PREFIXES: tuple[str, ...] = ("tuples/", "daemon/")
+#: Subspace name prefixes that are reserved for builtin / daemon namespaces.
+#: Third-party YAML schemas submitted via ``subspace_add`` must not use any of
+#: these prefixes; builtin schemas under ``nx/tuplespace/builtin/`` enter the
+#: store via ``seed_from_builtin_dir`` which deliberately bypasses this gate.
+#:
+#: Canonical builtin namespaces (RDR-110, RDR-111, RDR-112 nexus-0xaq):
+#:   tasks/           -- RDR-110 project tasks
+#:   mailbox/         -- RDR-110 agent mailboxes
+#:   locks/           -- RDR-110 mutual-exclusion resources
+#:   events/          -- RDR-110 generic event channels
+#:   barriers/        -- RDR-110 synchronisation barriers
+#:   hook_events/     -- RDR-111 Claude Code hook event channels
+#:   layout_state/    -- RDR-111 cockpit layout state
+#:   connection_manifest/ -- RDR-111 cockpit connection state
+#:   bindings/        -- RDR-112 nexus-0xaq binding profiles
+#:   derived/         -- RDR-112 nexus-0xaq derived event channel
+#: Daemon internals:
+#:   tuples/          -- RDR-110 namespace (raw tuple storage)
+#:   daemon/          -- RDR-112 daemon lifecycle channel
+_RESERVED_PREFIXES: tuple[str, ...] = (
+    "tasks/",
+    "mailbox/",
+    "locks/",
+    "events/",
+    "barriers/",
+    "hook_events/",
+    "layout_state/",
+    "connection_manifest/",
+    "bindings/",
+    "derived/",
+    "tuples/",
+    "daemon/",
+)
+
+
+#: Subdirectories of the builtin dir that ``seed_from_builtin_dir`` will
+#: walk in addition to the top level. Matches the ``subdirs`` arg used by
+#: existing client-side ``Registry.load`` callers (``hooks/``, ``bindings/``).
+_BUILTIN_SUBDIRS: tuple[str, ...] = ("hooks", "bindings")
 
 # ---------------------------------------------------------------------------
 # DDL (also in migrations.py via migrate_subspace_registry_table)
@@ -80,7 +121,12 @@ class SubspaceValidationError(Exception):
 
 
 class ReservedPrefixError(Exception):
-    """Subspace name starts with a reserved prefix (``tuples/`` or ``daemon/``)."""
+    """Subspace name starts with a reserved prefix.
+
+    Raised by ``RegistryStore.add`` (third-party path) when the schema's
+    name matches one of the prefixes in ``_RESERVED_PREFIXES``. Builtin
+    schemas use the ``seed_from_builtin_dir`` path and are exempt.
+    """
 
 
 class DuplicateSubspaceError(Exception):
@@ -162,11 +208,18 @@ def _parse_and_validate(yaml_str: str) -> SubspaceSchema:
 
 
 class RegistryStore:
-    """Persists third-party subspace schemas to ``tuples.db``.
+    """Persists subspace schemas to ``tuples.db``.
+
+    Two entry points:
+      * ``seed_from_builtin_dir`` -- idempotent bulk-upsert from
+        ``nx/tuplespace/builtin/``. Bypasses reserved-prefix gate.
+        Called at daemon startup before any socket binds.
+      * ``add`` -- third-party admission via ``subspace_add`` admin RPC.
+        Enforces reserved-prefix gate; raises on duplicate.
 
     Constructor injection: pass an explicit ``tuples_db_path``. The DDL is
     applied at construction so the table is always present before the first
-    ``add()`` call.
+    write.
 
     Thread-safety: each method opens a short-lived connection. The daemon
     invokes ``add()`` via ``run_in_executor`` (one call at a time), so no
@@ -198,13 +251,15 @@ class RegistryStore:
         return conn
 
     # ------------------------------------------------------------------
-    # Public API
+    # Public API -- third-party admission
     # ------------------------------------------------------------------
 
     def add(self, yaml_str: str) -> dict[str, str]:
-        """Validate and persist a subspace schema from a YAML string.
+        """Validate and persist a third-party subspace schema.
 
-        The parameter name avoids shadowing the module-level ``yaml`` import.
+        Enforces the reserved-prefix gate: names beginning with any prefix
+        in ``_RESERVED_PREFIXES`` are rejected. Builtin schemas must enter
+        via ``seed_from_builtin_dir`` instead.
 
         Args:
             yaml_str: Raw YAML text for the subspace schema.
@@ -220,12 +275,15 @@ class RegistryStore:
         schema = _parse_and_validate(yaml_str)
         name = schema.name
 
-        # Reserved-prefix check
+        # Reserved-prefix check (third-party gate; seed path is exempt)
         for prefix in _RESERVED_PREFIXES:
             if name.startswith(prefix):
                 raise ReservedPrefixError(
-                    f"subspace name {name!r} starts with reserved prefix {prefix!r}; "
-                    "reserved prefixes: tuples/ (RDR-110), daemon/ (RDR-112)"
+                    f"subspace name {name!r} starts with reserved prefix "
+                    f"{prefix!r}; reserved prefixes are managed by the "
+                    f"builtin seed path (nx/tuplespace/builtin/) and "
+                    f"cannot be registered via subspace_add. "
+                    f"All reserved prefixes: {', '.join(_RESERVED_PREFIXES)}"
                 )
 
         yaml_bytes = yaml_str.encode("utf-8")
@@ -256,14 +314,128 @@ class RegistryStore:
             op="subspace-added",
             name=name,
             digest=s_digest,
+            source="third_party",
         )
         return {"name": name, "digest": s_digest}
+
+    # ------------------------------------------------------------------
+    # Public API -- builtin seed
+    # ------------------------------------------------------------------
+
+    def seed_from_builtin_dir(self, builtin_dir: Path) -> int:
+        """Idempotently upsert every builtin subspace YAML into the store.
+
+        Walks *builtin_dir* and its conventional subdirs (``hooks/``,
+        ``bindings/``) via ``Registry.load`` so YAML parsing and JSON
+        Schema validation match the loader exactly. Bypasses the
+        reserved-prefix gate enforced by ``add``: builtins *define* the
+        reserved prefixes.
+
+        Idempotency contract:
+          * If a row for ``name`` does not exist, INSERT it.
+          * If a row for ``name`` exists and its ``schema_digest`` matches
+            the on-disk YAML digest, no write occurs.
+          * If a row exists with a stale digest (YAML was bumped), the
+            row is UPDATEd with the new yaml/digest/timestamp.
+
+        Args:
+            builtin_dir: Path to ``nx/tuplespace/builtin/`` (or test
+                equivalent).
+
+        Returns:
+            Number of rows written or updated (0 means everything was
+            already current).
+
+        Raises:
+            FileNotFoundError: builtin_dir does not exist.
+            SubspaceValidationError: a YAML file under builtin_dir failed
+                parse or schema validation (re-raised from the loader).
+        """
+        if not builtin_dir.is_dir():
+            raise FileNotFoundError(
+                f"builtin dir does not exist or is not a directory: {builtin_dir}"
+            )
+
+        # Reuse the client-side loader so parsing stays in lockstep.
+        registry = Registry.load(builtin_dir, subdirs=_BUILTIN_SUBDIRS)
+        schemas = registry.schemas()
+
+        now = time.time()
+        written = 0
+        conn = self._connect()
+        try:
+            for schema in schemas:
+                if schema.source_path is None:  # pragma: no cover -- defensive
+                    continue
+                yaml_bytes = schema.source_path.read_bytes()
+                s_digest = _schema_digest(yaml_bytes)
+                yaml_str = yaml_bytes.decode("utf-8")
+
+                row = conn.execute(
+                    "SELECT schema_digest FROM subspace_registry WHERE name = ?",
+                    (schema.name,),
+                ).fetchone()
+
+                if row is None:
+                    conn.execute(
+                        "INSERT INTO subspace_registry "
+                        "(name, yaml, schema_digest, added_at) "
+                        "VALUES (?, ?, ?, ?)",
+                        (schema.name, yaml_str, s_digest, now),
+                    )
+                    written += 1
+                    _log.info(
+                        "daemon/t2/lifecycle",
+                        op="subspace-seeded",
+                        name=schema.name,
+                        digest=s_digest,
+                        source="builtin",
+                        action="insert",
+                    )
+                elif row[0] != s_digest:
+                    conn.execute(
+                        "UPDATE subspace_registry "
+                        "SET yaml = ?, schema_digest = ?, added_at = ? "
+                        "WHERE name = ?",
+                        (yaml_str, s_digest, now, schema.name),
+                    )
+                    written += 1
+                    _log.info(
+                        "daemon/t2/lifecycle",
+                        op="subspace-seeded",
+                        name=schema.name,
+                        digest=s_digest,
+                        source="builtin",
+                        action="update",
+                        prior_digest=row[0],
+                    )
+                # else: row exists with current digest -- no-op
+            conn.commit()
+        finally:
+            conn.close()
+
+        if written:
+            self._cached_digest = None
+
+        _log.info(
+            "daemon/t2/lifecycle",
+            op="seed-complete",
+            builtin_dir=str(builtin_dir),
+            schemas_total=len(schemas),
+            schemas_written=written,
+        )
+        return written
+
+    # ------------------------------------------------------------------
+    # Public API -- digest
+    # ------------------------------------------------------------------
 
     def digest(self) -> str:
         """Return a sha256 digest over the sorted ``{name: schema_digest}`` map.
 
-        Cached between ``add()`` calls. Invalidated on every successful add.
-        Empty registry returns the sha256 of an empty JSON object (``{}``).
+        Cached between writes. Invalidated on every successful add or
+        seed-write. Empty registry returns the sha256 of an empty JSON
+        object (``{}``).
         """
         if self._cached_digest is not None:
             return self._cached_digest

--- a/src/nexus/daemon/t2_daemon.py
+++ b/src/nexus/daemon/t2_daemon.py
@@ -450,6 +450,7 @@ class T2Daemon:
         registry_store: Any = None,
         tuplespace_service: Any = None,
         enable_admin_ping: bool = False,
+        builtin_dir: Path | None = None,
     ) -> None:
         """Initialise the daemon.
 
@@ -524,6 +525,9 @@ class T2Daemon:
         # ``yaml`` import). A thin lambda bridges the two so the wire-level
         # kwarg name is stable for clients.
         self._registry_store = registry_store
+        # nexus-me9y: builtin-seed dir (None -> resolved lazily in start()
+        # from default_builtin_dir() when a registry_store is wired).
+        self._builtin_dir: Path | None = builtin_dir
         if registry_store is not None:
             def _subspace_add_handler(yaml: str) -> dict[str, str]:  # noqa: A006
                 # Add to the registry, then rewrite the discovery file so its
@@ -650,6 +654,41 @@ class T2Daemon:
             op="migration-applied",
             **{"from": from_ver, "to": to_ver},
         )
+
+        # nexus-me9y: seed the registry from nx/tuplespace/builtin/ BEFORE
+        # sockets bind. Builtin schemas are the single source of truth for
+        # reserved-prefix namespaces (tasks/, mailbox/, hook_events/, ...);
+        # third-party subspace_add cannot mint into those prefixes. Seed
+        # is idempotent across restarts -- a YAML bump becomes an UPDATE,
+        # an unchanged YAML is a no-op.
+        if self._registry_store is not None:
+            from nexus.tuplespace.registry import default_builtin_dir  # noqa: PLC0415
+
+            seed_dir = self._builtin_dir if self._builtin_dir is not None else default_builtin_dir()
+            if seed_dir.is_dir():
+                try:
+                    written = self._registry_store.seed_from_builtin_dir(seed_dir)
+                    _log.info(
+                        "daemon/t2/lifecycle",
+                        op="builtin-seed",
+                        builtin_dir=str(seed_dir),
+                        rows_written=written,
+                    )
+                except Exception as exc:
+                    _log.error(
+                        "daemon/t2/lifecycle",
+                        op="builtin-seed-failed",
+                        builtin_dir=str(seed_dir),
+                        error=str(exc),
+                    )
+                    raise
+            else:
+                _log.warning(
+                    "daemon/t2/lifecycle",
+                    op="builtin-seed-skipped",
+                    reason="builtin_dir_missing",
+                    builtin_dir=str(seed_dir),
+                )
 
         uds_sock = self._bind_uds()
         tcp_sock = self._bind_tcp()

--- a/tests/daemon/test_registry_seeding.py
+++ b/tests/daemon/test_registry_seeding.py
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Daemon-startup builtin-seed tests -- RDR-112 nexus-me9y.
+
+Covers the ``RegistryStore.seed_from_builtin_dir`` path and its wiring
+into ``T2Daemon.start()``:
+
+  (a) Startup seed populates every builtin YAML under
+      nx/tuplespace/builtin/ (and its hooks/ + bindings/ subdirs).
+  (b) Re-seeding the same on-disk YAML is a no-op (idempotent).
+  (c) Bumping a YAML schema (different bytes) updates the stored row.
+  (d) Seed bypasses the reserved-prefix gate (builtins legitimately use
+      reserved namespaces).
+  (e) The daemon ``start()`` call seeds before sockets bind: clients
+      observe the seeded names on first handshake.
+"""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from nexus.daemon.subspace_registry import RegistryStore
+from nexus.daemon.t2_daemon import T2Daemon
+
+
+# ---------------------------------------------------------------------------
+# Minimal YAML bodies for synthetic builtin dirs
+# ---------------------------------------------------------------------------
+
+# A top-level builtin (reserved prefix: tasks/)
+_TASKS_YAML_V1 = """\
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status:   { type: enum, values: [open, done], required: true }
+  priority: { type: enum, values: [P0, P1, P2], required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.50
+  margin: 0.05
+read:
+  default_floor: 0.40
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+_TASKS_YAML_V2_BUMPED = """\
+name: tasks/<project>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  status:   { type: enum, values: [open, done], required: true }
+  priority: { type: enum, values: [P0, P1, P2], required: true }
+  bumped:   { type: bool, required: false }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.55
+  margin: 0.05
+read:
+  default_floor: 0.40
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+# A hooks/ subdir builtin
+_HOOK_EVENTS_YAML = """\
+name: hook_events/tool_call_completed
+tier: project
+content_type: json
+embed_from: match_text
+dimensions:
+  actor:   { type: string, required: true }
+  session: { type: string, required: true }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.50
+  margin: 0.05
+read:
+  default_floor: 0.40
+  default_n: 10
+tiers: [project]
+retention_seconds: 604800
+"""
+
+# A bindings/ subdir builtin
+_BINDINGS_YAML = """\
+name: bindings/<profile>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  profile:    { type: string, required: true }
+  enabled:    { type: bool, required: true }
+  created_by: { type: string, required: true }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.50
+  margin: 0.05
+read:
+  default_floor: 0.30
+  default_n: 50
+tiers: [project]
+retention_seconds: 0
+"""
+
+
+def _make_builtin_dir(root: Path) -> Path:
+    """Build a synthetic nx/tuplespace/builtin/ tree under *root*."""
+    builtin = root / "builtin"
+    builtin.mkdir(parents=True)
+    (builtin / "tasks.yml").write_text(_TASKS_YAML_V1)
+
+    hooks = builtin / "hooks"
+    hooks.mkdir()
+    (hooks / "hook_events_tool_call_completed.yml").write_text(_HOOK_EVENTS_YAML)
+
+    bindings = builtin / "bindings"
+    bindings.mkdir()
+    (bindings / "bindings.yml").write_text(_BINDINGS_YAML)
+    return builtin
+
+
+# ---------------------------------------------------------------------------
+# (a) seed populates every builtin
+# ---------------------------------------------------------------------------
+
+
+def test_seed_populates_top_level_and_subdirs(tmp_path: Path) -> None:
+    """Seed picks up YAML at the top level, plus hooks/ and bindings/ subdirs."""
+    builtin = _make_builtin_dir(tmp_path)
+    store = RegistryStore(tuples_db_path=tmp_path / "tuples.db")
+
+    written = store.seed_from_builtin_dir(builtin)
+    assert written == 3, (
+        f"Expected 3 rows written on first seed, got {written}"
+    )
+
+    conn = sqlite3.connect(str(tmp_path / "tuples.db"))
+    try:
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM subspace_registry ORDER BY name"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert names == {
+        "tasks/<project>",
+        "hook_events/tool_call_completed",
+        "bindings/<profile>",
+    }, f"Unexpected seeded names: {names}"
+
+
+def test_seed_bypasses_reserved_prefix_gate(tmp_path: Path) -> None:
+    """Builtin schemas use reserved prefixes (tasks/, hook_events/,
+    bindings/) by design; the seed path must accept them. The same names
+    submitted via ``add`` would raise ReservedPrefixError."""
+    builtin = _make_builtin_dir(tmp_path)
+    store = RegistryStore(tuples_db_path=tmp_path / "tuples.db")
+
+    written = store.seed_from_builtin_dir(builtin)
+    assert written == 3, "Seed must persist all three reserved-prefix builtins"
+
+    # Sanity: the third-party path rejects the same names.
+    from nexus.daemon.subspace_registry import ReservedPrefixError
+    with pytest.raises(ReservedPrefixError):
+        store.add(_TASKS_YAML_V1)
+
+
+# ---------------------------------------------------------------------------
+# (b) Re-seed is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_seed_is_idempotent_on_unchanged_yaml(tmp_path: Path) -> None:
+    """Calling seed_from_builtin_dir twice with no YAML changes writes 0
+    rows on the second call and leaves all schema_digests unchanged."""
+    builtin = _make_builtin_dir(tmp_path)
+    store = RegistryStore(tuples_db_path=tmp_path / "tuples.db")
+
+    first = store.seed_from_builtin_dir(builtin)
+    assert first == 3
+
+    db_path = tmp_path / "tuples.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        digests_before = dict(
+            conn.execute(
+                "SELECT name, schema_digest FROM subspace_registry"
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+
+    second = store.seed_from_builtin_dir(builtin)
+    assert second == 0, (
+        f"Second seed of unchanged YAML must be a no-op, got {second} writes"
+    )
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        digests_after = dict(
+            conn.execute(
+                "SELECT name, schema_digest FROM subspace_registry"
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+
+    assert digests_before == digests_after
+
+
+# ---------------------------------------------------------------------------
+# (c) Bumped YAML triggers an update
+# ---------------------------------------------------------------------------
+
+
+def test_seed_updates_row_when_yaml_changes(tmp_path: Path) -> None:
+    """Bumping a builtin YAML on disk causes seed to UPDATE the stored row
+    (digest changes, only that one name is counted as written)."""
+    builtin = _make_builtin_dir(tmp_path)
+    store = RegistryStore(tuples_db_path=tmp_path / "tuples.db")
+
+    first = store.seed_from_builtin_dir(builtin)
+    assert first == 3
+
+    db_path = tmp_path / "tuples.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        digest_before = conn.execute(
+            "SELECT schema_digest FROM subspace_registry WHERE name = ?",
+            ("tasks/<project>",),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    # Bump the on-disk YAML
+    (builtin / "tasks.yml").write_text(_TASKS_YAML_V2_BUMPED)
+
+    second = store.seed_from_builtin_dir(builtin)
+    assert second == 1, (
+        f"Only the bumped row should be rewritten, got {second}"
+    )
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        digest_after = conn.execute(
+            "SELECT schema_digest FROM subspace_registry WHERE name = ?",
+            ("tasks/<project>",),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert digest_before != digest_after, (
+        "Bumping the YAML must change the persisted schema_digest"
+    )
+
+
+def test_seed_missing_dir_raises(tmp_path: Path) -> None:
+    """A non-existent builtin_dir is a programmer error, not a silent
+    skip. seed_from_builtin_dir surfaces FileNotFoundError."""
+    store = RegistryStore(tuples_db_path=tmp_path / "tuples.db")
+    with pytest.raises(FileNotFoundError):
+        store.seed_from_builtin_dir(tmp_path / "does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# (e) Daemon start() seeds before sockets bind
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def seeded_daemon(tmp_path: Path):
+    """Daemon constructed with a synthetic builtin_dir; start() must seed
+    before binding sockets."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    builtin = _make_builtin_dir(tmp_path)
+
+    tuples_db = config_dir / "tuples.db"
+    store = RegistryStore(tuples_db_path=tuples_db)
+    daemon = T2Daemon(
+        config_dir=config_dir,
+        tuples_db_path=tuples_db,
+        registry_store=store,
+        builtin_dir=builtin,
+    )
+    await daemon.start()
+    try:
+        yield daemon, store, tuples_db
+    finally:
+        await daemon.stop()
+
+
+@pytest.mark.asyncio
+async def test_daemon_start_seeds_builtin_before_bind(seeded_daemon) -> None:
+    """After T2Daemon.start() returns, the registry contains every builtin
+    schema (seed ran before bind, so any client that handshakes sees the
+    seeded state on first contact)."""
+    _daemon, _store, tuples_db = seeded_daemon
+
+    conn = sqlite3.connect(str(tuples_db))
+    try:
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM subspace_registry ORDER BY name"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert "tasks/<project>" in names
+    assert "hook_events/tool_call_completed" in names
+    assert "bindings/<profile>" in names
+
+
+@pytest.mark.asyncio
+async def test_daemon_restart_seed_is_idempotent(tmp_path: Path) -> None:
+    """Starting, stopping, and re-starting a daemon over the same tuples.db
+    leaves the registry unchanged (no duplicate rows, digests stable)."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    builtin = _make_builtin_dir(tmp_path)
+    tuples_db = config_dir / "tuples.db"
+
+    # First boot
+    store1 = RegistryStore(tuples_db_path=tuples_db)
+    daemon1 = T2Daemon(
+        config_dir=config_dir,
+        tuples_db_path=tuples_db,
+        registry_store=store1,
+        builtin_dir=builtin,
+    )
+    await daemon1.start()
+    await daemon1.stop()
+
+    conn = sqlite3.connect(str(tuples_db))
+    try:
+        digests_first = dict(
+            conn.execute(
+                "SELECT name, schema_digest FROM subspace_registry"
+            ).fetchall()
+        )
+        count_first = conn.execute(
+            "SELECT COUNT(*) FROM subspace_registry"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    # Second boot (simulated restart -- same on-disk YAML)
+    store2 = RegistryStore(tuples_db_path=tuples_db)
+    daemon2 = T2Daemon(
+        config_dir=config_dir,
+        tuples_db_path=tuples_db,
+        registry_store=store2,
+        builtin_dir=builtin,
+    )
+    await daemon2.start()
+    await daemon2.stop()
+
+    conn = sqlite3.connect(str(tuples_db))
+    try:
+        digests_second = dict(
+            conn.execute(
+                "SELECT name, schema_digest FROM subspace_registry"
+            ).fetchall()
+        )
+        count_second = conn.execute(
+            "SELECT COUNT(*) FROM subspace_registry"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert count_first == count_second == 3
+    assert digests_first == digests_second

--- a/tests/daemon/test_subspace_registry.py
+++ b/tests/daemon/test_subspace_registry.py
@@ -369,11 +369,14 @@ async def test_hello_ack_registry_digest_changes_after_add(
 
 
 @pytest.mark.asyncio
-async def test_all_seven_hook_event_subspaces_register(
+async def test_all_seven_hook_event_subspaces_rejected_via_subspace_add(
     registry_daemon: T2Daemon,
 ) -> None:
-    """All seven RDR-111 hook-event subspace names parse and register without error."""
-    registered = []
+    """nexus-me9y: hook_events/ is now a reserved-prefix namespace owned by
+    the builtin seed path. Third parties cannot mint into it via
+    ``subspace_add``; the gate must fire for every one of the seven RDR-111
+    hook-event channel names.
+    """
     for name in _HOOK_EVENT_SUBSPACES:
         yaml_str = _HOOK_EVENT_YAML_TEMPLATE.format(name=name)
         resp = await _rpc_uds(
@@ -381,16 +384,14 @@ async def test_all_seven_hook_event_subspaces_register(
             "subspace_add",
             {"yaml": yaml_str},
         )
-        assert "error" not in resp, (
-            f"hook-event subspace {name!r} failed to register: {resp}"
+        assert "error" in resp, (
+            f"hook-event subspace {name!r} must be rejected (reserved prefix): {resp}"
         )
-        result = resp.get("result", {})
-        assert result.get("name") == name, (
-            f"Expected name={name!r}, got: {result.get('name')!r}"
+        err = resp["error"]
+        msg = err.get("message", "") if isinstance(err, dict) else str(err)
+        assert "hook_events/" in msg or "reserved" in msg.lower(), (
+            f"Error must mention reserved prefix for {name!r}: {msg!r}"
         )
-        registered.append(result.get("name"))
-
-    assert len(registered) == 7, f"Expected 7 registered subspaces, got: {registered}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tuplespace/test_subspace_reserved_prefix.py
+++ b/tests/tuplespace/test_subspace_reserved_prefix.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Reserved-prefix gate tests for subspace_add -- RDR-112 nexus-me9y.
+
+The third-party admission path (``RegistryStore.add`` / ``subspace_add``
+admin RPC) must reject any subspace name whose prefix matches a builtin
+or daemon-internal namespace. Builtins enter via ``seed_from_builtin_dir``
+instead.
+
+This file exercises every reserved prefix listed in
+``nexus.daemon.subspace_registry._RESERVED_PREFIXES`` plus a handful of
+non-reserved names that must continue to succeed.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.daemon.subspace_registry import (
+    RegistryStore,
+    ReservedPrefixError,
+    _RESERVED_PREFIXES,
+)
+
+
+_YAML_TEMPLATE = """\
+name: {name}
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  actor: { type: string, required: true }
+take:
+  enabled: true
+  mode: semantic
+  floor: 0.50
+  margin: 0.05
+read:
+  default_floor: 0.40
+  default_n: 5
+tiers: [project]
+retention_seconds: 86400
+"""
+
+
+# The 10 RDR-defined reserved prefixes (RDR-110 + RDR-111 + RDR-112
+# nexus-0xaq) plus the two daemon-internal prefixes (tuples/, daemon/).
+_RESERVED_SAMPLE_NAMES = [
+    "tasks/myproject",
+    "mailbox/alice/primary",
+    "locks/db-write",
+    "events/lifecycle",
+    "barriers/release-1.0",
+    "hook_events/tool_call_completed",
+    "hook_events/foo",
+    "layout_state/cockpit",
+    "connection_manifest/peer-a",
+    "bindings/default",
+    "bindings/x",
+    "derived/default",
+    "tuples/raw",
+    "daemon/lifecycle",
+]
+
+
+def _make_store(tmp_path: Path) -> RegistryStore:
+    return RegistryStore(tuples_db_path=tmp_path / "tuples.db")
+
+
+def _yaml_for(name: str) -> str:
+    # The minimal template uses Python str.format placeholders; the only
+    # actual brace expansion we want is for the {name} field. The
+    # dimensions block uses curly braces literally, so we build the YAML
+    # without going through .format() to avoid KeyError on '{type: ...}'.
+    return _YAML_TEMPLATE.replace("{name}", name)
+
+
+@pytest.mark.parametrize("name", _RESERVED_SAMPLE_NAMES)
+def test_subspace_add_rejects_reserved_prefix(tmp_path: Path, name: str) -> None:
+    """Every reserved-prefix sample name must raise ReservedPrefixError
+    when submitted through the third-party ``add`` path."""
+    store = _make_store(tmp_path)
+    with pytest.raises(ReservedPrefixError) as exc_info:
+        store.add(_yaml_for(name))
+
+    msg = str(exc_info.value)
+    assert name in msg, (
+        f"Error message must name the offending subspace {name!r}: {msg!r}"
+    )
+    # The message must also identify which reserved prefix matched.
+    matched_prefix = next(p for p in _RESERVED_PREFIXES if name.startswith(p))
+    assert matched_prefix in msg, (
+        f"Error message must name the reserved prefix {matched_prefix!r}: {msg!r}"
+    )
+
+
+def test_reserved_prefixes_includes_all_ten_builtin_namespaces() -> None:
+    """nexus-me9y acceptance criterion 2: the reserved-prefix tuple must
+    list every canonical builtin namespace from RDR-110 / RDR-111 /
+    RDR-112 nexus-0xaq, plus the two daemon-internal prefixes."""
+    required = {
+        "tasks/",
+        "mailbox/",
+        "locks/",
+        "events/",
+        "barriers/",
+        "hook_events/",
+        "layout_state/",
+        "connection_manifest/",
+        "bindings/",
+        "derived/",
+    }
+    missing = required - set(_RESERVED_PREFIXES)
+    assert not missing, f"Reserved prefixes missing: {missing}"
+
+    # Daemon-internals must also remain present.
+    assert "tuples/" in _RESERVED_PREFIXES
+    assert "daemon/" in _RESERVED_PREFIXES
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "myapp/whatever",
+        "third_party/queue",
+        "telemetry/heartbeat",
+        "custom/foo/bar",
+    ],
+)
+def test_subspace_add_accepts_non_reserved_names(tmp_path: Path, name: str) -> None:
+    """Names that do not match a reserved prefix register normally."""
+    store = _make_store(tmp_path)
+    result = store.add(_yaml_for(name))
+    assert result["name"] == name
+    assert len(result["digest"]) == 64  # sha256 hex


### PR DESCRIPTION
## Summary

The daemon previously had two uncoordinated registry sources -- the client-side `Registry.load` YAML loader and the daemon-side `RegistryStore` populated by the `subspace_add` admin RPC. They could drift silently (a bumped builtin YAML left a stale `subspace_add` row visible to queries), and there was no gate preventing a third-party `subspace_add` from shadowing a builtin namespace.

Collapses to one path:

- `RegistryStore.seed_from_builtin_dir(path)` idempotently upserts every YAML under `nx/tuplespace/builtin/` (top level + `hooks/` + `bindings/` subdirs). Unchanged YAML is a no-op; a bumped `schema_digest` triggers an UPDATE.
- `T2Daemon.start()` calls the seed BEFORE any socket binds, so first-handshake clients always observe seeded state. New optional `builtin_dir` kwarg; defaults to `default_builtin_dir()`.
- `_RESERVED_PREFIXES` expanded from `(tuples/, daemon/)` to the full set: `tasks/`, `mailbox/`, `locks/`, `events/`, `barriers/`, `hook_events/`, `layout_state/`, `connection_manifest/`, `bindings/`, `derived/` + the two daemon internals.
- `add` (third-party) and `seed_from_builtin_dir` (builtin) are now structurally separate methods on `RegistryStore`, not flag-toggled branches.

## Tests

- `tests/daemon/test_registry_seeding.py` (7 cases): top-level + subdirs populated, reserved-prefix bypass on seed path, idempotency, UPDATE on bump, `FileNotFoundError` on missing dir, daemon-start seed-before-bind, restart idempotency.
- `tests/tuplespace/test_subspace_reserved_prefix.py` (19 cases): parameterised over 14 reserved-prefix sample names + 4 non-reserved + a constants-coverage assertion.
- `tests/daemon/test_subspace_registry.py`: the seven-hook-events test flipped contract -- `hook_events/` is now reserved so `subspace_add` must reject all seven channel names.

Focused suites green: 352 passed in `tests/daemon/ tests/tuplespace/`.

## Contract changes

- `subspace_add` of a name starting with any reserved prefix now raises `ReservedPrefixError`. The pre-existing test `test_all_seven_hook_event_subspaces_register` was renamed to `test_all_seven_hook_event_subspaces_rejected_via_subspace_add` -- the old assertion was always wrong (third parties should never have been able to register `hook_events/...`).

## Closes

Closes nexus-me9y
Refs epic nexus-hp9f