### PR TITLE
feat(operators): route nx_tidy + nx_plan_audit through qwen_agent_dispatch (tier-B completion)

### DIFF
--- a/scripts/spikes/spike_d_tier_b_parity.py
+++ b/scripts/spikes/spike_d_tier_b_parity.py
@@ -12,14 +12,14 @@ does not fit. This script ships the new harness.
 Routing reality
 ---------------
 
-Per PR #796, only ``nx_enrich_beads`` honors
-``NEXUS_TIER_B_DISPATCHER``. The other two unconditionally call
-``claude_dispatch``. For those tools the bench records
-``qwen_agent_skipped: true`` on the qwen leg and runs only the claude
-leg; the structural-diff axis becomes vacuously self-equal, but the
-elapsed/ok-rate axis is still useful as a baseline. Routing for those
-two is the **follow-on PR** — spike_d ships the harness, not the
-routing.
+As of the tier-B completion PR (follow-on to #796/#799), all three
+tools (``nx_enrich_beads``, ``nx_tidy``, ``nx_plan_audit``) honor
+``NEXUS_TIER_B_DISPATCHER=qwen_agent``. Earlier revisions of this
+harness short-circuited ``nx_tidy`` / ``nx_plan_audit`` with
+``qwen_agent_skipped: true``; that skip is now opt-in via the
+``--skip-unwired`` flag (kept for reproducing the original bench), and
+the aggregation / reporting code that handles the skipped state is
+retained for backward-compat with earlier JSONL records.
 
 Three-axis metric
 -----------------
@@ -82,8 +82,6 @@ Operator-supplied JSON list (no fixture corpus shipped with the PR)::
 Out of scope
 ------------
 
-* Routing for ``nx_tidy`` / ``nx_plan_audit`` — that's the follow-on
-  PR. spike_d *bench-skips* them on the qwen_agent leg.
 * Semantic-equivalence LLM judge — separate script.
 * Fixture corpus.
 """
@@ -111,10 +109,13 @@ SUPPORTED_TOOLS: tuple[str, ...] = (
     "nx_plan_audit",
 )
 
-# Tools currently NOT wired to NEXUS_TIER_B_DISPATCHER opt-in. Both
-# legs of the bench run claude_dispatch for these; the qwen leg is
-# recorded as skipped so per-tool aggregates flag the gap.
-QWEN_AGENT_UNWIRED: frozenset[str] = frozenset({"nx_tidy", "nx_plan_audit"})
+# Historically (PR #797 era) ``nx_tidy`` and ``nx_plan_audit`` were
+# unwired to ``NEXUS_TIER_B_DISPATCHER``; the harness recorded
+# ``qwen_agent_skipped: true`` for them. As of the tier-B completion
+# PR, all three tier-B tools honor the env. This set is empty by
+# default; pass ``--skip-unwired`` to re-enable the historical skip
+# (useful only for reproducing pre-completion benches).
+QWEN_AGENT_UNWIRED_DEFAULT: frozenset[str] = frozenset()
 
 # Per-tool structural fields used for Jaccard overlap.
 STRUCTURAL_FIELDS: dict[str, tuple[str, ...]] = {
@@ -396,6 +397,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("--backends", default="claude_agent,qwen_agent",
                    help="Comma-separated backends (default: "
                         "claude_agent,qwen_agent).")
+    p.add_argument("--skip-unwired", action="store_true",
+                   help="Reproduce the pre-completion bench by "
+                        "skipping qwen_agent for nx_tidy and "
+                        "nx_plan_audit. As of the tier-B completion "
+                        "PR all three tools are wired; this flag is "
+                        "retained only for replaying historical runs.")
     return p.parse_args(argv)
 
 
@@ -519,6 +526,7 @@ def _render_md(summary: dict, out_path: Path) -> str:
 async def _run_case(
     case: dict,
     backends: list[str],
+    unwired: frozenset[str] = QWEN_AGENT_UNWIRED_DEFAULT,
 ) -> dict:
     tool = case["tool"]
     row: dict[str, Any] = {
@@ -528,7 +536,7 @@ async def _run_case(
         "input": case["input"],
     }
     for backend in backends:
-        if backend == "qwen_agent" and tool in QWEN_AGENT_UNWIRED:
+        if backend == "qwen_agent" and tool in unwired:
             row["qwen_agent_skipped"] = True
             row["qwen_agent"] = None
             continue
@@ -569,12 +577,18 @@ async def _main_async(args: argparse.Namespace) -> int:
             print(f"error: unknown backend {b!r}", file=sys.stderr)
             return 2
 
+    unwired = (
+        frozenset({"nx_tidy", "nx_plan_audit"})
+        if args.skip_unwired
+        else QWEN_AGENT_UNWIRED_DEFAULT
+    )
+
     args.out.parent.mkdir(parents=True, exist_ok=True)
     records: list[dict] = []
     with args.out.open("w", encoding="utf-8") as fp:
         for repeat_ix in range(args.repeat):
             for case in cases:
-                row = await _run_case(case, backends)
+                row = await _run_case(case, backends, unwired=unwired)
                 row["repeat"] = repeat_ix
                 fp.write(json.dumps(row, default=str) + "\n")
                 fp.flush()

--- a/src/nexus/mcp/core.py
+++ b/src/nexus/mcp/core.py
@@ -3908,7 +3908,34 @@ async def nx_tidy(
         f"'{collection}'. Search for all related entries, identify duplicates "
         "or contradictions, and produce a consolidated summary."
     )
-    payload = await claude_dispatch(prompt, schema, timeout=timeout)
+    # Schema-conformance directive — mirror of nx_enrich_beads (#799).
+    # Tier-B qwen reliably emits narrative at finalization in tool-use
+    # loops instead of json_schema output; explicit "JSON only" trailer
+    # fixes that. No-op for claude.
+    prompt += (
+        "\n\nRespond with ONLY a JSON object conforming to the schema "
+        "above. No prose, no commentary, no prefix, no markdown fences. "
+        "Begin your response with `{` and end with `}`."
+    )
+
+    # Tier-B dispatcher selection — mirror of nx_enrich_beads.
+    tier_b = _os.environ.get("NEXUS_TIER_B_DISPATCHER", "claude").lower()
+    if tier_b == "qwen_agent":
+        from nexus.operators.qwen_agent_dispatch import qwen_agent_dispatch
+
+        payload = await qwen_agent_dispatch(
+            prompt,
+            schema,
+            timeout=timeout,
+            extensions=["nx"],
+            # 50 mirrors the nx_enrich_beads cap (#799) — no per-tool
+            # bench evidence yet; the harness change in this PR makes
+            # that bench possible as a follow-on operator action.
+            max_tool_calls=50,
+            operator_name="nx_tidy",
+        )
+    else:
+        payload = await claude_dispatch(prompt, schema, timeout=timeout)
 
     summary = payload.get("summary", "") if isinstance(payload, dict) else str(payload)
     actions = payload.get("actions", []) if isinstance(payload, dict) else []
@@ -4062,8 +4089,30 @@ async def nx_plan_audit(
     )
     if context:
         prompt += f"\n\nContext:\n{context}"
+    # Schema-conformance directive — mirror of nx_enrich_beads (#799).
+    prompt += (
+        "\n\nRespond with ONLY a JSON object conforming to the schema "
+        "above. No prose, no commentary, no prefix, no markdown fences. "
+        "Begin your response with `{` and end with `}`."
+    )
 
-    payload = await claude_dispatch(prompt, schema, timeout=timeout)
+    # Tier-B dispatcher selection — mirror of nx_enrich_beads.
+    tier_b = _os.environ.get("NEXUS_TIER_B_DISPATCHER", "claude").lower()
+    if tier_b == "qwen_agent":
+        from nexus.operators.qwen_agent_dispatch import qwen_agent_dispatch
+
+        payload = await qwen_agent_dispatch(
+            prompt,
+            schema,
+            timeout=timeout,
+            extensions=["nx"],
+            # 50 mirrors nx_enrich_beads (#799). Plan audit is bounded
+            # by plan size and is largely read-only; 50 is generous.
+            max_tool_calls=50,
+            operator_name="nx_plan_audit",
+        )
+    else:
+        payload = await claude_dispatch(prompt, schema, timeout=timeout)
     if isinstance(payload, dict):
         verdict = payload.get("verdict", "unknown")
         summary = payload.get("summary", "")

--- a/tests/test_nx_plan_audit_routing.py
+++ b/tests/test_nx_plan_audit_routing.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tier-B dispatcher routing for ``nx_plan_audit``.
+
+Mirrors ``test_nx_enrich_beads_routing.py`` (PR #796).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_default_env_routes_to_claude(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
+    fake = AsyncMock(return_value={
+        "verdict": "ok", "findings": [], "summary": "s",
+    })
+    with (
+        patch("nexus.operators.dispatch.claude_dispatch", fake),
+        patch(
+            "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+            new=AsyncMock(side_effect=AssertionError("qwen_agent must not run")),
+        ),
+    ):
+        from nexus.mcp.core import nx_plan_audit
+        impl = getattr(nx_plan_audit, "fn", nx_plan_audit)
+        result = await impl('{"phases": []}')
+    assert "ok" in result
+    assert fake.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_qwen_agent_env_routes_to_qwen_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEXUS_TIER_B_DISPATCHER", "qwen_agent")
+    fake_qwen = AsyncMock(return_value={
+        "verdict": "ok", "findings": [], "summary": "qwen-summary",
+    })
+    fake_claude = AsyncMock(side_effect=AssertionError("claude must not run"))
+    with (
+        patch(
+            "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+            fake_qwen,
+        ),
+        patch("nexus.operators.dispatch.claude_dispatch", fake_claude),
+    ):
+        from nexus.mcp.core import nx_plan_audit
+        impl = getattr(nx_plan_audit, "fn", nx_plan_audit)
+        result = await impl('{"phases": [{"id": "p1"}]}')
+
+    assert "qwen-summary" in result
+    assert fake_qwen.await_count == 1
+    _, kwargs = fake_qwen.call_args
+    assert kwargs.get("extensions") == ["nx"]
+    assert kwargs.get("operator_name") == "nx_plan_audit"
+    assert kwargs.get("max_tool_calls") == 50
+    args, _ = fake_qwen.call_args
+    assert "p1" in args[0]
+    assert isinstance(args[1], dict)
+    assert "verdict" in args[1].get("properties", {})
+    assert "ONLY a JSON object" in args[0]

--- a/tests/test_nx_tidy_routing.py
+++ b/tests/test_nx_tidy_routing.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tier-B dispatcher routing for ``nx_tidy``.
+
+Mirrors ``test_nx_enrich_beads_routing.py`` (PR #796). Asserts default
+env routes to ``claude_dispatch``; ``NEXUS_TIER_B_DISPATCHER=qwen_agent``
+routes to ``qwen_agent_dispatch`` with the expected kwargs.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_default_env_routes_to_claude(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
+    fake = AsyncMock(return_value={"summary": "out", "actions": []})
+    with (
+        patch("nexus.operators.dispatch.claude_dispatch", fake),
+        patch(
+            "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+            new=AsyncMock(side_effect=AssertionError("qwen_agent must not run")),
+        ),
+    ):
+        from nexus.mcp.core import nx_tidy
+        impl = getattr(nx_tidy, "fn", nx_tidy)
+        result = await impl("chromadb quotas")
+    assert "out" in result
+    assert fake.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_qwen_agent_env_routes_to_qwen_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NEXUS_TIER_B_DISPATCHER", "qwen_agent")
+    fake_qwen = AsyncMock(return_value={"summary": "qwen-out", "actions": []})
+    fake_claude = AsyncMock(side_effect=AssertionError("claude must not run"))
+    with (
+        patch(
+            "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+            fake_qwen,
+        ),
+        patch("nexus.operators.dispatch.claude_dispatch", fake_claude),
+    ):
+        from nexus.mcp.core import nx_tidy
+        impl = getattr(nx_tidy, "fn", nx_tidy)
+        result = await impl("chromadb quotas")
+
+    assert "qwen-out" in result
+    assert fake_qwen.await_count == 1
+    _, kwargs = fake_qwen.call_args
+    assert kwargs.get("extensions") == ["nx"]
+    assert kwargs.get("operator_name") == "nx_tidy"
+    assert kwargs.get("max_tool_calls") == 50
+    args, _ = fake_qwen.call_args
+    assert "chromadb quotas" in args[0]
+    assert isinstance(args[1], dict)
+    assert "summary" in args[1].get("properties", {})
+    # JSON-only trailer applied (#799 pattern).
+    assert "ONLY a JSON object" in args[0]

--- a/tests/test_spike_d_tier_b_parity.py
+++ b/tests/test_spike_d_tier_b_parity.py
@@ -170,10 +170,14 @@ async def test_qwen_agent_leg_sets_env(
 async def test_run_case_skips_qwen_for_unwired_tools(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Historical skip path — opt-in via ``--skip-unwired`` (which the
+    driver translates into a non-default ``unwired`` set). Verifies the
+    skip mechanism still works for replaying pre-completion benches.
+    """
     monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
     fake_claude = AsyncMock(return_value={"summary": "s", "actions": []})
     fake_qwen = AsyncMock(side_effect=AssertionError(
-        "qwen_agent must not run for nx_tidy until routing lands"
+        "qwen_agent must not run when caller opts into --skip-unwired"
     ))
     with (
         patch("nexus.operators.dispatch.claude_dispatch", fake_claude),
@@ -186,11 +190,39 @@ async def test_run_case_skips_qwen_for_unwired_tools(
             {"name": "tidy-1", "tool": "nx_tidy",
              "input": {"topic": "x", "collection": "knowledge"}},
             ["claude_agent", "qwen_agent"],
+            unwired=frozenset({"nx_tidy", "nx_plan_audit"}),
         )
     assert row["qwen_agent_skipped"] is True
     assert row["qwen_agent"] is None
     assert row["claude_agent"]["payload"] == {"summary": "s", "actions": []}
     fake_qwen.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_case_default_runs_qwen_for_nx_tidy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier-B completion: default ``unwired`` set is empty, so
+    ``nx_tidy`` now runs the qwen leg like ``nx_enrich_beads``.
+    """
+    monkeypatch.delenv("NEXUS_TIER_B_DISPATCHER", raising=False)
+    fake_claude = AsyncMock(return_value={"summary": "s", "actions": []})
+    fake_qwen = AsyncMock(return_value={"summary": "qs", "actions": []})
+    with (
+        patch("nexus.operators.dispatch.claude_dispatch", fake_claude),
+        patch(
+            "nexus.operators.qwen_agent_dispatch.qwen_agent_dispatch",
+            fake_qwen,
+        ),
+    ):
+        row = await spike._run_case(
+            {"name": "tidy-1", "tool": "nx_tidy",
+             "input": {"topic": "x", "collection": "knowledge"}},
+            ["claude_agent", "qwen_agent"],
+        )
+    assert not row.get("qwen_agent_skipped")
+    assert fake_claude.await_count == 1
+    assert fake_qwen.await_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Completes tier-B routing started in #796 (introduced `qwen_agent_dispatch` and wired `nx_enrich_beads`) and refined in #799 (prompt tightening + tool-call budget). Both remaining tier-B tools — `nx_tidy` and `nx_plan_audit` — now honor `NEXUS_TIER_B_DISPATCHER=qwen_agent`.

## Implementation

- Mirrors the #796/#799 pattern in `src/nexus/mcp/core.py`:
  - Read `NEXUS_TIER_B_DISPATCHER` env (default `claude`).
  - On `qwen_agent`: call `qwen_agent_dispatch(prompt, schema, timeout=…, extensions=["nx"], max_tool_calls=50, operator_name=<tool>)`.
  - JSON-only trailer appended to both prompts (no-op for claude, fixes qwen finalization narrative).
- `max_tool_calls=50` per call site — matches the nx_enrich_beads bench-validated cap (#799). No per-tool bench evidence exists yet; the harness change in this PR makes that bench possible as a follow-on operator action.
- `scripts/spikes/spike_d_tier_b_parity.py`: the `QWEN_AGENT_UNWIRED` skip is empty by default. The historical skip is gated behind a new `--skip-unwired` flag retained for replaying pre-completion benches. Aggregation / reporting code that handles `qwen_agent_skipped` records is left intact for JSONL backward-compat.

## Test plan

- `tests/test_nx_tidy_routing.py` and `tests/test_nx_plan_audit_routing.py` (new) — mirror `test_nx_enrich_beads_routing.py`. Default env asserts `claude_dispatch`; `qwen_agent` env asserts `qwen_agent_dispatch` with the right kwargs (extensions, operator_name, max_tool_calls=50) and that the JSON-only trailer is present in the forwarded prompt.
- `tests/test_spike_d_tier_b_parity.py` — historical-skip test now passes `unwired=frozenset({"nx_tidy","nx_plan_audit"})` explicitly. Added `test_run_case_default_runs_qwen_for_nx_tidy` to assert the new default behavior.
- 33 focused tests + 382 broader sanity tests pass.

## Bench note

Harness skip-logic is updated; the actual production-corpus bench across all three tier-B tools is an operator-driven follow-on action.

## Out of scope

- Actual bench runs.
- Per-tool tuning of `max_tool_calls` — that depends on bench output once it exists.

## Linked

#796, #797, #798, #799, #804.