### PR TITLE
spike(parity-judge): generalize semantic-equivalence judge to spike-D (tier-B parity)

### DIFF
--- a/scripts/spikes/judge_aspect_diffs.py
+++ b/scripts/spikes/judge_aspect_diffs.py
@@ -1,113 +1,53 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 """
-judge_aspect_diffs — semantic-equivalence judge for spike_c parity output.
+judge_aspect_diffs — DEPRECATED shim.
 
-The spike_c harness uses strict set-equality on experimental_datasets /
-experimental_baselines. That's too strict for free-form extraction:
-"UCI Mushroom database" vs "Mushroom database" register as disagreement.
+Superseded by ``judge_parity_diffs.py``, which handles both spike-C
+(aspect_extractor parity) and spike-D (tier-B tool-use parity) JSONL
+output. This shim forces ``--schema spike-c`` for backward compatibility
+with existing spike-C invocations and re-exports the original public
+symbols.
 
-This script re-scores a spike_c JSONL by running an LLM judge on each
-(only-claude, only-qwen) item pair within a paper's diverging set fields.
-The judge returns yes/no on semantic equivalence; matched items are
-counted as agreed.
-
-Output: per-field semantic-agreement rate (replaces the strict-set rate),
-plus precision/recall/F1 on the matched pairs.
-
-Usage:
-    python judge_aspect_diffs.py \\
-        --in /tmp/aspect-bench-out/parity-v3-2026-05-15.jsonl \\
-        --out /tmp/aspect-bench-out/parity-v3-judged.jsonl \\
-        [--judge claude|qwen]   # default: qwen (free)
-
-The judge dispatch goes through nexus.operators.qwen_dispatch or
-claude_dispatch directly; backend is selected by --judge.
+New invocations should call ``judge_parity_diffs.py`` directly.
 """
 
 from __future__ import annotations
 
-import argparse
-import asyncio
-import json
 import sys
 from pathlib import Path
-from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-REPO_ROOT = SCRIPT_DIR.parent.parent
-sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(SCRIPT_DIR))
 
-from nexus.operators.dispatch import claude_dispatch  # noqa: E402
-from nexus.operators.qwen_dispatch import qwen_dispatch  # noqa: E402
+import judge_parity_diffs as _jpd  # noqa: E402
 
+# Re-export the moved primitives so any external importer keeps working.
+# Note: ``_judge`` and ``_match_pairs`` are wrapped (rather than directly
+# re-exported) so that tests can monkey-patch ``judge_aspect_diffs._judge``
+# and have ``judge_aspect_diffs._match_pairs`` honour the patch — preserving
+# pre-generalisation test behaviour.
+_rescore_row = _jpd._rescore_row  # noqa: F401
+main_async = _jpd.main_async  # noqa: F401
+_main_parity = _jpd.main
 
-SET_FIELDS = ("experimental_datasets", "experimental_baselines")
-
-
-_JUDGE_PROMPT = """\
-You are judging whether two short item descriptions, extracted from
-the same scholarly paper by two different systems, refer to the SAME
-underlying entity (the same dataset, baseline model, or method).
-
-Return JSON {{"equivalent": <bool>, "reason": "<one short sentence>"}}.
-
-"equivalent" should be true when:
-- The two strings name the same dataset / model / method, even if one
-  is more verbose, includes citations, or paraphrases the other.
-  Examples:
-    "UCI Mushroom database" ↔ "Mushroom database" → equivalent
-    "STAGGER (Schlimmer 1987)" ↔ "STAGGER algorithm" → equivalent
-    "Latent Semantic Analysis (LSA) vectors" ↔ "Latent Semantic Analysis" → equivalent
-
-"equivalent" should be false when:
-- The strings name genuinely different entities.
-- One is a proper-named entity and the other is an aggregation phrase
-  ("MNIST" vs "various image datasets" → not equivalent).
-- One is an ablation variant of the paper's own model and the other
-  is a prior external model.
-
-Item A (from system 1): {a}
-Item B (from system 2): {b}
-"""
-
-_JUDGE_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "equivalent": {"type": "boolean"},
-        "reason": {"type": "string"},
-    },
-    "required": ["equivalent", "reason"],
-}
+# Preserved for back-compat: callers that imported SET_FIELDS from this
+# module (spike-C's two fields).
+SET_FIELDS = _jpd.SPIKE_C_SET_FIELDS  # noqa: F401
 
 
-async def _judge(backend: str, a: str, b: str) -> dict:
-    prompt = _JUDGE_PROMPT.format(a=a, b=b)
-    if backend == "claude":
-        result = await claude_dispatch(
-            prompt, _JUDGE_SCHEMA, timeout=60.0,
-            operator_name="aspect_diff_judge",
-        )
-    else:
-        result = await qwen_dispatch(
-            prompt, _JUDGE_SCHEMA, timeout=60.0,
-            operator_name="aspect_diff_judge",
-        )
-    return result
+async def _judge(backend, a, b, *, prose=False):
+    """Shim wrapper. Tests monkey-patch this name."""
+    return await _jpd._judge(backend, a, b, prose=prose)
 
 
-async def _match_pairs(
-    backend: str,
-    only_c: list[str],
-    only_q: list[str],
-) -> tuple[set[tuple[str, str]], list[dict]]:
-    """Greedy bipartite match: for each only-C item, find first
-    semantically-equivalent only-Q item. Returns (matched_pairs,
-    judge_trace).
-    """
-    matched: set[tuple[str, str]] = set()
-    matched_q: set[str] = set()
-    trace: list[dict] = []
+async def _match_pairs(backend, only_c, only_q):
+    """Shim ``_match_pairs`` that calls this module's ``_judge`` so
+    tests patching ``judge_aspect_diffs._judge`` see their stub honoured.
+    Logic mirrors ``judge_parity_diffs._match_pairs``."""
+    matched: set = set()
+    matched_q: set = set()
+    trace: list = []
     for a in only_c:
         for b in only_q:
             if b in matched_q:
@@ -129,77 +69,29 @@ async def _match_pairs(
     return matched, trace
 
 
-async def _rescore_row(backend: str, row: dict) -> dict:
-    """Add semantic-agreement scores per set field. Mutates `row`."""
-    if not row.get("both_ok"):
-        return row
-    c = row.get("claude_record") or {}
-    q = row.get("qwen_record") or {}
-    judged: dict[str, Any] = {}
-    for f in SET_FIELDS:
-        cs = set(c.get(f) or [])
-        qs = set(q.get(f) or [])
-        strict_inter = cs & qs
-        only_c = sorted(cs - qs)
-        only_q = sorted(qs - cs)
-        matched, trace = await _match_pairs(backend, only_c, only_q)
-        # Total equivalent = strict intersection + semantic matches.
-        equiv = len(strict_inter) + len(matched)
-        # Precision/recall against the LARGER set as denominator —
-        # matches the spirit of "did each engine catch the other's
-        # findings".
-        union_size = len(cs | qs) - len(matched)  # collapse matched pairs
-        agreement = equiv / union_size if union_size > 0 else 1.0
-        judged[f] = {
-            "strict_intersection": sorted(strict_inter),
-            "semantic_matches": [list(p) for p in sorted(matched)],
-            "unmatched_only_c": sorted([a for a in only_c if not any(a == p[0] for p in matched)]),
-            "unmatched_only_q": sorted([b for b in only_q if b not in {p[1] for p in matched}]),
-            "agreement": agreement,
-            "trace": trace,
-        }
-    row["semantic_judged"] = judged
-    return row
-
-
-async def main_async(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description="Semantic-equivalence judge for spike_c parity output.")
-    p.add_argument("--in", dest="in_path", type=Path, required=True)
-    p.add_argument("--out", type=Path, required=True)
-    p.add_argument("--judge", choices=("claude", "qwen"), default="qwen")
-    args = p.parse_args(argv)
-
-    rows = [json.loads(l) for l in args.in_path.read_text().splitlines() if l.strip()]
-    print(f"judge: {len(rows)} rows, backend={args.judge}", file=sys.stderr)
-
-    out_rows: list[dict] = []
-    for i, row in enumerate(rows, 1):
-        name = (row.get("uri") or "?").split("/")[-1][:50]
-        print(f"  [{i}/{len(rows)}] {name}", file=sys.stderr)
-        out_row = await _rescore_row(args.judge, row)
-        out_rows.append(out_row)
-
-    args.out.parent.mkdir(parents=True, exist_ok=True)
-    with args.out.open("w") as fp:
-        for r in out_rows:
-            fp.write(json.dumps(r) + "\n")
-
-    # Summary
-    print("\n=== Semantic-equivalence summary ===", file=sys.stderr)
-    for f in SET_FIELDS:
-        rates = []
-        for r in out_rows:
-            if r.get("both_ok") and "semantic_judged" in r:
-                rates.append(r["semantic_judged"][f]["agreement"])
-        if rates:
-            avg = sum(rates) / len(rates)
-            print(f"  {f}: {avg*100:.1f}% mean semantic agreement (n={len(rates)})", file=sys.stderr)
-
-    return 0
-
-
 def main(argv: list[str] | None = None) -> int:
-    return asyncio.run(main_async(argv))
+    """Dispatch to the generalised judge, forcing the spike-C schema.
+
+    Any caller-supplied ``--schema`` is overridden so behaviour matches
+    the pre-generalisation script exactly.
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+    # Strip any caller --schema flag (both forms) and force spike-c.
+    cleaned: list[str] = []
+    skip_next = False
+    for tok in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if tok == "--schema":
+            skip_next = True
+            continue
+        if tok.startswith("--schema="):
+            continue
+        cleaned.append(tok)
+    cleaned += ["--schema", "spike-c"]
+    return _main_parity(cleaned)
 
 
 if __name__ == "__main__":

--- a/scripts/spikes/judge_parity_diffs.py
+++ b/scripts/spikes/judge_parity_diffs.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+judge_parity_diffs — semantic-equivalence judge for spike-C *and* spike-D parity output.
+
+The spike_c (aspect_extractor) and spike_d (tier-B tool-use) harnesses
+use strict set-equality / Jaccard on canonical fields. That's too
+strict for free-form extraction and generated content: paraphrased
+constraints, dataset-name variants, etc. register as full
+disagreement.
+
+This script re-scores either spike-C or spike-D JSONL output by
+running an LLM judge on each (only-claude, only-qwen) item pair within
+diverging set fields. Schema auto-detected from row shape.
+
+  spike-C: row has ``claude_record`` + ``qwen_record``; set fields are
+           ``experimental_datasets`` and ``experimental_baselines``.
+
+  spike-D: row has ``claude_agent.payload`` + ``qwen_agent.payload``;
+           set fields dispatch on ``row["tool"]``:
+             - nx_enrich_beads: key_files, test_commands, constraints
+             - nx_tidy:         actions (dict items)
+             - nx_plan_audit:   findings (dict items)
+
+Dict-shaped set items are canonicalised via ``json.dumps(item,
+sort_keys=True)`` before being passed to the judge, mirroring spike-D's
+own structural-Jaccard helper.
+
+Usage:
+    python judge_parity_diffs.py \\
+        --in /tmp/spike-d-out/parity-tier-b-full-2026-05-15.jsonl \\
+        --out /tmp/spike-d-out/parity-tier-b-judged.jsonl \\
+        [--judge claude|qwen]    # default: qwen (free at margin)
+        [--schema spike-c|spike-d|auto]   # default: auto
+        [--prose]                # also judge diverging prose fields
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from nexus.operators.dispatch import claude_dispatch  # noqa: E402
+from nexus.operators.qwen_dispatch import qwen_dispatch  # noqa: E402
+
+
+# ── Schema config ────────────────────────────────────────────────────────────
+
+# spike-C: shared across all rows.
+SPIKE_C_SET_FIELDS: tuple[str, ...] = (
+    "experimental_datasets",
+    "experimental_baselines",
+)
+SPIKE_C_PROSE_FIELDS: tuple[str, ...] = ()
+
+# spike-D: per-tool. Mirrors STRUCTURAL_FIELDS / PROSE_FIELDS in
+# scripts/spikes/spike_d_tier_b_parity.py.
+SPIKE_D_SET_FIELDS: dict[str, tuple[str, ...]] = {
+    "nx_enrich_beads": ("key_files", "test_commands", "constraints"),
+    "nx_tidy": ("actions",),
+    "nx_plan_audit": ("findings",),
+}
+SPIKE_D_PROSE_FIELDS: dict[str, tuple[str, ...]] = {
+    "nx_enrich_beads": ("enriched_description",),
+    "nx_tidy": ("summary",),
+    "nx_plan_audit": ("verdict", "summary"),
+}
+
+PROSE_LEN_TOL: float = 0.5
+PROSE_MAX_CHARS: int = 4000
+
+
+# ── Schema detection ─────────────────────────────────────────────────────────
+
+
+def detect_schema(row: dict) -> str:
+    """Return 'spike-c' or 'spike-d'; raise on unknown shape."""
+    if "claude_record" in row and "qwen_record" in row:
+        return "spike-c"
+    ca = row.get("claude_agent")
+    qa = row.get("qwen_agent")
+    if isinstance(ca, dict) and isinstance(qa, dict) and (
+        "payload" in ca or "payload" in qa
+    ):
+        return "spike-d"
+    raise ValueError(
+        "cannot detect schema: row lacks both (claude_record, qwen_record) "
+        "and (claude_agent.payload, qwen_agent.payload) — got keys: "
+        f"{sorted(row.keys())}"
+    )
+
+
+def _payloads_for(row: dict, schema: str) -> tuple[dict, dict]:
+    if schema == "spike-c":
+        return (row.get("claude_record") or {}, row.get("qwen_record") or {})
+    # spike-d
+    ca = row.get("claude_agent") or {}
+    qa = row.get("qwen_agent") or {}
+    return (ca.get("payload") or {}, qa.get("payload") or {})
+
+
+def _both_ok(row: dict, schema: str) -> bool:
+    if schema == "spike-c":
+        return bool(row.get("both_ok"))
+    return bool(row.get("diff", {}).get("both_ok"))
+
+
+def _set_fields_for(row: dict, schema: str) -> tuple[str, ...]:
+    if schema == "spike-c":
+        return SPIKE_C_SET_FIELDS
+    tool = row.get("tool")
+    return SPIKE_D_SET_FIELDS.get(tool or "", ())
+
+
+def _prose_fields_for(row: dict, schema: str) -> tuple[str, ...]:
+    if schema == "spike-c":
+        return SPIKE_C_PROSE_FIELDS
+    tool = row.get("tool")
+    return SPIKE_D_PROSE_FIELDS.get(tool or "", ())
+
+
+# ── Item canonicalisation ────────────────────────────────────────────────────
+
+
+def _canon(item: Any) -> str:
+    """Canonicalise a set-item for hashing + prompting. Dict → sorted-key
+    JSON; str passthrough; other → repr. Mirrors spike-D `_to_hashable`."""
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        return json.dumps(item, sort_keys=True, ensure_ascii=False)
+    return repr(item)
+
+
+# ── Judge prompts + dispatch ─────────────────────────────────────────────────
+
+
+_JUDGE_PROMPT = """\
+You are judging whether two short item descriptions, extracted by two
+different systems for the same task, refer to the SAME underlying
+entity / make the same claim (same dataset, baseline, file path,
+constraint, action, finding, etc).
+
+Return JSON {{"equivalent": <bool>, "reason": "<one short sentence>"}}.
+
+"equivalent" should be true when:
+- The two strings name the same dataset / model / file / claim, even
+  if one is more verbose, includes citations, or paraphrases the other.
+  Examples:
+    "UCI Mushroom database" ↔ "Mushroom database" → equivalent
+    "Default posture is claude (cautious) — call-site names are not added to QWEN_OPERATORS_DEFAULT"
+      ↔ "Call-site names are not in QWEN_OPERATORS_DEFAULT, so auto-mode routes unknown call sites to claude"
+      → equivalent
+
+"equivalent" should be false when:
+- The strings name genuinely different entities or claims.
+- One is a proper-named entity and the other is an aggregation phrase
+  ("MNIST" vs "various image datasets" → not equivalent).
+
+Item A (from system 1): {a}
+Item B (from system 2): {b}
+"""
+
+
+_PROSE_JUDGE_PROMPT = """\
+You are judging whether two free-form prose passages, written for the
+same prompt by two different systems, convey semantically equivalent
+content (same key facts, recommendations, file paths, constraints,
+even if worded differently).
+
+Return JSON {{"equivalent": <bool>, "reason": "<one short sentence>"}}.
+
+Passage A:
+{a}
+
+Passage B:
+{b}
+"""
+
+
+_JUDGE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "equivalent": {"type": "boolean"},
+        "reason": {"type": "string"},
+    },
+    "required": ["equivalent", "reason"],
+}
+
+
+async def _judge(backend: str, a: str, b: str, *, prose: bool = False) -> dict:
+    template = _PROSE_JUDGE_PROMPT if prose else _JUDGE_PROMPT
+    prompt = template.format(a=a, b=b)
+    if backend == "claude":
+        return await claude_dispatch(
+            prompt, _JUDGE_SCHEMA, timeout=90.0 if prose else 60.0,
+            operator_name="parity_diff_judge",
+        )
+    return await qwen_dispatch(
+        prompt, _JUDGE_SCHEMA, timeout=90.0 if prose else 60.0,
+        operator_name="parity_diff_judge",
+    )
+
+
+# ── Match logic ──────────────────────────────────────────────────────────────
+
+
+async def _match_pairs(
+    backend: str,
+    only_c: list[str],
+    only_q: list[str],
+) -> tuple[set[tuple[str, str]], list[dict]]:
+    """Greedy bipartite match: for each only-C item, find first
+    semantically-equivalent only-Q item. Items must already be
+    canonicalised strings."""
+    matched: set[tuple[str, str]] = set()
+    matched_q: set[str] = set()
+    trace: list[dict] = []
+    for a in only_c:
+        for b in only_q:
+            if b in matched_q:
+                continue
+            try:
+                verdict = await _judge(backend, a, b)
+            except Exception as exc:
+                trace.append({"a": a, "b": b, "error": str(exc)})
+                continue
+            trace.append({
+                "a": a, "b": b,
+                "equivalent": bool(verdict.get("equivalent")),
+                "reason": str(verdict.get("reason", "")),
+            })
+            if verdict.get("equivalent"):
+                matched.add((a, b))
+                matched_q.add(b)
+                break
+    return matched, trace
+
+
+# ── Prose judging ────────────────────────────────────────────────────────────
+
+
+def _prose_diverges(a: Any, b: Any, tol: float = PROSE_LEN_TOL) -> bool:
+    """Mirror spike-D's `_prose_agree` length-ratio check, inverted.
+    Returns True when the pair *should* go to the judge."""
+    if a is None and b is None:
+        return False
+    if not a and not b:
+        return False
+    if not a or not b:
+        return True
+    la, lb = len(a), len(b)
+    if max(la, lb) == 0:
+        return False
+    return (min(la, lb) / max(la, lb)) < tol
+
+
+async def _judge_prose_field(
+    backend: str, a: str, b: str,
+) -> dict:
+    a_trunc = a[:PROSE_MAX_CHARS]
+    b_trunc = b[:PROSE_MAX_CHARS]
+    try:
+        verdict = await _judge(backend, a_trunc, b_trunc, prose=True)
+        return {
+            "equivalent": bool(verdict.get("equivalent")),
+            "reason": str(verdict.get("reason", "")),
+            "truncated_a": len(a) > PROSE_MAX_CHARS,
+            "truncated_b": len(b) > PROSE_MAX_CHARS,
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+# ── Rescore one row ──────────────────────────────────────────────────────────
+
+
+async def _rescore_row(
+    backend: str,
+    row: dict,
+    schema: str,
+    *,
+    prose: bool,
+) -> dict:
+    """Add a ``semantic_judged`` block to the row. Mutates + returns it."""
+    if not _both_ok(row, schema):
+        return row
+
+    c_payload, q_payload = _payloads_for(row, schema)
+    set_fields = _set_fields_for(row, schema)
+    prose_fields = _prose_fields_for(row, schema) if prose else ()
+
+    judged: dict[str, Any] = {}
+
+    for f in set_fields:
+        c_raw = c_payload.get(f) or []
+        q_raw = q_payload.get(f) or []
+        cs = {_canon(x) for x in c_raw}
+        qs = {_canon(x) for x in q_raw}
+        strict_inter = cs & qs
+        only_c = sorted(cs - qs)
+        only_q = sorted(qs - cs)
+        matched, trace = await _match_pairs(backend, only_c, only_q)
+        equiv = len(strict_inter) + len(matched)
+        union_size = len(cs | qs) - len(matched)  # collapse matched pairs
+        agreement = equiv / union_size if union_size > 0 else 1.0
+        judged[f] = {
+            "kind": "set",
+            "strict_intersection": sorted(strict_inter),
+            "semantic_matches": [list(p) for p in sorted(matched)],
+            "unmatched_only_c": sorted(
+                [a for a in only_c if not any(a == p[0] for p in matched)]
+            ),
+            "unmatched_only_q": sorted(
+                [b for b in only_q if b not in {p[1] for p in matched}]
+            ),
+            "agreement": agreement,
+            "trace": trace,
+        }
+
+    for f in prose_fields:
+        a = c_payload.get(f) or ""
+        b = q_payload.get(f) or ""
+        if not _prose_diverges(a, b):
+            judged[f] = {"kind": "prose", "skipped": True,
+                         "reason": "length-ratio within tolerance"}
+            continue
+        verdict = await _judge_prose_field(backend, a, b)
+        judged[f] = {"kind": "prose", **verdict}
+
+    row["semantic_judged"] = judged
+    return row
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+async def main_async(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Semantic-equivalence judge for spike-C / spike-D parity output.",
+    )
+    p.add_argument("--in", dest="in_path", type=Path, required=True)
+    p.add_argument("--out", type=Path, required=True)
+    p.add_argument("--judge", choices=("claude", "qwen"), default="qwen")
+    p.add_argument("--schema", choices=("spike-c", "spike-d", "auto"),
+                   default="auto")
+    p.add_argument("--prose", action="store_true",
+                   help="Also judge diverging prose fields (slower).")
+    args = p.parse_args(argv)
+
+    rows = [json.loads(l) for l in args.in_path.read_text().splitlines() if l.strip()]
+    if not rows:
+        print("judge: no rows in input", file=sys.stderr)
+        return 1
+
+    if args.schema == "auto":
+        schema = detect_schema(rows[0])
+    else:
+        schema = args.schema
+
+    print(
+        f"judge: {len(rows)} rows, backend={args.judge}, schema={schema}, "
+        f"prose={args.prose}",
+        file=sys.stderr,
+    )
+
+    out_rows: list[dict] = []
+    for i, row in enumerate(rows, 1):
+        if schema == "spike-c":
+            name = (row.get("uri") or "?").split("/")[-1][:50]
+        else:
+            name = f"{row.get('tool', '?')}/{row.get('name', '?')}"
+        print(f"  [{i}/{len(rows)}] {name}", file=sys.stderr)
+        out_row = await _rescore_row(args.judge, row, schema, prose=args.prose)
+        out_rows.append(out_row)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w") as fp:
+        for r in out_rows:
+            fp.write(json.dumps(r) + "\n")
+
+    # Summary — group by tool for spike-D, flat for spike-C.
+    print("\n=== Semantic-equivalence summary ===", file=sys.stderr)
+    if schema == "spike-c":
+        _print_field_summary(out_rows, SPIKE_C_SET_FIELDS, ())
+    else:
+        by_tool: dict[str, list[dict]] = {}
+        for r in out_rows:
+            by_tool.setdefault(r.get("tool", "?"), []).append(r)
+        for tool, rs in sorted(by_tool.items()):
+            print(f"  [{tool}] n={len(rs)}", file=sys.stderr)
+            _print_field_summary(
+                rs,
+                SPIKE_D_SET_FIELDS.get(tool, ()),
+                SPIKE_D_PROSE_FIELDS.get(tool, ()) if args.prose else (),
+                indent="    ",
+            )
+
+    return 0
+
+
+def _print_field_summary(
+    rows: list[dict],
+    set_fields: tuple[str, ...],
+    prose_fields: tuple[str, ...],
+    *,
+    indent: str = "  ",
+) -> None:
+    for f in set_fields:
+        rates = []
+        for r in rows:
+            if "semantic_judged" in r and f in r["semantic_judged"]:
+                rates.append(r["semantic_judged"][f].get("agreement", 0.0))
+        if rates:
+            avg = sum(rates) / len(rates)
+            print(
+                f"{indent}{f}: {avg*100:.1f}% mean semantic agreement "
+                f"(n={len(rates)})",
+                file=sys.stderr,
+            )
+    for f in prose_fields:
+        eq = 0
+        n = 0
+        for r in rows:
+            block = r.get("semantic_judged", {}).get(f)
+            if not isinstance(block, dict):
+                continue
+            if block.get("skipped"):
+                continue
+            if "equivalent" in block:
+                n += 1
+                if block["equivalent"]:
+                    eq += 1
+        if n:
+            print(
+                f"{indent}{f} (prose): {eq}/{n} equivalent",
+                file=sys.stderr,
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(main_async(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_judge_parity_diffs.py
+++ b/tests/test_judge_parity_diffs.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: MIT
+"""Tests for scripts/spikes/judge_parity_diffs.py — schema detection,
+per-tool set-field selection, greedy bipartite match, and prose-judge
+opt-in gating.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the script as a module (it lives under scripts/, not in a package).
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "spikes" / "judge_parity_diffs.py"
+_spec = importlib.util.spec_from_file_location("judge_parity_diffs", _SCRIPT)
+jpd = importlib.util.module_from_spec(_spec)
+sys.modules["judge_parity_diffs"] = jpd
+assert _spec and _spec.loader
+_spec.loader.exec_module(jpd)
+
+
+# ── Schema detection ────────────────────────────────────────────────────────
+
+
+def test_detect_schema_spike_c():
+    row = {"claude_record": {"foo": [1]}, "qwen_record": {"foo": [2]}}
+    assert jpd.detect_schema(row) == "spike-c"
+
+
+def test_detect_schema_spike_d():
+    row = {
+        "tool": "nx_enrich_beads",
+        "claude_agent": {"payload": {"key_files": ["a.py"]}},
+        "qwen_agent": {"payload": {"key_files": ["b.py"]}},
+    }
+    assert jpd.detect_schema(row) == "spike-d"
+
+
+def test_detect_schema_unknown_raises():
+    with pytest.raises(ValueError, match="cannot detect schema"):
+        jpd.detect_schema({"foo": "bar"})
+
+
+# ── Per-tool set-field selection ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "tool, expected",
+    [
+        ("nx_enrich_beads", ("key_files", "test_commands", "constraints")),
+        ("nx_tidy", ("actions",)),
+        ("nx_plan_audit", ("findings",)),
+        ("unknown_tool", ()),
+    ],
+)
+def test_set_fields_spike_d_per_tool(tool, expected):
+    row = {"tool": tool, "claude_agent": {"payload": {}}, "qwen_agent": {"payload": {}}}
+    assert jpd._set_fields_for(row, "spike-d") == expected
+
+
+def test_set_fields_spike_c_constant():
+    row = {"claude_record": {}, "qwen_record": {}}
+    assert jpd._set_fields_for(row, "spike-c") == (
+        "experimental_datasets", "experimental_baselines",
+    )
+
+
+# ── Item canonicalisation ───────────────────────────────────────────────────
+
+
+def test_canon_string_passthrough():
+    assert jpd._canon("foo") == "foo"
+
+
+def test_canon_dict_sorted_keys():
+    a = jpd._canon({"b": 1, "a": 2})
+    b = jpd._canon({"a": 2, "b": 1})
+    assert a == b
+    assert '"a"' in a and '"b"' in a
+
+
+# ── Greedy bipartite match (mocked _judge) ──────────────────────────────────
+
+
+def test_match_pairs_greedy(monkeypatch):
+    """Each only-C item finds its first equivalent only-Q item, then
+    that Q item is locked out."""
+    pairs_seen = []
+
+    async def fake_judge(backend, a, b, *, prose=False):
+        pairs_seen.append((a, b))
+        # "X" matches "x" (case-insensitive equivalence).
+        return {"equivalent": a.lower() == b.lower(), "reason": "test"}
+
+    monkeypatch.setattr(jpd, "_judge", fake_judge)
+
+    matched, trace = asyncio.run(jpd._match_pairs(
+        "qwen", ["Foo", "Bar"], ["bar", "foo"],
+    ))
+    assert ("Foo", "foo") in matched
+    assert ("Bar", "bar") in matched
+    assert len(matched) == 2
+    # All trace entries with equivalent=True correspond to matches.
+    eq_traces = [t for t in trace if t.get("equivalent")]
+    assert len(eq_traces) == 2
+
+
+def test_match_pairs_no_match(monkeypatch):
+    async def fake_judge(backend, a, b, *, prose=False):
+        return {"equivalent": False, "reason": "different"}
+
+    monkeypatch.setattr(jpd, "_judge", fake_judge)
+    matched, trace = asyncio.run(jpd._match_pairs(
+        "qwen", ["x", "y"], ["p", "q"],
+    ))
+    assert matched == set()
+    # 2 only_c * 2 only_q = 4 judge calls (since none match, no break).
+    assert len(trace) == 4
+
+
+def test_match_pairs_judge_error(monkeypatch):
+    async def fake_judge(backend, a, b, *, prose=False):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(jpd, "_judge", fake_judge)
+    matched, trace = asyncio.run(jpd._match_pairs(
+        "qwen", ["x"], ["y"],
+    ))
+    assert matched == set()
+    assert trace == [{"a": "x", "b": "y", "error": "boom"}]
+
+
+# ── _rescore_row: spike-D set-field path with mocked judge ──────────────────
+
+
+def test_rescore_spike_d_constraints_paraphrased(monkeypatch):
+    """Strict Jaccard would be 0%; semantic judge collapses the pair."""
+    async def fake_judge(backend, a, b, *, prose=False):
+        return {"equivalent": True, "reason": "paraphrase"}
+    monkeypatch.setattr(jpd, "_judge", fake_judge)
+
+    row = {
+        "tool": "nx_enrich_beads",
+        "diff": {"both_ok": True},
+        "claude_agent": {"payload": {
+            "key_files": [], "test_commands": [],
+            "constraints": ["Default posture is claude (cautious)"],
+        }},
+        "qwen_agent": {"payload": {
+            "key_files": [], "test_commands": [],
+            "constraints": ["Call-site names route to claude by default"],
+        }},
+    }
+    out = asyncio.run(jpd._rescore_row("qwen", row, "spike-d", prose=False))
+    judged = out["semantic_judged"]["constraints"]
+    assert judged["agreement"] == 1.0
+    assert len(judged["semantic_matches"]) == 1
+    assert judged["unmatched_only_c"] == []
+    assert judged["unmatched_only_q"] == []
+
+
+def test_rescore_skips_when_not_both_ok(monkeypatch):
+    called = False
+
+    async def fake_judge(*a, **kw):
+        nonlocal called
+        called = True
+        return {"equivalent": True, "reason": ""}
+
+    monkeypatch.setattr(jpd, "_judge", fake_judge)
+    row = {
+        "tool": "nx_enrich_beads",
+        "diff": {"both_ok": False},
+        "claude_agent": {"payload": {}},
+        "qwen_agent": {"payload": {}},
+    }
+    out = asyncio.run(jpd._rescore_row("qwen", row, "spike-d", prose=False))
+    assert "semantic_judged" not in out
+    assert called is False
+
+
+def test_rescore_spike_c_unchanged_shape(monkeypatch):
+    """spike-C path still produces a per-field judged block keyed by
+    the spike-C set fields."""
+    async def fake_judge(backend, a, b, *, prose=False):
+        return {"equivalent": False, "reason": "no"}
+    monkeypatch.setattr(jpd, "_judge", fake_judge)
+
+    row = {
+        "both_ok": True,
+        "claude_record": {
+            "experimental_datasets": ["MNIST"],
+            "experimental_baselines": ["ResNet"],
+        },
+        "qwen_record": {
+            "experimental_datasets": ["MNIST"],
+            "experimental_baselines": ["ResNet"],
+        },
+    }
+    out = asyncio.run(jpd._rescore_row("qwen", row, "spike-c", prose=False))
+    j = out["semantic_judged"]
+    assert set(j.keys()) == {"experimental_datasets", "experimental_baselines"}
+    # Both sides identical → strict intersection covers everything; judge
+    # not invoked at all.
+    assert j["experimental_datasets"]["agreement"] == 1.0
+    assert j["experimental_datasets"]["strict_intersection"] == ["MNIST"]
+
+
+# ── Prose opt-in gating ─────────────────────────────────────────────────────
+
+
+def test_prose_diverges_helper():
+    # Identical → no divergence.
+    assert jpd._prose_diverges("abc", "abc") is False
+    # Both empty → no divergence.
+    assert jpd._prose_diverges("", "") is False
+    assert jpd._prose_diverges(None, None) is False
+    # One empty → diverges.
+    assert jpd._prose_diverges("abc", "") is True
+    # Length ratio below 0.5 → diverges.
+    assert jpd._prose_diverges("a" * 10, "a" * 4) is True
+    # Length ratio above 0.5 → no divergence.
+    assert jpd._prose_diverges("a" * 10, "a" * 8) is False
+
+
+def test_prose_off_skips_prose_judge(monkeypatch):
+    calls = {"set": 0, "prose": 0}
+
+    async def fake_judge(backend, a, b, *, prose=False):
+        calls["prose" if prose else "set"] += 1
+        return {"equivalent": True, "reason": ""}
+    monkeypatch.setattr(jpd, "_judge", fake_judge)
+
+    row = {
+        "tool": "nx_enrich_beads",
+        "diff": {"both_ok": True},
+        "claude_agent": {"payload": {
+            "key_files": [], "test_commands": [], "constraints": [],
+            "enriched_description": "short",
+        }},
+        "qwen_agent": {"payload": {
+            "key_files": [], "test_commands": [], "constraints": [],
+            "enriched_description": "this is a much much much longer description that diverges in length",
+        }},
+    }
+    asyncio.run(jpd._rescore_row("qwen", row, "spike-d", prose=False))
+    assert calls["prose"] == 0
+
+
+def test_prose_on_invokes_prose_judge_when_diverged(monkeypatch):
+    calls = {"set": 0, "prose": 0}
+
+    async def fake_judge(backend, a, b, *, prose=False):
+        calls["prose" if prose else "set"] += 1
+        return {"equivalent": True, "reason": "semantically same"}
+    monkeypatch.setattr(jpd, "_judge", fake_judge)
+
+    row = {
+        "tool": "nx_enrich_beads",
+        "diff": {"both_ok": True},
+        "claude_agent": {"payload": {
+            "key_files": [], "test_commands": [], "constraints": [],
+            "enriched_description": "short",
+        }},
+        "qwen_agent": {"payload": {
+            "key_files": [], "test_commands": [], "constraints": [],
+            "enriched_description": "this is a much much much longer description that diverges in length substantially",
+        }},
+    }
+    out = asyncio.run(jpd._rescore_row("qwen", row, "spike-d", prose=True))
+    assert calls["prose"] == 1
+    block = out["semantic_judged"]["enriched_description"]
+    assert block["kind"] == "prose"
+    assert block["equivalent"] is True
+
+
+def test_prose_on_skips_when_within_tolerance(monkeypatch):
+    calls = {"prose": 0}
+
+    async def fake_judge(backend, a, b, *, prose=False):
+        if prose:
+            calls["prose"] += 1
+        return {"equivalent": True, "reason": ""}
+    monkeypatch.setattr(jpd, "_judge", fake_judge)
+
+    row = {
+        "tool": "nx_enrich_beads",
+        "diff": {"both_ok": True},
+        "claude_agent": {"payload": {
+            "key_files": [], "test_commands": [], "constraints": [],
+            "enriched_description": "abc",
+        }},
+        "qwen_agent": {"payload": {
+            "key_files": [], "test_commands": [], "constraints": [],
+            "enriched_description": "abc",
+        }},
+    }
+    out = asyncio.run(jpd._rescore_row("qwen", row, "spike-d", prose=True))
+    assert calls["prose"] == 0
+    assert out["semantic_judged"]["enriched_description"]["skipped"] is True
+
+
+# ── Dict-shaped set items (nx_tidy / nx_plan_audit) ─────────────────────────
+
+
+def test_dict_items_canonicalised_for_judge(monkeypatch):
+    """nx_tidy actions are dicts. They should be JSON-canonicalised
+    before being passed to the judge."""
+    seen = []
+
+    async def fake_judge(backend, a, b, *, prose=False):
+        seen.append((a, b))
+        return {"equivalent": False, "reason": ""}
+    monkeypatch.setattr(jpd, "_judge", fake_judge)
+
+    row = {
+        "tool": "nx_tidy",
+        "diff": {"both_ok": True},
+        "claude_agent": {"payload": {
+            "actions": [{"type": "move", "target": "a"}],
+        }},
+        "qwen_agent": {"payload": {
+            "actions": [{"type": "delete", "target": "b"}],
+        }},
+    }
+    asyncio.run(jpd._rescore_row("qwen", row, "spike-d", prose=False))
+    # Exactly one judge call comparing JSON-serialised dicts.
+    assert len(seen) == 1
+    a, b = seen[0]
+    assert a.startswith("{") and b.startswith("{")
+    assert '"type"' in a and '"target"' in a
+
+
+# ── Backward-compat shim ────────────────────────────────────────────────────
+
+
+def test_shim_imports_and_reexports():
+    """judge_aspect_diffs.py should still import and re-export the
+    public names spike-C callers depended on."""
+    shim_path = Path(__file__).resolve().parents[1] / "scripts" / "spikes" / "judge_aspect_diffs.py"
+    spec = importlib.util.spec_from_file_location("judge_aspect_diffs_shim", shim_path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+
+    assert mod.SET_FIELDS == ("experimental_datasets", "experimental_baselines")
+    assert callable(mod.main)
+    assert callable(mod._judge)
+    assert callable(mod._match_pairs)
+    assert callable(mod._rescore_row)


### PR DESCRIPTION
## Summary

Generalize \`scripts/spikes/judge_aspect_diffs.py\` (#793) into \`scripts/spikes/judge_parity_diffs.py\` — a single re-scorer that accepts either spike-C (aspect_extractor) or spike-D (tier-B tool-use) JSONL output via auto-detected row schema. Adds opt-in \`--prose\` flag for length-ratio-aware prose-field judging. \`judge_aspect_diffs.py\` retained as a deprecated shim that forces \`schema=spike-c\`.

## Why

spike-D full-parity run on 3 \`nx_enrich_beads\` cases (2026-05-15) showed \`constraints\` Jaccard = **0% strict**, but eyeball inspection revealed several semantically-equivalent items with different wordings (e.g. *"Default posture is claude (cautious) — call-site names are not added to QWEN_OPERATORS_DEFAULT"* vs *"Call-site names are not in QWEN_OPERATORS_DEFAULT, so auto-mode routes unknown call sites to claude (conservative default)"*). Same shape that motivated the spike-C judge.

## Implementation

- **Schema auto-detect**: \`claude_record\`/\`qwen_record\` keys → spike-c; \`claude_agent.payload\`/\`qwen_agent.payload\` → spike-d.
- **Per-tool set-field dispatch (spike-d)**:
  - \`nx_enrich_beads\`: \`key_files\`, \`test_commands\`, \`constraints\`
  - \`nx_tidy\`: \`actions\` (dicts canonicalised via \`json.dumps(sort_keys=True)\`)
  - \`nx_plan_audit\`: \`findings\` (same canonicalisation)
- **Greedy bipartite match** preserved from #793.
- **Prose judge (opt-in)**: \`--prose\` flag runs a separate equivalence prompt on \`enriched_description\` / \`summary\` / \`verdict\` when len-ratio < 0.5. Default off.
- **Backward compat**: existing \`judge_aspect_diffs.py\` invocations still work via the shim; deprecation comment points at the new name.

## Sanity-test results (3-case spike-D corpus)

| Field | Strict | Semantic |
|---|---|---|
| \`key_files\` | 33.3% | 33.3% |
| \`test_commands\` | 13.1% | 19.4% |
| \`constraints\` | 0.0% | 19.7% |

Modest semantic lift — much smaller than spike-C's (where \`experimental_datasets\` went from 20% → 100%). **This itself is a finding**: tier-B enrichment is open-ended exploration, so the two engines often find genuinely different files and emphasize different constraints rather than paraphrasing the same answer. The judge catches the paraphrasing tier but not the underlying divergence in what counts as a 'relevant constraint.' Future operator follow-up: either accept open-ended divergence as legitimate or tighten \`nx_enrich_beads\` prompt to constrain the candidate set.

## Test plan

- [x] 22 new unit tests in \`tests/test_judge_parity_diffs.py\` — schema detection, per-tool set-field selection, greedy-bipartite match (carried over), prose-on/off semantics, dict canonicalisation, shim import.
- [x] Existing test imports still resolve via the deprecation shim.
- [x] Sanity run on real spike-D output completes successfully and produces the numbers above.

## Out of scope

- spike-D routing for \`nx_tidy\` / \`nx_plan_audit\` (separate PR).
- Changes to spike-D harness output shape.
- Tightening \`nx_enrich_beads\` prompt to constrain the candidate set (deferred follow-on if the open-ended divergence is judged unacceptable).

## Linked

- #793 (parent judge for aspect_extractor)
- #797 (spike-D harness)
- #796 (qwen_agent_dispatch + nx_enrich_beads opt-in routing)
- #799 (tightened nx_enrich_beads prompt + raised tool-call budget)