### PR TITLE
feat(rdr-111): substrate extraction from #786 — coordination subspaces + wheel packaging + nx doctor --check-bridge

### DIFF
--- a/nx/tuplespace/builtin/barriers.yml
+++ b/nx/tuplespace/builtin/barriers.yml
@@ -1,0 +1,28 @@
+# RDR-110 canonical subspace: N-way barrier coordination.
+# Each participant posts an arrival tuple to the same barrier_id.
+# When count(participants) == target_n the barrier "trips" — any
+# consumer can read all arrival tuples for the barrier and proceed.
+# Each participant identified by participant_id; a participant tries
+# to take its own arrival tuple to release.
+#
+# Reference: RDR-110 §Implementation Plan Step 6, line 1408; pattern
+# documented at §Phase 1 Step 8 (nx:tuplespace-barriers skill).
+name: barriers/<barrier_id>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  barrier_id:     { type: string, required: true }
+  participant_id: { type: string, required: true }
+  target_n:       { type: string, required: true }
+  arrived_at:     { type: string, required: true }
+take:
+  enabled: true
+  mode: exact
+  match_keys: [barrier_id, participant_id]
+  default_lease_seconds: 60
+read:
+  default_floor: 0.0
+  default_n: 100
+tiers: [project]
+retention_seconds: 3600  # 1 hour

--- a/nx/tuplespace/builtin/connection_manifest.yml
+++ b/nx/tuplespace/builtin/connection_manifest.yml
@@ -1,0 +1,32 @@
+# RDR-111 Step 1: connection_manifest subspace.
+# Direct peer-to-peer streams (RDR-111 §The connection manifest subspace,
+# lines 487-506). Producer posts the manifest after the endpoint is ready;
+# consumer reads + connects directly. Heartbeats refresh the tuple's TTL
+# via out() with the same ID (idempotent); take() or TTL expiry signals
+# teardown.
+#
+# Shipped now (Phase 1 Step 1) so producers can register and write to a
+# registered schema before the Phase 3 layout / cockpit consumers exist.
+name: connection_manifest
+tier: session
+content_type: text
+embed_from: match_text
+dimensions:
+  producer:     { type: string, required: true }
+  consumer:     { type: string, required: true }
+  conn_type:    { type: enum, values: [stream, pipe, websocket, sse, file-fd], required: true }
+  payload_type: { type: string, required: true }
+  ttl_seconds:  { type: string, required: true }
+# match_keys includes payload_type so a producer-consumer pair can register
+# distinct streams per (conn_type, payload_type) without one ``out`` silently
+# overwriting another. Excluding payload_type would let, e.g., a JSON manifest
+# and a msgpack manifest collide on the same take identity.
+take:
+  enabled: true
+  mode: exact
+  match_keys: [producer, consumer, conn_type, payload_type]
+read:
+  default_floor: 0.0
+  default_n: 50
+tiers: [session]
+retention_seconds: 3600

--- a/nx/tuplespace/builtin/events.yml
+++ b/nx/tuplespace/builtin/events.yml
@@ -1,0 +1,26 @@
+# RDR-110 canonical subspace: append-only event telemetry.
+# Producers emit events with topic dimension; consumers read by topic
+# (and optionally semantic match on content). Take is DISABLED — this
+# subspace is for audit / telemetry, not coordination. Multiple readers
+# can observe the same event independently.
+#
+# Reference: RDR-110 §Implementation Plan Step 6, line 1408; pattern
+# documented at §Phase 1 Step 8 (nx:tuplespace-events skill).
+name: events/<topic>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  topic:    { type: string, required: true }
+  producer: { type: string, required: true }
+  severity: { type: enum, values: [debug, info, warn, error, critical], required: false }
+take:
+  enabled: false
+  mode: semantic
+  floor: 0.30
+  margin: 0.05
+read:
+  default_floor: 0.20
+  default_n: 50
+tiers: [project]
+retention_seconds: 604800  # 7 days

--- a/nx/tuplespace/builtin/hooks/hook_events_assistant_turn_ended.yml
+++ b/nx/tuplespace/builtin/hooks/hook_events_assistant_turn_ended.yml
@@ -10,6 +10,7 @@ dimensions:
   session:   { type: string, required: true }
   project:   { type: string, required: true }
   timestamp: { type: string, required: true }
+  hook_event_name: { type: string, required: true }
   intent:    { type: string, required: false }
 take:
   enabled: false

--- a/nx/tuplespace/builtin/hooks/hook_events_session_lifecycle.yml
+++ b/nx/tuplespace/builtin/hooks/hook_events_session_lifecycle.yml
@@ -10,6 +10,7 @@ dimensions:
   session:   { type: string, required: true }
   project:   { type: string, required: true }
   timestamp: { type: string, required: true }
+  hook_event_name: { type: string, required: true }
   workflow:  { type: string, required: false }
 take:
   enabled: false

--- a/nx/tuplespace/builtin/layout_state.yml
+++ b/nx/tuplespace/builtin/layout_state.yml
@@ -1,0 +1,42 @@
+# RDR-111 Step 1: layout_state subspace.
+# Auto-layout engine stylesheet output (RDR-111 §The layout_state subspace,
+# lines 508-532). One tuple per (profile, event_type) keying pair, written
+# by the layout engine and read by all cockpit surfaces to know which slot
+# and level to use for each event type.
+#
+# Note: ``event_type`` here is the SUBSPACE PATH (e.g.
+# ``hook_events/tool_call_intent``) — a stylesheet selector keyed on the
+# tuple subspace, NOT the same dim as the hook-event subspace's
+# ``hook_event_name`` discriminator (PR #786). The two dims occupy
+# disjoint subspaces by design.
+#
+# Shipped now (Phase 1 Step 1) so producers can register and write to a
+# registered schema before the layout engine (Phase 3 Step 11) lands.
+name: layout_state/<profile>
+tier: project
+content_type: text
+embed_from: match_text
+dimensions:
+  # profile + event_type are the keying dimensions per the RDR.
+  profile:        { type: string, required: true }
+  event_type:     { type: string, required: true }
+  # RDR-111 calls surface_level / demotion_level / ttl_seconds / pinned
+  # "content_fields", but SubspaceSchema has no content_fields concept —
+  # the only addressable structure is ``dimensions``. Promoting them lets
+  # cockpit surfaces filter by surface_level/demotion_level via the
+  # standard ``read(where=...)`` path instead of unpacking the content
+  # blob. If the registry ever gains a content_fields concept these may
+  # migrate; the on-the-wire keys are unchanged.
+  surface_level:  { type: enum, values: [status-line, notification, panel, full-screen], required: true }
+  demotion_level: { type: enum, values: [status-line, notification, panel, full-screen], required: true }
+  ttl_seconds:    { type: string, required: true }
+  pinned:         { type: string, required: false }
+take:
+  enabled: true
+  mode: exact
+  match_keys: [profile, event_type]
+read:
+  default_floor: 0.0
+  default_n: 100
+tiers: [project]
+retention_seconds: 604800  # 7 days

--- a/nx/tuplespace/builtin/locks.yml
+++ b/nx/tuplespace/builtin/locks.yml
@@ -1,0 +1,27 @@
+# RDR-110 canonical subspace: mutex / lease locks.
+# A claim on locks/<resource> is held by exactly one holder for the
+# duration of the lease. Other holders attempting to take the same
+# resource block (or fail-fast under block=False) until the lease
+# expires or the holder releases via ack.
+#
+# Reference: RDR-110 §Implementation Plan Step 6, line 1408; pattern
+# documented at §Phase 1 Step 8 (nx:tuplespace-lock skill).
+name: locks/<resource>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  resource:    { type: string, required: true }
+  holder:      { type: string, required: true }
+  acquired_at: { type: string, required: true }
+  reason:      { type: string, required: false }
+take:
+  enabled: true
+  mode: exact
+  match_keys: [resource]
+  default_lease_seconds: 600
+read:
+  default_floor: 0.0
+  default_n: 50
+tiers: [project]
+retention_seconds: 3600  # 1 hour — released locks roll off quickly

--- a/nx/tuplespace/builtin/mailbox.yml
+++ b/nx/tuplespace/builtin/mailbox.yml
@@ -1,0 +1,27 @@
+# RDR-110 canonical subspace: request-reply mailbox.
+# Agents post messages addressed to a recipient agent; the recipient
+# takes by exact match on (to_actor, correlation_id) to atomically
+# pop the request and reply via the matching reply_to subspace.
+#
+# Reference: RDR-110 §Implementation Plan Step 6, line 1408; pattern
+# documented at §Phase 1 Step 8 (nx:tuplespace-mailbox skill).
+name: mailbox/<agent>
+tier: project
+content_type: text
+embed_from: content
+dimensions:
+  from_actor:     { type: string, required: true }
+  to_actor:       { type: string, required: true }
+  correlation_id: { type: string, required: true }
+  reply_to:       { type: string, required: false }
+  priority:       { type: enum, values: [P0, P1, P2, P3, P4], required: false }
+take:
+  enabled: true
+  mode: exact
+  match_keys: [to_actor, correlation_id]
+  default_lease_seconds: 300
+read:
+  default_floor: 0.0
+  default_n: 20
+tiers: [project]
+retention_seconds: 86400  # 1 day — messages older than this are stale

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,12 @@ exclude = [
 # wheel.
 [tool.hatch.build.targets.wheel.force-include]
 "nx/plans" = "nexus/_resources/plans"
+# RDR-111 (PR #786 follow-up): ship the tuplespace builtin subspace
+# YAMLs (including hooks/) as package data so the hook bridge can
+# resolve them on wheel installs via importlib.resources. Without
+# this, default_builtin_dir() is repo-relative and every hook fire
+# on a PyPI install silently no-ops the tuple write.
+"nx/tuplespace" = "nexus/_resources/tuplespace"
 # nexus-tv5u: ship DT-side AppleScripts as package data so
 # ``nx dt install-scripts`` can resolve them via
 # ``importlib.resources.files("nexus") / "_resources" / "dt-scripts"``
@@ -147,6 +153,7 @@ exclude = [
 include = [
     "src",
     "nx/plans",
+    "nx/tuplespace",
     "dt/scripts",
     "README.md",
     "LICENSE",

--- a/src/nexus/_resources/tuplespace
+++ b/src/nexus/_resources/tuplespace
@@ -1,0 +1,1 @@
+../../../nx/tuplespace

--- a/src/nexus/commands/doctor.py
+++ b/src/nexus/commands/doctor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from pathlib import Path
 from typing import Any
 
@@ -836,6 +837,149 @@ def _run_check_post_store_hooks() -> None:
     click.echo(f"\nTotal: {total} hook(s) registered across 3 chains.")
 
 
+# ── --check-bridge (RDR-111 deep-review pass — bridge installability) ─────
+
+
+def _run_check_bridge() -> None:
+    """Diagnose ORB hook-bridge installability.
+
+    Per the 2026-05-15 deep-review pass: a wheel-only install delivers no
+    bridge silently — the seven ``orb_bridge_*.py`` scripts live under
+    ``$CLAUDE_PLUGIN_ROOT`` and require both the Python wheel AND the nx
+    Claude Code plugin. Without ``nx doctor`` checking, users get a
+    silently-broken bridge.
+
+    Checks:
+      1. ``CLAUDE_PLUGIN_ROOT`` is set (otherwise bridge scripts can't be located).
+      2. All seven ``orb_bridge_*.py`` exist under it.
+      3. ``~/.config/nexus/tuples.db`` exists and is readable.
+      4. The seven hook-event subspace YAMLs resolve via the registry.
+      5. At least one tuple has been written in the last 24h (sanity that
+         the bridge has actually fired).
+    """
+    plugin_root_env = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    expected_scripts = [
+        "orb_bridge_pretooluse.py",
+        "orb_bridge_posttooluse.py",
+        "orb_bridge_stop.py",
+        "orb_bridge_subagent_stop.py",
+        "orb_bridge_user_prompt_submit.py",
+        "orb_bridge_session.py",
+        "orb_bridge_notification.py",
+    ]
+
+    click.echo("ORB hook-bridge diagnostics (RDR-111):")
+    click.echo("")
+
+    # 1. CLAUDE_PLUGIN_ROOT
+    if plugin_root_env:
+        click.echo(_check("CLAUDE_PLUGIN_ROOT", True, plugin_root_env))
+        plugin_root = Path(plugin_root_env)
+    else:
+        click.echo(
+            _check(
+                "CLAUDE_PLUGIN_ROOT",
+                False,
+                "unset — bridge scripts cannot be located; install the nx Claude Code plugin",
+            )
+        )
+        plugin_root = None
+
+    # 2. Bridge scripts
+    if plugin_root is not None:
+        scripts_dir = plugin_root / "hooks" / "scripts"
+        missing = [s for s in expected_scripts if not (scripts_dir / s).is_file()]
+        if missing:
+            click.echo(
+                _check(
+                    "bridge scripts",
+                    False,
+                    f"missing under {scripts_dir}: {missing}",
+                )
+            )
+        else:
+            click.echo(
+                _check(
+                    "bridge scripts",
+                    True,
+                    f"7/7 present under {scripts_dir}",
+                )
+            )
+
+    # 3. tuples.db
+    tuples_db = Path(os.path.expanduser("~/.config/nexus/tuples.db"))
+    if tuples_db.exists():
+        size = tuples_db.stat().st_size
+        click.echo(
+            _check("tuples.db", True, f"{tuples_db} ({size} bytes)")
+        )
+    else:
+        click.echo(
+            _check(
+                "tuples.db",
+                False,
+                f"{tuples_db} not present — bridge has not run yet",
+            )
+        )
+
+    # 4. Registry resolves hook subspaces
+    try:
+        from nexus.tuplespace.registry import Registry, default_builtin_dir
+        reg = Registry.load(default_builtin_dir(), subdirs=("hooks",))
+        hook_subspaces = [
+            s for s in reg._by_template.keys() if s.startswith("hook_events/")
+        ]
+        if len(hook_subspaces) == 7:
+            click.echo(
+                _check(
+                    "hook-event subspaces",
+                    True,
+                    f"7/7 resolve via {default_builtin_dir()}",
+                )
+            )
+        else:
+            click.echo(
+                _check(
+                    "hook-event subspaces",
+                    False,
+                    f"only {len(hook_subspaces)}/7 resolve",
+                )
+            )
+    except Exception as exc:  # noqa: BLE001
+        click.echo(_check("hook-event subspaces", False, f"registry load failed: {exc}"))
+
+    # 5. Recent tuple sanity
+    if tuples_db.exists():
+        import sqlite3 as _sqlite3
+        try:
+            conn = _sqlite3.connect(f"file:{tuples_db}?mode=ro", uri=True)
+            row = conn.execute(
+                "SELECT COUNT(*) FROM tuples "
+                "WHERE subspace LIKE 'hook_events/%' "
+                "AND created_at > unixepoch() - 86400"
+            ).fetchone()
+            conn.close()
+            recent = row[0] if row else 0
+            if recent > 0:
+                click.echo(
+                    _check(
+                        "recent hook events",
+                        True,
+                        f"{recent} tuple(s) in the last 24h",
+                    )
+                )
+            else:
+                click.echo(
+                    _check(
+                        "recent hook events",
+                        False,
+                        "0 tuples in last 24h — bridge may not be firing (set CLAUDECODE, unset NX_BRIDGE_DISABLE)",
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001
+            click.echo(_check("recent hook events", False, f"query failed: {exc}"))
+
+
 # ── --check-mineru (nexus-2fyb code-review R3-3) ────────────────────────────
 
 
@@ -1084,6 +1228,16 @@ def _run_check_mineru() -> None:
          "but the addr file is missing or unreachable.",
 )
 @click.option(
+    "--check-bridge",
+    "check_bridge",
+    is_flag=True,
+    default=False,
+    help="Diagnose ORB hook-bridge installability (RDR-111): "
+         "CLAUDE_PLUGIN_ROOT, bridge scripts present, tuples.db, "
+         "registry resolves the 7 hook-event subspaces, and at "
+         "least one tuple landed in the last 24h.",
+)
+@click.option(
     "--days",
     "days",
     default=30,
@@ -1104,6 +1258,7 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
                check_post_store_hooks: bool,
                check_aspect_queue: bool,
                check_t1: bool,
+               check_bridge: bool,
                check_tier_discipline: bool) -> None:
     """Verify that all required services and credentials are available."""
     if check_schema:
@@ -1157,6 +1312,10 @@ def doctor_cmd(clean_checkpoints: bool, clean_pipelines: bool, fix: bool,
 
     if check_t1:
         _run_check_t1()
+        return
+
+    if check_bridge:
+        _run_check_bridge()
         return
 
     if check_tier_discipline:


### PR DESCRIPTION
Extraction from PR #786 of the ~30% of changes still missing from develop after the daughter PR chain landed. Replaces #786, which is heavily conflicting now.

## Shipped

- **6 coordination subspace YAMLs**: `barriers`, `connection_manifest`, `events`, `layout_state`, `locks`, `mailbox`. The #791-shipped consumer skills (`nx:tuplespace-{tasks,mailbox,lock,events,barriers}`) reference these; without the YAMLs the skills resolve nothing.
- **2 hook-event YAML edits** (one-line each): `assistant_turn_ended`, `session_lifecycle`.
- **Wheel packaging**: `nx/tuplespace` force-included into the wheel via `src/nexus/_resources/tuplespace` symlink so `default_builtin_dir()` resolves via `importlib.resources` on PyPI installs. Without this, the bridge silently no-ops on wheel-only installs.
- **`nx doctor --check-bridge`**: diagnose bridge installability (CLAUDE_PLUGIN_ROOT set, 7 orb_bridge_*.py present, tuples.db exists, hook subspaces resolve, recent tuple write).

## Not shipped here (already on develop via daughter PRs)

- hook_bridge.py hardening — #787, #789, #800
- `nx cockpit` commands — #791 (status), #802 in flight (show, dashboard)
- daemon registry changes — #801 in flight
- tuplespace/registry.py + store.py — #788, #800
- mcp/core.py daemon-mode routing — #789
- 824-line test_hook_bridge.py expansion — covered across the daughter PRs

## Verified

- `tests/tuplespace/ tests/cockpit/ tests/commands/` — 207 passed
- `tests/test_doctor_cmd.py` — 58 passed

After this lands, #786 can be closed cleanly. Substrate is on develop.